### PR TITLE
Follow-up to #1053: decide the DO ledger fence with an explicit row read

### DIFF
--- a/packages/worker/src/email/system-email-subscriptions.workers.test.ts
+++ b/packages/worker/src/email/system-email-subscriptions.workers.test.ts
@@ -387,7 +387,11 @@ test(
 				source: 'email',
 				idempotencyKey: `email:${stored.id}:${adminPackage.packageId}:${systemTopic}`,
 			})
-			const response = JSON.parse(String(invocation?.responseJson)) as {
+			const responseJson = invocation?.responseJson
+			if (!responseJson) {
+				throw new Error('Expected a stored replay response for the admin row.')
+			}
+			const response = JSON.parse(responseJson) as {
 				body: Record<string, unknown>
 			}
 			expect(response.body).toMatchObject({

--- a/packages/worker/src/platform-feedback/platform-feedback-subscriptions.workers.test.ts
+++ b/packages/worker/src/platform-feedback/platform-feedback-subscriptions.workers.test.ts
@@ -364,7 +364,13 @@ test(
 					source: 'platform-feedback',
 					idempotencyKey: `platform-feedback:${dispatchFeedback.id}:${adminPackage.packageId}:${platformFeedbackSubmittedTopic}`,
 				})
-				const response = JSON.parse(String(invocation?.responseJson)) as {
+				const responseJson = invocation?.responseJson
+				if (!responseJson) {
+					throw new Error(
+						'Expected a stored replay response for the admin row.',
+					)
+				}
+				const response = JSON.parse(responseJson) as {
 					body: Record<string, unknown>
 				}
 				expect(response.body).toMatchObject({

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -1228,17 +1228,25 @@ class RunLogBase extends DurableObject<Env> {
 		record: PackageInvocationLedgerRecord | null
 	}> {
 		const now = new Date().toISOString()
-		const updateCursor = this.ctx.storage.sql.exec(
-			`UPDATE package_invocation_ledger
-			SET status = ?, response_json = ?, updated_at = ?
-			WHERE id = ? AND status = 'in_progress' AND updated_at = ?`,
-			input.status,
-			input.responseJson,
-			now,
-			input.invocationId,
-			input.claimUpdatedAt,
-		)
-		const ledgerUpdated = updateCursor.rowsWritten > 0
+		// DO execution is serialized, so this read-then-write is atomic within
+		// the RPC; the fence is decided by an explicit row read instead of the
+		// billing-side rowsWritten counter.
+		const current = this.getInvocationLedgerRowById(input.invocationId)
+		const ledgerUpdated =
+			current != null &&
+			current.status === 'in_progress' &&
+			current.updatedAt === input.claimUpdatedAt
+		if (ledgerUpdated) {
+			this.ctx.storage.sql.exec(
+				`UPDATE package_invocation_ledger
+				SET status = ?, response_json = ?, updated_at = ?
+				WHERE id = ?`,
+				input.status,
+				input.responseJson,
+				now,
+				input.invocationId,
+			)
+		}
 		if (input.run) {
 			const existed = this.runExists(input.run.id)
 			this.upsertRun(input.run, 'replace')
@@ -1255,10 +1263,7 @@ class RunLogBase extends DurableObject<Env> {
 		if (ledgerUpdated) {
 			return { ledgerUpdated: true, record: null }
 		}
-		return {
-			ledgerUpdated: false,
-			record: this.getInvocationLedgerRowById(input.invocationId),
-		}
+		return { ledgerUpdated: false, record: current }
 	}
 
 	/**
@@ -1276,23 +1281,26 @@ class RunLogBase extends DurableObject<Env> {
 		/** Current row when the fence failed, so the caller can resolve it. */
 		record: PackageInvocationLedgerRecord | null
 	}> {
-		const deleteCursor = this.ctx.storage.sql.exec(
-			`DELETE FROM package_invocation_ledger
-			WHERE id = ? AND status = 'in_progress' AND updated_at = ?`,
-			input.invocationId,
-			input.claimUpdatedAt,
-		)
-		const released = deleteCursor.rowsWritten > 0
+		// Same explicit read-then-write fence as finishPackageInvocation: DO
+		// execution is serialized, so this is atomic within the RPC.
+		const current = this.getInvocationLedgerRowById(input.invocationId)
+		const released =
+			current != null &&
+			current.status === 'in_progress' &&
+			current.updatedAt === input.claimUpdatedAt
+		if (released) {
+			this.ctx.storage.sql.exec(
+				`DELETE FROM package_invocation_ledger WHERE id = ?`,
+				input.invocationId,
+			)
+		}
 		if (input.runId) {
 			await this.deleteRunIfRunning({ runId: input.runId })
 		}
 		if (released) {
 			return { released: true, record: null }
 		}
-		return {
-			released: false,
-			record: this.getInvocationLedgerRowById(input.invocationId),
-		}
+		return { released: false, record: current }
 	}
 
 	async listRuns(input: ListRunsInput): Promise<RunRecordPage> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#1053 merged while its final review-response commit was in flight (the branch was squashed and deleted seconds before the push landed). This carries that one commit, addressing the two remaining valid CodeRabbit findings on the merged PR:

- `finishPackageInvocation` / `releasePackageInvocation` in the RunLog DO decided the claim fence from `SqlStorageCursor.rowsWritten`, which is documented as a billing-side write counter (it also counts index writes). Functionally it could not produce false positives here — an `UPDATE`/`DELETE` matching zero rows writes nothing — but DO execution is serialized, so an explicit read-then-write inside the RPC is equally atomic and does not lean on billing-metric semantics at all. The fence is now decided by reading the row and comparing `status`/`updatedAt` explicitly before the unconditional write.
- The system-email and platform-feedback subscription workers tests parsed `String(invocation?.responseJson)` — `responseJson` is `string | null` (oversized replays drop the cache), so a null would have produced a confusing `TypeError` instead of a clear failure. They now fail loudly with an explicit guard, matching the inbound-email suite.

No behavior change on any invocation path: same fence outcomes, same return shapes, covered by the existing `invocation-ledger.workers.test.ts` fence tests (superseded finish is fenced out, stale release token rejected).

## Testing

- `invocation-ledger.workers.test.ts`, `system-email-subscriptions.workers.test.ts`, `platform-feedback-subscriptions.workers.test.ts` green against the real DO binding on top of latest `main` (21ce87f5).
- Full node + workers unit suites green via the pre-push gate; typecheck/format/lint green.

## Program report

MERGE-READY

Status: green and mergeable (mergeStateStatus CLEAN). All CI checks pass (🧹 Static, 🧪 Node, ☁️ Workers, 🔌 MCP, 🎭 E2E, ✅ Validate, preview deploy); Bugbot and CodeRabbit both pass with no findings. One-commit, no-behavior-change follow-up to #1053.

Note on the parent slice: #1053 is merged (squash `5beb6364`) and deployed — the production deploy workflow succeeded and https://heykody.dev/health returns `21ce87f5` (main head containing the merge). Conductor probes (keyed replay against the DO ledger; dual-read fallback for a pre-migration key) can run any time.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `21ce87f5` · **Head:** `d555ed12`

**Classification:** composes — no primitive contracts change; the RunLog DO ledger fence is decided by an explicit row read instead of the `rowsWritten` billing counter, plus two test hardening guards. Return shapes and fence outcomes are identical.

### Primitives touched

| Primitive     | Group     | Impact                                                               |
| ------------- | --------- | -------------------------------------------------------------------- |
| `run-records` | storage   | composes — internal fence implementation swap in two ledger RPCs      |
| `email`, `platform-feedback` | assistant | composes — test-only null-guards for replay caches      |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da9a62c3-6e38-4f03-b49e-1a3fc1355632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da9a62c3-6e38-4f03-b49e-1a3fc1355632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when completing or releasing package invocations, preventing stale updates from overwriting newer ledger state.
  * Preserved the latest invocation record when completion or release checks fail.
  * Added clearer validation for missing stored response data during system email and platform feedback processing.

* **Tests**
  * Updated coverage to verify stored response payloads are present and parsed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->