### PR TITLE
fix(sentry): drop D1 storage object-reset blips

### DIFF
--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -48,10 +48,31 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 			new Error('internal error; reference = 0u3odos5iotccpol68ppc0eg'),
 		),
 	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error(
+				'D1_ERROR: Internal error in D1 DB storage caused object to be reset; reference = 8t4dqqpoq1ctvjr8kca8fl4c',
+			),
+		),
+	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error(
+				'Internal error in D1 DB storage caused object to be reset; reference = 8t4dqqpoq1ctvjr8kca8fl4c',
+			),
+		),
+	).toBe(true)
 	expect(isRetryableD1LockError(new Error('internal error'))).toBe(false)
 	expect(
 		isRetryableD1LockError(
 			new Error('D1_ERROR: internal error while applying migration'),
+		),
+	).toBe(false)
+	expect(
+		isRetryableD1LockError(
+			new Error(
+				'D1_ERROR: Internal error in D1 DB storage while applying migration; reference = abc',
+			),
 		),
 	).toBe(false)
 	expect(isRetryableD1LockError(new Error('syntax error near SELECT'))).toBe(
@@ -122,6 +143,24 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
 		await expect(resultPromise).resolves.toBe('ok')
 		expect(internalErrorRetryOperation).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+
+	vi.useFakeTimers()
+	const objectResetRetryOperation = vi
+		.fn()
+		.mockRejectedValueOnce(
+			new Error(
+				'D1_ERROR: Internal error in D1 DB storage caused object to be reset; reference = 8t4dqqpoq1ctvjr8kca8fl4c',
+			),
+		)
+		.mockResolvedValueOnce('ok')
+	try {
+		const resultPromise = runD1WithRetry(objectResetRetryOperation)
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toBe('ok')
+		expect(objectResetRetryOperation).toHaveBeenCalledTimes(2)
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -65,6 +65,13 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 	expect(isRetryableD1LockError(new Error('internal error'))).toBe(false)
 	expect(
 		isRetryableD1LockError(
+			new Error(
+				'D1_ERROR: Internal error in D1 DB storage caused object to be reset',
+			),
+		),
+	).toBe(false)
+	expect(
+		isRetryableD1LockError(
 			new Error('D1_ERROR: internal error while applying migration'),
 		),
 	).toBe(false)

--- a/packages/worker/src/d1-retry.ts
+++ b/packages/worker/src/d1-retry.ts
@@ -28,15 +28,17 @@ export const d1LongRunningExportMessage =
 export const d1NetworkConnectionLostMessage = 'Network connection lost'
 
 /**
- * Cloudflare D1 opaque platform failure
- * (`D1_ERROR: internal error; reference = <id>`). Not an application defect —
- * D1's storage/backend hit an internal fault and surfaces a support reference.
+ * Cloudflare D1 opaque platform failures with a support reference, e.g.
+ * `D1_ERROR: internal error; reference = <id>` and
+ * `D1_ERROR: Internal error in D1 DB storage caused object to be reset; reference = <id>`.
+ * Not an application defect — D1's storage/backend hit an internal fault.
  * Same retry / Sentry-drop class as SQLITE_BUSY and binding transport blips.
- * Require the `reference =` token so bare "internal error" from app code
+ * Require the `reference =` token and only these known D1 phrasings so bare
+ * "internal error" (or unrelated "internal error while …") from app code
  * stays non-retryable and Sentry-visible.
  */
 const d1InternalErrorReferencePattern =
-	/^internal error;\s*reference\s*=\s*[A-Za-z0-9]+$/i
+	/^internal error(?: in D1 DB storage caused object to be reset)?;\s*reference\s*=\s*[A-Za-z0-9]+$/i
 
 function stripD1ErrorPrefixes(message: string) {
 	return message
@@ -86,11 +88,11 @@ export function isRetryableD1LockSentryEvent(event: ErrorEvent) {
  * Retries transient D1 unavailability: SQLITE_BUSY lock contention,
  * Cloudflare's "Currently processing a long-running export" (DR / REST
  * exports block other requests), binding "Network connection lost"
- * transport blips, and opaque "internal error; reference = …" platform
- * faults. D1 does not automatically retry write queries, so cron lanes and
- * long-running retention batches need application-level backoff when they
- * overlap with concurrent writers, an in-flight export, a brief D1 session
- * drop, or a D1 backend blip.
+ * transport blips, and opaque D1 "internal error …; reference = …" platform
+ * faults (including storage object-reset). D1 does not automatically retry
+ * write queries, so cron lanes and long-running retention batches need
+ * application-level backoff when they overlap with concurrent writers, an
+ * in-flight export, a brief D1 session drop, or a D1 backend blip.
  */
 export async function runD1WithRetry<T>(
 	operation: () => Promise<T>,

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -68,6 +68,30 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 			},
 		}),
 	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'D1_ERROR: Internal error in D1 DB storage caused object to be reset; reference = 8t4dqqpoq1ctvjr8kca8fl4c',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Internal error in D1 DB storage caused object to be reset; reference = 8t4dqqpoq1ctvjr8kca8fl4c',
+					},
+				],
+			},
+		}),
+	).toBeNull()
 
 	const unrelatedNetworkLoss = {
 		exception: {

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -107,6 +107,18 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	}
 	expect(filterSentryEvent(bareInternalError)).toBe(bareInternalError)
 
+	const bareObjectReset = {
+		exception: {
+			values: [
+				{
+					value:
+						'D1_ERROR: Internal error in D1 DB storage caused object to be reset',
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(bareObjectReset)).toBe(bareObjectReset)
+
 	const userModuleBuildFailure = {
 		exception: {
 			values: [

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -89,9 +89,10 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// forwarded them. The same applies to "Currently processing a
 		// long-running export" while the nightly DR D1 export holds the DB,
 		// "Network connection lost" when the D1 binding drops mid-query, and
-		// opaque "internal error; reference = …" platform faults. These are
-		// transient platform unavailability errors retried in app code and
-		// should not open or regress Sentry issues.
+		// opaque D1 "internal error …; reference = …" platform faults
+		// (including storage object-reset). These are transient platform
+		// unavailability errors retried in app code and should not open or
+		// regress Sentry issues.
 		//
 		// User-module esbuild failures and executor sandbox timeouts from
 		// inline workflows are similarly expected caller mistakes; see


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters Sentry noise from [KODY-CLOUDFLARE-28](https://kent-c-dodds-tech-llc.sentry.io/issues/7633760491/) (`Error: D1_ERROR: Internal error in D1 DB storage caused object to be reset; reference = 8t4dqqpoq1ctvjr8kca8fl4c`).

One production event on MCP capability `admin_user_usage` failed inside `readEntitlementResourceUsage` → `readDailyEntitlementCounter` when Cloudflare D1 returned an opaque storage fault (`D1DatabaseSessionAlwaysPrimary._sendOrThrow`, support reference `8t4dqqpoq1ctvjr8kca8fl4c`). This is transient D1 backend unavailability, not an application bug — the same class already handled for `SQLITE_BUSY`, long-running export blocks, `Network connection lost` (#952), and `internal error; reference = …` (#953).

PR #953 already filters the short `internal error; reference = <id>` form. This event used a longer Cloudflare phrasing that the exact matcher missed. This PR extends that matcher so:

1. `runD1WithRetry` / cron lane skip / module-artifact transient detection treat the storage object-reset form like other D1 platform blips
2. `beforeSend` (`filterRetryableD1LockSentryEvent`) drops matching events so these blips do not open or regress Sentry issues

The matcher still requires a `reference = <token>` and only accepts the two known D1 phrasings (`internal error; …` and `internal error in D1 DB storage caused object to be reset; …`), so bare `"internal error"` and unrelated wording stay retryable/Sentry-visible.

Siblings (client `updateCurrentEntry`, sandbox timeout, search validation) do not share this root cause and are left alone.

## Test plan

- [x] `d1-retry.node.test.ts` matches the object-reset+reference form; rejects unreferenced object-reset and mismatched wording; retries once then succeeds
- [x] `sentry-options.node.test.ts` drops both prefixed and unprefixed object-reset forms; keeps unreferenced object-reset
- [x] Local `npm run validate` green
- [ ] CI `npm run validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `6fed00ac` · **Head:** `e4bc82d8`

**Classification:** composes — narrow extension of the existing D1 transient matcher + Sentry `beforeSend` filter; no D1 schema, auth, or backup export contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(unmatched)_ `d1-retry.ts` / `sentry-options.ts` | observability | composes — treat D1 storage object-reset + `reference = …` like SQLITE_BUSY for retry + Sentry drop |

### System map

Transient D1 storage object-reset faults still fail uncovered queries; Sentry and retry paths no longer treat that blip as a novel platform failure.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	d1Retry["d1-retry<br/>Transient D1 matcher"]:::touched
	sentryOpts["sentry-options<br/>beforeSend filters"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	d1AppDb -->|"object to be reset; reference"| d1Retry
	d1Retry -->|"isRetryableD1LockSentryEvent"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-385b1a82-ab7c-4812-a764-587955d254f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-385b1a82-ab7c-4812-a764-587955d254f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded automatic retries for transient Cloudflare D1 “internal error … object to be reset” failures so operations recover after the retry delay.
  * Updated Sentry event filtering to suppress expected D1 “internal error … reference = …” noise (including prefixed/unprefixed variants), while keeping truly non-retryable cases unmodified.
* **Tests**
  * Added coverage for additional D1 error message variants and verified retry behavior using fake timers.
* **Documentation**
  * Clarified which D1 internal errors are treated as temporary, retryable, and suppressible for Sentry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->