### PR TITLE
Migrate the keyed package-invocation idempotency ledger from D1 into the per-user RunLog DO

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -184,10 +184,11 @@ Durable Object export behavior:
   hold application/job/service durable state and are the primary account
   migration surface for Durable Object storage.
 - `JobManager` exposes scheduler alarm/debug state through an export RPC.
-- `RunLog` exports per-user execution history (runs + log lines) through the
-  account-export `run_records` section (`exportRuns` RPC). Retention is
-  self-enforced inside the DO (~30 days / 2,000 runs); see
-  [Run records](./run-records.md).
+- `RunLog` exports per-user execution history (runs + log lines) and the keyed
+  package-invocation idempotency ledger through the account-export `run_records`
+  section (`exportRuns` RPC; one cursor pages runs first, then ledger rows).
+  Retention is self-enforced inside the DO (~30 days / 2,000 runs; ledger
+  terminal rows 90 days); see [Run records](./run-records.md).
 - `RemoteConnectorSession` exposes persisted connector metadata and tool
   descriptors through an export RPC.
 - `PackageServiceInstance` uses its status RPC as the stable persisted service
@@ -922,9 +923,14 @@ documented exemption.
 
 Current retention policies:
 
-- `package_invocations`: keep terminal idempotency rows for 90 days. Rows with
-  `status = 'in_progress'` are never pruned so duplicate requests cannot bypass
-  the in-flight guard.
+- `package_invocations`: **legacy dual-read window.** Keyed invocations now
+  claim and store replay responses in the per-user `RunLog` Durable Object
+  ledger (`package_invocation_ledger` table inside the DO), which self-enforces
+  the same 90-day terminal-row window; the keyed path only reads this D1 table
+  as a fallback for pre-migration keys and never writes it. The sweep keeps
+  draining pre-migration terminal rows (rows with `status = 'in_progress'` are
+  never pruned) until a follow-up drops the table, the fallback read, and this
+  policy entry.
 - `mcp_memory_conversation_suppressions`: keep active suppressions and prune
   expired rows only after they have not been seen for 90 days. The existing
   request-time memory prune may remove expired rows sooner.

--- a/docs/contributing/architecture/invocation-overhead-guardrails.md
+++ b/docs/contributing/architecture/invocation-overhead-guardrails.md
@@ -23,7 +23,13 @@ call, not about what user code does inside the call.
   belongs in the keyed mode or off the hot path (`waitUntil`).
 - **Keyed `packages.invoke`** deliberately pays for durability: a ledger claim,
   eager run records, and a bounded response snapshot for replay. That cost is
-  the feature; it must never silently leak into the keyless mode.
+  the feature; it must never silently leak into the keyless mode. The ledger
+  lives in the per-user `RunLog` Durable Object (see
+  [Run records](./run-records.md)), so the durability cost is **one awaited DO
+  call for claim + run-record begin and one for terminal response + run-record
+  finish** — not D1 round trips. During the dual-read window the keyed path also
+  pays one awaited D1 **read** for pre-migration keys; a follow-up removes it
+  with the legacy `package_invocations` table.
 
 ## Watch the percentiles
 

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -199,6 +199,38 @@ TTLs above. Reconciliation runs on the DO alarm, on retention passes, and **on
 read** (`getRun`, keyed lookup, `listRuns`, `summarize`) so Activity and
 keyed-execute recovery do not wait for an alarm.
 
+## Keyed package-invocation idempotency ledger
+
+The same per-user `RunLog` DO also hosts the **keyed package-invocation
+idempotency ledger** (`package_invocation_ledger` table), migrated off the D1
+`package_invocations` table. This is correctness state, not observability: it is
+what makes keyed `packages.invoke` exactly-once.
+
+- **Claim + run-record begin are one awaited DO RPC**
+  (`claimPackageInvocation`): lookup-then-insert is atomic because DO execution
+  is serialized — strictly better than the D1 `INSERT OR IGNORE` race it
+  replaced — and the eager `running` run row is written in the same call. Stale
+  `in_progress` claims (15 minutes, matching request hash) are reclaimed in
+  place.
+- **Terminal response + run-record finish are one awaited DO RPC**
+  (`finishPackageInvocation`): the bounded replay response (same restore-safe
+  byte ceiling as before) and the terminal run row land together; the ledger
+  update is fenced on the claim timestamp so a competing reclaim cannot be
+  overwritten.
+- **Ledger retention is DO-local**: terminal rows keep replay responses for 90
+  days (`packageInvocationLedgerRetentionDays`), pruned by the same retention
+  passes and alarm as run rows; `in_progress` rows are never pruned. The old D1
+  retention sweep remains only to drain pre-migration rows.
+- **Dual-read window**: the keyed path reads the DO first and falls back to a
+  read-only D1 `package_invocations` lookup for keys claimed before the
+  migration. Writes go only to the DO. A follow-up removes the fallback, the D1
+  table, its sweep, and the legacy row shapes.
+- Account export pages ledger rows through the same `run_records` section cursor
+  (runs first, then ledger rows); account deletion purges them with `clearAll`.
+  Disaster recovery deliberately does not stage the DO — losing it risks
+  duplicate execution of replayed webhooks (see
+  [disaster recovery](../disaster-recovery.md)).
+
 ## Invariant: state vs history
 
 Entity rows hold **current state**. Run records hold **history**. Never derive

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -203,8 +203,10 @@ keyed-execute recovery do not wait for an alarm.
 
 The same per-user `RunLog` DO also hosts the **keyed package-invocation
 idempotency ledger** (`package_invocation_ledger` table), migrated off the D1
-`package_invocations` table. This is correctness state, not observability: it is
-what makes keyed `packages.invoke` exactly-once.
+`package_invocations` table. This is correctness state, not observability: it
+holds the claims and bounded replay responses that keyed `packages.invoke`
+dedupes against. Unlike run history it cannot be rebuilt — a lost terminal row
+means a replayed delivery for that key re-executes instead of replaying.
 
 - **Claim + run-record begin are one awaited DO RPC**
   (`claimPackageInvocation`): lookup-then-insert is atomic because DO execution

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -194,14 +194,16 @@ Restore rebuilds these; do not treat them as recovery media:
   **Known risk — keyed invocation idempotency ledger:** the same `RunLog` DO
   also holds the keyed package-invocation idempotency ledger (claims + 90-day
   terminal replay responses; migrated off the D1 `package_invocations` table).
-  Losing the DO therefore loses exactly-once state, not just observability:
-  webhook providers and other keyed callers that retry deliveries would
-  **re-execute** invocations whose keys were already terminal, and in-flight
-  replays would return fresh executions instead of stored responses. This is
-  accepted: the ledger is per-user, self-expiring, and rebuilt organically by
-  new traffic, and the blast radius of a loss is duplicate side effects for at
-  most the retention window — not data loss. Restores from a D1 backup restore
-  the legacy table only; the DO ledger is not part of DR media.
+  Losing the DO therefore loses idempotency/replay state, not just
+  observability: webhook providers and other keyed callers that retry deliveries
+  would **re-execute** invocations whose keys were already terminal, and
+  in-flight replays would return fresh executions instead of stored responses.
+  This is accepted with eyes open: lost rows are gone — later traffic
+  re-establishes claims only for keys used after the loss, it does not restore
+  protection for keys used before it. The blast radius is duplicate side effects
+  (a loss of correctness state) bounded by the 90-day retention window; no
+  stored user content is lost. Restores from a D1 backup restore the legacy
+  table only; the DO ledger is not part of DR media.
 
 ### Honest gaps
 

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -191,6 +191,18 @@ Restore rebuilds these; do not treat them as recovery media:
   Account export/deletion cover run records for user-facing portability and
   purge; disaster recovery deliberately does not.
 
+  **Known risk — keyed invocation idempotency ledger:** the same `RunLog` DO
+  also holds the keyed package-invocation idempotency ledger (claims + 90-day
+  terminal replay responses; migrated off the D1 `package_invocations` table).
+  Losing the DO therefore loses exactly-once state, not just observability:
+  webhook providers and other keyed callers that retry deliveries would
+  **re-execute** invocations whose keys were already terminal, and in-flight
+  replays would return fresh executions instead of stored responses. This is
+  accepted: the ledger is per-user, self-expiring, and rebuilt organically by
+  new traffic, and the blast radius of a loss is duplicate side effects for at
+  most the retention window — not data loss. Restores from a D1 backup restore
+  the legacy table only; the DO ledger is not part of DR media.
+
 ### Honest gaps
 
 - **Artifacts Git history** is not mirrored. Only published source snapshots in

--- a/packages/worker/src/account/export.node.test.ts
+++ b/packages/worker/src/account/export.node.test.ts
@@ -1383,6 +1383,23 @@ test('account export includes run_records section with runs and log lines', asyn
 			fields: { ok: true },
 		},
 	]
+	// Keyed package-invocation idempotency ledger row stored in the same
+	// RunLog DO; exported through the same run_records section.
+	const packageInvocation = {
+		id: 'invocation-export-1',
+		tokenId: 'token-1',
+		packageId: 'pkg-1',
+		packageKodyId: 'pkg-one',
+		exportName: './send-message',
+		idempotencyKey: 'evt-1',
+		requestHash: 'hash-1',
+		source: 'webhook',
+		topic: null,
+		status: 'completed' as const,
+		responseJson: '{"status":200,"body":{"ok":true}}',
+		createdAt: '2026-07-26T00:00:00.000Z',
+		updatedAt: '2026-07-26T00:00:01.000Z',
+	}
 	const env = {
 		APP_DB: db,
 		STORAGE_RUNNER: {
@@ -1402,6 +1419,7 @@ test('account export includes run_records section with runs and log lines', asyn
 				exportRuns: async () => ({
 					runs: [run],
 					logs,
+					packageInvocations: [packageInvocation],
 					nextStartAfter: null,
 					truncated: false,
 				}),
@@ -1432,6 +1450,7 @@ test('account export includes run_records section with runs and log lines', asyn
 	expect(accountExport.durableObjects.runRecords).toEqual({
 		runs: [run],
 		logs,
+		packageInvocations: [packageInvocation],
 		nextStartAfter: null,
 		truncated: false,
 	})
@@ -1447,6 +1466,9 @@ test('account export includes run_records section with runs and log lines', asyn
 		{
 			run,
 			logs,
+		},
+		{
+			packageInvocation,
 		},
 	])
 })

--- a/packages/worker/src/account/export.node.test.ts
+++ b/packages/worker/src/account/export.node.test.ts
@@ -1446,7 +1446,8 @@ test('account export includes run_records section with runs and log lines', asyn
 		dbUserId: 1,
 		mcpUserId: 'user-aaa',
 	})
-	expect(accountExport.manifest.sections.run_records?.count).toBe(1)
+	// One run plus one invocation-ledger row exported through the section.
+	expect(accountExport.manifest.sections.run_records?.count).toBe(2)
 	expect(accountExport.durableObjects.runRecords).toEqual({
 		runs: [run],
 		logs,

--- a/packages/worker/src/account/export.ts
+++ b/packages/worker/src/account/export.ts
@@ -1772,10 +1772,18 @@ export async function readAccountExportSection(input: {
 		})
 		return {
 			section: input.section,
-			items: page.runs.map((run) => ({
-				run,
-				logs: page.logs.filter((log) => log.runId === run.id),
-			})),
+			// Runs page first; once runs are exhausted the same cursor continues
+			// through the keyed package-invocation idempotency ledger rows that
+			// live in the same per-user RunLog Durable Object.
+			items: [
+				...page.runs.map((run) => ({
+					run,
+					logs: page.logs.filter((log) => log.runId === run.id),
+				})),
+				...page.packageInvocations.map((packageInvocation) => ({
+					packageInvocation,
+				})),
+			],
 			truncated: page.truncated,
 			nextStartAfter: page.nextStartAfter,
 			pageSize,

--- a/packages/worker/src/account/export.ts
+++ b/packages/worker/src/account/export.ts
@@ -1456,10 +1456,14 @@ function buildManifest(input: {
 		discovery: { section: 'job_manager' },
 	}
 	sections.run_records = {
+		// The section carries runs plus the RunLog DO's package-invocation
+		// idempotency ledger rows, so count both when the export payload is
+		// present. The inventory fallback comes from `summarize` (runs only).
 		count:
-			input.durableObjects?.runRecords?.runs.length ??
-			input.inventoryCounts?.runRecords ??
-			0,
+			input.durableObjects?.runRecords == null
+				? (input.inventoryCounts?.runRecords ?? 0)
+				: input.durableObjects.runRecords.runs.length +
+					input.durableObjects.runRecords.packageInvocations.length,
 		warnings: input.warnings.filter((warning) =>
 			warning.startsWith('Run records '),
 		),

--- a/packages/worker/src/account/user-owned-surfaces.ts
+++ b/packages/worker/src/account/user-owned-surfaces.ts
@@ -121,7 +121,7 @@ export const accountUserOwnedDurableObjectSurfaces: ReadonlyArray<UserOwnedDurab
 			deletionResultKey: 'runLogs',
 			export: 'include',
 			notes:
-				'Execution history and captured logs across every runtime surface. Self-prunes inside the DO rather than through a retention cron lane.',
+				'Execution history and captured logs across every runtime surface, plus the keyed package-invocation idempotency ledger (terminal replay responses, 90-day window). Self-prunes inside the DO rather than through a retention cron lane; account deletion clearAll purges ledger rows with the run history, and account export pages both through the run_records section.',
 		},
 		{
 			id: 'mcp',

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -77,7 +77,7 @@ export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
 		retentionDays: packageInvocationRetentionDays,
 		batchSize: retentionDefaultBatchSize,
 		description:
-			'Package invocation idempotency rows keep terminal responses for 90 days; in-progress rows are never pruned.',
+			'LEGACY (dual-read window): keyed invocations now claim and store responses in the per-user RunLog Durable Object ledger, which self-enforces the same 90-day terminal-row window. This sweep only drains pre-migration terminal rows; in-progress rows are never pruned. Remove with the follow-up that drops the table and the D1 fallback read.',
 	},
 	{
 		table: 'mcp_memory_conversation_suppressions',

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -3387,15 +3387,19 @@ export default async function main(input = {}) {
 			).packageInvocations.filter((row) => row.packageId === packageId)
 			expect(invocations).toHaveLength(2)
 			// Anchor each stored response to its message body instead of relying
-			// on ledger ordering.
-			const responseBodies = invocations.map(
-				(row) =>
-					(
-						JSON.parse(String(row.responseJson)) as {
-							status: number
-							body: Record<string, unknown>
-						}
-					).body,
+			// on ledger ordering. Rows without a replay cache (oversized) would
+			// simply not match and fail the assertions below.
+			const responseBodies = invocations.flatMap((row) =>
+				row.responseJson == null
+					? []
+					: [
+							(
+								JSON.parse(row.responseJson) as {
+									status: number
+									body: Record<string, unknown>
+								}
+							).body,
+						],
 			)
 			const responseForTextBody = (textBody: string) =>
 				responseBodies.find(

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -3384,17 +3384,26 @@ export default async function main(input = {}) {
 			// The keyed idempotency ledger lives in the owner's RunLog DO now.
 			const invocations = (
 				await exportRunRecords({ env, userId, pageSize: 100 })
-			).packageInvocations
-				.filter((row) => row.packageId === packageId)
-				.sort((a, b) =>
-					a.createdAt === b.createdAt
-						? a.id.localeCompare(b.id)
-						: a.createdAt.localeCompare(b.createdAt),
-				)
+			).packageInvocations.filter((row) => row.packageId === packageId)
 			expect(invocations).toHaveLength(2)
-			const responses = invocations.map((row) =>
-				JSON.parse(String(row.responseJson)),
-			) as Array<{ status: number; body: Record<string, unknown> }>
+			// Anchor each stored response to its message body instead of relying
+			// on ledger ordering.
+			const responseBodies = invocations.map(
+				(row) =>
+					(
+						JSON.parse(String(row.responseJson)) as {
+							status: number
+							body: Record<string, unknown>
+						}
+					).body,
+			)
+			const responseForTextBody = (textBody: string) =>
+				responseBodies.find(
+					(body) =>
+						(body['result'] as Record<string, unknown> | undefined)?.[
+							'textBody'
+						] === textBody,
+				)
 			const outboundMessages = await listEmailMessages({
 				db: env.APP_DB,
 				userId,
@@ -3410,7 +3419,7 @@ export default async function main(input = {}) {
 				'email.message.received',
 			])
 			expect(invocations.map((row) => row.source)).toEqual(['email', 'email'])
-			expect(responses[0]?.body).toMatchObject({
+			expect(responseForTextBody('Stored body.\n')).toMatchObject({
 				ok: true,
 				result: {
 					eventType: 'received',
@@ -3420,7 +3429,7 @@ export default async function main(input = {}) {
 					replyDirection: 'outbound',
 				},
 			})
-			expect(responses[1]?.body).toMatchObject({
+			expect(responseForTextBody('Approved body.\n')).toMatchObject({
 				ok: true,
 				result: {
 					eventType: 'received',

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -38,6 +38,7 @@ import {
 } from './service.ts'
 import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
+import { exportRunRecords } from '#worker/run-records/service.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import {
@@ -3380,18 +3381,19 @@ export default async function main(input = {}) {
 				}
 			}
 
-			const invocations = await db
-				.prepare(
-					`SELECT export_name, topic, source, response_json
-				FROM package_invocations
-				WHERE package_id = ?
-				ORDER BY created_at ASC, id ASC`,
+			// The keyed idempotency ledger lives in the owner's RunLog DO now.
+			const invocations = (
+				await exportRunRecords({ env, userId, pageSize: 100 })
+			).packageInvocations
+				.filter((row) => row.packageId === packageId)
+				.sort((a, b) =>
+					a.createdAt === b.createdAt
+						? a.id.localeCompare(b.id)
+						: a.createdAt.localeCompare(b.createdAt),
 				)
-				.bind(packageId)
-				.all<Record<string, unknown>>()
-			expect(invocations.results).toHaveLength(2)
-			const responses = (invocations.results ?? []).map((row) =>
-				JSON.parse(String(row['response_json'])),
+			expect(invocations).toHaveLength(2)
+			const responses = invocations.map((row) =>
+				JSON.parse(String(row.responseJson)),
 			) as Array<{ status: number; body: Record<string, unknown> }>
 			const outboundMessages = await listEmailMessages({
 				db: env.APP_DB,
@@ -3399,18 +3401,15 @@ export default async function main(input = {}) {
 				direction: 'outbound',
 				limit: 10,
 			})
-			expect(invocations.results?.map((row) => row['export_name'])).toEqual([
+			expect(invocations.map((row) => row.exportName)).toEqual([
 				'subscription:email.message.received',
 				'subscription:email.message.received',
 			])
-			expect(invocations.results?.map((row) => row['topic'])).toEqual([
+			expect(invocations.map((row) => row.topic)).toEqual([
 				'email.message.received',
 				'email.message.received',
 			])
-			expect(invocations.results?.map((row) => row['source'])).toEqual([
-				'email',
-				'email',
-			])
+			expect(invocations.map((row) => row.source)).toEqual(['email', 'email'])
 			expect(responses[0]?.body).toMatchObject({
 				ok: true,
 				result: {

--- a/packages/worker/src/email/system-email-subscriptions.workers.test.ts
+++ b/packages/worker/src/email/system-email-subscriptions.workers.test.ts
@@ -7,6 +7,7 @@ import { createForwardableEmailMessage } from './test-fixtures.ts'
 import { ensureEmailTestSchema } from './test-schema.ts'
 import { ensureUsageRollupsTestSchema } from '#worker/usage/test-schema.ts'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { exportRunRecords } from '#worker/run-records/service.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 
@@ -369,23 +370,24 @@ test(
 			expect(stored).toBeDefined()
 			if (!stored) throw new Error('Expected stored system message')
 
-			const invocations = await env.APP_DB.prepare(
-				`SELECT package_id, export_name, topic, source, idempotency_key, response_json
-			FROM package_invocations
-			WHERE package_id IN (?, ?)`,
-			)
-				.bind(adminPackage.packageId, regularPackage.packageId)
-				.all<Record<string, unknown>>()
-			expect(invocations.results).toHaveLength(1)
-			const invocation = invocations.results?.[0]
+			// The keyed idempotency ledger lives in each owner's RunLog DO now.
+			const adminInvocations = (
+				await exportRunRecords({ env, userId: adminStableId, pageSize: 100 })
+			).packageInvocations
+			const regularInvocations = (
+				await exportRunRecords({ env, userId: regularStableId, pageSize: 100 })
+			).packageInvocations
+			expect(regularInvocations).toHaveLength(0)
+			expect(adminInvocations).toHaveLength(1)
+			const invocation = adminInvocations[0]
 			expect(invocation).toMatchObject({
-				package_id: adminPackage.packageId,
-				export_name: `subscription:${systemTopic}`,
+				packageId: adminPackage.packageId,
+				exportName: `subscription:${systemTopic}`,
 				topic: systemTopic,
 				source: 'email',
-				idempotency_key: `email:${stored.id}:${adminPackage.packageId}:${systemTopic}`,
+				idempotencyKey: `email:${stored.id}:${adminPackage.packageId}:${systemTopic}`,
 			})
-			const response = JSON.parse(String(invocation?.['response_json'])) as {
+			const response = JSON.parse(String(invocation?.responseJson)) as {
 				body: Record<string, unknown>
 			}
 			expect(response.body).toMatchObject({

--- a/packages/worker/src/package-invocations/idempotency.ts
+++ b/packages/worker/src/package-invocations/idempotency.ts
@@ -1,10 +1,17 @@
 import { canonicalJsonStringify } from '@kody-internal/shared/canonical-json.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { buildJsonErrorResponse } from './responses.ts'
-import {
-	type getPackageInvocationByKey,
-	type PackageInvocationStoredResponse,
-} from './repo.ts'
+import { type PackageInvocationStoredResponse } from './repo.ts'
+
+/**
+ * Store-agnostic view of an idempotency row: the RunLog DO ledger record and
+ * the legacy D1 `package_invocations` row (dual-read window) both map into it.
+ */
+export type ResolvableInvocationRecord = {
+	requestHash: string
+	status: string
+	storedResponse: PackageInvocationStoredResponse | null
+}
 
 export function markStoredResponseAsReplayed(
 	response: PackageInvocationStoredResponse,
@@ -54,11 +61,11 @@ function buildIdempotencyResponseUnavailable(input: {
 }
 
 export function resolveExistingInvocation(input: {
-	record: NonNullable<Awaited<ReturnType<typeof getPackageInvocationByKey>>>
+	record: ResolvableInvocationRecord
 	requestHash: string
 	idempotencyKey: string
 }): PackageInvocationStoredResponse {
-	if (input.record.request_hash !== input.requestHash) {
+	if (input.record.requestHash !== input.requestHash) {
 		return buildJsonErrorResponse({
 			status: 409,
 			code: 'idempotency_mismatch',

--- a/packages/worker/src/package-invocations/idempotent-module-invocation.ts
+++ b/packages/worker/src/package-invocations/idempotent-module-invocation.ts
@@ -236,10 +236,14 @@ export async function invokeSavedPackageModule(input: {
 
 	/**
 	 * Dual-read fallback for keys claimed before the ledger moved into the
-	 * RunLog DO. Runs only after a FRESH DO claim (the DO had no row for the
-	 * key); reclaims and replays never touch D1. Returns the response to
-	 * serve from the legacy row, or `null` when this attempt should proceed
-	 * to execute. Awaited D1 reads only — never writes.
+	 * RunLog DO. Runs after every claim (fresh or stale reclaim): a
+	 * pre-migration key can sit terminal in D1 while a dead attempt's stale
+	 * DO claim still exists — e.g. a takeover attempt died and a zombie
+	 * pre-migration isolate later finished the legacy row — and replaying it
+	 * beats re-executing. DO replays never reach this (terminal DO rows
+	 * resolve before claiming). Returns the response to serve from the
+	 * legacy row, or `null` when this attempt should proceed to execute.
+	 * Awaited D1 reads only — never writes.
 	 */
 	const resolveLegacyFallback = async (claimed: ClaimedInvocation) => {
 		let legacy: Awaited<ReturnType<typeof lookupLegacy>>
@@ -380,10 +384,8 @@ export async function invokeSavedPackageModule(input: {
 		claimUpdatedAt: claim.claimUpdatedAt,
 		handle: claim.handle,
 	}
-	if (!claim.reclaimed) {
-		const legacyResponse = await resolveLegacyFallback(claimed)
-		if (legacyResponse) return legacyResponse
-	}
+	const legacyResponse = await resolveLegacyFallback(claimed)
+	if (legacyResponse) return legacyResponse
 
 	const outcome = await runSavedPackageModuleOnce({
 		env: input.env,

--- a/packages/worker/src/package-invocations/idempotent-module-invocation.ts
+++ b/packages/worker/src/package-invocations/idempotent-module-invocation.ts
@@ -1,22 +1,36 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
-import { withAccountWriteLease } from '#worker/account/deletion-state.ts'
+import {
+	claimPackageInvocationRecord,
+	finishPackageInvocationRecord,
+	getPackageInvocationRecord,
+	releasePackageInvocationRecord,
+	type PackageInvocationLedgerRecord,
+} from '#worker/run-records/service.ts'
+import {
+	type RunRecordContext,
+	type RunRecordHandle,
+} from '#worker/run-records/types.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import {
+	buildPackageInvocationStorageId,
+	resolveInvocationRuntimeName,
+	resolveInvocationRuntimeSurface,
 	type PackageInvocationActor,
 	type PackageModuleSelector,
 	type PackageRuntimeToolFactories,
 } from './common.ts'
-import { createRequestHash, resolveExistingInvocation } from './idempotency.ts'
+import {
+	createRequestHash,
+	resolveExistingInvocation,
+	type ResolvableInvocationRecord,
+} from './idempotency.ts'
 import { type ensureModuleArtifact } from './module-artifacts.ts'
 import { runSavedPackageModuleOnce } from './module-execution.ts'
 import { buildJsonErrorResponse } from './responses.ts'
 import {
+	boundedResponseJson,
 	getPackageInvocationByKey,
-	insertPackageInvocationRow,
-	releasePackageInvocationClaim,
-	tryClaimStalePackageInvocation,
-	updatePackageInvocationResult,
-	type PackageInvocationStoredResponse,
+	parseStoredResponse,
 } from './repo.ts'
 
 export const packageInvocationStaleAfterMs = 15 * 60 * 1000
@@ -27,11 +41,53 @@ function isStaleInvocation(updatedAt: string, now: Date) {
 	return Date.parse(updatedAt) <= now.getTime() - packageInvocationStaleAfterMs
 }
 
+function toResolvableLedgerRecord(
+	record: PackageInvocationLedgerRecord,
+): ResolvableInvocationRecord {
+	return {
+		requestHash: record.requestHash,
+		status: record.status,
+		storedResponse: parseStoredResponse(record.responseJson),
+	}
+}
+
+function toResolvableLegacyRecord(
+	record: NonNullable<Awaited<ReturnType<typeof getPackageInvocationByKey>>>,
+): ResolvableInvocationRecord {
+	return {
+		requestHash: record.request_hash,
+		status: record.status,
+		storedResponse: record.storedResponse,
+	}
+}
+
+type ClaimedInvocation = {
+	invocationId: string
+	claimUpdatedAt: string
+	handle: RunRecordHandle | null
+}
+
 /**
- * Keyed (exactly-once) invocation path: idempotency ledger claim, bounded
- * response replay, eager run records. Key-less callers take
+ * Keyed (exactly-once) invocation path. The idempotency ledger lives in the
+ * per-user RunLog Durable Object: the claim and the eager run-record begin
+ * are one awaited DO call, and the terminal response and run-record finish
+ * are one awaited DO call. Key-less callers take
  * `runSavedPackageModuleEphemeral` in module-execution.ts instead — the
  * execution itself is shared via `runSavedPackageModuleOnce`.
+ *
+ * During the dual-read window this path still READS the legacy D1
+ * `package_invocations` table for keys claimed before the migration, but it
+ * never writes it; a follow-up removes the fallback together with the table
+ * and its retention sweep.
+ *
+ * This path deliberately takes no `withAccountWriteLease`: the lease guards
+ * D1 writes against concurrent account deletion, and no D1 writes remain
+ * here. D1 writes made by the executing package go through capability
+ * services that hold their own leases — the same guard profile the key-less
+ * lean path shipped with. The DO rows this path writes are purged by account
+ * deletion's `clearRunRecords`, and a write racing past that purge is the
+ * same accepted residual as every other run-record write, bounded by the
+ * DO's own retention.
  */
 export async function invokeSavedPackageModule(input: {
 	env: Env
@@ -58,296 +114,395 @@ export async function invokeSavedPackageModule(input: {
 	> | null
 	executorTimeoutMs?: number | null
 }) {
-	return await withAccountWriteLease({
-		db: input.env.APP_DB,
-		stableUserId: input.actor.userId,
-		async write() {
-			const requestHash = await createRequestHash({
-				packageId: input.savedPackage.id,
+	const requestHash = await createRequestHash({
+		packageId: input.savedPackage.id,
+		exportName: input.invocationName,
+		params: input.params,
+		source: input.source,
+		topic: input.topic,
+	})
+	const ledgerKey = {
+		tokenId: input.actor.tokenId,
+		packageId: input.savedPackage.id,
+		exportName: input.invocationName,
+		idempotencyKey: input.idempotencyKey,
+	}
+
+	const resolveLedgerRecord = (record: PackageInvocationLedgerRecord) =>
+		resolveExistingInvocation({
+			record: toResolvableLedgerRecord(record),
+			requestHash,
+			idempotencyKey: input.idempotencyKey,
+		})
+	const buildLookupFailedResponse = () =>
+		buildJsonErrorResponse({
+			status: 500,
+			code: 'idempotency_lookup_failed',
+			message:
+				'Unable to look up the package invocation idempotency record. Please retry.',
+			idempotencyKey: input.idempotencyKey,
+		})
+	const buildPersistenceFailedResponse = () =>
+		buildJsonErrorResponse({
+			status: 500,
+			code: 'idempotency_persistence_failed',
+			message:
+				'Unable to persist the package invocation idempotency record. Please retry.',
+			idempotencyKey: input.idempotencyKey,
+		})
+
+	const buildRunRecordContext = (): RunRecordContext | null => {
+		const runtimeSurface = resolveInvocationRuntimeSurface({
+			selector: input.moduleSelector,
+			source: input.source,
+		})
+		// `null` surface: the caller (package-backed workflows) owns the run
+		// record, so the claim writes only the ledger row.
+		if (runtimeSurface == null) return null
+		return {
+			packageId: input.savedPackage.id,
+			kodyId: input.savedPackage.kodyId,
+			sourceId: input.savedPackage.sourceId,
+			// Known only after the artifact loads; module-execution enriches the
+			// handle context before the terminal write.
+			publishedCommit: null,
+			storageId: buildPackageInvocationStorageId(input.savedPackage.id),
+			surface: runtimeSurface,
+			name: resolveInvocationRuntimeName({
+				surface: runtimeSurface,
+				invocationName: input.invocationName,
+				topic: input.topic,
+			}),
+			invocationId: null,
+			idempotencyKey: input.idempotencyKey,
+			metadata: {
 				exportName: input.invocationName,
-				params: input.params,
 				source: input.source,
 				topic: input.topic,
+			},
+		}
+	}
+
+	const attemptClaim = async () =>
+		await claimPackageInvocationRecord({
+			env: input.env,
+			userId: input.actor.userId,
+			context: buildRunRecordContext(),
+			invocation: {
+				id: crypto.randomUUID(),
+				...ledgerKey,
+				packageKodyId: input.savedPackage.kodyId,
+				requestHash,
+				source: input.source,
+				topic: input.topic,
+			},
+			staleBefore: new Date(
+				Date.now() - packageInvocationStaleAfterMs,
+			).toISOString(),
+		})
+	const lookupLedger = async () =>
+		await getPackageInvocationRecord({
+			env: input.env,
+			userId: input.actor.userId,
+			key: ledgerKey,
+		})
+	const lookupLegacy = async () =>
+		await getPackageInvocationByKey({
+			db: input.env.APP_DB,
+			userId: input.actor.userId,
+			tokenId: input.actor.tokenId,
+			packageId: input.savedPackage.id,
+			exportName: input.invocationName,
+			idempotencyKey: input.idempotencyKey,
+		})
+	const releaseClaimBestEffort = async (claimed: ClaimedInvocation) => {
+		try {
+			await releasePackageInvocationRecord({
+				env: input.env,
+				userId: input.actor.userId,
+				invocationId: claimed.invocationId,
+				claimUpdatedAt: claimed.claimUpdatedAt,
+				handle: claimed.handle,
 			})
-			const lookupInvocation = async () =>
-				await getPackageInvocationByKey({
-					db: input.env.APP_DB,
-					userId: input.actor.userId,
-					tokenId: input.actor.tokenId,
-					packageId: input.savedPackage.id,
-					exportName: input.invocationName,
-					idempotencyKey: input.idempotencyKey,
-				})
-			let existing: Awaited<ReturnType<typeof getPackageInvocationByKey>>
+		} catch (error) {
+			// Worst case the key stays claimed until the 15-minute stale
+			// reclaim — the same failure mode as an isolate death mid-run.
+			console.warn(
+				'package invocation claim release failed',
+				getErrorMessage(error),
+			)
+		}
+	}
+
+	/**
+	 * Dual-read fallback for keys claimed before the ledger moved into the
+	 * RunLog DO. Runs only after a FRESH DO claim (the DO had no row for the
+	 * key); reclaims and replays never touch D1. Returns the response to
+	 * serve from the legacy row, or `null` when this attempt should proceed
+	 * to execute. Awaited D1 reads only — never writes.
+	 */
+	const resolveLegacyFallback = async (claimed: ClaimedInvocation) => {
+		let legacy: Awaited<ReturnType<typeof lookupLegacy>>
+		try {
+			legacy = await lookupLegacy()
+		} catch (error) {
+			console.error('package invocation idempotency lookup failed', error)
+			await releaseClaimBestEffort(claimed)
+			return buildLookupFailedResponse()
+		}
+		if (!legacy) return null
+		const resolveLegacy = (
+			record: NonNullable<Awaited<ReturnType<typeof lookupLegacy>>>,
+		) =>
+			resolveExistingInvocation({
+				record: toResolvableLegacyRecord(record),
+				requestHash,
+				idempotencyKey: input.idempotencyKey,
+			})
+		if (
+			legacy.request_hash !== requestHash ||
+			legacy.status !== 'in_progress'
+		) {
+			await releaseClaimBestEffort(claimed)
+			return resolveLegacy(legacy)
+		}
+		// A legacy in-progress row may still be finished by an old-code isolate
+		// during the deploy window, so poll it like the pre-migration path did.
+		const pollDeadline = Date.now() + packageInvocationPollBudgetMs
+		let current: Awaited<ReturnType<typeof lookupLegacy>> = legacy
+		while (
+			current &&
+			current.status === 'in_progress' &&
+			!isStaleInvocation(current.updated_at, new Date()) &&
+			Date.now() < pollDeadline
+		) {
+			await new Promise((resolve) =>
+				setTimeout(resolve, packageInvocationPollIntervalMs),
+			)
 			try {
-				existing = await lookupInvocation()
+				current = await lookupLegacy()
 			} catch (error) {
 				console.error('package invocation idempotency lookup failed', error)
-				return buildJsonErrorResponse({
-					status: 500,
-					code: 'idempotency_lookup_failed',
-					message:
-						'Unable to look up the package invocation idempotency record. Please retry.',
+				await releaseClaimBestEffort(claimed)
+				return buildLookupFailedResponse()
+			}
+		}
+		if (!current) return null
+		if (current.status !== 'in_progress') {
+			await releaseClaimBestEffort(claimed)
+			return resolveLegacy(current)
+		}
+		if (!isStaleInvocation(current.updated_at, new Date())) {
+			await releaseClaimBestEffort(claimed)
+			return resolveLegacy(current)
+		}
+		// Stale legacy in-progress row: nothing writes D1 anymore, so it can
+		// never finish. Keep the DO claim and execute — the equivalent of the
+		// old D1 stale reclaim, recorded in the DO instead. The abandoned row
+		// is dropped with the table in the follow-up.
+		return null
+	}
+
+	let claim: Awaited<ReturnType<typeof attemptClaim>>
+	try {
+		claim = await attemptClaim()
+	} catch (error) {
+		console.error('package invocation idempotency persistence failed', error)
+		return buildPersistenceFailedResponse()
+	}
+
+	// Resolve an existing DO owner: mismatch and terminal rows resolve
+	// immediately; fresh in-progress rows are polled within the budget; stale
+	// in-progress rows are reclaimed atomically by a second claim call (which
+	// loops back here when a competitor wins the reclaim).
+	while (claim.outcome === 'existing') {
+		let record: PackageInvocationLedgerRecord | null = claim.record
+		if (record.requestHash !== requestHash || record.status !== 'in_progress') {
+			return resolveLedgerRecord(record)
+		}
+		const pollDeadline = Date.now() + packageInvocationPollBudgetMs
+		while (
+			record &&
+			record.status === 'in_progress' &&
+			!isStaleInvocation(record.updatedAt, new Date()) &&
+			Date.now() < pollDeadline
+		) {
+			await new Promise((resolve) =>
+				setTimeout(resolve, packageInvocationPollIntervalMs),
+			)
+			try {
+				record = await lookupLedger()
+			} catch (error) {
+				console.error('package invocation idempotency lookup failed', error)
+				return buildLookupFailedResponse()
+			}
+		}
+		if (!record) {
+			// The owner released its claim (transient artifact failure, or a
+			// dual-read fallback hit whose response lives in the legacy table).
+			let legacy: Awaited<ReturnType<typeof lookupLegacy>>
+			try {
+				legacy = await lookupLegacy()
+			} catch (error) {
+				console.error('package invocation idempotency lookup failed', error)
+				return buildLookupFailedResponse()
+			}
+			if (legacy) {
+				return resolveExistingInvocation({
+					record: toResolvableLegacyRecord(legacy),
+					requestHash,
 					idempotencyKey: input.idempotencyKey,
 				})
 			}
-			let invocationId: string = crypto.randomUUID()
-			let claimUpdatedAt: string | null = null
-			if (existing) {
-				if (
-					existing.request_hash !== requestHash ||
-					existing.status !== 'in_progress'
-				) {
-					return resolveExistingInvocation({
-						record: existing,
-						requestHash,
-						idempotencyKey: input.idempotencyKey,
-					})
-				}
-				const pollDeadline = Date.now() + packageInvocationPollBudgetMs
-				while (
-					existing.status === 'in_progress' &&
-					!isStaleInvocation(existing.updated_at, new Date()) &&
-					Date.now() < pollDeadline
-				) {
-					await new Promise((resolve) =>
-						setTimeout(resolve, packageInvocationPollIntervalMs),
-					)
-					existing = await lookupInvocation()
-					if (!existing) break
-				}
-				if (!existing) {
-					return buildJsonErrorResponse({
-						status: 500,
-						code: 'idempotency_conflict_unresolved',
-						message: 'Package invocation disappeared while polling.',
-						idempotencyKey: input.idempotencyKey,
-					})
-				}
-				if (existing.status !== 'in_progress') {
-					return resolveExistingInvocation({
-						record: existing,
-						requestHash,
-						idempotencyKey: input.idempotencyKey,
-					})
-				}
-				const now = new Date()
-				if (!isStaleInvocation(existing.updated_at, now)) {
-					return resolveExistingInvocation({
-						record: existing,
-						requestHash,
-						idempotencyKey: input.idempotencyKey,
-					})
-				}
-				const reclaimedAt = now.toISOString()
-				const reclaimed = await tryClaimStalePackageInvocation({
-					db: input.env.APP_DB,
-					id: existing.id,
-					userId: input.actor.userId,
-					expectedUpdatedAt: existing.updated_at,
-					staleBefore: new Date(
-						now.getTime() - packageInvocationStaleAfterMs,
-					).toISOString(),
-					now: reclaimedAt,
-				})
-				if (!reclaimed) {
-					const current = await lookupInvocation()
-					if (!current) {
-						return buildJsonErrorResponse({
-							status: 500,
-							code: 'idempotency_conflict_unresolved',
-							message: 'Stale package invocation reclaim conflicted.',
-							idempotencyKey: input.idempotencyKey,
-						})
-					}
-					return resolveExistingInvocation({
-						record: current,
-						requestHash,
-						idempotencyKey: input.idempotencyKey,
-					})
-				}
-				invocationId = existing.id
-				claimUpdatedAt = reclaimedAt
-			}
-
-			if (!claimUpdatedAt) {
-				let insertResult: Awaited<ReturnType<typeof insertPackageInvocationRow>>
-				try {
-					insertResult = await insertPackageInvocationRow({
-						db: input.env.APP_DB,
-						row: {
-							id: invocationId,
-							userId: input.actor.userId,
-							tokenId: input.actor.tokenId,
-							packageId: input.savedPackage.id,
-							packageKodyId: input.savedPackage.kodyId,
-							exportName: input.invocationName,
-							idempotencyKey: input.idempotencyKey,
-							requestHash,
-							source: input.source,
-							topic: input.topic,
-							status: 'in_progress',
-						},
-					})
-				} catch (error) {
-					console.error(
-						'package invocation idempotency persistence failed',
-						error,
-					)
-					return buildJsonErrorResponse({
-						status: 500,
-						code: 'idempotency_persistence_failed',
-						message:
-							'Unable to persist the package invocation idempotency record. Please retry.',
-						idempotencyKey: input.idempotencyKey,
-					})
-				}
-				if (insertResult.inserted) {
-					claimUpdatedAt = insertResult.claimUpdatedAt
-				} else {
-					let current: Awaited<ReturnType<typeof getPackageInvocationByKey>>
-					try {
-						current = await lookupInvocation()
-					} catch (error) {
-						console.error('package invocation idempotency lookup failed', error)
-						return buildJsonErrorResponse({
-							status: 500,
-							code: 'idempotency_lookup_failed',
-							message:
-								'Unable to look up the package invocation idempotency record. Please retry.',
-							idempotencyKey: input.idempotencyKey,
-						})
-					}
-					if (!current) {
-						return buildJsonErrorResponse({
-							status: 500,
-							code: 'idempotency_conflict_unresolved',
-							message:
-								'Package invocation idempotency insert conflicted but no existing row was found.',
-							idempotencyKey: input.idempotencyKey,
-						})
-					}
-					return resolveExistingInvocation({
-						record: current,
-						requestHash,
-						idempotencyKey: input.idempotencyKey,
-					})
-				}
-			}
-			if (!claimUpdatedAt) {
-				throw new Error(
-					'Package invocation claim timestamp was not established.',
-				)
-			}
-			const persistClaimedResult = async (
-				status: 'completed' | 'failed',
-				response: PackageInvocationStoredResponse,
-			) => {
-				const updated = await updatePackageInvocationResult({
-					db: input.env.APP_DB,
-					id: invocationId,
-					userId: input.actor.userId,
-					status,
-					response,
-					claimUpdatedAt,
-				})
-				if (updated) return response
-				const current = await lookupInvocation()
-				if (current) {
-					return resolveExistingInvocation({
-						record: current,
-						requestHash,
-						idempotencyKey: input.idempotencyKey,
-					})
-				}
-				return buildJsonErrorResponse({
-					status: 500,
-					code: 'idempotency_response_unavailable',
-					message: 'Package invocation result lost its recovery claim.',
-					idempotencyKey: input.idempotencyKey,
-				})
-			}
-
-			const outcome = await runSavedPackageModuleOnce({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				actor: input.actor,
-				savedPackage: input.savedPackage,
-				invocationName: input.invocationName,
-				moduleSelector: input.moduleSelector,
-				params: input.params,
+			return buildJsonErrorResponse({
+				status: 500,
+				code: 'idempotency_conflict_unresolved',
+				message: 'Package invocation disappeared while polling.',
 				idempotencyKey: input.idempotencyKey,
-				invocationId,
-				source: input.source,
-				topic: input.topic,
-				notFoundCode: input.notFoundCode,
-				runtimeInvokeDepth: input.runtimeInvokeDepth,
-				toolFactories: input.toolFactories,
-				waitUntil: input.waitUntil,
-				preloadedModuleArtifact: input.preloadedModuleArtifact,
-				executorTimeoutMs: input.executorTimeoutMs,
 			})
-			switch (outcome.kind) {
-				case 'artifact-unavailable': {
-					const released = await releasePackageInvocationClaim({
-						db: input.env.APP_DB,
-						id: invocationId,
-						userId: input.actor.userId,
-						claimUpdatedAt,
-					})
-					if (!released) {
-						const current = await lookupInvocation()
-						if (current?.status !== 'in_progress') {
-							return current
-								? resolveExistingInvocation({
-										record: current,
-										requestHash,
-										idempotencyKey: input.idempotencyKey,
-									})
-								: buildJsonErrorResponse({
-										status: 500,
-										code: 'idempotency_conflict_unresolved',
-										message:
-											'Transient artifact preparation lost its invocation claim.',
-										idempotencyKey: input.idempotencyKey,
-									})
-						}
-					}
-					return outcome.response
-				}
-				case 'completed': {
-					try {
-						return await persistClaimedResult('completed', outcome.response)
-					} catch (error) {
-						// The module already succeeded; do not poison the key with a
-						// stored permanent failure. Return the result to the caller and
-						// leave the claim in progress so the stale-reclaim path decides
-						// what happens on a later retry.
-						console.warn(
-							'package invocation completed-result persistence failed',
-							getErrorMessage(error),
-						)
-						return outcome.response
-					}
-				}
-				case 'failed': {
-					return await persistClaimedResult('failed', outcome.response).catch(
-						(error: unknown) => {
-							// Best effort; preserve the original invocation error.
-							console.warn(
-								'package invocation terminal persistence failed',
-								getErrorMessage(error),
-							)
-							return outcome.response
-						},
-					)
-				}
-				default: {
-					const exhaustive: never = outcome
-					void exhaustive
-					throw new Error('Unhandled package module run outcome.')
+		}
+		if (record.status !== 'in_progress') {
+			return resolveLedgerRecord(record)
+		}
+		if (!isStaleInvocation(record.updatedAt, new Date())) {
+			return resolveLedgerRecord(record)
+		}
+		try {
+			claim = await attemptClaim()
+		} catch (error) {
+			console.error('package invocation idempotency persistence failed', error)
+			return buildPersistenceFailedResponse()
+		}
+	}
+
+	const claimed: ClaimedInvocation = {
+		invocationId: claim.invocationId,
+		claimUpdatedAt: claim.claimUpdatedAt,
+		handle: claim.handle,
+	}
+	if (!claim.reclaimed) {
+		const legacyResponse = await resolveLegacyFallback(claimed)
+		if (legacyResponse) return legacyResponse
+	}
+
+	const outcome = await runSavedPackageModuleOnce({
+		env: input.env,
+		baseUrl: input.baseUrl,
+		actor: input.actor,
+		savedPackage: input.savedPackage,
+		invocationName: input.invocationName,
+		moduleSelector: input.moduleSelector,
+		params: input.params,
+		idempotencyKey: input.idempotencyKey,
+		invocationId: claimed.invocationId,
+		source: input.source,
+		topic: input.topic,
+		notFoundCode: input.notFoundCode,
+		runtimeInvokeDepth: input.runtimeInvokeDepth,
+		toolFactories: input.toolFactories,
+		waitUntil: input.waitUntil,
+		preloadedModuleArtifact: input.preloadedModuleArtifact,
+		executorTimeoutMs: input.executorTimeoutMs,
+		externalRunRecordHandle: claimed.handle,
+	})
+	switch (outcome.kind) {
+		case 'artifact-unavailable': {
+			const release = await releasePackageInvocationRecord({
+				env: input.env,
+				userId: input.actor.userId,
+				invocationId: claimed.invocationId,
+				claimUpdatedAt: claimed.claimUpdatedAt,
+				handle: claimed.handle,
+			})
+			if (!release.released) {
+				const current = release.record
+				if (current?.status !== 'in_progress') {
+					return current
+						? resolveLedgerRecord(current)
+						: buildJsonErrorResponse({
+								status: 500,
+								code: 'idempotency_conflict_unresolved',
+								message:
+									'Transient artifact preparation lost its invocation claim.',
+								idempotencyKey: input.idempotencyKey,
+							})
 				}
 			}
-		},
-	})
+			return outcome.response
+		}
+		case 'completed': {
+			try {
+				const finished = await finishPackageInvocationRecord({
+					env: input.env,
+					userId: input.actor.userId,
+					handle: claimed.handle,
+					invocationId: claimed.invocationId,
+					claimUpdatedAt: claimed.claimUpdatedAt,
+					ledgerStatus: 'completed',
+					responseJson: boundedResponseJson(outcome.response),
+					status: 'success',
+					logs: outcome.logs,
+					result: outcome.result,
+					waitUntil: input.waitUntil,
+				})
+				if (finished.ledgerUpdated) return outcome.response
+				return finished.record
+					? resolveLedgerRecord(finished.record)
+					: buildJsonErrorResponse({
+							status: 500,
+							code: 'idempotency_response_unavailable',
+							message: 'Package invocation result lost its recovery claim.',
+							idempotencyKey: input.idempotencyKey,
+						})
+			} catch (error) {
+				// The module already succeeded; do not poison the key with a
+				// stored permanent failure. Return the result to the caller and
+				// leave the claim in progress so the stale-reclaim path decides
+				// what happens on a later retry.
+				console.warn(
+					'package invocation completed-result persistence failed',
+					getErrorMessage(error),
+				)
+				return outcome.response
+			}
+		}
+		case 'failed': {
+			try {
+				const finished = await finishPackageInvocationRecord({
+					env: input.env,
+					userId: input.actor.userId,
+					handle: claimed.handle,
+					invocationId: claimed.invocationId,
+					claimUpdatedAt: claimed.claimUpdatedAt,
+					ledgerStatus: 'failed',
+					responseJson: boundedResponseJson(outcome.response),
+					status: 'error',
+					logs: outcome.logs,
+					error: outcome.error,
+					waitUntil: input.waitUntil,
+				})
+				if (finished.ledgerUpdated) return outcome.response
+				return finished.record
+					? resolveLedgerRecord(finished.record)
+					: buildJsonErrorResponse({
+							status: 500,
+							code: 'idempotency_response_unavailable',
+							message: 'Package invocation result lost its recovery claim.',
+							idempotencyKey: input.idempotencyKey,
+						})
+			} catch (error) {
+				// Best effort; preserve the original invocation error.
+				console.warn(
+					'package invocation terminal persistence failed',
+					getErrorMessage(error),
+				)
+				return outcome.response
+			}
+		}
+		default: {
+			const exhaustive: never = outcome
+			void exhaustive
+			throw new Error('Unhandled package module run outcome.')
+		}
+	}
 }

--- a/packages/worker/src/package-invocations/module-execution.ts
+++ b/packages/worker/src/package-invocations/module-execution.ts
@@ -2,7 +2,10 @@ import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { persistableExecutionArtifacts } from '#mcp/downstream-mcp-result.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
-import { type RunRecordContext } from '#worker/run-records/types.ts'
+import {
+	type RunRecordContext,
+	type RunRecordHandle,
+} from '#worker/run-records/types.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import { getEntitySourceByIdForUser } from '#worker/repo/entity-sources.ts'
 import {
@@ -41,10 +44,24 @@ import {
  * - `artifact-unavailable`: artifact preparation failed transiently before
  *   any sandbox work started. Nothing executed, so keyed callers release
  *   their claim and key-less callers can simply retry.
+ *
+ * `logs` / `result` / `error` carry what the registry would otherwise feed
+ * its own run-record finish, for keyed callers that own the run record via
+ * `externalRunRecordHandle` and finish it together with the ledger write.
  */
 export type SavedPackageModuleRunOutcome =
-	| { kind: 'completed'; response: PackageInvocationResponse }
-	| { kind: 'failed'; response: PackageInvocationResponse }
+	| {
+			kind: 'completed'
+			response: PackageInvocationResponse
+			logs: Array<string>
+			result: unknown
+	  }
+	| {
+			kind: 'failed'
+			response: PackageInvocationResponse
+			logs: Array<string>
+			error: unknown
+	  }
 	| { kind: 'artifact-unavailable'; response: PackageInvocationResponse }
 
 export type SavedPackageModuleRunInput = {
@@ -82,6 +99,15 @@ export type SavedPackageModuleRunInput = {
 	 * full Cloudflare Workflow step window.
 	 */
 	executorTimeoutMs?: number | null
+	/**
+	 * Keyed path: the caller already claimed the run record together with the
+	 * idempotency-ledger row (one DO call) and finishes both together from
+	 * the outcome, so the registry must not begin or finish a run record of
+	 * its own. The handle's context still feeds `parentRunRecord` for nested
+	 * invoke/event tools, and is enriched here with the `publishedCommit`
+	 * that is only known after the artifact loads.
+	 */
+	externalRunRecordHandle?: RunRecordHandle | null
 }
 
 export async function runSavedPackageModuleOnce(
@@ -133,8 +159,18 @@ export async function runSavedPackageModuleOnce(
 			kodyId: input.savedPackage.kodyId,
 			sourceId: input.savedPackage.sourceId,
 		}
-		const runRecord: RunRecordContext | null =
-			runtimeSurface == null
+		const externalHandle = input.externalRunRecordHandle ?? null
+		if (externalHandle) {
+			// The caller claimed before the artifact loaded, so its context could
+			// not know the published commit yet; enrich it for the terminal write.
+			externalHandle.context = {
+				...externalHandle.context,
+				publishedCommit: repoSource?.published_commit ?? null,
+			}
+		}
+		const runRecord: RunRecordContext | null = externalHandle
+			? externalHandle.context
+			: runtimeSurface == null
 				? null
 				: {
 						packageId: input.savedPackage.id,
@@ -170,7 +206,9 @@ export async function runSavedPackageModuleOnce(
 				// No ambient `storage` binding: package code reaches its bucket via
 				// `packageStorage()` (granted through packageContext below). Legacy
 				// ambient use gets the structured runtime_helper_unbound hint.
-				runRecord,
+				// Keyed callers own their run record (claimed with the ledger row);
+				// the registry must not begin/finish a second one for this run.
+				runRecord: externalHandle ? null : runRecord,
 				emailTools: {
 					getMessage: async (messageId) => {
 						const loaded = await getEmailMessageWithAttachmentsById({
@@ -300,6 +338,8 @@ export async function runSavedPackageModuleOnce(
 					error: executionResult.error,
 					logs: executionResult.logs ?? [],
 				}),
+				logs: executionResult.logs ?? [],
+				error: executionResult.error,
 			}
 		}
 		const persistedArtifacts = persistableExecutionArtifacts(
@@ -318,6 +358,8 @@ export async function runSavedPackageModuleOnce(
 				rawContentOmitted: persistedArtifacts.rawContentOmitted,
 				logs: executionResult.logs ?? [],
 			}),
+			logs: executionResult.logs ?? [],
+			result: persistedArtifacts.result,
 		}
 	} catch (error) {
 		if (
@@ -345,6 +387,8 @@ export async function runSavedPackageModuleOnce(
 					message: getErrorMessage(error),
 					idempotencyKey: input.idempotencyKey ?? undefined,
 				}),
+				logs: [],
+				error,
 			}
 		}
 		return {
@@ -355,6 +399,8 @@ export async function runSavedPackageModuleOnce(
 				message: getErrorMessage(error),
 				idempotencyKey: input.idempotencyKey ?? undefined,
 			}),
+			logs: [],
+			error,
 		}
 	}
 }
@@ -367,12 +413,16 @@ export async function runSavedPackageModuleOnce(
  * exactly-once path).
  */
 export async function runSavedPackageModuleEphemeral(
-	input: Omit<SavedPackageModuleRunInput, 'idempotencyKey' | 'invocationId'>,
+	input: Omit<
+		SavedPackageModuleRunInput,
+		'idempotencyKey' | 'invocationId' | 'externalRunRecordHandle'
+	>,
 ): Promise<PackageInvocationResponse> {
 	const outcome = await runSavedPackageModuleOnce({
 		...input,
 		idempotencyKey: null,
 		invocationId: null,
+		externalRunRecordHandle: null,
 	})
 	return outcome.response
 }

--- a/packages/worker/src/package-invocations/repo.ts
+++ b/packages/worker/src/package-invocations/repo.ts
@@ -20,7 +20,12 @@ import { toHex } from '@kody-internal/shared/hex.ts'
  */
 export const maxStoredInvocationResponseJsonBytes = maxRestorableTextColumnBytes
 
-function boundedResponseJson(
+/**
+ * Serialize a terminal response for the replay cache, dropping it when
+ * oversized. Shared by the legacy D1 write path and the RunLog DO ledger so
+ * both stores enforce the same restore-safe bound.
+ */
+export function boundedResponseJson(
 	response: PackageInvocationStoredResponse,
 ): string | null {
 	const responseJson = JSON.stringify({
@@ -119,7 +124,7 @@ function parseStringArrayJson(input: { value: string; field: string }) {
 	})
 }
 
-function parseStoredResponse(
+export function parseStoredResponse(
 	value: string | null,
 ): PackageInvocationStoredResponse | null {
 	if (!value) return null
@@ -399,117 +404,12 @@ export async function deletePackageInvocationToken(input: {
 	return (result.meta.changes ?? 0) > 0
 }
 
-export async function insertPackageInvocationRow(input: {
-	db: D1Database
-	row: {
-		id: string
-		userId: string
-		tokenId: string
-		packageId: string
-		packageKodyId: string
-		exportName: string
-		idempotencyKey: string
-		requestHash: string
-		source?: string | null
-		topic?: string | null
-		status: 'in_progress' | 'completed' | 'failed'
-		response?: PackageInvocationStoredResponse | null
-	}
-}) {
-	const now = new Date().toISOString()
-	const responseJson = input.row.response
-		? boundedResponseJson(input.row.response)
-		: null
-	const result = await input.db
-		.prepare(
-			`INSERT OR IGNORE INTO package_invocations (
-				id,
-				user_id,
-				token_id,
-				package_id,
-				package_kody_id,
-				export_name,
-				idempotency_key,
-				request_hash,
-				source,
-				topic,
-				status,
-				response_json,
-				created_at,
-				updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		)
-		.bind(
-			input.row.id,
-			input.row.userId,
-			input.row.tokenId,
-			input.row.packageId,
-			input.row.packageKodyId,
-			input.row.exportName,
-			input.row.idempotencyKey,
-			input.row.requestHash,
-			input.row.source ?? null,
-			input.row.topic ?? null,
-			input.row.status,
-			responseJson,
-			now,
-			now,
-		)
-		.run()
-	return {
-		inserted: (result.meta.changes ?? 0) > 0,
-		claimUpdatedAt: now,
-	}
-}
-
-export async function tryClaimStalePackageInvocation(input: {
-	db: D1Database
-	id: string
-	userId: string
-	expectedUpdatedAt: string
-	staleBefore: string
-	now: string
-}) {
-	const result = await input.db
-		.prepare(
-			`UPDATE package_invocations
-			SET updated_at = ?
-			WHERE id = ?
-				AND user_id = ?
-				AND status = 'in_progress'
-				AND updated_at = ?
-				AND updated_at <= ?`,
-		)
-		.bind(
-			input.now,
-			input.id,
-			input.userId,
-			input.expectedUpdatedAt,
-			input.staleBefore,
-		)
-		.run()
-	return (result.meta.changes ?? 0) > 0
-}
-
-export async function releasePackageInvocationClaim(input: {
-	db: D1Database
-	id: string
-	userId: string
-	claimUpdatedAt: string
-}) {
-	const result = await input.db
-		.prepare(
-			`DELETE FROM package_invocations
-			WHERE id = ?
-				AND user_id = ?
-				AND status = 'in_progress'
-				AND updated_at = ?`,
-		)
-		.bind(input.id, input.userId, input.claimUpdatedAt)
-		.run()
-	return (result.meta.changes ?? 0) > 0
-}
-
+/**
+ * Dual-read fallback lookup for keys claimed before the idempotency ledger
+ * moved into the per-user RunLog Durable Object. The D1 table is read-only
+ * now — the write helpers were removed with the migration — and a follow-up
+ * removes this lookup together with the table and its retention sweep.
+ */
 export async function getPackageInvocationByKey(input: {
 	db: D1Database
 	userId: string
@@ -537,34 +437,4 @@ export async function getPackageInvocationByKey(input: {
 		)
 		.first<Record<string, unknown>>()
 	return row ? mapRow(row) : null
-}
-
-export async function updatePackageInvocationResult(input: {
-	db: D1Database
-	id: string
-	userId: string
-	status: 'completed' | 'failed'
-	response: PackageInvocationStoredResponse
-	claimUpdatedAt: string
-}) {
-	const responseJson = boundedResponseJson(input.response)
-	const result = await input.db
-		.prepare(
-			`UPDATE package_invocations
-			SET status = ?, response_json = ?, updated_at = ?
-			WHERE id = ?
-				AND user_id = ?
-				AND status = 'in_progress'
-				AND updated_at = ?`,
-		)
-		.bind(
-			input.status,
-			responseJson,
-			new Date().toISOString(),
-			input.id,
-			input.userId,
-			input.claimUpdatedAt,
-		)
-		.run()
-	return (result.meta.changes ?? 0) > 0
 }

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -8,11 +8,8 @@ import {
 	invokePackageExport,
 	invokePackageSubscription,
 } from './service.ts'
-import {
-	maxStoredInvocationResponseJsonBytes,
-	tryClaimStalePackageInvocation,
-	updatePackageInvocationResult,
-} from './repo.ts'
+import { createRequestHash } from './idempotency.ts'
+import { maxStoredInvocationResponseJsonBytes } from './repo.ts'
 
 const repoMockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
@@ -26,6 +23,8 @@ const repoMockModule = vi.hoisted(() => ({
 	typecheckPackageEntrypointsFromSourceFiles: vi.fn(),
 	runBundledModuleWithRegistry: vi.fn(),
 	recordAgentPackageConversationUse: vi.fn(),
+	recordSuccessfulPackageRun: vi.fn(),
+	dispatchRunErrorSubscriptionEvents: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -71,28 +70,240 @@ vi.mock('#worker/usage/agent-package-conversation-uses.ts', () => ({
 		repoMockModule.recordAgentPackageConversationUse(...args),
 }))
 
-function createDatabase(options: { failInsert?: boolean } = {}) {
-	const tables = new Map<string, Array<Record<string, unknown>>>([
-		['package_invocations', []],
-	])
+vi.mock('#worker/usage/activation.ts', () => ({
+	recordSuccessfulPackageRun: (...args: Array<unknown>) =>
+		repoMockModule.recordSuccessfulPackageRun(...args),
+}))
 
+vi.mock('#worker/run-records/package-subscriptions.ts', () => ({
+	dispatchRunErrorSubscriptionEvents: (...args: Array<unknown>) =>
+		repoMockModule.dispatchRunErrorSubscriptionEvents(...args),
+}))
+
+type FakeLedgerRow = {
+	id: string
+	tokenId: string
+	packageId: string
+	packageKodyId: string
+	exportName: string
+	idempotencyKey: string
+	requestHash: string
+	source: string | null
+	topic: string | null
+	status: 'in_progress' | 'completed' | 'failed'
+	responseJson: string | null
+	createdAt: string
+	updatedAt: string
+}
+
+/**
+ * In-memory stand-in for the RunLog Durable Object's package-invocation
+ * ledger RPCs (the real DO semantics are covered by
+ * run-records/invocation-ledger.workers.test.ts against the actual binding).
+ */
+function createFakeRunLog(options: { failClaim?: boolean } = {}) {
+	const ledgerRows: Array<FakeLedgerRow> = []
+	const runRows = new Map<string, Record<string, unknown>>()
 	const clone = <T>(value: T): T => structuredClone(value)
-
-	function getTable(name: string) {
-		const table = tables.get(name)
-		if (!table) {
-			throw new Error(`Unknown table ${name}`)
-		}
-		return table
+	const findByKey = (key: {
+		tokenId: string
+		packageId: string
+		exportName: string
+		idempotencyKey: string
+	}) =>
+		ledgerRows.find(
+			(row) =>
+				row.tokenId === key.tokenId &&
+				row.packageId === key.packageId &&
+				row.exportName === key.exportName &&
+				row.idempotencyKey === key.idempotencyKey,
+		) ?? null
+	const rpc = {
+		async claimPackageInvocation(input: {
+			invocation: Omit<
+				FakeLedgerRow,
+				'status' | 'responseJson' | 'createdAt' | 'updatedAt'
+			>
+			staleBefore: string
+			run: Record<string, unknown> | null
+		}) {
+			if (options.failClaim) throw new Error('RunLog unavailable')
+			const now = new Date().toISOString()
+			const existing = findByKey(input.invocation)
+			if (existing) {
+				const reclaimable =
+					existing.status === 'in_progress' &&
+					existing.requestHash === input.invocation.requestHash &&
+					existing.updatedAt <= input.staleBefore
+				if (!reclaimable) {
+					return { outcome: 'existing' as const, record: clone(existing) }
+				}
+				existing.updatedAt = now
+				if (input.run) {
+					runRows.set(
+						String(input.run['id']),
+						clone({ ...input.run, invocationId: existing.id }),
+					)
+				}
+				return {
+					outcome: 'claimed' as const,
+					invocationId: existing.id,
+					claimUpdatedAt: now,
+					reclaimed: true,
+				}
+			}
+			ledgerRows.push({
+				...clone(input.invocation),
+				status: 'in_progress',
+				responseJson: null,
+				createdAt: now,
+				updatedAt: now,
+			})
+			if (input.run) {
+				runRows.set(
+					String(input.run['id']),
+					clone({ ...input.run, invocationId: input.invocation.id }),
+				)
+			}
+			return {
+				outcome: 'claimed' as const,
+				invocationId: input.invocation.id,
+				claimUpdatedAt: now,
+				reclaimed: false,
+			}
+		},
+		async getPackageInvocation(key: {
+			tokenId: string
+			packageId: string
+			exportName: string
+			idempotencyKey: string
+		}) {
+			const row = findByKey(key)
+			return row ? clone(row) : null
+		},
+		async finishPackageInvocation(input: {
+			invocationId: string
+			claimUpdatedAt: string
+			status: 'completed' | 'failed'
+			responseJson: string | null
+			run: Record<string, unknown> | null
+			logs: Array<unknown>
+		}) {
+			const row =
+				ledgerRows.find((candidate) => candidate.id === input.invocationId) ??
+				null
+			let ledgerUpdated = false
+			if (
+				row &&
+				row.status === 'in_progress' &&
+				row.updatedAt === input.claimUpdatedAt
+			) {
+				row.status = input.status
+				row.responseJson = input.responseJson
+				row.updatedAt = new Date().toISOString()
+				ledgerUpdated = true
+			}
+			if (input.run) {
+				runRows.set(String(input.run['id']), clone(input.run))
+			}
+			return {
+				ledgerUpdated,
+				record: ledgerUpdated ? null : row ? clone(row) : null,
+			}
+		},
+		async releasePackageInvocation(input: {
+			invocationId: string
+			claimUpdatedAt: string
+			runId: string | null
+		}) {
+			const index = ledgerRows.findIndex(
+				(candidate) => candidate.id === input.invocationId,
+			)
+			const row = index >= 0 ? ledgerRows[index] : null
+			let released = false
+			if (
+				row &&
+				row.status === 'in_progress' &&
+				row.updatedAt === input.claimUpdatedAt
+			) {
+				ledgerRows.splice(index, 1)
+				released = true
+			}
+			if (input.runId) {
+				const run = runRows.get(input.runId)
+				if (run && run['status'] === 'running') {
+					runRows.delete(input.runId)
+				}
+			}
+			return {
+				released,
+				record: released || !row ? null : clone(row),
+			}
+		},
 	}
-
-	function selectOne(
-		tableName: string,
-		predicate: (row: Record<string, unknown>) => boolean,
-	) {
-		return clone(getTable(tableName).find(predicate) ?? null)
+	return {
+		namespace: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => rpc,
+		},
+		ledgerRows,
+		runRows,
+		corruptStoredResponses() {
+			for (const row of ledgerRows) {
+				row.responseJson = '{"status":200,"body":null}'
+			}
+		},
+		seedStaleInvocation(idempotencyKey: string) {
+			const completed = ledgerRows[0]
+			if (!completed) throw new Error('Expected completed invocation seed.')
+			const row: FakeLedgerRow = {
+				...structuredClone(completed),
+				id: crypto.randomUUID(),
+				idempotencyKey,
+				status: 'in_progress',
+				responseJson: null,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}
+			ledgerRows.push(row)
+			return structuredClone(row)
+		},
+		seedFreshInvocation(idempotencyKey: string) {
+			const completed = ledgerRows[0]
+			if (!completed) throw new Error('Expected completed invocation seed.')
+			const now = new Date().toISOString()
+			ledgerRows.push({
+				...structuredClone(completed),
+				id: crypto.randomUUID(),
+				idempotencyKey,
+				status: 'in_progress',
+				responseJson: null,
+				createdAt: now,
+				updatedAt: now,
+			})
+		},
+		completeInvocation(idempotencyKey: string) {
+			const row = ledgerRows.find(
+				(candidate) => candidate.idempotencyKey === idempotencyKey,
+			)
+			const completed = ledgerRows[0]
+			if (!row || !completed) throw new Error('Expected invocation rows.')
+			row.status = 'completed'
+			row.responseJson = completed.responseJson
+			row.updatedAt = new Date().toISOString()
+		},
 	}
+}
 
+/**
+ * Fake D1 with a READ-ONLY legacy `package_invocations` table for the
+ * dual-read window. Any attempted D1 write throws, which is the test-level
+ * proof that no awaited D1 write remains on the keyed hot path.
+ */
+function createDatabase(options: { failClaim?: boolean } = {}) {
+	const legacyRows: Array<Record<string, unknown>> = []
+	const runLog = createFakeRunLog(options)
+	const clone = <T>(value: T): T => structuredClone(value)
 	const db = {
 		prepare(query: string) {
 			return {
@@ -103,166 +314,101 @@ function createDatabase(options: { failInsert?: boolean } = {}) {
 								query.includes('FROM package_invocations') &&
 								query.includes('idempotency_key = ?')
 							) {
-								return selectOne(
-									'package_invocations',
-									(row) =>
-										row['user_id'] === params[0] &&
-										row['token_id'] === params[1] &&
-										row['package_id'] === params[2] &&
-										row['export_name'] === params[3] &&
-										row['idempotency_key'] === params[4],
+								return clone(
+									legacyRows.find(
+										(row) =>
+											row['user_id'] === params[0] &&
+											row['token_id'] === params[1] &&
+											row['package_id'] === params[2] &&
+											row['export_name'] === params[3] &&
+											row['idempotency_key'] === params[4],
+									) ?? null,
 								) as T | null
 							}
 							return null
 						},
 						async run() {
-							if (query.includes('UPDATE users')) {
-								return { meta: { changes: 1, last_row_id: 0 } }
-							}
-							if (query.includes('DELETE FROM package_invocations')) {
-								const table = getTable('package_invocations')
-								const index = table.findIndex(
-									(row) =>
-										row['id'] === params[0] &&
-										row['user_id'] === params[1] &&
-										row['status'] === 'in_progress' &&
-										row['updated_at'] === params[2],
-								)
-								if (index < 0) return { meta: { changes: 0 } }
-								table.splice(index, 1)
-								return { meta: { changes: 1 } }
-							}
-							if (query.includes('INTO package_invocations')) {
-								if (options.failInsert) {
-									throw new Error('D1 unavailable')
-								}
-								const table = getTable('package_invocations')
-								const existing = table.find(
-									(row) =>
-										row['user_id'] === params[1] &&
-										row['token_id'] === params[2] &&
-										row['package_id'] === params[3] &&
-										row['export_name'] === params[5] &&
-										row['idempotency_key'] === params[6],
-								)
-								if (existing) {
-									return { meta: { changes: 0, last_row_id: 0 } }
-								}
-								table.push(
-									clone({
-										id: params[0],
-										user_id: params[1],
-										token_id: params[2],
-										package_id: params[3],
-										package_kody_id: params[4],
-										export_name: params[5],
-										idempotency_key: params[6],
-										request_hash: params[7],
-										source: params[8],
-										topic: params[9],
-										status: params[10],
-										response_json: params[11],
-										created_at: params[12],
-										updated_at: params[13],
-									}),
-								)
-								return { meta: { changes: 1, last_row_id: 1 } }
-							}
-							if (query.includes('UPDATE package_invocations')) {
-								const table = getTable('package_invocations')
-								if (
-									query.includes('SET updated_at = ?') &&
-									!query.includes('SET status = ?')
-								) {
-									const existing = table.find(
-										(row) =>
-											row['id'] === params[1] &&
-											row['user_id'] === params[2] &&
-											row['status'] === 'in_progress' &&
-											row['updated_at'] === params[3] &&
-											String(row['updated_at']) <= String(params[4]),
-									)
-									if (!existing) return { meta: { changes: 0 } }
-									existing['updated_at'] = params[0]
-									return { meta: { changes: 1 } }
-								}
-								const existing = table.find(
-									(row) =>
-										row['id'] === params[3] &&
-										row['user_id'] === params[4] &&
-										row['status'] === 'in_progress' &&
-										row['updated_at'] === params[5],
-								)
-								if (!existing) {
-									return { meta: { changes: 0, last_row_id: 0 } }
-								}
-								existing['status'] = params[0]
-								existing['response_json'] = params[1]
-								existing['updated_at'] = params[2]
-								return { meta: { changes: 1, last_row_id: 0 } }
-							}
-							throw new Error(`Unhandled query: ${query}`)
+							throw new Error(
+								`Unexpected D1 write on the keyed invocation path: ${query}`,
+							)
 						},
 					}
 				},
 			}
 		},
-		corruptStoredResponses() {
-			for (const row of getTable('package_invocations')) {
-				row['response_json'] = '{"status":200,"body":null}'
-			}
-		},
-		seedStaleInvocation(idempotencyKey: string) {
-			const completed = getTable('package_invocations')[0]
-			if (!completed) throw new Error('Expected completed invocation seed.')
-			const row = {
-				...clone(completed),
+		runLog,
+		seedLegacyInvocation(row: {
+			tokenId: string
+			packageId: string
+			packageKodyId: string
+			exportName: string
+			idempotencyKey: string
+			requestHash: string
+			source?: string | null
+			topic?: string | null
+			status: 'in_progress' | 'completed' | 'failed'
+			responseJson?: string | null
+			updatedAt?: string
+		}) {
+			const updatedAt = row.updatedAt ?? new Date().toISOString()
+			const legacy = {
 				id: crypto.randomUUID(),
-				idempotency_key: idempotencyKey,
-				status: 'in_progress',
-				response_json: null,
-				created_at: '2026-01-01T00:00:00.000Z',
-				updated_at: '2026-01-01T00:00:00.000Z',
+				user_id: 'user-123',
+				token_id: row.tokenId,
+				package_id: row.packageId,
+				package_kody_id: row.packageKodyId,
+				export_name: row.exportName,
+				idempotency_key: row.idempotencyKey,
+				request_hash: row.requestHash,
+				source: row.source ?? null,
+				topic: row.topic ?? null,
+				status: row.status,
+				response_json: row.responseJson ?? null,
+				created_at: updatedAt,
+				updated_at: updatedAt,
 			}
-			getTable('package_invocations').push(row)
-			return clone(row)
+			legacyRows.push(legacy)
+			return clone(legacy)
 		},
-		seedFreshInvocation(idempotencyKey: string) {
-			const completed = getTable('package_invocations')[0]
-			if (!completed) throw new Error('Expected completed invocation seed.')
-			const now = new Date().toISOString()
-			getTable('package_invocations').push({
-				...clone(completed),
-				id: crypto.randomUUID(),
-				idempotency_key: idempotencyKey,
-				status: 'in_progress',
-				response_json: null,
-				created_at: now,
-				updated_at: now,
-			})
-		},
-		completeInvocation(idempotencyKey: string) {
-			const row = getTable('package_invocations').find(
-				(candidate) => candidate['idempotency_key'] === idempotencyKey,
+		completeLegacyInvocation(input: {
+			idempotencyKey: string
+			responseJson: string
+		}) {
+			const row = legacyRows.find(
+				(candidate) => candidate['idempotency_key'] === input.idempotencyKey,
 			)
-			const completed = getTable('package_invocations')[0]
-			if (!row || !completed) throw new Error('Expected invocation rows.')
+			if (!row) throw new Error('Expected legacy invocation row.')
 			row['status'] = 'completed'
-			row['response_json'] = completed['response_json']
+			row['response_json'] = input.responseJson
 			row['updated_at'] = new Date().toISOString()
 		},
 	} as unknown as D1Database & {
-		corruptStoredResponses(): void
-		seedStaleInvocation(idempotencyKey: string): Record<string, unknown>
-		seedFreshInvocation(idempotencyKey: string): void
-		completeInvocation(idempotencyKey: string): void
+		runLog: ReturnType<typeof createFakeRunLog>
+		seedLegacyInvocation(row: {
+			tokenId: string
+			packageId: string
+			packageKodyId: string
+			exportName: string
+			idempotencyKey: string
+			requestHash: string
+			source?: string | null
+			topic?: string | null
+			status: 'in_progress' | 'completed' | 'failed'
+			responseJson?: string | null
+			updatedAt?: string
+		}): Record<string, unknown>
+		completeLegacyInvocation(input: {
+			idempotencyKey: string
+			responseJson: string
+		}): void
 	}
 	return db
 }
 
-function createEnv(db: D1Database) {
+function createEnv(db: ReturnType<typeof createDatabase>) {
 	return {
 		APP_DB: db,
+		RUN_LOG: db.runLog.namespace,
 		BUNDLE_ARTIFACTS_KV: {
 			get: async () => null,
 			put: async () => undefined,
@@ -973,12 +1119,21 @@ test('keyed packages.invoke keeps exactly-once semantics: repeat calls replay th
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
 	const runOptions =
 		repoMockModule.runBundledModuleWithRegistry.mock.calls[0]?.[4]
-	expect(runOptions).toMatchObject({
-		runRecord: {
-			surface: 'export',
-			invocationId: expect.any(String),
-			idempotencyKey: 'evt-keyed-1',
-		},
+	// The keyed path owns its run record (claimed together with the ledger
+	// row in one DO call), so the registry must not open a second one.
+	expect(runOptions).toMatchObject({ runRecord: null })
+	const ledgerRow = db.runLog.ledgerRows.find(
+		(row) => row.idempotencyKey === 'evt-keyed-1',
+	)
+	expect(ledgerRow).toMatchObject({ status: 'completed' })
+	const runRow = [...db.runLog.runRows.values()].find(
+		(row) => row['idempotencyKey'] === 'evt-keyed-1',
+	)
+	expect(runRow).toMatchObject({
+		surface: 'export',
+		status: 'success',
+		invocationId: ledgerRow?.id,
+		idempotencyKey: 'evt-keyed-1',
 	})
 })
 
@@ -1658,9 +1813,7 @@ test('invokePackageExport enforces idempotency replay, mismatch, corruption, and
 			topic: 'discord.message.created',
 		},
 	})
-	;(
-		db as unknown as { corruptStoredResponses(): void }
-	).corruptStoredResponses()
+	db.runLog.corruptStoredResponses()
 	const corruptSecond = await invokePackageExport({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
@@ -1689,7 +1842,7 @@ test('invokePackageExport enforces idempotency replay, mismatch, corruption, and
 	})
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(3)
 
-	const failingDb = createDatabase({ failInsert: true })
+	const failingDb = createDatabase({ failClaim: true })
 	seedPackageResolution()
 	consoleError.mockImplementation(() => {})
 	const persistenceFailure = await invokePackageExport({
@@ -1769,6 +1922,228 @@ test('oversized terminal responses are not stored so backups stay restorable', a
 		ok: false,
 		error: { code: 'idempotency_response_unavailable' },
 		idempotency: { key: 'evt-oversized', replayed: false },
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+})
+
+async function dispatchMessageCreatedRequestHash(
+	params: Record<string, unknown>,
+) {
+	return await createRequestHash({
+		packageId: 'pkg-1',
+		exportName: './dispatch-message-created',
+		params,
+		source: 'discord-gateway',
+		topic: 'discord.message.created',
+	})
+}
+
+function dispatchMessageCreatedRequest(idempotencyKey: string) {
+	return {
+		packageIdOrKodyId: 'discord-gateway',
+		exportName: 'dispatch-message-created',
+		params: { content: 'hi' },
+		idempotencyKey,
+		source: 'discord-gateway',
+		topic: 'discord.message.created',
+	}
+}
+
+test('dual-read window: a pre-migration terminal D1 row replays without executing', async () => {
+	const db = createDatabase()
+	seedPackageResolution()
+	repoMockModule.runBundledModuleWithRegistry.mockClear()
+	db.seedLegacyInvocation({
+		tokenId: 'discord-gateway',
+		packageId: 'pkg-1',
+		packageKodyId: 'discord-gateway',
+		exportName: './dispatch-message-created',
+		idempotencyKey: 'evt-pre-migration',
+		requestHash: await dispatchMessageCreatedRequestHash({ content: 'hi' }),
+		source: 'discord-gateway',
+		topic: 'discord.message.created',
+		status: 'completed',
+		responseJson: JSON.stringify({
+			status: 200,
+			body: {
+				ok: true,
+				result: { reply: 'stored before the migration' },
+				idempotency: { key: 'evt-pre-migration', replayed: false },
+			},
+		}),
+	})
+
+	const replayed = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: dispatchMessageCreatedRequest('evt-pre-migration'),
+	})
+
+	expect(replayed.status).toBe(200)
+	expect(replayed.body).toMatchObject({
+		ok: true,
+		result: { reply: 'stored before the migration' },
+		idempotency: { key: 'evt-pre-migration', replayed: true },
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
+	// The DO claim taken ahead of the fallback lookup was released again, so
+	// nothing lingers in the ledger for the legacy-owned key.
+	expect(db.runLog.ledgerRows).toHaveLength(0)
+
+	// A different request against the same pre-migration key still mismatches.
+	const mismatch = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			...dispatchMessageCreatedRequest('evt-pre-migration'),
+			params: { content: 'different' },
+		},
+	})
+	expect(mismatch.status).toBe(409)
+	expect(mismatch.body).toMatchObject({
+		ok: false,
+		error: { code: 'idempotency_mismatch' },
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
+	expect(db.runLog.ledgerRows).toHaveLength(0)
+})
+
+test('dual-read window: fresh legacy in-progress rows are polled, stale ones are taken over', async () => {
+	const db = createDatabase()
+	seedPackageResolution()
+	repoMockModule.runBundledModuleWithRegistry.mockClear()
+	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
+		result: { reply: 'executed after takeover' },
+		logs: [],
+	})
+	const requestHash = await dispatchMessageCreatedRequestHash({
+		content: 'hi',
+	})
+	// Fresh in-progress row finished by an old-code isolate mid-poll.
+	db.seedLegacyInvocation({
+		tokenId: 'discord-gateway',
+		packageId: 'pkg-1',
+		packageKodyId: 'discord-gateway',
+		exportName: './dispatch-message-created',
+		idempotencyKey: 'evt-legacy-open',
+		requestHash,
+		source: 'discord-gateway',
+		topic: 'discord.message.created',
+		status: 'in_progress',
+	})
+	const completionTimer = setTimeout(() => {
+		db.completeLegacyInvocation({
+			idempotencyKey: 'evt-legacy-open',
+			responseJson: JSON.stringify({
+				status: 200,
+				body: {
+					ok: true,
+					result: { reply: 'finished by an old isolate' },
+					idempotency: { key: 'evt-legacy-open', replayed: false },
+				},
+			}),
+		})
+	}, 150)
+	try {
+		const polled = await invokePackageExport({
+			env: createEnv(db),
+			baseUrl: 'https://kody.dev',
+			token: createToken(),
+			request: dispatchMessageCreatedRequest('evt-legacy-open'),
+		})
+		expect(polled.status).toBe(200)
+		expect(polled.body).toMatchObject({
+			ok: true,
+			result: { reply: 'finished by an old isolate' },
+			idempotency: { key: 'evt-legacy-open', replayed: true },
+		})
+	} finally {
+		clearTimeout(completionTimer)
+	}
+	expect(repoMockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
+	expect(db.runLog.ledgerRows).toHaveLength(0)
+
+	// A stale legacy in-progress row can never finish (nothing writes D1 any
+	// more), so the DO claim proceeds to execute — the old reclaim, recorded
+	// in the DO instead of D1.
+	db.seedLegacyInvocation({
+		tokenId: 'discord-gateway',
+		packageId: 'pkg-1',
+		packageKodyId: 'discord-gateway',
+		exportName: './dispatch-message-created',
+		idempotencyKey: 'evt-legacy-stale',
+		requestHash,
+		source: 'discord-gateway',
+		topic: 'discord.message.created',
+		status: 'in_progress',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+	})
+	const takeover = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: dispatchMessageCreatedRequest('evt-legacy-stale'),
+	})
+	expect(takeover.status).toBe(200)
+	expect(takeover.body).toMatchObject({
+		ok: true,
+		result: { reply: 'executed after takeover' },
+		idempotency: { key: 'evt-legacy-stale', replayed: false },
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+	expect(
+		db.runLog.ledgerRows.find(
+			(row) => row.idempotencyKey === 'evt-legacy-stale',
+		),
+	).toMatchObject({ status: 'completed' })
+})
+
+test('the RunLog DO ledger is read first; legacy D1 rows are only a fallback for unknown keys', async () => {
+	const db = createDatabase()
+	seedPackageResolution()
+	repoMockModule.runBundledModuleWithRegistry.mockClear()
+	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
+		result: { reply: 'do-backed execution' },
+		logs: [],
+	})
+	const first = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: dispatchMessageCreatedRequest('evt-do-first'),
+	})
+	expect(first.status).toBe(200)
+
+	// A conflicting legacy row appearing afterwards (e.g. a restored backup)
+	// must lose to the DO row: replay serves the DO-stored response.
+	db.seedLegacyInvocation({
+		tokenId: 'discord-gateway',
+		packageId: 'pkg-1',
+		packageKodyId: 'discord-gateway',
+		exportName: './dispatch-message-created',
+		idempotencyKey: 'evt-do-first',
+		requestHash: await dispatchMessageCreatedRequestHash({ content: 'hi' }),
+		source: 'discord-gateway',
+		topic: 'discord.message.created',
+		status: 'completed',
+		responseJson: JSON.stringify({
+			status: 200,
+			body: { ok: true, result: { reply: 'stale legacy copy' } },
+		}),
+	})
+	const replay = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: dispatchMessageCreatedRequest('evt-do-first'),
+	})
+	expect(replay.status).toBe(200)
+	expect(replay.body).toMatchObject({
+		ok: true,
+		result: { reply: 'do-backed execution' },
+		idempotency: { key: 'evt-do-first', replayed: true },
 	})
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
 })
@@ -2198,7 +2573,9 @@ test('invokePackageSubscription uses the normal capability registry with package
 		(runOptions as { storageTools?: unknown }).storageTools,
 	).toBeUndefined()
 
-	db.seedStaleInvocation('email:message-stale:pkg-1:email.message.received')
+	db.runLog.seedStaleInvocation(
+		'email:message-stale:pkg-1:email.message.received',
+	)
 	const recovered = await invokePackageSubscription({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
@@ -2215,9 +2592,9 @@ test('invokePackageSubscription uses the normal capability registry with package
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(2)
 
 	const freshKey = 'email:message-fresh:pkg-1:email.message.received'
-	db.seedFreshInvocation(freshKey)
+	db.runLog.seedFreshInvocation(freshKey)
 	const completionTimer = setTimeout(() => {
-		db.completeInvocation(freshKey)
+		db.runLog.completeInvocation(freshKey)
 	}, 150)
 	try {
 		const polled = await invokePackageSubscription({
@@ -2237,42 +2614,6 @@ test('invokePackageSubscription uses the normal capability registry with package
 	} finally {
 		clearTimeout(completionTimer)
 	}
-
-	const fenced = db.seedStaleInvocation(
-		'email:message-fenced:pkg-1:email.message.received',
-	)
-	const reclaimedAt = new Date().toISOString()
-	expect(
-		await tryClaimStalePackageInvocation({
-			db,
-			id: String(fenced['id']),
-			userId: String(fenced['user_id']),
-			expectedUpdatedAt: String(fenced['updated_at']),
-			staleBefore: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
-			now: reclaimedAt,
-		}),
-	).toBe(true)
-	const storedResponse = { status: 200, body: { ok: true } }
-	expect(
-		await updatePackageInvocationResult({
-			db,
-			id: String(fenced['id']),
-			userId: String(fenced['user_id']),
-			status: 'completed',
-			response: storedResponse,
-			claimUpdatedAt: String(fenced['updated_at']),
-		}),
-	).toBe(false)
-	expect(
-		await updatePackageInvocationResult({
-			db,
-			id: String(fenced['id']),
-			userId: String(fenced['user_id']),
-			status: 'completed',
-			response: storedResponse,
-			claimUpdatedAt: reclaimedAt,
-		}),
-	).toBe(true)
 
 	const transientKey = 'email:message-transient:pkg-1:email.message.received'
 	repoMockModule.loadPublishedBundleArtifactByIdentity.mockRejectedValueOnce(

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -2100,6 +2100,68 @@ test('dual-read window: fresh legacy in-progress rows are polled, stale ones are
 	).toMatchObject({ status: 'completed' })
 })
 
+test('dual-read window: a stale DO claim defers to a terminal pre-migration row instead of re-executing', async () => {
+	const db = createDatabase()
+	seedPackageResolution()
+	repoMockModule.runBundledModuleWithRegistry.mockClear()
+	const requestHash = await dispatchMessageCreatedRequestHash({
+		content: 'hi',
+	})
+	// A takeover attempt claimed the key in the DO and died (claim now
+	// stale), while a zombie pre-migration isolate finished the legacy row.
+	db.runLog.ledgerRows.push({
+		id: crypto.randomUUID(),
+		tokenId: 'discord-gateway',
+		packageId: 'pkg-1',
+		packageKodyId: 'discord-gateway',
+		exportName: './dispatch-message-created',
+		idempotencyKey: 'evt-zombie-finish',
+		requestHash,
+		source: 'discord-gateway',
+		topic: 'discord.message.created',
+		status: 'in_progress',
+		responseJson: null,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+	})
+	db.seedLegacyInvocation({
+		tokenId: 'discord-gateway',
+		packageId: 'pkg-1',
+		packageKodyId: 'discord-gateway',
+		exportName: './dispatch-message-created',
+		idempotencyKey: 'evt-zombie-finish',
+		requestHash,
+		source: 'discord-gateway',
+		topic: 'discord.message.created',
+		status: 'completed',
+		responseJson: JSON.stringify({
+			status: 200,
+			body: {
+				ok: true,
+				result: { reply: 'finished by a zombie isolate' },
+				idempotency: { key: 'evt-zombie-finish', replayed: false },
+			},
+		}),
+	})
+
+	const replayed = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: dispatchMessageCreatedRequest('evt-zombie-finish'),
+	})
+
+	expect(replayed.status).toBe(200)
+	expect(replayed.body).toMatchObject({
+		ok: true,
+		result: { reply: 'finished by a zombie isolate' },
+		idempotency: { key: 'evt-zombie-finish', replayed: true },
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
+	// The reclaimed DO claim was released; the legacy row owns the key again.
+	expect(db.runLog.ledgerRows).toHaveLength(0)
+})
+
 test('the RunLog DO ledger is read first; legacy D1 rows are only a fallback for unknown keys', async () => {
 	const db = createDatabase()
 	seedPackageResolution()

--- a/packages/worker/src/platform-feedback/platform-feedback-subscriptions.workers.test.ts
+++ b/packages/worker/src/platform-feedback/platform-feedback-subscriptions.workers.test.ts
@@ -1,6 +1,7 @@
 import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
 import { buildPublishedSourceManifestSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { exportRunRecords } from '#worker/run-records/service.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import {
 	assignAdminRole,
@@ -343,31 +344,27 @@ test(
 				feedbackId: dispatchFeedback.id,
 			})
 
-			const invocations = await env.APP_DB.prepare(
-				`SELECT package_id, token_id, export_name, topic, source, idempotency_key, response_json
-			 FROM package_invocations
-			 WHERE package_id IN (?, ?, ?)`,
-			)
-				.bind(
-					firstAdminPackage.packageId,
-					secondAdminPackage.packageId,
-					regularPackage.packageId,
-				)
-				.all<Record<string, unknown>>()
-			expect(invocations.results).toHaveLength(2)
+			// The keyed idempotency ledger lives in each owner's RunLog DO now.
+			const adminInvocations = (
+				await exportRunRecords({ env, userId: adminStableId, pageSize: 100 })
+			).packageInvocations
+			const regularInvocations = (
+				await exportRunRecords({ env, userId: regularStableId, pageSize: 100 })
+			).packageInvocations
+			expect(adminInvocations).toHaveLength(2)
 			for (const adminPackage of [firstAdminPackage, secondAdminPackage]) {
-				const invocation = invocations.results?.find(
-					(row) => row['package_id'] === adminPackage.packageId,
+				const invocation = adminInvocations.find(
+					(row) => row.packageId === adminPackage.packageId,
 				)
 				expect(invocation).toMatchObject({
-					package_id: adminPackage.packageId,
-					token_id: 'internal:platform-feedback-subscriptions',
-					export_name: `subscription:${platformFeedbackSubmittedTopic}`,
+					packageId: adminPackage.packageId,
+					tokenId: 'internal:platform-feedback-subscriptions',
+					exportName: `subscription:${platformFeedbackSubmittedTopic}`,
 					topic: platformFeedbackSubmittedTopic,
 					source: 'platform-feedback',
-					idempotency_key: `platform-feedback:${dispatchFeedback.id}:${adminPackage.packageId}:${platformFeedbackSubmittedTopic}`,
+					idempotencyKey: `platform-feedback:${dispatchFeedback.id}:${adminPackage.packageId}:${platformFeedbackSubmittedTopic}`,
 				})
-				const response = JSON.parse(String(invocation?.['response_json'])) as {
+				const response = JSON.parse(String(invocation?.responseJson)) as {
 					body: Record<string, unknown>
 				}
 				expect(response.body).toMatchObject({
@@ -389,17 +386,24 @@ test(
 					},
 				})
 			}
+			// Nothing may reach the non-admin subscriber's ledger.
+			expect(regularInvocations).toHaveLength(0)
 			expect(
-				invocations.results?.some(
-					(row) => row['package_id'] === regularPackage.packageId,
+				adminInvocations.some(
+					(row) => row.packageId === regularPackage.packageId,
 				),
 			).toBe(false)
 
 			const countInvocations = async () => {
-				const row = await env.APP_DB.prepare(
-					`SELECT COUNT(*) AS total FROM package_invocations`,
-				).first<{ total: number }>()
-				return row?.total ?? 0
+				const pages = await Promise.all(
+					[adminStableId, regularStableId].map((userId) =>
+						exportRunRecords({ env, userId, pageSize: 100 }),
+					),
+				)
+				return pages.reduce(
+					(total, page) => total + page.packageInvocations.length,
+					0,
+				)
 			}
 			await env.APP_DB.prepare(`DELETE FROM user_roles`).run()
 			const before = await countInvocations()

--- a/packages/worker/src/run-records/invocation-ledger.workers.test.ts
+++ b/packages/worker/src/run-records/invocation-ledger.workers.test.ts
@@ -1,0 +1,481 @@
+import { env } from 'cloudflare:workers'
+import { runInDurableObject } from 'cloudflare:test'
+import { expect, test } from 'vitest'
+import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
+import { RunLog } from './run-log-do.ts'
+import {
+	claimPackageInvocationRecord,
+	clearRunRecords,
+	exportRunRecords,
+	finishPackageInvocationRecord,
+	getPackageInvocationRecord,
+	getRunRecord,
+	releasePackageInvocationRecord,
+} from './service.ts'
+import {
+	packageInvocationLedgerRetentionDays,
+	runRecordRetentionEveryNFinishes,
+	type RunRecordContext,
+} from './types.ts'
+
+function uniqueUserId(label: string) {
+	return `invocation-ledger-${label}-${crypto.randomUUID()}`
+}
+
+function ledgerKey(overrides?: Partial<Record<string, string>>) {
+	return {
+		tokenId: overrides?.tokenId ?? 'token-1',
+		packageId: overrides?.packageId ?? 'pkg-1',
+		exportName: overrides?.exportName ?? './send-message',
+		idempotencyKey: overrides?.idempotencyKey ?? 'evt-1',
+	}
+}
+
+function claimInput(overrides?: Partial<Record<string, string | null>>) {
+	return {
+		id: String(overrides?.id ?? crypto.randomUUID()),
+		tokenId: String(overrides?.tokenId ?? 'token-1'),
+		packageId: String(overrides?.packageId ?? 'pkg-1'),
+		packageKodyId: String(overrides?.packageKodyId ?? 'pkg-one'),
+		exportName: String(overrides?.exportName ?? './send-message'),
+		idempotencyKey: String(overrides?.idempotencyKey ?? 'evt-1'),
+		requestHash: String(overrides?.requestHash ?? 'hash-1'),
+		source: overrides?.source === undefined ? 'webhook' : overrides.source,
+		topic: overrides?.topic === undefined ? null : overrides.topic,
+	}
+}
+
+function exportContext(
+	overrides?: Partial<RunRecordContext>,
+): RunRecordContext {
+	return {
+		surface: 'export',
+		name: './send-message',
+		idempotencyKey: 'evt-1',
+		metadata: { exportName: './send-message' },
+		...overrides,
+	}
+}
+
+function freshStaleBefore() {
+	return new Date(Date.now() - 15 * 60 * 1000).toISOString()
+}
+
+async function seedStaleClaim(input: {
+	userId: string
+	idempotencyKey: string
+	requestHash?: string
+}) {
+	const claimed = await claimPackageInvocationRecord({
+		env,
+		userId: input.userId,
+		context: exportContext({ idempotencyKey: input.idempotencyKey }),
+		invocation: claimInput({
+			idempotencyKey: input.idempotencyKey,
+			requestHash: input.requestHash,
+		}),
+		staleBefore: freshStaleBefore(),
+	})
+	if (claimed.outcome !== 'claimed') {
+		throw new Error('Expected a fresh claim while seeding.')
+	}
+	// Backdate the claim so it is past the 15-minute stale window.
+	const staleUpdatedAt = new Date(Date.now() - 16 * 60 * 1000).toISOString()
+	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(input.userId))
+	await runInDurableObject(stub, async (instance: RunLog, state) => {
+		expect(instance).toBeInstanceOf(RunLog)
+		state.storage.sql.exec(
+			`UPDATE package_invocation_ledger SET updated_at = ? WHERE id = ?`,
+			staleUpdatedAt,
+			claimed.invocationId,
+		)
+	})
+	return { invocationId: claimed.invocationId, staleUpdatedAt }
+}
+
+test('claim + finish journey: one call each, replay record, run row lifecycle', async () => {
+	silenceExpectedConsoleWarns(['activation-run-record-failed'])
+	const userId = uniqueUserId('journey')
+
+	const claimed = await claimPackageInvocationRecord({
+		env,
+		userId,
+		context: exportContext(),
+		invocation: claimInput(),
+		staleBefore: freshStaleBefore(),
+	})
+	expect(claimed.outcome).toBe('claimed')
+	if (claimed.outcome !== 'claimed') throw new Error('unreachable')
+	expect(claimed.reclaimed).toBe(false)
+	expect(claimed.handle).not.toBeNull()
+
+	// The eager running row landed in the same DO call as the ledger claim.
+	const running = await getRunRecord({
+		env,
+		userId,
+		runId: claimed.handle!.id,
+	})
+	expect(running?.run).toMatchObject({
+		status: 'running',
+		surface: 'export',
+		idempotencyKey: 'evt-1',
+		invocationId: claimed.invocationId,
+	})
+
+	// A duplicate claim sees the in-progress owner instead of double-claiming.
+	const duplicate = await claimPackageInvocationRecord({
+		env,
+		userId,
+		context: exportContext(),
+		invocation: claimInput(),
+		staleBefore: freshStaleBefore(),
+	})
+	expect(duplicate.outcome).toBe('existing')
+	if (duplicate.outcome !== 'existing') throw new Error('unreachable')
+	expect(duplicate.record).toMatchObject({
+		id: claimed.invocationId,
+		status: 'in_progress',
+		requestHash: 'hash-1',
+	})
+
+	const responseJson = JSON.stringify({
+		status: 200,
+		body: { ok: true, result: { sent: true } },
+	})
+	const finished = await finishPackageInvocationRecord({
+		env,
+		userId,
+		handle: claimed.handle,
+		invocationId: claimed.invocationId,
+		claimUpdatedAt: claimed.claimUpdatedAt,
+		ledgerStatus: 'completed',
+		responseJson,
+		status: 'success',
+		logs: ['sent'],
+		result: { sent: true },
+	})
+	expect(finished).toMatchObject({ ledgerUpdated: true, record: null })
+
+	const record = await getPackageInvocationRecord({
+		env,
+		userId,
+		key: ledgerKey(),
+	})
+	expect(record).toMatchObject({
+		id: claimed.invocationId,
+		status: 'completed',
+		responseJson,
+	})
+
+	// The terminal run row (with logs and result snapshot) landed in the same
+	// DO call as the ledger response.
+	const terminalRun = await getRunRecord({
+		env,
+		userId,
+		runId: claimed.handle!.id,
+	})
+	expect(terminalRun?.run).toMatchObject({
+		status: 'success',
+		invocationId: claimed.invocationId,
+		metadata: expect.objectContaining({ result: { sent: true } }),
+	})
+	expect(terminalRun?.logs.map((log) => log.message)).toEqual(['sent'])
+})
+
+test('stale in-progress claims are reclaimed atomically; mismatched hashes are not', async () => {
+	const userId = uniqueUserId('stale-reclaim')
+	const seeded = await seedStaleClaim({ userId, idempotencyKey: 'evt-stale' })
+
+	// A different request hash never reclaims (mismatch resolution owns it).
+	const mismatch = await claimPackageInvocationRecord({
+		env,
+		userId,
+		context: exportContext({ idempotencyKey: 'evt-stale' }),
+		invocation: claimInput({
+			idempotencyKey: 'evt-stale',
+			requestHash: 'other-hash',
+		}),
+		staleBefore: freshStaleBefore(),
+	})
+	expect(mismatch.outcome).toBe('existing')
+
+	const reclaimed = await claimPackageInvocationRecord({
+		env,
+		userId,
+		context: exportContext({ idempotencyKey: 'evt-stale' }),
+		invocation: claimInput({ idempotencyKey: 'evt-stale' }),
+		staleBefore: freshStaleBefore(),
+	})
+	expect(reclaimed.outcome).toBe('claimed')
+	if (reclaimed.outcome !== 'claimed') throw new Error('unreachable')
+	expect(reclaimed).toMatchObject({
+		invocationId: seeded.invocationId,
+		reclaimed: true,
+	})
+	expect(reclaimed.claimUpdatedAt > seeded.staleUpdatedAt).toBe(true)
+
+	// The superseded attempt's finish is fenced out of the ledger but its own
+	// run row still lands terminal.
+	const staleAttemptHandle = {
+		id: crypto.randomUUID(),
+		userId,
+		startedAt: new Date().toISOString(),
+		persistence: 'eager' as const,
+		context: exportContext({ idempotencyKey: 'evt-stale' }),
+	}
+	const fenced = await finishPackageInvocationRecord({
+		env,
+		userId,
+		handle: staleAttemptHandle,
+		invocationId: seeded.invocationId,
+		claimUpdatedAt: seeded.staleUpdatedAt,
+		ledgerStatus: 'failed',
+		responseJson: JSON.stringify({ status: 500, body: { ok: false } }),
+		status: 'error',
+		error: new Error('superseded attempt'),
+	})
+	expect(fenced.ledgerUpdated).toBe(false)
+	expect(fenced.record).toMatchObject({
+		id: seeded.invocationId,
+		status: 'in_progress',
+		updatedAt: reclaimed.claimUpdatedAt,
+	})
+	const fencedRun = await getRunRecord({
+		env,
+		userId,
+		runId: staleAttemptHandle.id,
+	})
+	expect(fencedRun?.run.status).toBe('error')
+
+	// The reclaiming attempt finishes normally.
+	const finished = await finishPackageInvocationRecord({
+		env,
+		userId,
+		handle: reclaimed.handle,
+		invocationId: reclaimed.invocationId,
+		claimUpdatedAt: reclaimed.claimUpdatedAt,
+		ledgerStatus: 'failed',
+		responseJson: JSON.stringify({ status: 500, body: { ok: false } }),
+		status: 'error',
+		error: new Error('handler failed'),
+	})
+	expect(finished.ledgerUpdated).toBe(true)
+	const record = await getPackageInvocationRecord({
+		env,
+		userId,
+		key: ledgerKey({ idempotencyKey: 'evt-stale' }),
+	})
+	expect(record?.status).toBe('failed')
+})
+
+test('release deletes the in-progress claim and its running row so retries are clean', async () => {
+	const userId = uniqueUserId('release')
+	const claimed = await claimPackageInvocationRecord({
+		env,
+		userId,
+		context: exportContext({ idempotencyKey: 'evt-release' }),
+		invocation: claimInput({ idempotencyKey: 'evt-release' }),
+		staleBefore: freshStaleBefore(),
+	})
+	if (claimed.outcome !== 'claimed') throw new Error('Expected fresh claim.')
+
+	const released = await releasePackageInvocationRecord({
+		env,
+		userId,
+		invocationId: claimed.invocationId,
+		claimUpdatedAt: claimed.claimUpdatedAt,
+		handle: claimed.handle,
+	})
+	expect(released).toMatchObject({ released: true, record: null })
+	expect(
+		await getPackageInvocationRecord({
+			env,
+			userId,
+			key: ledgerKey({ idempotencyKey: 'evt-release' }),
+		}),
+	).toBeNull()
+	expect(
+		await getRunRecord({ env, userId, runId: claimed.handle!.id }),
+	).toBeNull()
+
+	// A stale release token cannot delete a newer claim; the caller gets the
+	// current owner back instead.
+	const second = await claimPackageInvocationRecord({
+		env,
+		userId,
+		context: exportContext({ idempotencyKey: 'evt-release' }),
+		invocation: claimInput({ idempotencyKey: 'evt-release' }),
+		staleBefore: freshStaleBefore(),
+	})
+	if (second.outcome !== 'claimed') throw new Error('Expected fresh claim.')
+	const fencedRelease = await releasePackageInvocationRecord({
+		env,
+		userId,
+		invocationId: second.invocationId,
+		claimUpdatedAt: new Date(0).toISOString(),
+		handle: null,
+	})
+	expect(fencedRelease.released).toBe(false)
+	expect(fencedRelease.record).toMatchObject({
+		id: second.invocationId,
+		status: 'in_progress',
+	})
+})
+
+test('DO-local retention prunes terminal ledger rows after 90 days and keeps in-progress rows', async () => {
+	const userId = uniqueUserId('retention')
+	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
+	const expiredCreatedAt = new Date(
+		Date.now() -
+			(packageInvocationLedgerRetentionDays + 1) * 24 * 60 * 60 * 1000,
+	).toISOString()
+	const insertLedgerRow = (input: {
+		id: string
+		idempotencyKey: string
+		status: string
+		createdAt: string
+	}) =>
+		runInDurableObject(stub, async (instance: RunLog, state) => {
+			expect(instance).toBeInstanceOf(RunLog)
+			state.storage.sql.exec(
+				`INSERT INTO package_invocation_ledger (
+					id, token_id, package_id, package_kody_id, export_name,
+					idempotency_key, request_hash, source, topic, status,
+					response_json, created_at, updated_at
+				) VALUES (?, 'token-1', 'pkg-1', 'pkg-one', './send-message', ?, 'hash-1',
+					NULL, NULL, ?, NULL, ?, ?)`,
+				input.id,
+				input.idempotencyKey,
+				input.status,
+				input.createdAt,
+				input.createdAt,
+			)
+		})
+	await insertLedgerRow({
+		id: 'expired-terminal',
+		idempotencyKey: 'evt-expired',
+		status: 'completed',
+		createdAt: expiredCreatedAt,
+	})
+	await insertLedgerRow({
+		id: 'expired-in-progress',
+		idempotencyKey: 'evt-expired-open',
+		status: 'in_progress',
+		createdAt: expiredCreatedAt,
+	})
+	await insertLedgerRow({
+		id: 'recent-terminal',
+		idempotencyKey: 'evt-recent',
+		status: 'completed',
+		createdAt: new Date().toISOString(),
+	})
+
+	// Arm retention so the next finish runs a full pass.
+	await runInDurableObject(stub, async (_instance: RunLog, state) => {
+		state.storage.sql.exec(
+			`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
+			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+			'finishes_since_retention',
+			runRecordRetentionEveryNFinishes - 1,
+		)
+	})
+	const claimed = await claimPackageInvocationRecord({
+		env,
+		userId,
+		context: null,
+		invocation: claimInput({ idempotencyKey: 'evt-trigger' }),
+		staleBefore: freshStaleBefore(),
+	})
+	if (claimed.outcome !== 'claimed') throw new Error('Expected fresh claim.')
+	await finishPackageInvocationRecord({
+		env,
+		userId,
+		handle: null,
+		invocationId: claimed.invocationId,
+		claimUpdatedAt: claimed.claimUpdatedAt,
+		ledgerStatus: 'completed',
+		responseJson: null,
+		status: 'success',
+	})
+
+	expect(
+		await getPackageInvocationRecord({
+			env,
+			userId,
+			key: ledgerKey({ idempotencyKey: 'evt-expired' }),
+		}),
+	).toBeNull()
+	expect(
+		await getPackageInvocationRecord({
+			env,
+			userId,
+			key: ledgerKey({ idempotencyKey: 'evt-expired-open' }),
+		}),
+	).toMatchObject({ id: 'expired-in-progress', status: 'in_progress' })
+	expect(
+		await getPackageInvocationRecord({
+			env,
+			userId,
+			key: ledgerKey({ idempotencyKey: 'evt-recent' }),
+		}),
+	).toMatchObject({ id: 'recent-terminal', status: 'completed' })
+})
+
+test('account export pages runs first, then ledger rows, through one cursor; clearAll purges both', async () => {
+	silenceExpectedConsoleWarns(['activation-run-record-failed'])
+	const userId = uniqueUserId('export')
+	const keys = ['evt-a', 'evt-b', 'evt-c']
+	for (const key of keys) {
+		const claimed = await claimPackageInvocationRecord({
+			env,
+			userId,
+			context: exportContext({ idempotencyKey: key }),
+			invocation: claimInput({ idempotencyKey: key }),
+			staleBefore: freshStaleBefore(),
+		})
+		if (claimed.outcome !== 'claimed') throw new Error('Expected fresh claim.')
+		await finishPackageInvocationRecord({
+			env,
+			userId,
+			handle: claimed.handle,
+			invocationId: claimed.invocationId,
+			claimUpdatedAt: claimed.claimUpdatedAt,
+			ledgerStatus: 'completed',
+			responseJson: JSON.stringify({ status: 200, body: { ok: true } }),
+			status: 'success',
+		})
+	}
+
+	const seenRunIds = new Set<string>()
+	const seenLedgerIds = new Set<string>()
+	let startAfter: string | null = null
+	for (let page = 0; page < 10; page += 1) {
+		const exported = await exportRunRecords({
+			env,
+			userId,
+			pageSize: 2,
+			startAfter,
+		})
+		for (const run of exported.runs) seenRunIds.add(run.id)
+		for (const row of exported.packageInvocations) seenLedgerIds.add(row.id)
+		if (!exported.truncated) break
+		startAfter = exported.nextStartAfter
+	}
+	expect(seenRunIds.size).toBe(3)
+	expect(seenLedgerIds.size).toBe(3)
+
+	await clearRunRecords({ env, userId })
+	const afterClear = await exportRunRecords({ env, userId, pageSize: 10 })
+	expect(afterClear).toMatchObject({
+		runs: [],
+		packageInvocations: [],
+		truncated: false,
+	})
+	expect(
+		await getPackageInvocationRecord({
+			env,
+			userId,
+			key: ledgerKey({ idempotencyKey: 'evt-a' }),
+		}),
+	).toBeNull()
+})

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -10,6 +10,7 @@ import {
 	type RunRecordSummary,
 	type RunStatus,
 	type RunSurface,
+	packageInvocationLedgerRetentionDays,
 	runRecordMaxJsonBytes,
 	runRecordMaxLogEntriesPerRun,
 	runRecordMaxRunsPerUser,
@@ -27,18 +28,28 @@ const textEncoder = new TextEncoder()
 const maxAgeDeletesPerFinish = 100
 const maxExcessDeletesPerFinish = 100
 const maxStaleRunningReconcilesPerPass = 100
+const maxLedgerAgeDeletesPerPass = 100
 
 const metaRunCountKey = 'run_count'
 const metaFinishesSinceRetentionKey = 'finishes_since_retention'
 const metaSchemaVersionKey = 'schema_version'
 /** Bump when initializeSchema's DDL set changes; warm objects skip DDL. */
-const runLogSchemaVersion = 4
+const runLogSchemaVersion = 5
+
+/**
+ * Cursor namespace for the invocation-ledger phase of `exportRuns`. Run-phase
+ * cursors stay raw run ids for backward compatibility with cursors minted
+ * before the ledger moved into this DO.
+ */
+const exportLedgerCursorPrefix = 'invocation-ledger:'
 
 const staleRunningErrorName = 'Interrupted'
 const staleRunningErrorMessage =
 	'Run did not finish; outcome unknown (reconciled after stale running TTL).'
 
 const retentionMs = runRecordRetentionDays * 24 * 60 * 60 * 1000
+const ledgerRetentionMs =
+	packageInvocationLedgerRetentionDays * 24 * 60 * 60 * 1000
 
 export type RunLogRowInput = {
 	id: string
@@ -72,6 +83,57 @@ export type RunLogEntryInput = {
 	message: string
 	fieldsJson: string | null
 }
+
+export type PackageInvocationLedgerStatus =
+	| 'in_progress'
+	| 'completed'
+	| 'failed'
+
+/**
+ * One keyed package-invocation idempotency row. Same shape as the legacy D1
+ * `package_invocations` table minus `user_id` — the DO identity is the user.
+ */
+export type PackageInvocationLedgerRecord = {
+	id: string
+	tokenId: string
+	packageId: string
+	packageKodyId: string
+	exportName: string
+	idempotencyKey: string
+	requestHash: string
+	source: string | null
+	topic: string | null
+	status: PackageInvocationLedgerStatus
+	/** Bounded replay cache; `null` when the terminal response was oversized. */
+	responseJson: string | null
+	createdAt: string
+	updatedAt: string
+}
+
+export type PackageInvocationLedgerKey = {
+	tokenId: string
+	packageId: string
+	exportName: string
+	idempotencyKey: string
+}
+
+export type PackageInvocationClaimInput = PackageInvocationLedgerKey & {
+	id: string
+	packageKodyId: string
+	requestHash: string
+	source: string | null
+	topic: string | null
+}
+
+export type PackageInvocationClaimResult =
+	| {
+			outcome: 'claimed'
+			invocationId: string
+			claimUpdatedAt: string
+			/** True when a stale `in_progress` row was taken over in place. */
+			reclaimed: boolean
+	  }
+	| { outcome: 'existing'; record: PackageInvocationLedgerRecord }
 
 type ListRunsInput = {
 	surface?: RunSurface | null
@@ -226,6 +288,30 @@ function mapLogRow(row: Record<string, SqlStorageValue>): RunRecordLog {
 	}
 }
 
+function mapInvocationLedgerRow(
+	row: Record<string, SqlStorageValue>,
+): PackageInvocationLedgerRecord {
+	const status = String(row['status'] ?? '')
+	return {
+		id: String(row['id']),
+		tokenId: String(row['token_id']),
+		packageId: String(row['package_id']),
+		packageKodyId: String(row['package_kody_id']),
+		exportName: String(row['export_name']),
+		idempotencyKey: String(row['idempotency_key']),
+		requestHash: String(row['request_hash']),
+		source: row['source'] == null ? null : String(row['source']),
+		topic: row['topic'] == null ? null : String(row['topic']),
+		status: (status === 'completed' || status === 'failed'
+			? status
+			: 'in_progress') as PackageInvocationLedgerStatus,
+		responseJson:
+			row['response_json'] == null ? null : String(row['response_json']),
+		createdAt: String(row['created_at']),
+		updatedAt: String(row['updated_at']),
+	}
+}
+
 function clampMetadataJson(metadataJson: string) {
 	if (textEncoder.encode(metadataJson).length <= runRecordMaxJsonBytes) {
 		return metadataJson
@@ -338,6 +424,35 @@ class RunLogBase extends DurableObject<Env> {
 				PRIMARY KEY (run_id, sequence)
 			)
 		`)
+		// Keyed package-invocation idempotency ledger (migrated from the D1
+		// package_invocations table). No user_id column: the DO identity is the
+		// user. The unique index is the exactly-once claim scope; unlike D1's
+		// INSERT OR IGNORE it never races because DO execution is serialized.
+		this.ctx.storage.sql.exec(`
+			CREATE TABLE IF NOT EXISTS package_invocation_ledger (
+				id TEXT PRIMARY KEY NOT NULL,
+				token_id TEXT NOT NULL,
+				package_id TEXT NOT NULL,
+				package_kody_id TEXT NOT NULL,
+				export_name TEXT NOT NULL,
+				idempotency_key TEXT NOT NULL,
+				request_hash TEXT NOT NULL,
+				source TEXT,
+				topic TEXT,
+				status TEXT NOT NULL,
+				response_json TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)
+		`)
+		this.ctx.storage.sql.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_invocation_ledger_key
+			ON package_invocation_ledger(token_id, package_id, export_name, idempotency_key)`,
+		)
+		this.ctx.storage.sql.exec(
+			`CREATE INDEX IF NOT EXISTS idx_invocation_ledger_status_created
+			ON package_invocation_ledger(status, created_at ASC)`,
+		)
 		this.setMeta(metaSchemaVersionKey, runLogSchemaVersion)
 	}
 
@@ -710,6 +825,20 @@ class RunLogBase extends DurableObject<Env> {
 			consider(Date.parse(oldestFinished.started_at) + retentionMs)
 		}
 
+		const oldestTerminalLedgerRow = this.ctx.storage.sql
+			.exec<{ created_at: string }>(
+				`SELECT created_at FROM package_invocation_ledger
+				WHERE status != 'in_progress'
+				ORDER BY created_at ASC
+				LIMIT 1`,
+			)
+			.toArray()[0]
+		if (oldestTerminalLedgerRow) {
+			consider(
+				Date.parse(oldestTerminalLedgerRow.created_at) + ledgerRetentionMs,
+			)
+		}
+
 		// Soonest stale due-time can belong to a newer short-lived surface
 		// (execute) even when an older long-lived service/job row exists.
 		// Only the earliest row per surface can produce that due-time.
@@ -771,7 +900,29 @@ class RunLogBase extends DurableObject<Env> {
 			this.deleteRunsByIds(ids)
 		}
 
+		this.pruneInvocationLedgerForRetention()
 		this.setFinishesSinceRetention(0)
+	}
+
+	/**
+	 * DO-local replacement for the D1 `package_invocations` retention sweep:
+	 * terminal ledger rows keep their replay responses for 90 days;
+	 * `in_progress` rows are never pruned so duplicate requests cannot bypass
+	 * the in-flight guard. Batched so one retention pass stays bounded.
+	 */
+	private pruneInvocationLedgerForRetention() {
+		const cutoff = new Date(Date.now() - ledgerRetentionMs).toISOString()
+		this.ctx.storage.sql.exec(
+			`DELETE FROM package_invocation_ledger
+			WHERE id IN (
+				SELECT id FROM package_invocation_ledger
+				WHERE status != 'in_progress' AND created_at < ?
+				ORDER BY created_at ASC
+				LIMIT ?
+			)`,
+			cutoff,
+			maxLedgerAgeDeletesPerPass,
+		)
 	}
 
 	private maybeEnforceRetention() {
@@ -944,6 +1095,206 @@ class RunLogBase extends DurableObject<Env> {
 		return { ok: true }
 	}
 
+	private findInvocationLedgerRow(
+		key: PackageInvocationLedgerKey,
+	): PackageInvocationLedgerRecord | null {
+		const row = this.ctx.storage.sql
+			.exec<Record<string, SqlStorageValue>>(
+				`SELECT * FROM package_invocation_ledger
+				WHERE token_id = ?
+					AND package_id = ?
+					AND export_name = ?
+					AND idempotency_key = ?
+				LIMIT 1`,
+				key.tokenId,
+				key.packageId,
+				key.exportName,
+				key.idempotencyKey,
+			)
+			.toArray()[0]
+		return row ? mapInvocationLedgerRow(row) : null
+	}
+
+	private getInvocationLedgerRowById(
+		id: string,
+	): PackageInvocationLedgerRecord | null {
+		const row = this.ctx.storage.sql
+			.exec<Record<string, SqlStorageValue>>(
+				`SELECT * FROM package_invocation_ledger WHERE id = ? LIMIT 1`,
+				id,
+			)
+			.toArray()[0]
+		return row ? mapInvocationLedgerRow(row) : null
+	}
+
+	/**
+	 * Claim a keyed package invocation and begin its run record in one on-path
+	 * DO call. DO execution is serialized, so lookup-then-insert here is
+	 * atomic — strictly better claim semantics than the racy D1
+	 * `INSERT OR IGNORE` this replaces. A matching stale `in_progress` row
+	 * (same request hash, `updated_at <= staleBefore`) is reclaimed in place;
+	 * everything else the key already owns is returned to the caller for
+	 * replay / mismatch / in-progress resolution.
+	 */
+	async claimPackageInvocation(input: {
+		invocation: PackageInvocationClaimInput
+		/** ISO cutoff: matching `in_progress` rows at or before it are reclaimable. */
+		staleBefore: string
+		/** Eager `running` run row for this attempt; `null` when the caller owns the run record (workflow-sourced invokes). */
+		run: RunLogRowInput | null
+	}): Promise<PackageInvocationClaimResult> {
+		const now = new Date().toISOString()
+		const existing = this.findInvocationLedgerRow(input.invocation)
+		if (existing) {
+			const reclaimable =
+				existing.status === 'in_progress' &&
+				existing.requestHash === input.invocation.requestHash &&
+				existing.updatedAt <= input.staleBefore
+			if (!reclaimable) {
+				return { outcome: 'existing', record: existing }
+			}
+			this.ctx.storage.sql.exec(
+				`UPDATE package_invocation_ledger SET updated_at = ? WHERE id = ?`,
+				now,
+				existing.id,
+			)
+			if (input.run) {
+				this.insertRunningRun({ ...input.run, invocationId: existing.id })
+				await this.ensureRetentionAlarm()
+			}
+			return {
+				outcome: 'claimed',
+				invocationId: existing.id,
+				claimUpdatedAt: now,
+				reclaimed: true,
+			}
+		}
+		this.ctx.storage.sql.exec(
+			`INSERT INTO package_invocation_ledger (
+				id, token_id, package_id, package_kody_id, export_name,
+				idempotency_key, request_hash, source, topic, status,
+				response_json, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'in_progress', NULL, ?, ?)`,
+			input.invocation.id,
+			input.invocation.tokenId,
+			input.invocation.packageId,
+			input.invocation.packageKodyId,
+			input.invocation.exportName,
+			input.invocation.idempotencyKey,
+			input.invocation.requestHash,
+			input.invocation.source,
+			input.invocation.topic,
+			now,
+			now,
+		)
+		if (input.run) {
+			this.insertRunningRun({
+				...input.run,
+				invocationId: input.invocation.id,
+			})
+			await this.ensureRetentionAlarm()
+		}
+		return {
+			outcome: 'claimed',
+			invocationId: input.invocation.id,
+			claimUpdatedAt: now,
+			reclaimed: false,
+		}
+	}
+
+	async getPackageInvocation(
+		input: PackageInvocationLedgerKey,
+	): Promise<PackageInvocationLedgerRecord | null> {
+		return this.findInvocationLedgerRow(input)
+	}
+
+	/**
+	 * Store the terminal response and finish the attempt's run record in one
+	 * on-path DO call. The ledger update is fenced on `claimUpdatedAt` so a
+	 * competing stale reclaim cannot be overwritten; the run row is this
+	 * attempt's alone, so it is finished even when the fence fails (the
+	 * attempt still happened and must not stay `running` forever).
+	 */
+	async finishPackageInvocation(input: {
+		invocationId: string
+		claimUpdatedAt: string
+		status: 'completed' | 'failed'
+		responseJson: string | null
+		run: RunLogRowInput | null
+		logs: Array<RunLogEntryInput>
+	}): Promise<{
+		ledgerUpdated: boolean
+		/** Current row when the fence failed, so the caller can resolve it. */
+		record: PackageInvocationLedgerRecord | null
+	}> {
+		const now = new Date().toISOString()
+		const updateCursor = this.ctx.storage.sql.exec(
+			`UPDATE package_invocation_ledger
+			SET status = ?, response_json = ?, updated_at = ?
+			WHERE id = ? AND status = 'in_progress' AND updated_at = ?`,
+			input.status,
+			input.responseJson,
+			now,
+			input.invocationId,
+			input.claimUpdatedAt,
+		)
+		const ledgerUpdated = updateCursor.rowsWritten > 0
+		if (input.run) {
+			const existed = this.runExists(input.run.id)
+			this.upsertRun(input.run, 'replace')
+			this.replaceLogs(input.run.id, input.logs)
+			if (!existed) {
+				this.adjustRunCount(1)
+			}
+		}
+		// A terminal ledger row creates future age-prune work even when no run
+		// row was written, so a stale idle conclusion must be cleared.
+		this.retentionIdleConfirmed = false
+		this.maybeEnforceRetention()
+		await this.ensureRetentionAlarm()
+		if (ledgerUpdated) {
+			return { ledgerUpdated: true, record: null }
+		}
+		return {
+			ledgerUpdated: false,
+			record: this.getInvocationLedgerRowById(input.invocationId),
+		}
+	}
+
+	/**
+	 * Release a claim whose execution never started (transient artifact
+	 * failure, dual-read fallback hit) so retries are not poisoned. Deletes
+	 * the still-`in_progress` ledger row (fenced on `claimUpdatedAt`) and the
+	 * attempt's still-`running` run row.
+	 */
+	async releasePackageInvocation(input: {
+		invocationId: string
+		claimUpdatedAt: string
+		runId: string | null
+	}): Promise<{
+		released: boolean
+		/** Current row when the fence failed, so the caller can resolve it. */
+		record: PackageInvocationLedgerRecord | null
+	}> {
+		const deleteCursor = this.ctx.storage.sql.exec(
+			`DELETE FROM package_invocation_ledger
+			WHERE id = ? AND status = 'in_progress' AND updated_at = ?`,
+			input.invocationId,
+			input.claimUpdatedAt,
+		)
+		const released = deleteCursor.rowsWritten > 0
+		if (input.runId) {
+			await this.deleteRunIfRunning({ runId: input.runId })
+		}
+		if (released) {
+			return { released: true, record: null }
+		}
+		return {
+			released: false,
+			record: this.getInvocationLedgerRowById(input.invocationId),
+		}
+	}
+
 	async listRuns(input: ListRunsInput): Promise<RunRecordPage> {
 		// Heal before listing so `status=running` filters and Activity views
 		// do not keep advertising stranded rows past their surface TTL.
@@ -1094,14 +1445,35 @@ class RunLogBase extends DurableObject<Env> {
 			.map((row) => row.storage_id)
 	}
 
+	/**
+	 * Paged over runs first, then invocation-ledger rows: run-phase cursors
+	 * stay raw run ids (compatible with pre-ledger cursors); ledger-phase
+	 * cursors carry the `invocation-ledger:` prefix. The remainder of the last
+	 * run page is filled with ledger rows so exports stay one-cursor.
+	 */
 	async exportRuns(input: ExportRunsInput): Promise<{
 		runs: Array<RunRecord>
 		logs: Array<RunRecordLog>
+		packageInvocations: Array<PackageInvocationLedgerRecord>
 		nextStartAfter: string | null
 		truncated: boolean
 	}> {
 		const pageSize = normalizePageSize(input.pageSize, runRecordDefaultPageSize)
-		const startAfter = input.startAfter?.trim() || null
+		const startAfterRaw = input.startAfter?.trim() || null
+		if (startAfterRaw?.startsWith(exportLedgerCursorPrefix)) {
+			const ledgerPage = this.exportInvocationLedgerPage({
+				startAfterId: startAfterRaw.slice(exportLedgerCursorPrefix.length),
+				limit: pageSize,
+			})
+			return {
+				runs: [],
+				logs: [],
+				packageInvocations: ledgerPage.rows,
+				nextStartAfter: ledgerPage.nextStartAfter,
+				truncated: ledgerPage.truncated,
+			}
+		}
+		const startAfter = startAfterRaw
 		const rows = (
 			startAfter
 				? this.ctx.storage.sql.exec<Record<string, SqlStorageValue>>(
@@ -1141,10 +1513,57 @@ class RunLogBase extends DurableObject<Env> {
 			logs.push(...runLogs)
 		}
 		const last = pageRows[pageRows.length - 1]
+		if (truncated) {
+			return {
+				runs,
+				logs,
+				packageInvocations: [],
+				nextStartAfter: last ? String(last['id']) : null,
+				truncated,
+			}
+		}
+		const ledgerPage = this.exportInvocationLedgerPage({
+			startAfterId: '',
+			limit: pageSize - runs.length,
+		})
 		return {
 			runs,
 			logs,
-			nextStartAfter: truncated && last ? String(last['id']) : null,
+			packageInvocations: ledgerPage.rows,
+			nextStartAfter: ledgerPage.nextStartAfter,
+			truncated: ledgerPage.truncated,
+		}
+	}
+
+	private exportInvocationLedgerPage(input: {
+		startAfterId: string
+		limit: number
+	}): {
+		rows: Array<PackageInvocationLedgerRecord>
+		nextStartAfter: string | null
+		truncated: boolean
+	} {
+		const limit = Math.max(input.limit, 0)
+		const rows = this.ctx.storage.sql
+			.exec<Record<string, SqlStorageValue>>(
+				`SELECT * FROM package_invocation_ledger
+				WHERE id > ?
+				ORDER BY id ASC
+				LIMIT ?`,
+				input.startAfterId,
+				limit + 1,
+			)
+			.toArray()
+		const truncated = rows.length > limit
+		const pageRows = truncated ? rows.slice(0, limit) : rows
+		const last = pageRows[pageRows.length - 1]
+		return {
+			rows: pageRows.map(mapInvocationLedgerRow),
+			// A zero-limit page (runs filled the whole page) restarts the ledger
+			// phase from the same cursor so the next call makes progress.
+			nextStartAfter: truncated
+				? `${exportLedgerCursorPrefix}${last ? String(last['id']) : input.startAfterId}`
+				: null,
 			truncated,
 		}
 	}
@@ -1189,11 +1608,39 @@ export type RunLogRpc = {
 	deleteRunIfRunning: (input: {
 		runId: string
 	}) => Promise<{ deleted: boolean }>
+	claimPackageInvocation: (input: {
+		invocation: PackageInvocationClaimInput
+		staleBefore: string
+		run: RunLogRowInput | null
+	}) => Promise<PackageInvocationClaimResult>
+	getPackageInvocation: (
+		input: PackageInvocationLedgerKey,
+	) => Promise<PackageInvocationLedgerRecord | null>
+	finishPackageInvocation: (input: {
+		invocationId: string
+		claimUpdatedAt: string
+		status: 'completed' | 'failed'
+		responseJson: string | null
+		run: RunLogRowInput | null
+		logs: Array<RunLogEntryInput>
+	}) => Promise<{
+		ledgerUpdated: boolean
+		record: PackageInvocationLedgerRecord | null
+	}>
+	releasePackageInvocation: (input: {
+		invocationId: string
+		claimUpdatedAt: string
+		runId: string | null
+	}) => Promise<{
+		released: boolean
+		record: PackageInvocationLedgerRecord | null
+	}>
 	summarize: (input: { since: string }) => Promise<RunRecordSummary>
 	listStorageIds: () => Promise<Array<string>>
 	exportRuns: (input: ExportRunsInput) => Promise<{
 		runs: Array<RunRecord>
 		logs: Array<RunRecordLog>
+		packageInvocations: Array<PackageInvocationLedgerRecord>
 		nextStartAfter: string | null
 		truncated: boolean
 	}>

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -2,6 +2,9 @@ import { toJsonSafeValue } from '@kody-internal/shared/json-safe-value.ts'
 import { recordSuccessfulPackageRun } from '#worker/usage/activation.ts'
 import { runLogDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import {
+	type PackageInvocationClaimInput,
+	type PackageInvocationLedgerKey,
+	type PackageInvocationLedgerRecord,
 	type RunLogEntryInput,
 	type RunLogRowInput,
 	type RunLogRpc,
@@ -573,6 +576,236 @@ export async function abandonRunRecord(input: {
 	}
 }
 
+/**
+ * Claim a keyed package invocation: idempotency-ledger claim plus eager
+ * run-record begin in ONE awaited on-path DO RPC. Unlike {@link beginRunRecord}
+ * this is correctness, not observability — a failed claim must fail the
+ * invocation — so errors propagate to the caller instead of being swallowed.
+ */
+export async function claimPackageInvocationRecord(input: {
+	env: Env
+	userId: string
+	/** `null` when the caller owns the run record (workflow-sourced invokes). */
+	context: RunRecordContext | null
+	invocation: PackageInvocationClaimInput
+	/** ISO cutoff for in-place stale `in_progress` reclaims. */
+	staleBefore: string
+}): Promise<
+	| {
+			outcome: 'claimed'
+			invocationId: string
+			claimUpdatedAt: string
+			reclaimed: boolean
+			handle: RunRecordHandle | null
+	  }
+	| { outcome: 'existing'; record: PackageInvocationLedgerRecord }
+> {
+	let handle: RunRecordHandle | null = null
+	let run: RunLogRowInput | null = null
+	if (input.context) {
+		const startedAt = new Date().toISOString()
+		handle = {
+			id: crypto.randomUUID(),
+			userId: input.userId,
+			startedAt,
+			persistence: runPersistenceForContext(input.context),
+			context: input.context,
+		}
+		run = buildRunRow({
+			handle,
+			status: 'running',
+			finishedAt: null,
+			durationMs: null,
+			errorName: null,
+			errorMessage: null,
+			updatedAt: startedAt,
+		})
+	}
+	const claimed = await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).claimPackageInvocation({
+		invocation: input.invocation,
+		staleBefore: input.staleBefore,
+		run,
+	})
+	if (claimed.outcome === 'existing') {
+		return claimed
+	}
+	if (handle) {
+		// Stale reclaims keep the original ledger row id; the run record must
+		// reference the invocation id that actually owns the claim.
+		handle.context = { ...handle.context, invocationId: claimed.invocationId }
+	}
+	return { ...claimed, handle }
+}
+
+export async function getPackageInvocationRecord(input: {
+	env: Env
+	userId: string
+	key: PackageInvocationLedgerKey
+}): Promise<PackageInvocationLedgerRecord | null> {
+	return await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).getPackageInvocation(input.key)
+}
+
+/**
+ * Terminal ledger response and run-record finish in ONE awaited on-path DO
+ * RPC — the counterpart to {@link claimPackageInvocationRecord}. RPC failures
+ * propagate (the caller decides whether a lost terminal write may poison the
+ * key); the activation-milestone and run-error subscription side effects
+ * shared with {@link finishRunRecord} never throw and are scheduled on
+ * `waitUntil` when provided.
+ */
+export async function finishPackageInvocationRecord(input: {
+	env: Env
+	userId: string
+	handle: RunRecordHandle | null
+	invocationId: string
+	claimUpdatedAt: string
+	ledgerStatus: 'completed' | 'failed'
+	/** Bounded replay cache JSON; `null` drops the replay (oversized). */
+	responseJson: string | null
+	status: RunTerminalStatus
+	logs?: Array<RunRecordLogInput>
+	error?: unknown
+	result?: unknown
+	waitUntil?: (promise: Promise<unknown>) => void
+}): Promise<{
+	ledgerUpdated: boolean
+	record: PackageInvocationLedgerRecord | null
+}> {
+	const handle = input.handle
+	let run: RunLogRowInput | null = null
+	if (handle) {
+		const finishedAt = new Date().toISOString()
+		const durationMs = Math.max(
+			0,
+			Date.parse(finishedAt) - Date.parse(handle.startedAt),
+		)
+		const { errorName, errorMessage } = getErrorFields(input.error)
+		const metadata =
+			input.result === undefined
+				? handle.context.metadata
+				: {
+						...(handle.context.metadata ?? {}),
+						result: snapshotRunRecordResult(input.result),
+					}
+		run = buildRunRow({
+			handle: {
+				...handle,
+				context: {
+					...handle.context,
+					metadata,
+				},
+			},
+			status: input.status,
+			finishedAt,
+			durationMs,
+			errorName,
+			errorMessage,
+			updatedAt: finishedAt,
+		})
+	}
+	const finished = await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).finishPackageInvocation({
+		invocationId: input.invocationId,
+		claimUpdatedAt: input.claimUpdatedAt,
+		status: input.ledgerStatus,
+		responseJson: input.responseJson,
+		run,
+		logs: run ? normalizeLogs(input.logs) : [],
+	})
+	if (handle && run) {
+		const sideEffects = dispatchTerminalRunRecordSideEffects({
+			env: input.env,
+			handle,
+			persistedRun: run,
+			status: input.status,
+			waitUntil: input.waitUntil,
+		})
+		if (input.waitUntil) {
+			input.waitUntil(sideEffects)
+		} else {
+			await sideEffects
+		}
+	}
+	return finished
+}
+
+/**
+ * Release a claim whose execution never started (transient artifact failure
+ * or the dual-read D1 fallback finding a pre-migration owner). Deletes the
+ * still-`in_progress` ledger row and the attempt's `running` run row.
+ */
+export async function releasePackageInvocationRecord(input: {
+	env: Env
+	userId: string
+	invocationId: string
+	claimUpdatedAt: string
+	handle: RunRecordHandle | null
+}): Promise<{
+	released: boolean
+	record: PackageInvocationLedgerRecord | null
+}> {
+	return await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).releasePackageInvocation({
+		invocationId: input.invocationId,
+		claimUpdatedAt: input.claimUpdatedAt,
+		runId: input.handle?.id ?? null,
+	})
+}
+
+/**
+ * Post-terminal-write observers shared by {@link finishRunRecord} and
+ * {@link finishPackageInvocationRecord}: the activation milestone on success
+ * and best-effort `run.error.recorded` dispatch on error. Never throws.
+ */
+async function dispatchTerminalRunRecordSideEffects(input: {
+	env: Env
+	handle: RunRecordHandle
+	persistedRun: RunLogRowInput
+	status: RunTerminalStatus
+	waitUntil?: (promise: Promise<unknown>) => void
+}): Promise<void> {
+	if (input.status === 'success') {
+		const packageId = normalizeOptionalString(input.handle.context.packageId)
+		if (!packageId) return
+		try {
+			await recordSuccessfulPackageRun(input.env, {
+				userId: input.handle.userId,
+				packageId,
+				surface: input.handle.context.surface,
+			})
+		} catch (error) {
+			console.warn('run-record-activation-failed', error)
+		}
+		return
+	}
+	if (input.handle.context.surface === 'subscription') return
+	try {
+		// Dynamic import: a static edge to package-subscriptions pulls
+		// package-invocations and deepens the account-export cycle (see the
+		// matching note in finishRunRecord).
+		const { dispatchRunErrorSubscriptionEvents } =
+			await import('./package-subscriptions.ts')
+		await dispatchRunErrorSubscriptionEvents({
+			env: input.env,
+			userId: input.handle.userId,
+			run: input.persistedRun,
+			waitUntil: input.waitUntil,
+		})
+	} catch (error) {
+		console.warn('run-error-subscription-dispatch-failed', error)
+	}
+}
+
 export async function summarizeRunRecords(input: {
 	env: Env
 	userId: string
@@ -613,6 +846,7 @@ export async function exportRunRecords(input: {
 }): Promise<{
 	runs: Array<RunRecord>
 	logs: Array<RunRecordLog>
+	packageInvocations: Array<PackageInvocationLedgerRecord>
 	nextStartAfter: string | null
 	truncated: boolean
 }> {
@@ -620,14 +854,22 @@ export async function exportRunRecords(input: {
 		return {
 			runs: [],
 			logs: [],
+			packageInvocations: [],
 			nextStartAfter: null,
 			truncated: false,
 		}
 	}
-	return await runLogRpc({ env: input.env, userId: input.userId }).exportRuns({
+	const page = await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).exportRuns({
 		pageSize: input.pageSize ?? runRecordDefaultPageSize,
 		startAfter: input.startAfter ?? null,
 	})
+	return {
+		...page,
+		packageInvocations: page.packageInvocations ?? [],
+	}
 }
 
 export async function clearRunRecords(input: {
@@ -639,3 +881,9 @@ export async function clearRunRecords(input: {
 }
 
 export type { RunLogRpc }
+export type {
+	PackageInvocationClaimInput,
+	PackageInvocationLedgerKey,
+	PackageInvocationLedgerRecord,
+	PackageInvocationLedgerStatus,
+} from './run-log-do.ts'

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -291,3 +291,14 @@ export function runRecordStaleRunningTtlMsForSurface(
 
 /** How often the DO alarm re-runs retention when the object is otherwise idle. */
 export const runRecordRetentionAlarmMs = 60 * 60 * 1000
+
+/**
+ * Keyed package-invocation idempotency ledger rows live in the same per-user
+ * `RunLog` Durable Object as run records (they moved off the shared D1 writer;
+ * see `docs/contributing/architecture/run-records.md`). Terminal rows keep
+ * their replay responses for 90 days — the same window the legacy D1
+ * `package_invocations` sweep used — and are pruned by the DO's own retention
+ * passes. `in_progress` rows are never pruned so duplicate requests cannot
+ * bypass the in-flight guard.
+ */
+export const packageInvocationLedgerRetentionDays = 90


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`package_invocations` is per-user data on the global single-writer D1 database: every keyed invoke paid a claim `INSERT`, a terminal `UPDATE`, an account write lease (~5 more D1 statements), plus separate run-record DO round trips. The per-user `RunLog` Durable Object already indexes runs by idempotency key and executes serially, which gives strictly better claim atomicity than `INSERT OR IGNORE` races. This is the ledger slice of the static-first invocation program (follows #1046, complements #1045/#1047).

## What changed

- **RunLog DO** (`run-log-do.ts`, schema v5): new `package_invocation_ledger` table (same shape as the D1 table minus `user_id` — the DO identity is the user; unique index on `token_id, package_id, export_name, idempotency_key`) with four RPCs:
  - `claimPackageInvocation` — ledger claim **plus eager run-record begin in one awaited DO call**; atomic lookup-then-insert; in-place stale reclaim (15 min, matching request hash only).
  - `finishPackageInvocation` — **terminal replay response plus run-record finish in one awaited DO call**; ledger update fenced on the claim timestamp; the attempt's own run row is always finished.
  - `releasePackageInvocation` — deletes an unexecuted claim and its `running` run row (transient artifact failure / dual-read fallback hit).
  - `getPackageInvocation` — conflict-poll lookups.
- **Keyed path** (`idempotent-module-invocation.ts`): rewired onto the DO. All keyed semantics preserved exactly: request-hash mismatch → 409 `idempotency_mismatch`; in-progress polling at 100 ms with a 1 s budget; 15-minute stale reclaim; bounded response replay (`maxStoredInvocationResponseJsonBytes`) with the `replayed` flag; identical error codes. The registry no longer opens a second run record for keyed runs — the claim handle owns it, and `module-execution.ts` enriches it with the published commit after artifact load.
- **Dual-read window**: the DO is read first; a **read-only** D1 fallback serves keys claimed before the migration (terminal → replay; fresh in-progress → poll then 409; stale in-progress → the DO claim proceeds, the old reclaim recorded in the DO). The fallback runs after every claim — including stale reclaims, so a terminal legacy row finished by a zombie pre-migration isolate replays instead of re-executing (Bugbot catch). Writes go **only** to the DO — the D1 write helpers are deleted, and the node suite's fake D1 throws on any write to prove no awaited D1 write remains on the keyed hot path.
- **Retention**: DO-local 90-day terminal-row sweep (`packageInvocationLedgerRetentionDays`) wired into the existing retention passes and alarm scheduling; `in_progress` rows are never pruned. The D1 `package_invocations` policy entry in `app/retention.ts` stays to drain pre-migration rows and is marked **legacy / remove in follow-up**.
- **Account export/deletion**: `exportRuns` pages runs first, then ledger rows, through one cursor (`invocation-ledger:` prefix; pre-existing run cursors stay valid), surfaced in the `run_records` export section (manifest count includes ledger rows); account deletion's existing `clearAll` purges ledger rows with run history. Disposition notes extended in `account/user-owned-surfaces.ts`.
- **Docs**: run-records architecture doc gains a ledger section; data-storage retention notes updated; disaster-recovery doc records the accepted risk that losing the RunLog DO loses idempotency/replay state (duplicate execution of replayed webhooks — lost rows are not rebuilt, bounded by the 90-day window); invocation-overhead-guardrails records the new keyed budget (one DO call each for begin/finish, one temporary awaited D1 read).

## Decision: `withAccountWriteLease` is dropped from the keyed path

Its purpose is guarding **D1 writes** against concurrent account deletion, and no D1 writes remain on this path. This is not a silent drop:

- The keyed path's own writes now go to the per-user RunLog DO, which account deletion purges via `clearRunRecords` after the lease barrier drains. A DO write racing past that purge is the same residual every run-record write already has (the key-less lean path in #1046 shipped with exactly this profile, deliberately), and any leaked row self-deletes within the DO's own retention windows.
- D1 writes made by the *executing package* go through capability services (`jobs/service.ts`, `mcp/memory/service.ts`, `package-registry/service.ts`, email, …) that take their own leases — again identical to the merged key-less lean path.
- All remaining ledger interactions with D1 are reads (the dual-read fallback), which the lease never guarded.

## Follow-up (deliberately out of this PR)

Once production traffic confirms the DO ledger (a deploy-window's worth of pre-migration keys aged out): remove the dual-read D1 fallback (`getPackageInvocationByKey` + the legacy poll/reclaim consults in `idempotent-module-invocation.ts`), the `package_invocations` retention policy entry, the table's account data-target/disposition rows, and migration follow-ups to drop the table (including its never-pruned pre-migration `in_progress` rows).

## Testing

- `packages/worker/src/run-records/invocation-ledger.workers.test.ts` (new, real DO via `cloudflare:test`): claim+begin/finish+terminal journeys, duplicate claim, atomic stale reclaim, fence behavior for superseded finishes and releases, DO-local 90-day sweep (terminal pruned, in-progress and recent kept), one-cursor export paging across runs and ledger rows, `clearAll` purge.
- `packages/worker/src/package-invocations/service.node.test.ts`: all pre-existing keyed-semantics tests preserved (replay, mismatch, corruption, persistence failure, stale reclaim, poll, oversized-response drop) against an in-memory RunLog fake whose D1 stand-in **throws on any write**; new dual-read tests (pre-migration terminal replay + mismatch, fresh legacy in-progress poll-to-replay, stale legacy takeover, stale-DO-claim-defers-to-terminal-legacy, DO-first precedence over a conflicting legacy row).
- Subscription dispatch workers suites (system-email, platform-feedback, inbound email) updated to read the ledger from the owner's RunLog DO.

## Program report

MERGE-READY

Status: green and mergeable at head `c97cbb6b` (mergeStateStatus CLEAN against `main`, includes merged #1045/#1047/#1052).
- Local `npm run validate` exit 0 on the head commit (format, lint, typecheck, node + workers unit, Playwright E2E, MCP E2E, backup:build, primitives/migrations checks).
- CI: all jobs green (🧹 Static, 🧪 Node, ☁️ Workers, 🔌 MCP, 🎭 E2E, ✅ Validate, preview deploy).
- AI reviewers: Bugbot high-severity dual-read gap fixed (`c97cbb6b`, legacy fallback now runs on stale reclaims too, with a regression test); Bugbot medium (observer side effects vs ledger fence) answered — deliberately preserves pre-migration semantics; Bugbot low (manifest count) fixed. CodeRabbit: docs wording + test-ordering findings fixed; the "invalid YAML" finding dismissed with a parse proof (also note: main was format-broken by #1052's workflow file; this branch formats it, `22711d7f`).
- After merge + deploy I will verify the deploy workflow is green on the squashed commit and that https://heykody.dev/health returns its sha; conductor runs the authenticated production probes (keyed invoke replay against the DO ledger; dual-read fallback for a pre-migration key).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends run-records and the keyed invocation path</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `06aa3d7a` · **Head:** `c97cbb6b`

**Classification:** extends — the run-records primitive gains the keyed package-invocation idempotency ledger (new DO table + RPCs); the keyed `packages.invoke` path is rewired onto it. No new primitive: the ledger is absorbed into `run-records`.

### Primitives touched

| Primitive        | Group     | Impact                                                                                     |
| ---------------- | --------- | ------------------------------------------------------------------------------------------ |
| `run-records`    | storage   | extends — `package_invocation_ledger` table, combined claim/finish/release RPCs, 90-day DO-local sweep, export cursor |
| `account-export` | assistant | extends — `run_records` section pages ledger rows after runs through the same cursor; manifest counts both |
| `scheduled-cron` | surfaces  | composes — D1 `package_invocations` sweep kept but marked legacy for the dual-read window   |
| `email`, `platform-feedback` | assistant | composes — dispatch tests read the DO ledger instead of D1                     |

Unmapped path: `packages/worker/src/package-invocations/` (keyed `packages.invoke` surface) — extends: claim/finish moved off D1; dual-read fallback added; account write lease dropped.

### System map

Keyed `packages.invoke` claims and finishes in the per-user RunLog DO; D1 is read-only fallback during the dual-read window.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	invoke["package-invocations<br/>Keyed packages.invoke"]:::extended
	runRecords["run-records<br/>Run records (RunLog DO)"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	accountExport["account-export<br/>Account data export"]:::extended
	cron["scheduled-cron<br/>Retention cron"]:::touched
	invoke -->|"claimPackageInvocation: ledger claim + run begin (1 DO call)"| runRecords
	invoke -->|"finishPackageInvocation: replay response + run finish (1 DO call)"| runRecords
	invoke -->|"dual-read fallback: read-only getPackageInvocationByKey"| d1AppDb
	accountExport -->|"run_records section pages ledger rows (one cursor)"| runRecords
	cron -->|"legacy package_invocations sweep (drain-only, follow-up removes)"| d1AppDb
	runRecords -->|"DO-local 90-day terminal-row sweep + alarm"| runRecords
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Keyed invoke step   | Before (D1)                                             | After (RunLog DO)                              |
| ------------------- | ------------------------------------------------------- | ---------------------------------------------- |
| Claim               | lookup SELECT + `INSERT OR IGNORE` (+ stale-reclaim UPDATE) | one `claimPackageInvocation` RPC (atomic)      |
| Run-record begin    | separate fire-and-forget `startRun` DO call             | inside the same claim RPC                      |
| Terminal write      | awaited D1 `UPDATE` + separate `finishRun` DO call      | one `finishPackageInvocation` RPC              |
| Account write lease | acquire/release (~5 D1 statements)                      | none (see PR body for the decision)            |
| Retention           | hourly D1 cron sweep                                    | DO-local sweep on retention passes/alarm       |

### Invariants

- `no-per-event-shared-writes` strengthened: per-invoke ledger writes leave the shared D1 writer for per-user DO SQLite.
- Per-user isolation preserved structurally: ledger rows live inside the per-user RunLog DO (no `user_id` column needed — the DO identity is the user).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da9a62c3-6e38-4f03-b49e-1a3fc1355632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da9a62c3-6e38-4f03-b49e-1a3fc1355632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyed package invocations now use durable run records for deduplication and replay of completed responses.
  * Account exports now include package-invocation history alongside runs and logs, with unified pagination.
  * Invocation records are retained for up to 90 days; active invocations remain protected.

* **Bug Fixes**
  * Improved handling of stale, duplicate, failed, and interrupted invocations to prevent unintended repeated execution.

* **Documentation**
  * Updated architecture, retention, export, and disaster-recovery guidance, including replay-protection limitations after data loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->