### PR TITLE
Replace nullable plans with explicit unlimited

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -96,7 +96,8 @@ The `invites` table stores operator-created invite codes:
   describe current invite state
 - `plan` (nullable, migration `0065-invite-plans.sql`) is an optional signup
   plan name; password and social signup copy a known value onto `users.plan`.
-  NULL keeps legacy/unlimited behavior. See [Entitlements](./entitlements.md).
+  Missing or NULL invite plans write `unlimited` at signup. See
+  [Entitlements](./entitlements.md).
 
 Production signup atomically consumes an invite with a single conditional
 `UPDATE ... WHERE use_count < max_uses AND revoked_at IS NULL ...`; concurrent

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -8,8 +8,8 @@ in `planLimits` remain independently configured placeholders.
 
 Module: `packages/worker/src/entitlements/`
 
-- `plans.ts` — plan names (`free`, `pro`, `partner`), the `PlanLimits` config
-  per plan, the `EntitlementResource` registry,
+- `plans.ts` — plan names (`free`, `pro`, `partner`, `unlimited`), the
+  `PlanLimits` config per plan, the `EntitlementResource` registry,
   `resolvePlanLimit(plan, resource)`, `getPlanRank`, and
   `resolveEffectivePlan(manual, stripe)`.
 - `errors.ts` — the one typed error (`EntitlementLimitError`) and the one
@@ -17,52 +17,87 @@ Module: `packages/worker/src/entitlements/`
 - `service.ts` — `getUserPlan`, `assertWithinEntitlement`, built-in D1 usage
   counters, and the daily-counter helpers for rate-style limits.
 
-## The NULL-plan invariant
+## Plan model
 
-`users.plan` is a nullable TEXT column (added by migration
-`0046-invites-email-verification.sql`). **NULL means legacy/unlimited**: nothing
-is enforced, and no counting query runs, for users without a plan. Unknown
-stored plan values are also treated as NULL so plan renames can never lock users
-out. Enforcement activates only when a known plan name is set.
+`users.plan` and `invites.plan` are nullable TEXT columns (added by migrations
+`0046-invites-email-verification.sql` and `0065-invite-plans.sql`). The plan
+registry in `plans.ts` includes `free`, `pro`, `partner`, and `unlimited`.
 
-A Stripe subscription never downgrades a NULL manual plan into enforcement:
-`resolveEffectivePlan` returns NULL whenever `users.plan` is NULL, regardless of
-`users.stripe_plan`. Legacy/unlimited accounts stay unlimited until an admin or
-invite assigns a manual plan.
+**Write and default:** new writers always persist a plan name (never NULL).
+`resolvePlanWrite` maps nullish inputs to `unlimited`, which is the default for
+new accounts, invites without an explicit plan, and admin plan resets. Nullish
+admin/API inputs (`null`, empty string, omitted invite plan) map to `unlimited`
+for backward compatibility.
 
-Exception: the email resources are abuse-sensitive and bind plan-less users to
-the `nullPlanEmailFallbackLimits` backstops from `plans.ts` instead of unlimited
-— outbound sends (`email_sends_per_day`) because sending is an outreach-abuse
-surface, and the inbound resources (`email_receives_per_day`,
-`stored_email_messages`, `email_message_bytes`) because inbound volume is
-attacker-controlled (anyone can send to a `{username}@<platform domain>`
-address). Use `resolveEmailResourceLimit` to read the effective limit for those
-resources.
+The **`unlimited` plan** gives ordinary resources uncapped limits (`null` in
+`planLimits`), uses deployment-level email backstops
+(`nullPlanEmailFallbackLimits`), and keeps the workflow concurrency env global
+backstop (`maxConcurrentWorkflows: null` plus `fallbackLimit`).
+
+`users.stripe_plan` stays nullable because it is Stripe-derived; `unlimited` is
+manual-only and never written from Stripe (`parseStripePlanName` rejects it).
+
+`resolveEffectivePlan(manual, stripe)` returns the higher-ranked manual and
+Stripe plans when manual resolves to a recognized name; manual `unlimited`
+always wins over Stripe. When `parsePlanName(users.plan)` is null (stored NULL
+or an unrecognized string), effective plan is null and ordinary resources stay
+fail-open; a Stripe subscription never downgrades such an account into
+enforcement.
+
+Exception: the email resources are abuse-sensitive and bind the `unlimited` plan
+(and other accounts whose effective plan is null) to the
+`nullPlanEmailFallbackLimits` backstops from `plans.ts` instead of uncapped
+inbound/outbound mail — outbound sends (`email_sends_per_day`) because sending
+is an outreach-abuse surface, and the inbound resources
+(`email_receives_per_day`, `stored_email_messages`, `email_message_bytes`)
+because inbound volume is attacker-controlled (anyone can send to a
+`{username}@<platform domain>` address). Use `resolveEmailResourceLimit` to read
+the effective limit for those resources.
+
+## Rollout sequencing
+
+Migration `0080-backfill-unlimited-plan.sql` backfills existing `users.plan` and
+`invites.plan` NULL rows to `'unlimited'`. Nullable columns remain until a later
+NOT NULL stage. During that compatibility window, stored NULL and unknown plan
+strings still parse as null via `parsePlanName` and retain fail-open behavior so
+plan renames cannot lock users out. Enforcement activates only when a recognized
+plan name is resolved.
+
+**Deployment ordering:** production deploys apply D1 migrations before Worker
+code (`.github/workflows/deploy.yml`: `🗄️ Apply D1 Migrations`, then
+`☁️ Deploy to Cloudflare Workers`). On a NOT NULL stage deploy, the new Worker
+that writes `unlimited` instead of NULL can run while columns are still
+nullable, so rows written during that window may still contain NULL. The NOT
+NULL migration must reconcile or verify those residual NULLs (backfill or abort)
+before rebuilding the column NOT NULL.
 
 ## Assigning plans
 
-New accounts start with `users.plan = NULL` (legacy/unlimited plus the email
-backstops above) unless the consumed invite carries a plan. Migration
+New accounts start with `users.plan = 'unlimited'` (plus the email backstops
+above) unless the consumed invite carries another plan. Migration
 `0065-invite-plans.sql` adds nullable `invites.plan`. Password and social signup
 apply that value to the new `users.plan` when present (validated with
-`parsePlanName`); a NULL invite plan keeps today's legacy/unlimited behavior.
-Admins set invite plans when creating codes at `/admin/invites`.
+`parsePlanName`); missing or NULL invite plans write `unlimited`. Admins set
+invite plans when creating codes at `/admin/invites`.
 
-Admins also assign or clear plans on existing users through two audited,
+Admins also assign or reset plans on existing users through two audited,
 admin-only surfaces, both backed by `updateAdminUserPlan` in
 `packages/worker/src/app/admin-users-data.ts`:
 
 - **Admin UI** — the "Manage plan" panel on `/admin/users` posts
   `{ action: 'update_plan', userId, plan }` to `POST /admin/users.json` (guarded
-  by `update:user:any`). `plan: null` clears the plan; unknown plan strings are
-  rejected with `400` rather than coerced to null.
+  by `update:user:any`). `plan: null` maps to `unlimited` (writers never persist
+  NULL); unknown plan strings are rejected with `400` rather than coerced to
+  null.
 - **MCP** — the `admin_user_update` capability (`requiredRole: 'admin'`) updates
-  one user by `id` or `email` and accepts `plan: PlanName | null`.
+  one user by `id` or `email` and accepts `plan: PlanName | null` (null maps to
+  `unlimited`).
 
 Both paths validate against the plan registry (`parsePlanName` / `planNames`)
 and write an `admin`-category audit event with reason `target_user_id=…;plan=…`.
-Because daily counters accumulate even for plan-less users, assigning a plan
-later binds immediately against the usage already counted that day.
+Because daily counters accumulate even when effective plan is null
+(compatibility fail-open), assigning a recognized plan later binds immediately
+against the usage already counted that day.
 
 Paid upgrades via Stripe write `users.stripe_plan` (not `users.plan`); see
 [Billing](#billing). Effective entitlement uses the higher-ranked of the two
@@ -74,17 +109,18 @@ The MCP `userId` is the account's stored `users.stable_user_id` (NOT NULL,
 unique index; initially from `createStableUserIdFromEmail` at signup, then
 preserved across email changes). `getUserPlan(db, { userId, email })`:
 
-1. Normalizes the email and returns null (unlimited) when email or `userId` is
+1. Normalizes the email and returns null (fail-open) when email or `userId` is
    absent.
 2. Returns null without touching D1 when `userId` is not a 64-char hex string.
    Synthetic runtime contexts (package-scoped caller contexts with `email: ''`,
    workflow-internal users, test fixtures) therefore fail open / stay unlimited.
 3. Reads
    `SELECT plan, stripe_plan FROM users WHERE email = ? AND stable_user_id = ?`
-   and returns `resolveEffectivePlan(parsePlanName(plan), stripe_plan)`: NULL
-   manual plan stays unlimited; otherwise the higher-ranked of manual
-   `users.plan` and `users.stripe_plan` (rank: `free` < `pro` < `partner`). A
-   mismatched email/stable-id pair returns null (unlimited) intentionally.
+   and returns `resolveEffectivePlan(parsePlanName(plan), stripe_plan)`: stored
+   NULL or unrecognized strings fail open; otherwise the higher-ranked of manual
+   `users.plan` and `users.stripe_plan` (rank: `free` < `pro` < `partner` <
+   `unlimited`). A mismatched email/stable-id pair returns null (fail-open)
+   intentionally.
 
 Consequence: enforcement points must have the acting user's account email
 available. Both auth surfaces provide it — app sessions expose
@@ -149,17 +185,18 @@ Rules:
   `entitlement_daily_counters` table keyed by `(user_id, resource, day)` with
   UTC day keys. Call `consumeDailyEntitlement` on every attempt: it checks the
   plan limit and increments the counter in one conditional D1 upsert (no
-  check-then-increment race), and still increments (uncapped) for users without
-  a plan so counters reflect real usage the moment a plan is assigned — unless
-  the caller passes `fallbackLimit`, which caps plan-less users with a
-  deployment-level backstop (both email sends and receives do this). Counting
-  attempts rather than successes keeps the limit abuse-resistant for permanent
-  rejects (parse failures, entitlement/quota rejects). Only typed pre-commit
-  `RetryableInboundStorageError` failures (thread prework, R2 put, D1
-  message/attachment storage after successful cleanup) refund exactly one
-  `email_receives_per_day` unit via `refundDailyEntitlement` for the same UTC
-  day that was charged, so Cloudflare Email Routing retries do not burn the
-  daily receive quota. Post-commit bookkeeping failures do not refund or retry.
+  check-then-increment race), and still increments (uncapped) when effective
+  plan is null so counters reflect real usage the moment a recognized plan is
+  assigned — unless the caller passes `fallbackLimit`, which caps accounts whose
+  effective plan is null with a deployment-level backstop (both email sends and
+  receives do this). Counting attempts rather than successes keeps the limit
+  abuse-resistant for permanent rejects (parse failures, entitlement/quota
+  rejects). Only typed pre-commit `RetryableInboundStorageError` failures
+  (thread prework, R2 put, D1 message/attachment storage after successful
+  cleanup) refund exactly one `email_receives_per_day` unit via
+  `refundDailyEntitlement` for the same UTC day that was charged, so Cloudflare
+  Email Routing retries do not burn the daily receive quota. Post-commit
+  bookkeeping failures do not refund or retry.
   `incrementDailyEntitlementCounter` remains for raw counter writes (tests,
   backfills).
 - **Boolean allowances** (persistent package services) are modeled as limit `0`
@@ -183,7 +220,7 @@ Rules:
   documented in `data-storage.md`.
 
 Because the plan check happens before any counting, enforcement adds zero
-counting overhead for NULL-plan users.
+counting overhead when effective plan is null (compatibility fail-open).
 
 ### Concurrency
 
@@ -222,10 +259,11 @@ The exemplar is job scheduling: `createJob` in
    })
    ```
 
-   Use `fallbackLimit` only for global backstops that must bind plan-less users
-   (the workflow concurrency limit absorbed the `WORKFLOW_CONCURRENT_LIMIT` env
-   var this way via `getWorkflowConcurrencyBackstop`, and the email resources
-   cap plan-less users via `nullPlanEmailFallbackLimits`).
+   Use `fallbackLimit` only for global backstops that must bind accounts whose
+   effective plan is null (the workflow concurrency limit absorbed the
+   `WORKFLOW_CONCURRENT_LIMIT` env var this way via
+   `getWorkflowConcurrencyBackstop`, and the email resources cap `unlimited` and
+   compatibility fail-open users via `nullPlanEmailFallbackLimits`).
    `consumeDailyEntitlement` accepts the same `fallbackLimit` for daily rate
    resources. Use `getCurrent` only when the built-in D1 counter cannot express
    the resource.
@@ -236,10 +274,10 @@ The exemplar is job scheduling: `createJob` in
    in `service.ts` when it is D1-countable.
 5. Test both sides: a plan user at the limit is denied with
    `details.code === 'entitlement_limit_exceeded'` (assert `resource`, `plan`,
-   `limit`, `current`), and a NULL-plan user is unaffected. Build the test
-   user's id with `createStableUserIdFromEmail(email)` (or any stored
+   `limit`, `current`), and a compatibility fail-open user is unaffected. Build
+   the test user's id with `createStableUserIdFromEmail(email)` (or any stored
    `stable_user_id`) and assert plan lookup against the email + stable-id pair;
-   a mismatched pair must resolve as unlimited.
+   a mismatched pair must resolve as fail-open.
 
 ## Enforcement points
 
@@ -250,12 +288,12 @@ The exemplar is job scheduling: `createJob` in
 | `package_services`            | `service_start` capability path                                                                                                |
 | `persistent_package_services` | `service_start` for services declared `mode: 'persistent'`                                                                     |
 | `repo_sessions`               | `repo_open_session` before creating a new session                                                                              |
-| `email_sends_per_day`         | `sendOutboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan backstop)                                                     |
-| `email_receives_per_day`      | `handleInboundEmail` (atomic `consumeDailyEntitlement`, NULL-plan fallback; refund only on `RetryableInboundStorageError`)     |
-| `stored_email_messages`       | `handleInboundEmail` before storage (NULL-plan fallback)                                                                       |
-| `email_message_bytes`         | `handleInboundEmail` before quota/parse (per-message raw size, NULL-plan fallback)                                             |
+| `email_sends_per_day`         | `sendOutboundEmail` (atomic `consumeDailyEntitlement`, email backstop)                                                         |
+| `email_receives_per_day`      | `handleInboundEmail` (atomic `consumeDailyEntitlement`, email backstop; refund only on `RetryableInboundStorageError`)         |
+| `stored_email_messages`       | `handleInboundEmail` before storage (email backstop)                                                                           |
+| `email_message_bytes`         | `handleInboundEmail` before quota/parse (per-message raw size, email backstop)                                                 |
 | `secrets`                     | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts`                                               |
-| `concurrent_workflows`        | `createDynamicCallableWorkflow` (plan limit, env-var backstop for NULL plan)                                                   |
+| `concurrent_workflows`        | `createDynamicCallableWorkflow` (plan limit, env-var backstop for `unlimited` and compatibility fail-open)                     |
 | `storage_bytes`               | D1 payload writes (values, secrets, memories, saved-package projections, email storage) and StorageRunner write tools/app RPCs |
 
 ## Billing
@@ -287,13 +325,18 @@ in [`../environment-variables.md`](../environment-variables.md).
 
 - `users.plan` — added by the invite-signup migration
   (`0046-invites-email-verification.sql`); the entitlements module is the
-  consumer of that column (manual / invite / admin grant).
+  consumer of that column (manual / invite / admin grant). Writers default to
+  `unlimited`; migration `0080-backfill-unlimited-plan.sql` materializes
+  historical NULL rows.
 - `invites.plan` — nullable signup plan from migration `0065-invite-plans.sql`;
-  applied to `users.plan` when the invite is consumed at signup.
+  applied to `users.plan` when the invite is consumed at signup (missing/NULL
+  invite plans write `unlimited`). Migration `0080-backfill-unlimited-plan.sql`
+  materializes historical NULL rows.
 - `users.stripe_customer_id`, `users.stripe_plan`,
   `users.stripe_plan_refreshed_at` — Stripe billing columns from migration
   `0066-stripe-billing.sql`; owned by `packages/worker/src/billing/`, read by
-  `getUserPlan` via `resolveEffectivePlan`.
+  `getUserPlan` via `resolveEffectivePlan`. `stripe_plan` stays nullable because
+  it is Stripe-derived; `unlimited` is manual-only.
 - `entitlement_daily_counters` — rate counters, created by migration
   `0048-user-plans-and-entitlement-counters.sql`; included in the
   account-deletion cascade (`packages/worker/src/app/account-deletion.ts`).

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -22,7 +22,7 @@ to become.
   routes, and the `any`-access exception to per-user isolation.
 - [Entitlements](./entitlements.md): per-user plans (`users.plan`), per-plan
   resource limits, and the shared `assertWithinEntitlement` enforcement helper
-  (NULL plan = legacy/unlimited).
+  (`unlimited` default; nullish admin inputs map to `unlimited`).
 - [Feature Flags](./feature-flags.md): code-registry flags with D1-backed global
   state, percentage rollouts, and per-user overrides, managed at
   `/admin/feature-flags`.

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -79,8 +79,8 @@ Inbound storage is quota-gated per user:
   storage failures (for example an R2 outage while saving raw MIME) do not keep
   the daily receive charge — the attempt is refunded so delivery retries are not
   blocked by quota.
-- Plan users get their plan's limits; users without a plan get conservative
-  deployment fallbacks (they are not unlimited for inbound mail).
+- Plan users get their plan's limits; the `unlimited` plan uses conservative
+  deployment email backstops (inbound mail is never uncapped).
 - Quota, size, and unverified-account rejections store at most five detailed
   `rejected` delivery events per inbox per UTC day; further rejections increment
   a single daily aggregate event (with a total count and the last reason) so
@@ -108,7 +108,7 @@ Inbound storage is quota-gated per user:
   platform-assigned address, and `email_send` only delivers to the signed-in
   user's own account email. `email_reply` is the only way to address external
   recipients, and only recipients taken from stored inbound mail.
-- Outbound sends consume a per-day entitlement. Users without a plan are capped
+- Outbound sends consume a per-day entitlement. The `unlimited` plan is capped
   by a global daily backstop instead of sending unlimited mail.
 - A successful send request has `processing_status: "sent"`. Cloudflare delivery
   events independently populate `delivery_status` with `delivered`, `deferred`,

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -210,6 +210,10 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 
 	const planSelect = page.getByLabel('Plan')
 	await expect(planSelect).toHaveValue('unlimited')
+	await expect(planSelect.getByRole('option')).toHaveCount(4)
+	await expect(
+		planSelect.getByRole('option', { name: 'unlimited', exact: true }),
+	).toHaveCount(1)
 	await planSelect.selectOption('pro')
 	await page.getByRole('button', { name: 'Save plan' }).click()
 	await expect(planSelect).toHaveValue('pro')

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -145,7 +145,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 		(user: { email: string }) => user.email === memberUser.email,
 	)
 	expect(memberRecord).toBeTruthy()
-	expect(memberRecord.plan).toBe(null)
+	expect(memberRecord.plan).toBe('unlimited')
 	expect(JSON.stringify(memberRecord)).not.toContain('memberPrivateSecret')
 	expect(JSON.stringify(memberRecord)).not.toContain('super-secret-value')
 
@@ -196,7 +196,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await expect(page.getByText('Account metadata only')).toBeVisible()
 
 	const planSelect = page.getByLabel('Plan')
-	await expect(planSelect).toHaveValue('')
+	await expect(planSelect).toHaveValue('unlimited')
 	await planSelect.selectOption('pro')
 	await page.getByRole('button', { name: 'Save plan' }).click()
 	await expect(planSelect).toHaveValue('pro')

--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -1,3 +1,5 @@
+import type { ConsoleMessage } from '@playwright/test'
+
 import { expect, test } from './playwright-utils.ts'
 
 test('admin RBAC controls access, role assignment, and privacy boundaries', async ({
@@ -191,7 +193,18 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	expect(JSON.stringify(insightsPayload)).not.toContain('super-secret-value')
 	expect(JSON.stringify(insightsPayload)).not.toContain(memberUser.email)
 
-	await page.goto(`/admin/users?q=rbac-${runId}`)
+	const clientConsoleProblems: Array<string> = []
+	const captureClientConsoleProblems = (message: ConsoleMessage) => {
+		if (message.type() === 'warning' || message.type() === 'error') {
+			clientConsoleProblems.push(`${message.type()}: ${message.text()}`)
+		}
+	}
+	page.on('console', captureClientConsoleProblems)
+
+	// Return through SPA navigation so the plan select is hydrated from loader
+	// data rather than relying on a fresh document load.
+	await page.getByRole('link', { name: 'Users', exact: true }).click()
+	await usersSearchInput.fill(`rbac-${runId}`)
 	await page.getByRole('button', { name: memberUser.username }).click()
 	await expect(page.getByText('Account metadata only')).toBeVisible()
 
@@ -200,6 +213,9 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	await planSelect.selectOption('pro')
 	await page.getByRole('button', { name: 'Save plan' }).click()
 	await expect(planSelect).toHaveValue('pro')
+	await expect(
+		page.getByText('Updated plan to pro.', { exact: true }),
+	).toBeVisible()
 	const planApiResponse = await page.request.get(
 		`/admin/users.json?q=rbac-${runId}`,
 	)
@@ -209,6 +225,24 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 		(user: { email: string }) => user.email === memberUser.email,
 	)
 	expect(memberAfterPlan.plan).toBe('pro')
+
+	await planSelect.selectOption('unlimited')
+	await page.getByRole('button', { name: 'Save plan' }).click()
+	await expect(planSelect).toHaveValue('unlimited')
+	await expect(
+		page.getByText('Updated plan to unlimited.', { exact: true }),
+	).toBeVisible()
+	const unlimitedPlanApiResponse = await page.request.get(
+		`/admin/users.json?q=rbac-${runId}`,
+	)
+	expect(unlimitedPlanApiResponse.ok()).toBe(true)
+	const unlimitedPlanPayload = await unlimitedPlanApiResponse.json()
+	const memberAfterUnlimitedPlan = unlimitedPlanPayload.users.find(
+		(user: { email: string }) => user.email === memberUser.email,
+	)
+	expect(memberAfterUnlimitedPlan.plan).toBe('unlimited')
+	expect(clientConsoleProblems).toEqual([])
+	page.off('console', captureClientConsoleProblems)
 
 	// Mutations under an active role filter: removing the filtered role must
 	// drop the row from the list and shrink the filtered total in place.

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -64,7 +64,7 @@ const planTiers: Array<{
 	},
 ]
 
-/** Mirrors server rank: free < pro < partner. */
+/** Mirrors server rank: free < pro < partner < unlimited. */
 function getPlanRank(plan: AdminPlanName): number {
 	switch (plan) {
 		case 'free':
@@ -73,6 +73,8 @@ function getPlanRank(plan: AdminPlanName): number {
 			return 1
 		case 'partner':
 			return 2
+		case 'unlimited':
+			return 3
 		default: {
 			const exhaustive: never = plan
 			throw new Error(`Unknown plan: ${String(exhaustive)}`)
@@ -85,7 +87,7 @@ function isBillingPath(href: string) {
 }
 
 function formatPlanLabel(plan: AdminPlanName | null) {
-	if (plan == null) return 'Legacy / unlimited'
+	if (plan == null || plan === 'unlimited') return 'Unlimited'
 	return plan.charAt(0).toUpperCase() + plan.slice(1)
 }
 
@@ -100,7 +102,7 @@ function planCoversTier(
 	effectivePlan: AdminPlanName | null,
 	tier: PlanTier,
 ): boolean {
-	if (effectivePlan == null) return true
+	if (effectivePlan == null || effectivePlan === 'unlimited') return true
 	return getPlanRank(effectivePlan) >= getPlanRank(tier)
 }
 

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -86,8 +86,13 @@ function isBillingPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === billingPath
 }
 
-function formatPlanLabel(plan: AdminPlanName | null) {
-	if (plan == null || plan === 'unlimited') return 'Unlimited'
+/** Stripe missing → "None"; manual/effective compatibility missing → "Unlimited". */
+function formatPlanLabel(
+	plan: AdminPlanName | null,
+	missingLabel: 'None' | 'Unlimited',
+) {
+	if (plan == null) return missingLabel
+	if (plan === 'unlimited') return 'Unlimited'
 	return plan.charAt(0).toUpperCase() + plan.slice(1)
 }
 
@@ -243,11 +248,11 @@ export function AccountBillingRoute(handle: Handle) {
 				? [
 						{
 							label: 'Granted plan',
-							value: formatPlanLabel(billing.manualPlan),
+							value: formatPlanLabel(billing.manualPlan, 'Unlimited'),
 						},
 						{
 							label: 'Subscription plan',
-							value: formatPlanLabel(billing.stripePlan),
+							value: formatPlanLabel(billing.stripePlan, 'None'),
 						},
 					]
 				: []
@@ -292,7 +297,7 @@ export function AccountBillingRoute(handle: Handle) {
 									color: colors.text,
 								})}
 							>
-								{formatPlanLabel(billing.effectivePlan)}
+								{formatPlanLabel(billing.effectivePlan, 'Unlimited')}
 							</p>
 							{currentPlanItems.length > 0 ? (
 								<MetadataGrid items={currentPlanItems} />

--- a/packages/worker/client/routes/admin-invites.tsx
+++ b/packages/worker/client/routes/admin-invites.tsx
@@ -394,8 +394,12 @@ export function AdminInvitesRoute(handle: Handle) {
 						</label>
 						<label mix={css(fieldCss)}>
 							<span mix={css(fieldLabelCss)}>Plan</span>
-							<select name="plan" disabled={isMutating} mix={css(inputCss)}>
-								<option value="">Legacy / unlimited</option>
+							<select
+								name="plan"
+								disabled={isMutating}
+								defaultValue="unlimited"
+								mix={css(inputCss)}
+							>
 								{availablePlans.map((plan) => (
 									<option key={plan} value={plan}>
 										{plan}
@@ -494,7 +498,7 @@ export function AdminInvitesRoute(handle: Handle) {
 										},
 										{
 											label: 'Plan',
-											value: invite.plan ?? 'Legacy / unlimited',
+											value: invite.plan ?? 'unlimited',
 										},
 										{
 											label: 'Expires',

--- a/packages/worker/client/routes/admin-invites.tsx
+++ b/packages/worker/client/routes/admin-invites.tsx
@@ -248,6 +248,9 @@ export function AdminInvitesRoute(handle: Handle) {
 			handle.queueTask(loadInvites)
 		}
 		const isMutating = actionState !== 'idle'
+		// Plan options arrive with loader data; disable create until then so an
+		// empty <select> cannot submit plan="" before Unlimited is available.
+		const inviteFormDisabled = isMutating || availablePlans.length === 0
 
 		return (
 			<AccountManagementShell>
@@ -367,7 +370,7 @@ export function AdminInvitesRoute(handle: Handle) {
 								name="code"
 								type="text"
 								placeholder="Optional"
-								disabled={isMutating}
+								disabled={inviteFormDisabled}
 								mix={css(inputCss)}
 							/>
 						</label>
@@ -377,7 +380,7 @@ export function AdminInvitesRoute(handle: Handle) {
 								name="note"
 								type="text"
 								placeholder="Cohort or recipient"
-								disabled={isMutating}
+								disabled={inviteFormDisabled}
 								mix={css(inputCss)}
 							/>
 						</label>
@@ -388,7 +391,7 @@ export function AdminInvitesRoute(handle: Handle) {
 								type="number"
 								min="1"
 								defaultValue="1"
-								disabled={isMutating}
+								disabled={inviteFormDisabled}
 								mix={css(inputCss)}
 							/>
 						</label>
@@ -396,7 +399,7 @@ export function AdminInvitesRoute(handle: Handle) {
 							<span mix={css(fieldLabelCss)}>Plan</span>
 							<select
 								name="plan"
-								disabled={isMutating}
+								disabled={inviteFormDisabled}
 								defaultValue="unlimited"
 								mix={css(inputCss)}
 							>
@@ -412,13 +415,13 @@ export function AdminInvitesRoute(handle: Handle) {
 							<input
 								name="expiresAt"
 								type="datetime-local"
-								disabled={isMutating}
+								disabled={inviteFormDisabled}
 								mix={css(inputCss)}
 							/>
 						</label>
 						<button
 							type="submit"
-							disabled={isMutating}
+							disabled={inviteFormDisabled}
 							mix={css(primaryButtonCss)}
 						>
 							{actionState === 'creating' ? 'Creating…' : 'Create'}

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -146,9 +146,9 @@ export function AdminUsersRoute(handle: Handle) {
 	let message: string | null = null
 	let actionState: 'idle' | 'assigning' | 'removing' | 'saving-plan' = 'idle'
 	let selectedRoleToAssign = 'user' as RoleName
-	// '' represents the NULL plan (legacy/unlimited). The draft follows the
-	// selected user (see the render body) until the admin edits it.
-	let selectedPlanChoice: AdminPlanName | '' = ''
+	// Draft follows the selected user (see the render body) until the admin
+	// edits it. Null stored plan values are shown/saved as `unlimited`.
+	let selectedPlanChoice: AdminPlanName = 'unlimited'
 	let planDraftUserId: number | null = null
 	let loadRequestId = 0
 	let lastLoadedHref = ''
@@ -435,7 +435,7 @@ export function AdminUsersRoute(handle: Handle) {
 	async function submitPlanAction() {
 		const selectedUser = getSelectedUser()
 		if (!selectedUser || actionState !== 'idle') return
-		const plan = selectedPlanChoice === '' ? null : selectedPlanChoice
+		const plan = selectedPlanChoice
 		actionState = 'saving-plan'
 		message = null
 		handle.update()
@@ -471,7 +471,7 @@ export function AdminUsersRoute(handle: Handle) {
 			invalidateUsage()
 			selectedUserId = selectedUser.id
 			lastLoadedHref = readCurrentRouterHref(handle)
-			message = `Updated plan to ${plan ?? 'Legacy / unlimited'}.`
+			message = `Updated plan to ${plan}.`
 			status = 'ready'
 			actionState = 'idle'
 			handle.update()
@@ -560,7 +560,7 @@ export function AdminUsersRoute(handle: Handle) {
 		// the select always starts from that user's stored plan.
 		if (selectedUser && selectedUser.id !== planDraftUserId) {
 			planDraftUserId = selectedUser.id
-			selectedPlanChoice = selectedUser.plan ?? ''
+			selectedPlanChoice = selectedUser.plan ?? 'unlimited'
 		}
 
 		return (
@@ -753,7 +753,7 @@ export function AdminUsersRoute(handle: Handle) {
 										},
 										{
 											label: 'Plan',
-											value: selectedUser.plan ?? 'Legacy / unlimited',
+											value: selectedUser.plan ?? 'unlimited',
 										},
 										{
 											label: 'Created',
@@ -840,15 +840,13 @@ export function AdminUsersRoute(handle: Handle) {
 												aria-label="Plan"
 												mix={[
 													on('change', (event) => {
-														selectedPlanChoice = event.currentTarget.value as
-															| AdminPlanName
-															| ''
+														selectedPlanChoice = event.currentTarget
+															.value as AdminPlanName
 														handle.update()
 													}),
 													css(inputCss),
 												]}
 											>
-												<option value="">Legacy / unlimited</option>
 												{availablePlans.map((plan) => (
 													<option key={plan} value={plan}>
 														{plan}
@@ -860,7 +858,8 @@ export function AdminUsersRoute(handle: Handle) {
 											type="button"
 											disabled={
 												isMutating ||
-												selectedPlanChoice === (selectedUser.plan ?? '')
+												selectedPlanChoice ===
+													(selectedUser.plan ?? 'unlimited')
 											}
 											mix={[
 												on('click', () => void submitPlanAction()),

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -848,7 +848,11 @@ export function AdminUsersRoute(handle: Handle) {
 												]}
 											>
 												{availablePlans.map((plan) => (
-													<option key={plan} value={plan}>
+													<option
+														key={plan}
+														value={plan}
+														selected={plan === selectedPlanChoice}
+													>
 														{plan}
 													</option>
 												))}

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -835,7 +835,6 @@ export function AdminUsersRoute(handle: Handle) {
 										<label mix={css(fieldCss)}>
 											<span mix={css(fieldLabelCss)}>Plan</span>
 											<select
-												value={selectedPlanChoice}
 												disabled={isMutating}
 												aria-label="Plan"
 												mix={[

--- a/packages/worker/migrations/0080-backfill-unlimited-plan.sql
+++ b/packages/worker/migrations/0080-backfill-unlimited-plan.sql
@@ -1,0 +1,33 @@
+-- Stage 1: materialize stored NULL plans as the explicit sentinel 'unlimited'
+-- on users.plan and invites.plan.
+--
+-- Behavior invariant: no existing account gains new ordinary entitlement
+-- enforcement. `unlimited` is a first-class plan name; ordinary resources stay
+-- uncapped, email resources keep the historical nullPlanEmailFallbackLimits
+-- backstops, and concurrent workflows keep the env global backstop. Residual
+-- stored NULL and unknown plan strings still dual-read as fail-open until
+-- stage 2. Stripe never downgrades a stored-NULL account into enforcement, so
+-- this migration intentionally does not touch users.stripe_plan.
+--
+-- Stage 1 does not make plan NOT NULL and does not rebuild tables.
+--
+-- Fail-closed: residual NULLs abort the migration (D1 wraps each file in a
+-- transaction and rolls it back).
+
+UPDATE users SET plan = 'unlimited' WHERE plan IS NULL;
+UPDATE invites SET plan = 'unlimited' WHERE plan IS NULL;
+
+-- __migration_assertions intentionally uses CHECK (0) as an unreachable trap.
+CREATE TABLE __migration_assertions (
+	message TEXT NOT NULL CHECK (0)
+);
+
+INSERT INTO __migration_assertions (message)
+SELECT 'users.plan still contains NULL after unlimited backfill; aborting 0080.'
+WHERE EXISTS (SELECT 1 FROM users WHERE plan IS NULL);
+
+INSERT INTO __migration_assertions (message)
+SELECT 'invites.plan still contains NULL after unlimited backfill; aborting 0080.'
+WHERE EXISTS (SELECT 1 FROM invites WHERE plan IS NULL);
+
+DROP TABLE __migration_assertions;

--- a/packages/worker/src/app/account-billing-data.ts
+++ b/packages/worker/src/app/account-billing-data.ts
@@ -6,6 +6,7 @@ import {
 import { refreshStripePlanForUser } from '#worker/billing/subscription-sync.ts'
 import {
 	parsePlanName,
+	parseStripePlanName,
 	resolveEffectivePlan,
 	type PlanName,
 } from '#worker/entitlements/plans.ts'
@@ -61,7 +62,7 @@ export async function loadAccountBillingData(input: {
 		.first<BillingUserRow>()
 
 	const manualPlan: PlanName | null = parsePlanName(row?.plan)
-	let stripePlan: PlanName | null = parsePlanName(row?.stripe_plan)
+	let stripePlan: PlanName | null = parseStripePlanName(row?.stripe_plan)
 	let cancelAt: string | null = null
 	const customerId = row?.stripe_customer_id?.trim() || null
 	const hasStripeCustomer = Boolean(customerId)

--- a/packages/worker/src/app/admin-user-creation.node.test.ts
+++ b/packages/worker/src/app/admin-user-creation.node.test.ts
@@ -8,6 +8,7 @@ type TestUser = {
 	email: string
 	password_hash: string
 	email_verified_at: string | null
+	plan: string | null
 }
 
 type TestPasswordReset = {
@@ -72,12 +73,18 @@ function createAdminUserCreationTestDb(initialUsers: Array<TestUser> = []) {
 								) {
 									throw new Error('UNIQUE constraint failed: users.username')
 								}
+								const plan =
+									normalizedQuery.includes(', plan)') &&
+									normalizedQuery.includes("'unlimited'")
+										? 'unlimited'
+										: null
 								const user = {
 									id: nextId,
 									username: String(username),
 									email: String(email),
 									password_hash: String(passwordHash),
 									email_verified_at: String(emailVerifiedAt),
+									plan,
 								}
 								nextId += 1
 								users.set(user.id, user)
@@ -130,6 +137,7 @@ test('adminCreateUserWithPasswordSetup rejects duplicate email', async () => {
 			email: 'existing@example.com',
 			password_hash: 'hash',
 			email_verified_at: new Date(0).toISOString(),
+			plan: 'unlimited',
 		},
 	])
 
@@ -172,6 +180,7 @@ test('adminCreateUserWithPasswordSetup creates verified user and seven-day setup
 		username: 'person-launch',
 		email_verified_at: now.toISOString(),
 		password_hash: 'admin_created_no_usable_password',
+		plan: 'unlimited',
 	})
 	expect(passwordResets.get(created.userId)?.expires_at).toBe(
 		now.getTime() + adminPasswordSetupTokenExpiryMs,

--- a/packages/worker/src/app/admin-user-creation.ts
+++ b/packages/worker/src/app/admin-user-creation.ts
@@ -111,8 +111,8 @@ export async function adminCreateUserWithPasswordSetup(input: {
 	try {
 		const result = await input.db
 			.prepare(
-				`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
-				 VALUES (?, ?, ?, ?, ?)`,
+				`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, plan)
+				 VALUES (?, ?, ?, ?, ?, 'unlimited')`,
 			)
 			.bind(
 				username,

--- a/packages/worker/src/app/admin-users-data.ts
+++ b/packages/worker/src/app/admin-users-data.ts
@@ -5,6 +5,7 @@ import { type RoleName, roleNames } from '#app/permissions.ts'
 import {
 	parsePlanName,
 	planNames,
+	resolvePlanWrite,
 	type PlanName,
 } from '#worker/entitlements/plans.ts'
 import {
@@ -160,9 +161,9 @@ export async function loadAdminUserByIdOrEmail(
 }
 
 /**
- * Set or clear (null = legacy/unlimited) the entitlement plan on one user
- * account. Returns the updated account metadata record, or null when no
- * user matches `id`/`email`.
+ * Set the entitlement plan on one user account. Nullish inputs map to the
+ * first-class `unlimited` plan; writers never persist NULL. Returns the
+ * updated account metadata record, or null when no user matches `id`/`email`.
  */
 export async function updateAdminUserPlan(
 	db: D1Database,
@@ -173,7 +174,7 @@ export async function updateAdminUserPlan(
 
 	await db
 		.prepare(`UPDATE users SET plan = ?, updated_at = ? WHERE id = ?`)
-		.bind(input.plan, utcSqliteTimestamp(), existing.id)
+		.bind(resolvePlanWrite(input.plan), utcSqliteTimestamp(), existing.id)
 		.run()
 
 	return loadAdminUserByIdOrEmail(db, { id: existing.id })

--- a/packages/worker/src/app/handlers/admin-invites.ts
+++ b/packages/worker/src/app/handlers/admin-invites.ts
@@ -21,7 +21,11 @@ import {
 import { requireUserWithRole } from '#app/permissions-server.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
-import { parsePlanName, type PlanName } from '#worker/entitlements/plans.ts'
+import {
+	parsePlanName,
+	resolvePlanWrite,
+	type PlanName,
+} from '#worker/entitlements/plans.ts'
 
 export function createAdminInvitesHandler(env: Env) {
 	return {
@@ -173,7 +177,7 @@ async function handleCreateInviteAction(input: {
 			{
 				ok: false,
 				error:
-					'Plan must be one of the known plan names, or empty for legacy/tierless.',
+					'Plan must be one of the known plan names, or empty for unlimited.',
 			},
 			400,
 		)
@@ -197,7 +201,7 @@ async function handleCreateInviteAction(input: {
 			email: input.actor.email,
 			ip: requestIp,
 			path: input.url.pathname,
-			reason: `invite_code=${invite.code};max_uses=${invite.max_uses};plan=${planResult.plan ?? 'none'}`,
+			reason: `invite_code=${invite.code};max_uses=${invite.max_uses};plan=${planResult.plan}`,
 		})
 	} catch (error) {
 		return jsonResponse(
@@ -214,18 +218,20 @@ async function handleCreateInviteAction(input: {
 }
 
 /**
- * Read an optional invite plan: missing/empty → null (legacy/tierless).
- * Unknown non-empty values are rejected instead of being coerced to null.
+ * Read an optional invite plan: missing/empty/null → `unlimited`.
+ * Unknown non-empty values are rejected. Writers never persist NULL.
  */
 function readInvitePlan(
 	body: object,
-): { ok: true; plan: PlanName | null } | { ok: false } {
-	if (!('plan' in body)) return { ok: true, plan: null }
+): { ok: true; plan: PlanName } | { ok: false } {
+	if (!('plan' in body)) return { ok: true, plan: resolvePlanWrite(null) }
 	const value = (body as Record<string, unknown>).plan
-	if (value === null || value === undefined) return { ok: true, plan: null }
+	if (value === null || value === undefined) {
+		return { ok: true, plan: resolvePlanWrite(null) }
+	}
 	if (typeof value === 'string') {
 		const trimmed = value.trim()
-		if (!trimmed) return { ok: true, plan: null }
+		if (!trimmed) return { ok: true, plan: resolvePlanWrite(null) }
 		const plan = parsePlanName(trimmed)
 		if (plan) return { ok: true, plan }
 	}

--- a/packages/worker/src/app/handlers/admin-users.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-users.node.test.ts
@@ -332,7 +332,7 @@ test('admin users list payload exposes only account metadata fields', async () =
 			email: 'member@example.com',
 			email_verified: false,
 			email_verified_at: null,
-			// Unknown stored plan values read back as null (legacy/unlimited).
+			// Unknown stored plan values read back as null.
 			plan: null,
 		}),
 	])
@@ -561,7 +561,7 @@ test('remove role removes admin when another admin remains', async () => {
 	)
 })
 
-test('update plan action sets, clears, validates, and scopes plan changes', async () => {
+test('update plan action sets, maps null to unlimited, validates, and scopes plan changes', async () => {
 	logAuditEventSpy.mockClear()
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(
 		createAdminActor(['admin']),
@@ -616,13 +616,13 @@ test('update plan action sets, clears, validates, and scopes plan changes', asyn
 		plan: null,
 	})
 	expect(clearPlanResponse.status).toBe(200)
-	expect((await clearPlanResponse.json()).users[0].plan).toBe(null)
+	expect((await clearPlanResponse.json()).users[0].plan).toBe('unlimited')
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'admin',
 			action: 'update_plan',
 			result: 'success',
-			reason: 'target_user_id=2;plan=null',
+			reason: 'target_user_id=2;plan=unlimited',
 		}),
 	)
 

--- a/packages/worker/src/app/handlers/admin-users.ts
+++ b/packages/worker/src/app/handlers/admin-users.ts
@@ -11,7 +11,11 @@ import {
 	updateAdminUserPlan,
 	type AdminUserListItem,
 } from '#app/admin-users-data.ts'
-import { parsePlanName, type PlanName } from '#worker/entitlements/plans.ts'
+import {
+	parsePlanName,
+	resolvePlanWrite,
+	type PlanName,
+} from '#worker/entitlements/plans.ts'
 import { readAuthSessionResult } from '#app/auth-session.ts'
 import { redirectToLogin } from '#app/auth-redirect.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -336,7 +340,7 @@ async function handleUpdatePlanAction(input: {
 			{
 				ok: false,
 				error:
-					'Plan must be one of the known plan names, or null to clear the plan.',
+					'Plan must be one of the known plan names, or null for unlimited.',
 			},
 			400,
 		)
@@ -358,25 +362,27 @@ async function handleUpdatePlanAction(input: {
 		email: input.actor.email,
 		ip: requestIp,
 		path: input.url.pathname,
-		reason: `target_user_id=${targetUserId};plan=${planUpdate.plan ?? 'null'}`,
+		reason: `target_user_id=${targetUserId};plan=${planUpdate.plan}`,
 	})
 
 	return buildMutationResponse(input.env, input.request.url, targetUserId)
 }
 
 /**
- * Read the requested plan value: a known plan name sets it, explicit null
- * clears it (legacy/unlimited). Anything else — including a missing key or
- * an unknown plan string — is rejected instead of being coerced to null.
+ * Read the requested plan value: a known plan name sets it; explicit null
+ * (and empty string) map to `unlimited` for backward compatibility. Writers
+ * never persist NULL. Missing key or unknown plan strings are rejected.
  */
 function readPlanUpdate(
 	body: object,
-): { ok: true; plan: PlanName | null } | { ok: false } {
+): { ok: true; plan: PlanName } | { ok: false } {
 	if (!('plan' in body)) return { ok: false }
 	const value = (body as Record<string, unknown>).plan
-	if (value === null) return { ok: true, plan: null }
+	if (value === null) return { ok: true, plan: resolvePlanWrite(null) }
 	if (typeof value === 'string') {
-		const plan = parsePlanName(value.trim())
+		const trimmed = value.trim()
+		if (!trimmed) return { ok: true, plan: resolvePlanWrite(null) }
+		const plan = parsePlanName(trimmed)
 		if (plan) return { ok: true, plan }
 	}
 	return { ok: false }

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -710,26 +710,28 @@ test('signup consuming a plan invite sets users.plan', async () => {
 	)
 })
 
-test('signup consuming a plan-less invite leaves users.plan null', async () => {
+test('signup consuming an invite without plan writes users.plan unlimited', async () => {
 	const context = createAuthTestContext({ emailConfigured: true })
 	stubCloudflareEmailFetch({ ok: true })
 	context.testDb.addInvite('PLAN-NONE')
 
 	const response = await context.request({
-		email: 'legacy-invite@example.com',
-		username: 'legacy-invite-user',
+		email: 'null-plan-invite@example.com',
+		username: 'null-plan-invite-user',
 		password: 'password123',
 		mode: 'signup',
 		inviteCode: 'plan-none',
 	})
 	expect(response.status).toBe(200)
-	expect(context.testDb.users.get('legacy-invite@example.com')?.plan).toBeNull()
+	expect(context.testDb.users.get('null-plan-invite@example.com')?.plan).toBe(
+		'unlimited',
+	)
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
 			category: 'auth',
 			action: 'invite_use',
 			result: 'success',
-			reason: expect.stringContaining('plan=none'),
+			reason: expect.stringContaining('plan=unlimited'),
 		}),
 	)
 })

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -481,7 +481,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 						stable_user_id: stableUserId,
 						password_hash: oauthNoUsablePasswordHash,
 						email_verified_at: new Date().toISOString(),
-						...(consumedInvitePlan ? { plan: consumedInvitePlan } : {}),
+						plan: consumedInvitePlan ?? 'unlimited',
 					},
 					{ returnRow: true },
 				)
@@ -572,7 +572,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					email,
 					ip: requestIp,
 					path: url.pathname,
-					reason: `invite_code=${consumedInviteCode};user_id=${newUser.id};provider=${provider};plan=${consumedInvitePlan ?? 'none'}`,
+					reason: `invite_code=${consumedInviteCode};user_id=${newUser.id};provider=${provider};plan=${consumedInvitePlan ?? 'unlimited'}`,
 				})
 			}
 			return issueLogin({ id: newUser.id, email })

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -251,7 +251,7 @@ export function createAuthHandler(env: Env) {
 							email: normalizedEmail,
 							stable_user_id: stableUserId,
 							password_hash: passwordHash,
-							...(consumedInvitePlan ? { plan: consumedInvitePlan } : {}),
+							plan: consumedInvitePlan ?? 'unlimited',
 						},
 						{
 							returnRow: true,
@@ -434,7 +434,7 @@ export function createAuthHandler(env: Env) {
 						email: normalizedEmail,
 						ip: requestIp,
 						path: url.pathname,
-						reason: `invite_code=${consumedInviteCode};user_id=${record.id};plan=${consumedInvitePlan ?? 'none'}`,
+						reason: `invite_code=${consumedInviteCode};user_id=${record.id};plan=${consumedInvitePlan ?? 'unlimited'}`,
 					})
 				}
 				return Response.json(

--- a/packages/worker/src/app/invites.node.test.ts
+++ b/packages/worker/src/app/invites.node.test.ts
@@ -188,7 +188,7 @@ test('createInvite stores plan and roundtrips through getInviteByCode and listIn
 	])
 })
 
-test('createInvite without plan stores null', async () => {
+test('createInvite without plan stores unlimited', async () => {
 	const db = createInviteDb()
 	const created = await createInvite({
 		db,
@@ -197,11 +197,11 @@ test('createInvite without plan stores null', async () => {
 		maxUses: 1,
 	})
 
-	expect(created.plan).toBeNull()
+	expect(created.plan).toBe('unlimited')
 	await expect(getInviteByCode(db, 'PLAN-NONE')).resolves.toEqual(
 		expect.objectContaining({
 			code: 'PLAN-NONE',
-			plan: null,
+			plan: 'unlimited',
 		}),
 	)
 })

--- a/packages/worker/src/app/invites.ts
+++ b/packages/worker/src/app/invites.ts
@@ -98,7 +98,7 @@ export async function createInvite(input: {
 			input.note?.trim() ?? '',
 			input.maxUses,
 			input.expiresAt ?? null,
-			input.plan ?? null,
+			input.plan ?? 'unlimited',
 		)
 		.run()
 

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -223,7 +223,7 @@ export type AdminUsageEntitlementResource =
 	| 'concurrent_workflows'
 	| 'storage_bytes'
 
-export type AdminPlanName = 'free' | 'partner' | 'pro'
+export type AdminPlanName = 'free' | 'partner' | 'pro' | 'unlimited'
 
 export type AdminUsageRollup = {
 	metric: AdminUsageMetric

--- a/packages/worker/src/app/platform-account-creation.ts
+++ b/packages/worker/src/app/platform-account-creation.ts
@@ -89,8 +89,8 @@ export async function createPlatformAccount(input: {
 	try {
 		const result = await input.db
 			.prepare(
-				`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, account_type)
-				 VALUES (?, ?, ?, ?, ?, 'platform')`,
+				`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, account_type, plan)
+				 VALUES (?, ?, ?, ?, ?, 'platform', 'unlimited')`,
 			)
 			.bind(
 				username,

--- a/packages/worker/src/billing/billing-config.node.test.ts
+++ b/packages/worker/src/billing/billing-config.node.test.ts
@@ -109,6 +109,19 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 		),
 	).toEqual({ stripePlan: null, cancelAt: null })
 
+	expect(
+		resolveSubscriptionPlan(
+			[
+				subscription({
+					status: 'active',
+					priceIds: ['price_unknown'],
+					metadata: { kody_plan: 'unlimited' },
+				}),
+			],
+			env,
+		),
+	).toEqual({ stripePlan: null, cancelAt: null })
+
 	const sooner = 1_700_000_000
 	const later = 1_800_000_000
 	expect(

--- a/packages/worker/src/billing/billing-config.ts
+++ b/packages/worker/src/billing/billing-config.ts
@@ -1,7 +1,7 @@
 import { toHex } from '@kody-internal/shared/hex.ts'
 import {
 	getPlanRank,
-	parsePlanName,
+	parseStripePlanName,
 	type PlanName,
 } from '#worker/entitlements/plans.ts'
 import { type StripeSubscription } from './stripe-client.ts'
@@ -69,7 +69,7 @@ function planFromSubscription(
 		}
 	}
 	const metadataPlan = subscription.metadata?.['kody_plan']
-	return parsePlanName(metadataPlan)
+	return parseStripePlanName(metadataPlan)
 }
 
 /**

--- a/packages/worker/src/billing/subscription-sync.ts
+++ b/packages/worker/src/billing/subscription-sync.ts
@@ -1,4 +1,7 @@
-import { parsePlanName, type PlanName } from '#worker/entitlements/plans.ts'
+import {
+	parseStripePlanName,
+	type PlanName,
+} from '#worker/entitlements/plans.ts'
 import {
 	createBillingLinkReference,
 	isBillingConfigured,
@@ -255,5 +258,5 @@ export async function refreshStaleStripePlans(input: {
 }
 
 export function parseStoredStripePlan(value: string | null | undefined) {
-	return parsePlanName(value)
+	return parseStripePlanName(value)
 }

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import {
 	EntitlementLimitError,
@@ -8,10 +8,12 @@ import {
 	getPlanRank,
 	nullPlanEmailFallbackLimits,
 	parsePlanName,
+	parseStripePlanName,
 	planLimits,
 	planNames,
 	resolveEffectivePlan,
 	resolvePlanLimit,
+	resolvePlanWrite,
 } from './plans.ts'
 import {
 	assertWithinEntitlement,
@@ -209,6 +211,20 @@ test('parsePlanName accepts registered plan names and treats everything else as 
 	expect(parsePlanName(1)).toBeNull()
 })
 
+test('parseStripePlanName rejects unlimited and unknown values', () => {
+	expect(parseStripePlanName('pro')).toBe('pro')
+	expect(parseStripePlanName('unlimited')).toBeNull()
+	expect(parseStripePlanName('enterprise')).toBeNull()
+	expect(parseStripePlanName(null)).toBeNull()
+})
+
+test('resolvePlanWrite maps nullish inputs to unlimited', () => {
+	expect(resolvePlanWrite(null)).toBe('unlimited')
+	expect(resolvePlanWrite(undefined)).toBe('unlimited')
+	expect(resolvePlanWrite('pro')).toBe('pro')
+	expect(resolvePlanWrite('unlimited')).toBe('unlimited')
+})
+
 test('storage byte entry estimates support net-positive upsert deltas', () => {
 	const existing = {
 		key: 'workspace',
@@ -355,7 +371,7 @@ test('assertWithinEntitlement passes under the limit, throws at it, and skips co
 	expect(error.message).toBe(buildEntitlementLimitMessage(error.details))
 })
 
-test('assertWithinEntitlement applies fallbackLimit for plan-less users', async () => {
+test('assertWithinEntitlement applies fallbackLimit for stored-NULL dual-read users', async () => {
 	const { db } = createEntitlementsTestDb({
 		counts: { workflow_runs: 100 },
 	})
@@ -556,7 +572,7 @@ test('refundDailyEntitlement decrements the user/day counter and floors at zero'
 	).toBe(0)
 })
 
-test('plan-less users count uncapped sends but honor fallback receive limits', async () => {
+test('stored-NULL dual-read users count uncapped sends but honor fallback receive limits', async () => {
 	const { db, counters } = createEntitlementsTestDb()
 	const sendLimit = planLimits.free.maxEmailSendsPerDay
 	if (sendLimit === null)
@@ -684,7 +700,7 @@ test('requested units and getCurrent overrides are honored', async () => {
 	})
 })
 
-test('storage bytes enforce for planned users and skip NULL-plan users', async () => {
+test('storage bytes enforce for planned users and skip stored-NULL dual-read users', async () => {
 	const userId = await createStableUserIdFromEmail(plannedEmail)
 	const limit = planLimits.pro.maxStorageBytes
 	if (limit === null) throw new Error('Expected a numeric pro storage cap.')
@@ -740,9 +756,10 @@ test('storage bytes enforce for planned users and skip NULL-plan users', async (
 	})
 })
 
-test('getPlanRank orders free < pro < partner', () => {
+test('getPlanRank orders free < pro < partner < unlimited', () => {
 	expect(getPlanRank('free')).toBeLessThan(getPlanRank('pro'))
 	expect(getPlanRank('pro')).toBeLessThan(getPlanRank('partner'))
+	expect(getPlanRank('partner')).toBeLessThan(getPlanRank('unlimited'))
 })
 
 test('resolveEffectivePlan never downgrades a NULL manual plan', () => {
@@ -750,6 +767,13 @@ test('resolveEffectivePlan never downgrades a NULL manual plan', () => {
 	expect(resolveEffectivePlan(null, 'partner')).toBeNull()
 	expect(resolveEffectivePlan(null, null)).toBeNull()
 	expect(resolveEffectivePlan(null, 'unknown')).toBeNull()
+})
+
+test('resolveEffectivePlan manual unlimited always beats Stripe', () => {
+	expect(resolveEffectivePlan('unlimited', 'pro')).toBe('unlimited')
+	expect(resolveEffectivePlan('unlimited', 'partner')).toBe('unlimited')
+	expect(resolveEffectivePlan('unlimited', 'unlimited')).toBe('unlimited')
+	expect(resolveEffectivePlan('unlimited', null)).toBe('unlimited')
 })
 
 test('resolveEffectivePlan picks the higher of manual and stripe plans', () => {
@@ -760,6 +784,7 @@ test('resolveEffectivePlan picks the higher of manual and stripe plans', () => {
 	expect(resolveEffectivePlan('pro', null)).toBe('pro')
 	expect(resolveEffectivePlan('pro', 'not-a-plan')).toBe('pro')
 	expect(resolveEffectivePlan('pro', 'personal')).toBe('pro')
+	expect(resolveEffectivePlan('free', 'unlimited')).toBe('free')
 })
 
 test('free plan limits are stricter than pro', () => {
@@ -777,14 +802,133 @@ test('free plan limits are stricter than pro', () => {
 	expect(resolvePlanLimit('free', 'saved_packages')).toBe(5)
 })
 
+test('unlimited plan has null ordinary limits, email fallbacks, and persistent services', () => {
+	expect(planLimits.unlimited.maxSavedPackages).toBeNull()
+	expect(planLimits.unlimited.maxScheduledJobs).toBeNull()
+	expect(planLimits.unlimited.maxPackageServices).toBeNull()
+	expect(planLimits.unlimited.maxRepoSessions).toBeNull()
+	expect(planLimits.unlimited.maxSecrets).toBeNull()
+	expect(planLimits.unlimited.maxStorageBytes).toBeNull()
+	expect(planLimits.unlimited.maxConcurrentWorkflows).toBeNull()
+	expect(planLimits.unlimited.packageServicePersistentAllowed).toBe(true)
+	expect(
+		resolvePlanLimit('unlimited', 'persistent_package_services'),
+	).toBeNull()
+	expect(planLimits.unlimited.maxEmailSendsPerDay).toBe(
+		nullPlanEmailFallbackLimits.email_sends_per_day,
+	)
+	expect(planLimits.unlimited.maxEmailReceivesPerDay).toBe(
+		nullPlanEmailFallbackLimits.email_receives_per_day,
+	)
+	expect(planLimits.unlimited.maxStoredEmailMessages).toBe(
+		nullPlanEmailFallbackLimits.stored_email_messages,
+	)
+	expect(planLimits.unlimited.maxEmailMessageBytes).toBe(
+		nullPlanEmailFallbackLimits.email_message_bytes,
+	)
+})
+
+test('stored unlimited matches stored-NULL ordinary fail-open and still uses concurrent_workflows fallbackLimit', async () => {
+	const nullPlanEmail = 'null-plan@example.com'
+	const unlimitedEmail = 'unlimited-plan@example.com'
+	const nullPlanUserId = await createStableUserIdFromEmail(nullPlanEmail)
+	const unlimitedUserId = await createStableUserIdFromEmail(unlimitedEmail)
+
+	const nullPlanGetCurrent = vi.fn(async () => 10_000)
+	const nullPlan = createEntitlementsTestDb({
+		users: [
+			{ email: nullPlanEmail, plan: null, stable_user_id: nullPlanUserId },
+		],
+		counts: { jobs: 10_000 },
+	})
+	await assertWithinEntitlement({
+		db: nullPlan.db,
+		userId: nullPlanUserId,
+		email: nullPlanEmail,
+		resource: 'scheduled_jobs',
+		getCurrent: nullPlanGetCurrent,
+	})
+	expect(nullPlanGetCurrent).not.toHaveBeenCalled()
+	expect(nullPlan.queries).toHaveLength(1)
+	expect(nullPlan.queries[0]?.sql).toContain(
+		'SELECT plan, stripe_plan FROM users',
+	)
+
+	const unlimitedGetCurrent = vi.fn(async () => 10_000)
+	const unlimited = createEntitlementsTestDb({
+		users: [
+			{
+				email: unlimitedEmail,
+				plan: 'unlimited',
+				stable_user_id: unlimitedUserId,
+			},
+		],
+		counts: { jobs: 10_000 },
+	})
+	await assertWithinEntitlement({
+		db: unlimited.db,
+		userId: unlimitedUserId,
+		email: unlimitedEmail,
+		resource: 'scheduled_jobs',
+		getCurrent: unlimitedGetCurrent,
+	})
+	expect(unlimitedGetCurrent).not.toHaveBeenCalled()
+	expect(unlimited.queries).toHaveLength(1)
+	expect(unlimited.queries[0]?.sql).toContain(
+		'SELECT plan, stripe_plan FROM users',
+	)
+	expect(unlimited.queries[0]?.params).toEqual([
+		unlimitedEmail,
+		unlimitedUserId,
+	])
+
+	const concurrent = createEntitlementsTestDb({
+		users: [
+			{
+				email: unlimitedEmail,
+				plan: 'unlimited',
+				stable_user_id: unlimitedUserId,
+			},
+		],
+		counts: { workflow_runs: 100 },
+	})
+	const error = await assertWithinEntitlement({
+		db: concurrent.db,
+		userId: unlimitedUserId,
+		email: unlimitedEmail,
+		resource: 'concurrent_workflows',
+		fallbackLimit: 100,
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(error instanceof EntitlementLimitError)) {
+		throw new Error('Expected an EntitlementLimitError.')
+	}
+	expect(error.details).toMatchObject({
+		plan: 'unlimited',
+		limit: 100,
+		current: 100,
+	})
+	expect(
+		concurrent.queries.some((query) =>
+			query.sql.includes('FROM workflow_runs'),
+		),
+	).toBe(true)
+})
+
 test('getUserPlan resolves effective plan from manual plan and stripe_plan', async () => {
 	const freePlusProEmail = 'manual-free-stripe-pro@example.com'
 	const nullPlusProEmail = 'manual-null-stripe-pro@example.com'
 	const proPlusPartnerEmail = 'manual-pro-stripe-partner@example.com'
+	const unlimitedPlusProEmail = 'manual-unlimited-stripe-pro@example.com'
 	const freePlusProUserId = await createStableUserIdFromEmail(freePlusProEmail)
 	const nullPlusProUserId = await createStableUserIdFromEmail(nullPlusProEmail)
 	const proPlusPartnerUserId =
 		await createStableUserIdFromEmail(proPlusPartnerEmail)
+	const unlimitedPlusProUserId = await createStableUserIdFromEmail(
+		unlimitedPlusProEmail,
+	)
 	const { db } = createEntitlementsTestDb({
 		users: [
 			{
@@ -804,6 +948,12 @@ test('getUserPlan resolves effective plan from manual plan and stripe_plan', asy
 				plan: 'pro',
 				stripe_plan: 'partner',
 				stable_user_id: proPlusPartnerUserId,
+			},
+			{
+				email: unlimitedPlusProEmail,
+				plan: 'unlimited',
+				stripe_plan: 'pro',
+				stable_user_id: unlimitedPlusProUserId,
 			},
 		],
 	})
@@ -826,4 +976,10 @@ test('getUserPlan resolves effective plan from manual plan and stripe_plan', asy
 			email: proPlusPartnerEmail,
 		}),
 	).toBe('partner')
+	expect(
+		await getUserPlan(db, {
+			userId: unlimitedPlusProUserId,
+			email: unlimitedPlusProEmail,
+		}),
+	).toBe('unlimited')
 })

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -1,13 +1,14 @@
 /**
  * Plan definitions and per-plan resource limits.
  *
- * `users.plan` is nullable: NULL means legacy/unlimited and disables all
- * entitlement enforcement for that user. Enforcement only activates when a
- * plan name from `planNames` is set. Unknown stored values are treated as
- * NULL (unlimited) so adding or renaming plans never locks users out.
+ * First-class plans include `unlimited`. New writers always persist a plan
+ * name (never NULL). During stage 1, reads stay dual-compatible: stored NULL
+ * and unknown strings still parse as null and retain historical fail-open
+ * behavior (no ordinary entitlement enforcement). Enforcement activates for
+ * recognized plan names from `planNames`.
  */
 
-export const planNames = ['free', 'partner', 'pro'] as const
+export const planNames = ['free', 'partner', 'pro', 'unlimited'] as const
 
 export type PlanName = (typeof planNames)[number]
 
@@ -19,8 +20,25 @@ export function parsePlanName(value: unknown): PlanName | null {
 }
 
 /**
+ * Parse a plan name that may come from Stripe metadata or `users.stripe_plan`.
+ * `unlimited` is never purchasable or Stripe-sourced.
+ */
+export function parseStripePlanName(value: unknown): PlanName | null {
+	const plan = parsePlanName(value)
+	return plan === 'unlimited' ? null : plan
+}
+
+/**
+ * Coerce admin/API nullish plan inputs to the first-class `unlimited` plan.
+ * Production writers must never persist NULL.
+ */
+export function resolvePlanWrite(plan: PlanName | null | undefined): PlanName {
+	return plan ?? 'unlimited'
+}
+
+/**
  * Rank order for comparing manual grants vs Stripe subscription plans.
- * Higher rank wins. free(0) < pro(1) < partner(2).
+ * Higher rank wins. free(0) < pro(1) < partner(2) < unlimited(3).
  */
 export function getPlanRank(plan: PlanName): number {
 	switch (plan) {
@@ -30,6 +48,8 @@ export function getPlanRank(plan: PlanName): number {
 			return 1
 		case 'partner':
 			return 2
+		case 'unlimited':
+			return 3
 		default: {
 			const exhaustive: never = plan
 			throw new Error(`Unknown plan: ${String(exhaustive)}`)
@@ -40,17 +60,19 @@ export function getPlanRank(plan: PlanName): number {
 /**
  * Effective plan for entitlement enforcement.
  *
- * - Manual plan NULL → effective NULL (legacy/unlimited always wins; a Stripe
- *   subscription never downgrades a plan-less account into enforcement).
+ * - Manual plan NULL → effective NULL (stage-1 dual-read fail-open; a Stripe
+ *   subscription never downgrades a stored-NULL account into enforcement).
+ * - Manual `unlimited` always wins over any Stripe plan.
  * - Otherwise the higher-ranked of manual and stripe plans.
- * - Unknown/NULL stripe_plan contributes nothing.
+ * - Unknown/NULL/`unlimited` stripe_plan contributes nothing.
  */
 export function resolveEffectivePlan(
 	manualPlan: PlanName | null,
 	stripePlan: string | null,
 ): PlanName | null {
 	if (!manualPlan) return null
-	const parsedStripe = parsePlanName(stripePlan)
+	if (manualPlan === 'unlimited') return 'unlimited'
+	const parsedStripe = parseStripePlanName(stripePlan)
 	if (!parsedStripe) return manualPlan
 	return getPlanRank(parsedStripe) > getPlanRank(manualPlan)
 		? parsedStripe
@@ -89,6 +111,63 @@ export type PlanLimits = {
 	/** Maximum concurrently active workflow runs. */
 	maxConcurrentWorkflows: number | null
 }
+
+export const entitlementResources = [
+	'saved_packages',
+	'scheduled_jobs',
+	'package_services',
+	'persistent_package_services',
+	'repo_sessions',
+	'email_sends_per_day',
+	'email_receives_per_day',
+	'stored_email_messages',
+	'email_message_bytes',
+	'secrets',
+	'storage_bytes',
+	'concurrent_workflows',
+] as const
+
+export type EntitlementResource = (typeof entitlementResources)[number]
+
+/** Human-readable resource labels used in the shared error message. */
+export const entitlementResourceLabels: Record<EntitlementResource, string> = {
+	saved_packages: 'saved packages',
+	scheduled_jobs: 'scheduled jobs',
+	package_services: 'running package services',
+	persistent_package_services: 'persistent package services',
+	repo_sessions: 'active repo sessions',
+	email_sends_per_day: 'email sends per day',
+	email_receives_per_day: 'email receives per day',
+	stored_email_messages: 'stored email messages',
+	email_message_bytes: 'bytes per email message',
+	secrets: 'secrets',
+	storage_bytes: 'storage bytes',
+	concurrent_workflows: 'concurrent workflows',
+}
+
+/**
+ * Fallback limits for users without a plan on the email resources.
+ *
+ * Email is abuse-sensitive in both directions — inbound volume is
+ * attacker-controlled (anyone can send to a `{username}@<platform domain>`
+ * address) and outbound sending is an outreach-abuse surface — so unlike
+ * other resources stored NULL / unknown strings during stage 1 do not mean
+ * uncapped mail here: accounts without a recognized plan and the explicit
+ * `unlimited` plan get these deployment-level backstops instead. The receive
+ * and storage numbers sit between the `free` and `pro` plan limits; the send
+ * backstop sits between `free` and `pro` send limits as well.
+ *
+ * The first-class `unlimited` plan uses these same numbers as its email
+ * limits so new accounts match historical stored-NULL email behavior.
+ */
+export const nullPlanEmailFallbackLimits = {
+	email_sends_per_day: 100,
+	email_receives_per_day: 200,
+	stored_email_messages: 2000,
+	email_message_bytes: 512 * 1024,
+} as const satisfies Partial<Record<EntitlementResource, number>>
+
+export type EmailFallbackResource = keyof typeof nullPlanEmailFallbackLimits
 
 /**
  * Initial limit numbers are conservative placeholders chosen before usage
@@ -140,60 +219,23 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxStorageBytes: 5 * 1024 * 1024 * 1024,
 		maxConcurrentWorkflows: 100,
 	},
+	unlimited: {
+		maxSavedPackages: null,
+		maxScheduledJobs: null,
+		maxPackageServices: null,
+		packageServicePersistentAllowed: true,
+		maxRepoSessions: null,
+		maxEmailSendsPerDay: nullPlanEmailFallbackLimits.email_sends_per_day,
+		maxEmailReceivesPerDay: nullPlanEmailFallbackLimits.email_receives_per_day,
+		maxStoredEmailMessages: nullPlanEmailFallbackLimits.stored_email_messages,
+		maxEmailMessageBytes: nullPlanEmailFallbackLimits.email_message_bytes,
+		maxSecrets: null,
+		maxStorageBytes: null,
+		// null so assertWithinEntitlement falls through to the env workflow
+		// concurrency backstop (same behavior as historical stored-NULL users).
+		maxConcurrentWorkflows: null,
+	},
 }
-
-export const entitlementResources = [
-	'saved_packages',
-	'scheduled_jobs',
-	'package_services',
-	'persistent_package_services',
-	'repo_sessions',
-	'email_sends_per_day',
-	'email_receives_per_day',
-	'stored_email_messages',
-	'email_message_bytes',
-	'secrets',
-	'storage_bytes',
-	'concurrent_workflows',
-] as const
-
-export type EntitlementResource = (typeof entitlementResources)[number]
-
-/** Human-readable resource labels used in the shared error message. */
-export const entitlementResourceLabels: Record<EntitlementResource, string> = {
-	saved_packages: 'saved packages',
-	scheduled_jobs: 'scheduled jobs',
-	package_services: 'running package services',
-	persistent_package_services: 'persistent package services',
-	repo_sessions: 'active repo sessions',
-	email_sends_per_day: 'email sends per day',
-	email_receives_per_day: 'email receives per day',
-	stored_email_messages: 'stored email messages',
-	email_message_bytes: 'bytes per email message',
-	secrets: 'secrets',
-	storage_bytes: 'storage bytes',
-	concurrent_workflows: 'concurrent workflows',
-}
-
-/**
- * Fallback limits for users without a plan on the email resources.
- *
- * Email is abuse-sensitive in both directions — inbound volume is
- * attacker-controlled (anyone can send to a `{username}@<platform domain>`
- * address) and outbound sending is an outreach-abuse surface — so unlike
- * other resources the NULL-plan invariant does not mean unlimited here:
- * plan-less users get these deployment-level backstops instead. The receive
- * and storage numbers sit between the `free` and `pro` plan limits; the send
- * backstop sits between `free` and `pro` send limits as well.
- */
-export const nullPlanEmailFallbackLimits = {
-	email_sends_per_day: 100,
-	email_receives_per_day: 200,
-	stored_email_messages: 2000,
-	email_message_bytes: 512 * 1024,
-} as const satisfies Partial<Record<EntitlementResource, number>>
-
-export type EmailFallbackResource = keyof typeof nullPlanEmailFallbackLimits
 
 export function isEmailFallbackResource(
 	resource: EntitlementResource,
@@ -203,7 +245,7 @@ export function isEmailFallbackResource(
 
 /**
  * Resolve the effective limit for an inbound email resource: the plan limit
- * when the user has a plan, otherwise the NULL-plan fallback backstop.
+ * when the user has a recognized plan, otherwise the email backstop.
  */
 export function resolveEmailResourceLimit(
 	plan: PlanName | null,

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -13,8 +13,8 @@ import {
 const stableUserIdPattern = /^[a-f0-9]{64}$/i
 
 /**
- * Resolve the effective plan for a user, or null when the user is
- * legacy/unlimited.
+ * Resolve the effective plan for a user, or null when stored NULL or an
+ * unknown plan string dual-reads as fail-open during stage 1.
  *
  * The MCP `userId` is the account's stored `users.stable_user_id`. Lookup
  * requires the email + stable id pair so a mismatched caller context
@@ -22,12 +22,13 @@ const stableUserIdPattern = /^[a-f0-9]{64}$/i
  * test fixtures) cannot resolve another account's plan. Non-hex userIds
  * short-circuit without touching D1 — which also means enforcement is skipped,
  * matching the invariant that enforcement only activates for users with a
- * verified plan.
+ * recognized plan.
  *
- * Effective plan = f(manual users.plan, users.stripe_plan): a NULL manual
- * plan always wins (legacy/unlimited); otherwise the higher-ranked of the
- * manual grant and Stripe subscription plan is returned. Signature stays
- * `(db, { userId, email })` so enforcement call sites are unchanged.
+ * Effective plan = f(manual users.plan, users.stripe_plan): stored NULL
+ * dual-reads as fail-open during stage 1; manual `unlimited` always beats Stripe;
+ * otherwise the higher-ranked of the manual grant and Stripe subscription plan
+ * is returned. Signature stays `(db, { userId, email })` so enforcement call
+ * sites are unchanged.
  */
 export async function getUserPlan(
 	db: D1Database,
@@ -633,9 +634,11 @@ export type AssertWithinEntitlementInput = {
 	/** Override the built-in D1 usage counter for this resource. */
 	getCurrent?: () => Promise<number>
 	/**
-	 * Limit that applies when the user has no plan. Used to absorb global
-	 * backstops (for example the workflow concurrency env var) into the
-	 * shared enforcement path. Default: no limit for plan-less users.
+	 * Limit used when the resolved plan limit is null — including stored-NULL /
+	 * unknown dual-read users and recognized plans whose resource limit is null
+	 * (for example `unlimited` concurrent_workflows). Absorbs global backstops
+	 * such as the workflow concurrency env var into the shared enforcement path.
+	 * Default: no limit when both the plan limit and this fallback are null.
 	 */
 	fallbackLimit?: number | null
 	now?: Date
@@ -647,10 +650,11 @@ export type AssertWithinEntitlementInput = {
  * error shape and user-facing message stay identical across MCP and UI
  * surfaces.
  *
- * Users with a NULL (or unknown) plan are unlimited: the helper returns
- * before running any counting query, so enforcement adds no D1 reads for
- * legacy users beyond the single plan lookup (and not even that when the
- * caller context has no verified email).
+ * Users with a NULL (or unknown) plan are fail-open for ordinary resources:
+ * the helper returns before running any counting query when neither a plan
+ * limit nor `fallbackLimit` applies. When a plan limit is null (including
+ * `unlimited` concurrent_workflows), `fallbackLimit` still applies so env
+ * backstops retain historical stored-NULL behavior.
  */
 export async function assertWithinEntitlement(
 	input: AssertWithinEntitlementInput,
@@ -659,9 +663,8 @@ export async function assertWithinEntitlement(
 		userId: input.userId,
 		email: input.email,
 	})
-	const limit = plan
-		? resolvePlanLimit(plan, input.resource)
-		: (input.fallbackLimit ?? null)
+	const planLimit = plan ? resolvePlanLimit(plan, input.resource) : null
+	const limit = planLimit ?? input.fallbackLimit ?? null
 	if (limit == null) return
 	const now = input.now ?? new Date()
 	const requested = input.requested ?? 1
@@ -694,7 +697,7 @@ export async function assertWithinEntitlement(
  *
  * Users without a plan (or without a resolvable limit) consume without a
  * cap: the counter still accumulates so limits bind the moment a plan is
- * assigned. Pass `fallbackLimit` to cap plan-less users with a
+ * assigned. Pass `fallbackLimit` to cap accounts without a recognized plan with a
  * deployment-level backstop (for example inbound email receives).
  */
 export async function consumeDailyEntitlement(input: {
@@ -703,8 +706,9 @@ export async function consumeDailyEntitlement(input: {
 	email: string | null | undefined
 	resource: EntitlementResource
 	/**
-	 * Limit that applies when the user has no plan. Default: no limit for
-	 * plan-less users (the counter still accumulates).
+	 * Limit used when the resolved plan limit is null — including stored-NULL /
+	 * unknown dual-read users and recognized plans with a null resource limit.
+	 * Default: no limit (the counter still accumulates).
 	 */
 	fallbackLimit?: number | null
 	now?: Date
@@ -714,9 +718,8 @@ export async function consumeDailyEntitlement(input: {
 		userId: input.userId,
 		email: input.email,
 	})
-	const limit = plan
-		? resolvePlanLimit(plan, input.resource)
-		: (input.fallbackLimit ?? null)
+	const planLimit = plan ? resolvePlanLimit(plan, input.resource) : null
+	const limit = planLimit ?? input.fallbackLimit ?? null
 	if (limit == null) {
 		await incrementDailyEntitlementCounter({
 			db: input.db,

--- a/packages/worker/src/entitlements/unlimited-plan-backfill-migration.node.test.ts
+++ b/packages/worker/src/entitlements/unlimited-plan-backfill-migration.node.test.ts
@@ -1,0 +1,201 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+
+/** Upper bound (exclusive): only migrations before this file are applied as setup. */
+const unlimitedPlanBackfillMigration = '0080-backfill-unlimited-plan.sql'
+
+/** D1 wraps each migration file in a transaction; mirror that in rollback tests. */
+function applyMigrationLikeD1(db: DatabaseSync, fileName: string) {
+	const sql = readFileSync(new URL(fileName, migrationsDirectory), 'utf8')
+	db.exec('BEGIN')
+	try {
+		db.exec(sql)
+		db.exec('COMMIT')
+	} catch (error) {
+		db.exec('ROLLBACK')
+		throw error
+	}
+}
+
+function applyMigrationsBeforeBackfill(db: DatabaseSync) {
+	db.exec('PRAGMA foreign_keys = ON')
+	for (const fileName of readdirSync(migrationsDirectory)
+		.filter(
+			(file) => file.endsWith('.sql') && file < unlimitedPlanBackfillMigration,
+		)
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
+	}
+}
+
+function usersTableSql(db: DatabaseSync) {
+	const row = db
+		.prepare(
+			`SELECT sql FROM sqlite_master
+			 WHERE type = 'table' AND name = 'users'`,
+		)
+		.get() as { sql: string } | undefined
+	return row?.sql ?? ''
+}
+
+function invitesTableSql(db: DatabaseSync) {
+	const row = db
+		.prepare(
+			`SELECT sql FROM sqlite_master
+			 WHERE type = 'table' AND name = 'invites'`,
+		)
+		.get() as { sql: string } | undefined
+	return row?.sql ?? ''
+}
+
+function seedPlanRows(db: DatabaseSync) {
+	db.exec(`
+		INSERT INTO users (
+			id, username, email, password_hash, stable_user_id, plan, stripe_plan
+		) VALUES
+			(
+				1, 'null-plan-user', 'null-plan@example.com', 'hash-l', 'stable-null-plan',
+				NULL, 'pro'
+			),
+			(
+				2, 'paid', 'paid@example.com', 'hash-p', 'stable-paid',
+				'pro', 'free'
+			),
+			(
+				3, 'partner', 'partner@example.com', 'hash-r', 'stable-partner',
+				'partner', NULL
+			),
+			(
+				4, 'free', 'free@example.com', 'hash-f', 'stable-free',
+				'free', 'pro'
+			);
+
+		INSERT INTO invites (code, created_by, note, max_uses, use_count, plan)
+		VALUES
+			('invite-null', 1, 'null-plan invite', 1, 0, NULL),
+			('invite-pro', 2, 'paid invite', 3, 1, 'pro'),
+			('invite-free', 4, 'free invite', 2, 0, 'free');
+	`)
+}
+
+test('unlimited plan backfill materializes NULL plans and preserves enforcement-bearing rows under a D1 transaction', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBeforeBackfill(db)
+	seedPlanRows(db)
+
+	expect(usersTableSql(db)).toMatch(/plan TEXT DEFAULT NULL/)
+	expect(usersTableSql(db)).not.toMatch(/plan TEXT NOT NULL/)
+	expect(invitesTableSql(db)).toContain('plan')
+	expect(
+		db
+			.prepare(`SELECT username, plan, stripe_plan FROM users ORDER BY id`)
+			.all(),
+	).toEqual([
+		{ username: 'null-plan-user', plan: null, stripe_plan: 'pro' },
+		{ username: 'paid', plan: 'pro', stripe_plan: 'free' },
+		{ username: 'partner', plan: 'partner', stripe_plan: null },
+		{ username: 'free', plan: 'free', stripe_plan: 'pro' },
+	])
+	expect(
+		db.prepare(`SELECT code, plan FROM invites ORDER BY code`).all(),
+	).toEqual([
+		{ code: 'invite-free', plan: 'free' },
+		{ code: 'invite-null', plan: null },
+		{ code: 'invite-pro', plan: 'pro' },
+	])
+
+	applyMigrationLikeD1(db, unlimitedPlanBackfillMigration)
+
+	expect(
+		db
+			.prepare(`SELECT username, plan, stripe_plan FROM users ORDER BY id`)
+			.all(),
+	).toEqual([
+		{ username: 'null-plan-user', plan: 'unlimited', stripe_plan: 'pro' },
+		{ username: 'paid', plan: 'pro', stripe_plan: 'free' },
+		{ username: 'partner', plan: 'partner', stripe_plan: null },
+		{ username: 'free', plan: 'free', stripe_plan: 'pro' },
+	])
+	expect(
+		db.prepare(`SELECT code, plan FROM invites ORDER BY code`).all(),
+	).toEqual([
+		{ code: 'invite-free', plan: 'free' },
+		{ code: 'invite-null', plan: 'unlimited' },
+		{ code: 'invite-pro', plan: 'pro' },
+	])
+	expect(
+		db.prepare(`SELECT COUNT(*) AS count FROM users WHERE plan IS NULL`).get(),
+	).toEqual({ count: 0 })
+	expect(
+		db
+			.prepare(`SELECT COUNT(*) AS count FROM invites WHERE plan IS NULL`)
+			.get(),
+	).toEqual({ count: 0 })
+
+	// Stage 1 keeps nullable columns and does not rebuild tables.
+	expect(usersTableSql(db)).toMatch(/plan TEXT DEFAULT NULL/)
+	expect(usersTableSql(db)).not.toMatch(/plan TEXT NOT NULL/)
+	expect(
+		db
+			.prepare(
+				`SELECT sql FROM sqlite_master
+				 WHERE name = '__migration_assertions'
+				    OR name LIKE '_mig0080_%'`,
+			)
+			.all(),
+	).toEqual([])
+	expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+})
+
+test('unlimited plan backfill fails closed and rolls back when a residual NULL plan remains', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBeforeBackfill(db)
+	seedPlanRows(db)
+
+	const beforeUsers = db
+		.prepare(`SELECT username, plan, stripe_plan FROM users ORDER BY id`)
+		.all()
+	const beforeInvites = db
+		.prepare(`SELECT code, plan FROM invites ORDER BY code`)
+		.all()
+
+	// Force one eligible users.plan NULL to survive the real UPDATE so the
+	// migration's residual-NULL assertion aborts. Created outside the D1-style
+	// migration transaction so the ignore behavior persists through rollback.
+	db.exec(`
+		CREATE TRIGGER test_keep_null_plan_user
+		BEFORE UPDATE OF plan ON users
+		WHEN OLD.id = 1 AND OLD.plan IS NULL
+		BEGIN
+			SELECT RAISE(IGNORE);
+		END;
+	`)
+
+	expect(() =>
+		applyMigrationLikeD1(db, unlimitedPlanBackfillMigration),
+	).toThrow(/CHECK constraint failed: 0/)
+
+	// Whole migration transaction rolled back: invites UPDATE undone too.
+	expect(
+		db
+			.prepare(`SELECT username, plan, stripe_plan FROM users ORDER BY id`)
+			.all(),
+	).toEqual(beforeUsers)
+	expect(
+		db.prepare(`SELECT code, plan FROM invites ORDER BY code`).all(),
+	).toEqual(beforeInvites)
+	expect(
+		db
+			.prepare(
+				`SELECT sql FROM sqlite_master
+				 WHERE name = '__migration_assertions'`,
+			)
+			.all(),
+	).toEqual([])
+	expect(usersTableSql(db)).toMatch(/plan TEXT DEFAULT NULL/)
+	expect(usersTableSql(db)).not.toMatch(/plan TEXT NOT NULL/)
+	expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -387,11 +387,17 @@ function createAdminCapabilityTestDb(input: {
 							throw new Error('UNIQUE constraint failed: users.username')
 						}
 						const now = new Date().toISOString()
+						const plan =
+							normalizedQuery.includes(', plan)') &&
+							normalizedQuery.includes("'unlimited'")
+								? 'unlimited'
+								: null
 						const user: UserRow = {
 							id: nextUserId,
 							username: String(username),
 							email: String(email),
 							stable_user_id: stableUserId,
+							plan,
 							created_at: now,
 							updated_at: now,
 							password_hash: String(passwordHash),
@@ -761,6 +767,7 @@ test('admin_user_create records audit metadata and assigns the default role', as
 	expect(users.find((user) => user.id === 2)).toMatchObject({
 		email: 'person+launch@example.com',
 		stable_user_id: testStableUserIdFromEmail('person+launch@example.com'),
+		plan: 'unlimited',
 	})
 	expect(userRoles).toContainEqual({ user_id: 2, role_name: 'user' })
 	expect(auditEvents).toEqual([
@@ -772,7 +779,7 @@ test('admin_user_create records audit metadata and assigns the default role', as
 	])
 })
 
-test('admin_user_update sets and clears the entitlement plan with audit metadata', async () => {
+test('admin_user_update sets plan and maps null clear to unlimited with audit metadata', async () => {
 	const { db, auditEvents, users } = createAdminCapabilityTestDb({
 		users: [
 			adminTestUser({
@@ -815,8 +822,8 @@ test('admin_user_update sets and clears the entitlement plan with audit metadata
 		{ id: 2, plan: null },
 		ctx,
 	)
-	expect(clearById.user).toMatchObject({ id: 2, plan: null })
-	expect(users.find((user) => user.id === 2)?.plan).toBe(null)
+	expect(clearById.user).toMatchObject({ id: 2, plan: 'unlimited' })
+	expect(users.find((user) => user.id === 2)?.plan).toBe('unlimited')
 
 	expect(auditEvents).toEqual([
 		expect.objectContaining({
@@ -827,7 +834,7 @@ test('admin_user_update sets and clears the entitlement plan with audit metadata
 		expect.objectContaining({
 			action: 'admin_user_update',
 			result: 'success',
-			reason: 'target_user_id=2;plan=null',
+			reason: 'target_user_id=2;plan=unlimited',
 		}),
 	])
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-shared.ts
@@ -36,7 +36,7 @@ export const adminUserMetadataSchema = z.object({
 	plan: planNameSchema
 		.nullable()
 		.describe(
-			'Entitlement plan, or null for legacy/unlimited (no entitlement enforcement).',
+			'Entitlement plan name, or null when the stored value is not recognized.',
 		),
 	created_at: z.string(),
 	updated_at: z.string(),

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-update.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-update.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { updateAdminUserPlan } from '#app/admin-users-data.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { resolvePlanWrite } from '#worker/entitlements/plans.ts'
 import {
 	adminMutationCapabilityAccess,
 	adminUserMetadataSchema,
@@ -21,7 +22,7 @@ const inputSchema = z
 		plan: planNameSchema
 			.nullable()
 			.describe(
-				'Entitlement plan to set, or null to clear the plan (legacy/unlimited: no entitlement enforcement).',
+				'Entitlement plan to set. Null maps to unlimited (never persists NULL).',
 			),
 	})
 	.refine((value) => value.id !== undefined || value.email !== undefined, {
@@ -38,7 +39,7 @@ export const adminUserUpdateCapability = defineDomainCapability(
 		...adminMutationCapabilityAccess,
 		name: 'admin_user_update',
 		description:
-			'Update account metadata for one user by id or email. Supports setting or clearing the entitlement plan. Admin-only; never touches user content.',
+			'Update account metadata for one user by id or email. Supports setting the entitlement plan (null maps to unlimited). Admin-only; never touches user content.',
 		keywords: ['admin', 'user', 'update', 'account', 'plan', 'entitlements'],
 		inputSchema,
 		outputSchema,
@@ -50,7 +51,7 @@ export const adminUserUpdateCapability = defineDomainCapability(
 					const user = await updateAdminUserPlan(ctx.env.APP_DB, {
 						id: args.id,
 						email: args.email,
-						plan: args.plan,
+						plan: resolvePlanWrite(args.plan),
 					})
 					if (!user) {
 						throw new Error('User not found.')
@@ -59,7 +60,7 @@ export const adminUserUpdateCapability = defineDomainCapability(
 				},
 				{
 					successReason: ({ user }) =>
-						`target_user_id=${user.id};plan=${user.plan ?? 'null'}`,
+						`target_user_id=${user.id};plan=${user.plan ?? 'unlimited'}`,
 				},
 			)
 		},

--- a/packages/worker/src/package-registry/scope-grants.workers.test.ts
+++ b/packages/worker/src/package-registry/scope-grants.workers.test.ts
@@ -88,7 +88,7 @@ test('createPlatformAccount rejects non-reserved usernames and duplicates; creat
 	})
 
 	const row = await env.APP_DB.prepare(
-		`SELECT account_type, password_hash, username, email FROM users WHERE id = ?`,
+		`SELECT account_type, password_hash, username, email, plan FROM users WHERE id = ?`,
 	)
 		.bind(created.userId)
 		.first<{
@@ -96,12 +96,14 @@ test('createPlatformAccount rejects non-reserved usernames and duplicates; creat
 			password_hash: string
 			username: string
 			email: string
+			plan: string | null
 		}>()
 	expect(row).toEqual({
 		account_type: 'platform',
 		password_hash: 'platform_account_no_usable_password',
 		username,
 		email,
+		plan: 'unlimited',
 	})
 
 	await expect(

--- a/packages/worker/src/package-registry/test-schema.ts
+++ b/packages/worker/src/package-registry/test-schema.ts
@@ -1,8 +1,8 @@
 /**
  * Schema for package scope grant / platform account workers-unit tests.
  * Local D1 does not apply migrations, so suites provision the tables they need.
- * Mirrors users columns from early migrations plus 0052/0075 (stable_user_id)
- * and 0072 (account_type, package_scope_grants).
+ * Mirrors users columns from early migrations plus 0052/0075 (stable_user_id),
+ * 0072 (account_type, package_scope_grants), and 0048 (plan).
  */
 export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
 	await db
@@ -15,6 +15,7 @@ export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
 	email_verified_at TEXT,
 	stable_user_id TEXT NOT NULL,
 	account_type TEXT NOT NULL DEFAULT 'person' CHECK (account_type IN ('person', 'platform')),
+	plan TEXT,
 	created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 	updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 )`,
@@ -24,6 +25,7 @@ export async function ensurePackageScopeGrantsTestSchema(db: D1Database) {
 		'email_verified_at TEXT',
 		'stable_user_id TEXT',
 		`account_type TEXT NOT NULL DEFAULT 'person'`,
+		'plan TEXT',
 	]) {
 		try {
 			await db.prepare(`ALTER TABLE users ADD COLUMN ${column}`).run()

--- a/tools/seed-sql.ts
+++ b/tools/seed-sql.ts
@@ -39,13 +39,14 @@ export function buildSeedUserSql(input: {
 	].join('\n')
 
 	return `
-INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
-VALUES (${quoteSqlString(input.username)}, ${quoteSqlString(input.email)}, ${quoteSqlString(input.passwordHash)}, CURRENT_TIMESTAMP, ${quoteSqlString(stableUserIdFromEmail(input.email))})
+INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id, plan)
+VALUES (${quoteSqlString(input.username)}, ${quoteSqlString(input.email)}, ${quoteSqlString(input.passwordHash)}, CURRENT_TIMESTAMP, ${quoteSqlString(stableUserIdFromEmail(input.email))}, 'unlimited')
 ON CONFLICT(email) DO UPDATE SET
   username = excluded.username,
   password_hash = excluded.password_hash,
   email_verified_at = COALESCE(users.email_verified_at, excluded.email_verified_at),
   stable_user_id = COALESCE(users.stable_user_id, excluded.stable_user_id),
+  plan = COALESCE(users.plan, excluded.plan),
   updated_at = CURRENT_TIMESTAMP;
 ${roleSql}`.trim()
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `unlimited` as a first-class manual plan with the same ordinary-resource access, email backstops, and workflow backstop behavior as the prior NULL state
- make signup, invite, admin, platform-account, and seed writers persist `unlimited`; keep Stripe-derived `stripe_plan` nullable and reject `unlimited` as Stripe metadata
- backfill `users.plan` and `invites.plan` from NULL to `unlimited` in migration 0080
- replace plan-related legacy wording in admin, billing, invite, entitlement, authentication, and email documentation

## Behavior invariant
No existing account loses access or gains enforcement it did not have. `unlimited` covers every ordinary tier exactly as NULL did; its email limits equal the existing NULL-plan abuse backstops, and the workflow deployment backstop remains active.

## Rollout
This PR keeps nullable/unknown stored-plan reads fail-open for deployment compatibility. `stripe_plan` remains nullable because it mirrors Stripe subscription state; `unlimited` is a manual/admin plan and is not purchasable. The follow-up NOT NULL stage will reconcile and verify any NULL written during the migration-before-Worker deployment window before rebuilding the tables.

## Validation
- `npm run validate`: passed on final reviewer-feedback head (format, lint, typecheck, 333 unit test files / 1,052 tests, 17 Playwright E2E tests, 2 MCP E2E tests, primitives, migrations)
- migration 0080 tests execute the real SQL for successful backfill and fail-closed rollback
- manual admin UI verification confirms metadata and selection stay synchronized, with exactly one explicit Unlimited option

![Admin plan options including one Unlimited choice](https://cursor.com/artifacts/c/art-310e2b5a-976f-4287-8de0-cec15c45dbd1)

<a href="https://cursor.com/agents/bc-a15e05b3-a0e4-4fb9-a65c-6f96ea59b6ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_unlimited_plan_final_clean.mp4"><img src="https://cursor.com/artifacts/c/art-f448132a-ab38-445e-aab1-a05ff3ce5941" alt="admin_unlimited_plan_final_clean.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `bc183102` · **Head:** `0977c081`

**Classification:** extends — plan storage and entitlement behavior gain an explicit unlimited state without changing effective access.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — first-class `unlimited` plan preserves prior NULL behavior |
| `d1-app-db` | storage | extends — backfills nullable user and invite plans |
| `app-sessions` | auth | extends — signup always writes an explicit plan |
| `rbac` | auth | extends — admin plan clearing becomes setting unlimited |
| `billing` | auth | composes — Stripe parsing excludes manual-only unlimited and missing subscription displays None |
| `app-ui` | surfaces | composes — admin and billing surfaces label/select Unlimited and guard loading states |

### System map

Signup and admin plan assignments now persist explicit unlimited grants into D1, while entitlement resolution keeps Stripe and abuse backstops behavior-preserving.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	rbac["rbac<br/>Role-based access control"]:::extended
	billing["billing<br/>Stripe billing"]:::touched
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	appUi -->|"select and display Unlimited"| rbac
	appSessions -->|"signup plan=unlimited"| d1AppDb
	rbac -->|"admin plan=unlimited"| d1AppDb
	d1AppDb -->|"users.plan + stripe_plan"| entitlements
	billing -->|"Stripe plans exclude unlimited"| entitlements
	entitlements -->|"ordinary unlimited; email/workflow backstops"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| NULL manual plan means unlimited | `unlimited` is an explicit manual plan |
| plan-less invite/signup writes NULL | every production writer stores a plan name |
| admin clears a plan | admin sets Unlimited |
| NULL email abuse backstops | identical limits live on `unlimited` |

### Invariants

- No existing account gains entitlement enforcement or loses access.
- Every user lookup remains scoped by stable `userId` plus account email.
- `stripe_plan` remains a nullable Stripe projection and cannot contain manual-only `unlimited` through billing parsing.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a15e05b3-a0e4-4fb9-a65c-6f96ea59b6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a15e05b3-a0e4-4fb9-a65c-6f96ea59b6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit **Unlimited** entitlement plan across billing, invitations, signup, and admin account management.
  * Admin plan edits now treat stored legacy/NULL selections as **Unlimited**, including correct UI defaults and payloads.
  * Introduced a migration to backfill `users.plan` and `invites.plan` from NULL to **unlimited**, and aligned plan fallback/fail-open enforcement behavior.

* **Documentation**
  * Updated entitlements and authentication docs to reflect the new **Unlimited** model, defaulting, and fallback semantics.

* **Tests**
  * Expanded e2e and unit coverage for plan parsing, UI hydration, migration rollback safety, and updated enforcement expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->