### PR TITLE
Stripe webhooks, deeper billing UX, and email delivery alerts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,7 @@ jobs:
           X_CLIENT_SECRET: ${{ secrets.OAUTH_X_CLIENT_SECRET }}
           KIT_API_KEY: ${{ secrets.KIT_API_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
         run: >
           node tools/ci/sync-worker-secrets.ts --env production --config
           "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET
@@ -140,7 +141,8 @@ jobs:
           GOOGLE_CLIENT_ID --set-from-env-optional GOOGLE_CLIENT_SECRET
           --set-from-env-optional X_CLIENT_ID --set-from-env-optional
           X_CLIENT_SECRET --set-from-env-optional KIT_API_KEY
-          --set-from-env-optional STRIPE_SECRET_KEY
+          --set-from-env-optional STRIPE_SECRET_KEY --set-from-env-optional
+          STRIPE_WEBHOOK_SECRET
 
       - name: 🗄️ Apply D1 Migrations
         env:

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -871,6 +871,9 @@ Current retention policies:
   any remaining rows.
 - `audit_events`: global hashed auth/security audit events keep 180 days. They
   are not user-owned D1 rows and remain independent of account deletion/export.
+- `stripe_webhook_events`: platform Stripe webhook idempotency rows keep 30 days
+  by `processed_at`. They are not user-owned and remain independent of account
+  deletion/export.
 
 Migration `0055-retention-indexes.sql` adds the global time-column indexes these
 prunes order by (`created_at` / `day` / `month` / `started_at` across users);

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -343,16 +343,44 @@ manual plans only.
 
 Checkout sessions are created server-side for authenticated users via
 `POST /account/billing/checkout.json` (Stripe Checkout Session,
-`mode=subscription`, with a signed `client_reference_id`). Public Payment Links
-were removed after a card-testing incident so checkout is not reachable without
-a signed-in session. `GET /account/billing/success` verifies
-`client_reference_id` before linking `users.stripe_customer_id`, then refreshes
-`users.stripe_plan`. `GET /account/billing/portal` opens the Stripe customer
-portal for linked customers.
+`mode=subscription`, with a signed `client_reference_id` and
+`metadata.kody_stable_user_id`). Public Payment Links were removed after a
+card-testing incident so checkout is not reachable without a signed-in session.
+`GET /account/billing/success` verifies `client_reference_id` before linking
+`users.stripe_customer_id`, then refreshes `users.stripe_plan`.
+`GET /account/billing/portal` opens the Stripe customer portal for linked
+customers.
 
-`users.stripe_plan` stays fresh via an hourly cron lane
+### Webhooks (primary sync)
+
+`POST /webhooks/stripe` is the primary path for linking customers and refreshing
+plans when Stripe subscription state changes. It is unauthenticated and verifies
+the `Stripe-Signature` header with `STRIPE_WEBHOOK_SECRET` (HMAC-SHA256 over
+`${t}.${rawBody}`; ~300s timestamp tolerance). When the secret is unset, the
+endpoint returns 503.
+
+Handled event types:
+
+- `checkout.session.completed` — resolve the user via `client_reference_id`
+  matching `createBillingLinkReference` (candidates from
+  `metadata.kody_stable_user_id`, existing `stripe_customer_id`, or customer
+  email), then run the same link+refresh helper as the success redirect
+- `customer.subscription.updated` / `customer.subscription.deleted` — look up
+  the user by `users.stripe_customer_id` and call `refreshStripePlanForUser`
+- `invoice.payment_failed` — same customer lookup + refresh (surfaces
+  `subscriptionStatus` such as `past_due` for UX; does not email users)
+- Unknown event types — acknowledge `200` after recording the event id
+
+Idempotency uses migration `0093-stripe-webhook-events.sql`
+(`stripe_webhook_events.event_id` unique). Duplicate deliveries return `200`
+without re-running side effects.
+
+### Poll backup
+
+`users.stripe_plan` also stays fresh via an hourly cron lane
 (`refreshStaleStripePlans`: 25 users/sweep, 1h staleness) and an on-page refresh
-when `/account/billing` loads with data older than 60s. Migration
+when `/account/billing` loads with data older than 60s. Keep the poll as a
+backup if a webhook is missed or the success URL is never hit. Migration
 `0066-stripe-billing.sql` adds `stripe_customer_id` (unique partial index),
 `stripe_plan`, and `stripe_plan_refreshed_at`.
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -379,8 +379,9 @@ without re-running side effects.
 
 `users.stripe_plan` also stays fresh via an hourly cron lane
 (`refreshStaleStripePlans`: 25 users/sweep, 1h staleness) and an on-page refresh
-when `/account/billing` loads with data older than 60s. Keep the poll as a
-backup if a webhook is missed or the success URL is never hit. Migration
+every time `/account/billing` loads (always calls Stripe so non-persisted
+`cancel_at` / `subscriptionStatus` stay current). Keep the poll as a backup if a
+webhook is missed or the success URL is never hit. Migration
 `0066-stripe-billing.sql` adds `stripe_customer_id` (unique partial index),
 `stripe_plan`, and `stripe_plan_refreshed_at`.
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -369,11 +369,13 @@ Handled event types:
   the user by `users.stripe_customer_id` and call `refreshStripePlanForUser`
 - `invoice.payment_failed` — same customer lookup + refresh (surfaces
   `subscriptionStatus` such as `past_due` for UX; does not email users)
-- Unknown event types — acknowledge `200` after recording the event id
+- Unknown event types — acknowledge `200` after process+record
 
 Idempotency uses migration `0093-stripe-webhook-events.sql`
-(`stripe_webhook_events.event_id` unique). Duplicate deliveries return `200`
-without re-running side effects.
+(`stripe_webhook_events.event_id` unique). Events are processed first (handlers
+are idempotent), then recorded. A UNIQUE conflict after a successful process is
+treated as duplicate success (`200`). Process failures return `500` without
+inserting so Stripe can retry. Rows older than 30 days are pruned by retention.
 
 ### Poll backup
 

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -143,10 +143,11 @@ primitives:
     group: auth
     name: Stripe billing
     summary:
-      Authenticated Checkout Session creation, customer linking, and
-      subscription→plan sync.
+      Authenticated Checkout Session creation, Stripe webhooks, customer
+      linking, and subscription→plan sync (cron poll as backup).
     code:
       - packages/worker/src/billing/
+      - packages/worker/src/app/handlers/stripe-webhook.ts
     docs:
       - docs/contributing/architecture/entitlements.md
 

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -73,6 +73,7 @@ primitives:
       - packages/worker/src/repo/repo-session-cleanup.ts
       - packages/worker/src/app/retention.ts
       - packages/worker/src/app/auth-denial-alerts.ts
+      - packages/worker/src/app/email-delivery-alerts.ts
       - packages/worker/src/usage/aggregate-rollups.ts
     docs:
       - docs/contributing/architecture/data-storage.md

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -123,6 +123,10 @@ safely. Manual `users.plan` grants and invite-assigned plans still work.
 - `STRIPE_SECRET_KEY` — Stripe secret API key. Required for checkout linking,
   portal sessions, and `stripe_plan` refresh. Synced as a Worker secret from the
   GitHub Actions secret of the same name on production deploy when set.
+- `STRIPE_WEBHOOK_SECRET` — Stripe endpoint signing secret (`whsec_...`) for
+  `POST /webhooks/stripe`. When unset, the webhook endpoint returns 503. Synced
+  as a Worker secret from the GitHub Actions secret of the same name on
+  production deploy when set.
 - `STRIPE_API_BASE_URL` — optional API base URL; defaults to
   `https://api.stripe.com` when unset. Override for tests/mocks.
 - `STRIPE_PRO_PRICE_ID` — Stripe Price id used to map active/trialing

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -142,8 +142,8 @@ cooldown prevents re-paging on the same sustained spike. Charts on
 A second hourly lane (`email_delivery_alert`, implemented by
 `checkEmailDeliveryBurstAndNotify` in
 `packages/worker/src/app/email-delivery-alerts.ts`) pages admins when
-platform-wide Cloudflare Email Sending outcomes of `complained` or `bounced`
-in the last 60 minutes cross a threshold (default 20). Those match the
+platform-wide Cloudflare Email Sending outcomes of `complained` or `bounced` in
+the last 60 minutes cross a threshold (default 20). Those match the
 outbound-abuse reputation signals (`failed` / `rejected` are not counted).
 Cooldown is 6 hours via `BUNDLE_ARTIFACTS_KV`. This complements the per-user
 outbound pause in `outbound-abuse.ts` — that path stops one account; the cron

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -142,8 +142,9 @@ cooldown prevents re-paging on the same sustained spike. Charts on
 A second hourly lane (`email_delivery_alert`, implemented by
 `checkEmailDeliveryBurstAndNotify` in
 `packages/worker/src/app/email-delivery-alerts.ts`) pages admins when
-platform-wide Cloudflare Email Sending outcomes of `complained`, `bounced`,
-`failed`, or `rejected` in the last 60 minutes cross a threshold (default 20).
+platform-wide Cloudflare Email Sending outcomes of `complained` or `bounced`
+in the last 60 minutes cross a threshold (default 20). Those match the
+outbound-abuse reputation signals (`failed` / `rejected` are not counted).
 Cooldown is 6 hours via `BUNDLE_ARTIFACTS_KV`. This complements the per-user
 outbound pause in `outbound-abuse.ts` — that path stops one account; the cron
 pages when the shared sending domain is under platform-wide pressure. Review the

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -139,6 +139,16 @@ MCP auth denials in the last 60 minutes cross a threshold (default 50). A KV
 cooldown prevents re-paging on the same sustained spike. Charts on
 `/admin/insights` remain the browse surface; the email is the page.
 
+A second hourly lane (`email_delivery_alert`, implemented by
+`checkEmailDeliveryBurstAndNotify` in
+`packages/worker/src/app/email-delivery-alerts.ts`) pages admins when
+platform-wide Cloudflare Email Sending outcomes of `complained`, `bounced`,
+`failed`, or `rejected` in the last 60 minutes cross a threshold (default 20).
+Cooldown is 6 hours via `BUNDLE_ARTIFACTS_KV`. This complements the per-user
+outbound pause in `outbound-abuse.ts` — that path stops one account; the cron
+pages when the shared sending domain is under platform-wide pressure. Review the
+Email delivery health chart on `/admin/insights`.
+
 **Deliberately not recorded:** rejections that happen before a grant resolves —
 a missing, empty, or unparseable bearer token. Those are reachable by any
 anonymous request, so auditing them would let a stranger drive unbounded D1
@@ -211,7 +221,9 @@ blast radius:
   is idempotent (only transitions NULL), the send path rejects while paused, and
   the audited `resume_email_outbound` admin action clears it after review. The
   `/admin/insights` "Email delivery health" chart shows platform-wide outcome
-  trends so reputation trouble is visible before providers act on it.
+  trends so reputation trouble is visible before providers act on it. The hourly
+  `email_delivery_alert` cron pages admins on a platform-wide burst (see above)
+  without replacing this per-user pause.
 - **Compute quotas.** `execute_calls_per_day` and `outbound_fetches_per_day`
   entitlements bound sandbox compute and egress volume per user per day (see
   [`architecture/entitlements.md`](./architecture/entitlements.md)).

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -232,6 +232,8 @@ automatically:
 - `STRIPE_SECRET_KEY` (optional Worker secret; enables Stripe checkout linking,
   billing portal, and `users.stripe_plan` refresh. When unset, billing degrades
   to manual plans.)
+- `STRIPE_WEBHOOK_SECRET` (optional Worker secret; Stripe webhook signing secret
+  for `POST /webhooks/stripe`. When unset, the webhook endpoint returns 503.)
 - `STRIPE_API_BASE_URL` (optional; defaults to `https://api.stripe.com`.
   Override for tests/mocks.)
 - `STRIPE_PRO_PRICE_ID` (optional Worker var; Stripe Price id mapped to the
@@ -302,6 +304,9 @@ Configure these GitHub Actions secrets and variables for workflows:
   for account billing. Production deploy syncs it when set. The Pro price id is
   a Worker var committed in `packages/worker/wrangler.jsonc`, not a GitHub
   secret.)
+- `STRIPE_WEBHOOK_SECRET` (optional GitHub / Worker secret; Stripe endpoint
+  signing secret (`whsec_...`) for platform billing webhooks at
+  `POST /webhooks/stripe`. Production deploy syncs it when set.)
 - `SENTRY_AUTH_TOKEN` (optional GitHub **secret**; Sentry auth token with
   `project:releases` / source map upload permissions — used only by CI to run
   `npm run sentry:upload-sourcemaps` after deploy)

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -82,6 +82,9 @@ X_CLIENT_SECRET=MOCK_X_CLIENT_SECRET
 # "Billing is not configured" notice, and success/portal/cron skip safely.
 # Checkout sessions are created server-side for authenticated users.
 # STRIPE_SECRET_KEY=sk_test_...
+# Platform webhook signing secret for POST /webhooks/stripe (whsec_...).
+# When unset, the webhook endpoint returns 503.
+# STRIPE_WEBHOOK_SECRET=whsec_...
 # STRIPE_API_BASE_URL=https://api.stripe.com
 # STRIPE_PRO_PRICE_ID=price_...
 

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -481,20 +481,14 @@ export function AccountBillingRoute(handle: Handle) {
 								{showManageCta ? (
 									<a
 										href={billingPortalPath}
-										mix={[
-											on('click', (event) => {
-												event.preventDefault()
-												window.location.assign(billingPortalPath)
-											}),
-											css({
-												...(statusInfo?.tone === 'action'
-													? primaryButtonCss
-													: secondaryButtonCss),
-												display: 'inline-block',
-												textDecoration: 'none',
-												textAlign: 'center',
-											}),
-										]}
+										mix={css({
+											...(statusInfo?.tone === 'action'
+												? primaryButtonCss
+												: secondaryButtonCss),
+											display: 'inline-block',
+											textDecoration: 'none',
+											textAlign: 'center',
+										})}
 									>
 										Manage subscription
 									</a>

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -40,9 +40,11 @@ import {
 const billingApiPath = '/account/billing.json'
 const billingCheckoutApiPath = '/account/billing/checkout.json'
 const billingPath = '/account/billing'
+const billingPortalPath = '/account/billing/portal'
 
 type PaidTier = 'pro'
 type PlanTier = 'free' | PaidTier
+type SubscriptionStatusTone = 'ok' | 'warn' | 'action' | 'muted'
 
 const planTiers: Array<{
 	id: PlanTier
@@ -104,6 +106,99 @@ function formatCancelDate(value: string) {
 
 function planCoversTier(effectivePlan: AdminPlanName, tier: PlanTier): boolean {
 	return getPlanRank(effectivePlan) >= getPlanRank(tier)
+}
+
+function describeSubscriptionStatus(status: string): {
+	label: string
+	detail: string
+	tone: SubscriptionStatusTone
+} {
+	switch (status) {
+		case 'active':
+			return {
+				label: 'Active',
+				detail: 'Your Stripe subscription is active.',
+				tone: 'ok',
+			}
+		case 'trialing':
+			return {
+				label: 'Trialing',
+				detail: 'You are on a Stripe trial.',
+				tone: 'ok',
+			}
+		case 'past_due':
+			return {
+				label: 'Past due',
+				detail:
+					'Payment is past due. Update your payment method in Manage subscription to keep paid access.',
+				tone: 'action',
+			}
+		case 'unpaid':
+			return {
+				label: 'Unpaid',
+				detail:
+					'Stripe reports this subscription as unpaid. Open Manage subscription to update billing.',
+				tone: 'action',
+			}
+		case 'canceled':
+			return {
+				label: 'Canceled',
+				detail: 'This Stripe subscription is canceled.',
+				tone: 'muted',
+			}
+		case 'incomplete':
+			return {
+				label: 'Incomplete',
+				detail:
+					'Checkout did not finish. Subscribe again or open Manage subscription if a customer already exists.',
+				tone: 'warn',
+			}
+		case 'incomplete_expired':
+			return {
+				label: 'Incomplete (expired)',
+				detail:
+					'An incomplete checkout expired. Subscribe again to start billing.',
+				tone: 'muted',
+			}
+		case 'paused':
+			return {
+				label: 'Paused',
+				detail: 'This Stripe subscription is paused.',
+				tone: 'warn',
+			}
+		default:
+			return {
+				label: status.replaceAll('_', ' '),
+				detail: `Stripe subscription status: ${status}.`,
+				tone: 'muted',
+			}
+	}
+}
+
+function subscriptionStatusBadgeCss(tone: SubscriptionStatusTone) {
+	const accent =
+		tone === 'action'
+			? colors.error
+			: tone === 'warn'
+				? colors.primaryText
+				: tone === 'ok'
+					? colors.primary
+					: colors.textMuted
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		padding: `0.2rem ${spacing.sm}`,
+		borderRadius: radius.md,
+		border: `1px solid ${accent}`,
+		backgroundColor:
+			tone === 'action'
+				? 'color-mix(in srgb, var(--color-danger) 10%, var(--color-surface))'
+				: colors.surface,
+		color: accent,
+		fontSize: typography.fontSize.xs,
+		fontWeight: typography.fontWeight.semibold,
+		textTransform: 'capitalize' as const,
+	}
 }
 
 export async function accountBillingRouteLoader(
@@ -238,6 +333,21 @@ export function AccountBillingRoute(handle: Handle) {
 		}
 
 		const billing = status === 'ready' ? data : null
+		const subscriptionStatus = billing?.subscriptionStatus?.trim() || null
+		const statusInfo = subscriptionStatus
+			? describeSubscriptionStatus(subscriptionStatus)
+			: null
+		const paymentActionNeeded =
+			subscriptionStatus === 'past_due' || subscriptionStatus === 'unpaid'
+		const showSubscribeCta = Boolean(
+			billing?.checkoutAvailable &&
+			billing &&
+			!planCoversTier(billing.effectivePlan, 'pro') &&
+			!paymentActionNeeded,
+		)
+		const showManageCta = Boolean(
+			billing?.configured && billing.hasStripeCustomer,
+		)
 		const currentPlanItems =
 			billing && billing.manualPlan !== billing.stripePlan
 				? [
@@ -279,21 +389,55 @@ export function AccountBillingRoute(handle: Handle) {
 								granted by an administrator.
 							</AccountManagementMessage>
 						) : null}
+						{billing.configured && !billing.hasStripeCustomer ? (
+							<AccountManagementMessage tone="info">
+								No Stripe customer is linked yet. Subscribe to Pro to create one
+								and manage billing in Stripe.
+							</AccountManagementMessage>
+						) : null}
+						{billing.configured && billing.hasStripeCustomer ? (
+							<p mix={css(descriptionCss)}>
+								Stripe customer linked. Use Manage subscription for payment
+								methods, invoices, and cancellation.
+							</p>
+						) : null}
+						{statusInfo?.tone === 'action' ? (
+							<AccountManagementMessage tone="error">
+								{statusInfo.detail}
+							</AccountManagementMessage>
+						) : null}
 
 						<AccountManagementPanel
 							title="Current plan"
 							description="Your effective plan is the higher of any admin grant and your Stripe subscription."
 						>
-							<p
+							<div
 								mix={css({
-									margin: 0,
-									fontSize: typography.fontSize.lg,
-									fontWeight: typography.fontWeight.semibold,
-									color: colors.text,
+									display: 'flex',
+									flexWrap: 'wrap',
+									alignItems: 'center',
+									gap: spacing.sm,
 								})}
 							>
-								{formatPlanLabel(billing.effectivePlan, 'Free')}
-							</p>
+								<p
+									mix={css({
+										margin: 0,
+										fontSize: typography.fontSize.lg,
+										fontWeight: typography.fontWeight.semibold,
+										color: colors.text,
+									})}
+								>
+									{formatPlanLabel(billing.effectivePlan, 'Free')}
+								</p>
+								{statusInfo ? (
+									<span mix={css(subscriptionStatusBadgeCss(statusInfo.tone))}>
+										{statusInfo.label}
+									</span>
+								) : null}
+							</div>
+							{statusInfo && statusInfo.tone !== 'action' ? (
+								<p mix={css(descriptionCss)}>{statusInfo.detail}</p>
+							) : null}
 							{currentPlanItems.length > 0 ? (
 								<MetadataGrid items={currentPlanItems} />
 							) : null}
@@ -303,6 +447,70 @@ export function AccountBillingRoute(handle: Handle) {
 									{formatCancelDate(billing.cancelAt)}.
 								</p>
 							) : null}
+							<p mix={css(descriptionCss)}>
+								Upgrades and payment changes apply after Stripe confirms them
+								(usually within a few seconds via webhooks). Refresh this page
+								if the plan looks stale.
+							</p>
+						</AccountManagementPanel>
+
+						<AccountManagementPanel
+							title="Actions"
+							description="Subscribe, open the Stripe portal, or check entitlement use."
+						>
+							<div
+								mix={css({
+									display: 'flex',
+									flexWrap: 'wrap',
+									gap: spacing.sm,
+									alignItems: 'center',
+								})}
+							>
+								{showSubscribeCta ? (
+									<button
+										type="button"
+										disabled={checkoutPending}
+										mix={[
+											on('click', () => void startCheckout()),
+											css(primaryButtonCss),
+										]}
+									>
+										{checkoutPending ? 'Starting checkout…' : 'Subscribe'}
+									</button>
+								) : null}
+								{showManageCta ? (
+									<a
+										href={billingPortalPath}
+										mix={[
+											on('click', (event) => {
+												event.preventDefault()
+												window.location.assign(billingPortalPath)
+											}),
+											css({
+												...(statusInfo?.tone === 'action'
+													? primaryButtonCss
+													: secondaryButtonCss),
+												display: 'inline-block',
+												textDecoration: 'none',
+												textAlign: 'center',
+											}),
+										]}
+									>
+										Manage subscription
+									</a>
+								) : null}
+								<a
+									href={billing.usageHref}
+									mix={css({
+										...secondaryButtonCss,
+										display: 'inline-block',
+										textDecoration: 'none',
+										textAlign: 'center',
+									})}
+								>
+									View usage
+								</a>
+							</div>
 						</AccountManagementPanel>
 
 						<AccountManagementPanel
@@ -327,7 +535,8 @@ export function AccountBillingRoute(handle: Handle) {
 										tier.id !== 'free' &&
 										!isCurrent &&
 										!isIncluded &&
-										billing.checkoutAvailable
+										billing.checkoutAvailable &&
+										!paymentActionNeeded
 
 									return (
 										<div
@@ -394,36 +603,6 @@ export function AccountBillingRoute(handle: Handle) {
 								})}
 							</div>
 						</AccountManagementPanel>
-
-						{billing.hasStripeCustomer && billing.configured ? (
-							<AccountManagementPanel
-								title="Manage subscription"
-								description="Open the Stripe billing portal to cancel, upgrade, update payment methods, or download invoices."
-							>
-								<div>
-									{/* Server-only redirect route: bypass the SPA router with a
-									    full-page navigation, matching the app's established
-									    window.location.assign pattern. */}
-									<a
-										href="/account/billing/portal"
-										mix={[
-											on('click', (event) => {
-												event.preventDefault()
-												window.location.assign('/account/billing/portal')
-											}),
-											css({
-												...secondaryButtonCss,
-												display: 'inline-block',
-												textDecoration: 'none',
-												textAlign: 'center',
-											}),
-										]}
-									>
-										Manage subscription
-									</a>
-								</div>
-							</AccountManagementPanel>
-						) : null}
 					</>
 				) : null}
 

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -130,14 +130,14 @@ function describeSubscriptionStatus(status: string): {
 			return {
 				label: 'Past due',
 				detail:
-					'Payment is past due. Update your payment method in Manage subscription to keep paid access.',
+					'Payment is past due, so paid plan limits are not active. Update your payment method in Manage subscription to restore Pro.',
 				tone: 'action',
 			}
 		case 'unpaid':
 			return {
 				label: 'Unpaid',
 				detail:
-					'Stripe reports this subscription as unpaid. Open Manage subscription to update billing.',
+					'Stripe reports this subscription as unpaid, so paid plan limits are not active. Open Manage subscription to restore billing.',
 				tone: 'action',
 			}
 		case 'canceled':

--- a/packages/worker/migrations/0093-stripe-webhook-events.sql
+++ b/packages/worker/migrations/0093-stripe-webhook-events.sql
@@ -1,0 +1,11 @@
+-- Idempotency ledger for Stripe platform-billing webhook deliveries.
+-- Stores processed Stripe event ids so redeliveries are acknowledged without
+-- re-running link/refresh side effects.
+CREATE TABLE IF NOT EXISTS stripe_webhook_events (
+	event_id TEXT PRIMARY KEY NOT NULL,
+	event_type TEXT NOT NULL,
+	processed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_processed_at
+ON stripe_webhook_events(processed_at);

--- a/packages/worker/src/app/account-billing-data.node.test.ts
+++ b/packages/worker/src/app/account-billing-data.node.test.ts
@@ -1,0 +1,148 @@
+import { expect, test, vi } from 'vitest'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+
+const refreshStripePlanForUser = vi.hoisted(() =>
+	vi.fn(async () => ({
+		stripePlan: 'pro' as const,
+		cancelAt: null as string | null,
+		subscriptionStatus: 'active' as string | null,
+	})),
+)
+
+vi.mock('#worker/billing/subscription-sync.ts', () => ({
+	refreshStripePlanForUser,
+}))
+
+import {
+	loadAccountBillingData,
+	resolveBillingErrorMessage,
+} from '#app/account-billing-data.ts'
+
+function createBillingTestDb(input: {
+	plan: string
+	stripePlan?: string | null
+	stripeCustomerId?: string | null
+}) {
+	return {
+		prepare(query: string) {
+			const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async first<T>() {
+							if (
+								normalized.includes('from users') &&
+								normalized.includes('where id')
+							) {
+								void params
+								return {
+									plan: input.plan,
+									stripe_plan: input.stripePlan ?? null,
+									stripe_customer_id: input.stripeCustomerId ?? null,
+									stripe_plan_refreshed_at: null,
+								} as T
+							}
+							return null
+						},
+						async run() {
+							return { success: true }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+test('resolveBillingErrorMessage maps known codes and passes through unknown', () => {
+	expect(resolveBillingErrorMessage('no_customer')).toContain('Subscribe first')
+	expect(resolveBillingErrorMessage('totally_new_code')).toBe(
+		'totally_new_code',
+	)
+	expect(resolveBillingErrorMessage(null)).toBeUndefined()
+})
+
+test('loadAccountBillingData passes subscriptionStatus from Stripe refresh', async () => {
+	refreshStripePlanForUser.mockResolvedValueOnce({
+		stripePlan: 'pro',
+		cancelAt: '2026-08-01T00:00:00.000Z',
+		subscriptionStatus: 'past_due',
+	})
+
+	const env = {
+		APP_DB: createBillingTestDb({
+			plan: 'free',
+			stripePlan: 'pro',
+			stripeCustomerId: 'cus_test',
+		}),
+		STRIPE_SECRET_KEY: 'sk_test',
+		STRIPE_PRO_PRICE_ID: 'price_pro',
+	} as Env
+
+	const data = await loadAccountBillingData({
+		env,
+		userId: 9,
+		now: new Date('2026-07-25T12:00:00.000Z'),
+	})
+
+	expect(data.ok).toBe(true)
+	expect(data.configured).toBe(true)
+	expect(data.hasStripeCustomer).toBe(true)
+	expect(data.stripePlan).toBe('pro')
+	expect(data.effectivePlan).toBe('pro')
+	expect(data.subscriptionStatus).toBe('past_due')
+	expect(data.cancelAt).toBe('2026-08-01T00:00:00.000Z')
+	expect(data.usageHref).toBe('/account/usage')
+	expect(data.checkoutAvailable).toBe(true)
+	expect(refreshStripePlanForUser).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 9,
+			customerId: 'cus_test',
+		}),
+	)
+})
+
+test('loadAccountBillingData leaves subscriptionStatus null when refresh fails', async () => {
+	consoleError.mockImplementation(() => {})
+	refreshStripePlanForUser.mockRejectedValueOnce(new Error('stripe down'))
+
+	const env = {
+		APP_DB: createBillingTestDb({
+			plan: 'free',
+			stripePlan: 'pro',
+			stripeCustomerId: 'cus_test',
+		}),
+		STRIPE_SECRET_KEY: 'sk_test',
+		STRIPE_PRO_PRICE_ID: 'price_pro',
+	} as Env
+
+	const data = await loadAccountBillingData({ env, userId: 3 })
+	expect(data.stripePlan).toBe('pro')
+	expect(data.subscriptionStatus).toBeNull()
+	expect(data.cancelAt).toBeNull()
+	expect(data.usageHref).toBe('/account/usage')
+	expect(consoleError).toHaveBeenCalledWith(
+		'account_billing_refresh_failed',
+		expect.objectContaining({ userId: 3, error: 'stripe down' }),
+	)
+})
+
+test('loadAccountBillingData skips refresh when there is no Stripe customer', async () => {
+	refreshStripePlanForUser.mockClear()
+
+	const env = {
+		APP_DB: createBillingTestDb({
+			plan: 'free',
+			stripePlan: null,
+			stripeCustomerId: null,
+		}),
+		STRIPE_SECRET_KEY: 'sk_test',
+		STRIPE_PRO_PRICE_ID: 'price_pro',
+	} as Env
+
+	const data = await loadAccountBillingData({ env, userId: 4 })
+	expect(data.hasStripeCustomer).toBe(false)
+	expect(data.subscriptionStatus).toBeNull()
+	expect(data.configured).toBe(true)
+	expect(refreshStripePlanForUser).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/app/account-billing-data.ts
+++ b/packages/worker/src/app/account-billing-data.ts
@@ -64,14 +64,16 @@ export async function loadAccountBillingData(input: {
 	const manualPlan: PlanName = row ? parseStoredPlanName(row.plan) : 'max'
 	let stripePlan: PlanName | null = parseStripePlanName(row?.stripe_plan)
 	let cancelAt: string | null = null
+	let subscriptionStatus: string | null = null
 	const customerId = row?.stripe_customer_id?.trim() || null
 	const hasStripeCustomer = Boolean(customerId)
 
 	if (configured && customerId) {
-		// Always refresh on page view: cancel_at is not persisted, so serving
-		// the stored stripe_plan would hide a scheduled cancellation. Billing
-		// page loads are rare enough that one Stripe call per view is fine;
-		// failures fall back to the stored plan.
+		// Always refresh on page view: cancel_at and subscriptionStatus are not
+		// persisted, so serving the stored stripe_plan would hide a scheduled
+		// cancellation or past_due state. Billing page loads are rare enough
+		// that one Stripe call per view is fine; failures fall back to the
+		// stored plan with null status.
 		try {
 			const refreshed = await refreshStripePlanForUser({
 				env: input.env,
@@ -81,6 +83,7 @@ export async function loadAccountBillingData(input: {
 			})
 			stripePlan = refreshed.stripePlan
 			cancelAt = refreshed.cancelAt
+			subscriptionStatus = refreshed.subscriptionStatus
 		} catch (refreshError) {
 			console.error('account_billing_refresh_failed', {
 				userId: input.userId,
@@ -102,7 +105,9 @@ export async function loadAccountBillingData(input: {
 		effectivePlan: resolveEffectivePlan(manualPlan, stripePlan),
 		hasStripeCustomer,
 		cancelAt,
+		subscriptionStatus,
 		checkoutAvailable,
+		usageHref: '/account/usage',
 		...(error ? { error } : {}),
 	}
 }

--- a/packages/worker/src/app/account-retention-dispositions.ts
+++ b/packages/worker/src/app/account-retention-dispositions.ts
@@ -22,6 +22,7 @@ export const accountRetentionDispositions: ReadonlyArray<AccountRetentionDisposi
 		{ table: 'entitlement_daily_counters', kind: 'scheduled_policy' },
 		{ table: 'usage_rollups', kind: 'scheduled_policy' },
 		{ table: 'audit_events', kind: 'scheduled_policy' },
+		{ table: 'stripe_webhook_events', kind: 'scheduled_policy' },
 		{
 			table: 'archived_job_artifacts',
 			kind: 'alternate_cleanup',

--- a/packages/worker/src/app/email-delivery-alerts.node.test.ts
+++ b/packages/worker/src/app/email-delivery-alerts.node.test.ts
@@ -1,0 +1,153 @@
+import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+
+const sendCloudflareEmail = vi.fn(async () => ({ ok: true }))
+
+vi.mock('#app/email/cloudflare-email.ts', () => ({
+	sendCloudflareEmail: (...args: Array<unknown>) =>
+		sendCloudflareEmail(...args),
+}))
+
+const {
+	emailDeliveryAlertKvKey,
+	checkEmailDeliveryBurstAndNotify,
+	shouldRunEmailDeliveryAlertCron,
+} = await import('#app/email-delivery-alerts.ts')
+
+function createDb(count: number) {
+	return {
+		prepare(query: string) {
+			const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+			return {
+				bind(..._params: Array<unknown>) {
+					return this
+				},
+				async first<T>() {
+					if (normalized.includes('from email_delivery_events')) {
+						return { count } as T
+					}
+					return null
+				},
+				async all<T>() {
+					if (normalized.includes('from users u')) {
+						return {
+							results: [{ email: 'admin@example.com' }],
+						} as { results: Array<T> }
+					}
+					return { results: [] }
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+test('shouldRunEmailDeliveryAlertCron runs on the hour', () => {
+	expect(
+		shouldRunEmailDeliveryAlertCron(new Date('2026-07-25T12:00:00.000Z')),
+	).toBe(true)
+	expect(
+		shouldRunEmailDeliveryAlertCron(new Date('2026-07-25T12:05:00.000Z')),
+	).toBe(false)
+})
+
+test('checkEmailDeliveryBurstAndNotify stays quiet below threshold', async () => {
+	sendCloudflareEmail.mockClear()
+	const result = await checkEmailDeliveryBurstAndNotify({
+		env: {
+			APP_DB: createDb(10),
+			APP_BASE_URL: 'https://heykody.dev',
+			CLOUDFLARE_ACCOUNT_ID: 'acct',
+			CLOUDFLARE_API_TOKEN: 'token',
+		},
+		threshold: 20,
+	})
+	expect(result).toEqual({ status: 'below_threshold', count: 10 })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+})
+
+test('checkEmailDeliveryBurstAndNotify emails admins and respects cooldown', async () => {
+	sendCloudflareEmail.mockClear()
+	consoleWarn.mockImplementation(() => {})
+	const kvStore = new Map<string, string>()
+	const kv = {
+		async get(key: string) {
+			return kvStore.get(key) ?? null
+		},
+		async put(key: string, value: string) {
+			kvStore.set(key, value)
+		},
+	} as unknown as KVNamespace
+
+	const env = {
+		APP_DB: createDb(35),
+		APP_BASE_URL: 'https://heykody.dev',
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token',
+		BUNDLE_ARTIFACTS_KV: kv,
+	}
+	const now = new Date('2026-07-25T12:00:00.000Z')
+	try {
+		const first = await checkEmailDeliveryBurstAndNotify({
+			env,
+			now,
+			threshold: 20,
+		})
+		expect(first).toEqual({ status: 'notified', count: 35, recipients: 1 })
+		expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+		expect(kvStore.get(emailDeliveryAlertKvKey)).toBe(String(now.getTime()))
+		expect(consoleWarn).toHaveBeenCalledWith(
+			'email-delivery-burst-alerted',
+			expect.objectContaining({ count: 35 }),
+		)
+
+		const second = await checkEmailDeliveryBurstAndNotify({
+			env,
+			now: new Date(now.getTime() + 60_000),
+			threshold: 20,
+		})
+		expect(second).toEqual({ status: 'cooldown', count: 35 })
+		expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+	} finally {
+		consoleWarn.mockReset()
+	}
+})
+
+test('checkEmailDeliveryBurstAndNotify does not write cooldown when notify fails', async () => {
+	sendCloudflareEmail.mockClear()
+	sendCloudflareEmail.mockRejectedValueOnce(new Error('cf email down'))
+	consoleWarn.mockImplementation(() => {})
+	const kvStore = new Map<string, string>()
+	const kv = {
+		async get(key: string) {
+			return kvStore.get(key) ?? null
+		},
+		async put(key: string, value: string) {
+			kvStore.set(key, value)
+		},
+	} as unknown as KVNamespace
+
+	const env = {
+		APP_DB: createDb(35),
+		APP_BASE_URL: 'https://heykody.dev',
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token',
+		BUNDLE_ARTIFACTS_KV: kv,
+	}
+	try {
+		await expect(
+			checkEmailDeliveryBurstAndNotify({
+				env,
+				now: new Date('2026-07-25T12:00:00.000Z'),
+				threshold: 20,
+			}),
+		).rejects.toThrow('cf email down')
+		expect(kvStore.has(emailDeliveryAlertKvKey)).toBe(false)
+		expect(consoleWarn).toHaveBeenCalledWith(
+			'email-delivery-alert-notification-failed',
+			expect.any(Error),
+		)
+	} finally {
+		consoleWarn.mockReset()
+		sendCloudflareEmail.mockResolvedValue({ ok: true })
+	}
+})

--- a/packages/worker/src/app/email-delivery-alerts.ts
+++ b/packages/worker/src/app/email-delivery-alerts.ts
@@ -2,8 +2,8 @@ import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
 
 /**
- * Hourly platform-wide email delivery reputation burst check. Bad outcomes
- * (`complained`, `bounced`, `failed`, `rejected`) are already recorded in
+ * Hourly platform-wide email delivery reputation burst check. Reputation
+ * outcomes (`complained`, `bounced`) are already recorded in
  * `email_delivery_events` and charted on `/admin/insights`; this lane emails
  * admins when the last hour crosses a threshold so sender-reputation trouble
  * is not only visible in charts.
@@ -11,26 +11,24 @@ import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
  * Complements the per-user outbound pause in
  * `packages/worker/src/email/outbound-abuse.ts` — that path stops one account;
  * this path pages operators when the shared domain is under platform-wide load.
+ * Watched types match that outbound-abuse reputation set (`failed` /
+ * `rejected` are delivery failures, not reputation signals).
  */
 
 export const emailDeliveryAlertWindowMinutes = 60
-/** Platform-wide bad outcomes in one hour before admins are paged. */
+/** Platform-wide reputation outcomes in one hour before admins are paged. */
 export const emailDeliveryAlertThreshold = 20
 /** Avoid re-paging on the same sustained spike every hour. */
 export const emailDeliveryAlertCooldownMinutes = 6 * 60
 export const emailDeliveryAlertKvKey = 'ops-alert:email-delivery-burst:v1'
 
 /**
- * Reputation-relevant Cloudflare Email Sending outcomes. Scoped to
- * `provider = 'cloudflare-email'` so inbound routing rejections
- * (`cloudflare-email-routing`) do not inflate the count.
+ * Reputation-relevant Cloudflare Email Sending outcomes (same signals that
+ * drive per-user outbound pause). Scoped to `provider = 'cloudflare-email'`
+ * so inbound routing rejections (`cloudflare-email-routing`) do not inflate
+ * the count.
  */
-const watchedEmailDeliveryEventTypes = [
-	'complained',
-	'bounced',
-	'failed',
-	'rejected',
-] as const
+const watchedEmailDeliveryEventTypes = ['complained', 'bounced'] as const
 
 type EmailDeliveryAlertEnv = {
 	APP_DB: D1Database
@@ -151,7 +149,7 @@ async function notifyAdminsOfEmailDeliveryBurst(input: {
 
 	const baseUrl = input.env.APP_BASE_URL?.trim() || `https://${systemDomain}`
 	const text = [
-		`Kody recorded ${input.count} reputation-relevant email delivery outcomes (complained, bounced, failed, or rejected) in the last ${input.windowMinutes} minutes (threshold ${input.threshold}).`,
+		`Kody recorded ${input.count} reputation-relevant email delivery outcomes (complained or bounced) in the last ${input.windowMinutes} minutes (threshold ${input.threshold}).`,
 		'Per-user outbound pause already stops individual abusers; a platform-wide burst can mean the shared sending domain is under pressure.',
 		`Review the Email delivery health chart at ${baseUrl}/admin/insights.`,
 		`Checked at ${input.now.toISOString()}.`,

--- a/packages/worker/src/app/email-delivery-alerts.ts
+++ b/packages/worker/src/app/email-delivery-alerts.ts
@@ -156,7 +156,7 @@ async function notifyAdminsOfEmailDeliveryBurst(input: {
 	].join('\n\n')
 
 	try {
-		await sendCloudflareEmail(
+		const sent = await sendCloudflareEmail(
 			{
 				accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
 				apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
@@ -173,6 +173,14 @@ async function notifyAdminsOfEmailDeliveryBurst(input: {
 					.join('')}</body></html>`,
 			},
 		)
+		if (!sent.ok) {
+			// Do not write cooldown when Cloudflare email is unconfigured.
+			throw new Error(
+				sent.skipped
+					? 'Cloudflare email sending is not configured.'
+					: 'Failed to send email delivery reputation alert.',
+			)
+		}
 	} catch (error) {
 		console.warn('email-delivery-alert-notification-failed', error)
 		throw error

--- a/packages/worker/src/app/email-delivery-alerts.ts
+++ b/packages/worker/src/app/email-delivery-alerts.ts
@@ -1,0 +1,202 @@
+import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
+import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
+
+/**
+ * Hourly platform-wide email delivery reputation burst check. Bad outcomes
+ * (`complained`, `bounced`, `failed`, `rejected`) are already recorded in
+ * `email_delivery_events` and charted on `/admin/insights`; this lane emails
+ * admins when the last hour crosses a threshold so sender-reputation trouble
+ * is not only visible in charts.
+ *
+ * Complements the per-user outbound pause in
+ * `packages/worker/src/email/outbound-abuse.ts` — that path stops one account;
+ * this path pages operators when the shared domain is under platform-wide load.
+ */
+
+export const emailDeliveryAlertWindowMinutes = 60
+/** Platform-wide bad outcomes in one hour before admins are paged. */
+export const emailDeliveryAlertThreshold = 20
+/** Avoid re-paging on the same sustained spike every hour. */
+export const emailDeliveryAlertCooldownMinutes = 6 * 60
+export const emailDeliveryAlertKvKey = 'ops-alert:email-delivery-burst:v1'
+
+/**
+ * Reputation-relevant Cloudflare Email Sending outcomes. Scoped to
+ * `provider = 'cloudflare-email'` so inbound routing rejections
+ * (`cloudflare-email-routing`) do not inflate the count.
+ */
+const watchedEmailDeliveryEventTypes = [
+	'complained',
+	'bounced',
+	'failed',
+	'rejected',
+] as const
+
+type EmailDeliveryAlertEnv = {
+	APP_DB: D1Database
+	APP_BASE_URL?: string
+	CLOUDFLARE_ACCOUNT_ID?: string
+	CLOUDFLARE_API_BASE_URL?: string
+	CLOUDFLARE_API_TOKEN?: string
+	BUNDLE_ARTIFACTS_KV?: KVNamespace
+}
+
+export function shouldRunEmailDeliveryAlertCron(now: Date) {
+	// Same hourly gate as auth-denial / retention / usage aggregation (minute 0).
+	return now.getUTCMinutes() === 0
+}
+
+export type EmailDeliveryAlertResult =
+	| { status: 'below_threshold'; count: number }
+	| { status: 'cooldown'; count: number }
+	| { status: 'notified'; count: number; recipients: number }
+	| { status: 'skipped'; reason: 'no_system_domain' | 'no_admins' }
+
+export async function checkEmailDeliveryBurstAndNotify(input: {
+	env: EmailDeliveryAlertEnv
+	now?: Date
+	threshold?: number
+	windowMinutes?: number
+	cooldownMinutes?: number
+}): Promise<EmailDeliveryAlertResult> {
+	const now = input.now ?? new Date()
+	const threshold = input.threshold ?? emailDeliveryAlertThreshold
+	const windowMinutes = input.windowMinutes ?? emailDeliveryAlertWindowMinutes
+	const cooldownMinutes =
+		input.cooldownMinutes ?? emailDeliveryAlertCooldownMinutes
+
+	const windowStart = new Date(
+		now.getTime() - windowMinutes * 60_000,
+	).toISOString()
+	const eventPlaceholders = watchedEmailDeliveryEventTypes
+		.map(() => '?')
+		.join(', ')
+	const row = await input.env.APP_DB.prepare(
+		`SELECT COUNT(*) AS count FROM email_delivery_events
+		 WHERE provider = 'cloudflare-email'
+			 AND event_type IN (${eventPlaceholders})
+			 AND created_at >= ?`,
+	)
+		.bind(...watchedEmailDeliveryEventTypes, windowStart)
+		.first<{ count: number }>()
+	const count = Number(row?.count ?? 0)
+	if (count < threshold) {
+		return { status: 'below_threshold', count }
+	}
+
+	if (input.env.BUNDLE_ARTIFACTS_KV) {
+		const lastSentRaw = await input.env.BUNDLE_ARTIFACTS_KV.get(
+			emailDeliveryAlertKvKey,
+		)
+		const lastSentMs = lastSentRaw ? Number(lastSentRaw) : NaN
+		if (
+			Number.isFinite(lastSentMs) &&
+			now.getTime() - lastSentMs < cooldownMinutes * 60_000
+		) {
+			return { status: 'cooldown', count }
+		}
+	}
+
+	const notified = await notifyAdminsOfEmailDeliveryBurst({
+		env: input.env,
+		count,
+		threshold,
+		windowMinutes,
+		now,
+	})
+	if (notified.status !== 'notified') {
+		return notified
+	}
+
+	if (input.env.BUNDLE_ARTIFACTS_KV) {
+		await input.env.BUNDLE_ARTIFACTS_KV.put(
+			emailDeliveryAlertKvKey,
+			String(now.getTime()),
+			{
+				// Keep the cooldown marker a bit longer than the cooldown window.
+				expirationTtl: (cooldownMinutes + 60) * 60,
+			},
+		)
+	}
+
+	return notified
+}
+
+async function notifyAdminsOfEmailDeliveryBurst(input: {
+	env: EmailDeliveryAlertEnv
+	count: number
+	threshold: number
+	windowMinutes: number
+	now: Date
+}): Promise<
+	| { status: 'notified'; count: number; recipients: number }
+	| { status: 'skipped'; reason: 'no_system_domain' | 'no_admins' }
+> {
+	const systemDomain = getSystemEmailDomain(input.env)
+	if (!systemDomain) {
+		return { status: 'skipped', reason: 'no_system_domain' }
+	}
+
+	const admins = await input.env.APP_DB.prepare(
+		`SELECT u.email FROM users u
+		 INNER JOIN user_roles ur ON ur.user_id = u.id
+		 INNER JOIN roles r ON r.id = ur.role_id
+		 WHERE r.name = 'admin'
+		 ORDER BY u.id ASC`,
+	).all<{ email: string }>()
+	const recipients = (admins.results ?? []).map((row) => row.email)
+	if (recipients.length === 0) {
+		return { status: 'skipped', reason: 'no_admins' }
+	}
+
+	const baseUrl = input.env.APP_BASE_URL?.trim() || `https://${systemDomain}`
+	const text = [
+		`Kody recorded ${input.count} reputation-relevant email delivery outcomes (complained, bounced, failed, or rejected) in the last ${input.windowMinutes} minutes (threshold ${input.threshold}).`,
+		'Per-user outbound pause already stops individual abusers; a platform-wide burst can mean the shared sending domain is under pressure.',
+		`Review the Email delivery health chart at ${baseUrl}/admin/insights.`,
+		`Checked at ${input.now.toISOString()}.`,
+	].join('\n\n')
+
+	try {
+		await sendCloudflareEmail(
+			{
+				accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
+				apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
+				apiToken: input.env.CLOUDFLARE_API_TOKEN,
+			},
+			{
+				to: recipients.length === 1 ? recipients[0]! : recipients,
+				from: `kody@${systemDomain}`,
+				subject: `Email delivery reputation burst: ${input.count} in ${input.windowMinutes}m`,
+				text,
+				html: `<!doctype html><html lang="en"><body>${text
+					.split('\n\n')
+					.map((paragraph) => `<p>${escapeHtml(paragraph)}</p>`)
+					.join('')}</body></html>`,
+			},
+		)
+	} catch (error) {
+		console.warn('email-delivery-alert-notification-failed', error)
+		throw error
+	}
+
+	console.warn('email-delivery-burst-alerted', {
+		count: input.count,
+		threshold: input.threshold,
+		recipients: recipients.length,
+	})
+
+	return {
+		status: 'notified',
+		count: input.count,
+		recipients: recipients.length,
+	}
+}
+
+function escapeHtml(value: string) {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+}

--- a/packages/worker/src/app/handlers/account-billing.ts
+++ b/packages/worker/src/app/handlers/account-billing.ts
@@ -19,7 +19,7 @@ import {
 } from '#worker/billing/billing-config.ts'
 import {
 	BillingLinkError,
-	linkStripeCustomerFromCheckoutSession,
+	linkStripeCustomerFromCheckoutSessionAttribution,
 } from '#worker/billing/subscription-sync.ts'
 
 function billingErrorRedirect(request: Request, errorCode: string) {
@@ -122,6 +122,9 @@ export function createAccountBillingCheckoutApiHandler(env: Env) {
 					successUrl,
 					cancelUrl,
 					...(customerId ? { customerId } : { customerEmail: user.email }),
+					// Lets the Stripe webhook resolve the user without reversing
+					// the HMAC client_reference_id (still verified on link).
+					metadata: { kody_stable_user_id: user.mcpUser.userId },
 				})
 				void logAuditEvent({
 					category: 'account',
@@ -173,14 +176,14 @@ export function createAccountBillingSuccessHandler(env: Env) {
 
 			const requestIp = getRequestIp(request) ?? undefined
 			try {
-				await linkStripeCustomerFromCheckoutSession({
+				await linkStripeCustomerFromCheckoutSessionAttribution({
 					env,
+					sessionId,
 					user: {
 						id: user.userId,
 						email: user.email,
 						stableUserId: user.mcpUser.userId,
 					},
-					sessionId,
 				})
 				void logAuditEvent({
 					category: 'account',

--- a/packages/worker/src/app/handlers/stripe-webhook.ts
+++ b/packages/worker/src/app/handlers/stripe-webhook.ts
@@ -1,0 +1,21 @@
+import { type Action } from 'remix/router'
+import { type routes } from '#app/routes.ts'
+import { jsonResponse } from '#worker/json-response.ts'
+import { handleStripeWebhookRequest } from '#worker/billing/stripe-webhooks.ts'
+
+/**
+ * Unauthenticated Stripe platform-billing webhook ingress.
+ * Signature verification requires the raw request body.
+ */
+export function createStripeWebhookHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			if (request.method !== 'POST') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+			const result = await handleStripeWebhookRequest({ env, request })
+			return jsonResponse(result.body, result.status)
+		},
+	} satisfies Action<typeof routes.stripeWebhook>
+}

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -1028,7 +1028,11 @@ export type AccountBillingLoaderData = {
 	effectivePlan: AdminPlanName
 	hasStripeCustomer: boolean
 	cancelAt: string | null
+	/** Stripe subscription status from on-page refresh; null if unknown/unavailable. */
+	subscriptionStatus: string | null
 	checkoutAvailable: boolean
+	/** Deep link to the account usage page (limits / consumption). */
+	usageHref: '/account/usage'
 	error?: string
 }
 

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -814,9 +814,7 @@ test('memory suppression, email delivery, audit, and stripe webhook retention re
 	expect(
 		(
 			sqlite
-				.prepare(
-					`SELECT event_id FROM stripe_webhook_events ORDER BY event_id`,
-				)
+				.prepare(`SELECT event_id FROM stripe_webhook_events ORDER BY event_id`)
 				.all() as Array<{ event_id: string }>
 		).map((row) => row.event_id),
 	).toEqual(['evt_boundary'])
@@ -1502,8 +1500,7 @@ test('retention coverage includes every live growth-pattern table or documented 
 		const hasGlobalAuditShape =
 			table.name === 'audit_events' && columnNames.has('timestamp')
 		const hasGlobalStripeWebhookShape =
-			table.name === 'stripe_webhook_events' &&
-			columnNames.has('processed_at')
+			table.name === 'stripe_webhook_events' && columnNames.has('processed_at')
 		const hasPlatformFeedbackGrowthShape =
 			table.name === 'platform_feedback' &&
 			columnNames.has('submitter_user_id') &&

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -21,11 +21,13 @@ import {
 	prunePlatformFeedbackForRetention,
 	prunePublishedBundleArtifactsForRetention,
 	pruneRetention,
+	pruneStripeWebhookEventsForRetention,
 	pruneUsageRollupsForRetention,
 	pruneUserEmailMessagesForRetention,
 	pruneWorkflowRunsForRetention,
 	publishedBundleArtifactRetentionDays,
 	shouldRunRetentionCron,
+	stripeWebhookEventRetentionDays,
 	workflowRunRetentionDays,
 } from './retention.ts'
 import { systemEmailOwnerId } from '#worker/email/system-email.ts'
@@ -286,6 +288,11 @@ function createRetentionDb() {
 			path TEXT,
 			reason TEXT,
 			timestamp TEXT NOT NULL
+		);
+		CREATE TABLE stripe_webhook_events (
+			event_id TEXT PRIMARY KEY NOT NULL,
+			event_type TEXT NOT NULL,
+			processed_at TEXT NOT NULL
 		);
 		CREATE TABLE platform_feedback (
 			id TEXT PRIMARY KEY NOT NULL,
@@ -705,7 +712,7 @@ test('platform feedback retention prunes terminal rows in bounded batches and ru
 	])
 })
 
-test('memory suppression, email delivery, and audit retention respect boundaries', async () => {
+test('memory suppression, email delivery, audit, and stripe webhook retention respect boundaries', async () => {
 	const { sqlite, db } = createRetentionDb()
 	for (const [memoryId, lastSeenAt, expiresAt] of [
 		[
@@ -753,6 +760,18 @@ test('memory suppression, email delivery, and audit retention respect boundaries
 			)
 			.run(timestamp)
 	}
+	for (const [eventId, processedAt] of [
+		['evt_old', daysAgo(stripeWebhookEventRetentionDays + 1)],
+		['evt_boundary', daysAgo(stripeWebhookEventRetentionDays)],
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO stripe_webhook_events (
+				event_id, event_type, processed_at
+			) VALUES (?, 'checkout.session.completed', ?)`,
+			)
+			.run(eventId, processedAt)
+	}
 
 	expect(await pruneMemorySuppressionsForRetention({ db, now })).toEqual({
 		selected: 1,
@@ -763,6 +782,10 @@ test('memory suppression, email delivery, and audit retention respect boundaries
 		deleted: 1,
 	})
 	expect(await pruneAuditEventsForRetention({ db, now })).toEqual({
+		selected: 1,
+		deleted: 1,
+	})
+	expect(await pruneStripeWebhookEventsForRetention({ db, now })).toEqual({
 		selected: 1,
 		deleted: 1,
 	})
@@ -788,6 +811,15 @@ test('memory suppression, email delivery, and audit retention respect boundaries
 	expect(auditRows.map((row) => row.timestamp)).toEqual([
 		daysAgo(auditEventRetentionDays),
 	])
+	expect(
+		(
+			sqlite
+				.prepare(
+					`SELECT event_id FROM stripe_webhook_events ORDER BY event_id`,
+				)
+				.all() as Array<{ event_id: string }>
+		).map((row) => row.event_id),
+	).toEqual(['evt_boundary'])
 })
 
 test('email message retention deletes old user rows, R2 blobs, attachments, and orphan threads', async () => {
@@ -1469,6 +1501,9 @@ test('retention coverage includes every live growth-pattern table or documented 
 			growthPattern.test(table.name)
 		const hasGlobalAuditShape =
 			table.name === 'audit_events' && columnNames.has('timestamp')
+		const hasGlobalStripeWebhookShape =
+			table.name === 'stripe_webhook_events' &&
+			columnNames.has('processed_at')
 		const hasPlatformFeedbackGrowthShape =
 			table.name === 'platform_feedback' &&
 			columnNames.has('submitter_user_id') &&
@@ -1476,6 +1511,7 @@ test('retention coverage includes every live growth-pattern table or documented 
 		if (
 			hasUserCreatedGrowthShape ||
 			hasGlobalAuditShape ||
+			hasGlobalStripeWebhookShape ||
 			hasPlatformFeedbackGrowthShape
 		) {
 			candidateTables.add(table.name)

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -61,6 +61,7 @@ export const emailMessageRetentionDays = 365
 export const entitlementDailyCounterRetentionDays = 400
 export const usageRollupRetentionMonths = 24
 export const auditEventRetentionDays = 180
+export const stripeWebhookEventRetentionDays = 30
 
 const millisecondsPerDay = 24 * 60 * 60 * 1000
 const terminalWorkflowStatusList = terminalWorkflowStatusValues
@@ -187,6 +188,14 @@ export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
 		description:
 			'Global hashed auth/security audit events keep 180 days and are independent of account deletion.',
 	},
+	{
+		table: 'stripe_webhook_events',
+		scope: 'global',
+		retentionDays: stripeWebhookEventRetentionDays,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Stripe platform webhook idempotency rows keep 30 days by processed_at and are independent of account deletion.',
+	},
 ] as const
 
 export const retentionPolicyExemptions: ReadonlyArray<RetentionPolicyExemption> =
@@ -234,6 +243,7 @@ export type RetentionPruneResult = {
 	entitlementDailyCounters: number
 	usageRollups: number
 	auditEvents: number
+	stripeWebhookEvents: number
 	batchesPerTable: Record<string, number>
 	timeBudgetExhausted: boolean
 }
@@ -1033,6 +1043,29 @@ export async function pruneAuditEventsForRetention(input: {
 	})
 }
 
+export async function pruneStripeWebhookEventsForRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const cutoff = cutoffIso(
+		input.now ?? new Date(),
+		stripeWebhookEventRetentionDays,
+	)
+	return selectAndDeleteByIds({
+		db: input.db,
+		column: 'event_id',
+		bindings: [cutoff, input.batchSize ?? retentionDefaultBatchSize],
+		sql: `SELECT event_id
+			FROM stripe_webhook_events
+			WHERE processed_at < ?
+			ORDER BY processed_at ASC, event_id ASC
+			LIMIT ?`,
+		table: 'stripe_webhook_events',
+		idColumn: 'event_id',
+	})
+}
+
 export async function pruneRetention(input: {
 	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'EMAIL_BLOBS'>
 	now?: Date
@@ -1070,6 +1103,7 @@ export async function pruneRetention(input: {
 		entitlementDailyCounters: 0,
 		usageRollups: 0,
 		auditEvents: 0,
+		stripeWebhookEvents: 0,
 		batchesPerTable: {},
 		timeBudgetExhausted: false,
 	}
@@ -1195,6 +1229,13 @@ export async function pruneRetention(input: {
 			() => pruneAuditEventsForRetention({ db, now }),
 			(count) => {
 				result.auditEvents += count
+			},
+		),
+		countTask(
+			'stripe_webhook_events',
+			() => pruneStripeWebhookEventsForRetention({ db, now }),
+			(count) => {
+				result.stripeWebhookEvents += count
 			},
 		),
 	]

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -139,6 +139,7 @@ import {
 } from '#app/handlers/profile.tsx'
 import { createProfileAvatarHandler } from '#app/handlers/profile-avatar.ts'
 import { createWebhookIngressHandler } from '#app/handlers/webhook-ingress.ts'
+import { createStripeWebhookHandler } from '#app/handlers/stripe-webhook.ts'
 import {
 	createTimelineApiHandler,
 	createTimelineHandler,
@@ -340,6 +341,7 @@ export function createAppRouter(env: Env) {
 			profileOgImage: createProfileOgImageHandler(env),
 			profileFollowApiPost: createProfileFollowApiPostHandler(env),
 			webhookIngress: createWebhookIngressHandler(env),
+			stripeWebhook: createStripeWebhookHandler(env),
 			timeline: createTimelineHandler(env),
 			timelineApi: createTimelineApiHandler(env),
 			connectOauth: createConnectOauthHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -122,6 +122,7 @@ export const routes = route({
 	webhookIngress: post(
 		'/@:username/webhooks/:packageKodyId/:webhookName/:urlSecret',
 	),
+	stripeWebhook: post('/webhooks/stripe'),
 	timeline: '/timeline',
 	timelineApi: '/timeline.json',
 	health: '/health',

--- a/packages/worker/src/billing/billing-config.node.test.ts
+++ b/packages/worker/src/billing/billing-config.node.test.ts
@@ -58,7 +58,11 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			],
 			env,
 		),
-	).toEqual({ stripePlan: null, cancelAt: null })
+	).toEqual({
+		stripePlan: null,
+		cancelAt: null,
+		subscriptionStatus: 'incomplete',
+	})
 
 	expect(
 		resolveSubscriptionPlan(
@@ -70,7 +74,11 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			],
 			env,
 		),
-	).toEqual({ stripePlan: 'pro', cancelAt: null })
+	).toEqual({
+		stripePlan: 'pro',
+		cancelAt: null,
+		subscriptionStatus: 'active',
+	})
 
 	expect(
 		resolveSubscriptionPlan(
@@ -82,7 +90,11 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			],
 			env,
 		),
-	).toEqual({ stripePlan: 'pro', cancelAt: null })
+	).toEqual({
+		stripePlan: 'pro',
+		cancelAt: null,
+		subscriptionStatus: 'trialing',
+	})
 
 	expect(
 		resolveSubscriptionPlan(
@@ -95,7 +107,11 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			],
 			env,
 		),
-	).toEqual({ stripePlan: 'pro', cancelAt: null })
+	).toEqual({
+		stripePlan: 'pro',
+		cancelAt: null,
+		subscriptionStatus: 'active',
+	})
 
 	expect(
 		resolveSubscriptionPlan(
@@ -107,7 +123,11 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			],
 			env,
 		),
-	).toEqual({ stripePlan: null, cancelAt: null })
+	).toEqual({
+		stripePlan: null,
+		cancelAt: null,
+		subscriptionStatus: 'active',
+	})
 
 	expect(
 		resolveSubscriptionPlan(
@@ -120,7 +140,11 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			],
 			env,
 		),
-	).toEqual({ stripePlan: null, cancelAt: null })
+	).toEqual({
+		stripePlan: null,
+		cancelAt: null,
+		subscriptionStatus: 'active',
+	})
 
 	expect(
 		resolveSubscriptionPlan(
@@ -133,7 +157,11 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			],
 			env,
 		),
-	).toEqual({ stripePlan: null, cancelAt: null })
+	).toEqual({
+		stripePlan: null,
+		cancelAt: null,
+		subscriptionStatus: 'active',
+	})
 
 	const sooner = 1_700_000_000
 	const later = 1_800_000_000
@@ -161,5 +189,26 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 	).toEqual({
 		stripePlan: 'pro',
 		cancelAt: new Date(sooner * 1000).toISOString(),
+		subscriptionStatus: 'active',
+	})
+
+	expect(
+		resolveSubscriptionPlan(
+			[
+				subscription({
+					status: 'canceled',
+					priceIds: ['price_pro'],
+				}),
+				subscription({
+					status: 'past_due',
+					priceIds: ['price_pro'],
+				}),
+			],
+			env,
+		),
+	).toEqual({
+		stripePlan: null,
+		cancelAt: null,
+		subscriptionStatus: 'past_due',
 	})
 })

--- a/packages/worker/src/billing/billing-config.ts
+++ b/packages/worker/src/billing/billing-config.ts
@@ -13,6 +13,22 @@ type BillingEnv = {
 
 const activeSubscriptionStatuses = new Set(['active', 'trialing'])
 
+/** Higher rank = more useful UX signal when no active/trialing sub exists. */
+const subscriptionStatusSignalRank: Record<string, number> = {
+	past_due: 100,
+	unpaid: 90,
+	incomplete: 80,
+	paused: 70,
+	incomplete_expired: 60,
+	canceled: 50,
+}
+
+export type ResolvedSubscriptionPlan = {
+	stripePlan: PlanName | null
+	cancelAt: string | null
+	subscriptionStatus: string | null
+}
+
 export function isBillingConfigured(env: BillingEnv) {
 	return Boolean(env.STRIPE_SECRET_KEY?.trim())
 }
@@ -72,15 +88,48 @@ function planFromSubscription(
 	return parseStripePlanName(metadataPlan)
 }
 
+function pickSubscriptionStatus(
+	subscriptions: ReadonlyArray<StripeSubscription>,
+): string | null {
+	let hasActive = false
+	let hasTrialing = false
+	let bestSignal: string | null = null
+	let bestRank = -1
+
+	for (const subscription of subscriptions) {
+		const status = subscription.status.trim()
+		if (!status) continue
+		if (status === 'active') {
+			hasActive = true
+			continue
+		}
+		if (status === 'trialing') {
+			hasTrialing = true
+			continue
+		}
+		const rank = subscriptionStatusSignalRank[status] ?? 1
+		if (rank > bestRank) {
+			bestRank = rank
+			bestSignal = status
+		}
+	}
+
+	if (hasActive) return 'active'
+	if (hasTrialing) return 'trialing'
+	return bestSignal
+}
+
 /**
  * Map Stripe subscriptions to the highest matching Kody plan among
  * active/trialing subscriptions, plus the soonest non-null cancel_at
- * (Unix seconds → ISO string) for display.
+ * (Unix seconds → ISO string) for display, and a UX-oriented
+ * subscriptionStatus (prefer active/trialing, else highest-signal status
+ * such as past_due).
  */
 export function resolveSubscriptionPlan(
 	subscriptions: ReadonlyArray<StripeSubscription>,
 	env: BillingEnv,
-): { stripePlan: PlanName | null; cancelAt: string | null } {
+): ResolvedSubscriptionPlan {
 	const proPriceId = getProPriceId(env)
 	let stripePlan: PlanName | null = null
 	let soonestCancelAt: number | null = null
@@ -106,5 +155,6 @@ export function resolveSubscriptionPlan(
 			soonestCancelAt == null
 				? null
 				: new Date(soonestCancelAt * 1000).toISOString(),
+		subscriptionStatus: pickSubscriptionStatus(subscriptions),
 	}
 }

--- a/packages/worker/src/billing/stripe-client.ts
+++ b/packages/worker/src/billing/stripe-client.ts
@@ -204,6 +204,8 @@ export async function createCheckoutSession(
 		cancelUrl: string
 		customerId?: string
 		customerEmail?: string
+		/** Opaque session metadata (e.g. kody_stable_user_id for webhook lookup). */
+		metadata?: Record<string, string>
 	},
 ): Promise<{ id: string; url: string }> {
 	const priceId = input.priceId.trim()
@@ -240,6 +242,14 @@ export async function createCheckoutSession(
 		form.customer = customerId
 	} else if (customerEmail) {
 		form.customer_email = customerEmail
+	}
+	if (input.metadata) {
+		for (const [key, value] of Object.entries(input.metadata)) {
+			const trimmedKey = key.trim()
+			const trimmedValue = value.trim()
+			if (!trimmedKey || !trimmedValue) continue
+			form[`metadata[${trimmedKey}]`] = trimmedValue
+		}
 	}
 
 	const body = await stripeRequest(env, {

--- a/packages/worker/src/billing/stripe-webhook-signature.node.test.ts
+++ b/packages/worker/src/billing/stripe-webhook-signature.node.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from 'vitest'
+import {
+	buildStripeWebhookSignatureHeader,
+	computeStripeWebhookSignature,
+	verifyStripeWebhookSignature,
+} from './stripe-webhook-signature.ts'
+
+const fixtureSecret = 'whsec_test_fixture_secret'
+const fixtureBody =
+	'{"id":"evt_test_fixture","object":"event","type":"checkout.session.completed","data":{"object":{"id":"cs_test"}}}'
+const fixtureTimestamp = 1_700_000_000
+/** HMAC-SHA256 hex of `${t}.${rawBody}` keyed by UTF-8(whsec_...) via Node crypto. */
+const fixtureSignature =
+	'850a8305dd40d37b2ad74f83d4a32d429fe9a017a6db9ac082e7ea2c3b430140'
+
+test('computeStripeWebhookSignature matches known HMAC fixture', async () => {
+	const signature = await computeStripeWebhookSignature({
+		secret: fixtureSecret,
+		timestamp: fixtureTimestamp,
+		rawBody: fixtureBody,
+	})
+	expect(signature).toBe(fixtureSignature)
+})
+
+test('verifyStripeWebhookSignature accepts valid headers and rejects bad ones', async () => {
+	const header = `t=${fixtureTimestamp},v1=${fixtureSignature}`
+
+	await expect(
+		verifyStripeWebhookSignature({
+			secret: fixtureSecret,
+			signatureHeader: header,
+			rawBody: fixtureBody,
+			nowSeconds: fixtureTimestamp,
+		}),
+	).resolves.toEqual({ timestamp: fixtureTimestamp })
+
+	const built = await buildStripeWebhookSignatureHeader({
+		secret: fixtureSecret,
+		rawBody: fixtureBody,
+		timestamp: fixtureTimestamp,
+	})
+	expect(built).toBe(header)
+
+	await expect(
+		verifyStripeWebhookSignature({
+			secret: fixtureSecret,
+			signatureHeader: null,
+			rawBody: fixtureBody,
+			nowSeconds: fixtureTimestamp,
+		}),
+	).rejects.toMatchObject({
+		name: 'StripeWebhookSignatureError',
+		code: 'missing_header',
+	})
+
+	await expect(
+		verifyStripeWebhookSignature({
+			secret: fixtureSecret,
+			signatureHeader: `t=${fixtureTimestamp},v1=${'0'.repeat(64)}`,
+			rawBody: fixtureBody,
+			nowSeconds: fixtureTimestamp,
+		}),
+	).rejects.toMatchObject({ code: 'signature_mismatch' })
+
+	await expect(
+		verifyStripeWebhookSignature({
+			secret: fixtureSecret,
+			signatureHeader: header,
+			rawBody: fixtureBody.replace('evt_test_fixture', 'evt_tampered'),
+			nowSeconds: fixtureTimestamp,
+		}),
+	).rejects.toMatchObject({ code: 'signature_mismatch' })
+
+	await expect(
+		verifyStripeWebhookSignature({
+			secret: fixtureSecret,
+			signatureHeader: header,
+			rawBody: fixtureBody,
+			toleranceSeconds: 300,
+			nowSeconds: fixtureTimestamp + 301,
+		}),
+	).rejects.toMatchObject({ code: 'timestamp_tolerance' })
+
+	await expect(
+		verifyStripeWebhookSignature({
+			secret: fixtureSecret,
+			signatureHeader: `t=${fixtureTimestamp},v0=deadbeef`,
+			rawBody: fixtureBody,
+			nowSeconds: fixtureTimestamp,
+		}),
+	).rejects.toMatchObject({ code: 'no_v1_signatures' })
+})

--- a/packages/worker/src/billing/stripe-webhook-signature.ts
+++ b/packages/worker/src/billing/stripe-webhook-signature.ts
@@ -1,0 +1,153 @@
+/**
+ * Stripe webhook signature verification (no SDK).
+ *
+ * Matches the algorithm used by Stripe's official libraries: HMAC-SHA256 of
+ * `${t}.${rawBody}` keyed by the endpoint signing secret string (including the
+ * `whsec_` prefix), compared against each `v1` signature in `Stripe-Signature`.
+ * Timestamps older than the tolerance window are rejected.
+ *
+ * @see https://docs.stripe.com/webhooks#verify-manually
+ */
+import { toHex } from '@kody-internal/shared/hex.ts'
+import { timingSafeEqualString } from '#worker/maintenance-handler.ts'
+
+export const stripeWebhookDefaultToleranceSeconds = 300
+
+export class StripeWebhookSignatureError extends Error {
+	readonly code:
+		| 'missing_header'
+		| 'invalid_header'
+		| 'no_v1_signatures'
+		| 'signature_mismatch'
+		| 'timestamp_tolerance'
+
+	constructor(code: StripeWebhookSignatureError['code'], message: string) {
+		super(message)
+		this.name = 'StripeWebhookSignatureError'
+		this.code = code
+	}
+}
+
+function parseStripeSignatureHeader(header: string): {
+	timestamp: number
+	v1Signatures: Array<string>
+} | null {
+	let timestamp = -1
+	const v1Signatures: Array<string> = []
+	for (const part of header.split(',')) {
+		const separator = part.indexOf('=')
+		if (separator <= 0) continue
+		const key = part.slice(0, separator).trim()
+		const value = part.slice(separator + 1).trim()
+		if (!value) continue
+		if (key === 't') {
+			const parsed = Number.parseInt(value, 10)
+			if (Number.isFinite(parsed)) timestamp = parsed
+			continue
+		}
+		if (key === 'v1') {
+			v1Signatures.push(value)
+		}
+	}
+	if (timestamp < 0) return null
+	return { timestamp, v1Signatures }
+}
+
+export async function computeStripeWebhookSignature(input: {
+	secret: string
+	timestamp: number
+	rawBody: string
+}): Promise<string> {
+	// Stripe endpoint secrets are UTF-8 key material, including the `whsec_`
+	// prefix — matching Stripe's official libraries.
+	const key = await crypto.subtle.importKey(
+		'raw',
+		new TextEncoder().encode(input.secret.trim()),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign'],
+	)
+	const signedPayload = `${input.timestamp}.${input.rawBody}`
+	const digest = await crypto.subtle.sign(
+		'HMAC',
+		key,
+		new TextEncoder().encode(signedPayload),
+	)
+	return toHex(new Uint8Array(digest))
+}
+
+export async function verifyStripeWebhookSignature(input: {
+	secret: string
+	signatureHeader: string | null | undefined
+	rawBody: string
+	toleranceSeconds?: number
+	nowSeconds?: number
+}): Promise<{ timestamp: number }> {
+	const header = input.signatureHeader?.trim()
+	if (!header) {
+		throw new StripeWebhookSignatureError(
+			'missing_header',
+			'Missing Stripe-Signature header.',
+		)
+	}
+
+	const parsed = parseStripeSignatureHeader(header)
+	if (!parsed) {
+		throw new StripeWebhookSignatureError(
+			'invalid_header',
+			'Unable to extract timestamp from Stripe-Signature header.',
+		)
+	}
+	if (parsed.v1Signatures.length === 0) {
+		throw new StripeWebhookSignatureError(
+			'no_v1_signatures',
+			'No v1 signatures found in Stripe-Signature header.',
+		)
+	}
+
+	const expected = await computeStripeWebhookSignature({
+		secret: input.secret,
+		timestamp: parsed.timestamp,
+		rawBody: input.rawBody,
+	})
+
+	let matched = false
+	for (const candidate of parsed.v1Signatures) {
+		if (await timingSafeEqualString(expected, candidate)) {
+			matched = true
+			break
+		}
+	}
+	if (!matched) {
+		throw new StripeWebhookSignatureError(
+			'signature_mismatch',
+			'No Stripe-Signature v1 value matched the expected HMAC.',
+		)
+	}
+
+	const tolerance =
+		input.toleranceSeconds ?? stripeWebhookDefaultToleranceSeconds
+	const nowSeconds = input.nowSeconds ?? Math.floor(Date.now() / 1000)
+	if (tolerance > 0 && Math.abs(nowSeconds - parsed.timestamp) > tolerance) {
+		throw new StripeWebhookSignatureError(
+			'timestamp_tolerance',
+			'Stripe-Signature timestamp is outside the allowed tolerance.',
+		)
+	}
+
+	return { timestamp: parsed.timestamp }
+}
+
+export async function buildStripeWebhookSignatureHeader(input: {
+	secret: string
+	rawBody: string
+	timestamp?: number
+}): Promise<string> {
+	const timestamp = input.timestamp ?? Math.floor(Date.now() / 1000)
+	const signature = await computeStripeWebhookSignature({
+		secret: input.secret,
+		timestamp,
+		rawBody: input.rawBody,
+	})
+	return `t=${timestamp},v1=${signature}`
+}

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -1,8 +1,9 @@
 /**
  * Platform Stripe billing webhook processing (not package inbound webhooks).
  *
- * Verifies Stripe-Signature against STRIPE_WEBHOOK_SECRET, records event ids
- * for idempotency, and reuses subscription-sync helpers for link/refresh.
+ * Verifies Stripe-Signature against STRIPE_WEBHOOK_SECRET, processes the event
+ * (handlers are idempotent), then records the event id so later deliveries can
+ * short-circuit as duplicates. Failures do not insert, so Stripe can retry.
  */
 import {
 	any,
@@ -69,12 +70,16 @@ function readStringField(
 	return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
-export async function claimStripeWebhookEvent(input: {
+/**
+ * Records a successfully processed event. UNIQUE conflict means another
+ * delivery already finished the same event — treat as duplicate success.
+ */
+export async function recordStripeWebhookEvent(input: {
 	env: Env
 	eventId: string
 	eventType: string
 	now?: Date
-}): Promise<'claimed' | 'duplicate'> {
+}): Promise<'recorded' | 'duplicate'> {
 	const now = input.now ?? new Date()
 	try {
 		await input.env.APP_DB.prepare(
@@ -83,7 +88,7 @@ export async function claimStripeWebhookEvent(input: {
 		)
 			.bind(input.eventId, input.eventType, now.toISOString())
 			.run()
-		return 'claimed'
+		return 'recorded'
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
 		if (/UNIQUE constraint failed/i.test(message)) {
@@ -91,17 +96,6 @@ export async function claimStripeWebhookEvent(input: {
 		}
 		throw error
 	}
-}
-
-export async function releaseStripeWebhookEventClaim(input: {
-	env: Env
-	eventId: string
-}) {
-	await input.env.APP_DB.prepare(
-		`DELETE FROM stripe_webhook_events WHERE event_id = ?`,
-	)
-		.bind(input.eventId)
-		.run()
 }
 
 async function handleCheckoutSessionCompleted(input: {
@@ -245,7 +239,7 @@ export async function processStripeWebhookEvent(input: {
 			})
 			return
 		default:
-			// Unknown types are acknowledged after idempotency insert.
+			// Unknown types are acknowledged after a successful process+record.
 			return
 	}
 }
@@ -313,16 +307,6 @@ export async function handleStripeWebhookRequest(input: {
 	}
 
 	const event = parsedEvent.value
-	const claim = await claimStripeWebhookEvent({
-		env: input.env,
-		eventId: event.id,
-		eventType: event.type,
-		now: input.now,
-	})
-	if (claim === 'duplicate') {
-		return { status: 200, body: { ok: true, duplicate: true } }
-	}
-
 	try {
 		await processStripeWebhookEvent({
 			env: input.env,
@@ -331,10 +315,6 @@ export async function handleStripeWebhookRequest(input: {
 			now: input.now,
 		})
 	} catch (error) {
-		await releaseStripeWebhookEventClaim({
-			env: input.env,
-			eventId: event.id,
-		})
 		console.error('stripe_webhook_process_failed', {
 			eventId: event.id,
 			eventType: event.type,
@@ -344,6 +324,16 @@ export async function handleStripeWebhookRequest(input: {
 			status: 500,
 			body: { ok: false, error: 'Failed to process Stripe webhook event.' },
 		}
+	}
+
+	const record = await recordStripeWebhookEvent({
+		env: input.env,
+		eventId: event.id,
+		eventType: event.type,
+		now: input.now,
+	})
+	if (record === 'duplicate') {
+		return { status: 200, body: { ok: true, duplicate: true } }
 	}
 
 	return { status: 200, body: { ok: true } }

--- a/packages/worker/src/billing/stripe-webhooks.ts
+++ b/packages/worker/src/billing/stripe-webhooks.ts
@@ -1,0 +1,350 @@
+/**
+ * Platform Stripe billing webhook processing (not package inbound webhooks).
+ *
+ * Verifies Stripe-Signature against STRIPE_WEBHOOK_SECRET, records event ids
+ * for idempotency, and reuses subscription-sync helpers for link/refresh.
+ */
+import {
+	any,
+	nullable,
+	object,
+	optional,
+	parseSafe,
+	record,
+	string,
+} from 'remix/data-schema'
+import { isBillingConfigured } from './billing-config.ts'
+import {
+	BillingLinkError,
+	linkStripeCustomerFromCheckoutSessionAttribution,
+	refreshStripePlanForStripeCustomer,
+} from './subscription-sync.ts'
+import {
+	StripeWebhookSignatureError,
+	verifyStripeWebhookSignature,
+} from './stripe-webhook-signature.ts'
+
+const stripeEventSchema = object({
+	id: string(),
+	type: string(),
+	data: object({
+		object: record(string(), any()),
+	}),
+})
+
+const checkoutSessionObjectSchema = object({
+	id: string(),
+	customer: optional(nullable(string())),
+	client_reference_id: optional(nullable(string())),
+	customer_email: optional(nullable(string())),
+	customer_details: optional(
+		nullable(
+			object({
+				email: optional(nullable(string())),
+			}),
+		),
+	),
+	metadata: optional(nullable(record(string(), string()))),
+})
+
+const customerObjectSchema = object({
+	customer: optional(nullable(string())),
+})
+
+export type StripeWebhookProcessResult = {
+	status: number
+	body: { ok: boolean; duplicate?: boolean; ignored?: boolean; error?: string }
+}
+
+function readCustomerId(value: unknown): string | null {
+	if (typeof value === 'string' && value.trim()) return value.trim()
+	return null
+}
+
+function readStringField(
+	recordValue: Record<string, unknown>,
+	key: string,
+): string | null {
+	const value = recordValue[key]
+	return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export async function claimStripeWebhookEvent(input: {
+	env: Env
+	eventId: string
+	eventType: string
+	now?: Date
+}): Promise<'claimed' | 'duplicate'> {
+	const now = input.now ?? new Date()
+	try {
+		await input.env.APP_DB.prepare(
+			`INSERT INTO stripe_webhook_events (event_id, event_type, processed_at)
+			 VALUES (?, ?, ?)`,
+		)
+			.bind(input.eventId, input.eventType, now.toISOString())
+			.run()
+		return 'claimed'
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		if (/UNIQUE constraint failed/i.test(message)) {
+			return 'duplicate'
+		}
+		throw error
+	}
+}
+
+export async function releaseStripeWebhookEventClaim(input: {
+	env: Env
+	eventId: string
+}) {
+	await input.env.APP_DB.prepare(
+		`DELETE FROM stripe_webhook_events WHERE event_id = ?`,
+	)
+		.bind(input.eventId)
+		.run()
+}
+
+async function handleCheckoutSessionCompleted(input: {
+	env: Env
+	object: Record<string, unknown>
+	now?: Date
+}) {
+	const parsed = parseSafe(checkoutSessionObjectSchema, input.object)
+	if (!parsed.success) {
+		console.error('stripe_webhook_checkout_shape', {
+			error: 'unexpected checkout session shape',
+		})
+		return
+	}
+	const session = parsed.value
+	const customerEmail =
+		session.customer_details?.email?.trim() ||
+		session.customer_email?.trim() ||
+		null
+	const stableUserIdHint =
+		session.metadata?.['kody_stable_user_id']?.trim() || null
+
+	try {
+		await linkStripeCustomerFromCheckoutSessionAttribution({
+			env: input.env,
+			sessionId: session.id,
+			clientReferenceId: session.client_reference_id,
+			stableUserIdHint,
+			customerId: session.customer,
+			customerEmail,
+			now: input.now,
+		})
+	} catch (error) {
+		if (error instanceof BillingLinkError) {
+			switch (error.code) {
+				case 'billing_not_configured':
+				case 'missing_session':
+				case 'client_reference_mismatch':
+				case 'missing_customer':
+				case 'customer_already_linked':
+				case 'account_already_linked':
+				case 'user_not_found':
+					console.error('stripe_webhook_checkout_link_skipped', {
+						code: error.code,
+						sessionId: session.id,
+					})
+					return
+				case 'stripe_error':
+					throw error
+				default: {
+					const exhaustive: never = error.code
+					throw new Error(
+						`Unhandled BillingLinkError code: ${String(exhaustive)}`,
+					)
+				}
+			}
+		}
+		throw error
+	}
+}
+
+async function handleCustomerSubscriptionChange(input: {
+	env: Env
+	object: Record<string, unknown>
+	now?: Date
+}) {
+	const parsed = parseSafe(customerObjectSchema, input.object)
+	const customerId =
+		(parsed.success ? readCustomerId(parsed.value.customer) : null) ??
+		readStringField(input.object, 'customer')
+	if (!customerId) {
+		console.error('stripe_webhook_subscription_missing_customer')
+		return
+	}
+	const result = await refreshStripePlanForStripeCustomer({
+		env: input.env,
+		customerId,
+		now: input.now,
+	})
+	if (result.userId == null) {
+		console.error('stripe_webhook_subscription_user_not_found', { customerId })
+	}
+}
+
+async function handleInvoicePaymentFailed(input: {
+	env: Env
+	object: Record<string, unknown>
+	now?: Date
+}) {
+	const parsed = parseSafe(customerObjectSchema, input.object)
+	const customerId =
+		(parsed.success ? readCustomerId(parsed.value.customer) : null) ??
+		readStringField(input.object, 'customer')
+	if (!customerId) {
+		console.error('stripe_webhook_invoice_missing_customer')
+		return
+	}
+	const result = await refreshStripePlanForStripeCustomer({
+		env: input.env,
+		customerId,
+		now: input.now,
+	})
+	if (result.userId == null) {
+		console.error('stripe_webhook_invoice_user_not_found', { customerId })
+		return
+	}
+	console.error('stripe_webhook_invoice_payment_failed', {
+		userId: result.userId,
+		customerId,
+		subscriptionStatus: result.resolved?.subscriptionStatus ?? null,
+	})
+}
+
+export async function processStripeWebhookEvent(input: {
+	env: Env
+	eventType: string
+	object: Record<string, unknown>
+	now?: Date
+}): Promise<void> {
+	switch (input.eventType) {
+		case 'checkout.session.completed':
+			await handleCheckoutSessionCompleted({
+				env: input.env,
+				object: input.object,
+				now: input.now,
+			})
+			return
+		case 'customer.subscription.updated':
+		case 'customer.subscription.deleted':
+			await handleCustomerSubscriptionChange({
+				env: input.env,
+				object: input.object,
+				now: input.now,
+			})
+			return
+		case 'invoice.payment_failed':
+			await handleInvoicePaymentFailed({
+				env: input.env,
+				object: input.object,
+				now: input.now,
+			})
+			return
+		default:
+			// Unknown types are acknowledged after idempotency insert.
+			return
+	}
+}
+
+/**
+ * Full HTTP handler body for POST /webhooks/stripe.
+ * Uses the raw request text for signature verification.
+ */
+export async function handleStripeWebhookRequest(input: {
+	env: Env
+	request: Request
+	now?: Date
+}): Promise<StripeWebhookProcessResult> {
+	const secret = input.env.STRIPE_WEBHOOK_SECRET?.trim()
+	if (!secret) {
+		return {
+			status: 503,
+			body: { ok: false, error: 'Stripe webhooks are not configured.' },
+		}
+	}
+
+	if (!isBillingConfigured(input.env)) {
+		return {
+			status: 503,
+			body: { ok: false, error: 'Stripe billing is not configured.' },
+		}
+	}
+
+	const rawBody = await input.request.text()
+	try {
+		await verifyStripeWebhookSignature({
+			secret,
+			signatureHeader: input.request.headers.get('stripe-signature'),
+			rawBody,
+			nowSeconds: input.now
+				? Math.floor(input.now.valueOf() / 1000)
+				: undefined,
+		})
+	} catch (error) {
+		if (error instanceof StripeWebhookSignatureError) {
+			return {
+				status: 400,
+				body: { ok: false, error: error.message },
+			}
+		}
+		throw error
+	}
+
+	let parsedJson: unknown
+	try {
+		parsedJson = JSON.parse(rawBody) as unknown
+	} catch {
+		return {
+			status: 400,
+			body: { ok: false, error: 'Invalid JSON payload.' },
+		}
+	}
+
+	const parsedEvent = parseSafe(stripeEventSchema, parsedJson)
+	if (!parsedEvent.success) {
+		return {
+			status: 400,
+			body: { ok: false, error: 'Unexpected Stripe event shape.' },
+		}
+	}
+
+	const event = parsedEvent.value
+	const claim = await claimStripeWebhookEvent({
+		env: input.env,
+		eventId: event.id,
+		eventType: event.type,
+		now: input.now,
+	})
+	if (claim === 'duplicate') {
+		return { status: 200, body: { ok: true, duplicate: true } }
+	}
+
+	try {
+		await processStripeWebhookEvent({
+			env: input.env,
+			eventType: event.type,
+			object: event.data.object,
+			now: input.now,
+		})
+	} catch (error) {
+		await releaseStripeWebhookEventClaim({
+			env: input.env,
+			eventId: event.id,
+		})
+		console.error('stripe_webhook_process_failed', {
+			eventId: event.id,
+			eventType: event.type,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return {
+			status: 500,
+			body: { ok: false, error: 'Failed to process Stripe webhook event.' },
+		}
+	}
+
+	return { status: 200, body: { ok: true } }
+}

--- a/packages/worker/src/billing/stripe-webhooks.workers.test.ts
+++ b/packages/worker/src/billing/stripe-webhooks.workers.test.ts
@@ -1,0 +1,294 @@
+import { env } from 'cloudflare:workers'
+import { expect, test, vi } from 'vitest'
+import { ensureEntitlementTestSchema } from '#worker/entitlements/test-schema.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { createBillingLinkReference } from './billing-config.ts'
+import { buildStripeWebhookSignatureHeader } from './stripe-webhook-signature.ts'
+import { handleStripeWebhookRequest } from './stripe-webhooks.ts'
+
+const webhookSecret = 'whsec_test_workers_secret'
+const now = new Date('2026-07-25T12:00:00.000Z')
+
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	})
+}
+
+function createWebhookEnv(
+	overrides: {
+		STRIPE_SECRET_KEY?: string
+		STRIPE_WEBHOOK_SECRET?: string
+		STRIPE_PRO_PRICE_ID?: string
+		STRIPE_API_BASE_URL?: string
+	} = {},
+): Env {
+	return {
+		...env,
+		STRIPE_SECRET_KEY: 'sk_test_secret',
+		STRIPE_WEBHOOK_SECRET: webhookSecret,
+		STRIPE_PRO_PRICE_ID: 'price_pro',
+		STRIPE_API_BASE_URL: 'https://stripe.mock',
+		...overrides,
+	}
+}
+
+async function seedUser(input: {
+	email: string
+	stripeCustomerId?: string | null
+	stripePlan?: string | null
+}) {
+	await ensureEntitlementTestSchema(env.APP_DB)
+	const stableUserId = await createStableUserIdFromEmail(input.email)
+	await env.APP_DB.prepare(
+		`INSERT INTO users (
+			username, email, password_hash, email_verified_at, stable_user_id, plan,
+			stripe_customer_id, stripe_plan, stripe_plan_refreshed_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			`wh-${crypto.randomUUID().slice(0, 8)}`,
+			input.email,
+			'test-password-hash',
+			now.toISOString(),
+			stableUserId,
+			'free',
+			input.stripeCustomerId ?? null,
+			input.stripePlan ?? null,
+			null,
+		)
+		.run()
+	const row = await env.APP_DB.prepare(`SELECT id FROM users WHERE email = ?`)
+		.bind(input.email)
+		.first<{ id: number }>()
+	if (!row) throw new Error(`Failed to seed user ${input.email}`)
+	return {
+		id: row.id,
+		email: input.email,
+		stableUserId,
+		linkReference: await createBillingLinkReference(env, stableUserId),
+	}
+}
+
+async function readUserBilling(userId: number) {
+	return env.APP_DB.prepare(
+		`SELECT stripe_customer_id, stripe_plan, stripe_plan_refreshed_at
+		 FROM users WHERE id = ?`,
+	)
+		.bind(userId)
+		.first<{
+			stripe_customer_id: string | null
+			stripe_plan: string | null
+			stripe_plan_refreshed_at: string | null
+		}>()
+}
+
+async function readWebhookEvent(eventId: string) {
+	return env.APP_DB.prepare(
+		`SELECT event_id, event_type FROM stripe_webhook_events WHERE event_id = ?`,
+	)
+		.bind(eventId)
+		.first<{ event_id: string; event_type: string }>()
+}
+
+function stubStripeFetch(input: {
+	checkout?: unknown
+	subscriptions?: unknown
+}) {
+	const fetchStub = vi.fn(async (request: RequestInfo | URL) => {
+		const url = String(request)
+		if (url.includes('/v1/checkout/sessions/')) {
+			return jsonResponse(
+				input.checkout ?? {
+					id: 'cs_test',
+					customer: 'cus_linked',
+					client_reference_id: null,
+				},
+			)
+		}
+		if (url.includes('/v1/subscriptions')) {
+			return jsonResponse(
+				input.subscriptions ?? {
+					data: [
+						{
+							id: 'sub_1',
+							status: 'active',
+							cancel_at: null,
+							items: {
+								data: [{ price: { id: 'price_pro' } }],
+							},
+						},
+					],
+				},
+			)
+		}
+		return jsonResponse({ error: 'unexpected stripe path' }, 500)
+	})
+	vi.stubGlobal('fetch', fetchStub)
+	return fetchStub
+}
+
+async function signedWebhookRequest(input: {
+	event: Record<string, unknown>
+	secret?: string
+}) {
+	const rawBody = JSON.stringify(input.event)
+	const signature = await buildStripeWebhookSignatureHeader({
+		secret: input.secret ?? webhookSecret,
+		rawBody,
+		timestamp: Math.floor(now.valueOf() / 1000),
+	})
+	return new Request('https://test.kody.dev/webhooks/stripe', {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			'stripe-signature': signature,
+		},
+		body: rawBody,
+	})
+}
+
+test('stripe webhook returns 503 when webhook secret is unset', async () => {
+	await ensureEntitlementTestSchema(env.APP_DB)
+	const result = await handleStripeWebhookRequest({
+		env: createWebhookEnv({ STRIPE_WEBHOOK_SECRET: '' }),
+		request: new Request('https://test.kody.dev/webhooks/stripe', {
+			method: 'POST',
+			body: '{}',
+		}),
+		now,
+	})
+	expect(result.status).toBe(503)
+	expect(result.body.ok).toBe(false)
+})
+
+test('stripe webhook verifies signature, links checkout, refreshes subscription, and is idempotent', async () => {
+	const email = `wh-checkout-${crypto.randomUUID()}@example.com`
+	const user = await seedUser({ email })
+	stubStripeFetch({
+		checkout: {
+			id: 'cs_webhook',
+			customer: 'cus_webhook',
+			client_reference_id: user.linkReference,
+		},
+		subscriptions: {
+			data: [
+				{
+					id: 'sub_webhook',
+					status: 'active',
+					cancel_at: null,
+					items: { data: [{ price: { id: 'price_pro' } }] },
+				},
+			],
+		},
+	})
+
+	const checkoutEvent = {
+		id: `evt_checkout_${crypto.randomUUID()}`,
+		type: 'checkout.session.completed',
+		data: {
+			object: {
+				id: 'cs_webhook',
+				customer: 'cus_webhook',
+				client_reference_id: user.linkReference,
+				customer_email: email,
+				metadata: { kody_stable_user_id: user.stableUserId },
+			},
+		},
+	}
+
+	const first = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({ event: checkoutEvent }),
+		now,
+	})
+	expect(first).toEqual({ status: 200, body: { ok: true } })
+	expect(await readUserBilling(user.id)).toEqual({
+		stripe_customer_id: 'cus_webhook',
+		stripe_plan: 'pro',
+		stripe_plan_refreshed_at: now.toISOString(),
+	})
+	expect(await readWebhookEvent(checkoutEvent.id)).toEqual({
+		event_id: checkoutEvent.id,
+		event_type: 'checkout.session.completed',
+	})
+
+	const duplicate = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({ event: checkoutEvent }),
+		now,
+	})
+	expect(duplicate).toEqual({
+		status: 200,
+		body: { ok: true, duplicate: true },
+	})
+
+	stubStripeFetch({
+		subscriptions: {
+			data: [
+				{
+					id: 'sub_webhook',
+					status: 'past_due',
+					cancel_at: null,
+					items: { data: [{ price: { id: 'price_pro' } }] },
+				},
+			],
+		},
+	})
+	const updatedEvent = {
+		id: `evt_sub_${crypto.randomUUID()}`,
+		type: 'customer.subscription.updated',
+		data: {
+			object: {
+				id: 'sub_webhook',
+				customer: 'cus_webhook',
+				status: 'past_due',
+			},
+		},
+	}
+	const updated = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({ event: updatedEvent }),
+		now,
+	})
+	expect(updated).toEqual({ status: 200, body: { ok: true } })
+	expect(await readUserBilling(user.id)).toMatchObject({
+		stripe_customer_id: 'cus_webhook',
+		stripe_plan: null,
+		stripe_plan_refreshed_at: now.toISOString(),
+	})
+
+	const unknownEvent = {
+		id: `evt_unknown_${crypto.randomUUID()}`,
+		type: 'radar.early_fraud_warning.created',
+		data: { object: { id: 'issfr_1' } },
+	}
+	const unknown = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({ event: unknownEvent }),
+		now,
+	})
+	expect(unknown).toEqual({ status: 200, body: { ok: true } })
+	expect(await readWebhookEvent(unknownEvent.id)).toEqual({
+		event_id: unknownEvent.id,
+		event_type: 'radar.early_fraud_warning.created',
+	})
+
+	const badSig = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({
+			event: {
+				id: `evt_bad_${crypto.randomUUID()}`,
+				type: 'checkout.session.completed',
+				data: { object: { id: 'cs_x' } },
+			},
+			secret: 'whsec_wrong_secret',
+		}),
+		now,
+	})
+	expect(badSig.status).toBe(400)
+	expect(badSig.body.ok).toBe(false)
+
+	vi.unstubAllGlobals()
+})

--- a/packages/worker/src/billing/stripe-webhooks.workers.test.ts
+++ b/packages/worker/src/billing/stripe-webhooks.workers.test.ts
@@ -1,6 +1,7 @@
 import { env } from 'cloudflare:workers'
 import { expect, test, vi } from 'vitest'
 import { ensureEntitlementTestSchema } from '#worker/entitlements/test-schema.ts'
+import { silenceExpectedConsoleErrors } from '#worker/test-support/console-spies.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { createBillingLinkReference } from './billing-config.ts'
 import { buildStripeWebhookSignatureHeader } from './stripe-webhook-signature.ts'
@@ -289,6 +290,74 @@ test('stripe webhook verifies signature, links checkout, refreshes subscription,
 	})
 	expect(badSig.status).toBe(400)
 	expect(badSig.body.ok).toBe(false)
+
+	vi.unstubAllGlobals()
+})
+
+test('stripe webhook process failure returns 500 without recording the event', async () => {
+	silenceExpectedConsoleErrors([
+		'stripe_api_error',
+		'stripe_webhook_process_failed',
+	])
+	const email = `wh-fail-${crypto.randomUUID()}@example.com`
+	const user = await seedUser({
+		email,
+		stripeCustomerId: 'cus_fail_retry',
+	})
+	const eventId = `evt_fail_${crypto.randomUUID()}`
+	const event = {
+		id: eventId,
+		type: 'customer.subscription.updated',
+		data: {
+			object: {
+				id: 'sub_fail',
+				customer: 'cus_fail_retry',
+				status: 'active',
+			},
+		},
+	}
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => jsonResponse({ error: 'stripe down' }, 500)),
+	)
+
+	const result = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({ event }),
+		now,
+	})
+	expect(result.status).toBe(500)
+	expect(result.body.ok).toBe(false)
+	expect(await readWebhookEvent(eventId)).toBeNull()
+
+	// A later delivery must still be able to process after the failed attempt
+	// (no stuck claim that would ack duplicates with 200).
+	stubStripeFetch({
+		subscriptions: {
+			data: [
+				{
+					id: 'sub_fail',
+					status: 'active',
+					cancel_at: null,
+					items: { data: [{ price: { id: 'price_pro' } }] },
+				},
+			],
+		},
+	})
+	const retry = await handleStripeWebhookRequest({
+		env: createWebhookEnv(),
+		request: await signedWebhookRequest({ event }),
+		now,
+	})
+	expect(retry).toEqual({ status: 200, body: { ok: true } })
+	expect(await readWebhookEvent(eventId)).toEqual({
+		event_id: eventId,
+		event_type: 'customer.subscription.updated',
+	})
+	expect(await readUserBilling(user.id)).toMatchObject({
+		stripe_customer_id: 'cus_fail_retry',
+		stripe_plan: 'pro',
+	})
 
 	vi.unstubAllGlobals()
 })

--- a/packages/worker/src/billing/subscription-sync.ts
+++ b/packages/worker/src/billing/subscription-sync.ts
@@ -1,3 +1,4 @@
+import { normalizeEmail } from '#app/normalize-email.ts'
 import {
 	parseStripePlanName,
 	type PlanName,
@@ -6,6 +7,7 @@ import {
 	createBillingLinkReference,
 	isBillingConfigured,
 	resolveSubscriptionPlan,
+	type ResolvedSubscriptionPlan,
 } from './billing-config.ts'
 import {
 	BillingNotConfiguredError,
@@ -26,6 +28,7 @@ export class BillingLinkError extends Error {
 		| 'customer_already_linked'
 		| 'account_already_linked'
 		| 'stripe_error'
+		| 'user_not_found'
 
 	constructor(
 		code: BillingLinkError['code'],
@@ -51,7 +54,7 @@ export async function refreshStripePlanForUser(input: {
 	userId: number
 	customerId: string
 	now?: Date
-}): Promise<{ stripePlan: PlanName | null; cancelAt: string | null }> {
+}): Promise<ResolvedSubscriptionPlan> {
 	const now = input.now ?? new Date()
 	const subscriptions = await listSubscriptions(input.env, input.customerId)
 	const resolved = resolveSubscriptionPlan(subscriptions, input.env)
@@ -70,6 +73,129 @@ export async function refreshStripePlanForUser(input: {
 	return resolved
 }
 
+async function loadBillingUserById(
+	env: SyncEnv,
+	userId: number,
+): Promise<BillingUser | null> {
+	const row = await env.APP_DB.prepare(
+		`SELECT id, email, stable_user_id FROM users WHERE id = ?`,
+	)
+		.bind(userId)
+		.first<{ id: number; email: string; stable_user_id: string }>()
+	if (!row) return null
+	return {
+		id: row.id,
+		email: row.email,
+		stableUserId: row.stable_user_id,
+	}
+}
+
+/**
+ * Resolve the Kody user that owns a Checkout Session by verifying
+ * `client_reference_id` against `createBillingLinkReference`. Candidate users
+ * are found via stable-user-id hint (session metadata), Stripe customer id, or
+ * customer email — never by reversing the HMAC.
+ */
+export async function resolveBillingUserForCheckoutLink(input: {
+	env: SyncEnv
+	clientReferenceId: string | null | undefined
+	stableUserIdHint?: string | null
+	customerId?: string | null
+	customerEmail?: string | null
+}): Promise<BillingUser | null> {
+	const clientReferenceId = input.clientReferenceId?.trim()
+	if (!clientReferenceId) return null
+
+	const candidates: Array<BillingUser> = []
+	const seenIds = new Set<number>()
+
+	async function pushCandidate(user: BillingUser | null) {
+		if (!user || seenIds.has(user.id)) return
+		seenIds.add(user.id)
+		candidates.push(user)
+	}
+
+	const stableUserIdHint = input.stableUserIdHint?.trim()
+	if (stableUserIdHint) {
+		const row = await input.env.APP_DB.prepare(
+			`SELECT id, email, stable_user_id FROM users WHERE stable_user_id = ?`,
+		)
+			.bind(stableUserIdHint)
+			.first<{ id: number; email: string; stable_user_id: string }>()
+		await pushCandidate(
+			row
+				? {
+						id: row.id,
+						email: row.email,
+						stableUserId: row.stable_user_id,
+					}
+				: null,
+		)
+	}
+
+	const customerId = input.customerId?.trim()
+	if (customerId) {
+		const row = await input.env.APP_DB.prepare(
+			`SELECT id, email, stable_user_id FROM users WHERE stripe_customer_id = ?`,
+		)
+			.bind(customerId)
+			.first<{ id: number; email: string; stable_user_id: string }>()
+		await pushCandidate(
+			row
+				? {
+						id: row.id,
+						email: row.email,
+						stableUserId: row.stable_user_id,
+					}
+				: null,
+		)
+	}
+
+	const customerEmail = input.customerEmail?.trim()
+	if (customerEmail) {
+		const normalized = normalizeEmail(customerEmail)
+		const row = await input.env.APP_DB.prepare(
+			`SELECT id, email, stable_user_id FROM users WHERE lower(email) = ?`,
+		)
+			.bind(normalized)
+			.first<{ id: number; email: string; stable_user_id: string }>()
+		await pushCandidate(
+			row
+				? {
+						id: row.id,
+						email: row.email,
+						stableUserId: row.stable_user_id,
+					}
+				: null,
+		)
+	}
+
+	for (const candidate of candidates) {
+		const expected = await createBillingLinkReference(
+			input.env,
+			candidate.stableUserId,
+		)
+		if (expected === clientReferenceId) {
+			return candidate
+		}
+	}
+	return null
+}
+
+export async function findUserIdByStripeCustomerId(input: {
+	env: SyncEnv
+	customerId: string
+}): Promise<number | null> {
+	const customerId = input.customerId.trim()
+	if (!customerId) return null
+	const row = await input.env.APP_DB.prepare(
+		`SELECT id FROM users WHERE stripe_customer_id = ?`,
+	)
+		.bind(customerId)
+		.first<{ id: number }>()
+	return row?.id ?? null
+}
+
 /**
  * Verify a completed Stripe Checkout session belongs to the logged-in user
  * (`client_reference_id` must equal their stable user id), link the Stripe
@@ -80,7 +206,7 @@ export async function linkStripeCustomerFromCheckoutSession(input: {
 	user: BillingUser
 	sessionId: string
 	now?: Date
-}): Promise<{ stripePlan: PlanName | null; cancelAt: string | null }> {
+}): Promise<ResolvedSubscriptionPlan> {
 	if (!isBillingConfigured(input.env)) {
 		throw new BillingLinkError(
 			'billing_not_configured',
@@ -203,10 +329,84 @@ export async function linkStripeCustomerFromCheckoutSession(input: {
 				userId: input.user.id,
 				error: error instanceof Error ? error.message : String(error),
 			})
-			return { stripePlan: null, cancelAt: null }
+			return { stripePlan: null, cancelAt: null, subscriptionStatus: null }
 		}
 		throw error
 	}
+}
+
+/**
+ * Shared checkout-link path used by the success redirect and the
+ * `checkout.session.completed` webhook: resolve the owning user from session
+ * attribution fields, then run the same link+refresh logic.
+ */
+export async function linkStripeCustomerFromCheckoutSessionAttribution(input: {
+	env: SyncEnv
+	sessionId: string
+	clientReferenceId?: string | null
+	stableUserIdHint?: string | null
+	customerId?: string | null
+	customerEmail?: string | null
+	/** When set (success redirect), skip candidate lookup and use this user. */
+	user?: BillingUser
+	now?: Date
+}): Promise<ResolvedSubscriptionPlan> {
+	if (input.user) {
+		return linkStripeCustomerFromCheckoutSession({
+			env: input.env,
+			user: input.user,
+			sessionId: input.sessionId,
+			now: input.now,
+		})
+	}
+
+	const user = await resolveBillingUserForCheckoutLink({
+		env: input.env,
+		clientReferenceId: input.clientReferenceId,
+		stableUserIdHint: input.stableUserIdHint,
+		customerId: input.customerId,
+		customerEmail: input.customerEmail,
+	})
+	if (!user) {
+		throw new BillingLinkError(
+			'user_not_found',
+			'No Kody account matched this checkout session attribution.',
+		)
+	}
+	return linkStripeCustomerFromCheckoutSession({
+		env: input.env,
+		user,
+		sessionId: input.sessionId,
+		now: input.now,
+	})
+}
+
+export async function refreshStripePlanForStripeCustomer(input: {
+	env: SyncEnv
+	customerId: string
+	now?: Date
+}): Promise<{
+	userId: number | null
+	resolved: ResolvedSubscriptionPlan | null
+}> {
+	const userId = await findUserIdByStripeCustomerId({
+		env: input.env,
+		customerId: input.customerId,
+	})
+	if (userId == null) {
+		return { userId: null, resolved: null }
+	}
+	const user = await loadBillingUserById(input.env, userId)
+	if (!user) {
+		return { userId: null, resolved: null }
+	}
+	const resolved = await refreshStripePlanForUser({
+		env: input.env,
+		userId: user.id,
+		customerId: input.customerId,
+		now: input.now,
+	})
+	return { userId: user.id, resolved }
 }
 
 /**
@@ -260,3 +460,5 @@ export async function refreshStaleStripePlans(input: {
 export function parseStoredStripePlan(value: string | null | undefined) {
 	return parseStripePlanName(value)
 }
+
+export type { PlanName, ResolvedSubscriptionPlan }

--- a/packages/worker/src/billing/subscription-sync.workers.test.ts
+++ b/packages/worker/src/billing/subscription-sync.workers.test.ts
@@ -165,7 +165,11 @@ test('linkStripeCustomerFromCheckoutSession links customer and refreshes stripe_
 		sessionId: 'cs_happy',
 		now,
 	})
-	expect(result).toEqual({ stripePlan: 'pro', cancelAt: null })
+	expect(result).toEqual({
+		stripePlan: 'pro',
+		cancelAt: null,
+		subscriptionStatus: 'active',
+	})
 
 	const row = await readUserBilling(user.id)
 	expect(row).toEqual({

--- a/packages/worker/src/entitlements/test-schema.ts
+++ b/packages/worker/src/entitlements/test-schema.ts
@@ -88,4 +88,13 @@ export async function ensureEntitlementTestSchema(db: D1Database) {
 )`,
 		)
 		.run()
+	await db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS stripe_webhook_events (
+	event_id TEXT PRIMARY KEY NOT NULL,
+	event_type TEXT NOT NULL,
+	processed_at TEXT NOT NULL
+)`,
+		)
+		.run()
 }

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -208,6 +208,9 @@ export const EnvSchema = object({
 	// Stripe billing — optional; when STRIPE_SECRET_KEY is unset, billing
 	// surfaces render a "not configured" notice and sync/cron/portal skip.
 	STRIPE_SECRET_KEY: optionalNonEmptyStringSchema,
+	// Stripe platform webhook signing secret (`whsec_...`). When unset,
+	// POST /webhooks/stripe returns 503.
+	STRIPE_WEBHOOK_SECRET: optionalNonEmptyStringSchema,
 	// Override for tests/mocks; defaults to https://api.stripe.com.
 	STRIPE_API_BASE_URL: optionalUrlStringSchema,
 	STRIPE_PRO_PRICE_ID: optionalNonEmptyStringSchema,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -73,6 +73,10 @@ import {
 	shouldRunAuthDenialAlertCron,
 } from '#app/auth-denial-alerts.ts'
 import {
+	checkEmailDeliveryBurstAndNotify,
+	shouldRunEmailDeliveryAlertCron,
+} from '#app/email-delivery-alerts.ts'
+import {
 	aggregateUsageRollups,
 	shouldRunUsageAggregationCron,
 } from '#worker/usage/aggregate-rollups.ts'
@@ -612,6 +616,12 @@ const workerHandler = {
 			lanes.push({
 				name: 'auth_denial_alert',
 				run: () => checkAuthDenialBurstAndNotify({ env, now: scheduledAt }),
+			})
+		}
+		if (shouldRunEmailDeliveryAlertCron(scheduledAt)) {
+			lanes.push({
+				name: 'email_delivery_alert',
+				run: () => checkEmailDeliveryBurstAndNotify({ env, now: scheduledAt }),
 			})
 		}
 		if (shouldRunDrExportCron(scheduledAt) && isDrExportConfigured(env)) {

--- a/packages/worker/src/index.workers.test.ts
+++ b/packages/worker/src/index.workers.test.ts
@@ -23,6 +23,11 @@ const mocks = vi.hoisted(() => ({
 		count: 0,
 	})),
 	shouldRunAuthDenialAlertCron: vi.fn(() => false),
+	checkEmailDeliveryBurstAndNotify: vi.fn(async () => ({
+		status: 'below_threshold',
+		count: 0,
+	})),
+	shouldRunEmailDeliveryAlertCron: vi.fn(() => false),
 	aggregateUsageRollups: vi.fn(async () => ({ skipped: true })),
 	shouldRunUsageAggregationCron: vi.fn(() => false),
 	runDrExportTick: vi.fn(async () => ({ skipped: true })),
@@ -61,6 +66,11 @@ vi.mock('#app/auth-denial-alerts.ts', () => ({
 	shouldRunAuthDenialAlertCron: mocks.shouldRunAuthDenialAlertCron,
 }))
 
+vi.mock('#app/email-delivery-alerts.ts', () => ({
+	checkEmailDeliveryBurstAndNotify: mocks.checkEmailDeliveryBurstAndNotify,
+	shouldRunEmailDeliveryAlertCron: mocks.shouldRunEmailDeliveryAlertCron,
+}))
+
 vi.mock('#worker/usage/aggregate-rollups.ts', () => ({
 	aggregateUsageRollups: mocks.aggregateUsageRollups,
 	shouldRunUsageAggregationCron: mocks.shouldRunUsageAggregationCron,
@@ -95,6 +105,7 @@ function getOAuthPurgeCoordinator() {
 test('scheduled runs gated lanes and passes EMAIL_BLOBS to system-email retention', async () => {
 	mocks.shouldRunUsageAggregationCron.mockReturnValueOnce(true)
 	mocks.shouldRunAuthDenialAlertCron.mockReturnValueOnce(true)
+	mocks.shouldRunEmailDeliveryAlertCron.mockReturnValueOnce(true)
 	const scheduledTime = Date.parse('2026-07-05T10:00:30.000Z')
 
 	await worker.scheduled?.(
@@ -120,6 +131,9 @@ test('scheduled runs gated lanes and passes EMAIL_BLOBS to system-email retentio
 		new Date(scheduledTime),
 	)
 	expect(mocks.checkAuthDenialBurstAndNotify).toHaveBeenCalledWith(
+		expect.objectContaining({ now: new Date(scheduledTime) }),
+	)
+	expect(mocks.checkEmailDeliveryBurstAndNotify).toHaveBeenCalledWith(
 		expect.objectContaining({ now: new Date(scheduledTime) }),
 	)
 	expect(mocks.refreshStaleStripePlans).toHaveBeenCalledWith(

--- a/tools/check-migrations.node.test.ts
+++ b/tools/check-migrations.node.test.ts
@@ -139,8 +139,8 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 	).toMatchObject({
 		ok: true,
 		errors: [],
-		nextPrefix: '0093',
-		maxPrefix: 92,
+		nextPrefix: '0094',
+		maxPrefix: 93,
 	})
 
 	const modifiedFiles = baselineFiles.map((entry) =>
@@ -199,7 +199,7 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 	])
 
 	const monotonicAddition: MigrationLedgerEntry = {
-		filename: '0093-normal-addition.sql',
+		filename: '0094-normal-addition.sql',
 		sha256: '2'.repeat(64),
 	}
 	const ledgerWithMonotonicAddition = structuredClone(ledger)
@@ -213,8 +213,8 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 	).toMatchObject({
 		ok: true,
 		errors: [],
-		nextPrefix: '0094',
-		maxPrefix: 93,
+		nextPrefix: '0095',
+		maxPrefix: 94,
 	})
 })
 
@@ -222,11 +222,11 @@ test('trusted history rejects a migration and ledger digest co-edit', async () =
 	const ledger = await readMigrationLedger()
 	const bootstrapFiles = ledger.migrations.map((entry) => ({ ...entry }))
 	const historicalEntry = {
-		filename: '0093-historical.sql',
+		filename: '0094-historical.sql',
 		sha256: hashMigrationContent('SELECT 1;\n'),
 	}
 	const trustedHistory: TrustedMigrationHistory = {
-		ref: 'trusted-base-with-0093',
+		ref: 'trusted-base-with-0094',
 		files: [...bootstrapFiles, historicalEntry],
 		ledgerEntries: [...bootstrapFiles, historicalEntry],
 	}
@@ -244,7 +244,7 @@ test('trusted history rejects a migration and ledger digest co-edit', async () =
 	)
 	expect(result.ok).toBe(false)
 	expectErrorsMention(result.errors, [
-		'0093-historical.sql',
+		'0094-historical.sql',
 		'Historical ledger entries cannot be edited',
 		'differs from trusted history',
 		'Migration and ledger digests cannot be changed together',

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -395,6 +395,10 @@
 		{
 			"filename": "0092-password-changed-at.sql",
 			"sha256": "9b5ab5019e2c18def21e562c9f0d36fe4385817e9b1ac12e9bec6512ba16d85c"
+		},
+		{
+			"filename": "0093-stripe-webhook-events.sql",
+			"sha256": "59f95b476e4ac07d0c29b4d33426f65122756abaa030d685843d53b2b429b587"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three invite-cohort readiness follow-ups, orchestrated as parallel tracks then integrated:

1. **Stripe platform webhooks** at `POST /webhooks/stripe`
   - Signature verification (`STRIPE_WEBHOOK_SECRET`), process-then-record idempotency (`stripe_webhook_events`), 30-day retention prune
   - Handles `checkout.session.completed` (link customer without relying on success redirect), `customer.subscription.updated`/`deleted`, `invoice.payment_failed`
   - Cron poll kept as backup; refresh now returns `subscriptionStatus`
2. **Deeper `/account/billing` UX** — status badge (incl. `past_due`), clear Subscribe / Manage / View usage actions, webhook-aware copy
3. **Email delivery reputation alert** — hourly admin email when `complained`/`bounced` burst (≥20/hour), KV cooldown, complements per-user outbound pause

### Stripe ops (already done in this agent run)
- Created live webhook endpoint `we_1TxB2NLAQpAnsYszAr7S6krK` → `https://heykody.dev/webhooks/stripe` with the four events above
- Stored signing secret as GitHub Actions secret `STRIPE_WEBHOOK_SECRET` (deploy.yml syncs via `--set-from-env-optional`)

## Test plan

- [x] Focused unit/workers tests for webhook signature, event processing, billing loader, email alerts, retention prune
- [x] `typecheck`, `lint`, `format:check`, `migrations:check`, `primitives:check`
- [ ] CI `npm run validate`
- [ ] After deploy: Stripe Dashboard → webhook deliveries succeed; checkout without hitting success URL still links plan; `/account/billing` shows status

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `367cd150` · **Head:** `1cc057c5`

**Classification:** extends — Stripe billing gains signed webhook ingress + idempotency table; scheduled cron gains a second ops alert; account billing UI surfaces subscription status.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `billing` | auth | extends — webhook receiver, signature verify, event→plan sync |
| `d1-app-db` | storage | extends — `stripe_webhook_events` + retention prune |
| `scheduled-cron` | surfaces | extends — email delivery reputation burst alert |
| `app-ui` | surfaces | extends — `/account/billing` status + CTA depth |
| `entitlements` | auth | composes — test schema only |

### System map

Stripe events enter a signed webhook, update per-user `stripe_plan`, and the billing UI reads refreshed status; a separate hourly cron pages admins on email reputation bursts.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  stripe["Stripe"]:::untouched
  billing["billing<br/>Stripe billing"]:::extended
  d1["d1-app-db<br/>D1 app database"]:::extended
  appUi["app-ui<br/>Account UI"]:::extended
  cron["scheduled-cron<br/>Scheduled cron"]:::extended
  stripe -->|"POST /webhooks/stripe signed"| billing
  billing -->|"stripe_plan + webhook event ids"| d1
  appUi -->|"refresh + subscriptionStatus"| billing
  cron -->|"email delivery burst email"| d1
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
  participant Stripe
  participant Webhook as POST /webhooks/stripe
  participant Sync as subscription-sync
  participant D1
  Stripe->>Webhook: signed event
  Webhook->>Webhook: verify Stripe-Signature
  Webhook->>Sync: link/refresh by event type
  Sync->>D1: users.stripe_plan
  Webhook->>D1: insert stripe_webhook_events
```

### Invariants

- Per-user isolation unchanged: webhook attribution uses HMAC `client_reference_id` / linked `stripe_customer_id`; alerts use aggregate delivery counts + admin emails only.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cad2696c-d046-4cf0-afae-a0d6dc030731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cad2696c-d046-4cf0-afae-a0d6dc030731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a signed Stripe webhook endpoint to handle billing-related events with signature verification, safe behavior when the secret is unset, and idempotent processing.
  * Updated the billing page to surface subscription status and gate Subscribe/Manage subscription actions, plus added a Usage shortcut.
  * Introduced an hourly admin alert for bounced/complained email spikes with cooldown throttling.
* **Documentation**
  * Documented `STRIPE_WEBHOOK_SECRET` and updated billing/retention/setup guidance.
* **Tests**
  * Expanded automated coverage for webhook signing/processing, billing data refresh, retention pruning, and email alert cron behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->