### PR TITLE
Enrich Sentry events with diagnostic context for workflows, cron, MCP, and connectors

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -628,7 +628,15 @@ const workerHandler = {
 					continue
 				}
 				console.error(`scheduled_lane_failed lane=${lane.name}`, error)
-				Sentry.captureException(error)
+				Sentry.withScope((scope) => {
+					scope.setTag('scheduled.lane', lane.name)
+					scope.setContext('scheduled', {
+						lane: lane.name,
+						scheduledTime: scheduledAt.toISOString(),
+						cron: controller.cron,
+					})
+					Sentry.captureException(error)
+				})
 			}
 		}
 	},

--- a/packages/worker/src/index.workers.test.ts
+++ b/packages/worker/src/index.workers.test.ts
@@ -297,6 +297,10 @@ test('scheduled isolates a failing lane: logs it and keeps siblings and the invo
 	const consoleErrorSpy = vi
 		.spyOn(console, 'error')
 		.mockImplementation(() => {})
+	const withScope = vi.spyOn(Sentry, 'withScope')
+	const captureException = vi
+		.spyOn(Sentry, 'captureException')
+		.mockImplementation(() => '')
 	mocks.reconcileArtifactsPushes.mockRejectedValueOnce(
 		new Error('reconcile exploded'),
 	)
@@ -317,8 +321,35 @@ test('scheduled isolates a failing lane: logs it and keeps siblings and the invo
 			'scheduled_lane_failed lane=reconcile_artifacts_pushes',
 			expect.objectContaining({ message: 'reconcile exploded' }),
 		)
+		expect(withScope).toHaveBeenCalled()
+		expect(captureException).toHaveBeenCalledWith(
+			expect.objectContaining({ message: 'reconcile exploded' }),
+		)
+		const scopeCallback = withScope.mock.calls[0]?.[0] as
+			| ((scope: {
+					setTag: (key: string, value: string) => void
+					setContext: (key: string, value: Record<string, unknown>) => void
+			  }) => void)
+			| undefined
+		expect(scopeCallback).toBeTypeOf('function')
+		const setTag = vi.fn()
+		const setContext = vi.fn()
+		scopeCallback?.({ setTag, setContext })
+		expect(setTag).toHaveBeenCalledWith(
+			'scheduled.lane',
+			'reconcile_artifacts_pushes',
+		)
+		expect(setContext).toHaveBeenCalledWith(
+			'scheduled',
+			expect.objectContaining({
+				lane: 'reconcile_artifacts_pushes',
+				scheduledTime: new Date(scheduledTime).toISOString(),
+			}),
+		)
 	} finally {
 		consoleErrorSpy.mockRestore()
+		withScope.mockRestore()
+		captureException.mockRestore()
 	}
 })
 

--- a/packages/worker/src/index.workers.test.ts
+++ b/packages/worker/src/index.workers.test.ts
@@ -344,6 +344,7 @@ test('scheduled isolates a failing lane: logs it and keeps siblings and the invo
 			expect.objectContaining({
 				lane: 'reconcile_artifacts_pushes',
 				scheduledTime: new Date(scheduledTime).toISOString(),
+				cron: '*/5 * * * *',
 			}),
 		)
 	} finally {

--- a/packages/worker/src/mcp/capabilities/define-capability.ts
+++ b/packages/worker/src/mcp/capabilities/define-capability.ts
@@ -71,9 +71,15 @@ export function defineCapability<
 			: {}),
 		async handler(args, ctx) {
 			const startedAt = performance.now()
-			const { baseUrl, hasUser, userId } = callerContextFields(
+			const { baseUrl, hasUser, userId, storageId } = callerContextFields(
 				ctx.callerContext,
 			)
+			const mcpCallerFields = {
+				baseUrl,
+				hasUser,
+				userId,
+				...(storageId ? { storageId } : {}),
+			}
 			await assertCallerCanAccessCapability(ctx.callerContext, definition, {
 				env: ctx.env,
 			})
@@ -91,9 +97,7 @@ export function defineCapability<
 					capabilitySource: source,
 					outcome: 'failure',
 					durationMs: Math.round(performance.now() - startedAt),
-					baseUrl,
-					hasUser,
-					userId,
+					...mcpCallerFields,
 					failurePhase: 'parse_input',
 					errorName,
 					errorMessage,
@@ -115,9 +119,7 @@ export function defineCapability<
 					capabilitySource: source,
 					outcome: 'failure',
 					durationMs: Math.round(performance.now() - startedAt),
-					baseUrl,
-					hasUser,
-					userId,
+					...mcpCallerFields,
 					failurePhase: 'handler',
 					errorName,
 					errorMessage,
@@ -136,9 +138,7 @@ export function defineCapability<
 					capabilitySource: source,
 					outcome: 'success',
 					durationMs: Math.round(performance.now() - startedAt),
-					baseUrl,
-					hasUser,
-					userId,
+					...mcpCallerFields,
 				})
 				return finalized
 			} catch (error) {
@@ -151,9 +151,7 @@ export function defineCapability<
 					capabilitySource: source,
 					outcome: 'failure',
 					durationMs: Math.round(performance.now() - startedAt),
-					baseUrl,
-					hasUser,
-					userId,
+					...mcpCallerFields,
 					failurePhase: 'parse_output',
 					errorName,
 					errorMessage,

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -176,5 +176,49 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 	)
 	expect(sentryMock.scope.setLevel).toHaveBeenCalledWith('error')
 	expect(sentryMock.scope.setUser).toHaveBeenCalledWith({ id: 'user-1' })
+	expect(sentryMock.scope.setContext).toHaveBeenCalledWith(
+		'mcp',
+		expect.objectContaining({
+			baseUrl: 'https://example.com',
+			hasUser: true,
+			errorMessage: 'platform handler blew up',
+			detail: undefined,
+		}),
+	)
 	expect(sentryMock.captureMessage).not.toHaveBeenCalled()
+})
+
+test('logMcpEvent copies conversationId, storageId, and detail into Sentry mcp context', () => {
+	sentryMock.scope.setContext.mockClear()
+	sentryMock.captureException.mockClear()
+
+	captureMcpEvents(() => {
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'storage_query',
+			domain: 'storage',
+			capabilitySource: 'builtin',
+			conversationId: 'conv-storage-1',
+			storageId: 'storage-notes-1',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage: 'no such table: notes: SQLITE_ERROR',
+			context: {
+				sqlPreview: 'SELECT * FROM notes LIMIT 1',
+			},
+			cause: new Error('no such table: notes: SQLITE_ERROR'),
+		})
+	})
+
+	expect(sentryMock.captureException).toHaveBeenCalledOnce()
+	expect(sentryMock.scope.setContext).toHaveBeenCalledWith(
+		'mcp',
+		expect.objectContaining({
+			conversationId: 'conv-storage-1',
+			storageId: 'storage-notes-1',
+			detail: {
+				sqlPreview: 'SELECT * FROM notes LIMIT 1',
+			},
+		}),
+	)
 })

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -19,6 +19,16 @@ export type McpObservabilityPayload = {
 	hasUser: boolean
 	/** Stable user id of the caller, when authenticated. */
 	userId?: string
+	/**
+	 * MCP tool conversation id when the call is part of a multi-turn tool
+	 * session. Kept on context (not tags) to avoid high-cardinality indexing.
+	 */
+	conversationId?: string
+	/**
+	 * Bound durable storage id for execute/capability calls that run against a
+	 * specific bucket. Kept on context (not tags) for the same reason.
+	 */
+	storageId?: string
 	failurePhase?: McpFailurePhase
 	sandboxError?: boolean
 	/**
@@ -46,6 +56,7 @@ export function callerContextFields(context: McpCallerContext) {
 		hasUser: context.user != null,
 		userId: context.user?.userId,
 		storageContext: context.storageContext ?? null,
+		storageId: context.storageContext?.storageId ?? undefined,
 	}
 }
 
@@ -109,6 +120,11 @@ function reportMcpFailureToSentry(
 				errorName: payload.errorName,
 				errorMessage: payload.errorMessage,
 				registeredCapabilityCount: payload.registeredCapabilityCount,
+				conversationId: payload.conversationId,
+				storageId: payload.storageId,
+				// Structured call-site detail (entity refs, validation phase,
+				// intent telemetry). Nested so it cannot clobber core fields.
+				detail: payload.context,
 			})
 
 			if (cause instanceof Error) {

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -146,9 +146,20 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				},
 			}
 			const resolvedConversationId = resolveConversationId(conversationId)
-			const { baseUrl, hasUser, userId, storageContext } =
-				callerContextFields(callerContext)
-			const activeStorageId = storageContext?.storageId ?? null
+			const {
+				baseUrl,
+				hasUser,
+				userId,
+				storageId: boundStorageId,
+			} = callerContextFields(callerContext)
+			const activeStorageId = boundStorageId ?? null
+			const mcpCallerFields = {
+				baseUrl,
+				hasUser,
+				userId,
+				conversationId: resolvedConversationId,
+				...(activeStorageId ? { storageId: activeStorageId } : {}),
+			}
 			try {
 				return await runExecuteTool()
 			} catch (cause) {
@@ -164,9 +175,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					toolName: 'execute',
 					outcome: 'failure',
 					durationMs: timing.durationMs,
-					baseUrl,
-					hasUser,
-					userId,
+					...mcpCallerFields,
 					sandboxError: false,
 					errorName,
 					errorMessage,
@@ -288,9 +297,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						toolName: 'execute',
 						outcome: 'failure',
 						durationMs,
-						baseUrl,
-						hasUser,
-						userId,
+						...mcpCallerFields,
 						registeredCapabilityCount,
 						sandboxError: true,
 						errorName,
@@ -329,9 +336,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					toolName: 'execute',
 					outcome: 'success',
 					durationMs,
-					baseUrl,
-					hasUser,
-					userId,
+					...mcpCallerFields,
 					registeredCapabilityCount,
 					sandboxError: false,
 					context: activeStorageId ? { storageId: activeStorageId } : undefined,

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -60,8 +60,16 @@ export async function runSearchTool(input: {
 		baseUrl,
 		hasUser,
 		userId: callerUserId,
+		storageId,
 	} = callerContextFields(callerContext)
 	const userId = callerUserId ?? null
+	const mcpCallerFields = {
+		baseUrl,
+		hasUser,
+		userId: userId ?? undefined,
+		conversationId,
+		...(storageId ? { storageId } : {}),
+	}
 	const includeHiddenPackages = !!args.includeHiddenPackages
 	const domainFilter = args.domain?.trim() || undefined
 	// Whitespace-only queries stay valid (memory enrichment may still run) but
@@ -75,9 +83,7 @@ export async function runSearchTool(input: {
 			toolName: 'search',
 			outcome: 'failure',
 			durationMs: timing.durationMs,
-			baseUrl,
-			hasUser,
-			userId: userId ?? undefined,
+			...mcpCallerFields,
 			sandboxError: false,
 			callerError: true,
 			errorName: 'ValidationError',
@@ -259,9 +265,7 @@ export async function runSearchTool(input: {
 				toolName: 'search',
 				outcome: 'success',
 				durationMs: timing.durationMs,
-				baseUrl,
-				hasUser,
-				userId: userId ?? undefined,
+				...mcpCallerFields,
 			})
 			return {
 				content: prependToolMetadataContent(conversationId, [
@@ -338,9 +342,7 @@ export async function runSearchTool(input: {
 				toolName: 'search',
 				outcome: allFailed ? 'failure' : 'success',
 				durationMs: timing.durationMs,
-				baseUrl,
-				hasUser,
-				userId: userId ?? undefined,
+				...mcpCallerFields,
 				...(allFailed
 					? {
 							sandboxError: false,
@@ -502,9 +504,7 @@ export async function runSearchTool(input: {
 			toolName: 'search',
 			outcome: 'success',
 			durationMs: timing.durationMs,
-			baseUrl,
-			hasUser,
-			userId: userId ?? undefined,
+			...mcpCallerFields,
 			message: 'Search completed successfully.',
 			context: {
 				task: execution.result.intent.task.name,
@@ -544,9 +544,7 @@ export async function runSearchTool(input: {
 			toolName: 'search',
 			outcome: 'failure',
 			durationMs: timing.durationMs,
-			baseUrl,
-			hasUser,
-			userId: userId ?? undefined,
+			...mcpCallerFields,
 			sandboxError: false,
 			errorName,
 			errorMessage,

--- a/packages/worker/src/package-runtime/package-workflows-sentry.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows-sentry.node.test.ts
@@ -1,0 +1,103 @@
+import { expect, test, vi } from 'vitest'
+
+const sentryMock = vi.hoisted(() => ({
+	isInitialized: vi.fn(() => true),
+	setUser: vi.fn(),
+	setTag: vi.fn(),
+	setContext: vi.fn(),
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+	isInitialized: (...args: Array<unknown>) => sentryMock.isInitialized(...args),
+	setUser: (...args: Array<unknown>) => sentryMock.setUser(...args),
+	setTag: (...args: Array<unknown>) => sentryMock.setTag(...args),
+	setContext: (...args: Array<unknown>) => sentryMock.setContext(...args),
+}))
+
+const { applyDynamicWorkflowSentryScope } =
+	await import('./package-workflows-sentry.ts')
+
+test('applyDynamicWorkflowSentryScope tags package workflows with user and coordinates', () => {
+	sentryMock.setUser.mockClear()
+	sentryMock.setTag.mockClear()
+	sentryMock.setContext.mockClear()
+
+	applyDynamicWorkflowSentryScope({
+		instanceId: 'wf-instance-1',
+		payload: {
+			version: 2,
+			sourceType: 'package',
+			userId: 'user-stable-1',
+			packageId: 'pkg-1',
+			kodyId: 'demo-package',
+			sourceId: 'source-1',
+			workflowName: 'nightly',
+			exportName: 'run',
+			idempotencyKey: 'idem-1',
+			runAt: '2026-07-25T00:00:00.000Z',
+			planDate: null,
+		},
+	})
+
+	expect(sentryMock.setUser).toHaveBeenCalledWith({ id: 'user-stable-1' })
+	expect(sentryMock.setTag).toHaveBeenCalledWith(
+		'workflow.source_type',
+		'package',
+	)
+	expect(sentryMock.setTag).toHaveBeenCalledWith(
+		'workflow.kody_id',
+		'demo-package',
+	)
+	expect(sentryMock.setContext).toHaveBeenCalledWith(
+		'workflow',
+		expect.objectContaining({
+			instanceId: 'wf-instance-1',
+			packageId: 'pkg-1',
+			kodyId: 'demo-package',
+			exportName: 'run',
+			workflowName: 'nightly',
+			idempotencyKey: 'idem-1',
+		}),
+	)
+})
+
+test('applyDynamicWorkflowSentryScope records inline code size without package tags', () => {
+	sentryMock.setUser.mockClear()
+	sentryMock.setTag.mockClear()
+	sentryMock.setContext.mockClear()
+
+	applyDynamicWorkflowSentryScope({
+		instanceId: 'wf-inline-1',
+		payload: {
+			version: 3,
+			sourceType: 'inline',
+			userId: 'user-stable-2',
+			packageContext: null,
+			workflowName: 'ad-hoc',
+			code: 'export default async () => 1',
+			idempotencyKey: 'idem-2',
+			runAt: '2026-07-25T01:00:00.000Z',
+			planDate: null,
+		},
+	})
+
+	expect(sentryMock.setUser).toHaveBeenCalledWith({ id: 'user-stable-2' })
+	expect(sentryMock.setTag).toHaveBeenCalledWith(
+		'workflow.source_type',
+		'inline',
+	)
+	expect(sentryMock.setTag).not.toHaveBeenCalledWith(
+		'workflow.kody_id',
+		expect.anything(),
+	)
+	expect(sentryMock.setContext).toHaveBeenCalledWith(
+		'workflow',
+		expect.objectContaining({
+			instanceId: 'wf-inline-1',
+			sourceType: 'inline',
+			packageId: null,
+			kodyId: null,
+			codeBytes: 'export default async () => 1'.length,
+		}),
+	)
+})

--- a/packages/worker/src/package-runtime/package-workflows-sentry.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows-sentry.node.test.ts
@@ -25,7 +25,6 @@ test('applyDynamicWorkflowSentryScope tags package workflows with user and coord
 	applyDynamicWorkflowSentryScope({
 		instanceId: 'wf-instance-1',
 		payload: {
-			version: 2,
 			sourceType: 'package',
 			userId: 'user-stable-1',
 			packageId: 'pkg-1',
@@ -69,7 +68,6 @@ test('applyDynamicWorkflowSentryScope records inline code size without package t
 	applyDynamicWorkflowSentryScope({
 		instanceId: 'wf-inline-1',
 		payload: {
-			version: 3,
 			sourceType: 'inline',
 			userId: 'user-stable-2',
 			packageContext: null,

--- a/packages/worker/src/package-runtime/package-workflows-sentry.ts
+++ b/packages/worker/src/package-runtime/package-workflows-sentry.ts
@@ -1,0 +1,71 @@
+import * as Sentry from '@sentry/cloudflare'
+
+type WorkflowSentryPayload =
+	| {
+			sourceType: 'package'
+			userId: string
+			packageId: string
+			kodyId: string
+			sourceId: string
+			workflowName: string
+			exportName: string
+			idempotencyKey: string
+			runAt: string
+			planDate: string | null
+	  }
+	| {
+			sourceType: 'inline'
+			userId: string
+			packageContext: {
+				packageId: string
+				kodyId: string
+				sourceId?: string | null
+			} | null
+			workflowName: string
+			code: string
+			idempotencyKey: string
+			runAt: string
+			planDate: string | null
+	  }
+
+/**
+ * Attach identity + workflow coordinates so instrumentWorkflowWithSentry
+ * auto-captures (timeouts, unhandled throws) are diagnosable without digging
+ * through D1 breadcrumbs. High-cardinality ids stay on context, not tags.
+ */
+export function applyDynamicWorkflowSentryScope(input: {
+	payload: WorkflowSentryPayload
+	instanceId: string
+}) {
+	const { payload, instanceId } = input
+	try {
+		if (!Sentry.isInitialized()) return
+		if (payload.userId) Sentry.setUser({ id: payload.userId })
+		Sentry.setTag('workflow.source_type', payload.sourceType)
+		if (payload.sourceType === 'package') {
+			Sentry.setTag('workflow.kody_id', payload.kodyId)
+		}
+		Sentry.setContext('workflow', {
+			instanceId,
+			sourceType: payload.sourceType,
+			workflowName: payload.workflowName,
+			idempotencyKey: payload.idempotencyKey,
+			runAt: payload.runAt,
+			planDate: payload.planDate,
+			...(payload.sourceType === 'package'
+				? {
+						packageId: payload.packageId,
+						kodyId: payload.kodyId,
+						sourceId: payload.sourceId,
+						exportName: payload.exportName,
+					}
+				: {
+						packageId: payload.packageContext?.packageId ?? null,
+						kodyId: payload.packageContext?.kodyId ?? null,
+						codeBytes: payload.code.length,
+					}),
+		})
+	} catch {
+		// Observability must never break workflow execution.
+	}
+}

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -29,6 +29,7 @@ import {
 	terminalWorkflowStatusValues,
 	type WorkflowRunStatus,
 } from './workflow-statuses.ts'
+import { applyDynamicWorkflowSentryScope } from './package-workflows-sentry.ts'
 
 export type PackageWorkflowParams = Record<string, unknown>
 
@@ -978,6 +979,10 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 		step: WorkflowStep,
 	) {
 		const payload = validateDynamicCallableWorkflowPayload(event.payload)
+		applyDynamicWorkflowSentryScope({
+			payload,
+			instanceId: event.instanceId,
+		})
 		const runAt = new Date(payload.runAt)
 		if (runAt.getTime() > Date.now()) {
 			await step.sleepUntil('wait until dynamic workflow runAt', runAt)

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -2,8 +2,28 @@ import { expect, test, vi } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const captureMessageMock = vi.fn()
+const setTagMock = vi.fn()
+const setUserMock = vi.fn()
+const setContextMock = vi.fn()
+const setLevelMock = vi.fn()
 
 vi.mock('@sentry/cloudflare', () => ({
+	isInitialized: () => true,
+	withScope: (
+		callback: (scope: {
+			setLevel: typeof setLevelMock
+			setTag: typeof setTagMock
+			setUser: typeof setUserMock
+			setContext: typeof setContextMock
+		}) => void,
+	) => {
+		callback({
+			setLevel: setLevelMock,
+			setTag: setTagMock,
+			setUser: setUserMock,
+			setContext: setContextMock,
+		})
+	},
 	captureMessage: (...args: Array<unknown>) => captureMessageMock(...args),
 	instrumentDurableObjectWithSentry: (
 		_getOptions: unknown,
@@ -81,6 +101,10 @@ async function createRemoteConnectorSession(
 	input: Parameters<typeof createState>[0] = {},
 ) {
 	captureMessageMock.mockReset()
+	setTagMock.mockReset()
+	setUserMock.mockReset()
+	setContextMock.mockReset()
+	setLevelMock.mockReset()
 	const { state, persistedEntries } = createState(input)
 	const session = new RemoteConnectorSession(
 		{
@@ -296,6 +320,10 @@ test('remote connector session lifecycle across restore, snapshot, heartbeat, cl
 test('tools/list_changed soft-fails disconnects and reports malformed snapshots', async () => {
 	consoleWarn.mockImplementation(() => {})
 	captureMessageMock.mockClear()
+	setTagMock.mockClear()
+	setUserMock.mockClear()
+	setContextMock.mockClear()
+	setLevelMock.mockClear()
 
 	const softFail = await createRemoteConnectorSession({
 		storedState: {
@@ -344,6 +372,10 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 	})
 
 	captureMessageMock.mockClear()
+	setTagMock.mockClear()
+	setUserMock.mockClear()
+	setContextMock.mockClear()
+	setLevelMock.mockClear()
 	const sent: Array<string> = []
 	const socket = {
 		send: (payload: string) => {
@@ -400,13 +432,19 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 
 	expect(captureMessageMock).toHaveBeenCalledWith(
 		'Remote connector session message handler threw.',
+	)
+	expect(setLevelMock).toHaveBeenCalledWith('error')
+	expect(setTagMock).toHaveBeenCalledWith(
+		'worker_component',
+		'remote-connector-session',
+	)
+	expect(setTagMock).toHaveBeenCalledWith('remote_connector.id', 'home')
+	expect(setContextMock).toHaveBeenCalledWith(
+		'remote_connector',
 		expect.objectContaining({
-			level: 'error',
-			extra: expect.objectContaining({
-				connectorId: 'home',
-				messageType: 'connector.jsonrpc',
-				error: 'Malformed tools/list result.',
-			}),
+			connectorId: 'home',
+			messageType: 'connector.jsonrpc',
+			error: 'Malformed tools/list result.',
 		}),
 	)
 	expect(

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -381,6 +381,10 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 		send: (payload: string) => {
 			sent.push(payload)
 		},
+		deserializeAttachment: () => ({
+			ingressSessionKey: 'session-home',
+			ingressUserId: 'user-home-1',
+		}),
 	} as unknown as WebSocket
 	const malformed = await createRemoteConnectorSession({
 		storedState: {
@@ -439,10 +443,12 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 		'remote-connector-session',
 	)
 	expect(setTagMock).toHaveBeenCalledWith('remote_connector.id', 'home')
+	expect(setUserMock).toHaveBeenCalledWith({ id: 'user-home-1' })
 	expect(setContextMock).toHaveBeenCalledWith(
 		'remote_connector',
 		expect.objectContaining({
 			connectorId: 'home',
+			userId: 'user-home-1',
 			messageType: 'connector.jsonrpc',
 			error: 'Malformed tools/list result.',
 		}),

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -108,6 +108,8 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		message: string,
 		input: {
 			level?: 'warning' | 'error'
+			/** Owning user for the socket/event that triggered this capture. */
+			userId?: string | null
 			extra?: Record<string, unknown>
 		} = {},
 	) {
@@ -115,7 +117,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			typeof input.extra?.connectorId === 'string'
 				? input.extra.connectorId
 				: (this.stateSnapshot.persisted.connectorId ?? undefined)
-		const userId = this.resolveConnectedIngressUserId()
+		const userId = input.userId ?? null
 		Sentry.withScope((scope) => {
 			scope.setLevel(input.level ?? 'warning')
 			scope.setTag('service', 'worker')
@@ -128,20 +130,12 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			}
 			scope.setContext('remote_connector', {
 				connectorId: connectorId ?? null,
-				userId: userId ?? null,
+				userId,
 				connected: this.ctx.getWebSockets(connectorTag).length > 0,
 				...input.extra,
 			})
 			Sentry.captureMessage(message)
 		})
-	}
-
-	private resolveConnectedIngressUserId(): string | null {
-		for (const socket of this.ctx.getWebSockets(connectorTag)) {
-			const userId = this.loadIngressUserId(socket)
-			if (userId) return userId
-		}
-		return null
 	}
 
 	async fetch(request: Request): Promise<Response> {
@@ -384,6 +378,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 				'Remote connector session received invalid websocket payload.',
 				{
 					level: 'error',
+					userId: this.loadIngressUserId(ws),
 					extra: {
 						connectorId: this.stateSnapshot.persisted.connectorId,
 						error: getErrorMessage(error),
@@ -416,6 +411,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 				'Remote connector session message handler threw.',
 				{
 					level: 'error',
+					userId: this.loadIngressUserId(ws),
 					extra: {
 						connectorId: this.stateSnapshot.persisted.connectorId,
 						messageType: parsed.type,
@@ -450,6 +446,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 				'Remote connector session rejected hello (missing user id on ingress).',
 				{
 					level: 'error',
+					userId: null,
 					extra: {
 						connectorId: canonicalInstanceId,
 					},
@@ -475,6 +472,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 				'Remote connector session rejected hello (session key mismatch).',
 				{
 					level: 'error',
+					userId: ingressUserId,
 					extra: {
 						connectorId: canonicalInstanceId,
 						ingressSessionKeySummary: summarizeSessionKey(ingressSessionKey),
@@ -509,6 +507,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 				'Remote connector session rejected websocket hello.',
 				{
 					level: 'error',
+					userId: ingressUserId,
 					extra: {
 						connectorId: canonicalInstanceId,
 						hasExpectedSecret,

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -111,14 +111,37 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			extra?: Record<string, unknown>
 		} = {},
 	) {
-		Sentry.captureMessage(message, {
-			level: input.level ?? 'warning',
-			tags: {
-				service: 'worker',
-				worker_component: 'remote-connector-session',
-			},
-			extra: input.extra ?? {},
+		const connectorId =
+			typeof input.extra?.connectorId === 'string'
+				? input.extra.connectorId
+				: (this.stateSnapshot.persisted.connectorId ?? undefined)
+		const userId = this.resolveConnectedIngressUserId()
+		Sentry.withScope((scope) => {
+			scope.setLevel(input.level ?? 'warning')
+			scope.setTag('service', 'worker')
+			scope.setTag('worker_component', 'remote-connector-session')
+			if (connectorId) {
+				scope.setTag('remote_connector.id', connectorId)
+			}
+			if (userId) {
+				scope.setUser({ id: userId })
+			}
+			scope.setContext('remote_connector', {
+				connectorId: connectorId ?? null,
+				userId: userId ?? null,
+				connected: this.ctx.getWebSockets(connectorTag).length > 0,
+				...input.extra,
+			})
+			Sentry.captureMessage(message)
 		})
+	}
+
+	private resolveConnectedIngressUserId(): string | null {
+		for (const socket of this.ctx.getWebSockets(connectorTag)) {
+			const userId = this.loadIngressUserId(socket)
+			if (userId) return userId
+		}
+		return null
 	}
 
 	async fetch(request: Request): Promise<Response> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recent production Sentry issues (workflow timeouts, scheduled Analytics Engine failures, MCP storage_query errors, remote-connector session noise) were hard to triage because auto-captures only had environment/release/IP. This PR attaches the coordinates we already have in-process onto Sentry scopes.

- **Workflows:** set user + `workflow.source_type` / `workflow.kody_id` tags and a `workflow` context (package/export/instance/idempotency) at the start of `DynamicCallableWorkflow` so `instrumentWorkflowWithSentry` auto-captures are diagnosable.
- **Scheduled lanes:** tag `scheduled.lane` and include cron/scheduledTime context on lane `captureException`.
- **MCP:** copy `conversationId`, `storageId`, and call-site `detail` into the Sentry `mcp` context (kept off tags to avoid high cardinality).
- **Remote connectors:** promote `connectorId` to a tag, attribute captures to the originating socket's ingress user, and move extras into a `remote_connector` context.

## Test plan

- [x] Unit tests for MCP observability context enrichment
- [x] Unit tests for workflow Sentry scope helper
- [x] Remote connector session capture expectations updated (including socket user attribution)
- [x] Scheduled lane workers test asserts lane + cron context
- [x] `npm run typecheck` / `npm run lint` / focused vitest

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7d88928a` · **Head:** `59f252c0`

**Classification:** extends — observability capture sites gain richer tags/contexts; no new primitives and no behavior changes outside Sentry reporting.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `workflows` | assistant | extends — attach user/package/export context before auto-capture |
| `scheduled-cron` | surfaces | extends — tag failing lanes on capture |
| `mcp-server` | surfaces | extends — include conversationId/storageId/detail on MCP failures |
| `capability-registry` | assistant | composes — pass storageId through defineCapability logging |
| `package-runtime` | runtime | composes — shared workflow Sentry helper |
| `remote-connectors` / `connector-ingress` | assistant / surfaces | extends — connector id + originating socket user on session captures |

### System map

_How failures reach Sentry, and which coordinates this PR attaches at each capture site._

**Legend:** green = composes · amber = extended · gray = context

```mermaid
flowchart LR
  subgraph surfaces["surfaces"]
    MCP["mcp-server"]
    CRON["scheduled-cron"]
    ING["connector-ingress"]
  end
  subgraph assistant["assistant"]
    WF["workflows"]
    CAP["capability-registry"]
    RC["remote-connectors"]
  end
  subgraph runtime["runtime"]
    PR["package-runtime"]
  end
  Sentry[(Sentry)]

  CAP -->|storageId on logMcpEvent| MCP
  MCP -->|mcp context + detail| Sentry
  WF -->|user + workflow context| Sentry
  PR -.->|helper| WF
  CRON -->|scheduled.lane tag| Sentry
  ING --> RC
  RC -->|remote_connector.id + socket user| Sentry

  style WF fill:#f5c542,stroke:#333,color:#000
  style CRON fill:#f5c542,stroke:#333,color:#000
  style MCP fill:#f5c542,stroke:#333,color:#000
  style RC fill:#f5c542,stroke:#333,color:#000
  style ING fill:#f5c542,stroke:#333,color:#000
  style CAP fill:#8fd19e,stroke:#333,color:#000
  style PR fill:#8fd19e,stroke:#333,color:#000
  style Sentry fill:#c8c8c8,stroke:#333,color:#000
```

### Risk and invariants

- Medium risk: changes only what is reported to Sentry; no user-facing control flow changes.
- Per-user isolation: only stable `user.id` is set (no email/PII); `sendDefaultPii` remains false.
- High-cardinality ids (`conversationId`, `storageId`, workflow instance ids) stay on contexts, not tags.

### Docs

No docs updates — contributor-facing observability detail only.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1296b83-c0ea-49da-a305-3e8c6c2640e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1296b83-c0ea-49da-a305-3e8c6c2640e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Observability**
  - Improved monitoring for scheduled task lane failures with richer Sentry scope context.
  - Enhanced MCP activity reporting with added conversation/storage identifiers and more structured diagnostic details.
  - Improved remote connector session message reporting with clearer scope tags/levels and connector context.
  - Added dynamic Sentry scoping for workflow executions (packaged vs inline) with workflow metadata.
  - Monitoring instrumentation is guarded so it won’t disrupt execution.

- **Bug Fixes**
  - Better coverage and validation for scheduled lane failure isolation while keeping sibling lanes running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->