### PR TITLE
feat(repo): run heavy check phases in throwaway isolates

### DIFF
--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -1604,7 +1604,7 @@ test('heavy check phases run in throwaway isolates when the env has the bindings
 		string,
 		{ expirationTtl: number },
 	]
-	expect(stagingKey.startsWith('repo-checks-staging:v1:')).toBe(true)
+	expect(stagingKey.startsWith('repo-checks-staging:v1:user-123:')).toBe(true)
 	expect(JSON.parse(stagedBody).sourceFiles['src/a.ts']).toContain(
 		'export default',
 	)
@@ -1621,6 +1621,11 @@ test('heavy check phases run in throwaway isolates when the env has the bindings
 		(request) => request.phase === 'typecheck',
 	)
 	expect(typecheckRequests).toHaveLength(1)
+	expect(typecheckRequests[0]).toMatchObject({ userId: 'user-123' })
+	// Throwaway isolate ids are namespaced by the requesting user.
+	for (const [name] of namespace.idFromName.mock.calls) {
+		expect(name as string).toContain('-user-123-')
+	}
 	const bundleRequests = phaseRequests.filter(
 		(request) => request.phase === 'bundle-chunk',
 	)

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -32,6 +32,7 @@ import {
 	repoChecksSourceMaxTotalBytes,
 	runRepoChecks,
 } from './checks.ts'
+import { isolatedBundleChunkSize } from './isolated-check-phases.ts'
 
 type MockSnapshot = {
 	read: ReturnType<typeof vi.fn>
@@ -1519,4 +1520,198 @@ export default async function main() {
 	)
 	expect(aliasedStorageLint).toMatchObject({ kind: 'lint', ok: false })
 	expect(aliasedStorageLint?.message).toContain('packageStorage()')
+})
+
+test('heavy check phases run in throwaway isolates when the env has the bindings', async () => {
+	setupDefaultBundleMocks()
+	const files = new Map<string, string>([
+		[
+			'package.json',
+			createPackageManifest({
+				packageName: '@kody/offloaded-package',
+				kodyId: 'offloaded-package',
+				description: 'Package with enough targets to require chunking',
+				exports: {
+					'.': './src/index.ts',
+					'./a': './src/a.ts',
+					'./b': './src/b.ts',
+					'./c': './src/c.ts',
+					'./d': './src/d.ts',
+					'./e': './src/e.ts',
+				},
+				jobs: {
+					daily: {
+						entry: './src/index.ts',
+						schedule: { type: 'interval', every: '1d' },
+					},
+				},
+			}),
+		],
+		...['index', 'a', 'b', 'c', 'd', 'e'].map(
+			(name) =>
+				[
+					`src/${name}.ts`,
+					`export default async function ${name}() {\n\treturn '${name}'\n}\n`,
+				] as const,
+		),
+	])
+	const snapshot = createSnapshotFromFiles(files)
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+
+	const phaseRequests: Array<Record<string, unknown>> = []
+	const stub = {
+		runIsolatedCheckPhase: vi.fn(async (request: Record<string, unknown>) => {
+			phaseRequests.push(request)
+			return request.phase === 'typecheck'
+				? { ok: true, message: 'No semantic diagnostics (isolated).' }
+				: { ok: true, message: 'chunk ok' }
+		}),
+	}
+	const kv = {
+		put: vi.fn(async () => undefined),
+		delete: vi.fn(async () => undefined),
+	}
+	const namespace = {
+		idFromName: vi.fn((name: string) => ({ name })),
+		get: vi.fn(() => stub),
+	}
+	const env = {
+		REPO_SESSION: namespace,
+		BUNDLE_ARTIFACTS_KV: kv,
+	} as unknown as Env
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		env,
+		baseUrl: '/',
+		userId: 'user-123',
+	})
+
+	expect(result.ok).toBe(true)
+	// The staged snapshot is written once with a TTL and cleaned up after.
+	expect(kv.put).toHaveBeenCalledTimes(1)
+	const [stagingKey, stagedBody, stagedOptions] = kv.put.mock.calls[0] as [
+		string,
+		string,
+		{ expirationTtl: number },
+	]
+	expect(stagingKey.startsWith('repo-checks-staging:v1:')).toBe(true)
+	expect(JSON.parse(stagedBody).sourceFiles['src/a.ts']).toContain(
+		'export default',
+	)
+	expect(stagedOptions.expirationTtl).toBeGreaterThan(0)
+	expect(kv.delete).toHaveBeenCalledWith(stagingKey)
+
+	// The language service and bundlers never run in this isolate.
+	expect(mockModule.createTypescriptLanguageService).not.toHaveBeenCalled()
+	expect(mockModule.buildKodyModuleBundle).not.toHaveBeenCalled()
+
+	// One typecheck phase plus ceil(targets / chunk) bundle chunks, each in a
+	// fresh throwaway isolate.
+	const typecheckRequests = phaseRequests.filter(
+		(request) => request.phase === 'typecheck',
+	)
+	expect(typecheckRequests).toHaveLength(1)
+	const bundleRequests = phaseRequests.filter(
+		(request) => request.phase === 'bundle-chunk',
+	)
+	const chunkSizes = bundleRequests.map(
+		(request) => (request.bundleTargets as Array<unknown>).length,
+	)
+	const totalTargets = chunkSizes.reduce((sum, size) => sum + size, 0)
+	expect(totalTargets).toBeGreaterThanOrEqual(6)
+	expect(Math.max(...chunkSizes)).toBeLessThanOrEqual(isolatedBundleChunkSize)
+	expect(bundleRequests.length).toBe(
+		Math.ceil(totalTargets / isolatedBundleChunkSize),
+	)
+	const distinctIsolateNames = new Set(
+		namespace.idFromName.mock.calls.map(([name]) => name as string),
+	)
+	expect(distinctIsolateNames.size).toBe(phaseRequests.length)
+
+	const bundleResult = result.results.find((entry) => entry.kind === 'bundle')
+	expect(bundleResult).toMatchObject({
+		ok: true,
+		message: `Bundled ${totalTargets} package target(s) successfully.`,
+	})
+	const typecheckResult = result.results.find(
+		(entry) => entry.kind === 'typecheck',
+	)
+	expect(typecheckResult).toMatchObject({
+		ok: true,
+		message: 'No semantic diagnostics (isolated).',
+	})
+})
+
+test('an isolate reset during a check phase becomes a failed check, not a crash', async () => {
+	setupDefaultBundleMocks()
+	const files = new Map<string, string>([
+		[
+			'package.json',
+			createPackageManifest({
+				packageName: '@kody/oversized-package',
+				kodyId: 'oversized-package',
+				description: 'Package whose bundle phase exceeds isolate limits',
+			}),
+		],
+		[
+			'src/index.ts',
+			`export default async function main() {\n\treturn 'ok'\n}\n`,
+		],
+	])
+	const snapshot = createSnapshotFromFiles(files)
+	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
+
+	const stub = {
+		runIsolatedCheckPhase: vi.fn(async (request: { phase: string }) => {
+			if (request.phase === 'bundle-chunk') {
+				throw new Error(
+					"Durable Object's isolate exceeded its memory limit and was reset.",
+				)
+			}
+			return { ok: true, message: 'No semantic diagnostics (isolated).' }
+		}),
+	}
+	const env = {
+		REPO_SESSION: {
+			idFromName: vi.fn((name: string) => ({ name })),
+			get: vi.fn(() => stub),
+		},
+		BUNDLE_ARTIFACTS_KV: {
+			put: vi.fn(async () => undefined),
+			delete: vi.fn(async () => undefined),
+		},
+	} as unknown as Env
+
+	const result = await runRepoChecks({
+		workspace: {
+			async readFile(path: string) {
+				return files.get(path) ?? null
+			},
+			async glob() {
+				return Array.from(files.keys()).map((path) => ({ path, type: 'file' }))
+			},
+		},
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		env,
+		baseUrl: '/',
+		userId: 'user-123',
+	})
+
+	expect(result.ok).toBe(false)
+	const bundleResult = result.results.find((entry) => entry.kind === 'bundle')
+	expect(bundleResult?.ok).toBe(false)
+	expect(bundleResult?.message).toContain(
+		"exceeded the isolated check runner's",
+	)
 })

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -34,6 +34,11 @@ import {
 	repoBackedModuleEntrypointExportErrorMessage,
 	repoCapabilitiesModuleTypecheckHarnessPath,
 } from './repo-kody-execution.ts'
+import {
+	createIsolatedCheckPhaseRunner,
+	isolatedBundleChunkSize,
+	type IsolatedCheckPhaseRunner,
+} from './isolated-check-phases.ts'
 import { normalizeRepoWorkspacePath } from './manifest.ts'
 
 export type RepoCheckKind =
@@ -472,12 +477,12 @@ declare const storage: KodyStorageRuntime;
 `.trim()
 }
 
-type PackageBundleTarget = {
+export type PackageBundleTarget = {
 	path: string
 	bundleKind: 'app' | 'callable' | 'importable'
 }
 
-type PackageCallableTypecheckTarget = {
+export type PackageCallableTypecheckTarget = {
 	path: string
 	includeStorage: boolean
 	emittedEventTopics: Array<string>
@@ -677,7 +682,7 @@ function validateStaticKodyPackageDependencyDeclarations(input: {
 	}
 }
 
-async function validatePackageBundles(input: {
+export async function validatePackageBundles(input: {
 	env: Env
 	baseUrl: string
 	userId: string
@@ -891,7 +896,8 @@ export async function typecheckPackageEntrypointsFromSourceFiles(input: {
 				: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
 		}
 	} finally {
-		// Release the compiler program eagerly; large snapshots otherwise keep
+		// `using` needs Symbol.dispose in the worker lib target; manual
+		// disposal releases the compiler program eagerly instead of keeping
 		// the whole TypeScript program reachable until GC gets around to it.
 		languageService.dispose()
 	}
@@ -1003,6 +1009,98 @@ function buildLintCheck(sourceFiles: Record<string, string>): {
 			"bucket in the package's own runtime and keeps working when the code is statically imported into " +
 			'another context. Ambient `storage` remains only for ad hoc execute code with a `storageId` bound on ' +
 			'the execute call.',
+	}
+}
+
+/**
+ * The expensive half of the typecheck check: a TypeScript language service
+ * over the full source snapshot. Exported so throwaway check-phase isolates
+ * can run it against KV-staged source files (see isolated-check-phases.ts).
+ */
+export async function runPackageTypecheckLanguageService(input: {
+	sourceFiles: Record<string, string>
+	targets: Array<PackageCallableTypecheckTarget>
+}): Promise<{ ok: boolean; message: string }> {
+	const { createFileSystemSnapshot } = await loadWorkerBundlerSnapshotTools()
+	const snapshot = await createFileSystemSnapshot(
+		(async function* () {
+			for (const [path, content] of Object.entries(input.sourceFiles)) {
+				yield [path, content] as const
+			}
+		})(),
+	)
+	const typecheckFileSystem = createRepoChecksFileSystem({
+		fileSystem: snapshot,
+	})
+	const baseTsconfig = snapshot.read(repoChecksSyntheticTsconfigPath)
+	if (baseTsconfig != null) {
+		typecheckFileSystem.write(
+			repoChecksSyntheticTsconfigExtendsPath.slice('./'.length),
+			baseTsconfig,
+		)
+	}
+	typecheckFileSystem.write(
+		repoChecksSyntheticTsconfigPath,
+		buildRepoChecksTsconfig(baseTsconfig),
+	)
+	const { createTypescriptLanguageService } =
+		await loadWorkerBundlerTypescriptTools()
+	const { fileSystem, languageService } = await createTypescriptLanguageService(
+		{
+			fileSystem: typecheckFileSystem,
+		},
+	)
+	try {
+		const diagnostics = getPackageTypecheckDiagnostics({
+			targets: input.targets,
+			languageService,
+			fileSystem,
+		})
+		const ok = diagnostics.every((entry) => entry.diagnostics.length === 0)
+		return {
+			ok,
+			message: ok
+				? `No semantic diagnostics for ${input.targets.length} callable package runtime entrypoint(s).`
+				: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
+		}
+	} finally {
+		// Release the compiler program before anything else allocates.
+		languageService.dispose()
+	}
+}
+
+async function runChunkedBundleValidation(input: {
+	runner: IsolatedCheckPhaseRunner
+	stagingKey: string
+	baseUrl: string
+	userId: string
+	entryPoints: Array<PackageBundleTarget>
+}) {
+	const failures: Array<string> = []
+	for (
+		let start = 0;
+		start < input.entryPoints.length;
+		start += isolatedBundleChunkSize
+	) {
+		const chunk = input.entryPoints.slice(
+			start,
+			start + isolatedBundleChunkSize,
+		)
+		const outcome = await input.runner.run({
+			phase: 'bundle-chunk',
+			stagingKey: input.stagingKey,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			bundleTargets: chunk,
+		})
+		if (!outcome.ok) failures.push(outcome.message)
+	}
+	return {
+		ok: failures.length === 0,
+		message:
+			failures.length === 0
+				? `Bundled ${input.entryPoints.length} package target(s) successfully.`
+				: failures.join('\n'),
 	}
 }
 
@@ -1169,109 +1267,113 @@ export async function runRepoChecks(input: {
 					userId: input.userId,
 				}
 			: null
-	// The TypeScript check runs BEFORE bundle validation, inside a helper
-	// scope. The language service allocates a large JS heap (the compiler
-	// plus a full program over the snapshot) that becomes collectable once
-	// this closure returns, while esbuild-wasm memory grown during bundling
-	// stays resident for the isolate's lifetime (the wasm instance is a
-	// module-level singleton and wasm memories never shrink). Typechecking
-	// first keeps peak isolate memory near max(typecheck, bundling) instead
-	// of their sum — checks over large multi-entrypoint packages were
-	// exceeding the Durable Object memory limit and killing publishes
-	// (kentcdodds/kody#987). The reported `results` order is unchanged:
-	// bundle before typecheck.
-	const typecheckResult: RepoCheckResult = await (async () => {
-		if (missingCallableTypecheckTargets.length > 0) {
-			return {
-				kind: 'typecheck',
-				ok: false,
-				message: `Typecheck skipped because callable package runtime entrypoint(s) are missing from the repo session snapshot: ${missingCallableTypecheckTargets
-					.map((path) => `"${path}"`)
-					.join(', ')}.`,
-			}
-		}
-		const callableTargetsMissingDefaultExport =
-			collectEntrypointsMissingDefaultExport({
-				snapshot,
-				targets: callableTypecheckTargets,
-			})
-		if (callableTargetsMissingDefaultExport.length > 0) {
-			return {
-				kind: 'typecheck',
-				ok: false,
-				message: formatMissingDefaultExportMessage(
-					callableTargetsMissingDefaultExport,
-				),
-			}
-		}
-		if (callableTypecheckTargets.length === 0) {
-			return {
-				kind: 'typecheck',
-				ok: true,
-				message: 'No callable package runtime entrypoint(s) to typecheck.',
-			}
-		}
-		const typecheckFileSystem = createRepoChecksFileSystem({
-			fileSystem: snapshot,
-		})
-		const baseTsconfig = snapshot.read(repoChecksSyntheticTsconfigPath)
-		if (baseTsconfig != null) {
-			typecheckFileSystem.write(
-				repoChecksSyntheticTsconfigExtendsPath.slice('./'.length),
-				baseTsconfig,
-			)
-		}
-		typecheckFileSystem.write(
-			repoChecksSyntheticTsconfigPath,
-			buildRepoChecksTsconfig(baseTsconfig),
-		)
-		const { createTypescriptLanguageService } =
-			await loadWorkerBundlerTypescriptTools()
-		const { fileSystem, languageService } =
-			await createTypescriptLanguageService({
-				fileSystem: typecheckFileSystem,
-			})
-		try {
-			const diagnostics = getPackageTypecheckDiagnostics({
-				targets: callableTypecheckTargets,
-				languageService,
-				fileSystem,
-			})
-			return {
-				kind: 'typecheck',
-				ok: diagnostics.every((entry) => entry.diagnostics.length === 0),
-				message: diagnostics.every((entry) => entry.diagnostics.length === 0)
-					? `No semantic diagnostics for ${callableTypecheckTargets.length} callable package runtime entrypoint(s).`
-					: formatPackageTypecheckDiagnostics(diagnostics).join('\n'),
-			}
-		} finally {
-			// Release the compiler program before bundling allocates.
-			languageService.dispose()
-		}
-	})()
+	// Heavy phases (TypeScript language service, esbuild-wasm bundling) run
+	// in fresh throwaway isolates whenever the env carries the bindings for
+	// it: one large package could otherwise push this isolate (session
+	// workspace + git state + checks) over the Durable Object memory limit
+	// and kill every publish attempt (kentcdodds/kody#987). Without the
+	// bindings (unit tests, minimal envs) the phases run inline; typecheck
+	// then runs BEFORE bundling so its disposable heap never stacks on top
+	// of esbuild-wasm memory, which stays resident once grown. The reported
+	// `results` order is unchanged: bundle before typecheck.
+	const isolatedRunner = bundleContext
+		? createIsolatedCheckPhaseRunner(bundleContext.env)
+		: null
+	const wantsLanguageServiceTypecheck =
+		missingCallableTypecheckTargets.length === 0 &&
+		callableTypecheckTargets.length > 0
+	const wantsBundleValidation =
+		bundleContext !== null &&
+		missingBundleTargets.length === 0 &&
+		bundleTargets.length > 0
+	const stagingKey =
+		isolatedRunner && (wantsLanguageServiceTypecheck || wantsBundleValidation)
+			? await isolatedRunner.stage(sourceFiles)
+			: null
 
-	const bundleCheckResult =
-		missingBundleTargets.length > 0
-			? {
+	let typecheckResult: RepoCheckResult
+	let bundleCheckResult: { ok: boolean; message: string }
+	try {
+		typecheckResult = await (async (): Promise<RepoCheckResult> => {
+			if (missingCallableTypecheckTargets.length > 0) {
+				return {
+					kind: 'typecheck',
 					ok: false,
-					message: formatBundleCheckMessage({
-						missingEntryPoints: missingBundleTargets,
-						targetCount: bundleTargets.length,
-					}),
+					message: `Typecheck skipped because callable package runtime entrypoint(s) are missing from the repo session snapshot: ${missingCallableTypecheckTargets
+						.map((path) => `"${path}"`)
+						.join(', ')}.`,
 				}
-			: bundleContext
-				? await validatePackageBundles({
-						...bundleContext,
-						sourceFiles,
-						entryPoints: bundleTargets,
-					})
-				: {
-						ok: true,
+			}
+			const callableTargetsMissingDefaultExport =
+				collectEntrypointsMissingDefaultExport({
+					snapshot,
+					targets: callableTypecheckTargets,
+				})
+			if (callableTargetsMissingDefaultExport.length > 0) {
+				return {
+					kind: 'typecheck',
+					ok: false,
+					message: formatMissingDefaultExportMessage(
+						callableTargetsMissingDefaultExport,
+					),
+				}
+			}
+			if (callableTypecheckTargets.length === 0) {
+				return {
+					kind: 'typecheck',
+					ok: true,
+					message: 'No callable package runtime entrypoint(s) to typecheck.',
+				}
+			}
+			const outcome =
+				isolatedRunner && stagingKey
+					? await isolatedRunner.run({
+							phase: 'typecheck',
+							stagingKey,
+							typecheckTargets: callableTypecheckTargets,
+						})
+					: await runPackageTypecheckLanguageService({
+							sourceFiles,
+							targets: callableTypecheckTargets,
+						})
+			return { kind: 'typecheck', ...outcome }
+		})()
+
+		bundleCheckResult =
+			missingBundleTargets.length > 0
+				? {
+						ok: false,
 						message: formatBundleCheckMessage({
 							missingEntryPoints: missingBundleTargets,
 							targetCount: bundleTargets.length,
 						}),
 					}
+				: bundleContext
+					? isolatedRunner && stagingKey
+						? await runChunkedBundleValidation({
+								runner: isolatedRunner,
+								stagingKey,
+								baseUrl: bundleContext.baseUrl,
+								userId: bundleContext.userId,
+								entryPoints: bundleTargets,
+							})
+						: await validatePackageBundles({
+								...bundleContext,
+								sourceFiles,
+								entryPoints: bundleTargets,
+							})
+					: {
+							ok: true,
+							message: formatBundleCheckMessage({
+								missingEntryPoints: missingBundleTargets,
+								targetCount: bundleTargets.length,
+							}),
+						}
+	} finally {
+		if (isolatedRunner && stagingKey) {
+			await isolatedRunner.discard(stagingKey)
+		}
+	}
 	results.push({
 		kind: 'bundle',
 		ok: bundleCheckResult.ok,

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1287,8 +1287,13 @@ export async function runRepoChecks(input: {
 		missingBundleTargets.length === 0 &&
 		bundleTargets.length > 0
 	const stagingKey =
-		isolatedRunner && (wantsLanguageServiceTypecheck || wantsBundleValidation)
-			? await isolatedRunner.stage(sourceFiles)
+		isolatedRunner &&
+		bundleContext &&
+		(wantsLanguageServiceTypecheck || wantsBundleValidation)
+			? await isolatedRunner.stage({
+					userId: bundleContext.userId,
+					sourceFiles,
+				})
 			: null
 
 	let typecheckResult: RepoCheckResult
@@ -1326,10 +1331,11 @@ export async function runRepoChecks(input: {
 				}
 			}
 			const outcome =
-				isolatedRunner && stagingKey
+				isolatedRunner && stagingKey && bundleContext
 					? await isolatedRunner.run({
 							phase: 'typecheck',
 							stagingKey,
+							userId: bundleContext.userId,
 							typecheckTargets: callableTypecheckTargets,
 						})
 					: await runPackageTypecheckLanguageService({

--- a/packages/worker/src/repo/isolated-check-phases.ts
+++ b/packages/worker/src/repo/isolated-check-phases.ts
@@ -44,8 +44,27 @@ export type IsolatedCheckPhaseRequest =
 	| {
 			phase: 'typecheck'
 			stagingKey: string
+			userId: string
 			typecheckTargets: Array<PackageCallableTypecheckTarget>
 	  }
+
+/**
+ * Staged snapshots are user-owned content, so the staging key is namespaced
+ * by `userId` and the consuming Durable Object verifies the key belongs to
+ * the requesting user before reading it.
+ */
+export function isolatedCheckStagingKeyForUser(userId: string) {
+	return `${isolatedCheckStagingKeyPrefix}${userId}:${crypto.randomUUID()}`
+}
+
+export function isolatedCheckStagingKeyBelongsToUser(input: {
+	stagingKey: string
+	userId: string
+}) {
+	return input.stagingKey.startsWith(
+		`${isolatedCheckStagingKeyPrefix}${input.userId}:`,
+	)
+}
 
 export type IsolatedCheckPhaseOutcome = {
 	ok: boolean
@@ -59,7 +78,10 @@ type IsolatedCheckPhaseStub = {
 }
 
 export type IsolatedCheckPhaseRunner = {
-	stage(sourceFiles: Record<string, string>): Promise<string>
+	stage(input: {
+		userId: string
+		sourceFiles: Record<string, string>
+	}): Promise<string>
 	run(request: IsolatedCheckPhaseRequest): Promise<IsolatedCheckPhaseOutcome>
 	discard(stagingKey: string): Promise<void>
 }
@@ -98,19 +120,25 @@ export function createIsolatedCheckPhaseRunner(
 	)?.BUNDLE_ARTIFACTS_KV
 	if (!namespace || !stagingKv) return null
 	return {
-		async stage(sourceFiles) {
-			const stagingKey = `${isolatedCheckStagingKeyPrefix}${crypto.randomUUID()}`
-			await stagingKv.put(stagingKey, JSON.stringify({ sourceFiles }), {
-				expirationTtl: stagingTtlSeconds,
-			})
+		async stage(input) {
+			const stagingKey = isolatedCheckStagingKeyForUser(input.userId)
+			await stagingKv.put(
+				stagingKey,
+				JSON.stringify({ sourceFiles: input.sourceFiles }),
+				{
+					expirationTtl: stagingTtlSeconds,
+				},
+			)
 			return stagingKey
 		},
 		async run(request) {
-			// A fresh id per phase invocation puts every heavy phase in its own
-			// isolate. The instance never touches its Durable Object storage,
-			// so nothing persists for the random name.
+			// A fresh, user-namespaced id per phase invocation puts every heavy
+			// phase in its own isolate. The instance never touches its Durable
+			// Object storage, so nothing persists for the random name.
 			const stub = namespace.get(
-				namespace.idFromName(`isolated-check-phase-${crypto.randomUUID()}`),
+				namespace.idFromName(
+					`isolated-check-phase-${request.userId}-${crypto.randomUUID()}`,
+				),
 			) as unknown as IsolatedCheckPhaseStub
 			try {
 				return await stub.runIsolatedCheckPhase(request)

--- a/packages/worker/src/repo/isolated-check-phases.ts
+++ b/packages/worker/src/repo/isolated-check-phases.ts
@@ -1,0 +1,139 @@
+import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
+import {
+	type PackageBundleTarget,
+	type PackageCallableTypecheckTarget,
+} from './checks.ts'
+
+/**
+ * Heavy repo-check phases (esbuild-wasm bundle validation, TypeScript
+ * language-service typecheck) run in fresh, throwaway `REPO_SESSION`
+ * isolates instead of the session/publish Durable Object. One large package
+ * could otherwise push the session isolate (workspace + git state + checks)
+ * over the Durable Object memory limit and kill every publish attempt
+ * (kentcdodds/kody#987). Each phase invocation gets a brand-new DO id, so:
+ *
+ * - phases never stack their peak memory on top of the session isolate or
+ *   each other (esbuild-wasm memory in particular never shrinks once grown),
+ * - a package too large for even a single phase surfaces as a failed check
+ *   with an actionable message instead of an opaque isolate reset, and
+ * - the throwaway instances never touch their own Durable Object storage, so
+ *   nothing persists for their random ids.
+ *
+ * The collected source files (bounded by the repo-check source caps) are
+ * staged once in KV with a short TTL and fetched by each phase isolate;
+ * the RPC payloads stay small.
+ */
+
+export const isolatedCheckStagingKeyPrefix = 'repo-checks-staging:v1:'
+const stagingTtlSeconds = 15 * 60
+/**
+ * Bundle targets validated per throwaway isolate. Small enough that a chunk
+ * stays far from the isolate memory limit, large enough to keep the isolate
+ * fan-out modest for typical packages.
+ */
+export const isolatedBundleChunkSize = 4
+
+export type IsolatedCheckPhaseRequest =
+	| {
+			phase: 'bundle-chunk'
+			stagingKey: string
+			baseUrl: string
+			userId: string
+			bundleTargets: Array<PackageBundleTarget>
+	  }
+	| {
+			phase: 'typecheck'
+			stagingKey: string
+			typecheckTargets: Array<PackageCallableTypecheckTarget>
+	  }
+
+export type IsolatedCheckPhaseOutcome = {
+	ok: boolean
+	message: string
+}
+
+type IsolatedCheckPhaseStub = {
+	runIsolatedCheckPhase(
+		input: IsolatedCheckPhaseRequest,
+	): Promise<IsolatedCheckPhaseOutcome>
+}
+
+export type IsolatedCheckPhaseRunner = {
+	stage(sourceFiles: Record<string, string>): Promise<string>
+	run(request: IsolatedCheckPhaseRequest): Promise<IsolatedCheckPhaseOutcome>
+	discard(stagingKey: string): Promise<void>
+}
+
+function isDurableObjectResetError(error: unknown) {
+	return errorCauseChainIncludes(
+		error,
+		(message) =>
+			message.includes('Durable Object exceeded its CPU time limit') ||
+			message.includes("Durable Object's isolate exceeded its memory limit") ||
+			message.includes('Durable Object was reset'),
+	)
+}
+
+function phaseLabel(request: IsolatedCheckPhaseRequest) {
+	return request.phase === 'bundle-chunk'
+		? `Bundle validation for ${request.bundleTargets
+				.map((target) => `"${target.path}"`)
+				.join(', ')}`
+		: 'The TypeScript typecheck'
+}
+
+/**
+ * Returns a runner when the env carries the bindings the offload needs;
+ * callers fall back to inline phase execution otherwise (unit tests and
+ * minimal envs).
+ */
+export function createIsolatedCheckPhaseRunner(
+	env: Env | undefined,
+): IsolatedCheckPhaseRunner | null {
+	const namespace = (
+		env as (Env & { REPO_SESSION?: DurableObjectNamespace }) | undefined
+	)?.REPO_SESSION
+	const stagingKv = (
+		env as (Env & { BUNDLE_ARTIFACTS_KV?: KVNamespace }) | undefined
+	)?.BUNDLE_ARTIFACTS_KV
+	if (!namespace || !stagingKv) return null
+	return {
+		async stage(sourceFiles) {
+			const stagingKey = `${isolatedCheckStagingKeyPrefix}${crypto.randomUUID()}`
+			await stagingKv.put(stagingKey, JSON.stringify({ sourceFiles }), {
+				expirationTtl: stagingTtlSeconds,
+			})
+			return stagingKey
+		},
+		async run(request) {
+			// A fresh id per phase invocation puts every heavy phase in its own
+			// isolate. The instance never touches its Durable Object storage,
+			// so nothing persists for the random name.
+			const stub = namespace.get(
+				namespace.idFromName(`isolated-check-phase-${crypto.randomUUID()}`),
+			) as unknown as IsolatedCheckPhaseStub
+			try {
+				return await stub.runIsolatedCheckPhase(request)
+			} catch (error) {
+				if (isDurableObjectResetError(error)) {
+					return {
+						ok: false,
+						message:
+							`${phaseLabel(request)} exceeded the isolated check runner's ` +
+							'memory or CPU limits even on its own. Reduce the package ' +
+							'source size (split large generated modules, remove vendored ' +
+							'or data files) and run the checks again.',
+					}
+				}
+				throw error
+			}
+		},
+		async discard(stagingKey) {
+			try {
+				await stagingKv.delete(stagingKey)
+			} catch {
+				// Best effort: the staging entry expires via its TTL anyway.
+			}
+		},
+	}
+}

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1403,7 +1403,7 @@ test('runIsolatedCheckPhase loads staged files from KV and dispatches the phase'
 
 	const bundleOutcome = await session.runIsolatedCheckPhase({
 		phase: 'bundle-chunk',
-		stagingKey: 'repo-checks-staging:v1:abc',
+		stagingKey: 'repo-checks-staging:v1:user-1:abc',
 		baseUrl: '/',
 		userId: 'user-1',
 		bundleTargets: [{ path: 'src/index.ts', bundleKind: 'callable' }],
@@ -1419,7 +1419,8 @@ test('runIsolatedCheckPhase loads staged files from KV and dispatches the phase'
 
 	const typecheckOutcome = await session.runIsolatedCheckPhase({
 		phase: 'typecheck',
-		stagingKey: 'repo-checks-staging:v1:abc',
+		stagingKey: 'repo-checks-staging:v1:user-1:abc',
+		userId: 'user-1',
 		typecheckTargets: [
 			{ path: 'src/index.ts', includeStorage: false, emittedEventTopics: [] },
 		],
@@ -1436,9 +1437,22 @@ test('runIsolatedCheckPhase loads staged files from KV and dispatches the phase'
 	kv.get.mockResolvedValueOnce(null)
 	const expired = await session.runIsolatedCheckPhase({
 		phase: 'typecheck',
-		stagingKey: 'repo-checks-staging:v1:gone',
+		stagingKey: 'repo-checks-staging:v1:user-1:gone',
+		userId: 'user-1',
 		typecheckTargets: [],
 	})
 	expect(expired.ok).toBe(false)
 	expect(expired.message).toContain('staging data expired')
+
+	// A staging key namespaced to another user is rejected before any read.
+	kv.get.mockClear()
+	const crossUser = await session.runIsolatedCheckPhase({
+		phase: 'typecheck',
+		stagingKey: 'repo-checks-staging:v1:user-2:abc',
+		userId: 'user-1',
+		typecheckTargets: [],
+	})
+	expect(crossUser.ok).toBe(false)
+	expect(crossUser.message).toContain('does not belong to the requesting user')
+	expect(kv.get).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -116,6 +116,15 @@ const mockModule = vi.hoisted(() => {
 			},
 		})),
 		writePublishedSourceSnapshot: vi.fn(async () => 'snapshot-key'),
+		validatePackageBundles: vi.fn(async () => ({
+			ok: true,
+			message: 'Bundled 2 package target(s) successfully.',
+		})),
+		runPackageTypecheckLanguageService: vi.fn(async () => ({
+			ok: true,
+			message:
+				'No semantic diagnostics for 1 callable package runtime entrypoint(s).',
+		})),
 	}
 })
 
@@ -336,6 +345,10 @@ vi.mock('./manifest.ts', () => ({
 
 vi.mock('./checks.ts', () => ({
 	runRepoChecks: (...args: Array<unknown>) => mockModule.runRepoChecks(...args),
+	validatePackageBundles: (...args: Array<unknown>) =>
+		mockModule.validatePackageBundles(...args),
+	runPackageTypecheckLanguageService: (...args: Array<unknown>) =>
+		mockModule.runPackageTypecheckLanguageService(...args),
 }))
 
 vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', async () => {
@@ -1374,4 +1387,58 @@ test('publishFromExternalRef checks fast-forward ancestry through shell git adap
 			scope: 'repo.publishFromExternalRef.publish-git-note',
 		}),
 	)
+})
+
+test('runIsolatedCheckPhase loads staged files from KV and dispatches the phase', async () => {
+	const staged = {
+		sourceFiles: { 'package.json': '{"name":"@kody/demo"}' },
+	}
+	const kv = {
+		get: vi.fn(async () => staged),
+	}
+	const session = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: kv,
+	} as unknown as Env)
+
+	const bundleOutcome = await session.runIsolatedCheckPhase({
+		phase: 'bundle-chunk',
+		stagingKey: 'repo-checks-staging:v1:abc',
+		baseUrl: '/',
+		userId: 'user-1',
+		bundleTargets: [{ path: 'src/index.ts', bundleKind: 'callable' }],
+	})
+	expect(bundleOutcome.ok).toBe(true)
+	expect(mockModule.validatePackageBundles).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			sourceFiles: staged.sourceFiles,
+			entryPoints: [{ path: 'src/index.ts', bundleKind: 'callable' }],
+		}),
+	)
+
+	const typecheckOutcome = await session.runIsolatedCheckPhase({
+		phase: 'typecheck',
+		stagingKey: 'repo-checks-staging:v1:abc',
+		typecheckTargets: [
+			{ path: 'src/index.ts', includeStorage: false, emittedEventTopics: [] },
+		],
+	})
+	expect(typecheckOutcome.ok).toBe(true)
+	expect(mockModule.runPackageTypecheckLanguageService).toHaveBeenCalledWith({
+		sourceFiles: staged.sourceFiles,
+		targets: [
+			{ path: 'src/index.ts', includeStorage: false, emittedEventTopics: [] },
+		],
+	})
+
+	// Expired staging fails closed with an actionable message.
+	kv.get.mockResolvedValueOnce(null)
+	const expired = await session.runIsolatedCheckPhase({
+		phase: 'typecheck',
+		stagingKey: 'repo-checks-staging:v1:gone',
+		typecheckTargets: [],
+	})
+	expect(expired.ok).toBe(false)
+	expect(expired.message).toContain('staging data expired')
 })

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -47,6 +47,7 @@ import {
 	validatePackageBundles,
 } from './checks.ts'
 import {
+	isolatedCheckStagingKeyBelongsToUser,
 	type IsolatedCheckPhaseOutcome,
 	type IsolatedCheckPhaseRequest,
 } from './isolated-check-phases.ts'
@@ -1683,6 +1684,18 @@ class RepoSessionBase extends DurableObject<Env> {
 	async runIsolatedCheckPhase(
 		input: IsolatedCheckPhaseRequest,
 	): Promise<IsolatedCheckPhaseOutcome> {
+		if (
+			!isolatedCheckStagingKeyBelongsToUser({
+				stagingKey: input.stagingKey,
+				userId: input.userId,
+			})
+		) {
+			return {
+				ok: false,
+				message:
+					'Isolated check phase staging key does not belong to the requesting user.',
+			}
+		}
 		const staged = await this.env.BUNDLE_ARTIFACTS_KV.get<{
 			sourceFiles?: Record<string, string>
 		}>(input.stagingKey, 'json')

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -41,7 +41,15 @@ import {
 	toRepoSessionInfoResult,
 	toRepoSessionTreeResult,
 } from './repo-session-tree.ts'
-import { runRepoChecks } from './checks.ts'
+import {
+	runPackageTypecheckLanguageService,
+	runRepoChecks,
+	validatePackageBundles,
+} from './checks.ts'
+import {
+	type IsolatedCheckPhaseOutcome,
+	type IsolatedCheckPhaseRequest,
+} from './isolated-check-phases.ts'
 import { parseRepoManifest } from './manifest.ts'
 import {
 	type EntityKind,
@@ -1662,6 +1670,49 @@ class RepoSessionBase extends DurableObject<Env> {
 		)
 		await this.touchRepoSession(sessionRow)
 		return this.readCheckStatus()
+	}
+
+	/**
+	 * Pure-compute entrypoint for one heavy repo-check phase, invoked on a
+	 * throwaway Durable Object id so the phase's peak memory lives in its own
+	 * isolate (see isolated-check-phases.ts and kentcdodds/kody#987). It has
+	 * no session and never touches this instance's storage; the staged source
+	 * files come from a short-TTL KV entry written by the orchestrating
+	 * checks run.
+	 */
+	async runIsolatedCheckPhase(
+		input: IsolatedCheckPhaseRequest,
+	): Promise<IsolatedCheckPhaseOutcome> {
+		const staged = await this.env.BUNDLE_ARTIFACTS_KV.get<{
+			sourceFiles?: Record<string, string>
+		}>(input.stagingKey, 'json')
+		const sourceFiles = staged?.sourceFiles
+		if (!sourceFiles) {
+			return {
+				ok: false,
+				message:
+					'Isolated check phase staging data expired or is missing; run the checks again.',
+			}
+		}
+		if (input.phase === 'bundle-chunk') {
+			return await validatePackageBundles({
+				env: this.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceFiles,
+				entryPoints: input.bundleTargets,
+			})
+		}
+		if (input.phase === 'typecheck') {
+			return await runPackageTypecheckLanguageService({
+				sourceFiles,
+				targets: input.typecheckTargets,
+			})
+		}
+		const exhaustive: never = input
+		throw new Error(
+			`Unsupported isolated check phase: ${JSON.stringify(exhaustive)}`,
+		)
 	}
 
 	async listPublishedPackageArtifactTargets(input: {

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -3,6 +3,10 @@ import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtim
 import { repoSessionDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import { type RepoRunCommandsResult } from './repo-session-commands.ts'
 import {
+	type IsolatedCheckPhaseOutcome,
+	type IsolatedCheckPhaseRequest,
+} from './isolated-check-phases.ts'
+import {
 	type RepoSourceBootstrapResult,
 	type RepoSearchMode,
 	type RepoSearchOutputMode,
@@ -109,6 +113,9 @@ export type RepoSessionRpc = {
 		userId: string
 		expectedPackageScope?: string
 	}) => Promise<RepoSessionCheckRun>
+	runIsolatedCheckPhase: (
+		payload: IsolatedCheckPhaseRequest,
+	) => Promise<IsolatedCheckPhaseOutcome>
 	getCheckStatus: (payload: {
 		sessionId: string
 		userId: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #987 (the part #988 could not).

**Problem.** One large package can push the session/publish Durable Object (workspace + git state + checks) over the isolate memory limit and kill every publish attempt with repeated resets. After #988's typecheck-first ordering deployed, `@kentcdodds/personal-history` (14 bundle targets + an app over ~809 KB of source) *still* OOMed the checks lane — verified live at 02:16 UTC on 2026-07-28.

**Fix.** `runRepoChecks` now stages the collected source files once in `BUNDLE_ARTIFACTS_KV` (`repo-checks-staging:v1:*`, 15-minute TTL, bounded by the existing 2000-file / 15 MiB repo-check caps) and runs the two heavy phases in fresh throwaway `REPO_SESSION` isolates via a new pure-compute `runIsolatedCheckPhase` RPC:

- **Fresh isolate per phase invocation** (`isolated-check-phase-${uuid}` ids): phases never stack their peak memory on the session isolate or on each other — esbuild-wasm memory is a module-level singleton that never shrinks once grown.
- **Bundle targets validate in chunks of 4** per isolate (`isolatedBundleChunkSize`), so per-isolate peak stays far below the limit regardless of target count.
- **Graceful capacity failure**: if a package is too large for even a single phase, the isolate reset is converted into a failed `bundle`/`typecheck` check with an actionable message ("reduce package source size…") instead of an opaque `Durable Object's isolate exceeded its memory limit` crash after three retries.
- **No storage residue**: the throwaway instances never touch their own DO storage, so nothing persists for the random ids; the KV staging entry is deleted after the run (TTL as backstop).

Without the bindings (unit tests, minimal envs) the phases run inline exactly as before. Check result kinds, ordering, and messages are unchanged (`Bundled N package target(s) successfully.` etc.), so dashboards and pinned tests see identical shapes.

**Testing**: new orchestration tests (staging lifecycle, chunk fan-out with fresh isolate names, isolate-reset → failed-check conversion) and a DO-side dispatch test for `runIsolatedCheckPhase` (KV hit, both phases, expired staging fails closed); full unit suites (node + workers) pass; typecheck/lint/format clean. Post-deploy acceptance: `repo_run_commands` with `run_checks: true` on `personal-history` — the exact call that OOMs today.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `175a8a49`

**Classification:** extends — the repo-session checks pipeline fans heavy phases out to throwaway instances of the same DO class; new KV staging convention; no new primitives.

### Primitives touched

| Primitive           | Group   | Impact                                                                        |
| ------------------- | ------- | ------------------------------------------------------------------------------ |
| `repo-sessions`     | storage | extends — `runIsolatedCheckPhase` RPC + KV-staged fan-out from `runRepoChecks` |
| `bundle-artifacts-kv` | storage | composes — short-TTL `repo-checks-staging:v1:*` entries during a checks run   |

### System map

A checks run stages sources in KV once, then each heavy phase runs in its own throwaway isolate and reports back.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	repoSessions["repo-sessions<br/>Repo-backed source sessions"]:::extended
	throwaway["repo-sessions (throwaway ids)<br/>Isolated check phases"]:::extended
	bundleKv["bundle-artifacts-kv<br/>Bundle artifacts KV"]:::touched
	repoSessions -->|"stage sourceFiles (15 min TTL)"| bundleKv
	repoSessions -->|"runIsolatedCheckPhase: typecheck + bundle chunks (fresh id each)"| throwaway
	throwaway -->|"read staged sourceFiles"| bundleKv
	repoSessions -->|"delete staging key after run"| bundleKv
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Staged source files are already bounded by the repo-check caps and scoped to a random single-run key with TTL; the throwaway isolates run only against staged data plus the same env bindings the session DO already holds. Per-user isolation is unchanged — phase requests carry the same `userId` the checks run started with.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository checks can now run intensive typechecking and bundle validation in isolated execution environments when isolate support is available.
  * Bundle validation is performed in smaller chunk batches to improve throughput and stability.
  * Staged check data is automatically cleaned up after processing.
* **Bug Fixes**
  * Isolate memory-limit/reset events now produce clear failed check results instead of crashing.
  * Missing/expired or unauthorized staged data now fails safely with an explanatory message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->