### PR TITLE
Escalate slow package publishes durably instead of hanging the MCP request

### DIFF
--- a/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
@@ -1,0 +1,238 @@
+import { expect, test, vi } from 'vitest'
+import {
+	defaultDurableEscalationBudgetMs,
+	runWithDurableEscalation,
+} from './durable-escalation.ts'
+import { activeWorkflowStatusValues } from '#worker/package-runtime/workflow-statuses.ts'
+
+const mockModule = vi.hoisted(() => ({
+	createDynamicCallableWorkflow: vi.fn(),
+}))
+
+vi.mock('#worker/package-runtime/package-workflows.ts', () => ({
+	createDynamicCallableWorkflow: (...args: Array<unknown>) =>
+		mockModule.createDynamicCallableWorkflow(...args),
+}))
+
+function createWorkflowRunsDb(rows: Array<Record<string, unknown>> = []) {
+	return {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async first() {
+							if (
+								!query.includes('FROM workflow_runs') ||
+								!query.includes('idempotency_key = ?')
+							) {
+								return null
+							}
+							const userId = params[0]
+							const idempotencyKey = params[1]
+							const statusFilter = new Set(
+								params.slice(2).map((value) => String(value)),
+							)
+							return (
+								rows.find(
+									(row) =>
+										row['user_id'] === userId &&
+										row['idempotency_key'] === idempotencyKey &&
+										statusFilter.has(String(row['status'] ?? '')),
+								) ?? null
+							)
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+test('runWithDurableEscalation returns the inline result when work finishes within budget', async () => {
+	const run = vi.fn(async () => ({ status: 'published', commit: 'abc' }))
+	const outcome = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb(),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyKey: 'publish:pkg-1:commit-1',
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 5_000,
+		run,
+	})
+
+	expect(outcome).toEqual({
+		kind: 'completed',
+		value: { status: 'published', commit: 'abc' },
+	})
+	expect(run).toHaveBeenCalledTimes(1)
+	expect(run.mock.calls[0]?.[0]).toBeInstanceOf(AbortSignal)
+	expect(mockModule.createDynamicCallableWorkflow).not.toHaveBeenCalled()
+	expect(defaultDurableEscalationBudgetMs).toBeLessThan(90_000)
+})
+
+test('runWithDurableEscalation dispatches once on budget exhaustion and reuses an active run', async () => {
+	mockModule.createDynamicCallableWorkflow.mockResolvedValue({
+		ok: true,
+		id: 'dynwf-escalated-1',
+		workflow_name: 'package_publish_external_push',
+		source_type: 'inline',
+		run_at: '2026-07-27T00:00:00.000Z',
+		plan_date: '2026-07-27',
+		status: 'queued',
+	})
+
+	const hangUntilAborted = vi.fn(
+		async (signal: AbortSignal) =>
+			await new Promise<never>((_resolve, reject) => {
+				signal.addEventListener(
+					'abort',
+					() => {
+						reject(new DOMException('Aborted', 'AbortError'))
+					},
+					{ once: true },
+				)
+			}),
+	)
+
+	const first = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb(),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		userEmail: 'user@example.com',
+		idempotencyKey: 'publish:pkg-1:commit-slow',
+		workflowName: 'package_publish_external_push',
+		durableCode:
+			'import { kody } from "kody:runtime"; export default async function main(p) { return await kody.package_publish_external_push(p) }',
+		durableParams: { package_id: 'pkg-1' },
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+
+	expect(first).toEqual({
+		kind: 'dispatched',
+		handle: {
+			status: 'dispatched',
+			workflow_id: 'dynwf-escalated-1',
+			workflow_name: 'package_publish_external_push',
+			idempotency_key: 'publish:pkg-1:commit-slow',
+			run_status: 'queued',
+			message: expect.stringMatching(/dispatched to a durable workflow/i),
+		},
+	})
+	expect(mockModule.createDynamicCallableWorkflow).toHaveBeenCalledTimes(1)
+	expect(mockModule.createDynamicCallableWorkflow).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			userEmail: 'user@example.com',
+			body: expect.objectContaining({
+				idempotencyKey: 'publish:pkg-1:commit-slow',
+				workflowName: 'package_publish_external_push',
+				params: { package_id: 'pkg-1' },
+			}),
+		}),
+	)
+
+	mockModule.createDynamicCallableWorkflow.mockClear()
+	const activeRow = {
+		id: 'dynwf-escalated-1',
+		user_id: 'user-1',
+		workflow_name: 'package_publish_external_push',
+		idempotency_key: 'publish:pkg-1:commit-slow',
+		status: 'running',
+	}
+	expect(activeWorkflowStatusValues).toContain('running')
+
+	const second = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb([activeRow]),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyKey: 'publish:pkg-1:commit-slow',
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+
+	expect(second).toEqual({
+		kind: 'dispatched',
+		handle: expect.objectContaining({
+			status: 'dispatched',
+			workflow_id: 'dynwf-escalated-1',
+			idempotency_key: 'publish:pkg-1:commit-slow',
+			run_status: 'running',
+		}),
+	})
+	expect(mockModule.createDynamicCallableWorkflow).not.toHaveBeenCalled()
+	expect(hangUntilAborted).toHaveBeenCalledTimes(1)
+})
+
+test('runWithDurableEscalation never throws and reports structured failures', async () => {
+	const rejected = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb(),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyKey: 'publish:pkg-1:fail',
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 5_000,
+		run: async () => {
+			throw new Error('checks blew up')
+		},
+	})
+	expect(rejected).toEqual({
+		kind: 'failed',
+		error: 'checks blew up',
+	})
+
+	const emptyKey = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb(),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyKey: '   ',
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		run: async () => ({ ok: true }),
+	})
+	expect(emptyKey).toEqual({
+		kind: 'failed',
+		error: 'Durable escalation requires a non-empty idempotencyKey.',
+	})
+
+	mockModule.createDynamicCallableWorkflow.mockRejectedValue(
+		new Error('Missing DYNAMIC_CALLABLE_WORKFLOWS binding.'),
+	)
+	const dispatchFailed = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb(),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyKey: 'publish:pkg-1:dispatch-fail',
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 20,
+		run: async (signal) =>
+			await new Promise<never>((_resolve, reject) => {
+				signal.addEventListener(
+					'abort',
+					() => reject(new DOMException('Aborted', 'AbortError')),
+					{ once: true },
+				)
+			}),
+	})
+	expect(dispatchFailed).toEqual({
+		kind: 'failed',
+		error: 'Missing DYNAMIC_CALLABLE_WORKFLOWS binding.',
+	})
+})

--- a/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
@@ -459,3 +459,157 @@ test('runWithDurableEscalation never throws and reports structured failures', as
 		error: 'Missing DYNAMIC_CALLABLE_WORKFLOWS binding.',
 	})
 })
+
+test('budget abort dispatches while the inline attempt is still in flight', async () => {
+	const events: Array<string> = []
+	mockModule.createDynamicCallableWorkflow.mockImplementation(async () => {
+		events.push('dispatched')
+		return {
+			ok: true,
+			id: 'dynwf-overlap-1',
+			workflow_name: 'package_publish_external_push',
+			source_type: 'inline',
+			run_at: '2026-07-27T00:00:00.000Z',
+			plan_date: '2026-07-27',
+			status: 'queued',
+		}
+	})
+
+	let releaseInline: (() => void) | null = null
+	const outcome = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb(),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyParts: ['publish', 'pkg-1', 'overlap'],
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: async (signal) => {
+			events.push('run-start')
+			await new Promise<void>((resolve) => {
+				signal.addEventListener(
+					'abort',
+					() => {
+						events.push('aborted')
+						resolve()
+					},
+					{ once: true },
+				)
+			})
+			// Stay in flight after abort until the test releases us. The helper
+			// must dispatch without awaiting this completion.
+			await new Promise<void>((resolve) => {
+				releaseInline = resolve
+			})
+			events.push('run-end')
+			return { status: 'published' }
+		},
+	})
+
+	expect(outcome.kind).toBe('dispatched')
+	expect(events).toEqual(['run-start', 'aborted', 'dispatched'])
+	expect(events).not.toContain('run-end')
+	releaseInline?.()
+})
+
+test('force and non-force semantic keys do not reuse each other under dedupe', async () => {
+	const hangUntilAborted = async (signal: AbortSignal) =>
+		await new Promise<never>((_resolve, reject) => {
+			signal.addEventListener(
+				'abort',
+				() => reject(new DOMException('Aborted', 'AbortError')),
+				{ once: true },
+			)
+		})
+
+	const safeParts = [
+		'package_publish_external_push',
+		'{"allowForce":false,"destructiveOverwriteConfirmed":false,"newCommit":"commit-new","ownerUserId":"owner-1","packageId":"package-1"}',
+	]
+	const forceParts = [
+		'package_publish_external_push',
+		'{"allowForce":true,"destructiveOverwriteConfirmed":true,"newCommit":"commit-new","ownerUserId":"owner-1","packageId":"package-1"}',
+	]
+	const safeKey = buildCallerScopedIdempotencyKey({
+		userId: 'user-1',
+		parts: safeParts,
+	})
+	const forceKey = buildCallerScopedIdempotencyKey({
+		userId: 'user-1',
+		parts: forceParts,
+	})
+	expect(safeKey).not.toBe(forceKey)
+
+	mockModule.createDynamicCallableWorkflow
+		.mockResolvedValueOnce({
+			ok: true,
+			id: 'dynwf-safe',
+			workflow_name: 'package_publish_external_push',
+			source_type: 'inline',
+			run_at: '2026-07-27T00:00:00.000Z',
+			plan_date: '2026-07-27',
+			status: 'queued',
+		})
+		.mockResolvedValueOnce({
+			ok: true,
+			id: 'dynwf-force',
+			workflow_name: 'package_publish_external_push',
+			source_type: 'inline',
+			run_at: '2026-07-27T00:00:00.000Z',
+			plan_date: '2026-07-27',
+			status: 'queued',
+		})
+
+	const rows: Array<Record<string, unknown>> = []
+	const db = createWorkflowRunsDb(rows)
+
+	const safe = await runWithDurableEscalation({
+		env: {
+			APP_DB: db,
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyParts: safeParts,
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+	expect(safe).toEqual({
+		kind: 'dispatched',
+		handle: expect.objectContaining({
+			workflow_id: 'dynwf-safe',
+			idempotency_key: safeKey,
+		}),
+	})
+	rows.push({
+		id: 'dynwf-safe',
+		user_id: 'user-1',
+		workflow_name: 'package_publish_external_push',
+		idempotency_key: safeKey,
+		status: 'running',
+	})
+
+	const force = await runWithDurableEscalation({
+		env: {
+			APP_DB: db,
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyParts: forceParts,
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+	expect(force).toEqual({
+		kind: 'dispatched',
+		handle: expect.objectContaining({
+			workflow_id: 'dynwf-force',
+			idempotency_key: forceKey,
+		}),
+	})
+	expect(mockModule.createDynamicCallableWorkflow).toHaveBeenCalledTimes(2)
+})

--- a/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import {
+	buildCallerScopedIdempotencyKey,
 	defaultDurableEscalationBudgetMs,
 	runWithDurableEscalation,
 } from './durable-escalation.ts'
@@ -48,6 +49,13 @@ function createWorkflowRunsDb(rows: Array<Record<string, unknown>> = []) {
 	} as unknown as D1Database
 }
 
+const publishParts = [
+	'package_publish_external_push',
+	'owner-platform',
+	'package-1',
+	'commit-new',
+] as const
+
 test('runWithDurableEscalation returns the inline result when work finishes within budget', async () => {
 	const run = vi.fn(async () => ({ status: 'published', commit: 'abc' }))
 	const outcome = await runWithDurableEscalation({
@@ -56,7 +64,7 @@ test('runWithDurableEscalation returns the inline result when work finishes with
 			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
 		} as Env,
 		userId: 'user-1',
-		idempotencyKey: 'publish:pkg-1:commit-1',
+		idempotencyParts: ['publish', 'pkg-1', 'commit-1'],
 		workflowName: 'package_publish_external_push',
 		durableCode: 'export default async function main() { return null }',
 		budgetMs: 5_000,
@@ -73,7 +81,7 @@ test('runWithDurableEscalation returns the inline result when work finishes with
 	expect(defaultDurableEscalationBudgetMs).toBeLessThan(90_000)
 })
 
-test('runWithDurableEscalation dispatches once on budget exhaustion and reuses an active run', async () => {
+test('runWithDurableEscalation dispatches once on budget exhaustion and reuses an active run for the same caller', async () => {
 	mockModule.createDynamicCallableWorkflow.mockResolvedValue({
 		ok: true,
 		id: 'dynwf-escalated-1',
@@ -97,6 +105,11 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 			}),
 	)
 
+	const expectedKey = buildCallerScopedIdempotencyKey({
+		userId: 'user-1',
+		parts: publishParts,
+	})
+
 	const first = await runWithDurableEscalation({
 		env: {
 			APP_DB: createWorkflowRunsDb(),
@@ -104,7 +117,7 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 		} as Env,
 		userId: 'user-1',
 		userEmail: 'user@example.com',
-		idempotencyKey: 'publish:pkg-1:commit-slow',
+		idempotencyParts: publishParts,
 		workflowName: 'package_publish_external_push',
 		durableCode:
 			'import { kody } from "kody:runtime"; export default async function main(p) { return await kody.package_publish_external_push(p) }',
@@ -119,7 +132,7 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 			status: 'dispatched',
 			workflow_id: 'dynwf-escalated-1',
 			workflow_name: 'package_publish_external_push',
-			idempotency_key: 'publish:pkg-1:commit-slow',
+			idempotency_key: expectedKey,
 			run_status: 'queued',
 			message: expect.stringMatching(/dispatched to a durable workflow/i),
 		},
@@ -130,7 +143,7 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 			userId: 'user-1',
 			userEmail: 'user@example.com',
 			body: expect.objectContaining({
-				idempotencyKey: 'publish:pkg-1:commit-slow',
+				idempotencyKey: expectedKey,
 				workflowName: 'package_publish_external_push',
 				params: { package_id: 'pkg-1' },
 			}),
@@ -142,7 +155,7 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 		id: 'dynwf-escalated-1',
 		user_id: 'user-1',
 		workflow_name: 'package_publish_external_push',
-		idempotency_key: 'publish:pkg-1:commit-slow',
+		idempotency_key: expectedKey,
 		status: 'running',
 	}
 	expect(activeWorkflowStatusValues).toContain('running')
@@ -153,7 +166,7 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
 		} as Env,
 		userId: 'user-1',
-		idempotencyKey: 'publish:pkg-1:commit-slow',
+		idempotencyParts: publishParts,
 		workflowName: 'package_publish_external_push',
 		durableCode: 'export default async function main() { return null }',
 		budgetMs: 30,
@@ -165,12 +178,159 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 		handle: expect.objectContaining({
 			status: 'dispatched',
 			workflow_id: 'dynwf-escalated-1',
-			idempotency_key: 'publish:pkg-1:commit-slow',
+			idempotency_key: expectedKey,
 			run_status: 'running',
 		}),
 	})
 	expect(mockModule.createDynamicCallableWorkflow).not.toHaveBeenCalled()
 	expect(hangUntilAborted).toHaveBeenCalledTimes(1)
+})
+
+test('different acting callers get non-colliding dedupe; same caller still reuses', async () => {
+	const hangUntilAborted = async (signal: AbortSignal) =>
+		await new Promise<never>((_resolve, reject) => {
+			signal.addEventListener(
+				'abort',
+				() => {
+					reject(new DOMException('Aborted', 'AbortError'))
+				},
+				{ once: true },
+			)
+		})
+
+	const delegateAKey = buildCallerScopedIdempotencyKey({
+		userId: 'delegate-a',
+		parts: publishParts,
+	})
+	const delegateBKey = buildCallerScopedIdempotencyKey({
+		userId: 'delegate-b',
+		parts: publishParts,
+	})
+	expect(delegateAKey).not.toBe(delegateBKey)
+	expect(delegateAKey).toBe(
+		'delegate-a:package_publish_external_push:owner-platform:package-1:commit-new',
+	)
+	expect(delegateBKey).toBe(
+		'delegate-b:package_publish_external_push:owner-platform:package-1:commit-new',
+	)
+
+	mockModule.createDynamicCallableWorkflow
+		.mockResolvedValueOnce({
+			ok: true,
+			id: 'dynwf-delegate-a',
+			workflow_name: 'package_publish_external_push',
+			source_type: 'inline',
+			run_at: '2026-07-27T00:00:00.000Z',
+			plan_date: '2026-07-27',
+			status: 'queued',
+		})
+		.mockResolvedValueOnce({
+			ok: true,
+			id: 'dynwf-delegate-b',
+			workflow_name: 'package_publish_external_push',
+			source_type: 'inline',
+			run_at: '2026-07-27T00:00:00.000Z',
+			plan_date: '2026-07-27',
+			status: 'queued',
+		})
+
+	const activeRows: Array<Record<string, unknown>> = []
+	const sharedDb = createWorkflowRunsDb(activeRows)
+
+	const delegateA = await runWithDurableEscalation({
+		env: {
+			APP_DB: sharedDb,
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'delegate-a',
+		idempotencyParts: publishParts,
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+	expect(delegateA).toEqual({
+		kind: 'dispatched',
+		handle: expect.objectContaining({
+			workflow_id: 'dynwf-delegate-a',
+			idempotency_key: delegateAKey,
+		}),
+	})
+	activeRows.push({
+		id: 'dynwf-delegate-a',
+		user_id: 'delegate-a',
+		workflow_name: 'package_publish_external_push',
+		idempotency_key: delegateAKey,
+		status: 'running',
+	})
+
+	// A second acting caller must not reuse the first caller's active row even
+	// when owner/package/commit parts match (workflow_runs are user-scoped).
+	const delegateB = await runWithDurableEscalation({
+		env: {
+			APP_DB: sharedDb,
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'delegate-b',
+		idempotencyParts: publishParts,
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+	expect(delegateB).toEqual({
+		kind: 'dispatched',
+		handle: expect.objectContaining({
+			workflow_id: 'dynwf-delegate-b',
+			idempotency_key: delegateBKey,
+		}),
+	})
+	expect(mockModule.createDynamicCallableWorkflow).toHaveBeenCalledTimes(2)
+	expect(mockModule.createDynamicCallableWorkflow).toHaveBeenNthCalledWith(
+		1,
+		expect.objectContaining({
+			userId: 'delegate-a',
+			body: expect.objectContaining({ idempotencyKey: delegateAKey }),
+		}),
+	)
+	expect(mockModule.createDynamicCallableWorkflow).toHaveBeenNthCalledWith(
+		2,
+		expect.objectContaining({
+			userId: 'delegate-b',
+			body: expect.objectContaining({ idempotencyKey: delegateBKey }),
+		}),
+	)
+
+	mockModule.createDynamicCallableWorkflow.mockClear()
+	activeRows.push({
+		id: 'dynwf-delegate-b',
+		user_id: 'delegate-b',
+		workflow_name: 'package_publish_external_push',
+		idempotency_key: delegateBKey,
+		status: 'running',
+	})
+
+	const delegateARepeat = await runWithDurableEscalation({
+		env: {
+			APP_DB: sharedDb,
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'delegate-a',
+		idempotencyParts: publishParts,
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+	expect(delegateARepeat).toEqual({
+		kind: 'dispatched',
+		handle: expect.objectContaining({
+			workflow_id: 'dynwf-delegate-a',
+			idempotency_key: delegateAKey,
+			run_status: 'running',
+		}),
+	})
+	expect(mockModule.createDynamicCallableWorkflow).not.toHaveBeenCalled()
 })
 
 test('runWithDurableEscalation never throws and reports structured failures', async () => {
@@ -180,7 +340,7 @@ test('runWithDurableEscalation never throws and reports structured failures', as
 			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
 		} as Env,
 		userId: 'user-1',
-		idempotencyKey: 'publish:pkg-1:fail',
+		idempotencyParts: ['publish', 'pkg-1', 'fail'],
 		workflowName: 'package_publish_external_push',
 		durableCode: 'export default async function main() { return null }',
 		budgetMs: 5_000,
@@ -193,20 +353,20 @@ test('runWithDurableEscalation never throws and reports structured failures', as
 		error: 'checks blew up',
 	})
 
-	const emptyKey = await runWithDurableEscalation({
+	const emptyParts = await runWithDurableEscalation({
 		env: {
 			APP_DB: createWorkflowRunsDb(),
 			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
 		} as Env,
 		userId: 'user-1',
-		idempotencyKey: '   ',
+		idempotencyParts: ['   ', ''],
 		workflowName: 'package_publish_external_push',
 		durableCode: 'export default async function main() { return null }',
 		run: async () => ({ ok: true }),
 	})
-	expect(emptyKey).toEqual({
+	expect(emptyParts).toEqual({
 		kind: 'failed',
-		error: 'Durable escalation requires a non-empty idempotencyKey.',
+		error: 'Durable escalation requires at least one idempotency part.',
 	})
 
 	mockModule.createDynamicCallableWorkflow.mockRejectedValue(
@@ -218,7 +378,7 @@ test('runWithDurableEscalation never throws and reports structured failures', as
 			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
 		} as Env,
 		userId: 'user-1',
-		idempotencyKey: 'publish:pkg-1:dispatch-fail',
+		idempotencyParts: ['publish', 'pkg-1', 'dispatch-fail'],
 		workflowName: 'package_publish_external_push',
 		durableCode: 'export default async function main() { return null }',
 		budgetMs: 20,

--- a/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
@@ -1,10 +1,11 @@
 import { expect, test, vi } from 'vitest'
 import {
+	alreadyDispatchedWorkflowStatusExclusion,
 	buildCallerScopedIdempotencyKey,
 	defaultDurableEscalationBudgetMs,
 	runWithDurableEscalation,
 } from './durable-escalation.ts'
-import { activeWorkflowStatusValues } from '#worker/package-runtime/workflow-statuses.ts'
+import { terminalWorkflowStatusValues } from '#worker/package-runtime/workflow-statuses.ts'
 
 const mockModule = vi.hoisted(() => ({
 	createDynamicCallableWorkflow: vi.fn(),
@@ -30,16 +31,23 @@ function createWorkflowRunsDb(rows: Array<Record<string, unknown>> = []) {
 							}
 							const userId = params[0]
 							const idempotencyKey = params[1]
-							const statusFilter = new Set(
+							const excludedStatuses = new Set(
 								params.slice(2).map((value) => String(value)),
 							)
+							const usesNotIn = query.includes('NOT IN')
 							return (
-								rows.find(
-									(row) =>
-										row['user_id'] === userId &&
-										row['idempotency_key'] === idempotencyKey &&
-										statusFilter.has(String(row['status'] ?? '')),
-								) ?? null
+								rows.find((row) => {
+									if (
+										row['user_id'] !== userId ||
+										row['idempotency_key'] !== idempotencyKey
+									) {
+										return false
+									}
+									const status = String(row['status'] ?? '')
+									return usesNotIn
+										? !excludedStatuses.has(status)
+										: excludedStatuses.has(status)
+								}) ?? null
 							)
 						},
 					}
@@ -158,7 +166,6 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 		idempotency_key: expectedKey,
 		status: 'running',
 	}
-	expect(activeWorkflowStatusValues).toContain('running')
 
 	const second = await runWithDurableEscalation({
 		env: {
@@ -184,6 +191,62 @@ test('runWithDurableEscalation dispatches once on budget exhaustion and reuses a
 	})
 	expect(mockModule.createDynamicCallableWorkflow).not.toHaveBeenCalled()
 	expect(hangUntilAborted).toHaveBeenCalledTimes(1)
+})
+
+test('mid-creation workflow_runs rows are treated as already dispatched', async () => {
+	expect(alreadyDispatchedWorkflowStatusExclusion).toEqual(
+		terminalWorkflowStatusValues,
+	)
+	expect(alreadyDispatchedWorkflowStatusExclusion).not.toContain('creating')
+
+	const hangUntilAborted = vi.fn(
+		async (signal: AbortSignal) =>
+			await new Promise<never>((_resolve, reject) => {
+				signal.addEventListener(
+					'abort',
+					() => {
+						reject(new DOMException('Aborted', 'AbortError'))
+					},
+					{ once: true },
+				)
+			}),
+	)
+	const expectedKey = buildCallerScopedIdempotencyKey({
+		userId: 'user-1',
+		parts: publishParts,
+	})
+	const creatingRow = {
+		id: 'dynwf-creating-1',
+		user_id: 'user-1',
+		workflow_name: 'package_publish_external_push',
+		idempotency_key: expectedKey,
+		status: 'creating',
+	}
+
+	const outcome = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb([creatingRow]),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyParts: publishParts,
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+
+	expect(outcome).toEqual({
+		kind: 'dispatched',
+		handle: expect.objectContaining({
+			status: 'dispatched',
+			workflow_id: 'dynwf-creating-1',
+			idempotency_key: expectedKey,
+			run_status: 'creating',
+		}),
+	})
+	expect(hangUntilAborted).not.toHaveBeenCalled()
+	expect(mockModule.createDynamicCallableWorkflow).not.toHaveBeenCalled()
 })
 
 test('different acting callers get non-colliding dedupe; same caller still reuses', async () => {

--- a/packages/worker/src/mcp/capabilities/durable-escalation.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.ts
@@ -1,0 +1,209 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import {
+	createDynamicCallableWorkflow,
+	type PackageWorkflowCreateResult,
+} from '#worker/package-runtime/package-workflows.ts'
+import {
+	activeWorkflowStatusValues,
+	type WorkflowRunStatus,
+} from '#worker/package-runtime/workflow-statuses.ts'
+
+/** Soft budget under MCP execute's ~90s hard cap, leaving room to dispatch. */
+export const defaultDurableEscalationBudgetMs = 55_000
+
+export type DurableEscalationHandle = {
+	status: 'dispatched'
+	workflow_id: string
+	workflow_name: string
+	idempotency_key: string
+	run_status: string | null
+	message: string
+}
+
+export type DurableEscalationOutcome<T> =
+	| { kind: 'completed'; value: T }
+	| { kind: 'dispatched'; handle: DurableEscalationHandle }
+	| { kind: 'failed'; error: string }
+
+const activeWorkflowStatuses = new Set<string>(activeWorkflowStatusValues)
+
+function createDispatchedHandle(input: {
+	workflow: PackageWorkflowCreateResult
+	idempotencyKey: string
+}): DurableEscalationHandle {
+	return {
+		status: 'dispatched',
+		workflow_id: input.workflow.id,
+		workflow_name: input.workflow.workflow_name,
+		idempotency_key: input.idempotencyKey,
+		run_status: input.workflow.status ?? null,
+		message:
+			'Work exceeded the inline budget and was dispatched to a durable workflow. Poll workflow_run_list with this workflow_id; do not retry the same operation while the run is active.',
+	}
+}
+
+async function findActiveWorkflowRunByIdempotencyKey(input: {
+	db: D1Database
+	userId: string
+	idempotencyKey: string
+}): Promise<{
+	id: string
+	workflowName: string
+	idempotencyKey: string
+	status: WorkflowRunStatus | null
+} | null> {
+	const trimmedKey = input.idempotencyKey.trim()
+	if (!trimmedKey) return null
+	const placeholders = activeWorkflowStatusValues.map(() => '?').join(', ')
+	const row = await input.db
+		.prepare(
+			`SELECT id, workflow_name, idempotency_key, status
+			FROM workflow_runs
+			WHERE user_id = ?
+				AND idempotency_key = ?
+				AND status IN (${placeholders})
+			ORDER BY created_at ASC
+			LIMIT 1`,
+		)
+		.bind(input.userId, trimmedKey, ...activeWorkflowStatusValues)
+		.first<Record<string, unknown>>()
+	if (!row) return null
+	const status =
+		typeof row['status'] === 'string' &&
+		activeWorkflowStatuses.has(row['status'])
+			? (row['status'] as WorkflowRunStatus)
+			: null
+	return {
+		id: String(row['id']),
+		workflowName: String(row['workflow_name']),
+		idempotencyKey: String(row['idempotency_key']),
+		status,
+	}
+}
+
+function waitForAbort(signal: AbortSignal) {
+	return new Promise<void>((resolve) => {
+		if (signal.aborted) {
+			resolve()
+			return
+		}
+		signal.addEventListener('abort', () => resolve(), { once: true })
+	})
+}
+
+/**
+ * Attempt `run` within a wall-clock budget. On budget exhaustion, create a
+ * durable Cloudflare Workflow for the same work and return a handle instead of
+ * hanging past MCP execute's timeout. Never throws.
+ */
+export async function runWithDurableEscalation<T>(input: {
+	env: Pick<Env, 'APP_DB' | 'DYNAMIC_CALLABLE_WORKFLOWS'>
+	userId: string
+	userEmail?: string | null
+	budgetMs?: number
+	idempotencyKey: string
+	workflowName: string
+	packageContext?: {
+		packageId: string
+		kodyId: string
+		sourceId?: string | null
+	} | null
+	durableCode: string
+	durableParams?: Record<string, unknown>
+	run: (signal: AbortSignal) => Promise<T>
+}): Promise<DurableEscalationOutcome<T>> {
+	const idempotencyKey = input.idempotencyKey.trim()
+	if (!idempotencyKey) {
+		return {
+			kind: 'failed',
+			error: 'Durable escalation requires a non-empty idempotencyKey.',
+		}
+	}
+
+	try {
+		if (input.env.APP_DB) {
+			const existing = await findActiveWorkflowRunByIdempotencyKey({
+				db: input.env.APP_DB,
+				userId: input.userId,
+				idempotencyKey,
+			})
+			if (existing) {
+				return {
+					kind: 'dispatched',
+					handle: {
+						status: 'dispatched',
+						workflow_id: existing.id,
+						workflow_name: existing.workflowName,
+						idempotency_key: existing.idempotencyKey,
+						run_status: existing.status,
+						message:
+							'An active durable run already exists for this idempotency key. Poll workflow_run_list with this workflow_id; do not create another run.',
+					},
+				}
+			}
+		}
+
+		const budgetMs = Math.max(
+			1,
+			input.budgetMs ?? defaultDurableEscalationBudgetMs,
+		)
+		const controller = new AbortController()
+		const timer = setTimeout(() => {
+			controller.abort()
+		}, budgetMs)
+
+		const runPromise = input.run(controller.signal)
+		// Prevent unhandled rejection if we abandon the inline attempt on abort.
+		void runPromise.catch(() => {})
+
+		try {
+			const raced = await Promise.race([
+				runPromise.then(
+					(value) => ({ kind: 'completed' as const, value }),
+					(error: unknown) => ({ kind: 'rejected' as const, error }),
+				),
+				waitForAbort(controller.signal).then(() => ({
+					kind: 'aborted' as const,
+				})),
+			])
+
+			if (raced.kind === 'completed') {
+				return { kind: 'completed', value: raced.value }
+			}
+			if (raced.kind === 'rejected') {
+				if (controller.signal.aborted) {
+					// Fall through to durable dispatch.
+				} else {
+					return {
+						kind: 'failed',
+						error: getErrorMessage(raced.error),
+					}
+				}
+			}
+		} finally {
+			clearTimeout(timer)
+		}
+
+		const workflow = await createDynamicCallableWorkflow({
+			env: input.env,
+			userId: input.userId,
+			userEmail: input.userEmail,
+			packageContext: input.packageContext ?? null,
+			body: {
+				workflowName: input.workflowName,
+				idempotencyKey,
+				code: input.durableCode,
+				params: input.durableParams,
+			},
+		})
+		return {
+			kind: 'dispatched',
+			handle: createDispatchedHandle({ workflow, idempotencyKey }),
+		}
+	} catch (error) {
+		return {
+			kind: 'failed',
+			error: getErrorMessage(error),
+		}
+	}
+}

--- a/packages/worker/src/mcp/capabilities/durable-escalation.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.ts
@@ -3,10 +3,7 @@ import {
 	createDynamicCallableWorkflow,
 	type PackageWorkflowCreateResult,
 } from '#worker/package-runtime/package-workflows.ts'
-import {
-	activeWorkflowStatusValues,
-	type WorkflowRunStatus,
-} from '#worker/package-runtime/workflow-statuses.ts'
+import { terminalWorkflowStatusValues } from '#worker/package-runtime/workflow-statuses.ts'
 
 /** Soft budget under MCP execute's ~90s hard cap, leaving room to dispatch. */
 export const defaultDurableEscalationBudgetMs = 55_000
@@ -25,7 +22,17 @@ export type DurableEscalationOutcome<T> =
 	| { kind: 'dispatched'; handle: DurableEscalationHandle }
 	| { kind: 'failed'; error: string }
 
-const activeWorkflowStatuses = new Set<string>(activeWorkflowStatusValues)
+/**
+ * workflow_runs statuses that mean a durable dispatch is already underway.
+ * Defined as the complement of terminal statuses so the set stays aligned with
+ * createDynamicCallableWorkflow: active Cloudflare statuses plus any
+ * transitional D1 projection status written before the instance is queued
+ * (today that transitional value is `creating`). New pre-active statuses are
+ * covered automatically; only completed/errored/terminated runs allow another
+ * inline attempt.
+ */
+export const alreadyDispatchedWorkflowStatusExclusion =
+	terminalWorkflowStatusValues
 
 /**
  * Compose a workflow_runs idempotency key that is always scoped to the same
@@ -64,7 +71,7 @@ function createDispatchedHandle(input: {
 	}
 }
 
-async function findActiveWorkflowRunByIdempotencyKey(input: {
+async function findAlreadyDispatchedWorkflowRunByIdempotencyKey(input: {
 	db: D1Database
 	userId: string
 	idempotencyKey: string
@@ -72,34 +79,31 @@ async function findActiveWorkflowRunByIdempotencyKey(input: {
 	id: string
 	workflowName: string
 	idempotencyKey: string
-	status: WorkflowRunStatus | null
+	status: string | null
 } | null> {
 	const trimmedKey = input.idempotencyKey.trim()
 	if (!trimmedKey) return null
-	const placeholders = activeWorkflowStatusValues.map(() => '?').join(', ')
+	const placeholders = alreadyDispatchedWorkflowStatusExclusion
+		.map(() => '?')
+		.join(', ')
 	const row = await input.db
 		.prepare(
 			`SELECT id, workflow_name, idempotency_key, status
 			FROM workflow_runs
 			WHERE user_id = ?
 				AND idempotency_key = ?
-				AND status IN (${placeholders})
+				AND COALESCE(status, '') NOT IN (${placeholders})
 			ORDER BY created_at ASC
 			LIMIT 1`,
 		)
-		.bind(input.userId, trimmedKey, ...activeWorkflowStatusValues)
+		.bind(input.userId, trimmedKey, ...alreadyDispatchedWorkflowStatusExclusion)
 		.first<Record<string, unknown>>()
 	if (!row) return null
-	const status =
-		typeof row['status'] === 'string' &&
-		activeWorkflowStatuses.has(row['status'])
-			? (row['status'] as WorkflowRunStatus)
-			: null
 	return {
 		id: String(row['id']),
 		workflowName: String(row['workflow_name']),
 		idempotencyKey: String(row['idempotency_key']),
-		status,
+		status: typeof row['status'] === 'string' ? row['status'] : null,
 	}
 }
 
@@ -157,7 +161,7 @@ export async function runWithDurableEscalation<T>(input: {
 
 	try {
 		if (input.env.APP_DB) {
-			const existing = await findActiveWorkflowRunByIdempotencyKey({
+			const existing = await findAlreadyDispatchedWorkflowRunByIdempotencyKey({
 				db: input.env.APP_DB,
 				userId: input.userId,
 				idempotencyKey,

--- a/packages/worker/src/mcp/capabilities/durable-escalation.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.ts
@@ -27,6 +27,28 @@ export type DurableEscalationOutcome<T> =
 
 const activeWorkflowStatuses = new Set<string>(activeWorkflowStatusValues)
 
+/**
+ * Compose a workflow_runs idempotency key that is always scoped to the same
+ * acting `userId` used for row lookup/create. Callers pass operation-specific
+ * parts only; they must not invent a key under a different identity.
+ */
+export function buildCallerScopedIdempotencyKey(input: {
+	userId: string
+	parts: ReadonlyArray<string>
+}) {
+	const userId = input.userId.trim()
+	if (!userId) {
+		throw new Error('Durable escalation userId must not be empty.')
+	}
+	const parts = input.parts.map((part) => part.trim()).filter(Boolean)
+	if (parts.length === 0) {
+		throw new Error(
+			'Durable escalation requires at least one idempotency part.',
+		)
+	}
+	return [userId, ...parts].join(':')
+}
+
 function createDispatchedHandle(input: {
 	workflow: PackageWorkflowCreateResult
 	idempotencyKey: string
@@ -95,13 +117,21 @@ function waitForAbort(signal: AbortSignal) {
  * Attempt `run` within a wall-clock budget. On budget exhaustion, create a
  * durable Cloudflare Workflow for the same work and return a handle instead of
  * hanging past MCP execute's timeout. Never throws.
+ *
+ * Idempotency is always caller-scoped: `idempotencyParts` are joined with the
+ * same `userId` used for workflow_runs lookup/create, so keys cannot silently
+ * disagree with row ownership.
  */
 export async function runWithDurableEscalation<T>(input: {
 	env: Pick<Env, 'APP_DB' | 'DYNAMIC_CALLABLE_WORKFLOWS'>
 	userId: string
 	userEmail?: string | null
 	budgetMs?: number
-	idempotencyKey: string
+	/**
+	 * Operation-specific key segments (not including userId). The helper
+	 * prefixes `userId` so workflow_runs dedupe stays aligned with row scope.
+	 */
+	idempotencyParts: ReadonlyArray<string>
 	workflowName: string
 	packageContext?: {
 		packageId: string
@@ -112,11 +142,16 @@ export async function runWithDurableEscalation<T>(input: {
 	durableParams?: Record<string, unknown>
 	run: (signal: AbortSignal) => Promise<T>
 }): Promise<DurableEscalationOutcome<T>> {
-	const idempotencyKey = input.idempotencyKey.trim()
-	if (!idempotencyKey) {
+	let idempotencyKey: string
+	try {
+		idempotencyKey = buildCallerScopedIdempotencyKey({
+			userId: input.userId,
+			parts: input.idempotencyParts,
+		})
+	} catch (error) {
 		return {
 			kind: 'failed',
-			error: 'Durable escalation requires a non-empty idempotencyKey.',
+			error: getErrorMessage(error),
 		}
 	}
 

--- a/packages/worker/src/mcp/capabilities/durable-escalation.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.ts
@@ -117,6 +117,10 @@ function waitForAbort(signal: AbortSignal) {
 	})
 }
 
+type SettledInlineRun<T> =
+	| { kind: 'completed'; value: T }
+	| { kind: 'rejected'; error: unknown }
+
 /**
  * Attempt `run` within a wall-clock budget. On budget exhaustion, create a
  * durable Cloudflare Workflow for the same work and return a handle instead of
@@ -191,8 +195,22 @@ export async function runWithDurableEscalation<T>(input: {
 			controller.abort()
 		}, budgetMs)
 
-		const runPromise = input.run(controller.signal)
-		// Prevent unhandled rejection if we abandon the inline attempt on abort.
+		const settledRef: { current: SettledInlineRun<T> | null } = {
+			current: null,
+		}
+		const runPromise = input.run(controller.signal).then(
+			(value) => {
+				settledRef.current = { kind: 'completed', value }
+				return value
+			},
+			(error: unknown) => {
+				settledRef.current = { kind: 'rejected', error }
+				throw error
+			},
+		)
+		// The inline attempt is not cancelled on budget expiry (and must not be:
+		// aborting mid-publish could leave partial state). Keep the rejection
+		// handled so an abandoned-in-flight attempt cannot surface unhandled.
 		void runPromise.catch(() => {})
 
 		try {
@@ -211,7 +229,7 @@ export async function runWithDurableEscalation<T>(input: {
 			}
 			if (raced.kind === 'rejected') {
 				if (controller.signal.aborted) {
-					// Fall through to durable dispatch.
+					// Fall through: prefer any same-tick settlement below, else dispatch.
 				} else {
 					return {
 						kind: 'failed',
@@ -219,6 +237,27 @@ export async function runWithDurableEscalation<T>(input: {
 					}
 				}
 			}
+
+			// Drain microtasks so a run that finished in the same turn as the
+			// abort is observed before we create a redundant workflow.
+			await Promise.resolve()
+			const settled = settledRef.current
+			if (settled?.kind === 'completed') {
+				return { kind: 'completed', value: settled.value }
+			}
+			if (settled?.kind === 'rejected' && !controller.signal.aborted) {
+				return {
+					kind: 'failed',
+					error: getErrorMessage(settled.error),
+				}
+			}
+			// Inline work may still be running. We dispatch anyway rather than
+			// awaiting it (awaiting would reintroduce the opaque MCP timeout).
+			// Overlap is intentional and safe for publish: we do not cancel the
+			// in-flight attempt (partial apply is worse than duplication), the
+			// durable re-entry is idempotent on matching published_commit
+			// (already_published), and RepoSession DO RPCs serialize per session
+			// id so the common first-attempt session cannot interleave mutations.
 		} finally {
 			clearTimeout(timer)
 		}

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -4,10 +4,21 @@ const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
 	getSavedPackageByKodyId: vi.fn(),
 	getEntitySourceByIdForUser: vi.fn(),
-	resolveArtifactDefaultBranchHead: vi.fn(),
 	resolveExistingArtifactSourceRepo: vi.fn(),
 	createStubSavedPackage: vi.fn(),
 	resolvePackageOwnerContext: vi.fn(),
+	listServerRefs: vi.fn(),
+}))
+
+vi.mock('isomorphic-git', () => ({
+	default: {
+		listServerRefs: (...args: Array<unknown>) =>
+			mockModule.listServerRefs(...args),
+	},
+}))
+
+vi.mock('isomorphic-git/http/web', () => ({
+	default: {},
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -32,8 +43,6 @@ vi.mock('#worker/repo/artifacts.ts', async () => {
 	const actual = await vi.importActual('#worker/repo/artifacts.ts')
 	return {
 		...(actual as object),
-		resolveArtifactDefaultBranchHead: (...args: Array<unknown>) =>
-			mockModule.resolveArtifactDefaultBranchHead(...args),
 		resolveExistingArtifactSourceRepo: (...args: Array<unknown>) =>
 			mockModule.resolveExistingArtifactSourceRepo(...args),
 	}
@@ -63,35 +72,46 @@ function resetMocks() {
 	mockModule.resolvePackageOwnerContext.mockResolvedValue(personalOwner())
 }
 
-function createContext(userId = 'user-1') {
+function createPublishedSnapshot() {
+	return {
+		version: 1,
+		sourceId: 'source-1',
+		repoId: 'package-package-1',
+		entityKind: 'package',
+		entityId: 'package-1',
+		publishedCommit: 'commit-1',
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		files: {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/unleashed-wifi',
+				exports: { '.': './src/index.ts' },
+				kody: {
+					id: 'unleashed-wifi',
+					description: 'Unleashed WiFi controls.',
+				},
+			}),
+			'src/index.ts': 'export default async function main() {}\n',
+		},
+		createdAt: '2026-05-04T00:00:00.000Z',
+	}
+}
+
+function createContext(
+	userId = 'user-1',
+	options: { snapshot?: unknown | null } = {},
+) {
+	const snapshot =
+		options.snapshot === undefined
+			? createPublishedSnapshot()
+			: options.snapshot
 	return {
 		env: {
 			APP_DB: {},
 			BUNDLE_ARTIFACTS_KV: {
 				async get(_key: string, type?: 'text' | 'json') {
 					if (type !== 'json') return null
-					return {
-						version: 1,
-						sourceId: 'source-1',
-						repoId: 'package-package-1',
-						entityKind: 'package',
-						entityId: 'package-1',
-						publishedCommit: 'commit-1',
-						manifestPath: 'package.json',
-						sourceRoot: '/',
-						files: {
-							'package.json': JSON.stringify({
-								name: '@kentcdodds/unleashed-wifi',
-								exports: { '.': './src/index.ts' },
-								kody: {
-									id: 'unleashed-wifi',
-									description: 'Unleashed WiFi controls.',
-								},
-							}),
-							'src/index.ts': 'export default async function main() {}\n',
-						},
-						createdAt: '2026-05-04T00:00:00.000Z',
-					}
+					return snapshot
 				},
 			},
 		} as unknown as Env,
@@ -147,22 +167,20 @@ function mockPackageSource(sourceUserId = 'user-1') {
 		scope,
 		expiresAt: new Date(Date.now() + ttl * 1000).toISOString(),
 	}))
+	const remote =
+		'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git'
 	const repo = {
 		info: vi.fn(async () => ({
-			remote:
-				'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
+			remote,
 			defaultBranch: 'main',
 		})),
 		createToken,
 	}
 	mockModule.resolveExistingArtifactSourceRepo.mockResolvedValue(repo)
-	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValue({
-		remote:
-			'https://acct.artifacts.cloudflare.net/git/default/package-package-1.git',
-		defaultBranch: 'main',
-		commit: 'commit-1',
-	})
-	return { createToken }
+	mockModule.listServerRefs.mockResolvedValue([
+		{ ref: 'refs/heads/main', oid: 'commit-1' },
+	])
+	return { createToken, remote, repo }
 }
 
 test('get_git_remote returns scoped artifact remotes and rejects invalid input', async () => {
@@ -187,14 +205,19 @@ test('get_git_remote returns scoped artifact remotes and rejects invalid input',
 	).rejects.toThrow('Repo source was not found for this user.')
 
 	resetMocks()
-	const { createToken } = mockPackageSource()
+	const { createToken, remote } = mockPackageSource()
 	const before = Date.now()
 	const writeResult = await getGitRemoteCapability.handler(
 		{ package_id: 'package-1', ttl_seconds: 1800 },
 		createContext(),
 	)
 	const writeExpiresAt = new Date(writeResult.expires_at).getTime()
+	expect(createToken).toHaveBeenCalledTimes(1)
 	expect(createToken).toHaveBeenCalledWith('write', 1800)
+	expect(writeResult.package_id).toBe('package-1')
+	expect(writeResult.kody_id).toBe('unleashed-wifi')
+	expect(writeResult.created).toBe(false)
+	expect(writeResult.remote).toBe(remote)
 	expect(writeResult.scope).toBe('write')
 	expect(writeExpiresAt).toBeGreaterThanOrEqual(before + 1799 * 1000)
 	expect(writeExpiresAt).toBeLessThanOrEqual(Date.now() + 1801 * 1000)
@@ -204,8 +227,15 @@ test('get_git_remote returns scoped artifact remotes and rejects invalid input',
 	expect(writeResult.git_extra_header).toBe(
 		'Authorization: Bearer art_v1_write_token',
 	)
-	expect(writeResult.setup_commands.length).toBeGreaterThan(0)
-	expect(writeResult.setup_commands[0]).toMatch(/^git -c http\.extraHeader=/)
+	expect(writeResult.setup_commands).toEqual([
+		`git -c http.extraHeader='Authorization: Bearer art_v1_write_token' clone '${remote}' 'package-1'`,
+		`cd 'package-1'`,
+		`git remote add kody '${remote}'`,
+		`git config remote.kody.fetch '+refs/heads/*:refs/remotes/kody/*'`,
+		`git config --add remote.kody.fetch '+refs/notes/*:refs/notes/*'`,
+		`git -c http.extraHeader='Authorization: Bearer art_v1_write_token' fetch kody 'refs/notes/*:refs/notes/*'`,
+		`git -c http.extraHeader='Authorization: Bearer art_v1_write_token' push kody HEAD:'main'`,
+	])
 
 	resetMocks()
 	const readSetup = mockPackageSource()
@@ -213,8 +243,18 @@ test('get_git_remote returns scoped artifact remotes and rejects invalid input',
 		{ kody_id: 'unleashed-wifi', scope: 'read' },
 		createContext(),
 	)
+	expect(readSetup.createToken).toHaveBeenCalledTimes(1)
 	expect(readSetup.createToken).toHaveBeenCalledWith('read', 14_400)
 	expect(readResult.scope).toBe('read')
+	expect(readResult.remote).toBe(readSetup.remote)
+	expect(readResult.authenticated_remote).toContain(
+		'https://x:art_v1_read_token@',
+	)
+	expect(readResult.git_extra_header).toBe(
+		'Authorization: Bearer art_v1_read_token',
+	)
+	expect(readResult.setup_commands[0]).toMatch(/^git -c http\.extraHeader=/)
+	expect(readResult.setup_commands.at(-1)).toContain("HEAD:'main'")
 
 	resetMocks()
 	mockPackageSource()
@@ -230,6 +270,28 @@ test('get_git_remote returns scoped artifact remotes and rejects invalid input',
 			createContext(),
 		),
 	).rejects.toThrow()
+})
+
+test('get_git_remote write scope blocks when no restorable backup snapshot exists', async () => {
+	resetMocks()
+	mockPackageSource()
+	await expect(
+		getGitRemoteCapability.handler(
+			{ package_id: 'package-1', scope: 'write' },
+			createContext('user-1', { snapshot: null }),
+		),
+	).rejects.toThrow('Stop and report this source recovery problem')
+})
+
+test('get_git_remote prefers package-not-found over snapshot errors', async () => {
+	resetMocks()
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	await expect(
+		getGitRemoteCapability.handler(
+			{ package_id: 'missing' },
+			createContext('user-1', { snapshot: null }),
+		),
+	).rejects.toThrow('Saved package "missing" was not found.')
 })
 
 test('get_git_remote create mode registers stubs for owner and delegated scopes', async () => {

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -132,24 +132,45 @@ export const getGitRemoteCapability = defineDomainCapability(
 					kody_id: requestedKodyId,
 				},
 			})
-			if (args.scope === 'write') {
-				await assertRestorablePackageSourceSnapshot({
-					env: ctx.env,
-					userId: owner.ownerUserId,
-					source,
-					operation: 'package_get_git_remote write access',
-				})
-			}
-			const sourceHead = await assertPublishedPackageSourceRepoHead({
+			const headPromise = assertPublishedPackageSourceRepoHead({
 				env: ctx.env,
 				source,
 				operation: 'package_get_git_remote',
+				accessToken: {
+					scope: args.scope,
+					ttlSeconds: args.ttl_seconds,
+				},
 			})
+			let sourceHead: Awaited<typeof headPromise>
+			if (args.scope === 'write') {
+				const [snapshotResult, headResult] = await Promise.allSettled([
+					assertRestorablePackageSourceSnapshot({
+						env: ctx.env,
+						userId: owner.ownerUserId,
+						source,
+						operation: 'package_get_git_remote write access',
+					}),
+					headPromise,
+				])
+				if (snapshotResult.status === 'rejected') {
+					throw snapshotResult.reason
+				}
+				if (headResult.status === 'rejected') {
+					throw headResult.reason
+				}
+				sourceHead = headResult.value
+			} else {
+				sourceHead = await headPromise
+			}
 			if (!sourceHead) {
 				throw new Error('package_get_git_remote requires a package source.')
 			}
-			const { repo } = sourceHead
-			const token = await repo.createToken(args.scope, args.ttl_seconds)
+			const token = sourceHead.accessToken
+			if (!token) {
+				throw new Error(
+					'package_get_git_remote failed to mint an artifact access token.',
+				)
+			}
 			const gitExtraHeader = `Authorization: Bearer ${parseArtifactTokenSecret(token.plaintext)}`
 			const cloneDirectory = source.entity_id
 			return {

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -10,6 +10,7 @@ const mockModule = vi.hoisted(() => ({
 	listPublishedPackageArtifactTargets: vi.fn(),
 	rebuildPublishedPackageArtifact: vi.fn(),
 	getStaticPackageDependentsSummary: vi.fn(),
+	runWithDurableEscalation: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -49,6 +50,12 @@ vi.mock('#worker/repo/published-source.ts', () => ({
 	loadPublishedEntitySource: async () => {
 		throw new Error('published source unavailable in unit test')
 	},
+}))
+
+vi.mock('#mcp/capabilities/durable-escalation.ts', () => ({
+	defaultDurableEscalationBudgetMs: 55_000,
+	runWithDurableEscalation: (...args: Array<unknown>) =>
+		mockModule.runWithDurableEscalation(...args),
 }))
 
 const { publishExternalPushCapability } =
@@ -94,28 +101,40 @@ function setupDefaultMocks() {
 		},
 		kvKey: 'bundle-key',
 	})
+	mockModule.runWithDurableEscalation.mockImplementation(
+		async (input: { run: (signal: AbortSignal) => Promise<unknown> }) => {
+			const value = await input.run(new AbortController().signal)
+			return { kind: 'completed', value }
+		},
+	)
 }
 
-function createContext() {
+function createContext(executionOrigin?: 'interactive' | 'background') {
 	return {
 		env: {
 			APP_DB: {
-				prepare() {
+				prepare(query: string) {
 					return {
 						bind() {
 							return {
-								first: async () => ({ username: 'user' }),
+								first: async () => {
+									if (query.includes('FROM workflow_runs')) return null
+									return { username: 'user' }
+								},
 							}
 						},
 					}
 				},
 			},
+			DYNAMIC_CALLABLE_WORKFLOWS: {},
 		} as unknown as Env,
 		callerContext: {
 			baseUrl: 'https://kody.test',
+			executionOrigin,
 			user: {
 				userId: 'user-1',
 				email: 'user@example.com',
+				username: 'user',
 				displayName: 'User',
 			},
 			remoteConnectors: null,
@@ -165,6 +184,7 @@ test('publishExternalPush publishes HEAD and rebuilds bundle artifacts per targe
 		}),
 	)
 	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
+	expect(mockModule.runWithDurableEscalation).toHaveBeenCalledTimes(1)
 
 	const targets = [
 		{
@@ -390,6 +410,7 @@ test('force publish passes destructive confirmation through and refuses without 
 			allowForce: false,
 		}),
 	)
+	expect(mockModule.runWithDurableEscalation).toHaveBeenCalled()
 
 	mockModule.publishFromExternalRef.mockResolvedValue({
 		status: 'published',
@@ -412,6 +433,90 @@ test('force publish passes destructive confirmation through and refuses without 
 			destructiveOverwriteConfirmed: true,
 		}),
 	)
+})
+
+test('ineligible publishes return structured results without durable escalation dispatch', async () => {
+	setupDefaultMocks()
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'checks_failed',
+		failed_checks: [{ kind: 'typecheck', ok: false, message: 'type error' }],
+		manifest: {},
+		run_id: 'run-1',
+	})
+
+	const failed = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext(),
+	)
+	expect(failed).toEqual({
+		status: 'checks_failed',
+		failed_checks: [{ kind: 'typecheck', ok: false, message: 'type error' }],
+		manifest: {},
+		run_id: 'run-1',
+	})
+	expect(mockModule.runWithDurableEscalation).toHaveBeenCalledTimes(1)
+	const escalationInput = mockModule.runWithDurableEscalation.mock
+		.calls[0]?.[0] as {
+		idempotencyKey: string
+	}
+	expect(escalationInput.idempotencyKey).toBe(
+		'package_publish_external_push:user-1:package-1:commit-new',
+	)
+})
+
+test('budget exhaustion returns a dispatched handle and background re-entry skips escalation', async () => {
+	setupDefaultMocks()
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.runWithDurableEscalation.mockResolvedValue({
+		kind: 'dispatched',
+		handle: {
+			status: 'dispatched',
+			workflow_id: 'dynwf-publish-1',
+			workflow_name: 'package_publish_external_push',
+			idempotency_key:
+				'package_publish_external_push:user-1:package-1:commit-new',
+			run_status: 'queued',
+			message: 'dispatched',
+		},
+	})
+
+	const dispatched = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext('interactive'),
+	)
+	expect(dispatched).toEqual({
+		status: 'dispatched',
+		workflow_id: 'dynwf-publish-1',
+		workflow_name: 'package_publish_external_push',
+		idempotency_key:
+			'package_publish_external_push:user-1:package-1:commit-new',
+		run_status: 'queued',
+		message: 'dispatched',
+	})
+	expect(mockModule.publishFromExternalRef).not.toHaveBeenCalled()
+
+	mockModule.runWithDurableEscalation.mockClear()
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'published',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-new',
+		manifest: {},
+		checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+	})
+	const background = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext('background'),
+	)
+	expect(background.status).toBe('published')
+	expect(mockModule.runWithDurableEscalation).not.toHaveBeenCalled()
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(1)
 })
 
 test('publishExternalPush recovers from transient Durable Object resets', async () => {

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -54,6 +54,10 @@ vi.mock('#worker/repo/published-source.ts', () => ({
 
 vi.mock('#mcp/capabilities/durable-escalation.ts', () => ({
 	defaultDurableEscalationBudgetMs: 55_000,
+	buildCallerScopedIdempotencyKey: (input: {
+		userId: string
+		parts: ReadonlyArray<string>
+	}) => [input.userId, ...input.parts].join(':'),
 	runWithDurableEscalation: (...args: Array<unknown>) =>
 		mockModule.runWithDurableEscalation(...args),
 }))
@@ -461,11 +465,17 @@ test('ineligible publishes return structured results without durable escalation 
 	expect(mockModule.runWithDurableEscalation).toHaveBeenCalledTimes(1)
 	const escalationInput = mockModule.runWithDurableEscalation.mock
 		.calls[0]?.[0] as {
-		idempotencyKey: string
+		userId: string
+		idempotencyParts: ReadonlyArray<string>
 	}
-	expect(escalationInput.idempotencyKey).toBe(
-		'package_publish_external_push:user-1:package-1:commit-new',
-	)
+	// workflow_runs rows are scoped by acting userId; parts keep owner/package/commit.
+	expect(escalationInput.userId).toBe('user-1')
+	expect(escalationInput.idempotencyParts).toEqual([
+		'package_publish_external_push',
+		'user-1',
+		'package-1',
+		'commit-new',
+	])
 })
 
 test('budget exhaustion returns a dispatched handle and background re-entry skips escalation', async () => {
@@ -481,7 +491,7 @@ test('budget exhaustion returns a dispatched handle and background re-entry skip
 			workflow_id: 'dynwf-publish-1',
 			workflow_name: 'package_publish_external_push',
 			idempotency_key:
-				'package_publish_external_push:user-1:package-1:commit-new',
+				'user-1:package_publish_external_push:user-1:package-1:commit-new',
 			run_status: 'queued',
 			message: 'dispatched',
 		},
@@ -496,11 +506,22 @@ test('budget exhaustion returns a dispatched handle and background re-entry skip
 		workflow_id: 'dynwf-publish-1',
 		workflow_name: 'package_publish_external_push',
 		idempotency_key:
-			'package_publish_external_push:user-1:package-1:commit-new',
+			'user-1:package_publish_external_push:user-1:package-1:commit-new',
 		run_status: 'queued',
 		message: 'dispatched',
 	})
 	expect(mockModule.publishFromExternalRef).not.toHaveBeenCalled()
+	expect(mockModule.runWithDurableEscalation).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			idempotencyParts: [
+				'package_publish_external_push',
+				'user-1',
+				'package-1',
+				'commit-new',
+			],
+		}),
+	)
 
 	mockModule.runWithDurableEscalation.mockClear()
 	mockModule.publishFromExternalRef.mockResolvedValue({

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -62,7 +62,7 @@ vi.mock('#mcp/capabilities/durable-escalation.ts', () => ({
 		mockModule.runWithDurableEscalation(...args),
 }))
 
-const { publishExternalPushCapability } =
+const { buildExternalPublishIdempotencyParts, publishExternalPushCapability } =
 	await import('./publish-external-push.ts')
 
 function setupDefaultMocks() {
@@ -113,7 +113,9 @@ function setupDefaultMocks() {
 	)
 }
 
-function createContext(executionOrigin?: 'interactive' | 'background') {
+function createContext(
+	executionOrigin: 'interactive' | 'background' | 'omit' = 'interactive',
+) {
 	return {
 		env: {
 			APP_DB: {
@@ -134,7 +136,7 @@ function createContext(executionOrigin?: 'interactive' | 'background') {
 		} as unknown as Env,
 		callerContext: {
 			baseUrl: 'https://kody.test',
-			executionOrigin,
+			...(executionOrigin === 'omit' ? {} : { executionOrigin }),
 			user: {
 				userId: 'user-1',
 				email: 'user@example.com',
@@ -468,14 +470,61 @@ test('ineligible publishes return structured results without durable escalation 
 		userId: string
 		idempotencyParts: ReadonlyArray<string>
 	}
-	// workflow_runs rows are scoped by acting userId; parts keep owner/package/commit.
+	// workflow_runs rows are scoped by acting userId; parts keep full semantic input.
 	expect(escalationInput.userId).toBe('user-1')
-	expect(escalationInput.idempotencyParts).toEqual([
-		'package_publish_external_push',
-		'user-1',
-		'package-1',
-		'commit-new',
-	])
+	expect(escalationInput.idempotencyParts).toEqual(
+		buildExternalPublishIdempotencyParts({
+			ownerUserId: 'user-1',
+			packageId: 'package-1',
+			newCommit: 'commit-new',
+			allowForce: false,
+			destructiveOverwriteConfirmed: false,
+		}),
+	)
+})
+
+test('force and non-force publishes get distinct durable idempotency keys', () => {
+	const base = {
+		ownerUserId: 'owner-1',
+		packageId: 'package-1',
+		newCommit: 'commit-new',
+	}
+	const safe = buildExternalPublishIdempotencyParts({
+		...base,
+		allowForce: false,
+		destructiveOverwriteConfirmed: false,
+	})
+	const force = buildExternalPublishIdempotencyParts({
+		...base,
+		allowForce: true,
+		destructiveOverwriteConfirmed: true,
+	})
+	expect(safe).not.toEqual(force)
+	expect(safe[1]).toContain('"allowForce":false')
+	expect(force[1]).toContain('"allowForce":true')
+})
+
+test('missing executionOrigin fails closed and does not escalate', async () => {
+	setupDefaultMocks()
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-new',
+	})
+	mockModule.publishFromExternalRef.mockResolvedValue({
+		status: 'published',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-new',
+		manifest: {},
+		checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+	})
+
+	const result = await publishExternalPushCapability.handler(
+		{ package_id: 'package-1' },
+		createContext('omit'),
+	)
+	expect(result.status).toBe('published')
+	expect(mockModule.runWithDurableEscalation).not.toHaveBeenCalled()
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(1)
 })
 
 test('budget exhaustion returns a dispatched handle and background re-entry skips escalation', async () => {
@@ -484,14 +533,20 @@ test('budget exhaustion returns a dispatched handle and background re-entry skip
 		branch: 'main',
 		commit: 'commit-new',
 	})
+	const expectedParts = buildExternalPublishIdempotencyParts({
+		ownerUserId: 'user-1',
+		packageId: 'package-1',
+		newCommit: 'commit-new',
+		allowForce: false,
+		destructiveOverwriteConfirmed: false,
+	})
 	mockModule.runWithDurableEscalation.mockResolvedValue({
 		kind: 'dispatched',
 		handle: {
 			status: 'dispatched',
 			workflow_id: 'dynwf-publish-1',
 			workflow_name: 'package_publish_external_push',
-			idempotency_key:
-				'user-1:package_publish_external_push:user-1:package-1:commit-new',
+			idempotency_key: ['user-1', ...expectedParts].join(':'),
 			run_status: 'queued',
 			message: 'dispatched',
 		},
@@ -505,8 +560,7 @@ test('budget exhaustion returns a dispatched handle and background re-entry skip
 		status: 'dispatched',
 		workflow_id: 'dynwf-publish-1',
 		workflow_name: 'package_publish_external_push',
-		idempotency_key:
-			'user-1:package_publish_external_push:user-1:package-1:commit-new',
+		idempotency_key: ['user-1', ...expectedParts].join(':'),
 		run_status: 'queued',
 		message: 'dispatched',
 	})
@@ -514,12 +568,7 @@ test('budget exhaustion returns a dispatched handle and background re-entry skip
 	expect(mockModule.runWithDurableEscalation).toHaveBeenCalledWith(
 		expect.objectContaining({
 			userId: 'user-1',
-			idempotencyParts: [
-				'package_publish_external_push',
-				'user-1',
-				'package-1',
-				'commit-new',
-			],
+			idempotencyParts: expectedParts,
 		}),
 	)
 

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -2,6 +2,10 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
+	defaultDurableEscalationBudgetMs,
+	runWithDurableEscalation,
+} from '#mcp/capabilities/durable-escalation.ts'
+import {
 	errorCauseChainIncludes,
 	getErrorMessage,
 } from '@kody-internal/shared/error-message.ts'
@@ -44,6 +48,11 @@ const inputSchema = z.object({
 
 const externalPublishRetryDelaysMs = [100, 500] as const
 
+const durablePublishWorkflowCode = `import { kody } from 'kody:runtime'
+export default async function main(params = {}) {
+	return await kody.package_publish_external_push(params)
+}`
+
 function isTransientDurableObjectResetError(error: unknown) {
 	return errorCauseChainIncludes(
 		error,
@@ -80,8 +89,29 @@ function logExternalPublishRetry(input: {
 	)
 }
 
-async function delay(ms: number) {
-	await new Promise((resolve) => setTimeout(resolve, ms))
+function assertNotAborted(signal: AbortSignal | undefined) {
+	if (signal?.aborted) {
+		throw new DOMException('The publish attempt was aborted.', 'AbortError')
+	}
+}
+
+async function delay(ms: number, signal?: AbortSignal) {
+	assertNotAborted(signal)
+	if (!signal) {
+		await new Promise((resolve) => setTimeout(resolve, ms))
+		return
+	}
+	await new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			signal.removeEventListener('abort', onAbort)
+			resolve()
+		}, ms)
+		const onAbort = () => {
+			clearTimeout(timer)
+			reject(new DOMException('The publish attempt was aborted.', 'AbortError'))
+		}
+		signal.addEventListener('abort', onAbort, { once: true })
+	})
 }
 
 const checkSchema = z.object({
@@ -214,7 +244,17 @@ const outputSchema = z.discriminatedUnion('status', [
 		static_dependents: staticDependentsSchema,
 		pending_secret_package_approvals: pendingPackageSecretApprovalsSchema,
 	}),
+	z.object({
+		status: z.literal('dispatched'),
+		workflow_id: z.string(),
+		workflow_name: z.string(),
+		idempotency_key: z.string(),
+		run_status: z.string().nullable(),
+		message: z.string(),
+	}),
 ])
+
+type PublishExternalPushResult = z.infer<typeof outputSchema>
 
 function readSecretMountsFromPackageJson(content: string | undefined) {
 	if (!content) return null
@@ -295,12 +335,156 @@ async function getPublishStaticDependents(input: {
 	})
 }
 
+function buildExternalPublishIdempotencyKey(input: {
+	ownerUserId: string
+	packageId: string
+	newCommit: string
+}) {
+	return `package_publish_external_push:${input.ownerUserId}:${input.packageId}:${input.newCommit}`
+}
+
+async function runExternalPublishAttempt(input: {
+	env: Env
+	baseUrl: string
+	ownerUserId: string
+	expectedPackageScope: string
+	packageId: string
+	kodyId: string
+	source: {
+		id: string
+		repo_id: string
+	}
+	newCommit: string
+	allowForce: boolean
+	destructiveOverwriteConfirmed: boolean
+	signal?: AbortSignal
+}): Promise<Exclude<PublishExternalPushResult, { status: 'dispatched' }>> {
+	const maxAttempts = externalPublishRetryDelaysMs.length + 1
+	let lastTransientError: unknown = null
+	for (let attemptIndex = 0; attemptIndex < maxAttempts; attemptIndex += 1) {
+		assertNotAborted(input.signal)
+		const attempt = attemptIndex + 1
+		const sessionId =
+			attemptIndex === 0
+				? `external-publish-${input.source.id}`
+				: `external-publish-${input.source.id}-retry-${attempt}`
+		try {
+			const result = await repoSessionRpc(
+				input.env,
+				sessionId,
+			).publishFromExternalRef({
+				sessionId,
+				sourceId: input.source.id,
+				userId: input.ownerUserId,
+				newCommit: input.newCommit,
+				expectedHead: input.newCommit,
+				allowForce: input.allowForce,
+				destructiveOverwriteConfirmed: input.destructiveOverwriteConfirmed,
+				baseUrl: input.baseUrl,
+				rebuildPackageArtifacts: false,
+				expectedPackageScope: input.expectedPackageScope,
+			})
+			assertNotAborted(input.signal)
+			if (result.status === 'already_published') {
+				if (!result.published_commit) {
+					throw new Error(
+						`Package "${input.packageId}" is already published, but no published commit is available to rebuild artifacts.`,
+					)
+				}
+				await rebuildPublishedPackageArtifactsViaRepoSession({
+					env: input.env,
+					rpcSessionId: sessionId,
+					sourceId: input.source.id,
+					userId: input.ownerUserId,
+					publishedCommit: result.published_commit,
+					baseUrl: input.baseUrl,
+				})
+				return {
+					...result,
+					static_dependents: await getPublishStaticDependents({
+						db: input.env.APP_DB,
+						userId: input.ownerUserId,
+						sourceId: input.source.id,
+						publishedCommit: result.published_commit,
+					}),
+					pending_secret_package_approvals:
+						await getPendingSecretApprovalsForPublishedPackage({
+							env: input.env,
+							baseUrl: input.baseUrl,
+							userId: input.ownerUserId,
+							packageId: input.packageId,
+							kodyId: input.kodyId,
+							sourceId: input.source.id,
+						}),
+				} as const
+			}
+			if (result.status !== 'published') {
+				return result
+			}
+			await rebuildPublishedPackageArtifactsViaRepoSession({
+				env: input.env,
+				rpcSessionId: sessionId,
+				sourceId: input.source.id,
+				userId: input.ownerUserId,
+				publishedCommit: result.published_commit,
+				baseUrl: input.baseUrl,
+			})
+			return {
+				...result,
+				static_dependents: await getPublishStaticDependents({
+					db: input.env.APP_DB,
+					userId: input.ownerUserId,
+					sourceId: input.source.id,
+					publishedCommit: result.published_commit,
+				}),
+				pending_secret_package_approvals:
+					await getPendingSecretApprovalsForPublishedPackage({
+						env: input.env,
+						baseUrl: input.baseUrl,
+						userId: input.ownerUserId,
+						packageId: input.packageId,
+						kodyId: input.kodyId,
+						sourceId: input.source.id,
+					}),
+			} as const
+		} catch (error) {
+			assertNotAborted(input.signal)
+			if (!isTransientDurableObjectResetError(error)) {
+				throw error
+			}
+			lastTransientError = error
+			const willRetry = attemptIndex < externalPublishRetryDelaysMs.length
+			const nextDelayMs = willRetry
+				? (externalPublishRetryDelaysMs[attemptIndex] ?? 0)
+				: 0
+			logExternalPublishRetry({
+				sourceId: input.source.id,
+				repoId: input.source.repo_id,
+				packageId: input.packageId,
+				newCommit: input.newCommit,
+				attempt,
+				nextDelayMs,
+				error,
+			})
+			if (!willRetry) {
+				break
+			}
+			await delay(nextDelayMs, input.signal)
+		}
+	}
+	throw new Error(
+		`package_publish_external_push could not recover after ${maxAttempts} transient Durable Object reset attempts: ${getErrorMessage(
+			lastTransientError,
+		)}`,
+	)
+}
+
 export const publishExternalPushCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_publish_external_push',
 		description:
-			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically.',
+			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically. Common cases return the full synchronous result. If the publish exceeds the inline budget (~55s), the work is dispatched once to a durable workflow (idempotent per owner/package/commit) and this capability returns status dispatched with a workflow_id to poll via workflow_run_list instead of hanging until an opaque execute timeout.',
 		keywords: ['package', 'publish', 'git', 'artifacts', 'external', 'push'],
 		readOnly: false,
 		idempotent: true,
@@ -315,140 +499,88 @@ export const publishExternalPushCapability = defineDomainCapability(
 				args.package_scope,
 			)
 			const expectedPackageScope = owner.ownerScope
-			const maxAttempts = externalPublishRetryDelaysMs.length + 1
-			let lastTransientError: unknown = null
-			for (
-				let attemptIndex = 0;
-				attemptIndex < maxAttempts;
-				attemptIndex += 1
-			) {
-				const attempt = attemptIndex + 1
-				const { packageId, kodyId, source } = await resolveOwnedPackageSource({
-					db: ctx.env.APP_DB,
-					userId: owner.ownerUserId,
-					args: {
-						package_id: args.package_id,
-						kody_id: args.kody_id,
-					},
-				})
-				const head = await resolveArtifactSourceHead(ctx.env, source.repo_id)
-				const newCommit = head.commit
-				if (!newCommit) {
+			const { packageId, kodyId, source } = await resolveOwnedPackageSource({
+				db: ctx.env.APP_DB,
+				userId: owner.ownerUserId,
+				args: {
+					package_id: args.package_id,
+					kody_id: args.kody_id,
+				},
+			})
+			const head = await resolveArtifactSourceHead(ctx.env, source.repo_id)
+			const newCommit = head.commit
+			if (!newCommit) {
+				throw new Error(
+					`Artifacts repo "${source.repo_id}" has no published HEAD to reconcile.`,
+				)
+			}
+
+			const publishInput = {
+				env: ctx.env,
+				baseUrl: ctx.callerContext.baseUrl,
+				ownerUserId: owner.ownerUserId,
+				expectedPackageScope,
+				packageId,
+				kodyId,
+				source: { id: source.id, repo_id: source.repo_id },
+				newCommit,
+				allowForce: args.allow_force,
+				destructiveOverwriteConfirmed: args.confirm_destructive_overwrite,
+			}
+
+			// Durable workflow re-entry uses executionOrigin "background" and must
+			// not escalate again (avoids recursive workflow creation).
+			if (ctx.callerContext.executionOrigin === 'background') {
+				return await runExternalPublishAttempt(publishInput)
+			}
+
+			const idempotencyKey = buildExternalPublishIdempotencyKey({
+				ownerUserId: owner.ownerUserId,
+				packageId,
+				newCommit,
+			})
+			const durableParams = {
+				...(args.package_id ? { package_id: args.package_id } : {}),
+				...(args.kody_id ? { kody_id: args.kody_id } : {}),
+				...(args.package_scope ? { package_scope: args.package_scope } : {}),
+				allow_force: args.allow_force,
+				confirm_destructive_overwrite: args.confirm_destructive_overwrite,
+			}
+			const outcome = await runWithDurableEscalation({
+				env: ctx.env,
+				userId: user.userId,
+				userEmail: user.email,
+				budgetMs: defaultDurableEscalationBudgetMs,
+				idempotencyKey,
+				workflowName: 'package_publish_external_push',
+				packageContext: {
+					packageId,
+					kodyId,
+					sourceId: source.id,
+				},
+				durableCode: durablePublishWorkflowCode,
+				durableParams,
+				run: async (signal) =>
+					await runExternalPublishAttempt({
+						...publishInput,
+						signal,
+					}),
+			})
+
+			switch (outcome.kind) {
+				case 'completed':
+					return outcome.value
+				case 'dispatched':
+					return outcome.handle
+				case 'failed':
+					throw new Error(outcome.error)
+				default: {
+					const exhaustive: never = outcome
 					throw new Error(
-						`Artifacts repo "${source.repo_id}" has no published HEAD to reconcile.`,
+						`Unexpected durable escalation outcome: ${JSON.stringify(exhaustive)}`,
 					)
 				}
-				const sessionId =
-					attemptIndex === 0
-						? `external-publish-${source.id}`
-						: `external-publish-${source.id}-retry-${attempt}`
-				try {
-					const result = await repoSessionRpc(
-						ctx.env,
-						sessionId,
-					).publishFromExternalRef({
-						sessionId,
-						sourceId: source.id,
-						userId: owner.ownerUserId,
-						newCommit,
-						expectedHead: newCommit,
-						allowForce: args.allow_force,
-						destructiveOverwriteConfirmed: args.confirm_destructive_overwrite,
-						baseUrl: ctx.callerContext.baseUrl,
-						rebuildPackageArtifacts: false,
-						expectedPackageScope,
-					})
-					if (result.status === 'already_published') {
-						if (!result.published_commit) {
-							throw new Error(
-								`Package "${packageId}" is already published, but no published commit is available to rebuild artifacts.`,
-							)
-						}
-						await rebuildPublishedPackageArtifactsViaRepoSession({
-							env: ctx.env,
-							rpcSessionId: sessionId,
-							sourceId: source.id,
-							userId: owner.ownerUserId,
-							publishedCommit: result.published_commit,
-							baseUrl: ctx.callerContext.baseUrl,
-						})
-						return {
-							...result,
-							static_dependents: await getPublishStaticDependents({
-								db: ctx.env.APP_DB,
-								userId: owner.ownerUserId,
-								sourceId: source.id,
-								publishedCommit: result.published_commit,
-							}),
-							pending_secret_package_approvals:
-								await getPendingSecretApprovalsForPublishedPackage({
-									env: ctx.env,
-									baseUrl: ctx.callerContext.baseUrl,
-									userId: owner.ownerUserId,
-									packageId,
-									kodyId,
-									sourceId: source.id,
-								}),
-						} as const
-					}
-					if (result.status !== 'published') {
-						return result
-					}
-					await rebuildPublishedPackageArtifactsViaRepoSession({
-						env: ctx.env,
-						rpcSessionId: sessionId,
-						sourceId: source.id,
-						userId: owner.ownerUserId,
-						publishedCommit: result.published_commit,
-						baseUrl: ctx.callerContext.baseUrl,
-					})
-					return {
-						...result,
-						static_dependents: await getPublishStaticDependents({
-							db: ctx.env.APP_DB,
-							userId: owner.ownerUserId,
-							sourceId: source.id,
-							publishedCommit: result.published_commit,
-						}),
-						pending_secret_package_approvals:
-							await getPendingSecretApprovalsForPublishedPackage({
-								env: ctx.env,
-								baseUrl: ctx.callerContext.baseUrl,
-								userId: owner.ownerUserId,
-								packageId,
-								kodyId,
-								sourceId: source.id,
-							}),
-					} as const
-				} catch (error) {
-					if (!isTransientDurableObjectResetError(error)) {
-						throw error
-					}
-					lastTransientError = error
-					const willRetry = attemptIndex < externalPublishRetryDelaysMs.length
-					const nextDelayMs = willRetry
-						? (externalPublishRetryDelaysMs[attemptIndex] ?? 0)
-						: 0
-					logExternalPublishRetry({
-						sourceId: source.id,
-						repoId: source.repo_id,
-						packageId,
-						newCommit,
-						attempt,
-						nextDelayMs,
-						error,
-					})
-					if (!willRetry) {
-						break
-					}
-					await delay(nextDelayMs)
-				}
 			}
-			throw new Error(
-				`package_publish_external_push could not recover after ${maxAttempts} transient Durable Object reset attempts: ${getErrorMessage(
-					lastTransientError,
-				)}`,
-			)
 		},
 	},
 )

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -335,12 +335,22 @@ async function getPublishStaticDependents(input: {
 	})
 }
 
-function buildExternalPublishIdempotencyKey(input: {
+function buildExternalPublishIdempotencyParts(input: {
 	ownerUserId: string
 	packageId: string
 	newCommit: string
 }) {
-	return `package_publish_external_push:${input.ownerUserId}:${input.packageId}:${input.newCommit}`
+	// Caller identity is applied by runWithDurableEscalation (workflow_runs are
+	// user-scoped). Keep owner/package/commit here so the key stays meaningful.
+	// Distinct delegates may each dispatch for the same publish; that is safe
+	// because re-invoking publish when published_commit already matches HEAD
+	// returns already_published without checks or D1 writes.
+	return [
+		'package_publish_external_push',
+		input.ownerUserId,
+		input.packageId,
+		input.newCommit,
+	] as const
 }
 
 async function runExternalPublishAttempt(input: {
@@ -534,11 +544,6 @@ export const publishExternalPushCapability = defineDomainCapability(
 				return await runExternalPublishAttempt(publishInput)
 			}
 
-			const idempotencyKey = buildExternalPublishIdempotencyKey({
-				ownerUserId: owner.ownerUserId,
-				packageId,
-				newCommit,
-			})
 			const durableParams = {
 				...(args.package_id ? { package_id: args.package_id } : {}),
 				...(args.kody_id ? { kody_id: args.kody_id } : {}),
@@ -551,7 +556,11 @@ export const publishExternalPushCapability = defineDomainCapability(
 				userId: user.userId,
 				userEmail: user.email,
 				budgetMs: defaultDurableEscalationBudgetMs,
-				idempotencyKey,
+				idempotencyParts: buildExternalPublishIdempotencyParts({
+					ownerUserId: owner.ownerUserId,
+					packageId,
+					newCommit,
+				}),
 				workflowName: 'package_publish_external_push',
 				packageContext: {
 					packageId,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { canonicalJsonStringify } from '@kody-internal/shared/canonical-json.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
@@ -335,22 +336,39 @@ async function getPublishStaticDependents(input: {
 	})
 }
 
-function buildExternalPublishIdempotencyParts(input: {
+/**
+ * Every input that changes publish semantics for durable dedupe. Adding a
+ * field here is a compile-time break at the call site that builds this object,
+ * and the canonical JSON blob below includes every property automatically.
+ */
+export type ExternalPublishSemanticInput = {
 	ownerUserId: string
 	packageId: string
 	newCommit: string
-}) {
+	allowForce: boolean
+	destructiveOverwriteConfirmed: boolean
+}
+
+export function buildExternalPublishIdempotencyParts(
+	input: ExternalPublishSemanticInput,
+) {
 	// Caller identity is applied by runWithDurableEscalation (workflow_runs are
-	// user-scoped). Keep owner/package/commit here so the key stays meaningful.
-	// Distinct delegates may each dispatch for the same publish; that is safe
-	// because re-invoking publish when published_commit already matches HEAD
-	// returns already_published without checks or D1 writes.
+	// user-scoped). Distinct delegates may each dispatch for the same publish;
+	// that is safe because re-invoking publish when published_commit already
+	// matches HEAD returns already_published without checks or D1 writes.
 	return [
 		'package_publish_external_push',
-		input.ownerUserId,
-		input.packageId,
-		input.newCommit,
+		canonicalJsonStringify(input),
 	] as const
+}
+
+function shouldEscalateExternalPublish(executionOrigin: string | undefined) {
+	// Fail closed: only interactive MCP calls escalate. Missing origin and
+	// background (durable workflow re-entry) must not create another workflow.
+	// package-workflows invokeInlineWorkflowCode always sets background today;
+	// requiring an explicit interactive origin still prevents a self-replicating
+	// chain if any future path forgets to set it.
+	return executionOrigin === 'interactive'
 }
 
 async function runExternalPublishAttempt(input: {
@@ -494,7 +512,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 	{
 		name: 'package_publish_external_push',
 		description:
-			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically. Common cases return the full synchronous result. If the publish exceeds the inline budget (~55s), the work is dispatched once to a durable workflow (idempotent per owner/package/commit) and this capability returns status dispatched with a workflow_id to poll via workflow_run_list instead of hanging until an opaque execute timeout.',
+			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically. Common cases return the full synchronous result. If the publish exceeds the inline budget (~55s), the work is dispatched once to a durable workflow (idempotent per acting caller plus the full semantic publish input, including force/overwrite flags) and this capability returns status dispatched with a workflow_id to poll via workflow_run_list instead of hanging until an opaque execute timeout.',
 		keywords: ['package', 'publish', 'git', 'artifacts', 'external', 'push'],
 		readOnly: false,
 		idempotent: true,
@@ -538,12 +556,17 @@ export const publishExternalPushCapability = defineDomainCapability(
 				destructiveOverwriteConfirmed: args.confirm_destructive_overwrite,
 			}
 
-			// Durable workflow re-entry uses executionOrigin "background" and must
-			// not escalate again (avoids recursive workflow creation).
-			if (ctx.callerContext.executionOrigin === 'background') {
+			if (!shouldEscalateExternalPublish(ctx.callerContext.executionOrigin)) {
 				return await runExternalPublishAttempt(publishInput)
 			}
 
+			const semanticInput = {
+				ownerUserId: owner.ownerUserId,
+				packageId,
+				newCommit,
+				allowForce: args.allow_force,
+				destructiveOverwriteConfirmed: args.confirm_destructive_overwrite,
+			} satisfies ExternalPublishSemanticInput
 			const durableParams = {
 				...(args.package_id ? { package_id: args.package_id } : {}),
 				...(args.kody_id ? { kody_id: args.kody_id } : {}),
@@ -556,11 +579,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 				userId: user.userId,
 				userEmail: user.email,
 				budgetMs: defaultDurableEscalationBudgetMs,
-				idempotencyParts: buildExternalPublishIdempotencyParts({
-					ownerUserId: owner.ownerUserId,
-					packageId,
-					newCommit,
-				}),
+				idempotencyParts: buildExternalPublishIdempotencyParts(semanticInput),
 				workflowName: 'package_publish_external_push',
 				packageContext: {
 					packageId,

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -1,0 +1,84 @@
+import { expect, test, vi } from 'vitest'
+import { publishedPackageArtifactRebuildConcurrency } from './package-artifact-rebuild.ts'
+
+const mockModule = vi.hoisted(() => ({
+	listPublishedPackageArtifactTargets: vi.fn(),
+	rebuildPublishedPackageArtifact: vi.fn(),
+}))
+
+vi.mock('#worker/repo/repo-session-do.ts', () => ({
+	repoSessionRpc: () => ({
+		listPublishedPackageArtifactTargets: (...args: Array<unknown>) =>
+			mockModule.listPublishedPackageArtifactTargets(...args),
+		rebuildPublishedPackageArtifact: (...args: Array<unknown>) =>
+			mockModule.rebuildPublishedPackageArtifact(...args),
+	}),
+}))
+
+const { rebuildPublishedPackageArtifactsViaRepoSession } =
+	await import('./package-artifact-rebuild.ts')
+
+test('rebuildPublishedPackageArtifactsViaRepoSession pipelines targets with bounded concurrency', async () => {
+	expect(publishedPackageArtifactRebuildConcurrency).toBe(2)
+
+	const targets = [
+		{
+			kind: 'module' as const,
+			artifactName: '.',
+			entryPoint: 'src/a.ts',
+			bundleKind: 'module' as const,
+		},
+		{
+			kind: 'module' as const,
+			artifactName: './b',
+			entryPoint: 'src/b.ts',
+			bundleKind: 'module' as const,
+		},
+		{
+			kind: 'module' as const,
+			artifactName: './c',
+			entryPoint: 'src/c.ts',
+			bundleKind: 'module' as const,
+		},
+	]
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
+
+	let inFlight = 0
+	let maxInFlight = 0
+	const releaseGates: Array<() => void> = []
+	mockModule.rebuildPublishedPackageArtifact.mockImplementation(async () => {
+		inFlight += 1
+		maxInFlight = Math.max(maxInFlight, inFlight)
+		await new Promise<void>((resolve) => {
+			releaseGates.push(() => {
+				inFlight -= 1
+				resolve()
+			})
+		})
+		return { ok: true }
+	})
+
+	const rebuildPromise = rebuildPublishedPackageArtifactsViaRepoSession({
+		env: {} as Env,
+		rpcSessionId: 'session-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		baseUrl: 'https://kody.test',
+	})
+
+	await vi.waitFor(() => {
+		expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
+	})
+	expect(maxInFlight).toBe(2)
+
+	releaseGates.splice(0).forEach((release) => release())
+	await vi.waitFor(() => {
+		expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(3)
+	})
+	releaseGates.splice(0).forEach((release) => release())
+	await rebuildPromise
+
+	expect(maxInFlight).toBe(2)
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(3)
+})

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -82,3 +82,68 @@ test('rebuildPublishedPackageArtifactsViaRepoSession pipelines targets with boun
 	expect(maxInFlight).toBe(2)
 	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(3)
 })
+
+test('rebuild failure stops later chunks and reports succeeded versus failed targets', async () => {
+	const targets = [
+		{
+			kind: 'module' as const,
+			artifactName: '.',
+			entryPoint: 'src/a.ts',
+			bundleKind: 'module' as const,
+		},
+		{
+			kind: 'module' as const,
+			artifactName: './b',
+			entryPoint: 'src/b.ts',
+			bundleKind: 'module' as const,
+		},
+		{
+			kind: 'module' as const,
+			artifactName: './c',
+			entryPoint: 'src/c.ts',
+			bundleKind: 'module' as const,
+		},
+		{
+			kind: 'module' as const,
+			artifactName: './d',
+			entryPoint: 'src/d.ts',
+			bundleKind: 'module' as const,
+		},
+	]
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
+	mockModule.rebuildPublishedPackageArtifact.mockImplementation(
+		async (input: { target: (typeof targets)[number] }) => {
+			if (input.target.artifactName === './b') {
+				throw new Error('bundle b failed')
+			}
+			return { ok: true, target: input.target, kvKey: 'bundle-key' }
+		},
+	)
+
+	await expect(
+		rebuildPublishedPackageArtifactsViaRepoSession({
+			env: {} as Env,
+			rpcSessionId: 'session-1',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-1',
+			baseUrl: 'https://kody.test',
+		}),
+	).rejects.toThrow(
+		/Succeeded: \{ kind "module", artifact "\.", entry "src\/a\.ts", bundle "module" \}\. Failed: \{ kind "module", artifact "\.\/b", entry "src\/b\.ts", bundle "module" \}: bundle b failed/,
+	)
+
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledWith(
+		expect.objectContaining({ target: targets[0] }),
+	)
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledWith(
+		expect.objectContaining({ target: targets[1] }),
+	)
+	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalledWith(
+		expect.objectContaining({ target: targets[2] }),
+	)
+	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalledWith(
+		expect.objectContaining({ target: targets[3] }),
+	)
+})

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -25,13 +25,35 @@ function describePackageArtifactTarget(
 function buildRebuildFailureMessage(input: {
 	sourceId: string
 	publishedCommit: string
-	target?: PublishedPackageArtifactBuildTarget
-	error: unknown
+	succeeded: ReadonlyArray<PublishedPackageArtifactBuildTarget>
+	failed: ReadonlyArray<{
+		target: PublishedPackageArtifactBuildTarget
+		error: unknown
+	}>
+	error?: unknown
 }) {
-	const target = input.target
-		? ` target { ${describePackageArtifactTarget(input.target)} }`
-		: ''
-	return `Package source publish succeeded, but bundle artifact rebuild failed for source "${input.sourceId}" at commit "${input.publishedCommit}"${target}. Cause: ${formatErrorCauseChain(input.error)}. Re-run the publish capability to repair artifacts.`
+	const succeededSummary =
+		input.succeeded.length === 0
+			? 'none'
+			: input.succeeded
+					.map((target) => `{ ${describePackageArtifactTarget(target)} }`)
+					.join(', ')
+	const failedSummary =
+		input.failed.length === 0
+			? input.error
+				? formatErrorCauseChain(input.error)
+				: 'unknown'
+			: input.failed
+					.map(
+						({ target, error }) =>
+							`{ ${describePackageArtifactTarget(target)} }: ${formatErrorCauseChain(error)}`,
+					)
+					.join('; ')
+	// Partial artifact writes were already possible with sequential rebuilds
+	// (earlier targets stay written when a later one fails). Bounded concurrency
+	// only widens that to the in-flight peer in the current chunk; later chunks
+	// are not scheduled after a failure.
+	return `Package source publish succeeded, but bundle artifact rebuild failed for source "${input.sourceId}" at commit "${input.publishedCommit}". Succeeded: ${succeededSummary}. Failed: ${failedSummary}. Re-run the publish capability to repair artifacts.`
 }
 
 export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
@@ -56,15 +78,26 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 			buildRebuildFailureMessage({
 				sourceId: input.sourceId,
 				publishedCommit: input.publishedCommit,
+				succeeded: [],
+				failed: [],
 				error,
 			}),
 			{ cause: error },
 		)
 	}
+
+	const succeeded: Array<PublishedPackageArtifactBuildTarget> = []
+	const failed: Array<{
+		target: PublishedPackageArtifactBuildTarget
+		error: unknown
+	}> = []
+
 	for (const targetChunk of chunkArray(
 		targets,
 		publishedPackageArtifactRebuildConcurrency,
 	)) {
+		if (failed.length > 0) break
+
 		const settled = await Promise.allSettled(
 			targetChunk.map(async (target) => {
 				await session.rebuildPublishedPackageArtifact({
@@ -75,20 +108,30 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 					target,
 					baseUrl: input.baseUrl,
 				})
+				return target
 			}),
 		)
+
 		for (const [index, result] of settled.entries()) {
-			if (result.status === 'fulfilled') continue
 			const target = targetChunk[index]
-			throw new Error(
-				buildRebuildFailureMessage({
-					sourceId: input.sourceId,
-					publishedCommit: input.publishedCommit,
-					target,
-					error: result.reason,
-				}),
-				{ cause: result.reason },
-			)
+			if (!target) continue
+			if (result.status === 'fulfilled') {
+				succeeded.push(target)
+				continue
+			}
+			failed.push({ target, error: result.reason })
 		}
 	}
+
+	if (failed.length === 0) return
+
+	throw new Error(
+		buildRebuildFailureMessage({
+			sourceId: input.sourceId,
+			publishedCommit: input.publishedCommit,
+			succeeded,
+			failed,
+		}),
+		{ cause: failed[0]?.error },
+	)
 }

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -1,6 +1,15 @@
-import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
-import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/package-artifact-targets.ts'
+import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { formatErrorCauseChain } from '@kody-internal/shared/error-message.ts'
+import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/package-artifact-targets.ts'
+import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+
+/**
+ * Same-session rebuild RPCs hit one Durable Object, which serializes
+ * execution. Depth 2 pipelines the next RPC while the DO finishes the current
+ * one (cuts inter-call worker round-trip idle time) without flooding the DO
+ * input gate the way unbounded Promise.all would.
+ */
+export const publishedPackageArtifactRebuildConcurrency = 2
 
 function describePackageArtifactTarget(
 	target: PublishedPackageArtifactBuildTarget,
@@ -52,25 +61,33 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 			{ cause: error },
 		)
 	}
-	for (const target of targets) {
-		try {
-			await session.rebuildPublishedPackageArtifact({
-				sessionId: input.repoSessionId,
-				sourceId: input.sourceId,
-				userId: input.userId,
-				publishedCommit: input.publishedCommit,
-				target,
-				baseUrl: input.baseUrl,
-			})
-		} catch (error) {
+	for (const targetChunk of chunkArray(
+		targets,
+		publishedPackageArtifactRebuildConcurrency,
+	)) {
+		const settled = await Promise.allSettled(
+			targetChunk.map(async (target) => {
+				await session.rebuildPublishedPackageArtifact({
+					sessionId: input.repoSessionId,
+					sourceId: input.sourceId,
+					userId: input.userId,
+					publishedCommit: input.publishedCommit,
+					target,
+					baseUrl: input.baseUrl,
+				})
+			}),
+		)
+		for (const [index, result] of settled.entries()) {
+			if (result.status === 'fulfilled') continue
+			const target = targetChunk[index]
 			throw new Error(
 				buildRebuildFailureMessage({
 					sourceId: input.sourceId,
 					publishedCommit: input.publishedCommit,
 					target,
-					error,
+					error: result.reason,
 				}),
-				{ cause: error },
+				{ cause: result.reason },
 			)
 		}
 	}

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -1,5 +1,20 @@
 import { expect, test, vi } from 'vitest'
 
+const gitMocks = vi.hoisted(() => ({
+	listServerRefs: vi.fn(),
+}))
+
+vi.mock('isomorphic-git', () => ({
+	default: {
+		listServerRefs: (...args: Array<unknown>) =>
+			gitMocks.listServerRefs(...args),
+	},
+}))
+
+vi.mock('isomorphic-git/http/web', () => ({
+	default: {},
+}))
+
 const {
 	buildArtifactsGitAuth,
 	buildAuthenticatedArtifactsRemote,
@@ -7,6 +22,7 @@ const {
 	getArtifactsBinding,
 	getArtifactsNamespace,
 	parseArtifactTokenSecret,
+	resolveArtifactDefaultBranchHead,
 	resolveArtifactSourceHead,
 	resolveArtifactSourceRepo,
 	resolveExistingArtifactSourceRepo,
@@ -440,4 +456,65 @@ test('artifacts REST client error paths and missing source repos', async () => {
 		/parseable expires timestamp/,
 	)
 	expect(invalidTokenFetch).toHaveBeenCalledTimes(1)
+})
+
+test('resolveArtifactDefaultBranchHead reuses a provided token and still works without one', async () => {
+	gitMocks.listServerRefs.mockReset()
+	gitMocks.listServerRefs.mockResolvedValue([
+		{ ref: 'refs/heads/main', oid: 'abc123' },
+	])
+	const createToken = vi.fn(async () => ({
+		id: 'tok_read',
+		plaintext: 'art_v1_throwaway',
+		scope: 'read',
+		expiresAt: '2026-10-09T08:55:00.000Z',
+	}))
+	const info = vi.fn(async () => ({
+		id: 'repo_1',
+		name: 'repo-1',
+		description: null,
+		defaultBranch: 'main',
+		createdAt: '2026-04-17T00:00:00.000Z',
+		updatedAt: '2026-04-17T00:00:00.000Z',
+		lastPushAt: null,
+		source: null,
+		readOnly: false,
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+	}))
+	const repo = { info, createToken }
+
+	await expect(resolveArtifactDefaultBranchHead({ repo })).resolves.toEqual({
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+		defaultBranch: 'main',
+		commit: 'abc123',
+	})
+	expect(createToken).toHaveBeenCalledTimes(1)
+	expect(createToken).toHaveBeenCalledWith('read', 300)
+	expect(gitMocks.listServerRefs).toHaveBeenCalledWith(
+		expect.objectContaining({
+			url: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+			prefix: 'refs/heads/main',
+		}),
+	)
+
+	createToken.mockClear()
+	info.mockClear()
+	gitMocks.listServerRefs.mockClear()
+	gitMocks.listServerRefs.mockResolvedValue([
+		{ ref: 'refs/heads/main', oid: 'abc123' },
+	])
+	await expect(
+		resolveArtifactDefaultBranchHead({
+			repo,
+			token: 'art_v1_reused_write',
+			info: await info(),
+		}),
+	).resolves.toEqual({
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+		defaultBranch: 'main',
+		commit: 'abc123',
+	})
+	expect(createToken).not.toHaveBeenCalled()
+	expect(info).toHaveBeenCalledTimes(1)
+	expect(gitMocks.listServerRefs).toHaveBeenCalledTimes(1)
 })

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -522,16 +522,22 @@ export async function listArtifactServerRefs(input: {
 
 export async function resolveArtifactDefaultBranchHead(input: {
 	repo: ArtifactRepoHandle
+	token?: string
+	info?: ArtifactRepoInfo | null
 }) {
-	const info = await input.repo.info()
+	const [info, tokenPlaintext] = await Promise.all([
+		input.info === undefined ? input.repo.info() : Promise.resolve(input.info),
+		input.token !== undefined
+			? Promise.resolve(input.token)
+			: input.repo.createToken('read', 300).then((token) => token.plaintext),
+	])
 	if (!info?.remote) {
 		throw new Error('Artifact repo remote URL is unavailable.')
 	}
-	const token = await input.repo.createToken('read', 300)
 	const refName = `refs/heads/${info.defaultBranch || 'main'}`
 	const refs = await listArtifactServerRefs({
 		remote: info.remote,
-		token: token.plaintext,
+		token: tokenPlaintext,
 		prefix: refName,
 	})
 	const branchRef = refs.find((ref) => ref.ref === refName)

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -184,7 +184,9 @@ test('returns no-op when commit is already current', async () => {
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 
 	// Re-invoking after a partial/timed-out publish whose D1 published_commit
-	// already matches the pushed HEAD must stay a no-op (safe durable retry).
+	// already matches the pushed HEAD must stay a no-op. This is what makes
+	// overlapping inline + durable escalation safe: the second attempt cannot
+	// double-apply checks or D1 writes.
 	await expect(
 		publishFromExternalRef({
 			env: { APP_DB: {} } as Env,

--- a/packages/worker/src/repo/external-publish.node.test.ts
+++ b/packages/worker/src/repo/external-publish.node.test.ts
@@ -182,6 +182,28 @@ test('returns no-op when commit is already current', async () => {
 	})
 	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+
+	// Re-invoking after a partial/timed-out publish whose D1 published_commit
+	// already matches the pushed HEAD must stay a no-op (safe durable retry).
+	await expect(
+		publishFromExternalRef({
+			env: { APP_DB: {} } as Env,
+			sourceId: 'source-1',
+			userId: 'user-1',
+			newCommit: 'commit-old',
+			isFastForward: async () => {
+				throw new Error('must not check ancestry when already published')
+			},
+			workspace: workspace(),
+			files: {},
+			baseUrl: 'https://kody.test',
+		}),
+	).resolves.toEqual({
+		status: 'already_published',
+		published_commit: 'commit-old',
+	})
+	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 })
 
 test('non-fast-forward publish requires allowForce, destructive confirmation, and a restorable backup snapshot', async () => {

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1295,11 +1295,9 @@ test('readFile retries D1 reads and falls back to cached sessions when replicas 
 
 test('publishFromExternalRef rejects stale expected HEAD values', async () => {
 	setCommonSessionFixtures()
-	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValueOnce({
-		defaultBranch: 'main',
-		commit: 'commit-new',
-		remote: 'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
-	})
+	// Clone tip (git.log depth 1) is the remote default-branch HEAD at clone
+	// time; a mismatch with expectedHead means the Artifacts tip moved.
+	mockModule.gitState.headCommit = 'commit-new'
 
 	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
 
@@ -1314,6 +1312,7 @@ test('publishFromExternalRef rejects stale expected HEAD values', async () => {
 	).rejects.toThrow(
 		'Artifacts HEAD changed from "commit-stale" to "commit-new" before publish.',
 	)
+	expect(mockModule.resolveArtifactDefaultBranchHead).not.toHaveBeenCalled()
 })
 
 test('publishFromExternalRef checks fast-forward ancestry through shell git adapter', async () => {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -21,7 +21,6 @@ import {
 	type ArtifactRepoInfo,
 	buildArtifactsGitAuth,
 	buildAuthenticatedArtifactsRemote,
-	resolveArtifactDefaultBranchHead,
 	resolveExistingArtifactSourceRepo,
 	resolveArtifactSourceRepo,
 } from './artifacts.ts'
@@ -1945,16 +1944,6 @@ class RepoSessionBase extends DurableObject<Env> {
 			scope: 'read',
 		})
 		const targetBranch = sourceInfo?.defaultBranch ?? defaultSessionBranch
-		if (input.expectedHead) {
-			const currentHead = await resolveArtifactDefaultBranchHead({
-				repo: sourceRepo,
-			})
-			if (currentHead?.commit !== input.expectedHead) {
-				throw new Error(
-					`Artifacts HEAD changed from "${input.expectedHead}" to "${currentHead?.commit ?? 'unknown'}" before publish.`,
-				)
-			}
-		}
 		await this.resetWorkspace()
 		await this.workspace.mkdir(repoSessionWorkspacePrefix, {
 			recursive: true,
@@ -1969,6 +1958,17 @@ class RepoSessionBase extends DurableObject<Env> {
 					token: sourceAccess.token,
 				}),
 			})
+			// Race protection without a second Artifacts REST HEAD resolve: the
+			// single-branch clone tip is the remote default-branch HEAD at clone
+			// time. Compare it to the worker-resolved expectedHead before checkout.
+			if (input.expectedHead) {
+				const clonedHead = await this.getHeadCommit()
+				if (clonedHead !== input.expectedHead) {
+					throw new Error(
+						`Artifacts HEAD changed from "${input.expectedHead}" to "${clonedHead ?? 'unknown'}" before publish.`,
+					)
+				}
+			}
 			await this.git.checkout({
 				dir: repoSessionWorkspacePrefix,
 				ref: input.newCommit,
@@ -1976,6 +1976,9 @@ class RepoSessionBase extends DurableObject<Env> {
 			})
 		} catch (error) {
 			const message = getErrorMessage(error)
+			if (message.includes('Artifacts HEAD changed from')) {
+				throw error
+			}
 			throw new Error(
 				buildSourceRecoveryProblemMessage({
 					source,

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -7,6 +7,7 @@ import {
 } from '#worker/package-registry/package-private.ts'
 import {
 	type ArtifactRepoHandle,
+	type ArtifactToken,
 	resolveArtifactDefaultBranchHead,
 	resolveExistingArtifactSourceRepo,
 } from './artifacts.ts'
@@ -144,6 +145,10 @@ export async function assertPublishedPackageSourceRepoHead(input: {
 	source: EntitySourceRow
 	operation: string
 	requirePublishedCommitHead?: boolean
+	accessToken?: {
+		scope: 'read' | 'write'
+		ttlSeconds: number
+	}
 }): Promise<{
 	sourceId: string
 	publishedCommit: string
@@ -151,6 +156,7 @@ export async function assertPublishedPackageSourceRepoHead(input: {
 	defaultBranch: string
 	remote: string
 	repo: ArtifactRepoHandle
+	accessToken: ArtifactToken | null
 } | null> {
 	if (input.source.entity_kind !== 'package') {
 		return null
@@ -191,8 +197,22 @@ export async function assertPublishedPackageSourceRepoHead(input: {
 		)
 	}
 	let head: Awaited<ReturnType<typeof resolveArtifactDefaultBranchHead>>
+	let accessToken: ArtifactToken | null = null
 	try {
-		head = await resolveArtifactDefaultBranchHead({ repo })
+		if (input.accessToken) {
+			const [info, minted] = await Promise.all([
+				repo.info(),
+				repo.createToken(input.accessToken.scope, input.accessToken.ttlSeconds),
+			])
+			accessToken = minted
+			head = await resolveArtifactDefaultBranchHead({
+				repo,
+				token: minted.plaintext,
+				info,
+			})
+		} else {
+			head = await resolveArtifactDefaultBranchHead({ repo })
+		}
 	} catch (error) {
 		const message = getErrorMessage(error)
 		throw new Error(
@@ -232,6 +252,7 @@ export async function assertPublishedPackageSourceRepoHead(input: {
 		defaultBranch: head.defaultBranch,
 		remote: head.remote,
 		repo,
+		accessToken,
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finishes the reliability work started in the `@kentcdodds/github` package. That fixed slow merges; this fixes the two Kody capabilities that hit the same wall, which a package cannot fix from outside.

## The problem

`package_publish_external_push` blocks the `execute` request until an entire publish pipeline finishes. When it exceeds execute's ~90s cap, the agent gets an opaque timeout with **no idea whether the publish applied**. This bit two separate agents in one session, and the same ceiling hit `package_get_git_remote`.

Measured cost structure before designing anything:

- One large DO RPC does a git clone plus `runRepoChecks`, which materializes the whole source tree (up to 2000 files / 15 MiB), runs esbuild per manifest entrypoint, a TypeScript typecheck, and a lint pass. That is the CPU-heavy part and what trips DO memory/CPU resets.
- Then `1 + T` **sequential** DO RPCs rebuild artifacts, each re-walking the workspace and re-bundling its target.
- A transient-reset retry loop could multiply the whole thing up to **3×**.

So unlike the merge case, this is not an external service stalling — it is genuinely heavy work that sometimes does not fit in a request.

## The fix

**A reusable helper, not a one-off.** `runWithDurableEscalation` attempts the work inline within a bounded budget (default 55s, inside the ~90s cap) and, if the budget runs out, dispatches the same work as a durable Cloudflare Workflow and returns a handle. It never throws — a helper whose job is preventing opaque failures must not produce them. There was no shared "run this durably" helper before; every long path wired it ad hoc, which is why this kept recurring.

**The synchronous contract is preserved.** This mattered more than the timeout fix. Agents depend on the rich synchronous result — `checks_failed` detail, `not_fast_forward`, static dependents, pending secret approvals. Making publish async-by-default would have been a real UX regression, so escalation happens *only* on budget exhaustion. Ineligible publishes complete inline and never dispatch.

**Escalation is only sound because re-invoking publish is safe**, and that was verified rather than assumed: `publishFromExternalRef` short-circuits to `already_published` when `published_commit` already equals the pushed head, doing no checks and no D1 write. Durable re-entry runs with `executionOrigin: 'background'` so it cannot escalate recursively.

**Retries respect the budget.** The existing transient-DO-reset loop now honors the abort signal, so it can no longer quietly blow past the ceiling.

## Reducing how often escalation is needed

Artifact rebuilds now run with **bounded concurrency of 2** rather than fully sequentially. Depth 2 rather than unbounded is deliberate: these RPCs all target one Durable Object, which serializes requests, so flooding the input gate would add memory pressure without adding throughput. Depth 2 pipelines the next call while the current one finishes.

Duplicate Artifacts round trips are gone in both capabilities. `package_get_git_remote` was minting **two** tokens per call — one thrown away just to resolve HEAD — and now mints one and reuses it. The publish path no longer re-resolves HEAD over REST before cloning; it compares `expectedHead` against the clone tip instead, keeping the race protection that parameter exists for.

## Deliberate follow-up

**Double bundling remains.** `runRepoChecks` bundles every entrypoint, then artifact rebuild bundles every target again — the tree is read twice and each target built twice per publish. It is the largest remaining win and the reason publishes are slow at all, but it is invasive enough to deserve its own change rather than riding along here.

Also left alone: `package_get_git_remote`'s `create: true` path runs a full stub bootstrap plus artifact rebuild just to mint a remote. Over-scoped, but changing it is a behavioral change.

## Verification

`npm run validate` green: 1402 tests across 430 files, Playwright E2E, MCP E2E, `primitives:check`, `migrations:check`.

Tests cover the cases that matter: inline success returns the full synchronous result unchanged, budget exhaustion escalates exactly once, a repeat call with the same idempotency key reuses the existing run instead of stacking a second, ineligible publishes do not escalate, re-invoking an already-published head is safe, the helper never throws, and `get-git-remote` mints fewer tokens while its write-scope backup gate still blocks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - External package publishes now switch to durable background processing when the inline time limit is exceeded, returning a `dispatched` status with workflow identifiers and polling guidance.
  - Publishing is more resilient to retries and long-running operations via caller-scoped idempotency and structured outcomes.
  - Published package artifact rebuilds run with bounded concurrency for faster throughput.
- **Bug Fixes**
  - Improved validation around idempotency inputs, repository head changes, backup snapshot availability, and access-token requirements to prevent incorrect or duplicate work.
- **Tests**
  - Expanded coverage for durable escalation behavior, dispatch/re-entry flows, and concurrency limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->