### PR TITLE
fix(repo): keep invalid package.json publish failures out of Sentry

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -233,7 +233,12 @@ const outputSchema = z.discriminatedUnion('status', [
 	z.object({
 		status: z.literal('checks_failed'),
 		failed_checks: z.array(checkSchema),
-		manifest: z.unknown(),
+		manifest: z
+			.unknown()
+			.nullable()
+			.describe(
+				'Parsed package.json when available; null when the manifest itself failed validation or was missing.',
+			),
 		run_id: z.string(),
 	}),
 	z.object({

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
@@ -39,6 +41,25 @@ import {
 	packageSummarySchema,
 	pendingPackageSecretApprovalsSchema,
 } from './shared.ts'
+
+function parseSavedPackageManifest(input: {
+	content: string
+	expectedPackageScope: string
+}) {
+	try {
+		const manifest = parseAuthoredPackageJson({
+			content: input.content,
+			manifestPath: 'package.json',
+			expectedPackageScope: input.expectedPackageScope,
+		})
+		assertKodyDescriptionLength(manifest.kody.description)
+		return manifest
+	} catch (error) {
+		// Caller-authored package.json mistakes (wrong kody.dependencies shape,
+		// scope mismatches, etc.) — keep them off Sentry via McpCallerError.
+		throw new McpCallerError(getErrorMessage(error), { cause: error })
+	}
+}
 
 const inputSchema = z
 	.object({
@@ -147,7 +168,9 @@ export const savePackageCapability = defineDomainCapability(
 			let files = normalizeFiles(args.files)
 			let packageJsonContent = files['package.json']
 			if (!packageJsonContent) {
-				throw new Error('Saved packages require a root package.json file.')
+				throw new McpCallerError(
+					'Saved packages require a root package.json file.',
+				)
 			}
 			const expectedPackageScope = owner.ownerScope
 			const existing =
@@ -158,9 +181,8 @@ export const savePackageCapability = defineDomainCapability(
 						})
 					: await getSavedPackageByKodyId(ctx.env.APP_DB, {
 							userId: owner.ownerUserId,
-							kodyId: parseAuthoredPackageJson({
+							kodyId: parseSavedPackageManifest({
 								content: packageJsonContent,
-								manifestPath: 'package.json',
 								expectedPackageScope,
 							}).kody.id,
 						})
@@ -174,12 +196,10 @@ export const savePackageCapability = defineDomainCapability(
 				packageJsonContent = injectDefaultPrivateField(packageJsonContent)
 				files = { ...files, 'package.json': packageJsonContent }
 			}
-			const manifest = parseAuthoredPackageJson({
+			const manifest = parseSavedPackageManifest({
 				content: packageJsonContent,
-				manifestPath: 'package.json',
 				expectedPackageScope,
 			})
-			assertKodyDescriptionLength(manifest.kody.description)
 			const packageId = existing?.id ?? args.package_id ?? crypto.randomUUID()
 			const canonicalExistingSource =
 				existing == null

--- a/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-shared.ts
@@ -463,12 +463,17 @@ export const repoCheckResultSchema = z.object({
 export const repoRunChecksOutputSchema = z.object({
 	ok: z.boolean(),
 	results: z.array(repoCheckResultSchema),
-	manifest: z.object({
-		name: z.string(),
-		kody_id: z.string(),
-		description: z.string(),
-		has_app: z.boolean(),
-	}),
+	manifest: z
+		.object({
+			name: z.string(),
+			kody_id: z.string(),
+			description: z.string(),
+			has_app: z.boolean(),
+		})
+		.nullable()
+		.describe(
+			'Parsed package.json summary when available; null when the manifest itself failed validation or was missing.',
+		),
 })
 
 const repoRunCommandResultSchema = z.object({
@@ -478,7 +483,7 @@ const repoRunCommandResultSchema = z.object({
 	output: z.unknown(),
 })
 
-export function normalizeRepoManifestSummary(manifest: {
+type RepoManifestSummaryInput = {
 	name?: unknown
 	title?: unknown
 	description?: unknown
@@ -487,7 +492,26 @@ export function normalizeRepoManifestSummary(manifest: {
 		description?: unknown
 		app?: unknown
 	}
-}) {
+}
+
+type RepoManifestSummary = {
+	name: string
+	kody_id: string
+	description: string
+	has_app: boolean
+}
+
+export function normalizeRepoManifestSummary(manifest: null): null
+export function normalizeRepoManifestSummary(
+	manifest: RepoManifestSummaryInput,
+): RepoManifestSummary
+export function normalizeRepoManifestSummary(
+	manifest: RepoManifestSummaryInput | null,
+): RepoManifestSummary | null
+export function normalizeRepoManifestSummary(
+	manifest: RepoManifestSummaryInput | null,
+): RepoManifestSummary | null {
+	if (manifest == null) return null
 	const packageName =
 		typeof manifest.name === 'string'
 			? manifest.name

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { getStaticRegistry } from '#mcp/capabilities/registry.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import {
@@ -239,53 +240,53 @@ test('package_save logs parse failures, rejects invalid manifests, and logs succ
 		}),
 	}
 
-	await expect(
-		handler(
-			{
-				files: [
-					{
-						path: 'package.json',
-						content: JSON.stringify({
-							name: 'pkg',
-							kody: {
-								id: 'pkg',
-								description: 'missing exports',
-							},
-						}),
-					},
-				],
-			},
-			signedInContext,
-		),
-	).rejects.toThrow('Invalid package.json')
+	const invalidManifest = handler(
+		{
+			files: [
+				{
+					path: 'package.json',
+					content: JSON.stringify({
+						name: 'pkg',
+						kody: {
+							id: 'pkg',
+							description: 'missing exports',
+						},
+					}),
+				},
+			],
+		},
+		signedInContext,
+	)
+	await expect(invalidManifest).rejects.toThrow(McpCallerError)
+	await expect(invalidManifest).rejects.toThrow('Invalid package.json')
 
-	await expect(
-		handler(
-			{
-				files: [
-					{
-						path: 'package.json',
-						content: JSON.stringify({
-							name: '@other/observed-package',
-							exports: {
-								'.': './src/index.ts',
-							},
-							kody: {
-								id: 'observed-package',
-								description: 'Observation test package.',
-							},
-						}),
-					},
-					{
-						path: 'src/index.ts',
-						content:
-							'export default async function main() { return { ok: true } }\n',
-					},
-				],
-			},
-			signedInContext,
-		),
-	).rejects.toThrow(
+	const wrongScope = handler(
+		{
+			files: [
+				{
+					path: 'package.json',
+					content: JSON.stringify({
+						name: '@other/observed-package',
+						exports: {
+							'.': './src/index.ts',
+						},
+						kody: {
+							id: 'observed-package',
+							description: 'Observation test package.',
+						},
+					}),
+				},
+				{
+					path: 'src/index.ts',
+					content:
+						'export default async function main() { return { ok: true } }\n',
+				},
+			],
+		},
+		signedInContext,
+	)
+	await expect(wrongScope).rejects.toThrow(McpCallerError)
+	await expect(wrongScope).rejects.toThrow(
 		'package.json name "@other/observed-package" must use the authenticated user\'s package scope "@user/*".',
 	)
 	expect(repoMockModule.ensureEntitySource).not.toHaveBeenCalled()

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -812,6 +812,44 @@ test('runRepoChecks injects package tsconfig overlays that allow optional .ts im
 	).toBe(repoTsconfig)
 })
 
+test('runRepoChecks returns a failed manifest check for object-shaped kody.dependencies instead of throwing', async () => {
+	// Agents sometimes confuse npm dependencies (object map) with
+	// kody.dependencies (string array). Publish must return checks_failed, not
+	// throw — otherwise MCP observability opens a Sentry platform-bug issue.
+	const result = await runChecksOnWorkspaceFiles(
+		new Map<string, string>([
+			[
+				'package.json',
+				JSON.stringify({
+					name: '@kody/object-deps',
+					exports: {
+						'.': './src/index.ts',
+					},
+					kody: {
+						id: 'object-deps',
+						description: 'Uses object-shaped kody.dependencies by mistake',
+						dependencies: {
+							'@kentcdodds/helper': 'latest',
+						},
+					},
+				}),
+			],
+			['src/index.ts', 'export const ready = true\n'],
+		]),
+	)
+	expect(result.ok).toBe(false)
+	expect(result.manifest).toBeNull()
+	expect(result.results).toEqual([
+		expect.objectContaining({
+			kind: 'manifest',
+			ok: false,
+			message: expect.stringMatching(
+				/expected array, received object[\s\S]*kody\.dependencies/,
+			),
+		}),
+	])
+})
+
 test('runRepoChecks validates static kody package import declarations across missing, declared, type-only, declaration files, mixed exports, dynamic imports, invalid declarations, and unused declarations', async () => {
 	const missingDeclaration = await runChecksOnWorkspaceFiles(
 		new Map<string, string>([
@@ -957,29 +995,36 @@ test('runRepoChecks validates static kody package import declarations across mis
 		]),
 	)
 
-	await expect(
-		runChecksOnWorkspaceFiles(
-			new Map<string, string>([
-				[
-					'package.json',
-					JSON.stringify({
-						name: '@kody/invalid-dependency-declaration',
-						exports: {
-							'.': './src/index.ts',
-						},
-						kody: {
-							id: 'invalid-dependency-declaration',
-							description: 'Declares an invalid Kody dependency',
-							dependencies: ['@kentcdodds/helper/run'],
-						},
-					}),
-				],
-				['src/index.ts', 'export const ready = true\n'],
-			]),
-		),
-	).rejects.toThrow(
-		'Static Kody package dependencies must be scoped package names like "@scope/package".',
+	const invalidDeclaration = await runChecksOnWorkspaceFiles(
+		new Map<string, string>([
+			[
+				'package.json',
+				JSON.stringify({
+					name: '@kody/invalid-dependency-declaration',
+					exports: {
+						'.': './src/index.ts',
+					},
+					kody: {
+						id: 'invalid-dependency-declaration',
+						description: 'Declares an invalid Kody dependency',
+						dependencies: ['@kentcdodds/helper/run'],
+					},
+				}),
+			],
+			['src/index.ts', 'export const ready = true\n'],
+		]),
 	)
+	expect(invalidDeclaration.ok).toBe(false)
+	expect(invalidDeclaration.manifest).toBeNull()
+	expect(invalidDeclaration.results).toEqual([
+		expect.objectContaining({
+			kind: 'manifest',
+			ok: false,
+			message: expect.stringContaining(
+				'Static Kody package dependencies must be scoped package names like "@scope/package".',
+			),
+		}),
+	])
 
 	const unusedDeclaration = await runChecksOnWorkspaceFiles(
 		new Map<string, string>([

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -50,11 +50,45 @@ export type RepoCheckResult = {
 	message: string
 }
 
-export type RepoCheckRunResult = {
-	ok: boolean
+export type RepoCheckRunResult =
+	| {
+			ok: true
+			results: Array<RepoCheckResult>
+			manifest: AuthoredPackageJson
+			sourceFiles: Record<string, string>
+	  }
+	| {
+			ok: false
+			results: Array<RepoCheckResult>
+			/**
+			 * Present when the authored package.json parsed and only later checks
+			 * failed. Null when the manifest itself is missing or invalid — callers
+			 * must use `results` (kind `manifest`) for the failure message.
+			 */
+			manifest: AuthoredPackageJson | null
+			sourceFiles: Record<string, string>
+	  }
+
+function toRepoCheckRunResult(input: {
 	results: Array<RepoCheckResult>
 	manifest: AuthoredPackageJson
 	sourceFiles: Record<string, string>
+}): RepoCheckRunResult {
+	const ok = input.results.every((result) => result.ok)
+	if (ok) {
+		return {
+			ok: true,
+			results: input.results,
+			manifest: input.manifest,
+			sourceFiles: input.sourceFiles,
+		}
+	}
+	return {
+		ok: false,
+		results: input.results,
+		manifest: input.manifest,
+		sourceFiles: input.sourceFiles,
+	}
 }
 
 const executeTypecheckPreludePath = '.__kody_repo_runtime__.d.ts'
@@ -980,14 +1014,46 @@ export async function runRepoChecks(input: {
 }): Promise<RepoCheckRunResult> {
 	const manifestContent = await input.workspace.readFile(input.manifestPath)
 	if (manifestContent == null) {
-		throw new Error(`Manifest "${input.manifestPath}" was not found.`)
+		// Caller-authored source mistake (missing package.json). Return a failed
+		// check instead of throwing so MCP publish surfaces checks_failed and
+		// does not open a Sentry "platform bug" issue.
+		return {
+			ok: false,
+			results: [
+				{
+					kind: 'manifest',
+					ok: false,
+					message: `Manifest "${input.manifestPath}" was not found.`,
+				},
+			],
+			manifest: null,
+			sourceFiles: {},
+		}
 	}
-	const manifest = parseAuthoredPackageJson({
-		content: manifestContent,
-		manifestPath: input.manifestPath,
-		expectedPackageScope: input.expectedPackageScope,
-	})
-	assertKodyDescriptionLength(manifest.kody.description)
+	let manifest: AuthoredPackageJson
+	try {
+		manifest = parseAuthoredPackageJson({
+			content: manifestContent,
+			manifestPath: input.manifestPath,
+			expectedPackageScope: input.expectedPackageScope,
+		})
+		assertKodyDescriptionLength(manifest.kody.description)
+	} catch (error) {
+		// Invalid package.json shape (e.g. kody.dependencies as an object) is a
+		// caller fix — keep it on the check result path, not as an exception.
+		return {
+			ok: false,
+			results: [
+				{
+					kind: 'manifest',
+					ok: false,
+					message: getErrorMessage(error),
+				},
+			],
+			manifest: null,
+			sourceFiles: {},
+		}
+	}
 	const results: Array<RepoCheckResult> = [
 		{
 			kind: 'manifest',
@@ -1036,12 +1102,11 @@ export async function runRepoChecks(input: {
 			ok: false,
 			message: sourceWalk.message,
 		})
-		return {
-			ok: false,
+		return toRepoCheckRunResult({
 			results,
 			manifest,
 			sourceFiles: {},
-		}
+		})
 	}
 	const sourceFiles = sourceWalk.collected
 	const lintCheck = buildLintCheck(sourceFiles)
@@ -1139,12 +1204,11 @@ export async function runRepoChecks(input: {
 			ok: lintCheck.ok,
 			message: lintCheck.message,
 		})
-		return {
-			ok: results.every((result) => result.ok),
+		return toRepoCheckRunResult({
 			results,
 			manifest,
 			sourceFiles,
-		}
+		})
 	}
 
 	const callableTargetsMissingDefaultExport =
@@ -1165,12 +1229,11 @@ export async function runRepoChecks(input: {
 			ok: lintCheck.ok,
 			message: lintCheck.message,
 		})
-		return {
-			ok: results.every((result) => result.ok),
+		return toRepoCheckRunResult({
 			results,
 			manifest,
 			sourceFiles,
-		}
+		})
 	}
 
 	if (callableTypecheckTargets.length === 0) {
@@ -1184,12 +1247,11 @@ export async function runRepoChecks(input: {
 			ok: lintCheck.ok,
 			message: lintCheck.message,
 		})
-		return {
-			ok: results.every((result) => result.ok),
+		return toRepoCheckRunResult({
 			results,
 			manifest,
 			sourceFiles,
-		}
+		})
 	}
 
 	const typecheckFileSystem = createRepoChecksFileSystem({
@@ -1232,10 +1294,9 @@ export async function runRepoChecks(input: {
 		message: lintCheck.message,
 	})
 
-	return {
-		ok: results.every((result) => result.ok),
+	return toRepoCheckRunResult({
 		results,
 		manifest,
 		sourceFiles,
-	}
+	})
 }

--- a/packages/worker/src/repo/types.ts
+++ b/packages/worker/src/repo/types.ts
@@ -279,7 +279,8 @@ export type RepoSessionCheckRun = {
 		ok: boolean
 		message: string
 	}>
-	manifest: AuthoredPackageJson
+	/** Null when package.json itself failed to parse or was missing. */
+	manifest: AuthoredPackageJson | null
 	runId: string
 	treeHash: string
 	checkedAt: string
@@ -322,7 +323,8 @@ export type RepoExternalPublishResult =
 	| {
 			status: 'checks_failed'
 			failed_checks: NonNullable<RepoSessionCheckStatus['results']>
-			manifest: AuthoredPackageJson
+			/** Null when package.json itself failed to parse or was missing. */
+			manifest: AuthoredPackageJson | null
 			run_id: string
 	  }
 	| {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [7636965827](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7636965827/) fired when `package_publish_external_push` hit an authored `package.json` with object-shaped `kody.dependencies` (agents often confuse npm’s object map with Kody’s string array). Validation correctly rejected it, but `runRepoChecks` threw a plain `Error`, so MCP observability reported a platform bug.

### Fix

- `runRepoChecks` returns a failed `manifest` check (with `manifest: null`) instead of throwing on missing/invalid package.json or overlong `kody.description`
- `checks_failed` / `repo_run_checks` allow a null manifest summary when the manifest itself is the failure
- `package_save` wraps the same parse failures as `McpCallerError` so they stay on `mcp-event` logs only

Siblings (client-entry TypeError, execution timeout, search ValidationError) do not share this root cause.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `95d50a74` · **Head:** `3860a76f`

**Classification:** extends — `runRepoChecks` / publish `checks_failed` contract now allows a null manifest when package.json itself is invalid; save-package marks those failures as caller errors.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — invalid/missing package.json becomes a failed manifest check (`manifest: null`) instead of a thrown Error |
| `saved-packages` | assistant | extends — `package_save` wraps parse failures as `McpCallerError`; publish output allows null manifest on `checks_failed` |
| `capability-registry` | assistant | composes — nullable summary in `repo_run_checks` / shared normalizer |
| `mcp-server` | surfaces | composes — observability test asserts caller-error classification |

### System map

Invalid authored manifests fail as structured publish/save caller outcomes instead of uncaught handler exceptions that open Sentry issues.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	savedPackages -->|"publishFromExternalRef / runRepoChecks"| repoSessions
	repoSessions -->|"checks_failed or McpCallerError"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** object-shaped `kody.dependencies` → thrown `Error: Invalid /session/package.json` → Sentry issue via MCP handler failure.

**After:** same input → `status: "checks_failed"` with a failed `manifest` check (`manifest: null`); `package_save` throws `McpCallerError` (logged, not Sentry).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59704918-f7ce-4934-b323-ac2ea622ddac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59704918-f7ce-4934-b323-ac2ea622ddac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

