### PR TITLE
Report execute Server-Timing phases

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -104,6 +104,20 @@ caller whose flag is off. Operators can disable the user's override (or the
 global flag, if a broader rollout was started) to return immediately to the
 previous bundle-and-run behavior.
 
+### Server-Timing phases
+
+Execute responses include Server-Timing-style phase entries under
+**`timing.serverTiming`** (public tool) or top-level **`serverTiming`**
+(`meta.execute`): each entry is `{ name, durationMs }`.
+
+- `bundle` — module-graph preparation and bundling. This span contains the
+  typecheck phases below, so subtract `typecheck-total` for bundler-only time.
+- `run` — hydration, provider assembly, and sandbox execution.
+- `typecheck-queue`, `typecheck-compiler-startup`, `typecheck-project-write`,
+  `typecheck-diagnostics`, `typecheck-total` — present only when the
+  pre-execution check ran for the call. Failed diagnostics also report these
+  phases so slow checks can be attributed even when the module never executes.
+
 ## npm packages on Workers
 
 **execute** and saved packages may import npm packages directly when they are

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -8,6 +8,10 @@ import {
 import { resolveCallerFeatureFlags } from '#mcp/capabilities/access-control.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import {
+	ExecuteTypecheckError,
+	type ExecuteServerTimingEntry,
+} from '#mcp/execute-typecheck.ts'
 import { runModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
@@ -47,6 +51,14 @@ const executeOutputSchema = z.object({
 	error: z.string().optional(),
 	errorDetails: z.unknown().optional(),
 	logs: z.array(z.unknown()),
+	serverTiming: z
+		.array(
+			z.object({
+				name: z.string(),
+				durationMs: z.number().nonnegative(),
+			}),
+		)
+		.optional(),
 })
 
 export const executeCapability = defineDomainCapability(
@@ -250,7 +262,10 @@ export const executeCapability = defineDomainCapability(
 				claimedRunHandle = claim.handle
 			}
 
-			let result: ExecuteResult & { runId?: string }
+			let result: ExecuteResult & {
+				runId?: string
+				serverTiming?: Array<ExecuteServerTimingEntry>
+			}
 			try {
 				const featureFlags = await resolveCallerFeatureFlags(
 					ctx.env,
@@ -310,9 +325,16 @@ export const executeCapability = defineDomainCapability(
 					error: getErrorMessage(cause),
 					errorDetails: getExecutionErrorDetails(cause),
 					logs: [],
+					...(cause instanceof ExecuteTypecheckError && cause.serverTiming
+						? { serverTiming: cause.serverTiming }
+						: {}),
 				}
 			}
 			const logs = result.logs ?? []
+			const serverTiming =
+				result.serverTiming && result.serverTiming.length > 0
+					? result.serverTiming
+					: undefined
 			const runId =
 				typeof result.runId === 'string'
 					? result.runId
@@ -327,6 +349,7 @@ export const executeCapability = defineDomainCapability(
 					error: getErrorMessage(result.error),
 					errorDetails: getExecutionErrorDetails(result.error),
 					logs,
+					...(serverTiming ? { serverTiming } : {}),
 				}
 			}
 
@@ -348,6 +371,7 @@ export const executeCapability = defineDomainCapability(
 					: {}),
 				result: limitedResult.value,
 				logs,
+				...(serverTiming ? { serverTiming } : {}),
 			}
 		},
 	},

--- a/packages/worker/src/mcp/execute-typecheck.node.test.ts
+++ b/packages/worker/src/mcp/execute-typecheck.node.test.ts
@@ -170,9 +170,8 @@ export default async function run() {
 		}),
 	).rejects.toThrow("Type 'string' is not assignable to type 'number'")
 
-	await expect(
-		assertAdHocExecuteTypechecks({
-			source: `import call from 'kody:@kentcdodds/static-contract'
+	const serverTiming = await assertAdHocExecuteTypechecks({
+		source: `import call from 'kody:@kentcdodds/static-contract'
 import { kody, packageStorage } from 'kody:runtime'
 import arbitraryClient from 'arbitrary-uninstalled-npm-package'
 
@@ -183,9 +182,44 @@ export default async function run() {
 	const result = await call({ name: 'Ada' })
 	return result.message
 }`,
-			packages,
-		}),
-	).resolves.toBeUndefined()
+		packages,
+	})
+	expect(serverTiming.map((entry) => entry.name)).toEqual([
+		'typecheck-queue',
+		'typecheck-compiler-startup',
+		'typecheck-project-write',
+		'typecheck-diagnostics',
+		'typecheck-total',
+	])
+	for (const entry of serverTiming) {
+		expect(entry.durationMs).toBeGreaterThanOrEqual(0)
+	}
+	const totalMs = serverTiming.at(-1)!.durationMs
+	const phaseSumMs = serverTiming
+		.slice(0, -1)
+		.reduce((sum, entry) => sum + entry.durationMs, 0)
+	expect(totalMs).toBeGreaterThanOrEqual(phaseSumMs - 5)
+})
+
+test('failed typecheck diagnostics still carry phase timings on the error', async () => {
+	const failure = await assertAdHocExecuteTypechecks({
+		source: `export default function run(): string {
+	return 42
+}`,
+		packages: new Map() as LoadedKodyGraphPackages,
+	}).then(
+		() => null,
+		(error: unknown) => error,
+	)
+	expect(failure).toBeInstanceOf(ExecuteTypecheckError)
+	const timedFailure = failure as ExecuteTypecheckError
+	expect(timedFailure.serverTiming?.map((entry) => entry.name)).toEqual([
+		'typecheck-queue',
+		'typecheck-compiler-startup',
+		'typecheck-project-write',
+		'typecheck-diagnostics',
+		'typecheck-total',
+	])
 })
 
 test('warm typecheck service replaces package sources between requests', async () => {
@@ -201,7 +235,7 @@ export default async function run() {
 					'export default async function call(input: { name: number }): Promise<number> { return input.name }',
 			}),
 		}),
-	).resolves.toBeUndefined()
+	).resolves.toBeDefined()
 
 	await expect(
 		assertAdHocExecuteTypechecks({
@@ -211,7 +245,7 @@ export default async function run() {
 }`,
 			packages: createLoadedPackages(stringContract),
 		}),
-	).resolves.toBeUndefined()
+	).resolves.toBeDefined()
 
 	await expect(
 		assertAdHocExecuteTypechecks({
@@ -225,7 +259,7 @@ export default async function run() {
 					'export default async function call(input: { name: number }): Promise<number> { return input.name }',
 			}),
 		}),
-	).resolves.toBeUndefined()
+	).resolves.toBeDefined()
 })
 
 test('ad hoc execute typecheck rejects oversized source before loading the compiler', async () => {

--- a/packages/worker/src/mcp/execute-typecheck.ts
+++ b/packages/worker/src/mcp/execute-typecheck.ts
@@ -164,6 +164,7 @@ async function getReusableTypecheckService() {
 }
 
 async function withTypecheckLock<T>(
+	phases: ExecuteTypecheckPhaseRecorder,
 	callback: (service: ReusableTypecheckService) => T,
 ) {
 	if (pendingTypecheckCount >= maxPendingExecuteTypechecks) {
@@ -177,25 +178,31 @@ async function withTypecheckLock<T>(
 	typecheckQueue = new Promise<void>((resolve) => {
 		release = resolve
 	})
-	await previous
+	await phases.measure('queue', async () => {
+		await previous
+	})
 	let timeoutId: ReturnType<typeof setTimeout> | null = null
 	let startupTimedOut = false
 	const servicePromise = getReusableTypecheckService()
 	const cachedServicePromise = reusableTypecheckServicePromise
 	try {
-		const service = await Promise.race([
-			servicePromise,
-			new Promise<never>((_resolve, reject) => {
-				timeoutId = setTimeout(() => {
-					startupTimedOut = true
-					reject(
-						new ExecuteTypecheckError([
-							`The pre-execution TypeScript checker exceeded its ${maxExecuteTypecheckHoldMs}ms service startup budget.`,
-						]),
-					)
-				}, maxExecuteTypecheckHoldMs)
-			}),
-		])
+		const service = await phases.measure(
+			'compiler-startup',
+			async () =>
+				await Promise.race([
+					servicePromise,
+					new Promise<never>((_resolve, reject) => {
+						timeoutId = setTimeout(() => {
+							startupTimedOut = true
+							reject(
+								new ExecuteTypecheckError([
+									`The pre-execution TypeScript checker exceeded its ${maxExecuteTypecheckHoldMs}ms service startup budget.`,
+								]),
+							)
+						}, maxExecuteTypecheckHoldMs)
+					}),
+				]),
+		)
 		if (timeoutId !== null) {
 			clearTimeout(timeoutId)
 			timeoutId = null
@@ -518,6 +525,7 @@ function formatDiagnostic(input: {
 
 export class ExecuteTypecheckError extends Error {
 	readonly diagnostics: Array<string>
+	serverTiming: Array<ExecuteServerTimingEntry> | undefined
 
 	constructor(diagnostics: Array<string>) {
 		super(
@@ -530,45 +538,113 @@ export class ExecuteTypecheckError extends Error {
 	}
 }
 
+/**
+ * Server-Timing-style phase entry (`name` + `durationMs`) surfaced through the
+ * execute tool's structured response so agents can attribute latency.
+ */
+export type ExecuteServerTimingEntry = {
+	name: string
+	durationMs: number
+}
+
+type ExecuteTypecheckPhaseRecorder = {
+	entries: Array<ExecuteServerTimingEntry>
+	measure<T>(name: string, run: () => Promise<T> | T): Promise<T>
+	measureSync<T>(name: string, run: () => T): T
+}
+
+function createTypecheckPhaseRecorder(): ExecuteTypecheckPhaseRecorder {
+	const entries: Array<ExecuteServerTimingEntry> = []
+	const record = (name: string, startedAtMs: number) => {
+		entries.push({
+			name: `typecheck-${name}`,
+			durationMs: Date.now() - startedAtMs,
+		})
+	}
+	return {
+		entries,
+		async measure(name, run) {
+			const startedAtMs = Date.now()
+			try {
+				return await run()
+			} finally {
+				record(name, startedAtMs)
+			}
+		},
+		measureSync(name, run) {
+			const startedAtMs = Date.now()
+			try {
+				return run()
+			} finally {
+				record(name, startedAtMs)
+			}
+		},
+	}
+}
+
 export async function assertAdHocExecuteTypechecks(input: {
 	source: string
 	packages: LoadedKodyGraphPackages
-}) {
-	assertTypecheckInputWithinLimits(input)
-	await withTypecheckLock(({ fileSystem, languageService }) => {
-		clearRequestFiles(fileSystem)
-		try {
-			const rewrittenEntry = rewriteStaticKodyImports({
-				source: input.source,
-				modulePath: entryPath,
-			})
-			fileSystem.write(entryPath, rewrittenEntry.source)
-			writePackageSources({
-				fileSystem,
-				packages: input.packages,
-			})
-			writeKodyTypeProxies({
-				fileSystem,
-				source: input.source,
-				packages: input.packages,
-			})
-			const diagnostics = [
-				...languageService.getSyntacticDiagnostics(entryPath),
-				...languageService.getSemanticDiagnostics(entryPath),
-			]
-				.filter((diagnostic) => !isArbitraryNpmImportDiagnostic(diagnostic))
-				.map((diagnostic) =>
-					formatDiagnostic({
-						diagnostic,
-						originalSource: input.source,
-						toOriginalOffset: rewrittenEntry.toOriginalOffset,
-					}),
-				)
-			if (diagnostics.length > 0) {
-				throw new ExecuteTypecheckError(diagnostics)
-			}
-		} finally {
+}): Promise<Array<ExecuteServerTimingEntry>> {
+	const phases = createTypecheckPhaseRecorder()
+	const totalStartedAtMs = Date.now()
+	try {
+		assertTypecheckInputWithinLimits(input)
+		await withTypecheckLock(phases, ({ fileSystem, languageService }) => {
 			clearRequestFiles(fileSystem)
+			try {
+				const rewrittenEntry = phases.measureSync('project-write', () => {
+					const rewritten = rewriteStaticKodyImports({
+						source: input.source,
+						modulePath: entryPath,
+					})
+					fileSystem.write(entryPath, rewritten.source)
+					writePackageSources({
+						fileSystem,
+						packages: input.packages,
+					})
+					writeKodyTypeProxies({
+						fileSystem,
+						source: input.source,
+						packages: input.packages,
+					})
+					return rewritten
+				})
+				const diagnostics = phases
+					.measureSync('diagnostics', () => [
+						...languageService.getSyntacticDiagnostics(entryPath),
+						...languageService.getSemanticDiagnostics(entryPath),
+					])
+					.filter((diagnostic) => !isArbitraryNpmImportDiagnostic(diagnostic))
+					.map((diagnostic) =>
+						formatDiagnostic({
+							diagnostic,
+							originalSource: input.source,
+							toOriginalOffset: rewrittenEntry.toOriginalOffset,
+						}),
+					)
+				if (diagnostics.length > 0) {
+					throw new ExecuteTypecheckError(diagnostics)
+				}
+			} finally {
+				clearRequestFiles(fileSystem)
+			}
+		})
+		phases.entries.push({
+			name: 'typecheck-total',
+			durationMs: Date.now() - totalStartedAtMs,
+		})
+		return phases.entries
+	} catch (error) {
+		phases.entries.push({
+			name: 'typecheck-total',
+			durationMs: Date.now() - totalStartedAtMs,
+		})
+		if (error instanceof ExecuteTypecheckError) {
+			// Diagnostics failures still report where the time went; the execute
+			// tool includes these phases in the failed call's structured timing.
+			error.serverTiming = [...phases.entries]
 		}
-	})
+		throw error
+	}
 }

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -13,6 +13,7 @@ import {
 	runBundledModuleWithRegistry,
 	runModuleWithRegistry,
 } from './run-kody-registry.ts'
+import * as executeTypecheck from '#mcp/execute-typecheck.ts'
 import * as mcpExecutor from '#mcp/executor.ts'
 import { type KodyResolvedProvider } from '#mcp/kody-remote-types.ts'
 import { PackageSecretMountError } from '#mcp/secrets/package-access.ts'
@@ -1562,20 +1563,38 @@ test('runModuleWithRegistry only installs the pre-execution typecheck hook when 
 	const capabilityRegistry = buildCapabilityRegistry([])
 
 	try {
-		await runModuleWithRegistry(
+		const uncheckedResult = await runModuleWithRegistry(
 			{} as Env,
 			callerContext,
 			'export default async function run() { return "unchecked" }',
 			undefined,
 			{ capabilityRegistry },
 		)
-		await runModuleWithRegistry(
+		buildBundleMock.mockImplementationOnce(async (input) => {
+			await input.beforeBundle?.({ packages: new Map() })
+			return {
+				mainModule: 'entry.js',
+				modules: {
+					'entry.js':
+						'export default async function main(input = {}) { return input }',
+				},
+				dependencies: [],
+			}
+		})
+		const typecheckSpy = vi
+			.spyOn(executeTypecheck, 'assertAdHocExecuteTypechecks')
+			.mockResolvedValue([
+				{ name: 'typecheck-queue', durationMs: 1 },
+				{ name: 'typecheck-total', durationMs: 12 },
+			])
+		const checkedResult = await runModuleWithRegistry(
 			{} as Env,
 			callerContext,
 			'export default async function run() { return "checked" }',
 			undefined,
 			{ capabilityRegistry, preExecTypecheck: true },
 		)
+		typecheckSpy.mockRestore()
 
 		expect(buildBundleMock).toHaveBeenCalledTimes(2)
 		expect(buildBundleMock.mock.calls[0]?.[0].beforeBundle).toBeUndefined()
@@ -1588,6 +1607,21 @@ test('runModuleWithRegistry only installs the pre-execution typecheck hook when 
 		expect(buildBundleMock.mock.calls[1]?.[0].includeTypeOnlyKodyPackages).toBe(
 			true,
 		)
+		// Both runs report Server-Timing-style phases; only the opted-in run
+		// carries typecheck phase entries ahead of them.
+		expect(uncheckedResult.serverTiming?.map((entry) => entry.name)).toEqual([
+			'bundle',
+			'run',
+		])
+		expect(checkedResult.serverTiming?.map((entry) => entry.name)).toEqual([
+			'typecheck-queue',
+			'typecheck-total',
+			'bundle',
+			'run',
+		])
+		for (const entry of checkedResult.serverTiming ?? []) {
+			expect(entry.durationMs).toBeGreaterThanOrEqual(0)
+		}
 	} finally {
 		createExecuteExecutorSpy.mockRestore()
 	}

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -10,7 +10,10 @@ import { exports as workerExports } from 'cloudflare:workers'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
 import { createExecuteExecutor } from '#mcp/executor.ts'
-import { assertAdHocExecuteTypechecks } from '#mcp/execute-typecheck.ts'
+import {
+	assertAdHocExecuteTypechecks,
+	type ExecuteServerTimingEntry,
+} from '#mcp/execute-typecheck.ts'
 import { type RawFetchHostSink } from '#mcp/raw-fetch-host-nudge.ts'
 import {
 	getAdditionalPropertiesSchema,
@@ -639,8 +642,15 @@ export async function runModuleWithRegistry(
 		 */
 		waitUntil?: (promise: Promise<unknown>) => void
 	},
-): Promise<ExecuteResult & { runId?: string }> {
+): Promise<
+	ExecuteResult & {
+		runId?: string
+		serverTiming?: Array<ExecuteServerTimingEntry>
+	}
+> {
 	const userId = callerContext.user?.userId ?? ''
+	const serverTiming: Array<ExecuteServerTimingEntry> = []
+	const bundleStartedAtMs = Date.now()
 	const bundled = await buildKodyModuleBundle({
 		env,
 		baseUrl: callerContext.baseUrl,
@@ -653,12 +663,20 @@ export async function runModuleWithRegistry(
 		includeTypeOnlyKodyPackages: options?.preExecTypecheck === true,
 		beforeBundle: options?.preExecTypecheck
 			? async ({ packages }) => {
-					await assertAdHocExecuteTypechecks({
-						source: code,
-						packages,
-					})
+					serverTiming.push(
+						...(await assertAdHocExecuteTypechecks({
+							source: code,
+							packages,
+						})),
+					)
 				}
 			: undefined,
+	})
+	// `bundle` covers graph preparation plus the opt-in typecheck phases above;
+	// subtract `typecheck-total` when attributing bundler-only time.
+	serverTiming.push({
+		name: 'bundle',
+		durationMs: Date.now() - bundleStartedAtMs,
 	})
 	const conversationId = options?.conversationId?.trim()
 	if (conversationId && userId) {
@@ -673,7 +691,8 @@ export async function runModuleWithRegistry(
 			})
 		}
 	}
-	return runBundledModuleWithRegistry(
+	const runStartedAtMs = Date.now()
+	const result = await runBundledModuleWithRegistry(
 		env,
 		callerContext,
 		{
@@ -697,6 +716,11 @@ export async function runModuleWithRegistry(
 			conversationId: options?.conversationId ?? null,
 		},
 	)
+	serverTiming.push({
+		name: 'run',
+		durationMs: Date.now() - runStartedAtMs,
+	})
+	return { ...result, serverTiming }
 }
 
 /**

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -5,6 +5,7 @@ import {
 	maxMcpContentBlockCount,
 	wrapDownstreamMcpToolResult,
 } from '#mcp/downstream-mcp-result.ts'
+import { ExecuteTypecheckError } from '#mcp/execute-typecheck.ts'
 import { formatRawFetchHostNudge } from '#mcp/raw-fetch-host-nudge.ts'
 import type * as AccessControlModule from '#mcp/capabilities/access-control.ts'
 import type * as RunRecordsServiceModule from '#worker/run-records/service.ts'
@@ -283,6 +284,11 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
 		result: { ok: true },
 		logs: [],
+		serverTiming: [
+			{ name: 'typecheck-total', durationMs: 12 },
+			{ name: 'bundle', durationMs: 34 },
+			{ name: 'run', durationMs: 56 },
+		],
 	})
 
 	const jsonResponse = await handler({
@@ -307,6 +313,11 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 			startedAt: expect.any(String),
 			endedAt: expect.any(String),
 			durationMs: 9,
+			serverTiming: [
+				{ name: 'typecheck-total', durationMs: 12 },
+				{ name: 'bundle', durationMs: 34 },
+				{ name: 'run', durationMs: 56 },
+			],
 		},
 		returnedBytes: 11,
 		result: { ok: true },
@@ -560,6 +571,43 @@ test('execute enables the pre-exec typecheck only for an opted-in caller', async
 		expect.any(String),
 		undefined,
 		expect.objectContaining({ preExecTypecheck: true }),
+	)
+})
+
+test('execute reports typecheck phase timings when pre-exec diagnostics fail', async () => {
+	const handler = await getExecuteHandler()
+	const typecheckError = new ExecuteTypecheckError([
+		"entry.ts:1:1 TS2322: Type 'number' is not assignable to type 'string'.",
+	])
+	typecheckError.serverTiming = [
+		{ name: 'typecheck-queue', durationMs: 0 },
+		{ name: 'typecheck-diagnostics', durationMs: 21 },
+		{ name: 'typecheck-total', durationMs: 25 },
+	]
+	mockPerformanceSequence(3, 11)
+	mockModule.runModuleWithRegistry.mockRejectedValueOnce(typecheckError)
+
+	const response = await handler({
+		code: 'export default function run(): string { return 42 }',
+		conversationId: 'conv-typecheck-timing',
+	})
+
+	expect(response.isError).toBe(true)
+	expect(response.structuredContent).toEqual(
+		expect.objectContaining({
+			conversationId: 'conv-typecheck-timing',
+			timing: {
+				startedAt: expect.any(String),
+				endedAt: expect.any(String),
+				durationMs: 8,
+				serverTiming: [
+					{ name: 'typecheck-queue', durationMs: 0 },
+					{ name: 'typecheck-diagnostics', durationMs: 21 },
+					{ name: 'typecheck-total', durationMs: 25 },
+				],
+			},
+			error: typecheckError.message,
+		}),
 	)
 })
 

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -21,6 +21,7 @@ import {
 } from '#mcp/downstream-mcp-result.ts'
 import { resolveCallerFeatureFlags } from '#mcp/capabilities/access-control.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
+import { ExecuteTypecheckError } from '#mcp/execute-typecheck.ts'
 import { runModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
 import {
@@ -389,12 +390,20 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 								result: undefined,
 								error: getErrorMessage(cause),
 								logs: [],
+								...(cause instanceof ExecuteTypecheckError && cause.serverTiming
+									? { serverTiming: cause.serverTiming }
+									: {}),
 								...(claimedRunHandle ? { runId: claimedRunHandle.id } : {}),
 							}
 						}
 					},
 				)
-				const timing = finishToolTiming(timingStart)
+				const timing = {
+					...finishToolTiming(timingStart),
+					...(result.serverTiming && result.serverTiming.length > 0
+						? { serverTiming: result.serverTiming }
+						: {}),
+				}
 				const durationMs = timing.durationMs
 				const rawFetchHostNudges = await resolveRawFetchHostNudges({
 					agent,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- return Server-Timing-style phase entries (`{ name, durationMs }`) from ad hoc execute so agents can attribute latency
- typecheck phases: `typecheck-queue`, `typecheck-compiler-startup`, `typecheck-project-write`, `typecheck-diagnostics`, `typecheck-total` — recorded on success and attached to `ExecuteTypecheckError` on diagnostics failure
- pipeline phases: `bundle` (contains the typecheck span) and `run` (hydration + sandbox)
- public execute tool surfaces them under `structuredContent.timing.serverTiming`; `meta.execute` returns a top-level `serverTiming` field
- documented in `docs/use/execute.md`

## Why

Live A/B benchmarking of the `execute-pre-exec-typecheck` rollout was inconclusive because the response only reported total tool duration; one flag-ON run stalled with no way to attribute where time went. These phases make slow or stranded runs diagnosable directly from the execute response.

## Validation

- 31 focused Node tests across the typecheck, registry, execute tool, and meta execute suites
- workspace typecheck, format, lint
- pre-push gate: full unit/Workers suites plus all 20 Playwright E2E tests

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7ebea332` · **Head:** `2201b229`

**Classification:** extends — the execute response contract gains an optional `serverTiming` phase list; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — execute/meta.execute responses include phase timings |
| `capabilities-execute` | runtime | extends — records bundle/run spans and typecheck phase entries |
| `memories` | assistant | composes — meta execute surface passes the field through |

### System map

Phase timings flow from the typecheck/bundle/run pipeline into the execute response.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	executeRuntime["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	executeRuntime -->|"serverTiming: typecheck-*/bundle/run"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6309fa04-d26d-426f-9d3c-e56a9b2d9c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6309fa04-d26d-426f-9d3c-e56a9b2d9c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed server-side timing information to execution responses.
  * Execution timing now includes bundle and run phases, with optional typecheck phases.
  * Timing data is available for both successful executions and relevant failures.
  * Documented the timing entry format and available phases.

* **Bug Fixes**
  * Preserved typecheck timing details when pre-execution checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->