### PR TITLE
Clear remaining oxlint warnings

### DIFF
--- a/e2e/playwright-utils.ts
+++ b/e2e/playwright-utils.ts
@@ -54,12 +54,15 @@ export const test = base.extend<{
 			return { email, username, password }
 		})
 	},
-	assignRole: async (_fixtures, use) => {
+	// Playwright fixtures require object destructuring even with no deps.
+	// eslint-disable-next-line no-empty-pattern -- Playwright fixture signature
+	assignRole: async ({}, use) => {
 		await use(async (email, role) => {
 			assignRoleInE2eDatabase(email, role)
 		})
 	},
-	seedE2eUser: async (_fixtures, use) => {
+	// eslint-disable-next-line no-empty-pattern -- Playwright fixture signature
+	seedE2eUser: async ({}, use) => {
 		await use(async (options) => {
 			const runId = Date.now()
 			const email = options?.email ?? `e2e-user-${runId}@example.com`

--- a/e2e/playwright-utils.ts
+++ b/e2e/playwright-utils.ts
@@ -54,12 +54,12 @@ export const test = base.extend<{
 			return { email, username, password }
 		})
 	},
-	assignRole: async ({}, use) => {
+	assignRole: async (_fixtures, use) => {
 		await use(async (email, role) => {
 			assignRoleInE2eDatabase(email, role)
 		})
 	},
-	seedE2eUser: async ({}, use) => {
+	seedE2eUser: async (_fixtures, use) => {
 		await use(async (options) => {
 			const runId = Date.now()
 			const email = options?.email ?? `e2e-user-${runId}@example.com`

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -158,7 +158,6 @@ const tagChipCss = {
 
 export function AccountPackagesRoute(handle: Handle) {
 	let status: PageStatus = 'loading'
-	let pageSize = 20
 	let loadedThroughPage = 1
 	const packageList = createInfiniteList<AccountPackageListItem>({
 		mergeDirection: 'append',
@@ -201,7 +200,6 @@ export function AccountPackagesRoute(handle: Handle) {
 	}
 
 	function applyPayload(payload: AccountPackagesLoaderData, href: string) {
-		pageSize = payload.pageSize
 		const listKey = getListKey(href)
 		// Selection-only navigations deep in the scroll window keep the
 		// already-loaded pages; anything else reseeds from page one so

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -563,13 +563,6 @@ export function AccountSecretsRoute(handle: Handle) {
 		return new URL(getCurrentHref(), 'http://localhost').search
 	}
 
-	function buildSecretsHrefWithSearch(
-		pathname: string,
-		search = getCurrentSearch(),
-	) {
-		return buildSecretsHref(pathname, search)
-	}
-
 	function buildHrefWithUpdatedFilters(
 		nextFilters: Partial<SecretFilterState>,
 		options?: { pathname?: string },

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -132,7 +132,6 @@ export function AdminUsersRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let availableRoles: Array<RoleName> = []
 	let availablePlans: Array<AdminPlanName> = []
-	let pageSize = 20
 	let loadedThroughPage = 1
 	const userList = createInfiniteList<AdminUserListItem>({
 		mergeDirection: 'append',
@@ -185,7 +184,6 @@ export function AdminUsersRoute(handle: Handle) {
 	function seedUsersFromPayload(payload: AdminUsersLoaderData) {
 		availableRoles = payload.availableRoles
 		availablePlans = payload.availablePlans
-		pageSize = payload.pageSize
 		loadedThroughPage = payload.page
 		// reset() invalidates any in-flight load-more so a stale page fetched
 		// for the previous filters can never append into the fresh window.

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -661,6 +661,7 @@ export function LoginRoute(handle: Handle) {
 						</p>
 						{authProviders.map((provider) => (
 							<button
+								key={provider.id}
 								type="button"
 								disabled={isSubmitting}
 								mix={[

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import type * as AllowedCapabilities from '#mcp/secrets/allowed-capabilities.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(async () => ({
@@ -72,10 +73,7 @@ vi.mock('#mcp/secrets/allowed-hosts.ts', () => ({
 }))
 
 vi.mock('#mcp/secrets/allowed-capabilities.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<
-			typeof import('#mcp/secrets/allowed-capabilities.ts')
-		>()
+	const actual = await importOriginal<typeof AllowedCapabilities>()
 	return {
 		...actual,
 		normalizeAllowedCapabilities: (capabilities: Array<string>) => capabilities,

--- a/packages/worker/src/app/handlers/admin-feature-flags.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-feature-flags.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { type PermissionString, type RoleName } from '#app/permissions.ts'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import type * as AuditLog from '#app/audit-log.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
@@ -12,7 +13,7 @@ vi.mock('#app/authenticated-user.ts', () => ({
 }))
 
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	const actual = await importOriginal<typeof AuditLog>()
 	return {
 		...actual,
 		getRequestIp: () => '127.0.0.1',

--- a/packages/worker/src/app/handlers/admin-platform-feedback.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-platform-feedback.node.test.ts
@@ -2,6 +2,8 @@ import { expect, test, vi } from 'vitest'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 import { platformFeedbackContentWarning } from '#worker/platform-feedback/content-warning.ts'
 import { type AdminPlatformFeedbackLoaderData } from '#app/loader-data.ts'
+import type * as AdminPlatformFeedbackData from '#app/admin-platform-feedback-data.ts'
+import type * as AuditLog from '#app/audit-log.ts'
 
 const mockModule = vi.hoisted(() => ({
 	requireUserWithRole: vi.fn(),
@@ -14,10 +16,7 @@ vi.mock('#app/permissions-server.ts', () => ({
 }))
 
 vi.mock('#app/admin-platform-feedback-data.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<
-			typeof import('#app/admin-platform-feedback-data.ts')
-		>()
+	const actual = await importOriginal<typeof AdminPlatformFeedbackData>()
 	return {
 		...actual,
 		loadAdminPlatformFeedbackData: (...args: Array<unknown>) =>
@@ -26,7 +25,7 @@ vi.mock('#app/admin-platform-feedback-data.ts', async (importOriginal) => {
 })
 
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	const actual = await importOriginal<typeof AuditLog>()
 	return {
 		...actual,
 		getRequestIp: () => '127.0.0.1',

--- a/packages/worker/src/app/handlers/admin-roles.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-roles.node.test.ts
@@ -62,7 +62,7 @@ function createRolesTestEnv() {
 						}
 						return { results: [] as Array<T>, meta: { changes: 0 } }
 					},
-					async first<T>() {
+					async first() {
 						return null
 					},
 					async run() {

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { adminUserListItemFieldNames } from './admin-users.ts'
 import { type PermissionString, type RoleName } from '#app/permissions.ts'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import type * as AuditLog from '#app/audit-log.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
@@ -15,7 +16,7 @@ vi.mock('#app/authenticated-user.ts', () => ({
 // The shared audit-log-spy setup file routes logAuditEvent; this test also
 // needs a deterministic request IP for its audit assertions.
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	const actual = await importOriginal<typeof AuditLog>()
 	return {
 		...actual,
 		getRequestIp: () => '127.0.0.1',

--- a/packages/worker/src/app/handlers/community-feature.node.test.ts
+++ b/packages/worker/src/app/handlers/community-feature.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import { createCommunityFeatureApiPostHandler } from './community-feature.ts'
+import type * as AuditLog from '#app/audit-log.ts'
 
 const mockModule = vi.hoisted(() => ({
 	requireUserWithRole: vi.fn(),
@@ -19,7 +20,7 @@ vi.mock('#worker/community/service.ts', () => ({
 }))
 
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	const actual = await importOriginal<typeof AuditLog>()
 	return {
 		...actual,
 		logAuditEvent: (...args: Array<unknown>) =>

--- a/packages/worker/src/app/handlers/community-trust.node.test.ts
+++ b/packages/worker/src/app/handlers/community-trust.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import { createCommunityTrustApiPostHandler } from './community-trust.ts'
+import type * as AuditLog from '#app/audit-log.ts'
 
 const mockModule = vi.hoisted(() => ({
 	requireUserWithRole: vi.fn(),
@@ -19,7 +20,7 @@ vi.mock('#worker/community/service.ts', () => ({
 }))
 
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	const actual = await importOriginal<typeof AuditLog>()
 	return {
 		...actual,
 		logAuditEvent: (...args: Array<unknown>) =>

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import type * as AuditLog from '#app/audit-log.ts'
 
 const mockModule = vi.hoisted(() => ({
 	createRecord: vi.fn(async () => undefined),
@@ -24,7 +25,7 @@ vi.mock('#worker/db.ts', () => ({
 // The shared audit-log-spy setup file routes logAuditEvent; this test also
 // needs getRequestIp pinned to null for deterministic audit payloads.
 vi.mock('#app/audit-log.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/audit-log.ts')>()
+	const actual = await importOriginal<typeof AuditLog>()
 	return {
 		...actual,
 		getRequestIp: () => null,

--- a/packages/worker/src/app/handlers/profile.node.test.ts
+++ b/packages/worker/src/app/handlers/profile.node.test.ts
@@ -6,6 +6,7 @@ import {
 } from './profile.tsx'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import { type CommunityProfileRecord } from '#worker/community/types.ts'
+import type * as FrameRegistry from '#app/frame-registry.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
@@ -55,7 +56,7 @@ vi.mock('#app/frames/profile.ts', () => ({}))
 vi.mock('#app/frame-registrations.ts', () => ({}))
 
 vi.mock('#app/frame-registry.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('#app/frame-registry.ts')>()
+	const actual = await importOriginal<typeof FrameRegistry>()
 	return {
 		...actual,
 		handleFrameRequest: vi.fn(

--- a/packages/worker/src/app/handlers/two-factor.node.test.ts
+++ b/packages/worker/src/app/handlers/two-factor.node.test.ts
@@ -2,7 +2,7 @@ import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
 import { readdirSync, readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { generateTOTP } from '@epic-web/totp'
-import { expect, test, vi } from 'vitest'
+import { expect, test } from 'vitest'
 import {
 	createAuthCookie,
 	setAuthSessionSecret,

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -5,6 +5,7 @@ import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-regi
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+import type * as ModuleGraph from '#worker/package-runtime/module-graph.ts'
 import {
 	buildKodyFns,
 	buildKodyProvider,
@@ -328,9 +329,9 @@ export default async function main() {
 })
 
 vi.mock('#worker/package-runtime/module-graph.ts', async () => {
-	const actual = await vi.importActual<
-		typeof import('#worker/package-runtime/module-graph.ts')
-	>('#worker/package-runtime/module-graph.ts')
+	const actual = await vi.importActual<typeof ModuleGraph>(
+		'#worker/package-runtime/module-graph.ts',
+	)
 	return {
 		...actual,
 		buildKodyModuleBundle: vi.fn(async () => ({

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -1,6 +1,9 @@
 import { readFile } from 'node:fs/promises'
 import { expect, test, vi } from 'vitest'
 import { createDynamicWorkerCompatibilityOptions } from '#worker/dynamic-worker-compatibility.ts'
+import type * as CloudflareWorkers from 'cloudflare:workers'
+import type * as ModuleGraph from './module-graph.ts'
+import type * as PublishedBundleArtifacts from './published-bundle-artifacts.ts'
 
 async function extractCreatePackageAppWorkerSource() {
 	const sourceText = await readFile(
@@ -211,7 +214,7 @@ const packageAppRuntimeMock = vi.hoisted(() => ({
 }))
 
 vi.mock('cloudflare:workers', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('cloudflare:workers')>()
+	const actual = await importOriginal<typeof CloudflareWorkers>()
 	return {
 		...actual,
 		exports: {
@@ -222,10 +225,7 @@ vi.mock('cloudflare:workers', async (importOriginal) => {
 })
 
 vi.mock('./module-graph.ts', async () => {
-	const actual =
-		await vi.importActual<typeof import('./module-graph.ts')>(
-			'./module-graph.ts',
-		)
+	const actual = await vi.importActual<typeof ModuleGraph>('./module-graph.ts')
 	return {
 		...actual,
 		buildKodyAppBundle: (...args: Array<unknown>) =>
@@ -236,9 +236,9 @@ vi.mock('./module-graph.ts', async () => {
 })
 
 vi.mock('./published-bundle-artifacts.ts', async () => {
-	const actual = await vi.importActual<
-		typeof import('./published-bundle-artifacts.ts')
-	>('./published-bundle-artifacts.ts')
+	const actual = await vi.importActual<typeof PublishedBundleArtifacts>(
+		'./published-bundle-artifacts.ts',
+	)
 	return {
 		...actual,
 		loadPublishedBundleArtifactByIdentity: (...args: Array<unknown>) =>

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test, vi } from 'vitest'
+import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
@@ -57,13 +57,6 @@ vi.mock('#worker/package-invocations/service.ts', () => ({
 
 const usageModule = await import('#worker/usage/record-usage.ts')
 const recordUsageSpy = vi.spyOn(usageModule, 'recordUsage')
-
-// The global `mockReset: true` config restores the spy's real implementation
-// before every test; the real recordUsage would then run against the stub env
-// and log `usage-rollup-failed`. Re-stub per test.
-beforeEach(() => {
-	recordUsageSpy.mockResolvedValue(undefined)
-})
 
 const {
 	PackageServiceInstance,
@@ -177,7 +170,11 @@ function resetMocks() {
 	mockModule.runBundledModuleWithRegistry.mockReset()
 	mockModule.createPackageEventTools.mockReset()
 	mockModule.createPackageRuntimeInvokeTools.mockReset()
+	// The global `mockReset: true` config restores the spy's real
+	// implementation before every test; re-stub so recordUsage does not run
+	// against the stub env and log `usage-rollup-failed`.
 	recordUsageSpy.mockClear()
+	recordUsageSpy.mockResolvedValue(undefined)
 }
 
 function setupSavedPackage(mode: 'bounded' | 'persistent') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clears all 22 remaining oxlint warnings so `npm run lint` is clean (0 warnings / 0 errors).

- Replace forbidden `typeof import()` type annotations with `import type * as …` in unit tests
- Remove unused locals (`pageSize`, helper, `vi`, unused generic)
- Add a React `key` on login social-provider buttons
- Move `recordUsage` re-stubbing into `resetMocks()` instead of `beforeEach`
- Keep Playwright’s required empty fixture destructuring with targeted `no-empty-pattern` disables

## Test plan

- [x] `npm run lint` → 0 warnings / 0 errors
- [x] pre-commit typecheck / migrations check
- [x] pre-push Playwright e2e (17 passed)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `36d84e2e` · **Head:** `fcc5c45f`

**Classification:** composes — lint-only cleanup across UI routes and tests; no primitive behavior or contracts changed.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — unused locals / login provider key |
| `rbac` | auth | composes — admin handler test type imports |
| `community-listings` | assistant | composes — community handler test type imports |
| `mcp-server` | surfaces | composes — registry test type import |
| `package-runtime` | runtime | composes — test mock typing / recordUsage stub placement |

Unmatched: `e2e/playwright-utils.ts` (Playwright fixture signature disables).

### System map

Lint cleanup across browser routes and nearby unit/e2e tests; no runtime contract changes.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	rbac["rbac<br/>Role-based access control"]:::touched
	communityListings["community-listings<br/>Community package listings"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	packageRuntime["package-runtime<br/>Package runtime"]:::touched
	appUi -->|"unused locals + login key"| appUi
	rbac -->|"test typeof import → type import"| rbac
	communityListings -->|"test typeof import → type import"| communityListings
	mcpServer -->|"module-graph mock type import"| mcpServer
	packageRuntime -->|"mock typing + recordUsage stub in resetMocks"| packageRuntime
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9c40d02-4394-4881-87f0-08b83044ecac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9c40d02-4394-4881-87f0-08b83044ecac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

