### PR TITLE
feat(account): default /account/jobs to active and upcoming work

### DIFF
--- a/e2e/account-jobs.spec.ts
+++ b/e2e/account-jobs.spec.ts
@@ -3,6 +3,44 @@ import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
 import { createStableUserIdFromEmail } from '../packages/worker/src/user-id.ts'
 import { executeE2eD1Command } from './d1-utils.ts'
 
+function insertJob(input: {
+	userId: string
+	jobId: string
+	jobName: string
+	schedule: Record<string, string>
+	enabled: 0 | 1
+	nextRunAt: string
+	now: string
+}) {
+	executeE2eD1Command(
+		`INSERT INTO jobs (
+			id, user_id, name, source_id, published_commit, storage_id,
+			params_json, schedule_json, timezone, enabled, kill_switch_enabled,
+			caller_context_json, created_at, updated_at, next_run_at,
+			run_count, success_count, error_count
+		) VALUES (
+			${quoteSqlString(input.jobId)},
+			${quoteSqlString(input.userId)},
+			${quoteSqlString(input.jobName)},
+			${quoteSqlString(`source-${input.jobId}`)},
+			NULL,
+			${quoteSqlString(`job:${input.jobId}`)},
+			NULL,
+			${quoteSqlString(JSON.stringify(input.schedule))},
+			'UTC',
+			${input.enabled},
+			0,
+			'null',
+			${quoteSqlString(input.now)},
+			${quoteSqlString(input.now)},
+			${quoteSqlString(input.nextRunAt)},
+			0,
+			0,
+			0
+		)`,
+	)
+}
+
 test('account jobs detail URL persists across reload for a seeded job', async ({
 	page,
 	seedE2eUser,
@@ -20,33 +58,15 @@ test('account jobs detail URL persists across reload for a seeded job', async ({
 	const jobName = `Seeded job ${runId}`
 	const now = new Date().toISOString()
 	const nextRunAt = new Date(Date.now() + 60 * 60 * 1000).toISOString()
-	executeE2eD1Command(
-		`INSERT INTO jobs (
-			id, user_id, name, source_id, published_commit, storage_id,
-			params_json, schedule_json, timezone, enabled, kill_switch_enabled,
-			caller_context_json, created_at, updated_at, next_run_at,
-			run_count, success_count, error_count
-		) VALUES (
-			${quoteSqlString(jobId)},
-			${quoteSqlString(userId)},
-			${quoteSqlString(jobName)},
-			${quoteSqlString(`source-${jobId}`)},
-			NULL,
-			${quoteSqlString(`job:${jobId}`)},
-			NULL,
-			${quoteSqlString(JSON.stringify({ type: 'interval', every: '1h' }))},
-			'UTC',
-			1,
-			0,
-			'null',
-			${quoteSqlString(now)},
-			${quoteSqlString(now)},
-			${quoteSqlString(nextRunAt)},
-			0,
-			0,
-			0
-		)`,
-	)
+	insertJob({
+		userId,
+		jobId,
+		jobName,
+		schedule: { type: 'interval', every: '1h' },
+		enabled: 1,
+		nextRunAt,
+		now,
+	})
 
 	await login({
 		email: user.email,
@@ -68,4 +88,64 @@ test('account jobs detail URL persists across reload for a seeded job', async ({
 	await expect(
 		page.getByRole('heading', { name: jobName, exact: true }),
 	).toBeVisible()
+})
+
+test('account jobs defaults to active view and can show history', async ({
+	page,
+	seedE2eUser,
+	login,
+}) => {
+	const runId = Date.now()
+	const email = `account-jobs-filter-${runId}@example.com`
+	const user = await seedE2eUser({
+		email,
+		username: `account-jobs-filter-${runId}`,
+		password: 'account-jobs-password',
+	})
+	const userId = await createStableUserIdFromEmail(email)
+	const now = new Date().toISOString()
+	const activeJobId = crypto.randomUUID()
+	const activeJobName = `Active job ${runId}`
+	const historyJobId = crypto.randomUUID()
+	const historyJobName = `Past once job ${runId}`
+	insertJob({
+		userId,
+		jobId: activeJobId,
+		jobName: activeJobName,
+		schedule: { type: 'cron', expression: '0 9 * * *' },
+		enabled: 1,
+		nextRunAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+		now,
+	})
+	insertJob({
+		userId,
+		jobId: historyJobId,
+		jobName: historyJobName,
+		schedule: {
+			type: 'once',
+			runAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+		},
+		enabled: 0,
+		nextRunAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+		now,
+	})
+
+	await login({
+		email: user.email,
+		password: user.password,
+		mode: 'login',
+	})
+
+	await page.goto('/account/jobs')
+	await expect(
+		page.getByRole('heading', { name: 'Jobs', exact: true }),
+	).toBeVisible()
+	await expect(page.getByLabel('Jobs view filter')).toHaveValue('active')
+	await expect(page.getByText(activeJobName, { exact: true })).toBeVisible()
+	await expect(page.getByText(historyJobName, { exact: true })).toHaveCount(0)
+
+	await page.getByLabel('Jobs view filter').selectOption('history')
+	await expect(page).toHaveURL(/view=history/)
+	await expect(page.getByText(historyJobName, { exact: true })).toBeVisible()
+	await expect(page.getByText(activeJobName, { exact: true })).toHaveCount(0)
 })

--- a/packages/worker/client/routes/account-jobs-filter.node.test.ts
+++ b/packages/worker/client/routes/account-jobs-filter.node.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from 'vitest'
+import {
+	filterAccountJobs,
+	isActiveAccountJob,
+	readJobsViewFilter,
+	type FilterableAccountJob,
+} from './account-jobs-filter.ts'
+
+const nowMs = Date.parse('2026-07-27T12:00:00.000Z')
+
+function job(
+	overrides: Partial<FilterableAccountJob> & Pick<FilterableAccountJob, 'id'>,
+): FilterableAccountJob {
+	return {
+		name: overrides.id,
+		ownership: 'ad-hoc',
+		scheduleSummary: 'summary',
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		dueNow: false,
+		lastRunStatus: null,
+		nextRunAt: '2026-07-28T12:00:00.000Z',
+		scheduleType: 'cron',
+		...overrides,
+	}
+}
+
+test('isActiveAccountJob keeps enabled jobs and future disabled once jobs', () => {
+	expect(
+		isActiveAccountJob(
+			job({ id: 'enabled-cron', enabled: true, scheduleType: 'cron' }),
+			nowMs,
+		),
+	).toBe(true)
+	expect(
+		isActiveAccountJob(
+			job({
+				id: 'future-once',
+				enabled: false,
+				scheduleType: 'once',
+				nextRunAt: '2026-07-28T00:00:00.000Z',
+			}),
+			nowMs,
+		),
+	).toBe(true)
+	expect(
+		isActiveAccountJob(
+			job({
+				id: 'past-once',
+				enabled: false,
+				scheduleType: 'once',
+				nextRunAt: '2026-07-26T00:00:00.000Z',
+			}),
+			nowMs,
+		),
+	).toBe(false)
+	expect(
+		isActiveAccountJob(
+			job({
+				id: 'disabled-interval',
+				enabled: false,
+				scheduleType: 'interval',
+				nextRunAt: '2026-07-28T00:00:00.000Z',
+			}),
+			nowMs,
+		),
+	).toBe(false)
+})
+
+test('readJobsViewFilter defaults to active and accepts history', () => {
+	expect(readJobsViewFilter('/account/jobs')).toBe('active')
+	expect(readJobsViewFilter('/account/jobs?view=active')).toBe('active')
+	expect(readJobsViewFilter('/account/jobs?view=history')).toBe('history')
+	expect(readJobsViewFilter('/account/jobs?view=nope')).toBe('active')
+})
+
+test('filterAccountJobs defaults to active ops surface and supports history', () => {
+	const jobs = [
+		job({ id: 'live-cron', name: 'Live digest', enabled: true }),
+		job({
+			id: 'upcoming-once',
+			name: 'Tomorrow ping',
+			enabled: false,
+			scheduleType: 'once',
+			nextRunAt: '2026-07-28T09:00:00.000Z',
+		}),
+		job({
+			id: 'failed-once',
+			name: 'Failed ping',
+			enabled: false,
+			scheduleType: 'once',
+			nextRunAt: '2026-07-20T09:00:00.000Z',
+		}),
+		job({
+			id: 'disabled-cron',
+			name: 'Old digest',
+			enabled: false,
+			scheduleType: 'cron',
+		}),
+	]
+
+	expect(
+		filterAccountJobs(jobs, { view: 'active', search: '', nowMs }).map(
+			(item) => item.id,
+		),
+	).toEqual(['live-cron', 'upcoming-once'])
+
+	expect(
+		filterAccountJobs(jobs, { view: 'history', search: '', nowMs }).map(
+			(item) => item.id,
+		),
+	).toEqual(['failed-once', 'disabled-cron'])
+
+	expect(
+		filterAccountJobs(jobs, {
+			view: 'history',
+			search: 'failed',
+			nowMs,
+		}).map((item) => item.id),
+	).toEqual(['failed-once'])
+})

--- a/packages/worker/client/routes/account-jobs-filter.ts
+++ b/packages/worker/client/routes/account-jobs-filter.ts
@@ -1,0 +1,70 @@
+import { matchesSearchQuery } from '#client/search-filter.ts'
+
+export type AccountJobsViewFilter = 'active' | 'history'
+
+export type FilterableAccountJob = {
+	id: string
+	name: string
+	ownership: string
+	scheduleSummary: string
+	timezone: string
+	enabled: boolean
+	killSwitchEnabled: boolean
+	dueNow: boolean
+	lastRunStatus: string | null
+	nextRunAt: string
+	scheduleType: 'once' | 'interval' | 'cron'
+}
+
+/**
+ * Ops-surface rule: live work plus upcoming one-offs.
+ * enabled OR (once schedule with a future run_at / nextRunAt).
+ */
+export function isActiveAccountJob(
+	job: Pick<FilterableAccountJob, 'enabled' | 'scheduleType' | 'nextRunAt'>,
+	nowMs: number = Date.now(),
+) {
+	if (job.enabled) return true
+	if (job.scheduleType !== 'once') return false
+	const runAtMs = Date.parse(job.nextRunAt)
+	return Number.isFinite(runAtMs) && runAtMs > nowMs
+}
+
+export function readJobsViewFilter(href: string): AccountJobsViewFilter {
+	const value = new URL(href, 'http://localhost').searchParams
+		.get('view')
+		?.trim()
+	if (value === 'history') return 'history'
+	return 'active'
+}
+
+export function readJobsSearchFilter(href: string) {
+	return new URL(href, 'http://localhost').searchParams.get('q')?.trim() ?? ''
+}
+
+export function filterAccountJobs<Job extends FilterableAccountJob>(
+	jobs: ReadonlyArray<Job>,
+	input: {
+		view: AccountJobsViewFilter
+		search: string
+		nowMs?: number
+	},
+): Array<Job> {
+	const nowMs = input.nowMs ?? Date.now()
+	return jobs.filter((job) => {
+		const active = isActiveAccountJob(job, nowMs)
+		if (input.view === 'active' ? !active : active) return false
+		return matchesSearchQuery(input.search, [
+			job.name,
+			job.id,
+			job.ownership,
+			job.scheduleSummary,
+			job.timezone,
+			job.lastRunStatus,
+			job.enabled ? 'enabled' : 'disabled',
+			job.killSwitchEnabled ? 'kill switch' : '',
+			job.dueNow ? 'due' : '',
+			job.scheduleType,
+		])
+	})
+}

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -5,13 +5,18 @@ import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
-import { matchesSearchQuery } from '#client/search-filter.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import {
 	type AccountStatus,
 	readJson,
 } from '#client/routes/account-approval-shared.ts'
+import {
+	filterAccountJobs,
+	readJobsSearchFilter,
+	readJobsViewFilter,
+	type AccountJobsViewFilter,
+} from '#client/routes/account-jobs-filter.ts'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -61,10 +66,18 @@ type EditState = {
 const accountJobsApiPath = '/account/jobs.json'
 const jobsRoute = createListDetailRoute('/account/jobs')
 
+const viewFilterOptions: Array<{
+	value: AccountJobsViewFilter
+	label: string
+}> = [
+	{ value: 'active', label: 'Active' },
+	{ value: 'history', label: 'History' },
+]
+
 /**
  * Latch key includes the selected job id because detail fields (recent runs,
- * params, errors) are loaded with `?selected=`. The client-side `q` filter is
- * omitted so search typing does not refetch.
+ * params, errors) are loaded with `?selected=`. The client-side `q` / `view`
+ * filters are omitted so search typing and view toggles do not refetch.
  */
 function getDataLatchKey(href: string) {
 	const selectedId = jobsRoute.getSelection(href).selectedId
@@ -73,24 +86,19 @@ function getDataLatchKey(href: string) {
 		: '/account/jobs'
 }
 
-function readSearchFilter(href: string) {
-	return new URL(href, 'http://localhost').searchParams.get('q')?.trim() ?? ''
-}
-
-function filterJobs(jobs: Array<AccountJobListItem>, search: string) {
-	return jobs.filter((job) =>
-		matchesSearchQuery(search, [
-			job.name,
-			job.id,
-			job.ownership,
-			job.scheduleSummary,
-			job.timezone,
-			job.lastRunStatus,
-			job.enabled ? 'enabled' : 'disabled',
-			job.killSwitchEnabled ? 'kill switch' : '',
-			job.dueNow ? 'due' : '',
-		]),
-	)
+function emptyJobsMessage(input: {
+	totalCount: number
+	filteredCount: number
+	view: AccountJobsViewFilter
+	search: string
+}) {
+	if (input.totalCount === 0) return 'No scheduled jobs yet.'
+	if (input.filteredCount > 0) return null
+	if (input.search) return 'No jobs match the current filters.'
+	if (input.view === 'history') {
+		return 'No inactive or past jobs.'
+	}
+	return 'No active or upcoming jobs. Switch to History to see disabled or past jobs.'
 }
 
 function buildJobsApiRequestUrl(href: string) {
@@ -214,10 +222,17 @@ export function AccountJobsRoute(handle: Handle) {
 		return new URL(getCurrentHref(), 'http://localhost').search
 	}
 
-	function buildHrefWithUpdatedSearch(search: string) {
+	function buildHrefWithUpdatedFilters(next: {
+		search?: string
+		view?: AccountJobsViewFilter
+	}) {
 		const nextUrl = new URL(getCurrentHref(), 'http://localhost')
+		const search = next.search ?? nextUrl.searchParams.get('q')?.trim() ?? ''
+		const view = next.view ?? readJobsViewFilter(nextUrl.href)
 		if (search) nextUrl.searchParams.set('q', search)
 		else nextUrl.searchParams.delete('q')
+		if (view === 'history') nextUrl.searchParams.set('view', 'history')
+		else nextUrl.searchParams.delete('view')
 		return `${nextUrl.pathname}${nextUrl.search}`
 	}
 
@@ -362,8 +377,15 @@ export function AccountJobsRoute(handle: Handle) {
 		}
 		const isMutating = actionState !== 'idle'
 		const selection = jobsRoute.getSelection(currentHref)
-		const search = readSearchFilter(currentHref)
-		const filteredJobs = filterJobs(jobs, search)
+		const search = readJobsSearchFilter(currentHref)
+		const view = readJobsViewFilter(currentHref)
+		const filteredJobs = filterAccountJobs(jobs, { view, search })
+		const listEmptyMessage = emptyJobsMessage({
+			totalCount: jobs.length,
+			filteredCount: filteredJobs.length,
+			view,
+			search,
+		})
 		const detail =
 			selectedJob && selectedJob.id === selection.selectedId
 				? selectedJob
@@ -411,23 +433,48 @@ export function AccountJobsRoute(handle: Handle) {
 						sidebar={
 							<AccountManagementSidebar
 								title="Scheduled jobs"
-								description="Ad-hoc jobs and package-owned jobs for this account."
+								description="Default view shows active and upcoming jobs. Switch to History for disabled or past jobs."
 							>
-								<AccountManagementSearchField
-									label="Search"
-									placeholder="Search jobs"
-									value={search}
-									onInput={(value) => {
-										replaceLocation(buildHrefWithUpdatedSearch(value))
-									}}
-								/>
-								{jobs.length === 0 ? (
+								<div mix={css({ display: 'grid', gap: spacing.sm })}>
+									<label mix={css(fieldCss)}>
+										<span mix={css(fieldLabelCss)}>View</span>
+										<select
+											aria-label="Jobs view filter"
+											value={view}
+											mix={[
+												on('change', (event) => {
+													const value = event.currentTarget.value
+													if (value !== 'active' && value !== 'history') {
+														return
+													}
+													replaceLocation(
+														buildHrefWithUpdatedFilters({ view: value }),
+													)
+												}),
+												css(inputCss),
+											]}
+										>
+											{viewFilterOptions.map((option) => (
+												<option key={option.value} value={option.value}>
+													{option.label}
+												</option>
+											))}
+										</select>
+									</label>
+									<AccountManagementSearchField
+										label="Search"
+										placeholder="Search jobs"
+										value={search}
+										onInput={(value) => {
+											replaceLocation(
+												buildHrefWithUpdatedFilters({ search: value }),
+											)
+										}}
+									/>
+								</div>
+								{listEmptyMessage ? (
 									<p mix={css({ margin: 0, color: colors.textMuted })}>
-										No scheduled jobs yet.
-									</p>
-								) : filteredJobs.length === 0 ? (
-									<p mix={css({ margin: 0, color: colors.textMuted })}>
-										No jobs match the current filters.
+										{listEmptyMessage}
 									</p>
 								) : (
 									<AccountManagementList>

--- a/packages/worker/src/app/account-jobs-data.ts
+++ b/packages/worker/src/app/account-jobs-data.ts
@@ -19,6 +19,7 @@ export type AccountJobListItem = {
 	name: string
 	ownership: JobOwnership
 	scheduleSummary: string
+	scheduleType: JobSchedule['type']
 	timezone: string
 	enabled: boolean
 	killSwitchEnabled: boolean
@@ -116,6 +117,7 @@ function toListItem(
 		name: job.name,
 		ownership: jobOwnershipForId(job.id),
 		scheduleSummary: job.scheduleSummary,
+		scheduleType: job.schedule.type,
 		timezone: job.timezone,
 		enabled: job.enabled,
 		killSwitchEnabled: job.killSwitchEnabled,

--- a/packages/worker/src/app/handlers/account-jobs.node.test.ts
+++ b/packages/worker/src/app/handlers/account-jobs.node.test.ts
@@ -199,12 +199,14 @@ test('jobs API lists jobs with ownership and selected detail', async () => {
 				id: 'job-adhoc-1',
 				ownership: 'ad-hoc',
 				scheduleSummary: adHocJob.scheduleSummary,
+				scheduleType: 'cron',
 				enabled: true,
 				killSwitchEnabled: false,
 			}),
 			expect.objectContaining({
 				id: 'package-job:pkg-1:nightly',
 				ownership: 'package',
+				scheduleType: 'interval',
 			}),
 		],
 		alarm: expect.objectContaining({

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -796,11 +796,17 @@ export type AccountLoaderJsonValue =
 	| Array<AccountLoaderJsonValue>
 	| { [key: string]: AccountLoaderJsonValue }
 
+export type AccountJobSchedule =
+	| { type: 'once'; runAt: string }
+	| { type: 'interval'; every: string }
+	| { type: 'cron'; expression: string }
+
 export type AccountJobListItem = {
 	id: string
 	name: string
 	ownership: AccountJobOwnership
 	scheduleSummary: string
+	scheduleType: AccountJobSchedule['type']
 	timezone: string
 	enabled: boolean
 	killSwitchEnabled: boolean
@@ -821,11 +827,6 @@ export type AccountJobRecentRun = {
 	durationMs: number
 	error: string | null
 }
-
-export type AccountJobSchedule =
-	| { type: 'once'; runAt: string }
-	| { type: 'interval'; every: string }
-	| { type: 'cron'; expression: string }
 
 export type AccountJobDetail = AccountJobListItem & {
 	params: { [key: string]: AccountLoaderJsonValue } | null


### PR DESCRIPTION
## Summary

- Default `/account/jobs` to an **Active** ops surface: enabled jobs plus upcoming disabled once jobs (`enabled OR (schedule.type === once AND nextRunAt is future)`).
- Add an **Active | History** view control persisted as `?view=history` (default omits the param).
- Expose `scheduleType` on job list items so the client can apply that rule without loading every detail.
- Empty states distinguish no jobs / no active / no history / search miss.
- Unit coverage for the filter helper; e2e covers default Active vs History toggle.

## Test plan

- [x] Unit + typecheck
- [x] e2e/account-jobs.spec.ts

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/account-jobs-default-filter-c22a`

**Classification:** extends — additive `scheduleType` on account job list items plus client-side Active/History filtering on `/account/jobs`.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — jobs list payload adds `scheduleType`; default list filter + `?view=` control |

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive API field and client-only list filtering on account jobs; no change to job execution or mutations, but users may not see disabled/past jobs until they switch views.
> 
> **Overview**
> **`/account/jobs`** now defaults to an **Active** ops view instead of listing every job. Active means enabled jobs plus disabled **once** jobs whose `nextRunAt` is still in the future; everything else (disabled recurring jobs, past one-offs) appears under **History** via `?view=history`.
> 
> A **View** control (Active | History) updates the URL without refetching. List filtering moved into `account-jobs-filter.ts` (shared with search on `q`). Job list API payloads add **`scheduleType`** so the client can apply the active rule without loading full schedule details.
> 
> Empty states distinguish no jobs, no matches, no active/upcoming, and no history. E2E and unit tests cover the toggle and filter rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efffd712fa9206f653e7d5b1079b9a1e2fd6b7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Active and History views to the account jobs page.
  - The jobs list now defaults to showing active jobs and can be switched to show historical jobs.
  - Added search filtering across job details, status, schedule type, and related indicators.
  - View and search selections persist in the page URL and across reloads.
  - Improved empty-state messages for different views and search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->