### PR TITLE
fix(jobs): do not fail alarms when a fenced job claim is superseded

### DIFF
--- a/packages/worker/src/jobs/run-due-jobs-claim-fence.node.test.ts
+++ b/packages/worker/src/jobs/run-due-jobs-claim-fence.node.test.ts
@@ -1,0 +1,202 @@
+import { expect, test, vi } from 'vitest'
+import { consoleInfo } from '#worker/test-support/console-spies.ts'
+import { type JobRecord } from './types.ts'
+
+const withAccountWriteLease = vi.fn(
+	async (input: { write: () => Promise<unknown> }) => input.write(),
+)
+const disableExpiredJobRowsForUser = vi.fn(async () => 0)
+const listDueJobRows = vi.fn()
+const claimJobRow = vi.fn()
+const finalizeClaimedJobRow = vi.fn()
+const retryClaimedJobRow = vi.fn()
+const claimRunRecord = vi.fn()
+const listArchivedJobArtifactsDueBefore = vi.fn(async () => [])
+
+vi.mock('#worker/account/deletion-state.ts', () => ({
+	withAccountWriteLease: (...args: Array<unknown>) =>
+		withAccountWriteLease(...(args as [never])),
+}))
+
+vi.mock('./repo.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./repo.ts')>()
+	return {
+		...actual,
+		disableExpiredJobRowsForUser: (...args: Array<unknown>) =>
+			disableExpiredJobRowsForUser(...(args as [never])),
+		listDueJobRows: (...args: Array<unknown>) =>
+			listDueJobRows(...(args as [never])),
+		claimJobRow: (...args: Array<unknown>) => claimJobRow(...(args as [never])),
+		finalizeClaimedJobRow: (...args: Array<unknown>) =>
+			finalizeClaimedJobRow(...(args as [never])),
+		retryClaimedJobRow: (...args: Array<unknown>) =>
+			retryClaimedJobRow(...(args as [never])),
+	}
+})
+
+vi.mock('#worker/run-records/service.ts', () => ({
+	claimRunRecord: (...args: Array<unknown>) =>
+		claimRunRecord(...(args as [never])),
+	abandonRunRecord: vi.fn(),
+	finishRunRecord: vi.fn(),
+	getRunRecord: vi.fn(),
+}))
+
+vi.mock('./archived-artifacts-repo.ts', () => ({
+	listArchivedJobArtifactsDueBefore: (...args: Array<unknown>) =>
+		listArchivedJobArtifactsDueBefore(...(args as [never])),
+	deleteArchivedJobArtifact: vi.fn(),
+}))
+
+const { runDueJobsForUser } = await import('./service.ts')
+
+function createJobRecord(overrides: Partial<JobRecord> = {}): JobRecord {
+	return {
+		version: 1,
+		id: 'job-fenced',
+		userId: 'user-fenced',
+		name: 'Fenced job',
+		sourceId: 'source-fenced',
+		publishedCommit: null,
+		storageId: 'job:job-fenced',
+		schedule: { type: 'interval', every: '1h' },
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		preserved: false,
+		expiresAt: null,
+		createdAt: '2026-07-30T12:00:00.000Z',
+		updatedAt: '2026-07-30T12:00:00.000Z',
+		nextRunAt: '2026-07-30T19:00:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+		...overrides,
+	}
+}
+
+function claimedRow(record: JobRecord) {
+	const scheduledFor = record.nextRunAt
+	return {
+		id: record.id,
+		user_id: record.userId,
+		name: record.name,
+		source_id: record.sourceId,
+		published_commit: record.publishedCommit,
+		repo_check_policy_json: null,
+		storage_id: record.storageId,
+		params_json: null,
+		schedule_json: JSON.stringify(record.schedule),
+		timezone: record.timezone,
+		enabled: 1 as const,
+		kill_switch_enabled: 0 as const,
+		preserved: 0 as const,
+		expires_at: null,
+		caller_context_json: '{}',
+		created_at: record.createdAt,
+		updated_at: record.updatedAt,
+		last_run_at: null,
+		last_run_status: null,
+		last_run_error: null,
+		last_duration_ms: null,
+		next_run_at: record.nextRunAt,
+		run_count: 0,
+		success_count: 0,
+		error_count: 0,
+		claim_token: 'claim-token',
+		running_since: scheduledFor,
+		lease_expires_at: '2026-07-30T19:10:00.000Z',
+		claimed_scheduled_for: scheduledFor,
+		retry_scheduled_for: null,
+		retry_count: 0,
+		last_completed_scheduled_for: null,
+		schedulerWakeAt: scheduledFor,
+		record,
+		callerContext: null,
+		callerContextJson: '{}',
+	}
+}
+
+test('runDueJobsForUser treats a superseded finalization claim as expected fencing', async () => {
+	const now = new Date('2026-07-30T19:00:00.000Z')
+	const record = createJobRecord()
+	const row = claimedRow(record)
+	listDueJobRows.mockResolvedValue([row])
+	claimJobRow.mockResolvedValue(row)
+	claimRunRecord.mockResolvedValue({
+		claimed: false,
+		run: {
+			id: 'run-1',
+			surface: 'job',
+			status: 'success',
+			name: record.name,
+			packageId: null,
+			kodyId: null,
+			sourceId: record.sourceId,
+			publishedCommit: null,
+			storageId: record.storageId,
+			jobId: record.id,
+			workflowId: null,
+			invocationId: null,
+			sessionId: null,
+			idempotencyKey: `scheduled-job:${record.id}:${row.claimed_scheduled_for}`,
+			parentRunId: null,
+			startedAt: now.toISOString(),
+			finishedAt: now.toISOString(),
+			durationMs: 12,
+			errorName: null,
+			errorMessage: null,
+			metadata: { result: { ok: true } },
+			logCount: 0,
+		},
+	})
+	finalizeClaimedJobRow.mockResolvedValue(false)
+
+	const result = await runDueJobsForUser({
+		env: { APP_DB: {} } as Env,
+		userId: record.userId,
+		now,
+	})
+
+	expect(result).toEqual({
+		dueJobCount: 1,
+		successCount: 0,
+		errorCount: 0,
+		jobOutcomes: [],
+	})
+	expect(finalizeClaimedJobRow).toHaveBeenCalledOnce()
+	expect(retryClaimedJobRow).not.toHaveBeenCalled()
+	expect(consoleInfo).toHaveBeenCalledWith(
+		'job-scheduler',
+		expect.stringContaining('"event":"claim_lost_before_finalization"'),
+	)
+})
+
+test('runDueJobsForUser treats a superseded retry claim as expected fencing', async () => {
+	const now = new Date('2026-07-30T19:00:00.000Z')
+	const record = createJobRecord({ id: 'job-retry-fence' })
+	const row = claimedRow(record)
+	listDueJobRows.mockResolvedValue([row])
+	claimJobRow.mockResolvedValue(row)
+	claimRunRecord.mockResolvedValue(null)
+	retryClaimedJobRow.mockResolvedValue(false)
+
+	const result = await runDueJobsForUser({
+		env: { APP_DB: {} } as Env,
+		userId: record.userId,
+		now,
+	})
+
+	expect(result).toEqual({
+		dueJobCount: 1,
+		successCount: 0,
+		errorCount: 0,
+		jobOutcomes: [],
+	})
+	expect(retryClaimedJobRow).toHaveBeenCalledOnce()
+	expect(finalizeClaimedJobRow).not.toHaveBeenCalled()
+	expect(consoleInfo).toHaveBeenCalledWith(
+		'job-scheduler',
+		expect.stringContaining('"event":"claim_lost_before_retry_transition"'),
+	)
+})

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -1548,9 +1548,17 @@ export async function runDueJobsForUser(input: {
 						scheduledFor: row.claimed_scheduled_for,
 					})
 					if (!finalized) {
-						throw new Error(
-							`Scheduled job "${row.id}" lost its fenced execution claim before finalization.`,
-						)
+						// Ordinary edits clear claim_token; lease reclaim can
+						// also supersede this runner. The fence worked — do not
+						// fail the alarm or abort remaining due jobs.
+						logJobSchedulerEvent({
+							event: 'claim_lost_before_finalization',
+							userId: input.userId,
+							jobId: row.id,
+							scheduleType: row.record.schedule.type,
+							reason: 'fenced_claim_superseded',
+						})
+						continue
 					}
 					successCount += result.successCount
 					errorCount += result.errorCount
@@ -1571,9 +1579,14 @@ export async function runDueJobsForUser(input: {
 						nextRunAt: retryAt,
 					})
 					if (!retried) {
-						throw new Error(
-							`Scheduled job "${row.id}" lost its fenced execution claim before retry transition.`,
-						)
+						logJobSchedulerEvent({
+							event: 'claim_lost_before_retry_transition',
+							userId: input.userId,
+							jobId: row.id,
+							scheduleType: row.record.schedule.type,
+							reason: 'fenced_claim_superseded',
+						})
+						continue
 					}
 					errorCount += 1
 					jobOutcomes.push({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [7643039179](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7643039179/): `Scheduled job "…" lost its fenced execution claim before finalization.`

At-least-once job safety (#1012) intentionally clears `claim_token` on ordinary edits and fences stale finalizers / retry transitions (`finalizeClaimedJobRow` / `retryClaimedJobRow` return `false`). Throwing on that result turned expected fencing into a Sentry error and aborted the JobManager alarm mid-batch.

This change logs `claim_lost_before_finalization` / `claim_lost_before_retry_transition` and continues processing remaining due jobs.

## Testing

- `npm run test:node -- --run packages/worker/src/jobs/run-due-jobs-claim-fence.node.test.ts`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `5be54d3b` · **Head:** `941d11aa`

**Classification:** composes — call-site handling of the existing fenced claim write result; no claim/lease schema or finalize SQL changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `jobs` | assistant | composes — superseded claim finalization/retry no longer throws |

### System map

JobManager alarms run due jobs through fenced D1 claim finalization; a superseded claim is logged and skipped instead of failing the alarm.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  jobs["jobs<br/>Scheduled jobs"]:::touched
  d1["d1-app-db<br/>D1 app database"]:::untouched
  jobs -->|"finalize/retry returns false when claim_token cleared"| d1
  jobs -->|"log claim_lost_* and continue due-job loop"| jobs
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Claim, retry, and finalization queries remain scoped by `user_id`.
- Ordinary edits still cancel claims; stale finalizers still cannot overwrite them.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9612b862-e933-4fb5-8a06-a97301c14ebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9612b862-e933-4fb5-8a06-a97301c14ebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

