### PR TITLE
feat(account): jobs ownership filter, All view, and list scroll

### DIFF
--- a/e2e/account-jobs.spec.ts
+++ b/e2e/account-jobs.spec.ts
@@ -108,6 +108,8 @@ test('account jobs defaults to active view and can show history', async ({
 	const activeJobName = `Active job ${runId}`
 	const historyJobId = crypto.randomUUID()
 	const historyJobName = `Past once job ${runId}`
+	const packageJobId = `package-job:pkg-${runId}:nightly`
+	const packageJobName = `Package job ${runId}`
 	insertJob({
 		userId,
 		jobId: activeJobId,
@@ -129,6 +131,15 @@ test('account jobs defaults to active view and can show history', async ({
 		nextRunAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
 		now,
 	})
+	insertJob({
+		userId,
+		jobId: packageJobId,
+		jobName: packageJobName,
+		schedule: { type: 'interval', every: '1d' },
+		enabled: 1,
+		nextRunAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+		now,
+	})
 
 	await login({
 		email: user.email,
@@ -141,11 +152,31 @@ test('account jobs defaults to active view and can show history', async ({
 		page.getByRole('heading', { name: 'Jobs', exact: true }),
 	).toBeVisible()
 	await expect(page.getByLabel('Jobs view filter')).toHaveValue('active')
+	await expect(page.getByLabel('Jobs ownership filter')).toHaveValue('all')
 	await expect(page.getByText(activeJobName, { exact: true })).toBeVisible()
+	await expect(page.getByText(packageJobName, { exact: true })).toBeVisible()
 	await expect(page.getByText(historyJobName, { exact: true })).toHaveCount(0)
 
 	await page.getByLabel('Jobs view filter').selectOption('history')
 	await expect(page).toHaveURL(/view=history/)
 	await expect(page.getByText(historyJobName, { exact: true })).toBeVisible()
 	await expect(page.getByText(activeJobName, { exact: true })).toHaveCount(0)
+
+	await page.getByLabel('Jobs view filter').selectOption('all')
+	await expect(page).toHaveURL(/view=all/)
+	await expect(page.getByText(activeJobName, { exact: true })).toBeVisible()
+	await expect(page.getByText(historyJobName, { exact: true })).toBeVisible()
+	await expect(page.getByText(packageJobName, { exact: true })).toBeVisible()
+
+	await page.getByLabel('Jobs ownership filter').selectOption('package')
+	await expect(page).toHaveURL(/ownership=package/)
+	await expect(page.getByText(packageJobName, { exact: true })).toBeVisible()
+	await expect(page.getByText(activeJobName, { exact: true })).toHaveCount(0)
+	await expect(page.getByText(historyJobName, { exact: true })).toHaveCount(0)
+
+	await page.getByLabel('Jobs ownership filter').selectOption('ad-hoc')
+	await expect(page).toHaveURL(/ownership=ad-hoc/)
+	await expect(page.getByText(activeJobName, { exact: true })).toBeVisible()
+	await expect(page.getByText(historyJobName, { exact: true })).toBeVisible()
+	await expect(page.getByText(packageJobName, { exact: true })).toHaveCount(0)
 })

--- a/packages/worker/client/routes/account-jobs-filter.node.test.ts
+++ b/packages/worker/client/routes/account-jobs-filter.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import {
 	filterAccountJobs,
 	isActiveAccountJob,
+	readJobsOwnershipFilter,
 	readJobsViewFilter,
 	type FilterableAccountJob,
 } from './account-jobs-filter.ts'
@@ -68,21 +69,46 @@ test('isActiveAccountJob keeps enabled jobs and future disabled once jobs', () =
 	).toBe(false)
 })
 
-test('readJobsViewFilter defaults to active and accepts history', () => {
+test('readJobsViewFilter defaults to active and accepts history/all', () => {
 	expect(readJobsViewFilter('/account/jobs')).toBe('active')
 	expect(readJobsViewFilter('/account/jobs?view=active')).toBe('active')
 	expect(readJobsViewFilter('/account/jobs?view=history')).toBe('history')
+	expect(readJobsViewFilter('/account/jobs?view=all')).toBe('all')
 	expect(readJobsViewFilter('/account/jobs?view=nope')).toBe('active')
 })
 
-test('filterAccountJobs defaults to active ops surface and supports history', () => {
+test('readJobsOwnershipFilter defaults to all and accepts package/ad-hoc', () => {
+	expect(readJobsOwnershipFilter('/account/jobs')).toBe('all')
+	expect(readJobsOwnershipFilter('/account/jobs?ownership=all')).toBe('all')
+	expect(readJobsOwnershipFilter('/account/jobs?ownership=package')).toBe(
+		'package',
+	)
+	expect(readJobsOwnershipFilter('/account/jobs?ownership=ad-hoc')).toBe(
+		'ad-hoc',
+	)
+	expect(readJobsOwnershipFilter('/account/jobs?ownership=nope')).toBe('all')
+})
+
+test('filterAccountJobs supports view and ownership filters', () => {
 	const jobs = [
-		job({ id: 'live-cron', name: 'Live digest', enabled: true }),
+		job({
+			id: 'live-cron',
+			name: 'Live digest',
+			enabled: true,
+			ownership: 'ad-hoc',
+		}),
+		job({
+			id: 'live-package',
+			name: 'Package digest',
+			enabled: true,
+			ownership: 'package',
+		}),
 		job({
 			id: 'upcoming-once',
 			name: 'Tomorrow ping',
 			enabled: false,
 			scheduleType: 'once',
+			ownership: 'ad-hoc',
 			nextRunAt: '2026-07-28T09:00:00.000Z',
 		}),
 		job({
@@ -90,31 +116,64 @@ test('filterAccountJobs defaults to active ops surface and supports history', ()
 			name: 'Failed ping',
 			enabled: false,
 			scheduleType: 'once',
+			ownership: 'ad-hoc',
 			nextRunAt: '2026-07-20T09:00:00.000Z',
 		}),
 		job({
-			id: 'disabled-cron',
-			name: 'Old digest',
+			id: 'disabled-package',
+			name: 'Old package digest',
 			enabled: false,
 			scheduleType: 'cron',
+			ownership: 'package',
 		}),
 	]
 
 	expect(
-		filterAccountJobs(jobs, { view: 'active', search: '', nowMs }).map(
-			(item) => item.id,
-		),
-	).toEqual(['live-cron', 'upcoming-once'])
-
-	expect(
-		filterAccountJobs(jobs, { view: 'history', search: '', nowMs }).map(
-			(item) => item.id,
-		),
-	).toEqual(['failed-once', 'disabled-cron'])
+		filterAccountJobs(jobs, {
+			view: 'active',
+			ownership: 'all',
+			search: '',
+			nowMs,
+		}).map((item) => item.id),
+	).toEqual(['live-cron', 'live-package', 'upcoming-once'])
 
 	expect(
 		filterAccountJobs(jobs, {
 			view: 'history',
+			ownership: 'all',
+			search: '',
+			nowMs,
+		}).map((item) => item.id),
+	).toEqual(['failed-once', 'disabled-package'])
+
+	expect(
+		filterAccountJobs(jobs, {
+			view: 'all',
+			ownership: 'all',
+			search: '',
+			nowMs,
+		}).map((item) => item.id),
+	).toEqual([
+		'live-cron',
+		'live-package',
+		'upcoming-once',
+		'failed-once',
+		'disabled-package',
+	])
+
+	expect(
+		filterAccountJobs(jobs, {
+			view: 'active',
+			ownership: 'package',
+			search: '',
+			nowMs,
+		}).map((item) => item.id),
+	).toEqual(['live-package'])
+
+	expect(
+		filterAccountJobs(jobs, {
+			view: 'history',
+			ownership: 'ad-hoc',
 			search: 'failed',
 			nowMs,
 		}).map((item) => item.id),

--- a/packages/worker/client/routes/account-jobs-filter.ts
+++ b/packages/worker/client/routes/account-jobs-filter.ts
@@ -1,6 +1,7 @@
 import { matchesSearchQuery } from '#client/search-filter.ts'
 
-export type AccountJobsViewFilter = 'active' | 'history'
+export type AccountJobsViewFilter = 'active' | 'history' | 'all'
+export type AccountJobsOwnershipFilter = 'all' | 'ad-hoc' | 'package'
 
 export type FilterableAccountJob = {
 	id: string
@@ -34,8 +35,18 @@ export function readJobsViewFilter(href: string): AccountJobsViewFilter {
 	const value = new URL(href, 'http://localhost').searchParams
 		.get('view')
 		?.trim()
-	if (value === 'history') return 'history'
+	if (value === 'history' || value === 'all') return value
 	return 'active'
+}
+
+export function readJobsOwnershipFilter(
+	href: string,
+): AccountJobsOwnershipFilter {
+	const value = new URL(href, 'http://localhost').searchParams
+		.get('ownership')
+		?.trim()
+	if (value === 'ad-hoc' || value === 'package') return value
+	return 'all'
 }
 
 export function readJobsSearchFilter(href: string) {
@@ -46,14 +57,20 @@ export function filterAccountJobs<Job extends FilterableAccountJob>(
 	jobs: ReadonlyArray<Job>,
 	input: {
 		view: AccountJobsViewFilter
+		ownership: AccountJobsOwnershipFilter
 		search: string
 		nowMs?: number
 	},
 ): Array<Job> {
 	const nowMs = input.nowMs ?? Date.now()
 	return jobs.filter((job) => {
-		const active = isActiveAccountJob(job, nowMs)
-		if (input.view === 'active' ? !active : active) return false
+		if (input.ownership !== 'all' && job.ownership !== input.ownership) {
+			return false
+		}
+		if (input.view !== 'all') {
+			const active = isActiveAccountJob(job, nowMs)
+			if (input.view === 'active' ? !active : active) return false
+		}
 		return matchesSearchQuery(input.search, [
 			job.name,
 			job.id,

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -13,8 +13,10 @@ import {
 } from '#client/routes/account-approval-shared.ts'
 import {
 	filterAccountJobs,
+	readJobsOwnershipFilter,
 	readJobsSearchFilter,
 	readJobsViewFilter,
+	type AccountJobsOwnershipFilter,
 	type AccountJobsViewFilter,
 } from '#client/routes/account-jobs-filter.ts'
 import {
@@ -72,12 +74,23 @@ const viewFilterOptions: Array<{
 }> = [
 	{ value: 'active', label: 'Active' },
 	{ value: 'history', label: 'History' },
+	{ value: 'all', label: 'All' },
+]
+
+const ownershipFilterOptions: Array<{
+	value: AccountJobsOwnershipFilter
+	label: string
+}> = [
+	{ value: 'all', label: 'All ownership' },
+	{ value: 'ad-hoc', label: 'Ad-hoc' },
+	{ value: 'package', label: 'Package' },
 ]
 
 /**
  * Latch key includes the selected job id because detail fields (recent runs,
- * params, errors) are loaded with `?selected=`. The client-side `q` / `view`
- * filters are omitted so search typing and view toggles do not refetch.
+ * params, errors) are loaded with `?selected=`. The client-side `q` / `view` /
+ * `ownership` filters are omitted so search typing and filter toggles do not
+ * refetch.
  */
 function getDataLatchKey(href: string) {
 	const selectedId = jobsRoute.getSelection(href).selectedId
@@ -90,15 +103,18 @@ function emptyJobsMessage(input: {
 	totalCount: number
 	filteredCount: number
 	view: AccountJobsViewFilter
+	ownership: AccountJobsOwnershipFilter
 	search: string
 }) {
 	if (input.totalCount === 0) return 'No scheduled jobs yet.'
 	if (input.filteredCount > 0) return null
-	if (input.search) return 'No jobs match the current filters.'
+	if (input.search || input.ownership !== 'all' || input.view === 'all') {
+		return 'No jobs match the current filters.'
+	}
 	if (input.view === 'history') {
 		return 'No inactive or past jobs.'
 	}
-	return 'No active or upcoming jobs. Switch to History to see disabled or past jobs.'
+	return 'No active or upcoming jobs. Switch to History or All to see other jobs.'
 }
 
 function buildJobsApiRequestUrl(href: string) {
@@ -225,14 +241,18 @@ export function AccountJobsRoute(handle: Handle) {
 	function buildHrefWithUpdatedFilters(next: {
 		search?: string
 		view?: AccountJobsViewFilter
+		ownership?: AccountJobsOwnershipFilter
 	}) {
 		const nextUrl = new URL(getCurrentHref(), 'http://localhost')
 		const search = next.search ?? nextUrl.searchParams.get('q')?.trim() ?? ''
 		const view = next.view ?? readJobsViewFilter(nextUrl.href)
+		const ownership = next.ownership ?? readJobsOwnershipFilter(nextUrl.href)
 		if (search) nextUrl.searchParams.set('q', search)
 		else nextUrl.searchParams.delete('q')
-		if (view === 'history') nextUrl.searchParams.set('view', 'history')
-		else nextUrl.searchParams.delete('view')
+		if (view === 'active') nextUrl.searchParams.delete('view')
+		else nextUrl.searchParams.set('view', view)
+		if (ownership === 'all') nextUrl.searchParams.delete('ownership')
+		else nextUrl.searchParams.set('ownership', ownership)
 		return `${nextUrl.pathname}${nextUrl.search}`
 	}
 
@@ -379,11 +399,17 @@ export function AccountJobsRoute(handle: Handle) {
 		const selection = jobsRoute.getSelection(currentHref)
 		const search = readJobsSearchFilter(currentHref)
 		const view = readJobsViewFilter(currentHref)
-		const filteredJobs = filterAccountJobs(jobs, { view, search })
+		const ownership = readJobsOwnershipFilter(currentHref)
+		const filteredJobs = filterAccountJobs(jobs, {
+			view,
+			ownership,
+			search,
+		})
 		const listEmptyMessage = emptyJobsMessage({
 			totalCount: jobs.length,
 			filteredCount: filteredJobs.length,
 			view,
+			ownership,
 			search,
 		})
 		const detail =
@@ -433,7 +459,7 @@ export function AccountJobsRoute(handle: Handle) {
 						sidebar={
 							<AccountManagementSidebar
 								title="Scheduled jobs"
-								description="Default view shows active and upcoming jobs. Switch to History for disabled or past jobs."
+								description="Default view shows active and upcoming jobs. Filter by ownership or switch to History/All for other jobs."
 							>
 								<div mix={css({ display: 'grid', gap: spacing.sm })}>
 									<label mix={css(fieldCss)}>
@@ -444,7 +470,11 @@ export function AccountJobsRoute(handle: Handle) {
 											mix={[
 												on('change', (event) => {
 													const value = event.currentTarget.value
-													if (value !== 'active' && value !== 'history') {
+													if (
+														value !== 'active' &&
+														value !== 'history' &&
+														value !== 'all'
+													) {
 														return
 													}
 													replaceLocation(
@@ -455,6 +485,37 @@ export function AccountJobsRoute(handle: Handle) {
 											]}
 										>
 											{viewFilterOptions.map((option) => (
+												<option key={option.value} value={option.value}>
+													{option.label}
+												</option>
+											))}
+										</select>
+									</label>
+									<label mix={css(fieldCss)}>
+										<span mix={css(fieldLabelCss)}>Ownership</span>
+										<select
+											aria-label="Jobs ownership filter"
+											value={ownership}
+											mix={[
+												on('change', (event) => {
+													const value = event.currentTarget.value
+													if (
+														value !== 'all' &&
+														value !== 'ad-hoc' &&
+														value !== 'package'
+													) {
+														return
+													}
+													replaceLocation(
+														buildHrefWithUpdatedFilters({
+															ownership: value,
+														}),
+													)
+												}),
+												css(inputCss),
+											]}
+										>
+											{ownershipFilterOptions.map((option) => (
 												<option key={option.value} value={option.value}>
 													{option.label}
 												</option>
@@ -477,7 +538,7 @@ export function AccountJobsRoute(handle: Handle) {
 										{listEmptyMessage}
 									</p>
 								) : (
-									<AccountManagementList>
+									<AccountManagementList maxHeight="min(65vh, 48rem)">
 										{filteredJobs.map((item) => (
 											<li key={item.id}>
 												<AccountManagementListItemButton


### PR DESCRIPTION
## Summary

- Add an **Ownership** filter on `/account/jobs`: All / Ad-hoc / Package (`?ownership=`).
- Extend the View filter with **All** alongside Active / History (`?view=all`).
- Default remains Active + All ownership (params omitted).
- Fix long list scrolling by using shared `AccountManagementList maxHeight="min(65vh, 48rem)"` (same as secrets/packages).

## Test plan

- [x] Unit tests for filter helpers
- [x] `npm run typecheck`
- [x] `e2e/account-jobs.spec.ts` (view All + ownership package/ad-hoc)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/account-jobs-ownership-filter-8fb7`

**Classification:** extends — client-side jobs list filters and scroll container usage on the account jobs UI.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — ownership + All view filters; list uses shared maxHeight scroll |

### System map

Jobs sidebar filters compose URL params and reuse the shared list scroll primitive.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	listPrim["AccountManagementList<br/>maxHeight scroll"]:::untouched
	appUi -->|"view + ownership URL filters"| appUi
	appUi -->|"maxHeight min 65vh 48rem"| listPrim
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only client-side list filtering and layout; no API, auth, or job execution changes.
> 
> **Overview**
> Adds **client-side filtering** on `/account/jobs` so users can narrow the sidebar list without refetching (same latch behavior as search and view).
> 
> **View** gains an **All** option (`?view=all`) that skips the active vs history split. **Ownership** is a new control (`?ownership=`) with All / Ad-hoc / Package, applied alongside view and search in `filterAccountJobs`. Defaults stay **Active** + **All ownership** (query params omitted). Empty-state copy is updated for the new combinations.
> 
> The jobs list uses **`AccountManagementList` with `maxHeight="min(65vh, 48rem)"`** so long lists scroll like other account pages. Unit tests cover the filter helpers; e2e seeds a package-style job id and exercises All view plus package/ad-hoc ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f0efba15772e47118915121f81070a45ef27d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->