### PR TITLE
fix(remote-connector): stop treating D1 secret-read blips as invalid-secret

### DIFF
--- a/packages/worker/src/remote-connector/resolve-remote-connector-secret.node.test.ts
+++ b/packages/worker/src/remote-connector/resolve-remote-connector-secret.node.test.ts
@@ -1,18 +1,30 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
+import {
+	d1LockRetryBaseDelayMs,
+	d1LockRetryMaxAttempts,
+} from '#worker/d1-retry.ts'
 import {
 	hasRemoteConnectorSharedSecret,
 	remoteConnectorSharedSecretMatches,
 	resolveRemoteConnectorSharedSecret,
 } from './resolve-remote-connector-secret.ts'
 
-function createEmptyRemoteConnectorSettingsDb() {
+function createRemoteConnectorSettingsDb(input: {
+	all: () => Promise<{ results: Array<Record<string, unknown>> }>
+}) {
 	return {
 		prepare: () => ({
 			bind: () => ({
-				all: async () => ({ results: [], meta: { changes: 0 } }),
+				all: input.all,
 			}),
 		}),
 	} as unknown as D1Database
+}
+
+function createEmptyRemoteConnectorSettingsDb() {
+	return createRemoteConnectorSettingsDb({
+		all: async () => ({ results: [] }),
+	})
 }
 
 test('remote connector shared secrets are not read from environment variables', async () => {
@@ -47,4 +59,91 @@ test('remote connector shared secrets are not read from environment variables', 
 			instanceId: 'home',
 		}),
 	).resolves.toBe(false)
+})
+
+test('remote connector shared-secret reads retry transient D1 locks then succeed', async () => {
+	const all = vi
+		.fn()
+		.mockRejectedValueOnce(
+			new Error('D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY'),
+		)
+		.mockResolvedValueOnce({ results: [] })
+	const env = {
+		APP_DB: createRemoteConnectorSettingsDb({ all }),
+		SECRET_STORE_KEY: 'x'.repeat(32),
+	} as Env
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = remoteConnectorSharedSecretMatches({
+			env,
+			userId: 'user-aaa',
+			instanceId: 'home',
+			sharedSecret: 'home-secret',
+		})
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toBe(false)
+		expect(all).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+})
+
+test('remote connector shared-secret reads propagate non-retryable D1 failures', async () => {
+	const all = vi
+		.fn()
+		.mockRejectedValue(new Error('D1_ERROR: syntax error near SELECT'))
+	const env = {
+		APP_DB: createRemoteConnectorSettingsDb({ all }),
+		SECRET_STORE_KEY: 'x'.repeat(32),
+	} as Env
+
+	await expect(
+		remoteConnectorSharedSecretMatches({
+			env,
+			userId: 'user-aaa',
+			instanceId: 'home',
+			sharedSecret: 'home-secret',
+		}),
+	).rejects.toThrow('syntax error')
+	await expect(
+		hasRemoteConnectorSharedSecret({
+			env,
+			userId: 'user-aaa',
+			instanceId: 'home',
+		}),
+	).rejects.toThrow('syntax error')
+	expect(all).toHaveBeenCalledTimes(2)
+})
+
+test('remote connector shared-secret reads exhaust retryable D1 failures instead of returning empty', async () => {
+	const all = vi
+		.fn()
+		.mockRejectedValue(new Error('D1_ERROR: Network connection lost.'))
+	const env = {
+		APP_DB: createRemoteConnectorSettingsDb({ all }),
+		SECRET_STORE_KEY: 'x'.repeat(32),
+	} as Env
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = remoteConnectorSharedSecretMatches({
+			env,
+			userId: 'user-aaa',
+			instanceId: 'home',
+			sharedSecret: 'home-secret',
+		})
+		const rejection = expect(resultPromise).rejects.toThrow(
+			'Network connection lost',
+		)
+		for (let attempt = 1; attempt < d1LockRetryMaxAttempts; attempt += 1) {
+			await vi.advanceTimersByTimeAsync(
+				d1LockRetryBaseDelayMs * 2 ** (attempt - 1),
+			)
+		}
+		await rejection
+		expect(all).toHaveBeenCalledTimes(d1LockRetryMaxAttempts)
+	} finally {
+		vi.useRealTimers()
+	}
 })

--- a/packages/worker/src/remote-connector/resolve-remote-connector-secret.ts
+++ b/packages/worker/src/remote-connector/resolve-remote-connector-secret.ts
@@ -1,5 +1,4 @@
-import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
-import { normalizeRemoteConnectorInstanceId } from '@kody-internal/shared/remote-connectors.ts'
+import { runD1WithRetry } from '#worker/d1-retry.ts'
 import {
 	hasRemoteConnectorSharedSecretForRef,
 	listRemoteConnectorSharedSecretsForRef,
@@ -39,24 +38,23 @@ function timingSafeStringEquals(left: string, right: string) {
 	return isEqual && leftBytes.length === rightBytes.length
 }
 
+/**
+ * Read persisted connector shared secrets with D1 retry. Failures must
+ * propagate — swallowing them as "no secrets" made websocket hello treat
+ * transient D1 blips as invalid-secret auth rejects.
+ */
 async function listStoredSharedSecrets(input: {
 	userId: string
 	instanceId: string
 	env: Env
 }) {
-	try {
-		return await listRemoteConnectorSharedSecretsForRef({
+	return await runD1WithRetry(() =>
+		listRemoteConnectorSharedSecretsForRef({
 			env: input.env,
 			userId: input.userId,
 			instanceId: input.instanceId,
-		})
-	} catch (error) {
-		const detail = getErrorMessage(error)
-		console.error(
-			`[remote-connectors] failed to read persisted shared secrets for ${input.userId} ${normalizeRemoteConnectorInstanceId(input.instanceId)}: ${detail}`,
-		)
-		return []
-	}
+		}),
+	)
 }
 
 async function storedSharedSecretExists(input: {
@@ -64,19 +62,13 @@ async function storedSharedSecretExists(input: {
 	instanceId: string
 	env: Env
 }) {
-	try {
-		return await hasRemoteConnectorSharedSecretForRef({
+	return await runD1WithRetry(() =>
+		hasRemoteConnectorSharedSecretForRef({
 			env: input.env,
 			userId: input.userId,
 			instanceId: input.instanceId,
-		})
-	} catch (error) {
-		const detail = getErrorMessage(error)
-		console.error(
-			`[remote-connectors] failed to check persisted shared secret for ${input.userId} ${normalizeRemoteConnectorInstanceId(input.instanceId)}: ${detail}`,
-		)
-		return false
-	}
+		}),
+	)
 }
 
 export async function resolveRemoteConnectorSharedSecret(input: {

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -1,11 +1,16 @@
 import { expect, test, vi } from 'vitest'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	consoleWarn,
+	silenceExpectedConsoleWarns,
+} from '#worker/test-support/console-spies.ts'
 
 const captureMessageMock = vi.fn()
 const setTagMock = vi.fn()
 const setUserMock = vi.fn()
 const setContextMock = vi.fn()
 const setLevelMock = vi.fn()
+const remoteConnectorSharedSecretMatchesMock = vi.fn()
+const hasRemoteConnectorSharedSecretMock = vi.fn()
 
 vi.mock('@sentry/cloudflare', () => ({
 	isInitialized: () => true,
@@ -41,6 +46,14 @@ vi.mock('cloudflare:workers', () => ({
 			this.env = env
 		}
 	},
+}))
+
+vi.mock('./resolve-remote-connector-secret.ts', () => ({
+	remoteConnectorSharedSecretMatches: (
+		...args: Array<unknown>
+	): Promise<boolean> => remoteConnectorSharedSecretMatchesMock(...args),
+	hasRemoteConnectorSharedSecret: (...args: Array<unknown>): Promise<boolean> =>
+		hasRemoteConnectorSharedSecretMock(...args),
 }))
 
 const { RemoteConnectorSession } = await import('./session.ts')
@@ -105,6 +118,10 @@ async function createRemoteConnectorSession(
 	setUserMock.mockReset()
 	setContextMock.mockReset()
 	setLevelMock.mockReset()
+	remoteConnectorSharedSecretMatchesMock.mockReset()
+	hasRemoteConnectorSharedSecretMock.mockReset()
+	remoteConnectorSharedSecretMatchesMock.mockResolvedValue(false)
+	hasRemoteConnectorSharedSecretMock.mockResolvedValue(false)
 	const { state, persistedEntries } = createState(input)
 	const session = new RemoteConnectorSession(
 		{
@@ -117,6 +134,41 @@ async function createRemoteConnectorSession(
 	)
 	await waitForRestoreState(state)
 	return { session, state, persistedEntries }
+}
+
+function createHelloSocket(input: {
+	sent: Array<string>
+	closes: Array<{ code: number; reason: string }>
+	ingressUserId?: string
+}) {
+	return {
+		send: (payload: string) => {
+			input.sent.push(payload)
+		},
+		close: (code?: number, reason?: string) => {
+			input.closes.push({ code: code ?? 1005, reason: reason ?? '' })
+		},
+		// Empty ingress session key skips the mismatch gate so hello tests
+		// exercise the shared-secret path directly.
+		deserializeAttachment: () => ({
+			ingressSessionKey: '',
+			ingressUserId: input.ingressUserId ?? 'user-home-1',
+		}),
+	} as unknown as WebSocket
+}
+
+async function sendConnectorHello(
+	session: InstanceType<typeof RemoteConnectorSession>,
+	socket: WebSocket,
+) {
+	await session.webSocketMessage(
+		socket,
+		JSON.stringify({
+			type: 'connector.hello',
+			connectorId: 'home',
+			sharedSecret: 'home-secret',
+		}),
+	)
 }
 
 test('remote connector session lifecycle across restore, snapshot, heartbeat, close, and error', async () => {
@@ -458,4 +510,92 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 	).toMatchObject({
 		tools: [{ name: 'bond_shade_set_position' }],
 	})
+})
+
+test('remote connector hello rejects invalid shared secrets with Sentry auth error', async () => {
+	const sent: Array<string> = []
+	const closes: Array<{ code: number; reason: string }> = []
+	const socket = createHelloSocket({ sent, closes })
+	const { session } = await createRemoteConnectorSession({
+		webSockets: [socket],
+	})
+	remoteConnectorSharedSecretMatchesMock.mockResolvedValue(false)
+	hasRemoteConnectorSharedSecretMock.mockResolvedValue(true)
+
+	await sendConnectorHello(session, socket)
+
+	expect(captureMessageMock).toHaveBeenCalledWith(
+		'Remote connector session rejected websocket hello.',
+	)
+	expect(setLevelMock).toHaveBeenCalledWith('error')
+	expect(setContextMock).toHaveBeenCalledWith(
+		'remote_connector',
+		expect.objectContaining({
+			connectorId: 'home',
+			userId: 'user-home-1',
+			hasExpectedSecret: true,
+		}),
+	)
+	expect(JSON.parse(sent[0]!)).toMatchObject({
+		type: 'server.error',
+		message: 'Invalid connector shared secret.',
+	})
+	expect(closes).toEqual([{ code: 4001, reason: 'invalid-secret' }])
+})
+
+test('remote connector hello soft-fails transient D1 shared-secret lookup without Sentry auth noise', async () => {
+	silenceExpectedConsoleWarns([
+		/Remote connector shared-secret lookup failed during websocket hello \(transient D1\)/,
+	])
+	const sent: Array<string> = []
+	const closes: Array<{ code: number; reason: string }> = []
+	const socket = createHelloSocket({ sent, closes })
+	const { session } = await createRemoteConnectorSession({
+		webSockets: [socket],
+	})
+	remoteConnectorSharedSecretMatchesMock.mockRejectedValue(
+		new Error('D1_ERROR: Network connection lost.'),
+	)
+
+	await sendConnectorHello(session, socket)
+
+	expect(captureMessageMock).not.toHaveBeenCalled()
+	expect(consoleWarn).toHaveBeenCalled()
+	expect(JSON.parse(sent[0]!)).toMatchObject({
+		type: 'server.error',
+		message: 'Connector authentication temporarily unavailable. Retry shortly.',
+	})
+	expect(closes).toEqual([{ code: 1013, reason: 'secret-lookup-retry' }])
+})
+
+test('remote connector hello reports non-retryable shared-secret lookup failures distinctly', async () => {
+	const sent: Array<string> = []
+	const closes: Array<{ code: number; reason: string }> = []
+	const socket = createHelloSocket({ sent, closes })
+	const { session } = await createRemoteConnectorSession({
+		webSockets: [socket],
+	})
+	remoteConnectorSharedSecretMatchesMock.mockRejectedValue(
+		new Error('D1_ERROR: syntax error near SELECT'),
+	)
+
+	await sendConnectorHello(session, socket)
+
+	expect(captureMessageMock).toHaveBeenCalledWith(
+		'Remote connector session failed shared-secret lookup for websocket hello.',
+	)
+	expect(setLevelMock).toHaveBeenCalledWith('error')
+	expect(setContextMock).toHaveBeenCalledWith(
+		'remote_connector',
+		expect.objectContaining({
+			connectorId: 'home',
+			userId: 'user-home-1',
+			error: 'D1_ERROR: syntax error near SELECT',
+		}),
+	)
+	expect(JSON.parse(sent[0]!)).toMatchObject({
+		type: 'server.error',
+		message: 'Connector authentication temporarily unavailable. Retry shortly.',
+	})
+	expect(closes).toEqual([{ code: 1011, reason: 'secret-lookup-failed' }])
 })

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/cloudflare'
 import { DurableObject } from 'cloudflare:workers'
 import { type JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
 import { normalizeRemoteConnectorInstanceId } from '@kody-internal/shared/remote-connectors.ts'
+import { isRetryableD1LockError } from '#worker/d1-retry.ts'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
 import {
 	type RemoteConnectorHelloMessage,
@@ -433,6 +434,51 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		}
 	}
 
+	private rejectHelloSharedSecretLookupFailure(input: {
+		ws: WebSocket
+		connectorId: string
+		userId: string
+		error: unknown
+	}) {
+		const detail = getErrorMessage(input.error)
+		if (isRetryableD1LockError(input.error)) {
+			// Same class as other D1 blips already dropped from Sentry: keep an
+			// ops warn, ask the connector to reconnect, and do not report a
+			// false "invalid shared secret" auth failure.
+			console.warn(
+				`Remote connector shared-secret lookup failed during websocket hello (transient D1). connectorId=${input.connectorId} error=${detail}`,
+			)
+			input.ws.send(
+				stringifyRemoteConnectorMessage({
+					type: 'server.error',
+					message:
+						'Connector authentication temporarily unavailable. Retry shortly.',
+				}),
+			)
+			input.ws.close(1013, 'secret-lookup-retry')
+			return
+		}
+		this.captureSessionMessage(
+			'Remote connector session failed shared-secret lookup for websocket hello.',
+			{
+				level: 'error',
+				userId: input.userId,
+				extra: {
+					connectorId: input.connectorId,
+					error: detail,
+				},
+			},
+		)
+		input.ws.send(
+			stringifyRemoteConnectorMessage({
+				type: 'server.error',
+				message:
+					'Connector authentication temporarily unavailable. Retry shortly.',
+			}),
+		)
+		input.ws.close(1011, 'secret-lookup-failed')
+	}
+
 	private async handleHello(
 		ws: WebSocket,
 		message: RemoteConnectorHelloMessage,
@@ -491,18 +537,40 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			return
 		}
 
-		const secretMatches = await remoteConnectorSharedSecretMatches({
-			userId: ingressUserId,
-			instanceId: canonicalInstanceId,
-			sharedSecret: message.sharedSecret,
-			env: this.env,
-		})
-		if (!secretMatches) {
-			const hasExpectedSecret = await hasRemoteConnectorSharedSecret({
+		let secretMatches: boolean
+		try {
+			secretMatches = await remoteConnectorSharedSecretMatches({
 				userId: ingressUserId,
 				instanceId: canonicalInstanceId,
+				sharedSecret: message.sharedSecret,
 				env: this.env,
 			})
+		} catch (error) {
+			this.rejectHelloSharedSecretLookupFailure({
+				ws,
+				connectorId: canonicalInstanceId,
+				userId: ingressUserId,
+				error,
+			})
+			return
+		}
+		if (!secretMatches) {
+			let hasExpectedSecret: boolean
+			try {
+				hasExpectedSecret = await hasRemoteConnectorSharedSecret({
+					userId: ingressUserId,
+					instanceId: canonicalInstanceId,
+					env: this.env,
+				})
+			} catch (error) {
+				this.rejectHelloSharedSecretLookupFailure({
+					ws,
+					connectorId: canonicalInstanceId,
+					userId: ingressUserId,
+					error,
+				})
+				return
+			}
 			this.captureSessionMessage(
 				'Remote connector session rejected websocket hello.',
 				{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [7635145201](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7635145201/) (`Remote connector session rejected websocket hello.`) fired once in production for connector `home` with `hasExpectedSecret: false`, then the same connector reconnected successfully ~9s later with the same configured secret.

Root cause: shared-secret lookup failures were swallowed as “no secrets”, so transient D1 blips during reconnect were reported as `invalid-secret` auth rejects and opened a misleading Sentry auth error.

## Fix

- Retry transient D1 reads when loading connector shared secrets.
- Propagate exhausted / non-retryable lookup failures instead of returning empty.
- On hello, treat lookup failures as temporary auth unavailability (`1013` / `1011`) rather than `4001 invalid-secret`.
- Keep the existing Sentry auth error only for genuine secret mismatches after a successful read.

## Test plan

- [x] Unit tests for secret-read retry / propagation
- [x] Session hello tests for invalid secret, transient D1 soft-fail (no Sentry), and non-retryable lookup Sentry path
- [x] Pre-push hooks (including Playwright e2e) passed on commit

Refs Sentry issue 7635145201.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `9ab2e572` · **Head:** `58143311`

**Classification:** extends — changes remote-connector websocket hello failure handling when shared-secret lookup hits D1 unavailability (no longer maps storage blips to invalid-secret).

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `connector-ingress` | surfaces | extends — hello auth distinguishes secret mismatch from secret-lookup failure |
| `remote-connectors` | assistant | extends — shared-secret reads retry D1 and propagate failures |

### System map

_Hello shared-secret auth retries D1; lookup failures reconnect instead of false invalid-secret._

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff

  hello["connector hello"]:::untouched
  ingress["connector-ingress<br/>Remote connector ingress"]:::extended
  connectors["remote-connectors<br/>Remote connectors"]:::extended
  d1["d1-app-db<br/>D1 app database"]:::untouched

  hello -->|"sharedSecret in hello"| ingress
  ingress -->|"load secrets with D1 retry"| connectors
  connectors -->|"remote_connector_settings read"| d1
  d1 -->|"match / mismatch / lookup error"| ingress
  ingress -->|"4001 mismatch or 1013/1011 lookup fail"| hello
```

### Risk

- **Overall:** medium — extends connector hello auth failure semantics.
- **Why this classification:** behavior of shared-secret authentication on storage errors changed; successful match path unchanged.
- **Watch for:** connectors that previously saw `invalid-secret` during D1 blips now get temporary-unavailable closes and should reconnect; genuine wrong secrets still `4001`.

### Invariants

- Per-user isolation: unchanged (`userId` still scopes secret lookup and DO session key).
- No migrations / billing / DR surface changes.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28ba298d-79a1-42ba-9da2-7d714ef8f192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28ba298d-79a1-42ba-9da2-7d714ef8f192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote connector authentication when temporary database lock errors occur.
  * Automatically retries transient secret lookups before failing.
  * Added clearer connection responses for temporary, permanent, and invalid shared-secret errors.
  * Prevented transient lookup issues from being incorrectly reported as invalid credentials.
  * WebSocket connections now close with appropriate status information when secret verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->