### PR TITLE
fix(mcp): stop reporting sandbox execute failures to Sentry

### DIFF
--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -1,0 +1,102 @@
+import { expect, test, vi } from 'vitest'
+
+const sentryMock = vi.hoisted(() => ({
+	isInitialized: vi.fn(() => true),
+	getClient: vi.fn(() => ({ getOptions: () => ({ dsn: 'https://example' }) })),
+	withScope: vi.fn((callback: (scope: ScopeStub) => void) => {
+		callback(sentryMock.scope)
+	}),
+	captureException: vi.fn(),
+	captureMessage: vi.fn(),
+	scope: {
+		setLevel: vi.fn(),
+		setTag: vi.fn(),
+		setContext: vi.fn(),
+		setUser: vi.fn(),
+	},
+}))
+
+type ScopeStub = typeof sentryMock.scope
+
+vi.mock('@sentry/cloudflare', () => ({
+	isInitialized: (...args: Array<unknown>) => sentryMock.isInitialized(...args),
+	getClient: (...args: Array<unknown>) => sentryMock.getClient(...args),
+	withScope: (...args: Array<unknown>) => sentryMock.withScope(...args),
+	captureException: (...args: Array<unknown>) =>
+		sentryMock.captureException(...args),
+	captureMessage: (...args: Array<unknown>) =>
+		sentryMock.captureMessage(...args),
+}))
+
+const { logMcpEvent } = await import('./observability.ts')
+
+test('logMcpEvent keeps sandbox failures on mcp-event logs and skips Sentry', () => {
+	sentryMock.captureException.mockClear()
+	sentryMock.captureMessage.mockClear()
+	sentryMock.withScope.mockClear()
+	sentryMock.scope.setLevel.mockClear()
+
+	const originalInfo = console.info
+	const payloads: Array<string> = []
+	console.info = ((tag: unknown, json?: unknown) => {
+		if (tag === 'mcp-event' && typeof json === 'string') {
+			payloads.push(json)
+		}
+	}) as typeof console.info
+	try {
+		logMcpEvent({
+			category: 'mcp',
+			tool: 'execute',
+			toolName: 'execute',
+			outcome: 'failure',
+			durationMs: 12,
+			baseUrl: 'https://example.com',
+			hasUser: true,
+			userId: 'user-1',
+			sandboxError: true,
+			errorName: 'Unknown',
+			errorMessage:
+				'Notion API /data_sources/39977ef0-f2db-81c6-9147-000bd579e312/query failed: validation_error',
+			cause: 'Notion API /data_sources/.../query failed: validation_error',
+		})
+
+		logMcpEvent({
+			category: 'mcp',
+			tool: 'capability',
+			capabilityName: 'value_get',
+			capabilitySource: 'builtin',
+			outcome: 'failure',
+			durationMs: 3,
+			baseUrl: 'https://example.com',
+			hasUser: true,
+			userId: 'user-1',
+			sandboxError: false,
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage: 'platform handler blew up',
+			cause: new Error('platform handler blew up'),
+		})
+	} finally {
+		console.info = originalInfo
+	}
+
+	expect(payloads).toHaveLength(2)
+	expect(JSON.parse(payloads[0]!)).toMatchObject({
+		tool: 'execute',
+		outcome: 'failure',
+		sandboxError: true,
+	})
+	expect(JSON.parse(payloads[1]!)).toMatchObject({
+		tool: 'capability',
+		outcome: 'failure',
+		sandboxError: false,
+	})
+
+	expect(sentryMock.captureMessage).not.toHaveBeenCalled()
+	expect(sentryMock.captureException).toHaveBeenCalledTimes(1)
+	expect(sentryMock.captureException).toHaveBeenCalledWith(
+		expect.objectContaining({ message: 'platform handler blew up' }),
+	)
+	expect(sentryMock.scope.setLevel).toHaveBeenCalledWith('error')
+	expect(sentryMock.scope.setUser).toHaveBeenCalledWith({ id: 'user-1' })
+})

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -58,13 +58,17 @@ function reportMcpFailureToSentry(
 	cause?: unknown,
 ) {
 	try {
+		// Sandbox failures are caller/user-module errors (bad Notion filters,
+		// syntax errors, thrown strings). They stay on the structured
+		// `mcp-event` log line; sending them to Sentry creates warning issues
+		// that look like platform bugs and trip triage automation.
+		if (payload.sandboxError) return
 		if (!Sentry.isInitialized()) return
 		const client = Sentry.getClient()
 		if (!client?.getOptions().dsn) return
 
 		Sentry.withScope((scope) => {
-			const level = payload.sandboxError ? 'warning' : 'error'
-			scope.setLevel(level)
+			scope.setLevel('error')
 
 			// Id only: sendDefaultPii is false and emails stay out of Sentry.
 			if (payload.userId) scope.setUser({ id: payload.userId })
@@ -81,7 +85,6 @@ function reportMcpFailureToSentry(
 			if (payload.failurePhase) {
 				scope.setTag('mcp.failure_phase', payload.failurePhase)
 			}
-			if (payload.sandboxError) scope.setTag('mcp.sandbox_error', 'true')
 			scope.setContext('mcp', {
 				baseUrl: payload.baseUrl,
 				hasUser: payload.hasUser,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry issue [KODY-CLOUDFLARE-1H](https://kent-c-dodds-tech-llc.sentry.io/issues/7631365332/) was a **warning** with tags `mcp.sandbox_error=true` / `mcp.tool=execute`: a caller execute module hit Notion `POST /data_sources/.../query` and got `validation_error` (bad filter/sort body). That is not a platform defect.

`logMcpEvent` already records these on the structured `mcp-event` log line. Forwarding them to Sentry opened warning issues that look like platform bugs and spawn triage agents. This PR skips Sentry capture when `sandboxError` is true; real MCP/platform failures still report at error level.

## Test plan

- [x] `observability.node.test.ts` asserts sandbox failures still emit `mcp-event` but do not call `captureMessage` / `captureException`, while non-sandbox failures still report
- [x] Existing `observability.workers.test.ts` still passes
- [x] `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `9c877620` · **Head:** `93f349fd`

**Classification:** extends — changes MCP failure reporting so sandbox/user-module errors stay on logs only and no longer open Sentry issues.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — sandbox execute failures no longer reported to Sentry |

### System map

Sandbox execute failures used to become Sentry warnings via MCP observability; they now stay on the `mcp-event` log path only.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
	mcpExecute["mcp execute<br/>sandbox run"]:::untouched
	mcpEvent["mcp-event log"]:::untouched
	observability["mcp-server<br/>observability"]:::extended
	sentry["Sentry"]:::untouched
	mcpExecute -->|"result.error"| observability
	observability -->|"always"| mcpEvent
	observability -->|"platform failures only"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** execute sandbox failures (`sandboxError: true`) were captured in Sentry as warnings (`Unknown: …`), including third-party validation errors from caller modules.

**After:** sandbox failures remain on `mcp-event` logs; only non-sandbox MCP failures are sent to Sentry at error level.

### Risk and invariants

- Medium: changes production error visibility for one failure class; does not touch auth, storage isolation, or capability contracts.
- Per-user isolation unchanged; Sentry user id attachment for platform MCP failures is unchanged.

### Docs

No doc updates; behavior is an observability policy change covered by unit tests.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62cc8864-b123-4928-9798-b1689cce6c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62cc8864-b123-4928-9798-b1689cce6c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

