### PR TITLE
Cover the untested arm of the 0097 storage bucket backfill

### DIFF
--- a/packages/worker/src/storage-buckets/migration.node.test.ts
+++ b/packages/worker/src/storage-buckets/migration.node.test.ts
@@ -39,6 +39,15 @@ test('user_storage_buckets migration backfills jobs, apps, and runtime-only buck
 			'2026-07-04T00:00:00.000Z', '2026-07-05T00:00:00.000Z'
 		);
 
+		INSERT INTO archived_job_artifacts (
+			id, job_id, user_id, source_id, published_commit, storage_id,
+			retain_until, created_at, updated_at
+		) VALUES (
+			'archived-1', 'job-deleted', 'user-a', 'source-job-2', 'abc123',
+			'job:job-deleted', '2026-09-01T00:00:00.000Z',
+			'2026-07-07T00:00:00.000Z', '2026-07-08T00:00:00.000Z'
+		);
+
 		INSERT INTO package_runtime_runs (
 			id, user_id, package_id, package_kody_id, surface, status,
 			started_at, storage_id, created_at, updated_at
@@ -46,6 +55,17 @@ test('user_storage_buckets migration backfills jobs, apps, and runtime-only buck
 			'run-adhoc-1', 'user-a', 'pkg-none', 'none', 'export', 'success',
 			'2026-07-06T00:00:00.000Z', 'exec:legacy-only',
 			'2026-07-06T00:00:00.000Z', '2026-07-06T00:01:00.000Z'
+		);
+
+		-- Same bucket in both an authoritative table and run history: the
+		-- authoritative kind must win, since the rescue arm runs last.
+		INSERT INTO package_runtime_runs (
+			id, user_id, package_id, package_kody_id, surface, status,
+			started_at, storage_id, created_at, updated_at
+		) VALUES (
+			'run-job-1', 'user-a', 'pkg-none', 'none', 'export', 'success',
+			'2026-07-09T00:00:00.000Z', 'job:job-1',
+			'2026-07-09T00:00:00.000Z', '2026-07-09T00:01:00.000Z'
 		);
 	`)
 
@@ -79,6 +99,13 @@ test('user_storage_buckets migration backfills jobs, apps, and runtime-only buck
 			kind: 'job',
 			created_at: '2026-07-01T00:00:00.000Z',
 			last_seen_at: '2026-07-02T00:00:00.000Z',
+		},
+		{
+			user_id: 'user-a',
+			storage_id: 'job:job-deleted',
+			kind: 'job',
+			created_at: '2026-07-07T00:00:00.000Z',
+			last_seen_at: '2026-07-08T00:00:00.000Z',
 		},
 		{
 			user_id: 'user-a',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Test-only. Closes a verification gap on something that becomes unrecoverable after ~2026-08-25.

## Why this matters more than a normal missing test

Migration `0097` (from #965) backfills `user_storage_buckets` from four sources. It already applied to production successfully, so the SQL is valid — but "valid" is not "captured the rows it should have", and the existing test only exercised three of the four arms.

The untested one was `archived_job_artifacts`. Those buckets belong to jobs that have already been deleted, so **nothing else in D1 references them**. If that arm were semantically wrong, the buckets would still be reachable today via the legacy `package_runtime_runs` rows — and would silently become unreachable when those drain around 2026-08-25, leaving orphaned Durable Object storage that account deletion can never purge and that DR never backs up. We would not find out until after the only record was gone.

The good news is the arm is correct: `archived_job_artifacts.storage_id` is `NOT NULL`, and the test now proves the rows land with the right kind and timestamps. This just pins it.

## Also pinned: kind precedence

The migration runs the authoritative arms (`jobs`, `archived_job_artifacts`, `saved_packages`) before the `package_runtime_runs` rescue arm, and relies on `INSERT OR IGNORE` so the first writer wins. That means a bucket present in both an authoritative table and run history keeps its real kind (`job`) rather than the rescue arm's `unknown`.

That guarantee was implicit in statement ordering with nothing asserting it. Reordering the file would silently degrade kinds. Now a test catches it.

## What this does not tell us

It verifies the backfill *logic* against the real migration files on real SQLite. It does not tell us how many rows landed in **production** — `wrangler d1 migrations apply` does not report per-statement row counts, and there is no admin capability to query arbitrary tables. If you want that number, it is a one-off `SELECT kind, COUNT(*) FROM user_storage_buckets GROUP BY kind` against production.

## Verification

Node suite green (1197 tests), lint and format clean. No production code touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded migration coverage for archived job artifacts and package runtime records.
  * Added validation for backfilled job storage buckets, including timestamp fields.
  * Confirmed authoritative bucket information takes precedence over run history when both exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->