### PR TITLE
fix(dr): make D1 restore imports FK-safe with foreign_keys=OFF prelude

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -188,6 +188,13 @@ Creates `kody-dr-drill-{day}-{hex}` in `DRILL_ACCOUNT_ID` (must differ from
 success (keeps it on failure for inspection). This path does not restore
 StorageRunner/R2/artifacts into production.
 
+D1 remote import enforces foreign keys while applying `CREATE TABLE`, but
+Cloudflare exports are not topologically ordered. Before upload, the control
+plane verifies the unmodified SQL MD5 against the signed manifest R2 ETag, then
+prefixes `PRAGMA foreign_keys=OFF;` and uses the prepared body's MD5 for the D1
+import init/ingest etag. Without that prelude, drills fail with errors like
+`no such table: main.users`.
+
 ### Graduated production restore
 
 1. **Prepare** — sealed full manifest + D1 manifest signatures must verify; UI

--- a/packages/backup-control-plane/d1-import-api.node.test.ts
+++ b/packages/backup-control-plane/d1-import-api.node.test.ts
@@ -1,32 +1,72 @@
 import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
 
 import { test, vi } from 'vitest'
 
-import { importSqlIntoD1 } from './d1-import-api.ts'
+import {
+	d1ImportForeignKeysOffPrefix,
+	importSqlIntoD1,
+	prepareD1ImportUpload,
+} from './d1-import-api.ts'
 import { BackupError } from './backup-policy.ts'
 
 const ACCOUNT = '11111111-1111-4111-8111-111111111111'
 const DATABASE = '22222222-2222-4222-8222-222222222222'
-const MD5 = 'a'.repeat(32)
+const SOURCE_SQL = 'CREATE TABLE t(id INTEGER);\n'
+const SOURCE_MD5 = createHash('md5').update(SOURCE_SQL).digest('hex')
+const UPLOAD_MD5 = createHash('md5')
+	.update(d1ImportForeignKeysOffPrefix)
+	.update(SOURCE_SQL)
+	.digest('hex')
 
 function importPollSequence(pollResponses: Array<unknown>) {
 	let phase: 'init' | 'upload' | 'ingest' | 'poll' = 'init'
 	let pollIndex = 0
+	let uploadedText: string | null = null
+	let initEtag: string | null = null
 	const fetcher: typeof fetch = async (input, init) => {
 		const url = String(input)
 		if (url.includes('upload.example')) {
 			phase = 'ingest'
+			const body = init?.body
+			if (typeof body === 'string') {
+				uploadedText = body
+			} else if (body instanceof Uint8Array) {
+				uploadedText = new TextDecoder().decode(body)
+			} else if (body instanceof ArrayBuffer) {
+				uploadedText = new TextDecoder().decode(body)
+			} else if (body instanceof ReadableStream) {
+				const reader = body.getReader()
+				const chunks: Array<Uint8Array> = []
+				for (;;) {
+					const { done, value } = await reader.read()
+					if (done) break
+					if (value) chunks.push(value)
+				}
+				const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0)
+				const merged = new Uint8Array(total)
+				let offset = 0
+				for (const chunk of chunks) {
+					merged.set(chunk, offset)
+					offset += chunk.byteLength
+				}
+				uploadedText = new TextDecoder().decode(merged)
+			} else {
+				throw new Error(`unexpected upload body type: ${typeof body}`)
+			}
 			return new Response(null, {
 				status: 200,
-				headers: { etag: `"${MD5}"` },
+				headers: { etag: `"${UPLOAD_MD5}"` },
 			})
 		}
 		const body = JSON.parse(String(init?.body ?? '{}')) as {
 			action?: string
+			etag?: string
 		}
 		switch (body.action) {
 			case 'init':
 				phase = 'upload'
+				initEtag = typeof body.etag === 'string' ? body.etag : null
 				return Response.json({
 					success: true,
 					result: {
@@ -55,10 +95,43 @@ function importPollSequence(pollResponses: Array<unknown>) {
 	return {
 		fetcher,
 		getPollCount: () => pollIndex,
+		getUploadedText: () => uploadedText,
+		getInitEtag: () => initEtag,
 	}
 }
 
-test('importSqlIntoD1 completes on terminal status and final bookmark shapes', async () => {
+test('prepareD1ImportUpload verifies source MD5 and prefixes foreign_keys=OFF', async () => {
+	let loads = 0
+	const prepared = await prepareD1ImportUpload({
+		sourceMd5Etag: SOURCE_MD5,
+		loadSqlBody: async () => {
+			loads += 1
+			return SOURCE_SQL
+		},
+	})
+	assert.equal(loads, 2)
+	assert.equal(prepared.uploadMd5Hex, UPLOAD_MD5)
+	assert.equal(prepared.sourceBytes, SOURCE_SQL.length)
+	assert.ok(prepared.uploadBody instanceof Uint8Array)
+	assert.equal(
+		new TextDecoder().decode(prepared.uploadBody),
+		`${d1ImportForeignKeysOffPrefix}${SOURCE_SQL}`,
+	)
+})
+
+test('prepareD1ImportUpload rejects source MD5 mismatches', async () => {
+	await assert.rejects(
+		prepareD1ImportUpload({
+			sourceMd5Etag: 'b'.repeat(32),
+			loadSqlBody: async () => SOURCE_SQL,
+		}),
+		(error: unknown) =>
+			error instanceof BackupError &&
+			error.code === 'import-source-etag-mismatch',
+	)
+})
+
+test('importSqlIntoD1 uploads FK-off-prefixed SQL and uses its MD5', async () => {
 	for (const pollResponses of [
 		[
 			{ type: 'import', success: true, status: 'active' },
@@ -78,8 +151,8 @@ test('importSqlIntoD1 completes on terminal status and final bookmark shapes', a
 			accountId: ACCOUNT,
 			databaseId: DATABASE,
 			token: 'token',
-			sqlBody: 'CREATE TABLE t(id INTEGER);\n',
-			md5Etag: MD5,
+			sourceMd5Etag: SOURCE_MD5,
+			loadSqlBody: async () => SOURCE_SQL,
 			options: {
 				fetcher: sequence.fetcher,
 				sleep: async () => undefined,
@@ -88,7 +161,46 @@ test('importSqlIntoD1 completes on terminal status and final bookmark shapes', a
 			},
 		})
 		assert.equal(sequence.getPollCount(), 2)
+		assert.equal(sequence.getInitEtag(), UPLOAD_MD5)
+		assert.equal(
+			sequence.getUploadedText(),
+			`${d1ImportForeignKeysOffPrefix}${SOURCE_SQL}`,
+		)
 	}
+})
+
+test('importSqlIntoD1 streams reopen through loadSqlBody without buffering the source twice in one handle', async () => {
+	const sequence = importPollSequence([
+		{ type: 'import', success: true, status: 'complete' },
+	])
+	let loads = 0
+	await importSqlIntoD1({
+		accountId: ACCOUNT,
+		databaseId: DATABASE,
+		token: 'token',
+		sourceMd5Etag: SOURCE_MD5,
+		loadSqlBody: async () => {
+			loads += 1
+			return new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode(SOURCE_SQL))
+					controller.close()
+				},
+			})
+		},
+		options: {
+			fetcher: sequence.fetcher,
+			sleep: async () => undefined,
+			maxPollAttempts: 2,
+			pollDelayMs: 1,
+		},
+	})
+	assert.equal(loads, 2)
+	assert.equal(sequence.getInitEtag(), UPLOAD_MD5)
+	assert.equal(
+		sequence.getUploadedText(),
+		`${d1ImportForeignKeysOffPrefix}${SOURCE_SQL}`,
+	)
 })
 
 test('importSqlIntoD1 fails closed on non-terminal, expired, and error polls', async () => {
@@ -130,8 +242,8 @@ test('importSqlIntoD1 fails closed on non-terminal, expired, and error polls', a
 				accountId: ACCOUNT,
 				databaseId: DATABASE,
 				token: 'token',
-				sqlBody: 'CREATE TABLE t(id INTEGER);\n',
-				md5Etag: MD5,
+				sourceMd5Etag: SOURCE_MD5,
+				loadSqlBody: async () => SOURCE_SQL,
 				options: {
 					fetcher: sequence.fetcher,
 					sleep: async () => undefined,

--- a/packages/backup-control-plane/d1-import-api.ts
+++ b/packages/backup-control-plane/d1-import-api.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import { BackupError } from './backup-policy.ts'
 import { type ApiOptions, classifyHttpStatus } from './d1-export-api.ts'
 
@@ -9,6 +11,16 @@ const DEFAULT_REQUEST_ATTEMPTS = 5
 const MAX_RETRY_DELAY = 60_000
 const DEFAULT_POLL_ATTEMPTS = 120
 const DEFAULT_POLL_DELAY_MS = 2_000
+
+/**
+ * D1 remote import enforces foreign keys while applying CREATE TABLE. Cloudflare
+ * exports are not topologically ordered, so FK references to later tables
+ * (e.g. `users`) fail with `no such table`. `PRAGMA foreign_keys=OFF` must be
+ * the first statement — see cloudflare/workers-sdk#5683 / #9349.
+ */
+export const d1ImportForeignKeysOffPrefix = 'PRAGMA foreign_keys=OFF;\n'
+
+export type D1ImportSqlBody = ReadableStream<Uint8Array> | Uint8Array | string
 
 function isObject(value: unknown): value is JsonObject {
 	return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -249,12 +261,139 @@ function hexMd5FromR2Etag(etag: string): string {
 	return trimmed
 }
 
+function toUint8Array(body: string | Uint8Array): Uint8Array {
+	return typeof body === 'string' ? new TextEncoder().encode(body) : body
+}
+
+async function consumeSqlBodyForHashes(
+	body: D1ImportSqlBody,
+	prefix: Uint8Array,
+): Promise<{
+	sourceMd5Hex: string
+	uploadMd5Hex: string
+	sourceBytes: number
+}> {
+	const sourceHash = createHash('md5')
+	const uploadHash = createHash('md5')
+	uploadHash.update(prefix)
+	let sourceBytes = 0
+
+	if (typeof body === 'string' || body instanceof Uint8Array) {
+		const bytes = toUint8Array(body)
+		sourceHash.update(bytes)
+		uploadHash.update(bytes)
+		sourceBytes = bytes.byteLength
+	} else {
+		const reader = body.getReader()
+		for (;;) {
+			const { done, value } = await reader.read()
+			if (done) break
+			if (value === undefined) continue
+			sourceHash.update(value)
+			uploadHash.update(value)
+			sourceBytes += value.byteLength
+		}
+	}
+
+	if (sourceBytes === 0) {
+		throw new BackupError('import-sql-empty', 'Backup SQL body is empty')
+	}
+
+	return {
+		sourceMd5Hex: sourceHash.digest('hex'),
+		uploadMd5Hex: uploadHash.digest('hex'),
+		sourceBytes,
+	}
+}
+
+function prependForeignKeysOffStream(
+	prefix: Uint8Array,
+	body: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		async start(controller) {
+			controller.enqueue(prefix)
+			const reader = body.getReader()
+			try {
+				for (;;) {
+					const { done, value } = await reader.read()
+					if (done) break
+					if (value !== undefined) controller.enqueue(value)
+				}
+				controller.close()
+			} catch (error) {
+				controller.error(error)
+				await reader.cancel(error)
+			}
+		},
+		cancel(reason) {
+			return body.cancel(reason)
+		},
+	})
+}
+
+/**
+ * Verify the unmodified backup SQL MD5, then build the FK-safe upload body and
+ * its MD5. Streams are loaded twice via `loadSqlBody` so large backups are not
+ * buffered in Worker memory.
+ */
+export async function prepareD1ImportUpload(input: {
+	sourceMd5Etag: string
+	loadSqlBody: () => Promise<D1ImportSqlBody>
+}): Promise<{
+	uploadBody: BodyInit
+	uploadMd5Hex: string
+	sourceBytes: number
+}> {
+	const expectedSourceMd5 = hexMd5FromR2Etag(input.sourceMd5Etag)
+	const prefix = new TextEncoder().encode(d1ImportForeignKeysOffPrefix)
+	const first = await input.loadSqlBody()
+	const hashes = await consumeSqlBodyForHashes(first, prefix)
+	if (hashes.sourceMd5Hex !== expectedSourceMd5) {
+		throw new BackupError(
+			'import-source-etag-mismatch',
+			'Backup SQL MD5 did not match the signed manifest R2 ETag',
+		)
+	}
+
+	const second = await input.loadSqlBody()
+	if (typeof second === 'string' || second instanceof Uint8Array) {
+		const sourceBytes = toUint8Array(second)
+		const uploadBytes = new Uint8Array(
+			prefix.byteLength + sourceBytes.byteLength,
+		)
+		uploadBytes.set(prefix, 0)
+		uploadBytes.set(sourceBytes, prefix.byteLength)
+		return {
+			uploadBody: uploadBytes,
+			uploadMd5Hex: hashes.uploadMd5Hex,
+			sourceBytes: hashes.sourceBytes,
+		}
+	}
+
+	return {
+		uploadBody: prependForeignKeysOffStream(prefix, second),
+		uploadMd5Hex: hashes.uploadMd5Hex,
+		sourceBytes: hashes.sourceBytes,
+	}
+}
+
 export async function importSqlIntoD1(input: {
 	accountId: string
 	databaseId: string
 	token: string
-	sqlBody: ReadableStream<Uint8Array> | Uint8Array | string
-	md5Etag: string
+	/**
+	 * Expected MD5 (R2 ETag) of the *unmodified* backup SQL from the signed
+	 * manifest. The bytes uploaded to D1 are prefixed with
+	 * {@link d1ImportForeignKeysOffPrefix}; their MD5 is derived after that
+	 * verify step.
+	 */
+	sourceMd5Etag: string
+	/**
+	 * Load unmodified backup SQL. Invoked twice (hash/verify, then upload) so
+	 * stream bodies do not need to be fully buffered.
+	 */
+	loadSqlBody: () => Promise<D1ImportSqlBody>
 	options?: ApiOptions & {
 		maxPollAttempts?: number
 		pollDelayMs?: number
@@ -264,7 +403,11 @@ export async function importSqlIntoD1(input: {
 	const fetcher = options.fetcher ?? fetch
 	const sleep =
 		options.sleep ?? ((milliseconds) => scheduler.wait(milliseconds))
-	const etag = hexMd5FromR2Etag(input.md5Etag)
+	const prepared = await prepareD1ImportUpload({
+		sourceMd5Etag: input.sourceMd5Etag,
+		loadSqlBody: input.loadSqlBody,
+	})
+	const etag = prepared.uploadMd5Hex
 	const url = importUrl(input.accountId, input.databaseId)
 
 	const initResult = await apiJson(
@@ -290,7 +433,7 @@ export async function importSqlIntoD1(input: {
 	try {
 		uploadResponse = await fetcher(initResult.upload_url, {
 			method: 'PUT',
-			body: input.sqlBody as BodyInit,
+			body: prepared.uploadBody,
 		})
 	} catch {
 		throw new BackupError(
@@ -313,7 +456,7 @@ export async function importSqlIntoD1(input: {
 	) {
 		throw new BackupError(
 			'import-etag-mismatch',
-			'D1 import upload ETag did not match the SQL digest',
+			'D1 import upload ETag did not match the prepared SQL digest',
 		)
 	}
 

--- a/packages/backup-control-plane/production-restore.node.test.ts
+++ b/packages/backup-control-plane/production-restore.node.test.ts
@@ -13,6 +13,7 @@ import {
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
 import { backupPayload } from './backup-policy.ts'
+import { d1ImportForeignKeysOffPrefix } from './d1-import-api.ts'
 import { signBackupFullManifest } from './full-manifest-signing.ts'
 import { putImmutableManifest } from './immutable-storage.ts'
 import { runProductionRestore } from './production-restore.ts'
@@ -26,6 +27,10 @@ async function seedSealedRestoreDay(bucket: MemoryBucket, day = '2026-07-22') {
 	const d1Payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
 	const sqlBody = 'CREATE TABLE t(id INTEGER);\n'
 	const sqlMd5 = createHash('md5').update(sqlBody).digest('hex')
+	const preparedImportMd5 = createHash('md5')
+		.update(d1ImportForeignKeysOffPrefix)
+		.update(sqlBody)
+		.digest('hex')
 	const template = manifest({
 		bytes: sqlBody.length,
 		sha256: sha256Text(sqlBody),
@@ -65,14 +70,14 @@ async function seedSealedRestoreDay(bucket: MemoryBucket, day = '2026-07-22') {
 		sealedFullManifestKey(day),
 		serializeBackupFullManifest(full),
 	)
-	return { env, day, sqlMd5 }
+	return { env, day, preparedImportMd5 }
 }
 
 test('runProductionRestore returns failed progress when dr-restore emits warnings', async () => {
 	const consoleError = vi.spyOn(console, 'error')
 	consoleError.mockImplementation(() => undefined)
 	const bucket = new MemoryBucket()
-	const { env, day, sqlMd5 } = await seedSealedRestoreDay(bucket)
+	const { env, day, preparedImportMd5 } = await seedSealedRestoreDay(bucket)
 	let exportCalls = 0
 	const sql = 'CREATE TABLE safety(id INTEGER);\n'
 	const progress = await runProductionRestore(
@@ -123,7 +128,7 @@ test('runProductionRestore returns failed progress when dr-restore emits warning
 				if (url.includes('upload.example')) {
 					return new Response(null, {
 						status: 200,
-						headers: { etag: `"${sqlMd5}"` },
+						headers: { etag: `"${preparedImportMd5}"` },
 					})
 				}
 				if (url.includes('/__maintenance/dr-restore')) {

--- a/packages/backup-control-plane/production-restore.ts
+++ b/packages/backup-control-plane/production-restore.ts
@@ -362,8 +362,8 @@ export async function runProductionRestore(
 	try {
 		await publish()
 		const validated = await validateSealedDayForRestore(env, payload.day)
-		const sqlObject = await env.BACKUP_BUCKET.get(validated.sqlObjectKey)
-		if (sqlObject === null) {
+		const sqlHead = await env.BACKUP_BUCKET.head(validated.sqlObjectKey)
+		if (sqlHead === null) {
 			throw new BackupError(
 				'restore-sql-missing',
 				`SQL object missing for ${payload.day}`,
@@ -406,8 +406,17 @@ export async function runProductionRestore(
 			accountId: env.SOURCE_ACCOUNT_ID,
 			databaseId: env.SOURCE_DATABASE_ID,
 			token: env.CLOUDFLARE_API_TOKEN,
-			sqlBody: sqlObject.body,
-			md5Etag: validated.sqlR2Etag,
+			sourceMd5Etag: validated.sqlR2Etag,
+			loadSqlBody: async () => {
+				const sqlObject = await env.BACKUP_BUCKET.get(validated.sqlObjectKey)
+				if (sqlObject?.body == null) {
+					throw new BackupError(
+						'restore-sql-missing',
+						`SQL object missing for ${payload.day}`,
+					)
+				}
+				return sqlObject.body
+			},
 			options,
 		})
 		progress.d1ImportComplete = true

--- a/packages/backup-control-plane/restore-drill.ts
+++ b/packages/backup-control-plane/restore-drill.ts
@@ -91,8 +91,9 @@ export async function runRestoreDrill(
 			`D1 manifest signature invalid for ${day}`,
 		)
 	}
-	const sqlObject = await env.BACKUP_BUCKET.get(manifest.payload.sql.objectKey)
-	if (sqlObject === null) {
+	const sqlObjectKey = manifest.payload.sql.objectKey
+	const sqlHead = await env.BACKUP_BUCKET.head(sqlObjectKey)
+	if (sqlHead === null) {
 		throw new BackupError('drill-sql-missing', `SQL object missing for ${day}`)
 	}
 
@@ -112,7 +113,7 @@ export async function runRestoreDrill(
 		event: 'restore-drill-started',
 		status: 'success',
 		day,
-		objectKey: manifest.payload.sql.objectKey,
+		objectKey: sqlObjectKey,
 	})
 
 	try {
@@ -127,8 +128,17 @@ export async function runRestoreDrill(
 			accountId,
 			databaseId: created.uuid,
 			token,
-			sqlBody: sqlObject.body,
-			md5Etag: manifest.payload.sql.r2Etag,
+			sourceMd5Etag: manifest.payload.sql.r2Etag,
+			loadSqlBody: async () => {
+				const sqlObject = await env.BACKUP_BUCKET.get(sqlObjectKey)
+				if (sqlObject?.body == null) {
+					throw new BackupError(
+						'drill-sql-missing',
+						`SQL object missing for ${day}`,
+					)
+				}
+				return sqlObject.body
+			},
 			options,
 		})
 		const quickCheckRows = await queryD1Database({

--- a/packages/backup-control-plane/wrangler.jsonc
+++ b/packages/backup-control-plane/wrangler.jsonc
@@ -3,6 +3,7 @@
 	"name": "kody-production-d1-backups",
 	"main": "./worker.ts",
 	"compatibility_date": "2026-07-22",
+	"compatibility_flags": ["nodejs_compat"],
 	"observability": {
 		"enabled": true,
 	},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Isolated restore drills were failing with `import-failed` / `no such table: main.users` because D1 remote import enforces foreign keys during `CREATE TABLE`, while Cloudflare D1 exports are not topologically ordered.

This change verifies the unmodified backup SQL MD5 against the signed manifest R2 ETag, then prefixes `PRAGMA foreign_keys=OFF;` and uses the **prepared** body's MD5 for D1 import init/ingest. Stream bodies are loaded twice via `loadSqlBody` so large backups are not fully buffered in Worker memory.

## Operator follow-up after merge

1. Redeploy the DR control-plane Worker (`packages/backup-control-plane`) to the KCD account (not app CI).
2. Re-run **Run isolated restore drill** for `2026-07-24` (or `2026-07-23`) at https://kody-dr.kentcdodds.com
3. Expect `PRAGMA quick_check` ok and cleanup of the drill DB.

## Test plan

- [x] `packages/backup-control-plane` unit tests (64) + typecheck
- [x] Pre-push / husky validate (unit, Playwright, etc.)
- [ ] Live drill after control-plane redeploy

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends the backup control plane</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0a57498b` · **Head:** `15818d8e`

**Classification:** extends — changes restore/drill D1 import behavior (FK-safe prepare + etag contract) inside the existing `backup-control-plane` primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | extends — D1 import verifies source MD5, prefixes `PRAGMA foreign_keys=OFF;`, uploads prepared MD5; drill + production restore call sites updated; `nodejs_compat` enabled for streaming MD5 |

### System map

```mermaid
flowchart LR
  manifest["signed D1 manifest<br/>sql.r2Etag / objectKey"]:::untouched
  r2["BACKUP_BUCKET SQL object"]:::untouched
  prepare["prepareD1ImportUpload<br/>verify source MD5 + FK-off prefix"]:::extended
  d1import["Cloudflare D1 import API"]:::untouched
  drill["isolated restore drill"]:::extended
  prodRestore["production restore Workflow"]:::extended
  manifest -->|"sourceMd5Etag"| prepare
  r2 -->|"loadSqlBody x2"| prepare
  prepare -->|"upload prepared SQL + MD5"| d1import
  drill --> prepare
  prodRestore --> prepare
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
  participant Drill as restore drill / production restore
  participant Prep as prepareD1ImportUpload
  participant R2 as BACKUP_BUCKET
  participant D1 as D1 import API
  Drill->>Prep: sourceMd5Etag + loadSqlBody
  Prep->>R2: load SQL hash pass
  Prep->>Prep: verify source MD5 equals manifest r2Etag
  Prep->>R2: load SQL upload pass
  Prep->>D1: init with prepared MD5
  Prep->>D1: PUT prepared body
  Prep->>D1: ingest and poll to complete
```

### Invariants

- Signed-manifest provenance still gates restore: unmodified SQL MD5 must match `payload.sql.r2Etag` before any transform.
- Upload etag is the prepared body digest, not the raw backup etag.
- Large backups stay stream-friendly (`loadSqlBody` twice; no full-buffer requirement for streams).
- Drill remains isolated to `DRILL_ACCOUNT_ID`; production restore path shares the same import prepare logic.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e5f0844-7242-453a-b99c-9f13125550d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5f0844-7242-453a-b99c-9f13125550d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * D1 restore imports now safely handle foreign-key dependencies by temporarily disabling foreign-key enforcement during import.
  * Restore workflows validate SQL backups before loading and retrieve SQL data only when needed.
  * Import integrity checks now distinguish the original backup checksum from the prepared upload checksum.
  * Restore logs include the SQL backup location for improved visibility.

* **Documentation**
  * Updated disaster recovery guidance with the revised isolated restore import process and related failure prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->