### PR TITLE
Import loader-data types in client routes

### DIFF
--- a/docs/contributing/oxlint-js-plugins.md
+++ b/docs/contributing/oxlint-js-plugins.md
@@ -42,6 +42,10 @@ The example rule reports when it finds the identifier
 `__oxlint_plugin_example__`. This keeps the demo deterministic and avoids
 accidentally linting normal production code.
 
+Another live example is `kody-custom/prefer-loader-data-types`, which scopes
+itself to `packages/worker/client/routes/**` and reports route-local TypeScript
+payload declarations that should instead be imported from `#app/loader-data.ts`.
+
 ## Verify manually
 
 Create a temporary file containing the sentinel identifier and run:

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -1,4 +1,8 @@
 import { formatTimestamp } from '#client/format-timestamp.ts'
+import {
+	type AccountIntegrationListItem,
+	type AccountIntegrationsLoaderData,
+} from '#app/loader-data.ts'
 import { type Handle, css } from 'remix/ui'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
@@ -42,38 +46,6 @@ import {
 	sectionTitleCss,
 } from '#client/styles/style-primitives.ts'
 
-type IntegrationFlow = 'pkce' | 'confidential'
-
-type IntegrationAuthorization = {
-	authorizeUrl: string
-	scopes: Array<string>
-	scopeSeparator?: string | null
-	extraAuthorizeParams?: Record<string, string>
-}
-
-type AccountIntegrationListItem = {
-	name: string
-	valueName: string
-	tokenUrl: string
-	apiBaseUrl?: string | null
-	flow: IntegrationFlow
-	clientIdValueName: string
-	clientSecretSecretName?: string | null
-	accessTokenSecretName: string
-	refreshTokenSecretName?: string | null
-	requiredHosts?: Array<string>
-	authorization?: IntegrationAuthorization | null
-	createdAt: string
-	updatedAt: string
-}
-
-type AccountIntegrationsPayload = {
-	ok: true
-	email: string
-	username: string
-	integrations: Array<AccountIntegrationListItem>
-}
-
 const accountIntegrationsApiPath = '/account/integrations.json'
 const accountIntegrationsPath = '/account/integrations'
 
@@ -99,7 +71,7 @@ export async function accountIntegrationsRouteLoader(
 	if (response.status === 401) {
 		return routeLoaderRedirect('/login')
 	}
-	const payload = await readJson<AccountIntegrationsPayload>(response)
+	const payload = await readJson<AccountIntegrationsLoaderData>(response)
 	if (!response.ok || !payload?.ok) {
 		throw new Error('Unable to load integrations.')
 	}
@@ -173,7 +145,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 				window.location.assign('/login')
 				return
 			}
-			const payload = await readJson<AccountIntegrationsPayload>(response)
+			const payload = await readJson<AccountIntegrationsLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load integrations.')
 			}

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -1,6 +1,10 @@
 import { formatNullableTimestamp } from '#client/format-timestamp.ts'
 import { readCommaListParams, readTrimmedParam } from '#client/url-params.ts'
 import { bytesToBase64Url } from '@kody-internal/shared/base64.ts'
+import {
+	type AccountPackageInvocationTokenListItem,
+	type AccountPackageInvocationTokensLoaderData,
+} from '#app/loader-data.ts'
 import { type Handle, css } from 'remix/ui'
 import { createHref } from 'remix/route-pattern/href'
 import { on } from '#client/event-mixin.ts'
@@ -48,34 +52,8 @@ import {
 	MetadataGrid,
 } from './account-management-components.tsx'
 
-type PackageOption = {
-	id: string
-	kodyId: string
-	name: string
-}
-
-type PackageInvocationTokenListItem = {
-	id: string
-	name: string
-	packageIds: Array<string>
-	packageKodyIds: Array<string>
-	exportNames: Array<string>
-	sources: Array<string>
-	createdAt: string
-	updatedAt: string
-	lastUsedAt: string | null
-	revokedAt: string | null
-}
-
-type AccountPackageInvocationTokensPayload = {
-	ok: true
-	email: string
-	username: string
-	invocationUrlOrigin: string
-	packages: Array<PackageOption>
-	tokens: Array<PackageInvocationTokenListItem>
-	selectedTokenId?: string
-}
+type PackageOption =
+	AccountPackageInvocationTokensLoaderData['packages'][number]
 
 type EditorState = {
 	name: string
@@ -187,7 +165,7 @@ export async function accountPackageInvocationTokensRouteLoader(
 		return routeLoaderRedirect('/login')
 	}
 	const payload =
-		await readJson<AccountPackageInvocationTokensPayload>(response)
+		await readJson<AccountPackageInvocationTokensLoaderData>(response)
 	if (!response.ok || !payload?.ok) {
 		throw new Error('Unable to load package invocation tokens.')
 	}
@@ -284,11 +262,11 @@ function formatScope(values: Array<string>) {
 	return values.join(', ')
 }
 
-function tokenStatus(token: PackageInvocationTokenListItem) {
+function tokenStatus(token: AccountPackageInvocationTokenListItem) {
 	return token.revokedAt ? 'Revoked' : 'Active'
 }
 
-function tokenStatusCss(token: PackageInvocationTokenListItem) {
+function tokenStatusCss(token: AccountPackageInvocationTokenListItem) {
 	return {
 		display: 'inline-flex',
 		alignItems: 'center',
@@ -305,7 +283,7 @@ function tokenStatusCss(token: PackageInvocationTokenListItem) {
 }
 
 function createEditorStateFromToken(
-	token: PackageInvocationTokenListItem,
+	token: AccountPackageInvocationTokenListItem,
 ): EditorState {
 	return {
 		name: token.name,
@@ -329,7 +307,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	let username = ''
 	let invocationUrlOrigin = ''
 	let packages: Array<PackageOption> = []
-	let tokens: Array<PackageInvocationTokenListItem> = []
+	let tokens: Array<AccountPackageInvocationTokenListItem> = []
 	let editorState = createEmptyEditorState()
 	let selectedTokenId: string | null = null
 	let message: string | null = null
@@ -385,7 +363,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				return
 			}
 			const payload =
-				await readJson<AccountPackageInvocationTokensPayload>(response)
+				await readJson<AccountPackageInvocationTokensLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load package invocation tokens.')
 			}
@@ -413,7 +391,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	}
 
 	function applyPayload(
-		payload: AccountPackageInvocationTokensPayload,
+		payload: AccountPackageInvocationTokensLoaderData,
 		href: string,
 	) {
 		username = payload.username
@@ -527,7 +505,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function startEditToken(token: PackageInvocationTokenListItem) {
+	function startEditToken(token: AccountPackageInvocationTokenListItem) {
 		if (token.revokedAt) return
 		editorState = createEditorStateFromToken(token)
 		selectedTokenId = token.id
@@ -618,7 +596,10 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AccountPackageInvocationTokensPayload & { error?: string; ok?: boolean }
+				AccountPackageInvocationTokensLoaderData & {
+					error?: string
+					ok?: boolean
+				}
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to create token.')
@@ -701,7 +682,10 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AccountPackageInvocationTokensPayload & { error?: string; ok?: boolean }
+				AccountPackageInvocationTokensLoaderData & {
+					error?: string
+					ok?: boolean
+				}
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to update token.')
@@ -749,7 +733,10 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AccountPackageInvocationTokensPayload & { error?: string; ok?: boolean }
+				AccountPackageInvocationTokensLoaderData & {
+					error?: string
+					ok?: boolean
+				}
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to revoke token.')
@@ -798,7 +785,10 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AccountPackageInvocationTokensPayload & { error?: string; ok?: boolean }
+				AccountPackageInvocationTokensLoaderData & {
+					error?: string
+					ok?: boolean
+				}
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to reinstate token.')
@@ -844,7 +834,10 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 				return
 			}
 			const payload = await readJson<
-				AccountPackageInvocationTokensPayload & { error?: string; ok?: boolean }
+				AccountPackageInvocationTokensLoaderData & {
+					error?: string
+					ok?: boolean
+				}
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to delete token.')
@@ -868,7 +861,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		}
 	}
 
-	function selectToken(token: PackageInvocationTokenListItem) {
+	function selectToken(token: AccountPackageInvocationTokenListItem) {
 		selectedTokenId = token.id
 		editorState = token.revokedAt
 			? createEmptyEditorState()

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1,5 +1,10 @@
 import { formatTimestamp } from '#client/format-timestamp.ts'
 import { readCommaListParams, readTrimmedParam } from '#client/url-params.ts'
+import {
+	type AccountSecretDetail,
+	type AccountSecretListItem,
+	type AccountSecretsLoaderData,
+} from '#app/loader-data.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
@@ -61,47 +66,9 @@ import {
 	MetadataGrid,
 } from './account-management-components.tsx'
 
-type SecretScope = 'package' | 'user'
+type SecretScope = AccountSecretListItem['scope']
 
-type PackageOption = {
-	id: string
-	title: string
-	updatedAt: string
-}
-
-type SecretListItem = {
-	id: string
-	name: string
-	scope: SecretScope
-	description: string
-	packageId: string | null
-	packageTitle: string | null
-	allowedHosts: Array<string>
-	allowedCapabilities: Array<string>
-	allowedPackages: Array<string>
-	createdAt: string
-	updatedAt: string
-	ttlMs: number | null
-}
-
-type SecretDetail = SecretListItem & {
-	value: string
-}
-
-type AccountSecretsPayload = {
-	ok: true
-	email: string
-	packageOptions: Array<PackageOption>
-	packages: Array<{
-		id: string
-		kodyId: string
-		name: string
-	}>
-	secrets: Array<SecretListItem>
-	selectedSecret: SecretDetail | null
-	approval: ApprovalView | null
-	approvalError: string | null
-}
+type PackageOption = AccountSecretsLoaderData['packageOptions'][number]
 
 type EditorState = {
 	currentId: string | null
@@ -249,7 +216,7 @@ function collectRepeatedTextRows(
 	return out
 }
 
-function createEditorStateFromSecret(secret: SecretDetail): EditorState {
+function createEditorStateFromSecret(secret: AccountSecretDetail): EditorState {
 	const allowedHosts = coerceStringRows(secret.allowedHosts)
 	const allowedCapabilities = coerceStringRows(secret.allowedCapabilities)
 	const allowedPackages = coerceStringRows(secret.allowedPackages)
@@ -322,7 +289,7 @@ function normalizeSingleAllowedCapability(capability: string | null) {
 
 function getAlreadyAddedNotice(input: {
 	href: string
-	selectedSecret: SecretDetail | null
+	selectedSecret: AccountSecretDetail | null
 	approval: ApprovalView | null
 	formatPackageId: (packageId: string) => string
 }) {
@@ -467,7 +434,7 @@ export async function accountSecretsRouteLoader(
 	if (response.status === 401) {
 		return routeLoaderRedirect('/login')
 	}
-	const payload = await readJson<AccountSecretsPayload>(response)
+	const payload = await readJson<AccountSecretsLoaderData>(response)
 	if (!response.ok || !payload?.ok) {
 		throw new Error('Unable to load your secrets.')
 	}
@@ -500,7 +467,7 @@ function readFilterState(
 }
 
 function filterSecrets(
-	secrets: Array<SecretListItem>,
+	secrets: Array<AccountSecretListItem>,
 	filters: SecretFilterState,
 	packagesById: ReadonlyMap<string, { kodyId: string; name: string }>,
 ) {
@@ -540,8 +507,8 @@ export function AccountSecretsRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let packageOptions: Array<PackageOption> = []
 	let packagesById = new Map<string, { kodyId: string; name: string }>()
-	let secrets: Array<SecretListItem> = []
-	let selectedSecret: SecretDetail | null = null
+	let secrets: Array<AccountSecretListItem> = []
+	let selectedSecret: AccountSecretDetail | null = null
 	let approval: ApprovalView | null = null
 	let editorState = createEmptyEditorState([])
 	let message: string | null = null
@@ -604,7 +571,7 @@ export function AccountSecretsRoute(handle: Handle) {
 	}
 
 	function applyPayload(
-		payload: AccountSecretsPayload,
+		payload: AccountSecretsLoaderData,
 		selection: SelectionState,
 		nextMessage: string | null,
 	) {
@@ -673,7 +640,7 @@ export function AccountSecretsRoute(handle: Handle) {
 				return
 			}
 
-			const payload = await readJson<AccountSecretsPayload>(response)
+			const payload = await readJson<AccountSecretsLoaderData>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error('Unable to load your secrets.')
 			}
@@ -732,7 +699,7 @@ export function AccountSecretsRoute(handle: Handle) {
 				requestUrl.searchParams.set('selected', selection.selectedSecretId)
 			}
 			const payload = await submitApprovalRequest<
-				AccountSecretsPayload & { error?: string; ok?: boolean }
+				AccountSecretsLoaderData & { error?: string; ok?: boolean }
 			>(action, `${requestUrl.pathname}${requestUrl.search}`)
 			if (!payload) return
 
@@ -851,7 +818,7 @@ export function AccountSecretsRoute(handle: Handle) {
 			}
 
 			const payload = await readJson<
-				AccountSecretsPayload & { error?: string; ok?: boolean }
+				AccountSecretsLoaderData & { error?: string; ok?: boolean }
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to save secret.')
@@ -911,7 +878,7 @@ export function AccountSecretsRoute(handle: Handle) {
 			}
 
 			const payload = await readJson<
-				AccountSecretsPayload & { error?: string; ok?: boolean }
+				AccountSecretsLoaderData & { error?: string; ok?: boolean }
 			>(response)
 			if (!response.ok || !payload?.ok) {
 				throw new Error(payload?.error || 'Unable to delete secret.')

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -6,6 +6,10 @@ import {
 	normalizeProviderKey,
 	safeParseHost,
 } from '@kody-internal/shared/url-hosts.ts'
+import {
+	type AccountIntegrationListItem,
+	type AccountSecretsLoaderData,
+} from '#app/loader-data.ts'
 import { type Handle, css } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
@@ -87,26 +91,30 @@ type ConnectOauthConfig = {
 	allowedHosts: Array<string>
 }
 
-type StoredIntegrationConfig = {
-	name: string
-	tokenUrl: string
+type StoredIntegrationAuthorization = NonNullable<
+	NonNullable<AccountIntegrationListItem['authorization']>
+>
+
+// Persisted integration values share the core account-integration payload shape
+// but omit account-only metadata and normalize nullable fields after parsing.
+type StoredIntegrationConfig = Omit<
+	AccountIntegrationListItem,
+	| 'apiBaseUrl'
+	| 'authorization'
+	| 'clientSecretSecretName'
+	| 'createdAt'
+	| 'refreshTokenSecretName'
+	| 'requiredHosts'
+	| 'updatedAt'
+	| 'valueName'
+> & {
 	apiBaseUrl: string | null
-	flow: OAuthFlow
-	usePkce?: boolean | null
-	clientIdValueName: string
 	clientSecretSecretName: string | null
-	accessTokenSecretName: string
 	refreshTokenSecretName: string | null
 	requiredHosts: Array<string>
-	tokenExchangeStyle?: TokenExchangeStyle | null
-	authorization?: StoredIntegrationAuthorization | null
-}
-
-type StoredIntegrationAuthorization = {
-	authorizeUrl: string
-	scopes: Array<string>
-	scopeSeparator: string | null
-	extraAuthorizeParams: Record<string, string>
+	usePkce: boolean | null
+	tokenExchangeStyle: TokenExchangeStyle | null
+	authorization: StoredIntegrationAuthorization | null
 }
 
 type OAuthExchangeResult =
@@ -143,11 +151,6 @@ type ConnectOauthNextSteps = {
 		label: string
 		prompt: string
 	}
-}
-
-type AccountSecretsListPayload = {
-	ok: true
-	secrets: Array<{ name: string; scope: string }>
 }
 
 type OAuthCallback =
@@ -447,9 +450,10 @@ export function ConnectOauthRoute(handle: Handle) {
 			credentials: 'include',
 		})
 		if (redirectToLoginOn401(response)) return null
-		const payload = (await response
-			.json()
-			.catch(() => null)) as AccountSecretsListPayload | null
+		const payload = (await response.json().catch(() => null)) as Pick<
+			AccountSecretsLoaderData,
+			'ok' | 'secrets'
+		> | null
 		if (
 			!response.ok ||
 			payload?.ok !== true ||
@@ -1436,7 +1440,7 @@ export function parseStoredIntegrationConfig(
 			accessTokenSecretName,
 			refreshTokenSecretName,
 			requiredHosts: normalizeHosts(requiredHosts),
-			...(tokenExchangeStyle ? { tokenExchangeStyle } : {}),
+			tokenExchangeStyle,
 			authorization,
 		}
 	} catch {

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -113,7 +113,8 @@ type StoredIntegrationConfig = Omit<
 	refreshTokenSecretName: string | null
 	requiredHosts: Array<string>
 	usePkce: boolean | null
-	tokenExchangeStyle: TokenExchangeStyle | null
+	/** Omitted when unset so persisted JSON stays sparse (matches pre-import shape). */
+	tokenExchangeStyle?: TokenExchangeStyle | null
 	authorization: StoredIntegrationAuthorization | null
 }
 
@@ -1440,7 +1441,7 @@ export function parseStoredIntegrationConfig(
 			accessTokenSecretName,
 			refreshTokenSecretName,
 			requiredHosts: normalizeHosts(requiredHosts),
-			tokenExchangeStyle,
+			...(tokenExchangeStyle ? { tokenExchangeStyle } : {}),
 			authorization,
 		}
 	} catch {

--- a/tools/oxlint/local-plugin.js
+++ b/tools/oxlint/local-plugin.js
@@ -1,4 +1,15 @@
 const EXAMPLE_IDENTIFIER = '__oxlint_plugin_example__'
+const CLIENT_ROUTE_FILE_PATTERN =
+	/(^|\/)packages\/worker\/client\/routes\/.+\.(ts|tsx)$/
+const SHARED_LOADER_DATA_TYPE_NAMES = new Set([
+	'AccountSecretListItem',
+	'AccountSecretDetail',
+	'AccountSecretsLoaderData',
+	'AccountPackageInvocationTokenListItem',
+	'AccountPackageInvocationTokensLoaderData',
+	'AccountIntegrationsLoaderData',
+	'AccountIntegrationListItem',
+])
 
 const noExampleIdentifierRule = {
 	meta: {
@@ -32,6 +43,27 @@ function isLiteralFrameSrc(value) {
 		return true
 	}
 	return expression.type === 'TemplateLiteral'
+}
+
+function normalizeFilePath(filename) {
+	return typeof filename === 'string' ? filename.replaceAll('\\', '/') : ''
+}
+
+function isClientRouteFile(filename) {
+	return CLIENT_ROUTE_FILE_PATTERN.test(normalizeFilePath(filename))
+}
+
+function shouldImportSharedLoaderDataType(typeName) {
+	if (!typeName) return false
+	return (
+		typeName.endsWith('LoaderData') ||
+		SHARED_LOADER_DATA_TYPE_NAMES.has(typeName)
+	)
+}
+
+function getDeclaredTypeName(node) {
+	if (!node?.id || node.id.type !== 'Identifier') return null
+	return node.id.name
 }
 
 const noLiteralFrameSrcRule = {
@@ -70,11 +102,49 @@ const noLiteralFrameSrcRule = {
 	},
 }
 
+const preferLoaderDataTypesRule = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Require client routes to import shared loader-data payload types instead of redeclaring them locally.',
+		},
+		schema: [],
+		messages: {
+			importFromLoaderData:
+				'Import shared payload types from #app/loader-data.ts instead of redeclaring this type in a client route.',
+		},
+	},
+	createOnce(context) {
+		let shouldCheckCurrentFile = false
+
+		function reportIfNeeded(node) {
+			if (!shouldCheckCurrentFile) return
+			const typeName = getDeclaredTypeName(node)
+			if (!shouldImportSharedLoaderDataType(typeName)) return
+			context.report({ node, messageId: 'importFromLoaderData' })
+		}
+
+		return {
+			Program() {
+				shouldCheckCurrentFile = isClientRouteFile(context.filename)
+			},
+			TSTypeAliasDeclaration(node) {
+				reportIfNeeded(node)
+			},
+			TSInterfaceDeclaration(node) {
+				reportIfNeeded(node)
+			},
+		}
+	},
+}
+
 const plugin = {
 	meta: { name: 'kody-custom' },
 	rules: {
 		'no-example-identifier': noExampleIdentifierRule,
 		'no-literal-frame-src': noLiteralFrameSrcRule,
+		'prefer-loader-data-types': preferLoaderDataTypesRule,
 	},
 }
 

--- a/tools/oxlint/oxlint-rules.json
+++ b/tools/oxlint/oxlint-rules.json
@@ -2,6 +2,7 @@
 	"jsPlugins": ["./local-plugin.js"],
 	"rules": {
 		"kody-custom/no-example-identifier": "error",
-		"kody-custom/no-literal-frame-src": "error"
+		"kody-custom/no-literal-frame-src": "error",
+		"kody-custom/prefer-loader-data-types": "error"
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Track A (web routing consolidation), PR 3 of 4: shared loader payload types + lint enforcement.

- `account-secrets.tsx`, `account-package-invocation-tokens.tsx`, and `account-integrations.tsx` import payload types from `#app/loader-data.ts` instead of local duplicates.
- `connect-oauth.tsx` reuses `AccountIntegrationListItem` / `AccountSecretsLoaderData` where shapes overlap; OAuth-flow-local types stay local (no shared `ConnectOauth*LoaderData` exists).
- Add `kody-custom/prefer-loader-data-types` in `tools/oxlint/local-plugin.js` (enabled in `oxlint-rules.json`) to block route-local redeclarations of shared payload type names / `*LoaderData`.

**Risk:** LOW — type-only + lint rule; no runtime behavior change.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` on touched routes/plugin
- [x] temp file confirmed rule fires, then deleted
- [ ] CI `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `9552694d` · **Head:** `032451c2`

**Classification:** composes — client routes consume existing loader-data type exports; lint prevents drift.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — client routes import shared `#app/loader-data` types |

### System map

Client account routes now type their JSON payloads from the shared loader-data module, with oxlint blocking local duplicates.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appUi -->|"import Account*LoaderData types"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Route | Before | After |
| --- | --- | --- |
| account-secrets | local `AccountSecretsPayload` / list item types | `AccountSecretsLoaderData` et al. |
| account-package-invocation-tokens | local payload/list types | shared loader-data types |
| connect-oauth | fully local type island | shared integration/secrets picks + local flow types |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b68d36b5-1723-43e1-adac-a76894708e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b68d36b5-1723-43e1-adac-a76894708e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

