### PR TITLE
Clear package-owned durable state on delete and key app values by appId only

### DIFF
--- a/packages/worker/migrations/0109-delete-stranded-app-value-buckets.sql
+++ b/packages/worker/migrations/0109-delete-stranded-app-value-buckets.sql
@@ -1,0 +1,9 @@
+-- Delete app-scoped value buckets that the old getStorageBindingKey fallback
+-- keyed by ad hoc job:/exec: storage ids. App-scoped values are package config
+-- keyed by saved package id (appId); those prefixes are never real package ids,
+-- and the saved_packages guard makes the delete unreachable for package config.
+
+DELETE FROM value_buckets
+WHERE scope = 'app'
+	AND (binding_key LIKE 'job:%' OR binding_key LIKE 'exec:%')
+	AND binding_key NOT IN (SELECT id FROM saved_packages);

--- a/packages/worker/src/mcp/storage-bindings.ts
+++ b/packages/worker/src/mcp/storage-bindings.ts
@@ -23,9 +23,7 @@ export function getStorageBindingKey(
 	if (scope === 'user') return ''
 	if (scope === 'app') {
 		const appId = storageContext?.appId?.trim()
-		if (appId) return appId
-		const storageId = storageContext?.storageId?.trim()
-		return storageId || null
+		return appId || null
 	}
 	if (scope === 'session') {
 		const sessionId = storageContext?.sessionId?.trim()

--- a/packages/worker/src/mcp/values/migration.node.test.ts
+++ b/packages/worker/src/mcp/values/migration.node.test.ts
@@ -1,0 +1,102 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationsDirectory = new URL('../../../migrations/', import.meta.url)
+const strandedAppValueBucketsMigration =
+	'0109-delete-stranded-app-value-buckets.sql'
+
+function applyMigrationsBefore(db: DatabaseSync, exclusiveUpperBound: string) {
+	for (const fileName of readdirSync(migrationsDirectory)
+		.filter((file) => file.endsWith('.sql') && file < exclusiveUpperBound)
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
+	}
+}
+
+function applyMigration(db: DatabaseSync, fileName: string) {
+	db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
+}
+
+const now = '2026-07-01T00:00:00.000Z'
+
+test('stranded job/exec app value buckets migration deletes fallback rows only', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBefore(db, strandedAppValueBucketsMigration)
+	db.exec('PRAGMA foreign_keys = ON')
+
+	db.exec(`
+		INSERT INTO saved_packages (
+			id, user_id, name, kody_id, description, source_id, has_app,
+			created_at, updated_at
+		) VALUES
+			(
+				'pkg-real-1', 'user-a', '@a/notes', 'notes', 'Notes',
+				'source-pkg-1', 1, '${now}', '${now}'
+			),
+			(
+				'job:guarded-package', 'user-a', '@a/guarded', 'guarded', 'Guarded',
+				'source-pkg-2', 0, '${now}', '${now}'
+			);
+
+		INSERT INTO value_buckets (
+			id, user_id, scope, binding_key, expires_at, created_at, updated_at
+		) VALUES
+			('bucket-job', 'user-a', 'app', 'job:job-123', NULL, '${now}', '${now}'),
+			('bucket-exec', 'user-a', 'app', 'exec:exec-456', NULL, '${now}', '${now}'),
+			('bucket-pkg', 'user-a', 'app', 'pkg-real-1', NULL, '${now}', '${now}'),
+			(
+				'bucket-guarded', 'user-a', 'app', 'job:guarded-package',
+				NULL, '${now}', '${now}'
+			),
+			('bucket-user', 'user-a', 'user', '', NULL, '${now}', '${now}');
+
+		INSERT INTO value_entries (
+			bucket_id, name, description, value, created_at, updated_at
+		) VALUES
+			('bucket-job', 'workspaceSlug', '', 'job-value', '${now}', '${now}'),
+			('bucket-exec', 'workspaceSlug', '', 'exec-value', '${now}', '${now}'),
+			('bucket-pkg', 'workspaceSlug', '', 'pkg-value', '${now}', '${now}'),
+			(
+				'bucket-guarded', 'workspaceSlug', '', 'guarded-value',
+				'${now}', '${now}'
+			),
+			('bucket-user', 'workspaceSlug', '', 'user-value', '${now}', '${now}');
+	`)
+
+	applyMigration(db, strandedAppValueBucketsMigration)
+
+	const buckets = db
+		.prepare(
+			`SELECT id, scope, binding_key
+			FROM value_buckets
+			ORDER BY id ASC`,
+		)
+		.all() as Array<{ id: string; scope: string; binding_key: string }>
+	expect(buckets).toEqual([
+		{
+			id: 'bucket-guarded',
+			scope: 'app',
+			binding_key: 'job:guarded-package',
+		},
+		{ id: 'bucket-pkg', scope: 'app', binding_key: 'pkg-real-1' },
+		{ id: 'bucket-user', scope: 'user', binding_key: '' },
+	])
+
+	const entries = db
+		.prepare(
+			`SELECT bucket_id, name, value
+			FROM value_entries
+			ORDER BY bucket_id ASC`,
+		)
+		.all() as Array<{ bucket_id: string; name: string; value: string }>
+	expect(entries).toEqual([
+		{
+			bucket_id: 'bucket-guarded',
+			name: 'workspaceSlug',
+			value: 'guarded-value',
+		},
+		{ bucket_id: 'bucket-pkg', name: 'workspaceSlug', value: 'pkg-value' },
+		{ bucket_id: 'bucket-user', name: 'workspaceSlug', value: 'user-value' },
+	])
+})

--- a/packages/worker/src/mcp/values/service.node.test.ts
+++ b/packages/worker/src/mcp/values/service.node.test.ts
@@ -2,6 +2,10 @@ import { expect, test } from 'vitest'
 import { maxRestorableTextColumnBytes } from '@kody-internal/shared/backup-restore-safety.ts'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import {
+	getStorageBindingKey,
+	resolveStorageScopeOrder,
+} from '#mcp/storage-bindings.ts'
+import {
 	deleteAllAppScopedValues,
 	deleteValue,
 	getValue,
@@ -371,6 +375,34 @@ test('value service rejects unavailable scoped storage', async () => {
 		(error: unknown) =>
 			error instanceof McpCallerError &&
 			error.message === 'Value scope "session" is unavailable in this context.',
+	)
+})
+
+test('value service rejects app scope when only storageId is bound', async () => {
+	const testDb = createValueTestDb()
+	const env = { APP_DB: testDb.db }
+	const storageContext = {
+		sessionId: null,
+		appId: null,
+		storageId: 'job:job-123',
+	}
+
+	expect(getStorageBindingKey('app', storageContext)).toBeNull()
+	expect(resolveStorageScopeOrder(storageContext)).toEqual(['user'])
+
+	await expect(
+		saveValue({
+			env,
+			userId: 'user-123',
+			scope: 'app',
+			name: 'workspaceSlug',
+			value: 'job-scratch-as-app',
+			storageContext,
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message === 'Value scope "app" is unavailable in this context.',
 	)
 })
 

--- a/packages/worker/src/mcp/values/service.node.test.ts
+++ b/packages/worker/src/mcp/values/service.node.test.ts
@@ -406,6 +406,61 @@ test('value service rejects app scope when only storageId is bound', async () =>
 	)
 })
 
+test('value service cannot read legacy app buckets keyed by storageId', async () => {
+	const testDb = createValueTestDb()
+	const env = { APP_DB: testDb.db }
+	const storageContext = {
+		sessionId: null,
+		appId: null,
+		storageId: 'job:job-123',
+	}
+	const now = new Date().toISOString()
+	const bucketId = 'legacy-job-app-bucket'
+	testDb.buckets.set('user-123:app:job:job-123', {
+		id: bucketId,
+		user_id: 'user-123',
+		scope: 'app',
+		binding_key: 'job:job-123',
+		expires_at: null,
+		created_at: now,
+		updated_at: now,
+	})
+	testDb.entries.set(`${bucketId}:workspaceSlug`, {
+		bucket_id: bucketId,
+		name: 'workspaceSlug',
+		description: 'Legacy job-keyed app value',
+		value: 'stranded-job-value',
+		created_at: now,
+		updated_at: now,
+	})
+
+	expect(resolveStorageScopeOrder(storageContext)).toEqual(['user'])
+	expect(
+		await getValue({
+			env,
+			userId: 'user-123',
+			name: 'workspaceSlug',
+			storageContext,
+		}),
+	).toBeNull()
+	expect(
+		await getValue({
+			env,
+			userId: 'user-123',
+			name: 'workspaceSlug',
+			scope: 'app',
+			storageContext,
+		}),
+	).toBeNull()
+	expect(
+		await listValues({
+			env,
+			userId: 'user-123',
+			storageContext,
+		}),
+	).toEqual([])
+})
+
 test('value service rejects values too large for restorable D1 backups', async () => {
 	const testDb = createValueTestDb()
 	const env = { APP_DB: testDb.db }

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -46,6 +46,9 @@ const mockModule = vi.hoisted(() => ({
 	cleanupArtifactReposForPackage: vi.fn(),
 	deleteAllPackageScopedSecrets: vi.fn(),
 	removeAllSecretApprovalsForPackage: vi.fn(),
+	deleteAllAppScopedValues: vi.fn(),
+	clearStorage: vi.fn(async () => ({ ok: true as const })),
+	storageRunnerRpc: vi.fn(),
 }))
 
 vi.mock('./manifest.ts', () => ({
@@ -73,6 +76,27 @@ vi.mock('#worker/package-runtime/package-service.ts', () => ({
 		mockModule.listSavedPackageServices(...args),
 	packageServiceRpc: (...args: Array<unknown>) =>
 		mockModule.packageServiceRpc(...args),
+	buildPackageServiceStorageId: (packageId: string, serviceName: string) =>
+		`service:${encodeURIComponent(packageId)}:${encodeURIComponent(serviceName)}`,
+}))
+
+vi.mock('#worker/storage-runner.ts', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>
+	return {
+		...actual,
+		storageRunnerRpc: (...args: Array<unknown>) => {
+			mockModule.storageRunnerRpc(...args)
+			return {
+				clearStorage: (...clearArgs: Array<unknown>) =>
+					mockModule.clearStorage(...clearArgs),
+			}
+		},
+	}
+})
+
+vi.mock('#mcp/values/service.ts', () => ({
+	deleteAllAppScopedValues: (...args: Array<unknown>) =>
+		mockModule.deleteAllAppScopedValues(...args),
 }))
 
 vi.mock('#worker/package-retrievers/manifest-cache.ts', () => ({
@@ -143,12 +167,21 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 const { deleteSavedPackageProjection, refreshSavedPackageProjection } =
 	await import('./service.ts')
 
-function createEnv(userId = 'user-1') {
+function createEnv(
+	userId = 'user-1',
+	options?: {
+		storageBuckets?: Array<{ userId: string; storageId: string }>
+	},
+) {
 	// Projection refresh asserts finite storage bytes (default/missing plan →
 	// `max`). Stub DB answers storage SUM queries with 0 so unplanned unit
 	// fixtures keep focusing on job/artifact side effects.
 	return {
-		APP_DB: createEntitlementsDatabase({ users: [], userId }),
+		APP_DB: createEntitlementsDatabase({
+			users: [],
+			userId,
+			storageBuckets: options?.storageBuckets,
+		}),
 		PACKAGE_SERVICE_INSTANCE: mockPackageServiceNamespace(),
 	} as Env
 }
@@ -195,6 +228,11 @@ function setupDefaultMocks() {
 		start: vi.fn().mockResolvedValue({ ok: true }),
 		stop: vi.fn().mockResolvedValue({ ok: true }),
 	})
+	mockModule.deleteAllAppScopedValues.mockResolvedValue(undefined)
+	mockModule.storageRunnerRpc.mockClear()
+	mockModule.clearStorage.mockReset()
+	mockModule.clearStorage.mockResolvedValue({ ok: true as const })
+	mockModule.listJobRowsByUserId.mockResolvedValue([])
 }
 
 test('refreshSavedPackageProjection syncs the job manager only when package jobs change', async () => {
@@ -691,15 +729,224 @@ test('deleteSavedPackageProjection cleans secrets when package projection is mis
 		userId: 'user-1',
 		packageId: 'missing-package',
 	})
+	expect(mockModule.deleteAllAppScopedValues).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+		appId: 'missing-package',
+	})
+	expect(mockModule.clearStorage).toHaveBeenCalled()
+})
+
+test('deleteSavedPackageProjection clears package-owned storage buckets and inventory rows', async () => {
+	setupDefaultMocks()
+	const packageId = 'b2fda105-005a-4e2b-9f22-1513b6752da2'
+	const jobStorageId = `job:package-job:${packageId}:event-runner`
+	const serviceStorageId = `service:${encodeURIComponent(packageId)}:${encodeURIComponent('realtime-supervisor')}`
+	const packageStorageId = `package:${encodeURIComponent(packageId)}`
+	const facetStorageId = `${packageId}:facet:main`
+	const otherPackageId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+	const otherUserBucket = {
+		userId: 'user-2',
+		storageId: packageStorageId,
+	}
+	const otherPackageBucket = {
+		userId: 'user-1',
+		storageId: `package:${encodeURIComponent(otherPackageId)}`,
+	}
+	const storageBuckets = [
+		{ userId: 'user-1', storageId: packageStorageId },
+		{ userId: 'user-1', storageId: packageId },
+		{ userId: 'user-1', storageId: jobStorageId },
+		{ userId: 'user-1', storageId: serviceStorageId },
+		{ userId: 'user-1', storageId: facetStorageId },
+		otherUserBucket,
+		otherPackageBucket,
+		{
+			userId: 'user-1',
+			storageId: `job:package-job:${otherPackageId}:nightly`,
+		},
+	]
+	const env = createEnv('user-1', { storageBuckets })
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: packageId,
+		kodyId: 'shade-automation',
+		sourceId: 'source-1',
+	})
+	mockModule.listSavedPackageServices.mockResolvedValue({
+		savedPackage: {
+			id: packageId,
+			kodyId: 'shade-automation',
+		},
+		services: [
+			{
+				name: 'realtime-supervisor',
+				entry: './src/services/realtime-supervisor.ts',
+				autoStart: true,
+				mode: 'persistent',
+				timeoutMs: null,
+			},
+		],
+	})
+	mockModule.listJobRowsByUserId.mockResolvedValue([
+		{
+			id: `package-job:${packageId}:event-runner`,
+			source_id: 'source-1',
+			storage_id: jobStorageId,
+		},
+	])
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		packageId,
+	})
+
+	const clearedStorageIds = mockModule.storageRunnerRpc.mock.calls.map(
+		(call) => (call[0] as { storageId: string }).storageId,
+	)
+	expect(clearedStorageIds).toEqual(
+		expect.arrayContaining([
+			packageStorageId,
+			packageId,
+			jobStorageId,
+			serviceStorageId,
+			facetStorageId,
+		]),
+	)
+	expect(clearedStorageIds).not.toContain(otherPackageBucket.storageId)
+	expect(clearedStorageIds).not.toContain(
+		`job:package-job:${otherPackageId}:nightly`,
+	)
+	for (const call of mockModule.storageRunnerRpc.mock.calls) {
+		expect(call[0]).toMatchObject({ userId: 'user-1' })
+	}
+	expect(mockModule.clearStorage).toHaveBeenCalledTimes(
+		clearedStorageIds.length,
+	)
+	expect(storageBuckets).toEqual(
+		expect.arrayContaining([
+			otherUserBucket,
+			otherPackageBucket,
+			{
+				userId: 'user-1',
+				storageId: `job:package-job:${otherPackageId}:nightly`,
+			},
+		]),
+	)
+	const remainingKeys = new Set(
+		storageBuckets.map((row) => `${row.userId}:${row.storageId}`),
+	)
+	for (const storageId of [
+		packageStorageId,
+		packageId,
+		jobStorageId,
+		serviceStorageId,
+		facetStorageId,
+	]) {
+		expect(remainingKeys.has(`user-1:${storageId}`)).toBe(false)
+	}
+	expect(mockModule.deleteAllAppScopedValues).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+		appId: packageId,
+	})
+})
+
+test('deleteSavedPackageProjection keeps inventory when clearStorage fails and continues delete', async () => {
+	consoleWarn.mockImplementation(() => {})
+	setupDefaultMocks()
+	const packageId = 'b2fda105-005a-4e2b-9f22-1513b6752da2'
+	const packageStorageId = `package:${encodeURIComponent(packageId)}`
+	const failingStorageId = `${packageId}:facet:main`
+	const storageBuckets = [
+		{ userId: 'user-1', storageId: packageStorageId },
+		{ userId: 'user-1', storageId: failingStorageId },
+		{ userId: 'user-1', storageId: packageId },
+	]
+	const env = createEnv('user-1', { storageBuckets })
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: packageId,
+		kodyId: 'shade-automation',
+		sourceId: 'source-1',
+	})
+	mockModule.listJobRowsByUserId.mockResolvedValue([])
+	mockModule.clearStorage.mockImplementation(async () => {
+		const call = mockModule.storageRunnerRpc.mock.calls.at(-1)?.[0] as
+			| { storageId: string }
+			| undefined
+		if (call?.storageId === failingStorageId) {
+			throw new Error('do unavailable')
+		}
+		return { ok: true as const }
+	})
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		packageId,
+	})
+
+	expect(mockModule.deleteSavedPackage).toHaveBeenCalledWith(env.APP_DB, {
+		userId: 'user-1',
+		packageId,
+	})
+	expect(mockModule.deleteAllAppScopedValues).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+		appId: packageId,
+	})
+	expect(storageBuckets.map((row) => row.storageId)).toContain(failingStorageId)
+	expect(storageBuckets.map((row) => row.storageId)).not.toContain(
+		packageStorageId,
+	)
+	expect(storageBuckets.map((row) => row.storageId)).not.toContain(packageId)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining('"message":"package storage clear failed"'),
+	)
+})
+
+test('deleteSavedPackageProjection clears deterministic storage when projection is missing', async () => {
+	setupDefaultMocks()
+	const packageId = 'b2fda105-005a-4e2b-9f22-1513b6752da2'
+	const packageStorageId = `package:${encodeURIComponent(packageId)}`
+	const facetStorageId = `${packageId}:facet:main`
+	const storageBuckets = [
+		{ userId: 'user-1', storageId: packageStorageId },
+		{ userId: 'user-1', storageId: packageId },
+		{ userId: 'user-1', storageId: facetStorageId },
+	]
+	const env = createEnv('user-1', { storageBuckets })
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		packageId,
+	})
+
+	const clearedStorageIds = mockModule.storageRunnerRpc.mock.calls.map(
+		(call) => (call[0] as { storageId: string }).storageId,
+	)
+	expect(clearedStorageIds).toEqual(
+		expect.arrayContaining([packageStorageId, packageId, facetStorageId]),
+	)
+	expect(storageBuckets).toEqual([])
+	expect(mockModule.deleteAllAppScopedValues).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+		appId: packageId,
+	})
 })
 
 function createEntitlementsDatabase(input: {
 	users?: Array<{ email: string; plan: string | null }>
 	savedPackageCount?: number
 	userId: string
+	storageBuckets?: Array<{ userId: string; storageId: string }>
 }) {
 	const users = input.users ?? []
 	const savedPackageCount = input.savedPackageCount ?? 0
+	const storageBuckets = input.storageBuckets ?? []
 
 	return {
 		prepare(query: string) {
@@ -709,6 +956,30 @@ function createEntitlementsDatabase(input: {
 						async run() {
 							if (query.includes('UPDATE users')) {
 								return { meta: { changes: 1 } }
+							}
+							if (
+								query.includes(
+									'DELETE FROM user_storage_buckets WHERE user_id = ? AND storage_id = ?',
+								)
+							) {
+								const userId = String(params[0])
+								const storageId = String(params[1])
+								const before = storageBuckets.length
+								for (
+									let index = storageBuckets.length - 1;
+									index >= 0;
+									index--
+								) {
+									const row = storageBuckets[index]
+									if (
+										row &&
+										row.userId === userId &&
+										row.storageId === storageId
+									) {
+										storageBuckets.splice(index, 1)
+									}
+								}
+								return { meta: { changes: before - storageBuckets.length } }
 							}
 							throw new Error(`Unsupported run query: ${query}`)
 						},
@@ -743,6 +1014,34 @@ function createEntitlementsDatabase(input: {
 								return { count: 0 } as T
 							}
 							throw new Error(`Unsupported first query: ${query}`)
+						},
+						async all<T>() {
+							if (
+								query.includes('FROM user_storage_buckets') &&
+								query.includes('SELECT storage_id AS storageId')
+							) {
+								const userId = String(params[0])
+								const exactPackageId = String(params[1])
+								const facetPrefix = String(params[2])
+								const packageStorageId = String(params[3])
+								const servicePrefix = String(params[4])
+								const jobPrefix = String(params[5])
+								const results = storageBuckets
+									.filter((row) => {
+										if (row.userId !== userId) return false
+										const id = row.storageId
+										return (
+											id === exactPackageId ||
+											id.startsWith(facetPrefix) ||
+											id === packageStorageId ||
+											id.startsWith(servicePrefix) ||
+											id.startsWith(jobPrefix)
+										)
+									})
+									.map((row) => ({ storageId: row.storageId }))
+								return { results: results as Array<T> }
+							}
+							throw new Error(`Unsupported all query: ${query}`)
 						},
 					}
 				},

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -164,8 +164,11 @@ vi.mock('#worker/repo/entity-sources.ts', () => ({
 		mockModule.deleteEntitySource(...args),
 }))
 
-const { deleteSavedPackageProjection, refreshSavedPackageProjection } =
-	await import('./service.ts')
+const {
+	deleteSavedPackageProjection,
+	filterPackageOwnedStorageIdsFromInventory,
+	refreshSavedPackageProjection,
+} = await import('./service.ts')
 
 function createEnv(
 	userId = 'user-1',
@@ -820,9 +823,6 @@ test('deleteSavedPackageProjection clears package-owned storage buckets and inve
 	for (const call of mockModule.storageRunnerRpc.mock.calls) {
 		expect(call[0]).toMatchObject({ userId: 'user-1' })
 	}
-	expect(mockModule.clearStorage).toHaveBeenCalledTimes(
-		clearedStorageIds.length,
-	)
 	expect(storageBuckets).toEqual(
 		expect.arrayContaining([
 			otherUserBucket,
@@ -938,6 +938,157 @@ test('deleteSavedPackageProjection clears deterministic storage when projection 
 	})
 })
 
+test('filterPackageOwnedStorageIdsFromInventory exact-matches only for non-UUID package ids', () => {
+	const otherPackageId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+	const inventory = [
+		'job',
+		'package:job',
+		'job:ad-hoc-1',
+		`job:package-job:${otherPackageId}:nightly`,
+		'job:facet:main',
+		'service:job:realtime',
+		'%',
+		'package:%25',
+		'exec:scratch-1',
+		`${otherPackageId}:facet:main`,
+	]
+
+	expect(
+		filterPackageOwnedStorageIdsFromInventory({
+			packageId: 'job',
+			storageIds: inventory,
+		}).toSorted(),
+	).toEqual(['job', 'package:job'].toSorted())
+
+	expect(
+		filterPackageOwnedStorageIdsFromInventory({
+			packageId: '%',
+			storageIds: inventory,
+		}).toSorted(),
+	).toEqual(['%', 'package:%25'].toSorted())
+
+	expect(
+		filterPackageOwnedStorageIdsFromInventory({
+			packageId: 'exec',
+			storageIds: [...inventory, 'exec', 'package:exec'],
+		}).toSorted(),
+	).toEqual(['exec', 'package:exec'].toSorted())
+})
+
+test('filterPackageOwnedStorageIdsFromInventory applies UUID-gated prefixes', () => {
+	const packageId = 'b2fda105-005a-4e2b-9f22-1513b6752da2'
+	const otherPackageId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+	const packageStorageId = `package:${encodeURIComponent(packageId)}`
+	const facetStorageId = `${packageId}:facet:main`
+	const jobStorageId = `job:package-job:${packageId}:event-runner`
+	const serviceStorageId = `service:${encodeURIComponent(packageId)}:realtime-supervisor`
+	const inventory = [
+		packageId,
+		packageStorageId,
+		facetStorageId,
+		jobStorageId,
+		serviceStorageId,
+		'job:ad-hoc-1',
+		`job:package-job:${otherPackageId}:nightly`,
+		`${otherPackageId}:facet:main`,
+		`service:${encodeURIComponent(otherPackageId)}:other`,
+		'exec:scratch-1',
+	]
+
+	expect(
+		filterPackageOwnedStorageIdsFromInventory({
+			packageId,
+			storageIds: inventory,
+		}).toSorted(),
+	).toEqual(
+		[
+			packageId,
+			packageStorageId,
+			facetStorageId,
+			jobStorageId,
+			serviceStorageId,
+		].toSorted(),
+	)
+})
+
+test('deleteSavedPackageProjection does not clear unrelated buckets for package id "job"', async () => {
+	setupDefaultMocks()
+	const otherPackageId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+	const storageBuckets = [
+		{ userId: 'user-1', storageId: 'job' },
+		{ userId: 'user-1', storageId: 'package:job' },
+		{ userId: 'user-1', storageId: 'job:ad-hoc-1' },
+		{
+			userId: 'user-1',
+			storageId: `job:package-job:${otherPackageId}:nightly`,
+		},
+		{ userId: 'user-1', storageId: 'job:facet:main' },
+	]
+	const env = createEnv('user-1', { storageBuckets })
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'job',
+		kodyId: 'job-pkg',
+		sourceId: 'source-job',
+	})
+	mockModule.listJobRowsByUserId.mockResolvedValue([])
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		packageId: 'job',
+	})
+
+	const clearedStorageIds = mockModule.storageRunnerRpc.mock.calls.map(
+		(call) => (call[0] as { storageId: string }).storageId,
+	)
+	expect(clearedStorageIds.toSorted()).toEqual(
+		['job', 'package:job'].toSorted(),
+	)
+	expect(storageBuckets.map((row) => row.storageId).toSorted()).toEqual(
+		[
+			'job:ad-hoc-1',
+			`job:package-job:${otherPackageId}:nightly`,
+			'job:facet:main',
+		].toSorted(),
+	)
+})
+
+test('deleteSavedPackageProjection does not clear unrelated buckets for package id "%"', async () => {
+	setupDefaultMocks()
+	const packageId = '%'
+	const packageStorageId = `package:${encodeURIComponent(packageId)}`
+	const otherPackageId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+	const storageBuckets = [
+		{ userId: 'user-1', storageId: packageId },
+		{ userId: 'user-1', storageId: packageStorageId },
+		{ userId: 'user-1', storageId: 'job:ad-hoc-1' },
+		{ userId: 'user-1', storageId: `${otherPackageId}:facet:main` },
+		{ userId: 'user-1', storageId: 'exec:scratch-1' },
+	]
+	const env = createEnv('user-1', { storageBuckets })
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-1',
+		packageId,
+	})
+
+	const clearedStorageIds = mockModule.storageRunnerRpc.mock.calls.map(
+		(call) => (call[0] as { storageId: string }).storageId,
+	)
+	expect(clearedStorageIds.toSorted()).toEqual(
+		[packageId, packageStorageId].toSorted(),
+	)
+	expect(storageBuckets.map((row) => row.storageId).toSorted()).toEqual(
+		[
+			'job:ad-hoc-1',
+			`${otherPackageId}:facet:main`,
+			'exec:scratch-1',
+		].toSorted(),
+	)
+})
+
 function createEntitlementsDatabase(input: {
 	users?: Array<{ email: string; plan: string | null }>
 	savedPackageCount?: number
@@ -1018,27 +1169,16 @@ function createEntitlementsDatabase(input: {
 						async all<T>() {
 							if (
 								query.includes('FROM user_storage_buckets') &&
-								query.includes('SELECT storage_id AS storageId')
+								query.includes('SELECT storage_id AS storageId') &&
+								query.includes('WHERE user_id = ?')
 							) {
 								const userId = String(params[0])
-								const exactPackageId = String(params[1])
-								const facetPrefix = String(params[2])
-								const packageStorageId = String(params[3])
-								const servicePrefix = String(params[4])
-								const jobPrefix = String(params[5])
 								const results = storageBuckets
-									.filter((row) => {
-										if (row.userId !== userId) return false
-										const id = row.storageId
-										return (
-											id === exactPackageId ||
-											id.startsWith(facetPrefix) ||
-											id === packageStorageId ||
-											id.startsWith(servicePrefix) ||
-											id.startsWith(jobPrefix)
-										)
-									})
+									.filter((row) => row.userId === userId)
 									.map((row) => ({ storageId: row.storageId }))
+									.sort((left, right) =>
+										left.storageId.localeCompare(right.storageId),
+									)
 								return { results: results as Array<T> }
 							}
 							throw new Error(`Unsupported all query: ${query}`)

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -27,6 +27,7 @@ import { deleteJobRow, listJobRowsByUserId } from '#worker/jobs/repo.ts'
 import { syncJobManagerAlarm } from '#worker/jobs/manager-client.ts'
 import { rebuildPublishedPackageArtifacts } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import {
+	buildPackageServiceStorageId,
 	listSavedPackageServices,
 	packageServiceRpc,
 } from '#worker/package-runtime/package-service.ts'
@@ -45,6 +46,11 @@ import {
 	deleteAllPackageScopedSecrets,
 	removeAllSecretApprovalsForPackage,
 } from '#mcp/secrets/service.ts'
+import { deleteAllAppScopedValues } from '#mcp/values/service.ts'
+import {
+	buildPackageStorageId,
+	storageRunnerRpc,
+} from '#worker/storage-runner.ts'
 
 function logPackageRetrieverProjectionError(input: {
 	action: 'refresh' | 'delete'
@@ -71,6 +77,85 @@ function logPackageRetrieverProjectionError(input: {
 
 function serializeTags(tags: Array<string>) {
 	return JSON.stringify(tags)
+}
+
+async function listPackageOwnedStorageIdsFromInventory(input: {
+	db: D1Database
+	userId: string
+	packageId: string
+}): Promise<Array<string>> {
+	const packageStorageId = buildPackageStorageId(input.packageId)
+	const servicePrefix = `service:${encodeURIComponent(input.packageId)}:`
+	const jobPrefix = `job:package-job:${input.packageId}:`
+	const facetPrefix = `${input.packageId}:`
+	const result = await input.db
+		.prepare(
+			`SELECT storage_id AS storageId
+			FROM user_storage_buckets
+			WHERE user_id = ?
+				AND (
+					storage_id = ?
+					OR storage_id LIKE ? || '%'
+					OR storage_id = ?
+					OR storage_id LIKE ? || '%'
+					OR storage_id LIKE ? || '%'
+				)`,
+		)
+		.bind(
+			input.userId,
+			input.packageId,
+			facetPrefix,
+			packageStorageId,
+			servicePrefix,
+			jobPrefix,
+		)
+		.all<{ storageId: string }>()
+	return (result.results ?? []).map((row) => row.storageId)
+}
+
+async function clearPackageOwnedStorageBucket(input: {
+	env: Env
+	userId: string
+	packageId: string
+	storageId: string
+}) {
+	let storageCleared = false
+	try {
+		await storageRunnerRpc({
+			env: input.env,
+			userId: input.userId,
+			storageId: input.storageId,
+		}).clearStorage()
+		storageCleared = true
+	} catch (error) {
+		console.warn(
+			JSON.stringify({
+				message: 'package storage clear failed',
+				userId: input.userId,
+				packageId: input.packageId,
+				storageId: input.storageId,
+				error: getErrorMessage(error),
+			}),
+		)
+	}
+	if (!storageCleared) return
+	try {
+		await input.env.APP_DB.prepare(
+			`DELETE FROM user_storage_buckets WHERE user_id = ? AND storage_id = ?`,
+		)
+			.bind(input.userId, input.storageId)
+			.run()
+	} catch (error) {
+		console.warn(
+			JSON.stringify({
+				message: 'package storage bucket unregister failed',
+				userId: input.userId,
+				packageId: input.packageId,
+				storageId: input.storageId,
+				error: getErrorMessage(error),
+			}),
+		)
+	}
 }
 
 function toSavedPackageInsertRow(input: {
@@ -330,6 +415,10 @@ export async function deleteSavedPackageProjection(input: {
 				userId: input.userId,
 				packageId: input.packageId,
 			})
+			const packageOwnedStorageIds = new Set<string>([
+				buildPackageStorageId(input.packageId),
+				input.packageId,
+			])
 			let packageJobsRemoved = false
 			if (savedPackage) {
 				const listedServices = await listSavedPackageServices({
@@ -349,6 +438,9 @@ export async function deleteSavedPackageProjection(input: {
 						baseUrl: 'https://package-service.invalid',
 						serviceName: service.name,
 					}).stop()
+					packageOwnedStorageIds.add(
+						buildPackageServiceStorageId(input.packageId, service.name),
+					)
 				}
 				await cleanupArtifactReposForPackage({
 					env: input.env,
@@ -387,9 +479,39 @@ export async function deleteSavedPackageProjection(input: {
 					(row) => row.source_id === savedPackage.sourceId,
 				)
 				for (const row of packageRows) {
+					if (row.storage_id) {
+						packageOwnedStorageIds.add(row.storage_id)
+					}
 					await deleteJobRow(input.env.APP_DB, input.userId, row.id)
 				}
 				packageJobsRemoved = packageRows.length > 0
+			}
+			try {
+				const inventoryIds = await listPackageOwnedStorageIdsFromInventory({
+					db: input.env.APP_DB,
+					userId: input.userId,
+					packageId: input.packageId,
+				})
+				for (const storageId of inventoryIds) {
+					packageOwnedStorageIds.add(storageId)
+				}
+			} catch (error) {
+				console.warn(
+					JSON.stringify({
+						message: 'package storage inventory lookup failed',
+						userId: input.userId,
+						packageId: input.packageId,
+						error: getErrorMessage(error),
+					}),
+				)
+			}
+			for (const storageId of packageOwnedStorageIds) {
+				await clearPackageOwnedStorageBucket({
+					env: input.env,
+					userId: input.userId,
+					packageId: input.packageId,
+					storageId,
+				})
 			}
 			await deleteAllPackageScopedSecrets({
 				env: input.env,
@@ -400,6 +522,20 @@ export async function deleteSavedPackageProjection(input: {
 				env: input.env,
 				userId: input.userId,
 				packageId: input.packageId,
+			})
+			await deleteAllAppScopedValues({
+				env: input.env,
+				userId: input.userId,
+				appId: input.packageId,
+			}).catch((error) => {
+				console.warn(
+					JSON.stringify({
+						message: 'package app-scoped values cleanup failed',
+						userId: input.userId,
+						packageId: input.packageId,
+						error: getErrorMessage(error),
+					}),
+				)
 			})
 			await deleteSavedPackage(input.env.APP_DB, {
 				userId: input.userId,

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -47,10 +47,14 @@ import {
 	removeAllSecretApprovalsForPackage,
 } from '#mcp/secrets/service.ts'
 import { deleteAllAppScopedValues } from '#mcp/values/service.ts'
+import { listUserStorageBucketIds } from '#worker/storage-buckets/service.ts'
 import {
 	buildPackageStorageId,
 	storageRunnerRpc,
 } from '#worker/storage-runner.ts'
+
+const savedPackageIdUuidPattern =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 function logPackageRetrieverProjectionError(input: {
 	action: 'refresh' | 'delete'
@@ -79,38 +83,60 @@ function serializeTags(tags: Array<string>) {
 	return JSON.stringify(tags)
 }
 
+/**
+ * Inventory prefix matching is UUID-gated on purpose. `package_save` accepts
+ * arbitrary non-empty package ids, so a raw prefix like `{packageId}:` can
+ * collide with reserved storage namespaces (`job:`, `exec:`, …) or carry LIKE
+ * metacharacters (`%`, `_`; `encodeURIComponent` can also introduce `%`). A
+ * UUID cannot contain `:` or those metacharacters and cannot equal the reserved
+ * namespace literals, which makes `{uuid}:…`, `service:{encodeURIComponent(uuid)}:…`,
+ * and `job:package-job:{uuid}:…` unambiguous. Non-UUID packages still clear the
+ * deterministic set (package bucket, raw id, job/service scratch ids from D1 /
+ * listed services); an orphaned facet bucket for a weird id stays inventoriable
+ * for account deletion.
+ */
+export function filterPackageOwnedStorageIdsFromInventory(input: {
+	packageId: string
+	storageIds: ReadonlyArray<string>
+}): Array<string> {
+	const packageStorageId = buildPackageStorageId(input.packageId)
+	const matched = new Set<string>()
+	for (const storageId of input.storageIds) {
+		if (storageId === input.packageId || storageId === packageStorageId) {
+			matched.add(storageId)
+		}
+	}
+	if (!savedPackageIdUuidPattern.test(input.packageId)) {
+		return [...matched]
+	}
+	const facetPrefix = `${input.packageId}:`
+	const servicePrefix = `service:${encodeURIComponent(input.packageId)}:`
+	const jobPrefix = `job:package-job:${input.packageId}:`
+	for (const storageId of input.storageIds) {
+		if (
+			storageId.startsWith(facetPrefix) ||
+			storageId.startsWith(servicePrefix) ||
+			storageId.startsWith(jobPrefix)
+		) {
+			matched.add(storageId)
+		}
+	}
+	return [...matched]
+}
+
 async function listPackageOwnedStorageIdsFromInventory(input: {
-	db: D1Database
+	env: Env
 	userId: string
 	packageId: string
 }): Promise<Array<string>> {
-	const packageStorageId = buildPackageStorageId(input.packageId)
-	const servicePrefix = `service:${encodeURIComponent(input.packageId)}:`
-	const jobPrefix = `job:package-job:${input.packageId}:`
-	const facetPrefix = `${input.packageId}:`
-	const result = await input.db
-		.prepare(
-			`SELECT storage_id AS storageId
-			FROM user_storage_buckets
-			WHERE user_id = ?
-				AND (
-					storage_id = ?
-					OR storage_id LIKE ? || '%'
-					OR storage_id = ?
-					OR storage_id LIKE ? || '%'
-					OR storage_id LIKE ? || '%'
-				)`,
-		)
-		.bind(
-			input.userId,
-			input.packageId,
-			facetPrefix,
-			packageStorageId,
-			servicePrefix,
-			jobPrefix,
-		)
-		.all<{ storageId: string }>()
-	return (result.results ?? []).map((row) => row.storageId)
+	const storageIds = await listUserStorageBucketIds({
+		env: input.env,
+		userId: input.userId,
+	})
+	return filterPackageOwnedStorageIdsFromInventory({
+		packageId: input.packageId,
+		storageIds,
+	})
 }
 
 async function clearPackageOwnedStorageBucket(input: {
@@ -488,7 +514,7 @@ export async function deleteSavedPackageProjection(input: {
 			}
 			try {
 				const inventoryIds = await listPackageOwnedStorageIdsFromInventory({
-					db: input.env.APP_DB,
+					env: input.env,
 					userId: input.userId,
 					packageId: input.packageId,
 				})

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -455,6 +455,10 @@
 		{
 			"filename": "0108-user-storage-buckets-package-kind.sql",
 			"sha256": "e5740a356896d759734a7699468dd67b7a7967cabfc20cded818dd01ae2f9f18"
+		},
+		{
+			"filename": "0109-delete-stranded-app-value-buckets.sql",
+			"sha256": "449a52a02206dd8801ab82f0e71720868a4c55ab22f7ba3097cb6e19c8036d57"
 		}
 	]
 }

--- a/tools/oxlint/local-plugin.js
+++ b/tools/oxlint/local-plugin.js
@@ -184,6 +184,11 @@ export const importBoundaries = [
 				reason:
 					'Package deletion revokes package-scoped secrets and approvals, which the MCP secrets service owns. TODO: move secret storage into a neutral #worker/secrets module.',
 			},
+			{
+				specifier: '#mcp/values/service.ts',
+				reason:
+					'Package deletion removes app-scoped values (package config), which the MCP values service owns. TODO: move value storage into a neutral #worker/values module.',
+			},
 		],
 		neverAllowedPrefix: null,
 		neverAllowedMessage: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings the two items deferred from #1022 into scope (follow-up requested on #231's conductor run; overlaps item 4 of #1024):

- **Package delete now clears package-owned durable state.** `deleteSavedPackageProjection` previously removed only D1 rows, orphaning every package-owned StorageRunner bucket (package bucket, legacy raw-id app root, facet/internal-DO buckets, job scratch, service scratch) and leaving app-scoped values behind while package secrets were deleted. It now collects the package-owned storage id set (deterministic ids plus the `user_storage_buckets` inventory), clears each bucket with per-bucket error tolerance — inventory rows survive failed clears so account deletion can still enumerate them — and deletes app-scoped values alongside secrets.
- **App-scoped values resolve from `appId` only.** The `app` value scope no longer falls back to the run's `storageId`, so non-package contexts (ad hoc execute or `job_schedule` runs with a bound storage id) can no longer mint "app"-scoped value buckets keyed by arbitrary storage ids. Every package surface sets `appId` to the saved package id, so package code is unaffected. Migration `0109` deletes the now-unreachable fallback-keyed buckets (`job:`/`exec:` binding keys), guarded so any binding key matching a real saved package id survives.

An independent review of the initial implementation found — and empirically verified — an over-deletion hole: saved package ids are caller-suppliable (not guaranteed UUIDs), so raw SQL `LIKE` prefix matching let a package id of `'job'` match every `job:*` bucket, and `%`/`_` survived into bound prefixes. Fixed before merge: inventory matching is now exact JS-side comparison, with prefix arms (facets, service/job scratch) applied only to UUID-shaped package ids where they are provably unambiguous; non-UUID packages clear the deterministic id set only.

The `#mcp/values` import from package-registry gets the same lint boundary exception (with the same extraction TODO) as the existing `#mcp/secrets` one.

## Testing

- `npm run validate` (full local gate)
- New unit coverage: bucket-set collection and clearing (including failure tolerance, cross-user/cross-package isolation, and adversarial package ids `'job'`/`'%'`), pure filter tests for the UUID gate, migration 0109 guard behavior, app-scope save rejection without `appId`, and the read-path regression showing fallback-keyed buckets are unreachable
- Independent review of the diff (data-loss focus); its BLOCKER finding is fixed in `3aca213e`

Refs #1024 (delivers the package-delete cleanup portion; the legacy app-bucket removal remains tracked there)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `356426e6` · **Head:** `d8544633`

**Classification:** extends — `saved-packages` delete behavior now destroys package-owned durable state; `mcp-server` value binding contract narrows; `d1-app-db` gains cleanup migration 0109. No new primitives; `primitives.yaml` unchanged.

### Primitives touched

| Primitive        | Group     | Impact                                                                                 |
| ---------------- | --------- | -------------------------------------------------------------------------------------- |
| `saved-packages` | assistant | extends — package delete clears StorageRunner buckets + app-scoped values               |
| `mcp-server`     | surfaces  | extends — app value scope resolves from `appId` only (storageId fallback removed)       |
| `d1-app-db`      | storage   | extends — migration 0109 deletes stranded fallback-keyed app value buckets              |
| `durable-storage`| assistant | composes — `clearStorage()` / inventory helpers reused as-is                            |

### System map

Package delete flows from the delete capability through the registry service, which enumerates buckets from the D1 inventory and clears each StorageRunner DO; the values service loses its storage-id fallback and the migration removes rows that fallback created.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	durableStorage["durable-storage<br/>StorageRunner buckets"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	savedPackages -->|"clearStorage() per package-owned bucket (UUID-gated prefix match)"| durableStorage
	savedPackages -->|"user_storage_buckets enumeration + row removal; deleteAllAppScopedValues"| d1AppDb
	mcpServer -->|"app value scope: appId only, no storageId fallback"| d1AppDb
	d1AppDb -->|"migration 0109: delete job:/exec:-keyed app value buckets"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
package delete:            D1 rows only, buckets/values orphaned  →  buckets cleared + inventory rows removed + app-scoped values deleted
app value scope binding:   appId, else fallback to storageId      →  appId or unavailable
fallback-keyed buckets:    reachable via bound storageId          →  deleted by migration 0109 (saved-package ids protected)
```

### Invariants

Per-user isolation unchanged: bucket enumeration is `WHERE user_id = ?`, every `clearStorage()` goes through `storageRunnerRpc({ userId })`, and the review confirmed cross-user deletion is structurally impossible. Deletion is destructive by design but reachable only through the intent-checked `package_delete` capability; the UUID gate prevents same-user cross-namespace over-deletion for adversarial package ids.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f40b943c-e067-43a8-b171-94721f7e81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f40b943c-e067-43a8-b171-94721f7e81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

