### PR TITLE
Unify user-owned data lifecycle registries for deletion and export

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -102,8 +102,13 @@ Deletion must cover these user-owned surfaces:
 
 Account export is implemented in `packages/worker/src/app/account-export.ts`. It
 mirrors the deletion inventory so portability and account migration cover the
-same user-owned storage surfaces. The D1 table list is shared with account
-deletion (`accountUserDataTargets`), and
+same user-owned storage surfaces. The D1 table list and shared kind→SQL match
+builders live in `account-data-targets.ts` (`accountUserDataTargets`,
+`buildUserScopedTargetMatch`); export redaction columns also live there.
+Out-of-band surfaces (Durable Objects, KV schemes, R2, Vectorize, Artifacts) are
+declared in `account-user-owned-surfaces.ts` and consumed by both deletion and
+export. Growth-table retention dispositions are linked in
+`account-retention-dispositions.ts`.
 `packages/worker/src/app/account-export.node.test.ts` applies the live
 migrations to SQLite and fails if a `user_id` / `*_user_id` column is not
 covered by the export list. The hard invariant is the same as every storage

--- a/packages/worker/src/app/account-data-targets.node.test.ts
+++ b/packages/worker/src/app/account-data-targets.node.test.ts
@@ -1,0 +1,161 @@
+import { expect, test } from 'vitest'
+import {
+	accountExportForeignUserIdColumnsByTable,
+	accountExportRedactedColumnsByTable,
+	accountExportRedactedForeignUserId,
+	accountUserDataTargets,
+	buildUserScopedDeleteOrUpdateSql,
+	buildUserScopedTargetMatch,
+	type UserScopedDataTarget,
+} from './account-data-targets.ts'
+
+function matchFor(target: UserScopedDataTarget) {
+	return buildUserScopedTargetMatch({
+		target,
+		mcpUserId: 'user-aaa',
+		dbUserId: 42,
+	})
+}
+
+test('shared user-scoped target match SQL is identical for deletion and export shapes', () => {
+	const samples: Array<UserScopedDataTarget> = [
+		{ kind: 'user_id', table: 'jobs' },
+		{ kind: 'db_user_id', table: 'passkeys' },
+		{ kind: 'db_user_target', table: 'verifications' },
+		{
+			kind: 'user_columns',
+			table: 'user_follows',
+			columns: ['follower_user_id', 'followee_user_id'],
+		},
+		{
+			kind: 'null_user_column',
+			table: 'platform_feedback',
+			matchColumn: 'reviewed_by_user_id',
+			nullColumns: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
+			includeInExport: false,
+		},
+		{
+			kind: 'replace_user_column',
+			table: 'community_bans',
+			matchColumn: 'banned_by_user_id',
+			setColumn: 'banned_by_user_id',
+			value: 'deleted-user',
+		},
+		{
+			kind: 'bucket_parent',
+			table: 'value_entries',
+			parentTable: 'value_buckets',
+		},
+		{ kind: 'attachment_parent', table: 'email_attachments' },
+		{
+			kind: 'community_listing_child',
+			table: 'community_stars',
+			listingColumn: 'listing_id',
+		},
+		{ kind: 'mcp_memory_suppression' },
+	]
+
+	expect(matchFor(samples[0]!)).toEqual({
+		table: 'jobs',
+		whereSql: 'user_id = ?',
+		qualifiedWhereSql: 'jobs.user_id = ?',
+		params: ['user-aaa'],
+		mutation: { kind: 'delete' },
+	})
+	expect(buildUserScopedDeleteOrUpdateSql(matchFor(samples[0]!))).toEqual({
+		sql: 'DELETE FROM jobs WHERE user_id = ?',
+		params: ['user-aaa'],
+	})
+
+	expect(matchFor(samples[1]!)).toEqual({
+		table: 'passkeys',
+		whereSql: 'user_id = ?',
+		qualifiedWhereSql: 'passkeys.user_id = ?',
+		params: [42],
+		mutation: { kind: 'delete' },
+	})
+	expect(matchFor(samples[2]!)).toEqual({
+		table: 'verifications',
+		whereSql: 'target = ?',
+		qualifiedWhereSql: 'verifications.target = ?',
+		params: ['42'],
+		mutation: { kind: 'delete' },
+	})
+	expect(matchFor(samples[3]!)).toEqual({
+		table: 'user_follows',
+		whereSql: 'follower_user_id = ? OR followee_user_id = ?',
+		qualifiedWhereSql:
+			'user_follows.follower_user_id = ? OR user_follows.followee_user_id = ?',
+		params: ['user-aaa', 'user-aaa'],
+		mutation: { kind: 'delete' },
+	})
+
+	const nullMatch = matchFor(samples[4]!)
+	expect(nullMatch.mutation).toEqual({
+		kind: 'null_columns',
+		columns: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
+	})
+	expect(buildUserScopedDeleteOrUpdateSql(nullMatch)).toEqual({
+		sql: `UPDATE platform_feedback
+						SET reviewed_by_user_id = NULL, reviewed_at = NULL, admin_note = NULL
+						WHERE reviewed_by_user_id = ?`,
+		params: ['user-aaa'],
+	})
+
+	const replaceMatch = matchFor(samples[5]!)
+	expect(buildUserScopedDeleteOrUpdateSql(replaceMatch)).toEqual({
+		sql: `UPDATE community_bans
+						SET banned_by_user_id = ?
+						WHERE banned_by_user_id = ?`,
+		params: ['deleted-user', 'user-aaa'],
+	})
+
+	expect(matchFor(samples[6]!).qualifiedWhereSql).toBe(
+		`value_entries.bucket_id IN (
+						SELECT id FROM value_buckets WHERE user_id = ?
+					)`,
+	)
+	expect(matchFor(samples[7]!).qualifiedWhereSql).toBe(
+		`email_attachments.message_id IN (
+						SELECT id FROM email_messages WHERE user_id = ?
+					)`,
+	)
+	expect(matchFor(samples[8]!).qualifiedWhereSql).toBe(
+		`community_stars.listing_id IN (
+						SELECT id FROM community_listings WHERE owner_user_id = ?
+					)`,
+	)
+	expect(matchFor(samples[9]!)).toEqual({
+		table: 'mcp_memory_conversation_suppressions',
+		whereSql: 'user_id = ?',
+		qualifiedWhereSql: 'mcp_memory_conversation_suppressions.user_id = ?',
+		params: ['user-aaa'],
+		mutation: { kind: 'delete' },
+	})
+})
+
+test('every accountUserDataTargets kind has a shared match builder', () => {
+	for (const target of accountUserDataTargets) {
+		const match = matchFor(target)
+		expect(match.table.length).toBeGreaterThan(0)
+		expect(match.whereSql.length).toBeGreaterThan(0)
+		expect(match.qualifiedWhereSql).toContain(match.table)
+		expect(match.params.length).toBeGreaterThan(0)
+		const statement = buildUserScopedDeleteOrUpdateSql(match)
+		expect(statement.sql).toContain(match.table)
+		expect(statement.params.length).toBeGreaterThan(0)
+	}
+})
+
+test('account export redaction maps stay centralized in the D1 registry', () => {
+	expect(accountExportRedactedColumnsByTable.users).toEqual(['password_hash'])
+	expect(accountExportRedactedColumnsByTable.secret_entries).toEqual([
+		'encrypted_value',
+		'lookup_hash',
+	])
+	expect(accountExportForeignUserIdColumnsByTable.user_follows).toEqual([
+		'follower_user_id',
+		'followee_user_id',
+	])
+	expect(accountExportRedactedForeignUserId).toBe('[redacted]')
+})

--- a/packages/worker/src/app/account-data-targets.ts
+++ b/packages/worker/src/app/account-data-targets.ts
@@ -308,3 +308,242 @@ export function getAccountD1UserColumnCoverage() {
 	}
 	return covered
 }
+
+/**
+ * Shared match predicate for a user-scoped D1 target. Account deletion wraps
+ * this in DELETE/UPDATE; account export uses the table-qualified form in
+ * SELECT WHERE clauses. Keep both SQL shapes here so the two paths cannot
+ * drift.
+ */
+export type UserScopedTargetMatch = {
+	table: string
+	/** Unqualified boolean SQL for DELETE/UPDATE WHERE clauses. */
+	whereSql: string
+	/** Table-qualified boolean SQL for SELECT WHERE clauses. */
+	qualifiedWhereSql: string
+	params: ReadonlyArray<unknown>
+	mutation:
+		| { kind: 'delete' }
+		| { kind: 'null_columns'; columns: ReadonlyArray<string> }
+		| { kind: 'replace_column'; column: string; value: string }
+}
+
+export function resolveUserScopedTargetTable(
+	target: UserScopedDataTarget,
+): string {
+	switch (target.kind) {
+		case 'mcp_memory_suppression': {
+			return 'mcp_memory_conversation_suppressions'
+		}
+		case 'attachment_parent': {
+			return 'email_attachments'
+		}
+		case 'user_id':
+		case 'db_user_id':
+		case 'db_user_target':
+		case 'user_columns':
+		case 'null_user_column':
+		case 'replace_user_column':
+		case 'bucket_parent':
+		case 'community_listing_child': {
+			return target.table
+		}
+		default: {
+			const exhaustive: never = target
+			throw new Error(
+				`Unhandled user-scoped target table: ${JSON.stringify(exhaustive)}`,
+			)
+		}
+	}
+}
+
+export function buildUserScopedTargetMatch(input: {
+	target: UserScopedDataTarget
+	mcpUserId: string
+	dbUserId: number
+}): UserScopedTargetMatch {
+	const { target } = input
+	const table = resolveUserScopedTargetTable(target)
+	switch (target.kind) {
+		case 'user_id': {
+			return {
+				table,
+				whereSql: 'user_id = ?',
+				qualifiedWhereSql: `${table}.user_id = ?`,
+				params: [input.mcpUserId],
+				mutation: { kind: 'delete' },
+			}
+		}
+		case 'db_user_id': {
+			return {
+				table,
+				whereSql: 'user_id = ?',
+				qualifiedWhereSql: `${table}.user_id = ?`,
+				params: [input.dbUserId],
+				mutation: { kind: 'delete' },
+			}
+		}
+		case 'db_user_target': {
+			return {
+				table,
+				whereSql: 'target = ?',
+				qualifiedWhereSql: `${table}.target = ?`,
+				params: [String(input.dbUserId)],
+				mutation: { kind: 'delete' },
+			}
+		}
+		case 'user_columns': {
+			return {
+				table,
+				whereSql: target.columns.map((column) => `${column} = ?`).join(' OR '),
+				qualifiedWhereSql: target.columns
+					.map((column) => `${table}.${column} = ?`)
+					.join(' OR '),
+				params: target.columns.map(() => input.mcpUserId),
+				mutation: { kind: 'delete' },
+			}
+		}
+		case 'null_user_column': {
+			return {
+				table,
+				whereSql: `${target.matchColumn} = ?`,
+				qualifiedWhereSql: `${table}.${target.matchColumn} = ?`,
+				params: [input.mcpUserId],
+				mutation: { kind: 'null_columns', columns: target.nullColumns },
+			}
+		}
+		case 'replace_user_column': {
+			return {
+				table,
+				whereSql: `${target.matchColumn} = ?`,
+				qualifiedWhereSql: `${table}.${target.matchColumn} = ?`,
+				params: [input.mcpUserId],
+				mutation: {
+					kind: 'replace_column',
+					column: target.setColumn,
+					value: target.value,
+				},
+			}
+		}
+		case 'bucket_parent': {
+			const whereSql = `bucket_id IN (
+						SELECT id FROM ${target.parentTable} WHERE user_id = ?
+					)`
+			return {
+				table,
+				whereSql,
+				qualifiedWhereSql: `${table}.${whereSql}`,
+				params: [input.mcpUserId],
+				mutation: { kind: 'delete' },
+			}
+		}
+		case 'attachment_parent': {
+			const whereSql = `message_id IN (
+						SELECT id FROM email_messages WHERE user_id = ?
+					)`
+			return {
+				table,
+				whereSql,
+				qualifiedWhereSql: `email_attachments.${whereSql}`,
+				params: [input.mcpUserId],
+				mutation: { kind: 'delete' },
+			}
+		}
+		case 'community_listing_child': {
+			const whereSql = `${target.listingColumn} IN (
+						SELECT id FROM community_listings WHERE owner_user_id = ?
+					)`
+			return {
+				table,
+				whereSql,
+				qualifiedWhereSql: `${table}.${whereSql}`,
+				params: [input.mcpUserId],
+				mutation: { kind: 'delete' },
+			}
+		}
+		case 'mcp_memory_suppression': {
+			return {
+				table,
+				whereSql: 'user_id = ?',
+				qualifiedWhereSql: `${table}.user_id = ?`,
+				params: [input.mcpUserId],
+				mutation: { kind: 'delete' },
+			}
+		}
+		default: {
+			const exhaustive: never = target
+			throw new Error(
+				`Unhandled user-scoped target match: ${JSON.stringify(exhaustive)}`,
+			)
+		}
+	}
+}
+
+export function buildUserScopedDeleteOrUpdateSql(
+	match: UserScopedTargetMatch,
+): { sql: string; params: ReadonlyArray<unknown> } {
+	switch (match.mutation.kind) {
+		case 'delete': {
+			return {
+				sql: `DELETE FROM ${match.table} WHERE ${match.whereSql}`,
+				params: match.params,
+			}
+		}
+		case 'null_columns': {
+			return {
+				sql: `UPDATE ${match.table}
+						SET ${match.mutation.columns.map((column) => `${column} = NULL`).join(', ')}
+						WHERE ${match.whereSql}`,
+				params: match.params,
+			}
+		}
+		case 'replace_column': {
+			return {
+				sql: `UPDATE ${match.table}
+						SET ${match.mutation.column} = ?
+						WHERE ${match.whereSql}`,
+				params: [match.mutation.value, ...match.params],
+			}
+		}
+		default: {
+			const exhaustive: never = match.mutation
+			throw new Error(
+				`Unhandled user-scoped mutation: ${JSON.stringify(exhaustive)}`,
+			)
+		}
+	}
+}
+
+// Secret values and credential-equivalent hashes must never leave Kody through
+// account export. Secret entries are metadata-only; encrypted payloads stay
+// server-side and token/password hashes are omitted for the same reason.
+export const accountExportRedactedColumnsByTable: Readonly<
+	Record<string, ReadonlyArray<string>>
+> = {
+	email_verifications: ['token_hash'],
+	package_invocation_tokens: ['token_hash'],
+	password_resets: ['token_hash'],
+	pending_email_changes: ['token_hash'],
+	platform_feedback: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
+	remote_connector_settings: ['encrypted_shared_secret'],
+	secret_entries: ['encrypted_value', 'lookup_hash'],
+	users: ['password_hash'],
+	verifications: ['secret'],
+}
+
+// Social-graph export rows can include another user's stable id. Keep the
+// exporter's own id; replace every other value in these columns.
+export const accountExportForeignUserIdColumnsByTable: Readonly<
+	Record<string, ReadonlyArray<string>>
+> = {
+	user_follows: ['follower_user_id', 'followee_user_id'],
+	community_stars: ['user_id'],
+	community_activity_events: ['actor_user_id'],
+	package_scope_grants: [
+		'scope_owner_user_id',
+		'grantee_user_id',
+		'created_by_user_id',
+	],
+}
+
+export const accountExportRedactedForeignUserId = '[redacted]'

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -16,8 +16,14 @@ import {
 import { packageRealtimeSessionRpc } from '#worker/package-runtime/realtime-session.ts'
 import {
 	accountUserDataTargets,
+	buildUserScopedDeleteOrUpdateSql,
+	buildUserScopedTargetMatch,
 	getAccountD1UserColumnCoverage,
 } from '#app/account-data-targets.ts'
+import {
+	accountUserOwnedVectorizeSurfaces,
+	getAccountDeletionDurableObjectResultKeys,
+} from '#app/account-user-owned-surfaces.ts'
 import {
 	buildPublishedSourceManifestSnapshotKvKey,
 	buildPublishedSourceSnapshotKvKey,
@@ -130,31 +136,24 @@ function uniqueStrings(values: Iterable<string | null | undefined>) {
 	)
 }
 
+const vectorIdBuildersBySurfaceId = {
+	memory: memoryVectorId,
+	job: jobVectorId,
+	saved_package: savedPackageVectorId,
+} as const
+
 async function listUserVectorIds(env: Env, userId: string) {
-	const memoryRows = await env.APP_DB.prepare(
-		`SELECT id FROM mcp_memories WHERE user_id = ?`,
-	)
-		.bind(userId)
-		.all<{ id: string }>()
-	const jobRows = await env.APP_DB.prepare(
-		`SELECT id FROM jobs WHERE user_id = ?`,
-	)
-		.bind(userId)
-		.all<{ id: string }>()
-	const packageRows = await env.APP_DB.prepare(
-		`SELECT id FROM saved_packages WHERE user_id = ?`,
-	)
-		.bind(userId)
-		.all<{ id: string }>()
 	const ids: Array<string> = []
-	for (const row of memoryRows.results ?? []) {
-		ids.push(memoryVectorId(row.id))
-	}
-	for (const row of jobRows.results ?? []) {
-		ids.push(jobVectorId(row.id))
-	}
-	for (const row of packageRows.results ?? []) {
-		ids.push(savedPackageVectorId(row.id))
+	for (const surface of accountUserOwnedVectorizeSurfaces) {
+		const rows = await env.APP_DB.prepare(
+			`SELECT id FROM ${surface.sourceTable} WHERE user_id = ?`,
+		)
+			.bind(userId)
+			.all<{ id: string }>()
+		const buildId = vectorIdBuildersBySurfaceId[surface.id]
+		for (const row of rows.results ?? []) {
+			ids.push(buildId(row.id))
+		}
 	}
 	return ids
 }
@@ -881,115 +880,28 @@ async function deleteUserScopedRows(input: {
 			(updatedRowCounts[tableName] ?? 0) + (changes ?? 0)
 	}
 	for (const target of accountUserDataTargets) {
+		const match = buildUserScopedTargetMatch({
+			target,
+			mcpUserId: input.mcpUserId,
+			dbUserId: input.dbUserId,
+		})
 		try {
-			let sql: string
-			let params: Array<unknown>
-			let tableName: string
-			switch (target.kind) {
-				case 'user_id': {
-					sql = `DELETE FROM ${target.table} WHERE user_id = ?`
-					params = [input.mcpUserId]
-					tableName = target.table
-					break
-				}
-				case 'db_user_id': {
-					sql = `DELETE FROM ${target.table} WHERE user_id = ?`
-					params = [input.dbUserId]
-					tableName = target.table
-					break
-				}
-				case 'db_user_target': {
-					sql = `DELETE FROM ${target.table} WHERE target = ?`
-					params = [String(input.dbUserId)]
-					tableName = target.table
-					break
-				}
-				case 'user_columns': {
-					sql = `DELETE FROM ${target.table} WHERE ${target.columns
-						.map((column) => `${column} = ?`)
-						.join(' OR ')}`
-					params = target.columns.map(() => input.mcpUserId)
-					tableName = target.table
-					break
-				}
-				case 'null_user_column': {
-					sql = `UPDATE ${target.table}
-						SET ${target.nullColumns.map((column) => `${column} = NULL`).join(', ')}
-						WHERE ${target.matchColumn} = ?`
-					params = [input.mcpUserId]
-					tableName = target.table
-					break
-				}
-				case 'replace_user_column': {
-					sql = `UPDATE ${target.table}
-						SET ${target.setColumn} = ?
-						WHERE ${target.matchColumn} = ?`
-					params = [target.value, input.mcpUserId]
-					tableName = target.table
-					break
-				}
-				case 'bucket_parent': {
-					sql = `DELETE FROM ${target.table} WHERE bucket_id IN (
-						SELECT id FROM ${target.parentTable} WHERE user_id = ?
-					)`
-					params = [input.mcpUserId]
-					tableName = target.table
-					break
-				}
-				case 'attachment_parent': {
-					sql = `DELETE FROM email_attachments WHERE message_id IN (
-						SELECT id FROM email_messages WHERE user_id = ?
-					)`
-					params = [input.mcpUserId]
-					tableName = 'email_attachments'
-					break
-				}
-				case 'community_listing_child': {
-					sql = `DELETE FROM ${target.table} WHERE ${target.listingColumn} IN (
-						SELECT id FROM community_listings WHERE owner_user_id = ?
-					)`
-					params = [input.mcpUserId]
-					tableName = target.table
-					break
-				}
-				case 'mcp_memory_suppression': {
-					sql = `DELETE FROM mcp_memory_conversation_suppressions WHERE user_id = ?`
-					params = [input.mcpUserId]
-					tableName = 'mcp_memory_conversation_suppressions'
-					break
-				}
-				default: {
-					const exhaustive: never = target
-					throw new Error(
-						`Unhandled user-scoped delete target: ${JSON.stringify(exhaustive)}`,
-					)
-				}
-			}
+			const { sql, params } = buildUserScopedDeleteOrUpdateSql(match)
 			const result = await input.env.APP_DB.prepare(sql)
 				.bind(...params)
 				.run()
-			if (
-				target.kind === 'null_user_column' ||
-				target.kind === 'replace_user_column'
-			) {
-				recordUpdated(tableName, result.meta.changes)
+			if (match.mutation.kind === 'delete') {
+				recordDeleted(match.table, result.meta.changes)
 			} else {
-				recordDeleted(tableName, result.meta.changes)
+				recordUpdated(match.table, result.meta.changes)
 			}
 		} catch (error) {
 			const message = getErrorMessage(error)
-			const targetLabel =
-				target.kind === 'mcp_memory_suppression'
-					? 'mcp_memory_conversation_suppressions'
-					: target.table
-			input.warnings.push(`Failed to delete from ${targetLabel}: ${message}`)
-			if (
-				target.kind === 'null_user_column' ||
-				target.kind === 'replace_user_column'
-			) {
-				recordUpdated(targetLabel, 0)
+			input.warnings.push(`Failed to delete from ${match.table}: ${message}`)
+			if (match.mutation.kind === 'delete') {
+				recordDeleted(match.table, 0)
 			} else {
-				recordDeleted(targetLabel, 0)
+				recordUpdated(match.table, 0)
 			}
 		}
 	}
@@ -1036,6 +948,10 @@ export async function deleteUserAccount(input: {
 	mcpUserId: string
 }): Promise<AccountDeletionResult> {
 	const warnings: Array<string> = []
+	const clearedDurableObjects: Record<string, number> = {}
+	for (const key of getAccountDeletionDurableObjectResultKeys()) {
+		clearedDurableObjects[key] = 0
+	}
 	const result: AccountDeletionResult = {
 		deletedRowCounts: {},
 		updatedRowCounts: {},
@@ -1044,7 +960,7 @@ export async function deleteUserAccount(input: {
 		deletedEmailBlobs: 0,
 		deletedArtifactRepos: 0,
 		revokedOAuthGrants: 0,
-		clearedDurableObjects: {},
+		clearedDurableObjects,
 		deletedVectors: 0,
 		warnings,
 	}

--- a/packages/worker/src/app/account-export.ts
+++ b/packages/worker/src/app/account-export.ts
@@ -1,11 +1,15 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
+	accountExportForeignUserIdColumnsByTable,
+	accountExportRedactedColumnsByTable,
+	accountExportRedactedForeignUserId,
 	accountUserDataTargets,
+	buildUserScopedTargetMatch,
 	getAccountExportExcludedD1Surfaces,
 	isExcludedFromAccountExport,
-	type UserScopedDataTarget,
 	getAccountD1UserColumnCoverage,
 } from '#app/account-data-targets.ts'
+import { getAccountExportExcludedDurableObjects } from '#app/account-user-owned-surfaces.ts'
 import { exportJobManagerForUser } from '#worker/jobs/manager-client.ts'
 import {
 	buildPackageServiceStorageId,
@@ -30,39 +34,6 @@ const d1ExportPageSize = 500
 // Internal alias for the SQLite rowid used as the keyset cursor. Stripped from
 // exported rows so the export document schema is unchanged.
 const exportRowidColumn = '__account_export_rowid'
-
-// Secret values and credential-equivalent hashes must never leave Kody through
-// account export. Secret entries are metadata-only; encrypted payloads stay
-// server-side and token/password hashes are omitted for the same reason.
-const redactedColumnsByTable: Readonly<Record<string, ReadonlyArray<string>>> =
-	{
-		email_verifications: ['token_hash'],
-		package_invocation_tokens: ['token_hash'],
-		password_resets: ['token_hash'],
-		pending_email_changes: ['token_hash'],
-		platform_feedback: ['reviewed_by_user_id', 'reviewed_at', 'admin_note'],
-		remote_connector_settings: ['encrypted_shared_secret'],
-		secret_entries: ['encrypted_value', 'lookup_hash'],
-		users: ['password_hash'],
-		verifications: ['secret'],
-	}
-
-// Social-graph export rows can include another user's stable id. Keep the
-// exporter's own id; replace every other value in these columns.
-const foreignUserIdColumnsByTable: Readonly<
-	Record<string, ReadonlyArray<string>>
-> = {
-	user_follows: ['follower_user_id', 'followee_user_id'],
-	community_stars: ['user_id'],
-	community_activity_events: ['actor_user_id'],
-	package_scope_grants: [
-		'scope_owner_user_id',
-		'grantee_user_id',
-		'created_by_user_id',
-	],
-}
-
-const redactedForeignUserId = '[redacted]'
 
 export const accountExportSectionNames = [
 	'd1_table',
@@ -274,120 +245,6 @@ type D1TableCondition = {
 	params: Array<unknown>
 }
 
-function buildConditionForTarget(input: {
-	target: UserScopedDataTarget
-	mcpUserId: string
-	dbUserId: number
-}): { table: string; condition: D1TableCondition } {
-	const { target } = input
-	switch (target.kind) {
-		case 'user_id': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.user_id = ?`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'db_user_id': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.user_id = ?`,
-					params: [input.dbUserId],
-				},
-			}
-		}
-		case 'db_user_target': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.target = ?`,
-					params: [String(input.dbUserId)],
-				},
-			}
-		}
-		case 'user_columns': {
-			return {
-				table: target.table,
-				condition: {
-					condition: target.columns
-						.map((column) => `${target.table}.${column} = ?`)
-						.join(' OR '),
-					params: target.columns.map(() => input.mcpUserId),
-				},
-			}
-		}
-		case 'null_user_column': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.${target.matchColumn} = ?`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'replace_user_column': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.${target.matchColumn} = ?`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'bucket_parent': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.bucket_id IN (
-						SELECT id FROM ${target.parentTable} WHERE user_id = ?
-					)`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'attachment_parent': {
-			return {
-				table: 'email_attachments',
-				condition: {
-					condition: `email_attachments.message_id IN (
-						SELECT id FROM email_messages WHERE user_id = ?
-					)`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'community_listing_child': {
-			return {
-				table: target.table,
-				condition: {
-					condition: `${target.table}.${target.listingColumn} IN (
-						SELECT id FROM community_listings WHERE owner_user_id = ?
-					)`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		case 'mcp_memory_suppression': {
-			return {
-				table: 'mcp_memory_conversation_suppressions',
-				condition: {
-					condition: `mcp_memory_conversation_suppressions.user_id = ?`,
-					params: [input.mcpUserId],
-				},
-			}
-		}
-		default: {
-			const exhaustive: never = target
-			throw new Error(
-				`Unhandled account export target: ${JSON.stringify(exhaustive)}`,
-			)
-		}
-	}
-}
-
 function buildD1TableConditions(input: {
 	mcpUserId: string
 	dbUserId: number
@@ -406,12 +263,15 @@ function buildD1TableConditions(input: {
 		if (isExcludedFromAccountExport(target)) {
 			continue
 		}
-		const built = buildConditionForTarget({
+		const match = buildUserScopedTargetMatch({
 			target,
 			mcpUserId: input.mcpUserId,
 			dbUserId: input.dbUserId,
 		})
-		add(built.table, built.condition)
+		add(match.table, {
+			condition: match.qualifiedWhereSql,
+			params: [...match.params],
+		})
 	}
 	return conditionsByTable
 }
@@ -421,8 +281,9 @@ function sanitizeRow(
 	row: Record<string, unknown>,
 	mcpUserId: string,
 ) {
-	const redactedColumns = redactedColumnsByTable[table] ?? []
-	const foreignUserIdColumns = foreignUserIdColumnsByTable[table] ?? []
+	const redactedColumns = accountExportRedactedColumnsByTable[table] ?? []
+	const foreignUserIdColumns =
+		accountExportForeignUserIdColumnsByTable[table] ?? []
 	const sanitized: Record<string, unknown> = {}
 	for (const [key, value] of Object.entries(row)) {
 		if (redactedColumns.includes(key)) continue
@@ -431,7 +292,7 @@ function sanitizeRow(
 			typeof value === 'string' &&
 			value !== mcpUserId
 		) {
-			sanitized[key] = redactedForeignUserId
+			sanitized[key] = accountExportRedactedForeignUserId
 			continue
 		}
 		sanitized[key] = value
@@ -1180,23 +1041,7 @@ function buildManifest(input: {
 			vectorize:
 				'Vectorize entries for memories, jobs, and packages are derived from exported D1 rows and are intentionally excluded; rebuild them by reindexing after import.',
 		},
-		excludedDurableObjects: [
-			{
-				name: 'MCP',
-				reason:
-					'Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.',
-			},
-			{
-				name: 'RepoSession',
-				reason:
-					'Ephemeral editing workspace. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources and repo_sessions metadata.',
-			},
-			{
-				name: 'PackageRealtimeSession',
-				reason:
-					'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
-			},
-		],
+		excludedDurableObjects: getAccountExportExcludedDurableObjects(),
 		excludedD1Surfaces: getAccountExportExcludedD1Surfaces(),
 	} satisfies AccountExportManifest
 }

--- a/packages/worker/src/app/account-retention-dispositions.node.test.ts
+++ b/packages/worker/src/app/account-retention-dispositions.node.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'vitest'
+import {
+	accountRetentionDispositions,
+	getAccountRetentionDispositionCoverage,
+} from './account-retention-dispositions.ts'
+import {
+	getRetentionPolicyCoverage,
+	retentionPolicies,
+	retentionPolicyExemptions,
+} from './retention.ts'
+
+test('account retention disposition coverage matches retention policy coverage', () => {
+	expect([...getAccountRetentionDispositionCoverage()].sort()).toEqual(
+		[...getRetentionPolicyCoverage()].sort(),
+	)
+})
+
+test('every scheduled retention disposition is backed by retentionPolicies', () => {
+	const policyTables = new Set(retentionPolicies.map((policy) => policy.table))
+	const scheduledTables = accountRetentionDispositions
+		.filter((disposition) => disposition.kind === 'scheduled_policy')
+		.map((disposition) => disposition.table)
+	expect(scheduledTables.sort()).toEqual([...policyTables].sort())
+	for (const table of scheduledTables) {
+		expect(
+			policyTables.has(table),
+			`missing retention policy for ${table}`,
+		).toBe(true)
+	}
+})
+
+test('non-scheduled retention dispositions are documented exemptions', () => {
+	const exemptions = new Map(
+		retentionPolicyExemptions.map((exemption) => [
+			exemption.table,
+			exemption.reason,
+		]),
+	)
+	const nonScheduled = accountRetentionDispositions.filter(
+		(disposition) => disposition.kind !== 'scheduled_policy',
+	)
+	expect(nonScheduled.map((disposition) => disposition.table).sort()).toEqual(
+		[...exemptions.keys()].sort(),
+	)
+	for (const disposition of nonScheduled) {
+		expect(exemptions.get(disposition.table)).toBe(disposition.reason)
+	}
+})
+
+test('retention disposition exemptions keep their explicit cleanup semantics', () => {
+	expect(accountRetentionDispositions).toEqual(
+		expect.arrayContaining([
+			{
+				table: 'archived_job_artifacts',
+				kind: 'alternate_cleanup',
+				reason:
+					'Archived job artifact rows are bounded by retain_until and cleaned by the job artifact cleanup path.',
+			},
+			{
+				table: 'mcp_memories',
+				kind: 'durable_forever',
+				reason:
+					'Memories are durable user-curated content removed by explicit user action or account deletion, not by time-based retention.',
+			},
+		]),
+	)
+	// The schema-growth heuristic in retention.node.test.ts remains the broader
+	// guardrail for discovering new growth-pattern tables.
+	expect(getRetentionPolicyCoverage().has('mcp_memories')).toBe(true)
+})

--- a/packages/worker/src/app/account-retention-dispositions.ts
+++ b/packages/worker/src/app/account-retention-dispositions.ts
@@ -1,0 +1,43 @@
+export type AccountRetentionDisposition =
+	| { table: string; kind: 'scheduled_policy' }
+	| { table: string; kind: 'alternate_cleanup'; reason: string }
+	| { table: string; kind: 'durable_forever'; reason: string }
+
+export const accountRetentionDispositions: ReadonlyArray<AccountRetentionDisposition> =
+	[
+		{ table: 'package_runtime_runs', kind: 'scheduled_policy' },
+		{ table: 'package_runtime_logs', kind: 'scheduled_policy' },
+		{ table: 'package_invocations', kind: 'scheduled_policy' },
+		{
+			table: 'mcp_memory_conversation_suppressions',
+			kind: 'scheduled_policy',
+		},
+		{ table: 'workflow_runs', kind: 'scheduled_policy' },
+		{ table: 'platform_feedback', kind: 'scheduled_policy' },
+		{ table: 'published_bundle_artifacts', kind: 'scheduled_policy' },
+		{ table: 'email_delivery_events', kind: 'scheduled_policy' },
+		{ table: 'email_messages', kind: 'scheduled_policy' },
+		{ table: 'email_attachments', kind: 'scheduled_policy' },
+		{ table: 'email_threads', kind: 'scheduled_policy' },
+		{ table: 'entitlement_daily_counters', kind: 'scheduled_policy' },
+		{ table: 'usage_rollups', kind: 'scheduled_policy' },
+		{ table: 'audit_events', kind: 'scheduled_policy' },
+		{
+			table: 'archived_job_artifacts',
+			kind: 'alternate_cleanup',
+			reason:
+				'Archived job artifact rows are bounded by retain_until and cleaned by the job artifact cleanup path.',
+		},
+		{
+			table: 'mcp_memories',
+			kind: 'durable_forever',
+			reason:
+				'Memories are durable user-curated content removed by explicit user action or account deletion, not by time-based retention.',
+		},
+	] as const
+
+export function getAccountRetentionDispositionCoverage(): Set<string> {
+	return new Set(
+		accountRetentionDispositions.map((disposition) => disposition.table),
+	)
+}

--- a/packages/worker/src/app/account-user-owned-surfaces.node.test.ts
+++ b/packages/worker/src/app/account-user-owned-surfaces.node.test.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import {
+	accountUserOwnedDurableObjectSurfaces,
+	accountUserOwnedKvKeySchemes,
+	accountUserOwnedR2Surfaces,
+	accountUserOwnedVectorizeSurfaces,
+	getAccountDeletionDurableObjectResultKeys,
+	getAccountExportExcludedDurableObjects,
+	getAccountUserOwnedSurfaceCoverage,
+} from './account-user-owned-surfaces.ts'
+
+const accountDeletionSource = readFileSync(
+	fileURLToPath(new URL('./account-deletion.ts', import.meta.url)),
+	'utf8',
+)
+const accountExportSource = readFileSync(
+	fileURLToPath(new URL('./account-export.ts', import.meta.url)),
+	'utf8',
+)
+
+test('account export excluded durable objects preserve the legacy manifest list', () => {
+	expect(getAccountExportExcludedDurableObjects()).toEqual([
+		{
+			name: 'MCP',
+			reason:
+				'Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.',
+		},
+		{
+			name: 'RepoSession',
+			reason:
+				'Ephemeral editing workspace. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources and repo_sessions metadata.',
+		},
+		{
+			name: 'PackageRealtimeSession',
+			reason:
+				'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
+		},
+	])
+})
+
+test('account deletion durable object result keys are declared by the registry', () => {
+	expect([...getAccountDeletionDurableObjectResultKeys()].sort()).toEqual([
+		'jobManagers',
+		'mcpClientHubs',
+		'packageRealtimeSessions',
+		'packageServiceInstances',
+		'remoteConnectorSessions',
+		'repoSessions',
+		'storageRunners',
+	])
+})
+
+test('account user-owned surface registry covers known out-of-band surfaces', () => {
+	const coverage = getAccountUserOwnedSurfaceCoverage()
+	expect([...coverage.durableObjectIds].sort()).toEqual([
+		'job_manager',
+		'mcp',
+		'mcp_client_hub',
+		'package_realtime_session',
+		'package_service_instance',
+		'remote_connector_session',
+		'repo_session',
+		'storage_runner',
+	])
+	expect([...coverage.vectorizeIds].sort()).toEqual([
+		'job',
+		'memory',
+		'saved_package',
+	])
+	expect([...coverage.kvSchemeIds].sort()).toEqual([
+		'community_icon_derived_cache',
+		'community_snapshot',
+		'package_retriever_index_entry',
+		'package_retriever_index_prefix',
+		'package_retriever_manifest',
+		'published_bundle_artifact_kv_key',
+		'source_manifest_snapshot',
+		'source_snapshot',
+	])
+	expect([...coverage.r2SurfaceIds].sort()).toEqual([
+		'community_icon',
+		'email_attachment_storage_key',
+		'email_raw_mime',
+		'user_avatar',
+	])
+	expect([...coverage.artifactSurfaceIds].sort()).toEqual([
+		'entity_sources',
+		'repo_sessions',
+	])
+})
+
+test('vectorize surfaces cover derived memory, job, and package vectors', () => {
+	expect(
+		accountUserOwnedVectorizeSurfaces.map((surface) => surface.sourceTable),
+	).toEqual(['mcp_memories', 'jobs', 'saved_packages'])
+	expect(
+		accountUserOwnedVectorizeSurfaces.every(
+			(surface) => surface.export === 'rebuild_from_d1',
+		),
+	).toBe(true)
+})
+
+test('KV key schemes include account deletion prefix guardrails', () => {
+	const prefixes = accountUserOwnedKvKeySchemes.map(
+		(scheme) => scheme.prefixTemplate,
+	)
+	expect(prefixes).toEqual(
+		expect.arrayContaining([
+			'source-snapshot:v1:{sourceId}:',
+			'source-manifest-snapshot:v1:{sourceId}:',
+			'package-retriever-index:v1:{userId}:',
+		]),
+	)
+})
+
+test('R2 surfaces cover email blobs, community icons, and user avatars', () => {
+	expect(accountUserOwnedR2Surfaces).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				id: 'email_raw_mime',
+				binding: 'EMAIL_BLOBS',
+			}),
+			expect.objectContaining({
+				id: 'email_attachment_storage_key',
+				binding: 'EMAIL_BLOBS',
+			}),
+			expect.objectContaining({
+				id: 'community_icon',
+				binding: 'COMMUNITY_ASSETS',
+			}),
+			expect.objectContaining({
+				id: 'user_avatar',
+				binding: 'COMMUNITY_ASSETS',
+			}),
+		]),
+	)
+})
+
+test('account deletion and export consume the out-of-band surface registry', () => {
+	expect(accountDeletionSource).toContain(
+		"from '#app/account-user-owned-surfaces.ts'",
+	)
+	expect(accountDeletionSource).toContain(
+		'getAccountDeletionDurableObjectResultKeys',
+	)
+	expect(accountDeletionSource).toContain('accountUserOwnedVectorizeSurfaces')
+	expect(accountExportSource).toContain(
+		'getAccountExportExcludedDurableObjects',
+	)
+
+	for (const prefix of [
+		'source-snapshot:v1:',
+		'source-manifest-snapshot:v1:',
+		'package-retriever-index:v1:',
+	]) {
+		expect(
+			accountUserOwnedKvKeySchemes.some((scheme) =>
+				scheme.prefixTemplate?.includes(prefix),
+			),
+			`KV scheme registry missing prefix ${prefix}`,
+		).toBe(true)
+		expect(
+			accountDeletionSource.includes(prefix),
+			`account-deletion.ts must still enumerate prefix ${prefix}`,
+		).toBe(true)
+	}
+
+	for (const surface of accountUserOwnedDurableObjectSurfaces) {
+		if (surface.deletionResultKey == null) continue
+		expect(
+			accountDeletionSource.includes(surface.deletionResultKey),
+			`account-deletion.ts missing clearedDurableObjects key ${surface.deletionResultKey}`,
+		).toBe(true)
+	}
+})

--- a/packages/worker/src/app/account-user-owned-surfaces.ts
+++ b/packages/worker/src/app/account-user-owned-surfaces.ts
@@ -1,0 +1,300 @@
+export type UserOwnedDurableObjectSurface = {
+	id:
+		| 'job_manager'
+		| 'storage_runner'
+		| 'repo_session'
+		| 'remote_connector_session'
+		| 'mcp_client_hub'
+		| 'package_realtime_session'
+		| 'package_service_instance'
+		| 'mcp'
+	binding: string
+	/** Result key used in AccountDeletionResult.clearedDurableObjects when purged */
+	deletionResultKey: string | null
+	export: 'include' | 'exclude'
+	excludeReason?: string
+	notes?: string
+}
+
+export type UserOwnedVectorizeSurface = {
+	id: 'memory' | 'job' | 'saved_package'
+	sourceTable: 'mcp_memories' | 'jobs' | 'saved_packages'
+	/** Exported as derivedData.vectorize note; never exported as vectors */
+	export: 'rebuild_from_d1'
+}
+
+export type UserOwnedKvKeyScheme = {
+	id:
+		| 'published_bundle_artifact_kv_key'
+		| 'source_snapshot'
+		| 'source_manifest_snapshot'
+		| 'community_snapshot'
+		| 'community_icon_derived_cache'
+		| 'package_retriever_manifest'
+		| 'package_retriever_index_entry'
+		| 'package_retriever_index_prefix'
+	binding: 'BUNDLE_ARTIFACTS_KV'
+	sourceTable?: string
+	sourceColumn?: string
+	prefixTemplate?: string
+	notes?: string
+}
+
+export type UserOwnedR2Surface = {
+	id:
+		| 'email_raw_mime'
+		| 'email_attachment_storage_key'
+		| 'community_icon'
+		| 'user_avatar'
+	binding: 'EMAIL_BLOBS' | 'COMMUNITY_ASSETS'
+	sourceTable: string
+	sourceColumn?: string
+	keyTemplate?: string
+	notes?: string
+}
+
+export type UserOwnedArtifactSurface = {
+	id: 'entity_sources' | 'repo_sessions'
+	sourceTable: string
+	repoColumn: string
+	notes: string
+}
+
+export const accountUserOwnedDurableObjectSurfaces: ReadonlyArray<UserOwnedDurableObjectSurface> =
+	[
+		{
+			id: 'job_manager',
+			binding: 'JOB_MANAGER',
+			deletionResultKey: 'jobManagers',
+			export: 'include',
+			notes: 'Job manager state is included in account export.',
+		},
+		{
+			id: 'storage_runner',
+			binding: 'STORAGE_RUNNER',
+			deletionResultKey: 'storageRunners',
+			export: 'include',
+		},
+		{
+			id: 'repo_session',
+			binding: 'REPO_SESSION',
+			deletionResultKey: 'repoSessions',
+			export: 'exclude',
+			excludeReason:
+				'Ephemeral editing workspace. Canonical repo-backed source is exported as Artifacts repo pointers via entity_sources and repo_sessions metadata.',
+		},
+		{
+			id: 'remote_connector_session',
+			binding: 'REMOTE_CONNECTOR_SESSION',
+			deletionResultKey: 'remoteConnectorSessions',
+			export: 'include',
+		},
+		{
+			id: 'mcp_client_hub',
+			binding: 'MCP_CLIENT_HUB',
+			deletionResultKey: 'mcpClientHubs',
+			export: 'exclude',
+			excludeReason:
+				'MCP client hub state can include OAuth tokens and SDK registrations that are non-portable; it is purged during account deletion instead of exported.',
+		},
+		{
+			id: 'package_realtime_session',
+			binding: 'PACKAGE_REALTIME_SESSION',
+			deletionResultKey: 'packageRealtimeSessions',
+			export: 'exclude',
+			excludeReason:
+				'Ephemeral live websocket/session state. Durable app storage is exported through StorageRunner buckets.',
+		},
+		{
+			id: 'package_service_instance',
+			binding: 'PACKAGE_SERVICE_INSTANCE',
+			deletionResultKey: 'packageServiceInstances',
+			export: 'include',
+		},
+		{
+			id: 'mcp',
+			binding: 'MCP',
+			deletionResultKey: null,
+			export: 'exclude',
+			excludeReason:
+				'Session-keyed by the MCP SDK and not globally enumerable; durable user data is carried by D1 and user-scoped stores instead.',
+			notes:
+				'Export-excluded only; not purged by account deletion enumeration.',
+		},
+	] as const
+
+export const accountUserOwnedVectorizeSurfaces: ReadonlyArray<UserOwnedVectorizeSurface> =
+	[
+		{
+			id: 'memory',
+			sourceTable: 'mcp_memories',
+			export: 'rebuild_from_d1',
+		},
+		{ id: 'job', sourceTable: 'jobs', export: 'rebuild_from_d1' },
+		{
+			id: 'saved_package',
+			sourceTable: 'saved_packages',
+			export: 'rebuild_from_d1',
+		},
+	] as const
+
+export const accountUserOwnedKvKeySchemes: ReadonlyArray<UserOwnedKvKeyScheme> =
+	[
+		{
+			id: 'published_bundle_artifact_kv_key',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			sourceTable: 'published_bundle_artifacts',
+			sourceColumn: 'kv_key',
+			prefixTemplate: 'bundle-artifact:v1:',
+		},
+		{
+			id: 'source_snapshot',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'source-snapshot:v1:{sourceId}:',
+		},
+		{
+			id: 'source_manifest_snapshot',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'source-manifest-snapshot:v1:{sourceId}:',
+		},
+		{
+			id: 'community_snapshot',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'community-snapshot:v1:',
+		},
+		{
+			id: 'community_icon_derived_cache',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'derived-cache:v1:community-icon:v1:{listingId}:',
+			notes:
+				'Derived cache key from derivedCacheKeyPrefix + buildCommunityIconCacheKey.',
+		},
+		{
+			id: 'package_retriever_manifest',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'package-retriever-manifest:v1:{userId}:{packageId}:',
+			notes: 'Deleted by deleteAllPackageRetrieverCacheEntriesForUser.',
+		},
+		{
+			id: 'package_retriever_index_entry',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate:
+				'package-retriever-index-entry:v1:{userId}:{scope}:{packageId}:',
+			notes: 'Deleted by deleteAllPackageRetrieverCacheEntriesForUser.',
+		},
+		{
+			id: 'package_retriever_index_prefix',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'package-retriever-index:v1:{userId}:',
+		},
+	] as const
+
+export const accountUserOwnedR2Surfaces: ReadonlyArray<UserOwnedR2Surface> = [
+	{
+		id: 'email_raw_mime',
+		binding: 'EMAIL_BLOBS',
+		sourceTable: 'email_messages',
+		sourceColumn: 'id',
+		keyTemplate: 'email-raw:v1:{userId}/{messageId}',
+		notes: 'Canonical key generated by emailRawMimeKey.',
+	},
+	{
+		id: 'email_attachment_storage_key',
+		binding: 'EMAIL_BLOBS',
+		sourceTable: 'email_attachments',
+		sourceColumn: 'storage_key',
+		keyTemplate: 'email-attachment:v1:{userId}/{messageId}/{attachmentId}',
+	},
+	{
+		id: 'community_icon',
+		binding: 'COMMUNITY_ASSETS',
+		sourceTable: 'community_listings',
+		keyTemplate: 'community-icon:v1/{listingId}/{commit}/asset',
+	},
+	{
+		id: 'user_avatar',
+		binding: 'COMMUNITY_ASSETS',
+		sourceTable: 'users',
+		sourceColumn: 'avatar_key',
+	},
+] as const
+
+export const accountUserOwnedArtifactSurfaces: ReadonlyArray<UserOwnedArtifactSurface> =
+	[
+		{
+			id: 'entity_sources',
+			sourceTable: 'entity_sources',
+			repoColumn: 'repo_id',
+			notes:
+				'Cloudflare Artifacts repos cleaned by cleanupAllUserArtifactRepos.',
+		},
+		{
+			id: 'repo_sessions',
+			sourceTable: 'repo_sessions',
+			repoColumn: 'source_repo_id',
+			notes:
+				'Cloudflare Artifacts repos cleaned by cleanupAllUserArtifactRepos.',
+		},
+	] as const
+
+const accountExportExcludedDurableObjectDisplayNames: Readonly<
+	Record<'mcp' | 'repo_session' | 'package_realtime_session', string>
+> = {
+	mcp: 'MCP',
+	repo_session: 'RepoSession',
+	package_realtime_session: 'PackageRealtimeSession',
+} as const
+
+export function getAccountExportExcludedDurableObjects(): Array<{
+	name: string
+	reason: string
+}> {
+	return (
+		['mcp', 'repo_session', 'package_realtime_session'] satisfies Array<
+			keyof typeof accountExportExcludedDurableObjectDisplayNames
+		>
+	).map((id) => {
+		const surface = accountUserOwnedDurableObjectSurfaces.find(
+			(candidate) => candidate.id === id,
+		)
+		if (!surface || surface.export !== 'exclude' || !surface.excludeReason) {
+			throw new Error(`Missing account export durable object exclusion: ${id}`)
+		}
+		return {
+			name: accountExportExcludedDurableObjectDisplayNames[id],
+			reason: surface.excludeReason,
+		}
+	})
+}
+
+export function getAccountDeletionDurableObjectResultKeys(): ReadonlyArray<string> {
+	return accountUserOwnedDurableObjectSurfaces
+		.map((surface) => surface.deletionResultKey)
+		.filter((key): key is string => key !== null)
+}
+
+export function getAccountUserOwnedSurfaceCoverage(): {
+	durableObjectIds: ReadonlySet<string>
+	vectorizeIds: ReadonlySet<string>
+	kvSchemeIds: ReadonlySet<string>
+	r2SurfaceIds: ReadonlySet<string>
+	artifactSurfaceIds: ReadonlySet<string>
+} {
+	return {
+		durableObjectIds: new Set(
+			accountUserOwnedDurableObjectSurfaces.map((surface) => surface.id),
+		),
+		vectorizeIds: new Set(
+			accountUserOwnedVectorizeSurfaces.map((surface) => surface.id),
+		),
+		kvSchemeIds: new Set(
+			accountUserOwnedKvKeySchemes.map((scheme) => scheme.id),
+		),
+		r2SurfaceIds: new Set(
+			accountUserOwnedR2Surfaces.map((surface) => surface.id),
+		),
+		artifactSurfaceIds: new Set(
+			accountUserOwnedArtifactSurfaces.map((surface) => surface.id),
+		),
+	}
+}

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -1,3 +1,4 @@
+import { accountRetentionDispositions } from '#app/account-retention-dispositions.ts'
 import { emailRawMimeKey } from '#worker/email/repo.ts'
 import { systemEmailOwnerId } from '#worker/email/system-email.ts'
 import { runD1WithRetry } from '#worker/d1-retry.ts'
@@ -70,6 +71,11 @@ const terminalWorkflowStatusList = terminalWorkflowStatusValues
  * Inventory of D1 growth-table retention policies. Keep this manifest in sync
  * with the scheduled prune implementation and data-storage.md so future growth
  * tables have an explicit retention story or a documented exemption.
+ *
+ * Explicit policy / alternate_cleanup / durable_forever dispositions also live
+ * in `account-retention-dispositions.ts` and must cover the same table set
+ * (`account-retention-dispositions.node.test.ts`). The schema-growth heuristic
+ * in `retention.node.test.ts` remains a second net for discovering new tables.
  */
 export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
 	{
@@ -184,18 +190,21 @@ export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
 ] as const
 
 export const retentionPolicyExemptions: ReadonlyArray<RetentionPolicyExemption> =
-	[
-		{
-			table: 'archived_job_artifacts',
-			reason:
-				'Archived job artifact rows are bounded by retain_until and cleaned by the job artifact cleanup path.',
-		},
-		{
-			table: 'mcp_memories',
-			reason:
-				'Memories are durable user-curated content removed by explicit user action or account deletion, not by time-based retention.',
-		},
-	] as const
+	accountRetentionDispositions
+		.filter(
+			(
+				disposition,
+			): disposition is Extract<
+				(typeof accountRetentionDispositions)[number],
+				{ kind: 'alternate_cleanup' | 'durable_forever' }
+			> =>
+				disposition.kind === 'alternate_cleanup' ||
+				disposition.kind === 'durable_forever',
+		)
+		.map((disposition) => ({
+			table: disposition.table,
+			reason: disposition.reason,
+		}))
 
 export type RetentionPruneResult = {
 	runtimeRuns: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Behavior-preserving Track B registry work: one D1 registry drives shared kind→SQL match builders and export redaction; companion registries declare out-of-band surfaces (DO/KV/R2/Vectorize/Artifacts) and growth-table retention dispositions. Account deletion and export consume the shared builders; Vectorize id enumeration and export DO exclusions come from the surface registry; retention exemptions derive from dispositions.

**What did not change:** delete/export/retain semantics — existing account-deletion, account-export, and retention tests plus new SQL/coverage pins are the proof.

**Guardrails added:**
- Shared match SQL pinned per target kind
- Out-of-band surface coverage + deletion/export consumption checks
- Retention dispositions ↔ `retentionPolicies` / exemptions sync (heuristic test kept)

**Risk:** MEDIUM — registry extraction with provably identical outputs; no intentional change to what is deleted, exported, or retained.

**Track B** PR 2 (follows #868 DO identity helpers).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** extends — account export/deletion/retention now share registry-driven builders and dispositions; runtime delete/export/retain outputs are intended to be identical.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `account-export` | assistant | extends — consumes shared D1 match builders, redaction maps, DO exclusion registry |
| `app-ui` | surfaces | extends — account-deletion + new lifecycle registries/guardrails |
| `scheduled-cron` | surfaces | extends — retention exemptions derived from disposition registry |

### System map

Deletion and export now read one D1/out-of-band registry family; retention exemptions link to dispositions.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	d1Targets["app-ui<br/>account-data-targets"]:::extended
	oobSurfaces["app-ui<br/>account-user-owned-surfaces"]:::extended
	retentionDisp["app-ui<br/>account-retention-dispositions"]:::extended
	accountExport["account-export<br/>Account data export"]:::extended
	accountDeletion["app-ui<br/>Account deletion"]:::extended
	retentionCron["scheduled-cron<br/>Scheduled retention"]:::extended
	d1Targets -->|"shared kind→SQL match + redaction"| accountExport
	d1Targets -->|"shared delete/update SQL"| accountDeletion
	oobSurfaces -->|"excluded DO list"| accountExport
	oobSurfaces -->|"DO result keys + Vectorize tables"| accountDeletion
	retentionDisp -->|"exemption reasons"| retentionCron
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Per-user isolation unchanged: all paths still scoped by authenticated `userId`.
- No intentional change to which rows/blobs/vectors are deleted, exported, or retained.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dccd364-43eb-4951-92b7-a833b9d80130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dccd364-43eb-4951-92b7-a833b9d80130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

