### PR TITLE
fix(mcp): stop Sentry noise for unpublished HEAD on repo_open_session

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/repo-open-session.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-open-session.node.test.ts
@@ -1,8 +1,10 @@
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { buildSourceRecoveryProblemMessage } from '#worker/repo/source-safety-policy.ts'
 import { repoOpenSessionInputSchema } from './repo-shared.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -162,6 +164,64 @@ test('repo target accepts camelCase aliases for its snake_case fields', () => {
 			target: { kind: 'package', kody_id: 'triage-github-pr' },
 		}).target,
 	).toEqual({ kind: 'package', kody_id: 'triage-github-pr' })
+})
+
+test('repo_open_session maps published HEAD mismatch to McpCallerError', async () => {
+	resetMocks()
+	const email = 'head-mismatch@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const env = {
+		APP_DB: createEntitlementsDatabase({
+			users: [{ email, plan: 'pro', stable_user_id: userId }],
+			repoSessionCount: 0,
+		}),
+	} as Env
+	const ctx = {
+		env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId,
+				email,
+				displayName: 'Head Mismatch User',
+			},
+		}),
+	}
+	const source = createPackageSourceRow(userId)
+	mockModule.getActiveRepoSessionByConversation.mockResolvedValueOnce(null)
+	mockModule.getSavedPackageByKodyId.mockResolvedValueOnce(
+		createSavedPackageRow(userId),
+	)
+	mockModule.getEntitySourceByIdForUser.mockResolvedValueOnce(source)
+	const openRpc = createRepoRpc()
+	openRpc.openSession.mockRejectedValueOnce(
+		new Error(
+			buildSourceRecoveryProblemMessage({
+				source,
+				operation: 'repo_open_session',
+				reason: `artifact source repo "${source.repo_id}" default branch HEAD "commit-unpublished" does not match published commit "${source.published_commit}"`,
+			}),
+		),
+	)
+	mockModule.repoSessionRpc.mockReturnValue(openRpc)
+
+	const error = await repoOpenSessionCapability
+		.handler(
+			{
+				target: { kind: 'package', kody_id: 'triage-github-pr' },
+			},
+			ctx,
+		)
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+
+	expect(error).toBeInstanceOf(McpCallerError)
+	expect(error).toMatchObject({
+		message: expect.stringContaining('package_publish_external_push'),
+	})
+	expect(openRpc.openSession).toHaveBeenCalled()
 })
 
 test('repo_open_session enforces the repo sessions entitlement for plan users opening a new session', async () => {

--- a/packages/worker/src/mcp/capabilities/repo/repo-open-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-open-session.ts
@@ -1,9 +1,14 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { assertWithinEntitlement } from '#worker/entitlements/service.ts'
 import { getActiveRepoSessionByConversation } from '#worker/repo/repo-sessions.ts'
+import {
+	buildPublishedCommitHeadMismatchCallerMessage,
+	isPublishedCommitHeadMismatchMessage,
+} from '#worker/repo/source-safety-policy.ts'
 import {
 	repoOpenSessionOutputSchema,
 	repoOpenSessionInputSchema,
@@ -74,15 +79,31 @@ export const repoOpenSessionCapability = defineDomainCapability(
 				resource: 'repo_sessions',
 			})
 
-			const session = await repoSessionRpc(ctx.env, sessionId).openSession({
-				sessionId,
-				sourceId: requested.source.id,
-				userId: user.userId,
-				baseUrl: ctx.callerContext.baseUrl,
-				conversationId: args.conversation_id ?? null,
-				sourceRoot: args.source_root ?? requested.source.source_root,
-				defaultBranch: args.default_branch ?? null,
-			})
+			let session
+			try {
+				session = await repoSessionRpc(ctx.env, sessionId).openSession({
+					sessionId,
+					sourceId: requested.source.id,
+					userId: user.userId,
+					baseUrl: ctx.callerContext.baseUrl,
+					conversationId: args.conversation_id ?? null,
+					sourceRoot: args.source_root ?? requested.source.source_root,
+					defaultBranch: args.default_branch ?? null,
+				})
+			} catch (error) {
+				const message = getErrorMessage(error)
+				// Unpublished git-lane pushes leave HEAD ahead of published_commit
+				// until package_publish_external_push (or reconcile) lands. Keep the
+				// safety gate, but classify it as a caller precondition so Sentry
+				// does not open platform-bug issues for expected workflow state.
+				if (isPublishedCommitHeadMismatchMessage(message)) {
+					throw new McpCallerError(
+						buildPublishedCommitHeadMismatchCallerMessage(message),
+						{ cause: error },
+					)
+				}
+				throw error
+			}
 			return {
 				...session,
 				resolved_target: requested.resolvedTarget,

--- a/packages/worker/src/repo/source-safety-policy.node.test.ts
+++ b/packages/worker/src/repo/source-safety-policy.node.test.ts
@@ -2,7 +2,10 @@ import { expect, test } from 'vitest'
 import {
 	assertPackageSourceOverwriteAllowed,
 	assertRestorablePackageSourceSnapshot,
+	buildPublishedCommitHeadMismatchCallerMessage,
+	buildSourceRecoveryProblemMessage,
 	destructiveOverwriteConfirmationField,
+	isPublishedCommitHeadMismatchMessage,
 } from './source-safety-policy.ts'
 import { type EntitySourceRow } from './types.ts'
 
@@ -57,6 +60,31 @@ function createEnvWithRawSnapshot(snapshot: unknown) {
 		},
 	} as unknown as Env
 }
+
+test('published commit HEAD mismatch messages are detected for caller-error classification', () => {
+	const mismatch = buildSourceRecoveryProblemMessage({
+		source: packageSource({
+			published_commit: 'commit-published',
+			repo_id: 'package-1',
+		}),
+		operation: 'repo_open_session',
+		reason:
+			'artifact source repo "package-1" default branch HEAD "commit-unpublished" does not match published commit "commit-published"',
+	})
+	expect(isPublishedCommitHeadMismatchMessage(mismatch)).toBe(true)
+	expect(
+		isPublishedCommitHeadMismatchMessage(
+			buildSourceRecoveryProblemMessage({
+				source: packageSource(),
+				operation: 'repo_open_session',
+				reason: 'artifact source repo "package-1" was not found',
+			}),
+		),
+	).toBe(false)
+	expect(buildPublishedCommitHeadMismatchCallerMessage(mismatch)).toContain(
+		'package_publish_external_push',
+	)
+})
 
 test('package source overwrite requires explicit destructive confirmation before snapshot verification', async () => {
 	await expect(

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -44,6 +44,29 @@ export function buildSourceRecoveryProblemMessage(input: {
 	].join(' ')
 }
 
+/**
+ * True when a source-recovery message is specifically "Artifacts HEAD does not
+ * match published_commit". That state is expected after a git-lane push before
+ * `package_publish_external_push` (or the reconcile cron) lands — a caller
+ * precondition, not a platform defect.
+ */
+export function isPublishedCommitHeadMismatchMessage(message: string) {
+	return (
+		message.includes('default branch HEAD') &&
+		message.includes('does not match published commit')
+	)
+}
+
+export function buildPublishedCommitHeadMismatchCallerMessage(
+	recoveryMessage: string,
+) {
+	return [
+		recoveryMessage,
+		'Publish the current Artifacts HEAD with package_publish_external_push (or wait for the reconcile job), then retry.',
+		'Repo sessions open from the published commit and refuse to start while unpublished remote commits are present.',
+	].join(' ')
+}
+
 function buildDestructiveOverwriteConfirmationMessage(input: {
 	source: EntitySourceRow
 	operation: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY issue 7642635997](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7642635997/): `repo_open_session` threw a plain `Error` when Artifacts default-branch HEAD did not match `published_commit`.

That mismatch is **expected** after a git-lane push (`package_get_git_remote`) before `package_publish_external_push` or the reconcile cron lands. The production source-safety gate correctly refuses to open a session in that state; reporting it to Sentry made it look like a platform bug and tripped triage.

### Change

- Keep the HEAD===published gate in `RepoSession.openSession`
- Detect the mismatch signature and rethrow as `McpCallerError` from `repo_open_session` (covers `repo_run_commands` too) with guidance to publish/reconcile first
- MCP observability already skips `McpCallerError`, so these stay on `mcp-event` logs only

### Tests

- `source-safety-policy` helper coverage for mismatch detection
- `repo_open_session` maps the DO recovery message to `McpCallerError`

### Not in this PR

Sibling [7642291485](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7642291485/) (bundle artifact UNIQUE constraint after publish) is a different source/root cause and is left alone.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/sentry-triage-kody-cloudflare-7642635997-fdfc`

**Classification:** composes — keeps the existing source-safety gate; only reclassifies the unpublished-HEAD precondition as `McpCallerError` so Sentry skips it.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | composes — `repo_open_session` wraps HEAD mismatch as caller error |
| `repo-sessions` | runtime | composes — helpers to detect/message the mismatch signature |

### System map

Caller opens a repo session; when Artifacts HEAD is ahead of `published_commit`, the DO still refuses, but the capability returns `McpCallerError` so MCP observability does not open a Sentry issue.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	capabilityRegistry -->|"openSession RPC"| repoSessions
	repoSessions -->|"HEAD mismatch Error"| capabilityRegistry
	capabilityRegistry -->|"McpCallerError → skip Sentry"| capabilityRegistry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant RepoOpen as repo_open_session
	participant DO as RepoSession DO
	participant Obs as MCP observability
	Agent->>RepoOpen: open package source
	RepoOpen->>DO: openSession
	DO-->>RepoOpen: HEAD ≠ published_commit Error
	RepoOpen-->>Agent: McpCallerError + publish guidance
	Note over Obs: isCallerFailure → no Sentry
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c53ffa11-7f18-4fce-aeb8-350216a81378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c53ffa11-7f18-4fce-aeb8-350216a81378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when the published commit differs from the current Artifacts repository head.
  * Users now receive clearer guidance to publish the current head or wait for reconciliation before retrying.
  * Unrelated session-opening errors continue to be reported unchanged.
* **Tests**
  * Added coverage for published commit mismatch detection and caller-facing error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->