### PR TITLE
Add browser error capture and error-only session replay via same-origin Sentry tunnel

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -238,6 +238,21 @@ quota (10M events/month included on Workers Paid). Sampling is controlled by
 `observability.traces.head_sampling_rate` (defaults to full sampling, fine at
 current traffic).
 
+### Browser errors and session replay
+
+The client bundle initializes `@sentry/browser` from a `kody:sentry` meta tag
+that `ssr-document.tsx` renders when `SENTRY_DSN` is configured (the DSN is a
+publishable client key). Capture is errors plus **error-only Session Replay**:
+`replaysSessionSampleRate` is `0` and `replaysOnErrorSampleRate` is `1`, so
+nothing is recorded to Sentry unless an error occurs, and replays mask all text
+and block all media (`packages/worker/client/sentry-client.ts`) because Kody
+sessions contain personal content. Envelopes are sent through the same-origin
+`POST /sentry-tunnel` route
+(`packages/worker/src/app/handlers/sentry-tunnel.ts`), which only forwards
+envelopes whose DSN matches the Worker's own `SENTRY_DSN` — this keeps the
+first-party CSP at `connect-src 'self'`. The CSP allows `worker-src blob:` for
+the replay compression Web Worker.
+
 ### Source maps
 
 `packages/worker/wrangler.jsonc` sets

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -56,7 +56,10 @@ Optional Worker secret and vars (see `packages/worker/src/env-schema.ts` and
 
 - `SENTRY_DSN` — ingest URL from your Sentry project. When unset, the Worker
   skips `Sentry.withSentry`; Durable Objects use the same options builder and
-  will not send events without a DSN.
+  will not send events without a DSN. The DSN (a publishable client key) is also
+  exposed to the browser via the `kody:sentry` meta tag to enable client error
+  capture and error-only session replay through the same-origin `/sentry-tunnel`
+  route.
 - `SENTRY_ENVIRONMENT` — also set as a Wrangler `var` per environment in
   `packages/worker/wrangler.jsonc` for deploys.
 - `SENTRY_TRACES_SAMPLE_RATE` — optional `0`–`1`; defaults to **`1.0`** (sample

--- a/package-lock.json
+++ b/package-lock.json
@@ -4617,6 +4617,60 @@
       "version": "1.0.0-rc.15",
       "license": "MIT"
     },
+    "node_modules/@sentry/browser": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.68.0.tgz",
+      "integrity": "sha512-8xVgk7oG2lajXnbXF6a7H1xMZ/U6icqSldHGzQu1+bajfrK8Gan9ULG/Xsj1VM1LlNeK6/7znDJ3u1jgvIwznw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/feedback": "10.68.0",
+        "@sentry/replay": "10.68.0",
+        "@sentry/replay-canvas": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.68.0.tgz",
+      "integrity": "sha512-be8VtdjCngKc77cstJeV+gO15iH+blyXpBDk8yOehmtX4BkFO33mfTMNCWVR2LA0oOxjIHWRAhf77fIUEhzxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sentry/cli": {
       "version": "3.3.4",
       "dev": true,
@@ -4824,6 +4878,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sentry/feedback": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.68.0.tgz",
+      "integrity": "sha512-XbdcXiBnpC3vgw46eHOPeD/ZQ+XzluP75ubdUcaPDW02hCh2nsdXiwjZ2DBImbpvIpTbJgjHf/sIlHWvcZJ2Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sentry/node": {
       "version": "10.67.0",
       "license": "MIT",
@@ -4893,6 +4971,56 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.68.0.tgz",
+      "integrity": "sha512-ZoG2n16vbkx4GWSCnLIqUUN9xlUmccQFbQ2US2rhruQeHTUnHl/ukr8NHOQXZaEbwKyMkX9bEMwfmZHJm+wSTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.68.0.tgz",
+      "integrity": "sha512-HusYcr+He+ohnUDHunYrc5St6vdDnBXpUAndnT5ReyUMVSCiWKfY3paXowU/0787HwYfxdcpZgwC5u79+XbEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.68.0",
+        "@sentry/replay": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/server-utils": {
@@ -14898,6 +15026,7 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@remix-run/cookie": "^0.5.1",
         "@resvg/resvg-wasm": "^2.6.2",
+        "@sentry/browser": "^10.68.0",
         "@sentry/cloudflare": "^10.67.0",
         "@simplewebauthn/browser": "^13.3.0",
         "@simplewebauthn/server": "^13.3.2",

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -1,7 +1,13 @@
 import { run } from 'remix/ui'
 import { REMIX_FRAME_TARGET_HEADER } from '#app/frame-constants.ts'
 import { consumePrefetchedFrame } from '#client/frame-prefetch.ts'
+import {
+	captureClientException,
+	initSentryClient,
+} from '#client/sentry-client.ts'
 import { AppRoot, APP_ROOT_ENTRY_ID } from './app-root.tsx'
+
+initSentryClient(document)
 
 const clientRegistry: Record<string, typeof AppRoot> = {
 	AppRoot,
@@ -40,6 +46,7 @@ const app = run({
 
 app.addEventListener('error', (event) => {
 	console.error('Client hydration error:', event.error)
+	captureClientException(event.error)
 })
 
 void app.ready()

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -1,0 +1,60 @@
+import * as Sentry from '@sentry/browser'
+import {
+	parseSentryClientConfig,
+	SENTRY_CONFIG_META_NAME,
+} from '#client/sentry-config.ts'
+
+/**
+ * Browser-side Sentry: error capture plus error-only Session Replay.
+ *
+ * Privacy defaults are strict on purpose — Kody sessions contain personal
+ * assistant content (chats, email, secrets pages), so all text is masked and
+ * all media blocked in replays, no session-based recording happens (only the
+ * ~60s buffer around an error is uploaded), and no PII is attached. Envelopes
+ * go through the same-origin `/sentry-tunnel` route, so the first-party CSP
+ * (`connect-src 'self'`) stays unchanged.
+ *
+ * No-ops when the config meta tag is absent (local dev / tests without a
+ * DSN). Must never break app boot.
+ */
+export function initSentryClient(doc: Document) {
+	try {
+		const content = doc
+			.querySelector(`meta[name="${SENTRY_CONFIG_META_NAME}"]`)
+			?.getAttribute('content')
+		const config = parseSentryClientConfig(content)
+		if (!config) return false
+
+		Sentry.init({
+			dsn: config.dsn,
+			tunnel: config.tunnel,
+			environment: config.environment,
+			...(config.release ? { release: config.release } : {}),
+			sendDefaultPii: false,
+			integrations: [
+				Sentry.replayIntegration({
+					maskAllText: true,
+					blockAllMedia: true,
+				}),
+			],
+			// Error-only replays: nothing is recorded to Sentry for normal
+			// sessions; the in-memory buffer is uploaded only when an error
+			// happens.
+			replaysSessionSampleRate: 0,
+			replaysOnErrorSampleRate: 1.0,
+		})
+		return true
+	} catch (error) {
+		console.warn('sentry-client-init-failed', error)
+		return false
+	}
+}
+
+/** Report a caught client error without letting reporting itself throw. */
+export function captureClientException(error: unknown) {
+	try {
+		Sentry.captureException(error)
+	} catch {
+		// Reporting must never break the app.
+	}
+}

--- a/packages/worker/client/sentry-config.node.test.ts
+++ b/packages/worker/client/sentry-config.node.test.ts
@@ -47,4 +47,14 @@ test('rejects missing, malformed, or non-same-origin-tunnel configs', () => {
 			}),
 		),
 	).toBeNull()
+	// Scheme-relative URLs start with '/' but leave the origin.
+	expect(
+		parseSentryClientConfig(
+			JSON.stringify({
+				dsn: 'https://key@o1.ingest.sentry.io/2',
+				environment: 'production',
+				tunnel: '//evil.example.com/collect',
+			}),
+		),
+	).toBeNull()
 })

--- a/packages/worker/client/sentry-config.node.test.ts
+++ b/packages/worker/client/sentry-config.node.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest'
+import { parseSentryClientConfig } from './sentry-config.ts'
+
+test('parses a complete config and normalizes missing release to null', () => {
+	expect(
+		parseSentryClientConfig(
+			JSON.stringify({
+				dsn: 'https://key@o1.ingest.sentry.io/2',
+				environment: 'production',
+				release: 'abc123',
+				tunnel: '/sentry-tunnel',
+			}),
+		),
+	).toEqual({
+		dsn: 'https://key@o1.ingest.sentry.io/2',
+		environment: 'production',
+		release: 'abc123',
+		tunnel: '/sentry-tunnel',
+	})
+
+	expect(
+		parseSentryClientConfig(
+			JSON.stringify({
+				dsn: 'https://key@o1.ingest.sentry.io/2',
+				environment: 'preview',
+				tunnel: '/sentry-tunnel',
+			}),
+		),
+	).toMatchObject({ release: null })
+})
+
+test('rejects missing, malformed, or non-same-origin-tunnel configs', () => {
+	expect(parseSentryClientConfig(null)).toBeNull()
+	expect(parseSentryClientConfig('')).toBeNull()
+	expect(parseSentryClientConfig('not json')).toBeNull()
+	expect(
+		parseSentryClientConfig(
+			JSON.stringify({ environment: 'production', tunnel: '/t' }),
+		),
+	).toBeNull()
+	expect(
+		parseSentryClientConfig(
+			JSON.stringify({
+				dsn: 'https://key@o1.ingest.sentry.io/2',
+				environment: 'production',
+				tunnel: 'https://evil.example.com/collect',
+			}),
+		),
+	).toBeNull()
+})

--- a/packages/worker/client/sentry-config.ts
+++ b/packages/worker/client/sentry-config.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared shape for the browser Sentry config. The server serializes it into a
+ * `<meta name="kody:sentry">` tag (see `ssr-document.tsx`); the client reads
+ * it back in `sentry-client.ts`. Kept free of `@sentry/browser` imports so the
+ * SSR bundle never pulls in the browser SDK.
+ */
+
+export const SENTRY_CONFIG_META_NAME = 'kody:sentry'
+
+/** Same-origin envelope tunnel; keeps CSP `connect-src 'self'` intact. */
+export const SENTRY_TUNNEL_PATH = '/sentry-tunnel'
+
+export type SentryClientConfig = {
+	dsn: string
+	environment: string
+	release?: string | null
+	tunnel: string
+}
+
+export function parseSentryClientConfig(
+	content: string | null | undefined,
+): SentryClientConfig | null {
+	if (!content) return null
+	try {
+		const parsed = JSON.parse(content) as Partial<SentryClientConfig>
+		if (
+			typeof parsed.dsn !== 'string' ||
+			!parsed.dsn ||
+			typeof parsed.environment !== 'string' ||
+			typeof parsed.tunnel !== 'string' ||
+			!parsed.tunnel.startsWith('/')
+		) {
+			return null
+		}
+		return {
+			dsn: parsed.dsn,
+			environment: parsed.environment,
+			release: typeof parsed.release === 'string' ? parsed.release : null,
+			tunnel: parsed.tunnel,
+		}
+	} catch {
+		return null
+	}
+}

--- a/packages/worker/client/sentry-config.ts
+++ b/packages/worker/client/sentry-config.ts
@@ -28,7 +28,10 @@ export function parseSentryClientConfig(
 			!parsed.dsn ||
 			typeof parsed.environment !== 'string' ||
 			typeof parsed.tunnel !== 'string' ||
-			!parsed.tunnel.startsWith('/')
+			// Same-origin path only: reject scheme-relative URLs like
+			// //evil.example/collect, which start with '/' but leave origin.
+			!parsed.tunnel.startsWith('/') ||
+			parsed.tunnel.startsWith('//')
 		) {
 			return null
 		}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -19,6 +19,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@remix-run/cookie": "^0.5.1",
     "@resvg/resvg-wasm": "^2.6.2",
+    "@sentry/browser": "^10.68.0",
     "@sentry/cloudflare": "^10.67.0",
     "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.2",

--- a/packages/worker/src/app/handlers/sentry-tunnel.node.test.ts
+++ b/packages/worker/src/app/handlers/sentry-tunnel.node.test.ts
@@ -33,6 +33,10 @@ test('buildEnvelopeIngestUrl derives the envelope endpoint from the DSN', () => 
 	)
 	expect(buildEnvelopeIngestUrl('not a url')).toBeNull()
 	expect(buildEnvelopeIngestUrl('https://key@host.example.com/')).toBeNull()
+	// Self-hosted Sentry under a base path keeps the path prefix.
+	expect(
+		buildEnvelopeIngestUrl('https://key@sentry.example.com/sentry/456'),
+	).toBe('https://sentry.example.com/sentry/api/456/envelope/')
 })
 
 test('forwards envelopes whose dsn matches the configured DSN', async () => {

--- a/packages/worker/src/app/handlers/sentry-tunnel.node.test.ts
+++ b/packages/worker/src/app/handlers/sentry-tunnel.node.test.ts
@@ -68,6 +68,12 @@ test('rejects envelopes for a different DSN without forwarding', async () => {
 	)
 
 	expect(response.status).toBe(403)
+
+	// Truthy non-string dsn values must 403, not crash.
+	const nonString = await handler.handler(
+		tunnelRequest('{"dsn":{"nested":true}}\n{"type":"event"}'),
+	)
+	expect(nonString.status).toBe(403)
 	expect(fetchMock).not.toHaveBeenCalled()
 })
 

--- a/packages/worker/src/app/handlers/sentry-tunnel.node.test.ts
+++ b/packages/worker/src/app/handlers/sentry-tunnel.node.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+	buildEnvelopeIngestUrl,
+	createSentryTunnelHandler,
+} from './sentry-tunnel.ts'
+
+const configuredDsn = 'https://publickey@o123.ingest.us.sentry.io/456'
+
+function buildEnvelope(dsn?: string) {
+	const header = JSON.stringify(dsn ? { dsn } : {})
+	return `${header}\n{"type":"event"}\n{"message":"boom"}`
+}
+
+function tunnelRequest(body: string | ArrayBuffer) {
+	return {
+		request: new Request('http://example.com/sentry-tunnel', {
+			method: 'POST',
+			body,
+		}),
+		url: new URL('http://example.com/sentry-tunnel'),
+	} as unknown as Parameters<
+		ReturnType<typeof createSentryTunnelHandler>['handler']
+	>[0]
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+test('buildEnvelopeIngestUrl derives the envelope endpoint from the DSN', () => {
+	expect(buildEnvelopeIngestUrl(configuredDsn)).toBe(
+		'https://o123.ingest.us.sentry.io/api/456/envelope/',
+	)
+	expect(buildEnvelopeIngestUrl('not a url')).toBeNull()
+	expect(buildEnvelopeIngestUrl('https://key@host.example.com/')).toBeNull()
+})
+
+test('forwards envelopes whose dsn matches the configured DSN', async () => {
+	const fetchMock = vi.fn(async () => new Response(null, { status: 200 }))
+	vi.stubGlobal('fetch', fetchMock)
+	const handler = createSentryTunnelHandler({ SENTRY_DSN: configuredDsn })
+
+	const response = await handler.handler(
+		tunnelRequest(buildEnvelope(configuredDsn)),
+	)
+
+	expect(response.status).toBe(200)
+	expect(fetchMock).toHaveBeenCalledTimes(1)
+	const [ingestUrl, init] = fetchMock.mock.calls[0] as unknown as [
+		string,
+		RequestInit,
+	]
+	expect(ingestUrl).toBe('https://o123.ingest.us.sentry.io/api/456/envelope/')
+	expect(init.method).toBe('POST')
+})
+
+test('rejects envelopes for a different DSN without forwarding', async () => {
+	const fetchMock = vi.fn()
+	vi.stubGlobal('fetch', fetchMock)
+	const handler = createSentryTunnelHandler({ SENTRY_DSN: configuredDsn })
+
+	const response = await handler.handler(
+		tunnelRequest(buildEnvelope('https://other@o999.ingest.sentry.io/1')),
+	)
+
+	expect(response.status).toBe(403)
+	expect(fetchMock).not.toHaveBeenCalled()
+})
+
+test('returns 404 when no DSN is configured and 400 on malformed envelopes', async () => {
+	const fetchMock = vi.fn()
+	vi.stubGlobal('fetch', fetchMock)
+
+	const disabled = createSentryTunnelHandler({})
+	expect(
+		(await disabled.handler(tunnelRequest(buildEnvelope(configuredDsn))))
+			.status,
+	).toBe(404)
+
+	const enabled = createSentryTunnelHandler({ SENTRY_DSN: configuredDsn })
+	expect((await enabled.handler(tunnelRequest('not json\nrest'))).status).toBe(
+		400,
+	)
+	expect(fetchMock).not.toHaveBeenCalled()
+})
+
+test('returns 502 when the upstream forward fails', async () => {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => {
+			throw new Error('network down')
+		}),
+	)
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	try {
+		const handler = createSentryTunnelHandler({ SENTRY_DSN: configuredDsn })
+		const response = await handler.handler(
+			tunnelRequest(buildEnvelope(configuredDsn)),
+		)
+		expect(response.status).toBe(502)
+	} finally {
+		warnSpy.mockRestore()
+	}
+})

--- a/packages/worker/src/app/handlers/sentry-tunnel.ts
+++ b/packages/worker/src/app/handlers/sentry-tunnel.ts
@@ -24,9 +24,13 @@ type SentryTunnelEnv = {
 export function buildEnvelopeIngestUrl(dsn: string): string | null {
 	try {
 		const dsnUrl = new URL(dsn)
-		const projectId = dsnUrl.pathname.replace(/\//g, '')
+		// Self-hosted Sentry may live under a base path:
+		// https://key@host/base/123 -> https://host/base/api/123/envelope/
+		const segments = dsnUrl.pathname.split('/').filter(Boolean)
+		const projectId = segments.pop()
 		if (!projectId) return null
-		return `https://${dsnUrl.host}/api/${projectId}/envelope/`
+		const basePath = segments.length > 0 ? `/${segments.join('/')}` : ''
+		return `https://${dsnUrl.host}${basePath}/api/${projectId}/envelope/`
 	} catch {
 		return null
 	}

--- a/packages/worker/src/app/handlers/sentry-tunnel.ts
+++ b/packages/worker/src/app/handlers/sentry-tunnel.ts
@@ -1,0 +1,88 @@
+import { type Action } from 'remix/router'
+import { type routes } from '#app/routes.ts'
+
+/**
+ * Same-origin Sentry tunnel for the browser SDK.
+ *
+ * The first-party CSP pins `connect-src 'self'`, so the browser cannot post
+ * envelopes to Sentry ingest directly. The client SDK is configured with
+ * `tunnel: '/sentry-tunnel'` and this handler forwards envelopes server-side.
+ *
+ * Abuse safety: the envelope header's `dsn` must exactly match the Worker's
+ * own `SENTRY_DSN`, so this can only ever forward to Kody's Sentry project —
+ * it is not an open proxy. Bodies are capped because replay payloads are
+ * attacker-length-controlled at the HTTP layer.
+ */
+
+/** Replay segments are the largest envelopes; 10 MB leaves ample headroom. */
+const maxEnvelopeBytes = 10 * 1024 * 1024
+
+type SentryTunnelEnv = {
+	SENTRY_DSN?: string
+}
+
+export function buildEnvelopeIngestUrl(dsn: string): string | null {
+	try {
+		const dsnUrl = new URL(dsn)
+		const projectId = dsnUrl.pathname.replace(/\//g, '')
+		if (!projectId) return null
+		return `https://${dsnUrl.host}/api/${projectId}/envelope/`
+	} catch {
+		return null
+	}
+}
+
+export function createSentryTunnelHandler(appEnv: SentryTunnelEnv) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const configuredDsn = appEnv.SENTRY_DSN?.trim()
+			if (!configuredDsn) {
+				return new Response('Not Found', { status: 404 })
+			}
+
+			const contentLength = Number(request.headers.get('content-length') ?? 0)
+			if (contentLength > maxEnvelopeBytes) {
+				return new Response('Payload Too Large', { status: 413 })
+			}
+
+			const body = await request.arrayBuffer()
+			if (body.byteLength > maxEnvelopeBytes) {
+				return new Response('Payload Too Large', { status: 413 })
+			}
+
+			// The envelope header is the first newline-delimited JSON line.
+			const headerEnd = new Uint8Array(body).indexOf(0x0a)
+			const headerText = new TextDecoder().decode(
+				headerEnd === -1 ? body : body.slice(0, headerEnd),
+			)
+			let envelopeDsn: string | undefined
+			try {
+				const header = JSON.parse(headerText) as { dsn?: string }
+				envelopeDsn = header.dsn
+			} catch {
+				return new Response('Malformed envelope', { status: 400 })
+			}
+			if (!envelopeDsn || envelopeDsn.trim() !== configuredDsn) {
+				return new Response('Forbidden', { status: 403 })
+			}
+
+			const ingestUrl = buildEnvelopeIngestUrl(configuredDsn)
+			if (!ingestUrl) {
+				return new Response('Not Found', { status: 404 })
+			}
+
+			try {
+				const upstream = await fetch(ingestUrl, {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-sentry-envelope' },
+					body,
+				})
+				return new Response(null, { status: upstream.ok ? 200 : 502 })
+			} catch (error) {
+				console.warn('sentry-tunnel-forward-failed', error)
+				return new Response(null, { status: 502 })
+			}
+		},
+	} satisfies Action<typeof routes.sentryTunnel>
+}

--- a/packages/worker/src/app/handlers/sentry-tunnel.ts
+++ b/packages/worker/src/app/handlers/sentry-tunnel.ts
@@ -60,14 +60,17 @@ export function createSentryTunnelHandler(appEnv: SentryTunnelEnv) {
 			const headerText = new TextDecoder().decode(
 				headerEnd === -1 ? body : body.slice(0, headerEnd),
 			)
-			let envelopeDsn: string | undefined
+			let envelopeDsn: unknown
 			try {
-				const header = JSON.parse(headerText) as { dsn?: string }
+				const header = JSON.parse(headerText) as { dsn?: unknown }
 				envelopeDsn = header.dsn
 			} catch {
 				return new Response('Malformed envelope', { status: 400 })
 			}
-			if (!envelopeDsn || envelopeDsn.trim() !== configuredDsn) {
+			if (
+				typeof envelopeDsn !== 'string' ||
+				envelopeDsn.trim() !== configuredDsn
+			) {
 				return new Response('Forbidden', { status: 403 })
 			}
 

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -131,6 +131,7 @@ import {
 	createBlogRssHandler,
 } from '#app/handlers/blog.tsx'
 import { createHealthHandler } from '#app/handlers/health.ts'
+import { createSentryTunnelHandler } from '#app/handlers/sentry-tunnel.ts'
 import { createHomeHandler } from '#app/handlers/home.ts'
 import { createLoginHandler } from '#app/handlers/login.ts'
 import { createOgPageImageHandler } from '#app/handlers/og-page-image.ts'
@@ -179,6 +180,7 @@ export function createAppRouter(env: Env) {
 		actions: {
 			home: createHomeHandler(env),
 			health: createHealthHandler(env),
+			sentryTunnel: createSentryTunnelHandler(env),
 			login: createLoginHandler(env),
 			ogPageImage: createOgPageImageHandler(env),
 			blog: createBlogHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -104,6 +104,7 @@ export const routes = route({
 	timeline: '/timeline',
 	timelineApi: '/timeline.json',
 	health: '/health',
+	sentryTunnel: post('/sentry-tunnel'),
 	login: '/login',
 	ogPageImage: '/og/:page.png',
 	privacy: '/privacy',

--- a/packages/worker/src/app/security-headers.ts
+++ b/packages/worker/src/app/security-headers.ts
@@ -22,6 +22,12 @@
  *   injection, plugin content, and form exfiltration to third-party origins.
  * - `connect-src 'self'` is safe because the first-party client only calls
  *   same-origin JSON endpoints; all third-party calls happen server-side.
+ *   Browser Sentry envelopes stay same-origin too via the `/sentry-tunnel`
+ *   route (see `handlers/sentry-tunnel.ts`).
+ * - `worker-src 'self' blob:` exists for Sentry Session Replay's compression
+ *   Web Worker, which is created from a blob URL. Spawning a blob worker
+ *   already requires script execution, which `script-src 'self'` still gates,
+ *   so this does not widen the injection surface.
  */
 const contentSecurityPolicy = [
 	"default-src 'self'",
@@ -34,6 +40,7 @@ const contentSecurityPolicy = [
 	"style-src 'self' 'unsafe-inline'",
 	"script-src 'self'",
 	"connect-src 'self'",
+	"worker-src 'self' blob:",
 ].join('; ')
 
 export const firstPartySecurityHeaders: Readonly<Record<string, string>> = {

--- a/packages/worker/src/app/ssr-document.tsx
+++ b/packages/worker/src/app/ssr-document.tsx
@@ -10,6 +10,10 @@ import {
 	DOCUMENT_HEAD_ATTR,
 	type ResolvedDocumentHead,
 } from '#app/document-head.ts'
+import {
+	SENTRY_CONFIG_META_NAME,
+	type SentryClientConfig,
+} from '#client/sentry-config.ts'
 
 export const CLIENT_ENTRY_HREF = '/client-entry.js'
 export const STYLESHEET_HREF = '/styles.css'
@@ -19,6 +23,11 @@ export type SsrDocumentProps = AppRootProps & {
 	documentHead?: ResolvedDocumentHead
 	clientEntryHref?: string
 	stylesheetHref?: string
+	/**
+	 * Browser Sentry config (error capture + error-only replay). Omitted when
+	 * SENTRY_DSN is not configured; the DSN is a publishable client key.
+	 */
+	sentryConfig?: SentryClientConfig | null
 }
 
 function managedHeadAttr(value: string) {
@@ -145,6 +154,12 @@ export function SsrDocument(handle: Handle<SsrDocumentProps>) {
 				</title>
 				{handle.props.documentHead ? (
 					<ManagedDocumentHead head={handle.props.documentHead} />
+				) : null}
+				{handle.props.sentryConfig ? (
+					<meta
+						name={SENTRY_CONFIG_META_NAME}
+						content={JSON.stringify(handle.props.sentryConfig)}
+					/>
 				) : null}
 				<link rel="modulepreload" href={clientEntryHref} />
 				<link rel="stylesheet" href={stylesheetHref} />

--- a/packages/worker/src/app/ssr-render.tsx
+++ b/packages/worker/src/app/ssr-render.tsx
@@ -19,6 +19,10 @@ import { getRequestDataCacheLookup } from '#app/request-cache.ts'
 import { applyFirstPartySecurityHeaders } from '#app/security-headers.ts'
 import { loadSessionInfo } from '#app/session-info.ts'
 import { SsrDocument } from '#app/ssr-document.tsx'
+import {
+	SENTRY_TUNNEL_PATH,
+	type SentryClientConfig,
+} from '#client/sentry-config.ts'
 import '#app/frame-registrations.ts'
 import { resolveRegisteredFrameHtml } from '#app/frame-registry.ts'
 
@@ -52,6 +56,16 @@ export async function renderAppPage(input: RenderAppPageInput) {
 	if (title !== undefined) {
 		documentHead.title = title
 	}
+	const parsedEnv = getEnv(env)
+	const sentryDsn = parsedEnv.SENTRY_DSN?.trim()
+	const sentryConfig: SentryClientConfig | null = sentryDsn
+		? {
+				dsn: sentryDsn,
+				environment: parsedEnv.SENTRY_ENVIRONMENT?.trim() || 'development',
+				release: parsedEnv.APP_COMMIT_SHA ?? null,
+				tunnel: SENTRY_TUNNEL_PATH,
+			}
+		: null
 
 	const stream = renderToStream(
 		// Remix server components accept props via handle.props; JSX typing is loose here.
@@ -64,6 +78,7 @@ export async function renderAppPage(input: RenderAppPageInput) {
 				notFound={notFound}
 				clientEntryHref={clientEntryHref}
 				stylesheetHref={stylesheetHref}
+				sentryConfig={sentryConfig}
 			/>
 		) as RemixNode,
 		{

--- a/packages/worker/tsconfig-worker.json
+++ b/packages/worker/tsconfig-worker.json
@@ -39,7 +39,8 @@
 		"./src/**/*.ts",
 		"./src/**/*.tsx",
 		"./client/styles/tokens.ts",
-		"./client/styles/style-primitives.ts"
+		"./client/styles/style-primitives.ts",
+		"./client/sentry-config.ts"
 	],
 	"exclude": [
 		"**/*.test.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds client-side Sentry with strict privacy defaults, completing the observability rollout (#905, #906, #908):

- **Browser SDK** (`@sentry/browser`): `packages/worker/client/sentry-client.ts` initializes from a `kody:sentry` meta tag that `ssr-document.tsx` renders when `SENTRY_DSN` is configured (the DSN is a publishable client key). No-ops entirely when the tag is absent (local dev / tests). The hydration error listener in `entry.tsx` also reports through it.
- **Error-only Session Replay**: `replaysSessionSampleRate: 0`, `replaysOnErrorSampleRate: 1.0` — nothing is recorded to Sentry during normal sessions; only the in-memory buffer around an error is uploaded. `maskAllText` and `blockAllMedia` are set explicitly because Kody sessions contain personal-assistant content.
- **Same-origin Sentry tunnel**: new `POST /sentry-tunnel` route (`packages/worker/src/app/handlers/sentry-tunnel.ts`) forwards envelopes server-side, so the first-party CSP keeps `connect-src 'self'`. Abuse-safe: the envelope header's DSN must exactly match the Worker's own `SENTRY_DSN` (403 otherwise), bodies are capped at 10 MB, and the route 404s when no DSN is configured.
- **CSP**: adds `worker-src 'self' blob:` for replay's compression Web Worker (spawning a blob worker already requires script execution, which `script-src 'self'` still gates).
- `tsconfig-worker.json` includes `client/sentry-config.ts` (the SDK-free config module shared by SSR and client); docs updated in `request-lifecycle.md` and `environment-variables.md`.

## Cost note

The client bundle grows from ~600 KB to ~850 KB minified (~75 KB gzip delta) — the Sentry CDN/lazy-load alternative is not available under `script-src 'self'`, so static bundling is the CSP-correct option.

## Verification

- Unit: 7 new tests — tunnel handler (forward on DSN match, 403 mismatch, 404 unconfigured, 400 malformed, 502 upstream failure, ingest-URL derivation) and config parsing (rejects missing DSN and non-same-origin tunnels).
- Manual browser E2E against the local dev server with a DSN set: meta tag rendered; SDK initialized with the Replay integration in `buffer` mode; a thrown error produced both the error-event envelope **and** the replay recording envelope through `/sentry-tunnel` (`tunnel-envelopes: ['error_event', 'replay']`); curl checks confirmed 403 on mismatched DSN and forward-attempt on match; CSP header includes the new `worker-src` directive.
- Interesting SDK behavior confirmed empirically: replay only flushes its buffer after the error event is *successfully* sent, so a failing upstream leaves the buffer unflushed — worth knowing when debugging.
- Full pre-push suite green: 387 test files, 18 Playwright E2E.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends the app shell with client telemetry</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `52b06b46` · **Head:** branch tip

**Classification:** extends — new route on the app surface, CSP directive addition, and a browser SDK in the client bundle; no data-model or MCP changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — client bundle initializes Sentry + error-only replay |
| `app-router` | surfaces | extends — new `POST /sentry-tunnel` route |
| `security-headers` | platform | extends — `worker-src 'self' blob:` added to CSP |

### System map

Browser errors flow from the client bundle through the same-origin tunnel into Sentry, keeping CSP locked.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appRouter["app-router<br/>App routes"]:::extended
	csp["security-headers<br/>CSP"]:::extended
	sentry["Sentry ingest<br/>(external)"]:::untouched
	appUi -->|"envelopes via POST /sentry-tunnel"| appRouter
	appRouter -->|"forward only when DSN matches SENTRY_DSN"| sentry
	csp -->|"connect-src 'self' preserved; worker-src blob: for replay"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Replay privacy: all text masked, all media blocked, no session recording without an error, `sendDefaultPii: false`. The tunnel cannot proxy to arbitrary destinations (DSN allowlist of exactly one).

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72eb9618-ed14-47ce-9951-b3ebac70837c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72eb9618-ed14-47ce-9951-b3ebac70837c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser error monitoring with Sentry, initialized from server-rendered config.
  * Added privacy-focused, error-only session replay (text masked, media blocked).
  * Added secure same-origin event forwarding via a `/sentry-tunnel` endpoint.

* **Documentation**
  * Expanded contributing docs and environment-variable guidance for the client setup and replay/tunneling behavior.

* **Bug Fixes**
  * Added stricter validation for Sentry config and tunnel submissions, including DSN matching and payload-size limits.

* **Tests**
  * Added coverage for client config parsing and the `/sentry-tunnel` forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->