### PR TITLE
fix(mcp): keep package service caller mistakes off Sentry

### DIFF
--- a/packages/worker/src/mcp/capabilities/apps/shared.ts
+++ b/packages/worker/src/mcp/capabilities/apps/shared.ts
@@ -1,6 +1,7 @@
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { z } from 'zod'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 
 export const packageRealtimeSessionRecordSchema = z.object({
@@ -53,8 +54,9 @@ function resolvePackageId(
 	if (appId) {
 		return appId
 	}
-	throw new Error(
-		'Package realtime APIs require package app or package job caller context.',
+	// Agent calls from MCP omit package context unless they pass package_id.
+	throw new McpCallerError(
+		'Package realtime APIs require package_id, or a package app or package job caller context.',
 	)
 }
 
@@ -73,7 +75,9 @@ export async function requirePackageRealtimeContext(input: {
 		packageId,
 	})
 	if (!savedPackage || !savedPackage.hasApp) {
-		throw new Error('Saved package app was not found for realtime operations.')
+		throw new McpCallerError(
+			'Saved package app was not found for realtime operations.',
+		)
 	}
 	return {
 		user,

--- a/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -258,5 +259,56 @@ test('package service capabilities list, tolerate status failures, and delegate 
 		),
 	).resolves.toEqual({
 		ok: true,
+	})
+})
+
+test('service_list missing package context throws McpCallerError', async () => {
+	resetMocks()
+	const env = {
+		APP_DB: {} as D1Database,
+	} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+
+	const error = await serviceListCapability
+		.handler({}, { env, callerContext })
+		.catch((caught: unknown) => caught)
+	expect(error).toBeInstanceOf(McpCallerError)
+	expect(error).toMatchObject({
+		message: expect.stringMatching(/require package_id/),
+	})
+	expect(mockModule.getSavedPackageById).not.toHaveBeenCalled()
+})
+
+test('service_list unknown package_id throws McpCallerError', async () => {
+	resetMocks()
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	const env = {
+		APP_DB: {} as D1Database,
+	} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+
+	const error = await serviceListCapability
+		.handler(
+			{ package_id: 'missing-package' },
+			{ env, callerContext },
+		)
+		.catch((caught: unknown) => caught)
+	expect(error).toBeInstanceOf(McpCallerError)
+	expect(error).toMatchObject({
+		message: expect.stringMatching(/Saved package was not found/),
 	})
 })

--- a/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
@@ -302,10 +302,7 @@ test('service_list unknown package_id throws McpCallerError', async () => {
 	})
 
 	const error = await serviceListCapability
-		.handler(
-			{ package_id: 'missing-package' },
-			{ env, callerContext },
-		)
+		.handler({ package_id: 'missing-package' }, { env, callerContext })
 		.catch((caught: unknown) => caught)
 	expect(error).toBeInstanceOf(McpCallerError)
 	expect(error).toMatchObject({

--- a/packages/worker/src/mcp/capabilities/services/shared.ts
+++ b/packages/worker/src/mcp/capabilities/services/shared.ts
@@ -1,6 +1,7 @@
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { z } from 'zod'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import {
 	listSavedPackageServices,
@@ -43,8 +44,9 @@ function resolvePackageId(
 	if (appId) {
 		return appId
 	}
-	throw new Error(
-		'Package service APIs require package app or package job caller context.',
+	// Agent calls from MCP omit package context unless they pass package_id.
+	throw new McpCallerError(
+		'Package service APIs require package_id, or a package app or package job caller context.',
 	)
 }
 
@@ -94,7 +96,7 @@ export async function requirePackageServiceContext(input: {
 		packageId,
 	})
 	if (!savedPackage) {
-		throw new Error(
+		throw new McpCallerError(
 			'Saved package was not found for package service operations.',
 		)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [issue 7641856363](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7641856363/) (`service_list` → `resolvePackageId`) and sibling [7641856395](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7641856395/) (`Saved package was not found…`) were opened when MCP agents called package service APIs without `package_id` / package caller context, or with an unknown package id.

Those are caller mistakes. `logMcpEvent` already keeps `McpCallerError` off Sentry; the helpers were throwing plain `Error`, so they looked like platform bugs.

### Fix

- Throw `McpCallerError` from package service and package realtime context resolvers (missing `package_id`/context, unknown package).
- Clarify the missing-context message to mention `package_id`.
- Cover both paths in `services-domain.node.test.ts`.

## Test plan

- [x] `npx vitest run packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts`
- [ ] CI `validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** triage branch

**Classification:** composes — reuses existing `McpCallerError` / MCP observability filtering; no new primitives or contracts.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | composes — package service/realtime helpers throw `McpCallerError` for missing/unknown package context |

### System map

MCP `service_list` (and sibling service/realtime capabilities) resolve package id from args or caller context; invalid caller input is classified as a caller error so it stays on `mcp-event` logs and out of Sentry.

**Legend:** green = composes · gray = context.

```mermaid
flowchart LR
	mcpServer["mcp-server"]:::untouched
	capabilityRegistry["capability-registry<br/>service_list / apps realtime"]:::touched
	observability["mcp observability<br/>McpCallerError filter"]:::untouched
	mcpServer -->|"capability call"| capabilityRegistry
	capabilityRegistry -->|"caller mistake"| observability
	classDef touched fill:#1a7f37,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Missing `package_id` / unknown package → plain `Error` → Sentry issue | Same user-facing failure as `McpCallerError` → logged, not Sentry |

### Risk

Low. Behavior for valid calls unchanged; only error class / Sentry routing for known caller mistakes.

### Invariants

No auth, isolation, billing, or migration changes.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-291bf076-43c7-4af8-9e13-f6dd61b3fcac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-291bf076-43c7-4af8-9e13-f6dd61b3fcac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for package service and realtime operations.
  - Client-facing failures now return clearer, more actionable messages when required package context is missing or when a saved package cannot be found.
  - Expanded automated test coverage to confirm consistent error behavior and message contents for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->