### PR TITLE
Fix integration package suggestion ranking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "packages/worker",
         "packages/mock-servers/*"
       ],
+      "dependencies": {
+        "tldts": "^7.4.9"
+      },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.17.0",
         "@cloudflare/workers-types": "^4.20260702.1",
@@ -13071,19 +13074,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.3",
-      "dev": true,
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.3"
+        "tldts-core": "^7.4.9"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.3",
-      "dev": true,
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
       "license": "MIT"
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -109,5 +109,8 @@
     "sharp": true,
     "unrs-resolver": true,
     "workerd": true
+  },
+  "dependencies": {
+    "tldts": "^7.4.9"
   }
 }

--- a/packages/worker/src/app/connect-oauth-next-steps.node.test.ts
+++ b/packages/worker/src/app/connect-oauth-next-steps.node.test.ts
@@ -196,6 +196,7 @@ test('loadConnectOauthNextSteps searches with bounded limit and fails open', asy
 		env,
 		query: 'GitHub',
 		limit: connectOauthCommunitySearchCandidateLimit,
+		trustedFirst: true,
 	})
 	expect(nextSteps.suggestions.map((entry) => entry.listingId)).toEqual([
 		'trusted',

--- a/packages/worker/src/app/connect-oauth-next-steps.ts
+++ b/packages/worker/src/app/connect-oauth-next-steps.ts
@@ -137,6 +137,7 @@ export async function loadConnectOauthNextSteps(input: {
 				env: input.env,
 				query,
 				limit: connectOauthCommunitySearchCandidateLimit,
+				trustedFirst: true,
 			})
 		} catch (error) {
 			console.error(

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -1475,6 +1475,7 @@ test('connect oauth persists usePkce for confidential + PKCE providers like Canv
 		env: expect.anything(),
 		query: 'canva',
 		limit: 12,
+		trustedFirst: true,
 	})
 	expect(mockModule.saveValue).toHaveBeenCalledWith(
 		expect.objectContaining({

--- a/packages/worker/src/community/community-scoring.node.test.ts
+++ b/packages/worker/src/community/community-scoring.node.test.ts
@@ -237,4 +237,32 @@ test('trusted-first community search promotes a trusted relevance rank 13 before
 	expect(trustedFirst.slice(1).map((listing) => listing.id)).toEqual(
 		relevanceOnly.slice(0, 11).map((listing) => listing.id),
 	)
+
+	const trustedFalsePositive = {
+		...githubListing(),
+		id: 'trusted-false-positive',
+		kodyId: 'workflow-tools',
+		name: '@owner/workflow-tools',
+		trustedCommit: 'trusted-commit',
+		trustedAt: '2026-07-20T00:00:00.000Z',
+		trusted: true,
+	}
+	const realProviderListing = {
+		...githubListing(),
+		id: 'real-provider-listing',
+		kodyId: 'github-helpers',
+		name: '@owner/github-helpers',
+	}
+	mockListings([trustedFalsePositive, realProviderListing])
+
+	const providerFiltered = await searchCommunityListings({
+		env: createEnv(),
+		query: 'github',
+		limit: 1,
+		trustedFirst: true,
+		resultFilter: (listing) => listing.id === 'real-provider-listing',
+	})
+	expect(providerFiltered.map((listing) => listing.id)).toEqual([
+		'real-provider-listing',
+	])
 })

--- a/packages/worker/src/community/community-scoring.node.test.ts
+++ b/packages/worker/src/community/community-scoring.node.test.ts
@@ -235,6 +235,6 @@ test('trusted-first community search promotes a trusted relevance rank 13 before
 	})
 	expect(trustedFirst[0]?.id).toBe('listing-trusted-13')
 	expect(trustedFirst.slice(1).map((listing) => listing.id)).toEqual(
-		untrusted.slice(0, 11).map((listing) => listing.id),
+		relevanceOnly.slice(0, 11).map((listing) => listing.id),
 	)
 })

--- a/packages/worker/src/community/community-scoring.node.test.ts
+++ b/packages/worker/src/community/community-scoring.node.test.ts
@@ -199,3 +199,42 @@ test('community scoring and search rank listings and filter by query', async () 
 		'meal-planner',
 	])
 })
+
+test('trusted-first community search promotes a trusted relevance rank 13 before limiting', async () => {
+	const untrusted = Array.from({ length: 12 }, (_, index) => ({
+		...githubListing(),
+		id: `listing-untrusted-${String(index + 1).padStart(2, '0')}`,
+		kodyId: `github-untrusted-${index + 1}`,
+		name: `@owner/github-untrusted-${index + 1}`,
+	}))
+	const trusted = {
+		...githubListing(),
+		id: 'listing-trusted-13',
+		kodyId: 'github-trusted',
+		name: '@kody/github-trusted',
+		trustedCommit: 'trusted-commit',
+		trustedAt: '2026-07-20T00:00:00.000Z',
+		trusted: true,
+	}
+	mockListings([...untrusted, trusted])
+
+	const relevanceOnly = await searchCommunityListings({
+		env: createEnv(),
+		query: 'github',
+		limit: 12,
+	})
+	expect(relevanceOnly.map((listing) => listing.id)).not.toContain(
+		'listing-trusted-13',
+	)
+
+	const trustedFirst = await searchCommunityListings({
+		env: createEnv(),
+		query: 'github',
+		limit: 12,
+		trustedFirst: true,
+	})
+	expect(trustedFirst[0]?.id).toBe('listing-trusted-13')
+	expect(trustedFirst.slice(1).map((listing) => listing.id)).toEqual(
+		untrusted.slice(0, 11).map((listing) => listing.id),
+	)
+})

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -732,6 +732,7 @@ export async function searchCommunityListings(input: {
 	env: Env
 	query: string
 	limit: number
+	trustedFirst?: boolean
 }): Promise<Array<CommunityListingWithAggregates>> {
 	const trimmedQuery = input.query.trim()
 	let listings = await listCommunityListingCandidates(input.env.APP_DB, {
@@ -745,7 +746,15 @@ export async function searchCommunityListings(input: {
 			listings,
 		)
 		return withAggregates
-			.sort(compareCommunityListingsByBayesianAndPublishedAt)
+			.sort((left, right) => {
+				const trustOrder = input.trustedFirst
+					? Number(right.trusted) - Number(left.trusted)
+					: 0
+				return (
+					trustOrder ||
+					compareCommunityListingsByBayesianAndPublishedAt(left, right)
+				)
+			})
 			.slice(0, input.limit)
 	}
 	const matchesQuery = (listing: CommunityListingRecord) =>
@@ -792,7 +801,12 @@ export async function searchCommunityListings(input: {
 	})
 
 	return scored
-		.sort((left, right) => right.score - left.score)
+		.sort((left, right) => {
+			const trustOrder = input.trustedFirst
+				? Number(right.listing.trusted) - Number(left.listing.trusted)
+				: 0
+			return trustOrder || right.score - left.score
+		})
 		.slice(0, input.limit)
 		.map((entry) => entry.listing)
 }

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -733,6 +733,7 @@ export async function searchCommunityListings(input: {
 	query: string
 	limit: number
 	trustedFirst?: boolean
+	resultFilter?: (listing: CommunityListingWithAggregates) => boolean
 }): Promise<Array<CommunityListingWithAggregates>> {
 	const trimmedQuery = input.query.trim()
 	let listings = await listCommunityListingCandidates(input.env.APP_DB, {
@@ -745,17 +746,10 @@ export async function searchCommunityListings(input: {
 			input.env.APP_DB,
 			listings,
 		)
-		return withAggregates
-			.sort((left, right) => {
-				const trustOrder = input.trustedFirst
-					? Number(right.trusted) - Number(left.trusted)
-					: 0
-				return (
-					trustOrder ||
-					compareCommunityListingsByBayesianAndPublishedAt(left, right)
-				)
-			})
-			.slice(0, input.limit)
+		const relevanceOrdered = withAggregates.sort(
+			compareCommunityListingsByBayesianAndPublishedAt,
+		)
+		return finalizeCommunitySearchResults(relevanceOrdered, input)
 	}
 	const matchesQuery = (listing: CommunityListingRecord) =>
 		isCommunityListingSearchMatch({
@@ -800,15 +794,27 @@ export async function searchCommunityListings(input: {
 		}
 	})
 
-	return scored
-		.sort((left, right) => {
-			const trustOrder = input.trustedFirst
-				? Number(right.listing.trusted) - Number(left.listing.trusted)
-				: 0
-			return trustOrder || right.score - left.score
-		})
-		.slice(0, input.limit)
+	const relevanceOrdered = scored
+		.sort((left, right) => right.score - left.score)
 		.map((entry) => entry.listing)
+	return finalizeCommunitySearchResults(relevanceOrdered, input)
+}
+
+function finalizeCommunitySearchResults(
+	relevanceOrdered: Array<CommunityListingWithAggregates>,
+	input: {
+		limit: number
+		trustedFirst?: boolean
+		resultFilter?: (listing: CommunityListingWithAggregates) => boolean
+	},
+): Array<CommunityListingWithAggregates> {
+	const filtered = input.resultFilter
+		? relevanceOrdered.filter(input.resultFilter)
+		: relevanceOrdered
+	if (input.trustedFirst) {
+		filtered.sort((left, right) => Number(right.trusted) - Number(left.trusted))
+	}
+	return filtered.slice(0, input.limit)
 }
 
 export async function listCommunityActivityForAdmin(input: {

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
@@ -450,7 +450,7 @@ test('account-specific integration names still match the stable provider', async
 
 	for (const providerHost of [
 		'auth.eu.my-provider.co.uk',
-		'auth.my-provider.github.io',
+		'auth.apac.my-provider.com.au',
 	]) {
 		const hyphenatedProvider = resolveIntegrationProviderName({
 			...createIntegration('my-provider-business'),

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
@@ -367,4 +367,19 @@ test('account-specific integration names still match the stable provider', async
 			acmeProvider,
 		),
 	).toBe(false)
+
+	const rapidApiIntegration = {
+		...createIntegration('rapidapi-team'),
+		tokenUrl: 'https://rapidapi.com/oauth/token',
+		apiBaseUrl: 'https://api.rapidapi.com/v1',
+		requiredHosts: ['api.rapidapi.com'],
+		authorization: null,
+	}
+	expect(resolveIntegrationProviderName(rapidApiIntegration)).toBe('rapidapi')
+	expect(
+		resolveIntegrationProviderName({
+			...rapidApiIntegration,
+			name: 'rapid-team',
+		}),
+	).toBe('rapid-team')
 })

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
@@ -233,3 +233,33 @@ test('integration package suggestions stay same-provider, user-first, and capped
 	})
 	expect(failedCommunity).toEqual([])
 })
+
+test('account-specific integration names still match the stable provider', async () => {
+	for (const integrationName of [
+		'google-business',
+		'google-youtube-brand',
+		'google-team-2',
+	]) {
+		expect(
+			packageIdentityMentionsProvider(
+				{
+					kodyId: 'google-calendar',
+					name: '@kody/google-calendar',
+					tags: ['google', 'calendar'],
+				},
+				integrationName,
+			),
+		).toBe(true)
+	}
+
+	expect(
+		packageIdentityMentionsProvider(
+			{
+				kodyId: 'github',
+				name: '@kody/github',
+				tags: ['github'],
+			},
+			'google-business',
+		),
+	).toBe(false)
+})

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
@@ -3,6 +3,7 @@ import {
 	collectIntegrationPackageSuggestions,
 	maxIntegrationPackageSuggestions,
 	packageIdentityMentionsProvider,
+	resolveIntegrationProviderName,
 } from './integration-package-suggestions.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -26,6 +27,24 @@ function createPackageRow(input: {
 			name: input.name,
 			description: input.description ?? `${input.kodyId} package`,
 			tags: input.tags ?? [],
+		},
+	}
+}
+
+function createIntegration(name: string) {
+	return {
+		name,
+		tokenUrl: 'https://oauth2.googleapis.com/token',
+		apiBaseUrl: 'https://www.googleapis.com/calendar/v3',
+		flow: 'confidential' as const,
+		clientIdValueName: `${name}-client-id`,
+		clientSecretSecretName: `${name}ClientSecret`,
+		accessTokenSecretName: `${name}AccessToken`,
+		refreshTokenSecretName: `${name}RefreshToken`,
+		requiredHosts: ['www.googleapis.com'],
+		authorization: {
+			authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+			scopes: ['https://www.googleapis.com/auth/calendar'],
 		},
 	}
 }
@@ -128,7 +147,16 @@ test('integration package suggestions stay same-provider, user-first, and capped
 	const withUserPackages = await collectIntegrationPackageSuggestions({
 		env: {} as Env,
 		baseUrl: 'https://example.com',
-		providerName: 'github',
+		integration: {
+			...createIntegration('github'),
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			requiredHosts: ['api.github.com'],
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+				scopes: ['repo'],
+			},
+		},
 		packageRows: userRows,
 	})
 	expect(mockModule.searchCommunityListings).not.toHaveBeenCalled()
@@ -181,7 +209,16 @@ test('integration package suggestions stay same-provider, user-first, and capped
 	const communityOnly = await collectIntegrationPackageSuggestions({
 		env: {} as Env,
 		baseUrl: 'https://example.com',
-		providerName: 'GitHub',
+		integration: {
+			...createIntegration('GitHub'),
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			requiredHosts: ['api.github.com'],
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+				scopes: ['repo'],
+			},
+		},
 		packageRows: [
 			createPackageRow({
 				kodyId: 'notes',
@@ -195,6 +232,7 @@ test('integration package suggestions stay same-provider, user-first, and capped
 		env: {},
 		query: 'github',
 		limit: 12,
+		trustedFirst: true,
 	})
 	expect(communityOnly).toEqual([
 		expect.objectContaining({
@@ -228,7 +266,16 @@ test('integration package suggestions stay same-provider, user-first, and capped
 	const failedCommunity = await collectIntegrationPackageSuggestions({
 		env: {} as Env,
 		baseUrl: 'https://example.com',
-		providerName: 'github',
+		integration: {
+			...createIntegration('github'),
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			requiredHosts: ['api.github.com'],
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+				scopes: ['repo'],
+			},
+		},
 		packageRows: [],
 	})
 	expect(failedCommunity).toEqual([])
@@ -240,6 +287,10 @@ test('account-specific integration names still match the stable provider', async
 		'google-youtube-brand',
 		'google-team-2',
 	]) {
+		const providerName = resolveIntegrationProviderName(
+			createIntegration(integrationName),
+		)
+		expect(providerName).toBe('google')
 		expect(
 			packageIdentityMentionsProvider(
 				{
@@ -247,11 +298,14 @@ test('account-specific integration names still match the stable provider', async
 					name: '@kody/google-calendar',
 					tags: ['google', 'calendar'],
 				},
-				integrationName,
+				providerName,
 			),
 		).toBe(true)
 	}
 
+	const googleProvider = resolveIntegrationProviderName(
+		createIntegration('google-business'),
+	)
 	expect(
 		packageIdentityMentionsProvider(
 			{
@@ -259,7 +313,29 @@ test('account-specific integration names still match the stable provider', async
 				name: '@kody/github',
 				tags: ['github'],
 			},
-			'google-business',
+			googleProvider,
+		),
+	).toBe(false)
+
+	const acmeProvider = resolveIntegrationProviderName({
+		...createIntegration('acme-business'),
+		tokenUrl: 'https://auth.acme.com/oauth/token',
+		apiBaseUrl: 'https://api.acme.com/v1',
+		requiredHosts: ['api.acme.com'],
+		authorization: {
+			authorizeUrl: 'https://auth.acme.com/oauth/authorize',
+			scopes: ['read'],
+		},
+	})
+	expect(acmeProvider).toBe('acme')
+	expect(
+		packageIdentityMentionsProvider(
+			{
+				kodyId: 'google-calendar',
+				name: '@kody/google-calendar',
+				tags: ['google', 'calendar'],
+			},
+			acmeProvider,
 		),
 	).toBe(false)
 })

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
@@ -303,6 +303,35 @@ test('account-specific integration names still match the stable provider', async
 		).toBe(true)
 	}
 
+	const legacyGoogleIntegration = {
+		...createIntegration('google-business'),
+		authorization: null,
+	}
+	expect(resolveIntegrationProviderName(legacyGoogleIntegration)).toBe('google')
+	const accountSpecificSuggestions = await collectIntegrationPackageSuggestions(
+		{
+			env: {} as Env,
+			baseUrl: 'https://example.com',
+			integration: legacyGoogleIntegration,
+			packageRows: [
+				createPackageRow({
+					kodyId: 'google-calendar',
+					name: '@kody/google-calendar',
+					tags: ['google', 'calendar'],
+				}),
+				createPackageRow({
+					kodyId: 'github',
+					name: '@kody/github',
+					tags: ['github'],
+				}),
+			],
+		},
+	)
+	expect(
+		accountSpecificSuggestions.map((suggestion) => suggestion.kodyId),
+	).toEqual(['google-calendar'])
+	expect(mockModule.searchCommunityListings).not.toHaveBeenCalled()
+
 	const googleProvider = resolveIntegrationProviderName(
 		createIntegration('google-business'),
 	)

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.node.test.ts
@@ -88,6 +88,8 @@ function createCommunityListing(input: {
 	}
 }
 
+type CommunityListingFixture = ReturnType<typeof createCommunityListing>
+
 test('integration package suggestions stay same-provider, user-first, and capped', async () => {
 	expect(
 		packageIdentityMentionsProvider(
@@ -233,6 +235,7 @@ test('integration package suggestions stay same-provider, user-first, and capped
 		query: 'github',
 		limit: 12,
 		trustedFirst: true,
+		resultFilter: expect.any(Function),
 	})
 	expect(communityOnly).toEqual([
 		expect.objectContaining({
@@ -279,6 +282,68 @@ test('integration package suggestions stay same-provider, user-first, and capped
 		packageRows: [],
 	})
 	expect(failedCommunity).toEqual([])
+})
+
+test('community suggestions provider-filter before trust ordering and limiting', async () => {
+	const trustedFalsePositives = Array.from({ length: 12 }, (_, index) =>
+		createCommunityListing({
+			id: `trusted-false-positive-${index + 1}`,
+			kodyId: `workflow-${index + 1}`,
+			name: `@owner/workflow-${index + 1}`,
+			description: 'A trusted workflow whose prose mentions GitHub.',
+			tags: ['workflow'],
+			trusted: true,
+		}),
+	)
+	const realProviderListing = createCommunityListing({
+		id: 'github-rank-13',
+		kodyId: 'github-helpers',
+		name: '@owner/github-helpers',
+		tags: ['github'],
+		trusted: false,
+	})
+	const relevanceOrdered = [...trustedFalsePositives, realProviderListing]
+	mockModule.searchCommunityListings.mockImplementationOnce(
+		async (input: {
+			limit: number
+			trustedFirst?: boolean
+			resultFilter?: (listing: CommunityListingFixture) => boolean
+		}) => {
+			const providerMatches = input.resultFilter
+				? relevanceOrdered.filter(input.resultFilter)
+				: relevanceOrdered
+			const trustedFirst = input.trustedFirst
+				? [
+						...providerMatches.filter((listing) => listing.trusted),
+						...providerMatches.filter((listing) => !listing.trusted),
+					]
+				: providerMatches
+			return trustedFirst.slice(0, input.limit)
+		},
+	)
+
+	const suggestions = await collectIntegrationPackageSuggestions({
+		env: {} as Env,
+		baseUrl: 'https://example.com',
+		integration: {
+			...createIntegration('github'),
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			requiredHosts: ['api.github.com'],
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+				scopes: ['repo'],
+			},
+		},
+		packageRows: [],
+	})
+
+	expect(suggestions).toEqual([
+		expect.objectContaining({
+			listingId: 'github-rank-13',
+			kodyId: 'github-helpers',
+		}),
+	])
 })
 
 test('account-specific integration names still match the stable provider', async () => {
@@ -382,4 +447,28 @@ test('account-specific integration names still match the stable provider', async
 			name: 'rapid-team',
 		}),
 	).toBe('rapid-team')
+
+	for (const providerHost of [
+		'auth.eu.my-provider.co.uk',
+		'auth.my-provider.github.io',
+	]) {
+		const hyphenatedProvider = resolveIntegrationProviderName({
+			...createIntegration('my-provider-business'),
+			tokenUrl: `https://${providerHost}/oauth/token`,
+			apiBaseUrl: `https://${providerHost}/api`,
+			requiredHosts: [providerHost],
+			authorization: null,
+		})
+		expect(hyphenatedProvider).toBe('my-provider')
+		expect(
+			packageIdentityMentionsProvider(
+				{
+					kodyId: 'my-provider-tools',
+					name: '@owner/my-provider-tools',
+					tags: ['my-provider'],
+				},
+				hyphenatedProvider,
+			),
+		).toBe(true)
+	}
 })

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.ts
@@ -49,9 +49,12 @@ function providerMetadataHosts(
 	return [...hosts, ...(integration.requiredHosts ?? [])]
 }
 
+const providerDomainAliases: Readonly<Record<string, string>> = {
+	googleapis: 'google',
+}
+
 function normalizeProviderDomainLabel(label: string): string {
-	const withoutApiSuffix = label.replace(/apis?$/, '')
-	return withoutApiSuffix || label
+	return providerDomainAliases[label] ?? label
 }
 
 /**

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.ts
@@ -1,4 +1,5 @@
 import { buildCommunityPublicUrl } from '#mcp/capabilities/community/shared.ts'
+import { getDomain } from 'tldts'
 import {
 	canonicalIntegrationName,
 	type IntegrationConfig,
@@ -57,6 +58,13 @@ function normalizeProviderDomainLabel(label: string): string {
 	return providerDomainAliases[label] ?? label
 }
 
+function providerTokensFromHost(host: string): Array<string> {
+	const registrableDomain =
+		getDomain(host, { allowPrivateDomains: true }) ?? host.toLowerCase()
+	const providerLabel = registrableDomain.split('.')[0] ?? registrableDomain
+	return extractSearchTokens(normalizeProviderDomainLabel(providerLabel))
+}
+
 /**
  * Separate the provider identity from an account-specific integration label.
  * A prefix is accepted only when saved endpoint metadata independently
@@ -67,19 +75,22 @@ export function resolveIntegrationProviderName(
 	integration: IntegrationProviderMetadata,
 ): string {
 	const integrationName = canonicalIntegrationName(integration.name)
-	const nameTokens = integrationName.split('-').filter(Boolean)
-	const providerTokens = new Set(
-		providerMetadataHosts(integration).flatMap((host) => {
-			const labels = host.toLowerCase().split('.').filter(Boolean)
-			if (labels.length < 2) return labels
-			return [normalizeProviderDomainLabel(labels.at(-2) ?? '')]
-		}),
-	)
+	const nameSegments = integrationName.split('-').filter(Boolean)
+	const providerTokenGroups = providerMetadataHosts(integration)
+		.map(providerTokensFromHost)
+		.filter((tokens) => tokens.length > 0)
 
-	for (let length = nameTokens.length; length > 0; length--) {
-		const prefix = nameTokens.slice(0, length)
-		if (prefix.every((token) => providerTokens.has(token))) {
-			return prefix.join('-')
+	const matchesProviderTokens = (tokens: Array<string>) =>
+		providerTokenGroups.some(
+			(providerTokens) =>
+				providerTokens.length === tokens.length &&
+				providerTokens.every((token, index) => token === tokens[index]),
+		)
+
+	for (let length = nameSegments.length; length > 0; length--) {
+		const prefix = nameSegments.slice(0, length).join('-')
+		if (matchesProviderTokens(extractSearchTokens(prefix))) {
+			return prefix
 		}
 	}
 	return integrationName
@@ -165,6 +176,15 @@ async function collectSameProviderCommunitySuggestions(input: {
 			query: provider,
 			limit: communitySuggestionCandidateLimit,
 			trustedFirst: true,
+			resultFilter: (listing) =>
+				packageIdentityMentionsProvider(
+					{
+						kodyId: listing.kodyId,
+						name: listing.name,
+						tags: listing.tags,
+					},
+					provider,
+				),
 		})
 	} catch {
 		return []

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.ts
@@ -1,11 +1,19 @@
 import { buildCommunityPublicUrl } from '#mcp/capabilities/community/shared.ts'
-import { canonicalIntegrationName } from '#mcp/capabilities/integrations/integration-shared.ts'
+import {
+	canonicalIntegrationName,
+	type IntegrationConfig,
+} from '#mcp/capabilities/integrations/integration-shared.ts'
 import { searchCommunityListings } from '#worker/community/service.ts'
 import { type RelatedIntegrationPackageSuggestion } from './search-format.ts'
 import { extractSearchTokens } from './understand-search-query.ts'
 
 export const maxIntegrationPackageSuggestions = 3
 const communitySuggestionCandidateLimit = 12
+
+type IntegrationProviderMetadata = Pick<
+	IntegrationConfig,
+	'name' | 'tokenUrl' | 'apiBaseUrl' | 'requiredHosts' | 'authorization'
+>
 
 type ProviderPackageIdentity = {
 	kodyId: string
@@ -20,6 +28,53 @@ type SuggestionPackageRow = {
 		description: string
 		tags: Array<string>
 	}
+}
+
+function providerMetadataHosts(
+	integration: IntegrationProviderMetadata,
+): Array<string> {
+	const urls = [
+		integration.tokenUrl,
+		integration.apiBaseUrl,
+		integration.authorization?.authorizeUrl,
+	]
+	const hosts = urls.flatMap((url) => {
+		if (!url) return []
+		try {
+			return [new URL(url).hostname]
+		} catch {
+			return []
+		}
+	})
+	return [...hosts, ...(integration.requiredHosts ?? [])]
+}
+
+/**
+ * Separate the provider identity from an account-specific integration label.
+ * A prefix is accepted only when saved endpoint metadata independently
+ * identifies every token, so an arbitrary first segment is never assumed to be
+ * the provider. The full integration name is the safe fallback.
+ */
+export function resolveIntegrationProviderName(
+	integration: IntegrationProviderMetadata,
+): string {
+	const integrationName = canonicalIntegrationName(integration.name)
+	const nameTokens = integrationName.split('-').filter(Boolean)
+	const providerTokens = new Set(
+		providerMetadataHosts(integration).flatMap((host) => {
+			const labels = host.toLowerCase().split('.').filter(Boolean)
+			if (labels.length < 2) return labels
+			return [labels.at(-2) ?? '']
+		}),
+	)
+
+	for (let length = nameTokens.length; length > 0; length--) {
+		const prefix = nameTokens.slice(0, length)
+		if (prefix.every((token) => providerTokens.has(token))) {
+			return prefix.join('-')
+		}
+	}
+	return integrationName
 }
 
 export function packageIdentityMentionsProvider(
@@ -101,6 +156,7 @@ async function collectSameProviderCommunitySuggestions(input: {
 			env: input.env,
 			query: provider,
 			limit: communitySuggestionCandidateLimit,
+			trustedFirst: true,
 		})
 	} catch {
 		return []
@@ -135,12 +191,13 @@ async function collectSameProviderCommunitySuggestions(input: {
 export async function collectIntegrationPackageSuggestions(input: {
 	env: Env
 	baseUrl: string
-	providerName: string
+	integration: IntegrationProviderMetadata
 	packageRows: ReadonlyArray<SuggestionPackageRow>
 }): Promise<Array<RelatedIntegrationPackageSuggestion>> {
+	const providerName = resolveIntegrationProviderName(input.integration)
 	const userSuggestions = collectSameProviderUserSuggestions(
 		input.packageRows,
-		input.providerName,
+		providerName,
 	)
 	if (userSuggestions.length > 0) {
 		return userSuggestions
@@ -148,6 +205,6 @@ export async function collectIntegrationPackageSuggestions(input: {
 	return await collectSameProviderCommunitySuggestions({
 		env: input.env,
 		baseUrl: input.baseUrl,
-		providerName: input.providerName,
+		providerName,
 	})
 }

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.ts
@@ -49,6 +49,11 @@ function providerMetadataHosts(
 	return [...hosts, ...(integration.requiredHosts ?? [])]
 }
 
+function normalizeProviderDomainLabel(label: string): string {
+	const withoutApiSuffix = label.replace(/apis?$/, '')
+	return withoutApiSuffix || label
+}
+
 /**
  * Separate the provider identity from an account-specific integration label.
  * A prefix is accepted only when saved endpoint metadata independently
@@ -64,7 +69,7 @@ export function resolveIntegrationProviderName(
 		providerMetadataHosts(integration).flatMap((host) => {
 			const labels = host.toLowerCase().split('.').filter(Boolean)
 			if (labels.length < 2) return labels
-			return [labels.at(-2) ?? '']
+			return [normalizeProviderDomainLabel(labels.at(-2) ?? '')]
 		}),
 	)
 

--- a/packages/worker/src/mcp/tools/integration-package-suggestions.ts
+++ b/packages/worker/src/mcp/tools/integration-package-suggestions.ts
@@ -59,8 +59,7 @@ function normalizeProviderDomainLabel(label: string): string {
 }
 
 function providerTokensFromHost(host: string): Array<string> {
-	const registrableDomain =
-		getDomain(host, { allowPrivateDomains: true }) ?? host.toLowerCase()
+	const registrableDomain = getDomain(host) ?? host.toLowerCase()
 	const providerLabel = registrableDomain.split('.')[0] ?? registrableDomain
 	return extractSearchTokens(normalizeProviderDomainLabel(providerLabel))
 }

--- a/packages/worker/src/mcp/tools/search-detail.ts
+++ b/packages/worker/src/mcp/tools/search-detail.ts
@@ -152,7 +152,7 @@ export async function resolveEntityDetail(input: {
 			await collectIntegrationPackageSuggestions({
 				env: input.agent.getEnv(),
 				baseUrl: input.callerContext.baseUrl,
-				providerName: integration.config.name,
+				integration: integration.config,
 				packageRows: input.searchRows.packageRows,
 			})
 		return {

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -787,6 +787,7 @@ test('integration entity detail enriches related packages without bloating ranke
 		env: { APP_DB: {} },
 		query: 'github',
 		limit: 12,
+		trustedFirst: true,
 	})
 	expect(detail.structuredContent.result).toMatchObject({
 		kind: 'entity',

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -788,6 +788,7 @@ test('integration entity detail enriches related packages without bloating ranke
 		query: 'github',
 		limit: 12,
 		trustedFirst: true,
+		resultFilter: expect.any(Function),
 	})
 	expect(detail.structuredContent.result).toMatchObject({
 		kind: 'entity',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rebase onto current `main` and port integration-config suggestion resolution to the relocated `search-detail.ts` call site.
- Resolve account labels from ICANN public-suffix-aware provider domains, with consistent tokenization for hyphenated providers and an explicit legacy `googleapis` alias.
- Apply exact provider identity filtering before trusted-first ordering and truncation, preventing trusted prose-only false positives from evicting real provider packages.

## Test plan

- [x] `npm run typecheck`
- [x] Targeted tests: 5 files, 27 tests
- [x] `npm run validate`: format, lint, typecheck, 1,085 unit/worker tests, 17 Playwright tests, MCP E2E, primitives, and migrations

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0b1b70d8` · **Head:** `6ca83d3f`

**Classification:** extends — provider identity resolution and opt-in community suggestion filtering/ranking change without adding a new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — integration detail derives provider identity from registrable domains before package matching |
| `community-listings` | assistant | extends — optional result filtering now precedes trust ordering and result limits |
| `app-ui` | surfaces | composes — post-OAuth next steps retains trusted-first community ordering |

### System map

Integration detail derives a metadata-backed provider identity, then community search filters exact provider packages before trust ordering and truncation.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	communityListings["community-listings<br/>Community package listings"]:::extended
	mcpServer -->|"provider predicate before trusted-first limit"| communityListings
	appUi -->|"post-OAuth trusted-first suggestions"| communityListings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Behavior | Before | After |
| --- | --- | --- |
| `my-provider-business` metadata | Hyphenated domain label did not match split name tokens | ICANN registrable domain and name use the same tokenization |
| 12 trusted prose-only matches + real rank 13 | False positives were limited before exact provider filtering | Exact provider filter runs before trust ordering and limit |
| Integration detail wiring | Stale call shape in moved code | `search-detail.ts` passes the full integration config |

### Invariants

Per-user isolation is unchanged: saved package candidates remain scoped to the requesting user; community listings remain public data.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e58f6331-ffd5-43ae-b9bb-528e1035167c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e58f6331-ffd5-43ae-b9bb-528e1035167c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved community package suggestions by prioritizing trusted listings.
  * Added provider-aware filtering to show more relevant integration suggestions.
  * Improved provider identification across integration configurations and legacy naming formats.
  * Added support for filtering and ordering search results before applying result limits.

* **Bug Fixes**
  * Ensured integration suggestions remain correctly scoped and relevant to the selected provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->