### PR TITLE
fix(workflows): stop replaying timed-out workflow exports

### DIFF
--- a/.github/workflows/backfill-mcp-agent-sessions.yml
+++ b/.github/workflows/backfill-mcp-agent-sessions.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: Dry-run audits only; execute writes index rows and the completion marker.
+        description:
+          Dry-run audits only; execute writes index rows and the completion
+          marker.
         type: choice
         options:
           - dry-run
@@ -15,7 +17,9 @@ on:
         type: string
         default: https://heykody.dev
       worker_script:
-        description: Cloudflare Workers script name that owns the MCP Durable Object namespace
+        description:
+          Cloudflare Workers script name that owns the MCP Durable Object
+          namespace
         type: string
         default: kody-production
 
@@ -23,7 +27,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: backfill-mcp-agent-sessions-${{ inputs.origin }}-${{ inputs.worker_script }}
+  group:
+    backfill-mcp-agent-sessions-${{ inputs.origin }}-${{ inputs.worker_script }}
   cancel-in-progress: false
 
 jobs:

--- a/docs/use/workflows.md
+++ b/docs/use/workflows.md
@@ -6,8 +6,12 @@ subscriptions, package exports, and package services.
 
 Use workflows instead of plain `execute` for durable batch sweeps, migrations,
 polling loops, retryable steps, or work that may run longer than execute's
-timeout. The initial `execute` call should submit one `workflows.create`;
-inspect that workflow later with `workflow_run_list`.
+timeout (~90s). Workflow-invoked package exports and inline workflow code get a
+longer sandbox budget (~4.5 minutes, under the Cloudflare Workflow step
+timeout) and run without the package-invocation idempotency ledger, so a step
+retry re-executes instead of replaying a cached timeout. The initial `execute`
+call should submit one `workflows.create`; inspect that workflow later with
+`workflow_run_list`.
 
 ```ts
 import { workflows } from 'kody:runtime'

--- a/docs/use/workflows.md
+++ b/docs/use/workflows.md
@@ -7,10 +7,10 @@ subscriptions, package exports, and package services.
 Use workflows instead of plain `execute` for durable batch sweeps, migrations,
 polling loops, retryable steps, or work that may run longer than execute's
 timeout (~90s). Workflow-invoked package exports and inline workflow code get a
-longer sandbox budget (~4.5 minutes, under the Cloudflare Workflow step
-timeout) and run without the package-invocation idempotency ledger, so a step
-retry re-executes instead of replaying a cached timeout. The initial `execute`
-call should submit one `workflows.create`; inspect that workflow later with
+longer sandbox budget (~4.5 minutes, under the Cloudflare Workflow step timeout)
+and run without the package-invocation idempotency ledger, so a step retry
+re-executes instead of replaying a cached timeout. The initial `execute` call
+should submit one `workflows.create`; inspect that workflow later with
 `workflow_run_list`.
 
 ```ts

--- a/packages/worker/src/package-invocations/http-invoke.ts
+++ b/packages/worker/src/package-invocations/http-invoke.ts
@@ -257,7 +257,9 @@ export async function invokePackageExportWithToolFactories(input: {
 	// External HTTP token invocations stay keyed-only: providers retry
 	// deliveries, so exactly-once is the point of this surface. Workflow
 	// step retries pass ephemeral: true and run key-less instead.
-	const idempotencyKey = normalizeNullableString(input.request.idempotencyKey)
+	const idempotencyKey = input.ephemeral
+		? null
+		: normalizeNullableString(input.request.idempotencyKey)
 	if (!input.ephemeral && !idempotencyKey) {
 		return buildJsonErrorResponse({
 			status: 400,
@@ -331,7 +333,7 @@ export async function invokePackageExportWithToolFactories(input: {
 		executorTimeoutMs: input.executorTimeoutMs,
 	}
 
-	if (input.ephemeral || !idempotencyKey) {
+	if (!idempotencyKey) {
 		return await runSavedPackageModuleEphemeral(shared)
 	}
 

--- a/packages/worker/src/package-invocations/http-invoke.ts
+++ b/packages/worker/src/package-invocations/http-invoke.ts
@@ -238,6 +238,12 @@ export async function invokePackageExportWithToolFactories(input: {
 	runtimeInvokeDepth?: number
 	toolFactories: PackageRuntimeToolFactories
 	waitUntil?: (promise: Promise<unknown>) => void
+	/**
+	 * Internal workflow runner: skip the idempotency ledger so Cloudflare
+	 * Workflow step retries re-execute instead of replaying a cached timeout.
+	 */
+	ephemeral?: boolean
+	executorTimeoutMs?: number | null
 }): Promise<PackageInvocationResponse> {
 	const packageIdOrKodyId = input.request.packageIdOrKodyId.trim()
 	if (!packageIdOrKodyId) {
@@ -249,9 +255,10 @@ export async function invokePackageExportWithToolFactories(input: {
 	}
 	const exportName = normalizeExportName(input.request.exportName)
 	// External HTTP token invocations stay keyed-only: providers retry
-	// deliveries, so exactly-once is the point of this surface.
+	// deliveries, so exactly-once is the point of this surface. Workflow
+	// step retries pass ephemeral: true and run key-less instead.
 	const idempotencyKey = normalizeNullableString(input.request.idempotencyKey)
-	if (!idempotencyKey) {
+	if (!input.ephemeral && !idempotencyKey) {
 		return buildJsonErrorResponse({
 			status: 400,
 			code: 'missing_idempotency_key',
@@ -265,7 +272,7 @@ export async function invokePackageExportWithToolFactories(input: {
 			status: 403,
 			code: 'source_not_allowed',
 			message: 'This token is not allowed to invoke the requested source.',
-			idempotencyKey,
+			idempotencyKey: idempotencyKey ?? undefined,
 		})
 	}
 	const savedPackage = await resolveSavedPackage({
@@ -278,7 +285,7 @@ export async function invokePackageExportWithToolFactories(input: {
 			status: 404,
 			code: 'package_not_found',
 			message: buildSavedPackageNotFoundMessage(packageIdOrKodyId),
-			idempotencyKey,
+			idempotencyKey: idempotencyKey ?? undefined,
 		})
 	}
 	if (!tokenAllowsPackage({ token: input.token, savedPackage })) {
@@ -286,7 +293,7 @@ export async function invokePackageExportWithToolFactories(input: {
 			status: 403,
 			code: 'package_not_allowed',
 			message: 'This token is not allowed to invoke the requested package.',
-			idempotencyKey,
+			idempotencyKey: idempotencyKey ?? undefined,
 		})
 	}
 	if (!tokenAllowsExport({ token: input.token, exportName })) {
@@ -294,11 +301,11 @@ export async function invokePackageExportWithToolFactories(input: {
 			status: 403,
 			code: 'export_not_allowed',
 			message: `This token is not allowed to invoke export "${exportName}".`,
-			idempotencyKey,
+			idempotencyKey: idempotencyKey ?? undefined,
 		})
 	}
 
-	return await invokeSavedPackageModule({
+	const shared = {
 		env: input.env,
 		baseUrl: input.baseUrl,
 		actor: {
@@ -311,16 +318,25 @@ export async function invokePackageExportWithToolFactories(input: {
 		savedPackage,
 		invocationName: exportName,
 		moduleSelector: {
-			kind: 'export',
+			kind: 'export' as const,
 			exportName,
 		},
 		params: input.request.params,
-		idempotencyKey,
 		source,
 		topic,
-		notFoundCode: 'export_not_found',
+		notFoundCode: 'export_not_found' as const,
 		runtimeInvokeDepth: input.runtimeInvokeDepth ?? 0,
 		toolFactories: input.toolFactories,
 		waitUntil: input.waitUntil,
+		executorTimeoutMs: input.executorTimeoutMs,
+	}
+
+	if (input.ephemeral || !idempotencyKey) {
+		return await runSavedPackageModuleEphemeral(shared)
+	}
+
+	return await invokeSavedPackageModule({
+		...shared,
+		idempotencyKey,
 	})
 }

--- a/packages/worker/src/package-invocations/idempotent-module-invocation.ts
+++ b/packages/worker/src/package-invocations/idempotent-module-invocation.ts
@@ -56,6 +56,7 @@ export async function invokeSavedPackageModule(input: {
 	preloadedModuleArtifact?: Awaited<
 		ReturnType<typeof ensureModuleArtifact>
 	> | null
+	executorTimeoutMs?: number | null
 }) {
 	return await withAccountWriteLease({
 		db: input.env.APP_DB,
@@ -284,6 +285,7 @@ export async function invokeSavedPackageModule(input: {
 				toolFactories: input.toolFactories,
 				waitUntil: input.waitUntil,
 				preloadedModuleArtifact: input.preloadedModuleArtifact,
+				executorTimeoutMs: input.executorTimeoutMs,
 			})
 			switch (outcome.kind) {
 				case 'artifact-unavailable': {

--- a/packages/worker/src/package-invocations/module-execution.ts
+++ b/packages/worker/src/package-invocations/module-execution.ts
@@ -76,6 +76,12 @@ export type SavedPackageModuleRunInput = {
 	preloadedModuleArtifact?: Awaited<
 		ReturnType<typeof ensureModuleArtifact>
 	> | null
+	/**
+	 * Sandbox wall-clock budget. Defaults to the execute/export 90s cap when
+	 * omitted. Workflow invocations pass a longer budget so they can use the
+	 * full Cloudflare Workflow step window.
+	 */
+	executorTimeoutMs?: number | null
 }
 
 export async function runSavedPackageModuleOnce(
@@ -160,6 +166,7 @@ export async function runSavedPackageModuleOnce(
 			},
 			input.params,
 			{
+				executorTimeoutMs: input.executorTimeoutMs,
 				// No ambient `storage` binding: package code reaches its bucket via
 				// `packageStorage()` (granted through packageContext below). Legacy
 				// ambient use gets the structured runtime_helper_unbound hint.

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -100,6 +100,14 @@ export async function invokePackageExport(input: {
 	request: PackageInvocationRequest
 	runtimeInvokeDepth?: number
 	waitUntil?: (promise: Promise<unknown>) => void
+	/**
+	 * Skip the idempotency ledger and run key-less. Required for Cloudflare
+	 * Workflow step retries: reusing a keyed timeout/error would replay the
+	 * failure in milliseconds instead of re-executing.
+	 */
+	ephemeral?: boolean
+	/** Sandbox wall-clock budget; omit for the default ~90s export cap. */
+	executorTimeoutMs?: number | null
 }): Promise<PackageInvocationResponse> {
 	return await invokePackageExportWithToolFactories({
 		...input,

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -6,6 +6,7 @@ import {
 	DynamicCallableWorkflowBase,
 	createDynamicCallableWorkflow,
 	listWorkflowRunsForUser,
+	workflowExecutorTimeoutMs,
 } from './package-workflows.ts'
 
 const invocationMocks = vi.hoisted(() => ({
@@ -381,7 +382,10 @@ test('DynamicCallableWorkflowBase executes queued inline code and records comple
 			}),
 			'export default async function main(p){ return { ok: true, p }; }',
 			{ greeting: 'hello' },
-			{ packageContext: null },
+			{
+				packageContext: null,
+				executorTimeoutMs: workflowExecutorTimeoutMs,
+			},
 		)
 		expect(db.workflowRuns.get(created.id)).toMatchObject({
 			status: 'complete',
@@ -540,7 +544,10 @@ test('package-created inline workflows retain package secret authorization conte
 		}),
 		expect.any(String),
 		undefined,
-		{ packageContext },
+		{
+			packageContext,
+			executorTimeoutMs: workflowExecutorTimeoutMs,
+		},
 	)
 })
 
@@ -597,7 +604,10 @@ test('DynamicCallableWorkflowBase restores attached remote connectors for inline
 		expect.objectContaining({ remoteConnectors }),
 		expect.any(String),
 		undefined,
-		{ packageContext: null },
+		{
+			packageContext: null,
+			executorTimeoutMs: workflowExecutorTimeoutMs,
+		},
 	)
 
 	const packageBinding = createStatefulWorkflowBinding()
@@ -646,6 +656,11 @@ test('DynamicCallableWorkflowBase restores attached remote connectors for inline
 	expect(invocationMocks.invokePackageExport).toHaveBeenCalledWith(
 		expect.objectContaining({
 			token: expect.objectContaining({ remoteConnectors }),
+			ephemeral: true,
+			executorTimeoutMs: workflowExecutorTimeoutMs,
+			request: expect.objectContaining({
+				idempotencyKey: null,
+			}),
 		}),
 	)
 })

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -141,6 +141,13 @@ const workflowStepDoConfig: WorkflowStepDoConfig = {
 	timeout: '5 minutes',
 }
 
+/**
+ * Sandbox budget for workflow-invoked package exports / inline code.
+ * Kept under the Cloudflare Workflow step timeout (`5 minutes`) so status
+ * bookkeeping still has headroom after the sandbox returns.
+ */
+export const workflowExecutorTimeoutMs = 270_000
+
 type DynamicCallableWorkflowStep = {
 	do(
 		name: string,
@@ -1166,6 +1173,10 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 				env: this.env,
 				userId: payload.userId,
 			})
+			// Ephemeral + raised timeout: Workflow step.do already caches
+			// successful results. Keyed invoke would replay a sandbox timeout
+			// on retry (~ms) instead of re-executing; the default 90s export
+			// cap is also below the 5-minute step window.
 			const response = await invokePackageExport({
 				env: this.env,
 				baseUrl: getAppBaseUrl({
@@ -1186,10 +1197,12 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 					packageIdOrKodyId: payload.packageId,
 					exportName: payload.exportName,
 					params: payload.params,
-					idempotencyKey: payload.idempotencyKey,
+					idempotencyKey: null,
 					source: packageWorkflowInvocationSource,
 					topic: payload.workflowName,
 				},
+				ephemeral: true,
+				executorTimeoutMs: workflowExecutorTimeoutMs,
 			})
 			if (response.status < 200 || response.status >= 300) {
 				throwWorkflowInvocationFailure(response)
@@ -1277,6 +1290,7 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 				payload.params,
 				{
 					packageContext: payload.packageContext,
+					executorTimeoutMs: workflowExecutorTimeoutMs,
 				},
 			)
 			logs = result.logs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Workflow-invoked package exports were still hitting the default ~90s sandbox cap, and Cloudflare Workflow step retries reused the same package-invocation idempotency key — so a timeout was cached and “retried” in ~300ms without re-executing. That is what kept today’s nightly release stuck after the prepare phase succeeded.

## Fix

- Run workflow package exports **ephemerally** (no invocation ledger), so step retries actually re-run
- Raise the workflow sandbox budget to **270s** (under the 5-minute Workflow step timeout)
- Apply the same budget to inline workflow code
- Document the behavior in `docs/use/workflows.md`

## Companion package change

`@kentcdodds/release` was also updated (published separately): prepare → write (notes only, no research) → publish (X + GitHub + Discord), so each phase fits a sandbox even before this platform fix deploys.

## Test plan

- [x] `vitest` package-workflows unit tests updated/passing
- [ ] Re-run `nightly-release` after deploy and confirm `vYYYY.MM.DD` publishes on a busy night
- [ ] Confirm a deliberate workflow export timeout retries with a fresh sandbox (not a ~ms cached error)

<details>
<summary>System recap</summary>

### At a glance
- **Overall:** extends · **Risk:** Medium
- **Primitives:** workflows, package-runtime
- **What changed:** Workflow exports no longer share execute’s 90s cap or keyed timeout replay on step retry.

### Overview
Nightly release (and any long workflow export) could die at ~90s, then “retry” by replaying the cached timeout. This aligns the sandbox with the Workflow step window and makes retries real re-executions.

### System impact
| Primitive | Classification | Risk | What changed |
| --- | --- | --- | --- |
| workflows | extends | Medium | Ephemeral invoke + 270s sandbox for package/inline workflow bodies |
| package-runtime | extends | Medium | Invocation path accepts `ephemeral` / `executorTimeoutMs` for workflow runner |

### Flows
```mermaid
flowchart LR
  job[Package job] --> wf[workflows.create]
  wf --> step[Workflow step.do]
  step -->|ephemeral + 270s| export[Package export sandbox]
  step -->|on timeout| retry[Step retry re-executes]
  retry --> export
```

### Docs
- `docs/use/workflows.md` — documents longer budget and key-less retries

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79d1e099-1243-4162-a3eb-f15355b61fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d1e099-1243-4162-a3eb-f15355b61fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow-invoked package exports and inline workflow code now have an extended execution window of approximately 4.5 minutes.
  * Added support for ephemeral invocations, enabling retries to re-execute without relying on cached timeout results.
  * Added configurable execution timeouts for package invocations.

* **Documentation**
  * Clarified workflow invocation timing, retry behavior, and recommended workflow inspection steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->