### PR TITLE
Retry transient D1 export errors during vector reindex

### DIFF
--- a/packages/worker/src/jobs/job-reindex.node.test.ts
+++ b/packages/worker/src/jobs/job-reindex.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test, vi } from 'vitest'
 import { jobVectorId } from '#mcp/jobs-vectorize.ts'
+import {
+	d1LockRetryBaseDelayMs,
+	d1LockRetryMaxAttempts,
+} from '#worker/d1-retry.ts'
 import { type JobRecord } from './types.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -130,4 +134,58 @@ test('job reindex walks keyset pages and merges the page results', async () => {
 	)
 	expect(upsertedIds).toHaveLength(201)
 	expect(new Set(upsertedIds).size).toBe(201)
+})
+
+test('job reindex retries a transient D1 export error on page listing', async () => {
+	resetMocks()
+	const upsert = vi.fn()
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.embedTextsForVectorize.mockResolvedValue([[0.1]])
+	mockModule.listJobRowsPage
+		.mockRejectedValueOnce(
+			new Error('D1_ERROR: Currently processing a long-running export.'),
+		)
+		.mockResolvedValueOnce([buildJobRow('job-1')])
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = reindexJobVectors({ APP_DB: {} } as Env)
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toEqual({ upserted: 1 })
+	} finally {
+		vi.useRealTimers()
+	}
+
+	expect(mockModule.listJobRowsPage).toHaveBeenCalledTimes(2)
+	expect(upsert).toHaveBeenCalledTimes(1)
+})
+
+test('job reindex surfaces page listing failures after the retry budget', async () => {
+	resetMocks()
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert: vi.fn() })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.listJobRowsPage.mockRejectedValue(
+		new Error('D1_ERROR: Currently processing a long-running export.'),
+	)
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = reindexJobVectors({ APP_DB: {} } as Env)
+		const expectation = expect(resultPromise).rejects.toThrow(
+			'Currently processing a long-running export',
+		)
+		for (let attempt = 1; attempt < d1LockRetryMaxAttempts; attempt++) {
+			await vi.advanceTimersByTimeAsync(
+				d1LockRetryBaseDelayMs * 2 ** (attempt - 1),
+			)
+		}
+		await expectation
+	} finally {
+		vi.useRealTimers()
+	}
+
+	expect(mockModule.listJobRowsPage).toHaveBeenCalledTimes(
+		d1LockRetryMaxAttempts,
+	)
 })

--- a/packages/worker/src/jobs/job-reindex.ts
+++ b/packages/worker/src/jobs/job-reindex.ts
@@ -9,6 +9,7 @@ import {
 } from '#mcp/capabilities/reindex-batches.ts'
 import { buildJobEmbedText } from '#mcp/jobs-embed.ts'
 import { jobVectorId } from '#mcp/jobs-vectorize.ts'
+import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { listJobRowsPage } from './repo.ts'
 import { toJobView } from './schedule.ts'
 
@@ -30,10 +31,12 @@ export async function reindexJobVectors(
 	const pageResults: Array<VectorReindexResult> = []
 	let afterId: string | null = null
 	while (true) {
-		const rows = await listJobRowsPage(env.APP_DB, {
-			afterId,
-			limit: reindexPageSize,
-		})
+		const rows = await runD1WithRetry(() =>
+			listJobRowsPage(env.APP_DB, {
+				afterId,
+				limit: reindexPageSize,
+			}),
+		)
 		if (rows.length === 0) break
 		const candidates = rows
 			.filter((row) => row.user_id)

--- a/packages/worker/src/mcp/memory/memory-reindex.node.test.ts
+++ b/packages/worker/src/mcp/memory/memory-reindex.node.test.ts
@@ -1,4 +1,8 @@
 import { expect, test, vi } from 'vitest'
+import {
+	d1LockRetryBaseDelayMs,
+	d1LockRetryMaxAttempts,
+} from '#worker/d1-retry.ts'
 import { type McpMemoryRow } from './types.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -104,4 +108,58 @@ test('memory reindex returns zero upserts for an empty table', async () => {
 		upserted: 0,
 	})
 	expect(mockModule.listMemoriesPage).toHaveBeenCalledTimes(1)
+})
+
+test('memory reindex retries a transient D1 export error on page listing', async () => {
+	resetMocks()
+	const upsert = vi.fn()
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.embedTextsForVectorize.mockResolvedValue([[0.1]])
+	mockModule.listMemoriesPage
+		.mockRejectedValueOnce(
+			new Error('D1_ERROR: Currently processing a long-running export.'),
+		)
+		.mockResolvedValueOnce([buildMemoryRow('memory-1')])
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = reindexMemoryVectors({ APP_DB: {} } as Env)
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toEqual({ upserted: 1 })
+	} finally {
+		vi.useRealTimers()
+	}
+
+	expect(mockModule.listMemoriesPage).toHaveBeenCalledTimes(2)
+	expect(upsert).toHaveBeenCalledTimes(1)
+})
+
+test('memory reindex surfaces page listing failures after the retry budget', async () => {
+	resetMocks()
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert: vi.fn() })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.listMemoriesPage.mockRejectedValue(
+		new Error('D1_ERROR: Currently processing a long-running export.'),
+	)
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = reindexMemoryVectors({ APP_DB: {} } as Env)
+		const expectation = expect(resultPromise).rejects.toThrow(
+			'Currently processing a long-running export',
+		)
+		for (let attempt = 1; attempt < d1LockRetryMaxAttempts; attempt++) {
+			await vi.advanceTimersByTimeAsync(
+				d1LockRetryBaseDelayMs * 2 ** (attempt - 1),
+			)
+		}
+		await expectation
+	} finally {
+		vi.useRealTimers()
+	}
+
+	expect(mockModule.listMemoriesPage).toHaveBeenCalledTimes(
+		d1LockRetryMaxAttempts,
+	)
 })

--- a/packages/worker/src/mcp/memory/memory-reindex.ts
+++ b/packages/worker/src/mcp/memory/memory-reindex.ts
@@ -7,6 +7,7 @@ import {
 	reindexVectorCandidates,
 	type VectorReindexResult,
 } from '#mcp/capabilities/reindex-batches.ts'
+import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { buildMemoryEmbedTextFromRow } from './memory-embed.ts'
 import { listMemoriesPage } from './repo.ts'
 import { memoryVectorId } from './memory-vectorize.ts'
@@ -29,11 +30,13 @@ export async function reindexMemoryVectors(
 	const pageResults: Array<VectorReindexResult> = []
 	let afterId: string | null = null
 	while (true) {
-		const rows = await listMemoriesPage({
-			db: env.APP_DB,
-			afterId,
-			limit: reindexPageSize,
-		})
+		const rows = await runD1WithRetry(() =>
+			listMemoriesPage({
+				db: env.APP_DB,
+				afterId,
+				limit: reindexPageSize,
+			}),
+		)
 		if (rows.length === 0) break
 		pageResults.push(
 			await reindexVectorCandidates({

--- a/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
@@ -1,0 +1,193 @@
+import { expect, test, vi } from 'vitest'
+import {
+	d1LockRetryBaseDelayMs,
+	d1LockRetryMaxAttempts,
+	d1LongRunningExportMessage,
+} from '#worker/d1-retry.ts'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+
+const mockModule = vi.hoisted(() => ({
+	buildSavedPackageEmbedText: vi.fn(),
+	embedTextsForVectorize: vi.fn(),
+	getCapabilityVectorIndex: vi.fn(),
+	getEntitySourceById: vi.fn(),
+	isCapabilitySearchOffline: vi.fn(),
+	listSavedPackagesPage: vi.fn(),
+	loadPublishedEntityManifest: vi.fn(),
+}))
+
+vi.mock('#mcp/capabilities/capability-search.ts', () => ({
+	embedTextsForVectorize: (...args: Array<unknown>) =>
+		mockModule.embedTextsForVectorize(...args),
+	getCapabilityVectorIndex: (...args: Array<unknown>) =>
+		mockModule.getCapabilityVectorIndex(...args),
+	isCapabilitySearchOffline: (...args: Array<unknown>) =>
+		mockModule.isCapabilitySearchOffline(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/published-source.ts', () => ({
+	loadPublishedEntityManifest: (...args: Array<unknown>) =>
+		mockModule.loadPublishedEntityManifest(...args),
+	loadPublishedEntitySource: vi.fn(),
+}))
+
+vi.mock('./embed.ts', () => ({
+	buildSavedPackageEmbedText: (...args: Array<unknown>) =>
+		mockModule.buildSavedPackageEmbedText(...args),
+}))
+
+vi.mock('./repo.ts', () => ({
+	listSavedPackagesPage: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesPage(...args),
+	savedPackageVectorId: (packageId: string) => `package_${packageId}`,
+}))
+
+const { reindexSavedPackageVectors } = await import('./package-reindex.ts')
+
+const exportError = () => new Error(`D1_ERROR: ${d1LongRunningExportMessage}.`)
+
+function resetMocks() {
+	mockModule.buildSavedPackageEmbedText.mockReset()
+	mockModule.embedTextsForVectorize.mockReset()
+	mockModule.getCapabilityVectorIndex.mockReset()
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.isCapabilitySearchOffline.mockReset()
+	mockModule.listSavedPackagesPage.mockReset()
+	mockModule.loadPublishedEntityManifest.mockReset()
+}
+
+function createSourceRow(sourceId: string) {
+	return {
+		id: sourceId,
+		user_id: 'user-1',
+		entity_kind: 'package' as const,
+		entity_id: `package-${sourceId}`,
+		repo_id: `repo-${sourceId}`,
+		published_commit: 'commit-1',
+		indexed_commit: 'commit-1',
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-01-01T00:00:00.000Z',
+		updated_at: '2026-01-01T00:00:00.000Z',
+	}
+}
+
+function createSavedPackage(id: string) {
+	return {
+		id,
+		userId: 'user-1',
+		name: `@user/${id}`,
+		kodyId: id,
+		description: `Package ${id}`,
+		tags: [],
+		searchText: null,
+		sourceId: `source-${id}`,
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+	}
+}
+
+function stubSuccessfulManifestLoad(sourceId: string) {
+	const source = createSourceRow(sourceId)
+	const manifest = {
+		name: '@user/pkg',
+		exports: { '.': './index.ts' },
+		kody: { id: 'pkg', description: 'Package' },
+	}
+	mockModule.loadPublishedEntityManifest.mockResolvedValue({
+		source,
+		content: JSON.stringify(manifest),
+		manifest,
+	})
+	mockModule.buildSavedPackageEmbedText.mockReturnValue('manifest embed')
+	mockModule.embedTextsForVectorize.mockResolvedValue([[0.1, 0.2, 0.3]])
+	return { source, manifest }
+}
+
+test('saved package reindex recovers when source D1 read hits a transient export error', async () => {
+	resetMocks()
+	const upsert = vi.fn()
+	const env = {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+	} as Env
+	const pkg = createSavedPackage('pkg-1')
+	const { source } = stubSuccessfulManifestLoad(pkg.sourceId)
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.listSavedPackagesPage.mockResolvedValue([pkg])
+	mockModule.getEntitySourceById
+		.mockRejectedValueOnce(exportError())
+		.mockResolvedValueOnce(source)
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = reindexSavedPackageVectors(env, {
+			baseUrl: 'https://kody.example.com',
+		})
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toEqual({ upserted: 1 })
+	} finally {
+		vi.useRealTimers()
+	}
+
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(2)
+	expect(upsert).toHaveBeenCalledTimes(1)
+})
+
+test('saved package reindex keeps load failure reporting when source D1 retries are exhausted', async () => {
+	resetMocks()
+	consoleError.mockImplementation(() => {})
+	const upsert = vi.fn()
+	const env = {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+	} as Env
+	const pkg = createSavedPackage('pkg-1')
+	stubSuccessfulManifestLoad(pkg.sourceId)
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.listSavedPackagesPage.mockResolvedValue([pkg])
+	mockModule.getEntitySourceById.mockRejectedValue(exportError())
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = reindexSavedPackageVectors(env, {
+			baseUrl: 'https://kody.example.com',
+		})
+		const expectation = expect(resultPromise).resolves.toEqual({
+			upserted: 0,
+			failed: 1,
+			failures: [
+				{
+					id: 'package_pkg-1',
+					phase: 'load',
+					error: `D1_ERROR: ${d1LongRunningExportMessage}.`,
+				},
+			],
+			error: '1 saved package vector(s) failed to reindex',
+		})
+		for (let attempt = 1; attempt < d1LockRetryMaxAttempts; attempt++) {
+			await vi.advanceTimersByTimeAsync(
+				d1LockRetryBaseDelayMs * 2 ** (attempt - 1),
+			)
+		}
+		await expectation
+	} finally {
+		vi.useRealTimers()
+	}
+
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(
+		d1LockRetryMaxAttempts,
+	)
+	expect(mockModule.loadPublishedEntityManifest).not.toHaveBeenCalled()
+	expect(upsert).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/package-registry/package-reindex.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex.node.test.ts
@@ -1,4 +1,9 @@
 import { expect, test, vi } from 'vitest'
+import {
+	d1LockRetryBaseDelayMs,
+	d1LockRetryMaxAttempts,
+} from '#worker/d1-retry.ts'
+import { consoleError } from '#worker/test-support/console-spies.ts'
 
 const mockModule = vi.hoisted(() => ({
 	buildSavedPackageEmbedText: vi.fn(),
@@ -132,7 +137,7 @@ test('saved package reindex embeds full manifests with user-scoped metadata', as
 
 test('saved package reindex skips failed manifest loads and continues the batch', async () => {
 	resetMocks()
-	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+	consoleError.mockImplementation(() => {})
 	const upsert = vi.fn()
 	const env = {
 		APP_DB: {},
@@ -192,40 +197,101 @@ test('saved package reindex skips failed manifest loads and continues the batch'
 	mockModule.buildSavedPackageEmbedText.mockReturnValue('tasks manifest embed')
 	mockModule.embedTextsForVectorize.mockResolvedValue([[0.4, 0.5, 0.6]])
 
-	try {
-		await expect(
-			reindexSavedPackageVectors(env, {
-				baseUrl: 'https://kody.example.com',
-			}),
-		).resolves.toEqual({
-			upserted: 1,
-			failed: 1,
-			failures: [
-				{
-					id: 'package_pkg-bad',
-					phase: 'load',
-					error: 'manifest missing',
-				},
-			],
-			warning: '1 saved package vector(s) failed to reindex',
-		})
-
-		expect(mockModule.embedTextsForVectorize).toHaveBeenCalledWith(env, [
-			'tasks manifest embed',
-		])
-		expect(upsert).toHaveBeenCalledWith([
+	await expect(
+		reindexSavedPackageVectors(env, {
+			baseUrl: 'https://kody.example.com',
+		}),
+	).resolves.toEqual({
+		upserted: 1,
+		failed: 1,
+		failures: [
 			{
-				id: 'package_pkg-good',
-				values: [0.4, 0.5, 0.6],
-				metadata: {
-					kind: 'package',
-					userId: 'user-1',
-				},
+				id: 'package_pkg-bad',
+				phase: 'load',
+				error: 'manifest missing',
 			},
-		])
+		],
+		warning: '1 saved package vector(s) failed to reindex',
+	})
+
+	expect(mockModule.embedTextsForVectorize).toHaveBeenCalledWith(env, [
+		'tasks manifest embed',
+	])
+	expect(upsert).toHaveBeenCalledWith([
+		{
+			id: 'package_pkg-good',
+			values: [0.4, 0.5, 0.6],
+			metadata: {
+				kind: 'package',
+				userId: 'user-1',
+			},
+		},
+	])
+})
+
+test('saved package reindex retries a transient D1 export error on page listing', async () => {
+	resetMocks()
+	const upsert = vi.fn()
+	const env = { APP_DB: {} } as Env
+	const pkg = buildSavedPackage('pkg-1')
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.loadPackageManifestBySourceId.mockResolvedValue({
+		manifest: { name: pkg.name },
+	})
+	mockModule.buildSavedPackageEmbedText.mockReturnValue('manifest embed')
+	mockModule.embedTextsForVectorize.mockResolvedValue([[0.1]])
+	mockModule.listSavedPackagesPage
+		.mockRejectedValueOnce(
+			new Error('D1_ERROR: Currently processing a long-running export.'),
+		)
+		.mockResolvedValueOnce([pkg])
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = reindexSavedPackageVectors(env, {
+			baseUrl: 'https://kody.example.com',
+		})
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toEqual({ upserted: 1 })
 	} finally {
-		consoleError.mockRestore()
+		vi.useRealTimers()
 	}
+
+	expect(mockModule.listSavedPackagesPage).toHaveBeenCalledTimes(2)
+	expect(upsert).toHaveBeenCalledTimes(1)
+})
+
+test('saved package reindex surfaces page listing failures after the retry budget', async () => {
+	resetMocks()
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert: vi.fn() })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.listSavedPackagesPage.mockRejectedValue(
+		new Error('D1_ERROR: Currently processing a long-running export.'),
+	)
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = reindexSavedPackageVectors({ APP_DB: {} } as Env, {
+			baseUrl: 'https://kody.example.com',
+		})
+		const expectation = expect(resultPromise).rejects.toThrow(
+			'Currently processing a long-running export',
+		)
+		for (let attempt = 1; attempt < d1LockRetryMaxAttempts; attempt++) {
+			await vi.advanceTimersByTimeAsync(
+				d1LockRetryBaseDelayMs * 2 ** (attempt - 1),
+			)
+		}
+		await expectation
+	} finally {
+		vi.useRealTimers()
+	}
+
+	expect(mockModule.listSavedPackagesPage).toHaveBeenCalledTimes(
+		d1LockRetryMaxAttempts,
+	)
+	expect(mockModule.loadPackageManifestBySourceId).not.toHaveBeenCalled()
 })
 
 test('saved package reindex walks keyset pages and merges the page results', async () => {

--- a/packages/worker/src/package-registry/package-reindex.ts
+++ b/packages/worker/src/package-registry/package-reindex.ts
@@ -9,6 +9,7 @@ import {
 	type VectorReindexFailure,
 	type VectorReindexResult,
 } from '#mcp/capabilities/reindex-batches.ts'
+import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { buildSavedPackageEmbedText } from './embed.ts'
 import { listSavedPackagesPage, savedPackageVectorId } from './repo.ts'
@@ -33,10 +34,12 @@ export async function reindexSavedPackageVectors(
 	const pageResults: Array<VectorReindexResult> = []
 	let afterId: string | null = null
 	while (true) {
-		const rows = await listSavedPackagesPage(env.APP_DB, {
-			afterId,
-			limit: reindexPageSize,
-		})
+		const rows = await runD1WithRetry(() =>
+			listSavedPackagesPage(env.APP_DB, {
+				afterId,
+				limit: reindexPageSize,
+			}),
+		)
 		if (rows.length === 0) break
 		const loadFailures: Array<VectorReindexFailure> = []
 		const candidates: Array<VectorReindexCandidate> = []

--- a/packages/worker/src/package-registry/source.node.test.ts
+++ b/packages/worker/src/package-registry/source.node.test.ts
@@ -1,4 +1,8 @@
 import { expect, test, vi } from 'vitest'
+import {
+	d1LockRetryBaseDelayMs,
+	d1LongRunningExportMessage,
+} from '#worker/d1-retry.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getEntitySourceById: vi.fn(),
@@ -378,4 +382,61 @@ test('loadPackageSourceBySourceId evicts failed published source loads before re
 	})
 
 	expect(mockModule.loadPublishedEntitySource).toHaveBeenCalledTimes(2)
+})
+
+test('loadPackageManifestBySourceId retries transient D1 export errors on the source row read', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.loadPublishedEntityManifest.mockReset()
+	const bundleKv = {
+		get: vi.fn(async () => null),
+		put: vi.fn(async () => undefined),
+		delete: vi.fn(async () => undefined),
+	} as unknown as KVNamespace
+	const source = createPackageSourceRow({
+		id: 'source-retry-export',
+		publishedCommit: 'commit-retry-1',
+	})
+	const manifest = {
+		name: '@kentcdodds/example-package',
+		exports: { '.': './index.js' },
+		kody: {
+			id: 'example-package',
+			description: 'Example package',
+		},
+	}
+	mockModule.getEntitySourceById
+		.mockRejectedValueOnce(
+			new Error(`D1_ERROR: ${d1LongRunningExportMessage}.`),
+		)
+		.mockResolvedValueOnce(source)
+	mockModule.loadPublishedEntityManifest.mockResolvedValue({
+		source,
+		content: JSON.stringify(manifest),
+		manifest,
+	})
+
+	vi.useFakeTimers()
+	try {
+		const resultPromise = loadPackageManifestBySourceId({
+			env: {
+				APP_DB: {},
+				BUNDLE_ARTIFACTS_KV: bundleKv,
+			} as Env,
+			baseUrl: 'https://heykody.dev',
+			userId: 'user-1',
+			sourceId: 'source-retry-export',
+		})
+		await vi.advanceTimersByTimeAsync(d1LockRetryBaseDelayMs)
+		await expect(resultPromise).resolves.toMatchObject({
+			manifest: {
+				name: '@kentcdodds/example-package',
+				kody: { id: 'example-package' },
+			},
+		})
+	} finally {
+		vi.useRealTimers()
+	}
+
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(2)
+	expect(mockModule.loadPublishedEntityManifest).toHaveBeenCalledTimes(1)
 })

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -1,3 +1,4 @@
+import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import {
@@ -97,7 +98,9 @@ async function resolvePackageSourceRow(input: {
 	userId: string
 	sourceId: string
 }) {
-	const source = await getEntitySourceById(input.env.APP_DB, input.sourceId)
+	const source = await runD1WithRetry(() =>
+		getEntitySourceById(input.env.APP_DB, input.sourceId),
+	)
 	if (!source || source.user_id !== input.userId) {
 		throw new Error(`Saved package source "${input.sourceId}" was not found.`)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes a real production failure observed on the last deploy: **44 saved-package search vectors silently went stale.**

## What happened

From the `🧭 Reindex capability vectors` step of the deploy for `9ab2e57`:

```json
{"capabilities":{"upserted":141},"memories":{"upserted":58},"jobs":{"upserted":31},
 "packages":{"upserted":38,"failed":44,
   "failures":[{"id":"package_...","phase":"load",
     "error":"D1_ERROR: Currently processing a long-running export."}],
   "warning":"44 saved package vector(s) failed to reindex"},"ok":true}
```

All 44 failures shared one cause: the nightly DR D1 export held a lock during the reindex window. The previous deploy reported `upserted: 82` with no failures, so this is intermittent rather than a regression.

The step only gates on HTTP status, so it reported `ok: true` and the deploy passed with degraded package search.

## Why it was avoidable

`packages/worker/src/d1-retry.ts` already exists and already lists that exact error as retryable. Its own doc comment describes this situation: D1 does not auto-retry, DR/REST exports block other D1 traffic, and long-running maintenance batches therefore need application-level backoff.

The reindex is squarely that class of work — it runs from the deploy pipeline and overlaps the nightly export. It just was never wired up. `rg -n "runD1WithRetry" packages/worker/src/package-registry/` returned nothing.

## The fix

Retry at the **D1 boundary**, not around unrelated work:

- `package-registry/source.ts` — the source-row read inside `resolvePackageSourceRow`. This is the read that produced all 44 `phase: 'load'` failures. Wrapping it here rather than wrapping `loadPackageManifestBySourceId` matters: that function also does Artifacts and KV work, and retrying a network fetch under a helper named for D1 would be both misleading and wasteful. Fixing it at this layer also benefits every other caller, not just reindex.
- Keyset page reads in `package-reindex.ts`, `job-reindex.ts`, and `memory-reindex.ts`. A page read throwing previously aborted the entire reindex, which is worse than a partial result.

`capability-reindex.ts` was audited and deliberately left alone — it builds from the static capability registry and performs no D1 reads.

## Partial-failure reporting is unchanged

Retry should reduce how often failures happen, not hide them when they do. A reindex that exhausts its retry budget still reports exactly what it does today: `failed`, `failures` with `phase: 'load'`, and the `warning` (or `error` when nothing succeeded). There is a test pinning that specifically, so the fix cannot quietly turn a real outage into silence.

## Verification

`npm run validate` green: 1425 tests across 432 files (16 new), Playwright E2E, MCP E2E, `primitives:check`, `migrations:check`.

I confirmed the tests actually catch the absence of the fix rather than passing vacuously — removing the retry wrapper from `source.ts` fails three of them, including `saved package reindex recovers when source D1 read hits a transient export error`.

Note for after deploy: the 44 currently-stale vectors should catch up on the next clean reindex. Worth a glance at the reindex output on this deploy to confirm.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c395166-fb36-4a97-8634-7e5b31f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of job, memory, and package reindexing when temporary database export errors occur.
  * Added automatic retries with backoff for paginated data retrieval and package source loading.
  * Operations now continue after transient failures and report clear failures when retry limits are reached.
* **Tests**
  * Added coverage for successful retries, exhausted retry attempts, and expected operation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->