### PR TITLE
Backfill package service states from run history before it drains

### DIFF
--- a/packages/worker/migrations/0098-backfill-package-service-states.sql
+++ b/packages/worker/migrations/0098-backfill-package-service-states.sql
@@ -1,0 +1,34 @@
+-- One-time rescue of package services that only survive in run history.
+--
+-- `package_service_states` (0095) is written on service lifecycle transitions
+-- and heartbeated while running, so it only gains a row once a
+-- `PackageServiceInstance` Durable Object wakes. A service that stopped before
+-- the run-records migration and never woke again therefore has no row, and is
+-- reachable only through `package_runtime_runs` — which stopped being written
+-- and drains under the 30-day retention policy.
+--
+-- Account deletion enumerates services to purge their Durable Objects, so
+-- losing that record would leave service state alive after an account is
+-- deleted. This backfill is the last opportunity to capture them, and it is
+-- what lets the legacy `package_runtime_runs` read be removed.
+--
+-- Rescued rows are recorded as `stopped`: these services have not run in
+-- weeks, `stopped` is the honest status, and it keeps them out of the running
+-- count that enforces the concurrency entitlement. `updated_at` carries the
+-- last observed run so staleness handling stays accurate.
+
+INSERT OR IGNORE INTO package_service_states (
+	user_id, package_id, service_name, status, started_at, updated_at
+)
+SELECT
+	user_id,
+	package_id,
+	name,
+	'stopped',
+	NULL,
+	MAX(started_at)
+FROM package_runtime_runs
+WHERE surface = 'service'
+	AND name IS NOT NULL
+	AND trim(name) != ''
+GROUP BY user_id, package_id, name;

--- a/packages/worker/src/entitlements/package-service-states-migration.node.test.ts
+++ b/packages/worker/src/entitlements/package-service-states-migration.node.test.ts
@@ -1,0 +1,111 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+const backfillMigration = '0098-backfill-package-service-states.sql'
+
+function applyMigrationsBefore(db: DatabaseSync, exclusiveUpperBound: string) {
+	for (const fileName of readdirSync(migrationsDirectory)
+		.filter((file) => file.endsWith('.sql') && file < exclusiveUpperBound)
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
+	}
+}
+
+function insertServiceRun(
+	db: DatabaseSync,
+	input: { id: string; packageId: string; name: string; startedAt: string },
+) {
+	db.exec(`
+		INSERT INTO package_runtime_runs (
+			id, user_id, package_id, package_kody_id, surface, status,
+			started_at, created_at, updated_at, name
+		) VALUES (
+			'${input.id}', 'user-a', '${input.packageId}', 'kody-id', 'service',
+			'success', '${input.startedAt}', '${input.startedAt}',
+			'${input.startedAt}', '${input.name}'
+		);
+	`)
+}
+
+test('backfill rescues legacy-only services as stopped with their last run', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBefore(db, backfillMigration)
+
+	// Two runs of the same service: the newest run wins as `updated_at`.
+	insertServiceRun(db, {
+		id: 'run-1',
+		packageId: 'pkg-1',
+		name: 'email-agent-processor',
+		startedAt: '2026-05-30T14:24:06.316Z',
+	})
+	insertServiceRun(db, {
+		id: 'run-2',
+		packageId: 'pkg-1',
+		name: 'email-agent-processor',
+		startedAt: '2026-07-06T20:11:51.487Z',
+	})
+	insertServiceRun(db, {
+		id: 'run-3',
+		packageId: 'pkg-2',
+		name: 'other-service',
+		startedAt: '2026-06-01T00:00:00.000Z',
+	})
+
+	// A service that already projected real state must not be overwritten.
+	db.exec(`
+		INSERT INTO package_service_states (
+			user_id, package_id, service_name, status, started_at, updated_at
+		) VALUES (
+			'user-a', 'pkg-3', 'live-service', 'running',
+			'2026-07-26T00:00:00.000Z', '2026-07-26T01:00:00.000Z'
+		);
+	`)
+	insertServiceRun(db, {
+		id: 'run-4',
+		packageId: 'pkg-3',
+		name: 'live-service',
+		startedAt: '2026-05-01T00:00:00.000Z',
+	})
+
+	db.exec(readFileSync(new URL(backfillMigration, migrationsDirectory), 'utf8'))
+
+	const rows = db
+		.prepare(
+			`SELECT package_id, service_name, status, started_at, updated_at
+			FROM package_service_states
+			ORDER BY package_id ASC`,
+		)
+		.all() as Array<{
+		package_id: string
+		service_name: string
+		status: string
+		started_at: string | null
+		updated_at: string
+	}>
+
+	expect(rows).toEqual([
+		{
+			package_id: 'pkg-1',
+			service_name: 'email-agent-processor',
+			status: 'stopped',
+			started_at: null,
+			updated_at: '2026-07-06T20:11:51.487Z',
+		},
+		{
+			package_id: 'pkg-2',
+			service_name: 'other-service',
+			status: 'stopped',
+			started_at: null,
+			updated_at: '2026-06-01T00:00:00.000Z',
+		},
+		{
+			package_id: 'pkg-3',
+			service_name: 'live-service',
+			status: 'running',
+			started_at: '2026-07-26T00:00:00.000Z',
+			updated_at: '2026-07-26T01:00:00.000Z',
+		},
+	])
+})

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -415,6 +415,10 @@
 		{
 			"filename": "0097-user-storage-buckets.sql",
 			"sha256": "280af0890f1e517830535f9379d1d90b5bc05b9da5b1d8a5c6b9423ca3da842b"
+		},
+		{
+			"filename": "0098-backfill-package-service-states.sql",
+			"sha256": "e10562862d228d694b0516bf278ef81bdfb8a27c2691e8299f13b81582c41eda"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Step 1 of 2 for closing out #956. This rescues data; a follow-up drops the legacy tables and removes the code.

## Why now

I queried production to check whether the "wait for the drain" plan actually holds. It does not, and two numbers explain why:

- `package_service_states` has **0 rows**, fourteen hours after #955 shipped it. It only gains a row when a `PackageServiceInstance` Durable Object wakes, and nothing has.
- There are **2 services** known only through `package_runtime_runs` — both `email-agent-processor`, in different packages, last run 2026-05-30 and 2026-07-06. Neither has run since, so their Durable Objects are dormant and will never project state on their own.

Account deletion enumerates services to purge their Durable Objects. Once `package_runtime_runs` drains, those two become unenumerable and their state survives account deletion. This backfill is the last opportunity to capture them, and it is the thing that lets the final legacy read be removed rather than merely waiting on it.

## A correction to the plan in #956

While checking, I found the drain premise is wrong. `package_runtime_runs` holds 5,515 rows; **13 are older than 30 days and all 13 have `status = 'running'`** — the retention keep-condition. Nothing writes the table anymore, so those rows can never reach a terminal status and will never age out.

The table will not reach zero. #956 currently says the legacy arms become provably dead "once drained"; that will never happen by waiting. The follow-up PR drops the tables outright, which is the only thing that actually ends it.

## What the migration does

Rescued services are recorded as `stopped`, which is honest — neither has run in weeks — and keeps them out of the running count that enforces the concurrency entitlement. `updated_at` carries the last observed run so staleness handling stays accurate. `started_at` is left `NULL` because we do not know it.

`INSERT OR IGNORE` means a service that has already projected real state is never overwritten by a historical guess. There is a test asserting exactly that, alongside newest-run-wins for a service with multiple historical runs.

## Verification

The test applies every real migration file in order and then the real `0098` against SQLite, the same harness used for `0097`, so it exercises the shipped SQL rather than a copy.

`npm run validate` green apart from two sandbox-boot timeouts (`mcp endpoint requires OAuth bearer auth` and a run-records sandbox test) on a heavily loaded machine — the run reported a 5813s import phase. Both pass on re-run; this change is SQL plus one node test and cannot affect Wrangler boot time.

Expected production effect: exactly 2 rows inserted. I will confirm that against production after deploy before opening the drop PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored missing package service state records from historical runtime data.
  * Ensured recovered services appear as stopped while preserving existing live service states.
  * Applied the latest available activity timestamp to recovered records.

* **Tests**
  * Added coverage validating recovery behavior for legacy service records and existing state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->