### PR TITLE
fix(storage): stop packages.invoke hangs from read SQL entitlement fan-out

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -271,12 +271,13 @@ Rules:
   `packageStorage().sql` statements (`SELECT` / `EXPLAIN` / schema `PRAGMA`)
   skip this fan-out even when the helper marks the call writable. Mutating SQL
   and `storage.set` in one sandbox share a per-run baseline cache so repeated
-  writes do not rescan every bucket. Each estimate RPC is bounded (~2s) and
-  fails closed on timeout. The counter intentionally does **not** attempt to
-  scan Cloudflare Artifacts repository contents, KV snapshot/bundle bodies, R2
-  object listings beyond `email_messages.raw_size`, or Vectorize: those stores
-  either lack reliable byte metadata or are derived from D1 and are documented
-  in `data-storage.md`.
+  writes do not rescan every bucket. Each estimate read waits at most ~2s via
+  `Promise.race` and fails closed for the caller; the underlying DO RPC is not
+  cancelled if the runtime keeps it running. The counter intentionally does
+  **not** attempt to scan Cloudflare Artifacts repository contents, KV
+  snapshot/bundle bodies, R2 object listings beyond `email_messages.raw_size`,
+  or Vectorize: those stores either lack reliable byte metadata or are derived
+  from D1 and are documented in `data-storage.md`.
 
 ### Concurrency
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -264,9 +264,15 @@ Rules:
   records in the per-user `RunLog` Durable Object are intentionally **excluded**
   from the quota — they are observability history, not user content.
   StorageRunner Durable Object buckets expose their own `estimatedBytes`; write
-  chokepoints that target a specific bucket pass `getCurrent` as
-  `D1 estimate + target bucket estimate` and `requested` as the candidate
-  payload size when known. The counter intentionally does **not** attempt to
+  chokepoints pass `getCurrent` as
+  `D1 estimate + sum of inventoried StorageRunner bucket estimates` (plus the
+  target bucket when its inventory row has not landed yet) and `requested` as
+  the candidate payload size when known. Pure read-only `storage.sql` /
+  `packageStorage().sql` statements (`SELECT` / `EXPLAIN` / schema `PRAGMA`)
+  skip this fan-out even when the helper marks the call writable. Mutating SQL
+  and `storage.set` in one sandbox share a per-run baseline cache so repeated
+  writes do not rescan every bucket. Each estimate RPC is bounded (~2s) and
+  fails closed on timeout. The counter intentionally does **not** attempt to
   scan Cloudflare Artifacts repository contents, KV snapshot/bundle bodies, R2
   object listings beyond `email_messages.raw_size`, or Vectorize: those stores
   either lack reliable byte metadata or are derived from D1 and are documented

--- a/packages/worker/src/mcp/capabilities/storage/storage-query.ts
+++ b/packages/worker/src/mcp/capabilities/storage/storage-query.ts
@@ -5,6 +5,7 @@ import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
 	assertStorageRunnerWriteWithinEntitlement,
+	isReadOnlyStorageSqlQuery,
 	storageRunnerRpc,
 } from '#worker/storage-runner.ts'
 import { estimateEntitlementStorageSqlWriteBytes } from '#worker/entitlements/service.ts'
@@ -51,7 +52,7 @@ export const storageQueryCapability = defineDomainCapability(
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
 			const writable = args.writable ?? false
-			if (writable) {
+			if (writable && !isReadOnlyStorageSqlQuery(args.query)) {
 				await assertStorageRunnerWriteWithinEntitlement({
 					env: ctx.env,
 					userId: user.userId,

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -11,6 +11,7 @@ import {
 import {
 	createPackageStorageHelperPrelude,
 	createPackageStorageKodyTools,
+	createStorageBytesEntitlementRunCache,
 	createStorageKodyTools,
 	createStorageHelperPrelude,
 } from '#worker/storage-runner.ts'
@@ -527,6 +528,7 @@ const runtimeHelperManifest: Array<RuntimeHelperManifestEntry> = [
 				email: context.callerContext.user?.email,
 				storageId: storageTools.storageId,
 				writable: storageTools.writable,
+				entitlementCache: createStorageBytesEntitlementRunCache(),
 			})
 		},
 	},

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -33,6 +33,8 @@ import {
 	assertStorageRunnerWriteWithinEntitlement,
 	buildPackageStorageId,
 	createPackageStorageAccessDeniedMessage,
+	createStorageBytesEntitlementRunCache,
+	isReadOnlyStorageSqlQuery,
 	storageRunnerRpc,
 } from '#worker/storage-runner.ts'
 import {
@@ -846,6 +848,9 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		})
 	}
 
+	private readonly storageBytesEntitlementCache =
+		createStorageBytesEntitlementRunCache()
+
 	private async assertStorageWriteAllowed(input: {
 		storageId: string
 		requested?: number
@@ -856,6 +861,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			email: this.ctx.props.email,
 			storageId: input.storageId,
 			requested: input.requested,
+			cache: this.storageBytesEntitlementCache,
 		})
 	}
 
@@ -1081,7 +1087,9 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		params?: Array<unknown>
 		writable: boolean
 	}) {
-		if (input.writable) {
+		// package app bridges always mark packageStorage SQL writable, so skip
+		// the all-bucket fan-out for pure SELECT/EXPLAIN/PRAGMA statements.
+		if (input.writable && !isReadOnlyStorageSqlQuery(input.query)) {
 			await this.assertStorageWriteAllowed({
 				storageId: input.storageId,
 				requested: estimateEntitlementStorageSqlWriteBytes({

--- a/packages/worker/src/storage-runner.read-sql-entitlement.node.test.ts
+++ b/packages/worker/src/storage-runner.read-sql-entitlement.node.test.ts
@@ -1,0 +1,181 @@
+import { expect, test, vi } from 'vitest'
+import type * as EntitlementsService from '#worker/entitlements/service.ts'
+
+const mockModule = vi.hoisted(() => ({
+	listUserStorageBucketIds: vi.fn(async () => ['bucket-a', 'bucket-b']),
+	readUserD1StorageBytes: vi.fn(async () => 0),
+	registerStorageBucket: vi.fn(),
+	getEstimatedBytes: vi.fn(async () => ({ estimatedBytes: 64 })),
+}))
+
+vi.mock('#worker/storage-buckets/service.ts', () => ({
+	listUserStorageBucketIds: (...args: Array<unknown>) =>
+		mockModule.listUserStorageBucketIds(...args),
+	registerStorageBucket: (...args: Array<unknown>) =>
+		mockModule.registerStorageBucket(...args),
+	storageBucketKindFromStorageId: (storageId: string) => {
+		if (storageId.startsWith('package:')) return 'package'
+		return 'unknown'
+	},
+	flushStorageBucketRegistrationsForTests: async () => undefined,
+	clearStorageBucketRegistrationDedupeForTests: () => undefined,
+	listPlatformStorageBuckets: async () => [],
+}))
+
+vi.mock('#worker/entitlements/service.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof EntitlementsService>()
+	return {
+		...actual,
+		readUserD1StorageBytes: (...args: Array<unknown>) =>
+			mockModule.readUserD1StorageBytes(...args),
+	}
+})
+
+const {
+	assertStorageRunnerWriteWithinEntitlement,
+	createStorageBytesEntitlementRunCache,
+	createStorageKodyTools,
+	isReadOnlyStorageSqlQuery,
+} = await import('#worker/storage-runner.ts')
+
+function createEstimateEnv() {
+	return {
+		APP_DB: {
+			prepare() {
+				throw new Error('APP_DB should not be queried when email is absent')
+			},
+		},
+		STORAGE_RUNNER: {
+			idFromName: (name: string) => name,
+			get: () => ({
+				getEstimatedBytes: () => mockModule.getEstimatedBytes(),
+				sqlQuery: async (input: {
+					query: string
+					params?: Array<unknown>
+					writable?: boolean
+				}) => ({
+					columns: [],
+					rows: [],
+					rowCount: 0,
+					rowsRead: 0,
+					rowsWritten: input.writable ? 1 : 0,
+				}),
+				getValue: async ({ key }: { key: string }) => ({
+					key,
+					value: null,
+				}),
+				setValue: async ({ key }: { key: string }) => ({
+					ok: true as const,
+					key,
+				}),
+				deleteValue: async () => ({
+					ok: true as const,
+					key: 'x',
+					deleted: true,
+				}),
+				clearStorage: async () => ({ ok: true as const }),
+				listValues: async () => ({
+					entries: [],
+					estimatedBytes: 0,
+					truncated: false,
+					nextStartAfter: null,
+					pageSize: 50,
+				}),
+			}),
+		},
+	} as unknown as Env
+}
+
+test('isReadOnlyStorageSqlQuery accepts single SELECT/EXPLAIN/PRAGMA only', () => {
+	expect(isReadOnlyStorageSqlQuery('SELECT 1')).toBe(true)
+	expect(isReadOnlyStorageSqlQuery('  explain query plan select 1')).toBe(true)
+	expect(isReadOnlyStorageSqlQuery('PRAGMA table_info(skills)')).toBe(true)
+	expect(isReadOnlyStorageSqlQuery('CREATE TABLE skills (id TEXT)')).toBe(false)
+	expect(
+		isReadOnlyStorageSqlQuery('SELECT 1; CREATE TABLE skills (id TEXT)'),
+	).toBe(false)
+	expect(isReadOnlyStorageSqlQuery('')).toBe(false)
+})
+
+test('writable storage_sql skips entitlement fan-out for read-only queries', async () => {
+	mockModule.getEstimatedBytes.mockClear()
+	mockModule.listUserStorageBucketIds.mockClear()
+	const tools = createStorageKodyTools({
+		env: createEstimateEnv(),
+		userId: 'user-1',
+		email: null,
+		storageId: 'package:skills',
+		writable: true,
+	})
+
+	await expect(
+		tools.storage_sql({
+			query: 'SELECT id FROM skills',
+			params: [],
+			writable: true,
+		}),
+	).resolves.toMatchObject({ rowCount: 0 })
+
+	expect(mockModule.listUserStorageBucketIds).not.toHaveBeenCalled()
+	expect(mockModule.getEstimatedBytes).not.toHaveBeenCalled()
+})
+
+test('writable storage_sql still enforces entitlement for mutating SQL', async () => {
+	mockModule.getEstimatedBytes.mockClear()
+	mockModule.listUserStorageBucketIds.mockClear()
+	const tools = createStorageKodyTools({
+		env: createEstimateEnv(),
+		userId: 'user-1',
+		email: null,
+		storageId: 'package:skills',
+		writable: true,
+	})
+
+	await expect(
+		tools.storage_sql({
+			query: 'CREATE TABLE IF NOT EXISTS skills (id TEXT)',
+			params: [],
+			writable: true,
+		}),
+	).resolves.toMatchObject({ rowsWritten: 1 })
+
+	expect(mockModule.listUserStorageBucketIds).toHaveBeenCalledTimes(1)
+	// Inventoried buckets plus the not-yet-registered target id.
+	expect(mockModule.getEstimatedBytes).toHaveBeenCalledTimes(3)
+})
+
+test('entitlement run cache pays the fan-out once across mutating writes', async () => {
+	mockModule.getEstimatedBytes.mockClear()
+	mockModule.listUserStorageBucketIds.mockClear()
+	const cache = createStorageBytesEntitlementRunCache()
+	const env = createEstimateEnv()
+
+	await assertStorageRunnerWriteWithinEntitlement({
+		env,
+		userId: 'user-1',
+		email: null,
+		storageId: 'package:skills',
+		requested: 10,
+		cache,
+	})
+	await assertStorageRunnerWriteWithinEntitlement({
+		env,
+		userId: 'user-1',
+		email: null,
+		storageId: 'package:skills',
+		requested: 10,
+		cache,
+	})
+	await assertStorageRunnerWriteWithinEntitlement({
+		env,
+		userId: 'user-1',
+		email: null,
+		storageId: 'package:skills',
+		requested: 10,
+		cache,
+	})
+
+	expect(mockModule.listUserStorageBucketIds).toHaveBeenCalledTimes(1)
+	expect(mockModule.getEstimatedBytes).toHaveBeenCalledTimes(3)
+	expect(cache.reservedBytes).toBe(30)
+})

--- a/packages/worker/src/storage-runner.read-sql-entitlement.node.test.ts
+++ b/packages/worker/src/storage-runner.read-sql-entitlement.node.test.ts
@@ -179,3 +179,37 @@ test('entitlement run cache pays the fan-out once across mutating writes', async
 	expect(mockModule.getEstimatedBytes).toHaveBeenCalledTimes(3)
 	expect(cache.reservedBytes).toBe(30)
 })
+
+test('entitlement run cache drops a rejected baseline so later writes retry', async () => {
+	mockModule.listUserStorageBucketIds.mockResolvedValue(['bucket-a'])
+	mockModule.getEstimatedBytes
+		.mockRejectedValueOnce(new Error('transient estimate failure'))
+		.mockRejectedValueOnce(new Error('transient estimate failure'))
+		.mockResolvedValue({ estimatedBytes: 64 })
+	const cache = createStorageBytesEntitlementRunCache()
+	const env = createEstimateEnv()
+
+	await expect(
+		assertStorageRunnerWriteWithinEntitlement({
+			env,
+			userId: 'user-1',
+			email: null,
+			storageId: 'bucket-a',
+			requested: 1,
+			cache,
+		}),
+	).rejects.toThrow(/could not be read/)
+	expect(cache.baseline).toBeNull()
+
+	await expect(
+		assertStorageRunnerWriteWithinEntitlement({
+			env,
+			userId: 'user-1',
+			email: null,
+			storageId: 'bucket-a',
+			requested: 1,
+			cache,
+		}),
+	).resolves.toBeUndefined()
+	expect(cache.reservedBytes).toBe(1)
+})

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -779,13 +779,25 @@ export async function assertStorageRunnerWriteWithinEntitlement(input: {
 }) {
 	const cache = input.cache
 	if (cache) {
+		const beginBaselineRead = (storageId: string) => {
+			const pending = readStorageBytesEntitlementBaseline({
+				env: input.env,
+				userId: input.userId,
+				storageId,
+			}).catch((error: unknown) => {
+				// Do not memoize a transient failure for the whole run — the
+				// uncached path recovers on retry; the cache must too.
+				if (cache.baseline === pending) {
+					cache.baseline = null
+				}
+				throw error
+			})
+			cache.baseline = pending
+			return pending
+		}
 		const loadBaseline = () => {
 			if (!cache.baseline) {
-				cache.baseline = readStorageBytesEntitlementBaseline({
-					env: input.env,
-					userId: input.userId,
-					storageId: input.storageId,
-				})
+				return beginBaselineRead(input.storageId)
 			}
 			return cache.baseline
 		}
@@ -793,12 +805,7 @@ export async function assertStorageRunnerWriteWithinEntitlement(input: {
 		if (!baseline.storageIds.has(input.storageId)) {
 			// A write targeted a bucket missing from the first scan (registration
 			// race or first touch). Recompute so the new bucket is counted.
-			cache.baseline = readStorageBytesEntitlementBaseline({
-				env: input.env,
-				userId: input.userId,
-				storageId: input.storageId,
-			})
-			baseline = await cache.baseline
+			baseline = await beginBaselineRead(input.storageId)
 		}
 		await assertWithinStorageBytesEntitlement({
 			db: input.env.APP_DB,

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -21,12 +21,48 @@ const maxConcurrentStorageEstimateReads = 16
 /** One bounded pause before re-reading a failed estimate chunk. */
 export const storageEstimateReadRetryDelayMs = 150
 /**
+ * Bound each StorageRunner `getEstimatedBytes` RPC so one hung DO cannot own
+ * the whole sandbox deadline (~90s). Fail closed after this budget.
+ */
+export const storageEstimateReadTimeoutMs = 2_000
+/**
  * `ctx.storage.sql.databaseSize` for a never-written StorageRunner DO (one
  * SQLite page). Audit/entitlement callers that need a "has user data" signal
  * must compare against this floor rather than treating any positive size as
  * non-empty.
  */
 export const emptyStorageRunnerEstimatedBytes = 4096
+
+const readOnlyStorageSqlPrefixes = [
+	'select',
+	'explain',
+	'pragma table_info(',
+	'pragma index_list(',
+	'pragma index_info(',
+	'pragma database_list',
+	'pragma table_list',
+] as const
+
+/**
+ * Per-run memo for storage-byte entitlement totals. The first mutating write
+ * in a sandbox pays the all-bucket estimate fan-out; later writes reuse that
+ * baseline and accumulate `reservedBytes` so the run still accounts for its
+ * own earlier accepted writes without rescanning every Durable Object.
+ */
+export type StorageBytesEntitlementRunCache = {
+	baseline: Promise<{
+		bytes: number
+		storageIds: ReadonlySet<string>
+	}> | null
+	reservedBytes: number
+}
+
+export function createStorageBytesEntitlementRunCache(): StorageBytesEntitlementRunCache {
+	return {
+		baseline: null,
+		reservedBytes: 0,
+	}
+}
 
 type StorageEntry = {
 	key: string
@@ -319,33 +355,68 @@ function hasMultipleSqlStatements(query: string) {
 	return false
 }
 
+/**
+ * True when `query` is a single SELECT / EXPLAIN / schema PRAGMA that the
+ * read-only storage.sql contract accepts. Mutating SQL (and multi-statement
+ * batches) return false even when the caller passed `writable: true`.
+ *
+ * Used to skip the all-bucket storage-byte entitlement fan-out on pure reads:
+ * `packageStorage().sql(...)` always marks calls writable so CREATE/INSERT
+ * work, but SELECT-heavy package exports were paying that fan-out on every
+ * query and timing out under large bucket inventories.
+ */
+export function isReadOnlyStorageSqlQuery(query: string) {
+	const trimmed = query.trim()
+	if (!trimmed || hasMultipleSqlStatements(trimmed)) {
+		return false
+	}
+	const normalized = trimmed.toLowerCase()
+	return readOnlyStorageSqlPrefixes.some((prefix) =>
+		normalized.startsWith(prefix),
+	)
+}
+
 function assertSqlAllowed(query: string, writable: boolean | undefined) {
 	const trimmed = query.trim()
 	if (!trimmed) {
 		throw new Error('storage.sql requires a non-empty query.')
 	}
 	if (writable) return trimmed
-	if (hasMultipleSqlStatements(trimmed)) {
+	if (!isReadOnlyStorageSqlQuery(trimmed)) {
 		throw new Error(
 			'Read-only storage.sql only allows a single SELECT, EXPLAIN, or schema PRAGMA statement. Pass writable: true to allow multi-statement or mutating queries.',
 		)
 	}
-	const normalized = trimmed.toLowerCase()
-	const allowedReadOnlyPrefixes = [
-		'select',
-		'explain',
-		'pragma table_info(',
-		'pragma index_list(',
-		'pragma index_info(',
-		'pragma database_list',
-		'pragma table_list',
-	] as const
-	if (allowedReadOnlyPrefixes.some((prefix) => normalized.startsWith(prefix))) {
-		return trimmed
+	return trimmed
+}
+
+async function withStorageEstimateReadTimeout<T>(
+	read: () => Promise<T>,
+	storageId: string,
+): Promise<T> {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			read(),
+			new Promise<never>((_resolve, reject) => {
+				timeoutId = setTimeout(() => {
+					reject(
+						createStorageEstimateReadError({
+							storageId,
+							attempts: 1,
+							cause: new Error(
+								`Storage estimate read timed out after ${storageEstimateReadTimeoutMs}ms.`,
+							),
+						}),
+					)
+				}, storageEstimateReadTimeoutMs)
+			}),
+		])
+	} finally {
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId)
+		}
 	}
-	throw new Error(
-		'Read-only storage.sql only allows a single SELECT, EXPLAIN, or schema PRAGMA statement. Pass writable: true to allow multi-statement or mutating queries.',
-	)
 }
 
 function cursorToSqlResult(
@@ -582,11 +653,15 @@ async function readStorageEstimateChunkWithRetry(input: {
 	storageIds: Array<string>
 }): Promise<Array<StorageEstimateResult>> {
 	const readOne = (storageId: string) =>
-		storageRunnerRpc({
-			env: input.env,
-			userId: input.userId,
+		withStorageEstimateReadTimeout(
+			() =>
+				storageRunnerRpc({
+					env: input.env,
+					userId: input.userId,
+					storageId,
+				}).getEstimatedBytes(),
 			storageId,
-		}).getEstimatedBytes()
+		)
 
 	// Wait for every first-attempt read to settle before retrying so a fast
 	// rejection cannot overlap still-pending peers and exceed the fan-out cap.
@@ -640,59 +715,115 @@ async function readStorageEstimateChunkWithRetry(input: {
 	})
 }
 
+async function readStorageBytesEntitlementBaseline(input: {
+	env: Env
+	userId: string
+	storageId: string
+}) {
+	const [d1Bytes, registeredStorageIds] = await Promise.all([
+		readUserD1StorageBytes({
+			db: input.env.APP_DB,
+			userId: input.userId,
+		}),
+		listUserStorageBucketIds({
+			env: input.env,
+			userId: input.userId,
+		}),
+	])
+	// Registration is asynchronous, so include the bucket being written even
+	// when its inventory row has not landed yet. The Set avoids double-counting
+	// once it is registered. Estimate reads are batched to cap concurrent DO
+	// fan-out; total work remains O(bucket count) so every inventoried bucket is
+	// counted exactly. Large inventories are expected to stay rare; callers that
+	// issue many mutating SQL statements in one sandbox should pass a run cache
+	// so only the first write pays this scan.
+	const storageIds = [...new Set([...registeredStorageIds, input.storageId])]
+	let durableObjectBytes = 0
+	for (
+		let offset = 0;
+		offset < storageIds.length;
+		offset += maxConcurrentStorageEstimateReads
+	) {
+		const chunkIds = storageIds.slice(
+			offset,
+			offset + maxConcurrentStorageEstimateReads,
+		)
+		const estimates = await readStorageEstimateChunkWithRetry({
+			env: input.env,
+			userId: input.userId,
+			storageIds: chunkIds,
+		})
+		durableObjectBytes += estimates.reduce(
+			(total, estimate) => total + estimate.estimatedBytes,
+			0,
+		)
+	}
+	return {
+		bytes: d1Bytes + durableObjectBytes,
+		storageIds: new Set(storageIds),
+	}
+}
+
 export async function assertStorageRunnerWriteWithinEntitlement(input: {
 	env: Env
 	userId: string
 	email: string | null | undefined
 	storageId: string
 	requested?: number
+	/**
+	 * Optional per-sandbox memo. When set, the expensive all-bucket estimate
+	 * runs once; later asserts reuse the baseline and accumulate reserved
+	 * bytes from earlier accepted writes in this run.
+	 */
+	cache?: StorageBytesEntitlementRunCache | null
 }) {
+	const cache = input.cache
+	if (cache) {
+		const loadBaseline = () => {
+			if (!cache.baseline) {
+				cache.baseline = readStorageBytesEntitlementBaseline({
+					env: input.env,
+					userId: input.userId,
+					storageId: input.storageId,
+				})
+			}
+			return cache.baseline
+		}
+		let baseline = await loadBaseline()
+		if (!baseline.storageIds.has(input.storageId)) {
+			// A write targeted a bucket missing from the first scan (registration
+			// race or first touch). Recompute so the new bucket is counted.
+			cache.baseline = readStorageBytesEntitlementBaseline({
+				env: input.env,
+				userId: input.userId,
+				storageId: input.storageId,
+			})
+			baseline = await cache.baseline
+		}
+		await assertWithinStorageBytesEntitlement({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			email: input.email,
+			requested: input.requested,
+			getCurrent: async () => baseline.bytes + cache.reservedBytes,
+		})
+		cache.reservedBytes += input.requested ?? 0
+		return
+	}
+
 	await assertWithinStorageBytesEntitlement({
 		db: input.env.APP_DB,
 		userId: input.userId,
 		email: input.email,
 		requested: input.requested,
-		getCurrent: async () => {
-			const [d1Bytes, registeredStorageIds] = await Promise.all([
-				readUserD1StorageBytes({
-					db: input.env.APP_DB,
-					userId: input.userId,
-				}),
-				listUserStorageBucketIds({
+		getCurrent: async () =>
+			(
+				await readStorageBytesEntitlementBaseline({
 					env: input.env,
 					userId: input.userId,
-				}),
-			])
-			// Registration is asynchronous, so include the bucket being written even
-			// when its inventory row has not landed yet. The Set avoids double-counting
-			// once it is registered. Estimate reads are batched to cap concurrent DO
-			// fan-out; total work remains O(bucket count) so every inventoried bucket is
-			// counted exactly. Bucket inventories are expected to remain small.
-			const storageIds = [
-				...new Set([...registeredStorageIds, input.storageId]),
-			]
-			let durableObjectBytes = 0
-			for (
-				let offset = 0;
-				offset < storageIds.length;
-				offset += maxConcurrentStorageEstimateReads
-			) {
-				const chunkIds = storageIds.slice(
-					offset,
-					offset + maxConcurrentStorageEstimateReads,
-				)
-				const estimates = await readStorageEstimateChunkWithRetry({
-					env: input.env,
-					userId: input.userId,
-					storageIds: chunkIds,
+					storageId: input.storageId,
 				})
-				durableObjectBytes += estimates.reduce(
-					(total, estimate) => total + estimate.estimatedBytes,
-					0,
-				)
-			}
-			return d1Bytes + durableObjectBytes
-		},
+			).bytes,
 	})
 }
 
@@ -702,12 +833,27 @@ export function createStorageKodyTools(input: {
 	email?: string | null
 	storageId: string
 	writable: boolean
+	/**
+	 * Optional per-sandbox memo shared across storage tool instances so many
+	 * mutating SQL/set calls do not rescan every inventoried bucket.
+	 */
+	entitlementCache?: StorageBytesEntitlementRunCache | null
 }) {
 	const runner = storageRunnerRpc({
 		env: input.env,
 		userId: input.userId,
 		storageId: input.storageId,
 	})
+	const assertWriteWithinEntitlement = async (requested?: number) => {
+		await assertStorageRunnerWriteWithinEntitlement({
+			env: input.env,
+			userId: input.userId,
+			email: input.email,
+			storageId: input.storageId,
+			requested,
+			cache: input.entitlementCache,
+		})
+	}
 	return {
 		storage_get: async (args: unknown) => {
 			const key =
@@ -751,17 +897,16 @@ export function createStorageKodyTools(input: {
 				: false
 			const query = typeof payload.query === 'string' ? payload.query : ''
 			const params = Array.isArray(payload.params) ? payload.params : undefined
-			if (writable) {
-				await assertStorageRunnerWriteWithinEntitlement({
-					env: input.env,
-					userId: input.userId,
-					email: input.email,
-					storageId: input.storageId,
-					requested: estimateEntitlementStorageSqlWriteBytes({
+			// packageStorage()/writable helpers always pass writable:true so
+			// CREATE/INSERT are allowed, but pure reads must not pay the
+			// all-bucket entitlement fan-out.
+			if (writable && !isReadOnlyStorageSqlQuery(query)) {
+				await assertWriteWithinEntitlement(
+					estimateEntitlementStorageSqlWriteBytes({
 						query,
 						params,
 					}),
-				})
+				)
 			}
 			return await runner.sqlQuery({
 				query,
@@ -778,12 +923,8 @@ export function createStorageKodyTools(input: {
 								: {}
 						const key = typeof payload.key === 'string' ? payload.key : ''
 						const existing = await runner.getValue({ key })
-						await assertStorageRunnerWriteWithinEntitlement({
-							env: input.env,
-							userId: input.userId,
-							email: input.email,
-							storageId: input.storageId,
-							requested: estimateEntitlementStorageEntryByteDelta({
+						await assertWriteWithinEntitlement(
+							estimateEntitlementStorageEntryByteDelta({
 								next: {
 									key,
 									value: payload.value,
@@ -796,7 +937,7 @@ export function createStorageKodyTools(input: {
 												value: existing.value,
 											},
 							}),
-						})
+						)
 						return await runner.setValue({
 							key,
 							value: payload.value,
@@ -860,6 +1001,10 @@ export function createPackageStorageKodyTools(input: {
 	email?: string | null
 	grantedPackageIds: ReadonlySet<string>
 }) {
+	// One cache for the whole sandbox so nested packageStorage() SQL across
+	// granted packages (and repeated CREATE/INSERT in one export) does not
+	// rescan every inventoried bucket on each statement.
+	const entitlementCache = createStorageBytesEntitlementRunCache()
 	const createWritableStorageTools = (packageId: string) => {
 		const {
 			storage_get,
@@ -874,6 +1019,7 @@ export function createPackageStorageKodyTools(input: {
 			email: input.email,
 			storageId: buildPackageStorageId(packageId),
 			writable: true,
+			entitlementCache,
 		})
 		if (!storage_set || !storage_delete || !storage_clear) {
 			// createStorageKodyTools only omits these when writable is false.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production nested `packages.invoke` looked hung (~20–90s / MCP timeouts) after the keyless-invoke deploy. The lean invoke path itself is fine (~400ms for a no-storage export); the cost was **`packageStorage().sql` paying the all-bucket storage-byte entitlement fan-out on every statement**, including `SELECT`.

`packageStorage()` always marks SQL `writable: true` so CREATE/INSERT work. With a large bucket inventory (dozens of package DOs), SELECT-heavy exports like `@kentcdodds/skills` `skill-list` rescanned every bucket on each query — and a hung estimate RPC could own the whole ~90s sandbox deadline.

## Fix

- Skip entitlement checks for read-only SQL (`SELECT` / `EXPLAIN` / schema `PRAGMA`) even when the helper marks the call writable
- Share a per-sandbox entitlement baseline cache so repeated mutating SQL/`set` does not rescan every bucket
- Drop a rejected baseline from the cache so later writes can retry
- Bound each estimate caller wait (~2s) and fail closed (underlying DO RPC is not cancelled)
- Same behavior in package-app bridges and `storage_query`
- Docs updated to match the real all-bucket write accounting

## Evidence

| Probe | Before | Expected after deploy |
| --- | --- | --- |
| `packages.invoke({ kodyId: 'skills', exportName: '.' })` (no storage) | ~400ms | unchanged |
| `packages.invoke` / static `skill-list` | ~20–90s timeout | should drop toward sub-second / low seconds (CREATE still pays one cached fan-out) |

## Test plan

- [x] Node unit tests for read-only skip + run cache + poisoned-baseline retry
- [x] Existing entitlement node tests still pass
- [ ] After merge/deploy: re-time `packages.invoke` `skills/skill-list` in prod

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/fix-packages-invoke-hang-2035`

**Classification:** extends — changes durable-storage write-entitlement behavior for SQL paths (reads skip fan-out; mutating writes share a per-run cache; estimate waits are time-bounded).

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `durable-storage` | assistant | extends — read-only SQL skips all-bucket entitlement fan-out; per-run baseline cache; estimate wait timeout |
| `package-apps` | assistant | extends — package-app storage SQL uses the same read-skip + cache |
| `mcp-server` | surfaces | composes — ambient storage helper wires the run cache |

### System map

Nested package invoke was stalling on storage-byte entitlement scans during ordinary SELECTs; reads now bypass that path.

```mermaid
flowchart LR
  exec[execute / packages.invoke] --> pkg[package export sandbox]
  pkg --> sql["packageStorage().sql"]
  sql -->|SELECT / EXPLAIN / PRAGMA| run[StorageRunner DO]
  sql -->|mutating SQL| ent[storage_bytes entitlement]
  ent -->|first write in run| fanout[all-bucket estimate fan-out]
  ent -->|later writes| cache[per-run baseline cache]
  fanout --> run
```

**Legend:** amber = extended entitlement behavior on durable-storage / package-apps · gray = unchanged invoke path.

### Invariants

- Per-user isolation unchanged: estimates still scoped by `userId`
- Mutating SQL and `storage.set` still enforce `storage_bytes` before write
- Estimate failures remain fail-closed; cached baseline rejections are not sticky

### Docs

- `docs/contributing/architecture/entitlements.md` — documents all-bucket write accounting, read-skip, run cache, and estimate wait timeout

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85f3b9bd-8b49-4402-9d57-eacdfb012035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85f3b9bd-8b49-4402-9d57-eacdfb012035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Read-only `storage.sql` statements (`SELECT`, `EXPLAIN`, `PRAGMA`/schema-style) no longer trigger write quota/entitlement checks even when marked writable.
  * Storage byte entitlement calculations are now cached and reused across related write operations to better reflect cumulative writes.
  * Storage capacity/byte estimates are time-limited and will safely deny writes if an estimate can’t be completed.

* **Documentation**
  * Updated entitlement documentation to clarify timeout behavior, “fail closed” semantics, and supported/unsupported storage sources.

* **Tests**
  * Added coverage for entitlement cache invalidation when baseline calculation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->