### PR TITLE
Loosen ad hoc execute TypeScript precheck for lazy agent code

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -101,12 +101,16 @@ use the same caller-scoped flag; saved-package exports, jobs, workflows, and
 services are not changed by this flag.
 
 When enabled, type errors are returned through the normal execute error result
-before the module's default export runs. Use those diagnostics to correct the
-module and retry. If a module unexpectedly stops before execution during the
-rollout, compare the reported TypeScript diagnostics with the same module for a
-caller whose flag is off. Operators can disable the user's override (or the
-global flag, if a broader rollout was started) to return immediately to the
-previous bundle-and-run behavior.
+before the module's default export runs. The checker is intentionally
+**non-strict**: untyped parameters, property access on `input = {}`, and other
+lazy TypeScript patterns are allowed so agents can iterate quickly. It still
+reports real assignability and property mismatches against published `kody:@…`
+package contracts (wrong argument or result types). Use those diagnostics to
+correct the module and retry. If a module unexpectedly stops before execution
+during the rollout, compare the reported TypeScript diagnostics with the same
+module for a caller whose flag is off. Operators can disable the user's override
+(or the global flag, if a broader rollout was started) to return immediately to
+the previous bundle-and-run behavior.
 
 ### Server-Timing phases
 

--- a/packages/worker/src/mcp/execute-typecheck.node.test.ts
+++ b/packages/worker/src/mcp/execute-typecheck.node.test.ts
@@ -221,6 +221,36 @@ export default async function run() {
 	])
 })
 
+test('ad hoc execute typecheck allows lazy untyped agent TypeScript', async () => {
+	await expect(
+		assertAdHocExecuteTypechecks({
+			source: `export default async function run(input = {}) {
+	const byId = {}
+	const rows = input.messages || []
+	return rows.map((msg, name) => {
+		const headers = (msg.headers || []).map((h) => h)
+		byId[msg.id] = { name, headers }
+		return byId[msg.id]
+	})
+}`,
+			packages: new Map() as LoadedKodyGraphPackages,
+		}),
+	).resolves.toBeDefined()
+
+	// Property errors on real package contracts must still fail.
+	await expect(
+		assertAdHocExecuteTypechecks({
+			source: `import type { StaticInput } from 'kody:@kentcdodds/static-contract'
+
+export default async function run() {
+	const input: StaticInput = { name: 'Ada' }
+	return input.missingField
+}`,
+			packages: createLoadedPackages(stringContract),
+		}),
+	).rejects.toThrow(/Property 'missingField' does not exist/)
+})
+
 test('warm typecheck service replaces package sources between requests', async () => {
 	await expect(
 		assertAdHocExecuteTypechecks({

--- a/packages/worker/src/mcp/execute-typecheck.ts
+++ b/packages/worker/src/mcp/execute-typecheck.ts
@@ -94,13 +94,17 @@ class MemoryTypecheckFileSystem implements TypecheckFileSystem {
 }
 
 function createTypecheckTsconfig() {
+	// Ad hoc execute modules are usually agent-authored one-offs. Keep contract
+	// assignability checks (wrong args/results against published package types)
+	// without failing on lazy patterns like untyped parameters or implicit any.
 	return JSON.stringify({
 		compilerOptions: {
 			allowJs: true,
 			allowImportingTsExtensions: true,
 			noEmit: true,
 			skipLibCheck: true,
-			strict: true,
+			strict: false,
+			noImplicitAny: false,
 			types: [],
 		},
 	})
@@ -494,6 +498,26 @@ function isArbitraryNpmImportDiagnostic(diagnostic: TypecheckDiagnostic) {
 	)
 }
 
+function isLooseEmptyObjectPropertyDiagnostic(diagnostic: TypecheckDiagnostic) {
+	// `input = {}` (and other fresh empty objects) still reject property access
+	// under non-strict settings. Agents and the execute docs use that shape, so
+	// treat "does not exist on type '{}'" as allowed laziness while keeping
+	// property errors on real package/result types.
+	if (diagnostic.code !== 2339) return false
+	return /on type '\{\}'\.?$/.test(
+		flattenDiagnosticMessage(diagnostic.messageText),
+	)
+}
+
+function shouldIgnoreExecuteTypecheckDiagnostic(
+	diagnostic: TypecheckDiagnostic,
+) {
+	return (
+		isArbitraryNpmImportDiagnostic(diagnostic) ||
+		isLooseEmptyObjectPropertyDiagnostic(diagnostic)
+	)
+}
+
 function getLineAndCharacter(source: string, position: number) {
 	const prefix = source.slice(0, position)
 	const lines = prefix.split('\n')
@@ -615,7 +639,9 @@ export async function assertAdHocExecuteTypechecks(input: {
 						...languageService.getSyntacticDiagnostics(entryPath),
 						...languageService.getSemanticDiagnostics(entryPath),
 					])
-					.filter((diagnostic) => !isArbitraryNpmImportDiagnostic(diagnostic))
+					.filter(
+						(diagnostic) => !shouldIgnoreExecuteTypecheckDiagnostic(diagnostic),
+					)
 					.map((diagnostic) =>
 						formatDiagnostic({
 							diagnostic,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The feature-flagged pre-execution TypeScript checker for ad hoc `execute` was running with `strict: true`, which rejects the lazy patterns agents commonly write (untyped parameters, `input = {}` property access, indexing plain objects).

This keeps useful contract checking against published `kody:@…` package types, but loosens the checker so agent-authored one-offs can stay non-strict.

### Changes

- Set execute typecheck `tsconfig` to `strict: false` / `noImplicitAny: false`
- Ignore TS2339 diagnostics that only complain about property access on type `{}` (covers the docs-endorsed `input = {}` shape without hiding property errors on real package types)
- Add a regression test for lazy untyped agent modules, while still asserting typed package property errors fail
- Document the non-strict intent in `docs/use/execute.md`

### Test plan

- [x] `npx vitest run packages/worker/src/mcp/execute-typecheck.node.test.ts`
- [x] CI green on rebased head

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e8ab3531` · **Head:** `dac20b30`

**Classification:** extends — changes the pre-execution TypeScript checker contract for ad hoc MCP execute modules (strictness), without adding primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — looser ad hoc execute TypeScript precheck (`strict: false`, allow empty-object property laziness) |

### System map

Ad hoc execute modules hit the precheck before sandbox run; this PR only changes how strict that precheck is.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	executePrecheck["execute-typecheck<br/>pre-exec TS check"]:::extended
	mcpServer -->|"flagged ad hoc execute"| executePrecheck
	executePrecheck -->|"non-strict config + ignore TS2339 on {}"| executePrecheck
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** `strict: true` → implicit `any`, `input = {}` property access, and similar lazy agent TS failed the precheck.

**After:** non-strict config; empty-object property diagnostics ignored; wrong args/results against published package contracts still fail.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d17d1b1-5d34-4b4c-bd7b-7dd3b3d776d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d17d1b1-5d34-4b4c-bd7b-7dd3b3d776d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-execution TypeScript checks now support non-strict coding patterns, including untyped parameters and empty object access.
  * Type contracts and genuine assignability errors continue to be enforced.

* **Documentation**
  * Clarified the non-strict checking behavior and provided guidance for reverting to the previous execution behavior if rollout issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->