### PR TITLE
Drop check/invokeChecked from the package typecheck typedef and stale references

### DIFF
--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -371,9 +371,7 @@ test('execute tool serializes successes and errors, binds storage, passes packag
 	})
 
 	const packageInvokeTools = {
-		check: vi.fn(),
 		invoke: vi.fn(),
-		invokeChecked: vi.fn(),
 	}
 	mockModule.createExecutePackageInvokeTools.mockReturnValueOnce(
 		packageInvokeTools,

--- a/packages/worker/src/package-invocations/invoke-check.ts
+++ b/packages/worker/src/package-invocations/invoke-check.ts
@@ -57,8 +57,8 @@ function buildPackageInvokeCheckWarnings(input: {
  * Everything the check phase already loaded that the invoke phase would
  * otherwise reload from D1/KV: the saved-package row, the current manifest,
  * the resolved module target, and the prepared bundle artifact.
- * `packages.invokeChecked` passes these straight into the invocation so one
- * logical call resolves its package exactly once.
+ * `packages.invoke` passes these straight into the invocation so one logical
+ * call resolves its package exactly once.
  */
 export type PackageInvokeCheckPreloads = {
 	savedPackage: NonNullable<Awaited<ReturnType<typeof resolveSavedPackage>>>

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -306,53 +306,14 @@ type KodyPackagesInvokeInput = KodyPackagesInvokeTarget &
   idempotency_key?: string;
   topic?: string | null;
 };
-type KodyPackagesInvokeNormalizedInput = {
-  kodyId?: string;
-  packageId?: string;
-  exportName: string;
-  params?: Record<string, unknown>;
-  idempotencyKey?: string;
-  topic?: string;
-};
-type KodyPackagesInvokeContract = {
-  packageId: string;
-  kodyId: string;
-  name: string;
-  sourceId: string;
-  publishedCommit: string | null;
-  exportName: string;
-  runtimeTarget: string | null;
-  description?: string | null;
-  typeDefinition?: string | null;
-  warnings: string[];
-};
-type KodyPackagesInvokeCheckResult =
-  | {
-      ok: true;
-      invoke: KodyPackagesInvokeNormalizedInput;
-      contract: KodyPackagesInvokeContract;
-    }
-  | {
-      ok: false;
-      message: string;
-      problems: string[];
-      contract?: Partial<KodyPackagesInvokeContract>;
-    };
 type KodyPackagesRuntime = {
   /**
-   * Actively resolves the current published package export, validates the
-   * invocation input as far as Kody metadata allows, and returns a normalized
-   * input suitable for packages.invoke. This is runtime contract visibility,
-   * not compile-time type safety; warnings explain weak validation.
+   * The only dynamic invocation primitive. Always contract-checks the current
+   * published package export before invoking; a failing contract rejects with
+   * "packages.invoke contract check failed: ...". Key-less calls are
+   * lean/ephemeral; pass idempotencyKey only for exactly-once semantics.
    */
-  check(input: KodyPackagesInvokeInput): Promise<KodyPackagesInvokeCheckResult>;
   invoke(input: KodyPackagesInvokeInput): Promise<unknown>;
-  /**
-   * Runs packages.check first, throws on check failure, then invokes the
-   * normalized current package export. Prefer this over packages.invoke when
-   * dynamically calling a package whose contract may have changed.
-   */
-  invokeChecked(input: KodyPackagesInvokeInput): Promise<unknown>;
 };
 type KodyStorageRuntime = {
   id: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final-sweep follow-up to the narrow phase (#1065), caught by the done-definition grep: the generated `KodyPackagesRuntime` typedef used by the pre-exec/package typecheck harness still declared the removed `check` / `invokeChecked` members, so legacy package code would **typecheck cleanly** and only fail at lint/runtime. Now the typechecker errors too — the earliest possible teaching signal.

- `repo/checks.ts`: `KodyPackagesRuntime` narrows to `{ invoke }` with the two-rule contract in its doc comment; the orphaned `KodyPackagesInvokeContract` / `KodyPackagesInvokeCheckResult` / `KodyPackagesInvokeNormalizedInput` typedefs (only consumed by the removed members) are deleted.
- `invoke-check.ts`: stale preload doc comment reworded to `packages.invoke`.
- `execute.node.test.ts`: mock pruned to the real `PackageInvokeTools` shape.

Typecheck green; checks/execute/package-invocations suites green (48 tests); format clean.

## Program report

- Mechanical final-sweep slice under standing ship authority; squash-merging as Kody once CI is green. After this, the only remaining `invokeChecked` references on main are the removal collector/codemod, teaching-error strings, tests proving absence, and docs describing the removal — exactly the done-definition allowance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3b1e796-faee-4b69-910d-1ec4f03e60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3b1e796-faee-4b69-910d-1ec4f03e60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the package invocation flow to use a single runtime invocation path.
  * Improved consistency in how package preloads are passed through execution.
  * Simplified internal runtime contracts while preserving existing invocation behavior.

* **Tests**
  * Updated execution test coverage to reflect the streamlined invocation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->