### PR TITLE
Rewrite the home value section to claims you cannot get elsewhere

### DIFF
--- a/docs/use/what-can-kody-do.md
+++ b/docs/use/what-can-kody-do.md
@@ -17,6 +17,31 @@ and keep running while your computer is off. Kody makes no inference calls of
 its own — your agent supplies the intelligence; Kody supplies memory,
 credentials, saved code, schedules, and execution.
 
+## What you cannot get elsewhere
+
+If you are comparing Kody against something else, or explaining it to someone,
+these three are the reasons it exists. Everything in the next section is
+supporting cast.
+
+1. **One-off agent work becomes permanent.** Your agent explores against your
+   real APIs, and the moment something works it saves as code that runs on a
+   schedule with no model in the loop. This is not an agent re-run on a timer:
+   there are no tokens spent, no prompt to drift, and nothing waiting on a model
+   to respond. See [Packages](./packages.md) and
+   [Execute and workflows](./execute.md).
+2. **Your agent uses your keys without ever reading them.** It writes whatever
+   code the job needs and still cannot see a credential — no capability returns
+   one. Code references secrets by name and Kody substitutes them at the network
+   boundary, only for hosts you approved. The
+   [secrets capabilities](https://github.com/kentcdodds/kody/tree/main/packages/worker/src/mcp/capabilities/secrets)
+   are `secret_list`, `secret_set`, `secret_delete`, and `secret_jwt_sign`;
+   there is deliberately no `secret_get`. See
+   [Secrets, values, and host approval](./secrets-and-values.md).
+3. **Every install is a fork you own.** Installing someone else's automation
+   puts code in your account, on your credentials, that you can open, change,
+   schedule, and republish. Nothing stays locked in someone else's runtime. See
+   [Community packages](./community-packages.md).
+
 ## The building blocks
 
 - **Integrations and secrets** — bring your own API keys and OAuth apps for the

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -45,21 +45,40 @@ const workflowSteps = [
 	},
 ] as const
 
+/**
+ * Deliberately short. Each entry has to survive one question: can you get this
+ * somewhere else? Things that read well but fail that test (a template gallery,
+ * server-side secret storage, cloud scheduling, cross-host tool access) are
+ * left off, because a claim like this invites the reader to go check.
+ *
+ * Every entry carries a link to the code or docs that proves it. The source
+ * being readable is what makes that possible, and almost nothing else in this
+ * category can do it.
+ */
 const capabilityHighlights = [
 	{
-		title: 'Access you decide on, service by service',
+		title: 'One-off agent work becomes permanent',
 		description:
-			'Not all-or-nothing access to your machine. You approve each credential, each host, and each package. Secrets stay server-side and never enter your assistant\u2019s context.',
+			'Your agent explores against your real APIs, and the moment something works it saves as code that runs on a schedule with no model in the loop. Not an agent re-run on a timer—no tokens, no drift, no waiting on a model.',
+		proofLabel: 'How packages and jobs work',
+		proofHref:
+			'https://github.com/kentcdodds/kody/blob/main/docs/use/packages.md',
 	},
 	{
-		title: 'The fastest way to start',
+		title: 'Your agent uses your keys without ever reading them',
 		description:
-			'Install a community package in one click. Every install is a fork you own—open it, change it, schedule it, or publish your version back.',
+			'It writes whatever code the job needs, and still cannot see a credential. There is no capability that returns one. Your code references secrets by name and Kody substitutes them at the network boundary, only for hosts you approved.',
+		proofLabel: 'There is no secret_get—check for yourself',
+		proofHref:
+			'https://github.com/kentcdodds/kody/tree/main/packages/worker/src/mcp/capabilities/secrets',
 	},
 	{
-		title: 'One-off work becomes permanent',
+		title: 'Every install is a fork you own',
 		description:
-			'Your agent explores against your real APIs, and once something works it saves as a package that runs on a schedule—no model in the loop, no tokens, no drift.',
+			'Install someone else\u2019s automation in one click and it lands in your account as code you own, on your credentials. Open it, change it, schedule it, publish your version back. Nothing is locked in someone else\u2019s runtime.',
+		proofLabel: 'How community packages work',
+		proofHref:
+			'https://github.com/kentcdodds/kody/blob/main/docs/use/community-packages.md',
 	},
 ] as const
 
@@ -188,7 +207,11 @@ export function HomeRoute(handle: Handle) {
 						<a href={`${onboardingPath}#discovery`} mix={css(discoveryLinkCss)}>
 							Ask your agent with the discovery prompt
 						</a>
-						— no account needed.
+						— no account needed. Or see{' '}
+						<a href="#why-kody" mix={css(discoveryLinkCss)}>
+							what you can&apos;t get elsewhere
+						</a>
+						.
 					</p>
 				</section>
 
@@ -205,12 +228,15 @@ export function HomeRoute(handle: Handle) {
 					</div>
 				</section>
 
-				<section mix={css(sectionCss)}>
+				<section id="why-kody" mix={css(sectionCss)}>
 					<div mix={css(sectionHeaderCss)}>
-						<h2 mix={css(sectionTitleCss)}>What your assistant keeps</h2>
+						<h2 mix={css(sectionTitleCss)}>
+							Three things you cannot get elsewhere
+						</h2>
 						<p mix={css(sectionDescriptionCss)}>
-							Memory, keys, reusable packages, scheduled jobs, a personal inbox,
-							and durable storage—portable across every MCP host.
+							Kody also keeps your memory, keys, packages, scheduled jobs, a
+							personal inbox, and durable storage. These three are the reasons
+							it exists.
 						</p>
 					</div>
 					<div mix={css(capabilityGridCss)}>
@@ -227,16 +253,17 @@ export function HomeRoute(handle: Handle) {
 				</p>
 
 				<p mix={css(fairSourceLineCss)}>
-					Kody is{' '}
+					Kody&apos;s{' '}
 					<a
 						href="https://github.com/kentcdodds/kody"
 						target="_blank"
 						rel="noreferrer noopener"
 						mix={css(fairSourceLinkCss)}
 					>
-						Fair Source
+						source is open
 					</a>
-					, so you can inspect the code.
+					— read it, fork it, self-host it. Every claim above links to the code
+					that proves it.
 				</p>
 			</section>
 		)
@@ -272,14 +299,26 @@ function renderWorkflowStep({
 function renderCapabilityCard({
 	title,
 	description,
+	proofLabel,
+	proofHref,
 }: {
 	title: string
 	description: string
+	proofLabel: string
+	proofHref: string
 }) {
 	return (
 		<div mix={css(capabilityCardCss)}>
 			<h3 mix={css(capabilityTitleCss)}>{title}</h3>
 			<p mix={css(capabilityDescriptionCss)}>{description}</p>
+			<a
+				href={proofHref}
+				target="_blank"
+				rel="noreferrer noopener"
+				mix={css(capabilityProofLinkCss)}
+			>
+				{proofLabel}
+			</a>
 		</div>
 	)
 }
@@ -507,6 +546,13 @@ const capabilityDescriptionCss = {
 	margin: 0,
 	color: colors.textMuted,
 	lineHeight: 1.7,
+}
+
+const capabilityProofLinkCss = {
+	color: colors.primaryText,
+	fontSize: typography.fontSize.sm,
+	textDecoration: 'none',
+	':hover': { textDecoration: 'underline' },
 }
 
 const trustLineCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prompted by [@flybayer](https://x.com/flybayer/status/2081069725115662404): *"every marketing site should have a KILLER FEATURES YOU CANT FIND ELSEWHERE section to help you understand core unique value."*

Applying that filter honestly, **two of the three cards in this section did not survive it.**

- "Install a community package in one click" — Zapier has had a template gallery for a decade.
- "You approve each credential and host" — Composio and Executor claim per-service auth too. Our own positioning notes already call server-side secret storage table stakes.

A claim like this invites the reader to go check, so shorter and unfalsifiable beats longer and contestable.

## The three that survive

**One-off agent work becomes permanent.** The distinguishing detail is what it *isn't* — not an agent re-run on a timer. No tokens, no prompt to drift, nothing waiting on a model. Coding agents write code but you host it; Zapier and n8n are deterministic but hand-built; gateways keep the LLM in every invocation; Letta and Codex cron the *agent*.

**Your agent uses your keys without ever reading them.** Precision is the whole differentiator here. "Secrets stay server-side" is a gateway claim. "No capability returns a credential, and you can verify that by listing the directory" is not — the secrets domain is `secret_list`, `secret_set`, `secret_delete`, `secret_jwt_sign`, and deliberately no `secret_get`.

**Every install is a fork you own.** Not a copy locked in someone else's runtime.

## Each claim links to its proof

Every card now carries a link to the code or docs that backs it. Readable source is what makes that possible and almost nothing else in this category can do it, so the section leans on it deliberately. For an audience that is cynical about AI marketing claims, a *check this yourself* link is itself hard to copy.

## Also in the docs, not just the HTML

The same three claims go into `docs/use/what-can-kody-do.md`. That's the page the pre-signup discovery prompt sends an **agent** to read, and it listed ten building blocks with no ranking — so an agent running discovery on someone's behalf had no way to tell them what was actually unique.

## License wording

The footer now reads "Kody's source is open — read it, fork it, self-host it" rather than leading with the Fair Source label, per Kent's preference for the more recognizable phrasing. This is deliberately the middle path: it uses the word people recognize and stays literally true, without making the capital-letters "Open Source" claim that FSL-1.1-ALv2 doesn't support. Happy to go further if that's the call — see the note in the agent summary.

## Validation

`npm run validate` passes clean locally — all nine checks exit 0.

Copy only; no logic changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d6cfa42-3c7e-489d-a190-5ef4c4e034ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d6cfa42-3c7e-489d-a190-5ef4c4e034ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide section highlighting capabilities that distinguish Kody, including persistent scheduled work, secure credential use, and customizable installations.

* **New Features**
  * Updated the home page capabilities area with clearer explanations and links to supporting information.
  * Added a dedicated “Why Kody” section and improved discovery links.
  * Refreshed open-source messaging and added proof links to capability cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->