### PR TITLE
Add at-least-once safety to scheduled job execution

### DIFF
--- a/packages/worker/migrations/0107-job-execution-claims.sql
+++ b/packages/worker/migrations/0107-job-execution-claims.sql
@@ -1,0 +1,7 @@
+ALTER TABLE jobs ADD COLUMN claim_token TEXT;
+ALTER TABLE jobs ADD COLUMN running_since TEXT;
+ALTER TABLE jobs ADD COLUMN lease_expires_at TEXT;
+ALTER TABLE jobs ADD COLUMN claimed_scheduled_for TEXT;
+ALTER TABLE jobs ADD COLUMN retry_scheduled_for TEXT;
+ALTER TABLE jobs ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE jobs ADD COLUMN last_completed_scheduled_for TEXT;

--- a/packages/worker/src/jobs/execution-safety.node.test.ts
+++ b/packages/worker/src/jobs/execution-safety.node.test.ts
@@ -1,0 +1,217 @@
+import { expect, test, vi } from 'vitest'
+import {
+	buildScheduledJobIdempotencyKey,
+	computeJobRetryAt,
+	executeOrReplayScheduledJobRun,
+	isTransientJobExecutionError,
+	markPreExecutionTransientError,
+	resolveScheduledJobCallerContext,
+	TransientJobExecutionError,
+} from './execution-safety.ts'
+import { processDueJobs } from './process-due-jobs.ts'
+import { type JobRecord, type PersistedJobCallerContext } from './types.ts'
+
+function createJob(schedule: JobRecord['schedule']): JobRecord {
+	return {
+		version: 1,
+		id: 'job-1',
+		userId: 'user-1',
+		name: 'Safe job',
+		sourceId: 'source-1',
+		publishedCommit: null,
+		storageId: 'job:job-1',
+		schedule,
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		preserved: false,
+		createdAt: '2026-07-29T12:00:00.000Z',
+		updatedAt: '2026-07-29T12:00:00.000Z',
+		nextRunAt: '2026-07-29T12:00:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+	}
+}
+
+test('terminal scheduled run replay returns retained result without executing', async () => {
+	const execute = vi.fn()
+	const scheduledFor = '2026-07-29T12:00:00.000Z'
+	const outcome = await executeOrReplayScheduledJobRun({
+		claim: {
+			claimed: false,
+			run: {
+				id: 'run-1',
+				surface: 'job',
+				status: 'success',
+				name: 'Safe job',
+				packageId: null,
+				kodyId: null,
+				sourceId: 'source-1',
+				publishedCommit: null,
+				storageId: 'job:job-1',
+				jobId: 'job-1',
+				workflowId: null,
+				invocationId: null,
+				sessionId: null,
+				idempotencyKey: buildScheduledJobIdempotencyKey({
+					jobId: 'job-1',
+					scheduledFor,
+				}),
+				parentRunId: null,
+				startedAt: scheduledFor,
+				finishedAt: '2026-07-29T12:00:01.000Z',
+				durationMs: 1_000,
+				errorName: null,
+				errorMessage: null,
+				metadata: {
+					scheduledFor,
+					result: { retained: true },
+				},
+				logCount: 0,
+			},
+		},
+		execute,
+	})
+
+	expect(execute).not.toHaveBeenCalled()
+	expect(outcome).toEqual({
+		execution: {
+			ok: true,
+			result: { retained: true },
+			logs: [],
+		},
+		startedAt: scheduledFor,
+		finishedAt: '2026-07-29T12:00:01.000Z',
+		durationMs: 1_000,
+	})
+
+	await expect(
+		executeOrReplayScheduledJobRun({
+			claim: null,
+			execute,
+		}),
+	).rejects.toThrow(
+		'Unable to claim scheduled job idempotency key; RUN_LOG is unavailable.',
+	)
+	expect(execute).not.toHaveBeenCalled()
+})
+
+test('running scheduled run backs off without duplicate execution', async () => {
+	const execute = vi.fn()
+	const scheduledFor = '2026-07-29T12:00:00.000Z'
+	await expect(
+		executeOrReplayScheduledJobRun({
+			claim: {
+				claimed: false,
+				run: {
+					id: 'run-running',
+					surface: 'job',
+					status: 'running',
+					name: 'Safe job',
+					packageId: null,
+					kodyId: null,
+					sourceId: 'source-1',
+					publishedCommit: null,
+					storageId: 'job:job-1',
+					jobId: 'job-1',
+					workflowId: null,
+					invocationId: null,
+					sessionId: null,
+					idempotencyKey: buildScheduledJobIdempotencyKey({
+						jobId: 'job-1',
+						scheduledFor,
+					}),
+					parentRunId: null,
+					startedAt: scheduledFor,
+					finishedAt: null,
+					durationMs: null,
+					errorName: null,
+					errorMessage: null,
+					metadata: { scheduledFor },
+					logCount: 0,
+				},
+			},
+			execute,
+		}),
+	).rejects.toBeInstanceOf(TransientJobExecutionError)
+	expect(execute).not.toHaveBeenCalled()
+})
+
+test('scheduled caller context must belong to the jobs row user', () => {
+	const callerContext = {
+		user: { userId: 'user-1' },
+	} as PersistedJobCallerContext
+	expect(
+		resolveScheduledJobCallerContext({
+			rowUserId: 'user-1',
+			callerContext,
+		}),
+	).toBe(callerContext)
+	expect(
+		resolveScheduledJobCallerContext({
+			rowUserId: 'user-2',
+			callerContext,
+		}),
+	).toBeNull()
+})
+
+test('transient platform failures back off the same occurrence while permanent once failures complete it', async () => {
+	const now = new Date('2026-07-29T12:00:00.000Z')
+	expect(
+		isTransientJobExecutionError(
+			new Error('D1_ERROR: Network connection lost.'),
+		),
+	).toBe(true)
+	expect(
+		isTransientJobExecutionError(
+			new Error(
+				"Durable Object's isolate exceeded its memory limit and was reset.",
+			),
+		),
+	).toBe(true)
+	expect(isTransientJobExecutionError(new Error('user code failed'))).toBe(
+		false,
+	)
+	expect(
+		markPreExecutionTransientError(
+			new Error('D1_ERROR: Network connection lost.'),
+		),
+	).toBeInstanceOf(TransientJobExecutionError)
+	expect(
+		markPreExecutionTransientError(new Error('user code failed')),
+	).not.toBeInstanceOf(TransientJobExecutionError)
+	expect(computeJobRetryAt({ now, retryCount: 0 })).toBe(
+		'2026-07-29T12:00:05.000Z',
+	)
+	expect(computeJobRetryAt({ now, retryCount: 3 })).toBe(
+		'2026-07-29T12:00:40.000Z',
+	)
+
+	const once = createJob({
+		type: 'once',
+		runAt: now.toISOString(),
+	})
+	const permanent = await processDueJobs({
+		jobs: [once],
+		now,
+		async executeJob() {
+			return {
+				execution: {
+					ok: false,
+					error: 'user code failed',
+					logs: [],
+				},
+				startedAt: now.toISOString(),
+				finishedAt: now.toISOString(),
+				durationMs: 0,
+			}
+		},
+	})
+	expect(permanent.saveJobs[0]).toMatchObject({
+		enabled: false,
+		runCount: 1,
+		errorCount: 1,
+		lastRunError: 'user code failed',
+	})
+})

--- a/packages/worker/src/jobs/execution-safety.ts
+++ b/packages/worker/src/jobs/execution-safety.ts
@@ -1,0 +1,117 @@
+import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
+import { isRetryableD1LockError } from '#worker/d1-retry.ts'
+import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
+import {
+	type RunRecord,
+	type RunRecordHandle,
+} from '#worker/run-records/types.ts'
+import {
+	type JobExecutionOutcome,
+	type PersistedJobCallerContext,
+} from './types.ts'
+
+export const jobRetryBaseDelayMs = 5_000
+export const jobRetryMaximumDelayMs = 5 * 60 * 1_000
+
+export class TransientJobExecutionError extends Error {
+	override readonly name = 'TransientJobExecutionError'
+}
+
+export function buildScheduledJobIdempotencyKey(input: {
+	jobId: string
+	scheduledFor: string
+}) {
+	return `scheduled-job:${input.jobId}:${input.scheduledFor}`
+}
+
+export function isTransientJobExecutionError(error: unknown) {
+	return (
+		error instanceof TransientJobExecutionError ||
+		isRetryableD1LockError(error) ||
+		errorCauseChainIncludes(error, isDurableObjectIsolateResetMessage)
+	)
+}
+
+export function markPreExecutionTransientError(error: unknown): unknown {
+	if (
+		error instanceof TransientJobExecutionError ||
+		!isTransientJobExecutionError(error)
+	) {
+		return error
+	}
+	const message = error instanceof Error ? error.message : String(error)
+	return new TransientJobExecutionError(message, { cause: error })
+}
+
+export function computeJobRetryAt(input: { now: Date; retryCount: number }) {
+	const delayMs = Math.min(
+		jobRetryMaximumDelayMs,
+		jobRetryBaseDelayMs * 2 ** Math.max(0, input.retryCount),
+	)
+	return new Date(input.now.valueOf() + delayMs).toISOString()
+}
+
+export function replayScheduledJobRun(run: RunRecord): JobExecutionOutcome {
+	const finishedAt = run.finishedAt ?? run.startedAt
+	switch (run.status) {
+		case 'success':
+			return {
+				execution: {
+					ok: true,
+					result: run.metadata['result'],
+					logs: [],
+				},
+				startedAt: run.startedAt,
+				finishedAt,
+				durationMs: run.durationMs ?? 0,
+			}
+		case 'error':
+			return {
+				execution: {
+					ok: false,
+					error:
+						run.errorMessage ??
+						'The retained scheduled job run ended with an unknown error.',
+					logs: [],
+				},
+				startedAt: run.startedAt,
+				finishedAt,
+				durationMs: run.durationMs ?? 0,
+			}
+		case 'running':
+			throw new TransientJobExecutionError(
+				'A previous execution still owns this scheduled occurrence; it will be retried without duplicate execution.',
+			)
+		default: {
+			const exhaustive: never = run.status
+			throw new Error(`Unhandled run status: ${String(exhaustive)}`)
+		}
+	}
+}
+
+export async function executeOrReplayScheduledJobRun(input: {
+	claim:
+		| { claimed: true; handle: RunRecordHandle }
+		| { claimed: false; run: RunRecord }
+		| null
+	execute: (handle: RunRecordHandle) => Promise<JobExecutionOutcome>
+}) {
+	if (!input.claim) {
+		throw new TransientJobExecutionError(
+			'Unable to claim scheduled job idempotency key; RUN_LOG is unavailable.',
+		)
+	}
+	if (!input.claim.claimed) {
+		return replayScheduledJobRun(input.claim.run)
+	}
+	return await input.execute(input.claim.handle)
+}
+
+export function resolveScheduledJobCallerContext(input: {
+	rowUserId: string
+	callerContext: PersistedJobCallerContext | null
+}) {
+	return input.callerContext?.user.userId === input.rowUserId
+		? input.callerContext
+		: null
+}

--- a/packages/worker/src/jobs/repo.ts
+++ b/packages/worker/src/jobs/repo.ts
@@ -26,12 +26,20 @@ type JobRowRecord = {
 	run_count: number
 	success_count: number
 	error_count: number
+	claim_token: string | null
+	running_since: string | null
+	lease_expires_at: string | null
+	claimed_scheduled_for: string | null
+	retry_scheduled_for: string | null
+	retry_count: number
+	last_completed_scheduled_for: string | null
 }
 
 export type JobRow = JobRowRecord & {
 	record: JobRecord
 	callerContextJson: string
 	callerContext: PersistedJobCallerContext | null
+	schedulerWakeAt: string
 }
 
 function serializeJob(job: JobRecord) {
@@ -153,6 +161,24 @@ function mapRow(row: Record<string, unknown>): JobRow {
 		run_count: record.runCount,
 		success_count: record.successCount,
 		error_count: record.errorCount,
+		claim_token: row['claim_token'] == null ? null : String(row['claim_token']),
+		running_since:
+			row['running_since'] == null ? null : String(row['running_since']),
+		lease_expires_at:
+			row['lease_expires_at'] == null ? null : String(row['lease_expires_at']),
+		claimed_scheduled_for:
+			row['claimed_scheduled_for'] == null
+				? null
+				: String(row['claimed_scheduled_for']),
+		retry_scheduled_for:
+			row['retry_scheduled_for'] == null
+				? null
+				: String(row['retry_scheduled_for']),
+		retry_count: Number(row['retry_count']) || 0,
+		last_completed_scheduled_for:
+			row['last_completed_scheduled_for'] == null
+				? null
+				: String(row['last_completed_scheduled_for']),
 		record,
 		callerContextJson: String(row['caller_context_json']),
 		callerContext: parseJson<PersistedJobCallerContext | null>(
@@ -161,6 +187,10 @@ function mapRow(row: Record<string, unknown>): JobRow {
 				: String(row['caller_context_json']),
 			null,
 		),
+		schedulerWakeAt:
+			row['scheduler_wake_at'] == null
+				? record.nextRunAt
+				: String(row['scheduler_wake_at']),
 	}
 }
 
@@ -222,7 +252,10 @@ export async function updateJobRow(input: {
 				name = ?, source_id = ?, published_commit = ?, repo_check_policy_json = ?, storage_id = ?, params_json = ?, schedule_json = ?, timezone = ?,
 				enabled = ?, kill_switch_enabled = ?, preserved = ?, caller_context_json = ?, updated_at = ?,
 				last_run_at = ?, last_run_status = ?, last_run_error = ?, last_duration_ms = ?,
-				next_run_at = ?, run_count = ?, success_count = ?, error_count = ?
+				next_run_at = ?, run_count = ?, success_count = ?, error_count = ?,
+				claim_token = NULL, running_since = NULL, lease_expires_at = NULL,
+				claimed_scheduled_for = NULL, retry_scheduled_for = NULL,
+				retry_count = 0
 			WHERE id = ? AND user_id = ?`,
 		)
 		.bind(
@@ -316,10 +349,19 @@ export async function listDueJobRows(
 				AND enabled = 1
 				AND kill_switch_enabled = 0
 				AND next_run_at <= ?
+				AND (
+					claim_token IS NULL
+					OR lease_expires_at IS NULL
+					OR lease_expires_at <= ?
+				)
+				AND (
+					last_completed_scheduled_for IS NULL
+					OR last_completed_scheduled_for != COALESCE(retry_scheduled_for, next_run_at)
+				)
 			ORDER BY next_run_at ASC, name ASC
 			LIMIT ?`,
 		)
-		.bind(userId, nowIso, maxDueJobsPerAlarm)
+		.bind(userId, nowIso, nowIso, maxDueJobsPerAlarm)
 		.all<Record<string, unknown>>()
 	return (results ?? []).map(mapRow)
 }
@@ -327,19 +369,169 @@ export async function listDueJobRows(
 export async function getNextRunnableJobRow(
 	db: D1Database,
 	userId: string,
+	nowIso = new Date().toISOString(),
 ): Promise<JobRow | null> {
 	const result = await db
 		.prepare(
-			`SELECT * FROM jobs
+			`SELECT jobs.*,
+				CASE
+					WHEN claim_token IS NOT NULL
+						AND lease_expires_at IS NOT NULL
+						AND lease_expires_at > ?
+					THEN lease_expires_at
+					ELSE next_run_at
+				END AS scheduler_wake_at
+			FROM jobs
 			WHERE user_id = ?
 				AND enabled = 1
 				AND kill_switch_enabled = 0
-			ORDER BY next_run_at ASC, name ASC
+				AND (
+					last_completed_scheduled_for IS NULL
+					OR last_completed_scheduled_for != COALESCE(retry_scheduled_for, next_run_at)
+				)
+			ORDER BY scheduler_wake_at ASC, name ASC
 			LIMIT 1`,
 		)
-		.bind(userId)
+		.bind(nowIso, userId)
 		.first<Record<string, unknown>>()
 	return result ? mapRow(result) : null
+}
+
+/**
+ * Scheduled executions use a ten-minute lease, comfortably above the
+ * sandbox's default 90-second maximum runtime. A single conditional D1 write
+ * is the ownership boundary; reading due rows alone never grants ownership.
+ */
+export const jobExecutionLeaseMs = 10 * 60 * 1_000
+
+export async function claimJobRow(input: {
+	db: D1Database
+	userId: string
+	jobId: string
+	now: Date
+	claimToken: string
+}): Promise<JobRow | null> {
+	const nowIso = input.now.toISOString()
+	const leaseExpiresAt = new Date(
+		input.now.valueOf() + jobExecutionLeaseMs,
+	).toISOString()
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
+				claim_token = ?,
+				running_since = ?,
+				lease_expires_at = ?,
+				claimed_scheduled_for = COALESCE(retry_scheduled_for, next_run_at)
+			WHERE id = ?
+				AND user_id = ?
+				AND enabled = 1
+				AND kill_switch_enabled = 0
+				AND next_run_at <= ?
+				AND (
+					claim_token IS NULL
+					OR lease_expires_at IS NULL
+					OR lease_expires_at <= ?
+				)
+				AND (
+					last_completed_scheduled_for IS NULL
+					OR last_completed_scheduled_for != COALESCE(retry_scheduled_for, next_run_at)
+				)
+			RETURNING *`,
+		)
+		.bind(
+			input.claimToken,
+			nowIso,
+			leaseExpiresAt,
+			input.jobId,
+			input.userId,
+			nowIso,
+			nowIso,
+		)
+		.first<Record<string, unknown>>()
+	return result ? mapRow(result) : null
+}
+
+export async function finalizeClaimedJobRow(input: {
+	db: D1Database
+	userId: string
+	job: JobRecord
+	callerContextJson: string
+	claimToken: string
+	scheduledFor: string
+}): Promise<boolean> {
+	const serialized = serializeJob(input.job)
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
+				name = ?, source_id = ?, published_commit = ?, repo_check_policy_json = ?, storage_id = ?, params_json = ?, schedule_json = ?, timezone = ?,
+				enabled = ?, kill_switch_enabled = ?, preserved = ?, caller_context_json = ?, updated_at = ?,
+				last_run_at = ?, last_run_status = ?, last_run_error = ?, last_duration_ms = ?,
+				next_run_at = ?, run_count = ?, success_count = ?, error_count = ?,
+				claim_token = NULL, running_since = NULL, lease_expires_at = NULL,
+				claimed_scheduled_for = NULL, retry_scheduled_for = NULL,
+				retry_count = 0, last_completed_scheduled_for = ?
+			WHERE id = ? AND user_id = ? AND claim_token = ?`,
+		)
+		.bind(
+			serialized.name,
+			serialized.source_id,
+			serialized.published_commit,
+			serialized.repo_check_policy_json,
+			serialized.storage_id,
+			serialized.params_json,
+			serialized.schedule_json,
+			serialized.timezone,
+			serialized.enabled,
+			serialized.kill_switch_enabled,
+			serialized.preserved,
+			input.callerContextJson,
+			serialized.updated_at,
+			serialized.last_run_at,
+			serialized.last_run_status,
+			serialized.last_run_error,
+			serialized.last_duration_ms,
+			serialized.next_run_at,
+			serialized.run_count,
+			serialized.success_count,
+			serialized.error_count,
+			input.scheduledFor,
+			serialized.id,
+			input.userId,
+			input.claimToken,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
+}
+
+export async function retryClaimedJobRow(input: {
+	db: D1Database
+	userId: string
+	jobId: string
+	claimToken: string
+	nextRunAt: string
+}): Promise<boolean> {
+	const result = await input.db
+		.prepare(
+			`UPDATE jobs SET
+				next_run_at = ?,
+				updated_at = ?,
+				retry_scheduled_for = claimed_scheduled_for,
+				retry_count = retry_count + 1,
+				claim_token = NULL,
+				running_since = NULL,
+				lease_expires_at = NULL,
+				claimed_scheduled_for = NULL
+			WHERE id = ? AND user_id = ? AND claim_token = ?`,
+		)
+		.bind(
+			input.nextRunAt,
+			new Date().toISOString(),
+			input.jobId,
+			input.userId,
+			input.claimToken,
+		)
+		.run()
+	return (result.meta.changes ?? 0) > 0
 }
 
 export async function deleteJobRow(

--- a/packages/worker/src/jobs/repo.workers.test.ts
+++ b/packages/worker/src/jobs/repo.workers.test.ts
@@ -1,6 +1,16 @@
 import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
-import { listDueJobRows, maxDueJobsPerAlarm } from './repo.ts'
+import {
+	claimJobRow,
+	finalizeClaimedJobRow,
+	getJobRowById,
+	getNextRunnableJobRow,
+	jobExecutionLeaseMs,
+	listDueJobRows,
+	maxDueJobsPerAlarm,
+	retryClaimedJobRow,
+	updateJobRow,
+} from './repo.ts'
 
 async function ensureJobsSchema() {
 	await env.APP_DB.prepare(
@@ -28,7 +38,14 @@ async function ensureJobsSchema() {
 			next_run_at TEXT NOT NULL,
 			run_count INTEGER NOT NULL DEFAULT 0,
 			success_count INTEGER NOT NULL DEFAULT 0,
-			error_count INTEGER NOT NULL DEFAULT 0
+			error_count INTEGER NOT NULL DEFAULT 0,
+			claim_token TEXT,
+			running_since TEXT,
+			lease_expires_at TEXT,
+			claimed_scheduled_for TEXT,
+			retry_scheduled_for TEXT,
+			retry_count INTEGER NOT NULL DEFAULT 0,
+			last_completed_scheduled_for TEXT
 		)`,
 	).run()
 	await env.APP_DB.prepare(`DELETE FROM jobs`).run()
@@ -130,4 +147,167 @@ test('listDueJobRows caps a due-job backlog at maxDueJobsPerAlarm, oldest first'
 				`due-${String(maxDueJobsPerAlarm + index).padStart(3, '0')}`,
 		),
 	)
+})
+
+test('conditional job claims exclude overlap and reclaim only after lease expiry', async () => {
+	await ensureJobsSchema()
+	const userId = 'user-claim'
+	const scheduledFor = '2026-04-20T12:00:00.000Z'
+	const now = new Date(scheduledFor)
+	await insertJob({
+		id: 'claimed-job',
+		userId,
+		nextRunAt: scheduledFor,
+	})
+
+	const [first, overlap] = await Promise.all([
+		claimJobRow({
+			db: env.APP_DB,
+			userId,
+			jobId: 'claimed-job',
+			now,
+			claimToken: 'claim-first',
+		}),
+		claimJobRow({
+			db: env.APP_DB,
+			userId,
+			jobId: 'claimed-job',
+			now,
+			claimToken: 'claim-overlap',
+		}),
+	])
+	const winner = first ?? overlap
+	expect(winner).not.toBeNull()
+	expect([first, overlap].filter(Boolean)).toHaveLength(1)
+	expect(winner?.claimed_scheduled_for).toBe(scheduledFor)
+	expect(winner?.lease_expires_at).toBe(
+		new Date(now.valueOf() + jobExecutionLeaseMs).toISOString(),
+	)
+
+	expect(
+		await listDueJobRows(
+			env.APP_DB,
+			userId,
+			new Date(now.valueOf() + jobExecutionLeaseMs - 1).toISOString(),
+		),
+	).toEqual([])
+	const nextWhileLeased = await getNextRunnableJobRow(
+		env.APP_DB,
+		userId,
+		now.toISOString(),
+	)
+	expect(nextWhileLeased?.schedulerWakeAt).toBe(winner?.lease_expires_at)
+
+	const reclaimed = await claimJobRow({
+		db: env.APP_DB,
+		userId,
+		jobId: 'claimed-job',
+		now: new Date(now.valueOf() + jobExecutionLeaseMs),
+		claimToken: 'claim-reclaimed',
+	})
+	expect(reclaimed?.claim_token).toBe('claim-reclaimed')
+	expect(reclaimed?.claimed_scheduled_for).toBe(scheduledFor)
+
+	const retryAt = '2026-04-20T12:10:05.000Z'
+	expect(
+		await retryClaimedJobRow({
+			db: env.APP_DB,
+			userId,
+			jobId: 'claimed-job',
+			claimToken: 'claim-reclaimed',
+			nextRunAt: retryAt,
+		}),
+	).toBe(true)
+	const retryRow = await getNextRunnableJobRow(
+		env.APP_DB,
+		userId,
+		new Date('2026-04-20T12:10:00.000Z').toISOString(),
+	)
+	expect(retryRow).toMatchObject({
+		claim_token: null,
+		retry_scheduled_for: scheduledFor,
+		retry_count: 1,
+		schedulerWakeAt: retryAt,
+	})
+	const retriedOccurrence = await claimJobRow({
+		db: env.APP_DB,
+		userId,
+		jobId: 'claimed-job',
+		now: new Date(retryAt),
+		claimToken: 'claim-retry',
+	})
+	expect(retriedOccurrence?.claimed_scheduled_for).toBe(scheduledFor)
+	expect(retriedOccurrence?.retry_count).toBe(1)
+})
+
+test('ordinary updates cancel claims and completed occurrence guards fence malformed due rows', async () => {
+	await ensureJobsSchema()
+	const userId = 'user-fencing'
+	const scheduledFor = '2026-04-20T12:00:00.000Z'
+	await insertJob({
+		id: 'cancelled-claim',
+		userId,
+		nextRunAt: scheduledFor,
+	})
+	const claimed = await claimJobRow({
+		db: env.APP_DB,
+		userId,
+		jobId: 'cancelled-claim',
+		now: new Date(scheduledFor),
+		claimToken: 'stale-token',
+	})
+	if (!claimed) throw new Error('Expected job claim.')
+
+	expect(
+		await updateJobRow({
+			db: env.APP_DB,
+			userId,
+			job: {
+				...claimed.record,
+				name: 'Edited while claimed',
+			},
+			callerContextJson: claimed.callerContextJson,
+		}),
+	).toBe(true)
+	expect(await getJobRowById(env.APP_DB, userId, claimed.id)).toMatchObject({
+		name: 'Edited while claimed',
+		claim_token: null,
+		running_since: null,
+		lease_expires_at: null,
+		claimed_scheduled_for: null,
+		retry_scheduled_for: null,
+		retry_count: 0,
+	})
+	expect(
+		await finalizeClaimedJobRow({
+			db: env.APP_DB,
+			userId,
+			job: claimed.record,
+			callerContextJson: claimed.callerContextJson,
+			claimToken: 'stale-token',
+			scheduledFor,
+		}),
+	).toBe(false)
+
+	await insertJob({
+		id: 'already-completed',
+		userId,
+		nextRunAt: scheduledFor,
+	})
+	await env.APP_DB.prepare(
+		`UPDATE jobs SET last_completed_scheduled_for = ? WHERE id = ? AND user_id = ?`,
+	)
+		.bind(scheduledFor, 'already-completed', userId)
+		.run()
+	const due = await listDueJobRows(env.APP_DB, userId, scheduledFor)
+	expect(due.map((row) => row.id)).not.toContain('already-completed')
+	expect(
+		await claimJobRow({
+			db: env.APP_DB,
+			userId,
+			jobId: 'already-completed',
+			now: new Date(scheduledFor),
+			claimToken: 'must-not-claim',
+		}),
+	).toBeNull()
 })

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -1,10 +1,18 @@
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { type ExecuteResult } from '@cloudflare/codemode'
 import { withAccountWriteLease } from '#app/account-deletion-state.ts'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext, parseMcpCallerContext } from '#mcp/context.ts'
 import { buildJobEmbedText } from '#mcp/jobs-embed.ts'
 import { deleteJobVector, upsertJobVector } from '#mcp/jobs-vectorize.ts'
-import { type ExecuteResult } from '@cloudflare/codemode'
+import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
+import {
+	abandonRunRecord,
+	claimRunRecord,
+	finishRunRecord,
+	getRunRecord,
+} from '#worker/run-records/service.ts'
+import { type RunRecordHandle } from '#worker/run-records/types.ts'
 import { applyExecutionOutcome, processDueJobs } from './process-due-jobs.ts'
 import {
 	getJobManagerDebugState,
@@ -12,13 +20,25 @@ import {
 } from './manager-client.ts'
 import {
 	deleteJobRow,
+	claimJobRow,
+	finalizeClaimedJobRow,
 	getJobRowById,
 	listDueJobRows,
 	listJobRowsByUserId,
 	getNextRunnableJobRow,
 	insertJobRow,
+	retryClaimedJobRow,
 	updateJobRow,
 } from './repo.ts'
+import {
+	buildScheduledJobIdempotencyKey,
+	computeJobRetryAt,
+	executeOrReplayScheduledJobRun,
+	isTransientJobExecutionError,
+	markPreExecutionTransientError,
+	resolveScheduledJobCallerContext,
+	TransientJobExecutionError,
+} from './execution-safety.ts'
 import {
 	computeNextRunAt,
 	formatJobError,
@@ -54,7 +74,6 @@ import { typecheckPackageEntrypointsFromSourceFiles } from '#worker/repo/checks.
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { buildJobSourceFiles } from '#worker/repo/source-templates.ts'
 import { repoBackedModuleEntrypointExportErrorMessage } from '#worker/repo/repo-kody-execution.ts'
-import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
 import {
 	deleteEntitySource,
@@ -467,6 +486,8 @@ async function rebuildAndExecuteJobArtifact(input: {
 		sourceId: string
 	} | null
 	waitUntil?: (promise: Promise<unknown>) => void
+	runRecordHandle?: RunRecordHandle | null
+	idempotencyKey?: string | null
 }) {
 	if (!input.job.sourceId) {
 		throw new Error('Repo-backed job source is missing.')
@@ -480,6 +501,8 @@ async function rebuildAndExecuteJobArtifact(input: {
 		entryPoint: input.entryPoint,
 		artifactName: input.artifactName,
 		packageContext: input.packageContext ?? null,
+	}).catch((error: unknown) => {
+		throw markPreExecutionTransientError(error)
 	})
 	if (!artifact) {
 		throw new Error(
@@ -493,6 +516,8 @@ async function rebuildAndExecuteJobArtifact(input: {
 		artifact,
 		bypassLogs: [],
 		waitUntil: input.waitUntil,
+		runRecordHandle: input.runRecordHandle,
+		idempotencyKey: input.idempotencyKey,
 	})
 }
 
@@ -505,8 +530,15 @@ async function executePublishedJobArtifact(input: {
 		| Awaited<ReturnType<typeof ensurePublishedBundleArtifactForJob>>
 	bypassLogs: Array<string>
 	waitUntil?: (promise: Promise<unknown>) => void
+	runRecordHandle?: RunRecordHandle | null
+	idempotencyKey?: string | null
 }): Promise<ExecuteResult> {
-	const source = await getEntitySourceById(input.env.APP_DB, input.job.sourceId)
+	const source = await getEntitySourceById(
+		input.env.APP_DB,
+		input.job.sourceId,
+	).catch((error: unknown) => {
+		throw markPreExecutionTransientError(error)
+	})
 	const callerContext = {
 		...input.callerContext,
 		repoContext: source
@@ -531,6 +563,7 @@ async function executePublishedJobArtifact(input: {
 		storageId: input.job.storageId,
 		sourceId: packageContext?.sourceId ?? input.job.sourceId,
 		publishedCommit: source?.published_commit ?? input.job.publishedCommit,
+		...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
 		...(packageContext
 			? {
 					packageId: packageContext.packageId,
@@ -576,8 +609,9 @@ async function executePublishedJobArtifact(input: {
 			},
 			...(packageContext ? { packageContext } : {}),
 			runRecord,
+			runRecordHandle: input.runRecordHandle,
 			...(packageRuntimeTools ?? {}),
-			waitUntil: input.waitUntil,
+			waitUntil: input.runRecordHandle ? undefined : input.waitUntil,
 		},
 	).then((result) => ({
 		...result,
@@ -1286,6 +1320,8 @@ export async function executeJobOnce(input: {
 	callerContext: PersistedJobCallerContext | null
 	repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 	waitUntil?: (promise: Promise<unknown>) => void
+	runRecordHandle?: RunRecordHandle | null
+	idempotencyKey?: string | null
 }): Promise<JobExecutionOutcome> {
 	return await withAccountWriteLease({
 		db: input.env.APP_DB,
@@ -1296,6 +1332,7 @@ export async function executeJobOnce(input: {
 			let outcome: 'success' | 'error' = 'success'
 			let finished = started
 			let durationMs = 0
+			let completedOccurrence = false
 			try {
 				if (!input.callerContext) {
 					outcome = 'error'
@@ -1305,6 +1342,7 @@ export async function executeJobOnce(input: {
 							'Job caller context is missing. Re-save the job to refresh its execution context.',
 						logs: [],
 					}
+					completedOccurrence = true
 				} else {
 					const runtimeCallerContext: PersistedJobCallerContext = {
 						...input.callerContext,
@@ -1323,6 +1361,8 @@ export async function executeJobOnce(input: {
 						callerContext: runtimeCallerContext,
 						repoCheckPolicyOverride: input.repoCheckPolicyOverride,
 						waitUntil: input.waitUntil,
+						runRecordHandle: input.runRecordHandle,
+						idempotencyKey: input.idempotencyKey,
 					})
 					if (result.error) {
 						outcome = 'error'
@@ -1341,19 +1381,24 @@ export async function executeJobOnce(input: {
 								result: result.result,
 								logs: result.logs ?? [],
 							}
+					completedOccurrence = true
 				}
 			} catch (error) {
+				if (error instanceof TransientJobExecutionError) {
+					throw error
+				}
 				outcome = 'error'
 				execution = {
 					ok: false,
 					error: formatJobError(error),
 					logs: [],
 				}
+				completedOccurrence = true
 			} finally {
 				finished = new Date()
 				durationMs = Math.max(0, finished.valueOf() - started.valueOf())
 				const userId = input.job.userId
-				if (userId) {
+				if (userId && completedOccurrence) {
 					await recordUsage(input.env, {
 						userId,
 						eventType: 'job_run',
@@ -1379,14 +1424,21 @@ async function runRepoBackedJob(input: {
 	callerContext: PersistedJobCallerContext
 	repoCheckPolicyOverride?: JobRepoCheckPolicy | null
 	waitUntil?: (promise: Promise<unknown>) => void
+	runRecordHandle?: RunRecordHandle | null
+	idempotencyKey?: string | null
 }): Promise<ExecuteResult> {
 	const resolved = await resolvePublishedJobSource({
 		env: input.env,
 		userId: input.callerContext.user.userId,
 		job: input.job,
-	}).catch((error: unknown) => ({
-		error: formatJobError(error),
-	}))
+	}).catch((error: unknown) => {
+		if (isTransientJobExecutionError(error)) {
+			throw markPreExecutionTransientError(error)
+		}
+		return {
+			error: formatJobError(error),
+		}
+	})
 	if ('error' in resolved) {
 		return {
 			error: resolved.error,
@@ -1401,6 +1453,8 @@ async function runRepoBackedJob(input: {
 		kind: 'job',
 		artifactName: resolved.artifactName,
 		entryPoint: resolved.entryPoint,
+	}).catch((error: unknown) => {
+		throw markPreExecutionTransientError(error)
 	})
 	if (
 		loadedArtifact?.artifact &&
@@ -1417,6 +1471,8 @@ async function runRepoBackedJob(input: {
 			artifact: loadedArtifact.artifact,
 			bypassLogs: [],
 			waitUntil: input.waitUntil,
+			runRecordHandle: input.runRecordHandle,
+			idempotencyKey: input.idempotencyKey,
 		})
 	}
 	return await rebuildAndExecuteJobArtifact({
@@ -1428,6 +1484,8 @@ async function runRepoBackedJob(input: {
 		artifactName: resolved.artifactName,
 		packageContext: resolved.packageContext,
 		waitUntil: input.waitUntil,
+		runRecordHandle: input.runRecordHandle,
+		idempotencyKey: input.idempotencyKey,
 	})
 }
 
@@ -1494,6 +1552,78 @@ export async function runJobNow(input: {
 	})
 }
 
+async function executeClaimedScheduledJob(input: {
+	env: Env
+	row: NonNullable<Awaited<ReturnType<typeof claimJobRow>>>
+	scheduledFor: string
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	const idempotencyKey = buildScheduledJobIdempotencyKey({
+		jobId: input.row.record.id,
+		scheduledFor: input.scheduledFor,
+	})
+	const claim = await claimRunRecord({
+		env: input.env,
+		userId: input.row.record.userId,
+		context: {
+			surface: 'job',
+			name: input.row.record.name,
+			jobId: input.row.record.id,
+			storageId: input.row.record.storageId,
+			sourceId: input.row.record.sourceId,
+			publishedCommit: input.row.record.publishedCommit,
+			idempotencyKey,
+			metadata: {
+				scheduledFor: input.scheduledFor,
+			},
+		},
+	})
+	try {
+		const outcome = await executeOrReplayScheduledJobRun({
+			claim,
+			execute: async (handle) =>
+				executeJobOnce({
+					env: input.env,
+					job: input.row.record,
+					callerContext: resolveScheduledJobCallerContext({
+						rowUserId: input.row.record.userId,
+						callerContext: input.row.callerContext,
+					}),
+					waitUntil: input.waitUntil,
+					runRecordHandle: handle,
+					idempotencyKey,
+				}),
+		})
+		if (claim?.claimed) {
+			const retained = await getRunRecord({
+				env: input.env,
+				userId: claim.handle.userId,
+				runId: claim.handle.id,
+			}).catch(() => null)
+			if (!retained || retained.run.status === 'running') {
+				await finishRunRecord({
+					env: input.env,
+					handle: claim.handle,
+					status: outcome.execution.ok ? 'success' : 'error',
+					logs: outcome.execution.logs,
+					...(outcome.execution.ok
+						? { result: outcome.execution.result }
+						: { error: outcome.execution.error }),
+				})
+			}
+		}
+		return outcome
+	} catch (error) {
+		if (claim?.claimed && error instanceof TransientJobExecutionError) {
+			await abandonRunRecord({
+				env: input.env,
+				handle: claim.handle,
+			})
+		}
+		throw error
+	}
+}
+
 export async function runDueJobsForUser(input: {
 	env: Env
 	userId: string
@@ -1510,9 +1640,6 @@ export async function runDueJobsForUser(input: {
 				input.userId,
 				now.toISOString(),
 			)
-			const dueRowById = new Map(
-				dueRows.map((row) => [row.record.id, row] as const),
-			)
 			if (dueRows.length === 0) {
 				logJobSchedulerEvent({
 					event: 'run_due_jobs_empty',
@@ -1527,38 +1654,100 @@ export async function runDueJobsForUser(input: {
 					jobOutcomes: [] satisfies Array<SchedulerJobOutcomeLog>,
 				}
 			}
-			const result = await processDueJobs({
-				jobs: dueRows.map((row) => row.record),
-				now,
-				executeJob: async (job) => {
-					const row = dueRowById.get(job.id)
-					const callerContext = row?.callerContext ?? null
-					return executeJobOnce({
-						env: input.env,
-						job,
-						callerContext,
-						waitUntil: input.waitUntil,
-					})
-				},
-			})
-			for (const job of result.saveJobs) {
-				const row = dueRowById.get(job.id)
-				await updateJobRow({
+			let claimedJobCount = 0
+			let successCount = 0
+			let errorCount = 0
+			const jobOutcomes: Array<SchedulerJobOutcomeLog> = []
+			for (const dueRow of dueRows) {
+				const claimToken = crypto.randomUUID()
+				const claimNow = input.now ?? new Date()
+				const row = await claimJobRow({
 					db: input.env.APP_DB,
 					userId: input.userId,
-					job,
-					callerContextJson: row?.callerContextJson ?? 'null',
+					jobId: dueRow.id,
+					now: claimNow,
+					claimToken,
 				})
+				if (!row?.claimed_scheduled_for) {
+					continue
+				}
+				claimedJobCount += 1
+				try {
+					const outcome = await executeClaimedScheduledJob({
+						env: input.env,
+						row,
+						scheduledFor: row.claimed_scheduled_for,
+						waitUntil: input.waitUntil,
+					})
+					const result = await processDueJobs({
+						jobs: [row.record],
+						now,
+						async executeJob() {
+							return outcome
+						},
+					})
+					const updated = result.saveJobs[0]
+					if (!updated) {
+						throw new Error(
+							`Scheduled job "${row.id}" produced no final job state.`,
+						)
+					}
+					const finalized = await finalizeClaimedJobRow({
+						db: input.env.APP_DB,
+						userId: input.userId,
+						job: updated,
+						callerContextJson: row.callerContextJson,
+						claimToken,
+						scheduledFor: row.claimed_scheduled_for,
+					})
+					if (!finalized) {
+						throw new Error(
+							`Scheduled job "${row.id}" lost its fenced execution claim before finalization.`,
+						)
+					}
+					successCount += result.successCount
+					errorCount += result.errorCount
+					jobOutcomes.push(...result.jobOutcomes)
+				} catch (error) {
+					if (!(error instanceof TransientJobExecutionError)) {
+						throw error
+					}
+					const retryAt = computeJobRetryAt({
+						now: input.now ?? new Date(),
+						retryCount: row.retry_count,
+					})
+					const retried = await retryClaimedJobRow({
+						db: input.env.APP_DB,
+						userId: input.userId,
+						jobId: row.id,
+						claimToken,
+						nextRunAt: retryAt,
+					})
+					if (!retried) {
+						throw new Error(
+							`Scheduled job "${row.id}" lost its fenced execution claim before retry transition.`,
+						)
+					}
+					errorCount += 1
+					jobOutcomes.push({
+						jobId: row.id,
+						scheduleType: row.record.schedule.type,
+						outcome: 'failure',
+						nextRunAt: retryAt,
+						deleted: false,
+						error: error.message,
+					})
+				}
 			}
 			await cleanupArchivedJobArtifacts({
 				env: input.env,
 				now,
 			})
 			return {
-				dueJobCount: dueRows.length,
-				successCount: result.successCount,
-				errorCount: result.errorCount,
-				jobOutcomes: result.jobOutcomes,
+				dueJobCount: claimedJobCount,
+				successCount,
+				errorCount,
+				jobOutcomes,
 			}
 		},
 	})
@@ -1566,5 +1755,10 @@ export async function runDueJobsForUser(input: {
 
 export async function getNextRunnableJob(input: { env: Env; userId: string }) {
 	const row = await getNextRunnableJobRow(input.env.APP_DB, input.userId)
-	return row?.record ?? null
+	return row
+		? {
+				...row.record,
+				nextRunAt: row.schedulerWakeAt,
+			}
+		: null
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -447,6 +447,10 @@
 		{
 			"filename": "0105-restore-safe-row-sizes.sql",
 			"sha256": "0c40218da221b778df2869e0533828844fabe3664423b07a3466721ba924f6c5"
+		},
+		{
+			"filename": "0107-job-execution-claims.sql",
+			"sha256": "2912bf29b37f179cf6517e02a064a509089c146edf49ab829f92927a517c5242"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- atomically claim due jobs with user-scoped, expiring D1 leases
- deduplicate each scheduled occurrence through a `{jobId, scheduledFor}` run-record key
- retry transient pre-execution failures with exponential backoff while preserving permanent/once behavior
- fence stale finalizers and ordinary edits, and wake the scheduler for lease/backoff expiry

## Testing
- `npm run test:node -- --run packages/worker/src/jobs` — 54 passed
- `npm run test:workers -- --run packages/worker/src/jobs/repo.workers.test.ts` — 3 passed
- `npm run validate` — passed

## Conductor Report
STATUS: done

What changed:
- `packages/worker/src/jobs/repo.ts`: conditional claims, ten-minute leases, retry state, completion fencing, and scheduler wake selection
- `packages/worker/src/jobs/service.ts`: run-record idempotency/replay, transient backoff, caller-user validation, and fenced finalization
- `packages/worker/src/jobs/execution-safety.ts`: occurrence keys, transient classification/backoff, replay helpers
- `packages/worker/migrations/0107-job-execution-claims.sql` + migration ledger: append-only claim columns
- focused node and Workers workflow coverage for overlap, replay, retry, and lease reclaim

Tests run:
- focused jobs node tests: 54 passed
- real D1 jobs repository tests: 3 passed
- `npm run validate`: passed (format, lint, typecheck, node/Workers tests, Playwright, MCP E2E, backup build, primitives, migrations)

Blocker: none.

Scope spill: none.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6620d1b3` · **Head:** `d18e762c`

**Classification:** extends — scheduled-job execution and D1 metadata gain lease, replay, and retry contracts.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `jobs` | assistant | extends — conditional execution claims, occurrence replay, and transient backoff |
| `d1-app-db` | storage | extends — append-only job claim/retry columns |
| `run-records` | storage | composes — existing user-scoped idempotency claims fence scheduled occurrences |

### System map

Due jobs flow through a fenced D1 claim, use RunLog as the per-occurrence replay boundary, then finalize or back off the same D1 occurrence.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  jobs["jobs<br/>Scheduled jobs"]:::extended
  d1["d1-app-db<br/>D1 app database"]:::extended
  runs["run-records<br/>Run records"]:::touched
  jobs -->|"conditional claim, lease, retry, fenced finalize"| d1
  jobs -->|"jobId + scheduledFor idempotency key"| runs
  runs -->|"terminal replay or running backoff"| jobs
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Every claim, retry, and finalization query is scoped by `user_id`.
- Persisted caller context must match the authoritative job-row user before execution.
- Run records remain history; D1 job rows remain current scheduler state.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05e05fce-0a05-4f38-a773-b2b5d382f69a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e05fce-0a05-4f38-a773-b2b5d382f69a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

