### PR TITLE
Centralize user-scoped Durable Object idFromName builders

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -393,32 +393,37 @@ Storage split:
 ## Per-user Durable Object naming
 
 The Durable Objects whose state is intrinsically owned by one user are named so
-that two different users always resolve to two different object ids:
+that two different users always resolve to two different object ids. Builders
+live in `packages/worker/src/user-scoped-durable-object-name.ts` (JSON tuples
+via `durableObjectNameFromParts`); domain helpers such as
+`userScopedConnectorSessionKey` delegate to that module.
 
-- `JobManager` — `idFromName(userId)`
-  (`packages/worker/src/jobs/manager-client.ts`).
-- `StorageRunner` — `idFromName(JSON.stringify([userId, storageId]))`
-  (`packages/worker/src/storage-runner.ts`).
-- `RepoSession` — keyed by `repo_sessions.id`; every RPC validates the D1
-  session row's `user_id` before touching the workspace. Account deletion
-  enumerates the user's session ids before deleting D1 rows and purges each DO.
-- `PackageRealtimeSession` and `PackageServiceInstance` — keyed by
-  `(userId, packageId, ...)` via the helpers in
-  `packages/worker/src/package-runtime/`. Account deletion enumerates app
-  packages and observed service instances, closes live sessions/services, clears
-  alarms, and deletes DO storage.
+- `JobManager` — `jobManagerDurableObjectName(userId)` → `idFromName(userId)`.
+- `McpClientHub` — `mcpClientHubDurableObjectName(userId)` →
+  `idFromName(userId.trim())`.
+- `StorageRunner` — `storageRunnerDurableObjectName(userId, storageId)` →
+  `idFromName(JSON.stringify([userId, storageId]))`.
+- `PackageRealtimeSession` —
+  `packageRealtimeSessionDurableObjectName({ userId, packageId })`.
+- `PackageServiceInstance` —
+  `packageServiceInstanceDurableObjectName({ userId, packageId, serviceName })`.
 - `RemoteConnectorSession` —
-  `userScopedConnectorSessionKey(userId, kind, instanceId)`, where `instanceId`
-  is the explicit user-chosen connector name (globally unique per user).
-  Connectors must connect through the username-scoped ingress URL
-  `/@{username}/connectors/{kind}/{connectorName}`. Renaming a connector changes
-  this DO id; the old live session snapshot can be orphaned, but reconnecting
+  `userScopedConnectorSessionKey({ userId, instanceId })`, where `instanceId` is
+  the explicit user-chosen connector name (globally unique per user). Connectors
+  must connect through the username-scoped ingress URL
+  `/@{username}/connectors/{connectorName}`. Renaming a connector changes this
+  DO id; the old live session snapshot can be orphaned, but reconnecting
   rebuilds it from settings. The DO carries the ingress user id forward via
   headers + websocket attachment and verifies the shared secret against that
-  user's row only. The `MCP` Durable Object is addressed by MCP session id
-  rather than user id; ownership is enforced at the request boundary by
-  validating the authenticated user against the `McpCallerContext` on every
-  request.
+  user's row only.
+- `RepoSession` — `repoSessionDurableObjectName(sessionId)` keyed by
+  `repo_sessions.id` only (not user-prefixed). Every RPC validates the D1
+  session row's `user_id` before touching the workspace. Account deletion
+  enumerates the user's session ids before deleting D1 rows and purges each DO.
+  Documented exception to user-scoped naming.
+- The `MCP` Durable Object is addressed by MCP session id rather than user id;
+  ownership is enforced at the request boundary by validating the authenticated
+  user against the `McpCallerContext` on every request.
 
 ## Per-user runtime context (no shared `globalThis`)
 
@@ -655,9 +660,15 @@ on write unless a migration backfills existing rows.
 ### Durable Object id contracts
 
 `idFromName` inputs are Durable Object identity. Changing any of these strings
-or tuple layouts creates new objects and strands existing object storage.
+or tuple layouts creates new objects and strands existing object storage. All
+builders are centralized in
+`packages/worker/src/user-scoped-durable-object-name.ts` (plus
+`userScopedConnectorSessionKey` in
+`packages/worker/src/remote-connector/connector-session-key.ts`, which delegates
+to `durableObjectNameFromParts`).
 
-- `JobManager`: `idFromName(userId)`.
+- `JobManager`: `idFromName(userId)` (no trim).
+- `McpClientHub`: `idFromName(userId.trim())`.
 - `StorageRunner`: `idFromName(JSON.stringify([userId, storageId]))`.
 - `RepoSession`: `idFromName(repo_sessions.id)`; the key is not user-prefixed,
   so every RPC must keep validating the D1 row's `user_id`.
@@ -665,7 +676,7 @@ or tuple layouts creates new objects and strands existing object storage.
 - `PackageServiceInstance`:
   `idFromName(JSON.stringify([userId, packageId, serviceName]))`.
 - `RemoteConnectorSession`:
-  `idFromName(JSON.stringify([userId, normalizedKind, normalizedInstanceId]))`.
+  `idFromName(JSON.stringify([userId.trim(), normalizedInstanceId]))`.
 - `MCP`: session-keyed by the MCP SDK rather than by user id; OAuth caller
   context is the request-time ownership boundary.
 

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -8,6 +8,7 @@ import { getCapabilityVectorIndex } from '#mcp/capabilities/capability-search.ts
 import { cleanupAllUserArtifactRepos } from '#worker/repo/artifact-repo-cleanup.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-rpc.ts'
 import { userScopedConnectorSessionKey } from '#worker/remote-connector/connector-session-key.ts'
+import { mcpClientHubDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import {
 	buildPackageServiceStorageId,
 	packageServiceRpc,
@@ -680,7 +681,7 @@ async function purgeMcpClientHub(input: {
 	}
 	try {
 		const stub = namespace.get(
-			namespace.idFromName(input.userId.trim()),
+			namespace.idFromName(mcpClientHubDurableObjectName(input.userId)),
 		) as unknown as {
 			purgeForAccountDeletion: () => Promise<void>
 		}

--- a/packages/worker/src/jobs/manager-client.ts
+++ b/packages/worker/src/jobs/manager-client.ts
@@ -1,4 +1,5 @@
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { jobManagerDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import {
 	logJobSchedulerError,
 	logJobSchedulerEvent,
@@ -58,7 +59,9 @@ export function jobManagerRpc(env: Env, userId: string): JobManagerRpc | null {
 	if (!namespace) {
 		return null
 	}
-	return namespace.get(namespace.idFromName(userId)) as unknown as JobManagerRpc
+	return namespace.get(
+		namespace.idFromName(jobManagerDurableObjectName(userId)),
+	) as unknown as JobManagerRpc
 }
 
 export async function purgeJobManagerForUser(input: {

--- a/packages/worker/src/mcp-client/hub-client.ts
+++ b/packages/worker/src/mcp-client/hub-client.ts
@@ -1,5 +1,6 @@
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
+import { mcpClientHubDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import {
 	type McpClientHubSnapshot,
 	type McpServerConnectResult,
@@ -9,12 +10,13 @@ import {
 export const mcpClientHubSnapshotCacheTtlMs = 30_000
 export const mcpClientHubSnapshotCacheLimit = 100
 
+/** Cache/DO key alias for {@link mcpClientHubDurableObjectName}. */
 export function mcpClientHubKey(userId: string) {
-	return userId.trim()
+	return mcpClientHubDurableObjectName(userId)
 }
 
 function getMcpClientHubStub(input: { env: Env; userId: string }) {
-	const key = mcpClientHubKey(input.userId)
+	const key = mcpClientHubDurableObjectName(input.userId)
 	return input.env.MCP_CLIENT_HUB.get(input.env.MCP_CLIENT_HUB.idFromName(key))
 }
 

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -15,6 +15,7 @@ import {
 	type UsageEvent,
 	type UsageOutcome,
 } from '#worker/usage/record-usage.ts'
+import { packageServiceInstanceDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from './published-source-dependencies.ts'
 
 const serviceStateStorageKey = 'package-service-state'
@@ -113,14 +114,6 @@ function createInitialPackageServiceState(): PackageServiceState {
 	}
 }
 
-function buildPackageServiceName(input: {
-	userId: string
-	packageId: string
-	serviceName: string
-}) {
-	return JSON.stringify([input.userId, input.packageId, input.serviceName])
-}
-
 function getPackageServiceNamespace(env: Env) {
 	return env.PACKAGE_SERVICE_INSTANCE
 }
@@ -136,7 +129,7 @@ function getPackageServiceStub(input: {
 		throw new Error('Missing PACKAGE_SERVICE_INSTANCE binding.')
 	}
 	const id = namespace.idFromName(
-		buildPackageServiceName({
+		packageServiceInstanceDurableObjectName({
 			userId: input.userId,
 			packageId: input.packageId,
 			serviceName: input.serviceName,

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -4,6 +4,7 @@ import { buildFacetName } from '#mcp/app-runner-facet-names.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import { packageRealtimeSessionDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import { buildPackageAppWorker } from './package-app.ts'
 
 const sessionStateStorageKey = 'package-realtime-state'
@@ -871,13 +872,6 @@ type PackageRealtimeSessionRpc = {
 	fetch: (request: Request) => Promise<Response>
 }
 
-function buildRealtimeSessionName(input: {
-	userId: string
-	packageId: string
-}) {
-	return JSON.stringify([input.userId, input.packageId])
-}
-
 function getPackageRealtimeNamespace(env: Env) {
 	return env.PACKAGE_REALTIME_SESSION
 }
@@ -892,7 +886,7 @@ function getPackageRealtimeStub(input: {
 		throw new Error('Missing PACKAGE_REALTIME_SESSION binding.')
 	}
 	const id = namespace.idFromName(
-		buildRealtimeSessionName({
+		packageRealtimeSessionDurableObjectName({
 			userId: input.userId,
 			packageId: input.packageId,
 		}),

--- a/packages/worker/src/remote-connector/connector-session-key.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.ts
@@ -2,6 +2,7 @@ import {
 	isValidRemoteConnectorName,
 	normalizeRemoteConnectorInstanceId,
 } from '@kody-internal/shared/remote-connectors.ts'
+import { durableObjectNameFromParts } from '#worker/user-scoped-durable-object-name.ts'
 
 export { userScopedConnectorIngressPath } from '@kody-internal/shared/remote-connectors.ts'
 
@@ -22,7 +23,7 @@ export function userScopedConnectorSessionKey(input: {
 	userId: string
 	instanceId: string
 }) {
-	return JSON.stringify([
+	return durableObjectNameFromParts([
 		input.userId.trim(),
 		normalizeRemoteConnectorInstanceId(input.instanceId),
 	])

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -1,5 +1,6 @@
 import { type ArtifactBootstrapAccess } from './artifacts.ts'
 import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { repoSessionDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import { type RepoRunCommandsResult } from './repo-session-commands.ts'
 import {
 	type RepoSourceBootstrapResult,
@@ -164,6 +165,6 @@ export function repoSessionRpc(env: Env, sessionId: string): RepoSessionRpc {
 		throw new Error('REPO_SESSION binding is not configured.')
 	}
 	return namespace.get(
-		namespace.idFromName(sessionId),
+		namespace.idFromName(repoSessionDurableObjectName(sessionId)),
 	) as unknown as RepoSessionRpc
 }

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -7,6 +7,7 @@ import {
 	estimateEntitlementStorageSqlWriteBytes,
 	readUserD1StorageBytes,
 } from '#worker/entitlements/service.ts'
+import { storageRunnerDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 
 const defaultStorageExportPageSize = 250
 const maxStorageExportPageSize = 1_000
@@ -53,10 +54,6 @@ type StorageClearResult = {
 
 type StorageEstimateResult = {
 	estimatedBytes: number
-}
-
-function buildStorageRunnerName(userId: string, storageId: string) {
-	return JSON.stringify([userId, storageId])
 }
 
 export function createExecuteStorageId() {
@@ -396,7 +393,7 @@ export function storageRunnerRpc(input: {
 }) {
 	return input.env.STORAGE_RUNNER.get(
 		input.env.STORAGE_RUNNER.idFromName(
-			buildStorageRunnerName(input.userId, input.storageId),
+			storageRunnerDurableObjectName(input.userId, input.storageId),
 		),
 	) as unknown as {
 		getValue: (payload: { key: string }) => Promise<{
@@ -604,7 +601,7 @@ export function createPackageStorageAccessDeniedMessage(packageId: string) {
  * module source claiming an arbitrary package id is rejected here even if it
  * forges a stamped-looking call, so a malicious package cannot reach other
  * installed packages' buckets. Cross-user access is structurally impossible:
- * `buildStorageRunnerName` keys the durable object on this run's user id.
+ * `storageRunnerDurableObjectName` keys the durable object on this run's user id.
  */
 export function createPackageStorageKodyTools(input: {
 	env: Env

--- a/packages/worker/src/user-scoped-durable-object-name.node.test.ts
+++ b/packages/worker/src/user-scoped-durable-object-name.node.test.ts
@@ -1,0 +1,119 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import {
+	durableObjectNameFromParts,
+	jobManagerDurableObjectName,
+	mcpClientHubDurableObjectName,
+	packageRealtimeSessionDurableObjectName,
+	packageServiceInstanceDurableObjectName,
+	repoSessionDurableObjectName,
+	storageRunnerDurableObjectName,
+} from './user-scoped-durable-object-name.ts'
+
+const identityModuleRelativePath =
+	'packages/worker/src/user-scoped-durable-object-name.ts'
+const connectorSessionKeyRelativePath =
+	'packages/worker/src/remote-connector/connector-session-key.ts'
+
+test('user-scoped Durable Object name helpers preserve frozen idFromName contracts', () => {
+	expect(jobManagerDurableObjectName('user-aaa')).toBe('user-aaa')
+	// JobManager historically does not trim; keep that wire format frozen.
+	expect(jobManagerDurableObjectName('  user-aaa  ')).toBe('  user-aaa  ')
+
+	expect(mcpClientHubDurableObjectName('  user-aaa  ')).toBe('user-aaa')
+
+	expect(storageRunnerDurableObjectName('user-aaa', 'job:1')).toBe(
+		'["user-aaa","job:1"]',
+	)
+	expect(
+		packageRealtimeSessionDurableObjectName({
+			userId: 'user-aaa',
+			packageId: 'pkg-1',
+		}),
+	).toBe('["user-aaa","pkg-1"]')
+	expect(
+		packageServiceInstanceDurableObjectName({
+			userId: 'user-aaa',
+			packageId: 'pkg-1',
+			serviceName: 'gateway',
+		}),
+	).toBe('["user-aaa","pkg-1","gateway"]')
+
+	expect(repoSessionDurableObjectName('session-1')).toBe('session-1')
+
+	expect(durableObjectNameFromParts(['user-aaa', 'a/b'])).toBe(
+		'["user-aaa","a/b"]',
+	)
+	expect(durableObjectNameFromParts(['user-aaa', 'a'])).not.toBe(
+		durableObjectNameFromParts(['user-aaa', 'a/b']),
+	)
+})
+
+test('private JSON-tuple Durable Object name builders live only in the identity module', () => {
+	const workerSrcRoot = fileURLToPath(new URL('.', import.meta.url))
+	const repoRoot = fileURLToPath(new URL('../../..', import.meta.url))
+
+	// Extracted private builders must not return; new DO naming must go through
+	// user-scoped-durable-object-name.ts (or connector-session-key for connectors).
+	const bannedPrivateBuilders = [
+		'function buildStorageRunnerName',
+		'function buildPackageServiceName',
+		'function buildRealtimeSessionName',
+	]
+	// Production call sites must not invent tuple DO names inline.
+	const inlineIdFromNameTuple = /idFromName\(\s*JSON\.stringify\s*\(/g
+
+	const offenders: Array<string> = []
+	const connectorSource = readFileSync(
+		join(repoRoot, connectorSessionKeyRelativePath),
+		'utf8',
+	)
+	expect(
+		connectorSource.includes('durableObjectNameFromParts'),
+		'connector-session-key.ts must build DO names via durableObjectNameFromParts',
+	).toBe(true)
+	expect(connectorSource).not.toMatch(/JSON\.stringify\(\s*\[/)
+
+	function walk(dir: string) {
+		for (const entry of readdirSync(dir)) {
+			const fullPath = join(dir, entry)
+			const stat = statSync(fullPath)
+			if (stat.isDirectory()) {
+				if (
+					entry === 'node_modules' ||
+					entry === 'dist' ||
+					entry === '.wrangler'
+				) {
+					continue
+				}
+				walk(fullPath)
+				continue
+			}
+			if (!entry.endsWith('.ts')) continue
+			if (entry.endsWith('.test.ts') || entry.endsWith('.workers.test.ts')) {
+				continue
+			}
+			const relativePath = relative(repoRoot, fullPath).replaceAll('\\', '/')
+			if (relativePath === identityModuleRelativePath) continue
+			const source = readFileSync(fullPath, 'utf8')
+			for (const banned of bannedPrivateBuilders) {
+				if (source.includes(banned)) {
+					offenders.push(`${relativePath}: ${banned}`)
+				}
+			}
+			if (inlineIdFromNameTuple.test(source)) {
+				offenders.push(`${relativePath}: idFromName(JSON.stringify(...))`)
+			}
+			inlineIdFromNameTuple.lastIndex = 0
+		}
+	}
+
+	walk(workerSrcRoot)
+
+	expect(
+		offenders,
+		'Move private JSON.stringify([userId, ...]) DO name builders into user-scoped-durable-object-name.ts',
+	).toEqual([])
+})

--- a/packages/worker/src/user-scoped-durable-object-name.ts
+++ b/packages/worker/src/user-scoped-durable-object-name.ts
@@ -1,0 +1,75 @@
+/**
+ * Frozen Durable Object `idFromName` builders for user-owned (and documented
+ * exception) objects. Changing any of these strings or tuple layouts creates
+ * new objects and strands existing object storage. See
+ * `docs/contributing/architecture/data-storage.md` (§ Durable Object id
+ * contracts).
+ *
+ * JSON-tuple names use {@link durableObjectNameFromParts} so components that
+ * may contain `/` or `:` round-trip unambiguously.
+ */
+
+/**
+ * Encode Durable Object name parts as a JSON tuple. Prefer the typed helpers
+ * below at call sites; use this only when building a new user-scoped DO name
+ * that is not yet covered by a dedicated helper.
+ */
+export function durableObjectNameFromParts(
+	parts: ReadonlyArray<string>,
+): string {
+	return JSON.stringify(parts)
+}
+
+/** JobManager — one scheduler DO per user. */
+export function jobManagerDurableObjectName(userId: string) {
+	return userId
+}
+
+/** McpClientHub — one client-hub DO per user (trimmed). */
+export function mcpClientHubDurableObjectName(userId: string) {
+	return userId.trim()
+}
+
+/** StorageRunner — isolated SQLite DO per (userId, storageId). */
+export function storageRunnerDurableObjectName(
+	userId: string,
+	storageId: string,
+) {
+	return durableObjectNameFromParts([userId, storageId])
+}
+
+/** PackageRealtimeSession — live app session DO per (userId, packageId). */
+export function packageRealtimeSessionDurableObjectName(input: {
+	userId: string
+	packageId: string
+}) {
+	return durableObjectNameFromParts([input.userId, input.packageId])
+}
+
+/**
+ * PackageServiceInstance — long-lived service DO per
+ * (userId, packageId, serviceName).
+ */
+export function packageServiceInstanceDurableObjectName(input: {
+	userId: string
+	packageId: string
+	serviceName: string
+}) {
+	return durableObjectNameFromParts([
+		input.userId,
+		input.packageId,
+		input.serviceName,
+	])
+}
+
+/**
+ * RepoSession is keyed by `repo_sessions.id` only (not user-prefixed). Every
+ * RPC must validate the D1 session row's `user_id` before touching the
+ * workspace. Account deletion enumerates the user's session ids before
+ * deleting D1 rows and purges each DO. Documented exception to user-scoped
+ * naming — do not "fix" this by prefixing userId without a storage
+ * migration plan.
+ */
+export function repoSessionDurableObjectName(sessionId: string) {
+	return sessionId
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Behavior-preserving extraction of frozen Durable Object `idFromName` builders into `packages/worker/src/user-scoped-durable-object-name.ts`. JobManager, McpClientHub, StorageRunner, PackageRealtimeSession, PackageServiceInstance, and RepoSession (documented non-user-prefixed exception) adopt the helpers; remote connector session keys delegate to the shared JSON-tuple encoder. Wire formats are unchanged — changing them would strand DO storage.

A source-scan guardrail fails CI if the old private builders return or if production call sites invent `idFromName(JSON.stringify(...))` inline. Docs in `data-storage.md` updated (including correcting the RemoteConnectorSession key to `[userId, instanceId]`).

**Risk:** LOW — pure identity helper extraction with pinned outputs; no change to what is deleted/exported/retained.

**Track B** (user-owned data lifecycle registry), PR 1/N.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** composes — call sites adopt shared `idFromName` builders; Durable Object wire names are unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `durable-storage` | assistant | composes — StorageRunner name via shared helper |
| `jobs` | assistant | composes — JobManager name via shared helper |
| `mcp-client-servers` | assistant | composes — McpClientHub name via shared helper |
| `package-services` | assistant | composes — PackageServiceInstance name via shared helper |
| `realtime-sessions` | assistant | composes — PackageRealtimeSession name via shared helper |
| `remote-connectors` / `connector-ingress` | assistant / surfaces | composes — connector key delegates to tuple encoder |
| `repo-sessions` | assistant | composes — RepoSession exception documented + wrapped |
| `app-ui` | surfaces | composes — account deletion hub purge uses shared hub name |

### System map

Call sites resolve DO ids through one naming module; storage layout is unchanged.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	doNames["user-scoped-do-names<br/>Shared idFromName builders"]:::touched
	durableStorage["durable-storage<br/>Durable storage buckets"]:::touched
	jobs["jobs<br/>Scheduled jobs"]:::touched
	mcpClient["mcp-client-servers<br/>MCP client servers"]:::touched
	pkgServices["package-services<br/>Package services"]:::touched
	realtime["realtime-sessions<br/>Realtime sessions"]:::touched
	connectors["remote-connectors<br/>Remote connectors"]:::touched
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	accountDeletion["app-ui<br/>Account deletion purge"]:::touched
	doNames -->|"storageRunnerDurableObjectName"| durableStorage
	doNames -->|"jobManagerDurableObjectName"| jobs
	doNames -->|"mcpClientHubDurableObjectName"| mcpClient
	doNames -->|"packageServiceInstanceDurableObjectName"| pkgServices
	doNames -->|"packageRealtimeSessionDurableObjectName"| realtime
	doNames -->|"durableObjectNameFromParts"| connectors
	doNames -->|"repoSessionDurableObjectName exception"| repoSessions
	doNames -->|"hub name for purge"| accountDeletion
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Per-user isolation: DO names remain user-scoped (RepoSession stays session-id-keyed with RPC ownership checks).
- Frozen `idFromName` contracts: tuple layouts and trim behavior unchanged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dccd364-43eb-4951-92b7-a833b9d80130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dccd364-43eb-4951-92b7-a833b9d80130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability and consistency when locating user-scoped sessions, services, storage, jobs, and connector resources.
  - Preserved existing resource identity contracts while preventing ambiguous identifiers from producing collisions.

- **Documentation**
  - Updated architecture documentation to clarify resource identity and naming contracts.

- **Tests**
  - Added coverage to verify stable resource identifiers and enforce consistent naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->