### PR TITLE
fix(email): keep email_send non-self recipient errors out of Sentry

### DIFF
--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -8,6 +8,7 @@ import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { isAccountEmailVerified } from '#app/email-verification.ts'
 import { normalizeEmail } from '#app/normalize-email.ts'
 import { withAccountWriteLease } from '#app/account-deletion-state.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	assertWithinEntitlement,
 	assertWithinStorageBytesEntitlement,
@@ -122,13 +123,17 @@ function resolveSelfRecipients(input: {
 	const normalized = values.map((value) => {
 		const address = normalizeEmailAddress(value)
 		if (!address) {
-			throw new Error(`Invalid recipient email address: ${value}`)
+			// Caller-supplied address that does not parse — keep it off Sentry.
+			throw new McpCallerError(`Invalid recipient email address: ${value}`)
 		}
 		return address
 	})
 	const disallowed = normalized.filter((value) => value !== accountEmail)
 	if (disallowed.length > 0) {
-		throw new Error(
+		// email_send is notify-self only; agents often pass a third-party
+		// address by mistake. That is a routine caller correction (use
+		// email_reply), not a platform defect — keep it off Sentry.
+		throw new McpCallerError(
 			`email_send only delivers to your own account email (${accountEmail}). Use email_reply to answer stored inbound messages.`,
 		)
 	}

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import {
@@ -221,32 +222,37 @@ test('sendOutboundEmail rejects non-self recipients under the self policy', asyn
 	const userId = await createStableUserIdFromEmail(accountEmail)
 	await seedVerifiedAccount({ email: accountEmail })
 
-	await expect(
-		sendOutboundEmail({
-			env: createBindingSendEnv(),
-			userId,
-			accountEmail,
-			recipientPolicy: 'self',
-			to: 'someone-else@example.net',
-			subject: 'Blocked',
-			text: 'Body',
-		}),
-	).rejects.toThrow(
-		`email_send only delivers to your own account email (${accountEmail})`,
-	)
+	const nonSelfError = await sendOutboundEmail({
+		env: createBindingSendEnv(),
+		userId,
+		accountEmail,
+		recipientPolicy: 'self',
+		to: 'someone-else@example.net',
+		subject: 'Blocked',
+		text: 'Body',
+	}).catch((caught: unknown) => caught)
+	// Agent mistakes (third-party `to`) must stay off Sentry as McpCallerError.
+	expect(nonSelfError).toBeInstanceOf(McpCallerError)
+	expect(nonSelfError).toMatchObject({
+		message: expect.stringContaining(
+			`email_send only delivers to your own account email (${accountEmail})`,
+		),
+	})
 	// Malformed explicit recipients are rejected instead of silently dropped
 	// (a dropped value would fall back to the account email).
-	await expect(
-		sendOutboundEmail({
-			env: createBindingSendEnv(),
-			userId,
-			accountEmail,
-			recipientPolicy: 'self',
-			to: 'not-an-email',
-			subject: 'Blocked',
-			text: 'Body',
-		}),
-	).rejects.toThrow('Invalid recipient email address: not-an-email')
+	const invalidError = await sendOutboundEmail({
+		env: createBindingSendEnv(),
+		userId,
+		accountEmail,
+		recipientPolicy: 'self',
+		to: 'not-an-email',
+		subject: 'Blocked',
+		text: 'Body',
+	}).catch((caught: unknown) => caught)
+	expect(invalidError).toBeInstanceOf(McpCallerError)
+	expect(invalidError).toMatchObject({
+		message: 'Invalid recipient email address: not-an-email',
+	})
 	// Providing the own account email explicitly is allowed.
 	const allowed = await sendOutboundEmail({
 		env: createBindingSendEnv(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-2K](https://kent-c-dodds-tech-llc.sentry.io/issues/7637167909/) was opened when an agent called `email_send` with a third-party `to`. That path is intentionally notify-self only and correctly rejects the call — but it threw a plain `Error`, so MCP observability treated it like a platform bug.

Throw `McpCallerError` for invalid/disallowed self-policy recipients so these stay on structured `mcp-event` logs and out of Sentry (same carve-out as missing job ids, unknown domains, etc.). Delivery policy is unchanged.

## Test plan

- [x] `outbound.workers.test.ts` asserts `McpCallerError` for non-self and invalid recipients
- [ ] `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f78a596a` · **Head:** `916b291c`

**Classification:** composes — wires the existing `McpCallerError` carve-out into email self-recipient validation; no new primitives or delivery-policy changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `email` | assistant | composes — throw site type only (`Error` → `McpCallerError`) |

### System map

Caller mistakes on `email_send` self-policy stay on mcp-event logs instead of opening Sentry issues.

```mermaid
flowchart LR
  agent[Agent / MCP client] --> emailSend[email_send]
  emailSend --> resolve[resolveSelfRecipients]
  resolve -->|disallowed or invalid to| callerErr[McpCallerError]
  callerErr --> mcpLog[mcp-event log]
  callerErr -.->|skipped| sentry[Sentry]
  resolve -->|account email only| send[Cloudflare send]
```

**Legend:** green = composes · amber = extended · red = new · gray = context.

### Risk

Low. Same rejection messages and policy; only Sentry reporting changes for these caller mistakes. No auth, isolation, billing, or migration surface.

### Docs

No doc updates required — behavior matches existing `email_send` description and the MCP caller-error observability contract.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20a1900a-c6a0-4462-8134-638836025b43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20a1900a-c6a0-4462-8134-638836025b43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid recipient email addresses and self-only notification policy violations.
  * These expected input errors now receive clearer, more specific error classification and messaging.
* **Tests**
  * Added coverage to verify the correct error type and message details for invalid recipients and policy violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->