### PR TITLE
fix(usage): retry transient Analytics Engine SQL API failures

### DIFF
--- a/packages/worker/src/usage/aggregate-rollups.node.test.ts
+++ b/packages/worker/src/usage/aggregate-rollups.node.test.ts
@@ -1,6 +1,8 @@
 import { expect, test, vi } from 'vitest'
 import {
 	aggregateUsageRollups,
+	analyticsEngineSqlRetryMaxAttempts,
+	isRetryableAnalyticsEngineSqlStatus,
 	resolveUsageEventsDataset,
 	shouldRunUsageAggregationCron,
 } from './aggregate-rollups.ts'
@@ -154,6 +156,30 @@ function stubFetchSequence(bodies: Array<unknown>) {
 		return new Response(
 			typeof body === 'string' ? body : JSON.stringify(body),
 			{ status: 200 },
+		)
+	})
+	vi.stubGlobal('fetch', fetchMock)
+	return Object.assign(fetchMock, {
+		[Symbol.dispose]() {
+			vi.unstubAllGlobals()
+		},
+	})
+}
+
+function stubFetchStatusSequence(
+	responses: Array<{ status: number; body: unknown }>,
+) {
+	let index = 0
+	const fetchMock = vi.fn(async () => {
+		const next = responses[index] ??
+			responses.at(-1) ?? {
+				status: 200,
+				body: { data: [] },
+			}
+		index += 1
+		return new Response(
+			typeof next.body === 'string' ? next.body : JSON.stringify(next.body),
+			{ status: next.status },
 		)
 	})
 	vi.stubGlobal('fetch', fetchMock)
@@ -685,5 +711,70 @@ test('aggregateUsageRollups surfaces a timed-out Analytics Engine fetch as an er
 			new Date('2026-07-15T10:00:00.000Z'),
 		),
 	).rejects.toThrow('timed out')
+	expect(batches).toHaveLength(0)
+})
+
+test('isRetryableAnalyticsEngineSqlStatus covers transient Cloudflare statuses', () => {
+	expect(isRetryableAnalyticsEngineSqlStatus(429)).toBe(true)
+	expect(isRetryableAnalyticsEngineSqlStatus(500)).toBe(true)
+	expect(isRetryableAnalyticsEngineSqlStatus(502)).toBe(true)
+	expect(isRetryableAnalyticsEngineSqlStatus(503)).toBe(true)
+	expect(isRetryableAnalyticsEngineSqlStatus(400)).toBe(false)
+	expect(isRetryableAnalyticsEngineSqlStatus(401)).toBe(false)
+	expect(isRetryableAnalyticsEngineSqlStatus(404)).toBe(false)
+})
+
+test('aggregateUsageRollups retries Analytics Engine SQL 500 then succeeds', async () => {
+	using fetchMock = stubFetchStatusSequence([
+		{ status: 500, body: 'Internal server error' },
+		{ status: 200, body: { data: [] } },
+		{ status: 200, body: { data: [] } },
+	])
+	const { db, batches } = createFakeDb()
+
+	await expect(
+		aggregateUsageRollups(
+			createAggregationEnv(db),
+			new Date('2026-07-15T10:00:00.000Z'),
+		),
+	).resolves.toMatchObject({ skipped: false, upsertedRows: 0 })
+	expect(fetchMock).toHaveBeenCalledTimes(3)
+	expect(batches).toHaveLength(0)
+})
+
+test('aggregateUsageRollups exhausts retries on persistent Analytics Engine 500', async () => {
+	using fetchMock = stubFetchStatusSequence([
+		{ status: 500, body: 'Internal server error' },
+		{ status: 500, body: 'Internal server error' },
+		{ status: 500, body: 'Internal server error' },
+	])
+	const { db, batches } = createFakeDb()
+
+	await expect(
+		aggregateUsageRollups(
+			createAggregationEnv(db),
+			new Date('2026-07-15T10:00:00.000Z'),
+		),
+	).rejects.toThrow('Analytics Engine SQL query failed (500)')
+	expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(
+		analyticsEngineSqlRetryMaxAttempts,
+	)
+	expect(batches).toHaveLength(0)
+})
+
+test('aggregateUsageRollups does not retry Analytics Engine SQL 400', async () => {
+	using fetchMock = stubFetchStatusSequence([
+		{ status: 400, body: 'query error: unknown table' },
+	])
+	const { db, batches } = createFakeDb()
+
+	await expect(
+		aggregateUsageRollups(
+			createAggregationEnv(db),
+			new Date('2026-07-15T10:00:00.000Z'),
+		),
+	).rejects.toThrow('Analytics Engine SQL query failed (400)')
+	// Both month queries may start in parallel, but neither retries a 400.
+	expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(2)
 	expect(batches).toHaveLength(0)
 })

--- a/packages/worker/src/usage/aggregate-rollups.ts
+++ b/packages/worker/src/usage/aggregate-rollups.ts
@@ -82,6 +82,23 @@ const deleteStatementPairLimit = 49
  */
 export const analyticsEngineSqlTimeoutMs = 30_000
 
+/**
+ * Transient Cloudflare Analytics Engine SQL API failures (5xx / 429) are
+ * retried with exponential backoff. The hourly aggregation is already
+ * idempotent, but absorbing a single blip avoids a missed rollup hour and
+ * Sentry noise from `scheduled_lane_failed`.
+ */
+export const analyticsEngineSqlRetryMaxAttempts = 3
+export const analyticsEngineSqlRetryBaseDelayMs = 200
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+export function isRetryableAnalyticsEngineSqlStatus(status: number) {
+	return status === 429 || (status >= 500 && status <= 599)
+}
+
 const usageRollupAbsoluteUpsertStatement = `
 INSERT INTO usage_rollups (
 	user_id, metric, month,
@@ -273,24 +290,39 @@ async function queryAnalyticsEngineSql(input: {
 	query: string
 }): Promise<Array<AnalyticsEngineSqlRow>> {
 	const url = `${input.baseUrl.replace(/\/$/, '')}/client/v4/accounts/${input.accountId}/analytics_engine/sql`
-	const response = await fetch(url, {
-		method: 'POST',
-		headers: {
-			authorization: `Bearer ${input.apiToken}`,
-		},
-		body: input.query,
-		signal: AbortSignal.timeout(analyticsEngineSqlTimeoutMs),
-	})
-	const text = await response.text()
-	if (!response.ok) {
-		throw new Error(
+	let lastError: Error | undefined
+	for (
+		let attempt = 1;
+		attempt <= analyticsEngineSqlRetryMaxAttempts;
+		attempt++
+	) {
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${input.apiToken}`,
+			},
+			body: input.query,
+			signal: AbortSignal.timeout(analyticsEngineSqlTimeoutMs),
+		})
+		const text = await response.text()
+		if (response.ok) {
+			const parsed = JSON.parse(text) as {
+				data?: Array<AnalyticsEngineSqlRow>
+			}
+			return parsed.data ?? []
+		}
+		lastError = new Error(
 			`Analytics Engine SQL query failed (${response.status}): ${text.slice(0, 500)}`,
 		)
+		if (
+			!isRetryableAnalyticsEngineSqlStatus(response.status) ||
+			attempt === analyticsEngineSqlRetryMaxAttempts
+		) {
+			throw lastError
+		}
+		await sleep(analyticsEngineSqlRetryBaseDelayMs * 2 ** (attempt - 1))
 	}
-	const parsed = JSON.parse(text) as {
-		data?: Array<AnalyticsEngineSqlRow>
-	}
-	return parsed.data ?? []
+	throw lastError ?? new Error('Analytics Engine SQL query failed')
 }
 
 function toCount(value: number | string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sentry [7631994416](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7631994416/): hourly `usage_aggregation` failed when Cloudflare's Analytics Engine SQL API returned `500 Internal server error` on one of two parallel month queries (the sibling query returned 200).

## Root cause

`queryAnalyticsEngineSql` treated every non-OK response as fatal. A single Cloudflare 500 aborted `Promise.all` for the current/previous month recompute, so the scheduled lane logged `scheduled_lane_failed` and reported to Sentry. Aggregation is already idempotent and hourly, but a transient CF blip still missed that hour.

## Fix

Retry Analytics Engine SQL responses with status `429` or `5xx` (3 attempts, exponential backoff from 200ms). Client errors such as `400` still fail immediately. Exhausted retries still throw so a persistent outage remains visible in Sentry.

## Tests

- Retry after a single `500` then succeed
- Exhaust retries on persistent `500`
- Do not retry `400`
- Status classifier unit coverage

Siblings (Navigation API TypeError, execute timeout, MCP validation) do not share this root cause.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b690725a` · **Head:** `510cad24`

**Classification:** extends — adds retry/backoff inside the usage rollup Analytics Engine SQL client; scheduled cron call site unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `usage-metering` | storage | extends — retry 429/5xx from Analytics Engine SQL API |
| `scheduled-cron` | surfaces | composes — same `aggregateUsageRollups` lane, more resilient |

### System map

Hourly cron recompute of usage rollups retries transient Cloudflare SQL API failures before failing the lane.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::touched
	usageMetering["usage-metering<br/>Usage metering"]:::extended
	scheduledCron -->|"usage_aggregation lane"| usageMetering
	usageMetering -->|"retry AE SQL 429/5xx"| usageMetering
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cron as scheduled-cron
	participant Agg as aggregateUsageRollups
	participant AE as Cloudflare AE SQL API
	Cron->>Agg: hourly usage_aggregation
	Agg->>AE: month query
	AE-->>Agg: 500 Internal server error
	Agg->>AE: retry (backoff)
	AE-->>Agg: 200 + rows
	Agg-->>Cron: upserted rollups
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e5e5cc2-55f8-4fe1-b11d-ab871c158601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e5e5cc2-55f8-4fe1-b11d-ab871c158601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of usage rollup processing by automatically retrying transient Analytics Engine SQL failures.
  * Retries temporary service errors and rate limits, while failing immediately for non-retryable errors.
  * Provides clearer error reporting when all retry attempts are exhausted.

* **Tests**
  * Added coverage for successful retries, exhausted retry attempts, and non-retryable SQL errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->