### PR TITLE
Meter statically imported package export calls (package_static_call)

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -39,17 +39,18 @@ stays reviewable in one place.
 
 ### Metrics and their chokepoints
 
-| `eventType`        | Metered unit                                    | Recorded at                                                                                | `entityId`                     |
-| ------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------ |
-| `execute`          | one dynamic-worker sandbox evaluation           | `packages/worker/src/mcp/executor.ts` (`execute`)                                          | none                           |
-| `package_export`   | one saved-package bundled-code run              | `packages/worker/src/mcp/run-kody-registry.ts` (bundled runs with a package context)       | package id                     |
-| `job_run`          | one job execution                               | `packages/worker/src/jobs/service.ts` (`executeJobOnce`)                                   | job id                         |
-| `workflow_run`     | one Cloudflare Workflow run                     | `packages/worker/src/package-runtime/package-workflows.ts` (`DynamicCallableWorkflow.run`) | workflow instance id           |
-| `service_runtime`  | one package service run (bounded or persistent) | `packages/worker/src/package-runtime/package-service.ts` (run finalization)                | `{packageId}:{serviceName}`    |
-| `realtime_session` | one realtime websocket session                  | reserved — not yet instrumented                                                            | session id                     |
-| `outbound_fetch`   | one outbound fetch through the gateway          | `packages/worker/src/mcp/fetch-gateway.ts` (`KodyFetchGateway.fetch`)                      | request host                   |
-| `email_send`       | one outbound email send attempt                 | `packages/worker/src/email/outbound.ts` (`sendOutboundEmail`)                              | email message id               |
-| `email_received`   | one inbound receive attempt for a routed inbox  | `packages/worker/src/email/inbound.ts` (`handleInboundEmail`, after inbox resolution)      | email message id (when stored) |
+| `eventType`           | Metered unit                                                                      | Recorded at                                                                                                                                                                 | `entityId`                     |
+| --------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `execute`             | one dynamic-worker sandbox evaluation                                             | `packages/worker/src/mcp/executor.ts` (`execute`)                                                                                                                           | none                           |
+| `package_export`      | one saved-package bundled-code run                                                | `packages/worker/src/mcp/run-kody-registry.ts` (bundled runs with a package context)                                                                                        | package id                     |
+| `package_static_call` | one call of a statically imported package export (function-valued, incl. default) | sandbox-side wrapper stamped by the bundler; validated and recorded host-side by `packages/worker/src/usage/package-static-call-usage.ts` (wired in `run-kody-registry.ts`) | callee package id              |
+| `job_run`             | one job execution                                                                 | `packages/worker/src/jobs/service.ts` (`executeJobOnce`)                                                                                                                    | job id                         |
+| `workflow_run`        | one Cloudflare Workflow run                                                       | `packages/worker/src/package-runtime/package-workflows.ts` (`DynamicCallableWorkflow.run`)                                                                                  | workflow instance id           |
+| `service_runtime`     | one package service run (bounded or persistent)                                   | `packages/worker/src/package-runtime/package-service.ts` (run finalization)                                                                                                 | `{packageId}:{serviceName}`    |
+| `realtime_session`    | one realtime websocket session                                                    | reserved — not yet instrumented                                                                                                                                             | session id                     |
+| `outbound_fetch`      | one outbound fetch through the gateway                                            | `packages/worker/src/mcp/fetch-gateway.ts` (`KodyFetchGateway.fetch`)                                                                                                       | request host                   |
+| `email_send`          | one outbound email send attempt                                                   | `packages/worker/src/email/outbound.ts` (`sendOutboundEmail`)                                                                                                               | email message id               |
+| `email_received`      | one inbound receive attempt for a routed inbox                                    | `packages/worker/src/email/inbound.ts` (`handleInboundEmail`, after inbox resolution)                                                                                       | email message id (when stored) |
 
 `email_received` covers receive attempts once an inbound message is routed to a
 known, enabled inbox: stored messages record `success`; unverified-account
@@ -58,13 +59,58 @@ rejections, size rejections, entitlement rejections, and parse failures record
 rejected mail. Mail rejected before inbox resolution (unknown alias, disabled
 inbox) has no owning user and is not metered.
 
+### `package_static_call`: statically imported package export calls
+
+Static imports (`import fn from 'kody:@scope/pkg/export'`) are the default way
+package code is reused, so calls through them are metered per call:
+
+- **Metered unit:** one call of a function-valued export (named or default) that
+  was statically imported from a saved package. Non-function exports pass
+  through unwrapped; imports that are never called record nothing. `userId` is
+  the user the host run executes as, `entityId` is the **callee** package id,
+  `durationMs` is the wall time of the call (through settlement for async
+  functions), and `outcome` is `error` iff the call threw or rejected — the
+  error still propagates to the caller unchanged.
+- **Provenance is bundler stamping, never sandbox strings.** The import
+  rewriter's proxy module (`ensurePackageProxy` in
+  `packages/worker/src/package-runtime/module-graph-import-rewriting.ts`) knows
+  which saved package a `kody:@…` specifier resolved to and bakes that id into
+  the generated proxy (`createMeteredPackageImportProxySource`), which wraps
+  function exports with `__kodyMeterStaticPackageExport` from the virtual
+  runtime module — the same stamping discipline as per-package
+  `packageStorage()` routing. Root self-imports are not stamped (the run already
+  records `package_export` for that package).
+- **Host-side validation (trust model, stated honestly):** stamped ids ride in
+  generated code, but that code still executes inside the sandbox realm, so a
+  malicious module could forge reports. The host
+  (`createPackageStaticCallMeterTools` in
+  `packages/worker/src/usage/package-static-call-usage.ts`) only records events
+  whose stamped id is in the run's bundler-recorded static dependency grant set
+  (the same set `packageStorage()` grants use) and silently drops the rest with
+  a debug log. Forgery can therefore at worst inflate counts for packages the
+  bundle already statically depends on.
+- **Delivery never blocks the call path.** Each call does one synchronous buffer
+  push (capped at 1000 events per run; overflow is dropped); the run wrapper in
+  `runBundledModuleWithRegistry` flushes the buffer over a runtime bridge in one
+  batch at the end of the run, while the sandbox RPC dispatchers are still live
+  — a fire-and-forget RPC per call would race dispatcher teardown and lose
+  events. Flush failures are swallowed.
+- **Coverage:** every surface that funnels through
+  `runBundledModuleWithRegistry` (ad hoc execute with static `kody:@…` imports,
+  saved-package invocations, and the job/workflow/service runs built on them).
+  Package-app fetch handlers use a separate runtime bridge and do not bind the
+  meter yet; the wrapper silently no-ops there.
+
 ### Nesting: metrics are independent, do not sum across types
 
 Execution surfaces nest. A job run funnels through the bundled-module runner and
 the sandbox executor, so a single package job produces one `job_run`, one
-`package_export`, and one `execute` event, each measuring its own layer. This is
-intentional: each metric answers its own question (`execute` is total sandbox
-pressure; `job_run` is job activity). Never add durations across different
+`package_export`, and one `execute` event, each measuring its own layer.
+Likewise, a bundled run that calls statically imported package exports produces
+one `package_static_call` event per call **inside** the run's own
+`execute`/`package_export` span. This is intentional: each metric answers its
+own question (`execute` is total sandbox pressure; `job_run` is job activity;
+`package_static_call` is per-callee reuse). Never add durations across different
 `eventType` values — that double counts nested layers. Within one `eventType`,
 each chokepoint records exactly one event per metered unit, so sums are safe.
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -90,15 +90,19 @@ package code is reused, so calls through them are metered per call:
   a debug log. Forgery can therefore at worst inflate counts for packages the
   bundle already statically depends on.
 - **Delivery never blocks the call path.** Each call does one synchronous buffer
-  push (capped at 1000 events per run; overflow is dropped); the run wrapper in
-  `runBundledModuleWithRegistry` flushes the buffer over a runtime bridge in
-  batches at the end of the run, while the sandbox RPC dispatchers are still
-  live — a fire-and-forget RPC per call would race dispatcher teardown and lose
-  events. The flush loops (bounded) so async calls that settle during an
-  in-flight flush are still delivered; calls that have **not settled when the
-  run's entrypoint finishes** (a promise the run never awaited) are not metered
-  — metering never extends a run's lifetime, and such a dangling promise may
-  never settle inside the sandbox at all. Flush failures are swallowed.
+  push (capped at 200 events per run — Analytics Engine allows 250
+  `writeDataPoint` calls per invocation, one per event, and the run's other
+  usage events need headroom; overflow is dropped and the cap is enforced
+  host-side too); the run wrapper in `runBundledModuleWithRegistry` flushes the
+  buffer over a runtime bridge in batches at the end of the run, while the
+  sandbox RPC dispatchers are still live — a fire-and-forget RPC per call would
+  race dispatcher teardown and lose events. The awaited flush is bounded by a
+  short timeout so a slow bridge never owns the run's tail latency, and it loops
+  (bounded) so async calls that settle during an in-flight flush are still
+  delivered; calls that have **not settled when the run's entrypoint finishes**
+  (a promise the run never awaited) are not metered — metering never extends a
+  run's lifetime, and such a dangling promise may never settle inside the
+  sandbox at all. Flush failures are swallowed.
 - **Coverage:** every surface that funnels through
   `runBundledModuleWithRegistry` (ad hoc execute with static `kody:@…` imports,
   saved-package invocations, and the job/workflow/service runs built on them).

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -85,10 +85,13 @@ package code is reused, so calls through them are metered per call:
   malicious module could forge reports. The host
   (`createPackageStaticCallMeterTools` in
   `packages/worker/src/usage/package-static-call-usage.ts`) only records events
-  whose stamped id is in the run's bundler-recorded static dependency grant set
-  (the same set `packageStorage()` grants use) and silently drops the rest with
-  a debug log. Forgery can therefore at worst inflate counts for packages the
-  bundle already statically depends on.
+  whose stamped id is in the bundle's **static** dependency package ids recorded
+  at build time (`bundle.dependencies`) — a strict subset of the
+  `packageStorage()` grant set, which additionally grants the run's own package
+  id and dynamic-import dependencies, neither of which the bundler ever stamps
+  into a metered proxy — and silently drops the rest with a debug log. Forgery
+  can therefore at worst inflate counts for packages the bundle already
+  statically depends on.
 - **Delivery never blocks the call path.** Each call does one synchronous buffer
   push (capped at 200 events per run — Analytics Engine allows 250
   `writeDataPoint` calls per invocation, one per event, and the run's other
@@ -108,6 +111,13 @@ package code is reused, so calls through them are metered per call:
   saved-package invocations, and the job/workflow/service runs built on them).
   Package-app fetch handlers use a separate runtime bridge and do not bind the
   meter yet; the wrapper silently no-ops there.
+- **Capacity note:** the 200-events-per-run cap shares the ~250
+  `writeDataPoint`-per-invocation Analytics Engine budget with every other usage
+  event in the same invocation — in particular `outbound_fetch`, which also
+  scales per operation. A heavy run (many static calls **and** many gateway
+  fetches) can exceed the budget and Analytics Engine silently drops the
+  overflow points. The eventual fix is aggregation (coalescing per-callee
+  counts/durations into fewer data points), not raising the cap.
 
 ### Nesting: metrics are independent, do not sum across types
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -91,10 +91,14 @@ package code is reused, so calls through them are metered per call:
   bundle already statically depends on.
 - **Delivery never blocks the call path.** Each call does one synchronous buffer
   push (capped at 1000 events per run; overflow is dropped); the run wrapper in
-  `runBundledModuleWithRegistry` flushes the buffer over a runtime bridge in one
-  batch at the end of the run, while the sandbox RPC dispatchers are still live
-  — a fire-and-forget RPC per call would race dispatcher teardown and lose
-  events. Flush failures are swallowed.
+  `runBundledModuleWithRegistry` flushes the buffer over a runtime bridge in
+  batches at the end of the run, while the sandbox RPC dispatchers are still
+  live — a fire-and-forget RPC per call would race dispatcher teardown and lose
+  events. The flush loops (bounded) so async calls that settle during an
+  in-flight flush are still delivered; calls that have **not settled when the
+  run's entrypoint finishes** (a promise the run never awaited) are not metered
+  — metering never extends a run's lifetime, and such a dangling promise may
+  never settle inside the sandbox at all. Flush failures are swallowed.
 - **Coverage:** every surface that funnels through
   `runBundledModuleWithRegistry` (ad hoc execute with static `kody:@…` imports,
   saved-package invocations, and the job/workflow/service runs built on them).

--- a/packages/worker/client/charts/chart-theme.ts
+++ b/packages/worker/client/charts/chart-theme.ts
@@ -13,6 +13,7 @@ export const chartColor = {
 	cyan: '#06b6d4',
 	lime: '#84cc16',
 	fuchsia: '#d946ef',
+	teal: '#14b8a6',
 } as const
 
 export const chartSeriesColors = [
@@ -24,6 +25,7 @@ export const chartSeriesColors = [
 	chartColor.cyan,
 	chartColor.lime,
 	chartColor.fuchsia,
+	chartColor.teal,
 ] as const
 
 export const chartGridStroke =

--- a/packages/worker/client/charts/usage-metric-series.ts
+++ b/packages/worker/client/charts/usage-metric-series.ts
@@ -19,6 +19,11 @@ export const usageMetricSeries: Array<UsageMetricSeries> = [
 		label: 'Package runs',
 		color: chartColor.emerald,
 	},
+	{
+		metric: 'package_static_call',
+		label: 'Static package calls',
+		color: chartColor.teal,
+	},
 	{ metric: 'job_run', label: 'Job runs', color: chartColor.amber },
 	{ metric: 'workflow_run', label: 'Workflow runs', color: chartColor.violet },
 	{

--- a/packages/worker/src/admin/user-usage-data.ts
+++ b/packages/worker/src/admin/user-usage-data.ts
@@ -22,6 +22,7 @@ import {
 export const adminUsageMetrics = [
 	'execute',
 	'package_export',
+	'package_static_call',
 	'job_run',
 	'workflow_run',
 	'service_runtime',

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -213,6 +213,7 @@ export type AdminFeatureFlagsLoaderData = {
 export type AdminUsageMetric =
 	| 'execute'
 	| 'package_export'
+	| 'package_static_call'
 	| 'job_run'
 	| 'workflow_run'
 	| 'service_runtime'

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
@@ -12,6 +12,7 @@ import {
 const usageMetricSchema = z.enum([
 	'execute',
 	'package_export',
+	'package_static_call',
 	'job_run',
 	'workflow_run',
 	'service_runtime',

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -1881,7 +1881,9 @@ test('runBundledModuleWithRegistry passes params and injects runtime helpers', a
 			() =>
 				({
 					async execute(_wrapped, providers) {
-						expect(providers).toHaveLength(2)
+						// Main provider + packages bridge + static-call meter
+						// bridge (bound whenever the run has a user).
+						expect(providers).toHaveLength(3)
 						providerFns = (
 							providers[0] as {
 								fns: Record<string, (args: unknown) => Promise<unknown>>

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -943,13 +943,20 @@ export async function runBundledModuleWithRegistry(
 			dynamicDependencyPackageIds,
 		})
 		// Static package export calls report through a sandbox bridge with a
-		// bundler-stamped callee package id; only ids from the same
-		// bundler/host controlled provenance set as packageStorage grants are
-		// recorded (mismatches are dropped host-side).
+		// bundler-stamped callee package id; only ids recorded as *static*
+		// bundle dependencies at build time are accepted (mismatches are
+		// dropped host-side). This is deliberately tighter than the
+		// packageStorage grant set, which additionally includes the run's own
+		// package id and dynamic-import dependencies — neither of which the
+		// bundler ever stamps into a metered static import proxy.
 		const staticCallMeterTools = createPackageStaticCallMeterTools({
 			env,
 			userId: callerContext.user?.userId ?? null,
-			grantedPackageIds: grantedPackageStorageIds,
+			grantedPackageIds: new Set(
+				(bundle.dependencies ?? [])
+					.map((dependency) => dependency.packageId)
+					.filter((packageId): packageId is string => Boolean(packageId)),
+			),
 		})
 		const executor = createExecuteExecutor({
 			env,

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -1051,14 +1051,23 @@ ${runtimeHelperRuntimePropertySource}
     packageContext: ${JSON.stringify(options?.packageContext ?? null)},
     serviceContext: ${JSON.stringify(options?.serviceContext ?? null)},
   };
-  return await __kodyRuntimeStorage.run(__kodyRuntime, async () => {
-    const __kodyModule = await import(${JSON.stringify(`./${bundle.mainModule}`)});
-    const __kodyEntrypoint = __kodyModule?.default;
-    if (typeof __kodyEntrypoint !== 'function') {
-      throw new Error('Kody execute modules must default export a function.');
+  try {
+    return await __kodyRuntimeStorage.run(__kodyRuntime, async () => {
+      const __kodyModule = await import(${JSON.stringify(`./${bundle.mainModule}`)});
+      const __kodyEntrypoint = __kodyModule?.default;
+      if (typeof __kodyEntrypoint !== 'function') {
+        throw new Error('Kody execute modules must default export a function.');
+      }
+      return await __kodyEntrypoint(${entrypointInputSource});
+    });
+  } finally {
+    // Deliver buffered static package export call usage events while the
+    // sandbox RPC dispatchers are still live. Metering never breaks the
+    // run it observes.
+    if (typeof __kodyStaticCallMeter !== 'undefined' && __kodyStaticCallMeter != null) {
+      try { await __kodyStaticCallMeter.flush(); } catch {}
     }
-    return await __kodyEntrypoint(${entrypointInputSource});
-  });
+  }
 }`
 		try {
 			const providers: Array<ResolvedProvider> = [

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -1063,9 +1063,19 @@ ${runtimeHelperRuntimePropertySource}
   } finally {
     // Deliver buffered static package export call usage events while the
     // sandbox RPC dispatchers are still live. Metering never breaks the
-    // run it observes.
+    // run it observes, and the bounded race keeps a slow metering bridge
+    // from owning the run's tail latency.
     if (typeof __kodyStaticCallMeter !== 'undefined' && __kodyStaticCallMeter != null) {
-      try { await __kodyStaticCallMeter.flush(); } catch {}
+      try {
+        let __kodyStaticCallMeterFlushTimer;
+        await Promise.race([
+          __kodyStaticCallMeter.flush(),
+          new Promise((resolve) => {
+            __kodyStaticCallMeterFlushTimer = setTimeout(resolve, 2_000);
+          }),
+        ]);
+        clearTimeout(__kodyStaticCallMeterFlushTimer);
+      } catch {}
     }
   }
 }`

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -79,6 +79,7 @@ import {
 import { createDynamicCallableWorkflow } from '#worker/package-runtime/package-workflows.ts'
 import { type BundleArtifactDependency } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
+import { createPackageStaticCallMeterTools } from '#worker/usage/package-static-call-usage.ts'
 import { recordAgentPackageConversationUses } from '#worker/usage/agent-package-conversation-uses.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import {
@@ -941,6 +942,15 @@ export async function runBundledModuleWithRegistry(
 			dependencies: bundle.dependencies ?? [],
 			dynamicDependencyPackageIds,
 		})
+		// Static package export calls report through a sandbox bridge with a
+		// bundler-stamped callee package id; only ids from the same
+		// bundler/host controlled provenance set as packageStorage grants are
+		// recorded (mismatches are dropped host-side).
+		const staticCallMeterTools = createPackageStaticCallMeterTools({
+			env,
+			userId: callerContext.user?.userId ?? null,
+			grantedPackageIds: grantedPackageStorageIds,
+		})
 		const executor = createExecuteExecutor({
 			env,
 			exports: options?.executorExports ?? workerExports,
@@ -1009,6 +1019,7 @@ export async function runBundledModuleWithRegistry(
 			workflowTools,
 			packageInvokeTools: options?.packageInvokeTools,
 			packageEventTools: options?.packageEventTools,
+			staticCallMeterTools,
 		}
 		const runtimeHelperPreludes =
 			createRuntimeHelperPreludes(runtimeHelperContext)

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -291,15 +291,21 @@ const events = {
 // synchronous buffer push (the call path never awaits and never throws);
 // the run wrapper awaits one `flush` bridge call at the end of the run,
 // while the sandbox RPC dispatchers are still live — a fire-and-forget RPC
-// per call would race dispatcher teardown and drop events. The buffer cap
-// bounds memory and the flush payload; calls past the cap in one run are
-// dropped (mirror the cap host-side in `createPackageStaticCallMeterTools`).
+// per call would race dispatcher teardown and drop events. The cumulative
+// cap bounds memory, the flush payload, and — most importantly — the
+// Analytics Engine budget: Workers Analytics Engine allows 250
+// `writeDataPoint` calls per invocation and each event is one data point,
+// so 200 leaves headroom for the run's other usage events. Calls past the
+// cap in one run are dropped (mirror the cap host-side in
+// `createPackageStaticCallMeterTools`).
 function createStaticCallMeterHelperPrelude() {
 	return `
+let __kodyStaticCallMeterReportedCount = 0;
 const __kodyStaticCallMeterEvents = [];
 const __kodyStaticCallMeter = {
   report: (event) => {
-    if (__kodyStaticCallMeterEvents.length >= 1000) return;
+    if (__kodyStaticCallMeterReportedCount >= 200) return;
+    __kodyStaticCallMeterReportedCount += 1;
     __kodyStaticCallMeterEvents.push(event);
   },
   // Flush in rounds: async calls that settle while a flush RPC is in

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -15,6 +15,10 @@ import {
 	createStorageHelperPrelude,
 } from '#worker/storage-runner.ts'
 import { type PackageWorkflowCreateInput } from '#worker/package-runtime/package-workflows.ts'
+import {
+	type PackageStaticCallMeterInput,
+	type PackageStaticCallMeterTools,
+} from '#worker/usage/package-static-call-usage.ts'
 
 export type AdditionalKodyTools = Record<
 	string,
@@ -132,6 +136,7 @@ export type RuntimeHelperManifestContext = {
 	workflowTools?: PackageWorkflowTools | undefined
 	packageInvokeTools?: PackageInvokeTools | undefined
 	packageEventTools?: PackageEventTools | undefined
+	staticCallMeterTools?: PackageStaticCallMeterTools | undefined
 }
 
 type RuntimeHelperManifestEntry = {
@@ -242,6 +247,8 @@ const workflows = {
 const packageInvokeRuntimeBridgeProviderName =
 	'__kodyPackageInvokeRuntimeBridge'
 const packageEventRuntimeBridgeProviderName = '__kodyPackageEventRuntimeBridge'
+const staticCallMeterRuntimeBridgeProviderName =
+	'__kodyStaticCallMeterRuntimeBridge'
 
 function createPackagesHelperPrelude() {
 	// `check` and `invokeChecked` are deprecated widen-phase shims: they keep
@@ -274,6 +281,18 @@ function createEventsHelperPrelude() {
 	return `
 const events = {
   dispatch: async (input) => await ${packageEventRuntimeBridgeProviderName}.dispatch(input ?? {}),
+};
+	`.trim()
+}
+
+// Internal bridge for the static package export call meter in the runtime
+// module (`__kodyMeterStaticPackageExport`): not an author-facing helper,
+// so it has no unbound-access rewrite name. The runtime wrapper reads it
+// from the run store and fires events without awaiting.
+function createStaticCallMeterHelperPrelude() {
+	return `
+const __kodyStaticCallMeter = {
+  record: (input) => ${staticCallMeterRuntimeBridgeProviderName}.record(input ?? {}),
 };
 	`.trim()
 }
@@ -410,6 +429,23 @@ function createPackageEventRuntimeBridgeProvider(
 				execute: async (args: unknown) =>
 					await packageEventTools.dispatch(
 						(args ?? {}) as PackageEventDispatchInput,
+					),
+			},
+		},
+	}
+	return resolveProvider(provider)
+}
+
+function createStaticCallMeterRuntimeBridgeProvider(
+	staticCallMeterTools: PackageStaticCallMeterTools,
+): ResolvedProvider {
+	const provider: ToolProvider = {
+		name: staticCallMeterRuntimeBridgeProviderName,
+		tools: {
+			record: {
+				execute: async (args: unknown) =>
+					await staticCallMeterTools.record(
+						(args ?? {}) as PackageStaticCallMeterInput,
 					),
 			},
 		},
@@ -554,6 +590,23 @@ const runtimeHelperManifest: Array<RuntimeHelperManifestEntry> = [
 				? [createPackageEventRuntimeBridgeProvider(context.packageEventTools)]
 				: [],
 	},
+	{
+		runtimeName: 'staticCallMeter',
+		runtimeBindings: [
+			{ runtimeName: '__kodyStaticCallMeter', absentValue: 'undefined' },
+		],
+		unboundNames: [],
+		isBound: (context) => Boolean(context.staticCallMeterTools),
+		createPrelude: () => createStaticCallMeterHelperPrelude(),
+		extraProviders: (context) =>
+			context.staticCallMeterTools
+				? [
+						createStaticCallMeterRuntimeBridgeProvider(
+							context.staticCallMeterTools,
+						),
+					]
+				: [],
+	},
 ]
 
 const runtimeHelperRuntimeBindingOrder: Array<string> = [
@@ -566,6 +619,7 @@ const runtimeHelperRuntimeBindingOrder: Array<string> = [
 	'workflows',
 	'packages',
 	'events',
+	'staticCallMeter',
 ]
 
 function runtimeHelperRuntimeBindings() {

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -287,12 +287,26 @@ const events = {
 
 // Internal bridge for the static package export call meter in the runtime
 // module (`__kodyMeterStaticPackageExport`): not an author-facing helper,
-// so it has no unbound-access rewrite name. The runtime wrapper reads it
-// from the run store and fires events without awaiting.
+// so it has no unbound-access rewrite name. Per-call reporting is a
+// synchronous buffer push (the call path never awaits and never throws);
+// the run wrapper awaits one `flush` bridge call at the end of the run,
+// while the sandbox RPC dispatchers are still live — a fire-and-forget RPC
+// per call would race dispatcher teardown and drop events. The buffer cap
+// bounds memory and the flush payload; calls past the cap in one run are
+// dropped (mirror the cap host-side in `createPackageStaticCallMeterTools`).
 function createStaticCallMeterHelperPrelude() {
 	return `
+const __kodyStaticCallMeterEvents = [];
 const __kodyStaticCallMeter = {
-  record: (input) => ${staticCallMeterRuntimeBridgeProviderName}.record(input ?? {}),
+  report: (event) => {
+    if (__kodyStaticCallMeterEvents.length >= 1000) return;
+    __kodyStaticCallMeterEvents.push(event);
+  },
+  flush: async () => {
+    if (__kodyStaticCallMeterEvents.length === 0) return;
+    const events = __kodyStaticCallMeterEvents.splice(0, __kodyStaticCallMeterEvents.length);
+    await ${staticCallMeterRuntimeBridgeProviderName}.record({ events });
+  },
 };
 	`.trim()
 }

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -302,10 +302,17 @@ const __kodyStaticCallMeter = {
     if (__kodyStaticCallMeterEvents.length >= 1000) return;
     __kodyStaticCallMeterEvents.push(event);
   },
+  // Flush in rounds: async calls that settle while a flush RPC is in
+  // flight land in the buffer afterwards, so loop (bounded) until the
+  // buffer stays empty. Calls still pending when the run's entrypoint has
+  // finished are not metered — metering never extends a run's lifetime,
+  // and a dangling promise may never settle inside the sandbox at all.
   flush: async () => {
-    if (__kodyStaticCallMeterEvents.length === 0) return;
-    const events = __kodyStaticCallMeterEvents.splice(0, __kodyStaticCallMeterEvents.length);
-    await ${staticCallMeterRuntimeBridgeProviderName}.record({ events });
+    for (let round = 0; round < 3; round += 1) {
+      if (__kodyStaticCallMeterEvents.length === 0) return;
+      const events = __kodyStaticCallMeterEvents.splice(0, __kodyStaticCallMeterEvents.length);
+      await ${staticCallMeterRuntimeBridgeProviderName}.record({ events });
+    }
   },
 };
 	`.trim()

--- a/packages/worker/src/package-runtime/module-export-names.node.test.ts
+++ b/packages/worker/src/package-runtime/module-export-names.node.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from 'vitest'
+import { collectModuleExportNames } from './module-export-names.ts'
+
+test('collects declaration, specifier, and destructured export names', () => {
+	const names = collectModuleExportNames({
+		files: {
+			'pkg/index.ts': [
+				'export function add(left: number, right: number) { return left + right }',
+				'export async function fetchStuff() {}',
+				'export class Toolbox {}',
+				'export const answer = 42',
+				'export const { first, rest: [second] } = { first: 1, rest: [2] }',
+				'export const [third, ...others] = [3, 4]',
+				'const hidden = () => {}',
+				'export { hidden as renamed }',
+				'export default function main() {}',
+			].join('\n'),
+		},
+		modulePath: 'pkg/index.ts',
+	})
+	expect(names).toEqual([
+		'Toolbox',
+		'add',
+		'answer',
+		'fetchStuff',
+		'first',
+		'others',
+		'renamed',
+		'second',
+		'third',
+	])
+})
+
+test('skips type-only exports and declare statements', () => {
+	const names = collectModuleExportNames({
+		files: {
+			'pkg/index.ts': [
+				'export type Loud = string',
+				'export interface Config { value: number }',
+				'export declare function ghost(): void',
+				'declare const spooky: number',
+				'export type { AnotherType } from "./types.ts"',
+				'type Local = number',
+				'export { type Local, realValue } from "./values.ts"',
+				'export function real() {}',
+			].join('\n'),
+			'pkg/values.ts': 'export const realValue = 1',
+		},
+		modulePath: 'pkg/index.ts',
+	})
+	expect(names).toEqual(['real', 'realValue'])
+})
+
+test('follows relative export-star chains and keeps namespace re-exports shallow', () => {
+	const names = collectModuleExportNames({
+		files: {
+			'pkg/index.ts': [
+				"export * from './math.ts'",
+				"export * from './extensionless'",
+				"export * as helpers from './helpers.ts'",
+				"export * from 'some-npm-package'",
+				'export const local = 1',
+			].join('\n'),
+			'pkg/math.ts':
+				"export function multiply() {}\nexport * from './deep/nested.ts'",
+			'pkg/deep/nested.ts': 'export const nestedValue = 2',
+			'pkg/extensionless.ts': 'export const extensionless = 3',
+			'pkg/helpers.ts': 'export const shouldStayHidden = 4',
+		},
+		modulePath: 'pkg/index.ts',
+	})
+	expect(names).toEqual([
+		'extensionless',
+		'helpers',
+		'local',
+		'multiply',
+		'nestedValue',
+	])
+})
+
+test('excludes default, non-identifier names, and tolerates cycles and parse failures', () => {
+	expect(
+		collectModuleExportNames({
+			files: {
+				'pkg/a.ts': [
+					"export * from './b.ts'",
+					'const value = 1',
+					'export { value as "not an identifier" }',
+					'export { value as default }',
+				].join('\n'),
+				'pkg/b.ts': "export * from './a.ts'\nexport const fromB = 2",
+			},
+			modulePath: 'pkg/a.ts',
+		}),
+	).toEqual(['fromB'])
+
+	expect(
+		collectModuleExportNames({
+			files: { 'pkg/broken.ts': 'export const = not parseable {{{' },
+			modulePath: 'pkg/broken.ts',
+		}),
+	).toEqual([])
+
+	expect(
+		collectModuleExportNames({
+			files: {},
+			modulePath: 'pkg/missing.ts',
+		}),
+	).toEqual([])
+})
+
+test('collects export names from bundled javascript artifact modules', () => {
+	// Shape of esbuild output for a published importable-module artifact.
+	const names = collectModuleExportNames({
+		files: {
+			'artifact/index.js': [
+				'var entry_default = async function main() {}',
+				'function listItems() {}',
+				'export { entry_default as default, listItems }',
+			].join('\n'),
+		},
+		modulePath: 'artifact/index.js',
+	})
+	expect(names).toEqual(['listItems'])
+})

--- a/packages/worker/src/package-runtime/module-export-names.ts
+++ b/packages/worker/src/package-runtime/module-export-names.ts
@@ -199,7 +199,7 @@ export function collectModuleExportNames(input: {
 		}
 	}
 	names.delete('default')
-	return [...names]
-		.filter((name) => identifierNamePattern.test(name))
-		.sort((left, right) => left.localeCompare(right))
+	// Codepoint sort keeps generated proxy content (and therefore bundle
+	// cache digests) deterministic across ICU locale data.
+	return [...names].filter((name) => identifierNamePattern.test(name)).sort()
 }

--- a/packages/worker/src/package-runtime/module-export-names.ts
+++ b/packages/worker/src/package-runtime/module-export-names.ts
@@ -1,0 +1,205 @@
+import { parseModuleSource, type ModuleAstNode } from '#worker/module-source.ts'
+import {
+	resolveRelativeModulePath,
+	resolveWorkspaceSourceFilePath,
+} from './module-graph-paths.ts'
+
+/**
+ * Best-effort static discovery of a module's runtime export names, used by
+ * the metered static-import proxy to know which named exports to wrap.
+ * Missing a name is safe: the proxy keeps `export * from` as a passthrough,
+ * so an undiscovered export still works — it is just not metered. Because of
+ * that, this collector prefers precision over completeness: type-only
+ * exports are skipped and anything unparseable is simply omitted.
+ */
+
+const identifierNamePattern = /^[A-Za-z$_][A-Za-z0-9$_]*$/
+
+function getModuleExportName(node: unknown): string | null {
+	if (!node || typeof node !== 'object') return null
+	const candidate = node as { name?: unknown; value?: unknown }
+	if (typeof candidate.name === 'string') return candidate.name
+	if (typeof candidate.value === 'string') return candidate.value
+	return null
+}
+
+function collectPatternBoundNames(node: unknown, names: Set<string>) {
+	if (!node || typeof node !== 'object') return
+	const typedNode = node as ModuleAstNode
+	switch (typedNode.type) {
+		case 'Identifier': {
+			const name = getModuleExportName(typedNode)
+			if (name) names.add(name)
+			return
+		}
+		case 'ObjectPattern': {
+			const properties = (typedNode as { properties?: unknown }).properties
+			if (!Array.isArray(properties)) return
+			for (const property of properties) {
+				if (!property || typeof property !== 'object') continue
+				const typedProperty = property as ModuleAstNode
+				if (typedProperty.type === 'RestElement') {
+					collectPatternBoundNames(
+						(typedProperty as { argument?: unknown }).argument,
+						names,
+					)
+					continue
+				}
+				collectPatternBoundNames(
+					(typedProperty as { value?: unknown }).value,
+					names,
+				)
+			}
+			return
+		}
+		case 'ArrayPattern': {
+			const elements = (typedNode as { elements?: unknown }).elements
+			if (!Array.isArray(elements)) return
+			for (const element of elements) {
+				collectPatternBoundNames(element, names)
+			}
+			return
+		}
+		case 'AssignmentPattern': {
+			collectPatternBoundNames((typedNode as { left?: unknown }).left, names)
+			return
+		}
+		case 'RestElement': {
+			collectPatternBoundNames(
+				(typedNode as { argument?: unknown }).argument,
+				names,
+			)
+			return
+		}
+		default:
+			return
+	}
+}
+
+function isRuntimeExportDeclaration(declaration: ModuleAstNode) {
+	if ((declaration as { declare?: unknown }).declare === true) return false
+	return (
+		declaration.type !== 'TSInterfaceDeclaration' &&
+		declaration.type !== 'TSTypeAliasDeclaration' &&
+		declaration.type !== 'TSDeclareFunction'
+	)
+}
+
+function collectOwnExports(source: string): {
+	names: Set<string>
+	starSpecifiers: Array<string>
+} | null {
+	let program: unknown
+	try {
+		program = parseModuleSource(source)
+	} catch {
+		return null
+	}
+	const names = new Set<string>()
+	const starSpecifiers: Array<string> = []
+	const programNode = (program as { program?: { body?: unknown } }).program
+	const body = programNode?.body
+	if (!Array.isArray(body)) return { names, starSpecifiers }
+	for (const statement of body) {
+		if (!statement || typeof statement !== 'object') continue
+		const typedStatement = statement as ModuleAstNode & {
+			declaration?: ModuleAstNode
+			specifiers?: Array<ModuleAstNode>
+			source?: { value?: unknown }
+			exportKind?: unknown
+		}
+		if (typedStatement.type === 'ExportAllDeclaration') {
+			if (typedStatement.exportKind === 'type') continue
+			// `export * as ns from ...` re-exports a single namespace binding,
+			// not the target's names (Babel usually models it as an
+			// ExportNamespaceSpecifier, but guard the ExportAllDeclaration
+			// shape too).
+			const namespaceName = getModuleExportName(
+				(typedStatement as { exported?: unknown }).exported,
+			)
+			if (namespaceName) {
+				names.add(namespaceName)
+				continue
+			}
+			const starSource = typedStatement.source?.value
+			if (typeof starSource === 'string') starSpecifiers.push(starSource)
+			continue
+		}
+		if (typedStatement.type !== 'ExportNamedDeclaration') continue
+		if (typedStatement.exportKind === 'type') continue
+		const declaration = typedStatement.declaration
+		if (declaration && isRuntimeExportDeclaration(declaration)) {
+			if (declaration.type === 'VariableDeclaration') {
+				const declarators = (declaration as { declarations?: unknown })
+					.declarations
+				if (Array.isArray(declarators)) {
+					for (const declarator of declarators) {
+						collectPatternBoundNames(
+							(declarator as { id?: unknown })?.id,
+							names,
+						)
+					}
+				}
+			} else {
+				const declaredName = getModuleExportName(
+					(declaration as { id?: unknown }).id,
+				)
+				if (declaredName) names.add(declaredName)
+			}
+		}
+		if (Array.isArray(typedStatement.specifiers)) {
+			for (const specifier of typedStatement.specifiers) {
+				if (!specifier || typeof specifier !== 'object') continue
+				if ((specifier as { exportKind?: unknown }).exportKind === 'type') {
+					continue
+				}
+				const exportedName = getModuleExportName(
+					(specifier as { exported?: unknown }).exported,
+				)
+				if (exportedName) names.add(exportedName)
+			}
+		}
+	}
+	return { names, starSpecifiers }
+}
+
+/**
+ * Collects the runtime export names of `modulePath` within `files`, following
+ * relative `export * from` chains that resolve inside the same file map.
+ * Star re-exports that leave the map (bare npm specifiers, unresolved paths)
+ * are ignored — their names remain reachable through the proxy's own
+ * `export * from` passthrough. Returns names excluding `default` and any
+ * name that is not a plain ASCII identifier (those also fall back to the
+ * unmetered passthrough).
+ */
+export function collectModuleExportNames(input: {
+	files: Record<string, string>
+	modulePath: string
+}): Array<string> {
+	const names = new Set<string>()
+	const visited = new Set<string>()
+	const queue: Array<string> = [input.modulePath]
+	while (queue.length > 0) {
+		const modulePath = queue.shift()
+		if (!modulePath || visited.has(modulePath)) continue
+		visited.add(modulePath)
+		const source = input.files[modulePath]
+		if (typeof source !== 'string') continue
+		const collected = collectOwnExports(source)
+		if (!collected) continue
+		for (const name of collected.names) names.add(name)
+		for (const starSpecifier of collected.starSpecifiers) {
+			const resolvedPath = resolveRelativeModulePath(modulePath, starSpecifier)
+			if (!resolvedPath) continue
+			const resolvedFilePath = resolveWorkspaceSourceFilePath({
+				files: input.files,
+				path: resolvedPath,
+			})
+			if (resolvedFilePath) queue.push(resolvedFilePath)
+		}
+	}
+	names.delete('default')
+	return [...names]
+		.filter((name) => identifierNamePattern.test(name))
+		.sort((left, right) => left.localeCompare(right))
+}

--- a/packages/worker/src/package-runtime/module-graph-import-rewriting.ts
+++ b/packages/worker/src/package-runtime/module-graph-import-rewriting.ts
@@ -45,11 +45,13 @@ import {
 	createComputedDynamicImportGuardSource,
 	createDynamicPackageImportHelperSource,
 	createDynamicPackageImportPlaceholderSource,
+	createMeteredPackageImportProxySource,
 	createPackageImportProxySource,
 	createPackageRuntimeModuleSource,
 	createRuntimeModuleSource,
 	iterateModuleSourceTexts,
 } from './runtime-source-modules.ts'
+import { collectModuleExportNames } from './module-export-names.ts'
 import { materializePublishedArtifactModules } from './module-graph-artifacts.ts'
 import {
 	collectReachableSourceFilePaths,
@@ -232,6 +234,11 @@ async function ensurePackageProxy(
 	const existing = state.proxies.get(specifier)
 	if (existing) return existing
 	const parsed = parseKodyPackageSpecifier(specifier)
+	// Callee saved-package UUID stamped into the metered proxy below. Root
+	// self-imports resolve back into the bundle's own source and are not
+	// stamped: the surrounding run already meters that package via
+	// `package_export`.
+	let calleePackageId: string | null = null
 	const absoluteExportPath =
 		parsed.packageName === state.rootPackage?.manifest.name
 			? joinPath(
@@ -244,6 +251,7 @@ async function ensurePackageProxy(
 				)
 			: await (async () => {
 					const loaded = await ensurePackageLoaded(state, specifier)
+					calleePackageId = loaded.row.id
 					return (
 						(await maybeEnsurePublishedArtifactTarget({
 							state,
@@ -274,9 +282,22 @@ async function ensurePackageProxy(
 		proxyPath,
 		absoluteExportPath,
 	)
-	state.files[proxyPath] = createPackageImportProxySource({
-		targetPath: proxyTarget,
-	})
+	state.files[proxyPath] = calleePackageId
+		? createMeteredPackageImportProxySource({
+				targetPath: proxyTarget,
+				runtimeSpecifier: createRelativeImportSpecifier(
+					proxyPath,
+					runtimeModulePath,
+				),
+				packageId: calleePackageId,
+				exportNames: collectModuleExportNames({
+					files: state.files,
+					modulePath: absoluteExportPath,
+				}),
+			})
+		: createPackageImportProxySource({
+				targetPath: proxyTarget,
+			})
 	state.proxies.set(specifier, proxyPath)
 	return proxyPath
 }

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -820,9 +820,9 @@ test('buildKodyModuleBundle proxies package module default and named exports', a
 		'export default __kodyMeterStaticPackageExport("pkg-1", __kodyPackageModule.default)',
 	)
 	expect(proxy).toContain(
-		'__kodyMeterStaticPackageExport("pkg-1", __kodyPackageModule.add)',
+		'const __kodyMeteredStaticExport0 = __kodyMeterStaticPackageExport("pkg-1", __kodyPackageModule.add);',
 	)
-	expect(proxy).toContain('as add')
+	expect(proxy).toContain('export { __kodyMeteredStaticExport0 as add };')
 })
 
 test('buildKodyModuleBundle imports callable entrypoints as ESM default exports', async () => {

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -814,7 +814,15 @@ test('buildKodyModuleBundle proxies package module default and named exports', a
 	)?.[1]
 	expect(proxy).toContain('export * from')
 	expect(proxy).toContain('import * as __kodyPackageModule')
-	expect(proxy).toContain('export default __kodyPackageModule.default')
+	// Static import proxies stamp the callee package id and wrap function
+	// valued exports in the call-metering runtime helper.
+	expect(proxy).toContain(
+		'export default __kodyMeterStaticPackageExport("pkg-1", __kodyPackageModule.default)',
+	)
+	expect(proxy).toContain(
+		'__kodyMeterStaticPackageExport("pkg-1", __kodyPackageModule.add)',
+	)
+	expect(proxy).toContain('as add')
 })
 
 test('buildKodyModuleBundle imports callable entrypoints as ESM default exports', async () => {

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -249,7 +249,10 @@ function __kodyRecordStaticPackageCall(packageId, startedAtMs, outcome) {
 // pass through unchanged; function exports keep their identity semantics
 // (arguments, this, return values, thrown errors, properties, construct)
 // behind a transparent Proxy whose only addition is a non-blocking usage
-// event per call.
+// event per call. Only [[Call]] is trapped: every other internal method,
+// including [[Construct]], forwards to the target per the Proxy spec, so
+// \`new WrappedClass()\` constructs the real class (construction is not
+// metered).
 export function __kodyMeterStaticPackageExport(packageId, exportValue) {
 	if (typeof exportValue !== 'function') return exportValue;
 	return new Proxy(exportValue, {
@@ -262,6 +265,14 @@ export function __kodyMeterStaticPackageExport(packageId, exportValue) {
 				__kodyRecordStaticPackageCall(packageId, startedAtMs, 'error');
 				throw error;
 			}
+			// Deliberately only native promises: subscribing to an arbitrary
+			// user thenable would invoke its then() from the metering path,
+			// which can trigger lazy side effects (query-builder style
+			// thenables execute when first awaited) — a behavior change the
+			// wrapper must never cause. All modules run in one isolate, so
+			// async exports always return same-realm native promises;
+			// non-promise thenables record at return time instead of
+			// settlement.
 			if (result instanceof Promise) {
 				result.then(
 					() => __kodyRecordStaticPackageCall(packageId, startedAtMs, 'success'),

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -223,6 +223,61 @@ export function __kodyCreatePackageBoundStorage(packageId) {
 	};
 }
 
+function __kodyRecordStaticPackageCall(packageId, startedAtMs, outcome) {
+	// Fire-and-forget metering: never block and never throw into the call
+	// path. The bridge is read late-bound from the current run's store so
+	// reused worker isolates never pin a disposed dispatcher stub.
+	try {
+		const meter = __kodyRuntimeStorage.getStore()?.__kodyStaticCallMeter;
+		if (meter == null || typeof meter.record !== 'function') return;
+		const pending = meter.record({
+			packageId,
+			durationMs: Date.now() - startedAtMs,
+			outcome,
+		});
+		if (pending != null && typeof pending.then === 'function') {
+			pending.then(
+				() => {},
+				() => {},
+			);
+		}
+	} catch {}
+}
+
+// Call-metering wrapper for statically imported package exports. The
+// bundler stamps the callee package id into generated import proxies (see
+// createMeteredPackageImportProxySource); the id is identity routing only —
+// the host independently validates it against the run's bundler-recorded
+// dependency provenance before recording anything. Non-function exports
+// pass through unchanged; function exports keep their identity semantics
+// (arguments, this, return values, thrown errors, properties, construct)
+// behind a transparent Proxy whose only addition is a non-blocking usage
+// event per call.
+export function __kodyMeterStaticPackageExport(packageId, exportValue) {
+	if (typeof exportValue !== 'function') return exportValue;
+	return new Proxy(exportValue, {
+		apply(target, thisArg, argumentsList) {
+			const startedAtMs = Date.now();
+			let result;
+			try {
+				result = Reflect.apply(target, thisArg, argumentsList);
+			} catch (error) {
+				__kodyRecordStaticPackageCall(packageId, startedAtMs, 'error');
+				throw error;
+			}
+			if (result instanceof Promise) {
+				result.then(
+					() => __kodyRecordStaticPackageCall(packageId, startedAtMs, 'success'),
+					() => __kodyRecordStaticPackageCall(packageId, startedAtMs, 'error'),
+				);
+				return result;
+			}
+			__kodyRecordStaticPackageCall(packageId, startedAtMs, 'success');
+			return result;
+		},
+	});
+}
+
 // Unstamped fallback: modules without bundler-recorded package provenance
 // (ad hoc execute code, artifacts published before stamping existed) can only
 // reach the storage of the package the run itself belongs to.
@@ -535,6 +590,43 @@ export function createPackageImportProxySource(input: { targetPath: string }) {
 export * from ${JSON.stringify(input.targetPath)};
 import * as __kodyPackageModule from ${JSON.stringify(input.targetPath)};
 export default __kodyPackageModule.default;
+`.trim()
+}
+
+/**
+ * Static-import proxy stamped with the callee saved-package id: function
+ * valued exports are wrapped in the call-metering Proxy from the runtime
+ * module (`__kodyMeterStaticPackageExport`), non-function exports pass
+ * through unchanged. The `export * from` passthrough stays first so any
+ * export name the bundler could not statically discover keeps working (it
+ * is just not metered) — explicitly re-exported wrapped names shadow the
+ * star re-export per the ES module ambiguity rules. Only the static import
+ * rewrite uses this variant; dynamic package import proxies keep the plain
+ * source above.
+ */
+export function createMeteredPackageImportProxySource(input: {
+	targetPath: string
+	runtimeSpecifier: string
+	packageId: string
+	exportNames: Array<string>
+}) {
+	const packageIdJson = JSON.stringify(input.packageId)
+	const namedExportLines = input.exportNames.flatMap((exportName, index) => {
+		if (exportName === 'default') return []
+		const localName = `__kodyMeteredStaticExport${index}`
+		return [
+			`const ${localName} = __kodyMeterStaticPackageExport(${packageIdJson}, __kodyPackageModule.${exportName});`,
+			`export { ${localName} as ${exportName} };`,
+		]
+	})
+	return `
+export * from ${JSON.stringify(input.targetPath)};
+import * as __kodyPackageModule from ${JSON.stringify(input.targetPath)};
+import { __kodyMeterStaticPackageExport } from ${JSON.stringify(
+		input.runtimeSpecifier,
+	)};
+export default __kodyMeterStaticPackageExport(${packageIdJson}, __kodyPackageModule.default);
+${namedExportLines.join('\n')}
 `.trim()
 }
 

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -224,23 +224,20 @@ export function __kodyCreatePackageBoundStorage(packageId) {
 }
 
 function __kodyRecordStaticPackageCall(packageId, startedAtMs, outcome) {
-	// Fire-and-forget metering: never block and never throw into the call
-	// path. The bridge is read late-bound from the current run's store so
-	// reused worker isolates never pin a disposed dispatcher stub.
+	// Metering must never block or throw into the call path: reporting is a
+	// synchronous buffer push into the current run's meter (the surrounding
+	// wrapper flushes the buffer over the host bridge once, at the end of
+	// the run, while its RPC dispatchers are still live). The meter is read
+	// late-bound from the run store so reused worker isolates never pin a
+	// previous run's state, and runs without a meter simply skip recording.
 	try {
 		const meter = __kodyRuntimeStorage.getStore()?.__kodyStaticCallMeter;
-		if (meter == null || typeof meter.record !== 'function') return;
-		const pending = meter.record({
+		if (meter == null || typeof meter.report !== 'function') return;
+		meter.report({
 			packageId,
 			durationMs: Date.now() - startedAtMs,
 			outcome,
 		});
-		if (pending != null && typeof pending.then === 'function') {
-			pending.then(
-				() => {},
-				() => {},
-			);
-		}
 	} catch {}
 }
 

--- a/packages/worker/src/package-runtime/static-call-metering.workers.test.ts
+++ b/packages/worker/src/package-runtime/static-call-metering.workers.test.ts
@@ -174,6 +174,15 @@ test(
 						"\tif (shouldThrow) throw new Error('asked to throw')",
 						"\treturn 'calm'",
 						'}',
+						'export class Accumulator {',
+						'\ttotal: number',
+						'\tconstructor(start: number) {',
+						'\t\tthis.total = start',
+						'\t}',
+						'\tbump() {',
+						'\t\treturn ++this.total',
+						'\t}',
+						'}',
 						'export const answer = 42',
 					].join('\n'),
 				},
@@ -186,7 +195,7 @@ test(
 			userId,
 			sourceFiles: {
 				'entry.ts': [
-					"import compute, { throwWhenAsked, answer } from 'kody:@kentcdodds/metered-dep'",
+					"import compute, { throwWhenAsked, Accumulator, answer } from 'kody:@kentcdodds/metered-dep'",
 					'export default async function main() {',
 					'\tconst first = await compute(1)',
 					'\tconst second = await compute(2)',
@@ -197,12 +206,16 @@ test(
 					'\t} catch (error) {',
 					'\t\tthrownMessage = String(error instanceof Error ? error.message : error)',
 					'\t}',
+					'\t// The wrapper only traps [[Call]]: `new` on a wrapped class',
+					'\t// constructs the real class (and is not metered).',
+					'\tconst accumulator = new Accumulator(10)',
 					'\treturn {',
 					'\t\tfirst,',
 					'\t\tsecond,',
 					'\t\tthird,',
 					'\t\tthrownMessage,',
 					'\t\tcalm: throwWhenAsked(false),',
+					'\t\tconstructed: accumulator.bump(),',
 					'\t\tanswer,',
 					'\t\tanswerType: typeof answer,',
 					'\t}',
@@ -220,14 +233,16 @@ test(
 		)
 
 		expect(result.error).toBeUndefined()
-		// The throwing export still throws to the caller; non-function exports
-		// pass through unwrapped.
+		// The throwing export still throws to the caller; class exports
+		// construct through the wrapper; non-function exports pass through
+		// unwrapped.
 		expect(result.result).toEqual({
 			first: { doubled: 2 },
 			second: { doubled: 4 },
 			third: { doubled: 6 },
 			thrownMessage: 'asked to throw',
 			calm: 'calm',
+			constructed: 11,
 			answer: 42,
 			answerType: 'number',
 		})
@@ -361,6 +376,12 @@ test(
 				})
 			},
 			{ timeout: 10_000, interval: 100 },
+		)
+		// Guard against the count racing past 2 after the wait: re-read once
+		// everything in flight has had time to settle.
+		await new Promise((resolve) => setTimeout(resolve, 500))
+		expect(await readStaticCallRollup(userId)).toEqual(
+			expect.objectContaining({ event_count: 2 }),
 		)
 	},
 )

--- a/packages/worker/src/package-runtime/static-call-metering.workers.test.ts
+++ b/packages/worker/src/package-runtime/static-call-metering.workers.test.ts
@@ -1,0 +1,366 @@
+import { env } from 'cloudflare:workers'
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
+import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
+import {
+	buildKodyImportableModuleBundle,
+	buildKodyModuleBundle,
+} from './module-graph.ts'
+import { persistPublishedSourceSnapshot } from './published-runtime-artifacts.ts'
+import { persistPublishedBundleArtifact } from './published-bundle-artifacts.ts'
+
+async function runSql(sql: string, ...values: Array<unknown>) {
+	await env.APP_DB.prepare(sql)
+		.bind(...values)
+		.run()
+}
+
+async function ensureSavedPackageArtifactSchema() {
+	await runSql(`CREATE TABLE IF NOT EXISTS entity_sources (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		entity_kind TEXT NOT NULL,
+		entity_id TEXT NOT NULL,
+		repo_id TEXT NOT NULL,
+		published_commit TEXT,
+		indexed_commit TEXT,
+		manifest_path TEXT NOT NULL DEFAULT 'package.json',
+		source_root TEXT NOT NULL DEFAULT '/',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`)
+	await runSql(`CREATE TABLE IF NOT EXISTS saved_packages (
+		id TEXT PRIMARY KEY NOT NULL,
+		user_id TEXT NOT NULL,
+		name TEXT NOT NULL,
+		kody_id TEXT NOT NULL,
+		description TEXT NOT NULL,
+		tags_json TEXT NOT NULL DEFAULT '[]',
+		search_text TEXT,
+		source_id TEXT NOT NULL,
+		has_app INTEGER NOT NULL DEFAULT 0 CHECK (has_app IN (0, 1)),
+		hidden INTEGER NOT NULL DEFAULT 0 CHECK (hidden IN (0, 1)),
+		is_private INTEGER NOT NULL DEFAULT 1 CHECK (is_private IN (0, 1)),
+		created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+		updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+	)`)
+	await runSql(`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		source_id TEXT NOT NULL,
+		published_commit TEXT NOT NULL,
+		artifact_kind TEXT NOT NULL,
+		artifact_name TEXT,
+		entry_point TEXT NOT NULL,
+		kv_key TEXT NOT NULL,
+		dependencies_json TEXT NOT NULL DEFAULT '[]',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`)
+}
+
+async function insertSavedPackage(input: {
+	userId: string
+	packageId: string
+	kodyId: string
+	name: string
+	sourceId: string
+	publishedCommit: string
+}) {
+	const now = new Date().toISOString()
+	await runSql(
+		`INSERT INTO saved_packages (
+			id, user_id, name, kody_id, description, tags_json, search_text,
+			source_id, has_app, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, '[]', NULL, ?, 0, ?, ?)`,
+		input.packageId,
+		input.userId,
+		input.name,
+		input.kodyId,
+		`${input.name} package`,
+		input.sourceId,
+		now,
+		now,
+	)
+	await runSql(
+		`INSERT INTO entity_sources (
+			id, user_id, entity_kind, entity_id, repo_id, published_commit,
+			indexed_commit, manifest_path, source_root, created_at, updated_at
+		) VALUES (?, ?, 'package', ?, ?, ?, NULL, 'package.json', '/', ?, ?)`,
+		input.sourceId,
+		input.userId,
+		input.packageId,
+		`repo-${input.sourceId}`,
+		input.publishedCommit,
+		now,
+		now,
+	)
+	return {
+		id: input.sourceId,
+		user_id: input.userId,
+		entity_kind: 'package' as const,
+		entity_id: input.packageId,
+		repo_id: `repo-${input.sourceId}`,
+		published_commit: input.publishedCommit,
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: now,
+		updated_at: now,
+	}
+}
+
+function createCallerContext(userId: string) {
+	return createMcpCallerContext({
+		baseUrl: 'https://kody.dev',
+		user: {
+			userId,
+			email: 'worker@example.com',
+			displayName: 'Worker Test',
+		},
+	})
+}
+
+async function readStaticCallRollup(userId: string) {
+	const row = await env.APP_DB.prepare(
+		`SELECT event_count, error_count, total_duration_ms
+		FROM usage_rollups WHERE user_id = ?1 AND metric = 'package_static_call'`,
+	)
+		.bind(userId)
+		.first<{
+			event_count: number
+			error_count: number
+			total_duration_ms: number
+		}>()
+	return row ?? null
+}
+
+test(
+	'statically imported package exports meter one package_static_call per call',
+	{ timeout: 30_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		await ensureSavedPackageArtifactSchema()
+		await ensureUsageRollupsTestSchema(env.APP_DB)
+		const unique = crypto.randomUUID()
+		const userId = `user-${unique}`
+		const packageId = `pkg-${unique}`
+		const source = await insertSavedPackage({
+			userId,
+			packageId,
+			kodyId: 'metered-dep',
+			name: '@kentcdodds/metered-dep',
+			sourceId: `source-${unique}`,
+			publishedCommit: `commit-${unique}`,
+		})
+		await persistPublishedSourceSnapshot({
+			env,
+			userId,
+			source,
+			snapshot: {
+				files: {
+					'package.json': JSON.stringify({
+						name: '@kentcdodds/metered-dep',
+						exports: { '.': './src/index.ts' },
+						kody: { id: 'metered-dep', description: 'Metered dependency' },
+					}),
+					'src/index.ts': [
+						'export default async function compute(input: number) {',
+						'\treturn { doubled: input * 2 }',
+						'}',
+						'export function throwWhenAsked(shouldThrow: boolean) {',
+						"\tif (shouldThrow) throw new Error('asked to throw')",
+						"\treturn 'calm'",
+						'}',
+						'export const answer = 42',
+					].join('\n'),
+				},
+			},
+		})
+
+		const bundle = await buildKodyModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId,
+			sourceFiles: {
+				'entry.ts': [
+					"import compute, { throwWhenAsked, answer } from 'kody:@kentcdodds/metered-dep'",
+					'export default async function main() {',
+					'\tconst first = await compute(1)',
+					'\tconst second = await compute(2)',
+					'\tconst third = await compute(3)',
+					'\tlet thrownMessage = null',
+					'\ttry {',
+					'\t\tthrowWhenAsked(true)',
+					'\t} catch (error) {',
+					'\t\tthrownMessage = String(error instanceof Error ? error.message : error)',
+					'\t}',
+					'\treturn {',
+					'\t\tfirst,',
+					'\t\tsecond,',
+					'\t\tthird,',
+					'\t\tthrownMessage,',
+					'\t\tcalm: throwWhenAsked(false),',
+					'\t\tanswer,',
+					'\t\tanswerType: typeof answer,',
+					'\t}',
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+		const result = await runBundledModuleWithRegistry(
+			env,
+			createCallerContext(userId),
+			bundle,
+			undefined,
+			{ skipCapabilityRegistry: true },
+		)
+
+		expect(result.error).toBeUndefined()
+		// The throwing export still throws to the caller; non-function exports
+		// pass through unwrapped.
+		expect(result.result).toEqual({
+			first: { doubled: 2 },
+			second: { doubled: 4 },
+			third: { doubled: 6 },
+			thrownMessage: 'asked to throw',
+			calm: 'calm',
+			answer: 42,
+			answerType: 'number',
+		})
+
+		// 3 default calls + 1 throwing call + 1 calm call = 5 events, 1 error.
+		// Metering is fire-and-forget from the sandbox, so poll the rollup.
+		await vi.waitFor(
+			async () => {
+				const rollup = await readStaticCallRollup(userId)
+				expect(rollup).toEqual({
+					event_count: 5,
+					error_count: 1,
+					total_duration_ms: expect.any(Number),
+				})
+			},
+			{ timeout: 10_000, interval: 100 },
+		)
+	},
+)
+
+test(
+	'published-artifact static imports meter calls and drop forged stamped ids',
+	{ timeout: 30_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		await ensureSavedPackageArtifactSchema()
+		await ensureUsageRollupsTestSchema(env.APP_DB)
+		const unique = crypto.randomUUID()
+		const userId = `user-${unique}`
+		const packageId = `pkg-${unique}`
+		const source = await insertSavedPackage({
+			userId,
+			packageId,
+			kodyId: 'artifact-dep',
+			name: '@kentcdodds/artifact-dep',
+			sourceId: `source-${unique}`,
+			publishedCommit: `commit-${unique}`,
+		})
+		const sourceFiles = {
+			'package.json': JSON.stringify({
+				name: '@kentcdodds/artifact-dep',
+				exports: { '.': './src/index.ts' },
+				kody: { id: 'artifact-dep', description: 'Artifact dependency' },
+			}),
+			'src/index.ts': [
+				'export default async function run() {',
+				"\treturn 'artifact-ok'",
+				'}',
+				'export function greet(name: string) {',
+				'\treturn `hello ${name}`',
+				'}',
+			].join('\n'),
+		}
+		await persistPublishedSourceSnapshot({
+			env,
+			userId,
+			source,
+			snapshot: { files: sourceFiles },
+		})
+		const artifactBundle = await buildKodyImportableModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId,
+			sourceFiles,
+			entryPoint: 'src/index.ts',
+		})
+		await persistPublishedBundleArtifact({
+			env,
+			userId,
+			source,
+			kind: 'importable-module',
+			artifactName: '.',
+			entryPoint: 'src/index.ts',
+			mainModule: artifactBundle.mainModule,
+			modules: artifactBundle.modules,
+			dependencies: artifactBundle.dependencies,
+			packageContext: {
+				packageId,
+				kodyId: 'artifact-dep',
+				sourceId: source.id,
+			},
+		})
+
+		const bundle = await buildKodyModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId,
+			sourceFiles: {
+				'entry.ts': [
+					"import run, { greet } from 'kody:@kentcdodds/artifact-dep'",
+					"import { __kodyMeterStaticPackageExport } from 'kody:runtime'",
+					'export default async function main() {',
+					'\t// Forge a stamp for a package this bundle does not statically',
+					'\t// depend on: the host must drop it silently.',
+					'\tconst forged = __kodyMeterStaticPackageExport(',
+					"\t\t'pkg-not-a-dependency',",
+					"\t\t() => 'forged-ok',",
+					'\t)',
+					'\tconst forgedValue = forged()',
+					'\treturn { ran: await run(), greeting: greet("kody"), forgedValue }',
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+		const result = await runBundledModuleWithRegistry(
+			env,
+			createCallerContext(userId),
+			bundle,
+			undefined,
+			{ skipCapabilityRegistry: true },
+		)
+
+		expect(result.error).toBeUndefined()
+		expect(result.result).toEqual({
+			ran: 'artifact-ok',
+			greeting: 'hello kody',
+			forgedValue: 'forged-ok',
+		})
+
+		// The forged event fires before the two granted ones; once the granted
+		// events land, a count of exactly 2 proves the forged stamp was
+		// dropped by the host-side dependency-provenance check.
+		await vi.waitFor(
+			async () => {
+				const rollup = await readStaticCallRollup(userId)
+				expect(rollup).toEqual({
+					event_count: 2,
+					error_count: 0,
+					total_duration_ms: expect.any(Number),
+				})
+			},
+			{ timeout: 10_000, interval: 100 },
+		)
+	},
+)

--- a/packages/worker/src/usage/package-static-call-usage.node.test.ts
+++ b/packages/worker/src/usage/package-static-call-usage.node.test.ts
@@ -118,21 +118,43 @@ test('drops invalid outcomes and normalizes invalid durations', async () => {
 	})
 })
 
-test('caps the number of events processed per batch', async () => {
+test('caps recorded events per run, cumulatively across batches', async () => {
 	await withRecordUsageSpy(async (recordUsageSpy) => {
 		const tools = createPackageStaticCallMeterTools({
 			env: {} as Env,
 			userId: 'user-1',
 			grantedPackageIds: new Set(['pkg-callee']),
 		})
+		const grantedEvent = {
+			packageId: 'pkg-callee',
+			durationMs: 1,
+			outcome: 'success',
+		}
 		await tools?.record({
-			events: Array.from({ length: 1500 }, () => ({
-				packageId: 'pkg-callee',
-				durationMs: 1,
-				outcome: 'success',
-			})),
+			events: Array.from({ length: 500 }, () => grantedEvent),
 		})
-		expect(recordUsageSpy).toHaveBeenCalledTimes(1000)
+		expect(recordUsageSpy).toHaveBeenCalledTimes(200)
+
+		// The cap is per run (per tools instance), not per batch: flush
+		// rounds from the same run share one Analytics Engine budget.
+		recordUsageSpy.mockClear()
+		await tools?.record({
+			events: Array.from({ length: 50 }, () => grantedEvent),
+		})
+		expect(recordUsageSpy).not.toHaveBeenCalled()
+
+		const freshTools = createPackageStaticCallMeterTools({
+			env: {} as Env,
+			userId: 'user-1',
+			grantedPackageIds: new Set(['pkg-callee']),
+		})
+		await freshTools?.record({
+			events: Array.from({ length: 150 }, () => grantedEvent),
+		})
+		await freshTools?.record({
+			events: Array.from({ length: 150 }, () => grantedEvent),
+		})
+		expect(recordUsageSpy).toHaveBeenCalledTimes(200)
 	})
 })
 

--- a/packages/worker/src/usage/package-static-call-usage.node.test.ts
+++ b/packages/worker/src/usage/package-static-call-usage.node.test.ts
@@ -1,0 +1,181 @@
+import { expect, test, vi, type MockInstance } from 'vitest'
+import { createPackageStaticCallMeterTools } from './package-static-call-usage.ts'
+
+async function withRecordUsageSpy(
+	run: (recordUsageSpy: MockInstance) => Promise<void>,
+) {
+	const usageModule = await import('#worker/usage/record-usage.ts')
+	const recordUsageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockResolvedValue(undefined)
+	try {
+		await run(recordUsageSpy)
+	} finally {
+		recordUsageSpy.mockRestore()
+	}
+}
+
+test('records one package_static_call event per granted batch entry', async () => {
+	await withRecordUsageSpy(async (recordUsageSpy) => {
+		const env = {} as Env
+		const tools = createPackageStaticCallMeterTools({
+			env,
+			userId: 'user-1',
+			grantedPackageIds: new Set(['pkg-callee']),
+		})
+		expect(tools).toBeDefined()
+
+		await tools?.record({
+			events: [
+				{ packageId: 'pkg-callee', durationMs: 42, outcome: 'success' },
+				{ packageId: 'pkg-callee', durationMs: 7, outcome: 'error' },
+				{ packageId: 'pkg-callee', durationMs: 3, outcome: 'success' },
+			],
+		})
+		expect(recordUsageSpy).toHaveBeenCalledTimes(3)
+		expect(recordUsageSpy).toHaveBeenNthCalledWith(1, env, {
+			userId: 'user-1',
+			eventType: 'package_static_call',
+			entityId: 'pkg-callee',
+			durationMs: 42,
+			outcome: 'success',
+		})
+		expect(recordUsageSpy).toHaveBeenNthCalledWith(
+			2,
+			env,
+			expect.objectContaining({
+				entityId: 'pkg-callee',
+				outcome: 'error',
+				durationMs: 7,
+			}),
+		)
+	})
+})
+
+test('drops stamped package ids outside the static dependency grant set', async () => {
+	await withRecordUsageSpy(async (recordUsageSpy) => {
+		const tools = createPackageStaticCallMeterTools({
+			env: {} as Env,
+			userId: 'user-1',
+			grantedPackageIds: new Set(['pkg-callee']),
+		})
+		await tools?.record({
+			events: [
+				{
+					packageId: 'pkg-other-users-package',
+					durationMs: 1,
+					outcome: 'success',
+				},
+				{ packageId: '', durationMs: 1, outcome: 'success' },
+				{ durationMs: 1, outcome: 'success' },
+				{ packageId: 42, durationMs: 1, outcome: 'success' },
+				'not-an-object',
+			],
+		})
+		expect(recordUsageSpy).not.toHaveBeenCalled()
+
+		// A dropped entry does not block granted entries in the same batch.
+		await tools?.record({
+			events: [
+				{ packageId: 'pkg-forged', durationMs: 1, outcome: 'success' },
+				{ packageId: 'pkg-callee', durationMs: 1, outcome: 'success' },
+			],
+		})
+		expect(recordUsageSpy).toHaveBeenCalledTimes(1)
+		expect(recordUsageSpy).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ entityId: 'pkg-callee' }),
+		)
+	})
+})
+
+test('drops invalid outcomes and normalizes invalid durations', async () => {
+	await withRecordUsageSpy(async (recordUsageSpy) => {
+		const tools = createPackageStaticCallMeterTools({
+			env: {} as Env,
+			userId: 'user-1',
+			grantedPackageIds: new Set(['pkg-callee']),
+		})
+		await tools?.record({
+			events: [{ packageId: 'pkg-callee', durationMs: 1, outcome: 'made-up' }],
+		})
+		expect(recordUsageSpy).not.toHaveBeenCalled()
+
+		await tools?.record({
+			events: [
+				{ packageId: 'pkg-callee', durationMs: -5, outcome: 'success' },
+				{
+					packageId: 'pkg-callee',
+					durationMs: 'not-a-number',
+					outcome: 'success',
+				},
+			],
+		})
+		expect(recordUsageSpy).toHaveBeenCalledTimes(2)
+		for (const call of recordUsageSpy.mock.calls) {
+			expect(call[1]).toEqual(expect.objectContaining({ durationMs: null }))
+		}
+	})
+})
+
+test('caps the number of events processed per batch', async () => {
+	await withRecordUsageSpy(async (recordUsageSpy) => {
+		const tools = createPackageStaticCallMeterTools({
+			env: {} as Env,
+			userId: 'user-1',
+			grantedPackageIds: new Set(['pkg-callee']),
+		})
+		await tools?.record({
+			events: Array.from({ length: 1500 }, () => ({
+				packageId: 'pkg-callee',
+				durationMs: 1,
+				outcome: 'success',
+			})),
+		})
+		expect(recordUsageSpy).toHaveBeenCalledTimes(1000)
+	})
+})
+
+test('requires a calling user and never throws into the call path', async () => {
+	expect(
+		createPackageStaticCallMeterTools({
+			env: {} as Env,
+			userId: null,
+			grantedPackageIds: new Set(['pkg-callee']),
+		}),
+	).toBeUndefined()
+	expect(
+		createPackageStaticCallMeterTools({
+			env: {} as Env,
+			userId: '   ',
+			grantedPackageIds: new Set(['pkg-callee']),
+		}),
+	).toBeUndefined()
+
+	const usageModule = await import('#worker/usage/record-usage.ts')
+	const recordUsageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockImplementation(() => {
+			throw new Error('sink exploded')
+		})
+	try {
+		const tools = createPackageStaticCallMeterTools({
+			env: {} as Env,
+			userId: 'user-1',
+			grantedPackageIds: new Set(['pkg-callee']),
+		})
+		await expect(
+			tools?.record({
+				events: [
+					{ packageId: 'pkg-callee', durationMs: 1, outcome: 'success' },
+				],
+			}),
+		).resolves.toBeUndefined()
+		await expect(
+			tools?.record({ events: 'not-an-array' }),
+		).resolves.toBeUndefined()
+		await expect(tools?.record({})).resolves.toBeUndefined()
+	} finally {
+		recordUsageSpy.mockRestore()
+	}
+})

--- a/packages/worker/src/usage/package-static-call-usage.ts
+++ b/packages/worker/src/usage/package-static-call-usage.ts
@@ -29,11 +29,14 @@ export type PackageStaticCallMeterTools = {
 }
 
 /**
- * Mirrors the sandbox-side buffer cap in the static-call meter prelude
- * (`createStaticCallMeterHelperPrelude`): bounds work per reported batch
- * even for a sandbox that forges an oversized payload.
+ * Mirrors the sandbox-side cumulative cap in the static-call meter prelude
+ * (`createStaticCallMeterHelperPrelude`), enforced across every batch of
+ * one run even for a sandbox that forges oversized payloads. Sized to fit
+ * the Workers Analytics Engine budget: 250 `writeDataPoint` calls per
+ * invocation, one per event, with headroom left for the run's other usage
+ * events.
  */
-const maxEventsPerBatch = 1000
+const maxRecordedEventsPerRun = 200
 
 export function createPackageStaticCallMeterTools(input: {
 	env: UsageEnv
@@ -48,17 +51,20 @@ export function createPackageStaticCallMeterTools(input: {
 }): PackageStaticCallMeterTools | undefined {
 	const userId = input.userId?.trim()
 	if (!userId) return undefined
+	let recordedCount = 0
 	return {
 		record: async (batch) => {
 			try {
 				const events = Array.isArray(batch?.events) ? batch.events : []
-				for (const rawEvent of events.slice(0, maxEventsPerBatch)) {
-					await recordStaticCallEvent({
+				for (const rawEvent of events.slice(0, maxRecordedEventsPerRun)) {
+					if (recordedCount >= maxRecordedEventsPerRun) return
+					const recorded = await recordStaticCallEvent({
 						env: input.env,
 						userId,
 						grantedPackageIds: input.grantedPackageIds,
 						rawEvent,
 					})
+					if (recorded) recordedCount += 1
 				}
 			} catch (error) {
 				console.debug('package-static-call-usage-failed', error)
@@ -67,6 +73,7 @@ export function createPackageStaticCallMeterTools(input: {
 	}
 }
 
+/** Returns true when the event was recorded (counts against the run cap). */
 async function recordStaticCallEvent(input: {
 	env: UsageEnv
 	userId: string
@@ -85,12 +92,12 @@ async function recordStaticCallEvent(input: {
 			'stamped package id is not a static dependency of this run',
 			packageId,
 		)
-		return
+		return false
 	}
 	const outcome = rawEvent.outcome
 	if (outcome !== 'success' && outcome !== 'error') {
 		console.debug('package-static-call-usage-dropped', 'invalid outcome')
-		return
+		return false
 	}
 	const durationMs =
 		typeof rawEvent.durationMs === 'number' &&
@@ -105,4 +112,5 @@ async function recordStaticCallEvent(input: {
 		durationMs,
 		outcome,
 	})
+	return true
 }

--- a/packages/worker/src/usage/package-static-call-usage.ts
+++ b/packages/worker/src/usage/package-static-call-usage.ts
@@ -1,0 +1,81 @@
+import { recordUsage, type UsageEnv } from './record-usage.ts'
+
+/**
+ * Host-side sink for `package_static_call` usage events reported by the
+ * sandbox-side call-metering wrapper around statically imported package
+ * exports (see `__kodyMeterStaticPackageExport` in
+ * `packages/worker/src/package-runtime/runtime-source-modules.ts`).
+ *
+ * Trust model: the callee package id is stamped into generated import-proxy
+ * code by the bundler, never taken from author-supplied strings. Generated
+ * code still runs inside the sandbox realm, though, so the host validates
+ * every reported id against the run's bundler-recorded static dependency
+ * provenance (the same grant set `packageStorage()` uses) and silently
+ * drops anything else. A malicious module can therefore at worst inflate
+ * call counts for packages its own bundle already statically depends on —
+ * it can never attribute usage to an arbitrary package.
+ *
+ * `record` never throws and never rejects: metering must not break the call
+ * path it observes (same contract as `recordUsage`).
+ */
+
+export type PackageStaticCallMeterInput = Record<string, unknown>
+
+export type PackageStaticCallMeterTools = {
+	record: (input: PackageStaticCallMeterInput) => Promise<void>
+}
+
+export function createPackageStaticCallMeterTools(input: {
+	env: UsageEnv
+	userId: string | null | undefined
+	/**
+	 * Saved-package UUIDs statically loaded into the running bundle, from
+	 * bundler/host controlled provenance only (see
+	 * `collectPackageStorageGrantIds`). Reported events whose stamped id is
+	 * not in this set are dropped.
+	 */
+	grantedPackageIds: ReadonlySet<string>
+}): PackageStaticCallMeterTools | undefined {
+	const userId = input.userId?.trim()
+	if (!userId) return undefined
+	return {
+		record: async (rawEvent) => {
+			try {
+				const packageId =
+					typeof rawEvent?.packageId === 'string' ? rawEvent.packageId : ''
+				if (!packageId || !input.grantedPackageIds.has(packageId)) {
+					console.debug(
+						'package-static-call-usage-dropped',
+						'stamped package id is not a static dependency of this run',
+						packageId,
+					)
+					return
+				}
+				const outcome = rawEvent.outcome
+				if (outcome !== 'success' && outcome !== 'error') {
+					console.debug(
+						'package-static-call-usage-dropped',
+						'invalid outcome',
+						outcome,
+					)
+					return
+				}
+				const durationMs =
+					typeof rawEvent.durationMs === 'number' &&
+					Number.isFinite(rawEvent.durationMs) &&
+					rawEvent.durationMs >= 0
+						? rawEvent.durationMs
+						: null
+				await recordUsage(input.env, {
+					userId,
+					eventType: 'package_static_call',
+					entityId: packageId,
+					durationMs,
+					outcome,
+				})
+			} catch (error) {
+				console.debug('package-static-call-usage-failed', error)
+			}
+		},
+	}
+}

--- a/packages/worker/src/usage/package-static-call-usage.ts
+++ b/packages/worker/src/usage/package-static-call-usage.ts
@@ -9,11 +9,13 @@ import { recordUsage, type UsageEnv } from './record-usage.ts'
  * Trust model: the callee package id is stamped into generated import-proxy
  * code by the bundler, never taken from author-supplied strings. Generated
  * code still runs inside the sandbox realm, though, so the host validates
- * every reported id against the run's bundler-recorded static dependency
- * provenance (the same grant set `packageStorage()` uses) and silently
- * drops anything else. A malicious module can therefore at worst inflate
- * call counts for packages its own bundle already statically depends on —
- * it can never attribute usage to an arbitrary package.
+ * every reported id against the bundle's *static* dependency package ids
+ * recorded at build time (a strict subset of the `packageStorage()` grant
+ * set, which additionally grants the run's own package id and
+ * dynamic-import dependencies) and silently drops anything else. A
+ * malicious module can therefore at worst inflate call counts for packages
+ * its own bundle already statically depends on — it can never attribute
+ * usage to an arbitrary package.
  *
  * Events arrive as one batch per run (buffered sandbox-side and flushed by
  * the run wrapper while the sandbox RPC dispatchers are still live); each
@@ -42,10 +44,10 @@ export function createPackageStaticCallMeterTools(input: {
 	env: UsageEnv
 	userId: string | null | undefined
 	/**
-	 * Saved-package UUIDs statically loaded into the running bundle, from
-	 * bundler/host controlled provenance only (see
-	 * `collectPackageStorageGrantIds`). Reported events whose stamped id is
-	 * not in this set are dropped.
+	 * Saved-package UUIDs recorded as static dependencies of the running
+	 * bundle at build time (`bundle.dependencies`), from bundler/host
+	 * controlled provenance only. Reported events whose stamped id is not
+	 * in this set are dropped.
 	 */
 	grantedPackageIds: ReadonlySet<string>
 }): PackageStaticCallMeterTools | undefined {

--- a/packages/worker/src/usage/package-static-call-usage.ts
+++ b/packages/worker/src/usage/package-static-call-usage.ts
@@ -15,8 +15,11 @@ import { recordUsage, type UsageEnv } from './record-usage.ts'
  * call counts for packages its own bundle already statically depends on —
  * it can never attribute usage to an arbitrary package.
  *
- * `record` never throws and never rejects: metering must not break the call
- * path it observes (same contract as `recordUsage`).
+ * Events arrive as one batch per run (buffered sandbox-side and flushed by
+ * the run wrapper while the sandbox RPC dispatchers are still live); each
+ * batch entry becomes one usage event. `record` never throws and never
+ * rejects: metering must not break the call path it observes (same
+ * contract as `recordUsage`).
  */
 
 export type PackageStaticCallMeterInput = Record<string, unknown>
@@ -24,6 +27,13 @@ export type PackageStaticCallMeterInput = Record<string, unknown>
 export type PackageStaticCallMeterTools = {
 	record: (input: PackageStaticCallMeterInput) => Promise<void>
 }
+
+/**
+ * Mirrors the sandbox-side buffer cap in the static-call meter prelude
+ * (`createStaticCallMeterHelperPrelude`): bounds work per reported batch
+ * even for a sandbox that forges an oversized payload.
+ */
+const maxEventsPerBatch = 1000
 
 export function createPackageStaticCallMeterTools(input: {
 	env: UsageEnv
@@ -39,43 +49,60 @@ export function createPackageStaticCallMeterTools(input: {
 	const userId = input.userId?.trim()
 	if (!userId) return undefined
 	return {
-		record: async (rawEvent) => {
+		record: async (batch) => {
 			try {
-				const packageId =
-					typeof rawEvent?.packageId === 'string' ? rawEvent.packageId : ''
-				if (!packageId || !input.grantedPackageIds.has(packageId)) {
-					console.debug(
-						'package-static-call-usage-dropped',
-						'stamped package id is not a static dependency of this run',
-						packageId,
-					)
-					return
+				const events = Array.isArray(batch?.events) ? batch.events : []
+				for (const rawEvent of events.slice(0, maxEventsPerBatch)) {
+					await recordStaticCallEvent({
+						env: input.env,
+						userId,
+						grantedPackageIds: input.grantedPackageIds,
+						rawEvent,
+					})
 				}
-				const outcome = rawEvent.outcome
-				if (outcome !== 'success' && outcome !== 'error') {
-					console.debug(
-						'package-static-call-usage-dropped',
-						'invalid outcome',
-						outcome,
-					)
-					return
-				}
-				const durationMs =
-					typeof rawEvent.durationMs === 'number' &&
-					Number.isFinite(rawEvent.durationMs) &&
-					rawEvent.durationMs >= 0
-						? rawEvent.durationMs
-						: null
-				await recordUsage(input.env, {
-					userId,
-					eventType: 'package_static_call',
-					entityId: packageId,
-					durationMs,
-					outcome,
-				})
 			} catch (error) {
 				console.debug('package-static-call-usage-failed', error)
 			}
 		},
 	}
+}
+
+async function recordStaticCallEvent(input: {
+	env: UsageEnv
+	userId: string
+	grantedPackageIds: ReadonlySet<string>
+	rawEvent: unknown
+}) {
+	const rawEvent =
+		typeof input.rawEvent === 'object' && input.rawEvent !== null
+			? (input.rawEvent as Record<string, unknown>)
+			: {}
+	const packageId =
+		typeof rawEvent.packageId === 'string' ? rawEvent.packageId : ''
+	if (!packageId || !input.grantedPackageIds.has(packageId)) {
+		console.debug(
+			'package-static-call-usage-dropped',
+			'stamped package id is not a static dependency of this run',
+			packageId,
+		)
+		return
+	}
+	const outcome = rawEvent.outcome
+	if (outcome !== 'success' && outcome !== 'error') {
+		console.debug('package-static-call-usage-dropped', 'invalid outcome')
+		return
+	}
+	const durationMs =
+		typeof rawEvent.durationMs === 'number' &&
+		Number.isFinite(rawEvent.durationMs) &&
+		rawEvent.durationMs >= 0
+			? rawEvent.durationMs
+			: null
+	await recordUsage(input.env, {
+		userId: input.userId,
+		eventType: 'package_static_call',
+		entityId: packageId,
+		durationMs,
+		outcome,
+	})
 }

--- a/packages/worker/src/usage/record-usage.ts
+++ b/packages/worker/src/usage/record-usage.ts
@@ -2,8 +2,9 @@
  * Per-user usage metering.
  *
  * One event schema covers every metered chokepoint (execute runs, package
- * export invocations, job runs, workflow runs, package service runtime,
- * realtime websocket sessions, gateway fetches, email sends and receives).
+ * export invocations, statically imported package export calls, job runs,
+ * workflow runs, package service runtime, realtime websocket sessions,
+ * gateway fetches, email sends and receives).
  *
  * The write path depends on the environment:
  *
@@ -40,6 +41,7 @@ const runtimeTracing: typeof cloudflareWorkers.tracing | undefined = (
 export type UsageEventType =
 	| 'execute'
 	| 'package_export'
+	| 'package_static_call'
 	| 'job_run'
 	| 'workflow_run'
 	| 'service_runtime'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Static imports (`import fn from 'kody:@scope/pkg/export'`) are the default for package reuse, but calls through them were invisible to usage metering. This PR adds a new member of the closed `UsageEventType` union, `package_static_call`, and emits **one non-blocking usage event per call** of a statically imported, function-valued package export:

- `userId` = the calling user (host-side, from caller context)
- `entityId` = the callee package id (the package whose export was imported)
- `durationMs` = wall time of the call (through settlement for async functions)
- `outcome` = `success` | `error` (whether the wrapped call threw/rejected — the error still propagates to the caller unchanged)

The metric also renders on the admin usage pages (curated `adminUsageMetrics` list, insights + per-user charts).

## How

- **Bundler stamping (provenance, never sandbox strings).** `ensurePackageProxy` knows which saved package a `kody:@…` specifier resolved to; it now emits a metered proxy (`createMeteredPackageImportProxySource`) that bakes the callee package id in and wraps function-valued exports (default + statically discovered named exports) in a transparent `Proxy` from the virtual runtime module. Only `[[Call]]` is trapped, so `new` on a wrapped class constructs the real class. `export * from` stays as a passthrough, so any export name the bundler cannot statically discover keeps working (it is just unmetered). Non-function exports pass through unchanged; dynamic-import proxies and root self-imports keep the plain proxy.
- **Export-name discovery.** New `module-export-names.ts` collects runtime export names (Babel AST, skipping type-only exports, following relative `export * from` chains inside the file map). Missing a name is always safe (passthrough).
- **Sandbox → host bridge with host validation.** Each call does one synchronous buffer push (~0 overhead, capped at 200 events per run to fit Analytics Engine's 250 `writeDataPoint`-per-invocation budget); the run wrapper in `runBundledModuleWithRegistry` flushes the batch over a new runtime-helper bridge **while the sandbox RPC dispatchers are still live** (a fire-and-forget RPC per call races dispatcher teardown and loses events — verified empirically), bounded by a short timeout so metering never owns the run's tail latency. The host (`createPackageStaticCallMeterTools`) only records events whose stamped id is one of the bundle's **static dependency package ids recorded at build time** — a strict subset of the `packageStorage()` grant set, which additionally grants the run's own package id and dynamic-import dependencies, neither of which the bundler ever stamps into a metered proxy. Everything else is silently dropped. Trust model stated honestly in code + docs: generated code still runs in the sandbox realm, so forgery can at worst inflate counts for packages the bundle already statically depends on.
- **Never blocks, never throws** into the call path (same contract as `recordUsage`); flush failures are swallowed.

## Testing

- `module-export-names.node.test.ts` — declaration/specifier/destructuring/type-only/star-chain/cycle/parse-failure cases.
- `package-static-call-usage.node.test.ts` — one event per batch entry with correct `entityId`/`outcome`/`durationMs`, forged/unknown ids dropped, invalid outcomes dropped, durations normalized, cumulative per-run cap, never-throws.
- `static-call-metering.workers.test.ts` — real bundles through `runBundledModuleWithRegistry` against local D1 rollups: 5 calls ⇒ `event_count: 5` with `error_count: 1`; a throwing export records `error` and still throws to the caller; `new` on a wrapped class constructs correctly and is not metered; non-function exports untouched; published-artifact imports metered; an in-sandbox forged stamp for a non-dependency package records nothing (with a post-settle re-check).
- Full `npm run validate` green locally (fresh Playwright E2E run: 19 passed); re-validated after rebasing onto `main` @ `c54a2686` (lean-invoke + deprecation shims) — all 138 overlapping unit test files pass post-rebase.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c54a2686` · **Head:** `a10ac251`

**Classification:** extends — no new primitives; the package runtime's import rewriting, the execute runtime wrapper, the runtime-helper bridge surface, usage metering, and the admin usage read model each gain behavior.

### Primitives touched

| Primitive             | Group   | Impact                                                                                     |
| --------------------- | ------- | ------------------------------------------------------------------------------------------ |
| `package-runtime`     | runtime | extends — static import proxies stamp callee package id and wrap function exports          |
| `capabilities-execute`| runtime | extends — run wrapper flushes buffered call events; meter validated against static deps    |
| `mcp-server`          | surfaces| extends — new internal runtime-helper bridge (`staticCallMeter`) in the helper manifest    |
| `usage-metering`      | storage | extends — new `package_static_call` event type + validated host-side sink                  |
| `app-ui`              | surfaces| composes — `package_static_call` added to admin usage chart series (new teal color)        |
| `rbac`                | auth    | composes — admin-user-usage capability output schema lists the new metric                  |

### System map

A statically imported package export call flows from the sandbox call-metering wrapper through the run-end bridge flush into validated usage events, which the admin usage pages now chart.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	usageMetering["usage-metering<br/>Usage metering"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	packageRuntime -->|"stamped metered import proxy + call wrapper"| capabilitiesExecute
	capabilitiesExecute -->|"buffered events flushed via staticCallMeter bridge"| mcpServer
	mcpServer -->|"validate stamped id against static bundle.dependencies ids"| usageMetering
	usageMetering -->|"package_static_call events (AE / usage_rollups fallback)"| d1AppDb
	appUi -->|"admin usage charts render package_static_call series"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user isolation holds: events are attributed to the calling user only, and stamped callee ids are validated host-side against the bundle's static dependency ids recorded at build time for that user's own bundle — sandbox-supplied ids can never attribute usage across users or to non-dependency packages.

</details>

<!-- system-recap:end -->

## Program report

**Status: MERGED + DEPLOY-VERIFIED (agent side).**

- **Merged:** squash-merged by the conductor at 2026-07-30T12:09:59Z as `f0d0b2b89bcec1cab35b1775ac6d94a33d088d87`.
- **Deploy verified (agent half of the split):**
  - ✅ Validate on `main` @ `f0d0b2b8`: success ([run 30541425455](https://github.com/kentcdodds/kody/actions/runs/30541425455)).
  - 🚀 Deploy (production) on `f0d0b2b8`: success ([run 30541718572](https://github.com/kentcdodds/kody/actions/runs/30541718572)).
  - `https://heykody.dev/health` → `{"ok":true,"commitSha":"f0d0b2b89bcec1cab35b1775ac6d94a33d088d87"}` — matches the merge commit.
- **Awaiting (conductor half):** authenticated production probes — run a static package export call in production, then query `kody_usage_events` for `package_static_call` rows (blobs: `[userId, eventType, entityId, outcome, timestamp]`, doubles: `[durationMs, cpuMs, bytes]`) — and confirm here.
- **Pre-merge summary:** rebased cleanly onto `main` @ `c54a2686` (lean-invoke + deprecation shims), no semantic conflicts; CI fully green on head `a10ac251` (one Node round flaked on runner load in files outside this diff, retriggered and green). QA follow-ups all landed: static-deps-only validation set, `package_static_call` on admin usage pages, Analytics Engine capacity note. Reviewer findings triaged: two fixed (bounded flush rounds; cumulative 200-event cap for the AE budget), three declined with evidence (Proxy construct claim — pinned by test; thenable subscription — lazy side-effect risk; late-settling-events rehash — documented delivery-window limit), one low-value nitpick skipped (shared constant for the metric key; string literals with the closed union are the codebase pattern).
- **Blocked:** nothing.
- **Remaining work:** none on the agent side; track closes once the conductor's authenticated production probes confirm `package_static_call` rows in `kody_usage_events`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec14e2e3-27db-46d7-91d5-3eb3c83ade75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec14e2e3-27db-46d7-91d5-3eb3c83ade75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added usage metering for statically imported package export calls with duration and success/error outcomes.
  * Introduced buffering/flushing runtime support and metered export proxying for non-root package imports.
  * Added admin insights support for the new metric, including chart series and theme color.
* **Documentation**
  * Updated the usage metering spec for the new `package_static_call` event type, validation rules, and nesting guidance.
* **Tests**
  * Added/expanded coverage for static-call metering behavior, forged-stamp dropping, export name discovery, and proxy/bundling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->