### PR TITLE
Constrain sender identities to verified

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -330,6 +330,15 @@ column, `raw_mime_offload_blocked`, the unblocked inline partial index, and
 `email_raw_mime_cleanup_queue`. Runtime code from Stage 4b1 is already
 compatible with the final schema.
 
+**Expand/contract Stage 5 (migration + types):** migration
+`0078-email-sender-identities-verified-only.sql` normalizes every
+`email_sender_identities.status` to `verified`, then rebuilds the table with a
+verified-only CHECK. Because D1 keeps foreign keys on inside the migration
+transaction, the rebuild snapshots and restores
+`email_messages.sender_identity_id` (ON DELETE SET NULL) so message linkage is
+not lost. Runtime types and `ensurePlatformSenderIdentity` provision verified
+rows only.
+
 - All reads go through `loadRawMime` in `packages/worker/src/email/repo.ts`,
   which fetches the blob by `raw_mime_key` only. Attachment content extraction
   re-parses the resolved MIME the same way as before.

--- a/packages/worker/migrations/0078-email-sender-identities-verified-only.sql
+++ b/packages/worker/migrations/0078-email-sender-identities-verified-only.sql
@@ -1,0 +1,101 @@
+-- Stage 5: contract email_sender_identities.status to verified-only.
+-- Platform-assigned sender identities are always provisioned verified; legacy
+-- pending/disabled values are stale bookkeeping with no authorization meaning.
+--
+-- Cloudflare D1 wraps each migration in a transaction, so PRAGMA foreign_keys=OFF
+-- is a no-op there. email_messages.sender_identity_id references this table with
+-- ON DELETE SET NULL, so DROP TABLE would null those FKs. Snapshot every
+-- non-null sender_identity_id, rebuild identities, then restore the references.
+--
+-- Fail-closed: after restore, any unrecovered message linkage aborts (and D1
+-- rolls the transaction back).
+
+UPDATE email_sender_identities
+SET
+	status = 'verified',
+	verified_at = COALESCE(verified_at, created_at);
+
+CREATE TABLE _mig0078_email_message_sender_refs AS
+SELECT id AS message_id, sender_identity_id
+FROM email_messages
+WHERE sender_identity_id IS NOT NULL;
+
+CREATE TABLE email_sender_identities_next (
+	id TEXT PRIMARY KEY,
+	user_id TEXT NOT NULL,
+	package_id TEXT,
+	email TEXT NOT NULL,
+	domain TEXT,
+	display_name TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL CHECK (status IN ('verified')),
+	verified_at TEXT,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+
+INSERT INTO email_sender_identities_next (
+	id,
+	user_id,
+	package_id,
+	email,
+	domain,
+	display_name,
+	status,
+	verified_at,
+	created_at,
+	updated_at
+)
+SELECT
+	id,
+	user_id,
+	package_id,
+	email,
+	domain,
+	display_name,
+	status,
+	verified_at,
+	created_at,
+	updated_at
+FROM email_sender_identities;
+
+DROP TABLE email_sender_identities;
+
+ALTER TABLE email_sender_identities_next RENAME TO email_sender_identities;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_email_sender_identities_user_email
+ON email_sender_identities(user_id, email);
+
+CREATE INDEX IF NOT EXISTS idx_email_sender_identities_user_domain
+ON email_sender_identities(user_id, domain);
+
+UPDATE email_messages
+SET sender_identity_id = (
+	SELECT refs.sender_identity_id
+	FROM _mig0078_email_message_sender_refs AS refs
+	WHERE refs.message_id = email_messages.id
+)
+WHERE id IN (
+	SELECT message_id
+	FROM _mig0078_email_message_sender_refs
+);
+
+CREATE TABLE __migration_assertions (
+	message TEXT NOT NULL CHECK (0)
+);
+
+INSERT INTO __migration_assertions (message)
+SELECT 'email_messages.sender_identity_id restore incomplete after 0078 rebuild.'
+WHERE EXISTS (
+	SELECT 1
+	FROM _mig0078_email_message_sender_refs AS refs
+	WHERE NOT EXISTS (
+		SELECT 1
+		FROM email_messages AS message
+		WHERE message.id = refs.message_id
+			AND message.sender_identity_id = refs.sender_identity_id
+	)
+);
+
+DROP TABLE __migration_assertions;
+
+DROP TABLE _mig0078_email_message_sender_refs;

--- a/packages/worker/src/email/email-sender-identities-verified-only-migration.node.test.ts
+++ b/packages/worker/src/email/email-sender-identities-verified-only-migration.node.test.ts
@@ -1,0 +1,391 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+
+/** Upper bound (exclusive): only migrations before this file are applied as setup. */
+const verifiedOnlyMigration = '0078-email-sender-identities-verified-only.sql'
+
+const durableSenderIdentityIndexes = [
+	'idx_email_sender_identities_user_domain',
+	'idx_email_sender_identities_user_email',
+] as const
+
+/** D1 wraps each migration file in a transaction; PRAGMA foreign_keys=OFF is a no-op. */
+function applyMigrationLikeD1(db: DatabaseSync, fileName: string) {
+	const sql = readFileSync(new URL(fileName, migrationsDirectory), 'utf8')
+	db.exec('BEGIN')
+	try {
+		db.exec(sql)
+		db.exec('COMMIT')
+	} catch (error) {
+		db.exec('ROLLBACK')
+		throw error
+	}
+}
+
+function applyMigrationsBeforeVerifiedOnly(db: DatabaseSync) {
+	db.exec('PRAGMA foreign_keys = ON')
+	for (const fileName of readdirSync(migrationsDirectory)
+		.filter((file) => file.endsWith('.sql') && file < verifiedOnlyMigration)
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
+	}
+}
+
+function senderIdentitiesTableSql(db: DatabaseSync) {
+	const row = db
+		.prepare(
+			`SELECT sql FROM sqlite_master
+			 WHERE type = 'table' AND name = 'email_sender_identities'`,
+		)
+		.get() as { sql: string } | undefined
+	return row?.sql ?? ''
+}
+
+function senderIdentityIndexes(db: DatabaseSync) {
+	return (
+		db
+			.prepare(
+				`SELECT name FROM sqlite_master
+				 WHERE type = 'index'
+				   AND tbl_name = 'email_sender_identities'
+				   AND name NOT LIKE 'sqlite_%'
+				 ORDER BY name`,
+			)
+			.all() as Array<{ name: string }>
+	).map((row) => row.name)
+}
+
+function senderIdentityForeignKeys(db: DatabaseSync) {
+	return db.prepare(`PRAGMA foreign_key_list(email_messages)`).all() as Array<{
+		table: string
+		from: string
+		on_delete: string
+	}>
+}
+
+function seedLegacySenderIdentities(db: DatabaseSync) {
+	db.exec(`
+		INSERT INTO users (username, email, password_hash, stable_user_id)
+		VALUES ('alice', 'alice@example.com', 'hash', 'stable-alice');
+
+		INSERT INTO email_sender_identities (
+			id, user_id, package_id, email, domain, display_name, status,
+			verified_at, created_at, updated_at
+		) VALUES
+			(
+				'identity-pending', 'stable-alice', NULL,
+				'pending@inbox.example.com', 'inbox.example.com', '',
+				'pending', NULL, '2026-07-01T00:00:00.000Z',
+				'2026-07-01T00:00:00.000Z'
+			),
+			(
+				'identity-disabled', 'stable-alice', NULL,
+				'disabled@inbox.example.com', 'inbox.example.com', 'Disabled',
+				'disabled', NULL, '2026-07-01T01:00:00.000Z',
+				'2026-07-01T01:00:00.000Z'
+			),
+			(
+				'identity-verified', 'stable-alice', 'pkg-1',
+				'alice@inbox.example.com', 'inbox.example.com', 'Alice',
+				'verified', '2026-07-01T02:00:00.000Z',
+				'2026-07-01T02:00:00.000Z', '2026-07-01T02:00:00.000Z'
+			);
+
+		INSERT INTO email_messages (
+			id, direction, user_id, sender_identity_id, from_address,
+			processing_status, created_at, updated_at
+		) VALUES
+			(
+				'message-pending', 'outbound', 'stable-alice', 'identity-pending',
+				'pending@inbox.example.com', 'sent',
+				'2026-07-01T03:00:00.000Z', '2026-07-01T03:00:00.000Z'
+			),
+			(
+				'message-disabled', 'outbound', 'stable-alice', 'identity-disabled',
+				'disabled@inbox.example.com', 'sent',
+				'2026-07-01T04:00:00.000Z', '2026-07-01T04:00:00.000Z'
+			),
+			(
+				'message-verified', 'outbound', 'stable-alice', 'identity-verified',
+				'alice@inbox.example.com', 'sent',
+				'2026-07-01T05:00:00.000Z', '2026-07-01T05:00:00.000Z'
+			),
+			(
+				'message-unlinked', 'inbound', 'stable-alice', NULL,
+				'sender@example.net', 'stored',
+				'2026-07-01T06:00:00.000Z', '2026-07-01T06:00:00.000Z'
+			);
+	`)
+}
+
+test('email sender identities verified-only migration normalizes statuses and preserves message linkage under a D1 transaction', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBeforeVerifiedOnly(db)
+	seedLegacySenderIdentities(db)
+
+	expect(senderIdentitiesTableSql(db)).toContain(
+		"status TEXT NOT NULL CHECK (status IN ('pending', 'verified', 'disabled'))",
+	)
+	expect(senderIdentityIndexes(db)).toEqual([...durableSenderIdentityIndexes])
+	expect(
+		senderIdentityForeignKeys(db).some(
+			(foreignKey) =>
+				foreignKey.table === 'email_sender_identities' &&
+				foreignKey.from === 'sender_identity_id' &&
+				foreignKey.on_delete === 'SET NULL',
+		),
+	).toBe(true)
+	expect(
+		db
+			.prepare(
+				`SELECT id, status, verified_at FROM email_sender_identities
+				 ORDER BY id`,
+			)
+			.all(),
+	).toEqual([
+		{
+			id: 'identity-disabled',
+			status: 'disabled',
+			verified_at: null,
+		},
+		{
+			id: 'identity-pending',
+			status: 'pending',
+			verified_at: null,
+		},
+		{
+			id: 'identity-verified',
+			status: 'verified',
+			verified_at: '2026-07-01T02:00:00.000Z',
+		},
+	])
+
+	applyMigrationLikeD1(db, verifiedOnlyMigration)
+
+	expect(senderIdentitiesTableSql(db)).toContain(
+		"status TEXT NOT NULL CHECK (status IN ('verified'))",
+	)
+	expect(senderIdentitiesTableSql(db)).not.toContain('pending')
+	expect(senderIdentitiesTableSql(db)).not.toContain('disabled')
+	expect(senderIdentityIndexes(db)).toEqual([...durableSenderIdentityIndexes])
+	expect(
+		db
+			.prepare(`SELECT sql FROM sqlite_master WHERE name LIKE '_mig0078_%'`)
+			.all(),
+	).toEqual([])
+	expect(
+		db
+			.prepare(
+				`SELECT sql FROM sqlite_master WHERE name = '__migration_assertions'`,
+			)
+			.all(),
+	).toEqual([])
+
+	expect(
+		db
+			.prepare(
+				`SELECT id, user_id, package_id, email, domain, display_name, status,
+					verified_at, created_at, updated_at
+				 FROM email_sender_identities
+				 ORDER BY id`,
+			)
+			.all(),
+	).toEqual([
+		{
+			id: 'identity-disabled',
+			user_id: 'stable-alice',
+			package_id: null,
+			email: 'disabled@inbox.example.com',
+			domain: 'inbox.example.com',
+			display_name: 'Disabled',
+			status: 'verified',
+			verified_at: '2026-07-01T01:00:00.000Z',
+			created_at: '2026-07-01T01:00:00.000Z',
+			updated_at: '2026-07-01T01:00:00.000Z',
+		},
+		{
+			id: 'identity-pending',
+			user_id: 'stable-alice',
+			package_id: null,
+			email: 'pending@inbox.example.com',
+			domain: 'inbox.example.com',
+			display_name: '',
+			status: 'verified',
+			verified_at: '2026-07-01T00:00:00.000Z',
+			created_at: '2026-07-01T00:00:00.000Z',
+			updated_at: '2026-07-01T00:00:00.000Z',
+		},
+		{
+			id: 'identity-verified',
+			user_id: 'stable-alice',
+			package_id: 'pkg-1',
+			email: 'alice@inbox.example.com',
+			domain: 'inbox.example.com',
+			display_name: 'Alice',
+			status: 'verified',
+			verified_at: '2026-07-01T02:00:00.000Z',
+			created_at: '2026-07-01T02:00:00.000Z',
+			updated_at: '2026-07-01T02:00:00.000Z',
+		},
+	])
+
+	expect(
+		db
+			.prepare(`SELECT id, sender_identity_id FROM email_messages ORDER BY id`)
+			.all(),
+	).toEqual([
+		{ id: 'message-disabled', sender_identity_id: 'identity-disabled' },
+		{ id: 'message-pending', sender_identity_id: 'identity-pending' },
+		{ id: 'message-unlinked', sender_identity_id: null },
+		{ id: 'message-verified', sender_identity_id: 'identity-verified' },
+	])
+
+	expect(
+		senderIdentityForeignKeys(db).some(
+			(foreignKey) =>
+				foreignKey.table === 'email_sender_identities' &&
+				foreignKey.from === 'sender_identity_id' &&
+				foreignKey.on_delete === 'SET NULL',
+		),
+	).toBe(true)
+	expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+
+	expect(() => {
+		db.prepare(
+			`INSERT INTO email_sender_identities (
+				id, user_id, email, domain, display_name, status, created_at, updated_at
+			) VALUES (?, ?, ?, ?, '', 'pending', ?, ?)`,
+		).run(
+			'identity-reject-pending',
+			'stable-alice',
+			'reject-pending@inbox.example.com',
+			'inbox.example.com',
+			'2026-07-02T00:00:00.000Z',
+			'2026-07-02T00:00:00.000Z',
+		)
+	}).toThrow(/CHECK constraint failed/)
+
+	expect(() => {
+		db.prepare(
+			`INSERT INTO email_sender_identities (
+				id, user_id, email, domain, display_name, status, created_at, updated_at
+			) VALUES (?, ?, ?, ?, '', 'disabled', ?, ?)`,
+		).run(
+			'identity-reject-disabled',
+			'stable-alice',
+			'reject-disabled@inbox.example.com',
+			'inbox.example.com',
+			'2026-07-02T00:00:00.000Z',
+			'2026-07-02T00:00:00.000Z',
+		)
+	}).toThrow(/CHECK constraint failed/)
+
+	db.prepare(
+		`INSERT INTO email_sender_identities (
+			id, user_id, email, domain, display_name, status, verified_at,
+			created_at, updated_at
+		) VALUES (?, ?, ?, ?, '', 'verified', ?, ?, ?)`,
+	).run(
+		'identity-new-verified',
+		'stable-alice',
+		'new@inbox.example.com',
+		'inbox.example.com',
+		'2026-07-02T00:00:00.000Z',
+		'2026-07-02T00:00:00.000Z',
+		'2026-07-02T00:00:00.000Z',
+	)
+	expect(
+		db
+			.prepare(`SELECT status FROM email_sender_identities WHERE id = ?`)
+			.get('identity-new-verified'),
+	).toEqual({ status: 'verified' })
+})
+
+test('email sender identities verified-only migration rolls back when rebuild linkage restore would be incomplete', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBeforeVerifiedOnly(db)
+	seedLegacySenderIdentities(db)
+
+	const beforeIdentities = db
+		.prepare(
+			`SELECT id, status, verified_at FROM email_sender_identities
+			 ORDER BY id`,
+		)
+		.all()
+	const beforeMessages = db
+		.prepare(`SELECT id, sender_identity_id FROM email_messages ORDER BY id`)
+		.all()
+
+	expect(() => {
+		db.exec('BEGIN')
+		try {
+			db.exec(`
+				UPDATE email_sender_identities
+				SET
+					status = 'verified',
+					verified_at = COALESCE(verified_at, created_at);
+
+				CREATE TABLE _mig0078_email_message_sender_refs AS
+				SELECT id AS message_id, sender_identity_id
+				FROM email_messages
+				WHERE sender_identity_id IS NOT NULL;
+
+				CREATE TABLE email_sender_identities_next (
+					id TEXT PRIMARY KEY,
+					user_id TEXT NOT NULL,
+					package_id TEXT,
+					email TEXT NOT NULL,
+					domain TEXT,
+					display_name TEXT NOT NULL DEFAULT '',
+					status TEXT NOT NULL CHECK (status IN ('verified')),
+					verified_at TEXT,
+					created_at TEXT NOT NULL,
+					updated_at TEXT NOT NULL
+				);
+
+				INSERT INTO email_sender_identities_next
+				SELECT * FROM email_sender_identities;
+
+				DROP TABLE email_sender_identities;
+				ALTER TABLE email_sender_identities_next
+				RENAME TO email_sender_identities;
+
+				CREATE TABLE __migration_assertions (
+					message TEXT NOT NULL CHECK (0)
+				);
+				INSERT INTO __migration_assertions (message)
+				SELECT 'forced abort before sender_identity_id restore';
+			`)
+			db.exec('COMMIT')
+		} catch (error) {
+			db.exec('ROLLBACK')
+			throw error
+		}
+	}).toThrow(/CHECK constraint failed: 0/)
+
+	expect(senderIdentitiesTableSql(db)).toContain(
+		"status TEXT NOT NULL CHECK (status IN ('pending', 'verified', 'disabled'))",
+	)
+	expect(
+		db
+			.prepare(
+				`SELECT id, status, verified_at FROM email_sender_identities
+				 ORDER BY id`,
+			)
+			.all(),
+	).toEqual(beforeIdentities)
+	expect(
+		db
+			.prepare(`SELECT id, sender_identity_id FROM email_messages ORDER BY id`)
+			.all(),
+	).toEqual(beforeMessages)
+	expect(
+		db
+			.prepare(`SELECT sql FROM sqlite_master WHERE name LIKE '_mig0078_%'`)
+			.all(),
+	).toEqual([])
+	expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+})

--- a/packages/worker/src/email/repo.ts
+++ b/packages/worker/src/email/repo.ts
@@ -503,13 +503,8 @@ async function getSenderIdentityByEmail(input: {
 /**
  * Ensure the platform-assigned sender identity row
  * (`{username}@<platform domain>`, status `verified`) exists for the user.
- * This is the only way sender identities are created: they are provisioned
- * by the platform, never self-registered or "verified" by users. Any
- * non-verified stored status is overwritten: identity status carries no
- * authorization meaning under the platform-assigned model (outbound is
- * gated by the verified-account check and the reserved-username block, not
- * by identity rows), so a legacy 'pending'/'disabled' row is just stale
- * bookkeeping to repair.
+ * Platform provisioning is the only writer; identities are always verified.
+ * Race-tolerant with signup / first-inbound concurrency via ON CONFLICT.
  */
 export async function ensurePlatformSenderIdentity(input: {
 	db: D1Database
@@ -518,7 +513,7 @@ export async function ensurePlatformSenderIdentity(input: {
 	domain: string
 }): Promise<EmailSenderIdentityRecord> {
 	const existing = await getSenderIdentityByEmail(input)
-	if (existing?.status === 'verified') return existing
+	if (existing) return existing
 	const timestamp = nowIso()
 	await input.db
 		.prepare(
@@ -527,8 +522,6 @@ export async function ensurePlatformSenderIdentity(input: {
 			) VALUES (?, ?, ?, ?, 'verified', ?, ?, ?)
 			ON CONFLICT(user_id, email) DO UPDATE SET
 				domain = excluded.domain,
-				status = excluded.status,
-				verified_at = excluded.verified_at,
 				updated_at = excluded.updated_at`,
 		)
 		.bind(

--- a/packages/worker/src/email/test-schema.ts
+++ b/packages/worker/src/email/test-schema.ts
@@ -21,7 +21,7 @@ export async function ensureEmailTestSchema(db: D1Database) {
 	email TEXT NOT NULL,
 	domain TEXT,
 	display_name TEXT NOT NULL DEFAULT '',
-	status TEXT NOT NULL CHECK (status IN ('pending', 'verified', 'disabled')),
+	status TEXT NOT NULL CHECK (status IN ('verified')),
 	verified_at TEXT,
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL

--- a/packages/worker/src/email/types.ts
+++ b/packages/worker/src/email/types.ts
@@ -92,7 +92,7 @@ export type EmailSenderIdentityRecord = {
 	userId: string
 	email: string
 	domain: string
-	status: 'pending' | 'verified' | 'disabled'
+	status: 'verified'
 	verifiedAt: string | null
 	createdAt: string
 	updatedAt: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize all sender identity statuses to `verified`
- rebuild the table with a verified-only CHECK while preserving message FK links
- narrow runtime types and provisioning logic to verified-only

## Validation
- D1 transaction test covers pending/disabled normalization, message-link restoration, indexes, FK integrity, rejection, rollback
- typecheck, migration ordering, focused tests passed

<!-- system-recap:start --><details><summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ab380636` · **Head:** `5e69070e`

**Classification:** extends — contracts sender identity state to platform-supported verified-only semantics.

**Invariant:** all `email_messages.sender_identity_id` references survive the D1 rebuild.
</details><!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e59f01b-ce4b-45f8-baaf-af79662c32a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e59f01b-ce4b-45f8-baaf-af79662c32a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Email sender identities are now consistently treated as verified.
  * Existing message associations with sender identities are preserved during the update.
  * Platform sender identity provisioning now avoids overwriting verification details.
* **Documentation**
  * Added documentation describing the sender identity storage migration and behavior.
* **Bug Fixes**
  * Added safeguards to prevent incomplete migrations from leaving email data inconsistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->