### PR TITLE
Extract shared page auth and request-body helpers

### DIFF
--- a/packages/worker/src/app/handlers/account-billing.ts
+++ b/packages/worker/src/app/handlers/account-billing.ts
@@ -2,12 +2,8 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { loadAccountBillingData } from '#app/account-billing-data.ts'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 import {
@@ -36,14 +32,9 @@ export function createAccountBillingHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const errorCode = new URL(request.url).searchParams.get('error')
@@ -165,14 +156,9 @@ export function createAccountBillingSuccessHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			if (!isBillingConfigured(env)) {
@@ -227,14 +213,9 @@ export function createAccountBillingPortalHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			if (!isBillingConfigured(env)) {

--- a/packages/worker/src/app/handlers/account-integrations.ts
+++ b/packages/worker/src/app/handlers/account-integrations.ts
@@ -1,12 +1,8 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { loadAccountIntegrationsData } from '#app/account-integrations-data.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -14,14 +10,9 @@ export function createAccountIntegrationsHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const accountIntegrations = await loadAccountIntegrationsData(env, user)

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -2,12 +2,9 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { type Action } from 'remix/router'
 import { loadAccountMcpServersData } from '#app/account-mcp-servers-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
@@ -27,14 +24,9 @@ export function createAccountMcpServersHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const accountMcpServers = await loadAccountMcpServersData({ env, user })
@@ -70,7 +62,7 @@ export function createAccountMcpServersApiHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
 			}
 
-			const action = readString(body, 'action')
+			const action = readTrimmedStringOrEmpty(body, 'action')
 			try {
 				if (action === 'add') {
 					return await handleAddAction({ env, user, body, request })
@@ -124,13 +116,9 @@ export function createAccountMcpServersOauthCallbackHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const hub = createMcpClientHubClient({
@@ -173,8 +161,8 @@ async function handleAddAction(input: {
 	const { setting } = await addMcpServer({
 		env: input.env,
 		userId: input.user.mcpUser.userId,
-		name: readString(input.body, 'name'),
-		url: readString(input.body, 'url'),
+		name: readTrimmedStringOrEmpty(input.body, 'name'),
+		url: readTrimmedStringOrEmpty(input.body, 'url'),
 		baseUrl: getAppBaseUrl({
 			env: input.env,
 			requestUrl: input.request.url,
@@ -265,7 +253,7 @@ async function requireSetting(input: {
 	user: AuthenticatedUser
 	body: object
 }) {
-	const id = readString(input.body, 'id')
+	const id = readTrimmedStringOrEmpty(input.body, 'id')
 	if (!id) {
 		throw new Error('MCP server id is required.')
 	}
@@ -278,11 +266,6 @@ async function requireSetting(input: {
 		throw new Error('MCP server not found.')
 	}
 	return setting
-}
-
-function readString(body: object, key: string) {
-	const value = (body as Record<string, unknown>)[key]
-	return typeof value === 'string' ? value.trim() : ''
 }
 
 function readBoolean(body: object, key: string, defaultValue: boolean) {

--- a/packages/worker/src/app/handlers/account-package-invocation-tokens.ts
+++ b/packages/worker/src/app/handlers/account-package-invocation-tokens.ts
@@ -1,12 +1,9 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { loadAccountPackageInvocationTokensData } from '#app/account-package-invocation-tokens-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 import {
@@ -37,14 +34,9 @@ export function createAccountPackageInvocationTokensHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request, params }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const accountPackageInvocationTokens =
@@ -98,7 +90,7 @@ export function createAccountPackageInvocationTokensApiHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
 			}
 
-			const action = readString(body, 'action')
+			const action = readTrimmedStringOrEmpty(body, 'action')
 			if (action === 'create') {
 				return handleCreateAction({ env, request, user, body })
 			}
@@ -126,8 +118,8 @@ async function handleCreateAction(input: {
 	user: AuthenticatedUser
 	body: object
 }) {
-	const name = readString(input.body, 'name')
-	const rawToken = readString(input.body, 'rawToken')
+	const name = readTrimmedStringOrEmpty(input.body, 'name')
+	const rawToken = readTrimmedStringOrEmpty(input.body, 'rawToken')
 	if (!name) {
 		return jsonResponse({ ok: false, error: 'Token name is required.' }, 400)
 	}
@@ -252,9 +244,9 @@ async function handleUpdateAction(input: {
 	user: AuthenticatedUser
 	body: object
 }) {
-	const id = readString(input.body, 'id')
-	const name = readString(input.body, 'name')
-	const rawToken = readString(input.body, 'rawToken')
+	const id = readTrimmedStringOrEmpty(input.body, 'id')
+	const name = readTrimmedStringOrEmpty(input.body, 'name')
+	const rawToken = readTrimmedStringOrEmpty(input.body, 'rawToken')
 	if (!id) {
 		return jsonResponse({ ok: false, error: 'Token id is required.' }, 400)
 	}
@@ -383,7 +375,7 @@ async function handleRevokeAction(input: {
 	user: AuthenticatedUser
 	body: object
 }) {
-	const id = readString(input.body, 'id')
+	const id = readTrimmedStringOrEmpty(input.body, 'id')
 	if (!id) {
 		return jsonResponse({ ok: false, error: 'Token id is required.' }, 400)
 	}
@@ -413,7 +405,7 @@ async function handleReinstateAction(input: {
 	user: AuthenticatedUser
 	body: object
 }) {
-	const id = readString(input.body, 'id')
+	const id = readTrimmedStringOrEmpty(input.body, 'id')
 	if (!id) {
 		return jsonResponse({ ok: false, error: 'Token id is required.' }, 400)
 	}
@@ -444,7 +436,7 @@ async function handleDeleteAction(input: {
 	user: AuthenticatedUser
 	body: object
 }) {
-	const id = readString(input.body, 'id')
+	const id = readTrimmedStringOrEmpty(input.body, 'id')
 	if (!id) {
 		return jsonResponse({ ok: false, error: 'Token id is required.' }, 400)
 	}
@@ -526,11 +518,6 @@ function normalizeExportScopeList(values: Array<string>) {
 		return [packageInvocationScopeWildcard]
 	}
 	return Array.from(new Set(normalized))
-}
-
-function readString(body: object, key: string) {
-	const value = (body as Record<string, unknown>)[key]
-	return typeof value === 'string' ? value.trim() : ''
 }
 
 function readStringArray(body: object, keys: Array<string>) {

--- a/packages/worker/src/app/handlers/account-packages.ts
+++ b/packages/worker/src/app/handlers/account-packages.ts
@@ -1,12 +1,8 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { loadAccountPackagesData } from '#app/account-packages-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -14,14 +10,9 @@ export function createAccountPackagesHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request, params }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const accountPackages = await loadAccountPackagesData({

--- a/packages/worker/src/app/handlers/account-passkeys.ts
+++ b/packages/worker/src/app/handlers/account-passkeys.ts
@@ -2,16 +2,12 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { enum_, object, optional, parseSafe, string } from 'remix/data-schema'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
 import {
 	buildDefaultPasskeyName,
 	validatePasskeyName,
 } from '#app/passkey-label.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import {
 	deletePasskeyForUser,
 	listPasskeysForUser,
@@ -25,14 +21,9 @@ export function createAccountPasskeysHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			return renderAppPage({

--- a/packages/worker/src/app/handlers/account-remote-connectors.ts
+++ b/packages/worker/src/app/handlers/account-remote-connectors.ts
@@ -1,12 +1,9 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { loadAccountRemoteConnectorsData } from '#app/account-remote-connectors-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 import {
@@ -22,14 +19,9 @@ export function createAccountRemoteConnectorsHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const accountRemoteConnectors = await loadAccountRemoteConnectorsData({
@@ -75,7 +67,7 @@ export function createAccountRemoteConnectorsApiHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
 			}
 
-			const action = readString(body, 'action')
+			const action = readTrimmedStringOrEmpty(body, 'action')
 			try {
 				if (action === 'save') {
 					return await handleSaveAction({
@@ -121,7 +113,7 @@ async function handleSaveAction(input: {
 		env: input.env,
 		userId: input.user.mcpUser.userId,
 		id: readOptionalString(input.body, 'id'),
-		instanceId: readString(input.body, 'instanceId'),
+		instanceId: readTrimmedStringOrEmpty(input.body, 'instanceId'),
 		enabled: readBoolean(input.body, 'enabled', true),
 		attached: readBoolean(input.body, 'attached', true),
 		sharedSecret: readOptionalString(input.body, 'sharedSecret'),
@@ -143,7 +135,7 @@ async function handleDeleteAction(input: {
 	request: Request
 	body: object
 }) {
-	const id = readString(input.body, 'id')
+	const id = readTrimmedStringOrEmpty(input.body, 'id')
 	if (!id) {
 		return jsonResponse(
 			{ ok: false, error: 'Remote connector setting id is required.' },
@@ -170,13 +162,8 @@ async function handleDeleteAction(input: {
 	)
 }
 
-function readString(body: object, key: string) {
-	const value = (body as Record<string, unknown>)[key]
-	return typeof value === 'string' ? value.trim() : ''
-}
-
 function readOptionalString(body: object, key: string) {
-	const value = readString(body, key)
+	const value = readTrimmedStringOrEmpty(body, key)
 	return value || null
 }
 

--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -17,13 +17,8 @@ import {
 	toPackageOptions,
 } from '#app/account-secrets-data.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { loadConnectOauthNextSteps } from '#app/connect-oauth-next-steps.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { buildSecretHostApprovalUrl } from '#mcp/secrets/host-approval.ts'
 import { normalizeBulkPackageSecretApprovalNames } from '#mcp/secrets/package-approval-url.ts'
@@ -47,6 +42,7 @@ import {
 	buildIntegrationValueName,
 	parseIntegrationConfig,
 } from '#mcp/capabilities/integrations/integration-shared.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import {
 	buildOAuthTokenExchangeFailurePayload,
 	buildOAuthTokenExchangeRequest,
@@ -54,6 +50,7 @@ import {
 	resolveTokenExchangeStyle,
 	type TokenExchangeStyle,
 } from '#app/oauth-token-exchange.ts'
+import { readNonEmptyTrimmedString as readString } from '#app/request-body.ts'
 
 type AccountEditableSecretScope = Extract<SecretScope, 'package' | 'user'>
 
@@ -78,14 +75,9 @@ export function createAccountSecretsHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const accountSecrets = await loadAccountSecretsData({
@@ -1131,11 +1123,6 @@ async function handleDeleteAction(input: {
 		...payload,
 		deleted: true,
 	})
-}
-
-function readString(body: object, key: string) {
-	const value = (body as Record<string, unknown>)[key]
-	return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
 function readOptionalString(body: object, key: string) {

--- a/packages/worker/src/app/handlers/account-stars.ts
+++ b/packages/worker/src/app/handlers/account-stars.ts
@@ -1,11 +1,7 @@
 import { type Action } from 'remix/router'
 import { loadAccountStarsData } from '#app/account-stars-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { type routes } from '#app/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { jsonResponse } from '#worker/json-response.ts'
@@ -14,14 +10,9 @@ export function createAccountStarsHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const accountStars = await loadAccountStarsData({

--- a/packages/worker/src/app/handlers/account-two-factor.ts
+++ b/packages/worker/src/app/handlers/account-two-factor.ts
@@ -2,12 +2,8 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { enum_, object, optional, parseSafe, string } from 'remix/data-schema'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 import {
@@ -26,14 +22,9 @@ export function createAccountTwoFactorHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			return renderAppPage({

--- a/packages/worker/src/app/handlers/account.ts
+++ b/packages/worker/src/app/handlers/account.ts
@@ -1,13 +1,8 @@
 import { type Action } from 'remix/router'
 import { loadAccountConnectionsData } from '#app/account-connections-data.ts'
 import { loadAccountProfileData } from '#app/account-profile-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
 import { loadOnboardingData } from '#app/onboarding-data.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -15,15 +10,9 @@ export function createAccountHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const [accountProfile, accountConnections, onboarding] =

--- a/packages/worker/src/app/handlers/admin-community-reports.ts
+++ b/packages/worker/src/app/handlers/admin-community-reports.ts
@@ -2,8 +2,7 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { z } from 'zod'
 import { type Action } from 'remix/router'
 import { loadAdminCommunityReportsData } from '#app/admin-community-reports-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { requireUserWithRole } from '#app/permissions-server.ts'
 import { type routes } from '#app/routes.ts'
@@ -30,16 +29,9 @@ export function createAdminCommunityReportsHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			try {
-				await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
-			}
-
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const admin = await requirePageUserWithRole(request, env, 'admin')
+			if (admin instanceof Response) {
+				return admin
 			}
 
 			const adminCommunityReports = await loadAdminCommunityReportsData(

--- a/packages/worker/src/app/handlers/admin-feature-flags.ts
+++ b/packages/worker/src/app/handlers/admin-feature-flags.ts
@@ -2,9 +2,9 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { loadAdminFeatureFlagsData } from '#app/admin-feature-flags-data.ts'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { requireUserWithRole } from '#app/permissions-server.ts'
+import { readNonEmptyTrimmedStringOrNumber } from '#app/request-body.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 import { isFeatureFlagKey } from '#worker/feature-flags/registry.ts'
@@ -19,16 +19,9 @@ export function createAdminFeatureFlagsHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			try {
-				await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
-			}
-
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const admin = await requirePageUserWithRole(request, env, 'admin')
+			if (admin instanceof Response) {
+				return admin
 			}
 
 			const adminFeatureFlags = await loadAdminFeatureFlagsData(env)
@@ -67,7 +60,7 @@ export function createAdminFeatureFlagsApiHandler(env: Env) {
 					)
 				}
 
-				const action = readString(body, 'action')
+				const action = readNonEmptyTrimmedStringOrNumber(body, 'action')
 				if (action === 'set_global') {
 					return handleSetGlobalAction({ env, request, url, actor, body })
 				}
@@ -109,7 +102,7 @@ async function handleSetGlobalAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithRole>>
 	body: object
 }) {
-	const key = readString(input.body, 'key')
+	const key = readNonEmptyTrimmedStringOrNumber(input.body, 'key')
 	if (!key || !isFeatureFlagKey(key)) {
 		return jsonResponse(
 			{ ok: false, error: 'Unknown or invalid feature flag key.' },
@@ -181,7 +174,7 @@ async function handleSetUserOverrideAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithRole>>
 	body: object
 }) {
-	const key = readString(input.body, 'key')
+	const key = readNonEmptyTrimmedStringOrNumber(input.body, 'key')
 	if (!key || !isFeatureFlagKey(key)) {
 		return jsonResponse(
 			{ ok: false, error: 'Unknown or invalid feature flag key.' },
@@ -238,7 +231,7 @@ async function handleClearUserOverrideAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithRole>>
 	body: object
 }) {
-	const key = readString(input.body, 'key')
+	const key = readNonEmptyTrimmedStringOrNumber(input.body, 'key')
 	if (!key || !isFeatureFlagKey(key)) {
 		return jsonResponse(
 			{ ok: false, error: 'Unknown or invalid feature flag key.' },
@@ -280,7 +273,7 @@ async function handleDeleteStaleAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithRole>>
 	body: object
 }) {
-	const key = readString(input.body, 'key')
+	const key = readNonEmptyTrimmedStringOrNumber(input.body, 'key')
 	if (!key) {
 		return jsonResponse(
 			{ ok: false, error: 'Feature flag key is required.' },
@@ -334,7 +327,7 @@ async function resolveOverrideUserId(
 ): Promise<ResolveOverrideUserIdResult> {
 	const record = body as Record<string, unknown>
 	const hasUserId = Object.hasOwn(record, 'userId') && record.userId != null
-	const username = readString(body, 'username')
+	const username = readNonEmptyTrimmedStringOrNumber(body, 'username')
 	const hasUsername = username !== null
 
 	if (!hasUserId && !hasUsername) {
@@ -423,17 +416,6 @@ function readPositiveIntField(body: object, key: string): number | null {
 		if (Number.isInteger(parsed) && parsed > 0) {
 			return parsed
 		}
-	}
-	return null
-}
-
-function readString(body: object, key: string) {
-	const value = (body as Record<string, unknown>)[key]
-	if (typeof value === 'string' && value.trim()) {
-		return value.trim()
-	}
-	if (typeof value === 'number' && Number.isFinite(value)) {
-		return String(value)
 	}
 	return null
 }

--- a/packages/worker/src/app/handlers/admin-insights.ts
+++ b/packages/worker/src/app/handlers/admin-insights.ts
@@ -1,8 +1,7 @@
 import { type Action } from 'remix/router'
 import { jsonResponse } from '#worker/json-response.ts'
 import { loadAdminInsightsData } from '#app/admin-insights-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { requireUserWithRole } from '#app/permissions-server.ts'
 import { type routes } from '#app/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -11,16 +10,9 @@ export function createAdminInsightsHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			try {
-				await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
-			}
-
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const admin = await requirePageUserWithRole(request, env, 'admin')
+			if (admin instanceof Response) {
+				return admin
 			}
 
 			const adminInsights = await loadAdminInsightsData(env)

--- a/packages/worker/src/app/handlers/admin-invites.ts
+++ b/packages/worker/src/app/handlers/admin-invites.ts
@@ -11,14 +11,14 @@ import {
 	adminCreateUserWithPasswordSetup,
 	AdminCreateUserError,
 } from '#app/admin-user-creation.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
 import {
 	createInvite,
 	normalizeInviteCode,
 	revokeInvite,
 } from '#app/invites.ts'
+import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { requireUserWithRole } from '#app/permissions-server.ts'
+import { readNonEmptyTrimmedStringOrNumber } from '#app/request-body.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 import {
@@ -31,16 +31,9 @@ export function createAdminInvitesHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			try {
-				await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
-			}
-
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const admin = await requirePageUserWithRole(request, env, 'admin')
+			if (admin instanceof Response) {
+				return admin
 			}
 
 			const adminInvites = await loadAdminInvitesData(env)
@@ -79,7 +72,7 @@ export function createAdminInvitesApiHandler(env: Env) {
 					)
 				}
 
-				const action = readString(body, 'action')
+				const action = readNonEmptyTrimmedStringOrNumber(body, 'action')
 				if (action === 'create_invite') {
 					return handleCreateInviteAction({ env, request, url, actor, body })
 				}
@@ -106,8 +99,8 @@ async function handleCreateUserAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithRole>>
 	body: object
 }) {
-	const email = readString(input.body, 'email') ?? ''
-	const username = readString(input.body, 'username')
+	const email = readNonEmptyTrimmedStringOrNumber(input.body, 'email') ?? ''
+	const username = readNonEmptyTrimmedStringOrNumber(input.body, 'username')
 
 	try {
 		const createdUser = await adminCreateUserWithPasswordSetup({
@@ -161,9 +154,12 @@ async function handleCreateInviteAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithRole>>
 	body: object
 }) {
-	const code = readString(input.body, 'code')
-	const note = readString(input.body, 'note') ?? ''
-	const maxUses = readPositiveInt(readString(input.body, 'maxUses'), 1)
+	const code = readNonEmptyTrimmedStringOrNumber(input.body, 'code')
+	const note = readNonEmptyTrimmedStringOrNumber(input.body, 'note') ?? ''
+	const maxUses = readPositiveInt(
+		readNonEmptyTrimmedStringOrNumber(input.body, 'maxUses'),
+		1,
+	)
 	const expiresAt = readExpiresAt(input.body)
 	if (expiresAt === false) {
 		return jsonResponse(
@@ -244,7 +240,9 @@ async function handleRevokeInviteAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithRole>>
 	body: object
 }) {
-	const code = normalizeInviteCode(readString(input.body, 'code'))
+	const code = normalizeInviteCode(
+		readNonEmptyTrimmedStringOrNumber(input.body, 'code'),
+	)
 	if (!code) {
 		return jsonResponse({ ok: false, error: 'Invite code is required.' }, 400)
 	}
@@ -268,20 +266,9 @@ async function handleRevokeInviteAction(input: {
 }
 
 function readExpiresAt(body: object): string | null | false {
-	const value = readString(body, 'expiresAt')
+	const value = readNonEmptyTrimmedStringOrNumber(body, 'expiresAt')
 	if (!value) return null
 	const date = new Date(value)
 	if (Number.isNaN(date.getTime())) return false
 	return date.toISOString()
-}
-
-function readString(body: object, key: string) {
-	const value = (body as Record<string, unknown>)[key]
-	if (typeof value === 'string' && value.trim()) {
-		return value.trim()
-	}
-	if (typeof value === 'number' && Number.isFinite(value)) {
-		return String(value)
-	}
-	return null
 }

--- a/packages/worker/src/app/handlers/admin-platform-feedback.ts
+++ b/packages/worker/src/app/handlers/admin-platform-feedback.ts
@@ -4,8 +4,7 @@ import {
 	loadAdminPlatformFeedbackData,
 	readAdminPlatformFeedbackId,
 } from '#app/admin-platform-feedback-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { requireUserWithRole } from '#app/permissions-server.ts'
 import { type routes } from '#app/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -53,17 +52,9 @@ export function createAdminPlatformFeedbackHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			let actor: Awaited<ReturnType<typeof requireUserWithRole>>
-			try {
-				actor = await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
-			}
-
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const actor = await requirePageUserWithRole(request, env, 'admin')
+			if (actor instanceof Response) {
+				return actor
 			}
 
 			const adminPlatformFeedback = await loadAdminPlatformFeedbackData(

--- a/packages/worker/src/app/handlers/admin-roles.ts
+++ b/packages/worker/src/app/handlers/admin-roles.ts
@@ -1,29 +1,18 @@
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { loadAdminRolesData } from '#app/admin-roles-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
-import {
-	requireUserWithPermission,
-	requireUserWithRole,
-} from '#app/permissions-server.ts'
+import { requireUserWithPermission } from '#app/permissions-server.ts'
 import { type routes } from '#app/routes.ts'
 
 export function createAdminRolesHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			try {
-				await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
-			}
-
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const admin = await requirePageUserWithRole(request, env, 'admin')
+			if (admin instanceof Response) {
+				return admin
 			}
 
 			const adminRoles = await loadAdminRolesData(env)

--- a/packages/worker/src/app/handlers/admin-system-email.ts
+++ b/packages/worker/src/app/handlers/admin-system-email.ts
@@ -2,8 +2,7 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { getRequestIp, logAuditEvent } from '#app/audit-log.ts'
 import { loadAdminSystemEmailData } from '#app/admin-system-email-data.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { requireUserWithRole } from '#app/permissions-server.ts'
 import { type routes } from '#app/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -33,17 +32,9 @@ export function createAdminSystemEmailHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			let actor: Awaited<ReturnType<typeof requireUserWithRole>>
-			try {
-				actor = await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
-			}
-
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const actor = await requirePageUserWithRole(request, env, 'admin')
+			if (actor instanceof Response) {
+				return actor
 			}
 
 			const adminSystemEmail = await loadAdminSystemEmailData(env, request.url)

--- a/packages/worker/src/app/handlers/admin-users.ts
+++ b/packages/worker/src/app/handlers/admin-users.ts
@@ -16,17 +16,16 @@ import {
 	resolvePlanWrite,
 	type PlanName,
 } from '#worker/entitlements/plans.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import {
 	assignUserRole,
 	removeAdminRolePreservingLastAdmin,
 	removeUserRole,
 	requireUserWithPermission,
-	requireUserWithRole,
 } from '#app/permissions-server.ts'
 import { type RoleName, roleNames } from '#app/permissions.ts'
+import { readNonEmptyTrimmedStringOrNumber } from '#app/request-body.ts'
 import { type routes } from '#app/routes.ts'
 
 export { adminUserListItemFieldNames, type AdminUserListItem }
@@ -35,11 +34,9 @@ export function createAdminHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			try {
-				await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
+			const admin = await requirePageUserWithRole(request, env, 'admin')
+			if (admin instanceof Response) {
+				return admin
 			}
 			return Response.redirect(new URL('/admin/users', request.url), 302)
 		},
@@ -50,16 +47,9 @@ export function createAdminUsersHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			try {
-				await requireUserWithRole(request, env, 'admin')
-			} catch (error) {
-				if (error instanceof Response) return error
-				throw error
-			}
-
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const admin = await requirePageUserWithRole(request, env, 'admin')
+			if (admin instanceof Response) {
+				return admin
 			}
 
 			// The HTML page always seeds the first window; infinite scroll owns
@@ -107,7 +97,7 @@ export function createAdminUsersApiHandler(env: Env) {
 					)
 				}
 
-				const action = readString(body, 'action')
+				const action = readNonEmptyTrimmedStringOrNumber(body, 'action')
 				if (action === 'assign_role') {
 					return handleAssignRoleAction({
 						env,
@@ -183,7 +173,10 @@ async function handleAssignRoleAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithPermission>>
 	body: object
 }) {
-	const targetUserId = readPositiveInt(readString(input.body, 'userId'), 0)
+	const targetUserId = readPositiveInt(
+		readNonEmptyTrimmedStringOrNumber(input.body, 'userId'),
+		0,
+	)
 	const roleName = readRoleName(input.body, 'role')
 	if (!targetUserId) {
 		return jsonResponse({ ok: false, error: 'User id is required.' }, 400)
@@ -245,7 +238,10 @@ async function handleRemoveRoleAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithPermission>>
 	body: object
 }) {
-	const targetUserId = readPositiveInt(readString(input.body, 'userId'), 0)
+	const targetUserId = readPositiveInt(
+		readNonEmptyTrimmedStringOrNumber(input.body, 'userId'),
+		0,
+	)
 	const roleName = readRoleName(input.body, 'role')
 	if (!targetUserId) {
 		return jsonResponse({ ok: false, error: 'User id is required.' }, 400)
@@ -330,7 +326,10 @@ async function handleUpdatePlanAction(input: {
 	actor: Awaited<ReturnType<typeof requireUserWithPermission>>
 	body: object
 }) {
-	const targetUserId = readPositiveInt(readString(input.body, 'userId'), 0)
+	const targetUserId = readPositiveInt(
+		readNonEmptyTrimmedStringOrNumber(input.body, 'userId'),
+		0,
+	)
 	if (!targetUserId) {
 		return jsonResponse({ ok: false, error: 'User id is required.' }, 400)
 	}
@@ -392,17 +391,6 @@ function isRoleName(value: string): value is RoleName {
 }
 
 function readRoleName(body: object, key: string): RoleName | null {
-	const value = readString(body, key)
+	const value = readNonEmptyTrimmedStringOrNumber(body, key)
 	return value && isRoleName(value) ? value : null
-}
-
-function readString(body: object, key: string) {
-	const value = (body as Record<string, unknown>)[key]
-	if (typeof value === 'string' && value.trim()) {
-		return value.trim()
-	}
-	if (typeof value === 'number' && Number.isFinite(value)) {
-		return String(value)
-	}
-	return null
 }

--- a/packages/worker/src/app/handlers/connect-oauth.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.ts
@@ -1,6 +1,5 @@
 import { type Action } from 'remix/router'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { redirectToLogin } from '#app/auth-redirect.ts'
+import { requirePageSession } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -8,9 +7,9 @@ export function createConnectOauthHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
+			const sessionRedirect = await requirePageSession(request)
+			if (sessionRedirect) {
+				return sessionRedirect
 			}
 			return renderAppPage({
 				request,

--- a/packages/worker/src/app/handlers/pending-verification.ts
+++ b/packages/worker/src/app/handlers/pending-verification.ts
@@ -1,11 +1,6 @@
 import { type Action } from 'remix/router'
-import {
-	normalizeRedirectTo,
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
-import { readAuthSessionResult } from '#app/auth-session.ts'
-import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { normalizeRedirectTo } from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#app/routes.ts'
 
@@ -20,14 +15,9 @@ export function createPendingVerificationHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			if (user.emailVerified) {

--- a/packages/worker/src/app/handlers/timeline.tsx
+++ b/packages/worker/src/app/handlers/timeline.tsx
@@ -1,12 +1,8 @@
 /** @jsxImportSource remix/ui */
 /** @jsxRuntime automatic */
 import { type Action } from 'remix/router'
-import { readAuthSessionResult } from '#app/auth-session.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import {
-	redirectToLogin,
-	redirectToLoginWhenUnauthenticated,
-} from '#app/auth-redirect.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { type routes } from '#app/routes.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { loadTimelineData } from '#app/timeline-data.ts'
@@ -16,14 +12,9 @@ export function createTimelineHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
-			const { session } = await readAuthSessionResult(request)
-			if (!session) {
-				return redirectToLogin(request)
-			}
-
-			const user = await readAuthenticatedAppUser(request, env)
-			if (!user) {
-				return redirectToLoginWhenUnauthenticated(request, env)
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
 			}
 
 			const timeline = await loadTimelineData({

--- a/packages/worker/src/app/page-auth.ts
+++ b/packages/worker/src/app/page-auth.ts
@@ -1,0 +1,54 @@
+import {
+	redirectToLogin,
+	redirectToLoginWhenUnauthenticated,
+} from '#app/auth-redirect.ts'
+import {
+	readAuthenticatedAppUser,
+	type AuthenticatedAppUser,
+} from '#app/authenticated-user.ts'
+import { readAuthSessionResult } from '#app/auth-session.ts'
+import { requireUserWithRole } from '#app/permissions-server.ts'
+import { type RoleName } from '#app/permissions.ts'
+
+export async function requirePageSession(
+	request: Request,
+): Promise<Response | null> {
+	const { session } = await readAuthSessionResult(request)
+	if (!session) {
+		return redirectToLogin(request)
+	}
+
+	return null
+}
+
+export async function requireAuthenticatedPageUser(
+	request: Request,
+	env: Env,
+): Promise<AuthenticatedAppUser | Response> {
+	const { session } = await readAuthSessionResult(request)
+	if (!session) {
+		return redirectToLogin(request)
+	}
+
+	const user = await readAuthenticatedAppUser(request, env)
+	if (!user) {
+		return redirectToLoginWhenUnauthenticated(request, env)
+	}
+
+	return user
+}
+
+export async function requirePageUserWithRole(
+	request: Request,
+	env: Env,
+	role: RoleName,
+): Promise<AuthenticatedAppUser | Response> {
+	try {
+		return await requireUserWithRole(request, env, role)
+	} catch (error) {
+		if (error instanceof Response) {
+			return error
+		}
+		throw error
+	}
+}

--- a/packages/worker/src/app/request-body.ts
+++ b/packages/worker/src/app/request-body.ts
@@ -1,0 +1,32 @@
+export function readNonEmptyTrimmedString(
+	body: object,
+	key: string,
+): string | null {
+	const value = (body as Record<string, unknown>)[key]
+	if (typeof value !== 'string') {
+		return null
+	}
+
+	const trimmed = value.trim()
+	return trimmed ? trimmed : null
+}
+
+export function readNonEmptyTrimmedStringOrNumber(
+	body: object,
+	key: string,
+): string | null {
+	const value = (body as Record<string, unknown>)[key]
+	if (typeof value === 'string') {
+		const trimmed = value.trim()
+		return trimmed ? trimmed : null
+	}
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return String(value)
+	}
+	return null
+}
+
+export function readTrimmedStringOrEmpty(body: object, key: string): string {
+	const value = (body as Record<string, unknown>)[key]
+	return typeof value === 'string' ? value.trim() : ''
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Track A (web routing consolidation), PR 2 of 4: shared handler auth/body helpers.

- Add `#app/page-auth.ts` with `requirePageSession`, `requireAuthenticatedPageUser`, and `requirePageUserWithRole`.
- Add `#app/request-body.ts` with the three existing `readString` semantics (nullable trimmed, nullable trimmed-or-number, trimmed-or-empty).
- Replace copy-pasted page auth blocks and local `readString` helpers across account/admin handlers.
- JSON API handlers that return `401` via `readAuthenticatedAppUser` are unchanged.
- No Remix middleware rewrite (`middleware: []` remains).

**Risk:** LOW — behavior-preserving extraction; redirect and body-parse semantics kept distinct.

## Test plan

- [x] `npm run typecheck`
- [x] focused vitest: timeline, admin-users, account-secrets handlers
- [ ] CI `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `2d926462` · **Head:** `fcc6d693`

**Classification:** composes — handlers call the same session/user/RBAC primitives through thin shared helpers.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — page handlers use `page-auth` / `request-body` |
| `app-sessions` | auth | composes — session redirect path centralized |
| `rbac` | auth | composes — admin page try/catch wrapped as `requirePageUserWithRole` |
| `mcp-client-servers` | assistant | composes — handler auth/body helper call sites only |
| `remote-connectors` | assistant | composes — handler auth/body helper call sites only |
| `community-listings` | assistant | composes — admin reports page auth helper only |

### System map

Page and admin HTML handlers now enter auth through shared helpers instead of inlined session/user/RBAC blocks.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appSessions["app-sessions<br/>Browser sessions"]:::touched
	rbac["rbac<br/>Role-based access control"]:::touched
	appUi -->|"requireAuthenticatedPageUser"| appSessions
	appUi -->|"requirePageUserWithRole"| rbac
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Concern | Before | After |
| --- | --- | --- |
| Page auth | 4-line session+user block copied per handler | `requireAuthenticatedPageUser` |
| Admin page auth | try/catch `requireUserWithRole` + redundant session check | `requirePageUserWithRole` |
| Body strings | 7 local `readString` copies (3 semantics) | `#app/request-body.ts` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b68d36b5-1723-43e1-adac-a76894708e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b68d36b5-1723-43e1-adac-a76894708e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

