### PR TITLE
fix(repo): stop publish-note reads from crashing on lstat('.')

### DIFF
--- a/packages/worker/src/repo/ephemeral-git-workspace.node.test.ts
+++ b/packages/worker/src/repo/ephemeral-git-workspace.node.test.ts
@@ -1,5 +1,8 @@
+import rawGit from 'isomorphic-git'
 import { expect, test } from 'vitest'
 import { createEphemeralGitWorkspace } from './ephemeral-git-workspace.ts'
+
+type RawGitInitFs = Parameters<typeof rawGit.init>[0]['fs']
 
 test('ephemeral git workspace preserves and follows symlinks', async () => {
 	const workspace = createEphemeralGitWorkspace()
@@ -22,4 +25,35 @@ test('ephemeral git workspace preserves and follows symlinks', async () => {
 			await workspace.fs.promises.readFile('/repo/link.txt'),
 		),
 	).toBe('target contents')
+})
+
+test('ephemeral git workspace normalizes dot paths so isomorphic-git checkout can walk the workdir root', async () => {
+	const workspace = createEphemeralGitWorkspace()
+	const fs = workspace.fs as RawGitInitFs
+
+	await rawGit.init({ fs, dir: workspace.dir, defaultBranch: 'main' })
+	await workspace.fs.promises.writeFile(
+		'/repo/README.md',
+		new TextEncoder().encode('hello\n'),
+	)
+	await rawGit.add({ fs, dir: workspace.dir, filepath: 'README.md' })
+	const oid = await rawGit.commit({
+		fs,
+		dir: workspace.dir,
+		message: 'Initial commit',
+		author: { name: 'Kody Test', email: 'test@local.invalid' },
+	})
+
+	// isomorphic-git's workdir walker stats `${dir}/.` for the root entry.
+	const rootDot = await workspace.fs.promises.lstat('/repo/.')
+	expect(rootDot.isDirectory()).toBe(true)
+
+	await expect(
+		rawGit.checkout({ fs, dir: workspace.dir, ref: oid }),
+	).resolves.toBeUndefined()
+	expect(
+		new TextDecoder().decode(
+			await workspace.fs.promises.readFile('/repo/README.md'),
+		),
+	).toBe('hello\n')
 })

--- a/packages/worker/src/repo/ephemeral-git-workspace.ts
+++ b/packages/worker/src/repo/ephemeral-git-workspace.ts
@@ -2,6 +2,23 @@ import { createIsomorphicGitFs } from './isomorphic-git-fs.ts'
 
 type EphemeralGitFileSystem = Parameters<typeof createIsomorphicGitFs>[0]
 
+/**
+ * Collapse `.` / `..` segments and empty parts so isomorphic-git walker paths
+ * like `/repo/.` resolve to the same store key as `/repo`.
+ */
+function normalizeFsPath(path: string): string {
+	const parts: Array<string> = []
+	for (const part of path.split('/')) {
+		if (!part || part === '.') continue
+		if (part === '..') {
+			parts.pop()
+			continue
+		}
+		parts.push(part)
+	}
+	return parts.length === 0 ? '/' : `/${parts.join('/')}`
+}
+
 export function createEphemeralGitWorkspace() {
 	const store = new Map<string, Uint8Array>()
 	const symlinkTargets = new Map<string, string>()
@@ -22,21 +39,32 @@ export function createEphemeralGitWorkspace() {
 		return `/${parts.join('/')}`
 	}
 	function readStoredBytes(path: string, depth = 0): Uint8Array {
+		const normalized = normalizeFsPath(path)
 		if (depth > 16) {
-			throw Object.assign(new Error(`ELOOP: ${path}`), { code: 'ELOOP' })
+			throw Object.assign(new Error(`ELOOP: ${normalized}`), { code: 'ELOOP' })
 		}
-		const target = symlinkTargets.get(path)
+		const target = symlinkTargets.get(normalized)
 		if (target != null) {
-			return readStoredBytes(resolveSymlinkPath(path, target), depth + 1)
+			return readStoredBytes(resolveSymlinkPath(normalized, target), depth + 1)
 		}
-		const bytes = store.get(path)
+		const bytes = store.get(normalized)
 		if (!bytes) {
-			throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+			throw Object.assign(new Error(`ENOENT: ${normalized}`), {
+				code: 'ENOENT',
+			})
 		}
 		return bytes
 	}
 	function storedStat(path: string, followSymlink: boolean) {
-		const target = symlinkTargets.get(path)
+		const normalized = normalizeFsPath(path)
+		if (normalized === '/') {
+			return {
+				type: 'directory' as const,
+				size: 0,
+				mtime: new Date(),
+			}
+		}
+		const target = symlinkTargets.get(normalized)
 		if (target != null && !followSymlink) {
 			return {
 				type: 'symlink' as const,
@@ -45,17 +73,19 @@ export function createEphemeralGitWorkspace() {
 			}
 		}
 		if (target != null) {
-			return storedStat(resolveSymlinkPath(path, target), true)
+			return storedStat(resolveSymlinkPath(normalized, target), true)
 		}
-		if (!store.has(path)) {
-			throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+		if (!store.has(normalized)) {
+			throw Object.assign(new Error(`ENOENT: ${normalized}`), {
+				code: 'ENOENT',
+			})
 		}
 		const isDirectory = [...store.keys()].some(
-			(key) => key.startsWith(`${path}/`) && key !== path,
+			(key) => key.startsWith(`${normalized}/`) && key !== normalized,
 		)
 		return {
 			type: isDirectory ? ('directory' as const) : ('file' as const),
-			size: store.get(path)?.byteLength ?? 0,
+			size: store.get(normalized)?.byteLength ?? 0,
 			mtime: new Date(),
 		}
 	}
@@ -63,29 +93,34 @@ export function createEphemeralGitWorkspace() {
 		readFile: async (path) => textDecoder.decode(readStoredBytes(path)),
 		readFileBytes: async (path) => readStoredBytes(path),
 		writeFile: async (path, data) => {
-			symlinkTargets.delete(path)
-			store.set(path, textEncoder.encode(data))
+			const normalized = normalizeFsPath(path)
+			symlinkTargets.delete(normalized)
+			store.set(normalized, textEncoder.encode(data))
 		},
 		writeFileBytes: async (path, data) => {
-			symlinkTargets.delete(path)
-			store.set(path, data)
+			const normalized = normalizeFsPath(path)
+			symlinkTargets.delete(normalized)
+			store.set(normalized, data)
 		},
 		rm: async (path, options) => {
+			const normalized = normalizeFsPath(path)
 			if (options?.recursive) {
 				for (const key of [...store.keys()]) {
-					if (key === path || key.startsWith(`${path}/`)) {
+					if (key === normalized || key.startsWith(`${normalized}/`)) {
 						store.delete(key)
 						symlinkTargets.delete(key)
 					}
 				}
 				return
 			}
-			store.delete(path)
-			symlinkTargets.delete(path)
+			store.delete(normalized)
+			symlinkTargets.delete(normalized)
 		},
 		mkdir: async (path, options) => {
+			const normalized = normalizeFsPath(path)
+			if (normalized === '/') return
 			if (options?.recursive) {
-				const parts = path.split('/').filter(Boolean)
+				const parts = normalized.split('/').filter(Boolean)
 				let current = ''
 				for (const part of parts) {
 					current = `${current}/${part}`
@@ -94,11 +129,12 @@ export function createEphemeralGitWorkspace() {
 				}
 				return
 			}
-			symlinkTargets.delete(path)
-			store.set(path, new Uint8Array())
+			symlinkTargets.delete(normalized)
+			store.set(normalized, new Uint8Array())
 		},
 		readdir: async (path) => {
-			const prefix = path.endsWith('/') ? path : `${path}/`
+			const normalized = normalizeFsPath(path)
+			const prefix = normalized === '/' ? '/' : `${normalized}/`
 			const names = new Set<string>()
 			for (const key of store.keys()) {
 				if (!key.startsWith(prefix)) continue
@@ -111,15 +147,19 @@ export function createEphemeralGitWorkspace() {
 		stat: async (path) => storedStat(path, true),
 		lstat: async (path) => storedStat(path, false),
 		readlink: async (path) => {
-			const target = symlinkTargets.get(path)
+			const normalized = normalizeFsPath(path)
+			const target = symlinkTargets.get(normalized)
 			if (target == null) {
-				throw Object.assign(new Error(`EINVAL: ${path}`), { code: 'EINVAL' })
+				throw Object.assign(new Error(`EINVAL: ${normalized}`), {
+					code: 'EINVAL',
+				})
 			}
 			return target
 		},
 		symlink: async (target, path) => {
-			store.set(path, textEncoder.encode(target))
-			symlinkTargets.set(path, target)
+			const normalized = normalizeFsPath(path)
+			store.set(normalized, textEncoder.encode(target))
+			symlinkTargets.set(normalized, target)
 		},
 	}
 	return {

--- a/packages/worker/src/repo/publish-git-notes.node.test.ts
+++ b/packages/worker/src/repo/publish-git-notes.node.test.ts
@@ -3,7 +3,8 @@ import { expect, test, vi } from 'vitest'
 const mockGit = vi.hoisted(() => ({
 	addNote: vi.fn(async () => 'note-commit-1'),
 	push: vi.fn(async () => ({ ok: true, refs: {} })),
-	clone: vi.fn(async () => undefined),
+	init: vi.fn(async () => undefined),
+	addRemote: vi.fn(async () => undefined),
 	fetch: vi.fn(async () => ({ ok: true, refs: {} })),
 	readNote: vi.fn(async () => new TextEncoder().encode('{"v":1}\n')),
 }))
@@ -197,7 +198,8 @@ test('publish git notes build, parse, write, and read from artifacts repos', asy
 		commitOid: 'commit-1',
 	}
 
-	mockGit.clone.mockClear()
+	mockGit.init.mockClear()
+	mockGit.addRemote.mockClear()
 	mockGit.fetch.mockClear()
 	mockGit.readNote.mockClear()
 	mockGit.fetch.mockRejectedValueOnce(
@@ -208,6 +210,23 @@ test('publish git notes build, parse, write, and read from artifacts repos', asy
 
 	const missingNotesRef = await readPublishGitNoteFromArtifactsRepo(readInput)
 	expect(missingNotesRef.found).toBe(false)
+	expect(mockGit.init).toHaveBeenCalledWith(
+		expect.objectContaining({ dir: '/repo' }),
+	)
+	expect(mockGit.addRemote).toHaveBeenCalledWith(
+		expect.objectContaining({
+			dir: '/repo',
+			remote: 'origin',
+			url: 'https://example.com/repo.git',
+		}),
+	)
+	expect(mockGit.fetch).toHaveBeenCalledWith(
+		expect.objectContaining({
+			dir: '/repo',
+			remote: 'origin',
+			ref: 'refs/notes/commits',
+		}),
+	)
 	expect(mockGit.readNote).not.toHaveBeenCalled()
 
 	mockGit.fetch.mockRejectedValueOnce(new Error('HTTP Error: 401 Unauthorized'))

--- a/packages/worker/src/repo/publish-git-notes.ts
+++ b/packages/worker/src/repo/publish-git-notes.ts
@@ -273,19 +273,20 @@ export async function readPublishGitNoteFromArtifactsRepo(input: {
 		remote: info.remote,
 		token: token.plaintext,
 	})
+	// Notes live only under refs/notes/commits — init + fetch that ref (no
+	// working-tree checkout). A full clone/checkout previously crashed the
+	// ephemeral FS walker on `lstat('/repo/.')` and pulled an unused branch tip.
 	const workspace = createEphemeralGitWorkspace()
 	const auth = buildArtifactsGitAuth({ token: token.plaintext })
-	await git.clone({
+	await git.init({
 		fs: workspace.fs,
-		http,
 		dir: workspace.dir,
+	})
+	await git.addRemote({
+		fs: workspace.fs,
+		dir: workspace.dir,
+		remote: 'origin',
 		url: remote,
-		depth: 1,
-		singleBranch: true,
-		ref: info.defaultBranch || 'main',
-		onAuth() {
-			return auth
-		},
 	})
 	try {
 		await git.fetch({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Sentry [KODY-CLOUDFLARE-2H](https://kent-c-dodds-tech-llc.sentry.io/issues/7637020263/) (`repo_show_publish_note` → `ENOENT: … lstat '.'`).

**Root cause:** `readPublishGitNoteFromArtifactsRepo` used `git.clone`, which checks out a working tree. isomorphic-git's workdir walker stats `` `${dir}/.` `` (`/repo/.`). The ephemeral in-memory FS stored `/repo` but not `/repo/.`, so `lstat` returned null and the walker threw.

**Fix:**
1. Normalize `.` / `..` path segments in `createEphemeralGitWorkspace` so `/repo/.` resolves to `/repo`.
2. Read publish notes with `git.init` + `addRemote` + fetch `refs/notes/commits` only (no working-tree checkout), matching the `readArtifactFileAtCommit` pattern.

## Test plan

- [x] `ephemeral-git-workspace` unit test: `lstat('/repo/.')` + real `git.checkout` succeeds
- [x] `publish-git-notes` unit test: missing notes ref uses init/addRemote/fetch (not clone)
- [ ] CI `npm run validate` / PR checks green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f9da10e5` · **Head:** `26a30c2b`

**Classification:** extends — hardens the ephemeral git filesystem and changes
how `repo_show_publish_note` materializes Artifacts notes (init+fetch notes ref
instead of clone/checkout).

### Primitives touched

| Primitive       | Group   | Impact                                                             |
| --------------- | ------- | ------------------------------------------------------------------ |
| `repo-sessions` | runtime | extends — path normalize + notes-only fetch for publish note reads |

### System map

`repo_show_publish_note` reads Artifacts publish notes through the ephemeral git
workspace without checking out a working tree.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red =
new primitive · gray = context (unchanged, included only when an edge crosses
it).

```mermaid
flowchart LR
	repoShow["repo_show_publish_note<br/>MCP capability"]:::untouched
	publishNotes["publish-git-notes<br/>note read helper"]:::extended
	ephemeralFs["ephemeral-git-workspace<br/>in-memory FS"]:::extended
	artifacts["Cloudflare Artifacts<br/>git remote"]:::untouched
	repoShow -->|"readPublishGitNoteFromArtifactsRepo"| publishNotes
	publishNotes -->|"init + fetch refs/notes/commits"| ephemeralFs
	publishNotes -->|"authenticated git-upload-pack"| artifacts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant MCP as repo_show_publish_note
	participant Notes as publish-git-notes
	participant FS as ephemeral-git-workspace
	participant Art as Artifacts remote
	MCP->>Notes: read note for commit
	Notes->>FS: git.init + addRemote
	Notes->>Art: fetch refs/notes/commits
	Art-->>Notes: note objects
	Notes->>FS: git.readNote(oid)
	Notes-->>MCP: found / raw_note / note
```

### Before / after

| Path                         | Before                                  | After                                       |
| ---------------------------- | --------------------------------------- | ------------------------------------------- |
| `readPublishGitNote…`        | `git.clone` (checkout) then fetch notes | `git.init` + `addRemote` + fetch notes only |
| ephemeral `lstat('/repo/.')` | ENOENT → isomorphic-git walker crash    | normalizes to `/repo` directory stat        |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba1a30dd-2d88-4175-872a-67bd3a9ae714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba1a30dd-2d88-4175-872a-67bd3a9ae714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

