### PR TITLE
feat(invoke): key-less packages.invoke lean path + widen-phase deprecation shims

### DIFF
--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -244,12 +244,29 @@ const packageInvokeRuntimeBridgeProviderName =
 const packageEventRuntimeBridgeProviderName = '__kodyPackageEventRuntimeBridge'
 
 function createPackagesHelperPrelude() {
+	// `check` and `invokeChecked` are deprecated widen-phase shims: they keep
+	// working but warn once per run naming the replacement, because agents
+	// learn the current contract from logs and error text.
 	return `
-const packages = {
-  check: async (input) => await ${packageInvokeRuntimeBridgeProviderName}.check(input ?? {}),
-  invoke: async (input) => await ${packageInvokeRuntimeBridgeProviderName}.invoke(input ?? {}),
-  invokeChecked: async (input) => await ${packageInvokeRuntimeBridgeProviderName}.invokeChecked(input ?? {}),
-};
+const packages = (() => {
+  const warned = new Set();
+  const warnOnce = (name, message) => {
+    if (warned.has(name)) return;
+    warned.add(name);
+    console.warn(message);
+  };
+  return {
+    check: async (input) => {
+      warnOnce('check', '[deprecated] packages.check: packages.invoke always contract-checks before invoking, so call packages.invoke({ kodyId, exportName, params }) directly (add idempotencyKey only when you need exactly-once).');
+      return await ${packageInvokeRuntimeBridgeProviderName}.check(input ?? {});
+    },
+    invoke: async (input) => await ${packageInvokeRuntimeBridgeProviderName}.invoke(input ?? {}),
+    invokeChecked: async (input) => {
+      warnOnce('invokeChecked', '[deprecated] packages.invokeChecked: use a static import (import fn from "kody:@scope/pkg/export") when the target package is known at write time, or packages.invoke({ kodyId, exportName, params }) for dynamic targets (add idempotencyKey only when you need exactly-once).');
+      return await ${packageInvokeRuntimeBridgeProviderName}.invokeChecked(input ?? {});
+    },
+  };
+})();
 	`.trim()
 }
 

--- a/packages/worker/src/package-invocations/common.ts
+++ b/packages/worker/src/package-invocations/common.ts
@@ -32,7 +32,12 @@ export type PackageInvocationRequest = {
 	packageIdOrKodyId: string
 	exportName: string
 	params?: Record<string, unknown>
-	idempotencyKey: string
+	/**
+	 * `null` selects the key-less (lean/ephemeral) path for runtime callers:
+	 * no idempotency ledger row, no account write lease, run records on
+	 * failure only. External HTTP token invocations still require a key.
+	 */
+	idempotencyKey: string | null
 	source?: string | null
 	topic?: string | null
 }

--- a/packages/worker/src/package-invocations/http-invoke.ts
+++ b/packages/worker/src/package-invocations/http-invoke.ts
@@ -14,6 +14,7 @@ import {
 	type PackageRuntimeToolFactories,
 } from './common.ts'
 import { invokeSavedPackageModule } from './idempotent-module-invocation.ts'
+import { runSavedPackageModuleEphemeral } from './module-execution.ts'
 import { type PackageInvokeCheckPreloads } from './invoke-check.ts'
 import { resolveSavedPackage } from './module-artifacts.ts'
 import { buildJsonErrorResponse } from './responses.ts'
@@ -89,14 +90,7 @@ export async function invokePackageExportForExecuteRuntime(input: {
 		})
 	}
 	const exportName = normalizeExportName(input.request.exportName)
-	const idempotencyKey = input.request.idempotencyKey.trim()
-	if (!idempotencyKey) {
-		return buildJsonErrorResponse({
-			status: 400,
-			code: 'missing_idempotency_key',
-			message: 'Package invocations require a non-empty idempotencyKey.',
-		})
-	}
+	const idempotencyKey = normalizeNullableString(input.request.idempotencyKey)
 	const savedPackage =
 		input.preloads?.savedPackage ??
 		(await resolveSavedPackage({
@@ -109,7 +103,7 @@ export async function invokePackageExportForExecuteRuntime(input: {
 			status: 404,
 			code: 'package_not_found',
 			message: buildSavedPackageNotFoundMessage(packageIdOrKodyId),
-			idempotencyKey,
+			idempotencyKey: idempotencyKey ?? undefined,
 		})
 	}
 	const conversationId = input.conversationId?.trim()
@@ -121,16 +115,17 @@ export async function invokePackageExportForExecuteRuntime(input: {
 			conversationId,
 		})
 	}
-	return await invokeSavedPackageModule({
+	const actor = {
+		tokenId: internalExecuteRuntimeInvokeTokenId,
+		userId: input.caller.userId,
+		email: input.caller.email,
+		displayName: input.caller.displayName || input.caller.email || 'execute',
+		remoteConnectors: input.caller.remoteConnectors ?? null,
+	}
+	const shared = {
 		env: input.env,
 		baseUrl: input.baseUrl,
-		actor: {
-			tokenId: internalExecuteRuntimeInvokeTokenId,
-			userId: input.caller.userId,
-			email: input.caller.email,
-			displayName: input.caller.displayName || input.caller.email || 'execute',
-			remoteConnectors: input.caller.remoteConnectors ?? null,
-		},
+		actor,
 		savedPackage,
 		invocationName: exportName,
 		moduleSelector: {
@@ -138,7 +133,6 @@ export async function invokePackageExportForExecuteRuntime(input: {
 			exportName,
 		},
 		params: input.request.params,
-		idempotencyKey,
 		source: 'execute',
 		topic: normalizeNullableString(input.request.topic),
 		notFoundCode: 'export_not_found',
@@ -146,7 +140,14 @@ export async function invokePackageExportForExecuteRuntime(input: {
 		toolFactories: input.toolFactories,
 		waitUntil: input.waitUntil,
 		preloadedModuleArtifact: input.preloads?.moduleArtifact ?? null,
-	})
+	} satisfies Omit<
+		Parameters<typeof invokeSavedPackageModule>[0],
+		'idempotencyKey'
+	>
+	if (!idempotencyKey) {
+		return await runSavedPackageModuleEphemeral(shared)
+	}
+	return await invokeSavedPackageModule({ ...shared, idempotencyKey })
 }
 
 export async function invokePackageExportForPackageRuntime(input: {
@@ -175,14 +176,7 @@ export async function invokePackageExportForPackageRuntime(input: {
 		})
 	}
 	const exportName = normalizeExportName(input.request.exportName)
-	const idempotencyKey = input.request.idempotencyKey.trim()
-	if (!idempotencyKey) {
-		return buildJsonErrorResponse({
-			status: 400,
-			code: 'missing_idempotency_key',
-			message: 'Package invocations require a non-empty idempotencyKey.',
-		})
-	}
+	const idempotencyKey = normalizeNullableString(input.request.idempotencyKey)
 	const savedPackage =
 		input.preloads?.savedPackage ??
 		(await resolveSavedPackage({
@@ -195,10 +189,10 @@ export async function invokePackageExportForPackageRuntime(input: {
 			status: 404,
 			code: 'package_not_found',
 			message: buildSavedPackageNotFoundMessage(packageIdOrKodyId),
-			idempotencyKey,
+			idempotencyKey: idempotencyKey ?? undefined,
 		})
 	}
-	return await invokeSavedPackageModule({
+	const shared = {
 		env: input.env,
 		baseUrl: input.baseUrl,
 		actor: {
@@ -217,7 +211,6 @@ export async function invokePackageExportForPackageRuntime(input: {
 			exportName,
 		},
 		params: input.request.params,
-		idempotencyKey,
 		source:
 			normalizeNullableString(input.request.source) ??
 			`package:${input.caller.packageContext.kodyId}`,
@@ -227,7 +220,14 @@ export async function invokePackageExportForPackageRuntime(input: {
 		toolFactories: input.toolFactories,
 		waitUntil: input.waitUntil,
 		preloadedModuleArtifact: input.preloads?.moduleArtifact ?? null,
-	})
+	} satisfies Omit<
+		Parameters<typeof invokeSavedPackageModule>[0],
+		'idempotencyKey'
+	>
+	if (!idempotencyKey) {
+		return await runSavedPackageModuleEphemeral(shared)
+	}
+	return await invokeSavedPackageModule({ ...shared, idempotencyKey })
 }
 
 export async function invokePackageExportWithToolFactories(input: {
@@ -248,7 +248,9 @@ export async function invokePackageExportWithToolFactories(input: {
 		})
 	}
 	const exportName = normalizeExportName(input.request.exportName)
-	const idempotencyKey = input.request.idempotencyKey.trim()
+	// External HTTP token invocations stay keyed-only: providers retry
+	// deliveries, so exactly-once is the point of this surface.
+	const idempotencyKey = normalizeNullableString(input.request.idempotencyKey)
 	if (!idempotencyKey) {
 		return buildJsonErrorResponse({
 			status: 400,

--- a/packages/worker/src/package-invocations/idempotency.ts
+++ b/packages/worker/src/package-invocations/idempotency.ts
@@ -1,8 +1,5 @@
 import { canonicalJsonStringify } from '@kody-internal/shared/canonical-json.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
-import { type RunRecordContext } from '#worker/run-records/types.ts'
-import { normalizeExportName, type PackageRuntimeContext } from './common.ts'
-import { type ParsedPackageInvokeInput } from './input-parsing.ts'
 import { buildJsonErrorResponse } from './responses.ts'
 import {
 	type getPackageInvocationByKey,
@@ -42,44 +39,6 @@ export async function createRequestHash(input: {
 		new TextEncoder().encode(canonical),
 	)
 	return toHex(new Uint8Array(digest))
-}
-
-export async function createAutoPackageInvokeIdempotencyKey(input: {
-	callerPackageContext: PackageRuntimeContext | null
-	parentRunRecord: RunRecordContext | null
-	sequence: number
-	request: ParsedPackageInvokeInput
-}) {
-	if (!input.callerPackageContext) {
-		return `pkginvoke:${crypto.randomUUID()}`
-	}
-	const parentKey = input.parentRunRecord?.idempotencyKey?.trim()
-	if (!parentKey) {
-		return `pkginvoke:${crypto.randomUUID()}`
-	}
-	const digest = await crypto.subtle.digest(
-		'SHA-256',
-		new TextEncoder().encode(
-			canonicalJsonStringify({
-				callerPackageId: input.callerPackageContext.packageId,
-				parentKey,
-				parentSurface: input.parentRunRecord?.surface ?? null,
-				parentName: input.parentRunRecord?.name ?? null,
-				sequence: input.sequence,
-				packageIdOrKodyId: input.request.packageIdOrKodyId,
-				exportName: normalizeExportName(input.request.exportName),
-				params: input.request.params,
-				topic: input.request.topic,
-			}),
-		),
-	)
-	return [
-		'pkginvoke',
-		input.callerPackageContext.packageId,
-		parentKey,
-		String(input.sequence),
-		toHex(new Uint8Array(digest)).slice(0, 24),
-	].join(':')
 }
 
 function buildIdempotencyResponseUnavailable(input: {

--- a/packages/worker/src/package-invocations/idempotent-module-invocation.ts
+++ b/packages/worker/src/package-invocations/idempotent-module-invocation.ts
@@ -317,15 +317,15 @@ export async function invokeSavedPackageModule(input: {
 					try {
 						return await persistClaimedResult('completed', outcome.response)
 					} catch (error) {
-						const response = buildJsonErrorResponse({
-							status: 500,
-							code: 'invocation_failed',
-							message: getErrorMessage(error),
-							idempotencyKey: input.idempotencyKey,
-						})
-						return await persistClaimedResult('failed', response).catch(
-							() => response,
+						// The module already succeeded; do not poison the key with a
+						// stored permanent failure. Return the result to the caller and
+						// leave the claim in progress so the stale-reclaim path decides
+						// what happens on a later retry.
+						console.warn(
+							'package invocation completed-result persistence failed',
+							getErrorMessage(error),
 						)
+						return outcome.response
 					}
 				}
 				case 'failed': {

--- a/packages/worker/src/package-invocations/idempotent-module-invocation.ts
+++ b/packages/worker/src/package-invocations/idempotent-module-invocation.ts
@@ -1,36 +1,15 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
-import { persistableExecutionArtifacts } from '#mcp/downstream-mcp-result.ts'
-import { createMcpCallerContext } from '#mcp/context.ts'
-import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { withAccountWriteLease } from '#worker/account/deletion-state.ts'
-import { type RunRecordContext } from '#worker/run-records/types.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
-import { getEntitySourceByIdForUser } from '#worker/repo/entity-sources.ts'
 import {
-	getEmailAttachmentById,
-	getEmailMessageById,
-	getEmailMessageWithAttachmentsById,
-} from '#worker/email/service.ts'
-import {
-	buildPackageInvocationStorageId,
-	createRepoContext,
-	resolveInvocationRuntimeName,
-	resolveInvocationRuntimeSurface,
 	type PackageInvocationActor,
 	type PackageModuleSelector,
 	type PackageRuntimeToolFactories,
 } from './common.ts'
 import { createRequestHash, resolveExistingInvocation } from './idempotency.ts'
-import {
-	ensureModuleArtifact,
-	isMissingPackageModuleError,
-	isTransientModuleArtifactError,
-} from './module-artifacts.ts'
-import {
-	buildExecutionErrorResponse,
-	buildExecutionSuccessResponse,
-	buildJsonErrorResponse,
-} from './responses.ts'
+import { type ensureModuleArtifact } from './module-artifacts.ts'
+import { runSavedPackageModuleOnce } from './module-execution.ts'
+import { buildJsonErrorResponse } from './responses.ts'
 import {
 	getPackageInvocationByKey,
 	insertPackageInvocationRow,
@@ -48,6 +27,12 @@ function isStaleInvocation(updatedAt: string, now: Date) {
 	return Date.parse(updatedAt) <= now.getTime() - packageInvocationStaleAfterMs
 }
 
+/**
+ * Keyed (exactly-once) invocation path: idempotency ledger claim, bounded
+ * response replay, eager run records. Key-less callers take
+ * `runSavedPackageModuleEphemeral` in module-execution.ts instead — the
+ * execution itself is shared via `runSavedPackageModuleOnce`.
+ */
 export async function invokeSavedPackageModule(input: {
 	env: Env
 	baseUrl: string
@@ -64,9 +49,9 @@ export async function invokeSavedPackageModule(input: {
 	toolFactories: PackageRuntimeToolFactories
 	waitUntil?: (promise: Promise<unknown>) => void
 	/**
-	 * Artifact already prepared by a `packages.invokeChecked` check phase
-	 * moments earlier; skips a second manifest + artifact load. The claim
-	 * still happens first, so replay semantics are unchanged.
+	 * Artifact already prepared by a `packages.invoke` check phase moments
+	 * earlier; skips a second manifest + artifact load. The claim still
+	 * happens first, so replay semantics are unchanged.
 	 */
 	preloadedModuleArtifact?: Awaited<
 		ReturnType<typeof ensureModuleArtifact>
@@ -93,7 +78,6 @@ export async function invokeSavedPackageModule(input: {
 					idempotencyKey: input.idempotencyKey,
 				})
 			let existing: Awaited<ReturnType<typeof getPackageInvocationByKey>>
-			let executionStarted = false
 			try {
 				existing = await lookupInvocation()
 			} catch (error) {
@@ -283,241 +267,26 @@ export async function invokeSavedPackageModule(input: {
 				})
 			}
 
-			try {
-				const { artifact, source: sourceRow } =
-					input.preloadedModuleArtifact ??
-					(await ensureModuleArtifact({
-						env: input.env,
-						baseUrl: input.baseUrl,
-						savedPackage: input.savedPackage,
-						selector: input.moduleSelector,
-						userId: input.actor.userId,
-					}))
-				const repoSource =
-					artifact.packageContext?.sourceId == null ||
-					artifact.packageContext.sourceId === sourceRow.id
-						? sourceRow
-						: await getEntitySourceByIdForUser(input.env.APP_DB, {
-								id: artifact.packageContext.sourceId,
-								userId: input.actor.userId,
-							})
-				const callerContext = createMcpCallerContext({
-					baseUrl: input.baseUrl,
-					executionOrigin: 'background',
-					user: {
-						userId: input.actor.userId,
-						email: input.actor.email,
-						username: undefined,
-						displayName: input.actor.displayName,
-					},
-					storageContext: {
-						sessionId: null,
-						appId: input.savedPackage.id,
-						packageId: input.savedPackage.id,
-						storageId: buildPackageInvocationStorageId(input.savedPackage.id),
-					},
-					remoteConnectors: input.actor.remoteConnectors ?? null,
-					repoContext: repoSource ? createRepoContext(repoSource) : null,
-				})
-				const runtimeSurface = resolveInvocationRuntimeSurface({
-					selector: input.moduleSelector,
-					source: input.source,
-				})
-				const packageContext = artifact.packageContext ?? {
-					packageId: input.savedPackage.id,
-					kodyId: input.savedPackage.kodyId,
-					sourceId: input.savedPackage.sourceId,
-				}
-				const runRecord: RunRecordContext | null =
-					runtimeSurface == null
-						? null
-						: {
-								packageId: input.savedPackage.id,
-								kodyId: input.savedPackage.kodyId,
-								sourceId: input.savedPackage.sourceId,
-								publishedCommit: repoSource?.published_commit ?? null,
-								surface: runtimeSurface,
-								name: resolveInvocationRuntimeName({
-									surface: runtimeSurface,
-									invocationName: input.invocationName,
-									topic: input.topic,
-								}),
-								invocationId,
-								idempotencyKey: input.idempotencyKey,
-								metadata: {
-									exportName: input.invocationName,
-									source: input.source,
-									topic: input.topic,
-								},
-							}
-				executionStarted = true
-				const executionResult = await runBundledModuleWithRegistry(
-					input.env,
-					callerContext,
-					{
-						mainModule: artifact.mainModule,
-						modules: artifact.modules,
-						dependencies: artifact.dependencies,
-					},
-					input.params,
-					{
-						// No ambient `storage` binding: package code reaches its bucket via
-						// `packageStorage()` (granted through packageContext below). Legacy
-						// ambient use gets the structured runtime_helper_unbound hint.
-						runRecord,
-						emailTools: {
-							getMessage: async (messageId) => {
-								const loaded = await getEmailMessageWithAttachmentsById({
-									db: input.env.APP_DB,
-									userId: input.actor.userId,
-									messageId,
-								})
-								if (!loaded) {
-									throw new Error(`Email message not found: ${messageId}`)
-								}
-								return {
-									id: loaded.message.id,
-									direction: loaded.message.direction,
-									inbox_id: loaded.message.inboxId,
-									thread_id: loaded.message.threadId,
-									from_address: loaded.message.fromAddress,
-									envelope_from: loaded.message.envelopeFrom,
-									to_addresses: loaded.message.toAddresses,
-									cc_addresses: loaded.message.ccAddresses,
-									bcc_addresses: loaded.message.bccAddresses,
-									reply_to_addresses: loaded.message.replyToAddresses,
-									subject: loaded.message.subject,
-									message_id_header: loaded.message.messageIdHeader,
-									in_reply_to_header: loaded.message.inReplyToHeader,
-									references: loaded.message.references,
-									headers: loaded.message.headers,
-									auth_results: loaded.message.authResults,
-									text_body: loaded.message.textBody,
-									html_body: loaded.message.htmlBody,
-									raw_size: loaded.message.rawSize,
-									processing_status: loaded.message.processingStatus,
-									provider_message_id: loaded.message.providerMessageId,
-									delivery_status: loaded.message.deliveryStatus,
-									delivery_status_at: loaded.message.deliveryStatusAt,
-									error: loaded.message.error,
-									received_at: loaded.message.receivedAt,
-									sent_at: loaded.message.sentAt,
-									created_at: loaded.message.createdAt,
-									updated_at: loaded.message.updatedAt,
-									attachments: loaded.attachments.map((attachment) => ({
-										id: attachment.id,
-										filename: attachment.filename,
-										content_type: attachment.contentType,
-										content_id: attachment.contentId,
-										disposition: attachment.disposition,
-										size: attachment.size,
-										storage_kind: attachment.storageKind,
-										storage_key: attachment.storageKey,
-										created_at: attachment.createdAt,
-									})),
-								}
-							},
-							getAttachment: async (attachmentId) => {
-								const attachment = await getEmailAttachmentById({
-									db: input.env.APP_DB,
-									blobs: input.env.EMAIL_BLOBS,
-									userId: input.actor.userId,
-									attachmentId,
-								})
-								if (!attachment) {
-									throw new Error(`Email attachment not found: ${attachmentId}`)
-								}
-								const message = await getEmailMessageById({
-									db: input.env.APP_DB,
-									userId: input.actor.userId,
-									messageId: attachment.messageId,
-								})
-								if (!message) {
-									throw new Error(
-										`Email message not found for attachment: ${attachment.messageId}`,
-									)
-								}
-								return {
-									id: attachment.id,
-									message_id: attachment.messageId,
-									filename: attachment.filename,
-									content_type: attachment.contentType,
-									content_id: attachment.contentId,
-									disposition: attachment.disposition,
-									size: attachment.size,
-									storage_kind: attachment.storageKind,
-									storage_key: attachment.storageKey,
-									created_at: attachment.createdAt,
-									message: {
-										id: message.id,
-										message_id_header: message.messageIdHeader,
-										subject: message.subject,
-									},
-									content: attachment.content,
-									content_base64: attachment.contentBase64,
-								}
-							},
-						},
-						packageContext,
-						packageInvokeTools:
-							input.toolFactories.createPackageRuntimeInvokeTools({
-								env: input.env,
-								baseUrl: input.baseUrl,
-								callerContext,
-								packageContext,
-								parentRunRecord: runRecord,
-								packageInvokeDepth: input.runtimeInvokeDepth ?? 0,
-								waitUntil: input.waitUntil,
-							}),
-						packageEventTools: input.toolFactories.createPackageEventTools({
-							env: input.env,
-							baseUrl: input.baseUrl,
-							callerContext,
-							packageContext,
-							parentRunRecord: runRecord,
-							packageInvokeDepth: input.runtimeInvokeDepth ?? 0,
-							waitUntil: input.waitUntil,
-						}),
-						waitUntil: input.waitUntil,
-					},
-				)
-				let response: PackageInvocationStoredResponse
-				if (executionResult.error) {
-					response = buildExecutionErrorResponse({
-						savedPackage: input.savedPackage,
-						invocationName: input.invocationName,
-						idempotencyKey: input.idempotencyKey,
-						source: input.source,
-						topic: input.topic,
-						error: executionResult.error,
-						logs: executionResult.logs ?? [],
-					})
-				} else {
-					const persistedArtifacts = persistableExecutionArtifacts(
-						executionResult.result,
-					)
-					response = buildExecutionSuccessResponse({
-						savedPackage: input.savedPackage,
-						invocationName: input.invocationName,
-						idempotencyKey: input.idempotencyKey,
-						source: input.source,
-						topic: input.topic,
-						result: persistedArtifacts.result,
-						rawContent: persistedArtifacts.rawContent,
-						rawContentOmitted: persistedArtifacts.rawContentOmitted,
-						logs: executionResult.logs ?? [],
-					})
-				}
-				return await persistClaimedResult(
-					executionResult.error ? 'failed' : 'completed',
-					response,
-				)
-			} catch (error) {
-				if (
-					!executionStarted &&
-					!isMissingPackageModuleError(error) &&
-					isTransientModuleArtifactError(error)
-				) {
+			const outcome = await runSavedPackageModuleOnce({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				actor: input.actor,
+				savedPackage: input.savedPackage,
+				invocationName: input.invocationName,
+				moduleSelector: input.moduleSelector,
+				params: input.params,
+				idempotencyKey: input.idempotencyKey,
+				invocationId,
+				source: input.source,
+				topic: input.topic,
+				notFoundCode: input.notFoundCode,
+				runtimeInvokeDepth: input.runtimeInvokeDepth,
+				toolFactories: input.toolFactories,
+				waitUntil: input.waitUntil,
+				preloadedModuleArtifact: input.preloadedModuleArtifact,
+			})
+			switch (outcome.kind) {
+				case 'artifact-unavailable': {
 					const released = await releasePackageInvocationClaim({
 						db: input.env.APP_DB,
 						id: invocationId,
@@ -542,36 +311,40 @@ export async function invokeSavedPackageModule(input: {
 									})
 						}
 					}
-					return buildJsonErrorResponse({
-						status: 503,
-						code: 'artifact_preparation_failed',
-						message:
-							'Package artifact preparation failed before execution. Please retry.',
-						idempotencyKey: input.idempotencyKey,
-					})
+					return outcome.response
 				}
-				if (isMissingPackageModuleError(error)) {
-					const response = buildJsonErrorResponse({
-						status: 404,
-						code: input.notFoundCode,
-						message: getErrorMessage(error),
-						idempotencyKey: input.idempotencyKey,
-					})
-					return await persistClaimedResult('failed', response).catch(() => {
-						// Best effort; preserve the original invocation error.
-						return response
-					})
+				case 'completed': {
+					try {
+						return await persistClaimedResult('completed', outcome.response)
+					} catch (error) {
+						const response = buildJsonErrorResponse({
+							status: 500,
+							code: 'invocation_failed',
+							message: getErrorMessage(error),
+							idempotencyKey: input.idempotencyKey,
+						})
+						return await persistClaimedResult('failed', response).catch(
+							() => response,
+						)
+					}
 				}
-				const response = buildJsonErrorResponse({
-					status: 500,
-					code: 'invocation_failed',
-					message: getErrorMessage(error),
-					idempotencyKey: input.idempotencyKey,
-				})
-				return await persistClaimedResult('failed', response).catch(() => {
-					// Best effort; preserve the original invocation error.
-					return response
-				})
+				case 'failed': {
+					return await persistClaimedResult('failed', outcome.response).catch(
+						(error: unknown) => {
+							// Best effort; preserve the original invocation error.
+							console.warn(
+								'package invocation terminal persistence failed',
+								getErrorMessage(error),
+							)
+							return outcome.response
+						},
+					)
+				}
+				default: {
+					const exhaustive: never = outcome
+					void exhaustive
+					throw new Error('Unhandled package module run outcome.')
+				}
 			}
 		},
 	})

--- a/packages/worker/src/package-invocations/invoke-check.ts
+++ b/packages/worker/src/package-invocations/invoke-check.ts
@@ -87,10 +87,16 @@ export type PackageInvokeCheckOutcome = {
 	preloads: PackageInvokeCheckPreloads | null
 }
 
+export type PackageInvokeCheckOperationName =
+	| 'packages.invoke'
+	| 'packages.check'
+	/** Deprecated widen-phase alias for `packages.invoke`. */
+	| 'packages.invokeChecked'
+
 export async function checkPackageInvokeForRuntime(input: {
 	env: Env
 	baseUrl: string
-	operationName: 'packages.check' | 'packages.invokeChecked'
+	operationName: PackageInvokeCheckOperationName
 	userId: string
 	rawInput: PackageInvokeInput
 }): Promise<PackageInvokeCheckResult> {
@@ -105,7 +111,7 @@ export async function checkPackageInvokeForRuntime(input: {
 export async function checkPackageInvokeForRuntimeWithPreloads(input: {
 	env: Env
 	baseUrl: string
-	operationName: 'packages.check' | 'packages.invokeChecked'
+	operationName: PackageInvokeCheckOperationName
 	userId: string
 	rawInput: PackageInvokeInput
 	/**

--- a/packages/worker/src/package-invocations/module-execution.ts
+++ b/packages/worker/src/package-invocations/module-execution.ts
@@ -1,0 +1,371 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { persistableExecutionArtifacts } from '#mcp/downstream-mcp-result.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
+import { type RunRecordContext } from '#worker/run-records/types.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import { getEntitySourceByIdForUser } from '#worker/repo/entity-sources.ts'
+import {
+	getEmailAttachmentById,
+	getEmailMessageById,
+	getEmailMessageWithAttachmentsById,
+} from '#worker/email/service.ts'
+import {
+	buildPackageInvocationStorageId,
+	createRepoContext,
+	resolveInvocationRuntimeName,
+	resolveInvocationRuntimeSurface,
+	type PackageInvocationActor,
+	type PackageInvocationResponse,
+	type PackageModuleSelector,
+	type PackageRuntimeToolFactories,
+} from './common.ts'
+import {
+	ensureModuleArtifact,
+	isMissingPackageModuleError,
+	isTransientModuleArtifactError,
+} from './module-artifacts.ts'
+import {
+	buildExecutionErrorResponse,
+	buildExecutionSuccessResponse,
+	buildJsonErrorResponse,
+} from './responses.ts'
+
+/**
+ * One saved-package module execution, uncoupled from durability:
+ *
+ * - `completed`: the sandbox ran and the export succeeded.
+ * - `failed`: the sandbox ran and errored, the module/export was missing, or
+ *   an unexpected error interrupted the run. Keyed callers persist this as a
+ *   terminal ledger state.
+ * - `artifact-unavailable`: artifact preparation failed transiently before
+ *   any sandbox work started. Nothing executed, so keyed callers release
+ *   their claim and key-less callers can simply retry.
+ */
+export type SavedPackageModuleRunOutcome =
+	| { kind: 'completed'; response: PackageInvocationResponse }
+	| { kind: 'failed'; response: PackageInvocationResponse }
+	| { kind: 'artifact-unavailable'; response: PackageInvocationResponse }
+
+export type SavedPackageModuleRunInput = {
+	env: Env
+	baseUrl: string
+	actor: PackageInvocationActor
+	savedPackage: SavedPackageRecord
+	invocationName: string
+	moduleSelector: PackageModuleSelector
+	params?: Record<string, unknown>
+	/**
+	 * `null` for key-less (ephemeral) invocations: no ledger row exists, the
+	 * response carries no `idempotency` section, and the run record downgrades
+	 * to on-failure-only persistence (see `runPersistenceForContext`).
+	 */
+	idempotencyKey: string | null
+	/** Ledger row id for keyed invocations; `null` for key-less ones. */
+	invocationId: string | null
+	source: string | null
+	topic: string | null
+	notFoundCode: 'export_not_found' | 'subscription_not_found'
+	runtimeInvokeDepth?: number
+	toolFactories: PackageRuntimeToolFactories
+	waitUntil?: (promise: Promise<unknown>) => void
+	/**
+	 * Artifact already prepared by a `packages.invoke` check phase moments
+	 * earlier; skips a second manifest + artifact load.
+	 */
+	preloadedModuleArtifact?: Awaited<
+		ReturnType<typeof ensureModuleArtifact>
+	> | null
+}
+
+export async function runSavedPackageModuleOnce(
+	input: SavedPackageModuleRunInput,
+): Promise<SavedPackageModuleRunOutcome> {
+	let executionStarted = false
+	try {
+		const { artifact, source: sourceRow } =
+			input.preloadedModuleArtifact ??
+			(await ensureModuleArtifact({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				savedPackage: input.savedPackage,
+				selector: input.moduleSelector,
+				userId: input.actor.userId,
+			}))
+		const repoSource =
+			artifact.packageContext?.sourceId == null ||
+			artifact.packageContext.sourceId === sourceRow.id
+				? sourceRow
+				: await getEntitySourceByIdForUser(input.env.APP_DB, {
+						id: artifact.packageContext.sourceId,
+						userId: input.actor.userId,
+					})
+		const callerContext = createMcpCallerContext({
+			baseUrl: input.baseUrl,
+			executionOrigin: 'background',
+			user: {
+				userId: input.actor.userId,
+				email: input.actor.email,
+				username: undefined,
+				displayName: input.actor.displayName,
+			},
+			storageContext: {
+				sessionId: null,
+				appId: input.savedPackage.id,
+				packageId: input.savedPackage.id,
+				storageId: buildPackageInvocationStorageId(input.savedPackage.id),
+			},
+			remoteConnectors: input.actor.remoteConnectors ?? null,
+			repoContext: repoSource ? createRepoContext(repoSource) : null,
+		})
+		const runtimeSurface = resolveInvocationRuntimeSurface({
+			selector: input.moduleSelector,
+			source: input.source,
+		})
+		const packageContext = artifact.packageContext ?? {
+			packageId: input.savedPackage.id,
+			kodyId: input.savedPackage.kodyId,
+			sourceId: input.savedPackage.sourceId,
+		}
+		const runRecord: RunRecordContext | null =
+			runtimeSurface == null
+				? null
+				: {
+						packageId: input.savedPackage.id,
+						kodyId: input.savedPackage.kodyId,
+						sourceId: input.savedPackage.sourceId,
+						publishedCommit: repoSource?.published_commit ?? null,
+						surface: runtimeSurface,
+						name: resolveInvocationRuntimeName({
+							surface: runtimeSurface,
+							invocationName: input.invocationName,
+							topic: input.topic,
+						}),
+						invocationId: input.invocationId,
+						idempotencyKey: input.idempotencyKey,
+						metadata: {
+							exportName: input.invocationName,
+							source: input.source,
+							topic: input.topic,
+						},
+					}
+		executionStarted = true
+		const executionResult = await runBundledModuleWithRegistry(
+			input.env,
+			callerContext,
+			{
+				mainModule: artifact.mainModule,
+				modules: artifact.modules,
+				dependencies: artifact.dependencies,
+			},
+			input.params,
+			{
+				// No ambient `storage` binding: package code reaches its bucket via
+				// `packageStorage()` (granted through packageContext below). Legacy
+				// ambient use gets the structured runtime_helper_unbound hint.
+				runRecord,
+				emailTools: {
+					getMessage: async (messageId) => {
+						const loaded = await getEmailMessageWithAttachmentsById({
+							db: input.env.APP_DB,
+							userId: input.actor.userId,
+							messageId,
+						})
+						if (!loaded) {
+							throw new Error(`Email message not found: ${messageId}`)
+						}
+						return {
+							id: loaded.message.id,
+							direction: loaded.message.direction,
+							inbox_id: loaded.message.inboxId,
+							thread_id: loaded.message.threadId,
+							from_address: loaded.message.fromAddress,
+							envelope_from: loaded.message.envelopeFrom,
+							to_addresses: loaded.message.toAddresses,
+							cc_addresses: loaded.message.ccAddresses,
+							bcc_addresses: loaded.message.bccAddresses,
+							reply_to_addresses: loaded.message.replyToAddresses,
+							subject: loaded.message.subject,
+							message_id_header: loaded.message.messageIdHeader,
+							in_reply_to_header: loaded.message.inReplyToHeader,
+							references: loaded.message.references,
+							headers: loaded.message.headers,
+							auth_results: loaded.message.authResults,
+							text_body: loaded.message.textBody,
+							html_body: loaded.message.htmlBody,
+							raw_size: loaded.message.rawSize,
+							processing_status: loaded.message.processingStatus,
+							provider_message_id: loaded.message.providerMessageId,
+							delivery_status: loaded.message.deliveryStatus,
+							delivery_status_at: loaded.message.deliveryStatusAt,
+							error: loaded.message.error,
+							received_at: loaded.message.receivedAt,
+							sent_at: loaded.message.sentAt,
+							created_at: loaded.message.createdAt,
+							updated_at: loaded.message.updatedAt,
+							attachments: loaded.attachments.map((attachment) => ({
+								id: attachment.id,
+								filename: attachment.filename,
+								content_type: attachment.contentType,
+								content_id: attachment.contentId,
+								disposition: attachment.disposition,
+								size: attachment.size,
+								storage_kind: attachment.storageKind,
+								storage_key: attachment.storageKey,
+								created_at: attachment.createdAt,
+							})),
+						}
+					},
+					getAttachment: async (attachmentId) => {
+						const attachment = await getEmailAttachmentById({
+							db: input.env.APP_DB,
+							blobs: input.env.EMAIL_BLOBS,
+							userId: input.actor.userId,
+							attachmentId,
+						})
+						if (!attachment) {
+							throw new Error(`Email attachment not found: ${attachmentId}`)
+						}
+						const message = await getEmailMessageById({
+							db: input.env.APP_DB,
+							userId: input.actor.userId,
+							messageId: attachment.messageId,
+						})
+						if (!message) {
+							throw new Error(
+								`Email message not found for attachment: ${attachment.messageId}`,
+							)
+						}
+						return {
+							id: attachment.id,
+							message_id: attachment.messageId,
+							filename: attachment.filename,
+							content_type: attachment.contentType,
+							content_id: attachment.contentId,
+							disposition: attachment.disposition,
+							size: attachment.size,
+							storage_kind: attachment.storageKind,
+							storage_key: attachment.storageKey,
+							created_at: attachment.createdAt,
+							message: {
+								id: message.id,
+								message_id_header: message.messageIdHeader,
+								subject: message.subject,
+							},
+							content: attachment.content,
+							content_base64: attachment.contentBase64,
+						}
+					},
+				},
+				packageContext,
+				packageInvokeTools: input.toolFactories.createPackageRuntimeInvokeTools(
+					{
+						env: input.env,
+						baseUrl: input.baseUrl,
+						callerContext,
+						packageContext,
+						parentRunRecord: runRecord,
+						packageInvokeDepth: input.runtimeInvokeDepth ?? 0,
+						waitUntil: input.waitUntil,
+					},
+				),
+				packageEventTools: input.toolFactories.createPackageEventTools({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					callerContext,
+					packageContext,
+					parentRunRecord: runRecord,
+					packageInvokeDepth: input.runtimeInvokeDepth ?? 0,
+					waitUntil: input.waitUntil,
+				}),
+				waitUntil: input.waitUntil,
+			},
+		)
+		if (executionResult.error) {
+			return {
+				kind: 'failed',
+				response: buildExecutionErrorResponse({
+					savedPackage: input.savedPackage,
+					invocationName: input.invocationName,
+					idempotencyKey: input.idempotencyKey,
+					source: input.source,
+					topic: input.topic,
+					error: executionResult.error,
+					logs: executionResult.logs ?? [],
+				}),
+			}
+		}
+		const persistedArtifacts = persistableExecutionArtifacts(
+			executionResult.result,
+		)
+		return {
+			kind: 'completed',
+			response: buildExecutionSuccessResponse({
+				savedPackage: input.savedPackage,
+				invocationName: input.invocationName,
+				idempotencyKey: input.idempotencyKey,
+				source: input.source,
+				topic: input.topic,
+				result: persistedArtifacts.result,
+				rawContent: persistedArtifacts.rawContent,
+				rawContentOmitted: persistedArtifacts.rawContentOmitted,
+				logs: executionResult.logs ?? [],
+			}),
+		}
+	} catch (error) {
+		if (
+			!executionStarted &&
+			!isMissingPackageModuleError(error) &&
+			isTransientModuleArtifactError(error)
+		) {
+			return {
+				kind: 'artifact-unavailable',
+				response: buildJsonErrorResponse({
+					status: 503,
+					code: 'artifact_preparation_failed',
+					message:
+						'Package artifact preparation failed before execution. Please retry.',
+					idempotencyKey: input.idempotencyKey ?? undefined,
+				}),
+			}
+		}
+		if (isMissingPackageModuleError(error)) {
+			return {
+				kind: 'failed',
+				response: buildJsonErrorResponse({
+					status: 404,
+					code: input.notFoundCode,
+					message: getErrorMessage(error),
+					idempotencyKey: input.idempotencyKey ?? undefined,
+				}),
+			}
+		}
+		return {
+			kind: 'failed',
+			response: buildJsonErrorResponse({
+				status: 500,
+				code: 'invocation_failed',
+				message: getErrorMessage(error),
+				idempotencyKey: input.idempotencyKey ?? undefined,
+			}),
+		}
+	}
+}
+
+/**
+ * Key-less (lean) invocation path: contract-checked upstream, executed in the
+ * target package's own runtime, with no idempotency ledger row, no account
+ * write lease, and run records persisted on failure only. This is the
+ * ephemeral counterpart to `invokeSavedPackageModule` (the keyed,
+ * exactly-once path).
+ */
+export async function runSavedPackageModuleEphemeral(
+	input: Omit<SavedPackageModuleRunInput, 'idempotencyKey' | 'invocationId'>,
+): Promise<PackageInvocationResponse> {
+	const outcome = await runSavedPackageModuleOnce({
+		...input,
+		idempotencyKey: null,
+		invocationId: null,
+	})
+	return outcome.response
+}

--- a/packages/worker/src/package-invocations/responses.ts
+++ b/packages/worker/src/package-invocations/responses.ts
@@ -8,7 +8,8 @@ import { type PackageInvocationStoredResponse } from './repo.ts'
 export function buildExecutionSuccessResponse(input: {
 	savedPackage: SavedPackageRecord
 	invocationName: string
-	idempotencyKey: string
+	/** `null` for key-less (ephemeral) invocations, which have no ledger row. */
+	idempotencyKey: string | null
 	source: string | null
 	topic: string | null
 	result: unknown
@@ -31,10 +32,14 @@ export function buildExecutionSuccessResponse(input: {
 			exportName: input.invocationName,
 			source: input.source,
 			topic: input.topic,
-			idempotency: {
-				key: input.idempotencyKey,
-				replayed: false,
-			},
+			...(input.idempotencyKey
+				? {
+						idempotency: {
+							key: input.idempotencyKey,
+							replayed: false,
+						},
+					}
+				: {}),
 			result: toJsonSafeValue(input.result),
 			logs: input.logs,
 			...(input.rawContent
@@ -50,7 +55,8 @@ export function buildExecutionSuccessResponse(input: {
 export function buildExecutionErrorResponse(input: {
 	savedPackage: SavedPackageRecord
 	invocationName: string
-	idempotencyKey: string
+	/** `null` for key-less (ephemeral) invocations, which have no ledger row. */
+	idempotencyKey: string | null
 	source: string | null
 	topic: string | null
 	error: unknown
@@ -68,10 +74,14 @@ export function buildExecutionErrorResponse(input: {
 			exportName: input.invocationName,
 			source: input.source,
 			topic: input.topic,
-			idempotency: {
-				key: input.idempotencyKey,
-				replayed: false,
-			},
+			...(input.idempotencyKey
+				? {
+						idempotency: {
+							key: input.idempotencyKey,
+							replayed: false,
+						},
+					}
+				: {}),
 			error: {
 				code: 'execution_failed',
 				message,

--- a/packages/worker/src/package-invocations/runtime-tool-factories.ts
+++ b/packages/worker/src/package-invocations/runtime-tool-factories.ts
@@ -11,7 +11,6 @@ import {
 	type PackageRuntimeContext,
 	type PackageRuntimeToolFactories,
 } from './common.ts'
-import { createAutoPackageInvokeIdempotencyKey } from './idempotency.ts'
 import {
 	invokePackageExportForExecuteRuntime,
 	invokePackageExportForPackageRuntime,
@@ -20,7 +19,6 @@ import { parsePackageInvokeInput } from './input-parsing.ts'
 import {
 	checkPackageInvokeForRuntime,
 	checkPackageInvokeForRuntimeWithPreloads,
-	type PackageInvokeCheckPreloads,
 } from './invoke-check.ts'
 
 export function createPackageRuntimeInvokeToolsWithToolFactories(input: {
@@ -70,7 +68,6 @@ function createPackageInvokeTools(input: {
 	toolFactories: PackageRuntimeToolFactories
 	waitUntil?: (promise: Promise<unknown>) => void
 }): PackageInvokeTools {
-	let autoIdempotencySequence = 0
 	const requireRuntimeCaller = (operationName: string) => {
 		const user = input.callerContext.user
 		if (!user?.userId) {
@@ -81,10 +78,14 @@ function createPackageInvokeTools(input: {
 		}
 		return { user, packageContext: input.packageContext }
 	}
-	const invoke = async (
-		rawInput: PackageInvokeInput,
-		preloads?: PackageInvokeCheckPreloads | null,
-	) => {
+	/**
+	 * The single dynamic invocation primitive. Always contract-checked first
+	 * (the check preloads the package row, manifest, and bundle artifact so
+	 * the invoke phase never reloads them), then routed by key presence:
+	 * key-less runs the lean/ephemeral path, keyed runs the exactly-once
+	 * ledger path.
+	 */
+	const invoke = async (rawInput: PackageInvokeInput) => {
 		const { user, packageContext } = requireRuntimeCaller('packages.invoke')
 		const packageInvokeDepth = input.packageInvokeDepth ?? 0
 		if (packageInvokeDepth >= maxPackageRuntimeInvokeDepth) {
@@ -93,15 +94,24 @@ function createPackageInvokeTools(input: {
 			)
 		}
 		const request = parsePackageInvokeInput(rawInput)
-		autoIdempotencySequence += 1
-		const idempotencyKey =
-			request.idempotencyKey ??
-			(await createAutoPackageInvokeIdempotencyKey({
-				callerPackageContext: packageContext,
-				parentRunRecord: input.parentRunRecord ?? null,
-				sequence: autoIdempotencySequence,
-				request,
-			}))
+		const check = await checkPackageInvokeForRuntimeWithPreloads({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			operationName: 'packages.invoke',
+			userId: user.userId,
+			rawInput,
+			includeExportProjection: false,
+		})
+		if (!check.result.ok || !check.preloads) {
+			const message = check.result.ok
+				? 'packages.invoke could not preload the package artifact.'
+				: `packages.invoke contract check failed: ${check.result.message}`
+			const error = new Error(message) as Error & {
+				check?: PackageInvokeCheckResult
+			}
+			error.check = check.result
+			throw error
+		}
 		const response = packageContext
 			? await invokePackageExportForPackageRuntime({
 					env: input.env,
@@ -117,14 +127,14 @@ function createPackageInvokeTools(input: {
 						packageIdOrKodyId: request.packageIdOrKodyId,
 						exportName: request.exportName,
 						params: request.params,
-						idempotencyKey,
+						idempotencyKey: request.idempotencyKey,
 						source: `package:${packageContext.kodyId}`,
 						topic: request.topic,
 					},
 					runtimeInvokeDepth: packageInvokeDepth + 1,
 					toolFactories: input.toolFactories,
 					waitUntil: input.waitUntil,
-					preloads: preloads ?? null,
+					preloads: check.preloads,
 				})
 			: await invokePackageExportForExecuteRuntime({
 					env: input.env,
@@ -139,14 +149,14 @@ function createPackageInvokeTools(input: {
 						packageIdOrKodyId: request.packageIdOrKodyId,
 						exportName: request.exportName,
 						params: request.params,
-						idempotencyKey,
+						idempotencyKey: request.idempotencyKey,
 						topic: request.topic,
 					},
 					runtimeInvokeDepth: packageInvokeDepth + 1,
 					conversationId: input.conversationId ?? null,
 					toolFactories: input.toolFactories,
 					waitUntil: input.waitUntil,
-					preloads: preloads ?? null,
+					preloads: check.preloads,
 				})
 		if (response.status >= 200 && response.status < 400) {
 			return response.body['result']
@@ -170,6 +180,9 @@ function createPackageInvokeTools(input: {
 	}
 	return {
 		check: async (rawInput) => {
+			// Deprecated: packages.invoke always contract-checks before invoking.
+			// Kept as a working shim during the widen phase; the sandbox prelude
+			// emits the deprecation warning naming the replacement.
 			const { user } = requireRuntimeCaller('packages.check')
 			return await checkPackageInvokeForRuntime({
 				env: input.env,
@@ -180,30 +193,9 @@ function createPackageInvokeTools(input: {
 			})
 		},
 		invoke,
-		invokeChecked: async (rawInput) => {
-			const { user } = requireRuntimeCaller('packages.invokeChecked')
-			// Skip the export projection (full package source) that a bare
-			// `packages.check` surfaces: invokeChecked discards the success
-			// contract, and the preloads let the invoke phase reuse the
-			// package row, manifest, and bundle artifact loaded here.
-			const check = await checkPackageInvokeForRuntimeWithPreloads({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				operationName: 'packages.invokeChecked',
-				userId: user.userId,
-				rawInput,
-				includeExportProjection: false,
-			})
-			if (!check.result.ok) {
-				const error = new Error(
-					`packages.invokeChecked check failed: ${check.result.message}`,
-				) as Error & {
-					check?: PackageInvokeCheckResult
-				}
-				error.check = check.result
-				throw error
-			}
-			return await invoke(check.result.invoke, check.preloads)
-		},
+		// Deprecated alias for the widen phase: packages.invoke is now always
+		// contract-checked, so invokeChecked adds nothing. Key-less calls take
+		// the lean path; the sandbox prelude emits the deprecation warning.
+		invokeChecked: invoke,
 	}
 }

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -912,6 +912,100 @@ test('package runtime can dynamically invoke the current published export from a
 	).toEqual(expect.any(Function))
 })
 
+test('key-less packages.invoke takes the lean path: re-executes on repeat and writes no ledger row', async () => {
+	const db = createDatabase()
+	seedRuntimeDispatchPackages()
+	repoMockModule.runBundledModuleWithRegistry.mockClear()
+	let executionCount = 0
+	repoMockModule.runBundledModuleWithRegistry.mockImplementation(async () => {
+		executionCount += 1
+		return { result: { handled: true, executionCount }, logs: [] }
+	})
+	const tools = createRuntimeDispatchTools(db)
+
+	const request = {
+		kodyId: 'discord-general-chat',
+		exportName: './handle-discord-message-created',
+		params: { event: { id: 'message-1' } },
+	}
+	const first = await tools.invoke(request)
+	const second = await tools.invoke(request)
+
+	// Ephemeral semantics: identical key-less calls execute independently.
+	expect(first).toEqual({ handled: true, executionCount: 1 })
+	expect(second).toEqual({ handled: true, executionCount: 2 })
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(2)
+	const runOptions =
+		repoMockModule.runBundledModuleWithRegistry.mock.calls[0]?.[4]
+	// No ledger row exists, so the run record carries neither an invocation id
+	// nor an idempotency key (which downgrades it to on-failure persistence).
+	expect(runOptions).toMatchObject({
+		runRecord: {
+			surface: 'export',
+			invocationId: null,
+			idempotencyKey: null,
+		},
+	})
+})
+
+test('keyed packages.invoke keeps exactly-once semantics: repeat calls replay the stored response', async () => {
+	const db = createDatabase()
+	seedRuntimeDispatchPackages()
+	repoMockModule.runBundledModuleWithRegistry.mockClear()
+	let executionCount = 0
+	repoMockModule.runBundledModuleWithRegistry.mockImplementation(async () => {
+		executionCount += 1
+		return { result: { handled: true, executionCount }, logs: [] }
+	})
+	const tools = createRuntimeDispatchTools(db)
+
+	const request = {
+		kodyId: 'discord-general-chat',
+		exportName: './handle-discord-message-created',
+		params: { event: { id: 'message-1' } },
+		idempotencyKey: 'evt-keyed-1',
+	}
+	const first = await tools.invoke(request)
+	const second = await tools.invoke(request)
+
+	expect(first).toEqual({ handled: true, executionCount: 1 })
+	expect(second).toEqual({ handled: true, executionCount: 1 })
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+	const runOptions =
+		repoMockModule.runBundledModuleWithRegistry.mock.calls[0]?.[4]
+	expect(runOptions).toMatchObject({
+		runRecord: {
+			surface: 'export',
+			invocationId: expect.any(String),
+			idempotencyKey: 'evt-keyed-1',
+		},
+	})
+})
+
+test('packages.invokeChecked remains a working key-less alias during the widen phase', async () => {
+	const db = createDatabase()
+	seedRuntimeDispatchPackages()
+	repoMockModule.runBundledModuleWithRegistry.mockClear()
+	let executionCount = 0
+	repoMockModule.runBundledModuleWithRegistry.mockImplementation(async () => {
+		executionCount += 1
+		return { result: { handled: true, executionCount }, logs: [] }
+	})
+	const tools = createRuntimeDispatchTools(db)
+
+	const request = {
+		kodyId: 'discord-general-chat',
+		exportName: './handle-discord-message-created',
+		params: { event: { id: 'message-1' } },
+	}
+	const first = await tools.invokeChecked(request)
+	const second = await tools.invokeChecked(request)
+
+	expect(first).toEqual({ handled: true, executionCount: 1 })
+	expect(second).toEqual({ handled: true, executionCount: 2 })
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(2)
+})
+
 test('package runtime dispatches declared events to same-user package subscriptions', async () => {
 	const db = createDatabase()
 	seedRuntimeDispatchPackages()
@@ -1245,7 +1339,7 @@ test('package runtime dispatch rejects invalid targets before and during invocat
 			params: {},
 		}),
 	).rejects.toThrow(
-		'packages.invokeChecked check failed: Saved package "@kentcdodds/discord-general-chat" was not found for this user. Dynamic package invocation uses the bare kodyId (for example, "github"), not the npm-scoped package name (for example, "@kentcdodds/github").',
+		'packages.invoke contract check failed: Saved package "@kentcdodds/discord-general-chat" was not found for this user. Dynamic package invocation uses the bare kodyId (for example, "github"), not the npm-scoped package name (for example, "@kentcdodds/github").',
 	)
 	await expect(
 		tools.check({
@@ -1285,7 +1379,7 @@ test('package runtime dispatch rejects invalid targets before and during invocat
 			params: {},
 		}),
 	).rejects.toThrow(
-		'packages.invokeChecked check failed: Package "discord-general-chat" does not define export "./missing-export".',
+		'packages.invoke contract check failed: Package "discord-general-chat" does not define export "./missing-export".',
 	)
 	await expect(
 		tools.invokeChecked({
@@ -1294,7 +1388,7 @@ test('package runtime dispatch rejects invalid targets before and during invocat
 			params: 'not-an-object',
 		}),
 	).rejects.toThrow(
-		'packages.invokeChecked check failed: packages.invokeChecked params must be a JSON object when provided.',
+		'packages.invoke params must be a JSON object when provided.',
 	)
 	expect(repoMockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
 
@@ -1333,7 +1427,7 @@ test('package runtime dispatch rejects invalid targets before and during invocat
 			exportName: './handle-discord-message-created',
 		}),
 	).rejects.toThrow(
-		'[package_not_found] Saved package "missing-package" was not found for this user.',
+		'packages.invoke contract check failed: Saved package "missing-package" was not found for this user.',
 	)
 
 	repoMockModule.getSavedPackageByKodyId.mockReset()
@@ -1344,10 +1438,15 @@ test('package runtime dispatch rejects invalid targets before and during invocat
 			exportName: './missing-export',
 			params: { event: { id: 'message-1' } },
 		}),
-	).rejects.toThrow('[export_not_found]')
+	).rejects.toThrow(
+		'packages.invoke contract check failed: Package "discord-general-chat" does not define export "./missing-export".',
+	)
 })
 
-test('package runtime auto idempotency keys include parent runtime identity', async () => {
+// Auto-generated idempotency keys were removed with the lean key-less path:
+// nested key-less invokes are ephemeral and always re-execute, regardless of
+// the parent run's identity. Exactly-once now requires an explicit key.
+test('key-less nested invokes re-execute for every parent run', async () => {
 	const db = createDatabase()
 	seedRuntimeDispatchPackages()
 	repoMockModule.runBundledModuleWithRegistry.mockImplementation(

--- a/packages/worker/src/package-runtime/deprecated-invocation-usage.ts
+++ b/packages/worker/src/package-runtime/deprecated-invocation-usage.ts
@@ -1,0 +1,137 @@
+import { parseModuleSource } from '#worker/module-source.ts'
+import { collectLiteralImportNodes } from './import-specifiers.ts'
+import { packageSpecifierPrefix } from './package-import-resolution.ts'
+import { isTypeDeclarationFilePath } from './static-kody-imports.ts'
+
+/**
+ * Widen-phase deprecation detection for the legacy dynamic invocation
+ * surface: `packages.check`, `packages.invokeChecked`, and literal dynamic
+ * `import("kody:@...")`. Publish checks surface these as non-fatal warnings
+ * so new usage stops before the narrow phase removes the shims.
+ */
+export type DeprecatedInvocationUsageKind =
+	| 'packages.check'
+	| 'packages.invokeChecked'
+	| 'dynamic-kody-import'
+
+export type DeprecatedInvocationUsage = {
+	filePath: string
+	kind: DeprecatedInvocationUsageKind
+}
+
+const scannableModuleFilePattern = /\.(?:[cm]?[jt]s|[jt]sx)$/
+
+function collectDeprecatedPackagesMemberKinds(
+	source: string,
+): Set<DeprecatedInvocationUsageKind> {
+	const kinds = new Set<DeprecatedInvocationUsageKind>()
+	let program: unknown
+	try {
+		program = parseModuleSource(source)
+	} catch {
+		return kinds
+	}
+
+	function visit(node: unknown): void {
+		if (node == null || typeof node !== 'object') return
+		if (Array.isArray(node)) {
+			for (const item of node) visit(item)
+			return
+		}
+		if (!('type' in node)) return
+		const typedNode = node as {
+			type?: string
+			computed?: boolean
+			object?: { type?: string; name?: unknown }
+			property?: { type?: string; name?: unknown }
+		}
+		if (
+			// Babel emits OptionalMemberExpression for `packages?.check`.
+			(typedNode.type === 'MemberExpression' ||
+				typedNode.type === 'OptionalMemberExpression') &&
+			typedNode.computed !== true &&
+			typedNode.object?.type === 'Identifier' &&
+			typedNode.object.name === 'packages' &&
+			typedNode.property?.type === 'Identifier'
+		) {
+			if (typedNode.property.name === 'check') {
+				kinds.add('packages.check')
+			} else if (typedNode.property.name === 'invokeChecked') {
+				kinds.add('packages.invokeChecked')
+			}
+		}
+		for (const value of Object.values(node as Record<string, unknown>)) {
+			if (value != null && typeof value === 'object') {
+				visit(value)
+			}
+		}
+	}
+
+	visit(program)
+	return kinds
+}
+
+function moduleHasLiteralDynamicKodyImport(source: string) {
+	return collectLiteralImportNodes(source).some(
+		(node) =>
+			node.kind === 'dynamic' &&
+			node.specifier.startsWith(packageSpecifierPrefix),
+	)
+}
+
+export function collectDeprecatedInvocationUsage(
+	sourceFiles: Record<string, string>,
+): Array<DeprecatedInvocationUsage> {
+	const usages: Array<DeprecatedInvocationUsage> = []
+	for (const [filePath, source] of Object.entries(sourceFiles)) {
+		if (!scannableModuleFilePattern.test(filePath)) continue
+		if (isTypeDeclarationFilePath(filePath)) continue
+		if (source.includes('packages')) {
+			for (const kind of collectDeprecatedPackagesMemberKinds(source)) {
+				usages.push({ filePath, kind })
+			}
+		}
+		if (
+			source.includes(packageSpecifierPrefix) &&
+			moduleHasLiteralDynamicKodyImport(source)
+		) {
+			usages.push({ filePath, kind: 'dynamic-kody-import' })
+		}
+	}
+	return usages.sort(
+		(left, right) =>
+			left.filePath.localeCompare(right.filePath) ||
+			left.kind.localeCompare(right.kind),
+	)
+}
+
+const deprecatedUsageReplacements: Record<
+	DeprecatedInvocationUsageKind,
+	string
+> = {
+	'packages.check':
+		'packages.check is deprecated: packages.invoke always contract-checks before invoking, so call it directly',
+	'packages.invokeChecked':
+		'packages.invokeChecked is deprecated: use a static kody:@scope/pkg/export import when the target package is known at write time, or packages.invoke({ kodyId, exportName, params }) for dynamic targets',
+	'dynamic-kody-import':
+		'literal dynamic import("kody:@...") is deprecated: use a static import and declare it in package.json#kody.dependencies',
+}
+
+const maxReportedDeprecatedUsages = 5
+
+export function formatDeprecatedInvocationUsageWarning(
+	usages: Array<DeprecatedInvocationUsage>,
+) {
+	if (usages.length === 0) return null
+	const shown = usages.slice(0, maxReportedDeprecatedUsages)
+	const hiddenCount = usages.length - shown.length
+	const details = shown
+		.map(
+			(usage) =>
+				`"${usage.filePath}": ${deprecatedUsageReplacements[usage.kind]}`,
+		)
+		.join('; ')
+	return `Deprecation warnings (non-blocking): ${details}${
+		hiddenCount > 0 ? ` (and ${hiddenCount} more)` : ''
+	}.`
+}

--- a/packages/worker/src/package-runtime/module-graph-import-rewriting.ts
+++ b/packages/worker/src/package-runtime/module-graph-import-rewriting.ts
@@ -432,7 +432,7 @@ async function rewriteKodyImports(input: {
 				end: node.end,
 				value: `${dynamicPackageImportHelperName}(${JSON.stringify(
 					`./${proxyPath}`,
-				)})`,
+				)}, ${JSON.stringify(node.literalSpecifier)})`,
 			})
 			continue
 		}

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import type * as PublishedBundleArtifactsModule from './published-bundle-artifacts.ts'
 
@@ -1491,6 +1492,7 @@ export default async function run() {
 		userId: 'user-1',
 		modules: bundle.modules,
 	})
+	consoleWarn.mockImplementation(() => {})
 	const moduleGraph = await createTemporaryModuleGraph(hydratedModules)
 	try {
 		const entry = (await moduleGraph.importModule(bundle.mainModule)) as {
@@ -1504,6 +1506,14 @@ export default async function run() {
 	} finally {
 		await moduleGraph.cleanup()
 	}
+	// The literal dynamic import shim warns once per specifier, naming the
+	// static-import replacement.
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining(
+			'[deprecated] dynamic import("kody:@kentcdodds/example-package/value")',
+		),
+	)
 	expect(mockModule.getSavedPackageByName).toHaveBeenCalledWith(
 		{},
 		expect.objectContaining({

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'vitest'
 import { createWorker } from '@cloudflare/worker-bundler'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
+import { createExecutePackageInvokeTools } from '#worker/package-invocations/service.ts'
 import {
 	buildKodyImportableModuleBundle,
 	buildKodyModuleBundle,
@@ -861,3 +862,185 @@ test('ad hoc execute runtime exposes packages as null without package invoke too
 		hasInvoke: false,
 	})
 })
+
+test(
+	'key-less packages.invoke runs the target package lean in its own realm',
+	{ timeout: 30_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		await ensureSavedPackageArtifactSchema()
+		const unique = crypto.randomUUID()
+		const userId = `user-${unique}`
+		const sourceId = `source-${unique}`
+		const packageId = `pkg-${unique}`
+		const publishedCommit = `commit-${unique}`
+		const source = await insertSavedPackage({
+			userId,
+			packageId,
+			kodyId: 'lean-target',
+			name: '@kentcdodds/lean-target',
+			sourceId,
+			publishedCommit,
+		})
+		const targetSourceFiles = {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/lean-target',
+				exports: {
+					'./probe': './src/probe.ts',
+				},
+				kody: {
+					id: 'lean-target',
+					description: 'Lean invoke probe target',
+				},
+			}),
+			'src/probe.ts': [
+				"import { packageContext } from 'kody:runtime'",
+				'',
+				'let isolateCallCount = 0',
+				'',
+				'export default async function probe(input: { marker?: string } = {}) {',
+				'\tisolateCallCount += 1',
+				";(globalThis as Record<string, unknown>).__kodyLeanTargetMarker = 'target'",
+				'\treturn {',
+				'\t\tmarker: input.marker ?? null,',
+				'\t\tisolateCallCount,',
+				'\t\ttargetKodyId: packageContext?.kodyId ?? null,',
+				"\t\tcallerMarkerVisible: typeof (globalThis as Record<string, unknown>).__kodyLeanCallerMarker !== 'undefined',",
+				'\t}',
+				'}',
+			].join('\n'),
+		}
+		await persistPublishedSourceSnapshot({
+			env,
+			userId,
+			source,
+			snapshot: {
+				files: targetSourceFiles,
+			},
+		})
+		const artifactBundle = await buildKodyImportableModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId,
+			sourceFiles: targetSourceFiles,
+			entryPoint: 'src/probe.ts',
+		})
+		await persistPublishedBundleArtifact({
+			env,
+			userId,
+			source,
+			kind: 'importable-module',
+			artifactName: './probe',
+			entryPoint: 'src/probe.ts',
+			mainModule: artifactBundle.mainModule,
+			modules: artifactBundle.modules,
+			dependencies: artifactBundle.dependencies,
+			packageContext: {
+				packageId,
+				kodyId: 'lean-target',
+				sourceId,
+			},
+		})
+
+		const callerBundle = await buildKodyModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId,
+			sourceFiles: {
+				'entry.ts': [
+					"import { packages } from 'kody:runtime'",
+					'',
+					'export default async function main() {',
+					";(globalThis as Record<string, unknown>).__kodyLeanCallerMarker = 'caller'",
+					'\tconst startedAt = Date.now()',
+					"\tconst first = await packages?.invoke({ kodyId: 'lean-target', exportName: './probe', params: { marker: 'first' } })",
+					'\tconst firstDurationMs = Date.now() - startedAt',
+					"\tconst second = await packages?.invoke({ kodyId: 'lean-target', exportName: './probe', params: { marker: 'second' } })",
+					"\tconst checked = await packages?.invokeChecked({ kodyId: 'lean-target', exportName: './probe', params: { marker: 'checked' } })",
+					"\tconst checkResult = (await packages?.check({ kodyId: 'lean-target', exportName: './probe' })) as { ok?: boolean }",
+					'\treturn {',
+					'\t\tfirst,',
+					'\t\tsecond,',
+					'\t\tchecked,',
+					'\t\tcheckOk: checkResult?.ok === true,',
+					'\t\tfirstDurationMs,',
+					"\t\ttargetMarkerVisible: typeof (globalThis as Record<string, unknown>).__kodyLeanTargetMarker !== 'undefined',",
+					'\t}',
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+		const callerContext = createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId,
+				email: 'worker@example.com',
+				displayName: 'Worker Test',
+			},
+		})
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			{
+				mainModule: callerBundle.mainModule,
+				modules: callerBundle.modules,
+			},
+			undefined,
+			{
+				packageContext: null,
+				packageInvokeTools: createExecutePackageInvokeTools({
+					env,
+					baseUrl: 'https://kody.dev',
+					callerContext,
+				}),
+				skipCapabilityRegistry: true,
+			},
+		)
+
+		expect(result.error).toBeUndefined()
+		const payload = result.result as {
+			first: Record<string, unknown>
+			second: Record<string, unknown>
+			checked: Record<string, unknown>
+			checkOk: boolean
+			firstDurationMs: number
+			targetMarkerVisible: boolean
+		}
+		// The target ran in its own runtime (packageContext bound to the target
+		// package) and each key-less invoke got a fresh isolate.
+		expect(payload.first).toEqual({
+			marker: 'first',
+			isolateCallCount: 1,
+			targetKodyId: 'lean-target',
+			callerMarkerVisible: false,
+		})
+		expect(payload.second).toEqual({
+			marker: 'second',
+			isolateCallCount: 1,
+			targetKodyId: 'lean-target',
+			callerMarkerVisible: false,
+		})
+		// Deprecated shims keep working end to end.
+		expect(payload.checked).toEqual({
+			marker: 'checked',
+			isolateCallCount: 1,
+			targetKodyId: 'lean-target',
+			callerMarkerVisible: false,
+		})
+		expect(payload.checkOk).toBe(true)
+		// Realm separation in the other direction: the target's globals never
+		// leak back into the caller realm.
+		expect(payload.targetMarkerVisible).toBe(false)
+		expect(payload.firstDurationMs).toBeGreaterThanOrEqual(0)
+		// The deprecation warnings surface in the caller's captured logs, once
+		// per helper, naming the replacement.
+		const warningLogs = (result.logs ?? []).filter((entry) =>
+			entry.includes('[deprecated]'),
+		)
+		expect(warningLogs).toEqual([
+			expect.stringContaining('[deprecated] packages.invokeChecked'),
+			expect.stringContaining('[deprecated] packages.check'),
+		])
+	},
+)

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -1032,7 +1032,10 @@ test(
 		// Realm separation in the other direction: the target's globals never
 		// leak back into the caller realm.
 		expect(payload.targetMarkerVisible).toBe(false)
-		expect(payload.firstDurationMs).toBeGreaterThanOrEqual(0)
+		// Sanity bound only: workerd test timing is too noisy for a strict
+		// budget; the production lean-path latency claim is validated by live
+		// probes, not this test.
+		expect(payload.firstDurationMs).toBeLessThan(20_000)
 		// The deprecation warnings surface in the caller's captured logs, once
 		// per helper, naming the replacement.
 		const warningLogs = (result.logs ?? []).filter((entry) =>

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -579,10 +579,20 @@ const ${input.helperName} = async (specifier) => {
 export function createDynamicPackageImportHelperSource(input: {
 	helperName: string
 }) {
+	// Literal dynamic kody:@ imports are a deprecated widen-phase shim: they
+	// keep resolving via host hydration but warn once per specifier naming
+	// the static-import replacement.
 	return `
-const ${input.helperName} = async (specifier) => {
-	return await import(specifier);
-};
+const ${input.helperName} = (() => {
+	const warned = new Set();
+	return async (specifier, kodySpecifier) => {
+		if (kodySpecifier && !warned.has(kodySpecifier)) {
+			warned.add(kodySpecifier);
+			console.warn('[deprecated] dynamic import("' + kodySpecifier + '"): use a static import (import fn from "' + kodySpecifier + '") instead. Static imports from execute always see the current published version; saved packages must also declare the dependency in package.json#kody.dependencies. When the target name is only known at runtime, use packages.invoke({ kodyId, exportName, params }).');
+		}
+		return await import(specifier);
+	};
+})();
 `.trim()
 }
 

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -1522,6 +1522,54 @@ export default async function main() {
 	expect(aliasedStorageLint?.message).toContain('packageStorage()')
 })
 
+test('runRepoChecks warns (without failing) on deprecated dynamic invocation usage', async () => {
+	// Widen-phase contract: packages.check, packages.invokeChecked, and
+	// literal dynamic import("kody:@...") keep publishing, but the passing
+	// lint message names each usage and its replacement.
+	const deprecated = await runPackageJobTypecheckChecks(
+		new Map<string, string>([
+			[
+				'package.json',
+				createPackageManifest({
+					packageName: '@kody/deprecated-invocation-package',
+					kodyId: 'deprecated-invocation-package',
+					description: 'Uses deprecated dynamic invocation APIs',
+				}),
+			],
+			[
+				'src/index.ts',
+				`import { packages } from 'kody:runtime'
+
+export default async function main() {
+	const dynamicModule = await import('kody:@kentcdodds/example-package/value')
+	await packages?.check({ kodyId: 'example-package', exportName: './value' })
+	return await packages?.invokeChecked({
+		kodyId: 'example-package',
+		exportName: './value',
+		params: { fromDynamic: typeof dynamicModule.default },
+	})
+}
+`,
+			],
+		]),
+	)
+	expect(deprecated.result.ok).toBe(true)
+	const deprecatedLint = deprecated.result.results.find(
+		(entry) => entry.kind === 'lint',
+	)
+	expect(deprecatedLint).toMatchObject({ kind: 'lint', ok: true })
+	expect(deprecatedLint?.message).toContain('Deprecation warnings')
+	expect(deprecatedLint?.message).toContain('"src/index.ts"')
+	expect(deprecatedLint?.message).toContain(
+		'packages.invokeChecked is deprecated',
+	)
+	expect(deprecatedLint?.message).toContain('packages.check is deprecated')
+	expect(deprecatedLint?.message).toContain(
+		'literal dynamic import("kody:@...") is deprecated',
+	)
+	expect(deprecatedLint?.message).toContain('static')
+})
+
 test('heavy check phases run in throwaway isolates when the env has the bindings', async () => {
 	setupDefaultBundleMocks()
 	const files = new Map<string, string>([

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -21,6 +21,10 @@ import {
 	type PublishedPackageArtifactBuildTarget,
 } from '#worker/package-runtime/package-artifact-targets.ts'
 import {
+	collectDeprecatedInvocationUsage,
+	formatDeprecatedInvocationUsageWarning,
+} from '#worker/package-runtime/deprecated-invocation-usage.ts'
+import {
 	collectStaticKodyPackageImportsFromFiles,
 	isTypeDeclarationFilePath,
 } from '#worker/package-runtime/static-kody-imports.ts'
@@ -993,6 +997,18 @@ function buildLintCheck(sourceFiles: Record<string, string>): {
 } {
 	const ambientStorageFiles = collectAmbientStorageImportFiles(sourceFiles)
 	if (ambientStorageFiles.length === 0) {
+		// Widen-phase deprecations stay non-fatal: publishes succeed, but the
+		// passing lint message names each legacy invocation usage and its
+		// replacement so new packages stop adopting the retired surface.
+		const deprecationWarning = formatDeprecatedInvocationUsageWarning(
+			collectDeprecatedInvocationUsage(sourceFiles),
+		)
+		if (deprecationWarning) {
+			return {
+				ok: true,
+				message: `Lint passed. ${deprecationWarning}`,
+			}
+		}
 		return { ok: true, message: lintPlaceholderPassedMessage }
 	}
 	const shownFiles = ambientStorageFiles.slice(

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -108,7 +108,10 @@ export type RunRecordContext = {
 
 /**
  * Persistence for one begin/finish pair. Same as
- * {@link runPersistenceForSurface} except keyed `execute` upgrades to `eager`.
+ * {@link runPersistenceForSurface} except the idempotency key toggles the two
+ * caller-facing surfaces: keyed `execute` upgrades to `eager`, and key-less
+ * `export` (the lean `packages.invoke` path, which has no ledger row and
+ * returns its result inline) downgrades to `on-failure`.
  */
 export function runPersistenceForContext(
 	context: Pick<RunRecordContext, 'surface' | 'idempotencyKey'>,
@@ -116,6 +119,9 @@ export function runPersistenceForContext(
 	const key = context.idempotencyKey?.trim()
 	if (context.surface === 'execute' && key) {
 		return 'eager'
+	}
+	if (context.surface === 'export' && !key) {
+		return 'on-failure'
 	}
 	return runPersistenceForSurface(context.surface)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First slice of the static-first package model program (widen phase): `packages.invoke` becomes the single dynamic invocation primitive — always contract-checked, with durability selected by key presence — and the legacy surface (`packages.check`, `packages.invokeChecked`, literal dynamic `import("kody:@...")`) turns into working deprecation shims that teach the replacement.

### The decided model (two ways, one rule each)

1. `import fn from 'kody:@scope/pkg/export'` — the default for package reuse when the target's name is known at write time. Typed, publish-verified, dependency-graph-visible, ~0 ms per call.
2. `packages.invoke({ kodyId, exportName, params, idempotencyKey? })` — the only dynamic primitive, always contract-checked before invoking.
   - **Keyless = lean/ephemeral**: current published version, runs in the target package's own runtime (packageContext, secret mounts, packageStorage, fresh isolate), no idempotency ledger row, no account write lease, run records on-failure-only. The spike measured this shape at ~17 ms warm vs ~600–1000 ms for the ledger path.
   - **Keyed = durable/exactly-once**: unchanged ledger claim, bounded response replay, eager run records.

This mirrors execute's existing keyless/keyed convention.

### What changed

- **`package-invocations/module-execution.ts` (new)**: the single-run execution core (artifact ensure → caller context → `runBundledModuleWithRegistry` → response build), extracted from `invokeSavedPackageModule` and shared by both paths. `runSavedPackageModuleEphemeral` is the lean entry.
- **`idempotent-module-invocation.ts`**: keeps every keyed semantic (request-hash mismatch → 409, in-progress poll 100 ms / 1 s budget, stale reclaim at 15 min, bounded replay with `replayed` flag, transient-artifact claim release) and delegates execution to the shared core. One review-driven improvement: a failed terminal persist after a successful run no longer stores a permanent failure under the key — the success is returned and the claim stays eligible for stale reclaim.
- **`runtime-tool-factories.ts`**: `packages.invoke` now contract-checks first via `checkPackageInvokeForRuntimeWithPreloads` (the check preloads the package row, manifest, and bundle artifact, so one logical call resolves its package exactly once), then routes keyed/keyless. `invokeChecked` is a working alias. Auto-generated idempotency keys are removed: keyless nested invokes are ephemeral by contract; exactly-once needs an explicit key.
- **`http-invoke.ts`**: runtime entry points route `idempotencyKey: null` to the lean path. External HTTP token invocations stay keyed-only (providers retry deliveries; exactly-once is the point of that surface). Event dispatch / subscriptions / webhooks / workflows always mint keys and are untouched.
- **`run-records/types.ts`**: keyless `export`-surface runs downgrade to on-failure persistence, mirroring keyless `execute`.
- **Deprecation shims (results/logs name the exact replacement)**: sandbox `packages` prelude warns once per run on `check`/`invokeChecked`; the dynamic package import helper warns once per specifier; publish checks emit non-fatal deprecation warnings in the passing lint message (new `package-runtime/deprecated-invocation-usage.ts` AST collector).

### Behavior notes for reviewers

- `packages.invoke` previously auto-generated an idempotency key (random for execute callers; parent-derived for nested package calls). Under the decided model keyless = no ledger row, so a keyed parent replaying mid-crash re-executes keyless children. Callers that need exactly-once children now pass explicit keys — this is the intended semantic, and phase 2 migrated production packages accordingly.
- `invokeChecked`'s check-failure error text changed from `packages.invokeChecked check failed: …` to `packages.invoke contract check failed: …`.
- Keyless responses carry no `idempotency` section — the absence is the signal that the call was ephemeral.

### Testing

- New end-to-end workers test (`module-graph.workers.test.ts`, real workerd + real D1-seeded target package + real invoke tools, adapted from the spike harness): keyless invoke runs the target in its own realm — fresh isolate per call, `packageContext` bound to the target, globals invisible in both directions — and the shim warnings surface in run logs.
- New node tests: keyless re-executes on repeat with no ledger row; keyed replays exactly-once; `invokeChecked` alias parity; publish-check deprecation warnings (including `packages?.check` optional-chaining and literal dynamic imports).
- Full unit suite green: 465 files / 1596 tests. Full local `npm run validate` green. CI ✅ Validate green.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `60badbaf` · **Head:** `8d5a8032`

**Classification:** extends — the dynamic invocation contract (`packages.invoke`), run-record persistence policy, and publish lint check change shape; no new primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `capabilities-execute` | runtime | extends — invocation path split into keyed/keyless around a shared execution core (`package-invocations/` is currently unmapped in primitives.yaml; it belongs to this territory) |
| `package-runtime` | runtime | extends — dynamic import helper warns per specifier; new deprecated-usage AST collector |
| `mcp-server` | surfaces | extends — sandbox `packages` prelude emits deprecation warnings for `check`/`invokeChecked` |
| `run-records` | storage | extends — keyless `export` surface downgrades to on-failure persistence |
| `repo-sessions` | runtime | composes — lint check appends non-fatal deprecation warnings to its passing message |

### System map

Keyless `packages.invoke` flows from the sandbox bridge through the contract check into a lean execution core, skipping the D1 ledger and account write lease that the keyed path keeps.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	runRecords["run-records<br/>Run records"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	mcpServer -->|"packages prelude: invoke routes by key; check/invokeChecked warn"| capabilitiesExecute
	capabilitiesExecute -->|"keyless: runSavedPackageModuleEphemeral (no ledger, no lease)"| packageRuntime
	capabilitiesExecute -->|"keyed only: package_invocations claim + replay"| d1AppDb
	packageRuntime -->|"keyless export runs persist on failure only"| runRecords
	repoSessions -->|"lint message: non-fatal deprecation warnings"| packageRuntime
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
before: packages.invoke(input)        -> auto idempotency key -> D1 ledger claim -> lease -> execute -> terminal write
after:  packages.invoke(input)        -> contract check (preloads) -> lean execute (no durable writes on success)
        packages.invoke({..., idempotencyKey }) -> contract check (preloads) -> D1 ledger claim -> lease -> execute -> terminal write
```

</details>

<!-- system-recap:end -->

## Program report

- **Program**: static imports default for package reuse; `packages.invoke` the only dynamic primitive; legacy surface retired via widen → migrate → narrow.
- **Status**: Phase 1 core slice green (CI ✅, CodeRabbit's one actionable comment addressed — successful results no longer persist as failed ledger states). Phase 2 production migration completed 2026-07-30 ~11:15 UTC (before the hold-off instruction landed): all 58 saved packages audited; the 10 using `invokeChecked` (release, bwk-publish, morning-briefing, journaling, personal-history, sentry-triage, discord, email-received-subscriber, skills, github) migrated to static imports / keyless `packages.invoke`, republished, and smoke-tested live (static `sentry-triage/get-issue-state`: 28 ms end-to-end; bwk-publish: full Notion+Transistor+Kit round-trip green). Zero `packages.check` / bare-invoke / dynamic `import("kody:@")` call sites existed. Skills registry clean; two-rule model recorded in memory.
- **Codemod coordination (per Kent, 11:30 UTC)**: no further manual package migrations. The package-codemod framework (agent bc-b0ac2c03, design phase, awaiting Kent's in-repo confirmation) becomes the vehicle for everything package-touching from here: once it merges, this program registers a `static-first-invocation` codemod (detect+transform for `invokeChecked` / `packages.check` / literal dynamic `kody:@` imports) and uses its fleet-wide `scan` as the phase-3 gate ("legacy surface absent from all production packages") plus the migration path for community forks and future users. No file conflicts between the codemod framework's planned surface and PRs #1045/#1046/#1047.
- **Parallel tracks**: static-call metering [#1047](https://github.com/kentcdodds/kody/pull/1047) (QA'd: mergeable, follow-ups relayed); guidance rewrite [#1045](https://github.com/kentcdodds/kody/pull/1045) (QA'd: mergeable after this PR, one stale-example fix relayed).
- **Decision needed**: per program policy this core API-change PR waits for Kent's review — comment "merge granted" (or review-approve) and Kody ships it, then the D1→RunLog DO ledger migration track starts.
- **Next phase gate**: this PR merged + deployed → live lean-path probes (keyless tens of ms) → guidance PR merges → codemod framework merges → static-first codemod registered + fleet scan zero → phase 3 narrow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3b1e796-faee-4b69-910d-1ec4f03e60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3b1e796-faee-4b69-910d-1ec4f03e60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added key-less package invocations that run ephemerally without idempotency records.
  * Keyed invocations continue to support exactly-once replay behavior.
* **Deprecations**
  * Deprecated invocation methods and dynamic imports now provide clear, non-blocking warnings.
  * Repository checks identify deprecated usage while still allowing validation to pass.
* **Bug Fixes**
  * Improved invocation error handling and response formatting for key-less requests.
  * Preserved isolated execution behavior for nested package invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->