### PR TITLE
Keep unknown search domains out of Sentry, and stop the batch carve-out over-suppressing

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -3,7 +3,7 @@ import { expect, test, vi } from 'vitest'
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
-	getEntitySourceById: vi.fn(),
+	getEntitySourceByIdForUser: vi.fn(),
 	resolveArtifactDefaultBranchHead: vi.fn(),
 	resolveExistingArtifactSourceRepo: vi.fn(),
 	createStubSavedPackage: vi.fn(),
@@ -24,8 +24,8 @@ vi.mock('#worker/package-registry/package-owner.ts', () => ({
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
-	getEntitySourceById: (...args: Array<unknown>) =>
-		mockModule.getEntitySourceById(...args),
+	getEntitySourceByIdForUser: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceByIdForUser(...args),
 }))
 
 vi.mock('#worker/repo/artifacts.ts', async () => {
@@ -122,20 +122,25 @@ function mockPackageSource(sourceUserId = 'user-1') {
 		name: '@kentcdodds/unleashed-wifi',
 		sourceId: 'source-1',
 	})
-	mockModule.getEntitySourceById.mockResolvedValue({
-		id: 'source-1',
-		user_id: sourceUserId,
-		entity_kind: 'package',
-		entity_id: 'package-1',
-		repo_id: 'package-package-1',
-		published_commit: 'commit-1',
-		indexed_commit: null,
-		manifest_path: 'package.json',
-		source_root: '/',
-		last_external_check_at: null,
-		created_at: '2026-05-04T00:00:00.000Z',
-		updated_at: '2026-05-04T00:00:00.000Z',
-	})
+	mockModule.getEntitySourceByIdForUser.mockImplementation(
+		async (_db: unknown, input: { id: string; userId: string }) => {
+			if (input.userId !== sourceUserId) return null
+			return {
+				id: 'source-1',
+				user_id: sourceUserId,
+				entity_kind: 'package',
+				entity_id: 'package-1',
+				repo_id: 'package-package-1',
+				published_commit: 'commit-1',
+				indexed_commit: null,
+				manifest_path: 'package.json',
+				source_root: '/',
+				last_external_check_at: null,
+				created_at: '2026-05-04T00:00:00.000Z',
+				updated_at: '2026-05-04T00:00:00.000Z',
+			}
+		},
+	)
 	const createToken = vi.fn(async (scope: 'read' | 'write', ttl: number) => ({
 		id: 'token-1',
 		plaintext: `art_v1_${scope}_token?expires=${Math.floor(Date.now() / 1000) + ttl}`,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -5,7 +5,7 @@ const mockModule = vi.hoisted(() => ({
 	captureException: vi.fn(),
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
-	getEntitySourceById: vi.fn(),
+	getEntitySourceByIdForUser: vi.fn(),
 	resolveArtifactSourceHead: vi.fn(),
 	publishFromExternalRef: vi.fn(),
 	listPublishedPackageArtifactTargets: vi.fn(),
@@ -26,8 +26,8 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
-	getEntitySourceById: (...args: Array<unknown>) =>
-		mockModule.getEntitySourceById(...args),
+	getEntitySourceByIdForUser: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceByIdForUser(...args),
 }))
 
 vi.mock('#worker/repo/artifacts.ts', () => ({
@@ -67,7 +67,7 @@ function setupDefaultMocks() {
 		name: '@kentcdodds/demo-package',
 		sourceId: 'source-1',
 	})
-	mockModule.getEntitySourceById.mockResolvedValue({
+	mockModule.getEntitySourceByIdForUser.mockResolvedValue({
 		id: 'source-1',
 		user_id: 'user-1',
 		entity_kind: 'package',
@@ -470,7 +470,7 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 	expect(consoleWarn).toHaveBeenCalledTimes(1)
 
 	setupDefaultMocks()
-	mockModule.getEntitySourceById
+	mockModule.getEntitySourceByIdForUser
 		.mockResolvedValueOnce({
 			id: 'source-1',
 			user_id: 'user-1',

--- a/packages/worker/src/mcp/capabilities/packages/resolve-package-source.ts
+++ b/packages/worker/src/mcp/capabilities/packages/resolve-package-source.ts
@@ -3,7 +3,7 @@ import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
 } from '#worker/package-registry/repo.ts'
-import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import { getEntitySourceByIdForUser } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 
 export type PackageSourceIdentity = {
@@ -47,8 +47,11 @@ export async function resolveOwnedPackageSource(input: {
 		const missingId = input.args.package_id ?? input.args.kody_id
 		throw new McpCallerError(`Saved package "${missingId}" was not found.`)
 	}
-	const source = await getEntitySourceById(input.db, savedPackage.sourceId)
-	if (!source || source.user_id !== input.userId) {
+	const source = await getEntitySourceByIdForUser(input.db, {
+		id: savedPackage.sourceId,
+		userId: input.userId,
+	})
+	if (!source) {
 		throw new McpCallerError('Repo source was not found for this user.')
 	}
 	return {

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -126,6 +126,18 @@ test('logMcpEvent keeps caller mistakes out of Sentry', () => {
 
 		logMcpEvent({
 			...callerFailureBase,
+			tool: 'search',
+			toolName: 'search',
+			errorName: 'McpCallerError',
+			errorMessage:
+				'Unknown domain "skills". Available domains: account, packages.',
+			cause: new McpCallerError(
+				'Unknown domain "skills". Available domains: account, packages.',
+			),
+		})
+
+		logMcpEvent({
+			...callerFailureBase,
 			capabilityName: 'repo_open_session',
 			failurePhase: 'handler',
 			errorName: 'Error',
@@ -154,7 +166,7 @@ test('logMcpEvent keeps caller mistakes out of Sentry', () => {
 		})
 	})
 
-	expect(payloads).toHaveLength(4)
+	expect(payloads).toHaveLength(5)
 	expect(sentryMock.captureException).not.toHaveBeenCalled()
 	expect(sentryMock.captureMessage).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/tools/search-core.ts
+++ b/packages/worker/src/mcp/tools/search-core.ts
@@ -1,3 +1,4 @@
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	deterministicEmbedding,
 	embedTextForVectorize,
@@ -174,7 +175,9 @@ export async function searchUnified(input: {
 	if (domainFilter) {
 		const availableDomains = listSearchDomainNames(input.registry)
 		if (!availableDomains.includes(domainFilter)) {
-			throw new Error(
+			// Caller passed a non-domain id (often a package kody id such as
+			// "skills"). Clear from the message alone — keep it off Sentry.
+			throw new McpCallerError(
 				`Unknown domain "${domainFilter}". Available domains: ${[...availableDomains].sort().join(', ')}.`,
 			)
 		}

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -643,24 +643,96 @@ test('search tool batches entity detail with per-ref isolation and preserves sin
 	])
 
 	mockPerformanceNow.mockReturnValueOnce(400).mockReturnValueOnce(410)
-	const allFailed = await handler({
-		entity: ['missing_a:capability', 'missing_b:capability'],
-		conversationId: 'conv-batch-all-failed',
-	})
-	expect(allFailed.isError).toBe(true)
-	expect(allFailed.structuredContent.error).toMatch(
-		/all entity lookups failed/i,
+	const observability = await import('#mcp/observability.ts')
+	const logMcpEventSpy = vi.spyOn(observability, 'logMcpEvent')
+	try {
+		const allFailed = await handler({
+			entity: ['missing_a:capability', 'missing_b:capability'],
+			conversationId: 'conv-batch-all-failed',
+		})
+		expect(allFailed.isError).toBe(true)
+		expect(allFailed.structuredContent.error).toMatch(
+			/all entity lookups failed/i,
+		)
+		expect(allFailed.structuredContent.result).toEqual([
+			expect.objectContaining({
+				entityRef: 'missing_a:capability',
+				error: expect.any(String),
+			}),
+			expect.objectContaining({
+				entityRef: 'missing_b:capability',
+				error: expect.any(String),
+			}),
+		])
+		expect(logMcpEventSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				outcome: 'failure',
+				callerError: true,
+				errorName: 'EntityBatchError',
+			}),
+		)
+	} finally {
+		logMcpEventSpy.mockRestore()
+	}
+})
+
+test('entity batch all-fail reports platform errors to Sentry (no callerError)', async () => {
+	const observability = await import('#mcp/observability.ts')
+	const logMcpEventSpy = vi.spyOn(observability, 'logMcpEvent')
+	mockModule.getSavedPackageById.mockImplementation(
+		async (_db: unknown, input: { packageId: string }) => ({
+			id: input.packageId,
+			userId: 'user-1',
+			name: input.packageId,
+			kodyId: input.packageId,
+			description: 'pkg',
+			tags: [],
+			searchText: 'pkg',
+			sourceId: `source-${input.packageId}`,
+			hasApp: false,
+			hidden: false,
+			isPrivate: true,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		}),
 	)
-	expect(allFailed.structuredContent.result).toEqual([
-		expect.objectContaining({
-			entityRef: 'missing_a:capability',
-			error: expect.any(String),
-		}),
-		expect.objectContaining({
-			entityRef: 'missing_b:capability',
-			error: expect.any(String),
-		}),
-	])
+	mockModule.loadPackageSourceBySourceId.mockRejectedValue(
+		new Error('D1 read failed'),
+	)
+	try {
+		const { handler } = await getSearchRegistration({
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User',
+				username: 'user',
+			},
+		})
+		mockPerformanceNow.mockReturnValueOnce(500).mockReturnValueOnce(510)
+		const response = await handler({
+			entity: ['pkg-a:package', 'pkg-b:package'],
+			conversationId: 'conv-batch-platform-fail',
+		})
+		expect(response.isError).toBe(true)
+		expect(logMcpEventSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				outcome: 'failure',
+				errorName: 'EntityBatchError',
+				cause: expect.objectContaining({
+					message: 'All entity lookups failed.',
+				}),
+			}),
+		)
+		const failureCall = logMcpEventSpy.mock.calls.find(
+			(call) =>
+				(call[0] as { errorName?: string }).errorName === 'EntityBatchError',
+		)
+		expect(failureCall?.[0]).not.toHaveProperty('callerError', true)
+	} finally {
+		logMcpEventSpy.mockRestore()
+		mockModule.getSavedPackageById.mockReset()
+		mockModule.loadPackageSourceBySourceId.mockReset()
+	}
 })
 
 test('integration entity detail enriches related packages without bloating ranked search', async () => {

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -324,18 +324,9 @@ export async function runSearchTool(input: {
 				markdownParts.push(entityResult.markdown)
 			}
 			const allFailed = successCount === 0
-			const failedEntries = outcome.results.filter(
-				(
-					entry,
-				): entry is Extract<(typeof outcome.results)[number], { ok: false }> =>
-					!entry.ok,
-			)
-			// Only treat a total batch failure as caller-caused when every
-			// failed lookup was a caller mistake. Shared platform failures
-			// (DB/load) still reach Sentry.
-			const allCallerFailures =
-				failedEntries.length > 0 &&
-				failedEntries.every((entry) => entry.callerError)
+			const allFailuresAreCallerErrors =
+				allFailed &&
+				outcome.results.every((entry) => !entry.ok && entry.callerError)
 			logMcpEvent({
 				category: 'mcp',
 				tool: 'search',
@@ -348,7 +339,14 @@ export async function runSearchTool(input: {
 				...(allFailed
 					? {
 							sandboxError: false,
-							...(allCallerFailures ? { callerError: true } : {}),
+							// Only treat the batch as a caller mistake when every
+							// entry failed with McpCallerError. Mixed/platform
+							// failures must still reach Sentry.
+							...(allFailuresAreCallerErrors
+								? { callerError: true }
+								: {
+										cause: new Error('All entity lookups failed.'),
+									}),
 							errorName: 'EntityBatchError',
 							errorMessage: 'All entity lookups failed.',
 						}

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
 import {
 	CAPABILITY_EMBEDDING_DIMENSIONS,
@@ -2001,17 +2002,19 @@ test('searchUnified domain scoping: filter, browse, reject unknown, and overview
 	expect(names).toContain('email_send')
 	expect(names).not.toContain('job_schedule')
 
-	await expect(
-		searchUnified({
-			env: {} as Env,
-			query: 'send email',
-			limit: 10,
-			userId: 'user-1',
-			registry,
-			optionalRows: emptyOptionalSearchRows,
-			domain: 'nope',
-		}),
-	).rejects.toThrow(/Unknown domain "nope"/)
+	const unknownDomain = await searchUnified({
+		env: {} as Env,
+		query: 'send email',
+		limit: 10,
+		userId: 'user-1',
+		registry,
+		optionalRows: emptyOptionalSearchRows,
+		domain: 'nope',
+	}).catch((error: unknown) => error)
+	expect(unknownDomain).toBeInstanceOf(McpCallerError)
+	expect(unknownDomain).toMatchObject({
+		message: expect.stringMatching(/Unknown domain "nope"/),
+	})
 
 	const browse = await searchUnified({
 		env: {} as Env,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-CLOUDFLARE-1T](https://kent-c-dodds-tech-llc.sentry.io/issues/7631557973/).

> **Rebuilt on current `main` after #919 merged.** This branch and #919 were written in parallel against the same files and both independently created `packages/worker/src/mcp/caller-error.ts` and the `observability.ts` carve-out. #919 landed first, so everything it already covers has been dropped from here and the branch was rebuilt from `main` as a single commit. See the comment below for the details of what was removed and why. Original history: `be6f6d3b`, `40c09329`, `ff5546c1`, `c452e166`.

An MCP client called `search({ domain: "skills" })`. `skills` is a popular package kody id, not a capability domain. `searchUnified` correctly rejected it, but threw a plain `Error`, so observability opened a Sentry issue that looks like a platform bug.

### What is left in this PR

1. **Unknown search domain is a caller mistake.** `searchUnified` now throws `McpCallerError` for a domain id that is not in the registry, so the failure stays on the `mcp-event` log line. This is the actual `-1T` fix.

2. **The entity-batch carve-out no longer over-suppresses.** #919 marks a fully-failed `search({ entity: [...] })` batch as `callerError`. That is right when every ref was simply unresolvable, but wrong when the batch failed because something underneath broke — a D1 read failing mid-batch would have been silently swallowed. The batch is now only marked `callerError` when *every* entry failed with a caller error, and otherwise passes a `cause` so the failure reaches Sentry as an exception. Two tests in `search-handler.node.test.ts` cover both directions, which is the regression guard for the whole carve-out.

3. **`resolveOwnedPackageSource` scopes in the query.** It used the existing `getEntitySourceByIdForUser` helper instead of loading a source by id and then filtering on `source.user_id` in app code. Behaviour is unchanged; the scoping just lives where `AGENTS.md` asks for it. Mock updates in `get-git-remote.node.test.ts` and `publish-external-push.node.test.ts` follow from that.

Item 3 is unrelated to the Sentry cleanup and is easy to drop if you would rather keep this PR to items 1 and 2 — it survived only because it had already been written and reviewed here.

### Not in this PR any more

Everything #919 shipped: `caller-error.ts`, the `isCallerFailure` skip in `observability.ts`, and the `meta/search.ts`, `openapi-provider/*`, `packages/*`, `repo-open-session.ts`, and `search-detail.ts` throw-site conversions.

### Related

#923 finishes the same family from the other direction — the sibling throw sites that raise message strings identical to ones #919 converted, which would otherwise have reopened the archived Sentry groups under a different culprit. #923 and this PR touch disjoint files.

## Validation

`npm run validate` green in full on the rebuilt branch: `format:check`, `lint` (1 pre-existing warning in `sentry-tunnel.node.test.ts`, 0 errors), `typecheck`, 1289 unit tests across 397 files, 18 Playwright E2E, 2 MCP E2E, `backup:build`, `primitives:check`, `migrations:check`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `653ae7c1` · **Head:** `a2ff96b8`

**Classification:** composes — reuses #919's `McpCallerError` contract at one more throw site and tightens the batch classification it introduced. No primitive changes shape.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | composes — unknown `search` domain throws `McpCallerError`; entity-batch failures only count as caller errors when every entry was one |
| `saved-packages` | assistant | composes — package source resolution scopes by user in the query |

### System map

Unknown domain ids and fully-unresolvable entity batches are classified as caller mistakes; anything else in those paths still reaches Sentry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
  capabilityRegistry["capability-registry<br/>Capability registry"]:::untouched
  savedPackages["saved-packages<br/>Saved packages"]:::touched
  mcpServer -->|"unknown domain id rejected as McpCallerError"| capabilityRegistry
  mcpServer -->|"batch marked callerError only when every entry was one"| mcpServer
  savedPackages -->|"getEntitySourceByIdForUser scopes the lookup"| savedPackages
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** `search({ domain: "skills" })` opened a Sentry issue. A fully-failed entity batch was always treated as a caller mistake, so a platform failure underneath it was suppressed.

**After:** the unknown domain stays on `mcp-event`. A fully-failed batch is only suppressed when every entry was itself a caller error; otherwise it reaches Sentry as an exception.

### Invariants

Per-user isolation is preserved and slightly tightened: `resolveOwnedPackageSource` now filters by `userId` in the query rather than after the read.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0369148-b9df-4a36-825b-d95623e484ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0369148-b9df-4a36-825b-d95623e484ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid MCP requests, missing resources, authentication issues, and unsupported search domains with clearer caller-facing errors.
  * Prevented caller-caused errors from being reported to Sentry as platform failures.
  * Improved error classification across search, package, repository, and OpenAPI operations.
* **Tests**
  * Added coverage confirming caller errors are classified correctly and excluded from platform failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->