### PR TITLE
fix(sentry): stop reporting executor sandbox timeouts from workflows

### DIFF
--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'vitest'
 import {
+	executorSandboxTimeoutMessage,
+	filterExecutorSandboxTimeoutSentryEvent,
 	filterRetryableD1LockSentryEvent,
 	filterSentryEvent,
 	filterUserModuleBundlerFailureSentryEvent,
@@ -68,11 +70,43 @@ test('filterUserModuleBundlerFailureSentryEvent drops esbuild failures in caller
 
 	const unrelated = {
 		exception: {
-			values: [{ value: 'Execution timed out' }],
+			values: [{ value: 'D1_ERROR: syntax error near INSERTZ' }],
 		},
 	}
 	expect(filterUserModuleBundlerFailureSentryEvent(unrelated)).toBe(unrelated)
 	expect(filterSentryEvent(unrelated)).toBe(unrelated)
+})
+
+test('filterExecutorSandboxTimeoutSentryEvent drops exact sandbox timeout message', () => {
+	const sandboxTimeout = {
+		exception: {
+			values: [{ value: executorSandboxTimeoutMessage }],
+		},
+	}
+	expect(filterExecutorSandboxTimeoutSentryEvent(sandboxTimeout)).toBeNull()
+	expect(filterSentryEvent(sandboxTimeout)).toBeNull()
+
+	const topLevelMessage = { message: executorSandboxTimeoutMessage }
+	expect(filterExecutorSandboxTimeoutSentryEvent(topLevelMessage)).toBeNull()
+	expect(filterSentryEvent(topLevelMessage)).toBeNull()
+
+	const similarButDifferent = {
+		exception: {
+			values: [{ value: 'Webhook sync invocation timed out.' }],
+		},
+	}
+	expect(filterExecutorSandboxTimeoutSentryEvent(similarButDifferent)).toBe(
+		similarButDifferent,
+	)
+	expect(filterSentryEvent(similarButDifferent)).toBe(similarButDifferent)
+
+	const prefixed = {
+		exception: {
+			values: [{ value: `Error: ${executorSandboxTimeoutMessage}` }],
+		},
+	}
+	expect(filterExecutorSandboxTimeoutSentryEvent(prefixed)).toBe(prefixed)
+	expect(filterSentryEvent(prefixed)).toBe(prefixed)
 })
 
 test('filterSentryEvent still drops retryable D1 lock contention', () => {

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -39,9 +39,31 @@ export function filterUserModuleBundlerFailureSentryEvent(event: ErrorEvent) {
 	return null
 }
 
+/**
+ * Exact message emitted by the execute sandbox when caller code exceeds
+ * `timeoutMs` (`packages/worker/src/mcp/executor.ts`). Inline workflows rethrow
+ * that string as `new Error(...)`; `instrumentWorkflowWithSentry` then
+ * auto-captures it. MCP execute already skips sandbox failures via
+ * `sandboxError`, but workflow instrumentation still reports the rethrow.
+ * Other platform timeouts use different wording (Kit, webhook, snapshot, …).
+ */
+export const executorSandboxTimeoutMessage = 'Execution timed out'
+
+export function isExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
+	return sentryEventMessages(event).some(
+		(message) => message === executorSandboxTimeoutMessage,
+	)
+}
+
+export function filterExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
+	if (!isExecutorSandboxTimeoutSentryEvent(event)) return event
+	return null
+}
+
 export function filterSentryEvent(event: ErrorEvent) {
 	if (filterRetryableD1LockSentryEvent(event) === null) return null
 	if (filterUserModuleBundlerFailureSentryEvent(event) === null) return null
+	if (filterExecutorSandboxTimeoutSentryEvent(event) === null) return null
 	return event
 }
 
@@ -67,8 +89,10 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// forwarded them. These are transient lock-contention errors retried in
 		// app code and should not open or regress Sentry issues.
 		//
-		// User-module esbuild failures from inline workflows are similarly
-		// expected caller mistakes; see filterUserModuleBundlerFailureSentryEvent.
+		// User-module esbuild failures and executor sandbox timeouts from
+		// inline workflows are similarly expected caller mistakes; see
+		// filterUserModuleBundlerFailureSentryEvent and
+		// filterExecutorSandboxTimeoutSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-CLOUDFLARE-1Y](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7631786101/) (`Error: Execution timed out` / `DynamicCallableWorkflowBase.invokeInlineWorkflowCode`).

An inline Cloudflare Workflow ran caller-supplied code that exceeded the execute sandbox `timeoutMs`. The sandbox returns the exact message `Execution timed out`; `invokeInlineWorkflowCode` rethrows it as `new Error(...)`, the workflow marks the run `errored`, and `Sentry.instrumentWorkflowWithSentry` auto-captures the rethrow (`mechanism=auto.faas.cloudflare.workflow`) as if it were a platform bug.

MCP `execute` already treats the same sandbox timeouts as caller/sandbox failures (not Sentry). This PR adds a narrow `beforeSend` filter for that exact executor message so workflow auto-capture matches that policy. Other timeout wording (Kit, webhook, snapshot, …) still reports.

Also covers residual noise for sibling [KODY-CLOUDFLARE-12](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7631263947/) (same message via MCP execute) as a belt-and-suspenders alongside `#917`.

## Test plan

- [x] `sentry-options.node.test.ts` asserts the exact sandbox timeout message is dropped (exception + top-level message), similar/prefixed timeout strings are kept, and combined filters still drop D1 lock + bundler noise
- [x] Pre-push hooks (unit + e2e) passed on push
- [ ] CI `npm run validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `887d5ba3` · **Head:** `7d35c389`

**Classification:** composes — narrow Sentry `beforeSend` filter only; no primitive contracts or workflow execution behavior changed.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(unmatched)_ `sentry-options.ts` | observability | composes — drops executor sandbox timeouts already handled as workflow run errors |

### System map

Inline workflow sandbox timeouts still fail the workflow run; Sentry no longer opens a platform issue for the same caller timeout.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
	inlineWorkflow["workflows<br/>Inline workflow run"]:::untouched
	executor["execute sandbox<br/>timeoutMs race"]:::untouched
	sentryFilter["sentry-options<br/>beforeSend filter"]:::touched
	inlineWorkflow -->|"execute inline code"| executor
	executor -->|"Execution timed out"| sentryFilter
	sentryFilter -->|"drop event"| dropped["Sentry issue skipped"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant WF as DynamicCallableWorkflow
	participant Sandbox as execute sandbox
	participant Sentry as beforeSend
	WF->>Sandbox: inline entry
	Sandbox-->>WF: Execution timed out
	WF->>WF: mark workflow_runs errored, rethrow
	WF->>Sentry: auto.faas.cloudflare.workflow
	Sentry-->>Sentry: filter drops exact message
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1002b20-001d-4d4e-b360-96f3e30eaece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1002b20-001d-4d4e-b360-96f3e30eaece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary error reporting by excluding known executor sandbox timeout events from error monitoring.
  - Preserved reporting for similar or unrelated errors to avoid hiding actionable issues.
  - Improved filtering consistency across supported error formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->