### PR TITLE
Close the keyless packages.invoke latency gap with per-isolate, commit-keyed contract-check caches

### DIFF
--- a/docs/contributing/architecture/invocation-overhead-guardrails.md
+++ b/docs/contributing/architecture/invocation-overhead-guardrails.md
@@ -34,18 +34,18 @@ call, not about what user code does inside the call.
 
 The keyless `packages.invoke` contract check (saved-package row, entity-source
 row, manifest, bundle artifact) and per-run registry assembly are cached per
-isolate so a warm invoke of an already-warm package+commit performs **zero
-D1/KV loads** before dispatch. The caches come in two tiers with different
-correctness arguments (see
+isolate so a warm invoke of an already-warm package+commit performs **zero D1/KV
+loads** before dispatch. The caches come in two tiers with different correctness
+arguments (see
 `packages/worker/src/package-invocations/invoke-contract-cache.ts`):
 
 - **Freshness tier** — saved-package row and entity-source row (the row that
-  carries `published_commit`), TTL **15 s**. This TTL is the republish
-  staleness bound: after a republish, rename, or delete, another isolate may
-  serve the previous contract for at most 15 s. The isolate that runs the
-  projection refresh / delete invalidates eagerly, so it observes the change
-  immediately. Cache misses (unknown package) are never retained, so a
-  just-saved package is visible on the next lookup.
+  carries `published_commit`), TTL **15 s**. This TTL is the republish staleness
+  bound: after a republish, rename, or delete, another isolate may serve the
+  previous contract for at most 15 s. The isolate that runs the projection
+  refresh / delete invalidates eagerly, so it observes the change immediately.
+  Cache misses (unknown package) are never retained, so a just-saved package is
+  visible on the next lookup.
 - **Commit tier** — manifest and prepared bundle artifact, keyed by
   `published_commit` taken from the freshness tier. A commit's artifacts are
   immutable, so these entries are never a staleness source; their TTL only

--- a/docs/contributing/architecture/invocation-overhead-guardrails.md
+++ b/docs/contributing/architecture/invocation-overhead-guardrails.md
@@ -30,6 +30,37 @@ call, not about what user code does inside the call.
   finish** — no D1 round trips at all (the legacy `package_invocations` table
   and its dual-read fallback are gone).
 
+## Per-isolate caches and their staleness bounds
+
+The keyless `packages.invoke` contract check (saved-package row, entity-source
+row, manifest, bundle artifact) and per-run registry assembly are cached per
+isolate so a warm invoke of an already-warm package+commit performs **zero
+D1/KV loads** before dispatch. The caches come in two tiers with different
+correctness arguments (see
+`packages/worker/src/package-invocations/invoke-contract-cache.ts`):
+
+- **Freshness tier** — saved-package row and entity-source row (the row that
+  carries `published_commit`), TTL **15 s**. This TTL is the republish
+  staleness bound: after a republish, rename, or delete, another isolate may
+  serve the previous contract for at most 15 s. The isolate that runs the
+  projection refresh / delete invalidates eagerly, so it observes the change
+  immediately. Cache misses (unknown package) are never retained, so a
+  just-saved package is visible on the next lookup.
+- **Commit tier** — manifest and prepared bundle artifact, keyed by
+  `published_commit` taken from the freshness tier. A commit's artifacts are
+  immutable, so these entries are never a staleness source; their TTL only
+  bounds isolate memory.
+- **Registry source lists** — enabled MCP-server refs and OpenAPI bindings,
+  per-user TTL **30 s** with eager invalidation on mutation, matching the
+  existing remote-connector and MCP hub snapshot bounds.
+
+Rules for touching these paths: publish and rebuild flows must keep using the
+uncached row/manifest loaders (`loadPackageManifestBySourceId`,
+`loadPackageSourceBySourceId`) so a rebuild can never run against a stale
+`published_commit`; every cache key must start with the owning `userId` (per
+user isolation is inviolable); and new caches on invocation paths need an
+explicit staleness bound documented here.
+
 ## Watch the percentiles
 
 Every invocation surface is metered through `recordUsage()` (see

--- a/packages/worker/src/mcp-client/settings-service.node.test.ts
+++ b/packages/worker/src/mcp-client/settings-service.node.test.ts
@@ -1,0 +1,121 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	listEnabledMcpServerSettingRows: vi.fn(),
+	getMcpServerSettingRowById: vi.fn(),
+	getMcpServerSettingRowByName: vi.fn(),
+	insertMcpServerSettingRow: vi.fn(),
+	updateMcpServerSettingRow: vi.fn(),
+	deleteMcpServerSettingRow: vi.fn(),
+	listMcpServerSettingRows: vi.fn(),
+	hubClient: {
+		addServer: vi.fn(),
+		removeServer: vi.fn(),
+	},
+}))
+
+vi.mock('./settings-repo.ts', () => ({
+	listEnabledMcpServerSettingRows: (...args: Array<unknown>) =>
+		mockModule.listEnabledMcpServerSettingRows(...args),
+	getMcpServerSettingRowById: (...args: Array<unknown>) =>
+		mockModule.getMcpServerSettingRowById(...args),
+	getMcpServerSettingRowByName: (...args: Array<unknown>) =>
+		mockModule.getMcpServerSettingRowByName(...args),
+	insertMcpServerSettingRow: (...args: Array<unknown>) =>
+		mockModule.insertMcpServerSettingRow(...args),
+	updateMcpServerSettingRow: (...args: Array<unknown>) =>
+		mockModule.updateMcpServerSettingRow(...args),
+	deleteMcpServerSettingRow: (...args: Array<unknown>) =>
+		mockModule.deleteMcpServerSettingRow(...args),
+	listMcpServerSettingRows: (...args: Array<unknown>) =>
+		mockModule.listMcpServerSettingRows(...args),
+}))
+
+vi.mock('./hub-client.ts', () => ({
+	createMcpClientHubClient: () => mockModule.hubClient,
+}))
+
+const {
+	clearEnabledMcpServerRefsCacheForTests,
+	enabledMcpServerRefsCacheTtlMs,
+	listEnabledMcpServerRefsCached,
+	setMcpServerEnabled,
+} = await import('./settings-service.ts')
+
+function createSettingRow(input: { id: string; enabled?: boolean }) {
+	return {
+		id: input.id,
+		user_id: 'user-1',
+		name: `server-${input.id}`,
+		url: `https://mcp.example.com/${input.id}`,
+		enabled: input.enabled ?? true,
+		created_at: '2026-07-01T00:00:00.000Z',
+		updated_at: '2026-07-01T00:00:00.000Z',
+	}
+}
+
+function setupEnabledServerFixture() {
+	clearEnabledMcpServerRefsCacheForTests()
+	mockModule.listEnabledMcpServerSettingRows.mockResolvedValue([
+		createSettingRow({ id: 'server-1' }),
+	])
+}
+
+test('listEnabledMcpServerRefsCached serves warm calls without a D1 read, per user', async () => {
+	setupEnabledServerFixture()
+	const env = { APP_DB: {} } as Env
+
+	const first = await listEnabledMcpServerRefsCached({ env, userId: 'user-1' })
+	const second = await listEnabledMcpServerRefsCached({ env, userId: 'user-1' })
+
+	expect(first).toEqual([{ serverId: 'server-1', name: 'server-server-1' }])
+	expect(second).toBe(first)
+	expect(mockModule.listEnabledMcpServerSettingRows).toHaveBeenCalledTimes(1)
+
+	await listEnabledMcpServerRefsCached({ env, userId: 'user-2' })
+	// Another user's lookup must not reuse user-1's entry.
+	expect(mockModule.listEnabledMcpServerSettingRows).toHaveBeenCalledTimes(2)
+	expect(mockModule.listEnabledMcpServerSettingRows).toHaveBeenLastCalledWith(
+		expect.objectContaining({ userId: 'user-2' }),
+	)
+})
+
+test('listEnabledMcpServerRefsCached expires after its TTL', async () => {
+	setupEnabledServerFixture()
+	vi.useFakeTimers()
+	try {
+		const env = { APP_DB: {} } as Env
+		await listEnabledMcpServerRefsCached({ env, userId: 'user-1' })
+		vi.setSystemTime(Date.now() + enabledMcpServerRefsCacheTtlMs + 1)
+		await listEnabledMcpServerRefsCached({ env, userId: 'user-1' })
+		expect(mockModule.listEnabledMcpServerSettingRows).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+})
+
+test('mutations invalidate the enabled-refs cache in the same isolate', async () => {
+	setupEnabledServerFixture()
+	const env = { APP_DB: {} } as Env
+	const warm = await listEnabledMcpServerRefsCached({ env, userId: 'user-1' })
+	expect(warm).toHaveLength(1)
+
+	mockModule.getMcpServerSettingRowById.mockResolvedValue(
+		createSettingRow({ id: 'server-1' }),
+	)
+	mockModule.updateMcpServerSettingRow.mockResolvedValue(true)
+	await setMcpServerEnabled({
+		env,
+		userId: 'user-1',
+		id: 'server-1',
+		enabled: false,
+	})
+
+	mockModule.listEnabledMcpServerSettingRows.mockResolvedValue([])
+	const afterDisable = await listEnabledMcpServerRefsCached({
+		env,
+		userId: 'user-1',
+	})
+	expect(afterDisable).toEqual([])
+	expect(mockModule.listEnabledMcpServerSettingRows).toHaveBeenCalledTimes(2)
+})

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -5,6 +5,7 @@ import {
 	validateMcpServerUrl,
 	type McpServerRef,
 } from '@kody-internal/shared/mcp-servers.ts'
+import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
 import { createMcpClientHubClient } from './hub-client.ts'
 import {
 	deleteMcpServerSettingRow,
@@ -62,6 +63,46 @@ export async function listEnabledMcpServerRefs(input: {
 		serverId: row.id,
 		name: row.name,
 	}))
+}
+
+export const enabledMcpServerRefsCacheTtlMs = 30_000
+export const enabledMcpServerRefsCacheLimit = 200
+
+function createEnabledMcpServerRefsCache() {
+	return new PromiseLruCache<ReadonlyArray<McpServerRef>>({
+		ttlMs: enabledMcpServerRefsCacheTtlMs,
+		limit: enabledMcpServerRefsCacheLimit,
+	})
+}
+
+let enabledMcpServerRefsCache = createEnabledMcpServerRefsCache()
+
+/**
+ * Short-TTL per-user cache over {@link listEnabledMcpServerRefs} for hot
+ * invocation paths (capability-registry / runtime metadata assembly, which
+ * otherwise pay this D1 read on every run). Mutations in this module
+ * invalidate eagerly, so the same-isolate staleness after add / enable /
+ * delete is zero; other isolates converge within the TTL — the same bound
+ * the MCP hub and remote-connector snapshot caches already use. Settings UI
+ * reads should keep using the uncached functions.
+ */
+export function listEnabledMcpServerRefsCached(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+}): Promise<ReadonlyArray<McpServerRef>> {
+	return enabledMcpServerRefsCache.getOrCreate({
+		cacheKey: input.userId,
+		create: async () =>
+			Object.freeze(await listEnabledMcpServerRefs(input)),
+	})
+}
+
+function invalidateEnabledMcpServerRefsCache(input: { userId: string }) {
+	enabledMcpServerRefsCache.delete(input.userId)
+}
+
+export function clearEnabledMcpServerRefsCacheForTests() {
+	enabledMcpServerRefsCache = createEnabledMcpServerRefsCache()
 }
 
 function validateNameOrThrow(name: string) {
@@ -137,6 +178,7 @@ export async function addMcpServer(input: {
 		await hub.removeServer({ serverId: row.id }).catch(() => {})
 		throw error
 	}
+	invalidateEnabledMcpServerRefsCache({ userId: input.userId })
 	return {
 		setting: toMetadata(row),
 		connection,
@@ -170,6 +212,7 @@ export async function setMcpServerEnabled(input: {
 	if (!updated) {
 		throw new Error('MCP server setting not found.')
 	}
+	invalidateEnabledMcpServerRefsCache({ userId: input.userId })
 	return toMetadata(row)
 }
 
@@ -189,11 +232,13 @@ export async function deleteMcpServer(input: {
 		userId: input.userId,
 	})
 	await hub.removeServer({ serverId: input.id })
-	return deleteMcpServerSettingRow({
+	const deleted = await deleteMcpServerSettingRow({
 		db: input.env.APP_DB,
 		userId: input.userId,
 		id: input.id,
 	})
+	invalidateEnabledMcpServerRefsCache({ userId: input.userId })
+	return deleted
 }
 
 export async function getMcpServerSettingById(input: {

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -92,8 +92,7 @@ export function listEnabledMcpServerRefsCached(input: {
 }): Promise<ReadonlyArray<McpServerRef>> {
 	return enabledMcpServerRefsCache.getOrCreate({
 		cacheKey: input.userId,
-		create: async () =>
-			Object.freeze(await listEnabledMcpServerRefs(input)),
+		create: async () => Object.freeze(await listEnabledMcpServerRefs(input)),
 	})
 }
 

--- a/packages/worker/src/mcp/capabilities/registry.ts
+++ b/packages/worker/src/mcp/capabilities/registry.ts
@@ -19,12 +19,12 @@ import {
 } from '@kody-internal/shared/remote-connectors.ts'
 import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
 import { getCachedMcpClientHubSnapshot } from '#worker/mcp-client/hub-client.ts'
-import { listEnabledMcpServerRefs } from '#worker/mcp-client/settings-service.ts'
+import { listEnabledMcpServerRefsCached } from '#worker/mcp-client/settings-service.ts'
 import { type McpServerSnapshot } from '#worker/mcp-client/types.ts'
 import { getCachedRemoteConnectorSnapshot } from '#worker/remote-connector/snapshot-cache.ts'
 import { type RemoteConnectorSnapshot } from '#worker/remote-connector/types.ts'
 import { type OpenApiBinding } from '#worker/openapi/binding-shared.ts'
-import { listOpenApiBindings } from '#worker/openapi/binding-service.ts'
+import { listOpenApiBindingsCached } from '#worker/openapi/binding-service.ts'
 
 let staticRegistryMemo: BuiltCapabilityRegistry | null = null
 
@@ -165,9 +165,11 @@ async function resolveFeatureFlagsForRegistry(input: {
 async function loadEnabledMcpServerRefs(input: {
 	env: Env
 	userId: string
-}): Promise<Array<McpServerRef>> {
+}): Promise<ReadonlyArray<McpServerRef>> {
 	try {
-		return await listEnabledMcpServerRefs({
+		// Per-user 30s cache: registry assembly runs on every execute /
+		// package invocation, so this must not cost a D1 read per call.
+		return await listEnabledMcpServerRefsCached({
 			env: input.env,
 			userId: input.userId,
 		})
@@ -226,9 +228,11 @@ async function loadRemoteConnectorSnapshots(input: {
 async function loadOpenApiBindingsForRegistry(input: {
 	env: Env
 	userId: string
-}): Promise<Array<OpenApiBinding>> {
+}): Promise<ReadonlyArray<OpenApiBinding>> {
 	try {
-		return await listOpenApiBindings({
+		// Per-user 30s cache: registry assembly runs on every execute /
+		// package invocation, so this must not cost a D1 read per call.
+		return await listOpenApiBindingsCached({
 			env: input.env,
 			userId: input.userId,
 		})

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -92,7 +92,7 @@ import {
 	getMcpServerStatus,
 } from '#worker/mcp-client/status.ts'
 import { mcpServerKodyName } from '#worker/mcp-client/mcp-domain-id.ts'
-import { listEnabledMcpServerRefs } from '#worker/mcp-client/settings-service.ts'
+import { listEnabledMcpServerRefsCached } from '#worker/mcp-client/settings-service.ts'
 
 export type {
 	PackageEventDispatchInput,
@@ -436,7 +436,9 @@ async function buildKodyMcpServerMetadata(input: {
 	const servers = new Map<string, KodyMcpServerMetadata>()
 
 	if (userId) {
-		const refs = await listEnabledMcpServerRefs({
+		// Per-user 30s cache: runtime metadata assembly runs on every execute /
+		// package invocation, so this must not cost a D1 read per call.
+		const refs = await listEnabledMcpServerRefsCached({
 			env: input.env,
 			userId,
 		}).catch((error: unknown) => {

--- a/packages/worker/src/openapi/binding-service.node.test.ts
+++ b/packages/worker/src/openapi/binding-service.node.test.ts
@@ -1,0 +1,87 @@
+import { expect, test, vi } from 'vitest'
+import { type OpenApiBinding } from './binding-shared.ts'
+
+const mockModule = vi.hoisted(() => ({
+	listOpenApiBindingsForUser: vi.fn(),
+	getOpenApiBindingByName: vi.fn(),
+	upsertOpenApiBinding: vi.fn(),
+	deleteOpenApiBindingByName: vi.fn(),
+}))
+
+vi.mock('#worker/openapi/repo.ts', () => ({
+	listOpenApiBindingsForUser: (...args: Array<unknown>) =>
+		mockModule.listOpenApiBindingsForUser(...args),
+	getOpenApiBindingByName: (...args: Array<unknown>) =>
+		mockModule.getOpenApiBindingByName(...args),
+	upsertOpenApiBinding: (...args: Array<unknown>) =>
+		mockModule.upsertOpenApiBinding(...args),
+	deleteOpenApiBindingByName: (...args: Array<unknown>) =>
+		mockModule.deleteOpenApiBindingByName(...args),
+}))
+
+const {
+	clearOpenApiBindingsCacheForTests,
+	deleteOpenApiBinding,
+	listOpenApiBindingsCached,
+	openApiBindingsCacheTtlMs,
+	saveOpenApiBinding,
+} = await import('./binding-service.ts')
+
+function setupBindingFixture() {
+	clearOpenApiBindingsCacheForTests()
+	mockModule.listOpenApiBindingsForUser.mockResolvedValue([])
+	mockModule.getOpenApiBindingByName.mockResolvedValue(null)
+	mockModule.upsertOpenApiBinding.mockResolvedValue(undefined)
+	mockModule.deleteOpenApiBindingByName.mockResolvedValue(true)
+}
+
+test('listOpenApiBindingsCached serves warm calls without a D1 read, per user', async () => {
+	setupBindingFixture()
+	const env = { APP_DB: {} } as Env
+
+	const first = await listOpenApiBindingsCached({ env, userId: 'user-1' })
+	const second = await listOpenApiBindingsCached({ env, userId: 'user-1' })
+
+	expect(second).toBe(first)
+	expect(mockModule.listOpenApiBindingsForUser).toHaveBeenCalledTimes(1)
+
+	await listOpenApiBindingsCached({ env, userId: 'user-2' })
+	// Another user's lookup must not reuse user-1's entry.
+	expect(mockModule.listOpenApiBindingsForUser).toHaveBeenCalledTimes(2)
+	expect(mockModule.listOpenApiBindingsForUser).toHaveBeenLastCalledWith(
+		expect.objectContaining({ userId: 'user-2' }),
+	)
+})
+
+test('listOpenApiBindingsCached expires after its TTL', async () => {
+	setupBindingFixture()
+	vi.useFakeTimers()
+	try {
+		const env = { APP_DB: {} } as Env
+		await listOpenApiBindingsCached({ env, userId: 'user-1' })
+		vi.setSystemTime(Date.now() + openApiBindingsCacheTtlMs + 1)
+		await listOpenApiBindingsCached({ env, userId: 'user-1' })
+		expect(mockModule.listOpenApiBindingsForUser).toHaveBeenCalledTimes(2)
+	} finally {
+		vi.useRealTimers()
+	}
+})
+
+test('save and delete invalidate the bindings cache in the same isolate', async () => {
+	setupBindingFixture()
+	const env = { APP_DB: {} } as Env
+	await listOpenApiBindingsCached({ env, userId: 'user-1' })
+	expect(mockModule.listOpenApiBindingsForUser).toHaveBeenCalledTimes(1)
+
+	await saveOpenApiBinding({
+		env,
+		userId: 'user-1',
+		binding: { name: 'petstore' } as OpenApiBinding,
+	})
+	await listOpenApiBindingsCached({ env, userId: 'user-1' })
+	expect(mockModule.listOpenApiBindingsForUser).toHaveBeenCalledTimes(2)
+
+	await deleteOpenApiBinding({ env, userId: 'user-1', name: 'petstore' })
+	await listOpenApiBindingsCached({ env, userId: 'user-1' })
+	expect(mockModule.listOpenApiBindingsForUser).toHaveBeenCalledTimes(3)
+})

--- a/packages/worker/src/openapi/binding-service.ts
+++ b/packages/worker/src/openapi/binding-service.ts
@@ -10,6 +10,7 @@ import {
 	upsertOpenApiBinding,
 	type OpenApiBindingWithOperations,
 } from '#worker/openapi/repo.ts'
+import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
 
 export async function listOpenApiBindings(input: {
 	env: Pick<Env, 'APP_DB'>
@@ -25,6 +26,45 @@ export async function listOpenApiBindings(input: {
 		if (parsed) bindings.push(parsed)
 	}
 	return bindings
+}
+
+export const openApiBindingsCacheTtlMs = 30_000
+export const openApiBindingsCacheLimit = 200
+
+function createOpenApiBindingsCache() {
+	return new PromiseLruCache<ReadonlyArray<OpenApiBinding>>({
+		ttlMs: openApiBindingsCacheTtlMs,
+		limit: openApiBindingsCacheLimit,
+	})
+}
+
+let openApiBindingsCache = createOpenApiBindingsCache()
+
+/**
+ * Short-TTL per-user cache over {@link listOpenApiBindings} for hot
+ * invocation paths (capability-registry assembly pays this D1 read on every
+ * run otherwise). Mutations in this module invalidate eagerly, so
+ * same-isolate staleness after save / delete is zero; other isolates
+ * converge within the TTL — the same bound the capability-registry cache
+ * uses. Listing surfaces (UI, `openapi_binding_list`) should keep using the
+ * uncached function.
+ */
+export function listOpenApiBindingsCached(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+}): Promise<ReadonlyArray<OpenApiBinding>> {
+	return openApiBindingsCache.getOrCreate({
+		cacheKey: input.userId,
+		create: async () => Object.freeze(await listOpenApiBindings(input)),
+	})
+}
+
+function invalidateOpenApiBindingsCache(input: { userId: string }) {
+	openApiBindingsCache.delete(input.userId)
+}
+
+export function clearOpenApiBindingsCacheForTests() {
+	openApiBindingsCache = createOpenApiBindingsCache()
 }
 
 export async function getOpenApiBinding(input: {
@@ -58,6 +98,7 @@ export async function saveOpenApiBinding(input: {
 		binding: input.binding,
 		createdAt: existing?.binding.created_at,
 	})
+	invalidateOpenApiBindingsCache({ userId: input.userId })
 }
 
 export async function deleteOpenApiBinding(input: {
@@ -65,11 +106,13 @@ export async function deleteOpenApiBinding(input: {
 	userId: string
 	name: string
 }): Promise<boolean> {
-	return deleteOpenApiBindingByName({
+	const deleted = await deleteOpenApiBindingByName({
 		db: input.env.APP_DB,
 		userId: input.userId,
 		name: input.name,
 	})
+	invalidateOpenApiBindingsCache({ userId: input.userId })
+	return deleted
 }
 
 function toOpenApiBinding(

--- a/packages/worker/src/package-invocations/invoke-check.ts
+++ b/packages/worker/src/package-invocations/invoke-check.ts
@@ -5,7 +5,6 @@ import {
 	type PackageInvokeInput,
 } from '#mcp/run-kody-registry.ts'
 import { type PackageExportProjection } from '#worker/package-registry/manifest.ts'
-import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import {
 	buildSavedPackageNotFoundMessage,
 	normalizeExportName,
@@ -16,6 +15,7 @@ import {
 } from './input-parsing.ts'
 import {
 	ensureModuleArtifact,
+	loadInvokeManifestBySourceId,
 	resolvePackageModuleResolution,
 	resolveSavedPackage,
 } from './module-artifacts.ts'
@@ -117,11 +117,10 @@ export async function checkPackageInvokeForRuntimeWithPreloads(input: {
 		sourceId: savedPackage.sourceId,
 		exportName,
 	}
-	let manifestResult: Awaited<ReturnType<typeof loadPackageManifestBySourceId>>
+	let manifestResult: Awaited<ReturnType<typeof loadInvokeManifestBySourceId>>
 	try {
-		manifestResult = await loadPackageManifestBySourceId({
+		manifestResult = await loadInvokeManifestBySourceId({
 			env: input.env,
-			baseUrl: input.baseUrl,
 			userId: input.userId,
 			sourceId: savedPackage.sourceId,
 		})

--- a/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
@@ -5,6 +5,10 @@ import {
 	invokeContractFreshnessTtlMs,
 	loadModuleArtifactWithCommitCache,
 } from './invoke-contract-cache.ts'
+import {
+	ensureModuleArtifact,
+	loadInvokeManifestBySourceId,
+} from './module-artifacts.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
@@ -14,6 +18,8 @@ const mockModule = vi.hoisted(() => ({
 	loadPublishedEntitySource: vi.fn(),
 	loadPublishedBundleArtifactByIdentity: vi.fn(),
 	persistPublishedBundleArtifact: vi.fn(),
+	typecheckPackageEntrypointsFromSourceFiles: vi.fn(),
+	buildKodyModuleBundle: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -40,6 +46,16 @@ vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', () => ({
 		mockModule.loadPublishedBundleArtifactByIdentity(...args),
 	persistPublishedBundleArtifact: (...args: Array<unknown>) =>
 		mockModule.persistPublishedBundleArtifact(...args),
+}))
+
+vi.mock('#worker/repo/checks.ts', () => ({
+	typecheckPackageEntrypointsFromSourceFiles: (...args: Array<unknown>) =>
+		mockModule.typecheckPackageEntrypointsFromSourceFiles(...args),
+}))
+
+vi.mock('#worker/package-runtime/module-graph.ts', () => ({
+	buildKodyModuleBundle: (...args: Array<unknown>) =>
+		mockModule.buildKodyModuleBundle(...args),
 }))
 
 /**
@@ -343,6 +359,105 @@ test('contract-check caches never serve entries across users', async () => {
 	// The second user's check must load its own rows, not reuse user-1's.
 	expect(mockModule.getSavedPackageByKodyId).toHaveBeenCalledTimes(1)
 	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(1)
+})
+
+test('an artifact rebuild resolves its entry point from the fresh source, not the cached manifest', async () => {
+	const userId = 'user-rebuild'
+	const sourceId = 'source-rebuild'
+	const savedPackage = createFixture({
+		userId,
+		publishedCommit: 'commit-1',
+		suffix: 'rebuild',
+	}).savedPackage
+	const buildManifestContent = (entryPoint: string) =>
+		JSON.stringify({
+			name: '@kentcdodds/sentry-triage',
+			exports: { './probe': entryPoint },
+			kody: { id: 'sentry-triage', description: 'probe' },
+		})
+	const buildSourceRow = (publishedCommit: string) => ({
+		...createFixture({ userId, publishedCommit, suffix: 'rebuild' }).source,
+		id: sourceId,
+	})
+
+	// Warm the freshness cache with the commit-1 row + manifest, where the
+	// probe export points at the v1 entry point.
+	mockModule.getEntitySourceById.mockResolvedValue(buildSourceRow('commit-1'))
+	mockModule.loadPublishedEntityManifest.mockResolvedValue({
+		source: buildSourceRow('commit-1'),
+		content: buildManifestContent('./src/probe-v1.ts'),
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue(null)
+	mockModule.typecheckPackageEntrypointsFromSourceFiles.mockResolvedValue({
+		ok: true,
+	})
+	mockModule.buildKodyModuleBundle.mockResolvedValue({
+		mainModule: 'main.js',
+		modules: { 'main.js': 'export default async () => ({ ok: true })' },
+		dependencies: [],
+		dynamicDependencies: [],
+	})
+	mockModule.persistPublishedBundleArtifact.mockResolvedValue('kv-key')
+
+	// Republish lands between the manifest load and the rebuild: the fresh
+	// source is commit-2 and moves the probe export to the v2 entry point,
+	// while this isolate's freshness cache still holds the commit-1 row.
+	const v2Files = {
+		'package.json': buildManifestContent('./src/probe-v2.ts'),
+		'src/probe-v2.ts': 'export default async function probe() { return 2 }',
+	}
+	const runEnsure = async () =>
+		await ensureModuleArtifact({
+			env: createEnv(),
+			baseUrl: 'https://kody.dev',
+			savedPackage: { ...savedPackage, sourceId },
+			selector: { kind: 'export', exportName: 'probe' },
+			userId,
+		})
+
+	// Warm only the freshness-tier row cache with the commit-1 manifest (no
+	// artifact exists for the identity yet).
+	await loadInvokeManifestBySourceId({
+		env: createEnv(),
+		userId,
+		sourceId,
+	})
+
+	// Now the republish is visible to fresh reads only; the first-ever
+	// artifact rebuild for this identity happens against the stale cached
+	// manifest.
+	mockModule.getEntitySourceById.mockResolvedValue(buildSourceRow('commit-2'))
+	mockModule.loadPublishedEntitySource.mockResolvedValue({
+		source: buildSourceRow('commit-2'),
+		files: v2Files,
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity
+		.mockResolvedValueOnce(null)
+		.mockResolvedValueOnce({
+			row: { kvKey: 'kv-key' },
+			artifact: { publishedCommit: 'commit-2', entryPoint: 'src/probe-v2.ts' },
+		})
+
+	const rebuilt = await runEnsure()
+
+	// The rebuild must be self-consistent with the freshly loaded commit-2
+	// source: typecheck, bundle, and persisted identity all use the v2 entry
+	// point, even though this isolate's cached manifest still says v1.
+	expect(
+		mockModule.typecheckPackageEntrypointsFromSourceFiles,
+	).toHaveBeenCalledWith(
+		expect.objectContaining({
+			entryPoints: [{ path: 'src/probe-v2.ts', includeStorage: true }],
+		}),
+	)
+	expect(mockModule.buildKodyModuleBundle).toHaveBeenCalledWith(
+		expect.objectContaining({ entryPoint: 'src/probe-v2.ts' }),
+	)
+	expect(mockModule.persistPublishedBundleArtifact).toHaveBeenCalledWith(
+		expect.objectContaining({ entryPoint: 'src/probe-v2.ts' }),
+	)
+	expect(rebuilt.artifact.publishedCommit).toBe('commit-2')
+	expect(rebuilt.entryPoint).toBe('src/probe-v2.ts')
 })
 
 test('an artifact from a different commit is served but never retained', async () => {

--- a/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
@@ -1,0 +1,376 @@
+import { expect, test, vi } from 'vitest'
+import { checkPackageInvokeForRuntimeWithPreloads } from './invoke-check.ts'
+import {
+	invalidateInvokeContractFreshness,
+	invokeContractFreshnessTtlMs,
+	loadModuleArtifactWithCommitCache,
+} from './invoke-contract-cache.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
+	getEntitySourceById: vi.fn(),
+	loadPublishedEntityManifest: vi.fn(),
+	loadPublishedEntitySource: vi.fn(),
+	loadPublishedBundleArtifactByIdentity: vi.fn(),
+	persistPublishedBundleArtifact: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/published-source.ts', () => ({
+	loadPublishedEntityManifest: (...args: Array<unknown>) =>
+		mockModule.loadPublishedEntityManifest(...args),
+	loadPublishedEntitySource: (...args: Array<unknown>) =>
+		mockModule.loadPublishedEntitySource(...args),
+}))
+
+vi.mock('#worker/package-runtime/published-bundle-artifacts.ts', () => ({
+	loadPublishedBundleArtifactByIdentity: (...args: Array<unknown>) =>
+		mockModule.loadPublishedBundleArtifactByIdentity(...args),
+	persistPublishedBundleArtifact: (...args: Array<unknown>) =>
+		mockModule.persistPublishedBundleArtifact(...args),
+}))
+
+/**
+ * Every mock above stands in for exactly one awaited D1 or KV load the
+ * contract check would otherwise perform per call. The warm-path tests assert
+ * all of them stay at zero.
+ */
+const contractCheckLoadMocks = [
+	['saved package by id (D1)', mockModule.getSavedPackageById],
+	['saved package by kody id (D1)', mockModule.getSavedPackageByKodyId],
+	['entity source row (D1)', mockModule.getEntitySourceById],
+	['published manifest snapshot (KV)', mockModule.loadPublishedEntityManifest],
+	['published source snapshot (KV)', mockModule.loadPublishedEntitySource],
+	[
+		'bundle artifact identity + payload (D1 + KV)',
+		mockModule.loadPublishedBundleArtifactByIdentity,
+	],
+] as const
+
+function countContractCheckLoads() {
+	return Object.fromEntries(
+		contractCheckLoadMocks.map(([label, mock]) => [
+			label,
+			mock.mock.calls.length,
+		]),
+	)
+}
+
+function clearContractCheckLoadCounters() {
+	for (const [, mock] of contractCheckLoadMocks) {
+		mock.mockClear()
+	}
+}
+
+function createFixture(input: {
+	userId: string
+	publishedCommit: string
+	suffix?: string
+}) {
+	const suffix = input.suffix ?? input.userId
+	const sourceId = `source-${suffix}`
+	const savedPackage = {
+		id: `pkg-${suffix}`,
+		userId: input.userId,
+		name: '@kentcdodds/sentry-triage',
+		kodyId: 'sentry-triage',
+		description: 'Sentry triage helpers',
+		tags: [],
+		searchText: null,
+		sourceId,
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		createdAt: '2026-07-01T00:00:00.000Z',
+		updatedAt: '2026-07-01T00:00:00.000Z',
+	}
+	const source = {
+		id: sourceId,
+		user_id: input.userId,
+		entity_kind: 'package' as const,
+		entity_id: savedPackage.id,
+		repo_id: `repo-${suffix}`,
+		published_commit: input.publishedCommit,
+		indexed_commit: input.publishedCommit,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		created_at: '2026-07-01T00:00:00.000Z',
+		updated_at: '2026-07-01T00:00:00.000Z',
+	}
+	const manifestContent = JSON.stringify({
+		name: '@kentcdodds/sentry-triage',
+		exports: {
+			'./get-issue-state': './src/get-issue-state.ts',
+		},
+		kody: {
+			id: 'sentry-triage',
+			description: 'Sentry triage helpers',
+		},
+	})
+	const artifact = {
+		version: 1,
+		kind: 'module' as const,
+		artifactName: './get-issue-state',
+		sourceId,
+		publishedCommit: input.publishedCommit,
+		entryPoint: 'src/get-issue-state.ts',
+		mainModule: 'main.js',
+		modules: { 'main.js': 'export default async () => ({ ok: true })' },
+		dependencies: [],
+		dynamicDependencies: [],
+		packageContext: {
+			packageId: savedPackage.id,
+			kodyId: savedPackage.kodyId,
+			sourceId,
+		},
+		serviceContext: null,
+		createdAt: '2026-07-01T00:00:00.000Z',
+	}
+	return { savedPackage, source, manifestContent, artifact }
+}
+
+type Fixture = ReturnType<typeof createFixture>
+
+function seedFixtures(fixturesByUserId: Record<string, Fixture>) {
+	const byKodyId = (userId: string, kodyId: string) => {
+		const fixture = fixturesByUserId[userId]
+		return fixture && fixture.savedPackage.kodyId === kodyId
+			? fixture.savedPackage
+			: null
+	}
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	mockModule.getSavedPackageByKodyId.mockImplementation(
+		async (_db: unknown, input: { userId: string; kodyId: string }) =>
+			byKodyId(input.userId, input.kodyId),
+	)
+	mockModule.getEntitySourceById.mockImplementation(
+		async (_db: unknown, sourceId: string) =>
+			Object.values(fixturesByUserId).find(
+				(fixture) => fixture.source.id === sourceId,
+			)?.source ?? null,
+	)
+	mockModule.loadPublishedEntityManifest.mockImplementation(
+		async (input: { sourceId: string }) => {
+			const fixture = Object.values(fixturesByUserId).find(
+				(candidate) => candidate.source.id === input.sourceId,
+			)
+			if (!fixture) throw new Error(`No manifest for ${input.sourceId}`)
+			return { source: fixture.source, content: fixture.manifestContent }
+		},
+	)
+	mockModule.loadPublishedBundleArtifactByIdentity.mockImplementation(
+		async (input: { sourceId: string }) => {
+			const fixture = Object.values(fixturesByUserId).find(
+				(candidate) => candidate.source.id === input.sourceId,
+			)
+			if (!fixture) return null
+			return { row: { kvKey: 'kv-key' }, artifact: fixture.artifact }
+		},
+	)
+}
+
+function createEnv() {
+	return {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+	} as Env
+}
+
+async function runContractCheck(input: { userId: string }) {
+	return await checkPackageInvokeForRuntimeWithPreloads({
+		env: createEnv(),
+		baseUrl: 'https://kody.dev',
+		operationName: 'packages.invoke',
+		userId: input.userId,
+		rawInput: {
+			kodyId: 'sentry-triage',
+			exportName: 'get-issue-state',
+			params: { issueId: 'issue-1' },
+		},
+		includeExportProjection: false,
+	})
+}
+
+test('a warm keyless invoke contract check performs zero D1/KV loads', async () => {
+	seedFixtures({
+		'user-1': createFixture({ userId: 'user-1', publishedCommit: 'commit-1' }),
+	})
+
+	const cold = await runContractCheck({ userId: 'user-1' })
+	expect(cold.result.ok).toBe(true)
+	expect(cold.preloads?.moduleArtifact.artifact.publishedCommit).toBe(
+		'commit-1',
+	)
+	expect(mockModule.getSavedPackageByKodyId).toHaveBeenCalledTimes(1)
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadPublishedEntityManifest).toHaveBeenCalledTimes(1)
+	expect(
+		mockModule.loadPublishedBundleArtifactByIdentity,
+	).toHaveBeenCalledTimes(1)
+
+	clearContractCheckLoadCounters()
+	const warm = await runContractCheck({ userId: 'user-1' })
+
+	expect(warm.result.ok).toBe(true)
+	expect(warm.result.ok && warm.result.contract.publishedCommit).toBe(
+		'commit-1',
+	)
+	expect(warm.preloads?.savedPackage.id).toBe('pkg-user-1')
+	expect(warm.preloads?.moduleArtifact.artifact.publishedCommit).toBe(
+		'commit-1',
+	)
+	expect(countContractCheckLoads()).toEqual({
+		'saved package by id (D1)': 0,
+		'saved package by kody id (D1)': 0,
+		'entity source row (D1)': 0,
+		'published manifest snapshot (KV)': 0,
+		'published source snapshot (KV)': 0,
+		'bundle artifact identity + payload (D1 + KV)': 0,
+	})
+})
+
+test('a republish is picked up immediately after same-isolate invalidation', async () => {
+	const fixture = createFixture({
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+	})
+	seedFixtures({ 'user-1': fixture })
+
+	const beforeRepublish = await runContractCheck({ userId: 'user-1' })
+	expect(
+		beforeRepublish.result.ok &&
+			beforeRepublish.result.contract.publishedCommit,
+	).toBe('commit-1')
+
+	// Republish: the source row advances to commit-2 and new artifacts exist.
+	seedFixtures({
+		'user-1': createFixture({ userId: 'user-1', publishedCommit: 'commit-2' }),
+	})
+
+	// Still within the freshness TTL, the warm cache serves the old contract.
+	const stillCached = await runContractCheck({ userId: 'user-1' })
+	expect(
+		stillCached.result.ok && stillCached.result.contract.publishedCommit,
+	).toBe('commit-1')
+
+	// The projection refresh invalidates in its own isolate.
+	invalidateInvokeContractFreshness({
+		userId: 'user-1',
+		packageIdOrKodyIds: [fixture.savedPackage.id, fixture.savedPackage.kodyId],
+		sourceId: fixture.source.id,
+	})
+	const afterInvalidation = await runContractCheck({ userId: 'user-1' })
+	expect(
+		afterInvalidation.result.ok &&
+			afterInvalidation.result.contract.publishedCommit,
+	).toBe('commit-2')
+	expect(
+		afterInvalidation.preloads?.moduleArtifact.artifact.publishedCommit,
+	).toBe('commit-2')
+})
+
+test('a republish is picked up in other isolates once the freshness TTL elapses', async () => {
+	vi.useFakeTimers()
+	try {
+		seedFixtures({
+			'user-1': createFixture({
+				userId: 'user-1',
+				publishedCommit: 'commit-1',
+			}),
+		})
+		const warm = await runContractCheck({ userId: 'user-1' })
+		expect(warm.result.ok && warm.result.contract.publishedCommit).toBe(
+			'commit-1',
+		)
+
+		// Republish observed only through D1/KV — no invalidation reaches this
+		// isolate.
+		seedFixtures({
+			'user-1': createFixture({
+				userId: 'user-1',
+				publishedCommit: 'commit-2',
+			}),
+		})
+		vi.setSystemTime(Date.now() + invokeContractFreshnessTtlMs + 1)
+
+		const afterTtl = await runContractCheck({ userId: 'user-1' })
+		expect(afterTtl.result.ok && afterTtl.result.contract.publishedCommit).toBe(
+			'commit-2',
+		)
+		expect(afterTtl.preloads?.moduleArtifact.artifact.publishedCommit).toBe(
+			'commit-2',
+		)
+	} finally {
+		vi.useRealTimers()
+	}
+})
+
+test('contract-check caches never serve entries across users', async () => {
+	seedFixtures({
+		'user-1': createFixture({ userId: 'user-1', publishedCommit: 'commit-1' }),
+		'user-2': createFixture({
+			userId: 'user-2',
+			publishedCommit: 'commit-2',
+			suffix: 'user-2',
+		}),
+	})
+
+	const first = await runContractCheck({ userId: 'user-1' })
+	expect(first.result.ok && first.result.contract.publishedCommit).toBe(
+		'commit-1',
+	)
+
+	clearContractCheckLoadCounters()
+	const other = await runContractCheck({ userId: 'user-2' })
+
+	expect(other.result.ok && other.result.contract.publishedCommit).toBe(
+		'commit-2',
+	)
+	expect(other.preloads?.savedPackage.id).toBe('pkg-user-2')
+	// The second user's check must load its own rows, not reuse user-1's.
+	expect(mockModule.getSavedPackageByKodyId).toHaveBeenCalledTimes(1)
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(1)
+})
+
+test('an artifact from a different commit is served but never retained', async () => {
+	const load = vi.fn(async () => ({
+		artifact: { publishedCommit: 'commit-old' } as never,
+		source: { id: 'source-mismatch' } as never,
+		entryPoint: 'src/index.ts',
+	}))
+
+	const first = await loadModuleArtifactWithCommitCache({
+		userId: 'user-1',
+		sourceId: 'source-mismatch',
+		publishedCommit: 'commit-new',
+		artifactName: './index',
+		entryPoint: 'src/index.ts',
+		load,
+	})
+	const second = await loadModuleArtifactWithCommitCache({
+		userId: 'user-1',
+		sourceId: 'source-mismatch',
+		publishedCommit: 'commit-new',
+		artifactName: './index',
+		entryPoint: 'src/index.ts',
+		load,
+	})
+
+	expect(first.artifact.publishedCommit).toBe('commit-old')
+	expect(second.artifact.publishedCommit).toBe('commit-old')
+	// A commit mismatch means the entry must not be cached under this key.
+	expect(load).toHaveBeenCalledTimes(2)
+})

--- a/packages/worker/src/package-invocations/invoke-contract-cache.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.ts
@@ -1,0 +1,193 @@
+import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import { type PublishedBundleArtifact } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { type EntitySourceRow } from '#worker/repo/types.ts'
+
+/**
+ * Per-isolate caches for the `packages.invoke` contract check, so a warm
+ * keyless invoke of an already-warm package+commit performs zero D1/KV loads
+ * before dispatch (see
+ * docs/contributing/architecture/invocation-overhead-guardrails.md).
+ *
+ * Two tiers with different lifetimes:
+ *
+ * - **Freshness tier** (saved-package row, entity-source row): these rows can
+ *   change on republish/rename, so they carry a short TTL. That TTL is the
+ *   cross-isolate republish staleness bound; the isolate that runs the
+ *   projection refresh also invalidates eagerly, so it picks the new publish
+ *   up immediately. Misses are never retained — a package saved moments later
+ *   is visible on the next lookup.
+ * - **Commit tier** (prepared bundle artifact): keyed by the published commit
+ *   taken from the freshness tier, and a published commit's artifact is
+ *   immutable, so entries here are never a staleness source. The TTL only
+ *   bounds memory.
+ *
+ * Every cache key starts with the caller's `userId`; entries are never shared
+ * across users.
+ */
+
+/**
+ * Cross-isolate republish staleness bound for invocation paths: after
+ * `entity_sources.published_commit` (or the saved-package row) changes, other
+ * isolates serve the previous contract for at most this long.
+ */
+export const invokeContractFreshnessTtlMs = 15_000
+export const invokeContractFreshnessCacheLimit = 200
+
+/**
+ * Commit-keyed artifact entries are immutable; this TTL and the small limit
+ * exist only to bound isolate memory (bundle payloads can be large).
+ */
+export const invokeContractArtifactCacheTtlMs = 5 * 60 * 1000
+export const invokeContractArtifactCacheLimit = 20
+
+export type CachedInvokeModuleArtifact = {
+	artifact: PublishedBundleArtifact
+	source: EntitySourceRow
+	entryPoint: string
+}
+
+function createFreshnessCache<T>() {
+	return new PromiseLruCache<T>({
+		ttlMs: invokeContractFreshnessTtlMs,
+		limit: invokeContractFreshnessCacheLimit,
+	})
+}
+
+function createArtifactCache() {
+	return new PromiseLruCache<CachedInvokeModuleArtifact>({
+		ttlMs: invokeContractArtifactCacheTtlMs,
+		limit: invokeContractArtifactCacheLimit,
+	})
+}
+
+let savedPackageCache = createFreshnessCache<SavedPackageRecord | null>()
+let sourceRowCache = createFreshnessCache<EntitySourceRow>()
+let moduleArtifactCache = createArtifactCache()
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+	if (value && typeof value === 'object') {
+		const objectValue = value as object
+		if (seen.has(objectValue)) {
+			return value
+		}
+		seen.add(objectValue)
+		for (const child of Object.values(value as Record<string, unknown>)) {
+			deepFreeze(child, seen)
+		}
+		Object.freeze(objectValue)
+	}
+	return value
+}
+
+function savedPackageCacheKey(input: {
+	userId: string
+	packageIdOrKodyId: string
+}) {
+	return JSON.stringify(['saved-package', input.userId, input.packageIdOrKodyId])
+}
+
+function sourceRowCacheKey(input: { userId: string; sourceId: string }) {
+	return JSON.stringify(['source-row', input.userId, input.sourceId])
+}
+
+export async function resolveSavedPackageWithFreshnessCache(input: {
+	userId: string
+	packageIdOrKodyId: string
+	load: () => Promise<SavedPackageRecord | null>
+}): Promise<SavedPackageRecord | null> {
+	const cacheKey = savedPackageCacheKey(input)
+	return await savedPackageCache.getOrCreate({
+		cacheKey,
+		create: async () => {
+			const record = await input.load()
+			if (!record) {
+				// Do not retain misses: a package saved moments later must be
+				// visible on the next lookup instead of after the TTL.
+				savedPackageCache.delete(cacheKey)
+				return null
+			}
+			return deepFreeze(record)
+		},
+	})
+}
+
+export async function loadSourceRowWithFreshnessCache(input: {
+	userId: string
+	sourceId: string
+	load: () => Promise<EntitySourceRow>
+}): Promise<EntitySourceRow> {
+	return await sourceRowCache.getOrCreate({
+		cacheKey: sourceRowCacheKey(input),
+		create: async () => deepFreeze(await input.load()),
+	})
+}
+
+export async function loadModuleArtifactWithCommitCache(input: {
+	userId: string
+	sourceId: string
+	publishedCommit: string | null
+	artifactName: string
+	entryPoint: string
+	load: () => Promise<CachedInvokeModuleArtifact>
+}): Promise<CachedInvokeModuleArtifact> {
+	if (!input.publishedCommit) {
+		return await input.load()
+	}
+	const cacheKey = JSON.stringify([
+		'module-artifact',
+		input.userId,
+		input.sourceId,
+		input.publishedCommit,
+		input.artifactName,
+		input.entryPoint,
+	])
+	return await moduleArtifactCache.getOrCreate({
+		cacheKey,
+		create: async () => {
+			const value = await input.load()
+			if (value.artifact.publishedCommit !== input.publishedCommit) {
+				// The bundle-artifact identity row can briefly point at a different
+				// commit than the source row (e.g. mid-republish). Serve it, but do
+				// not retain it under this commit's key — retaining would extend
+				// staleness past the freshness-tier TTL.
+				moduleArtifactCache.delete(cacheKey)
+				return value
+			}
+			return deepFreeze(value)
+		},
+	})
+}
+
+/**
+ * Eager same-isolate invalidation for publish / projection-refresh / delete
+ * flows. Cross-isolate pickup is bounded by
+ * {@link invokeContractFreshnessTtlMs}. The commit-tier artifact cache needs
+ * no invalidation: a republish changes the commit and therefore the key.
+ */
+export function invalidateInvokeContractFreshness(input: {
+	userId: string
+	/**
+	 * Every lookup key the package resolves under: its package id plus any
+	 * current (and, on rename, previous) kody ids.
+	 */
+	packageIdOrKodyIds: Array<string>
+	sourceId?: string | null
+}) {
+	for (const packageIdOrKodyId of input.packageIdOrKodyIds) {
+		savedPackageCache.delete(
+			savedPackageCacheKey({ userId: input.userId, packageIdOrKodyId }),
+		)
+	}
+	if (input.sourceId) {
+		sourceRowCache.delete(
+			sourceRowCacheKey({ userId: input.userId, sourceId: input.sourceId }),
+		)
+	}
+}
+
+export function clearInvokeContractCachesForTests() {
+	savedPackageCache = createFreshnessCache<SavedPackageRecord | null>()
+	sourceRowCache = createFreshnessCache<EntitySourceRow>()
+	moduleArtifactCache = createArtifactCache()
+}

--- a/packages/worker/src/package-invocations/invoke-contract-cache.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.ts
@@ -84,7 +84,11 @@ function savedPackageCacheKey(input: {
 	userId: string
 	packageIdOrKodyId: string
 }) {
-	return JSON.stringify(['saved-package', input.userId, input.packageIdOrKodyId])
+	return JSON.stringify([
+		'saved-package',
+		input.userId,
+		input.packageIdOrKodyId,
+	])
 }
 
 function sourceRowCacheKey(input: { userId: string; sourceId: string }) {

--- a/packages/worker/src/package-invocations/invoke-contract-cache.workers.test.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.workers.test.ts
@@ -1,0 +1,347 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+import { persistPublishedBundleArtifact } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { persistPublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
+import { checkPackageInvokeForRuntimeWithPreloads } from './invoke-check.ts'
+import { invalidateInvokeContractFreshness } from './invoke-contract-cache.ts'
+
+async function runSql(sql: string, ...values: Array<unknown>) {
+	await env.APP_DB.prepare(sql)
+		.bind(...values)
+		.run()
+}
+
+async function ensureSavedPackageArtifactSchema() {
+	await runSql(`CREATE TABLE IF NOT EXISTS entity_sources (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		entity_kind TEXT NOT NULL,
+		entity_id TEXT NOT NULL,
+		repo_id TEXT NOT NULL,
+		published_commit TEXT,
+		indexed_commit TEXT,
+		manifest_path TEXT NOT NULL DEFAULT 'package.json',
+		source_root TEXT NOT NULL DEFAULT '/',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`)
+	await runSql(`CREATE TABLE IF NOT EXISTS saved_packages (
+		id TEXT PRIMARY KEY NOT NULL,
+		user_id TEXT NOT NULL,
+		name TEXT NOT NULL,
+		kody_id TEXT NOT NULL,
+		description TEXT NOT NULL,
+		tags_json TEXT NOT NULL DEFAULT '[]',
+		search_text TEXT,
+		source_id TEXT NOT NULL,
+		has_app INTEGER NOT NULL DEFAULT 0 CHECK (has_app IN (0, 1)),
+		hidden INTEGER NOT NULL DEFAULT 0 CHECK (hidden IN (0, 1)),
+		is_private INTEGER NOT NULL DEFAULT 1 CHECK (is_private IN (0, 1)),
+		created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+		updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+	)`)
+	await runSql(`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		source_id TEXT NOT NULL,
+		published_commit TEXT NOT NULL,
+		artifact_kind TEXT NOT NULL,
+		artifact_name TEXT,
+		entry_point TEXT NOT NULL,
+		kv_key TEXT NOT NULL,
+		dependencies_json TEXT NOT NULL DEFAULT '[]',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`)
+}
+
+function createSourceRow(input: {
+	userId: string
+	packageId: string
+	sourceId: string
+	publishedCommit: string
+}) {
+	return {
+		id: input.sourceId,
+		user_id: input.userId,
+		entity_kind: 'package' as const,
+		entity_id: input.packageId,
+		repo_id: `repo-${input.sourceId}`,
+		published_commit: input.publishedCommit,
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		created_at: '2026-07-30T00:00:00.000Z',
+		updated_at: '2026-07-30T00:00:00.000Z',
+	}
+}
+
+function createProbeSourceFiles(input: { kodyId: string; version: string }) {
+	return {
+		'package.json': JSON.stringify({
+			name: `@kentcdodds/${input.kodyId}`,
+			exports: {
+				'./probe': './src/probe.ts',
+			},
+			kody: {
+				id: input.kodyId,
+				description: 'Invoke contract cache probe target',
+			},
+		}),
+		'src/probe.ts': [
+			'export default async function probe() {',
+			`\treturn { version: 'republish-${input.version}-marker' }`,
+			'}',
+		].join('\n'),
+	}
+}
+
+async function seedPublishedProbePackage(input: {
+	userId: string
+	packageId: string
+	kodyId: string
+	sourceId: string
+	publishedCommit: string
+	version: string
+	insertRows: boolean
+}) {
+	const now = new Date().toISOString()
+	if (input.insertRows) {
+		await runSql(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, tags_json, search_text,
+				source_id, has_app, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, '[]', NULL, ?, 0, ?, ?)`,
+			input.packageId,
+			input.userId,
+			`@kentcdodds/${input.kodyId}`,
+			input.kodyId,
+			'Invoke contract cache probe target',
+			input.sourceId,
+			now,
+			now,
+		)
+		await runSql(
+			`INSERT INTO entity_sources (
+				id, user_id, entity_kind, entity_id, repo_id, published_commit,
+				indexed_commit, manifest_path, source_root, created_at, updated_at
+			) VALUES (?, ?, 'package', ?, ?, ?, NULL, 'package.json', '/', ?, ?)`,
+			input.sourceId,
+			input.userId,
+			input.packageId,
+			`repo-${input.sourceId}`,
+			input.publishedCommit,
+			now,
+			now,
+		)
+	} else {
+		await runSql(
+			`UPDATE entity_sources SET published_commit = ?, updated_at = ? WHERE id = ?`,
+			input.publishedCommit,
+			now,
+			input.sourceId,
+		)
+	}
+	const source = createSourceRow(input)
+	const sourceFiles = createProbeSourceFiles({
+		kodyId: input.kodyId,
+		version: input.version,
+	})
+	await persistPublishedSourceSnapshot({
+		env,
+		userId: input.userId,
+		source,
+		snapshot: { files: sourceFiles },
+	})
+	const bundle = await buildKodyModuleBundle({
+		env,
+		baseUrl: 'https://kody.dev',
+		userId: input.userId,
+		sourceFiles,
+		entryPoint: 'src/probe.ts',
+	})
+	await persistPublishedBundleArtifact({
+		env,
+		userId: input.userId,
+		source,
+		kind: 'module',
+		artifactName: './probe',
+		entryPoint: 'src/probe.ts',
+		mainModule: bundle.mainModule,
+		modules: bundle.modules,
+		dependencies: bundle.dependencies,
+		packageContext: {
+			packageId: input.packageId,
+			kodyId: input.kodyId,
+			sourceId: input.sourceId,
+		},
+	})
+}
+
+/**
+ * Wraps the real D1 and KV bindings so every awaited load the contract check
+ * performs is counted at the binding boundary. The contract check only ever
+ * reads through `prepare` (D1) and `get` (KV).
+ */
+function createCountingEnv() {
+	const counters = { d1Prepare: 0, kvGet: 0 }
+	const countedDb = {
+		prepare(...args: Parameters<D1Database['prepare']>) {
+			counters.d1Prepare += 1
+			return env.APP_DB.prepare(...args)
+		},
+	} as D1Database
+	const realKv = env.BUNDLE_ARTIFACTS_KV as KVNamespace
+	const countedKv = {
+		get(...args: Parameters<KVNamespace['get']>) {
+			counters.kvGet += 1
+			return (realKv.get as (...getArgs: Array<unknown>) => unknown)(...args)
+		},
+		put: (...args: Parameters<KVNamespace['put']>) => realKv.put(...args),
+		delete: (...args: Parameters<KVNamespace['delete']>) =>
+			realKv.delete(...args),
+		list: (...args: Parameters<KVNamespace['list']>) => realKv.list(...args),
+	} as unknown as KVNamespace
+	const countedEnv = {
+		...env,
+		APP_DB: countedDb,
+		BUNDLE_ARTIFACTS_KV: countedKv,
+	} as Env
+	const resetCounters = () => {
+		counters.d1Prepare = 0
+		counters.kvGet = 0
+	}
+	return { countedEnv, counters, resetCounters }
+}
+
+async function runContractCheck(input: {
+	countedEnv: Env
+	userId: string
+	kodyId: string
+}) {
+	return await checkPackageInvokeForRuntimeWithPreloads({
+		env: input.countedEnv,
+		baseUrl: 'https://kody.dev',
+		operationName: 'packages.invoke',
+		userId: input.userId,
+		rawInput: {
+			kodyId: input.kodyId,
+			exportName: './probe',
+			params: {},
+		},
+		includeExportProjection: false,
+	})
+}
+
+test(
+	'a warm keyless invoke contract check performs zero D1/KV loads against real bindings',
+	{ timeout: 30_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		await ensureSavedPackageArtifactSchema()
+		const unique = crypto.randomUUID()
+		const userId = `user-${unique}`
+		const kodyId = `cache-probe-${unique}`
+		await seedPublishedProbePackage({
+			userId,
+			packageId: `pkg-${unique}`,
+			kodyId,
+			sourceId: `source-${unique}`,
+			publishedCommit: `commit-1-${unique}`,
+			version: 'v1',
+			insertRows: true,
+		})
+		const { countedEnv, counters, resetCounters } = createCountingEnv()
+
+		const cold = await runContractCheck({ countedEnv, userId, kodyId })
+		expect(cold.result.ok).toBe(true)
+		expect(cold.result.ok && cold.result.contract.publishedCommit).toBe(
+			`commit-1-${unique}`,
+		)
+		expect(counters.d1Prepare).toBeGreaterThan(0)
+		expect(counters.kvGet).toBeGreaterThan(0)
+
+		resetCounters()
+		const warm = await runContractCheck({ countedEnv, userId, kodyId })
+
+		expect(warm.result.ok).toBe(true)
+		expect(warm.result.ok && warm.result.contract.publishedCommit).toBe(
+			`commit-1-${unique}`,
+		)
+		expect(warm.preloads?.moduleArtifact.artifact.publishedCommit).toBe(
+			`commit-1-${unique}`,
+		)
+		expect(counters).toEqual({ d1Prepare: 0, kvGet: 0 })
+	},
+)
+
+test(
+	'the cached contract check serves the new commit and artifact after a republish',
+	{ timeout: 30_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		await ensureSavedPackageArtifactSchema()
+		const unique = crypto.randomUUID()
+		const userId = `user-${unique}`
+		const packageId = `pkg-${unique}`
+		const kodyId = `republish-probe-${unique}`
+		const sourceId = `source-${unique}`
+		await seedPublishedProbePackage({
+			userId,
+			packageId,
+			kodyId,
+			sourceId,
+			publishedCommit: `commit-1-${unique}`,
+			version: 'v1',
+			insertRows: true,
+		})
+		const { countedEnv } = createCountingEnv()
+
+		const beforeRepublish = await runContractCheck({
+			countedEnv,
+			userId,
+			kodyId,
+		})
+		expect(
+			beforeRepublish.result.ok &&
+				beforeRepublish.result.contract.publishedCommit,
+		).toBe(`commit-1-${unique}`)
+
+		await seedPublishedProbePackage({
+			userId,
+			packageId,
+			kodyId,
+			sourceId,
+			publishedCommit: `commit-2-${unique}`,
+			version: 'v2',
+			insertRows: false,
+		})
+		// The projection refresh runs this invalidation in its isolate; other
+		// isolates converge within invokeContractFreshnessTtlMs (covered by the
+		// node suite with fake timers).
+		invalidateInvokeContractFreshness({
+			userId,
+			packageIdOrKodyIds: [packageId, kodyId],
+			sourceId,
+		})
+
+		const afterRepublish = await runContractCheck({
+			countedEnv,
+			userId,
+			kodyId,
+		})
+		expect(
+			afterRepublish.result.ok &&
+				afterRepublish.result.contract.publishedCommit,
+		).toBe(`commit-2-${unique}`)
+		const artifact = afterRepublish.preloads?.moduleArtifact.artifact
+		expect(artifact?.publishedCommit).toBe(`commit-2-${unique}`)
+		// The preloaded artifact is the exact bundle the lean invoke executes;
+		// it must carry the republished code, not the cached v1 bundle.
+		const moduleSources = Object.values(artifact?.modules ?? {}).join('\n')
+		expect(moduleSources).toContain('republish-v2-marker')
+		expect(moduleSources).not.toContain('republish-v1-marker')
+	},
+)

--- a/packages/worker/src/package-invocations/module-artifacts.ts
+++ b/packages/worker/src/package-invocations/module-artifacts.ts
@@ -3,8 +3,10 @@ import {
 	getSavedPackageByKodyId,
 } from '#worker/package-registry/repo.ts'
 import {
-	loadPackageManifestBySourceId,
+	loadPackageManifestForSource,
 	loadPackageSourceBySourceId,
+	loadPackageSourceRowForUser,
+	type LoadedPackageManifest,
 } from '#worker/package-registry/source.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 import {
@@ -26,6 +28,12 @@ import {
 	type PackageModuleResolution,
 	type PackageModuleSelector,
 } from './common.ts'
+import {
+	loadModuleArtifactWithCommitCache,
+	loadSourceRowWithFreshnessCache,
+	resolveSavedPackageWithFreshnessCache,
+	type CachedInvokeModuleArtifact,
+} from './invoke-contract-cache.ts'
 import { isRetryableD1LockError } from '#worker/d1-retry.ts'
 
 export async function resolveSavedPackage(input: {
@@ -33,32 +41,64 @@ export async function resolveSavedPackage(input: {
 	userId: string
 	packageIdOrKodyId: string
 }): Promise<SavedPackageRecord | null> {
-	return (
-		(await getSavedPackageById(input.db, {
-			userId: input.userId,
-			packageId: input.packageIdOrKodyId,
-		})) ??
-		(await getSavedPackageByKodyId(input.db, {
-			userId: input.userId,
-			kodyId: input.packageIdOrKodyId,
-		}))
-	)
+	return await resolveSavedPackageWithFreshnessCache({
+		userId: input.userId,
+		packageIdOrKodyId: input.packageIdOrKodyId,
+		load: async () =>
+			(await getSavedPackageById(input.db, {
+				userId: input.userId,
+				packageId: input.packageIdOrKodyId,
+			})) ??
+			(await getSavedPackageByKodyId(input.db, {
+				userId: input.userId,
+				kodyId: input.packageIdOrKodyId,
+			})),
+	})
+}
+
+/**
+ * Manifest load for invocation paths: the entity-source row (the freshness
+ * anchor carrying `published_commit`) comes from the short-TTL invoke
+ * contract cache, and the manifest itself from the commit-keyed manifest
+ * cache. Warm calls perform zero D1/KV loads. Publish and rebuild flows must
+ * keep using `loadPackageManifestBySourceId`, which always reads the row
+ * fresh.
+ */
+export async function loadInvokeManifestBySourceId(input: {
+	env: Env
+	userId: string
+	sourceId: string
+}): Promise<LoadedPackageManifest> {
+	const source = await loadSourceRowWithFreshnessCache({
+		userId: input.userId,
+		sourceId: input.sourceId,
+		load: () =>
+			loadPackageSourceRowForUser({
+				env: input.env,
+				userId: input.userId,
+				sourceId: input.sourceId,
+			}),
+	})
+	return await loadPackageManifestForSource({
+		env: input.env,
+		userId: input.userId,
+		source,
+	})
 }
 
 export async function ensureModuleArtifact(input: {
 	env: Env
 	baseUrl: string
-	packageManifest?: Awaited<ReturnType<typeof loadPackageManifestBySourceId>>
+	packageManifest?: LoadedPackageManifest
 	resolution?: PackageModuleResolution
 	savedPackage: SavedPackageRecord
 	selector: PackageModuleSelector
 	userId: string
-}) {
+}): Promise<CachedInvokeModuleArtifact> {
 	const packageManifest =
 		input.packageManifest ??
-		(await loadPackageManifestBySourceId({
+		(await loadInvokeManifestBySourceId({
 			env: input.env,
-			baseUrl: input.baseUrl,
 			userId: input.userId,
 			sourceId: input.savedPackage.sourceId,
 		}))
@@ -68,6 +108,35 @@ export async function ensureModuleArtifact(input: {
 			manifest: packageManifest.manifest,
 			selector: input.selector,
 		})
+	return await loadModuleArtifactWithCommitCache({
+		userId: input.userId,
+		sourceId: input.savedPackage.sourceId,
+		publishedCommit: packageManifest.source.published_commit,
+		artifactName: resolution.artifactName,
+		entryPoint: resolution.entryPoint,
+		load: () =>
+			ensureModuleArtifactUncached({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				packageManifest,
+				resolution,
+				savedPackage: input.savedPackage,
+				selector: input.selector,
+				userId: input.userId,
+			}),
+	})
+}
+
+async function ensureModuleArtifactUncached(input: {
+	env: Env
+	baseUrl: string
+	packageManifest: LoadedPackageManifest
+	resolution: PackageModuleResolution
+	savedPackage: SavedPackageRecord
+	selector: PackageModuleSelector
+	userId: string
+}): Promise<CachedInvokeModuleArtifact> {
+	const { packageManifest, resolution } = input
 	const loaded = await loadPublishedBundleArtifactByIdentity({
 		env: input.env,
 		userId: input.userId,

--- a/packages/worker/src/package-invocations/module-artifacts.ts
+++ b/packages/worker/src/package-invocations/module-artifacts.ts
@@ -158,9 +158,18 @@ async function ensureModuleArtifactUncached(input: {
 		userId: input.userId,
 		sourceId: input.savedPackage.sourceId,
 	})
+	// The caller's manifest may come from the freshness-cached source row and
+	// trail a republish by up to the freshness TTL, while the source load
+	// above is always current. Re-derive the module resolution from the
+	// freshly loaded manifest so the typecheck, bundle, and persisted
+	// artifact identity are all self-consistent with the commit being built.
+	const freshResolution = resolvePackageModuleResolution({
+		manifest: packageSource.manifest,
+		selector: input.selector,
+	})
 	const typecheckResult = await typecheckPackageEntrypointsFromSourceFiles({
 		sourceFiles: packageSource.files,
-		entryPoints: [{ path: resolution.entryPoint, includeStorage: true }],
+		entryPoints: [{ path: freshResolution.entryPoint, includeStorage: true }],
 		emittedEventTopics: Object.keys(packageSource.manifest.kody.emits ?? {}),
 	})
 	if (!typecheckResult.ok) {
@@ -168,7 +177,7 @@ async function ensureModuleArtifactUncached(input: {
 	}
 	assertPublishedSourceCanRebuildWithoutInstallingDeps({
 		sourceFiles: packageSource.files,
-		bundleLabel: `Saved package export "${resolution.artifactName}"`,
+		bundleLabel: `Saved package export "${freshResolution.artifactName}"`,
 	})
 	const { buildKodyModuleBundle } =
 		await import('#worker/package-runtime/module-graph.ts')
@@ -177,7 +186,7 @@ async function ensureModuleArtifactUncached(input: {
 		baseUrl: input.baseUrl,
 		userId: input.userId,
 		sourceFiles: packageSource.files,
-		entryPoint: resolution.entryPoint,
+		entryPoint: freshResolution.entryPoint,
 		rootPackageId: input.savedPackage.id,
 	})
 	await persistPublishedBundleArtifact({
@@ -185,8 +194,8 @@ async function ensureModuleArtifactUncached(input: {
 		userId: input.userId,
 		source: packageSource.source,
 		kind: 'module',
-		artifactName: resolution.artifactName,
-		entryPoint: resolution.entryPoint,
+		artifactName: freshResolution.artifactName,
+		entryPoint: freshResolution.entryPoint,
 		mainModule: bundle.mainModule,
 		modules: bundle.modules,
 		dependencies: bundle.dependencies,
@@ -202,8 +211,8 @@ async function ensureModuleArtifactUncached(input: {
 		userId: input.userId,
 		sourceId: input.savedPackage.sourceId,
 		kind: 'module',
-		artifactName: resolution.artifactName,
-		entryPoint: resolution.entryPoint,
+		artifactName: freshResolution.artifactName,
+		entryPoint: freshResolution.entryPoint,
 	})
 	if (!rebuilt?.artifact) {
 		const moduleLabel =
@@ -217,7 +226,7 @@ async function ensureModuleArtifactUncached(input: {
 	return {
 		artifact: rebuilt.artifact,
 		source: packageSource.source,
-		entryPoint: resolution.entryPoint,
+		entryPoint: freshResolution.entryPoint,
 	}
 }
 

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -8,23 +8,41 @@ import {
 	invokePackageExport,
 	invokePackageSubscription,
 } from './service.ts'
+import { clearInvokeContractCachesForTests } from './invoke-contract-cache.ts'
 import { maxStoredInvocationResponseJsonBytes } from './repo.ts'
 
-const repoMockModule = vi.hoisted(() => ({
-	getSavedPackageById: vi.fn(),
-	getSavedPackageByKodyId: vi.fn(),
-	listSavedPackagesByUserId: vi.fn(),
-	loadPackageManifestBySourceId: vi.fn(),
-	loadPackageSourceBySourceId: vi.fn(),
-	getEntitySourceById: vi.fn(),
-	loadPublishedBundleArtifactByIdentity: vi.fn(),
-	persistPublishedBundleArtifact: vi.fn(),
-	typecheckPackageEntrypointsFromSourceFiles: vi.fn(),
-	runBundledModuleWithRegistry: vi.fn(),
-	recordAgentPackageConversationUse: vi.fn(),
-	recordSuccessfulPackageRun: vi.fn(),
-	dispatchRunErrorSubscriptionEvents: vi.fn(),
-}))
+const repoMockModule = vi.hoisted(() => {
+	const loadPackageManifestBySourceId = vi.fn()
+	return {
+		getSavedPackageById: vi.fn(),
+		getSavedPackageByKodyId: vi.fn(),
+		listSavedPackagesByUserId: vi.fn(),
+		loadPackageManifestBySourceId,
+		// The invoke path loads the source row and manifest separately (see
+		// loadInvokeManifestBySourceId); default to the same per-test data the
+		// combined mock is configured with.
+		loadPackageSourceRowForUser: vi.fn(
+			async (input: { sourceId: string; userId: string }) =>
+				(await loadPackageManifestBySourceId(input)).source,
+		),
+		loadPackageManifestForSource: vi.fn(
+			async (input: { source: { id: string }; userId: string }) =>
+				await loadPackageManifestBySourceId({
+					...input,
+					sourceId: input.source.id,
+				}),
+		),
+		loadPackageSourceBySourceId: vi.fn(),
+		getEntitySourceById: vi.fn(),
+		loadPublishedBundleArtifactByIdentity: vi.fn(),
+		persistPublishedBundleArtifact: vi.fn(),
+		typecheckPackageEntrypointsFromSourceFiles: vi.fn(),
+		runBundledModuleWithRegistry: vi.fn(),
+		recordAgentPackageConversationUse: vi.fn(),
+		recordSuccessfulPackageRun: vi.fn(),
+		dispatchRunErrorSubscriptionEvents: vi.fn(),
+	}
+})
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
 	getSavedPackageById: (...args: Array<unknown>) =>
@@ -40,6 +58,10 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 		repoMockModule.loadPackageManifestBySourceId(...args),
 	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
 		repoMockModule.loadPackageSourceBySourceId(...args),
+	loadPackageSourceRowForUser: (...args: Array<unknown>) =>
+		repoMockModule.loadPackageSourceRowForUser(...args),
+	loadPackageManifestForSource: (...args: Array<unknown>) =>
+		repoMockModule.loadPackageManifestForSource(...args),
 }))
 
 vi.mock('#worker/repo/entity-sources.ts', () => ({
@@ -1213,7 +1235,7 @@ test('package runtime invoke contract-checks once and executes the target', asyn
 		result: { handled: true, eventId: 'message-1' },
 		logs: [],
 	})
-	repoMockModule.loadPackageManifestBySourceId.mockClear()
+	repoMockModule.loadPackageManifestForSource.mockClear()
 	const tools = createRuntimeDispatchTools(db)
 
 	const result = await tools.invoke({
@@ -1227,7 +1249,7 @@ test('package runtime invoke contract-checks once and executes the target', asyn
 	expect(result).toEqual({ handled: true, eventId: 'message-1' })
 	// One logical call resolves its package exactly once: the mandatory
 	// contract check preloads the manifest and the invoke phase reuses it.
-	expect(repoMockModule.loadPackageManifestBySourceId).toHaveBeenCalledTimes(1)
+	expect(repoMockModule.loadPackageManifestForSource).toHaveBeenCalledTimes(1)
 	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
 })
 
@@ -2239,6 +2261,10 @@ test('invokePackageSubscription uses the normal capability registry with package
 	}
 
 	const transientKey = 'email:message-transient:pkg-1:email.message.received'
+	// The commit-keyed artifact cache is warm from the invocations above and
+	// would absorb the injected KV failure; this scenario is about a cold
+	// artifact load failing transiently.
+	clearInvokeContractCachesForTests()
 	repoMockModule.loadPublishedBundleArtifactByIdentity.mockRejectedValueOnce(
 		new Error('KV timeout'),
 	)

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -35,6 +35,7 @@ import {
 	refreshPackageRetrieverManifestCache,
 	removePackageRetrieverManifestCacheEntries,
 } from '#worker/package-retrievers/manifest-cache.ts'
+import { invalidateInvokeContractFreshness } from '#worker/package-invocations/invoke-contract-cache.ts'
 import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-cleanup.ts'
 import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
 import {
@@ -419,6 +420,19 @@ export async function refreshSavedPackageProjection(input: {
 					userId: input.userId,
 				})
 			}
+			// Same-isolate invoke paths must observe this refresh immediately;
+			// other isolates converge within the freshness-cache TTL.
+			invalidateInvokeContractFreshness({
+				userId: input.userId,
+				packageIdOrKodyIds: [
+					input.packageId,
+					row.kody_id,
+					...(existing && existing.kodyId !== row.kody_id
+						? [existing.kodyId]
+						: []),
+				],
+				sourceId: input.sourceId,
+			})
 			return {
 				record: savedPackage,
 				manifest: loaded.manifest,
@@ -581,6 +595,14 @@ export async function deleteSavedPackageProjection(input: {
 				})
 			}
 			await deleteSavedPackageVector(input.env, input.packageId)
+			invalidateInvokeContractFreshness({
+				userId: input.userId,
+				packageIdOrKodyIds: [
+					input.packageId,
+					...(savedPackage ? [savedPackage.kodyId] : []),
+				],
+				sourceId: savedPackage?.sourceId ?? null,
+			})
 			if (packageJobsRemoved) {
 				await syncJobManagerAlarm({
 					env: input.env,

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -93,7 +93,14 @@ function canResolveRepoBackedPackageSource(env: Env) {
 	)
 }
 
-async function resolvePackageSourceRow(input: {
+/**
+ * Loads the entity-source row for a saved package, rejecting rows owned by a
+ * different user. Always a fresh D1 read: publish and rebuild flows depend on
+ * observing the current `published_commit`. Invocation hot paths that can
+ * tolerate a bounded-staleness row wrap this in the invoke contract cache
+ * instead (see `#worker/package-invocations/invoke-contract-cache.ts`).
+ */
+export async function loadPackageSourceRowForUser(input: {
 	env: Env
 	userId: string
 	sourceId: string
@@ -152,7 +159,7 @@ export async function loadPackageSourceBySourceId(input: {
 	if (!canResolveRepoBackedPackageSource(input.env)) {
 		throw new Error('Saved package source bindings are not available.')
 	}
-	const source = await resolvePackageSourceRow({
+	const source = await loadPackageSourceRowForUser({
 		env: input.env,
 		userId: input.userId,
 		sourceId: input.sourceId,
@@ -190,11 +197,31 @@ export async function loadPackageManifestBySourceId(input: {
 	if (!canResolveRepoBackedPackageSource(input.env)) {
 		throw new Error('Saved package source bindings are not available.')
 	}
-	const source = await resolvePackageSourceRow({
+	const source = await loadPackageSourceRowForUser({
 		env: input.env,
 		userId: input.userId,
 		sourceId: input.sourceId,
 	})
+	return await loadPackageManifestForSource({
+		env: input.env,
+		userId: input.userId,
+		source,
+	})
+}
+
+/**
+ * Manifest load for a caller that already holds the entity-source row (e.g.
+ * the invoke contract check, which resolves the row through its own
+ * freshness-bounded cache). Shares the commit-keyed manifest cache with
+ * {@link loadPackageManifestBySourceId}, so the KV snapshot is read at most
+ * once per published commit per isolate.
+ */
+export async function loadPackageManifestForSource(input: {
+	env: Env
+	userId: string
+	source: EntitySourceRow
+}): Promise<LoadedPackageManifest> {
+	const source = input.source
 	const cacheKey = createPackageSourceCacheKey({
 		userId: input.userId,
 		source,

--- a/packages/worker/src/test-support/invoke-contract-cache-reset.ts
+++ b/packages/worker/src/test-support/invoke-contract-cache-reset.ts
@@ -1,0 +1,10 @@
+import { beforeEach } from 'vitest'
+import { clearInvokeContractCachesForTests } from '#worker/package-invocations/invoke-contract-cache.ts'
+
+// The invoke contract check caches saved-package rows, source rows, and
+// prepared bundle artifacts at module scope (per isolate in production).
+// Tests in one file share that module state and routinely reuse fixture ids
+// with different data, so reset the caches before every test.
+beforeEach(() => {
+	clearInvokeContractCachesForTests()
+})

--- a/vitest-shared.ts
+++ b/vitest-shared.ts
@@ -53,6 +53,10 @@ export const sharedProjectConfig = {
 		mockReset: true,
 		setupFiles: [
 			resolve(rootDir, 'packages/worker/src/test-support/console-spies.ts'),
+			resolve(
+				rootDir,
+				'packages/worker/src/test-support/invoke-contract-cache-reset.ts',
+			),
 		],
 		// msw's cookie store probes `typeof localStorage`, which trips Node's
 		// experimental localStorage warning in every fork that loads it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Program report

MERGE-READY

CI green (Validate aggregator ✅, Node / Workers / MCP / E2E / Static all pass), Cursor Bugbot pass (its one finding — rebuild resolution mixing a freshness-cached manifest with fresh source — was fixed and regression-tested in `0a98431f`), CodeRabbit rate-limited, branch MERGEABLE and rebased onto `main` @ `028e93f6` (includes #1064 ledger retirement and the sibling narrow-phase #1065). Post-deploy: probe 5 sequential keyless invokes of `sentry-triage/get-issue-state`; predicted warm ≈ 80 ms (see expectations below), and watch `package_export` / `execute` percentiles in `kody_usage_events`.

## Summary

Executes [#1062](https://github.com/kentcdodds/kody/issues/1062): the warm keyless `packages.invoke` path measured ~320 ms in production vs a ~17 ms spike for the same nested-execution shape. The gap is dominated by per-call contract-check loads (saved-package row + source row via D1, manifest + bundle artifact via KV) and two per-call D1 reads inside capability-registry/runtime-metadata assembly. This PR removes all of them from the warm path with per-isolate caches keyed by `userId` and published commit.

**A warm keyless invoke of an already-warm package+commit now performs zero D1/KV loads for the contract check** — proven by a workers test that counts loads at the real D1/KV binding boundary (`invoke-contract-cache.workers.test.ts`).

### Design (two cache tiers, one new module)

`packages/worker/src/package-invocations/invoke-contract-cache.ts`:

- **Freshness tier** — saved-package row and entity-source row (the row carrying `published_commit`), TTL **15 s**, misses never retained. This TTL is the documented cross-isolate republish staleness bound. `refreshSavedPackageProjection` / `deleteSavedPackageProjection` invalidate eagerly, so the isolate that performs a publish observes it immediately.
- **Commit tier** — manifest (existing commit-keyed cache in `source.ts`, now reachable without the per-call D1 row read) and the prepared bundle artifact (new cache keyed by `userId + sourceId + publishedCommit + artifact identity`). A commit's artifacts are immutable, so this tier is never a staleness source; its 5-minute TTL and small limit only bound isolate memory. An artifact whose commit does not match the freshness-tier commit (mid-republish race) is served but deliberately **not retained**, so staleness can never exceed the freshness TTL.
- **Registry assembly** — `listEnabledMcpServerRefs` and `listOpenApiBindings` (a D1 read each per run, in both `getCapabilityRegistryForContext` and `buildKodyMcpServerMetadata`) get per-user 30 s caches with eager same-file invalidation on add/enable/delete/save — the same bound the remote-connector and MCP-hub snapshot caches already use. Listing surfaces (settings UI, `openapi_binding_list`) keep the uncached functions.
- **Rebuild coherence (Bugbot fix)** — a missing-artifact rebuild re-derives its module resolution from the freshly loaded source manifest instead of the (possibly freshness-cached) caller manifest, so the typecheck, bundle, and persisted artifact identity are always self-consistent with the commit being built.

### Staleness bounds (republish pickup)

| Change | Same isolate | Other isolates |
| --- | --- | --- |
| Republish / rename / delete of a package | immediate (eager invalidation from projection refresh) | ≤ **15 s** |
| MCP server / OpenAPI binding mutation | immediate | ≤ **30 s** |

Documented in `docs/contributing/architecture/invocation-overhead-guardrails.md` (new "Per-isolate caches and their staleness bounds" section), with the rule that publish/rebuild flows must keep using the uncached loaders — `refreshSavedPackageProjection` still reads the source row fresh, so a rebuild can never run against a stale `published_commit`.

### Guardrails compliance

- **No new awaited D1 writes** on any path — this PR only removes awaited reads; invalidation is synchronous in-memory map deletion.
- **Per-user isolation**: every cache key starts with the owning `userId`; a dedicated test asserts a second user's check never reuses the first user's entries.
- **Fresh isolate per call is unchanged.** Issue item 3 (isolate reuse across keyless invokes of the same package+commit) is deliberately **not implemented**: the lean-path contract from #1046 documents and tests fresh-realm-per-call semantics (module-level state invisible across calls, in both directions), and reusing isolates would silently change that contract for user code. If we want it, it should be its own PR with explicit realm-separation review — flagging loudly here per the issue's instruction.

### What's left on the warm path

Worker-loader sandbox spin-up (kept, see above), module hydration + provider assembly CPU (static registry already isolate-memoized, dynamic registry already 30 s LRU'd), and non-awaited observability (`recordUsage`, on-failure run records).

### Production expectations (before → after)

Baseline (2026-07-30, 5 sequential keyless invokes of `sentry-triage/get-issue-state`): **[2381, 335, 307, 321, 347] ms** — cold first, ~320 ms warm.

Predicted after deploy: first call per isolate still pays the cold loads (~similar to baseline warm or better), subsequent warm calls **~60–100 ms; predicted ≈ 80 ms** (contract check drops ~4 sequential D1 round trips + 1 KV read; registry assembly drops 2 D1 reads). Watch `package_export` and `execute` `durationMs` percentiles in `kody_usage_events` after deploy; a regression there is a release blocker per the guardrails doc.

### Test plan

- [x] `invoke-contract-cache.workers.test.ts` (real workerd + real D1/KV): warm contract check performs **zero** D1 `prepare` / KV `get` calls; after a republish (row update + new snapshot + new artifact) the check serves the new commit and the preloaded artifact carries the republished code.
- [x] `invoke-contract-cache.node.test.ts`: TTL-bounded pickup with fake timers (`invokeContractFreshnessTtlMs`), eager invalidation, per-user isolation, commit-mismatch no-retain rule, and the Bugbot rebuild-coherence regression.
- [x] `settings-service.node.test.ts` / `binding-service.node.test.ts`: dedupe within TTL, TTL expiry, eager invalidation on mutation, per-user keying.
- [x] Full `npm run test:node` and `npm run test:workers` green after rebasing onto #1064 + #1065; `npm run validate` components all green locally (Playwright + MCP E2E re-run serially on the 4-core agent VM where the fully-parallel run starved the dev servers).
- [x] CI: Validate aggregator ✅ with all parallel jobs green; Cursor Bugbot pass.

### Notes for reviewers

- Rebased onto the sibling narrow-phase merge (#1065): `invoke-check.ts` keeps main's single-check shape with a one-call-site swap (`loadPackageManifestBySourceId` → `loadInvokeManifestBySourceId`).
- A shared vitest setup (`test-support/invoke-contract-cache-reset.ts`) clears the module-level caches before every test so fixture ids can be reused across tests in a file.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `028e93f6` · **Head:** `0a98431f`

**Classification:** extends — the keyless invoke contract check and registry assembly gain per-isolate caching contracts with documented staleness bounds; no new primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capabilities-execute` | runtime | extends — invoke contract check (package-invocations territory) reads through the new two-tier cache; runtime MCP metadata uses cached refs |
| `capability-registry` | assistant | extends — registry assembly reads MCP refs / OpenAPI bindings through 30 s per-user caches |
| `saved-packages` | assistant | extends — `loadPackageManifestForSource` split for preloaded rows; projection refresh/delete invalidate the invoke caches |
| `mcp-client-servers` | assistant | extends — `listEnabledMcpServerRefsCached` + eager invalidation on add/enable/delete |
| `openapi-bindings` | assistant | extends — `listOpenApiBindingsCached` + eager invalidation on save/delete |

### System map

A warm keyless invoke resolves its entire contract (package row, source row, manifest, bundle artifact) from per-isolate caches instead of D1/KV, and registry assembly stops paying two D1 reads per run.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	mcpClientServers["mcp-client-servers<br/>User MCP servers"]:::extended
	openapiBindings["openapi-bindings<br/>OpenAPI bindings"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	capabilitiesExecute -->|"contract check: 15s freshness + commit-keyed artifact caches (zero warm D1/KV)"| savedPackages
	savedPackages -->|"publish refresh/delete: eager cache invalidation; uncached row reads kept for rebuilds"| d1AppDb
	capabilityRegistry -->|"listEnabledMcpServerRefsCached (30s per user)"| mcpClientServers
	capabilityRegistry -->|"listOpenApiBindingsCached (30s per user)"| openapiBindings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Invoke as packages.invoke (keyless)
	participant Cache as invoke-contract-cache
	participant D1 as D1 / KV
	Invoke->>Cache: resolve saved package + source row
	alt warm (≤15s)
		Cache-->>Invoke: cached rows (zero loads)
	else cold or expired
		Cache->>D1: row reads (then commit-keyed manifest/artifact fill)
		D1-->>Cache: rows @ published_commit
	end
	Cache-->>Invoke: preloads {savedPackage, manifest, artifact@commit}
	Note over Invoke: dispatch into target runtime (fresh isolate, unchanged)
```

### Invariants

Per-user isolation: every new cache key begins with the owning `userId`; cross-user reuse is covered by a dedicated regression test. No new awaited D1 writes on hot invocation paths.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17ea3be8-c6fe-468a-b367-476d1bdad292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17ea3be8-c6fe-468a-b367-476d1bdad292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

