### PR TITLE
Add workflow_run_cancel: first-class workflow run cancellation

### DIFF
--- a/docs/use/workflows.md
+++ b/docs/use/workflows.md
@@ -74,7 +74,10 @@ Cancelling an already-finished run (`complete`, `errored`, `terminated`, or
 `cancelled`) is a safe no-op: the response has `cancelled: false` and
 `already_terminal: true` with the run's terminal status. Cancelling is
 idempotent. If the run finishes in the moment you cancel it, the cancel reports
-the run's actual terminal status instead of pretending it was cancelled.
+the run's actual terminal status instead of pretending it was cancelled. In rare
+races a cancelled run can instead surface as `terminated` (the engine's own
+terminal status) — treat `cancelled` and `terminated` both as "the run was
+stopped".
 
 A cancelled run keeps single-flighting its idempotency key, exactly like a
 `complete` or `errored` run — calling `workflows.create` again with the same key

--- a/docs/use/workflows.md
+++ b/docs/use/workflows.md
@@ -11,7 +11,7 @@ longer sandbox budget (~4.5 minutes, under the Cloudflare Workflow step timeout)
 and run without the package-invocation idempotency ledger, so a step retry
 re-executes instead of replaying a cached timeout. The initial `execute` call
 should submit one `workflows.create`; inspect that workflow later with
-`workflow_run_list`.
+`workflow_run_list`, or cancel it with `workflow_run_cancel`.
 
 ```ts
 import { workflows } from 'kody:runtime'
@@ -56,7 +56,45 @@ example `storage-sweep:2026-05-08`. Kody enforces a finite per-user concurrent
 workflow limit from the account plan (free 3, pro 50, partner 100, max 5000); if
 the cap is reached, `workflows.create` returns a clear quota error.
 
-Use `workflow_run_list` to inspect recent workflow runs and statuses.
+Use `workflow_run_list` to inspect recent workflow runs and statuses, and
+`workflow_run_cancel` to stop a run by id.
+
+## Cancelling workflow runs
+
+`workflow_run_cancel({ id })` cancels one workflow run by id. Run ids look like
+`dynwf-…` for inline runs and `pkgwf-…` for package runs; get them from
+`workflows.create` output or `workflow_run_list`. The call terminates the
+underlying Cloudflare Workflow instance and marks the run `cancelled` in
+`workflow_run_list`.
+
+You can only cancel your own runs. Unknown ids or another user's id return a
+"not found" error.
+
+Cancelling an already-finished run (`complete`, `errored`, `terminated`, or
+`cancelled`) is a safe no-op: the response has `cancelled: false` and
+`already_terminal: true` with the run's terminal status. Cancelling is
+idempotent. If the run finishes in the moment you cancel it, the cancel reports
+the run's actual terminal status instead of pretending it was cancelled.
+
+A cancelled run keeps single-flighting its idempotency key, exactly like a
+`complete` or `errored` run — calling `workflows.create` again with the same key
+returns the cancelled run instead of starting a new one. To genuinely re-run,
+pick a new idempotency key. This prevents a cancelled self-rescheduling chain
+from being accidentally revived by a retry that reuses old keys.
+
+Cancelling one run does not un-schedule runs it already created. Each queued run
+is an independent workflow instance — use `workflow_run_list` to find every
+queued run in the chain and cancel each one by id. A run that is mid-execution
+may still create its successor before termination lands, so list again after
+cancelling to catch stragglers.
+
+```ts
+import { kody } from 'kody:runtime'
+
+export default async function main() {
+	return await kody.workflow_run_cancel({ id: 'dynwf-abc123' })
+}
+```
 
 ## Package export example
 

--- a/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
@@ -460,6 +460,85 @@ test('runWithDurableEscalation never throws and reports structured failures', as
 	})
 })
 
+test('budget exhaustion fails closed when create single-flights onto a dead terminal run', async () => {
+	const hangUntilAborted = vi.fn(
+		async (signal: AbortSignal) =>
+			await new Promise<never>((_resolve, reject) => {
+				signal.addEventListener(
+					'abort',
+					() => {
+						reject(new DOMException('Aborted', 'AbortError'))
+					},
+					{ once: true },
+				)
+			}),
+	)
+
+	mockModule.createDynamicCallableWorkflow.mockResolvedValueOnce({
+		ok: true,
+		id: 'dynwf-cancelled-1',
+		workflow_name: 'package_publish_external_push',
+		source_type: 'inline',
+		run_at: '2026-07-27T00:00:00.000Z',
+		plan_date: '2026-07-27',
+		status: 'cancelled',
+	})
+	const cancelledOutcome = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb(),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyParts: publishParts,
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+	expect(cancelledOutcome.kind).toBe('failed')
+	if (cancelledOutcome.kind !== 'failed') {
+		throw new Error('Expected cancelled single-flight to fail closed.')
+	}
+	expect(cancelledOutcome.error).toContain('dynwf-cancelled-1')
+	expect(cancelledOutcome.error).toContain('cancelled')
+	expect(cancelledOutcome.error).toContain('blocks re-dispatch')
+
+	mockModule.createDynamicCallableWorkflow.mockResolvedValueOnce({
+		ok: true,
+		id: 'dynwf-complete-1',
+		workflow_name: 'package_publish_external_push',
+		source_type: 'inline',
+		run_at: '2026-07-27T00:00:00.000Z',
+		plan_date: '2026-07-27',
+		status: 'complete',
+	})
+	const completeParts = [...publishParts, 'complete-replay'] as const
+	const completeOutcome = await runWithDurableEscalation({
+		env: {
+			APP_DB: createWorkflowRunsDb(),
+			DYNAMIC_CALLABLE_WORKFLOWS: {} as Workflow,
+		} as Env,
+		userId: 'user-1',
+		idempotencyParts: completeParts,
+		workflowName: 'package_publish_external_push',
+		durableCode: 'export default async function main() { return null }',
+		budgetMs: 30,
+		run: hangUntilAborted,
+	})
+	expect(completeOutcome).toEqual({
+		kind: 'dispatched',
+		handle: expect.objectContaining({
+			status: 'dispatched',
+			workflow_id: 'dynwf-complete-1',
+			run_status: 'complete',
+			idempotency_key: buildCallerScopedIdempotencyKey({
+				userId: 'user-1',
+				parts: completeParts,
+			}),
+		}),
+	})
+})
+
 test('budget abort dispatches while the inline attempt is still in flight', async () => {
 	const events: Array<string> = []
 	mockModule.createDynamicCallableWorkflow.mockImplementation(async () => {

--- a/packages/worker/src/mcp/capabilities/durable-escalation.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.ts
@@ -28,11 +28,21 @@ export type DurableEscalationOutcome<T> =
  * createDynamicCallableWorkflow: active Cloudflare statuses plus any
  * transitional D1 projection status written before the instance is queued
  * (today that transitional value is `creating`). New pre-active statuses are
- * covered automatically; only completed/errored/terminated runs allow another
- * inline attempt.
+ * covered automatically; only terminal runs (complete/errored/terminated/
+ * cancelled) allow another inline attempt.
  */
 export const alreadyDispatchedWorkflowStatusExclusion =
 	terminalWorkflowStatusValues
+
+/**
+ * Terminal create() statuses that mean the durable work did not succeed.
+ * `complete` is excluded: a finished run under the key is an honest dispatched
+ * handle (the work already happened). Derived from terminalWorkflowStatusValues
+ * so cancelled stays aligned with the cancel projection.
+ */
+const deadDurableEscalationStatuses = new Set<string>(
+	terminalWorkflowStatusValues.filter((status) => status !== 'complete'),
+)
 
 /**
  * Compose a workflow_runs idempotency key that is always scoped to the same
@@ -274,6 +284,15 @@ export async function runWithDurableEscalation<T>(input: {
 				params: input.durableParams,
 			},
 		})
+		if (
+			typeof workflow.status === 'string' &&
+			deadDurableEscalationStatuses.has(workflow.status)
+		) {
+			return {
+				kind: 'failed',
+				error: `A previous durable run "${workflow.id}" for this operation ended with status "${workflow.status}" and its idempotency key blocks re-dispatch; the durable work did not run.`,
+			}
+		}
 		return {
 			kind: 'dispatched',
 			handle: createDispatchedHandle({ workflow, idempotencyKey }),

--- a/packages/worker/src/mcp/capabilities/durable-escalation.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.ts
@@ -290,7 +290,7 @@ export async function runWithDurableEscalation<T>(input: {
 		) {
 			return {
 				kind: 'failed',
-				error: `A previous durable run "${workflow.id}" for this operation ended with status "${workflow.status}" and its idempotency key blocks re-dispatch; the durable work did not run.`,
+				error: `A previous durable run "${workflow.id}" for this operation ended with status "${workflow.status}" and its idempotency key blocks re-dispatch; the durable work did not complete successfully.`,
 			}
 		}
 		return {

--- a/packages/worker/src/mcp/capabilities/jobs/domain.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/domain.ts
@@ -7,6 +7,7 @@ import { jobRunNowCapability } from './job-run-now.ts'
 import { jobScheduleCapability } from './job-schedule.ts'
 import { jobScheduleOnceCapability } from './job-schedule-once.ts'
 import { jobUpdateCapability } from './job-update.ts'
+import { workflowCancelCapability } from './workflow-cancel.ts'
 import { workflowListCapability } from './workflow-list.ts'
 
 export const jobsDomain = defineDomain({
@@ -28,6 +29,9 @@ export const jobsDomain = defineDomain({
 		'inspect',
 		'run now',
 		'immediate',
+		'cancel',
+		'stop',
+		'workflow',
 	],
 	capabilities: [
 		jobListCapability,
@@ -38,5 +42,6 @@ export const jobsDomain = defineDomain({
 		jobDeleteCapability,
 		jobRunNowCapability,
 		workflowListCapability,
+		workflowCancelCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/jobs/workflow-cancel.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/workflow-cancel.node.test.ts
@@ -1,0 +1,106 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	cancelWorkflowRunForUser: vi.fn(),
+}))
+
+vi.mock('#worker/package-runtime/package-workflows.ts', () => ({
+	cancelWorkflowRunForUser: (...args: Array<unknown>) =>
+		mockModule.cancelWorkflowRunForUser(...args),
+}))
+
+const { workflowCancelCapability } = await import('./workflow-cancel.ts')
+
+test('workflow_run_cancel maps service outcomes for the signed-in user', async () => {
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-123',
+			email: 'user@example.com',
+			displayName: 'User Example',
+		},
+	})
+
+	mockModule.cancelWorkflowRunForUser.mockResolvedValueOnce({
+		outcome: 'not_found',
+	})
+	await expect(
+		workflowCancelCapability.handler(
+			{ id: 'dynwf-missing' },
+			{ env, callerContext },
+		),
+	).rejects.toThrow('was not found for the current user')
+	expect(mockModule.cancelWorkflowRunForUser).toHaveBeenCalledWith({
+		env,
+		userId: 'user-123',
+		workflowRunId: 'dynwf-missing',
+	})
+
+	mockModule.cancelWorkflowRunForUser.mockResolvedValueOnce({
+		outcome: 'cancelled',
+		run: {
+			id: 'dynwf-123',
+			userId: 'user-123',
+			sourceType: 'inline',
+			packageId: null,
+			kodyId: null,
+			sourceId: null,
+			workflowName: 'inline-code',
+			exportName: null,
+			idempotencyKey: 'cancel-key',
+			runAt: '2026-05-03T12:00:00.000Z',
+			planDate: '2026-05-03',
+			status: 'cancelled',
+			createdAt: '2026-05-03T11:59:00.000Z',
+			updatedAt: '2026-05-03T12:00:01.000Z',
+			completedAt: '2026-05-03T12:00:01.000Z',
+			lastError: null,
+		},
+	})
+	const cancelled = await workflowCancelCapability.handler(
+		{ id: 'dynwf-123' },
+		{ env, callerContext },
+	)
+	expect(cancelled).toEqual({
+		id: 'dynwf-123',
+		cancelled: true,
+		already_terminal: false,
+		status: 'cancelled',
+		message: 'Workflow run cancelled.',
+	})
+
+	mockModule.cancelWorkflowRunForUser.mockResolvedValueOnce({
+		outcome: 'already_terminal',
+		run: {
+			id: 'dynwf-done',
+			userId: 'user-123',
+			sourceType: 'inline',
+			packageId: null,
+			kodyId: null,
+			sourceId: null,
+			workflowName: 'inline-code',
+			exportName: null,
+			idempotencyKey: 'done-key',
+			runAt: '2026-05-03T12:00:00.000Z',
+			planDate: '2026-05-03',
+			status: 'complete',
+			createdAt: '2026-05-03T11:59:00.000Z',
+			updatedAt: '2026-05-03T12:00:01.000Z',
+			completedAt: '2026-05-03T12:00:01.000Z',
+			lastError: null,
+		},
+	})
+	const alreadyTerminal = await workflowCancelCapability.handler(
+		{ id: 'dynwf-done' },
+		{ env, callerContext },
+	)
+	expect(alreadyTerminal).toMatchObject({
+		id: 'dynwf-done',
+		cancelled: false,
+		already_terminal: true,
+		status: 'complete',
+	})
+	expect(alreadyTerminal.message).toContain('complete')
+})

--- a/packages/worker/src/mcp/capabilities/jobs/workflow-cancel.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/workflow-cancel.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+
+export const workflowCancelCapability = defineDomainCapability(
+	capabilityDomainNames.jobs,
+	{
+		name: 'workflow_run_cancel',
+		description:
+			'Cancel a Cloudflare Workflow run created through kody:runtime workflows.create by id. Terminates the underlying workflow instance and marks the run cancelled; cancelling an already-finished run is a safe no-op.',
+		keywords: [
+			'workflow',
+			'cancel',
+			'stop',
+			'terminate',
+			'abort',
+			'kill',
+			'halt',
+			'background',
+		],
+		readOnly: false,
+		idempotent: true,
+		destructive: true,
+		inputSchema: z.object({
+			id: z
+				.string()
+				.min(1)
+				.describe(
+					'Workflow run id from workflow_run_list or workflows.create output (dynwf-… inline runs or pkgwf-… package runs).',
+				),
+		}),
+		outputSchema: z.object({
+			id: z.string(),
+			cancelled: z.boolean(),
+			already_terminal: z.boolean(),
+			status: z
+				.enum([
+					'queued',
+					'running',
+					'paused',
+					'waiting',
+					'waitingForPause',
+					'unknown',
+					'complete',
+					'errored',
+					'terminated',
+					'cancelled',
+				])
+				.nullable(),
+			message: z.string(),
+		}),
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const { cancelWorkflowRunForUser } =
+				await import('#worker/package-runtime/package-workflows.ts')
+			const result = await cancelWorkflowRunForUser({
+				env: ctx.env,
+				userId: user.userId,
+				workflowRunId: args.id,
+			})
+			switch (result.outcome) {
+				case 'not_found':
+					throw new Error(
+						`Workflow run "${args.id}" was not found for the current user.`,
+					)
+				case 'already_terminal':
+					return {
+						id: result.run.id,
+						cancelled: false,
+						already_terminal: true,
+						status: result.run.status,
+						message: `Workflow run already finished with status "${result.run.status}"; cancellation is a no-op.`,
+					}
+				case 'cancelled':
+					return {
+						id: result.run.id,
+						cancelled: true,
+						already_terminal: false,
+						status: result.run.status,
+						message: 'Workflow run cancelled.',
+					}
+				default: {
+					const exhaustive: never = result
+					throw new Error(
+						`Unhandled cancelWorkflowRunForUser outcome: ${JSON.stringify(exhaustive)}`,
+					)
+				}
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/jobs/workflow-list.ts
+++ b/packages/worker/src/mcp/capabilities/jobs/workflow-list.ts
@@ -25,6 +25,7 @@ const workflowRunSchema = z.object({
 			'complete',
 			'errored',
 			'terminated',
+			'cancelled',
 		])
 		.nullable(),
 	created_at: z.string(),

--- a/packages/worker/src/package-runtime/package-workflows-cancel.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows-cancel.node.test.ts
@@ -1,0 +1,406 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	cancelWorkflowRunForUser,
+	createDynamicCallableWorkflow,
+	listWorkflowRunsForUser,
+} from './package-workflows.ts'
+
+const workflowRunsDdl = `
+CREATE TABLE IF NOT EXISTS workflow_runs (
+	id TEXT PRIMARY KEY,
+	user_id TEXT NOT NULL,
+	source_type TEXT NOT NULL CHECK (source_type IN ('package', 'inline')),
+	package_id TEXT,
+	kody_id TEXT,
+	source_id TEXT,
+	workflow_name TEXT NOT NULL,
+	export_name TEXT,
+	idempotency_key TEXT NOT NULL,
+	run_at TEXT NOT NULL,
+	plan_date TEXT,
+	status TEXT,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	completed_at TEXT,
+	last_error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS workflow_runs_user_created_idx
+ON workflow_runs(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS workflow_runs_user_active_idx
+ON workflow_runs(user_id, status);
+`
+
+type FakeInstanceOptions = {
+	status?: string
+	terminateThrows?: Error | null
+	statusAfterTerminate?: string
+}
+
+function createCancelTestBinding(options?: {
+	missingIds?: Set<string>
+	perInstance?: Map<string, FakeInstanceOptions>
+}) {
+	const instances = new Map<string, WorkflowInstanceCreateOptions>()
+	const terminateCalls: Array<string> = []
+	const missingIds = options?.missingIds ?? new Set<string>()
+	const perInstance =
+		options?.perInstance ?? new Map<string, FakeInstanceOptions>()
+
+	const create = vi.fn(async (input: WorkflowInstanceCreateOptions) => {
+		if (instances.has(input.id)) {
+			throw new Error('Workflow instance already exists')
+		}
+		instances.set(input.id, input)
+		return createInstanceHandle(input.id)
+	})
+
+	function createInstanceHandle(id: string) {
+		const knobs = perInstance.get(id) ?? {}
+		return {
+			id,
+			status: async () => ({
+				status: knobs.statusAfterTerminate ?? knobs.status ?? 'queued',
+			}),
+			terminate: vi.fn(async () => {
+				terminateCalls.push(id)
+				if (knobs.terminateThrows) throw knobs.terminateThrows
+				knobs.status = 'terminated'
+				knobs.statusAfterTerminate = 'terminated'
+			}),
+		}
+	}
+
+	const get = vi.fn(async (id: string) => {
+		if (missingIds.has(id) || !instances.has(id)) {
+			throw new Error('workflow instance does not exist')
+		}
+		return createInstanceHandle(id)
+	})
+
+	return {
+		workflow: { get, create } as unknown as Workflow,
+		get,
+		create,
+		instances,
+		terminateCalls,
+		missingIds,
+		perInstance,
+	}
+}
+
+function createWorkflowRunsDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(workflowRunsDdl)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function readWorkflowRunRow(sqlite: DatabaseSync, id: string) {
+	return sqlite
+		.prepare(
+			`SELECT id, user_id, status, completed_at, updated_at, idempotency_key
+			FROM workflow_runs WHERE id = ?`,
+		)
+		.get(id) as
+		| {
+				id: string
+				user_id: string
+				status: string | null
+				completed_at: string | null
+				updated_at: string
+				idempotency_key: string
+		  }
+		| undefined
+}
+
+test('cancelWorkflowRunForUser cancels a queued run and is idempotent', async () => {
+	const binding = createCancelTestBinding()
+	const { sqlite, db } = createWorkflowRunsDb()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+	} as Env
+
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main() { return { ok: true } }',
+			idempotencyKey: 'cancel-idempotent-key',
+			runAt: '2026-05-03T12:34:56.000Z',
+		},
+	})
+	expect(created.status).toBe('queued')
+	expect(binding.create).toHaveBeenCalledTimes(1)
+
+	const cancelled = await cancelWorkflowRunForUser({
+		env,
+		userId: 'user-1',
+		workflowRunId: created.id,
+	})
+	expect(cancelled).toMatchObject({
+		outcome: 'cancelled',
+		run: {
+			id: created.id,
+			status: 'cancelled',
+			completedAt: expect.any(String),
+		},
+	})
+	expect(binding.terminateCalls).toEqual([created.id])
+	const row = readWorkflowRunRow(sqlite, created.id)
+	expect(row).toMatchObject({
+		status: 'cancelled',
+		completed_at: expect.any(String),
+	})
+
+	const listed = await listWorkflowRunsForUser({
+		env,
+		userId: 'user-1',
+		limit: 10,
+	})
+	expect(listed).toEqual([
+		expect.objectContaining({
+			id: created.id,
+			status: 'cancelled',
+		}),
+	])
+
+	const again = await cancelWorkflowRunForUser({
+		env,
+		userId: 'user-1',
+		workflowRunId: created.id,
+	})
+	expect(again).toMatchObject({
+		outcome: 'already_terminal',
+		run: { id: created.id, status: 'cancelled' },
+	})
+	expect(binding.terminateCalls).toEqual([created.id])
+})
+
+test('cancelWorkflowRunForUser enforces user isolation', async () => {
+	const binding = createCancelTestBinding()
+	const { sqlite, db } = createWorkflowRunsDb()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+	} as Env
+
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main() { return { ok: true } }',
+			idempotencyKey: 'isolation-key',
+			runAt: '2026-05-03T12:34:56.000Z',
+		},
+	})
+	const before = readWorkflowRunRow(sqlite, created.id)
+	binding.get.mockClear()
+	binding.create.mockClear()
+
+	const result = await cancelWorkflowRunForUser({
+		env,
+		userId: 'user-2',
+		workflowRunId: created.id,
+	})
+	expect(result).toEqual({ outcome: 'not_found' })
+	expect(binding.terminateCalls).toEqual([])
+	expect(binding.get).not.toHaveBeenCalled()
+	expect(readWorkflowRunRow(sqlite, created.id)).toEqual(before)
+	expect(before?.status).toBe('queued')
+})
+
+test('a cancelled run keeps single-flighting its idempotency key', async () => {
+	const binding = createCancelTestBinding()
+	const { db } = createWorkflowRunsDb()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+	} as Env
+
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main() { return { ok: true } }',
+			idempotencyKey: 'single-flight-key',
+			runAt: '2026-05-03T12:34:56.000Z',
+		},
+	})
+	await cancelWorkflowRunForUser({
+		env,
+		userId: 'user-1',
+		workflowRunId: created.id,
+	})
+	expect(binding.create).toHaveBeenCalledTimes(1)
+
+	const replay = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main() { return { ok: true } }',
+			idempotencyKey: 'single-flight-key',
+			runAt: '2026-05-03T12:35:56.000Z',
+		},
+	})
+	expect(replay.id).toBe(created.id)
+	expect(replay.status).toBe('cancelled')
+	expect(binding.create).toHaveBeenCalledTimes(1)
+
+	const fresh = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main() { return { ok: true } }',
+			idempotencyKey: 'single-flight-key-other',
+			runAt: '2026-05-03T12:36:56.000Z',
+		},
+	})
+	expect(fresh.id).not.toBe(created.id)
+	expect(fresh.status).toBe('queued')
+	expect(binding.create).toHaveBeenCalledTimes(2)
+})
+
+test('cancel races with a run that finishes first', async () => {
+	const { sqlite, db } = createWorkflowRunsDb()
+	const completeRaceBinding = createCancelTestBinding()
+	const completeEnv = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: completeRaceBinding.workflow,
+	} as Env
+	const completeCreated = await createDynamicCallableWorkflow({
+		env: completeEnv,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main() { return { ok: true } }',
+			idempotencyKey: 'race-complete-key',
+			runAt: '2026-05-03T12:34:56.000Z',
+		},
+	})
+	completeRaceBinding.perInstance.set(completeCreated.id, {
+		terminateThrows: new Error(
+			'Instance is in a state that cannot be terminated',
+		),
+		statusAfterTerminate: 'complete',
+	})
+
+	const completeResult = await cancelWorkflowRunForUser({
+		env: completeEnv,
+		userId: 'user-1',
+		workflowRunId: completeCreated.id,
+	})
+	expect(completeResult).toMatchObject({
+		outcome: 'already_terminal',
+		run: {
+			id: completeCreated.id,
+			status: 'complete',
+			completedAt: expect.any(String),
+		},
+	})
+	expect(readWorkflowRunRow(sqlite, completeCreated.id)).toMatchObject({
+		status: 'complete',
+		completed_at: expect.any(String),
+	})
+
+	const runningRaceSqlite = new DatabaseSync(':memory:')
+	runningRaceSqlite.exec(workflowRunsDdl)
+	const runningDb = createD1FromSqlite(runningRaceSqlite)
+	const runningRaceBinding = createCancelTestBinding()
+	const runningEnv = {
+		APP_DB: runningDb,
+		DYNAMIC_CALLABLE_WORKFLOWS: runningRaceBinding.workflow,
+	} as Env
+	const runningCreated = await createDynamicCallableWorkflow({
+		env: runningEnv,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main() { return { ok: true } }',
+			idempotencyKey: 'race-running-key',
+			runAt: '2026-05-03T12:34:56.000Z',
+		},
+	})
+	const terminateError = new Error(
+		'Instance is in a state that cannot be terminated',
+	)
+	runningRaceBinding.perInstance.set(runningCreated.id, {
+		terminateThrows: terminateError,
+		statusAfterTerminate: 'running',
+	})
+
+	await expect(
+		cancelWorkflowRunForUser({
+			env: runningEnv,
+			userId: 'user-1',
+			workflowRunId: runningCreated.id,
+		}),
+	).rejects.toThrow('Instance is in a state that cannot be terminated')
+	expect(
+		readWorkflowRunRow(runningRaceSqlite, runningCreated.id),
+	).toMatchObject({
+		status: 'queued',
+		completed_at: null,
+	})
+})
+
+test('cancelling a run whose engine instance is missing still projects cancelled', async () => {
+	const { sqlite, db } = createWorkflowRunsDb()
+	const binding = createCancelTestBinding()
+	const now = '2026-05-03T12:34:56.000Z'
+	const runId = 'dynwf-missing-instance'
+	await db
+		.prepare(
+			`INSERT INTO workflow_runs (
+				id, user_id, source_type, package_id, kody_id, source_id,
+				workflow_name, export_name, idempotency_key, run_at, plan_date,
+				status, created_at, updated_at, completed_at, last_error
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			runId,
+			'user-1',
+			'inline',
+			null,
+			null,
+			null,
+			'inline-code',
+			null,
+			'missing-instance-key',
+			now,
+			'2026-05-03',
+			'queued',
+			now,
+			now,
+			null,
+			null,
+		)
+		.run()
+	binding.missingIds.add(runId)
+
+	const result = await cancelWorkflowRunForUser({
+		env: {
+			APP_DB: db,
+			DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+		} as Env,
+		userId: 'user-1',
+		workflowRunId: runId,
+	})
+	expect(result).toMatchObject({
+		outcome: 'cancelled',
+		run: { id: runId, status: 'cancelled' },
+	})
+	expect(binding.terminateCalls).toEqual([])
+	expect(readWorkflowRunRow(sqlite, runId)).toMatchObject({
+		status: 'cancelled',
+		completed_at: expect.any(String),
+	})
+})

--- a/packages/worker/src/package-runtime/package-workflows-cancel.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows-cancel.node.test.ts
@@ -38,6 +38,7 @@ type FakeInstanceOptions = {
 	status?: string
 	terminateThrows?: Error | null
 	statusAfterTerminate?: string
+	onTerminate?: () => void | Promise<void>
 }
 
 function createCancelTestBinding(options?: {
@@ -67,6 +68,7 @@ function createCancelTestBinding(options?: {
 			}),
 			terminate: vi.fn(async () => {
 				terminateCalls.push(id)
+				if (knobs.onTerminate) await knobs.onTerminate()
 				if (knobs.terminateThrows) throw knobs.terminateThrows
 				knobs.status = 'terminated'
 				knobs.statusAfterTerminate = 'terminated'
@@ -349,6 +351,56 @@ test('cancel races with a run that finishes first', async () => {
 	).toMatchObject({
 		status: 'queued',
 		completed_at: null,
+	})
+})
+
+test('cancel projection loses to a concurrent complete write', async () => {
+	const { sqlite, db } = createWorkflowRunsDb()
+	const binding = createCancelTestBinding()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+	} as Env
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main() { return { ok: true } }',
+			idempotencyKey: 'guarded-projection-key',
+			runAt: '2026-05-03T12:34:56.000Z',
+		},
+	})
+	const completedAt = '2026-05-03T12:35:00.000Z'
+	binding.perInstance.set(created.id, {
+		onTerminate: async () => {
+			await db
+				.prepare(
+					`UPDATE workflow_runs
+					SET status = 'complete', completed_at = ?, updated_at = ?
+					WHERE id = ? AND user_id = ?`,
+				)
+				.bind(completedAt, completedAt, created.id, 'user-1')
+				.run()
+		},
+	})
+
+	const result = await cancelWorkflowRunForUser({
+		env,
+		userId: 'user-1',
+		workflowRunId: created.id,
+	})
+	expect(result).toMatchObject({
+		outcome: 'already_terminal',
+		run: {
+			id: created.id,
+			status: 'complete',
+			completedAt,
+		},
+	})
+	expect(readWorkflowRunRow(sqlite, created.id)).toMatchObject({
+		status: 'complete',
+		completed_at: completedAt,
 	})
 })
 

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -950,6 +950,105 @@ export async function createDynamicCallableWorkflow(input: {
 	return createWorkflowCreateResult({ summary, payload })
 }
 
+export type CancelWorkflowRunResult =
+	| { outcome: 'not_found' }
+	| { outcome: 'already_terminal'; run: WorkflowRunInspection }
+	| { outcome: 'cancelled'; run: WorkflowRunInspection }
+
+export async function cancelWorkflowRunForUser(input: {
+	env: Pick<Env, 'APP_DB' | 'DYNAMIC_CALLABLE_WORKFLOWS'>
+	userId: string
+	workflowRunId: string
+}): Promise<CancelWorkflowRunResult> {
+	const workflowRunId = normalizeNonEmptyString(
+		input.workflowRunId,
+		'workflowRunId',
+	)
+	// USER-ISOLATION BOUNDARY: never touch the workflow binding before this
+	// ownership check passes.
+	const result = await input.env.APP_DB.prepare(
+		`SELECT * FROM workflow_runs WHERE id = ? AND user_id = ? LIMIT 1`,
+	)
+		.bind(workflowRunId, input.userId)
+		.first<Record<string, unknown>>()
+	if (!result) {
+		return { outcome: 'not_found' }
+	}
+	const row = mapWorkflowRunRow(result)
+	if (row.status !== null && terminalWorkflowStatuses.has(row.status)) {
+		return { outcome: 'already_terminal', run: row }
+	}
+	if (!input.env.DYNAMIC_CALLABLE_WORKFLOWS) {
+		throw new Error('Missing DYNAMIC_CALLABLE_WORKFLOWS binding.')
+	}
+	let instance: WorkflowInstance | null = null
+	try {
+		instance = await input.env.DYNAMIC_CALLABLE_WORKFLOWS.get(row.id)
+	} catch (error) {
+		if (!isMissingWorkflowInstanceError(error)) {
+			throw error
+		}
+	}
+	if (instance) {
+		try {
+			// Terminate before projecting cancelled: if the run finishes first,
+			// terminate throws instead of stamping cancelled over a finished run.
+			await instance.terminate()
+		} catch (error) {
+			const statusResult = await instance.status()
+			const engineStatus =
+				typeof statusResult?.status === 'string' ? statusResult.status : null
+			if (engineStatus && terminalWorkflowStatuses.has(engineStatus)) {
+				const now = new Date().toISOString()
+				await input.env.APP_DB.prepare(
+					`UPDATE workflow_runs
+					SET status = ?, updated_at = ?, completed_at = COALESCE(completed_at, ?)
+					WHERE id = ? AND user_id = ?`,
+				)
+					.bind(engineStatus, now, now, row.id, input.userId)
+					.run()
+				return {
+					outcome: 'already_terminal',
+					run: {
+						...row,
+						status: engineStatus as WorkflowRunStatus,
+						updatedAt: now,
+						completedAt: row.completedAt ?? now,
+					},
+				}
+			}
+			throw error
+		}
+	} else {
+		// Missing instance (stuck `creating`, or engine retention expiry): nothing
+		// can fire, so projecting cancelled is safe. A concurrent create may still
+		// be in flight for a `creating` row; its own status projection would then
+		// surface the run again as active, which is visible and re-cancellable
+		// (deliberately no extra guard — creation semantics must not change).
+	}
+	const now = new Date().toISOString()
+	// Accepted straggler race: a `mark workflow running` step write that lands
+	// after this cancelled projection can flip the row back to an active status;
+	// the next listWorkflowRunsForUser refresh then projects the engine's
+	// terminal `terminated`. Self-healing; no guard added on purpose.
+	await input.env.APP_DB.prepare(
+		`UPDATE workflow_runs
+		SET status = 'cancelled', updated_at = ?, completed_at = COALESCE(completed_at, ?)
+		WHERE id = ? AND user_id = ?`,
+	)
+		.bind(now, now, row.id, input.userId)
+		.run()
+	return {
+		outcome: 'cancelled',
+		run: {
+			...row,
+			status: 'cancelled',
+			updatedAt: now,
+			completedAt: row.completedAt ?? now,
+		},
+	}
+}
+
 export async function listWorkflowRunsForUser(input: {
 	env: Pick<Env, 'APP_DB' | 'DYNAMIC_CALLABLE_WORKFLOWS'>
 	userId: string

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -1076,9 +1076,10 @@ export async function cancelWorkflowRunForUser(input: {
 	// An active straggler write (for example `mark workflow running`) landed
 	// between the guarded update and the re-read. The terminate already
 	// succeeded (or the instance was missing), so the cancellation itself
-	// worked; the row self-heals to the engine's terminal status on the next
+	// worked; report the effective cancelled status to the caller while the
+	// row self-heals to the engine's terminal status on the next
 	// listWorkflowRunsForUser refresh.
-	return { outcome: 'cancelled', run: projectedRun }
+	return { outcome: 'cancelled', run: { ...projectedRun, status: 'cancelled' } }
 }
 
 export async function listWorkflowRunsForUser(input: {

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -995,7 +995,15 @@ export async function cancelWorkflowRunForUser(input: {
 			// terminate throws instead of stamping cancelled over a finished run.
 			await instance.terminate()
 		} catch (error) {
-			const statusResult = await instance.status()
+			// Per Cloudflare WorkflowInstance.terminate (worker-configuration.d.ts):
+			// "Terminate the instance. If it is errored, terminated or complete, an
+			// error will be thrown." — that contract makes catch-and-reread correct.
+			let statusResult: { status?: string } | null = null
+			try {
+				statusResult = await instance.status()
+			} catch {
+				throw error
+			}
 			const engineStatus =
 				typeof statusResult?.status === 'string' ? statusResult.status : null
 			if (engineStatus && terminalWorkflowStatuses.has(engineStatus)) {
@@ -1027,26 +1035,50 @@ export async function cancelWorkflowRunForUser(input: {
 		// (deliberately no extra guard — creation semantics must not change).
 	}
 	const now = new Date().toISOString()
-	// Accepted straggler race: a `mark workflow running` step write that lands
-	// after this cancelled projection can flip the row back to an active status;
-	// the next listWorkflowRunsForUser refresh then projects the engine's
-	// terminal `terminated`. Self-healing; no guard added on purpose.
+	const terminalStatusPlaceholders = terminalWorkflowStatusValues
+		.map(() => '?')
+		.join(', ')
+	// Guard against stamping cancelled over a concurrent terminal D1 write
+	// (complete/errored/…) that landed while terminate still succeeded — the
+	// engine can still report running when the workflow's own terminal step
+	// write has already finished. Re-SELECT decides the winner; do not trust
+	// meta.changes. An active straggler (`mark workflow running`) that lands
+	// after a successful cancelled projection can still flip the row back; the
+	// next listWorkflowRunsForUser refresh then projects engine `terminated`.
 	await input.env.APP_DB.prepare(
 		`UPDATE workflow_runs
 		SET status = 'cancelled', updated_at = ?, completed_at = COALESCE(completed_at, ?)
-		WHERE id = ? AND user_id = ?`,
+		WHERE id = ? AND user_id = ?
+			AND COALESCE(status, '') NOT IN (${terminalStatusPlaceholders})`,
 	)
-		.bind(now, now, row.id, input.userId)
+		.bind(now, now, row.id, input.userId, ...terminalWorkflowStatusValues)
 		.run()
-	return {
-		outcome: 'cancelled',
-		run: {
-			...row,
-			status: 'cancelled',
-			updatedAt: now,
-			completedAt: row.completedAt ?? now,
-		},
+	const projected = await input.env.APP_DB.prepare(
+		`SELECT * FROM workflow_runs WHERE id = ? AND user_id = ? LIMIT 1`,
+	)
+		.bind(row.id, input.userId)
+		.first<Record<string, unknown>>()
+	if (!projected) {
+		throw new Error(
+			`Workflow run "${row.id}" disappeared while cancelling for the current user.`,
+		)
 	}
+	const projectedRun = mapWorkflowRunRow(projected)
+	if (projectedRun.status === 'cancelled') {
+		return { outcome: 'cancelled', run: projectedRun }
+	}
+	if (
+		projectedRun.status !== null &&
+		terminalWorkflowStatuses.has(projectedRun.status)
+	) {
+		return { outcome: 'already_terminal', run: projectedRun }
+	}
+	// An active straggler write (for example `mark workflow running`) landed
+	// between the guarded update and the re-read. The terminate already
+	// succeeded (or the instance was missing), so the cancellation itself
+	// worked; the row self-heals to the engine's terminal status on the next
+	// listWorkflowRunsForUser refresh.
+	return { outcome: 'cancelled', run: projectedRun }
 }
 
 export async function listWorkflowRunsForUser(input: {

--- a/packages/worker/src/package-runtime/workflow-statuses.ts
+++ b/packages/worker/src/package-runtime/workflow-statuses.ts
@@ -8,6 +8,7 @@ export type WorkflowRunStatus =
 	| 'complete'
 	| 'errored'
 	| 'terminated'
+	| 'cancelled'
 
 export const activeWorkflowStatusValues = [
 	'queued',
@@ -22,4 +23,5 @@ export const terminalWorkflowStatusValues = [
 	'complete',
 	'errored',
 	'terminated',
+	'cancelled',
 ] as const satisfies ReadonlyArray<WorkflowRunStatus>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

An agent created a self-rescheduling inline workflow chain (each run re-schedules itself with `runAt +5min` and a fresh idempotency key). There was no way to stop it: `workflow_run_list` was the only workflow capability, and the only workaround was squatting future idempotency keys with no-op workflows. This adds a real cancel.

## What

- **New user-scoped MCP capability `workflow_run_cancel`** (jobs domain): cancels a workflow run by id (`dynwf-…` inline and `pkgwf-…` package runs).
  - Ownership check (`WHERE id = ? AND user_id = ?`) runs **before** any engine access; other users' run ids and unknown ids return the same "not found" error (no existence oracle).
  - Terminates the underlying Cloudflare Workflow instance (`DYNAMIC_CALLABLE_WORKFLOWS`), then projects a new terminal **`cancelled`** status into `workflow_runs` (no migration needed; `status` is unconstrained TEXT, and the concurrency entitlement only counts active statuses, so cancelling frees quota).
  - Cancelling an already-terminal run is an idempotent no-op with `cancelled: false, already_terminal: true`.
  - Race handling: terminate-before-project ordering. If the run finishes in the race window, `terminate()` throws (per the Workers API contract); we re-read the engine status and project the actual terminal status instead of stamping `cancelled` over a finished run. The cancelled projection is additionally guarded (`… NOT IN (<terminal statuses>)` + re-read) so a concurrent terminal D1 write can never be silently overwritten, and a straggling active-step write self-heals via the existing `workflow_run_list` status refresh.
- **Idempotency-key decision (deliberate):** a cancelled run keeps single-flighting its key, exactly like `complete`/`errored` — `workflows.create` with the same user+key returns the cancelled run instead of re-creating. Rationale: a key represents one logical run forever, and a cancelled self-rescheduling chain cannot be accidentally revived by a retry reusing old keys. Re-running requires a new key. Pinned by test.
- **Durable-escalation follow-through:** since escalation idempotency keys are derived (callers cannot pick a new one), `runWithDurableEscalation` now returns a `failed` outcome with an explicit message when the key is held by a dead terminal run (`cancelled`/`errored`/`terminated`) instead of handing back a dispatched handle for work that will never run. A `complete` run under the key still yields an honest dispatched handle.
- **Docs:** `docs/use/workflows.md` gains a "Cancelling workflow runs" section, including the self-rescheduling-chain caveat (cancelling one run does not un-schedule runs it already created — list and cancel each queued run, then re-list for stragglers) and the rare `cancelled`-vs-`terminated` race.
- **Tests:** service-level tests against a real `node:sqlite`-backed D1 (cancel happy path + idempotence, cross-user isolation, single-flight-after-cancel, finish-vs-cancel race both ways, guarded projection vs concurrent terminal write, missing engine instance), capability-handler outcome mapping tests, and durable-escalation dead-key coverage.

Creation/identity semantics are otherwise unchanged. Out of scope: pause/resume, cancelling package invocations or jobs, admin fleet-cancel, UI.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1aa4702c` · **Head:** `b0760d35`

**Classification:** extends — the workflows primitive gains a cancellation operation and a new terminal `cancelled` status; no new primitive added.

### Primitives touched

| Primitive             | Group     | Impact                                                                                                          |
| --------------------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
| `workflows`           | assistant | extends — `cancelWorkflowRunForUser`, new terminal `cancelled` status, guarded terminal projection               |
| `package-runtime`     | runtime   | extends — `WorkflowRunStatus` union + `terminalWorkflowStatusValues` gain `cancelled`                            |
| `capability-registry` | assistant | extends — new `workflow_run_cancel` capability in jobs domain; durable escalation fails dead-key dispatch honestly |

### System map

`workflow_run_cancel` flows from the MCP capability registry through the workflows service into the Workflows engine binding and the D1 `workflow_runs` projection; durable escalation consumes the new terminal status.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	workflows["workflows<br/>Workflows"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	capabilityRegistry -->|"workflow_run_cancel → cancelWorkflowRunForUser(userId, id)"| workflows
	capabilityRegistry -->|"durable escalation: dead terminal key → failed outcome"| workflows
	workflows -->|"instance.terminate() on DYNAMIC_CALLABLE_WORKFLOWS"| packageRuntime
	workflows -->|"guarded UPDATE workflow_runs SET status='cancelled' WHERE id AND user_id"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- **Per-user isolation:** the ownership check (`SELECT … WHERE id = ? AND user_id = ?`) gates every cancel before any engine access; the not-found response is identical for nonexistent and other-user ids. Covered by a dedicated isolation test asserting the binding is never touched for a cross-user attempt.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bec6242-4817-47bb-b6e9-8f2eee35618f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bec6242-4817-47bb-b6e9-8f2eee35618f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `workflow_run_cancel` capability for cancelling workflow runs by ID.
  * Cancellation now enforces ownership, supports idempotent requests, and reports already-terminal runs clearly.
  * Workflow listings now include `cancelled` as a terminal status.

* **Bug Fixes**
  * Prevented re-dispatch after durable workflow runs end in terminal failure states.

* **Documentation**
  * Added guidance and examples for cancelling workflow runs, including authorization, errors, races, and chained workflows.

* **Tests**
  * Added coverage for cancellation behavior, idempotency, ownership, races, and terminal workflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->