### PR TITLE
Correct Kody Fair Source product copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you are trying to understand what this repository is for, start with
 
 ## Scope
 
-- Open-source personal assistant platform, not a general-purpose agent harness
+- Fair Source personal assistant platform, not a general-purpose agent harness
 - MCP-first architecture intended to work across compatible AI agent hosts
 - Compact MCP surface area preferred over a large static tool inventory
 - ChatGPT is a likely primary host target, while keeping the server usable from
@@ -109,10 +109,15 @@ Request → packages/worker/src/index.ts
 
 Kody is licensed under the
 [Functional Source License, Version 1.1, ALv2 Future License](./LICENSE)
-([FSL-1.1-ALv2](https://fsl.software/)). You can use, modify, and redistribute
-the software for any purpose other than offering a competing product or service.
-Each version becomes available under Apache License 2.0 on the second
-anniversary of the date that version was made available.
+([FSL-1.1-ALv2](https://fsl.software/)). You can use, copy, modify, create
+derivative works from, publicly perform, publicly display, and redistribute the
+software for any purpose other than Competing Use. Competing Use means making
+the software available to others in a commercial product or service that
+substitutes for Kody, substitutes for another product or service offered using
+Kody that existed when the version was made available, or offers the same or
+substantially similar functionality. Each version becomes available under the
+Apache License 2.0 on the second anniversary of the date that version was made
+available.
 
 Community packages published through Kody remain MIT-licensed; that requirement
 is separate from this repository's license.

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Kody is licensed under the
 derivative works from, publicly perform, publicly display, and redistribute the
 software for any purpose other than Competing Use. Competing Use means making
 the software available to others in a commercial product or service that
-substitutes for Kody, substitutes for another product or service offered using
-Kody that existed when the version was made available, or offers the same or
-substantially similar functionality. Each version becomes available under the
-Apache License 2.0 on the second anniversary of the date that version was made
-available.
+substitutes for Kody, substitutes for another product or service the licensor
+offers using Kody that existed when the version was made available, or offers
+the same or substantially similar functionality. Each version becomes available
+under the Apache License 2.0 on the second anniversary of the date that version
+was made available.
 
 Community packages published through Kody remain MIT-licensed; that requirement
 is separate from this repository's license.

--- a/docs/use/what-can-kody-do.md
+++ b/docs/use/what-can-kody-do.md
@@ -8,13 +8,14 @@ connection exists.
 
 ## What Kody is
 
-Kody is an open-source personal assistant platform. You do not chat with Kody
-directly: you connect the AI agent you already use (Claude, ChatGPT, Cursor,
-Codex, or any other MCP-capable host) to your Kody account, and that agent gains
-durable capabilities that outlive the conversation and keep running while your
-computer is off. Kody makes no inference calls of its own — your agent supplies
-the intelligence; Kody supplies memory, credentials, saved code, schedules, and
-execution.
+Kody is a Fair Source personal assistant platform: its source is available to
+inspect, and each version converts to the Apache License 2.0 after two years.
+You do not chat with Kody directly: you connect the AI agent you already use
+(Claude, ChatGPT, Cursor, Codex, or any other MCP-capable host) to your Kody
+account, and that agent gains durable capabilities that outlive the conversation
+and keep running while your computer is off. Kody makes no inference calls of
+its own — your agent supplies the intelligence; Kody supplies memory,
+credentials, saved code, schedules, and execution.
 
 ## The building blocks
 

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -59,7 +59,7 @@ const capabilityHighlights = [
 	{
 		title: 'Self-service means ownership',
 		description:
-			'Bring your own OAuth apps and API keys. Your data is exportable and Kody is open source, so your assistant stays portable.',
+			"Bring your own OAuth apps and API keys. Your data is exportable and Kody's source is available to inspect, so your assistant stays portable.",
 	},
 ] as const
 
@@ -222,17 +222,17 @@ export function HomeRoute(handle: Handle) {
 					isolated.
 				</p>
 
-				<p mix={css(openSourceLineCss)}>
+				<p mix={css(fairSourceLineCss)}>
 					Kody is{' '}
 					<a
 						href="https://github.com/kentcdodds/kody"
 						target="_blank"
 						rel="noreferrer noopener"
-						mix={css(openSourceLinkCss)}
+						mix={css(fairSourceLinkCss)}
 					>
-						open source
+						Fair Source
 					</a>
-					.
+					, so you can inspect the code.
 				</p>
 			</section>
 		)
@@ -513,13 +513,13 @@ const trustLineCss = {
 	lineHeight: 1.6,
 }
 
-const openSourceLineCss = {
+const fairSourceLineCss = {
 	margin: 0,
 	color: colors.textMuted,
 	fontSize: typography.fontSize.sm,
 	lineHeight: 1.6,
 }
 
-const openSourceLinkCss = {
+const fairSourceLinkCss = {
 	color: colors.primaryText,
 }

--- a/packages/worker/src/blog/posts/every-install-is-a-fork-you-own.md
+++ b/packages/worker/src/blog/posts/every-install-is-a-fork-you-own.md
@@ -110,7 +110,7 @@ rest of the ladder feel real. The docs on
 and
 [packages generally](https://github.com/kentcdodds/kody/blob/main/docs/use/packages.md)
 cover the details, and the whole platform is
-[open source](https://github.com/kentcdodds/kody) if you want to go deeper than
+[Fair Source](https://github.com/kentcdodds/kody) if you want to go deeper than
 that.
 
 Kody is invite-gated right now, so if you don't have an account yet,

--- a/packages/worker/src/blog/posts/gateways-connect-homes-accumulate.md
+++ b/packages/worker/src/blog/posts/gateways-connect-homes-accumulate.md
@@ -126,8 +126,8 @@ OAuth connections use your own OAuth app, created at the provider and connected
 at https://heykody.dev/connect/oauth: a few minutes of setup instead of one
 click, in exchange for your scopes, your rate limits, and no fixed provider list
 ([guide](https://github.com/kentcdodds/kody/blob/main/docs/guides/oauth.md)).
-And the whole thing is open source at https://github.com/kentcdodds/kody, so
-"trust me" never has to be the answer.
+And the whole thing is Fair Source, with code available at
+https://github.com/kentcdodds/kody, so "trust me" never has to be the answer.
 
 ## Honest trade-offs, both directions
 

--- a/packages/worker/src/blog/posts/self-service-means-ownership.md
+++ b/packages/worker/src/blog/posts/self-service-means-ownership.md
@@ -108,7 +108,7 @@ the time.
 
 Kody is invite-gated right now, so if you're not in yet,
 [join the waitlist on the signup page](https://heykody.dev/signup). The whole
-thing is [open source](https://github.com/kentcdodds/kody) if you want to verify
+thing is [Fair Source](https://github.com/kentcdodds/kody) if you want to verify
 any of this yourself, which, given the subject of this post, seems fitting.
 
 A few minutes of setup, and the door into your own data has your name on it.

--- a/packages/worker/src/blog/posts/the-assistant-that-cant-leak-your-keychain.md
+++ b/packages/worker/src/blog/posts/the-assistant-that-cant-leak-your-keychain.md
@@ -35,7 +35,7 @@ doesn't exist. When I evaluate any system that combines LLMs with credentials,
 this is the question I ask: is the safety property enforced by the architecture,
 or by the model's good behavior?
 
-Kody is open source
+Kody is Fair Source
 ([github.com/kentcdodds/kody](https://github.com/kentcdodds/kody)), so you don't
 have to take my word for any of what follows. You can read the code. Here are
 the three layers.

--- a/packages/worker/src/blog/posts/your-assistants-home.md
+++ b/packages/worker/src/blog/posts/your-assistants-home.md
@@ -101,7 +101,7 @@ can't be an afterthought. Here's how it actually works:
 - **Per-user isolation everywhere.** Every read and write path is scoped by
   userId, and your scheduler and storage run in your own Durable Objects.
 
-And the part I care about most: Kody is open source at
+And the part I care about most: Kody is Fair Source, with code available at
 https://github.com/kentcdodds/kody. You don't have to take my word for any of
 the above. Read the code.
 

--- a/packages/worker/src/blog/posts/zero-inference-calls.md
+++ b/packages/worker/src/blog/posts/zero-inference-calls.md
@@ -116,7 +116,7 @@ when I burn.
 
 ## Owning vs renting
 
-Kody is open source
+Kody is Fair Source
 ([github.com/kentcdodds/kody](https://github.com/kentcdodds/kody)) and built for
 people who'd rather own their assistant than rent one. Zero inference calls is
 what that principle looks like when it reaches the balance sheet: the thinking


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace Kody-specific open-source claims with accurate Fair Source/source-available wording across the README, usage docs, homepage, and six blog posts
- preserve statements that readers can inspect Kody's source
- expand the README license summary to mirror the FSL-1.1-ALv2 Competing Use criteria, explicitly identify criterion 2 as products or services the licensor offers, and retain the two-year Apache-2.0 conversion

## Verification
- [x] `npm run validate` on Node v26.4.0 after the licensor clarification (format, lint, typecheck, unit tests, Playwright E2E, MCP E2E, primitives, and migrations all exited 0)
- [x] repository-wide `open[ -]source` scan rerun after the clarification; only two generic third-party references remain
- [x] manual desktop homepage walkthrough confirms both revised strings render cleanly without overlap or clipping

The repository testing guidance discourages assertions that only pin instructional copy, so this change relies on the authoritative validation gate, exact scan evidence, and rendered-page verification instead of adding a brittle copy-only test.

<a href="https://cursor.com/agents/bc-3d83351b-62c1-4181-bb0c-838edb151837/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-fair-source-copy.mp4"><img src="https://cursor.com/artifacts/c/art-96aa0049-71b1-4005-b364-a6d45a37f174" alt="homepage-fair-source-copy.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `218e7684` · **Head:** `c9a4afa3`

**Classification:** composes — no primitives are added or behaviorally changed; this PR updates public copy on the existing browser and documentation surfaces.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — homepage product and license copy only |

Unmatched documentation surfaces updated: README, usage documentation, and six blog posts.

### System map

The FSL-1.1-ALv2 terms are reflected accurately in Kody's existing public homepage surface.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	licenseTerms["FSL-1.1-ALv2<br/>License terms"]:::untouched
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	licenseTerms -->|"Fair Source and inspectable-code wording"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d83351b-62c1-4181-bb0c-838edb151837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d83351b-62c1-4181-bb0c-838edb151837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product messaging to describe Kody as a **Fair Source** personal assistant platform.
  * Clarified how Kody connects with existing MCP-capable AI agents and highlighted its memory, credentials, saved code, scheduling, and execution capabilities.
  * Expanded licensing details, including permitted uses and the definition of competing use.
  * Updated website and blog content to consistently reflect Fair Source terminology and code availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->