### PR TITLE
fix(sentry): stop reporting browser AbortError noise

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from 'vitest'
+import {
+	filterBrowserAbortSentryEvent,
+	isBrowserAbortError,
+	isBrowserAbortErrorMessage,
+	isBrowserAbortSentryEvent,
+} from './sentry-browser-filters.ts'
+
+test('isBrowserAbortErrorMessage matches Chromium and common abort texts', () => {
+	expect(
+		isBrowserAbortErrorMessage('AbortError: The user aborted a request.'),
+	).toBe(true)
+	expect(isBrowserAbortErrorMessage('The user aborted a request.')).toBe(true)
+	expect(isBrowserAbortErrorMessage('The operation was aborted.')).toBe(true)
+	expect(isBrowserAbortErrorMessage('AbortError: aborted')).toBe(true)
+	expect(
+		isBrowserAbortErrorMessage('NetworkError when attempting to fetch'),
+	).toBe(false)
+	expect(isBrowserAbortErrorMessage('TypeError: Failed to fetch')).toBe(false)
+	expect(
+		isBrowserAbortErrorMessage('The operation was aborted due to timeout.'),
+	).toBe(false)
+})
+
+test('isBrowserAbortError recognizes AbortError-named exceptions', () => {
+	expect(isBrowserAbortError(new DOMException('aborted', 'AbortError'))).toBe(
+		true,
+	)
+	expect(
+		isBrowserAbortError(Object.assign(new Error('x'), { name: 'AbortError' })),
+	).toBe(true)
+	expect(
+		isBrowserAbortError(new Error('AbortError: The user aborted a request.')),
+	).toBe(false)
+	expect(isBrowserAbortError(null)).toBe(false)
+})
+
+test('filterBrowserAbortSentryEvent drops KODY-CLOUDFLARE-23 signature and keeps real errors', () => {
+	// Production event: type Error, value AbortError:…, no stack frames.
+	const cloudflare23 = {
+		exception: {
+			values: [
+				{
+					type: 'Error',
+					value: 'AbortError: The user aborted a request.',
+				},
+			],
+		},
+	}
+	expect(isBrowserAbortSentryEvent(cloudflare23)).toBe(true)
+	expect(filterBrowserAbortSentryEvent(cloudflare23)).toBeNull()
+
+	const typedAbort = {
+		exception: {
+			values: [{ type: 'AbortError', value: 'The user aborted a request.' }],
+		},
+	}
+	expect(filterBrowserAbortSentryEvent(typedAbort)).toBeNull()
+
+	const viaOriginal = {
+		exception: {
+			values: [{ type: 'Error', value: 'something else' }],
+		},
+	}
+	expect(
+		filterBrowserAbortSentryEvent(
+			viaOriginal,
+			new DOMException('The user aborted a request.', 'AbortError'),
+		),
+	).toBeNull()
+
+	const realBug = {
+		exception: {
+			values: [
+				{
+					type: 'TypeError',
+					value:
+						"undefined is not an object (evaluating 'r.updateCurrentEntry')",
+				},
+			],
+		},
+	}
+	expect(filterBrowserAbortSentryEvent(realBug)).toBe(realBug)
+	expect(isBrowserAbortSentryEvent(realBug)).toBe(false)
+})

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -12,6 +12,9 @@ test('isBrowserAbortErrorMessage matches Chromium and common abort texts', () =>
 	).toBe(true)
 	expect(isBrowserAbortErrorMessage('The user aborted a request.')).toBe(true)
 	expect(isBrowserAbortErrorMessage('The operation was aborted.')).toBe(true)
+	expect(
+		isBrowserAbortErrorMessage('AbortError: The operation was aborted.'),
+	).toBe(true)
 	expect(isBrowserAbortErrorMessage('AbortError: aborted')).toBe(true)
 	expect(
 		isBrowserAbortErrorMessage('NetworkError when attempting to fetch'),
@@ -19,6 +22,11 @@ test('isBrowserAbortErrorMessage matches Chromium and common abort texts', () =>
 	expect(isBrowserAbortErrorMessage('TypeError: Failed to fetch')).toBe(false)
 	expect(
 		isBrowserAbortErrorMessage('The operation was aborted due to timeout.'),
+	).toBe(false)
+	expect(
+		isBrowserAbortErrorMessage(
+			'AbortError: The operation was aborted due to timeout.',
+		),
 	).toBe(false)
 })
 

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -24,15 +24,21 @@ function sentryEventMessages(event: SentryErrorEventLike) {
 
 /**
  * Chromium/Edge fetch abort text from KODY-CLOUDFLARE-23 and common browser
- * variants. Matching is intentionally narrow: only AbortError-named exceptions
- * or the well-known abort message strings — never blanket-drop network errors.
+ * variants. Matching is intentionally narrow: only these exact abort strings
+ * (plus AbortError-named exceptions via `isBrowserAbortError`) — never
+ * blanket-drop network errors or timeout wording.
  */
+const browserAbortErrorMessages = new Set([
+	'AbortError: The user aborted a request.',
+	'The user aborted a request.',
+	'AbortError: The operation was aborted.',
+	'The operation was aborted.',
+	'AbortError: aborted',
+	'aborted',
+])
+
 export function isBrowserAbortErrorMessage(message: string) {
-	if (message.startsWith('AbortError:')) return true
-	return (
-		message === 'The user aborted a request.' ||
-		message === 'The operation was aborted.'
-	)
+	return browserAbortErrorMessages.has(message)
 }
 
 export function isBrowserAbortError(error: unknown) {

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -34,7 +34,6 @@ const browserAbortErrorMessages = new Set([
 	'AbortError: The operation was aborted.',
 	'The operation was aborted.',
 	'AbortError: aborted',
-	'aborted',
 ])
 
 export function isBrowserAbortErrorMessage(message: string) {

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -1,0 +1,77 @@
+/**
+ * Browser Sentry event filters. Kept free of `@sentry/browser` imports so unit
+ * tests can exercise the predicates with plain event shapes.
+ */
+
+type SentryExceptionValue = {
+	type?: string
+	value?: string
+}
+
+export type SentryErrorEventLike = {
+	message?: string
+	exception?: {
+		values?: Array<SentryExceptionValue>
+	}
+}
+
+function sentryEventMessages(event: SentryErrorEventLike) {
+	return [
+		event.message,
+		...(event.exception?.values?.map((value) => value.value) ?? []),
+	]
+}
+
+/**
+ * Chromium/Edge fetch abort text from KODY-CLOUDFLARE-23 and common browser
+ * variants. Matching is intentionally narrow: only AbortError-named exceptions
+ * or the well-known abort message strings — never blanket-drop network errors.
+ */
+export function isBrowserAbortErrorMessage(message: string) {
+	if (message.startsWith('AbortError:')) return true
+	return (
+		message === 'The user aborted a request.' ||
+		message === 'The operation was aborted.'
+	)
+}
+
+export function isBrowserAbortError(error: unknown) {
+	if (typeof error !== 'object' || error === null) return false
+	return 'name' in error && error.name === 'AbortError'
+}
+
+/**
+ * Drop expected browser AbortError noise (user navigated away, superseding
+ * SPA navigation aborted an in-flight fetch, etc.). These surface as
+ * unhandledrejection via `auto.browser.global_handlers.onunhandledrejection`
+ * and are not actionable product defects.
+ */
+export function isBrowserAbortSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isBrowserAbortError(originalException)) return true
+	if (
+		event.exception?.values?.some(
+			(value) =>
+				value.type === 'AbortError' ||
+				(value.type === 'DOMException' &&
+					typeof value.value === 'string' &&
+					isBrowserAbortErrorMessage(value.value)),
+		)
+	) {
+		return true
+	}
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' && isBrowserAbortErrorMessage(message),
+	)
+}
+
+export function filterBrowserAbortSentryEvent<T extends SentryErrorEventLike>(
+	event: T,
+	originalException?: unknown,
+): T | null {
+	if (isBrowserAbortSentryEvent(event, originalException)) return null
+	return event
+}

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/browser'
 import {
+	filterBrowserAbortSentryEvent,
+	isBrowserAbortError,
+} from '#client/sentry-browser-filters.ts'
+import {
 	parseSentryClientConfig,
 	SENTRY_CONFIG_META_NAME,
 } from '#client/sentry-config.ts'
@@ -42,6 +46,12 @@ export function initSentryClient(doc: Document) {
 			// happens.
 			replaysSessionSampleRate: 0,
 			replaysOnErrorSampleRate: 1.0,
+			// Superseded SPA navigations and user-driven aborts reject in-flight
+			// fetches with AbortError. Those are expected and not actionable —
+			// see filterBrowserAbortSentryEvent / KODY-CLOUDFLARE-23.
+			beforeSend(event, hint) {
+				return filterBrowserAbortSentryEvent(event, hint.originalException)
+			},
 		})
 		return true
 	} catch (error) {
@@ -52,6 +62,7 @@ export function initSentryClient(doc: Document) {
 
 /** Report a caught client error without letting reporting itself throw. */
 export function captureClientException(error: unknown) {
+	if (isBrowserAbortError(error)) return
 	try {
 		Sentry.captureException(error)
 	} catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-23](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7632135877/) reported a single browser `AbortError: The user aborted a request.` on `/oauth/authorize` via `auto.browser.global_handlers.onunhandledrejection` (Edge 150, no stack frames, `DOMException.code=20`).

That is expected Chromium/Edge behavior when an in-flight `fetch` is aborted (superseded SPA navigation, user leaving the page, etc.). It is not an actionable product defect, and without a client filter it will keep reopening issues whenever users abort requests.

## Change

- Add a narrow browser `beforeSend` filter (`filterBrowserAbortSentryEvent`) that drops AbortError-named exceptions and exact well-known abort message strings (`AbortError: The user aborted a request.`, `The operation was aborted.`, etc.). Timeout wording is intentionally not matched.
- Skip AbortError in `captureClientException` as a belt-and-suspenders path.
- Unit tests cover the KODY-CLOUDFLARE-23 signature and ensure unrelated client errors (e.g. Navigation API `TypeError`) and timeout abort wording still report.

Worker-side `sentry-options.ts` cannot help here: browser envelopes are forwarded by `/sentry-tunnel` without going through Worker `beforeSend`.

## Outcome

**filtered** — ship the filter, then mark the Sentry issue ignored once deployed.

Siblings (KODY-CLOUDFLARE-17 Navigation API, sandbox timeout, MCP validation) do not share this root cause and are left alone.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c1687e26` · **Head:** latest on branch

**Classification:** composes — no primitives added or changed; wires a narrow
`beforeSend` filter into the existing browser Sentry client.

### Primitives touched

| Primitive | Group    | Impact                                                         |
| --------- | -------- | -------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — browser Sentry `beforeSend` drops AbortError noise |

### System map

Browser AbortErrors are dropped in the client SDK before the envelope reaches the same-origin tunnel.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	sentryTunnel["sentry-tunnel<br/>Same-origin envelope forward"]:::untouched
	appUi -->|"beforeSend drops AbortError; other events still tunnel"| sentryTunnel
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Case | Before | After |
| --- | --- | --- |
| `AbortError: The user aborted a request.` unhandledrejection | Opens/regresses Sentry issue | Dropped in client `beforeSend` |
| Unrelated client `TypeError` / app bugs | Reported | Still reported |
| Timeout abort wording | Reported | Still reported |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95d20226-eed5-41e0-9fad-935977c375da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95d20226-eed5-41e0-9fad-935977c375da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced Sentry noise by filtering expected browser abort/navigation-related errors before they’re sent.
  * Prevented known browser abort exceptions from being reported, while leaving unrelated errors untouched.
  * Improved abort detection across common browser error message variants and error shapes, including Cloudflare’s abort signature.
* **Tests**
  * Added coverage for abort message variants, abort detection from different error forms (including `AbortError`), and validation that non-abort events remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->