### PR TITLE
Give the free tier room to reach a working automation

### DIFF
--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -56,13 +56,14 @@ const planTiers: Array<{
 		id: 'free',
 		name: 'Free',
 		price: '$0',
-		description: 'Tight limits for trying Kody.',
+		description:
+			'Room to build real automations. Capped on daily volume, not on how much you build.',
 	},
 	{
 		id: 'pro',
 		name: 'Pro',
 		price: '$5/month',
-		description: 'Higher limits for heavier workflows and services.',
+		description: 'Higher daily volume, more services, and persistent ones.',
 	},
 ]
 

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -11,6 +11,7 @@ import {
 	parseEntitlementLimitMessage,
 } from './errors.ts'
 import {
+	entitlementResources,
 	getPlanRank,
 	maxPlanEmailLimits,
 	parsePlanName,
@@ -875,19 +876,22 @@ test('resolveEffectivePlan picks the higher of manual and stripe plans', () => {
 	expect(resolveEffectivePlan('free', 'unlimited')).toBe('free')
 })
 
-test('free plan limits are stricter than pro', () => {
-	expect(planLimits.free.maxSavedPackages).toBe(5)
-	expect(planLimits.free.maxScheduledJobs).toBe(3)
-	expect(planLimits.free.maxPackageServices).toBe(1)
+// Asserts the invariant rather than the numbers. `plans.ts` says the limits are
+// placeholders meant to be tuned as metering data arrives, so pinning exact
+// values here would make every tuning change look like a regression. What must
+// never break is the ordering between plans and the persistent-services gate.
+test('free plan limits are stricter than pro for every resource', () => {
+	for (const resource of entitlementResources) {
+		expect(
+			resolvePlanLimit('free', resource),
+			`free ${resource} should be below pro`,
+		).toBeLessThan(resolvePlanLimit('pro', resource))
+	}
+	// Persistent services are the one hard gate rather than a smaller number:
+	// free cannot run them at all.
 	expect(planLimits.free.packageServicePersistentAllowed).toBe(0)
-	expect(planLimits.free.maxSavedPackages).toBeLessThan(
-		planLimits.pro.maxSavedPackages,
-	)
-	expect(planLimits.free.maxScheduledJobs).toBeLessThan(
-		planLimits.pro.maxScheduledJobs,
-	)
 	expect(resolvePlanLimit('free', 'persistent_package_services')).toBe(0)
-	expect(resolvePlanLimit('free', 'saved_packages')).toBe(5)
+	expect(resolvePlanLimit('pro', 'persistent_package_services')).toBe(1)
 })
 
 test('max plan has finite ordinary limits, email caps, and persistent services', () => {

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -232,19 +232,39 @@ export type MaxPlanEmailResource = keyof typeof maxPlanEmailLimits
  * {@link maxPlanEmailLimits} abuse caps instead.
  */
 export const planLimits: Record<PlanName, PlanLimits> = {
+	// Free is deliberately generous on *counts* and unchanged on *rates*.
+	//
+	// Counts (packages, jobs, secrets, repo sessions) are close to free to
+	// serve — a handful of D1 rows — and they are exactly what stands between
+	// someone and the moment the product makes sense, which is the second or
+	// third automation rather than the first. Rates and long-lived compute
+	// (execute calls, outbound fetches, inbound mail, workflows, services) are
+	// the real cost and abuse surfaces and stay where they were.
+	//
+	// The old ceilings ran out during setup rather than after conviction. Five
+	// secrets is the clearest case: one OAuth integration commonly needs three
+	// (client secret, access token, refresh token), so five allowed barely one
+	// and a half integrations on a product whose whole point is holding
+	// credentials safely.
 	free: {
-		maxSavedPackages: 5,
-		maxScheduledJobs: 3,
+		maxSavedPackages: 25,
+		maxScheduledJobs: 10,
+		// Long-lived compute. Unchanged, and persistent services stay off.
 		maxPackageServices: 1,
 		packageServicePersistentAllowed: 0,
-		maxRepoSessions: 2,
-		maxEmailSendsPerDay: 5,
+		maxRepoSessions: 5,
+		// notify-self and reply-to-stored only, so the outreach-abuse surface
+		// is small; a daily digest plus a few alerts should not hit the wall.
+		maxEmailSendsPerDay: 10,
+		// Inbound volume is attacker-controlled. Unchanged.
 		maxEmailReceivesPerDay: 50,
 		maxStoredEmailMessages: 500,
 		maxEmailMessageBytes: 256 * 1024,
-		maxSecrets: 5,
+		maxSecrets: 15,
 		maxStorageBytes: 64 * 1024 * 1024,
+		// Compute. Unchanged.
 		maxConcurrentWorkflows: 3,
+		// The primary cost meter. Unchanged.
 		maxExecuteCallsPerDay: 500,
 		maxOutboundFetchesPerDay: 2_000,
 	},

--- a/packages/worker/src/mcp/tools/search-hidden-packages.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-hidden-packages.node.test.ts
@@ -104,4 +104,8 @@ test('hidden package retrievers skip search by default, honor includeHiddenPacka
 		env.APP_DB,
 		'source-hidden',
 	)
-})
+	// The dynamic import above pulls in the retriever service module graph, and a
+	// cold transform of it can exceed the 5s default when the worker pool is
+	// saturated (the suite spends far longer importing than running). Same
+	// allowance as search-handler.node.test.ts, which imports the same graph.
+}, 10_000)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The activation event we now measure (#942) is **a package that ran successfully at least twice**. The old free ceilings could bite before a user got there, which would make our own pricing a confound in the funnel we just started instrumenting.

The clearest case is secrets. Free allowed **5**, but a single OAuth integration commonly needs **three** — client secret, access token, refresh token. So free permitted roughly one and a half integrations, on the product whose entire differentiator is holding credentials safely. Worth noting: there is **no user feedback evidence** for any pricing change (all four feedback sources contained zero pricing discussion), so this is a product-judgment change justified by the activation argument, not by demand.

## The split: counts up, rates unchanged

Counts cost a handful of D1 rows and are exactly what stands between someone and the moment the product makes sense — which is the second or third automation, not the first.

| Resource | Before | After |
| --- | --- | --- |
| Saved packages | 5 | 25 |
| Scheduled jobs | 3 | 10 |
| Secrets | 5 | 15 |
| Repo sessions | 2 | 5 |
| Email sends / day | 5 | 10 |

Email sends is the only rate that moved, and only because `email_send` is notify-self and `email_reply` is reply-to-stored, so the outreach-abuse surface is small.

**Deliberately unchanged**, because these are the real cost and abuse surfaces: execute calls per day (the primary cost meter), outbound fetches per day, inbound email receives (attacker-controlled volume), stored messages, storage bytes, concurrent workflows, package services, and the persistent-services gate — free still cannot run persistent services at all.

Pro, partner, and max are untouched. `max` derives from pro, so it is unaffected.

## Test change

Rewrote the plan-limit test to assert the **free-below-pro invariant across every resource** instead of pinning magic numbers. `plans.ts` states these values are placeholders expected to be tuned once metering data exists, so pinned values made every tuning change look like a regression. The new version is strictly stronger — it now covers all 14 resources rather than 2 — and keeps the meaningful specific assertion that persistent services are a hard gate rather than a smaller number.

## Second commit: an unrelated flake

`search-hidden-packages.node.test.ts` dynamically imports the retriever service module graph inside the test body, and a cold transform of it exceeds vitest's 5s default when the worker pool is saturated (the suite spends more wall time importing than running). It failed **four times** across parallel validate runs and passed every time in isolation. Given the same 10s allowance as `search-handler.node.test.ts`, which imports the same graph.

Separate concern, kept as its own commit; bundled because it was blocking a green gate.

## Validation

`npm run validate` passes clean — all nine checks exit 0, including the previously flaky test under full parallel load.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d6cfa42-3c7e-489d-a190-5ef4c4e034ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d6cfa42-3c7e-489d-a190-5ef4c4e034ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

