### PR TITLE
fix(mcp): keep unavailable value/secret scopes out of Sentry

### DIFF
--- a/packages/worker/src/mcp/capabilities/values/value-set.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-set.ts
@@ -31,7 +31,9 @@ export const valueSetCapability = defineDomainCapability(
 			scope: z
 				.enum(valueScopeValues)
 				.default('session')
-				.describe('Storage scope for the value.'),
+				.describe(
+					'Storage scope for the value. "session" requires an active session context; use "user" for durable values from MCP or other contexts without a session.',
+				)
 		}),
 		outputSchema: valueMetadataSchema,
 		async handler(args, ctx: CapabilityContext) {

--- a/packages/worker/src/mcp/capabilities/values/value-set.ts
+++ b/packages/worker/src/mcp/capabilities/values/value-set.ts
@@ -33,7 +33,7 @@ export const valueSetCapability = defineDomainCapability(
 				.default('session')
 				.describe(
 					'Storage scope for the value. "session" requires an active session context; use "user" for durable values from MCP or other contexts without a session.',
-				)
+				),
 		}),
 		outputSchema: valueMetadataSchema,
 		async handler(args, ctx: CapabilityContext) {

--- a/packages/worker/src/mcp/secrets/service.node.test.ts
+++ b/packages/worker/src/mcp/secrets/service.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -373,6 +374,35 @@ test('resolveSecret returns the first scope hit in precedence order', async () =
 		allowedCapabilities: [],
 		allowedPackages: [],
 	})
+})
+
+test('saveSecret rejects unavailable scoped storage as McpCallerError', async () => {
+	const testDb = createSecretTestDb()
+	const env = {
+		APP_DB: testDb.db,
+		COOKIE_SECRET: 'test-cookie-secret',
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+	}
+
+	await expect(
+		saveSecret({
+			env,
+			userId: 'user-123',
+			scope: 'session',
+			name: 'token',
+			value: 'missing-session',
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				packageId: null,
+			},
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message ===
+				'Secret scope "session" is unavailable in this context.',
+	)
 })
 
 test('listPackageSecretsByPackageIds groups package-owned secrets', async () => {

--- a/packages/worker/src/mcp/secrets/service.node.test.ts
+++ b/packages/worker/src/mcp/secrets/service.node.test.ts
@@ -403,6 +403,26 @@ test('saveSecret rejects unavailable scoped storage as McpCallerError', async ()
 			error.message ===
 				'Secret scope "session" is unavailable in this context.',
 	)
+
+	await expect(
+		saveSecret({
+			env,
+			userId: 'user-123',
+			scope: 'package',
+			name: 'token',
+			value: 'missing-package',
+			storageContext: {
+				sessionId: null,
+				appId: null,
+				packageId: null,
+			},
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message ===
+				'Secret scope "package" is unavailable in this context.',
+	)
 })
 
 test('listPackageSecretsByPackageIds groups package-owned secrets', async () => {

--- a/packages/worker/src/mcp/secrets/service.ts
+++ b/packages/worker/src/mcp/secrets/service.ts
@@ -1,3 +1,4 @@
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	normalizeAllowedCapabilities,
 	parseAllowedCapabilities,
@@ -582,7 +583,9 @@ async function getOrCreateSecretBucket(input: {
 }) {
 	const bindingKey = getSecretBindingKey(input.scope, input.storageContext)
 	if (bindingKey == null) {
-		throw new Error(
+		// Caller asked for session/package scope without that binding in the
+		// current storage context. Keep it off Sentry via McpCallerError.
+		throw new McpCallerError(
 			`Secret scope "${input.scope}" is unavailable in this context.`,
 		)
 	}

--- a/packages/worker/src/mcp/values/service.node.test.ts
+++ b/packages/worker/src/mcp/values/service.node.test.ts
@@ -369,8 +369,7 @@ test('value service rejects unavailable scoped storage', async () => {
 	).rejects.toSatisfy(
 		(error: unknown) =>
 			error instanceof McpCallerError &&
-			error.message ===
-				'Value scope "session" is unavailable in this context.',
+			error.message === 'Value scope "session" is unavailable in this context.',
 	)
 })
 

--- a/packages/worker/src/mcp/values/service.node.test.ts
+++ b/packages/worker/src/mcp/values/service.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	deleteAllAppScopedValues,
 	deleteValue,
@@ -347,7 +348,30 @@ test('value service rejects unavailable scoped storage', async () => {
 				appId: null,
 			},
 		}),
-	).rejects.toThrow('Value scope "app" is unavailable in this context.')
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message === 'Value scope "app" is unavailable in this context.',
+	)
+
+	await expect(
+		saveValue({
+			env,
+			userId: 'user-123',
+			scope: 'session',
+			name: 'workspaceSlug',
+			value: 'missing-session',
+			storageContext: {
+				sessionId: null,
+				appId: null,
+			},
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message ===
+				'Value scope "session" is unavailable in this context.',
+	)
 })
 
 test('deleteAllAppScopedValues removes all app-scoped values for one app', async () => {

--- a/packages/worker/src/mcp/values/service.ts
+++ b/packages/worker/src/mcp/values/service.ts
@@ -1,3 +1,4 @@
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	getStorageBindingKey,
 	resolveStorageScopeOrder,
@@ -261,7 +262,10 @@ async function getOrCreateValueBucket(input: {
 }) {
 	const bindingKey = getStorageBindingKey(input.scope, input.storageContext)
 	if (bindingKey == null) {
-		throw new Error(
+		// Caller asked for session/app scope without that binding in the
+		// current storage context (common for MCP value_set with default
+		// scope "session"). Keep it off Sentry via McpCallerError.
+		throw new McpCallerError(
 			`Value scope "${input.scope}" is unavailable in this context.`,
 		)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [7634425298](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7634425298/): `value_set` threw a plain `Error` when scope `"session"` was requested without a session binding (the capability defaults to `session`). That is a caller mistake — MCP observability should keep it on `mcp-event` logs, not open a platform bug issue.

## Fix

- Throw `McpCallerError` from `getOrCreateValueBucket` / `getOrCreateSecretBucket` when the requested scope has no binding in the current storage context (same pattern as recent job/MCP caller-error triage PRs).
- Clarify `value_set` scope docs: use `"user"` when there is no session context.
- Unit tests cover unavailable session/app value scopes and session/package secret scopes.

## Risk

**composes / low** — error-class wiring only; no auth, isolation, billing, or migration surface. Intended to squash-merge after CI + AI review.

## Siblings

Prefetched unresolved siblings (`updateCurrentEntry`, workflow timeout, search ValidationError) do not share this root cause.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `01399f13` · **Head:** `90f324af`

**Classification:** composes — reuses the existing `McpCallerError` carve-out so unavailable session/app/package scopes stay off Sentry; no primitive shape or contract change.

### Primitives touched

| Primitive    | Group     | Impact                                                                 |
| ------------ | --------- | ---------------------------------------------------------------------- |
| `mcp-server` | surfaces  | composes — throw `McpCallerError` for unavailable value/secret scopes |
| `values`     | assistant | composes — clarify `value_set` scope description                      |

### System map

`value_set` / secret save hit the values/secrets services; unavailable scope bindings now surface as caller errors so MCP observability skips Sentry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	valuesCap["values<br/>Values"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	observability["mcp observability<br/>caller-error carve-out"]:::untouched
	valuesCap -->|"value_set scope binding"| mcpServer
	mcpServer -->|"McpCallerError skips Sentry"| observability
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant value_set
	participant saveValue
	participant Sentry
	Agent->>value_set: scope=session (default), no sessionId
	value_set->>saveValue: getOrCreateValueBucket
	saveValue-->>value_set: McpCallerError
	value_set-->>Agent: caller-facing error
	Note over Sentry: not captured (isMcpCallerError)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc14df0c-e7ab-4882-9c1e-753615c33d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc14df0c-e7ab-4882-9c1e-753615c33d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified storage semantics for `scope`: session-scoped items require an active session, while user-scoped items are available without one.
- **Bug Fixes**
  - Improved handling when requested storage scope isn’t available for the current context for both values and secrets.
  - These now return a consistent `McpCallerError` with clear, scope-specific messages instead of a generic failure.
- **Tests**
  - Added/updated unit tests to assert `McpCallerError` type and exact error messages for unavailable session-scope and related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->