### PR TITLE
Fix aggregate storage entitlement usage across buckets

### DIFF
--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -603,17 +603,26 @@ export async function assertStorageRunnerWriteWithinEntitlement(input: {
 				offset < storageIds.length;
 				offset += maxConcurrentStorageEstimateReads
 			) {
-				const estimates = await Promise.all(
-					storageIds
-						.slice(offset, offset + maxConcurrentStorageEstimateReads)
-						.map((storageId) =>
-							storageRunnerRpc({
-								env: input.env,
-								userId: input.userId,
-								storageId,
-							}).getEstimatedBytes(),
-						),
-				)
+				let estimates: Array<StorageEstimateResult>
+				try {
+					estimates = await Promise.all(
+						storageIds
+							.slice(offset, offset + maxConcurrentStorageEstimateReads)
+							.map((storageId) =>
+								storageRunnerRpc({
+									env: input.env,
+									userId: input.userId,
+									storageId,
+								}).getEstimatedBytes(),
+							),
+					)
+				} catch (error) {
+					// An unreadable bucket cannot safely be treated as zero usage.
+					throw new Error(
+						'Unable to verify the storage byte entitlement because a bucket estimate could not be read.',
+						{ cause: error },
+					)
+				}
 				durableObjectBytes += estimates.reduce(
 					(total, estimate) => total + estimate.estimatedBytes,
 					0,

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -8,6 +8,7 @@ import {
 	readUserD1StorageBytes,
 } from '#worker/entitlements/service.ts'
 import {
+	listUserStorageBucketIds,
 	registerStorageBucket,
 	storageBucketKindFromStorageId,
 } from '#worker/storage-buckets/service.ts'
@@ -15,6 +16,7 @@ import { storageRunnerDurableObjectName } from '#worker/user-scoped-durable-obje
 
 const defaultStorageExportPageSize = 250
 const maxStorageExportPageSize = 1_000
+const maxConcurrentStorageEstimateReads = 16
 
 type StorageEntry = {
 	key: string
@@ -571,21 +573,54 @@ export async function assertStorageRunnerWriteWithinEntitlement(input: {
 	storageId: string
 	requested?: number
 }) {
-	const runner = storageRunnerRpc({
-		env: input.env,
-		userId: input.userId,
-		storageId: input.storageId,
-	})
 	await assertWithinStorageBytesEntitlement({
 		db: input.env.APP_DB,
 		userId: input.userId,
 		email: input.email,
 		requested: input.requested,
-		getCurrent: async () =>
-			(await readUserD1StorageBytes({
-				db: input.env.APP_DB,
-				userId: input.userId,
-			})) + (await runner.getEstimatedBytes()).estimatedBytes,
+		getCurrent: async () => {
+			const [d1Bytes, registeredStorageIds] = await Promise.all([
+				readUserD1StorageBytes({
+					db: input.env.APP_DB,
+					userId: input.userId,
+				}),
+				listUserStorageBucketIds({
+					env: input.env,
+					userId: input.userId,
+				}),
+			])
+			// Registration is asynchronous, so include the bucket being written even
+			// when its inventory row has not landed yet. The Set avoids double-counting
+			// once it is registered. Estimate reads are batched to cap concurrent DO
+			// fan-out; total work remains O(bucket count) so every inventoried bucket is
+			// counted exactly. Bucket inventories are expected to remain small.
+			const storageIds = [
+				...new Set([...registeredStorageIds, input.storageId]),
+			]
+			let durableObjectBytes = 0
+			for (
+				let offset = 0;
+				offset < storageIds.length;
+				offset += maxConcurrentStorageEstimateReads
+			) {
+				const estimates = await Promise.all(
+					storageIds
+						.slice(offset, offset + maxConcurrentStorageEstimateReads)
+						.map((storageId) =>
+							storageRunnerRpc({
+								env: input.env,
+								userId: input.userId,
+								storageId,
+							}).getEstimatedBytes(),
+						),
+				)
+				durableObjectBytes += estimates.reduce(
+					(total, estimate) => total + estimate.estimatedBytes,
+					0,
+				)
+			}
+			return d1Bytes + durableObjectBytes
+		},
 	})
 }
 

--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -3,6 +3,7 @@ import { runInDurableObject } from 'cloudflare:test'
 import { expect, test } from 'vitest'
 import { EntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
+import { readUserD1StorageBytes } from '#worker/entitlements/service.ts'
 import { ensureEntitlementTestSchema } from '#worker/entitlements/test-schema.ts'
 import {
 	clearStorageBucketRegistrationDedupeForTests,
@@ -12,6 +13,7 @@ import {
 import { ensureUserStorageBucketsTestSchema } from '#worker/storage-buckets/test-schema.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import {
+	assertStorageRunnerWriteWithinEntitlement,
 	createStorageKodyTools,
 	createExecuteStorageId,
 	StorageRunner,
@@ -236,6 +238,87 @@ test('storage runner write tools enforce storage byte entitlements for planned u
 			value: 'new-value',
 		}),
 	).resolves.toEqual({ ok: true, key: 'new-key' })
+})
+
+test('storage runner storage byte entitlement aggregates only inventoried user buckets', async () => {
+	await ensureStorageBytesEmailTestSchema()
+	clearStorageBucketRegistrationDedupeForTests()
+	const limit = planLimits.pro.maxStorageBytes
+	const email = `storage-aggregate-${crypto.randomUUID()}@example.com`
+	const userId = await seedPlannedStorageUser({
+		email,
+		plan: 'pro',
+		rawSize: 0,
+	})
+	const storageIdA = createExecuteStorageId()
+	const storageIdB = createExecuteStorageId()
+	const runnerA = storageRunnerRpc({ env, userId, storageId: storageIdA })
+	const runnerB = storageRunnerRpc({ env, userId, storageId: storageIdB })
+	await runnerA.setValue({ key: 'first-bucket', value: 'stored bytes' })
+	await runnerB.setValue({ key: 'second-bucket', value: 'stored bytes' })
+	await flushStorageBucketRegistrationsForTests()
+	await expect(listUserStorageBucketIds({ env, userId })).resolves.toEqual(
+		[storageIdA, storageIdB].sort(),
+	)
+
+	const estimateA = (await runnerA.getEstimatedBytes()).estimatedBytes
+	const estimateB = (await runnerB.getEstimatedBytes()).estimatedBytes
+	const initialD1Bytes = await readUserD1StorageBytes({
+		db: env.APP_DB,
+		userId,
+	})
+	const targetD1Bytes = limit - estimateB - 1
+	await env.APP_DB.prepare(
+		`UPDATE email_messages SET raw_size = ? WHERE user_id = ?`,
+	)
+		.bind(targetD1Bytes - initialD1Bytes, userId)
+		.run()
+
+	const aggregateDenied = await assertStorageRunnerWriteWithinEntitlement({
+		env,
+		userId,
+		email,
+		storageId: storageIdB,
+		requested: 1,
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(aggregateDenied instanceof EntitlementLimitError)) {
+		throw new Error(
+			'Expected aggregate bucket usage to exceed the entitlement.',
+		)
+	}
+	expect(aggregateDenied.details).toMatchObject({
+		resource: 'storage_bytes',
+		limit,
+		current: targetD1Bytes + estimateA + estimateB,
+	})
+
+	// The first bucket still exists physically, but removing its ownership row
+	// makes it ineligible for this user's aggregate. The remaining single bucket
+	// is exactly at the allowed boundary and retains the previous behavior.
+	await env.APP_DB.prepare(
+		`DELETE FROM user_storage_buckets WHERE user_id = ? AND storage_id = ?`,
+	)
+		.bind(userId, storageIdA)
+		.run()
+	await expect(listUserStorageBucketIds({ env, userId })).resolves.toEqual([
+		storageIdB,
+	])
+	await expect(
+		assertStorageRunnerWriteWithinEntitlement({
+			env,
+			userId,
+			email,
+			storageId: storageIdB,
+			requested: 1,
+		}),
+	).resolves.toBeUndefined()
+	await expect(runnerA.getValue({ key: 'first-bucket' })).resolves.toEqual({
+		key: 'first-bucket',
+		value: 'stored bytes',
+	})
 })
 
 test('storage runner supports raw SQL with explicit writable access', async () => {

--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -263,6 +263,8 @@ test('storage runner storage byte entitlement aggregates only inventoried user b
 
 	const estimateA = (await runnerA.getEstimatedBytes()).estimatedBytes
 	const estimateB = (await runnerB.getEstimatedBytes()).estimatedBytes
+	expect(estimateA).toBeGreaterThan(0)
+	expect(estimateB).toBeGreaterThan(0)
 	const initialD1Bytes = await readUserD1StorageBytes({
 		db: env.APP_DB,
 		userId,
@@ -273,6 +275,9 @@ test('storage runner storage byte entitlement aggregates only inventoried user b
 	)
 		.bind(targetD1Bytes - initialD1Bytes, userId)
 		.run()
+	await expect(
+		readUserD1StorageBytes({ db: env.APP_DB, userId }),
+	).resolves.toBe(targetD1Bytes)
 
 	const aggregateDenied = await assertStorageRunnerWriteWithinEntitlement({
 		env,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- count every inventoried StorageRunner bucket when enforcing `storage_bytes`
- include the current bucket before asynchronous registration completes, without double-counting it
- cap concurrent Durable Object estimate reads at 16 while retaining exact aggregate accounting
- fail closed with an explicit entitlement-verification error if any bucket estimate is unreadable
- cover aggregate denial, unchanged single-bucket boundary behavior, and unregistered bucket exclusion

## Testing

- `npm run test:workers -- --run packages/worker/src/storage-runner.workers.test.ts` (8 tests passed)
- `npm run validate` (passed before and after AI review fixes)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6620d1b3` · **Head:** `69ff2f95`

**Classification:** extends — storage entitlement enforcement now aggregates every bucket in the per-user durable storage inventory.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `durable-storage` | assistant | extends — quota checks aggregate all inventoried bucket estimates |

### System map

A storage write reads the acting user's bucket inventory, obtains bounded-concurrency estimates from those user-scoped Durable Objects, and combines them with D1 usage before enforcement.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	inventory["d1-app-db<br/>Per-user bucket inventory"]:::untouched
	storage["durable-storage<br/>Durable storage buckets"]:::extended
	entitlement["entitlements<br/>Resource enforcement"]:::untouched
	inventory -->|"user_id-scoped storage IDs"| storage
	storage -->|"batched estimated-byte total"| entitlement
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Every inventory query and Durable Object name remains scoped by `userId`.
- Unregistered buckets are excluded unless they are the current bucket being written; the current bucket is deduplicated after registration.
- Concurrent estimate fan-out is capped at 16 while all inventoried buckets remain counted.
- Unreadable estimates fail entitlement verification closed rather than being treated as zero usage.

</details>

<!-- system-recap:end -->

## Conductor Report

STATUS: done

What changed: storage-byte entitlement checks now sum D1 bytes plus every inventoried per-user StorageRunner bucket, with the current bucket included and deduplicated during registration races. Durable Object estimate reads run in batches of at most 16 and fail closed with an explicit verification error if unreadable.

Tests run: focused Workers suite passed (8/8). `npm run validate` passed twice, including after AI review fixes; formatting, lint, typecheck, Node/Workers tests, Playwright E2E, MCP E2E, backup build, primitives, and migrations checks are green.

Blocker: none.

Scope spill: none.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-529a9de0-cfe7-4319-8b9c-0efc8e76a174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-529a9de0-cfe7-4319-8b9c-0efc8e76a174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Storage entitlement checks now aggregate current storage usage across all inventoried storage buckets a user owns, instead of only the bucket being written.
  * Writes are blocked more reliably when the combined storage footprint would exceed the user’s entitlement.
  * Buckets removed from the ownership inventory are excluded from entitlement calculations, while previously stored data remains readable.
* **Tests**
  * Added coverage to verify entitlement aggregation behavior across multiple inventoried buckets and correct exclusion after inventory removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->