### PR TITLE
Cut ~1.5s cold-isolate first kody.* dispatch by slim job inspect path

### DIFF
--- a/packages/worker/src/app/account-jobs-data.ts
+++ b/packages/worker/src/app/account-jobs-data.ts
@@ -9,7 +9,7 @@ import {
 	type JobRetentionPreferences,
 } from '#worker/jobs/job-retention.ts'
 import { readJobRetentionPreferencesForUser } from '#worker/jobs/job-retention-cleanup.ts'
-import { inspectJobsForUser } from '#worker/jobs/service.ts'
+import { inspectJobsForUser } from '#worker/jobs/inspect.ts'
 import { type JobSchedule, type JobView } from '#worker/jobs/types.ts'
 import { listRunRecords } from '#worker/run-records/service.ts'
 

--- a/packages/worker/src/app/handlers/account-jobs.node.test.ts
+++ b/packages/worker/src/app/handlers/account-jobs.node.test.ts
@@ -122,9 +122,12 @@ vi.mock('#worker/app-base-url.ts', () => ({
 	getAppBaseUrl: (...args: Array<unknown>) => mockModule.getAppBaseUrl(...args),
 }))
 
-vi.mock('#worker/jobs/service.ts', () => ({
+vi.mock('#worker/jobs/inspect.ts', () => ({
 	inspectJobsForUser: (...args: Array<unknown>) =>
 		mockModule.inspectJobsForUser(...args),
+}))
+
+vi.mock('#worker/jobs/service.ts', () => ({
 	updateJob: (...args: Array<unknown>) => mockModule.updateJob(...args),
 	deleteJob: (...args: Array<unknown>) => mockModule.deleteJob(...args),
 }))

--- a/packages/worker/src/jobs/inspect-published-source.ts
+++ b/packages/worker/src/jobs/inspect-published-source.ts
@@ -1,0 +1,136 @@
+import {
+	normalizePackageWorkspacePath,
+	parseAuthoredPackageJson,
+} from '#worker/package-registry/manifest.ts'
+import {
+	loadPublishedEntitySource,
+	type PublishedEntitySource,
+} from '#worker/repo/published-source.ts'
+import {
+	getManifestEntrypointPath,
+	parseRepoManifest,
+} from '#worker/repo/manifest.ts'
+import { formatJobError } from './schedule.ts'
+import {
+	type JobRecord,
+	type JobSourceInspection,
+	type JobView,
+} from './types.ts'
+
+export type PublishedJobSourceResolution = {
+	source: NonNullable<PublishedEntitySource['source']>
+	files: Record<string, string>
+	artifactName: string
+	entryPoint: string
+	emittedEventTopics: Array<string>
+	packageContext: {
+		packageId: string
+		kodyId: string
+		sourceId: string
+	} | null
+}
+
+export async function resolvePublishedJobSource(input: {
+	env: Env
+	userId: string
+	job: Pick<JobRecord, 'id' | 'name' | 'sourceId'>
+}): Promise<PublishedJobSourceResolution> {
+	if (!input.job.sourceId) {
+		throw new Error('Repo-backed job source is missing.')
+	}
+	const published = await loadPublishedEntitySource({
+		env: input.env,
+		userId: input.userId,
+		sourceId: input.job.sourceId,
+	})
+	const publishedSource = published.source
+	if (!publishedSource) {
+		throw new Error(`Published source "${input.job.sourceId}" was not found.`)
+	}
+	const manifestPath = publishedSource.manifest_path.replace(/^\/+/, '')
+	const manifestContent = published.files[manifestPath]
+	if (!manifestContent) {
+		throw new Error(`Job manifest "${manifestPath}" was not found.`)
+	}
+	const artifactName =
+		publishedSource.entity_kind === 'package' ? input.job.name : input.job.id
+	if (manifestPath === 'kody.json' || publishedSource.entity_kind === 'job') {
+		const manifest = parseRepoManifest({
+			content: manifestContent,
+			manifestPath,
+		})
+		if (manifest.kind !== 'job') {
+			throw new Error(
+				`Repo source "${input.job.sourceId}" is not a job manifest.`,
+			)
+		}
+		return {
+			source: publishedSource,
+			files: published.files,
+			artifactName,
+			entryPoint: getManifestEntrypointPath(manifest),
+			emittedEventTopics: [],
+			packageContext: null,
+		}
+	}
+
+	const manifest = parseAuthoredPackageJson({
+		content: manifestContent,
+		manifestPath,
+	})
+	const jobDefinition = manifest.kody.jobs?.[input.job.name]
+	if (!jobDefinition) {
+		throw new Error(
+			`Package "${manifest.kody.id}" does not define job "${input.job.name}".`,
+		)
+	}
+	return {
+		source: publishedSource,
+		files: published.files,
+		artifactName,
+		entryPoint: normalizePackageWorkspacePath(jobDefinition.entry),
+		emittedEventTopics: Object.keys(manifest.kody.emits ?? {}),
+		packageContext: {
+			packageId: publishedSource.entity_id,
+			kodyId: manifest.kody.id,
+			sourceId: input.job.sourceId,
+		},
+	}
+}
+
+function buildJobSourceInspectionError(error: unknown): JobSourceInspection {
+	return {
+		entrypoint: null,
+		code: null,
+		error: formatJobError(error),
+	}
+}
+
+export async function inspectPublishedJobSource(input: {
+	env: Env
+	userId: string
+	job: JobView
+}): Promise<JobSourceInspection> {
+	try {
+		const resolved = await resolvePublishedJobSource({
+			env: input.env,
+			userId: input.userId,
+			job: input.job,
+		})
+		const code = resolved.files[resolved.entryPoint]
+		if (typeof code !== 'string') {
+			return {
+				entrypoint: resolved.entryPoint,
+				code: null,
+				error: `Job entrypoint "${resolved.entryPoint}" was not found.`,
+			}
+		}
+		return {
+			entrypoint: resolved.entryPoint,
+			code,
+			error: null,
+		}
+	} catch (error) {
+		return buildJobSourceInspectionError(error)
+	}
+}

--- a/packages/worker/src/jobs/inspect.node.test.ts
+++ b/packages/worker/src/jobs/inspect.node.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+function importSpecs(source: string) {
+	return [
+		...source.matchAll(/(?:from|import)\s*\(?\s*['"]([^'"]+)['"]\s*\)?/g),
+	].map((match) => match[1])
+}
+
+test('job inspect module stays off the job execution import graph', () => {
+	const source = readFileSync(join(here, 'inspect.ts'), 'utf8')
+	const specs = importSpecs(source)
+	expect(specs).not.toEqual(
+		expect.arrayContaining([
+			expect.stringMatching(/run-kody-registry/),
+			expect.stringMatching(/jobs\/service/),
+			expect.stringMatching(/module-graph/),
+			expect.stringMatching(/entitlements\/service/),
+		]),
+	)
+	expect(specs).toContain('./manager-client.ts')
+	expect(specs).toContain('./repo.ts')
+})
+
+test('job_list capability statically imports slim inspect, not service', () => {
+	const source = readFileSync(
+		join(here, '../mcp/capabilities/jobs/job-list.ts'),
+		'utf8',
+	)
+	const specs = importSpecs(source)
+	expect(specs).toContain('#worker/jobs/inspect.ts')
+	expect(specs).not.toEqual(
+		expect.arrayContaining([expect.stringMatching(/jobs\/service/)]),
+	)
+	expect(source).not.toMatch(/await import\s*\(/)
+})
+
+test('job_get capability statically imports slim inspect, not service', () => {
+	const source = readFileSync(
+		join(here, '../mcp/capabilities/jobs/job-get.ts'),
+		'utf8',
+	)
+	const specs = importSpecs(source)
+	expect(specs).toContain('#worker/jobs/inspect.ts')
+	expect(specs).not.toEqual(
+		expect.arrayContaining([expect.stringMatching(/jobs\/service/)]),
+	)
+})

--- a/packages/worker/src/jobs/inspect.ts
+++ b/packages/worker/src/jobs/inspect.ts
@@ -1,0 +1,92 @@
+import { McpCallerError } from '#mcp/caller-error.ts'
+import {
+	getJobManagerDebugState,
+	type JobManagerDebugState,
+} from './manager-client.ts'
+import { getJobRowById, listJobRowsByUserId } from './repo.ts'
+import { toJobView } from './schedule.ts'
+import { type JobSourceInspection, type JobView } from './types.ts'
+
+/**
+ * Read-side job inspection helpers for capability/UI list+get paths.
+ *
+ * Kept separate from `service.ts` so `job_list` / `job_get` do not lazy-load the
+ * job execution graph (`run-kody-registry`, bundler, entitlements, …) on the
+ * first cold-isolate capability dispatch.
+ */
+export async function listJobs(input: { env: Env; userId: string }) {
+	const rows = await listJobRowsByUserId(input.env.APP_DB, input.userId)
+	return rows.map((row) => toJobView(row.record))
+}
+
+export async function getJob(input: {
+	env: Env
+	userId: string
+	jobId: string
+}) {
+	const row = await getJobRowById(input.env.APP_DB, input.userId, input.jobId)
+	if (!row) {
+		// Caller-supplied job id that does not resolve for this user — keep it
+		// off Sentry via McpCallerError (agent typos / stale ids are routine).
+		throw new McpCallerError(`Job "${input.jobId}" was not found.`)
+	}
+	return toJobView(row.record)
+}
+
+export async function inspectJobsForUser(input: {
+	env: Env
+	userId: string
+}): Promise<{
+	jobs: Array<JobView>
+	alarm: JobManagerDebugState
+}> {
+	const [jobs, alarm] = await Promise.all([
+		listJobs(input),
+		getJobManagerDebugState({
+			env: input.env,
+			userId: input.userId,
+		}),
+	])
+	return {
+		jobs,
+		alarm,
+	}
+}
+
+export async function getJobInspection(input: {
+	env: Env
+	userId: string
+	jobId: string
+	includeCode?: boolean
+}): Promise<{
+	job: JobView
+	alarm: JobManagerDebugState
+	source?: JobSourceInspection
+}> {
+	const [job, alarm] = await Promise.all([
+		getJob(input),
+		getJobManagerDebugState({
+			env: input.env,
+			userId: input.userId,
+		}),
+	])
+	if (!input.includeCode) {
+		return {
+			job,
+			alarm,
+		}
+	}
+	// Rare path: pay for published-source resolution only when code is requested.
+	const { inspectPublishedJobSource } =
+		await import('./inspect-published-source.ts')
+	const source = await inspectPublishedJobSource({
+		env: input.env,
+		userId: input.userId,
+		job,
+	})
+	return {
+		job,
+		alarm,
+		source,
+	}
+}

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -14,10 +14,7 @@ import {
 } from '#worker/run-records/service.ts'
 import { type RunRecordHandle } from '#worker/run-records/types.ts'
 import { applyExecutionOutcome, processDueJobs } from './process-due-jobs.ts'
-import {
-	getJobManagerDebugState,
-	syncJobManagerAlarm,
-} from './manager-client.ts'
+import { syncJobManagerAlarm } from './manager-client.ts'
 import {
 	deleteJobRow,
 	claimJobRow,
@@ -52,7 +49,6 @@ import {
 	type JobExecutionResult,
 	type JobRepoCheckPolicy,
 	type JobRecord,
-	type JobSourceInspection,
 	type JobUpdateInput,
 	type JobView,
 	type PersistedJobCallerContext,
@@ -66,10 +62,6 @@ import {
 	parseAuthoredPackageJson,
 } from '#worker/package-registry/manifest.ts'
 import { hasTopLevelDefaultExport } from '#worker/module-source.ts'
-import {
-	getManifestEntrypointPath,
-	parseRepoManifest,
-} from '#worker/repo/manifest.ts'
 import { typecheckPackageEntrypointsFromSourceFiles } from '#worker/repo/checks.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { buildJobSourceFiles } from '#worker/repo/source-templates.ts'
@@ -83,14 +75,17 @@ import {
 import { cleanupArtifactReposForSource } from '#worker/repo/artifact-repo-cleanup.ts'
 import { deleteRepoSessionsBySourceForUser } from '#worker/repo/repo-sessions.ts'
 import {
-	loadPublishedEntitySource,
-	type PublishedEntitySource,
-} from '#worker/repo/published-source.ts'
-import {
 	deletePublishedArtifactsForSource,
 	loadPublishedBundleArtifactByIdentity,
 	persistPublishedBundleArtifact,
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { resolvePublishedJobSource } from './inspect-published-source.ts'
+import {
+	getJob,
+	getJobInspection,
+	inspectJobsForUser,
+	listJobs,
+} from './inspect.ts'
 import {
 	deleteArchivedJobArtifact,
 	listArchivedJobArtifactsDueBefore,
@@ -105,6 +100,8 @@ import {
 	schedulerErrorFields,
 	type SchedulerJobOutcomeLog,
 } from './scheduler-logging.ts'
+
+export { getJob, getJobInspection, inspectJobsForUser, listJobs }
 
 function requirePersistableJobCallerContext(
 	callerContext: McpCallerContext,
@@ -269,87 +266,6 @@ function isPublishedJobBundleCurrent(input: {
 	)
 }
 
-type PublishedJobSourceResolution = {
-	source: NonNullable<PublishedEntitySource['source']>
-	files: Record<string, string>
-	artifactName: string
-	entryPoint: string
-	emittedEventTopics: Array<string>
-	packageContext: {
-		packageId: string
-		kodyId: string
-		sourceId: string
-	} | null
-}
-
-async function resolvePublishedJobSource(input: {
-	env: Env
-	userId: string
-	job: Pick<JobRecord, 'id' | 'name' | 'sourceId'>
-}): Promise<PublishedJobSourceResolution> {
-	if (!input.job.sourceId) {
-		throw new Error('Repo-backed job source is missing.')
-	}
-	const published = await loadPublishedEntitySource({
-		env: input.env,
-		userId: input.userId,
-		sourceId: input.job.sourceId,
-	})
-	const publishedSource = published.source
-	if (!publishedSource) {
-		throw new Error(`Published source "${input.job.sourceId}" was not found.`)
-	}
-	const manifestPath = publishedSource.manifest_path.replace(/^\/+/, '')
-	const manifestContent = published.files[manifestPath]
-	if (!manifestContent) {
-		throw new Error(`Job manifest "${manifestPath}" was not found.`)
-	}
-	const artifactName =
-		publishedSource.entity_kind === 'package' ? input.job.name : input.job.id
-	if (manifestPath === 'kody.json' || publishedSource.entity_kind === 'job') {
-		const manifest = parseRepoManifest({
-			content: manifestContent,
-			manifestPath,
-		})
-		if (manifest.kind !== 'job') {
-			throw new Error(
-				`Repo source "${input.job.sourceId}" is not a job manifest.`,
-			)
-		}
-		return {
-			source: publishedSource,
-			files: published.files,
-			artifactName,
-			entryPoint: getManifestEntrypointPath(manifest),
-			emittedEventTopics: [],
-			packageContext: null,
-		}
-	}
-
-	const manifest = parseAuthoredPackageJson({
-		content: manifestContent,
-		manifestPath,
-	})
-	const jobDefinition = manifest.kody.jobs?.[input.job.name]
-	if (!jobDefinition) {
-		throw new Error(
-			`Package "${manifest.kody.id}" does not define job "${input.job.name}".`,
-		)
-	}
-	return {
-		source: publishedSource,
-		files: published.files,
-		artifactName,
-		entryPoint: normalizePackageWorkspacePath(jobDefinition.entry),
-		emittedEventTopics: Object.keys(manifest.kody.emits ?? {}),
-		packageContext: {
-			packageId: publishedSource.entity_id,
-			kodyId: manifest.kody.id,
-			sourceId: input.job.sourceId,
-		},
-	}
-}
-
 async function ensurePublishedBundleArtifactForJob(input: {
 	env: Env
 	job: JobRecord
@@ -434,43 +350,6 @@ async function ensurePublishedBundleArtifactForJob(input: {
 		)
 	}
 	return loadedArtifact.artifact
-}
-
-function buildJobSourceInspectionError(error: unknown): JobSourceInspection {
-	return {
-		entrypoint: null,
-		code: null,
-		error: formatJobError(error),
-	}
-}
-
-async function inspectPublishedJobSource(input: {
-	env: Env
-	userId: string
-	job: JobView
-}): Promise<JobSourceInspection> {
-	try {
-		const resolved = await resolvePublishedJobSource({
-			env: input.env,
-			userId: input.userId,
-			job: input.job,
-		})
-		const code = resolved.files[resolved.entryPoint]
-		if (typeof code !== 'string') {
-			return {
-				entrypoint: resolved.entryPoint,
-				code: null,
-				error: `Job entrypoint "${resolved.entryPoint}" was not found.`,
-			}
-		}
-		return {
-			entrypoint: resolved.entryPoint,
-			code,
-			error: null,
-		}
-	} catch (error) {
-		return buildJobSourceInspectionError(error)
-	}
 }
 
 async function rebuildAndExecuteJobArtifact(input: {
@@ -1061,66 +940,6 @@ export async function createJob(input: {
 			return toJobView(job)
 		},
 	})
-}
-
-export async function listJobs(input: { env: Env; userId: string }) {
-	const rows = await listJobRowsByUserId(input.env.APP_DB, input.userId)
-	return rows.map((row) => toJobView(row.record))
-}
-
-export async function getJob(input: {
-	env: Env
-	userId: string
-	jobId: string
-}) {
-	const row = await getJobRowById(input.env.APP_DB, input.userId, input.jobId)
-	if (!row) {
-		// Caller-supplied job id that does not resolve for this user — keep it
-		// off Sentry via McpCallerError (agent typos / stale ids are routine).
-		throw new McpCallerError(`Job "${input.jobId}" was not found.`)
-	}
-	return toJobView(row.record)
-}
-
-export async function inspectJobsForUser(input: { env: Env; userId: string }) {
-	const [jobs, alarm] = await Promise.all([
-		listJobs(input),
-		getJobManagerDebugState({
-			env: input.env,
-			userId: input.userId,
-		}),
-	])
-	return {
-		jobs,
-		alarm,
-	}
-}
-
-export async function getJobInspection(input: {
-	env: Env
-	userId: string
-	jobId: string
-	includeCode?: boolean
-}) {
-	const [job, alarm] = await Promise.all([
-		getJob(input),
-		getJobManagerDebugState({
-			env: input.env,
-			userId: input.userId,
-		}),
-	])
-	const source = input.includeCode
-		? await inspectPublishedJobSource({
-				env: input.env,
-				userId: input.userId,
-				job,
-			})
-		: undefined
-	return {
-		job,
-		alarm,
-		...(source ? { source } : {}),
-	}
 }
 
 export async function updateJob(input: {

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -50,7 +50,6 @@ import {
 	type JobRepoCheckPolicy,
 	type JobRecord,
 	type JobUpdateInput,
-	type JobView,
 	type PersistedJobCallerContext,
 } from './types.ts'
 import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'

--- a/packages/worker/src/mcp/capabilities/jobs/job-get.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-get.ts
@@ -1,6 +1,7 @@
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { getJobInspection } from '#worker/jobs/inspect.ts'
 import { listRunRecords } from '#worker/run-records/service.ts'
 import {
 	buildJobInspectionOutput,
@@ -35,7 +36,6 @@ export const jobGetCapability = defineDomainCapability(
 		outputSchema: jobGetOutputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
-			const { getJobInspection } = await import('#worker/jobs/service.ts')
 			const jobId = resolveJobGetId(args)
 			const inspection = await getJobInspection({
 				env: ctx.env,

--- a/packages/worker/src/mcp/capabilities/jobs/job-list.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-list.ts
@@ -2,6 +2,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import { inspectJobsForUser } from '#worker/jobs/inspect.ts'
 import {
 	buildJobInspectionOutput,
 	buildJobManagerDebugOutput,
@@ -30,7 +31,6 @@ export const jobListCapability = defineDomainCapability(
 		outputSchema: jobListOutputSchema,
 		async handler(_args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
-			const { inspectJobsForUser } = await import('#worker/jobs/service.ts')
 			const inspection = await inspectJobsForUser({
 				env: ctx.env,
 				userId: user.userId,

--- a/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/job-schedule.node.test.ts
@@ -15,11 +15,14 @@ const mockModule = vi.hoisted(() => ({
 vi.mock('#worker/jobs/service.ts', () => ({
 	createJob: (...args: Array<unknown>) => mockModule.createJob(...args),
 	deleteJob: (...args: Array<unknown>) => mockModule.deleteJob(...args),
+	updateJob: (...args: Array<unknown>) => mockModule.updateJob(...args),
+}))
+
+vi.mock('#worker/jobs/inspect.ts', () => ({
 	getJobInspection: (...args: Array<unknown>) =>
 		mockModule.getJobInspection(...args),
 	inspectJobsForUser: (...args: Array<unknown>) =>
 		mockModule.inspectJobsForUser(...args),
-	updateJob: (...args: Array<unknown>) => mockModule.updateJob(...args),
 }))
 
 vi.mock('#worker/jobs/manager-client.ts', () => ({

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -110,6 +110,10 @@ export type PackageContextOptions = {
 	sourceId?: string | null
 } | null
 
+/** Once per isolate: sample the first kody.* capability RPC wall time. */
+let firstCapabilityDispatchSampled = false
+const firstCapabilityDispatchWarnMs = 250
+
 function isPackageSecretAvailabilityError(error: unknown) {
 	return (
 		error instanceof Error &&
@@ -255,6 +259,13 @@ async function buildKodyToolContext(
 		Object.entries(capabilityMap).map(([capabilityName, capability]) => [
 			capabilityName,
 			async (args: unknown) => {
+				// First capability RPC in a cold isolate often pays for lazy module
+				// graphs behind handlers; log once so regressions stay visible.
+				const shouldSampleFirstDispatch = !firstCapabilityDispatchSampled
+				const dispatchStartedAtMs = shouldSampleFirstDispatch ? Date.now() : 0
+				if (shouldSampleFirstDispatch) {
+					firstCapabilityDispatchSampled = true
+				}
 				await assertCallerCanAccessCapability(callerContext, capability, {
 					env,
 				})
@@ -276,10 +287,25 @@ async function buildKodyToolContext(
 					value: resolvedArgs,
 					track: options?.trackSecretInputValue,
 				})
-				return capability.handler(resolvedArgs as Record<string, unknown>, {
-					env,
-					callerContext,
-				})
+				try {
+					return await capability.handler(
+						resolvedArgs as Record<string, unknown>,
+						{
+							env,
+							callerContext,
+						},
+					)
+				} finally {
+					if (shouldSampleFirstDispatch) {
+						const durationMs = Date.now() - dispatchStartedAtMs
+						if (durationMs >= firstCapabilityDispatchWarnMs) {
+							console.warn('kody-first-capability-dispatch-slow', {
+								capabilityName,
+								durationMs,
+							})
+						}
+					}
+				}
 			},
 		]),
 	) as AdditionalKodyTools

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -266,28 +266,28 @@ async function buildKodyToolContext(
 				if (shouldSampleFirstDispatch) {
 					firstCapabilityDispatchSampled = true
 				}
-				await assertCallerCanAccessCapability(callerContext, capability, {
-					env,
-				})
-				const resolveSecretValue =
-					options?.resolveSecretValue ??
-					createCapabilityInputSecretResolver(
-						env,
-						callerContext,
-						capabilityName,
-					)
-				const resolvedArgs = await resolveCapabilityInputSecrets({
-					schema: capability.inputSchema,
-					value: (args ?? {}) as Record<string, unknown>,
-					resolveSecretValue: (secret) =>
-						resolveSecretValue(secret, capabilityName),
-				})
-				collectSecretInputValues({
-					schema: capability.inputSchema,
-					value: resolvedArgs,
-					track: options?.trackSecretInputValue,
-				})
 				try {
+					await assertCallerCanAccessCapability(callerContext, capability, {
+						env,
+					})
+					const resolveSecretValue =
+						options?.resolveSecretValue ??
+						createCapabilityInputSecretResolver(
+							env,
+							callerContext,
+							capabilityName,
+						)
+					const resolvedArgs = await resolveCapabilityInputSecrets({
+						schema: capability.inputSchema,
+						value: (args ?? {}) as Record<string, unknown>,
+						resolveSecretValue: (secret) =>
+							resolveSecretValue(secret, capabilityName),
+					})
+					collectSecretInputValues({
+						schema: capability.inputSchema,
+						value: resolvedArgs,
+						track: options?.trackSecretInputValue,
+					})
 					return await capability.handler(
 						resolvedArgs as Record<string, unknown>,
 						{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production probe on Jul 30 (warm MCP session, cold/new isolate) measured the first `kody.job_list` inside one execute at **1514ms**; the second call in the same execute was **36ms**. Later executes on the same warm isolate stayed in the **34–76ms** band. A probe right after deploy can look fine (~65ms) because the isolate is already warm — this is **per-isolate lazy work**, not per-execute.

### Where the ~1.5s goes (runtime + static evidence)

| Contributor | Verdict | Evidence |
| --- | --- | --- |
| Lazy `await import('#worker/jobs/service.ts')` on `job_list` / `job_get` | **Dominant** | `service.ts` statically reaches ~500 first-party modules / ~2.9MB (includes `run-kody-registry`, bundler/module-graph, entitlements, repo checks, …). First call pays module evaluation; subsequent calls are ~40ms. |
| `getStaticRegistry` / Zod→JSON Schema | **Not on first-dispatch path** | Already memoized; MCP DO `init()` and execute `provider-assembly` call `getCapabilityRegistryForContext` before sandbox capability RPCs. |
| `assertCallerCanAccessCapability` / feature flags | **Negligible for `job_list`** | No `featureFlag` on jobs list → no D1 flag lookup. |
| Secret-store / Sentry init | **Not implicated** | Not on `job_list` handler path; secret/value list first calls were 80–114ms on the cold probe (their own services, already static-imported). |
| Job Manager DO `getDebugState` | **Secondary residual** | Still awaited for alarm debug; DO hibernation can add tens–hundreds of ms after idle, but does not explain the consistent ~1.5s module hit. |
| Platform isolate cold start outside app control | **Not the measured 1.5s** | Cost appears *after* execute sandbox is running, on the first capability RPC into the parent isolate. |

### Fix

1. Extract read-side helpers to `jobs/inspect.ts` (+ `inspect-published-source.ts` for optional `includeCode`).
2. Point `job_list` / `job_get` / account jobs UI at the slim static import (avoids the cycle that forced the lazy `service` import).
3. Log once per isolate when the first capability dispatch is ≥250ms (`kody-first-capability-dispatch-slow`) so regressions stay visible — sampling covers the full RPC path (access + secrets + handler).

Write paths (`create`/`update`/`delete`/`run`) still lazy-load `service.ts` — appropriate for less frequent paths.

### Test plan

- [x] Focused node suites (inspect / job-schedule / account-jobs / service / run-kody-registry)
- [x] `npm run validate` (typecheck fix included; full gate green locally)
- [x] CI Validate green
- [x] Bugbot feedback: wrap first-dispatch sample around full RPC path
- [ ] Post-deploy: cold first `kody.job_list` in a fresh isolate should no longer sit near 1.5s; watch for `kody-first-capability-dispatch-slow` warnings

### Systemic impact

- **Per-user D1 write amplification:** unchanged here; keep read paths free of write leases and avoid pulling write-side services into list/get.
- **Per-call overhead budgets:** capability handlers must not lazy-import mega modules that import execute/bundler graphs. Prefer slim read modules; keep execution graphs behind write/run entrypoints. Treat first-dispatch p95 as a budget (goal: ≪250ms after isolate is serving MCP).
- **Observability guardrails:** keep execute Server-Timing (`bundle` / `provider-assembly` / `sandbox`) and the once-per-isolate first-dispatch warn; alert or triage on `kody-first-capability-dispatch-slow` spikes after deploys.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `40446ccf` · **Head:** `981c6c67`

**Classification:** extends — splits job read/inspect helpers off the execution
service so cold first `kody.*` dispatch no longer evaluates the job-run module
graph; adds once-per-isolate slow-dispatch logging.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `jobs` | assistant | extends — new slim `inspect.ts` / `inspect-published-source.ts` read path |
| `capability-registry` | assistant | extends — `job_list` / `job_get` static-import inspect instead of lazy `service` |
| `capabilities-execute` | runtime | extends — sample/warn first capability RPC when ≥250ms |
| `app-ui` | surfaces | composes — account jobs list uses inspect import |

### System map

Cold first `job_list` no longer pulls the job execution graph through a lazy
`service.ts` import; dispatch logs a one-shot slow warning when regressions
return.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red =
new primitive · gray = context (unchanged, included only when an edge crosses
it).

```mermaid
flowchart LR
	executeRuntime["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	jobs["jobs<br/>Scheduled jobs"]:::extended
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	executeRuntime -->|"first kody.* RPC warn ≥250ms"| capabilityRegistry
	capabilityRegistry -->|"job_list/job_get static import"| jobs
	appUi -->|"account jobs list inspectJobsForUser"| jobs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Sandbox as Execute sandbox
	participant Dispatch as capabilityKodyTools
	participant Inspect as jobs/inspect.ts
	participant Service as jobs/service.ts
	Sandbox->>Dispatch: kody.job_list()
	Dispatch->>Inspect: inspectJobsForUser (static)
	Note over Service: Not loaded on list/get
	Inspect-->>Dispatch: jobs + alarm
	Dispatch-->>Sandbox: result
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| `job_list` / `job_get` | `await import('#worker/jobs/service.ts')` (~500 modules) | static `#worker/jobs/inspect.ts` (~read/repo/manager only) |
| `includeCode: true` on `job_get` | inlined in `service.ts` | dynamic `inspect-published-source.ts` only when requested |
| First slow dispatch | silent | once-per-isolate `kody-first-capability-dispatch-slow` warn |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68722159-e381-47bf-8a52-83d2aec1e4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68722159-e381-47bf-8a52-83d2aec1e4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

