### PR TITLE
fix(repo): run publish typecheck before bundling to halve peak DO memory

### DIFF
--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -170,6 +170,7 @@ async function runPackageJobTypecheckChecks(
 	mockModule.createTypescriptLanguageService.mockResolvedValue({
 		fileSystem: typeScriptFileSystem,
 		languageService: {
+			dispose: vi.fn(),
 			getSemanticDiagnostics,
 		},
 	})
@@ -341,6 +342,7 @@ test('runRepoChecks strips repo-session workspace prefixes from package snapshot
 	mockModule.createTypescriptLanguageService.mockResolvedValue({
 		fileSystem: typeScriptFileSystem,
 		languageService: {
+			dispose: vi.fn(),
 			getSemanticDiagnostics,
 		},
 	})
@@ -574,6 +576,7 @@ test('runRepoChecks validates every persisted package artifact target before pub
 	mockModule.createTypescriptLanguageService.mockResolvedValue({
 		fileSystem: typeScriptFileSystem,
 		languageService: {
+			dispose: vi.fn(),
 			getSemanticDiagnostics,
 		},
 	})
@@ -666,6 +669,7 @@ test('runRepoChecks still reports unknown globals for package-owned jobs', async
 	mockModule.createTypescriptLanguageService.mockResolvedValue({
 		fileSystem: typeScriptFileSystem,
 		languageService: {
+			dispose: vi.fn(),
 			getSemanticDiagnostics,
 		},
 	})
@@ -729,6 +733,7 @@ test('runRepoChecks injects package tsconfig overlays that allow optional .ts im
 		mockModule.createTypescriptLanguageService.mockResolvedValue({
 			fileSystem: typeScriptFileSystem,
 			languageService: {
+				dispose: vi.fn(),
 				getSemanticDiagnostics: vi.fn(() => []),
 			},
 		})
@@ -1040,6 +1045,7 @@ test('runRepoChecks surfaces bundle validation failures when runtime bundling ca
 	mockModule.createTypescriptLanguageService.mockResolvedValue({
 		fileSystem: unresolvedTypeScriptFileSystem,
 		languageService: {
+			dispose: vi.fn(),
 			getSemanticDiagnostics: vi.fn(() => []),
 		},
 	})
@@ -1126,6 +1132,7 @@ test('runRepoChecks surfaces bundle validation failures when runtime bundling ca
 	mockModule.createTypescriptLanguageService.mockResolvedValue({
 		fileSystem: unresolvedVersionTypeScriptFileSystem,
 		languageService: {
+			dispose: vi.fn(),
 			getSemanticDiagnostics: vi.fn(() => []),
 		},
 	})
@@ -1193,6 +1200,7 @@ test('runRepoChecks fails before publish when an exported module artifact cannot
 	mockModule.createTypescriptLanguageService.mockResolvedValue({
 		fileSystem: typeScriptFileSystem,
 		languageService: {
+			dispose: vi.fn(),
 			getSemanticDiagnostics: vi.fn(() => []),
 		},
 	})
@@ -1282,6 +1290,7 @@ test('runRepoChecks validates package runtime bundles with npm dependencies', as
 	mockModule.createTypescriptLanguageService.mockResolvedValue({
 		fileSystem: typeScriptFileSystem,
 		languageService: {
+			dispose: vi.fn(),
 			getSemanticDiagnostics,
 		},
 	})

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -839,21 +839,27 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 			fileSystem: typecheckFileSystem,
 		},
 	)
-	const diagnostics = getPackageTypecheckDiagnostics({
-		targets: input.entryPoints.map((entryPoint) => ({
-			path: entryPoint.path,
-			includeStorage: entryPoint.includeStorage === true,
-			emittedEventTopics: input.emittedEventTopics ?? [],
-		})),
-		languageService,
-		fileSystem,
-	})
-	const ok = diagnostics.every((entry) => entry.diagnostics.length === 0)
-	return {
-		ok,
-		message: ok
-			? `No semantic diagnostics for ${input.entryPoints.length} package runtime entrypoint(s).`
-			: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
+	try {
+		const diagnostics = getPackageTypecheckDiagnostics({
+			targets: input.entryPoints.map((entryPoint) => ({
+				path: entryPoint.path,
+				includeStorage: entryPoint.includeStorage === true,
+				emittedEventTopics: input.emittedEventTopics ?? [],
+			})),
+			languageService,
+			fileSystem,
+		})
+		const ok = diagnostics.every((entry) => entry.diagnostics.length === 0)
+		return {
+			ok,
+			message: ok
+				? `No semantic diagnostics for ${input.entryPoints.length} package runtime entrypoint(s).`
+				: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
+		}
+	} finally {
+		// Release the compiler program eagerly; large snapshots otherwise keep
+		// the whole TypeScript program reachable until GC gets around to it.
+		languageService.dispose()
 	}
 }
 
@@ -1160,17 +1166,22 @@ export async function runRepoChecks(input: {
 			await createTypescriptLanguageService({
 				fileSystem: typecheckFileSystem,
 			})
-		const diagnostics = getPackageTypecheckDiagnostics({
-			targets: callableTypecheckTargets,
-			languageService,
-			fileSystem,
-		})
-		return {
-			kind: 'typecheck',
-			ok: diagnostics.every((entry) => entry.diagnostics.length === 0),
-			message: diagnostics.every((entry) => entry.diagnostics.length === 0)
-				? `No semantic diagnostics for ${callableTypecheckTargets.length} callable package runtime entrypoint(s).`
-				: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
+		try {
+			const diagnostics = getPackageTypecheckDiagnostics({
+				targets: callableTypecheckTargets,
+				languageService,
+				fileSystem,
+			})
+			return {
+				kind: 'typecheck',
+				ok: diagnostics.every((entry) => entry.diagnostics.length === 0),
+				message: diagnostics.every((entry) => entry.diagnostics.length === 0)
+					? `No semantic diagnostics for ${callableTypecheckTargets.length} callable package runtime entrypoint(s).`
+					: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
+			}
+		} finally {
+			// Release the compiler program before bundling allocates.
+			languageService.dispose()
 		}
 	})()
 

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1098,6 +1098,82 @@ export async function runRepoChecks(input: {
 					userId: input.userId,
 				}
 			: null
+	// The TypeScript check runs BEFORE bundle validation, inside a helper
+	// scope. The language service allocates a large JS heap (the compiler
+	// plus a full program over the snapshot) that becomes collectable once
+	// this closure returns, while esbuild-wasm memory grown during bundling
+	// stays resident for the isolate's lifetime (the wasm instance is a
+	// module-level singleton and wasm memories never shrink). Typechecking
+	// first keeps peak isolate memory near max(typecheck, bundling) instead
+	// of their sum — checks over large multi-entrypoint packages were
+	// exceeding the Durable Object memory limit and killing publishes
+	// (kentcdodds/kody#987). The reported `results` order is unchanged:
+	// bundle before typecheck.
+	const typecheckResult: RepoCheckResult = await (async () => {
+		if (missingCallableTypecheckTargets.length > 0) {
+			return {
+				kind: 'typecheck',
+				ok: false,
+				message: `Typecheck skipped because callable package runtime entrypoint(s) are missing from the repo session snapshot: ${missingCallableTypecheckTargets
+					.map((path) => `"${path}"`)
+					.join(', ')}.`,
+			}
+		}
+		const callableTargetsMissingDefaultExport =
+			collectEntrypointsMissingDefaultExport({
+				snapshot,
+				targets: callableTypecheckTargets,
+			})
+		if (callableTargetsMissingDefaultExport.length > 0) {
+			return {
+				kind: 'typecheck',
+				ok: false,
+				message: formatMissingDefaultExportMessage(
+					callableTargetsMissingDefaultExport,
+				),
+			}
+		}
+		if (callableTypecheckTargets.length === 0) {
+			return {
+				kind: 'typecheck',
+				ok: true,
+				message: 'No callable package runtime entrypoint(s) to typecheck.',
+			}
+		}
+		const typecheckFileSystem = createRepoChecksFileSystem({
+			fileSystem: snapshot,
+		})
+		const baseTsconfig = snapshot.read(repoChecksSyntheticTsconfigPath)
+		if (baseTsconfig != null) {
+			typecheckFileSystem.write(
+				repoChecksSyntheticTsconfigExtendsPath.slice('./'.length),
+				baseTsconfig,
+			)
+		}
+		typecheckFileSystem.write(
+			repoChecksSyntheticTsconfigPath,
+			buildRepoChecksTsconfig(baseTsconfig),
+		)
+		const { createTypescriptLanguageService } =
+			await loadWorkerBundlerTypescriptTools()
+		const { fileSystem, languageService } =
+			await createTypescriptLanguageService({
+				fileSystem: typecheckFileSystem,
+			})
+		const diagnostics = getPackageTypecheckDiagnostics({
+			targets: callableTypecheckTargets,
+			languageService,
+			fileSystem,
+		})
+		return {
+			kind: 'typecheck',
+			ok: diagnostics.every((entry) => entry.diagnostics.length === 0),
+			message: diagnostics.every((entry) => entry.diagnostics.length === 0)
+				? `No semantic diagnostics for ${callableTypecheckTargets.length} callable package runtime entrypoint(s).`
+				: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
+		}
+	})()
+
 	const bundleCheckResult =
 		missingBundleTargets.length > 0
 			? {
@@ -1125,107 +1201,7 @@ export async function runRepoChecks(input: {
 		ok: bundleCheckResult.ok,
 		message: bundleCheckResult.message,
 	})
-
-	if (missingCallableTypecheckTargets.length > 0) {
-		results.push({
-			kind: 'typecheck',
-			ok: false,
-			message: `Typecheck skipped because callable package runtime entrypoint(s) are missing from the repo session snapshot: ${missingCallableTypecheckTargets
-				.map((path) => `"${path}"`)
-				.join(', ')}.`,
-		})
-		results.push({
-			kind: 'lint',
-			ok: lintCheck.ok,
-			message: lintCheck.message,
-		})
-		return {
-			ok: results.every((result) => result.ok),
-			results,
-			manifest,
-			sourceFiles,
-		}
-	}
-
-	const callableTargetsMissingDefaultExport =
-		collectEntrypointsMissingDefaultExport({
-			snapshot,
-			targets: callableTypecheckTargets,
-		})
-	if (callableTargetsMissingDefaultExport.length > 0) {
-		results.push({
-			kind: 'typecheck',
-			ok: false,
-			message: formatMissingDefaultExportMessage(
-				callableTargetsMissingDefaultExport,
-			),
-		})
-		results.push({
-			kind: 'lint',
-			ok: lintCheck.ok,
-			message: lintCheck.message,
-		})
-		return {
-			ok: results.every((result) => result.ok),
-			results,
-			manifest,
-			sourceFiles,
-		}
-	}
-
-	if (callableTypecheckTargets.length === 0) {
-		results.push({
-			kind: 'typecheck',
-			ok: true,
-			message: 'No callable package runtime entrypoint(s) to typecheck.',
-		})
-		results.push({
-			kind: 'lint',
-			ok: lintCheck.ok,
-			message: lintCheck.message,
-		})
-		return {
-			ok: results.every((result) => result.ok),
-			results,
-			manifest,
-			sourceFiles,
-		}
-	}
-
-	const typecheckFileSystem = createRepoChecksFileSystem({
-		fileSystem: snapshot,
-	})
-	const baseTsconfig = snapshot.read(repoChecksSyntheticTsconfigPath)
-	if (baseTsconfig != null) {
-		typecheckFileSystem.write(
-			repoChecksSyntheticTsconfigExtendsPath.slice('./'.length),
-			baseTsconfig,
-		)
-	}
-	typecheckFileSystem.write(
-		repoChecksSyntheticTsconfigPath,
-		buildRepoChecksTsconfig(baseTsconfig),
-	)
-	const { createTypescriptLanguageService } =
-		await loadWorkerBundlerTypescriptTools()
-	const { fileSystem, languageService } = await createTypescriptLanguageService(
-		{
-			fileSystem: typecheckFileSystem,
-		},
-	)
-	const diagnostics = getPackageTypecheckDiagnostics({
-		targets: callableTypecheckTargets,
-		languageService,
-		fileSystem,
-	})
-	results.push({
-		kind: 'typecheck',
-		ok: diagnostics.every((entry) => entry.diagnostics.length === 0),
-		message: diagnostics.every((entry) => entry.diagnostics.length === 0)
-			? `No semantic diagnostics for ${callableTypecheckTargets.length} callable package runtime entrypoint(s).`
-			: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
-	})
-
+	results.push(typecheckResult)
 	results.push({
 		kind: 'lint',
 		ok: lintCheck.ok,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #987.

`runRepoChecks` stacked the TypeScript language service's large JS heap on top of esbuild-wasm memory grown during bundle validation. The esbuild wasm instance is a module-level singleton (`@cloudflare/worker-bundler` initializes it once per isolate) and wasm memories never shrink, so checks over a large multi-entrypoint package exceeded the Durable Object isolate memory limit and killed every publish attempt — three DO resets per call, deterministic.

**Live evidence** (2026-07-27/28, `@kentcdodds/personal-history`, 14 bundle targets + app over ~809 KB source):
- `package_publish_external_push`: failed 5/5 calls with "Durable Object's isolate exceeded its memory limit and was reset".
- Session lane (`repo_run_commands` with `run_checks: true`): **same isolate memory reset**, which pins the OOM to the checks phase (bundles + typecheck), not the git clone.
- `tesla-solar` (6 exports / 53 KB) and `environment` (9 exports / 59 KB) published cleanly minutes earlier via the identical flow.

**Change**: typechecking now runs *before* bundle validation, inside a helper closure whose references (language service, program, typecheck filesystem) become collectable before esbuild ever grows the wasm heap. Peak isolate memory drops from roughly `typecheck + bundling` to `max(typecheck, bundling)`. The reported `results` array keeps its existing order (`manifest`, `dependencies`, `bundle`, `typecheck`, `lint`) and all early-outcome semantics (missing targets, missing default exports, zero targets) are unchanged — the three duplicated early-return blocks collapse into the helper.

If a future package outgrows even a single phase, the durable end state is splitting check phases across isolates; this is the low-risk first-order fix.

**Testing**: `checks.node.test.ts`, `external-publish.node.test.ts`, `repo-session-do.node.test.ts` (29 tests) pass; worker typecheck clean; lint/format clean (2 pre-existing warnings in unrelated files). After deploy, the concrete acceptance test is republishing `@kentcdodds/personal-history` (its migration commit is parked on the `restore-safe-prompt-history` branch of its Artifacts repo — see #987).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `a2d7b760`

**Classification:** extends — reorders phases inside the repo-session publish checks; no new primitives, no contract changes (check result order and messages unchanged).

### Primitives touched

| Primitive       | Group    | Impact                                                              |
| --------------- | -------- | -------------------------------------------------------------------- |
| `repo-sessions` | storage  | extends — `runRepoChecks` executes typecheck before bundle validation |

### System map

One-file change inside the repo-session checks path; no cross-primitive edges change.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
	repoSessions["repo-sessions<br/>Repo-backed source sessions"]:::extended
	repoSessions -->|"runRepoChecks: typecheck phase now precedes esbuild bundle validation"| repoSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository validation for callable entrypoints and default exports.
  * Ensured bundle, typecheck, and lint results are consistently reported, including when typechecking is skipped or encounters issues.
  * Enhanced semantic TypeScript diagnostics for callable targets.
  * Overall validation status now accurately reflects all completed checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->