### PR TITLE
fix(sentry): drop bare Cloudflare DO isolate reset noise

### DIFF
--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -225,7 +225,7 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).toBeNull()
 
-	const exhaustedPublishRecovery = {
+	const exhaustedPublishRecoveryInline = {
 		exception: {
 			values: [
 				{
@@ -234,8 +234,23 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 			],
 		},
 	}
-	expect(filterSentryEvent(exhaustedPublishRecovery)).toBe(
-		exhaustedPublishRecovery,
+	expect(filterSentryEvent(exhaustedPublishRecoveryInline)).toBe(
+		exhaustedPublishRecoveryInline,
+	)
+
+	const exhaustedPublishRecoveryChained = {
+		exception: {
+			values: [
+				{
+					value:
+						'package_publish_external_push could not recover after 3 transient Durable Object reset attempts',
+				},
+				{ value: durableObjectIsolateMemoryResetMessage },
+			],
+		},
+	}
+	expect(filterSentryEvent(exhaustedPublishRecoveryChained)).toBe(
+		exhaustedPublishRecoveryChained,
 	)
 
 	const unrelatedDoFailure = {

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from 'vitest'
 import { isUserCodeError, UserCodeError } from './user-code-error.ts'
 import {
+	durableObjectIsolateCpuResetMessage,
+	durableObjectIsolateMemoryResetMessage,
 	executorSandboxTimeoutMessage,
 	filterSentryEvent,
 } from './sentry-options.ts'
@@ -183,4 +185,64 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).toBe(platformEvent)
 	expect(filterSentryEvent(platformEvent)).toBe(platformEvent)
+
+	// Bare Cloudflare DO isolate resets (memory / CPU) are transient platform
+	// limit hits — drop exact strings, including optional `Error:` prefix and
+	// missing trailing period. Wrapped recovery failures must stay visible.
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [{ value: durableObjectIsolateMemoryResetMessage }],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							"Error: Durable Object's isolate exceeded its memory limit and was reset.",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Durable Object exceeded its CPU time limit and was reset',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			message: durableObjectIsolateCpuResetMessage,
+		}),
+	).toBeNull()
+
+	const exhaustedPublishRecovery = {
+		exception: {
+			values: [
+				{
+					value: `package_publish_external_push could not recover after 3 transient Durable Object reset attempts: ${durableObjectIsolateMemoryResetMessage}`,
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(exhaustedPublishRecovery)).toBe(
+		exhaustedPublishRecovery,
+	)
+
+	const unrelatedDoFailure = {
+		exception: {
+			values: [{ value: 'Durable Object was reset during migration' }],
+		},
+	}
+	expect(filterSentryEvent(unrelatedDoFailure)).toBe(unrelatedDoFailure)
 })

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -213,8 +213,7 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 			exception: {
 				values: [
 					{
-						value:
-							'Durable Object exceeded its CPU time limit and was reset',
+						value: 'Durable Object exceeded its CPU time limit and was reset',
 					},
 				],
 			},

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -112,10 +112,15 @@ export function isDurableObjectIsolateResetMessage(message: string) {
 }
 
 export function isDurableObjectIsolateResetSentryEvent(event: ErrorEvent) {
-	return sentryEventMessages(event).some(
-		(message) =>
-			typeof message === 'string' &&
-			isDurableObjectIsolateResetMessage(message),
+	const messages = sentryEventMessages(event).filter(
+		(message): message is string =>
+			typeof message === 'string' && message.trim().length > 0,
+	)
+	// Drop only when every reported message is a bare reset. A chained cause
+	// that pairs a recovery/wrapper value with an inner reset must stay visible.
+	return (
+		messages.length > 0 &&
+		messages.every((message) => isDurableObjectIsolateResetMessage(message))
 	)
 }
 

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -81,6 +81,48 @@ export function filterExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
 	return null
 }
 
+/**
+ * Exact Cloudflare Durable Object isolate-reset messages. When a DO hits its
+ * memory or CPU limit, the platform resets the isolate and surfaces this error
+ * to the RPC caller (for example `job_run_now` → JobManager). The next call
+ * gets a fresh isolate; app-level retry is unsafe for non-idempotent jobs, and
+ * moving heavy orchestration off JobManager is an architectural change outside
+ * a triage fix. Match only the bare platform strings so wrapped failures such
+ * as exhausted `package_publish_external_push` recovery messages stay visible.
+ */
+export const durableObjectIsolateMemoryResetMessage =
+	"Durable Object's isolate exceeded its memory limit and was reset."
+
+export const durableObjectIsolateCpuResetMessage =
+	'Durable Object exceeded its CPU time limit and was reset.'
+
+function normalizeDurableObjectIsolateResetMessage(message: string) {
+	const withoutErrorPrefix = message.trim().replace(/^Error:\s*/i, '')
+	return withoutErrorPrefix.endsWith('.')
+		? withoutErrorPrefix
+		: `${withoutErrorPrefix}.`
+}
+
+export function isDurableObjectIsolateResetMessage(message: string) {
+	const normalized = normalizeDurableObjectIsolateResetMessage(message)
+	return (
+		normalized === durableObjectIsolateMemoryResetMessage ||
+		normalized === durableObjectIsolateCpuResetMessage
+	)
+}
+
+export function isDurableObjectIsolateResetSentryEvent(event: ErrorEvent) {
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' && isDurableObjectIsolateResetMessage(message),
+	)
+}
+
+export function filterDurableObjectIsolateResetSentryEvent(event: ErrorEvent) {
+	if (!isDurableObjectIsolateResetSentryEvent(event)) return event
+	return null
+}
+
 export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	// Marker first: primary mechanism for user-authored failures.
 	if (filterUserCodeErrorSentryEvent(event, hint) === null) return null
@@ -88,6 +130,7 @@ export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	// String-match backstops for paths that cannot yet be marked.
 	if (filterUserModuleBundlerFailureSentryEvent(event) === null) return null
 	if (filterExecutorSandboxTimeoutSentryEvent(event) === null) return null
+	if (filterDurableObjectIsolateResetSentryEvent(event) === null) return null
 	return event
 }
 
@@ -122,7 +165,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// (`filterUserCodeErrorSentryEvent`). Bundler / sandbox-timeout string
 		// matches remain as backstops for unmarked paths; see
 		// filterUserModuleBundlerFailureSentryEvent and
-		// filterExecutorSandboxTimeoutSentryEvent.
+		// filterExecutorSandboxTimeoutSentryEvent. Bare Cloudflare Durable
+		// Object isolate memory/CPU reset strings are dropped the same way —
+		// see filterDurableObjectIsolateResetSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -114,7 +114,8 @@ export function isDurableObjectIsolateResetMessage(message: string) {
 export function isDurableObjectIsolateResetSentryEvent(event: ErrorEvent) {
 	return sentryEventMessages(event).some(
 		(message) =>
-			typeof message === 'string' && isDurableObjectIsolateResetMessage(message),
+			typeof message === 'string' &&
+			isDurableObjectIsolateResetMessage(message),
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-2C](https://kent-c-dodds-tech-llc.sentry.io/issues/7634158509/) fired when MCP `job_run_now` hit JobManager during a burst of heavy runs (~45–50s successes, then failure). Cloudflare reset the Durable Object isolate with:

`Durable Object's isolate exceeded its memory limit and was reset.`

User job code runs in the LOADER sandbox; this error is the **orchestrating JobManager DO** exceeding platform memory/CPU limits. The next RPC gets a fresh isolate. App-level retry is unsafe for non-idempotent jobs, and moving heavy orchestration off JobManager is an architectural change outside triage scope.

This PR adds a targeted `beforeSend` filter for the **exact** Cloudflare isolate memory/CPU reset strings (same class as D1 object-reset blips). Events are dropped only when every reported message is a bare reset, so chained/wrapped recovery failures stay Sentry-visible. `mcp-event` logs are unchanged.

Related but separate: [#960](https://github.com/kentcdodds/kody/pull/960) stops per-attempt Sentry capture on publish DO-reset retries (RepoSession path).

## Test plan

- [x] `npm run test -- --run packages/worker/src/sentry-options.node.test.ts`
- [x] CI `validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `81799504` · **Head:** `01dc833f`

**Classification:** composes — observability-only `beforeSend` filter for exact Cloudflare DO isolate reset strings; no capability, storage, or auth contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| _(unmatched paths)_ `packages/worker/src/sentry-options.ts` | — | composes — narrow `beforeSend` drop for bare DO memory/CPU isolate resets |

### System map

MCP `job_run_now` (and similar DO RPC callers) can surface Cloudflare isolate resets when a warm JobManager DO hits platform limits; those exact strings no longer open Sentry issues.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	jobs["jobs<br/>JobManager / job_run_now"]:::untouched
	sentryOpts["sentry-options<br/>beforeSend filters"]:::touched
	jobs -->|"DO isolate memory/CPU reset"| sentryOpts
	sentryOpts -->|"exact bare message → drop"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cap as job_run_now
	participant DO as JobManager DO
	participant MCP as mcp-event log
	participant Sentry as Sentry beforeSend
	Cap->>DO: runNow (heavy successive runs)
	DO-->>Cap: isolate memory/CPU reset
	Cap->>MCP: failure still logged
	Cap->>Sentry: captureException
	Note over Sentry: exact bare CF reset string dropped
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-527dea00-7f00-4a09-976a-4283bcd65dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-527dea00-7f00-4a09-976a-4283bcd65dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise in error monitoring by filtering transient Durable Object isolate memory and CPU reset events.
  * Improved event classification to correctly drop exact reset message variants across both `exception` and top-level `message`.
  * Preserved visibility for exhausted recovery events and unrelated reset errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->