### PR TITLE
fix(sentry): stop reporting user-module esbuild failures from workflows

### DIFF
--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { filterRetryableD1LockSentryEvent } from './sentry-options.ts'
+import {
+	filterRetryableD1LockSentryEvent,
+	filterSentryEvent,
+	filterUserModuleBundlerFailureSentryEvent,
+} from './sentry-options.ts'
 
 test('filterRetryableD1LockSentryEvent drops transient D1 lock contention and keeps other errors', () => {
 	expect(
@@ -20,4 +24,58 @@ test('filterRetryableD1LockSentryEvent drops transient D1 lock contention and ke
 		},
 	}
 	expect(filterRetryableD1LockSentryEvent(unrelatedEvent)).toBe(unrelatedEvent)
+})
+
+test('filterUserModuleBundlerFailureSentryEvent drops esbuild failures in caller modules', () => {
+	const userModuleBuildFailure = {
+		exception: {
+			values: [
+				{
+					value:
+						'Build failed with 1 error:\nvirtual:.__kody_root__/entry.ts:11:49: ERROR: Unexpected "^"',
+				},
+			],
+		},
+	}
+	expect(
+		filterUserModuleBundlerFailureSentryEvent(userModuleBuildFailure),
+	).toBeNull()
+	expect(filterSentryEvent(userModuleBuildFailure)).toBeNull()
+
+	const platformBuildFailure = {
+		exception: {
+			values: [
+				{
+					value:
+						'Build failed with 1 error:\npackages/worker/src/index.ts:1:0: ERROR: Unexpected "{"',
+				},
+			],
+		},
+	}
+	expect(filterUserModuleBundlerFailureSentryEvent(platformBuildFailure)).toBe(
+		platformBuildFailure,
+	)
+	expect(filterSentryEvent(platformBuildFailure)).toBe(platformBuildFailure)
+
+	const unrelated = {
+		exception: {
+			values: [{ value: 'Execution timed out' }],
+		},
+	}
+	expect(filterUserModuleBundlerFailureSentryEvent(unrelated)).toBe(unrelated)
+	expect(filterSentryEvent(unrelated)).toBe(unrelated)
+})
+
+test('filterSentryEvent still drops retryable D1 lock contention', () => {
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: 'D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY',
+					},
+				],
+			},
+		}),
+	).toBeNull()
 })

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -42,6 +42,15 @@ test('filterUserModuleBundlerFailureSentryEvent drops esbuild failures in caller
 	).toBeNull()
 	expect(filterSentryEvent(userModuleBuildFailure)).toBeNull()
 
+	const userModuleMessageFailure = {
+		message:
+			'Build failed with 1 error:\nvirtual:.__kody_root__/entry.ts:11:49: ERROR: Unexpected "^"',
+	}
+	expect(
+		filterUserModuleBundlerFailureSentryEvent(userModuleMessageFailure),
+	).toBeNull()
+	expect(filterSentryEvent(userModuleMessageFailure)).toBeNull()
+
 	const platformBuildFailure = {
 		exception: {
 			values: [

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -2,6 +2,13 @@ import { type CloudflareOptions } from '@sentry/cloudflare'
 import { type ErrorEvent } from '@sentry/core'
 import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
 
+function sentryEventMessages(event: ErrorEvent) {
+	return [
+		event.message,
+		...(event.exception?.values?.map((value) => value.value) ?? []),
+	]
+}
+
 /**
  * Shared Sentry options for the Cloudflare Worker and Durable Objects.
  * `dsn` may be undefined when Sentry is not configured (local dev / opt-out).
@@ -9,6 +16,33 @@ import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
 export function filterRetryableD1LockSentryEvent(event: ErrorEvent) {
 	if (!isRetryableD1LockSentryEvent(event)) return event
 	return null
+}
+
+/**
+ * Runtime bundling of caller-supplied modules (MCP execute, inline workflows)
+ * puts source under `.__kody_root__/`. When that source is invalid, esbuild
+ * throws `Build failed with … virtual:.__kody_root__/…`. Those are user-module
+ * mistakes, not platform defects — MCP execute already routes them as sandbox
+ * errors, but workflow instrumentation still auto-captures the rethrow.
+ */
+export function isUserModuleBundlerFailureSentryEvent(event: ErrorEvent) {
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			message.includes('Build failed with') &&
+			message.includes('.__kody_root__/'),
+	)
+}
+
+export function filterUserModuleBundlerFailureSentryEvent(event: ErrorEvent) {
+	if (!isUserModuleBundlerFailureSentryEvent(event)) return event
+	return null
+}
+
+export function filterSentryEvent(event: ErrorEvent) {
+	if (filterRetryableD1LockSentryEvent(event) === null) return null
+	if (filterUserModuleBundlerFailureSentryEvent(event) === null) return null
+	return event
 }
 
 export function buildSentryOptions(env: Env): CloudflareOptions {
@@ -32,7 +66,10 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// application capture paths (for example scheduled_lane_failed) still
 		// forwarded them. These are transient lock-contention errors retried in
 		// app code and should not open or regress Sentry issues.
-		beforeSend: filterRetryableD1LockSentryEvent,
+		//
+		// User-module esbuild failures from inline workflows are similarly
+		// expected caller mistakes; see filterUserModuleBundlerFailureSentryEvent.
+		beforeSend: filterSentryEvent,
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-CLOUDFLARE-1X](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7631743981/) (`Error: Build failed with 1 error:` / `failureErrorWithLog`).

An inline Cloudflare Workflow ran caller-supplied code with a broken regex:

```text
subject.match(/[([^/]+)/([^]]+)].*(PR #(d+))/i)
```

esbuild failed with `Unexpected "^"` under `virtual:.__kody_root__/entry.ts`. The workflow correctly marked the run as `errored` and rethrew; `Sentry.instrumentWorkflowWithSentry` then opened a Sentry issue that looks like a platform bug.

MCP `execute` already catches the same bundler failures and reports them as sandbox/caller errors (not Sentry). This PR adds a narrow `beforeSend` filter for the shared signature (`Build failed with` + `.__kody_root__/`) so workflow auto-capture matches that policy. Unrelated build failures without the user-module path still report.

## Test plan

- [x] `sentry-options.node.test.ts` asserts the user-module bundler signature is dropped, platform-path build failures and unrelated errors are kept, and the combined filter still drops D1 lock noise
- [x] Pre-push hooks (unit + e2e) passed on push
- [ ] CI `npm run validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `569128cb` · **Head:** `b1acae8e`

**Classification:** composes — narrow Sentry `beforeSend` filter only; no primitive contracts or workflow execution behavior changed.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(unmatched)_ `sentry-options.ts` | observability | composes — drops user-module esbuild failures already handled as workflow run errors |

### System map

Inline workflow bundler failures still fail the workflow run; Sentry no longer opens a platform issue for the same caller mistake.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
	inlineWorkflow["workflows<br/>Inline workflow run"]:::untouched
	bundler["worker-bundler / esbuild<br/>.__kody_root__ build"]:::untouched
	sentryFilter["sentry-options<br/>beforeSend filter"]:::touched
	inlineWorkflow -->|"execute inline code"| bundler
	bundler -->|"Build failed with … __kody_root__"| sentryFilter
	sentryFilter -->|"drop event"| dropped["Sentry issue skipped"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant WF as DynamicCallableWorkflow
	participant Bundle as buildKodyModuleBundle
	participant Sentry as beforeSend
	WF->>Bundle: inline entry.ts
	Bundle-->>WF: Build failed (__kody_root__)
	WF->>WF: mark workflow_runs errored, rethrow
	WF->>Sentry: auto.faas.cloudflare.workflow
	Sentry-->>Sentry: filter drops event
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bbbaf24-6bb7-4522-b3b7-f83d49062e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bbbaf24-6bb7-4522-b3b7-f83d49062e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced misleading error reports by suppressing Sentry events caused by user-module bundling failures.
  * Continued suppressing retryable database lock contention events.
  * Preserved reporting for platform build failures and unrelated error details.
* **Tests**
  * Added coverage to ensure Sentry filtering behavior correctly suppresses user-module bundling failures while keeping other relevant events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->