### PR TITLE
fix(mcp): soft-fail stalled package retrievers during search/execute

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -407,6 +407,9 @@ automatic context retrieval without promoting those records to durable memory.
 - Retriever exports reach the package storage bucket through `packageStorage()`
   (writable, like every packageStorage surface); keeping retrievers read-mostly
   is a convention
+- Host budgets default to 3s for `search` and 1s for `context` (clamped to 5s /
+  3s). Optional enrichment: a timed-out or failing retriever is skipped with a
+  warning and must not fail the surrounding MCP `search` / `execute` call
 
 Example:
 
@@ -419,7 +422,7 @@ Example:
 				"name": "Personal Inbox",
 				"description": "Searches saved notes and snippets.",
 				"scopes": ["search"],
-				"timeoutMs": 1000,
+				"timeoutMs": 3000,
 				"maxResults": 5
 			}
 		}

--- a/packages/worker/src/package-retrievers/service.node.test.ts
+++ b/packages/worker/src/package-retrievers/service.node.test.ts
@@ -1,0 +1,179 @@
+import { expect, test, vi } from 'vitest'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+
+const mockFns = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	getEntitySourceById: vi.fn(),
+	listPackageRetrieversForScope: vi.fn(),
+	loadPublishedBundleArtifactByIdentity: vi.fn(),
+	runBundledModuleWithRegistry: vi.fn(),
+	createPackageEventTools: vi.fn(() => ({})),
+	createPackageRuntimeInvokeTools: vi.fn(() => ({})),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: mockFns.getSavedPackageById,
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: mockFns.getEntitySourceById,
+}))
+
+vi.mock('#worker/package-retrievers/manifest-cache.ts', () => ({
+	listPackageRetrieversForScope: mockFns.listPackageRetrieversForScope,
+}))
+
+vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', () => ({
+	loadPublishedBundleArtifactByIdentity:
+		mockFns.loadPublishedBundleArtifactByIdentity,
+}))
+
+vi.mock('#mcp/run-kody-registry.ts', () => ({
+	runBundledModuleWithRegistry: mockFns.runBundledModuleWithRegistry,
+}))
+
+vi.mock('#worker/package-invocations/service.ts', () => ({
+	createPackageEventTools: mockFns.createPackageEventTools,
+	createPackageRuntimeInvokeTools: mockFns.createPackageRuntimeInvokeTools,
+}))
+
+function createRetrieverEntry(input: {
+	packageId: string
+	kodyId: string
+	retrieverKey: string
+	scopes?: Array<'search' | 'context'>
+}) {
+	return {
+		userId: 'user-1',
+		packageId: input.packageId,
+		kodyId: input.kodyId,
+		sourceId: `source-${input.packageId}`,
+		revision: 'commit-1',
+		retrieverKey: input.retrieverKey,
+		exportName: `./${input.retrieverKey}`,
+		entryPoint: `./${input.retrieverKey}.ts`,
+		name: input.retrieverKey,
+		description: `${input.retrieverKey} retriever`,
+		scopes: input.scopes ?? (['search'] as Array<'search' | 'context'>),
+		timeoutMs: null,
+		maxResults: null,
+	}
+}
+
+function createSavedPackage(input: { packageId: string; kodyId: string }) {
+	return {
+		id: input.packageId,
+		userId: 'user-1',
+		name: input.kodyId,
+		kodyId: input.kodyId,
+		description: input.kodyId,
+		tags: [],
+		searchText: input.kodyId,
+		sourceId: `source-${input.packageId}`,
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+	}
+}
+
+function createEntitySource(input: { packageId: string }) {
+	return {
+		id: `source-${input.packageId}`,
+		user_id: 'user-1',
+		repo_id: `repo-${input.packageId}`,
+		entity_kind: 'package',
+		entity_id: input.packageId,
+		manifest_path: 'package.json',
+		source_root: '.',
+		published_commit: 'commit-1',
+		created_at: '2026-01-01T00:00:00.000Z',
+		updated_at: '2026-01-01T00:00:00.000Z',
+	}
+}
+
+test('runPackageRetrievers soft-fails a timed-out retriever and keeps healthy results', async () => {
+	const healthy = createRetrieverEntry({
+		packageId: 'pkg-healthy',
+		kodyId: 'healthy-pkg',
+		retrieverKey: 'notes',
+	})
+	const stalled = createRetrieverEntry({
+		packageId: 'pkg-stalled',
+		kodyId: 'stalled-pkg',
+		retrieverKey: 'inbox',
+	})
+	mockFns.listPackageRetrieversForScope.mockResolvedValue([healthy, stalled])
+	mockFns.getSavedPackageById.mockImplementation(
+		async (_db: unknown, input: { packageId: string }) =>
+			createSavedPackage({
+				packageId: input.packageId,
+				kodyId:
+					input.packageId === 'pkg-healthy' ? 'healthy-pkg' : 'stalled-pkg',
+			}),
+	)
+	mockFns.getEntitySourceById.mockImplementation(
+		async (_db: unknown, sourceId: string) =>
+			createEntitySource({
+				packageId: sourceId.replace(/^source-/, ''),
+			}),
+	)
+	mockFns.loadPublishedBundleArtifactByIdentity.mockResolvedValue({
+		artifact: {
+			mainModule: 'main.js',
+			modules: { 'main.js': 'export default async () => ({ results: [] })' },
+			dependencies: [],
+		},
+	})
+	mockFns.runBundledModuleWithRegistry.mockImplementation(
+		async (
+			_env: unknown,
+			_caller: unknown,
+			_bundle: unknown,
+			_params: unknown,
+			options: { runtimeDebug?: { name?: string } },
+		) => {
+			if (options.runtimeDebug?.name === 'inbox') {
+				return { result: undefined, error: 'Execution timed out' }
+			}
+			return {
+				result: {
+					results: [
+						{
+							id: 'note-1',
+							title: 'Healthy note',
+							summary: 'from healthy retriever',
+							score: 0.9,
+						},
+					],
+				},
+			}
+		},
+	)
+
+	consoleError.mockImplementation(() => {})
+
+	const { runPackageRetrievers } =
+		await import('#worker/package-retrievers/service.ts')
+	const run = await runPackageRetrievers({
+		env: { APP_DB: {}, BUNDLE_ARTIFACTS_KV: {} } as Env,
+		baseUrl: 'https://example.com',
+		userId: 'user-1',
+		scope: 'search',
+		query: 'notes',
+	})
+
+	expect(run.results).toEqual([
+		expect.objectContaining({
+			id: 'note-1',
+			packageId: 'pkg-healthy',
+			kodyId: 'healthy-pkg',
+			retrieverKey: 'notes',
+		}),
+	])
+	expect(run.warnings).toEqual([
+		'Package retriever "stalled-pkg/inbox" failed and was skipped: Execution timed out',
+	])
+	expect(consoleError).toHaveBeenCalledTimes(1)
+})

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
@@ -17,10 +18,13 @@ const defaultSearchLimit = 5
 const defaultContextLimit = 2
 const maxSearchLimit = 20
 const maxContextLimit = 3
-const defaultSearchTimeoutMs = 1_000
-const defaultContextTimeoutMs = 300
+// Retrievers are optional enrichment. Keep budgets short so a slow package
+// cannot dominate search/execute wall time, but leave enough headroom for cold
+// isolate + packageStorage work. Individual failures must not fail the tool.
+const defaultSearchTimeoutMs = 3_000
+const defaultContextTimeoutMs = 1_000
 const maxSearchTimeoutMs = 5_000
-const maxContextTimeoutMs = 1_000
+const maxContextTimeoutMs = 3_000
 const maxResultSummaryLength = 1_000
 const maxResultDetailsLength = 4_000
 
@@ -214,7 +218,7 @@ async function invokeRetriever(input: {
 		},
 	)
 	if (executionResult.error) {
-		throw executionResult.error
+		throw new Error(getErrorMessage(executionResult.error))
 	}
 	const parsed = packageRetrieverOutputSchema.safeParse(executionResult.result)
 	if (!parsed.success) {
@@ -279,27 +283,53 @@ export async function runPackageRetrievers(input: {
 			scope: input.scope,
 		})
 	).slice(0, input.maxProviders ?? (input.scope === 'context' ? 3 : 10))
-	const results = (
-		await Promise.all(
-			entries.map((entry) =>
-				invokeRetriever({
-					env: input.env,
-					baseUrl: input.baseUrl,
-					userId,
-					scope: input.scope,
-					entry,
-					query,
-					includeHiddenPackages,
-					memoryContext: input.memoryContext,
-					conversationId: input.conversationId,
-				}),
-			),
+	// Soft-fail per retriever: one stalled/buggy package must not fail MCP
+	// `search` or pre-sandbox execute memory/context enrichment. Callers already
+	// surface `warnings` to agents.
+	const settled = await Promise.allSettled(
+		entries.map((entry) =>
+			invokeRetriever({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId,
+				scope: input.scope,
+				entry,
+				query,
+				includeHiddenPackages,
+				memoryContext: input.memoryContext,
+				conversationId: input.conversationId,
+			}),
+		),
+	)
+	const results: Array<PackageRetrieverSurfaceResult> = []
+	const warnings: Array<string> = []
+	for (let index = 0; index < settled.length; index += 1) {
+		const outcome = settled[index]
+		const entry = entries[index]
+		if (!outcome || !entry) continue
+		if (outcome.status === 'fulfilled') {
+			results.push(...outcome.value)
+			continue
+		}
+		const reason = getErrorMessage(outcome.reason)
+		console.error(
+			JSON.stringify({
+				message: 'package retriever failed',
+				packageId: entry.packageId,
+				kodyId: entry.kodyId,
+				retrieverKey: entry.retrieverKey,
+				scope: input.scope,
+				reason,
+			}),
 		)
-	).flat()
+		warnings.push(
+			`Package retriever "${entry.kodyId}/${entry.retrieverKey}" failed and was skipped: ${reason}`,
+		)
+	}
 	return {
 		results: results.sort(
 			(left, right) => (right.score ?? 0) - (left.score ?? 0),
 		),
-		warnings: [],
+		warnings,
 	}
 }


### PR DESCRIPTION
## Summary

Agents were seeing MCP `Error: Execution timed out` on `search` (and sometimes `execute`) after ~1–2s — far below the documented ~90s execute sandbox budget.

**Root cause:** package retrievers are optional enrichment with short sandbox budgets (previously 1s search / 300ms context). After #551, a single timed-out retriever used `Promise.all` and failed the entire MCP tool call with the sandbox string `"Execution timed out"`. That matches Sentry `KODY-CLOUDFLARE-P` / `KODY-CLOUDFLARE-12` durations (~1–2s) and "some agents" (those with slow/cold package retrievers).

**Fix:**
- Soft-fail per retriever again (`Promise.allSettled` + warning); keep healthy results
- Raise defaults to 3s search / 1s context (max 5s / 3s)
- Do not reintroduce Sentry capture for these optional failures (keeps triage noise down after #917)
- Document host budgets and fail-soft behavior

## Validation

- Unit: `packages/worker/src/package-retrievers/service.node.test.ts` (soft-fail keeps healthy results)
- Pre-push hooks ran on push (includes e2e)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `dc25e719` · **Head:** `f111178e`

**Classification:** extends — optional package-retriever enrichment no longer fails MCP `search` / `execute` when one retriever times out.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `packages` | assistant | extends — package retriever runs soft-fail with warnings; default budgets raised |
| `mcp-server` | surfaces | composes — search/execute keep working when enrichment stalls |

Classifier note: `packages/worker/src/package-retrievers/**` is not yet under a `code` root in `primitives.yaml`; behavior is package-enrichment for MCP tools.

### System map

Package retrievers enrich MCP search/execute; a stalled retriever now skips instead of aborting the tool.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
	mcpSearch["MCP search / execute"]:::untouched
	retrievers["packages<br/>package retrievers"]:::extended
	sandbox["execute sandbox<br/>short budget"]:::untouched
	mcpSearch -->|"enrichment"| retrievers
	retrievers -->|"timeout/error → warn + skip"| mcpSearch
	retrievers --> sandbox
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** one retriever `"Execution timed out"` failed the whole MCP `search`/`execute` call (~1–2s wall time).

**After:** that retriever is skipped with a warning; other retrievers and core search/execute results still return.

### Invariants

Retriever runs remain user-scoped (`userId` on package/source lookups). Soft-fail never substitutes another user's retriever data.

### Docs

`docs/contributing/packages-and-manifests.md` documents host budgets and fail-soft enrichment.

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP search/execute enrichment behavior and timeout defaults; failures are isolated but agents may see new warnings instead of hard errors when retrievers stall.
> 
> **Overview**
> Fixes MCP **`search`** and **`execute`** failing with **`Execution timed out`** when a single optional package retriever stalled under the old short budgets.
> 
> **`runPackageRetrievers`** now uses **`Promise.allSettled`** so one slow or broken retriever is logged, recorded in **`warnings`**, and skipped while other retrievers still contribute results. Default host budgets rise to **3s search / 1s context** (caps **5s / 3s**), and contributor docs describe fail-soft enrichment behavior.
> 
> A unit test covers the timeout skip path; per-retriever execution errors are normalized via **`getErrorMessage`** before surfacing in warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f111178e8fa8a59c3d633300171d31f27aafa751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retriever timeouts now allow more time for search and context operations, within defined limits.
  * Failed or timed-out retrievers are skipped with a warning while successful retrievers continue returning results.

* **Documentation**
  * Updated contributor guidance to explain timeout defaults, limits, and failure behavior.
  * Updated the example retriever timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->