### PR TITLE
Assert the caller userId in the publish-note isolation test

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/repo-show-publish-note.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-show-publish-note.node.test.ts
@@ -139,6 +139,6 @@ test('repo_show_publish_note reads notes by source or package identity and rejec
 	).rejects.toThrow('Repo source was not found for this user.')
 	expect(mockModule.getEntitySourceByIdForUser).toHaveBeenCalledWith(
 		expect.anything(),
-		expect.objectContaining({ id: 'source-1' }),
+		{ id: 'source-1', userId: 'user-1' },
 	)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Last review point from #925, which merged before I could fold it in. CodeRabbit was right and it is worth fixing rather than leaving.

The cross-user test for `repo_show_publish_note` asserted the scoped lookup like this:

```ts
expect(mockModule.getEntitySourceByIdForUser).toHaveBeenCalledWith(
	expect.anything(),
	expect.objectContaining({ id: 'source-1' }),
)
```

`objectContaining` only checks the keys it names, so the assertion would still have passed if `userId` were omitted entirely or passed with the wrong value — which is the single thing that test exists to verify. Now it asserts the exact argument:

```ts
expect(mockModule.getEntitySourceByIdForUser).toHaveBeenCalledWith(
	expect.anything(),
	{ id: 'source-1', userId: 'user-1' },
)
```

One line, test-only, no production change.

## Validation

`npm run validate` green in full: `format:check`, `lint` (1 pre-existing warning in `sentry-tunnel.node.test.ts`, 0 errors), `typecheck`, 1295 unit tests across 400 files, 18 Playwright E2E, 2 MCP E2E, `backup:build`, `primitives:check`, `migrations:check`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `36edd717` · **Head:** `5d8adab9`

**Classification:** composes — test-only assertion tightening. No production code, no primitive behaviour change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | composes — test coverage only |

### Invariants

Strengthens the guard on per-user isolation rather than changing it: the repo-source lookup test now fails if the `userId` predicate is dropped from the query call.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59763862-a4a0-4be2-b0cd-f6c32bd45700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59763862-a4a0-4be2-b0cd-f6c32bd45700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated access-control test expectations to verify that source lookups include both the source identifier and requesting user identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->