### PR TITLE
fix: rebuild package artifacts in throwaway Durable Objects

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -63,7 +63,7 @@ function resetMocks() {
 	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(false)
 }
 
-test('isolated rebuild stages once, fans out with bounded concurrency, and discards staging', async () => {
+test('isolated rebuild lists then stages once, fans out with bounded concurrency, and discards staging', async () => {
 	expect(publishedPackageArtifactRebuildConcurrency).toBe(2)
 	resetMocks()
 
@@ -77,9 +77,9 @@ test('isolated rebuild stages once, fans out with bounded concurrency, and disca
 		run,
 		discard,
 	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(sampleTargets)
 	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
-		targets: sampleTargets,
 	})
 
 	let inFlight = 0
@@ -113,11 +113,11 @@ test('isolated rebuild stages once, fans out with bounded concurrency, and disca
 		expect(run).toHaveBeenCalledTimes(2)
 	})
 	expect(maxInFlight).toBe(2)
+	expect(mockModule.listPublishedPackageArtifactTargets).toHaveBeenCalledTimes(1)
 	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
 		1,
 	)
 	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
-	expect(mockModule.listPublishedPackageArtifactTargets).not.toHaveBeenCalled()
 
 	releaseGates.splice(0).forEach((release) => release())
 	await vi.waitFor(() => {
@@ -151,9 +151,9 @@ test('isolated rebuild skips targets already built for the published commit', as
 		run,
 		discard,
 	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(sampleTargets)
 	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
-		targets: sampleTargets,
 	})
 	mockModule.isPublishedPackageArtifactBuiltForCommit.mockImplementation(
 		async (input: { target: (typeof sampleTargets)[number] }) =>
@@ -176,7 +176,40 @@ test('isolated rebuild skips targets already built for the published commit', as
 	expect(run).toHaveBeenCalledWith(
 		expect.objectContaining({ target: sampleTargets[1] }),
 	)
+	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
+		1,
+	)
 	expect(discard).toHaveBeenCalledTimes(1)
+})
+
+test('does not stage workspace when every artifact target is already built', async () => {
+	resetMocks()
+	const run = vi.fn(async () => ({ ok: true, message: 'rebuilt' }))
+	const discard = vi.fn(async () => undefined)
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		stage: vi.fn(),
+		run,
+		discard,
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(sampleTargets)
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(true)
+
+	await rebuildPublishedPackageArtifactsViaRepoSession({
+		env: {
+			REPO_SESSION: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as unknown as Env,
+		rpcSessionId: 'session-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(mockModule.listPublishedPackageArtifactTargets).toHaveBeenCalledTimes(1)
+	expect(mockModule.stagePublishedPackageArtifactRebuild).not.toHaveBeenCalled()
+	expect(run).not.toHaveBeenCalled()
+	expect(discard).not.toHaveBeenCalled()
 })
 
 test('isolated rebuild failure stops later chunks, discards staging, and reports succeeded versus failed', async () => {
@@ -204,9 +237,9 @@ test('isolated rebuild failure stops later chunks, discards staging, and reports
 		run,
 		discard,
 	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
 	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
-		targets,
 	})
 
 	await expect(

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -3,45 +3,244 @@ import { publishedPackageArtifactRebuildConcurrency } from './package-artifact-r
 
 const mockModule = vi.hoisted(() => ({
 	listPublishedPackageArtifactTargets: vi.fn(),
+	stagePublishedPackageArtifactRebuild: vi.fn(),
 	rebuildPublishedPackageArtifact: vi.fn(),
+	createIsolatedArtifactRebuildRunner: vi.fn(),
+	isPublishedPackageArtifactBuiltForCommit: vi.fn(),
 }))
 
 vi.mock('#worker/repo/repo-session-do.ts', () => ({
 	repoSessionRpc: () => ({
 		listPublishedPackageArtifactTargets: (...args: Array<unknown>) =>
 			mockModule.listPublishedPackageArtifactTargets(...args),
+		stagePublishedPackageArtifactRebuild: (...args: Array<unknown>) =>
+			mockModule.stagePublishedPackageArtifactRebuild(...args),
 		rebuildPublishedPackageArtifact: (...args: Array<unknown>) =>
 			mockModule.rebuildPublishedPackageArtifact(...args),
 	}),
 }))
 
+vi.mock('#worker/repo/isolated-artifact-rebuild.ts', () => ({
+	createIsolatedArtifactRebuildRunner: (...args: Array<unknown>) =>
+		mockModule.createIsolatedArtifactRebuildRunner(...args),
+}))
+
+vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', () => ({
+	isPublishedPackageArtifactBuiltForCommit: (...args: Array<unknown>) =>
+		mockModule.isPublishedPackageArtifactBuiltForCommit(...args),
+}))
+
 const { rebuildPublishedPackageArtifactsViaRepoSession } =
 	await import('./package-artifact-rebuild.ts')
 
-test('rebuildPublishedPackageArtifactsViaRepoSession pipelines targets with bounded concurrency', async () => {
-	expect(publishedPackageArtifactRebuildConcurrency).toBe(2)
+const sampleTargets = [
+	{
+		kind: 'module' as const,
+		artifactName: '.',
+		entryPoint: 'src/a.ts',
+		bundleKind: 'module' as const,
+	},
+	{
+		kind: 'module' as const,
+		artifactName: './b',
+		entryPoint: 'src/b.ts',
+		bundleKind: 'module' as const,
+	},
+	{
+		kind: 'module' as const,
+		artifactName: './c',
+		entryPoint: 'src/c.ts',
+		bundleKind: 'module' as const,
+	},
+]
 
+function resetMocks() {
+	mockModule.listPublishedPackageArtifactTargets.mockReset()
+	mockModule.stagePublishedPackageArtifactRebuild.mockReset()
+	mockModule.rebuildPublishedPackageArtifact.mockReset()
+	mockModule.createIsolatedArtifactRebuildRunner.mockReset()
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockReset()
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(false)
+}
+
+test('isolated rebuild stages once, fans out with bounded concurrency, and discards staging', async () => {
+	expect(publishedPackageArtifactRebuildConcurrency).toBe(2)
+	resetMocks()
+
+	const run = vi.fn(async () => ({
+		ok: true,
+		message: 'rebuilt',
+	}))
+	const discard = vi.fn(async () => undefined)
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		stage: vi.fn(),
+		run,
+		discard,
+	})
+	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
+		targets: sampleTargets,
+	})
+
+	let inFlight = 0
+	let maxInFlight = 0
+	const releaseGates: Array<() => void> = []
+	run.mockImplementation(async () => {
+		inFlight += 1
+		maxInFlight = Math.max(maxInFlight, inFlight)
+		await new Promise<void>((resolve) => {
+			releaseGates.push(() => {
+				inFlight -= 1
+				resolve()
+			})
+		})
+		return { ok: true, message: 'rebuilt' }
+	})
+
+	const rebuildPromise = rebuildPublishedPackageArtifactsViaRepoSession({
+		env: {
+			REPO_SESSION: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as unknown as Env,
+		rpcSessionId: 'session-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		baseUrl: 'https://kody.test',
+	})
+
+	await vi.waitFor(() => {
+		expect(run).toHaveBeenCalledTimes(2)
+	})
+	expect(maxInFlight).toBe(2)
+	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
+		1,
+	)
+	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
+	expect(mockModule.listPublishedPackageArtifactTargets).not.toHaveBeenCalled()
+
+	releaseGates.splice(0).forEach((release) => release())
+	await vi.waitFor(() => {
+		expect(run).toHaveBeenCalledTimes(3)
+	})
+	releaseGates.splice(0).forEach((release) => release())
+	await rebuildPromise
+
+	expect(maxInFlight).toBe(2)
+	expect(run).toHaveBeenCalledTimes(3)
+	expect(discard).toHaveBeenCalledWith(
+		'repo-artifact-rebuild-staging:v1:user-1:stage-1',
+	)
+	expect(run).toHaveBeenCalledWith(
+		expect.objectContaining({
+			stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-1',
+			target: sampleTargets[0],
+		}),
+	)
+})
+
+test('isolated rebuild skips targets already built for the published commit', async () => {
+	resetMocks()
+	const run = vi.fn(async () => ({ ok: true, message: 'rebuilt' }))
+	const discard = vi.fn(async () => undefined)
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		stage: vi.fn(),
+		run,
+		discard,
+	})
+	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
+		targets: sampleTargets,
+	})
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockImplementation(
+		async (input: { target: (typeof sampleTargets)[number] }) =>
+			input.target.artifactName === '.' || input.target.artifactName === './c',
+	)
+
+	await rebuildPublishedPackageArtifactsViaRepoSession({
+		env: {
+			REPO_SESSION: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as unknown as Env,
+		rpcSessionId: 'session-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(run).toHaveBeenCalledTimes(1)
+	expect(run).toHaveBeenCalledWith(
+		expect.objectContaining({ target: sampleTargets[1] }),
+	)
+	expect(discard).toHaveBeenCalledTimes(1)
+})
+
+test('isolated rebuild failure stops later chunks, discards staging, and reports succeeded versus failed', async () => {
+	resetMocks()
 	const targets = [
+		...sampleTargets,
 		{
 			kind: 'module' as const,
-			artifactName: '.',
-			entryPoint: 'src/a.ts',
-			bundleKind: 'module' as const,
-		},
-		{
-			kind: 'module' as const,
-			artifactName: './b',
-			entryPoint: 'src/b.ts',
-			bundleKind: 'module' as const,
-		},
-		{
-			kind: 'module' as const,
-			artifactName: './c',
-			entryPoint: 'src/c.ts',
+			artifactName: './d',
+			entryPoint: 'src/d.ts',
 			bundleKind: 'module' as const,
 		},
 	]
-	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
+	const run = vi.fn(
+		async (input: { target: (typeof targets)[number] }) => {
+			if (input.target.artifactName === './b') {
+				return { ok: false, message: 'bundle b failed' }
+			}
+			return { ok: true, message: 'rebuilt' }
+		},
+	)
+	const discard = vi.fn(async () => undefined)
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		stage: vi.fn(),
+		run,
+		discard,
+	})
+	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
+		targets,
+	})
+
+	await expect(
+		rebuildPublishedPackageArtifactsViaRepoSession({
+			env: {
+				REPO_SESSION: {},
+				BUNDLE_ARTIFACTS_KV: {},
+			} as unknown as Env,
+			rpcSessionId: 'session-1',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-1',
+			baseUrl: 'https://kody.test',
+		}),
+	).rejects.toThrow(
+		/Succeeded: \{ kind "module", artifact "\.", entry "src\/a\.ts", bundle "module" \}\. Failed: \{ kind "module", artifact "\.\/b", entry "src\/b\.ts", bundle "module" \}: bundle b failed/,
+	)
+
+	expect(run).toHaveBeenCalledTimes(2)
+	expect(run).not.toHaveBeenCalledWith(
+		expect.objectContaining({ target: targets[2] }),
+	)
+	expect(run).not.toHaveBeenCalledWith(
+		expect.objectContaining({ target: targets[3] }),
+	)
+	expect(discard).toHaveBeenCalledWith(
+		'repo-artifact-rebuild-staging:v1:user-1:stage-1',
+	)
+})
+
+test('falls back to per-target session rebuild when isolated runner bindings are missing', async () => {
+	resetMocks()
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue(null)
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(sampleTargets)
 
 	let inFlight = 0
 	let maxInFlight = 0
@@ -71,6 +270,7 @@ test('rebuildPublishedPackageArtifactsViaRepoSession pipelines targets with boun
 		expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
 	})
 	expect(maxInFlight).toBe(2)
+	expect(mockModule.stagePublishedPackageArtifactRebuild).not.toHaveBeenCalled()
 
 	releaseGates.splice(0).forEach((release) => release())
 	await vi.waitFor(() => {
@@ -83,26 +283,10 @@ test('rebuildPublishedPackageArtifactsViaRepoSession pipelines targets with boun
 	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(3)
 })
 
-test('rebuild failure stops later chunks and reports succeeded versus failed targets', async () => {
+test('fallback rebuild failure stops later chunks and reports succeeded versus failed targets', async () => {
+	resetMocks()
 	const targets = [
-		{
-			kind: 'module' as const,
-			artifactName: '.',
-			entryPoint: 'src/a.ts',
-			bundleKind: 'module' as const,
-		},
-		{
-			kind: 'module' as const,
-			artifactName: './b',
-			entryPoint: 'src/b.ts',
-			bundleKind: 'module' as const,
-		},
-		{
-			kind: 'module' as const,
-			artifactName: './c',
-			entryPoint: 'src/c.ts',
-			bundleKind: 'module' as const,
-		},
+		...sampleTargets,
 		{
 			kind: 'module' as const,
 			artifactName: './d',
@@ -110,6 +294,7 @@ test('rebuild failure stops later chunks and reports succeeded versus failed tar
 			bundleKind: 'module' as const,
 		},
 	]
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue(null)
 	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(targets)
 	mockModule.rebuildPublishedPackageArtifact.mockImplementation(
 		async (input: { target: (typeof targets)[number] }) => {

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -71,9 +71,10 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 		ok: true,
 		message: 'rebuilt',
 	}))
+	const touch = vi.fn(async () => undefined)
 	const discard = vi.fn(async () => undefined)
 	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
-		stage: vi.fn(),
+		touch,
 		run,
 		discard,
 	})
@@ -122,16 +123,21 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 		1,
 	)
 	expect(mockModule.rebuildPublishedPackageArtifact).not.toHaveBeenCalled()
+	expect(touch).not.toHaveBeenCalled()
 
 	releaseGates.splice(0).forEach((release) => release())
 	await vi.waitFor(() => {
 		expect(run).toHaveBeenCalledTimes(3)
 	})
+	expect(touch).toHaveBeenCalledWith(
+		'repo-artifact-rebuild-staging:v1:user-1:stage-1',
+	)
 	releaseGates.splice(0).forEach((release) => release())
 	await rebuildPromise
 
 	expect(maxInFlight).toBe(2)
 	expect(run).toHaveBeenCalledTimes(3)
+	expect(touch).toHaveBeenCalledTimes(1)
 	expect(discard).toHaveBeenCalledWith(
 		'repo-artifact-rebuild-staging:v1:user-1:stage-1',
 	)
@@ -151,7 +157,7 @@ test('isolated rebuild skips targets already built for the published commit', as
 	const run = vi.fn(async () => ({ ok: true, message: 'rebuilt' }))
 	const discard = vi.fn(async () => undefined)
 	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
-		stage: vi.fn(),
+		touch: vi.fn(),
 		run,
 		discard,
 	})
@@ -193,7 +199,7 @@ test('does not stage workspace when every artifact target is already built', asy
 	const run = vi.fn(async () => ({ ok: true, message: 'rebuilt' }))
 	const discard = vi.fn(async () => undefined)
 	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
-		stage: vi.fn(),
+		touch: vi.fn(),
 		run,
 		discard,
 	})
@@ -239,9 +245,10 @@ test('isolated rebuild failure stops later chunks, discards staging, and reports
 		}
 		return { ok: true, message: 'rebuilt' }
 	})
+	const touch = vi.fn(async () => undefined)
 	const discard = vi.fn(async () => undefined)
 	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
-		stage: vi.fn(),
+		touch,
 		run,
 		discard,
 	})
@@ -265,6 +272,7 @@ test('isolated rebuild failure stops later chunks, discards staging, and reports
 	).rejects.toThrow(
 		/Succeeded: \{ kind "module", artifact "\.", entry "src\/a\.ts", bundle "module" \}\. Failed: \{ kind "module", artifact "\.\/b", entry "src\/b\.ts", bundle "module" \}: bundle b failed/,
 	)
+	expect(touch).not.toHaveBeenCalled()
 
 	expect(run).toHaveBeenCalledTimes(2)
 	expect(run).not.toHaveBeenCalledWith(

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -77,7 +77,9 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 		run,
 		discard,
 	})
-	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(sampleTargets)
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(
+		sampleTargets,
+	)
 	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
 	})
@@ -113,7 +115,9 @@ test('isolated rebuild lists then stages once, fans out with bounded concurrency
 		expect(run).toHaveBeenCalledTimes(2)
 	})
 	expect(maxInFlight).toBe(2)
-	expect(mockModule.listPublishedPackageArtifactTargets).toHaveBeenCalledTimes(1)
+	expect(mockModule.listPublishedPackageArtifactTargets).toHaveBeenCalledTimes(
+		1,
+	)
 	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
 		1,
 	)
@@ -151,7 +155,9 @@ test('isolated rebuild skips targets already built for the published commit', as
 		run,
 		discard,
 	})
-	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(sampleTargets)
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(
+		sampleTargets,
+	)
 	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
 	})
@@ -191,7 +197,9 @@ test('does not stage workspace when every artifact target is already built', asy
 		run,
 		discard,
 	})
-	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(sampleTargets)
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(
+		sampleTargets,
+	)
 	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(true)
 
 	await rebuildPublishedPackageArtifactsViaRepoSession({
@@ -206,7 +214,9 @@ test('does not stage workspace when every artifact target is already built', asy
 		baseUrl: 'https://kody.test',
 	})
 
-	expect(mockModule.listPublishedPackageArtifactTargets).toHaveBeenCalledTimes(1)
+	expect(mockModule.listPublishedPackageArtifactTargets).toHaveBeenCalledTimes(
+		1,
+	)
 	expect(mockModule.stagePublishedPackageArtifactRebuild).not.toHaveBeenCalled()
 	expect(run).not.toHaveBeenCalled()
 	expect(discard).not.toHaveBeenCalled()
@@ -223,14 +233,12 @@ test('isolated rebuild failure stops later chunks, discards staging, and reports
 			bundleKind: 'module' as const,
 		},
 	]
-	const run = vi.fn(
-		async (input: { target: (typeof targets)[number] }) => {
-			if (input.target.artifactName === './b') {
-				return { ok: false, message: 'bundle b failed' }
-			}
-			return { ok: true, message: 'rebuilt' }
-		},
-	)
+	const run = vi.fn(async (input: { target: (typeof targets)[number] }) => {
+		if (input.target.artifactName === './b') {
+			return { ok: false, message: 'bundle b failed' }
+		}
+		return { ok: true, message: 'rebuilt' }
+	})
 	const discard = vi.fn(async () => undefined)
 	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
 		stage: vi.fn(),
@@ -273,7 +281,9 @@ test('isolated rebuild failure stops later chunks, discards staging, and reports
 test('falls back to per-target session rebuild when isolated runner bindings are missing', async () => {
 	resetMocks()
 	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue(null)
-	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(sampleTargets)
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(
+		sampleTargets,
+	)
 
 	let inFlight = 0
 	let maxInFlight = 0

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -85,6 +85,33 @@ async function filterTargetsNeedingRebuild(input: {
 	return { remaining, alreadyBuilt }
 }
 
+async function listTargetsOrThrow(input: {
+	session: ReturnType<typeof repoSessionRpc>
+	repoSessionId?: string
+	sourceId: string
+	userId: string
+	publishedCommit: string
+}) {
+	try {
+		return await input.session.listPublishedPackageArtifactTargets({
+			sessionId: input.repoSessionId,
+			sourceId: input.sourceId,
+			userId: input.userId,
+		})
+	} catch (error) {
+		throw new Error(
+			buildRebuildFailureMessage({
+				sourceId: input.sourceId,
+				publishedCommit: input.publishedCommit,
+				succeeded: [],
+				failed: [],
+				error,
+			}),
+			{ cause: error },
+		)
+	}
+}
+
 async function rebuildPublishedPackageArtifactsOnSession(input: {
 	env: Env
 	rpcSessionId: string
@@ -168,25 +195,13 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 	const isolatedRunner = createIsolatedArtifactRebuildRunner(input.env)
 
 	if (!isolatedRunner) {
-		let targets: Array<PublishedPackageArtifactBuildTarget>
-		try {
-			targets = await session.listPublishedPackageArtifactTargets({
-				sessionId: input.repoSessionId,
-				sourceId: input.sourceId,
-				userId: input.userId,
-			})
-		} catch (error) {
-			throw new Error(
-				buildRebuildFailureMessage({
-					sourceId: input.sourceId,
-					publishedCommit: input.publishedCommit,
-					succeeded: [],
-					failed: [],
-					error,
-				}),
-				{ cause: error },
-			)
-		}
+		const targets = await listTargetsOrThrow({
+			session,
+			repoSessionId: input.repoSessionId,
+			sourceId: input.sourceId,
+			userId: input.userId,
+			publishedCommit: input.publishedCommit,
+		})
 		await rebuildPublishedPackageArtifactsOnSession({
 			...input,
 			targets,
@@ -196,25 +211,13 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 
 	// List + skip before staging so already_published / repair resumes do not
 	// pay collectWorkspaceFiles + KV stage when nothing remains to rebuild.
-	let targets: Array<PublishedPackageArtifactBuildTarget>
-	try {
-		targets = await session.listPublishedPackageArtifactTargets({
-			sessionId: input.repoSessionId,
-			sourceId: input.sourceId,
-			userId: input.userId,
-		})
-	} catch (error) {
-		throw new Error(
-			buildRebuildFailureMessage({
-				sourceId: input.sourceId,
-				publishedCommit: input.publishedCommit,
-				succeeded: [],
-				failed: [],
-				error,
-			}),
-			{ cause: error },
-		)
-	}
+	const targets = await listTargetsOrThrow({
+		session,
+		repoSessionId: input.repoSessionId,
+		sourceId: input.sourceId,
+		userId: input.userId,
+		publishedCommit: input.publishedCommit,
+	})
 
 	const { remaining, alreadyBuilt } = await filterTargetsNeedingRebuild({
 		env: input.env,
@@ -254,11 +257,15 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 	}> = []
 
 	try {
-		for (const targetChunk of chunkArray(
+		const targetChunks = chunkArray(
 			remaining,
 			publishedPackageArtifactRebuildConcurrency,
-		)) {
+		)
+		for (const [chunkIndex, targetChunk] of targetChunks.entries()) {
 			if (failed.length > 0) break
+			if (chunkIndex > 0) {
+				await isolatedRunner.touch(stagingKey)
+			}
 
 			const settled = await Promise.allSettled(
 				targetChunk.map(async (target) => {

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -1,13 +1,16 @@
 import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { formatErrorCauseChain } from '@kody-internal/shared/error-message.ts'
+import { isPublishedPackageArtifactBuiltForCommit } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/package-artifact-targets.ts'
+import { createIsolatedArtifactRebuildRunner } from '#worker/repo/isolated-artifact-rebuild.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 
 /**
  * Same-session rebuild RPCs hit one Durable Object, which serializes
  * execution. Depth 2 pipelines the next RPC while the DO finishes the current
  * one (cuts inter-call worker round-trip idle time) without flooding the DO
- * input gate the way unbounded Promise.all would.
+ * input gate the way unbounded Promise.all would. The isolated throwaway-DO
+ * path uses the same bound so fan-out stays modest.
  */
 export const publishedPackageArtifactRebuildConcurrency = 2
 
@@ -56,7 +59,33 @@ function buildRebuildFailureMessage(input: {
 	return `Package source publish succeeded, but bundle artifact rebuild failed for source "${input.sourceId}" at commit "${input.publishedCommit}". Succeeded: ${succeededSummary}. Failed: ${failedSummary}. Re-run the publish capability to repair artifacts.`
 }
 
-export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
+async function filterTargetsNeedingRebuild(input: {
+	env: Env
+	userId: string
+	sourceId: string
+	publishedCommit: string
+	targets: ReadonlyArray<PublishedPackageArtifactBuildTarget>
+}) {
+	const remaining: Array<PublishedPackageArtifactBuildTarget> = []
+	const alreadyBuilt: Array<PublishedPackageArtifactBuildTarget> = []
+	for (const target of input.targets) {
+		const built = await isPublishedPackageArtifactBuiltForCommit({
+			env: input.env,
+			userId: input.userId,
+			sourceId: input.sourceId,
+			publishedCommit: input.publishedCommit,
+			target,
+		})
+		if (built) {
+			alreadyBuilt.push(target)
+			continue
+		}
+		remaining.push(target)
+	}
+	return { remaining, alreadyBuilt }
+}
+
+async function rebuildPublishedPackageArtifactsOnSession(input: {
 	env: Env
 	rpcSessionId: string
 	repoSessionId?: string
@@ -64,36 +93,26 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 	userId: string
 	publishedCommit: string
 	baseUrl: string
+	targets: ReadonlyArray<PublishedPackageArtifactBuildTarget>
 }) {
 	const session = repoSessionRpc(input.env, input.rpcSessionId)
-	let targets: Array<PublishedPackageArtifactBuildTarget>
-	try {
-		targets = await session.listPublishedPackageArtifactTargets({
-			sessionId: input.repoSessionId,
-			sourceId: input.sourceId,
-			userId: input.userId,
-		})
-	} catch (error) {
-		throw new Error(
-			buildRebuildFailureMessage({
-				sourceId: input.sourceId,
-				publishedCommit: input.publishedCommit,
-				succeeded: [],
-				failed: [],
-				error,
-			}),
-			{ cause: error },
-		)
-	}
-
 	const succeeded: Array<PublishedPackageArtifactBuildTarget> = []
+	const { remaining, alreadyBuilt } = await filterTargetsNeedingRebuild({
+		env: input.env,
+		userId: input.userId,
+		sourceId: input.sourceId,
+		publishedCommit: input.publishedCommit,
+		targets: input.targets,
+	})
+	succeeded.push(...alreadyBuilt)
+
 	const failed: Array<{
 		target: PublishedPackageArtifactBuildTarget
 		error: unknown
 	}> = []
 
 	for (const targetChunk of chunkArray(
-		targets,
+		remaining,
 		publishedPackageArtifactRebuildConcurrency,
 	)) {
 		if (failed.length > 0) break
@@ -121,6 +140,133 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 			}
 			failed.push({ target, error: result.reason })
 		}
+	}
+
+	if (failed.length === 0) return
+
+	throw new Error(
+		buildRebuildFailureMessage({
+			sourceId: input.sourceId,
+			publishedCommit: input.publishedCommit,
+			succeeded,
+			failed,
+		}),
+		{ cause: failed[0]?.error },
+	)
+}
+
+export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
+	env: Env
+	rpcSessionId: string
+	repoSessionId?: string
+	sourceId: string
+	userId: string
+	publishedCommit: string
+	baseUrl: string
+}) {
+	const session = repoSessionRpc(input.env, input.rpcSessionId)
+	const isolatedRunner = createIsolatedArtifactRebuildRunner(input.env)
+
+	if (!isolatedRunner) {
+		let targets: Array<PublishedPackageArtifactBuildTarget>
+		try {
+			targets = await session.listPublishedPackageArtifactTargets({
+				sessionId: input.repoSessionId,
+				sourceId: input.sourceId,
+				userId: input.userId,
+			})
+		} catch (error) {
+			throw new Error(
+				buildRebuildFailureMessage({
+					sourceId: input.sourceId,
+					publishedCommit: input.publishedCommit,
+					succeeded: [],
+					failed: [],
+					error,
+				}),
+				{ cause: error },
+			)
+		}
+		await rebuildPublishedPackageArtifactsOnSession({
+			...input,
+			targets,
+		})
+		return
+	}
+
+	let stagingKey: string
+	let targets: Array<PublishedPackageArtifactBuildTarget>
+	try {
+		;({ stagingKey, targets } =
+			await session.stagePublishedPackageArtifactRebuild({
+				sessionId: input.repoSessionId,
+				sourceId: input.sourceId,
+				userId: input.userId,
+			}))
+	} catch (error) {
+		throw new Error(
+			buildRebuildFailureMessage({
+				sourceId: input.sourceId,
+				publishedCommit: input.publishedCommit,
+				succeeded: [],
+				failed: [],
+				error,
+			}),
+			{ cause: error },
+		)
+	}
+
+	const succeeded: Array<PublishedPackageArtifactBuildTarget> = []
+	const failed: Array<{
+		target: PublishedPackageArtifactBuildTarget
+		error: unknown
+	}> = []
+
+	try {
+		const { remaining, alreadyBuilt } = await filterTargetsNeedingRebuild({
+			env: input.env,
+			userId: input.userId,
+			sourceId: input.sourceId,
+			publishedCommit: input.publishedCommit,
+			targets,
+		})
+		succeeded.push(...alreadyBuilt)
+
+		for (const targetChunk of chunkArray(
+			remaining,
+			publishedPackageArtifactRebuildConcurrency,
+		)) {
+			if (failed.length > 0) break
+
+			const settled = await Promise.allSettled(
+				targetChunk.map(async (target) => {
+					const outcome = await isolatedRunner.run({
+						stagingKey,
+						sourceId: input.sourceId,
+						userId: input.userId,
+						publishedCommit: input.publishedCommit,
+						target,
+						baseUrl: input.baseUrl,
+					})
+					if (!outcome.ok) {
+						throw new Error(outcome.message)
+					}
+					return target
+				}),
+			)
+
+			for (const [index, result] of settled.entries()) {
+				const target = targetChunk[index]
+				if (!target) continue
+				if (result.status === 'fulfilled') {
+					succeeded.push(target)
+					continue
+				}
+				failed.push({ target, error: result.reason })
+			}
+		}
+	} finally {
+		await isolatedRunner.discard(stagingKey)
 	}
 
 	if (failed.length === 0) return

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -223,7 +223,9 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 		publishedCommit: input.publishedCommit,
 		targets,
 	})
-	const succeeded: Array<PublishedPackageArtifactBuildTarget> = [...alreadyBuilt]
+	const succeeded: Array<PublishedPackageArtifactBuildTarget> = [
+		...alreadyBuilt,
+	]
 	if (remaining.length === 0) return
 
 	let stagingKey: string

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -194,15 +194,15 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 		return
 	}
 
-	let stagingKey: string
+	// List + skip before staging so already_published / repair resumes do not
+	// pay collectWorkspaceFiles + KV stage when nothing remains to rebuild.
 	let targets: Array<PublishedPackageArtifactBuildTarget>
 	try {
-		;({ stagingKey, targets } =
-			await session.stagePublishedPackageArtifactRebuild({
-				sessionId: input.repoSessionId,
-				sourceId: input.sourceId,
-				userId: input.userId,
-			}))
+		targets = await session.listPublishedPackageArtifactTargets({
+			sessionId: input.repoSessionId,
+			sourceId: input.sourceId,
+			userId: input.userId,
+		})
 	} catch (error) {
 		throw new Error(
 			buildRebuildFailureMessage({
@@ -216,22 +216,42 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 		)
 	}
 
-	const succeeded: Array<PublishedPackageArtifactBuildTarget> = []
+	const { remaining, alreadyBuilt } = await filterTargetsNeedingRebuild({
+		env: input.env,
+		userId: input.userId,
+		sourceId: input.sourceId,
+		publishedCommit: input.publishedCommit,
+		targets,
+	})
+	const succeeded: Array<PublishedPackageArtifactBuildTarget> = [...alreadyBuilt]
+	if (remaining.length === 0) return
+
+	let stagingKey: string
+	try {
+		;({ stagingKey } = await session.stagePublishedPackageArtifactRebuild({
+			sessionId: input.repoSessionId,
+			sourceId: input.sourceId,
+			userId: input.userId,
+		}))
+	} catch (error) {
+		throw new Error(
+			buildRebuildFailureMessage({
+				sourceId: input.sourceId,
+				publishedCommit: input.publishedCommit,
+				succeeded,
+				failed: [],
+				error,
+			}),
+			{ cause: error },
+		)
+	}
+
 	const failed: Array<{
 		target: PublishedPackageArtifactBuildTarget
 		error: unknown
 	}> = []
 
 	try {
-		const { remaining, alreadyBuilt } = await filterTargetsNeedingRebuild({
-			env: input.env,
-			userId: input.userId,
-			sourceId: input.sourceId,
-			publishedCommit: input.publishedCommit,
-			targets,
-		})
-		succeeded.push(...alreadyBuilt)
-
 		for (const targetChunk of chunkArray(
 			remaining,
 			publishedPackageArtifactRebuildConcurrency,

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import type * as PublishedBundleArtifactRepo from '#worker/repo/published-bundle-artifacts-repo.ts'
 import type * as PublishedRuntimeArtifacts from './published-runtime-artifacts.ts'
 import {
+	isPublishedPackageArtifactBuiltForCommit,
 	loadPublishedBundleArtifactByIdentity,
 	rebuildPublishedPackageArtifacts,
 } from './published-bundle-artifacts.ts'
@@ -143,6 +144,176 @@ test('loadPublishedBundleArtifactByIdentity treats mismatched and malformed KV a
 			artifact: null,
 		})
 	}
+})
+
+test('isPublishedPackageArtifactBuiltForCommit requires matching row and KV artifact for the commit', async () => {
+	mockModule.getPublishedBundleArtifactByIdentity.mockReset()
+	mockModule.readPublishedBundleArtifact.mockReset()
+
+	const envWithoutKv = { APP_DB: {} } as unknown as Env
+	expect(
+		await isPublishedPackageArtifactBuiltForCommit({
+			env: envWithoutKv,
+			userId: 'user-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			target: {
+				kind: 'module',
+				artifactName: '.',
+				entryPoint: 'src/index.ts',
+				bundleKind: 'module',
+			},
+		}),
+	).toBe(false)
+	expect(mockModule.getPublishedBundleArtifactByIdentity).not.toHaveBeenCalled()
+
+	const env = {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+	} as unknown as Env
+	const target = {
+		kind: 'module' as const,
+		artifactName: '.',
+		entryPoint: 'src/index.ts',
+		bundleKind: 'module' as const,
+	}
+
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValueOnce(null)
+	expect(
+		await isPublishedPackageArtifactBuiltForCommit({
+			env,
+			userId: 'user-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			target,
+		}),
+	).toBe(false)
+
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue({
+		id: 'artifact-row-1',
+		userId: 'user-1',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		artifactKind: 'module',
+		artifactName: '.',
+		entryPoint: 'src/index.ts',
+		kvKey: 'kv:module',
+		dependenciesJson: '[]',
+		createdAt: '2026-05-13T00:00:00.000Z',
+		updatedAt: '2026-05-13T00:00:00.000Z',
+	})
+	mockModule.readPublishedBundleArtifact.mockResolvedValueOnce(null)
+	expect(
+		await isPublishedPackageArtifactBuiltForCommit({
+			env,
+			userId: 'user-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			target,
+		}),
+	).toBe(false)
+
+	mockModule.readPublishedBundleArtifact.mockResolvedValueOnce({
+		version: 1,
+		kind: 'module',
+		artifactName: '.',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-old',
+		entryPoint: 'src/index.ts',
+		mainModule: 'dist/index.js',
+		modules: { 'dist/index.js': 'export default {}' },
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: null,
+		serviceContext: null,
+		createdAt: '2026-05-13T00:00:00.000Z',
+	})
+	// Identity mismatch (KV commit differs from row) is treated as a miss.
+	expect(
+		await isPublishedPackageArtifactBuiltForCommit({
+			env,
+			userId: 'user-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			target,
+		}),
+	).toBe(false)
+
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue({
+		id: 'artifact-row-1',
+		userId: 'user-1',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-old',
+		artifactKind: 'module',
+		artifactName: '.',
+		entryPoint: 'src/index.ts',
+		kvKey: 'kv:module',
+		dependenciesJson: '[]',
+		createdAt: '2026-05-13T00:00:00.000Z',
+		updatedAt: '2026-05-13T00:00:00.000Z',
+	})
+	mockModule.readPublishedBundleArtifact.mockResolvedValueOnce({
+		version: 1,
+		kind: 'module',
+		artifactName: '.',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-old',
+		entryPoint: 'src/index.ts',
+		mainModule: 'dist/index.js',
+		modules: { 'dist/index.js': 'export default {}' },
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: null,
+		serviceContext: null,
+		createdAt: '2026-05-13T00:00:00.000Z',
+	})
+	expect(
+		await isPublishedPackageArtifactBuiltForCommit({
+			env,
+			userId: 'user-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			target,
+		}),
+	).toBe(false)
+
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue({
+		id: 'artifact-row-1',
+		userId: 'user-1',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		artifactKind: 'module',
+		artifactName: '.',
+		entryPoint: 'src/index.ts',
+		kvKey: 'kv:module',
+		dependenciesJson: '[]',
+		createdAt: '2026-05-13T00:00:00.000Z',
+		updatedAt: '2026-05-13T00:00:00.000Z',
+	})
+	mockModule.readPublishedBundleArtifact.mockResolvedValueOnce({
+		version: 1,
+		kind: 'module',
+		artifactName: '.',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		entryPoint: 'src/index.ts',
+		mainModule: 'dist/index.js',
+		modules: { 'dist/index.js': 'export default {}' },
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: null,
+		serviceContext: null,
+		createdAt: '2026-05-13T00:00:00.000Z',
+	})
+	expect(
+		await isPublishedPackageArtifactBuiltForCommit({
+			env,
+			userId: 'user-1',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			target,
+		}),
+	).toBe(true)
 })
 
 test('rebuildPublishedPackageArtifacts bundles declared subscription handlers', async () => {

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -251,6 +251,34 @@ export async function loadPublishedBundleArtifactByIdentity(input: {
 	}
 }
 
+/**
+ * True when a published bundle artifact already exists for this target
+ * identity at `publishedCommit` (row + KV payload). Used to skip rebuild work
+ * that would only rewrite the same commit's artifact.
+ */
+export async function isPublishedPackageArtifactBuiltForCommit(input: {
+	env: Env
+	userId: string
+	sourceId: string
+	publishedCommit: string
+	target: PublishedPackageArtifactBuildTarget
+}) {
+	if (!hasPublishedRuntimeArtifacts(input.env)) return false
+	const loaded = await loadPublishedBundleArtifactByIdentity({
+		env: input.env,
+		userId: input.userId,
+		sourceId: input.sourceId,
+		kind: input.target.kind,
+		artifactName: input.target.artifactName,
+		entryPoint: input.target.entryPoint,
+	})
+	if (!loaded?.artifact) return false
+	return (
+		loaded.row.publishedCommit === input.publishedCommit &&
+		loaded.artifact.publishedCommit === input.publishedCommit
+	)
+}
+
 export async function persistPublishedPackageArtifactTarget(
 	input: {
 		env: Env

--- a/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
@@ -46,29 +46,28 @@ test('createIsolatedArtifactRebuildRunner returns null without bindings', () => 
 	).toBeNull()
 })
 
-test('runner stages to KV, fans out one target per throwaway DO, and maps reset errors', async () => {
+test('runner touches staging TTL, fans out one target per throwaway DO, and maps reset errors', async () => {
 	const put = vi.fn(async () => undefined)
+	const get = vi.fn(async () =>
+		JSON.stringify({ sourceFiles: { 'package.json': '{}' } }),
+	)
 	const del = vi.fn(async () => undefined)
 	const runIsolatedArtifactRebuild = vi.fn(async () => ({
 		ok: true,
 		message: 'rebuilt',
 	}))
 	const idFromName = vi.fn((name: string) => ({ name }))
-	const get = vi.fn(() => ({ runIsolatedArtifactRebuild }))
+	const getStub = vi.fn(() => ({ runIsolatedArtifactRebuild }))
 	const runner = createIsolatedArtifactRebuildRunner({
-		REPO_SESSION: { idFromName, get },
-		BUNDLE_ARTIFACTS_KV: { put, delete: del },
+		REPO_SESSION: { idFromName, get: getStub },
+		BUNDLE_ARTIFACTS_KV: { put, get, delete: del },
 	} as unknown as Env)
 	expect(runner).not.toBeNull()
 	if (!runner) throw new Error('expected runner')
 
-	const stagingKey = await runner.stage({
-		userId: 'user-1',
-		sourceFiles: { 'package.json': '{}' },
-	})
-	expect(
-		stagingKey.startsWith(`${isolatedArtifactRebuildStagingKeyPrefix}user-1:`),
-	).toBe(true)
+	const stagingKey = `${isolatedArtifactRebuildStagingKeyPrefix}user-1:stage-1`
+	await runner.touch(stagingKey)
+	expect(get).toHaveBeenCalledWith(stagingKey, 'text')
 	expect(put).toHaveBeenCalledWith(
 		stagingKey,
 		JSON.stringify({ sourceFiles: { 'package.json': '{}' } }),

--- a/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
@@ -1,0 +1,121 @@
+import { expect, test, vi } from 'vitest'
+import {
+	createIsolatedArtifactRebuildRunner,
+	isolatedArtifactRebuildStagingKeyBelongsToUser,
+	isolatedArtifactRebuildStagingKeyForUser,
+	isolatedArtifactRebuildStagingKeyPrefix,
+} from './isolated-artifact-rebuild.ts'
+
+test('staging keys are user-namespaced and ownership-checked', () => {
+	const key = isolatedArtifactRebuildStagingKeyForUser('user-1')
+	expect(key.startsWith(`${isolatedArtifactRebuildStagingKeyPrefix}user-1:`)).toBe(
+		true,
+	)
+	expect(
+		isolatedArtifactRebuildStagingKeyBelongsToUser({
+			stagingKey: key,
+			userId: 'user-1',
+		}),
+	).toBe(true)
+	expect(
+		isolatedArtifactRebuildStagingKeyBelongsToUser({
+			stagingKey: key,
+			userId: 'user-2',
+		}),
+	).toBe(false)
+	expect(
+		isolatedArtifactRebuildStagingKeyBelongsToUser({
+			stagingKey: 'repo-checks-staging:v1:user-1:abc',
+			userId: 'user-1',
+		}),
+	).toBe(false)
+})
+
+test('createIsolatedArtifactRebuildRunner returns null without bindings', () => {
+	expect(createIsolatedArtifactRebuildRunner(undefined)).toBeNull()
+	expect(createIsolatedArtifactRebuildRunner({} as Env)).toBeNull()
+	expect(
+		createIsolatedArtifactRebuildRunner({
+			REPO_SESSION: {},
+		} as unknown as Env),
+	).toBeNull()
+	expect(
+		createIsolatedArtifactRebuildRunner({
+			BUNDLE_ARTIFACTS_KV: {},
+		} as unknown as Env),
+	).toBeNull()
+})
+
+test('runner stages to KV, fans out one target per throwaway DO, and maps reset errors', async () => {
+	const put = vi.fn(async () => undefined)
+	const del = vi.fn(async () => undefined)
+	const runIsolatedArtifactRebuild = vi.fn(async () => ({
+		ok: true,
+		message: 'rebuilt',
+	}))
+	const idFromName = vi.fn((name: string) => ({ name }))
+	const get = vi.fn(() => ({ runIsolatedArtifactRebuild }))
+	const runner = createIsolatedArtifactRebuildRunner({
+		REPO_SESSION: { idFromName, get },
+		BUNDLE_ARTIFACTS_KV: { put, delete: del },
+	} as unknown as Env)
+	expect(runner).not.toBeNull()
+	if (!runner) throw new Error('expected runner')
+
+	const stagingKey = await runner.stage({
+		userId: 'user-1',
+		sourceFiles: { 'package.json': '{}' },
+	})
+	expect(stagingKey.startsWith(`${isolatedArtifactRebuildStagingKeyPrefix}user-1:`)).toBe(
+		true,
+	)
+	expect(put).toHaveBeenCalledWith(
+		stagingKey,
+		JSON.stringify({ sourceFiles: { 'package.json': '{}' } }),
+		{ expirationTtl: 15 * 60 },
+	)
+
+	const target = {
+		kind: 'module' as const,
+		artifactName: '.',
+		entryPoint: 'src/index.ts',
+		bundleKind: 'module' as const,
+	}
+	const outcome = await runner.run({
+		stagingKey,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		target,
+		baseUrl: 'https://kody.test',
+	})
+	expect(outcome.ok).toBe(true)
+	expect(idFromName).toHaveBeenCalledWith(
+		expect.stringMatching(/^isolated-artifact-rebuild-user-1-/),
+	)
+	expect(runIsolatedArtifactRebuild).toHaveBeenCalledWith({
+		stagingKey,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		target,
+		baseUrl: 'https://kody.test',
+	})
+
+	runIsolatedArtifactRebuild.mockRejectedValueOnce(
+		new Error("Durable Object's isolate exceeded its memory limit"),
+	)
+	const resetOutcome = await runner.run({
+		stagingKey,
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		target,
+	})
+	expect(resetOutcome.ok).toBe(false)
+	expect(resetOutcome.message).toContain('memory or CPU limits')
+	expect(resetOutcome.target).toEqual(target)
+
+	await runner.discard(stagingKey)
+	expect(del).toHaveBeenCalledWith(stagingKey)
+})

--- a/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
@@ -8,9 +8,9 @@ import {
 
 test('staging keys are user-namespaced and ownership-checked', () => {
 	const key = isolatedArtifactRebuildStagingKeyForUser('user-1')
-	expect(key.startsWith(`${isolatedArtifactRebuildStagingKeyPrefix}user-1:`)).toBe(
-		true,
-	)
+	expect(
+		key.startsWith(`${isolatedArtifactRebuildStagingKeyPrefix}user-1:`),
+	).toBe(true)
 	expect(
 		isolatedArtifactRebuildStagingKeyBelongsToUser({
 			stagingKey: key,
@@ -66,9 +66,9 @@ test('runner stages to KV, fans out one target per throwaway DO, and maps reset 
 		userId: 'user-1',
 		sourceFiles: { 'package.json': '{}' },
 	})
-	expect(stagingKey.startsWith(`${isolatedArtifactRebuildStagingKeyPrefix}user-1:`)).toBe(
-		true,
-	)
+	expect(
+		stagingKey.startsWith(`${isolatedArtifactRebuildStagingKeyPrefix}user-1:`),
+	).toBe(true)
 	expect(put).toHaveBeenCalledWith(
 		stagingKey,
 		JSON.stringify({ sourceFiles: { 'package.json': '{}' } }),

--- a/packages/worker/src/repo/isolated-artifact-rebuild.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.ts
@@ -19,7 +19,8 @@ import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtim
  *
  * Workspace source files are staged once in KV with a short TTL (collected by
  * the session DO) and fetched by each rebuild isolate; the RPC payloads stay
- * small.
+ * small. The orchestrator refreshes that TTL between target chunks so large
+ * packages cannot outlive the initial lease mid-fan-out.
  */
 
 export const isolatedArtifactRebuildStagingKeyPrefix =
@@ -68,10 +69,11 @@ type IsolatedArtifactRebuildStub = {
 }
 
 export type IsolatedArtifactRebuildRunner = {
-	stage(input: {
-		userId: string
-		sourceFiles: Record<string, string>
-	}): Promise<string>
+	/**
+	 * Re-put the existing staging payload so its TTL resets. Call between
+	 * rebuild chunks so multi-target publishes do not expire mid-fan-out.
+	 */
+	touch(stagingKey: string): Promise<void>
 	run(
 		request: IsolatedArtifactRebuildRequest,
 	): Promise<IsolatedArtifactRebuildOutcome>
@@ -113,16 +115,12 @@ export function createIsolatedArtifactRebuildRunner(
 	)?.BUNDLE_ARTIFACTS_KV
 	if (!namespace || !stagingKv) return null
 	return {
-		async stage(input) {
-			const stagingKey = isolatedArtifactRebuildStagingKeyForUser(input.userId)
-			await stagingKv.put(
-				stagingKey,
-				JSON.stringify({ sourceFiles: input.sourceFiles }),
-				{
-					expirationTtl: stagingTtlSeconds,
-				},
-			)
-			return stagingKey
+		async touch(stagingKey) {
+			const payload = await stagingKv.get(stagingKey, 'text')
+			if (payload == null) return
+			await stagingKv.put(stagingKey, payload, {
+				expirationTtl: stagingTtlSeconds,
+			})
 		},
 		async run(request) {
 			// A fresh, user-namespaced id per target puts every heavy rebuild

--- a/packages/worker/src/repo/isolated-artifact-rebuild.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.ts
@@ -1,0 +1,164 @@
+import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
+import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/published-bundle-artifacts.ts'
+
+/**
+ * Heavy published-package artifact rebuilds run in fresh, throwaway
+ * `REPO_SESSION` isolates instead of the long-lived publish session Durable
+ * Object. One large package (for example morning-briefing) could otherwise
+ * push the session isolate (workspace + git state + esbuild-wasm) over the
+ * Durable Object memory limit and kill the publish (same class of failure as
+ * kentcdodds/kody#987 for check phases). Each target rebuild gets a brand-new
+ * DO id, so:
+ *
+ * - rebuilds never stack their peak memory on top of the session isolate or
+ *   each other (esbuild-wasm memory in particular never shrinks once grown),
+ * - a package too large for even a single target surfaces as a failed rebuild
+ *   with an actionable message instead of an opaque isolate reset, and
+ * - the throwaway instances never touch their own Durable Object storage, so
+ *   nothing persists for their random ids.
+ *
+ * Workspace source files are staged once in KV with a short TTL (collected by
+ * the session DO) and fetched by each rebuild isolate; the RPC payloads stay
+ * small.
+ */
+
+export const isolatedArtifactRebuildStagingKeyPrefix =
+	'repo-artifact-rebuild-staging:v1:'
+const stagingTtlSeconds = 15 * 60
+
+export type IsolatedArtifactRebuildRequest = {
+	stagingKey: string
+	sourceId: string
+	userId: string
+	publishedCommit: string
+	target: PublishedPackageArtifactBuildTarget
+	baseUrl?: string
+}
+
+/**
+ * Staged snapshots are user-owned content, so the staging key is namespaced
+ * by `userId` and the consuming Durable Object verifies the key belongs to
+ * the requesting user before reading it.
+ */
+export function isolatedArtifactRebuildStagingKeyForUser(userId: string) {
+	return `${isolatedArtifactRebuildStagingKeyPrefix}${userId}:${crypto.randomUUID()}`
+}
+
+export function isolatedArtifactRebuildStagingKeyBelongsToUser(input: {
+	stagingKey: string
+	userId: string
+}) {
+	return input.stagingKey.startsWith(
+		`${isolatedArtifactRebuildStagingKeyPrefix}${input.userId}:`,
+	)
+}
+
+export type IsolatedArtifactRebuildOutcome = {
+	ok: boolean
+	message: string
+	skipped?: boolean
+	kvKey?: string | null
+	target?: PublishedPackageArtifactBuildTarget
+}
+
+type IsolatedArtifactRebuildStub = {
+	runIsolatedArtifactRebuild(
+		input: IsolatedArtifactRebuildRequest,
+	): Promise<IsolatedArtifactRebuildOutcome>
+}
+
+export type IsolatedArtifactRebuildRunner = {
+	stage(input: {
+		userId: string
+		sourceFiles: Record<string, string>
+	}): Promise<string>
+	run(
+		request: IsolatedArtifactRebuildRequest,
+	): Promise<IsolatedArtifactRebuildOutcome>
+	discard(stagingKey: string): Promise<void>
+}
+
+function isDurableObjectResetError(error: unknown) {
+	return errorCauseChainIncludes(
+		error,
+		(message) =>
+			message.includes('Durable Object exceeded its CPU time limit') ||
+			message.includes("Durable Object's isolate exceeded its memory limit") ||
+			message.includes('Durable Object was reset'),
+	)
+}
+
+function describeTarget(target: PublishedPackageArtifactBuildTarget) {
+	return [
+		`kind "${target.kind}"`,
+		`artifact "${target.artifactName ?? '<default>'}"`,
+		`entry "${target.entryPoint}"`,
+		`bundle "${target.bundleKind}"`,
+	].join(', ')
+}
+
+/**
+ * Returns a runner when the env carries the bindings the offload needs;
+ * callers fall back to per-target session rebuild otherwise (unit tests and
+ * minimal envs).
+ */
+export function createIsolatedArtifactRebuildRunner(
+	env: Env | undefined,
+): IsolatedArtifactRebuildRunner | null {
+	const namespace = (
+		env as (Env & { REPO_SESSION?: DurableObjectNamespace }) | undefined
+	)?.REPO_SESSION
+	const stagingKv = (
+		env as (Env & { BUNDLE_ARTIFACTS_KV?: KVNamespace }) | undefined
+	)?.BUNDLE_ARTIFACTS_KV
+	if (!namespace || !stagingKv) return null
+	return {
+		async stage(input) {
+			const stagingKey = isolatedArtifactRebuildStagingKeyForUser(input.userId)
+			await stagingKv.put(
+				stagingKey,
+				JSON.stringify({ sourceFiles: input.sourceFiles }),
+				{
+					expirationTtl: stagingTtlSeconds,
+				},
+			)
+			return stagingKey
+		},
+		async run(request) {
+			// A fresh, user-namespaced id per target puts every heavy rebuild
+			// in its own isolate. The instance never touches its Durable Object
+			// storage, so nothing persists for the random name.
+			const stub = namespace.get(
+				namespace.idFromName(
+					`isolated-artifact-rebuild-${request.userId}-${crypto.randomUUID()}`,
+				),
+			) as unknown as IsolatedArtifactRebuildStub
+			try {
+				return await stub.runIsolatedArtifactRebuild(request)
+			} catch (error) {
+				if (isDurableObjectResetError(error)) {
+					return {
+						ok: false,
+						message:
+							`Artifact rebuild for { ${describeTarget(request.target)} } ` +
+							"exceeded the isolated rebuild runner's memory or CPU limits " +
+							'even on its own. Reduce the package source size (split large ' +
+							'generated modules, remove vendored or data files) and re-run ' +
+							'the publish capability to repair artifacts.',
+						target: request.target,
+					}
+				}
+				throw error
+			}
+		},
+		async discard(stagingKey) {
+			try {
+				await stagingKv.delete(stagingKey)
+			} catch {
+				// Best effort: the staging entry expires via its TTL anyway.
+			}
+		},
+	}
+}
+
+export { stagingTtlSeconds as isolatedArtifactRebuildStagingTtlSeconds }

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1631,15 +1631,6 @@ test('stagePublishedPackageArtifactRebuild collects workspace files once and sta
 	expect(
 		staged.stagingKey.startsWith('repo-artifact-rebuild-staging:v1:user-1:'),
 	).toBe(true)
-	expect(staged.targets).toEqual(
-		expect.arrayContaining([
-			expect.objectContaining({
-				kind: 'module',
-				artifactName: '.',
-				entryPoint: 'index.ts',
-			}),
-		]),
-	)
 	expect(put).toHaveBeenCalledTimes(1)
 	expect(put).toHaveBeenCalledWith(
 		staged.stagingKey,

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1542,7 +1542,9 @@ test('runIsolatedArtifactRebuild loads staged files, skips built targets, and re
 	})
 	expect(skipped).toMatchObject({ ok: true, skipped: true })
 	expect(kv.get).not.toHaveBeenCalled()
-	expect(mockModule.persistPublishedPackageArtifactTarget).not.toHaveBeenCalled()
+	expect(
+		mockModule.persistPublishedPackageArtifactTarget,
+	).not.toHaveBeenCalled()
 
 	const rebuilt = await session.runIsolatedArtifactRebuild({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:abc',

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -3,6 +3,7 @@ import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import type * as CloudflareWorkers from 'cloudflare:workers'
 import type * as Artifacts from './artifacts.ts'
 import type * as PublishedRuntimeArtifacts from '#worker/package-runtime/published-runtime-artifacts.ts'
+import type * as PublishedBundleArtifactsModule from '#worker/package-runtime/published-bundle-artifacts.ts'
 
 const mockModule = vi.hoisted(() => {
 	const gitState = {
@@ -379,9 +380,9 @@ vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', async () => {
 })
 
 vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', async () => {
-	const actual = await vi.importActual<
-		typeof import('#worker/package-runtime/published-bundle-artifacts.ts')
-	>('#worker/package-runtime/published-bundle-artifacts.ts')
+	const actual = await vi.importActual<typeof PublishedBundleArtifactsModule>(
+		'#worker/package-runtime/published-bundle-artifacts.ts',
+	)
 	return {
 		...actual,
 		isPublishedPackageArtifactBuiltForCommit: (...args: Array<unknown>) =>

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -125,6 +125,13 @@ const mockModule = vi.hoisted(() => {
 			message:
 				'No semantic diagnostics for 1 callable package runtime entrypoint(s).',
 		})),
+		isPublishedPackageArtifactBuiltForCommit: vi.fn(async () => false),
+		persistPublishedPackageArtifactTarget: vi.fn(async () => 'kv:artifact'),
+		getSavedPackageById: vi.fn(async () => ({
+			id: 'package-1',
+			kodyId: 'demo',
+			sourceId: 'source-1',
+		})),
 	}
 })
 
@@ -192,6 +199,15 @@ function restoreRepoSessionMockBaseline() {
 		},
 	})
 	mockModule.writePublishedSourceSnapshot.mockResolvedValue('snapshot-key')
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(false)
+	mockModule.persistPublishedPackageArtifactTarget.mockResolvedValue(
+		'kv:artifact',
+	)
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'demo',
+		sourceId: 'source-1',
+	})
 	mockModule.rawPush.mockResolvedValue({ ok: true, refs: {} })
 	mockModule.rawPush.mockClear()
 
@@ -361,6 +377,24 @@ vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', async () => {
 			mockModule.writePublishedSourceSnapshot(...args),
 	}
 })
+
+vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', async () => {
+	const actual = await vi.importActual<
+		typeof import('#worker/package-runtime/published-bundle-artifacts.ts')
+	>('#worker/package-runtime/published-bundle-artifacts.ts')
+	return {
+		...actual,
+		isPublishedPackageArtifactBuiltForCommit: (...args: Array<unknown>) =>
+			mockModule.isPublishedPackageArtifactBuiltForCommit(...args),
+		persistPublishedPackageArtifactTarget: (...args: Array<unknown>) =>
+			mockModule.persistPublishedPackageArtifactTarget(...args),
+	}
+})
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+}))
 
 const { RepoSession } = await import('./repo-session-do.ts')
 const { deleteRepoSession, insertRepoSession } =
@@ -1455,4 +1489,169 @@ test('runIsolatedCheckPhase loads staged files from KV and dispatches the phase'
 	expect(crossUser.ok).toBe(false)
 	expect(crossUser.message).toContain('does not belong to the requesting user')
 	expect(kv.get).not.toHaveBeenCalled()
+})
+
+test('runIsolatedArtifactRebuild loads staged files, skips built targets, and rejects cross-user keys', async () => {
+	restoreRepoSessionMockBaseline()
+	const staged = {
+		sourceFiles: {
+			'package.json':
+				'{"name":"@kody/demo","exports":{".":"./index.ts"},"kody":{"id":"demo","description":"Demo"}}',
+			'index.ts': 'export const ready = true\n',
+		},
+	}
+	const kv = {
+		get: vi.fn(async () => staged),
+		put: vi.fn(async () => undefined),
+	}
+	const packageSource = {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-1',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	}
+	mockModule.getEntitySourceById.mockResolvedValue(packageSource)
+	const session = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: kv,
+	} as unknown as Env)
+	const target = {
+		kind: 'module' as const,
+		artifactName: '.',
+		entryPoint: 'index.ts',
+		bundleKind: 'module' as const,
+	}
+
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValueOnce(
+		true,
+	)
+	const skipped = await session.runIsolatedArtifactRebuild({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:abc',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		target,
+	})
+	expect(skipped).toMatchObject({ ok: true, skipped: true })
+	expect(kv.get).not.toHaveBeenCalled()
+	expect(mockModule.persistPublishedPackageArtifactTarget).not.toHaveBeenCalled()
+
+	const rebuilt = await session.runIsolatedArtifactRebuild({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:abc',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		target,
+		baseUrl: 'https://kody.test',
+	})
+	expect(rebuilt).toMatchObject({
+		ok: true,
+		kvKey: 'kv:artifact',
+		target,
+	})
+	expect(mockModule.persistPublishedPackageArtifactTarget).toHaveBeenCalledWith(
+		expect.objectContaining({
+			userId: 'user-1',
+			target,
+			source: expect.objectContaining({ published_commit: 'commit-1' }),
+		}),
+	)
+
+	kv.get.mockResolvedValueOnce(null)
+	const expired = await session.runIsolatedArtifactRebuild({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:gone',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		target,
+	})
+	expect(expired.ok).toBe(false)
+	expect(expired.message).toContain('staging data expired')
+
+	kv.get.mockClear()
+	const crossUser = await session.runIsolatedArtifactRebuild({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-2:abc',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		target,
+	})
+	expect(crossUser.ok).toBe(false)
+	expect(crossUser.message).toContain('does not belong to the requesting user')
+	expect(kv.get).not.toHaveBeenCalled()
+})
+
+test('stagePublishedPackageArtifactRebuild collects workspace files once and stages them', async () => {
+	restoreRepoSessionMockBaseline()
+	const packageJson =
+		'{"name":"@kody/demo","exports":{".":"./index.ts"},"kody":{"id":"demo","description":"Demo"}}'
+	mockModule.workspaceGlob.mockResolvedValue([
+		{ type: 'file', path: '/session/package.json' },
+		{ type: 'file', path: '/session/index.ts' },
+	] as unknown as Array<{ type: 'file'; path: string }>)
+	mockModule.workspaceReadFile.mockImplementation(async (path: string) => {
+		if (path === '/session/package.json') return packageJson
+		if (path === '/session/index.ts') return 'export const ready = true\n'
+		return null
+	})
+	const packageSource = {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-1',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	}
+	mockModule.getEntitySourceById.mockResolvedValue(packageSource)
+
+	const put = vi.fn(async () => undefined)
+	const session = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: { put },
+	} as unknown as Env)
+
+	const staged = await session.stagePublishedPackageArtifactRebuild({
+		sourceId: 'source-1',
+		userId: 'user-1',
+	})
+	expect(
+		staged.stagingKey.startsWith('repo-artifact-rebuild-staging:v1:user-1:'),
+	).toBe(true)
+	expect(staged.targets).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				kind: 'module',
+				artifactName: '.',
+				entryPoint: 'index.ts',
+			}),
+		]),
+	)
+	expect(put).toHaveBeenCalledTimes(1)
+	expect(put).toHaveBeenCalledWith(
+		staged.stagingKey,
+		expect.stringContaining('"package.json"'),
+		{ expirationTtl: 15 * 60 },
+	)
+	const payload = JSON.parse(put.mock.calls[0]?.[1] as string) as {
+		sourceFiles: Record<string, string>
+	}
+	expect(payload.sourceFiles).toEqual({
+		'package.json': packageJson,
+		'index.ts': 'export const ready = true\n',
+	})
+	expect(mockModule.workspaceGlob).toHaveBeenCalledTimes(1)
 })

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1765,9 +1765,8 @@ class RepoSessionBase extends DurableObject<Env> {
 				'Published bundle artifacts can only be rebuilt for packages.',
 			)
 		}
-		const stagingKv = (
-			this.env as Env & { BUNDLE_ARTIFACTS_KV?: KVNamespace }
-		).BUNDLE_ARTIFACTS_KV
+		const stagingKv = (this.env as Env & { BUNDLE_ARTIFACTS_KV?: KVNamespace })
+			.BUNDLE_ARTIFACTS_KV
 		if (!stagingKv) {
 			throw new Error(
 				'BUNDLE_ARTIFACTS_KV binding is required to stage published package artifact rebuilds.',
@@ -1775,11 +1774,9 @@ class RepoSessionBase extends DurableObject<Env> {
 		}
 		const sourceFiles = await this.collectWorkspaceFiles()
 		const stagingKey = isolatedArtifactRebuildStagingKeyForUser(input.userId)
-		await stagingKv.put(
-			stagingKey,
-			JSON.stringify({ sourceFiles }),
-			{ expirationTtl: isolatedArtifactRebuildStagingTtlSeconds },
-		)
+		await stagingKv.put(stagingKey, JSON.stringify({ sourceFiles }), {
+			expirationTtl: isolatedArtifactRebuildStagingTtlSeconds,
+		})
 		return { stagingKey }
 	}
 

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -1747,9 +1747,10 @@ class RepoSessionBase extends DurableObject<Env> {
 	}
 
 	/**
-	 * Collect workspace files once on the long-lived publish session, list
-	 * artifact targets, and stage the snapshot in KV for throwaway rebuild
-	 * isolates (see isolated-artifact-rebuild.ts).
+	 * Collect workspace files once on the long-lived publish session and stage
+	 * the snapshot in KV for throwaway rebuild isolates (see
+	 * isolated-artifact-rebuild.ts). Callers list and filter targets before
+	 * staging so already-built resumes skip this work.
 	 */
 	async stagePublishedPackageArtifactRebuild(input: {
 		sessionId?: string
@@ -1757,7 +1758,6 @@ class RepoSessionBase extends DurableObject<Env> {
 		userId: string
 	}): Promise<{
 		stagingKey: string
-		targets: Array<PublishedPackageArtifactBuildTarget>
 	}> {
 		const source = await this.resolvePublishSource(input)
 		if (source.entity_kind !== 'package') {
@@ -1773,17 +1773,14 @@ class RepoSessionBase extends DurableObject<Env> {
 				'BUNDLE_ARTIFACTS_KV binding is required to stage published package artifact rebuilds.',
 			)
 		}
-		const [sourceFiles, targets] = await Promise.all([
-			this.collectWorkspaceFiles(),
-			this.listPackageArtifactTargetsForSource(source),
-		])
+		const sourceFiles = await this.collectWorkspaceFiles()
 		const stagingKey = isolatedArtifactRebuildStagingKeyForUser(input.userId)
 		await stagingKv.put(
 			stagingKey,
 			JSON.stringify({ sourceFiles }),
 			{ expirationTtl: isolatedArtifactRebuildStagingTtlSeconds },
 		)
-		return { stagingKey, targets }
+		return { stagingKey }
 	}
 
 	/**

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -28,8 +28,10 @@ import { buildSentryOptions } from '#worker/sentry-options.ts'
 import { getEntitySourceById, updateEntitySource } from './entity-sources.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import {
 	collectPublishedPackageArtifactTargets,
+	isPublishedPackageArtifactBuiltForCommit,
 	persistPublishedPackageArtifactTarget,
 	type PublishedPackageArtifactBuildTarget,
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
@@ -46,6 +48,13 @@ import {
 	runRepoChecks,
 	validatePackageBundles,
 } from './checks.ts'
+import {
+	isolatedArtifactRebuildStagingKeyBelongsToUser,
+	isolatedArtifactRebuildStagingKeyForUser,
+	isolatedArtifactRebuildStagingTtlSeconds,
+	type IsolatedArtifactRebuildOutcome,
+	type IsolatedArtifactRebuildRequest,
+} from './isolated-artifact-rebuild.ts'
 import {
 	isolatedCheckStagingKeyBelongsToUser,
 	type IsolatedCheckPhaseOutcome,
@@ -1737,6 +1746,146 @@ class RepoSessionBase extends DurableObject<Env> {
 		return await this.listPackageArtifactTargetsForSource(source)
 	}
 
+	/**
+	 * Collect workspace files once on the long-lived publish session, list
+	 * artifact targets, and stage the snapshot in KV for throwaway rebuild
+	 * isolates (see isolated-artifact-rebuild.ts).
+	 */
+	async stagePublishedPackageArtifactRebuild(input: {
+		sessionId?: string
+		sourceId?: string
+		userId: string
+	}): Promise<{
+		stagingKey: string
+		targets: Array<PublishedPackageArtifactBuildTarget>
+	}> {
+		const source = await this.resolvePublishSource(input)
+		if (source.entity_kind !== 'package') {
+			throw new Error(
+				'Published bundle artifacts can only be rebuilt for packages.',
+			)
+		}
+		const stagingKv = (
+			this.env as Env & { BUNDLE_ARTIFACTS_KV?: KVNamespace }
+		).BUNDLE_ARTIFACTS_KV
+		if (!stagingKv) {
+			throw new Error(
+				'BUNDLE_ARTIFACTS_KV binding is required to stage published package artifact rebuilds.',
+			)
+		}
+		const [sourceFiles, targets] = await Promise.all([
+			this.collectWorkspaceFiles(),
+			this.listPackageArtifactTargetsForSource(source),
+		])
+		const stagingKey = isolatedArtifactRebuildStagingKeyForUser(input.userId)
+		await stagingKv.put(
+			stagingKey,
+			JSON.stringify({ sourceFiles }),
+			{ expirationTtl: isolatedArtifactRebuildStagingTtlSeconds },
+		)
+		return { stagingKey, targets }
+	}
+
+	/**
+	 * Pure-compute entrypoint for one published-package artifact rebuild,
+	 * invoked on a throwaway Durable Object id so the rebuild's peak memory
+	 * lives in its own isolate (see isolated-artifact-rebuild.ts). It has no
+	 * session and never touches this instance's storage; the staged source
+	 * files come from a short-TTL KV entry written by
+	 * `stagePublishedPackageArtifactRebuild`.
+	 */
+	async runIsolatedArtifactRebuild(
+		input: IsolatedArtifactRebuildRequest,
+	): Promise<IsolatedArtifactRebuildOutcome> {
+		if (
+			!isolatedArtifactRebuildStagingKeyBelongsToUser({
+				stagingKey: input.stagingKey,
+				userId: input.userId,
+			})
+		) {
+			return {
+				ok: false,
+				message:
+					'Isolated artifact rebuild staging key does not belong to the requesting user.',
+				target: input.target,
+			}
+		}
+		const alreadyBuilt = await isPublishedPackageArtifactBuiltForCommit({
+			env: this.env,
+			userId: input.userId,
+			sourceId: input.sourceId,
+			publishedCommit: input.publishedCommit,
+			target: input.target,
+		})
+		if (alreadyBuilt) {
+			return {
+				ok: true,
+				message: 'Published package artifact already built for this commit.',
+				skipped: true,
+				kvKey: null,
+				target: input.target,
+			}
+		}
+		const staged = await this.env.BUNDLE_ARTIFACTS_KV.get<{
+			sourceFiles?: Record<string, string>
+		}>(input.stagingKey, 'json')
+		const sourceFiles = staged?.sourceFiles
+		if (!sourceFiles) {
+			return {
+				ok: false,
+				message:
+					'Isolated artifact rebuild staging data expired or is missing; re-run the publish capability to repair artifacts.',
+				target: input.target,
+			}
+		}
+		try {
+			const source = await this.resolvePublishSource({
+				sourceId: input.sourceId,
+				userId: input.userId,
+			})
+			if (source.entity_kind !== 'package') {
+				return {
+					ok: false,
+					message:
+						'Published bundle artifacts can only be rebuilt for packages.',
+					target: input.target,
+				}
+			}
+			const savedPackage = await getSavedPackageById(this.env.APP_DB, {
+				userId: input.userId,
+				packageId: source.entity_id,
+			})
+			if (!savedPackage) {
+				return {
+					ok: false,
+					message: `Saved package "${source.entity_id}" was not found.`,
+					target: input.target,
+				}
+			}
+			const kvKey = await this.persistPublishedPackageArtifactTargetFromFiles({
+				source,
+				savedPackage,
+				userId: input.userId,
+				publishedCommit: input.publishedCommit,
+				target: input.target,
+				baseUrl: input.baseUrl,
+				sourceFiles,
+			})
+			return {
+				ok: true,
+				message: 'Published package artifact rebuilt.',
+				kvKey,
+				target: input.target,
+			}
+		} catch (error) {
+			return {
+				ok: false,
+				message: getErrorMessage(error),
+				target: input.target,
+			}
+		}
+	}
+
 	async rebuildPublishedPackageArtifact(input: {
 		sessionId?: string
 		sourceId?: string
@@ -1763,8 +1912,33 @@ class RepoSessionBase extends DurableObject<Env> {
 			throw new Error(`Saved package "${source.entity_id}" was not found.`)
 		}
 		const sourceFiles = await this.collectWorkspaceFiles()
+		const kvKey = await this.persistPublishedPackageArtifactTargetFromFiles({
+			source,
+			savedPackage,
+			userId: input.userId,
+			publishedCommit: input.publishedCommit,
+			target: input.target,
+			baseUrl: input.baseUrl,
+			sourceFiles,
+		})
+		return {
+			ok: true,
+			target: input.target,
+			kvKey,
+		}
+	}
+
+	private async persistPublishedPackageArtifactTargetFromFiles(input: {
+		source: EntitySourceRow
+		savedPackage: SavedPackageRecord
+		userId: string
+		publishedCommit: string
+		target: PublishedPackageArtifactBuildTarget
+		baseUrl?: string
+		sourceFiles: Record<string, string>
+	}) {
 		const sourceAtPublishedCommit = {
-			...source,
+			...input.source,
 			published_commit: input.publishedCommit,
 		}
 		const {
@@ -1772,46 +1946,41 @@ class RepoSessionBase extends DurableObject<Env> {
 			buildKodyModuleBundle,
 			buildKodyImportableModuleBundle,
 		} = await import('#worker/package-runtime/module-graph.ts')
-		const kvKey = await persistPublishedPackageArtifactTarget({
+		return await persistPublishedPackageArtifactTarget({
 			env: this.env,
 			userId: input.userId,
 			source: sourceAtPublishedCommit,
-			savedPackage,
+			savedPackage: input.savedPackage,
 			target: input.target,
 			buildAppBundle: async ({ entryPoint }) =>
 				await buildKodyAppBundle({
 					env: this.env,
-					baseUrl: input.baseUrl ?? source.source_root,
+					baseUrl: input.baseUrl ?? input.source.source_root,
 					userId: input.userId,
-					sourceFiles,
+					sourceFiles: input.sourceFiles,
 					entryPoint,
-					rootPackageId: savedPackage.id,
+					rootPackageId: input.savedPackage.id,
 					cacheKey: null,
 				}),
 			buildModuleBundle: async ({ entryPoint }) =>
 				await buildKodyModuleBundle({
 					env: this.env,
-					baseUrl: input.baseUrl ?? source.source_root,
+					baseUrl: input.baseUrl ?? input.source.source_root,
 					userId: input.userId,
-					sourceFiles,
+					sourceFiles: input.sourceFiles,
 					entryPoint,
-					rootPackageId: savedPackage.id,
+					rootPackageId: input.savedPackage.id,
 				}),
 			buildImportableModuleBundle: async ({ entryPoint }) =>
 				await buildKodyImportableModuleBundle({
 					env: this.env,
-					baseUrl: input.baseUrl ?? source.source_root,
+					baseUrl: input.baseUrl ?? input.source.source_root,
 					userId: input.userId,
-					sourceFiles,
+					sourceFiles: input.sourceFiles,
 					entryPoint,
-					rootPackageId: savedPackage.id,
+					rootPackageId: input.savedPackage.id,
 				}),
 		})
-		return {
-			ok: true,
-			target: input.target,
-			kvKey,
-		}
 	}
 
 	async rebaseSession(input: {

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -3,6 +3,10 @@ import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtim
 import { repoSessionDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import { type RepoRunCommandsResult } from './repo-session-commands.ts'
 import {
+	type IsolatedArtifactRebuildOutcome,
+	type IsolatedArtifactRebuildRequest,
+} from './isolated-artifact-rebuild.ts'
+import {
 	type IsolatedCheckPhaseOutcome,
 	type IsolatedCheckPhaseRequest,
 } from './isolated-check-phases.ts'
@@ -125,6 +129,17 @@ export type RepoSessionRpc = {
 		sourceId?: string
 		userId: string
 	}) => Promise<Array<PublishedPackageArtifactBuildTarget>>
+	stagePublishedPackageArtifactRebuild: (payload: {
+		sessionId?: string
+		sourceId?: string
+		userId: string
+	}) => Promise<{
+		stagingKey: string
+		targets: Array<PublishedPackageArtifactBuildTarget>
+	}>
+	runIsolatedArtifactRebuild: (
+		payload: IsolatedArtifactRebuildRequest,
+	) => Promise<IsolatedArtifactRebuildOutcome>
 	rebuildPublishedPackageArtifact: (payload: {
 		sessionId?: string
 		sourceId?: string

--- a/packages/worker/src/repo/repo-session-rpc.ts
+++ b/packages/worker/src/repo/repo-session-rpc.ts
@@ -135,7 +135,6 @@ export type RepoSessionRpc = {
 		userId: string
 	}) => Promise<{
 		stagingKey: string
-		targets: Array<PublishedPackageArtifactBuildTarget>
 	}>
 	runIsolatedArtifactRebuild: (
 		payload: IsolatedArtifactRebuildRequest,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Package publish artifact rebuild previously ran every bundle/app/job target on the long-lived repo session Durable Object. Large packages (many exports × dual bundles + apps + jobs) could hit DO memory limits during rebuild even after checks already used throwaway isolates.

This PR mirrors the isolated-check pattern for artifact rebuild:

1. **List + skip first** — skip targets already built for the published commit (resume-friendly repairs).
2. **Stage once** — collect workspace files on the publish session into a short-TTL KV snapshot only when something still needs rebuilding.
3. **Fan out to throwaway DOs** — each rebuild target runs on an ephemeral repo-session isolate (concurrency 2); staging TTL is refreshed between chunks; then discard staging.
4. **Fallback** — if throwaway bindings are unavailable, keep the previous per-target same-session rebuild path (also with skip-already-built).

## Test plan

- [x] `package-artifact-rebuild.node.test.ts` — staging order, skip-all (no stage), concurrency, TTL touch between chunks, failure reporting, fallback
- [x] `isolated-artifact-rebuild.node.test.ts`
- [x] `repo-session-do` staging test
- [x] `published-bundle-artifacts` already-built helper tests
- [ ] CI `npm run validate` / parallel jobs green
- [ ] After deploy: re-publish a large package (e.g. morning-briefing) and confirm artifact rebuild completes without DO memory exhaustion; repair resume skips already-built targets

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b83c9843` · **Head:** `77c2152f`

**Classification:** extends — changes how published package artifact rebuild runs on repo sessions (throwaway isolates + skip-already-built), without adding a new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — stage KV snapshot + `runIsolatedArtifactRebuild` on throwaway DO ids |
| `capability-registry` | assistant | extends — publish rebuild orchestrator lists/filters before staging, fans out via isolated runner, refreshes staging TTL between chunks |
| `package-runtime` | runtime | extends — `isPublishedPackageArtifactBuiltForCommit` resume helper |
| `bundle-artifacts-kv` | storage | extends — short-TTL staging keys for throwaway rebuild isolates |

### System map

Publish rebuild now stages once (only when needed), then rebuilds each artifact target in a throwaway repo-session isolate that writes into bundle-artifacts KV.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	bundleArtifactsKv["bundle-artifacts-kv<br/>Bundle artifacts KV"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	capabilityRegistry -->|"list/filter targets then stage"| repoSessions
	repoSessions -->|"short-TTL workspace snapshot"| bundleArtifactsKv
	capabilityRegistry -->|"fan-out runIsolatedArtifactRebuild + touch TTL"| repoSessions
	repoSessions -->|"read staging + write artifact"| bundleArtifactsKv
	capabilityRegistry -->|"isPublishedPackageArtifactBuiltForCommit"| packageRuntime
	packageRuntime -->|"artifact presence for commit"| bundleArtifactsKv
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Pub as publish orchestrator
	participant Sess as long-lived repo session
	participant KV as BUNDLE_ARTIFACTS_KV
	participant Iso as throwaway repo session DO
	Pub->>Sess: listPublishedPackageArtifactTargets
	Pub->>KV: isPublishedPackageArtifactBuiltForCommit (per target)
	alt remaining targets
		Pub->>Sess: stagePublishedPackageArtifactRebuild
		Sess->>KV: put staging snapshot (TTL)
		loop concurrency 2
			Pub->>KV: touch staging TTL (after first chunk)
			Pub->>Iso: runIsolatedArtifactRebuild(target)
			Iso->>KV: get staging + put artifact
		end
		Pub->>KV: discard staging
	else all already built
		Pub-->>Pub: return (no stage)
	end
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Where rebuild runs | Long-lived publish session DO | Throwaway DO per target (fallback: session) |
| Workspace collect | Implicitly per rebuild / shared session pressure | Once into KV staging, only if work remains |
| Resume / repair | Rebuild every target again | Skip targets already built for commit |
| Staging lifetime | N/A | 15m TTL, refreshed between rebuild chunks |

### Invariants

Per-user isolation preserved: staging keys are user-namespaced; throwaway DO requests reject staging keys that do not belong to the requesting `userId`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff60845d-0b6b-464d-8e7c-5bb54227340d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff60845d-0b6b-464d-8e7c-5bb54227340d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published package artifact rebuilds now use an isolated execution path when available, improving reliability for resource-intensive builds.
  * Rebuilds temporarily stage workspace data and automatically clean it up after completion.
  * Failure reports now highlight which targets succeeded vs failed.

* **Bug Fixes**
  * Prevents unnecessary rebuilds by skipping targets already built for the selected commit.
  * Adds robust handling for missing/expired staging data and isolates resource-limit failures.
  * When isolated execution isn’t available, the workflow safely falls back to the standard rebuild path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->