### PR TITLE
feat(run-records): recover timed-out execute and retain handler results

### DIFF
--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -130,8 +130,9 @@ Rules:
   execute) should pass it so `run_get` can show what the handler returned.
 - Keyed execute claims the idempotency key through `claimRunRecord` (awaited DO
   RPC) before sandbox work so a concurrent retry sees `running` or the terminal
-  row instead of starting a second attempt. Key uniqueness is enforced per user
-  inside the `RunLog` DO.
+  row instead of starting a second attempt. Claim is select-then-insert inside
+  one DO RPC (serialized), not a unique SQL constraint — other surfaces may
+  reuse idempotency keys across history.
 - Bundled-module runners (`runBundledModuleWithRegistry`) accept a `runRecord`
   context (and an optional pre-claimed `runRecordHandle`) and call begin/finish
   internally; surfaces that do not go through that helper call the service

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -51,14 +51,26 @@ Add new members there — never invent ad hoc surface strings at call sites.
 
 - **`eager`** — every surface except `execute`. A `running` row is written at
   begin so an evicted or hung run is still visible in history.
-- **`on-failure`** — `execute` only. Nothing is persisted unless the run ends in
-  `error`.
+- **`on-failure`** — key-less `execute` only. Nothing is persisted unless the
+  run ends in `error`.
 
-`execute` is on-failure because it is the highest-volume surface and already
-returns its result (and logs) inline to the caller. Success counts for ad-hoc
-execute come from Analytics Engine via [usage metering](./usage-metering.md),
-not from run records. Users who look for successful `execute` rows in Activity
-will not find them; that is intentional.
+`runPersistenceForContext(context)` is what begin/finish actually use: same as
+the surface default, except **`execute` with a caller-supplied `idempotencyKey`
+upgrades to `eager`**.
+
+Key-less `execute` stays on-failure because it is the highest-volume surface and
+already returns its result (and logs) inline to the caller. Success counts for
+key-less ad-hoc execute come from Analytics Engine via
+[usage metering](./usage-metering.md), not from run records. Users who look for
+successful key-less `execute` rows in Activity will not find them; that is
+intentional.
+
+When an external MCP client times out (for example MCP error `-32001`) while the
+sandbox continues, a keyed execute call still has a recoverable record: the
+caller can poll `run_get` with the returned `runId`, or retry `execute` with the
+same `idempotencyKey` to receive a `replayed: true` result (or
+`inProgress: true` while the first attempt is still running) without starting a
+duplicate sandbox.
 
 ## Begin / finish contract
 
@@ -110,9 +122,20 @@ Rules:
   request critical path.
 - **`on-failure` + `success` is a no-op** at finish (no DO write).
 - Finish **never throws into the observed path**. Sink failures log a warning.
+- Finish may accept an optional JSON-serializable **`result`**. When present it
+  is stored under `metadata.result` after a bounded snapshot
+  (`runRecordMaxResultSnapshotBytes`, currently 4 KiB). Oversized values become
+  `{ __truncated__: true, preview }`. Eager surfaces that produce a handler
+  return value (at minimum webhook deliveries and package exports, plus keyed
+  execute) should pass it so `run_get` can show what the handler returned.
+- Keyed execute claims the idempotency key through `claimRunRecord` (awaited DO
+  RPC) before sandbox work so a concurrent retry sees `running` or the terminal
+  row instead of starting a second attempt. Key uniqueness is enforced per user
+  inside the `RunLog` DO.
 - Bundled-module runners (`runBundledModuleWithRegistry`) accept a `runRecord`
-  context and call begin/finish internally; surfaces that do not go through that
-  helper call the service directly (webhooks, package apps, and similar).
+  context (and an optional pre-claimed `runRecordHandle`) and call begin/finish
+  internally; surfaces that do not go through that helper call the service
+  directly (webhooks, package apps, and similar).
 
 ## Per-user Durable Object
 
@@ -148,12 +171,13 @@ or per-user DO SQLite, never the shared D1 writer.
 Enforced **inside the DO on every `finishRun`**, not by a global cron lane over
 a shared D1 table:
 
-| Cap                       | Value                                           |
-| ------------------------- | ----------------------------------------------- |
-| Age                       | ~30 days (`runRecordRetentionDays`)             |
-| Count                     | 2,000 runs per user (`runRecordMaxRunsPerUser`) |
-| Log lines per run         | 200                                             |
-| Text / JSON field budgets | 16 KiB / 32 KiB truncated                       |
+| Cap                        | Value                                           |
+| -------------------------- | ----------------------------------------------- |
+| Age                        | ~30 days (`runRecordRetentionDays`)             |
+| Count                      | 2,000 runs per user (`runRecordMaxRunsPerUser`) |
+| Log lines per run          | 200                                             |
+| Text / JSON field budgets  | 16 KiB / 32 KiB truncated                       |
+| `metadata.result` snapshot | 4 KiB (`runRecordMaxResultSnapshotBytes`)       |
 
 Age prune deletes finished runs older than the cutoff (rows still `running` are
 kept). Count prune deletes the oldest excess rows **failure-last**: successes
@@ -260,7 +284,8 @@ run path. There is no Queue for this topic in v1.
 
 **Usage metering** and run records are the aggregates/records pair: metering is
 sampling-tolerant and quota-oriented; run records are user-facing history.
-Successful ad-hoc `execute` appears only in metering.
+Successful key-less ad-hoc `execute` appears only in metering. Keyed execute
+successes are retained as run records so timed-out clients can recover.
 
 **Sentry** must not open issues for user-authored failures. Boundaries that know
 the code is user-supplied throw `UserCodeError`

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -130,9 +130,12 @@ Rules:
   execute) should pass it so `run_get` can show what the handler returned.
 - Keyed execute claims the idempotency key through `claimRunRecord` (awaited DO
   RPC) before sandbox work so a concurrent retry sees `running` or the terminal
-  row instead of starting a second attempt. Claim is select-then-insert inside
-  one DO RPC (serialized), not a unique SQL constraint — other surfaces may
-  reuse idempotency keys across history.
+  row instead of starting a second attempt. Lookups are scoped by
+  `(surface, idempotency_key)` so execute keys cannot collide with
+  package/workflow history. Claim is select-then-insert inside one DO RPC
+  (serialized), not a unique SQL constraint — other surfaces may reuse
+  idempotency keys across history. Setup failures before sandbox work
+  `abandonRunRecord` (delete if still `running`) so keys are not poisoned.
 - Bundled-module runners (`runBundledModuleWithRegistry`) accept a `runRecord`
   context (and an optional pre-claimed `runRecordHandle`) and call begin/finish
   internally; surfaces that do not go through that helper call the service

--- a/docs/use/activity.md
+++ b/docs/use/activity.md
@@ -33,18 +33,23 @@ does not surface those names yet.
 
 Records are kept about **30 days**, capped per account, and pruned so failures
 tend to outlive successes. Payload bodies for inbound webhooks are never stored
-— only delivery metadata and logs.
+— only delivery metadata, a bounded handler-result snapshot when available, and
+logs. Package exports and keyed execute runs similarly retain a small
+`metadata.result` snapshot (truncated when large).
 
-## Successful `execute` calls are not listed
+## Successful key-less `execute` calls are not listed
 
-Ad-hoc MCP **`execute`** calls that succeed are **not** written to Activity. You
-already get the result and logs in the tool response, and success volume is
-tracked separately for usage. **Failed** `execute` calls do appear. Every other
-surface (jobs, webhooks, package apps, services, workflows, exports, and so on)
-records both success and error.
+Ad-hoc MCP **`execute`** calls that succeed **without** an `idempotencyKey` are
+**not** written to Activity. You already get the result and logs in the tool
+response, and success volume is tracked separately for usage. **Failed**
+`execute` calls do appear, and execute calls that pass an `idempotencyKey` are
+recorded eagerly (including successes) so a client-side timeout can recover via
+`run_get` or a keyed retry. Every other surface (jobs, webhooks, package apps,
+services, workflows, exports, and so on) records both success and error.
 
-If a successful one-off `execute` is missing from Activity, that is expected —
-check the original tool result instead.
+If a successful one-off `execute` without a key is missing from Activity, that
+is expected — check the original tool result instead. See
+[Execute and workflows](./execute.md) for keyed recovery.
 
 ## React to failures from a package
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -109,6 +109,29 @@ long-running work (>~60s, batch sweeps, migrations, polling loops), use one
 **execute** call to submit `workflows.create({ code, params })`, then inspect
 progress with `workflow_run_list` instead of chaining many MCP tool calls.
 
+### Recovering from MCP client timeouts
+
+Some MCP clients abort the tool call (for example error `-32001` Request timed
+out) while Kody’s sandbox may still be running. Key-less successful execute
+calls are not written to Activity, so that timeout can leave you unsure whether
+side effects already happened.
+
+Pass an optional **`idempotencyKey`** (string, max 256 characters) when the call
+must be recoverable:
+
+- Kody persists that execute run **eagerly** (a `running` row at start, terminal
+  row at finish) and stores a **bounded result snapshot** on the run record.
+- The tool response includes **`runId`** whenever a record exists — poll
+  **`run_get`** with it if the client timed out.
+- Retrying with the **same** `idempotencyKey` after completion returns the
+  retained result with **`replayed: true`** and the same **`runId`** (no second
+  sandbox).
+- Retrying while the first attempt is still running returns
+  **`inProgress: true`** with the **`runId`** (no duplicate start).
+
+Omit the key for ordinary short calls; key-less execute stays on-failure-only so
+Activity is not flooded with successful one-offs.
+
 To read field shapes while coding, use **search** with
 **`entity: "{name}:capability"`** for builtin capability type definitions, or
 inspect the relevant saved package with **`entity: "{kody_id}:package"`**.

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -39,6 +39,6 @@ If connector-provided tools appear missing, check connector status with
 ## Job, webhook, or package app failed
 
 Open **[`/account/activity`](./activity.md)** (failures-first) or ask your agent
-to use **`run_summary`** / **`run_list`** / **`run_get`**. Successful ad-hoc
-**`execute`** calls are not stored there — only execute failures and other
-runtime surfaces.
+to use **`run_summary`** / **`run_list`** / **`run_get`**. Successful key-less
+ad-hoc **`execute`** calls are not stored there — only execute failures, keyed
+execute runs (including successes), and other runtime surfaces.

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { type ExecuteResult } from '@cloudflare/codemode'
 import {
 	defaultExecutionResponseLimitBytes,
 	getExecutionErrorDetails,
@@ -190,7 +191,17 @@ export const executeCapability = defineDomainCapability(
 						metadata: { conversationId },
 					},
 				})
-				if (claim && !claim.claimed) {
+				if (!claim) {
+					return {
+						ok: false,
+						conversationId,
+						...(storage ? { storage } : {}),
+						error:
+							'Unable to claim execute idempotency key; RUN_LOG is unavailable.',
+						logs: [],
+					}
+				}
+				if (!claim.claimed) {
 					if (claim.run.status === 'running') {
 						return {
 							ok: false,
@@ -229,15 +240,13 @@ export const executeCapability = defineDomainCapability(
 						logs: [],
 					}
 				}
-				if (claim?.claimed) {
-					claimedRunHandle = claim.handle
-				}
+				claimedRunHandle = claim.handle
 			}
 
-			const { runModuleWithRegistry } =
-				await import('#mcp/run-kody-registry.ts')
-			let result: Awaited<ReturnType<typeof runModuleWithRegistry>>
+			let result: ExecuteResult & { runId?: string }
 			try {
+				const { runModuleWithRegistry } =
+					await import('#mcp/run-kody-registry.ts')
 				result = await runModuleWithRegistry(
 					ctx.env,
 					callerContext,

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -143,7 +143,9 @@ export const executeCapability = defineDomainCapability(
 				if (existing) {
 					if (existing.status === 'running') {
 						return {
-							ok: false,
+							// Match the public execute tool: in-progress is not a
+							// failure — callers should poll run_get / retry the key.
+							ok: true,
 							conversationId,
 							...(storage ? { storage } : {}),
 							runId: existing.id,
@@ -207,7 +209,7 @@ export const executeCapability = defineDomainCapability(
 				if (!claim.claimed) {
 					if (claim.run.status === 'running') {
 						return {
-							ok: false,
+							ok: true,
 							conversationId,
 							...(storage ? { storage } : {}),
 							runId: claim.run.id,

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -15,8 +15,10 @@ import {
 	resolveConversationId,
 } from '#mcp/tools/tool-call-context.ts'
 import {
+	abandonRunRecord,
 	claimRunRecord,
 	finishRunRecord,
+	getRunRecord,
 	getRunRecordByIdempotencyKey,
 } from '#worker/run-records/service.ts'
 import {
@@ -136,6 +138,7 @@ export const executeCapability = defineDomainCapability(
 					env: ctx.env,
 					userId,
 					idempotencyKey,
+					surface: 'execute',
 				})
 				if (existing) {
 					if (existing.status === 'running') {
@@ -272,12 +275,24 @@ export const executeCapability = defineDomainCapability(
 				)
 			} catch (cause) {
 				if (claimedRunHandle) {
-					await finishRunRecord({
+					const current = await getRunRecord({
 						env: ctx.env,
-						handle: claimedRunHandle,
-						status: 'error',
-						error: cause,
+						userId: claimedRunHandle.userId,
+						runId: claimedRunHandle.id,
 					})
+					if (current?.run.status === 'running') {
+						await finishRunRecord({
+							env: ctx.env,
+							handle: claimedRunHandle,
+							status: 'error',
+							error: cause,
+						})
+					} else if (!current) {
+						await abandonRunRecord({
+							env: ctx.env,
+							handle: claimedRunHandle,
+						})
+					}
 				}
 				return {
 					ok: false,

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -13,6 +13,15 @@ import {
 	memoryContextInputField,
 	resolveConversationId,
 } from '#mcp/tools/tool-call-context.ts'
+import {
+	claimRunRecord,
+	finishRunRecord,
+	getRunRecordByIdempotencyKey,
+} from '#worker/run-records/service.ts'
+import {
+	runRecordMaxIdempotencyKeyLength,
+	type RunRecordHandle,
+} from '#worker/run-records/types.ts'
 
 const storageOutputSchema = z.object({
 	id: z.string(),
@@ -22,6 +31,10 @@ const executeOutputSchema = z.object({
 	ok: z.boolean(),
 	conversationId: z.string(),
 	storage: storageOutputSchema.optional(),
+	runId: z.string().optional(),
+	replayed: z.boolean().optional(),
+	inProgress: z.boolean().optional(),
+	status: z.enum(['running', 'success', 'error']).optional(),
 	returnedBytes: z.number().int().nonnegative().optional(),
 	truncated: z.boolean().optional(),
 	note: z.string().optional(),
@@ -77,6 +90,14 @@ export const executeCapability = defineDomainCapability(
 				),
 			conversationId: conversationIdInputField,
 			memoryContext: memoryContextInputField,
+			idempotencyKey: z
+				.string()
+				.min(1)
+				.max(runRecordMaxIdempotencyKeyLength)
+				.optional()
+				.describe(
+					`Optional caller-supplied idempotency key (max ${runRecordMaxIdempotencyKeyLength} chars). When set, persist the run eagerly with a bounded result snapshot and replay finished/in-progress outcomes instead of re-executing. Key-less execute stays on-failure-only.`,
+				),
 		}),
 		outputSchema: executeOutputSchema,
 		async handler(
@@ -87,6 +108,7 @@ export const executeCapability = defineDomainCapability(
 				writable?: boolean
 				responseLimit?: number
 				conversationId?: string
+				idempotencyKey?: string
 			},
 			ctx: CapabilityContext,
 		) {
@@ -104,31 +126,172 @@ export const executeCapability = defineDomainCapability(
 				},
 			}
 			const conversationId = resolveConversationId(args.conversationId)
+			const storage = resolvedStorageId ? { id: resolvedStorageId } : undefined
+			const idempotencyKey = args.idempotencyKey?.trim() || null
+			const userId = callerContext.user?.userId ?? null
+
+			if (idempotencyKey && userId) {
+				const existing = await getRunRecordByIdempotencyKey({
+					env: ctx.env,
+					userId,
+					idempotencyKey,
+				})
+				if (existing) {
+					if (existing.status === 'running') {
+						return {
+							ok: false,
+							conversationId,
+							...(storage ? { storage } : {}),
+							runId: existing.id,
+							inProgress: true,
+							status: 'running' as const,
+							logs: [],
+						}
+					}
+					const retained = existing.metadata['result']
+					if (existing.status === 'error') {
+						return {
+							ok: false,
+							conversationId,
+							...(storage ? { storage } : {}),
+							runId: existing.id,
+							replayed: true,
+							status: 'error' as const,
+							error:
+								existing.errorMessage ??
+								'Execute failed (replayed from run record).',
+							...(retained !== undefined ? { result: retained } : {}),
+							logs: [],
+						}
+					}
+					return {
+						ok: true,
+						conversationId,
+						...(storage ? { storage } : {}),
+						runId: existing.id,
+						replayed: true,
+						status: 'success' as const,
+						result: retained,
+						logs: [],
+					}
+				}
+			}
+
+			let claimedRunHandle: RunRecordHandle | null = null
+			if (idempotencyKey && userId) {
+				const claim = await claimRunRecord({
+					env: ctx.env,
+					userId,
+					context: {
+						surface: 'execute',
+						name: null,
+						storageId: resolvedStorageId,
+						idempotencyKey,
+						metadata: { conversationId },
+					},
+				})
+				if (claim && !claim.claimed) {
+					if (claim.run.status === 'running') {
+						return {
+							ok: false,
+							conversationId,
+							...(storage ? { storage } : {}),
+							runId: claim.run.id,
+							inProgress: true,
+							status: 'running' as const,
+							logs: [],
+						}
+					}
+					const retained = claim.run.metadata['result']
+					if (claim.run.status === 'error') {
+						return {
+							ok: false,
+							conversationId,
+							...(storage ? { storage } : {}),
+							runId: claim.run.id,
+							replayed: true,
+							status: 'error' as const,
+							error:
+								claim.run.errorMessage ??
+								'Execute failed (replayed from run record).',
+							...(retained !== undefined ? { result: retained } : {}),
+							logs: [],
+						}
+					}
+					return {
+						ok: true,
+						conversationId,
+						...(storage ? { storage } : {}),
+						runId: claim.run.id,
+						replayed: true,
+						status: 'success' as const,
+						result: retained,
+						logs: [],
+					}
+				}
+				if (claim?.claimed) {
+					claimedRunHandle = claim.handle
+				}
+			}
+
 			const { runModuleWithRegistry } =
 				await import('#mcp/run-kody-registry.ts')
-			const result = await runModuleWithRegistry(
-				ctx.env,
-				callerContext,
-				args.code,
-				args.params,
-				{
-					storageTools: resolvedStorageId
-						? {
-								userId: callerContext.user?.userId ?? '',
-								storageId: resolvedStorageId,
-								writable: args.writable ?? false,
-							}
-						: undefined,
-				},
-			)
+			let result: Awaited<ReturnType<typeof runModuleWithRegistry>>
+			try {
+				result = await runModuleWithRegistry(
+					ctx.env,
+					callerContext,
+					args.code,
+					args.params,
+					{
+						storageTools: resolvedStorageId
+							? {
+									userId: callerContext.user?.userId ?? '',
+									storageId: resolvedStorageId,
+									writable: args.writable ?? false,
+								}
+							: undefined,
+						runRecordHandle: claimedRunHandle,
+						runRecord: {
+							surface: 'execute',
+							name: null,
+							storageId: resolvedStorageId,
+							idempotencyKey,
+							metadata: { conversationId },
+						},
+					},
+				)
+			} catch (cause) {
+				if (claimedRunHandle) {
+					await finishRunRecord({
+						env: ctx.env,
+						handle: claimedRunHandle,
+						status: 'error',
+						error: cause,
+					})
+				}
+				return {
+					ok: false,
+					conversationId,
+					...(storage ? { storage } : {}),
+					...(claimedRunHandle ? { runId: claimedRunHandle.id } : {}),
+					error: getErrorMessage(cause),
+					errorDetails: getExecutionErrorDetails(cause),
+					logs: [],
+				}
+			}
 			const logs = result.logs ?? []
-			const storage = resolvedStorageId ? { id: resolvedStorageId } : undefined
+			const runId =
+				typeof result.runId === 'string'
+					? result.runId
+					: (claimedRunHandle?.id ?? undefined)
 
 			if (result.error) {
 				return {
 					ok: false,
 					conversationId,
 					...(storage ? { storage } : {}),
+					...(runId ? { runId } : {}),
 					error: getErrorMessage(result.error),
 					errorDetails: getExecutionErrorDetails(result.error),
 					logs,
@@ -143,6 +306,7 @@ export const executeCapability = defineDomainCapability(
 				ok: true,
 				conversationId,
 				...(storage ? { storage } : {}),
+				...(runId ? { runId } : {}),
 				returnedBytes: limitedResult.returnedBytes,
 				...(limitedResult.truncated
 					? {

--- a/packages/worker/src/mcp/capabilities/meta/search-and-execute.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/search-and-execute.node.test.ts
@@ -58,12 +58,17 @@ test('execute capability runs modules through the shared execute runtime', async
 		}),
 		expect.stringContaining('execute-ok'),
 		undefined,
-		{
+		expect.objectContaining({
 			storageTools: {
 				userId: 'user-1',
 				storageId: 'package:agent-turns',
 				writable: true,
 			},
-		},
+			runRecordHandle: null,
+			runRecord: expect.objectContaining({
+				surface: 'execute',
+				storageId: 'package:agent-turns',
+			}),
+		}),
 	)
 })

--- a/packages/worker/src/mcp/capabilities/runs/run-get.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-get.ts
@@ -30,7 +30,7 @@ export const runGetCapability = defineDomainCapability(
 	{
 		name: 'run_get',
 		description:
-			'Load one retained run with its captured log lines and error details so you can explain a failed job, crashed package app, broken webhook delivery, or other runtime failure. Records are retained about 30 days, capped per user, and pruned failure-last. Successful ad-hoc execute runs are not stored; only execute failures appear here.',
+			'Load one retained run with its captured log lines, error details, and (when available) a bounded metadata.result snapshot of the handler return value — useful for webhook deliveries, package exports, and keyed execute recovery. Records are retained about 30 days, capped per user, and pruned failure-last. Key-less successful ad-hoc execute runs are not stored; execute failures and execute calls that supplied an idempotencyKey are.',
 		keywords: [
 			'run',
 			'logs',

--- a/packages/worker/src/mcp/capabilities/runs/run-get.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-get.ts
@@ -30,7 +30,7 @@ export const runGetCapability = defineDomainCapability(
 	{
 		name: 'run_get',
 		description:
-			'Load one retained run with its captured log lines, error details, and (when available) a bounded metadata.result snapshot of the handler return value — useful for webhook deliveries, package exports, and keyed execute recovery. Records are retained about 30 days, capped per user, and pruned failure-last. Key-less successful ad-hoc execute runs are not stored; execute failures and execute calls that supplied an idempotencyKey are.',
+			'Load one retained run with its captured log lines, error details, and (when available) a bounded metadata.result snapshot of the handler return value — useful for webhook deliveries, package exports, and keyed execute recovery. Records are retained about 30 days, capped per user, and pruned failure-last. Key-less successful ad-hoc execute runs are not stored; execute failures and execute calls that supplied an idempotencyKey are retained.',
 		keywords: [
 			'run',
 			'logs',

--- a/packages/worker/src/mcp/capabilities/runs/run-list.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-list.ts
@@ -60,7 +60,7 @@ export const runListCapability = defineDomainCapability(
 	{
 		name: 'run_list',
 		description:
-			'List recent execution history across jobs, webhooks, package apps, services, workflows, and other runtimes so you can debug failures, crashes, and "why did my job stop working" questions. Successful ad-hoc execute runs are intentionally not recorded (only execute failures are); every other surface records both success and error. Records are retained about 30 days, capped per user, and pruned failure-last (successes drop before errors).',
+			'List recent execution history across jobs, webhooks, package apps, services, workflows, and other runtimes so you can debug failures, crashes, and "why did my job stop working" questions. Key-less successful ad-hoc execute runs are intentionally not recorded (only execute failures are, plus execute calls that supplied an idempotencyKey); every other surface records both success and error. Terminal rows may include a bounded metadata.result snapshot. Records are retained about 30 days, capped per user, and pruned failure-last (successes drop before errors).',
 		keywords: [
 			'run',
 			'runs',

--- a/packages/worker/src/mcp/capabilities/runs/runs.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/runs/runs.workers.test.ts
@@ -52,6 +52,7 @@ async function finishRun(input: {
 	startedAt?: string
 	logs?: Array<string>
 	error?: unknown
+	result?: unknown
 }) {
 	const handle: RunRecordHandle = {
 		id: input.id ?? crypto.randomUUID(),
@@ -66,6 +67,7 @@ async function finishRun(input: {
 		status: input.status,
 		logs: input.logs,
 		error: input.error,
+		result: input.result,
 	})
 	return handle
 }
@@ -194,6 +196,41 @@ test(
 		)
 		expect(otherSummary.total).toBe(0)
 		expect(otherSummary.errors).toBe(0)
+	},
+	runLogSuiteTimeoutMs,
+)
+
+test(
+	'run_get exposes bounded metadata.result for webhook deliveries',
+	async () => {
+		const userId = uniqueUserId('webhook-result')
+		const callerContext = buildCallerContext({
+			userId,
+			email: `${userId}@example.com`,
+		})
+		const handle = await finishRun({
+			userId,
+			context: baseContext({
+				surface: 'webhook',
+				name: 'sentry',
+				metadata: {
+					endpointId: 'ep-result',
+					httpStatus: 202,
+					outcome: 'delivered',
+				},
+			}),
+			status: 'success',
+			result: { ok: true, agentId: 'agent-123' },
+		})
+		const detail = await runGetCapability.handler(
+			{ run_id: handle.id },
+			{ env, callerContext },
+		)
+		expect(detail.run.metadata).toMatchObject({
+			endpointId: 'ep-result',
+			outcome: 'delivered',
+			result: { ok: true, agentId: 'agent-123' },
+		})
 	},
 	runLogSuiteTimeoutMs,
 )

--- a/packages/worker/src/mcp/instructions/execute-tool-description.ts
+++ b/packages/worker/src/mcp/instructions/execute-tool-description.ts
@@ -21,6 +21,8 @@ export const executeToolSandboxSurfaceDescription = `Sandbox surface:
 - \`await kody.secret_list({ scope? })\` — metadata only. \`secret_set\` — persist values already in trusted execution (e.g. refreshed tokens); write-only. No \`secret_get\` / \`secrets\` helpers in the sandbox.
 - \`value_get\` / \`value_list\` for non-secret persisted config.`
 
+export const executeToolIdempotencyDescription = `Optional \`idempotencyKey\` (max 256 chars): when set, Kody persists the run eagerly (including successes) with a bounded result snapshot under the run record. If the MCP client times out (-32001) while the sandbox continues, retry with the same key to get \`replayed: true\` plus the retained result and \`runId\`, or an \`inProgress: true\` response with \`runId\` while still running — neither re-executes. Poll \`run_get\` with that \`runId\`. Key-less execute stays on-failure-only (successes are not listed in Activity).`
+
 export const executeToolCallPlanningDescription = `Prefer one \`execute\` when the workflow is clear; split calls when you need new user input or a changed plan.`
 
 export const executeToolExampleDescription = `Example:
@@ -44,6 +46,7 @@ export const executeToolDescriptionFragments = [
 	executeToolOverviewDescription,
 	executeToolProjectionRuleDescription,
 	executeToolSandboxSurfaceDescription,
+	executeToolIdempotencyDescription,
 	executeToolCallPlanningDescription,
 	executeToolExampleDescription,
 	executeToolRawContentDescription,

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -68,7 +68,10 @@ import {
 	findUnboundRuntimeHelperAccess,
 } from '#worker/package-runtime/unbound-runtime-helpers.ts'
 import { beginRunRecord, finishRunRecord } from '#worker/run-records/service.ts'
-import { type RunRecordContext } from '#worker/run-records/types.ts'
+import {
+	type RunRecordContext,
+	type RunRecordHandle,
+} from '#worker/run-records/types.ts'
 import { createDynamicCallableWorkflow } from '#worker/package-runtime/package-workflows.ts'
 import { type BundleArtifactDependency } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
@@ -621,6 +624,7 @@ export async function runModuleWithRegistry(
 		 */
 		conversationId?: string | null
 		runRecord?: RunRecordContext | null
+		runRecordHandle?: RunRecordHandle | null
 		/**
 		 * When set, terminal run-record writes are scheduled on this callback
 		 * (typically `ctx.waitUntil`) instead of being awaited. Observability
@@ -629,7 +633,7 @@ export async function runModuleWithRegistry(
 		 */
 		waitUntil?: (promise: Promise<unknown>) => void
 	},
-): Promise<ExecuteResult> {
+): Promise<ExecuteResult & { runId?: string }> {
 	const userId = callerContext.user?.userId ?? ''
 	const bundled = await buildKodyModuleBundle({
 		env,
@@ -739,6 +743,11 @@ export async function runBundledModuleWithRegistry(
 		skipCapabilityRegistry?: boolean
 		executorTimeoutMs?: number | null
 		runRecord?: RunRecordContext | null
+		/**
+		 * Pre-claimed handle from {@link claimRunRecord} (keyed execute). When
+		 * set, begin is skipped so the running row already owns the key.
+		 */
+		runRecordHandle?: RunRecordHandle | null
 		capabilityRegistry?: BuiltCapabilityRegistry
 		rawFetchHostSink?: RawFetchHostSink
 		conversationId?: string | null
@@ -750,7 +759,7 @@ export async function runBundledModuleWithRegistry(
 		 */
 		waitUntil?: (promise: Promise<unknown>) => void
 	},
-): Promise<ExecuteResult> {
+): Promise<ExecuteResult & { runId?: string }> {
 	const secretRedactor = createExecutionSecretRedactor()
 	const normalizedStorageContext = normalizeStorageContext(
 		callerContext.storageContext ?? null,
@@ -766,13 +775,16 @@ export async function runBundledModuleWithRegistry(
 			}
 		: null
 	const waitUntil = options?.waitUntil
-	const runRecordHandle = beginRunRecord({
-		env,
-		userId: callerContext.user?.userId ?? null,
-		context: runRecordContext,
-		waitUntil,
-	})
+	const runRecordHandle =
+		options?.runRecordHandle ??
+		beginRunRecord({
+			env,
+			userId: callerContext.user?.userId ?? null,
+			context: runRecordContext,
+			waitUntil,
+		})
 	let runRecordFinished = false
+	let exposeRunId = runRecordHandle?.persistence === 'eager'
 	// The metering span covers the whole bundled run (module hydration,
 	// provider assembly, and sandbox execution) so pre-executor failures are
 	// still counted as failed package runs.
@@ -795,16 +807,27 @@ export async function runBundledModuleWithRegistry(
 		status: 'success' | 'error'
 		logs?: Array<string>
 		error?: unknown
+		result?: unknown
 	}) {
+		if (input.status === 'error') {
+			exposeRunId = Boolean(runRecordHandle)
+		}
 		await finishRunRecord({
 			env,
 			handle: runRecordHandle,
 			status: input.status,
 			logs: input.logs,
 			error: input.error,
+			result: input.result,
 			waitUntil,
 		})
 		runRecordFinished = true
+	}
+	function withRunId<T extends ExecuteResult>(
+		result: T,
+	): T & { runId?: string } {
+		if (!exposeRunId || !runRecordHandle) return result
+		return { ...result, runId: runRecordHandle.id }
 	}
 	try {
 		// Hydration can install additional published-package sources (literal
@@ -950,9 +973,10 @@ ${runtimeHelperRuntimePropertySource}
 				await finishObservedRun({
 					status: 'success',
 					logs: sanitizedResult.logs ?? [],
+					result: sanitizedResult.result,
 				})
 				await recordPackageExportUsage('success')
-				return sanitizedResult
+				return withRunId(sanitizedResult)
 			}
 			const rewrittenMessage =
 				(await rewriteCapabilitySecretError({
@@ -977,7 +1001,7 @@ ${runtimeHelperRuntimePropertySource}
 				error: finalResult.error,
 			})
 			await recordPackageExportUsage('error')
-			return finalResult
+			return withRunId(finalResult)
 		} catch (error) {
 			if (!runRecordFinished) {
 				await finishObservedRun({

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -6,6 +6,7 @@ import {
 	wrapDownstreamMcpToolResult,
 } from '#mcp/downstream-mcp-result.ts'
 import { formatRawFetchHostNudge } from '#mcp/raw-fetch-host-nudge.ts'
+import type * as RunRecordsServiceModule from '#worker/run-records/service.ts'
 
 const mockModule = vi.hoisted(() => ({
 	runModuleWithRegistry: vi.fn(),
@@ -42,9 +43,9 @@ vi.mock('#worker/openapi/binding-service.ts', () => ({
 }))
 
 vi.mock('#worker/run-records/service.ts', async () => {
-	const actual = await vi.importActual<
-		typeof import('#worker/run-records/service.ts')
-	>('#worker/run-records/service.ts')
+	const actual = await vi.importActual<typeof RunRecordsServiceModule>(
+		'#worker/run-records/service.ts',
+	)
 	return {
 		...actual,
 		getRunRecordByIdempotencyKey: (...args: Array<unknown>) =>

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -16,6 +16,9 @@ const mockModule = vi.hoisted(() => ({
 		},
 	})),
 	listOpenApiBindings: vi.fn(async () => []),
+	getRunRecordByIdempotencyKey: vi.fn(async () => null),
+	claimRunRecord: vi.fn(async () => null),
+	finishRunRecord: vi.fn(async () => undefined),
 }))
 
 vi.mock('#mcp/run-kody-registry.ts', () => ({
@@ -37,6 +40,21 @@ vi.mock('#worker/openapi/binding-service.ts', () => ({
 	listOpenApiBindings: (...args: Array<unknown>) =>
 		mockModule.listOpenApiBindings(...args),
 }))
+
+vi.mock('#worker/run-records/service.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('#worker/run-records/service.ts')
+	>('#worker/run-records/service.ts')
+	return {
+		...actual,
+		getRunRecordByIdempotencyKey: (...args: Array<unknown>) =>
+			mockModule.getRunRecordByIdempotencyKey(...args),
+		claimRunRecord: (...args: Array<unknown>) =>
+			mockModule.claimRunRecord(...args),
+		finishRunRecord: (...args: Array<unknown>) =>
+			mockModule.finishRunRecord(...args),
+	}
+})
 
 const { registerExecuteTool } = await import('./execute.ts')
 
@@ -151,11 +169,16 @@ async function getExecuteHandler(
 		writable?: boolean
 		responseLimit?: number
 		conversationId?: string
+		idempotencyKey?: string
 	}) => Promise<{
 		content: Array<ContentBlock>
 		structuredContent: {
 			conversationId: string
 			storage?: { id: string }
+			runId?: string
+			replayed?: boolean
+			inProgress?: boolean
+			status?: string
 			returnedBytes: number
 			truncated?: boolean
 			note?: string
@@ -358,10 +381,12 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 		expect.objectContaining({
 			packageInvokeTools,
 			conversationId: 'conv-packages',
+			runRecordHandle: null,
 			runRecord: {
 				surface: 'execute',
 				name: null,
 				storageId: null,
+				idempotencyKey: null,
 				metadata: {
 					conversationId: 'conv-packages',
 				},
@@ -736,4 +761,139 @@ export default async () => ({ ok: true })`,
 	expect(authHelperTipped.structuredContent.warnings?.[0]).not.toBe(
 		tipped.structuredContent.warnings?.[0],
 	)
+})
+
+test('execute tool replays finished keyed runs and reports in-progress without re-executing', async () => {
+	const authenticatedCaller = {
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-keyed-execute',
+			email: 'keyed@example.com',
+			displayName: 'Keyed',
+		},
+	}
+	const finishedRun = {
+		id: 'run-finished-1',
+		surface: 'execute' as const,
+		status: 'success' as const,
+		name: null,
+		packageId: null,
+		kodyId: null,
+		sourceId: null,
+		publishedCommit: null,
+		storageId: null,
+		jobId: null,
+		workflowId: null,
+		invocationId: null,
+		sessionId: null,
+		idempotencyKey: 'spawn-agent-1',
+		parentRunId: null,
+		startedAt: '2026-07-28T00:00:00.000Z',
+		finishedAt: '2026-07-28T00:00:01.000Z',
+		durationMs: 1000,
+		errorName: null,
+		errorMessage: null,
+		metadata: { result: { ok: true, agentId: 'agent-9' } },
+		logCount: 0,
+	}
+	const handler = await getExecuteHandler(authenticatedCaller)
+	mockModule.getRunRecordByIdempotencyKey.mockResolvedValueOnce(finishedRun)
+	mockPerformanceSequence(1, 2)
+	const replayed = await handler({
+		code: 'export default async () => ({ shouldNotRun: true })',
+		idempotencyKey: 'spawn-agent-1',
+		conversationId: 'conv-replay',
+	})
+	expect(mockModule.runModuleWithRegistry).not.toHaveBeenCalled()
+	expect(replayed.isError).toBe(false)
+	expect(replayed.structuredContent).toMatchObject({
+		runId: 'run-finished-1',
+		replayed: true,
+		result: { ok: true, agentId: 'agent-9' },
+	})
+
+	mockModule.getRunRecordByIdempotencyKey.mockResolvedValueOnce({
+		...finishedRun,
+		id: 'run-running-1',
+		status: 'running',
+		finishedAt: null,
+		durationMs: null,
+		metadata: {},
+	})
+	mockPerformanceSequence(3, 4)
+	const inProgress = await handler({
+		code: 'export default async () => ({ shouldNotRun: true })',
+		idempotencyKey: 'spawn-agent-1',
+		conversationId: 'conv-running',
+	})
+	expect(mockModule.runModuleWithRegistry).not.toHaveBeenCalled()
+	expect(inProgress.isError).toBe(false)
+	expect(inProgress.structuredContent).toMatchObject({
+		runId: 'run-running-1',
+		inProgress: true,
+		status: 'running',
+	})
+})
+
+test('execute tool claims a keyed run, passes the handle, and returns runId', async () => {
+	const authenticatedCaller = {
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-claim-execute',
+			email: 'claim@example.com',
+			displayName: 'Claim',
+		},
+	}
+	const claimedHandle = {
+		id: 'run-claimed-1',
+		userId: 'user-claim-execute',
+		startedAt: '2026-07-28T00:00:00.000Z',
+		persistence: 'eager' as const,
+		context: {
+			surface: 'execute' as const,
+			idempotencyKey: 'claim-key-1',
+		},
+	}
+	const handler = await getExecuteHandler(authenticatedCaller)
+	mockModule.getRunRecordByIdempotencyKey.mockResolvedValueOnce(null)
+	mockModule.claimRunRecord.mockResolvedValueOnce({
+		claimed: true,
+		handle: claimedHandle,
+	})
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: { spawned: true },
+		logs: [],
+		runId: 'run-claimed-1',
+	})
+	mockPerformanceSequence(5, 6)
+	const response = await handler({
+		code: 'export default async () => ({ spawned: true })',
+		idempotencyKey: 'claim-key-1',
+		conversationId: 'conv-claim',
+	})
+	expect(mockModule.claimRunRecord).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-claim-execute',
+			context: expect.objectContaining({
+				surface: 'execute',
+				idempotencyKey: 'claim-key-1',
+			}),
+		}),
+	)
+	expect(mockModule.runModuleWithRegistry).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.anything(),
+		'export default async () => ({ spawned: true })',
+		undefined,
+		expect.objectContaining({
+			runRecordHandle: claimedHandle,
+			runRecord: expect.objectContaining({
+				idempotencyKey: 'claim-key-1',
+			}),
+		}),
+	)
+	expect(response.structuredContent).toMatchObject({
+		runId: 'run-claimed-1',
+		result: { spawned: true },
+	})
 })

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -50,6 +50,16 @@ import {
 import { listOpenApiBindings } from '#worker/openapi/binding-service.ts'
 import { normalizeHost } from '#mcp/secrets/allowed-hosts.ts'
 import { consumeDailyEntitlement } from '#worker/entitlements/service.ts'
+import {
+	claimRunRecord,
+	finishRunRecord,
+	getRunRecordByIdempotencyKey,
+} from '#worker/run-records/service.ts'
+import {
+	runRecordMaxIdempotencyKeyLength,
+	type RunRecord,
+	type RunRecordHandle,
+} from '#worker/run-records/types.ts'
 
 const executeTool = {
 	name: 'execute',
@@ -109,6 +119,14 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					),
 				conversationId: conversationIdInputField,
 				memoryContext: memoryContextInputField,
+				idempotencyKey: z
+					.string()
+					.min(1)
+					.max(runRecordMaxIdempotencyKeyLength)
+					.optional()
+					.describe(
+						`Optional caller-supplied idempotency key (max ${runRecordMaxIdempotencyKeyLength} chars). When set, the run is persisted eagerly (including successes) with a bounded result snapshot so a client-side MCP transport timeout can recover via run_get or by retrying the same key. Retries of a finished key return the retained result with replayed: true; retries while still running return inProgress: true with the runId — neither re-executes. Key-less execute stays on-failure-only (successes are not recorded).`,
+					),
 			},
 			annotations: executeTool.annotations,
 		},
@@ -120,6 +138,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			responseLimit,
 			conversationId,
 			memoryContext,
+			idempotencyKey,
 		}: {
 			code: string
 			params?: Record<string, unknown>
@@ -128,6 +147,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			responseLimit?: number
 			conversationId?: string
 			memoryContext?: z.infer<typeof memoryContextInputField>
+			idempotencyKey?: string
 		}) => {
 			const timingStart = startToolTiming()
 			const env = agent.getEnv()
@@ -195,6 +215,28 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			}
 
 			async function runExecuteTool() {
+				const normalizedIdempotencyKey =
+					normalizeExecuteIdempotencyKey(idempotencyKey)
+				// Look up an existing keyed run before consuming quota so
+				// transport-timeout retries can replay / report in-progress
+				// without burning another daily execute slot.
+				if (normalizedIdempotencyKey && callerContext.user?.userId) {
+					const existing = await getRunRecordByIdempotencyKey({
+						env,
+						userId: callerContext.user.userId,
+						idempotencyKey: normalizedIdempotencyKey,
+					})
+					if (existing) {
+						const timing = finishToolTiming(timingStart)
+						return buildKeyedExecuteLookupResponse({
+							run: existing,
+							conversationId: resolvedConversationId,
+							timing,
+							activeStorageId,
+						})
+					}
+				}
+
 				// Daily execute quota, consumed before any bundling or sandbox
 				// work so over-limit calls cost nothing. The thrown
 				// EntitlementLimitError propagates through the outer catch as
@@ -206,6 +248,35 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						email: callerContext.user.email,
 						resource: 'execute_calls_per_day',
 					})
+				}
+
+				let claimedRunHandle: RunRecordHandle | null = null
+				if (normalizedIdempotencyKey && callerContext.user?.userId) {
+					const claim = await claimRunRecord({
+						env,
+						userId: callerContext.user.userId,
+						context: {
+							surface: 'execute',
+							name: null,
+							storageId: activeStorageId,
+							idempotencyKey: normalizedIdempotencyKey,
+							metadata: {
+								conversationId: resolvedConversationId,
+							},
+						},
+					})
+					if (claim && !claim.claimed) {
+						const timing = finishToolTiming(timingStart)
+						return buildKeyedExecuteLookupResponse({
+							run: claim.run,
+							conversationId: resolvedConversationId,
+							timing,
+							activeStorageId,
+						})
+					}
+					if (claim?.claimed) {
+						claimedRunHandle = claim.handle
+					}
 				}
 				const { getCapabilityRegistryForContext } =
 					await import('#mcp/capabilities/registry.ts')
@@ -262,10 +333,12 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 									packageInvokeTools,
 									rawFetchHostSink: rawFetchHosts.sink,
 									conversationId: resolvedConversationId,
+									runRecordHandle: claimedRunHandle,
 									runRecord: {
 										surface: 'execute',
 										name: null,
 										storageId: activeStorageId,
+										idempotencyKey: normalizedIdempotencyKey,
 										metadata: {
 											conversationId: resolvedConversationId,
 										},
@@ -276,11 +349,22 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							// Bundling the caller-provided module (syntax errors,
 							// unresolved imports) throws before the sandbox runs;
 							// route it through the sandbox-error result path so it
-							// is not logged as a platform failure.
+							// is not logged as a platform failure. Finish any
+							// pre-claimed keyed run so retries can replay the error
+							// instead of seeing a stuck `running` row.
+							if (claimedRunHandle) {
+								await finishRunRecord({
+									env,
+									handle: claimedRunHandle,
+									status: 'error',
+									error: cause,
+								})
+							}
 							return {
 								result: undefined,
 								error: getErrorMessage(cause),
 								logs: [],
+								...(claimedRunHandle ? { runId: claimedRunHandle.id } : {}),
 							}
 						}
 					},
@@ -295,6 +379,10 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					hostCounts: rawFetchHosts.hostCounts(),
 					usedIntegrationAuthHelpers: codeUsesIntegrationAuthHelpers(code),
 				})
+				const runId =
+					typeof result.runId === 'string'
+						? result.runId
+						: (claimedRunHandle?.id ?? undefined)
 
 				if (result.error) {
 					const errorDetails = getExecutionErrorDetails(result.error)
@@ -325,6 +413,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							conversationId: resolvedConversationId,
 							timing,
 							...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
+							...(runId ? { runId } : {}),
 							returnedBytes: 0,
 							error: errorMessage,
 							errorDetails,
@@ -377,6 +466,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 								...(activeStorageId
 									? { storage: { id: activeStorageId } }
 									: {}),
+								...(runId ? { runId } : {}),
 								returnedBytes: 0,
 								error: message,
 								result: passthrough?.structuredResult ?? null,
@@ -406,6 +496,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 								...(activeStorageId
 									? { storage: { id: activeStorageId } }
 									: {}),
+								...(runId ? { runId } : {}),
 								returnedBytes: contentLimited.returnedBytes,
 								truncated: true,
 								note: contentLimited.note,
@@ -436,6 +527,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							conversationId: resolvedConversationId,
 							timing,
 							...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
+							...(runId ? { runId } : {}),
 							returnedBytes:
 								contentLimited.returnedBytes +
 								(companionLimited?.returnedBytes ?? 0),
@@ -492,6 +584,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						conversationId: resolvedConversationId,
 						timing,
 						...(activeStorageId ? { storage: { id: activeStorageId } } : {}),
+						...(runId ? { runId } : {}),
 						returnedBytes: structuredResultValue.returnedBytes,
 						...(structuredResultValue.truncated
 							? {
@@ -511,6 +604,100 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			}
 		},
 	)
+}
+
+function normalizeExecuteIdempotencyKey(
+	value: string | undefined,
+): string | null {
+	const trimmed = value?.trim()
+	if (!trimmed) return null
+	return trimmed.slice(0, runRecordMaxIdempotencyKeyLength)
+}
+
+function buildKeyedExecuteLookupResponse(input: {
+	run: RunRecord
+	conversationId: string
+	timing: {
+		startedAt: string
+		endedAt: string
+		durationMs: number
+	}
+	activeStorageId: string | null
+}) {
+	const storage = input.activeStorageId
+		? { storage: { id: input.activeStorageId } }
+		: {}
+	if (input.run.status === 'running') {
+		return {
+			content: prependToolMetadataContent(input.conversationId, [
+				{
+					type: 'text',
+					text: `Execute still in progress (runId: ${input.run.id}). Poll run_get with that id, or retry with the same idempotencyKey.`,
+				},
+			]),
+			structuredContent: {
+				conversationId: input.conversationId,
+				timing: input.timing,
+				...storage,
+				runId: input.run.id,
+				inProgress: true,
+				status: 'running' as const,
+			},
+			isError: false,
+		}
+	}
+
+	const retainedResult = input.run.metadata['result']
+	if (input.run.status === 'error') {
+		const errorMessage =
+			input.run.errorMessage ?? 'Execute failed (replayed from run record).'
+		return {
+			content: prependToolMetadataContent(input.conversationId, [
+				{
+					type: 'text',
+					text: `Error: ${errorMessage}`,
+				},
+			]),
+			structuredContent: {
+				conversationId: input.conversationId,
+				timing: input.timing,
+				...storage,
+				runId: input.run.id,
+				replayed: true,
+				returnedBytes: 0,
+				error: errorMessage,
+				...(input.run.errorName ? { errorName: input.run.errorName } : {}),
+				...(retainedResult !== undefined ? { result: retainedResult } : {}),
+				logs: [] as Array<unknown>,
+			},
+			isError: true,
+		}
+	}
+
+	return {
+		content: prependToolMetadataContent(input.conversationId, [
+			{
+				type: 'text',
+				text: formatLimitedExecutionOutput({
+					value: retainedResult,
+					truncated: false,
+					note: undefined,
+					displayText: undefined,
+				}),
+			},
+		]),
+		structuredContent: {
+			conversationId: input.conversationId,
+			timing: input.timing,
+			...storage,
+			runId: input.run.id,
+			replayed: true,
+			returnedBytes: 0,
+			result: retainedResult,
+			logs: [] as Array<unknown>,
+		},
+		isError: false,
+	}
 }
 
 function formatRawFetchHostNudgeContent(nudges: Array<string>) {

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -180,12 +180,26 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				conversationId: resolvedConversationId,
 				...(activeStorageId ? { storageId: activeStorageId } : {}),
 			}
+			let claimedRunHandle: RunRecordHandle | null = null
 			try {
 				return await runExecuteTool()
 			} catch (cause) {
 				// Setup failures (registry build, module bundling, executor
 				// creation) must return a structured MCP error instead of an
 				// unhandled rejection, mirroring the search tool boundary.
+				// Finalize any pre-claimed keyed run so retries can replay the
+				// error instead of seeing a stuck `running` row.
+				// Nested-function assignments are invisible to TS control-flow
+				// analysis on the outer `let`, so reassert the declared type.
+				const claimedHandle = claimedRunHandle as RunRecordHandle | null
+				if (claimedHandle) {
+					await finishRunRecord({
+						env,
+						handle: claimedHandle,
+						status: 'error',
+						error: cause,
+					})
+				}
 				const timing = finishToolTiming(timingStart)
 				const error = cause instanceof Error ? cause : new Error(String(cause))
 				const { errorName, errorMessage } = errorFields(error)
@@ -208,6 +222,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					structuredContent: {
 						conversationId: resolvedConversationId,
 						timing,
+						...(claimedHandle ? { runId: claimedHandle.id } : {}),
 						error: error.message,
 					},
 					isError: true,
@@ -217,9 +232,9 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			async function runExecuteTool() {
 				const normalizedIdempotencyKey =
 					normalizeExecuteIdempotencyKey(idempotencyKey)
-				// Look up an existing keyed run before consuming quota so
-				// transport-timeout retries can replay / report in-progress
-				// without burning another daily execute slot.
+				// Look up / claim a keyed run before consuming quota so
+				// transport-timeout retries and lost races return
+				// replay/in-progress without burning another daily slot.
 				if (normalizedIdempotencyKey && callerContext.user?.userId) {
 					const existing = await getRunRecordByIdempotencyKey({
 						env,
@@ -235,23 +250,6 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							activeStorageId,
 						})
 					}
-				}
-
-				// Daily execute quota, consumed before any bundling or sandbox
-				// work so over-limit calls cost nothing. The thrown
-				// EntitlementLimitError propagates through the outer catch as
-				// a structured MCP error.
-				if (callerContext.user?.userId) {
-					await consumeDailyEntitlement({
-						db: env.APP_DB,
-						userId: callerContext.user.userId,
-						email: callerContext.user.email,
-						resource: 'execute_calls_per_day',
-					})
-				}
-
-				let claimedRunHandle: RunRecordHandle | null = null
-				if (normalizedIdempotencyKey && callerContext.user?.userId) {
 					const claim = await claimRunRecord({
 						env,
 						userId: callerContext.user.userId,
@@ -265,7 +263,12 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							},
 						},
 					})
-					if (claim && !claim.claimed) {
+					if (!claim) {
+						throw new Error(
+							'Unable to claim execute idempotency key; RUN_LOG is unavailable.',
+						)
+					}
+					if (!claim.claimed) {
 						const timing = finishToolTiming(timingStart)
 						return buildKeyedExecuteLookupResponse({
 							run: claim.run,
@@ -274,10 +277,22 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							activeStorageId,
 						})
 					}
-					if (claim?.claimed) {
-						claimedRunHandle = claim.handle
-					}
+					claimedRunHandle = claim.handle
 				}
+
+				// Daily execute quota, consumed before any bundling or sandbox
+				// work so over-limit calls cost nothing. The thrown
+				// EntitlementLimitError propagates through the outer catch as
+				// a structured MCP error (and finalizes any claimed key).
+				if (callerContext.user?.userId) {
+					await consumeDailyEntitlement({
+						db: env.APP_DB,
+						userId: callerContext.user.userId,
+						email: callerContext.user.email,
+						resource: 'execute_calls_per_day',
+					})
+				}
+
 				const { getCapabilityRegistryForContext } =
 					await import('#mcp/capabilities/registry.ts')
 				const registry = await getCapabilityRegistryForContext({

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -51,8 +51,10 @@ import { listOpenApiBindings } from '#worker/openapi/binding-service.ts'
 import { normalizeHost } from '#mcp/secrets/allowed-hosts.ts'
 import { consumeDailyEntitlement } from '#worker/entitlements/service.ts'
 import {
+	abandonRunRecord,
 	claimRunRecord,
 	finishRunRecord,
+	getRunRecord,
 	getRunRecordByIdempotencyKey,
 } from '#worker/run-records/service.ts'
 import {
@@ -192,13 +194,10 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 				// Nested-function assignments are invisible to TS control-flow
 				// analysis on the outer `let`, so reassert the declared type.
 				const claimedHandle = claimedRunHandle as RunRecordHandle | null
+				// Setup failures happen before sandbox work: release the key so
+				// a later retry is not poisoned by a non-sandbox error.
 				if (claimedHandle) {
-					await finishRunRecord({
-						env,
-						handle: claimedHandle,
-						status: 'error',
-						error: cause,
-					})
+					await abandonRunRecord({ env, handle: claimedHandle })
 				}
 				const timing = finishToolTiming(timingStart)
 				const error = cause instanceof Error ? cause : new Error(String(cause))
@@ -222,7 +221,6 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					structuredContent: {
 						conversationId: resolvedConversationId,
 						timing,
-						...(claimedHandle ? { runId: claimedHandle.id } : {}),
 						error: error.message,
 					},
 					isError: true,
@@ -232,14 +230,15 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			async function runExecuteTool() {
 				const normalizedIdempotencyKey =
 					normalizeExecuteIdempotencyKey(idempotencyKey)
-				// Look up / claim a keyed run before consuming quota so
-				// transport-timeout retries and lost races return
-				// replay/in-progress without burning another daily slot.
+				// Look up an existing keyed execute run before consuming quota
+				// so transport-timeout retries can replay / report in-progress
+				// without burning another daily slot.
 				if (normalizedIdempotencyKey && callerContext.user?.userId) {
 					const existing = await getRunRecordByIdempotencyKey({
 						env,
 						userId: callerContext.user.userId,
 						idempotencyKey: normalizedIdempotencyKey,
+						surface: 'execute',
 					})
 					if (existing) {
 						const timing = finishToolTiming(timingStart)
@@ -250,6 +249,20 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							activeStorageId,
 						})
 					}
+				}
+
+				// Daily execute quota, consumed before claim/bundling/sandbox
+				// so over-limit calls cost nothing and do not poison a key.
+				if (callerContext.user?.userId) {
+					await consumeDailyEntitlement({
+						db: env.APP_DB,
+						userId: callerContext.user.userId,
+						email: callerContext.user.email,
+						resource: 'execute_calls_per_day',
+					})
+				}
+
+				if (normalizedIdempotencyKey && callerContext.user?.userId) {
 					const claim = await claimRunRecord({
 						env,
 						userId: callerContext.user.userId,
@@ -278,19 +291,6 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						})
 					}
 					claimedRunHandle = claim.handle
-				}
-
-				// Daily execute quota, consumed before any bundling or sandbox
-				// work so over-limit calls cost nothing. The thrown
-				// EntitlementLimitError propagates through the outer catch as
-				// a structured MCP error (and finalizes any claimed key).
-				if (callerContext.user?.userId) {
-					await consumeDailyEntitlement({
-						db: env.APP_DB,
-						userId: callerContext.user.userId,
-						email: callerContext.user.email,
-						resource: 'execute_calls_per_day',
-					})
 				}
 
 				const { getCapabilityRegistryForContext } =
@@ -364,16 +364,23 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 							// Bundling the caller-provided module (syntax errors,
 							// unresolved imports) throws before the sandbox runs;
 							// route it through the sandbox-error result path so it
-							// is not logged as a platform failure. Finish any
-							// pre-claimed keyed run so retries can replay the error
-							// instead of seeing a stuck `running` row.
+							// is not logged as a platform failure. Finish a still-
+							// running claimed row only — if the registry already
+							// wrote a terminal row, do not double-finish.
 							if (claimedRunHandle) {
-								await finishRunRecord({
+								const current = await getRunRecord({
 									env,
-									handle: claimedRunHandle,
-									status: 'error',
-									error: cause,
+									userId: claimedRunHandle.userId,
+									runId: claimedRunHandle.id,
 								})
+								if (current?.run.status === 'running') {
+									await finishRunRecord({
+										env,
+										handle: claimedRunHandle,
+										status: 'error',
+										error: cause,
+									})
+								}
 							}
 							return {
 								result: undefined,

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -397,18 +397,29 @@ class RunLogBase extends DurableObject<Env> {
 		return row != null
 	}
 
-	private findRunByIdempotencyKey(idempotencyKey: string): RunRecord | null {
+	private findRunByIdempotencyKey(input: {
+		idempotencyKey: string
+		surface?: RunSurface | null
+	}): RunRecord | null {
 		// Prefer an in-flight row, then the newest terminal row, so execute
-		// replay sees the attempt that still owns the key.
+		// replay sees the attempt that still owns the key. Scope by surface
+		// when provided so execute keys cannot collide with package/workflow
+		// history that reused the same string.
+		const clauses = ['r.idempotency_key = ?']
+		const params: Array<SqlStorageValue> = [input.idempotencyKey]
+		if (input.surface) {
+			clauses.push('r.surface = ?')
+			params.push(input.surface)
+		}
 		const row = this.ctx.storage.sql
 			.exec<Record<string, SqlStorageValue>>(
 				`SELECT r.*,
 					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
 				FROM runs r
-				WHERE r.idempotency_key = ?
+				WHERE ${clauses.join(' AND ')}
 				ORDER BY (r.status = 'running') DESC, r.started_at DESC, r.id DESC
 				LIMIT 1`,
-				idempotencyKey,
+				...params,
 			)
 			.toArray()[0]
 		if (!row) return null
@@ -734,7 +745,10 @@ class RunLogBase extends DurableObject<Env> {
 	}> {
 		const key = input.run.idempotencyKey?.trim() || null
 		if (key) {
-			const existing = this.findRunByIdempotencyKey(key)
+			const existing = this.findRunByIdempotencyKey({
+				idempotencyKey: key,
+				surface: input.run.surface,
+			})
 			if (existing) {
 				return { claimed: false, run: existing }
 			}
@@ -774,10 +788,36 @@ class RunLogBase extends DurableObject<Env> {
 
 	async getRunByIdempotencyKey(input: {
 		idempotencyKey: string
+		surface?: RunSurface | null
 	}): Promise<RunRecord | null> {
 		const key = input.idempotencyKey.trim()
 		if (!key) return null
-		return this.findRunByIdempotencyKey(key)
+		return this.findRunByIdempotencyKey({
+			idempotencyKey: key,
+			surface: input.surface ?? null,
+		})
+	}
+
+	/**
+	 * Delete a still-`running` row (and its logs) so a failed setup path can
+	 * release an idempotency key without poisoning later retries.
+	 */
+	async deleteRunIfRunning(input: {
+		runId: string
+	}): Promise<{ deleted: boolean }> {
+		const row = this.ctx.storage.sql
+			.exec<{ status: string }>(
+				`SELECT status FROM runs WHERE id = ? LIMIT 1`,
+				input.runId,
+			)
+			.toArray()[0]
+		if (!row || row.status !== 'running') {
+			return { deleted: false }
+		}
+		this.deleteRunsByIds([input.runId])
+		this.retentionIdleConfirmed = false
+		await this.ensureRetentionAlarm()
+		return { deleted: true }
 	}
 
 	async finishRun(input: {
@@ -1032,7 +1072,11 @@ export type RunLogRpc = {
 	}) => Promise<{ run: RunRecord; logs: Array<RunRecordLog> } | null>
 	getRunByIdempotencyKey: (input: {
 		idempotencyKey: string
+		surface?: RunSurface | null
 	}) => Promise<RunRecord | null>
+	deleteRunIfRunning: (input: {
+		runId: string
+	}) => Promise<{ deleted: boolean }>
 	summarize: (input: { since: string }) => Promise<RunRecordSummary>
 	listStorageIds: () => Promise<Array<string>>
 	exportRuns: (input: ExportRunsInput) => Promise<{

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -32,7 +32,7 @@ const metaRunCountKey = 'run_count'
 const metaFinishesSinceRetentionKey = 'finishes_since_retention'
 const metaSchemaVersionKey = 'schema_version'
 /** Bump when initializeSchema's DDL set changes; warm objects skip DDL. */
-const runLogSchemaVersion = 3
+const runLogSchemaVersion = 4
 
 const staleRunningErrorName = 'Interrupted'
 const staleRunningErrorMessage =
@@ -319,10 +319,13 @@ class RunLogBase extends DurableObject<Env> {
 		this.ctx.storage.sql.exec(
 			`CREATE INDEX IF NOT EXISTS idx_runs_name_started_id ON runs(name, started_at DESC, id DESC)`,
 		)
-		// Caller-supplied execute keys (and other surfaces that set a key) must
-		// be unique per user so claim/replay can stay race-free inside one DO.
+		// Non-unique: package invocations / workflows may reuse the same
+		// idempotency key across history. Keyed execute claim/replay stays
+		// race-free because claimRun select-then-insert runs in one DO RPC.
+		// Drop any unique index from schema v3 so warm objects can migrate.
+		this.ctx.storage.sql.exec(`DROP INDEX IF EXISTS idx_runs_idempotency_key`)
 		this.ctx.storage.sql.exec(
-			`CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_idempotency_key
+			`CREATE INDEX IF NOT EXISTS idx_runs_idempotency_key
 			ON runs(idempotency_key) WHERE idempotency_key IS NOT NULL`,
 		)
 		this.ctx.storage.sql.exec(`
@@ -395,12 +398,15 @@ class RunLogBase extends DurableObject<Env> {
 	}
 
 	private findRunByIdempotencyKey(idempotencyKey: string): RunRecord | null {
+		// Prefer an in-flight row, then the newest terminal row, so execute
+		// replay sees the attempt that still owns the key.
 		const row = this.ctx.storage.sql
 			.exec<Record<string, SqlStorageValue>>(
 				`SELECT r.*,
 					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
 				FROM runs r
 				WHERE r.idempotency_key = ?
+				ORDER BY (r.status = 'running') DESC, r.started_at DESC, r.id DESC
 				LIMIT 1`,
 				idempotencyKey,
 			)

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -32,7 +32,7 @@ const metaRunCountKey = 'run_count'
 const metaFinishesSinceRetentionKey = 'finishes_since_retention'
 const metaSchemaVersionKey = 'schema_version'
 /** Bump when initializeSchema's DDL set changes; warm objects skip DDL. */
-const runLogSchemaVersion = 2
+const runLogSchemaVersion = 3
 
 const staleRunningErrorName = 'Interrupted'
 const staleRunningErrorMessage =
@@ -319,6 +319,12 @@ class RunLogBase extends DurableObject<Env> {
 		this.ctx.storage.sql.exec(
 			`CREATE INDEX IF NOT EXISTS idx_runs_name_started_id ON runs(name, started_at DESC, id DESC)`,
 		)
+		// Caller-supplied execute keys (and other surfaces that set a key) must
+		// be unique per user so claim/replay can stay race-free inside one DO.
+		this.ctx.storage.sql.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_idempotency_key
+			ON runs(idempotency_key) WHERE idempotency_key IS NOT NULL`,
+		)
 		this.ctx.storage.sql.exec(`
 			CREATE TABLE IF NOT EXISTS run_logs (
 				run_id TEXT NOT NULL,
@@ -386,6 +392,36 @@ class RunLogBase extends DurableObject<Env> {
 			)
 			.toArray()[0]
 		return row != null
+	}
+
+	private findRunByIdempotencyKey(idempotencyKey: string): RunRecord | null {
+		const row = this.ctx.storage.sql
+			.exec<Record<string, SqlStorageValue>>(
+				`SELECT r.*,
+					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
+				FROM runs r
+				WHERE r.idempotency_key = ?
+				LIMIT 1`,
+				idempotencyKey,
+			)
+			.toArray()[0]
+		if (!row) return null
+		return mapRunRow(row, Number(row['log_count'] ?? 0) || 0)
+	}
+
+	private insertRunningRun(run: RunLogRowInput) {
+		const existed = this.runExists(run.id)
+		if (!existed) {
+			this.upsertRun(run, 'ignore')
+			// INSERT OR IGNORE: count only when the row is new.
+			if (this.runExists(run.id)) {
+				this.adjustRunCount(1)
+				// New row ⇒ future age/stale work exists; idle conclusion is stale.
+				// Clear armed too: a new `running` row may need an earlier wake.
+				this.retentionIdleConfirmed = false
+				this.retentionAlarmArmed = false
+			}
+		}
 	}
 
 	private upsertRun(run: RunLogRowInput, mode: 'ignore' | 'replace') {
@@ -675,20 +711,67 @@ class RunLogBase extends DurableObject<Env> {
 	}
 
 	async startRun(input: { run: RunLogRowInput }): Promise<{ ok: true }> {
-		const existed = this.runExists(input.run.id)
-		if (!existed) {
-			this.upsertRun(input.run, 'ignore')
-			// INSERT OR IGNORE: count only when the row is new.
-			if (this.runExists(input.run.id)) {
-				this.adjustRunCount(1)
-				// New row ⇒ future age/stale work exists; idle conclusion is stale.
-				// Clear armed too: a new `running` row may need an earlier wake.
-				this.retentionIdleConfirmed = false
-				this.retentionAlarmArmed = false
-			}
-		}
+		this.insertRunningRun(input.run)
 		await this.ensureRetentionAlarm()
 		return { ok: true }
+	}
+
+	/**
+	 * Atomically claim an idempotency key (or return the existing owner). DO
+	 * RPCs are serialized, so select-then-insert here is race-free without a
+	 * separate lock. Callers that need keyed execute replay use this instead of
+	 * fire-and-forget `startRun`.
+	 */
+	async claimRun(input: { run: RunLogRowInput }): Promise<{
+		claimed: boolean
+		run: RunRecord
+	}> {
+		const key = input.run.idempotencyKey?.trim() || null
+		if (key) {
+			const existing = this.findRunByIdempotencyKey(key)
+			if (existing) {
+				return { claimed: false, run: existing }
+			}
+		}
+		this.insertRunningRun(input.run)
+		await this.ensureRetentionAlarm()
+		const inserted =
+			(await this.getRun({ runId: input.run.id }))?.run ??
+			mapRunRow(
+				{
+					id: input.run.id,
+					surface: input.run.surface,
+					status: input.run.status,
+					name: input.run.name,
+					package_id: input.run.packageId,
+					package_kody_id: input.run.kodyId,
+					source_id: input.run.sourceId,
+					published_commit: input.run.publishedCommit,
+					storage_id: input.run.storageId,
+					job_id: input.run.jobId,
+					workflow_id: input.run.workflowId,
+					invocation_id: input.run.invocationId,
+					session_id: input.run.sessionId,
+					idempotency_key: input.run.idempotencyKey,
+					parent_run_id: input.run.parentRunId,
+					started_at: input.run.startedAt,
+					finished_at: input.run.finishedAt,
+					duration_ms: input.run.durationMs,
+					error_name: input.run.errorName,
+					error_message: input.run.errorMessage,
+					metadata_json: input.run.metadataJson,
+				},
+				0,
+			)
+		return { claimed: true, run: inserted }
+	}
+
+	async getRunByIdempotencyKey(input: {
+		idempotencyKey: string
+	}): Promise<RunRecord | null> {
+		const key = input.idempotencyKey.trim()
+		if (!key) return null
+		return this.findRunByIdempotencyKey(key)
 	}
 
 	async finishRun(input: {
@@ -929,6 +1012,10 @@ export const RunLog = Sentry.instrumentDurableObjectWithSentry(
 
 export type RunLogRpc = {
 	startRun: (input: { run: RunLogRowInput }) => Promise<{ ok: true }>
+	claimRun: (input: { run: RunLogRowInput }) => Promise<{
+		claimed: boolean
+		run: RunRecord
+	}>
 	finishRun: (input: {
 		run: RunLogRowInput
 		logs: Array<RunLogEntryInput>
@@ -937,6 +1024,9 @@ export type RunLogRpc = {
 	getRun: (input: {
 		runId: string
 	}) => Promise<{ run: RunRecord; logs: Array<RunRecordLog> } | null>
+	getRunByIdempotencyKey: (input: {
+		idempotencyKey: string
+	}) => Promise<RunRecord | null>
 	summarize: (input: { since: string }) => Promise<RunRecordSummary>
 	listStorageIds: () => Promise<Array<string>>
 	exportRuns: (input: ExportRunsInput) => Promise<{

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -8,6 +8,7 @@ import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { RunLog } from './run-log-do.ts'
 import {
+	abandonRunRecord,
 	beginRunRecord,
 	claimRunRecord,
 	clearRunRecords,
@@ -1021,6 +1022,7 @@ test('keyed execute claims eagerly, retains bounded result, and replays without 
 		env,
 		userId,
 		idempotencyKey: key,
+		surface: 'execute',
 	})
 	expect(byKey?.id).toBe(first.handle.id)
 	expect(byKey?.status).toBe('success')
@@ -1066,6 +1068,58 @@ test('keyed execute claims eagerly, retains bounded result, and replays without 
 		filter: { surface: 'execute' },
 	})
 	expect(page.runs.map((run) => run.id)).toEqual([first.handle.id])
+})
+
+test('idempotency lookup is surface-scoped and abandon releases running claims', async () => {
+	const userId = uniqueUserId('surface-key')
+	const sharedKey = `shared-key-${crypto.randomUUID()}`
+	await recordRunRecord({
+		env,
+		userId,
+		context: {
+			surface: 'workflow',
+			name: 'wf',
+			idempotencyKey: sharedKey,
+		},
+		status: 'success',
+		result: { from: 'workflow' },
+	})
+	const executeClaim = await claimRunRecord({
+		env,
+		userId,
+		context: {
+			surface: 'execute',
+			idempotencyKey: sharedKey,
+		},
+	})
+	expect(executeClaim?.claimed).toBe(true)
+	if (!executeClaim || !executeClaim.claimed) throw new Error('expected claim')
+
+	const executeLookup = await getRunRecordByIdempotencyKey({
+		env,
+		userId,
+		idempotencyKey: sharedKey,
+		surface: 'execute',
+	})
+	expect(executeLookup?.id).toBe(executeClaim.handle.id)
+	expect(executeLookup?.surface).toBe('execute')
+
+	await abandonRunRecord({ env, handle: executeClaim.handle })
+	expect(
+		await getRunRecordByIdempotencyKey({
+			env,
+			userId,
+			idempotencyKey: sharedKey,
+			surface: 'execute',
+		}),
+	).toBeNull()
+	const workflowStillThere = await getRunRecordByIdempotencyKey({
+		env,
+		userId,
+		idempotencyKey: sharedKey,
+		surface: 'workflow',
+	})
+	expect(workflowStillThere?.metadata['result']).toEqual({ from: 'workflow' })
 })
 
 test('snapshotRunRecordResult keeps small values and marks oversized ones', () => {

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -9,16 +9,20 @@ import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidenta
 import { RunLog } from './run-log-do.ts'
 import {
 	beginRunRecord,
+	claimRunRecord,
 	clearRunRecords,
 	finishRunRecord,
 	getRunRecord,
+	getRunRecordByIdempotencyKey,
 	listRunRecords,
 	recordRunRecord,
 	runLogRpc,
+	snapshotRunRecordResult,
 	summarizeRunRecords,
 } from './service.ts'
 import {
 	runRecordMaxLogEntriesPerRun,
+	runRecordMaxResultSnapshotBytes,
 	runRecordMaxRunsPerUser,
 	runRecordRetentionDays,
 	runRecordRetentionEveryNFinishes,
@@ -969,3 +973,139 @@ test(
 		])
 	},
 )
+
+test('keyed execute claims eagerly, retains bounded result, and replays without a second claim', async () => {
+	const userId = uniqueUserId('keyed-execute')
+	const key = `execute-key-${crypto.randomUUID()}`
+	const first = await claimRunRecord({
+		env,
+		userId,
+		context: {
+			surface: 'execute',
+			name: null,
+			idempotencyKey: key,
+			metadata: { conversationId: 'conv-keyed' },
+		},
+	})
+	expect(first?.claimed).toBe(true)
+	if (!first || !first.claimed) throw new Error('expected claim')
+	expect(first.handle.persistence).toBe('eager')
+
+	const whileRunning = await claimRunRecord({
+		env,
+		userId,
+		context: {
+			surface: 'execute',
+			idempotencyKey: key,
+		},
+	})
+	expect(whileRunning).toEqual({
+		claimed: false,
+		run: expect.objectContaining({
+			id: first.handle.id,
+			status: 'running',
+			idempotencyKey: key,
+		}),
+	})
+
+	const oversized = { blob: 'x'.repeat(runRecordMaxResultSnapshotBytes + 512) }
+	await finishRunRecord({
+		env,
+		handle: first.handle,
+		status: 'success',
+		result: oversized,
+		logs: ['done'],
+	})
+
+	const byKey = await getRunRecordByIdempotencyKey({
+		env,
+		userId,
+		idempotencyKey: key,
+	})
+	expect(byKey?.id).toBe(first.handle.id)
+	expect(byKey?.status).toBe('success')
+	expect(byKey?.metadata['result']).toEqual(
+		expect.objectContaining({
+			__truncated__: true,
+			preview: expect.any(String),
+		}),
+	)
+
+	const replay = await claimRunRecord({
+		env,
+		userId,
+		context: {
+			surface: 'execute',
+			idempotencyKey: key,
+		},
+	})
+	expect(replay).toEqual({
+		claimed: false,
+		run: expect.objectContaining({
+			id: first.handle.id,
+			status: 'success',
+		}),
+	})
+
+	// Key-less execute success still does not persist.
+	const keyless = beginRunRecord({
+		env,
+		userId,
+		context: { surface: 'execute', name: 'keyless-ok' },
+	})
+	expect(keyless?.persistence).toBe('on-failure')
+	await finishRunRecord({
+		env,
+		handle: keyless,
+		status: 'success',
+		result: { ignored: true },
+	})
+	const page = await listRunRecords({
+		env,
+		userId,
+		filter: { surface: 'execute' },
+	})
+	expect(page.runs.map((run) => run.id)).toEqual([first.handle.id])
+})
+
+test('snapshotRunRecordResult keeps small values and marks oversized ones', () => {
+	expect(snapshotRunRecordResult({ ok: true, agentId: 'abc' })).toEqual({
+		ok: true,
+		agentId: 'abc',
+	})
+	const huge = 'y'.repeat(runRecordMaxResultSnapshotBytes + 100)
+	expect(snapshotRunRecordResult({ payload: huge })).toEqual({
+		__truncated__: true,
+		preview: expect.stringContaining('... [truncated]'),
+	})
+})
+
+test('webhook/export finish retains metadata.result for run_get', async () => {
+	const userId = uniqueUserId('result-snapshot')
+	const handle = await recordRunRecord({
+		env,
+		userId,
+		context: {
+			surface: 'webhook',
+			name: 'sentry',
+			metadata: {
+				endpointId: 'ep-1',
+				httpStatus: 202,
+				outcome: 'delivered',
+			},
+		},
+		status: 'success',
+		result: { skipped: 'other-project' },
+	})
+	expect(handle).not.toBeNull()
+	const detail = await getRunRecord({
+		env,
+		userId,
+		runId: handle!.id,
+	})
+	expect(detail?.run.metadata).toMatchObject({
+		endpointId: 'ep-1',
+		outcome: 'delivered',
+		result: { skipped: 'other-project' },
+	})
+})

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -540,13 +540,37 @@ export async function getRunRecordByIdempotencyKey(input: {
 	env: Env
 	userId: string
 	idempotencyKey: string
+	surface?: RunRecordContext['surface'] | null
 }): Promise<RunRecord | null> {
 	const key = normalizeOptionalString(input.idempotencyKey)
 	if (!runLogBinding(input.env) || !key) return null
 	return await runLogRpc({
 		env: input.env,
 		userId: input.userId,
-	}).getRunByIdempotencyKey({ idempotencyKey: key })
+	}).getRunByIdempotencyKey({
+		idempotencyKey: key,
+		surface: input.surface ?? null,
+	})
+}
+
+/**
+ * Release a claimed `running` row after setup failure (before sandbox work).
+ * Never throws. Terminal rows are left alone so legitimate finishes stay put.
+ */
+export async function abandonRunRecord(input: {
+	env: Env
+	handle: RunRecordHandle | null
+}): Promise<void> {
+	const handle = input.handle
+	if (!handle || !runLogBinding(input.env)) return
+	try {
+		await runLogRpc({
+			env: input.env,
+			userId: handle.userId,
+		}).deleteRunIfRunning({ runId: handle.id })
+	} catch (error) {
+		console.warn('run-record-abandon-failed', error)
+	}
 }
 
 export async function summarizeRunRecords(input: {

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -19,11 +19,12 @@ import {
 	type RunStatus,
 	type RunTerminalStatus,
 	runLogLevelValues,
-	runPersistenceForSurface,
+	runPersistenceForContext,
 	runRecordDefaultPageSize,
 	runRecordMaxJsonBytes,
 	runRecordMaxLogEntriesPerRun,
 	runRecordMaxPageSize,
+	runRecordMaxResultSnapshotBytes,
 	runRecordMaxTextBytes,
 } from './types.ts'
 
@@ -67,6 +68,33 @@ function serializeJson(value: unknown, maxBytes = runRecordMaxJsonBytes) {
 			__truncated__: true,
 			preview,
 		})
+	}
+	return wrapped
+}
+
+/**
+ * Bound a JSON-serializable handler result for `metadata.result`. Oversized
+ * values become `{ __truncated__: true, preview }` so `run_get` stays useful
+ * without blowing per-user DO storage.
+ */
+export function snapshotRunRecordResult(
+	value: unknown,
+	maxBytes = runRecordMaxResultSnapshotBytes,
+): unknown {
+	const safe = toJsonSafeValue(value)
+	const json = JSON.stringify(safe)
+	if (textEncoder.encode(json).length <= maxBytes) return safe
+	let preview = truncateUtf8(json, Math.max(0, maxBytes - 64))
+	let wrapped: { __truncated__: true; preview: string } = {
+		__truncated__: true,
+		preview,
+	}
+	while (
+		textEncoder.encode(JSON.stringify(wrapped)).length > maxBytes &&
+		preview.length > 0
+	) {
+		preview = preview.slice(0, Math.floor(preview.length * 0.8))
+		wrapped = { __truncated__: true, preview }
 	}
 	return wrapped
 }
@@ -209,7 +237,7 @@ export function beginRunRecord(input: {
 	try {
 		const id = crypto.randomUUID()
 		const startedAt = new Date().toISOString()
-		const persistence = runPersistenceForSurface(context.surface)
+		const persistence = runPersistenceForContext(context)
 		const handle: RunRecordHandle = {
 			id,
 			userId,
@@ -230,6 +258,8 @@ export function beginRunRecord(input: {
 			})
 			// A dropped startRun is deliberately harmless: finishRun upserts the
 			// complete row. That is why begin can stay off the request critical path.
+			// Keyed execute must use {@link claimRunRecord} instead so the running
+			// row is visible before work starts (replay / in-progress lookups).
 			const startPromise = runLogRpc({ env: input.env, userId })
 				.startRun({ run })
 				.catch((error: unknown) => {
@@ -250,6 +280,66 @@ export function beginRunRecord(input: {
 }
 
 /**
+ * Awaited claim for keyed runs (execute with `idempotencyKey`). Returns the
+ * existing owner when the key is already taken so callers can replay or report
+ * in-progress without starting a duplicate sandbox.
+ *
+ * Never throws: same observability contract as {@link beginRunRecord}.
+ */
+export async function claimRunRecord(input: {
+	env: Env
+	userId?: string | null
+	context?: RunRecordContext | null
+}): Promise<
+	| { claimed: true; handle: RunRecordHandle }
+	| { claimed: false; run: RunRecord }
+	| null
+> {
+	const namespace = runLogBinding(input.env)
+	const userId = normalizeOptionalString(input.userId ?? undefined)
+	const context = input.context
+	if (!namespace || !userId || !context) return null
+	const idempotencyKey = normalizeOptionalString(context.idempotencyKey)
+	if (!idempotencyKey) return null
+
+	try {
+		const startedAt = new Date().toISOString()
+		const handle: RunRecordHandle = {
+			id: crypto.randomUUID(),
+			userId,
+			startedAt,
+			persistence: runPersistenceForContext({
+				...context,
+				idempotencyKey,
+			}),
+			context: {
+				...context,
+				idempotencyKey,
+			},
+		}
+		const run = buildRunRow({
+			handle,
+			status: 'running',
+			finishedAt: null,
+			durationMs: null,
+			errorName: null,
+			errorMessage: null,
+			updatedAt: startedAt,
+		})
+		const claimed = await runLogRpc({ env: input.env, userId }).claimRun({
+			run,
+		})
+		if (!claimed.claimed) {
+			return { claimed: false, run: claimed.run }
+		}
+		return { claimed: true, handle }
+	} catch (error) {
+		console.warn('run-record-claim-failed', error)
+		return null
+	}
+}
+
+/**
  * Never throws, including the activation milestone write it fans out to: the
  * terminal record and the milestone both observe the run, so neither may fail
  * it.
@@ -260,6 +350,11 @@ export async function finishRunRecord(input: {
 	status: RunTerminalStatus
 	logs?: Array<RunRecordLogInput>
 	error?: unknown
+	/**
+	 * Optional JSON-serializable handler result retained under
+	 * `metadata.result` (bounded; see {@link snapshotRunRecordResult}).
+	 */
+	result?: unknown
 	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<void> {
 	const handle = input.handle
@@ -278,8 +373,21 @@ export async function finishRunRecord(input: {
 					Date.parse(finishedAt) - Date.parse(handle.startedAt),
 				)
 				const { errorName, errorMessage } = getErrorFields(input.error)
+				const metadata =
+					input.result === undefined
+						? handle.context.metadata
+						: {
+								...(handle.context.metadata ?? {}),
+								result: snapshotRunRecordResult(input.result),
+							}
 				const run = buildRunRow({
-					handle,
+					handle: {
+						...handle,
+						context: {
+							...handle.context,
+							metadata,
+						},
+					},
 					status: input.status,
 					finishedAt,
 					durationMs,
@@ -356,6 +464,7 @@ export async function recordRunRecord(input: {
 	status: RunTerminalStatus
 	logs?: Array<RunRecordLogInput>
 	error?: unknown
+	result?: unknown
 	startedAt?: string | null
 	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<RunRecordHandle | null> {
@@ -371,7 +480,7 @@ export async function recordRunRecord(input: {
 			userId,
 			startedAt:
 				normalizeOptionalString(input.startedAt) ?? new Date().toISOString(),
-			persistence: runPersistenceForSurface(context.surface),
+			persistence: runPersistenceForContext(context),
 			context,
 		}
 	} catch (error) {
@@ -384,6 +493,7 @@ export async function recordRunRecord(input: {
 		status: input.status,
 		logs: input.logs,
 		error: input.error,
+		result: input.result,
 		waitUntil: input.waitUntil,
 	})
 	return handle
@@ -424,6 +534,19 @@ export async function getRunRecord(input: {
 	return await runLogRpc({ env: input.env, userId: input.userId }).getRun({
 		runId: input.runId,
 	})
+}
+
+export async function getRunRecordByIdempotencyKey(input: {
+	env: Env
+	userId: string
+	idempotencyKey: string
+}): Promise<RunRecord | null> {
+	const key = normalizeOptionalString(input.idempotencyKey)
+	if (!runLogBinding(input.env) || !key) return null
+	return await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).getRunByIdempotencyKey({ idempotencyKey: key })
 }
 
 export async function summarizeRunRecords(input: {

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -53,9 +53,12 @@ export type RunLogLevel = (typeof runLogLevelValues)[number]
  * - `eager`: a `running` row is written at begin so an evicted or hung run is
  *   still visible. Used by every surface a user cannot watch interactively.
  * - `on-failure`: nothing is persisted unless the run ends in `error`. Used
- *   only by `execute`, which is the highest-volume surface and already returns
- *   its result (and logs) inline to the caller. Success counts for `execute`
- *   come from Analytics Engine via usage metering, not from run records.
+ *   only by key-less `execute`, which is the highest-volume surface and already
+ *   returns its result (and logs) inline to the caller. Success counts for
+ *   key-less `execute` come from Analytics Engine via usage metering, not from
+ *   run records. When the caller supplies an `idempotencyKey`, execute upgrades
+ *   to `eager` so a client-side transport timeout can still recover the outcome
+ *   via `run_get` / keyed replay.
  */
 export type RunPersistence = 'eager' | 'on-failure'
 
@@ -101,6 +104,20 @@ export type RunRecordContext = {
 	idempotencyKey?: string | null
 	parentRunId?: string | null
 	metadata?: Record<string, unknown> | null
+}
+
+/**
+ * Persistence for one begin/finish pair. Same as
+ * {@link runPersistenceForSurface} except keyed `execute` upgrades to `eager`.
+ */
+export function runPersistenceForContext(
+	context: Pick<RunRecordContext, 'surface' | 'idempotencyKey'>,
+): RunPersistence {
+	const key = context.idempotencyKey?.trim()
+	if (context.surface === 'execute' && key) {
+		return 'eager'
+	}
+	return runPersistenceForSurface(context.surface)
 }
 
 /**
@@ -201,6 +218,14 @@ export const runRecordMaxRunsPerUser = 2_000
 export const runRecordMaxLogEntriesPerRun = 200
 export const runRecordMaxTextBytes = 16 * 1024
 export const runRecordMaxJsonBytes = 32 * 1024
+/**
+ * Bound for `metadata.result` snapshots retained on finish. Kept small so
+ * per-user DO storage and the existing retention policy stay healthy; oversized
+ * values are replaced with `{ __truncated__: true, preview }`.
+ */
+export const runRecordMaxResultSnapshotBytes = 4 * 1024
+/** Max length for caller-supplied execute `idempotencyKey` values. */
+export const runRecordMaxIdempotencyKeyLength = 256
 export const runRecordDefaultPageSize = 25
 export const runRecordMaxPageSize = 100
 

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -134,6 +134,8 @@ async function recordDelivery(input: {
 	error?: string | null
 	payloadBytes: number
 	invocationId?: string
+	/** Handler return value from the bound package export (bounded on finish). */
+	result?: unknown
 	startedAt: string
 	waitUntil?: (promise: Promise<unknown>) => void
 }) {
@@ -157,12 +159,18 @@ async function recordDelivery(input: {
 			},
 			status,
 			error: input.error ?? undefined,
+			result: input.result,
 			startedAt: input.startedAt,
 			waitUntil: input.waitUntil,
 		})
 	} catch (error) {
 		console.error('[webhooks] failed to record delivery', error)
 	}
+}
+
+function readInvocationHandlerResult(body: unknown): unknown {
+	if (!body || typeof body !== 'object' || Array.isArray(body)) return undefined
+	return (body as Record<string, unknown>)['result']
 }
 
 async function readBodyWithCap(
@@ -533,6 +541,7 @@ export async function handleWebhookIngressRequest(
 					error: ok ? null : `invocation_status_${response.status}`,
 					payloadBytes: bodyBytes.byteLength,
 					invocationId: deliveryId,
+					result: readInvocationHandlerResult(response.body),
 					startedAt: receivedAt,
 					waitUntil,
 				})
@@ -582,6 +591,7 @@ export async function handleWebhookIngressRequest(
 			error: ok ? null : `invocation_status_${response.status}`,
 			payloadBytes: bodyBytes.byteLength,
 			invocationId: deliveryId,
+			result: readInvocationHandlerResult(response.body),
 			startedAt: receivedAt,
 			waitUntil,
 		})

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -329,6 +329,7 @@ test('package-centered webhook ingress auth, HMAC, size cap, ack/sync, and isola
 	expect(delivered?.metadata).toMatchObject({
 		httpStatus: 202,
 		outcome: 'delivered',
+		result: { handled: true },
 	})
 
 	declareWebhook({ name: 'sync-hook', responseMode: 'sync' })
@@ -512,6 +513,7 @@ test('webhook delivery records with one DO write, real startedAt duration, and e
 	expect(delivered?.metadata).toMatchObject({
 		outcome: 'delivered',
 		httpStatus: 200,
+		result: { handled: true },
 	})
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two platform-level run-record observability fixes for friction discovered while orchestrating Kody MCP calls from an external agent:

1. **Keyed execute recovery** — optional `idempotencyKey` on the MCP `execute` tool upgrades that call to eager persistence (running + terminal rows) with a bounded result snapshot. Retries of a finished key return `replayed: true` + retained result + `runId`; retries while still running return `inProgress: true` + `runId`. Key-less execute stays on-failure-only.
2. **Bounded handler results on eager surfaces** — `finishRunRecord` / `recordRunRecord` accept an optional `result` stored as `metadata.result` (4 KiB cap, `{ __truncated__: true, preview }` when oversized). Webhook deliveries and bundled export/execute finishes pass it through; `run_get` already exposes metadata.

## Review follow-ups addressed

- Claim after daily quota; fail closed if claim cannot run.
- Lookups/claims scoped by `(surface, idempotency_key)`.
- Setup failures `abandonRunRecord` (delete if still running) so keys are not poisoned.
- Finish claimed errors only when still `running` (no double-finish).
- Non-unique `idempotency_key` index (schema v4).
- Meta capability `inProgress` returns `ok: true` (aligned with public tool).

## Test plan

- [x] Keyed execute claim/replay/truncation + key-less success still omitted
- [x] Execute tool replay / in-progress / claim+runId
- [x] Surface-scoped lookup + abandon releases running claims
- [x] Webhook + `run_get` expose bounded `metadata.result`
- [x] `npm run validate` / CI green
- [x] Squash-merged and production deploy green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** merged as `4d3ccd8`

**Classification:** extends — run-record persistence and the execute tool contract gain optional keyed recovery and bounded result snapshots without adding primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `run-records` | storage | extends — claim/get/abandon by key+surface, keyed execute → eager, `metadata.result` |
| `mcp-server` | surfaces | extends — `execute` `idempotencyKey`, `runId` / `replayed` / `inProgress` |
| `capabilities-execute` | runtime | extends — pre-claimed handles, result on finish |
| `webhooks` | assistant | extends — delivery `metadata.result` |
| `memories` | assistant | composes — meta `execute` mirrors public tool |

</details>

<!-- system-recap:end -->

## Conductor report

- **status:** done
- **PR URL:** https://github.com/kentcdodds/kody/pull/1001
- **what changed:** Optional execute `idempotencyKey` (eager persist + replay/in-progress + runId); bounded `metadata.result` on finish for webhook/export/keyed execute; review hardenings including surface-scoped keys, abandon on setup failure, and meta `inProgress` as `ok: true`.
- **test evidence:** Local validate green; CI Validate green on PR and on main post-merge; production deploy healthcheck + execute smoke green.
- **merge decision + risk rationale:** Merged and deployed per explicit `/ship-pr deploy` request. Medium-risk platform change; CI fully green before squash merge.
- **open questions:** None.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5381263c-b06b-44b7-a74f-7f450c8499c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5381263c-b06b-44b7-a74f-7f450c8499c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `idempotencyKey` support for MCP `execute`, enabling safe retries and recovery after client timeouts.
  * Exposed `runId` plus `replayed` / `inProgress` / `status` for durable, keyed execution outcomes.
  * Retained run records can now include bounded handler-result snapshots (`metadata.result`), including for later retrieval.
  * Webhook delivery records now persist handler result details when available.

* **Documentation**
  * Clarified run persistence, Activity visibility, retention rules, timeout recovery behavior, and troubleshooting guidance for keyed vs key-less `execute`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->