### PR TITLE
fix(sentry): stop capturing transient DO resets during package publish

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -2,7 +2,6 @@ import { expect, test, vi } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const mockModule = vi.hoisted(() => ({
-	captureException: vi.fn(),
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
 	getEntitySourceByIdForUser: vi.fn(),
@@ -11,11 +10,6 @@ const mockModule = vi.hoisted(() => ({
 	listPublishedPackageArtifactTargets: vi.fn(),
 	rebuildPublishedPackageArtifact: vi.fn(),
 	getStaticPackageDependentsSummary: vi.fn(),
-}))
-
-vi.mock('@sentry/cloudflare', () => ({
-	captureException: (...args: Array<unknown>) =>
-		mockModule.captureException(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -458,15 +452,7 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 			sessionId: 'external-publish-source-1-retry-2',
 		}),
 	)
-	expect(mockModule.captureException).toHaveBeenCalledWith(
-		expect.any(Error),
-		expect.objectContaining({
-			tags: {
-				scope: 'package_publish_external_push.transient-do-reset',
-			},
-		}),
-	)
-	// Each transient reset leaves exactly one retry warn trail.
+	// Each transient reset leaves exactly one retry warn trail (no Sentry).
 	expect(consoleWarn).toHaveBeenCalledTimes(1)
 
 	setupDefaultMocks()
@@ -527,8 +513,8 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 	})
 
 	setupDefaultMocks()
-	mockModule.captureException.mockClear()
 	mockModule.publishFromExternalRef.mockClear()
+	consoleWarn.mockClear()
 	mockModule.publishFromExternalRef.mockRejectedValue(
 		new Error('Durable Object exceeded its CPU time limit and was reset'),
 	)
@@ -541,7 +527,7 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 		/could not recover after 3 transient Durable Object reset attempts/,
 	)
 	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(3)
-	expect(mockModule.captureException).toHaveBeenCalledTimes(3)
+	expect(consoleWarn).toHaveBeenCalledTimes(3)
 
 	setupDefaultMocks()
 	mockModule.publishFromExternalRef.mockClear()

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/cloudflare'
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
@@ -64,6 +63,8 @@ function logExternalPublishRetry(input: {
 	nextDelayMs: number
 	error: unknown
 }) {
+	// Log-only: DO isolate memory/CPU resets are retried; do not open Sentry
+	// issues per attempt. Exhausted retries still throw and hit MCP observability.
 	const errorMessage = getErrorMessage(input.error)
 	console.warn(
 		JSON.stringify({
@@ -77,20 +78,6 @@ function logExternalPublishRetry(input: {
 			errorMessage,
 		}),
 	)
-	Sentry.captureException(input.error, {
-		tags: {
-			scope: 'package_publish_external_push.transient-do-reset',
-		},
-		extra: {
-			sourceId: input.sourceId,
-			repoId: input.repoId,
-			packageId: input.packageId,
-			newCommit: input.newCommit,
-			attempt: input.attempt,
-			nextDelayMs: input.nextDelayMs,
-			errorMessage,
-		},
-	})
 }
 
 async function delay(ms: number) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-2A](https://kent-c-dodds-tech-llc.sentry.io/issues/7634154874/) was opened from `package_publish_external_push` **during a successful retry path**: artifact rebuild hit Cloudflare's Durable Object isolate memory limit, the capability logged + retried (attempts 1–2 in breadcrumbs, tag `scope=package_publish_external_push.transient-do-reset`), and `Sentry.captureException` still filed the attempt even though publish is designed to recover.

This change keeps the structured `console.warn` retry trail and removes per-attempt Sentry capture. Exhausted retries still throw (`could not recover after N…`) and remain visible via MCP failure observability.

## Test plan

- [x] `npm run test -- --run packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts`
- [ ] CI `validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `81799504` · **Head:** `e86e326d`

**Classification:** composes — observability-only change on the existing external package publish retry path; no capability contract, storage, or auth changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | composes — stop `Sentry.captureException` on transient DO reset retries in `package_publish_external_push` |

### System map

External package publish retries Cloudflare DO isolate resets during artifact rebuild; this PR stops filing those expected attempts to Sentry while keeping log trails and exhausted-retry failures.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	repoSession["repo-sessions<br/>Repo sessions"]:::untouched
	sentry["sentry<br/>Error reporting"]:::untouched
	savedPackages -->|"publish + rebuild via RepoSession DO"| repoSession
	savedPackages -->|"removed per-attempt captureException on DO reset retry"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cap as package_publish_external_push
	participant DO as RepoSession DO
	participant Log as console.warn
	participant Sentry as Sentry
	Cap->>DO: publish + rebuild artifacts
	DO-->>Cap: isolate memory/CPU reset
	Cap->>Log: transient DO reset (attempt N)
	Note over Cap,Sentry: no captureException on retry
	alt recovered on later attempt
		Cap->>DO: retry with fresh session id
		DO-->>Cap: success
	else retries exhausted
		Cap-->>Cap: throw could not recover
		Note over Cap,Sentry: MCP failure observability still reports
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-586bbb39-8353-49a3-bdb4-5593921734de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-586bbb39-8353-49a3-bdb4-5593921734de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging for transient recovery retries by reporting warnings directly in application logs.
  * Prevented repeated error tracking events from being generated for expected retry attempts.
  * Updated recovery behavior checks to verify warning output during Durable Object reset and rebuild scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->