### PR TITLE
Expose the package-storage audit over MCP and prove app packageStorage() end-to-end

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -226,6 +226,7 @@ Current admin capabilities:
 - `admin_package_scope_grant_create`
 - `admin_package_scope_grant_revoke`
 - `admin_package_scope_grant_list`
+- `admin_package_storage_audit`
 - `admin_audit_log_query`
 - `admin_user_usage`
 - `admin_feature_flag_list`

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
@@ -3,12 +3,11 @@ import {
 	type PermissionString,
 	type RoleName,
 } from '#worker/identity/permissions.ts'
-import type * as StorageRunnerModule from '#worker/storage-runner.ts'
+import type * as PackageStorageAuditService from '#worker/package-storage-audit/service.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
-	storageRunnerRpc: vi.fn(),
-	loadPackageSourceBySourceId: vi.fn(),
+	buildPackageStorageAuditReport: vi.fn(),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -16,34 +15,14 @@ vi.mock('#app/authenticated-user.ts', () => ({
 		mockModule.readAuthenticatedAppUser(...args),
 }))
 
-vi.mock('#worker/storage-runner.ts', async (importOriginal) => {
-	const actual = await importOriginal<typeof StorageRunnerModule>()
+vi.mock('#worker/package-storage-audit/service.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof PackageStorageAuditService>()
 	return {
 		...actual,
-		storageRunnerRpc: (...args: Array<unknown>) =>
-			mockModule.storageRunnerRpc(...args),
+		buildPackageStorageAuditReport: (...args: Array<unknown>) =>
+			mockModule.buildPackageStorageAuditReport(...args),
 	}
 })
-
-vi.mock('#worker/package-registry/source.ts', () => ({
-	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
-		mockModule.loadPackageSourceBySourceId(...args),
-}))
-
-type SavedPackageRow = {
-	userId: string
-	packageId: string
-	kodyId: string
-	sourceId: string
-	hasApp: number
-}
-
-type StorageBucketRow = {
-	userId: string
-	storageId: string
-	kind: string
-	lastSeenAt: string
-}
 
 function createAdminActor(roles: Array<RoleName>) {
 	const permissions: Array<PermissionString> = roles.includes('admin')
@@ -67,102 +46,6 @@ function createAdminActor(roles: Array<RoleName>) {
 	}
 }
 
-function packageOwnershipKey(userId: string, packageId: string) {
-	return `${userId}\0${packageId}`
-}
-
-function createAuditTestEnv(input: {
-	packages: Array<SavedPackageRow>
-	buckets: Array<StorageBucketRow>
-}) {
-	function normalize(query: string) {
-		return query.replace(/\s+/g, ' ').trim().toLowerCase()
-	}
-
-	function createStatement(query: string, params: Array<unknown> = []) {
-		const normalized = normalize(query)
-		return {
-			bind(...nextParams: Array<unknown>) {
-				return createStatement(query, nextParams)
-			},
-			async first() {
-				throw new Error(`Unsupported first query: ${query}`)
-			},
-			async all<T>() {
-				if (
-					normalized.includes('from saved_packages') &&
-					normalized.includes('has_app = 1')
-				) {
-					const limit = Number(params[0] ?? input.packages.length)
-					const rows = input.packages
-						.filter((row) => row.hasApp === 1)
-						.sort((left, right) => {
-							const byUser = left.userId.localeCompare(right.userId)
-							if (byUser !== 0) return byUser
-							return left.packageId.localeCompare(right.packageId)
-						})
-						.slice(0, limit)
-						.map((row) => ({
-							userId: row.userId,
-							packageId: row.packageId,
-							kodyId: row.kodyId,
-							sourceId: row.sourceId,
-						}))
-					return {
-						results: rows,
-						meta: { changes: 0 },
-					} as { results: Array<T>; meta: { changes: number } }
-				}
-				if (
-					normalized.includes('from user_storage_buckets b') &&
-					normalized.includes("kind = 'app'") &&
-					normalized.includes('p.user_id = b.user_id')
-				) {
-					const limit = Number(params[0] ?? Number.POSITIVE_INFINITY)
-					const ownedKeys = new Set(
-						input.packages.map((row) =>
-							packageOwnershipKey(row.userId, row.packageId),
-						),
-					)
-					const rows = input.buckets
-						.filter(
-							(row) =>
-								row.kind === 'app' &&
-								!ownedKeys.has(packageOwnershipKey(row.userId, row.storageId)),
-						)
-						.sort((left, right) => {
-							const byUser = left.userId.localeCompare(right.userId)
-							if (byUser !== 0) return byUser
-							return left.storageId.localeCompare(right.storageId)
-						})
-						.slice(0, limit)
-						.map((row) => ({
-							userId: row.userId,
-							storageId: row.storageId,
-							lastSeenAt: row.lastSeenAt,
-						}))
-					return {
-						results: rows,
-						meta: { changes: 0 },
-					} as { results: Array<T>; meta: { changes: number } }
-				}
-				throw new Error(`Unsupported all query: ${query}`)
-			},
-			async run() {
-				throw new Error(`Unsupported run query: ${query}`)
-			},
-		}
-	}
-
-	return {
-		APP_DB: {
-			prepare(query: string) {
-				return createStatement(query)
-			},
-		},
-	} as unknown as Env
-}
-
 const { createAdminPackageStorageAuditApiHandler } =
 	await import('./admin-package-storage-audit.ts')
 
@@ -181,248 +64,77 @@ function createHandlerRequest(input: { limit?: number } = {}) {
 	} as never
 }
 
-function stubEstimate(bytes: number | Error) {
-	return {
-		getEstimatedBytes: async () => {
-			if (bytes instanceof Error) throw bytes
-			return { estimatedBytes: bytes }
+test('admin package storage audit route requires admin and returns the report JSON', async () => {
+	const env = { APP_DB: {} } as unknown as Env
+	const handler = createAdminPackageStorageAuditApiHandler(env)
+	const report = {
+		ok: true as const,
+		packages: [],
+		orphanAppBuckets: [],
+		totals: {
+			appPackages: 0,
+			nonEmptyLegacyBuckets: 0,
+			packagesWithAmbientImports: 0,
+			orphanAppBuckets: 0,
+			truncated: false,
+			orphanTruncated: false,
 		},
 	}
-}
-
-test('admin package storage audit requires admin and returns the audit report', async () => {
-	const packages: Array<SavedPackageRow> = [
-		{
-			userId: 'user-a',
-			packageId: 'pkg-empty',
-			kodyId: 'empty-app',
-			sourceId: 'source-empty',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-a',
-			packageId: 'pkg-data',
-			kodyId: 'data-app',
-			sourceId: 'source-data',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-b',
-			packageId: 'pkg-ambient',
-			kodyId: 'ambient-app',
-			sourceId: 'source-ambient',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-b',
-			packageId: 'pkg-probe-error',
-			kodyId: 'probe-error-app',
-			sourceId: 'source-probe-error',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-b',
-			packageId: 'pkg-scan-error',
-			kodyId: 'scan-error-app',
-			sourceId: 'source-scan-error',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-a',
-			packageId: 'pkg-no-app',
-			kodyId: 'no-app',
-			sourceId: 'source-no-app',
-			hasApp: 0,
-		},
-	]
-	const buckets: Array<StorageBucketRow> = [
-		{
-			userId: 'user-a',
-			storageId: 'pkg-empty',
-			kind: 'app',
-			lastSeenAt: '2026-07-01T00:00:00.000Z',
-		},
-		{
-			userId: 'user-z',
-			storageId: 'deleted-pkg',
-			kind: 'app',
-			lastSeenAt: '2026-07-02T00:00:00.000Z',
-		},
-		{
-			// Cross-user collision: storage_id matches user-b's package, but the
-			// bucket belongs to user-a, so it must still count as an orphan.
-			userId: 'user-a',
-			storageId: 'pkg-ambient',
-			kind: 'app',
-			lastSeenAt: '2026-07-02T12:00:00.000Z',
-		},
-		{
-			userId: 'user-a',
-			storageId: 'job:still-here',
-			kind: 'job',
-			lastSeenAt: '2026-07-03T00:00:00.000Z',
-		},
-	]
-	const env = createAuditTestEnv({ packages, buckets })
-	const handler = createAdminPackageStorageAuditApiHandler(env)
 
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
 	const unauthorized = await handler.handler(createHandlerRequest())
 	expect(unauthorized.status).toBe(401)
+	expect(mockModule.buildPackageStorageAuditReport).not.toHaveBeenCalled()
 
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(
 		createAdminActor(['user']),
 	)
 	const forbidden = await handler.handler(createHandlerRequest())
 	expect(forbidden.status).toBe(403)
+	expect(mockModule.buildPackageStorageAuditReport).not.toHaveBeenCalled()
 
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(
 		createAdminActor(['admin']),
 	)
-	mockModule.storageRunnerRpc.mockImplementation(
-		(input: { storageId: string }) => {
-			if (input.storageId === 'pkg-empty') return stubEstimate(4096)
-			if (input.storageId === 'pkg-data') return stubEstimate(8192)
-			if (input.storageId === 'pkg-ambient') return stubEstimate(4096)
-			if (input.storageId === 'pkg-probe-error') {
-				return stubEstimate(new Error('DO unavailable'))
-			}
-			if (input.storageId === 'pkg-scan-error') return stubEstimate(4096)
-			throw new Error(`Unexpected storageId: ${input.storageId}`)
-		},
-	)
-	mockModule.loadPackageSourceBySourceId.mockImplementation(
-		async (input: { sourceId: string }) => {
-			if (
-				input.sourceId === 'source-empty' ||
-				input.sourceId === 'source-data' ||
-				input.sourceId === 'source-probe-error'
-			) {
-				return {
-					files: {
-						'index.ts': `import { packageStorage } from 'kody:runtime'\nexport const x = packageStorage()\n`,
-					},
-				}
-			}
-			if (input.sourceId === 'source-ambient') {
-				return {
-					files: {
-						'app.ts': `import { storage } from 'kody:runtime'\nexport const read = () => storage.get('k')\n`,
-						'helpers.ts': `import { kody } from 'kody:runtime'\nexport const noop = () => kody\n`,
-					},
-				}
-			}
-			if (input.sourceId === 'source-scan-error') {
-				throw new Error('source missing')
-			}
-			throw new Error(`Unexpected sourceId: ${input.sourceId}`)
-		},
-	)
+	mockModule.buildPackageStorageAuditReport.mockResolvedValue(report)
 
-	const response = await handler.handler(createHandlerRequest())
+	const response = await handler.handler(createHandlerRequest({ limit: 50 }))
 	expect(response.status).toBe(200)
-	const body = await response.json()
-	expect(body).toMatchObject({
-		ok: true,
-		totals: {
-			appPackages: 5,
-			nonEmptyLegacyBuckets: 1,
-			packagesWithAmbientImports: 1,
-			orphanAppBuckets: 2,
-			truncated: false,
-			orphanTruncated: false,
-		},
-		orphanAppBuckets: [
-			{
-				userId: 'user-a',
-				storageId: 'pkg-ambient',
-				lastSeenAt: '2026-07-02T12:00:00.000Z',
-			},
-			{
-				userId: 'user-z',
-				storageId: 'deleted-pkg',
-				lastSeenAt: '2026-07-02T00:00:00.000Z',
-			},
-		],
+	await expect(response.json()).resolves.toEqual(report)
+	expect(mockModule.buildPackageStorageAuditReport).toHaveBeenCalledWith({
+		env,
+		baseUrl: 'https://example.com',
+		limit: 50,
 	})
-
-	const byId = new Map(
-		(body.packages as Array<{ packageId: string }>).map((row) => [
-			row.packageId,
-			row,
-		]),
-	)
-	expect(byId.get('pkg-empty')).toMatchObject({
-		userId: 'user-a',
-		kodyId: 'empty-app',
-		legacyBucketBytes: 4096,
-		legacyBucketProbeError: null,
-		ambientStorageImportFiles: [],
-		sourceScanError: null,
-	})
-	expect(byId.get('pkg-data')).toMatchObject({
-		legacyBucketBytes: 8192,
-		legacyBucketProbeError: null,
-		ambientStorageImportFiles: [],
-		sourceScanError: null,
-	})
-	expect(byId.get('pkg-ambient')).toMatchObject({
-		userId: 'user-b',
-		legacyBucketBytes: 4096,
-		ambientStorageImportFiles: ['app.ts'],
-		sourceScanError: null,
-	})
-	expect(byId.get('pkg-probe-error')).toMatchObject({
-		legacyBucketBytes: null,
-		legacyBucketProbeError: 'DO unavailable',
-		ambientStorageImportFiles: [],
-		sourceScanError: null,
-	})
-	expect(byId.get('pkg-scan-error')).toMatchObject({
-		legacyBucketBytes: 4096,
-		legacyBucketProbeError: null,
-		ambientStorageImportFiles: [],
-		sourceScanError: 'source missing',
-	})
-
-	for (const call of mockModule.storageRunnerRpc.mock.calls) {
-		const arg = call[0] as { userId: string; storageId: string }
-		const pkg = packages.find((row) => row.packageId === arg.storageId)
-		expect(pkg).toBeTruthy()
-		expect(arg.userId).toBe(pkg?.userId)
-	}
 })
 
-test('admin package storage audit supports limit truncation', async () => {
-	const packages = Array.from({ length: 4 }, (_, index) => ({
-		userId: 'user-a',
-		packageId: `pkg-${index}`,
-		kodyId: `app-${index}`,
-		sourceId: `source-${index}`,
-		hasApp: 1 as const,
-	}))
-	const env = createAuditTestEnv({ packages, buckets: [] })
+test('admin package storage audit route clamps limit and applies the default', async () => {
+	const env = { APP_DB: {} } as unknown as Env
 	const handler = createAdminPackageStorageAuditApiHandler(env)
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(
 		createAdminActor(['admin']),
 	)
-	mockModule.storageRunnerRpc.mockImplementation(() => stubEstimate(0))
-	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
-		files: { 'index.ts': 'export const ok = true\n' },
-	})
-
-	const response = await handler.handler(createHandlerRequest({ limit: 2 }))
-	expect(response.status).toBe(200)
-	await expect(response.json()).resolves.toMatchObject({
+	mockModule.buildPackageStorageAuditReport.mockResolvedValue({
 		ok: true,
-		packages: [{ packageId: 'pkg-0' }, { packageId: 'pkg-1' }],
+		packages: [],
+		orphanAppBuckets: [],
 		totals: {
-			appPackages: 2,
+			appPackages: 0,
 			nonEmptyLegacyBuckets: 0,
 			packagesWithAmbientImports: 0,
 			orphanAppBuckets: 0,
-			truncated: true,
+			truncated: false,
 			orphanTruncated: false,
 		},
 	})
+
+	await handler.handler(createHandlerRequest({ limit: 9999 }))
+	expect(mockModule.buildPackageStorageAuditReport).toHaveBeenLastCalledWith(
+		expect.objectContaining({ limit: 500 }),
+	)
+
+	await handler.handler(createHandlerRequest())
+	expect(mockModule.buildPackageStorageAuditReport).toHaveBeenLastCalledWith(
+		expect.objectContaining({ limit: 200 }),
+	)
 })

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.ts
@@ -1,58 +1,13 @@
-import { chunkArray } from '@kody-internal/shared/chunk.ts'
-import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { type Action } from 'remix/router'
 import { requireUserWithRole } from '#app/permissions-server.ts'
 import { type routes } from '#app/routes.ts'
 import { jsonResponse } from '#worker/json-response.ts'
-import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
-import { readPositiveInt } from '#worker/query-params.ts'
-import { collectAmbientStorageImportFiles } from '#worker/repo/checks.ts'
 import {
-	emptyStorageRunnerEstimatedBytes,
-	storageRunnerRpc,
-} from '#worker/storage-runner.ts'
-
-const defaultAppPackageLimit = 200
-const maxAppPackageLimit = 500
-const maxOrphanAppBuckets = 500
-const maxConcurrentPackageAuditProbes = 5
-
-export type PackageStorageAuditPackageRow = {
-	userId: string
-	packageId: string
-	kodyId: string
-	legacyBucketBytes: number | null
-	legacyBucketProbeError: string | null
-	ambientStorageImportFiles: Array<string>
-	sourceScanError: string | null
-}
-
-export type PackageStorageAuditOrphanBucket = {
-	userId: string
-	storageId: string
-	lastSeenAt: string
-}
-
-export type PackageStorageAuditReport = {
-	ok: true
-	packages: Array<PackageStorageAuditPackageRow>
-	orphanAppBuckets: Array<PackageStorageAuditOrphanBucket>
-	totals: {
-		appPackages: number
-		nonEmptyLegacyBuckets: number
-		packagesWithAmbientImports: number
-		orphanAppBuckets: number
-		truncated: boolean
-		orphanTruncated: boolean
-	}
-}
-
-type AppPackageRow = {
-	userId: string
-	packageId: string
-	kodyId: string
-	sourceId: string
-}
+	buildPackageStorageAuditReport,
+	defaultPackageStorageAuditLimit,
+	maxPackageStorageAuditLimit,
+} from '#worker/package-storage-audit/service.ts'
+import { readPositiveInt } from '#worker/query-params.ts'
 
 export function createAdminPackageStorageAuditApiHandler(env: Env) {
 	return {
@@ -65,8 +20,8 @@ export function createAdminPackageStorageAuditApiHandler(env: Env) {
 				await requireUserWithRole(request, env, 'admin')
 				const limit = readPositiveInt(
 					url.searchParams.get('limit'),
-					defaultAppPackageLimit,
-					maxAppPackageLimit,
+					defaultPackageStorageAuditLimit,
+					maxPackageStorageAuditLimit,
 				)
 				const report = await buildPackageStorageAuditReport({
 					env,
@@ -80,172 +35,4 @@ export function createAdminPackageStorageAuditApiHandler(env: Env) {
 			}
 		},
 	} satisfies Action<typeof routes.adminPackageStorageAuditApi>
-}
-
-export async function buildPackageStorageAuditReport(input: {
-	env: Env
-	baseUrl: string
-	limit: number
-}): Promise<PackageStorageAuditReport> {
-	const [appPackagePage, orphanPage] = await Promise.all([
-		listAppPackagesForAudit({
-			db: input.env.APP_DB,
-			limit: input.limit,
-		}),
-		listOrphanAppBuckets({ db: input.env.APP_DB }),
-	])
-
-	const packages: Array<PackageStorageAuditPackageRow> = []
-	for (const chunk of chunkArray(
-		appPackagePage.rows,
-		maxConcurrentPackageAuditProbes,
-	)) {
-		const chunkRows = await Promise.all(
-			chunk.map((row) =>
-				auditAppPackage({
-					env: input.env,
-					baseUrl: input.baseUrl,
-					row,
-				}),
-			),
-		)
-		packages.push(...chunkRows)
-	}
-
-	return {
-		ok: true,
-		packages,
-		orphanAppBuckets: orphanPage.rows,
-		totals: {
-			appPackages: packages.length,
-			nonEmptyLegacyBuckets: packages.filter(
-				(row) =>
-					row.legacyBucketBytes != null &&
-					row.legacyBucketBytes > emptyStorageRunnerEstimatedBytes,
-			).length,
-			packagesWithAmbientImports: packages.filter(
-				(row) => row.ambientStorageImportFiles.length > 0,
-			).length,
-			orphanAppBuckets: orphanPage.rows.length,
-			truncated: appPackagePage.truncated,
-			orphanTruncated: orphanPage.truncated,
-		},
-	}
-}
-
-async function listAppPackagesForAudit(input: {
-	db: D1Database
-	limit: number
-}): Promise<{ rows: Array<AppPackageRow>; truncated: boolean }> {
-	const result = await input.db
-		.prepare(
-			`SELECT user_id AS userId, id AS packageId, kody_id AS kodyId,
-				source_id AS sourceId
-			FROM saved_packages
-			WHERE has_app = 1
-			ORDER BY user_id ASC, id ASC
-			LIMIT ?`,
-		)
-		.bind(input.limit + 1)
-		.all<AppPackageRow>()
-	const rows = result.results ?? []
-	const truncated = rows.length > input.limit
-	return {
-		rows: truncated ? rows.slice(0, input.limit) : rows,
-		truncated,
-	}
-}
-
-async function listOrphanAppBuckets(input: { db: D1Database }): Promise<{
-	rows: Array<PackageStorageAuditOrphanBucket>
-	truncated: boolean
-}> {
-	const result = await input.db
-		.prepare(
-			`SELECT b.user_id AS userId, b.storage_id AS storageId,
-				b.last_seen_at AS lastSeenAt
-			FROM user_storage_buckets b
-			LEFT JOIN saved_packages p
-				ON p.id = b.storage_id AND p.user_id = b.user_id
-			WHERE b.kind = 'app' AND p.id IS NULL
-			ORDER BY b.user_id ASC, b.storage_id ASC
-			LIMIT ?`,
-		)
-		.bind(maxOrphanAppBuckets + 1)
-		.all<PackageStorageAuditOrphanBucket>()
-	const rows = result.results ?? []
-	const truncated = rows.length > maxOrphanAppBuckets
-	return {
-		rows: truncated ? rows.slice(0, maxOrphanAppBuckets) : rows,
-		truncated,
-	}
-}
-
-async function auditAppPackage(input: {
-	env: Env
-	baseUrl: string
-	row: AppPackageRow
-}): Promise<PackageStorageAuditPackageRow> {
-	const [legacyProbe, sourceScan] = await Promise.all([
-		probeLegacyBucketBytes({
-			env: input.env,
-			userId: input.row.userId,
-			packageId: input.row.packageId,
-		}),
-		scanAmbientStorageImports({
-			env: input.env,
-			baseUrl: input.baseUrl,
-			userId: input.row.userId,
-			sourceId: input.row.sourceId,
-		}),
-	])
-
-	return {
-		userId: input.row.userId,
-		packageId: input.row.packageId,
-		kodyId: input.row.kodyId,
-		legacyBucketBytes: legacyProbe.bytes,
-		legacyBucketProbeError: legacyProbe.error,
-		ambientStorageImportFiles: sourceScan.files,
-		sourceScanError: sourceScan.error,
-	}
-}
-
-async function probeLegacyBucketBytes(input: {
-	env: Env
-	userId: string
-	packageId: string
-}): Promise<{ bytes: number | null; error: string | null }> {
-	try {
-		const estimate = await storageRunnerRpc({
-			env: input.env,
-			userId: input.userId,
-			storageId: input.packageId,
-		}).getEstimatedBytes()
-		return { bytes: estimate.estimatedBytes, error: null }
-	} catch (error) {
-		return { bytes: null, error: getErrorMessage(error) }
-	}
-}
-
-async function scanAmbientStorageImports(input: {
-	env: Env
-	baseUrl: string
-	userId: string
-	sourceId: string
-}): Promise<{ files: Array<string>; error: string | null }> {
-	try {
-		const loaded = await loadPackageSourceBySourceId({
-			env: input.env,
-			baseUrl: input.baseUrl,
-			userId: input.userId,
-			sourceId: input.sourceId,
-		})
-		return {
-			files: collectAmbientStorageImportFiles(loaded.files),
-			error: null,
-		}
-	} catch (error) {
-		return { files: [], error: getErrorMessage(error) }
-	}
 }

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.node.test.ts
@@ -1,0 +1,134 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+
+const mocks = vi.hoisted(() => ({
+	buildPackageStorageAuditReport: vi.fn(),
+}))
+
+vi.mock('#worker/package-storage-audit/service.ts', () => ({
+	defaultPackageStorageAuditLimit: 200,
+	maxPackageStorageAuditLimit: 500,
+	buildPackageStorageAuditReport: mocks.buildPackageStorageAuditReport,
+}))
+
+const { adminPackageStorageAuditCapability } =
+	await import('./admin-package-storage-audit.ts')
+
+function createContext(roles: Array<string>) {
+	return {
+		env: { APP_DB: {} as D1Database } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'admin-user',
+				username: 'admin',
+				email: 'admin@example.com',
+				roles,
+			},
+		}),
+	}
+}
+
+const emptyReport = {
+	ok: true as const,
+	packages: [],
+	orphanAppBuckets: [],
+	totals: {
+		appPackages: 0,
+		nonEmptyLegacyBuckets: 0,
+		packagesWithAmbientImports: 0,
+		orphanAppBuckets: 0,
+		truncated: false,
+		orphanTruncated: false,
+	},
+}
+
+test('admin package storage audit requires admin and returns the platform-wide report', async () => {
+	await expect(
+		adminPackageStorageAuditCapability.handler({}, createContext(['user'])),
+	).rejects.toThrow('lacks required role "admin"')
+	expect(mocks.buildPackageStorageAuditReport).not.toHaveBeenCalled()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'auth',
+			action: 'mcp_capability_denied',
+			result: 'failure',
+			reason: 'role',
+		}),
+	)
+
+	mocks.buildPackageStorageAuditReport.mockResolvedValue({
+		...emptyReport,
+		packages: [
+			{
+				userId: 'user-a',
+				packageId: 'pkg-1',
+				kodyId: 'demo',
+				legacyBucketBytes: 8192,
+				legacyBucketProbeError: null,
+				ambientStorageImportFiles: ['app.ts'],
+				sourceScanError: null,
+			},
+		],
+		totals: {
+			...emptyReport.totals,
+			appPackages: 1,
+			nonEmptyLegacyBuckets: 1,
+			packagesWithAmbientImports: 1,
+		},
+	})
+
+	const ctx = createContext(['admin'])
+	const result = await adminPackageStorageAuditCapability.handler(
+		{ limit: 25 },
+		ctx,
+	)
+
+	expect(mocks.buildPackageStorageAuditReport).toHaveBeenCalledWith({
+		env: ctx.env,
+		baseUrl: 'https://heykody.dev',
+		limit: 25,
+	})
+	expect(result).toMatchObject({
+		ok: true,
+		packages: [
+			expect.objectContaining({
+				packageId: 'pkg-1',
+				ambientStorageImportFiles: ['app.ts'],
+			}),
+		],
+		totals: {
+			appPackages: 1,
+			nonEmptyLegacyBuckets: 1,
+			packagesWithAmbientImports: 1,
+		},
+	})
+	expect(auditEventSummaries()).toEqual([
+		'mcp_capability_denied:failure',
+		'admin_package_storage_audit:success',
+	])
+})
+
+test('admin package storage audit defaults limit and rejects values above max', async () => {
+	mocks.buildPackageStorageAuditReport.mockResolvedValue(emptyReport)
+	const ctx = createContext(['admin'])
+
+	await adminPackageStorageAuditCapability.handler({}, ctx)
+	expect(mocks.buildPackageStorageAuditReport).toHaveBeenLastCalledWith(
+		expect.objectContaining({ limit: 200 }),
+	)
+
+	await expect(
+		adminPackageStorageAuditCapability.handler({ limit: 501 }, ctx),
+	).rejects.toThrow()
+	expect(mocks.buildPackageStorageAuditReport).toHaveBeenCalledTimes(1)
+
+	await adminPackageStorageAuditCapability.handler({ limit: 500 }, ctx)
+	expect(mocks.buildPackageStorageAuditReport).toHaveBeenLastCalledWith(
+		expect.objectContaining({ limit: 500 }),
+	)
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod'
+import {
+	buildPackageStorageAuditReport,
+	defaultPackageStorageAuditLimit,
+	maxPackageStorageAuditLimit,
+} from '#worker/package-storage-audit/service.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	adminCapabilityAccess,
+	auditAdminCapabilityInvocation,
+} from './admin-shared.ts'
+
+const packageRowSchema = z.object({
+	userId: z.string(),
+	packageId: z.string(),
+	kodyId: z.string(),
+	legacyBucketBytes: z.number().nullable(),
+	legacyBucketProbeError: z.string().nullable(),
+	ambientStorageImportFiles: z.array(z.string()),
+	sourceScanError: z.string().nullable(),
+})
+
+const orphanBucketSchema = z.object({
+	userId: z.string(),
+	storageId: z.string(),
+	lastSeenAt: z.string(),
+})
+
+const outputSchema = z.object({
+	ok: z.literal(true),
+	packages: z.array(packageRowSchema),
+	orphanAppBuckets: z.array(orphanBucketSchema),
+	totals: z.object({
+		appPackages: z.number().int().nonnegative(),
+		nonEmptyLegacyBuckets: z.number().int().nonnegative(),
+		packagesWithAmbientImports: z.number().int().nonnegative(),
+		orphanAppBuckets: z.number().int().nonnegative(),
+		truncated: z.boolean(),
+		orphanTruncated: z.boolean(),
+	}),
+})
+
+export const adminPackageStorageAuditCapability = defineDomainCapability(
+	capabilityDomainNames.admin,
+	{
+		...adminCapabilityAccess,
+		name: 'admin_package_storage_audit',
+		description:
+			'Platform-wide audit of has_app package legacy StorageRunner bucket sizes, ambient storage imports in published sources, and orphaned kind=app buckets. Admin-only and not user-scoped; returns aggregated metadata only, never raw bucket contents or full package source.',
+		keywords: [
+			'admin',
+			'package',
+			'storage',
+			'audit',
+			'legacy bucket',
+			'ambient storage',
+			'orphan',
+		],
+		inputSchema: z.object({
+			limit: z
+				.number()
+				.int()
+				.min(1)
+				.max(maxPackageStorageAuditLimit)
+				.optional()
+				.describe(
+					`Max has_app packages to audit. Defaults to ${String(defaultPackageStorageAuditLimit)} and maxes at ${String(maxPackageStorageAuditLimit)}.`,
+				),
+		}),
+		outputSchema,
+		async handler(args, ctx) {
+			return auditAdminCapabilityInvocation(
+				ctx,
+				'admin_package_storage_audit',
+				async () =>
+					buildPackageStorageAuditReport({
+						env: ctx.env,
+						baseUrl: ctx.callerContext.baseUrl,
+						limit: args.limit ?? defaultPackageStorageAuditLimit,
+					}),
+			)
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -12,6 +12,7 @@ import { adminPackageCodemodScanCapability } from './admin-package-codemod-scan.
 import { adminPackageScopeGrantCreateCapability } from './admin-package-scope-grant-create.ts'
 import { adminPackageScopeGrantListCapability } from './admin-package-scope-grant-list.ts'
 import { adminPackageScopeGrantRevokeCapability } from './admin-package-scope-grant-revoke.ts'
+import { adminPackageStorageAuditCapability } from './admin-package-storage-audit.ts'
 import { adminPlatformAccountCreateCapability } from './admin-platform-account-create.ts'
 import { adminPlatformFeedbackGetCapability } from './admin-platform-feedback-get.ts'
 import { adminPlatformFeedbackListCapability } from './admin-platform-feedback-list.ts'
@@ -32,7 +33,7 @@ import { adminAccountWriteLeaseRepairCapability } from './admin-account-write-le
 export const adminDomain = defineDomain({
 	name: capabilityDomainNames.admin,
 	description:
-		'Admin-only operator capabilities for account metadata, platform accounts, package scope grants, fleet package-codemod scan/dry-run/apply/revert over published package trees, feature flags, operator-owned system email, attributed platform feedback users explicitly submit for admin review, and metadata about activity on public community listings; never exposes secrets, memories, jobs, or user inbox email.',
+		'Admin-only operator capabilities for account metadata, platform accounts, package scope grants, fleet package-codemod scan/dry-run/apply/revert over published package trees, package storage audit aggregates, feature flags, operator-owned system email, attributed platform feedback users explicitly submit for admin review, and metadata about activity on public community listings; never exposes private package source or unrelated user content such as secrets, memories, jobs, or user inbox email.',
 	keywords: [
 		'admin',
 		'rbac',
@@ -51,6 +52,7 @@ export const adminDomain = defineDomain({
 		'package codemod',
 		'fleet',
 		'migration',
+		'package storage',
 	],
 	capabilities: [
 		adminUserListCapability,
@@ -67,6 +69,7 @@ export const adminDomain = defineDomain({
 		adminPackageCodemodDryRunCapability,
 		adminPackageCodemodApplyCapability,
 		adminPackageCodemodRevertCapability,
+		adminPackageStorageAuditCapability,
 		adminAuditLogQueryCapability,
 		adminUserUsageCapability,
 		adminFeatureFlagListCapability,

--- a/packages/worker/src/mcp/package-app-storage.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/package-app-storage.mcp-e2e.test.ts
@@ -1,0 +1,203 @@
+import { expect, test } from 'vitest'
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import {
+	createAppSessionCookie,
+	createMcpClient,
+	createTestDatabase,
+	startDevServer,
+} from '../../../../tools/mcp-test-support.ts'
+
+const kodyId = 'app-storage-smoke'
+const markerKey = 'smoke-marker'
+const markerValue = 'package-storage-ok'
+const tableName = 'app_storage_smoke'
+
+type ExecuteStructured = {
+	result?: unknown
+	error?: unknown
+}
+
+type PackageSaveResult = {
+	package_id: string
+	kody_id: string
+	has_app: boolean
+}
+
+type AppStorageResponse = {
+	bucketId: string
+	read: unknown
+	sqlRows: Array<Record<string, unknown>>
+}
+
+function readExecuteResult<T>(toolResult: CallToolResult): T {
+	expect(toolResult.isError).toBeFalsy()
+	const structured = toolResult.structuredContent as ExecuteStructured
+	expect(structured.error).toBeUndefined()
+	expect(structured.result).toBeTruthy()
+	return structured.result as T
+}
+
+function buildPackageFiles(username: string) {
+	const packageJson = {
+		name: `@${username}/${kodyId}`,
+		private: true,
+		exports: { '.': './src/index.ts' },
+		kody: {
+			id: kodyId,
+			description: 'MCP e2e smoke package for packageStorage in app fetch',
+			app: {
+				entry: './src/app.ts',
+			},
+		},
+	}
+	return [
+		{
+			path: 'package.json',
+			content: `${JSON.stringify(packageJson, null, '\t')}\n`,
+		},
+		{
+			path: 'README.md',
+			content:
+				'# App storage smoke\n\n## Intent\n\nProve package app fetch handlers can use packageStorage() end-to-end.\n',
+		},
+		{
+			path: 'src/index.ts',
+			content:
+				'export default async function main() {\n\treturn { ok: true }\n}\n',
+		},
+		{
+			path: 'src/app.ts',
+			content: `import { packageStorage } from 'kody:runtime'
+
+export default {
+	async fetch() {
+		const storage = packageStorage()
+		await storage.set(${JSON.stringify(markerKey)}, ${JSON.stringify(markerValue)})
+		const read = await storage.get(${JSON.stringify(markerKey)})
+		await storage.sql(
+			'CREATE TABLE IF NOT EXISTS ${tableName} (id INTEGER PRIMARY KEY AUTOINCREMENT, note TEXT NOT NULL)',
+		)
+		await storage.sql('INSERT INTO ${tableName} (note) VALUES (?)', [
+			${JSON.stringify(markerValue)},
+		])
+		const sqlResult = await storage.sql(
+			'SELECT id, note FROM ${tableName} ORDER BY id ASC',
+		)
+		return Response.json({
+			bucketId: storage.id,
+			read,
+			sqlRows: sqlResult.rows,
+		})
+	},
+}
+`,
+		},
+	]
+}
+
+test('package app fetch handler can use packageStorage against a real local worker', async () => {
+	await using database = await createTestDatabase()
+	await using server = await startDevServer(database.persistDir)
+	await using mcp = await createMcpClient(server.origin, database.user, {
+		persistDir: database.persistDir,
+	})
+	const { username } = database.user
+	const files = buildPackageFiles(username)
+	let packageId: string | undefined
+
+	try {
+		const saveResult = await mcp.client.callTool({
+			name: 'execute',
+			arguments: {
+				code: `import { kody } from 'kody:runtime'
+export default async function main(input) {
+	return await kody.package_save({ files: input.files })
+}
+`,
+				params: { files },
+			},
+		})
+		const saved = readExecuteResult<PackageSaveResult>(
+			saveResult as CallToolResult,
+		)
+		expect(saved.kody_id).toBe(kodyId)
+		expect(saved.has_app).toBe(true)
+		packageId = saved.package_id
+		const expectedBucketId = `package:${encodeURIComponent(packageId)}`
+
+		const cookie = await createAppSessionCookie(server.origin, database.user)
+		const appUrl = `${server.origin}/@${username}/packages/${kodyId}`
+
+		const firstResponse = await fetch(appUrl, {
+			headers: { Cookie: cookie, Accept: 'application/json' },
+			redirect: 'follow',
+		})
+		const firstBodyText = await firstResponse.text()
+		expect(
+			firstResponse.status,
+			`first app fetch failed: ${firstBodyText}`,
+		).toBe(200)
+		const firstBody = JSON.parse(firstBodyText) as AppStorageResponse
+		expect(firstBody.bucketId).toBe(expectedBucketId)
+		expect(firstBody.read).toBe(markerValue)
+		expect(firstBody.sqlRows).toEqual([{ id: 1, note: markerValue }])
+
+		const secondResponse = await fetch(appUrl, {
+			headers: { Cookie: cookie, Accept: 'application/json' },
+			redirect: 'follow',
+		})
+		const secondBodyText = await secondResponse.text()
+		expect(
+			secondResponse.status,
+			`second app fetch failed: ${secondBodyText}`,
+		).toBe(200)
+		const secondBody = JSON.parse(secondBodyText) as AppStorageResponse
+		expect(secondBody.bucketId).toBe(expectedBucketId)
+		expect(secondBody.read).toBe(markerValue)
+		expect(secondBody.sqlRows).toEqual([
+			{ id: 1, note: markerValue },
+			{ id: 2, note: markerValue },
+		])
+
+		const queryResult = await mcp.client.callTool({
+			name: 'execute',
+			arguments: {
+				code: `import { kody } from 'kody:runtime'
+export default async function main(input) {
+	return await kody.storage_query({
+		storage_id: input.storageId,
+		query: input.query,
+	})
+}
+`,
+				params: {
+					storageId: expectedBucketId,
+					query: `SELECT id, note FROM ${tableName} ORDER BY id ASC`,
+				},
+			},
+		})
+		const queried = readExecuteResult<{
+			rows: Array<Record<string, unknown>>
+			row_count: number
+		}>(queryResult as CallToolResult)
+		expect(queried.row_count).toBe(2)
+		expect(queried.rows).toEqual([
+			{ id: 1, note: markerValue },
+			{ id: 2, note: markerValue },
+		])
+	} finally {
+		if (packageId) {
+			await mcp.client.callTool({
+				name: 'execute',
+				arguments: {
+					code: `import { kody } from 'kody:runtime'
+export default async function main(input) {
+	return await kody.package_delete({ package_id: input.packageId })
+}
+`,
+					params: { packageId },
+				},
+			})
+		}
+	}
+}, 120_000)

--- a/packages/worker/src/mcp/package-app-storage.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/package-app-storage.mcp-e2e.test.ts
@@ -97,7 +97,9 @@ export default {
 
 test('package app fetch handler can use packageStorage against a real local worker', async () => {
 	await using database = await createTestDatabase()
-	await using server = await startDevServer(database.persistDir)
+	await using server = await startDevServer(database.persistDir, {
+		withCloudflareMock: true,
+	})
 	await using mcp = await createMcpClient(server.origin, database.user, {
 		persistDir: database.persistDir,
 	})

--- a/packages/worker/src/package-storage-audit/service.node.test.ts
+++ b/packages/worker/src/package-storage-audit/service.node.test.ts
@@ -1,0 +1,363 @@
+import { expect, test, vi } from 'vitest'
+import type * as StorageRunnerModule from '#worker/storage-runner.ts'
+
+const mockModule = vi.hoisted(() => ({
+	storageRunnerRpc: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
+}))
+
+vi.mock('#worker/storage-runner.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof StorageRunnerModule>()
+	return {
+		...actual,
+		storageRunnerRpc: (...args: Array<unknown>) =>
+			mockModule.storageRunnerRpc(...args),
+	}
+})
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageSourceBySourceId(...args),
+}))
+
+type SavedPackageRow = {
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+	hasApp: number
+}
+
+type StorageBucketRow = {
+	userId: string
+	storageId: string
+	kind: string
+	lastSeenAt: string
+}
+
+function packageOwnershipKey(userId: string, packageId: string) {
+	return `${userId}\0${packageId}`
+}
+
+function createAuditTestEnv(input: {
+	packages: Array<SavedPackageRow>
+	buckets: Array<StorageBucketRow>
+}) {
+	function normalize(query: string) {
+		return query.replace(/\s+/g, ' ').trim().toLowerCase()
+	}
+
+	function createStatement(query: string, params: Array<unknown> = []) {
+		const normalized = normalize(query)
+		return {
+			bind(...nextParams: Array<unknown>) {
+				return createStatement(query, nextParams)
+			},
+			async first() {
+				throw new Error(`Unsupported first query: ${query}`)
+			},
+			async all<T>() {
+				if (
+					normalized.includes('from saved_packages') &&
+					normalized.includes('has_app = 1')
+				) {
+					const limit = Number(params[0] ?? input.packages.length)
+					const rows = input.packages
+						.filter((row) => row.hasApp === 1)
+						.sort((left, right) => {
+							const byUser = left.userId.localeCompare(right.userId)
+							if (byUser !== 0) return byUser
+							return left.packageId.localeCompare(right.packageId)
+						})
+						.slice(0, limit)
+						.map((row) => ({
+							userId: row.userId,
+							packageId: row.packageId,
+							kodyId: row.kodyId,
+							sourceId: row.sourceId,
+						}))
+					return {
+						results: rows,
+						meta: { changes: 0 },
+					} as { results: Array<T>; meta: { changes: number } }
+				}
+				if (
+					normalized.includes('from user_storage_buckets b') &&
+					normalized.includes("kind = 'app'") &&
+					normalized.includes('p.user_id = b.user_id')
+				) {
+					const limit = Number(params[0] ?? Number.POSITIVE_INFINITY)
+					const ownedKeys = new Set(
+						input.packages.map((row) =>
+							packageOwnershipKey(row.userId, row.packageId),
+						),
+					)
+					const rows = input.buckets
+						.filter(
+							(row) =>
+								row.kind === 'app' &&
+								!ownedKeys.has(packageOwnershipKey(row.userId, row.storageId)),
+						)
+						.sort((left, right) => {
+							const byUser = left.userId.localeCompare(right.userId)
+							if (byUser !== 0) return byUser
+							return left.storageId.localeCompare(right.storageId)
+						})
+						.slice(0, limit)
+						.map((row) => ({
+							userId: row.userId,
+							storageId: row.storageId,
+							lastSeenAt: row.lastSeenAt,
+						}))
+					return {
+						results: rows,
+						meta: { changes: 0 },
+					} as { results: Array<T>; meta: { changes: number } }
+				}
+				throw new Error(`Unsupported all query: ${query}`)
+			},
+			async run() {
+				throw new Error(`Unsupported run query: ${query}`)
+			},
+		}
+	}
+
+	return {
+		APP_DB: {
+			prepare(query: string) {
+				return createStatement(query)
+			},
+		},
+	} as unknown as Env
+}
+
+const { buildPackageStorageAuditReport } = await import('./service.ts')
+
+function stubEstimate(bytes: number | Error) {
+	return {
+		getEstimatedBytes: async () => {
+			if (bytes instanceof Error) throw bytes
+			return { estimatedBytes: bytes }
+		},
+	}
+}
+
+test('package storage audit report probes legacy buckets, ambient imports, and orphans', async () => {
+	const packages: Array<SavedPackageRow> = [
+		{
+			userId: 'user-a',
+			packageId: 'pkg-empty',
+			kodyId: 'empty-app',
+			sourceId: 'source-empty',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-a',
+			packageId: 'pkg-data',
+			kodyId: 'data-app',
+			sourceId: 'source-data',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-b',
+			packageId: 'pkg-ambient',
+			kodyId: 'ambient-app',
+			sourceId: 'source-ambient',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-b',
+			packageId: 'pkg-probe-error',
+			kodyId: 'probe-error-app',
+			sourceId: 'source-probe-error',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-b',
+			packageId: 'pkg-scan-error',
+			kodyId: 'scan-error-app',
+			sourceId: 'source-scan-error',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-a',
+			packageId: 'pkg-no-app',
+			kodyId: 'no-app',
+			sourceId: 'source-no-app',
+			hasApp: 0,
+		},
+	]
+	const buckets: Array<StorageBucketRow> = [
+		{
+			userId: 'user-a',
+			storageId: 'pkg-empty',
+			kind: 'app',
+			lastSeenAt: '2026-07-01T00:00:00.000Z',
+		},
+		{
+			userId: 'user-z',
+			storageId: 'deleted-pkg',
+			kind: 'app',
+			lastSeenAt: '2026-07-02T00:00:00.000Z',
+		},
+		{
+			// Cross-user collision: storage_id matches user-b's package, but the
+			// bucket belongs to user-a, so it must still count as an orphan.
+			userId: 'user-a',
+			storageId: 'pkg-ambient',
+			kind: 'app',
+			lastSeenAt: '2026-07-02T12:00:00.000Z',
+		},
+		{
+			userId: 'user-a',
+			storageId: 'job:still-here',
+			kind: 'job',
+			lastSeenAt: '2026-07-03T00:00:00.000Z',
+		},
+	]
+	const env = createAuditTestEnv({ packages, buckets })
+
+	mockModule.storageRunnerRpc.mockImplementation(
+		(input: { storageId: string }) => {
+			if (input.storageId === 'pkg-empty') return stubEstimate(4096)
+			if (input.storageId === 'pkg-data') return stubEstimate(8192)
+			if (input.storageId === 'pkg-ambient') return stubEstimate(4096)
+			if (input.storageId === 'pkg-probe-error') {
+				return stubEstimate(new Error('DO unavailable'))
+			}
+			if (input.storageId === 'pkg-scan-error') return stubEstimate(4096)
+			throw new Error(`Unexpected storageId: ${input.storageId}`)
+		},
+	)
+	mockModule.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => {
+			if (
+				input.sourceId === 'source-empty' ||
+				input.sourceId === 'source-data' ||
+				input.sourceId === 'source-probe-error'
+			) {
+				return {
+					files: {
+						'index.ts': `import { packageStorage } from 'kody:runtime'\nexport const x = packageStorage()\n`,
+					},
+				}
+			}
+			if (input.sourceId === 'source-ambient') {
+				return {
+					files: {
+						'app.ts': `import { storage } from 'kody:runtime'\nexport const read = () => storage.get('k')\n`,
+						'helpers.ts': `import { kody } from 'kody:runtime'\nexport const noop = () => kody\n`,
+					},
+				}
+			}
+			if (input.sourceId === 'source-scan-error') {
+				throw new Error('source missing')
+			}
+			throw new Error(`Unexpected sourceId: ${input.sourceId}`)
+		},
+	)
+
+	const body = await buildPackageStorageAuditReport({
+		env,
+		baseUrl: 'https://example.com',
+		limit: 200,
+	})
+	expect(body).toMatchObject({
+		ok: true,
+		totals: {
+			appPackages: 5,
+			nonEmptyLegacyBuckets: 1,
+			packagesWithAmbientImports: 1,
+			orphanAppBuckets: 2,
+			truncated: false,
+			orphanTruncated: false,
+		},
+		orphanAppBuckets: [
+			{
+				userId: 'user-a',
+				storageId: 'pkg-ambient',
+				lastSeenAt: '2026-07-02T12:00:00.000Z',
+			},
+			{
+				userId: 'user-z',
+				storageId: 'deleted-pkg',
+				lastSeenAt: '2026-07-02T00:00:00.000Z',
+			},
+		],
+	})
+
+	const byId = new Map(body.packages.map((row) => [row.packageId, row]))
+	expect(byId.get('pkg-empty')).toMatchObject({
+		userId: 'user-a',
+		kodyId: 'empty-app',
+		legacyBucketBytes: 4096,
+		legacyBucketProbeError: null,
+		ambientStorageImportFiles: [],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-data')).toMatchObject({
+		legacyBucketBytes: 8192,
+		legacyBucketProbeError: null,
+		ambientStorageImportFiles: [],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-ambient')).toMatchObject({
+		userId: 'user-b',
+		legacyBucketBytes: 4096,
+		ambientStorageImportFiles: ['app.ts'],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-probe-error')).toMatchObject({
+		legacyBucketBytes: null,
+		legacyBucketProbeError: 'DO unavailable',
+		ambientStorageImportFiles: [],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-scan-error')).toMatchObject({
+		legacyBucketBytes: 4096,
+		legacyBucketProbeError: null,
+		ambientStorageImportFiles: [],
+		sourceScanError: 'source missing',
+	})
+
+	for (const call of mockModule.storageRunnerRpc.mock.calls) {
+		const arg = call[0] as { userId: string; storageId: string }
+		const pkg = packages.find((row) => row.packageId === arg.storageId)
+		expect(pkg).toBeTruthy()
+		expect(arg.userId).toBe(pkg?.userId)
+	}
+})
+
+test('package storage audit report supports limit truncation', async () => {
+	const packages = Array.from({ length: 4 }, (_, index) => ({
+		userId: 'user-a',
+		packageId: `pkg-${String(index)}`,
+		kodyId: `app-${String(index)}`,
+		sourceId: `source-${String(index)}`,
+		hasApp: 1 as const,
+	}))
+	const env = createAuditTestEnv({ packages, buckets: [] })
+	mockModule.storageRunnerRpc.mockImplementation(() => stubEstimate(0))
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		files: { 'index.ts': 'export const ok = true\n' },
+	})
+
+	await expect(
+		buildPackageStorageAuditReport({
+			env,
+			baseUrl: 'https://example.com',
+			limit: 2,
+		}),
+	).resolves.toMatchObject({
+		ok: true,
+		packages: [{ packageId: 'pkg-0' }, { packageId: 'pkg-1' }],
+		totals: {
+			appPackages: 2,
+			nonEmptyLegacyBuckets: 0,
+			packagesWithAmbientImports: 0,
+			orphanAppBuckets: 0,
+			truncated: true,
+			orphanTruncated: false,
+		},
+	})
+})

--- a/packages/worker/src/package-storage-audit/service.ts
+++ b/packages/worker/src/package-storage-audit/service.ts
@@ -1,0 +1,218 @@
+import { chunkArray } from '@kody-internal/shared/chunk.ts'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import { collectAmbientStorageImportFiles } from '#worker/repo/checks.ts'
+import {
+	emptyStorageRunnerEstimatedBytes,
+	storageRunnerRpc,
+} from '#worker/storage-runner.ts'
+
+export const defaultPackageStorageAuditLimit = 200
+export const maxPackageStorageAuditLimit = 500
+const maxOrphanAppBuckets = 500
+const maxConcurrentPackageAuditProbes = 5
+
+export type PackageStorageAuditPackageRow = {
+	userId: string
+	packageId: string
+	kodyId: string
+	legacyBucketBytes: number | null
+	legacyBucketProbeError: string | null
+	ambientStorageImportFiles: Array<string>
+	sourceScanError: string | null
+}
+
+export type PackageStorageAuditOrphanBucket = {
+	userId: string
+	storageId: string
+	lastSeenAt: string
+}
+
+export type PackageStorageAuditReport = {
+	ok: true
+	packages: Array<PackageStorageAuditPackageRow>
+	orphanAppBuckets: Array<PackageStorageAuditOrphanBucket>
+	totals: {
+		appPackages: number
+		nonEmptyLegacyBuckets: number
+		packagesWithAmbientImports: number
+		orphanAppBuckets: number
+		truncated: boolean
+		orphanTruncated: boolean
+	}
+}
+
+type AppPackageRow = {
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+}
+
+export async function buildPackageStorageAuditReport(input: {
+	env: Env
+	baseUrl: string
+	limit: number
+}): Promise<PackageStorageAuditReport> {
+	const [appPackagePage, orphanPage] = await Promise.all([
+		listAppPackagesForAudit({
+			db: input.env.APP_DB,
+			limit: input.limit,
+		}),
+		listOrphanAppBuckets({ db: input.env.APP_DB }),
+	])
+
+	const packages: Array<PackageStorageAuditPackageRow> = []
+	for (const chunk of chunkArray(
+		appPackagePage.rows,
+		maxConcurrentPackageAuditProbes,
+	)) {
+		const chunkRows = await Promise.all(
+			chunk.map((row) =>
+				auditAppPackage({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					row,
+				}),
+			),
+		)
+		packages.push(...chunkRows)
+	}
+
+	return {
+		ok: true,
+		packages,
+		orphanAppBuckets: orphanPage.rows,
+		totals: {
+			appPackages: packages.length,
+			nonEmptyLegacyBuckets: packages.filter(
+				(row) =>
+					row.legacyBucketBytes != null &&
+					row.legacyBucketBytes > emptyStorageRunnerEstimatedBytes,
+			).length,
+			packagesWithAmbientImports: packages.filter(
+				(row) => row.ambientStorageImportFiles.length > 0,
+			).length,
+			orphanAppBuckets: orphanPage.rows.length,
+			truncated: appPackagePage.truncated,
+			orphanTruncated: orphanPage.truncated,
+		},
+	}
+}
+
+async function listAppPackagesForAudit(input: {
+	db: D1Database
+	limit: number
+}): Promise<{ rows: Array<AppPackageRow>; truncated: boolean }> {
+	const result = await input.db
+		.prepare(
+			`SELECT user_id AS userId, id AS packageId, kody_id AS kodyId,
+				source_id AS sourceId
+			FROM saved_packages
+			WHERE has_app = 1
+			ORDER BY user_id ASC, id ASC
+			LIMIT ?`,
+		)
+		.bind(input.limit + 1)
+		.all<AppPackageRow>()
+	const rows = result.results ?? []
+	const truncated = rows.length > input.limit
+	return {
+		rows: truncated ? rows.slice(0, input.limit) : rows,
+		truncated,
+	}
+}
+
+async function listOrphanAppBuckets(input: { db: D1Database }): Promise<{
+	rows: Array<PackageStorageAuditOrphanBucket>
+	truncated: boolean
+}> {
+	const result = await input.db
+		.prepare(
+			`SELECT b.user_id AS userId, b.storage_id AS storageId,
+				b.last_seen_at AS lastSeenAt
+			FROM user_storage_buckets b
+			LEFT JOIN saved_packages p
+				ON p.id = b.storage_id AND p.user_id = b.user_id
+			WHERE b.kind = 'app' AND p.id IS NULL
+			ORDER BY b.user_id ASC, b.storage_id ASC
+			LIMIT ?`,
+		)
+		.bind(maxOrphanAppBuckets + 1)
+		.all<PackageStorageAuditOrphanBucket>()
+	const rows = result.results ?? []
+	const truncated = rows.length > maxOrphanAppBuckets
+	return {
+		rows: truncated ? rows.slice(0, maxOrphanAppBuckets) : rows,
+		truncated,
+	}
+}
+
+async function auditAppPackage(input: {
+	env: Env
+	baseUrl: string
+	row: AppPackageRow
+}): Promise<PackageStorageAuditPackageRow> {
+	const [legacyProbe, sourceScan] = await Promise.all([
+		probeLegacyBucketBytes({
+			env: input.env,
+			userId: input.row.userId,
+			packageId: input.row.packageId,
+		}),
+		scanAmbientStorageImports({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.row.userId,
+			sourceId: input.row.sourceId,
+		}),
+	])
+
+	return {
+		userId: input.row.userId,
+		packageId: input.row.packageId,
+		kodyId: input.row.kodyId,
+		legacyBucketBytes: legacyProbe.bytes,
+		legacyBucketProbeError: legacyProbe.error,
+		ambientStorageImportFiles: sourceScan.files,
+		sourceScanError: sourceScan.error,
+	}
+}
+
+async function probeLegacyBucketBytes(input: {
+	env: Env
+	userId: string
+	packageId: string
+}): Promise<{ bytes: number | null; error: string | null }> {
+	try {
+		const estimate = await storageRunnerRpc({
+			env: input.env,
+			userId: input.userId,
+			storageId: input.packageId,
+		}).getEstimatedBytes()
+		return { bytes: estimate.estimatedBytes, error: null }
+	} catch (error) {
+		return { bytes: null, error: getErrorMessage(error) }
+	}
+}
+
+async function scanAmbientStorageImports(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	sourceId: string
+}): Promise<{ files: Array<string>; error: string | null }> {
+	try {
+		const loaded = await loadPackageSourceBySourceId({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			sourceId: input.sourceId,
+		})
+		return {
+			files: collectAmbientStorageImportFiles(loaded.files),
+			error: null,
+		}
+	} catch (error) {
+		return { files: [], error: getErrorMessage(error) }
+	}
+}

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -1,8 +1,10 @@
 import { quoteSqlString } from '@kody-internal/shared/sql-literals.ts'
+import { randomUUID } from 'node:crypto'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
+import { stripVTControlCharacters } from 'node:util'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { type CallToolRequest } from '@modelcontextprotocol/sdk/types.js'
@@ -12,6 +14,7 @@ import {
 	nodeBin,
 	spawnProcess,
 	stopProcess,
+	wranglerBin,
 } from '#mcp/test-process.ts'
 import { buildRoleAssignmentSql } from './seed-sql.ts'
 
@@ -66,68 +69,182 @@ export async function createTestDatabase() {
 
 export async function startDevServer(persistDir: string) {
 	await applyMigrations(persistDir)
-	for (let attempt = 1; attempt <= maxPortBindRetries; attempt++) {
-		// These smoke tests do not exercise Cloudflare APIs. Leaving that client
-		// unconfigured keeps MCP authentication independent of the email mock;
-		// test-runtime signup deliberately permits a skipped verification send,
-		// and createMcpClient marks the account verified before OAuth begins.
-		const port = await getPort({ host: localhost })
-		const origin = `http://${localhost}:${port}`
-		const proc = spawnProcess({
-			cmd: [
-				nodeBin,
-				'--env-file=packages/worker/.env',
-				'./wrangler-env.ts',
-				'dev',
-				'--local',
-				'--persist-to',
-				persistDir,
-				'--port',
-				String(port),
-				'--ip',
-				localhost,
-				'--show-interactive-dev-session=false',
-				'--log-level',
-				'error',
-				'--var',
-				`APP_BASE_URL:${origin}`,
-			],
-			cwd: projectRoot,
-			env: {
-				...process.env,
-				CLOUDFLARE_ENV: 'test',
-			},
-		})
-		const getStdout = captureOutput(proc.stdout)
-		const getStderr = captureOutput(proc.stderr)
-
-		try {
-			await waitForHttpReady({
-				label: 'Test worker',
-				url: new URL('/mcp', origin),
-				isReady: (response) => response.status === 401 || response.ok,
-				exited: proc.exited,
-				getStdout,
-				getStderr,
-			})
-			return {
-				origin,
-				async [Symbol.asyncDispose]() {
-					await stopProcess(proc)
+	// package_save (and related repo persistence) needs the local Cloudflare
+	// Artifacts REST mock. Signup still permits a skipped verification send when
+	// the mock is unavailable; createMcpClient marks the account verified before
+	// OAuth begins either way.
+	await using cloudflareMock = await startMcpCloudflareMock()
+	const cloudflareVars = {
+		CLOUDFLARE_API_BASE_URL: cloudflareMock.origin,
+		CLOUDFLARE_API_TOKEN: cloudflareMock.token,
+		CLOUDFLARE_ACCOUNT_ID: 'cf_account_mock_123',
+	}
+	// Keep the mock alive across the returned worker lifetime by transferring
+	// ownership into the disposable we hand back.
+	let retainCloudflareMock = false
+	try {
+		for (let attempt = 1; attempt <= maxPortBindRetries; attempt++) {
+			const port = await getPort({ host: localhost })
+			const origin = `http://${localhost}:${port}`
+			const proc = spawnProcess({
+				cmd: [
+					nodeBin,
+					'--env-file=packages/worker/.env',
+					'./wrangler-env.ts',
+					'dev',
+					'--local',
+					'--persist-to',
+					persistDir,
+					'--port',
+					String(port),
+					'--ip',
+					localhost,
+					'--show-interactive-dev-session=false',
+					'--log-level',
+					'error',
+					'--var',
+					`APP_BASE_URL:${origin}`,
+					'--var',
+					`CLOUDFLARE_API_BASE_URL:${cloudflareVars.CLOUDFLARE_API_BASE_URL}`,
+					'--var',
+					`CLOUDFLARE_API_TOKEN:${cloudflareVars.CLOUDFLARE_API_TOKEN}`,
+					'--var',
+					`CLOUDFLARE_ACCOUNT_ID:${cloudflareVars.CLOUDFLARE_ACCOUNT_ID}`,
+				],
+				cwd: projectRoot,
+				env: {
+					...process.env,
+					CLOUDFLARE_ENV: 'test',
+					...cloudflareVars,
 				},
+			})
+			const getStdout = captureOutput(proc.stdout)
+			const getStderr = captureOutput(proc.stderr)
+
+			try {
+				await waitForHttpReady({
+					label: 'Test worker',
+					url: new URL('/mcp', origin),
+					isReady: (response) => response.status === 401 || response.ok,
+					exited: proc.exited,
+					getStdout,
+					getStderr,
+				})
+				retainCloudflareMock = true
+				const mockProc = cloudflareMock.proc
+				return {
+					origin,
+					async [Symbol.asyncDispose]() {
+						await stopProcess(proc)
+						await stopProcess(mockProc).catch(() => undefined)
+					},
+				}
+			} catch (error) {
+				await stopProcess(proc).catch(() => undefined)
+				if (isPortAlreadyInUseError(error) && attempt < maxPortBindRetries) {
+					continue
+				}
+				throw error
 			}
-		} catch (error) {
-			await stopProcess(proc).catch(() => undefined)
-			if (isPortAlreadyInUseError(error) && attempt < maxPortBindRetries) {
-				continue
-			}
-			throw error
+		}
+
+		throw new Error(
+			'Failed to start MCP test dev servers after multiple retries.',
+		)
+	} finally {
+		if (retainCloudflareMock) {
+			// Prevent await-using cleanup from stopping a mock the caller now owns.
+			cloudflareMock.proc = null
 		}
 	}
+}
 
-	throw new Error(
-		'Failed to start MCP test dev servers after multiple retries.',
-	)
+async function startMcpCloudflareMock() {
+	const token = `mcp-e2e-cloudflare-${randomUUID()}`
+	const proc = spawnProcess({
+		cmd: [
+			wranglerBin,
+			'dev',
+			'--local',
+			'--config',
+			'packages/mock-servers/cloudflare/wrangler.jsonc',
+			'--var',
+			`MOCK_API_TOKEN:${token}`,
+			'--port',
+			'0',
+			'--inspector-port',
+			'0',
+			'--ip',
+			localhost,
+			'--show-interactive-dev-session=false',
+			'--log-level',
+			'info',
+		],
+		cwd: projectRoot,
+	})
+	const getStdout = captureOutput(proc.stdout)
+	const getStderr = captureOutput(proc.stderr)
+	const mock = {
+		origin: '',
+		token,
+		proc: proc as ReturnType<typeof spawnProcess> | null,
+		async [Symbol.asyncDispose]() {
+			if (mock.proc) {
+				await stopProcess(mock.proc).catch(() => undefined)
+				mock.proc = null
+			}
+		},
+	}
+	try {
+		const deadline = Date.now() + defaultWaitTimeoutMs
+		while (Date.now() < deadline) {
+			const exitCode = await Promise.race([
+				proc.exited,
+				delay(200).then(() => null),
+			])
+			if (typeof exitCode === 'number') {
+				throw new Error(
+					[
+						`Mock Cloudflare exited before becoming ready (exit ${exitCode}).`,
+						getStdout(),
+						getStderr(),
+					]
+						.filter(Boolean)
+						.join('\n\n'),
+				)
+			}
+			const readyMatch = stripVTControlCharacters(
+				`${getStdout()}\n${getStderr()}`,
+			).match(/\bReady on (http:\/\/127\.0\.0\.1:\d+)\b/)
+			const origin = readyMatch?.[1]
+			if (!origin) continue
+			try {
+				const response = await fetch(`${origin}/__mocks/meta`, {
+					signal: AbortSignal.timeout(perAttemptFetchTimeoutMs),
+				})
+				await response.body?.cancel()
+				if (response.ok) {
+					mock.origin = origin
+					return mock
+				}
+			} catch {
+				// Retry until the mock accepts connections.
+			}
+		}
+		throw new Error(
+			[
+				'Timed out waiting for mock Cloudflare to become ready.',
+				getStdout(),
+				getStderr(),
+			]
+				.filter(Boolean)
+				.join('\n\n'),
+		)
+	} catch (error) {
+		await stopProcess(proc).catch(() => undefined)
+		mock.proc = null
+		throw error
+	}
 }
 
 export async function markEmailVerifiedInMcpTestDatabase(input: {
@@ -246,6 +363,15 @@ async function loginToApp(origin: string, user: TestUser) {
 	}
 
 	return readCookieHeader(loginResponse)
+}
+
+/**
+ * Browser session cookie for authenticated app-origin fetches
+ * (`Cookie: kody_session=…`). Same JSON `/auth` signup-or-login path used by
+ * MCP OAuth setup; safe to call again after `createMcpClient`.
+ */
+export async function createAppSessionCookie(origin: string, user: TestUser) {
+	return loginToApp(origin, user)
 }
 
 export async function createMcpClient(

--- a/tools/mcp-test-support.ts
+++ b/tools/mcp-test-support.ts
@@ -67,8 +67,80 @@ export async function createTestDatabase() {
 	}
 }
 
-export async function startDevServer(persistDir: string) {
+export async function startDevServer(
+	persistDir: string,
+	options?: { withCloudflareMock?: boolean },
+) {
 	await applyMigrations(persistDir)
+	if (options?.withCloudflareMock) {
+		return startDevServerWithCloudflareMock(persistDir)
+	}
+
+	// These smoke tests do not exercise Cloudflare APIs. Leaving that client
+	// unconfigured keeps MCP authentication independent of the email mock;
+	// test-runtime signup deliberately permits a skipped verification send,
+	// and createMcpClient marks the account verified before OAuth begins.
+	for (let attempt = 1; attempt <= maxPortBindRetries; attempt++) {
+		const port = await getPort({ host: localhost })
+		const origin = `http://${localhost}:${port}`
+		const proc = spawnProcess({
+			cmd: [
+				nodeBin,
+				'--env-file=packages/worker/.env',
+				'./wrangler-env.ts',
+				'dev',
+				'--local',
+				'--persist-to',
+				persistDir,
+				'--port',
+				String(port),
+				'--ip',
+				localhost,
+				'--show-interactive-dev-session=false',
+				'--log-level',
+				'error',
+				'--var',
+				`APP_BASE_URL:${origin}`,
+			],
+			cwd: projectRoot,
+			env: {
+				...process.env,
+				CLOUDFLARE_ENV: 'test',
+			},
+		})
+		const getStdout = captureOutput(proc.stdout)
+		const getStderr = captureOutput(proc.stderr)
+
+		try {
+			await waitForHttpReady({
+				label: 'Test worker',
+				url: new URL('/mcp', origin),
+				isReady: (response) => response.status === 401 || response.ok,
+				exited: proc.exited,
+				getStdout,
+				getStderr,
+			})
+			return {
+				origin,
+				async [Symbol.asyncDispose]() {
+					await stopProcess(proc)
+				},
+			}
+		} catch (error) {
+			await stopProcess(proc).catch(() => undefined)
+			if (isPortAlreadyInUseError(error) && attempt < maxPortBindRetries) {
+				continue
+			}
+			throw error
+		}
+	}
+
+	throw new Error(
+		'Failed to start MCP test dev servers after multiple retries.',
+	)
+}
+
+async function startDevServerWithCloudflareMock(persistDir: string) {
 	// package_save (and related repo persistence) needs the local Cloudflare
 	// Artifacts REST mock. Signup still permits a skipped verification send when
 	// the mock is unavailable; createMcpClient marks the account verified before


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unblocks the two remaining #1024 gates so the legacy app-bucket cleanup can proceed on evidence:

- **`admin_package_storage_audit` MCP capability** (admin domain, standard `adminCapabilityAccess` role gating + `auditAdminCapabilityInvocation` logging): agents with the admin role can now run the platform-wide audit without a browser session. `buildPackageStorageAuditReport` moves from the route handler into a neutral `package-storage-audit` service (respecting the `#mcp` → `#app/handlers` import ban); the admin route stays as a thin gate over the same service. Output is aggregated metadata only — bucket sizes, ambient-import file lists, orphan inventory — never bucket contents or source.
- **The missing app-surface verification, automated**: a new mcp-e2e test saves a real package whose app fetch handler uses `packageStorage()`, logs in for a `kody_session`, fetches the inline-hosted app URL against a real local Wrangler worker, and asserts the `package:{encodeURIComponent(id)}` bucket id, KV + SQL round-trips, persistence across requests, and cross-surface visibility of the app's writes via `storage_query`. This is the regression that gates removing the legacy raw-id ambient binding (#1024), and it passes: `packageStorage()` works in the app fetch surface for real. The mcp test harness now boots the local Cloudflare Artifacts mock so `package_save` runs for real in these tests.

## Testing

- `npm run validate` (full local gate)
- New mcp-e2e: `package-app-storage.mcp-e2e.test.ts` (passes against a real local worker, 27s); existing `mcp-server.mcp-e2e.test.ts` still green with the harness changes
- Node tests: audit service report-building (moved), route gating/limit clamping, capability admin-gating and limit behavior; `npm run primitives:check` green

Refs #1024

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `7ebea332` · **Head:** current branch tip

**Classification:** composes — an existing report generator gains an MCP capability wrapper and its logic moves to a neutral module; plus test infrastructure. No schema or behavior changes to production data paths; `primitives.yaml` unchanged.

### Primitives touched

| Primitive             | Group     | Impact                                                                          |
| --------------------- | --------- | -------------------------------------------------------------------------------- |
| `capability-registry` | assistant | composes — `admin_package_storage_audit` registered in the admin domain           |
| `mcp-server`          | surfaces  | composes — capability exposed to admin users over MCP                             |
| `app-ui` / admin      | surfaces  | composes — route handler thinned to gating over the extracted service             |
| `package-apps`        | assistant | composes — end-to-end regression proving `packageStorage()` in the app fetch path |

### System map

The audit logic moves to a neutral service consumed by both the admin route and the new MCP capability; the e2e test drives package save → app fetch → storage verification against a real worker.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	adminRoute["app-ui<br/>Admin audit route"]:::touched
	auditService["package-storage-audit<br/>Audit service (neutral module)"]:::touched
	rbac["rbac<br/>Role-based access control"]:::untouched
	mcpServer -->|"admin_package_storage_audit (adminCapabilityAccess)"| capabilityRegistry
	capabilityRegistry -->|"requiredRole: admin via access-control"| rbac
	capabilityRegistry -->|"buildPackageStorageAuditReport"| auditService
	adminRoute -->|"same service, thin gate"| auditService
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

The audit stays deliberately platform-wide and is therefore admin-gated on both surfaces (route RBAC + capability `requiredRole`); every StorageRunner probe passes the owning row's `userId`. The MCP capability adds no write paths.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f40b943c-e067-43a8-b171-94721f7e81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f40b943c-e067-43a8-b171-94721f7e81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only MCP capability for package storage audits with aggregated per-package, orphan bucket, totals, and truncation metadata.
  * Enforced audit `limit` handling with default and maximum bounds.
  * Extended the admin MCP domain to include the new storage-audit aggregate capability (and related fleet package-codemod capabilities).
  * Added an MCP end-to-end smoke test covering persistent package app storage across requests.

* **Documentation**
  * Updated contributing documentation to include the new admin capabilities.

* **Tests**
  * Added authorization, limit, and report-generation coverage for the storage-audit capability/handler.
  * Added unit tests for the storage audit report builder and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->