### PR TITLE
Harden webhook delivery prune and clarify delivery-log docs

### DIFF
--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -34,10 +34,12 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
 2. Resolve username → user; resolve `packageKodyId` to a saved package owned by
    that user; load minted row keyed by `(user_id, package_id, webhook_name)`.
 3. Unminted, disabled, missing declaration (after republish rename/remove), or
-   URL-secret mismatch → **404** (indistinguishable).
+   URL-secret mismatch → **404** (indistinguishable). URL-secret mismatches do
+   **not** write a delivery row (avoids log-flush DoS and rate-limit side
+   channels).
 4. Constant-time compare the URL secret against `url_secret_hash` (SHA-256).
-5. Enforce per-webhook rate limit (~60/min) → **429**; payload cap 1 MB →
-   **413**.
+5. After a matching URL secret, enforce per-webhook rate limit (~60/min) →
+   **429** (no delivery row on the limited path); payload cap 1 MB → **413**.
 6. When verification is declared, resolve `secretName` from the owner's secret
    store (user/package scope via package storage context). Missing secret or
    HMAC mismatch → **401**, with a clear delivery-log error for missing secrets.
@@ -45,7 +47,8 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
    the owning user / package / export, `source: 'webhook'`.
 8. `ack`: **202** + `waitUntil`. `sync`: await (30s) and return export JSON,
    **502** on failure.
-9. Every request records a `webhook_deliveries` row (no payload body); ~50 rows
+9. Authenticated deliveries (and post-auth rejects such as HMAC / size / missing
+   declaration) record a `webhook_deliveries` row (no payload body); ~50 rows
    retained per minted webhook.
 
 ## Isolation

--- a/packages/worker/src/webhooks/repo.ts
+++ b/packages/worker/src/webhooks/repo.ts
@@ -246,19 +246,23 @@ export async function insertWebhookDelivery(input: {
 	await input.db
 		.prepare(
 			`DELETE FROM webhook_deliveries
-			WHERE endpoint_id = ?
+			WHERE user_id = ?
+				AND endpoint_id = ?
 				AND id NOT IN (
 					SELECT id FROM (
 						SELECT id
 						FROM webhook_deliveries
-						WHERE endpoint_id = ?
+						WHERE user_id = ?
+							AND endpoint_id = ?
 						ORDER BY received_at DESC, id DESC
 						LIMIT ?
 					)
 				)`,
 		)
 		.bind(
+			input.userId,
 			input.endpointId,
+			input.userId,
 			input.endpointId,
 			webhookDeliveriesRetainedPerEndpoint,
 		)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small follow-up after #910 / #912 review feedback:

- Scope delivery retention `DELETE` by `user_id` as well as `endpoint_id`
- Document that URL-secret mismatches and rate-limited requests do not write delivery rows
- Move webhook table notes out of the D1 JSON-shadow section in data-storage docs

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends Inbound webhooks</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** current branch tip

**Classification:** extends — retention SQL isolation + architecture doc accuracy for `webhooks`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `webhooks` | assistant | extends — prune query scopes by `user_id`; docs match ingress behavior |
| `d1-app-db` | storage | composes — same tables, tighter delete predicate |

### System map

Delivery-log retention deletes now include `user_id` in both the outer delete and the keep-set subquery.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red =
new primitive · gray = context (unchanged, included only when an edge crosses
it).

```mermaid
flowchart LR
	webhooks["webhooks<br/>Inbound webhooks"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	webhooks -->|"prune deliveries WHERE user_id + endpoint_id"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

## Test plan

- [x] Pre-push unit + e2e
- [ ] CI Validate
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d07d3c76-62c9-4c43-ad63-7561fc89b4ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d07d3c76-62c9-4c43-ad63-7561fc89b4ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook delivery retention so cleanup keeps the correct number of recent deliveries for each user and endpoint.
  * URL-secret mismatches now return a 404 without creating delivery records, helping prevent excessive log generation.
  * Delivery records are now created only for authenticated deliveries and rejects identified after authentication.
* **Documentation**
  * Clarified webhook recording behavior, rejection scenarios, and the fact that delivery records do not contain payload bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->