### PR TITLE
Tighten webhook auth ordering, rate limits, and remint enablement

### DIFF
--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -313,31 +313,23 @@ export async function handleWebhookIngressRequest(
 		return notFoundResponse()
 	}
 
-	// Bound every subsequent delivery-log write (including pre-auth rejects).
-	const rateLimit = await checkRateLimit(
-		env.APP_DB,
-		`webhook:endpoint:${endpoint.id}`,
-		webhookRateLimitConfig,
-	)
-	if (!rateLimit.allowed) {
-		return rateLimitedResponse(rateLimit.retryAfterSeconds ?? 60)
-	}
-
 	const secretMatches = await webhookUrlSecretMatches({
 		candidate: route.urlSecret,
 		storedHash: endpoint.urlSecretHash,
 	})
+	// Wrong secret: no delivery row (avoids log-flush DoS) and no rate-limit
+	// side channel that would distinguish minted names from unknown ones.
 	if (!secretMatches) {
-		await recordDelivery({
-			db: env.APP_DB,
-			endpoint,
-			outcome: 'rejected',
-			httpStatus: 404,
-			error: 'url_secret_mismatch',
-			payloadBytes: 0,
-			receivedAt,
-		})
 		return notFoundResponse()
+	}
+
+	const rateLimit = await checkRateLimit(
+		env.APP_DB,
+		`webhook:user:${endpoint.userId}:endpoint:${endpoint.id}`,
+		webhookRateLimitConfig,
+	)
+	if (!rateLimit.allowed) {
+		return rateLimitedResponse(rateLimit.retryAfterSeconds ?? 60)
 	}
 
 	const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })

--- a/packages/worker/src/webhooks/repo.ts
+++ b/packages/worker/src/webhooks/repo.ts
@@ -70,6 +70,9 @@ function truncateDeliveryError(error: string | null | undefined) {
  * Insert or rotate a minted webhook URL secret.
  * Concurrent mints for the same (user, package, name) resolve via the unique
  * index instead of throwing a constraint error.
+ *
+ * When `updateEnabledOnConflict` is true (mint/activate), conflict updates also
+ * set `enabled` from the insert row. Rotate passes false so disable state sticks.
  */
 export async function upsertWebhookEndpointSecret(input: {
 	db: D1Database
@@ -79,20 +82,28 @@ export async function upsertWebhookEndpointSecret(input: {
 	webhookName: string
 	urlSecretHash: string
 	enabled?: boolean
+	updateEnabledOnConflict?: boolean
 	now?: string
 }): Promise<WebhookEndpointRecord> {
 	const now = input.now ?? new Date().toISOString()
 	const enabled = input.enabled === false ? 0 : 1
+	const conflictSql = input.updateEnabledOnConflict
+		? `ON CONFLICT(user_id, package_id, webhook_name)
+			DO UPDATE SET
+				url_secret_hash = excluded.url_secret_hash,
+				rotated_at = excluded.rotated_at,
+				enabled = excluded.enabled`
+		: `ON CONFLICT(user_id, package_id, webhook_name)
+			DO UPDATE SET
+				url_secret_hash = excluded.url_secret_hash,
+				rotated_at = excluded.rotated_at`
 	await input.db
 		.prepare(
 			`INSERT INTO webhook_endpoints (
 				id, user_id, package_id, webhook_name, url_secret_hash,
 				enabled, created_at, rotated_at
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-			ON CONFLICT(user_id, package_id, webhook_name)
-			DO UPDATE SET
-				url_secret_hash = excluded.url_secret_hash,
-				rotated_at = excluded.rotated_at`,
+			${conflictSql}`,
 		)
 		.bind(
 			input.id,

--- a/packages/worker/src/webhooks/service.node.test.ts
+++ b/packages/worker/src/webhooks/service.node.test.ts
@@ -191,6 +191,25 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	})
 	expect(disabled.enabled).toBe(false)
 
+	const rotatedWhileDisabled = await rotateWebhookUrlForUser({
+		env,
+		userId,
+		username: 'owner',
+		kodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+	})
+	expect(rotatedWhileDisabled.enabled).toBe(false)
+
+	const reminted = await mintWebhookUrlForUser({
+		env,
+		userId,
+		username: 'owner',
+		kodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+	})
+	expect(reminted.enabled).toBe(true)
+	expect(reminted.urlSecret).not.toBe(rotatedWhileDisabled.urlSecret)
+
 	const endpoint = await db
 		.prepare(`SELECT id FROM webhook_endpoints WHERE user_id = ?`)
 		.bind(userId)

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -189,9 +189,12 @@ export async function mintWebhookUrlForUser(input: {
 	kodyId?: string
 	webhookName: string
 	requestUrl?: string | null
+	/** When false, rotate secret without forcing enabled=true on conflict. */
+	activate?: boolean
 }): Promise<MintedWebhookUrl> {
 	const webhookName = input.webhookName.trim()
 	if (!webhookName) throw new Error('webhookName is required.')
+	const activate = input.activate !== false
 	const baseUrl = getAppBaseUrl({
 		env: input.env,
 		requestUrl: input.requestUrl,
@@ -220,6 +223,7 @@ export async function mintWebhookUrlForUser(input: {
 		webhookName,
 		urlSecretHash,
 		enabled: true,
+		updateEnabledOnConflict: activate,
 	})
 
 	const username = await resolveOwnerUsername({
@@ -274,7 +278,10 @@ export async function rotateWebhookUrlForUser(input: {
 			'Webhook URL has not been minted. Call webhook_url_mint first.',
 		)
 	}
-	return mintWebhookUrlForUser(input)
+	return mintWebhookUrlForUser({
+		...input,
+		activate: false,
+	})
 }
 
 export async function setWebhookEnabledForUser(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #910 (merged before these review fixes landed).

- Authenticate the URL secret **before** consuming the per-endpoint rate budget (no 429 side channel for guessed names; no pre-auth DoS of valid deliveries)
- Skip delivery-log rows for URL-secret mismatches (prevents log-flush attacks)
- Namespace rate-limit keys with `userId`
- `webhook_url_mint` re-enables a disabled row; `webhook_url_rotate` preserves disable state

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends Inbound webhooks</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c0ce4926` · **Head:** `439e0fc9`

**Classification:** extends — hardens auth/rate-limit ordering and mint enablement on the new `webhooks` primitive from #910.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `webhooks` | assistant | extends — ingress auth/rate-limit order; mint vs rotate enablement |

### System map

Ingress now checks the URL secret before rate limiting; mint re-enables disabled rows while rotate keeps them disabled.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red =
new primitive · gray = context (unchanged, included only when an edge crosses
it).

```mermaid
flowchart LR
	webhooks["webhooks<br/>Inbound webhooks"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	webhooks -->|"secret match then rate-limit key"| d1AppDb
	webhooks -->|"mint upsert may set enabled"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Provider
	participant Ingress
	participant D1
	Provider->>Ingress: POST with urlSecret
	Ingress->>D1: load minted endpoint
	alt secret mismatch
		Ingress-->>Provider: 404 (no delivery row)
	else secret ok
		Ingress->>D1: rate limit (user-scoped key)
		alt limited
			Ingress-->>Provider: 429 (no delivery row)
		else allowed
			Ingress->>Ingress: HMAC / dispatch as before
		end
	end
```

### Before / after

| Before (#910) | After |
| --- | --- |
| Rate limit before URL-secret check | Secret check first; rate limit only after match |
| Wrong secret wrote a delivery row | Wrong secret → 404, no log row |
| Remint left `enabled=0` | Mint re-enables; rotate preserves disable |

### Invariants

- **per-user-isolation:** rate-limit key includes `userId`; wrong-secret responses stay indistinguishable 404s.

</details>

<!-- system-recap:end -->

## Test plan

- [x] Unit: remint re-enables; rotate while disabled stays disabled
- [x] Pre-push unit + e2e
- [ ] CI Validate on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d07d3c76-62c9-4c43-ad63-7561fc89b4ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d07d3c76-62c9-4c43-ad63-7561fc89b4ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbound webhooks for package exports, supporting secure URL minting, rotation, enablement, and disablement.
  * Added webhook delivery handling with optional HMAC verification, asynchronous acknowledgements, synchronous responses, rate limiting, and payload limits.
  * Added delivery history access and package webhook discovery through the webhooks capabilities.
* **Documentation**
  * Added user and architecture guides covering webhook setup, security, lifecycle, privacy, and delivery behavior.
* **Privacy**
  * Webhook secrets are protected, payload bodies are not stored, and administrators cannot view webhook endpoints or delivery logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->