### PR TITLE
Raise MCP agent session backfill timeout to six hours

### DIFF
--- a/.github/workflows/backfill-mcp-agent-sessions.yml
+++ b/.github/workflows/backfill-mcp-agent-sessions.yml
@@ -35,7 +35,8 @@ jobs:
   backfill:
     runs-on: ubuntu-latest
     name: 🧭 Backfill MCP agent sessions (${{ inputs.mode }})
-    timeout-minutes: 180
+    # Production inventory is ~8k MCP DOs (~162 batches); 180m was not enough.
+    timeout-minutes: 360
     steps:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2

--- a/docs/contributing/mcp-agent-session-backfill.md
+++ b/docs/contributing/mcp-agent-session-backfill.md
@@ -22,7 +22,7 @@ gh workflow run backfill-mcp-agent-sessions.yml \
 
 Review the uploaded audit artifact, then re-run with `-f mode=execute` only when
 there are no `no_owner` rows, ownership conflicts, or other failures. Production
-inventory is large (thousands of MCP Durable Objects); the job timeout is three
+inventory is large (thousands of MCP Durable Objects); the job timeout is six
 hours.
 
 ## Required environment (local CLI)

--- a/tools/ci/backfill-mcp-agent-sessions.ts
+++ b/tools/ci/backfill-mcp-agent-sessions.ts
@@ -93,9 +93,16 @@ export async function runMcpAgentSessionBackfill(input: {
 		cursor = page.result_info?.cursor || undefined
 	} while (cursor)
 
+	const batchSize = 50
+	const batchCount = Math.ceil(doIds.length / batchSize)
+	console.info(
+		`Listed ${doIds.length} MCP objects with stored data across ${pages} page(s); processing ${batchCount} batch(es) of up to ${batchSize}.`,
+	)
+
 	const rows: Array<Record<string, unknown>> = []
 	const failures: Array<Record<string, unknown>> = []
-	for (let offset = 0; offset < doIds.length; offset += 50) {
+	for (let offset = 0; offset < doIds.length; offset += batchSize) {
+		const batchIndex = Math.floor(offset / batchSize) + 1
 		const result = await withRetry(() =>
 			postMaintenance({
 				origin: input.origin,
@@ -103,7 +110,7 @@ export async function runMcpAgentSessionBackfill(input: {
 				pathname: '/__maintenance/backfill-mcp-agent-sessions',
 				body: {
 					dryRun: !input.execute,
-					doIds: doIds.slice(offset, offset + 50),
+					doIds: doIds.slice(offset, offset + batchSize),
 				},
 				fetcher,
 			}),
@@ -112,6 +119,15 @@ export async function runMcpAgentSessionBackfill(input: {
 		failures.push(
 			...((result['failures'] as Array<Record<string, unknown>>) ?? []),
 		)
+		if (
+			batchIndex === 1 ||
+			batchIndex === batchCount ||
+			batchIndex % 10 === 0
+		) {
+			console.info(
+				`Batch ${batchIndex}/${batchCount}: rows=${rows.length} failures=${failures.length}`,
+			)
+		}
 	}
 	const audit = {
 		schemaVersion: 1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Production dry-run ([run 30543284522](https://github.com/kentcdodds/kody/actions/runs/30543284522)) was cancelled at the 180-minute job timeout before writing an audit artifact.
- Raises the workflow job timeout to 360 minutes (GitHub-hosted max) and adds batch progress logs.
- After merge, re-trigger dry-run; if clean, run `mode=execute`. Cleanup remains tracked in https://github.com/kentcdodds/kody/issues/1051.

## Test plan
- [x] `npm test -- tools/ci/backfill-mcp-agent-sessions.node.test.ts`
- [ ] Merge and re-run dry-run workflow
- [ ] Review audit summary / artifact
- [ ] Trigger `mode=execute` when clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90bbe4cf-1167-4400-8718-d94fb3a4beb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90bbe4cf-1167-4400-8718-d94fb3a4beb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Extended the MCP agent session backfill workflow timeout to six hours for larger inventories.
  * Added batch progress reporting, including processed batches, rows, and failures.
  * Improved batch handling for more efficient processing of large datasets.

* **Documentation**
  * Updated backfill workflow guidance to reflect the six-hour timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->