### PR TITLE
fix(account): contain list/detail sidebar overflow

### DIFF
--- a/packages/worker/client/routes/account-email.tsx
+++ b/packages/worker/client/routes/account-email.tsx
@@ -353,7 +353,7 @@ export function AccountEmailRoute(handle: Handle) {
 										</p>
 									) : (
 										<>
-											<AccountManagementList maxHeight="min(65vh, 48rem)">
+											<AccountManagementList>
 												{data.messages.map((emailMessage) => (
 													<li key={emailMessage.id} mix={css({ minWidth: 0 })}>
 														<AccountManagementListItemButton

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -538,7 +538,7 @@ export function AccountJobsRoute(handle: Handle) {
 										{listEmptyMessage}
 									</p>
 								) : (
-									<AccountManagementList maxHeight="min(65vh, 48rem)">
+									<AccountManagementList>
 										{filteredJobs.map((item) => (
 											<li key={item.id}>
 												<AccountManagementListItemButton

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -350,38 +350,56 @@ export function AccountManagementSidebar(
 	)
 }
 
+/**
+ * Default in-sidebar scroll viewport for management lists. Keeps long result
+ * sets from stretching the whole page; callers can override per page.
+ */
+export const accountManagementListMaxHeight = 'min(65vh, 48rem)'
+
 type AccountManagementListProps = {
 	children: AccountManagementSlot
-	maxHeight?: string
+	/**
+	 * Scroll viewport height. Defaults to {@link accountManagementListMaxHeight}.
+	 * Pass `null` only for the rare list that should grow with the page.
+	 */
+	maxHeight?: string | null
 }
 
 export function AccountManagementList(
 	handle: Handle<AccountManagementListProps>,
 ) {
-	return () => (
-		<div
-			mix={css({
-				minWidth: 0,
-				maxHeight: handle.props.maxHeight,
-				overflowY: handle.props.maxHeight ? 'auto' : undefined,
-				overflowX: handle.props.maxHeight ? 'hidden' : undefined,
-				paddingRight: handle.props.maxHeight ? spacing.xs : undefined,
-			})}
-		>
-			<ul
+	return () => {
+		const maxHeight =
+			handle.props.maxHeight === undefined
+				? accountManagementListMaxHeight
+				: handle.props.maxHeight
+		const scrollable = maxHeight != null
+
+		return (
+			<div
 				mix={css({
-					listStyle: 'none',
-					padding: 0,
-					margin: 0,
-					display: 'grid',
-					gap: spacing.sm,
 					minWidth: 0,
+					maxHeight: scrollable ? maxHeight : undefined,
+					overflowY: scrollable ? 'auto' : undefined,
+					overflowX: scrollable ? 'hidden' : undefined,
+					paddingRight: scrollable ? spacing.xs : undefined,
 				})}
 			>
-				{handle.props.children}
-			</ul>
-		</div>
-	)
+				<ul
+					mix={css({
+						listStyle: 'none',
+						padding: 0,
+						margin: 0,
+						display: 'grid',
+						gap: spacing.sm,
+						minWidth: 0,
+					})}
+				>
+					{handle.props.children}
+				</ul>
+			</div>
+		)
+	}
 }
 
 type AccountManagementSearchFieldProps = {

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -298,13 +298,14 @@ export function AccountManagementLayout(
 				gridTemplateColumns: `${handle.props.sidebarWidth ?? 'minmax(18rem, 22rem)'} minmax(0, 1fr)`,
 				gap: spacing.lg,
 				alignItems: 'start',
+				minWidth: 0,
 				[mq.mobile]: {
 					gridTemplateColumns: '1fr',
 				},
 			})}
 		>
 			{handle.props.sidebar}
-			<div mix={css({ display: 'grid', gap: spacing.lg })}>
+			<div mix={css({ display: 'grid', gap: spacing.lg, minWidth: 0 })}>
 				{handle.props.children}
 			</div>
 		</section>
@@ -325,11 +326,24 @@ export function AccountManagementSidebar(
 			mix={css({
 				...cardCss,
 				alignSelf: 'start',
+				// Grid items default to min-width:auto; without this, long
+				// search placeholders / unbreakable tokens expand past the
+				// sidebar track and paint over the detail pane.
+				minWidth: 0,
+				maxWidth: '100%',
+				overflow: 'hidden',
 			})}
 		>
-			<div mix={css({ display: 'grid', gap: spacing.xs })}>
+			<div mix={css({ display: 'grid', gap: spacing.xs, minWidth: 0 })}>
 				<h2 mix={css(cardTitleCss)}>{handle.props.title}</h2>
-				<p mix={css(descriptionCss)}>{handle.props.description}</p>
+				<p
+					mix={css({
+						...descriptionCss,
+						overflowWrap: 'anywhere',
+					})}
+				>
+					{handle.props.description}
+				</p>
 			</div>
 			{handle.props.children}
 		</aside>
@@ -347,6 +361,7 @@ export function AccountManagementList(
 	return () => (
 		<div
 			mix={css({
+				minWidth: 0,
 				maxHeight: handle.props.maxHeight,
 				overflowY: handle.props.maxHeight ? 'auto' : undefined,
 				overflowX: handle.props.maxHeight ? 'hidden' : undefined,
@@ -360,6 +375,7 @@ export function AccountManagementList(
 					margin: 0,
 					display: 'grid',
 					gap: spacing.sm,
+					minWidth: 0,
 				})}
 			>
 				{handle.props.children}
@@ -384,7 +400,7 @@ export function AccountManagementSearchField(
 	handle: Handle<AccountManagementSearchFieldProps>,
 ) {
 	return () => (
-		<label mix={css(fieldCss)}>
+		<label mix={css({ ...fieldCss, minWidth: 0 })}>
 			<span mix={css(fieldLabelCss)}>{handle.props.label}</span>
 			<input
 				type="search"
@@ -399,6 +415,8 @@ export function AccountManagementSearchField(
 					),
 					css({
 						...inputCss,
+						minWidth: 0,
+						maxWidth: '100%',
 						paddingRight: spacing.xl,
 					}),
 				]}
@@ -426,11 +444,13 @@ export function AccountManagementListItemButton(
 				css({
 					width: '100%',
 					minWidth: 0,
+					maxWidth: '100%',
 					textAlign: 'left',
 					display: 'grid',
 					gap: spacing.xs,
 					padding: spacing.md,
 					overflow: 'hidden',
+					overflowWrap: 'anywhere',
 					borderRadius: radius.md,
 					border: `1px solid ${
 						handle.props.active ? colors.primary : colors.border

--- a/packages/worker/client/routes/account-memories.tsx
+++ b/packages/worker/client/routes/account-memories.tsx
@@ -400,7 +400,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 								) : (
 									<AccountManagementList>
 										{filteredMemories.map((item) => (
-											<li key={item.id}>
+											<li key={item.id} mix={css({ minWidth: 0 })}>
 												<AccountManagementListItemButton
 													active={selection.selectedId === item.id}
 													disabled={isMutating}
@@ -416,7 +416,14 @@ export function AccountMemoriesRoute(handle: Handle) {
 														)
 													}}
 												>
-													<strong>{item.subject}</strong>
+													<strong
+														mix={css({
+															minWidth: 0,
+															overflowWrap: 'anywhere',
+														})}
+													>
+														{item.subject}
+													</strong>
 													<span
 														mix={css({
 															color: statusColor(item.status),
@@ -431,6 +438,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 															mix={css({
 																color: colors.textMuted,
 																fontSize: typography.fontSize.sm,
+																overflowWrap: 'anywhere',
 															})}
 														>
 															{item.tags.join(', ')}
@@ -440,6 +448,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 														mix={css({
 															color: colors.textMuted,
 															fontSize: typography.fontSize.sm,
+															overflowWrap: 'anywhere',
 														})}
 													>
 														{item.summary}

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -425,7 +425,7 @@ export function AccountPackagesRoute(handle: Handle) {
 								</p>
 							) : (
 								<>
-									<AccountManagementList maxHeight="min(65vh, 48rem)">
+									<AccountManagementList>
 										{packages.map((pkg) => (
 											<li key={pkg.id} mix={css({ minWidth: 0 })}>
 												<AccountManagementListItemButton

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1388,7 +1388,7 @@ export function AccountSecretsRoute(handle: Handle) {
 									No secrets match the current filters.
 								</p>
 							) : (
-								<AccountManagementList maxHeight="min(65vh, 48rem)">
+								<AccountManagementList>
 									{filteredSecrets.map((secret) => {
 										const isActive = activeSecretId === secret.id
 										return (

--- a/packages/worker/client/routes/admin-platform-feedback.tsx
+++ b/packages/worker/client/routes/admin-platform-feedback.tsx
@@ -377,7 +377,7 @@ export function AdminPlatformFeedbackRoute(handle: Handle) {
 											No platform feedback matches this view.
 										</p>
 									) : (
-										<AccountManagementList maxHeight="min(65vh, 48rem)">
+										<AccountManagementList>
 											{data.feedback.map((feedback) => {
 												const isActive = selectedFeedbackId === feedback.id
 												return (

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -764,7 +764,7 @@ export function AdminUsersRoute(handle: Handle) {
 								</p>
 							) : (
 								<>
-									<AccountManagementList maxHeight="min(65vh, 48rem)">
+									<AccountManagementList>
 										{users.map((user) => (
 											<li key={user.id} mix={css({ minWidth: 0 })}>
 												<AccountManagementListItemButton

--- a/packages/worker/client/styles/style-primitives.ts
+++ b/packages/worker/client/styles/style-primitives.ts
@@ -168,6 +168,7 @@ export const descriptionCss = {
 export const fieldCss = {
 	display: 'grid',
 	gap: spacing.xs,
+	minWidth: 0,
 }
 
 export const fieldLabelCss = {
@@ -178,6 +179,8 @@ export const fieldLabelCss = {
 
 export const inputCss = {
 	width: '100%',
+	minWidth: 0,
+	maxWidth: '100%',
 	padding: spacing.sm,
 	borderRadius: radius.md,
 	border: `1px solid ${colors.border}`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Memories (and other account list/detail) sidebar was painting over the detail pane: long search placeholders and unbreakable list text expanded past the grid track because shared layout/field/input styles lacked `min-width: 0` / overflow containment.

Separately, `AccountManagementList` only scrolled in-sidebar when callers passed `maxHeight`, so pages like Memories, Activity, Values, Integrations, MCP servers, connectors, and package tokens grew the whole document with the list. The default is now `min(65vh, 48rem)`.

This is a **primitive fix** in the shared account-management layout and style tokens (not Memories-only).

## Changes

- `AccountManagementLayout` / `Sidebar` / `List` / search field: constrain width so sidebar children cannot overflow into the detail column
- `fieldCss` / `inputCss`: `minWidth: 0` + `maxWidth: 100%` so inputs honor their column
- `AccountManagementList`: default `maxHeight` to `min(65vh, 48rem)` (opt out with `null`); remove redundant per-page props
- Memories list items: `minWidth: 0` + `overflowWrap: anywhere` on subject/tags/summary

## Verification

![Memories list scrolls in-sidebar](https://cursor.com/artifacts/c/art-5214a404-88a3-4e46-8fa3-01bd64dde9a3)
![Memory detail after selection](https://cursor.com/artifacts/c/art-e96eabe6-6c53-4264-9be8-69fb6378648e)

## Test plan

- [x] Pre-push hooks (format/lint/typecheck + e2e subset) green
- [x] Manual: `/account/memories` search stays in-column; list scrolls in-sidebar; detail pane readable
- [ ] CI green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c397b474` · **Head:** `e49b0347`

**Classification:** extends — shared account list/detail layout, list scroll default, and input style primitives now enforce column containment and in-sidebar scrolling.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — layout/sidebar/input containment + default list maxHeight scroll |

### System map

Account management list/detail pages render through shared Remix UI layout primitives; this PR tightens those primitives so sidebar content stays in-column and long lists scroll in-place.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	accountPages["account/* list/detail pages"]:::untouched
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	accountPages -->|"AccountManagementLayout / List / inputCss"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| ------ | ----- |
| Sidebar search/`input` min-content could paint over the detail pane | Sidebar and inputs constrained with `minWidth: 0` / `maxWidth: 100%` / overflow hidden |
| List scroll only when callers passed `maxHeight` | Default `min(65vh, 48rem)` in-sidebar scroll for all management lists |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0352a28f-54e6-4517-ab65-5f566d00e7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0352a28f-54e6-4517-ab65-5f566d00e7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

