### PR TITLE
feat(run-records): let packages subscribe to run.error.recorded

### DIFF
--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -247,6 +247,16 @@ Modelled on the
 | **Usage metering**              | How many / how long / aggregate cost pressure   | Analytics Engine + D1 `usage_rollups`     |
 | **Sentry**                      | Platform defects operators should fix           | Sentry project                            |
 | **Entity state columns/tables** | Current status (`last_run_*`, service liveness) | D1 entity rows / `package_service_states` |
+| **Package subscriptions**       | Same-user reaction to terminal errors           | Best-effort dispatch after `finishRun`    |
+
+After a successful terminal `finishRun` with `status: 'error'`,
+`finishRunRecord` best-effort dispatches `run.error.recorded` to the owning
+user’s packages that declare the topic (see
+`packages/worker/src/run-records/package-subscriptions.ts` and
+[Package subscriptions](../../guides/package-subscriptions.md)). Emission skips
+`surface === 'subscription'` so a failing notifier cannot recurse. Discovery and
+invocation infrastructure failures are warned, never thrown into the observed
+run path. There is no Queue for this topic in v1.
 
 **Usage metering** and run records are the aggregates/records pair: metering is
 sampling-tolerant and quota-oriented; run records are user-facing history.

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -297,6 +297,14 @@ event. Handlers should fetch full bodies or bytes only when needed through
 `email_message_get`, `email_attachment_get`, or the package runtime `email`
 helper.
 
+For user Activity failures, `run.error.recorded` dispatches best-effort after a
+successful run-record write for the owning user. The payload is metadata-first
+(run identifiers, truncated error fields, and a trusted `activity_url`); it
+omits log lines and the full metadata blob. Subscription-surface failures do not
+emit (recursion guard). See
+[Package subscriptions](../guides/package-subscriptions.md) and
+[Run records](./architecture/run-records.md).
+
 Operator system-inbox mail (`system:email` owner) dispatches the separate
 `email.system-message.received` topic to packages saved by users who hold the
 admin role at dispatch time. The payload is the same metadata-first envelope

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -5,17 +5,17 @@ Official markdown guides for agent and contributor workflows. At runtime, the
 branch via `raw.githubusercontent.com` (see capability description in code for
 available `guide` ids).
 
-| File                                                                                     | Topic                                                                                                                       |
-| ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                                     |
-| [package-lifecycle.md](./package-lifecycle.md)                                           | Choose reuse, one-off execute, community fork when close, direct job schedules, or a new durable package                    |
-| [integration-bootstrap.md](./integration-bootstrap.md)                                   | **Start here** for third-party integrations; after the smoke test, prefer a trusted community fork before building          |
-| [openapi-integrations.md](./openapi-integrations.md)                                     | OpenAPI discover → summarize → scaffold or curated `openapi:<name>` binding                                                 |
-| [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                                |
-| [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md)           | Default package app pattern after integration smoke test passes                                                             |
-| [package-service-pattern.md](./package-service-pattern.md)                               | General package-service pattern for native long-lived runtimes inside Kody                                                  |
-| [package-subscriptions.md](./package-subscriptions.md)                                   | Package subscription manifest shape, discovery, and email.message.received / email.system-message.received payload guidance |
-| [platform-friction.md](./platform-friction.md)                                           | Agent self-improvement loop for Kody capability, package, memory, and guide friction                                        |
-| [oauth.md](./oauth.md)                                                                   | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                                               |
-| [account-secret-setup.md](./account-secret-setup.md)                                     | `/account/secrets/new` URL parameters and policies                                                                          |
-| [account-package-invocation-token-setup.md](./account-package-invocation-token-setup.md) | `/account/package-invocation-tokens/new` URL parameters and bearer-token safety policy                                      |
+| File                                                                                     | Topic                                                                                                              |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                            |
+| [package-lifecycle.md](./package-lifecycle.md)                                           | Choose reuse, one-off execute, community fork when close, direct job schedules, or a new durable package           |
+| [integration-bootstrap.md](./integration-bootstrap.md)                                   | **Start here** for third-party integrations; after the smoke test, prefer a trusted community fork before building |
+| [openapi-integrations.md](./openapi-integrations.md)                                     | OpenAPI discover → summarize → scaffold or curated `openapi:<name>` binding                                        |
+| [secret-backed-integration.md](./secret-backed-integration.md)                           | Default recipe for non-OAuth integrations that use one or more saved secrets                                       |
+| [integration-backed-app-happy-path.md](./integration-backed-app-happy-path.md)           | Default package app pattern after integration smoke test passes                                                    |
+| [package-service-pattern.md](./package-service-pattern.md)                               | General package-service pattern for native long-lived runtimes inside Kody                                         |
+| [package-subscriptions.md](./package-subscriptions.md)                                   | Package subscription manifest shape, discovery, and email / run.error.recorded / admin topic payload guidance      |
+| [platform-friction.md](./platform-friction.md)                                           | Agent self-improvement loop for Kody capability, package, memory, and guide friction                               |
+| [oauth.md](./oauth.md)                                                                   | **Start here** for third-party OAuth (`/connect/oauth`, redirect URI, params)                                      |
+| [account-secret-setup.md](./account-secret-setup.md)                                     | `/account/secrets/new` URL parameters and policies                                                                 |
+| [account-package-invocation-token-setup.md](./account-package-invocation-token-setup.md) | `/account/package-invocation-tokens/new` URL parameters and bearer-token safety policy                             |

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -198,6 +198,57 @@ automatically rerunning; the DLQ is the recovery surface. Terminal handler
 execution failures are isolated without preventing attempts for sibling
 subscribers.
 
+## `run.error.recorded`
+
+When a user-scoped Activity / run record finishes with `status: 'error'`, Kody
+dispatches `run.error.recorded` to packages saved by that same user that declare
+the topic. Delivery is best-effort after a successful run-record Durable Object
+write — there is no Queue / DLQ for this topic in v1. Failures during subscriber
+discovery or package-invocation infrastructure are logged and do not fail the
+observed run.
+
+Handlers receive a metadata-first payload:
+
+```ts
+type RunErrorRecordedEvent = {
+	event: 'run.error.recorded'
+	run: {
+		id: string
+		surface: string
+		name: string | null
+		package_id: string | null
+		kody_id: string | null
+		source_id: string | null
+		published_commit: string | null
+		storage_id: string | null
+		job_id: string | null
+		workflow_id: string | null
+		invocation_id: string | null
+		session_id: string | null
+		parent_run_id: string | null
+		started_at: string
+		finished_at: string | null
+		duration_ms: number | null
+		error_name: string | null
+		error_message: string | null
+	}
+	activity_url: string
+}
+```
+
+`activity_url` is built from the trusted deployment origin and links to
+`/account/activity/<runId>`. The event deliberately omits log lines and the full
+run `metadata` blob — fetch detail with `run_get` when needed. Error name and
+message use the same truncation budget as the stored run record.
+
+Recursion guard: runs whose surface is `subscription` never emit this event.
+Subscription-handler failures themselves create run records; emitting again
+would recurse. Successful runs and `execute` successes (which are not persisted)
+never emit. Failed `execute` calls do persist and do emit.
+
+Use this topic for notifier packages that email, write to Sheets, spawn an
+agent, or otherwise react when something in the user's account fails.
+
 ## `community.activity.recorded` (admins)
 
 Successful community fork and rating writes enqueue a durable

--- a/docs/use/activity.md
+++ b/docs/use/activity.md
@@ -46,6 +46,16 @@ records both success and error.
 If a successful one-off `execute` is missing from Activity, that is expected —
 check the original tool result instead.
 
+## React to failures from a package
+
+Packages can subscribe to the `run.error.recorded` topic in
+`package.json#kody.subscriptions`. When one of your runs finishes with an error,
+Kody dispatches a metadata-first event (run identifiers, truncated error fields,
+and an `activity_url` link to this page) to matching handlers in your account.
+Use that to email yourself, write to a sheet, spawn an agent, or otherwise
+follow up. See [Packages](./packages.md) and the
+[package subscriptions guide](../guides/package-subscriptions.md).
+
 ## Related
 
 - [Execute and workflows](./execute.md)

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -403,7 +403,7 @@ Use the built-in `package_subscriptions_list` capability to discover the
 signed-in user's saved package subscriptions, optionally filtered by exact
 topic. This is the generic discovery step before building fan-out, debugging why
 an event did or did not dispatch, or checking which packages subscribe to
-`email.message.received`.
+`email.message.received` or `run.error.recorded`.
 
 For stored inbound email, the topic is `email.message.received`. Its payload is
 metadata-first: handlers receive the stored message id, recipient and sender
@@ -414,6 +414,13 @@ system-inbox mail dispatches the separate `email.system-message.received` topic
 to packages saved by admin users; its payload adds an `admin_url` link to the
 message in the admin interface. See [Email primitives](./email-primitives.md)
 for the full payload shapes.
+
+When a run in your Activity finishes with an error, Kody dispatches
+`run.error.recorded` to your packages that declare that topic. The payload is
+metadata-first (run id, surface, identifiers, truncated error fields, and an
+`activity_url` deep link). Fetch logs and full detail with `run_get` when
+needed. See [Activity](./activity.md) and the
+[package subscriptions guide](../guides/package-subscriptions.md).
 
 ## Package webhooks
 

--- a/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
+++ b/packages/worker/src/mcp/capabilities/coding/kody-official-guide.ts
@@ -75,7 +75,7 @@ export const kodyOfficialGuideCatalog = {
 		file: 'package-subscriptions.md',
 		title: 'Package subscription guide',
 		summary:
-			'Use package.json#kody.subscriptions for package-owned event handlers; discover subscribers with package_subscriptions_list and follow metadata-first email plus consent-gated admin-only platform.feedback.submitted notification guidance.',
+			'Use package.json#kody.subscriptions for package-owned event handlers; discover subscribers with package_subscriptions_list and follow metadata-first email, run.error.recorded activity notifiers, plus consent-gated admin-only platform.feedback.submitted notification guidance.',
 	},
 	platform_friction: {
 		file: 'platform-friction.md',
@@ -157,7 +157,7 @@ const guideFieldSchema = z
 			'`connect_secret`: /account/secrets/new for API keys, PATs, and other secret collection steps.',
 			'`package_invocation_token_setup`: /account/package-invocation-tokens/new setup URL shape, owner-scoped /@:username/api/package-invocations invocation route shape, query params, and bearer-token safety policy for external package invocation clients.',
 			'`package_service_pattern`: package-native long-lived service architecture built on package services and package app realtime.',
-			'`package_subscriptions`: package-owned event subscriptions, package_subscriptions_list discovery, metadata-first email payloads, and consent-gated admin-only platform.feedback.submitted notifications with untrusted text, submitter identity, and an admin deep link.',
+			'`package_subscriptions`: package-owned event subscriptions, package_subscriptions_list discovery, metadata-first email and run.error.recorded payloads, and consent-gated admin-only platform.feedback.submitted notifications with untrusted text, submitter identity, and an admin deep link.',
 			'`platform_friction`: choose an inline fix, an approved memory workflow, or attributed platform feedback after showing the exact proposal and notification disclosure and receiving explicit user approval, writing one actionable issue per submission.',
 		].join(' '),
 	)
@@ -244,6 +244,9 @@ const allKeywords = [
 		'package.json#kody.subscriptions',
 		'email.message.received',
 		'email message received',
+		'run.error.recorded',
+		'run error recorded',
+		'activity error notification',
 		'platform.feedback.submitted',
 		'platform feedback submitted',
 		'feedback notification event',

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
@@ -20,7 +20,7 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 	{
 		name: 'package_subscriptions_list',
 		description:
-			'List package.json#kody.subscriptions entries for the signed-in user, optionally filtered by exact event topic. Use this to discover package event handlers such as email receipt, delivery-update, admin platform-feedback, or admin community-activity notification subscribers before debugging dispatch or building fan-out. Admin-only topics carry only their documented narrow metadata, and declaring one does not grant delivery; dispatch checks the package owner role fresh at delivery time.',
+			'List package.json#kody.subscriptions entries for the signed-in user, optionally filtered by exact event topic. Use this to discover package event handlers such as email receipt, delivery-update, run.error.recorded activity notifiers, admin platform-feedback, or admin community-activity notification subscribers before debugging dispatch or building fan-out. Admin-only topics carry only their documented narrow metadata, and declaring one does not grant delivery; dispatch checks the package owner role fresh at delivery time.',
 		keywords: [
 			'package',
 			'package.json#kody.subscriptions',
@@ -35,6 +35,9 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 			'email delivery updated',
 			'email.system-message.received',
 			'system email',
+			'run.error.recorded',
+			'run error recorded',
+			'activity error',
 			'platform.feedback.submitted',
 			'platform feedback submitted',
 			'community.activity.recorded',
@@ -53,7 +56,7 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 				.min(1)
 				.optional()
 				.describe(
-					'Optional exact event topic filter such as "email.message.received", "platform.feedback.submitted", or "community.activity.recorded".',
+					'Optional exact event topic filter such as "email.message.received", "run.error.recorded", "platform.feedback.submitted", or "community.activity.recorded".',
 				),
 		}),
 		outputSchema: z.object({

--- a/packages/worker/src/run-records/package-subscriptions.node.test.ts
+++ b/packages/worker/src/run-records/package-subscriptions.node.test.ts
@@ -233,6 +233,42 @@ test('does not throw when discovery or invocation infrastructure fails', async (
 	warn.mockRestore()
 })
 
+test('does not throw when listing saved packages fails', async () => {
+	const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	mocks.listSavedPackagesByUserId.mockRejectedValueOnce(
+		new Error('D1 unavailable'),
+	)
+	mocks.invokePackageSubscription.mockClear()
+
+	await expect(
+		dispatchRunErrorSubscriptionEvents({
+			env: {
+				APP_DB: {},
+				BUNDLE_ARTIFACTS_KV: {},
+				APP_BASE_URL: 'https://example.com',
+			} as Env,
+			userId: 'user-1',
+			run: errorRun() as never,
+		}),
+	).resolves.toEqual([])
+
+	expect(mocks.invokePackageSubscription).not.toHaveBeenCalled()
+	expect(warn).toHaveBeenCalledWith(
+		'run.error.recorded package subscription discovery incomplete',
+		expect.objectContaining({
+			runId: 'run-1',
+			errorCount: 1,
+		}),
+	)
+	const warnPayload = warn.mock.calls.find(
+		(call) =>
+			call[0] ===
+			'run.error.recorded package subscription discovery incomplete',
+	)?.[1] as Record<string, unknown> | undefined
+	expect(warnPayload).not.toHaveProperty('userId')
+	warn.mockRestore()
+})
+
 test('isolates sibling handler failures with allSettled semantics', async () => {
 	const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 	const first = {

--- a/packages/worker/src/run-records/package-subscriptions.node.test.ts
+++ b/packages/worker/src/run-records/package-subscriptions.node.test.ts
@@ -1,0 +1,289 @@
+import { expect, test, vi } from 'vitest'
+
+const runErrorRecordedTopic = 'run.error.recorded'
+
+const mocks = vi.hoisted(() => ({
+	invokePackageSubscription: vi.fn(async () => ({ status: 200, body: {} })),
+	listSavedPackagesByUserId: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
+}))
+
+vi.mock('#worker/package-invocations/service.ts', () => ({
+	invokePackageSubscription: mocks.invokePackageSubscription,
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: mocks.listSavedPackagesByUserId,
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: mocks.loadPackageManifestBySourceId,
+}))
+
+const {
+	dispatchRunErrorSubscriptionEvents,
+	runErrorRecordedTopic: exportedTopic,
+} = await import('./package-subscriptions.ts')
+
+function errorRun(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'run-1',
+		surface: 'job',
+		status: 'error',
+		name: 'daily-sync',
+		packageId: 'pkg-owner',
+		kodyId: 'daily-sync',
+		sourceId: 'source-owner',
+		publishedCommit: 'commit-1',
+		storageId: 'storage-1',
+		jobId: 'job-1',
+		workflowId: null,
+		invocationId: null,
+		sessionId: null,
+		idempotencyKey: null,
+		parentRunId: null,
+		startedAt: '2026-07-27T12:00:00.000Z',
+		finishedAt: '2026-07-27T12:00:01.000Z',
+		durationMs: 1000,
+		errorName: 'Error',
+		errorMessage: 'boom',
+		metadataJson: '{}',
+		createdAt: '2026-07-27T12:00:00.000Z',
+		updatedAt: '2026-07-27T12:00:01.000Z',
+		...overrides,
+	}
+}
+
+test('exports the locked run.error.recorded topic', () => {
+	expect(exportedTopic).toBe(runErrorRecordedTopic)
+})
+
+test('run.error.recorded fans out only to the owning user packages', async () => {
+	const savedPackage = {
+		id: 'package-1',
+		userId: 'user-1',
+		sourceId: 'source-1',
+		kodyId: 'error-notifier',
+		name: '@user/error-notifier',
+	}
+	mocks.listSavedPackagesByUserId.mockResolvedValueOnce([savedPackage])
+	mocks.loadPackageManifestBySourceId.mockResolvedValueOnce({
+		manifest: {
+			name: '@user/error-notifier',
+			kody: {
+				id: 'error-notifier',
+				description: 'Error notifier',
+				subscriptions: {
+					[runErrorRecordedTopic]: {
+						handler: './src/on-run-error.ts',
+					},
+				},
+			},
+		},
+	})
+	const env = {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+		APP_BASE_URL: 'https://example.com',
+	} as Env
+	const run = errorRun()
+
+	const results = await dispatchRunErrorSubscriptionEvents({
+		env,
+		userId: 'user-1',
+		run: run as never,
+	})
+
+	expect(results).toHaveLength(1)
+	expect(mocks.listSavedPackagesByUserId).toHaveBeenCalledWith(env.APP_DB, {
+		userId: 'user-1',
+	})
+	expect(mocks.invokePackageSubscription).toHaveBeenCalledWith(
+		expect.objectContaining({
+			savedPackage,
+			topic: runErrorRecordedTopic,
+			idempotencyKey: `run-error:run-1:package-1:${runErrorRecordedTopic}`,
+			source: 'run-records',
+			params: expect.objectContaining({
+				event: runErrorRecordedTopic,
+				activity_url: 'https://example.com/account/activity/run-1',
+				run: expect.objectContaining({
+					id: 'run-1',
+					surface: 'job',
+					name: 'daily-sync',
+					package_id: 'pkg-owner',
+					kody_id: 'daily-sync',
+					source_id: 'source-owner',
+					published_commit: 'commit-1',
+					storage_id: 'storage-1',
+					job_id: 'job-1',
+					workflow_id: null,
+					invocation_id: null,
+					session_id: null,
+					parent_run_id: null,
+					started_at: '2026-07-27T12:00:00.000Z',
+					finished_at: '2026-07-27T12:00:01.000Z',
+					duration_ms: 1000,
+					error_name: 'Error',
+					error_message: 'boom',
+				}),
+			}),
+		}),
+	)
+	const params = mocks.invokePackageSubscription.mock.calls[0]?.[0]?.params as
+		| Record<string, unknown>
+		| undefined
+	expect(params).not.toHaveProperty('metadata')
+	expect(params?.['run']).not.toHaveProperty('metadata')
+	expect(params?.['run']).not.toHaveProperty('logs')
+})
+
+test('skips dispatch for subscription-surface errors to prevent recursion', async () => {
+	mocks.invokePackageSubscription.mockClear()
+	mocks.listSavedPackagesByUserId.mockClear()
+	const results = await dispatchRunErrorSubscriptionEvents({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {},
+			APP_BASE_URL: 'https://example.com',
+		} as Env,
+		userId: 'user-1',
+		run: errorRun({ surface: 'subscription' }) as never,
+	})
+	expect(results).toEqual([])
+	expect(mocks.listSavedPackagesByUserId).not.toHaveBeenCalled()
+	expect(mocks.invokePackageSubscription).not.toHaveBeenCalled()
+})
+
+test('skips dispatch for non-error terminal status', async () => {
+	mocks.invokePackageSubscription.mockClear()
+	mocks.listSavedPackagesByUserId.mockClear()
+	const results = await dispatchRunErrorSubscriptionEvents({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {},
+			APP_BASE_URL: 'https://example.com',
+		} as Env,
+		userId: 'user-1',
+		run: errorRun({
+			status: 'success',
+			errorName: null,
+			errorMessage: null,
+		}) as never,
+	})
+	expect(results).toEqual([])
+	expect(mocks.listSavedPackagesByUserId).not.toHaveBeenCalled()
+	expect(mocks.invokePackageSubscription).not.toHaveBeenCalled()
+})
+
+test('does not throw when discovery or invocation infrastructure fails', async () => {
+	const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const matchingPackage = {
+		id: 'package-1',
+		userId: 'user-1',
+		sourceId: 'source-1',
+		kodyId: 'error-notifier',
+		name: '@user/error-notifier',
+	}
+	const brokenPackage = {
+		id: 'package-2',
+		userId: 'user-1',
+		sourceId: 'source-2',
+		kodyId: 'broken',
+		name: '@user/broken',
+	}
+	mocks.listSavedPackagesByUserId.mockResolvedValueOnce([
+		matchingPackage,
+		brokenPackage,
+	])
+	mocks.loadPackageManifestBySourceId
+		.mockResolvedValueOnce({
+			manifest: {
+				name: '@user/error-notifier',
+				kody: {
+					id: 'error-notifier',
+					description: 'Error notifier',
+					subscriptions: {
+						[runErrorRecordedTopic]: {
+							handler: './src/on-run-error.ts',
+						},
+					},
+				},
+			},
+		})
+		.mockRejectedValueOnce(new Error('manifest unavailable'))
+	mocks.invokePackageSubscription.mockResolvedValueOnce({
+		status: 503,
+		body: { error: { code: 'artifact_preparation_failed' } },
+	})
+
+	await expect(
+		dispatchRunErrorSubscriptionEvents({
+			env: {
+				APP_DB: {},
+				BUNDLE_ARTIFACTS_KV: {},
+				APP_BASE_URL: 'https://example.com',
+			} as Env,
+			userId: 'user-1',
+			run: errorRun() as never,
+		}),
+	).resolves.toEqual([null])
+
+	expect(warn).toHaveBeenCalled()
+	warn.mockRestore()
+})
+
+test('isolates sibling handler failures with allSettled semantics', async () => {
+	const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const first = {
+		id: 'package-1',
+		userId: 'user-1',
+		sourceId: 'source-1',
+		kodyId: 'notifier-a',
+		name: '@user/notifier-a',
+	}
+	const second = {
+		id: 'package-2',
+		userId: 'user-1',
+		sourceId: 'source-2',
+		kodyId: 'notifier-b',
+		name: '@user/notifier-b',
+	}
+	mocks.listSavedPackagesByUserId.mockResolvedValueOnce([first, second])
+	mocks.loadPackageManifestBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => ({
+			manifest: {
+				name:
+					input.sourceId === 'source-1'
+						? '@user/notifier-a'
+						: '@user/notifier-b',
+				kody: {
+					id: input.sourceId === 'source-1' ? 'notifier-a' : 'notifier-b',
+					description: 'notifier',
+					subscriptions: {
+						[runErrorRecordedTopic]: {
+							handler: './src/on-run-error.ts',
+						},
+					},
+				},
+			},
+		}),
+	)
+	mocks.invokePackageSubscription
+		.mockRejectedValueOnce(new Error('handler boom'))
+		.mockResolvedValueOnce({ status: 200, body: { ok: true } })
+
+	const results = await dispatchRunErrorSubscriptionEvents({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {},
+			APP_BASE_URL: 'https://example.com',
+		} as Env,
+		userId: 'user-1',
+		run: errorRun() as never,
+	})
+
+	expect(results).toEqual([null, { status: 200, body: { ok: true } }])
+	expect(mocks.invokePackageSubscription).toHaveBeenCalledTimes(2)
+	warn.mockRestore()
+})

--- a/packages/worker/src/run-records/package-subscriptions.ts
+++ b/packages/worker/src/run-records/package-subscriptions.ts
@@ -1,0 +1,216 @@
+import { getAppBaseUrl } from '#app/app-base-url.ts'
+import { readPreExecutionPackageInvocationInfrastructureCode } from '#worker/package-invocations/admin-package-subscriptions.ts'
+import { invokePackageSubscription } from '#worker/package-invocations/service.ts'
+import { listPackageSubscriptions } from '#worker/package-registry/manifest.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import { type RunLogRowInput } from './run-log-do.ts'
+
+export const runErrorRecordedTopic = 'run.error.recorded'
+
+type RunErrorRecordedSubscriptionEnvelope = {
+	event: typeof runErrorRecordedTopic
+	run: {
+		id: string
+		surface: string
+		name: string | null
+		package_id: string | null
+		kody_id: string | null
+		source_id: string | null
+		published_commit: string | null
+		storage_id: string | null
+		job_id: string | null
+		workflow_id: string | null
+		invocation_id: string | null
+		session_id: string | null
+		parent_run_id: string | null
+		started_at: string
+		finished_at: string | null
+		duration_ms: number | null
+		error_name: string | null
+		error_message: string | null
+	}
+	activity_url: string
+}
+
+type LoadedRunErrorSubscription = {
+	savedPackage: SavedPackageRecord
+	subscription: ReturnType<typeof listPackageSubscriptions>[number]
+}
+
+function buildRunErrorEventPayload(input: {
+	run: RunLogRowInput
+	activityUrl: string
+}): RunErrorRecordedSubscriptionEnvelope {
+	return {
+		event: runErrorRecordedTopic,
+		run: {
+			id: input.run.id,
+			surface: input.run.surface,
+			name: input.run.name,
+			package_id: input.run.packageId,
+			kody_id: input.run.kodyId,
+			source_id: input.run.sourceId,
+			published_commit: input.run.publishedCommit,
+			storage_id: input.run.storageId,
+			job_id: input.run.jobId,
+			workflow_id: input.run.workflowId,
+			invocation_id: input.run.invocationId,
+			session_id: input.run.sessionId,
+			parent_run_id: input.run.parentRunId,
+			started_at: input.run.startedAt,
+			finished_at: input.run.finishedAt,
+			duration_ms: input.run.durationMs,
+			error_name: input.run.errorName,
+			error_message: input.run.errorMessage,
+		},
+		activity_url: input.activityUrl,
+	}
+}
+
+function buildSubscriptionIdempotencyKey(input: {
+	runId: string
+	packageId: string
+}) {
+	return `run-error:${input.runId}:${input.packageId}:${runErrorRecordedTopic}`
+}
+
+function buildActivityUrl(input: { baseUrl: string; runId: string }) {
+	return `${input.baseUrl}/account/activity/${encodeURIComponent(input.runId)}`
+}
+
+async function loadMatchingRunErrorSubscriptions(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+	baseUrl: string
+	userId: string
+}) {
+	let savedPackages: Array<SavedPackageRecord>
+	try {
+		savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
+			userId: input.userId,
+		})
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			error.message.includes('no such table: saved_packages')
+		) {
+			return {
+				subscriptions: [] as Array<LoadedRunErrorSubscription>,
+				discoveryErrors: [] as Array<unknown>,
+			}
+		}
+		throw error
+	}
+	const settled = await Promise.allSettled(
+		savedPackages.map(async (savedPackage) => {
+			const loaded = await loadPackageManifestBySourceId({
+				env: input.env as Env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: savedPackage.sourceId,
+			})
+			const subscription = listPackageSubscriptions(loaded.manifest).find(
+				(candidate) => candidate.topic === runErrorRecordedTopic,
+			)
+			if (!subscription) return null
+			return { savedPackage, subscription } satisfies LoadedRunErrorSubscription
+		}),
+	)
+	const subscriptions: Array<LoadedRunErrorSubscription> = []
+	const discoveryErrors: Array<unknown> = []
+	for (const [index, result] of settled.entries()) {
+		if (result.status === 'fulfilled') {
+			if (result.value) subscriptions.push(result.value)
+			continue
+		}
+		const savedPackage = savedPackages[index]
+		console.warn(
+			'Failed to load package manifest for run.error.recorded subscription',
+			{
+				sourceId: savedPackage?.sourceId,
+				packageId: savedPackage?.id,
+				error: result.reason,
+			},
+		)
+		discoveryErrors.push(result.reason)
+	}
+	return { subscriptions, discoveryErrors }
+}
+
+/**
+ * Fan a persisted terminal error run record out to the owning user's packages
+ * that declare `run.error.recorded`. Best-effort: discovery and invocation
+ * infrastructure failures are logged, never thrown — the observed run path
+ * must not fail because a notifier could not be reached. Sibling handler
+ * terminal failures are isolated via `Promise.allSettled`.
+ */
+export async function dispatchRunErrorSubscriptionEvents(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL'>
+	userId: string
+	run: RunLogRowInput
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	if (input.run.status !== 'error') return []
+	if (input.run.surface === 'subscription') return []
+
+	const baseUrl = getAppBaseUrl({ env: input.env })
+	const { subscriptions, discoveryErrors } =
+		await loadMatchingRunErrorSubscriptions({
+			env: input.env,
+			baseUrl,
+			userId: input.userId,
+		})
+	const eventPayload = buildRunErrorEventPayload({
+		run: input.run,
+		activityUrl: buildActivityUrl({ baseUrl, runId: input.run.id }),
+	})
+	const settled = await Promise.allSettled(
+		subscriptions.map(async ({ savedPackage }) => {
+			const response = await invokePackageSubscription({
+				env: input.env as Env,
+				baseUrl,
+				savedPackage,
+				topic: runErrorRecordedTopic,
+				params: eventPayload as Record<string, unknown>,
+				idempotencyKey: buildSubscriptionIdempotencyKey({
+					runId: input.run.id,
+					packageId: savedPackage.id,
+				}),
+				source: 'run-records',
+				waitUntil: input.waitUntil,
+			})
+			const retryableCode =
+				readPreExecutionPackageInvocationInfrastructureCode(response)
+			if (retryableCode) {
+				throw new Error(
+					`Retryable package invocation infrastructure response: ${retryableCode}.`,
+				)
+			}
+			return response
+		}),
+	)
+	for (const result of settled) {
+		if (result.status === 'rejected') {
+			console.warn('run.error.recorded package subscription invoke failed', {
+				runId: input.run.id,
+				userId: input.userId,
+				error: result.reason,
+			})
+		}
+	}
+	if (discoveryErrors.length > 0) {
+		console.warn(
+			'run.error.recorded package subscription discovery incomplete',
+			{
+				runId: input.run.id,
+				userId: input.userId,
+				errorCount: discoveryErrors.length,
+				error: discoveryErrors[0],
+			},
+		)
+	}
+	return settled.map((result) =>
+		result.status === 'fulfilled' ? result.value : null,
+	)
+}

--- a/packages/worker/src/run-records/package-subscriptions.ts
+++ b/packages/worker/src/run-records/package-subscriptions.ts
@@ -91,16 +91,15 @@ async function loadMatchingRunErrorSubscriptions(input: {
 			userId: input.userId,
 		})
 	} catch (error) {
-		if (
+		// Best-effort: discovery must not reject the dispatcher. Missing-table
+		// (local/test DBs) is silent; other DB failures are recorded for warn.
+		const missingTable =
 			error instanceof Error &&
 			error.message.includes('no such table: saved_packages')
-		) {
-			return {
-				subscriptions: [] as Array<LoadedRunErrorSubscription>,
-				discoveryErrors: [] as Array<unknown>,
-			}
+		return {
+			subscriptions: [] as Array<LoadedRunErrorSubscription>,
+			discoveryErrors: missingTable ? [] : [error],
 		}
-		throw error
 	}
 	const settled = await Promise.allSettled(
 		savedPackages.map(async (savedPackage) => {
@@ -194,7 +193,6 @@ export async function dispatchRunErrorSubscriptionEvents(input: {
 		if (result.status === 'rejected') {
 			console.warn('run.error.recorded package subscription invoke failed', {
 				runId: input.run.id,
-				userId: input.userId,
 				error: result.reason,
 			})
 		}
@@ -204,7 +202,6 @@ export async function dispatchRunErrorSubscriptionEvents(input: {
 			'run.error.recorded package subscription discovery incomplete',
 			{
 				runId: input.run.id,
-				userId: input.userId,
 				errorCount: discoveryErrors.length,
 				error: discoveryErrors[0],
 			},

--- a/packages/worker/src/run-records/service.node.test.ts
+++ b/packages/worker/src/run-records/service.node.test.ts
@@ -1,0 +1,165 @@
+import { expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	dispatchRunErrorSubscriptionEvents: vi.fn(async () => []),
+	finishRun: vi.fn(async () => ({ ok: true })),
+	startRun: vi.fn(async () => ({ ok: true })),
+	recordSuccessfulPackageRun: vi.fn(async () => {}),
+}))
+
+vi.mock('./package-subscriptions.ts', () => ({
+	dispatchRunErrorSubscriptionEvents: mocks.dispatchRunErrorSubscriptionEvents,
+}))
+
+vi.mock('#worker/usage/activation.ts', () => ({
+	recordSuccessfulPackageRun: mocks.recordSuccessfulPackageRun,
+}))
+
+const { beginRunRecord, finishRunRecord, recordRunRecord } =
+	await import('./service.ts')
+
+function createEnv() {
+	return {
+		RUN_LOG: {
+			idFromName: () => ({ toString: () => 'run-log-id' }),
+			get: () => ({
+				startRun: mocks.startRun,
+				finishRun: mocks.finishRun,
+			}),
+		},
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+		APP_BASE_URL: 'https://example.com',
+	} as unknown as Env
+}
+
+test('finishRunRecord dispatches run.error.recorded after a persisted error', async () => {
+	mocks.dispatchRunErrorSubscriptionEvents.mockClear()
+	mocks.finishRun.mockClear()
+	const env = createEnv()
+	const handle = beginRunRecord({
+		env,
+		userId: 'user-1',
+		context: { surface: 'job', name: 'daily', jobId: 'job-1' },
+	})
+	expect(handle).not.toBeNull()
+
+	await finishRunRecord({
+		env,
+		handle,
+		status: 'error',
+		error: new Error('boom'),
+	})
+
+	expect(mocks.finishRun).toHaveBeenCalledTimes(1)
+	expect(mocks.dispatchRunErrorSubscriptionEvents).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			run: expect.objectContaining({
+				id: handle!.id,
+				status: 'error',
+				surface: 'job',
+				errorName: 'Error',
+				errorMessage: 'boom',
+			}),
+		}),
+	)
+})
+
+test('finishRunRecord does not dispatch for success or subscription surface', async () => {
+	mocks.dispatchRunErrorSubscriptionEvents.mockClear()
+	const env = createEnv()
+
+	const successHandle = beginRunRecord({
+		env,
+		userId: 'user-1',
+		context: { surface: 'job', name: 'ok' },
+	})
+	await finishRunRecord({
+		env,
+		handle: successHandle,
+		status: 'success',
+	})
+	expect(mocks.dispatchRunErrorSubscriptionEvents).not.toHaveBeenCalled()
+
+	const subscriptionHandle = beginRunRecord({
+		env,
+		userId: 'user-1',
+		context: { surface: 'subscription', name: 'run.error.recorded' },
+	})
+	await finishRunRecord({
+		env,
+		handle: subscriptionHandle,
+		status: 'error',
+		error: new Error('handler failed'),
+	})
+	expect(mocks.dispatchRunErrorSubscriptionEvents).not.toHaveBeenCalled()
+})
+
+test('recordRunRecord error path also dispatches through finishRunRecord', async () => {
+	mocks.dispatchRunErrorSubscriptionEvents.mockClear()
+	const env = createEnv()
+	await recordRunRecord({
+		env,
+		userId: 'user-1',
+		context: { surface: 'execute', name: 'adhoc' },
+		status: 'error',
+		error: new Error('execute failed'),
+	})
+	expect(mocks.dispatchRunErrorSubscriptionEvents).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			run: expect.objectContaining({
+				status: 'error',
+				surface: 'execute',
+				errorMessage: 'execute failed',
+			}),
+		}),
+	)
+})
+
+test('finishRunRecord does not dispatch when finishRun RPC fails', async () => {
+	mocks.dispatchRunErrorSubscriptionEvents.mockClear()
+	mocks.finishRun.mockRejectedValueOnce(new Error('do unavailable'))
+	const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const env = createEnv()
+	const handle = beginRunRecord({
+		env,
+		userId: 'user-1',
+		context: { surface: 'job', name: 'daily' },
+	})
+	await finishRunRecord({
+		env,
+		handle,
+		status: 'error',
+		error: new Error('boom'),
+	})
+	expect(mocks.dispatchRunErrorSubscriptionEvents).not.toHaveBeenCalled()
+	warn.mockRestore()
+})
+
+test('finishRunRecord swallows dispatch failures', async () => {
+	mocks.dispatchRunErrorSubscriptionEvents.mockRejectedValueOnce(
+		new Error('dispatch exploded'),
+	)
+	const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	const env = createEnv()
+	const handle = beginRunRecord({
+		env,
+		userId: 'user-1',
+		context: { surface: 'webhook', name: 'hook' },
+	})
+	await expect(
+		finishRunRecord({
+			env,
+			handle,
+			status: 'error',
+			error: new Error('boom'),
+		}),
+	).resolves.toBeUndefined()
+	expect(warn).toHaveBeenCalledWith(
+		'run-error-subscription-dispatch-failed',
+		expect.any(Error),
+	)
+	warn.mockRestore()
+})

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -1,99 +1,99 @@
-import { toJsonSafeValue } from "@kody-internal/shared/json-safe-value.ts";
-import { recordSuccessfulPackageRun } from "#worker/usage/activation.ts";
-import { runLogDurableObjectName } from "#worker/user-scoped-durable-object-name.ts";
+import { toJsonSafeValue } from '@kody-internal/shared/json-safe-value.ts'
+import { recordSuccessfulPackageRun } from '#worker/usage/activation.ts'
+import { runLogDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import {
-  type RunLogEntryInput,
-  type RunLogRowInput,
-  type RunLogRpc,
-} from "./run-log-do.ts";
+	type RunLogEntryInput,
+	type RunLogRowInput,
+	type RunLogRpc,
+} from './run-log-do.ts'
 import {
-  type RunRecord,
-  type RunRecordContext,
-  type RunRecordFilter,
-  type RunRecordHandle,
-  type RunLogLevel,
-  type RunRecordLog,
-  type RunRecordLogInput,
-  type RunRecordPage,
-  type RunRecordSummary,
-  type RunStatus,
-  type RunTerminalStatus,
-  runLogLevelValues,
-  runPersistenceForSurface,
-  runRecordDefaultPageSize,
-  runRecordMaxJsonBytes,
-  runRecordMaxLogEntriesPerRun,
-  runRecordMaxPageSize,
-  runRecordMaxTextBytes,
-} from "./types.ts";
+	type RunRecord,
+	type RunRecordContext,
+	type RunRecordFilter,
+	type RunRecordHandle,
+	type RunLogLevel,
+	type RunRecordLog,
+	type RunRecordLogInput,
+	type RunRecordPage,
+	type RunRecordSummary,
+	type RunStatus,
+	type RunTerminalStatus,
+	runLogLevelValues,
+	runPersistenceForSurface,
+	runRecordDefaultPageSize,
+	runRecordMaxJsonBytes,
+	runRecordMaxLogEntriesPerRun,
+	runRecordMaxPageSize,
+	runRecordMaxTextBytes,
+} from './types.ts'
 
-const textEncoder = new TextEncoder();
+const textEncoder = new TextEncoder()
 
 function normalizeOptionalString(value: string | null | undefined) {
-  const trimmed = value?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : null;
+	const trimmed = value?.trim()
+	return trimmed && trimmed.length > 0 ? trimmed : null
 }
 
 function truncateUtf8(value: string, maxBytes: number) {
-  if (textEncoder.encode(value).length <= maxBytes) return value;
-  const suffix = "... [truncated]";
-  let low = 0;
-  let high = value.length;
-  let best = "";
-  while (low <= high) {
-    const midpoint = Math.floor((low + high) / 2);
-    const candidate = `${value.slice(0, midpoint)}${suffix}`;
-    if (textEncoder.encode(candidate).length <= maxBytes) {
-      best = candidate;
-      low = midpoint + 1;
-    } else {
-      high = midpoint - 1;
-    }
-  }
-  return best;
+	if (textEncoder.encode(value).length <= maxBytes) return value
+	const suffix = '... [truncated]'
+	let low = 0
+	let high = value.length
+	let best = ''
+	while (low <= high) {
+		const midpoint = Math.floor((low + high) / 2)
+		const candidate = `${value.slice(0, midpoint)}${suffix}`
+		if (textEncoder.encode(candidate).length <= maxBytes) {
+			best = candidate
+			low = midpoint + 1
+		} else {
+			high = midpoint - 1
+		}
+	}
+	return best
 }
 
 function serializeJson(value: unknown, maxBytes = runRecordMaxJsonBytes) {
-  const json = JSON.stringify(toJsonSafeValue(value));
-  if (textEncoder.encode(json).length <= maxBytes) return json;
-  let preview = truncateUtf8(json, Math.max(0, maxBytes - 128));
-  let wrapped = JSON.stringify({
-    __truncated__: true,
-    preview,
-  });
-  while (textEncoder.encode(wrapped).length > maxBytes && preview.length > 0) {
-    preview = preview.slice(0, Math.floor(preview.length * 0.8));
-    wrapped = JSON.stringify({
-      __truncated__: true,
-      preview,
-    });
-  }
-  return wrapped;
+	const json = JSON.stringify(toJsonSafeValue(value))
+	if (textEncoder.encode(json).length <= maxBytes) return json
+	let preview = truncateUtf8(json, Math.max(0, maxBytes - 128))
+	let wrapped = JSON.stringify({
+		__truncated__: true,
+		preview,
+	})
+	while (textEncoder.encode(wrapped).length > maxBytes && preview.length > 0) {
+		preview = preview.slice(0, Math.floor(preview.length * 0.8))
+		wrapped = JSON.stringify({
+			__truncated__: true,
+			preview,
+		})
+	}
+	return wrapped
 }
 
 function getErrorFields(error: unknown) {
-  if (!error) return { errorName: null, errorMessage: null };
-  if (error instanceof Error) {
-    return {
-      errorName: error.name,
-      errorMessage: truncateUtf8(error.message, runRecordMaxTextBytes),
-    };
-  }
-  if (typeof error === "object" && error !== null) {
-    const record = error as Record<string, unknown>;
-    const message = record["message"];
-    if (typeof message === "string") {
-      const name = record["name"];
-      return {
-        errorName: typeof name === "string" ? name : "Error",
-        errorMessage: truncateUtf8(message, runRecordMaxTextBytes),
-      };
-    }
-  }
-  return {
-    errorName: "Unknown",
-    errorMessage: truncateUtf8(String(error), runRecordMaxTextBytes),
-  };
+	if (!error) return { errorName: null, errorMessage: null }
+	if (error instanceof Error) {
+		return {
+			errorName: error.name,
+			errorMessage: truncateUtf8(error.message, runRecordMaxTextBytes),
+		}
+	}
+	if (typeof error === 'object' && error !== null) {
+		const record = error as Record<string, unknown>
+		const message = record['message']
+		if (typeof message === 'string') {
+			const name = record['name']
+			return {
+				errorName: typeof name === 'string' ? name : 'Error',
+				errorMessage: truncateUtf8(message, runRecordMaxTextBytes),
+			}
+		}
+	}
+	return {
+		errorName: 'Unknown',
+		errorMessage: truncateUtf8(String(error), runRecordMaxTextBytes),
+	}
 }
 
 /**
@@ -103,91 +103,91 @@ function getErrorFields(error: unknown) {
  * message text.
  */
 function splitLeveledLogMessage(message: string): {
-  level: RunLogLevel;
-  message: string;
+	level: RunLogLevel
+	message: string
 } {
-  for (const level of runLogLevelValues) {
-    const marker = `[${level}] `;
-    if (message.startsWith(marker)) {
-      return { level, message: message.slice(marker.length) };
-    }
-  }
-  return { level: "log", message };
+	for (const level of runLogLevelValues) {
+		const marker = `[${level}] `
+		if (message.startsWith(marker)) {
+			return { level, message: message.slice(marker.length) }
+		}
+	}
+	return { level: 'log', message }
 }
 
 function normalizeLogs(
-  logs: Array<RunRecordLogInput> | undefined,
+	logs: Array<RunRecordLogInput> | undefined,
 ): Array<RunLogEntryInput> {
-  return (logs ?? [])
-    .slice(-runRecordMaxLogEntriesPerRun)
-    .map((entry, index) => {
-      if (typeof entry === "string") {
-        const split = splitLeveledLogMessage(String(entry));
-        return {
-          sequence: index,
-          level: split.level,
-          message: truncateUtf8(split.message, runRecordMaxTextBytes),
-          fieldsJson: null,
-        };
-      }
-      return {
-        sequence: index,
-        level: entry.level ?? "log",
-        message: truncateUtf8(String(entry.message), runRecordMaxTextBytes),
-        fieldsJson: entry.fields == null ? null : serializeJson(entry.fields),
-      };
-    });
+	return (logs ?? [])
+		.slice(-runRecordMaxLogEntriesPerRun)
+		.map((entry, index) => {
+			if (typeof entry === 'string') {
+				const split = splitLeveledLogMessage(String(entry))
+				return {
+					sequence: index,
+					level: split.level,
+					message: truncateUtf8(split.message, runRecordMaxTextBytes),
+					fieldsJson: null,
+				}
+			}
+			return {
+				sequence: index,
+				level: entry.level ?? 'log',
+				message: truncateUtf8(String(entry.message), runRecordMaxTextBytes),
+				fieldsJson: entry.fields == null ? null : serializeJson(entry.fields),
+			}
+		})
 }
 
 function buildRunRow(input: {
-  handle: RunRecordHandle;
-  status: RunStatus;
-  finishedAt: string | null;
-  durationMs: number | null;
-  errorName: string | null;
-  errorMessage: string | null;
-  updatedAt: string;
+	handle: RunRecordHandle
+	status: RunStatus
+	finishedAt: string | null
+	durationMs: number | null
+	errorName: string | null
+	errorMessage: string | null
+	updatedAt: string
 }): RunLogRowInput {
-  const context = input.handle.context;
-  return {
-    id: input.handle.id,
-    surface: context.surface,
-    status: input.status,
-    name: normalizeOptionalString(context.name),
-    packageId: normalizeOptionalString(context.packageId),
-    kodyId: normalizeOptionalString(context.kodyId),
-    sourceId: normalizeOptionalString(context.sourceId),
-    publishedCommit: normalizeOptionalString(context.publishedCommit),
-    storageId: normalizeOptionalString(context.storageId),
-    jobId: normalizeOptionalString(context.jobId),
-    workflowId: normalizeOptionalString(context.workflowId),
-    invocationId: normalizeOptionalString(context.invocationId),
-    sessionId: normalizeOptionalString(context.sessionId),
-    idempotencyKey: normalizeOptionalString(context.idempotencyKey),
-    parentRunId: normalizeOptionalString(context.parentRunId),
-    startedAt: input.handle.startedAt,
-    finishedAt: input.finishedAt,
-    durationMs: input.durationMs,
-    errorName: input.errorName,
-    errorMessage: input.errorMessage,
-    metadataJson: serializeJson(context.metadata ?? {}),
-    createdAt: input.handle.startedAt,
-    updatedAt: input.updatedAt,
-  };
+	const context = input.handle.context
+	return {
+		id: input.handle.id,
+		surface: context.surface,
+		status: input.status,
+		name: normalizeOptionalString(context.name),
+		packageId: normalizeOptionalString(context.packageId),
+		kodyId: normalizeOptionalString(context.kodyId),
+		sourceId: normalizeOptionalString(context.sourceId),
+		publishedCommit: normalizeOptionalString(context.publishedCommit),
+		storageId: normalizeOptionalString(context.storageId),
+		jobId: normalizeOptionalString(context.jobId),
+		workflowId: normalizeOptionalString(context.workflowId),
+		invocationId: normalizeOptionalString(context.invocationId),
+		sessionId: normalizeOptionalString(context.sessionId),
+		idempotencyKey: normalizeOptionalString(context.idempotencyKey),
+		parentRunId: normalizeOptionalString(context.parentRunId),
+		startedAt: input.handle.startedAt,
+		finishedAt: input.finishedAt,
+		durationMs: input.durationMs,
+		errorName: input.errorName,
+		errorMessage: input.errorMessage,
+		metadataJson: serializeJson(context.metadata ?? {}),
+		createdAt: input.handle.startedAt,
+		updatedAt: input.updatedAt,
+	}
 }
 
 function runLogBinding(env: Env) {
-  return (env as Partial<Env>).RUN_LOG ?? null;
+	return (env as Partial<Env>).RUN_LOG ?? null
 }
 
 export function runLogRpc(input: { env: Env; userId: string }): RunLogRpc {
-  const namespace = runLogBinding(input.env);
-  if (!namespace) {
-    throw new Error("RUN_LOG Durable Object binding is not configured.");
-  }
-  return namespace.get(
-    namespace.idFromName(runLogDurableObjectName(input.userId)),
-  ) as unknown as RunLogRpc;
+	const namespace = runLogBinding(input.env)
+	if (!namespace) {
+		throw new Error('RUN_LOG Durable Object binding is not configured.')
+	}
+	return namespace.get(
+		namespace.idFromName(runLogDurableObjectName(input.userId)),
+	) as unknown as RunLogRpc
 }
 
 /**
@@ -196,57 +196,57 @@ export function runLogRpc(input: { env: Env; userId: string }): RunLogRpc {
  * and keep going. Same contract as `recordUsage`.
  */
 export function beginRunRecord(input: {
-  env: Env;
-  userId?: string | null;
-  context?: RunRecordContext | null;
-  waitUntil?: (promise: Promise<unknown>) => void;
+	env: Env
+	userId?: string | null
+	context?: RunRecordContext | null
+	waitUntil?: (promise: Promise<unknown>) => void
 }): RunRecordHandle | null {
-  const namespace = runLogBinding(input.env);
-  const userId = normalizeOptionalString(input.userId ?? undefined);
-  const context = input.context;
-  if (!namespace || !userId || !context) return null;
+	const namespace = runLogBinding(input.env)
+	const userId = normalizeOptionalString(input.userId ?? undefined)
+	const context = input.context
+	if (!namespace || !userId || !context) return null
 
-  try {
-    const id = crypto.randomUUID();
-    const startedAt = new Date().toISOString();
-    const persistence = runPersistenceForSurface(context.surface);
-    const handle: RunRecordHandle = {
-      id,
-      userId,
-      startedAt,
-      persistence,
-      context,
-    };
+	try {
+		const id = crypto.randomUUID()
+		const startedAt = new Date().toISOString()
+		const persistence = runPersistenceForSurface(context.surface)
+		const handle: RunRecordHandle = {
+			id,
+			userId,
+			startedAt,
+			persistence,
+			context,
+		}
 
-    if (persistence === "eager") {
-      const run = buildRunRow({
-        handle,
-        status: "running",
-        finishedAt: null,
-        durationMs: null,
-        errorName: null,
-        errorMessage: null,
-        updatedAt: startedAt,
-      });
-      // A dropped startRun is deliberately harmless: finishRun upserts the
-      // complete row. That is why begin can stay off the request critical path.
-      const startPromise = runLogRpc({ env: input.env, userId })
-        .startRun({ run })
-        .catch((error: unknown) => {
-          console.warn("run-record-start-failed", error);
-        });
-      if (input.waitUntil) {
-        input.waitUntil(startPromise);
-      } else {
-        void startPromise;
-      }
-    }
+		if (persistence === 'eager') {
+			const run = buildRunRow({
+				handle,
+				status: 'running',
+				finishedAt: null,
+				durationMs: null,
+				errorName: null,
+				errorMessage: null,
+				updatedAt: startedAt,
+			})
+			// A dropped startRun is deliberately harmless: finishRun upserts the
+			// complete row. That is why begin can stay off the request critical path.
+			const startPromise = runLogRpc({ env: input.env, userId })
+				.startRun({ run })
+				.catch((error: unknown) => {
+					console.warn('run-record-start-failed', error)
+				})
+			if (input.waitUntil) {
+				input.waitUntil(startPromise)
+			} else {
+				void startPromise
+			}
+		}
 
-    return handle;
-  } catch (error) {
-    console.warn("run-record-begin-failed", error);
-    return null;
-  }
+		return handle
+	} catch (error) {
+		console.warn('run-record-begin-failed', error)
+		return null
+	}
 }
 
 /**
@@ -255,92 +255,92 @@ export function beginRunRecord(input: {
  * it.
  */
 export async function finishRunRecord(input: {
-  env: Env;
-  handle: RunRecordHandle | null;
-  status: RunTerminalStatus;
-  logs?: Array<RunRecordLogInput>;
-  error?: unknown;
-  waitUntil?: (promise: Promise<unknown>) => void;
+	env: Env
+	handle: RunRecordHandle | null
+	status: RunTerminalStatus
+	logs?: Array<RunRecordLogInput>
+	error?: unknown
+	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<void> {
-  const handle = input.handle;
-  if (!handle) return;
-  if (handle.persistence === "on-failure" && input.status === "success") {
-    return;
-  }
+	const handle = input.handle
+	if (!handle) return
+	if (handle.persistence === 'on-failure' && input.status === 'success') {
+		return
+	}
 
-  const work = (async () => {
-    let persistedRun: RunLogRowInput | null = null;
-    try {
-      if (runLogBinding(input.env)) {
-        const finishedAt = new Date().toISOString();
-        const durationMs = Math.max(
-          0,
-          Date.parse(finishedAt) - Date.parse(handle.startedAt),
-        );
-        const { errorName, errorMessage } = getErrorFields(input.error);
-        const run = buildRunRow({
-          handle,
-          status: input.status,
-          finishedAt,
-          durationMs,
-          errorName,
-          errorMessage,
-          updatedAt: finishedAt,
-        });
-        await runLogRpc({ env: input.env, userId: handle.userId }).finishRun({
-          run,
-          logs: normalizeLogs(input.logs),
-        });
-        persistedRun = run;
-      }
-    } catch (error) {
-      console.warn("run-record-finish-failed", error);
-    }
+	const work = (async () => {
+		let persistedRun: RunLogRowInput | null = null
+		try {
+			if (runLogBinding(input.env)) {
+				const finishedAt = new Date().toISOString()
+				const durationMs = Math.max(
+					0,
+					Date.parse(finishedAt) - Date.parse(handle.startedAt),
+				)
+				const { errorName, errorMessage } = getErrorFields(input.error)
+				const run = buildRunRow({
+					handle,
+					status: input.status,
+					finishedAt,
+					durationMs,
+					errorName,
+					errorMessage,
+					updatedAt: finishedAt,
+				})
+				await runLogRpc({ env: input.env, userId: handle.userId }).finishRun({
+					run,
+					logs: normalizeLogs(input.logs),
+				})
+				persistedRun = run
+			}
+		} catch (error) {
+			console.warn('run-record-finish-failed', error)
+		}
 
-    if (input.status === "success") {
-      const packageId = normalizeOptionalString(handle.context.packageId);
-      if (packageId) {
-        try {
-          await recordSuccessfulPackageRun(input.env, {
-            userId: handle.userId,
-            packageId,
-            surface: handle.context.surface,
-          });
-        } catch (error) {
-          console.warn("run-record-activation-failed", error);
-        }
-      }
-    }
+		if (input.status === 'success') {
+			const packageId = normalizeOptionalString(handle.context.packageId)
+			if (packageId) {
+				try {
+					await recordSuccessfulPackageRun(input.env, {
+						userId: handle.userId,
+						packageId,
+						surface: handle.context.surface,
+					})
+				} catch (error) {
+					console.warn('run-record-activation-failed', error)
+				}
+			}
+		}
 
-    if (
-      persistedRun &&
-      input.status === "error" &&
-      handle.context.surface !== "subscription"
-    ) {
-      try {
-        // Dynamic import: a static edge to package-subscriptions pulls
-        // package-invocations and deepens the account-export cycle
-        // (account-export → … → account-export-shared → account-export),
-        // leaving z.enum(accountExportSectionNames) undefined at module load.
-        const { dispatchRunErrorSubscriptionEvents } =
-          await import("./package-subscriptions.ts");
-        await dispatchRunErrorSubscriptionEvents({
-          env: input.env,
-          userId: handle.userId,
-          run: persistedRun,
-          waitUntil: input.waitUntil,
-        });
-      } catch (error) {
-        console.warn("run-error-subscription-dispatch-failed", error);
-      }
-    }
-  })();
+		if (
+			persistedRun &&
+			input.status === 'error' &&
+			handle.context.surface !== 'subscription'
+		) {
+			try {
+				// Dynamic import: a static edge to package-subscriptions pulls
+				// package-invocations and deepens the account-export cycle
+				// (account-export → … → account-export-shared → account-export),
+				// leaving z.enum(accountExportSectionNames) undefined at module load.
+				const { dispatchRunErrorSubscriptionEvents } =
+					await import('./package-subscriptions.ts')
+				await dispatchRunErrorSubscriptionEvents({
+					env: input.env,
+					userId: handle.userId,
+					run: persistedRun,
+					waitUntil: input.waitUntil,
+				})
+			} catch (error) {
+				console.warn('run-error-subscription-dispatch-failed', error)
+			}
+		}
+	})()
 
-  if (input.waitUntil) {
-    input.waitUntil(work);
-    return;
-  }
-  await work;
+	if (input.waitUntil) {
+		input.waitUntil(work)
+		return
+	}
+	await work
 }
 
 /**
@@ -350,145 +350,145 @@ export async function finishRunRecord(input: {
  * no-op begin when the surface is known to be terminal-only.
  */
 export async function recordRunRecord(input: {
-  env: Env;
-  userId?: string | null;
-  context?: RunRecordContext | null;
-  status: RunTerminalStatus;
-  logs?: Array<RunRecordLogInput>;
-  error?: unknown;
-  startedAt?: string | null;
-  waitUntil?: (promise: Promise<unknown>) => void;
+	env: Env
+	userId?: string | null
+	context?: RunRecordContext | null
+	status: RunTerminalStatus
+	logs?: Array<RunRecordLogInput>
+	error?: unknown
+	startedAt?: string | null
+	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<RunRecordHandle | null> {
-  const namespace = runLogBinding(input.env);
-  const userId = normalizeOptionalString(input.userId ?? undefined);
-  const context = input.context;
-  if (!namespace || !userId || !context) return null;
+	const namespace = runLogBinding(input.env)
+	const userId = normalizeOptionalString(input.userId ?? undefined)
+	const context = input.context
+	if (!namespace || !userId || !context) return null
 
-  let handle: RunRecordHandle;
-  try {
-    handle = {
-      id: crypto.randomUUID(),
-      userId,
-      startedAt:
-        normalizeOptionalString(input.startedAt) ?? new Date().toISOString(),
-      persistence: runPersistenceForSurface(context.surface),
-      context,
-    };
-  } catch (error) {
-    console.warn("run-record-begin-failed", error);
-    return null;
-  }
-  await finishRunRecord({
-    env: input.env,
-    handle,
-    status: input.status,
-    logs: input.logs,
-    error: input.error,
-    waitUntil: input.waitUntil,
-  });
-  return handle;
+	let handle: RunRecordHandle
+	try {
+		handle = {
+			id: crypto.randomUUID(),
+			userId,
+			startedAt:
+				normalizeOptionalString(input.startedAt) ?? new Date().toISOString(),
+			persistence: runPersistenceForSurface(context.surface),
+			context,
+		}
+	} catch (error) {
+		console.warn('run-record-begin-failed', error)
+		return null
+	}
+	await finishRunRecord({
+		env: input.env,
+		handle,
+		status: input.status,
+		logs: input.logs,
+		error: input.error,
+		waitUntil: input.waitUntil,
+	})
+	return handle
 }
 
 export async function listRunRecords(input: {
-  env: Env;
-  userId: string;
-  filter?: RunRecordFilter | null;
-  limit?: number | null;
-  cursor?: string | null;
+	env: Env
+	userId: string
+	filter?: RunRecordFilter | null
+	limit?: number | null
+	cursor?: string | null
 }): Promise<RunRecordPage> {
-  if (!runLogBinding(input.env)) {
-    return { runs: [], nextCursor: null };
-  }
-  const limit = Math.min(
-    Math.max(input.limit ?? runRecordDefaultPageSize, 1),
-    runRecordMaxPageSize,
-  );
-  return await runLogRpc({ env: input.env, userId: input.userId }).listRuns({
-    surface: input.filter?.surface ?? null,
-    status: input.filter?.status ?? null,
-    packageId: normalizeOptionalString(input.filter?.packageId),
-    jobId: normalizeOptionalString(input.filter?.jobId),
-    name: normalizeOptionalString(input.filter?.name),
-    since: normalizeOptionalString(input.filter?.since),
-    limit,
-    cursor: input.cursor ?? null,
-  });
+	if (!runLogBinding(input.env)) {
+		return { runs: [], nextCursor: null }
+	}
+	const limit = Math.min(
+		Math.max(input.limit ?? runRecordDefaultPageSize, 1),
+		runRecordMaxPageSize,
+	)
+	return await runLogRpc({ env: input.env, userId: input.userId }).listRuns({
+		surface: input.filter?.surface ?? null,
+		status: input.filter?.status ?? null,
+		packageId: normalizeOptionalString(input.filter?.packageId),
+		jobId: normalizeOptionalString(input.filter?.jobId),
+		name: normalizeOptionalString(input.filter?.name),
+		since: normalizeOptionalString(input.filter?.since),
+		limit,
+		cursor: input.cursor ?? null,
+	})
 }
 
 export async function getRunRecord(input: {
-  env: Env;
-  userId: string;
-  runId: string;
+	env: Env
+	userId: string
+	runId: string
 }): Promise<{ run: RunRecord; logs: Array<RunRecordLog> } | null> {
-  if (!runLogBinding(input.env)) return null;
-  return await runLogRpc({ env: input.env, userId: input.userId }).getRun({
-    runId: input.runId,
-  });
+	if (!runLogBinding(input.env)) return null
+	return await runLogRpc({ env: input.env, userId: input.userId }).getRun({
+		runId: input.runId,
+	})
 }
 
 export async function summarizeRunRecords(input: {
-  env: Env;
-  userId: string;
-  since?: string | null;
+	env: Env
+	userId: string
+	since?: string | null
 }): Promise<RunRecordSummary> {
-  const since =
-    normalizeOptionalString(input.since) ?? new Date(0).toISOString();
-  if (!runLogBinding(input.env)) {
-    return {
-      since,
-      total: 0,
-      errors: 0,
-      running: 0,
-      bySurface: [],
-    };
-  }
-  return await runLogRpc({ env: input.env, userId: input.userId }).summarize({
-    since,
-  });
+	const since =
+		normalizeOptionalString(input.since) ?? new Date(0).toISOString()
+	if (!runLogBinding(input.env)) {
+		return {
+			since,
+			total: 0,
+			errors: 0,
+			running: 0,
+			bySurface: [],
+		}
+	}
+	return await runLogRpc({ env: input.env, userId: input.userId }).summarize({
+		since,
+	})
 }
 
 export async function listRunRecordStorageIds(input: {
-  env: Env;
-  userId: string;
+	env: Env
+	userId: string
 }): Promise<Array<string>> {
-  if (!runLogBinding(input.env)) return [];
-  return await runLogRpc({
-    env: input.env,
-    userId: input.userId,
-  }).listStorageIds();
+	if (!runLogBinding(input.env)) return []
+	return await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).listStorageIds()
 }
 
 export async function exportRunRecords(input: {
-  env: Env;
-  userId: string;
-  pageSize?: number;
-  startAfter?: string | null;
+	env: Env
+	userId: string
+	pageSize?: number
+	startAfter?: string | null
 }): Promise<{
-  runs: Array<RunRecord>;
-  logs: Array<RunRecordLog>;
-  nextStartAfter: string | null;
-  truncated: boolean;
+	runs: Array<RunRecord>
+	logs: Array<RunRecordLog>
+	nextStartAfter: string | null
+	truncated: boolean
 }> {
-  if (!runLogBinding(input.env)) {
-    return {
-      runs: [],
-      logs: [],
-      nextStartAfter: null,
-      truncated: false,
-    };
-  }
-  return await runLogRpc({ env: input.env, userId: input.userId }).exportRuns({
-    pageSize: input.pageSize ?? runRecordDefaultPageSize,
-    startAfter: input.startAfter ?? null,
-  });
+	if (!runLogBinding(input.env)) {
+		return {
+			runs: [],
+			logs: [],
+			nextStartAfter: null,
+			truncated: false,
+		}
+	}
+	return await runLogRpc({ env: input.env, userId: input.userId }).exportRuns({
+		pageSize: input.pageSize ?? runRecordDefaultPageSize,
+		startAfter: input.startAfter ?? null,
+	})
 }
 
 export async function clearRunRecords(input: {
-  env: Env;
-  userId: string;
+	env: Env
+	userId: string
 }): Promise<void> {
-  if (!runLogBinding(input.env)) return;
-  await runLogRpc({ env: input.env, userId: input.userId }).clearAll();
+	if (!runLogBinding(input.env)) return
+	await runLogRpc({ env: input.env, userId: input.userId }).clearAll()
 }
 
-export type { RunLogRpc };
+export type { RunLogRpc }

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -1,7 +1,6 @@
 import { toJsonSafeValue } from '@kody-internal/shared/json-safe-value.ts'
 import { recordSuccessfulPackageRun } from '#worker/usage/activation.ts'
 import { runLogDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
-import { dispatchRunErrorSubscriptionEvents } from './package-subscriptions.ts'
 import {
 	type RunLogEntryInput,
 	type RunLogRowInput,
@@ -319,6 +318,13 @@ export async function finishRunRecord(input: {
 			handle.context.surface !== 'subscription'
 		) {
 			try {
+				// Dynamic import: a static edge to package-subscriptions pulls
+				// package-invocations and deepens the account-export cycle
+				// (account-export → … → account-export-shared → account-export),
+				// leaving z.enum(accountExportSectionNames) undefined at module load.
+				const { dispatchRunErrorSubscriptionEvents } = await import(
+					'./package-subscriptions.ts'
+				)
 				await dispatchRunErrorSubscriptionEvents({
 					env: input.env,
 					userId: handle.userId,

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -1,99 +1,99 @@
-import { toJsonSafeValue } from '@kody-internal/shared/json-safe-value.ts'
-import { recordSuccessfulPackageRun } from '#worker/usage/activation.ts'
-import { runLogDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
+import { toJsonSafeValue } from "@kody-internal/shared/json-safe-value.ts";
+import { recordSuccessfulPackageRun } from "#worker/usage/activation.ts";
+import { runLogDurableObjectName } from "#worker/user-scoped-durable-object-name.ts";
 import {
-	type RunLogEntryInput,
-	type RunLogRowInput,
-	type RunLogRpc,
-} from './run-log-do.ts'
+  type RunLogEntryInput,
+  type RunLogRowInput,
+  type RunLogRpc,
+} from "./run-log-do.ts";
 import {
-	type RunRecord,
-	type RunRecordContext,
-	type RunRecordFilter,
-	type RunRecordHandle,
-	type RunLogLevel,
-	type RunRecordLog,
-	type RunRecordLogInput,
-	type RunRecordPage,
-	type RunRecordSummary,
-	type RunStatus,
-	type RunTerminalStatus,
-	runLogLevelValues,
-	runPersistenceForSurface,
-	runRecordDefaultPageSize,
-	runRecordMaxJsonBytes,
-	runRecordMaxLogEntriesPerRun,
-	runRecordMaxPageSize,
-	runRecordMaxTextBytes,
-} from './types.ts'
+  type RunRecord,
+  type RunRecordContext,
+  type RunRecordFilter,
+  type RunRecordHandle,
+  type RunLogLevel,
+  type RunRecordLog,
+  type RunRecordLogInput,
+  type RunRecordPage,
+  type RunRecordSummary,
+  type RunStatus,
+  type RunTerminalStatus,
+  runLogLevelValues,
+  runPersistenceForSurface,
+  runRecordDefaultPageSize,
+  runRecordMaxJsonBytes,
+  runRecordMaxLogEntriesPerRun,
+  runRecordMaxPageSize,
+  runRecordMaxTextBytes,
+} from "./types.ts";
 
-const textEncoder = new TextEncoder()
+const textEncoder = new TextEncoder();
 
 function normalizeOptionalString(value: string | null | undefined) {
-	const trimmed = value?.trim()
-	return trimmed && trimmed.length > 0 ? trimmed : null
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
 }
 
 function truncateUtf8(value: string, maxBytes: number) {
-	if (textEncoder.encode(value).length <= maxBytes) return value
-	const suffix = '... [truncated]'
-	let low = 0
-	let high = value.length
-	let best = ''
-	while (low <= high) {
-		const midpoint = Math.floor((low + high) / 2)
-		const candidate = `${value.slice(0, midpoint)}${suffix}`
-		if (textEncoder.encode(candidate).length <= maxBytes) {
-			best = candidate
-			low = midpoint + 1
-		} else {
-			high = midpoint - 1
-		}
-	}
-	return best
+  if (textEncoder.encode(value).length <= maxBytes) return value;
+  const suffix = "... [truncated]";
+  let low = 0;
+  let high = value.length;
+  let best = "";
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = `${value.slice(0, midpoint)}${suffix}`;
+    if (textEncoder.encode(candidate).length <= maxBytes) {
+      best = candidate;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+  return best;
 }
 
 function serializeJson(value: unknown, maxBytes = runRecordMaxJsonBytes) {
-	const json = JSON.stringify(toJsonSafeValue(value))
-	if (textEncoder.encode(json).length <= maxBytes) return json
-	let preview = truncateUtf8(json, Math.max(0, maxBytes - 128))
-	let wrapped = JSON.stringify({
-		__truncated__: true,
-		preview,
-	})
-	while (textEncoder.encode(wrapped).length > maxBytes && preview.length > 0) {
-		preview = preview.slice(0, Math.floor(preview.length * 0.8))
-		wrapped = JSON.stringify({
-			__truncated__: true,
-			preview,
-		})
-	}
-	return wrapped
+  const json = JSON.stringify(toJsonSafeValue(value));
+  if (textEncoder.encode(json).length <= maxBytes) return json;
+  let preview = truncateUtf8(json, Math.max(0, maxBytes - 128));
+  let wrapped = JSON.stringify({
+    __truncated__: true,
+    preview,
+  });
+  while (textEncoder.encode(wrapped).length > maxBytes && preview.length > 0) {
+    preview = preview.slice(0, Math.floor(preview.length * 0.8));
+    wrapped = JSON.stringify({
+      __truncated__: true,
+      preview,
+    });
+  }
+  return wrapped;
 }
 
 function getErrorFields(error: unknown) {
-	if (!error) return { errorName: null, errorMessage: null }
-	if (error instanceof Error) {
-		return {
-			errorName: error.name,
-			errorMessage: truncateUtf8(error.message, runRecordMaxTextBytes),
-		}
-	}
-	if (typeof error === 'object' && error !== null) {
-		const record = error as Record<string, unknown>
-		const message = record['message']
-		if (typeof message === 'string') {
-			const name = record['name']
-			return {
-				errorName: typeof name === 'string' ? name : 'Error',
-				errorMessage: truncateUtf8(message, runRecordMaxTextBytes),
-			}
-		}
-	}
-	return {
-		errorName: 'Unknown',
-		errorMessage: truncateUtf8(String(error), runRecordMaxTextBytes),
-	}
+  if (!error) return { errorName: null, errorMessage: null };
+  if (error instanceof Error) {
+    return {
+      errorName: error.name,
+      errorMessage: truncateUtf8(error.message, runRecordMaxTextBytes),
+    };
+  }
+  if (typeof error === "object" && error !== null) {
+    const record = error as Record<string, unknown>;
+    const message = record["message"];
+    if (typeof message === "string") {
+      const name = record["name"];
+      return {
+        errorName: typeof name === "string" ? name : "Error",
+        errorMessage: truncateUtf8(message, runRecordMaxTextBytes),
+      };
+    }
+  }
+  return {
+    errorName: "Unknown",
+    errorMessage: truncateUtf8(String(error), runRecordMaxTextBytes),
+  };
 }
 
 /**
@@ -103,91 +103,91 @@ function getErrorFields(error: unknown) {
  * message text.
  */
 function splitLeveledLogMessage(message: string): {
-	level: RunLogLevel
-	message: string
+  level: RunLogLevel;
+  message: string;
 } {
-	for (const level of runLogLevelValues) {
-		const marker = `[${level}] `
-		if (message.startsWith(marker)) {
-			return { level, message: message.slice(marker.length) }
-		}
-	}
-	return { level: 'log', message }
+  for (const level of runLogLevelValues) {
+    const marker = `[${level}] `;
+    if (message.startsWith(marker)) {
+      return { level, message: message.slice(marker.length) };
+    }
+  }
+  return { level: "log", message };
 }
 
 function normalizeLogs(
-	logs: Array<RunRecordLogInput> | undefined,
+  logs: Array<RunRecordLogInput> | undefined,
 ): Array<RunLogEntryInput> {
-	return (logs ?? [])
-		.slice(-runRecordMaxLogEntriesPerRun)
-		.map((entry, index) => {
-			if (typeof entry === 'string') {
-				const split = splitLeveledLogMessage(String(entry))
-				return {
-					sequence: index,
-					level: split.level,
-					message: truncateUtf8(split.message, runRecordMaxTextBytes),
-					fieldsJson: null,
-				}
-			}
-			return {
-				sequence: index,
-				level: entry.level ?? 'log',
-				message: truncateUtf8(String(entry.message), runRecordMaxTextBytes),
-				fieldsJson: entry.fields == null ? null : serializeJson(entry.fields),
-			}
-		})
+  return (logs ?? [])
+    .slice(-runRecordMaxLogEntriesPerRun)
+    .map((entry, index) => {
+      if (typeof entry === "string") {
+        const split = splitLeveledLogMessage(String(entry));
+        return {
+          sequence: index,
+          level: split.level,
+          message: truncateUtf8(split.message, runRecordMaxTextBytes),
+          fieldsJson: null,
+        };
+      }
+      return {
+        sequence: index,
+        level: entry.level ?? "log",
+        message: truncateUtf8(String(entry.message), runRecordMaxTextBytes),
+        fieldsJson: entry.fields == null ? null : serializeJson(entry.fields),
+      };
+    });
 }
 
 function buildRunRow(input: {
-	handle: RunRecordHandle
-	status: RunStatus
-	finishedAt: string | null
-	durationMs: number | null
-	errorName: string | null
-	errorMessage: string | null
-	updatedAt: string
+  handle: RunRecordHandle;
+  status: RunStatus;
+  finishedAt: string | null;
+  durationMs: number | null;
+  errorName: string | null;
+  errorMessage: string | null;
+  updatedAt: string;
 }): RunLogRowInput {
-	const context = input.handle.context
-	return {
-		id: input.handle.id,
-		surface: context.surface,
-		status: input.status,
-		name: normalizeOptionalString(context.name),
-		packageId: normalizeOptionalString(context.packageId),
-		kodyId: normalizeOptionalString(context.kodyId),
-		sourceId: normalizeOptionalString(context.sourceId),
-		publishedCommit: normalizeOptionalString(context.publishedCommit),
-		storageId: normalizeOptionalString(context.storageId),
-		jobId: normalizeOptionalString(context.jobId),
-		workflowId: normalizeOptionalString(context.workflowId),
-		invocationId: normalizeOptionalString(context.invocationId),
-		sessionId: normalizeOptionalString(context.sessionId),
-		idempotencyKey: normalizeOptionalString(context.idempotencyKey),
-		parentRunId: normalizeOptionalString(context.parentRunId),
-		startedAt: input.handle.startedAt,
-		finishedAt: input.finishedAt,
-		durationMs: input.durationMs,
-		errorName: input.errorName,
-		errorMessage: input.errorMessage,
-		metadataJson: serializeJson(context.metadata ?? {}),
-		createdAt: input.handle.startedAt,
-		updatedAt: input.updatedAt,
-	}
+  const context = input.handle.context;
+  return {
+    id: input.handle.id,
+    surface: context.surface,
+    status: input.status,
+    name: normalizeOptionalString(context.name),
+    packageId: normalizeOptionalString(context.packageId),
+    kodyId: normalizeOptionalString(context.kodyId),
+    sourceId: normalizeOptionalString(context.sourceId),
+    publishedCommit: normalizeOptionalString(context.publishedCommit),
+    storageId: normalizeOptionalString(context.storageId),
+    jobId: normalizeOptionalString(context.jobId),
+    workflowId: normalizeOptionalString(context.workflowId),
+    invocationId: normalizeOptionalString(context.invocationId),
+    sessionId: normalizeOptionalString(context.sessionId),
+    idempotencyKey: normalizeOptionalString(context.idempotencyKey),
+    parentRunId: normalizeOptionalString(context.parentRunId),
+    startedAt: input.handle.startedAt,
+    finishedAt: input.finishedAt,
+    durationMs: input.durationMs,
+    errorName: input.errorName,
+    errorMessage: input.errorMessage,
+    metadataJson: serializeJson(context.metadata ?? {}),
+    createdAt: input.handle.startedAt,
+    updatedAt: input.updatedAt,
+  };
 }
 
 function runLogBinding(env: Env) {
-	return (env as Partial<Env>).RUN_LOG ?? null
+  return (env as Partial<Env>).RUN_LOG ?? null;
 }
 
 export function runLogRpc(input: { env: Env; userId: string }): RunLogRpc {
-	const namespace = runLogBinding(input.env)
-	if (!namespace) {
-		throw new Error('RUN_LOG Durable Object binding is not configured.')
-	}
-	return namespace.get(
-		namespace.idFromName(runLogDurableObjectName(input.userId)),
-	) as unknown as RunLogRpc
+  const namespace = runLogBinding(input.env);
+  if (!namespace) {
+    throw new Error("RUN_LOG Durable Object binding is not configured.");
+  }
+  return namespace.get(
+    namespace.idFromName(runLogDurableObjectName(input.userId)),
+  ) as unknown as RunLogRpc;
 }
 
 /**
@@ -196,57 +196,57 @@ export function runLogRpc(input: { env: Env; userId: string }): RunLogRpc {
  * and keep going. Same contract as `recordUsage`.
  */
 export function beginRunRecord(input: {
-	env: Env
-	userId?: string | null
-	context?: RunRecordContext | null
-	waitUntil?: (promise: Promise<unknown>) => void
+  env: Env;
+  userId?: string | null;
+  context?: RunRecordContext | null;
+  waitUntil?: (promise: Promise<unknown>) => void;
 }): RunRecordHandle | null {
-	const namespace = runLogBinding(input.env)
-	const userId = normalizeOptionalString(input.userId ?? undefined)
-	const context = input.context
-	if (!namespace || !userId || !context) return null
+  const namespace = runLogBinding(input.env);
+  const userId = normalizeOptionalString(input.userId ?? undefined);
+  const context = input.context;
+  if (!namespace || !userId || !context) return null;
 
-	try {
-		const id = crypto.randomUUID()
-		const startedAt = new Date().toISOString()
-		const persistence = runPersistenceForSurface(context.surface)
-		const handle: RunRecordHandle = {
-			id,
-			userId,
-			startedAt,
-			persistence,
-			context,
-		}
+  try {
+    const id = crypto.randomUUID();
+    const startedAt = new Date().toISOString();
+    const persistence = runPersistenceForSurface(context.surface);
+    const handle: RunRecordHandle = {
+      id,
+      userId,
+      startedAt,
+      persistence,
+      context,
+    };
 
-		if (persistence === 'eager') {
-			const run = buildRunRow({
-				handle,
-				status: 'running',
-				finishedAt: null,
-				durationMs: null,
-				errorName: null,
-				errorMessage: null,
-				updatedAt: startedAt,
-			})
-			// A dropped startRun is deliberately harmless: finishRun upserts the
-			// complete row. That is why begin can stay off the request critical path.
-			const startPromise = runLogRpc({ env: input.env, userId })
-				.startRun({ run })
-				.catch((error: unknown) => {
-					console.warn('run-record-start-failed', error)
-				})
-			if (input.waitUntil) {
-				input.waitUntil(startPromise)
-			} else {
-				void startPromise
-			}
-		}
+    if (persistence === "eager") {
+      const run = buildRunRow({
+        handle,
+        status: "running",
+        finishedAt: null,
+        durationMs: null,
+        errorName: null,
+        errorMessage: null,
+        updatedAt: startedAt,
+      });
+      // A dropped startRun is deliberately harmless: finishRun upserts the
+      // complete row. That is why begin can stay off the request critical path.
+      const startPromise = runLogRpc({ env: input.env, userId })
+        .startRun({ run })
+        .catch((error: unknown) => {
+          console.warn("run-record-start-failed", error);
+        });
+      if (input.waitUntil) {
+        input.waitUntil(startPromise);
+      } else {
+        void startPromise;
+      }
+    }
 
-		return handle
-	} catch (error) {
-		console.warn('run-record-begin-failed', error)
-		return null
-	}
+    return handle;
+  } catch (error) {
+    console.warn("run-record-begin-failed", error);
+    return null;
+  }
 }
 
 /**
@@ -255,93 +255,92 @@ export function beginRunRecord(input: {
  * it.
  */
 export async function finishRunRecord(input: {
-	env: Env
-	handle: RunRecordHandle | null
-	status: RunTerminalStatus
-	logs?: Array<RunRecordLogInput>
-	error?: unknown
-	waitUntil?: (promise: Promise<unknown>) => void
+  env: Env;
+  handle: RunRecordHandle | null;
+  status: RunTerminalStatus;
+  logs?: Array<RunRecordLogInput>;
+  error?: unknown;
+  waitUntil?: (promise: Promise<unknown>) => void;
 }): Promise<void> {
-	const handle = input.handle
-	if (!handle) return
-	if (handle.persistence === 'on-failure' && input.status === 'success') {
-		return
-	}
+  const handle = input.handle;
+  if (!handle) return;
+  if (handle.persistence === "on-failure" && input.status === "success") {
+    return;
+  }
 
-	const work = (async () => {
-		let persistedRun: RunLogRowInput | null = null
-		try {
-			if (runLogBinding(input.env)) {
-				const finishedAt = new Date().toISOString()
-				const durationMs = Math.max(
-					0,
-					Date.parse(finishedAt) - Date.parse(handle.startedAt),
-				)
-				const { errorName, errorMessage } = getErrorFields(input.error)
-				const run = buildRunRow({
-					handle,
-					status: input.status,
-					finishedAt,
-					durationMs,
-					errorName,
-					errorMessage,
-					updatedAt: finishedAt,
-				})
-				await runLogRpc({ env: input.env, userId: handle.userId }).finishRun({
-					run,
-					logs: normalizeLogs(input.logs),
-				})
-				persistedRun = run
-			}
-		} catch (error) {
-			console.warn('run-record-finish-failed', error)
-		}
+  const work = (async () => {
+    let persistedRun: RunLogRowInput | null = null;
+    try {
+      if (runLogBinding(input.env)) {
+        const finishedAt = new Date().toISOString();
+        const durationMs = Math.max(
+          0,
+          Date.parse(finishedAt) - Date.parse(handle.startedAt),
+        );
+        const { errorName, errorMessage } = getErrorFields(input.error);
+        const run = buildRunRow({
+          handle,
+          status: input.status,
+          finishedAt,
+          durationMs,
+          errorName,
+          errorMessage,
+          updatedAt: finishedAt,
+        });
+        await runLogRpc({ env: input.env, userId: handle.userId }).finishRun({
+          run,
+          logs: normalizeLogs(input.logs),
+        });
+        persistedRun = run;
+      }
+    } catch (error) {
+      console.warn("run-record-finish-failed", error);
+    }
 
-		if (input.status === 'success') {
-			const packageId = normalizeOptionalString(handle.context.packageId)
-			if (packageId) {
-				try {
-					await recordSuccessfulPackageRun(input.env, {
-						userId: handle.userId,
-						packageId,
-						surface: handle.context.surface,
-					})
-				} catch (error) {
-					console.warn('run-record-activation-failed', error)
-				}
-			}
-		}
+    if (input.status === "success") {
+      const packageId = normalizeOptionalString(handle.context.packageId);
+      if (packageId) {
+        try {
+          await recordSuccessfulPackageRun(input.env, {
+            userId: handle.userId,
+            packageId,
+            surface: handle.context.surface,
+          });
+        } catch (error) {
+          console.warn("run-record-activation-failed", error);
+        }
+      }
+    }
 
-		if (
-			persistedRun &&
-			input.status === 'error' &&
-			handle.context.surface !== 'subscription'
-		) {
-			try {
-				// Dynamic import: a static edge to package-subscriptions pulls
-				// package-invocations and deepens the account-export cycle
-				// (account-export → … → account-export-shared → account-export),
-				// leaving z.enum(accountExportSectionNames) undefined at module load.
-				const { dispatchRunErrorSubscriptionEvents } = await import(
-					'./package-subscriptions.ts'
-				)
-				await dispatchRunErrorSubscriptionEvents({
-					env: input.env,
-					userId: handle.userId,
-					run: persistedRun,
-					waitUntil: input.waitUntil,
-				})
-			} catch (error) {
-				console.warn('run-error-subscription-dispatch-failed', error)
-			}
-		}
-	})()
+    if (
+      persistedRun &&
+      input.status === "error" &&
+      handle.context.surface !== "subscription"
+    ) {
+      try {
+        // Dynamic import: a static edge to package-subscriptions pulls
+        // package-invocations and deepens the account-export cycle
+        // (account-export → … → account-export-shared → account-export),
+        // leaving z.enum(accountExportSectionNames) undefined at module load.
+        const { dispatchRunErrorSubscriptionEvents } =
+          await import("./package-subscriptions.ts");
+        await dispatchRunErrorSubscriptionEvents({
+          env: input.env,
+          userId: handle.userId,
+          run: persistedRun,
+          waitUntil: input.waitUntil,
+        });
+      } catch (error) {
+        console.warn("run-error-subscription-dispatch-failed", error);
+      }
+    }
+  })();
 
-	if (input.waitUntil) {
-		input.waitUntil(work)
-		return
-	}
-	await work
+  if (input.waitUntil) {
+    input.waitUntil(work);
+    return;
+  }
+  await work;
 }
 
 /**
@@ -351,145 +350,145 @@ export async function finishRunRecord(input: {
  * no-op begin when the surface is known to be terminal-only.
  */
 export async function recordRunRecord(input: {
-	env: Env
-	userId?: string | null
-	context?: RunRecordContext | null
-	status: RunTerminalStatus
-	logs?: Array<RunRecordLogInput>
-	error?: unknown
-	startedAt?: string | null
-	waitUntil?: (promise: Promise<unknown>) => void
+  env: Env;
+  userId?: string | null;
+  context?: RunRecordContext | null;
+  status: RunTerminalStatus;
+  logs?: Array<RunRecordLogInput>;
+  error?: unknown;
+  startedAt?: string | null;
+  waitUntil?: (promise: Promise<unknown>) => void;
 }): Promise<RunRecordHandle | null> {
-	const namespace = runLogBinding(input.env)
-	const userId = normalizeOptionalString(input.userId ?? undefined)
-	const context = input.context
-	if (!namespace || !userId || !context) return null
+  const namespace = runLogBinding(input.env);
+  const userId = normalizeOptionalString(input.userId ?? undefined);
+  const context = input.context;
+  if (!namespace || !userId || !context) return null;
 
-	let handle: RunRecordHandle
-	try {
-		handle = {
-			id: crypto.randomUUID(),
-			userId,
-			startedAt:
-				normalizeOptionalString(input.startedAt) ?? new Date().toISOString(),
-			persistence: runPersistenceForSurface(context.surface),
-			context,
-		}
-	} catch (error) {
-		console.warn('run-record-begin-failed', error)
-		return null
-	}
-	await finishRunRecord({
-		env: input.env,
-		handle,
-		status: input.status,
-		logs: input.logs,
-		error: input.error,
-		waitUntil: input.waitUntil,
-	})
-	return handle
+  let handle: RunRecordHandle;
+  try {
+    handle = {
+      id: crypto.randomUUID(),
+      userId,
+      startedAt:
+        normalizeOptionalString(input.startedAt) ?? new Date().toISOString(),
+      persistence: runPersistenceForSurface(context.surface),
+      context,
+    };
+  } catch (error) {
+    console.warn("run-record-begin-failed", error);
+    return null;
+  }
+  await finishRunRecord({
+    env: input.env,
+    handle,
+    status: input.status,
+    logs: input.logs,
+    error: input.error,
+    waitUntil: input.waitUntil,
+  });
+  return handle;
 }
 
 export async function listRunRecords(input: {
-	env: Env
-	userId: string
-	filter?: RunRecordFilter | null
-	limit?: number | null
-	cursor?: string | null
+  env: Env;
+  userId: string;
+  filter?: RunRecordFilter | null;
+  limit?: number | null;
+  cursor?: string | null;
 }): Promise<RunRecordPage> {
-	if (!runLogBinding(input.env)) {
-		return { runs: [], nextCursor: null }
-	}
-	const limit = Math.min(
-		Math.max(input.limit ?? runRecordDefaultPageSize, 1),
-		runRecordMaxPageSize,
-	)
-	return await runLogRpc({ env: input.env, userId: input.userId }).listRuns({
-		surface: input.filter?.surface ?? null,
-		status: input.filter?.status ?? null,
-		packageId: normalizeOptionalString(input.filter?.packageId),
-		jobId: normalizeOptionalString(input.filter?.jobId),
-		name: normalizeOptionalString(input.filter?.name),
-		since: normalizeOptionalString(input.filter?.since),
-		limit,
-		cursor: input.cursor ?? null,
-	})
+  if (!runLogBinding(input.env)) {
+    return { runs: [], nextCursor: null };
+  }
+  const limit = Math.min(
+    Math.max(input.limit ?? runRecordDefaultPageSize, 1),
+    runRecordMaxPageSize,
+  );
+  return await runLogRpc({ env: input.env, userId: input.userId }).listRuns({
+    surface: input.filter?.surface ?? null,
+    status: input.filter?.status ?? null,
+    packageId: normalizeOptionalString(input.filter?.packageId),
+    jobId: normalizeOptionalString(input.filter?.jobId),
+    name: normalizeOptionalString(input.filter?.name),
+    since: normalizeOptionalString(input.filter?.since),
+    limit,
+    cursor: input.cursor ?? null,
+  });
 }
 
 export async function getRunRecord(input: {
-	env: Env
-	userId: string
-	runId: string
+  env: Env;
+  userId: string;
+  runId: string;
 }): Promise<{ run: RunRecord; logs: Array<RunRecordLog> } | null> {
-	if (!runLogBinding(input.env)) return null
-	return await runLogRpc({ env: input.env, userId: input.userId }).getRun({
-		runId: input.runId,
-	})
+  if (!runLogBinding(input.env)) return null;
+  return await runLogRpc({ env: input.env, userId: input.userId }).getRun({
+    runId: input.runId,
+  });
 }
 
 export async function summarizeRunRecords(input: {
-	env: Env
-	userId: string
-	since?: string | null
+  env: Env;
+  userId: string;
+  since?: string | null;
 }): Promise<RunRecordSummary> {
-	const since =
-		normalizeOptionalString(input.since) ?? new Date(0).toISOString()
-	if (!runLogBinding(input.env)) {
-		return {
-			since,
-			total: 0,
-			errors: 0,
-			running: 0,
-			bySurface: [],
-		}
-	}
-	return await runLogRpc({ env: input.env, userId: input.userId }).summarize({
-		since,
-	})
+  const since =
+    normalizeOptionalString(input.since) ?? new Date(0).toISOString();
+  if (!runLogBinding(input.env)) {
+    return {
+      since,
+      total: 0,
+      errors: 0,
+      running: 0,
+      bySurface: [],
+    };
+  }
+  return await runLogRpc({ env: input.env, userId: input.userId }).summarize({
+    since,
+  });
 }
 
 export async function listRunRecordStorageIds(input: {
-	env: Env
-	userId: string
+  env: Env;
+  userId: string;
 }): Promise<Array<string>> {
-	if (!runLogBinding(input.env)) return []
-	return await runLogRpc({
-		env: input.env,
-		userId: input.userId,
-	}).listStorageIds()
+  if (!runLogBinding(input.env)) return [];
+  return await runLogRpc({
+    env: input.env,
+    userId: input.userId,
+  }).listStorageIds();
 }
 
 export async function exportRunRecords(input: {
-	env: Env
-	userId: string
-	pageSize?: number
-	startAfter?: string | null
+  env: Env;
+  userId: string;
+  pageSize?: number;
+  startAfter?: string | null;
 }): Promise<{
-	runs: Array<RunRecord>
-	logs: Array<RunRecordLog>
-	nextStartAfter: string | null
-	truncated: boolean
+  runs: Array<RunRecord>;
+  logs: Array<RunRecordLog>;
+  nextStartAfter: string | null;
+  truncated: boolean;
 }> {
-	if (!runLogBinding(input.env)) {
-		return {
-			runs: [],
-			logs: [],
-			nextStartAfter: null,
-			truncated: false,
-		}
-	}
-	return await runLogRpc({ env: input.env, userId: input.userId }).exportRuns({
-		pageSize: input.pageSize ?? runRecordDefaultPageSize,
-		startAfter: input.startAfter ?? null,
-	})
+  if (!runLogBinding(input.env)) {
+    return {
+      runs: [],
+      logs: [],
+      nextStartAfter: null,
+      truncated: false,
+    };
+  }
+  return await runLogRpc({ env: input.env, userId: input.userId }).exportRuns({
+    pageSize: input.pageSize ?? runRecordDefaultPageSize,
+    startAfter: input.startAfter ?? null,
+  });
 }
 
 export async function clearRunRecords(input: {
-	env: Env
-	userId: string
+  env: Env;
+  userId: string;
 }): Promise<void> {
-	if (!runLogBinding(input.env)) return
-	await runLogRpc({ env: input.env, userId: input.userId }).clearAll()
+  if (!runLogBinding(input.env)) return;
+  await runLogRpc({ env: input.env, userId: input.userId }).clearAll();
 }
 
-export type { RunLogRpc }
+export type { RunLogRpc };

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -1,6 +1,7 @@
 import { toJsonSafeValue } from '@kody-internal/shared/json-safe-value.ts'
 import { recordSuccessfulPackageRun } from '#worker/usage/activation.ts'
 import { runLogDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
+import { dispatchRunErrorSubscriptionEvents } from './package-subscriptions.ts'
 import {
 	type RunLogEntryInput,
 	type RunLogRowInput,
@@ -269,6 +270,7 @@ export async function finishRunRecord(input: {
 	}
 
 	const work = (async () => {
+		let persistedRun: RunLogRowInput | null = null
 		try {
 			if (runLogBinding(input.env)) {
 				const finishedAt = new Date().toISOString()
@@ -290,6 +292,7 @@ export async function finishRunRecord(input: {
 					run,
 					logs: normalizeLogs(input.logs),
 				})
+				persistedRun = run
 			}
 		} catch (error) {
 			console.warn('run-record-finish-failed', error)
@@ -307,6 +310,23 @@ export async function finishRunRecord(input: {
 				} catch (error) {
 					console.warn('run-record-activation-failed', error)
 				}
+			}
+		}
+
+		if (
+			persistedRun &&
+			input.status === 'error' &&
+			handle.context.surface !== 'subscription'
+		) {
+			try {
+				await dispatchRunErrorSubscriptionEvents({
+					env: input.env,
+					userId: handle.userId,
+					run: persistedRun,
+					waitUntil: input.waitUntil,
+				})
+			} catch (error) {
+				console.warn('run-error-subscription-dispatch-failed', error)
 			}
 		}
 	})()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Packages can now subscribe to Activity/run-record failures via the existing package subscription primitive.

When a user-scoped run finishes with `status: 'error'` (and is actually persisted), Kody dispatches `run.error.recorded` to that user's packages that declare the topic in `package.json#kody.subscriptions`. Handlers get a metadata-first payload (run identifiers + truncated error fields + `activity_url`) and can email, write to Sheets, spawn an agent, etc. Full logs stay behind `run_get`.

### Design notes

- Same-user delivery (mirrors `email.message.received`), not admin fan-out
- Best-effort after successful DO write — never fails the observed run path
- Recursion guard: `surface === 'subscription'` never emits (handler failures would otherwise loop)
- No new Queue for v1

### Example

```json
{
  "kody": {
    "subscriptions": {
      "run.error.recorded": {
        "handler": "./src/on-run-error.ts",
        "description": "Notify when something in Activity fails."
      }
    }
  }
}
```

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/run-error-subscription-d8de`

**Classification:** extends — run-record finish now fans out a public package subscription topic; capability copy and docs update accordingly.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `run-records` | storage | extends — emit `run.error.recorded` after persisted error finishes |
| `saved-packages` | assistant | composes — `package_subscriptions_list` topic examples |
| `capability-registry` | assistant | composes — official guide / list capability copy |

### System map

Terminal error run records now discover same-user package subscriptions and invoke handlers after the DO write.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	runRecords["run-records<br/>Run records"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	runRecords -->|"finishRunRecord dispatches run.error.recorded"| savedPackages
	capabilityRegistry -->|"documents topic in list/guide copy"| savedPackages
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Surface as Runtime surface
	participant Finish as finishRunRecord
	participant DO as RunLog DO
	participant Dispatch as run.error.recorded dispatch
	participant Pkg as User package handler
	Surface->>Finish: status=error
	Finish->>DO: finishRun (persist)
	alt persisted and surface != subscription
		Finish->>Dispatch: best-effort fan-out
		Dispatch->>Pkg: invokePackageSubscription
	end
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Package react to Activity errors | Poll `run_list` / manual | Declare `run.error.recorded` subscription |
| Subscription surfaces on error | N/A | Skipped (recursion guard) |

### Invariants

- `per-user-isolation` — dispatch loads only the failing run owner's packages; payload is that user's run metadata

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eaaf112b-3e5b-47ff-b6be-b1262fd9d8de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaaf112b-3e5b-47ff-b6be-b1262fd9d8de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `run.error.recorded` package subscription support for activity/package error notifications (emitted after an error terminal run is successfully persisted).
  * Events use a metadata-first payload with an `activity_url`; delivery is best-effort and avoids recursion from subscription-surface runs.
* **Documentation**
  * Expanded architecture, package/subscription, and usage guides (including the guides index and MCP capability text) to cover `run.error.recorded` payload and delivery rules.
* **Tests**
  * Added/expanded coverage for dispatch filtering, payload shaping, per-package failure isolation, and warning-only behavior when dispatch/discovery fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->