### PR TITLE
Enrich integration search entity detail with related packages

### DIFF
--- a/docs/guides/integration-bootstrap.md
+++ b/docs/guides/integration-bootstrap.md
@@ -99,11 +99,14 @@ If those conditions are not met, stop and fix the integration first.
      surface.
 5. Only after the smoke test succeeds should you obtain the dependent package or
    package app.
-   - Search the user's account for an existing package that wraps the
-     integration.
-   - Call `community_search` for the provider or workflow (prefer `trusted`
-     matches). If a listing is close to the user's goal, fork or point them at
-     one-click install, then adapt — do not reimplement from scratch.
+   - `search({ entity: "<provider>:integration" })` may already surface a small
+     same-provider package suggestion set (user packages first, else
+     trusted-first community listings). Use those when present.
+   - Otherwise search the user's account for an existing package that wraps the
+     integration, then call `community_search` for the provider or workflow
+     (prefer `trusted` matches). If a listing is close to the user's goal, fork
+     or point them at one-click install, then adapt — do not reimplement from
+     scratch.
    - Create or save a thin helpers package only when no suitable community
      listing exists.
    - If the integration or tokens already exist and the smoke test passes,

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -83,6 +83,11 @@ the same provider** so create/poll pairs and sibling tools are visible without a
 second lookup. Built-in capabilities skip that section to keep common lookups
 lean.
 
+Integration entity detail may include a small set of **related package
+suggestions** for the same provider (the user's packages first; otherwise
+trusted-first community listings, capped). Ranked query results stay lean and do
+not run community lookup or expand those suggestions.
+
 Package detail includes a short **Maintain** pointer: the git lane
 (`package_get_git_remote` → clone/edit/push → `package_publish_external_push`)
 and the tool-only alternative (`package_save` / repo sessions, with

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
@@ -1,0 +1,235 @@
+import { expect, test, vi } from 'vitest'
+import {
+	collectIntegrationPackageSuggestions,
+	maxIntegrationPackageSuggestions,
+	packageIdentityMentionsProvider,
+} from './integration-package-suggestions.ts'
+
+const mockModule = vi.hoisted(() => ({
+	searchCommunityListings: vi.fn(),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	searchCommunityListings: (...args: Array<unknown>) =>
+		mockModule.searchCommunityListings(...args),
+}))
+
+function createPackageRow(input: {
+	kodyId: string
+	name: string
+	description?: string
+	tags?: Array<string>
+}) {
+	return {
+		record: {
+			kodyId: input.kodyId,
+			name: input.name,
+			description: input.description ?? `${input.kodyId} package`,
+			tags: input.tags ?? [],
+		},
+	}
+}
+
+function createCommunityListing(input: {
+	id: string
+	kodyId: string
+	name: string
+	trusted: boolean
+	tags?: Array<string>
+	description?: string
+}) {
+	return {
+		id: input.id,
+		ownerUserId: 'owner-1',
+		packageId: `pkg-${input.id}`,
+		sourceId: `source-${input.id}`,
+		kodyId: input.kodyId,
+		name: input.name,
+		description: input.description ?? `${input.kodyId} listing`,
+		tags: input.tags ?? [input.kodyId],
+		searchText: null,
+		readmeContent: null,
+		license: 'MIT',
+		pinnedCommit: 'abc123',
+		iconCommit: 'abc123',
+		status: 'active' as const,
+		trustedCommit: input.trusted ? 'abc123' : null,
+		trustedAt: input.trusted ? '2026-01-01T00:00:00.000Z' : null,
+		trusted: input.trusted,
+		featuredAt: null,
+		featured: false,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		publishedAt: '2026-01-01T00:00:00.000Z',
+		averageStars: null,
+		ratingCount: 0,
+		averageAdaptationEffort: null,
+		forkCount: 0,
+		starCount: 0,
+	}
+}
+
+test('integration package suggestions stay same-provider, user-first, and capped', async () => {
+	expect(
+		packageIdentityMentionsProvider(
+			{ kodyId: 'github', name: '@kody/github', tags: ['github', 'api'] },
+			'github',
+		),
+	).toBe(true)
+	expect(
+		packageIdentityMentionsProvider(
+			{
+				kodyId: 'cursor',
+				name: '@kody/cursor',
+				tags: ['cursor', 'api'],
+			},
+			'github',
+		),
+	).toBe(false)
+	expect(
+		packageIdentityMentionsProvider(
+			{
+				kodyId: 'google-calendar',
+				name: '@user/google-calendar',
+				tags: ['google', 'calendar'],
+			},
+			'google-calendar',
+		),
+	).toBe(true)
+
+	const userRows = [
+		createPackageRow({
+			kodyId: 'notes',
+			name: '@user/notes',
+			tags: ['notes'],
+		}),
+		createPackageRow({
+			kodyId: 'github',
+			name: '@user/github',
+			tags: ['github'],
+		}),
+		createPackageRow({
+			kodyId: 'github-pr',
+			name: '@user/github-pr',
+			tags: ['github', 'pr'],
+		}),
+		createPackageRow({
+			kodyId: 'github-actions',
+			name: '@user/github-actions',
+			tags: ['github'],
+		}),
+		createPackageRow({
+			kodyId: 'github-issues',
+			name: '@user/github-issues',
+			tags: ['github'],
+		}),
+	]
+
+	const withUserPackages = await collectIntegrationPackageSuggestions({
+		env: {} as Env,
+		baseUrl: 'https://example.com',
+		providerName: 'github',
+		packageRows: userRows,
+	})
+	expect(mockModule.searchCommunityListings).not.toHaveBeenCalled()
+	expect(withUserPackages).toHaveLength(maxIntegrationPackageSuggestions)
+	expect(withUserPackages.every((item) => item.source === 'user')).toBe(true)
+	expect(withUserPackages.map((item) => item.kodyId)).toEqual([
+		'github',
+		'github-pr',
+		'github-actions',
+	])
+
+	mockModule.searchCommunityListings.mockResolvedValueOnce([
+		createCommunityListing({
+			id: 'listing-cursor',
+			kodyId: 'cursor',
+			name: '@kody/cursor',
+			trusted: true,
+			tags: ['cursor'],
+		}),
+		createCommunityListing({
+			id: 'listing-github-untrusted',
+			kodyId: 'github-helpers',
+			name: '@someone/github-helpers',
+			trusted: false,
+			tags: ['github'],
+		}),
+		createCommunityListing({
+			id: 'listing-github-trusted',
+			kodyId: 'github',
+			name: '@kody/github',
+			trusted: true,
+			tags: ['github'],
+		}),
+		createCommunityListing({
+			id: 'listing-github-pr',
+			kodyId: 'github-pr',
+			name: '@kody/github-pr',
+			trusted: true,
+			tags: ['github', 'pr'],
+		}),
+		createCommunityListing({
+			id: 'listing-github-extra',
+			kodyId: 'github-extra',
+			name: '@kody/github-extra',
+			trusted: true,
+			tags: ['github'],
+		}),
+	])
+
+	const communityOnly = await collectIntegrationPackageSuggestions({
+		env: {} as Env,
+		baseUrl: 'https://example.com',
+		providerName: 'GitHub',
+		packageRows: [
+			createPackageRow({
+				kodyId: 'notes',
+				name: '@user/notes',
+				tags: ['notes'],
+			}),
+		],
+	})
+	expect(mockModule.searchCommunityListings).toHaveBeenCalledTimes(1)
+	expect(mockModule.searchCommunityListings).toHaveBeenCalledWith({
+		env: {},
+		query: 'github',
+		limit: 12,
+	})
+	expect(communityOnly).toEqual([
+		expect.objectContaining({
+			source: 'community',
+			kodyId: 'github',
+			listingId: 'listing-github-trusted',
+			trusted: true,
+			publicUrl: 'https://example.com/community/listing-github-trusted',
+		}),
+		expect.objectContaining({
+			source: 'community',
+			kodyId: 'github-pr',
+			trusted: true,
+		}),
+		expect.objectContaining({
+			source: 'community',
+			kodyId: 'github-extra',
+			trusted: true,
+		}),
+	])
+	expect(communityOnly).toHaveLength(maxIntegrationPackageSuggestions)
+	expect(
+		communityOnly.every(
+			(item) => item.source === 'community' && item.trusted === true,
+		),
+	).toBe(true)
+
+	mockModule.searchCommunityListings.mockRejectedValueOnce(
+		new Error('community unavailable'),
+	)
+	const failedCommunity = await collectIntegrationPackageSuggestions({
+		env: {} as Env,
+		baseUrl: 'https://example.com',
+		providerName: 'github',
+		packageRows: [],
+	})
+	expect(failedCommunity).toEqual([])
+})

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.ts
@@ -1,0 +1,153 @@
+import { buildCommunityPublicUrl } from '#mcp/capabilities/community/shared.ts'
+import { canonicalIntegrationName } from '#mcp/capabilities/integrations/integration-shared.ts'
+import { searchCommunityListings } from '#worker/community/service.ts'
+import { type RelatedIntegrationPackageSuggestion } from './search-format.ts'
+import { extractSearchTokens } from './understand-search-query.ts'
+
+export const maxIntegrationPackageSuggestions = 3
+const communitySuggestionCandidateLimit = 12
+
+type ProviderPackageIdentity = {
+	kodyId: string
+	name: string
+	tags: ReadonlyArray<string>
+}
+
+type SuggestionPackageRow = {
+	record: {
+		kodyId: string
+		name: string
+		description: string
+		tags: Array<string>
+	}
+}
+
+export function packageIdentityMentionsProvider(
+	identity: ProviderPackageIdentity,
+	providerName: string,
+): boolean {
+	const provider = canonicalIntegrationName(providerName)
+	const providerTokens = extractSearchTokens(provider)
+	if (providerTokens.length === 0) return false
+
+	const identityTokens = new Set(
+		extractSearchTokens(
+			[identity.kodyId, identity.name, identity.tags.join(' ')].join('\n'),
+		),
+	)
+	return providerTokens.every((token) => identityTokens.has(token))
+}
+
+function toUserSuggestion(
+	row: SuggestionPackageRow,
+): RelatedIntegrationPackageSuggestion {
+	return {
+		source: 'user',
+		kodyId: row.record.kodyId,
+		name: row.record.name,
+		description: row.record.description,
+		entityRef: `${row.record.kodyId}:package`,
+	}
+}
+
+function toCommunitySuggestion(input: {
+	listing: Awaited<ReturnType<typeof searchCommunityListings>>[number]
+	baseUrl: string
+}): RelatedIntegrationPackageSuggestion {
+	return {
+		source: 'community',
+		kodyId: input.listing.kodyId,
+		name: input.listing.name,
+		description: input.listing.description,
+		listingId: input.listing.id,
+		publicUrl: buildCommunityPublicUrl(input.baseUrl, input.listing.id),
+		trusted: input.listing.trusted,
+	}
+}
+
+function collectSameProviderUserSuggestions(
+	packageRows: ReadonlyArray<SuggestionPackageRow>,
+	providerName: string,
+): Array<RelatedIntegrationPackageSuggestion> {
+	const suggestions: Array<RelatedIntegrationPackageSuggestion> = []
+	for (const row of packageRows) {
+		if (
+			!packageIdentityMentionsProvider(
+				{
+					kodyId: row.record.kodyId,
+					name: row.record.name,
+					tags: row.record.tags,
+				},
+				providerName,
+			)
+		) {
+			continue
+		}
+		suggestions.push(toUserSuggestion(row))
+		if (suggestions.length >= maxIntegrationPackageSuggestions) break
+	}
+	return suggestions
+}
+
+async function collectSameProviderCommunitySuggestions(input: {
+	env: Env
+	baseUrl: string
+	providerName: string
+}): Promise<Array<RelatedIntegrationPackageSuggestion>> {
+	const provider = canonicalIntegrationName(input.providerName)
+	let listings: Awaited<ReturnType<typeof searchCommunityListings>>
+	try {
+		listings = await searchCommunityListings({
+			env: input.env,
+			query: provider,
+			limit: communitySuggestionCandidateLimit,
+		})
+	} catch {
+		return []
+	}
+
+	const sameProvider = listings.filter((listing) =>
+		packageIdentityMentionsProvider(
+			{
+				kodyId: listing.kodyId,
+				name: listing.name,
+				tags: listing.tags,
+			},
+			provider,
+		),
+	)
+	const trusted = sameProvider.filter((listing) => listing.trusted)
+	const untrusted = sameProvider.filter((listing) => !listing.trusted)
+	const ordered = [...trusted, ...untrusted].slice(
+		0,
+		maxIntegrationPackageSuggestions,
+	)
+	return ordered.map((listing) =>
+		toCommunitySuggestion({ listing, baseUrl: input.baseUrl }),
+	)
+}
+
+/**
+ * Detail-only helper: suggest same-provider packages for an integration.
+ * Prefers the user's own packages and skips community lookup when any exist.
+ * Community suggestions are trusted-first and capped.
+ */
+export async function collectIntegrationPackageSuggestions(input: {
+	env: Env
+	baseUrl: string
+	providerName: string
+	packageRows: ReadonlyArray<SuggestionPackageRow>
+}): Promise<Array<RelatedIntegrationPackageSuggestion>> {
+	const userSuggestions = collectSameProviderUserSuggestions(
+		input.packageRows,
+		input.providerName,
+	)
+	if (userSuggestions.length > 0) {
+		return userSuggestions
+	}
+	return await collectSameProviderCommunitySuggestions({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		providerName: input.providerName,
+	})
+}

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -217,6 +217,104 @@ test('search formatting keeps entity refs and generates safe, runnable usage sni
 		scope: 'user',
 		value: 'kentcdodds/kody',
 	})
+
+	const integrationDetail = formatEntityDetailMarkdown({
+		type: 'integration',
+		id: 'github',
+		title: 'github',
+		description: 'GitHub OAuth integration config',
+		row: {
+			name: '_integration:github',
+			scope: 'user',
+			value: '{}',
+			description: 'GitHub OAuth integration config',
+			appId: null,
+			createdAt: '2026-03-20T00:00:00.000Z',
+			updatedAt: '2026-03-20T00:00:00.000Z',
+			ttlMs: null,
+		},
+		config: {
+			name: 'github',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+			clientIdValueName: 'github_client_id',
+			clientSecretSecretName: 'github_client_secret',
+			accessTokenSecretName: 'github_access_token',
+			refreshTokenSecretName: null,
+			requiredHosts: ['api.github.com'],
+			authorization: null,
+		},
+		relatedPackageSuggestions: [
+			{
+				source: 'user',
+				kodyId: 'github',
+				name: '@user/github',
+				description: 'User GitHub package.',
+				entityRef: 'github:package',
+			},
+			{
+				source: 'community',
+				kodyId: 'github-helpers',
+				name: '@kody/github-helpers',
+				description: 'Trusted community GitHub helpers.',
+				listingId: 'listing-1',
+				publicUrl: 'https://example.com/community/listing-1',
+				trusted: true,
+			},
+		],
+	})
+	expect(integrationDetail.structured).toMatchObject({
+		type: 'integration',
+		entityRef: 'github:integration',
+		relatedPackageSuggestions: [
+			expect.objectContaining({
+				source: 'user',
+				entityRef: 'github:package',
+			}),
+			expect.objectContaining({
+				source: 'community',
+				listingId: 'listing-1',
+				trusted: true,
+			}),
+		],
+	})
+	expect(integrationDetail.markdown).toContain('## Related packages')
+	expect(integrationDetail.markdown).toContain('github:package')
+	expect(integrationDetail.markdown).toContain('listing-1')
+
+	const leanIntegrationDetail = formatEntityDetailMarkdown({
+		type: 'integration',
+		id: 'github',
+		title: 'github',
+		description: 'GitHub OAuth integration config',
+		row: {
+			name: '_integration:github',
+			scope: 'user',
+			value: '{}',
+			description: 'GitHub OAuth integration config',
+			appId: null,
+			createdAt: '2026-03-20T00:00:00.000Z',
+			updatedAt: '2026-03-20T00:00:00.000Z',
+			ttlMs: null,
+		},
+		config: {
+			name: 'github',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+			clientIdValueName: 'github_client_id',
+			clientSecretSecretName: 'github_client_secret',
+			accessTokenSecretName: 'github_access_token',
+			refreshTokenSecretName: null,
+			requiredHosts: ['api.github.com'],
+			authorization: null,
+		},
+	})
+	expect(leanIntegrationDetail.structured).not.toHaveProperty(
+		'relatedPackageSuggestions',
+	)
+	expect(leanIntegrationDetail.markdown).not.toContain('## Related packages')
 })
 
 test('capability formatting keeps execute contracts for identifier and bracket ids', async () => {

--- a/packages/worker/src/mcp/tools/search-format.ts
+++ b/packages/worker/src/mcp/tools/search-format.ts
@@ -123,6 +123,24 @@ export type RelatedCapabilityOperation = {
 	path?: string
 }
 
+export type RelatedIntegrationPackageSuggestion =
+	| {
+			source: 'user'
+			kodyId: string
+			name: string
+			description: string
+			entityRef: string
+	  }
+	| {
+			source: 'community'
+			kodyId: string
+			name: string
+			description: string
+			listingId: string
+			publicUrl: string
+			trusted: boolean
+	  }
+
 export type SlimSearchMatch =
 	| {
 			type: 'capability'
@@ -360,6 +378,7 @@ export type SearchEntityDetailStructured =
 			refreshTokenSecretName: string | null
 			requiredHosts: Array<string>
 			authorization: IntegrationConfig['authorization'] | null
+			relatedPackageSuggestions?: Array<RelatedIntegrationPackageSuggestion>
 	  }
 
 export type SearchEntityDetail =
@@ -404,6 +423,7 @@ export type SearchEntityDetail =
 			description: string
 			row: ValueMetadata
 			config: IntegrationConfig
+			relatedPackageSuggestions?: Array<RelatedIntegrationPackageSuggestion>
 	  }
 
 export type SearchMatch =
@@ -1199,6 +1219,7 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 	if (detail.type === 'integration') {
 		const requiredHosts = detail.config.requiredHosts ?? []
 		const authorization = detail.config.authorization ?? null
+		const relatedPackageSuggestions = detail.relatedPackageSuggestions ?? []
 		const lines = [
 			`# Integration — \`${detail.config.name}\``,
 			'',
@@ -1243,6 +1264,29 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				`Reconnect with \`/connect/oauth?provider=${encodeURIComponent(detail.config.name)}\`; Kody derives the provider authorize URL from the saved integration metadata plus the current client credentials.`,
 			)
 		}
+		if (relatedPackageSuggestions.length > 0) {
+			lines.push(
+				'',
+				'## Related packages',
+				'',
+				'Integrations store auth config. Packages are the agent API for this provider — inspect or fork one of these instead of treating the integration alone as the end state.',
+				'',
+			)
+			for (const suggestion of relatedPackageSuggestions) {
+				if (suggestion.source === 'user') {
+					lines.push(
+						`- **user** ${formatMarkdownInlineCode(suggestion.kodyId)} (${formatMarkdownInlineCode(suggestion.name)}) — ${escapeMarkdownText(formatOneLineSentence(suggestion.description))} Entity: ${formatMarkdownInlineCode(suggestion.entityRef)}`,
+					)
+					continue
+				}
+				const trustLabel = suggestion.trusted
+					? 'community (trusted)'
+					: 'community'
+				lines.push(
+					`- **${trustLabel}** ${formatMarkdownInlineCode(suggestion.kodyId)} (${formatMarkdownInlineCode(suggestion.name)}) — ${escapeMarkdownText(formatOneLineSentence(suggestion.description))} Listing: ${formatMarkdownInlineCode(suggestion.listingId)} · ${formatMarkdownInlineCode(suggestion.publicUrl)}`,
+				)
+			}
+		}
 		return {
 			markdown: lines.join('\n'),
 			structured: {
@@ -1262,6 +1306,9 @@ export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
 				refreshTokenSecretName: detail.config.refreshTokenSecretName ?? null,
 				requiredHosts,
 				authorization,
+				...(relatedPackageSuggestions.length > 0
+					? { relatedPackageSuggestions }
+					: {}),
 			} satisfies SearchEntityDetailStructured,
 		}
 	}

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -41,6 +41,7 @@ const mockModule = vi.hoisted(() => ({
 		connectedAt: null,
 		lastSeenAt: null,
 	})),
+	searchCommunityListings: vi.fn(async () => []),
 }))
 
 vi.mock('#mcp/capabilities/registry.ts', () => ({
@@ -90,6 +91,11 @@ vi.mock('#worker/package-retrievers/service.ts', () => ({
 vi.mock('#worker/remote-connector/status.ts', () => ({
 	getRemoteConnectorStatus: (...args: Array<unknown>) =>
 		mockModule.getRemoteConnectorStatus(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	searchCommunityListings: (...args: Array<unknown>) =>
+		mockModule.searchCommunityListings(...args),
 }))
 
 const {
@@ -654,6 +660,223 @@ test('search tool batches entity detail with per-ref isolation and preserves sin
 			error: expect.any(String),
 		}),
 	])
+})
+
+test('integration entity detail enriches related packages without bloating ranked search', async () => {
+	const user = {
+		userId: 'user-1',
+		email: 'user@example.com',
+		displayName: 'User',
+		username: 'user',
+	}
+	const githubIntegrationValue = {
+		name: '_integration:github',
+		scope: 'user' as const,
+		value: JSON.stringify({
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+			clientIdValueName: 'github-client-id',
+			clientSecretSecretName: 'github-client-secret',
+			accessTokenSecretName: 'github-access-token',
+			refreshTokenSecretName: null,
+			requiredHosts: ['api.github.com', 'github.com'],
+		}),
+		description: 'GitHub OAuth integration',
+		appId: null,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		ttlMs: null,
+	}
+
+	vi.clearAllMocks()
+	mockModule.listValues.mockResolvedValue([githubIntegrationValue])
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([])
+	mockModule.searchCommunityListings.mockResolvedValue([
+		{
+			id: 'listing-github',
+			ownerUserId: 'owner-1',
+			packageId: 'pkg-github',
+			sourceId: 'source-github',
+			kodyId: 'github',
+			name: '@kody/github',
+			description: 'GitHub helpers',
+			tags: ['github', 'api'],
+			searchText: null,
+			readmeContent: null,
+			license: 'MIT',
+			pinnedCommit: 'abc123',
+			iconCommit: 'abc123',
+			status: 'active',
+			trustedCommit: 'abc123',
+			trustedAt: '2026-01-01T00:00:00.000Z',
+			trusted: true,
+			featuredAt: null,
+			featured: false,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+			publishedAt: '2026-01-01T00:00:00.000Z',
+			averageStars: null,
+			ratingCount: 0,
+			averageAdaptationEffort: null,
+			forkCount: 0,
+			starCount: 0,
+		},
+		{
+			id: 'listing-cursor',
+			ownerUserId: 'owner-1',
+			packageId: 'pkg-cursor',
+			sourceId: 'source-cursor',
+			kodyId: 'cursor',
+			name: '@kody/cursor',
+			description: 'Cursor helpers that mention github.com in prose',
+			tags: ['cursor'],
+			searchText: null,
+			readmeContent: null,
+			license: 'MIT',
+			pinnedCommit: 'abc123',
+			iconCommit: 'abc123',
+			status: 'active',
+			trustedCommit: 'abc123',
+			trustedAt: '2026-01-01T00:00:00.000Z',
+			trusted: true,
+			featuredAt: null,
+			featured: false,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+			publishedAt: '2026-01-01T00:00:00.000Z',
+			averageStars: null,
+			ratingCount: 0,
+			averageAdaptationEffort: null,
+			forkCount: 0,
+			starCount: 0,
+		},
+	])
+
+	const { handler } = await getSearchRegistration({ user })
+
+	const ranked = await handler({
+		query: 'github integration',
+		conversationId: 'conv-integration-ranked',
+	})
+	expect(ranked.isError).toBeUndefined()
+	expect(mockModule.searchCommunityListings).not.toHaveBeenCalled()
+	const rankedResult = ranked.structuredContent.result as {
+		matches: Array<{
+			type: string
+			relatedPackageSuggestions?: unknown
+			entityRef?: string
+		}>
+	}
+	const rankedIntegration = rankedResult.matches.find(
+		(match) => match.type === 'integration',
+	)
+	expect(rankedIntegration).toMatchObject({
+		type: 'integration',
+		entityRef: 'github:integration',
+	})
+	expect(rankedIntegration).not.toHaveProperty('relatedPackageSuggestions')
+
+	const detail = await handler({
+		entity: 'github:integration',
+		conversationId: 'conv-integration-detail',
+	})
+	expect(detail.isError).toBeUndefined()
+	expect(mockModule.searchCommunityListings).toHaveBeenCalledTimes(1)
+	expect(mockModule.searchCommunityListings).toHaveBeenCalledWith({
+		env: { APP_DB: {} },
+		query: 'github',
+		limit: 12,
+	})
+	expect(detail.structuredContent.result).toMatchObject({
+		kind: 'entity',
+		type: 'integration',
+		id: 'github',
+		relatedPackageSuggestions: [
+			expect.objectContaining({
+				source: 'community',
+				kodyId: 'github',
+				listingId: 'listing-github',
+				trusted: true,
+			}),
+		],
+	})
+	const suggestions = (
+		detail.structuredContent.result as {
+			relatedPackageSuggestions: Array<{ kodyId: string }>
+		}
+	).relatedPackageSuggestions
+	expect(suggestions.map((item) => item.kodyId)).toEqual(['github'])
+
+	vi.clearAllMocks()
+	mockModule.listValues.mockResolvedValue([githubIntegrationValue])
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([
+		{
+			id: 'pkg-user-github',
+			userId: 'user-1',
+			name: '@user/github',
+			kodyId: 'github',
+			description: 'User github package',
+			tags: ['github'],
+			searchText: 'github helpers',
+			sourceId: 'source-user-github',
+			hasApp: false,
+			hidden: false,
+			isPrivate: false,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		},
+	])
+	mockModule.searchCommunityListings.mockResolvedValue([
+		{
+			id: 'listing-github',
+			ownerUserId: 'owner-1',
+			packageId: 'pkg-github',
+			sourceId: 'source-github',
+			kodyId: 'github',
+			name: '@kody/github',
+			description: 'GitHub helpers',
+			tags: ['github'],
+			searchText: null,
+			readmeContent: null,
+			license: 'MIT',
+			pinnedCommit: 'abc123',
+			iconCommit: 'abc123',
+			status: 'active',
+			trustedCommit: 'abc123',
+			trustedAt: '2026-01-01T00:00:00.000Z',
+			trusted: true,
+			featuredAt: null,
+			featured: false,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+			publishedAt: '2026-01-01T00:00:00.000Z',
+			averageStars: null,
+			ratingCount: 0,
+			averageAdaptationEffort: null,
+			forkCount: 0,
+			starCount: 0,
+		},
+	])
+
+	const { handler: userPackageHandler } = await getSearchRegistration({
+		user,
+	})
+	const userPackageDetail = await userPackageHandler({
+		entity: 'github:integration',
+		conversationId: 'conv-integration-user-pkg',
+	})
+	expect(mockModule.searchCommunityListings).not.toHaveBeenCalled()
+	expect(userPackageDetail.structuredContent.result).toMatchObject({
+		type: 'integration',
+		relatedPackageSuggestions: [
+			expect.objectContaining({
+				source: 'user',
+				kodyId: 'github',
+				entityRef: 'github:package',
+			}),
+		],
+	})
 })
 
 test('search tool memory enrichment: timeout, rejection, and ack failure stay off the critical path', async () => {

--- a/packages/worker/src/mcp/tools/search.ts
+++ b/packages/worker/src/mcp/tools/search.ts
@@ -92,6 +92,7 @@ import {
 	parseEntityRef,
 	toSlimStructuredMatches,
 } from './search-format.ts'
+import { collectIntegrationPackageSuggestions } from './integration-package-suggestions.ts'
 import { finishToolTiming, startToolTiming } from './tool-timing.ts'
 import { prependToolMetadataContent } from './tool-response-content.ts'
 import {
@@ -2408,8 +2409,10 @@ without competing semantic matches. Hidden exact queries require
 related lookups in one call. Capability detail includes an exact \`execute\`
 module snippet plus TypeScript call-shape definitions by default. Synthesized
 provider capabilities (OpenAPI, MCP server, remote connector) also list related
-operations from the same provider. Package ids may be UUIDs or kody ids, and
-hidden packages resolve here regardless of \`includeHiddenPackages\`.
+operations from the same provider. Integration detail may include a small set of
+same-provider package suggestions (user packages first, else trusted-first
+community listings). Package ids may be UUIDs or kody ids, and hidden packages
+resolve here regardless of \`includeHiddenPackages\`.
 
 Secret results expose metadata only; credential values never appear.
 
@@ -2682,6 +2685,13 @@ async function resolveEntityDetail(input: {
 		if (!integration) {
 			throw new Error('Saved integration not found for this user.')
 		}
+		const relatedPackageSuggestions =
+			await collectIntegrationPackageSuggestions({
+				env: input.agent.getEnv(),
+				baseUrl: input.callerContext.baseUrl,
+				providerName: integration.config.name,
+				packageRows: input.searchRows.packageRows,
+			})
 		return {
 			type: 'integration' as const,
 			id: integration.config.name,
@@ -2691,6 +2701,9 @@ async function resolveEntityDetail(input: {
 				`Saved OAuth integration configuration (${integration.config.flow} flow).`,
 			row: integration.row,
 			config: integration.config,
+			...(relatedPackageSuggestions.length > 0
+				? { relatedPackageSuggestions }
+				: {}),
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When agents call `search({ entity: "<provider>:integration" })`, entity detail now includes a small same-provider package suggestion set so OAuth config is not treated as the end state.

- Detail-only enrichment (ranked query stays lean; no community lookup on ranked search)
- Prefer the user's own same-provider packages; only then look up community listings
- Cap at 3; trusted-first for community matches; identity-token matching (kodyId/name/tags)
- Brief guidance that integrations are auth and packages are the agent API

Out of scope: raw-auth failure steer and post-connect OAuth suggestions (separate workstreams).

## Test plan

- [x] Unit tests for same-provider matching, user-first skip of community, trusted-first cap
- [x] Handler test proving ranked search does not call `searchCommunityListings`
- [x] Handler/format tests for entity-detail `relatedPackageSuggestions`
- [ ] CI green (`npm run validate` via PR checks)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends mcp-server</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `01359ac2` · **Head:** `d6ba03e3`

**Classification:** extends — integration entity-detail contract gains optional related package suggestions; ranked search path unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — integration entity detail may include `relatedPackageSuggestions` |
| `community-listings` | assistant | composes — detail-only call into `searchCommunityListings` when user has no obvious provider package |

### System map

Integration entity detail resolves saved OAuth config, then optionally attaches same-provider package suggestions from user packages or trusted-first community listings.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP server / tools"]:::extended
	communityListings["community-listings<br/>Community listings"]:::touched
	mcpServer -->|"entity detail only: searchCommunityListings when no user package"| communityListings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant Search as search tool
	participant UserPkgs as user package rows
	participant Community as searchCommunityListings
	Agent->>Search: entity: provider:integration
	Search->>UserPkgs: same-provider identity match
	alt user packages found
		Search-->>Agent: detail + up to 3 user suggestions
	else none
		Search->>Community: query provider (trusted-first, cap 3)
		Search-->>Agent: detail + community suggestions
	end
	Note over Agent,Search: ranked query path never calls Community
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| Ranked `query` | Integration hit summary only | Unchanged (no community lookup / no suggestions) |
| `entity: "<name>:integration"` | Auth/config detail only | Same detail + optional `relatedPackageSuggestions` (<=3) |

### Invariants

Per-user isolation preserved: user package suggestions come from the caller's saved packages; community listings are public marketplace data only.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8cd20f7-3032-406c-b2a0-233bee7902b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8cd20f7-3032-406c-b2a0-233bee7902b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

