### PR TITLE
Keep unguarded email insert off the service surface

### DIFF
--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -19,8 +19,8 @@ import {
 	getEmailMessageById,
 	getEmailMessageByMessageIdHeader,
 	insertEmailAttachments,
-	insertEmailMessage,
 	insertEmailDeliveryEvent,
+	insertEmailMessageWithoutRawMime,
 	updateEmailMessageDelivery,
 } from './service.ts'
 import { type EmailMessageRecord, type EmailProcessingStatus } from './types.ts'
@@ -546,7 +546,7 @@ export async function sendOutboundEmail(
 			})
 	const threadId = existingThreadId ?? thread?.id ?? null
 	const providerHeaders = buildProviderHeaders(storedHeaders)
-	const message = await insertEmailMessage({
+	const message = await insertEmailMessageWithoutRawMime({
 		db: input.env.APP_DB,
 		message: {
 			direction: 'outbound',
@@ -572,7 +572,6 @@ export async function sendOutboundEmail(
 			authResults: null,
 			textBody: text,
 			htmlBody: html,
-			rawMimeKey: null,
 			rawSize: null,
 			processingStatus: 'stored',
 			providerMessageId: null,

--- a/packages/worker/src/email/service.ts
+++ b/packages/worker/src/email/service.ts
@@ -28,7 +28,6 @@ export {
 	getEmailMessageByMessageIdHeader,
 	insertEmailAttachments,
 	insertEmailDeliveryEvent,
-	insertEmailMessage,
 	touchEmailThread,
 	updateEmailMessageDelivery,
 } from './repo.ts'
@@ -101,6 +100,12 @@ export async function loadRawMime(input: {
 }
 
 type InsertEmailMessageInput = Parameters<typeof insertEmailMessage>[0]
+type InsertEmailMessageWithoutRawMimeInput = Omit<
+	InsertEmailMessageInput,
+	'message'
+> & {
+	message: Omit<InsertEmailMessageInput['message'], 'rawMimeKey'>
+}
 type InsertEmailMessageWithRawMimeInput = Omit<
 	InsertEmailMessageInput,
 	'message'
@@ -109,6 +114,23 @@ type InsertEmailMessageWithRawMimeInput = Omit<
 	message: Omit<InsertEmailMessageInput['message'], 'rawMimeKey'> & {
 		rawMime?: string | null
 	}
+}
+
+/**
+ * Domain insert for messages that must not point at EMAIL_BLOBS raw MIME.
+ * Forces `rawMimeKey: null` so callers cannot invent a key without a blob.
+ * Inbound mail with raw MIME must use `insertEmailMessageWithRawMime`.
+ */
+export async function insertEmailMessageWithoutRawMime(
+	input: InsertEmailMessageWithoutRawMimeInput,
+) {
+	return await insertEmailMessage({
+		db: input.db,
+		message: {
+			...input.message,
+			rawMimeKey: null,
+		},
+	})
 }
 
 export async function insertEmailMessageWithRawMime(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Track D follow-up from post-merge compensating review.

`email/service.ts` was re-exporting repo-level `insertEmailMessage`, which accepts a caller-supplied `rawMimeKey` with no blob-existence guarantee. The old inbound path structurally guaranteed blob-before-row via `insertEmailMessageWithRawMime`; a future domain caller could otherwise insert a row pointing at a nonexistent blob.

**Change:**
- Stop re-exporting `insertEmailMessage` from `email/service.ts`
- Add `insertEmailMessageWithoutRawMime`, which omits `rawMimeKey` from the public message shape and always stores `rawMimeKey: null`
- Point `outbound.ts` at the safe insert (behavior unchanged: it already passed `rawMimeKey: null`)
- Inbound continues to use `insertEmailMessageWithRawMime` / `insertEmailMessageWithAttachments`

**Risk:** LOW — API surface tightening; existing callers preserve behavior. Repo-level insert remains available for tests/fixtures.

## Test plan

- [ ] `npm run validate` green
- [ ] coderabbitai feedback addressed if valid

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `6fa385cc`

**Classification:** composes — tightens the email domain service façade so unguarded raw-MIME key inserts are not part of the public service surface.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `email` | assistant | composes — safer domain insert API; no delivery behavior change |

### System map

Outbound message persistence goes through a service helper that forces a null raw MIME key; inbound still uses the blob-before-row helper.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	email["email<br/>Email"]:::touched
	emailBlobs["email-blobs-r2<br/>Email blob storage (R2)"]:::untouched
	email -->|"insertEmailMessageWithoutRawMime forces rawMimeKey null"| email
	email -->|"insertEmailMessageWithRawMime still writes blob before row"| emailBlobs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da51084e-2b68-423a-ad89-7259bad126c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da51084e-2b68-423a-ad89-7259bad126c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

