### PR TITLE
Enable Workers automatic tracing (OTel) and document OTLP export to Sentry

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -224,13 +224,14 @@ span is attributed to that span. Custom spans are available via
 `tracing.enterSpan()` from `cloudflare:workers` when application-level spans are
 worth adding.
 
-Traces (and logs) can additionally be exported to any OTLP endpoint — Sentry
-included — by creating an account-level destination in the Cloudflare dashboard
-and referencing it from `observability.traces.destinations`; the manual
-dashboard step is documented in [setup-manifest.md](../setup-manifest.md). Once
-Sentry ingests the exported OTLP traces, set `SENTRY_TRACES_SAMPLE_RATE=0` so
-the in-Worker Sentry SDK stops producing a second, duplicate set of traces
-(error capture is unaffected by the traces sample rate).
+Traces are additionally exported to Sentry: `observability.traces.destinations`
+references the account-level `sentry-otlp-traces` destination (Workers
+Observability → Destinations), which points at the `kody-cloudflare` Sentry
+project's OTLP endpoint. Destination provisioning (including for forks) is
+documented in [setup-manifest.md](../setup-manifest.md). Once Sentry ingests the
+exported OTLP traces, set `SENTRY_TRACES_SAMPLE_RATE=0` so the in-Worker Sentry
+SDK stops producing a second, duplicate set of traces (error capture is
+unaffected by the traces sample rate).
 
 Billing note: each span is one observability event sharing the Workers Logs
 quota (10M events/month included on Workers Paid). Sampling is controlled by

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -224,16 +224,13 @@ span is attributed to that span. Custom spans are available via
 `tracing.enterSpan()` from `cloudflare:workers` when application-level spans are
 worth adding.
 
-Production traces are additionally exported to Sentry: the production
-environment's `observability.traces.destinations` references the account-level
-`sentry-otlp-traces` destination (Workers Observability → Destinations), which
-points at the `kody-cloudflare` Sentry project's OTLP endpoint. Preview and test
-deploys inherit the top-level block without a destination, so their spans stay
-in the Cloudflare dashboard. Destination provisioning (including for forks) is
-documented in [setup-manifest.md](../setup-manifest.md). Once Sentry ingests the
-exported OTLP traces, set `SENTRY_TRACES_SAMPLE_RATE=0` so the in-Worker Sentry
-SDK stops producing a second, duplicate set of traces (error capture is
-unaffected by the traces sample rate).
+Production deploys additionally export these traces to Sentry through the
+account-level `sentry-otlp-traces` destination; preview and test deploys inherit
+the top-level block without a destination, so their spans stay in the Cloudflare
+dashboard. The destination itself (endpoint, auth header, fork provisioning) is
+documented in [setup-manifest.md](../setup-manifest.md), and the
+`SENTRY_TRACES_SAMPLE_RATE=0` follow-up that avoids duplicate SDK traces in
+[environment-variables.md](../environment-variables.md).
 
 Billing note: each span is one observability event sharing the Workers Logs
 quota (10M events/month included on Workers Paid). Sampling is controlled by

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -177,7 +177,7 @@ Full page navigations occur for:
 This keeps cross-origin behavior narrow while allowing same-origin browser and
 API requests.
 
-## Observability (Sentry)
+## Observability (Sentry and Workers tracing)
 
 The Worker default export is wrapped with `Sentry.withSentry` from
 `@sentry/cloudflare` (see `packages/worker/src/index.ts`) so incoming `fetch`
@@ -211,6 +211,31 @@ MCP tools emit structured `mcp-event` logs via
 `packages/worker/src/mcp/observability.ts`. On failures, the same module sends
 Sentry events (with MCP tags and context); sandbox user-code failures are
 reported at **warning** severity, while capability handler bugs use **error**.
+
+### Workers native tracing (OpenTelemetry)
+
+`packages/worker/wrangler.jsonc` also enables
+[Workers automatic tracing](https://developers.cloudflare.com/workers/observability/traces/)
+(`observability.traces.enabled`, beta). The runtime emits OTel-standard spans
+for handler invocations, outbound fetches, and binding calls (D1, KV, R2,
+Durable Objects, queues) with no SDK in the bundle; traces appear in the Workers
+Observability dashboard next to Workers Logs, and `console.*` output inside a
+span is attributed to that span. Custom spans are available via
+`tracing.enterSpan()` from `cloudflare:workers` when application-level spans are
+worth adding.
+
+Traces (and logs) can additionally be exported to any OTLP endpoint — Sentry
+included — by creating an account-level destination in the Cloudflare dashboard
+and referencing it from `observability.traces.destinations`; the manual
+dashboard step is documented in [setup-manifest.md](../setup-manifest.md). Once
+Sentry ingests the exported OTLP traces, set `SENTRY_TRACES_SAMPLE_RATE=0` so
+the in-Worker Sentry SDK stops producing a second, duplicate set of traces
+(error capture is unaffected by the traces sample rate).
+
+Billing note: each span is one observability event sharing the Workers Logs
+quota (10M events/month included on Workers Paid). Sampling is controlled by
+`observability.traces.head_sampling_rate` (defaults to full sampling, fine at
+current traffic).
 
 ### Source maps
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -224,10 +224,12 @@ span is attributed to that span. Custom spans are available via
 `tracing.enterSpan()` from `cloudflare:workers` when application-level spans are
 worth adding.
 
-Traces are additionally exported to Sentry: `observability.traces.destinations`
-references the account-level `sentry-otlp-traces` destination (Workers
-Observability → Destinations), which points at the `kody-cloudflare` Sentry
-project's OTLP endpoint. Destination provisioning (including for forks) is
+Production traces are additionally exported to Sentry: the production
+environment's `observability.traces.destinations` references the account-level
+`sentry-otlp-traces` destination (Workers Observability → Destinations), which
+points at the `kody-cloudflare` Sentry project's OTLP endpoint. Preview and test
+deploys inherit the top-level block without a destination, so their spans stay
+in the Cloudflare dashboard. Destination provisioning (including for forks) is
 documented in [setup-manifest.md](../setup-manifest.md). Once Sentry ingests the
 exported OTLP traces, set `SENTRY_TRACES_SAMPLE_RATE=0` so the in-Worker Sentry
 SDK stops producing a second, duplicate set of traces (error capture is

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -60,7 +60,10 @@ Optional Worker secret and vars (see `packages/worker/src/env-schema.ts` and
 - `SENTRY_ENVIRONMENT` — also set as a Wrangler `var` per environment in
   `packages/worker/wrangler.jsonc` for deploys.
 - `SENTRY_TRACES_SAMPLE_RATE` — optional `0`–`1`; defaults to **`1.0`** (sample
-  all traces). Set lower (e.g. `0.1`) for higher traffic or Sentry quota.
+  all traces). Set lower (e.g. `0.1`) for higher traffic or Sentry quota. Set to
+  `0` once Cloudflare's OTLP trace export into Sentry is active (see
+  `docs/contributing/setup-manifest.md`) so the SDK does not produce duplicate
+  traces; error reporting is unaffected.
 
 ## MCP `execute` and outbound HTTP
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -61,6 +61,23 @@ This project uses the following resources:
   - Production and preview route embedding calls through this binding. When
     `AI_GATEWAY_ID` is configured, calls are sent through AI Gateway via the
     Workers AI binding options.
+- Workers Observability OTLP destination (optional, manual dashboard step)
+  - Workers automatic tracing is enabled via `observability.traces` in
+    `packages/worker/wrangler.jsonc`; traces are viewable in the Workers
+    Observability dashboard with no further setup.
+  - To also export traces to Sentry (or another OTLP backend): in the Cloudflare
+    dashboard go to **Workers Observability → Destinations** and create a
+    **Traces** destination. For Sentry, the endpoint is
+    `https://<HOST>/api/<PROJECT_ID>/integration/otlp/v1/traces` with the
+    Sentry-provided auth header (see the Sentry project's OTLP settings).
+  - Then reference the destination by name from
+    `observability.traces.destinations` in `packages/worker/wrangler.jsonc` (a
+    commented `"destinations"` line marks the spot). Do not commit a destination
+    name before the dashboard destination exists — deploys can fail on unknown
+    destinations.
+  - Once Sentry ingests exported OTLP traces, set the Worker secret
+    `SENTRY_TRACES_SAMPLE_RATE=0` so the in-Worker Sentry SDK stops emitting a
+    duplicate set of traces (error reporting is unaffected).
 
 The checked-in
 [`packages/worker/wrangler.jsonc`](../../packages/worker/wrangler.jsonc)

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -61,19 +61,22 @@ This project uses the following resources:
   - Production and preview route embedding calls through this binding. When
     `AI_GATEWAY_ID` is configured, calls are sent through AI Gateway via the
     Workers AI binding options.
-- Workers Observability OTLP destination (optional, manual dashboard step)
+- Workers Observability OTLP destination (account-level)
   - Workers automatic tracing is enabled via `observability.traces` in
     `packages/worker/wrangler.jsonc`; traces are viewable in the Workers
     Observability dashboard with no further setup.
-  - To also export traces to Sentry (or another OTLP backend): in the Cloudflare
-    dashboard go to **Workers Observability → Destinations** and create a
-    **Traces** destination. For Sentry, the endpoint is
-    `https://<HOST>/api/<PROJECT_ID>/integration/otlp/v1/traces` with the
-    Sentry-provided auth header (see the Sentry project's OTLP settings).
-  - Then reference the destination by name from
-    `observability.traces.destinations` in `packages/worker/wrangler.jsonc` (a
-    commented `"destinations"` line marks the spot). Do not commit a destination
-    name before the dashboard destination exists — deploys can fail on unknown
+  - Traces are additionally exported to Sentry through the account-level
+    **Traces** destination `sentry-otlp-traces`, referenced from
+    `observability.traces.destinations`. In the production Cloudflare account it
+    points at the `kody-cloudflare` Sentry project's OTLP endpoint
+    (`https://<HOST>/api/<PROJECT_ID>/integration/otlp/v1/traces` with the
+    `x-sentry-auth: sentry sentry_key=<public key>` header derived from the
+    project DSN).
+  - Forks must create their own destination (dashboard: **Workers Observability
+    → Destinations**, or API:
+    `POST /accounts/{account_id}/workers/observability/destinations` with
+    `configuration.logpushDataset: "opentelemetry-traces"`) under the same name,
+    or remove the `destinations` line — deploys can fail on unknown
     destinations.
   - Once Sentry ingests exported OTLP traces, set the Worker secret
     `SENTRY_TRACES_SAMPLE_RATE=0` so the in-Worker Sentry SDK stops emitting a

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -65,19 +65,36 @@ This project uses the following resources:
   - Workers automatic tracing is enabled via `observability.traces` in
     `packages/worker/wrangler.jsonc`; traces are viewable in the Workers
     Observability dashboard with no further setup.
-  - Traces are additionally exported to Sentry through the account-level
-    **Traces** destination `sentry-otlp-traces`, referenced from
-    `observability.traces.destinations`. In the production Cloudflare account it
-    points at the `kody-cloudflare` Sentry project's OTLP endpoint
-    (`https://<HOST>/api/<PROJECT_ID>/integration/otlp/v1/traces` with the
-    `x-sentry-auth: sentry sentry_key=<public key>` header derived from the
+  - Production traces are additionally exported to Sentry through the
+    account-level **Traces** destination `sentry-otlp-traces`, referenced from
+    `observability.traces.destinations` in the **production** environment only
+    (preview and test deploys keep dashboard-only tracing). In the production
+    Cloudflare account it points at the `kody-cloudflare` Sentry project's OTLP
+    endpoint (`https://<HOST>/api/<PROJECT_ID>/integration/otlp/v1/traces` with
+    the `x-sentry-auth: sentry sentry_key=<public key>` header derived from the
     project DSN).
-  - Forks must create their own destination (dashboard: **Workers Observability
-    → Destinations**, or API:
-    `POST /accounts/{account_id}/workers/observability/destinations` with
-    `configuration.logpushDataset: "opentelemetry-traces"`) under the same name,
-    or remove the `destinations` line — deploys can fail on unknown
-    destinations.
+  - Forks must create their own destination under the same name, or remove the
+    `destinations` line — deploys can fail on unknown destinations. Create it in
+    the dashboard (**Workers Observability → Destinations**, type Traces) or via
+    the API:
+
+    ```sh
+    curl -X POST \
+      "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/workers/observability/destinations" \
+      -H "Authorization: Bearer <API_TOKEN>" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "name": "sentry-otlp-traces",
+        "enabled": true,
+        "configuration": {
+          "type": "logpush",
+          "logpushDataset": "opentelemetry-traces",
+          "url": "https://<HOST>/api/<PROJECT_ID>/integration/otlp/v1/traces",
+          "headers": { "x-sentry-auth": "sentry sentry_key=<public key>" }
+        }
+      }'
+    ```
+
   - Once Sentry ingests exported OTLP traces, set the Worker secret
     `SENTRY_TRACES_SAMPLE_RATE=0` so the in-Worker Sentry SDK stops emitting a
     duplicate set of traces (error reporting is unaffected).

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -95,9 +95,9 @@ This project uses the following resources:
       }'
     ```
 
-  - Once Sentry ingests exported OTLP traces, set the Worker secret
-    `SENTRY_TRACES_SAMPLE_RATE=0` so the in-Worker Sentry SDK stops emitting a
-    duplicate set of traces (error reporting is unaffected).
+  - Once Sentry ingests exported OTLP traces, set `SENTRY_TRACES_SAMPLE_RATE=0`
+    to avoid duplicate SDK traces; see
+    [environment-variables.md](./environment-variables.md).
 
 The checked-in
 [`packages/worker/wrangler.jsonc`](../../packages/worker/wrangler.jsonc)

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -90,6 +90,20 @@
 
 	"observability": {
 		"enabled": true,
+		// Workers automatic tracing (beta): OTel-standard spans for handler
+		// invocations, outbound fetches, and binding calls (D1, KV, R2, DO,
+		// queues). Spans share the Workers Logs event quota. Inherited by all
+		// environments; local dev and tests ignore it.
+		"traces": {
+			"enabled": true,
+			// To export traces to Sentry (or any OTLP endpoint), create a
+			// Traces destination in the Cloudflare dashboard (Workers
+			// Observability -> Destinations) and reference it here by name.
+			// Referencing a destination that does not exist yet can break
+			// deploys, so only uncomment after the dashboard step. See
+			// docs/contributing/setup-manifest.md.
+			// "destinations": ["sentry-otlp-traces"],
+		},
 	},
 	"triggers": {
 		"crons": ["*/5 * * * *"],

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -96,13 +96,13 @@
 		// environments; local dev and tests ignore it.
 		"traces": {
 			"enabled": true,
-			// To export traces to Sentry (or any OTLP endpoint), create a
-			// Traces destination in the Cloudflare dashboard (Workers
-			// Observability -> Destinations) and reference it here by name.
-			// Referencing a destination that does not exist yet can break
-			// deploys, so only uncomment after the dashboard step. See
-			// docs/contributing/setup-manifest.md.
-			// "destinations": ["sentry-otlp-traces"],
+			// Account-level OTLP export destination (Workers Observability ->
+			// Destinations). "sentry-otlp-traces" exists in the production
+			// Cloudflare account and points at the kody-cloudflare Sentry
+			// project's OTLP traces endpoint. The destination must exist in
+			// the target account before deploy; forks should create their own
+			// or remove this line. See docs/contributing/setup-manifest.md.
+			"destinations": ["sentry-otlp-traces"],
 		},
 	},
 	"triggers": {

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -93,16 +93,11 @@
 		// Workers automatic tracing (beta): OTel-standard spans for handler
 		// invocations, outbound fetches, and binding calls (D1, KV, R2, DO,
 		// queues). Spans share the Workers Logs event quota. Inherited by all
-		// environments; local dev and tests ignore it.
+		// environments unless overridden; local dev and tests ignore it. The
+		// production env overrides this block to add the Sentry OTLP export
+		// destination, so preview spans stay in the Cloudflare dashboard only.
 		"traces": {
 			"enabled": true,
-			// Account-level OTLP export destination (Workers Observability ->
-			// Destinations). "sentry-otlp-traces" exists in the production
-			// Cloudflare account and points at the kody-cloudflare Sentry
-			// project's OTLP traces endpoint. The destination must exist in
-			// the target account before deploy; forks should create their own
-			// or remove this line. See docs/contributing/setup-manifest.md.
-			"destinations": ["sentry-otlp-traces"],
 		},
 	},
 	"triggers": {
@@ -110,6 +105,21 @@
 	},
 	"env": {
 		"production": {
+			// Replaces the top-level observability block (wrangler env keys
+			// override wholesale, so "enabled" is restated): same tracing,
+			// plus the account-level Sentry OTLP export destination
+			// "sentry-otlp-traces" (Workers Observability -> Destinations),
+			// which points at the kody-cloudflare Sentry project's OTLP
+			// traces endpoint. The destination must exist in the target
+			// account before deploy; forks create their own or remove it.
+			// See docs/contributing/setup-manifest.md.
+			"observability": {
+				"enabled": true,
+				"traces": {
+					"enabled": true,
+					"destinations": ["sentry-otlp-traces"],
+				},
+			},
 			"worker_loaders": [
 				{
 					"binding": "LOADER",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Enables [Workers automatic tracing](https://developers.cloudflare.com/workers/observability/traces/) (beta) via `observability.traces.enabled` in `packages/worker/wrangler.jsonc`. The runtime emits OTel-standard spans for handler invocations, outbound fetches, and binding calls (D1, KV, R2, Durable Objects, queues) with no SDK added to the bundle. Traces land in the Workers Observability dashboard next to the existing Workers Logs, and `console.*` output inside a span is attributed to that span.
- Exports **production** traces to Sentry: the production environment's `observability.traces.destinations` references the account-level `sentry-otlp-traces` destination, which was created via the Cloudflare API (`POST /accounts/{id}/workers/observability/destinations`, dataset `opentelemetry-traces`) and points at the `kody-cloudflare` Sentry project's OTLP traces endpoint with the `x-sentry-auth` header derived from the project DSN. Preview/test deploys inherit the top-level block without a destination, so their spans stay dashboard-only.
- Docs: `request-lifecycle.md` gains a "Workers native tracing (OpenTelemetry)" section (billing/sampling notes included), `setup-manifest.md` is the canonical destination/provisioning reference (with the full API payload forks need), and `environment-variables.md` canonically documents the `SENTRY_TRACES_SAMPLE_RATE=0` follow-up that avoids duplicate SDK traces. The other pages link out instead of restating, per the docs gardening principle.

## Why

Kody had no OpenTelemetry story: observability was Sentry SDK tracing, Workers Logs, structured `mcp-event` lines, and Analytics Engine usage metering. Native tracing adds request-flow visibility across the DO/D1/queue fan-out with zero runtime dependencies, and the OTLP export lands the same traces in Sentry alongside existing error reports.

## Notes

- Wrangler env `observability` overrides the top-level key wholesale, so the production block restates `enabled: true`. Local dev and tests ignore observability config. The CI-generated production/preview configs are parsed from this file with only resource IDs rewritten, so the block carries through (`tools/ci/resource-utils.ts`, `writeGeneratedWranglerConfig`).
- Spans share the Workers Logs event quota (10M/month included on Workers Paid); `head_sampling_rate` defaults to full sampling, fine at current traffic.
- Follow-up after export delivery is confirmed: set `SENTRY_TRACES_SAMPLE_RATE=0` to stop duplicate SDK traces.

## Verification

- `npx wrangler deploy --dry-run` passes for both `production` and `preview` envs.
- `npm run validate` passed in full (format, lint, typecheck, unit, Playwright E2E, MCP E2E, structure checks); pre-push re-ran 1289 unit tests + 18 E2E on each commit: green.
- Destination verified live via `GET /accounts/{id}/workers/observability/destinations`: `sentry-otlp-traces`, dataset `opentelemetry-traces`, enabled.
- CodeRabbit feedback addressed: export scoped to production only; fork docs now include the full destination-creation payload.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `a73035bc` · **Head:** `6e84d3e8`

**Classification:** composes — no primitives added or changed. The diff touches only Worker platform configuration (`packages/worker/wrangler.jsonc`) and contributor docs; the primitives classifier matches zero primitives. Runtime code paths are unchanged. The paired infrastructure change (the `sentry-otlp-traces` OTLP destination) lives in the Cloudflare account, not the repo.

### Primitives touched

None — platform tracing is enabled in wrangler config and instrumented by the Workers runtime itself; no application primitive changes behavior.

### Before / after

```jsonc
// packages/worker/wrangler.jsonc — before
"observability": { "enabled": true }

// after (top level; inherited by preview/test)
"observability": {
	"enabled": true,
	"traces": { "enabled": true },
}

// after (env.production override)
"observability": {
	"enabled": true,
	"traces": {
		"enabled": true,
		"destinations": ["sentry-otlp-traces"], // account-level OTLP export → Sentry
	},
}
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72eb9618-ed14-47ce-9951-b3ebac70837c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72eb9618-ed14-47ce-9951-b3ebac70837c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Workers native tracing (OpenTelemetry) and documented automatic span coverage, including attribution for `console.*` output and export to Sentry via an account-level OTLP destination.

* **Documentation**
  * Expanded observability/tracing documentation to cover Workers tracing and production-only export behavior.
  * Updated `SENTRY_TRACES_SAMPLE_RATE` guidance to prevent duplicate in-Worker trace emission after OTLP export is active (errors unaffected).
  * Added/clarified setup-manifest instructions for provisioning the OTLP destination and handling fork deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->