### PR TITLE
Require public entity type lists in search entity docs

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -19,8 +19,9 @@ module under `packages/worker/src/mcp/tools/search-entity-plugins/`, one
 registration in `search-entity-registry.ts`, closed unions in
 `search-format-types.ts` (result unions for every list type; entity-backed
 detail unions only when `{id}:{type}` applies), Markdown list formatting in
-`search-format-list.ts`, and detail routing in `search-detail.ts` (plus
-`parseEntityRef` when the type is entity-backed). Plugin `formatSlimMatch`
+`search-format-list.ts`, detail routing in `search-detail.ts`, and for
+entity-backed types the public allowed-type lists in `search-tool-definition.ts`
+and `docs/use/search.md` (plus `parseEntityRef`). Plugin `formatSlimMatch`
 covers structured output only.
 
 ## Domains and registry (plain objects)

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -17,7 +17,7 @@ style, tests, MCP kody, and runtime architecture.
 - [External package invocation API](./package-invocation-api.md)
 - [Adding capabilities](./adding-capabilities.md)
 - [Search entity plugins](./search-entity-plugins.md) (plugin module + registry,
-  result/detail unions, list markdown, detail routing)
+  result/detail unions, list markdown, detail routing, public type lists)
 - [Architecture](./architecture/index.md) — includes
   [authorization](./architecture/authorization.md) (RBAC)
 - [MCP server patterns](./mcp-server-patterns.md) (reference for server design)

--- a/docs/contributing/search-entity-plugins.md
+++ b/docs/contributing/search-entity-plugins.md
@@ -36,8 +36,14 @@ To add a search entity:
    as `retriever_result`).
 8. Update `parseEntityRef` in `search-format-helpers.ts` so `{id}:{type}`
    parsing accepts the new entity-backed type.
-9. Add or update `search-entity-registry.node.test.ts` to prove the registry
-   order and whether the type is entity-backed.
+9. For entity-backed types, update the public allowed-type lists so agents and
+   docs stay in sync:
+   - `search-tool-definition.ts` (tool description and `entity` input schema
+     copy that enumerates `capability` | `package` | `secret` | `value` |
+     `integration`)
+   - `docs/use/search.md` (user-facing `{id}:{type}` type list)
+10. Add or update `search-entity-registry.node.test.ts` to prove the registry
+    order and whether the type is entity-backed.
 
 Current candidate flatten order is:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #892: the search-entity-plugins checklist now explicitly requires entity-backed allowed-type updates in `search-tool-definition.ts` and `docs/use/search.md`, so MCP tool copy and public search docs do not go stale. Mirrored summaries in the contributing index and adding-capabilities intro match.

**Risk:** LOW — docs-only.

## Test plan

- [x] Focused docs format check green
- [x] `primitives:check` / `migrations:check` green
- [x] `npm run validate` green
- [ ] CI Validate green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this PR

**Classification:** composes — documentation checklist accuracy only; no runtime code changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(none)_ | — | docs-only search-entity contributing checklist |

### System map

Contributor docs now require public allowed-type list updates alongside the plugin seam.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	docs["contributing docs<br/>search-entity checklist"]:::touched
	toolDef["search-tool-definition.ts<br/>public entity types"]:::untouched
	useDocs["docs/use/search.md<br/>public entity types"]:::untouched
	docs -->|"require updating"| toolDef
	docs -->|"require updating"| useDocs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a1cfb73-5de4-4039-8d72-248da97e1e1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a1cfb73-5de4-4039-8d72-248da97e1e1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

