### PR TITLE
Consolidate test harness helpers and document test flavors

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -464,7 +464,9 @@ Public MCP behavior should be verified through the compact tool surface:
 
 Prefer `*.node.test.ts` and `*.workers.test.ts` for capability behavior. Reserve
 `packages/worker/src/mcp/*.mcp-e2e.test.ts` for a very small number of real MCP
-contract smoke tests.
+contract smoke tests. See the
+[test flavor decision matrix](./testing-principles.md#test-flavor-decision-matrix)
+for when each flavor is appropriate.
 
 Registry invariants (duplicate capability names, domain/capability mismatches,
 duplicate domain registration) are covered in

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -209,7 +209,9 @@ Guarantees and rules:
    `undefined` — do not approximate.
 5. **Do not change behavior.** No new throws, no altered return values, no added
    latency beyond the awaited write (use `ctx.waitUntil` in DOs if needed).
-6. **Test it.** In `*.node.test.ts`, spy on the helper:
+6. **Test it.** Pick the flavor with the
+   [test flavor decision matrix](../testing-principles.md#test-flavor-decision-matrix).
+   In `*.node.test.ts`, spy on the helper:
 
    ```ts
    const usageModule = await import('#worker/usage/record-usage.ts')

--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -113,8 +113,9 @@ Common commands:
 - `npx playwright test e2e/login.spec.ts`
 
 For MCP capability work, prefer `*.node.test.ts` or `*.workers.test.ts` beside
-the implementation and keep `npm run test:mcp` limited to a couple of
-high-signal smoke journeys.
+the implementation (see the
+[test flavor decision matrix](./testing-principles.md#test-flavor-decision-matrix))
+and keep `npm run test:mcp` limited to a couple of high-signal smoke journeys.
 
 If `packages/worker/.env` is missing, the E2E server startup path copies
 `packages/worker/.env.example` to `packages/worker/.env` before Wrangler starts.

--- a/docs/contributing/testing-principles.md
+++ b/docs/contributing/testing-principles.md
@@ -4,6 +4,29 @@ This codebase favors small, readable test suites with explicit setup and minimal
 magic. Individual tests should follow a meaningful workflow end-to-end, even
 when that makes a single test longer and more assertion-heavy.
 
+## Test flavor decision matrix
+
+Choose the lightest flavor that can falsify the behavior. Filename suffixes pick
+the Vitest project (`vitest.config.ts`):
+
+| Flavor / command                              | Use when                                                                                                                                                                                                                                                                                                        | Avoid when                                                                                                                                                                                                                                         |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `*.node.test.ts` (`npm run test` / node-unit) | Pure server logic, pure functions, handlers/services that can run against an in-memory `node:sqlite` D1 facade (`createD1FromSqlite` in `packages/worker/src/test-support/`), or code that is correctly covered by spies/stubs (for example `vi.spyOn` on `recordUsage`). Fast feedback; no Workers runtime.    | The assertion needs real Cloudflare bindings (`env.APP_DB`, KV, DO, R2) or Workers-only APIs that the node stubs do not honestly exercise.                                                                                                         |
+| `*.workers.test.ts` (workers-unit)            | The behavior depends on real local bindings from `cloudflare:workers` / the Vitest Workers pool (D1 schema + queries, KV reads/writes, DO stubs as configured). Prefer shared explicit-import factories from `packages/worker/src/test-support/` and domain `test-schema.ts` helpers over copy-pasted seed SQL. | The file never reads `env` / bindings and only tests pure registry or string logic — prefer `*.node.test.ts` instead (several `src/mcp/**` workers suites are historical misclassifications; leave them unless you are already editing that area). |
+| `*.mcp-e2e.test.ts` (`npm run test:mcp`)      | A tiny smoke suite for the real MCP HTTP transport, OAuth, and package-app session wiring.                                                                                                                                                                                                                      | Capability-by-capability coverage that does not need that transport — put those beside the implementation as node or workers tests.                                                                                                                |
+| Playwright (`npm run test:e2e:run`)           | A very small number of user-critical happy-path journeys through the worker + client. See [end-to-end testing](./end-to-end-testing.md).                                                                                                                                                                        | Edge cases, copy pinning, or anything a faster unit/integration test can cover.                                                                                                                                                                    |
+
+**Usage metering example** (lifted from
+[usage metering](./architecture/usage-metering.md)): in `*.node.test.ts`, spy on
+`recordUsage` and assert call shape for success and failure paths. In
+`*.workers.test.ts` with a real local D1, call `ensureUsageRollupsTestSchema`
+from `packages/worker/src/usage/test-schema.ts` and assert on `usage_rollups`
+rows instead of spying.
+
+Shared test helpers live under `packages/worker/src/test-support/`. Import
+factories explicitly inside each test (or a per-test factory). Do not introduce
+`beforeEach` hooks that hide setup — that conflicts with the principles below.
+
 ## Principles
 
 - Prefer the "fewer, longer tests" style from Kent C. Dodds when assertions

--- a/packages/worker/src/app/admin-platform-feedback-data.node.test.ts
+++ b/packages/worker/src/app/admin-platform-feedback-data.node.test.ts
@@ -2,47 +2,8 @@ import { readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
 import { platformFeedbackContentWarning } from '#worker/platform-feedback/content-warning.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { loadAdminPlatformFeedbackData } from './admin-platform-feedback-data.ts'
-
-type TestD1Statement = {
-	bind(...params: Array<unknown>): TestD1Statement
-	all<T>(): Promise<{ results: Array<T>; meta: { changes: number } }>
-	first<T>(): Promise<T | null>
-	run(): Promise<{ meta: { changes: number } }>
-}
-
-function createD1FromSqlite(sqlite: DatabaseSync, queries: Array<string>) {
-	function createStatement(
-		query: string,
-		params: Array<unknown> = [],
-	): TestD1Statement {
-		return {
-			bind(...boundParams: Array<unknown>) {
-				return createStatement(query, boundParams)
-			},
-			async all<T>() {
-				return {
-					results: sqlite.prepare(query).all(...params) as Array<T>,
-					meta: { changes: 0 },
-				}
-			},
-			async first<T>() {
-				return (sqlite.prepare(query).get(...params) ?? null) as T | null
-			},
-			async run() {
-				const result = sqlite.prepare(query).run(...params)
-				return { meta: { changes: result.changes } }
-			},
-		}
-	}
-
-	return {
-		prepare(query: string) {
-			queries.push(query.replace(/\s+/g, ' ').trim())
-			return createStatement(query)
-		},
-	} as unknown as D1Database
-}
 
 function createAdminPlatformFeedbackFixture() {
 	const sqlite = new DatabaseSync(':memory:')
@@ -140,7 +101,7 @@ function createAdminPlatformFeedbackFixture() {
 	return {
 		sqlite,
 		queries,
-		env: { APP_DB: createD1FromSqlite(sqlite, queries) } as Env,
+		env: { APP_DB: createD1FromSqlite(sqlite, { queries }) } as Env,
 	}
 }
 

--- a/packages/worker/src/entitlements/entitlements-service.workers.test.ts
+++ b/packages/worker/src/entitlements/entitlements-service.workers.test.ts
@@ -7,33 +7,20 @@ import {
 	consoleWarn,
 	silenceExpectedConsoleWarns,
 } from '#worker/test-support/console-spies.ts'
+import { seedAccount } from '#worker/test-support/workers-seed.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
-
-async function seedAccount(
-	email: string,
-	plan: 'pro' | 'max',
-	stableUserId: string,
-) {
-	await env.APP_DB.prepare(
-		`INSERT INTO users (username, email, password_hash, email_verified_at, plan, stable_user_id)
-			VALUES (?, ?, ?, ?, ?, ?)`,
-	)
-		.bind(
-			`entitlement-service-${crypto.randomUUID().slice(0, 8)}`,
-			email,
-			'test-password-hash',
-			new Date().toISOString(),
-			plan,
-			stableUserId,
-		)
-		.run()
-}
 
 test('findUserAccountByStableUserId resolves accounts via indexed stable id and recovers from deletions', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
 	const email = `reverse-lookup-${crypto.randomUUID()}@example.com`
 	const userId = await createStableUserIdFromEmail(email)
-	await seedAccount(email, 'pro', userId)
+	await seedAccount({
+		db: env.APP_DB,
+		email,
+		username: `entitlement-service-${crypto.randomUUID().slice(0, 8)}`,
+		plan: 'pro',
+		stableUserId: userId,
+	})
 
 	expect(await findUserAccountByStableUserId(env.APP_DB, userId)).toEqual({
 		email,

--- a/packages/worker/src/package-registry/saved-packages-hidden-migration.node.test.ts
+++ b/packages/worker/src/package-registry/saved-packages-hidden-migration.node.test.ts
@@ -1,38 +1,12 @@
 import { readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 
 const migrationsDirectory = new URL('../../migrations/', import.meta.url)
 
 function applyMigration(db: DatabaseSync, fileName: string) {
 	db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
-}
-
-function createD1FromSqlite(db: DatabaseSync) {
-	return {
-		prepare(query: string) {
-			return {
-				bind(...params: Array<unknown>) {
-					return {
-						async all<T>() {
-							const statement = db.prepare(query)
-							const rows = statement.all(...params) as Array<T>
-							return { results: rows, meta: { changes: 0 } }
-						},
-						async first<T>() {
-							const statement = db.prepare(query)
-							return (statement.get(...params) ?? null) as T | null
-						},
-						async run() {
-							const statement = db.prepare(query)
-							const result = statement.run(...params)
-							return { meta: { changes: result.changes } }
-						},
-					}
-				},
-			}
-		},
-	} as unknown as D1Database
 }
 
 test('saved packages hidden migration defaults existing rows to visible and hydrates reads', async () => {

--- a/packages/worker/src/platform-feedback/platform-feedback-service.node.test.ts
+++ b/packages/worker/src/platform-feedback/platform-feedback-service.node.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import {
 	getPlatformFeedbackByIdForAdmin,
 	updatePlatformFeedbackStatusForAdmin,
@@ -11,59 +12,6 @@ import {
 	submitPlatformFeedback,
 	updatePlatformFeedbackForAdmin,
 } from './service.ts'
-
-type TestD1Statement = {
-	bind(...params: Array<unknown>): TestD1Statement
-	all<T>(): Promise<{ results: Array<T>; meta: { changes: number } }>
-	first<T>(): Promise<T | null>
-	run(): Promise<{ meta: { changes: number } }>
-}
-
-function createD1FromSqlite(sqlite: DatabaseSync, queries: Array<string> = []) {
-	function createStatement(
-		query: string,
-		params: Array<unknown> = [],
-	): TestD1Statement {
-		return {
-			bind(...boundParams: Array<unknown>) {
-				return createStatement(query, boundParams)
-			},
-			async all<T>() {
-				return {
-					results: sqlite.prepare(query).all(...params) as Array<T>,
-					meta: { changes: 0 },
-				}
-			},
-			async first<T>() {
-				return (sqlite.prepare(query).get(...params) ?? null) as T | null
-			},
-			async run() {
-				const result = sqlite.prepare(query).run(...params)
-				return { meta: { changes: result.changes } }
-			},
-		}
-	}
-	return {
-		prepare(query: string) {
-			queries.push(query.replace(/\s+/g, ' ').trim())
-			return createStatement(query)
-		},
-		async batch(statements: Array<TestD1Statement>) {
-			const results = []
-			sqlite.exec('BEGIN')
-			try {
-				for (const statement of statements) {
-					results.push(await statement.run())
-				}
-				sqlite.exec('COMMIT')
-				return results
-			} catch (error) {
-				sqlite.exec('ROLLBACK')
-				throw error
-			}
-		},
-	} as unknown as D1Database
-}
 
 function createPlatformFeedbackDb() {
 	const sqlite = new DatabaseSync(':memory:')
@@ -83,7 +31,11 @@ function createPlatformFeedbackDb() {
 		),
 	)
 	const queries: Array<string> = []
-	return { sqlite, db: createD1FromSqlite(sqlite, queries), queries }
+	return {
+		sqlite,
+		db: createD1FromSqlite(sqlite, { queries }),
+		queries,
+	}
 }
 
 test('platform feedback workflow submits, lists, reads, transitions, and preserves submitter attribution', async () => {

--- a/packages/worker/src/platform-feedback/platform-feedback-subscriptions.workers.test.ts
+++ b/packages/worker/src/platform-feedback/platform-feedback-subscriptions.workers.test.ts
@@ -2,6 +2,12 @@ import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
+import {
+	assignAdminRole,
+	ensurePackageSubscriptionTestSchema,
+	ensureRbacTestSchema,
+	seedAccount,
+} from '#worker/test-support/workers-seed.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { platformFeedbackContentWarning } from './content-warning.ts'
 import { dispatchPlatformFeedbackSubmittedSubscriptionEvent } from './package-subscriptions.ts'
@@ -26,84 +32,6 @@ const openFeedback = {
 	adminNote: null,
 	createdAt: '2026-07-19T01:00:00.000Z',
 	updatedAt: '2026-07-19T01:00:00.000Z',
-}
-
-async function ensurePackageSubscriptionTestSchema(db: D1Database) {
-	const statements = [
-		`CREATE TABLE IF NOT EXISTS saved_packages (
-			id TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
-			name TEXT NOT NULL,
-			kody_id TEXT NOT NULL,
-			description TEXT NOT NULL,
-			tags_json TEXT NOT NULL DEFAULT '[]',
-			search_text TEXT,
-			source_id TEXT NOT NULL,
-			has_app INTEGER NOT NULL DEFAULT 0,
-			hidden INTEGER NOT NULL DEFAULT 0,
-			is_private INTEGER NOT NULL DEFAULT 1,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL
-		)`,
-		`CREATE TABLE IF NOT EXISTS entity_sources (
-			id TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
-			entity_kind TEXT NOT NULL,
-			entity_id TEXT NOT NULL,
-			repo_id TEXT NOT NULL,
-			published_commit TEXT,
-			indexed_commit TEXT,
-			manifest_path TEXT NOT NULL,
-			source_root TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL
-		)`,
-		`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
-			id TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
-			source_id TEXT NOT NULL,
-			published_commit TEXT NOT NULL,
-			artifact_kind TEXT NOT NULL,
-			artifact_name TEXT,
-			entry_point TEXT NOT NULL,
-			kv_key TEXT NOT NULL,
-			dependencies_json TEXT NOT NULL DEFAULT '[]',
-			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-		)`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_published_bundle_artifacts_identity
-		ON published_bundle_artifacts(user_id, source_id, artifact_kind, COALESCE(artifact_name, ''), entry_point)`,
-		`CREATE TABLE IF NOT EXISTS package_invocations (
-			id TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
-			token_id TEXT NOT NULL,
-			package_id TEXT NOT NULL,
-			package_kody_id TEXT NOT NULL,
-			export_name TEXT NOT NULL,
-			idempotency_key TEXT NOT NULL,
-			request_hash TEXT NOT NULL,
-			source TEXT,
-			topic TEXT,
-			status TEXT NOT NULL,
-			response_json TEXT,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL
-		)`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_package_invocations_key
-		ON package_invocations(user_id, token_id, package_id, export_name, idempotency_key)`,
-	]
-	for (const statement of statements) {
-		await db.prepare(statement).run()
-	}
-	try {
-		await db
-			.prepare(
-				`ALTER TABLE saved_packages ADD COLUMN is_private INTEGER NOT NULL DEFAULT 1`,
-			)
-			.run()
-	} catch {
-		// Column already present on newer schemas.
-	}
 }
 
 async function ensurePlatformFeedbackTestSchema(db: D1Database) {
@@ -145,72 +73,6 @@ async function ensurePlatformFeedbackTestSchema(db: D1Database) {
 			.prepare(`ALTER TABLE platform_feedback ADD COLUMN submitter_email TEXT`)
 			.run()
 	}
-}
-
-async function ensureRbacTestSchema(db: D1Database) {
-	await db
-		.prepare(
-			`CREATE TABLE IF NOT EXISTS users (
-				id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-				username TEXT NOT NULL UNIQUE,
-				email TEXT NOT NULL UNIQUE,
-				password_hash TEXT NOT NULL,
-				email_verified_at TEXT,
-				stable_user_id TEXT,
-				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-			)`,
-		)
-		.run()
-	await db
-		.prepare(
-			`CREATE TABLE IF NOT EXISTS roles (
-				id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-				name TEXT NOT NULL UNIQUE,
-				description TEXT NOT NULL DEFAULT ''
-			)`,
-		)
-		.run()
-	await db
-		.prepare(
-			`CREATE TABLE IF NOT EXISTS user_roles (
-				user_id INTEGER NOT NULL,
-				role_id INTEGER NOT NULL,
-				PRIMARY KEY (user_id, role_id)
-			)`,
-		)
-		.run()
-	await db
-		.prepare(`INSERT OR IGNORE INTO roles (name) VALUES ('user'), ('admin')`)
-		.run()
-}
-
-async function seedAccount(input: { email: string; username: string }) {
-	const stableUserId = await createStableUserIdFromEmail(input.email)
-	await env.APP_DB.prepare(
-		`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
-		 VALUES (?, ?, 'test-password-hash', ?, ?)
-		 ON CONFLICT(email) DO UPDATE SET
-			username = excluded.username,
-			stable_user_id = COALESCE(users.stable_user_id, excluded.stable_user_id),
-			updated_at = CURRENT_TIMESTAMP`,
-	)
-		.bind(input.username, input.email, new Date().toISOString(), stableUserId)
-		.run()
-	const row = await env.APP_DB.prepare(`SELECT id FROM users WHERE email = ?`)
-		.bind(input.email)
-		.first<{ id: number }>()
-	if (!row) throw new Error(`Expected seeded user row for ${input.email}`)
-	return row.id
-}
-
-async function assignAdminRole(userId: number) {
-	await env.APP_DB.prepare(
-		`INSERT OR IGNORE INTO user_roles (user_id, role_id)
-		 SELECT ?, id FROM roles WHERE name = 'admin'`,
-	)
-		.bind(userId)
-		.run()
 }
 
 async function seedSubscribedPackage(input: {
@@ -361,6 +223,7 @@ test('platform feedback dispatch keeps stored identity snapshots idempotent acro
 	const submitterUsername = `feedbacksubmitter-${crypto.randomUUID().slice(0, 8)}`
 	const submitterStableId = await createStableUserIdFromEmail(submitterEmail)
 	const submitterAccountId = await seedAccount({
+		db: env.APP_DB,
 		email: submitterEmail,
 		username: submitterUsername,
 	})
@@ -394,14 +257,16 @@ test('platform feedback dispatch keeps stored identity snapshots idempotent acro
 	const adminEmail = `feedback-sub-admin-${crypto.randomUUID()}@example.com`
 	const adminStableId = await createStableUserIdFromEmail(adminEmail)
 	const adminAccountId = await seedAccount({
+		db: env.APP_DB,
 		email: adminEmail,
 		username: `feedbackadmin-${crypto.randomUUID().slice(0, 8)}`,
 	})
-	await assignAdminRole(adminAccountId)
+	await assignAdminRole({ db: env.APP_DB, userId: adminAccountId })
 
 	const regularEmail = `feedback-sub-user-${crypto.randomUUID()}@example.com`
 	const regularStableId = await createStableUserIdFromEmail(regularEmail)
 	await seedAccount({
+		db: env.APP_DB,
 		email: regularEmail,
 		username: `feedbackuser-${crypto.randomUUID().slice(0, 8)}`,
 	})

--- a/packages/worker/src/test-support/create-d1-from-sqlite.ts
+++ b/packages/worker/src/test-support/create-d1-from-sqlite.ts
@@ -1,4 +1,4 @@
-import  { type DatabaseSync } from 'node:sqlite'
+import { type DatabaseSync } from 'node:sqlite'
 
 export type CreateD1FromSqliteOptions = {
 	/**

--- a/packages/worker/src/test-support/create-d1-from-sqlite.ts
+++ b/packages/worker/src/test-support/create-d1-from-sqlite.ts
@@ -1,0 +1,123 @@
+import  { type DatabaseSync } from 'node:sqlite'
+
+export type CreateD1FromSqliteOptions = {
+	/**
+	 * When set, `bind(...params)` throws if `params.length` exceeds the limit
+	 * (used to exercise D1 binding-count constraints in tests).
+	 */
+	maxBindings?: number
+	/** Invoked with the row count whenever `all()` returns results. */
+	onQueryRows?: (rowCount: number) => void
+	/**
+	 * When provided, each prepared query is appended after whitespace
+	 * normalization (useful for asserting which SQL a code path issues).
+	 */
+	queries?: Array<string>
+}
+
+type StatementRunner = {
+	run: () => Promise<unknown>
+}
+
+/**
+ * Thin D1Database facade over `node:sqlite` `DatabaseSync` for `*.node.test.ts`
+ * suites that need SQL without Cloudflare Workers bindings.
+ *
+ * Prefer importing this over copy-pasting a local helper. Pass options only when
+ * a test needs query capture, binding limits, or row-count hooks.
+ */
+export function createD1FromSqlite(
+	db: DatabaseSync,
+	options: CreateD1FromSqliteOptions = {},
+): D1Database {
+	function assertBindingCount(params: Array<unknown>) {
+		if (
+			options.maxBindings !== undefined &&
+			params.length > options.maxBindings
+		) {
+			throw new Error(`too many SQL variables: ${params.length}`)
+		}
+	}
+
+	function createPreparedStatement(query: string) {
+		return {
+			query,
+			bind(...params: Array<unknown>) {
+				assertBindingCount(params)
+				return {
+					query,
+					async all<T>() {
+						const statement = db.prepare(query)
+						const rows = statement.all(...params) as Array<T>
+						options.onQueryRows?.(rows.length)
+						return {
+							results: rows,
+							meta: { changes: 0, last_row_id: 0 },
+						}
+					},
+					async first<T>() {
+						const statement = db.prepare(query)
+						return (statement.get(...params) ?? null) as T | null
+					},
+					async run() {
+						const statement = db.prepare(query)
+						const result = statement.run(...params)
+						return {
+							meta: {
+								changes: result.changes,
+								last_row_id: Number(result.lastInsertRowid),
+							},
+						}
+					},
+				}
+			},
+			async all<T>() {
+				const statement = db.prepare(query)
+				const rows = statement.all() as Array<T>
+				options.onQueryRows?.(rows.length)
+				return {
+					results: rows,
+					meta: { changes: 0, last_row_id: 0 },
+				}
+			},
+			async first<T>() {
+				const statement = db.prepare(query)
+				return (statement.get() ?? null) as T | null
+			},
+			async run() {
+				const statement = db.prepare(query)
+				const result = statement.run()
+				return {
+					meta: {
+						changes: result.changes,
+						last_row_id: Number(result.lastInsertRowid),
+					},
+				}
+			},
+		}
+	}
+
+	return {
+		prepare(query: string) {
+			options.queries?.push(query.replace(/\s+/g, ' ').trim())
+			return createPreparedStatement(query)
+		},
+		async batch(statements: Array<StatementRunner>) {
+			const results = []
+			db.exec('BEGIN')
+			try {
+				for (const statement of statements) {
+					results.push(await statement.run())
+				}
+				db.exec('COMMIT')
+				return results
+			} catch (error) {
+				db.exec('ROLLBACK')
+				throw error
+			}
+		},
+		async exec(query: string) {
+			db.exec(query)
+		},
+	} as unknown as D1Database
+}

--- a/packages/worker/src/test-support/workers-seed.ts
+++ b/packages/worker/src/test-support/workers-seed.ts
@@ -1,0 +1,193 @@
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { ensureEntitlementTestSchema } from '#worker/entitlements/test-schema.ts'
+
+/**
+ * Explicit-import factories for `*.workers.test.ts` suites that need a local
+ * D1 user/RBAC/package-subscription schema. Call these inside each test (or a
+ * per-test factory) — do not wire them through `beforeEach`.
+ */
+
+export async function ensureRbacTestSchema(db: D1Database) {
+	await ensureEntitlementTestSchema(db)
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS roles (
+				id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+				name TEXT NOT NULL UNIQUE,
+				description TEXT NOT NULL DEFAULT ''
+			)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS user_roles (
+				user_id INTEGER NOT NULL,
+				role_id INTEGER NOT NULL,
+				PRIMARY KEY (user_id, role_id)
+			)`,
+		)
+		.run()
+	await db
+		.prepare(`INSERT OR IGNORE INTO roles (name) VALUES ('user'), ('admin')`)
+		.run()
+}
+
+export async function ensurePackageSubscriptionTestSchema(db: D1Database) {
+	const statements = [
+		`CREATE TABLE IF NOT EXISTS saved_packages (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			kody_id TEXT NOT NULL,
+			description TEXT NOT NULL,
+			tags_json TEXT NOT NULL DEFAULT '[]',
+			search_text TEXT,
+			source_id TEXT NOT NULL,
+			has_app INTEGER NOT NULL DEFAULT 0,
+			hidden INTEGER NOT NULL DEFAULT 0,
+			is_private INTEGER NOT NULL DEFAULT 1,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS entity_sources (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			entity_kind TEXT NOT NULL,
+			entity_id TEXT NOT NULL,
+			repo_id TEXT NOT NULL,
+			published_commit TEXT,
+			indexed_commit TEXT,
+			manifest_path TEXT NOT NULL,
+			source_root TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			published_commit TEXT NOT NULL,
+			artifact_kind TEXT NOT NULL,
+			artifact_name TEXT,
+			entry_point TEXT NOT NULL,
+			kv_key TEXT NOT NULL,
+			dependencies_json TEXT NOT NULL DEFAULT '[]',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_published_bundle_artifacts_identity
+		ON published_bundle_artifacts(user_id, source_id, artifact_kind, COALESCE(artifact_name, ''), entry_point)`,
+		`CREATE TABLE IF NOT EXISTS package_invocations (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			token_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			package_kody_id TEXT NOT NULL,
+			export_name TEXT NOT NULL,
+			idempotency_key TEXT NOT NULL,
+			request_hash TEXT NOT NULL,
+			source TEXT,
+			topic TEXT,
+			status TEXT NOT NULL,
+			response_json TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_package_invocations_key
+		ON package_invocations(user_id, token_id, package_id, export_name, idempotency_key)`,
+	]
+	for (const statement of statements) {
+		await db.prepare(statement).run()
+	}
+	try {
+		await db
+			.prepare(
+				`ALTER TABLE saved_packages ADD COLUMN is_private INTEGER NOT NULL DEFAULT 1`,
+			)
+			.run()
+	} catch {
+		// Column already present on newer schemas.
+	}
+}
+
+/**
+ * Upserts a users row for workers-unit tests and returns the numeric account id.
+ * Pass `db` explicitly (usually `env.APP_DB`) — no ambient default.
+ */
+export async function seedAccount(input: {
+	db: D1Database
+	email: string
+	username: string
+	emailVerifiedAt?: string | null
+	plan?: string
+	passwordHash?: string
+	stableUserId?: string
+}): Promise<number> {
+	const stableUserId =
+		input.stableUserId ?? (await createStableUserIdFromEmail(input.email))
+	const emailVerifiedAt =
+		input.emailVerifiedAt === undefined
+			? new Date().toISOString()
+			: input.emailVerifiedAt
+	const passwordHash = input.passwordHash ?? 'test-password-hash'
+	if (input.plan === undefined) {
+		await input.db
+			.prepare(
+				`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
+				 VALUES (?, ?, ?, ?, ?)
+				 ON CONFLICT(email) DO UPDATE SET
+					username = excluded.username,
+					email_verified_at = excluded.email_verified_at,
+					stable_user_id = COALESCE(users.stable_user_id, excluded.stable_user_id),
+					updated_at = CURRENT_TIMESTAMP`,
+			)
+			.bind(
+				input.username,
+				input.email,
+				passwordHash,
+				emailVerifiedAt,
+				stableUserId,
+			)
+			.run()
+	} else {
+		await input.db
+			.prepare(
+				`INSERT INTO users (username, email, password_hash, email_verified_at, plan, stable_user_id)
+				 VALUES (?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(email) DO UPDATE SET
+					username = excluded.username,
+					email_verified_at = excluded.email_verified_at,
+					plan = excluded.plan,
+					stable_user_id = COALESCE(users.stable_user_id, excluded.stable_user_id),
+					updated_at = CURRENT_TIMESTAMP`,
+			)
+			.bind(
+				input.username,
+				input.email,
+				passwordHash,
+				emailVerifiedAt,
+				input.plan,
+				stableUserId,
+			)
+			.run()
+	}
+	const row = await input.db
+		.prepare(`SELECT id FROM users WHERE email = ?`)
+		.bind(input.email)
+		.first<{ id: number }>()
+	if (!row) throw new Error(`Expected seeded user row for ${input.email}`)
+	return row.id
+}
+
+export async function assignAdminRole(input: {
+	db: D1Database
+	userId: number
+}) {
+	await input.db
+		.prepare(
+			`INSERT OR IGNORE INTO user_roles (user_id, role_id)
+			 SELECT ?, id FROM roles WHERE name = 'admin'`,
+		)
+		.bind(input.userId)
+		.run()
+}

--- a/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
+++ b/packages/worker/src/usage/agent-package-conversation-uses.node.test.ts
@@ -2,49 +2,12 @@ import { readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import {
 	listPopularAgentPackagesForUser,
 	recordAgentPackageConversationUse,
 	recordAgentPackageConversationUses,
 } from './agent-package-conversation-uses.ts'
-
-type TestD1Statement = {
-	bind(...params: Array<unknown>): TestD1Statement
-	all<T>(): Promise<{ results: Array<T>; meta: { changes: number } }>
-	first<T>(): Promise<T | null>
-	run(): Promise<{ meta: { changes: number } }>
-}
-
-function createD1FromSqlite(sqlite: DatabaseSync) {
-	function createStatement(
-		query: string,
-		params: Array<unknown> = [],
-	): TestD1Statement {
-		return {
-			bind(...boundParams: Array<unknown>) {
-				return createStatement(query, boundParams)
-			},
-			async all<T>() {
-				return {
-					results: sqlite.prepare(query).all(...params) as Array<T>,
-					meta: { changes: 0 },
-				}
-			},
-			async first<T>() {
-				return (sqlite.prepare(query).get(...params) ?? null) as T | null
-			},
-			async run() {
-				const result = sqlite.prepare(query).run(...params)
-				return { meta: { changes: result.changes } }
-			},
-		}
-	}
-	return {
-		prepare(query: string) {
-			return createStatement(query)
-		},
-	} as unknown as D1Database
-}
 
 function createTestDb() {
 	const sqlite = new DatabaseSync(':memory:')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Track E of the repo-improvement program: consolidate duplicated test harness helpers and document when to use each test flavor. Test infra + docs only — no production behavior changes.

### What changed

- Added shared `createD1FromSqlite` (`packages/worker/src/test-support/create-d1-from-sqlite.ts`) for `*.node.test.ts` in-memory D1 facades.
- Added workers seed/schema factories (`packages/worker/src/test-support/workers-seed.ts`): `ensureRbacTestSchema`, `ensurePackageSubscriptionTestSchema`, `seedAccount`, `assignAdminRole` — explicit-import style (no `beforeEach`).
- Migrated non-sibling-owned call sites to the shared helpers.
- Documented the node / workers / mcp-e2e / Playwright decision matrix in [`docs/contributing/testing-principles.md`](../blob/cursor/kody-track-e-test-harness-c3cf/docs/contributing/testing-principles.md#test-flavor-decision-matrix), with cross-links from usage-metering, end-to-end-testing, and adding-capabilities.

### Migrated in this PR

- `usage/agent-package-conversation-uses.node.test.ts`
- `package-registry/saved-packages-hidden-migration.node.test.ts`
- `platform-feedback/platform-feedback-service.node.test.ts`
- `app/admin-platform-feedback-data.node.test.ts`
- `platform-feedback/platform-feedback-subscriptions.workers.test.ts`
- `entitlements/entitlements-service.workers.test.ts`

### Follow-up checklist (sibling-owned — migrate after those tracks land)

Replace local `createD1FromSqlite` with `#worker/test-support/create-d1-from-sqlite.ts`:

- [ ] `src/community/community-activity-service.node.test.ts` (Track D)
- [ ] `src/app/retention.node.test.ts` (Track B) — uses `maxBindings`
- [ ] `src/app/account-export.node.test.ts` (Track B) — uses `onQueryRows`
- [ ] `src/app/handlers/two-factor.node.test.ts` (Track A)
- [ ] `src/app/handlers/passkeys.node.test.ts` (Track A)
- [ ] `src/app/handlers/auth-provider.node.test.ts` (Track A)
- [ ] `src/app/handlers/account-email-change.node.test.ts` (Track A)

Replace local seed/schema helpers with `#worker/test-support/workers-seed.ts` (and keep domain-specific bits local):

- [ ] `src/email/system-email-subscriptions.workers.test.ts` — `ensurePackageSubscriptionTestSchema`, `ensureRbacTestSchema`, `seedAccount`, `assignAdminRole` (Track D)
- [ ] `src/email/inbound.workers.test.ts` — `seedAccount` (Track D)
- [ ] `src/email/inbound-account-isolation.workers.test.ts` — `seedAccount` (Track D)
- [ ] `src/email/inbound-entitlements.workers.test.ts` — fold `seedAccountWithPlan` into shared `seedAccount({ plan })` (Track D)
- [ ] Email `createInboundEnv()` copies across `src/email/*.workers.test.ts` (Track D) — extract a tiny shared helper if still duplicated after Track D

### Notes (out of scope)

- `silenceIncidentalRuntimeWarnings` was already centralized; no change needed.
- Misclassified workers tests under `src/mcp/` that do not use real bindings (e.g. `build-capability-registry.workers.test.ts`, `capability-search.workers.test.ts`) are noted in the decision matrix only — sibling territory, not edited here.

### Risk

Low — test helpers + contributing docs. Production code paths untouched.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/kody-track-e-test-harness-c3cf`

**Classification:** composes — shared test factories and docs only; no production primitive contracts changed.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — admin platform-feedback test adopts shared D1 helper |
| `entitlements` | auth | composes — workers test adopts shared `seedAccount` |
| `platform-feedback` | assistant | composes — node/workers tests adopt shared helpers |
| `saved-packages` | assistant | composes — migration test adopts shared D1 helper |
| `usage-metering` | storage | composes — usage test adopts shared D1 helper; docs cross-link flavor matrix |

### System map

Test suites compose shared test-support factories instead of inlined D1/seed helpers; contributing docs point at the flavor matrix.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	testSupport["test-support<br/>Shared factories"]:::touched
	usageMetering["usage-metering<br/>Usage metering"]:::touched
	platformFeedback["platform-feedback<br/>Platform feedback"]:::touched
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	entitlements["entitlements<br/>Entitlements"]:::touched
	appUi["app-ui<br/>App UI"]:::touched
	testSupport -->|"createD1FromSqlite import"| usageMetering
	testSupport -->|"createD1FromSqlite import"| platformFeedback
	testSupport -->|"createD1FromSqlite import"| savedPackages
	testSupport -->|"createD1FromSqlite import"| appUi
	testSupport -->|"seedAccount / schema factories"| platformFeedback
	testSupport -->|"seedAccount import"| entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71fbd95f-390e-46d0-af44-73409bda466c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71fbd95f-390e-46d0-af44-73409bda466c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a test flavor decision matrix to clarify when to use unit, Workers, MCP end-to-end, and Playwright tests.
  * Updated testing guidance for contract smoke tests, usage metering examples, and MCP-related end-to-end scenarios.

* **Tests**
  * Standardized D1 test database creation by using shared utilities across node and Workers test suites.
  * Centralized Workers test schema setup and account/role seeding via shared helpers, simplifying individual test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->