### PR TITLE
perf(test): parallelize unit test files to halve validate wall time

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,10 +15,22 @@
 			"cache": true
 		},
 		"test": {
-			"cache": true
+			"cache": true,
+			"inputs": [
+				"default",
+				"^default",
+				"{workspaceRoot}/vitest*.ts",
+				"{workspaceRoot}/tools/**/*"
+			]
 		},
 		"test-mcp": {
-			"cache": true
+			"cache": true,
+			"inputs": [
+				"default",
+				"^default",
+				"{workspaceRoot}/vitest*.ts",
+				"{workspaceRoot}/tools/**/*"
+			]
 		},
 		"prepare-e2e-env": {
 			"cache": true

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
 	webServer: {
 		command: webServerCommand,
 		url: baseURL,
+		// Startup (client build + D1 migrations + Wrangler boot) competes with
+		// the parallel unit test workers at the beginning of `validate`, and the
+		// default 60s budget times out on 4-core CI runners.
+		timeout: process.env.CI ? 180_000 : 60_000,
 		reuseExistingServer: hasExplicitBaseUrl,
 		env: {
 			CLOUDFLARE_ENV: 'test',

--- a/vitest-shared.ts
+++ b/vitest-shared.ts
@@ -45,7 +45,6 @@ export const sharedProjectConfig = {
 	test: {
 		testTimeout,
 		hookTimeout: testTimeout,
-		fileParallelism: false,
 		clearMocks: true,
 		mockReset: true,
 		setupFiles: [

--- a/vitest-shared.ts
+++ b/vitest-shared.ts
@@ -45,6 +45,10 @@ export const sharedProjectConfig = {
 	test: {
 		testTimeout,
 		hookTimeout: testTimeout,
+		// `validate` runs this suite concurrently with Playwright and two
+		// Wrangler servers on 4-core CI runners; leave a core free so their
+		// startup is not starved by test workers.
+		maxWorkers: process.env.CI ? 3 : undefined,
 		clearMocks: true,
 		mockReset: true,
 		setupFiles: [

--- a/vitest.mcp-e2e.config.ts
+++ b/vitest.mcp-e2e.config.ts
@@ -15,6 +15,9 @@ export default mergeConfig(
 			include: ['**/*.mcp-e2e.test.ts'],
 			testTimeout: mcpE2eTimeout,
 			hookTimeout: mcpE2eTimeout,
+			// Each file boots a real Wrangler dev server and shares the seeded
+			// e2e database, so files must not run in parallel.
+			fileParallelism: false,
 		},
 	}),
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`npm run validate` in CI takes ~5m20s, and the whole job ~6.5min. Per-check completion times inside a recent run (29892110417) show the unit test suite is the entire critical path:

| Check | Completion |
| --- | --- |
| primitives, migrations | ~2s |
| format, lint | ~9s |
| typecheck | 40s |
| MCP e2e | 1m36s |
| Playwright e2e | 3m15s |
| unit tests | **5m20s** |

The vitest summary explains why: 327 files, 310s total, of which **180s is module import time** and only 62s is actual test time — all serialized by `fileParallelism: false` in `vitest-shared.ts` (present since the original projects migration with no stated rationale).

## Change

- Remove `fileParallelism: false` from the shared vitest project config, so `node-unit` (289 files) and `workers-unit` (37 files) run files across all cores. In CI, cap vitest at 3 workers so the concurrent Wrangler/Playwright startups are not starved on 4-core runners.
- Keep `mcp-e2e` explicitly serial with a comment: each file boots a real Wrangler dev server against the shared seeded e2e database.
- Raise the Playwright `webServer` startup budget to 180s in CI: with unit tests using all cores, the e2e server (client build + D1 migrations + Wrangler boot) exceeded the default 60s on the first CI attempt.
- Fix an nx cache-correctness gap found while measuring: `worker:test` / `worker:test-mcp` only hashed project files, so edits to the root `vitest*.ts` configs or `tools/` (vite plugins + root-level test files the runner picks up) returned stale cache hits. Both targets now include those paths in their inputs.

## Measurements

- Unit suite alone (4-core VM, cold nx cache): **196s → 82s**.
- Full `npm run validate` locally with `CI=true`, cold cache: **1m54s**, all 8 checks green.
- Real CI (run 29894981813, green): validate step **5m20s → 4m00s**, unit tests **5m20s → 3m41s**, total job **~6m35s → 5m27s**. Playwright e2e is now the critical path.
- Stability: 6+ green runs of the parallel config across local, pre-push hooks, and CI.

## Follow-up candidates (not in this PR)

- Playwright is the new critical path (`workers: 1` due to documented SQLITE_BUSY contention on the shared local D1 file). Per-worker databases would unlock parallelism there.
- `isolate: false` for `node-unit` could cut the remaining per-file import cost further, but risks cross-file state leakage; not worth the flake risk without more investigation.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `36d84e2e` · **Head:** `e52169df`

**Classification:** composes — no primitives added or changed. The diff touches only test-runner configuration (`vitest-shared.ts`, `vitest.mcp-e2e.config.ts`, `playwright.config.ts`) and nx cache inputs (`nx.json`); the primitives classifier matches zero primitives, the lowest-risk outcome. No runtime, storage, or surface code changes.

### Primitives touched

_None. All four changed files are repo tooling outside the primitives map._

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5757e7e-bd29-4a0f-8577-e886c311911e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5757e7e-bd29-4a0f-8577-e886c311911e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test execution consistency by refining inputs used for cached test runs.
  * Limited test worker concurrency on CI for more predictable performance.
  * Updated end-to-end test execution to avoid parallel file startup when sharing dev servers and seeded data.
  * Increased the web server startup timeout (with CI-aware values) to reduce flaky startup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->