### PR TITLE
Bound package-storage audit work and add keyset pagination

### DIFF
--- a/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
@@ -49,10 +49,15 @@ function createAdminActor(roles: Array<RoleName>) {
 const { createAdminPackageStorageAuditApiHandler } =
 	await import('./admin-package-storage-audit.ts')
 
-function createHandlerRequest(input: { limit?: number } = {}) {
+function createHandlerRequest(
+	input: { limit?: number; startAfter?: string } = {},
+) {
 	const url = new URL('https://example.com/admin/package-storage-audit.json')
 	if (input.limit !== undefined) {
 		url.searchParams.set('limit', String(input.limit))
+	}
+	if (input.startAfter !== undefined) {
+		url.searchParams.set('startAfter', input.startAfter)
 	}
 	return {
 		request: new Request(url, {
@@ -71,6 +76,7 @@ test('admin package storage audit route requires admin and returns the report JS
 		ok: true as const,
 		packages: [],
 		orphanAppBuckets: [],
+		nextStartAfter: null,
 		totals: {
 			appPackages: 0,
 			nonEmptyLegacyBuckets: 0,
@@ -98,13 +104,17 @@ test('admin package storage audit route requires admin and returns the report JS
 	)
 	mockModule.buildPackageStorageAuditReport.mockResolvedValue(report)
 
-	const response = await handler.handler(createHandlerRequest({ limit: 50 }))
+	const cursor = JSON.stringify({ userId: 'user-a', packageId: 'pkg-1' })
+	const response = await handler.handler(
+		createHandlerRequest({ limit: 50, startAfter: cursor }),
+	)
 	expect(response.status).toBe(200)
 	await expect(response.json()).resolves.toEqual(report)
 	expect(mockModule.buildPackageStorageAuditReport).toHaveBeenCalledWith({
 		env,
 		baseUrl: 'https://example.com',
 		limit: 50,
+		startAfter: cursor,
 	})
 })
 
@@ -118,6 +128,7 @@ test('admin package storage audit route clamps limit and applies the default', a
 		ok: true,
 		packages: [],
 		orphanAppBuckets: [],
+		nextStartAfter: null,
 		totals: {
 			appPackages: 0,
 			nonEmptyLegacyBuckets: 0,
@@ -130,11 +141,11 @@ test('admin package storage audit route clamps limit and applies the default', a
 
 	await handler.handler(createHandlerRequest({ limit: 9999 }))
 	expect(mockModule.buildPackageStorageAuditReport).toHaveBeenLastCalledWith(
-		expect.objectContaining({ limit: 500 }),
+		expect.objectContaining({ limit: 500, startAfter: null }),
 	)
 
 	await handler.handler(createHandlerRequest())
 	expect(mockModule.buildPackageStorageAuditReport).toHaveBeenLastCalledWith(
-		expect.objectContaining({ limit: 200 }),
+		expect.objectContaining({ limit: 200, startAfter: null }),
 	)
 })

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.ts
@@ -5,6 +5,7 @@ import { jsonResponse } from '#worker/json-response.ts'
 import {
 	buildPackageStorageAuditReport,
 	defaultPackageStorageAuditLimit,
+	InvalidStartAfterCursorError,
 	maxPackageStorageAuditLimit,
 } from '#worker/package-storage-audit/service.ts'
 import { readPositiveInt } from '#worker/query-params.ts'
@@ -33,6 +34,9 @@ export function createAdminPackageStorageAuditApiHandler(env: Env) {
 				return jsonResponse(report)
 			} catch (error) {
 				if (error instanceof Response) return error
+				if (error instanceof InvalidStartAfterCursorError) {
+					return jsonResponse({ ok: false, error: error.message }, 400)
+				}
 				throw error
 			}
 		},

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.ts
@@ -23,10 +23,12 @@ export function createAdminPackageStorageAuditApiHandler(env: Env) {
 					defaultPackageStorageAuditLimit,
 					maxPackageStorageAuditLimit,
 				)
+				const startAfter = url.searchParams.get('startAfter')
 				const report = await buildPackageStorageAuditReport({
 					env,
 					baseUrl: url.origin,
 					limit,
+					startAfter,
 				})
 				return jsonResponse(report)
 			} catch (error) {

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.node.test.ts
@@ -37,6 +37,7 @@ const emptyReport = {
 	ok: true as const,
 	packages: [],
 	orphanAppBuckets: [],
+	nextStartAfter: null as string | null,
 	totals: {
 		appPackages: 0,
 		nonEmptyLegacyBuckets: 0,
@@ -61,6 +62,10 @@ test('admin package storage audit requires admin and returns the platform-wide r
 		}),
 	)
 
+	const nextStartAfter = JSON.stringify({
+		userId: 'user-a',
+		packageId: 'pkg-1',
+	})
 	mocks.buildPackageStorageAuditReport.mockResolvedValue({
 		...emptyReport,
 		packages: [
@@ -74,17 +79,20 @@ test('admin package storage audit requires admin and returns the platform-wide r
 				sourceScanError: null,
 			},
 		],
+		nextStartAfter,
 		totals: {
 			...emptyReport.totals,
 			appPackages: 1,
 			nonEmptyLegacyBuckets: 1,
 			packagesWithAmbientImports: 1,
+			truncated: true,
 		},
 	})
 
 	const ctx = createContext(['admin'])
+	const cursor = JSON.stringify({ userId: 'user-a', packageId: 'pkg-0' })
 	const result = await adminPackageStorageAuditCapability.handler(
-		{ limit: 25 },
+		{ limit: 25, start_after: cursor },
 		ctx,
 	)
 
@@ -92,9 +100,11 @@ test('admin package storage audit requires admin and returns the platform-wide r
 		env: ctx.env,
 		baseUrl: 'https://heykody.dev',
 		limit: 25,
+		startAfter: cursor,
 	})
 	expect(result).toMatchObject({
 		ok: true,
+		nextStartAfter,
 		packages: [
 			expect.objectContaining({
 				packageId: 'pkg-1',
@@ -105,6 +115,7 @@ test('admin package storage audit requires admin and returns the platform-wide r
 			appPackages: 1,
 			nonEmptyLegacyBuckets: 1,
 			packagesWithAmbientImports: 1,
+			truncated: true,
 		},
 	})
 	expect(auditEventSummaries()).toEqual([
@@ -119,7 +130,7 @@ test('admin package storage audit defaults limit and rejects values above max', 
 
 	await adminPackageStorageAuditCapability.handler({}, ctx)
 	expect(mocks.buildPackageStorageAuditReport).toHaveBeenLastCalledWith(
-		expect.objectContaining({ limit: 200 }),
+		expect.objectContaining({ limit: 200, startAfter: undefined }),
 	)
 
 	await expect(

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.ts
@@ -2,8 +2,10 @@ import { z } from 'zod'
 import {
 	buildPackageStorageAuditReport,
 	defaultPackageStorageAuditLimit,
+	InvalidStartAfterCursorError,
 	maxPackageStorageAuditLimit,
 } from '#worker/package-storage-audit/service.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
@@ -86,13 +88,21 @@ export const adminPackageStorageAuditCapability = defineDomainCapability(
 			return auditAdminCapabilityInvocation(
 				ctx,
 				'admin_package_storage_audit',
-				async () =>
-					buildPackageStorageAuditReport({
-						env: ctx.env,
-						baseUrl: ctx.callerContext.baseUrl,
-						limit: args.limit ?? defaultPackageStorageAuditLimit,
-						startAfter: args.start_after,
-					}),
+				async () => {
+					try {
+						return await buildPackageStorageAuditReport({
+							env: ctx.env,
+							baseUrl: ctx.callerContext.baseUrl,
+							limit: args.limit ?? defaultPackageStorageAuditLimit,
+							startAfter: args.start_after,
+						})
+					} catch (error) {
+						if (error instanceof InvalidStartAfterCursorError) {
+							throw new McpCallerError(error.message)
+						}
+						throw error
+					}
+				},
 			)
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.ts
@@ -31,6 +31,12 @@ const outputSchema = z.object({
 	ok: z.literal(true),
 	packages: z.array(packageRowSchema),
 	orphanAppBuckets: z.array(orphanBucketSchema),
+	nextStartAfter: z
+		.string()
+		.nullable()
+		.describe(
+			'Opaque keyset cursor for the next page when truncated; null when complete.',
+		),
 	totals: z.object({
 		appPackages: z.number().int().nonnegative(),
 		nonEmptyLegacyBuckets: z.number().int().nonnegative(),
@@ -47,7 +53,7 @@ export const adminPackageStorageAuditCapability = defineDomainCapability(
 		...adminCapabilityAccess,
 		name: 'admin_package_storage_audit',
 		description:
-			'Platform-wide audit of has_app package legacy StorageRunner bucket sizes, ambient storage imports in published sources, and orphaned kind=app buckets. Admin-only and not user-scoped; returns aggregated metadata only, never raw bucket contents or full package source.',
+			'Platform-wide audit of has_app package legacy StorageRunner bucket sizes, ambient storage imports in published sources, and orphaned kind=app buckets. Admin-only and not user-scoped; returns aggregated metadata only, never raw bucket contents or full package source. Page with limit + start_after / nextStartAfter.',
 		keywords: [
 			'admin',
 			'package',
@@ -67,6 +73,13 @@ export const adminPackageStorageAuditCapability = defineDomainCapability(
 				.describe(
 					`Max has_app packages to audit. Defaults to ${String(defaultPackageStorageAuditLimit)} and maxes at ${String(maxPackageStorageAuditLimit)}.`,
 				),
+			start_after: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					'Opaque keyset cursor from a prior nextStartAfter; resumes after that package.',
+				),
 		}),
 		outputSchema,
 		async handler(args, ctx) {
@@ -78,6 +91,7 @@ export const adminPackageStorageAuditCapability = defineDomainCapability(
 						env: ctx.env,
 						baseUrl: ctx.callerContext.baseUrl,
 						limit: args.limit ?? defaultPackageStorageAuditLimit,
+						startAfter: args.start_after,
 					}),
 			)
 		},

--- a/packages/worker/src/package-storage-audit/service.node.test.ts
+++ b/packages/worker/src/package-storage-audit/service.node.test.ts
@@ -39,6 +39,15 @@ function packageOwnershipKey(userId: string, packageId: string) {
 	return `${userId}\0${packageId}`
 }
 
+function comparePackageKeys(
+	left: { userId: string; packageId: string },
+	right: { userId: string; packageId: string },
+) {
+	const byUser = left.userId.localeCompare(right.userId)
+	if (byUser !== 0) return byUser
+	return left.packageId.localeCompare(right.packageId)
+}
+
 function createAuditTestEnv(input: {
 	packages: Array<SavedPackageRow>
 	buckets: Array<StorageBucketRow>
@@ -61,14 +70,22 @@ function createAuditTestEnv(input: {
 					normalized.includes('from saved_packages') &&
 					normalized.includes('has_app = 1')
 				) {
-					const limit = Number(params[0] ?? input.packages.length)
+					const hasKeyset = normalized.includes('user_id > ?')
+					const limit = Number(
+						params[hasKeyset ? 3 : 0] ?? input.packages.length,
+					)
+					const startAfter = hasKeyset
+						? {
+								userId: String(params[0]),
+								packageId: String(params[2]),
+							}
+						: null
 					const rows = input.packages
 						.filter((row) => row.hasApp === 1)
-						.sort((left, right) => {
-							const byUser = left.userId.localeCompare(right.userId)
-							if (byUser !== 0) return byUser
-							return left.packageId.localeCompare(right.packageId)
-						})
+						.filter((row) =>
+							startAfter ? comparePackageKeys(row, startAfter) > 0 : true,
+						)
+						.sort(comparePackageKeys)
 						.slice(0, limit)
 						.map((row) => ({
 							userId: row.userId,
@@ -140,6 +157,10 @@ function stubEstimate(bytes: number | Error) {
 			return { estimatedBytes: bytes }
 		},
 	}
+}
+
+function neverResolves<T>(): Promise<T> {
+	return new Promise(() => {})
 }
 
 test('package storage audit report probes legacy buckets, ambient imports, and orphans', async () => {
@@ -264,6 +285,7 @@ test('package storage audit report probes legacy buckets, ambient imports, and o
 	})
 	expect(body).toMatchObject({
 		ok: true,
+		nextStartAfter: null,
 		totals: {
 			appPackages: 5,
 			nonEmptyLegacyBuckets: 1,
@@ -328,7 +350,7 @@ test('package storage audit report probes legacy buckets, ambient imports, and o
 	}
 })
 
-test('package storage audit report supports limit truncation', async () => {
+test('package storage audit report supports limit truncation and keyset paging', async () => {
 	const packages = Array.from({ length: 4 }, (_, index) => ({
 		userId: 'user-a',
 		packageId: `pkg-${String(index)}`,
@@ -342,15 +364,18 @@ test('package storage audit report supports limit truncation', async () => {
 		files: { 'index.ts': 'export const ok = true\n' },
 	})
 
-	await expect(
-		buildPackageStorageAuditReport({
-			env,
-			baseUrl: 'https://example.com',
-			limit: 2,
-		}),
-	).resolves.toMatchObject({
+	const page1 = await buildPackageStorageAuditReport({
+		env,
+		baseUrl: 'https://example.com',
+		limit: 2,
+	})
+	expect(page1).toMatchObject({
 		ok: true,
 		packages: [{ packageId: 'pkg-0' }, { packageId: 'pkg-1' }],
+		nextStartAfter: JSON.stringify({
+			userId: 'user-a',
+			packageId: 'pkg-1',
+		}),
 		totals: {
 			appPackages: 2,
 			nonEmptyLegacyBuckets: 0,
@@ -359,5 +384,83 @@ test('package storage audit report supports limit truncation', async () => {
 			truncated: true,
 			orphanTruncated: false,
 		},
+	})
+
+	const page2 = await buildPackageStorageAuditReport({
+		env,
+		baseUrl: 'https://example.com',
+		limit: 2,
+		startAfter: page1.nextStartAfter,
+	})
+	expect(page2).toMatchObject({
+		ok: true,
+		packages: [{ packageId: 'pkg-2' }, { packageId: 'pkg-3' }],
+		nextStartAfter: null,
+		totals: {
+			appPackages: 2,
+			truncated: false,
+		},
+	})
+})
+
+test('package storage audit deadlines hanging probes and source scans', async () => {
+	const packages: Array<SavedPackageRow> = [
+		{
+			userId: 'user-a',
+			packageId: 'pkg-hang-probe',
+			kodyId: 'hang-probe',
+			sourceId: 'source-ok',
+			hasApp: 1,
+		},
+		{
+			userId: 'user-a',
+			packageId: 'pkg-hang-scan',
+			kodyId: 'hang-scan',
+			sourceId: 'source-hang',
+			hasApp: 1,
+		},
+	]
+	const env = createAuditTestEnv({ packages, buckets: [] })
+	mockModule.storageRunnerRpc.mockImplementation(
+		(input: { storageId: string }) => {
+			if (input.storageId === 'pkg-hang-probe') {
+				return { getEstimatedBytes: () => neverResolves() }
+			}
+			return stubEstimate(4096)
+		},
+	)
+	mockModule.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => {
+			if (input.sourceId === 'source-hang') return neverResolves()
+			return {
+				files: { 'index.ts': 'export const ok = true\n' },
+			}
+		},
+	)
+
+	const report = await buildPackageStorageAuditReport({
+		env,
+		baseUrl: 'https://example.com',
+		limit: 10,
+		budgets: {
+			legacyBucketProbeMs: 20,
+			sourceScanMs: 20,
+		},
+	})
+
+	expect(report.packages).toHaveLength(2)
+	expect(report.nextStartAfter).toBeNull()
+	const byId = new Map(report.packages.map((row) => [row.packageId, row]))
+	expect(byId.get('pkg-hang-probe')).toMatchObject({
+		legacyBucketBytes: null,
+		legacyBucketProbeError: 'timed out after 20ms',
+		ambientStorageImportFiles: [],
+		sourceScanError: null,
+	})
+	expect(byId.get('pkg-hang-scan')).toMatchObject({
+		legacyBucketBytes: 4096,
+		legacyBucketProbeError: null,
+		ambientStorageImportFiles: [],
+		sourceScanError: 'timed out after 20ms',
 	})
 })

--- a/packages/worker/src/package-storage-audit/service.ts
+++ b/packages/worker/src/package-storage-audit/service.ts
@@ -9,6 +9,8 @@ import {
 
 export const defaultPackageStorageAuditLimit = 200
 export const maxPackageStorageAuditLimit = 500
+export const defaultLegacyBucketProbeTimeoutMs = 10_000
+export const defaultSourceScanTimeoutMs = 20_000
 const maxOrphanAppBuckets = 500
 const maxConcurrentPackageAuditProbes = 5
 
@@ -32,6 +34,7 @@ export type PackageStorageAuditReport = {
 	ok: true
 	packages: Array<PackageStorageAuditPackageRow>
 	orphanAppBuckets: Array<PackageStorageAuditOrphanBucket>
+	nextStartAfter: string | null
 	totals: {
 		appPackages: number
 		nonEmptyLegacyBuckets: number
@@ -42,6 +45,11 @@ export type PackageStorageAuditReport = {
 	}
 }
 
+export type PackageStorageAuditBudgets = {
+	legacyBucketProbeMs?: number
+	sourceScanMs?: number
+}
+
 type AppPackageRow = {
 	userId: string
 	packageId: string
@@ -49,15 +57,30 @@ type AppPackageRow = {
 	sourceId: string
 }
 
+type PackageStorageAuditCursor = {
+	userId: string
+	packageId: string
+}
+
+type ResolvedBudgets = {
+	legacyBucketProbeMs: number
+	sourceScanMs: number
+}
+
 export async function buildPackageStorageAuditReport(input: {
 	env: Env
 	baseUrl: string
 	limit: number
+	startAfter?: string | null
+	budgets?: PackageStorageAuditBudgets
 }): Promise<PackageStorageAuditReport> {
+	const cursor = parseStartAfterCursor(input.startAfter)
+	const budgets = resolveBudgets(input.budgets)
 	const [appPackagePage, orphanPage] = await Promise.all([
 		listAppPackagesForAudit({
 			db: input.env.APP_DB,
 			limit: input.limit,
+			startAfter: cursor,
 		}),
 		listOrphanAppBuckets({ db: input.env.APP_DB }),
 	])
@@ -73,16 +96,25 @@ export async function buildPackageStorageAuditReport(input: {
 					env: input.env,
 					baseUrl: input.baseUrl,
 					row,
+					budgets,
 				}),
 			),
 		)
 		packages.push(...chunkRows)
 	}
 
+	const lastRow = packages.at(-1)
 	return {
 		ok: true,
 		packages,
 		orphanAppBuckets: orphanPage.rows,
+		nextStartAfter:
+			appPackagePage.truncated && lastRow
+				? encodeStartAfterCursor({
+						userId: lastRow.userId,
+						packageId: lastRow.packageId,
+					})
+				: null,
 		totals: {
 			appPackages: packages.length,
 			nonEmptyLegacyBuckets: packages.filter(
@@ -100,21 +132,109 @@ export async function buildPackageStorageAuditReport(input: {
 	}
 }
 
+function resolveBudgets(
+	budgets: PackageStorageAuditBudgets | undefined,
+): ResolvedBudgets {
+	return {
+		legacyBucketProbeMs:
+			budgets?.legacyBucketProbeMs ?? defaultLegacyBucketProbeTimeoutMs,
+		sourceScanMs: budgets?.sourceScanMs ?? defaultSourceScanTimeoutMs,
+	}
+}
+
+function encodeStartAfterCursor(cursor: PackageStorageAuditCursor) {
+	return JSON.stringify({
+		userId: cursor.userId,
+		packageId: cursor.packageId,
+	})
+}
+
+function parseStartAfterCursor(
+	startAfter: string | null | undefined,
+): PackageStorageAuditCursor | null {
+	if (startAfter == null) return null
+	const trimmed = startAfter.trim()
+	if (trimmed.length === 0) return null
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(trimmed)
+	} catch {
+		throw new Error('Invalid startAfter cursor: expected JSON object.')
+	}
+	if (
+		!parsed ||
+		typeof parsed !== 'object' ||
+		Array.isArray(parsed) ||
+		typeof (parsed as { userId?: unknown }).userId !== 'string' ||
+		typeof (parsed as { packageId?: unknown }).packageId !== 'string' ||
+		(parsed as { userId: string }).userId.length === 0 ||
+		(parsed as { packageId: string }).packageId.length === 0
+	) {
+		throw new Error(
+			'Invalid startAfter cursor: expected { userId, packageId } strings.',
+		)
+	}
+	return {
+		userId: (parsed as { userId: string }).userId,
+		packageId: (parsed as { packageId: string }).packageId,
+	}
+}
+
+async function withDeadline<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+): Promise<T> {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timeoutId = setTimeout(() => {
+					reject(new Error(`timed out after ${String(timeoutMs)}ms`))
+				}, timeoutMs)
+			}),
+		])
+	} finally {
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId)
+		}
+	}
+}
+
 async function listAppPackagesForAudit(input: {
 	db: D1Database
 	limit: number
+	startAfter: PackageStorageAuditCursor | null
 }): Promise<{ rows: Array<AppPackageRow>; truncated: boolean }> {
-	const result = await input.db
-		.prepare(
-			`SELECT user_id AS userId, id AS packageId, kody_id AS kodyId,
-				source_id AS sourceId
-			FROM saved_packages
-			WHERE has_app = 1
-			ORDER BY user_id ASC, id ASC
-			LIMIT ?`,
-		)
-		.bind(input.limit + 1)
-		.all<AppPackageRow>()
+	const result = input.startAfter
+		? await input.db
+				.prepare(
+					`SELECT user_id AS userId, id AS packageId, kody_id AS kodyId,
+						source_id AS sourceId
+					FROM saved_packages
+					WHERE has_app = 1
+						AND (user_id > ? OR (user_id = ? AND id > ?))
+					ORDER BY user_id ASC, id ASC
+					LIMIT ?`,
+				)
+				.bind(
+					input.startAfter.userId,
+					input.startAfter.userId,
+					input.startAfter.packageId,
+					input.limit + 1,
+				)
+				.all<AppPackageRow>()
+		: await input.db
+				.prepare(
+					`SELECT user_id AS userId, id AS packageId, kody_id AS kodyId,
+						source_id AS sourceId
+					FROM saved_packages
+					WHERE has_app = 1
+					ORDER BY user_id ASC, id ASC
+					LIMIT ?`,
+				)
+				.bind(input.limit + 1)
+				.all<AppPackageRow>()
 	const rows = result.results ?? []
 	const truncated = rows.length > input.limit
 	return {
@@ -152,18 +272,21 @@ async function auditAppPackage(input: {
 	env: Env
 	baseUrl: string
 	row: AppPackageRow
+	budgets: ResolvedBudgets
 }): Promise<PackageStorageAuditPackageRow> {
 	const [legacyProbe, sourceScan] = await Promise.all([
 		probeLegacyBucketBytes({
 			env: input.env,
 			userId: input.row.userId,
 			packageId: input.row.packageId,
+			timeoutMs: input.budgets.legacyBucketProbeMs,
 		}),
 		scanAmbientStorageImports({
 			env: input.env,
 			baseUrl: input.baseUrl,
 			userId: input.row.userId,
 			sourceId: input.row.sourceId,
+			timeoutMs: input.budgets.sourceScanMs,
 		}),
 	])
 
@@ -182,13 +305,17 @@ async function probeLegacyBucketBytes(input: {
 	env: Env
 	userId: string
 	packageId: string
+	timeoutMs: number
 }): Promise<{ bytes: number | null; error: string | null }> {
 	try {
-		const estimate = await storageRunnerRpc({
-			env: input.env,
-			userId: input.userId,
-			storageId: input.packageId,
-		}).getEstimatedBytes()
+		const estimate = await withDeadline(
+			storageRunnerRpc({
+				env: input.env,
+				userId: input.userId,
+				storageId: input.packageId,
+			}).getEstimatedBytes(),
+			input.timeoutMs,
+		)
 		return { bytes: estimate.estimatedBytes, error: null }
 	} catch (error) {
 		return { bytes: null, error: getErrorMessage(error) }
@@ -200,14 +327,18 @@ async function scanAmbientStorageImports(input: {
 	baseUrl: string
 	userId: string
 	sourceId: string
+	timeoutMs: number
 }): Promise<{ files: Array<string>; error: string | null }> {
 	try {
-		const loaded = await loadPackageSourceBySourceId({
-			env: input.env,
-			baseUrl: input.baseUrl,
-			userId: input.userId,
-			sourceId: input.sourceId,
-		})
+		const loaded = await withDeadline(
+			loadPackageSourceBySourceId({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: input.sourceId,
+			}),
+			input.timeoutMs,
+		)
 		return {
 			files: collectAmbientStorageImportFiles(loaded.files),
 			error: null,

--- a/packages/worker/src/package-storage-audit/service.ts
+++ b/packages/worker/src/package-storage-audit/service.ts
@@ -149,6 +149,8 @@ function encodeStartAfterCursor(cursor: PackageStorageAuditCursor) {
 	})
 }
 
+export class InvalidStartAfterCursorError extends Error {}
+
 function parseStartAfterCursor(
 	startAfter: string | null | undefined,
 ): PackageStorageAuditCursor | null {
@@ -159,7 +161,9 @@ function parseStartAfterCursor(
 	try {
 		parsed = JSON.parse(trimmed)
 	} catch {
-		throw new Error('Invalid startAfter cursor: expected JSON object.')
+		throw new InvalidStartAfterCursorError(
+			'Invalid startAfter cursor: expected JSON object.',
+		)
 	}
 	if (
 		!parsed ||
@@ -170,7 +174,7 @@ function parseStartAfterCursor(
 		(parsed as { userId: string }).userId.length === 0 ||
 		(parsed as { packageId: string }).packageId.length === 0
 	) {
-		throw new Error(
+		throw new InvalidStartAfterCursorError(
 			'Invalid startAfter cursor: expected { userId, packageId } strings.',
 		)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production hardening for the audit shipped in #1032: on prod the audit never completed — even `limit: 8` hit the 180s stale-run TTL. Root cause: per-package work had no deadline; `loadPackageSourceBySourceId` can hang on Artifacts fetches, a hanging promise never trips the per-package try/catch, and the chunk's `Promise.all` wedged forever.

- **Deadlines**: the legacy-bucket probe (10s) and source scan (20s) now race a timeout and record a `timed out after Nms` error row instead of blocking; the report always completes. The losing promise keeps running in the background (uncancellable fetch) — the report just stops waiting for it.
- **Keyset pagination**: optional opaque `startAfter` cursor (`{userId, packageId}` JSON) over the `(user_id, id)` ordering, `nextStartAfter` returned when truncated — threaded through the admin route (`?startAfter=`) and the MCP capability (`start_after`), so large installs are walkable in small reliable slices.

## Testing

- `npm run validate` intent: full loop runs in CI (this repo's CI mirrors it); targeted suites green locally: service (hanging probe/scan completes with timeout error rows; two-page cursor walk), route param passthrough, capability schema
- `npm run typecheck` green

Refs #1024

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `bb9491ed` · **Head:** `726b849d`

**Classification:** composes — deadline/pagination hardening inside the existing audit service and its two thin surfaces. No schema changes, no new primitives.

### Primitives touched

| Primitive             | Group     | Impact                                                        |
| --------------------- | --------- | -------------------------------------------------------------- |
| `capability-registry` | assistant | composes — `start_after`/`nextStartAfter` on the audit capability |
| `app-ui` / admin      | surfaces  | composes — `?startAfter=` passthrough on the audit route        |
| `saved-packages`      | assistant | composes — keyset cursor on the audit's `saved_packages` query  |

### Invariants

Read-only audit stays admin-gated on both surfaces; per-user DO probing unchanged. Deadlines only shorten how long the report waits — they add no new access.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f40b943c-e067-43a8-b171-94721f7e81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f40b943c-e067-43a8-b171-94721f7e81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination to the admin package storage audit.
  * Audit results now provide a cursor for retrieving the next page.
  * Added configurable time limits for package storage checks.

* **Bug Fixes**
  * Prevented slow or unresponsive storage checks from delaying the full audit report; timed-out checks are reported as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->