### PR TITLE
Harden migration and Nx cache validation contracts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+packages/worker/migrations/*.sql text eol=lf

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,3 +67,9 @@ jobs:
 
       - name: ✅ Validate
         run: npm run validate
+        env:
+          # PRs trust the fetched base SHA; main pushes trust the pre-push SHA.
+          # The validator rejects this value if it resolves to HEAD.
+          MIGRATION_VALIDATION_BASE: >-
+            ${{ github.event.pull_request.base.sha || github.event.before || ''
+            }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,6 +38,7 @@ jobs:
           # Migration immutability validation compares against the PR merge
           # base and must never silently fall back to an editable ledger.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 🟢 Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          # Migration immutability validation compares against the PR merge
+          # base and must never silently fall back to an editable ledger.
+          fetch-depth: 0
 
       - name: 🟢 Setup Node
         uses: actions/setup-node@v6

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -122,12 +122,14 @@ Quick notes for getting a local kody environment running.
   hook) enforces the naming rules above against the checked-in, append-only
   `tools/migration-ledger.json`. When adding a migration, append its filename
   and SHA-256 digest to the ledger; never edit or remove an existing ledger
-  entry. The check compares historical entries and SQL contents with the trusted
-  Git merge base. CI fetches complete history; local and cloud checkouts must
-  retain or fetch `origin/main`. If trusted history is unavailable, validation
-  fails safely once migrations exist beyond the frozen bootstrap baseline.
-  Migration SQL is hashed with canonical LF line endings, and `.gitattributes`
-  enforces LF checkouts.
+  entry. The check compares historical entries and SQL contents with a
+  pre-change Git commit: CI supplies the PR base or push-before SHA, local
+  branches use their `main` merge base, and main/detached checkouts fall back to
+  the first parent. `HEAD` itself is never trusted. CI fetches complete history;
+  local and cloud checkouts must retain or fetch `origin/main`. If no pre-change
+  commit is available, validation fails safely once migrations exist beyond the
+  frozen bootstrap baseline. Migration SQL is hashed with canonical LF line
+  endings, and `.gitattributes` enforces LF checkouts.
 - Seven historical duplicate prefixes are permanently accepted only for their
   exact existing filename pairs — applied migrations cannot be renamed, and
   Wrangler orders lexicographically. Do not rename these files or add a third

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -122,8 +122,12 @@ Quick notes for getting a local kody environment running.
   hook) enforces the naming rules above against the checked-in, append-only
   `tools/migration-ledger.json`. When adding a migration, append its filename
   and SHA-256 digest to the ledger; never edit or remove an existing ledger
-  entry. Because the ledger carries a frozen baseline, this check works in
-  local, CI, shallow, and cloud checkouts without fetching a merge base.
+  entry. The check compares historical entries and SQL contents with the trusted
+  Git merge base. CI fetches complete history; local and cloud checkouts must
+  retain or fetch `origin/main`. If trusted history is unavailable, validation
+  fails safely once migrations exist beyond the frozen bootstrap baseline.
+  Migration SQL is hashed with canonical LF line endings, and `.gitattributes`
+  enforces LF checkouts.
 - Seven historical duplicate prefixes are permanently accepted only for their
   exact existing filename pairs — applied migrations cannot be renamed, and
   Wrangler orders lexicographically. Do not rename these files or add a third

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -119,19 +119,23 @@ Quick notes for getting a local kody environment running.
   freely until they land in `main`; once deployed, any schema correction should
   ship as a new migration instead.
 - `npm run migrations:check` (also run by `npm run validate` and the pre-commit
-  hook) enforces the naming rules above.
+  hook) enforces the naming rules above against the checked-in, append-only
+  `tools/migration-ledger.json`. When adding a migration, append its filename
+  and SHA-256 digest to the ledger; never edit or remove an existing ledger
+  entry. Because the ledger carries a frozen baseline, this check works in
+  local, CI, shallow, and cloud checkouts without fetching a merge base.
 - Seven historical duplicate prefixes are permanently accepted only for their
   exact existing filename pairs — applied migrations cannot be renamed, and
   Wrangler orders lexicographically. Do not rename these files or add a third
   file to any of these prefixes:
-  - `0009-ui-artifact-parameters.sql` / `0009-secret-allowed-hosts.sql`
-  - `0010-value-buckets.sql` / `0010-secret-allowed-capabilities.sql`
-  - `0018-mcp-memory-source-uris.sql` / `0018-jobs.sql`
-  - `0023-secret-allowed-packages.sql` / `0023-entity-sources.sql`
-  - `0037-package-runtime-debug.sql` / `0037-drop-chat-threads.sql`
-  - `0053-two-factor-passkeys.sql` / `0053-mcp-server-settings.sql`
-  - `0073-community-forks-forked-package-index.sql` /
-    `0073-agent-package-conversation-uses.sql`
+  - `0009-secret-allowed-hosts.sql` / `0009-ui-artifact-parameters.sql`
+  - `0010-secret-allowed-capabilities.sql` / `0010-value-buckets.sql`
+  - `0018-jobs.sql` / `0018-mcp-memory-source-uris.sql`
+  - `0023-entity-sources.sql` / `0023-secret-allowed-packages.sql`
+  - `0037-drop-chat-threads.sql` / `0037-package-runtime-debug.sql`
+  - `0053-mcp-server-settings.sql` / `0053-two-factor-passkeys.sql`
+  - `0073-agent-package-conversation-uses.sql` /
+    `0073-community-forks-forked-package-index.sql`
 
 ## Documentation maintenance
 

--- a/nx.json
+++ b/nx.json
@@ -20,7 +20,8 @@
 				"default",
 				"^default",
 				"{workspaceRoot}/vitest*.ts",
-				"{workspaceRoot}/tools/**/*"
+				"{workspaceRoot}/tools/**/*",
+				"{workspaceRoot}/packages/mock-servers/cloudflare/**/*"
 			]
 		},
 		"test-mcp": {
@@ -29,7 +30,8 @@
 				"default",
 				"^default",
 				"{workspaceRoot}/vitest*.ts",
-				"{workspaceRoot}/tools/**/*"
+				"{workspaceRoot}/tools/**/*",
+				"{workspaceRoot}/wrangler-env.ts"
 			]
 		},
 		"prepare-e2e-env": {

--- a/tools/check-migrations.node.test.ts
+++ b/tools/check-migrations.node.test.ts
@@ -7,9 +7,11 @@ import {
 	formatMigrationPrefix,
 	getMaxMigrationPrefix,
 	getNextMigrationPrefix,
+	hashMigrationContent,
 	parseMigrationFilename,
 	readMigrationLedger,
 	type MigrationLedgerEntry,
+	type TrustedMigrationHistory,
 } from './check-migrations.ts'
 
 const historicalPair0009 = [
@@ -113,8 +115,15 @@ test('migration filename helpers parse, score prefixes, and accept unique plus g
 test('migration ledger rejects historical mutation and lower-prefix additions while accepting monotonic additions', async () => {
 	const ledger = await readMigrationLedger()
 	const baselineFiles = ledger.migrations.map((entry) => ({ ...entry }))
+	const trustedHistory: TrustedMigrationHistory = {
+		ref: 'trusted-base',
+		files: baselineFiles,
+		ledgerEntries: baselineFiles,
+	}
 
-	expect(checkMigrationLedger(baselineFiles, ledger)).toMatchObject({
+	expect(
+		checkMigrationLedger(baselineFiles, ledger, trustedHistory),
+	).toMatchObject({
 		ok: true,
 		errors: [],
 		nextPrefix: '0084',
@@ -126,14 +135,18 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 			? { ...entry, sha256: '0'.repeat(64) }
 			: entry,
 	)
-	const modified = checkMigrationLedger(modifiedFiles, ledger)
+	const modified = checkMigrationLedger(modifiedFiles, ledger, trustedHistory)
 	expect(modified.ok).toBe(false)
 	expectErrorsMention(modified.errors, ['0001-init.sql', 'modified'])
 
 	const withoutHistoricalPairMember = baselineFiles.filter(
 		(entry) => entry.filename !== historicalPair0009[0],
 	)
-	const deleted = checkMigrationLedger(withoutHistoricalPairMember, ledger)
+	const deleted = checkMigrationLedger(
+		withoutHistoricalPairMember,
+		ledger,
+		trustedHistory,
+	)
 	expect(deleted.ok).toBe(false)
 	expectErrorsMention(deleted.errors, [
 		historicalPair0009[0],
@@ -146,7 +159,7 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 			? { ...entry, filename: '0009-renamed.sql' }
 			: entry,
 	)
-	const renamed = checkMigrationLedger(renamedFiles, ledger)
+	const renamed = checkMigrationLedger(renamedFiles, ledger, trustedHistory)
 	expect(renamed.ok).toBe(false)
 	expectErrorsMention(renamed.errors, [
 		historicalPair0009[1],
@@ -164,6 +177,7 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 	const lower = checkMigrationLedger(
 		[...baselineFiles, lowerAddition],
 		ledgerWithLowerAddition,
+		trustedHistory,
 	)
 	expect(lower.ok).toBe(false)
 	expectErrorsMention(lower.errors, [
@@ -181,6 +195,7 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 		checkMigrationLedger(
 			[...baselineFiles, monotonicAddition],
 			ledgerWithMonotonicAddition,
+			trustedHistory,
 		),
 	).toMatchObject({
 		ok: true,
@@ -188,6 +203,58 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 		nextPrefix: '0085',
 		maxPrefix: 84,
 	})
+})
+
+test('trusted history rejects a migration and ledger digest co-edit', async () => {
+	const ledger = await readMigrationLedger()
+	const bootstrapFiles = ledger.migrations.map((entry) => ({ ...entry }))
+	const historicalEntry = {
+		filename: '0084-historical.sql',
+		sha256: hashMigrationContent('SELECT 1;\n'),
+	}
+	const trustedHistory: TrustedMigrationHistory = {
+		ref: 'trusted-base-with-0084',
+		files: [...bootstrapFiles, historicalEntry],
+		ledgerEntries: [...bootstrapFiles, historicalEntry],
+	}
+	const editedEntry = {
+		...historicalEntry,
+		sha256: hashMigrationContent('SELECT 2;\n'),
+	}
+	const editedLedger = structuredClone(ledger)
+	editedLedger.migrations.push(editedEntry)
+
+	const result = checkMigrationLedger(
+		[...bootstrapFiles, editedEntry],
+		editedLedger,
+		trustedHistory,
+	)
+	expect(result.ok).toBe(false)
+	expectErrorsMention(result.errors, [
+		'0084-historical.sql',
+		'Historical ledger entries cannot be edited',
+		'differs from trusted history',
+		'Migration and ledger digests cannot be changed together',
+	])
+
+	const withoutTrustedBase = checkMigrationLedger(
+		[...bootstrapFiles, editedEntry],
+		editedLedger,
+	)
+	expect(withoutTrustedBase.ok).toBe(false)
+	expectErrorsMention(withoutTrustedBase.errors, [
+		'no trusted Git base is available',
+		'Fetch origin/main history',
+	])
+})
+
+test('migration content hashing canonicalizes CRLF to LF', () => {
+	expect(hashMigrationContent('CREATE TABLE example (id TEXT);\r\n')).toBe(
+		hashMigrationContent('CREATE TABLE example (id TEXT);\n'),
+	)
+	expect(hashMigrationContent('line one\r\nline two\r\n')).toBe(
+		hashMigrationContent('line one\nline two\n'),
+	)
 })
 
 test('checkMigrationFilenames rejects malformed names, ordinary duplicates, and non-allowlisted prefix reuse', () => {

--- a/tools/check-migrations.node.test.ts
+++ b/tools/check-migrations.node.test.ts
@@ -1,3 +1,8 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { expect, test } from 'vitest'
 import {
 	allowedHistoricalDuplicateMigrationFilenames,
@@ -10,6 +15,8 @@ import {
 	hashMigrationContent,
 	parseMigrationFilename,
 	readMigrationLedger,
+	resolveTrustedMigrationBase,
+	type MigrationLedger,
 	type MigrationLedgerEntry,
 	type TrustedMigrationHistory,
 } from './check-migrations.ts'
@@ -33,6 +40,12 @@ function expectErrorsMention(
 	for (const needle of needles) {
 		expect(errors.some((error) => error.includes(needle))).toBe(true)
 	}
+}
+
+function mockGit(
+	responses: Readonly<Record<string, string | null>>,
+): (args: ReadonlyArray<string>) => Promise<string | null> {
+	return async (args) => responses[args.join(' ')] ?? null
 }
 
 test('migration filename helpers parse, score prefixes, and accept unique plus grandfathered pairs', async () => {
@@ -121,6 +134,10 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 		ledgerEntries: baselineFiles,
 	}
 
+	expect(checkMigrationLedger(baselineFiles, ledger)).toMatchObject({
+		ok: true,
+		errors: [],
+	})
 	expect(
 		checkMigrationLedger(baselineFiles, ledger, trustedHistory),
 	).toMatchObject({
@@ -255,6 +272,156 @@ test('migration content hashing canonicalizes CRLF to LF', () => {
 	expect(hashMigrationContent('line one\r\nline two\r\n')).toBe(
 		hashMigrationContent('line one\nline two\n'),
 	)
+})
+
+test.each([
+	{
+		name: 'pull request base SHA',
+		env: {
+			MIGRATION_VALIDATION_BASE: 'pr-base',
+			GITHUB_BASE_REF: 'main',
+		},
+		responses: {
+			'rev-parse HEAD^{commit}': 'head',
+			'rev-parse pr-base^{commit}': 'pr-base-sha',
+		},
+		expected: 'pr-base-sha',
+	},
+	{
+		name: 'main push before SHA',
+		env: { MIGRATION_VALIDATION_BASE: 'push-before' },
+		responses: {
+			'rev-parse HEAD^{commit}': 'head',
+			'rev-parse push-before^{commit}': 'before-sha',
+		},
+		expected: 'before-sha',
+	},
+	{
+		name: 'local feature branch merge base',
+		env: {},
+		responses: {
+			'rev-parse HEAD^{commit}': 'head',
+			'merge-base HEAD origin/main': 'branch-base',
+		},
+		expected: 'branch-base',
+	},
+	{
+		name: 'main or detached checkout first parent',
+		env: {},
+		responses: {
+			'rev-parse HEAD^{commit}': 'head',
+			'merge-base HEAD origin/main': 'head',
+			'merge-base HEAD main': 'head',
+			'rev-parse HEAD^1': 'parent-sha',
+		},
+		expected: 'parent-sha',
+	},
+	{
+		name: 'depth-one detached cloud checkout',
+		env: {},
+		responses: {
+			'rev-parse HEAD^{commit}': 'head',
+			'merge-base HEAD origin/main': 'head',
+			'merge-base HEAD main': 'head',
+			'rev-parse HEAD^1': null,
+		},
+		expected: null,
+	},
+])(
+	'trusted migration base resolves $name without accepting HEAD',
+	async ({ env, responses, expected }) => {
+		await expect(
+			resolveTrustedMigrationBase({
+				env: env as NodeJS.ProcessEnv,
+				git: mockGit(responses),
+			}),
+		).resolves.toBe(expected)
+	},
+)
+
+test('runtime main validation rejects a historical migration and ledger co-edit', async () => {
+	const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'kody-migration-main-'))
+	const checkerPath = fileURLToPath(
+		new URL('./check-migrations.ts', import.meta.url),
+	)
+	const runGit = (...args: Array<string>) =>
+		execFileSync('git', args, {
+			cwd: tempRoot,
+			encoding: 'utf8',
+			stdio: 'pipe',
+		})
+
+	try {
+		await mkdir(path.join(tempRoot, 'packages', 'worker'), {
+			recursive: true,
+		})
+		await mkdir(path.join(tempRoot, 'tools'), { recursive: true })
+		await cp(
+			path.join('packages', 'worker', 'migrations'),
+			path.join(tempRoot, 'packages', 'worker', 'migrations'),
+			{ recursive: true },
+		)
+		await cp(
+			path.join('tools', 'migration-ledger.json'),
+			path.join(tempRoot, 'tools', 'migration-ledger.json'),
+		)
+		runGit('init', '-b', 'main')
+		runGit('config', 'user.name', 'Migration Test')
+		runGit('config', 'user.email', 'migration-test@example.com')
+		runGit('add', '.')
+		runGit('commit', '-m', 'bootstrap')
+
+		const migrationPath = path.join(
+			tempRoot,
+			'packages',
+			'worker',
+			'migrations',
+			'0084-future.sql',
+		)
+		const ledgerPath = path.join(tempRoot, 'tools', 'migration-ledger.json')
+		const ledger = JSON.parse(
+			await readFile(ledgerPath, 'utf8'),
+		) as MigrationLedger
+		const originalSql = 'SELECT 1;\n'
+		await writeFile(migrationPath, originalSql)
+		ledger.migrations.push({
+			filename: '0084-future.sql',
+			sha256: hashMigrationContent(originalSql),
+		})
+		await writeFile(ledgerPath, `${JSON.stringify(ledger, null, '\t')}\n`)
+		runGit('add', '.')
+		runGit('commit', '-m', 'land migration')
+
+		const editedSql = 'SELECT 2;\n'
+		await writeFile(migrationPath, editedSql)
+		const futureEntry = ledger.migrations.at(-1)
+		if (!futureEntry) {
+			throw new Error('Expected the future migration ledger entry.')
+		}
+		futureEntry.sha256 = hashMigrationContent(editedSql)
+		await writeFile(ledgerPath, `${JSON.stringify(ledger, null, '\t')}\n`)
+		runGit('add', '.')
+		runGit('commit', '-m', 'co-edit migration and ledger')
+
+		const result = spawnSync(process.execPath, [checkerPath], {
+			cwd: tempRoot,
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				GITHUB_BASE_REF: '',
+				GITHUB_REF_NAME: 'main',
+				MIGRATION_VALIDATION_BASE: '',
+			},
+		})
+		expect(result.status).toBe(1)
+		expect(result.stderr).toContain('0084-future.sql')
+		expect(result.stderr).toContain(
+			'Historical ledger entries cannot be edited',
+		)
+		expect(result.stderr).toContain('differs from trusted history')
+	} finally {
+		await rm(tempRoot, { recursive: true, force: true })
+	}
 })
 
 test('checkMigrationFilenames rejects malformed names, ordinary duplicates, and non-allowlisted prefix reuse', () => {

--- a/tools/check-migrations.node.test.ts
+++ b/tools/check-migrations.node.test.ts
@@ -2,11 +2,14 @@ import { expect, test } from 'vitest'
 import {
 	allowedHistoricalDuplicateMigrationFilenames,
 	checkMigrationFilenames,
+	checkMigrationLedger,
 	checkMigrationsDirectory,
 	formatMigrationPrefix,
 	getMaxMigrationPrefix,
 	getNextMigrationPrefix,
 	parseMigrationFilename,
+	readMigrationLedger,
+	type MigrationLedgerEntry,
 } from './check-migrations.ts'
 
 const historicalPair0009 = [
@@ -60,6 +63,9 @@ test('migration filename helpers parse, score prefixes, and accept unique plus g
 	expect(formatMigrationPrefix(76)).toBe('0076')
 	expect(formatMigrationPrefix(1)).toBe('0001')
 	expect(getNextMigrationPrefix([])).toBe('0001')
+	expect(
+		getNextMigrationPrefix([...filenamesWithGap, '9999-BadName.sql']),
+	).toBe('0076')
 
 	const withGap = checkMigrationFilenames(filenamesWithGap)
 	expect(withGap).toMatchObject({ ok: true, errors: [], nextPrefix: '0076' })
@@ -102,6 +108,86 @@ test('migration filename helpers parse, score prefixes, and accept unique plus g
 	expect(live.errors).toEqual([])
 	expect(live.nextPrefix).toBe(formatMigrationPrefix(live.maxPrefix + 1))
 	expect(live.nextPrefix).toMatch(/^\d{4}$/)
+})
+
+test('migration ledger rejects historical mutation and lower-prefix additions while accepting monotonic additions', async () => {
+	const ledger = await readMigrationLedger()
+	const baselineFiles = ledger.migrations.map((entry) => ({ ...entry }))
+
+	expect(checkMigrationLedger(baselineFiles, ledger)).toMatchObject({
+		ok: true,
+		errors: [],
+		nextPrefix: '0084',
+		maxPrefix: 83,
+	})
+
+	const modifiedFiles = baselineFiles.map((entry) =>
+		entry.filename === '0001-init.sql'
+			? { ...entry, sha256: '0'.repeat(64) }
+			: entry,
+	)
+	const modified = checkMigrationLedger(modifiedFiles, ledger)
+	expect(modified.ok).toBe(false)
+	expectErrorsMention(modified.errors, ['0001-init.sql', 'modified'])
+
+	const withoutHistoricalPairMember = baselineFiles.filter(
+		(entry) => entry.filename !== historicalPair0009[0],
+	)
+	const deleted = checkMigrationLedger(withoutHistoricalPairMember, ledger)
+	expect(deleted.ok).toBe(false)
+	expectErrorsMention(deleted.errors, [
+		historicalPair0009[0],
+		'missing',
+		'cannot be deleted or renamed',
+	])
+
+	const renamedFiles = baselineFiles.map((entry) =>
+		entry.filename === historicalPair0009[1]
+			? { ...entry, filename: '0009-renamed.sql' }
+			: entry,
+	)
+	const renamed = checkMigrationLedger(renamedFiles, ledger)
+	expect(renamed.ok).toBe(false)
+	expectErrorsMention(renamed.errors, [
+		historicalPair0009[1],
+		'missing',
+		'0009-renamed.sql',
+		'not in tools/migration-ledger.json',
+	])
+
+	const lowerAddition: MigrationLedgerEntry = {
+		filename: '0039-too-low.sql',
+		sha256: '1'.repeat(64),
+	}
+	const ledgerWithLowerAddition = structuredClone(ledger)
+	ledgerWithLowerAddition.migrations.push(lowerAddition)
+	const lower = checkMigrationLedger(
+		[...baselineFiles, lowerAddition],
+		ledgerWithLowerAddition,
+	)
+	expect(lower.ok).toBe(false)
+	expectErrorsMention(lower.errors, [
+		'0039-too-low.sql',
+		'at or below frozen baseline maximum 0083',
+	])
+
+	const monotonicAddition: MigrationLedgerEntry = {
+		filename: '0084-normal-addition.sql',
+		sha256: '2'.repeat(64),
+	}
+	const ledgerWithMonotonicAddition = structuredClone(ledger)
+	ledgerWithMonotonicAddition.migrations.push(monotonicAddition)
+	expect(
+		checkMigrationLedger(
+			[...baselineFiles, monotonicAddition],
+			ledgerWithMonotonicAddition,
+		),
+	).toMatchObject({
+		ok: true,
+		errors: [],
+		nextPrefix: '0085',
+		maxPrefix: 84,
+	})
 })
 
 test('checkMigrationFilenames rejects malformed names, ordinary duplicates, and non-allowlisted prefix reuse', () => {

--- a/tools/check-migrations.ts
+++ b/tools/check-migrations.ts
@@ -1,7 +1,11 @@
 import { createHash } from 'node:crypto'
+import { execFile } from 'node:child_process'
 import { readFile, readdir } from 'node:fs/promises'
 import path from 'node:path'
+import { promisify } from 'node:util'
 import { isExecutedDirectly } from './node-runtime.ts'
+
+const execFileAsync = promisify(execFile)
 
 export const defaultMigrationsDir = path.join(
 	'packages',
@@ -67,6 +71,12 @@ export type MigrationLedger = {
 	baselineMaximumPrefix: number
 	baselineSha256: string
 	migrations: Array<MigrationLedgerEntry>
+}
+
+export type TrustedMigrationHistory = {
+	ref: string
+	files: Array<MigrationLedgerEntry>
+	ledgerEntries: Array<MigrationLedgerEntry>
 }
 
 export function parseMigrationFilename(
@@ -179,17 +189,20 @@ export function checkMigrationFilenames(
 	}
 }
 
-function sha256(value: string | Uint8Array): string {
-	return createHash('sha256').update(value).digest('hex')
+export function hashMigrationContent(value: string | Uint8Array): string {
+	const text =
+		typeof value === 'string' ? value : new TextDecoder().decode(value)
+	const canonicalLfText = text.replace(/\r\n?/g, '\n')
+	return createHash('sha256').update(canonicalLfText).digest('hex')
 }
 
 function getBaselineSha256(
 	entries: ReadonlyArray<MigrationLedgerEntry>,
 ): string {
-	return sha256(JSON.stringify(entries))
+	return createHash('sha256').update(JSON.stringify(entries)).digest('hex')
 }
 
-function isMigrationLedger(value: unknown): value is MigrationLedger {
+export function isMigrationLedger(value: unknown): value is MigrationLedger {
 	if (!value || typeof value !== 'object') {
 		return false
 	}
@@ -214,6 +227,7 @@ function isMigrationLedger(value: unknown): value is MigrationLedger {
 export function checkMigrationLedger(
 	files: ReadonlyArray<MigrationLedgerEntry>,
 	ledger: MigrationLedger,
+	trustedHistory: TrustedMigrationHistory | null = null,
 ): MigrationFilenameCheckResult {
 	const filenames = files.map(({ filename }) => filename)
 	const filenameResult = checkMigrationFilenames(filenames)
@@ -275,6 +289,36 @@ export function checkMigrationLedger(
 		}
 	}
 
+	const fallbackEntries = ledger.migrations.slice(0, ledger.baselineCount)
+	const trustedFiles = trustedHistory?.files ?? fallbackEntries
+	const trustedLedgerEntries = trustedHistory?.ledgerEntries ?? fallbackEntries
+	const trustedMaximumPrefix = getMaxMigrationPrefix(
+		trustedFiles.map(({ filename }) => filename),
+	)
+
+	if (
+		!trustedHistory &&
+		(ledger.migrations.length > ledger.baselineCount ||
+			files.length > ledger.baselineCount)
+	) {
+		errors.push(
+			'Cannot verify post-baseline migration history because no trusted Git base is available. Fetch origin/main history (CI uses fetch-depth: 0) and rerun validation.',
+		)
+	}
+
+	for (const [index, trustedEntry] of trustedLedgerEntries.entries()) {
+		const currentEntry = ledger.migrations[index]
+		if (
+			!currentEntry ||
+			currentEntry.filename !== trustedEntry.filename ||
+			currentEntry.sha256 !== trustedEntry.sha256
+		) {
+			errors.push(
+				`Migration ledger history from ${trustedHistory?.ref ?? 'the frozen bootstrap baseline'} changed at "${trustedEntry.filename}". Historical ledger entries cannot be edited, reordered, or deleted.`,
+			)
+		}
+	}
+
 	const filesByName = new Map(files.map((entry) => [entry.filename, entry]))
 	const ledgerByName = new Map(
 		ledger.migrations.map((entry) => [entry.filename, entry]),
@@ -299,6 +343,33 @@ export function checkMigrationLedger(
 		}
 	}
 
+	const trustedFilesByName = new Map(
+		trustedFiles.map((entry) => [entry.filename, entry]),
+	)
+	for (const trustedFile of trustedFiles) {
+		const currentFile = filesByName.get(trustedFile.filename)
+		if (!currentFile) {
+			errors.push(
+				`Migration "${trustedFile.filename}" exists in trusted history ${trustedHistory?.ref ?? 'the frozen bootstrap baseline'} but is missing from the checkout.`,
+			)
+		} else if (currentFile.sha256 !== trustedFile.sha256) {
+			errors.push(
+				`Migration "${trustedFile.filename}" differs from trusted history ${trustedHistory?.ref ?? 'the frozen bootstrap baseline'}. Migration and ledger digests cannot be changed together.`,
+			)
+		}
+	}
+	for (const file of files) {
+		if (trustedFilesByName.has(file.filename)) {
+			continue
+		}
+		const parsed = parseMigrationFilename(file.filename)
+		if (parsed && Number(parsed.prefix) <= trustedMaximumPrefix) {
+			errors.push(
+				`Migration "${file.filename}" is new relative to ${trustedHistory?.ref ?? 'the frozen bootstrap baseline'} but does not use a prefix above ${formatMigrationPrefix(trustedMaximumPrefix)}.`,
+			)
+		}
+	}
+
 	return {
 		...filenameResult,
 		ok: errors.length === 0,
@@ -316,6 +387,91 @@ export async function readMigrationLedger(
 	return parsed
 }
 
+async function gitOutput(
+	args: ReadonlyArray<string>,
+	options: { trim?: boolean } = {},
+): Promise<string | null> {
+	try {
+		const { stdout } = await execFileAsync('git', [...args], {
+			encoding: 'utf8',
+		})
+		return options.trim === false ? stdout : stdout.trim()
+	} catch {
+		return null
+	}
+}
+
+export async function resolveTrustedMigrationBase(): Promise<string | null> {
+	const candidates = [
+		process.env.MIGRATION_VALIDATION_BASE,
+		process.env.GITHUB_BASE_REF
+			? `origin/${process.env.GITHUB_BASE_REF}`
+			: undefined,
+		'origin/main',
+		'main',
+	].filter((candidate): candidate is string => Boolean(candidate))
+
+	for (const candidate of candidates) {
+		const mergeBase = await gitOutput(['merge-base', 'HEAD', candidate])
+		if (mergeBase) {
+			return mergeBase
+		}
+	}
+	return null
+}
+
+export async function readTrustedMigrationHistory(
+	ref: string,
+): Promise<TrustedMigrationHistory> {
+	const migrationRoot = defaultMigrationsDir.replaceAll(path.sep, '/')
+	const filenamesOutput = await gitOutput([
+		'ls-tree',
+		'-r',
+		'--name-only',
+		ref,
+		'--',
+		migrationRoot,
+	])
+	if (filenamesOutput === null) {
+		throw new Error(`Could not read migrations from trusted Git ref ${ref}.`)
+	}
+	const filenames = filenamesOutput
+		.split('\n')
+		.filter((filename) => filename.endsWith('.sql'))
+		.map((filename) => path.posix.basename(filename))
+		.sort()
+	const files = await Promise.all(
+		filenames.map(async (filename) => {
+			const content = await gitOutput(
+				['show', `${ref}:${migrationRoot}/${filename}`],
+				{ trim: false },
+			)
+			if (content === null) {
+				throw new Error(
+					`Could not read migration "${filename}" from trusted Git ref ${ref}.`,
+				)
+			}
+			return { filename, sha256: hashMigrationContent(content) }
+		}),
+	)
+
+	const ledgerJson = await gitOutput(
+		['show', `${ref}:${defaultMigrationLedgerPath.replaceAll(path.sep, '/')}`],
+		{ trim: false },
+	)
+	let ledgerEntries = files
+	if (ledgerJson !== null) {
+		const parsed: unknown = JSON.parse(ledgerJson)
+		if (!isMigrationLedger(parsed)) {
+			throw new Error(
+				`Invalid migration ledger structure at trusted Git ref ${ref}.`,
+			)
+		}
+		ledgerEntries = parsed.migrations
+	}
+	return { ref, files, ledgerEntries }
+}
+
 export async function checkMigrationsDirectory(
 	migrationsDir: string = defaultMigrationsDir,
 	ledgerPath: string = defaultMigrationLedgerPath,
@@ -329,11 +485,17 @@ export async function checkMigrationsDirectory(
 	const files = await Promise.all(
 		filenames.map(async (filename) => ({
 			filename,
-			sha256: sha256(await readFile(path.join(migrationsDir, filename))),
+			sha256: hashMigrationContent(
+				await readFile(path.join(migrationsDir, filename)),
+			),
 		})),
 	)
 	const ledger = await readMigrationLedger(ledgerPath)
-	return checkMigrationLedger(files, ledger)
+	const trustedBase = await resolveTrustedMigrationBase()
+	const trustedHistory = trustedBase
+		? await readTrustedMigrationHistory(trustedBase)
+		: null
+	return checkMigrationLedger(files, ledger, trustedHistory)
 }
 
 export async function main(

--- a/tools/check-migrations.ts
+++ b/tools/check-migrations.ts
@@ -79,6 +79,16 @@ export type TrustedMigrationHistory = {
 	ledgerEntries: Array<MigrationLedgerEntry>
 }
 
+type GitOutput = (
+	args: ReadonlyArray<string>,
+	options?: { trim?: boolean },
+) => Promise<string | null>
+
+export type TrustedMigrationBaseOptions = {
+	env?: NodeJS.ProcessEnv
+	git?: GitOutput
+}
+
 export function parseMigrationFilename(
 	filename: string,
 ): ParsedMigrationFilename | null {
@@ -401,23 +411,36 @@ async function gitOutput(
 	}
 }
 
-export async function resolveTrustedMigrationBase(): Promise<string | null> {
-	const candidates = [
-		process.env.MIGRATION_VALIDATION_BASE,
-		process.env.GITHUB_BASE_REF
-			? `origin/${process.env.GITHUB_BASE_REF}`
-			: undefined,
-		'origin/main',
-		'main',
-	].filter((candidate): candidate is string => Boolean(candidate))
+export async function resolveTrustedMigrationBase(
+	options: TrustedMigrationBaseOptions = {},
+): Promise<string | null> {
+	const env = options.env ?? process.env
+	const git = options.git ?? gitOutput
+	const head = await git(['rev-parse', 'HEAD^{commit}'])
+	if (!head) {
+		return null
+	}
 
-	for (const candidate of candidates) {
-		const mergeBase = await gitOutput(['merge-base', 'HEAD', candidate])
-		if (mergeBase) {
+	const explicitCandidates = [
+		env.MIGRATION_VALIDATION_BASE,
+		env.GITHUB_BASE_REF ? `origin/${env.GITHUB_BASE_REF}` : undefined,
+	].filter((candidate): candidate is string => Boolean(candidate))
+	for (const candidate of explicitCandidates) {
+		const commit = await git(['rev-parse', `${candidate}^{commit}`])
+		if (commit && commit !== head) {
+			return commit
+		}
+	}
+
+	for (const candidate of ['origin/main', 'main']) {
+		const mergeBase = await git(['merge-base', 'HEAD', candidate])
+		if (mergeBase && mergeBase !== head) {
 			return mergeBase
 		}
 	}
-	return null
+
+	const firstParent = await git(['rev-parse', 'HEAD^1'])
+	return firstParent && firstParent !== head ? firstParent : null
 }
 
 export async function readTrustedMigrationHistory(

--- a/tools/check-migrations.ts
+++ b/tools/check-migrations.ts
@@ -1,4 +1,5 @@
-import { readdir } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { readFile, readdir } from 'node:fs/promises'
 import path from 'node:path'
 import { isExecutedDirectly } from './node-runtime.ts'
 
@@ -7,6 +8,12 @@ export const defaultMigrationsDir = path.join(
 	'worker',
 	'migrations',
 )
+export const defaultMigrationLedgerPath = path.join(
+	'tools',
+	'migration-ledger.json',
+)
+export const expectedMigrationBaselineSha256 =
+	'33a6aadea996e639d158229a1322f00164a157e2ef8aa43c9abcd5bf22c59c3a'
 
 /**
  * Exact grandfathered duplicate-prefix pairs. Applied D1 migrations cannot be
@@ -49,6 +56,19 @@ export type MigrationFilenameCheckResult = {
 	maxPrefix: number
 }
 
+export type MigrationLedgerEntry = {
+	filename: string
+	sha256: string
+}
+
+export type MigrationLedger = {
+	version: 1
+	baselineCount: number
+	baselineMaximumPrefix: number
+	baselineSha256: string
+	migrations: Array<MigrationLedgerEntry>
+}
+
 export function parseMigrationFilename(
 	filename: string,
 ): ParsedMigrationFilename | null {
@@ -69,12 +89,11 @@ export function getMaxMigrationPrefix(
 ): number {
 	let maxPrefix = 0
 	for (const filename of filenames) {
-		const match = /^(?<prefix>\d{4})/.exec(filename)
-		const prefix = match?.groups?.prefix
-		if (!prefix) {
+		const parsed = parseMigrationFilename(filename)
+		if (!parsed) {
 			continue
 		}
-		maxPrefix = Math.max(maxPrefix, Number(prefix))
+		maxPrefix = Math.max(maxPrefix, Number(parsed.prefix))
 	}
 	return maxPrefix
 }
@@ -160,11 +179,161 @@ export function checkMigrationFilenames(
 	}
 }
 
+function sha256(value: string | Uint8Array): string {
+	return createHash('sha256').update(value).digest('hex')
+}
+
+function getBaselineSha256(
+	entries: ReadonlyArray<MigrationLedgerEntry>,
+): string {
+	return sha256(JSON.stringify(entries))
+}
+
+function isMigrationLedger(value: unknown): value is MigrationLedger {
+	if (!value || typeof value !== 'object') {
+		return false
+	}
+	const candidate = value as Partial<MigrationLedger>
+	return (
+		candidate.version === 1 &&
+		Number.isInteger(candidate.baselineCount) &&
+		Number.isInteger(candidate.baselineMaximumPrefix) &&
+		typeof candidate.baselineSha256 === 'string' &&
+		Array.isArray(candidate.migrations) &&
+		candidate.migrations.every(
+			(entry) =>
+				entry !== null &&
+				typeof entry === 'object' &&
+				typeof entry.filename === 'string' &&
+				typeof entry.sha256 === 'string' &&
+				/^[a-f0-9]{64}$/.test(entry.sha256),
+		)
+	)
+}
+
+export function checkMigrationLedger(
+	files: ReadonlyArray<MigrationLedgerEntry>,
+	ledger: MigrationLedger,
+): MigrationFilenameCheckResult {
+	const filenames = files.map(({ filename }) => filename)
+	const filenameResult = checkMigrationFilenames(filenames)
+	const errors = [...filenameResult.errors]
+	const ledgerFilenames = ledger.migrations.map(({ filename }) => filename)
+	const ledgerFilenameResult = checkMigrationFilenames(ledgerFilenames)
+
+	if (ledger.baselineSha256 !== expectedMigrationBaselineSha256) {
+		errors.push(
+			`Migration ledger baseline digest changed. Baseline migrations are immutable; expected ${expectedMigrationBaselineSha256}.`,
+		)
+	}
+
+	if (ledger.migrations.length < ledger.baselineCount) {
+		errors.push(
+			`Migration ledger contains ${String(ledger.migrations.length)} entries but its frozen baseline requires ${String(ledger.baselineCount)}.`,
+		)
+	} else {
+		const baselineEntries = ledger.migrations.slice(0, ledger.baselineCount)
+		const actualBaselineSha256 = getBaselineSha256(baselineEntries)
+		if (actualBaselineSha256 !== ledger.baselineSha256) {
+			errors.push(
+				`Migration ledger baseline entries changed (expected digest ${ledger.baselineSha256}, received ${actualBaselineSha256}). Baseline entries cannot be edited, reordered, renamed, or deleted.`,
+			)
+		}
+		const actualBaselineMaximum = getMaxMigrationPrefix(
+			baselineEntries.map(({ filename }) => filename),
+		)
+		if (actualBaselineMaximum !== ledger.baselineMaximumPrefix) {
+			errors.push(
+				`Migration ledger baseline maximum is ${String(actualBaselineMaximum)}, not the recorded ${String(ledger.baselineMaximumPrefix)}.`,
+			)
+		}
+	}
+
+	if (!ledgerFilenameResult.ok) {
+		errors.push(
+			...ledgerFilenameResult.errors.map((error) => `Ledger: ${error}`),
+		)
+	}
+
+	const sortedLedgerFilenames = [...ledgerFilenames].sort()
+	if (
+		sortedLedgerFilenames.some(
+			(filename, index) => filename !== ledgerFilenames[index],
+		)
+	) {
+		errors.push(
+			'Migration ledger entries must remain in lexicographic filename order; append new migrations without reordering history.',
+		)
+	}
+
+	for (const entry of ledger.migrations.slice(ledger.baselineCount)) {
+		const parsed = parseMigrationFilename(entry.filename)
+		if (parsed && Number(parsed.prefix) <= ledger.baselineMaximumPrefix) {
+			errors.push(
+				`Migration "${entry.filename}" was added at or below frozen baseline maximum ${formatMigrationPrefix(ledger.baselineMaximumPrefix)}. Additions must use a higher prefix.`,
+			)
+		}
+	}
+
+	const filesByName = new Map(files.map((entry) => [entry.filename, entry]))
+	const ledgerByName = new Map(
+		ledger.migrations.map((entry) => [entry.filename, entry]),
+	)
+	for (const entry of ledger.migrations) {
+		const file = filesByName.get(entry.filename)
+		if (!file) {
+			errors.push(
+				`Ledgered migration "${entry.filename}" is missing. Applied migrations cannot be deleted or renamed.`,
+			)
+		} else if (file.sha256 !== entry.sha256) {
+			errors.push(
+				`Ledgered migration "${entry.filename}" was modified (expected sha256 ${entry.sha256}, received ${file.sha256}). Applied migrations are immutable.`,
+			)
+		}
+	}
+	for (const file of files) {
+		if (!ledgerByName.has(file.filename)) {
+			errors.push(
+				`Migration "${file.filename}" is not in ${defaultMigrationLedgerPath}. Append its filename and sha256 after choosing a prefix above the ledger maximum.`,
+			)
+		}
+	}
+
+	return {
+		...filenameResult,
+		ok: errors.length === 0,
+		errors,
+	}
+}
+
+export async function readMigrationLedger(
+	ledgerPath: string = defaultMigrationLedgerPath,
+): Promise<MigrationLedger> {
+	const parsed: unknown = JSON.parse(await readFile(ledgerPath, 'utf8'))
+	if (!isMigrationLedger(parsed)) {
+		throw new Error(`Invalid migration ledger structure in ${ledgerPath}.`)
+	}
+	return parsed
+}
+
 export async function checkMigrationsDirectory(
 	migrationsDir: string = defaultMigrationsDir,
+	ledgerPath: string = defaultMigrationLedgerPath,
 ): Promise<MigrationFilenameCheckResult> {
-	const filenames = await readdir(migrationsDir)
-	return checkMigrationFilenames(filenames)
+	const directoryEntries = await readdir(migrationsDir, {
+		withFileTypes: true,
+	})
+	const filenames = directoryEntries
+		.filter((entry) => entry.isFile())
+		.map(({ name }) => name)
+	const files = await Promise.all(
+		filenames.map(async (filename) => ({
+			filename,
+			sha256: sha256(await readFile(path.join(migrationsDir, filename))),
+		})),
+	)
+	const ledger = await readMigrationLedger(ledgerPath)
+	return checkMigrationLedger(files, ledger)
 }
 
 export async function main(
@@ -182,9 +351,9 @@ export async function main(
 		return
 	}
 
-	const filenames = await readdir(migrationsDir)
+	const fileCount = (await readdir(migrationsDir)).length
 	console.log(
-		`Migration filenames ok: ${String(filenames.length)} file(s) in ${migrationsDir} (next free prefix ${result.nextPrefix}).`,
+		`Migration ledger ok: ${String(fileCount)} file(s) in ${migrationsDir} (next free prefix ${result.nextPrefix}).`,
 	)
 }
 

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -1,0 +1,364 @@
+{
+	"version": 1,
+	"baselineCount": 89,
+	"baselineMaximumPrefix": 83,
+	"baselineSha256": "33a6aadea996e639d158229a1322f00164a157e2ef8aa43c9abcd5bf22c59c3a",
+	"migrations": [
+		{
+			"filename": "0001-init.sql",
+			"sha256": "56cc379094c8f5baf5c2a275c1795c042241af8972d2ec78db90df2145472988"
+		},
+		{
+			"filename": "0002-chat-threads.sql",
+			"sha256": "3229a8dd69773aff94dbe4eeb08fed63a29cd3e3fd42784f02de558f172d789a"
+		},
+		{
+			"filename": "0003-mock-ai-requests.sql",
+			"sha256": "f2c39fe4a9fd91b2d20c93e6af5b855d20b7403c045307cdcfc86204e94c3e22"
+		},
+		{
+			"filename": "0004-mcp-skills.sql",
+			"sha256": "d5b6f78f743f8b43ab8fe794f859e3ccedb61946f25863eda0b1dfa44cb96961"
+		},
+		{
+			"filename": "0005-skill-parameters.sql",
+			"sha256": "d70d5ef879df545e7a9675174c0d041f159a9103f4661f509802dbb33ec27ae7"
+		},
+		{
+			"filename": "0006-ui-artifacts.sql",
+			"sha256": "e9f630e73cf7afce7b4e5aad56f1a9b4998b9d7409e8360527cf67f5f1fe3e5b"
+		},
+		{
+			"filename": "0007-drop-mock-request-tables.sql",
+			"sha256": "0473204c798a83dd00d84cb55b6bdbd0d10292ae3b1dd21a429abfe7fe7caa94"
+		},
+		{
+			"filename": "0008-secret-buckets.sql",
+			"sha256": "19707b34949c6193393db41a1e1a5a7fb11bc004480997d4a082f30435c0392b"
+		},
+		{
+			"filename": "0009-secret-allowed-hosts.sql",
+			"sha256": "70402a21c204687bf62a59fc1062f091b90d607c9e84c82567870256de1a59c9"
+		},
+		{
+			"filename": "0009-ui-artifact-parameters.sql",
+			"sha256": "0cc7b4e785c06b0afaeab1f6655b024e50a9bc41bf24cd3b3847b5e42a75709e"
+		},
+		{
+			"filename": "0010-secret-allowed-capabilities.sql",
+			"sha256": "01713cacfb88f5b2c6bce96fcf0f959d3c0d8afab3322a9f07cacad4f4cc78b2"
+		},
+		{
+			"filename": "0010-value-buckets.sql",
+			"sha256": "7cb488d5f108ee5170cd1f8c0fd360dc82606c46b1fde98e2a652af3edbf5fc3"
+		},
+		{
+			"filename": "0011-remove-ui-artifacts-search-columns.sql",
+			"sha256": "9b24087152eabe2a2fdb4a7911446649b6fdb9df7d0302d070ade5afc1170748"
+		},
+		{
+			"filename": "0012-skill-collections.sql",
+			"sha256": "8c24eeffb545faf1eca92bcdb11d28ba7bbe212b8a5939d5abeb6c9f378cd5d8"
+		},
+		{
+			"filename": "0013-ui-artifact-search-visibility.sql",
+			"sha256": "cd0574684f9da47e8e8edd80dee576f9c9d02fc98da93d996392cc9f795f3260"
+		},
+		{
+			"filename": "0014-skill-names.sql",
+			"sha256": "48ba3b65adceb3c60877baec4f512a107991d7fa5c99e75286e8de6b85a9ba39"
+		},
+		{
+			"filename": "0015-mcp-user-server-instructions.sql",
+			"sha256": "6f7c649f92f28788be69e753b88b48a6aec9dea8829a1f96723d70f2c5bd78b1"
+		},
+		{
+			"filename": "0016-mcp-memories.sql",
+			"sha256": "75fcdb1222e06056ad961cf55a08723d59ef5a414fb71b48c916e951d6a8184c"
+		},
+		{
+			"filename": "0017-saved-app-facets.sql",
+			"sha256": "550e5b1161bde0009db68c8fe32bc6c3800b18745f74024514f1bfb498470510"
+		},
+		{
+			"filename": "0018-jobs.sql",
+			"sha256": "746544e207e9478e213da65bd7ccffdd70fc9269d905be435f151ed6f9cee3a0"
+		},
+		{
+			"filename": "0018-mcp-memory-source-uris.sql",
+			"sha256": "90f54c6dd8c79cdddd84866804334b84ab02fe7d3c61d7202380b6daef8e6266"
+		},
+		{
+			"filename": "0019-jobs-constraints.sql",
+			"sha256": "79be83eb0ad85220863df018ccdb40b2e58cd3d4f63581dacf26bc7ec604d570"
+		},
+		{
+			"filename": "0020-jobs-codemode-only.sql",
+			"sha256": "bf7d65a4a61cc3ef80327cfc5975554b08860e9b81eaf1dcdcbad32e22902663"
+		},
+		{
+			"filename": "0021-jobs-storage-id.sql",
+			"sha256": "40ff8421bf484a3d8b76ac6e472cf0b64fe695b8b872eff8196b136515be4bd9"
+		},
+		{
+			"filename": "0022-secret-entry-lookup-hash.sql",
+			"sha256": "be8260bacff986e01cc8f56794ede0500981f4da0346c3fb93df82421134ba60"
+		},
+		{
+			"filename": "0023-entity-sources.sql",
+			"sha256": "c0767450ec2281a852b5824043465e170199d8e76d200d343026b822fb27f662"
+		},
+		{
+			"filename": "0023-secret-allowed-packages.sql",
+			"sha256": "45d0813307cb1dea7d68f5d7407cc78e162e591c73233ed403276b917da2d6e1"
+		},
+		{
+			"filename": "0024-repo-sessions-and-source-columns.sql",
+			"sha256": "bd83d1ec14395454b47ebed14af6527fbb247232d0c89a1b46ad74c0fc816983"
+		},
+		{
+			"filename": "0025-jobs-repo-check-policy.sql",
+			"sha256": "cf11be234348b92f033ba1fa7084eb0779e682aa8ea03b8b5bda450c2076845b"
+		},
+		{
+			"filename": "0026-drop-legacy-inline-sources.sql",
+			"sha256": "eff213c0489ae50add1a47dcd03b587e4fae63a35dc93e9d2963b64428dfdade"
+		},
+		{
+			"filename": "0027-saved-packages.sql",
+			"sha256": "c0195da679ca997e322908ffa750f1aabec8be21ac333b0da00c59d1a4a91842"
+		},
+		{
+			"filename": "0028-published-bundle-artifacts-and-archived-jobs.sql",
+			"sha256": "33b4a1e99f8b6c66193cac5f60ac927b1cc2ad708d8356b9686c091ad6b77437"
+		},
+		{
+			"filename": "0029-package-invocations.sql",
+			"sha256": "24bed5638f05e392d785ac3fbfa65f742a812ac19ca4f4ab45f1a2854454e149"
+		},
+		{
+			"filename": "0030-email-primitives.sql",
+			"sha256": "2c5d51c109f3fe6f5ea8f14a539de0aa780be99798f567434bf3ce468ac6a1c0"
+		},
+		{
+			"filename": "0031-unified-email-receipt.sql",
+			"sha256": "a4320a47e13a0473fb0c11863669e6e80240c82125d9009e5d7410f84fa837b7"
+		},
+		{
+			"filename": "0032-entity-sources-external-check.sql",
+			"sha256": "e921728381a7e514300b8339e8e30cf7e7f795291d273e7a76ab46da3bdd3962"
+		},
+		{
+			"filename": "0033-drop-legacy-inline-sources-archive.sql",
+			"sha256": "6e5f29fc735cfdcd65dadae18023f1ea6427c5332814e30adddf614c477e7f6f"
+		},
+		{
+			"filename": "0034-remote-connector-settings.sql",
+			"sha256": "cf16180b3ef275d3f4809bd1ac2c3ee2c18d05b067c617552126e373bed54725"
+		},
+		{
+			"filename": "0035-workflow-runs.sql",
+			"sha256": "bd8d2a45189765750b95f0666a9dd1f66b57eb83fd5373c800bb23560bfd0b70"
+		},
+		{
+			"filename": "0036-workflow-runs-idempotency-index.sql",
+			"sha256": "04664b46083e8f6f014f5b0f3a4e29670cd6d73d7a1f293edb8cbc2c6601c6fb"
+		},
+		{
+			"filename": "0037-drop-chat-threads.sql",
+			"sha256": "d9ac561a71e8180de67493cb3ec9e73655f3c421de34f9e7fd100a19f5539fa6"
+		},
+		{
+			"filename": "0037-package-runtime-debug.sql",
+			"sha256": "8361d75d370bfa47bb17a276e06d32d706d2c935c582616b7770e4b2b8b3aa42"
+		},
+		{
+			"filename": "0038-backfill-usernames.sql",
+			"sha256": "28c89b27ad3f08379f0b164ab6e2f5e4a38fe4a6a5e9f43929d8f94584a05b55"
+		},
+		{
+			"filename": "0040-drop-source-rescue-events.sql",
+			"sha256": "ac95590034ae08840f2f11b19dfc7865d2191b536a426d321f1551a381a267dd"
+		},
+		{
+			"filename": "0041-repo-session-branches.sql",
+			"sha256": "6f0b0579f855c2550d7d3bda0e59c1dc536c7a4108ace0178c812d6c965b6892"
+		},
+		{
+			"filename": "0042-drop-legacy-skill-app-tables.sql",
+			"sha256": "23322314d2ae303bca8a7a42d3c9c5ab07b1e8ce055f11dcb116c7198a598ca8"
+		},
+		{
+			"filename": "0043-rbac.sql",
+			"sha256": "1706f99de338f9095d29cfc5850852bb15e552a15afcb02409a2ddfa3fd5d7b4"
+		},
+		{
+			"filename": "0044-rbac-backfill-user-role.sql",
+			"sha256": "b53608d1b84e67e3905a774cd66362aa55fa8bc8a866417a0a90ff4c4e2cffa8"
+		},
+		{
+			"filename": "0045-community-listings.sql",
+			"sha256": "c9b1133c482d077ba66169190918920c92885c01afcb5d0a1c52d150e1d0cab4"
+		},
+		{
+			"filename": "0046-invites-email-verification.sql",
+			"sha256": "7c8a7b54b5eeeec4375d46ae724cc79dae96bc97bfed03d759d6810fe3cadd59"
+		},
+		{
+			"filename": "0047-usage-rollups.sql",
+			"sha256": "5060eaacf1250b524c835ee1d781c53252e45da577f7146c488be253a098d897"
+		},
+		{
+			"filename": "0048-user-plans-and-entitlement-counters.sql",
+			"sha256": "d88750d16e99e67590763638c649c327487f612f5b519f75d04c9b82a762a3ee"
+		},
+		{
+			"filename": "0049-audit-events.sql",
+			"sha256": "2f224055217d5cb3cb7ba35939d2f0b656af86dcbe0c4b852f41d54de03077db"
+		},
+		{
+			"filename": "0050-drop-remote-connector-kind.sql",
+			"sha256": "323a49bf260d8ba6ca61f46e1df059fbbbb74a628226dbaddb7c3ca3371a23ab"
+		},
+		{
+			"filename": "0051-system-email-daily-counters.sql",
+			"sha256": "72d443b373b9bb444a011fc69765109e29dba55da2abf4612b5a8d3de3016906"
+		},
+		{
+			"filename": "0052-stable-user-id-email-changes.sql",
+			"sha256": "cb753511d6f6b50cb52e79d52e6c95facbcd3e891f50b8832e3a243ee3b7d3e5"
+		},
+		{
+			"filename": "0053-mcp-server-settings.sql",
+			"sha256": "5416222f8f0627a7913c828ee06ce23ba43dc0bec2ee80b588e9c45d4fcee5e0"
+		},
+		{
+			"filename": "0053-two-factor-passkeys.sql",
+			"sha256": "e3505d34c15e1927cbd719f86b427cbe0ca33a65bb145ea15ffb8911defb69a4"
+		},
+		{
+			"filename": "0054-email-blob-storage.sql",
+			"sha256": "62929b34e5ec89ed9565bea2cfb18f896d1420e8be8e339fbd80900859b7c650"
+		},
+		{
+			"filename": "0055-retention-indexes.sql",
+			"sha256": "751a8efd6f72b3b63251b4753ce4ad90a2a0c6d2b110c69272aca93e1280d2a4"
+		},
+		{
+			"filename": "0056-oauth-connections.sql",
+			"sha256": "92d5ec8fd7f48dba7b9becc455f34b22e1ad88129e1da7912ea9cde77fb120e4"
+		},
+		{
+			"filename": "0057-package-scoped-secrets.sql",
+			"sha256": "00e9adcf0e7050330ab1dd0940baff28d721f1ae77393732d3c58ead38af573b"
+		},
+		{
+			"filename": "0058-saved-packages-hidden.sql",
+			"sha256": "60849a5a2444f7a685b1e875244e833f9265b0e6309cfcd6fad701a87795ee99"
+		},
+		{
+			"filename": "0059-community-trusted-listings.sql",
+			"sha256": "672911e4006f7e436b2875456d6f5fe5c14a06e78515cb7d000d5ff0c130c1e1"
+		},
+		{
+			"filename": "0060-community-featured-listings.sql",
+			"sha256": "334ae6cc09e310659eb209adbec512dfb813bf5795a1a3231de40d48c58dd1ae"
+		},
+		{
+			"filename": "0061-email-delivery-lifecycle.sql",
+			"sha256": "25c056b157187065753613d321093f0edb3199126034a6f7dfda818961e4d356"
+		},
+		{
+			"filename": "0062-platform-feedback.sql",
+			"sha256": "cdfc63cd18e51986b2094e972ed00f236534f8d502a386e6a9d9e1f3cdacbc43"
+		},
+		{
+			"filename": "0063-platform-feedback-submitter-snapshot.sql",
+			"sha256": "8cc8732a10bccabb91aa4a7ed70dcb0184426027e7998c84f07a04b7d2016496"
+		},
+		{
+			"filename": "0064-feature-flags.sql",
+			"sha256": "e8c6c91e4d9083b42770f499eb8be28e3689848d48434e721ce5f550e90c8473"
+		},
+		{
+			"filename": "0065-invite-plans.sql",
+			"sha256": "5c27f679e6fcd48a8a0fa2c51a8114758235bd8780b522ac2cf3434ced3f2618"
+		},
+		{
+			"filename": "0066-stripe-billing.sql",
+			"sha256": "978b93404f8895aa3bf37cdbf457838e599364530bfe19c6650582fb03258c8e"
+		},
+		{
+			"filename": "0067-personal-plan-to-pro.sql",
+			"sha256": "4bafa9b5ba8798c481c00c600f6fe07b920b1d2b918b5444add2e1cd9bb6ea78"
+		},
+		{
+			"filename": "0068-community-social.sql",
+			"sha256": "e1520b671152fb08c400a39c74c9677ff27763501c0b10fcf6bbaae088aaac1e"
+		},
+		{
+			"filename": "0069-user-avatars.sql",
+			"sha256": "9a04d8d325a6e5156f57e4a455efd7cc844dbb884aafeed5e4bd1927d92a6e46"
+		},
+		{
+			"filename": "0070-community-fork-listing-snapshots.sql",
+			"sha256": "4b2011cca4924c37b7f3741cf92e9696a6da6a78023d279bf438fcf8ae64566d"
+		},
+		{
+			"filename": "0071-passkey-labels.sql",
+			"sha256": "1f0d7e896a4eac3ce70262dcf005ea25fcd6c0ca23c1abfeccf8b2f2d392b09a"
+		},
+		{
+			"filename": "0072-package-scope-grants.sql",
+			"sha256": "3012ed4b686c76d9a22ac916ea00c4d782e60175b8151a073ef2492277ec4d5a"
+		},
+		{
+			"filename": "0073-agent-package-conversation-uses.sql",
+			"sha256": "26bb13773b3ba3c6549f0c578f8e05f45ce73a7112b8a334efe38f13f4acc3c9"
+		},
+		{
+			"filename": "0073-community-forks-forked-package-index.sql",
+			"sha256": "2687675b1c97d3d02710087ab63f6d3ed623b5c07e57677a86fed9186644fe2a"
+		},
+		{
+			"filename": "0074-community-fork-adoption.sql",
+			"sha256": "cd512427a421f770fc36815e49657055dd2de3d7b93c34a46c1bcdd4eead81d7"
+		},
+		{
+			"filename": "0075-stable-user-id-not-null.sql",
+			"sha256": "9238d6ca10c46efb56b722b73b6c2bc2325842c39dd2f50b6dbfa2944ebd4aeb"
+		},
+		{
+			"filename": "0076-email-raw-mime-offload-blocked.sql",
+			"sha256": "00b3fb258b9813c30e3d25715eb1081b216cebd2beb24b3bc9c10bc4ac3aab7d"
+		},
+		{
+			"filename": "0077-drop-email-raw-mime-inline.sql",
+			"sha256": "9c3207a19bca4f74d94cfbb177e7e19bae4bfda5d03a7688111a7e2e1ebccfeb"
+		},
+		{
+			"filename": "0078-email-sender-identities-verified-only.sql",
+			"sha256": "66d702411beba7097012d0d669a1fc587a49f6a30ffe1893a0c7eac1628d9693"
+		},
+		{
+			"filename": "0079-drop-email-inbox-address-reply-token-hash.sql",
+			"sha256": "153dfaae02183b2eebdf8dd5c9c34fdbe7245b83d7db8ccecdb6ee72294ca6ae"
+		},
+		{
+			"filename": "0080-backfill-unlimited-plan.sql",
+			"sha256": "066b8c7871a3852812a5e462e379f43082776c051ff42de8fe1d9e11816a267f"
+		},
+		{
+			"filename": "0081-plan-not-null.sql",
+			"sha256": "761276aac57c78a493416adaa999290528e6733c4e46f4b73b1eb24da5c43871"
+		},
+		{
+			"filename": "0082-rename-unlimited-plan-to-max.sql",
+			"sha256": "6e3b56a1ec1d033b7ab5d8902ea8903b44306bb9cbb085f3a8b2b2a42635d218"
+		},
+		{
+			"filename": "0083-plan-default-free.sql",
+			"sha256": "ef9925149fdd182ae3e6ded2b237d002305a4b883ed4350de6047c9f0debf1f8"
+		}
+	]
+}

--- a/tools/nx-cache-contract.node.test.ts
+++ b/tools/nx-cache-contract.node.test.ts
@@ -5,7 +5,7 @@ import {
 	type NxJsonConfiguration,
 	type ProjectConfiguration,
 	type ProjectGraphProjectNode,
-} from '@nx/devkit'
+} from 'nx/src/devkit-exports.js'
 import {
 	filterUsingGlobPatterns,
 	getTargetInputs,

--- a/tools/nx-cache-contract.node.test.ts
+++ b/tools/nx-cache-contract.node.test.ts
@@ -1,0 +1,76 @@
+import { readFile } from 'node:fs/promises'
+import {
+	hashArray,
+	type FileData,
+	type NxJsonConfiguration,
+	type ProjectConfiguration,
+	type ProjectGraphProjectNode,
+} from '@nx/devkit'
+import {
+	filterUsingGlobPatterns,
+	getTargetInputs,
+} from 'nx/src/hasher/task-hasher.js'
+import { expect, test } from 'vitest'
+
+async function readJson<T>(filename: string): Promise<T> {
+	return JSON.parse(await readFile(filename, 'utf8')) as T
+}
+
+async function getWorkerTargetPatterns(target: string): Promise<Array<string>> {
+	const [nxJson, worker] = await Promise.all([
+		readJson<NxJsonConfiguration>('nx.json'),
+		readJson<ProjectConfiguration>('packages/worker/project.json'),
+	])
+	const projectNode: ProjectGraphProjectNode = {
+		name: 'worker',
+		type: 'app',
+		data: worker,
+	}
+	return getTargetInputs(nxJson, projectNode, target).selfInputs
+}
+
+function hashMatchedInputs(
+	patterns: ReadonlyArray<string>,
+	files: ReadonlyArray<FileData>,
+): string {
+	const workspacePatterns = patterns.map((pattern) =>
+		pattern.replace('{workspaceRoot}/', ''),
+	)
+	const matchedFiles = filterUsingGlobPatterns(
+		'packages/worker',
+		[...files],
+		workspacePatterns,
+	)
+	return hashArray(
+		matchedFiles
+			.sort((left, right) => left.file.localeCompare(right.file))
+			.map(({ file, hash }) => `${file}:${hash}`),
+	)
+}
+
+test.each([
+	{
+		target: 'test',
+		requiredInput: '{workspaceRoot}/packages/mock-servers/cloudflare/**/*',
+		dependencyFile: 'packages/mock-servers/cloudflare/src/index.ts',
+	},
+	{
+		target: 'test-mcp',
+		requiredInput: '{workspaceRoot}/wrangler-env.ts',
+		dependencyFile: 'wrangler-env.ts',
+	},
+])(
+	'$target cache hash includes $dependencyFile',
+	async ({ target, requiredInput, dependencyFile }) => {
+		const patterns = await getWorkerTargetPatterns(target)
+		expect(patterns).toContain(requiredInput)
+
+		const before = hashMatchedInputs(patterns, [
+			{ file: dependencyFile, hash: 'before' },
+		])
+		const after = hashMatchedInputs(patterns, [
+			{ file: dependencyFile, hash: 'after' },
+		])
+		expect(after).not.toBe(before)
+	},
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- anchor historical migration filenames, contents, and ledger entries to a genuinely pre-change Git commit
- reject `HEAD` as a trust base; CI supplies PR-base/push-before SHAs, local branches use their merge base, and main/detached checkouts fall back to the first parent
- fail safely when post-bootstrap migrations cannot be checked against available history; CI fetches complete history without persisting checkout credentials
- canonicalize migration hashes to LF and enforce LF migration checkouts with `.gitattributes`
- include the root Wrangler wrapper and Cloudflare mock server in relevant Nx test cache inputs
- cover PR, main-push, local branch, detached/shallow, bootstrap, runtime main co-edit, CRLF, and Nx hash contracts

## Tests
- focused regression suites: 2 files, 13 tests passed
- `npm run validate`: passed (format, lint, typecheck, 1,091 unit/worker tests, 17 Playwright tests, 2 MCP E2E tests, primitives, migrations)
- replacement CI at `280ce219`: Validate, preview deployment, Cursor Bugbot, and CodeRabbit passed
- pre-commit and pre-push hooks: passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ac6b9736` · **Head:** `280ce219`

**Classification:** composes — repository validation behavior changes without adding or changing a runtime system primitive.

### Primitives touched

None. The diff is limited to repository tooling, CI/Nx metadata, regression tests, checkout attributes, and contributor documentation.

### Before / after

| Before | After |
| --- | --- |
| Validation could accept `HEAD` itself as trusted history | Trust resolution rejects `HEAD` and selects PR base, push-before SHA, merge base, or first parent |
| Editable ledger digests were the only trust anchor for post-bootstrap migrations | Pre-change Git contents and ledger entries anchor every migration already present before the change |
| Missing Git history could silently trust future ledger entries | Missing history fails safely for post-bootstrap migrations; CI checks out full history without retaining credentials |
| Raw-byte hashes varied under `core.autocrlf=true` | SQL hashes canonicalize CRLF to LF and Git enforces LF migration checkouts |
| Worker test caches omitted external runtime dependencies | Nx hashes Cloudflare mock sources for `test` and `wrangler-env.ts` for `test-mcp` |

### Invariants

Applied migration filenames and contents are immutable. Migration and ledger digest co-edits fail against pre-change history, including on main pushes. The grandfathered duplicate-prefix pairs, including both `0009` files, remain exact and mandatory.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a7ad539-5338-4ff9-a9e1-8b6e28f67d48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7ad539-5338-4ff9-a9e1-8b6e28f67d48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a migration ledger with SHA-256 checksums and expanded validation to ensure migration integrity, immutability, correct ordering, and proper add-only behavior.
  * Added support for trusted-history verification and improved error reporting when history or ledgers are co-edited.
  * Normalized migration hashing to consistent LF line endings for reliable comparisons.
* **Documentation**
  * Updated contributing guidance for migration authoring, ledger updates, hashing, naming rules, and trusted-history checks.
* **Tests**
  * Expanded migration validation and Nx cache hashing coverage with additional scenario-based checks.  
* **Chores**
  * Updated repository settings and CI workflow to enforce LF handling and consistent validation baselines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->