### PR TITLE
Post-OAuth-connect trusted community helpers package suggestions

### DIFF
--- a/docs/guides/integration-bootstrap.md
+++ b/docs/guides/integration-bootstrap.md
@@ -99,6 +99,12 @@ If those conditions are not met, stop and fix the integration first.
      surface.
 5. Only after the smoke test succeeds should you obtain the dependent package or
    package app.
+   - Remember: a saved integration is auth credentials only. The durable
+     agent-facing surface is a helpers package (or package app), not the
+     integration record itself.
+   - If the user just finished `/connect/oauth`, read `nextSteps` from the
+     connect success payload/UI first: it already includes trusted-first
+     community helpers suggestions and a create-helpers prompt.
    - `search({ entity: "<provider>:integration" })` may already surface a small
      same-provider package suggestion set (user packages first, else
      trusted-first community listings). Use those when present.

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -137,6 +137,24 @@ routes) are for clients authenticating to Kody itself.
 | --------------------------------- | ---------------- |
 | API keys or PATs instead of OAuth | `connect_secret` |
 
+## After a successful connect
+
+A saved OAuth integration is **auth credentials only**. It is not an
+agent-callable package API.
+
+The `/connect/oauth` success response (and success UI) includes `nextSteps`:
+
+- clear guidance that the integration stores credentials, while a helpers
+  package is the durable agent-facing surface
+- up to three community package suggestions for the provider, with trusted
+  listings ranked first, plus fork prompts / listing links
+- a create-helpers CTA/prompt when no suitable listing exists (and as a fallback
+  when suggestions do not fit)
+
+Do not treat connect success as “the Google/GitHub/etc. package is ready.” Next
+step is smoke-test auth, then fork a close trusted community helpers package or
+create a thin helpers package.
+
 ## Agent checklist
 
 1. Confirm OAuth is the right auth shape.
@@ -146,13 +164,18 @@ routes) are for clients authenticating to Kody itself.
    `https://heykody.dev/connect/oauth`. The page shows it with a copy button.
 4. Have the user open the URL while signed in and wait for success.
 5. Run the authenticated smoke test from `integration_bootstrap`.
-6. Continue with the package or package app only after the smoke test passes.
+6. Use the connect success `nextSteps` (or `community_search`, preferring
+   `trusted`) to fork/adapt a helpers package, or create a thin helpers package
+   when none fits. Continue with dependent package apps only after that surface
+   exists and the smoke test passes.
 
 ## Package-first recommendation for OAuth integrations
 
 For OAuth integrations with a successful hosted `/connect/oauth` flow and
 passing smoke test:
 
+- treat the saved integration as credentials; put agent-facing calls in a
+  helpers package (prefer a trusted community listing from `nextSteps`)
 - build a package app when the integration needs a hosted UI
 - keep provider API calls in package-owned backend code
 - keep reusable automation in package exports

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -4,6 +4,7 @@ import {
 	formatOAuthExchangeFailure,
 	isOAuthExchangeSessionExpired,
 	mergeConnectOauthConfig,
+	parseConnectOauthNextSteps,
 	parseSessionConnectOauthConfig,
 	parseStoredIntegrationConfig,
 	summarizeStoredSetupState,
@@ -534,4 +535,56 @@ test('session config parsing is strict: usePkce is required and stale shapes are
 			JSON.stringify({ ...sessionConfig, flow: 'implicit' }),
 		),
 	).toBeNull()
+})
+
+test('parseConnectOauthNextSteps accepts suggestion payload and drops unsafe URLs', () => {
+	const parsed = parseConnectOauthNextSteps({
+		guidance: 'Connected. Auth credentials only.',
+		integrationName: 'google',
+		suggestions: [
+			{
+				listingId: 'listing-1',
+				name: 'google-helpers',
+				kodyId: '@owner/google-helpers',
+				description: 'Trusted google helpers',
+				trusted: true,
+				publicUrl: 'https://example.com/community/listing-1',
+				forkPrompt: 'Fork google-helpers',
+			},
+			{
+				listingId: 'bad',
+				name: 'bad',
+				kodyId: '@owner/bad',
+				description: 'bad',
+				trusted: false,
+				publicUrl: 'javascript:alert(1)',
+				forkPrompt: 'bad',
+			},
+		],
+		createHelpersCta: {
+			label: 'Create helpers package',
+			prompt: 'Create a thin helpers package for google',
+		},
+	})
+	expect(parsed).toEqual({
+		guidance: 'Connected. Auth credentials only.',
+		integrationName: 'google',
+		suggestions: [
+			{
+				listingId: 'listing-1',
+				name: 'google-helpers',
+				kodyId: '@owner/google-helpers',
+				description: 'Trusted google helpers',
+				trusted: true,
+				publicUrl: 'https://example.com/community/listing-1',
+				forkPrompt: 'Fork google-helpers',
+			},
+		],
+		createHelpersCta: {
+			label: 'Create helpers package',
+			prompt: 'Create a thin helpers package for google',
+		},
+	})
+	expect(parseConnectOauthNextSteps(null)).toBeNull()
+	expect(parseConnectOauthNextSteps({ guidance: 'x' })).toBeNull()
 })

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -125,6 +125,26 @@ type ConnectOauthHostApprovalLink = {
 	approvalUrl: string
 }
 
+type ConnectOauthPackageSuggestion = {
+	listingId: string
+	name: string
+	kodyId: string
+	description: string
+	trusted: boolean
+	publicUrl: string
+	forkPrompt: string
+}
+
+type ConnectOauthNextSteps = {
+	guidance: string
+	integrationName: string
+	suggestions: Array<ConnectOauthPackageSuggestion>
+	createHelpersCta: {
+		label: string
+		prompt: string
+	}
+}
+
 type AccountSecretsListPayload = {
 	ok: true
 	secrets: Array<{ name: string; scope: string }>
@@ -149,6 +169,7 @@ export function ConnectOauthRoute(handle: Handle) {
 	let hasConfigError = false
 	let connectOauthHandled = false
 	let hostApprovalLinks: Array<ConnectOauthHostApprovalLink> = []
+	let nextSteps: ConnectOauthNextSteps | null = null
 	let approvingAllHosts = false
 	let submitting = false
 	let initialLoadStarted = false
@@ -175,6 +196,11 @@ export function ConnectOauthRoute(handle: Handle) {
 		links: Array<ConnectOauthHostApprovalLink>,
 	): void => {
 		hostApprovalLinks = links
+		update()
+	}
+
+	const setNextSteps = (value: ConnectOauthNextSteps | null): void => {
+		nextSteps = value
 		update()
 	}
 
@@ -757,6 +783,7 @@ export function ConnectOauthRoute(handle: Handle) {
 		accessTokenSaved = payload.accessTokenSaved === true
 		refreshTokenSaved = payload.refreshTokenSaved === true
 		setHostApprovalLinks(parseHostApprovalLinks(payload.hostApprovalLinks))
+		setNextSteps(parseConnectOauthNextSteps(payload.nextSteps))
 		setStatus('OAuth tokens saved.', 'info')
 		setStep('success')
 		return
@@ -1201,6 +1228,61 @@ export function ConnectOauthRoute(handle: Handle) {
 								</strong>
 							</div>
 						</div>
+						{nextSteps ? (
+							<div mix={css(insetCardCss)}>
+								<h3 mix={css(sectionTitleCss)}>Next: helpers package</h3>
+								<p mix={css(descriptionCss)}>{nextSteps.guidance}</p>
+								{nextSteps.suggestions.length > 0 ? (
+									<ul mix={css(listCss)}>
+										{nextSteps.suggestions.map((suggestion) => (
+											<li key={suggestion.listingId}>
+												<div mix={css(suggestionHeaderCss)}>
+													<a
+														href={suggestion.publicUrl}
+														target="_blank"
+														rel="noreferrer noopener"
+														mix={css(primaryLinkCss)}
+													>
+														{suggestion.name}
+													</a>
+													{suggestion.trusted ? (
+														<span mix={css(trustedBadgeCss)}>Trusted</span>
+													) : null}
+												</div>
+												<p mix={css(descriptionCss)}>
+													{suggestion.description}
+												</p>
+												<div mix={css(suggestionActionsCss)}>
+													<a
+														href={suggestion.publicUrl}
+														target="_blank"
+														rel="noreferrer noopener"
+														mix={css(primaryLinkCss)}
+													>
+														View listing
+													</a>
+													<CopyTextButton
+														value={suggestion.forkPrompt}
+														idleLabel="Copy fork prompt"
+														variant="secondary"
+													/>
+												</div>
+											</li>
+										))}
+									</ul>
+								) : null}
+								<div mix={css(suggestionActionsCss)}>
+									<strong mix={css(detailValueCss)}>
+										{nextSteps.createHelpersCta.label}
+									</strong>
+									<CopyTextButton
+										value={nextSteps.createHelpersCta.prompt}
+										idleLabel="Copy create prompt"
+										variant="secondary"
+									/>
+								</div>
+							</div>
+						) : null}
 						<h3 mix={css(sectionTitleCss)}>Host approvals</h3>
 						<p mix={css({ margin: 0, color: colors.text })}>
 							Hosts are never auto-approved. Review these allowed hosts in your
@@ -1701,6 +1783,65 @@ function parseHostApprovalLinks(
 	)
 }
 
+export function parseConnectOauthNextSteps(
+	raw: unknown,
+): ConnectOauthNextSteps | null {
+	if (!raw || typeof raw !== 'object') return null
+	const record = raw as Record<string, unknown>
+	if (
+		typeof record.guidance !== 'string' ||
+		typeof record.integrationName !== 'string' ||
+		!record.createHelpersCta ||
+		typeof record.createHelpersCta !== 'object' ||
+		!Array.isArray(record.suggestions)
+	) {
+		return null
+	}
+	const createHelpersCta = record.createHelpersCta as Record<string, unknown>
+	if (
+		typeof createHelpersCta.label !== 'string' ||
+		typeof createHelpersCta.prompt !== 'string'
+	) {
+		return null
+	}
+	const suggestions = record.suggestions.flatMap((entry) => {
+		if (!entry || typeof entry !== 'object') return []
+		const suggestion = entry as Record<string, unknown>
+		if (
+			typeof suggestion.listingId !== 'string' ||
+			typeof suggestion.name !== 'string' ||
+			typeof suggestion.kodyId !== 'string' ||
+			typeof suggestion.description !== 'string' ||
+			typeof suggestion.trusted !== 'boolean' ||
+			typeof suggestion.publicUrl !== 'string' ||
+			typeof suggestion.forkPrompt !== 'string' ||
+			!isSafeExternalUrl(suggestion.publicUrl)
+		) {
+			return []
+		}
+		return [
+			{
+				listingId: suggestion.listingId,
+				name: suggestion.name,
+				kodyId: suggestion.kodyId,
+				description: suggestion.description,
+				trusted: suggestion.trusted,
+				publicUrl: suggestion.publicUrl,
+				forkPrompt: suggestion.forkPrompt,
+			} satisfies ConnectOauthPackageSuggestion,
+		]
+	})
+	return {
+		guidance: record.guidance,
+		integrationName: record.integrationName,
+		suggestions,
+		createHelpersCta: {
+			label: createHelpersCta.label,
+			prompt: createHelpersCta.prompt,
+		},
+	}
+}
+
 function parseOptionalUrl(raw: string | null) {
 	if (!raw) return null
 	try {
@@ -1794,6 +1935,30 @@ const secondaryButtonCss = getSecondaryButtonCss({
 	size: 'lg',
 	weight: 'semibold',
 })
+const suggestionHeaderCss = {
+	display: 'flex',
+	flexWrap: 'wrap' as const,
+	alignItems: 'center',
+	gap: spacing.sm,
+}
+const suggestionActionsCss = {
+	display: 'flex',
+	flexWrap: 'wrap' as const,
+	alignItems: 'center',
+	gap: spacing.sm,
+	marginTop: spacing.sm,
+}
+const trustedBadgeCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	padding: `0.15rem ${spacing.sm}`,
+	borderRadius: radius.md,
+	backgroundColor: colors.primarySoftest,
+	color: colors.primaryText,
+	fontSize: typography.fontSize.xs,
+	fontWeight: typography.fontWeight.semibold,
+}
 
 function getStatusCardCss(tone: 'info' | 'warn' | 'error') {
 	return {

--- a/packages/worker/src/app/connect-oauth-next-steps.node.test.ts
+++ b/packages/worker/src/app/connect-oauth-next-steps.node.test.ts
@@ -131,10 +131,29 @@ test('buildConnectOauthNextSteps empty listings still guides create path', () =>
 		buildConnectOauthNextStepsGuidance({
 			integrationName: 'linear',
 			suggestionCount: 0,
+			trustedSuggestionCount: 0,
 		}),
 	)
 	expect(nextSteps.guidance).toContain('No close community helpers package')
 	expect(nextSteps.createHelpersCta.prompt).toContain('linear')
+})
+
+test('buildConnectOauthNextSteps avoids trusted copy when only untrusted listings match', () => {
+	const nextSteps = buildConnectOauthNextSteps({
+		integrationName: 'notion',
+		baseUrl: 'https://example.com',
+		listings: [
+			listing({
+				id: 'untrusted-notion',
+				name: 'notion-extra',
+				trusted: false,
+			}),
+		],
+	})
+	expect(nextSteps.suggestions).toHaveLength(1)
+	expect(nextSteps.suggestions[0]?.trusted).toBe(false)
+	expect(nextSteps.guidance).toContain('none are trusted yet')
+	expect(nextSteps.guidance).not.toContain('Prefer a trusted community listing')
 })
 
 test('buildConnectOauthPackageSuggestion includes fork CTA fields', () => {

--- a/packages/worker/src/app/connect-oauth-next-steps.node.test.ts
+++ b/packages/worker/src/app/connect-oauth-next-steps.node.test.ts
@@ -1,0 +1,211 @@
+import { expect, test, vi } from 'vitest'
+import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+import {
+	buildConnectOauthCreateHelpersPrompt,
+	buildConnectOauthNextSteps,
+	buildConnectOauthNextStepsGuidance,
+	buildConnectOauthPackageSuggestion,
+	connectOauthCommunitySearchCandidateLimit,
+	connectOauthPackageSuggestionLimit,
+	loadConnectOauthNextSteps,
+	rankTrustedFirstCommunityListings,
+} from './connect-oauth-next-steps.ts'
+
+const mockModule = vi.hoisted(() => ({
+	searchCommunityListings: vi.fn(),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	searchCommunityListings: (...args: Array<unknown>) =>
+		mockModule.searchCommunityListings(...args),
+}))
+
+function listing(
+	overrides: Partial<CommunityListingWithAggregates> &
+		Pick<CommunityListingWithAggregates, 'id' | 'name' | 'trusted'>,
+): CommunityListingWithAggregates {
+	return {
+		ownerUserId: 'owner',
+		packageId: 'pkg',
+		sourceId: 'src',
+		kodyId: overrides.kodyId ?? `@owner/${overrides.name}`,
+		description: overrides.description ?? `${overrides.name} helpers`,
+		tags: [],
+		searchText: null,
+		readmeContent: null,
+		license: 'MIT',
+		pinnedCommit: 'abc',
+		iconCommit: 'abc',
+		status: 'active',
+		trustedCommit: overrides.trusted ? 'abc' : null,
+		trustedAt: overrides.trusted ? '2026-01-01T00:00:00.000Z' : null,
+		featuredAt: null,
+		featured: false,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		publishedAt: '2026-01-01T00:00:00.000Z',
+		averageStars: null,
+		ratingCount: 0,
+		averageAdaptationEffort: null,
+		forkCount: 0,
+		starCount: 0,
+		...overrides,
+	}
+}
+
+test('rankTrustedFirstCommunityListings keeps relevance order within trust groups', () => {
+	const ranked = rankTrustedFirstCommunityListings([
+		{ id: 'u1', trusted: false },
+		{ id: 't1', trusted: true },
+		{ id: 'u2', trusted: false },
+		{ id: 't2', trusted: true },
+	])
+	expect(ranked.map((entry) => entry.id)).toEqual(['t1', 't2', 'u1', 'u2'])
+})
+
+test('buildConnectOauthNextSteps returns trusted-first suggestions and create CTA', () => {
+	const nextSteps = buildConnectOauthNextSteps({
+		integrationName: 'google',
+		baseUrl: 'https://example.com',
+		listings: [
+			listing({
+				id: 'untrusted-google',
+				name: 'google-untrusted',
+				trusted: false,
+				description: 'Community google helpers',
+			}),
+			listing({
+				id: 'trusted-google',
+				name: 'google-helpers',
+				trusted: true,
+				description: 'Trusted google helpers',
+			}),
+			listing({
+				id: 'other',
+				name: 'google-extra',
+				trusted: false,
+			}),
+			listing({
+				id: 'fourth',
+				name: 'google-fourth',
+				trusted: true,
+			}),
+		],
+	})
+
+	expect(nextSteps.integrationName).toBe('google')
+	expect(nextSteps.suggestions).toHaveLength(connectOauthPackageSuggestionLimit)
+	expect(
+		nextSteps.suggestions.map((suggestion) => suggestion.listingId),
+	).toEqual(['trusted-google', 'fourth', 'untrusted-google'])
+	expect(nextSteps.suggestions[0]).toMatchObject({
+		listingId: 'trusted-google',
+		name: 'google-helpers',
+		kodyId: '@owner/google-helpers',
+		description: 'Trusted google helpers',
+		trusted: true,
+		publicUrl: 'https://example.com/community/trusted-google',
+	})
+	expect(nextSteps.suggestions[0]?.forkPrompt).toContain('community_get')
+	expect(nextSteps.suggestions[0]?.forkPrompt).toContain('trusted-google')
+	expect(nextSteps.guidance).toContain('auth credentials only')
+	expect(nextSteps.guidance).toContain('not an agent-callable package')
+	expect(nextSteps.guidance).toContain('Prefer a trusted community listing')
+	expect(nextSteps.createHelpersCta).toEqual({
+		label: 'Create helpers package',
+		prompt: buildConnectOauthCreateHelpersPrompt('google'),
+	})
+	expect(nextSteps.createHelpersCta.prompt).toContain('thin helpers package')
+	expect(nextSteps.createHelpersCta.prompt).toContain('google')
+})
+
+test('buildConnectOauthNextSteps empty listings still guides create path', () => {
+	const nextSteps = buildConnectOauthNextSteps({
+		integrationName: 'linear',
+		baseUrl: 'https://example.com',
+		listings: [],
+	})
+	expect(nextSteps.suggestions).toEqual([])
+	expect(nextSteps.guidance).toBe(
+		buildConnectOauthNextStepsGuidance({
+			integrationName: 'linear',
+			suggestionCount: 0,
+		}),
+	)
+	expect(nextSteps.guidance).toContain('No close community helpers package')
+	expect(nextSteps.createHelpersCta.prompt).toContain('linear')
+})
+
+test('buildConnectOauthPackageSuggestion includes fork CTA fields', () => {
+	const suggestion = buildConnectOauthPackageSuggestion({
+		baseUrl: 'https://heykody.dev',
+		listing: listing({
+			id: 'listing-1',
+			name: 'spotify-helpers',
+			kodyId: '@kent/spotify-helpers',
+			description: 'Spotify playback helpers',
+			trusted: true,
+		}),
+	})
+	expect(suggestion).toEqual({
+		listingId: 'listing-1',
+		name: 'spotify-helpers',
+		kodyId: '@kent/spotify-helpers',
+		description: 'Spotify playback helpers',
+		trusted: true,
+		publicUrl: 'https://heykody.dev/community/listing-1',
+		forkPrompt: expect.stringContaining('spotify-helpers'),
+	})
+})
+
+test('loadConnectOauthNextSteps searches with bounded limit and fails open', async () => {
+	mockModule.searchCommunityListings.mockResolvedValueOnce([
+		listing({
+			id: 'trusted',
+			name: 'github-helpers',
+			trusted: true,
+		}),
+		listing({
+			id: 'untrusted',
+			name: 'github-extra',
+			trusted: false,
+		}),
+	])
+
+	const env = { APP_DB: {} } as Env
+	const nextSteps = await loadConnectOauthNextSteps({
+		env,
+		integrationName: 'github',
+		providerQuery: 'GitHub',
+		baseUrl: 'https://example.com',
+	})
+
+	expect(mockModule.searchCommunityListings).toHaveBeenCalledWith({
+		env,
+		query: 'GitHub',
+		limit: connectOauthCommunitySearchCandidateLimit,
+	})
+	expect(nextSteps.suggestions.map((entry) => entry.listingId)).toEqual([
+		'trusted',
+		'untrusted',
+	])
+
+	consoleError.mockImplementation(() => {})
+	mockModule.searchCommunityListings.mockRejectedValueOnce(new Error('db down'))
+	const failedOpen = await loadConnectOauthNextSteps({
+		env,
+		integrationName: 'github',
+		baseUrl: 'https://example.com',
+	})
+	expect(failedOpen.suggestions).toEqual([])
+	expect(failedOpen.guidance).toContain('No close community helpers package')
+	expect(failedOpen.createHelpersCta.prompt).toContain('github')
+	expect(consoleError).toHaveBeenCalledWith(
+		'Failed to load post-OAuth community package suggestions.',
+		expect.objectContaining({
+			integrationName: 'github',
+			query: 'github',
+		}),
+	)
+})

--- a/packages/worker/src/app/connect-oauth-next-steps.ts
+++ b/packages/worker/src/app/connect-oauth-next-steps.ts
@@ -54,12 +54,16 @@ export function buildConnectOauthCreateHelpersPrompt(integrationName: string) {
 export function buildConnectOauthNextStepsGuidance(input: {
 	integrationName: string
 	suggestionCount: number
+	trustedSuggestionCount: number
 }) {
 	const base = `Connected. "${input.integrationName}" is an OAuth integration (auth credentials only) — not an agent-callable package. Durable agent interaction goes through a helpers package.`
-	if (input.suggestionCount > 0) {
+	if (input.suggestionCount <= 0) {
+		return `${base} No close community helpers package was found for this provider — create a thin helpers package next.`
+	}
+	if (input.trustedSuggestionCount > 0) {
 		return `${base} Prefer a trusted community listing below (fork or one-click install, then adapt). Create a thin helpers package only when none of these fit.`
 	}
-	return `${base} No close community helpers package was found for this provider — create a thin helpers package next.`
+	return `${base} Community listings below may help, but none are trusted yet — review carefully before forking, or create a thin helpers package.`
 }
 
 export function buildConnectOauthPackageSuggestion(input: {
@@ -102,6 +106,9 @@ export function buildConnectOauthNextSteps(input: {
 		guidance: buildConnectOauthNextStepsGuidance({
 			integrationName: input.integrationName,
 			suggestionCount: suggestions.length,
+			trustedSuggestionCount: suggestions.filter(
+				(suggestion) => suggestion.trusted,
+			).length,
 		}),
 		integrationName: input.integrationName,
 		suggestions,

--- a/packages/worker/src/app/connect-oauth-next-steps.ts
+++ b/packages/worker/src/app/connect-oauth-next-steps.ts
@@ -1,0 +1,151 @@
+import { buildForkPrompt } from '#app/community-public.ts'
+import { searchCommunityListings } from '#worker/community/service.ts'
+import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
+import { buildCommunityPublicUrl } from '#mcp/capabilities/community/shared.ts'
+
+export const connectOauthPackageSuggestionLimit = 3
+export const connectOauthCommunitySearchCandidateLimit = 12
+
+export type ConnectOauthPackageSuggestion = {
+	listingId: string
+	name: string
+	kodyId: string
+	description: string
+	trusted: boolean
+	publicUrl: string
+	forkPrompt: string
+}
+
+export type ConnectOauthCreateHelpersCta = {
+	label: string
+	prompt: string
+}
+
+export type ConnectOauthNextSteps = {
+	guidance: string
+	integrationName: string
+	suggestions: Array<ConnectOauthPackageSuggestion>
+	createHelpersCta: ConnectOauthCreateHelpersCta
+}
+
+/**
+ * Prefer trusted listings while preserving the incoming relevance order within
+ * each trust group. Callers should pass score-ranked search results.
+ */
+export function rankTrustedFirstCommunityListings<
+	T extends { trusted: boolean },
+>(listings: ReadonlyArray<T>): Array<T> {
+	const trusted: Array<T> = []
+	const untrusted: Array<T> = []
+	for (const listing of listings) {
+		if (listing.trusted) {
+			trusted.push(listing)
+		} else {
+			untrusted.push(listing)
+		}
+	}
+	return [...trusted, ...untrusted]
+}
+
+export function buildConnectOauthCreateHelpersPrompt(integrationName: string) {
+	return `Create a thin helpers package for the "${integrationName}" OAuth integration. The saved integration is auth credentials only — not an agent-callable API. The helpers package should be the durable agent-facing surface (exports that call the provider with refreshAccessToken / createAuthenticatedFetch from kody:runtime). Load coding_guide_get({ guide: "package_authoring" }) and coding_guide_get({ guide: "integration_bootstrap" }), keep a README ## Intent section, and smoke-test with execute before saving.`
+}
+
+export function buildConnectOauthNextStepsGuidance(input: {
+	integrationName: string
+	suggestionCount: number
+}) {
+	const base = `Connected. "${input.integrationName}" is an OAuth integration (auth credentials only) — not an agent-callable package. Durable agent interaction goes through a helpers package.`
+	if (input.suggestionCount > 0) {
+		return `${base} Prefer a trusted community listing below (fork or one-click install, then adapt). Create a thin helpers package only when none of these fit.`
+	}
+	return `${base} No close community helpers package was found for this provider — create a thin helpers package next.`
+}
+
+export function buildConnectOauthPackageSuggestion(input: {
+	listing: Pick<
+		CommunityListingWithAggregates,
+		'id' | 'name' | 'kodyId' | 'description' | 'trusted'
+	>
+	baseUrl: string
+}): ConnectOauthPackageSuggestion {
+	return {
+		listingId: input.listing.id,
+		name: input.listing.name,
+		kodyId: input.listing.kodyId,
+		description: input.listing.description,
+		trusted: input.listing.trusted,
+		publicUrl: buildCommunityPublicUrl(input.baseUrl, input.listing.id),
+		forkPrompt: buildForkPrompt({
+			name: input.listing.name,
+			listingId: input.listing.id,
+		}),
+	}
+}
+
+export function buildConnectOauthNextSteps(input: {
+	integrationName: string
+	baseUrl: string
+	listings: ReadonlyArray<CommunityListingWithAggregates>
+}): ConnectOauthNextSteps {
+	const ranked = rankTrustedFirstCommunityListings(input.listings).slice(
+		0,
+		connectOauthPackageSuggestionLimit,
+	)
+	const suggestions = ranked.map((listing) =>
+		buildConnectOauthPackageSuggestion({
+			listing,
+			baseUrl: input.baseUrl,
+		}),
+	)
+	return {
+		guidance: buildConnectOauthNextStepsGuidance({
+			integrationName: input.integrationName,
+			suggestionCount: suggestions.length,
+		}),
+		integrationName: input.integrationName,
+		suggestions,
+		createHelpersCta: {
+			label: 'Create helpers package',
+			prompt: buildConnectOauthCreateHelpersPrompt(input.integrationName),
+		},
+	}
+}
+
+/**
+ * Bounded community search for post-connect suggestions. Fails open to an empty
+ * suggestion list so OAuth connect never blocks on marketplace availability.
+ */
+export async function loadConnectOauthNextSteps(input: {
+	env: Env
+	integrationName: string
+	baseUrl: string
+	providerQuery?: string
+}): Promise<ConnectOauthNextSteps> {
+	const query = (input.providerQuery ?? input.integrationName).trim()
+	let listings: Array<CommunityListingWithAggregates> = []
+	if (query) {
+		try {
+			listings = await searchCommunityListings({
+				env: input.env,
+				query,
+				limit: connectOauthCommunitySearchCandidateLimit,
+			})
+		} catch (error) {
+			console.error(
+				'Failed to load post-OAuth community package suggestions.',
+				{
+					integrationName: input.integrationName,
+					query,
+					error,
+				},
+			)
+			listings = []
+		}
+	}
+	return buildConnectOauthNextSteps({
+		integrationName: input.integrationName,
+		baseUrl: input.baseUrl,
+		listings,
+	})
+}

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -41,11 +41,17 @@ const mockModule = vi.hoisted(() => ({
 	setSecretAllowedCapabilities: vi.fn(async () => undefined),
 	setSecretAllowedPackages: vi.fn(async () => undefined),
 	getValue: vi.fn(async () => null),
+	searchCommunityListings: vi.fn(async () => []),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
 	readAuthenticatedAppUser: (...args: Array<unknown>) =>
 		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	searchCommunityListings: (...args: Array<unknown>) =>
+		mockModule.searchCommunityListings(...args),
 }))
 
 vi.mock('#app/auth-session.ts', () => ({
@@ -185,6 +191,15 @@ test('connect oauth saves tokens, integration metadata, and host approval links'
 			},
 		],
 		integrationName: 'github',
+		nextSteps: {
+			integrationName: 'github',
+			guidance: expect.stringContaining('auth credentials only'),
+			suggestions: [],
+			createHelpersCta: {
+				label: 'Create helpers package',
+				prompt: expect.stringContaining('thin helpers package'),
+			},
+		},
 	})
 	expect(mockModule.buildSecretHostApprovalUrl).toHaveBeenCalledTimes(4)
 	expect(mockModule.setSecretAllowedHosts).not.toHaveBeenCalled()
@@ -1335,6 +1350,67 @@ test('oauth_exchange supports Canva basic-form with PKCE code_verifier and a cli
 
 test('connect oauth persists usePkce for confidential + PKCE providers like Canva', async () => {
 	mockModule.saveValue.mockClear()
+	mockModule.searchCommunityListings.mockClear()
+	mockModule.searchCommunityListings.mockResolvedValueOnce([
+		{
+			id: 'canva-untrusted',
+			ownerUserId: 'owner',
+			packageId: 'pkg',
+			sourceId: 'src',
+			kodyId: '@owner/canva-extra',
+			name: 'canva-extra',
+			description: 'Untrusted canva helpers',
+			tags: [],
+			searchText: null,
+			readmeContent: null,
+			license: 'MIT',
+			pinnedCommit: 'abc',
+			iconCommit: 'abc',
+			status: 'active',
+			trustedCommit: null,
+			trustedAt: null,
+			trusted: false,
+			featuredAt: null,
+			featured: false,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+			publishedAt: '2026-01-01T00:00:00.000Z',
+			averageStars: null,
+			ratingCount: 0,
+			averageAdaptationEffort: null,
+			forkCount: 0,
+			starCount: 0,
+		},
+		{
+			id: 'canva-trusted',
+			ownerUserId: 'owner',
+			packageId: 'pkg-2',
+			sourceId: 'src-2',
+			kodyId: '@owner/canva-helpers',
+			name: 'canva-helpers',
+			description: 'Trusted canva helpers',
+			tags: ['canva'],
+			searchText: null,
+			readmeContent: null,
+			license: 'MIT',
+			pinnedCommit: 'def',
+			iconCommit: 'def',
+			status: 'active',
+			trustedCommit: 'def',
+			trustedAt: '2026-01-01T00:00:00.000Z',
+			trusted: true,
+			featuredAt: null,
+			featured: false,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+			publishedAt: '2026-01-01T00:00:00.000Z',
+			averageStars: 5,
+			ratingCount: 2,
+			averageAdaptationEffort: 1,
+			forkCount: 3,
+			starCount: 4,
+		},
+	])
 	const handler = createAccountSecretsApiHandler(createEnv())
 
 	const canvaResponse = await handler.handler({
@@ -1367,11 +1443,38 @@ test('connect oauth persists usePkce for confidential + PKCE providers like Canv
 	} as never)
 
 	expect(canvaResponse.status).toBe(200)
-	await expect(canvaResponse.json()).resolves.toMatchObject({
+	const canvaPayload = await canvaResponse.json()
+	expect(canvaPayload).toMatchObject({
 		ok: true,
 		accessTokenSaved: true,
 		refreshTokenSaved: true,
 		integrationName: 'canva',
+		nextSteps: {
+			integrationName: 'canva',
+			guidance: expect.stringContaining('auth credentials only'),
+			createHelpersCta: {
+				label: 'Create helpers package',
+				prompt: expect.stringContaining('thin helpers package'),
+			},
+		},
+	})
+	expect(canvaPayload.nextSteps.suggestions).toHaveLength(2)
+	expect(
+		canvaPayload.nextSteps.suggestions.map(
+			(entry: { listingId: string }) => entry.listingId,
+		),
+	).toEqual(['canva-trusted', 'canva-untrusted'])
+	expect(canvaPayload.nextSteps.suggestions[0]).toMatchObject({
+		listingId: 'canva-trusted',
+		name: 'canva-helpers',
+		trusted: true,
+		publicUrl: 'https://example.com/community/canva-trusted',
+		forkPrompt: expect.stringContaining('canva-helpers'),
+	})
+	expect(mockModule.searchCommunityListings).toHaveBeenCalledWith({
+		env: expect.anything(),
+		query: 'canva',
+		limit: 12,
 	})
 	expect(mockModule.saveValue).toHaveBeenCalledWith(
 		expect.objectContaining({

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -19,6 +19,7 @@ import {
 import { getAppBaseUrl } from '#app/app-base-url.ts'
 import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { loadConnectOauthNextSteps } from '#app/connect-oauth-next-steps.ts'
 import {
 	redirectToLogin,
 	redirectToLoginWhenUnauthenticated,
@@ -403,6 +404,16 @@ async function handleConnectOauthAction(input: {
 		})
 	}
 
+	const nextSteps = await loadConnectOauthNextSteps({
+		env: input.env,
+		integrationName,
+		providerQuery: provider,
+		baseUrl: getAppBaseUrl({
+			env: input.env,
+			requestUrl: input.request.url,
+		}),
+	})
+
 	return jsonResponse({
 		ok: true,
 		accessTokenSaved: Boolean(accessSaved),
@@ -410,6 +421,7 @@ async function handleConnectOauthAction(input: {
 		allowedHosts,
 		hostApprovalLinks,
 		integrationName,
+		nextSteps,
 	})
 }
 

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -33,7 +33,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'integration-bootstrap.md',
 		title: 'Integration bootstrap guide',
 		summary:
-			'START HERE when a third-party integration must work before saving a dependent package or package app: inspect integration/secret state, stop for setup, run an authenticated smoke test, then prefer a trusted community fork before building from scratch.',
+			'START HERE when a third-party integration must work before saving a dependent package or package app: inspect integration/secret state, stop for setup, run an authenticated smoke test, then use connect nextSteps or community_search (prefer trusted) before building from scratch.',
 	},
 	secret_backed_integration: {
 		file: 'secret-backed-integration.md',
@@ -51,7 +51,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'oauth.md',
 		title: 'OAuth guide (standard path)',
 		summary:
-			'START HERE for third-party OAuth: hosted /connect/oauth, the exact redirect URI (https://heykody.dev/connect/oauth), required query params, PKCE vs confidential, and how it differs from MCP OAuth.',
+			'START HERE for third-party OAuth: hosted /connect/oauth, the exact redirect URI (https://heykody.dev/connect/oauth), required query params, PKCE vs confidential, post-connect nextSteps with trusted community helpers suggestions, and how it differs from MCP OAuth.',
 	},
 	connect_secret: {
 		file: 'account-secret-setup.md',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a successful `/connect/oauth` connect, teach that a saved integration is **auth credentials only**, then suggest forking/creating a helpers package as the durable agent-facing surface.

- `connect_oauth` success payload now includes `nextSteps`: guidance, up to 3 trusted-first community suggestions (bounded search, fails open), and a create-helpers CTA/prompt
- Success UI renders that guidance, listing links, fork-prompt copy buttons, and the create CTA
- Guidance only says “prefer trusted” when a trusted suggestion is actually present
- OAuth + integration_bootstrap guides (and guide summaries) mention `nextSteps` / trusted-first helpers

## Test plan

- [x] Unit tests for trusted-first ranking, payload shape, fail-open search, untrusted-only guidance, and client nextSteps parsing
- [x] `connect_oauth` handler test asserts trusted-first ordering in `nextSteps`
- [x] CI validate green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4b43effe` · **Head:** latest on branch

**Classification:** extends — widens the OAuth connect success contract (`nextSteps`) and success UI; composes existing community search without changing its ranking API.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — connect success payload + UI next-steps |
| `capability-registry` | assistant | extends — oauth / integration_bootstrap guide copy |

### System map

OAuth connect success now returns bounded trusted-first community helpers suggestions before agents treat the integration as an API.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  connectUi["/connect/oauth success UI"]
  secretsApi["account/secrets.json connect_oauth"]
  nextSteps["connect-oauth-next-steps"]
  communitySearch["searchCommunityListings"]
  guides["oauth + integration_bootstrap guides"]

  connectUi -->|POST tokens| secretsApi
  secretsApi -->|load nextSteps| nextSteps
  nextSteps -->|bounded query| communitySearch
  nextSteps -->|trusted-first top 1-3 + create CTA| secretsApi
  secretsApi -->|nextSteps in JSON| connectUi
  guides -.->|agents read post-connect contract| nextSteps

  classDef composes fill:#d4edda,stroke:#2f6f3e,color:#163222;
  classDef extends fill:#fff2cc,stroke:#8a6d1d,color:#3f3110;
  classDef context fill:#eceff3,stroke:#6b7280,color:#1f2937;

  class communitySearch composes
  class connectUi,secretsApi,nextSteps,guides extends
```

### Key changes

- New `connect-oauth-next-steps` helper builds guidance + trusted-first suggestions + create CTA.
- Connect success API/UI surface that payload; search failures do not block token save.
- Guides tell agents integration ≠ package API and to use `nextSteps` / trusted community helpers next.

### Risk notes

- Medium: response contract and success UX change for every OAuth connect.
- Search is bounded (`limit` 12 candidates → max 3 suggestions) and fails open to empty suggestions + create guidance.
- No MCP server-instruction text added; no always-on agent spam path.

### Docs

- [docs/guides/oauth.md](docs/guides/oauth.md)
- [docs/guides/integration-bootstrap.md](docs/guides/integration-bootstrap.md)

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c8f002-6c3d-48eb-aef7-75539e19e3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c8f002-6c3d-48eb-aef7-75539e19e3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

