### PR TITLE
Fix MCP init crash on remote connector snapshot timeout

### DIFF
--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -6,18 +6,12 @@ import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validatio
 import { McpAgent } from 'agents/mcp'
 import { buildSentryOptions } from '../sentry-options.ts'
 import { parseMcpCallerContext, type McpServerProps } from './context.ts'
-import {
-	buildMcpServerInstructions,
-	type RemoteConnectorInstructionSummary,
-} from './server-instructions.ts'
+import { buildMcpServerInstructions } from './server-instructions.ts'
 import { registerTools } from './register-tools.ts'
 import { createKodyMcpServer } from './sentry-mcp-server.ts'
 import { getMcpUserServerInstructions } from './user-server-instructions-repo.ts'
 import { getCapabilityRegistryForContext } from './capabilities/registry.ts'
-import { createRemoteConnectorMcpClient } from '#worker/remote-connector/client.ts'
-import { remoteConnectorDomainId } from '#worker/remote-connector/remote-domain-id.ts'
-import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
-import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { loadRemoteConnectorInstructionSummaries } from './remote-connector-instruction-summaries.ts'
 import { type RawFetchHostNudgeState } from '#mcp/raw-fetch-host-nudge.ts'
 import { listPopularAgentPackagesForUser } from '#worker/usage/agent-package-conversation-uses.ts'
 import {
@@ -31,34 +25,6 @@ export type State = {
 	rawFetchHostNudges?: RawFetchHostNudgeState
 }
 export type Props = McpServerProps
-
-async function loadRemoteConnectorInstructionSummaries(input: {
-	env: Env
-	caller: McpCallerContext
-}): Promise<Array<RemoteConnectorInstructionSummary>> {
-	const refs = normalizeRemoteConnectorRefs(input.caller)
-	const userId = input.caller.user?.userId ?? null
-	if (refs.length === 0 || !userId) {
-		return []
-	}
-	const snapshots = await Promise.all(
-		refs.map(async (ref) => {
-			const snapshot = await createRemoteConnectorMcpClient({
-				env: input.env,
-				userId,
-				instanceId: ref.instanceId,
-			}).getSnapshot()
-			if (!snapshot) return null
-			const connectorId = snapshot.connectorId.trim()
-			return {
-				name: connectorId,
-				domain: remoteConnectorDomainId(ref),
-				description: snapshot.description ?? null,
-			}
-		}),
-	)
-	return snapshots.flatMap((snapshot) => (snapshot ? [snapshot] : []))
-}
 
 class MCPBase extends McpAgent<Env, State, Props> {
 	initialState: State = {

--- a/packages/worker/src/mcp/remote-connector-instruction-summaries.node.test.ts
+++ b/packages/worker/src/mcp/remote-connector-instruction-summaries.node.test.ts
@@ -1,0 +1,63 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { loadRemoteConnectorInstructionSummaries } from '#mcp/remote-connector-instruction-summaries.ts'
+import {
+	clearRemoteConnectorSnapshotCacheForTests,
+	remoteConnectorSnapshotTimeoutMs,
+} from '#worker/remote-connector/snapshot-cache.ts'
+
+test('loadRemoteConnectorInstructionSummaries keeps healthy connectors when one snapshot stalls', async () => {
+	vi.useFakeTimers()
+	clearRemoteConnectorSnapshotCacheForTests()
+	const env = {
+		REMOTE_CONNECTOR_SESSION: {
+			idFromName(name: string) {
+				return name
+			},
+			get(name: string) {
+				const [, instanceId] = JSON.parse(name) as [string, string]
+				return {
+					getSnapshot() {
+						if (instanceId === 'stalled') {
+							return new Promise(() => undefined)
+						}
+						return Promise.resolve({
+							connectorId: instanceId,
+							description: 'Healthy home automation connector.',
+							connectedAt: '2026-03-25T00:00:00.000Z',
+							lastSeenAt: '2026-03-25T00:00:01.000Z',
+							tools: [],
+						})
+					},
+				}
+			},
+		},
+	} as unknown as Env
+	const caller = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-1',
+			email: 'user-1@example.com',
+			displayName: 'user-1',
+		},
+		remoteConnectors: [{ instanceId: 'healthy' }, { instanceId: 'stalled' }],
+	})
+
+	try {
+		const summariesPromise = loadRemoteConnectorInstructionSummaries({
+			env,
+			caller,
+		})
+		await vi.advanceTimersByTimeAsync(remoteConnectorSnapshotTimeoutMs)
+		await expect(summariesPromise).resolves.toEqual([
+			{
+				name: 'healthy',
+				domain: 'remote:healthy',
+				description: 'Healthy home automation connector.',
+			},
+		])
+	} finally {
+		clearRemoteConnectorSnapshotCacheForTests()
+		vi.useRealTimers()
+	}
+})

--- a/packages/worker/src/mcp/remote-connector-instruction-summaries.ts
+++ b/packages/worker/src/mcp/remote-connector-instruction-summaries.ts
@@ -1,0 +1,39 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
+import { type RemoteConnectorInstructionSummary } from './server-instructions.ts'
+import { createRemoteConnectorMcpClient } from '#worker/remote-connector/client.ts'
+import { remoteConnectorDomainId } from '#worker/remote-connector/remote-domain-id.ts'
+
+export async function loadRemoteConnectorInstructionSummaries(input: {
+	env: Env
+	caller: McpCallerContext
+}): Promise<Array<RemoteConnectorInstructionSummary>> {
+	const refs = normalizeRemoteConnectorRefs(input.caller)
+	const userId = input.caller.user?.userId ?? null
+	if (refs.length === 0 || !userId) {
+		return []
+	}
+	const snapshots = await Promise.all(
+		refs.map(async (ref) => {
+			try {
+				const snapshot = await createRemoteConnectorMcpClient({
+					env: input.env,
+					userId,
+					instanceId: ref.instanceId,
+				}).getSnapshot()
+				if (!snapshot) return null
+				const connectorId = snapshot.connectorId.trim()
+				return {
+					name: connectorId,
+					domain: remoteConnectorDomainId(ref),
+					description: snapshot.description ?? null,
+				}
+			} catch {
+				// A stalled or unavailable connector must not fail MCP session
+				// initialization; omit its instruction summary instead.
+				return null
+			}
+		}),
+	)
+	return snapshots.flatMap((snapshot) => (snapshot ? [snapshot] : []))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-1D](https://kent-c-dodds-tech-llc.sentry.io/issues/7631334278/): `RemoteConnectorSnapshotTimeoutError` for connector `"home"` was aborting `/mcp` session setup.

- Capability registry already soft-failed stalled connector snapshots (#847)
- MCP Durable Object `init()` still loaded remote-connector instruction summaries without a catch, so a 5s snapshot timeout rejected `Promise.all` and failed the whole handshake (`handleMcpRequest` → `getServerByName` → `retryDurableObjectOperation`)
- Extract `loadRemoteConnectorInstructionSummaries` and omit stalled connectors instead of failing init
- Add regression coverage for mixed healthy/stalled connectors

## Validation

- `npm run validate` passed (format, lint, typecheck, 1282 unit tests, 18 Playwright e2e, 2 MCP e2e, primitives, migrations)

Do not merge until CI is green and reviewed.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `49893e20` · **Head:** `81982f5f`

**Classification:** extends — MCP session init now soft-fails stalled remote-connector snapshot reads used for instruction summaries.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — instruction-summary loading no longer fails MCP DO init when a connector snapshot times out |

### System map

MCP init loads instruction summaries and the capability registry in parallel; only the registry path was fail-soft before this change.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpRequest["/mcp request"]:::untouched
	mcpServer["mcp-server<br/>MCP DO init"]:::extended
	snapshotCache["remote connector<br/>snapshot cache"]:::untouched
	registry["capability-registry"]:::untouched
	mcpRequest --> mcpServer
	mcpServer -->|"instruction summaries: catch timeout → omit"| snapshotCache
	mcpServer -->|"already fail-soft (#847)"| registry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Connector snapshot cache keys remain user-scoped; soft-fail omits only the stalled connector's instruction summary and never substitutes another user's connector data.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59c891c9-314e-47b9-8db4-0d2da6a4617b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59c891c9-314e-47b9-8db4-0d2da6a4617b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Remote connector information now loads more reliably during MCP session initialization.
  - Unavailable or stalled connectors no longer prevent healthy connector information from being included.
  - Connector snapshot failures are handled individually, allowing sessions to continue successfully.

- **Tests**
  - Added coverage for stalled connector requests and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->