### PR TITLE
Extract shared assertNotCommunityBanned helper

### DIFF
--- a/packages/worker/src/community/assert-not-community-banned.ts
+++ b/packages/worker/src/community/assert-not-community-banned.ts
@@ -1,0 +1,9 @@
+import { CommunityActionError } from './errors.ts'
+import { getCommunityBan } from './repo.ts'
+
+export async function assertNotCommunityBanned(db: D1Database, userId: string) {
+	const ban = await getCommunityBan(db, userId)
+	if (ban) {
+		throw new CommunityActionError('banned from community participation')
+	}
+}

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -20,12 +20,12 @@ import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { assertPackageNotPrivateForCommunityPublish } from '#worker/package-registry/package-private.ts'
 import { assertKodyDescriptionLength } from '#worker/package-registry/types.ts'
 import { enqueueCommunityActivityDispatch } from './activity-dispatch-queue-producer.ts'
+import { assertNotCommunityBanned } from './assert-not-community-banned.ts'
 import { CommunityActionError } from './errors.ts'
 import {
 	countCommunityForksByListingIds,
 	deleteCommunityListing,
 	deleteCommunityRatingsByListingId,
-	getCommunityBan,
 	getCommunityActivityByIdForAdmin,
 	getCommunityForkByForkedPackageId,
 	getCommunityForkByListingAndUser,
@@ -254,13 +254,6 @@ async function cleanupFailedCommunityFork(input: {
 			}),
 		)
 	})
-}
-
-async function assertNotCommunityBanned(db: D1Database, userId: string) {
-	const ban = await getCommunityBan(db, userId)
-	if (ban) {
-		throw new CommunityActionError('banned from community participation')
-	}
 }
 
 function parseRawPackageLicense(packageJsonContent: string) {

--- a/packages/worker/src/community/social-service.ts
+++ b/packages/worker/src/community/social-service.ts
@@ -1,7 +1,8 @@
 import { invalidateCommunityPublicCache } from '#app/data-cache.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
+import { assertNotCommunityBanned } from './assert-not-community-banned.ts'
 import { CommunityActionError } from './errors.ts'
-import { getCommunityBan, getCommunityListingById } from './repo.ts'
+import { getCommunityListingById } from './repo.ts'
 import { attachListingAggregatesBatch } from './service.ts'
 import {
 	countActiveListingsForOwner,
@@ -176,13 +177,6 @@ export async function updateCommunityProfile(input: {
 		numericUserId: input.numericUserId,
 		...patch,
 	})
-}
-
-async function assertNotCommunityBanned(db: D1Database, userId: string) {
-	const ban = await getCommunityBan(db, userId)
-	if (ban) {
-		throw new CommunityActionError('banned from community participation')
-	}
 }
 
 export async function followCommunityUser(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Track D (domain service splitting) — community domain.

Deduplicates the identical `assertNotCommunityBanned` helper that was copy-pasted in `community/service.ts` and `community/social-service.ts` into a single shared module.

- Added `packages/worker/src/community/assert-not-community-banned.ts`
- Both services import the shared helper
- Behavior unchanged (same ban lookup + `CommunityActionError`)

**Risk:** LOW — pure extraction / dedup. Intended to ship autonomously once CI is green.

**Out of scope:** secrets/values bucket-store helper (optional; not cheap — different tables/entry shapes). Track A/B/C/E files untouched.

## Test plan

- [x] `rg` finds exactly one `assertNotCommunityBanned` definition
- [ ] CI `validate` green
- [ ] coderabbitai feedback addressed if valid

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `27004fcd` · **Head:** `4a35e726`

**Classification:** composes — no primitives added or changed; this PR extracts a duplicated guard into a shared helper used by existing community services.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | composes — shared ban guard extraction |
| `community-social` | assistant | composes — imports shared ban guard |

### System map

Community write paths still check the ban row in D1 before mutating listings or social graph state; only the helper definition is shared.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	communityListings["community-listings<br/>Community package listings"]:::touched
	communitySocial["community-social<br/>Community profiles and social graph"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	communityListings -->|"assertNotCommunityBanned via getCommunityBan"| d1AppDb
	communitySocial -->|"assertNotCommunityBanned via getCommunityBan"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user isolation unchanged: ban lookup remains scoped by `userId`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da51084e-2b68-423a-ad89-7259bad126c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da51084e-2b68-423a-ad89-7259bad126c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

