### PR TITLE
Attach user context to traces and Sentry errors

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -222,7 +222,11 @@ Durable Objects, queues) with no SDK in the bundle; traces appear in the Workers
 Observability dashboard next to Workers Logs, and `console.*` output inside a
 span is attributed to that span. Custom spans are available via
 `tracing.enterSpan()` from `cloudflare:workers` when application-level spans are
-worth adding.
+worth adding. App-level context rides on two hooks: every metered usage event
+emits a `kody.usage.{eventType}` child span with `kody.user_id` and entity
+attributes (see [usage-metering.md](./usage-metering.md)), and Sentry error
+events carry the signed-in user id (id only, no PII) via `Sentry.setUser` in the
+app auth resolver and the MCP failure reporter.
 
 Production deploys additionally export these traces to Sentry through the
 account-level `sentry-otlp-traces` destination; preview and test deploys inherit

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -155,6 +155,12 @@ Guarantees and rules:
 - `recordUsage` **never throws and never rejects.** Metering must not break the
   path it observes. Sink failures are logged at warn level; expected local-dev
   degradation is logged at debug level.
+- Every recorded event also emits a `kody.usage.{eventType}` **trace span**
+  (when Workers tracing is available) with `kody.user_id`, `kody.event_type`,
+  `kody.outcome`, and the optional `kody.entity_id` / `kody.duration_ms` /
+  `kody.bytes` attributes. It nests under the active platform span, so traces
+  become searchable by user and feature with no chokepoint changes. Span
+  emission follows the same never-throws contract.
 - It accepts any object with optional `USAGE_EVENTS` / `APP_DB` bindings
   (`UsageEnv`), so the full `Env` can be passed directly.
 - **Graceful degradation:** in local dev and tests where the Analytics Engine

--- a/packages/worker/src/app/request-auth-cache.ts
+++ b/packages/worker/src/app/request-auth-cache.ts
@@ -8,6 +8,7 @@
  * revocation hooks on every auth mutation path.
  */
 
+import * as Sentry from '@sentry/cloudflare'
 import {
 	destroyAuthCookie,
 	isSecureRequest,
@@ -94,6 +95,15 @@ async function resolveRequestAuth(
 		email: userRecord.email,
 		username: userRecord.username,
 	})
+
+	// Associate uncaught request errors with the signed-in user in Sentry.
+	// Id only: sendDefaultPii is false and emails stay out of Sentry. Must
+	// never break auth resolution.
+	try {
+		if (Sentry.isInitialized()) Sentry.setUser({ id: stableUserId })
+	} catch {
+		// Observability must not affect auth.
+	}
 
 	return {
 		sessionUserId: session.id,

--- a/packages/worker/src/mcp/capabilities/define-capability.ts
+++ b/packages/worker/src/mcp/capabilities/define-capability.ts
@@ -71,7 +71,9 @@ export function defineCapability<
 			: {}),
 		async handler(args, ctx) {
 			const startedAt = performance.now()
-			const { baseUrl, hasUser } = callerContextFields(ctx.callerContext)
+			const { baseUrl, hasUser, userId } = callerContextFields(
+				ctx.callerContext,
+			)
 			await assertCallerCanAccessCapability(ctx.callerContext, definition, {
 				env: ctx.env,
 			})
@@ -91,6 +93,7 @@ export function defineCapability<
 					durationMs: Math.round(performance.now() - startedAt),
 					baseUrl,
 					hasUser,
+					userId,
 					failurePhase: 'parse_input',
 					errorName,
 					errorMessage,
@@ -114,6 +117,7 @@ export function defineCapability<
 					durationMs: Math.round(performance.now() - startedAt),
 					baseUrl,
 					hasUser,
+					userId,
 					failurePhase: 'handler',
 					errorName,
 					errorMessage,
@@ -134,6 +138,7 @@ export function defineCapability<
 					durationMs: Math.round(performance.now() - startedAt),
 					baseUrl,
 					hasUser,
+					userId,
 				})
 				return finalized
 			} catch (error) {
@@ -148,6 +153,7 @@ export function defineCapability<
 					durationMs: Math.round(performance.now() - startedAt),
 					baseUrl,
 					hasUser,
+					userId,
 					failurePhase: 'parse_output',
 					errorName,
 					errorMessage,

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -16,6 +16,8 @@ export type McpObservabilityPayload = {
 	durationMs: number
 	baseUrl: string
 	hasUser: boolean
+	/** Stable user id of the caller, when authenticated. */
+	userId?: string
 	failurePhase?: McpFailurePhase
 	sandboxError?: boolean
 	registeredCapabilityCount?: number
@@ -36,6 +38,7 @@ export function callerContextFields(context: McpCallerContext) {
 	return {
 		baseUrl: context.baseUrl,
 		hasUser: context.user != null,
+		userId: context.user?.userId,
 		storageContext: context.storageContext ?? null,
 	}
 }
@@ -62,6 +65,9 @@ function reportMcpFailureToSentry(
 		Sentry.withScope((scope) => {
 			const level = payload.sandboxError ? 'warning' : 'error'
 			scope.setLevel(level)
+
+			// Id only: sendDefaultPii is false and emails stay out of Sentry.
+			if (payload.userId) scope.setUser({ id: payload.userId })
 
 			scope.setTag('mcp.tool', payload.tool)
 			if (payload.toolName) scope.setTag('mcp.tool_name', payload.toolName)

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -1,7 +1,11 @@
 import { expect, test, vi } from 'vitest'
 import { getStaticRegistry } from '#mcp/capabilities/registry.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
-import { errorFields, logMcpEvent } from '#mcp/observability.ts'
+import {
+	callerContextFields,
+	errorFields,
+	logMcpEvent,
+} from '#mcp/observability.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 
 const repoMockModule = vi.hoisted(() => ({
@@ -127,6 +131,48 @@ test('observability helpers normalize errors and emit resilient mcp-event logs',
 		console.info = originalInfo
 		console.warn = originalWarn
 	}
+})
+
+test('callerContextFields exposes the caller user id and logMcpEvent serializes it', () => {
+	expect(
+		callerContextFields({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User One',
+			},
+		}),
+	).toMatchObject({
+		baseUrl: 'https://example.com',
+		hasUser: true,
+		userId: 'user-1',
+	})
+	expect(
+		callerContextFields({ baseUrl: 'https://example.com', user: null }),
+	).toMatchObject({ hasUser: false, userId: undefined })
+
+	const originalInfo = console.info
+	let jsonArg: unknown
+	console.info = ((_tag: unknown, json?: unknown) => {
+		jsonArg = json
+	}) as typeof console.info
+	try {
+		logMcpEvent({
+			category: 'mcp',
+			tool: 'capability',
+			capabilityName: 'value_get',
+			outcome: 'success',
+			durationMs: 5,
+			baseUrl: 'https://example.com',
+			hasUser: true,
+			userId: 'user-1',
+		})
+	} finally {
+		console.info = originalInfo
+	}
+	const parsed = JSON.parse(jsonArg as string) as Record<string, unknown>
+	expect(parsed.userId).toBe('user-1')
 })
 
 test('package_save logs parse failures, rejects invalid manifests, and logs successful saves', async () => {

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -145,7 +145,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				},
 			}
 			const resolvedConversationId = resolveConversationId(conversationId)
-			const { baseUrl, hasUser, storageContext } =
+			const { baseUrl, hasUser, userId, storageContext } =
 				callerContextFields(callerContext)
 			const activeStorageId = storageContext?.storageId ?? null
 			try {
@@ -165,6 +165,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					durationMs: timing.durationMs,
 					baseUrl,
 					hasUser,
+					userId,
 					sandboxError: false,
 					errorName,
 					errorMessage,
@@ -276,6 +277,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						durationMs,
 						baseUrl,
 						hasUser,
+						userId,
 						registeredCapabilityCount,
 						sandboxError: true,
 						errorName,
@@ -316,6 +318,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					durationMs,
 					baseUrl,
 					hasUser,
+					userId,
 					registeredCapabilityCount,
 					sandboxError: false,
 					context: activeStorageId ? { storageId: activeStorageId } : undefined,

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -55,8 +55,12 @@ export async function runSearchTool(input: {
 	const timingStart = startToolTiming()
 	const conversationId = resolveConversationId(args.conversationId)
 	const callerContext = agent.getCallerContext()
-	const { baseUrl, hasUser } = callerContextFields(callerContext)
-	const userId = callerContext.user?.userId ?? null
+	const {
+		baseUrl,
+		hasUser,
+		userId: callerUserId,
+	} = callerContextFields(callerContext)
+	const userId = callerUserId ?? null
 	const includeHiddenPackages = !!args.includeHiddenPackages
 	const domainFilter = args.domain?.trim() || undefined
 	// Whitespace-only queries stay valid (memory enrichment may still run) but
@@ -72,6 +76,7 @@ export async function runSearchTool(input: {
 			durationMs: timing.durationMs,
 			baseUrl,
 			hasUser,
+			userId: userId ?? undefined,
 			sandboxError: false,
 			errorName: 'ValidationError',
 			errorMessage: 'Provide "query", "entity", or "domain".',
@@ -252,6 +257,7 @@ export async function runSearchTool(input: {
 				durationMs: timing.durationMs,
 				baseUrl,
 				hasUser,
+				userId: userId ?? undefined,
 			})
 			return {
 				content: prependToolMetadataContent(conversationId, [
@@ -322,6 +328,7 @@ export async function runSearchTool(input: {
 				durationMs: timing.durationMs,
 				baseUrl,
 				hasUser,
+				userId: userId ?? undefined,
 				...(allFailed
 					? {
 							sandboxError: false,
@@ -465,6 +472,7 @@ export async function runSearchTool(input: {
 			durationMs: timing.durationMs,
 			baseUrl,
 			hasUser,
+			userId: userId ?? undefined,
 			message: 'Search completed successfully.',
 			context: {
 				task: execution.result.intent.task.name,
@@ -506,6 +514,7 @@ export async function runSearchTool(input: {
 			durationMs: timing.durationMs,
 			baseUrl,
 			hasUser,
+			userId: userId ?? undefined,
 			sandboxError: false,
 			errorName,
 			errorMessage,

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -16,17 +16,21 @@ vi.mock('@sentry/cloudflare', () => ({
 	) => durableObjectClass,
 }))
 
-vi.mock('cloudflare:workers', () => ({
-	DurableObject: class {
-		protected readonly ctx: DurableObjectState
-		protected readonly env: Env
+vi.mock('cloudflare:workers', async (importOriginal) => {
+	const actual = await importOriginal<Record<string, unknown>>()
+	return {
+		...actual,
+		DurableObject: class {
+			protected readonly ctx: DurableObjectState
+			protected readonly env: Env
 
-		constructor(ctx: DurableObjectState, env: Env) {
-			this.ctx = ctx
-			this.env = env
-		}
-	},
-}))
+			constructor(ctx: DurableObjectState, env: Env) {
+				this.ctx = ctx
+				this.env = env
+			}
+		},
+	}
+})
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
 	getSavedPackageById: (...args: Array<unknown>) =>

--- a/packages/worker/src/test-support/cloudflare-workers-stub.ts
+++ b/packages/worker/src/test-support/cloudflare-workers-stub.ts
@@ -34,6 +34,35 @@ export class WorkflowEntrypoint<TEnv = unknown, TPayload = unknown> {
 
 export class RpcTarget {}
 
+type StubSpan = {
+	readonly isTraced: boolean
+	setAttribute(key: string, value?: boolean | number | string): void
+	end(): void
+}
+
+const stubSpan: StubSpan = {
+	isTraced: false,
+	setAttribute() {},
+	end() {},
+}
+
+export const tracing = {
+	enterSpan<T, A extends Array<unknown>>(
+		_name: string,
+		callback: (span: StubSpan, ...args: A) => T,
+		...args: A
+	): T {
+		return callback(stubSpan, ...args)
+	},
+	startActiveSpan<T, A extends Array<unknown>>(
+		_name: string,
+		callback: (span: StubSpan, ...args: A) => T,
+		...args: A
+	): T {
+		return callback(stubSpan, ...args)
+	},
+}
+
 export const exports = {
 	KodyFetchGateway() {
 		return async (request: Request) => fetch(request)

--- a/packages/worker/src/test-support/sentry-cloudflare-stub.ts
+++ b/packages/worker/src/test-support/sentry-cloudflare-stub.ts
@@ -2,6 +2,7 @@ type SentryScope = {
 	setLevel(_level: string): void
 	setTag(_key: string, _value: string): void
 	setContext(_key: string, _value: Record<string, unknown>): void
+	setUser(_user: Record<string, unknown> | null): void
 }
 
 type SentryClient = {
@@ -12,7 +13,10 @@ const defaultScope: SentryScope = {
 	setLevel() {},
 	setTag() {},
 	setContext() {},
+	setUser() {},
 }
+
+export function setUser(_user: Record<string, unknown> | null) {}
 
 export function isInitialized() {
 	return false

--- a/packages/worker/src/usage/record-usage.node.test.ts
+++ b/packages/worker/src/usage/record-usage.node.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+const spanCalls = vi.hoisted(() => ({
+	spans: [] as Array<{
+		name: string
+		attributes: Record<string, boolean | number | string | undefined>
+	}>,
+}))
+
+vi.mock('cloudflare:workers', () => ({
+	tracing: {
+		enterSpan(
+			name: string,
+			callback: (span: {
+				isTraced: boolean
+				setAttribute(key: string, value?: boolean | number | string): void
+				end(): void
+			}) => unknown,
+		) {
+			const attributes: Record<string, boolean | number | string | undefined> =
+				{}
+			spanCalls.spans.push({ name, attributes })
+			return callback({
+				isTraced: true,
+				setAttribute(key, value) {
+					attributes[key] = value
+				},
+				end() {},
+			})
+		},
+	},
+}))
+
+const { recordUsage } = await import('./record-usage.ts')
+
+beforeEach(() => {
+	spanCalls.spans.length = 0
+})
+
+test('recordUsage emits one kody.usage span with user and entity attributes', async () => {
+	await recordUsage(
+		{},
+		{
+			userId: 'user-1',
+			eventType: 'execute',
+			entityId: 'pkg-1',
+			durationMs: 120,
+			bytes: 512,
+			outcome: 'error',
+		},
+	)
+
+	expect(spanCalls.spans).toEqual([
+		{
+			name: 'kody.usage.execute',
+			attributes: {
+				'kody.user_id': 'user-1',
+				'kody.event_type': 'execute',
+				'kody.outcome': 'error',
+				'kody.entity_id': 'pkg-1',
+				'kody.duration_ms': 120,
+				'kody.bytes': 512,
+			},
+		},
+	])
+})
+
+test('recordUsage skips the span for events without a userId', async () => {
+	await recordUsage(
+		{},
+		{ userId: '', eventType: 'execute', outcome: 'success' },
+	)
+	expect(spanCalls.spans).toEqual([])
+})
+
+test('recordUsage omits optional attributes that were not measured', async () => {
+	await recordUsage(
+		{},
+		{ userId: 'user-2', eventType: 'job_run', outcome: 'success' },
+	)
+	expect(spanCalls.spans).toEqual([
+		{
+			name: 'kody.usage.job_run',
+			attributes: {
+				'kody.user_id': 'user-2',
+				'kody.event_type': 'job_run',
+				'kody.outcome': 'success',
+			},
+		},
+	])
+})

--- a/packages/worker/src/usage/record-usage.ts
+++ b/packages/worker/src/usage/record-usage.ts
@@ -21,7 +21,21 @@
  * paths it observes. In local dev and tests where a binding is missing it
  * degrades to a debug log. See
  * `docs/contributing/architecture/usage-metering.md`.
+ *
+ * Every recorded event also emits a `kody.usage.{eventType}` trace span (when
+ * Workers tracing is available) carrying the user id, entity id, and outcome
+ * as attributes. The chokepoints that meter usage are exactly the app-level
+ * units worth finding in traces, so this one funnel makes every trace
+ * searchable by user and feature without touching the chokepoints themselves.
  */
+
+import * as cloudflareWorkers from 'cloudflare:workers'
+
+// Older local runtimes (and the node test stub) may not expose `tracing`;
+// treat it as optional so metering keeps its never-throws contract.
+const runtimeTracing: typeof cloudflareWorkers.tracing | undefined = (
+	cloudflareWorkers as Partial<typeof cloudflareWorkers>
+).tracing
 
 export type UsageEventType =
 	| 'execute'
@@ -102,6 +116,7 @@ export async function recordUsage(
 			console.debug('usage-event-skipped', 'missing userId', event.eventType)
 			return
 		}
+		emitUsageSpan(event)
 		const timestamp = event.timestamp ?? new Date().toISOString()
 		if (env.USAGE_EVENTS) {
 			writeUsageDataPoint(env, event, timestamp)
@@ -111,6 +126,30 @@ export async function recordUsage(
 		await writeUsageRollup(env, event, timestamp)
 	} catch (error) {
 		console.warn('usage-event-record-failed', error)
+	}
+}
+
+/**
+ * Emit a marker span for one usage event, nested under whatever platform span
+ * is active in the current async context (HTTP handler, DO invocation, ...).
+ * When the invocation is not sampled, `enterSpan` still runs the callback but
+ * records nothing.
+ */
+function emitUsageSpan(event: UsageEvent) {
+	if (!runtimeTracing?.enterSpan) return
+	try {
+		runtimeTracing.enterSpan(`kody.usage.${event.eventType}`, (span) => {
+			span.setAttribute('kody.user_id', event.userId)
+			span.setAttribute('kody.event_type', event.eventType)
+			span.setAttribute('kody.outcome', event.outcome)
+			if (event.entityId) span.setAttribute('kody.entity_id', event.entityId)
+			if (event.durationMs != null) {
+				span.setAttribute('kody.duration_ms', event.durationMs)
+			}
+			if (event.bytes != null) span.setAttribute('kody.bytes', event.bytes)
+		})
+	} catch (error) {
+		console.debug('usage-span-failed', error)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Makes traces and error reports attributable to users and app-level features, following up on the OTel tracing rollout (#905, #906).

- **Usage spans**: `recordUsage` (`packages/worker/src/usage/record-usage.ts`) now emits a `kody.usage.{eventType}` trace span per metered event, nested under the active platform span, with `kody.user_id`, `kody.event_type`, `kody.outcome`, and optional `kody.entity_id` / `kody.duration_ms` / `kody.bytes` attributes. The metering chokepoints (execute, package export, job run, workflow run, service runtime, outbound fetch, email send/receive) are exactly the app-level units worth finding in traces, so this single funnel makes every trace searchable by user and feature without touching the chokepoints. Emission follows the same never-throws contract as metering, and guards for runtimes without `tracing`.
- **Sentry user on errors (id only, no PII; `sendDefaultPii` stays false)**:
  - MCP failures: `McpObservabilityPayload` gains `userId`, `callerContextFields` supplies it from the caller context, and `reportMcpFailureToSentry` sets `scope.setUser({ id })`. The `userId` also lands on the structured `mcp-event` log lines. Call sites in `define-capability.ts`, `execute.ts`, and `search-tool-runner.ts` pass it through.
  - App requests: `resolveRequestAuth` (`packages/worker/src/app/request-auth-cache.ts`) calls `Sentry.setUser({ id: stableUserId })` once per request after auth resolution, so uncaught app-route errors are user-attributed.
- Test stubs: `cloudflare-workers-stub.ts` gains a `tracing` stub; the Sentry stub gains `setUser`; `package-service.node.test.ts`'s module mock now spreads the original module.
- Docs: `usage-metering.md` documents the span contract; `request-lifecycle.md` points at both hooks.

## Why

Cloudflare's automatic tracing only knows platform operations — traces had no user or feature identity, and Sentry errors (reporting now enabled in production) had none either. Per-user isolation is the core invariant of this repo, which makes per-user traceability the natural debugging axis.

## Verification

- New `record-usage.node.test.ts` covers span emission, attribute shape, skip-on-missing-user, and optional-attribute omission (3 tests).
- `observability.workers.test.ts` extended for `callerContextFields` user id and payload serialization.
- Full pre-push suite green: 386 test files passed + all 18 Playwright E2E.
- `npm run typecheck` passes; real-workerd usage/observability suites pass (the `cloudflare:workers` namespace import with `tracing` access works in vitest-pool-workers).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends usage metering and MCP observability</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `66d6e32d` · **Head:** branch tip

**Classification:** extends — the usage-metering helper contract gains a span-emission side effect and the MCP observability payload gains a field; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `usage-metering` | platform | extends — `recordUsage` emits `kody.usage.*` spans |
| `mcp-server` | surfaces | extends — failure reports carry `scope.setUser`; `mcp-event` logs gain `userId` |
| `app-sessions` | auth | composes — per-request `Sentry.setUser` after auth resolution |

### System map

User identity flows from auth/caller context into trace spans and Sentry error scopes because of this PR.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged).

```mermaid
flowchart LR
	appSessions["app-sessions<br/>Browser sessions"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	usageMetering["usage-metering<br/>recordUsage()"]:::extended
	tracing["Workers tracing<br/>(platform)"]:::untouched
	sentry["Sentry<br/>(errors)"]:::untouched
	appSessions -->|"setUser({id}) after auth"| sentry
	mcpServer -->|"userId on mcp-event + failure scope"| sentry
	usageMetering -->|"kody.usage.* span with kody.user_id"| tracing
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user isolation is unaffected: user ids flow only into Kody's own telemetry (first-party spans/logs/Sentry), never across users. Only the stable user id is sent to Sentry — never email or display name.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72eb9618-ed14-47ce-9951-b3ebac70837c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72eb9618-ed14-47ce-9951-b3ebac70837c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Observability**
  * Improved tracing for usage events, including user, outcome, entity, duration, and byte details.
  * Added signed-in user context to error reports and MCP activity logs.
  * Usage tracking and observability continue working safely when tracing or error reporting is unavailable.
* **Documentation**
  * Clarified request tracing, usage metering, and error-reporting behavior.
* **Tests**
  * Added coverage for usage tracing, user context, and Cloudflare runtime stubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->