### PR TITLE
docs(codemods): mark the platform vs personal codemod boundary

### DIFF
--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -37,6 +37,20 @@ and publish paths are covered in
 - **Community listing publishes.** A successful apply republishes the owning
   user's saved package only. Pinned community listings keep serving the pinned
   commit; listing snapshots are not advanced by codemod apply or revert.
+- **Personal codemods.** The built-in system is for **platform-authored**
+  migrations: the transform ships in this repo, reviewed and fixture-tested in
+  CI, because its correctness is pinned to a platform version and it runs
+  fleet-wide over other users' source. A user transforming **their own**
+  packages with **their own** transform needs no primitive — every required
+  power (repo sessions, `repo_run_checks` against a staged tree, gated publish,
+  git history) already exists as user capabilities. That userland pattern is
+  packaged as the
+  [`@kentcdodds/codemod-runner`](https://heykody.dev/community/b06c0f98-865a-4379-adb0-d0fb2cdda14f)
+  community package: same contract vocabulary (`detect`/`transform`,
+  dry-run-before-apply, drift skips, idempotency verification, revert
+  snapshots), with the codemod authored as a package export the user owns. Do
+  not grow the built-in engine to execute user-authored transforms; the dividing
+  line is who authored the transform.
 
 ## Codemod contract
 

--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -48,9 +48,11 @@ and publish paths are covered in
   [`@kentcdodds/codemod-runner`](https://heykody.dev/community/b06c0f98-865a-4379-adb0-d0fb2cdda14f)
   community package: same contract vocabulary (`detect`/`transform`,
   dry-run-before-apply, drift skips, idempotency verification, revert
-  snapshots), with the codemod authored as a package export the user owns. Do
-  not grow the built-in engine to execute user-authored transforms; the dividing
-  line is who authored the transform.
+  snapshots), with the codemod authored as a package export the user owns. As
+  with any community package, inspect the source and fork (which pins your own
+  copy) before running it against your packages. Do not grow the built-in engine
+  to execute user-authored transforms; the dividing line is who authored the
+  transform.
 
 ## Codemod contract
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only follow-up to [#1049](https://github.com/kentcdodds/kody/pull/1049).

Adds one entry to the "codemods are not" list in `docs/contributing/package-codemods.md` marking the scope boundary of the built-in engine: platform-authored migrations live in-repo (version-coupled, CI-tested, fleet-reaching), while user-authored transforms over a user's own packages are a userland pattern — now packaged as the [`@kentcdodds/codemod-runner`](https://heykody.dev/community/b06c0f98-865a-4379-adb0-d0fb2cdda14f) community package (same contract vocabulary: `detect`/`transform`, dry-run-before-apply, drift skips, idempotency verification, revert snapshots). The dividing line documented: who authored the transform.

No code changes; `format:check` green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0ac2c03-d931-4b7f-b698-b1715e8b86c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0ac2c03-d931-4b7f-b698-b1715e8b86c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between personal (user-authored) codemods and built-in platform codemods.
  * Directed readers transforming their own packages to use existing user capabilities and community tooling.
  * Added guidance to review the community package source and fork/pin before running it, and reiterated that built-in engines shouldn’t run user-authored transforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->