### PR TITLE
Filter deploy-time Durable Object code-update resets from Sentry

### DIFF
--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { isUserCodeError, UserCodeError } from './user-code-error.ts'
 import {
+	durableObjectCodeUpdatedResetMessage,
 	durableObjectIsolateCpuResetMessage,
 	durableObjectIsolateMemoryResetMessage,
 	executorSandboxTimeoutMessage,
@@ -186,9 +187,10 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	).toBe(platformEvent)
 	expect(filterSentryEvent(platformEvent)).toBe(platformEvent)
 
-	// Bare Cloudflare DO isolate resets (memory / CPU) are transient platform
-	// limit hits — drop exact strings, including optional `Error:` prefix and
-	// missing trailing period. Wrapped recovery failures must stay visible.
+	// Bare Cloudflare DO platform resets (memory / CPU / deploy-time code
+	// update) are transient — drop exact strings, including optional `Error:`
+	// prefix and missing trailing period. Wrapped recovery failures must stay
+	// visible.
 	expect(
 		filterSentryEvent({
 			exception: {
@@ -224,6 +226,35 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 			message: durableObjectIsolateCpuResetMessage,
 		}),
 	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [{ value: durableObjectCodeUpdatedResetMessage }],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: `Error: ${durableObjectCodeUpdatedResetMessage}`,
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: 'Durable Object reset because its code was updated',
+					},
+				],
+			},
+		}),
+	).toBeNull()
 
 	const exhaustedPublishRecoveryInline = {
 		exception: {
@@ -251,6 +282,19 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	}
 	expect(filterSentryEvent(exhaustedPublishRecoveryChained)).toBe(
 		exhaustedPublishRecoveryChained,
+	)
+
+	const exhaustedCodeUpdateRecovery = {
+		exception: {
+			values: [
+				{
+					value: `package_publish_external_push could not recover after 3 transient Durable Object reset attempts: ${durableObjectCodeUpdatedResetMessage}`,
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(exhaustedCodeUpdateRecovery)).toBe(
+		exhaustedCodeUpdateRecovery,
 	)
 
 	const unrelatedDoFailure = {

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -82,19 +82,24 @@ export function filterExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
 }
 
 /**
- * Exact Cloudflare Durable Object isolate-reset messages. When a DO hits its
- * memory or CPU limit, the platform resets the isolate and surfaces this error
- * to the RPC caller (for example `job_run_now` → JobManager). The next call
- * gets a fresh isolate; app-level retry is unsafe for non-idempotent jobs, and
- * moving heavy orchestration off JobManager is an architectural change outside
- * a triage fix. Match only the bare platform strings so wrapped failures such
- * as exhausted `package_publish_external_push` recovery messages stay visible.
+ * Exact Cloudflare Durable Object platform-reset messages. When a DO hits its
+ * memory or CPU limit, or when a deploy replaces DO code under an in-flight
+ * RPC/alarm (for example cron `oauth_purge_expired` → OAuthPurgeCoordinator),
+ * the platform resets the isolate and surfaces one of these errors to the
+ * caller. The next call gets a fresh isolate; app-level retry is unsafe for
+ * non-idempotent jobs, and moving heavy orchestration off JobManager is an
+ * architectural change outside a triage fix. Match only the bare platform
+ * strings so wrapped failures such as exhausted
+ * `package_publish_external_push` recovery messages stay visible.
  */
 export const durableObjectIsolateMemoryResetMessage =
 	"Durable Object's isolate exceeded its memory limit and was reset."
 
 export const durableObjectIsolateCpuResetMessage =
 	'Durable Object exceeded its CPU time limit and was reset.'
+
+export const durableObjectCodeUpdatedResetMessage =
+	'Durable Object reset because its code was updated.'
 
 function normalizeDurableObjectIsolateResetMessage(message: string) {
 	const withoutErrorPrefix = message.trim().replace(/^Error:\s*/i, '')
@@ -107,7 +112,8 @@ export function isDurableObjectIsolateResetMessage(message: string) {
 	const normalized = normalizeDurableObjectIsolateResetMessage(message)
 	return (
 		normalized === durableObjectIsolateMemoryResetMessage ||
-		normalized === durableObjectIsolateCpuResetMessage
+		normalized === durableObjectIsolateCpuResetMessage ||
+		normalized === durableObjectCodeUpdatedResetMessage
 	)
 }
 
@@ -172,8 +178,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// matches remain as backstops for unmarked paths; see
 		// filterUserModuleBundlerFailureSentryEvent and
 		// filterExecutorSandboxTimeoutSentryEvent. Bare Cloudflare Durable
-		// Object isolate memory/CPU reset strings are dropped the same way —
-		// see filterDurableObjectIsolateResetSentryEvent.
+		// Object platform reset strings (memory/CPU limits and deploy-time
+		// code updates) are dropped the same way — see
+		// filterDurableObjectIsolateResetSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry

- Issue: [7639714312](https://kent-c-dodds-tech-llc.sentry.io/issues/7639714312/) / [KODY-CLOUDFLARE-2N](https://kent-c-dodds-tech-llc.sentry.io/issues/7639714312/) — `Error: Durable Object reset because its code was updated.`
- Culprit: `Object.scheduled(index)` · tag `scheduled.lane=oauth_purge_expired`
- Single production event on release `76bac57a` (deploy-window noise)

## Root cause

Not an application logic bug. Cloudflare resets Durable Object isolates when a deploy replaces DO code under an in-flight RPC/alarm. The scheduled `oauth_purge_expired` lane called into a DO mid-deploy and got the bare platform string; `scheduled_lane_failed` captured it via `Sentry.captureException`.

Memory/CPU isolate resets are already dropped by `filterDurableObjectIsolateResetSentryEvent`. This deploy-time wording was missing from that exact-match allowlist, so it still opened issues. Sibling [KODY-CLOUDFLARE-17](https://kent-c-dodds-tech-llc.sentry.io/issues/7631270155/) (`updateCurrentEntry`) is a different root cause and already covered by open [#998](https://github.com/kentcdodds/kody/pull/998) — left alone.

## Fix

Add `durableObjectCodeUpdatedResetMessage` to the existing DO platform-reset `beforeSend` filter (same normalize path: optional `Error:` prefix / missing trailing period). Wrapped recovery failures still report. Unit tests cover the production signature.

## Status

- Outcome: **filtered**
- Squash-merged: `7a5e752` (#1007)
- Production deploy: success ([run](https://github.com/kentcdodds/kody/actions/runs/30435276021))
- Sentry issue: ignored

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b7522594` · **Head:** `cbde4b12`

**Classification:** composes — no primitives added or reshaped; worker Sentry `beforeSend` gains one exact-message drop for deploy-time DO resets. Paths are outside the primitives taxonomy (`packages/worker/src/sentry-options.ts`).

### Primitives touched

_None matched by classifier. Observability wiring only._

### System map

Scheduled-lane DO RPC failures that are bare deploy-time reset strings are dropped before the Sentry envelope is sent.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::untouched
	sentryOpts["worker Sentry beforeSend<br/>sentry-options.ts"]:::touched
	scheduledCron -->|"oauth_purge_expired DO reset string"| sentryOpts
	sentryOpts -->|"filterDurableObjectIsolateResetSentryEvent drops code-updated reset"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Event | Before | After |
| --- | --- | --- |
| `Durable Object reset because its code was updated.` | Reported via `scheduled_lane_failed` → Sentry | Dropped in `beforeSend` |
| Exhausted publish DO-reset recovery wrapper | Reported | Unchanged |
| Real DO / scheduled failures | Reported | Unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24473151-6783-457b-9e2e-4e3d694f563e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24473151-6783-457b-9e2e-4e3d694f563e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reporting by filtering expected Durable Object resets that occur after code updates.
  * Improved recognition of reset messages with optional `Error:` prefixes or missing trailing periods.
  * Continued reporting failures when Durable Objects cannot recover after repeated reset attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->