### PR TITLE
Add open source repo link on the home page

### DIFF
--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -221,6 +221,19 @@ export function HomeRoute(handle: Handle) {
 					prompts or your assistant&apos;s context. Every user is fully
 					isolated.
 				</p>
+
+				<p mix={css(openSourceLineCss)}>
+					Kody is{' '}
+					<a
+						href="https://github.com/kentcdodds/kody"
+						target="_blank"
+						rel="noreferrer noopener"
+						mix={css(openSourceLinkCss)}
+					>
+						open source
+					</a>
+					.
+				</p>
 			</section>
 		)
 	}
@@ -498,4 +511,15 @@ const trustLineCss = {
 	color: colors.textMuted,
 	fontSize: typography.fontSize.base,
 	lineHeight: 1.6,
+}
+
+const openSourceLineCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
+	lineHeight: 1.6,
+}
+
+const openSourceLinkCss = {
+	color: colors.primaryText,
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a simple open-source callout at the bottom of the home page with a link to the GitHub repository.

## Changes
- Footer line on `/`: “Kody is [open source](https://github.com/kentcdodds/kody).”
- Opens in a new tab with `rel="noreferrer noopener"`

## Verification
Confirmed via local SSR HTML and browser QA that the line renders at the bottom of `/` and links to `https://github.com/kentcdodds/kody`.

![Home page open source footer](https://cursor.com/artifacts/c/art-d6b38a81-18a5-4bcd-8756-9ff6ea9621cc)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `bc183102` · **Head:** `e12e9ef7`

**Classification:** composes — landing-page copy/link only; no primitive behavior or contracts changed.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### System map

Home page footer now surfaces the public GitHub repo URL.

```mermaid
flowchart LR
  visitor[Visitor on /] --> homeUi["app-ui<br/>HomeRoute"]
  homeUi -->|"open source link"| github[github.com/kentcdodds/kody]

  classDef composes fill:#d1fae5,stroke:#065f46,color:#064e3b
  class homeUi composes
```

**Legend:** green = composes (wiring only)

### Risk and invariants

- **Overall risk:** low
- **Invariants:** none involved (public marketing copy; no auth, storage, or isolation paths)

### Reviewer anchors

- `packages/worker/client/routes/home.tsx` — open-source footer line + link styles after the trust line

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-032eb236-22c0-456c-9c78-772af4dbc2b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-032eb236-22c0-456c-9c78-772af4dbc2b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Kody is open source” callout to the home page.
  * Included a link to the project’s GitHub repository with updated styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->