### PR TITLE
fix(mcp): resolve package scope by stable user id, not email

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/save-package-entitlements.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package-entitlements.node.test.ts
@@ -111,13 +111,12 @@ function createDatabase(
 							}
 							if (
 								query.includes('SELECT username') &&
-								query.includes('FROM users')
+								query.includes('FROM users') &&
+								query.includes('stable_user_id')
 							) {
 								return selectOne(
 									'users',
-									(row) =>
-										String(row['email']).toLowerCase() ===
-										String(params[0]).toLowerCase(),
+									(row) => row['stable_user_id'] === params[0],
 								) as T | null
 							}
 							if (

--- a/packages/worker/src/mcp/capabilities/packages/save-package-private-visibility.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package-private-visibility.node.test.ts
@@ -75,14 +75,12 @@ function createDatabase(users: Array<Record<string, unknown>>) {
 							}
 							if (
 								query.includes('SELECT username') &&
-								query.includes('FROM users')
+								query.includes('FROM users') &&
+								query.includes('stable_user_id')
 							) {
 								return (
-									users.find(
-										(row) =>
-											String(row['email']).toLowerCase() ===
-											String(params[0]).toLowerCase(),
-									) ?? null
+									users.find((row) => row['stable_user_id'] === params[0]) ??
+									null
 								)
 							}
 							if (

--- a/packages/worker/src/package-registry/package-owner.workers.test.ts
+++ b/packages/worker/src/package-registry/package-owner.workers.test.ts
@@ -94,4 +94,22 @@ test('resolvePackageOwnerContext returns caller ownership, grant delegation, and
 	await expect(
 		resolvePackageOwnerContext(env.APP_DB, actorUser, 'missing-scope-xyz'),
 	).rejects.toThrow(/not a platform account scope/)
+
+	// Email on the caller context can drift (for example mid-request email
+	// change) while stable_user_id stays authoritative — package scope must
+	// still resolve from identity, not email.
+	const staleEmail = `stale-${crypto.randomUUID()}@example.com`
+	expect(
+		await resolvePackageOwnerContext(env.APP_DB, {
+			userId: person.stableUserId,
+			email: staleEmail,
+			displayName: person.username,
+		}),
+	).toEqual({
+		ownerUserId: person.stableUserId,
+		ownerScope: person.username,
+		ownerEmail: staleEmail,
+		actorUserId: person.stableUserId,
+		delegated: false,
+	})
 })

--- a/packages/worker/src/package-registry/user-scope.node.test.ts
+++ b/packages/worker/src/package-registry/user-scope.node.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'vitest'
+import { getMcpUserPackageScope } from './user-scope.ts'
+
+type UsernameRow = {
+	username: string | null
+}
+
+function createMockAppDb(options: {
+	rowByStableUserId?: UsernameRow | null
+	rowByEmail?: UsernameRow | null
+}) {
+	const queries: Array<{ sql: string; params: Array<unknown> }> = []
+	const db = {
+		prepare(sql: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					queries.push({ sql, params })
+					return {
+						async first<T>() {
+							const normalized = sql.replace(/\s+/g, ' ').toLowerCase()
+							if (normalized.includes('where stable_user_id = ?')) {
+								return (options.rowByStableUserId ?? null) as T | null
+							}
+							if (normalized.includes('where lower(email) = lower(?)')) {
+								return (options.rowByEmail ?? null) as T | null
+							}
+							throw new Error(`Unsupported query: ${sql}`)
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+	return { db, queries }
+}
+
+test('getMcpUserPackageScope uses context username, then stable user id — never email', async () => {
+	const fromContext = createMockAppDb({
+		rowByStableUserId: { username: 'from-db' },
+		rowByEmail: { username: 'from-email' },
+	})
+	await expect(
+		getMcpUserPackageScope(fromContext.db, {
+			userId: 'stable-1',
+			email: 'stale@example.com',
+			displayName: 'Caller',
+			username: 'From-Context',
+		}),
+	).resolves.toBe('from-context')
+	expect(fromContext.queries).toEqual([])
+
+	const fromStableId = createMockAppDb({
+		rowByStableUserId: { username: 'db-user' },
+		// Stale email still "resolves" in the old lookup path — must not be used.
+		rowByEmail: { username: 'wrong-email-user' },
+	})
+	await expect(
+		getMcpUserPackageScope(fromStableId.db, {
+			userId: 'stable-2',
+			email: 'no-longer-this@example.com',
+			displayName: 'Caller',
+		}),
+	).resolves.toBe('db-user')
+	expect(fromStableId.queries).toHaveLength(1)
+	expect(fromStableId.queries[0]?.sql).toMatch(/stable_user_id\s*=\s*\?/i)
+	expect(fromStableId.queries[0]?.params).toEqual(['stable-2'])
+
+	const missing = createMockAppDb({
+		rowByStableUserId: null,
+		rowByEmail: { username: 'email-only-hit' },
+	})
+	await expect(
+		getMcpUserPackageScope(missing.db, {
+			userId: 'orphan-stable',
+			email: 'orphan@example.com',
+			displayName: 'Orphan',
+		}),
+	).rejects.toThrow(
+		'Cannot validate package scope because the signed-in user record was not found.',
+	)
+	expect(missing.queries[0]?.params).toEqual(['orphan-stable'])
+})

--- a/packages/worker/src/package-registry/user-scope.ts
+++ b/packages/worker/src/package-registry/user-scope.ts
@@ -16,18 +16,34 @@ function normalizePackageScopeUsername(value: unknown) {
 	return username
 }
 
+/**
+ * Resolve the caller's personal package scope (username without "@").
+ *
+ * Identity is the MCP stable user id (`users.stable_user_id`), matching
+ * `buildMcpUserContextFromGrantProps`. Looking up by email is wrong: a
+ * concurrent email change (or any email/context drift) leaves the grant's
+ * stable id intact but makes an email query miss the row.
+ *
+ * When auth already attached a validated username to the caller context, use
+ * it — that snapshot is refreshed from D1 on every MCP/request auth path.
+ */
 export async function getMcpUserPackageScope(
 	db: D1Database,
 	user: McpUserContext,
 ) {
+	const contextUsername = user.username?.trim()
+	if (contextUsername) {
+		return normalizePackageScopeUsername(contextUsername)
+	}
+
 	const row = await db
 		.prepare(
 			`SELECT username
 			FROM users
-			WHERE lower(email) = lower(?)
+			WHERE stable_user_id = ?
 			LIMIT 1`,
 		)
-		.bind(user.email)
+		.bind(user.userId)
 		.first<UsernameRow>()
 	if (!row) {
 		throw new Error(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Sentry [KODY-CLOUDFLARE-2E](https://kent-c-dodds-tech-llc.sentry.io/issues/7634848229/) (`package_get_git_remote` → `getMcpUserPackageScope`).

## Root cause

`getMcpUserPackageScope` looked up `users` by email. MCP auth binds identity to `users.stable_user_id` (`buildMcpUserContextFromGrantProps`, #840). When the caller context email drifts from the D1 row (concurrent email change is the realistic case), the email query returns no row and package capabilities fail with:

> Cannot validate package scope because the signed-in user record was not found.

The grant's stable user id remains valid the whole time.

## Fix

- Prefer the auth-refreshed `user.username` on the caller context when present
- Otherwise look up username by `stable_user_id = user.userId`
- Never resolve package scope by email

## Tests

- Node unit: context username short-circuit, stable-id lookup ignores stale email, missing stable id still errors
- Workers: `resolvePackageOwnerContext` succeeds with a stale context email
- Updated save-package node D1 facades for the new query shape

Siblings (KODY-CLOUDFLARE-17 / 1Z / 1W) do not share this root cause.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `1fd9f8e9` · **Head:** `324a91a4`

**Classification:** composes — aligns package-scope resolution with the existing MCP stable-user-id identity contract; no new primitives or schema.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | composes — resolve personal package scope via stable user id / auth username instead of email |

### System map

Package capability calls resolve the caller's personal scope through stable identity, matching MCP grant auth.

```mermaid
flowchart LR
  MCP["MCP capability<br/>package_get_git_remote"] --> Own["resolvePackageOwnerContext"]
  Own --> Scope["getMcpUserPackageScope"]
  Scope -->|"username on context?"| Ctx["use user.username"]
  Scope -->|"else"| D1["users WHERE stable_user_id = ?"]
  D1 --> Own
  Ctx --> Own
  classDef composes fill:#e8f5e9,stroke:#2e7d32,color:#000
  class Scope,Ctx,D1 composes
```

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context

### Risk and invariants

- **Overall risk:** low — isolated lookup-key fix with regression tests
- **Invariants:** per-user isolation preserved; storage ownership remains keyed by `user.userId` / `ownerUserId`
- **Rollout notes:** no migration; deploy clears the Sentry signature for email-drift misses

### Verification

- Local + CI `npm run validate` green
- Node/Workers unit coverage for stale-email and stable-id lookup

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8627785f-4c98-422a-9fa7-acb381790e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8627785f-4c98-422a-9fa7-acb381790e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package scope resolution to prioritize stable user identity over email-based lookup.
  * When a signed-in username is provided, it’s trimmed and used without triggering database queries.
  * Added/strengthened validation when no matching user record is found.
  * Kept ownership and delegation resolution consistent even if a user’s email has changed.

* **Tests**
  * Updated and extended package-scope and entitlements-related tests to match stable user ID lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->