### PR TITLE
fix(mcp): Gemini-compatible OAuth handshake on /mcp

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -188,11 +188,29 @@ async function handleUserScopedConnectorRequest(request: Request, env: Env) {
 }
 
 const appHandler = withCors({
-	getCorsHeaders(request) {
+	getCorsHeaders(request): Record<string, string> | null {
 		const url = new URL(request.url)
 		const origin = request.headers.get('Origin')
 		if (!origin) return null
 		const requestOrigin = url.origin
+		// Remote MCP clients in browser hosts (Gemini custom apps, etc.) call
+		// `/mcp` cross-origin. Reflect any Origin and expose WWW-Authenticate so
+		// the client can read the OAuth challenge; same-origin stays the default
+		// for the rest of the app.
+		if (
+			url.pathname === mcpResourcePath ||
+			url.pathname === `${mcpResourcePath}/`
+		) {
+			return {
+				'Access-Control-Allow-Origin': origin,
+				'Access-Control-Allow-Methods': 'GET, HEAD, POST, DELETE, OPTIONS',
+				'Access-Control-Allow-Headers':
+					'Authorization, Content-Type, Accept, MCP-Protocol-Version, Last-Event-ID, Mcp-Session-Id',
+				'Access-Control-Expose-Headers':
+					'WWW-Authenticate, MCP-Session-Id, Content-Type',
+				Vary: 'Origin',
+			}
+		}
 		if (origin !== requestOrigin) return null
 		return {
 			'Access-Control-Allow-Origin': origin,
@@ -319,6 +337,14 @@ const appHandler = withCors({
 
 		if (isProtectedResourceMetadataRequest(url.pathname)) {
 			return handleProtectedResourceMetadata(request, env)
+		}
+
+		// Trailing-slash variants 404 otherwise; some MCP client docs (and paste
+		// habits) include the slash. Keep the protected resource at `/mcp`.
+		if (url.pathname === `${mcpResourcePath}/`) {
+			const canonical = new URL(request.url)
+			canonical.pathname = mcpResourcePath
+			return Response.redirect(canonical.toString(), 308)
 		}
 
 		if (url.pathname === mcpResourcePath) {

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -37,6 +37,11 @@ export function buildProtectedResourceMetadata(origin: string) {
 		resource: `${origin}${mcpResourcePath}`,
 		authorization_servers: [origin],
 		scopes_supported: oauthScopes,
+		// Match @cloudflare/workers-oauth-provider's path-based metadata document.
+		// Browser MCP clients (Gemini custom apps, etc.) fetch the root PRM from
+		// WWW-Authenticate; omitting this field leaves header-bearer support
+		// ambiguous and has broken Gemini's pre-DCR handshake in production.
+		bearer_methods_supported: ['header'],
 	}
 }
 
@@ -65,12 +70,22 @@ function buildWwwAuthenticateHeader(origin: string) {
 }
 
 function createUnauthorizedResponse(origin: string) {
-	return new Response(null, {
-		status: 401,
-		headers: {
-			'WWW-Authenticate': buildWwwAuthenticateHeader(origin),
+	// Keep a JSON body in addition to WWW-Authenticate. Some remote MCP clients
+	// (notably Gemini custom connected apps) treat an empty 401 as a hard
+	// connectivity failure and never start OAuth discovery / DCR.
+	return Response.json(
+		{
+			error: 'invalid_token',
+			error_description:
+				'Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer.',
 		},
-	})
+		{
+			status: 401,
+			headers: {
+				'WWW-Authenticate': buildWwwAuthenticateHeader(origin),
+			},
+		},
+	)
 }
 
 export function createEmailVerificationRequiredResponse(origin: string) {

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -315,6 +315,14 @@ test('protected resource metadata and auth challenge resolve origin consistently
 		fetchMcp: () => new Response('ok'),
 	})
 	expect(requestOriginUnauthorizedResponse.status).toBe(401)
+	expect(requestOriginUnauthorizedResponse.headers.get('Content-Type')).toMatch(
+		/application\/json/,
+	)
+	expect(await requestOriginUnauthorizedResponse.json()).toEqual({
+		error: 'invalid_token',
+		error_description:
+			'Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer.',
+	})
 	expectAuthenticateHeader(
 		requestOriginUnauthorizedResponse.headers.get('WWW-Authenticate') ?? '',
 		requestOrigin,
@@ -333,6 +341,12 @@ test('protected resource metadata and auth challenge resolve origin consistently
 		appBaseUrlUnauthorizedResponse.headers.get('WWW-Authenticate') ?? '',
 		workersDevOrigin,
 	)
+})
+
+test('protected resource metadata advertises header bearer methods', () => {
+	const metadata = buildProtectedResourceMetadata('https://example.com')
+	expect(metadata.bearer_methods_supported).toEqual(['header'])
+	expect(metadata.resource).toBe('https://example.com/mcp')
 })
 
 test('mcp request enforces token audience and forwards caller props', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Gemini’s custom connected-app flow was failing at the pre-auth probe (“We had trouble connecting to this server”) even though OAuth metadata was reachable. Cloudflare showed UA `Google` getting `401` on `/mcp` after successful well-known discovery, then never calling `/oauth/register`.

This aligns our unauthenticated `/mcp` handshake with what working Gemini MCP servers return and with the path-based PRM document the OAuth provider already serves.

## Changes

- Root `/.well-known/oauth-protected-resource` now includes `bearer_methods_supported: ["header"]` (Google fetches this document from `WWW-Authenticate`).
- Unauthenticated `/mcp` `401` responses include a JSON `invalid_token` body in addition to `WWW-Authenticate` (empty bodies were treated as hard failures).
- Cross-origin CORS on `/mcp` (and `/mcp/`), including `Access-Control-Expose-Headers: WWW-Authenticate`, so browser hosts can read the OAuth challenge.
- `308` canonicalize `/mcp/` → `/mcp`.

## Test plan

- [x] `vitest run --project workers-unit packages/worker/src/mcp-auth.workers.test.ts`
- [x] Pre-push hook (typecheck / e2e) passed on push
- [ ] After deploy: retry Gemini → Connected apps → Add custom app with `https://heykody.dev/mcp` (leave Advanced empty; expect Next to enable and OAuth popup)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `55983930` · **Head:** `c6638264`

**Classification:** extends — changes the unauthenticated MCP OAuth challenge contract (`401` body + root PRM shape) and `/mcp` CORS wiring.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-oauth` | auth | extends — root PRM gains `bearer_methods_supported`; unauthenticated `/mcp` returns JSON `invalid_token` with `WWW-Authenticate` |
| `scheduled-cron` | surfaces | composes — classifier match on `index.ts`; this PR only adds `/mcp` CORS + `/mcp/` redirect in the worker entry (no cron behavior) |

### System map

Gemini (or any browser MCP host) probes `/mcp`, reads the OAuth challenge, then discovers PRM / AS metadata before DCR.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	geminiClient["Gemini custom app<br/>MCP host"]:::untouched
	mcpOauth["mcp-oauth<br/>MCP OAuth"]:::extended
	workerEntry["scheduled-cron<br/>Worker entry /mcp CORS"]:::touched
	geminiClient -->|"OPTIONS/POST /mcp"| workerEntry
	workerEntry -->|"401 + WWW-Authenticate + JSON"| mcpOauth
	geminiClient -->|"GET root PRM"| mcpOauth
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Root protected-resource metadata**

```diff
 {
   "resource": "https://heykody.dev/mcp",
   "authorization_servers": ["https://heykody.dev"],
-  "scopes_supported": ["profile", "email"]
+  "scopes_supported": ["profile", "email"],
+  "bearer_methods_supported": ["header"]
 }
```

**Unauthenticated `/mcp`**

```diff
- 401, empty body, WWW-Authenticate only
+ 401, JSON { error: "invalid_token", ... }, WWW-Authenticate
+ CORS for any Origin; expose WWW-Authenticate
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2af799c-2749-42e3-b88b-8ffae8981c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2af799c-2749-42e3-b88b-8ffae8981c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

