### PR TITLE
docs(privacy): disclose package codemods as the one qualified admin exception

### DIFF
--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -101,6 +101,14 @@ transformed map.
    - the pattern spans generated or minified output,
    - a required symbol cannot be resolved from static analysis alone, or
    - the codemod would delete user logic to satisfy the migration.
+5. **Never put source contents in findings.** Finding `message` values must be
+   fixed, codemod-authored strings; `path` identifies the file. Interpolating
+   file contents, matched snippets, identifiers from user code, or manifest
+   values into a finding would surface private package source to the operator
+   running the fleet scan, breaking the
+   [privacy policy's codemod disclosure](../use/privacy.md#platform-maintenance-package-codemods)
+   ("codemods are forbidden from embedding file contents in their findings").
+   Both shipped codemods use constant messages; keep it that way.
 
 ### `0001-ambient-storage-to-package-storage`
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -532,6 +532,18 @@ Use:
 - `repo_run_commands` to edit, check, and publish repo-backed package source
   after it exists using parsed, git-only command forms rather than shell
 
+### Platform maintenance migrations (codemods)
+
+When the platform's package API changes, Kody may migrate your published package
+source with a **package codemod**: a versioned, deterministic, code-reviewed
+transform that ships in the open-source repository. An applied codemod
+republishes through the normal checks, records a `codemod(<id>): ...` commit in
+your package's git history, keeps a revert snapshot, and dispatches a
+`package.codemod.applied` event your packages can subscribe to. Ambiguous
+matches are never rewritten — they surface as findings for you instead. What
+this does and does not expose to deployment admins is covered in
+[Privacy → Platform maintenance](./privacy.md#platform-maintenance-package-codemods).
+
 ## Hidden packages
 
 Use **`package_update`** with a saved **`package_id`** and

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -107,7 +107,30 @@ does not let admins browse:
 - OAuth grants
 
 None of these stores appears in an admin endpoint, page, or API payload — not
-even in redacted or count form.
+even in redacted or count form — with one qualified exception: platform
+maintenance codemods, described next, surface package identity, affected file
+paths, and fixed migration messages (never file contents).
+
+## Platform maintenance (package codemods)
+
+When the platform's package API changes, Kody migrates published package source
+with **package codemods**: versioned, deterministic transforms that live in the
+open-source repository and ship through code review like any other platform
+change. Nobody can author an ad hoc transform through the admin surface — admins
+only choose when a published, reviewed codemod runs, and can scope it to a dry
+run first.
+
+A codemod apply rewrites only what the reviewed transform matches, republishes
+the package through the same checks as a normal publish, records a
+`codemod(<id>): ...` commit in the package's own git history, keeps a revert
+snapshot, and dispatches a `package.codemod.applied` (or `.reverted`) event your
+packages can subscribe to. Fleet runs are audit-logged.
+
+Running a codemod never shows an admin your source. Scan and run results expose
+only package identity (ids), affected file paths, and the codemod's own fixed
+finding messages — codemods are forbidden from embedding file contents in their
+findings. Ambiguous matches are skipped and reported for the owner rather than
+rewritten.
 
 ## Deployment operator access
 

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -112,7 +112,38 @@ export function PrivacyRoute(_handle: Handle) {
 				</ul>
 				<p mix={css(descriptionCss)}>
 					None of this appears in any admin endpoint, page, or API payload — not
-					even in redacted or count form.
+					even in redacted or count form — with one qualified exception:
+					platform maintenance codemods, described next, surface package
+					identity, affected file paths, and fixed migration messages (never
+					file contents).
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Platform maintenance (package codemods)</h2>
+				<p mix={css(descriptionCss)}>
+					When the platform&apos;s package API changes, Kody migrates published
+					package source with package codemods: versioned, deterministic
+					transforms that live in the open-source repository and ship through
+					code review like any other platform change. Nobody can author an ad
+					hoc transform through the admin surface — admins only choose when a
+					published, reviewed codemod runs, and can scope it to a dry run first.
+				</p>
+				<p mix={css(descriptionCss)}>
+					A codemod apply rewrites only what the reviewed transform matches,
+					republishes the package through the same checks as a normal publish,
+					records a <code>codemod(&lt;id&gt;)</code> commit in the
+					package&apos;s own git history, keeps a revert snapshot, and
+					dispatches a <code>package.codemod.applied</code> (or{' '}
+					<code>.reverted</code>) event your packages can subscribe to. Fleet
+					runs are audit-logged.
+				</p>
+				<p mix={css(descriptionCss)}>
+					Running a codemod never shows an admin your source. Scan and run
+					results expose only package identity (ids), affected file paths, and
+					the codemod&apos;s own fixed finding messages — codemods are forbidden
+					from embedding file contents in their findings. Ambiguous matches are
+					skipped and reported for the owner rather than rewritten.
 				</p>
 			</section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the package-codemod framework (#1049) and Kent's review question: the privacy policy currently promises that private packages and their source never appear in any admin endpoint, page, or API payload — *"not even in redacted or count form."* The fleet codemod surface makes that sentence inaccurate: `admin_package_codemod_scan` / `apply` results expose package identity (user/package ids), affected **file paths**, and finding messages, and `apply` writes reviewed migrations into user package source. This PR amends the policy honestly rather than leaving a promise the deployed product contradicts.

### Changes

- **`/privacy` page (`privacy.tsx`) + `docs/use/privacy.md`** (kept in sync): the absolute "never… not even in redacted or count form" sentence gains a pointer to one qualified exception, and a new **Platform maintenance (package codemods)** section explains the model: versioned, deterministic, code-reviewed in-repo transforms; admins choose *when* a published codemod runs (dry-run gated) and cannot author ad hoc transforms; applies republish through normal checks, leave a `codemod(<id>)` commit in the package's own history, keep revert snapshots, dispatch `package.codemod.applied`/`.reverted` events, and are audit-logged; results expose paths and fixed messages, **never file contents**.
- **`docs/use/packages.md`**: user-facing "Platform maintenance migrations (codemods)" note under Save and edit packages, linking to the privacy section.
- **`docs/contributing/package-codemods.md`**: new authoring invariant #5 — **never put source contents in findings** (fixed, codemod-authored messages only; interpolating matched snippets/identifiers would surface private source to the operator and break the policy). Both shipped codemods already comply; this pins it as a review requirement.

### Review notes

Policy wording is Kent's call — **this PR should not merge without his sign-off on the text.** The technical claims were verified against the shipped framework: findings are `{ path, message }` with constant messages in `0001` and `0002`; apply/revert paths, KV revert snapshots, audit logging, and subscription events per #1049.

## Program report

- **Status**: awaiting Kent's wording review (explicitly not self-merging policy text). All other program gates on [#1048](https://github.com/kentcdodds/kody/issues/1048) remain as last reported: fleet scan zero legacy usage; narrow-phase removal pending the deprecation observation window.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3b1e796-faee-4b69-910d-1ec4f03e60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3b1e796-faee-4b69-910d-1ec4f03e60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

