### PR TITLE
fix(execute): recover nested pre-exec typechecks

### DIFF
--- a/packages/worker/src/mcp/execute-nested-preexec-typecheck.workers.test.ts
+++ b/packages/worker/src/mcp/execute-nested-preexec-typecheck.workers.test.ts
@@ -1,0 +1,227 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	runBundledModuleWithRegistry,
+	runModuleWithRegistry,
+} from '#mcp/run-kody-registry.ts'
+import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
+import { persistPublishedSourceSnapshot } from '#worker/package-runtime/published-runtime-artifacts.ts'
+import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
+
+async function runSql(sql: string, ...values: Array<unknown>) {
+	await env.APP_DB.prepare(sql)
+		.bind(...values)
+		.run()
+}
+
+async function ensureSavedPackageSchema() {
+	await runSql(`CREATE TABLE IF NOT EXISTS entity_sources (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		entity_kind TEXT NOT NULL,
+		entity_id TEXT NOT NULL,
+		repo_id TEXT NOT NULL,
+		published_commit TEXT,
+		indexed_commit TEXT,
+		manifest_path TEXT NOT NULL DEFAULT 'package.json',
+		source_root TEXT NOT NULL DEFAULT '/',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`)
+	await runSql(`CREATE TABLE IF NOT EXISTS saved_packages (
+		id TEXT PRIMARY KEY NOT NULL,
+		user_id TEXT NOT NULL,
+		name TEXT NOT NULL,
+		kody_id TEXT NOT NULL,
+		description TEXT NOT NULL,
+		tags_json TEXT NOT NULL DEFAULT '[]',
+		search_text TEXT,
+		source_id TEXT NOT NULL,
+		has_app INTEGER NOT NULL DEFAULT 0 CHECK (has_app IN (0, 1)),
+		hidden INTEGER NOT NULL DEFAULT 0 CHECK (hidden IN (0, 1)),
+		is_private INTEGER NOT NULL DEFAULT 1 CHECK (is_private IN (0, 1)),
+		created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+		updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+	)`)
+	await runSql(`CREATE TABLE IF NOT EXISTS published_bundle_artifacts (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		source_id TEXT NOT NULL,
+		published_commit TEXT NOT NULL,
+		artifact_kind TEXT NOT NULL,
+		artifact_name TEXT,
+		entry_point TEXT NOT NULL,
+		kv_key TEXT NOT NULL,
+		dependencies_json TEXT NOT NULL DEFAULT '[]',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`)
+}
+
+async function saveStaticContractPackage(input: {
+	userId: string
+	packageId: string
+	sourceId: string
+	publishedCommit: string
+}) {
+	const now = new Date().toISOString()
+	const packageName = '@kentcdodds/nested-static-contract'
+	await runSql(
+		`INSERT INTO saved_packages (
+			id, user_id, name, kody_id, description, tags_json, search_text,
+			source_id, has_app, created_at, updated_at
+		) VALUES (?, ?, ?, 'nested-static-contract', ?, '[]', NULL, ?, 0, ?, ?)`,
+		input.packageId,
+		input.userId,
+		packageName,
+		'Nested static contract fixture',
+		input.sourceId,
+		now,
+		now,
+	)
+	await runSql(
+		`INSERT INTO entity_sources (
+			id, user_id, entity_kind, entity_id, repo_id, published_commit,
+			indexed_commit, manifest_path, source_root, created_at, updated_at
+		) VALUES (?, ?, 'package', ?, ?, ?, NULL, 'package.json', '/', ?, ?)`,
+		input.sourceId,
+		input.userId,
+		input.packageId,
+		`repo-${input.sourceId}`,
+		input.publishedCommit,
+		now,
+		now,
+	)
+	await persistPublishedSourceSnapshot({
+		env,
+		userId: input.userId,
+		source: {
+			id: input.sourceId,
+			user_id: input.userId,
+			entity_kind: 'package',
+			entity_id: input.packageId,
+			repo_id: `repo-${input.sourceId}`,
+			published_commit: input.publishedCommit,
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: now,
+			updated_at: now,
+		},
+		snapshot: {
+			files: {
+				'package.json': JSON.stringify({
+					name: packageName,
+					exports: {
+						'.': {
+							import: './src/index.ts',
+							types: './types/index.d.ts',
+						},
+					},
+					kody: {
+						id: 'nested-static-contract',
+						description: 'Nested static contract fixture',
+					},
+				}),
+				'src/index.ts':
+					'export default async function greet(input: { name: string }) { return { message: `Hello, ${input.name}` } }',
+				'types/index.d.ts':
+					'export default function greet(input: { name: string }): Promise<{ message: string }>',
+			},
+		},
+	})
+}
+
+test(
+	'nested execute with pre-exec typecheck and a static Kody import reaches its sandbox',
+	{ timeout: 30_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		await ensureSavedPackageSchema()
+		const unique = crypto.randomUUID()
+		const userId = `user-${unique}`
+		await saveStaticContractPackage({
+			userId,
+			packageId: `package-${unique}`,
+			sourceId: `source-${unique}`,
+			publishedCommit: `commit-${unique}`,
+		})
+		const callerContext = createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId,
+				email: 'nested@example.com',
+				displayName: 'Nested Execute Test',
+			},
+		})
+		const outerBundle = await buildKodyModuleBundle({
+			env,
+			baseUrl: callerContext.baseUrl,
+			userId,
+			sourceFiles: {
+				'entry.ts': [
+					"import { kody } from 'kody:runtime'",
+					'export default async function main() {',
+					"\treturn await kody.nested_execute({ marker: 'from-sandbox' })",
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+		const runNested = async (innerCode: string) =>
+			await runBundledModuleWithRegistry(
+				env,
+				callerContext,
+				{
+					mainModule: outerBundle.mainModule,
+					modules: outerBundle.modules,
+				},
+				undefined,
+				{
+					skipCapabilityRegistry: true,
+					additionalTools: {
+						nested_execute: async () =>
+							await runModuleWithRegistry(
+								env,
+								callerContext,
+								innerCode,
+								undefined,
+								{
+									preExecTypecheck: true,
+								},
+							),
+					},
+				},
+			)
+
+		const invalid = await runNested(
+			[
+				"import greet from 'kody:@kentcdodds/nested-static-contract'",
+				'export default async function main() {',
+				'\treturn await greet({ name: 42 })',
+				'}',
+			].join('\n'),
+		)
+		expect(invalid.error).toContain(
+			"Type 'number' is not assignable to type 'string'",
+		)
+
+		const nested = await runNested(
+			[
+				"import greet from 'kody:@kentcdodds/nested-static-contract'",
+				'export default async function main() {',
+				"\treturn await greet({ name: 'Ada' })",
+				'}',
+			].join('\n'),
+		)
+		expect(nested.error).toBeUndefined()
+		expect(nested.result).toMatchObject({
+			result: { message: 'Hello, Ada' },
+			serverTiming: expect.arrayContaining([
+				expect.objectContaining({ name: 'typecheck-total' }),
+				expect.objectContaining({ name: 'sandbox' }),
+			]),
+		})
+	},
+)

--- a/packages/worker/src/mcp/execute-typecheck-queue-recovery.node.test.ts
+++ b/packages/worker/src/mcp/execute-typecheck-queue-recovery.node.test.ts
@@ -1,0 +1,85 @@
+import { expect, test, vi } from 'vitest'
+import { type LoadedKodyGraphPackages } from '#worker/package-runtime/module-graph-import-rewriting.ts'
+
+const compilerMock = vi.hoisted(() => {
+	let resolveFirstService: ((service: unknown) => void) | undefined
+	let creationCount = 0
+	const createService = () => {
+		const files = new Map<string, string>()
+		return {
+			fileSystem: {
+				read: (path: string) => files.get(path) ?? null,
+				write: (path: string, content: string) => files.set(path, content),
+				delete: (path: string) => files.delete(path),
+				list: (prefix?: string) =>
+					[...files.keys()].filter(
+						(path) => prefix === undefined || path.startsWith(prefix),
+					),
+				flush: async () => undefined,
+			},
+			languageService: {
+				getSyntacticDiagnostics: () => [],
+				getSemanticDiagnostics: () => [],
+				dispose: vi.fn(),
+			},
+		}
+	}
+	return {
+		createTypescriptLanguageService: vi.fn(() => {
+			creationCount += 1
+			if (creationCount === 1) {
+				return new Promise((resolve) => {
+					resolveFirstService = resolve
+				})
+			}
+			return Promise.resolve(createService())
+		}),
+		resolveFirst() {
+			resolveFirstService?.(createService())
+		},
+	}
+})
+
+vi.mock('@cloudflare/worker-bundler/typescript', () => ({
+	createTypescriptLanguageService: compilerMock.createTypescriptLanguageService,
+}))
+
+import {
+	assertAdHocExecuteTypechecks,
+	ExecuteTypecheckError,
+} from './execute-typecheck.ts'
+
+test('a cancelled typecheck holder cannot strand the isolate queue', async () => {
+	vi.useFakeTimers()
+	const input = {
+		source: 'export default function main() { return "ok" }',
+		packages: new Map() as LoadedKodyGraphPackages,
+	}
+
+	const cancelled = assertAdHocExecuteTypechecks(input)
+	await vi.waitFor(() => {
+		expect(compilerMock.createTypescriptLanguageService).toHaveBeenCalledTimes(
+			1,
+		)
+	})
+	// Model workerd cancelling the request context: its timers and continuation
+	// disappear, while isolate module state survives for the next request.
+	vi.clearAllTimers()
+
+	const blocked = assertAdHocExecuteTypechecks(input)
+	const blockedExpectation = expect(blocked).rejects.toSatisfy(
+		(error: unknown) => {
+			expect(error).toBeInstanceOf(ExecuteTypecheckError)
+			expect((error as Error).message).toContain('queue budget')
+			return true
+		},
+	)
+	await vi.advanceTimersByTimeAsync(10_001)
+	await blockedExpectation
+
+	await expect(assertAdHocExecuteTypechecks(input)).resolves.toBeDefined()
+
+	compilerMock.resolveFirst()
+	await expect(cancelled).resolves.toBeDefined()
+	vi.useRealTimers()
+})

--- a/packages/worker/src/mcp/execute-typecheck-queue-recovery.node.test.ts
+++ b/packages/worker/src/mcp/execute-typecheck-queue-recovery.node.test.ts
@@ -85,7 +85,7 @@ test('cancelled typecheck holders cannot strand the queue or exhaust its slots',
 				return true
 			},
 		)
-		await vi.advanceTimersByTimeAsync(10_001)
+		await vi.advanceTimersByTimeAsync(12_001)
 		await blockedExpectation
 	}
 

--- a/packages/worker/src/mcp/execute-typecheck-queue-recovery.node.test.ts
+++ b/packages/worker/src/mcp/execute-typecheck-queue-recovery.node.test.ts
@@ -2,8 +2,9 @@ import { expect, test, vi } from 'vitest'
 import { type LoadedKodyGraphPackages } from '#worker/package-runtime/module-graph-import-rewriting.ts'
 
 const compilerMock = vi.hoisted(() => {
-	let resolveFirstService: ((service: unknown) => void) | undefined
+	const stalledServiceResolvers: Array<(service: unknown) => void> = []
 	let creationCount = 0
+	let stallNextCreation = true
 	const createService = () => {
 		const files = new Map<string, string>()
 		return {
@@ -27,15 +28,24 @@ const compilerMock = vi.hoisted(() => {
 	return {
 		createTypescriptLanguageService: vi.fn(() => {
 			creationCount += 1
-			if (creationCount === 1) {
+			if (stallNextCreation) {
+				stallNextCreation = false
 				return new Promise((resolve) => {
-					resolveFirstService = resolve
+					stalledServiceResolvers.push(resolve)
 				})
 			}
 			return Promise.resolve(createService())
 		}),
-		resolveFirst() {
-			resolveFirstService?.(createService())
+		stallNext() {
+			stallNextCreation = true
+		},
+		resolveStalled() {
+			for (const resolve of stalledServiceResolvers) {
+				resolve(createService())
+			}
+		},
+		getCreationCount() {
+			return creationCount
 		},
 	}
 })
@@ -49,37 +59,39 @@ import {
 	ExecuteTypecheckError,
 } from './execute-typecheck.ts'
 
-test('a cancelled typecheck holder cannot strand the isolate queue', async () => {
+test('cancelled typecheck holders cannot strand the queue or exhaust its slots', async () => {
 	vi.useFakeTimers()
 	const input = {
 		source: 'export default function main() { return "ok" }',
 		packages: new Map() as LoadedKodyGraphPackages,
 	}
+	const cancelledCalls: Array<Promise<unknown>> = []
 
-	const cancelled = assertAdHocExecuteTypechecks(input)
-	await vi.waitFor(() => {
-		expect(compilerMock.createTypescriptLanguageService).toHaveBeenCalledTimes(
-			1,
+	for (let cycle = 1; cycle <= 5; cycle += 1) {
+		if (cycle > 1) compilerMock.stallNext()
+		cancelledCalls.push(assertAdHocExecuteTypechecks(input))
+		await vi.waitFor(() => {
+			expect(compilerMock.getCreationCount()).toBe(cycle)
+		})
+		// Model workerd cancelling the request context: its timers and
+		// continuation disappear, while isolate module state survives.
+		vi.clearAllTimers()
+
+		const blocked = assertAdHocExecuteTypechecks(input)
+		const blockedExpectation = expect(blocked).rejects.toSatisfy(
+			(error: unknown) => {
+				expect(error).toBeInstanceOf(ExecuteTypecheckError)
+				expect((error as Error).message).toContain('queue budget')
+				return true
+			},
 		)
-	})
-	// Model workerd cancelling the request context: its timers and continuation
-	// disappear, while isolate module state survives for the next request.
-	vi.clearAllTimers()
-
-	const blocked = assertAdHocExecuteTypechecks(input)
-	const blockedExpectation = expect(blocked).rejects.toSatisfy(
-		(error: unknown) => {
-			expect(error).toBeInstanceOf(ExecuteTypecheckError)
-			expect((error as Error).message).toContain('queue budget')
-			return true
-		},
-	)
-	await vi.advanceTimersByTimeAsync(10_001)
-	await blockedExpectation
+		await vi.advanceTimersByTimeAsync(10_001)
+		await blockedExpectation
+	}
 
 	await expect(assertAdHocExecuteTypechecks(input)).resolves.toBeDefined()
 
-	compilerMock.resolveFirst()
-	await expect(cancelled).resolves.toBeDefined()
+	compilerMock.resolveStalled()
+	await expect(Promise.all(cancelledCalls)).resolves.toBeDefined()
 	vi.useRealTimers()
 })

--- a/packages/worker/src/mcp/execute-typecheck.ts
+++ b/packages/worker/src/mcp/execute-typecheck.ts
@@ -62,6 +62,9 @@ const maxExecuteTypecheckSourceBytes = 512 * 1024
 const maxExecuteTypecheckPackageFiles = 500
 const maxExecuteTypecheckPackageBytes = 5 * 1024 * 1024
 const maxPendingExecuteTypechecks = 4
+// Cold service creation fetches and extracts worker-bundler's TypeScript lib
+// declarations. Keep that bounded separately from the warm diagnostics hold.
+const maxExecuteTypecheckServiceStartupMs = 10_000
 const maxExecuteTypecheckHoldMs = 2_000
 
 class MemoryTypecheckFileSystem implements TypecheckFileSystem {
@@ -163,6 +166,17 @@ async function getReusableTypecheckService() {
 	}
 }
 
+function discardReusableTypecheckService() {
+	const staleServicePromise = reusableTypecheckServicePromise
+	reusableTypecheckServicePromise = null
+	if (staleServicePromise) {
+		void staleServicePromise.then(
+			(service) => service.languageService.dispose?.(),
+			() => undefined,
+		)
+	}
+}
+
 async function withTypecheckLock<T>(
 	phases: ExecuteTypecheckPhaseRecorder,
 	callback: (service: ReusableTypecheckService) => T,
@@ -178,14 +192,32 @@ async function withTypecheckLock<T>(
 	typecheckQueue = new Promise<void>((resolve) => {
 		release = resolve
 	})
-	await phases.measure('queue', async () => {
-		await previous
-	})
 	let timeoutId: ReturnType<typeof setTimeout> | null = null
+	let queueTimeoutId: ReturnType<typeof setTimeout> | null = null
 	let startupTimedOut = false
-	const servicePromise = getReusableTypecheckService()
-	const cachedServicePromise = reusableTypecheckServicePromise
 	try {
+		await phases.measure(
+			'queue',
+			async () =>
+				await Promise.race([
+					previous,
+					new Promise<never>((_resolve, reject) => {
+						queueTimeoutId = setTimeout(() => {
+							discardReusableTypecheckService()
+							reject(
+								new ExecuteTypecheckError([
+									`The pre-execution TypeScript checker exceeded its ${maxExecuteTypecheckServiceStartupMs}ms queue budget. Retry the execute call.`,
+								]),
+							)
+						}, maxExecuteTypecheckServiceStartupMs)
+					}),
+				]),
+		)
+		if (queueTimeoutId !== null) {
+			clearTimeout(queueTimeoutId)
+			queueTimeoutId = null
+		}
+		const servicePromise = getReusableTypecheckService()
 		const service = await phases.measure(
 			'compiler-startup',
 			async () =>
@@ -196,10 +228,10 @@ async function withTypecheckLock<T>(
 							startupTimedOut = true
 							reject(
 								new ExecuteTypecheckError([
-									`The pre-execution TypeScript checker exceeded its ${maxExecuteTypecheckHoldMs}ms service startup budget.`,
+									`The pre-execution TypeScript checker exceeded its ${maxExecuteTypecheckServiceStartupMs}ms service startup budget.`,
 								]),
 							)
-						}, maxExecuteTypecheckHoldMs)
+						}, maxExecuteTypecheckServiceStartupMs)
 					}),
 				]),
 		)
@@ -219,20 +251,11 @@ async function withTypecheckLock<T>(
 		}
 		return result
 	} catch (error) {
-		if (
-			startupTimedOut &&
-			cachedServicePromise &&
-			reusableTypecheckServicePromise === cachedServicePromise
-		) {
-			reusableTypecheckServicePromise = null
-			void cachedServicePromise.then(
-				(service) => service.languageService.dispose?.(),
-				() => undefined,
-			)
-		}
+		if (startupTimedOut) discardReusableTypecheckService()
 		throw error
 	} finally {
 		if (timeoutId !== null) clearTimeout(timeoutId)
+		if (queueTimeoutId !== null) clearTimeout(queueTimeoutId)
 		pendingTypecheckCount -= 1
 		release()
 	}

--- a/packages/worker/src/mcp/execute-typecheck.ts
+++ b/packages/worker/src/mcp/execute-typecheck.ts
@@ -47,6 +47,12 @@ type ReusableTypecheckService = {
 	}
 }
 
+type TypecheckGeneration = {
+	queue: Promise<void>
+	pendingCount: number
+	servicePromise: Promise<ReusableTypecheckService> | null
+}
+
 const entryPath = 'entry.ts'
 const tsconfigPath = 'tsconfig.json'
 const runtimeTypesPath = 'kody-runtime.d.ts'
@@ -132,11 +138,15 @@ function createRuntimeTypes() {
 }`
 }
 
-let reusableTypecheckServicePromise: Promise<ReusableTypecheckService> | null =
-	null
-let typecheckQueue = Promise.resolve()
-const pendingTypecheckRequestIds = new Set<number>()
-let nextTypecheckRequestId = 1
+function createTypecheckGeneration(): TypecheckGeneration {
+	return {
+		queue: Promise.resolve(),
+		pendingCount: 0,
+		servicePromise: null,
+	}
+}
+
+let currentTypecheckGeneration = createTypecheckGeneration()
 
 async function loadTypescriptLanguageService() {
 	// Keep the multi-megabyte compiler out of the default-off Worker's eager
@@ -147,8 +157,8 @@ async function loadTypescriptLanguageService() {
 	return createTypescriptLanguageService
 }
 
-async function getReusableTypecheckService() {
-	reusableTypecheckServicePromise ??= loadTypescriptLanguageService().then(
+async function getReusableTypecheckService(generation: TypecheckGeneration) {
+	generation.servicePromise ??= loadTypescriptLanguageService().then(
 		(createTypescriptLanguageService) =>
 			createTypescriptLanguageService({
 				fileSystem: new MemoryTypecheckFileSystem({
@@ -158,36 +168,31 @@ async function getReusableTypecheckService() {
 				}),
 			}) as Promise<ReusableTypecheckService>,
 	)
-	const servicePromise = reusableTypecheckServicePromise
+	const servicePromise = generation.servicePromise
 	try {
 		return await servicePromise
 	} catch (error) {
-		if (reusableTypecheckServicePromise === servicePromise) {
-			reusableTypecheckServicePromise = null
+		if (generation.servicePromise === servicePromise) {
+			generation.servicePromise = null
 		}
 		throw error
 	}
-}
-
-function invalidateReusableTypecheckService() {
-	reusableTypecheckServicePromise = null
 }
 
 async function withTypecheckLock<T>(
 	phases: ExecuteTypecheckPhaseRecorder,
 	callback: (service: ReusableTypecheckService) => T,
 ) {
-	if (pendingTypecheckRequestIds.size >= maxPendingExecuteTypechecks) {
+	const generation = currentTypecheckGeneration
+	if (generation.pendingCount >= maxPendingExecuteTypechecks) {
 		throw new ExecuteTypecheckError([
 			`The pre-execution TypeScript checker already has ${maxPendingExecuteTypechecks} active or queued requests. Retry after one finishes.`,
 		])
 	}
-	const requestId = nextTypecheckRequestId
-	nextTypecheckRequestId += 1
-	pendingTypecheckRequestIds.add(requestId)
-	const previous = typecheckQueue
+	generation.pendingCount += 1
+	const previous = generation.queue
 	let release: () => void = () => {}
-	typecheckQueue = new Promise<void>((resolve) => {
+	generation.queue = new Promise<void>((resolve) => {
 		release = resolve
 	})
 	let timeoutId: ReturnType<typeof setTimeout> | null = null
@@ -202,12 +207,9 @@ async function withTypecheckLock<T>(
 					previous,
 					new Promise<never>((_resolve, reject) => {
 						queueTimeoutId = setTimeout(() => {
-							for (const pendingRequestId of pendingTypecheckRequestIds) {
-								if (pendingRequestId < requestId) {
-									pendingTypecheckRequestIds.delete(pendingRequestId)
-								}
+							if (currentTypecheckGeneration === generation) {
+								currentTypecheckGeneration = createTypecheckGeneration()
 							}
-							invalidateReusableTypecheckService()
 							reject(
 								new ExecuteTypecheckError([
 									`The pre-execution TypeScript checker exceeded its ${maxExecuteTypecheckQueueWaitMs}ms queue budget. Retry the execute call.`,
@@ -217,12 +219,17 @@ async function withTypecheckLock<T>(
 					}),
 				]),
 		)
+		if (currentTypecheckGeneration !== generation) {
+			throw new ExecuteTypecheckError([
+				'The pre-execution TypeScript checker queue was reset after an earlier request stalled. Retry the execute call.',
+			])
+		}
 		if (queueTimeoutId !== null) {
 			clearTimeout(queueTimeoutId)
 			queueTimeoutId = null
 		}
-		const servicePromise = getReusableTypecheckService()
-		cachedServicePromise = reusableTypecheckServicePromise
+		const servicePromise = getReusableTypecheckService(generation)
+		cachedServicePromise = generation.servicePromise
 		const service = await phases.measure(
 			'compiler-startup',
 			async () =>
@@ -252,16 +259,16 @@ async function withTypecheckLock<T>(
 			// isolate. Do not turn a completed valid check into a false-positive
 			// failure; discard the slow service so the next request starts fresh.
 			service.languageService.dispose?.()
-			reusableTypecheckServicePromise = null
+			generation.servicePromise = null
 		}
 		return result
 	} catch (error) {
 		if (
 			startupTimedOut &&
 			cachedServicePromise &&
-			reusableTypecheckServicePromise === cachedServicePromise
+			generation.servicePromise === cachedServicePromise
 		) {
-			reusableTypecheckServicePromise = null
+			generation.servicePromise = null
 			void cachedServicePromise.then(
 				(service) => service.languageService.dispose?.(),
 				() => undefined,
@@ -271,7 +278,7 @@ async function withTypecheckLock<T>(
 	} finally {
 		if (timeoutId !== null) clearTimeout(timeoutId)
 		if (queueTimeoutId !== null) clearTimeout(queueTimeoutId)
-		pendingTypecheckRequestIds.delete(requestId)
+		generation.pendingCount -= 1
 		release()
 	}
 }

--- a/packages/worker/src/mcp/execute-typecheck.ts
+++ b/packages/worker/src/mcp/execute-typecheck.ts
@@ -133,7 +133,8 @@ function createRuntimeTypes() {
 let reusableTypecheckServicePromise: Promise<ReusableTypecheckService> | null =
 	null
 let typecheckQueue = Promise.resolve()
-let pendingTypecheckCount = 0
+const pendingTypecheckRequestIds = new Set<number>()
+let nextTypecheckRequestId = 1
 
 async function loadTypescriptLanguageService() {
 	// Keep the multi-megabyte compiler out of the default-off Worker's eager
@@ -167,26 +168,21 @@ async function getReusableTypecheckService() {
 }
 
 function discardReusableTypecheckService() {
-	const staleServicePromise = reusableTypecheckServicePromise
 	reusableTypecheckServicePromise = null
-	if (staleServicePromise) {
-		void staleServicePromise.then(
-			(service) => service.languageService.dispose?.(),
-			() => undefined,
-		)
-	}
 }
 
 async function withTypecheckLock<T>(
 	phases: ExecuteTypecheckPhaseRecorder,
 	callback: (service: ReusableTypecheckService) => T,
 ) {
-	if (pendingTypecheckCount >= maxPendingExecuteTypechecks) {
+	if (pendingTypecheckRequestIds.size >= maxPendingExecuteTypechecks) {
 		throw new ExecuteTypecheckError([
 			`The pre-execution TypeScript checker already has ${maxPendingExecuteTypechecks} active or queued requests. Retry after one finishes.`,
 		])
 	}
-	pendingTypecheckCount += 1
+	const requestId = nextTypecheckRequestId
+	nextTypecheckRequestId += 1
+	pendingTypecheckRequestIds.add(requestId)
 	const previous = typecheckQueue
 	let release: () => void = () => {}
 	typecheckQueue = new Promise<void>((resolve) => {
@@ -203,6 +199,11 @@ async function withTypecheckLock<T>(
 					previous,
 					new Promise<never>((_resolve, reject) => {
 						queueTimeoutId = setTimeout(() => {
+							for (const pendingRequestId of pendingTypecheckRequestIds) {
+								if (pendingRequestId < requestId) {
+									pendingTypecheckRequestIds.delete(pendingRequestId)
+								}
+							}
 							discardReusableTypecheckService()
 							reject(
 								new ExecuteTypecheckError([
@@ -256,7 +257,7 @@ async function withTypecheckLock<T>(
 	} finally {
 		if (timeoutId !== null) clearTimeout(timeoutId)
 		if (queueTimeoutId !== null) clearTimeout(queueTimeoutId)
-		pendingTypecheckCount -= 1
+		pendingTypecheckRequestIds.delete(requestId)
 		release()
 	}
 }

--- a/packages/worker/src/mcp/execute-typecheck.ts
+++ b/packages/worker/src/mcp/execute-typecheck.ts
@@ -66,6 +66,8 @@ const maxPendingExecuteTypechecks = 4
 // declarations. Keep that bounded separately from the warm diagnostics hold.
 const maxExecuteTypecheckServiceStartupMs = 10_000
 const maxExecuteTypecheckHoldMs = 2_000
+const maxExecuteTypecheckQueueWaitMs =
+	maxExecuteTypecheckServiceStartupMs + maxExecuteTypecheckHoldMs
 
 class MemoryTypecheckFileSystem implements TypecheckFileSystem {
 	readonly #files: Map<string, string>
@@ -167,7 +169,7 @@ async function getReusableTypecheckService() {
 	}
 }
 
-function discardReusableTypecheckService() {
+function invalidateReusableTypecheckService() {
 	reusableTypecheckServicePromise = null
 }
 
@@ -191,6 +193,7 @@ async function withTypecheckLock<T>(
 	let timeoutId: ReturnType<typeof setTimeout> | null = null
 	let queueTimeoutId: ReturnType<typeof setTimeout> | null = null
 	let startupTimedOut = false
+	let cachedServicePromise: Promise<ReusableTypecheckService> | null = null
 	try {
 		await phases.measure(
 			'queue',
@@ -204,13 +207,13 @@ async function withTypecheckLock<T>(
 									pendingTypecheckRequestIds.delete(pendingRequestId)
 								}
 							}
-							discardReusableTypecheckService()
+							invalidateReusableTypecheckService()
 							reject(
 								new ExecuteTypecheckError([
-									`The pre-execution TypeScript checker exceeded its ${maxExecuteTypecheckServiceStartupMs}ms queue budget. Retry the execute call.`,
+									`The pre-execution TypeScript checker exceeded its ${maxExecuteTypecheckQueueWaitMs}ms queue budget. Retry the execute call.`,
 								]),
 							)
-						}, maxExecuteTypecheckServiceStartupMs)
+						}, maxExecuteTypecheckQueueWaitMs)
 					}),
 				]),
 		)
@@ -219,6 +222,7 @@ async function withTypecheckLock<T>(
 			queueTimeoutId = null
 		}
 		const servicePromise = getReusableTypecheckService()
+		cachedServicePromise = reusableTypecheckServicePromise
 		const service = await phases.measure(
 			'compiler-startup',
 			async () =>
@@ -252,7 +256,17 @@ async function withTypecheckLock<T>(
 		}
 		return result
 	} catch (error) {
-		if (startupTimedOut) discardReusableTypecheckService()
+		if (
+			startupTimedOut &&
+			cachedServicePromise &&
+			reusableTypecheckServicePromise === cachedServicePromise
+		) {
+			reusableTypecheckServicePromise = null
+			void cachedServicePromise.then(
+				(service) => service.languageService.dispose?.(),
+				() => undefined,
+			)
+		}
 		throw error
 	} finally {
 		if (timeoutId !== null) clearTimeout(timeoutId)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1037
Part of #1069

## Summary
- give cold TypeScript service startup its own 10s budget instead of the 2s warm-diagnostics budget
- rotate stalled FIFO queues after 12s so future calls use a fresh queue and compiler generation
- keep late predecessors isolated on their old compiler generation and abort stale queued followers, preventing concurrent mutation of one language service
- cover nested ToolDispatcher execution with a static `kody:@…` import and repeated cancellation recovery

## Validation
- `npm run validate`
- focused Workers regression verifies invalid static imports are rejected and valid nested imports reach the sandbox
- focused node regression simulates repeated cancelled lock holders and verifies new generations recover without exhausting capacity

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `bb9491e` · **Head:** `171399b`

**Classification:** extends — changes pre-execution typecheck startup and cancellation recovery behavior without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — nested execute typechecks complete or fail within bounded startup/queue budgets |
| `capabilities-execute` | runtime | extends — stalled FIFO recovery rotates to isolated compiler generations |

### System map

Nested MCP capability calls enter the execute runtime; bounded preflight checking now rotates stalled work away from future calls without allowing old and new requests to share mutable compiler state.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	runRecords["run-records<br/>Run records"]:::untouched
	mcpServer -->|"nested kody.execute RPC"| capabilitiesExecute
	capabilitiesExecute -->|"terminal error before stale-row backstop"| runRecords
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Per-user package graph loading remains scoped by the existing caller `userId`.
- The feature flag remains intact; its global/default state is unchanged by this PR.

</details>

<!-- system-recap:end -->

## Conductor report

**Status:** done

**Verified:** On current main, the real Workers ToolDispatcher path loaded the static package graph but cold compiler construction took about 3.2–3.5s and failed under the old shared 2s startup budget before reaching the sandbox. Cancellation simulations reproduced the indefinitely blocked module FIFO and leaked capacity. After the fix, invalid nested source returns type diagnostics, valid nested source reaches the sandbox, repeated cancelled holders rotate future work to isolated compiler generations without exhausting capacity or sharing mutable compiler state, and `npm run validate` passes. Existing #1039 coverage remains the run-record backstop: stale execute rows reconcile to `Interrupted` after three minutes, while this path now terminates or recovers within twelve seconds.

**Scope spill:** none. The feature flag was not removed or collapsed. Kent has decided it stays, and re-enabled it for his user; a production run stranded at approximately 19:00 UTC before this fix landed, confirming live impact. #1050 is consistent with the same root cause: cold TypeScript tarball download/extraction can exceed the former 2s budget on slower CI runners.

**Decision:** keep `execute-pre-exec-typecheck`; fix only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-609e7cae-d379-4903-9a2c-04381be154b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-609e7cae-d379-4903-9a2c-04381be154b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when typechecking nested executions with statically imported modules.
  * Prevented cancelled typecheck requests from blocking subsequent typecheck operations.
  * Added separate safeguards for queue delays and compiler service startup, with automatic recovery when limits are exceeded.
* **Tests**
  * Added coverage for nested execution type validation, cancellation recovery, timeout handling, and continued typecheck availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->