### PR TITLE
ci: parallelize validate checks across GitHub Actions jobs

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -15,9 +15,10 @@ A full-stack web application built on Cloudflare Workers with Remix 3 (beta).
 | Build                  | `npm run build`        |
 | E2E tests              | `npm run test:e2e:run` |
 
-`npm run validate` is the single authoritative gate. CI runs the same script, so
-a green local `validate` means CI will pass. `validate` is read-only; use
-`npm run validate:fix` when you want auto-fixes applied.
+`npm run validate` is the single authoritative local gate. CI runs the same
+checks as parallel jobs, so a green local `validate` means CI will pass.
+`validate` is read-only; use `npm run validate:fix` when you want auto-fixes
+applied.
 
 ## Services
 

--- a/.github/actions/setup-validate/action.yml
+++ b/.github/actions/setup-validate/action.yml
@@ -1,0 +1,53 @@
+name: 🧰 Setup validate
+description: Shared Node/npm setup for parallel validate jobs
+
+inputs:
+  playwright:
+    description: Cache and install Playwright Chromium when true
+    required: false
+    default: 'false'
+  worker-env:
+    description: Copy packages/worker/.env.example to .env when true
+    required: false
+    default: 'false'
+  migrate-local:
+    description: Apply local D1 migrations when true
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: 🟢 Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: 26
+        cache: npm
+
+    - name: 🎭 Cache Playwright Browsers
+      if: inputs.playwright == 'true'
+      uses: actions/cache@v5.0.3
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
+    - name: 📥 Install Dependencies
+      shell: bash
+      run: npm ci
+
+    - name: 📝 Prepare worker env
+      if: inputs.worker-env == 'true'
+      shell: bash
+      run: cp packages/worker/.env.example packages/worker/.env
+
+    - name: 🎭 Install Playwright Browsers
+      if: inputs.playwright == 'true'
+      shell: bash
+      run: npm run test:e2e:install
+
+    - name: 🗄️ Apply D1 Migrations
+      if: inputs.migrate-local == 'true'
+      shell: bash
+      run: npm run migrate:local

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,11 +23,14 @@ concurrency:
     github.ref }}
   cancel-in-progress: true
 
+# Same checks as `npm run validate`, split across runners so CPU-heavy suites
+# (unit, Playwright E2E, MCP E2E, typecheck) do not contend on one machine.
+# Local `npm run validate` remains the authoritative single-command gate.
 jobs:
-  validate:
+  static:
     runs-on: ubuntu-latest
-    name: ✅ Validate
-    timeout-minutes: 15
+    name: 🧹 Static
+    timeout-minutes: 10
     if: >-
       github.event_name != 'pull_request' || github.event.pull_request.draft ==
       false
@@ -40,37 +43,132 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: 🟢 Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 26
-          cache: npm
+      - name: 🧰 Setup
+        uses: ./.github/actions/setup-validate
 
-      - name: 🎭 Cache Playwright Browsers
-        uses: actions/cache@v5.0.3
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
+      # Keep running sibling static checks after a failure (same as local
+      # `npm run validate` / concurrently), unless the job was cancelled.
+      - name: ✨ Format
+        if: ${{ !cancelled() }}
+        run: npm run format:check
 
-      - name: 📥 Install Dependencies
-        run: npm ci
+      - name: 🔍 Lint
+        if: ${{ !cancelled() }}
+        run: npm run lint
 
-      - name: 📝 Prepare worker env
-        run: cp packages/worker/.env.example packages/worker/.env
+      - name: 🧠 Typecheck
+        if: ${{ !cancelled() }}
+        run: npm run typecheck
 
-      - name: 🎭 Install Playwright Browsers
-        run: npm run test:e2e:install
+      - name: 🏗️ Backup build
+        if: ${{ !cancelled() }}
+        run: npm run backup:build
 
-      - name: 🗄️ Apply D1 Migrations
-        run: npm run migrate:local
+      - name: 🗺️ Primitives
+        if: ${{ !cancelled() }}
+        run: npm run primitives:check
 
-      - name: ✅ Validate
-        run: npm run validate
+      - name: 🗄️ Migrations
+        if: ${{ !cancelled() }}
+        run: npm run migrations:check
         env:
           # PRs trust the fetched base SHA; main pushes trust the pre-push SHA.
           # The validator rejects this value if it resolves to HEAD.
           MIGRATION_VALIDATION_BASE: >-
             ${{ github.event.pull_request.base.sha || github.event.before || ''
             }}
+
+  unit:
+    runs-on: ubuntu-latest
+    name: 🧪 Unit
+    timeout-minutes: 15
+    if: >-
+      github.event_name != 'pull_request' || github.event.pull_request.draft ==
+      false
+    steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧰 Setup
+        uses: ./.github/actions/setup-validate
+        with:
+          worker-env: 'true'
+          migrate-local: 'true'
+
+      - name: 🧪 Unit tests
+        run: npm run test
+
+  mcp:
+    runs-on: ubuntu-latest
+    name: 🔌 MCP
+    timeout-minutes: 10
+    if: >-
+      github.event_name != 'pull_request' || github.event.pull_request.draft ==
+      false
+    steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧰 Setup
+        uses: ./.github/actions/setup-validate
+        with:
+          worker-env: 'true'
+
+      - name: 🔌 MCP E2E
+        run: npm run test:mcp
+
+  e2e:
+    runs-on: ubuntu-latest
+    name: 🎭 E2E
+    timeout-minutes: 15
+    if: >-
+      github.event_name != 'pull_request' || github.event.pull_request.draft ==
+      false
+    steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🧰 Setup
+        uses: ./.github/actions/setup-validate
+        with:
+          playwright: 'true'
+          worker-env: 'true'
+
+      - name: 🎭 Playwright E2E
+        run: npm run test:e2e:run
+
+  validate:
+    runs-on: ubuntu-latest
+    name: ✅ Validate
+    timeout-minutes: 2
+    needs:
+      - static
+      - unit
+      - mcp
+      - e2e
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false)
+    steps:
+      - name: ✅ All checks passed
+        if: >-
+          needs.static.result == 'success' && needs.unit.result == 'success' &&
+          needs.mcp.result == 'success' && needs.e2e.result == 'success'
+        run: echo "All validate jobs passed"
+
+      - name: ❌ Report failures
+        if: >-
+          needs.static.result != 'success' || needs.unit.result != 'success' ||
+          needs.mcp.result != 'success' || needs.e2e.result != 'success'
+        run: |
+          echo "static=${{ needs.static.result }}"
+          echo "unit=${{ needs.unit.result }}"
+          echo "mcp=${{ needs.mcp.result }}"
+          echo "e2e=${{ needs.e2e.result }}"
+          exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,6 +89,9 @@ jobs:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
         with:
+          # Unit coverage includes migration immutability helpers that need a
+          # trusted pre-change Git base (same as migrations:check).
+          fetch-depth: 0
           persist-credentials: false
 
       - name: 🧰 Setup
@@ -99,6 +102,10 @@ jobs:
 
       - name: 🧪 Unit tests
         run: npm run test
+        env:
+          MIGRATION_VALIDATION_BASE: >-
+            ${{ github.event.pull_request.base.sha || github.event.before || ''
+            }}
 
   mcp:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,17 @@ Use Node 26 and npm for installs and scripts (`npm install`, `npm run ...`).
 
 ## Validation contract
 
-`npm run validate` is the single authoritative gate. It is read-only and runs
-the same checks CI runs — in fact CI invokes `npm run validate` literally. If
+`npm run validate` is the single authoritative local gate. It is read-only and
+runs the same checks CI runs. CI splits those checks across parallel GitHub
+Actions jobs (static, unit, MCP E2E, Playwright E2E) so heavy suites do not
+contend on one runner; the ✅ Validate job aggregates them. If
 `npm run validate` passes locally, CI will pass; if CI fails despite a green
-local `validate`, that is a bug in `validate` and should be filed.
+local `validate`, that is a bug and should be filed.
 
 - `npm run validate` runs `format:check`, `lint`, `typecheck`, unit tests,
-  Playwright E2E, MCP E2E, and repository structure checks (`primitives:check`
-  and `migrations:check`) in parallel and reports every failure (it does not
-  abort sibling checks on the first failure).
+  Playwright E2E, MCP E2E, `backup:build`, and repository structure checks
+  (`primitives:check` and `migrations:check`) in parallel and reports every
+  failure (it does not abort sibling checks on the first failure).
 - `npm run validate:fix` is the explicit opt-in for mutating auto-fixes
   (`format` + `lint:fix`). Running it is never required to pass `validate`.
 - The Husky `pre-commit` and `pre-push` hooks remain narrower fast gates; they

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -40,13 +40,13 @@ manually with native `unzip`:
 
 ## Quick commands
 
-| Task             | Command                                                         |
-| ---------------- | --------------------------------------------------------------- |
-| Install deps     | `npm install`                                                   |
-| Start dev        | `npm run dev` (prints the resolved URL)                         |
-| Migrate local D1 | `npm run migrate:local`                                         |
-| Seed test login  | `node tools/seed-test-data.ts --local` (see seeding note below) |
-| Full CI gate     | `npm run validate`                                              |
+| Task               | Command                                                         |
+| ------------------ | --------------------------------------------------------------- |
+| Install deps       | `npm install`                                                   |
+| Start dev          | `npm run dev` (prints the resolved URL)                         |
+| Migrate local D1   | `npm run migrate:local`                                         |
+| Seed test login    | `node tools/seed-test-data.ts --local` (see seeding note below) |
+| Full validate gate | `npm run validate` (CI runs the same checks as parallel jobs)   |
 
 ## Dev server
 

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -125,8 +125,9 @@ npm run migrate:local
 npm run validate
 ```
 
-`npm run validate` is the single authoritative CI gate. It runs format, lint,
-typecheck, unit tests, Playwright E2E, and MCP E2E in parallel.
+`npm run validate` is the single authoritative local gate. It runs format, lint,
+typecheck, unit tests, Playwright E2E, MCP E2E, backup build, and structure
+checks in parallel. CI runs the same checks as parallel jobs.
 
 To seed a deterministic test login after migrations:
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -83,8 +83,8 @@ Quick notes for getting a local kody environment running.
   executes `format:check`, `lint`, `typecheck`, unit tests, Playwright E2E, MCP
   E2E, `backup:build`, `primitives:check`, and `migrations:check` in parallel,
   reporting every failure (sibling checks are not aborted on the first failure).
-  CI runs the same checks as parallel GitHub Actions jobs (aggregated by the
-  ✅ Validate job). If `npm run validate` passes locally, CI will pass.
+  CI runs the same checks as parallel GitHub Actions jobs (aggregated by the ✅
+  Validate job). If `npm run validate` passes locally, CI will pass.
 - `npm run validate:fix` runs `format` + `lint:fix` and is the explicit opt-in
   for mutating auto-fixes. It is never required to pass `validate`.
 - `npm run format` applies formatting updates on its own.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -79,11 +79,12 @@ Quick notes for getting a local kody environment running.
 - Push-time hooks intentionally stop short of `npm run validate`; MCP E2E and
   repo-wide format checks remain explicit checks because they are heavier than
   the push gate.
-- `npm run validate` is the single authoritative gate and is what CI runs. It is
-  read-only and executes `format:check`, `lint`, `typecheck`, unit tests,
-  Playwright E2E, MCP E2E, `primitives:check`, and `migrations:check` in
-  parallel, reporting every failure (sibling checks are not aborted on the first
-  failure). If `npm run validate` passes locally, CI will pass.
+- `npm run validate` is the single authoritative local gate. It is read-only and
+  executes `format:check`, `lint`, `typecheck`, unit tests, Playwright E2E, MCP
+  E2E, `backup:build`, `primitives:check`, and `migrations:check` in parallel,
+  reporting every failure (sibling checks are not aborted on the first failure).
+  CI runs the same checks as parallel GitHub Actions jobs (aggregated by the
+  ✅ Validate job). If `npm run validate` passes locally, CI will pass.
 - `npm run validate:fix` runs `format` + `lint:fix` and is the explicit opt-in
   for mutating auto-fixes. It is never required to pass `validate`.
 - `npm run format` applies formatting updates on its own.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Yes — local `npm run validate` already parallelizes with `concurrently`, but everything still shares one GitHub Actions runner. Recent CI showed unit (~5m) and Playwright E2E (~5m) dominating wall clock under that contention.

This PR splits those checks onto dedicated runners:

| Job | Checks |
| --- | --- |
| 🧹 Static | format, lint, typecheck, backup:build, primitives, migrations |
| 🧪 Unit | `npm run test` |
| 🔌 MCP | `npm run test:mcp` |
| 🎭 E2E | Playwright (`npm run test:e2e:run`) |
| ✅ Validate | Aggregator / stable required check |

Shared setup lives in `.github/actions/setup-validate` (Node, `npm ci`, optional env/Playwright/migrate). Local `npm run validate` stays the authoritative single-command gate; docs/AGENTS updated to match.

### Observed speedup

Against ~**6m45s** for the old single-job validate on `main`, green parallel CI is ~**4m13s**:

| Job | Duration (dedicated runner) |
| --- | --- |
| 🧹 Static | ~1m9s |
| 🔌 MCP | ~1m51s (was ~2.8m contended) |
| 🎭 E2E | ~3m23s (was ~5.1m contended) |
| 🧪 Unit | ~3m54s (critical path) |
| ✅ Validate | ~4s aggregator |

## Test plan

- [x] Confirm CI shows the four parallel jobs plus ✅ Validate aggregator
- [x] Confirm a failure in any child fails the aggregator / workflow
- [x] Confirm draft PRs still skip the jobs
- [x] Confirm green run after unit-job git-history / format follow-ups
- [x] Spot-check that `MIGRATION_VALIDATION_BASE` still runs on 🧹 Static
- [ ] Confirm production deploy still triggers on successful ✅ Validate workflow runs (unchanged `workflow_run` name)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8b335be6` · **Head:** `76e11a24`

**Classification:** composes — no runtime primitives added or changed; this PR only rewires CI and contributor docs.

### Primitives touched

_None — CI workflow / docs only (`classify-primitives` unmatched paths)._

### System map

CI validates the same check set as local `npm run validate`, but on parallel runners with an aggregating gate job.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	localValidate["npm run validate<br/>local concurrently gate"]:::untouched
	staticJob["🧹 Static<br/>format/lint/typecheck/..."]:::touched
	unitJob["🧪 Unit<br/>vitest"]:::touched
	mcpJob["🔌 MCP<br/>MCP E2E"]:::touched
	e2eJob["🎭 E2E<br/>Playwright"]:::touched
	aggregate["✅ Validate<br/>aggregator job"]:::touched
	localValidate -->|"same check set"| staticJob
	localValidate -->|"same check set"| unitJob
	localValidate -->|"same check set"| mcpJob
	localValidate -->|"same check set"| e2eJob
	staticJob -->|"needs"| aggregate
	unitJob -->|"needs"| aggregate
	mcpJob -->|"needs"| aggregate
	e2eJob -->|"needs"| aggregate
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	trigger[push/PR/workflow_dispatch] --> parallel[Four check jobs in parallel]
	parallel --> static[🧹 Static]
	parallel --> unit[🧪 Unit]
	parallel --> mcp[🔌 MCP]
	parallel --> e2e[🎭 E2E]
	static --> gate[✅ Validate aggregator]
	unit --> gate
	mcp --> gate
	e2e --> gate
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f51bc2e-8aef-4dce-8475-631bc7a47b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f51bc2e-8aef-4dce-8475-631bc7a47b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Validation checks now run in parallel across static analysis, unit tests, MCP tests, and end-to-end tests.
  - A consolidated validation status reports whether all checks passed or identifies failures.

- **Documentation**
  - Clarified that `npm run validate` is the authoritative, read-only local validation command.
  - Updated contributor guidance to reflect the checks performed locally and in CI.
  - Added clearer instructions for automated validation setup and related checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->