### PR TITLE
ci: auto-deploy DR backup control plane when its code changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -392,17 +392,17 @@ jobs:
 
       - name: ☁️ Deploy backup control plane to DR account
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.DR_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.DR_DEPLOY_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DR_BACKUP_ACCOUNT_ID }}
           DEPLOY_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
         run: |
           set -euo pipefail
           if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
-            echo "Missing GitHub Actions secret DR_CLOUDFLARE_API_TOKEN." >&2
+            echo "Missing GitHub Actions secret DR_DEPLOY_TOKEN." >&2
             echo "Create an API token in the DR (KCD) Cloudflare account with" >&2
             echo "Workers Scripts Edit, Workers Scripts Read, Workers Tail Read," >&2
             echo "Account Workers Scripts Edit, and Workflows Edit, then add it" >&2
-            echo "as repository secret DR_CLOUDFLARE_API_TOKEN." >&2
+            echo "as repository secret DR_DEPLOY_TOKEN." >&2
             exit 1
           fi
           if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
     outputs:
       deploy_sha: ${{ steps.sha_guard.outputs.deploy_sha }}
       should_deploy: ${{ steps.sha_guard.outputs.should_deploy }}
+      deploy_backup_control_plane:
+        ${{ steps.sha_guard.outputs.deploy_backup_control_plane }}
     steps:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
@@ -65,12 +67,31 @@ jobs:
           echo "deploy_sha=$DEPLOY_SHA" >> "$GITHUB_OUTPUT"
           if [ "$HEAD_SHA" != "$DEPLOY_SHA" ]; then
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "deploy_backup_control_plane=false" >> "$GITHUB_OUTPUT"
             echo "Skipping deploy: target SHA is not current main HEAD."
             echo "target=$DEPLOY_SHA"
             echo "head=$HEAD_SHA"
             exit 0
           fi
           echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+
+          # Always redeploy the DR control plane on manual workflow_dispatch.
+          # On push-driven deploys, only when control-plane (or shared backup
+          # contracts) changed in the commit being deployed.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "deploy_backup_control_plane=true" >> "$GITHUB_OUTPUT"
+            echo "Backup control plane deploy: forced (workflow_dispatch)."
+            exit 0
+          fi
+
+          if git diff --name-only "${DEPLOY_SHA}^" "${DEPLOY_SHA}" | grep -E \
+            '^(packages/backup-control-plane/|packages/shared/src/backup-)'; then
+            echo "deploy_backup_control_plane=true" >> "$GITHUB_OUTPUT"
+            echo "Backup control plane deploy: path filter matched."
+          else
+            echo "deploy_backup_control_plane=false" >> "$GITHUB_OUTPUT"
+            echo "Backup control plane deploy: skipped (no relevant path changes)."
+          fi
 
   deploy:
     runs-on: ubuntu-latest
@@ -341,3 +362,71 @@ jobs:
             echo "Capability reindex failed with HTTP ${status}." >&2
             exit 1
           fi
+
+  deploy-backup-control-plane:
+    runs-on: ubuntu-latest
+    name: 🛟 Deploy DR backup control plane
+    timeout-minutes: 8
+    needs: sha-guard
+    if: >-
+      needs.sha-guard.outputs.should_deploy == 'true' &&
+      needs.sha-guard.outputs.deploy_backup_control_plane == 'true'
+    environment:
+      name: production
+      url: https://kody-dr.kentcdodds.com
+    steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ needs.sha-guard.outputs.deploy_sha }}
+          fetch-depth: 0
+
+      - name: 🟢 Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: 📥 Install Dependencies
+        run: npm ci
+
+      - name: ☁️ Deploy backup control plane to DR account
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.DR_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DR_BACKUP_ACCOUNT_ID }}
+          DEPLOY_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "Missing GitHub Actions secret DR_CLOUDFLARE_API_TOKEN." >&2
+            echo "Create an API token in the DR (KCD) Cloudflare account with" >&2
+            echo "Workers Scripts Edit, Workers Scripts Read, Workers Tail Read," >&2
+            echo "Account Workers Scripts Edit, and Workflows Edit, then add it" >&2
+            echo "as repository secret DR_CLOUDFLARE_API_TOKEN." >&2
+            exit 1
+          fi
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "Missing GitHub Actions secret DR_BACKUP_ACCOUNT_ID." >&2
+            exit 1
+          fi
+
+          deploy_attempts=3
+          deploy_delay_seconds=10
+          for attempt in $(seq 1 "$deploy_attempts"); do
+            echo "DR control-plane deploy attempt $attempt/$deploy_attempts"
+            set +e
+            npm run backup:deploy -- \
+              --var "BUILD_COMMIT:${DEPLOY_COMMIT_SHA}" 2>&1 | tee backup-deploy.log
+            deploy_status="${PIPESTATUS[0]}"
+            set -e
+            if [ "$deploy_status" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -eq "$deploy_attempts" ]; then
+              echo "DR control-plane deploy failed after $deploy_attempts attempts." >&2
+              exit "$deploy_status"
+            fi
+            echo "Retrying in ${deploy_delay_seconds}s."
+            sleep "$deploy_delay_seconds"
+            deploy_delay_seconds=$((deploy_delay_seconds * 2))
+          done

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -140,10 +140,14 @@ Admin UI auth is dual-layer:
    (same allowlisted address). Mutating POSTs also require
    `Sec-Fetch-Site: same-origin`.
 
-Deploy the control-plane Worker to the DR account via the Cloudflare API / local
-Wrangler authenticated to that account — not via the application deploy CI.
-Production restore requires the DR Worker to hold the production-account D1
-token as above; Access + JWT guard every UI action that could use it.
+The control-plane Worker deploys to the DR account from GitHub Actions
+(`.github/workflows/deploy.yml` → `deploy-backup-control-plane`) using
+`DR_CLOUDFLARE_API_TOKEN`, when `packages/backup-control-plane/` or shared
+backup contracts change on `main` (or on manual `workflow_dispatch`). Local
+Wrangler against the DR account remains available for emergencies
+(`npm run backup:deploy`). Production restore requires the DR Worker to hold the
+production-account D1 token as above; Access + JWT guard every UI action that
+could use it.
 
 ## Secret escrow
 
@@ -286,7 +290,8 @@ Work top-to-bottom. Leave gates false until the matching gate item is done.
 
 - [ ] Placeholders in `packages/backup-control-plane/wrangler.jsonc` replaced;
       both enable vars remain `"false"`.
-- [ ] Deployed to the DR account (not app CI); `BACKUP_BUCKET` bound; Workflows
+- [ ] `DR_CLOUDFLARE_API_TOKEN` GitHub secret set; control plane deploys from
+      Actions to the DR account; `BACKUP_BUCKET` bound; Workflows
       `kody-production-d1-backup` and `kody-production-dr-restore` present;
       public bucket access off.
 - [ ] UI loads only through Access; unauthenticated and wrong-email JWTs

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -142,9 +142,9 @@ Admin UI auth is dual-layer:
 
 The control-plane Worker deploys to the DR account from GitHub Actions
 (`.github/workflows/deploy.yml` → `deploy-backup-control-plane`) using
-`DR_CLOUDFLARE_API_TOKEN`, when `packages/backup-control-plane/` or shared
-backup contracts change on `main` (or on manual `workflow_dispatch`). Local
-Wrangler against the DR account remains available for emergencies
+`DR_DEPLOY_TOKEN`, when `packages/backup-control-plane/` or shared backup
+contracts change on `main` (or on manual `workflow_dispatch`). Local Wrangler
+against the DR account remains available for emergencies
 (`npm run backup:deploy`). Production restore requires the DR Worker to hold the
 production-account D1 token as above; Access + JWT guard every UI action that
 could use it.
@@ -290,8 +290,8 @@ Work top-to-bottom. Leave gates false until the matching gate item is done.
 
 - [ ] Placeholders in `packages/backup-control-plane/wrangler.jsonc` replaced;
       both enable vars remain `"false"`.
-- [ ] `DR_CLOUDFLARE_API_TOKEN` GitHub secret set; control plane deploys from
-      Actions to the DR account; `BACKUP_BUCKET` bound; Workflows
+- [ ] `DR_DEPLOY_TOKEN` GitHub secret set; control plane deploys from Actions to
+      the DR account; `BACKUP_BUCKET` bound; Workflows
       `kody-production-d1-backup` and `kody-production-dr-restore` present;
       public bucket access off.
 - [ ] UI loads only through Access; unauthenticated and wrong-email JWTs

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -234,7 +234,7 @@ See [Disaster recovery](./disaster-recovery.md).
 
 Lives under `packages/backup-control-plane/` in the DR Cloudflare account. Code
 deploys via the production GitHub Actions workflow when control-plane / shared
-backup contract paths change (secret `DR_CLOUDFLARE_API_TOKEN` +
+backup contract paths change (secret `DR_DEPLOY_TOKEN` +
 `DR_BACKUP_ACCOUNT_ID`). Enable gates and source identity vars live in that
 package's `wrangler.jsonc`.
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -232,8 +232,11 @@ See [Disaster recovery](./disaster-recovery.md).
 
 ## Backup control plane (DR account Worker)
 
-Deployed separately under `packages/backup-control-plane/` (not app CI). Enable
-gates and source identity vars live in that package's `wrangler.jsonc`.
+Lives under `packages/backup-control-plane/` in the DR Cloudflare account. Code
+deploys via the production GitHub Actions workflow when control-plane / shared
+backup contract paths change (secret `DR_CLOUDFLARE_API_TOKEN` +
+`DR_BACKUP_ACCOUNT_ID`). Enable gates and source identity vars live in that
+package's `wrangler.jsonc`.
 
 Non-secret vars:
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -115,12 +115,20 @@ resources from bindings alone, so the deploy workflow runs
 
 ### Disaster-recovery control plane
 
-Production backups are **not** provisioned or deployed by the application
-workflow above. The control-plane Worker/Workflows live under
-`packages/backup-control-plane/` in the independently administered DR Cloudflare
-account and are deployed via the Cloudflare API / Wrangler authenticated to that
-account. Its `BACKUP_BUCKET` R2 binding is private. Immutable prefixes include
-`daily/`, `weekly/`, `daily/full/`, and content-addressed `blobs/sha256/`.
+Production backup **resources** (R2 bucket locks/lifecycle) are still
+provisioned out-of-band with `tools/ci/backup-resources-cli.ts`. The
+control-plane Worker/Workflows under `packages/backup-control-plane/` live in
+the independently administered DR Cloudflare account. Its `BACKUP_BUCKET` R2
+binding is private. Immutable prefixes include `daily/`, `weekly/`,
+`daily/full/`, and content-addressed `blobs/sha256/`.
+
+Code deploys are automated by the production deploy workflow
+(`.github/workflows/deploy.yml` job `deploy-backup-control-plane`) when a `main`
+push changes `packages/backup-control-plane/` or `packages/shared/src/backup-*`,
+and on every manual `workflow_dispatch` of that workflow. The job uses
+`DR_CLOUDFLARE_API_TOKEN` + `DR_BACKUP_ACCOUNT_ID` (never the production-account
+`CLOUDFLARE_API_TOKEN`) and sets `BUILD_COMMIT` to the deploy SHA. Worker
+secrets on the control plane remain one-time / out-of-band.
 
 The production Worker also stages non-D1 canonical stores into the same bucket
 when `DR_EXPORT_ENABLED=true` (StorageRunner dumps, `EMAIL_BLOBS` /
@@ -276,9 +284,14 @@ Configure these GitHub Actions secrets and variables for workflows:
   reindex)
 - `DR_BACKUP_ACCOUNT_ID` / `DR_BACKUP_BUCKET_NAME` / `DR_BACKUP_ACCESS_KEY_ID` /
   `DR_BACKUP_SECRET_ACCESS_KEY` (production DR staging into the DR bucket; also
-  used by `.github/workflows/dr-escrow.yml`. Pair with Worker var
+  used by `.github/workflows/dr-escrow.yml`. `DR_BACKUP_ACCOUNT_ID` is also the
+  Cloudflare account id for control-plane deploys. Pair with Worker var
   `DR_EXPORT_ENABLED=true` only after enablement — see
   [Disaster recovery](./disaster-recovery.md))
+- `DR_CLOUDFLARE_API_TOKEN` (DR-account API token for
+  `deploy-backup-control-plane` in `.github/workflows/deploy.yml`. Needs Workers
+  Scripts Edit/Read, Account Workers Scripts Edit, and Workflows Edit on the DR
+  account only — keep separate from production `CLOUDFLARE_API_TOKEN`)
 - `DR_RESTORE_SECRET` (shared bearer for control-plane →
   `POST /__maintenance/dr-restore`)
 - `SECRET_ESCROW_PASSPHRASE` (operator passphrase for sealing `SECRET_STORE_KEY`

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -126,7 +126,7 @@ Code deploys are automated by the production deploy workflow
 (`.github/workflows/deploy.yml` job `deploy-backup-control-plane`) when a `main`
 push changes `packages/backup-control-plane/` or `packages/shared/src/backup-*`,
 and on every manual `workflow_dispatch` of that workflow. The job uses
-`DR_CLOUDFLARE_API_TOKEN` + `DR_BACKUP_ACCOUNT_ID` (never the production-account
+`DR_DEPLOY_TOKEN` + `DR_BACKUP_ACCOUNT_ID` (never the production-account
 `CLOUDFLARE_API_TOKEN`) and sets `BUILD_COMMIT` to the deploy SHA. Worker
 secrets on the control plane remain one-time / out-of-band.
 
@@ -288,10 +288,10 @@ Configure these GitHub Actions secrets and variables for workflows:
   Cloudflare account id for control-plane deploys. Pair with Worker var
   `DR_EXPORT_ENABLED=true` only after enablement — see
   [Disaster recovery](./disaster-recovery.md))
-- `DR_CLOUDFLARE_API_TOKEN` (DR-account API token for
-  `deploy-backup-control-plane` in `.github/workflows/deploy.yml`. Needs Workers
-  Scripts Edit/Read, Account Workers Scripts Edit, and Workflows Edit on the DR
-  account only — keep separate from production `CLOUDFLARE_API_TOKEN`)
+- `DR_DEPLOY_TOKEN` (DR-account API token for `deploy-backup-control-plane` in
+  `.github/workflows/deploy.yml`. Needs Workers Scripts Edit/Read, Account
+  Workers Scripts Edit, and Workflows Edit on the DR account only — keep
+  separate from production `CLOUDFLARE_API_TOKEN`)
 - `DR_RESTORE_SECRET` (shared bearer for control-plane →
   `POST /__maintenance/dr-restore`)
 - `SECRET_ESCROW_PASSPHRASE` (operator passphrase for sealing `SECRET_STORE_KEY`

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build:client": "npm run build:client:web",
     "build": "nx run worker:build",
     "backup:build": "wrangler deploy --dry-run --config packages/backup-control-plane/wrangler.jsonc",
+    "backup:deploy": "wrangler deploy --config packages/backup-control-plane/wrangler.jsonc",
     "backup:readiness": "node tools/disaster-recovery/canonical-readiness-cli.ts",
     "backup:resources": "node tools/ci/backup-resources-cli.ts",
     "backup:restore-drill": "node tools/disaster-recovery/d1-restore-drill-cli.ts",

--- a/packages/backup-control-plane/readme.md
+++ b/packages/backup-control-plane/readme.md
@@ -109,6 +109,24 @@ the scheduled event still fails afterward to preserve alerting. Exhausting the
 approved tick restarts it with fresh Workflow step state and a new export rather
 than replaying the cached pending poll sequence.
 
+## Deploy
+
+GitHub Actions deploys this Worker to the DR Cloudflare account from
+`.github/workflows/deploy.yml` (`deploy-backup-control-plane`) when
+`packages/backup-control-plane/` or `packages/shared/src/backup-*` change on
+`main`. Requires repository secrets `DR_CLOUDFLARE_API_TOKEN` and
+`DR_BACKUP_ACCOUNT_ID`. Manual/emergency:
+
+```sh
+CLOUDFLARE_ACCOUNT_ID=<DR_ACCOUNT_ID> \
+  CLOUDFLARE_API_TOKEN=<DR_DEPLOY_TOKEN> \
+  npm run backup:deploy -- --var "BUILD_COMMIT:$(git rev-parse HEAD)"
+```
+
+Worker secrets (`CLOUDFLARE_API_TOKEN`, `DRILL_API_TOKEN`, signing key, restore
+secrets) are not synced by that job — set them once with Wrangler / the
+Cloudflare dashboard.
+
 ## Integrity checks
 
 The hourly freshness check compares the immutable object's R2 size and ETag to

--- a/packages/backup-control-plane/readme.md
+++ b/packages/backup-control-plane/readme.md
@@ -114,7 +114,7 @@ than replaying the cached pending poll sequence.
 GitHub Actions deploys this Worker to the DR Cloudflare account from
 `.github/workflows/deploy.yml` (`deploy-backup-control-plane`) when
 `packages/backup-control-plane/` or `packages/shared/src/backup-*` change on
-`main`. Requires repository secrets `DR_CLOUDFLARE_API_TOKEN` and
+`main`. Requires repository secrets `DR_DEPLOY_TOKEN` and
 `DR_BACKUP_ACCOUNT_ID`. Manual/emergency:
 
 ```sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The DR control-plane Worker (`packages/backup-control-plane`) was intentionally left out of app CI and only deployable by hand against the KCD account. That meant merged control-plane fixes (including the FK-safe D1 import change) never reached `kody-dr.kentcdodds.com` until someone remembered to run Wrangler.

## What

- Add `deploy-backup-control-plane` job to `.github/workflows/deploy.yml`
  - Runs after the same `sha-guard` as production deploy (parallel with app deploy)
  - Path-filtered on `packages/backup-control-plane/` and `packages/shared/src/backup-*`
  - Always runs on manual `workflow_dispatch`
  - Uses `DR_DEPLOY_TOKEN` + `DR_BACKUP_ACCOUNT_ID` (not production `CLOUDFLARE_API_TOKEN`)
  - Sets `BUILD_COMMIT` to the deploy SHA via `npm run backup:deploy`
- Document the secret and deploy path in setup-manifest / DR runbook / package readme

## Operator step

`DR_DEPLOY_TOKEN` is already set (DR-account Workers Scripts Edit token). `DR_BACKUP_ACCOUNT_ID` is already required for escrow.

After merge, this PR’s `packages/backup-control-plane/readme.md` change will path-match and deploy the current control-plane code (including the earlier FK import fix).

## Test plan

- [x] Local husky validate on push
- [ ] After merge: confirm Actions job `🛟 Deploy DR backup control plane` succeeds
- [ ] Confirm https://kody-dr.kentcdodds.com still loads through Access
- [ ] Re-run isolated restore drill for `2026-07-24`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** branch tip

**Classification:** composes — wires CI deploy for the existing `backup-control-plane` primitive; no runtime behavior change in the Worker itself beyond getting shipped.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | composes — docs/readme only in-package; deploy automation added in GitHub Actions |

### System map

```mermaid
flowchart LR
  validate["Validate workflow on main"]:::untouched
  shaGuard["deploy.yml sha-guard"]:::extended
  appDeploy["Deploy app worker<br/>production account"]:::untouched
  drDeploy["deploy-backup-control-plane<br/>DR account"]:::added
  controlPlane["kody-production-d1-backups<br/>kody-dr.kentcdodds.com"]:::untouched
  validate --> shaGuard
  shaGuard --> appDeploy
  shaGuard -->|"path filter or workflow_dispatch"| drDeploy
  drDeploy -->|"wrangler + DR_DEPLOY_TOKEN"| controlPlane
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Invariants

- DR deploy credentials stay separate from production `CLOUDFLARE_API_TOKEN`.
- Control-plane Worker secrets are not rewritten by the deploy job.
- Unrelated app-only main pushes do not redeploy the DR Worker.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e5f0844-7242-453a-b99c-9f13125550d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5f0844-7242-453a-b99c-9f13125550d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

