### PR TITLE
fix(sentry): stop reporting D1 network connection lost blips

### DIFF
--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -23,13 +23,19 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 		),
 	).toBe(true)
 	expect(
-		isRetryableD1LockError(
-			new Error('D1_ERROR: Network connection lost.'),
-		),
+		isRetryableD1LockError(new Error('D1_ERROR: Network connection lost.')),
 	).toBe(true)
 	expect(isRetryableD1LockError(new Error('Network connection lost.'))).toBe(
 		true,
 	)
+	expect(
+		isRetryableD1LockError(new Error('Error: Network connection lost.')),
+	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error('Network connection lost while uploading...'),
+		),
+	).toBe(false)
 	expect(isRetryableD1LockError(new Error('syntax error near SELECT'))).toBe(
 		false,
 	)

--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -22,6 +22,14 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 			new Error('Currently processing a long-running export.'),
 		),
 	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error('D1_ERROR: Network connection lost.'),
+		),
+	).toBe(true)
+	expect(isRetryableD1LockError(new Error('Network connection lost.'))).toBe(
+		true,
+	)
 	expect(isRetryableD1LockError(new Error('syntax error near SELECT'))).toBe(
 		false,
 	)
@@ -58,6 +66,20 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
 		await expect(resultPromise).resolves.toBe('ok')
 		expect(exportRetryOperation).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+
+	vi.useFakeTimers()
+	const networkRetryOperation = vi
+		.fn()
+		.mockRejectedValueOnce(new Error('D1_ERROR: Network connection lost.'))
+		.mockResolvedValueOnce('ok')
+	try {
+		const resultPromise = runD1WithRetry(networkRetryOperation)
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toBe('ok')
+		expect(networkRetryOperation).toHaveBeenCalledTimes(2)
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -18,11 +18,19 @@ function sleep(ms: number) {
 export const d1LongRunningExportMessage =
 	'Currently processing a long-running export'
 
+/**
+ * Cloudflare D1 binding transport blip (`D1_ERROR: Network connection lost.`).
+ * Not an application defect — the Worker lost its session to D1 mid-query.
+ * Same retry / Sentry-drop class as SQLITE_BUSY and long-running exports.
+ */
+export const d1NetworkConnectionLostMessage = 'Network connection lost'
+
 export function isRetryableD1LockMessage(message: string) {
 	return (
 		message.includes('SQLITE_BUSY') ||
 		message.includes('database is locked') ||
-		message.includes(d1LongRunningExportMessage)
+		message.includes(d1LongRunningExportMessage) ||
+		message.includes(d1NetworkConnectionLostMessage)
 	)
 }
 
@@ -42,12 +50,13 @@ export function isRetryableD1LockSentryEvent(event: ErrorEvent) {
 }
 
 /**
- * Retries transient D1 unavailability: SQLITE_BUSY lock contention and
+ * Retries transient D1 unavailability: SQLITE_BUSY lock contention,
  * Cloudflare's "Currently processing a long-running export" (DR / REST
- * exports block other requests). D1 does not automatically retry write
- * queries, so cron lanes and long-running retention batches need
- * application-level backoff when they overlap with concurrent writers or
- * an in-flight export.
+ * exports block other requests), and binding "Network connection lost"
+ * transport blips. D1 does not automatically retry write queries, so cron
+ * lanes and long-running retention batches need application-level backoff
+ * when they overlap with concurrent writers, an in-flight export, or a
+ * brief D1 session drop.
  */
 export async function runD1WithRetry<T>(
 	operation: () => Promise<T>,

--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -22,15 +22,28 @@ export const d1LongRunningExportMessage =
  * Cloudflare D1 binding transport blip (`D1_ERROR: Network connection lost.`).
  * Not an application defect — the Worker lost its session to D1 mid-query.
  * Same retry / Sentry-drop class as SQLITE_BUSY and long-running exports.
+ * Match only the exact D1 forms (optional `Error:` / `D1_ERROR:` prefixes) so
+ * unrelated "Network connection lost while …" messages stay out.
  */
 export const d1NetworkConnectionLostMessage = 'Network connection lost'
+
+function isD1NetworkConnectionLostMessage(message: string) {
+	const normalized = message
+		.trim()
+		.replace(/^Error:\s*/i, '')
+		.replace(/^D1_ERROR:\s*/i, '')
+	return (
+		normalized === d1NetworkConnectionLostMessage ||
+		normalized === `${d1NetworkConnectionLostMessage}.`
+	)
+}
 
 export function isRetryableD1LockMessage(message: string) {
 	return (
 		message.includes('SQLITE_BUSY') ||
 		message.includes('database is locked') ||
 		message.includes(d1LongRunningExportMessage) ||
-		message.includes(d1NetworkConnectionLostMessage)
+		isD1NetworkConnectionLostMessage(message)
 	)
 }
 

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -32,6 +32,21 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).toBeNull()
 
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [{ value: 'Network connection lost.' }],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [{ value: 'D1_ERROR: Network connection lost.' }],
+			},
+		}),
+	).toBeNull()
+
 	const userModuleBuildFailure = {
 		exception: {
 			values: [

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -47,6 +47,13 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).toBeNull()
 
+	const unrelatedNetworkLoss = {
+		exception: {
+			values: [{ value: 'Network connection lost while uploading...' }],
+		},
+	}
+	expect(filterSentryEvent(unrelatedNetworkLoss)).toBe(unrelatedNetworkLoss)
+
 	const userModuleBuildFailure = {
 		exception: {
 			values: [

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -87,9 +87,10 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// D1 marks SQLITE_BUSY with NOSENTRY at the storage layer, but
 		// application capture paths (for example scheduled_lane_failed) still
 		// forwarded them. The same applies to "Currently processing a
-		// long-running export" while the nightly DR D1 export holds the DB.
-		// These are transient platform unavailability errors retried in app
-		// code and should not open or regress Sentry issues.
+		// long-running export" while the nightly DR D1 export holds the DB,
+		// and to "Network connection lost" when the D1 binding drops mid-
+		// query. These are transient platform unavailability errors retried
+		// in app code and should not open or regress Sentry issues.
 		//
 		// User-module esbuild failures and executor sandbox timeouts from
 		// inline workflows are similarly expected caller mistakes; see


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters Sentry noise from [issue 7633338189](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7633338189/) (`Error: D1_ERROR: Network connection lost.`).

One production event on `admin_user_usage` (`mcp.failure_phase=handler`) failed inside `readEntitlementResourceUsage` → `countRunningPackageServices` → `countRows` when the D1 binding dropped mid-query (`D1DatabaseSessionAlwaysPrimary._sendOrThrow`). This is transient Cloudflare D1 transport unavailability, not an application bug — the same class already handled for `SQLITE_BUSY` and long-running export blocks (#930).

This PR extends the existing retryable-D1 matcher so:

1. `runD1WithRetry` / cron lane skip / module-artifact transient detection treat "Network connection lost" like lock contention
2. `beforeSend` (`filterRetryableD1LockSentryEvent`) drops matching events so binding blips do not open or regress Sentry issues

The matcher accepts only the exact D1 phrase with optional `Error:` / `D1_ERROR:` prefixes, so unrelated "Network connection lost while …" messages stay retryable/Sentry-visible.

MCP requests can still fail for the caller when D1 drops the session before a retry wrapper covers that path. We stop treating that as a platform defect in Sentry.

Siblings (client `updateCurrentEntry`, sandbox timeout, search validation) do not share this root cause and are left alone.

## Test plan

- [x] `d1-retry.node.test.ts` matches exact D1 network-loss forms; rejects "Network connection lost while uploading..."; retries exact network errors; still rethrows syntax errors immediately
- [x] `sentry-options.node.test.ts` drops both exact message forms, keeps unrelated network-loss wording and other D1 errors
- [x] Local `npm run validate` green
- [ ] CI `npm run validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `7f6f85c2` · **Head:** `c70a5d88`

**Classification:** composes — narrow extension of the existing D1 transient matcher + Sentry `beforeSend` filter; no D1 schema, auth, or backup export contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(unmatched)_ `d1-retry.ts` / `sentry-options.ts` | observability | composes — treat exact D1 "Network connection lost" like SQLITE_BUSY for retry + Sentry drop |

### System map

Transient D1 binding drops still fail uncovered queries; Sentry and retry paths no longer treat that blip as a novel platform failure.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	d1Retry["d1-retry<br/>Transient D1 matcher"]:::touched
	sentryOpts["sentry-options<br/>beforeSend filters"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	d1AppDb -->|"Network connection lost"| d1Retry
	d1Retry -->|"isRetryableD1LockSentryEvent"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79d72dd4-88b1-4a9f-a5ae-f3f3a7c78292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d72dd4-88b1-4a9f-a5ae-f3f3a7c78292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience to transient database transport drops by automatically retrying operations when the error indicates a “Network connection lost”.
  - Ensured expected transient connection-loss messages don’t surface as reported application errors.

- **Tests**
  - Expanded retry coverage for “Network connection lost” variants and added assertions that retries occur exactly once when the first attempt fails.

- **Documentation**
  - Updated guidance to include transport “Network connection lost” scenarios and the resulting app/session loss behavior during mid-query drops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->