### PR TITLE
Deduplicate client route state helpers

### DIFF
--- a/packages/worker/client/double-check.node.test.ts
+++ b/packages/worker/client/double-check.node.test.ts
@@ -72,4 +72,15 @@ test('double check button mix requires two clicks, resets on blur, then invokes 
 	expect(action).toHaveBeenCalledTimes(1)
 	expect(firstClickAction).toHaveBeenCalledTimes(2)
 	expect(doubleCheck.doubleCheck).toBe(false)
+
+	const persistentCheck = createDoubleCheck(handle as never)
+	const persistentAction = vi.fn()
+	const persistentMix = persistentCheck.getButtonMix({
+		on: { click: persistentAction },
+		resetAfterAction: false,
+	})
+	invoke(persistentMix[1], { preventDefault: vi.fn() } as unknown as Event)
+	invoke(persistentMix[1], { preventDefault: vi.fn() } as unknown as Event)
+	expect(persistentAction).toHaveBeenCalledTimes(1)
+	expect(persistentCheck.doubleCheck).toBe(true)
 })

--- a/packages/worker/client/double-check.node.test.ts
+++ b/packages/worker/client/double-check.node.test.ts
@@ -26,11 +26,13 @@ function invoke(mixin: unknown, event: Event) {
 test('double check button mix requires two clicks, resets on blur, then invokes action', () => {
 	const handle = { update: vi.fn() }
 	const action = vi.fn()
+	const firstClickAction = vi.fn()
 	const doubleCheck = createDoubleCheck(handle as never)
 	const mix = doubleCheck.getButtonMix({
 		on: {
 			click: action,
 		},
+		onFirstClick: firstClickAction,
 	})
 
 	expect(mix).toHaveLength(2)
@@ -45,6 +47,7 @@ test('double check button mix requires two clicks, resets on blur, then invokes 
 	expect(firstClick.preventDefault).toHaveBeenCalled()
 	expect(doubleCheck.doubleCheck).toBe(true)
 	expect(action).not.toHaveBeenCalled()
+	expect(firstClickAction).toHaveBeenCalledTimes(1)
 
 	invoke(mix[0], new Event('blur'))
 	expect(doubleCheck.doubleCheck).toBe(false)
@@ -58,6 +61,7 @@ test('double check button mix requires two clicks, resets on blur, then invokes 
 	expect(thirdClick.preventDefault).toHaveBeenCalled()
 	expect(doubleCheck.doubleCheck).toBe(true)
 	expect(action).not.toHaveBeenCalled()
+	expect(firstClickAction).toHaveBeenCalledTimes(2)
 
 	const fourthClick = {
 		preventDefault: vi.fn(),
@@ -66,5 +70,6 @@ test('double check button mix requires two clicks, resets on blur, then invokes 
 
 	expect(fourthClick.preventDefault).not.toHaveBeenCalled()
 	expect(action).toHaveBeenCalledTimes(1)
+	expect(firstClickAction).toHaveBeenCalledTimes(2)
 	expect(doubleCheck.doubleCheck).toBe(false)
 })

--- a/packages/worker/client/double-check.ts
+++ b/packages/worker/client/double-check.ts
@@ -9,6 +9,7 @@ type ButtonLikeProps = {
 		blur?: BlurHandler
 		click?: ClickHandler
 	}
+	onFirstClick?: ClickHandler
 	[key: string]: unknown
 }
 
@@ -48,6 +49,7 @@ export function createDoubleCheck(handle: Handle) {
 			const onClick: ClickHandler = (event) => {
 				if (!doubleCheck) {
 					event.preventDefault()
+					buttonProps.onFirstClick?.(event)
 					setDoubleCheck(true)
 					return
 				}

--- a/packages/worker/client/double-check.ts
+++ b/packages/worker/client/double-check.ts
@@ -10,6 +10,7 @@ type ButtonLikeProps = {
 		click?: ClickHandler
 	}
 	onFirstClick?: ClickHandler
+	resetAfterAction?: boolean
 	[key: string]: unknown
 }
 
@@ -55,7 +56,9 @@ export function createDoubleCheck(handle: Handle) {
 				}
 
 				buttonProps.on?.click?.(event)
-				setDoubleCheck(false)
+				if (buttonProps.resetAfterAction !== false) {
+					setDoubleCheck(false)
+				}
 			}
 
 			return [

--- a/packages/worker/client/list-detail-route.node.test.ts
+++ b/packages/worker/client/list-detail-route.node.test.ts
@@ -2,6 +2,12 @@ import { expect, test } from 'vitest'
 import { createListDetailRoute } from './list-detail-route.ts'
 
 const mcpServersRoute = createListDetailRoute('/account/mcp-servers')
+const nestedRoute = createListDetailRoute('/account/secrets', {
+	parseDetailId(pathname) {
+		const match = /^\/account\/secrets\/user\/([^/]+)$/.exec(pathname)
+		return match?.[1] ? decodeURIComponent(match[1]) : null
+	},
+})
 
 test('list-detail route helper supports the URL-backed list/detail workflow', () => {
 	expect(mcpServersRoute.isRoutePath('/account/mcp-servers')).toBe(true)
@@ -59,4 +65,17 @@ test('list-detail route helper supports the URL-backed list/detail workflow', ()
 	expect(mcpServersRoute.buildDetailHref('server 1', '?q=docs')).toBe(
 		'/account/mcp-servers/server%201?q=docs',
 	)
+
+	expect(nestedRoute.getSelection('/account/secrets/new')).toEqual({
+		selectedId: null,
+		isCreating: true,
+	})
+	expect(nestedRoute.getSelection('/account/secrets/user/api%20key')).toEqual({
+		selectedId: 'api key',
+		isCreating: false,
+	})
+	expect(nestedRoute.getSelection('/account/secrets/approve')).toEqual({
+		selectedId: null,
+		isCreating: false,
+	})
 })

--- a/packages/worker/client/list-detail-route.ts
+++ b/packages/worker/client/list-detail-route.ts
@@ -13,11 +13,18 @@ export type ListDetailSelection = {
 	isCreating: boolean
 }
 
+type ListDetailRouteOptions = {
+	parseDetailId?: (pathname: string) => string | null
+}
+
 function appendSearch(pathname: string, search?: string) {
 	return `${pathname}${search ?? ''}`
 }
 
-export function createListDetailRoute(basePath: string) {
+export function createListDetailRoute(
+	basePath: string,
+	options: ListDetailRouteOptions = {},
+) {
 	const newPath = `${basePath}/new`
 	const detailPrefix = `${basePath}/`
 
@@ -32,6 +39,12 @@ export function createListDetailRoute(basePath: string) {
 			return {
 				selectedId: null,
 				isCreating: true,
+			}
+		}
+		if (options.parseDetailId) {
+			return {
+				selectedId: options.parseDetailId(pathname),
+				isCreating: false,
 			}
 		}
 		if (!pathname.startsWith(detailPrefix)) {

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -2,6 +2,7 @@ import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { createDoubleCheck } from '#client/double-check.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
@@ -237,7 +238,7 @@ export function AccountJobsRoute(handle: Handle) {
 	let message: string | null = null
 	let messageTone: MessageTone = 'info'
 	const loadLatch = createRouteLoadLatch()
-	let deleteConfirm = false
+	const deleteJobCheck = createDoubleCheck(handle)
 	let editState: EditState | null = null
 	let editing = false
 
@@ -289,7 +290,7 @@ export function AccountJobsRoute(handle: Handle) {
 		jobs = payload.jobs
 		selectedJob = payload.selectedJob
 		applyRetention(payload.retention)
-		deleteConfirm = false
+		deleteJobCheck.reset()
 		editing = false
 		editState = payload.selectedJob
 			? createEditState(payload.selectedJob)
@@ -702,7 +703,7 @@ export function AccountJobsRoute(handle: Handle) {
 													disabled={isMutating}
 													onClick={() => {
 														if (isMutating) return
-														deleteConfirm = false
+														deleteJobCheck.reset()
 														editing = false
 														setMessage(null)
 														navigate(
@@ -1373,27 +1374,25 @@ export function AccountJobsRoute(handle: Handle) {
 											type="button"
 											disabled={isMutating}
 											mix={[
-												on('click', () => {
-													if (!deleteConfirm) {
-														deleteConfirm = true
-														handle.update()
-														return
-													}
-													void postAction({
-														body: { action: 'delete', id: detail.id },
-														successMessage: () => 'Deleted job.',
-														failureMessage: 'Unable to delete job.',
-														afterSuccess: () => {
-															navigate(
-																jobsRoute.buildListHref(getCurrentSearch()),
-															)
-														},
-													})
+												...deleteJobCheck.getButtonMix({
+													on: {
+														click: () =>
+															void postAction({
+																body: { action: 'delete', id: detail.id },
+																successMessage: () => 'Deleted job.',
+																failureMessage: 'Unable to delete job.',
+																afterSuccess: () => {
+																	navigate(
+																		jobsRoute.buildListHref(getCurrentSearch()),
+																	)
+																},
+															}),
+													},
 												}),
 												css(dangerButtonCss),
 											]}
 										>
-											{deleteConfirm ? 'Confirm delete' : 'Delete'}
+											{deleteJobCheck.doubleCheck ? 'Confirm delete' : 'Delete'}
 										</button>
 									) : null}
 								</div>

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -1388,6 +1388,7 @@ export function AccountJobsRoute(handle: Handle) {
 																},
 															}),
 													},
+													resetAfterAction: false,
 												}),
 												css(dangerButtonCss),
 											]}

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -2,6 +2,7 @@ import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { createDoubleCheck } from '#client/double-check.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
@@ -180,7 +181,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 	let message: string | null = null
 	let messageTone: MessageTone = 'info'
 	const loadLatch = createRouteLoadLatch()
-	let deleteConfirm = false
+	const deleteServerCheck = createDoubleCheck(handle)
 	let oauthResultConsumed = false
 
 	const primaryButtonCss = getPrimaryButtonCss()
@@ -217,7 +218,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 
 	function applyPayload(payload: AccountMcpServersPayload) {
 		servers = payload.servers
-		deleteConfirm = false
+		deleteServerCheck.reset()
 	}
 
 	async function loadServers(signal: AbortSignal) {
@@ -405,7 +406,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 							mix={[
 								on('click', () => {
 									if (isMutating) return
-									deleteConfirm = false
+									deleteServerCheck.reset()
 									setMessage(null)
 									navigate(mcpServersRoute.buildNewHref(getCurrentSearch()))
 								}),
@@ -465,7 +466,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 													disabled={isMutating}
 													onClick={() => {
 														if (isMutating) return
-														deleteConfirm = false
+														deleteServerCheck.reset()
 														setMessage(null)
 														navigate(
 															mcpServersRoute.buildDetailHref(
@@ -763,27 +764,29 @@ export function AccountMcpServersRoute(handle: Handle) {
 										type="button"
 										disabled={isMutating}
 										mix={[
-											on('click', () => {
-												if (!deleteConfirm) {
-													deleteConfirm = true
-													handle.update()
-													return
-												}
-												void postAction({
-													body: { action: 'delete', id: server.id },
-													successMessage: () => 'Removed MCP server.',
-													failureMessage: 'Unable to remove MCP server.',
-													afterSuccess: () => {
-														navigate(
-															mcpServersRoute.buildListHref(getCurrentSearch()),
-														)
-													},
-												})
+											...deleteServerCheck.getButtonMix({
+												on: {
+													click: () =>
+														void postAction({
+															body: { action: 'delete', id: server.id },
+															successMessage: () => 'Removed MCP server.',
+															failureMessage: 'Unable to remove MCP server.',
+															afterSuccess: () => {
+																navigate(
+																	mcpServersRoute.buildListHref(
+																		getCurrentSearch(),
+																	),
+																)
+															},
+														}),
+												},
 											}),
 											css(dangerButtonCss),
 										]}
 									>
-										{deleteConfirm ? 'Confirm remove' : 'Remove'}
+										{deleteServerCheck.doubleCheck
+											? 'Confirm remove'
+											: 'Remove'}
 									</button>
 								</div>
 							</section>

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -780,6 +780,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 															},
 														}),
 												},
+												resetAfterAction: false,
 											}),
 											css(dangerButtonCss),
 										]}

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -12,6 +12,7 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { createDoubleCheck } from '#client/double-check.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
@@ -349,7 +350,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 	let lastNewTokenQueryKey = ''
 	let mutationVersion = 0
 	let revokeConfirm = false
-	let deleteConfirm = false
+	const deleteTokenCheck = createDoubleCheck(handle)
 	let editMode = false
 
 	const primaryButtonCss = getPrimaryButtonCss()
@@ -447,7 +448,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		packages = payload.packages
 		tokens = payload.tokens
 		revokeConfirm = false
-		deleteConfirm = false
+		deleteTokenCheck.reset()
 		if (payload.selectedTokenId) {
 			selectedTokenId = payload.selectedTokenId
 			const selectedToken = tokens.find(
@@ -543,7 +544,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		editorState = createEmptyEditorState()
 		selectedTokenId = null
 		revokeConfirm = false
-		deleteConfirm = false
+		deleteTokenCheck.reset()
 		editMode = false
 		message = null
 		messageTone = 'info'
@@ -560,7 +561,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		selectedTokenId = token.id
 		editMode = true
 		revokeConfirm = false
-		deleteConfirm = false
+		deleteTokenCheck.reset()
 		message = null
 		messageTone = 'info'
 		handle.update()
@@ -572,7 +573,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		editorState = createEmptyEditorState()
 		editMode = false
 		revokeConfirm = false
-		deleteConfirm = false
+		deleteTokenCheck.reset()
 		message = null
 		messageTone = 'info'
 		syncRouterLocation(
@@ -937,7 +938,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 			: createEditorStateFromToken(token)
 		lastNewTokenQueryKey = ''
 		revokeConfirm = false
-		deleteConfirm = false
+		deleteTokenCheck.reset()
 		editMode = !token.revokedAt
 		message = null
 		messageTone = 'info'
@@ -1625,7 +1626,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 												on('click', () => {
 													if (!revokeConfirm) {
 														revokeConfirm = true
-														deleteConfirm = false
+														deleteTokenCheck.reset()
 														handle.update()
 														return
 													}
@@ -1644,21 +1645,20 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 											type="button"
 											disabled={isMutating}
 											mix={[
-												on('click', () => {
-													if (!deleteConfirm) {
-														deleteConfirm = true
+												...deleteTokenCheck.getButtonMix({
+													onFirstClick: () => {
 														revokeConfirm = false
-														handle.update()
-														return
-													}
-													void deleteSelectedToken()
+													},
+													on: {
+														click: () => void deleteSelectedToken(),
+													},
 												}),
 												css(dangerButtonCss),
 											]}
 										>
 											{saveState === 'deleting'
 												? 'Deleting...'
-												: deleteConfirm
+												: deleteTokenCheck.doubleCheck
 													? 'Confirm permanent delete'
 													: 'Delete permanently'}
 										</button>
@@ -1782,7 +1782,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 														on('click', () => {
 															if (!revokeConfirm) {
 																revokeConfirm = true
-																deleteConfirm = false
+																deleteTokenCheck.reset()
 																handle.update()
 																return
 															}
@@ -1803,21 +1803,20 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 											type="button"
 											disabled={isMutating}
 											mix={[
-												on('click', () => {
-													if (!deleteConfirm) {
-														deleteConfirm = true
+												...deleteTokenCheck.getButtonMix({
+													onFirstClick: () => {
 														revokeConfirm = false
-														handle.update()
-														return
-													}
-													void deleteSelectedToken()
+													},
+													on: {
+														click: () => void deleteSelectedToken(),
+													},
 												}),
 												css(dangerButtonCss),
 											]}
 										>
 											{saveState === 'deleting'
 												? 'Deleting...'
-												: deleteConfirm
+												: deleteTokenCheck.doubleCheck
 													? 'Confirm permanent delete'
 													: 'Delete permanently'}
 										</button>

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -3,6 +3,7 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { createDoubleCheck } from '#client/double-check.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
@@ -393,7 +394,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 	let editorState = createEmptyEditorState()
 	let message: string | null = null
 	const loadLatch = createRouteLoadLatch()
-	let deleteConfirm = false
+	const deleteConnectorCheck = createDoubleCheck(handle)
 	let showSharedSecret = false
 	let syncedSelectionKey: string | null = null
 
@@ -433,7 +434,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 		const nextKey = selectionSyncKey(selection)
 		if (nextKey === syncedSelectionKey) return
 		syncedSelectionKey = nextKey
-		deleteConfirm = false
+		deleteConnectorCheck.reset()
 		showSharedSecret = false
 		if (selection.isCreating) {
 			editorState = createEmptyEditorState()
@@ -490,7 +491,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 		username = payload.username
 		connectorUrlOrigin = payload.connectorUrlOrigin
 		connectors = payload.connectors
-		deleteConfirm = false
+		deleteConnectorCheck.reset()
 		if (payload.selectedConnectorId) {
 			const selected = connectors.find(
 				(connector) => connector.id === payload.selectedConnectorId,
@@ -628,7 +629,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 			applyPayload(payload)
 			editorState = createEmptyEditorState()
 			syncedSelectionKey = 'none'
-			deleteConfirm = false
+			deleteConnectorCheck.reset()
 			saveState = 'idle'
 			message = 'Deleted remote connector.'
 			syncRouterLocation(
@@ -649,7 +650,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 		if (saveState !== 'idle') return
 		editorState = createEditorStateFromConnector(connector)
 		syncedSelectionKey = `id:${connector.id}`
-		deleteConfirm = false
+		deleteConnectorCheck.reset()
 		showSharedSecret = false
 		message = null
 		syncRouterLocation(
@@ -661,7 +662,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 	function startNewConnector() {
 		editorState = createEmptyEditorState()
 		syncedSelectionKey = 'new'
-		deleteConfirm = false
+		deleteConnectorCheck.reset()
 		showSharedSecret = false
 		message = null
 		syncRouterLocation(remoteConnectorsRoute.buildNewHref(getCurrentSearch()))
@@ -682,7 +683,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 		} else {
 			editorState = createEmptyEditorState()
 		}
-		deleteConfirm = false
+		deleteConnectorCheck.reset()
 		showSharedSecret = false
 		message = null
 		handle.update()
@@ -1143,20 +1144,17 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 											type="button"
 											disabled={isMutating}
 											mix={[
-												on('click', () => {
-													if (!deleteConfirm) {
-														deleteConfirm = true
-														handle.update()
-														return
-													}
-													void deleteConnector()
+												...deleteConnectorCheck.getButtonMix({
+													on: {
+														click: () => void deleteConnector(),
+													},
 												}),
 												css(dangerButtonCss),
 											]}
 										>
 											{saveState === 'deleting'
 												? 'Deleting...'
-												: deleteConfirm
+												: deleteConnectorCheck.doubleCheck
 													? 'Confirm delete'
 													: 'Delete'}
 										</button>

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -13,6 +13,10 @@ import {
 	parseAccountSecretPath,
 } from '@kody-internal/shared/account-secret-route.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import {
+	createListDetailRoute,
+	type ListDetailSelection,
+} from '#client/list-detail-route.ts'
 import { replaceLocation } from '#client/replace-location.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
@@ -82,11 +86,6 @@ type EditorState = {
 	allowedPackages: Array<string>
 }
 
-type SelectionState = {
-	selectedSecretId: string | null
-	isCreating: boolean
-}
-
 type SecretFilterScope = 'all' | 'user' | 'package'
 
 type SecretFilterState = {
@@ -96,11 +95,11 @@ type SecretFilterState = {
 }
 
 const secretsBasePath = '/account/secrets'
-
-function isAccountSecretsPath(href: string) {
-	const path = new URL(href, 'http://localhost').pathname
-	return path === secretsBasePath || path.startsWith(`${secretsBasePath}/`)
-}
+const secretsRoute = createListDetailRoute(secretsBasePath, {
+	parseDetailId(pathname) {
+		return parseAccountSecretPath(pathname)?.id ?? null
+	},
+})
 
 function formatRelativeTtl(ttlMs: number | null) {
 	if (ttlMs == null) return 'No expiry'
@@ -234,33 +233,6 @@ function createEditorStateFromSecret(secret: AccountSecretDetail): EditorState {
 	}
 }
 
-function getSelectionState(href: string): SelectionState {
-	const url = new URL(href, 'http://localhost')
-	if (url.pathname === `${secretsBasePath}/new`) {
-		return {
-			selectedSecretId: null,
-			isCreating: true,
-		}
-	}
-	if (url.pathname === `${secretsBasePath}/approve`) {
-		return {
-			selectedSecretId: null,
-			isCreating: false,
-		}
-	}
-	const parsedPath = parseAccountSecretPath(url.pathname)
-	if (parsedPath) {
-		return {
-			selectedSecretId: parsedPath.id,
-			isCreating: false,
-		}
-	}
-	return {
-		selectedSecretId: null,
-		isCreating: false,
-	}
-}
-
 function buildSecretsHref(pathname: string, search: string) {
 	return `${pathname}${search}`
 }
@@ -385,11 +357,11 @@ function buildSecretHref(
 }
 
 function buildNewSecretHref(search = '') {
-	return buildSecretsHref(`${secretsBasePath}/new`, search)
+	return secretsRoute.buildNewHref(search)
 }
 
 function buildBaseSecretsHref(search = '') {
-	return buildSecretsHref(secretsBasePath, search)
+	return secretsRoute.buildListHref(search)
 }
 
 function getDataRefreshKey(href: string) {
@@ -409,11 +381,11 @@ function getDataRefreshKey(href: string) {
 
 function buildSecretsApiRequestUrl(href: string) {
 	const pageUrl = new URL(href, 'http://localhost')
-	const selection = getSelectionState(href)
+	const selection = secretsRoute.getSelection(href)
 	const requestUrl = new URL(accountSecretsApiPath, 'http://localhost')
 	requestUrl.search = pageUrl.search
-	if (selection.selectedSecretId) {
-		requestUrl.searchParams.set('selected', selection.selectedSecretId)
+	if (selection.selectedId) {
+		requestUrl.searchParams.set('selected', selection.selectedId)
 	} else {
 		requestUrl.searchParams.delete('selected')
 	}
@@ -553,7 +525,7 @@ export function AccountSecretsRoute(handle: Handle) {
 		return `${nextUrl.pathname}${nextUrl.search}`
 	}
 
-	function syncEditorState(selection: SelectionState) {
+	function syncEditorState(selection: ListDetailSelection) {
 		deleteSecretCheck.reset()
 		showSecretValue = false
 		if (selection.isCreating) {
@@ -572,7 +544,7 @@ export function AccountSecretsRoute(handle: Handle) {
 
 	function applyPayload(
 		payload: AccountSecretsLoaderData,
-		selection: SelectionState,
+		selection: ListDetailSelection,
 		nextMessage: string | null,
 	) {
 		packageOptions = payload.packageOptions
@@ -597,9 +569,7 @@ export function AccountSecretsRoute(handle: Handle) {
 		message =
 			nextMessage ??
 			payload.approvalError ??
-			(selection.selectedSecretId &&
-			!payload.selectedSecret &&
-			!payload.approval
+			(selection.selectedId && !payload.selectedSecret && !payload.approval
 				? 'Secret not found.'
 				: null)
 		status = 'ready'
@@ -616,7 +586,7 @@ export function AccountSecretsRoute(handle: Handle) {
 
 	async function loadAccountSecrets() {
 		const href = getCurrentHref()
-		const selection = getSelectionState(href)
+		const selection = secretsRoute.getSelection(href)
 		const dataKey = getDataRefreshKey(href)
 		const requestId = ++loadRequestId
 		loadingDataKey = dataKey
@@ -692,11 +662,11 @@ export function AccountSecretsRoute(handle: Handle) {
 
 		try {
 			const currentUrl = new URL(getCurrentHref(), 'http://localhost')
-			const selection = getSelectionState(currentUrl.toString())
+			const selection = secretsRoute.getSelection(currentUrl.toString())
 			const requestUrl = new URL(accountSecretsApiPath, currentUrl)
 			requestUrl.search = currentUrl.search
-			if (selection.selectedSecretId) {
-				requestUrl.searchParams.set('selected', selection.selectedSecretId)
+			if (selection.selectedId) {
+				requestUrl.searchParams.set('selected', selection.selectedId)
 			}
 			const payload = await submitApprovalRequest<
 				AccountSecretsLoaderData & { error?: string; ok?: boolean }
@@ -825,8 +795,8 @@ export function AccountSecretsRoute(handle: Handle) {
 			}
 
 			const wasCreating = !submittedEditorState.currentId
-			const nextSelection: SelectionState = {
-				selectedSecretId: payload.selectedSecret?.id ?? null,
+			const nextSelection: ListDetailSelection = {
+				selectedId: payload.selectedSecret?.id ?? null,
 				isCreating: false,
 			}
 			applyPayload(
@@ -886,7 +856,7 @@ export function AccountSecretsRoute(handle: Handle) {
 
 			applyPayload(
 				payload,
-				{ selectedSecretId: null, isCreating: false },
+				{ selectedId: null, isCreating: false },
 				'Deleted secret.',
 			)
 			deleteSecretCheck.reset()
@@ -980,10 +950,10 @@ export function AccountSecretsRoute(handle: Handle) {
 	}
 
 	function applyRouteLoaderData(href: string) {
-		if (!isAccountSecretsPath(href)) return false
+		if (!secretsRoute.isRoutePath(href)) return false
 		const routeData = tryConsumeRouteLoaderData(handle, 'accountSecrets', href)
 		if (!routeData) return false
-		const selection = getSelectionState(href)
+		const selection = secretsRoute.getSelection(href)
 		applyPayload(routeData, selection, routeData.approvalError)
 		lastLoadedDataKey = getDataRefreshKey(href)
 		lastFailedDataKey = null
@@ -1017,7 +987,7 @@ export function AccountSecretsRoute(handle: Handle) {
 			handle.queueTask(loadAccountSecrets)
 		}
 
-		const selection = getSelectionState(currentHref)
+		const selection = secretsRoute.getSelection(currentHref)
 		const filters = readFilterState(currentHref, packageOptions)
 		const filteredSecrets = filterSecrets(secrets, filters, packagesById)
 		const packageSelectOptions = packageOptions.map((packageOption) => {
@@ -1040,8 +1010,7 @@ export function AccountSecretsRoute(handle: Handle) {
 			...packageSelectOptions,
 		]
 
-		const activeSecretId =
-			selection.selectedSecretId ?? selectedSecret?.id ?? null
+		const activeSecretId = selection.selectedId ?? selectedSecret?.id ?? null
 		const isMutating = saveState !== 'idle' || submittingApprovalAction != null
 		const canCreatePackageSecrets = packageOptions.length > 0
 		const showEditor = selection.isCreating || selectedSecret != null

--- a/packages/worker/client/routes/account-values.tsx
+++ b/packages/worker/client/routes/account-values.tsx
@@ -2,6 +2,7 @@ import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { createDoubleCheck } from '#client/double-check.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
@@ -154,7 +155,7 @@ export function AccountValuesRoute(handle: Handle) {
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
 	const loadLatch = createRouteLoadLatch()
-	let deleteConfirm = false
+	const deleteValueCheck = createDoubleCheck(handle)
 	let syncedSelectionKey: string | null = null
 
 	const primaryButtonCss = getPrimaryButtonCss()
@@ -195,7 +196,7 @@ export function AccountValuesRoute(handle: Handle) {
 		const nextKey = selectionSyncKey(selection)
 		if (nextKey === syncedSelectionKey) return
 		syncedSelectionKey = nextKey
-		deleteConfirm = false
+		deleteValueCheck.reset()
 		if (selection.isCreating) {
 			editorState = createEmptyEditorState()
 			selectedValue = null
@@ -221,7 +222,7 @@ export function AccountValuesRoute(handle: Handle) {
 	function applyPayload(payload: AccountValuesLoaderData) {
 		values = payload.values
 		selectedValue = payload.selectedValue
-		deleteConfirm = false
+		deleteValueCheck.reset()
 		if (payload.selectedValue) {
 			editorState = createEditorStateFromDetail(payload.selectedValue)
 			syncedSelectionKey = selectionSyncKey(
@@ -379,7 +380,7 @@ export function AccountValuesRoute(handle: Handle) {
 			selectedValue = null
 			editorState = createEmptyEditorState()
 			syncedSelectionKey = 'none'
-			deleteConfirm = false
+			deleteValueCheck.reset()
 			saveState = 'idle'
 			setMessage('Deleted value.')
 			syncRouterLocation(valuesRoute.buildListHref(getCurrentSearch()))
@@ -396,7 +397,7 @@ export function AccountValuesRoute(handle: Handle) {
 
 	function selectValue(entry: AccountValueListItem) {
 		if (saveState !== 'idle') return
-		deleteConfirm = false
+		deleteValueCheck.reset()
 		setMessage(null)
 		syncRouterLocation(
 			valuesRoute.buildDetailHref(entry.id, getCurrentSearch()),
@@ -408,7 +409,7 @@ export function AccountValuesRoute(handle: Handle) {
 		editorState = createEmptyEditorState()
 		selectedValue = null
 		syncedSelectionKey = 'new'
-		deleteConfirm = false
+		deleteValueCheck.reset()
 		setMessage(null)
 		syncRouterLocation(valuesRoute.buildNewHref(getCurrentSearch()))
 		handle.update()
@@ -423,7 +424,7 @@ export function AccountValuesRoute(handle: Handle) {
 		} else {
 			editorState = createEmptyEditorState()
 		}
-		deleteConfirm = false
+		deleteValueCheck.reset()
 		setMessage(null)
 		handle.update()
 	}
@@ -736,20 +737,17 @@ export function AccountValuesRoute(handle: Handle) {
 											type="button"
 											disabled={isMutating}
 											mix={[
-												on('click', () => {
-													if (!deleteConfirm) {
-														deleteConfirm = true
-														handle.update()
-														return
-													}
-													void deleteValueEntry()
+												...deleteValueCheck.getButtonMix({
+													on: {
+														click: () => void deleteValueEntry(),
+													},
 												}),
 												css(dangerButtonCss),
 											]}
 										>
 											{saveState === 'deleting'
 												? 'Deleting...'
-												: deleteConfirm
+												: deleteValueCheck.doubleCheck
 													? 'Confirm delete'
 													: 'Delete'}
 										</button>

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -350,7 +350,7 @@ export function ConnectOauthRoute(handle: Handle) {
 		try {
 			sessionStorage.setItem(configStorageKey, JSON.stringify(nextConfig))
 		} catch {
-			// Persisting this convenience state is best-effort.
+			// Config caching is best-effort; the required OAuth state write below still fails visibly.
 		}
 	}
 

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -349,7 +349,9 @@ export function ConnectOauthRoute(handle: Handle) {
 	const persistConfig = (nextConfig: ConnectOauthConfig) => {
 		try {
 			sessionStorage.setItem(configStorageKey, JSON.stringify(nextConfig))
-		} catch {}
+		} catch {
+			// Persisting this convenience state is best-effort.
+		}
 	}
 
 	const readStoredConfig = (): ConnectOauthConfig | null => {
@@ -1354,7 +1356,9 @@ function parseScopes(raw: string | null) {
 			if (Array.isArray(parsed)) {
 				return parsed.map((value) => String(value)).filter(Boolean)
 			}
-		} catch {}
+		} catch {
+			// Invalid JSON falls back to the tolerant delimited-list parser.
+		}
 	}
 	return trimmed
 		.split(/[\s,]+/)
@@ -1791,7 +1795,9 @@ function parseExtraParams(raw: string | null) {
 				Object.entries(parsed).map(([key, value]) => [key, String(value)]),
 			) as Record<string, string>
 		}
-	} catch {}
+	} catch {
+		// Invalid JSON is tolerated as an empty parameter map.
+	}
 	return {}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace five hand-rolled delete confirmation states with `createDoubleCheck`
- extend `createListDetailRoute` for nested detail paths and migrate Account Secrets without changing its semantic URLs
- document the three intentional best-effort/tolerant catches in the OAuth connection route
- preserve the original Jobs/MCP confirmation label through in-flight deletion

## Tests
- `npm run typecheck`
- `npm run test:node -- packages/worker/client/double-check.node.test.ts packages/worker/client/list-detail-route.node.test.ts`
- `npm run validate` — passed twice, including after the reviewer follow-up (format, lint, typecheck, Node/Workers tests, Playwright E2E, MCP E2E, backup build, primitives, and migrations)

## Conductor Report
STATUS: done

What changed: Deduplicated delete confirmation state across Jobs, Values, MCP Servers, Remote Connectors, and Package Invocation Tokens; migrated Account Secrets selection to the shared list/detail route helper with nested-path parsing; documented all three intentional empty OAuth catches. The reviewer follow-up preserves Jobs/MCP’s prior in-flight confirmation label.

Tests run: focused helper tests and typecheck pass. `npm run validate` passed in full twice, including client tests and Playwright E2E on the final revision.

Blocker: none.

Scope spill: none; all edits are under `packages/worker/client/**`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6620d1b` · **Head:** `54644bb`

**Classification:** extends — the browser-app helper contracts gain nested detail parsing and configurable confirmation reset behavior while route call sites adopt them.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — shared list/detail and double-check helpers cover additional existing route behavior |

### System map

Account routes compose shared client helpers for URL selection and two-click destructive actions.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	accountRoutes["account routes<br/>Jobs, values, MCP, connectors, tokens, secrets"]:::untouched
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	accountRoutes -->|"shared selection and delete-confirm behavior"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Account Secrets preserves existing nested user/package detail URLs and keeps `/approve` non-selecting.
- Delete actions still require two clicks; Jobs/MCP keep their confirmation label during requests; tokens retain revoke/delete mutual exclusion.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27464aa3-9ce7-438b-9f85-fe70fd43f97e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27464aa3-9ce7-438b-9f85-fe70fd43f97e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent two-step “confirm” interactions for deleting jobs, MCP servers, tokens, remote connectors, and values, powered by a shared double-check helper.
  * Confirmation state now resets automatically when switching items, applying fresh data, or leaving views; permanent-delete can keep state when desired.
  * Improved list/detail routing for account secrets with configurable selection parsing, including nested paths and custom detail ID extraction.
* **Bug Fixes**
  * Improved resilience in the OAuth flow by safely handling invalid optional inputs and storage write failures.
* **Tests**
  * Expanded double-check and list/detail route test coverage for new confirmation and nested selection behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->