### PR TITLE
Document merge statuses and the MCP timeout escape hatch in ship-pr

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -25,9 +25,50 @@ Squash and merge PR as Kody with `kody:@kentcdodds/github/pr/merge` using
 optional `commitTitle`), watch CI deploy. Relevant links for the discord message
 include: agent, PR, CI job, and relevant deployment page(s).
 
+Read `status` on the result rather than assuming success. Merge is idempotent,
+so retrying is safe, but **never blind-retry a timeout** — GitHub can complete a
+merge after the client gives up.
+
+| `status`                | What to do                                             |
+| ----------------------- | ------------------------------------------------------ |
+| `merged`                | Done; watch the deploy                                 |
+| `already_merged`        | Done; a previous attempt landed                        |
+| `merged_after_timeout`  | Done; the merge landed after the client aborted        |
+| `timed_out_unconfirmed` | Verify with `pr/get-checks` or `pr/get-info` first     |
+| `closed` / `draft`      | Not mergeable yet; fix the PR state                    |
+| `dirty` / `blocked`     | Conflicts or failing required checks; back to the loop |
+| `mergeable_unknown`     | GitHub is still computing; wait, then re-call          |
+
+The call is bounded (default `timeoutMs: 25000`) and returns `timings`, so a
+slow merge surfaces as a structured result instead of an opaque hang.
+
 Other useful exports on the same package: `pr/get-checks` for check-run status
 without `gh`, and `request` / `graphql` (`kody:@kentcdodds/github/request`,
 `kody:@kentcdodds/github/graphql`) for one-off authenticated GitHub calls.
+
+### When an MCP call times out anyway
+
+Some slower Kody MCP writes — `package_get_git_remote` and
+`package_publish_external_push` among them — can exceed the MCP request timeout
+even though the underlying work is fine. Reads on the same connection stay fast,
+so a hang is not evidence the connection is unhealthy.
+
+Wrap the call in a durable workflow to move it off the request path, then poll
+for the effect:
+
+```javascript
+import { workflows } from 'kody:runtime'
+
+export default async function main() {
+	return await workflows.create({
+		code: `import merge from 'kody:@kentcdodds/github/pr/merge'
+
+export default async function main() {
+	return await merge({ prUrl: '...', mergeMethod: 'squash' })
+}`,
+	})
+}
+```
 
 ## Done → Discord
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only. Pairs with a fix to the `@kentcdodds/github` Kody package (published at `2c5653f`).

## What happened

Merging #969 hung five consecutive times. Each attempt exceeded the MCP request timeout and returned `MCP error -32001` with **no indication of whether the merge had applied**. The PR stayed open. It only merged when the same call was wrapped in `workflows.create(...)`, where it completed in about 6 seconds.

## What it actually was

Measured from inside the execute sandbox:

| Probe | Time |
| --- | --- |
| `GET /user` | 1933ms |
| `GET /pulls/969` | 810ms |
| `PUT /pulls/969/merge` (already-merged PR) | 265ms |
| `pr/merge` helper (already-merged PR) | 443ms |
| 45s sleep inside execute | succeeded |

GitHub is normally fast, the helper's own logic is fast, and the sandbox tolerates at least 45s. So the hangs were GitHub's merge endpoint itself blocking for well over a minute — plausibly because two other PRs had just merged into the same base branch while CI was running.

The bug was not that GitHub was occasionally slow. It was that `pr/merge` issued the merge **unbounded with no recovery**, turning an occasional slow merge into an opaque hang with unknown state. That is the genuinely dangerous part: an agent facing it is one blind retry away from a double merge attempt on a PR that may already have landed.

## Package fix (already published)

`pr/merge` now bounds the request at `timeoutMs: 25000`, and on abort re-checks the PR and returns a structured status instead of throwing. Verified independently:

| Case | Result |
| --- | --- |
| `timeoutMs: 1` on a merged PR | `merged_after_timeout`, no throw, 2.6s |
| Normal call on a merged PR | `already_merged`, 430ms — idempotency intact |
| Closed unmerged PR | `closed` with a fix hint, 589ms |

## This PR

Adds a status table to the skill so agents read `status` rather than assuming success, with the load-bearing rule called out: merge is idempotent so retry is safe, but **never blind-retry a timeout**, because GitHub can complete a merge after the client gives up.

Also records the durable-workflow escape hatch, because this is not unique to merging — `package_get_git_remote` and `package_publish_external_push` hit the same ceiling during this session, and two different agents independently worked around it the same way. Worth documenting that a hang is not evidence the MCP connection is unhealthy, since reads stay fast throughout.

## Verification

`format:check` and `primitives:check` pass. No code changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for handling MCP call timeouts.
  * Added status-based actions for confirmed merges, unconfirmed timeouts, and unknown mergeability.
  * Documented bounded request timing and structured timing information for slow merges.
  * Added a durable workflow and polling approach for operations that exceed request time limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->