### PR TITLE
fix(oauth): default MCP resource when Gemini omits it

### DIFF
--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -25,6 +25,8 @@ import { invalidClientIdMismatchMessage } from '@kody-internal/shared/oauth-mess
 import { getUsernameFormatValidationError } from '#app/username.ts'
 import { getPkceValidationError } from '#worker/oauth-pkce.ts'
 import { oauthPaths } from '#app/oauth-paths.ts'
+import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { mcpResourcePath } from './mcp-auth.ts'
 
 export { oauthPaths }
 
@@ -214,7 +216,28 @@ function createSetCookieHeaders(cookies: Array<string | null | undefined>) {
 	return hasCookie ? headers : undefined
 }
 
-async function resolveAuthRequest(helpers: OAuthHelpers, request: Request) {
+function defaultMcpResourceForAuthRequest(
+	authRequest: AuthRequest,
+	request: Request,
+	env: Env,
+) {
+	// Gemini Spark (and some other MCP hosts) omit RFC 8707 `resource` on
+	// authorize. Without a grant resource, token exchange can mint a token with
+	// no audience, and `/mcp` rejects it. Default to the MCP resource when the
+	// client did not send one; explicit `resource` values are left unchanged.
+	if (authRequest.resource !== undefined) return
+	const origin = getAppBaseUrl({
+		env,
+		requestUrl: request.url,
+	})
+	authRequest.resource = `${origin}${mcpResourcePath}`
+}
+
+async function resolveAuthRequest(
+	helpers: OAuthHelpers,
+	request: Request,
+	env: Env,
+) {
 	try {
 		const authRequest = await helpers.parseAuthRequest(request)
 		if (!authRequest.clientId || !authRequest.redirectUri) {
@@ -227,6 +250,7 @@ async function resolveAuthRequest(helpers: OAuthHelpers, request: Request) {
 		if (!client) {
 			return { error: 'Unknown OAuth client.' }
 		}
+		defaultMcpResourceForAuthRequest(authRequest, request, env)
 		return { authRequest, client }
 	} catch (error) {
 		const message =
@@ -593,7 +617,7 @@ export async function loadOAuthAuthorizeData(
 	env: Env,
 ): Promise<OAuthAuthorizeDataResult> {
 	const helpers = getOAuthHelpers(env)
-	const resolution = await resolveAuthRequest(helpers, request)
+	const resolution = await resolveAuthRequest(helpers, request, env)
 	if ('error' in resolution) {
 		const { allowClientReset, setCookie } =
 			await resolveAuthorizeInfoResetState(
@@ -736,7 +760,7 @@ export async function handleAuthorizeRequest(
 		return handleResetClientRequest(request, env, helpers, requestIp)
 	}
 
-	const resolution = await resolveAuthRequest(helpers, request)
+	const resolution = await resolveAuthRequest(helpers, request, env)
 	if ('error' in resolution) {
 		return respondAuthorizeError(
 			request,

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -56,6 +56,25 @@ const claudeClient: ClientInfo = {
 	clientName: 'Claude',
 	tokenEndpointAuthMethod: 'none',
 }
+// Gemini Spark custom MCP apps omit RFC 8707 `resource` on authorize.
+const geminiAuthorizeUrl =
+	'https://heykody.dev/oauth/authorize?response_type=code&client_id=QuXak4ugdtPZncjp&redirect_uri=https%3A%2F%2Foauth-redirect.googleusercontent.com%2Fr%2Fuser_bound_custom-mcp-106664623666703652842-heykody_dev&scope=profile+email&code_challenge=uMIae0HtFCz1_e_KxVlJ_W2oz1eT87iC0h4WkBB4tEc&code_challenge_method=S256&state=gemini-demo-state'
+const geminiAuthRequestWithoutResource: AuthRequest = {
+	responseType: 'code',
+	clientId: 'QuXak4ugdtPZncjp',
+	redirectUri:
+		'https://oauth-redirect.googleusercontent.com/r/user_bound_custom-mcp-106664623666703652842-heykody_dev',
+	scope: ['profile', 'email'],
+	state: 'gemini-demo-state',
+	codeChallenge: 'uMIae0HtFCz1_e_KxVlJ_W2oz1eT87iC0h4WkBB4tEc',
+	codeChallengeMethod: 'S256',
+}
+const geminiClient: ClientInfo = {
+	clientId: geminiAuthRequestWithoutResource.clientId,
+	redirectUris: [geminiAuthRequestWithoutResource.redirectUri],
+	clientName: 'Gemini',
+	tokenEndpointAuthMethod: 'none',
+}
 
 function createHelpers(overrides: Partial<OAuthHelpers> = {}): OAuthHelpers {
 	return {
@@ -498,6 +517,46 @@ test('Claude-shaped authorize requests render and approve without throwing', asy
 	})
 	expect(capturedOptions?.request.resource).toBe('https://heykody.dev/mcp')
 	expect(capturedOptions?.request.scope).toEqual(['profile', 'email'])
+})
+
+test('Gemini-shaped authorize requests default resource to /mcp when omitted', async () => {
+	let capturedOptions: CompleteAuthorizationOptions | null = null
+	const helpers = createHelpers({
+		// Return a fresh object each time so the defaulting mutation stays local.
+		parseAuthRequest: async () => ({ ...geminiAuthRequestWithoutResource }),
+		lookupClient: async () => geminiClient,
+		async completeAuthorization(options) {
+			capturedOptions = options
+			return {
+				redirectTo:
+					'https://oauth-redirect.googleusercontent.com/r/user_bound_custom-mcp-106664623666703652842-heykody_dev?code=demo&state=gemini-demo-state',
+			}
+		},
+	})
+	const postResponse = await handleAuthorizeRequest(
+		new Request(geminiAuthorizeUrl, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				decision: 'approve',
+				email: 'user@example.com',
+				password: 'password123',
+			}),
+		}),
+		createEnv(helpers, await createDatabase('password123')),
+	)
+
+	expect(postResponse.status).toBe(200)
+	await expect(postResponse.json()).resolves.toEqual({
+		ok: true,
+		redirectTo:
+			'https://oauth-redirect.googleusercontent.com/r/user_bound_custom-mcp-106664623666703652842-heykody_dev?code=demo&state=gemini-demo-state',
+	})
+	expect(capturedOptions?.request.resource).toBe('https://heykody.dev/mcp')
+	expect(geminiAuthRequestWithoutResource.resource).toBeUndefined()
 })
 
 test('session approval uses database user id when cookie email is stale', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Gemini Spark custom MCP authorize requests omit RFC 8707 `resource`. That left grants without a resource, so token exchange minted tokens with no audience and `/mcp` rejected them (`invalid_token` / audience mismatch). After approve, Gemini saw “no resource” / failed to stay connected even though OAuth UI returned 200.

This defaults `authRequest.resource` to `{origin}/mcp` when the client does not send one. Explicit `resource` values (Claude, etc.) are unchanged.

## Test plan

- [x] Unit: Gemini-shaped authorize (no `resource`) defaults to `https://heykody.dev/mcp` in `completeAuthorization`
- [x] Unit: Claude-shaped authorize still keeps explicit `resource`
- [ ] After deploy: reconnect Gemini custom app with `https://heykody.dev/mcp` (fresh authorize so the new grant gets `/mcp`)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `32bd8b8c` · **Head:** `34885e34`

**Classification:** extends — MCP OAuth authorize now fills a missing RFC 8707 `resource` so grants/tokens carry an `/mcp` audience.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-oauth` | auth | extends — default `{origin}/mcp` when authorize omits `resource` |
| `app-sessions` | auth | composes — shared authorize handlers; session behavior unchanged |

### System map

Gemini authorize → approve → grant with default MCP resource → token audience accepted by `/mcp`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpOauth["mcp-oauth<br/>MCP OAuth"]:::extended
	appSessions["app-sessions<br/>Browser sessions"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	appSessions -->|"authorize approve"| mcpOauth
	mcpOauth -->|"default resource → grant/token audience"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Gemini authorize (no `resource`) | Grant has no resource → token has no audience → `/mcp` 401 | Grant resource = `{origin}/mcp` → token audience matches `/mcp` |
| Claude authorize (`resource` set) | Unchanged | Unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2af799c-2749-42e3-b88b-8ffae8981c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2af799c-2749-42e3-b88b-8ffae8981c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth authorization requests that omit an MCP resource now automatically use the app’s default MCP resource.
  * Improved compatibility with authorization clients that do not provide the optional resource parameter.

* **Tests**
  * Added coverage verifying default resource handling without altering the original authorization request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->