### PR TITLE
Lead the home hero with agent augmentation, plus stale-copy fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,11 @@ maintaining Kody). End-user / MCP usage docs live under
 [`docs/use/`](./docs/use/index.md).
 
 Kody is a multi-user personal assistant: every signed-in user gets a fully
-isolated assistant (own packages, jobs, secrets, values, memories, chat threads,
-remote connectors, email inboxes, durable storage). When adding code, every
-read/write path must be scoped by `userId`, every Durable Object id that backs
-user-owned state must be namespaced by `userId`, and every search/vector path
-must filter by `userId`. Cross-user data sharing is a bug.
+isolated assistant (own packages, jobs, secrets, values, memories, remote
+connectors, email inboxes, durable storage). When adding code, every read/write
+path must be scoped by `userId`, every Durable Object id that backs user-owned
+state must be namespaced by `userId`, and every search/vector path must filter
+by `userId`. Cross-user data sharing is a bug.
 
 Use Node 26 and npm for installs and scripts (`npm install`, `npm run ...`).
 

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -7,13 +7,13 @@ How Kody stores your data and what a deployment admin can see.
 Each signed-in user gets a fully isolated assistant. Kody stores account profile
 information (email, username, optional display name and bio, and profile
 visibility), secrets, values, memories, packages and their source, jobs, email
-inboxes and messages, chat threads, durable storage, remote connector
-configuration, OAuth grants, package invocation tokens, community social graph
-edges (follows, listing stars, and stored activity events), and any platform
-feedback you approve for submission. All of this remains scoped to your account
-except for content you deliberately make public (community listings and a public
-profile), the narrow admin review of approved platform feedback, and the
-community activity metadata described below.
+inboxes and messages, durable storage, remote connector configuration, OAuth
+grants, package invocation tokens, community social graph edges (follows,
+listing stars, and stored activity events), and any platform feedback you
+approve for submission. All of this remains scoped to your account except for
+content you deliberately make public (community listings and a public profile),
+the narrow admin review of approved platform feedback, and the community
+activity metadata described below.
 
 When profile visibility is **public**, display name, bio, public package
 metadata, follow counts, and public activity are visible on `/@username` and
@@ -101,7 +101,6 @@ does not let admins browse:
 - Jobs
 - Email inboxes and messages
 - Inbound webhook endpoints and delivery logs
-- Chat threads
 - Durable storage contents
 - Remote connector configuration
 - OAuth grants

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "#*": "./*",
     "#mcp/*": "./packages/worker/src/mcp/*"
   },
-  "description": "A starter and reference for building full stack web applications",
+  "description": "Your assistant's home — the memory, keys, code, and automations your AI agent keeps, portable across every MCP host",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}": [
       "oxfmt --no-error-on-unmatched-pattern",

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -47,9 +47,9 @@ const workflowSteps = [
 
 const capabilityHighlights = [
 	{
-		title: 'Use the assistant you already have',
+		title: 'Access you decide on, service by service',
 		description:
-			'Connect Kody to Claude, ChatGPT, Cursor, or Codex through MCP. Kody makes zero inference calls, so there is no second agent or model bill.',
+			'Not all-or-nothing access to your machine. You approve each credential, each host, and each package. Secrets stay server-side and never enter your assistant\u2019s context.',
 	},
 	{
 		title: 'The fastest way to start',
@@ -57,9 +57,9 @@ const capabilityHighlights = [
 			'Install a community package in one click. Every install is a fork you own—open it, change it, schedule it, or publish your version back.',
 	},
 	{
-		title: 'Self-service means ownership',
+		title: 'One-off work becomes permanent',
 		description:
-			"Bring your own OAuth apps and API keys. Your data is exportable and Kody's source is available to inspect, so your assistant stays portable.",
+			'Your agent explores against your real APIs, and once something works it saves as a package that runs on a schedule—no model in the loop, no tokens, no drift.',
 	},
 ] as const
 
@@ -149,21 +149,25 @@ export function HomeRoute(handle: Handle) {
 					<img src="/logo.png" alt="kody logo" mix={css(heroLogoCss)} />
 					<div mix={css(heroTextCss)}>
 						<h1 mix={css(heroTitleCss)}>
-							Your assistant&apos;s{' '}
-							<span mix={css({ color: colors.primaryText })}>home</span>
+							Kody{' '}
+							<span mix={css({ color: colors.primaryText })}>augments</span>{' '}
+							your agent
 						</h1>
 						<p mix={css(heroSubtitleCss)}>
-							The memory, keys, code, and automations it keeps, no matter which
-							agent you talk to. For builders who&apos;d rather own their
-							assistant than rent one.
+							It does not replace the assistant you already use. Connect Claude,
+							ChatGPT, Cursor, or Codex, and it gains your keys, your saved
+							code, and automations that keep running with your laptop closed.
 						</p>
 					</div>
 					<div mix={css(commandPillRowCss)}>
+						{renderCommandPill('connects')}
 						{renderCommandPill('remembers')}
 						{renderCommandPill('acts')}
 					</div>
 					<p mix={css(heroTaglineCss)}>
-						Kody keeps working while your computer is off.
+						Kody never calls a model. It is your assistant&apos;s home — the
+						memory, keys, code, and automations it keeps, no matter which agent
+						you talk to.
 					</p>
 					<div>
 						{onboardingStatus === 'ready' &&

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -27,11 +27,11 @@ export function PrivacyRoute(_handle: Handle) {
 					Each signed-in user gets a fully isolated assistant. Kody stores
 					account profile information (email and username), secrets, values,
 					memories, packages and their source, jobs, email inboxes and messages,
-					chat threads, durable storage, remote connector configuration, OAuth
-					grants, package invocation tokens, and any platform feedback you
-					approve for submission. All of this remains scoped to your account
-					except for the narrow admin review of approved platform feedback and
-					the community activity metadata described below.
+					durable storage, remote connector configuration, OAuth grants, package
+					invocation tokens, and any platform feedback you approve for
+					submission. All of this remains scoped to your account except for the
+					narrow admin review of approved platform feedback and the community
+					activity metadata described below.
 				</p>
 			</section>
 
@@ -106,7 +106,6 @@ export function PrivacyRoute(_handle: Handle) {
 					<li>Private packages and their source</li>
 					<li>Jobs</li>
 					<li>Email inboxes and messages</li>
-					<li>Chat threads</li>
 					<li>Durable storage contents</li>
 					<li>Remote connector configuration</li>
 					<li>OAuth grants</li>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two commits. The hero change is the substantive one and is a **strawman for Kent's voice** — the direction is evidence-backed, the exact wording is not precious.

## Why the hero changed

Feedback gathered from four independent sources — five recorded onboarding sessions in Notion, 22 waitlist email threads, X DMs, and ~330 public X replies — converges on a single misconception: **people assume Kody replaces the agent they already use, or that it is another OpenClaw.**

- @RussellCanfield: *"You made OpenClaw or Wingman :) missing some small features but otherwise its identical."*
- @cumpsd: *"Is Kody your agent or the name of a product?"*
- @glcst: *"Do you see Kody as a framework? A harness? Something in between?"*
- @tharshan_09 arrived planning to *replace* Claude Code with Kody.
- Kent has explained "Kody is not an agent" at least five times in email and twice more in DMs.

The homepage never corrected it. Worse, the correction is already the **best-performing message in four months of posting**: the Jun 30 "augments instead of replacing" post did 273 likes / 263 bookmarks / 82k impressions — roughly 3x the next best post and 4.4x the explicit pipeline post — and the word "augments" appeared nowhere on the home page.

## What changed

Hero leads with augmentation and names the hosts. `Your assistant's home` is preserved as the secondary tagline so the brand line survives (it also still anchors the README, `package.json`, and three blog posts).

Capability cards reordered to match the evidence rather than the old feature order: scoped access first (the anti-OpenClaw draw — Bernardo: *"All the other systems out there offer flexibility with nothing of safety"*), forking second (the validated activation path — 6 forks by 5 users, 3 ratings all five stars), explore-then-freeze third (best bookmark-to-like ratio in the corpus at 0.8–1.1 vs 0.13–0.31 for memory/jobs/email).

### Before / after

![Home hero before](https://cursor.com/artifacts/c/art-d7f5ebbc-a615-4268-b149-82778e503816)

![Home hero after](https://cursor.com/artifacts/c/art-f7af4b22-6761-4737-ab17-a9d70c66f65a)

![Reordered capability cards](https://cursor.com/artifacts/c/art-53c3ee49-b01d-4ff8-ac96-64f74cf53599)

## Second commit: stale copy

`package.json` still described the repo as "A starter and reference for building full stack web applications." And `chat_threads` was dropped in migration `0037` with no code referencing it, yet `docs/use/privacy.md` and the privacy page still listed chat threads both as data Kody stores and as data admins cannot see — an inaccurate disclosure on the page people read before handing over credentials.

## Validation

`npm run validate` passes clean on both commits — `format:check`, `lint`, `typecheck`, 1285 unit tests, 18 Playwright E2E, MCP E2E, `primitives:check`, `migrations:check` all exit 0.

Copy only; no logic changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d6cfa42-3c7e-489d-a190-5ef4c4e034ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d6cfa42-3c7e-489d-a190-5ef4c4e034ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated privacy guidance to clarify stored account data and the information administrators cannot access.
  - Refined product descriptions to better explain portable memory, credentials, code, and automations.

- **User Experience**
  - Updated homepage messaging to highlight granular service access approvals and server-side secret protection.
  - Clarified that the assistant complements existing agents rather than replacing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->