### PR TITLE
fix(jobs): keep missing job id lookups out of Sentry

### DIFF
--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -15,6 +15,7 @@ import {
 	createJob,
 	deleteJob,
 	executeJobOnce,
+	getJob,
 	getJobInspection,
 	inspectJobsForUser,
 	runJobNow,
@@ -1449,16 +1450,18 @@ test('updateJob and deleteJob reject another user trying to mutate or remove a j
 		},
 	}) as PersistedJobCallerContext
 
-	await expect(
-		updateJob({
-			env,
-			callerContext: otherCallerContext,
-			body: {
-				id: created.id,
-				enabled: false,
-			},
-		}),
-	).rejects.toThrow(`Job "${created.id}" was not found.`)
+	const updateError = await updateJob({
+		env,
+		callerContext: otherCallerContext,
+		body: {
+			id: created.id,
+			enabled: false,
+		},
+	}).catch((caught: unknown) => caught)
+	expect(updateError).toBeInstanceOf(McpCallerError)
+	expect(updateError).toMatchObject({
+		message: `Job "${created.id}" was not found.`,
+	})
 
 	let inspection = await getJobInspection({
 		env,
@@ -1467,13 +1470,15 @@ test('updateJob and deleteJob reject another user trying to mutate or remove a j
 	})
 	expect(inspection.job.enabled).toBe(true)
 
-	await expect(
-		deleteJob({
-			env,
-			userId: 'user-999',
-			jobId: created.id,
-		}),
-	).rejects.toThrow(`Job "${created.id}" was not found.`)
+	const deleteError = await deleteJob({
+		env,
+		userId: 'user-999',
+		jobId: created.id,
+	}).catch((caught: unknown) => caught)
+	expect(deleteError).toBeInstanceOf(McpCallerError)
+	expect(deleteError).toMatchObject({
+		message: `Job "${created.id}" was not found.`,
+	})
 
 	inspection = await getJobInspection({
 		env,
@@ -1481,6 +1486,44 @@ test('updateJob and deleteJob reject another user trying to mutate or remove a j
 		jobId: created.id,
 	})
 	expect(inspection.job.id).toBe(created.id)
+})
+
+test('missing job ids throw McpCallerError from get/inspect/run-now', async () => {
+	const env = {
+		APP_DB: createDatabase(),
+	} as Env
+	const missingJobId = 'missing-job-id'
+	const userId = createBaseCallerContext().user.userId
+
+	const getError = await getJob({
+		env,
+		userId,
+		jobId: missingJobId,
+	}).catch((caught: unknown) => caught)
+	expect(getError).toBeInstanceOf(McpCallerError)
+	expect(getError).toMatchObject({
+		message: `Job "${missingJobId}" was not found.`,
+	})
+
+	const inspectionError = await getJobInspection({
+		env,
+		userId,
+		jobId: missingJobId,
+	}).catch((caught: unknown) => caught)
+	expect(inspectionError).toBeInstanceOf(McpCallerError)
+	expect(inspectionError).toMatchObject({
+		message: `Job "${missingJobId}" was not found.`,
+	})
+
+	const runNowError = await runJobNow({
+		env,
+		userId,
+		jobId: missingJobId,
+	}).catch((caught: unknown) => caught)
+	expect(runNowError).toBeInstanceOf(McpCallerError)
+	expect(runNowError).toMatchObject({
+		message: `Job "${missingJobId}" was not found.`,
+	})
 })
 
 test('updateJob clears params, updates timezone, and disables a job', async () => {

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -1071,7 +1071,9 @@ export async function getJob(input: {
 }) {
 	const row = await getJobRowById(input.env.APP_DB, input.userId, input.jobId)
 	if (!row) {
-		throw new Error(`Job "${input.jobId}" was not found.`)
+		// Caller-supplied job id that does not resolve for this user — keep it
+		// off Sentry via McpCallerError (agent typos / stale ids are routine).
+		throw new McpCallerError(`Job "${input.jobId}" was not found.`)
 	}
 	return toJobView(row.record)
 }
@@ -1133,7 +1135,7 @@ export async function updateJob(input: {
 				input.body.id,
 			)
 			if (!existingRow) {
-				throw new Error(`Job "${input.body.id}" was not found.`)
+				throw new McpCallerError(`Job "${input.body.id}" was not found.`)
 			}
 			const existing = existingRow.record
 			const nextSchedule =
@@ -1248,7 +1250,7 @@ export async function deleteJob(input: {
 				input.jobId,
 			)
 			if (!row) {
-				throw new Error(`Job "${input.jobId}" was not found.`)
+				throw new McpCallerError(`Job "${input.jobId}" was not found.`)
 			}
 			await cleanupAdHocJobSource({
 				env: input.env,
@@ -1439,7 +1441,7 @@ export async function runJobNow(input: {
 				input.jobId,
 			)
 			if (!row) {
-				throw new Error(`Job "${input.jobId}" was not found.`)
+				throw new McpCallerError(`Job "${input.jobId}" was not found.`)
 			}
 			const activeCallerContext = input.callerContext
 				? requirePersistableJobCallerContext(input.callerContext)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`job_get` (and sibling job mutate paths) threw a plain `Error` when a caller-supplied job id did not resolve for the signed-in user. Agents routinely hit this with stale or typo’d ids; MCP observability then opened Sentry issues that look like platform bugs ([KODY-CLOUDFLARE-2B](https://kent-c-dodds-tech-llc.sentry.io/issues/7634158345/)).

Throw `McpCallerError` instead so the established caller-error carve-out keeps these on `mcp-event` logs only. MCP response messages are unchanged.

## Changes

- `getJob`, `updateJob`, `deleteJob`, and `runJobNow` throw `McpCallerError` for missing job ids
- Tests assert the caller-error type on get/inspect/run-now and cross-user mutate/delete

## Test plan

- [x] Focused unit tests for missing-job `McpCallerError` paths
- [ ] `npm run validate` / CI

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/sentry-triage-kody-cloudflare-2b-a6da`

**Classification:** composes — reuses existing `McpCallerError` on job not-found paths; no new primitives or API shape changes.

### Primitives touched

| Primitive | Group     | Impact   |
| --------- | --------- | -------- |
| `jobs`    | assistant | composes |

### System map

Missing job ids from MCP job capabilities now fail as caller errors so Sentry stays quiet.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	jobs["jobs<br/>Scheduled jobs"]:::touched
	mcpServer -->|"job_get / update / delete / run_now"| jobs
	jobs -->|"McpCallerError on missing id"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Path | Before | After |
| ---- | ------ | ----- |
| Missing job id | `Error` → Sentry issue | `McpCallerError` → mcp-event only |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5390b5b0-2557-4fa2-b811-c06b16b6bd4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5390b5b0-2557-4fa2-b811-c06b16b6bd4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when requested jobs are not found.
  * Standardized job-related errors for missing or unauthorized jobs, providing clearer and more consistent messages.
  * Updated behavior across viewing, updating, deleting, and running jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->