### PR TITLE
Filter Firefox DOM permission-denied noise from client Sentry

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { filterBrowserAbortSentryEvent } from './sentry-browser-filters.ts'
+import {
+	filterBrowserAbortSentryEvent,
+	filterBrowserSentryEvent,
+	filterFirefoxDomPermissionDeniedSentryEvent,
+} from './sentry-browser-filters.ts'
 
 test('filterBrowserAbortSentryEvent drops AbortError noise and keeps real errors', () => {
 	// Production KODY-CLOUDFLARE-23 signature: type Error, AbortError value, no frames.
@@ -81,4 +85,132 @@ test('filterBrowserAbortSentryEvent drops AbortError noise and keeps real errors
 			},
 		}),
 	).not.toBeNull()
+})
+
+test('filterFirefoxDomPermissionDeniedSentryEvent drops Firefox Xray noise and keeps real errors', () => {
+	// Production 7639685398: Remix hydration / Replay startRecording on Firefox.
+	expect(
+		filterFirefoxDomPermissionDeniedSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Permission denied to access property "childNodes"',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	expect(
+		filterFirefoxDomPermissionDeniedSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Permission denied to access property "nodeType"',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	expect(
+		filterFirefoxDomPermissionDeniedSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'DOMException',
+						value:
+							'Permission denied to access property "document" on cross-origin object',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	expect(
+		filterFirefoxDomPermissionDeniedSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: 'something else' }],
+				},
+			},
+			new Error('Permission denied to access property "childNodes"'),
+		),
+	).toBeNull()
+
+	const realBug = {
+		exception: {
+			values: [
+				{
+					type: 'TypeError',
+					value:
+						"undefined is not an object (evaluating 'r.updateCurrentEntry')",
+				},
+			],
+		},
+	}
+	expect(filterFirefoxDomPermissionDeniedSentryEvent(realBug)).toBe(realBug)
+
+	// Broader SecurityError / permission wording must still reach Sentry.
+	expect(
+		filterFirefoxDomPermissionDeniedSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'SecurityError',
+						value:
+							'CSSStyleSheet.cssRules getter: Not allowed to access cross-origin stylesheet',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterFirefoxDomPermissionDeniedSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Permission denied',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+})
+
+test('filterBrowserSentryEvent chains abort and Firefox DOM permission filters', () => {
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'AbortError: The user aborted a request.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Permission denied to access property "childNodes"',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	const realBug = {
+		exception: {
+			values: [{ type: 'TypeError', value: 'TypeError: Failed to fetch' }],
+		},
+	}
+	expect(filterBrowserSentryEvent(realBug)).toBe(realBug)
 })

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -80,3 +80,65 @@ export function filterBrowserAbortSentryEvent<T extends SentryErrorEventLike>(
 	if (isBrowserAbortSentryEvent(event, originalException)) return null
 	return event
 }
+
+/**
+ * Firefox throws when page JS (Remix hydration or Sentry Session Replay /
+ * rrweb `startRecording`) touches a DOM node the content compartment cannot
+ * read — typically an extension-injected Xray wrapper or a cross-origin
+ * object. Signature from production issue 7639685398 / MDN
+ * "Permission denied to access property". Not actionable in app code.
+ *
+ * Match is intentionally narrow: only this Firefox wording (optional
+ * "on cross-origin object" suffix). Never blanket-drop SecurityError /
+ * DOMException generally.
+ */
+const firefoxDomPermissionDeniedMessage =
+	/^Permission denied to access property ["'][^"']+["'](?: on cross-origin object)?\.?$/
+
+export function isFirefoxDomPermissionDeniedMessage(message: string) {
+	return firefoxDomPermissionDeniedMessage.test(message)
+}
+
+export function isFirefoxDomPermissionDeniedError(error: unknown) {
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isFirefoxDomPermissionDeniedMessage(error.message)
+}
+
+export function isFirefoxDomPermissionDeniedSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isFirefoxDomPermissionDeniedError(originalException)) return true
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isFirefoxDomPermissionDeniedMessage(message),
+	)
+}
+
+export function filterFirefoxDomPermissionDeniedSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isFirefoxDomPermissionDeniedSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
+/** Combined browser beforeSend / capture gate used by the client SDK. */
+export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
+	event: T,
+	originalException?: unknown,
+): T | null {
+	if (filterBrowserAbortSentryEvent(event, originalException) === null) {
+		return null
+	}
+	if (
+		filterFirefoxDomPermissionDeniedSentryEvent(event, originalException) ===
+		null
+	) {
+		return null
+	}
+	return event
+}

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -1,7 +1,8 @@
 import * as Sentry from '@sentry/browser'
 import {
-	filterBrowserAbortSentryEvent,
+	filterBrowserSentryEvent,
 	isBrowserAbortError,
+	isFirefoxDomPermissionDeniedError,
 } from '#client/sentry-browser-filters.ts'
 import {
 	parseSentryClientConfig,
@@ -46,11 +47,11 @@ export function initSentryClient(doc: Document) {
 			// happens.
 			replaysSessionSampleRate: 0,
 			replaysOnErrorSampleRate: 1.0,
-			// Superseded SPA navigations and user-driven aborts reject in-flight
-			// fetches with AbortError. Those are expected and not actionable —
-			// see filterBrowserAbortSentryEvent / KODY-CLOUDFLARE-23.
+			// Drop expected browser noise (AbortError aborts, Firefox DOM
+			// permission-denied from Replay/hydration on restricted nodes) —
+			// see filterBrowserSentryEvent / KODY-CLOUDFLARE-23 / issue 7639685398.
 			beforeSend(event, hint) {
-				return filterBrowserAbortSentryEvent(event, hint.originalException)
+				return filterBrowserSentryEvent(event, hint.originalException)
 			},
 		})
 		return true
@@ -63,6 +64,7 @@ export function initSentryClient(doc: Document) {
 /** Report a caught client error without letting reporting itself throw. */
 export function captureClientException(error: unknown) {
 	if (isBrowserAbortError(error)) return
+	if (isFirefoxDomPermissionDeniedError(error)) return
 	try {
 		Sentry.captureException(error)
 	} catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry

- Issue: [7639685398](https://kent-c-dodds-tech-llc.sentry.io/issues/7639685398/) — `Error: Permission denied to access property "childNodes"`
- Culprit: `Qc(client-entry)` (Remix hydration error handler in `entry.tsx`)
- Single production event: Firefox 153 / Ubuntu on `https://heykody.dev/`

## Root cause

Not an app logic bug. Breadcrumbs on the event show, in the same millisecond:

1. Sentry Replay (`@sentry/replay`) logging `Cannot get CSS styles from text's parentNode` (cross-origin stylesheet)
2. `Permission denied to access property "nodeType"` with stack ending in Replay `startRecording`
3. Remix `app` error event: `Client hydration error: Permission denied to access property "childNodes"`

Firefox denies content-compartment access to some DOM properties when Session Replay (and/or an extension) touches Xray-wrapped / cross-origin nodes. Same class as [getsentry/sentry-javascript#15559](https://github.com/getsentry/sentry-javascript/issues/15559). Not reasonably fixable in Kody code — filter like AbortError.

Sibling [KODY-CLOUDFLARE-17](https://kent-c-dodds-tech-llc.sentry.io/issues/7631270155/) (`updateCurrentEntry`) is a different root cause and already covered by open [#998](https://github.com/kentcdodds/kody/pull/998) — left alone.

## Fix

Narrow `beforeSend` / `captureClientException` drop for the Firefox wording `Permission denied to access property "…"`. Combined into `filterBrowserSentryEvent` with the existing AbortError filter. Unit tests cover the production signature and ensure broader `SecurityError` / bare `Permission denied` still report.

## Status

- Outcome: **filtered**
- Squash-merged: `b7522594` (#1006)
- Production deploy: success ([run](https://github.com/kentcdodds/kody/actions/runs/30434083221))
- Sentry issue: ignored

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `76bac57a` · **Head:** `22bd40f8`

**Classification:** composes — no primitives added or reshaped; client Sentry `beforeSend` gains one narrow drop predicate.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — browser Sentry filter only; no UI or hydration contract change |

### System map

Client-entry error reporting drops Firefox DOM permission-denied noise before envelopes hit the tunnel.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	sentryTunnel["sentry-tunnel<br/>Same-origin error reporting"]:::untouched
	appUi -->|"filterBrowserSentryEvent drops Firefox Permission denied to access property"| sentryTunnel
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Event | Before | After |
| --- | --- | --- |
| `Permission denied to access property "childNodes"` (Firefox) | Reported via Remix hydration `error` → Sentry | Dropped in `beforeSend` / `captureClientException` |
| Real `TypeError` / network failures | Reported | Unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a62dd857-610c-4e3a-ab04-10de93a0b67b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a62dd857-610c-4e3a-ab04-10de93a0b67b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced Sentry noise by filtering expected Firefox cross-origin permission errors.
  * Continued filtering browser abort errors from error reporting.
  * Preserved reporting for unrelated, actionable exceptions.
* **Tests**
  * Added coverage for Firefox permission-denied error variants and combined browser error filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->