### PR TITLE
Measure the activation funnel and separate agent-driven forks

### DIFF
--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -118,8 +118,16 @@ const activationStepLabels: Record<
 }
 
 function activationSubtitle(activation: AdminInsightsActivation) {
+	const activated =
+		activation.steps.find((entry) => entry.step === 'package_activated')
+			?.users ?? 0
+	if (activated === 0) return 'Nobody has activated yet.'
 	const median = activation.medianHoursToActivation
-	if (median == null) return 'Nobody has activated yet.'
+	// Activation can be recorded without usable timing — backfilled milestones
+	// carry no verification date to measure from.
+	if (median == null) {
+		return `${formatIntegerNumber(activated)} activated; not enough timing data for a median.`
+	}
 	const rounded = median < 1 ? '<1' : formatIntegerNumber(Math.round(median))
 	return `Median ${rounded}h from verified email to a package that ran twice.`
 }

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -27,7 +27,11 @@ import {
 	AccountManagementShell,
 	AdminPageHeader,
 } from './account-management-components.tsx'
-import { type AdminInsightsLoaderData } from '#app/loader-data.ts'
+import {
+	type AdminInsightsActivation,
+	type AdminInsightsActivationStep,
+	type AdminInsightsLoaderData,
+} from '#app/loader-data.ts'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -99,6 +103,80 @@ export async function adminInsightsRouteLoader(
 		throw new Error('Unable to load admin insights.')
 	}
 	return { adminInsights: payload }
+}
+
+const activationStepLabels: Record<
+	AdminInsightsActivationStep['step'],
+	string
+> = {
+	signed_up: 'Signed up',
+	email_verified: 'Verified email',
+	agent_connected: 'Connected an agent',
+	package_forked: 'Forked a package',
+	package_run_succeeded: 'Package ran once',
+	package_activated: 'Package ran twice',
+}
+
+function activationSubtitle(activation: AdminInsightsActivation) {
+	const median = activation.medianHoursToActivation
+	if (median == null) return 'Nobody has activated yet.'
+	const rounded = median < 1 ? '<1' : formatIntegerNumber(Math.round(median))
+	return `Median ${rounded}h from verified email to a package that ran twice.`
+}
+
+/**
+ * Horizontal funnel. Bars are scaled against the first step so the drop-off
+ * between stages is the thing you see; the per-row percentage is share of
+ * signups, which is the number worth tracking over time.
+ */
+function renderActivationFunnel(activation: AdminInsightsActivation) {
+	const total = activation.steps[0]?.users ?? 0
+	return (
+		<div mix={css({ display: 'grid', gap: spacing.sm })}>
+			{activation.steps.map((entry) => {
+				const share = total > 0 ? entry.users / total : 0
+				return (
+					<div mix={css({ display: 'grid', gap: spacing.xs })}>
+						<div
+							mix={css({
+								display: 'flex',
+								justifyContent: 'space-between',
+								gap: spacing.sm,
+								fontSize: typography.fontSize.sm,
+								color: colors.text,
+							})}
+						>
+							<span>{activationStepLabels[entry.step]}</span>
+							<span mix={css({ color: colors.textMuted })}>
+								{formatIntegerNumber(entry.users)} · {formatPercentShare(share)}
+							</span>
+						</div>
+						<div
+							role="img"
+							aria-label={`${activationStepLabels[entry.step]}: ${entry.users} users, ${formatPercentShare(share)} of signups`}
+							mix={css({
+								height: '10px',
+								borderRadius: '999px',
+								background: colors.border,
+								overflow: 'hidden',
+							})}
+						>
+							<div
+								mix={css({
+									height: '100%',
+									width: `${Math.round(share * 100)}%`,
+									background:
+										entry.step === 'package_activated'
+											? chartColor.emerald
+											: chartColor.blue,
+								})}
+							/>
+						</div>
+					</div>
+				)
+			})}
+		</div>
+	)
 }
 
 type ChartCardProps = {
@@ -368,6 +446,42 @@ function renderDashboard(data: AdminInsightsLoaderData) {
 					[mq.tablet]: { gridTemplateColumns: 'minmax(0, 1fr)' },
 				})}
 			>
+				<ChartCard
+					title="Activation funnel"
+					sub={activationSubtitle(data.activation)}
+					span={8}
+				>
+					{renderActivationFunnel(data.activation)}
+				</ChartCard>
+				<ChartCard
+					title="Who forks packages"
+					sub="Agent-driven installs are real usage but a weaker activation signal than a person choosing one."
+					span={4}
+				>
+					<DonutChart
+						ariaLabel="Community forks by actor"
+						centerLabel="forks"
+						emptyText="No forks recorded yet."
+						slices={[
+							{
+								label: 'Person',
+								value: data.activation.forksByActor.human,
+								color: chartColor.emerald,
+							},
+							{
+								label: 'Agent',
+								value: data.activation.forksByActor.agent,
+								color: chartColor.violet,
+							},
+							{
+								label: 'Unknown',
+								value: data.activation.forksByActor.unknown,
+								color: chartColor.amber,
+							},
+						]}
+					/>
+				</ChartCard>
+
 				<ChartCard
 					title="User growth"
 					sub="Cumulative registered users over the last 12 weeks."

--- a/packages/worker/migrations/0094-activation-milestones.sql
+++ b/packages/worker/migrations/0094-activation-milestones.sql
@@ -1,0 +1,74 @@
+-- Activation funnel storage.
+--
+-- Most funnel steps are already derivable from durable tables: signup and
+-- verification from `users`, agent connection from `mcp_agent_sessions`, and
+-- first fork from `community_forks`. Two things are not, and this migration
+-- adds exactly those.
+--
+-- 1. `community_forks.actor` — a fork created by a person clicking install in
+--    the web app and a fork created by that person's agent over MCP are the
+--    same row today. They are not the same activation signal, and conflating
+--    them lets agent-driven activity inflate the funnel. Existing rows stay
+--    NULL because their origin is genuinely unknown.
+--
+-- 2. `user_activation_milestones` — run-derived milestones. Activation is
+--    defined as a forked package that has run successfully at least twice,
+--    but `package_runtime_runs` is retention-pruned (see
+--    packages/worker/src/app/retention.ts), so the funnel cannot be
+--    reconstructed from run history after the fact. Milestones are therefore
+--    written once, when reached, and never updated.
+
+ALTER TABLE community_forks ADD COLUMN actor TEXT
+CHECK (actor IS NULL OR actor IN ('human', 'agent'));
+
+CREATE TABLE user_activation_milestones (
+	user_id TEXT NOT NULL,
+	milestone TEXT NOT NULL CHECK (
+		milestone IN ('package_run_succeeded', 'package_activated')
+	),
+	reached_at TEXT NOT NULL,
+	-- The package that reached the milestone. Kept so a later analysis can
+	-- tell whether activation came from a forked package or an authored one.
+	package_id TEXT,
+	PRIMARY KEY (user_id, milestone)
+);
+
+CREATE INDEX idx_user_activation_milestones_milestone_reached
+ON user_activation_milestones(milestone, reached_at);
+
+-- Backfill from the runs that survive retention. This under-counts users whose
+-- qualifying runs were already pruned; it cannot be better, and a partial
+-- baseline beats none.
+INSERT OR IGNORE INTO user_activation_milestones (
+	user_id, milestone, reached_at, package_id
+)
+SELECT user_id, 'package_run_succeeded', MIN(started_at), NULL
+FROM package_runtime_runs
+WHERE status = 'success'
+GROUP BY user_id;
+
+INSERT OR IGNORE INTO user_activation_milestones (
+	user_id, milestone, reached_at, package_id
+)
+SELECT user_id, 'package_activated', second_success_at, package_id
+FROM (
+	SELECT
+		user_id,
+		package_id,
+		MIN(started_at) AS second_success_at,
+		ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY MIN(started_at)) AS rn
+	FROM (
+		SELECT
+			user_id,
+			package_id,
+			started_at,
+			ROW_NUMBER() OVER (
+				PARTITION BY user_id, package_id ORDER BY started_at
+			) AS success_rank
+		FROM package_runtime_runs
+		WHERE status = 'success'
+	)
+	WHERE success_rank = 2
+	GROUP BY user_id, package_id
+)
+WHERE rn = 1;

--- a/packages/worker/src/app/account-data-targets.ts
+++ b/packages/worker/src/app/account-data-targets.ts
@@ -116,6 +116,7 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 	{ kind: 'user_id', table: 'package_runtime_logs' },
 	{ kind: 'user_id', table: 'package_runtime_runs' },
 	{ kind: 'user_id', table: 'usage_rollups' },
+	{ kind: 'user_id', table: 'user_activation_milestones' },
 	{ kind: 'user_id', table: 'agent_package_conversation_uses' },
 	{ kind: 'mcp_memory_suppression' },
 	{ kind: 'user_id', table: 'mcp_memories' },

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -146,7 +146,9 @@ function normalizeQuery(query: string) {
 	return query.replace(/\s+/g, ' ').trim().toLowerCase()
 }
 
-function createInsightsTestDb() {
+function createInsightsTestDb(
+	overrides: { activationLatencyRows?: Array<{ hours: number }> } = {},
+) {
 	const db = {
 		prepare(query: string) {
 			const normalizedQuery = normalizeQuery(query)
@@ -222,7 +224,11 @@ function createInsightsTestDb() {
 							}
 						}
 						// Latency query: one activated user, 36 hours after verifying.
-						return { results: [{ hours: 36 }] as Array<T> }
+						return {
+							results: (overrides.activationLatencyRows ?? [
+								{ hours: 36 },
+							]) as Array<T>,
+						}
 					}
 					if (normalizedQuery.includes('from community_forks')) {
 						return {
@@ -386,6 +392,19 @@ test('loadAdminInsightsData assembles the dashboard payload', async () => {
 		unknown: 4,
 	})
 	expect(data.activation.medianHoursToActivation).toBe(36)
+})
+
+test('activation latency excludes users who have no usable verification date', async () => {
+	const data = await loadAdminInsightsData(
+		{ APP_DB: createInsightsTestDb({ activationLatencyRows: [] }) } as Env,
+		now,
+	)
+	// Two users reached the milestone, but neither has timing we can measure.
+	expect(data.activation.steps.at(-1)).toEqual({
+		step: 'package_activated',
+		users: 1,
+	})
+	expect(data.activation.medianHoursToActivation).toBeNull()
 })
 
 test('medianOf averages the middle pair and ignores non-finite values', () => {

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -10,6 +10,7 @@ import {
 	listUtcMonthKeys,
 	listUtcWeekStarts,
 	loadAdminInsightsData,
+	medianOf,
 	utcWeekStart,
 } from './admin-insights-data.ts'
 
@@ -196,6 +197,12 @@ function createInsightsTestDb() {
 					if (normalizedQuery.includes('from oauth_connections')) {
 						return { n: 4 } as T
 					}
+					if (normalizedQuery.includes('from mcp_agent_sessions')) {
+						return { n: 4 } as T
+					}
+					if (normalizedQuery.includes('from community_forks')) {
+						return { n: 3 } as T
+					}
 					throw new Error(`Unsupported first query: ${query}`)
 				},
 				async all<T>() {
@@ -204,6 +211,27 @@ function createInsightsTestDb() {
 						normalizedQuery.includes('group by day')
 					) {
 						return { results: [{ day: '2026-07-07', n: 2 }] as Array<T> }
+					}
+					if (normalizedQuery.includes('from user_activation_milestones')) {
+						if (normalizedQuery.includes('group by milestone')) {
+							return {
+								results: [
+									{ milestone: 'package_run_succeeded', n: 2 },
+									{ milestone: 'package_activated', n: 1 },
+								] as Array<T>,
+							}
+						}
+						// Latency query: one activated user, 36 hours after verifying.
+						return { results: [{ hours: 36 }] as Array<T> }
+					}
+					if (normalizedQuery.includes('from community_forks')) {
+						return {
+							results: [
+								{ actor: 'human', n: 2 },
+								{ actor: 'agent', n: 1 },
+								{ actor: 'unknown', n: 4 },
+							] as Array<T>,
+						}
 					}
 					if (normalizedQuery.includes('from usage_rollups')) {
 						expect(params[0]).toBe('2025-08')
@@ -344,4 +372,26 @@ test('loadAdminInsightsData assembles the dashboard payload', async () => {
 		successRuns: 20,
 		errorRuns: 2,
 	})
+	expect(data.activation.steps).toEqual([
+		{ step: 'signed_up', users: 8 },
+		{ step: 'email_verified', users: 5 },
+		{ step: 'agent_connected', users: 4 },
+		{ step: 'package_forked', users: 3 },
+		{ step: 'package_run_succeeded', users: 2 },
+		{ step: 'package_activated', users: 1 },
+	])
+	expect(data.activation.forksByActor).toEqual({
+		human: 2,
+		agent: 1,
+		unknown: 4,
+	})
+	expect(data.activation.medianHoursToActivation).toBe(36)
+})
+
+test('medianOf averages the middle pair and ignores non-finite values', () => {
+	expect(medianOf([])).toBeNull()
+	expect(medianOf([5])).toBe(5)
+	expect(medianOf([1, 3])).toBe(2)
+	expect(medianOf([1, 2, 3])).toBe(2)
+	expect(medianOf([1, Number.NaN, 3])).toBe(2)
 })

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -3,6 +3,8 @@ import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
 import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
 import { adminUsageMetrics } from '#app/admin-user-usage-data.ts'
 import {
+	type AdminInsightsActivation,
+	type AdminInsightsActivationStep,
 	type AdminInsightsAuthCategory,
 	type AdminInsightsAuthDay,
 	type AdminInsightsEmailDay,
@@ -52,6 +54,9 @@ type JobStatsRow = {
 	success_runs: number | null
 	error_runs: number | null
 }
+type ForkActorRow = { actor: string | null; n: number }
+type MilestoneUserRow = { milestone: string; n: number }
+type ActivationLatencyRow = { hours: number }
 
 export async function loadAdminInsightsData(
 	env: Env,
@@ -102,6 +107,7 @@ async function queryAdminInsights(
 		authCategoryRows,
 		heatmapRows,
 		workflowRows,
+		activation,
 	] = await Promise.all([
 		queryTotals(db),
 		db
@@ -204,6 +210,7 @@ async function queryAdminInsights(
 				 ORDER BY n DESC`,
 			)
 			.all<WorkflowStatusRow>(),
+		queryActivation(db),
 	])
 
 	const jobHealth: AdminInsightsJobHealth = {
@@ -267,7 +274,121 @@ async function queryAdminInsights(
 			}),
 		),
 		jobHealth,
+		activation,
 	}
+}
+
+/**
+ * The activation funnel.
+ *
+ * Signup, verification, agent connection, and forking are all derivable from
+ * durable tables, so they are read where they already live rather than
+ * duplicated. Only the run-derived steps come from
+ * `user_activation_milestones`, because run history is retention-pruned. See
+ * `packages/worker/src/usage/activation.ts`.
+ */
+async function queryActivation(
+	db: D1Database,
+): Promise<AdminInsightsActivation> {
+	const [
+		signedUp,
+		emailVerified,
+		agentConnected,
+		packageForked,
+		milestoneRows,
+		forkActorRows,
+		latencyRows,
+	] = await Promise.all([
+		countQuery(db, `SELECT COUNT(*) AS n FROM users`),
+		countQuery(
+			db,
+			`SELECT COUNT(*) AS n FROM users WHERE email_verified_at IS NOT NULL`,
+		),
+		countQuery(
+			db,
+			`SELECT COUNT(DISTINCT user_id) AS n FROM mcp_agent_sessions`,
+		),
+		countQuery(
+			db,
+			`SELECT COUNT(DISTINCT forker_user_id) AS n FROM community_forks`,
+		),
+		db
+			.prepare(
+				`SELECT milestone, COUNT(DISTINCT user_id) AS n
+				 FROM user_activation_milestones
+				 GROUP BY milestone`,
+			)
+			.all<MilestoneUserRow>(),
+		db
+			.prepare(
+				`SELECT COALESCE(actor, 'unknown') AS actor, COUNT(*) AS n
+				 FROM community_forks
+				 GROUP BY COALESCE(actor, 'unknown')`,
+			)
+			.all<ForkActorRow>(),
+		db
+			.prepare(
+				// julianday() differences are in days; ×24 gives hours. Users
+				// who activated before verifying (not expected, but possible
+				// for seeded or admin-created accounts) would skew the median
+				// negative, so they are excluded rather than clamped.
+				`SELECT (julianday(m.reached_at) - julianday(u.email_verified_at)) * 24 AS hours
+				 FROM user_activation_milestones AS m
+				 JOIN users AS u ON u.id = m.user_id
+				 WHERE m.milestone = 'package_activated'
+				   AND u.email_verified_at IS NOT NULL
+				   AND julianday(m.reached_at) >= julianday(u.email_verified_at)
+				 ORDER BY hours ASC`,
+			)
+			.all<ActivationLatencyRow>(),
+	])
+
+	const milestoneUsers = new Map<string, number>()
+	for (const row of milestoneRows.results ?? []) {
+		milestoneUsers.set(row.milestone, Number(row.n))
+	}
+
+	const forksByActor = { human: 0, agent: 0, unknown: 0 }
+	for (const row of forkActorRows.results ?? []) {
+		if (row.actor === 'human') forksByActor.human += Number(row.n)
+		else if (row.actor === 'agent') forksByActor.agent += Number(row.n)
+		else forksByActor.unknown += Number(row.n)
+	}
+
+	const steps: Array<AdminInsightsActivationStep> = [
+		{ step: 'signed_up', users: signedUp },
+		{ step: 'email_verified', users: emailVerified },
+		{ step: 'agent_connected', users: agentConnected },
+		{ step: 'package_forked', users: packageForked },
+		{
+			step: 'package_run_succeeded',
+			users: milestoneUsers.get('package_run_succeeded') ?? 0,
+		},
+		{
+			step: 'package_activated',
+			users: milestoneUsers.get('package_activated') ?? 0,
+		},
+	]
+
+	return {
+		steps,
+		forksByActor,
+		medianHoursToActivation: medianOf(
+			(latencyRows.results ?? []).map((row) => Number(row.hours)),
+		),
+	}
+}
+
+/** Median of an ascending list. Even-length lists average the middle pair. */
+export function medianOf(sortedValues: Array<number>): number | null {
+	const values = sortedValues.filter((value) => Number.isFinite(value))
+	if (values.length === 0) return null
+	const middle = Math.floor(values.length / 2)
+	if (values.length % 2 === 1) return values[middle] ?? null
+	const lower = values[middle - 1]
+	const upper = values[middle]
+	if (lower == null || upper == null) return null
+	return (lower + upper) / 2
 }
 
 async function queryTotals(

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -362,6 +362,36 @@ export type AdminInsightsJobHealth = {
 	errorRuns: number
 }
 
+/**
+ * Ordered activation funnel. Each step counts users who ever reached it, so
+ * counts are monotonically non-increasing down the list.
+ */
+export type AdminInsightsActivationStep = {
+	step:
+		| 'signed_up'
+		| 'email_verified'
+		| 'agent_connected'
+		| 'package_forked'
+		| 'package_run_succeeded'
+		| 'package_activated'
+	users: number
+}
+
+export type AdminInsightsActivation = {
+	steps: Array<AdminInsightsActivationStep>
+	/**
+	 * Forks split by who caused them. Agent-driven forks are real usage but a
+	 * weaker activation signal than a person choosing to install something,
+	 * and rows predating the distinction are counted as unknown.
+	 */
+	forksByActor: { human: number; agent: number; unknown: number }
+	/**
+	 * Median hours from email verification to activation, over users who have
+	 * activated. Null when nobody has.
+	 */
+	medianHoursToActivation: number | null
+}
+
 export type AdminInsightsLoaderData = {
 	ok: true
 	generatedAt: string
@@ -376,6 +406,7 @@ export type AdminInsightsLoaderData = {
 	authHeatmap: Array<AdminInsightsHeatmapCell>
 	workflowStatuses: Array<AdminInsightsWorkflowStatus>
 	jobHealth: AdminInsightsJobHealth
+	activation: AdminInsightsActivation
 }
 
 export type AdminSystemEmailListItem = {

--- a/packages/worker/src/community/community-activity-service.node.test.ts
+++ b/packages/worker/src/community/community-activity-service.node.test.ts
@@ -70,6 +70,21 @@ function createCommunityDb() {
 			'utf8',
 		),
 	)
+	sqlite.exec(`CREATE TABLE package_runtime_runs (
+		user_id TEXT NOT NULL,
+		package_id TEXT NOT NULL,
+		status TEXT NOT NULL,
+		started_at TEXT NOT NULL
+	)`)
+	sqlite.exec(
+		readFileSync(
+			new URL(
+				'../../migrations/0094-activation-milestones.sql',
+				import.meta.url,
+			),
+			'utf8',
+		),
+	)
 	return { sqlite, db: createD1FromSqlite(sqlite) }
 }
 
@@ -261,6 +276,7 @@ test('fork snapshot migration also handles preview schemas that already have sna
 	)
 	sqlite.exec(`ALTER TABLE community_forks ADD COLUMN listing_name TEXT`)
 	sqlite.exec(`ALTER TABLE community_forks ADD COLUMN listing_kody_id TEXT`)
+	sqlite.exec(`ALTER TABLE community_forks ADD COLUMN actor TEXT`)
 	sqlite.exec(`
 		INSERT INTO community_listings (
 			id, owner_user_id, package_id, source_id, kody_id, name, description,

--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -109,6 +109,7 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 			listing_kody_id TEXT,
 			adopted_at TEXT,
 			adoption_note TEXT,
+			actor TEXT CHECK (actor IS NULL OR actor IN ('human', 'agent')),
 			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_community_forks_forked_package_id

--- a/packages/worker/src/community/install.ts
+++ b/packages/worker/src/community/install.ts
@@ -2,7 +2,7 @@ import { refreshSavedPackageProjection } from '#worker/package-registry/service.
 import { runRepoChecks, type RepoCheckResult } from '#worker/repo/checks.ts'
 import { normalizeRepoWorkspacePath } from '#worker/repo/manifest.ts'
 import { forkCommunityListing } from './service.ts'
-import { type CrossScopeReference } from './types.ts'
+import { type CommunityForkActor, type CrossScopeReference } from './types.ts'
 
 type InstallForkSummary = {
 	forkId: string
@@ -61,6 +61,11 @@ export async function installCommunityListing(input: {
 	 * different content in the meantime.
 	 */
 	expectedPinnedCommit: string
+	/**
+	 * Defaults to `human`: one-click install is a person clicking a button.
+	 * The MCP capability passes `agent` when it drives an install itself.
+	 */
+	actor?: CommunityForkActor | null
 }): Promise<InstallCommunityListingResult> {
 	const fork = await forkCommunityListing({
 		env: input.env,
@@ -70,6 +75,7 @@ export async function installCommunityListing(input: {
 		listingId: input.listingId,
 		kodyId: input.kodyId,
 		expectedPinnedCommit: input.expectedPinnedCommit,
+		actor: input.actor ?? 'human',
 	})
 	const summary: InstallForkSummary = {
 		forkId: fork.forkId,

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -6,6 +6,7 @@ import {
 	type CommunityBanRecord,
 	type CommunityBanRow,
 	type CommunityForkRecord,
+	type CommunityForkActor,
 	type CommunityForkRow,
 	type CommunityListingRecord,
 	type CommunityListingRow,
@@ -606,10 +607,14 @@ export async function setCommunityListingStatus(
 
 export async function insertCommunityFork(
 	db: D1Database,
-	row: Omit<CommunityForkRow, 'created_at' | 'adopted_at' | 'adoption_note'> & {
+	row: Omit<
+		CommunityForkRow,
+		'created_at' | 'adopted_at' | 'adoption_note' | 'actor'
+	> & {
 		listing_name: string
 		listing_kody_id: string
 		created_at?: string
+		actor?: CommunityForkActor | null
 	},
 ): Promise<void> {
 	await db
@@ -617,8 +622,8 @@ export async function insertCommunityFork(
 			`INSERT INTO community_forks (
 				id, listing_id, forker_user_id, origin_commit, forked_package_id,
 				forked_source_id, target_kody_id, listing_name, listing_kody_id,
-				created_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				created_at, actor
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.bind(
 			row.id,
@@ -631,6 +636,7 @@ export async function insertCommunityFork(
 			row.listing_name,
 			row.listing_kody_id,
 			row.created_at ?? new Date().toISOString(),
+			row.actor ?? null,
 		)
 		.run()
 }

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -75,6 +75,7 @@ import {
 	findCommunityIconPath,
 } from './community-icon.ts'
 import {
+	type CommunityForkActor,
 	type CommunityListingRecord,
 	type CommunityListingWithAggregates,
 	type CommunityActivityKind,
@@ -871,6 +872,12 @@ export async function forkCommunityListing(input: {
 	 * confirmation and the fork cannot swap in unreviewed content.
 	 */
 	expectedPinnedCommit?: string
+	/**
+	 * Who is forking. One-click install in the web app is `human`; the
+	 * `community_fork` capability is `agent`. Recorded so activation metrics
+	 * can separate what a user chose from what their agent did on its own.
+	 */
+	actor?: CommunityForkActor | null
 }): Promise<ForkCommunityListingResult> {
 	await assertNotCommunityBanned(input.env.APP_DB, input.userId)
 
@@ -984,6 +991,7 @@ export async function forkCommunityListing(input: {
 			target_kody_id: targetKodyId,
 			listing_name: listing.name,
 			listing_kody_id: listing.kodyId,
+			actor: input.actor ?? null,
 		})
 		await enqueueRecordedCommunityActivity({
 			env: input.env,

--- a/packages/worker/src/community/types.ts
+++ b/packages/worker/src/community/types.ts
@@ -156,6 +156,13 @@ export type CommunityActivityRecord =
 			adaptationEffort: number
 	  })
 
+/**
+ * Who caused a fork: a person clicking install in the web app, or that
+ * person's agent calling `community_fork` over MCP. Null on rows created
+ * before the distinction was recorded.
+ */
+export type CommunityForkActor = 'human' | 'agent'
+
 export type CommunityForkRow = {
 	id: string
 	listing_id: string
@@ -167,6 +174,7 @@ export type CommunityForkRow = {
 	created_at: string
 	adopted_at: string | null
 	adoption_note: string | null
+	actor: CommunityForkActor | null
 }
 
 export type CommunityForkRecord = {

--- a/packages/worker/src/mcp/capabilities/community/fork.ts
+++ b/packages/worker/src/mcp/capabilities/community/fork.ts
@@ -55,6 +55,7 @@ export const communityForkCapability = defineDomainCapability(
 				expectedPackageScope,
 				listingId: args.listing_id,
 				kodyId: args.kody_id,
+				actor: 'agent',
 			})
 			return {
 				fork_id: result.forkId,

--- a/packages/worker/src/package-runtime/package-runtime-debug.ts
+++ b/packages/worker/src/package-runtime/package-runtime-debug.ts
@@ -1,4 +1,6 @@
 import { toJsonSafeValue } from '@kody-internal/shared/json-safe-value.ts'
+import { recordSuccessfulPackageRun } from '#worker/usage/activation.ts'
+
 export const packageRuntimeSurfaceValues = [
 	'export',
 	'subscription',
@@ -362,6 +364,16 @@ export async function finishPackageRuntimeRun(input: {
 			.run()
 	} catch (error) {
 		console.warn('package-runtime-debug-status-failed', error)
+	}
+
+	// Every package surface (export, job, subscription, app, service, workflow,
+	// retriever) finishes here, so this is the one place activation can observe
+	// a package actually working.
+	if (input.status === 'success') {
+		await recordSuccessfulPackageRun(input.env, {
+			userId: handle.userId,
+			packageId: handle.packageId,
+		})
 	}
 }
 

--- a/packages/worker/src/usage/activation.node.test.ts
+++ b/packages/worker/src/usage/activation.node.test.ts
@@ -1,0 +1,186 @@
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	recordActivationMilestone,
+	recordSuccessfulPackageRun,
+} from './activation.ts'
+
+function createActivationDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(
+		readFileSync(
+			new URL(
+				'../../migrations/0037-package-runtime-debug.sql',
+				import.meta.url,
+			),
+			'utf8',
+		),
+	)
+	sqlite.exec(`
+		CREATE TABLE user_activation_milestones (
+			user_id TEXT NOT NULL,
+			milestone TEXT NOT NULL CHECK (
+				milestone IN ('package_run_succeeded', 'package_activated')
+			),
+			reached_at TEXT NOT NULL,
+			package_id TEXT,
+			PRIMARY KEY (user_id, milestone)
+		);
+	`)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function insertRun(
+	sqlite: DatabaseSync,
+	input: {
+		id: string
+		userId: string
+		packageId: string
+		status: 'success' | 'error'
+		startedAt: string
+	},
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO package_runtime_runs (
+				id, user_id, package_id, package_kody_id, surface, status,
+				started_at, created_at, updated_at
+			) VALUES (?, ?, ?, 'kody-id', 'job', ?, ?, ?, ?)`,
+		)
+		.run(
+			input.id,
+			input.userId,
+			input.packageId,
+			input.status,
+			input.startedAt,
+			input.startedAt,
+			input.startedAt,
+		)
+}
+
+function listMilestones(sqlite: DatabaseSync, userId: string) {
+	return sqlite
+		.prepare(
+			`SELECT milestone, package_id FROM user_activation_milestones
+			 WHERE user_id = ? ORDER BY milestone`,
+		)
+		.all(userId) as Array<{ milestone: string; package_id: string | null }>
+}
+
+test('activation requires the same package to succeed twice', async () => {
+	const { sqlite, db } = createActivationDb()
+	const env = { APP_DB: db }
+
+	insertRun(sqlite, {
+		id: 'run-1',
+		userId: 'user-1',
+		packageId: 'pkg-a',
+		status: 'success',
+		startedAt: '2026-07-01T00:00:00.000Z',
+	})
+	await recordSuccessfulPackageRun(env, {
+		userId: 'user-1',
+		packageId: 'pkg-a',
+	})
+	expect(listMilestones(sqlite, 'user-1').map((row) => row.milestone)).toEqual([
+		'package_run_succeeded',
+	])
+
+	// A different package succeeding once is still a user in setup, not a user
+	// with something working unattended.
+	insertRun(sqlite, {
+		id: 'run-2',
+		userId: 'user-1',
+		packageId: 'pkg-b',
+		status: 'success',
+		startedAt: '2026-07-02T00:00:00.000Z',
+	})
+	await recordSuccessfulPackageRun(env, {
+		userId: 'user-1',
+		packageId: 'pkg-b',
+	})
+	expect(listMilestones(sqlite, 'user-1').map((row) => row.milestone)).toEqual([
+		'package_run_succeeded',
+	])
+
+	insertRun(sqlite, {
+		id: 'run-3',
+		userId: 'user-1',
+		packageId: 'pkg-a',
+		status: 'success',
+		startedAt: '2026-07-03T00:00:00.000Z',
+	})
+	await recordSuccessfulPackageRun(env, {
+		userId: 'user-1',
+		packageId: 'pkg-a',
+	})
+	expect(listMilestones(sqlite, 'user-1')).toEqual([
+		{ milestone: 'package_activated', package_id: 'pkg-a' },
+		{ milestone: 'package_run_succeeded', package_id: 'pkg-a' },
+	])
+})
+
+test('milestones keep their first timestamp and failed runs never activate', async () => {
+	const { sqlite, db } = createActivationDb()
+	const env = { APP_DB: db }
+
+	await recordActivationMilestone(env, {
+		userId: 'user-2',
+		milestone: 'package_run_succeeded',
+		packageId: 'pkg-a',
+		reachedAt: '2026-07-01T00:00:00.000Z',
+	})
+	await recordActivationMilestone(env, {
+		userId: 'user-2',
+		milestone: 'package_run_succeeded',
+		packageId: 'pkg-z',
+		reachedAt: '2026-07-09T00:00:00.000Z',
+	})
+	const row = sqlite
+		.prepare(
+			`SELECT reached_at, package_id FROM user_activation_milestones
+			 WHERE user_id = 'user-2' AND milestone = 'package_run_succeeded'`,
+		)
+		.get() as { reached_at: string; package_id: string }
+	expect(row).toEqual({
+		reached_at: '2026-07-01T00:00:00.000Z',
+		package_id: 'pkg-a',
+	})
+
+	// Two failed runs of one package must not count toward activation.
+	insertRun(sqlite, {
+		id: 'run-e1',
+		userId: 'user-3',
+		packageId: 'pkg-c',
+		status: 'error',
+		startedAt: '2026-07-01T00:00:00.000Z',
+	})
+	insertRun(sqlite, {
+		id: 'run-e2',
+		userId: 'user-3',
+		packageId: 'pkg-c',
+		status: 'error',
+		startedAt: '2026-07-02T00:00:00.000Z',
+	})
+	await recordSuccessfulPackageRun(env, {
+		userId: 'user-3',
+		packageId: 'pkg-c',
+	})
+	expect(listMilestones(sqlite, 'user-3').map((row) => row.milestone)).toEqual([
+		'package_run_succeeded',
+	])
+})
+
+test('activation instrumentation never throws without a database', async () => {
+	await expect(
+		recordSuccessfulPackageRun({}, { userId: 'user-1', packageId: 'pkg-a' }),
+	).resolves.toBeUndefined()
+	await expect(
+		recordActivationMilestone(
+			{},
+			{ userId: 'user-1', milestone: 'package_activated' },
+		),
+	).resolves.toBeUndefined()
+})

--- a/packages/worker/src/usage/activation.ts
+++ b/packages/worker/src/usage/activation.ts
@@ -1,0 +1,119 @@
+/**
+ * Activation milestones.
+ *
+ * Activation is "a package that ran successfully at least twice" — the point
+ * where a user has something durable working unattended, rather than something
+ * they got running once during setup.
+ *
+ * Only run-derived milestones live here. Signup, verification, agent
+ * connection, and first fork are all derivable from durable tables and are
+ * read directly by the insights dashboard; storing them again would create two
+ * sources of truth. Run history is different: `package_runtime_runs` is
+ * retention-pruned, so a milestone that is not captured when it happens cannot
+ * be recovered.
+ *
+ * Like `recordUsage`, these writes never throw. Instrumentation must not break
+ * the paths it observes.
+ */
+
+export type ActivationMilestone = 'package_run_succeeded' | 'package_activated'
+
+export type ActivationEnv = { APP_DB?: D1Database }
+
+const insertMilestoneStatement = `
+INSERT OR IGNORE INTO user_activation_milestones (
+	user_id, milestone, reached_at, package_id
+) VALUES (?1, ?2, ?3, ?4)
+`.trim()
+
+const countSuccessfulRunsStatement = `
+SELECT COUNT(*) AS n
+FROM package_runtime_runs
+WHERE user_id = ?1 AND package_id = ?2 AND status = 'success'
+`.trim()
+
+const hasMilestoneStatement = `
+SELECT 1 AS n
+FROM user_activation_milestones
+WHERE user_id = ?1 AND milestone = ?2
+`.trim()
+
+/**
+ * Record one milestone for one user. Idempotent: the first write wins, so
+ * `reached_at` always reflects when the user first got there.
+ */
+export async function recordActivationMilestone(
+	env: ActivationEnv,
+	input: {
+		userId: string
+		milestone: ActivationMilestone
+		packageId?: string | null
+		reachedAt?: string
+	},
+): Promise<void> {
+	if (!env.APP_DB || !input.userId) return
+	try {
+		await env.APP_DB.prepare(insertMilestoneStatement)
+			.bind(
+				input.userId,
+				input.milestone,
+				input.reachedAt ?? new Date().toISOString(),
+				input.packageId ?? null,
+			)
+			.run()
+	} catch (error) {
+		console.warn('activation-milestone-failed', error)
+	}
+}
+
+/**
+ * Called after a package run finishes successfully.
+ *
+ * Records the first successful run, and promotes the user to activated once
+ * any single package has succeeded twice. Both milestones are terminal, so
+ * once a user is activated this costs one indexed lookup that returns a row
+ * and nothing else runs.
+ */
+export async function recordSuccessfulPackageRun(
+	env: ActivationEnv,
+	input: { userId: string; packageId: string },
+): Promise<void> {
+	if (!env.APP_DB || !input.userId || !input.packageId) return
+	try {
+		if (await hasMilestone(env, input.userId, 'package_activated')) return
+
+		await recordActivationMilestone(env, {
+			userId: input.userId,
+			milestone: 'package_run_succeeded',
+			packageId: input.packageId,
+		})
+
+		// Counted per package rather than per user: two different packages that
+		// each ran once is a user still in setup, not a user with something
+		// working.
+		const row = await env.APP_DB.prepare(countSuccessfulRunsStatement)
+			.bind(input.userId, input.packageId)
+			.first<{ n: number }>()
+		if (Number(row?.n ?? 0) < 2) return
+
+		await recordActivationMilestone(env, {
+			userId: input.userId,
+			milestone: 'package_activated',
+			packageId: input.packageId,
+		})
+	} catch (error) {
+		console.warn('activation-run-record-failed', error)
+	}
+}
+
+async function hasMilestone(
+	env: ActivationEnv,
+	userId: string,
+	milestone: ActivationMilestone,
+) {
+	if (!env.APP_DB) return false
+	const row = await env.APP_DB.prepare(hasMilestoneStatement)
+		.bind(userId, milestone)
+		.first<{ n: number }>()
+	return row != null
+}

--- a/tools/check-migrations.node.test.ts
+++ b/tools/check-migrations.node.test.ts
@@ -139,8 +139,8 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 	).toMatchObject({
 		ok: true,
 		errors: [],
-		nextPrefix: '0094',
-		maxPrefix: 93,
+		nextPrefix: '0095',
+		maxPrefix: 94,
 	})
 
 	const modifiedFiles = baselineFiles.map((entry) =>
@@ -199,7 +199,7 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 	])
 
 	const monotonicAddition: MigrationLedgerEntry = {
-		filename: '0094-normal-addition.sql',
+		filename: '0095-normal-addition.sql',
 		sha256: '2'.repeat(64),
 	}
 	const ledgerWithMonotonicAddition = structuredClone(ledger)
@@ -213,8 +213,8 @@ test('migration ledger rejects historical mutation and lower-prefix additions wh
 	).toMatchObject({
 		ok: true,
 		errors: [],
-		nextPrefix: '0095',
-		maxPrefix: 94,
+		nextPrefix: '0096',
+		maxPrefix: 95,
 	})
 })
 
@@ -222,11 +222,11 @@ test('trusted history rejects a migration and ledger digest co-edit', async () =
 	const ledger = await readMigrationLedger()
 	const bootstrapFiles = ledger.migrations.map((entry) => ({ ...entry }))
 	const historicalEntry = {
-		filename: '0094-historical.sql',
+		filename: '0095-historical.sql',
 		sha256: hashMigrationContent('SELECT 1;\n'),
 	}
 	const trustedHistory: TrustedMigrationHistory = {
-		ref: 'trusted-base-with-0094',
+		ref: 'trusted-base-with-0095',
 		files: [...bootstrapFiles, historicalEntry],
 		ledgerEntries: [...bootstrapFiles, historicalEntry],
 	}
@@ -244,7 +244,7 @@ test('trusted history rejects a migration and ledger digest co-edit', async () =
 	)
 	expect(result.ok).toBe(false)
 	expectErrorsMention(result.errors, [
-		'0094-historical.sql',
+		'0095-historical.sql',
 		'Historical ledger entries cannot be edited',
 		'differs from trusted history',
 		'Migration and ledger digests cannot be changed together',

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -399,6 +399,10 @@
 		{
 			"filename": "0093-stripe-webhook-events.sql",
 			"sha256": "59f95b476e4ac07d0c29b4d33426f65122756abaa030d685843d53b2b429b587"
+		},
+		{
+			"filename": "0094-activation-milestones.sql",
+			"sha256": "a267e2c1bbebf52168acd189124fc393c85165d1df6a71046be7aeefd83e5caf"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
We agreed activation is **a package that ran successfully at least twice** — the point where someone has something working unattended, rather than something they got running once during setup. This makes that measurable.

Baseline is perishable: every onboarding change from here on is unfalsifiable without a before. That's why this lands first.

## What needed new storage, and what didn't

Most funnel steps were already derivable, so they're read where they live rather than duplicated:

| Step | Source |
| --- | --- |
| Signed up / verified | `users` |
| Connected an agent | `mcp_agent_sessions` |
| Forked a package | `community_forks` |

Two things were not derivable.

**Run-derived milestones.** `package_runtime_runs` is retention-pruned (`packages/worker/src/app/retention.ts`), so a milestone not captured when it happens cannot be recovered. `user_activation_milestones` records them once, on the way past. The migration backfills from the runs that still survive — that under-counts, and a partial baseline beats none.

**Fork actor.** A person clicking install and that person's agent calling `community_fork` were the same row. They are not the same activation signal, and we have a concrete reason to care: at least one 5-star community rating was left by a user's agent *without the user knowing*. Agent activity will inflate these numbers if it isn't separated. `community_forks.actor` is now set by both call paths — `install.ts` defaults to `human`, the MCP capability passes `agent`. Existing rows stay NULL because their origin is genuinely unknown.

Activation is counted **per package**, not per user: two different packages that each ran once is a user still in setup, not a user with something working.

## Dashboard

![Activation funnel and fork actor breakdown on /admin/insights](https://cursor.com/artifacts/c/art-1d77ba87-a6d9-4b1c-a97e-75521b99a6d2)

Seeded local data. The funnel is scaled against signups so drop-off is the thing you see, and the median is measured from email verification rather than signup so invite lag doesn't pollute it.

Manual testing caught one bug worth calling out: the subtitle read "Nobody has activated yet" while the funnel directly below showed two activated users. Backfilled milestones have no verification date to measure from, so a null median doesn't mean nobody activated. Fixed in the second commit, with a regression test.

## Validation

`npm run validate` passes clean — `format:check`, `lint`, `typecheck`, 1290 unit tests, Playwright E2E, MCP E2E, `primitives:check`, `migrations:check` all exit 0. Migration `0093` applies cleanly against a from-scratch local D1 (all 99 migrations).

The repo's schema-coverage guardrails did their job here and required `user_activation_milestones` to be registered in `accountUserDataTargets`, so the new table is covered by account deletion and export like every other user-owned table.

Note: `search-hidden-packages` and `meta-list-capabilities` intermittently hit the 5s vitest timeout when validate runs alongside a dev server and browser. Both pass in isolation and in a quiet run; unrelated to this change, but worth knowing if CI is ever noisy on those two.

## Follow-ups not in this PR

Time-to-activation is only measurable going forward for users who verify after this deploys. And `agent_connected` counts anyone with an MCP session row, which is a connection rather than a successful first call — worth tightening if that step turns out to be the drop-off the feedback suggests it is.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d6cfa42-3c7e-489d-a190-5ef4c4e034ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d6cfa42-3c7e-489d-a190-5ef4c4e034ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added activation milestone tracking, including successful package runs and package activation.
  - Added an Admin Insights activation funnel with activation timing metrics.
  - Added a “Who forks packages” breakdown distinguishing human and agent activity.
  - Package installations now record whether they were initiated by a person or an agent.

- **Bug Fixes**
  - Improved activation metrics when timing data is unavailable.
  - Preserved activation history during account data management operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->