### PR TITLE
Add the 0002-static-first-invocation package codemod

### DIFF
--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -123,6 +123,27 @@ The first shipped codemod migrates deprecated ambient `storage` imports from
   and `packageStorage()` use different bucket identities on those execution
   surfaces, so automatic rewrite risks silent data repointing.
 
+### `0002-static-first-invocation`
+
+Migrates the deprecated dynamic invocation surface to the static-first two-rule
+model (see
+[`architecture/invocation-overhead-guardrails.md`](./architecture/invocation-overhead-guardrails.md)):
+
+- Rewrites `packages.invokeChecked(...)` member calls (including
+  `packages?.invokeChecked`) to `packages.invoke(...)` via AST range replacement
+  — identical input shape; `packages.invoke` is always contract-checked and
+  key-less calls take the lean/ephemeral path.
+- Emits `needsManual` for `packages.check(...)` (its contract return value has
+  no mechanical equivalent — `invoke` checks internally) and for literal dynamic
+  `import("kody:@...")` (namespace semantics and `kody.dependencies` manifest
+  changes need a human), naming the replacement in each finding.
+- Emits `needsManual` for parse failures on scannable module files that
+  reference the deprecated surface, and verifies post-rewrite that no detectable
+  `packages.invokeChecked` member expressions remain.
+- Detection reuses the publish-check collector
+  (`package-runtime/deprecated-invocation-usage.ts`), so `detect` findings and
+  the non-fatal publish lint warnings stay in lockstep.
+
 ## Engine
 
 The engine entry point is `runPackageCodemodStep` in

--- a/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.node.test.ts
+++ b/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.node.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from 'vitest'
+import { staticFirstInvocationCodemod } from './0002-static-first-invocation.ts'
+
+function manifest(name = '@user/demo', kodyId = 'demo') {
+	return `${JSON.stringify(
+		{
+			name,
+			exports: { '.': './index.ts' },
+			kody: {
+				id: kodyId,
+				description: 'Demo package for static-first invocation codemod tests.',
+			},
+		},
+		null,
+		'\t',
+	)}\n`
+}
+
+test('0002 rewrites invokeChecked member calls (including optional chaining) to invoke', () => {
+	const files = {
+		'package.json': manifest(),
+		'index.ts': [
+			"import { packages } from 'kody:runtime'",
+			'',
+			'export default async function run() {',
+			"\tconst direct = await packages.invokeChecked({ kodyId: 'github', exportName: './request', params: {} })",
+			"\tconst optional = await packages?.invokeChecked({ kodyId: 'github', exportName: './request', params: {} })",
+			'\treturn { direct, optional }',
+			'}',
+			'',
+		].join('\n'),
+	}
+
+	const findings = staticFirstInvocationCodemod.detect(files)
+	expect(findings).toEqual([
+		{
+			path: 'index.ts',
+			message: expect.stringContaining('`packages.invokeChecked`'),
+		},
+	])
+
+	const result = staticFirstInvocationCodemod.transform(files)
+	expect(result.changed).toBe(true)
+	expect(result.changedPaths).toEqual(['index.ts'])
+	expect(result.needsManual).toEqual([])
+	expect(result.files['index.ts']).toContain(
+		"await packages.invoke({ kodyId: 'github'",
+	)
+	expect(result.files['index.ts']).toContain(
+		"await packages?.invoke({ kodyId: 'github'",
+	)
+	expect(result.files['index.ts']).not.toContain('invokeChecked')
+
+	// Idempotent: rerunning on the transformed tree changes nothing.
+	const rerun = staticFirstInvocationCodemod.transform(result.files)
+	expect(rerun.changed).toBe(false)
+	expect(rerun.changedPaths).toEqual([])
+	expect(rerun.files).toEqual(result.files)
+})
+
+test('0002 leaves unrelated invokeChecked identifiers and non-code files alone', () => {
+	const files = {
+		'package.json': manifest(),
+		'README.md':
+			'Historical note: `packages.invokeChecked` used to be the recommendation.\n',
+		'index.ts': [
+			'const other = { invokeChecked: () => 1 }',
+			'export default async function run() {',
+			'\treturn other.invokeChecked()',
+			'}',
+			'',
+		].join('\n'),
+	}
+
+	expect(staticFirstInvocationCodemod.detect(files)).toEqual([])
+	const result = staticFirstInvocationCodemod.transform(files)
+	expect(result.changed).toBe(false)
+	expect(result.changedPaths).toEqual([])
+	expect(result.needsManual).toEqual([])
+	expect(result.files).toEqual(files)
+})
+
+test('0002 reports packages.check and literal dynamic kody imports as needsManual', () => {
+	const files = {
+		'package.json': manifest(),
+		'index.ts': [
+			"import { packages } from 'kody:runtime'",
+			'',
+			'export default async function run() {',
+			"\tconst contract = await packages.check({ kodyId: 'github', exportName: './request' })",
+			"\tconst dynamicModule = await import('kody:@kentcdodds/github/request')",
+			'\treturn { contract, dynamicType: typeof dynamicModule.default }',
+			'}',
+			'',
+		].join('\n'),
+	}
+
+	const findings = staticFirstInvocationCodemod.detect(files)
+	expect(findings).toEqual([
+		{
+			path: 'index.ts',
+			message: expect.stringContaining('literal dynamic `import("kody:@...")`'),
+		},
+		{
+			path: 'index.ts',
+			message: expect.stringContaining('`packages.check`'),
+		},
+	])
+
+	const result = staticFirstInvocationCodemod.transform(files)
+	expect(result.changed).toBe(false)
+	expect(result.changedPaths).toEqual([])
+	expect(result.files).toEqual(files)
+	expect(result.needsManual).toEqual([
+		{
+			path: 'index.ts',
+			message: expect.stringContaining('literal dynamic `import("kody:@...")`'),
+		},
+		{
+			path: 'index.ts',
+			message: expect.stringContaining('`packages.check`'),
+		},
+	])
+})
+
+test('0002 mixes mechanical rewrites with needsManual findings in one package', () => {
+	const files = {
+		'package.json': manifest(),
+		'auto.ts': [
+			"import { packages } from 'kody:runtime'",
+			'export default async function auto() {',
+			"\treturn await packages.invokeChecked({ kodyId: 'skills', exportName: './skill-get', params: { id: 'x' } })",
+			'}',
+			'',
+		].join('\n'),
+		'manual.ts': [
+			"import { packages } from 'kody:runtime'",
+			'export default async function manual() {',
+			"\treturn await packages.check({ kodyId: 'skills', exportName: './skill-get' })",
+			'}',
+			'',
+		].join('\n'),
+	}
+
+	const result = staticFirstInvocationCodemod.transform(files)
+	expect(result.changed).toBe(true)
+	expect(result.changedPaths).toEqual(['auto.ts'])
+	expect(result.files['auto.ts']).toContain('packages.invoke({')
+	expect(result.files['auto.ts']).not.toContain('invokeChecked')
+	expect(result.files['manual.ts']).toBe(files['manual.ts'])
+	expect(result.needsManual).toEqual([
+		{
+			path: 'manual.ts',
+			message: expect.stringContaining('`packages.check`'),
+		},
+	])
+})

--- a/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.node.test.ts
+++ b/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.node.test.ts
@@ -123,6 +123,38 @@ test('0002 reports packages.check and literal dynamic kody imports as needsManua
 	])
 })
 
+test('0002 flags unparseable files that reference the deprecated surface', () => {
+	const files = {
+		'package.json': manifest(),
+		'broken.ts': [
+			"import { packages } from 'kody:runtime'",
+			'export default async function run( {', // malformed on purpose
+			"\treturn await packages.invokeChecked({ kodyId: 'github', exportName: './request' })",
+			'}',
+			'',
+		].join('\n'),
+	}
+
+	const findings = staticFirstInvocationCodemod.detect(files)
+	expect(findings).toEqual([
+		{
+			path: 'broken.ts',
+			message: expect.stringContaining('could not be parsed'),
+		},
+	])
+
+	const result = staticFirstInvocationCodemod.transform(files)
+	expect(result.changed).toBe(false)
+	expect(result.changedPaths).toEqual([])
+	expect(result.files).toEqual(files)
+	expect(result.needsManual).toEqual([
+		{
+			path: 'broken.ts',
+			message: expect.stringContaining('could not be parsed'),
+		},
+	])
+})
+
 test('0002 mixes mechanical rewrites with needsManual findings in one package', () => {
 	const files = {
 		'package.json': manifest(),

--- a/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.ts
+++ b/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.ts
@@ -12,13 +12,13 @@ import {
 export const staticFirstInvocationCodemodId = '0002-static-first-invocation'
 
 const invokeCheckedDetectMessage =
-	'Calls deprecated `packages.invokeChecked`; `packages.invoke` is the single dynamic primitive (always contract-checked; key-less = lean/ephemeral, add `idempotencyKey` only for exactly-once). Prefer a static `kody:@scope/pkg/export` import when the target package is known at write time.'
+	'Calls deprecated `packages.invokeChecked`; rewrites mechanically to `packages.invoke` (same call shape and behavior — the runtime aliases them). Optionally, a human may later prefer a static `kody:@scope/pkg/export` import when the target package is known at write time.'
 
 const checkDetectMessage =
-	'Calls deprecated `packages.check`; `packages.invoke` always contract-checks before invoking. Call it directly, or use a static `kody:@scope/pkg/export` import when the target is known at write time; migrate manually.'
+	'Calls deprecated `packages.check`; `packages.invoke` already contract-checks before invoking, so restructure the call site manually (no mechanical rewrite preserves the contract return value).'
 
 const dynamicImportDetectMessage =
-	'Uses a literal dynamic `import("kody:@...")`; use a static import (declared in `package.json#kody.dependencies`) when the target is known at write time, or `packages.invoke` when the target is data; migrate manually.'
+	'Uses a literal dynamic `import("kody:@...")`; migrate manually — `packages.invoke` when the target is data, or a static import (declared in `package.json#kody.dependencies`) when the target is known at write time. Namespace semantics differ, so no mechanical rewrite is safe.'
 
 const manualParseFailureMessage =
 	'File references the deprecated dynamic invocation surface but could not be parsed; migrate to `packages.invoke` / static imports manually.'

--- a/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.ts
+++ b/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.ts
@@ -1,0 +1,218 @@
+import { parseModuleSource, type ModuleAstNode } from '#worker/module-source.ts'
+import {
+	collectDeprecatedInvocationUsage,
+	type DeprecatedInvocationUsage,
+} from '#worker/package-runtime/deprecated-invocation-usage.ts'
+import {
+	type PackageCodemod,
+	type PackageCodemodFinding,
+	type PackageCodemodTransformResult,
+} from '../types.ts'
+
+export const staticFirstInvocationCodemodId = '0002-static-first-invocation'
+
+const invokeCheckedDetectMessage =
+	'Calls deprecated `packages.invokeChecked`; `packages.invoke` is the single dynamic primitive (always contract-checked; key-less = lean/ephemeral, add `idempotencyKey` only for exactly-once). Prefer a static `kody:@scope/pkg/export` import when the target package is known at write time.'
+
+const checkDetectMessage =
+	'Calls deprecated `packages.check`; `packages.invoke` always contract-checks before invoking. Call it directly, or use a static `kody:@scope/pkg/export` import when the target is known at write time; migrate manually.'
+
+const dynamicImportDetectMessage =
+	'Uses a literal dynamic `import("kody:@...")`; use a static import (declared in `package.json#kody.dependencies`) when the target is known at write time, or `packages.invoke` when the target is data; migrate manually.'
+
+const manualParseFailureMessage =
+	'File references the deprecated dynamic invocation surface but could not be parsed; migrate to `packages.invoke` / static imports manually.'
+
+const scannableModuleFilePattern = /\.(?:[cm]?[jt]s|[jt]sx)$/
+
+type AstNode = ModuleAstNode & {
+	name?: unknown
+	start?: number
+	end?: number
+	computed?: boolean
+	object?: AstNode
+	property?: AstNode
+}
+
+function isTypeDeclarationFilePath(path: string) {
+	return (
+		path.endsWith('.d.ts') || path.endsWith('.d.mts') || path.endsWith('.d.cts')
+	)
+}
+
+function parseProgram(source: string): AstNode | null {
+	try {
+		return parseModuleSource(source) as unknown as AstNode
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Positions of the `invokeChecked` property identifier in
+ * `packages.invokeChecked` / `packages?.invokeChecked` member expressions.
+ * Only exact `packages` identifier objects match — the same shape the runtime
+ * exposes and the publish-check deprecation collector warns on.
+ */
+function collectInvokeCheckedPropertyRanges(
+	program: AstNode,
+): Array<{ start: number; end: number }> {
+	const ranges: Array<{ start: number; end: number }> = []
+
+	function visit(node: unknown): void {
+		if (node == null || typeof node !== 'object') return
+		if (Array.isArray(node)) {
+			for (const item of node) visit(item)
+			return
+		}
+		if (!('type' in node)) return
+		const typedNode = node as AstNode
+		if (
+			(typedNode.type === 'MemberExpression' ||
+				typedNode.type === 'OptionalMemberExpression') &&
+			typedNode.computed !== true &&
+			typedNode.object?.type === 'Identifier' &&
+			typedNode.object.name === 'packages' &&
+			typedNode.property?.type === 'Identifier' &&
+			typedNode.property.name === 'invokeChecked' &&
+			typeof typedNode.property.start === 'number' &&
+			typeof typedNode.property.end === 'number'
+		) {
+			ranges.push({
+				start: typedNode.property.start,
+				end: typedNode.property.end,
+			})
+		}
+		for (const value of Object.values(node as Record<string, unknown>)) {
+			if (value != null && typeof value === 'object') {
+				visit(value)
+			}
+		}
+	}
+
+	visit(program)
+	return ranges.sort((left, right) => left.start - right.start)
+}
+
+function rewriteInvokeChecked(source: string): string | null {
+	const program = parseProgram(source)
+	if (!program) return null
+	const ranges = collectInvokeCheckedPropertyRanges(program)
+	if (ranges.length === 0) return source
+	let rewritten = ''
+	let cursor = 0
+	for (const range of ranges) {
+		rewritten += source.slice(cursor, range.start)
+		rewritten += 'invoke'
+		cursor = range.end
+	}
+	rewritten += source.slice(cursor)
+	return rewritten
+}
+
+function findingMessageForUsage(usage: DeprecatedInvocationUsage): string {
+	switch (usage.kind) {
+		case 'packages.invokeChecked':
+			return invokeCheckedDetectMessage
+		case 'packages.check':
+			return checkDetectMessage
+		case 'dynamic-kody-import':
+			return dynamicImportDetectMessage
+		default: {
+			const exhaustive: never = usage.kind
+			void exhaustive
+			throw new Error('Unhandled deprecated invocation usage kind.')
+		}
+	}
+}
+
+function detect(files: Record<string, string>): Array<PackageCodemodFinding> {
+	return collectDeprecatedInvocationUsage(files).map((usage) => ({
+		path: usage.filePath,
+		message: findingMessageForUsage(usage),
+	}))
+}
+
+function transform(
+	files: Record<string, string>,
+): PackageCodemodTransformResult {
+	const usages = collectDeprecatedInvocationUsage(files)
+	const nextFiles: Record<string, string> = { ...files }
+	const changedPaths: Array<string> = []
+	const needsManual: Array<PackageCodemodFinding> = []
+	const invokeCheckedPaths = new Set(
+		usages
+			.filter((usage) => usage.kind === 'packages.invokeChecked')
+			.map((usage) => usage.filePath),
+	)
+
+	for (const usage of usages) {
+		// `packages.check` return values and dynamic-import namespaces have no
+		// mechanical one-to-one rewrite; report them instead of guessing.
+		if (usage.kind !== 'packages.invokeChecked') {
+			needsManual.push({
+				path: usage.filePath,
+				message: findingMessageForUsage(usage),
+			})
+		}
+	}
+
+	for (const path of [...invokeCheckedPaths].sort((left, right) =>
+		left.localeCompare(right),
+	)) {
+		const source = nextFiles[path]
+		if (typeof source !== 'string') continue
+		const rewritten = rewriteInvokeChecked(source)
+		if (rewritten == null) {
+			needsManual.push({ path, message: manualParseFailureMessage })
+			continue
+		}
+		if (rewritten !== source) {
+			nextFiles[path] = rewritten
+			changedPaths.push(path)
+		}
+	}
+
+	// Defensive verification: the rewrite must fully clear detectable
+	// `packages.invokeChecked` member expressions, or the file needs a human.
+	for (const path of changedPaths) {
+		const source = nextFiles[path]
+		if (!scannableModuleFilePattern.test(path)) continue
+		if (isTypeDeclarationFilePath(path)) continue
+		const remaining = collectDeprecatedInvocationUsage({
+			[path]: source ?? '',
+		}).filter((usage) => usage.kind === 'packages.invokeChecked')
+		if (remaining.length > 0) {
+			needsManual.push({
+				path,
+				message:
+					'`packages.invokeChecked` member expressions remain after the rewrite; migrate manually.',
+			})
+		}
+	}
+
+	return {
+		files: nextFiles,
+		changed: changedPaths.length > 0,
+		changedPaths,
+		needsManual,
+	}
+}
+
+/**
+ * Static-first invocation migration (narrow phase of the two-rule model):
+ *
+ * - `packages.invokeChecked(...)` is rewritten mechanically to
+ *   `packages.invoke(...)` — identical input shape; invoke is always
+ *   contract-checked, and key-less calls take the lean/ephemeral path.
+ * - `packages.check(...)` and literal dynamic `import("kody:@...")` have no
+ *   safe mechanical rewrite (return values / namespace semantics differ), so
+ *   they surface as `needsManual` findings naming the replacement.
+ */
+export const staticFirstInvocationCodemod: PackageCodemod = {
+	id: staticFirstInvocationCodemodId,
+	description:
+		'Rewrite deprecated packages.invokeChecked calls to packages.invoke and flag packages.check / literal dynamic import("kody:@...") usage for manual static-first migration.',
+	detect,
+	transform,
+}

--- a/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.ts
+++ b/packages/worker/src/package-codemods/codemods/0002-static-first-invocation.ts
@@ -49,6 +49,35 @@ function parseProgram(source: string): AstNode | null {
 }
 
 /**
+ * Textual net for the parse-failure path: `collectDeprecatedInvocationUsage`
+ * returns nothing for files it cannot parse, so unparseable files that still
+ * mention the deprecated surface must be caught here and surfaced as
+ * `needsManual` instead of silently scanning clean.
+ */
+function referencesDeprecatedSurface(source: string) {
+	return (
+		source.includes('invokeChecked') ||
+		/packages\s*\??\.\s*check\b/.test(source) ||
+		(source.includes('kody:@') && source.includes('import('))
+	)
+}
+
+function collectUnparseableDeprecatedFiles(
+	files: Record<string, string>,
+): Array<string> {
+	const paths: Array<string> = []
+	for (const [path, source] of Object.entries(files)) {
+		if (!scannableModuleFilePattern.test(path)) continue
+		if (isTypeDeclarationFilePath(path)) continue
+		if (!referencesDeprecatedSurface(source)) continue
+		if (parseProgram(source) == null) {
+			paths.push(path)
+		}
+	}
+	return paths.sort((left, right) => left.localeCompare(right))
+}
+
+/**
  * Positions of the `invokeChecked` property identifier in
  * `packages.invokeChecked` / `packages?.invokeChecked` member expressions.
  * Only exact `packages` identifier objects match — the same shape the runtime
@@ -127,10 +156,17 @@ function findingMessageForUsage(usage: DeprecatedInvocationUsage): string {
 }
 
 function detect(files: Record<string, string>): Array<PackageCodemodFinding> {
-	return collectDeprecatedInvocationUsage(files).map((usage) => ({
-		path: usage.filePath,
-		message: findingMessageForUsage(usage),
-	}))
+	const findings: Array<PackageCodemodFinding> =
+		collectDeprecatedInvocationUsage(files).map((usage) => ({
+			path: usage.filePath,
+			message: findingMessageForUsage(usage),
+		}))
+	for (const path of collectUnparseableDeprecatedFiles(files)) {
+		findings.push({ path, message: manualParseFailureMessage })
+	}
+	return findings.sort((left, right) =>
+		(left.path ?? '').localeCompare(right.path ?? ''),
+	)
 }
 
 function transform(
@@ -140,6 +176,11 @@ function transform(
 	const nextFiles: Record<string, string> = { ...files }
 	const changedPaths: Array<string> = []
 	const needsManual: Array<PackageCodemodFinding> = []
+	const unparseablePaths = collectUnparseableDeprecatedFiles(files)
+	for (const path of unparseablePaths) {
+		needsManual.push({ path, message: manualParseFailureMessage })
+	}
+	const unparseablePathSet = new Set(unparseablePaths)
 	const invokeCheckedPaths = new Set(
 		usages
 			.filter((usage) => usage.kind === 'packages.invokeChecked')
@@ -173,9 +214,13 @@ function transform(
 		}
 	}
 
-	// Defensive verification: the rewrite must fully clear detectable
-	// `packages.invokeChecked` member expressions, or the file needs a human.
-	for (const path of changedPaths) {
+	// Defensive verification over every rewrite candidate (not only changed
+	// files): any detectable `packages.invokeChecked` member expression that
+	// survives the rewrite pass needs a human.
+	for (const path of [...invokeCheckedPaths].sort((left, right) =>
+		left.localeCompare(right),
+	)) {
+		if (unparseablePathSet.has(path)) continue
 		const source = nextFiles[path]
 		if (!scannableModuleFilePattern.test(path)) continue
 		if (isTypeDeclarationFilePath(path)) continue

--- a/packages/worker/src/package-codemods/registry.ts
+++ b/packages/worker/src/package-codemods/registry.ts
@@ -1,8 +1,10 @@
 import { ambientStorageToPackageStorageCodemod } from './codemods/0001-ambient-storage-to-package-storage.ts'
+import { staticFirstInvocationCodemod } from './codemods/0002-static-first-invocation.ts'
 import { type PackageCodemod } from './types.ts'
 
 const packageCodemods: Array<PackageCodemod> = [
 	ambientStorageToPackageStorageCodemod,
+	staticFirstInvocationCodemod,
 ]
 
 const packageCodemodsById = new Map(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Registers the static-first migration in the new package-codemod framework (#1049) as `0002-static-first-invocation` — the narrow-phase enforcement vehicle for [#1048](https://github.com/kentcdodds/kody/issues/1048).

### Safety-first design (per Kent's direction: avoid changing semantics)

The **only** automated transform is the API rename:

- `packages.invokeChecked(...)` member calls (including `packages?.invokeChecked`) → `packages.invoke(...)` via AST range replacement. **Semantics-preserving by construction**: since #1046, the runtime aliases `invokeChecked` to `invoke` (`runtime-tool-factories.ts` returns `invokeChecked: invoke`) — same call shape, same mandatory contract check, same key-less behavior. The rewrite changes which name appears in source and nothing else; it future-proofs the package for the narrow phase when the alias is removed.

Everything that **would** change semantics is a conservative `needsManual` finding (per the codemod doctrine), naming the replacement:

- `packages.check(...)` — its contract return value has no mechanical equivalent (`invoke` checks internally); the call site needs human restructuring.
- Literal dynamic `import("kody:@...")` — namespace semantics and `kody.dependencies` manifest changes need a human; static-import conversion also changes bundling/pinning, realm, and storage binding, so it is never automated.
- Parse failures on files referencing the deprecated surface.

A post-rewrite verification confirms no detectable `invokeChecked` member expressions remain. Detection reuses `package-runtime/deprecated-invocation-usage.ts` (the publish-check collector from #1046), so codemod `detect` findings and the non-fatal publish lint warnings stay in lockstep by construction. Documented in `docs/contributing/package-codemods.md` alongside `0001`.

### Role in the program

Kent's own 10 affected packages were already migrated manually (pre-framework); this codemod's fleet-wide `scan` is the proof mechanism for the #1048 gate ("legacy surface absent from all production packages") and the migration path for community forks and post-launch users before the shims are removed.

### Testing

- 4 new node tests: mechanical rewrite incl. optional chaining + idempotent rerun; unrelated `invokeChecked` identifiers and non-code files untouched; `packages.check` / dynamic-import `needsManual` findings; mixed mechanical+manual package.
- Full `package-codemods` suite green (14 tests), typecheck green, format/lint clean.

## Program report

- **Status**: contained conductor-authored slice; consumes the merged codemod framework (#1049). Low-risk additive registry code — will squash-merge as Kody when green per the program's standing ship authority, then run the fleet `scan` via `admin_package_codemod_scan` and attach the zero-usage report to #1048.
- **In flight elsewhere**: ledger slice #1053 is MERGE-READY but rebasing onto the moved main (agent nudged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3b1e796-faee-4b69-910d-1ec4f03e60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3b1e796-faee-4b69-910d-1ec4f03e60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a migration codemod that updates deprecated `packages.invokeChecked(...)` calls to `packages.invoke(...)`, including optional chaining.
  * Detects related patterns that require manual review and provides targeted guidance.
  * Reports changed files and supports safe repeat execution without duplicating changes.

* **Documentation**
  * Added authoring guidance describing the codemod’s supported transformations, detection behavior, and manual-review scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->