### PR TITLE
fix(dr): announce Content-Length on D1 import uploads via FixedLengthStream

### DIFF
--- a/packages/backup-control-plane/d1-import-api.node.test.ts
+++ b/packages/backup-control-plane/d1-import-api.node.test.ts
@@ -203,6 +203,51 @@ test('importSqlIntoD1 streams reopen through loadSqlBody without buffering the s
 	)
 })
 
+test('importSqlIntoD1 pipes stream uploads through FixedLengthStream when available', async () => {
+	// Presigned D1 import upload URLs reject chunked bodies with HTTP 411;
+	// the Workers runtime only emits Content-Length for FixedLengthStream.
+	const constructedLengths: Array<number> = []
+	class StubFixedLengthStream extends TransformStream<Uint8Array, Uint8Array> {
+		constructor(expectedLength: number) {
+			super()
+			constructedLengths.push(expectedLength)
+		}
+	}
+	const globalWithStream = globalThis as { FixedLengthStream?: unknown }
+	globalWithStream.FixedLengthStream = StubFixedLengthStream
+	try {
+		const sequence = importPollSequence([
+			{ type: 'import', success: true, status: 'complete' },
+		])
+		await importSqlIntoD1({
+			accountId: ACCOUNT,
+			databaseId: DATABASE,
+			token: 'token',
+			sourceMd5Etag: SOURCE_MD5,
+			loadSqlBody: async () =>
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode(SOURCE_SQL))
+						controller.close()
+					},
+				}),
+			options: {
+				fetcher: sequence.fetcher,
+				sleep: async () => undefined,
+				maxPollAttempts: 2,
+				pollDelayMs: 1,
+			},
+		})
+		const expectedUpload = `${d1ImportForeignKeysOffPrefix}${SOURCE_SQL}`
+		assert.deepEqual(constructedLengths, [
+			new TextEncoder().encode(expectedUpload).byteLength,
+		])
+		assert.equal(sequence.getUploadedText(), expectedUpload)
+	} finally {
+		delete globalWithStream.FixedLengthStream
+	}
+})
+
 test('importSqlIntoD1 fails closed on non-terminal, expired, and error polls', async () => {
 	const consoleError = vi.spyOn(console, 'error')
 	consoleError.mockImplementation(() => undefined)

--- a/packages/backup-control-plane/d1-import-api.node.test.ts
+++ b/packages/backup-control-plane/d1-import-api.node.test.ts
@@ -214,6 +214,7 @@ test('importSqlIntoD1 pipes stream uploads through FixedLengthStream when availa
 		}
 	}
 	const globalWithStream = globalThis as { FixedLengthStream?: unknown }
+	const previousFixedLengthStream = globalWithStream.FixedLengthStream
 	globalWithStream.FixedLengthStream = StubFixedLengthStream
 	try {
 		const sequence = importPollSequence([
@@ -244,7 +245,11 @@ test('importSqlIntoD1 pipes stream uploads through FixedLengthStream when availa
 		])
 		assert.equal(sequence.getUploadedText(), expectedUpload)
 	} finally {
-		delete globalWithStream.FixedLengthStream
+		if (previousFixedLengthStream === undefined) {
+			delete globalWithStream.FixedLengthStream
+		} else {
+			globalWithStream.FixedLengthStream = previousFixedLengthStream
+		}
 	}
 })
 

--- a/packages/backup-control-plane/d1-import-api.ts
+++ b/packages/backup-control-plane/d1-import-api.ts
@@ -332,6 +332,34 @@ function prependForeignKeysOffStream(
 	})
 }
 
+type FixedLengthStreamConstructor = new (expectedLength: number) => {
+	readable: ReadableStream<Uint8Array>
+	writable: WritableStream<Uint8Array>
+}
+
+/**
+ * Workers `fetch` sends plain `ReadableStream` bodies with chunked
+ * transfer-encoding and no `Content-Length`, which presigned D1 import
+ * upload URLs reject with HTTP 411 (seen live on the 2026-07-28 restore
+ * drill). Piping through `FixedLengthStream` makes the runtime emit
+ * `Content-Length`. The global is Workers-only; in Node (unit tests with
+ * mock fetchers) the stream is returned unchanged.
+ */
+function withKnownLength(
+	stream: ReadableStream<Uint8Array>,
+	totalBytes: number,
+): ReadableStream<Uint8Array> {
+	const FixedLengthStream = (
+		globalThis as { FixedLengthStream?: FixedLengthStreamConstructor }
+	).FixedLengthStream
+	if (FixedLengthStream === undefined) return stream
+	const fixed = new FixedLengthStream(totalBytes)
+	// Failures propagate through the piped readable and surface as an upload
+	// error; the catch only suppresses the duplicate unhandled rejection.
+	void stream.pipeTo(fixed.writable).catch(() => {})
+	return fixed.readable
+}
+
 /**
  * Verify the unmodified backup SQL MD5, then build the FK-safe upload body and
  * its MD5. Streams are loaded twice via `loadSqlBody` so large backups are not
@@ -372,7 +400,10 @@ export async function prepareD1ImportUpload(input: {
 	}
 
 	return {
-		uploadBody: prependForeignKeysOffStream(prefix, second),
+		uploadBody: withKnownLength(
+			prependForeignKeysOffStream(prefix, second),
+			prefix.byteLength + hashes.sourceBytes,
+		),
 		uploadMd5Hex: hashes.uploadMd5Hex,
 		sourceBytes: hashes.sourceBytes,
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The 2026-07-28 restore drill (the first against a sealed day) failed with `errorCode=import-upload-http-error`, `D1 import upload returned HTTP 411`.

**Root cause:** Workers `fetch` sends plain `ReadableStream` bodies with chunked transfer-encoding and **no `Content-Length`**, and the presigned D1 import upload URL rejects that with 411 (Length Required). The streaming-upload refactor in `importSqlIntoD1` had only ever been exercised against mock fetchers and the ad hoc relay worker — never the real presigned endpoint, which is exactly the gap the drill exists to catch.

**Fix:** pipe stream upload bodies through `FixedLengthStream` — the Workers-native mechanism for emitting `Content-Length` on streamed request bodies. The exact length is already known from the verification hashing pass (`foreign_keys=OFF` prefix + source bytes). The global is Workers-only, so Node unit tests (mock fetchers) fall back to the unwrapped stream. This covers both the isolated drill and the graduated production-restore path, with no change to memory behavior (still no buffering of the ~118 MB SQL).

**Testing:** new regression test stubs `FixedLengthStream` on `globalThis` and asserts the upload is constructed with the exact expected byte length and the body arrives intact. Full control-plane suite passes (68 tests); typecheck/lint/format clean.

**After deploy:** re-run the drill for `2026-07-28` from the dashboard. The failed drill's kept-for-inspection database is empty (import never started) and can be deleted.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `780e6ab7`

**Classification:** extends — one-function hardening of the D1 import upload transport in the backup control plane. No schema, API, or primitive changes.

### Primitives touched

| Primitive              | Group   | Impact                                                              |
| ---------------------- | ------- | ------------------------------------------------------------------- |
| `backup-control-plane` | storage | extends — stream uploads to presigned D1 import URLs now carry `Content-Length` via `FixedLengthStream` |

### System map

The drill/restore flow streams backup SQL from R2 to the D1 import API; only the upload leg changes.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	drill["backup-control-plane<br/>Drill / production restore"]:::extended
	r2["kody-production-backups<br/>R2 (backup SQL)"]:::untouched
	d1["D1 import API<br/>presigned upload"]:::untouched
	r2 -->|"stream (verified MD5)"| drill
	drill -->|"PUT with Content-Length (FixedLengthStream)"| d1
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Upload integrity checks are unchanged: source MD5 is verified against the signed manifest before upload, and the returned ETag must match the computed upload MD5. Streaming behavior (no buffering) is preserved.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed database imports by providing an accurate upload size when supported.
  * Preserved stream upload errors while preventing duplicate error notifications.
  * Enhanced reliability of streamed SQL uploads across supported environments.

* **Tests**
  * Added a new test to verify streamed uploads use the expected known-length behavior and that the prefixed SQL content is uploaded correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->