### PR TITLE
Stop reporting remote connector websocket disconnects to Sentry

### DIFF
--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -96,8 +96,8 @@ async function createRemoteConnectorSession(
 }
 
 test('remote connector session lifecycle across restore, snapshot, heartbeat, close, and error', async () => {
-	// Websocket closes log an operational warning alongside the Sentry
-	// capture asserted below.
+	// Websocket closes log an operational warning only (no Sentry capture —
+	// disconnects are expected remote-connector lifecycle noise).
 	consoleWarn.mockImplementation(() => {})
 	const restored = await createRemoteConnectorSession({
 		storedState: {
@@ -165,12 +165,7 @@ test('remote connector session lifecycle across restore, snapshot, heartbeat, cl
 	expect(consoleWarn).toHaveBeenCalledWith(
 		'Remote connector session websocket closed code=1006 wasClean=false reason=network',
 	)
-	expect(captureMessageMock).toHaveBeenCalledWith(
-		expect.any(String),
-		expect.objectContaining({
-			level: 'warning',
-		}),
-	)
+	expect(captureMessageMock).not.toHaveBeenCalled()
 	expect(
 		closed.persistedEntries.get('remote-connector-session-state'),
 	).toMatchObject({
@@ -258,12 +253,7 @@ test('remote connector session lifecycle across restore, snapshot, heartbeat, cl
 		{} as WebSocket,
 		new Error('abnormal close'),
 	)
-	expect(captureMessageMock).toHaveBeenCalledWith(
-		expect.any(String),
-		expect.objectContaining({
-			level: 'warning',
-		}),
-	)
+	expect(captureMessageMock).not.toHaveBeenCalled()
 	expect(
 		errored.persistedEntries.get('remote-connector-session-state'),
 	).toMatchObject({
@@ -289,7 +279,8 @@ test('remote connector session lifecycle across restore, snapshot, heartbeat, cl
 	dedupe.state.getWebSockets.mockReturnValue([])
 	await dedupe.session.webSocketError(socket, new Error('abnormal close'))
 	await dedupe.session.webSocketClose(socket, 1006, 'runtime close', false)
-	expect(captureMessageMock).toHaveBeenCalledTimes(1)
+	expect(captureMessageMock).not.toHaveBeenCalled()
+	expect(consoleWarn).toHaveBeenCalled()
 	expect(dedupe.state.storage.put).toHaveBeenCalledTimes(1)
 	expect(
 		dedupe.persistedEntries.get('remote-connector-session-state'),

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -166,17 +166,13 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 				`Remote connector websocket closed code=${code} wasClean=${wasClean}${reason ? ` reason=${reason}` : ''} before RPC response.`,
 			)
 		}
-		const closeMessage = `Remote connector session websocket closed code=${code} wasClean=${wasClean}${reason ? ` reason=${reason}` : ''}`
-		console.warn(closeMessage)
-		this.captureSessionMessage(closeMessage, {
-			level: 'warning',
-			extra: {
-				code,
-				reason,
-				wasClean,
-				connectorId: this.stateSnapshot.persisted.connectorId,
-			},
-		})
+		// Disconnects are expected lifecycle noise for remote connectors
+		// (laptop sleep, process restart, flaky home networks, DO migration).
+		// Keep an ops log line; do not open Sentry issues. Auth failures and
+		// message-handler bugs already capture at error level above.
+		console.warn(
+			`Remote connector session websocket closed code=${code} wasClean=${wasClean}${reason ? ` reason=${reason}` : ''}`,
+		)
 		return this.persistState()
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry issue [7631428009](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7631428009/) (`code=1006 wasClean=false`) and sibling [7631278616](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7631278616/) (`code=1005 wasClean=true`) are warning-level `captureMessage` noise from `RemoteConnectorSession.handleDisconnect`.

Remote connector websockets disconnect constantly for expected reasons (laptop sleep, process restart, flaky home networks, DO migration). Auth failures and message-handler bugs already report at **error** level. This PR keeps the ops `console.warn` and stops opening Sentry issues for routine closes.

## Test plan

- [x] Unit test asserts disconnect/error paths still log via `console.warn` and do **not** call `Sentry.captureMessage`
- [x] Pre-push hooks / e2e green on push

## Siblings

- 7631428009 — code=1006 abnormal close (this issue)
- 7631278616 — code=1005 clean close (same capture site)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `49893e20` · **Head:** `4dd51ca9`

**Classification:** extends — remote connector session disconnects no longer open Sentry warnings; ops logging unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `connector-ingress` | surfaces | extends — disconnect path drops Sentry `captureMessage` |
| `remote-connectors` | assistant | extends — same session DO observability policy |

### System map

Remote connector websocket closes used to become Sentry warnings; they now stay on worker logs only.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
	connector["remote connector<br/>home client"]:::untouched
	session["connector-ingress<br/>Remote connector ingress"]:::extended
	logs["worker logs"]:::untouched
	sentry["Sentry"]:::untouched
	connector -->|"websocket close 1005/1006"| session
	session -->|"console.warn only"| logs
	session -.->|"no longer captureMessage"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** every `webSocketClose` / `webSocketError` called `Sentry.captureMessage` at warning, creating issues per close code/reason.

**After:** disconnects log with `console.warn`; Sentry remains for auth/handler errors already captured at error level.

### Risk and invariants

- Medium (extends observability policy) but narrow: no auth, isolation, billing, migrations, or DR changes.
- Per-user session DO namespacing unchanged.

### Docs

No doc updates; observability policy change covered by unit tests.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f242c25f-2933-4673-ae18-911d539d3c46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f242c25f-2933-4673-ae18-911d539d3c46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expected websocket disconnects by logging operational warnings without creating unnecessary error-monitoring alerts.
  * Preserved existing monitoring for authentication and message-handling failures.
  * Updated lifecycle checks to ensure disconnect warnings are logged consistently without duplicate error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->