### PR TITLE
Split execute run span into sub-phases

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -112,11 +112,22 @@ Execute responses include Server-Timing-style phase entries under
 
 - `bundle` — module-graph preparation and bundling. This span contains the
   typecheck phases below, so subtract `typecheck-total` for bundler-only time.
-- `run` — hydration, provider assembly, and sandbox execution.
+- `hydrate` — installing published sources for literal dynamic
+  `import("kody:@…")` targets.
+- `provider-assembly` — capability registry, runtime helper, and provider wiring
+  ahead of sandbox startup.
+- `sandbox` — the dynamic worker evaluation of the module itself.
+- `run` — the enclosing span for the three phases above (plus run-record and
+  usage bookkeeping).
 - `typecheck-queue`, `typecheck-compiler-startup`, `typecheck-project-write`,
   `typecheck-diagnostics`, `typecheck-total` — present only when the
   pre-execution check ran for the call. Failed diagnostics also report these
   phases so slow checks can be attributed even when the module never executes.
+
+Phase durations are measured with `Date.now()`, which the Workers runtime only
+advances across I/O boundaries — synchronous CPU inside one phase can be
+attributed to the next timer read. Treat phases as attribution for slow spans,
+not precise CPU accounting.
 
 ## npm packages on Workers
 

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -1611,12 +1611,18 @@ test('runModuleWithRegistry only installs the pre-execution typecheck hook when 
 		// carries typecheck phase entries ahead of them.
 		expect(uncheckedResult.serverTiming?.map((entry) => entry.name)).toEqual([
 			'bundle',
+			'hydrate',
+			'provider-assembly',
+			'sandbox',
 			'run',
 		])
 		expect(checkedResult.serverTiming?.map((entry) => entry.name)).toEqual([
 			'typecheck-queue',
 			'typecheck-total',
 			'bundle',
+			'hydrate',
+			'provider-assembly',
+			'sandbox',
 			'run',
 		])
 		for (const entry of checkedResult.serverTiming ?? []) {

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -716,7 +716,9 @@ export async function runModuleWithRegistry(
 			conversationId: options?.conversationId ?? null,
 		},
 	)
-	serverTiming.push({
+	// The bundled run reports its own sub-phases (hydrate, provider-assembly,
+	// sandbox); `run` is their enclosing wall-clock span.
+	serverTiming.push(...(result.serverTiming ?? []), {
 		name: 'run',
 		durationMs: Date.now() - runStartedAtMs,
 	})
@@ -798,7 +800,13 @@ export async function runBundledModuleWithRegistry(
 		 */
 		waitUntil?: (promise: Promise<unknown>) => void
 	},
-): Promise<ExecuteResult & { runId?: string }> {
+): Promise<
+	ExecuteResult & {
+		runId?: string
+		serverTiming?: Array<ExecuteServerTimingEntry>
+	}
+> {
+	const runServerTiming: Array<ExecuteServerTimingEntry> = []
 	const secretRedactor = createExecutionSecretRedactor()
 	const normalizedStorageContext = normalizeStorageContext(
 		callerContext.storageContext ?? null,
@@ -864,14 +872,19 @@ export async function runBundledModuleWithRegistry(
 	}
 	function withRunId<T extends ExecuteResult>(
 		result: T,
-	): T & { runId?: string } {
-		if (!exposeRunId || !runRecordHandle) return result
-		return { ...result, runId: runRecordHandle.id }
+	): T & { runId?: string; serverTiming?: Array<ExecuteServerTimingEntry> } {
+		const timed =
+			runServerTiming.length > 0
+				? { ...result, serverTiming: [...runServerTiming] }
+				: result
+		if (!exposeRunId || !runRecordHandle) return timed
+		return { ...timed, runId: runRecordHandle.id }
 	}
 	try {
 		// Hydration can install additional published-package sources (literal
 		// dynamic `import("kody:@...")` targets); keep a reference so error
 		// rewriting below scans the same module graph the sandbox executed.
+		const hydrateStartedAtMs = Date.now()
 		const { modules: hydratedModules, dynamicDependencyPackageIds } =
 			await hydrateKodyRuntimeModules({
 				env,
@@ -879,6 +892,10 @@ export async function runBundledModuleWithRegistry(
 				userId: callerContext.user?.userId ?? '',
 				modules: bundle.modules,
 			})
+		runServerTiming.push({
+			name: 'hydrate',
+			durationMs: Date.now() - hydrateStartedAtMs,
+		})
 		const agentConversationId = options?.conversationId?.trim()
 		const agentUserId = callerContext.user?.userId
 		if (
@@ -892,6 +909,7 @@ export async function runBundledModuleWithRegistry(
 				conversationId: agentConversationId,
 			})
 		}
+		const providerAssemblyStartedAtMs = Date.now()
 		const grantedPackageStorageIds = collectPackageStorageGrantIds({
 			packageContext: options?.packageContext ?? null,
 			dependencies: bundle.dependencies ?? [],
@@ -947,6 +965,10 @@ export async function runBundledModuleWithRegistry(
 			workflowTools,
 			skipCapabilityRegistry: options?.skipCapabilityRegistry,
 			capabilityRegistry: options?.capabilityRegistry,
+		})
+		runServerTiming.push({
+			name: 'provider-assembly',
+			durationMs: Date.now() - providerAssemblyStartedAtMs,
 		})
 		const runtimeHelperContext = {
 			env,
@@ -1006,7 +1028,12 @@ ${runtimeHelperRuntimePropertySource}
 				provider,
 				...createRuntimeHelperExtraProviders(runtimeHelperContext),
 			]
+			const sandboxStartedAtMs = Date.now()
 			const result = await executor.execute(wrapped, providers)
+			runServerTiming.push({
+				name: 'sandbox',
+				durationMs: Date.now() - sandboxStartedAtMs,
+			})
 			const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
 			if (!result.error) {
 				await finishObservedRun({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- break the execute `run` Server-Timing span into `hydrate` (dynamic `kody:@…` published-source install), `provider-assembly` (registry/runtime-helper/provider wiring), and `sandbox` (dynamic worker evaluation)
- `run` remains as the enclosing wall-clock span; `runBundledModuleWithRegistry` now returns its own `serverTiming` sub-entries and `runModuleWithRegistry` merges them into the combined phase list
- document the new phases plus the workerd `Date.now()` attribution caveat in `docs/use/execute.md`

## Why

Follow-up to #1034: live A/B benchmarking showed agent-reported slowness lives inside the `run` span (282–1675 ms with identical inputs), not in typechecking or bundling. These sub-phases make the slow outliers attributable to hydration, provider wiring, or sandbox evaluation directly from the execute response.

## Validation

- 31 focused Node tests (registry, execute tool, meta execute, typecheck suites)
- workspace typecheck, format, lint
- pre-push gate: full unit/Workers suites plus all 20 Playwright E2E tests

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (low-medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e1f3d835` · **Head:** `HEAD`

**Classification:** extends — additive timing detail on the execute response contract introduced by #1034; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capabilities-execute` | runtime | extends — bundled runs record hydrate/provider-assembly/sandbox spans |
| `mcp-server` | surfaces | composes — existing `serverTiming` field carries the extra entries |

### System map

Sub-phase timers inside the bundled run flow through the existing `serverTiming` merge into execute responses.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	executeRuntime["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	executeRuntime -->|"hydrate / provider-assembly / sandbox entries"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6309fa04-d26d-426f-9d3c-e56a9b2d9c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6309fa04-d26d-426f-9d3c-e56a9b2d9c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

