### PR TITLE
fix(mcp): keep package secret access denials off Sentry

### DIFF
--- a/packages/worker/src/mcp/capabilities/secrets/secret-set.ts
+++ b/packages/worker/src/mcp/capabilities/secrets/secret-set.ts
@@ -4,6 +4,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { assertPackageCanAccessResolvedSecret } from '#mcp/secrets/package-access.ts'
 import {
 	resolveSecret,
@@ -66,7 +67,7 @@ export const secretSetCapability = defineDomainCapability(
 					storageContext,
 				})
 				if (!existing.found) {
-					throw new Error(
+					throw new McpCallerError(
 						'Package runtimes cannot create user-scoped secrets. Create the secret from the account page and approve the package first.',
 					)
 				}

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -30,6 +30,8 @@ vi.mock('@sentry/cloudflare', () => ({
 
 const { logMcpEvent } = await import('./observability.ts')
 const { McpCallerError } = await import('./caller-error.ts')
+const { PackageSecretAccessDeniedError } =
+	await import('./secrets/package-access.ts')
 const { UserCodeError } = await import('#worker/user-code-error.ts')
 
 function captureMcpEvents(run: () => void) {
@@ -140,9 +142,23 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			errorMessage: 'boom from user code',
 			cause: new UserCodeError('boom from user code'),
 		})
+
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'secret_set',
+			domain: 'secrets',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'PackageSecretAccessDeniedError',
+			errorMessage:
+				'Secret "x-kodykoalaAccessToken" is not allowed for package "x".',
+			cause: new PackageSecretAccessDeniedError(
+				'Secret "x-kodykoalaAccessToken" is not allowed for package "x".',
+			),
+		})
 	})
 
-	expect(payloads).toHaveLength(7)
+	expect(payloads).toHaveLength(8)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/secrets/package-access.node.test.ts
+++ b/packages/worker/src/mcp/secrets/package-access.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { parsePackageAccessRequiredMessage } from './errors.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -30,6 +31,7 @@ vi.mock('./service.ts', () => ({
 const {
 	assertPackageCanAccessResolvedSecret,
 	buildPackageApprovalErrorForMounts,
+	PackageSecretAccessDeniedError,
 	resolvePackageMountedSecret,
 } = await import('./package-access.ts')
 
@@ -133,12 +135,13 @@ test('community-forked packages require an allowed-packages grant for user secre
 			},
 		}),
 	).rejects.toSatisfy((error: unknown) => {
-		const message = error instanceof Error ? error.message : String(error)
-		const parsed = parsePackageAccessRequiredMessage(message)
+		if (!(error instanceof PackageSecretAccessDeniedError)) return false
+		if (!(error instanceof McpCallerError)) return false
+		const parsed = parsePackageAccessRequiredMessage(error.message)
 		return (
 			parsed?.secretName === 'userToken' &&
 			parsed.packageName === 'discord-gateway' &&
-			message.includes('/account/secrets/user/userToken')
+			error.message.includes('/account/secrets/user/userToken')
 		)
 	})
 })
@@ -222,10 +225,11 @@ test('adopted community forks still require an allowed-packages grant for mutate
 			intent: 'mutate',
 		}),
 	).rejects.toSatisfy((error: unknown) => {
-		const message = error instanceof Error ? error.message : String(error)
 		return (
-			parsePackageAccessRequiredMessage(message)?.packageName ===
-			'discord-gateway'
+			error instanceof PackageSecretAccessDeniedError &&
+			error instanceof McpCallerError &&
+			parsePackageAccessRequiredMessage(error.message)?.packageName ===
+				'discord-gateway'
 		)
 	})
 	expect(mockModule.getCommunityForkByForkedPackageId).not.toHaveBeenCalled()
@@ -255,12 +259,13 @@ test('mutate intent requires an allowed-packages grant even for self-authored pa
 			intent: 'mutate',
 		}),
 	).rejects.toSatisfy((error: unknown) => {
-		const message = error instanceof Error ? error.message : String(error)
-		const parsed = parsePackageAccessRequiredMessage(message)
+		if (!(error instanceof PackageSecretAccessDeniedError)) return false
+		if (!(error instanceof McpCallerError)) return false
+		const parsed = parsePackageAccessRequiredMessage(error.message)
 		return (
 			parsed?.secretName === 'userToken' &&
 			parsed.packageName === 'discord-gateway' &&
-			message.includes('/account/secrets/user/userToken')
+			error.message.includes('/account/secrets/user/userToken')
 		)
 	})
 	expect(mockModule.getCommunityForkByForkedPackageId).not.toHaveBeenCalled()

--- a/packages/worker/src/mcp/secrets/package-access.ts
+++ b/packages/worker/src/mcp/secrets/package-access.ts
@@ -1,4 +1,5 @@
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	buildSecretPackageApprovalUrl,
 	buildSecretPackageBulkApprovalUrlIfNeeded,
@@ -22,9 +23,30 @@ type SecretMountDefinition = {
 	scope?: SecretScope
 }
 
-export class PackageSecretMountError extends Error {}
-export class PackageSecretMissingError extends Error {}
-export class PackageSecretAccessDeniedError extends Error {}
+/**
+ * Package secret mount/approval failures the caller can clear (approve the
+ * package, declare a mount, create the secret). Subclass McpCallerError so
+ * MCP observability keeps them off Sentry — they are policy denials, not
+ * platform defects.
+ */
+export class PackageSecretMountError extends McpCallerError {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options)
+		this.name = 'PackageSecretMountError'
+	}
+}
+export class PackageSecretMissingError extends McpCallerError {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options)
+		this.name = 'PackageSecretMissingError'
+	}
+}
+export class PackageSecretAccessDeniedError extends McpCallerError {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options)
+		this.name = 'PackageSecretAccessDeniedError'
+	}
+}
 
 export function isPackageSecretAccessUnavailableError(error: unknown) {
 	return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-2J](https://kent-c-dodds-tech-llc.sentry.io/issues/7637107075/) fired when package `x` called `secret_set` on a user secret without an `allowed_packages` grant. That denial is correct policy; the bug was classifying it as a platform failure.

`PackageSecretAccessDeniedError` (plus mount/missing siblings) now extend `McpCallerError`, so MCP observability keeps them on the `mcp-event` log and out of Sentry. Also wraps the “package cannot create user-scoped secrets” path in `secret_set` the same way.

## Test plan

- [x] `package-access` unit tests assert denials are `PackageSecretAccessDeniedError` ∩ `McpCallerError`
- [x] `observability` unit test: `secret_set` package-access denial is not sent to Sentry
- [x] Pre-push: unit + Playwright e2e passed

## Sentry

- Issue: KODY-CLOUDFLARE-2J (`7637107075`)
- Outcome: **fixed** (caller-error classification); resolve after merge deploy
- Siblings: none share this root cause

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f78a596a` · **Head:** `547ccd68`

**Classification:** composes — wires package-secret policy denials into the existing `McpCallerError` observability carve-out; secret access policy unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | composes — package secret errors subclass `McpCallerError` so MCP failure reporting skips Sentry |
| `secrets` | assistant | composes — `secret_set` create-denied path uses `McpCallerError`; mutate denials inherit via package-access |

### System map

Package runtime secret mutate/create denials flow through MCP capability handlers; this PR only changes which error class they throw so observability treats them as caller failures.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	secrets["secrets<br/>Secret references"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	secrets -->|"secret_set / package-access throws McpCallerError"| mcpServer
	mcpServer -->|"isCallerFailure skips Sentry"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Pkg as Package runtime
	participant Cap as secret_set
	participant Acc as assertPackageCanAccessResolvedSecret
	participant Obs as logMcpEvent
	Pkg->>Cap: mutate user secret (no allowed_packages)
	Cap->>Acc: intent mutate
	Acc-->>Cap: PackageSecretAccessDeniedError (McpCallerError)
	Cap-->>Obs: failure cause
	Note over Obs: isMcpCallerError → no Sentry
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d705290a-961b-45b9-adb4-a7a8f69444dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d705290a-961b-45b9-adb4-a7a8f69444dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

