### PR TITLE
fix(app-ui): Navigation API stand-in for KODY-CLOUDFLARE-17

### DIFF
--- a/e2e/ssr-hydration.spec.ts
+++ b/e2e/ssr-hydration.spec.ts
@@ -213,3 +213,48 @@ test('SSR community HTML hydrates SPA navigation and client search', async ({
 
 	expect(clientErrors).toEqual([])
 })
+
+test('the app hydrates on browsers without the Navigation API', async ({
+	page,
+}) => {
+	await ensurePrimaryUserExists()
+	await seedCommunityListingInE2eDatabase({
+		...alphaListing,
+		ownerEmail: primaryTestUser.email,
+		readmeContent: longReadme,
+	})
+
+	const clientErrors: Array<string> = []
+	page.on('pageerror', (error) => clientErrors.push(error.message))
+
+	// Firefox 146 and below, and every browser on iOS 26.1 and below, ship
+	// without the Navigation API. Chromium has had it since 102, so shadow the
+	// getter to stand in for those clients.
+	await page.addInitScript(() => {
+		Object.defineProperty(window, 'navigation', {
+			value: undefined,
+			configurable: true,
+		})
+	})
+
+	await page.goto('/community')
+	await expect(page.getByText(alphaListing.description)).toBeVisible()
+	await page.evaluate(() => {
+		;(window as Window & { __e2eMarker?: boolean }).__e2eMarker = true
+	})
+
+	await page.getByRole('link', { name: alphaListing.name }).click()
+	await expect(page).toHaveURL(
+		new RegExp(`/community/${alphaListing.listingId}$`),
+	)
+	await expect(page.getByRole('heading', { name: 'Stars' })).toBeVisible()
+	// The marker surviving proves the client router handled the click, so
+	// hydration ran rather than the browser doing a document navigation.
+	expect(
+		await page.evaluate(
+			() => (window as Window & { __e2eMarker?: boolean }).__e2eMarker,
+		),
+	).toBe(true)
+
+	expect(clientErrors).toEqual([])
+})

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -1,6 +1,7 @@
 import { run } from 'remix/ui'
 import { REMIX_FRAME_TARGET_HEADER } from '#app/frame-constants.ts'
 import { consumePrefetchedFrame } from '#client/frame-prefetch.ts'
+import { installNavigationApiFallback } from '#client/navigation-api-fallback.ts'
 import {
 	captureClientException,
 	initSentryClient,
@@ -8,6 +9,8 @@ import {
 import { AppRoot, APP_ROOT_ENTRY_ID } from './app-root.tsx'
 
 initSentryClient(document)
+// `run()` reads `window.navigation` unguarded, so this has to land first.
+installNavigationApiFallback(window)
 
 const clientRegistry: Record<string, typeof AppRoot> = {
 	AppRoot,

--- a/packages/worker/client/navigation-api-fallback.node.test.ts
+++ b/packages/worker/client/navigation-api-fallback.node.test.ts
@@ -1,0 +1,55 @@
+import { expect, test, vi } from 'vitest'
+import { installNavigationApiFallback } from './navigation-api-fallback.ts'
+
+function createFakeWindow() {
+	return {
+		location: {
+			href: 'https://heykody.dev/community',
+			assign: vi.fn(),
+			replace: vi.fn(),
+		},
+	} as unknown as Window
+}
+
+test('navigation fallback stands in for the Navigation API only when it is missing', () => {
+	const win = createFakeWindow()
+
+	expect(installNavigationApiFallback(win)).toBe(true)
+
+	// The unguarded call that kills Remix hydration on browsers without the
+	// Navigation API.
+	const navigation = win.navigation
+	navigation.updateCurrentEntry({
+		state: { src: 'https://heykody.dev/community', $rmx: true },
+	})
+	expect(navigation.currentEntry?.getState()).toEqual({
+		src: 'https://heykody.dev/community',
+		$rmx: true,
+	})
+	expect(navigation.entries()).toHaveLength(1)
+
+	// Remix subscribes to `navigate` with an abort signal; nothing ever
+	// dispatches one, so link clicks stay with the browser.
+	const listener = vi.fn()
+	const controller = new AbortController()
+	navigation.addEventListener('navigate', listener, {
+		signal: controller.signal,
+	})
+	expect(listener).not.toHaveBeenCalled()
+
+	navigation.navigate('/community/abc', { history: 'push' })
+	expect(win.location.assign).toHaveBeenCalledWith(
+		'https://heykody.dev/community/abc',
+	)
+	navigation.navigate('/login', { history: 'replace' })
+	expect(win.location.replace).toHaveBeenCalledWith('https://heykody.dev/login')
+
+	const browserWithNavigation = createFakeWindow()
+	const realNavigation = {
+		updateCurrentEntry: vi.fn(),
+	} as unknown as Navigation
+	browserWithNavigation.navigation = realNavigation
+
+	expect(installNavigationApiFallback(browserWithNavigation)).toBe(false)
+	expect(browserWithNavigation.navigation).toBe(realNavigation)
+})

--- a/packages/worker/client/navigation-api-fallback.ts
+++ b/packages/worker/client/navigation-api-fallback.ts
@@ -1,0 +1,113 @@
+/**
+ * Minimal stand-in for the Navigation API, installed only where the browser
+ * does not provide one.
+ *
+ * Remix 3 beta's client runtime reads `window.navigation.updateCurrentEntry()`
+ * unguarded while it boots (`@remix-run/ui`'s `startNavigationListener`), so
+ * `run()` throws on every browser without the Navigation API. The API only
+ * reached Firefox in 147 and WebKit in 26.2, both in early 2026, so that still
+ * covers Firefox 146 and below plus every browser on iOS 26.1 and below — all
+ * of them WebKit, so Chrome for iOS and in-app browsers included.
+ *
+ * The throw lands after `createFrame(...)` but before `run()` returns, so
+ * hydration already in flight survives and the app stays broadly usable. What
+ * those visitors actually lose is an unhandled `TypeError` on every page load,
+ * plus the `app.addEventListener('error', ...)` wiring and `app.ready()` call
+ * in `entry.tsx` that never run — meaning client error reporting is missing
+ * for exactly the people already hitting an error.
+ *
+ * Kody itself never uses the Navigation API: `client-router.tsx` drives SPA
+ * navigation through `history.pushState` and a document-level click handler,
+ * and it calls `preventDefault()` before the Remix listener could intercept
+ * anything. A stand-in that never emits `navigate` is therefore equivalent to
+ * the real API for this app, and the links Remix would have intercepted fall
+ * back to ordinary document navigation.
+ *
+ * Only the members the Remix runtime touches are implemented. Remove this once
+ * the upstream guard ships: https://github.com/remix-run/remix/issues/11641
+ */
+
+type FallbackHistoryEntry = {
+	readonly key: string
+	readonly id: string
+	readonly url: string
+	readonly index: number
+	readonly sameDocument: boolean
+	getState: () => unknown
+}
+
+type FallbackNavigateOptions = {
+	state?: unknown
+	history?: 'auto' | 'push' | 'replace'
+}
+
+const fallbackEntryKey = 'kody-navigation-fallback'
+
+class NavigationApiFallback extends EventTarget {
+	#window: Window
+	#state: unknown = null
+
+	constructor(win: Window) {
+		super()
+		this.#window = win
+	}
+
+	get currentEntry(): FallbackHistoryEntry {
+		return {
+			key: fallbackEntryKey,
+			id: fallbackEntryKey,
+			url: this.#window.location.href,
+			index: 0,
+			sameDocument: true,
+			getState: () => this.#state,
+		}
+	}
+
+	entries(): Array<FallbackHistoryEntry> {
+		return [this.currentEntry]
+	}
+
+	updateCurrentEntry(options: { state?: unknown }) {
+		this.#state = options?.state ?? null
+	}
+
+	navigate(url: string, options?: FallbackNavigateOptions) {
+		this.#state = options?.state ?? null
+		const destination = new URL(url, this.#window.location.href).toString()
+		if (options?.history === 'replace') {
+			this.#window.location.replace(destination)
+		} else {
+			this.#window.location.assign(destination)
+		}
+		// Cross-document navigations discard this document, so the real API
+		// never settles these promises either.
+		const pending = new Promise<FallbackHistoryEntry>(() => {})
+		return { committed: pending, finished: pending }
+	}
+}
+
+/**
+ * Defines `window.navigation` when the browser lacks it.
+ *
+ * @returns whether the fallback was installed.
+ */
+export function installNavigationApiFallback(win: Window) {
+	if (win.navigation) return false
+
+	try {
+		Object.defineProperty(win, 'navigation', {
+			// Only the subset Remix reads is implemented, so the real
+			// `Navigation` type overstates what this provides.
+			value: new NavigationApiFallback(win) as unknown as Navigation,
+			configurable: true,
+			writable: true,
+			enumerable: false,
+		})
+	} catch {
+		// A browser that refuses the definition still gets the unguarded
+		// upstream throw; failing to install must not add a second error.
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> ## Leave open for Kent — stopgap pending upstream
>
> Re-opens the proven workaround from #924. Upstream [remix-run/remix#11641](https://github.com/remix-run/remix/issues/11641) is still open; production still reports this on every affected page load (**23 events**, last seen 2026-07-28). **Do not squash-merge from triage** — medium-risk global shim; Kent decides whether to ship ahead of Remix.
>
> CI is green on this PR (Validate / Node / Workers / E2E / Static / MCP). Preview: https://kody-pr-998.kody-a99.workers.dev

## Sentry

- Issue: [KODY-CLOUDFLARE-17](https://kent-c-dodds-tech-llc.sentry.io/issues/7631270155/)
- Signature: `TypeError: undefined is not an object (evaluating 'r.updateCurrentEntry')` (WebKit) / `can't access property "updateCurrentEntry", r is undefined` (Firefox)
- Culprit: Remix `startNavigationListener` → `window.navigation.updateCurrentEntry` with no feature check
- Affected: Firefox ≤146, all WebKit on iOS ≤26.1 (Safari, Chrome iOS, Twitter/X in-app, …)

## Root cause

`@remix-run/ui`'s `run()` calls `startNavigationListener()`, which does:

```ts
let navigation = window.navigation
navigation.updateCurrentEntry({ ... }) // throws when API absent
```

Throw lands after `createFrame(...)` and before `run()` returns, so hydration in flight survives and the app stays broadly usable — but:

1. Unhandled `TypeError` on every page load for affected visitors
2. `entry.tsx` never reaches `app.addEventListener('error', ...)` / `app.ready()`, so client Sentry wiring is missing for exactly those users

## Fix

Install a minimal `window.navigation` stand-in **before** `run()` when the browser lacks the API. Kody never uses Navigation API for SPA routing (`client-router.tsx` + `history.pushState`), so a stand-in that never emits `navigate` is behaviourally identical here.

## Verification

- Unit: `navigation-api-fallback.node.test.ts`
- E2E: shadows `window.navigation` and asserts hydration + SPA nav (marker survives click)
- CI green: https://github.com/kentcdodds/kody/actions/runs/30365414901

Related: closed stopgap #924 (same approach; closed pending upstream).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk — stopgap, leave open)</summary>

**Mode:** recap · **Base:** `main` @ `f78a596a` · **Head:** `53c2a649`

**Classification:** extends — no new primitives; `app-ui` boot installs a feature-detected Navigation API stand-in before the Remix runtime starts.

### Primitives touched

| Primitive | Group    | Impact                                                                       |
| --------- | -------- | ---------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — client entry defines `window.navigation` when the browser lacks it |

### System map

Client boot feature-detects the Navigation API and installs a stand-in before starting the Remix runtime, so `run()` completes and `entry.tsx` wires its error listener.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	remixRuntime["remix-ui<br/>Remix client runtime"]:::untouched
	sentryTunnel["sentry-tunnel<br/>Same-origin error reporting"]:::untouched
	appUi -->|"installNavigationApiFallback(window) before run()"| remixRuntime
	remixRuntime -->|"run() returns, so app.addEventListener('error') is registered"| appUi
	appUi -->|"client errors reach Sentry on affected browsers again"| sentryTunnel
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Browser | Before | After |
| --- | --- | --- |
| Has Navigation API (Chrome, Edge, Firefox 147+, iOS 26.2+) | unaffected | unaffected — early return |
| Lacks it (Firefox ≤146, iOS ≤26.1) | unhandled TypeError per load; error reporting never wired | no error; `run()` returns and reporting wires up |

### Invariants

No change to per-user isolation. The stand-in holds only the current entry's navigation state and no user data.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb64b997-6481-4db8-845d-37f8ffecaf0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb64b997-6481-4db8-845d-37f8ffecaf0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app loading and navigation in browsers that do not support the Navigation API.
  * Preserved client-side routing behavior, including navigation to detail pages, without unnecessary full-page reloads.
  * Added safeguards to avoid interfering with browsers that already provide the Navigation API.

* **Tests**
  * Added automated coverage verifying hydration and navigation behavior across supported browser capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->