### PR TITLE
Scope repo entity-source lookups by user in the query

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/repo-open-session.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-open-session.node.test.ts
@@ -7,7 +7,7 @@ import { repoOpenSessionInputSchema } from './repo-shared.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getActiveRepoSessionByConversation: vi.fn(),
-	getEntitySourceById: vi.fn(),
+	getEntitySourceByIdForUser: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
 	repoSessionRpc: vi.fn(),
 }))
@@ -18,8 +18,8 @@ vi.mock('#worker/repo/repo-sessions.ts', () => ({
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
-	getEntitySourceById: (...args: Array<unknown>) =>
-		mockModule.getEntitySourceById(...args),
+	getEntitySourceByIdForUser: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceByIdForUser(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -139,7 +139,7 @@ function createOpenSessionResult() {
 
 function resetMocks() {
 	mockModule.getActiveRepoSessionByConversation.mockReset()
-	mockModule.getEntitySourceById.mockReset()
+	mockModule.getEntitySourceByIdForUser.mockReset()
 	mockModule.getSavedPackageByKodyId.mockReset()
 	mockModule.repoSessionRpc.mockReset()
 }
@@ -193,7 +193,7 @@ test('repo_open_session enforces the repo sessions entitlement for plan users op
 	mockModule.getSavedPackageByKodyId.mockResolvedValueOnce(
 		createSavedPackageRow(userId),
 	)
-	mockModule.getEntitySourceById.mockResolvedValueOnce(
+	mockModule.getEntitySourceByIdForUser.mockResolvedValueOnce(
 		createPackageSourceRow(userId),
 	)
 	const openRpc = createRepoRpc()
@@ -257,7 +257,7 @@ test('repo_open_session resumes an existing active session without enforcing the
 	mockModule.getSavedPackageByKodyId.mockResolvedValueOnce(
 		createSavedPackageRow(userId),
 	)
-	mockModule.getEntitySourceById.mockResolvedValueOnce(
+	mockModule.getEntitySourceByIdForUser.mockResolvedValueOnce(
 		createPackageSourceRow(userId),
 	)
 	const resumeRpc = createRepoRpc()
@@ -309,7 +309,7 @@ test('repo_open_session allows below-max usage and denies at the max plan ceilin
 	mockModule.getSavedPackageByKodyId.mockResolvedValueOnce(
 		createSavedPackageRow(userId),
 	)
-	mockModule.getEntitySourceById.mockResolvedValueOnce(
+	mockModule.getEntitySourceByIdForUser.mockResolvedValueOnce(
 		createPackageSourceRow(userId),
 	)
 	const belowMaxRpc = createRepoRpc()
@@ -347,7 +347,7 @@ test('repo_open_session allows below-max usage and denies at the max plan ceilin
 	mockModule.getSavedPackageByKodyId.mockResolvedValueOnce(
 		createSavedPackageRow(userId),
 	)
-	mockModule.getEntitySourceById.mockResolvedValueOnce(
+	mockModule.getEntitySourceByIdForUser.mockResolvedValueOnce(
 		createPackageSourceRow(userId),
 	)
 	const deniedRpc = createRepoRpc()

--- a/packages/worker/src/mcp/capabilities/repo/repo-resolve-target.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-resolve-target.node.test.ts
@@ -2,14 +2,14 @@ import { expect, test, vi } from 'vitest'
 import { McpCallerError } from '#mcp/caller-error.ts'
 
 const mockModule = vi.hoisted(() => ({
-	getEntitySourceById: vi.fn(),
+	getEntitySourceByIdForUser: vi.fn(),
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
-	getEntitySourceById: (...args: Array<unknown>) =>
-		mockModule.getEntitySourceById(...args),
+	getEntitySourceByIdForUser: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceByIdForUser(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -22,11 +22,11 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 const { resolveRepoSourceReference } = await import('./repo-resolve-target.ts')
 
 test('resolveRepoSourceReference throws McpCallerError for missing source and package', async () => {
-	mockModule.getEntitySourceById.mockReset()
+	mockModule.getEntitySourceByIdForUser.mockReset()
 	mockModule.getSavedPackageById.mockReset()
 	mockModule.getSavedPackageByKodyId.mockReset()
 
-	mockModule.getEntitySourceById.mockResolvedValue(null)
+	mockModule.getEntitySourceByIdForUser.mockResolvedValue(null)
 	const missingSource = resolveRepoSourceReference({
 		db: {} as D1Database,
 		userId: 'user-1',
@@ -48,5 +48,35 @@ test('resolveRepoSourceReference throws McpCallerError for missing source and pa
 	await expect(missingPackage).rejects.toThrow(McpCallerError)
 	await expect(missingPackage).rejects.toThrow(
 		'Saved package "pkg-missing" was not found.',
+	)
+
+	const missingIdentity = resolveRepoSourceReference({
+		db: {} as D1Database,
+		userId: 'user-1',
+		args: {},
+	})
+
+	await expect(missingIdentity).rejects.toThrow(McpCallerError)
+	await expect(missingIdentity).rejects.toThrow(
+		'Repo source identity is required.',
+	)
+})
+
+test('resolveRepoSourceReference scopes the source lookup to the caller', async () => {
+	mockModule.getEntitySourceByIdForUser.mockReset()
+	mockModule.getEntitySourceByIdForUser.mockResolvedValue(null)
+
+	await expect(
+		resolveRepoSourceReference({
+			db: {} as D1Database,
+			userId: 'user-1',
+			args: { source_id: 'source-1' },
+		}),
+	).rejects.toThrow('Repo source was not found for this user.')
+
+	// The user predicate belongs in the query, not in a post-read comparison.
+	expect(mockModule.getEntitySourceByIdForUser).toHaveBeenCalledWith(
+		expect.anything(),
+		{ id: 'source-1', userId: 'user-1' },
 	)
 })

--- a/packages/worker/src/mcp/capabilities/repo/repo-resolve-target.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-resolve-target.ts
@@ -4,7 +4,7 @@ import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
 } from '#worker/package-registry/repo.ts'
-import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import { getEntitySourceByIdForUser } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import {
 	type repoOpenSessionInputSchema,
@@ -21,8 +21,11 @@ async function requireOwnedEntitySource(input: {
 	userId: string
 	sourceId: string
 }): Promise<EntitySourceRow> {
-	const source = await getEntitySourceById(input.db, input.sourceId)
-	if (!source || source.user_id !== input.userId) {
+	const source = await getEntitySourceByIdForUser(input.db, {
+		id: input.sourceId,
+		userId: input.userId,
+	})
+	if (!source) {
 		throw new McpCallerError('Repo source was not found for this user.')
 	}
 	return source

--- a/packages/worker/src/mcp/capabilities/repo/repo-show-publish-note.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-show-publish-note.node.test.ts
@@ -1,14 +1,14 @@
 import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
-	getEntitySourceById: vi.fn(),
+	getEntitySourceByIdForUser: vi.fn(),
 	resolveOwnedPackageSource: vi.fn(),
 	readPublishGitNoteFromArtifactsRepo: vi.fn(),
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
-	getEntitySourceById: (...args: Array<unknown>) =>
-		mockModule.getEntitySourceById(...args),
+	getEntitySourceByIdForUser: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceByIdForUser(...args),
 }))
 
 vi.mock('#mcp/capabilities/packages/resolve-package-source.ts', () => ({
@@ -84,7 +84,7 @@ const sampleNote = {
 
 test('repo_show_publish_note reads notes by source or package identity and rejects cross-user access', async () => {
 	resetMocks()
-	mockModule.getEntitySourceById.mockResolvedValue(sampleSource)
+	mockModule.getEntitySourceByIdForUser.mockResolvedValue(sampleSource)
 	mockModule.readPublishGitNoteFromArtifactsRepo.mockResolvedValue({
 		found: true,
 		commit: 'commit-published',
@@ -127,15 +127,18 @@ test('repo_show_publish_note reads notes by source or package identity and rejec
 	expect(byPackage.found).toBe(false)
 	expect(byPackage.commit).toBe('commit-old')
 
+	// Another user's source is filtered out by the query itself, so the lookup
+	// returns nothing rather than returning a row we then have to reject.
 	resetMocks()
-	mockModule.getEntitySourceById.mockResolvedValue({
-		...sampleSource,
-		user_id: 'other-user',
-	})
+	mockModule.getEntitySourceByIdForUser.mockResolvedValue(null)
 	await expect(
 		repoShowPublishNoteCapability.handler(
 			{ source_id: 'source-1' },
 			createContext(),
 		),
 	).rejects.toThrow('Repo source was not found for this user.')
+	expect(mockModule.getEntitySourceByIdForUser).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining({ id: 'source-1' }),
+	)
 })

--- a/packages/worker/src/mcp/capabilities/repo/repo-show-publish-note.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-show-publish-note.ts
@@ -4,7 +4,7 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { resolveOwnedPackageSource } from '#mcp/capabilities/packages/resolve-package-source.ts'
 import { McpCallerError } from '#mcp/caller-error.ts'
-import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import { getEntitySourceByIdForUser } from '#worker/repo/entity-sources.ts'
 import {
 	kodyPublishGitNoteSchema,
 	readPublishGitNoteFromArtifactsRepo,
@@ -75,7 +75,10 @@ export const repoShowPublishNoteCapability = defineDomainCapability(
 			const user = requireMcpUser(ctx.callerContext)
 			const source =
 				args.source_id !== undefined
-					? await getEntitySourceById(ctx.env.APP_DB, args.source_id)
+					? await getEntitySourceByIdForUser(ctx.env.APP_DB, {
+							id: args.source_id,
+							userId: user.userId,
+						})
 					: (
 							await resolveOwnedPackageSource({
 								db: ctx.env.APP_DB,

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -3,7 +3,7 @@ import { createMcpCallerContext } from '#mcp/context.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getActiveRepoSessionByConversation: vi.fn(),
-	getEntitySourceById: vi.fn(),
+	getEntitySourceByIdForUser: vi.fn(),
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
 	repoSessionRpc: vi.fn(),
@@ -15,8 +15,8 @@ vi.mock('#worker/repo/repo-sessions.ts', () => ({
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
-	getEntitySourceById: (...args: Array<unknown>) =>
-		mockModule.getEntitySourceById(...args),
+	getEntitySourceByIdForUser: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceByIdForUser(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -77,7 +77,7 @@ function createRepoRpc(overrides?: Partial<Record<string, unknown>>) {
 
 function resetMocks() {
 	mockModule.getActiveRepoSessionByConversation.mockReset()
-	mockModule.getEntitySourceById.mockReset()
+	mockModule.getEntitySourceByIdForUser.mockReset()
 	mockModule.getSavedPackageById.mockReset()
 	mockModule.getSavedPackageByKodyId.mockReset()
 	mockModule.repoSessionRpc.mockReset()
@@ -123,7 +123,9 @@ test('repo open → run commands → publish session workflow', async () => {
 	mockModule.getSavedPackageByKodyId.mockResolvedValueOnce(
 		createSavedPackageRow(),
 	)
-	mockModule.getEntitySourceById.mockResolvedValueOnce(createPackageSourceRow())
+	mockModule.getEntitySourceByIdForUser.mockResolvedValueOnce(
+		createPackageSourceRow(),
+	)
 	const openRpc = createRepoRpc()
 	openRpc.openSession.mockResolvedValueOnce({
 		id: 'session-1',
@@ -175,7 +177,7 @@ test('repo open → run commands → publish session workflow', async () => {
 	mockModule.getSavedPackageByKodyId.mockResolvedValueOnce(
 		createSavedPackageRow(),
 	)
-	mockModule.getEntitySourceById.mockResolvedValueOnce({
+	mockModule.getEntitySourceByIdForUser.mockResolvedValueOnce({
 		...createPackageSourceRow(),
 		id: 'source-other',
 		entity_id: 'package-other',
@@ -208,7 +210,7 @@ test('repo open → run commands → publish session workflow', async () => {
 	mockModule.getSavedPackageById
 		.mockResolvedValueOnce(createSavedPackageRow())
 		.mockResolvedValueOnce(createSavedPackageRow())
-	mockModule.getEntitySourceById
+	mockModule.getEntitySourceByIdForUser
 		.mockResolvedValueOnce(createPackageSourceRow())
 		.mockResolvedValueOnce(createPackageSourceRow())
 	const resumeRpc = createRepoRpc()
@@ -309,7 +311,7 @@ test('repo open → run commands → publish session workflow', async () => {
 		createSavedPackageRow(),
 	)
 	mockModule.getSavedPackageById.mockResolvedValueOnce(createSavedPackageRow())
-	mockModule.getEntitySourceById
+	mockModule.getEntitySourceByIdForUser
 		.mockResolvedValueOnce(createPackageSourceRow())
 		.mockResolvedValueOnce(createPackageSourceRow())
 	const failedChecksRpc = createRepoRpc()
@@ -428,7 +430,7 @@ test('repo open → run commands → publish session workflow', async () => {
 	mockModule.getSavedPackageById
 		.mockResolvedValueOnce(createSavedPackageRow())
 		.mockResolvedValueOnce(createSavedPackageRow())
-	mockModule.getEntitySourceById
+	mockModule.getEntitySourceByIdForUser
 		.mockResolvedValueOnce(createPackageSourceRow())
 		.mockResolvedValueOnce(createPackageSourceRow())
 	const publishRpc = createRepoRpc()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Review follow-up to #923, which merged before I could fold this in. CodeRabbit raised a valid point on that PR that I agree with.

`resolveRepoSourceReference` and `repo_show_publish_note` loaded an entity source by id and *then* compared `source.user_id` in application code:

```ts
const source = await getEntitySourceById(input.db, input.sourceId)
if (!source || source.user_id !== input.userId) throw ...
```

`AGENTS.md` asks for every read path to be scoped by `userId`, and the repo already has `getEntitySourceByIdForUser` for exactly this. #922 applied the same change to `resolveOwnedPackageSource`; these two were the remaining instances on caller-supplied ids.

Behaviour is unchanged — another user's source was already rejected. The difference is that it is now filtered by the query rather than fetched and then discarded, so there is no window where a row belonging to someone else is in hand.

Also adds coverage for the missing-identity branch of `resolveRepoSourceReference` (`Repo source identity is required.`), which #923 converted to `McpCallerError` without a test — CodeRabbit's nitpick on the same review, and a fair one.

## Scope note

`getEntitySourceById` remains in use elsewhere (`repo-session-do.ts`, `jobs/service.ts`, `package-runtime/**`, and others). Those resolve ids from our own records rather than from caller input, and converting them is a broader change than this review point warrants. Left alone deliberately.

## Validation

`npm run validate` green in full: `format:check`, `lint` (1 pre-existing warning in `sentry-tunnel.node.test.ts`, 0 errors), `typecheck`, 1295 unit tests across 400 files, 18 Playwright E2E, 2 MCP E2E, `backup:build`, `primitives:check`, `migrations:check`.

The `repo_show_publish_note` cross-user test now asserts the lookup returns nothing for the caller, rather than returning another user's row for the handler to reject — which is the actual contract after this change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `28452280` · **Head:** `7085f365`

**Classification:** composes — swaps two call sites onto an existing user-scoped data-access helper. No primitive changes shape or behaviour; no schema change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | composes — repo target resolution and publish-note lookups use the user-scoped helper |
| `d1-app-db` | storage | composes — the `user_id` predicate moves into the `entity_sources` query |

### System map

Repo capabilities resolve a source through the user-scoped helper, so ownership is enforced by the query instead of a post-read comparison.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
  d1AppDb["d1-app-db<br/>D1 app database"]:::touched
  capabilityRegistry -->|"getEntitySourceByIdForUser filters entity_sources by user_id"| d1AppDb
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Invariants

Strengthens per-user isolation: `entity_sources` reads on caller-supplied ids now carry the `userId` predicate in SQL, so a row belonging to another user is never returned to application code on these paths.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59763862-a4a0-4be2-b0cd-f6c32bd45700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59763862-a4a0-4be2-b0cd-f6c32bd45700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository source access checks to ensure sources are scoped to the requesting user.
  * Prevented unauthorized or missing sources from being resolved or accessed.
  * Added clearer validation when repository source identity information is missing.
* **Tests**
  * Expanded coverage for user-scoped access, missing sources, authorization failures, session handling, and publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->