### PR TITLE
Preserve search entity source order

### DIFF
--- a/packages/worker/src/mcp/tools/search-descriptors.ts
+++ b/packages/worker/src/mcp/tools/search-descriptors.ts
@@ -93,7 +93,20 @@ export function buildSearchableEntityDescriptors(input: {
 	>
 }): Array<SearchableEntityDescriptor> {
 	const descriptors: Array<SearchableEntityDescriptor> = []
+	const valueRowDescriptorPlugins = searchEntityPlugins.filter(
+		(plugin) => 'buildValueRowDescriptor' in plugin,
+	)
 	for (const plugin of searchEntityPlugins) {
+		if ('buildValueRowDescriptor' in plugin) {
+			if (plugin !== valueRowDescriptorPlugins[0]) continue
+			for (const row of input.optionalRows.userValueRows) {
+				for (const valueRowPlugin of valueRowDescriptorPlugins) {
+					const descriptor = valueRowPlugin.buildValueRowDescriptor(row)
+					if (descriptor) descriptors.push(descriptor)
+				}
+			}
+			continue
+		}
 		if ('buildDescriptors' in plugin) {
 			descriptors.push(...plugin.buildDescriptors(input))
 		}

--- a/packages/worker/src/mcp/tools/search-entity-plugin.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugin.ts
@@ -1,4 +1,5 @@
 import { type getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
+import { type ValueMetadata } from '#mcp/values/types.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
 
 import {
@@ -60,6 +61,9 @@ export type SearchEntityPlugin<Type extends SearchMatch['type']> = {
 	buildDescriptors?: (
 		input: SearchEntityDescriptorInput,
 	) => Array<SearchableEntityDescriptor>
+	buildValueRowDescriptor?: (
+		row: ValueMetadata,
+	) => SearchableEntityDescriptor | undefined
 	buildCandidates?: (
 		input: SearchEntityCandidateInput,
 	) => Array<SearchCandidate> | Promise<Array<SearchCandidate>>

--- a/packages/worker/src/mcp/tools/search-entity-plugins/integration.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/integration.ts
@@ -43,36 +43,30 @@ export function buildIntegrationSearchDocument(input: {
 
 export const integrationSearchEntityPlugin = {
 	type: 'integration',
-	buildDescriptors(input) {
-		return input.optionalRows.userValueRows.flatMap((row) => {
-			const integrationName = parseIntegrationValueName(row.name)
-			if (!integrationName) return []
-			const config = parseIntegrationConfig(
-				parseIntegrationJson(row.value),
-				integrationName,
-			)
-			if (!config) return []
-			return [
-				{
-					type: 'integration',
-					id: integrationName,
-					title: integrationName,
-					primaryAliases: [integrationName],
-					secondaryAliases: [
-						row.description,
-						config.apiBaseUrl ?? '',
-						config.tokenUrl,
-						config.flow,
-					],
-					tertiaryAliases: [
-						...(config.requiredHosts ?? []),
-						...(config.apiBaseUrl
-							? extractSearchTokens(config.apiBaseUrl)
-							: []),
-					],
-				},
-			]
-		})
+	buildValueRowDescriptor(row) {
+		const integrationName = parseIntegrationValueName(row.name)
+		if (!integrationName) return undefined
+		const config = parseIntegrationConfig(
+			parseIntegrationJson(row.value),
+			integrationName,
+		)
+		if (!config) return undefined
+		return {
+			type: 'integration',
+			id: integrationName,
+			title: integrationName,
+			primaryAliases: [integrationName],
+			secondaryAliases: [
+				row.description,
+				config.apiBaseUrl ?? '',
+				config.tokenUrl,
+				config.flow,
+			],
+			tertiaryAliases: [
+				...(config.requiredHosts ?? []),
+				...(config.apiBaseUrl ? extractSearchTokens(config.apiBaseUrl) : []),
+			],
+		}
 	},
 	buildCandidates(input) {
 		return input.optionalRows.userValueRows

--- a/packages/worker/src/mcp/tools/search-entity-plugins/value.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/value.ts
@@ -15,20 +15,16 @@ import { buildCandidateBaseScore } from '../search-scoring.ts'
 
 export const valueSearchEntityPlugin = {
 	type: 'value',
-	buildDescriptors(input) {
-		return input.optionalRows.userValueRows.flatMap((row) => {
-			if (parseIntegrationValueName(row.name)) return []
-			return [
-				{
-					type: 'value',
-					id: buildValueEntityId(row),
-					title: row.name,
-					primaryAliases: [row.name],
-					secondaryAliases: [row.description, row.scope],
-					tertiaryAliases: [row.value],
-				},
-			]
-		})
+	buildValueRowDescriptor(row) {
+		if (parseIntegrationValueName(row.name)) return undefined
+		return {
+			type: 'value',
+			id: buildValueEntityId(row),
+			title: row.name,
+			primaryAliases: [row.name],
+			secondaryAliases: [row.description, row.scope],
+			tertiaryAliases: [row.value],
+		}
 	},
 	buildCandidates(input) {
 		return input.optionalRows.userValueRows

--- a/packages/worker/src/mcp/tools/search-entity-registry.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-entity-registry.node.test.ts
@@ -7,7 +7,11 @@ import {
 	searchEntityPlugins,
 } from './search-entity-registry.ts'
 import { buildSearchableEntityDescriptors } from './search-descriptors.ts'
-import { type PackageSearchRow } from './search-types.ts'
+import {
+	type OptionalSearchRowsResult,
+	type PackageSearchRow,
+} from './search-types.ts'
+import { understandSearchQuery } from './understand-search-query.ts'
 
 function createPackageRow(): PackageSearchRow {
 	return {
@@ -182,4 +186,62 @@ test('descriptor seam follows registry order across entity modules', () => {
 		'github',
 		'weather_api_key',
 	])
+})
+
+test('value-backed descriptors preserve source order and integration affinity', () => {
+	const userValueRows = [
+		{
+			userId: 'user-1',
+			name: buildIntegrationValueName('github'),
+			value: JSON.stringify({
+				name: 'github',
+				tokenUrl: 'https://github.com/login/oauth/access_token',
+				apiBaseUrl: 'https://api.github.com',
+				flow: 'confidential',
+				clientIdValueName: 'github_client_id',
+				clientSecretSecretName: 'github_client_secret',
+				accessTokenSecretName: 'github_access_token',
+			}),
+			description: 'GitHub integration',
+			scope: 'user' as const,
+			appId: null,
+			ttlMs: null,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		},
+		...Array.from({ length: 8 }, (_, index) => ({
+			userId: 'user-1',
+			name: `github_value_${index}`,
+			value: `github value ${index}`,
+			description: 'GitHub preference',
+			scope: 'user' as const,
+			appId: null,
+			ttlMs: null,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		})),
+	] satisfies OptionalSearchRowsResult['userValueRows']
+	const descriptors = buildSearchableEntityDescriptors({
+		registry: { capabilitySpecs: {} } as never,
+		optionalRows: {
+			packageRows: [],
+			userSecretRows: [],
+			userValueRows,
+		},
+	})
+
+	expect(descriptors.map((descriptor) => descriptor.type)).toEqual([
+		'integration',
+		...Array.from({ length: 8 }, () => 'value'),
+	])
+
+	const intent = understandSearchQuery({
+		query: 'github',
+		entities: descriptors,
+	})
+	expect(intent.entities).toHaveLength(8)
+	expect(intent.entities[0]).toMatchObject({
+		type: 'integration',
+		id: 'github',
+	})
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve interleaved value/integration descriptor ordering after the search entity plugin refactor
- prevent tied descriptor truncation from dropping integration affinity
- add regression coverage with eight same-token values plus an integration

## Context
Follow-up to #888 from the manual AI review sweep.

## Validation
- focused tests: 3/3 passed
- `npm run validate`: passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86ea396d-daa7-46f3-8f74-83eed4822b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86ea396d-daa7-46f3-8f74-83eed4822b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

