### PR TITLE
Bind MCP grants to stable account identity

### DIFF
--- a/packages/worker/src/app/email-verification.node.test.ts
+++ b/packages/worker/src/app/email-verification.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { buildEmailVerificationUrl } from '#app/email-verification.ts'
+import {
+	buildEmailVerificationUrl,
+	isAccountEmailVerified,
+} from '#app/email-verification.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
 test('email verification links preserve safe resume targets and reject open redirects', () => {
 	const oauthResume = '/oauth/authorize?client_id=demo&state=abc'
@@ -19,4 +23,135 @@ test('email verification links preserve safe resume targets and reject open redi
 	})
 	expect(withoutResume.searchParams.get('token')).toBe('verify-token')
 	expect(withoutResume.searchParams.has('redirectTo')).toBe(false)
+})
+
+type VerificationUser = {
+	email: string
+	stable_user_id: string
+	email_verified_at: string | null
+}
+
+function createVerificationTestDb(users: Array<VerificationUser>) {
+	const queries: Array<{ sql: string; params: Array<unknown> }> = []
+	const db = {
+		prepare(sql: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					queries.push({ sql, params })
+					const normalized = sql.replace(/\s+/g, ' ').toLowerCase()
+					return {
+						async first<T>() {
+							if (
+								normalized.includes('where email = ? and stable_user_id = ?')
+							) {
+								const row = users.find(
+									(user) =>
+										user.email === params[0] &&
+										user.stable_user_id === params[1],
+								)
+								return (
+									row ? { email_verified_at: row.email_verified_at } : null
+								) as T | null
+							}
+							if (
+								normalized.includes('where email = ?') &&
+								!normalized.includes('stable_user_id')
+							) {
+								const row = users.find((user) => user.email === params[0])
+								return (
+									row ? { email_verified_at: row.email_verified_at } : null
+								) as T | null
+							}
+							if (normalized.includes('where stable_user_id = ?')) {
+								const row = users.find(
+									(user) => user.stable_user_id === params[0],
+								)
+								return (
+									row ? { email_verified_at: row.email_verified_at } : null
+								) as T | null
+							}
+							throw new Error(`Unsupported query: ${sql}`)
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+	return { db, queries }
+}
+
+test('isAccountEmailVerified binds email+stable id when both are supplied', async () => {
+	const ownerEmail = 'owner@example.com'
+	const ownerStableId = await createStableUserIdFromEmail(ownerEmail)
+	const reusedEmail = 'reused@example.com'
+	const otherStableId = await createStableUserIdFromEmail(
+		'other-account@example.com',
+	)
+	const { db, queries } = createVerificationTestDb([
+		{
+			email: ownerEmail,
+			stable_user_id: ownerStableId,
+			email_verified_at: '2026-01-01T00:00:00.000Z',
+		},
+		{
+			email: reusedEmail,
+			stable_user_id: otherStableId,
+			email_verified_at: '2026-01-02T00:00:00.000Z',
+		},
+	])
+
+	expect(
+		await isAccountEmailVerified({
+			db,
+			email: ownerEmail,
+			stableUserId: ownerStableId,
+		}),
+	).toBe(true)
+
+	// Stale grant email now owned by another verified account must not pass
+	// for the original stable id.
+	expect(
+		await isAccountEmailVerified({
+			db,
+			email: reusedEmail,
+			stableUserId: ownerStableId,
+		}),
+	).toBe(false)
+
+	expect(
+		queries.every((query) =>
+			query.sql.toLowerCase().includes('email = ? and stable_user_id = ?'),
+		),
+	).toBe(true)
+})
+
+test('isAccountEmailVerified keeps email-only and stable-only lookup paths', async () => {
+	const email = 'browser@example.com'
+	const stableUserId = await createStableUserIdFromEmail(email)
+	const { db, queries } = createVerificationTestDb([
+		{
+			email,
+			stable_user_id: stableUserId,
+			email_verified_at: '2026-01-01T00:00:00.000Z',
+		},
+	])
+
+	expect(await isAccountEmailVerified({ db, email })).toBe(true)
+	expect(await isAccountEmailVerified({ db, stableUserId })).toBe(true)
+	expect(
+		await isAccountEmailVerified({
+			db,
+			email: 'missing@example.com',
+		}),
+	).toBe(false)
+	expect(
+		await isAccountEmailVerified({
+			db,
+			stableUserId: 'missing-stable-id',
+		}),
+	).toBe(false)
+
+	expect(queries[0]?.sql.toLowerCase()).toContain('where email = ?')
+	expect(queries[0]?.sql.toLowerCase()).not.toContain('stable_user_id')
+	expect(queries[1]?.sql.toLowerCase()).toContain('where stable_user_id = ?')
 })

--- a/packages/worker/src/app/email-verification.ts
+++ b/packages/worker/src/app/email-verification.ts
@@ -3,7 +3,6 @@ import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
 import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import { createDb, emailVerificationsTable } from '#worker/db.ts'
-import { findUserRowByStableUserId } from '#worker/user-id.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
 
 const verificationTokenBytes = 32
@@ -221,6 +220,22 @@ export async function isAccountEmailVerified(input: {
 }) {
 	const normalizedEmail =
 		typeof input.email === 'string' ? normalizeEmail(input.email) : ''
+	const stableUserId = input.stableUserId?.trim() ?? ''
+
+	// When both are present (typical MCP grant props), require the pair so a
+	// stale grant email that another verified account now owns cannot pass.
+	if (normalizedEmail && stableUserId) {
+		const row = await input.db
+			.prepare(
+				`SELECT email_verified_at FROM users
+				 WHERE email = ? AND stable_user_id = ?`,
+			)
+			.bind(normalizedEmail, stableUserId)
+			.first<{ email_verified_at: string | null }>()
+		return Boolean(row?.email_verified_at)
+	}
+
+	// Browser sessions carry email only.
 	if (normalizedEmail) {
 		const row = await input.db
 			.prepare(`SELECT email_verified_at FROM users WHERE email = ?`)
@@ -229,18 +244,12 @@ export async function isAccountEmailVerified(input: {
 		return Boolean(row?.email_verified_at)
 	}
 
-	const stableUserId = input.stableUserId?.trim()
+	// Package-runtime / grant contexts with only the stable id.
 	if (!stableUserId) return false
-	const row = await findUserRowByStableUserId<{
-		id: number
-		email: string
-		stable_user_id: string | null
-		email_verified_at: string | null
-	}>({
-		db: input.db,
-		stableUserId,
-		select: `SELECT id, email, stable_user_id, email_verified_at FROM users`,
-	})
+	const row = await input.db
+		.prepare(`SELECT email_verified_at FROM users WHERE stable_user_id = ?`)
+		.bind(stableUserId)
+		.first<{ email_verified_at: string | null }>()
 	return Boolean(row?.email_verified_at)
 }
 

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -36,13 +36,15 @@ async function seedAccount(input: {
 	username: string
 	emailVerifiedAt?: string | null
 }) {
+	const stableUserId = await createStableUserIdFromEmail(input.email)
 	await input.db
 		.prepare(
-			`INSERT INTO users (username, email, password_hash, email_verified_at)
-			 VALUES (?, ?, ?, ?)
+			`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
+			 VALUES (?, ?, ?, ?, ?)
 			 ON CONFLICT(email) DO UPDATE SET
 			   username = excluded.username,
 			   email_verified_at = excluded.email_verified_at,
+			   stable_user_id = COALESCE(users.stable_user_id, excluded.stable_user_id),
 			   updated_at = CURRENT_TIMESTAMP`,
 		)
 		.bind(
@@ -52,6 +54,7 @@ async function seedAccount(input: {
 			input.emailVerifiedAt === undefined
 				? new Date().toISOString()
 				: input.emailVerifiedAt,
+			stableUserId,
 		)
 		.run()
 }

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -54,9 +54,10 @@ async function seedVerifiedAccount(input: {
 	verified?: boolean
 }) {
 	const username = input.username ?? `sender-${crypto.randomUUID().slice(0, 8)}`
+	const stableUserId = await createStableUserIdFromEmail(input.email)
 	await env.APP_DB.prepare(
-		`INSERT INTO users (username, email, password_hash, email_verified_at, plan)
-			VALUES (?, ?, ?, ?, ?)`,
+		`INSERT INTO users (username, email, password_hash, email_verified_at, plan, stable_user_id)
+			VALUES (?, ?, ?, ?, ?, ?)`,
 	)
 		.bind(
 			username,
@@ -64,6 +65,7 @@ async function seedVerifiedAccount(input: {
 			'test-password-hash',
 			input.verified === false ? null : new Date().toISOString(),
 			input.plan ?? null,
+			stableUserId,
 		)
 		.run()
 	return { username, from: `${username}@${platformDomain}` }
@@ -249,13 +251,20 @@ test('sendOutboundEmail blocks reserved usernames and unconfigured platform doma
 	const reservedEmail = `reserved-${crypto.randomUUID()}@example.com`
 	const reservedUserId = await createStableUserIdFromEmail(reservedEmail)
 	await env.APP_DB.prepare(
-		`INSERT INTO users (username, email, password_hash, email_verified_at)
-			VALUES (?, ?, ?, ?)
+		`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
+			VALUES (?, ?, ?, ?, ?)
 			ON CONFLICT(username) DO UPDATE SET
 				email = excluded.email,
-				email_verified_at = excluded.email_verified_at`,
+				email_verified_at = excluded.email_verified_at,
+				stable_user_id = COALESCE(users.stable_user_id, excluded.stable_user_id)`,
 	)
-		.bind('kody', reservedEmail, 'test-password-hash', new Date().toISOString())
+		.bind(
+			'kody',
+			reservedEmail,
+			'test-password-hash',
+			new Date().toISOString(),
+			reservedUserId,
+		)
 		.run()
 	await expect(
 		sendOutboundEmail({

--- a/packages/worker/src/entitlements/test-schema.ts
+++ b/packages/worker/src/entitlements/test-schema.ts
@@ -2,8 +2,8 @@
  * Non-destructive schema for entitlement primitives in workers-unit tests,
  * where the D1 database starts empty and each suite provisions the tables it
  * needs. Mirrors migrations 0001 (users), 0046 (users.email_verified_at and
- * users.plan), 0048 (entitlement_daily_counters), and 0066 (Stripe billing
- * columns).
+ * users.plan), 0048 (entitlement_daily_counters), 0052 (nullable
+ * stable_user_id plus partial unique index), and 0066 (Stripe billing columns).
  */
 export async function ensureEntitlementTestSchema(db: D1Database) {
 	await db
@@ -14,6 +14,7 @@ export async function ensureEntitlementTestSchema(db: D1Database) {
 	email TEXT NOT NULL UNIQUE,
 	password_hash TEXT NOT NULL,
 	email_verified_at TEXT,
+	stable_user_id TEXT,
 	plan TEXT,
 	stripe_customer_id TEXT,
 	stripe_plan TEXT,
@@ -25,6 +26,7 @@ export async function ensureEntitlementTestSchema(db: D1Database) {
 		.run()
 	for (const column of [
 		'email_verified_at TEXT',
+		'stable_user_id TEXT',
 		'plan TEXT',
 		'stripe_customer_id TEXT',
 		'stripe_plan TEXT',
@@ -35,6 +37,17 @@ export async function ensureEntitlementTestSchema(db: D1Database) {
 		} catch {
 			// The column already exists (fresh CREATE above or migrations).
 		}
+	}
+	try {
+		await db
+			.prepare(
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stable_user_id
+				 ON users(stable_user_id)
+				 WHERE stable_user_id IS NOT NULL`,
+			)
+			.run()
+	} catch {
+		// Index already exists or a full legacy index remains from an earlier suite.
 	}
 	await db
 		.prepare(

--- a/packages/worker/src/mcp-auth-user-context.node.test.ts
+++ b/packages/worker/src/mcp-auth-user-context.node.test.ts
@@ -2,7 +2,6 @@ import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
 	getUserRolesAndPermissions: vi.fn(),
-	findOne: vi.fn(),
 }))
 
 vi.mock('#app/permissions-db.ts', () => ({
@@ -10,72 +9,124 @@ vi.mock('#app/permissions-db.ts', () => ({
 		mockModule.getUserRolesAndPermissions(...args),
 }))
 
-vi.mock('#worker/db.ts', () => ({
-	createDb: () => ({
-		findOne: (...args: Array<unknown>) => mockModule.findOne(...args),
-	}),
-	usersTable: {},
-}))
-
 const { buildMcpUserContextFromGrantProps } =
 	await import('./mcp-auth-user-context.ts')
 
-function createMockAppDb() {
-	return {
-		prepare: () => ({
-			bind: () => ({
-				all: async () => ({ results: [], meta: { changes: 0 } }),
-			}),
-		}),
-	} as unknown as D1Database
+type GrantUserRow = {
+	id: number
+	email: string
+	username: string | null
+	display_name: string | null
+	stable_user_id: string
 }
 
-test('buildMcpUserContextFromGrantProps loads fresh roles and permissions', async () => {
-	mockModule.findOne.mockResolvedValueOnce({
-		id: 42,
-		email: 'admin@example.com',
-		username: 'admin',
-	})
+function createMockAppDb(options: {
+	row?: GrantUserRow | null
+	reject?: Error
+}) {
+	const queries: Array<{ sql: string; params: Array<unknown> }> = []
+	const db = {
+		prepare(sql: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					queries.push({ sql, params })
+					return {
+						async first<T>() {
+							if (options.reject) throw options.reject
+							const normalized = sql.replace(/\s+/g, ' ').toLowerCase()
+							if (
+								normalized.includes('where stable_user_id = ?') &&
+								normalized.includes('select id')
+							) {
+								return (options.row ?? null) as T | null
+							}
+							throw new Error(`Unsupported query: ${sql}`)
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+	return { db, queries }
+}
+
+test('buildMcpUserContextFromGrantProps loads roles by stable id and refreshes profile fields', async () => {
 	mockModule.getUserRolesAndPermissions.mockResolvedValueOnce({
 		roles: ['admin'],
 		permissions: ['read:user:any', 'read:role:any'],
 	})
-
-	const user = await buildMcpUserContextFromGrantProps(
-		{ APP_DB: createMockAppDb() } as Env,
-		{
-			userId: 'stable-admin-id',
-			email: 'admin@example.com',
+	const { db, queries } = createMockAppDb({
+		row: {
+			id: 42,
+			email: 'current@example.com',
 			username: 'admin',
-			displayName: 'admin',
+			display_name: 'Admin Display',
+			stable_user_id: 'stable-admin-id',
 		},
-	)
+	})
+
+	const user = await buildMcpUserContextFromGrantProps({ APP_DB: db } as Env, {
+		userId: 'stable-admin-id',
+		email: 'stale@example.com',
+		username: 'stale-username',
+		displayName: 'stale display',
+	})
 
 	expect(user).toEqual({
 		userId: 'stable-admin-id',
-		email: 'admin@example.com',
+		email: 'current@example.com',
 		username: 'admin',
-		displayName: 'admin',
+		displayName: 'Admin Display',
 		roles: ['admin'],
 		permissions: ['read:user:any', 'read:role:any'],
 	})
-	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledWith(
-		expect.anything(),
-		42,
-	)
+	expect(queries).toHaveLength(1)
+	expect(queries[0]?.sql.toLowerCase()).toContain('where stable_user_id = ?')
+	expect(queries[0]?.params).toEqual(['stable-admin-id'])
+	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledWith(db, 42)
 })
 
-test('buildMcpUserContextFromGrantProps omits roles and permissions when the users row is missing', async () => {
-	mockModule.findOne.mockResolvedValueOnce(null)
-
-	const user = await buildMcpUserContextFromGrantProps(
-		{ APP_DB: createMockAppDb() } as Env,
-		{
-			userId: 'orphan-id',
-			email: 'missing@example.com',
-			displayName: 'missing',
+test('buildMcpUserContextFromGrantProps never attaches roles from a stale grant email owned by another account', async () => {
+	mockModule.getUserRolesAndPermissions.mockResolvedValueOnce({
+		roles: ['user'],
+		permissions: [],
+	})
+	const { db } = createMockAppDb({
+		row: {
+			id: 7,
+			email: 'original-owner@example.com',
+			username: 'original',
+			display_name: null,
+			stable_user_id: 'stable-original',
 		},
-	)
+	})
+
+	const user = await buildMcpUserContextFromGrantProps({ APP_DB: db } as Env, {
+		userId: 'stable-original',
+		// Email now belongs to a different verified admin account.
+		email: 'reused-by-admin@example.com',
+		displayName: 'stale',
+	})
+
+	expect(user).toEqual({
+		userId: 'stable-original',
+		email: 'original-owner@example.com',
+		username: 'original',
+		displayName: 'original',
+		roles: ['user'],
+		permissions: [],
+	})
+	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledWith(db, 7)
+})
+
+test('buildMcpUserContextFromGrantProps omits roles when the stable id row is missing', async () => {
+	const { db } = createMockAppDb({ row: null })
+
+	const user = await buildMcpUserContextFromGrantProps({ APP_DB: db } as Env, {
+		userId: 'orphan-id',
+		email: 'missing@example.com',
+		displayName: 'missing',
+	})
 
 	expect(user).toEqual({
 		userId: 'orphan-id',
@@ -85,15 +136,17 @@ test('buildMcpUserContextFromGrantProps omits roles and permissions when the use
 	expect(mockModule.getUserRolesAndPermissions).not.toHaveBeenCalled()
 })
 
-test('buildMcpUserContextFromGrantProps falls back to the base user when the rbac lookup fails', async () => {
-	mockModule.findOne.mockRejectedValueOnce(new Error('D1 unavailable'))
+test('buildMcpUserContextFromGrantProps falls back without elevation when D1 fails', async () => {
+	const { db } = createMockAppDb({
+		reject: new Error('D1 unavailable'),
+	})
 	const consoleError = vi
 		.spyOn(console, 'error')
 		.mockImplementation(() => undefined)
 
 	try {
 		const user = await buildMcpUserContextFromGrantProps(
-			{ APP_DB: createMockAppDb() } as Env,
+			{ APP_DB: db } as Env,
 			{
 				userId: 'resilient-id',
 				email: 'resilient@example.com',
@@ -107,24 +160,38 @@ test('buildMcpUserContextFromGrantProps falls back to the base user when the rba
 			displayName: 'resilient',
 		})
 		expect(consoleError).toHaveBeenCalled()
+		expect(mockModule.getUserRolesAndPermissions).not.toHaveBeenCalled()
 	} finally {
 		consoleError.mockRestore()
 	}
 })
 
-test('buildMcpUserContextFromGrantProps skips rbac lookup when grant props omit email', async () => {
-	const user = await buildMcpUserContextFromGrantProps(
-		{ APP_DB: createMockAppDb() } as Env,
-		{
-			userId: 'legacy-id',
+test('buildMcpUserContextFromGrantProps resolves by stable id when grant props omit email', async () => {
+	mockModule.getUserRolesAndPermissions.mockResolvedValueOnce({
+		roles: ['user'],
+		permissions: [],
+	})
+	const { db, queries } = createMockAppDb({
+		row: {
+			id: 9,
+			email: 'resolved@example.com',
+			username: 'resolved',
+			display_name: null,
+			stable_user_id: 'legacy-id',
 		},
-	)
+	})
+
+	const user = await buildMcpUserContextFromGrantProps({ APP_DB: db } as Env, {
+		userId: 'legacy-id',
+	})
 
 	expect(user).toEqual({
 		userId: 'legacy-id',
-		email: '',
-		displayName: 'user',
+		email: 'resolved@example.com',
+		username: 'resolved',
+		displayName: 'resolved',
+		roles: ['user'],
+		permissions: [],
 	})
-	expect(mockModule.findOne).not.toHaveBeenCalled()
-	expect(mockModule.getUserRolesAndPermissions).not.toHaveBeenCalled()
+	expect(queries[0]?.params).toEqual(['legacy-id'])
 })

--- a/packages/worker/src/mcp-auth-user-context.ts
+++ b/packages/worker/src/mcp-auth-user-context.ts
@@ -1,6 +1,8 @@
 import { getUserRolesAndPermissions } from '#app/permissions-db.ts'
-import { displayNameFromEmail } from '#app/username.ts'
-import { createDb, usersTable } from '#worker/db.ts'
+import {
+	displayNameFromEmail,
+	getUsernameFormatValidationError,
+} from '#app/username.ts'
 import { type McpUserContext } from '@kody-internal/shared/chat.ts'
 
 type McpOAuthGrantProps = {
@@ -10,14 +12,18 @@ type McpOAuthGrantProps = {
 	displayName?: unknown
 } | null
 
-export async function buildMcpUserContextFromGrantProps(
-	env: Env,
-	grantProps: McpOAuthGrantProps,
-): Promise<McpUserContext | null> {
-	if (!grantProps || typeof grantProps.userId !== 'string') {
-		return null
-	}
+type GrantUserRow = {
+	id: number
+	email: string
+	username: string | null
+	display_name: string | null
+	stable_user_id: string
+}
 
+function buildBaseUserFromGrant(
+	grantProps: NonNullable<McpOAuthGrantProps>,
+	userId: string,
+): McpUserContext {
 	const email =
 		typeof grantProps.email === 'string' ? grantProps.email.trim() : ''
 	const displayName =
@@ -27,43 +33,76 @@ export async function buildMcpUserContextFromGrantProps(
 				? displayNameFromEmail(email)
 				: 'user'
 
-	const user: McpUserContext = {
-		userId: grantProps.userId,
+	return {
+		userId,
 		email,
 		displayName,
 		...(typeof grantProps.username === 'string'
 			? { username: grantProps.username }
 			: {}),
 	}
+}
 
-	if (!email) {
-		return user
+/**
+ * Build the MCP caller user context from OAuth grant props.
+ *
+ * Account identity and RBAC always resolve through the grant's stable
+ * `userId` (`users.stable_user_id`). Grant email/username/displayName are only
+ * a fallback when D1 is unavailable; a successful lookup refreshes those
+ * fields from the authoritative row so a stale grant email that another
+ * account now owns can never attach that other account's roles.
+ */
+export async function buildMcpUserContextFromGrantProps(
+	env: Env,
+	grantProps: McpOAuthGrantProps,
+): Promise<McpUserContext | null> {
+	if (!grantProps || typeof grantProps.userId !== 'string') {
+		return null
 	}
+	const userId = grantProps.userId.trim()
+	if (!userId) return null
+
+	const baseUser = buildBaseUserFromGrant(grantProps, userId)
 
 	// A transient D1 failure must not take MCP auth down. Roles and
 	// permissions are optional on the context; falling back to the base
-	// grant-props user simply means no elevated permissions this request.
+	// grant-props user means no elevated permissions this request.
 	try {
-		const db = createDb(env.APP_DB)
-		const userRecord = await db.findOne(usersTable, {
-			where: { email },
-		})
-		if (!userRecord) {
-			return user
-		}
+		const row = await env.APP_DB.prepare(
+			`SELECT id, email, username, display_name, stable_user_id
+			 FROM users
+			 WHERE stable_user_id = ?`,
+		)
+			.bind(userId)
+			.first<GrantUserRow>()
+		if (!row) return baseUser
+
+		const email = row.email.trim().toLowerCase()
+		const usernameCandidate = row.username?.trim() ?? ''
+		const username =
+			usernameCandidate && !getUsernameFormatValidationError(usernameCandidate)
+				? usernameCandidate
+				: undefined
+		const displayName =
+			row.display_name?.trim() ||
+			username ||
+			(email ? displayNameFromEmail(email) : baseUser.displayName)
 
 		const { roles, permissions } = await getUserRolesAndPermissions(
 			env.APP_DB,
-			userRecord.id,
+			row.id,
 		)
 
 		return {
-			...user,
+			userId,
+			email,
+			displayName,
+			...(username ? { username } : {}),
 			roles,
 			permissions,
 		}
 	} catch (error) {
 		console.error('Failed to load roles for MCP user context:', error)
-		return user
+		return baseUser
 	}
 }

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -52,25 +52,34 @@ function createHelpers(overrides: Partial<OAuthHelpers> = {}): OAuthHelpers {
 	}
 }
 
+type MockAccountRow = {
+	id: number
+	email: string
+	username: string | null
+	display_name: string | null
+	stable_user_id: string
+	email_verified_at: string | null
+}
+
 type MockDbOptions = {
 	// Row returned for the `email_verified_at` lookup keyed by account email.
 	emailVerifiedAt?: string | null
-	// Rows returned for the full `users` table scan (stable-user-id fallback).
-	userRows?: Array<{ email: string; email_verified_at: string | null }>
+	// Row returned for the indexed `stable_user_id` verification lookup.
+	stableUserVerifiedAt?: string | null
+	// Optional authoritative users row for stable-id profile/RBAC resolution.
+	accountByStableId?: MockAccountRow | null
 	// Rows returned for remote connector settings queries.
 	connectorRows?: Array<Record<string, unknown>>
 }
 
 function createMockDb(options: MockDbOptions = {}) {
 	const statementFor = (query: string) => {
+		const normalized = query.replace(/\s+/g, ' ').toLowerCase()
 		const statement = {
 			bind: () => statement,
 			async all() {
-				if (/from\s+"?users"?/i.test(query)) {
-					return {
-						results: options.userRows ?? [],
-						meta: { changes: 0 },
-					}
+				if (normalized.includes('from user_roles')) {
+					return { results: [], meta: { changes: 0 } }
 				}
 				return {
 					results: options.connectorRows ?? [],
@@ -78,7 +87,44 @@ function createMockDb(options: MockDbOptions = {}) {
 				}
 			},
 			async first() {
-				if (query.includes('email_verified_at')) {
+				const isProfileLookup =
+					normalized.includes('from users') &&
+					normalized.includes('where stable_user_id') &&
+					normalized.includes('select id')
+				if (isProfileLookup) {
+					if (options.accountByStableId !== undefined) {
+						return options.accountByStableId
+					}
+					const verifiedAt =
+						options.stableUserVerifiedAt ?? options.emailVerifiedAt
+					if (verifiedAt === undefined) return null
+					return {
+						id: 1,
+						email: 'user@example.com',
+						username: 'user',
+						display_name: null,
+						stable_user_id: 'user',
+						email_verified_at: verifiedAt,
+					} satisfies MockAccountRow
+				}
+				if (normalized.includes('email = ? and stable_user_id')) {
+					if (options.emailVerifiedAt !== undefined) {
+						return { email_verified_at: options.emailVerifiedAt }
+					}
+					if (options.stableUserVerifiedAt !== undefined) {
+						return { email_verified_at: options.stableUserVerifiedAt }
+					}
+					return null
+				}
+				if (
+					normalized.includes('where stable_user_id') &&
+					normalized.includes('email_verified_at')
+				) {
+					return options.stableUserVerifiedAt === undefined
+						? null
+						: { email_verified_at: options.stableUserVerifiedAt }
+				}
+				if (normalized.includes('email_verified_at')) {
 					return options.emailVerifiedAt === undefined
 						? null
 						: { email_verified_at: options.emailVerifiedAt }
@@ -378,9 +424,10 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 	expect(noUserResponse.status).toBe(403)
 	expect(fetchMcpCalled).toBe(false)
 
-	// Stable-user-id fallback verifies accounts when grant props lack email.
+	// Indexed stable-user-id lookup verifies accounts when grant props lack email.
 	const fallbackEmail = 'fallback@example.com'
 	const stableUserId = await createStableUserIdFromEmail(fallbackEmail)
+	const verifiedAt = new Date(0).toISOString()
 	const fallbackResponse = await handleMcpRequest({
 		request,
 		env: createEnv(
@@ -389,12 +436,15 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 			}),
 			{},
 			{
-				userRows: [
-					{
-						email: fallbackEmail,
-						email_verified_at: new Date(0).toISOString(),
-					},
-				],
+				stableUserVerifiedAt: verifiedAt,
+				accountByStableId: {
+					id: 11,
+					email: fallbackEmail,
+					username: 'fallback',
+					display_name: null,
+					stable_user_id: stableUserId,
+					email_verified_at: verifiedAt,
+				},
 			},
 		),
 		ctx: createContext(),

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.workers.test.ts
@@ -15,9 +15,10 @@ async function seedUser(input: {
 	plan: 'pro' | null
 	emailVerifiedAt?: string | null
 }) {
+	const stableUserId = await createStableUserIdFromEmail(input.email)
 	await env.APP_DB.prepare(
-		`INSERT INTO users (username, email, password_hash, email_verified_at, plan)
-			VALUES (?, ?, ?, ?, ?)`,
+		`INSERT INTO users (username, email, password_hash, email_verified_at, plan, stable_user_id)
+			VALUES (?, ?, ?, ?, ?, ?)`,
 	)
 		.bind(
 			`email-usage-${crypto.randomUUID().slice(0, 8)}`,
@@ -27,6 +28,7 @@ async function seedUser(input: {
 				? new Date().toISOString()
 				: input.emailVerifiedAt,
 			input.plan,
+			stableUserId,
 		)
 		.run()
 }

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -82,32 +82,33 @@ async function createDatabase(
 	options: { emailVerifiedAt?: string | null } = {},
 ) {
 	const passwordHash = await createPasswordHash(password)
+	const email = 'user@example.com'
+	const stableUserId = await createStableUserIdFromEmail(email)
 	const emailVerifiedAt =
 		options.emailVerifiedAt === undefined
 			? new Date(0).toISOString()
 			: options.emailVerifiedAt
+	const userRow = {
+		id: 1,
+		username: 'test-user',
+		email,
+		password_hash: passwordHash,
+		email_verified_at: emailVerifiedAt,
+		stable_user_id: stableUserId,
+	}
 	return {
 		prepare(query: string) {
 			// The 2FA gate queries verifications during inline OAuth login; the
 			// mocked user has no verification rows, so those queries are empty.
 			const isVerificationsQuery = query.includes('FROM verifications')
-			const isEmailVerifiedQuery = query.includes('email_verified_at')
+			const isEmailVerifiedQuery =
+				query.includes('email_verified_at') && !query.includes('stable_user_id')
 			return {
 				bind() {
 					return {
 						async all() {
 							return {
-								results: isVerificationsQuery
-									? []
-									: [
-											{
-												id: 1,
-												username: 'test-user',
-												email: 'user@example.com',
-												password_hash: passwordHash,
-												email_verified_at: emailVerifiedAt,
-											},
-										],
+								results: isVerificationsQuery ? [] : [userRow],
 								meta: { changes: 0, last_row_id: 0 },
 							}
 						},
@@ -116,13 +117,7 @@ async function createDatabase(
 							if (isEmailVerifiedQuery) {
 								return { email_verified_at: emailVerifiedAt }
 							}
-							return {
-								id: 1,
-								username: 'test-user',
-								email: 'user@example.com',
-								password_hash: passwordHash,
-								email_verified_at: emailVerifiedAt,
-							}
+							return userRow
 						},
 						async run() {
 							return { meta: { changes: 1, last_row_id: 1 } }
@@ -213,6 +208,7 @@ async function seedWorkerUser(
 	options: { emailVerifiedAt?: string | null } = {},
 ) {
 	const passwordHash = await createPasswordHash(password)
+	const stableUserId = await createStableUserIdFromEmail(email)
 	await env.APP_DB.prepare(
 		`CREATE TABLE IF NOT EXISTS users (
 			id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -220,10 +216,18 @@ async function seedWorkerUser(
 			email TEXT NOT NULL UNIQUE,
 			password_hash TEXT NOT NULL,
 			email_verified_at TEXT,
+			stable_user_id TEXT NOT NULL,
 			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 			updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 		)`,
 	).run()
+	try {
+		await env.APP_DB.prepare(
+			`ALTER TABLE users ADD COLUMN stable_user_id TEXT`,
+		).run()
+	} catch {
+		// Column already present on a fresh CREATE above.
+	}
 	// The inline OAuth login checks two-factor status, which queries the
 	// verifications table (empty here: no seeded user has 2FA enabled).
 	await env.APP_DB.prepare(
@@ -246,17 +250,19 @@ async function seedWorkerUser(
 			? new Date(0).toISOString()
 			: options.emailVerifiedAt
 	const result = await env.APP_DB.prepare(
-		`INSERT INTO users (username, email, password_hash, email_verified_at)
-			VALUES (?, ?, ?, ?)
+		`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
+			VALUES (?, ?, ?, ?, ?)
 			ON CONFLICT(email) DO UPDATE SET
 				password_hash = excluded.password_hash,
-				email_verified_at = excluded.email_verified_at`,
+				email_verified_at = excluded.email_verified_at,
+				stable_user_id = COALESCE(users.stable_user_id, excluded.stable_user_id)`,
 	)
 		.bind(
 			`user-${crypto.randomUUID().slice(0, 8)}`,
 			email,
 			passwordHash,
 			emailVerifiedAt,
+			stableUserId,
 		)
 		.run()
 	return Number(result.meta.last_row_id)
@@ -840,6 +846,7 @@ test('worker entrypoint renders OAuth errors for delegated authorize route excep
 
 test('reset client deletes matching grants for redirect-uri, client-id, and authorize-info mismatches', async () => {
 	const userId = await createStableUserIdFromEmail('user@example.com')
+	const appDb = await createDatabase('password123')
 	setAuthSessionSecret(cookieSecret)
 	const cookie = await createAuthCookie(
 		{ id: 'session-id', email: 'user@example.com', rememberMe: false },
@@ -907,7 +914,7 @@ test('reset client deletes matching grants for redirect-uri, client-id, and auth
 				body: new URLSearchParams({ decision: 'reset-client' }),
 			},
 		),
-		createEnv(redirectUriHelpers),
+		createEnv(redirectUriHelpers, appDb),
 	)
 
 	expect(redirectUriResponse.status).toBe(200)
@@ -959,7 +966,7 @@ test('reset client deletes matching grants for redirect-uri, client-id, and auth
 		new Request(
 			`https://example.com/oauth/authorize-info?response_type=code&client_id=client-123&redirect_uri=${encodeURIComponent('https://example.com/callback')}&error_description=${encodeURIComponent(invalidClientIdMismatchMessage)}`,
 		),
-		createEnv(clientMismatchHelpers),
+		createEnv(clientMismatchHelpers, appDb),
 	)
 	const resetVerificationCookie =
 		authorizeInfoResponse.headers.get('Set-Cookie') ?? ''
@@ -977,7 +984,7 @@ test('reset client deletes matching grants for redirect-uri, client-id, and auth
 				body: new URLSearchParams({ decision: 'reset-client' }),
 			},
 		),
-		createEnv(clientMismatchHelpers),
+		createEnv(clientMismatchHelpers, appDb),
 	)
 
 	expect(clientMismatchResponse.status).toBe(200)
@@ -1029,7 +1036,7 @@ test('reset client deletes matching grants for redirect-uri, client-id, and auth
 				}),
 			},
 		),
-		createEnv(authorizeInfoHelpers),
+		createEnv(authorizeInfoHelpers, appDb),
 	)
 
 	expect(authorizeInfoResetResponse.status).toBe(200)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- resolve MCP grant accounts and RBAC by authoritative `users.stable_user_id`, not potentially stale grant email
- require email and stable ID to identify the same account during MCP email-verification checks
- refresh caller email/profile fields from the stored account and fail closed to no elevated roles on D1 errors
- add stale-email-reuse regression coverage and align affected worker fixtures with stable IDs

## Why
After an account email change, an old grant email can later belong to another account. Email-only verification or role lookup could then combine one account's stable data identity with another account's verification/RBAC state.

## Validation
- `npm run validate`: passed on final rebased head
- unit suite: 1,042 tests passed via pre-push
- Playwright E2E: 17 tests passed via pre-push

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0b824ebc` · **Head:** `c3ee1c9b`

**Classification:** extends — tightens identity binding across MCP auth, email verification, and RBAC.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-sessions` | auth | extends — verification binds email and stable identity |
| `email` | assistant | composes — affected email tests carry stable IDs |
| `entitlements` | auth | composes — shared test users expose indexed stable IDs |
| `app-ui` | surfaces | composes — verification regression coverage |

### System map

OAuth grant authentication resolves stable identity in D1 before attaching current account metadata or RBAC; verification checks bind both identity attributes.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	email["email<br/>Email"]:::touched
	entitlements["entitlements<br/>Plans & entitlements"]:::touched
	appSessions -->|"stable_user_id account + RBAC lookup"| appSessions
	appSessions -->|"email + stable ID verification pair"| email
	entitlements -->|"stable-ID-aware test schema"| appSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Grant `userId` remains the authoritative per-user data scope.
- Stale grant email cannot attach another account's roles or verified state.
- D1 lookup failures do not grant elevated permissions.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e59f01b-ce4b-45f8-baaf-af79662c32a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e59f01b-ce4b-45f8-baaf-af79662c32a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Email verification now confirms the correct account when both email and account identity are provided, preventing stale verification from being reused.
  - OAuth and MCP authentication now resolve profiles and permissions using a stable account identity, improving accuracy when email details change or are unavailable.
  - Failed or missing account lookups now safely fall back without granting roles or permissions.

- **Tests**
  - Expanded coverage for verification, identity resolution, permissions, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->