### PR TITLE
fix(jobs): keep missing job default-export validation out of Sentry

### DIFF
--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test, vi, afterEach } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
+import { repoBackedModuleEntrypointExportErrorMessage } from '#worker/repo/repo-kody-execution.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
@@ -1519,16 +1521,72 @@ test('updateJob clears params, updates timezone, and disables a job', async () =
 	expect(updated.timezone).toBe('America/Denver')
 	expect(updated.enabled).toBe(false)
 
-	await expect(
-		updateJob({
-			env,
-			callerContext,
-			body: {
-				id: created.id,
-				code: '   ',
+	const emptyCodeError = await updateJob({
+		env,
+		callerContext,
+		body: {
+			id: created.id,
+			code: '   ',
+		},
+	}).catch((caught: unknown) => caught)
+	expect(emptyCodeError).toBeInstanceOf(McpCallerError)
+	expect(emptyCodeError).toMatchObject({
+		message: 'Jobs require non-empty code.',
+	})
+})
+
+test('createJob and updateJob reject modules without a default export as McpCallerError', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+	} as Env
+	mockRepoPersistence()
+	const callerContext = createBaseCallerContext()
+	const bareArrowSnippet = 'async () => ({ ok: true })'
+
+	const createError = await createJob({
+		env,
+		callerContext,
+		body: {
+			name: 'Missing default export',
+			code: bareArrowSnippet,
+			schedule: {
+				type: 'once',
+				runAt: new Date(Date.now() + 60_000).toISOString(),
 			},
-		}),
-	).rejects.toThrow('Jobs require non-empty code.')
+		},
+	}).catch((caught: unknown) => caught)
+
+	expect(createError).toBeInstanceOf(McpCallerError)
+	expect(createError).toMatchObject({
+		message: repoBackedModuleEntrypointExportErrorMessage,
+	})
+
+	const created = await createJob({
+		env,
+		callerContext,
+		body: {
+			name: 'Mutable job for export check',
+			code: 'export default async () => ({ ok: true })',
+			schedule: {
+				type: 'once',
+				runAt: new Date(Date.now() + 60_000).toISOString(),
+			},
+		},
+	})
+
+	const updateError = await updateJob({
+		env,
+		callerContext,
+		body: {
+			id: created.id,
+			code: bareArrowSnippet,
+		},
+	}).catch((caught: unknown) => caught)
+
+	expect(updateError).toBeInstanceOf(McpCallerError)
+	expect(updateError).toMatchObject({
+		message: repoBackedModuleEntrypointExportErrorMessage,
+	})
 })
 
 test('inspectJobsForUser returns persisted job fields with alarm debug state', async () => {

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -1,5 +1,6 @@
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { withAccountWriteLease } from '#app/account-deletion-state.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext, parseMcpCallerContext } from '#mcp/context.ts'
 import { buildJobEmbedText } from '#mcp/jobs-embed.ts'
 import { deleteJobVector, upsertJobVector } from '#mcp/jobs-vectorize.ts'
@@ -104,7 +105,7 @@ function serializeCallerContext(callerContext: PersistedJobCallerContext) {
 function normalizeJobName(name: string) {
 	const trimmed = name.trim()
 	if (!trimmed) {
-		throw new Error('Jobs require a non-empty name.')
+		throw new McpCallerError('Jobs require a non-empty name.')
 	}
 	return trimmed
 }
@@ -112,10 +113,12 @@ function normalizeJobName(name: string) {
 function normalizeJobCode(code: string) {
 	const trimmed = code.trim()
 	if (!trimmed) {
-		throw new Error('Jobs require non-empty code.')
+		throw new McpCallerError('Jobs require non-empty code.')
 	}
 	if (!hasTopLevelDefaultExport(trimmed)) {
-		throw new Error(repoBackedModuleEntrypointExportErrorMessage)
+		// Caller-supplied module shape mistake — keep it off Sentry via
+		// McpCallerError so agent retries do not open platform bug issues.
+		throw new McpCallerError(repoBackedModuleEntrypointExportErrorMessage)
 	}
 	return trimmed
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [7633087633](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7633087633/) fired when `job_schedule_once` rejected caller-supplied job code that lacked a top-level `export default` (e.g. a bare async arrow snippet). That rejection is correct caller validation, not a platform defect — but `normalizeJobCode` threw a plain `Error`, so MCP observability reported it to Sentry.

This PR throws `McpCallerError` for empty name/code and missing default-export checks so those failures stay on the `mcp-event` log line and out of Sentry (same pattern as search/OpenAPI caller mistakes).

**Shipped:** squash-merged as `0a57498` · production deploy succeeded · Sentry issue resolved in commit.

## Test plan

- [x] Unit: `createJob` / `updateJob` reject bare arrow snippets with `McpCallerError` and the existing entrypoint message
- [x] Unit: empty-code update still fails with `McpCallerError`
- [x] CI `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `367cd150` · **Head:** `72a9fb1b`

**Classification:** composes — reuses existing `McpCallerError` so job entrypoint validation stays off Sentry; no new primitives or API shape changes.

### Primitives touched

| Primitive | Group     | Impact                                                                 |
| --------- | --------- | ---------------------------------------------------------------------- |
| `jobs`    | assistant | composes — throw `McpCallerError` from name/code/default-export checks |

### System map

Job schedule/update validation now surfaces as an MCP caller failure so observability skips Sentry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	jobs["jobs<br/>Scheduled jobs"]:::touched
	mcpServer["mcp-server<br/>MCP server"]:::untouched
	jobs -->|"McpCallerError on missing default export"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Path                         | Before                         | After                                      |
| ---------------------------- | ------------------------------ | ------------------------------------------ |
| Missing `export default`     | `Error` → Sentry issue         | `McpCallerError` → log only                |
| Empty job name/code          | plain `Error`                  | `McpCallerError` (same messages)           |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b430b9ca-5d57-4f6e-a838-05e94a3bbd55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b430b9ca-5d57-4f6e-a838-05e94a3bbd55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

