### PR TITLE
[DO NOT MERGE YET] Navigation API stand-in — stopgap pending remix-run/remix#11641

### DIFF
--- a/e2e/ssr-hydration.spec.ts
+++ b/e2e/ssr-hydration.spec.ts
@@ -214,3 +214,48 @@ test('SSR community HTML hydrates SPA navigation and client search', async ({
 
 	expect(clientErrors).toEqual([])
 })
+
+test('the app hydrates on browsers without the Navigation API', async ({
+	page,
+}) => {
+	await ensurePrimaryUserExists()
+	await seedCommunityListingInE2eDatabase({
+		...alphaListing,
+		ownerEmail: primaryTestUser.email,
+		readmeContent: longReadme,
+	})
+
+	const clientErrors: Array<string> = []
+	page.on('pageerror', (error) => clientErrors.push(error.message))
+
+	// Firefox 146 and below, and every browser on iOS 26.1 and below, ship
+	// without the Navigation API. Chromium has had it since 102, so shadow the
+	// getter to stand in for those clients.
+	await page.addInitScript(() => {
+		Object.defineProperty(window, 'navigation', {
+			value: undefined,
+			configurable: true,
+		})
+	})
+
+	await page.goto('/community')
+	await expect(page.getByText(alphaListing.description)).toBeVisible()
+	await page.evaluate(() => {
+		;(window as Window & { __e2eMarker?: boolean }).__e2eMarker = true
+	})
+
+	await page.getByRole('link', { name: alphaListing.name }).click()
+	await expect(page).toHaveURL(
+		new RegExp(`/community/${alphaListing.listingId}$`),
+	)
+	await expect(page.getByRole('heading', { name: 'Stars' })).toBeVisible()
+	// The marker surviving proves the client router handled the click, so
+	// hydration ran rather than the browser doing a document navigation.
+	expect(
+		await page.evaluate(
+			() => (window as Window & { __e2eMarker?: boolean }).__e2eMarker,
+		),
+	).toBe(true)
+
+	expect(clientErrors).toEqual([])
+})

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -1,6 +1,7 @@
 import { run } from 'remix/ui'
 import { REMIX_FRAME_TARGET_HEADER } from '#app/frame-constants.ts'
 import { consumePrefetchedFrame } from '#client/frame-prefetch.ts'
+import { installNavigationApiFallback } from '#client/navigation-api-fallback.ts'
 import {
 	captureClientException,
 	initSentryClient,
@@ -8,6 +9,8 @@ import {
 import { AppRoot, APP_ROOT_ENTRY_ID } from './app-root.tsx'
 
 initSentryClient(document)
+// `run()` reads `window.navigation` unguarded, so this has to land first.
+installNavigationApiFallback(window)
 
 const clientRegistry: Record<string, typeof AppRoot> = {
 	AppRoot,

--- a/packages/worker/client/navigation-api-fallback.node.test.ts
+++ b/packages/worker/client/navigation-api-fallback.node.test.ts
@@ -1,0 +1,55 @@
+import { expect, test, vi } from 'vitest'
+import { installNavigationApiFallback } from './navigation-api-fallback.ts'
+
+function createFakeWindow() {
+	return {
+		location: {
+			href: 'https://heykody.dev/community',
+			assign: vi.fn(),
+			replace: vi.fn(),
+		},
+	} as unknown as Window
+}
+
+test('navigation fallback stands in for the Navigation API only when it is missing', () => {
+	const win = createFakeWindow()
+
+	expect(installNavigationApiFallback(win)).toBe(true)
+
+	// The unguarded call that kills Remix hydration on browsers without the
+	// Navigation API.
+	const navigation = win.navigation
+	navigation.updateCurrentEntry({
+		state: { src: 'https://heykody.dev/community', $rmx: true },
+	})
+	expect(navigation.currentEntry?.getState()).toEqual({
+		src: 'https://heykody.dev/community',
+		$rmx: true,
+	})
+	expect(navigation.entries()).toHaveLength(1)
+
+	// Remix subscribes to `navigate` with an abort signal; nothing ever
+	// dispatches one, so link clicks stay with the browser.
+	const listener = vi.fn()
+	const controller = new AbortController()
+	navigation.addEventListener('navigate', listener, {
+		signal: controller.signal,
+	})
+	expect(listener).not.toHaveBeenCalled()
+
+	navigation.navigate('/community/abc', { history: 'push' })
+	expect(win.location.assign).toHaveBeenCalledWith(
+		'https://heykody.dev/community/abc',
+	)
+	navigation.navigate('/login', { history: 'replace' })
+	expect(win.location.replace).toHaveBeenCalledWith('https://heykody.dev/login')
+
+	const browserWithNavigation = createFakeWindow()
+	const realNavigation = {
+		updateCurrentEntry: vi.fn(),
+	} as unknown as Navigation
+	browserWithNavigation.navigation = realNavigation
+
+	expect(installNavigationApiFallback(browserWithNavigation)).toBe(false)
+	expect(browserWithNavigation.navigation).toBe(realNavigation)
+})

--- a/packages/worker/client/navigation-api-fallback.ts
+++ b/packages/worker/client/navigation-api-fallback.ts
@@ -1,0 +1,113 @@
+/**
+ * Minimal stand-in for the Navigation API, installed only where the browser
+ * does not provide one.
+ *
+ * Remix 3 beta's client runtime reads `window.navigation.updateCurrentEntry()`
+ * unguarded while it boots (`@remix-run/ui`'s `startNavigationListener`), so
+ * `run()` throws on every browser without the Navigation API. The API only
+ * reached Firefox in 147 and WebKit in 26.2, both in early 2026, so that still
+ * covers Firefox 146 and below plus every browser on iOS 26.1 and below — all
+ * of them WebKit, so Chrome for iOS and in-app browsers included.
+ *
+ * The throw lands after `createFrame(...)` but before `run()` returns, so
+ * hydration already in flight survives and the app stays broadly usable. What
+ * those visitors actually lose is an unhandled `TypeError` on every page load,
+ * plus the `app.addEventListener('error', ...)` wiring and `app.ready()` call
+ * in `entry.tsx` that never run — meaning client error reporting is missing
+ * for exactly the people already hitting an error.
+ *
+ * Kody itself never uses the Navigation API: `client-router.tsx` drives SPA
+ * navigation through `history.pushState` and a document-level click handler,
+ * and it calls `preventDefault()` before the Remix listener could intercept
+ * anything. A stand-in that never emits `navigate` is therefore equivalent to
+ * the real API for this app, and the links Remix would have intercepted fall
+ * back to ordinary document navigation.
+ *
+ * Only the members the Remix runtime touches are implemented. Remove this once
+ * the upstream guard ships: https://github.com/remix-run/remix/issues/11641
+ */
+
+type FallbackHistoryEntry = {
+	readonly key: string
+	readonly id: string
+	readonly url: string
+	readonly index: number
+	readonly sameDocument: boolean
+	getState: () => unknown
+}
+
+type FallbackNavigateOptions = {
+	state?: unknown
+	history?: 'auto' | 'push' | 'replace'
+}
+
+const fallbackEntryKey = 'kody-navigation-fallback'
+
+class NavigationApiFallback extends EventTarget {
+	#window: Window
+	#state: unknown = null
+
+	constructor(win: Window) {
+		super()
+		this.#window = win
+	}
+
+	get currentEntry(): FallbackHistoryEntry {
+		return {
+			key: fallbackEntryKey,
+			id: fallbackEntryKey,
+			url: this.#window.location.href,
+			index: 0,
+			sameDocument: true,
+			getState: () => this.#state,
+		}
+	}
+
+	entries(): Array<FallbackHistoryEntry> {
+		return [this.currentEntry]
+	}
+
+	updateCurrentEntry(options: { state?: unknown }) {
+		this.#state = options?.state ?? null
+	}
+
+	navigate(url: string, options?: FallbackNavigateOptions) {
+		this.#state = options?.state ?? null
+		const destination = new URL(url, this.#window.location.href).toString()
+		if (options?.history === 'replace') {
+			this.#window.location.replace(destination)
+		} else {
+			this.#window.location.assign(destination)
+		}
+		// Cross-document navigations discard this document, so the real API
+		// never settles these promises either.
+		const pending = new Promise<FallbackHistoryEntry>(() => {})
+		return { committed: pending, finished: pending }
+	}
+}
+
+/**
+ * Defines `window.navigation` when the browser lacks it.
+ *
+ * @returns whether the fallback was installed.
+ */
+export function installNavigationApiFallback(win: Window) {
+	if (win.navigation) return false
+
+	try {
+		Object.defineProperty(win, 'navigation', {
+			// Only the subset Remix reads is implemented, so the real
+			// `Navigation` type overstates what this provides.
+			value: new NavigationApiFallback(win) as unknown as Navigation,
+			configurable: true,
+			writable: true,
+			enumerable: false,
+		})
+	} catch {
+		// A browser that refuses the definition still gets the unguarded
+		// upstream throw; failing to install must not add a second error.
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> ## ⚠️ Not for merge — awaiting Kent's decision
>
> This is a **stopgap** for an upstream Remix bug ([remix-run/remix#11641](https://github.com/remix-run/remix/issues/11641)), not a fix for anything in our code. A separate agent is building a minimal reproduction repository to attach to that issue so it can be fixed upstream instead.
>
> Opened so the workaround is reviewable if you want it in the meantime. **Do not merge while the upstream fix is still in play.** Merging deploys to heykody.dev.

Split out of #921. The other half of that PR — our own update-during-render bug, KODY-CLOUDFLARE-10 — was merged separately.

## The bug this works around

`@remix-run/ui`'s `startNavigationListener` reads `window.navigation.updateCurrentEntry()` with no feature check, and `run()` calls it during boot:

```ts
export function startNavigationListenerImpl(signal, options) {
  let navigation = window.navigation
  navigation.updateCurrentEntry({ ... })   // throws when the API is absent
```

## Why this is worth your attention despite a 4-event count

**Affected users report nothing at all.** The throw happens *inside* `run()`, so `run()` never returns — which means `entry.tsx` never reaches the two lines after it:

```ts
const app = run({ ... })                     // ← throws here

app.addEventListener('error', (event) => {   // ← never registered
	captureClientException(event.error)
})
void app.ready()                             // ← never called
```

So for exactly the browsers hitting this, our client-side error reporting is never wired up. Every client error those users encounter — this one and any other — goes unreported. The event count is not a measure of how many users are affected; it is a measure of how thoroughly the bug hides itself.

## Who is affected

The Navigation API is far newer than it looks. It reached **Firefox in 147** and **WebKit in 26.2**, both in early 2026:

| Engine | First version with the Navigation API | Still affected |
| --- | --- | --- |
| Chrome / Edge | 102 (2022) | no |
| Firefox | **147** (Jan 2026) | **146 and below** |
| Safari / WebKit | **26.2** | **iOS 26.1 and below, all browsers** |

Every browser on iOS is WebKit, so on iOS ≤ 26.1 this hits Safari, Chrome for iOS, and in-app browsers alike. The Sentry group matches exactly: Firefox 141 on Ubuntu, Chrome Mobile iOS 150 on iOS 26.1, and the X in-app browser on iOS 26.1.

## What actually breaks (corrected)

I initially assumed hydration died completely. Testing against a real Firefox 146 disproved that, and I would rather you have the accurate version: the throw lands *after* `createFrame(...)`, so hydration already in flight survives and **the app stays broadly usable** — client-side routing still intercepts link clicks on production today.

The concrete costs are:

1. An unhandled `TypeError` on every page load for affected visitors.
2. No client-side error reporting for those visitors, per above.
3. The Remix runtime's `navigate` interception never installs (we do not rely on it — see below).

I posted the same correction on the upstream issue.

## What the stopgap does

Kody never uses the Navigation API. `client-router.tsx` drives SPA navigation with `history.pushState` and a document-level click handler, and it calls `preventDefault()` before the Remix listener could ever intercept. So a stand-in that never emits `navigate` is behaviourally identical to the real API *for this app*, and it is a strict no-op wherever the real API exists (`if (win.navigation) return false`).

Only the members the Remix runtime reads are implemented — `updateCurrentEntry`, `entries`, `navigate`, plus `EventTarget`. It is one self-contained file plus two lines in `entry.tsx`, removable in a single revert once upstream lands.

## The case against merging it

- It is a global shim over a framework internal, which is the category you flagged as wanting your eyes.
- If upstream fixes this quickly, we carry a workaround for nothing.
- Defining `window.navigation` where the browser deliberately does not is the kind of thing that can confuse other feature-detecting code, even though nothing in our bundle does that today (the Sentry SDK uses history patching, not the Navigation API).

## The case for merging it as an interim

- Affected users currently get zero client error reporting, so we are blind to their errors until upstream ships *and* we upgrade.
- Firefox 147 and iOS 26.2 are both very recent, so the affected population is not a long tail yet — it is everyone who has not updated.

## Verification

Playwright ships Firefox **146.0.1**, the last release without the Navigation API, so this is the genuine failure condition in a real Gecko engine rather than a simulation. Production (no fix) versus a preview with the fix, same page, same minute:

![Real Firefox 146 comparing production and a deployment with the stand-in](https://cursor.com/artifacts/c/art-bcbb4ac8-7eb3-419f-9d21-09f2e294e307)

<a href="https://cursor.com/agents/bc-0f10e336-544f-4e2c-8675-55edc9b90361/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirefox-146-before-after-verification.mp4"><img src="https://cursor.com/artifacts/c/art-c11161f2-5986-41ce-8645-cb797deefee2" alt="firefox-146-before-after-verification.mp4" /></a>

Also covered by:

- `packages/worker/client/navigation-api-fallback.node.test.ts` — the fallback contract, and that a real Navigation API is never replaced.
- `e2e/ssr-hydration.spec.ts` — a Chromium test that shadows `window.navigation` and asserts the app still hydrates and handles SPA navigation, with a `window` marker proving the client router took the click rather than the browser doing a document load.

`npm run validate` passes.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk — stopgap, not for merge)</summary>

**Mode:** recap · **Base:** `main` @ `569128cb` · **Head:** `2b6b4970`

**Classification:** extends — no new primitives; `app-ui`'s boot sequence gains a
feature-detected global stand-in installed before the Remix runtime starts.

### Primitives touched

| Primitive | Group    | Impact                                                                       |
| --------- | -------- | ---------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — client entry defines `window.navigation` when the browser lacks it |

### System map

Client boot feature-detects the Navigation API and installs a stand-in before starting the Remix runtime, so `run()` completes and `entry.tsx` gets to wire up its error listener.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	remixRuntime["remix-ui<br/>Remix client runtime"]:::untouched
	sentryTunnel["sentry-tunnel<br/>Same-origin error reporting"]:::untouched
	appUi -->|"installNavigationApiFallback(window) before run()"| remixRuntime
	remixRuntime -->|"run() returns, so app.addEventListener('error') is registered"| appUi
	appUi -->|"client errors reach Sentry on affected browsers again"| sentryTunnel
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Browser | Before | After |
| --- | --- | --- |
| Has the Navigation API (Chrome, Edge, Firefox 147+, iOS 26.2+) | unaffected | unaffected — `installNavigationApiFallback` returns early |
| Lacks it (Firefox ≤146, iOS ≤26.1) | unhandled `TypeError` per page load; `entry.tsx` never wires up error reporting | no error; `run()` returns and error reporting is wired up |

### Invariants

No change to per-user isolation. The stand-in holds only the current entry's navigation state and no user data.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f10e336-544f-4e2c-8675-55edc9b90361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f10e336-544f-4e2c-8675-55edc9b90361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for app navigation in browsers that do not provide the Navigation API.
  * Navigation now preserves expected page state and supports standard link routing, including history replacement and back/forward behavior.

* **Bug Fixes**
  * Improved client-side hydration and navigation reliability in environments without native Navigation API support.
  * Prevented navigation-related page errors when opening community listings and their detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->