### PR TITLE
fix(sentry): keep malformed search entity refs out of Sentry

### DIFF
--- a/packages/worker/src/mcp/tools/search-detail.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-detail.node.test.ts
@@ -80,6 +80,18 @@ test('resolveEntityDetail reports unresolvable entity refs as caller errors', as
 		['user:missing-value:value', 'Persisted value not found for this user.'],
 		['notion:integration', 'Saved integration not found for this user.'],
 		['API_KEY:secret', 'Secret not found for this user.'],
+		[
+			'not-a-ref',
+			'Entity must use the format "{id}:{type}" where type is capability, package, secret, value, or integration.',
+		],
+		[
+			'thing:widget',
+			'Entity type must be one of: capability, package, secret, value, or integration.',
+		],
+		[
+			'workspace:preferred_repo:value',
+			'Value entity scope must be one of: session, app, or user.',
+		],
 	] as const
 
 	for (const [entity, message] of expected) {

--- a/packages/worker/src/mcp/tools/search-entities.ts
+++ b/packages/worker/src/mcp/tools/search-entities.ts
@@ -1,3 +1,4 @@
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { storageScopeValues, type StorageScope } from '#mcp/storage.ts'
 import { type ValueMetadata } from '#mcp/values/types.ts'
 
@@ -14,24 +15,31 @@ export function parseValueEntityId(id: string): {
 } {
 	const separator = id.indexOf(':')
 	if (separator <= 0 || separator === id.length - 1) {
-		throw new Error('Value entities must use the format "{scope}:{name}".')
+		throw new McpCallerError(
+			'Value entities must use the format "{scope}:{name}".',
+		)
 	}
 	const scope = id.slice(0, separator).trim()
 	if (!storageScopeValues.includes(scope as StorageScope)) {
-		throw new Error('Value entity scope must be one of: session, app, or user.')
+		throw new McpCallerError(
+			'Value entity scope must be one of: session, app, or user.',
+		)
 	}
 	const encodedName = id.slice(separator + 1).trim()
 	if (!encodedName) {
-		throw new Error('Value entity name must not be empty.')
+		throw new McpCallerError('Value entity name must not be empty.')
 	}
 	try {
 		const name = decodeURIComponent(encodedName)
 		if (!name) {
-			throw new Error('Value entity name must not be empty.')
+			throw new McpCallerError('Value entity name must not be empty.')
 		}
 		return { name, scope: scope as StorageScope }
-	} catch {
-		throw new Error('Value entity name must be URL-encoded when needed.')
+	} catch (cause) {
+		if (cause instanceof McpCallerError) throw cause
+		throw new McpCallerError(
+			'Value entity name must be URL-encoded when needed.',
+		)
 	}
 }
 

--- a/packages/worker/src/mcp/tools/search-format-helpers.ts
+++ b/packages/worker/src/mcp/tools/search-format-helpers.ts
@@ -1,4 +1,5 @@
 import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { buildKodyCapabilityAccessor } from '#mcp/kody-capability-accessors.ts'
 import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
 import { type PackageJobSchedule } from '#worker/package-registry/types.ts'
@@ -140,7 +141,7 @@ export function parseEntityRef(entity: string): {
 	const trimmed = entity.trim()
 	const separator = trimmed.lastIndexOf(':')
 	if (separator <= 0 || separator === trimmed.length - 1) {
-		throw new Error(
+		throw new McpCallerError(
 			'Entity must use the format "{id}:{type}" where type is capability, package, secret, value, or integration.',
 		)
 	}
@@ -153,12 +154,12 @@ export function parseEntityRef(entity: string): {
 		type !== 'value' &&
 		type !== 'integration'
 	) {
-		throw new Error(
+		throw new McpCallerError(
 			'Entity type must be one of: capability, package, secret, value, or integration.',
 		)
 	}
 	if (!id) {
-		throw new Error('Entity id must not be empty.')
+		throw new McpCallerError('Entity id must not be empty.')
 	}
 	return { id, type }
 }

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -1,5 +1,6 @@
 import { Script, createContext } from 'node:vm'
 import { expect, test } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	compactCapabilityInputTypeDefinition,
 	formatEntityDetailMarkdown,
@@ -72,6 +73,13 @@ async function executeCapabilityExample(executeExample: string) {
 	).runInNewContext({ kody })
 	return { calls, result }
 }
+
+test('parseEntityRef rejects malformed refs as caller errors', () => {
+	expect(() => parseEntityRef('not-an-entity-ref')).toThrow(McpCallerError)
+	expect(() => parseEntityRef('foo:bar')).toThrow(/Entity type must be one of/)
+	expect(() => parseEntityRef(':capability')).toThrow(McpCallerError)
+	expect(() => parseEntityRef('id:')).toThrow(McpCallerError)
+})
 
 test('search formatting keeps entity refs and generates safe, runnable usage snippets', () => {
 	expect(parseEntityRef('user:preferred_repo:value')).toEqual({

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -669,6 +669,33 @@ test('search tool batches entity detail with per-ref isolation and preserves sin
 		)
 
 		logMcpEventSpy.mockClear()
+		mockPerformanceNow.mockReturnValueOnce(420).mockReturnValueOnce(430)
+		const malformedBatch = await handler({
+			entity: ['not-a-ref', 'thing:widget'],
+			conversationId: 'conv-batch-malformed',
+		})
+		expect(malformedBatch.isError).toBe(true)
+		expect(logMcpEventSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				outcome: 'failure',
+				callerError: true,
+				errorName: 'EntityBatchError',
+				context: expect.objectContaining({
+					entityFailures: [
+						expect.objectContaining({
+							entityRef: 'not-a-ref',
+							callerError: true,
+						}),
+						expect.objectContaining({
+							entityRef: 'thing:widget',
+							callerError: true,
+						}),
+					],
+				}),
+			}),
+		)
+
+		logMcpEventSpy.mockClear()
 		mockModule.getSavedPackageById.mockImplementation(
 			async (_db: unknown, input: { packageId: string }) => ({
 				id: input.packageId,
@@ -712,6 +739,15 @@ test('search tool batches entity detail with per-ref isolation and preserves sin
 			errorName: 'EntityBatchError',
 			cause: expect.objectContaining({
 				message: 'All entity lookups failed.',
+				cause: expect.any(AggregateError),
+			}),
+			context: expect.objectContaining({
+				entityFailures: expect.arrayContaining([
+					expect.objectContaining({
+						callerError: false,
+						error: expect.stringMatching(/D1 read failed/i),
+					}),
+				]),
 			}),
 		})
 		expect(platformFailureCall?.[0]).not.toHaveProperty('callerError', true)

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -324,9 +324,14 @@ export async function runSearchTool(input: {
 				markdownParts.push(entityResult.markdown)
 			}
 			const allFailed = successCount === 0
+			const failedEntries = outcome.results.filter((entry) => !entry.ok)
 			const allFailuresAreCallerErrors =
-				allFailed &&
-				outcome.results.every((entry) => !entry.ok && entry.callerError)
+				allFailed && failedEntries.every((entry) => entry.callerError)
+			const entityFailures = failedEntries.map((entry) => ({
+				entityRef: entry.entityRef,
+				error: entry.error,
+				callerError: entry.callerError,
+			}))
 			logMcpEvent({
 				category: 'mcp',
 				tool: 'search',
@@ -345,10 +350,22 @@ export async function runSearchTool(input: {
 							...(allFailuresAreCallerErrors
 								? { callerError: true }
 								: {
-										cause: new Error('All entity lookups failed.'),
+										cause: new Error('All entity lookups failed.', {
+											cause: new AggregateError(
+												failedEntries.map(
+													(entry) =>
+														new Error(`${entry.entityRef}: ${entry.error}`),
+												),
+												'Entity lookup failures',
+											),
+										}),
 									}),
 							errorName: 'EntityBatchError',
 							errorMessage: 'All entity lookups failed.',
+							context: {
+								failurePhase: 'handler',
+								entityFailures,
+							},
 						}
 					: {}),
 			})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [issue 7631143592](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7631143592/) (`Error: All entity lookups failed.` in `runSearchTool`) was fired when an agent batch-looked-up entities with malformed refs (or other caller-input parse failures). `parseEntityRef` / `parseValueEntityId` threw plain `Error`, so the entity-batch path treated every failure as a platform incident and reported a synthetic `All entity lookups failed.` exception.

This continues the `#919` / `#922` `McpCallerError` carve-out: bad entity ref / value-entity format is a caller mistake and stays on the `mcp-event` log line. Genuine platform batch failures still reach Sentry, now with per-entity failure context + an `AggregateError` cause so triage is not blind.

## Changes

- Throw `McpCallerError` from `parseEntityRef` and `parseValueEntityId`
- On total entity-batch failure, log `entityFailures` context; for non-caller failures, chain an `AggregateError` under the synthetic cause
- Tests for malformed refs (unit + batch handler path)

## Risk / merge

Low (`composes`): observability attribution only; agent-facing error text unchanged. Platform batch failures still report to Sentry.

## Siblings

- Prefetched validation issue `7631582437` (`Provide "query", "entity", or "domain"`) does **not** share this root cause — that path already sets `callerError: true` (event was from a pre-`#919` release).
- Timeout events previously fingerprint-grouped under this issue, and sibling `7631797267`, are separate.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `42d211e0` · **Head:** `e22f04b7`

**Classification:** composes — reuses the existing `McpCallerError` / `callerError` observability carve-out; no new primitives, no contract change to search results beyond Sentry attribution.

### Primitives touched

| Primitive    | Group    | Impact                                                                 |
| ------------ | -------- | ---------------------------------------------------------------------- |
| `mcp-server` | surfaces | composes — marks malformed entity refs as caller errors; richer batch failure context for real platform fails |

### System map

_Malformed `search({ entity })` refs are attributed as caller mistakes so they stay off Sentry; platform batch failures still alert with per-entity detail._

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  Agent["Agent / MCP client"] --> Search["search tool<br/>entity batch"]
  Search --> Parse["parseEntityRef /<br/>parseValueEntityId"]
  Parse -->|bad input| CallerErr["McpCallerError<br/>callerError=true"]
  Parse -->|ok| Resolve["resolveEntityDetail"]
  Resolve -->|not found| CallerErr
  Resolve -->|platform fail| Platform["Sentry exception<br/>+ entityFailures"]
  CallerErr --> Log["mcp-event log only"]
  Platform --> Sentry["Sentry"]

  classDef composes fill:#d4edda,stroke:#28a745,color:#000
  classDef context fill:#f1f3f5,stroke:#868e96,color:#000
  class Search,Parse,CallerErr,Log,Platform composes
  class Agent,Resolve,Sentry context
```

### Invariants

- Per-user isolation: unchanged (entity lookup still scoped by `userId`).
- No auth / billing / migration / DR surface.

### Risk notes

- Low: only changes which failures are reported to Sentry and what context they carry. Agent-visible error strings for malformed refs are unchanged.
- Remaining true platform batch failures (e.g. D1 read mid-batch) still open Sentry issues by design.

### Docs

- No doc updates required (internal observability attribution).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64a5ccd5-0140-4d72-895a-600ef89f0cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64a5ccd5-0140-4d72-895a-600ef89f0cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid entity references now return clear caller errors for malformed formats, unsupported types, and invalid value scopes.
  * Entity batch failures now distinguish invalid requests from platform or lookup failures.
  * Batch error reporting includes details for each failed entity lookup.

* **Tests**
  * Added coverage for validation errors and mixed entity-batch failure scenarios.
  * Improved verification of aggregated failure reporting and error classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->