### PR TITLE
fix(mcp): stop Sentry noise for unknown MCP server names

### DIFF
--- a/packages/worker/src/mcp/capabilities/mcp-servers/shared.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/shared.node.test.ts
@@ -63,6 +63,7 @@ test('resolveMcpServerSetting throws McpCallerError for blank server identifiers
 		'Provide the MCP server id or name in "server".',
 	)
 	expect(mockModule.getMcpServerSettingById).not.toHaveBeenCalled()
+	expect(mockModule.listMcpServerSettings).not.toHaveBeenCalled()
 })
 
 test('resolveMcpServerSetting resolves by id or normalized name', async () => {

--- a/packages/worker/src/mcp/capabilities/mcp-servers/shared.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/shared.node.test.ts
@@ -1,0 +1,93 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { type McpServerSettingMetadata } from '#worker/mcp-client/settings-types.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getMcpServerSettingById: vi.fn(),
+	listMcpServerSettings: vi.fn(),
+}))
+
+vi.mock('#worker/mcp-client/settings-service.ts', () => ({
+	getMcpServerSettingById: (...args: Array<unknown>) =>
+		mockModule.getMcpServerSettingById(...args),
+	listMcpServerSettings: (...args: Array<unknown>) =>
+		mockModule.listMcpServerSettings(...args),
+}))
+
+const { resolveMcpServerSetting } = await import('./shared.ts')
+
+function setting(
+	overrides: Partial<McpServerSettingMetadata> = {},
+): McpServerSettingMetadata {
+	return {
+		id: 'server-1',
+		name: 'ha',
+		url: 'https://example.com/mcp',
+		enabled: true,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		...overrides,
+	}
+}
+
+test('resolveMcpServerSetting throws McpCallerError for unknown server names', async () => {
+	mockModule.getMcpServerSettingById.mockReset()
+	mockModule.listMcpServerSettings.mockReset()
+	mockModule.getMcpServerSettingById.mockResolvedValue(null)
+	mockModule.listMcpServerSettings.mockResolvedValue([setting()])
+
+	const missing = resolveMcpServerSetting({
+		env: { APP_DB: {} as D1Database },
+		userId: 'user-1',
+		server: 'recipe-keeper',
+	})
+
+	await expect(missing).rejects.toThrow(McpCallerError)
+	await expect(missing).rejects.toThrow(
+		'No MCP server matches "recipe-keeper". Saved servers: ha.',
+	)
+})
+
+test('resolveMcpServerSetting throws McpCallerError for blank server identifiers', async () => {
+	mockModule.getMcpServerSettingById.mockReset()
+	mockModule.listMcpServerSettings.mockReset()
+
+	const blank = resolveMcpServerSetting({
+		env: { APP_DB: {} as D1Database },
+		userId: 'user-1',
+		server: '   ',
+	})
+
+	await expect(blank).rejects.toThrow(McpCallerError)
+	await expect(blank).rejects.toThrow(
+		'Provide the MCP server id or name in "server".',
+	)
+	expect(mockModule.getMcpServerSettingById).not.toHaveBeenCalled()
+})
+
+test('resolveMcpServerSetting resolves by id or normalized name', async () => {
+	mockModule.getMcpServerSettingById.mockReset()
+	mockModule.listMcpServerSettings.mockReset()
+
+	const byId = setting({ id: 'server-by-id', name: 'ha' })
+	mockModule.getMcpServerSettingById.mockResolvedValueOnce(byId)
+	await expect(
+		resolveMcpServerSetting({
+			env: { APP_DB: {} as D1Database },
+			userId: 'user-1',
+			server: 'server-by-id',
+		}),
+	).resolves.toEqual(byId)
+
+	mockModule.getMcpServerSettingById.mockResolvedValueOnce(null)
+	mockModule.listMcpServerSettings.mockResolvedValueOnce([
+		setting({ id: 'server-by-name', name: 'ha' }),
+	])
+	await expect(
+		resolveMcpServerSetting({
+			env: { APP_DB: {} as D1Database },
+			userId: 'user-1',
+			server: 'HA',
+		}),
+	).resolves.toMatchObject({ id: 'server-by-name', name: 'ha' })
+})

--- a/packages/worker/src/mcp/capabilities/mcp-servers/shared.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/shared.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { normalizeMcpServerName } from '@kody-internal/shared/mcp-servers.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { getCachedMcpClientHubSnapshot } from '#worker/mcp-client/hub-client.ts'
 import {
 	getMcpServerSettingById,
@@ -66,7 +67,7 @@ export async function resolveMcpServerSetting(input: {
 }): Promise<McpServerSettingMetadata> {
 	const identifier = input.server.trim()
 	if (!identifier) {
-		throw new Error('Provide the MCP server id or name in "server".')
+		throw new McpCallerError('Provide the MCP server id or name in "server".')
 	}
 	const byId = await getMcpServerSettingById({
 		env: input.env,
@@ -82,7 +83,8 @@ export async function resolveMcpServerSetting(input: {
 	const byName = settings.find((setting) => setting.name === normalized)
 	if (byName) return byName
 	const available = settings.map((setting) => setting.name).join(', ') || 'none'
-	throw new Error(
+	// Unknown id/name is a caller mistake (stale name, typo). Keep it off Sentry.
+	throw new McpCallerError(
 		`No MCP server matches "${identifier}". Saved servers: ${available}.`,
 	)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-29](https://kent-c-dodds-tech-llc.sentry.io/issues/7633941836/) fired when `mcp_server_reconnect` was called with a server name that is not saved (`recipe-keeper`; only `ha` existed). That is a routine caller mistake (stale name / typo), not a platform defect.

`resolveMcpServerSetting` threw a plain `Error`, so MCP observability reported it to Sentry. This PR throws `McpCallerError` instead (same pattern as missing packages/runs), so these stay on `mcp-event` logs and out of Sentry.

## Changes

- Blank and unknown server identifiers in `resolveMcpServerSetting` → `McpCallerError`
- Unit tests for unknown name, blank id, and happy-path id/name resolution

## Test plan

- [x] `shared.node.test.ts` (3 tests)
- [x] CI `validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `405751b2` · **Head:** `cursor/sentry-triage-kody-cloudflare-29-215a`

**Classification:** composes — reuses existing `McpCallerError` so caller-resolvable MCP server lookup failures stay off Sentry; no new primitives or contracts.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | composes — unknown/blank server lookup throws `McpCallerError` |

### System map

Unknown MCP server names from reconnect/refresh/remove/set-enabled now classify as caller errors instead of platform exceptions.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpClientServers["mcp-client-servers<br/>MCP client servers"]:::touched
	mcpObs["mcp-server<br/>MCP endpoint"]:::untouched
	mcpClientServers -->|"McpCallerError skips Sentry"| mcpObs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| Unknown / blank `server` in `resolveMcpServerSetting` | `Error` → Sentry issue | `McpCallerError` → mcp-event only |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a2ec64f-0d9e-4845-9935-77321a477381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a2ec64f-0d9e-4845-9935-77321a477381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for missing or blank MCP server selections, now returning caller-specific errors.
  * Added clearer caller-facing errors when an MCP server cannot be found (including known saved server guidance).
  * Server names are resolved consistently regardless of capitalization.
* **Tests**
  * Added Vitest coverage for resolving MCP server settings by ID and case-insensitive name, including invalid and unmatched inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->