### PR TITLE
Add the package-storage audit route and harden entitlement estimate reads

### DIFF
--- a/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
@@ -1,0 +1,400 @@
+import { expect, test, vi } from 'vitest'
+import {
+	type PermissionString,
+	type RoleName,
+} from '#worker/identity/permissions.ts'
+import type * as StorageRunnerModule from '#worker/storage-runner.ts'
+
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn(),
+	storageRunnerRpc: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#worker/storage-runner.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof StorageRunnerModule>()
+	return {
+		...actual,
+		storageRunnerRpc: (...args: Array<unknown>) =>
+			mockModule.storageRunnerRpc(...args),
+	}
+})
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageSourceBySourceId(...args),
+}))
+
+type SavedPackageRow = {
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+	hasApp: number
+}
+
+type StorageBucketRow = {
+	userId: string
+	storageId: string
+	kind: string
+	lastSeenAt: string
+}
+
+function createAdminActor(roles: Array<RoleName>) {
+	const permissions: Array<PermissionString> = roles.includes('admin')
+		? ['read:user:any', 'update:user:any']
+		: ['read:user:own']
+	return {
+		sessionUserId: '1',
+		userId: 1,
+		email: 'admin@example.com',
+		username: 'admin-user',
+		displayName: 'admin-user',
+		roles,
+		permissions,
+		artifactOwnerIds: ['1'],
+		mcpUser: {
+			userId: 'stable-admin',
+			email: 'admin@example.com',
+			username: 'admin-user',
+			displayName: 'admin-user',
+		},
+	}
+}
+
+function createAuditTestEnv(input: {
+	packages: Array<SavedPackageRow>
+	buckets: Array<StorageBucketRow>
+}) {
+	function normalize(query: string) {
+		return query.replace(/\s+/g, ' ').trim().toLowerCase()
+	}
+
+	function createStatement(query: string, params: Array<unknown> = []) {
+		const normalized = normalize(query)
+		return {
+			bind(...nextParams: Array<unknown>) {
+				return createStatement(query, nextParams)
+			},
+			async first() {
+				throw new Error(`Unsupported first query: ${query}`)
+			},
+			async all<T>() {
+				if (
+					normalized.includes('from saved_packages') &&
+					normalized.includes('has_app = 1')
+				) {
+					const limit = Number(params[0] ?? input.packages.length)
+					const rows = input.packages
+						.filter((row) => row.hasApp === 1)
+						.sort((left, right) => {
+							const byUser = left.userId.localeCompare(right.userId)
+							if (byUser !== 0) return byUser
+							return left.packageId.localeCompare(right.packageId)
+						})
+						.slice(0, limit)
+						.map((row) => ({
+							userId: row.userId,
+							packageId: row.packageId,
+							kodyId: row.kodyId,
+							sourceId: row.sourceId,
+						}))
+					return {
+						results: rows,
+						meta: { changes: 0 },
+					} as { results: Array<T>; meta: { changes: number } }
+				}
+				if (
+					normalized.includes('from user_storage_buckets b') &&
+					normalized.includes("kind = 'app'")
+				) {
+					const packageIds = new Set(input.packages.map((row) => row.packageId))
+					const rows = input.buckets
+						.filter(
+							(row) => row.kind === 'app' && !packageIds.has(row.storageId),
+						)
+						.sort((left, right) => {
+							const byUser = left.userId.localeCompare(right.userId)
+							if (byUser !== 0) return byUser
+							return left.storageId.localeCompare(right.storageId)
+						})
+						.map((row) => ({
+							userId: row.userId,
+							storageId: row.storageId,
+							lastSeenAt: row.lastSeenAt,
+						}))
+					return {
+						results: rows,
+						meta: { changes: 0 },
+					} as { results: Array<T>; meta: { changes: number } }
+				}
+				throw new Error(`Unsupported all query: ${query}`)
+			},
+			async run() {
+				throw new Error(`Unsupported run query: ${query}`)
+			},
+		}
+	}
+
+	return {
+		APP_DB: {
+			prepare(query: string) {
+				return createStatement(query)
+			},
+		},
+	} as unknown as Env
+}
+
+const { createAdminPackageStorageAuditApiHandler } =
+	await import('./admin-package-storage-audit.ts')
+
+function createHandlerRequest(input: { limit?: number } = {}) {
+	const url = new URL('https://example.com/admin/package-storage-audit.json')
+	if (input.limit !== undefined) {
+		url.searchParams.set('limit', String(input.limit))
+	}
+	return {
+		request: new Request(url, {
+			method: 'GET',
+			headers: { Accept: 'application/json' },
+		}),
+		params: {},
+		url,
+	} as never
+}
+
+function stubEstimate(bytes: number | Error) {
+	return {
+		getEstimatedBytes: async () => {
+			if (bytes instanceof Error) throw bytes
+			return { estimatedBytes: bytes }
+		},
+	}
+}
+
+test('admin package storage audit requires admin and returns the audit report', async () => {
+	const packages: Array<SavedPackageRow> = [
+		{
+			userId: 'user-a',
+			packageId: 'pkg-empty',
+			kodyId: 'empty-app',
+			sourceId: 'source-empty',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-a',
+			packageId: 'pkg-data',
+			kodyId: 'data-app',
+			sourceId: 'source-data',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-b',
+			packageId: 'pkg-ambient',
+			kodyId: 'ambient-app',
+			sourceId: 'source-ambient',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-b',
+			packageId: 'pkg-probe-error',
+			kodyId: 'probe-error-app',
+			sourceId: 'source-probe-error',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-b',
+			packageId: 'pkg-scan-error',
+			kodyId: 'scan-error-app',
+			sourceId: 'source-scan-error',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-a',
+			packageId: 'pkg-no-app',
+			kodyId: 'no-app',
+			sourceId: 'source-no-app',
+			hasApp: 0,
+		},
+	]
+	const buckets: Array<StorageBucketRow> = [
+		{
+			userId: 'user-a',
+			storageId: 'pkg-empty',
+			kind: 'app',
+			lastSeenAt: '2026-07-01T00:00:00.000Z',
+		},
+		{
+			userId: 'user-z',
+			storageId: 'deleted-pkg',
+			kind: 'app',
+			lastSeenAt: '2026-07-02T00:00:00.000Z',
+		},
+		{
+			userId: 'user-a',
+			storageId: 'job:still-here',
+			kind: 'job',
+			lastSeenAt: '2026-07-03T00:00:00.000Z',
+		},
+	]
+	const env = createAuditTestEnv({ packages, buckets })
+	const handler = createAdminPackageStorageAuditApiHandler(env)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	const unauthorized = await handler.handler(createHandlerRequest())
+	expect(unauthorized.status).toBe(401)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['user']),
+	)
+	const forbidden = await handler.handler(createHandlerRequest())
+	expect(forbidden.status).toBe(403)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['admin']),
+	)
+	mockModule.storageRunnerRpc.mockImplementation(
+		(input: { storageId: string }) => {
+			if (input.storageId === 'pkg-empty') return stubEstimate(4096)
+			if (input.storageId === 'pkg-data') return stubEstimate(8192)
+			if (input.storageId === 'pkg-ambient') return stubEstimate(4096)
+			if (input.storageId === 'pkg-probe-error') {
+				return stubEstimate(new Error('DO unavailable'))
+			}
+			if (input.storageId === 'pkg-scan-error') return stubEstimate(4096)
+			throw new Error(`Unexpected storageId: ${input.storageId}`)
+		},
+	)
+	mockModule.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => {
+			if (
+				input.sourceId === 'source-empty' ||
+				input.sourceId === 'source-data' ||
+				input.sourceId === 'source-probe-error'
+			) {
+				return {
+					files: {
+						'index.ts': `import { packageStorage } from 'kody:runtime'\nexport const x = packageStorage()\n`,
+					},
+				}
+			}
+			if (input.sourceId === 'source-ambient') {
+				return {
+					files: {
+						'app.ts': `import { storage } from 'kody:runtime'\nexport const read = () => storage.get('k')\n`,
+						'helpers.ts': `import { kody } from 'kody:runtime'\nexport const noop = () => kody\n`,
+					},
+				}
+			}
+			if (input.sourceId === 'source-scan-error') {
+				throw new Error('source missing')
+			}
+			throw new Error(`Unexpected sourceId: ${input.sourceId}`)
+		},
+	)
+
+	const response = await handler.handler(createHandlerRequest())
+	expect(response.status).toBe(200)
+	const body = await response.json()
+	expect(body).toMatchObject({
+		ok: true,
+		totals: {
+			appPackages: 5,
+			nonEmptyLegacyBuckets: 1,
+			packagesWithAmbientImports: 1,
+			orphanAppBuckets: 1,
+			truncated: false,
+		},
+		orphanAppBuckets: [
+			{
+				userId: 'user-z',
+				storageId: 'deleted-pkg',
+				lastSeenAt: '2026-07-02T00:00:00.000Z',
+			},
+		],
+	})
+
+	const byId = new Map(
+		(body.packages as Array<{ packageId: string }>).map((row) => [
+			row.packageId,
+			row,
+		]),
+	)
+	expect(byId.get('pkg-empty')).toMatchObject({
+		userId: 'user-a',
+		kodyId: 'empty-app',
+		legacyBucketBytes: 4096,
+		legacyBucketProbeError: null,
+		ambientStorageImportFiles: [],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-data')).toMatchObject({
+		legacyBucketBytes: 8192,
+		legacyBucketProbeError: null,
+		ambientStorageImportFiles: [],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-ambient')).toMatchObject({
+		userId: 'user-b',
+		legacyBucketBytes: 4096,
+		ambientStorageImportFiles: ['app.ts'],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-probe-error')).toMatchObject({
+		legacyBucketBytes: null,
+		legacyBucketProbeError: 'DO unavailable',
+		ambientStorageImportFiles: [],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-scan-error')).toMatchObject({
+		legacyBucketBytes: 4096,
+		legacyBucketProbeError: null,
+		ambientStorageImportFiles: [],
+		sourceScanError: 'source missing',
+	})
+
+	for (const call of mockModule.storageRunnerRpc.mock.calls) {
+		const arg = call[0] as { userId: string; storageId: string }
+		const pkg = packages.find((row) => row.packageId === arg.storageId)
+		expect(pkg).toBeTruthy()
+		expect(arg.userId).toBe(pkg?.userId)
+	}
+})
+
+test('admin package storage audit supports limit truncation', async () => {
+	const packages = Array.from({ length: 4 }, (_, index) => ({
+		userId: 'user-a',
+		packageId: `pkg-${index}`,
+		kodyId: `app-${index}`,
+		sourceId: `source-${index}`,
+		hasApp: 1 as const,
+	}))
+	const env = createAuditTestEnv({ packages, buckets: [] })
+	const handler = createAdminPackageStorageAuditApiHandler(env)
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['admin']),
+	)
+	mockModule.storageRunnerRpc.mockImplementation(() => stubEstimate(0))
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		files: { 'index.ts': 'export const ok = true\n' },
+	})
+
+	const response = await handler.handler(createHandlerRequest({ limit: 2 }))
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		packages: [{ packageId: 'pkg-0' }, { packageId: 'pkg-1' }],
+		totals: {
+			appPackages: 2,
+			nonEmptyLegacyBuckets: 0,
+			packagesWithAmbientImports: 0,
+			orphanAppBuckets: 0,
+			truncated: true,
+		},
+	})
+})

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
@@ -67,6 +67,10 @@ function createAdminActor(roles: Array<RoleName>) {
 	}
 }
 
+function packageOwnershipKey(userId: string, packageId: string) {
+	return `${userId}\0${packageId}`
+}
+
 function createAuditTestEnv(input: {
 	packages: Array<SavedPackageRow>
 	buckets: Array<StorageBucketRow>
@@ -111,18 +115,27 @@ function createAuditTestEnv(input: {
 				}
 				if (
 					normalized.includes('from user_storage_buckets b') &&
-					normalized.includes("kind = 'app'")
+					normalized.includes("kind = 'app'") &&
+					normalized.includes('p.user_id = b.user_id')
 				) {
-					const packageIds = new Set(input.packages.map((row) => row.packageId))
+					const limit = Number(params[0] ?? Number.POSITIVE_INFINITY)
+					const ownedKeys = new Set(
+						input.packages.map((row) =>
+							packageOwnershipKey(row.userId, row.packageId),
+						),
+					)
 					const rows = input.buckets
 						.filter(
-							(row) => row.kind === 'app' && !packageIds.has(row.storageId),
+							(row) =>
+								row.kind === 'app' &&
+								!ownedKeys.has(packageOwnershipKey(row.userId, row.storageId)),
 						)
 						.sort((left, right) => {
 							const byUser = left.userId.localeCompare(right.userId)
 							if (byUser !== 0) return byUser
 							return left.storageId.localeCompare(right.storageId)
 						})
+						.slice(0, limit)
 						.map((row) => ({
 							userId: row.userId,
 							storageId: row.storageId,
@@ -236,6 +249,14 @@ test('admin package storage audit requires admin and returns the audit report', 
 			lastSeenAt: '2026-07-02T00:00:00.000Z',
 		},
 		{
+			// Cross-user collision: storage_id matches user-b's package, but the
+			// bucket belongs to user-a, so it must still count as an orphan.
+			userId: 'user-a',
+			storageId: 'pkg-ambient',
+			kind: 'app',
+			lastSeenAt: '2026-07-02T12:00:00.000Z',
+		},
+		{
 			userId: 'user-a',
 			storageId: 'job:still-here',
 			kind: 'job',
@@ -307,10 +328,16 @@ test('admin package storage audit requires admin and returns the audit report', 
 			appPackages: 5,
 			nonEmptyLegacyBuckets: 1,
 			packagesWithAmbientImports: 1,
-			orphanAppBuckets: 1,
+			orphanAppBuckets: 2,
 			truncated: false,
+			orphanTruncated: false,
 		},
 		orphanAppBuckets: [
+			{
+				userId: 'user-a',
+				storageId: 'pkg-ambient',
+				lastSeenAt: '2026-07-02T12:00:00.000Z',
+			},
 			{
 				userId: 'user-z',
 				storageId: 'deleted-pkg',
@@ -395,6 +422,7 @@ test('admin package storage audit supports limit truncation', async () => {
 			packagesWithAmbientImports: 0,
 			orphanAppBuckets: 0,
 			truncated: true,
+			orphanTruncated: false,
 		},
 	})
 })

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.ts
@@ -1,0 +1,239 @@
+import { chunkArray } from '@kody-internal/shared/chunk.ts'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { type Action } from 'remix/router'
+import { requireUserWithRole } from '#app/permissions-server.ts'
+import { type routes } from '#app/routes.ts'
+import { jsonResponse } from '#worker/json-response.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import { readPositiveInt } from '#worker/query-params.ts'
+import { collectAmbientStorageImportFiles } from '#worker/repo/checks.ts'
+import {
+	emptyStorageRunnerEstimatedBytes,
+	storageRunnerRpc,
+} from '#worker/storage-runner.ts'
+
+const defaultAppPackageLimit = 200
+const maxAppPackageLimit = 500
+const maxConcurrentPackageAuditProbes = 5
+
+export type PackageStorageAuditPackageRow = {
+	userId: string
+	packageId: string
+	kodyId: string
+	legacyBucketBytes: number | null
+	legacyBucketProbeError: string | null
+	ambientStorageImportFiles: Array<string>
+	sourceScanError: string | null
+}
+
+export type PackageStorageAuditOrphanBucket = {
+	userId: string
+	storageId: string
+	lastSeenAt: string
+}
+
+export type PackageStorageAuditReport = {
+	ok: true
+	packages: Array<PackageStorageAuditPackageRow>
+	orphanAppBuckets: Array<PackageStorageAuditOrphanBucket>
+	totals: {
+		appPackages: number
+		nonEmptyLegacyBuckets: number
+		packagesWithAmbientImports: number
+		orphanAppBuckets: number
+		truncated: boolean
+	}
+}
+
+type AppPackageRow = {
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+}
+
+export function createAdminPackageStorageAuditApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, url }) {
+			try {
+				if (request.method !== 'GET') {
+					return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+				}
+				await requireUserWithRole(request, env, 'admin')
+				const limit = readPositiveInt(
+					url.searchParams.get('limit'),
+					defaultAppPackageLimit,
+					maxAppPackageLimit,
+				)
+				const report = await buildPackageStorageAuditReport({
+					env,
+					baseUrl: url.origin,
+					limit,
+				})
+				return jsonResponse(report)
+			} catch (error) {
+				if (error instanceof Response) return error
+				throw error
+			}
+		},
+	} satisfies Action<typeof routes.adminPackageStorageAuditApi>
+}
+
+export async function buildPackageStorageAuditReport(input: {
+	env: Env
+	baseUrl: string
+	limit: number
+}): Promise<PackageStorageAuditReport> {
+	const [appPackagePage, orphanAppBuckets] = await Promise.all([
+		listAppPackagesForAudit({
+			db: input.env.APP_DB,
+			limit: input.limit,
+		}),
+		listOrphanAppBuckets({ db: input.env.APP_DB }),
+	])
+
+	const packages: Array<PackageStorageAuditPackageRow> = []
+	for (const chunk of chunkArray(
+		appPackagePage.rows,
+		maxConcurrentPackageAuditProbes,
+	)) {
+		const chunkRows = await Promise.all(
+			chunk.map((row) =>
+				auditAppPackage({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					row,
+				}),
+			),
+		)
+		packages.push(...chunkRows)
+	}
+
+	return {
+		ok: true,
+		packages,
+		orphanAppBuckets,
+		totals: {
+			appPackages: packages.length,
+			nonEmptyLegacyBuckets: packages.filter(
+				(row) =>
+					row.legacyBucketBytes != null &&
+					row.legacyBucketBytes > emptyStorageRunnerEstimatedBytes,
+			).length,
+			packagesWithAmbientImports: packages.filter(
+				(row) => row.ambientStorageImportFiles.length > 0,
+			).length,
+			orphanAppBuckets: orphanAppBuckets.length,
+			truncated: appPackagePage.truncated,
+		},
+	}
+}
+
+async function listAppPackagesForAudit(input: {
+	db: D1Database
+	limit: number
+}): Promise<{ rows: Array<AppPackageRow>; truncated: boolean }> {
+	const result = await input.db
+		.prepare(
+			`SELECT user_id AS userId, id AS packageId, kody_id AS kodyId,
+				source_id AS sourceId
+			FROM saved_packages
+			WHERE has_app = 1
+			ORDER BY user_id ASC, id ASC
+			LIMIT ?`,
+		)
+		.bind(input.limit + 1)
+		.all<AppPackageRow>()
+	const rows = result.results ?? []
+	const truncated = rows.length > input.limit
+	return {
+		rows: truncated ? rows.slice(0, input.limit) : rows,
+		truncated,
+	}
+}
+
+async function listOrphanAppBuckets(input: {
+	db: D1Database
+}): Promise<Array<PackageStorageAuditOrphanBucket>> {
+	const result = await input.db
+		.prepare(
+			`SELECT b.user_id AS userId, b.storage_id AS storageId,
+				b.last_seen_at AS lastSeenAt
+			FROM user_storage_buckets b
+			LEFT JOIN saved_packages p ON p.id = b.storage_id
+			WHERE b.kind = 'app' AND p.id IS NULL
+			ORDER BY b.user_id ASC, b.storage_id ASC`,
+		)
+		.all<PackageStorageAuditOrphanBucket>()
+	return result.results ?? []
+}
+
+async function auditAppPackage(input: {
+	env: Env
+	baseUrl: string
+	row: AppPackageRow
+}): Promise<PackageStorageAuditPackageRow> {
+	const [legacyProbe, sourceScan] = await Promise.all([
+		probeLegacyBucketBytes({
+			env: input.env,
+			userId: input.row.userId,
+			packageId: input.row.packageId,
+		}),
+		scanAmbientStorageImports({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.row.userId,
+			sourceId: input.row.sourceId,
+		}),
+	])
+
+	return {
+		userId: input.row.userId,
+		packageId: input.row.packageId,
+		kodyId: input.row.kodyId,
+		legacyBucketBytes: legacyProbe.bytes,
+		legacyBucketProbeError: legacyProbe.error,
+		ambientStorageImportFiles: sourceScan.files,
+		sourceScanError: sourceScan.error,
+	}
+}
+
+async function probeLegacyBucketBytes(input: {
+	env: Env
+	userId: string
+	packageId: string
+}): Promise<{ bytes: number | null; error: string | null }> {
+	try {
+		const estimate = await storageRunnerRpc({
+			env: input.env,
+			userId: input.userId,
+			storageId: input.packageId,
+		}).getEstimatedBytes()
+		return { bytes: estimate.estimatedBytes, error: null }
+	} catch (error) {
+		return { bytes: null, error: getErrorMessage(error) }
+	}
+}
+
+async function scanAmbientStorageImports(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	sourceId: string
+}): Promise<{ files: Array<string>; error: string | null }> {
+	try {
+		const loaded = await loadPackageSourceBySourceId({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			sourceId: input.sourceId,
+		})
+		return {
+			files: collectAmbientStorageImportFiles(loaded.files),
+			error: null,
+		}
+	} catch (error) {
+		return { files: [], error: getErrorMessage(error) }
+	}
+}

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.ts
@@ -14,6 +14,7 @@ import {
 
 const defaultAppPackageLimit = 200
 const maxAppPackageLimit = 500
+const maxOrphanAppBuckets = 500
 const maxConcurrentPackageAuditProbes = 5
 
 export type PackageStorageAuditPackageRow = {
@@ -42,6 +43,7 @@ export type PackageStorageAuditReport = {
 		packagesWithAmbientImports: number
 		orphanAppBuckets: number
 		truncated: boolean
+		orphanTruncated: boolean
 	}
 }
 
@@ -85,7 +87,7 @@ export async function buildPackageStorageAuditReport(input: {
 	baseUrl: string
 	limit: number
 }): Promise<PackageStorageAuditReport> {
-	const [appPackagePage, orphanAppBuckets] = await Promise.all([
+	const [appPackagePage, orphanPage] = await Promise.all([
 		listAppPackagesForAudit({
 			db: input.env.APP_DB,
 			limit: input.limit,
@@ -113,7 +115,7 @@ export async function buildPackageStorageAuditReport(input: {
 	return {
 		ok: true,
 		packages,
-		orphanAppBuckets,
+		orphanAppBuckets: orphanPage.rows,
 		totals: {
 			appPackages: packages.length,
 			nonEmptyLegacyBuckets: packages.filter(
@@ -124,8 +126,9 @@ export async function buildPackageStorageAuditReport(input: {
 			packagesWithAmbientImports: packages.filter(
 				(row) => row.ambientStorageImportFiles.length > 0,
 			).length,
-			orphanAppBuckets: orphanAppBuckets.length,
+			orphanAppBuckets: orphanPage.rows.length,
 			truncated: appPackagePage.truncated,
+			orphanTruncated: orphanPage.truncated,
 		},
 	}
 }
@@ -153,20 +156,29 @@ async function listAppPackagesForAudit(input: {
 	}
 }
 
-async function listOrphanAppBuckets(input: {
-	db: D1Database
-}): Promise<Array<PackageStorageAuditOrphanBucket>> {
+async function listOrphanAppBuckets(input: { db: D1Database }): Promise<{
+	rows: Array<PackageStorageAuditOrphanBucket>
+	truncated: boolean
+}> {
 	const result = await input.db
 		.prepare(
 			`SELECT b.user_id AS userId, b.storage_id AS storageId,
 				b.last_seen_at AS lastSeenAt
 			FROM user_storage_buckets b
-			LEFT JOIN saved_packages p ON p.id = b.storage_id
+			LEFT JOIN saved_packages p
+				ON p.id = b.storage_id AND p.user_id = b.user_id
 			WHERE b.kind = 'app' AND p.id IS NULL
-			ORDER BY b.user_id ASC, b.storage_id ASC`,
+			ORDER BY b.user_id ASC, b.storage_id ASC
+			LIMIT ?`,
 		)
+		.bind(maxOrphanAppBuckets + 1)
 		.all<PackageStorageAuditOrphanBucket>()
-	return result.results ?? []
+	const rows = result.results ?? []
+	const truncated = rows.length > maxOrphanAppBuckets
+	return {
+		rows: truncated ? rows.slice(0, maxOrphanAppBuckets) : rows,
+		truncated,
+	}
 }
 
 async function auditAppPackage(input: {

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -17,6 +17,7 @@ import {
 	createAdminFeatureFlagsApiHandler,
 	createAdminFeatureFlagsHandler,
 } from '#app/handlers/admin-feature-flags.ts'
+import { createAdminPackageStorageAuditApiHandler } from '#app/handlers/admin-package-storage-audit.ts'
 import {
 	createAdminRolesApiHandler,
 	createAdminRolesHandler,
@@ -320,6 +321,8 @@ export function createAppRouter(env: Env) {
 			adminFeatureFlags: createAdminFeatureFlagsHandler(env),
 			adminFeatureFlagsApi: createAdminFeatureFlagsApiHandler(env),
 			adminFeatureFlagsApiPost: createAdminFeatureFlagsApiHandler(env),
+			adminPackageStorageAuditApi:
+				createAdminPackageStorageAuditApiHandler(env),
 			adminRoles: createAdminRolesHandler(env),
 			adminRolesApi: createAdminRolesApiHandler(env),
 			adminCommunityReports: createAdminCommunityReportsHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -94,6 +94,7 @@ export const routes = route({
 	adminFeatureFlags: '/admin/feature-flags',
 	adminFeatureFlagsApi: '/admin/feature-flags.json',
 	adminFeatureFlagsApiPost: post('/admin/feature-flags.json'),
+	adminPackageStorageAuditApi: '/admin/package-storage-audit.json',
 	adminCommunityReports: '/admin/community-reports',
 	adminCommunityReportsApi: '/admin/community-reports.json',
 	adminCommunityReportsApiPost: post('/admin/community-reports.json'),

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -960,7 +960,9 @@ function moduleImportsAmbientStorage(source: string) {
 	return false
 }
 
-function collectAmbientStorageImportFiles(sourceFiles: Record<string, string>) {
+export function collectAmbientStorageImportFiles(
+	sourceFiles: Record<string, string>,
+) {
 	const filePaths: Array<string> = []
 	for (const [filePath, source] of Object.entries(sourceFiles)) {
 		if (!scannableModuleFilePattern.test(filePath)) continue

--- a/packages/worker/src/storage-runner.entitlement.node.test.ts
+++ b/packages/worker/src/storage-runner.entitlement.node.test.ts
@@ -38,7 +38,7 @@ const { assertStorageRunnerWriteWithinEntitlement } =
 	await import('#worker/storage-runner.ts')
 
 function createEstimateEnv(
-	getEstimatedBytes: () => Promise<{ estimatedBytes: number }>,
+	getEstimatedBytes: (storageId: string) => Promise<{ estimatedBytes: number }>,
 ) {
 	return {
 		APP_DB: {
@@ -48,9 +48,13 @@ function createEstimateEnv(
 		},
 		STORAGE_RUNNER: {
 			idFromName: (name: string) => name,
-			get: () => ({
-				getEstimatedBytes,
-			}),
+			get: (name: string) => {
+				const parts = JSON.parse(name) as [string, string]
+				const storageId = parts[1]
+				return {
+					getEstimatedBytes: () => getEstimatedBytes(storageId),
+				}
+			},
 		},
 	} as unknown as Env
 }
@@ -65,7 +69,7 @@ test('assertStorageRunnerWriteWithinEntitlement retries a failed estimate chunk 
 	vi.useFakeTimers()
 	try {
 		const assertion = assertStorageRunnerWriteWithinEntitlement({
-			env: createEstimateEnv(getEstimatedBytes),
+			env: createEstimateEnv(() => getEstimatedBytes()),
 			userId: 'user-1',
 			email: null,
 			storageId: 'bucket-a',
@@ -88,7 +92,7 @@ test('assertStorageRunnerWriteWithinEntitlement fails closed when the retry also
 	vi.useFakeTimers()
 	try {
 		const assertion = assertStorageRunnerWriteWithinEntitlement({
-			env: createEstimateEnv(getEstimatedBytes),
+			env: createEstimateEnv(() => getEstimatedBytes()),
 			userId: 'user-1',
 			email: null,
 			storageId: 'bucket-a',
@@ -103,4 +107,73 @@ test('assertStorageRunnerWriteWithinEntitlement fails closed when the retry also
 	} finally {
 		vi.useRealTimers()
 	}
+})
+
+test('estimate chunk retry waits for pending first-attempt reads before retrying', async () => {
+	const chunkStorageIds = ['fast-fail', 'slow-ok'] as const
+	mockModule.listUserStorageBucketIds.mockResolvedValue([...chunkStorageIds])
+
+	let inFlight = 0
+	let maxInFlight = 0
+	let resolveSlow: (() => void) | undefined
+	const slowPending = new Promise<void>((resolve) => {
+		resolveSlow = resolve
+	})
+	const callCounts = new Map<string, number>()
+
+	const getEstimatedBytes = async (storageId: string) => {
+		inFlight += 1
+		maxInFlight = Math.max(maxInFlight, inFlight)
+		const callCount = (callCounts.get(storageId) ?? 0) + 1
+		callCounts.set(storageId, callCount)
+		try {
+			if (storageId === 'fast-fail') {
+				if (callCount === 1) {
+					// Yield so the peer read is in-flight before this rejects;
+					// a sync throw would never overlap and miss the fan-out bug.
+					await Promise.resolve()
+					throw new Error('fast fail on first attempt')
+				}
+				return { estimatedBytes: 8 }
+			}
+			if (storageId === 'slow-ok') {
+				if (callCount === 1) {
+					await slowPending
+				}
+				return { estimatedBytes: 16 }
+			}
+			throw new Error(`Unexpected storageId: ${storageId}`)
+		} finally {
+			inFlight -= 1
+		}
+	}
+
+	const assertion = assertStorageRunnerWriteWithinEntitlement({
+		env: createEstimateEnv(getEstimatedBytes),
+		userId: 'user-1',
+		email: null,
+		storageId: 'fast-fail',
+		requested: 1,
+	})
+
+	await vi.waitFor(() => {
+		expect(callCounts.get('fast-fail')).toBe(1)
+		expect(callCounts.get('slow-ok')).toBe(1)
+	})
+	expect(maxInFlight).toBe(chunkStorageIds.length)
+
+	// Even after the retry delay elapses, the second wave must not start while
+	// the slow first-attempt peer is still in flight (allSettled must win).
+	await new Promise<void>((resolve) => {
+		setTimeout(resolve, storageEstimateReadRetryDelayMs + 50)
+	})
+	expect(callCounts.get('fast-fail')).toBe(1)
+	expect(callCounts.get('slow-ok')).toBe(1)
+
+	resolveSlow?.()
+	await expect(assertion).resolves.toBeUndefined()
+
+	expect(callCounts.get('fast-fail')).toBe(2)
+	expect(callCounts.get('slow-ok')).toBe(2)
+	expect(maxInFlight).toBe(chunkStorageIds.length)
 })

--- a/packages/worker/src/storage-runner.entitlement.node.test.ts
+++ b/packages/worker/src/storage-runner.entitlement.node.test.ts
@@ -1,0 +1,106 @@
+import { expect, test, vi } from 'vitest'
+import { storageEstimateReadRetryDelayMs } from '#worker/storage-runner.ts'
+import type * as EntitlementsService from '#worker/entitlements/service.ts'
+
+const mockModule = vi.hoisted(() => ({
+	listUserStorageBucketIds: vi.fn(),
+	readUserD1StorageBytes: vi.fn(async () => 0),
+	registerStorageBucket: vi.fn(),
+}))
+
+vi.mock('#worker/storage-buckets/service.ts', () => ({
+	listUserStorageBucketIds: (...args: Array<unknown>) =>
+		mockModule.listUserStorageBucketIds(...args),
+	registerStorageBucket: (...args: Array<unknown>) =>
+		mockModule.registerStorageBucket(...args),
+	storageBucketKindFromStorageId: (storageId: string) => {
+		if (storageId.startsWith('job:')) return 'job'
+		if (storageId.startsWith('exec:')) return 'execute'
+		if (storageId.startsWith('package:')) return 'package'
+		if (storageId.startsWith('service:')) return 'service'
+		return 'unknown'
+	},
+	flushStorageBucketRegistrationsForTests: async () => undefined,
+	clearStorageBucketRegistrationDedupeForTests: () => undefined,
+	listPlatformStorageBuckets: async () => [],
+}))
+
+vi.mock('#worker/entitlements/service.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof EntitlementsService>()
+	return {
+		...actual,
+		readUserD1StorageBytes: (...args: Array<unknown>) =>
+			mockModule.readUserD1StorageBytes(...args),
+	}
+})
+
+const { assertStorageRunnerWriteWithinEntitlement } =
+	await import('#worker/storage-runner.ts')
+
+function createEstimateEnv(
+	getEstimatedBytes: () => Promise<{ estimatedBytes: number }>,
+) {
+	return {
+		APP_DB: {
+			prepare() {
+				throw new Error('APP_DB should not be queried when email is absent')
+			},
+		},
+		STORAGE_RUNNER: {
+			idFromName: (name: string) => name,
+			get: () => ({
+				getEstimatedBytes,
+			}),
+		},
+	} as unknown as Env
+}
+
+test('assertStorageRunnerWriteWithinEntitlement retries a failed estimate chunk once', async () => {
+	mockModule.listUserStorageBucketIds.mockResolvedValue(['bucket-a'])
+	const getEstimatedBytes = vi
+		.fn()
+		.mockRejectedValueOnce(new Error('transient DO read failure'))
+		.mockResolvedValueOnce({ estimatedBytes: 32 })
+
+	vi.useFakeTimers()
+	try {
+		const assertion = assertStorageRunnerWriteWithinEntitlement({
+			env: createEstimateEnv(getEstimatedBytes),
+			userId: 'user-1',
+			email: null,
+			storageId: 'bucket-a',
+			requested: 1,
+		})
+		await vi.advanceTimersByTimeAsync(storageEstimateReadRetryDelayMs)
+		await expect(assertion).resolves.toBeUndefined()
+		expect(getEstimatedBytes).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+})
+
+test('assertStorageRunnerWriteWithinEntitlement fails closed when the retry also fails', async () => {
+	mockModule.listUserStorageBucketIds.mockResolvedValue(['bucket-a'])
+	const getEstimatedBytes = vi
+		.fn()
+		.mockRejectedValue(new Error('persistent DO read failure'))
+
+	vi.useFakeTimers()
+	try {
+		const assertion = assertStorageRunnerWriteWithinEntitlement({
+			env: createEstimateEnv(getEstimatedBytes),
+			userId: 'user-1',
+			email: null,
+			storageId: 'bucket-a',
+			requested: 1,
+		})
+		const expectation = expect(assertion).rejects.toThrow(
+			'Unable to verify the storage byte entitlement because a bucket estimate could not be read.',
+		)
+		await vi.advanceTimersByTimeAsync(storageEstimateReadRetryDelayMs)
+		await expectation
+		expect(getEstimatedBytes).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+})

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -580,31 +580,44 @@ async function readStorageEstimateChunkWithRetry(input: {
 	userId: string
 	storageIds: Array<string>
 }): Promise<Array<StorageEstimateResult>> {
-	const readChunk = () =>
-		Promise.all(
-			input.storageIds.map((storageId) =>
-				storageRunnerRpc({
-					env: input.env,
-					userId: input.userId,
-					storageId,
-				}).getEstimatedBytes(),
-			),
-		)
-	try {
-		return await readChunk()
-	} catch {
-		await new Promise<void>((resolve) => {
-			setTimeout(resolve, storageEstimateReadRetryDelayMs)
-		})
-		try {
-			return await readChunk()
-		} catch (retryError) {
-			// An unreadable bucket cannot safely be treated as zero usage.
-			throw new Error(
-				'Unable to verify the storage byte entitlement because a bucket estimate could not be read.',
-				{ cause: retryError },
-			)
+	const readOne = (storageId: string) =>
+		storageRunnerRpc({
+			env: input.env,
+			userId: input.userId,
+			storageId,
+		}).getEstimatedBytes()
+
+	// Wait for every first-attempt read to settle before retrying so a fast
+	// rejection cannot overlap still-pending peers and exceed the fan-out cap.
+	const firstAttempt = await Promise.allSettled(
+		input.storageIds.map((storageId) => readOne(storageId)),
+	)
+	const firstValues: Array<StorageEstimateResult> = []
+	let firstFailed = false
+	for (const result of firstAttempt) {
+		if (result.status === 'fulfilled') {
+			firstValues.push(result.value)
+			continue
 		}
+		firstFailed = true
+	}
+	if (!firstFailed) {
+		return firstValues
+	}
+
+	await new Promise<void>((resolve) => {
+		setTimeout(resolve, storageEstimateReadRetryDelayMs)
+	})
+	try {
+		return await Promise.all(
+			input.storageIds.map((storageId) => readOne(storageId)),
+		)
+	} catch (retryError) {
+		// An unreadable bucket cannot safely be treated as zero usage.
+		throw new Error(
+			'Unable to verify the storage byte entitlement because a bucket estimate could not be read.',
+			{ cause: retryError },
+		)
 	}
 }
 

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -17,6 +17,15 @@ import { storageRunnerDurableObjectName } from '#worker/user-scoped-durable-obje
 const defaultStorageExportPageSize = 250
 const maxStorageExportPageSize = 1_000
 const maxConcurrentStorageEstimateReads = 16
+/** One bounded pause before re-reading a failed estimate chunk. */
+export const storageEstimateReadRetryDelayMs = 150
+/**
+ * `ctx.storage.sql.databaseSize` for a never-written StorageRunner DO (one
+ * SQLite page). Audit/entitlement callers that need a "has user data" signal
+ * must compare against this floor rather than treating any positive size as
+ * non-empty.
+ */
+export const emptyStorageRunnerEstimatedBytes = 4096
 
 type StorageEntry = {
 	key: string
@@ -566,6 +575,39 @@ export function storageRunnerRpc(input: {
 	}
 }
 
+async function readStorageEstimateChunkWithRetry(input: {
+	env: Env
+	userId: string
+	storageIds: Array<string>
+}): Promise<Array<StorageEstimateResult>> {
+	const readChunk = () =>
+		Promise.all(
+			input.storageIds.map((storageId) =>
+				storageRunnerRpc({
+					env: input.env,
+					userId: input.userId,
+					storageId,
+				}).getEstimatedBytes(),
+			),
+		)
+	try {
+		return await readChunk()
+	} catch {
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, storageEstimateReadRetryDelayMs)
+		})
+		try {
+			return await readChunk()
+		} catch (retryError) {
+			// An unreadable bucket cannot safely be treated as zero usage.
+			throw new Error(
+				'Unable to verify the storage byte entitlement because a bucket estimate could not be read.',
+				{ cause: retryError },
+			)
+		}
+	}
+}
+
 export async function assertStorageRunnerWriteWithinEntitlement(input: {
 	env: Env
 	userId: string
@@ -603,26 +645,15 @@ export async function assertStorageRunnerWriteWithinEntitlement(input: {
 				offset < storageIds.length;
 				offset += maxConcurrentStorageEstimateReads
 			) {
-				let estimates: Array<StorageEstimateResult>
-				try {
-					estimates = await Promise.all(
-						storageIds
-							.slice(offset, offset + maxConcurrentStorageEstimateReads)
-							.map((storageId) =>
-								storageRunnerRpc({
-									env: input.env,
-									userId: input.userId,
-									storageId,
-								}).getEstimatedBytes(),
-							),
-					)
-				} catch (error) {
-					// An unreadable bucket cannot safely be treated as zero usage.
-					throw new Error(
-						'Unable to verify the storage byte entitlement because a bucket estimate could not be read.',
-						{ cause: error },
-					)
-				}
+				const chunkIds = storageIds.slice(
+					offset,
+					offset + maxConcurrentStorageEstimateReads,
+				)
+				const estimates = await readStorageEstimateChunkWithRetry({
+					env: input.env,
+					userId: input.userId,
+					storageIds: chunkIds,
+				})
 				durableObjectBytes += estimates.reduce(
 					(total, estimate) => total + estimate.estimatedBytes,
 					0,

--- a/packages/worker/src/storage-runner.workers.test.ts
+++ b/packages/worker/src/storage-runner.workers.test.ts
@@ -16,6 +16,7 @@ import {
 	assertStorageRunnerWriteWithinEntitlement,
 	createStorageKodyTools,
 	createExecuteStorageId,
+	emptyStorageRunnerEstimatedBytes,
 	StorageRunner,
 	storageRunnerRpc,
 } from './storage-runner.ts'
@@ -468,6 +469,17 @@ test('storage runner registers buckets on writes but not on reads', async () => 
 	await expect(listUserStorageBucketIds({ env, userId })).resolves.toEqual([
 		writeStorageId,
 	])
+})
+
+test('getEstimatedBytes on a never-written bucket returns the empty DO baseline without registering', async () => {
+	await ensureStorageRunnerTestSchema()
+	const userId = `storage-empty-probe-${crypto.randomUUID()}`
+	const storageId = crypto.randomUUID()
+	const runner = storageRunnerRpc({ env, userId, storageId })
+	const estimate = await runner.getEstimatedBytes()
+	expect(estimate.estimatedBytes).toBe(emptyStorageRunnerEstimatedBytes)
+	await flushStorageBucketRegistrationsForTests()
+	await expect(listUserStorageBucketIds({ env, userId })).resolves.toEqual([])
 })
 
 test('storage runner dedupes bucket registration to one D1 write per isolate', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pre-cleanup groundwork for #1024 (removing the legacy raw-package-id app bucket), plus one hardening fix informed by production evidence:

- **`GET /admin/package-storage-audit.json`** (admin RBAC): the read-only audit that gates the #1024 delete-vs-migrate decision. Platform-wide, it reports every `has_app` package's legacy raw-id bucket size (probed per-user through `storageRunnerRpc`; probing is side-effect-free — `getEstimatedBytes` never registers buckets — and 4096 bytes is the never-written SQLite floor), which published app sources still import the banned ambient `storage` (reusing the repo-check AST scan, now exported), and orphaned `kind='app'` inventory rows from packages deleted before #1026. Bounded: `?limit=` (default 200, max 500) with a `truncated` flag, DO probes in concurrency-5 chunks, per-package error tolerance so one bad row can't sink the report.
- **Entitlement estimator retry**: `assertStorageRunnerWriteWithinEntitlement` fans out `getEstimatedBytes` over every registered bucket and fails closed on any error. Since #1026, package delete clears buckets concurrently with live traffic, and we observed exactly one production write flake ("Unable to verify the storage byte entitlement…") coinciding to the second with a package deletion. Each chunk now gets one bounded retry (150ms) before the existing fail-closed error.

Production verification that motivated this (run via MCP against prod): `packageStorage()` round-trips (KV + SQL) in the real invocation runtime across runs; `package_delete` deallocates the bucket (post-delete query: `no such table`); zero `Value scope "app"` errors in run records since the fallback removal.

## Testing

- `npm run validate` (full local gate)
- New node tests: audit route 401/403, happy path across two users, empty vs non-empty legacy buckets, ambient-import flagging, probe/scan error tolerance, orphan detection, limit/truncation; entitlement retry (fail→retry→succeed, fail→fail→throw)
- New workers test: never-written DO `getEstimatedBytes` baseline (4096) and probe-does-not-register behavior

Refs #1024

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `9bf6dd26` · **Head:** `2f9e8` (audit commit)

**Classification:** composes — a read-only admin surface wiring existing primitives together, plus a bounded retry inside an existing durable-storage code path. No schema changes, no new primitives, `primitives.yaml` unchanged.

### Primitives touched

| Primitive         | Group     | Impact                                                                     |
| ----------------- | --------- | --------------------------------------------------------------------------- |
| `app-ui` / admin  | surfaces  | composes — new admin JSON route `/admin/package-storage-audit.json` (RBAC)  |
| `durable-storage` | assistant | extends (softly) — one bounded retry before the fail-closed entitlement error |
| `saved-packages`  | assistant | composes — read-only D1 queries over `saved_packages` / `user_storage_buckets` |
| `rbac`            | auth      | composes — `requireUserWithRole('admin')` gating                             |

### System map

The admin route reads package rows and bucket inventory from D1, probes legacy buckets through StorageRunner per owning user, and scans published sources with the existing repo-check helper.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	adminRoute["app-ui<br/>Admin audit route"]:::touched
	rbac["rbac<br/>Role-based access control"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	durableStorage["durable-storage<br/>StorageRunner buckets"]:::extended
	repoChecks["saved-packages<br/>Repo checks / published source"]:::touched
	adminRoute -->|"requireUserWithRole('admin')"| rbac
	adminRoute -->|"saved_packages has_app rows + orphan kind='app' inventory"| d1AppDb
	adminRoute -->|"getEstimatedBytes per raw-id bucket (per-user, read-only)"| durableStorage
	adminRoute -->|"loadPackageSourceBySourceId + collectAmbientStorageImportFiles"| repoChecks
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user isolation: the D1 enumeration is deliberately platform-wide (admin surface, RBAC-gated, read-only), but every StorageRunner probe passes the row's own `userId`, so DO access stays namespaced. No writes anywhere in the audit path.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f40b943c-e067-43a8-b171-94721f7e81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f40b943c-e067-43a8-b171-94721f7e81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin package storage audit API.
  * Audit reports include package storage estimates, ambient import files, orphaned storage buckets, errors, totals, and truncation status.
  * Added support for limiting audit results with the `limit` parameter.

* **Bug Fixes**
  * Improved storage usage checks by retrying transient estimate failures.
  * Never-used storage buckets now report a consistent empty baseline.

* **Tests**
  * Added coverage for authorization, audit reporting, result limits, storage failures, retries, and empty buckets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->