### PR TITLE
fix(sentry): stop reporting D1 internal error blips

### DIFF
--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -36,6 +36,24 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 			new Error('Network connection lost while uploading...'),
 		),
 	).toBe(false)
+	expect(
+		isRetryableD1LockError(
+			new Error(
+				'D1_ERROR: internal error; reference = 0u3odos5iotccpol68ppc0eg',
+			),
+		),
+	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error('internal error; reference = 0u3odos5iotccpol68ppc0eg'),
+		),
+	).toBe(true)
+	expect(isRetryableD1LockError(new Error('internal error'))).toBe(false)
+	expect(
+		isRetryableD1LockError(
+			new Error('D1_ERROR: internal error while applying migration'),
+		),
+	).toBe(false)
 	expect(isRetryableD1LockError(new Error('syntax error near SELECT'))).toBe(
 		false,
 	)
@@ -86,6 +104,24 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
 		await expect(resultPromise).resolves.toBe('ok')
 		expect(networkRetryOperation).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+
+	vi.useFakeTimers()
+	const internalErrorRetryOperation = vi
+		.fn()
+		.mockRejectedValueOnce(
+			new Error(
+				'D1_ERROR: internal error; reference = 0u3odos5iotccpol68ppc0eg',
+			),
+		)
+		.mockResolvedValueOnce('ok')
+	try {
+		const resultPromise = runD1WithRetry(internalErrorRetryOperation)
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toBe('ok')
+		expect(internalErrorRetryOperation).toHaveBeenCalledTimes(2)
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -27,15 +27,34 @@ export const d1LongRunningExportMessage =
  */
 export const d1NetworkConnectionLostMessage = 'Network connection lost'
 
-function isD1NetworkConnectionLostMessage(message: string) {
-	const normalized = message
+/**
+ * Cloudflare D1 opaque platform failure
+ * (`D1_ERROR: internal error; reference = <id>`). Not an application defect —
+ * D1's storage/backend hit an internal fault and surfaces a support reference.
+ * Same retry / Sentry-drop class as SQLITE_BUSY and binding transport blips.
+ * Require the `reference =` token so bare "internal error" from app code
+ * stays retryable/Sentry-visible.
+ */
+const d1InternalErrorReferencePattern =
+	/^internal error;\s*reference\s*=\s*[A-Za-z0-9]+$/i
+
+function stripD1ErrorPrefixes(message: string) {
+	return message
 		.trim()
 		.replace(/^Error:\s*/i, '')
 		.replace(/^D1_ERROR:\s*/i, '')
+}
+
+function isD1NetworkConnectionLostMessage(message: string) {
+	const normalized = stripD1ErrorPrefixes(message)
 	return (
 		normalized === d1NetworkConnectionLostMessage ||
 		normalized === `${d1NetworkConnectionLostMessage}.`
 	)
+}
+
+function isD1InternalErrorMessage(message: string) {
+	return d1InternalErrorReferencePattern.test(stripD1ErrorPrefixes(message))
 }
 
 export function isRetryableD1LockMessage(message: string) {
@@ -43,7 +62,8 @@ export function isRetryableD1LockMessage(message: string) {
 		message.includes('SQLITE_BUSY') ||
 		message.includes('database is locked') ||
 		message.includes(d1LongRunningExportMessage) ||
-		isD1NetworkConnectionLostMessage(message)
+		isD1NetworkConnectionLostMessage(message) ||
+		isD1InternalErrorMessage(message)
 	)
 }
 
@@ -65,11 +85,12 @@ export function isRetryableD1LockSentryEvent(event: ErrorEvent) {
 /**
  * Retries transient D1 unavailability: SQLITE_BUSY lock contention,
  * Cloudflare's "Currently processing a long-running export" (DR / REST
- * exports block other requests), and binding "Network connection lost"
- * transport blips. D1 does not automatically retry write queries, so cron
- * lanes and long-running retention batches need application-level backoff
- * when they overlap with concurrent writers, an in-flight export, or a
- * brief D1 session drop.
+ * exports block other requests), binding "Network connection lost"
+ * transport blips, and opaque "internal error; reference = …" platform
+ * faults. D1 does not automatically retry write queries, so cron lanes and
+ * long-running retention batches need application-level backoff when they
+ * overlap with concurrent writers, an in-flight export, a brief D1 session
+ * drop, or a D1 backend blip.
  */
 export async function runD1WithRetry<T>(
 	operation: () => Promise<T>,

--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -33,7 +33,7 @@ export const d1NetworkConnectionLostMessage = 'Network connection lost'
  * D1's storage/backend hit an internal fault and surfaces a support reference.
  * Same retry / Sentry-drop class as SQLITE_BUSY and binding transport blips.
  * Require the `reference =` token so bare "internal error" from app code
- * stays retryable/Sentry-visible.
+ * stays non-retryable and Sentry-visible.
  */
 const d1InternalErrorReferencePattern =
 	/^internal error;\s*reference\s*=\s*[A-Za-z0-9]+$/i

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -47,12 +47,41 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).toBeNull()
 
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'D1_ERROR: internal error; reference = 0u3odos5iotccpol68ppc0eg',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{ value: 'internal error; reference = 0u3odos5iotccpol68ppc0eg' },
+				],
+			},
+		}),
+	).toBeNull()
+
 	const unrelatedNetworkLoss = {
 		exception: {
 			values: [{ value: 'Network connection lost while uploading...' }],
 		},
 	}
 	expect(filterSentryEvent(unrelatedNetworkLoss)).toBe(unrelatedNetworkLoss)
+
+	const bareInternalError = {
+		exception: {
+			values: [{ value: 'internal error' }],
+		},
+	}
+	expect(filterSentryEvent(bareInternalError)).toBe(bareInternalError)
 
 	const userModuleBuildFailure = {
 		exception: {

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -88,9 +88,10 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// application capture paths (for example scheduled_lane_failed) still
 		// forwarded them. The same applies to "Currently processing a
 		// long-running export" while the nightly DR D1 export holds the DB,
-		// and to "Network connection lost" when the D1 binding drops mid-
-		// query. These are transient platform unavailability errors retried
-		// in app code and should not open or regress Sentry issues.
+		// "Network connection lost" when the D1 binding drops mid-query, and
+		// opaque "internal error; reference = …" platform faults. These are
+		// transient platform unavailability errors retried in app code and
+		// should not open or regress Sentry issues.
 		//
 		// User-module esbuild failures and executor sandbox timeouts from
 		// inline workflows are similarly expected caller mistakes; see


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters Sentry noise from [issue 7633443587](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7633443587/) (`Error: D1_ERROR: internal error; reference = 0u3odos5iotccpol68ppc0eg`).

One production event on scheduled lane `reconcile_artifacts_pushes` failed inside `listEntitySourcesForExternalReconcile` when Cloudflare D1 returned an opaque platform fault (`D1DatabaseSessionAlwaysPrimary._sendOrThrow`, support reference `0u3odos5iotccpol68ppc0eg`). This is transient D1 backend unavailability, not an application bug — the same class already handled for `SQLITE_BUSY`, long-running export blocks, and `Network connection lost` (#952).

This PR extends the existing retryable-D1 matcher so:

1. `runD1WithRetry` / cron lane skip / module-artifact transient detection treat `internal error; reference = <id>` like lock contention
2. `beforeSend` (`filterRetryableD1LockSentryEvent`) drops matching events so platform blips do not open or regress Sentry issues

The matcher accepts only messages whose payload (after optional `Error:` / `D1_ERROR:` prefixes) is exactly `internal error; reference = <token>`, so bare `"internal error"` from app code stays retryable/Sentry-visible.

Siblings (client `updateCurrentEntry`, sandbox timeout, search validation) do not share this root cause and are left alone.

## Test plan

- [x] `d1-retry.node.test.ts` matches D1 internal-error+reference forms; rejects bare `"internal error"` and other wording; retries once then succeeds
- [x] `sentry-options.node.test.ts` drops both exception value forms; keeps bare `"internal error"`
- [x] Local pre-push `validate` green
- [ ] CI `npm run validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `330f65cb` · **Head:** `175a7ea8`

**Classification:** composes — narrow extension of the existing D1 transient matcher + Sentry `beforeSend` filter; no D1 schema, auth, or backup export contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(unmatched)_ `d1-retry.ts` / `sentry-options.ts` | observability | composes — treat D1 `internal error; reference = …` like SQLITE_BUSY for retry + Sentry drop |

### System map

Transient D1 platform faults still fail uncovered queries; Sentry and retry paths no longer treat that blip as a novel platform failure.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	d1Retry["d1-retry<br/>Transient D1 matcher"]:::touched
	sentryOpts["sentry-options<br/>beforeSend filters"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	d1AppDb -->|"internal error; reference"| d1Retry
	d1Retry -->|"isRetryableD1LockSentryEvent"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bbac1d3-2624-48f0-8ab9-0713195d886d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bbac1d3-2624-48f0-8ab9-0713195d886d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved D1 retry handling for additional “internal error” messages that include a `reference = ...` token.
  * Reduced Sentry event noise by continuing to filter expected transient platform/D1 error variants with reference details.
* **Tests**
  * Added Vitest assertions for retryable vs non-retryable D1 internal-error message patterns.
  * Added a retry scenario confirming the operation retries after the base delay and succeeds on the next attempt.
* **Documentation**
  * Clarified Sentry filtering expectations in inline comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->