### PR TITLE
fix(dr): survive bucket-lock put rejections and inventory drift so days seal

### DIFF
--- a/packages/backup-control-plane/backup-control-plane-test-support.ts
+++ b/packages/backup-control-plane/backup-control-plane-test-support.ts
@@ -82,6 +82,16 @@ export class MemoryBucket {
 	private readonly objects = new Map<string, Uint8Array>()
 	private readonly reportedSizes = new Map<string, number>()
 	private nextPutRace: { key: string; bytes: Uint8Array } | undefined
+	private lockPolicyEnabled = false
+
+	/**
+	 * Emulate an R2 bucket-lock rule: puts targeting an existing key are
+	 * rejected with error 10069 before conditional headers are evaluated
+	 * (matches live behavior on the locked backup prefixes).
+	 */
+	enableLockPolicy(): void {
+		this.lockPolicyEnabled = true
+	}
 
 	async put(
 		key: string,
@@ -92,6 +102,9 @@ export class MemoryBucket {
 		if (this.nextPutRace?.key === key) {
 			this.objects.set(key, this.nextPutRace.bytes)
 			this.nextPutRace = undefined
+		}
+		if (this.lockPolicyEnabled && this.objects.has(key)) {
+			throw new Error('put: The object is locked by the bucket policy. (10069)')
 		}
 		if (
 			options.onlyIf &&

--- a/packages/backup-control-plane/backup-runtime.ts
+++ b/packages/backup-control-plane/backup-runtime.ts
@@ -6,6 +6,7 @@ import {
 import { runDurableExport, type DurableExportStep } from './durable-export.ts'
 import {
 	assertDuplicateMatchesManifest,
+	isBucketLockPolicyPutError,
 	putImmutableManifest,
 	storeSignedDownload,
 } from './immutable-storage.ts'
@@ -72,10 +73,14 @@ async function recordSqlStatementStats(input: {
 	})
 	// The stats object is advisory; an existing object from a replayed step
 	// wins and is left alone (the prefix is under the bucket's immutable
-	// lock, so overwrites are rejected anyway).
+	// lock, which rejects puts on existing keys with error 10069 before the
+	// conditional is evaluated).
 	await input.env.BACKUP_BUCKET.put(`${input.objectKey}.stats.json`, body, {
 		onlyIf: { etagDoesNotMatch: '*' },
 		httpMetadata: { contentType: 'application/json' },
+	}).catch((error: unknown) => {
+		if (isBucketLockPolicyPutError(error)) return null
+		throw error
 	})
 }
 

--- a/packages/backup-control-plane/immutable-storage.ts
+++ b/packages/backup-control-plane/immutable-storage.ts
@@ -13,6 +13,23 @@ import {
 
 export const MAXIMUM_SINGLE_BACKUP_OBJECT_BYTES = 5 * 1024 * 1024 * 1024
 
+/**
+ * R2 rejects any put targeting an existing object under a bucket-lock rule
+ * with `put: The object is locked by the bucket policy. (10069)` before
+ * evaluating conditional headers, so the `onlyIf: { etagDoesNotMatch: '*' }`
+ * create-only pattern throws on locked prefixes instead of returning null.
+ * Verified live 2026-07-28: sealing wedged hourly on the locked `daily/`
+ * prefix. Treat the rejection as "object already exists" so retries and
+ * replays fall through to byte comparison.
+ */
+export function isBucketLockPolicyPutError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error)
+	return (
+		message.includes('locked by the bucket policy') ||
+		message.includes('(10069)')
+	)
+}
+
 const SINGLE_QUOTE = 0x27
 const SEMICOLON = 0x3b
 
@@ -342,6 +359,10 @@ export async function storeSignedDownload(
 					onlyIf: { etagDoesNotMatch: '*' },
 					httpMetadata: { contentType: 'application/sql' },
 				})
+				.catch((error: unknown) => {
+					if (isBucketLockPolicyPutError(error)) return null
+					throw error
+				})
 				.then(async (result) => {
 					if (result === null && !r2Body.locked) await r2Body.cancel()
 					return result
@@ -374,10 +395,15 @@ export async function putImmutableManifest(
 	manifest: BackupManifest,
 ): Promise<void> {
 	const body = serializeBackupManifest(manifest)
-	const result = await bucket.put(key, body, {
-		onlyIf: { etagDoesNotMatch: '*' },
-		httpMetadata: { contentType: 'application/json' },
-	})
+	const result = await bucket
+		.put(key, body, {
+			onlyIf: { etagDoesNotMatch: '*' },
+			httpMetadata: { contentType: 'application/json' },
+		})
+		.catch((error: unknown) => {
+			if (isBucketLockPolicyPutError(error)) return null
+			throw error
+		})
 	if (result !== null) return
 	const existing = await bucket.get(key)
 	if (existing === null) {

--- a/packages/backup-control-plane/seal-full-backup.node.test.ts
+++ b/packages/backup-control-plane/seal-full-backup.node.test.ts
@@ -26,7 +26,11 @@ function sha256Text(value: string): string {
 	return createHash('sha256').update(value).digest('hex')
 }
 
-async function seedCompleteDay(bucket: MemoryBucket, day = '2026-07-22') {
+async function seedCompleteDay(
+	bucket: MemoryBucket,
+	day = '2026-07-22',
+	options: { duplicateIndexEntry?: boolean } = {},
+) {
 	const env = environment(bucket)
 	const d1Payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
 	const sqlBody = 'CREATE TABLE t(id INTEGER);\n'
@@ -58,18 +62,19 @@ async function seedCompleteDay(bucket: MemoryBucket, day = '2026-07-22') {
 
 	const dumpKey = stagingStorageDumpKey(day, 'user-storage-1')
 	const dumpBody = '{"key":"a","valueJson":"1"}\n'
+	const indexEntry = {
+		storageId: 'user-storage-1',
+		objectKey: dumpKey,
+		entryCount: 1,
+		bytes: dumpBody.length,
+		sha256: sha256Text(dumpBody),
+	}
 	const storageIndexBody = JSON.stringify({
 		schemaVersion: 1,
 		day,
-		entries: [
-			{
-				storageId: 'user-storage-1',
-				objectKey: dumpKey,
-				entryCount: 1,
-				bytes: dumpBody.length,
-				sha256: sha256Text(dumpBody),
-			},
-		],
+		entries: options.duplicateIndexEntry
+			? [indexEntry, indexEntry]
+			: [indexEntry],
 	})
 	const blobHash = 'e'.repeat(64)
 	const r2IndexBody = `{"key":"blob","size":1,"sha256":"${blobHash}"}\n`
@@ -143,6 +148,39 @@ test('sealFullBackupDay seals a complete day and is idempotent', async () => {
 	assert.equal(second.kind, 'sealed')
 	if (second.kind !== 'sealed') return
 	assert.equal(second.alreadySealed, true)
+})
+
+test('sealFullBackupDay completes over locked partial state and duplicate index entries', async () => {
+	// Reproduces the 2026-07-28 production wedge: the bucket-lock rule
+	// rejects puts on existing keys with error 10069, the storage index
+	// contained duplicate entries from mid-window inventory drift, and a
+	// partial earlier attempt had already copied some sealed objects. The
+	// seal must fall through to byte comparison in all three situations.
+	const bucket = new MemoryBucket()
+	bucket.enableLockPolicy()
+	const { env, day } = await seedCompleteDay(bucket, '2026-07-22', {
+		duplicateIndexEntry: true,
+	})
+	// Simulate the partial earlier attempt: the dump is already sealed.
+	const dumpBody = '{"key":"a","valueJson":"1"}\n'
+	await bucket.put(
+		`daily/full/${day}/storage/${encodeURIComponent('user-storage-1')}.ndjson`,
+		dumpBody,
+	)
+
+	const result = await sealFullBackupDay(
+		env,
+		day,
+		new Date(`${day}T04:00:00.000Z`),
+	)
+	assert.equal(result.kind, 'sealed')
+	if (result.kind !== 'sealed') return
+	assert.equal(result.alreadySealed, false)
+	const sealed = await readFullManifest(
+		bucket as unknown as R2Bucket,
+		sealedFullManifestKey(day),
+	)
+	assert.equal(sealed?.payload.day, day)
 })
 
 test('sealFullBackupDay fails closed on staging sha mismatch', async () => {

--- a/packages/backup-control-plane/seal-full-backup.ts
+++ b/packages/backup-control-plane/seal-full-backup.ts
@@ -30,7 +30,10 @@ import {
 	signBackupFullManifest,
 	verifyBackupFullManifestSignature,
 } from './full-manifest-signing.ts'
-import { readManifest } from './immutable-storage.ts'
+import {
+	isBucketLockPolicyPutError,
+	readManifest,
+} from './immutable-storage.ts'
 import { verifyBackupManifestSignature } from './manifest-signing.ts'
 
 const sha256Pattern = /^[0-9a-f]{64}$/
@@ -141,10 +144,19 @@ async function putImmutableBytes(
 	bytes: Uint8Array,
 	contentType: string,
 ): Promise<void> {
-	const result = await bucket.put(key, bytes, {
-		onlyIf: { etagDoesNotMatch: '*' },
-		httpMetadata: { contentType },
-	})
+	// A bucket-lock rule rejects puts on existing keys with error 10069
+	// before evaluating the conditional, so a partially sealed day (or a
+	// duplicate index entry) must fall through to byte comparison instead of
+	// failing the whole seal.
+	const result = await bucket
+		.put(key, bytes, {
+			onlyIf: { etagDoesNotMatch: '*' },
+			httpMetadata: { contentType },
+		})
+		.catch((error: unknown) => {
+			if (isBucketLockPolicyPutError(error)) return null
+			throw error
+		})
 	if (result !== null) return
 	const existing = await bucket.get(key)
 	if (existing === null) {
@@ -172,10 +184,15 @@ async function putImmutableFullManifest(
 	manifest: BackupFullManifest,
 ): Promise<void> {
 	const body = serializeBackupFullManifest(manifest)
-	const result = await bucket.put(key, body, {
-		onlyIf: { etagDoesNotMatch: '*' },
-		httpMetadata: { contentType: 'application/json' },
-	})
+	const result = await bucket
+		.put(key, body, {
+			onlyIf: { etagDoesNotMatch: '*' },
+			httpMetadata: { contentType: 'application/json' },
+		})
+		.catch((error: unknown) => {
+			if (isBucketLockPolicyPutError(error)) return null
+			throw error
+		})
 	if (result !== null) return
 	const existing = await bucket.get(key)
 	if (existing === null) {

--- a/packages/worker/src/dr/exporter.node.test.ts
+++ b/packages/worker/src/dr/exporter.node.test.ts
@@ -347,6 +347,89 @@ test('exporter resumes from progress cursor across ticks when budget is exhauste
 	}
 })
 
+test('inventory drift between ticks neither duplicates nor skips storage dumps', async () => {
+	storageMocks.exportStorage.mockReset()
+	storageMocks.exportStorage.mockResolvedValue({
+		entries: [{ key: 'k', value: 1 }],
+		truncated: false,
+		nextStartAfter: null,
+		pageSize: 250,
+		estimatedBytes: 1,
+	})
+	const { client } = createMemoryS3()
+	let nowMs = 1_000_000
+	const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+	const originalPut = client.put.bind(client)
+	client.put = async (key, body, options) => {
+		const result = await originalPut(key, body, options)
+		// Exhaust the budget after the first dump so the run resumes on the
+		// next tick against a drifted inventory.
+		if (key.includes('/storage/') && key.endsWith('.ndjson')) {
+			nowMs += 50_000
+		}
+		return result
+	}
+	// Sorted inventory starts as [job:2, job:3]; tick 1 completes job:2.
+	const jobs = [
+		{ userId: 'user-a', storageId: 'job:2' },
+		{ userId: 'user-a', storageId: 'job:3' },
+	]
+	const env = {
+		DR_EXPORT_ENABLED: 'true',
+		DR_BACKUP_ACCOUNT_ID: 'acct',
+		DR_BACKUP_BUCKET_NAME: 'bucket',
+		DR_BACKUP_ACCESS_KEY_ID: 'key',
+		DR_BACKUP_SECRET_ACCESS_KEY: 'secret',
+		APP_DB: createDb({ jobs }),
+		EMAIL_BLOBS: createR2({}),
+		COMMUNITY_ASSETS: createR2({}),
+		BUNDLE_ARTIFACTS_KV: { get: async () => null },
+		STORAGE_RUNNER: {},
+	} as unknown as Env
+	const now = new Date('2026-07-23T01:00:00.000Z')
+
+	try {
+		const tick1 = await runDrExportTick({
+			env,
+			now,
+			timeBudgetMs: 20_000,
+			s3: client,
+		})
+		expect(tick1.storageDumpsCompleted).toBe(1)
+
+		// A job registers a new bucket mid-window that sorts BEFORE the
+		// completed identity. A positional cursor would re-dump job:2
+		// (duplicate index entry) and never dump job:1.
+		jobs.unshift({ userId: 'user-a', storageId: 'job:1' })
+
+		nowMs = 1_000_000
+		const tick2 = await runDrExportTick({
+			env,
+			now,
+			timeBudgetMs: 200_000,
+			s3: client,
+		})
+		expect(tick2.summaryWritten).toBe(true)
+
+		const summary = JSON.parse(
+			(await client.getText(stagingSummaryKey('2026-07-23')))!.text,
+		)
+		const storageIndex = JSON.parse(
+			(await client.getText(summary.storageIndex.objectKey))!.text,
+		) as { entries: Array<{ storageId: string }> }
+		const identities = storageIndex.entries.map((entry) => entry.storageId)
+		expect(identities.sort()).toEqual([
+			encodeStorageIdentity('user-a', 'job:1'),
+			encodeStorageIdentity('user-a', 'job:2'),
+			encodeStorageIdentity('user-a', 'job:3'),
+		])
+		expect(new Set(identities).size).toBe(identities.length)
+		expect(storageMocks.exportStorage.mock.calls.length).toBe(3)
+	} finally {
+		dateNow.mockRestore()
+	}
+})
+
 test('exporter skips oversized storage dumps with a summary warning', async () => {
 	storageMocks.exportStorage.mockReset()
 	const hugeValue = 'x'.repeat(drExportMaxStorageDumpBufferBytes + 1)

--- a/packages/worker/src/dr/exporter.ts
+++ b/packages/worker/src/dr/exporter.ts
@@ -53,13 +53,24 @@ export type DrExporterProgress = {
 	phase: DrExporterPhase
 	/** Monotonic counter bumped on every progress persist. */
 	revision: number
-	/** Next index into the platform storage inventory. */
+	/**
+	 * Count of storage identities completed or skipped. The inventory is
+	 * re-listed every tick and can drift mid-run (jobs registering new
+	 * buckets), so resume is identity-driven, not positional; this field is
+	 * observability only.
+	 */
 	storageIndex: number
 	/**
 	 * Within the current storage dump: key cursor for exportStorage paging.
 	 * Null means the next storage identity has not started yet.
 	 */
 	storagePageStartAfter: string | null
+	/**
+	 * Identity the partial page state below belongs to. Guards resumed
+	 * partial pages against inventory drift between ticks; absent/mismatched
+	 * identity resets the partial state.
+	 */
+	storagePartialIdentity?: string | null
 	/** Accumulated NDJSON for the in-progress storage dump (resumed pages). */
 	storagePartialNdjson: string
 	storagePartialEntryCount: number
@@ -175,6 +186,7 @@ function createInitialProgress(day: string, now: Date): DrExporterProgress {
 		revision: 0,
 		storageIndex: 0,
 		storagePageStartAfter: null,
+		storagePartialIdentity: null,
 		storagePartialNdjson: '',
 		storagePartialEntryCount: 0,
 		storageEntries: [],
@@ -392,15 +404,34 @@ async function loadOrCreateProgress(input: {
 	}
 }
 
+const oversizedStorageDumpWarningPrefix = 'storage dump too large: '
+
+function resetPartialStorageState(progress: DrExporterProgress) {
+	progress.storagePageStartAfter = null
+	progress.storagePartialIdentity = null
+	progress.storagePartialNdjson = ''
+	progress.storagePartialEntryCount = 0
+}
+
 function skipOversizedStorageDump(
 	progress: DrExporterProgress,
 	identity: string,
 ) {
-	progress.warnings.push(`storage dump too large: ${identity}`)
+	progress.warnings.push(`${oversizedStorageDumpWarningPrefix}${identity}`)
 	progress.storageIndex += 1
-	progress.storagePageStartAfter = null
-	progress.storagePartialNdjson = ''
-	progress.storagePartialEntryCount = 0
+	resetPartialStorageState(progress)
+}
+
+function collectHandledStorageIdentities(progress: DrExporterProgress) {
+	const handled = new Set(
+		progress.storageEntries.map((entry) => entry.storageId),
+	)
+	for (const warning of progress.warnings) {
+		if (warning.startsWith(oversizedStorageDumpWarningPrefix)) {
+			handled.add(warning.slice(oversizedStorageDumpWarningPrefix.length))
+		}
+	}
+	return handled
 }
 
 async function exportStoragePhase(input: {
@@ -414,9 +445,24 @@ async function exportStoragePhase(input: {
 }): Promise<boolean> {
 	const { session, inventory, s3, env } = input
 	const { progress } = session
-	while (progress.storageIndex < inventory.length) {
+	// Identity-driven resume: the inventory is re-listed every tick and can
+	// drift mid-run (jobs registering new buckets during the export window),
+	// which shifts positions in the sorted list. A positional cursor then
+	// dumps the same identity twice — producing duplicate storage-index
+	// entries that later wedge sealing — or silently skips identities.
+	const handledIdentities = collectHandledStorageIdentities(progress)
+	for (;;) {
 		if (Date.now() - input.startedAtMs >= input.timeBudgetMs) return true
-		const item = inventory[progress.storageIndex]!
+		const item = inventory.find(
+			(candidate) => !handledIdentities.has(candidate.identity),
+		)
+		if (!item) break
+		if (progress.storagePartialIdentity !== item.identity) {
+			// The persisted partial page state belongs to a different (drifted)
+			// identity; restart this identity's dump from its first page.
+			resetPartialStorageState(progress)
+			progress.storagePartialIdentity = item.identity
+		}
 		const page = await storageRunnerRpc({
 			env,
 			userId: item.userId,
@@ -438,6 +484,7 @@ async function exportStoragePhase(input: {
 			drExportMaxStorageDumpBufferBytes
 		) {
 			skipOversizedStorageDump(progress, item.identity)
+			handledIdentities.add(item.identity)
 			await persistProgress(s3, session)
 			continue
 		}
@@ -457,10 +504,9 @@ async function exportStoragePhase(input: {
 			bytes: summary.bytes,
 			sha256: summary.sha256,
 		})
+		handledIdentities.add(item.identity)
 		progress.storageIndex += 1
-		progress.storagePageStartAfter = null
-		progress.storagePartialNdjson = ''
-		progress.storagePartialEntryCount = 0
+		resetPartialStorageState(progress)
 		input.counts.storageDumpsCompleted += 1
 		await persistProgress(s3, session)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The first day ever with both a verified D1 manifest and a completed staging run (2026-07-28, visible on the DR dashboard as `SEALED: no`) still failed to seal — every hourly tick died with `put: The object is locked by the bucket policy. (10069)` (confirmed via control-plane observability). Two stacked bugs:

1. **Bucket-lock rules break the create-only put pattern.** R2 rejects *any* put targeting an existing key under a lock rule with error 10069 **before** evaluating conditional headers, so `onlyIf: { etagDoesNotMatch: '*' }` throws on the locked `daily/`/`weekly/` prefixes instead of returning null. Consequences: a partially sealed day could never be retried (the retry died at the first already-copied object — today's day had 103 of 186 objects copied and was wedged), and D1 manifest / stats-object replays had the same latent failure. All immutable put sites (`seal-full-backup.ts`, `immutable-storage.ts`, `backup-runtime.ts`) now treat the lock rejection as "object already exists" and fall through to the existing byte-comparison paths via a shared `isBucketLockPolicyPutError` guard.

2. **Positional resume over a drifting inventory duplicated dumps.** The staging exporter re-lists the storage inventory every tick and resumed with a positional cursor. Buckets registering mid-window (the `daily-hrv-air-quality` job runs every 15 minutes) shift the sorted list, so the cursor dumped the same identity twice — today's storage index contains exact duplicate entries at #102/#103 and #111/#112, and the duplicate's second sealed-copy put is what first hit the lock error — and could equally *skip* shifted identities. Resume is now identity-driven: completed dumps plus oversized skips form the done-set, and partial page state is guarded by a persisted `storagePartialIdentity` so drifted resumes restart the right dump instead of stitching pages from two different buckets.

**No manual data surgery needed**: with both fixes deployed, the next hourly seal tick completes the wedged 2026-07-28 day in place — the 103 already-sealed objects byte-match their staged sources and the duplicate index entries compare equal.

**Testing**: new regression tests — seal over locked partial state + duplicate index entries (MemoryBucket now emulates the 10069 lock behavior), and exporter inventory-drift (identity inserted before the resume point → no duplicates, no skips, summary still written). Full unit suites pass; typecheck/lint/format clean.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `c1f12a0c`

**Classification:** extends — hardens the backup control plane's immutable-write contract against R2 bucket-lock semantics and makes the DR staging exporter's resume identity-driven. No new primitives.

### Primitives touched

| Primitive              | Group   | Impact                                                                     |
| ---------------------- | ------- | ---------------------------------------------------------------------------- |
| `backup-control-plane` | storage | extends — lock-tolerant immutable puts (seal, manifests, stats); exporter identity-driven resume + `storagePartialIdentity` progress field |

### System map

Sealing copies staged files into the locked `daily/full/` prefix; both the copy and the exporter's resume now tolerate real-world races (lock rejections, mid-window inventory drift).

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	exporter["backup-control-plane<br/>DR staging exporter (production worker)"]:::extended
	seal["backup-control-plane<br/>Seal + immutable writes (DR worker)"]:::extended
	bucket["kody-production-backups<br/>Locked R2 bucket"]:::untouched
	exporter -->|"identity-driven resume; deduped storage index"| bucket
	seal -->|"put-if-absent tolerates 10069 lock rejection → byte compare"| bucket
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Immutability is preserved: locked objects are never overwritten — the change only converts the lock's put rejection into the same "compare bytes, fail closed on mismatch" behavior the code already used for conditional-put conflicts. Storage dumps remain scoped per `userId/storageId` identity.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

