### PR TITLE
Drop the run-history legacy tables and every remaining reference

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -244,16 +244,11 @@ The schema is defined by migrations in `packages/worker/migrations/`:
 - `jobs`: persisted job metadata, caller context, schedule state, repo source
   pointers, and run observability state (`last_run_*`, counters). Execution
   history lives in the per-user `RunLog` Durable Object (see
-  [Run records](./run-records.md)); `jobs.run_history_json` is left unwritten
-  and pending a drop migration.
+  [Run records](./run-records.md)).
 - `package_service_states` (`0095-package-service-states.sql`): authoritative
   per-service liveness projection (`running` / `idle` / `stopped` / `error`) for
   entitlement concurrency. Upserted and heartbeaten by the package-service
   Durable Object; not derived from run history.
-- `package_runtime_runs` / `package_runtime_logs`
-  (`0037-package-runtime-debug.sql`): **unwritten leftovers.** Writers do not
-  use these tables. Hourly retention drains any remaining rows; a follow-up
-  migration drops the tables. Execution history lives in `RunLog`.
 - `entity_sources`: durable mapping from user-facing entities to Artifacts repos
   and their latest published commit
 - `saved_packages`: package metadata/search projection derived from published
@@ -643,14 +638,12 @@ The following columns store JSON whose schema is defined in TypeScript rather
 than in D1 constraints. Changes must be backward compatible on read and additive
 on write unless a migration backfills existing rows.
 
-- `jobs.params_json`, `jobs.schedule_json`, `jobs.caller_context_json`,
-  `jobs.run_history_json`, and `jobs.repo_check_policy_json`
-  (`packages/worker/migrations/0018-jobs.sql`,
-  `0025-jobs-repo-check-policy.sql`, `packages/worker/src/jobs/repo.ts`).
-  `run_history_json` is **unwritten** (run records own history; the column
-  remains until a follow-up drop migration). The other fields rely on parser and
-  normalizer compatibility. Package jobs persist both `storageContext.appId` for
-  value scope and `storageContext.packageId` for package-owned secret scope.
+- `jobs.params_json`, `jobs.schedule_json`, `jobs.caller_context_json`, and
+  `jobs.repo_check_policy_json` (`packages/worker/migrations/0018-jobs.sql`,
+  `0025-jobs-repo-check-policy.sql`, `packages/worker/src/jobs/repo.ts`) rely on
+  parser and normalizer compatibility. Package jobs persist both
+  `storageContext.appId` for value scope and `storageContext.packageId` for
+  package-owned secret scope.
 - `saved_packages.tags_json` and `community_listings.tags_json`
   (`0027-saved-packages.sql`, `0045-community-listings.sql`) are `string[]`
   projections.
@@ -670,15 +663,13 @@ on write unless a migration backfills existing rows.
   delivery details. Provider event ids are unique for idempotent Queue
   ingestion; `email_messages.delivery_status` is the latest provider state,
   separate from send-request `processing_status`.
-- `webhook_endpoints` / `webhook_deliveries` (`0090-webhook-endpoints.sql`)
-  store per-user minted URL state for `package.json#kody.webhooks`, keyed by
+- `webhook_endpoints` (`0090-webhook-endpoints.sql`) stores per-user minted URL
+  state for `package.json#kody.webhooks`, keyed by
   `(user_id, package_id, webhook_name)`. URL secrets are SHA-256 hashed;
   verification secrets stay in the secrets primitive (`secretName` at delivery
   time). Delivery history is recorded as `webhook` surface run records (see
-  [Run records](./run-records.md) and [Inbound webhooks](./webhooks.md));
-  writers do not use `webhook_deliveries`; the table remains until a follow-up
-  drop migration. Account deletion/export still include any remaining delivery
-  rows.
+  [Run records](./run-records.md) and [Inbound webhooks](./webhooks.md)), not as
+  D1 rows.
 - `system_email_daily_counters` (`0051-system-email-daily-counters.sql`) stores
   fixed per-local daily receive counters for operator-owned system inboxes.
   These counters are not user entitlements and are pruned by the system-email
@@ -700,11 +691,6 @@ on write unless a migration backfills existing rows.
   Mutations from package code (`secret_set` / `secret_delete` / OpenAPI
   token-refresh writes) always require the grant. Package-scoped secrets are
   owned exclusively by the package id in their bucket binding.
-- `package_runtime_runs.metadata_json` and `package_runtime_logs.fields_json`
-  (`0037-package-runtime-debug.sql`) are **unwritten** leftover JSON shapes.
-  Writers do not use those tables; metadata and log fields live in the `RunLog`
-  Durable Object (`runs.metadata_json`, `run_logs.fields_json`). A follow-up
-  migration drops the D1 tables.
 
 ### Durable Object id contracts
 
@@ -850,16 +836,6 @@ documented exemption.
 
 Current retention policies:
 
-- `package_runtime_runs` / `package_runtime_logs`: **drain-only leftovers.** Run
-  records self-prune inside the per-user `RunLog` Durable Object (about 30 days
-  and at most 2,000 runs per user, failure-last — see
-  [Run records](./run-records.md)). These D1 lanes drain any remaining rows (30
-  days / at most 500 runs per `(user_id, package_id)`, keeping `running` rows
-  and referenced runs) until a follow-up migration drops the tables. Logs are
-  deleted before their runs, and orphan logs are pruned separately. The age
-  prune is index-driven; the per-package cap prune ranks only a bounded set of
-  the largest `(user_id, package_id)` pairs per batch
-  (`packageRuntimeCapPairsPerBatch`) instead of window-ranking the whole table.
 - `package_invocations`: keep terminal idempotency rows for 90 days. Rows with
   `status = 'in_progress'` are never pruned so duplicate requests cannot bypass
   the in-flight guard.

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -261,16 +261,16 @@ Rules:
   extracted message bodies/metadata, externally stored attachments, values,
   encrypted secrets, memories, saved-package projections, jobs, repo/session
   metadata, package invocation results, and published artifact metadata). Run
-  records (per-user `RunLog` Durable Object history, and any leftover
-  `package_runtime_*` D1 rows) are intentionally **excluded** from the quota —
-  they are observability history, not user content. StorageRunner Durable Object
-  buckets expose their own `estimatedBytes`; write chokepoints that target a
-  specific bucket pass `getCurrent` as `D1 estimate + target bucket estimate`
-  and `requested` as the candidate payload size when known. The counter
-  intentionally does **not** attempt to scan Cloudflare Artifacts repository
-  contents, KV snapshot/bundle bodies, R2 object listings beyond
-  `email_messages.raw_size`, or Vectorize: those stores either lack reliable
-  byte metadata or are derived from D1 and are documented in `data-storage.md`.
+  records in the per-user `RunLog` Durable Object are intentionally **excluded**
+  from the quota — they are observability history, not user content.
+  StorageRunner Durable Object buckets expose their own `estimatedBytes`; write
+  chokepoints that target a specific bucket pass `getCurrent` as
+  `D1 estimate + target bucket estimate` and `requested` as the candidate
+  payload size when known. The counter intentionally does **not** attempt to
+  scan Cloudflare Artifacts repository contents, KV snapshot/bundle bodies, R2
+  object listings beyond `email_messages.raw_size`, or Vectorize: those stores
+  either lack reliable byte metadata or are derived from D1 and are documented
+  in `data-storage.md`.
 
 ### Concurrency
 

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -139,16 +139,14 @@ deployment. Putting every execute failure, job run, webhook delivery, and
 service wake on that writer would serialize unrelated user traffic — the same
 reason usage metering writes Analytics Engine data points instead of upserting
 D1 per event (see [Usage metering](./usage-metering.md) § Sinks). Per-user DO
-SQLite keeps write contention on the user who produced the events.
-
-Writers do not use D1 tables `package_runtime_runs` / `package_runtime_logs`.
-Hourly retention drains any remaining rows; a follow-up migration drops the
-tables. See [Data storage](./data-storage.md).
+SQLite keeps write contention on the user who produced the events. That is the
+`no-per-event-shared-writes` invariant: per-event writes go to Analytics Engine
+or per-user DO SQLite, never the shared D1 writer.
 
 ## Retention
 
 Enforced **inside the DO on every `finishRun`**, not by a global cron lane over
-a shared table:
+a shared D1 table:
 
 | Cap                       | Value                                           |
 | ------------------------- | ----------------------------------------------- |
@@ -173,8 +171,7 @@ authoritative D1 projection upserted and heartbeaten by the service Durable
 Object. History rows can outlive an evicted DO or stay `running` after a crash,
 so they are not a reliable liveness signal. Jobs keep `last_run_*` and counters
 on the `jobs` row for the same reason — those fields are entity state, not a
-substitute for run history. `jobs.run_history_json` is intentionally left
-unwritten.
+substitute for run history.
 
 ## Recipe: instrumenting a new surface
 

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -35,11 +35,12 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
    that user; load minted row keyed by `(user_id, package_id, webhook_name)`.
 3. Unminted, disabled, missing declaration (after republish rename/remove), or
    URL-secret mismatch → **404** (indistinguishable). URL-secret mismatches do
-   **not** write a delivery row (avoids log-flush DoS and rate-limit side
+   **not** record delivery history (avoids log-flush DoS and rate-limit side
    channels).
 4. Constant-time compare the URL secret against `url_secret_hash` (SHA-256).
 5. After a matching URL secret, enforce per-webhook rate limit (~60/min) →
-   **429** (no delivery row on the limited path); payload cap 1 MB → **413**.
+   **429** (no delivery history on the limited path); payload cap 1 MB →
+   **413**.
 6. When verification is declared, resolve `secretName` from the owner's secret
    store (user/package scope via package storage context). Missing secret or
    HMAC mismatch → **401**, with a clear delivery-log error for missing secrets.
@@ -58,15 +59,14 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
   `requireMcpUser(...).userId`.
 - Ingress may look up by username + kody id + webhook name, then immediately
   re-scopes by the owning user.
-- Account deletion/export include `webhook_endpoints` and any remaining
-  `webhook_deliveries` rows (writers do not use the deliveries table; history
-  lives in run records). Export redacts `url_secret_hash`.
+- Account deletion/export include `webhook_endpoints` (minted URL state).
+  Delivery history lives in run records and is covered with the rest of `RunLog`
+  export/deletion. Export redacts `url_secret_hash`.
 - Plaintext URL secrets and verification secrets are never logged. URL secrets
   are hashed; verification secrets stay in the secrets primitive.
 
 ## Storage
 
 Minted endpoint state is in migration `0090-webhook-endpoints.sql`. Delivery
-history is in the per-user `RunLog` Durable Object (`webhook` surface);
-`webhook_deliveries` remains in schema until a follow-up drop migration. See
-[Data storage](./data-storage.md) and [Run records](./run-records.md).
+history is in the per-user `RunLog` Durable Object (`webhook` surface), not in
+D1. See [Data storage](./data-storage.md) and [Run records](./run-records.md).

--- a/e2e/account-jobs.spec.ts
+++ b/e2e/account-jobs.spec.ts
@@ -25,7 +25,7 @@ test('account jobs detail URL persists across reload for a seeded job', async ({
 			id, user_id, name, source_id, published_commit, storage_id,
 			params_json, schedule_json, timezone, enabled, kill_switch_enabled,
 			caller_context_json, created_at, updated_at, next_run_at,
-			run_count, success_count, error_count, run_history_json
+			run_count, success_count, error_count
 		) VALUES (
 			${quoteSqlString(jobId)},
 			${quoteSqlString(userId)},
@@ -44,8 +44,7 @@ test('account jobs detail URL persists across reload for a seeded job', async ({
 			${quoteSqlString(nextRunAt)},
 			0,
 			0,
-			0,
-			'[]'
+			0
 		)`,
 	)
 

--- a/packages/worker/migrations/0099-drop-run-history-legacy.sql
+++ b/packages/worker/migrations/0099-drop-run-history-legacy.sql
@@ -1,0 +1,20 @@
+-- Drop the last D1 leftovers of package-shaped run history.
+--
+-- `package_runtime_runs` / `package_runtime_logs` held per-package run and log
+-- rows before RunLog owned history. `webhook_deliveries` held webhook delivery
+-- rows before those were recorded as run records. `jobs.run_history_json` was
+-- the older inline job-history blob.
+--
+-- Writers stopped using all of these in the RunLog migration; production data
+-- that still mattered was rescued into `user_storage_buckets` (0097) and
+-- `package_service_states` (0098). Nothing derives state from these leftovers
+-- any more, so they are safe to drop.
+--
+-- Drop logs before runs (child before parent). D1 supports ALTER TABLE DROP
+-- COLUMN in place for the unindexed `run_history_json` column.
+
+DROP TABLE IF EXISTS package_runtime_logs;
+DROP TABLE IF EXISTS package_runtime_runs;
+DROP TABLE IF EXISTS webhook_deliveries;
+
+ALTER TABLE jobs DROP COLUMN run_history_json;

--- a/packages/worker/src/app/account-data-targets.ts
+++ b/packages/worker/src/app/account-data-targets.ts
@@ -113,8 +113,6 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 	{ kind: 'user_id', table: 'package_invocations' },
 	{ kind: 'user_id', table: 'package_invocation_tokens' },
 	{ kind: 'user_id', table: 'workflow_runs' },
-	{ kind: 'user_id', table: 'package_runtime_logs' },
-	{ kind: 'user_id', table: 'package_runtime_runs' },
 	{ kind: 'user_id', table: 'package_service_states' },
 	{ kind: 'user_id', table: 'user_storage_buckets' },
 	{ kind: 'user_id', table: 'usage_rollups' },
@@ -167,7 +165,6 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 	{ kind: 'user_id', table: 'email_inbox_addresses' },
 	{ kind: 'user_id', table: 'email_inboxes' },
 	{ kind: 'user_id', table: 'email_sender_identities' },
-	{ kind: 'user_id', table: 'webhook_deliveries' },
 	{ kind: 'user_id', table: 'webhook_endpoints' },
 	{ kind: 'user_id', table: 'entitlement_daily_counters' },
 	{

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1,6 +1,5 @@
 import { quoteSqlIdentifier } from '@kody-internal/shared/sql-literals.ts'
 import { readdirSync, readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
 import {
@@ -199,37 +198,6 @@ function createTestDb(
 										kody_id: savedPackage?.['kody_id'] ?? null,
 										source_id: savedPackage?.['source_id'] ?? null,
 										name: row['service_name'],
-									})
-								}
-								return { results: results as Array<T>, meta: { changes: 0 } }
-							}
-							if (
-								lower.includes('from package_runtime_runs as r') &&
-								lower.includes("r.surface = 'service'")
-							) {
-								const seen = new Set<string>()
-								results = []
-								for (const row of rows.package_runtime_runs ?? []) {
-									if (row['user_id'] !== userId) continue
-									if (row['surface'] !== 'service') continue
-									if (row['name'] == null) continue
-									const savedPackage = (rows.saved_packages ?? []).find(
-										(pkg) =>
-											pkg['id'] === row['package_id'] &&
-											pkg['user_id'] === row['user_id'],
-									)
-									const key = `${String(row['package_id'])}:${String(row['name'])}`
-									if (seen.has(key)) continue
-									seen.add(key)
-									results.push({
-										package_id: row['package_id'],
-										kody_id:
-											savedPackage?.['kody_id'] ??
-											row['package_kody_id'] ??
-											null,
-										source_id:
-											savedPackage?.['source_id'] ?? row['source_id'] ?? null,
-										name: row['name'],
 									})
 								}
 								return { results: results as Array<T>, meta: { changes: 0 } }
@@ -703,52 +671,6 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 			{ id: 'job-2', user_id: userAaa, storage_id: null },
 			{ id: packageJobId, user_id: userAaa, storage_id: null },
 			{ id: 'job-3', user_id: userBbb, storage_id: 'job:job-3' },
-		],
-		package_runtime_runs: [
-			{
-				id: 'run-1',
-				user_id: userAaa,
-				package_id: 'pkg-1',
-				package_kody_id: 'demo',
-				source_id: 'src-1',
-				surface: 'service',
-				name: 'sync',
-				storage_id: 'service:pkg-1:sync',
-			},
-			{
-				id: 'run-2',
-				user_id: userAaa,
-				package_id: 'pkg-1',
-				package_kody_id: 'demo',
-				source_id: 'src-1',
-				surface: 'app_fetch',
-				name: null,
-				storage_id: 'exec:run-2',
-			},
-			{
-				id: 'run-orphan-service',
-				user_id: userAaa,
-				package_id: 'pkg-orphan',
-				package_kody_id: 'legacy',
-				source_id: null,
-				surface: 'service',
-				name: 'legacy-sync',
-				storage_id: null,
-			},
-			{
-				id: 'run-3',
-				user_id: userBbb,
-				package_id: 'pkg-2',
-				package_kody_id: 'other',
-				source_id: 'src-2',
-				surface: 'service',
-				name: 'sync',
-				storage_id: 'service:pkg-2:sync',
-			},
-		],
-		package_runtime_logs: [
-			{ id: 'log-1', run_id: 'run-1', user_id: userAaa, package_id: 'pkg-1' },
-			{ id: 'log-2', run_id: 'run-3', user_id: userBbb, package_id: 'pkg-2' },
 		],
 		package_service_states: [
 			{
@@ -1270,21 +1192,6 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 			admin_note: 'Reviewed by B.',
 		},
 	])
-	expect(rows.package_runtime_runs).toEqual([
-		{
-			id: 'run-3',
-			user_id: userBbb,
-			package_id: 'pkg-2',
-			package_kody_id: 'other',
-			source_id: 'src-2',
-			surface: 'service',
-			name: 'sync',
-			storage_id: 'service:pkg-2:sync',
-		},
-	])
-	expect(rows.package_runtime_logs).toEqual([
-		{ id: 'log-2', run_id: 'run-3', user_id: userBbb, package_id: 'pkg-2' },
-	])
 	expect(rows.package_service_states).toEqual([
 		{
 			user_id: userBbb,
@@ -1393,8 +1300,6 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	expect(result.deletedRowCounts.jobs).toBe(3)
 	expect(result.deletedRowCounts.users).toBe(1)
 	expect(result.deletedRowCounts.email_attachments).toBe(1)
-	expect(result.deletedRowCounts.package_runtime_runs).toBe(3)
-	expect(result.deletedRowCounts.package_runtime_logs).toBe(1)
 	expect(result.deletedRowCounts.package_service_states).toBe(3)
 	expect(result.deletedRowCounts.user_storage_buckets).toBe(1)
 	expect(result.deletedRowCounts.community_listings).toBe(1)
@@ -2014,120 +1919,6 @@ test('account deletion purges a PackageServiceInstance known only via package_se
 	)
 })
 
-test('account deletion purges a PackageServiceInstance known only via legacy package_runtime_runs', async () => {
-	const userId = 'user-legacy-runs-only'
-	const serviceFetch = vi.fn(async () => Response.json({ ok: true }))
-	const idFromName = vi.fn((name: string) => name as unknown as DurableObjectId)
-	const { db } = createTestDb({
-		users: [{ id: 1, email: 'legacy@example.com', stable_user_id: userId }],
-		saved_packages: [
-			{
-				id: 'pkg-legacy',
-				user_id: userId,
-				kody_id: 'legacy-pkg',
-				source_id: 'src-legacy',
-				has_app: 0,
-			},
-		],
-		package_runtime_runs: [
-			{
-				id: 'run-legacy-only',
-				user_id: userId,
-				package_id: 'pkg-legacy',
-				package_kody_id: 'legacy-pkg',
-				source_id: 'src-legacy',
-				surface: 'service',
-				name: 'only-in-runtime-runs',
-				status: 'succeeded',
-				started_at: '2026-07-05T00:00:00.000Z',
-				finished_at: '2026-07-05T00:00:01.000Z',
-			},
-		],
-	})
-
-	const listSaved = vi.spyOn(
-		await import('#worker/package-registry/repo.ts'),
-		'listSavedPackagesByUserId',
-	)
-	listSaved.mockResolvedValue([
-		{
-			id: 'pkg-legacy',
-			userId,
-			name: 'Legacy Package',
-			kodyId: 'legacy-pkg',
-			description: '',
-			tags: [],
-			searchText: null,
-			sourceId: 'src-legacy',
-			hasApp: false,
-			hidden: false,
-			isPrivate: true,
-			createdAt: '2026-07-05T00:00:00.000Z',
-			updatedAt: '2026-07-05T00:00:00.000Z',
-		},
-	])
-	const loadManifest = vi.spyOn(
-		await import('#worker/package-registry/source.ts'),
-		'loadPackageManifestBySourceId',
-	)
-	loadManifest.mockResolvedValue({
-		source: {
-			id: 'src-legacy',
-			userId,
-			entityKind: 'package',
-			entityId: 'pkg-legacy',
-			repoId: 'repo-1',
-			manifestPath: 'package.json',
-			sourceRoot: '.',
-			publishedCommit: null,
-		},
-		manifest: {
-			name: 'legacy-pkg',
-			kody: {
-				services: {},
-			},
-		},
-	} as never)
-
-	try {
-		const result = await deleteUserAccount({
-			env: createSuccessfulDeletionEnv(db, {
-				BUNDLE_ARTIFACTS_KV: {
-					get: async () => null,
-					async list() {
-						return { keys: [], list_complete: true as const }
-					},
-					delete: async () => undefined,
-				},
-				PACKAGE_SERVICE_INSTANCE: {
-					idFromName,
-					get: () => ({ fetch: serviceFetch }),
-				},
-			}),
-			dbUserId: 1,
-			mcpUserId: userId,
-		})
-
-		expect(result.clearedDurableObjects.packageServiceInstances).toBe(1)
-		expect(serviceFetch).toHaveBeenCalledTimes(1)
-		const request = serviceFetch.mock.calls[0]?.[0] as Request
-		expect(new URL(request.url).pathname).toContain('/purge')
-		const body = (await request.clone().json()) as {
-			binding: { packageId: string; serviceName: string }
-		}
-		expect(body.binding).toMatchObject({
-			packageId: 'pkg-legacy',
-			serviceName: 'only-in-runtime-runs',
-		})
-		expect(idFromName).toHaveBeenCalledWith(
-			JSON.stringify([userId, 'pkg-legacy', 'only-in-runtime-runs']),
-		)
-	} finally {
-		loadManifest.mockRestore()
-		listSaved.mockRestore()
-	}
-})
-
 test('account deletion purges a service declared only in the package manifest', async () => {
 	const userId = 'user-manifest-only'
 	const serviceFetch = vi.fn(async () => Response.json({ ok: true }))
@@ -2338,28 +2129,4 @@ test('account deletion continues when manifest load fails and still purges state
 		listSaved.mockRestore()
 		consoleWarn.mockReset()
 	}
-})
-
-test('export and DR sources no longer read package_runtime_runs; deletion inventory keeps the legacy arm', () => {
-	const mustNotRead = [
-		'./account-deletion.ts',
-		'./account-export.ts',
-		'../dr/exporter.ts',
-	]
-	for (const relative of mustNotRead) {
-		const source = readFileSync(
-			fileURLToPath(new URL(relative, import.meta.url)),
-			'utf8',
-		)
-		expect(
-			source.includes('package_runtime_runs'),
-			`${relative} must not read package_runtime_runs`,
-		).toBe(false)
-	}
-	const inventory = readFileSync(
-		fileURLToPath(new URL('./account-user-inventory.ts', import.meta.url)),
-		'utf8',
-	)
-	expect(inventory.includes('package_runtime_runs')).toBe(true)
-	expect(inventory.includes('includeLegacyRuntimeRuns')).toBe(true)
 })

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -286,8 +286,6 @@ async function listUserPackageServices(
 		userId,
 		baseUrl: 'https://account-deletion.invalid',
 		warnings,
-		// Legacy pre-#955 service arm via includeLegacyRuntimeRuns (issue #956).
-		includeLegacyRuntimeRuns: true,
 	})
 }
 

--- a/packages/worker/src/app/account-export.node.test.ts
+++ b/packages/worker/src/app/account-export.node.test.ts
@@ -1,6 +1,5 @@
 import { quoteSqlIdentifier } from '@kody-internal/shared/sql-literals.ts'
 import { readdirSync, readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
 import {
@@ -1837,12 +1836,4 @@ test('storage_runner section treats malformed service storage ids as not found',
 			storageId: 'service:pkg%:worker%',
 		}),
 	).rejects.toThrow('Storage runner was not found for account export.')
-})
-
-test('account export source no longer reads package_runtime_runs', () => {
-	const source = readFileSync(
-		fileURLToPath(new URL('./account-export.ts', import.meta.url)),
-		'utf8',
-	)
-	expect(source.includes('package_runtime_runs')).toBe(false)
 })

--- a/packages/worker/src/app/account-retention-dispositions.ts
+++ b/packages/worker/src/app/account-retention-dispositions.ts
@@ -5,8 +5,6 @@ export type AccountRetentionDisposition =
 
 export const accountRetentionDispositions: ReadonlyArray<AccountRetentionDisposition> =
 	[
-		{ table: 'package_runtime_runs', kind: 'scheduled_policy' },
-		{ table: 'package_runtime_logs', kind: 'scheduled_policy' },
 		{ table: 'package_invocations', kind: 'scheduled_policy' },
 		{
 			table: 'mcp_memory_conversation_suppressions',

--- a/packages/worker/src/app/account-user-inventory.ts
+++ b/packages/worker/src/app/account-user-inventory.ts
@@ -65,19 +65,12 @@ function upsertPackageService(
  * deletion never aborts for a missing manifest. Pass `warnings` so callers can
  * surface that degradation in their result (incomplete deletion must not look
  * clean).
- *
- * Pass `includeLegacyRuntimeRuns: true` on the deletion path only. That arm
- * catches pre-#955 services whose DOs still exist but never projected into
- * `package_service_states` and are no longer declared in the manifest.
- * Migration 0097 backfills storage-bucket ownership, not service identity.
- * Remove once `package_runtime_runs` drains (~2026-08-25); tracked by #956.
  */
 export async function listAccountUserPackageServices(input: {
 	env: Env
 	userId: string
 	baseUrl: string
 	warnings?: Array<string>
-	includeLegacyRuntimeRuns?: boolean
 }): Promise<Array<AccountUserPackageService>> {
 	const stateRows = await input.env.APP_DB.prepare(
 		`SELECT
@@ -142,42 +135,6 @@ export async function listAccountUserPackageServices(input: {
 		)
 	}
 
-	if (input.includeLegacyRuntimeRuns) {
-		// Legacy arm for account deletion only (issue #956): remove once
-		// package_runtime_runs drains (~2026-08-25). Covers pre-#955 service
-		// DOs that never projected into package_service_states and are no
-		// longer declared in the package manifest. 0097 backfills storage
-		// bucket ids, not (packageId, serviceName) tuples.
-		const legacyRows = await input.env.APP_DB.prepare(
-			`SELECT
-				r.package_id AS package_id,
-				COALESCE(p.kody_id, r.package_kody_id) AS kody_id,
-				COALESCE(p.source_id, r.source_id) AS source_id,
-				r.name AS name
-			FROM package_runtime_runs AS r
-			LEFT JOIN saved_packages AS p
-				ON p.id = r.package_id AND p.user_id = r.user_id
-			WHERE r.user_id = ?
-				AND r.surface = 'service'
-				AND r.name IS NOT NULL`,
-		)
-			.bind(input.userId)
-			.all<{
-				package_id: string
-				kody_id: string | null
-				source_id: string | null
-				name: string
-			}>()
-		for (const row of legacyRows.results ?? []) {
-			upsertPackageService(byKey, {
-				packageId: row.package_id,
-				kodyId: row.kody_id ?? '',
-				sourceId: row.source_id ?? '',
-				serviceName: row.name,
-			})
-		}
-	}
-
 	return Array.from(byKey.values()).sort((left, right) => {
 		const byPackage = left.packageId.localeCompare(right.packageId)
 		if (byPackage !== 0) return byPackage
@@ -201,7 +158,6 @@ export async function listAccountUserStorageIds(input: {
 	userId: string
 	baseUrl: string
 	warnings?: Array<string>
-	includeLegacyRuntimeRuns?: boolean
 	packageServices?: ReadonlyArray<AccountUserPackageService>
 }): Promise<Array<string>> {
 	const [

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -10,14 +10,12 @@ import {
 	getRetentionPolicyCoverage,
 	memorySuppressionRetentionDays,
 	packageInvocationRetentionDays,
-	packageRuntimeRunRetentionDays,
 	platformFeedbackRetentionDays,
 	pruneAuditEventsForRetention,
 	pruneEmailDeliveryEventsForRetention,
 	pruneEntitlementDailyCountersForRetention,
 	pruneMemorySuppressionsForRetention,
 	prunePackageInvocationsForRetention,
-	prunePackageRuntimeRetention,
 	prunePlatformFeedbackForRetention,
 	prunePublishedBundleArtifactsForRetention,
 	pruneRetention,
@@ -101,44 +99,6 @@ function createD1FromSqlite(
 function createRetentionDb() {
 	const sqlite = new DatabaseSync(':memory:')
 	sqlite.exec(`
-		CREATE TABLE package_runtime_runs (
-			id TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
-			package_id TEXT NOT NULL,
-			package_kody_id TEXT NOT NULL,
-			source_id TEXT,
-			published_commit TEXT,
-			surface TEXT NOT NULL,
-			name TEXT,
-			status TEXT NOT NULL,
-			started_at TEXT NOT NULL,
-			finished_at TEXT,
-			duration_ms INTEGER,
-			error_name TEXT,
-			error_message TEXT,
-			storage_id TEXT,
-			job_id TEXT,
-			workflow_id TEXT,
-			invocation_id TEXT,
-			session_id TEXT,
-			idempotency_key TEXT,
-			parent_run_id TEXT,
-			metadata_json TEXT NOT NULL DEFAULT '{}',
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL
-		);
-		CREATE TABLE package_runtime_logs (
-			id TEXT PRIMARY KEY,
-			run_id TEXT NOT NULL,
-			user_id TEXT NOT NULL,
-			package_id TEXT NOT NULL,
-			timestamp TEXT NOT NULL,
-			sequence INTEGER NOT NULL,
-			level TEXT NOT NULL,
-			message TEXT NOT NULL,
-			fields_json TEXT,
-			created_at TEXT NOT NULL
-		);
 		CREATE TABLE package_invocations (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL,
@@ -313,50 +273,6 @@ function daysAgo(days: number) {
 	return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString()
 }
 
-function insertRuntimeRun(
-	db: DatabaseSync,
-	input: {
-		id: string
-		packageId?: string
-		status?: string
-		startedAt: string
-		invocationId?: string | null
-		workflowId?: string | null
-		sessionId?: string | null
-		parentRunId?: string | null
-	},
-) {
-	db.prepare(
-		`INSERT INTO package_runtime_runs (
-			id, user_id, package_id, package_kody_id, surface, status, started_at,
-			invocation_id, workflow_id, session_id, parent_run_id, created_at, updated_at
-		) VALUES (?, 'user-1', ?, ?, 'export', ?, ?, ?, ?, ?, ?, ?, ?)`,
-	).run(
-		input.id,
-		input.packageId ?? 'pkg-1',
-		input.packageId ?? 'pkg-1',
-		input.status ?? 'success',
-		input.startedAt,
-		input.invocationId ?? null,
-		input.workflowId ?? null,
-		input.sessionId ?? null,
-		input.parentRunId ?? null,
-		input.startedAt,
-		input.startedAt,
-	)
-	db.prepare(
-		`INSERT INTO package_runtime_logs (
-			id, run_id, user_id, package_id, timestamp, sequence, level, message, created_at
-		) VALUES (?, ?, 'user-1', ?, ?, 0, 'log', 'message', ?)`,
-	).run(
-		`log-${input.id}`,
-		input.id,
-		input.packageId ?? 'pkg-1',
-		input.startedAt,
-		input.startedAt,
-	)
-}
-
 function insertEmailMessage(
 	db: DatabaseSync,
 	input: {
@@ -432,151 +348,6 @@ test('retention cron runs only on the hourly gate', () => {
 	expect(shouldRunRetentionCron(new Date('2026-07-07T03:05:00.000Z'))).toBe(
 		false,
 	)
-})
-
-test('runtime retention prunes old runs, caps per package, and keeps active references', async () => {
-	const { sqlite, db } = createRetentionDb()
-	const cutoff = daysAgo(packageRuntimeRunRetentionDays)
-	insertRuntimeRun(sqlite, { id: 'old-delete', startedAt: daysAgo(31) })
-	insertRuntimeRun(sqlite, { id: 'boundary-keep', startedAt: cutoff })
-	insertRuntimeRun(sqlite, {
-		id: 'running-keep',
-		status: 'running',
-		startedAt: daysAgo(31),
-	})
-	sqlite
-		.prepare(
-			`INSERT INTO package_invocations (
-			id, user_id, token_id, package_id, package_kody_id, export_name,
-			idempotency_key, request_hash, status, created_at, updated_at
-		) VALUES ('inv-active', 'user-1', 'token', 'pkg-1', 'pkg-1', '.', 'key', 'hash', 'in_progress', ?, ?)`,
-		)
-		.run(daysAgo(31), daysAgo(31))
-	insertRuntimeRun(sqlite, {
-		id: 'invocation-keep',
-		startedAt: daysAgo(31),
-		invocationId: 'inv-active',
-	})
-	sqlite
-		.prepare(
-			`INSERT INTO workflow_runs (
-			id, user_id, source_type, workflow_name, idempotency_key, run_at, status,
-			created_at, updated_at
-		) VALUES ('workflow-active', 'user-1', 'inline', 'wf', 'key', ?, 'running', ?, ?)`,
-		)
-		.run(daysAgo(31), daysAgo(31), daysAgo(31))
-	insertRuntimeRun(sqlite, {
-		id: 'workflow-keep',
-		startedAt: daysAgo(31),
-		workflowId: 'workflow-active',
-	})
-	sqlite
-		.prepare(
-			`INSERT INTO repo_sessions (
-			id, user_id, source_id, status, created_at, updated_at
-		) VALUES ('session-active', 'user-1', 'source-1', 'active', ?, ?)`,
-		)
-		.run(daysAgo(31), daysAgo(31))
-	insertRuntimeRun(sqlite, {
-		id: 'session-keep',
-		startedAt: daysAgo(31),
-		sessionId: 'session-active',
-	})
-	insertRuntimeRun(sqlite, { id: 'parent-keep', startedAt: daysAgo(31) })
-	insertRuntimeRun(sqlite, {
-		id: 'child-running',
-		status: 'running',
-		startedAt: daysAgo(1),
-		parentRunId: 'parent-keep',
-	})
-	for (let index = 0; index < 502; index += 1) {
-		insertRuntimeRun(sqlite, {
-			id: `cap-${String(index).padStart(3, '0')}`,
-			packageId: 'pkg-cap',
-			startedAt: new Date(now.getTime() - index * 1000).toISOString(),
-		})
-	}
-	sqlite
-		.prepare(
-			`INSERT INTO package_runtime_logs (
-			id, run_id, user_id, package_id, timestamp, sequence, level, message, created_at
-		) VALUES ('orphan-log', 'missing-run', 'user-1', 'pkg-1', ?, 0, 'log', 'orphan', ?)`,
-		)
-		.run(daysAgo(40), daysAgo(40))
-
-	const result = await prunePackageRuntimeRetention({ db, now, batchSize: 20 })
-
-	expect(result).toEqual({
-		deletedRuns: 3,
-		deletedLogs: 3,
-		deletedOrphanLogs: 1,
-		hasMore: false,
-	})
-	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('boundary-keep')
-	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('running-keep')
-	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain(
-		'invocation-keep',
-	)
-	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('workflow-keep')
-	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('session-keep')
-	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('parent-keep')
-	expect(idsForTable(sqlite, 'package_runtime_runs')).not.toContain(
-		'old-delete',
-	)
-	expect(idsForTable(sqlite, 'package_runtime_runs')).not.toContain('cap-500')
-	expect(idsForTable(sqlite, 'package_runtime_runs')).not.toContain('cap-501')
-	expect(idsForTable(sqlite, 'package_runtime_logs')).not.toContain(
-		'orphan-log',
-	)
-})
-
-test('runtime cap retention ranks bounded candidate pairs largest first', async () => {
-	const { sqlite, db } = createRetentionDb()
-	for (const [packageId, runCount] of [
-		['pkg-large', 503],
-		['pkg-small', 502],
-	] as const) {
-		for (let index = 0; index < runCount; index += 1) {
-			insertRuntimeRun(sqlite, {
-				id: `${packageId}-${String(index).padStart(3, '0')}`,
-				packageId,
-				startedAt: new Date(now.getTime() - index * 1000).toISOString(),
-			})
-		}
-	}
-
-	const first = await prunePackageRuntimeRetention({
-		db,
-		now,
-		batchSize: 50,
-		maxCapPairs: 1,
-	})
-	expect(first.deletedRuns).toBe(3)
-	expect(first.hasMore).toBe(true)
-	expect(idsForTable(sqlite, 'package_runtime_runs')).not.toContain(
-		'pkg-large-502',
-	)
-	expect(idsForTable(sqlite, 'package_runtime_runs')).toContain('pkg-small-501')
-
-	const second = await prunePackageRuntimeRetention({
-		db,
-		now,
-		batchSize: 50,
-		maxCapPairs: 1,
-	})
-	expect(second.deletedRuns).toBe(2)
-	expect(idsForTable(sqlite, 'package_runtime_runs')).not.toContain(
-		'pkg-small-501',
-	)
-
-	const third = await prunePackageRuntimeRetention({
-		db,
-		now,
-		batchSize: 50,
-		maxCapPairs: 1,
-	})
-	expect(third.deletedRuns).toBe(0)
-	expect(third.hasMore).toBe(false)
 })
 
 test('package invocation and workflow retention keeps boundary and active idempotency rows', async () => {

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -42,15 +42,7 @@ export const publishedBundleArtifactRetentionBatchSize = 100
  * batch per table per hour.
  */
 export const retentionRunTimeBudgetMs = 20_000
-/**
- * Upper bound on distinct (user_id, package_id) pairs examined per runtime-run
- * cap batch, largest pairs first, so the cap prune never ranks the whole
- * table in one query.
- */
-export const packageRuntimeCapPairsPerBatch = 20
 
-export const packageRuntimeRunRetentionDays = 30
-export const packageRuntimeMaxRunsPerPackage = 500
 export const packageInvocationRetentionDays = 90
 export const memorySuppressionRetentionDays = 90
 export const workflowRunRetentionDays = 90
@@ -79,25 +71,6 @@ const terminalWorkflowStatusList = terminalWorkflowStatusValues
  * in `retention.node.test.ts` remains a second net for discovering new tables.
  */
 export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
-	// New run records self-prune inside the per-user RunLog Durable Object
-	// (age + count caps on every finish). These D1 lanes exist only to drain
-	// legacy package_runtime_runs / package_runtime_logs rows.
-	{
-		table: 'package_runtime_runs',
-		scope: 'per-user',
-		retentionDays: packageRuntimeRunRetentionDays,
-		maxRowsPerPartition: packageRuntimeMaxRunsPerPackage,
-		batchSize: retentionDefaultBatchSize,
-		description:
-			'Runtime debug runs keep 30 days and at most 500 rows per user/package. Running or actively referenced runs are kept.',
-	},
-	{
-		table: 'package_runtime_logs',
-		scope: 'per-user',
-		batchSize: retentionDefaultBatchSize,
-		description:
-			'Runtime logs follow retained runtime runs; orphan logs are pruned in small batches.',
-	},
 	{
 		table: 'package_invocations',
 		scope: 'per-user',
@@ -219,11 +192,6 @@ export const retentionPolicyExemptions: ReadonlyArray<RetentionPolicyExemption> 
 		}))
 
 export type RetentionPruneResult = {
-	runtimeRuns: {
-		deletedRuns: number
-		deletedLogs: number
-		deletedOrphanLogs: number
-	}
 	packageInvocations: number
 	memorySuppressions: number
 	workflowRuns: number
@@ -382,158 +350,6 @@ async function deletePublishedBundleArtifactRowIfStillStale(input: {
 			.run(),
 	)
 	return result.meta.changes ?? 0
-}
-
-/**
- * Keep-conditions shared by the age prune and the per-package cap prune.
- * Expects the outer query to alias package_runtime_runs as `run`.
- */
-const runtimeRunKeepConditions = `run.status != 'running'
-	AND NOT EXISTS (
-		SELECT 1
-		FROM package_invocations AS invocation
-		WHERE invocation.user_id = run.user_id
-			AND invocation.id = run.invocation_id
-			AND invocation.status = 'in_progress'
-	)
-	AND NOT EXISTS (
-		SELECT 1
-		FROM workflow_runs AS workflow
-		WHERE workflow.user_id = run.user_id
-			AND workflow.id = run.workflow_id
-			AND (
-				workflow.status IS NULL
-				OR workflow.status NOT IN (${terminalWorkflowStatusList})
-			)
-	)
-	AND NOT EXISTS (
-		SELECT 1
-		FROM repo_sessions AS session
-		WHERE session.user_id = run.user_id
-			AND session.id = run.session_id
-			AND session.status = 'active'
-	)
-	AND NOT EXISTS (
-		SELECT 1
-		FROM package_runtime_runs AS child_run
-		WHERE child_run.user_id = run.user_id
-			AND child_run.parent_run_id = run.id
-			AND child_run.status = 'running'
-	)`
-
-export async function prunePackageRuntimeRetention(input: {
-	db: D1Database
-	now?: Date
-	batchSize?: number
-	maxCapPairs?: number
-}) {
-	const now = input.now ?? new Date()
-	const cutoff = cutoffIso(now, packageRuntimeRunRetentionDays)
-	const batchSize = input.batchSize ?? retentionDefaultBatchSize
-	const maxCapPairs = input.maxCapPairs ?? packageRuntimeCapPairsPerBatch
-	const ageRunIds = await selectIds({
-		db: input.db,
-		bindings: [cutoff, batchSize],
-		sql: `SELECT id
-			FROM package_runtime_runs AS run
-			WHERE run.started_at < ?
-				AND ${runtimeRunKeepConditions}
-			ORDER BY run.started_at ASC, run.id ASC
-			LIMIT ?`,
-	})
-	const runIds = new Set<IdValue>(ageRunIds)
-	// The per-(user, package) cap prune examines a bounded set of the largest
-	// pairs per batch instead of ranking the whole table with a window
-	// function; remaining pairs are picked up by later batches or runs.
-	let capPairCount = 0
-	let capDeletedCandidates = 0
-	if (runIds.size < batchSize) {
-		const { results: pairs } = await runD1WithRetry(() =>
-			input.db
-				.prepare(
-					`SELECT user_id, package_id, COUNT(*) AS run_count
-				FROM package_runtime_runs
-				GROUP BY user_id, package_id
-				HAVING COUNT(*) > ?
-				ORDER BY run_count DESC
-				LIMIT ?`,
-				)
-				.bind(packageRuntimeMaxRunsPerPackage, maxCapPairs)
-				.all<{ user_id: string; package_id: string; run_count: number }>(),
-		)
-		capPairCount = (pairs ?? []).length
-		for (const pair of pairs ?? []) {
-			if (runIds.size >= batchSize) break
-			const capIds = await selectIds({
-				db: input.db,
-				bindings: [
-					pair.user_id,
-					pair.package_id,
-					pair.user_id,
-					pair.package_id,
-					packageRuntimeMaxRunsPerPackage,
-					batchSize - runIds.size,
-				],
-				sql: `SELECT id
-					FROM package_runtime_runs AS run
-					WHERE run.user_id = ?
-						AND run.package_id = ?
-						AND run.id NOT IN (
-							SELECT recent.id
-							FROM package_runtime_runs AS recent
-							WHERE recent.user_id = ?
-								AND recent.package_id = ?
-							ORDER BY recent.started_at DESC, recent.id DESC
-							LIMIT ?
-						)
-						AND ${runtimeRunKeepConditions}
-					ORDER BY run.started_at ASC, run.id ASC
-					LIMIT ?`,
-			})
-			for (const id of capIds) {
-				capDeletedCandidates += 1
-				runIds.add(id)
-			}
-		}
-	}
-	const ids = [...runIds]
-	const deletedLogs = await deleteByIds({
-		db: input.db,
-		table: 'package_runtime_logs',
-		idColumn: 'run_id',
-		ids,
-	})
-	const deletedRuns = await deleteByIds({
-		db: input.db,
-		table: 'package_runtime_runs',
-		idColumn: 'id',
-		ids,
-	})
-	const orphanLogIds = await selectIds({
-		db: input.db,
-		bindings: [batchSize],
-		sql: `SELECT log.id
-			FROM package_runtime_logs AS log
-			WHERE NOT EXISTS (
-				SELECT 1
-				FROM package_runtime_runs AS run
-				WHERE run.user_id = log.user_id AND run.id = log.run_id
-			)
-			ORDER BY log.created_at ASC, log.id ASC
-			LIMIT ?`,
-	})
-	const deletedOrphanLogs = await deleteByIds({
-		db: input.db,
-		table: 'package_runtime_logs',
-		idColumn: 'id',
-		ids: orphanLogIds,
-	})
-	const hasMore =
-		ageRunIds.length >= batchSize ||
-		ids.length >= batchSize ||
-		orphanLogIds.length >= batchSize ||
-		(capDeletedCandidates > 0 && capPairCount >= maxCapPairs)
-	return { deletedRuns, deletedLogs, deletedOrphanLogs, hasMore }
 }
 
 export async function prunePackageInvocationsForRetention(input: {
@@ -1083,7 +899,6 @@ export async function pruneRetention(input: {
 	// for blob reasons so a blocked head cannot wedge later batches.
 	let emailMessagesCursor: EmailMessageRetentionCursor | null = null
 	const result: RetentionPruneResult = {
-		runtimeRuns: { deletedRuns: 0, deletedLogs: 0, deletedOrphanLogs: 0 },
 		packageInvocations: 0,
 		memorySuppressions: 0,
 		workflowRuns: 0,
@@ -1130,17 +945,6 @@ export async function pruneRetention(input: {
 		done: boolean
 		run: () => Promise<boolean>
 	}> = [
-		{
-			table: 'package_runtime_runs',
-			done: false,
-			run: async () => {
-				const batch = await prunePackageRuntimeRetention({ db, now })
-				result.runtimeRuns.deletedRuns += batch.deletedRuns
-				result.runtimeRuns.deletedLogs += batch.deletedLogs
-				result.runtimeRuns.deletedOrphanLogs += batch.deletedOrphanLogs
-				return batch.hasMore
-			},
-		},
 		countTask(
 			'package_invocations',
 			() => prunePackageInvocationsForRetention({ db, now }),

--- a/packages/worker/src/community/community-activity-service.node.test.ts
+++ b/packages/worker/src/community/community-activity-service.node.test.ts
@@ -70,12 +70,15 @@ function createCommunityDb() {
 			'utf8',
 		),
 	)
-	sqlite.exec(`CREATE TABLE package_runtime_runs (
-		user_id TEXT NOT NULL,
-		package_id TEXT NOT NULL,
-		status TEXT NOT NULL,
-		started_at TEXT NOT NULL
-	)`)
+	sqlite.exec(
+		readFileSync(
+			new URL(
+				'../../migrations/0037-package-runtime-debug.sql',
+				import.meta.url,
+			),
+			'utf8',
+		),
+	)
 	sqlite.exec(
 		readFileSync(
 			new URL(

--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -196,8 +196,7 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 			next_run_at TEXT NOT NULL,
 			run_count INTEGER NOT NULL DEFAULT 0,
 			success_count INTEGER NOT NULL DEFAULT 0,
-			error_count INTEGER NOT NULL DEFAULT 0,
-			run_history_json TEXT NOT NULL DEFAULT '[]'
+			error_count INTEGER NOT NULL DEFAULT 0
 		)`,
 		`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
 			id TEXT PRIMARY KEY,

--- a/packages/worker/src/dr/exporter.node.test.ts
+++ b/packages/worker/src/dr/exporter.node.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import { expect, test, vi } from 'vitest'
 import {
 	backupBlobKey,
@@ -590,12 +588,4 @@ test('DR inventory includes registry buckets and package_service_states services
 		'service:pkg-1:worker',
 	])
 	expect(inventory.every((entry) => entry.userId === 'user-a')).toBe(true)
-})
-
-test('DR exporter source no longer reads package_runtime_runs', () => {
-	const source = readFileSync(
-		fileURLToPath(new URL('./exporter.ts', import.meta.url)),
-		'utf8',
-	)
-	expect(source.includes('package_runtime_runs')).toBe(false)
 })

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -58,8 +58,6 @@ function createEntitlementsTestDb(
 				| 'saved_packages'
 				| 'jobs'
 				| 'repo_sessions'
-				| 'package_runtime_runs'
-				| 'package_runtime_logs'
 				| 'package_invocations'
 				| 'published_bundle_artifacts'
 				| 'secret_entries'
@@ -93,8 +91,6 @@ function createEntitlementsTestDb(
 			'jobs',
 			'repo_sessions',
 			'package_invocations',
-			'package_runtime_runs',
-			'package_runtime_logs',
 			'published_bundle_artifacts',
 			'workflow_runs',
 		] as const
@@ -1149,7 +1145,6 @@ test('countRunningPackageServices queries package_service_states with staleness 
 		}),
 	).toBe(2)
 	expect(queries[0]?.sql).toContain('FROM package_service_states')
-	expect(queries[0]?.sql).not.toContain('package_runtime_runs')
 	expect(queries[0]?.params).toEqual([
 		'user-1',
 		new Date(now.valueOf() - packageServiceStateStaleMs).toISOString(),

--- a/packages/worker/src/entitlements/package-service-states-migration.node.test.ts
+++ b/packages/worker/src/entitlements/package-service-states-migration.node.test.ts
@@ -13,47 +13,10 @@ function applyMigrationsBefore(db: DatabaseSync, exclusiveUpperBound: string) {
 	}
 }
 
-function insertServiceRun(
-	db: DatabaseSync,
-	input: { id: string; packageId: string; name: string; startedAt: string },
-) {
-	db.exec(`
-		INSERT INTO package_runtime_runs (
-			id, user_id, package_id, package_kody_id, surface, status,
-			started_at, created_at, updated_at, name
-		) VALUES (
-			'${input.id}', 'user-a', '${input.packageId}', 'kody-id', 'service',
-			'success', '${input.startedAt}', '${input.startedAt}',
-			'${input.startedAt}', '${input.name}'
-		);
-	`)
-}
-
-test('backfill rescues legacy-only services as stopped with their last run', () => {
+test('backfill migration is a no-op when no legacy service runs exist', () => {
 	const db = new DatabaseSync(':memory:')
 	applyMigrationsBefore(db, backfillMigration)
 
-	// Two runs of the same service: the newest run wins as `updated_at`.
-	insertServiceRun(db, {
-		id: 'run-1',
-		packageId: 'pkg-1',
-		name: 'email-agent-processor',
-		startedAt: '2026-05-30T14:24:06.316Z',
-	})
-	insertServiceRun(db, {
-		id: 'run-2',
-		packageId: 'pkg-1',
-		name: 'email-agent-processor',
-		startedAt: '2026-07-06T20:11:51.487Z',
-	})
-	insertServiceRun(db, {
-		id: 'run-3',
-		packageId: 'pkg-2',
-		name: 'other-service',
-		startedAt: '2026-06-01T00:00:00.000Z',
-	})
-
-	// A service that already projected real state must not be overwritten.
 	db.exec(`
 		INSERT INTO package_service_states (
 			user_id, package_id, service_name, status, started_at, updated_at
@@ -62,12 +25,6 @@ test('backfill rescues legacy-only services as stopped with their last run', () 
 			'2026-07-26T00:00:00.000Z', '2026-07-26T01:00:00.000Z'
 		);
 	`)
-	insertServiceRun(db, {
-		id: 'run-4',
-		packageId: 'pkg-3',
-		name: 'live-service',
-		startedAt: '2026-05-01T00:00:00.000Z',
-	})
 
 	db.exec(readFileSync(new URL(backfillMigration, migrationsDirectory), 'utf8'))
 
@@ -86,20 +43,6 @@ test('backfill rescues legacy-only services as stopped with their last run', () 
 	}>
 
 	expect(rows).toEqual([
-		{
-			package_id: 'pkg-1',
-			service_name: 'email-agent-processor',
-			status: 'stopped',
-			started_at: null,
-			updated_at: '2026-07-06T20:11:51.487Z',
-		},
-		{
-			package_id: 'pkg-2',
-			service_name: 'other-service',
-			status: 'stopped',
-			started_at: null,
-			updated_at: '2026-06-01T00:00:00.000Z',
-		},
 		{
 			package_id: 'pkg-3',
 			service_name: 'live-service',

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -344,7 +344,6 @@ export async function readUserD1StorageBytes(input: {
 					'caller_context_json',
 					'last_run_status',
 					'last_run_error',
-					'run_history_json',
 					'source_id',
 					'published_commit',
 					'storage_id',

--- a/packages/worker/src/jobs/repo.ts
+++ b/packages/worker/src/jobs/repo.ts
@@ -25,8 +25,6 @@ type JobRowRecord = {
 	run_count: number
 	success_count: number
 	error_count: number
-	// Intentionally left unwritten pending a follow-up drop migration.
-	run_history_json: string
 }
 
 export type JobRow = JobRowRecord & {
@@ -151,8 +149,6 @@ function mapRow(row: Record<string, unknown>): JobRow {
 		run_count: record.runCount,
 		success_count: record.successCount,
 		error_count: record.errorCount,
-		// Column retained unread into JobRecord pending a follow-up drop migration.
-		run_history_json: String(row['run_history_json'] ?? '[]'),
 		record,
 		callerContextJson: String(row['caller_context_json']),
 		callerContext: parseJson<PersistedJobCallerContext | null>(
@@ -177,8 +173,8 @@ export async function insertJobRow(input: {
 				id, user_id, name, source_id, published_commit, repo_check_policy_json, storage_id, params_json, schedule_json, timezone, enabled,
 				kill_switch_enabled, caller_context_json, created_at, updated_at,
 				last_run_at, last_run_status, last_run_error, last_duration_ms,
-				next_run_at, run_count, success_count, error_count, run_history_json
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				next_run_at, run_count, success_count, error_count
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.bind(
 			serialized.id,
@@ -204,8 +200,6 @@ export async function insertJobRow(input: {
 			serialized.run_count,
 			serialized.success_count,
 			serialized.error_count,
-			// Intentionally left unwritten as history; default empty blob only.
-			'[]',
 		)
 		.run()
 }

--- a/packages/worker/src/jobs/repo.workers.test.ts
+++ b/packages/worker/src/jobs/repo.workers.test.ts
@@ -27,8 +27,7 @@ async function ensureJobsSchema() {
 			next_run_at TEXT NOT NULL,
 			run_count INTEGER NOT NULL DEFAULT 0,
 			success_count INTEGER NOT NULL DEFAULT 0,
-			error_count INTEGER NOT NULL DEFAULT 0,
-			run_history_json TEXT NOT NULL DEFAULT '[]'
+			error_count INTEGER NOT NULL DEFAULT 0
 		)`,
 	).run()
 	await env.APP_DB.prepare(`DELETE FROM jobs`).run()

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -738,7 +738,6 @@ function createDatabase(
 									run_count: params[20],
 									success_count: params[21],
 									error_count: params[22],
-									run_history_json: params[23] ?? '[]',
 								}
 								upsert(
 									'jobs',
@@ -779,7 +778,6 @@ function createDatabase(
 									run_count: params[17],
 									success_count: params[18],
 									error_count: params[19],
-									run_history_json: existingJob?.['run_history_json'] ?? '[]',
 									created_at: existingJob?.['created_at'] ?? params[11],
 								}
 								upsert(

--- a/packages/worker/src/jobs/types.ts
+++ b/packages/worker/src/jobs/types.ts
@@ -47,8 +47,6 @@ export type JobRecord = {
 	runCount: number
 	successCount: number
 	errorCount: number
-	// `jobs.run_history_json` is intentionally left unwritten; run records own
-	// history. Column stays until a follow-up drop migration.
 }
 
 export type JobView = Omit<JobRecord, 'userId'> & {

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -160,7 +160,6 @@ function createAdminCapabilityTestDb(input: {
 			'saved_packages',
 			'jobs',
 			'repo_sessions',
-			'package_runtime_runs',
 			'secret_entries',
 			'workflow_runs',
 		] as const

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
@@ -326,7 +326,7 @@ test('webhook_delivery_list pushes name filter and returns a full page for one w
 	})
 })
 
-test('webhook_delivery_list round-trips explicit outcomes and maps legacy records', async () => {
+test('webhook_delivery_list round-trips explicit outcomes', async () => {
 	mockModule.resolveSavedPackage.mockResolvedValue({
 		id: 'pkg-1',
 		kodyId: 'sentry-bridge',
@@ -382,38 +382,6 @@ test('webhook_delivery_list round-trips explicit outcomes and maps legacy record
 				},
 				errorMessage: 'invocation_failed',
 			}),
-			makeWebhookRun({
-				id: 'legacy-rejected',
-				name: 'sentry',
-				status: 'error',
-				startedAt: '2026-07-24T00:30:00.000Z',
-				metadata: {
-					httpStatus: 413,
-					payloadBytes: 4,
-				},
-				errorMessage: 'payload_too_large',
-			}),
-			makeWebhookRun({
-				id: 'legacy-failed',
-				name: 'sentry',
-				status: 'error',
-				startedAt: '2026-07-24T00:20:00.000Z',
-				metadata: {
-					httpStatus: 502,
-					payloadBytes: 5,
-				},
-				errorMessage: 'invocation_failed',
-			}),
-			makeWebhookRun({
-				id: 'legacy-delivered',
-				name: 'sentry',
-				status: 'success',
-				startedAt: '2026-07-24T00:10:00.000Z',
-				metadata: {
-					httpStatus: 202,
-					payloadBytes: 6,
-				},
-			}),
 		],
 		nextCursor: null,
 	})
@@ -428,8 +396,5 @@ test('webhook_delivery_list round-trips explicit outcomes and maps legacy record
 		['delivered-1', 'delivered'],
 		['rejected-1', 'rejected'],
 		['failed-1', 'failed'],
-		['legacy-rejected', 'rejected'],
-		['legacy-failed', 'failed'],
-		['legacy-delivered', 'delivered'],
 	])
 })

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-delivery-list.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-delivery-list.ts
@@ -52,12 +52,6 @@ function deliveryOutcome(
 ): (typeof webhookOutcomeValues)[number] {
 	const explicit = metadataOutcome(run.metadata)
 	if (explicit) return explicit
-	// Legacy records written before outcome was always stored in metadata.
-	if (run.status === 'success') return 'delivered'
-	const httpStatus = metadataNumber(run.metadata, ['http_status', 'httpStatus'])
-	if (httpStatus != null && httpStatus >= 400 && httpStatus < 500) {
-		return 'rejected'
-	}
 	return 'failed'
 }
 

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -597,7 +597,6 @@ function createJobRow(
 		run_count: job.runCount,
 		success_count: job.successCount,
 		error_count: job.errorCount,
-		run_history_json: '[]',
 	}
 }
 

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -733,8 +733,6 @@ function createEntitlementsDatabase(input: {
 								'jobs',
 								'repo_sessions',
 								'package_invocations',
-								'package_runtime_runs',
-								'package_runtime_logs',
 								'published_bundle_artifacts',
 							]
 							if (

--- a/packages/worker/src/run-history-legacy-guardrail.node.test.ts
+++ b/packages/worker/src/run-history-legacy-guardrail.node.test.ts
@@ -1,0 +1,51 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+
+const forbidden =
+	/package_runtime_runs|package_runtime_logs|webhook_deliveries|run_history_json/g
+
+test('production worker sources do not reference dropped run-history legacy', () => {
+	const workerSrcRoot = fileURLToPath(new URL('.', import.meta.url))
+	const offenders: Array<string> = []
+
+	function walk(dir: string) {
+		for (const entry of readdirSync(dir)) {
+			const fullPath = join(dir, entry)
+			const stat = statSync(fullPath)
+			if (stat.isDirectory()) {
+				if (
+					entry === 'node_modules' ||
+					entry === 'dist' ||
+					entry === '.wrangler'
+				) {
+					continue
+				}
+				walk(fullPath)
+				continue
+			}
+			if (!entry.endsWith('.ts')) continue
+			if (entry.endsWith('.test.ts') || entry.endsWith('.workers.test.ts')) {
+				continue
+			}
+			const relativePath = relative(workerSrcRoot, fullPath).replaceAll(
+				'\\',
+				'/',
+			)
+			const source = readFileSync(fullPath, 'utf8')
+			forbidden.lastIndex = 0
+			let match: RegExpExecArray | null
+			while ((match = forbidden.exec(source)) !== null) {
+				offenders.push(`${relativePath}: ${match[0]}`)
+			}
+		}
+	}
+
+	walk(workerSrcRoot)
+
+	expect(
+		offenders,
+		'Dropped D1 run-history leftovers must not return in production sources',
+	).toEqual([])
+})

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -83,8 +83,8 @@ export function runPersistenceForSurface(surface: RunSurface): RunPersistence {
 /**
  * Everything a caller knows about a run when it starts. `packageId`/`kodyId`
  * are optional because ad-hoc execute, standalone `kody.json` jobs, and inline
- * workflows have no owning package — that optionality is the whole reason this
- * replaced the package-shaped `package_runtime_runs` table.
+ * workflows have no owning package — that optionality is why run records are
+ * user-scoped rather than package-shaped.
  */
 export type RunRecordContext = {
 	surface: RunSurface

--- a/packages/worker/src/storage-buckets/migration.node.test.ts
+++ b/packages/worker/src/storage-buckets/migration.node.test.ts
@@ -17,7 +17,7 @@ function applyMigration(db: DatabaseSync, fileName: string) {
 	db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
 }
 
-test('user_storage_buckets migration backfills jobs, apps, and runtime-only buckets', () => {
+test('user_storage_buckets migration backfills jobs, apps, and archived job buckets', () => {
 	const db = new DatabaseSync(':memory:')
 	applyMigrationsBefore(db, userStorageBucketsMigration)
 
@@ -48,25 +48,6 @@ test('user_storage_buckets migration backfills jobs, apps, and runtime-only buck
 			'2026-07-07T00:00:00.000Z', '2026-07-08T00:00:00.000Z'
 		);
 
-		INSERT INTO package_runtime_runs (
-			id, user_id, package_id, package_kody_id, surface, status,
-			started_at, storage_id, created_at, updated_at
-		) VALUES (
-			'run-adhoc-1', 'user-a', 'pkg-none', 'none', 'export', 'success',
-			'2026-07-06T00:00:00.000Z', 'exec:legacy-only',
-			'2026-07-06T00:00:00.000Z', '2026-07-06T00:01:00.000Z'
-		);
-
-		-- Same bucket in both an authoritative table and run history: the
-		-- authoritative kind must win, since the rescue arm runs last.
-		INSERT INTO package_runtime_runs (
-			id, user_id, package_id, package_kody_id, surface, status,
-			started_at, storage_id, created_at, updated_at
-		) VALUES (
-			'run-job-1', 'user-a', 'pkg-none', 'none', 'export', 'success',
-			'2026-07-09T00:00:00.000Z', 'job:job-1',
-			'2026-07-09T00:00:00.000Z', '2026-07-09T00:01:00.000Z'
-		);
 	`)
 
 	applyMigration(db, userStorageBucketsMigration)
@@ -86,13 +67,6 @@ test('user_storage_buckets migration backfills jobs, apps, and runtime-only buck
 	}>
 
 	expect(rows).toEqual([
-		{
-			user_id: 'user-a',
-			storage_id: 'exec:legacy-only',
-			kind: 'unknown',
-			created_at: '2026-07-06T00:00:00.000Z',
-			last_seen_at: '2026-07-06T00:01:00.000Z',
-		},
 		{
 			user_id: 'user-a',
 			storage_id: 'job:job-1',

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -106,22 +106,6 @@ async function ensureSchema(db: D1Database) {
 		.run()
 	await db
 		.prepare(
-			`CREATE TABLE IF NOT EXISTS webhook_deliveries (
-				id TEXT PRIMARY KEY,
-				endpoint_id TEXT NOT NULL,
-				user_id TEXT NOT NULL,
-				package_id TEXT NOT NULL,
-				webhook_name TEXT NOT NULL,
-				received_at TEXT NOT NULL,
-				outcome TEXT NOT NULL,
-				http_status INTEGER NOT NULL,
-				error TEXT,
-				payload_bytes INTEGER NOT NULL DEFAULT 0
-			)`,
-		)
-		.run()
-	await db
-		.prepare(
 			`CREATE TABLE IF NOT EXISTS remote_connector_settings (
 				id TEXT PRIMARY KEY,
 				user_id TEXT NOT NULL,
@@ -254,21 +238,9 @@ async function listDeliveries(userId: string, webhookName: string) {
 	return page.runs.filter((run) => run.name === webhookName)
 }
 
-async function countWebhookDeliveryRows(webhookName: string) {
-	const result = await env.APP_DB.prepare(
-		`SELECT COUNT(*) AS count
-		FROM webhook_deliveries
-		WHERE webhook_name = ?`,
-	)
-		.bind(webhookName)
-		.first<{ count: number }>()
-	return Number(result?.count ?? 0)
-}
-
 test('package-centered webhook ingress auth, HMAC, size cap, ack/sync, and isolation', async () => {
 	silenceExpectedConsoleWarns(['activation-run-record-failed'])
 	await ensureSchema(env.APP_DB)
-	await env.APP_DB.prepare(`DELETE FROM webhook_deliveries`).run()
 	await env.APP_DB.prepare(`DELETE FROM webhook_endpoints`).run()
 	await env.APP_DB.prepare(`DELETE FROM saved_packages`).run()
 	await env.APP_DB.prepare(`DELETE FROM users`).run()
@@ -358,7 +330,6 @@ test('package-centered webhook ingress auth, HMAC, size cap, ack/sync, and isola
 		httpStatus: 202,
 		outcome: 'delivered',
 	})
-	expect(await countWebhookDeliveryRows('sentry')).toBe(0)
 
 	declareWebhook({ name: 'sync-hook', responseMode: 'sync' })
 	mocks.invokePackageExport.mockClear()
@@ -374,7 +345,6 @@ test('package-centered webhook ingress auth, HMAC, size cap, ack/sync, and isola
 		result: { handled: true },
 	})
 	expect((await listDeliveries(userId, 'sync-hook'))[0]?.status).toBe('success')
-	expect(await countWebhookDeliveryRows('sync-hook')).toBe(0)
 
 	expect(
 		(
@@ -482,7 +452,6 @@ test('package-centered webhook ingress auth, HMAC, size cap, ack/sync, and isola
 test('webhook delivery records with one DO write, real startedAt duration, and explicit outcome', async () => {
 	silenceExpectedConsoleWarns(['activation-run-record-failed'])
 	await ensureSchema(env.APP_DB)
-	await env.APP_DB.prepare(`DELETE FROM webhook_deliveries`).run()
 	await env.APP_DB.prepare(`DELETE FROM webhook_endpoints`).run()
 	await env.APP_DB.prepare(`DELETE FROM saved_packages`).run()
 	await env.APP_DB.prepare(`DELETE FROM users`).run()
@@ -549,7 +518,6 @@ test('webhook delivery records with one DO write, real startedAt duration, and e
 test('webhook delivery records explicit rejected and failed outcomes', async () => {
 	silenceExpectedConsoleWarns(['activation-run-record-failed'])
 	await ensureSchema(env.APP_DB)
-	await env.APP_DB.prepare(`DELETE FROM webhook_deliveries`).run()
 	await env.APP_DB.prepare(`DELETE FROM webhook_endpoints`).run()
 	await env.APP_DB.prepare(`DELETE FROM saved_packages`).run()
 	await env.APP_DB.prepare(`DELETE FROM users`).run()

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -419,6 +419,10 @@
 		{
 			"filename": "0098-backfill-package-service-states.sql",
 			"sha256": "e10562862d228d694b0516bf278ef81bdfb8a27c2691e8299f13b81582c41eda"
+		},
+		{
+			"filename": "0099-drop-run-history-legacy.sql",
+			"sha256": "b3c25eb9855ddc2d15ec7c5d848e71e3fc25ddc8f4d247845a9c85216027bb26"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #956. Net **−856 lines**.

This is the last step. #955 stopped writing these, #965 and #968 rescued the data that only lived in them, and this drops the schema and deletes every remaining reference.

## Why it is safe, with evidence

I verified against the production database rather than reasoning about it:

| Check | Result |
| --- | --- |
| Legacy buckets not captured by `user_storage_buckets` | **0** |
| Legacy-only services not captured by `package_service_states` | **0** |
| Services rescued by `0098` | 2, both recorded `stopped` |
| Running services affected | 0 |

Migration `0097` rescued **73** storage buckets that existed in no other table. Migration `0098` rescued the two `email-agent-processor` services whose Durable Objects are dormant and would never have projected state on their own. Nothing derives anything from these tables now.

## Why waiting would never have finished the job

The plan in #956 was to wait for the 30-day retention drain and then remove the arms once they provably returned nothing. Production data showed that premise was wrong: of 5,515 rows in `package_runtime_runs`, **13 are older than 30 days and all 13 have `status = 'running'`** — the retention keep-condition. Nothing writes the table any more, so those rows can never reach a terminal status and would never age out.

The table was never going to reach zero. Dropping it is the only thing that actually ends this.

## What is gone

`package_runtime_runs`, `package_runtime_logs`, `webhook_deliveries`, and the `jobs.run_history_json` column, plus:

- the legacy service arm and its `includeLegacyRuntimeRuns` option in `account-user-inventory.ts`
- the legacy drain lanes and their helpers in `retention.ts` — an entire hourly cron surface that existed only to drain tables that no longer exist
- the account data-target and retention-disposition registrations
- `run_history_json` handling in `jobs/repo.ts`, `jobs/types.ts`, and the entitlements storage accounting
- the outcome-inference fallback in `webhook-delivery-list.ts` — safe because the writer has always set `outcome` explicitly, since that change shipped in #955, the same deploy that started writing run records at all
- dead test fixtures, mock branches, and test-schema columns for all of the above

## A guardrail so it cannot creep back

`run-history-legacy-guardrail.node.test.ts` walks `packages/worker/src/**` (excluding tests) and fails if any of the four names reappear. Historical migrations are out of scope — they legitimately name the tables they created.

## Deliberately kept

`docs/contributing/architecture/capability-and-primitive-audit-2026-07.md` still mentions the tables. It is a dated point-in-time audit and should stay accurate to its own date.

The docs keep the *reasoning* about why history moved out of shared D1 — that is load-bearing context for the `state-vs-history` and `no-per-event-shared-writes` invariants. Only the "these tables still exist" caveats were removed.

`primitives.yaml` is unchanged, deliberately: its header says to edit only when a primitive is added, removed, or materially reshaped. Dropping already-unwritten tables changes no primitive's id, group, code roots, or meaning.

## Verification

`npm run validate` green: 1388 tests across 426 files, Playwright E2E, MCP E2E, `primitives:check`, `migrations:check`.

`ALTER TABLE jobs DROP COLUMN run_history_json` is used in place of a table rebuild — the column is unindexed and this matches the pattern already used in `0077` and `0079`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete run-history storage and legacy webhook delivery records.
  * Webhook delivery outcomes now rely on explicit recorded outcomes, with unknown outcomes reported as failed.
  * Updated account deletion, export, storage quotas, and retention handling to exclude retired legacy records.

* **Documentation**
  * Clarified run-record storage, retention, webhook behavior, and account data coverage.
  * Documented webhook validation responses, rate limits, and upload-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->