### PR TITLE
Finish the MCP caller-error carve-out, and give auth denials a home in the audit log

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -216,8 +216,20 @@ comes from `APP_COMMIT_SHA` when set (deploy workflows pass it as a var), and
 
 MCP tools emit structured `mcp-event` logs via
 `packages/worker/src/mcp/observability.ts`. On failures, the same module sends
-Sentry events (with MCP tags and context); sandbox user-code failures are
-reported at **warning** severity, while capability handler bugs use **error**.
+Sentry events at **error** severity (with MCP tags and context). Failures the
+caller can clear from the message alone — `McpCallerError`,
+`failurePhase: 'parse_input'`, or an explicit `callerError` payload flag,
+including sandbox user-code failures — stay on the structured `mcp-event` log
+line and never reach Sentry; genuine platform failures still do. New "not found
+/ bad argument" throw sites in `packages/worker/src/mcp/**` should use
+`McpCallerError`.
+
+Authentication and authorization denials are deliberately **not**
+`McpCallerError`. `/mcp` rejects anonymous callers at the transport before any
+capability runs, so a denial reaching a handler means an internal caller built a
+context without a user — a defect worth an issue. Attack visibility for these
+lives in the audit log rather than the error stream; see
+[Security](../security.md).
 
 ### Workers native tracing (OpenTelemetry)
 

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -114,6 +114,36 @@ accounts are never locked out.
 - `/mcp` requires a bearer token whose audience matches the origin
   (`packages/worker/src/mcp-auth.ts`).
 
+## MCP denial visibility
+
+MCP authentication and authorization denials are recorded in `audit_events`
+(`category: 'auth'`, `result: 'failure'`) via `recordMcpAuthDenial`
+(`packages/worker/src/mcp/auth-audit.ts`), not in Sentry. A single denial is a
+routine agent turn, so it is not an error; a burst from one principal is how
+permission probing or a compromised account would look, and the audit log is the
+surface built for that — hashed identifiers, 180-day retention, an admin-only
+query (`admin_audit_log_query`), and the failure-per-day and failure-per-hour
+charts on `/admin/insights`. Two sites record:
+
+- `handleMcpRequest` rejecting a resolved grant (`mcp_token_rejected`):
+  unidentifiable grant, unverified email, suspended account.
+- `assertCallerCanAccessCapability` refusing a capability
+  (`mcp_capability_denied`): missing user, role, permission, or feature flag.
+  This is the single choke point every capability call passes through, so it
+  covers the whole authorization surface.
+
+**Deliberately not recorded:** rejections that happen before a grant resolves —
+a missing, empty, or unparseable bearer token. Those are reachable by any
+anonymous request, so auditing them would let a stranger drive unbounded D1
+writes, and "someone sent a bad token" is not attributable to a principal. The
+consequence is that **brute-forcing or replaying tokens against `/mcp` does not
+appear in the audit log**; flood control for anonymous traffic belongs at the
+edge (Cloudflare rate limiting / WAF), not in application writes.
+
+There is also no automatic alerting. Denials are recorded and charted, but
+nothing pages anyone, so a slow, low-volume prober would be present in the data
+without necessarily drawing attention.
+
 ## Public connector routes are WebSocket-only
 
 The Worker entrypoint (`packages/worker/src/index.ts`) only forwards user-scoped

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -4,8 +4,13 @@ import {
 } from '@cloudflare/workers-oauth-provider'
 import { isAccountSuspended } from '#app/account-suspension.ts'
 import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { getRequestIp } from '#app/audit-log.ts'
 import { isAccountEmailVerified } from '#app/email-verification.ts'
 import { buildMcpUserContextFromGrantProps } from './mcp-auth-user-context.ts'
+import {
+	type McpAuthDenialReason,
+	recordMcpAuthDenial,
+} from './mcp/auth-audit.ts'
 import { withAccountWriteLease } from '#app/account-deletion-state.ts'
 import { createMcpCallerContext, type McpServerProps } from './mcp/context.ts'
 import { oauthScopes } from './oauth-handlers.ts'
@@ -118,6 +123,25 @@ export async function handleMcpRequest({
 		env,
 		requestUrl: url,
 	})
+	const recordRejection = async (
+		reason: McpAuthDenialReason,
+		email?: string,
+	) => {
+		await recordMcpAuthDenial({
+			db: env.APP_DB,
+			action: 'mcp_token_rejected',
+			reason,
+			email,
+			ip: getRequestIp(request),
+			path: url.pathname,
+		})
+	}
+
+	// Rejections before a grant resolves are deliberately not audited. They are
+	// reachable by any anonymous request, so writing a row per attempt would let
+	// a stranger drive unbounded D1 writes, and an unattributable "someone sent
+	// a bad token" carries little signal on its own. Flood control for anonymous
+	// traffic belongs at the edge; see docs/contributing/security.md.
 	const authHeader = request.headers.get('Authorization')
 	if (!authHeader || !authHeader.startsWith('Bearer ')) {
 		return createUnauthorizedResponse(origin)
@@ -148,6 +172,7 @@ export async function handleMcpRequest({
 	// A D1 failure inside `isAccountEmailVerified` propagates as an error
 	// instead of silently allowing access.
 	if (!mcpUser) {
+		await recordRejection('unidentified_grant')
 		return createEmailVerificationRequiredResponse(origin)
 	}
 	const emailVerified = await isAccountEmailVerified({
@@ -156,6 +181,7 @@ export async function handleMcpRequest({
 		stableUserId: mcpUser.userId,
 	})
 	if (!emailVerified) {
+		await recordRejection('email_unverified', mcpUser.email)
 		return createEmailVerificationRequiredResponse(origin)
 	}
 
@@ -169,6 +195,7 @@ export async function handleMcpRequest({
 		stableUserId: mcpUser.userId,
 	})
 	if (suspended) {
+		await recordRejection('account_suspended', mcpUser.email)
 		return createAccountSuspendedResponse()
 	}
 

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -90,6 +90,8 @@ type MockDbOptions = {
 	accountByStableId?: MockAccountRow | null
 	// Rows returned for remote connector settings queries.
 	connectorRows?: Array<Record<string, unknown>>
+	// Optional sink for audit rows written while rejecting a request.
+	auditInserts?: Array<Array<unknown>>
 	// Optional sink for which verification SQL shapes were exercised.
 	verificationLookups?: Array<VerificationLookupKind>
 }
@@ -120,6 +122,12 @@ function createMockDb(options: MockDbOptions = {}) {
 				}
 			},
 			async run() {
+				// Denials that resolve to a principal are recorded in the audit
+				// log on the way out.
+				if (normalized.startsWith('insert into audit_events')) {
+					options.auditInserts?.push(boundParams)
+					return { meta: { changes: 1 } }
+				}
 				if (normalized.startsWith('update users')) {
 					if (
 						!normalized.includes('where stable_user_id = ?') ||
@@ -544,7 +552,10 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 	expect(noUserResponse.status).toBe(403)
 	expect(fetchMcpCalled).toBe(false)
 
-	// Verified but suspended accounts are rejected with a dedicated error.
+	// Verified but suspended accounts are rejected with a dedicated error, and
+	// the rejection is recorded so a suspended principal that keeps calling
+	// stays visible instead of failing silently.
+	const auditInserts: Array<Array<unknown>> = []
 	const suspendedResponse = await handleMcpRequest({
 		request,
 		env: createEnv(
@@ -554,6 +565,7 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 			}),
 			{},
 			{
+				auditInserts,
 				emailVerifiedAt: new Date(0).toISOString(),
 				suspendedAt: new Date(0).toISOString(),
 			},
@@ -566,6 +578,14 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 		error: 'account_suspended',
 	})
 	expect(fetchMcpCalled).toBe(false)
+	expect(auditInserts).toHaveLength(1)
+	// category, action, result, then the hashed email — never the raw address.
+	expect(auditInserts[0]?.slice(0, 3)).toEqual([
+		'auth',
+		'mcp_token_rejected',
+		'failure',
+	])
+	expect(auditInserts[0]).not.toContain('user@example.com')
 
 	// Indexed stable-user-id lookup verifies accounts when grant props lack email.
 	const fallbackEmail = 'fallback@example.com'

--- a/packages/worker/src/mcp/auth-audit.node.test.ts
+++ b/packages/worker/src/mcp/auth-audit.node.test.ts
@@ -1,0 +1,119 @@
+import { expect, test, vi } from 'vitest'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+import { assertCallerCanAccessCapability } from './capabilities/access-control.ts'
+import { createMcpCallerContext } from './context.ts'
+
+const sentryMock = vi.hoisted(() => ({
+	captureException: vi.fn(),
+	captureMessage: vi.fn(),
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+	isInitialized: () => true,
+	getClient: () => ({
+		getOptions: () => ({ dsn: 'https://audit@example.com/1' }),
+	}),
+	withScope: (run: (scope: unknown) => void) =>
+		run({
+			setLevel: vi.fn(),
+			setUser: vi.fn(),
+			setTag: vi.fn(),
+			setContext: vi.fn(),
+		}),
+	captureException: sentryMock.captureException,
+	captureMessage: sentryMock.captureMessage,
+}))
+
+const adminCapability = {
+	name: 'admin_user_get',
+	requiredRole: 'admin',
+} as const
+
+function memberContext(userId: string) {
+	return createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId,
+			email: `${userId}@example.com`,
+			displayName: userId,
+			roles: ['user'],
+			permissions: ['read:user:own'],
+		},
+	})
+}
+
+test('a single capability denial is audited without becoming a Sentry error', async () => {
+	const callerContext = memberContext('user-1')
+
+	await expect(
+		assertCallerCanAccessCapability(callerContext, adminCapability),
+	).rejects.toThrow(
+		'MCP user lacks required role "admin" for capability "admin_user_get".',
+	)
+
+	expect(auditEventSummaries()).toEqual(['mcp_capability_denied:failure'])
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'mcp_capability_denied',
+			result: 'failure',
+			reason: 'role',
+			email: 'user-1@example.com',
+			path: 'admin_user_get',
+		}),
+	)
+	expect(sentryMock.captureException).not.toHaveBeenCalled()
+	expect(sentryMock.captureMessage).not.toHaveBeenCalled()
+})
+
+// The point of this one: routine denials are quiet, but a principal walking the
+// capability surface must stay visible. If a future change silences denials the
+// way an earlier revision of this work did, this test fails.
+test('a principal enumerating admin capabilities stays visible in the audit log', async () => {
+	const callerContext = memberContext('prober')
+	const probedCapabilities = Array.from(
+		{ length: 25 },
+		(_, index) => `admin_capability_${index}`,
+	)
+
+	for (const name of probedCapabilities) {
+		await expect(
+			assertCallerCanAccessCapability(callerContext, {
+				name,
+				requiredRole: 'admin',
+			}),
+		).rejects.toThrow(`for capability "${name}".`)
+	}
+
+	const denials = logAuditEventSpy.mock.calls.map(([event]) => event)
+	expect(denials).toHaveLength(probedCapabilities.length)
+	expect(denials.every((event) => event.result === 'failure')).toBe(true)
+	expect(denials.every((event) => event.category === 'auth')).toBe(true)
+
+	// One principal against many distinct capabilities is the shape that
+	// separates probing from an agent that simply called the wrong thing once.
+	expect(new Set(denials.map((event) => event.email))).toEqual(
+		new Set(['prober@example.com']),
+	)
+	expect(new Set(denials.map((event) => event.path))).toEqual(
+		new Set(probedCapabilities),
+	)
+})
+
+test('audit denials carry the raw identifier for the sink to hash, never a stored secret', async () => {
+	await expect(
+		assertCallerCanAccessCapability(
+			createMcpCallerContext({ baseUrl: 'https://heykody.dev' }),
+			adminCapability,
+		),
+	).rejects.toThrow(
+		'Authenticated MCP user is required to execute capability "admin_user_get".',
+	)
+
+	const [event] = logAuditEventSpy.mock.calls.at(-1) ?? []
+	expect(event).toMatchObject({ reason: 'no_user', category: 'auth' })
+	expect(event?.email).toBeUndefined()
+})

--- a/packages/worker/src/mcp/auth-audit.ts
+++ b/packages/worker/src/mcp/auth-audit.ts
@@ -1,0 +1,52 @@
+import { logAuditEvent } from '#app/audit-log.ts'
+
+/**
+ * Why MCP auth denials go to the audit log instead of Sentry.
+ *
+ * A single denial is a conversation turn: an agent calls something it is not
+ * allowed to call, reads the message, and corrects itself. Reporting each one
+ * as an error creates issues that look like platform bugs. But this is also the
+ * only place we would see a token being replayed or a principal walking the
+ * capability surface, so dropping them outright trades noise for a blind spot.
+ *
+ * The audit log already resolves that tension for browser and OAuth sign-in
+ * failures: identifiers are hashed, rows keep for 180 days, admins can query
+ * them, and `/admin/insights` charts failures per day and per hour. Recording
+ * denials there keeps the error stream clean while a burst still shows up as a
+ * spike on a chart that already exists.
+ *
+ * Only denials that resolve to a principal are recorded. Anonymous rejections
+ * are reachable by anyone and would let a stranger drive unbounded writes, so
+ * `/mcp` deliberately drops them rather than auditing them.
+ */
+export type McpAuthDenialReason =
+	| 'unidentified_grant'
+	| 'email_unverified'
+	| 'account_suspended'
+	| 'no_user'
+	| 'role'
+	| 'permission'
+	| 'feature_flag'
+	| 'denied'
+
+export async function recordMcpAuthDenial(input: {
+	db?: D1Database
+	action: 'mcp_token_rejected' | 'mcp_capability_denied'
+	reason: McpAuthDenialReason
+	/** Hashed by the audit sink; the raw value is never stored. */
+	email?: string
+	ip?: string | null
+	/** Capability name for a denial, request path for a token rejection. */
+	path?: string
+}) {
+	await logAuditEvent({
+		db: input.db,
+		category: 'auth',
+		action: input.action,
+		result: 'failure',
+		reason: input.reason,
+		email: input.email,
+		ip: input.ip ?? undefined,
+		path: input.path,
+	})
+}

--- a/packages/worker/src/mcp/capabilities/access-control.ts
+++ b/packages/worker/src/mcp/capabilities/access-control.ts
@@ -11,6 +11,10 @@ import {
 } from '#worker/feature-flags/registry.ts'
 import { getFeatureFlagsForUser } from '#worker/feature-flags/service.ts'
 import { normalizeStableUserId } from '#worker/user-id.ts'
+import {
+	type McpAuthDenialReason,
+	recordMcpAuthDenial,
+} from '#mcp/auth-audit.ts'
 import { type BuiltCapabilityRegistry } from './build-capability-registry.ts'
 import { type Capability, type CapabilitySpec } from './types.ts'
 
@@ -135,33 +139,57 @@ export async function assertCallerCanAccessCapability(
 	}
 
 	const user = getUserAccessContext(callerContext)
+	const denial = describeCapabilityDenial(user, capability)
+	// A denial is the one signal we would have that a principal is walking the
+	// capability surface, so it is recorded even though it is not an error.
+	await recordMcpAuthDenial({
+		db: options.env?.APP_DB,
+		action: 'mcp_capability_denied',
+		reason: denial.reason,
+		email: callerContext.user?.email,
+		path: capability.name,
+	})
+	throw new Error(denial.message)
+}
+
+function describeCapabilityDenial(
+	user: ReturnType<typeof getUserAccessContext>,
+	capability: CapabilityAccessRequirement,
+): { reason: McpAuthDenialReason; message: string } {
 	if (!user) {
-		throw new Error(
-			`Authenticated MCP user is required to execute capability "${capability.name}".`,
-		)
+		return {
+			reason: 'no_user',
+			message: `Authenticated MCP user is required to execute capability "${capability.name}".`,
+		}
 	}
 	if (
 		capability.requiredRole &&
 		!hasRequiredRole(user, capability.requiredRole)
 	) {
-		throw new Error(
-			`MCP user lacks required role "${capability.requiredRole}" for capability "${capability.name}".`,
-		)
+		return {
+			reason: 'role',
+			message: `MCP user lacks required role "${capability.requiredRole}" for capability "${capability.name}".`,
+		}
 	}
 	if (
 		capability.requiredPermission &&
 		!hasRequiredPermission(user, capability.requiredPermission)
 	) {
-		throw new Error(
-			`MCP user lacks required permission "${capability.requiredPermission}" for capability "${capability.name}".`,
-		)
+		return {
+			reason: 'permission',
+			message: `MCP user lacks required permission "${capability.requiredPermission}" for capability "${capability.name}".`,
+		}
 	}
 	if (capability.featureFlag) {
-		throw new Error(
-			`MCP user lacks required feature flag "${capability.featureFlag}" for capability "${capability.name}".`,
-		)
+		return {
+			reason: 'feature_flag',
+			message: `MCP user lacks required feature flag "${capability.featureFlag}" for capability "${capability.name}".`,
+		}
 	}
-	throw new Error(`MCP user cannot access capability "${capability.name}".`)
+	return {
+		reason: 'denied',
+		message: `MCP user cannot access capability "${capability.name}".`,
+	}
 }
 
 export function filterCapabilityRegistryForCaller(

--- a/packages/worker/src/mcp/capabilities/admin-community-activity.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin-community-activity.node.test.ts
@@ -34,7 +34,14 @@ test('admin community activity list enforces admin role, filters, paginates, and
 		adminCommunityActivityListCapability.handler({}, createContext(['user'])),
 	).rejects.toThrow('lacks required role "admin"')
 	expect(mocks.listCommunityActivityForAdmin).not.toHaveBeenCalled()
-	expect(logAuditEventSpy).not.toHaveBeenCalled()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'mcp_capability_denied',
+			result: 'failure',
+			reason: 'role',
+		}),
+	)
 
 	mocks.listCommunityActivityForAdmin.mockResolvedValue({
 		total: 3,
@@ -94,6 +101,7 @@ test('admin community activity list enforces admin role, filters, paginates, and
 	expect(result.activity[0]).not.toHaveProperty('user_id')
 	expect(result.activity[0]).not.toHaveProperty('package_source')
 	expect(auditEventSummaries()).toEqual([
+		'mcp_capability_denied:failure',
 		'admin_community_activity_list:success',
 	])
 })

--- a/packages/worker/src/mcp/capabilities/openapi/openapi-binding-refresh.ts
+++ b/packages/worker/src/mcp/capabilities/openapi/openapi-binding-refresh.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { saveValue } from '#mcp/values/service.ts'
 import {
 	assertOpenApiBindingWithinSizeLimit,
@@ -74,7 +75,9 @@ export const openapiBindingRefreshCapability = defineDomainCapability(
 				},
 			})
 			if (!existing) {
-				throw new Error(`OpenAPI binding "${args.name}" was not found.`)
+				throw new McpCallerError(
+					`OpenAPI binding "${args.name}" was not found.`,
+				)
 			}
 			const rawText = await fetchOpenApiSpecText({
 				specUrl: existing.specUrl,

--- a/packages/worker/src/mcp/capabilities/packages/package-debug-get-run.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-debug-get-run.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { getPackageRuntimeRun } from '#worker/package-runtime/package-runtime-debug.ts'
 import {
 	formatPackageRuntimeLog,
@@ -39,7 +40,9 @@ export const packageDebugGetRunCapability = defineDomainCapability(
 				runId: args.run_id,
 			})
 			if (!result) {
-				throw new Error(`Package runtime run "${args.run_id}" was not found.`)
+				throw new McpCallerError(
+					`Package runtime run "${args.run_id}" was not found.`,
+				)
 			}
 			return {
 				run: formatPackageRuntimeRun(result.run),

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-get.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-get.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { getPackageInvocationTokenById } from '#worker/package-invocations/repo.ts'
 import { packageInvocationTokenMetadataSchema } from './shared.ts'
 
@@ -39,7 +40,9 @@ export const packageInvocationTokenGetCapability = defineDomainCapability(
 				tokenId: args.token_id,
 			})
 			if (!token) {
-				throw new Error('Package invocation token not found for this user.')
+				throw new McpCallerError(
+					'Package invocation token not found for this user.',
+				)
 			}
 			return {
 				token: {

--- a/packages/worker/src/mcp/capabilities/platform-feedback-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/platform-feedback-capabilities.node.test.ts
@@ -236,7 +236,14 @@ test('admin platform feedback capabilities enforce role access, redact lists, pa
 		),
 	).rejects.toThrow('lacks required role "admin"')
 	expect(mockModule.listPlatformFeedbackForAdmin).not.toHaveBeenCalled()
-	expect(logAuditEventSpy).not.toHaveBeenCalled()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'mcp_capability_denied',
+			result: 'failure',
+			reason: 'role',
+		}),
+	)
 
 	mockModule.listPlatformFeedbackForAdmin.mockResolvedValue({
 		total: 3,
@@ -346,6 +353,7 @@ test('admin platform feedback capabilities enforce role access, redact lists, pa
 		'Cannot dismiss platform feedback "feedback-1" from status "resolved".',
 	)
 	expect(auditEventSummaries()).toEqual([
+		'mcp_capability_denied:failure',
 		'admin_platform_feedback_list:success',
 		'admin_platform_feedback_get:success',
 		'admin_platform_feedback_update:success',

--- a/packages/worker/src/mcp/capabilities/repo/repo-resolve-target.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-resolve-target.node.test.ts
@@ -1,0 +1,52 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getEntitySourceById: vi.fn(),
+	getSavedPackageById: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
+}))
+
+const { resolveRepoSourceReference } = await import('./repo-resolve-target.ts')
+
+test('resolveRepoSourceReference throws McpCallerError for missing source and package', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.getSavedPackageById.mockReset()
+	mockModule.getSavedPackageByKodyId.mockReset()
+
+	mockModule.getEntitySourceById.mockResolvedValue(null)
+	const missingSource = resolveRepoSourceReference({
+		db: {} as D1Database,
+		userId: 'user-1',
+		args: { source_id: 'source-missing' },
+	})
+
+	await expect(missingSource).rejects.toThrow(McpCallerError)
+	await expect(missingSource).rejects.toThrow(
+		'Repo source was not found for this user.',
+	)
+
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	const missingPackage = resolveRepoSourceReference({
+		db: {} as D1Database,
+		userId: 'user-1',
+		args: { target: { kind: 'package', package_id: 'pkg-missing' } },
+	})
+
+	await expect(missingPackage).rejects.toThrow(McpCallerError)
+	await expect(missingPackage).rejects.toThrow(
+		'Saved package "pkg-missing" was not found.',
+	)
+})

--- a/packages/worker/src/mcp/capabilities/repo/repo-resolve-target.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-resolve-target.ts
@@ -1,10 +1,11 @@
 import { type z } from 'zod'
-import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
-import { type EntitySourceRow } from '#worker/repo/types.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
 } from '#worker/package-registry/repo.ts'
+import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import { type EntitySourceRow } from '#worker/repo/types.ts'
 import {
 	type repoOpenSessionInputSchema,
 	type repoResolvedTargetSchema,
@@ -22,7 +23,7 @@ async function requireOwnedEntitySource(input: {
 }): Promise<EntitySourceRow> {
 	const source = await getEntitySourceById(input.db, input.sourceId)
 	if (!source || source.user_id !== input.userId) {
-		throw new Error('Repo source was not found for this user.')
+		throw new McpCallerError('Repo source was not found for this user.')
 	}
 	return source
 }
@@ -56,7 +57,7 @@ async function requirePackageTarget(input: {
 			'package_id' in input.target
 				? input.target.package_id
 				: input.target.kody_id
-		throw new Error(`Saved package "${missingId}" was not found.`)
+		throw new McpCallerError(`Saved package "${missingId}" was not found.`)
 	}
 	const source = await requireOwnedEntitySource({
 		db: input.db,
@@ -92,7 +93,7 @@ export async function resolveRepoSourceReference(input: {
 		}
 	}
 	if (!input.args.target) {
-		throw new Error('Repo source identity is required.')
+		throw new McpCallerError('Repo source identity is required.')
 	}
 	return requirePackageTarget({
 		db: input.db,

--- a/packages/worker/src/mcp/capabilities/repo/repo-show-publish-note.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-show-publish-note.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { resolveOwnedPackageSource } from '#mcp/capabilities/packages/resolve-package-source.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import {
 	kodyPublishGitNoteSchema,
@@ -86,11 +87,11 @@ export const repoShowPublishNoteCapability = defineDomainCapability(
 							})
 						).source
 			if (!source || source.user_id !== user.userId) {
-				throw new Error('Repo source was not found for this user.')
+				throw new McpCallerError('Repo source was not found for this user.')
 			}
 			const commit = args.commit ?? source.published_commit
 			if (!commit) {
-				throw new Error(
+				throw new McpCallerError(
 					`Source "${source.id}" has no published commit yet. Pass an explicit \`commit\` or publish source first.`,
 				)
 			}

--- a/packages/worker/src/mcp/capabilities/services/service-get.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-get.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
-import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	normalizePackageServiceStatus,
 	packageServiceStatusSchema,
@@ -30,7 +31,9 @@ export const serviceGetCapability = defineDomainCapability(
 				explicitPackageId: args.package_id,
 			})
 			if (!serviceContext.service) {
-				throw new Error(`Package service "${args.service_name}" was not found.`)
+				throw new McpCallerError(
+					`Package service "${args.service_name}" was not found.`,
+				)
 			}
 			return normalizePackageServiceStatus(
 				await serviceContext.service.status(),

--- a/packages/worker/src/mcp/capabilities/services/service-stop.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-stop.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { requirePackageServiceContext } from './shared.ts'
 
 const inputSchema = z.object({
@@ -31,7 +32,9 @@ export const serviceStopCapability = defineDomainCapability(
 				explicitPackageId: args.package_id,
 			})
 			if (!serviceContext.service) {
-				throw new Error(`Package service "${args.service_name}" was not found.`)
+				throw new McpCallerError(
+					`Package service "${args.service_name}" was not found.`,
+				)
 			}
 			const result = (await serviceContext.service.stop()) as { ok?: unknown }
 			return {

--- a/packages/worker/src/mcp/tools/search-detail.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-detail.node.test.ts
@@ -1,0 +1,90 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
+	getValue: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
+	collectIntegrationPackageSuggestions: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageSourceBySourceId(...args),
+}))
+
+vi.mock('#mcp/values/service.ts', () => ({
+	getValue: (...args: Array<unknown>) => mockModule.getValue(...args),
+}))
+
+vi.mock('./integration-package-suggestions.ts', () => ({
+	collectIntegrationPackageSuggestions: (...args: Array<unknown>) =>
+		mockModule.collectIntegrationPackageSuggestions(...args),
+}))
+
+const { resolveEntityDetail } = await import('./search-detail.ts')
+
+function createAgent() {
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'user',
+		},
+	})
+	return {
+		getEnv: () => ({ APP_DB: {} }) as Env,
+		getCallerContext: () => callerContext,
+	} as unknown as McpRegistrationAgent
+}
+
+function emptySearchRows() {
+	return {
+		userValueRows: [],
+		userSecretRows: [],
+		packageRows: [],
+		registry: { capabilitySpecs: {} },
+	}
+}
+
+test('resolveEntityDetail reports unresolvable entity refs as caller errors', async () => {
+	mockModule.getValue.mockReset()
+	mockModule.getValue.mockResolvedValue(null)
+
+	const agent = createAgent()
+	const callerContext = agent.getCallerContext()
+	const searchRows = emptySearchRows() as never
+	const resolve = (entity: string) =>
+		resolveEntityDetail({
+			agent,
+			callerContext,
+			userId: 'user-1',
+			username: 'user',
+			entity,
+			searchRows,
+		})
+
+	const expected = [
+		['nope:capability', 'Capability not found.'],
+		['user:missing-value:value', 'Persisted value not found for this user.'],
+		['notion:integration', 'Saved integration not found for this user.'],
+		['API_KEY:secret', 'Secret not found for this user.'],
+	] as const
+
+	for (const [entity, message] of expected) {
+		const detail = resolve(entity)
+		await expect(detail).rejects.toThrow(McpCallerError)
+		await expect(detail).rejects.toThrow(message)
+	}
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two separable commits. Review them independently — the first is mechanical, the second is the design answer to the auth question Kent raised on the previous revision of this PR.

| Commit | What |
| --- | --- |
| `da782759` | Finish the not-found caller-error family (uncontroversial) |
| `46c92150` | Record MCP auth denials in the audit log instead of Sentry (the design work) |

> These would have been two PRs. The Cursor Cloud PR tool is pinned to this task's designated branch and refuses to open a second one, so they are stacked here as separate commits instead. `cursor/sentry-k1-mcp-auth-audit-signal` holds the second commit alone if splitting is preferred.

**The earlier revision of this PR routed auth denials through `McpCallerError`. That is gone.** Both guards report exactly as they did before; the second commit is what replaces it.

---

## Commit 1 — finish the not-found family

#919 carved out a first batch of caller-error throw sites. Sibling sites raise the identical message strings from other files, and because Sentry groups by message they would reopen the same archived groups (`KODY-CLOUDFLARE-V`, `-13`, `-11`, `-16`, `-Z`) under a different culprit.

Converted: repo target resolution and publish-note source lookups; the value/integration/secret/capability branches of `resolveEntityDetail` (#919 carved out only the saved-package branch); package run, invocation token, package service, and OpenAPI binding lookups by caller-supplied id. **Every message string is unchanged**, so the MCP response a caller sees is identical.

Left reporting deliberately: `mcp/secrets/package-access.ts` and `capabilities/admin/**`, where the id comes from our own resolution, so a miss is a real inconsistency.

---

## Commit 2 — auth denials

### What I found before designing anything

Three facts changed the shape of the problem:

1. **There is no noise to suppress.** `kody-cloudflare` has 43 Sentry issues across all statuses since the project started, 152 events total. **Not one is an auth or permission denial.** The trade-off as posed had an empty side.
2. **`requireMcpUserWithPermission` has zero production call sites.** Defined, unit-tested, never called. Converting it was a no-op.
3. **Neither guard was the real authorization wall.** `/mcp` rejects anonymous callers at the transport (`mcp-auth.ts` returns 401/403 before any capability runs), so `ctx.callerContext.user` is always populated for a remote call. The wall a real principal hits is `assertCallerCanAccessCapability`, which throws at `define-capability.ts:77` — **before** the `try` at line 82 — so it never goes through `logMcpEvent` and **has never reached Sentry at all**.

So the blind spot was already there, in a third code path, and this PR was neither causing it nor fixing it.

### What I chose

**Record denials in `audit_events`, not Sentry.** Sentry is an error tracker; these are security events with different retention, audience, and query needs. The repo already has the right surface and already uses it for browser and OAuth sign-in failures: identifiers are hashed (raw email and IP never stored), rows keep for 180 days, admins query via `admin_audit_log_query`, and `/admin/insights` charts failures **per day and per hour**. A burst shows up as a spike on a chart that already exists.

| Site | Action | Covers |
| --- | --- | --- |
| `handleMcpRequest` after a grant resolves | `mcp_token_rejected` | unidentifiable grant, unverified email, suspended account |
| `assertCallerCanAccessCapability` | `mcp_capability_denied` | missing user, role, permission, feature flag |

The second is the choke point every capability call passes through, so it covers the whole authorization surface rather than the two guards that prompted the question. Its denial tail is restructured so one audit call replaces five throw sites; every message is unchanged.

**On the Workers / Durable Object constraint:** no counter, no window, no in-process state. Append-only D1 rows. Nothing to lose on a cold start, nothing to reconcile across DOs.

### What I rejected

- **Blanket `McpCallerError` on both guards.** Zero measured benefit, real blind spot. Also wrong on its own terms: since transport auth guarantees a user, a `requireMcpUser` denial reaching a handler means an internal caller built a context without one — a defect we want to see.
- **Fingerprint + TTL dedupe, as in `kody-home-connector#39`.** Right shape for that problem, but its throttle state is a module-scope `Map` in a long-lived Node daemon. In Workers that is per-isolate and evaporates on cold start, so the throttle would be unreliable and unbounded across isolates. Making it correct means D1 state and a window — real machinery, to throttle a stream whose current volume is zero.
- **Per-principal counters with velocity/breadth thresholds.** The textbook answer, and what I would build if volume justified it. It does not.
- **Sentry sampling / rate limits / `beforeSend` aggregation.** Keeps security events in the error tracker, which is the wrong destination however well they are grouped.

### What an attacker could now do without us noticing

1. **Token brute-forcing or replay against `/mcp` is invisible in the audit log.** Rejections before a grant resolves — missing, empty, or unparseable bearer — are deliberately **not** recorded: they are reachable by any anonymous request, so auditing them would let a stranger drive unbounded D1 writes for free. Flood control for anonymous traffic belongs at the edge (Cloudflare rate limiting / WAF), not in application writes. This is the largest gap and it is a deliberate layering choice.
2. **Nothing alerts.** Denials are recorded and charted; no threshold pages anyone. A slow, low-volume prober would be in the data without necessarily drawing attention.
3. **Enumeration via `search` is not a denial.** `filterCapabilityRegistryForCaller` hides admin capabilities from non-admins, so a prober using normal search mostly gets "not found" and never trips this signal.
4. **A compromised admin account generates no denials at all**, because nothing denies it. This signal is about principals hitting walls, not misuse by principals with legitimate access.

### Tests

The attack test is the important one — it is what stops a silent regression in six months.

- `mcp/auth-audit.node.test.ts` — **`a principal enumerating admin capabilities stays visible in the audit log`**: one non-admin principal against 25 distinct admin capabilities produces 25 `auth`/`failure` rows sharing one `email_hash` across 25 distinct capability names. That "one principal, many capabilities" shape is what separates probing from an agent that called the wrong thing once.
- Alongside it: a single denial is audited **and** produces no Sentry capture (proving the noise did not just move), and an anonymous denial carries no email.
- `mcp-auth.workers.test.ts` — a suspended account's rejection is recorded, and the persisted row does **not** contain the raw email address.
- Two existing admin capability tests asserted a role denial produced *no* audit event. That assertion is exactly what changed, so they now assert the denial is recorded.

**I verified the attack test is falsifiable** rather than assuming it: with the `recordMcpAuthDenial` call removed, all three tests in the new file fail. Restored before committing.

## Validation

`npm run validate` green in full: `format:check`, `lint` (1 pre-existing warning in `sentry-tunnel.node.test.ts`, 0 errors), `typecheck`, 1294 unit tests across 400 files, 18 Playwright E2E, 2 MCP E2E, `backup:build`, `primitives:check`, `migrations:check`.

Two unit tests intermittently time out at ~5s under full parallel load and pass in isolation and on re-run; neither is touched here. Pre-existing flake, worth watching on `main` now that #920 raised retriever budgets from 1s/300ms to 3s/1s.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `569128cb` · **Head:** `46c92150`

**Classification:** extends — MCP authorization denials gain an audit-log record; the caller-error carve-out extends to the remaining not-found sites. No new primitive, no new storage, no migration; `audit_events` gains two new `action` values.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — grant-resolved token rejections record an audit event; entity-detail misses throw `McpCallerError` |
| `capability-registry` | assistant | extends — capability denials record an audit event at the shared access-control choke point |
| `rbac` | auth | composes — role/permission denial reasons are classified, not changed |
| `d1-app-db` | storage | composes — new rows in the existing `audit_events` table |
| `saved-packages` | assistant | composes — package run and invocation token misses throw `McpCallerError` |
| `openapi-bindings` | assistant | composes — binding refresh miss throws `McpCallerError` |

### System map

Caller mistakes stay off Sentry; authorization denials leave the error stream entirely and enter the audit log, which already feeds the admin query and the insights failure charts.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
  capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
  rbac["rbac<br/>Role-based access control"]:::touched
  d1AppDb["d1-app-db<br/>D1 app database"]:::touched
  adminUi["app-ui<br/>Browser app"]:::untouched
  mcpServer -->|"not-found misses throw McpCallerError, staying off Sentry"| mcpServer
  mcpServer -->|"grant-resolved rejection writes mcp_token_rejected"| d1AppDb
  capabilityRegistry -->|"denial writes mcp_capability_denied"| d1AppDb
  rbac -->|"role / permission / flag classified as denial reason"| capabilityRegistry
  d1AppDb -->|"audit_events feeds /admin/insights failure charts"| adminUi
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** capability authorization denials threw before `logMcpEvent` ran, so they reached nothing — no Sentry issue, no audit row, no metric. Transport rejections were equally unobserved. Not-found sibling sites still opened Sentry issues.

**After:** denials are rows in `audit_events` with hashed identifiers, visible via `admin_audit_log_query` and the existing `/admin/insights` failure charts. Not-found misses stay on the `mcp-event` log line. Every caller-visible message is unchanged.

### Invariants

Per-user isolation holds. Audit rows store a SHA-256 `email_hash` and `ip_hash`, never raw identifiers, and `audit_events` is readable only through admin-gated surfaces — no user can see another user's activity. No new cross-user read path.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59763862-a4a0-4be2-b0cd-f6c32bd45700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59763862-a4a0-4be2-b0cd-f6c32bd45700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP authentication and capability-access denials are now recorded in audit logs with structured reasons and relevant request details.
  - Administrators can review denial activity and failure trends through the existing insights and audit-log views.

- **Bug Fixes**
  - Caller-originated MCP failures now use consistent caller-facing error handling and are excluded from Sentry reporting.
  - Missing resources and invalid references return clearer MCP caller errors.

- **Documentation**
  - Updated guidance explains MCP failure logging, denial auditing, and visibility limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->