### PR TITLE
Document the five-file add-a-page checklist

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -117,18 +117,24 @@ therefore cannot persist stale. Routes should still consume before deriving
 list/detail state — the follow-up render is a safety net, not the primary
 ordering contract.
 
-Route loaders are registered in `clientRouteLoaders` (`routes/index.tsx`) and
-matched with the same Remix route-pattern specificity as `clientRoutes`. Loaders
-return a `RouteLoaderRedirect` (via `routeLoaderRedirect`) to abort the SPA
-navigation with a full-document redirect (for example, `401` → login). The
-router performs the redirect, never the loader itself, so speculative loader
-runs stay side-effect free. Loader errors still commit the navigation so the
-destination route can fall back to its own fetch; the router marks the
-destination stale (`markNavigationDataStale`) so same-path refreshes — where no
-href change would otherwise trigger a refetch — still reload. Hash-only changes
-commit immediately without a loader. Back/forward (`popstate`) and same-path
-refreshes after form POST also run loaders before notifying, keeping the
-previous UI visible until data is ready.
+Route loaders are registered in `packages/worker/client/routes/index.tsx` under
+`clientRouteLoaders`, keyed by `routePattern(routes.<name>)`. The same keying
+scheme is used by `clientRoutes` and `document-head.ts`, so pathname renames
+flow from `packages/worker/src/app/routes.ts` instead of duplicated literal
+strings. OAuth authorize/callback are the exception: those shells use
+`oauthPaths.authorize` and `oauthPaths.callback` because the Cloudflare OAuth
+provider wrapper, not `routes.ts`, owns those pathnames. Loaders still match
+with the same Remix route-pattern specificity as `clientRoutes`. They return a
+`RouteLoaderRedirect` (via `routeLoaderRedirect`) to abort the SPA navigation
+with a full-document redirect (for example, `401` → login). The router performs
+the redirect, never the loader itself, so speculative loader runs stay side-
+effect free. Loader errors still commit the navigation so the destination route
+can fall back to its own fetch; the router marks the destination stale
+(`markNavigationDataStale`) so same-path refreshes — where no href change would
+otherwise trigger a refetch — still reload. Hash-only changes commit immediately
+without a loader. Back/forward (`popstate`) and same-path refreshes after form
+POST also run loaders before notifying, keeping the previous UI visible until
+data is ready.
 
 ### Intent prefetch
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -11,7 +11,7 @@ style, tests, MCP kody, and runtime architecture.
   [testing](./testing-principles.md)
 - [Package discovery routing evaluation](./package-discovery-evaluation.md)
 - [Cursor Cloud Agent notes](./cloud-agents.md)
-- [Remix skills](./remix.md), [frames](./frames.md)
+- [Remix skills and page checklist](./remix.md), [frames](./frames.md)
 - [Packages and manifests](./packages-and-manifests.md)
 - [Community packages](./community-packages.md)
 - [External package invocation API](./package-invocation-api.md)

--- a/docs/contributing/remix.md
+++ b/docs/contributing/remix.md
@@ -41,3 +41,38 @@ template:
 
 If a Node server entry point is added later, evaluate `trustProxy` only at that
 trusted reverse-proxy boundary. Do not copy it into Worker request handling.
+
+## Adding a page
+
+For a typical authenticated HTML page, start with the route contract and wire
+the narrowest owners. The core route-wiring path is five files:
+
+1. `packages/worker/src/app/routes.ts` — add the route identity. Treat
+   `routes.<name>` as the canonical source of the pathname.
+2. `packages/worker/src/app/router.ts` — map the route to its handler in
+   `router.map(...)`.
+3. `packages/worker/src/app/handlers/<page>.ts` — implement the page handler.
+   Use the helpers in `#app/page-auth.ts` (`requireAuthenticatedPageUser`,
+   `requirePageSession`, `requirePageUserWithRole`) for page auth, and use
+   `#app/request-body.ts` helpers when the page reads structured request bodies.
+4. `packages/worker/client/routes/<page>.tsx` — add the route component and,
+   when the page participates in SPA preload navigation, its route loader.
+   Import shared loader payload types from `#app/loader-data.ts`
+   (`kody-custom/prefer-loader-data-types` enforces this). Keep UI-only state
+   types local.
+5. `packages/worker/client/routes/index.tsx` — register the component in
+   `clientRoutes` and any loader in `clientRouteLoaders`, keyed by
+   `routePattern(routes.<name>)` instead of a duplicated literal pathname.
+
+That covers the server contract, page handler, client route, and client
+registries in five edits. Treat `packages/worker/src/app/document-head.ts` as
+the 5-vs-6 check: the count stays at five when the page can reuse existing head
+behavior, and it becomes six when the new pathname needs its own title,
+canonical URL, or Open Graph metadata. A brand-new standalone route commonly
+needs that sixth edit because unmatched pathnames fall back to the `Not found`
+title.
+
+OAuth authorize/callback shells are the exception to the `routes.ts` rule. Those
+pathnames are owned by the Cloudflare OAuth provider wrapper, so client
+registries and document head use `#app/oauth-paths.ts` (`oauthPaths.authorize`
+and `oauthPaths.callback`) instead of `routes.ts`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Track A (web routing consolidation), PR 4 of 4: contributing docs for the reduced add-a-page surface.

- Add an **Adding a page** checklist to `docs/contributing/remix.md` (5 core files; document-head as the optional 6th).
- Update `request-lifecycle.md` so client registries/`document-head` are described as keyed by `routePattern(routes.*)` (with `oauthPaths` for authorize/callback).
- Point the contributing index at the Remix page checklist.

**Risk:** LOW — docs only.

## Test plan

- [x] Docs review against Track A PRs #869, #871, #873
- [ ] CI `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f2f137e7` · **Head:** `24fc5eb3`

**Classification:** composes — documentation only; no runtime code changes.

### Primitives touched

_None matched by code roots (docs-only)._

### System map

Contributing docs now describe the post–Track A page-wiring path: `routes.ts` → handler with page-auth → client route + `routePattern` registries.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	docs["contributing docs"]:::touched
	docs -->|"add-a-page checklist"| docs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b68d36b5-1723-43e1-adac-a76894708e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b68d36b5-1723-43e1-adac-a76894708e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how SPA route loaders are registered, matched, redirected, and handled during errors and navigation.
  - Added a checklist for adding new pages, including route wiring, client loaders, authentication, and document head updates.
  - Documented OAuth route exceptions and their path configuration.
  - Added a Remix page checklist resource to the contributing documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->