### PR TITLE
fix(sentry): stop reporting remote connector tools/list refresh noise

### DIFF
--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -292,3 +292,45 @@ test('remote connector session lifecycle across restore, snapshot, heartbeat, cl
 		tools: [],
 	})
 })
+
+test('tools/list_changed snapshot refresh failures log a warning without Sentry', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const { session, state, persistedEntries } =
+		await createRemoteConnectorSession({
+			storedState: {
+				persisted: {
+					connectorId: 'home',
+					connectedAt: '2026-04-26T05:00:00.000Z',
+					lastSeenAt: '2026-04-26T05:01:00.000Z',
+				},
+				tools: [{ name: 'bond_shade_set_position' }],
+			},
+			webSockets: [{} as WebSocket],
+		})
+	// Drop the socket before tools/list so refresh fails immediately (same
+	// soft-fail path as an RPC timeout against a stalled home connector).
+	state.getWebSockets.mockReturnValue([])
+
+	await session.webSocketMessage(
+		{} as WebSocket,
+		JSON.stringify({
+			type: 'connector.jsonrpc',
+			message: {
+				jsonrpc: '2.0',
+				method: 'notifications/tools/list_changed',
+			},
+		}),
+	)
+
+	expect(captureMessageMock).not.toHaveBeenCalled()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'Remote connector tools snapshot refresh failed on tools/list_changed. connectorId=home error=No remote connector is connected.',
+	)
+	expect(persistedEntries.get('remote-connector-session-state')).toMatchObject({
+		persisted: {
+			connectorId: 'home',
+			connectedAt: '2026-04-26T05:00:00.000Z',
+		},
+		tools: [],
+	})
+})

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -397,6 +397,7 @@ test('malformed tools/list snapshot responses still report to Sentry', async () 
 			extra: expect.objectContaining({
 				connectorId: 'home',
 				messageType: 'connector.jsonrpc',
+				error: 'Malformed tools/list result.',
 			}),
 		}),
 	)

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -334,3 +334,73 @@ test('tools/list_changed snapshot refresh failures log a warning without Sentry'
 		tools: [],
 	})
 })
+
+test('malformed tools/list snapshot responses still report to Sentry', async () => {
+	const sent: Array<string> = []
+	const socket = {
+		send: (payload: string) => {
+			sent.push(payload)
+		},
+	} as unknown as WebSocket
+	const { session, persistedEntries } = await createRemoteConnectorSession({
+		storedState: {
+			persisted: {
+				connectorId: 'home',
+				connectedAt: '2026-04-26T05:00:00.000Z',
+				lastSeenAt: '2026-04-26T05:01:00.000Z',
+			},
+			tools: [{ name: 'bond_shade_set_position' }],
+		},
+		webSockets: [socket],
+	})
+
+	const refresh = session.webSocketMessage(
+		socket,
+		JSON.stringify({
+			type: 'connector.jsonrpc',
+			message: {
+				jsonrpc: '2.0',
+				method: 'notifications/tools/list_changed',
+			},
+		}),
+	)
+
+	await vi.waitFor(() => {
+		expect(sent.length).toBeGreaterThan(0)
+	})
+	const request = JSON.parse(sent[0]!) as {
+		type: string
+		message: { id: string; method: string }
+	}
+	expect(request).toMatchObject({
+		type: 'connector.jsonrpc',
+		message: { method: 'tools/list' },
+	})
+
+	await session.webSocketMessage(
+		socket,
+		JSON.stringify({
+			type: 'connector.jsonrpc',
+			message: {
+				jsonrpc: '2.0',
+				id: request.message.id,
+				result: null,
+			},
+		}),
+	)
+	await refresh
+
+	expect(captureMessageMock).toHaveBeenCalledWith(
+		'Remote connector session message handler threw.',
+		expect.objectContaining({
+			level: 'error',
+			extra: expect.objectContaining({
+				connectorId: 'home',
+				messageType: 'connector.jsonrpc',
+			}),
+		}),
+	)
+	expect(persistedEntries.get('remote-connector-session-state')).toMatchObject({
+		tools: [{ name: 'bond_shade_set_position' }],
+	})
+})

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -503,16 +503,10 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			await this.refreshToolsSnapshot()
 		} catch (error) {
 			this.stateSnapshot.tools = []
-			this.captureSessionMessage(
-				'Remote connector tools snapshot refresh failed after websocket hello.',
-				{
-					level: 'error',
-					extra: {
-						connectorId: this.stateSnapshot.persisted.connectorId,
-						error: getErrorMessage(error),
-					},
-				},
-			)
+			this.logToolsSnapshotRefreshFailure({
+				phase: 'after websocket hello',
+				error,
+			})
 			await this.persistState()
 		}
 	}
@@ -539,20 +533,27 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 				await this.refreshToolsSnapshot()
 			} catch (error) {
 				this.stateSnapshot.tools = []
-				this.captureSessionMessage(
-					'Remote connector tools snapshot refresh failed.',
-					{
-						level: 'error',
-						extra: {
-							connectorId: this.stateSnapshot.persisted.connectorId,
-							error: getErrorMessage(error),
-						},
-					},
-				)
+				this.logToolsSnapshotRefreshFailure({
+					phase: 'on tools/list_changed',
+					error,
+				})
 				await this.persistState()
 				return
 			}
 		}
+	}
+
+	private logToolsSnapshotRefreshFailure(input: {
+		phase: 'after websocket hello' | 'on tools/list_changed'
+		error: unknown
+	}) {
+		// tools/list timeouts, disconnects mid-RPC, and connector-side errors are
+		// expected remote-connector lifecycle noise (same class as websocket
+		// closes). Soft-fail by clearing tools; keep an ops log line and do not
+		// open Sentry issues. Auth failures and message-handler bugs still capture.
+		console.warn(
+			`Remote connector tools snapshot refresh failed ${input.phase}. connectorId=${this.stateSnapshot.persisted.connectorId ?? 'null'} error=${getErrorMessage(input.error)}`,
+		)
 	}
 
 	private async refreshToolsSnapshot() {

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -568,12 +568,19 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		// Timeouts, disconnects mid-RPC, and "not connected" are expected
 		// remote-connector lifecycle noise (same class as websocket closes).
 		// Soft-fail by clearing tools; keep an ops log line and do not open
-		// Sentry issues.
+		// Sentry issues. Restore the in-memory cache if persistence fails so
+		// later reads are not left empty while Sentry captures the storage bug.
+		const previousTools = this.stateSnapshot.tools
 		this.stateSnapshot.tools = []
 		console.warn(
 			`Remote connector tools snapshot refresh failed ${input.phase}. connectorId=${this.stateSnapshot.persisted.connectorId ?? 'null'} error=${getErrorMessage(input.error)}`,
 		)
-		await this.persistState()
+		try {
+			await this.persistState()
+		} catch (persistError) {
+			this.stateSnapshot.tools = previousTools
+			throw persistError
+		}
 	}
 
 	private async refreshToolsSnapshot() {
@@ -584,7 +591,11 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			throw error
 		}
 		const result = response.result
-		if (result === null || typeof result !== 'object') {
+		if (
+			result === null ||
+			typeof result !== 'object' ||
+			Array.isArray(result)
+		) {
 			throw new Error('Malformed tools/list result.')
 		}
 		const tools = (result as { tools?: unknown }).tools

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -27,6 +27,23 @@ const connectorTag = 'connector'
 const stateStorageKey = 'remote-connector-session-state'
 const rpcTimeoutMs = 15_000
 
+const remoteConnectorToolsListRpcErrorName = 'RemoteConnectorToolsListRpcError'
+
+function isExpectedToolsSnapshotRefreshFailure(error: unknown) {
+	if (
+		error instanceof Error &&
+		error.name === remoteConnectorToolsListRpcErrorName
+	) {
+		return true
+	}
+	const message = getErrorMessage(error)
+	return (
+		message === 'No remote connector is connected.' ||
+		message.startsWith('Timed out waiting for remote connector response to ') ||
+		message.includes(' before RPC response.')
+	)
+}
+
 type PendingRpcRequest = {
 	resolve: (message: RemoteConnectorJsonRpcResponse) => void
 	reject: (error: Error) => void
@@ -502,12 +519,10 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		try {
 			await this.refreshToolsSnapshot()
 		} catch (error) {
-			this.stateSnapshot.tools = []
-			this.logToolsSnapshotRefreshFailure({
+			await this.handleToolsSnapshotRefreshFailure({
 				phase: 'after websocket hello',
 				error,
 			})
-			await this.persistState()
 		}
 	}
 
@@ -532,34 +547,41 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			try {
 				await this.refreshToolsSnapshot()
 			} catch (error) {
-				this.stateSnapshot.tools = []
-				this.logToolsSnapshotRefreshFailure({
+				await this.handleToolsSnapshotRefreshFailure({
 					phase: 'on tools/list_changed',
 					error,
 				})
-				await this.persistState()
-				return
 			}
 		}
 	}
 
-	private logToolsSnapshotRefreshFailure(input: {
+	private async handleToolsSnapshotRefreshFailure(input: {
 		phase: 'after websocket hello' | 'on tools/list_changed'
 		error: unknown
 	}) {
-		// tools/list timeouts, disconnects mid-RPC, and connector-side errors are
-		// expected remote-connector lifecycle noise (same class as websocket
-		// closes). Soft-fail by clearing tools; keep an ops log line and do not
-		// open Sentry issues. Auth failures and message-handler bugs still capture.
+		if (!isExpectedToolsSnapshotRefreshFailure(input.error)) {
+			// Malformed tools/list payloads, storage failures, and other
+			// implementation bugs should still open Sentry via the outer
+			// message-handler catch — do not clear a still-valid tool cache.
+			throw input.error
+		}
+		// Timeouts, disconnects mid-RPC, and "not connected" are expected
+		// remote-connector lifecycle noise (same class as websocket closes).
+		// Soft-fail by clearing tools; keep an ops log line and do not open
+		// Sentry issues.
+		this.stateSnapshot.tools = []
 		console.warn(
 			`Remote connector tools snapshot refresh failed ${input.phase}. connectorId=${this.stateSnapshot.persisted.connectorId ?? 'null'} error=${getErrorMessage(input.error)}`,
 		)
+		await this.persistState()
 	}
 
 	private async refreshToolsSnapshot() {
 		const response = await this.sendRpcRequest('tools/list', {})
 		if ('error' in response) {
-			throw new Error(response.error.message)
+			const error = new Error(response.error.message)
+			error.name = remoteConnectorToolsListRpcErrorName
+			throw error
 		}
 		const result = response.result as {
 			tools?: Array<RemoteConnectorSnapshot['tools'][number]>

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -583,10 +583,17 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			error.name = remoteConnectorToolsListRpcErrorName
 			throw error
 		}
-		const result = response.result as {
-			tools?: Array<RemoteConnectorSnapshot['tools'][number]>
+		const result = response.result
+		if (result === null || typeof result !== 'object') {
+			throw new Error('Malformed tools/list result.')
 		}
-		this.stateSnapshot.tools = result.tools ?? []
+		const tools = (result as { tools?: unknown }).tools
+		if (tools !== undefined && !Array.isArray(tools)) {
+			throw new Error('Malformed tools/list tools.')
+		}
+		this.stateSnapshot.tools =
+			(tools as Array<RemoteConnectorSnapshot['tools'][number]> | undefined) ??
+			[]
 		this.stateSnapshot.persisted.lastSeenAt = new Date().toISOString()
 		await this.persistState()
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-24](https://kent-c-dodds-tech-llc.sentry.io/issues/7632265374/) reported `Remote connector tools snapshot refresh failed.` for the `home` connector. The event context was:

`Timed out waiting for remote connector response to tools/list.`

That path already soft-fails (clears tools, persists, continues). The timeout is the same class of remote-connector lifecycle noise as websocket disconnects (#916): flaky home networks, slow connector processes, mid-RPC disconnects.

This PR stops opening Sentry issues for **expected** refresh failures (timeout / disconnect / not connected / connector RPC error) and keeps an ops `console.warn` instead. **Unexpected** failures (malformed `tools/list` payloads, storage bugs) still rethrow into the existing message-handler Sentry capture and do not clear a still-valid tool cache. Auth rejections still capture at error level.

## Test plan

- [x] Unit test: expected `tools/list_changed` refresh failure logs warn, does not call Sentry, clears tools
- [x] Unit test: malformed `tools/list` result still reports to Sentry and keeps cached tools
- [x] Existing remote connector session lifecycle test still passes
- [ ] CI `npm run validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `0bfcec47` · **Head:** `cursor/sentry-triage-kody-cloudflare-24-6962`

**Classification:** composes — observability wiring only; soft-fail behavior for expected snapshot refresh failures is unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `connector-ingress` | surfaces | composes — expected refresh noise → `console.warn`; unexpected still Sentry |
| `remote-connectors` | assistant | composes — same session DO path; no protocol/settings change |

### System map

_tools/list_changed (or hello) refresh fails → expected: soft-clear + warn; unexpected: rethrow to Sentry without clearing tools._

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
  RC[home connector] -->|notifications/tools/list_changed| DO[RemoteConnectorSession DO]
  DO -->|tools/list RPC| RC
  DO -->|timeout / disconnect| Soft[clear tools + console.warn]
  Soft -.->|no longer| Sentry[(Sentry)]
  DO -->|malformed result / impl bug| Sentry
  DO -->|auth / invalid payload| Sentry
  classDef composes fill:#e6f4ea,stroke:#1e8e3e,color:#0d401c;
  classDef context fill:#f1f3f4,stroke:#80868b,color:#3c4043;
  class DO,Soft composes;
  class RC,Sentry context;
```

### Risk notes

- Low: matches #916 disconnect noise policy; no auth, isolation, billing, or migration surface.
- Soft-fail still clears `tools` only for expected refresh failures (pre-existing for those cases).

### Docs

No taxonomy or architecture doc changes required.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-392fe94a-4758-4411-a3c9-07a210674eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-392fe94a-4758-4411-a3c9-07a210674eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when remote tool lists cannot be refreshed via `tools/list`.
  * For expected refresh failures, tools are cleared while preserving the existing connection timestamp, and a warning is emitted.
  * Malformed `tools/list` responses are still reported, without clearing the existing tools list.
* **Tests**
  * Added WebSocket lifecycle coverage for `notifications/tools/list_changed` refresh failure and malformed snapshot response scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->