### PR TITLE
fix: use package-app origin for search hosted URLs

### DIFF
--- a/packages/worker/src/mcp/tools/search-detail.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-detail.node.test.ts
@@ -225,3 +225,53 @@ test('resolveEntityDetail keeps integrations isolated by userId', async () => {
 		name: 'github',
 	})
 })
+
+test('resolveEntityDetail hostedUrl uses PACKAGE_APP_BASE_URL when configured', async () => {
+	mockModule.getSavedPackageByKodyId.mockReset()
+	mockModule.getSavedPackageByKodyId.mockResolvedValue({
+		packageId: 'pkg-1',
+		kodyId: 'demo',
+		name: '@user/demo',
+		description: 'Demo package',
+		hasApp: true,
+		sourceId: 'source-1',
+	})
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	mockModule.loadPackageSourceBySourceId.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		manifest: { kody: {} },
+		files: {},
+	})
+
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'user',
+		},
+	})
+	const agent = {
+		getEnv: () =>
+			({
+				APP_DB: {},
+				PACKAGE_APP_BASE_URL: 'https://kodyapps.dev',
+			}) as Env,
+		getCallerContext: () => callerContext,
+	} as unknown as McpRegistrationAgent
+
+	const detail = await resolveEntityDetail({
+		agent,
+		callerContext,
+		userId: 'user-1',
+		username: 'kentcdodds',
+		entity: 'demo:package',
+		searchRows: emptySearchRows() as never,
+	})
+
+	expect(detail).toMatchObject({
+		type: 'package',
+		hostedUrl: 'https://kodyapps.dev/@kentcdodds/packages/demo',
+		baseUrl: 'https://heykody.dev',
+	})
+})

--- a/packages/worker/src/mcp/tools/search-detail.ts
+++ b/packages/worker/src/mcp/tools/search-detail.ts
@@ -7,6 +7,7 @@ import {
 	parseValueEntityId,
 } from '#mcp/tools/search-entities.ts'
 import { getValue } from '#mcp/values/service.ts'
+import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
 import {
 	getJoinedIntegration,
 	toIntegrationConfig,
@@ -69,12 +70,15 @@ export async function resolveEntityDetail(input: {
 		if (!record) {
 			throw new McpCallerError('Saved package not found for this user.')
 		}
+		const env = input.agent.getEnv()
 		const loaded = await loadPackageSourceBySourceId({
-			env: input.agent.getEnv(),
+			env,
 			baseUrl: input.callerContext.baseUrl,
 			userId: input.userId,
 			sourceId: record.sourceId,
 		})
+		const packageAppOrigin =
+			getPackageAppBaseUrl({ env }) ?? input.callerContext.baseUrl
 		return {
 			type: 'package' as const,
 			id: record.kodyId,
@@ -88,7 +92,7 @@ export async function resolveEntityDetail(input: {
 			hostedUrl:
 				record.hasApp && input.username
 					? buildPackageAppUrl({
-							origin: input.callerContext.baseUrl,
+							origin: packageAppOrigin,
 							username: input.username,
 							kodyId: record.kodyId,
 						})

--- a/packages/worker/src/mcp/tools/search-entity-plugin.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugin.ts
@@ -44,6 +44,8 @@ export type SearchEntitySlimFormatInput<
 > = {
 	match: Match
 	baseUrl: string
+	/** Origin for hosted package apps when separate from the app origin. */
+	packageAppBaseUrl?: string | null
 	username?: string | null
 }
 

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -405,7 +405,8 @@ export const packageSearchEntityPlugin = {
 			keptIds.has(candidate.match.packageId),
 		)
 	},
-	formatSlimMatch({ match, baseUrl, username }) {
+	formatSlimMatch({ match, baseUrl, packageAppBaseUrl, username }) {
+		const hostedAppOrigin = packageAppBaseUrl ?? baseUrl
 		const rootImportUsage = buildPackageRootImportUsage(match.name)
 		const actionMatches = (match.actionMatches ?? []).map((actionMatch) => {
 			const importSpecifier = buildPackageImportSpecifier(
@@ -456,7 +457,7 @@ export const packageSearchEntityPlugin = {
 			hidden: match.hidden,
 			hostedUrl:
 				match.hasApp && username
-					? buildPackageHostedUrl(baseUrl, username, match.kodyId)
+					? buildPackageHostedUrl(hostedAppOrigin, username, match.kodyId)
 					: null,
 			readmeSnippet: match.readmeSnippet
 				? {

--- a/packages/worker/src/mcp/tools/search-format-slim.ts
+++ b/packages/worker/src/mcp/tools/search-format-slim.ts
@@ -7,6 +7,7 @@ import {
 export function toSlimStructuredMatches(input: {
 	matches: Array<SearchMatch>
 	baseUrl: string
+	packageAppBaseUrl?: string | null
 	username?: string | null
 }): Array<SlimSearchMatch> {
 	return input.matches.map((match) => {
@@ -17,6 +18,7 @@ export function toSlimStructuredMatches(input: {
 		return plugin.formatSlimMatch({
 			match: match as never,
 			baseUrl: input.baseUrl,
+			packageAppBaseUrl: input.packageAppBaseUrl,
 			username: input.username,
 		})
 	})

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/cloudflare'
+import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
 import { resolvePublicUsername } from '#worker/identity/user-lookup.ts'
 import { isMcpCallerError } from '#mcp/caller-error.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
@@ -494,6 +495,7 @@ export async function runSearchTool(input: {
 			matches: toSlimStructuredMatches({
 				matches: trimmedPayload.matches,
 				baseUrl,
+				packageAppBaseUrl: getPackageAppBaseUrl({ env: agent.getEnv() }),
 				username,
 			}),
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Search was still building package **Hosted URL** / **Open** links from the MCP app origin (`heykody.dev`). With package apps on `kodyapps.dev` via `PACKAGE_APP_BASE_URL`, those links should use the package-app origin (falling back to the app origin when unset, e.g. local/preview).

External invocation / account URLs stay on the app origin.

## Changes

- Package entity detail `hostedUrl` prefers `getPackageAppBaseUrl(env)`
- Slim package search matches thread `packageAppBaseUrl` the same way
- Unit coverage for `PACKAGE_APP_BASE_URL` → hosted URL

## Package audit (separate, already published)

Hardcoded hosted-app references in Kent’s packages were updated and published via the git lane (not this PR):

| Package | Change |
| --- | --- |
| `morning-briefing` | report/screenshot URLs + normalize old stored reports on read |
| `discord` | operator + chat-trace hosted URLs (canonical `/@kentcdodds/packages/...`) |
| `email-received-subscriber` | trace app URLs |
| `personal-history` | discord `gatewayHostedUrl` |
| `stash` | R2 CORS origin |
| `youtube-livestream-vod-manager` | app fallback URL |

Account/API/`@inbox.heykody.dev` refs left unchanged. Other packages had no hosted-app URL hits.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

### Overall
- **Classification:** extends
- **Risk:** medium — changes which origin search uses for hosted package-app links
- **Primitives touched:** `mcp-server`

### Primitive impact

| Primitive | Classification | What changed |
| --- | --- | --- |
| `mcp-server` | extends | Search package `hostedUrl` / slim match Open links prefer `PACKAGE_APP_BASE_URL` over the MCP request app origin |

### Flow

```mermaid
flowchart LR
  MCP["MCP search on heykody.dev"] --> Resolve["resolveEntityDetail / formatSlimMatch"]
  Resolve --> PkgOrigin["getPackageAppBaseUrl()"]
  PkgOrigin -->|set| Apps["kodyapps.dev/@user/packages/..."]
  PkgOrigin -->|unset| AppOrigin["app origin /@user/packages/..."]
  Resolve --> Api["invocation URLs stay on app origin"]
```

### Invariants
- Per-user package isolation unchanged
- Account / package-invocation URLs remain on the app origin

### Docs
- Related: `docs/contributing/environment-variables.md` (`PACKAGE_APP_BASE_URL`), `docs/contributing/security.md` (package-app origin)

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff60845d-0b6b-464d-8e7c-5bb54227340d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff60845d-0b6b-464d-8e7c-5bb54227340d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Package search results now generate hosted links using the configured package app address when available.
  - Package details and slim search results consistently preserve the caller’s base address while linking to the appropriate package application.
  - When no separate package app address is configured, links continue to use the standard application address.

- **Tests**
  - Added coverage verifying package links and base addresses are resolved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->