### PR TITLE
docs(dr): add live evidence log for proven backup and drill lanes

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -7,9 +7,10 @@ registries populated only via code review, source/drill identity allowlists, D1
 size ceilings, and drill-before-production-restore.
 
 This document describes the designed end state. Treat every checklist item as
-unproven until you have live evidence for that item. Code-complete packages are
-not proof that the DR account, bucket locks, secrets, schedules, Access policy,
-or escrow blob are live.
+unproven until you have live evidence for that item (see the
+[live evidence log](#live-evidence-log)). Code-complete packages are not proof
+that the DR account, bucket locks, secrets, schedules, Access policy, or escrow
+blob are live.
 
 Primary operator surface:
 
@@ -21,6 +22,23 @@ Primary operator surface:
 - Destination provisioner: `node tools/ci/backup-resources-cli.ts plan|apply`.
 
 Do not use `tools/export-d1-remote-to-sqlite.sh` as a backup or restore tool.
+
+## Live evidence log
+
+First-proven dates for each lane (newest first). Re-prove and update after
+material schema/storage/pipeline changes; a lane is only as trusted as its most
+recent evidence.
+
+| Date (UTC) | Lane proven                                                                                                                                                                                                                                                                                                                                                    |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | Isolated restore drill green through the product UI against a sealed day (`PRAGMA quick_check` ok, table counts plausible, temp database cleaned up). Required [#1002](https://github.com/kentcdodds/kody/pull/1002): presigned D1 import uploads reject chunked bodies with HTTP 411, so stream uploads go through `FixedLengthStream`.                       |
+| 2026-07-28 | First sealed full-backup day (`daily/full/2026-07-28/manifest.json`). Required [#1000](https://github.com/kentcdodds/kody/pull/1000): bucket-lock rules reject puts on existing keys with error 10069 before conditionals are evaluated, and exporter resume became identity-driven after mid-window inventory drift produced duplicate storage-index entries. |
+| 2026-07-28 | First completed staging run (`staging/2026-07-28/exporter/summary.json`; 186 storage dumps, R2 indexes, artifacts index).                                                                                                                                                                                                                                      |
+| 2026-07-26 | First verified nightly D1 export (signed manifest, stored-object digest verified; ~118 MB).                                                                                                                                                                                                                                                                    |
+
+Still unproven live: graduated production restore into the production database
+(drill-level evidence only; it shares the now-fixed upload path), the offline
+escrow unseal smoke test, and `weekly/` retention aging through its lifecycle.
 
 ## Objectives
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The DR runbook says "treat every checklist item as unproven until you have live evidence" — as of 2026-07-28 that evidence exists for most of the pipeline, so this records it in a dated **live evidence log** at the top of the runbook:

- **2026-07-26** — first verified nightly D1 export (signed manifest, digest-verified, ~118 MB)
- **2026-07-28** — first completed staging run (186 storage dumps + indexes)
- **2026-07-28** — first sealed full-backup day (unblocked by #1000: bucket-lock put rejections + exporter inventory drift)
- **2026-07-28** — first green in-product isolated restore drill against a sealed day: `quick_check` ok, temp DB cleaned up (unblocked by #1002: `Content-Length` on presigned D1 import uploads)

It also names what is still unproven live: graduated production restore (drill-level evidence only), the offline escrow unseal smoke test, and `weekly/` retention aging through its lifecycle.

Docs-only change; format and lint pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310ee695-4cbf-4722-bf8f-ab82ce31933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

