### PR TITLE
fix(execute): stop hangs past 90s and self-heal stranded running runs

### DIFF
--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -193,10 +193,11 @@ Orphan log lines are cleaned in the same pass. Caps are applied in small batches
 per finish so a single RPC stays bounded.
 
 Stranded `running` rows (isolate reset, lost `waitUntil` finish, hung Worker
-Loader `evaluate`) are reconciled to `error` / `Interrupted` / outcome-unknown
-using the surface-aware TTLs above. Reconciliation runs on the DO alarm, on
-retention passes, and **on read** (`getRun`, keyed lookup, `listRuns`,
-`summarize`) so Activity and keyed-execute recovery do not wait for an alarm.
+Loader `evaluate`) are reconciled to `status=error` with `errorName=Interrupted`
+(Interrupted means the execution outcome is unknown) using the surface-aware
+TTLs above. Reconciliation runs on the DO alarm, on retention passes, and **on
+read** (`getRun`, keyed lookup, `listRuns`, `summarize`) so Activity and
+keyed-execute recovery do not wait for an alarm.
 
 ## Invariant: state vs history
 

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -182,12 +182,21 @@ a shared D1 table:
 | Log lines per run          | 200                                             |
 | Text / JSON field budgets  | 16 KiB / 32 KiB truncated                       |
 | `metadata.result` snapshot | 4 KiB (`runRecordMaxResultSnapshotBytes`)       |
+| Stale `running` (short)    | ~3 minutes for execute/export/webhook/…         |
+| Stale `running` (job)      | ~6 hours                                        |
+| Stale `running` (long)     | ~24 hours for service/workflow                  |
 
 Age prune deletes finished runs older than the cutoff (rows still `running` are
 kept). Count prune deletes the oldest excess rows **failure-last**: successes
 are removed before errors (`ORDER BY (status = 'error') ASC, started_at ASC`).
 Orphan log lines are cleaned in the same pass. Caps are applied in small batches
 per finish so a single RPC stays bounded.
+
+Stranded `running` rows (isolate reset, lost `waitUntil` finish, hung Worker
+Loader `evaluate`) are reconciled to `error` / `Interrupted` / outcome-unknown
+using the surface-aware TTLs above. Reconciliation runs on the DO alarm, on
+retention passes, and **on read** (`getRun`, keyed lookup, `listRuns`,
+`summarize`) so Activity and keyed-execute recovery do not wait for an alarm.
 
 ## Invariant: state vs history
 

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -170,6 +170,10 @@ must be recoverable:
   sandbox).
 - Retrying while the first attempt is still running returns
   **`inProgress: true`** with the **`runId`** (no duplicate start).
+- If a keyed run is stranded as `running` (for example the Worker isolate reset
+  before the terminal write), Kody reconciles it to an **Interrupted** error
+  after a few minutes. Polling **`run_get`** or retrying the same key then
+  returns that terminal outcome instead of `inProgress` forever.
 
 Omit the key for ordinary short calls; key-less execute stays on-failure-only so
 Activity is not flooded with successful one-offs.

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -539,6 +539,66 @@ test('createExecuteExecutor returns sandbox timeout when Loader evaluate hangs',
 	expect(Date.now() - startedAtMs).toBeLessThan(500)
 })
 
+test('createExecuteExecutor drops queued evaluations when the host deadline expires', async () => {
+	let evaluateStarts = 0
+	let releaseHolders: () => void = () => {}
+	const holdersMayFinish = new Promise<void>((resolve) => {
+		releaseHolders = resolve
+	})
+	let resolveAllHoldersStarted: () => void = () => {}
+	const allHoldersStarted = new Promise<void>((resolve) => {
+		resolveAllHoldersStarted = resolve
+	})
+	let sharedEnv: Env
+	const exports = createExecutorTestExports()
+	const providers = [{ name: 'kody', fns: {} }]
+	const loader = {
+		get(_id: string, factory: () => FakeWorkerOptions) {
+			factory()
+			return {
+				getEntrypoint() {
+					return {
+						async evaluate() {
+							evaluateStarts += 1
+							if (evaluateStarts === 4) resolveAllHoldersStarted()
+							await holdersMayFinish
+							return { result: 'done', logs: [] }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as Env['LOADER']
+	sharedEnv = createExecutorTestEnv(loader)
+
+	await runWithDynamicWorkerEvaluationBudget(async () => {
+		const holders = Array.from({ length: 4 }, () =>
+			createExecuteExecutor({
+				env: sharedEnv,
+				exports,
+				gatewayProps: createGatewayProps('queue-user'),
+				timeoutMs: 10_000,
+			}).execute('async () => "holder"', providers),
+		)
+		await allHoldersStarted
+		expect(evaluateStarts).toBe(4)
+
+		const queuedResult = await createExecuteExecutor({
+			env: sharedEnv,
+			exports,
+			gatewayProps: createGatewayProps('queue-user'),
+			timeoutMs: 40,
+		}).execute('async () => "queued"', providers)
+
+		expect(queuedResult.error).toBe(executorSandboxTimeoutMessage)
+		expect(evaluateStarts).toBe(4)
+
+		releaseHolders()
+		await Promise.all(holders)
+		expect(evaluateStarts).toBe(4)
+	})
+})
+
 test('createExecuteExecutor fails fast when nested fan-out saturates its request budget', async () => {
 	let evaluationCount = 0
 	let maxActiveEvaluations = 0

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -506,10 +506,7 @@ test('explicit request budgets cap independent roots at four without blocking se
 test('raceWithHostEvaluationDeadline rejects when evaluate never settles', async () => {
 	const startedAtMs = Date.now()
 	await expect(
-		raceWithHostEvaluationDeadline(
-			async () => await new Promise(() => {}),
-			40,
-		),
+		raceWithHostEvaluationDeadline(async () => await new Promise(() => {}), 40),
 	).rejects.toThrow(executorSandboxTimeoutMessage)
 	expect(Date.now() - startedAtMs).toBeLessThan(500)
 })

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -21,8 +21,10 @@ import {
 	formatLimitedExecutionOutput,
 	getExecutionErrorDetails,
 	limitExecutionResultValue,
+	raceWithHostEvaluationDeadline,
 	runWithDynamicWorkerEvaluationBudget,
 } from './executor.ts'
+import { executorSandboxTimeoutMessage } from '#worker/sentry-options.ts'
 import { assertGeneratedExecutorSourceIsBundleSafe } from './kody-remote-proxy-source.ts'
 import { createDynamicWorkerCompatibilityOptions } from '#worker/dynamic-worker-compatibility.ts'
 
@@ -499,6 +501,45 @@ test('explicit request budgets cap independent roots at four without blocking se
 	await expect(secondRequest).resolves.toHaveLength(5)
 	expect(firstState.active).toBe(0)
 	expect(secondState.active).toBe(0)
+})
+
+test('raceWithHostEvaluationDeadline rejects when evaluate never settles', async () => {
+	const startedAtMs = Date.now()
+	await expect(
+		raceWithHostEvaluationDeadline(
+			async () => await new Promise(() => {}),
+			40,
+		),
+	).rejects.toThrow(executorSandboxTimeoutMessage)
+	expect(Date.now() - startedAtMs).toBeLessThan(500)
+})
+
+test('createExecuteExecutor returns sandbox timeout when Loader evaluate hangs', async () => {
+	const loader = {
+		get(_id: string, factory: () => FakeWorkerOptions) {
+			factory()
+			return {
+				getEntrypoint() {
+					return {
+						async evaluate() {
+							return await new Promise(() => {})
+						},
+					}
+				},
+			}
+		},
+	} as unknown as Env['LOADER']
+	const env = createExecutorTestEnv(loader)
+	const startedAtMs = Date.now()
+	const result = await createExecuteExecutor({
+		env,
+		exports: createExecutorTestExports(),
+		gatewayProps: createGatewayProps('hang-user'),
+		timeoutMs: 40,
+	}).execute('async () => "never"', [{ name: 'kody', fns: {} }])
+	expect(result.error).toBe(executorSandboxTimeoutMessage)
+	expect(result.result).toBeUndefined()
+	expect(Date.now() - startedAtMs).toBeLessThan(500)
 })
 
 test('createExecuteExecutor fails fast when nested fan-out saturates its request budget', async () => {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -308,13 +308,14 @@ async function runWithDynamicWorkerEvaluationPermit<T>(
 			evaluate,
 		)
 	} finally {
-		if (!acquired) return
-		const next = gate.queue.shift()
-		if (next) {
-			// Transfer this permit directly to the oldest waiter.
-			next.resolve()
-		} else {
-			gate.active -= 1
+		if (acquired) {
+			const next = gate.queue.shift()
+			if (next) {
+				// Transfer this permit directly to the oldest waiter.
+				next.resolve()
+			} else {
+				gate.active -= 1
+			}
 		}
 	}
 }

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -146,9 +146,14 @@ type DynamicWorkerEntrypoint = {
 	}>
 }
 
+type DynamicWorkerPermitWaiter = {
+	resolve: () => void
+	reject: (error: Error) => void
+}
+
 type DynamicWorkerEvaluationGate = {
 	active: number
-	queue: Array<() => void>
+	queue: Array<DynamicWorkerPermitWaiter>
 }
 
 type DynamicWorkerEvaluationContext = {
@@ -178,14 +183,22 @@ export async function runWithDynamicWorkerEvaluationBudget<T>(
 
 async function withDynamicWorkerEvaluationPermit<T>(
 	evaluate: () => Promise<T>,
+	signal?: AbortSignal,
 ): Promise<T> {
 	return await runWithDynamicWorkerEvaluationBudget(async () => {
 		const context = dynamicWorkerEvaluationGateStorage.getStore()
 		if (!context) {
 			throw new Error('Dynamic worker evaluation budget was not initialized.')
 		}
-		return await runWithDynamicWorkerEvaluationPermit(context, evaluate)
+		return await runWithDynamicWorkerEvaluationPermit(context, evaluate, signal)
 	})
+}
+
+function throwIfEvaluationDeadlineAborted(signal?: AbortSignal) {
+	if (!signal?.aborted) return
+	const reason = signal.reason
+	if (reason instanceof Error) throw reason
+	throw new Error(executorSandboxTimeoutMessage)
 }
 
 /**
@@ -194,30 +207,35 @@ async function withDynamicWorkerEvaluationPermit<T>(
  * dynamic worker is running and can schedule timers. If `evaluate` never
  * returns (or never starts), this host race is what bounds the request and
  * lets run-record finish write an error instead of leaving `running` forever.
+ *
+ * The AbortSignal is shared with the permit queue so a timed-out waiter is
+ * removed and cannot start `evaluate` after `execute` has already returned.
  */
 export async function raceWithHostEvaluationDeadline<T>(
-	evaluate: () => Promise<T>,
+	evaluate: (signal: AbortSignal) => Promise<T>,
 	timeoutMs: number,
 ): Promise<T> {
 	if (
 		!Number.isFinite(timeoutMs) ||
 		timeoutMs >= maxSupportedExecutorTimeoutMs
 	) {
-		return await evaluate()
+		return await evaluate(new AbortController().signal)
 	}
+	const controller = new AbortController()
 	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	const timeoutPromise = new Promise<never>((_resolve, reject) => {
+		timeoutId = setTimeout(
+			() => {
+				const error = new Error(executorSandboxTimeoutMessage)
+				controller.abort(error)
+				reject(error)
+			},
+			Math.max(1, timeoutMs),
+		)
+	})
 	try {
-		return await Promise.race([
-			evaluate(),
-			new Promise<never>((_resolve, reject) => {
-				timeoutId = setTimeout(
-					() => {
-						reject(new Error(executorSandboxTimeoutMessage))
-					},
-					Math.max(1, timeoutMs),
-				)
-			}),
-		])
+		throwIfEvaluationDeadlineAborted(controller.signal)
+		return await Promise.race([evaluate(controller.signal), timeoutPromise])
 	} finally {
 		if (timeoutId !== undefined) {
 			clearTimeout(timeoutId)
@@ -228,10 +246,14 @@ export async function raceWithHostEvaluationDeadline<T>(
 async function runWithDynamicWorkerEvaluationPermit<T>(
 	context: DynamicWorkerEvaluationContext,
 	evaluate: () => Promise<T>,
+	signal?: AbortSignal,
 ): Promise<T> {
 	const { gate } = context
+	throwIfEvaluationDeadlineAborted(signal)
+	let acquired = false
 	if (gate.active < maxConcurrentDynamicWorkerEvaluationsPerRequest) {
 		gate.active += 1
+		acquired = true
 	} else if (context.depth > 0) {
 		// A nested evaluation cannot wait safely once the request is saturated:
 		// every active permit may belong to an ancestor/sibling that is itself
@@ -240,11 +262,44 @@ async function runWithDynamicWorkerEvaluationPermit<T>(
 		// waiting for the queued evaluation.
 		throw new Error(dynamicWorkerCapacityErrorMessages[1])
 	} else {
-		await new Promise<void>((resolve) => {
-			gate.queue.push(resolve)
+		await new Promise<void>((resolve, reject) => {
+			const waiter: DynamicWorkerPermitWaiter = {
+				resolve: () => {
+					cleanup()
+					resolve()
+				},
+				reject: (error) => {
+					cleanup()
+					reject(error)
+				},
+			}
+			const onAbort = () => {
+				const index = gate.queue.indexOf(waiter)
+				if (index >= 0) {
+					gate.queue.splice(index, 1)
+				}
+				waiter.reject(new Error(executorSandboxTimeoutMessage))
+			}
+			const cleanup = () => {
+				if (signal) {
+					signal.removeEventListener('abort', onAbort)
+				}
+			}
+			if (signal) {
+				signal.addEventListener('abort', onAbort, { once: true })
+				if (signal.aborted) {
+					onAbort()
+					return
+				}
+			}
+			gate.queue.push(waiter)
 		})
+		// A cancelled waiter never reaches here; a transferred permit means we
+		// already own `active` without incrementing again.
+		acquired = true
 	}
 	try {
+		throwIfEvaluationDeadlineAborted(signal)
 		return await dynamicWorkerEvaluationGateStorage.run(
 			{
 				gate,
@@ -253,10 +308,11 @@ async function runWithDynamicWorkerEvaluationPermit<T>(
 			evaluate,
 		)
 	} finally {
+		if (!acquired) return
 		const next = gate.queue.shift()
 		if (next) {
 			// Transfer this permit directly to the oldest waiter.
-			next()
+			next.resolve()
 		} else {
 			gate.active -= 1
 		}
@@ -434,10 +490,11 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 				let response: Awaited<ReturnType<DynamicWorkerEntrypoint['evaluate']>>
 				try {
 					response = await raceWithHostEvaluationDeadline(
-						async () =>
-							await withDynamicWorkerEvaluationPermit(
-								async () => await entrypoint.evaluate(dispatchers),
-							),
+						async (signal) =>
+							await withDynamicWorkerEvaluationPermit(async () => {
+								throwIfEvaluationDeadlineAborted(signal)
+								return await entrypoint.evaluate(dispatchers)
+							}, signal),
 						input.timeout,
 					)
 				} catch (error) {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -199,7 +199,10 @@ export async function raceWithHostEvaluationDeadline<T>(
 	evaluate: () => Promise<T>,
 	timeoutMs: number,
 ): Promise<T> {
-	if (!Number.isFinite(timeoutMs) || timeoutMs >= maxSupportedExecutorTimeoutMs) {
+	if (
+		!Number.isFinite(timeoutMs) ||
+		timeoutMs >= maxSupportedExecutorTimeoutMs
+	) {
 		return await evaluate()
 	}
 	let timeoutId: ReturnType<typeof setTimeout> | undefined
@@ -207,9 +210,12 @@ export async function raceWithHostEvaluationDeadline<T>(
 		return await Promise.race([
 			evaluate(),
 			new Promise<never>((_resolve, reject) => {
-				timeoutId = setTimeout(() => {
-					reject(new Error(executorSandboxTimeoutMessage))
-				}, Math.max(1, timeoutMs))
+				timeoutId = setTimeout(
+					() => {
+						reject(new Error(executorSandboxTimeoutMessage))
+					},
+					Math.max(1, timeoutMs),
+				)
 			}),
 		])
 	} finally {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -188,6 +188,37 @@ async function withDynamicWorkerEvaluationPermit<T>(
 	})
 }
 
+/**
+ * Host-side deadline around Worker Loader `evaluate` (and its permit wait).
+ * The sandbox also races an internal timer, but that only helps once the
+ * dynamic worker is running and can schedule timers. If `evaluate` never
+ * returns (or never starts), this host race is what bounds the request and
+ * lets run-record finish write an error instead of leaving `running` forever.
+ */
+export async function raceWithHostEvaluationDeadline<T>(
+	evaluate: () => Promise<T>,
+	timeoutMs: number,
+): Promise<T> {
+	if (!Number.isFinite(timeoutMs) || timeoutMs >= maxSupportedExecutorTimeoutMs) {
+		return await evaluate()
+	}
+	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			evaluate(),
+			new Promise<never>((_resolve, reject) => {
+				timeoutId = setTimeout(() => {
+					reject(new Error(executorSandboxTimeoutMessage))
+				}, Math.max(1, timeoutMs))
+			}),
+		])
+	} finally {
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId)
+		}
+	}
+}
+
 async function runWithDynamicWorkerEvaluationPermit<T>(
 	context: DynamicWorkerEvaluationContext,
 	evaluate: () => Promise<T>,
@@ -394,9 +425,27 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 				const entrypoint = input.loader
 					.get(workerId, () => workerOptions)
 					.getEntrypoint() as unknown as DynamicWorkerEntrypoint
-				const response = await withDynamicWorkerEvaluationPermit(
-					async () => await entrypoint.evaluate(dispatchers),
-				)
+				let response: Awaited<ReturnType<DynamicWorkerEntrypoint['evaluate']>>
+				try {
+					response = await raceWithHostEvaluationDeadline(
+						async () =>
+							await withDynamicWorkerEvaluationPermit(
+								async () => await entrypoint.evaluate(dispatchers),
+							),
+						input.timeout,
+					)
+				} catch (error) {
+					const message = getErrorMessage(error)
+					if (message === executorSandboxTimeoutMessage) {
+						outcome = 'error'
+						return {
+							result: undefined,
+							error: executorSandboxTimeoutMessage,
+							logs: [],
+						}
+					}
+					throw error
+				}
 				if (input.rawFetchHostSink) {
 					for (const hostname of response.rawFetchHosts ?? []) {
 						input.rawFetchHostSink.add(hostname)

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -841,3 +841,40 @@ test('gateway fetch metering never derives a hostname from expanded secret place
 		resolveSpy.mockRestore()
 	}
 })
+
+test('fetch gateway aborts hung outbound fetches at the default deadline', async () => {
+	const fetchStub = vi.fn((_request: Request) => {
+		return new Promise<Response>((_resolve, reject) => {
+			_request.signal.addEventListener(
+				'abort',
+				() => {
+					reject(
+						_request.signal.reason ??
+							new DOMException('The operation was aborted.', 'AbortError'),
+					)
+				},
+				{ once: true },
+			)
+		})
+	})
+	const startedAtMs = Date.now()
+	await expect(
+		executeGatewayFetch({
+			env,
+			props,
+			request: new Request('https://example.com/slow'),
+			globalFetch: fetchStub as unknown as typeof fetch,
+			timeoutMs: 40,
+		}),
+	).rejects.toSatisfy((error: unknown) => {
+		const name =
+			error && typeof error === 'object' && 'name' in error
+				? String(error.name)
+				: ''
+		return name === 'TimeoutError' || name === 'AbortError'
+	})
+	expect(Date.now() - startedAtMs).toBeLessThan(500)
+	expect(fetchStub).toHaveBeenCalledTimes(1)
+	const outbound = fetchStub.mock.calls[0]?.[0]
+	expect(outbound?.signal.aborted).toBe(true)
+})

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -55,6 +55,13 @@ export type { FetchGatewayProps }
  */
 export const secretResolutionHeaderName = 'x-kody-secret-resolution'
 
+/**
+ * Default deadline for sandbox outbound `fetch` when the caller did not pass
+ * a tighter `AbortSignal`. Kept under the execute sandbox budget (90s) so a
+ * hung upstream cannot strand the whole evaluation past the host deadline.
+ */
+export const defaultOutboundFetchTimeoutMs = 60_000
+
 export class KodyFetchGateway extends WorkerEntrypoint<Env, FetchGatewayProps> {
 	async fetch(request: Request) {
 		return executeGatewayFetch({
@@ -66,18 +73,40 @@ export class KodyFetchGateway extends WorkerEntrypoint<Env, FetchGatewayProps> {
 	}
 }
 
+function applyOutboundFetchTimeout(
+	request: Request,
+	timeoutMs: number,
+): Request {
+	const timeoutSignal = AbortSignal.timeout(timeoutMs)
+	const existing = request.signal
+	const signal =
+		existing && typeof AbortSignal.any === 'function'
+			? AbortSignal.any([existing, timeoutSignal])
+			: timeoutSignal
+	return new Request(request, { signal })
+}
+
 export async function executeGatewayFetch(input: {
 	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'> & UsageEnv
 	props: FetchGatewayProps
 	request: Request
 	globalFetch?: typeof fetch
 	waitUntil?: (promise: Promise<unknown>) => void
+	/**
+	 * Override the default outbound deadline. `null` disables the gateway
+	 * timeout (caller signal only). Tests use short values.
+	 */
+	timeoutMs?: number | null
 }): Promise<Response> {
 	const globalFetch = input.globalFetch ?? fetch
 	const startedAtMs = Date.now()
 	let outcome: 'success' | 'error' = 'success'
 	let response: Response | undefined
 	let meteredEntityId = readMeteredRequestHostname(input.request.url, null)
+	const timeoutMs =
+		input.timeoutMs === null
+			? null
+			: (input.timeoutMs ?? defaultOutboundFetchTimeoutMs)
 
 	try {
 		// Daily outbound-fetch quota: every sandbox fetch leaves through
@@ -116,7 +145,11 @@ export async function executeGatewayFetch(input: {
 			input.request.url,
 			transformed.url,
 		)
-		response = await globalFetch(transformed)
+		const outbound =
+			timeoutMs == null
+				? transformed
+				: applyOutboundFetchTimeout(transformed, timeoutMs)
+		response = await globalFetch(outbound)
 		return response
 	} catch (error) {
 		outcome = 'error'

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -570,18 +570,32 @@ class RunLogBase extends DurableObject<Env> {
 	private reconcileStaleRunning() {
 		const nowMs = Date.now()
 		const finishedAt = new Date(nowMs).toISOString()
-		// Shortest surface TTL is the earliest a row can possibly be stale;
-		// filter the rest in JS so each surface keeps its own budget.
-		const earliestCutoff = new Date(
+		// Per-surface cutoffs so long-lived job/service rows cannot fill the
+		// batch and starve short-lived execute/export rows that are already
+		// past their 3-minute TTL.
+		const shortLivedCutoff = new Date(
 			nowMs - runRecordStaleRunningTtlMsForSurface('execute'),
+		).toISOString()
+		const jobCutoff = new Date(
+			nowMs - runRecordStaleRunningTtlMsForSurface('job'),
+		).toISOString()
+		const longLivedCutoff = new Date(
+			nowMs - runRecordStaleRunningTtlMsForSurface('service'),
 		).toISOString()
 		const candidates = this.ctx.storage.sql
 			.exec<{ id: string; started_at: string; surface: string }>(
 				`SELECT id, started_at, surface FROM runs
-				WHERE status = 'running' AND started_at < ?
+				WHERE status = 'running' AND (
+					(surface IN ('execute', 'export', 'retriever', 'webhook', 'subscription', 'app_fetch', 'app_realtime')
+						AND started_at < ?)
+					OR (surface = 'job' AND started_at < ?)
+					OR (surface IN ('service', 'workflow') AND started_at < ?)
+				)
 				ORDER BY started_at ASC
 				LIMIT ?`,
-				earliestCutoff,
+				shortLivedCutoff,
+				jobCutoff,
+				longLivedCutoff,
 				maxStaleRunningReconcilesPerPass,
 			)
 			.toArray()

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -19,7 +19,7 @@ import {
 	runRecordRetentionAlarmMs,
 	runRecordRetentionDays,
 	runRecordRetentionEveryNFinishes,
-	runRecordStaleRunningTtlMs,
+	runRecordStaleRunningTtlMsForSurface,
 	runSurfaceValues,
 } from './types.ts'
 
@@ -516,52 +516,128 @@ class RunLogBase extends DurableObject<Env> {
 		this.adjustRunCount(-ids.length)
 	}
 
+	private isStaleRunning(input: {
+		surface: string
+		startedAt: string
+		nowMs?: number
+	}): boolean {
+		const surface = isRunSurface(input.surface) ? input.surface : 'execute'
+		const startedMs = Date.parse(input.startedAt)
+		if (!Number.isFinite(startedMs)) return false
+		const nowMs = input.nowMs ?? Date.now()
+		return nowMs - startedMs >= runRecordStaleRunningTtlMsForSurface(surface)
+	}
+
+	private markRunningInterrupted(input: {
+		id: string
+		startedAt: string
+		finishedAt?: string
+	}) {
+		const finishedAt = input.finishedAt ?? new Date().toISOString()
+		const startedMs = Date.parse(input.startedAt)
+		const finishedMs = Date.parse(finishedAt)
+		const durationMs =
+			Number.isFinite(startedMs) && Number.isFinite(finishedMs)
+				? Math.max(0, finishedMs - startedMs)
+				: null
+		this.ctx.storage.sql.exec(
+			`UPDATE runs
+			SET status = 'error',
+				finished_at = ?,
+				duration_ms = ?,
+				error_name = ?,
+				error_message = ?,
+				updated_at = ?
+			WHERE id = ? AND status = 'running'`,
+			finishedAt,
+			durationMs,
+			staleRunningErrorName,
+			staleRunningErrorMessage,
+			finishedAt,
+			input.id,
+		)
+	}
+
 	/**
 	 * Prefer marking stranded `running` rows terminal over deleting them: an
 	 * interrupted attempt is useful history. `error` + Interrupted is used
 	 * because the public status union has no dedicated unknown-outcome value;
 	 * live "is it running?" state must not be read from these rows anyway.
+	 *
+	 * TTL is surface-aware: sandbox-backed surfaces (execute/export/…) heal in
+	 * minutes; long-lived service/workflow rows keep the day-scale TTL.
 	 */
 	private reconcileStaleRunning() {
-		const cutoff = new Date(
-			Date.now() - runRecordStaleRunningTtlMs,
+		const nowMs = Date.now()
+		const finishedAt = new Date(nowMs).toISOString()
+		// Shortest surface TTL is the earliest a row can possibly be stale;
+		// filter the rest in JS so each surface keeps its own budget.
+		const earliestCutoff = new Date(
+			nowMs - runRecordStaleRunningTtlMsForSurface('execute'),
 		).toISOString()
-		const finishedAt = new Date().toISOString()
-		const stale = this.ctx.storage.sql
-			.exec<{ id: string; started_at: string }>(
-				`SELECT id, started_at FROM runs
+		const candidates = this.ctx.storage.sql
+			.exec<{ id: string; started_at: string; surface: string }>(
+				`SELECT id, started_at, surface FROM runs
 				WHERE status = 'running' AND started_at < ?
 				ORDER BY started_at ASC
 				LIMIT ?`,
-				cutoff,
+				earliestCutoff,
 				maxStaleRunningReconcilesPerPass,
 			)
 			.toArray()
-		for (const row of stale) {
-			const startedMs = Date.parse(row.started_at)
-			const finishedMs = Date.parse(finishedAt)
-			const durationMs =
-				Number.isFinite(startedMs) && Number.isFinite(finishedMs)
-					? Math.max(0, finishedMs - startedMs)
-					: null
-			this.ctx.storage.sql.exec(
-				`UPDATE runs
-				SET status = 'error',
-					finished_at = ?,
-					duration_ms = ?,
-					error_name = ?,
-					error_message = ?,
-					updated_at = ?
-				WHERE id = ? AND status = 'running'`,
+		let reconciled = 0
+		for (const row of candidates) {
+			if (
+				!this.isStaleRunning({
+					surface: row.surface,
+					startedAt: row.started_at,
+					nowMs,
+				})
+			) {
+				continue
+			}
+			this.markRunningInterrupted({
+				id: row.id,
+				startedAt: row.started_at,
 				finishedAt,
-				durationMs,
-				staleRunningErrorName,
-				staleRunningErrorMessage,
-				finishedAt,
-				row.id,
-			)
+			})
+			reconciled += 1
 		}
-		return stale.length
+		return reconciled
+	}
+
+	/**
+	 * Heal one still-`running` row when a reader observes it past its surface
+	 * TTL. Keeps Activity / keyed-execute recovery honest even when the DO
+	 * alarm has not fired yet (unvisited objects, sticky armed alarms).
+	 */
+	private healStaleRunningRecord(run: RunRecord): RunRecord {
+		if (run.status !== 'running') return run
+		if (
+			!this.isStaleRunning({
+				surface: run.surface,
+				startedAt: run.startedAt,
+			})
+		) {
+			return run
+		}
+		this.markRunningInterrupted({
+			id: run.id,
+			startedAt: run.startedAt,
+		})
+		this.retentionIdleConfirmed = false
+		const healed = this.ctx.storage.sql
+			.exec<Record<string, SqlStorageValue>>(
+				`SELECT r.*,
+					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
+				FROM runs r
+				WHERE r.id = ?
+				LIMIT 1`,
+				run.id,
+			)
+			.toArray()[0]
+		if (!healed) return run
+		return mapRunRow(healed, Number(healed['log_count'] ?? 0) || 0)
 	}
 
 	private deleteOldestWithStatus(status: RunStatus, limit: number) {
@@ -618,17 +694,19 @@ class RunLogBase extends DurableObject<Env> {
 			consider(Date.parse(oldestFinished.started_at) + retentionMs)
 		}
 
-		const oldestRunning = this.ctx.storage.sql
-			.exec<{ started_at: string }>(
-				`SELECT started_at FROM runs
-				WHERE status = 'running'
-				ORDER BY started_at ASC
-				LIMIT 1`,
+		// Soonest stale due-time can belong to a newer short-lived surface
+		// (execute) even when an older long-lived service/job row exists.
+		const runningRows = this.ctx.storage.sql
+			.exec<{ started_at: string; surface: string }>(
+				`SELECT started_at, surface FROM runs
+				WHERE status = 'running'`,
 			)
-			.toArray()[0]
-		if (oldestRunning) {
+			.toArray()
+		for (const row of runningRows) {
+			const surface = isRunSurface(row.surface) ? row.surface : 'execute'
 			consider(
-				Date.parse(oldestRunning.started_at) + runRecordStaleRunningTtlMs,
+				Date.parse(row.started_at) +
+					runRecordStaleRunningTtlMsForSurface(surface),
 			)
 		}
 
@@ -750,7 +828,14 @@ class RunLogBase extends DurableObject<Env> {
 				surface: input.run.surface,
 			})
 			if (existing) {
-				return { claimed: false, run: existing }
+				// Heal stranded `running` owners before refusing the claim so a
+				// keyed retry after an isolate death is not stuck on inProgress
+				// forever. Terminal rows (including reconciled Interrupted)
+				// still own the key for replay.
+				return {
+					claimed: false,
+					run: this.healStaleRunningRecord(existing),
+				}
 			}
 		}
 		this.insertRunningRun(input.run)
@@ -792,10 +877,12 @@ class RunLogBase extends DurableObject<Env> {
 	}): Promise<RunRecord | null> {
 		const key = input.idempotencyKey.trim()
 		if (!key) return null
-		return this.findRunByIdempotencyKey({
+		const existing = this.findRunByIdempotencyKey({
 			idempotencyKey: key,
 			surface: input.surface ?? null,
 		})
+		if (!existing) return null
+		return this.healStaleRunningRecord(existing)
 	}
 
 	/**
@@ -840,6 +927,9 @@ class RunLogBase extends DurableObject<Env> {
 	}
 
 	async listRuns(input: ListRunsInput): Promise<RunRecordPage> {
+		// Heal before listing so `status=running` filters and Activity views
+		// do not keep advertising stranded rows past their surface TTL.
+		this.reconcileStaleRunning()
 		const limit = normalizePageSize(input.limit, runRecordDefaultPageSize)
 		const clauses: Array<string> = ['1 = 1']
 		const params: Array<SqlStorageValue> = []
@@ -916,6 +1006,9 @@ class RunLogBase extends DurableObject<Env> {
 			)
 			.toArray()[0]
 		if (!row) return null
+		const run = this.healStaleRunningRecord(
+			mapRunRow(row, Number(row['log_count'] ?? 0) || 0),
+		)
 		const logs = this.ctx.storage.sql
 			.exec<Record<string, SqlStorageValue>>(
 				`SELECT * FROM run_logs WHERE run_id = ? ORDER BY sequence ASC`,
@@ -924,12 +1017,13 @@ class RunLogBase extends DurableObject<Env> {
 			.toArray()
 			.map(mapLogRow)
 		return {
-			run: mapRunRow(row, Number(row['log_count'] ?? 0) || 0),
+			run,
 			logs,
 		}
 	}
 
 	async summarize(input: { since: string }): Promise<RunRecordSummary> {
+		this.reconcileStaleRunning()
 		const since = input.since
 		const totals = this.ctx.storage.sql
 			.exec<{ total: number; errors: number; running: number }>(

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -556,6 +556,9 @@ class RunLogBase extends DurableObject<Env> {
 			finishedAt,
 			input.id,
 		)
+		// Row became terminal: age-prune now applies, so any prior idle
+		// conclusion is stale (covers reconcile + heal-on-read callers).
+		this.retentionIdleConfirmed = false
 	}
 
 	/**
@@ -639,7 +642,6 @@ class RunLogBase extends DurableObject<Env> {
 			id: run.id,
 			startedAt: run.startedAt,
 		})
-		this.retentionIdleConfirmed = false
 		const healed = this.ctx.storage.sql
 			.exec<Record<string, SqlStorageValue>>(
 				`SELECT r.*,
@@ -710,13 +712,15 @@ class RunLogBase extends DurableObject<Env> {
 
 		// Soonest stale due-time can belong to a newer short-lived surface
 		// (execute) even when an older long-lived service/job row exists.
-		const runningRows = this.ctx.storage.sql
-			.exec<{ started_at: string; surface: string }>(
-				`SELECT started_at, surface FROM runs
-				WHERE status = 'running'`,
+		// Only the earliest row per surface can produce that due-time.
+		const oldestRunningPerSurface = this.ctx.storage.sql
+			.exec<{ surface: string; started_at: string }>(
+				`SELECT surface, MIN(started_at) AS started_at FROM runs
+				WHERE status = 'running'
+				GROUP BY surface`,
 			)
 			.toArray()
-		for (const row of runningRows) {
+		for (const row of oldestRunningPerSurface) {
 			const surface = isRunSurface(row.surface) ? row.surface : 'execute'
 			consider(
 				Date.parse(row.started_at) +

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -27,7 +27,8 @@ import {
 	runRecordMaxRunsPerUser,
 	runRecordRetentionDays,
 	runRecordRetentionEveryNFinishes,
-	runRecordStaleRunningTtlMs,
+	runRecordStaleRunningTtlMsJob,
+	runRecordStaleRunningTtlMsShortLived,
 	type RunRecordContext,
 	type RunRecordHandle,
 	type RunSurface,
@@ -576,7 +577,7 @@ test('cap and stale retention journey', async () => {
 		const userId = uniqueUserId('stale-running')
 		const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
 		const staleStartedAt = new Date(
-			Date.now() - runRecordStaleRunningTtlMs - 60_000,
+			Date.now() - runRecordStaleRunningTtlMsJob - 60_000,
 		).toISOString()
 		const freshStartedAt = new Date().toISOString()
 		await runInDurableObject(stub, async (instance: RunLog, state) => {
@@ -616,13 +617,40 @@ test('cap and stale retention journey', async () => {
 		expect(fresh?.run.finishedAt).toBeNull()
 	}
 
+	// --- execute-surface stale rows heal on read within minutes, not 24h ---
+	{
+		const userId = uniqueUserId('stale-execute-heal')
+		const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
+		const staleStartedAt = new Date(
+			Date.now() - runRecordStaleRunningTtlMsShortLived - 1_000,
+		).toISOString()
+		await runInDurableObject(stub, async (instance: RunLog, state) => {
+			expect(instance).toBeInstanceOf(RunLog)
+			insertRunRow(state, {
+				id: 'stale-execute',
+				status: 'running',
+				startedAt: staleStartedAt,
+				finishedAt: null,
+				surface: 'execute',
+			})
+		})
+		const healed = await getRunRecord({
+			env,
+			userId,
+			runId: 'stale-execute',
+		})
+		expect(healed?.run.status).toBe('error')
+		expect(healed?.run.errorName).toBe('Interrupted')
+		expect(healed?.run.surface).toBe('execute')
+	}
+
 	// --- stale rows become cap-evictable after reconcile ---
 	{
 		const userId = uniqueUserId('stale-cap-evict')
 		const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
 		const baseMs = Date.now() - 3_600_000
 		const staleStartedAt = new Date(
-			Date.now() - runRecordStaleRunningTtlMs - 60_000,
+			Date.now() - runRecordStaleRunningTtlMsJob - 60_000,
 		).toISOString()
 		const successCount = 2
 		const errorCount = runRecordMaxRunsPerUser - 2

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -236,10 +236,52 @@ export const runRecordMaxPageSize = 100
 export const runRecordRetentionEveryNFinishes = 32
 
 /**
- * `running` rows older than this are marked terminal with outcome-unknown.
- * History only — live service/job state lives on entity rows, not here.
+ * Default / longest stale-`running` TTL (service + workflow). Prefer
+ * {@link runRecordStaleRunningTtlMsForSurface} so short-lived surfaces heal
+ * in minutes instead of a day.
  */
 export const runRecordStaleRunningTtlMs = 24 * 60 * 60 * 1000
+
+/**
+ * Execute / export / similar sandbox surfaces default to a 90s host timeout.
+ * Keep this TTL a small multiple of that budget so stranded `running` rows
+ * (isolate reset, lost `waitUntil` finish, hung evaluate) self-heal soon
+ * enough for Activity and keyed-execute recovery, without waiting 24h.
+ */
+export const runRecordStaleRunningTtlMsShortLived = 3 * 60 * 1000
+
+/** Jobs can run longer than a single sandbox invoke; still bound the history row. */
+export const runRecordStaleRunningTtlMsJob = 6 * 60 * 60 * 1000
+
+/**
+ * Surface-aware stale-`running` TTL. Persistent services and workflows keep the
+ * long default; sandbox-backed surfaces heal after a few minutes.
+ *
+ * History only — live service/job state lives on entity rows, not here.
+ */
+export function runRecordStaleRunningTtlMsForSurface(
+	surface: RunSurface,
+): number {
+	switch (surface) {
+		case 'execute':
+		case 'export':
+		case 'retriever':
+		case 'webhook':
+		case 'subscription':
+		case 'app_fetch':
+		case 'app_realtime':
+			return runRecordStaleRunningTtlMsShortLived
+		case 'job':
+			return runRecordStaleRunningTtlMsJob
+		case 'workflow':
+		case 'service':
+			return runRecordStaleRunningTtlMs
+		default: {
+			const exhaustive: never = surface
+			throw new Error(`Unhandled run surface: ${String(exhaustive)}`)
+		}
+	}
+}
 
 /** How often the DO alarm re-runs retention when the object is otherwise idle. */
 export const runRecordRetentionAlarmMs = 60 * 60 * 1000


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production execute calls can stay stuck far past the ~90s sandbox timeout, and keyed / eager run records can remain `status=running` for hours (example: `306bd2fe-f46b-4359-823d-1589d2be0dbd`, still running 5+ hours later; 47+ stranded execute rows for one user on 2026-07-30).

### Root cause (runtime evidence)

1. **Sandbox timeout is inside the dynamic worker only.** `Promise.race` + `setTimeout` in the Loader-evaluated module never helps if `evaluate()` never returns / never starts. There was **no host-side deadline** around permit wait + `entrypoint.evaluate()`.
2. **Stranded `running` heal was effectively 24h + alarm-dependent.** PR #1001 recovers client MCP timeouts via `idempotencyKey` replay/`inProgress`, but does **not** mark timed-out/killed sandboxes terminal. Production still had dozens of execute rows `running` for hours; p99 execute duration has been pegged at ~90 017–90 054 ms on several days since Jul 24 (`kody_usage_events`), while stranded rows never emit a usage point at all.
3. **Outbound `KodyFetchGateway` had no default timeout**, so a hung upstream fetch could hold sandbox work until the host/request died.

Live checks (pre-deploy): stuck run still `running` at ~312 min; identical discord static import retry completed in ~2 s with success.

### Fix

- **Host-side evaluation deadline** racing Worker Loader `evaluate` (+ permit queue) with the same `Execution timed out` outcome so finish paths can write a terminal row. Permit waiters share an `AbortSignal` so timed-out queued evaluations are removed and cannot start after execute returns.
- **60s default outbound fetch deadline** on the fetch gateway (`AbortSignal.timeout`, combined with any caller signal).
- **Surface-aware stale-`running` TTLs** (≈3 min for execute/export/webhook/…, 6 h jobs, 24 h service/workflow) with **heal-on-read** (`getRun`, keyed lookup, `listRuns`, `summarize`) and SQL that selects by surface cutoff so long-lived jobs cannot starve short-lived execute heals.

### Validation

- `npm run validate` green
- Focused unit tests for host deadline, queued-permit cancel, fetch abort, and execute-surface heal-on-read
- Live MCP: stuck-run inspection + successful discord import timing probe
- CI Validate + Preview green; review feedback addressed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `05e1f2f5` · **Head:** `493bb61e`

**Classification:** extends — host-side execute deadline, outbound fetch timeout, and surface-aware run-record stale heal change runtime/storage contracts without new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — host evaluation deadline + 60s outbound fetch timeout |
| `run-records` | storage | extends — surface-aware stale-`running` TTL + heal-on-read |

### System map

Hung execute evaluations are bounded on the host; stranded keyed/`eager` running rows self-heal on read and retention with shorter execute TTLs.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	runRecords["run-records<br/>Run records"]:::extended
	mcpServer -->|"host evaluate deadline + fetch AbortSignal.timeout"| mcpServer
	mcpServer -->|"finish / claim / run_get"| runRecords
	runRecords -->|"3m execute stale heal-on-read"| runRecords
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bea88227-5232-42c8-a224-3b28d6e1ded2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bea88227-5232-42c8-a224-3b28d6e1ded2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Outbound requests now stop automatically when they exceed the configured timeout, preventing indefinitely hanging executions.
  - Stalled executions are now detected and converted into clear **Interrupted** outcomes instead of remaining “in progress” indefinitely.
  - Recovery applies during status checks, lookups, listings, summaries, and retries using the same key.

- **Documentation**
  - Added guidance explaining recovery from client timeouts and stranded keyed executions.
  - Clarified how stale execution records are reconciled and retained across execution types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->