### PR TITLE
fix(sentry): stop reporting D1 long-running export blocks

### DIFF
--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -12,6 +12,16 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 		),
 	).toBe(true)
 	expect(isRetryableD1LockError(new Error('database is locked'))).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error('D1_ERROR: Currently processing a long-running export.'),
+		),
+	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error('Currently processing a long-running export.'),
+		),
+	).toBe(true)
 	expect(isRetryableD1LockError(new Error('syntax error near SELECT'))).toBe(
 		false,
 	)
@@ -32,6 +42,22 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
 		await expect(resultPromise).resolves.toBe('ok')
 		expect(retryOperation).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+
+	vi.useFakeTimers()
+	const exportRetryOperation = vi
+		.fn()
+		.mockRejectedValueOnce(
+			new Error('D1_ERROR: Currently processing a long-running export.'),
+		)
+		.mockResolvedValueOnce('ok')
+	try {
+		const resultPromise = runD1WithRetry(exportRetryOperation)
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toBe('ok')
+		expect(exportRetryOperation).toHaveBeenCalledTimes(2)
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -9,9 +9,20 @@ function sleep(ms: number) {
 	return new Promise<void>((resolve) => setTimeout(resolve, ms))
 }
 
+/**
+ * Cloudflare D1 emits this while a REST/API export is in progress. Exports
+ * block other database requests for consistency (see D1 import/export docs),
+ * so production MCP/cron traffic fails for the duration of the nightly DR
+ * backup export. Same class of transient unavailability as SQLITE_BUSY.
+ */
+export const d1LongRunningExportMessage =
+	'Currently processing a long-running export'
+
 export function isRetryableD1LockMessage(message: string) {
 	return (
-		message.includes('SQLITE_BUSY') || message.includes('database is locked')
+		message.includes('SQLITE_BUSY') ||
+		message.includes('database is locked') ||
+		message.includes(d1LongRunningExportMessage)
 	)
 }
 
@@ -31,10 +42,12 @@ export function isRetryableD1LockSentryEvent(event: ErrorEvent) {
 }
 
 /**
- * Retries transient D1 lock contention (SQLITE_BUSY). D1 does not
- * automatically retry write queries, so cron lanes and long-running
- * retention batches need application-level backoff when they overlap
- * with concurrent writers.
+ * Retries transient D1 unavailability: SQLITE_BUSY lock contention and
+ * Cloudflare's "Currently processing a long-running export" (DR / REST
+ * exports block other requests). D1 does not automatically retry write
+ * queries, so cron lanes and long-running retention batches need
+ * application-level backoff when they overlap with concurrent writers or
+ * an in-flight export.
  */
 export async function runD1WithRetry<T>(
 	operation: () => Promise<T>,

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -20,6 +20,21 @@ test('filterRetryableD1LockSentryEvent drops transient D1 lock contention and ke
 		}),
 	).toBeNull()
 
+	expect(
+		filterRetryableD1LockSentryEvent({
+			exception: {
+				values: [
+					{
+						value: 'Currently processing a long-running export.',
+					},
+					{
+						value: 'D1_ERROR: Currently processing a long-running export.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
 	const unrelatedEvent = {
 		exception: {
 			values: [{ value: 'D1_ERROR: syntax error near INSERTZ' }],
@@ -116,6 +131,18 @@ test('filterSentryEvent still drops retryable D1 lock contention', () => {
 				values: [
 					{
 						value: 'D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: 'D1_ERROR: Currently processing a long-running export.',
 					},
 				],
 			},

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -86,8 +86,10 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		sendDefaultPii: false,
 		// D1 marks SQLITE_BUSY with NOSENTRY at the storage layer, but
 		// application capture paths (for example scheduled_lane_failed) still
-		// forwarded them. These are transient lock-contention errors retried in
-		// app code and should not open or regress Sentry issues.
+		// forwarded them. The same applies to "Currently processing a
+		// long-running export" while the nightly DR D1 export holds the DB.
+		// These are transient platform unavailability errors retried in app
+		// code and should not open or regress Sentry issues.
 		//
 		// User-module esbuild failures and executor sandbox timeouts from
 		// inline workflows are similarly expected caller mistakes; see


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters Sentry noise from [KODY-CLOUDFLARE-22](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7632008645/) and sibling [KODY-CLOUDFLARE-21](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7632006594/) (`Error: D1_ERROR: Currently processing a long-running export.`).

Cloudflare D1 blocks other database requests while a REST/API export is in progress. Production events landed on `/mcp` during the nightly DR D1 export window (~02:15 UTC): `handleMcpRequest` → `withAccountWriteLease` → D1 write rejected with that exact message. This is expected platform unavailability during backups, not an application bug — the same class of transient D1 failure as `SQLITE_BUSY`.

This PR extends the existing retryable-D1 matcher so:

1. `runD1WithRetry` / cron lane skip / module-artifact transient detection treat the export message like lock contention
2. `beforeSend` (`filterRetryableD1LockSentryEvent`) drops matching events so backups do not open or regress Sentry issues

MCP requests can still fail for users while an export holds the DB (Cloudflare limitation; short app retries cannot cover a multi-minute export). We stop treating that as a platform defect in Sentry.

## Test plan

- [x] `d1-retry.node.test.ts` matches both `D1_ERROR: Currently processing…` and bare cause-chain forms; retries export errors; still rethrows syntax errors immediately
- [x] `sentry-options.node.test.ts` drops the production exception chain and keeps unrelated D1 errors
- [x] Pre-push hooks (unit + e2e) passed on push
- [ ] CI `npm run validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `7b2e5749` · **Head:** `34a9865b`

**Classification:** composes — narrow extension of the existing D1 transient matcher + Sentry `beforeSend` filter; no D1 schema, auth, or backup export contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(unmatched)_ `d1-retry.ts` / `sentry-options.ts` | observability | composes — treat DR export blocks like SQLITE_BUSY for retry + Sentry drop |

### System map

Nightly DR D1 exports still block production queries; Sentry and cron/retry paths no longer treat that block as a novel platform failure.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	drExport["backup-control-plane<br/>Nightly D1 export"]:::untouched
	d1AppDb["d1-app-db<br/>Production D1"]:::untouched
	mcpServer["mcp-server<br/>/mcp write lease"]:::untouched
	d1Retry["d1-retry<br/>Transient matcher"]:::touched
	sentryFilter["sentry-options<br/>beforeSend filter"]:::touched
	drExport -->|"REST export holds DB"| d1AppDb
	mcpServer -->|"D1_ERROR long-running export"| d1AppDb
	d1AppDb -->|"isRetryableD1LockError"| d1Retry
	d1Retry -->|"beforeSend drop"| sentryFilter
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ae5bfdb-5100-4a0a-ae0e-97c8a6ee9e30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ae5bfdb-5100-4a0a-ae0e-97c8a6ee9e30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

