### PR TITLE
Document intentional kody resources kept on the DR (KCD) Cloudflare account (#656)

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -74,6 +74,39 @@ Nightly */5 ticks 00:30–06:10 UTC           02:15 UTC: D1 export Workflow
 06:15 UTC: staging watchdog → Sentry        Admin UI: drill / production restore
 ```
 
+### What intentionally lives on the DR (KCD) account
+
+The DR (“KCD”) Cloudflare account (`a41d50ecaf0ae0f86dd1824ef6729cb2`) is the
+old pre-migration production account, kept as the independently administered DR
+destination. Production runs on the Kody account
+(`a99ee2e72728dd52902ef288b7b1447d`). Future account cleanups must not delete
+the kody-named resources below — they are intentional cross-account leftovers.
+
+**DR / backup stack (this runbook):**
+
+- Worker `kody-production-d1-backups` (hourly + nightly crons)
+- Workflows `kody-production-d1-backup` and `kody-production-dr-restore`
+- Locked R2 bucket `kody-production-backups`
+- Custom domain `kody-dr.kentcdodds.com`
+
+**Personal journaling package data** (not platform infrastructure; reached via
+API tokens from Kent's personal Kody packages, not Worker bindings):
+
+- D1 `kody-journals`
+- Vectorize index `kody-journals`
+- R2 buckets `kody-journals` and `kody-journals-backup`
+
+**AI Gateway `kody`** — still used by personal package jobs against that
+account's Workers AI. The platform's own `AI_GATEWAY_ID` routes through the
+same-named gateway on the production (Kody) account via the Workers AI binding,
+which is account-scoped; the two gateways are independent.
+
+A 2026-07-29 cleanup ([#656](https://github.com/kentcdodds/kody/issues/656))
+removed the last orphaned platform leftovers on the KCD account (stale
+`kody-capabilities-prod` / `kody-capabilities-preview` Vectorize indexes; the
+old production workers, KV namespaces, preview D1, and the `heykody.dev` zone
+were already gone or moved).
+
 ### Bucket layout
 
 Contract: `packages/shared/src/backup-staging.ts`.

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -101,7 +101,8 @@ account's Workers AI. The platform's own `AI_GATEWAY_ID` routes through the
 same-named gateway on the production (Kody) account via the Workers AI binding,
 which is account-scoped; the two gateways are independent.
 
-A 2026-07-29 cleanup ([#656](https://github.com/kentcdodds/kody/issues/656))
+A 2026-07-29 cleanup ([#656](https://github.com/kentcdodds/kody/issues/656);
+[full audit and deletion record](https://github.com/kentcdodds/kody/issues/656#issuecomment-5122327193))
 removed the last orphaned platform leftovers on the KCD account (stale
 `kody-capabilities-prod` / `kody-capabilities-preview` Vectorize indexes; the
 old production workers, KV namespaces, preview D1, and the `heykody.dev` zone


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the documentation half of [#656](https://github.com/kentcdodds/kody/issues/656) (clean up leftover Kody resources on the old KCD Cloudflare account). The cloud-side cleanup was executed via the Cloudflare API on 2026-07-29; this PR records the permanent cross-account keepers in the disaster-recovery runbook so a future cleanup does not delete live resources.

## What the audit found (old KCD account `a41d50ec…`)

- **Already gone:** every leftover the issue listed — workers `kody-production` / `kody-well-known`, KV `kody-oauth` / `kody-bundle-artifacts`, D1 `kody-preview`, and the `heykody.dev` zone (no stale custom-domain bindings). Nothing in GitHub Actions, DNS, email routing, or production config targets them.
- **Deleted in this cleanup:** orphaned Vectorize indexes `kody-capabilities-prod` and `kody-capabilities-preview` (no worker bindings across all 79 scripts on the account, idle since the 2026-07-06/07 migration, superseded by same-named indexes on the Kody account).
- **Kept intentionally (now documented):**
  - the DR/backup stack (`kody-production-d1-backups` worker + two workflows + locked `kody-production-backups` R2 bucket + `kody-dr.kentcdodds.com`), which deliberately lives on the independently administered KCD account per the DR runbook;
  - live personal journaling package data (`kody-journals` D1/Vectorize/R2 + `kody-journals-backup` R2, written as recently as 2026-07-28);
  - AI Gateway `kody`, still receiving scheduled personal-package traffic (the platform's `AI_GATEWAY_ID` routes through the independent same-named gateway on the production account via the account-scoped Workers AI binding).

## Docs change

Adds a "What intentionally lives on the DR (KCD) account" section to `docs/contributing/disaster-recovery.md`, placed with the architecture description of the DR account.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk, docs-only)</summary>

**Mode:** recap · **Base:** `main` @ `60edb3d3` · **Head:** `8a1a06f6`

**Classification:** composes — docs-only change; no primitives added or changed. The classifier matched no primitive code roots (`docs/contributing/disaster-recovery.md` only).

### Primitives touched

None. This PR documents which Cloudflare resources intentionally remain on the DR (KCD) account after the #656 cleanup; runtime behavior is unchanged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27dfc149-f420-441f-ac56-7ca6db27ca1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27dfc149-f420-441f-ac56-7ca6db27ca1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the disaster-recovery runbook with guidance on resources intentionally retained in the DR account.
  * Documented protected backup infrastructure and personal journaling data that must remain during account cleanup.
  * Clarified how AI Gateway usage is maintained across accounts.
  * Recorded the resources removed during the July 29, 2026 cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->