### PR TITLE
Steer raw OAuth product-API calls toward packages

### DIFF
--- a/docs/guides/integration-bootstrap.md
+++ b/docs/guides/integration-bootstrap.md
@@ -92,13 +92,20 @@ If those conditions are not met, stop and fix the integration first.
      similarly small account/profile endpoint.
    - Confirm the integration or secret name, token refresh behavior, and allowed
      hosts all work end-to-end.
+   - Keep raw OAuth helpers (`createAuthenticatedFetch`, `refreshAccessToken`)
+     for smoke tests and short exploration. **Integrations = auth; packages =
+     how agents should call the product.** Do not keep hand-rolling product API
+     calls with raw auth helpers in `execute` when a package should own that
+     surface.
 5. Only after the smoke test succeeds should you obtain the dependent package or
    package app.
+   - Search the user's account for an existing package that wraps the
+     integration.
    - Call `community_search` for the provider or workflow (prefer `trusted`
      matches). If a listing is close to the user's goal, fork or point them at
      one-click install, then adapt — do not reimplement from scratch.
-   - Create or save a new package only when no suitable community listing
-     exists.
+   - Create or save a thin helpers package only when no suitable community
+     listing exists.
    - If the integration or tokens already exist and the smoke test passes,
      proceed directly to that fork-or-create step.
    - Do not spend extra time exploring the local repo when the integration
@@ -165,3 +172,6 @@ Avoid these common mistakes:
 - building a package-app OAuth callback flow by default instead of the standard
   `/connect/oauth` path
 - skipping the authenticated smoke test after the user completes setup
+- treating a connected OAuth integration as a pre-built product API package, or
+  continuing to call Gmail/Calendar/etc. with raw `createAuthenticatedFetch` in
+  `execute` instead of searching for / forking / creating a helpers package

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -80,6 +80,12 @@ Move the behavior into a package when one or more of these become true:
   history
 - inputs, output, error handling, or integration behavior will evolve
 - a one-off script has already been copied, repaired, or rerun
+- you are calling a third-party **product** API with raw integration auth
+  helpers (`createAuthenticatedFetch`, `refreshAccessToken`, or equivalent)
+  beyond a cheap smoke test — **integrations = auth; packages = how agents
+  should call the product**. Search for an existing wrapper package first, then
+  `community_search` (prefer **trusted**), then fork or create a thin helpers
+  package
 
 Do not create a package merely to wrap one clear call to an existing capability
 or package export, or merely because a simple self-contained job needs a

--- a/packages/worker/src/mcp/raw-fetch-host-nudge.node.test.ts
+++ b/packages/worker/src/mcp/raw-fetch-host-nudge.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import {
 	applyRawFetchHostCounts,
+	codeUsesIntegrationAuthHelpers,
 	createRawFetchHostSink,
 	formatRawFetchHostNudge,
 	listHostsApproachingRawFetchNudge,
@@ -156,4 +157,35 @@ test('raw-fetch host nudge counts hosts, tips at threshold once, excludes covere
 			count: 3,
 		}),
 	])
+
+	expect(codeUsesIntegrationAuthHelpers('const x = 1')).toBe(false)
+	expect(
+		codeUsesIntegrationAuthHelpers(
+			`import { createAuthenticatedFetch } from 'kody:runtime'`,
+		),
+	).toBe(true)
+	expect(
+		codeUsesIntegrationAuthHelpers(
+			`import { refreshAccessToken } from 'kody:runtime'`,
+		),
+	).toBe(true)
+
+	const authHelperTip = applyRawFetchHostCounts({
+		state: null,
+		conversationId: 'conv-oauth',
+		hostCounts: { 'gmail.googleapis.com': 3 },
+		usedIntegrationAuthHelpers: true,
+	})
+	const authHelperNudge = formatRawFetchHostNudge({
+		hostname: 'gmail.googleapis.com',
+		count: 3,
+		usedIntegrationAuthHelpers: true,
+	})
+	const plainNudge = formatRawFetchHostNudge({
+		hostname: 'gmail.googleapis.com',
+		count: 3,
+	})
+	expect(authHelperTip.nudges).toEqual([authHelperNudge])
+	expect(authHelperNudge).not.toBe(plainNudge)
+	expect(authHelperNudge).toContain('gmail.googleapis.com')
 })

--- a/packages/worker/src/mcp/raw-fetch-host-nudge.ts
+++ b/packages/worker/src/mcp/raw-fetch-host-nudge.ts
@@ -96,11 +96,35 @@ export function wrapOutboundFetcherRecordingHosts(
 	} as Fetcher
 }
 
+/**
+ * True when execute/package source references raw OAuth/integration auth
+ * helpers. Used only to sharpen the packages-first failure-moment steer —
+ * not as a hard gate (smoke tests still use these helpers).
+ */
+export function codeUsesIntegrationAuthHelpers(code: string) {
+	return /\b(?:createAuthenticatedFetch|refreshAccessToken)\b/.test(code)
+}
+
+/**
+ * One-line packages-first steer when ad hoc execute repeatedly raw-fetches a
+ * product API host. Integrations are auth; packages are how agents should call
+ * the product. Prefer trusted community packages when forking.
+ */
 export function formatRawFetchHostNudge(input: {
 	hostname: string
 	count: number
+	usedIntegrationAuthHelpers?: boolean
 }) {
-	return `Raw-fetched ${input.hostname} ${input.count}x this conversation — consider openapi_binding_save or a saved package for this API (search for existing ones first).`
+	const mentalModel =
+		'Integrations = auth; packages = how agents should call the product.'
+	const packagesFirst =
+		'Prefer a package: search for an existing wrapper, then community_search (prefer trusted), then fork or create a thin helpers package.'
+	const openapiAside =
+		'Use openapi_binding_save only when an OpenAPI binding fits.'
+	if (input.usedIntegrationAuthHelpers) {
+		return `Raw integration auth hit ${input.hostname} ${input.count}x this conversation. ${mentalModel} ${packagesFirst} ${openapiAside}`
+	}
+	return `Raw-fetched ${input.hostname} ${input.count}x this conversation. ${mentalModel} ${packagesFirst} ${openapiAside}`
 }
 
 /**
@@ -136,6 +160,11 @@ export function applyRawFetchHostCounts(input: {
 	hostCounts: ReadonlyMap<string, number> | Record<string, number>
 	/** Hosts that already have a saved OpenAPI binding — never nudge these. */
 	coveredHosts?: ReadonlySet<string> | Iterable<string>
+	/**
+	 * When the execute module used createAuthenticatedFetch / refreshAccessToken,
+	 * sharpen the nudge toward packages (integrations are auth only).
+	 */
+	usedIntegrationAuthHelpers?: boolean
 }): {
 	state: RawFetchHostNudgeState
 	nudges: Array<string>
@@ -153,6 +182,7 @@ export function applyRawFetchHostCounts(input: {
 	const covered = toNormalizedHostSet(input.coveredHosts)
 	const increments = toHostCountEntries(input.hostCounts)
 	const nudges: Array<string> = []
+	const usedIntegrationAuthHelpers = input.usedIntegrationAuthHelpers === true
 
 	for (const [hostname, increment] of increments) {
 		if (increment <= 0) continue
@@ -166,7 +196,13 @@ export function applyRawFetchHostCounts(input: {
 			!covered.has(hostname)
 		) {
 			entry.nudged = true
-			nudges.push(formatRawFetchHostNudge({ hostname, count: entry.count }))
+			nudges.push(
+				formatRawFetchHostNudge({
+					hostname,
+					count: entry.count,
+					usedIntegrationAuthHelpers,
+				}),
+			)
 		}
 	}
 

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -630,4 +630,33 @@ test('execute tool nudges repeated raw-fetch hosts once per conversation and ski
 		conversationId: 'conv-covered',
 	})
 	expect(covered.structuredContent.warnings).toBeUndefined()
+
+	// Integration-auth helper source sharpens the packages-first warning text.
+	mockModule.runModuleWithRegistry.mockImplementationOnce(
+		async (
+			_env,
+			_ctx,
+			_code,
+			_params,
+			options: { rawFetchHostSink?: { add: (hostname: string) => void } },
+		) => {
+			options.rawFetchHostSink?.add('gmail.googleapis.com')
+			options.rawFetchHostSink?.add('gmail.googleapis.com')
+			options.rawFetchHostSink?.add('gmail.googleapis.com')
+			return { result: { ok: true }, logs: [] }
+		},
+	)
+	mockPerformanceSequence(9, 10)
+	const authHelperTipped = await handler({
+		code: `import { createAuthenticatedFetch } from 'kody:runtime'
+export default async () => ({ ok: true })`,
+		conversationId: 'conv-oauth-nudge',
+	})
+	expect(authHelperTipped.structuredContent.warnings).toHaveLength(1)
+	expect(authHelperTipped.structuredContent.warnings?.[0]).toContain(
+		'gmail.googleapis.com',
+	)
+	expect(authHelperTipped.structuredContent.warnings?.[0]).not.toBe(
+		tipped.structuredContent.warnings?.[0],
+	)
 })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -40,6 +40,7 @@ import { finishToolTiming, startToolTiming } from './tool-timing.ts'
 import { prependToolMetadataContent } from './tool-response-content.ts'
 import {
 	applyRawFetchHostCounts,
+	codeUsesIntegrationAuthHelpers,
 	createRawFetchHostSink,
 	listHostsApproachingRawFetchNudge,
 	readLiteralRequestHostname,
@@ -300,6 +301,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					callerContext,
 					conversationId: resolvedConversationId,
 					hostCounts: rawFetchHosts.hostCounts(),
+					usedIntegrationAuthHelpers: codeUsesIntegrationAuthHelpers(code),
 				})
 
 				if (result.error) {
@@ -537,6 +539,7 @@ async function resolveRawFetchHostNudges(input: {
 	callerContext: ReturnType<McpRegistrationAgent['getCallerContext']>
 	conversationId: string
 	hostCounts: ReadonlyMap<string, number>
+	usedIntegrationAuthHelpers?: boolean
 }): Promise<Array<string>> {
 	if (input.hostCounts.size === 0) return []
 
@@ -566,6 +569,7 @@ async function resolveRawFetchHostNudges(input: {
 		conversationId: input.conversationId,
 		hostCounts: input.hostCounts,
 		coveredHosts,
+		usedIntegrationAuthHelpers: input.usedIntegrationAuthHelpers,
 	})
 	if (typeof statefulAgent.setState === 'function') {
 		statefulAgent.setState({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When MCP `execute` repeatedly raw-fetches a product API host (especially via raw OAuth helpers like `createAuthenticatedFetch` / `refreshAccessToken`), the failure-moment warning now steers packages-first:

1. `search` for an existing wrapper package
2. `community_search` (prefer **trusted**)
3. fork or create a thin helpers package

Brief mental model in the nudge: **integrations = auth; packages = how agents should call the product.** Same rule is taught in `integration_bootstrap` and `package_lifecycle` guides — not in always-on MCP server instructions.

## Behavior

- Existing raw-fetch host threshold (3), once-per-host-per-conversation dedup, and OpenAPI-covered exclusion are unchanged.
- Message is packages-first; `openapi_binding_save` is demoted to an "only when it fits" aside.
- When the execute module source references `createAuthenticatedFetch` or `refreshAccessToken`, the nudge uses the sharper "Raw integration auth hit …" variant.
- Token cost stays low: one short warning, once per host per conversation.

## Ship status

- Squash merged to `main` as `01359ac`
- Production deploy: success — https://github.com/kentcdodds/kody/actions/runs/29896235222

## Test plan

- [x] Unit tests for auth-helper detection + distinct nudge variant
- [x] Execute tool integration test for oauth-helper-sharpened warning
- [x] Pre-push unit + Playwright E2E (husky)
- [x] CI Validate on PR + main
- [x] Production deploy

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4b43eff` · **Head:** merged `01359ac`

**Classification:** extends — MCP execute raw-fetch warning becomes a packages-first failure-moment steer (with an integration-auth variant); official coding guides teach the same rule.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — packages-first raw-fetch / raw-auth warning text + optional auth-helper sharpening |

### System map

Execute raw `fetch` (including via OAuth helpers) still tips the existing host counter; the warning text now steers search → trusted community → helpers package.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	mcpServer -->|"raw-fetch tip → packages-first warning"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant Execute as execute tool
	participant Nudge as raw-fetch host nudge
	Agent->>Execute: execute(code with createAuthenticatedFetch, conversationId)
	Execute->>Execute: count product API hosts from sandbox fetch
	Execute->>Nudge: apply counts + usedIntegrationAuthHelpers
	alt host count reaches 3 and not nudged
		Nudge-->>Agent: result + packages-first warning
	else below threshold / already nudged / OpenAPI-covered
		Nudge-->>Agent: result
	end
```

### Before / after

**Warning text (conceptually)**

- Before: consider `openapi_binding_save` or a saved package (search first)
- After: integrations = auth; packages = product call surface → search → trusted `community_search` → fork/create thin helpers (`openapi_binding_save` only if it fits)

### Invariants

- Per-user isolation preserved: counts remain on the per-user MCP agent DO keyed by `conversationId`.
- Always-on MCP server instructions are unchanged (failure-moment + opt-in guides only).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c151e382-bae9-472d-934f-314935203dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c151e382-bae9-472d-934f-314935203dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more targeted guidance when raw OAuth authentication helpers are used for product API calls.
  * Contextual execution warnings now distinguish raw API access from integration-authenticated requests and recommend using an appropriate helper package.
* **Documentation**
  * Clarified bootstrap and package lifecycle guidance for finding, forking, or creating thin helper packages.
  * Added an anti-pattern warning against treating connected integrations as complete product API packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->