### PR TITLE
Associate feature flags with success metrics (exposures + cohort readout)

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -950,6 +950,10 @@ Current retention policies:
 - `entitlement_daily_counters`: daily rate counters keep 400 days by `day` key.
 - `usage_rollups`: per user/metric/month rollups keep 24 months by `month` key;
   raw Analytics Engine usage events follow platform retention.
+- `feature_flag_exposure_rollups`: local-dev/test flag exposure rollups keep 90
+  days by `day` key, matching Analytics Engine retention for the production
+  `FLAG_EXPOSURES` exposure stream; the admin metric readout window is the
+  current month.
 - `platform_feedback`: open and triaged rows remain until review changes them to
   resolved or dismissed, or the submitter deletes their account. Resolved and
   dismissed rows keep 365 days after `updated_at`; submitter deletion removes

--- a/docs/contributing/architecture/feature-flags.md
+++ b/docs/contributing/architecture/feature-flags.md
@@ -9,9 +9,15 @@ Module: `packages/worker/src/feature-flags/`
 
 - `registry.ts` — the typed flag registry (`featureFlagDefinitions`,
   `FeatureFlagKey`). Flags are created and removed only via code review by
-  editing this array; every gate site is compile-checked against it.
-- `service.ts` — evaluation (`isFeatureEnabled`, `getFeatureFlagsForUser`) and
-  admin mutations (global state, per-user overrides, stale cleanup).
+  editing this array; every gate site is compile-checked against it. Flags
+  should also declare a `successMetric` (see below).
+- `service.ts` — evaluation (`isFeatureEnabled`, `getFeatureFlagsForUser`,
+  `getFeatureFlagEvaluationsForUser` with assignment sources) and admin
+  mutations (global state, per-user overrides, stale cleanup).
+- `exposure.ts` — success-metric exposure recording (which value each user saw
+  and how it was assigned).
+- `success-metric-readout.ts` — the on/off cohort metric readout for the admin
+  surfaces.
 - `types.ts` — dependency-free transport types shared with the client tsconfig.
 
 ## The registry-owns-existence invariant
@@ -62,3 +68,49 @@ default-on flag can never bypass an operator kill switch when D1 is unavailable.
 The registry ships with one permanent flag, `demo-indicator`, which renders a
 small badge in the app chrome and exists so the system stays exercised
 end-to-end (`e2e/admin-feature-flags.spec.ts`).
+
+## Success metrics
+
+Every flag exists to move something; the `successMetric` field on a registry
+definition states what, in code review, alongside the flag itself:
+
+```ts
+successMetric: {
+	eventType: 'execute', // a UsageEventType from usage metering
+	measure: 'error_rate', // 'event_count' | 'error_rate' | 'avg_duration_ms'
+	goal: 'decrease',
+	hypothesis: 'One human sentence stating why this flag should move it.',
+}
+```
+
+The field is compile-checked against the closed `UsageEventType` union
+(`packages/worker/src/usage/event-types.ts`), so a flag can only be judged
+against a metric the usage-metering pipeline already collects. It stays optional
+for genuinely unmeasurable flags (like the permanent `demo-indicator`), but the
+admin UI and the `admin_feature_flag_list` capability render a notice strongly
+recommending one everywhere else.
+
+### Exposures
+
+Current flag state cannot reconstruct who was inside a percentage rollout last
+week, so measured flags record **exposures** at the two evaluation chokepoints
+(the app session flag cache and the MCP caller flag resolver):
+`(stable user id, flag key, on/off, assignment source, timestamp)`. The write
+path mirrors usage metering — the `FLAG_EXPOSURES` Analytics Engine dataset in
+production/preview, the D1 `feature_flag_exposure_rollups` table (migration
+`0113`, 90-day retention) in local dev and tests — and never throws.
+
+The assignment source (`default` / `global` / `rollout` / `override`) is what
+keeps the readout honest: `override` users are hand-picked and excluded from
+comparisons, while `rollout` users are deterministically bucketed.
+
+### Readout
+
+`success-metric-readout.ts` joins exposures with the usage event stream for the
+declared `eventType` over the current UTC month to date, splits users into
+on/off cohorts (excluding override and mixed-exposure users, reported
+separately), and aggregates event count, error rate, and average duration per
+cohort. The admin UI (`/admin/feature-flags`) and `admin_feature_flag_list`
+attach this readout to every measured flag. The comparison is decision support
+for a human — "keep rolling out or kill it" stays an operator call, not an
+automated one.

--- a/docs/contributing/architecture/feature-flags.md
+++ b/docs/contributing/architecture/feature-flags.md
@@ -98,7 +98,7 @@ week, so measured flags record **exposures** at the two evaluation chokepoints
 `(stable user id, flag key, on/off, assignment source, timestamp)`. The write
 path mirrors usage metering — the `FLAG_EXPOSURES` Analytics Engine dataset in
 production/preview, the D1 `feature_flag_exposure_rollups` table (migration
-`0113`, 90-day retention) in local dev and tests — and never throws.
+`0117`, 90-day retention) in local dev and tests — and never throws.
 
 The assignment source (`default` / `global` / `rollout` / `override`) is what
 keeps the readout honest: `override` users are hand-picked and excluded from

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -33,9 +33,13 @@ type UsageEvent = {
 }
 ```
 
-`eventType` is a closed union. Add new members to `UsageEventType` in
-`record-usage.ts` (never ad hoc strings at call sites) so the set of metrics
-stays reviewable in one place.
+`eventType` is a closed union defined in the dependency-free
+`packages/worker/src/usage/event-types.ts` (re-exported by `record-usage.ts`).
+Add new members there (never ad hoc strings at call sites) so the set of metrics
+stays reviewable in one place. The feature-flag registry declares flag success
+metrics against this union, and the flag-exposure stream (`FLAG_EXPOSURES`
+dataset, see [feature-flags.md](./feature-flags.md#success-metrics)) is joined
+with these events for the admin on/off cohort readout.
 
 ### Metrics and their chokepoints
 

--- a/e2e/admin-feature-flags.spec.ts
+++ b/e2e/admin-feature-flags.spec.ts
@@ -33,6 +33,15 @@ test('admin feature flags: global toggle and per-user override visibility', asyn
 		page.getByRole('heading', { name: 'Admin feature flags' }),
 	).toBeVisible()
 
+	// Success-metric surfaces: the measured flag renders its readout panel and
+	// the unmeasured demo flag renders the strong recommendation notice.
+	await expect(
+		page.getByTestId('success-metric-notice-demo-indicator'),
+	).toContainText('No success metric declared')
+	await expect(
+		page.getByTestId('success-metric-execute-pre-exec-typecheck'),
+	).toContainText('error rate should decrease')
+
 	const demoFlagSection = page
 		.getByRole('heading', { name: 'demo-indicator' })
 		.locator('xpath=ancestor::section[1]')

--- a/packages/worker/client/routes/admin-feature-flags.tsx
+++ b/packages/worker/client/routes/admin-feature-flags.tsx
@@ -28,6 +28,11 @@ import {
 	type AdminFeatureFlagsLoaderData,
 } from '#app/loader-data.ts'
 import {
+	missingSuccessMetricNotice,
+	type FeatureFlagSuccessMetricMeasure,
+} from '#worker/feature-flags/registry.ts'
+import { type FeatureFlagMetricCohort } from '#worker/feature-flags/types.ts'
+import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
@@ -44,6 +49,48 @@ const adminFeatureFlagsApiPath = '/admin/feature-flags.json'
 
 function isAdminFeatureFlagsPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === '/admin/feature-flags'
+}
+
+function formatMeasureLabel(measure: FeatureFlagSuccessMetricMeasure): string {
+	switch (measure) {
+		case 'event_count':
+			return 'event count'
+		case 'error_rate':
+			return 'error rate'
+		case 'avg_duration_ms':
+			return 'average duration'
+		default:
+			measure satisfies never
+			return measure
+	}
+}
+
+function formatMeasureValue(
+	measure: FeatureFlagSuccessMetricMeasure,
+	cohort: FeatureFlagMetricCohort,
+): string {
+	switch (measure) {
+		case 'event_count':
+			return String(cohort.eventCount)
+		case 'error_rate':
+			return cohort.errorRate === null
+				? 'n/a'
+				: `${(cohort.errorRate * 100).toFixed(1)}%`
+		case 'avg_duration_ms':
+			return cohort.avgDurationMs === null
+				? 'n/a'
+				: `${Math.round(cohort.avgDurationMs)} ms`
+		default:
+			measure satisfies never
+			return 'n/a'
+	}
+}
+
+function summarizeMetricCohort(
+	measure: FeatureFlagSuccessMetricMeasure,
+	cohort: FeatureFlagMetricCohort,
+): string {
+	return `${cohort.users} user(s) · ${cohort.eventCount} event(s) · ${formatMeasureLabel(measure)} ${formatMeasureValue(measure, cohort)}`
 }
 
 function summarizeEffectiveSource(flag: AdminFeatureFlag): string {
@@ -324,6 +371,103 @@ export function AdminFeatureFlagsRoute(handle: Handle) {
 									{flag.description ?? 'No description provided.'}
 								</p>
 							</div>
+							{flag.successMetric ? (
+								<div
+									data-testid={`success-metric-${flag.key}`}
+									mix={css({
+										border: `1px solid ${colors.border}`,
+										borderRadius: '0.75rem',
+										padding: spacing.md,
+										marginBottom: spacing.lg,
+										display: 'grid',
+										gap: spacing.sm,
+									})}
+								>
+									<h3
+										mix={css({
+											margin: 0,
+											fontSize: typography.fontSize.base,
+											fontWeight: typography.fontWeight.semibold,
+										})}
+									>
+										Success metric:{' '}
+										<code mix={css({ fontSize: typography.fontSize.sm })}>
+											{flag.successMetric.eventType}
+										</code>{' '}
+										{formatMeasureLabel(flag.successMetric.measure)} should{' '}
+										{flag.successMetric.goal}
+									</h3>
+									<p mix={css(descriptionCss)}>
+										{flag.successMetric.hypothesis}
+									</p>
+									{flag.metricReadout?.status === 'ok' ? (
+										<>
+											<MetadataGrid
+												columns={3}
+												items={[
+													{
+														label: 'On cohort',
+														value: summarizeMetricCohort(
+															flag.successMetric.measure,
+															flag.metricReadout.on,
+														),
+													},
+													{
+														label: 'Off cohort',
+														value: summarizeMetricCohort(
+															flag.successMetric.measure,
+															flag.metricReadout.off,
+														),
+													},
+													{
+														label: 'Excluded',
+														value: `${flag.metricReadout.overrideUsers} override user(s) · ${flag.metricReadout.mixedUsers} mixed-exposure user(s)`,
+													},
+												]}
+											/>
+											<p
+												mix={css({
+													margin: 0,
+													color: colors.textMuted,
+													fontSize: typography.fontSize.sm,
+												})}
+											>
+												Window: {flag.metricReadout.windowStart.slice(0, 10)} to{' '}
+												{flag.metricReadout.windowEnd.slice(0, 10)} (current
+												month to date). Override users are excluded because they
+												are hand-picked; mixed users saw both values inside the
+												window.
+											</p>
+										</>
+									) : flag.metricReadout?.status === 'unavailable' ? (
+										<p
+											mix={css({
+												margin: 0,
+												color: colors.textMuted,
+												fontSize: typography.fontSize.sm,
+											})}
+										>
+											{flag.metricReadout.reason}
+										</p>
+									) : null}
+								</div>
+							) : (
+								<p
+									data-testid={`success-metric-notice-${flag.key}`}
+									mix={css({
+										margin: 0,
+										marginBottom: spacing.lg,
+										padding: spacing.sm,
+										border: `1px solid ${colors.border}`,
+										borderRadius: '0.75rem',
+										background: colors.primarySoftest,
+										color: colors.textMuted,
+										fontSize: typography.fontSize.sm,
+									})}
+								>
+									{missingSuccessMetricNotice}
+								</p>
+							)}
 							<form
 								mix={[
 									css({

--- a/packages/worker/migrations/0117-feature-flag-exposure-rollups.sql
+++ b/packages/worker/migrations/0117-feature-flag-exposure-rollups.sql
@@ -19,3 +19,8 @@ CREATE TABLE IF NOT EXISTS feature_flag_exposure_rollups (
 
 CREATE INDEX IF NOT EXISTS idx_feature_flag_exposure_rollups_user_id
 	ON feature_flag_exposure_rollups (user_id);
+
+-- Retention prunes select and order by day (see retention.ts); the composite
+-- primary key starts with flag_key so it cannot serve that scan.
+CREATE INDEX IF NOT EXISTS idx_feature_flag_exposure_rollups_day
+	ON feature_flag_exposure_rollups (day);

--- a/packages/worker/migrations/0117-feature-flag-exposure-rollups.sql
+++ b/packages/worker/migrations/0117-feature-flag-exposure-rollups.sql
@@ -1,0 +1,21 @@
+-- Local-dev/test sink for feature-flag success-metric exposures.
+--
+-- In production/preview, exposures are written only to the FLAG_EXPOSURES
+-- Analytics Engine dataset (see
+-- packages/worker/src/feature-flags/exposure.ts). This table is the fallback
+-- sink when that binding is absent (local dev, tests) so the admin metric
+-- readout keeps working without Analytics Engine access. user_id holds the
+-- stable user id so exposure rows join with usage_rollups.user_id.
+CREATE TABLE IF NOT EXISTS feature_flag_exposure_rollups (
+	flag_key TEXT NOT NULL,
+	user_id TEXT NOT NULL,
+	day TEXT NOT NULL,
+	enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+	source TEXT NOT NULL,
+	exposure_count INTEGER NOT NULL DEFAULT 0,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY (flag_key, user_id, day, enabled, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_exposure_rollups_user_id
+	ON feature_flag_exposure_rollups (user_id);

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -129,6 +129,7 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 	{ kind: 'user_id', table: 'package_service_states' },
 	{ kind: 'user_id', table: 'user_storage_buckets' },
 	{ kind: 'user_id', table: 'usage_rollups' },
+	{ kind: 'user_id', table: 'feature_flag_exposure_rollups' },
 	{ kind: 'user_id', table: 'user_activation_milestones' },
 	{ kind: 'user_id', table: 'user_package_run_successes' },
 	{ kind: 'user_id', table: 'agent_package_conversation_uses' },

--- a/packages/worker/src/app/account-retention-dispositions.ts
+++ b/packages/worker/src/app/account-retention-dispositions.ts
@@ -18,6 +18,7 @@ export const accountRetentionDispositions: ReadonlyArray<AccountRetentionDisposi
 		{ table: 'email_threads', kind: 'scheduled_policy' },
 		{ table: 'entitlement_daily_counters', kind: 'scheduled_policy' },
 		{ table: 'usage_rollups', kind: 'scheduled_policy' },
+		{ table: 'feature_flag_exposure_rollups', kind: 'scheduled_policy' },
 		{ table: 'audit_events', kind: 'scheduled_policy' },
 		{ table: 'stripe_webhook_events', kind: 'scheduled_policy' },
 		{

--- a/packages/worker/src/app/admin-feature-flags-data.ts
+++ b/packages/worker/src/app/admin-feature-flags-data.ts
@@ -1,11 +1,14 @@
 import { type AdminFeatureFlagsLoaderData } from '#app/loader-data.ts'
 import { listFeatureFlagsForAdmin } from '#worker/feature-flags/service.ts'
+import { attachFeatureFlagMetricReadouts } from '#worker/feature-flags/success-metric-readout.ts'
 
 export async function loadAdminFeatureFlagsData(
 	env: Env,
 ): Promise<AdminFeatureFlagsLoaderData> {
+	const featureFlags = await listFeatureFlagsForAdmin(env.APP_DB)
+	await attachFeatureFlagMetricReadouts(env, featureFlags)
 	return {
 		ok: true,
-		featureFlags: await listFeatureFlagsForAdmin(env.APP_DB),
+		featureFlags,
 	}
 }

--- a/packages/worker/src/app/handlers/admin-feature-flags.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-feature-flags.node.test.ts
@@ -207,6 +207,19 @@ function createFeatureFlagsTestEnv(
 						meta: { changes: 0 },
 					} as { results: Array<T>; meta: { changes: number } }
 				}
+				// Metric readout queries (D1 fallback path); no data in this test.
+				if (normalized.includes('from feature_flag_exposure_rollups')) {
+					return {
+						results: [],
+						meta: { changes: 0 },
+					} as { results: Array<T>; meta: { changes: number } }
+				}
+				if (normalized.includes('from usage_rollups')) {
+					return {
+						results: [],
+						meta: { changes: 0 },
+					} as { results: Array<T>; meta: { changes: number } }
+				}
 				throw new Error(`Unsupported all query: ${query}`)
 			},
 			async run() {

--- a/packages/worker/src/app/handlers/session-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/session-handler.node.test.ts
@@ -103,6 +103,10 @@ function createSessionTestDb() {
 		prepare(query: string) {
 			return createStatement(query)
 		},
+		// Feature-flag exposure recording upserts via db.batch in local mode.
+		async batch(statements: Array<unknown>) {
+			return statements.map(() => ({ meta: { changes: 1 } }))
+		},
 		async exec() {
 			return
 		},

--- a/packages/worker/src/app/request-feature-flags-cache.ts
+++ b/packages/worker/src/app/request-feature-flags-cache.ts
@@ -6,19 +6,29 @@
  * need auth should keep using `loadResolvedRequestAuth` /
  * `readAuthenticatedAppUser` and will not hit this path.
  *
+ * Evaluation also records success-metric exposures for measured flags (see
+ * `#worker/feature-flags/exposure.ts`), which is why authenticated
+ * evaluation needs the caller's stable user id alongside the numeric one.
+ *
  * On evaluation failure for an authenticated user, every flag is forced off
  * (fail closed) so a default-on registry flag cannot bypass a kill switch when
  * D1 is unavailable. Anonymous requests still use registry defaults.
  */
 
+import { recordFeatureFlagExposures } from '#worker/feature-flags/exposure.ts'
 import {
 	featureFlagDefinitions,
 	featureFlagKeys,
 	type FeatureFlagKey,
 } from '#worker/feature-flags/registry.ts'
-import { getFeatureFlagsForUser } from '#worker/feature-flags/service.ts'
+import { getFeatureFlagEvaluationsForUser } from '#worker/feature-flags/service.ts'
 
 export type EvaluatedFeatureFlags = Record<FeatureFlagKey, boolean>
+
+export type FeatureFlagRequestUser = {
+	userId: number
+	stableUserId: string
+}
 
 const requestFeatureFlagsStore = new WeakMap<
 	Request,
@@ -43,13 +53,25 @@ function disabledFeatureFlags(): EvaluatedFeatureFlags {
 
 async function resolveRequestFeatureFlags(
 	env: Env,
-	userId: number | null,
+	user: FeatureFlagRequestUser | null,
 ): Promise<EvaluatedFeatureFlags> {
-	if (userId === null) {
+	if (user === null) {
 		return defaultFeatureFlags()
 	}
 	try {
-		return await getFeatureFlagsForUser(env.APP_DB, userId)
+		const evaluations = await getFeatureFlagEvaluationsForUser(
+			env.APP_DB,
+			user.userId,
+		)
+		await recordFeatureFlagExposures(env, {
+			stableUserId: user.stableUserId,
+			evaluations,
+		})
+		const flags = {} as EvaluatedFeatureFlags
+		for (const key of featureFlagKeys) {
+			flags[key] = evaluations[key].enabled
+		}
+		return flags
 	} catch (error) {
 		console.error('Failed to load feature flags for authenticated user:', error)
 		return disabledFeatureFlags()
@@ -59,11 +81,11 @@ async function resolveRequestFeatureFlags(
 export function loadRequestFeatureFlags(
 	request: Request,
 	env: Env,
-	userId: number | null,
+	user: FeatureFlagRequestUser | null,
 ): Promise<EvaluatedFeatureFlags> {
 	let promise = requestFeatureFlagsStore.get(request)
 	if (!promise) {
-		promise = resolveRequestFeatureFlags(env, userId)
+		promise = resolveRequestFeatureFlags(env, user)
 		requestFeatureFlagsStore.set(request, promise)
 	}
 	return promise

--- a/packages/worker/src/app/retention.node.test.ts
+++ b/packages/worker/src/app/retention.node.test.ts
@@ -7,12 +7,14 @@ import {
 	emailDeliveryEventRetentionDays,
 	emailMessageRetentionDays,
 	entitlementDailyCounterRetentionDays,
+	featureFlagExposureRetentionDays,
 	getRetentionPolicyCoverage,
 	memorySuppressionRetentionDays,
 	platformFeedbackRetentionDays,
 	pruneAuditEventsForRetention,
 	pruneEmailDeliveryEventsForRetention,
 	pruneEntitlementDailyCountersForRetention,
+	pruneFeatureFlagExposuresForRetention,
 	pruneMemorySuppressionsForRetention,
 	prunePlatformFeedbackForRetention,
 	prunePublishedBundleArtifactsForRetention,
@@ -218,6 +220,16 @@ function createRetentionDb() {
 			total_bytes INTEGER NOT NULL DEFAULT 0,
 			updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
 			PRIMARY KEY (user_id, metric, month)
+		);
+		CREATE TABLE feature_flag_exposure_rollups (
+			flag_key TEXT NOT NULL,
+			user_id TEXT NOT NULL,
+			day TEXT NOT NULL,
+			enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+			source TEXT NOT NULL,
+			exposure_count INTEGER NOT NULL DEFAULT 0,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (flag_key, user_id, day, enabled, source)
 		);
 		CREATE TABLE audit_events (
 			id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -892,6 +904,36 @@ test('entitlement counter and usage rollup retention respect boundaries', async 
 		.prepare(`SELECT month FROM usage_rollups ORDER BY month`)
 		.all() as Array<{ month: string }>
 	expect(months.map((row) => row.month)).toEqual(['2024-07', '2026-06'])
+})
+
+test('feature flag exposure rollup retention respects the day boundary', async () => {
+	const { sqlite, db } = createRetentionDb()
+	const cutoffDay = daysAgo(featureFlagExposureRetentionDays).slice(0, 10)
+	for (const day of [
+		daysAgo(featureFlagExposureRetentionDays + 1).slice(0, 10),
+		cutoffDay,
+		daysAgo(1).slice(0, 10),
+	]) {
+		sqlite
+			.prepare(
+				`INSERT INTO feature_flag_exposure_rollups (
+				flag_key, user_id, day, enabled, source, exposure_count, updated_at
+			) VALUES ('execute-pre-exec-typecheck', 'user-1', ?, 1, 'rollout', 1, ?)`,
+			)
+			.run(day, now.toISOString())
+	}
+
+	expect(await pruneFeatureFlagExposuresForRetention({ db, now })).toEqual({
+		selected: 1,
+		deleted: 1,
+	})
+	const days = sqlite
+		.prepare(`SELECT day FROM feature_flag_exposure_rollups ORDER BY day`)
+		.all() as Array<{ day: string }>
+	expect(days.map((row) => row.day)).toEqual([
+		cutoffDay,
+		daysAgo(1).slice(0, 10),
+	])
 })
 
 test('published bundle artifact retention deletes stale rows, KV blobs, and source snapshots', async () => {

--- a/packages/worker/src/app/retention.ts
+++ b/packages/worker/src/app/retention.ts
@@ -51,6 +51,7 @@ export const emailDeliveryEventRetentionDays = 90
 export const emailMessageRetentionDays = 365
 export const entitlementDailyCounterRetentionDays = 400
 export const usageRollupRetentionMonths = 24
+export const featureFlagExposureRetentionDays = 90
 export const auditEventRetentionDays = 180
 export const stripeWebhookEventRetentionDays = 30
 
@@ -148,6 +149,14 @@ export const retentionPolicies: ReadonlyArray<RetentionPolicy> = [
 			'Per user/metric/month usage rollups keep 24 months; Analytics Engine retains the raw event stream separately.',
 	},
 	{
+		table: 'feature_flag_exposure_rollups',
+		scope: 'per-user',
+		retentionDays: featureFlagExposureRetentionDays,
+		batchSize: retentionDefaultBatchSize,
+		description:
+			'Local-dev/test flag exposure rollups keep 90 days, matching Analytics Engine retention for the production exposure stream; the metric readout window is the current month.',
+	},
+	{
 		table: 'audit_events',
 		scope: 'global',
 		retentionDays: auditEventRetentionDays,
@@ -203,6 +212,7 @@ export type RetentionPruneResult = {
 	}
 	entitlementDailyCounters: number
 	usageRollups: number
+	featureFlagExposureRollups: number
 	auditEvents: number
 	stripeWebhookEvents: number
 	batchesPerTable: Record<string, number>
@@ -810,6 +820,29 @@ export async function pruneUsageRollupsForRetention(input: {
 	})
 }
 
+export async function pruneFeatureFlagExposuresForRetention(input: {
+	db: D1Database
+	now?: Date
+	batchSize?: number
+}) {
+	const cutoffDay = cutoffIso(
+		input.now ?? new Date(),
+		featureFlagExposureRetentionDays,
+	).slice(0, 'YYYY-MM-DD'.length)
+	return selectAndDeleteByIds({
+		db: input.db,
+		column: 'rowid',
+		bindings: [cutoffDay, input.batchSize ?? retentionDefaultBatchSize],
+		sql: `SELECT rowid
+			FROM feature_flag_exposure_rollups
+			WHERE day < ?
+			ORDER BY day ASC, rowid ASC
+			LIMIT ?`,
+		table: 'feature_flag_exposure_rollups',
+		idColumn: 'rowid',
+	})
+}
+
 export async function pruneAuditEventsForRetention(input: {
 	db: D1Database
 	now?: Date
@@ -886,6 +919,7 @@ export async function pruneRetention(input: {
 		},
 		entitlementDailyCounters: 0,
 		usageRollups: 0,
+		featureFlagExposureRollups: 0,
 		auditEvents: 0,
 		stripeWebhookEvents: 0,
 		batchesPerTable: {},
@@ -988,6 +1022,13 @@ export async function pruneRetention(input: {
 			() => pruneUsageRollupsForRetention({ db, now }),
 			(count) => {
 				result.usageRollups += count
+			},
+		),
+		countTask(
+			'feature_flag_exposure_rollups',
+			() => pruneFeatureFlagExposuresForRetention({ db, now }),
+			(count) => {
+				result.featureFlagExposureRollups += count
 			},
 		),
 		countTask(

--- a/packages/worker/src/app/session-info.ts
+++ b/packages/worker/src/app/session-info.ts
@@ -36,11 +36,10 @@ export async function loadSessionInfo(
 		}
 	}
 
-	const featureFlags = await loadRequestFeatureFlags(
-		request,
-		env,
-		resolved.user.userId,
-	)
+	const featureFlags = await loadRequestFeatureFlags(request, env, {
+		userId: resolved.user.userId,
+		stableUserId: resolved.user.mcpUser.userId,
+	})
 
 	return {
 		session: {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -134,6 +134,10 @@ function createUserTestDb(users: Array<TestUser>) {
 		prepare(query: string) {
 			return createStatement(query)
 		},
+		// Feature-flag exposure recording upserts via db.batch in local mode.
+		async batch(statements: Array<unknown>) {
+			return statements.map(() => ({ meta: { changes: 1 } }))
+		},
 		async exec() {
 			return
 		},

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -183,6 +183,7 @@ export const EnvSchema = object({
 	APP_COMMIT_SHA: optionalCommitShaSchema,
 	EMAIL: optionalSendEmailSchema,
 	USAGE_EVENTS: optionalAnalyticsEngineDatasetSchema,
+	FLAG_EXPOSURES: optionalAnalyticsEngineDatasetSchema,
 	SENTRY_DSN: optionalUrlStringSchema,
 	SENTRY_ENVIRONMENT: optionalNonEmptyStringSchema,
 	SENTRY_TRACES_SAMPLE_RATE: optionalSentryTracesSampleRateSchema,

--- a/packages/worker/src/feature-flags/exposure.node.test.ts
+++ b/packages/worker/src/feature-flags/exposure.node.test.ts
@@ -79,6 +79,23 @@ test('falls back to D1 exposure rollups without the Analytics Engine binding', a
 	])
 })
 
+test('prefers the D1 sink in local Wrangler dev even when the binding exists', async () => {
+	const dataset = createAnalyticsDataset()
+	const { db, batches } = createExposureTestDb()
+	await recordFeatureFlagExposures(
+		{ FLAG_EXPOSURES: dataset, APP_DB: db, WRANGLER_IS_LOCAL_DEV: 'true' },
+		{
+			stableUserId: 'user-local',
+			evaluations: {
+				'execute-pre-exec-typecheck': { enabled: true, source: 'global' },
+			},
+			timestamp: '2026-07-15T12:00:00.000Z',
+		},
+	)
+	expect(dataset.writeDataPoint).not.toHaveBeenCalled()
+	expect(batches).toHaveLength(1)
+})
+
 test('skips recording without a stable user id or measured flags', async () => {
 	const dataset = createAnalyticsDataset()
 	await recordFeatureFlagExposures(

--- a/packages/worker/src/feature-flags/exposure.node.test.ts
+++ b/packages/worker/src/feature-flags/exposure.node.test.ts
@@ -1,0 +1,142 @@
+import { expect, test, vi } from 'vitest'
+import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
+import { recordFeatureFlagExposures } from './exposure.ts'
+
+function createAnalyticsDataset() {
+	return { writeDataPoint: vi.fn() } as unknown as AnalyticsEngineDataset & {
+		writeDataPoint: ReturnType<typeof vi.fn>
+	}
+}
+
+function createExposureTestDb() {
+	const batches: Array<Array<{ query: string; params: Array<unknown> }>> = []
+	const db = {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return { query, params }
+				},
+			}
+		},
+		async batch(statements: Array<{ query: string; params: Array<unknown> }>) {
+			batches.push(statements)
+			return statements.map(() => ({ meta: { changes: 1 } }))
+		},
+	}
+	return { db: db as unknown as D1Database, batches }
+}
+
+test('records one Analytics Engine data point per measured flag only', async () => {
+	const dataset = createAnalyticsDataset()
+	await recordFeatureFlagExposures(
+		{ FLAG_EXPOSURES: dataset },
+		{
+			stableUserId: 'user-1',
+			evaluations: {
+				// demo-indicator has no successMetric and must be skipped.
+				'demo-indicator': { enabled: true, source: 'global' },
+				'execute-pre-exec-typecheck': { enabled: true, source: 'rollout' },
+			},
+			timestamp: '2026-07-15T12:00:00.000Z',
+		},
+	)
+	expect(dataset.writeDataPoint).toHaveBeenCalledTimes(1)
+	expect(dataset.writeDataPoint).toHaveBeenCalledWith({
+		indexes: ['user-1'],
+		blobs: [
+			'user-1',
+			'execute-pre-exec-typecheck',
+			'on',
+			'rollout',
+			'2026-07-15T12:00:00.000Z',
+		],
+		doubles: [],
+	})
+})
+
+test('falls back to D1 exposure rollups without the Analytics Engine binding', async () => {
+	const { db, batches } = createExposureTestDb()
+	await recordFeatureFlagExposures(
+		{ APP_DB: db },
+		{
+			stableUserId: 'user-2',
+			evaluations: {
+				'execute-pre-exec-typecheck': { enabled: false, source: 'override' },
+			},
+			timestamp: '2026-07-15T12:00:00.000Z',
+		},
+	)
+	expect(batches).toHaveLength(1)
+	expect(batches[0]).toHaveLength(1)
+	expect(batches[0]?.[0]?.query).toContain('feature_flag_exposure_rollups')
+	expect(batches[0]?.[0]?.params).toEqual([
+		'execute-pre-exec-typecheck',
+		'user-2',
+		'2026-07-15',
+		0,
+		'override',
+		'2026-07-15T12:00:00.000Z',
+	])
+})
+
+test('skips recording without a stable user id or measured flags', async () => {
+	const dataset = createAnalyticsDataset()
+	await recordFeatureFlagExposures(
+		{ FLAG_EXPOSURES: dataset },
+		{
+			stableUserId: '',
+			evaluations: {
+				'execute-pre-exec-typecheck': { enabled: true, source: 'default' },
+			},
+		},
+	)
+	await recordFeatureFlagExposures(
+		{ FLAG_EXPOSURES: dataset },
+		{
+			stableUserId: 'user-3',
+			evaluations: {
+				'demo-indicator': { enabled: true, source: 'default' },
+			},
+		},
+	)
+	expect(dataset.writeDataPoint).not.toHaveBeenCalled()
+})
+
+test('never throws when the sink fails', async () => {
+	silenceExpectedConsoleWarns([
+		'flag-exposure-analytics-failed',
+		'flag-exposure-rollup-failed',
+	])
+	const dataset = createAnalyticsDataset()
+	dataset.writeDataPoint.mockImplementation(() => {
+		throw new Error('analytics down')
+	})
+	await expect(
+		recordFeatureFlagExposures(
+			{ FLAG_EXPOSURES: dataset },
+			{
+				stableUserId: 'user-4',
+				evaluations: {
+					'execute-pre-exec-typecheck': { enabled: true, source: 'global' },
+				},
+			},
+		),
+	).resolves.toBeUndefined()
+
+	const failingDb = {
+		prepare() {
+			throw new Error('d1 down')
+		},
+	} as unknown as D1Database
+	await expect(
+		recordFeatureFlagExposures(
+			{ APP_DB: failingDb },
+			{
+				stableUserId: 'user-4',
+				evaluations: {
+					'execute-pre-exec-typecheck': { enabled: true, source: 'global' },
+				},
+			},
+		),
+	).resolves.toBeUndefined()
+})

--- a/packages/worker/src/feature-flags/exposure.ts
+++ b/packages/worker/src/feature-flags/exposure.ts
@@ -13,9 +13,11 @@
  *
  * - With the `FLAG_EXPOSURES` Analytics Engine binding (production/preview),
  *   each exposure is a single non-blocking `writeDataPoint` call.
- * - Without it (local dev, tests), exposures are upserted into the D1
- *   `feature_flag_exposure_rollups` table (one row per flag/user/day/state)
- *   so the readout keeps working without Analytics Engine access.
+ * - Without it — or in local Wrangler dev, where the binding is a local
+ *   emulation whose data the SQL API can never read — exposures are upserted
+ *   into the D1 `feature_flag_exposure_rollups` table (one row per
+ *   flag/user/day/state) so the readout keeps working without Analytics
+ *   Engine access.
  *
  * `recordFeatureFlagExposures` never throws and never rejects: exposure
  * recording must not break session loading or MCP request handling.
@@ -27,6 +29,7 @@ import { type FeatureFlagEvaluation } from './service.ts'
 export type FeatureFlagExposureEnv = {
 	FLAG_EXPOSURES?: AnalyticsEngineDataset
 	APP_DB?: D1Database
+	WRANGLER_IS_LOCAL_DEV?: string
 }
 
 const exposureRollupUpsertStatement = `
@@ -58,7 +61,7 @@ export async function recordFeatureFlagExposures(
 		) as Array<[FeatureFlagKey, FeatureFlagEvaluation]>
 		if (exposures.length === 0) return
 		const timestamp = input.timestamp ?? new Date().toISOString()
-		if (env.FLAG_EXPOSURES) {
+		if (env.FLAG_EXPOSURES && env.WRANGLER_IS_LOCAL_DEV !== 'true') {
 			writeExposureDataPoints(env, input.stableUserId, exposures, timestamp)
 			return
 		}

--- a/packages/worker/src/feature-flags/exposure.ts
+++ b/packages/worker/src/feature-flags/exposure.ts
@@ -1,0 +1,127 @@
+/**
+ * Feature-flag success-metric exposure recording.
+ *
+ * For every flag that declares a `successMetric` in the registry, the two
+ * per-request evaluation chokepoints (the app session flag cache and the MCP
+ * caller flag resolver) record which value the user saw and how it was
+ * assigned. Exposures are what make the admin metric readout honest: current
+ * flag state cannot reconstruct who was inside a percentage rollout last
+ * week, and hand-picked override users must be excluded from on/off
+ * comparisons.
+ *
+ * The write path mirrors `packages/worker/src/usage/record-usage.ts`:
+ *
+ * - With the `FLAG_EXPOSURES` Analytics Engine binding (production/preview),
+ *   each exposure is a single non-blocking `writeDataPoint` call.
+ * - Without it (local dev, tests), exposures are upserted into the D1
+ *   `feature_flag_exposure_rollups` table (one row per flag/user/day/state)
+ *   so the readout keeps working without Analytics Engine access.
+ *
+ * `recordFeatureFlagExposures` never throws and never rejects: exposure
+ * recording must not break session loading or MCP request handling.
+ */
+
+import { measuredFeatureFlagKeys, type FeatureFlagKey } from './registry.ts'
+import { type FeatureFlagEvaluation } from './service.ts'
+
+export type FeatureFlagExposureEnv = {
+	FLAG_EXPOSURES?: AnalyticsEngineDataset
+	APP_DB?: D1Database
+}
+
+const exposureRollupUpsertStatement = `
+INSERT INTO feature_flag_exposure_rollups (
+	flag_key, user_id, day, enabled, source, exposure_count, updated_at
+) VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6)
+ON CONFLICT (flag_key, user_id, day, enabled, source) DO UPDATE SET
+	exposure_count = exposure_count + 1,
+	updated_at = excluded.updated_at
+`.trim()
+
+/**
+ * Record one exposure per measured flag in `evaluations` for the given
+ * stable user id. Flags without a registry `successMetric` are skipped, so
+ * request volume for unmeasured flags never reaches a sink.
+ */
+export async function recordFeatureFlagExposures(
+	env: FeatureFlagExposureEnv,
+	input: {
+		stableUserId: string
+		evaluations: Partial<Record<FeatureFlagKey, FeatureFlagEvaluation>>
+		timestamp?: string
+	},
+): Promise<void> {
+	try {
+		if (!input.stableUserId) return
+		const exposures = Object.entries(input.evaluations).filter(([key]) =>
+			measuredFeatureFlagKeys.has(key as FeatureFlagKey),
+		) as Array<[FeatureFlagKey, FeatureFlagEvaluation]>
+		if (exposures.length === 0) return
+		const timestamp = input.timestamp ?? new Date().toISOString()
+		if (env.FLAG_EXPOSURES) {
+			writeExposureDataPoints(env, input.stableUserId, exposures, timestamp)
+			return
+		}
+		await writeExposureRollups(env, input.stableUserId, exposures, timestamp)
+	} catch (error) {
+		console.warn('flag-exposure-record-failed', error)
+	}
+}
+
+function writeExposureDataPoints(
+	env: FeatureFlagExposureEnv,
+	stableUserId: string,
+	exposures: Array<[FeatureFlagKey, FeatureFlagEvaluation]>,
+	timestamp: string,
+) {
+	if (!env.FLAG_EXPOSURES) return
+	for (const [flagKey, evaluation] of exposures) {
+		try {
+			env.FLAG_EXPOSURES.writeDataPoint({
+				indexes: [stableUserId],
+				blobs: [
+					stableUserId,
+					flagKey,
+					evaluation.enabled ? 'on' : 'off',
+					evaluation.source,
+					timestamp,
+				],
+				doubles: [],
+			})
+		} catch (error) {
+			console.warn('flag-exposure-analytics-failed', error)
+		}
+	}
+}
+
+async function writeExposureRollups(
+	env: FeatureFlagExposureEnv,
+	stableUserId: string,
+	exposures: Array<[FeatureFlagKey, FeatureFlagEvaluation]>,
+	timestamp: string,
+) {
+	const db = env.APP_DB
+	if (!db) {
+		console.debug('flag-exposure-skipped', 'missing APP_DB binding')
+		return
+	}
+	try {
+		const day = timestamp.slice(0, 'YYYY-MM-DD'.length)
+		await db.batch(
+			exposures.map(([flagKey, evaluation]) =>
+				db
+					.prepare(exposureRollupUpsertStatement)
+					.bind(
+						flagKey,
+						stableUserId,
+						day,
+						evaluation.enabled ? 1 : 0,
+						evaluation.source,
+						timestamp,
+					),
+			),
+		)
+	} catch (error) {
+		console.warn('flag-exposure-rollup-failed', error)
+	}
+}

--- a/packages/worker/src/feature-flags/registry.ts
+++ b/packages/worker/src/feature-flags/registry.ts
@@ -4,12 +4,39 @@
  * runtime state (global toggles/rollouts and per-user overrides), not which
  * flags exist. Removing a key from this array leaves any leftover DB rows
  * visible as "stale" in the admin UI until an operator deletes them.
+ *
+ * Flags should declare a `successMetric`: the usage metric the flag is
+ * expected to move, reviewed in the same PR that creates the flag. Flags
+ * with one get exposure recording and an on/off cohort readout on the admin
+ * surfaces (see `docs/contributing/architecture/feature-flags.md`). The
+ * field stays optional for flags that are genuinely unmeasurable (such as
+ * the permanent `demo-indicator`), and the admin UI and MCP list surface a
+ * notice strongly recommending one everywhere else.
  */
+
+import { type UsageEventType } from '#worker/usage/event-types.ts'
+
+export type FeatureFlagSuccessMetricMeasure =
+	| 'event_count'
+	| 'error_rate'
+	| 'avg_duration_ms'
+
+export type FeatureFlagSuccessMetric = {
+	/** The metered usage event stream this flag is expected to move. */
+	eventType: UsageEventType
+	/** Which aggregate of that stream the flag is judged against. */
+	measure: FeatureFlagSuccessMetricMeasure
+	/** The direction the flag is supposed to push the measure. */
+	goal: 'increase' | 'decrease'
+	/** One human sentence stating the hypothesis behind the flag. */
+	hypothesis: string
+}
 
 export type FeatureFlagDefinition = {
 	key: string
 	description: string
 	defaultEnabled: boolean
+	successMetric?: FeatureFlagSuccessMetric
 }
 
 export const featureFlagDefinitions = [
@@ -18,12 +45,22 @@ export const featureFlagDefinitions = [
 		defaultEnabled: false,
 		description:
 			'Reserved for exercising the feature flag system end-to-end. When enabled it shows a small demo indicator in the app UI. Safe to toggle.',
+		// Intentionally no successMetric: this permanent flag exists to
+		// exercise the flag system itself (including the "no success metric"
+		// admin notice), not to move a product metric.
 	},
 	{
 		key: 'execute-pre-exec-typecheck',
 		defaultEnabled: false,
 		description:
 			'Runs the pre-execution TypeScript checker for ad hoc execute modules before sandbox execution. Keep off globally during rollout and enable with per-user overrides.',
+		successMetric: {
+			eventType: 'execute',
+			measure: 'error_rate',
+			goal: 'decrease',
+			hypothesis:
+				'Typechecking execute modules before sandbox execution should catch type errors early and lower the execute error rate.',
+		},
 	},
 ] as const satisfies ReadonlyArray<FeatureFlagDefinition>
 
@@ -41,6 +78,29 @@ const featureFlagDefinitionByKey = new Map<
 		definition as FeatureFlagDefinition,
 	]),
 )
+
+/**
+ * Registry flags that declare a success metric. Only these flags get
+ * exposure recording and admin metric readouts.
+ */
+export const measuredFeatureFlagDefinitions: ReadonlyArray<
+	FeatureFlagDefinition & { successMetric: FeatureFlagSuccessMetric }
+> = featureFlagDefinitions.flatMap((definition) =>
+	'successMetric' in definition ? [definition] : [],
+)
+
+export const measuredFeatureFlagKeys: ReadonlySet<FeatureFlagKey> = new Set(
+	measuredFeatureFlagDefinitions.map(
+		(definition) => definition.key as FeatureFlagKey,
+	),
+)
+
+/**
+ * Shared notice shown by the admin UI and the `admin_feature_flag_list`
+ * capability for registry flags that do not declare a success metric.
+ */
+export const missingSuccessMetricNotice =
+	'No success metric declared. Strongly recommended: add a successMetric to this flag in packages/worker/src/feature-flags/registry.ts so exposures are recorded and the on/off cohort readout can show whether the flag is moving the metric it exists for.'
 
 export function isFeatureFlagKey(value: string): value is FeatureFlagKey {
 	return featureFlagDefinitionByKey.has(value as FeatureFlagKey)

--- a/packages/worker/src/feature-flags/service.node.test.ts
+++ b/packages/worker/src/feature-flags/service.node.test.ts
@@ -3,6 +3,7 @@ import {
 	clearFeatureFlagUserOverride,
 	computeRolloutBucket,
 	deleteStaleFeatureFlag,
+	getFeatureFlagEvaluationsForUser,
 	getFeatureFlagsForUser,
 	isFeatureEnabled,
 	listFeatureFlagsForAdmin,
@@ -461,6 +462,54 @@ test('user override wins over global off and global on; clear restores evaluatio
 	).resolves.toBe(false)
 })
 
+test('getFeatureFlagEvaluationsForUser reports assignment sources', async () => {
+	const db = createFeatureFlagsTestDb()
+
+	await expect(getFeatureFlagEvaluationsForUser(db, 7)).resolves.toEqual({
+		'demo-indicator': { enabled: false, source: 'default' },
+		'execute-pre-exec-typecheck': { enabled: false, source: 'default' },
+	})
+
+	await setFeatureFlagGlobalState(db, {
+		key: 'demo-indicator',
+		enabled: true,
+		rolloutPercent: null,
+		updatedBy: 1,
+	})
+	await expect(getFeatureFlagEvaluationsForUser(db, 7)).resolves.toMatchObject({
+		'demo-indicator': { enabled: true, source: 'global' },
+	})
+
+	await setFeatureFlagGlobalState(db, {
+		key: 'demo-indicator',
+		enabled: true,
+		rolloutPercent: 50,
+		updatedBy: 1,
+	})
+	const evaluations = await getFeatureFlagEvaluationsForUser(db, 7)
+	expect(evaluations['demo-indicator'].source).toBe('rollout')
+	expect(evaluations['demo-indicator'].enabled).toBe(
+		computeRolloutBucket('demo-indicator', 7) < 50,
+	)
+	// Anonymous users are excluded from percentage rollouts but the
+	// assignment is still rollout-sourced.
+	await expect(
+		getFeatureFlagEvaluationsForUser(db, null),
+	).resolves.toMatchObject({
+		'demo-indicator': { enabled: false, source: 'rollout' },
+	})
+
+	await setFeatureFlagUserOverride(db, {
+		key: 'demo-indicator',
+		userId: 7,
+		enabled: false,
+		updatedBy: 1,
+	})
+	await expect(getFeatureFlagEvaluationsForUser(db, 7)).resolves.toMatchObject({
+		'demo-indicator': { enabled: false, source: 'override' },
+	})
+})
+
 test('listFeatureFlagsForAdmin includes registry flags and stale DB-only keys', async () => {
 	const db = createFeatureFlagsTestDb({
 		users: [
@@ -511,6 +560,7 @@ test('listFeatureFlagsForAdmin includes registry flags and stale DB-only keys', 
 		key: 'demo-indicator',
 		stale: false,
 		defaultEnabled: false,
+		successMetric: null,
 		global: {
 			enabled: true,
 			rolloutPercent: 25,
@@ -535,9 +585,17 @@ test('listFeatureFlagsForAdmin includes registry flags and stale DB-only keys', 
 		key: 'execute-pre-exec-typecheck',
 		stale: false,
 		defaultEnabled: false,
+		successMetric: {
+			eventType: 'execute',
+			measure: 'error_rate',
+			goal: 'decrease',
+		},
 		global: null,
 		overrides: [],
 	})
+	expect(executeTypecheck?.successMetric?.hypothesis).toEqual(
+		expect.any(String),
+	)
 
 	const retired = listed.find((flag) => flag.key === 'retired-flag')
 	expect(retired).toEqual({
@@ -545,6 +603,7 @@ test('listFeatureFlagsForAdmin includes registry flags and stale DB-only keys', 
 		description: null,
 		defaultEnabled: null,
 		stale: true,
+		successMetric: null,
 		global: {
 			enabled: false,
 			rolloutPercent: null,
@@ -561,6 +620,7 @@ test('listFeatureFlagsForAdmin includes registry flags and stale DB-only keys', 
 		description: null,
 		defaultEnabled: null,
 		stale: true,
+		successMetric: null,
 		global: null,
 		overrides: [
 			{

--- a/packages/worker/src/feature-flags/service.ts
+++ b/packages/worker/src/feature-flags/service.ts
@@ -42,26 +42,47 @@ export function computeRolloutBucket(key: string, userId: number): number {
 	return fnv1a32(`${key}:${userId}`) % 100
 }
 
+/**
+ * How a flag's evaluated value was assigned. Recorded with success-metric
+ * exposures so readouts can compare only fairly assigned cohorts: `override`
+ * users are hand-picked (selection bias) and are excluded from on/off
+ * comparisons, while `rollout` users are deterministically bucketed.
+ */
+export type FeatureFlagAssignmentSource =
+	| 'override'
+	| 'global'
+	| 'rollout'
+	| 'default'
+
+export type FeatureFlagEvaluation = {
+	enabled: boolean
+	source: FeatureFlagAssignmentSource
+}
+
 function evaluateFlagState(input: {
 	key: string
 	userId: number | null
 	overrideEnabled: boolean | null
 	global: { enabled: boolean; rolloutPercent: number | null } | null
 	defaultEnabled: boolean
-}): boolean {
+}): FeatureFlagEvaluation {
 	if (input.overrideEnabled !== null) {
-		return input.overrideEnabled
+		return { enabled: input.overrideEnabled, source: 'override' }
 	}
 	if (input.global) {
-		if (!input.global.enabled) return false
-		if (input.global.rolloutPercent === null) return true
-		if (input.userId === null) return false
-		return (
-			computeRolloutBucket(input.key, input.userId) <
-			input.global.rolloutPercent
-		)
+		if (!input.global.enabled) return { enabled: false, source: 'global' }
+		if (input.global.rolloutPercent === null) {
+			return { enabled: true, source: 'global' }
+		}
+		if (input.userId === null) return { enabled: false, source: 'rollout' }
+		return {
+			enabled:
+				computeRolloutBucket(input.key, input.userId) <
+				input.global.rolloutPercent,
+			source: 'rollout',
+		}
 	}
-	return input.defaultEnabled
+	return { enabled: input.defaultEnabled, source: 'default' }
 }
 
 function assertValidRolloutPercent(rolloutPercent: number | null) {
@@ -130,13 +151,13 @@ export async function isFeatureEnabled(
 				}
 			: null,
 		defaultEnabled: getFeatureFlagDefinition(key).defaultEnabled,
-	})
+	}).enabled
 }
 
-export async function getFeatureFlagsForUser(
+export async function getFeatureFlagEvaluationsForUser(
 	db: D1Database,
 	userId: number | null,
-): Promise<Record<FeatureFlagKey, boolean>> {
+): Promise<Record<FeatureFlagKey, FeatureFlagEvaluation>> {
 	const globalResult = await db
 		.prepare(
 			`SELECT key, enabled, rollout_percent
@@ -162,13 +183,13 @@ export async function getFeatureFlagsForUser(
 		}
 	}
 
-	const flags = {} as Record<FeatureFlagKey, boolean>
+	const evaluations = {} as Record<FeatureFlagKey, FeatureFlagEvaluation>
 	for (const key of featureFlagKeys) {
 		const global = globalByKey.get(key)
 		const overrideEnabled = overrideByKey.has(key)
 			? (overrideByKey.get(key) ?? false)
 			: null
-		flags[key] = evaluateFlagState({
+		evaluations[key] = evaluateFlagState({
 			key,
 			userId,
 			overrideEnabled,
@@ -180,6 +201,18 @@ export async function getFeatureFlagsForUser(
 				: null,
 			defaultEnabled: getFeatureFlagDefinition(key).defaultEnabled,
 		})
+	}
+	return evaluations
+}
+
+export async function getFeatureFlagsForUser(
+	db: D1Database,
+	userId: number | null,
+): Promise<Record<FeatureFlagKey, boolean>> {
+	const evaluations = await getFeatureFlagEvaluationsForUser(db, userId)
+	const flags = {} as Record<FeatureFlagKey, boolean>
+	for (const key of featureFlagKeys) {
+		flags[key] = evaluations[key].enabled
 	}
 	return flags
 }
@@ -306,6 +339,8 @@ export async function listFeatureFlagsForAdmin(
 			description: definition.description,
 			defaultEnabled: definition.defaultEnabled,
 			stale: false,
+			successMetric:
+				'successMetric' in definition ? definition.successMetric : null,
 			global: global
 				? {
 						enabled: global.enabled === 1,
@@ -334,6 +369,7 @@ export async function listFeatureFlagsForAdmin(
 			description: null,
 			defaultEnabled: null,
 			stale: true,
+			successMetric: null,
 			global: global
 				? {
 						enabled: global.enabled === 1,

--- a/packages/worker/src/feature-flags/success-metric-readout.node.test.ts
+++ b/packages/worker/src/feature-flags/success-metric-readout.node.test.ts
@@ -1,0 +1,247 @@
+import { expect, test, vi } from 'vitest'
+import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
+import { type FeatureFlagSuccessMetric } from './registry.ts'
+import {
+	attachFeatureFlagMetricReadouts,
+	loadFeatureFlagSuccessMetricReadout,
+	resolveFlagExposuresDataset,
+} from './success-metric-readout.ts'
+import { type AdminFeatureFlag } from './types.ts'
+
+const successMetric: FeatureFlagSuccessMetric = {
+	eventType: 'execute',
+	measure: 'error_rate',
+	goal: 'decrease',
+	hypothesis: 'Fewer execute errors.',
+}
+
+const now = new Date('2026-07-15T12:00:00.000Z')
+
+type ExposureRow = { user_id: string; enabled: number; source: string }
+type UsageRow = {
+	user_id: string
+	event_count: number
+	error_count: number
+	total_duration_ms: number
+}
+
+function createReadoutTestDb(input: {
+	exposures: Array<ExposureRow>
+	usage: Array<UsageRow>
+}) {
+	const queries: Array<{ query: string; params: Array<unknown> }> = []
+	const db = {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async all() {
+							queries.push({ query, params })
+							if (query.includes('feature_flag_exposure_rollups')) {
+								return { results: input.exposures }
+							}
+							if (query.includes('usage_rollups')) {
+								return { results: input.usage }
+							}
+							throw new Error(`Unsupported query: ${query}`)
+						},
+					}
+				},
+			}
+		},
+	}
+	return { db: db as unknown as D1Database, queries }
+}
+
+test('D1 readout splits cohorts and excludes override and mixed users', async () => {
+	const { db, queries } = createReadoutTestDb({
+		exposures: [
+			{ user_id: 'user-on', enabled: 1, source: 'rollout' },
+			{ user_id: 'user-on-quiet', enabled: 1, source: 'rollout' },
+			{ user_id: 'user-off', enabled: 0, source: 'rollout' },
+			{ user_id: 'user-override', enabled: 1, source: 'override' },
+			{ user_id: 'user-mixed', enabled: 1, source: 'rollout' },
+			{ user_id: 'user-mixed', enabled: 0, source: 'rollout' },
+		],
+		usage: [
+			{
+				user_id: 'user-on',
+				event_count: 10,
+				error_count: 2,
+				total_duration_ms: 1000,
+			},
+			{
+				user_id: 'user-off',
+				event_count: 8,
+				error_count: 4,
+				total_duration_ms: 400,
+			},
+			{
+				user_id: 'user-override',
+				event_count: 100,
+				error_count: 0,
+				total_duration_ms: 0,
+			},
+			{
+				user_id: 'user-unexposed',
+				event_count: 50,
+				error_count: 50,
+				total_duration_ms: 0,
+			},
+		],
+	})
+
+	const readout = await loadFeatureFlagSuccessMetricReadout(
+		{ APP_DB: db },
+		{ flagKey: 'execute-pre-exec-typecheck', successMetric },
+		now,
+	)
+
+	expect(readout).toEqual({
+		status: 'ok',
+		windowStart: '2026-07-01T00:00:00.000Z',
+		windowEnd: '2026-07-15T12:00:00.000Z',
+		on: {
+			users: 2,
+			eventCount: 10,
+			errorCount: 2,
+			errorRate: 0.2,
+			avgDurationMs: 100,
+		},
+		off: {
+			users: 1,
+			eventCount: 8,
+			errorCount: 4,
+			errorRate: 0.5,
+			avgDurationMs: 50,
+		},
+		overrideUsers: 1,
+		mixedUsers: 1,
+	})
+	expect(queries[0]?.params).toEqual([
+		'execute-pre-exec-typecheck',
+		'2026-07-01',
+	])
+	expect(queries[1]?.params).toEqual(['execute', '2026-07'])
+})
+
+test('Analytics Engine readout queries both datasets and joins by user', async () => {
+	const fetchMock = vi.fn(async (_url: unknown, init: unknown) => {
+		const query = String((init as { body: string }).body)
+		if (query.includes('kody_flag_exposures')) {
+			expect(query).toContain("blob2 = 'execute-pre-exec-typecheck'")
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							user_id: 'user-on',
+							on_count: 3,
+							off_count: 0,
+							override_count: 0,
+						},
+						{
+							user_id: 'user-off',
+							on_count: 0,
+							off_count: 2,
+							override_count: 0,
+						},
+						{
+							user_id: 'user-override',
+							on_count: 1,
+							off_count: 0,
+							override_count: 4,
+						},
+					],
+				}),
+			)
+		}
+		expect(query).toContain('kody_usage_events')
+		expect(query).toContain("blob2 = 'execute'")
+		return new Response(
+			JSON.stringify({
+				data: [
+					{
+						user_id: 'user-on',
+						event_count: 4,
+						error_count: 1,
+						total_duration_ms: 800,
+					},
+					{
+						user_id: 'user-off',
+						event_count: 5,
+						error_count: 5,
+						total_duration_ms: 500,
+					},
+				],
+			}),
+		)
+	})
+	vi.stubGlobal('fetch', fetchMock)
+	try {
+		const readout = await loadFeatureFlagSuccessMetricReadout(
+			{
+				APP_DB: {} as D1Database,
+				FLAG_EXPOSURES: {} as AnalyticsEngineDataset,
+				CLOUDFLARE_ACCOUNT_ID: 'account',
+				CLOUDFLARE_API_TOKEN: 'token',
+			},
+			{ flagKey: 'execute-pre-exec-typecheck', successMetric },
+			now,
+		)
+
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(readout).toMatchObject({
+			status: 'ok',
+			on: { users: 1, eventCount: 4, errorCount: 1, errorRate: 0.25 },
+			off: { users: 1, eventCount: 5, errorCount: 5, errorRate: 1 },
+			overrideUsers: 1,
+			mixedUsers: 0,
+		})
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('degrades to unavailable when the data source fails', async () => {
+	silenceExpectedConsoleWarns(['flag-metric-readout-failed'])
+	const db = {
+		prepare() {
+			throw new Error('d1 down')
+		},
+	} as unknown as D1Database
+	const readout = await loadFeatureFlagSuccessMetricReadout(
+		{ APP_DB: db },
+		{ flagKey: 'execute-pre-exec-typecheck', successMetric },
+		now,
+	)
+	expect(readout).toEqual({
+		status: 'unavailable',
+		reason: expect.stringContaining('readout query failed'),
+	})
+})
+
+test('attachFeatureFlagMetricReadouts only decorates measured registry flags', async () => {
+	const { db } = createReadoutTestDb({ exposures: [], usage: [] })
+	const flags = [
+		{
+			key: 'execute-pre-exec-typecheck',
+			stale: false,
+			successMetric,
+		},
+		{ key: 'demo-indicator', stale: false, successMetric: null },
+		{ key: 'retired-flag', stale: true, successMetric: null },
+	] as Array<AdminFeatureFlag>
+
+	await attachFeatureFlagMetricReadouts({ APP_DB: db }, flags, now)
+
+	expect(flags[0]?.metricReadout).toMatchObject({ status: 'ok' })
+	expect(flags[1]?.metricReadout).toBeUndefined()
+	expect(flags[2]?.metricReadout).toBeUndefined()
+})
+
+test('resolveFlagExposuresDataset picks the preview dataset in preview', () => {
+	expect(resolveFlagExposuresDataset({})).toBe('kody_flag_exposures')
+	expect(resolveFlagExposuresDataset({ SENTRY_ENVIRONMENT: 'preview' })).toBe(
+		'kody_flag_exposures_preview',
+	)
+})

--- a/packages/worker/src/feature-flags/success-metric-readout.node.test.ts
+++ b/packages/worker/src/feature-flags/success-metric-readout.node.test.ts
@@ -121,6 +121,7 @@ test('D1 readout splits cohorts and excludes override and mixed users', async ()
 	expect(queries[0]?.params).toEqual([
 		'execute-pre-exec-typecheck',
 		'2026-07-01',
+		'2026-07-15',
 	])
 	expect(queries[1]?.params).toEqual(['execute', '2026-07'])
 })

--- a/packages/worker/src/feature-flags/success-metric-readout.node.test.ts
+++ b/packages/worker/src/feature-flags/success-metric-readout.node.test.ts
@@ -202,6 +202,23 @@ test('Analytics Engine readout queries both datasets and joins by user', async (
 	}
 })
 
+test('uses the D1 path in local Wrangler dev even with binding and credentials', async () => {
+	const { db, queries } = createReadoutTestDb({ exposures: [], usage: [] })
+	const readout = await loadFeatureFlagSuccessMetricReadout(
+		{
+			APP_DB: db,
+			FLAG_EXPOSURES: {} as AnalyticsEngineDataset,
+			CLOUDFLARE_ACCOUNT_ID: 'account',
+			CLOUDFLARE_API_TOKEN: 'token',
+			WRANGLER_IS_LOCAL_DEV: 'true',
+		},
+		{ flagKey: 'execute-pre-exec-typecheck', successMetric },
+		now,
+	)
+	expect(readout).toMatchObject({ status: 'ok' })
+	expect(queries).toHaveLength(2)
+})
+
 test('degrades to unavailable when the data source fails', async () => {
 	silenceExpectedConsoleWarns(['flag-metric-readout-failed'])
 	const db = {

--- a/packages/worker/src/feature-flags/success-metric-readout.node.test.ts
+++ b/packages/worker/src/feature-flags/success-metric-readout.node.test.ts
@@ -219,6 +219,22 @@ test('uses the D1 path in local Wrangler dev even with binding and credentials',
 	expect(queries).toHaveLength(2)
 })
 
+test('reports unavailable when the binding exists but SQL credentials are missing', async () => {
+	// Falling back to the empty D1 tables here would present confident zero
+	// cohorts even though exposures were written to Analytics Engine.
+	const { db, queries } = createReadoutTestDb({ exposures: [], usage: [] })
+	const readout = await loadFeatureFlagSuccessMetricReadout(
+		{ APP_DB: db, FLAG_EXPOSURES: {} as AnalyticsEngineDataset },
+		{ flagKey: 'execute-pre-exec-typecheck', successMetric },
+		now,
+	)
+	expect(readout).toEqual({
+		status: 'unavailable',
+		reason: expect.stringContaining('credentials'),
+	})
+	expect(queries).toHaveLength(0)
+})
+
 test('degrades to unavailable when the data source fails', async () => {
 	silenceExpectedConsoleWarns(['flag-metric-readout-failed'])
 	const db = {

--- a/packages/worker/src/feature-flags/success-metric-readout.ts
+++ b/packages/worker/src/feature-flags/success-metric-readout.ts
@@ -277,14 +277,17 @@ async function loadReadoutFromD1(input: {
 	now: Date
 }): Promise<AdminFeatureFlagMetricReadout> {
 	const window = utcMonthWindow(input.now)
+	// The upper bound mirrors the Analytics Engine path: rows stamped after
+	// the window end (clock skew, backdated writes) must not join the cohorts.
+	const windowEndDay = window.windowEnd.slice(0, 'YYYY-MM-DD'.length)
 	const exposureResult = await input.db
 		.prepare(
 			`SELECT user_id, enabled, source
 			 FROM feature_flag_exposure_rollups
-			 WHERE flag_key = ? AND day >= ?
+			 WHERE flag_key = ? AND day >= ? AND day <= ?
 			 GROUP BY user_id, enabled, source`,
 		)
-		.bind(input.flagKey, window.monthStartDay)
+		.bind(input.flagKey, window.monthStartDay, windowEndDay)
 		.all<D1ExposureRow>()
 	const exposuresByUser = new Map<string, UserExposureState>()
 	for (const row of exposureResult.results ?? []) {

--- a/packages/worker/src/feature-flags/success-metric-readout.ts
+++ b/packages/worker/src/feature-flags/success-metric-readout.ts
@@ -41,6 +41,7 @@ export type FeatureFlagReadoutEnv = {
 	CLOUDFLARE_API_TOKEN?: string
 	CLOUDFLARE_API_BASE_URL?: string
 	SENTRY_ENVIRONMENT?: string
+	WRANGLER_IS_LOCAL_DEV?: string
 }
 
 /**
@@ -329,7 +330,15 @@ export async function loadFeatureFlagSuccessMetricReadout(
 	try {
 		const accountId = env.CLOUDFLARE_ACCOUNT_ID?.trim()
 		const apiToken = env.CLOUDFLARE_API_TOKEN?.trim()
-		if (env.FLAG_EXPOSURES && accountId && apiToken) {
+		// Local Wrangler dev emulates the Analytics Engine binding and the CLI
+		// injects mock REST credentials, but the SQL API cannot read locally
+		// emulated datasets — exposures are written to D1 there instead.
+		if (
+			env.FLAG_EXPOSURES &&
+			accountId &&
+			apiToken &&
+			env.WRANGLER_IS_LOCAL_DEV !== 'true'
+		) {
 			return await loadReadoutFromAnalyticsEngine({
 				env,
 				accountId,

--- a/packages/worker/src/feature-flags/success-metric-readout.ts
+++ b/packages/worker/src/feature-flags/success-metric-readout.ts
@@ -1,0 +1,380 @@
+/**
+ * Feature-flag success-metric readout.
+ *
+ * Answers "is this flag moving its declared metric?" by joining recorded
+ * flag exposures (see `exposure.ts`) with the usage-metering event stream
+ * over the current UTC month to date, split by exposure cohort:
+ *
+ * - Users with any `override`-sourced exposure are excluded from the
+ *   comparison (hand-picked users are selection-biased) and reported as
+ *   `overrideUsers`.
+ * - Users who saw both values inside the window are excluded as
+ *   `mixedUsers`.
+ * - Everyone else lands in the `on` or `off` cohort, and their usage events
+ *   for the declared `eventType` are aggregated per cohort.
+ *
+ * Like usage rollups, the data source depends on the environment: with the
+ * Analytics Engine bindings and Cloudflare REST credentials
+ * (production/preview) both sides come from Analytics Engine SQL queries;
+ * otherwise (local dev, tests) the D1 fallback tables
+ * (`feature_flag_exposure_rollups`, `usage_rollups`) are used. Readout
+ * failures degrade to `{ status: 'unavailable' }` — the admin surfaces must
+ * render even when the analytics backend is down.
+ */
+
+import {
+	queryAnalyticsEngineSql,
+	resolveUsageEventsDataset,
+} from '#worker/usage/aggregate-rollups.ts'
+import { type FeatureFlagSuccessMetric } from './registry.ts'
+import {
+	type AdminFeatureFlag,
+	type AdminFeatureFlagMetricReadout,
+	type FeatureFlagMetricCohort,
+} from './types.ts'
+
+export type FeatureFlagReadoutEnv = {
+	APP_DB: D1Database
+	FLAG_EXPOSURES?: AnalyticsEngineDataset
+	USAGE_EVENTS?: AnalyticsEngineDataset
+	CLOUDFLARE_ACCOUNT_ID?: string
+	CLOUDFLARE_API_TOKEN?: string
+	CLOUDFLARE_API_BASE_URL?: string
+	SENTRY_ENVIRONMENT?: string
+}
+
+/**
+ * The Analytics Engine SQL API dataset (= table name) written by the
+ * `FLAG_EXPOSURES` binding; see `packages/worker/wrangler.jsonc`.
+ */
+export function resolveFlagExposuresDataset(env: {
+	SENTRY_ENVIRONMENT?: string
+}) {
+	return env.SENTRY_ENVIRONMENT === 'preview'
+		? 'kody_flag_exposures_preview'
+		: 'kody_flag_exposures'
+}
+
+type UserExposureState = {
+	sawOn: boolean
+	sawOff: boolean
+	sawOverride: boolean
+}
+
+type UserUsageAggregate = {
+	eventCount: number
+	errorCount: number
+	totalDurationMs: number
+}
+
+function toCount(value: number | string | null | undefined) {
+	const parsed = Number(value ?? 0)
+	return Number.isFinite(parsed) ? Math.round(parsed) : 0
+}
+
+function emptyCohort(): FeatureFlagMetricCohort {
+	return {
+		users: 0,
+		eventCount: 0,
+		errorCount: 0,
+		errorRate: null,
+		avgDurationMs: null,
+	}
+}
+
+function finalizeCohort(cohort: FeatureFlagMetricCohort, durationMs: number) {
+	cohort.errorRate =
+		cohort.eventCount > 0 ? cohort.errorCount / cohort.eventCount : null
+	cohort.avgDurationMs =
+		cohort.eventCount > 0 ? durationMs / cohort.eventCount : null
+}
+
+function buildReadout(input: {
+	exposuresByUser: Map<string, UserExposureState>
+	usageByUser: Map<string, UserUsageAggregate>
+	windowStart: string
+	windowEnd: string
+}): AdminFeatureFlagMetricReadout {
+	const on = emptyCohort()
+	const off = emptyCohort()
+	let overrideUsers = 0
+	let mixedUsers = 0
+	const totals = { on: { durationMs: 0 }, off: { durationMs: 0 } }
+	for (const [userId, state] of input.exposuresByUser) {
+		if (state.sawOverride) {
+			overrideUsers += 1
+			continue
+		}
+		if (state.sawOn && state.sawOff) {
+			mixedUsers += 1
+			continue
+		}
+		if (!state.sawOn && !state.sawOff) continue
+		const cohort = state.sawOn ? on : off
+		const totalsSide = state.sawOn ? totals.on : totals.off
+		cohort.users += 1
+		const usage = input.usageByUser.get(userId)
+		if (usage) {
+			cohort.eventCount += usage.eventCount
+			cohort.errorCount += usage.errorCount
+			totalsSide.durationMs += usage.totalDurationMs
+		}
+	}
+	finalizeCohort(on, totals.on.durationMs)
+	finalizeCohort(off, totals.off.durationMs)
+	return {
+		status: 'ok',
+		windowStart: input.windowStart,
+		windowEnd: input.windowEnd,
+		on,
+		off,
+		overrideUsers,
+		mixedUsers,
+	}
+}
+
+function utcMonthWindow(now: Date) {
+	const monthStart = new Date(
+		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+	)
+	return {
+		windowStart: monthStart.toISOString(),
+		windowEnd: now.toISOString(),
+		monthStartDay: monthStart.toISOString().slice(0, 'YYYY-MM-DD'.length),
+		month: monthStart.toISOString().slice(0, 'YYYY-MM'.length),
+	}
+}
+
+/**
+ * Registry flag keys and usage event types are code-owned kebab/snake-case
+ * identifiers, but they are interpolated into Analytics Engine SQL (which
+ * has no parameter binding), so reject anything that could break out of a
+ * string literal.
+ */
+function assertSqlSafeIdentifier(value: string) {
+	if (!/^[a-z0-9_-]+$/.test(value)) {
+		throw new Error(`Unsafe identifier for Analytics Engine SQL: ${value}`)
+	}
+	return value
+}
+
+function toDateTimeArgument(iso: string) {
+	return `${iso.slice(0, 'YYYY-MM-DD'.length)} 00:00:00`
+}
+
+type AnalyticsExposureRow = {
+	user_id: string
+	on_count: number | string
+	off_count: number | string
+	override_count: number | string
+}
+
+type AnalyticsUsageRow = {
+	user_id: string
+	event_count: number | string
+	error_count: number | string
+	total_duration_ms: number | string
+}
+
+async function loadReadoutFromAnalyticsEngine(input: {
+	env: FeatureFlagReadoutEnv
+	accountId: string
+	apiToken: string
+	flagKey: string
+	successMetric: FeatureFlagSuccessMetric
+	now: Date
+}): Promise<AdminFeatureFlagMetricReadout> {
+	const window = utcMonthWindow(input.now)
+	const baseUrl =
+		input.env.CLOUDFLARE_API_BASE_URL?.trim() || 'https://api.cloudflare.com'
+	// The window upper bound is exclusive at the *next day* boundary so both
+	// datasets see the same time filter shape as the usage aggregation cron;
+	// month-to-date plus today is exactly what the readout wants.
+	const nextDay = new Date(input.now.getTime() + 24 * 60 * 60 * 1000)
+	const timeFilter = `timestamp >= toDateTime('${toDateTimeArgument(window.windowStart)}') AND timestamp < toDateTime('${toDateTimeArgument(nextDay.toISOString())}')`
+	const exposuresQuery = `
+SELECT
+	blob1 AS user_id,
+	sum(if(blob3 = 'on' AND blob4 != 'override', _sample_interval, 0)) AS on_count,
+	sum(if(blob3 = 'off' AND blob4 != 'override', _sample_interval, 0)) AS off_count,
+	sum(if(blob4 = 'override', _sample_interval, 0)) AS override_count
+FROM ${resolveFlagExposuresDataset(input.env)}
+WHERE ${timeFilter}
+	AND blob2 = '${assertSqlSafeIdentifier(input.flagKey)}'
+GROUP BY blob1
+FORMAT JSON
+`.trim()
+	const usageQuery = `
+SELECT
+	blob1 AS user_id,
+	sum(_sample_interval) AS event_count,
+	sum(if(blob4 = 'error', _sample_interval, 0)) AS error_count,
+	sum(double1 * _sample_interval) AS total_duration_ms
+FROM ${resolveUsageEventsDataset(input.env)}
+WHERE ${timeFilter}
+	AND blob2 = '${assertSqlSafeIdentifier(input.successMetric.eventType)}'
+GROUP BY blob1
+FORMAT JSON
+`.trim()
+	const [exposureRows, usageRows] = await Promise.all([
+		queryAnalyticsEngineSql<AnalyticsExposureRow>({
+			accountId: input.accountId,
+			apiToken: input.apiToken,
+			baseUrl,
+			query: exposuresQuery,
+		}),
+		queryAnalyticsEngineSql<AnalyticsUsageRow>({
+			accountId: input.accountId,
+			apiToken: input.apiToken,
+			baseUrl,
+			query: usageQuery,
+		}),
+	])
+	const exposuresByUser = new Map<string, UserExposureState>()
+	for (const row of exposureRows) {
+		if (!row.user_id) continue
+		exposuresByUser.set(row.user_id, {
+			sawOn: toCount(row.on_count) > 0,
+			sawOff: toCount(row.off_count) > 0,
+			sawOverride: toCount(row.override_count) > 0,
+		})
+	}
+	const usageByUser = new Map<string, UserUsageAggregate>()
+	for (const row of usageRows) {
+		if (!row.user_id) continue
+		usageByUser.set(row.user_id, {
+			eventCount: toCount(row.event_count),
+			errorCount: toCount(row.error_count),
+			totalDurationMs: toCount(row.total_duration_ms),
+		})
+	}
+	return buildReadout({
+		exposuresByUser,
+		usageByUser,
+		windowStart: window.windowStart,
+		windowEnd: window.windowEnd,
+	})
+}
+
+type D1ExposureRow = {
+	user_id: string
+	enabled: number
+	source: string
+}
+
+type D1UsageRow = {
+	user_id: string
+	event_count: number
+	error_count: number
+	total_duration_ms: number
+}
+
+async function loadReadoutFromD1(input: {
+	db: D1Database
+	flagKey: string
+	successMetric: FeatureFlagSuccessMetric
+	now: Date
+}): Promise<AdminFeatureFlagMetricReadout> {
+	const window = utcMonthWindow(input.now)
+	const exposureResult = await input.db
+		.prepare(
+			`SELECT user_id, enabled, source
+			 FROM feature_flag_exposure_rollups
+			 WHERE flag_key = ? AND day >= ?
+			 GROUP BY user_id, enabled, source`,
+		)
+		.bind(input.flagKey, window.monthStartDay)
+		.all<D1ExposureRow>()
+	const exposuresByUser = new Map<string, UserExposureState>()
+	for (const row of exposureResult.results ?? []) {
+		const state = exposuresByUser.get(row.user_id) ?? {
+			sawOn: false,
+			sawOff: false,
+			sawOverride: false,
+		}
+		if (row.source === 'override') state.sawOverride = true
+		else if (row.enabled === 1) state.sawOn = true
+		else state.sawOff = true
+		exposuresByUser.set(row.user_id, state)
+	}
+	const usageResult = await input.db
+		.prepare(
+			`SELECT user_id, event_count, error_count, total_duration_ms
+			 FROM usage_rollups
+			 WHERE metric = ? AND month = ?`,
+		)
+		.bind(input.successMetric.eventType, window.month)
+		.all<D1UsageRow>()
+	const usageByUser = new Map<string, UserUsageAggregate>()
+	for (const row of usageResult.results ?? []) {
+		usageByUser.set(row.user_id, {
+			eventCount: toCount(row.event_count),
+			errorCount: toCount(row.error_count),
+			totalDurationMs: toCount(row.total_duration_ms),
+		})
+	}
+	return buildReadout({
+		exposuresByUser,
+		usageByUser,
+		windowStart: window.windowStart,
+		windowEnd: window.windowEnd,
+	})
+}
+
+export async function loadFeatureFlagSuccessMetricReadout(
+	env: FeatureFlagReadoutEnv,
+	input: { flagKey: string; successMetric: FeatureFlagSuccessMetric },
+	now: Date = new Date(),
+): Promise<AdminFeatureFlagMetricReadout> {
+	try {
+		const accountId = env.CLOUDFLARE_ACCOUNT_ID?.trim()
+		const apiToken = env.CLOUDFLARE_API_TOKEN?.trim()
+		if (env.FLAG_EXPOSURES && accountId && apiToken) {
+			return await loadReadoutFromAnalyticsEngine({
+				env,
+				accountId,
+				apiToken,
+				flagKey: input.flagKey,
+				successMetric: input.successMetric,
+				now,
+			})
+		}
+		return await loadReadoutFromD1({
+			db: env.APP_DB,
+			flagKey: input.flagKey,
+			successMetric: input.successMetric,
+			now,
+		})
+	} catch (error) {
+		console.warn('flag-metric-readout-failed', input.flagKey, error)
+		return {
+			status: 'unavailable',
+			reason:
+				'Metric readout query failed; exposure or usage data could not be loaded.',
+		}
+	}
+}
+
+/**
+ * Attach a metric readout to every non-stale flag that declares a success
+ * metric. Mutates and returns the given array; flags without a metric are
+ * left untouched (the admin surfaces render the strong recommendation notice
+ * for those instead).
+ */
+export async function attachFeatureFlagMetricReadouts(
+	env: FeatureFlagReadoutEnv,
+	flags: Array<AdminFeatureFlag>,
+	now: Date = new Date(),
+): Promise<Array<AdminFeatureFlag>> {
+	await Promise.all(
+		flags.map(async (flag) => {
+			if (flag.stale || !flag.successMetric) return
+			flag.metricReadout = await loadFeatureFlagSuccessMetricReadout(
+				env,
+				{ flagKey: flag.key, successMetric: flag.successMetric },
+				now,
+			)
+		}),
+	)
+	return flags
+}

--- a/packages/worker/src/feature-flags/success-metric-readout.ts
+++ b/packages/worker/src/feature-flags/success-metric-readout.ts
@@ -333,12 +333,17 @@ export async function loadFeatureFlagSuccessMetricReadout(
 		// Local Wrangler dev emulates the Analytics Engine binding and the CLI
 		// injects mock REST credentials, but the SQL API cannot read locally
 		// emulated datasets — exposures are written to D1 there instead.
-		if (
-			env.FLAG_EXPOSURES &&
-			accountId &&
-			apiToken &&
-			env.WRANGLER_IS_LOCAL_DEV !== 'true'
-		) {
+		if (env.FLAG_EXPOSURES && env.WRANGLER_IS_LOCAL_DEV !== 'true') {
+			if (!accountId || !apiToken) {
+				// With the binding present, exposures were written only to
+				// Analytics Engine; falling back to the (empty) D1 tables would
+				// present confident zero cohorts instead of a config problem.
+				return {
+					status: 'unavailable',
+					reason:
+						'Analytics Engine SQL credentials (CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN) are not configured, so recorded exposures cannot be read.',
+				}
+			}
 			return await loadReadoutFromAnalyticsEngine({
 				env,
 				accountId,

--- a/packages/worker/src/feature-flags/types.ts
+++ b/packages/worker/src/feature-flags/types.ts
@@ -1,13 +1,49 @@
 /**
- * Shared admin feature-flag shape used by the worker service and client
+ * Shared admin feature-flag shapes used by the worker service and client
  * loader/route types. Kept dependency-free so the client tsconfig can include
  * it without pulling in D1-typed modules.
  */
+
+import { type FeatureFlagSuccessMetric } from './registry.ts'
+
+/**
+ * One exposure cohort's aggregates over the flag's declared usage metric.
+ * `errorRate` and `avgDurationMs` are null when the cohort has no events.
+ */
+export type FeatureFlagMetricCohort = {
+	users: number
+	eventCount: number
+	errorCount: number
+	errorRate: number | null
+	avgDurationMs: number | null
+}
+
+/**
+ * On/off cohort comparison for a flag's declared success metric, computed
+ * from recorded exposures joined with usage events over the current UTC
+ * month to date. `overrideUsers` (hand-picked, selection-biased) and
+ * `mixedUsers` (saw both values inside the window) are excluded from the
+ * cohorts and reported separately.
+ */
+export type AdminFeatureFlagMetricReadout =
+	| { status: 'unavailable'; reason: string }
+	| {
+			status: 'ok'
+			windowStart: string
+			windowEnd: string
+			on: FeatureFlagMetricCohort
+			off: FeatureFlagMetricCohort
+			overrideUsers: number
+			mixedUsers: number
+	  }
+
 export type AdminFeatureFlag = {
 	key: string
 	description: string | null
 	defaultEnabled: boolean | null
 	stale: boolean
+	successMetric: FeatureFlagSuccessMetric | null
+	metricReadout?: AdminFeatureFlagMetricReadout
 	global: {
 		enabled: boolean
 		rolloutPercent: number | null

--- a/packages/worker/src/mcp/capabilities/access-control.ts
+++ b/packages/worker/src/mcp/capabilities/access-control.ts
@@ -5,11 +5,12 @@ import {
 	userHasPermission,
 	userHasRole,
 } from '#worker/identity/permissions.ts'
+import { recordFeatureFlagExposures } from '#worker/feature-flags/exposure.ts'
 import {
 	type FeatureFlagKey,
 	featureFlagKeys,
 } from '#worker/feature-flags/registry.ts'
-import { getFeatureFlagsForUser } from '#worker/feature-flags/service.ts'
+import { getFeatureFlagEvaluationsForUser } from '#worker/feature-flags/service.ts'
 import { normalizeStableUserId } from '#worker/user-id.ts'
 import {
 	type McpAuthDenialReason,
@@ -56,11 +57,8 @@ function disabledFeatureFlags(): CallerFeatureFlags {
 
 async function resolveFeatureFlagUserId(
 	db: D1Database,
-	callerContext: McpCallerContext,
+	stableUserId: string,
 ): Promise<number | null> {
-	const user = callerContext.user
-	const stableUserId = normalizeStableUserId(user?.userId)
-	if (!stableUserId) return null
 	const row = await db
 		.prepare(`SELECT id FROM users WHERE stable_user_id = ?`)
 		.bind(stableUserId)
@@ -71,6 +69,9 @@ async function resolveFeatureFlagUserId(
 /**
  * Resolve the caller's evaluated feature-flag map once per request. Used by
  * registry filtering (search/list) so access checks stay synchronous.
+ * Evaluation also records success-metric exposures for measured flags (see
+ * `#worker/feature-flags/exposure.ts`) so MCP-only users are represented in
+ * admin metric readouts.
  *
  * Fail-closed rules: anonymous callers and authenticated callers whose stable
  * id cannot be resolved to a `users.id` get every flag off, so gated
@@ -84,9 +85,18 @@ export async function resolveCallerFeatureFlags(
 	if (!env.APP_DB) return disabledFeatureFlags()
 	if (!callerContext.user?.userId) return disabledFeatureFlags()
 	try {
-		const userId = await resolveFeatureFlagUserId(env.APP_DB, callerContext)
+		const stableUserId = normalizeStableUserId(callerContext.user.userId)
+		if (!stableUserId) return disabledFeatureFlags()
+		const userId = await resolveFeatureFlagUserId(env.APP_DB, stableUserId)
 		if (userId === null) return disabledFeatureFlags()
-		return await getFeatureFlagsForUser(env.APP_DB, userId)
+		const evaluations = await getFeatureFlagEvaluationsForUser(
+			env.APP_DB,
+			userId,
+		)
+		await recordFeatureFlagExposures(env, { stableUserId, evaluations })
+		return Object.fromEntries(
+			featureFlagKeys.map((key) => [key, evaluations[key].enabled]),
+		) as Record<FeatureFlagKey, boolean>
 	} catch {
 		// Fail closed: gated capabilities stay hidden when evaluation fails.
 		return disabledFeatureFlags()

--- a/packages/worker/src/mcp/capabilities/admin/admin-feature-flag-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-feature-flag-list.ts
@@ -5,7 +5,9 @@ import {
 	emptyCapabilityInputSchema,
 	type CapabilityContext,
 } from '#mcp/capabilities/types.ts'
+import { missingSuccessMetricNotice } from '#worker/feature-flags/registry.ts'
 import { listFeatureFlagsForAdmin } from '#worker/feature-flags/service.ts'
+import { attachFeatureFlagMetricReadouts } from '#worker/feature-flags/success-metric-readout.ts'
 import {
 	adminCapabilityAccess,
 	auditAdminCapabilityInvocation,
@@ -13,7 +15,11 @@ import {
 import { adminFeatureFlagSchema } from './feature-flag-shared.ts'
 
 const outputSchema = z.object({
-	flags: z.array(adminFeatureFlagSchema),
+	flags: z.array(
+		adminFeatureFlagSchema.extend({
+			successMetricNotice: z.string().optional(),
+		}),
+	),
 })
 
 export const adminFeatureFlagListCapability = defineDomainCapability(
@@ -22,7 +28,7 @@ export const adminFeatureFlagListCapability = defineDomainCapability(
 		...adminCapabilityAccess,
 		name: 'admin_feature_flag_list',
 		description:
-			'List feature flags for admin review, including registry metadata, global state, and per-user overrides. Admin-only; never returns user content.',
+			"List feature flags for admin review, including registry metadata, global state, per-user overrides, and each flag's declared success metric with its on/off cohort readout (exposures joined with usage events, current month to date). Registry flags without a success metric carry a successMetricNotice strongly recommending one. Admin-only; never returns user content.",
 		keywords: [
 			'admin',
 			'feature flags',
@@ -30,6 +36,10 @@ export const adminFeatureFlagListCapability = defineDomainCapability(
 			'rollout',
 			'overrides',
 			'toggles',
+			'success metric',
+			'metrics',
+			'readout',
+			'experiment',
 		],
 		inputSchema: emptyCapabilityInputSchema,
 		outputSchema,
@@ -39,7 +49,15 @@ export const adminFeatureFlagListCapability = defineDomainCapability(
 				'admin_feature_flag_list',
 				async () => {
 					const flags = await listFeatureFlagsForAdmin(ctx.env.APP_DB)
-					return { flags }
+					await attachFeatureFlagMetricReadouts(ctx.env, flags)
+					return {
+						flags: flags.map((flag) => ({
+							...flag,
+							...(flag.stale || flag.successMetric
+								? {}
+								: { successMetricNotice: missingSuccessMetricNotice }),
+						})),
+					}
 				},
 			)
 		},

--- a/packages/worker/src/mcp/capabilities/admin/feature-flag-shared.ts
+++ b/packages/worker/src/mcp/capabilities/admin/feature-flag-shared.ts
@@ -6,6 +6,7 @@ import {
 	isFeatureFlagKey,
 	type FeatureFlagKey,
 } from '#worker/feature-flags/registry.ts'
+import { usageEventTypes } from '#worker/usage/event-types.ts'
 import { isStableUserId, normalizeStableUserId } from '#worker/user-id.ts'
 import { stableUserIdSchema } from './admin-shared.ts'
 
@@ -16,11 +17,47 @@ export const adminFeatureFlagOverrideSchema = z.object({
 	updatedAt: z.string(),
 })
 
+export const featureFlagSuccessMetricSchema = z.object({
+	eventType: z.enum(usageEventTypes),
+	measure: z.enum(['event_count', 'error_rate', 'avg_duration_ms']),
+	goal: z.enum(['increase', 'decrease']),
+	hypothesis: z.string(),
+})
+
+const featureFlagMetricCohortSchema = z.object({
+	users: z.number().int().min(0),
+	eventCount: z.number().int().min(0),
+	errorCount: z.number().int().min(0),
+	errorRate: z.number().nullable(),
+	avgDurationMs: z.number().nullable(),
+})
+
+export const adminFeatureFlagMetricReadoutSchema = z.discriminatedUnion(
+	'status',
+	[
+		z.object({
+			status: z.literal('unavailable'),
+			reason: z.string(),
+		}),
+		z.object({
+			status: z.literal('ok'),
+			windowStart: z.string(),
+			windowEnd: z.string(),
+			on: featureFlagMetricCohortSchema,
+			off: featureFlagMetricCohortSchema,
+			overrideUsers: z.number().int().min(0),
+			mixedUsers: z.number().int().min(0),
+		}),
+	],
+)
+
 export const adminFeatureFlagSchema = z.object({
 	key: z.string(),
 	description: z.string().nullable(),
 	defaultEnabled: z.boolean().nullable(),
 	stale: z.boolean(),
+	successMetric: featureFlagSuccessMetricSchema.nullable(),
+	metricReadout: adminFeatureFlagMetricReadoutSchema.optional(),
 	global: z
 		.object({
 			enabled: z.boolean(),

--- a/packages/worker/src/usage/aggregate-rollups.ts
+++ b/packages/worker/src/usage/aggregate-rollups.ts
@@ -283,12 +283,20 @@ export async function readIdempotentInboundEmailUsage(input: {
 	return result.results ?? []
 }
 
-async function queryAnalyticsEngineSql(input: {
+/**
+ * Run one Analytics Engine SQL API query (with timeout + retry on transient
+ * failures) and return the parsed rows. Shared with the feature-flag
+ * success-metric readout, which queries the same API against the usage and
+ * flag-exposure datasets.
+ */
+export async function queryAnalyticsEngineSql<
+	Row = AnalyticsEngineSqlRow,
+>(input: {
 	accountId: string
 	apiToken: string
 	baseUrl: string
 	query: string
-}): Promise<Array<AnalyticsEngineSqlRow>> {
+}): Promise<Array<Row>> {
 	const url = `${input.baseUrl.replace(/\/$/, '')}/client/v4/accounts/${input.accountId}/analytics_engine/sql`
 	let lastError: Error | undefined
 	for (
@@ -307,7 +315,7 @@ async function queryAnalyticsEngineSql(input: {
 		const text = await response.text()
 		if (response.ok) {
 			const parsed = JSON.parse(text) as {
-				data?: Array<AnalyticsEngineSqlRow>
+				data?: Array<Row>
 			}
 			return parsed.data ?? []
 		}

--- a/packages/worker/src/usage/event-types.ts
+++ b/packages/worker/src/usage/event-types.ts
@@ -1,0 +1,23 @@
+/**
+ * The closed set of metered usage event types.
+ *
+ * Kept dependency-free (no `cloudflare:workers` import) so client-safe
+ * modules — most notably the feature-flag registry, which declares success
+ * metrics against these types — can import it under the client tsconfig.
+ * The write path and event schema live in `record-usage.ts`.
+ */
+
+export const usageEventTypes = [
+	'execute',
+	'package_export',
+	'package_static_call',
+	'job_run',
+	'workflow_run',
+	'service_runtime',
+	'realtime_session',
+	'outbound_fetch',
+	'email_send',
+	'email_received',
+] as const
+
+export type UsageEventType = (typeof usageEventTypes)[number]

--- a/packages/worker/src/usage/record-usage.ts
+++ b/packages/worker/src/usage/record-usage.ts
@@ -31,24 +31,18 @@
  */
 
 import * as cloudflareWorkers from 'cloudflare:workers'
+import { type UsageEventType } from '#worker/usage/event-types.ts'
+
+export {
+	usageEventTypes,
+	type UsageEventType,
+} from '#worker/usage/event-types.ts'
 
 // Older local runtimes (and the node test stub) may not expose `tracing`;
 // treat it as optional so metering keeps its never-throws contract.
 const runtimeTracing: typeof cloudflareWorkers.tracing | undefined = (
 	cloudflareWorkers as Partial<typeof cloudflareWorkers>
 ).tracing
-
-export type UsageEventType =
-	| 'execute'
-	| 'package_export'
-	| 'package_static_call'
-	| 'job_run'
-	| 'workflow_run'
-	| 'service_runtime'
-	| 'realtime_session'
-	| 'outbound_fetch'
-	| 'email_send'
-	| 'email_received'
 
 export type UsageOutcome = 'success' | 'error'
 

--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -38,6 +38,7 @@
 		"./src/identity/permissions.ts",
 		"./src/feature-flags/registry.ts",
 		"./src/feature-flags/types.ts",
+		"./src/usage/event-types.ts",
 		"./src/og/pages.ts"
 	],
 	"exclude": ["./client/**/*.test.ts", "./client/**/*.spec.ts"]

--- a/packages/worker/worker-configuration.d.ts
+++ b/packages/worker/worker-configuration.d.ts
@@ -10,6 +10,7 @@ interface __BaseEnv_Env {
 	CAPABILITY_VECTOR_INDEX: VectorizeIndex;
 	EMAIL: SendEmail;
 	USAGE_EVENTS: AnalyticsEngineDataset;
+	FLAG_EXPOSURES: AnalyticsEngineDataset;
 	PLATFORM_FEEDBACK_DISPATCH_QUEUE: Queue;
 	COMMUNITY_ACTIVITY_DISPATCH_QUEUE: Queue;
 	LOADER: WorkerLoader;

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -272,6 +272,10 @@
 					"binding": "USAGE_EVENTS",
 					"dataset": "kody_usage_events",
 				},
+				{
+					"binding": "FLAG_EXPOSURES",
+					"dataset": "kody_flag_exposures",
+				},
 			],
 			"ai": {
 				"binding": "AI",
@@ -435,6 +439,10 @@
 				{
 					"binding": "USAGE_EVENTS",
 					"dataset": "kody_usage_events_preview",
+				},
+				{
+					"binding": "FLAG_EXPOSURES",
+					"dataset": "kody_flag_exposures_preview",
 				},
 			],
 			"ai": {

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -490,7 +490,7 @@
 		},
 		{
 			"filename": "0117-feature-flag-exposure-rollups.sql",
-			"sha256": "2e9622e32b82e6783dc638572f39172cc6d0bdbaf040ab2654e1c789176efb8d"
+			"sha256": "21c909ac033dbe55fc0654b8a729a4cb3344f769dcb7b1e86aa8f978ed89a6cd"
 		}
 	]
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -487,6 +487,10 @@
 		{
 			"filename": "0116-job-expires-at.sql",
 			"sha256": "f8fc33d7860b074cfb116cec16179b07fca6364d0b37e26883e48df5a2c0fec7"
+		},
+		{
+			"filename": "0117-feature-flag-exposure-rollups.sql",
+			"sha256": "2e9622e32b82e6783dc638572f39172cc6d0bdbaf040ab2654e1c789176efb8d"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Every feature flag can now declare the metric it exists to move, and the admin surfaces show whether it is actually moving it.

- **Declaration** — `FeatureFlagDefinition` gains an optional `successMetric` (`eventType` from the closed usage-metering union, `measure`, `goal`, `hypothesis`), reviewed in the same PR that creates the flag. `execute-pre-exec-typecheck` declares one (`execute` error rate should decrease); the permanent `demo-indicator` deliberately does not.
- **Exposures** — for measured flags, the two evaluation chokepoints (app session flag cache, MCP caller flag resolver) record `(stable user id, flag key, on/off, assignment source, timestamp)`. Production/preview writes go to a new `FLAG_EXPOSURES` Analytics Engine dataset; local dev/tests use a new D1 `feature_flag_exposure_rollups` table (migration `0117`, 90-day retention, covered by account deletion/export targets). The writer mirrors `recordUsage`'s never-throws contract.
- **Readout** — `success-metric-readout.ts` joins exposures with usage events for the declared metric over the current UTC month, splits users into on/off cohorts, and excludes hand-picked override users and mixed-exposure users (reported separately). Attached to `/admin/feature-flags` and `admin_feature_flag_list`.
- **Strong recommendation notice** — registry flags without a `successMetric` render a notice in the admin UI and carry a `successMetricNotice` field in the MCP list output.

## Why

Flags gate rollouts, but nothing connected "flag is on" to "the thing we hoped would improve actually improved". Associating each flag with a code-reviewed metric hypothesis plus exposure-based cohort data makes "push forward or kill it" an evidence-based operator decision. Assignment-source tracking is what keeps the comparison honest: current flag state cannot reconstruct who was inside a percentage rollout last week, and override users are selection-biased.

## Demo (local dev)

Two seeded users were split by a 20% rollout (jane on, kody off), with seeded `execute` usage for the month. The admin page shows the missing-metric notice on `demo-indicator` and the cohort readout on `execute-pre-exec-typecheck` (on cohort 6.7% error rate vs off cohort 36.0%).

<a href="https://cursor.com/agents/bc-3010104c-eaa5-46a3-b224-a739d5ada971/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_feature_flags_success_metric_readout_demo.mp4"><img src="https://cursor.com/artifacts/c/art-0b03fa3b-95e7-4da1-86d3-1464095f20a7" alt="admin_feature_flags_success_metric_readout_demo.mp4" /></a>

![Success metric panel with on/off cohort readout](https://cursor.com/artifacts/c/art-02abe9ca-85d7-4611-8823-ed8f987e99c9)

## Notes for review

- `UsageEventType` moved to a dependency-free `packages/worker/src/usage/event-types.ts` (re-exported from `record-usage.ts`) so the client-safe flag registry can reference it.
- `getFeatureFlagsForUser` is now a thin wrapper over `getFeatureFlagEvaluationsForUser`, which also returns the assignment source (`override` / `global` / `rollout` / `default`). Evaluation precedence is unchanged.
- Local Wrangler dev emulates Analytics Engine bindings and injects mock REST credentials, but the SQL API cannot read locally emulated datasets — exposure writes and the readout use the D1 path when `WRANGLER_IS_LOCAL_DEV` is set.
- The new D1 table gets a scheduled retention policy (90 days, matching Analytics Engine retention) and an `accountUserDataTargets` entry.
- Readout failures degrade to `{ status: 'unavailable' }` so the admin page renders even when the analytics backend is down.
- The migration was renumbered from `0113` to `0117` after rebasing on main; the branch is rebased on top of the stable-user-id admin transport change (#1072).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends feature flags and usage metering</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `3b84c504` · **Head:** `6580b1bc`

**Classification:** extends — no new primitive; the `feature-flags` primitive gains success-metric declaration, exposure recording, and a metric readout, joined against the existing `usage-metering` event stream.

### Primitives touched

| Primitive             | Group     | Impact                                                                                              |
| --------------------- | --------- | --------------------------------------------------------------------------------------------------- |
| `feature-flags`       | auth      | extends — `successMetric` registry field, evaluation sources, exposure writer, cohort readout       |
| `usage-metering`      | storage   | extends — `UsageEventType` extracted to a dependency-free module; AE SQL helper exported for reuse  |
| `d1-app-db`           | storage   | extends — new `feature_flag_exposure_rollups` table (migration `0117`)                              |
| `app-ui`              | surfaces  | extends — success-metric panel + missing-metric notice on `/admin/feature-flags`                    |
| `capability-registry` | assistant | composes — MCP caller flag resolver records exposures; `admin_feature_flag_list` output extended    |
| `scheduled-cron`      | surfaces  | extends — retention prune for exposure rollups (90 days)                                            |
| `account-export`      | account   | composes — exposure rollups added to deletion/export targets                                        |

### System map

Flag evaluation now emits exposures alongside its answer, and the admin surfaces join those exposures with usage events into an on/off cohort readout.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	featureFlags["feature-flags<br/>Feature flags"]:::extended
	usageMetering["usage-metering<br/>Usage metering"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::extended
	accountExport["account-export<br/>Account data export"]:::touched
	appUi -->|"session flag cache records exposures"| featureFlags
	capabilityRegistry -->|"resolveCallerFeatureFlags records exposures"| featureFlags
	featureFlags -->|"FLAG_EXPOSURES dataset / feature_flag_exposure_rollups"| d1AppDb
	featureFlags -->|"successMetric.eventType compile-checked"| usageMetering
	appUi -->|"readout joins exposures with usage events"| usageMetering
	scheduledCron -->|"prune exposure rollups > 90 days"| d1AppDb
	accountExport -->|"deletion/export target"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
Before: FeatureFlagDefinition = { key, description, defaultEnabled }
After:  FeatureFlagDefinition = { key, description, defaultEnabled,
          successMetric?: { eventType: UsageEventType, measure, goal, hypothesis } }

New D1 table (local/test sink; production uses the FLAG_EXPOSURES AE dataset):
feature_flag_exposure_rollups (flag_key, user_id, day, enabled, source,
  exposure_count, updated_at) PK (flag_key, user_id, day, enabled, source)
```

### Invariants

Per-user isolation: exposures are keyed by the stable user id, the D1 fallback table is in `accountUserDataTargets` (deletion + export), and the readout only ever aggregates across users for the admin-only surfaces (admin role required on both the route and the capability).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3010104c-eaa5-46a3-b224-a739d5ada971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3010104c-eaa5-46a3-b224-a739d5ada971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable “success metrics” for feature flags (event type, goals, hypotheses), including measurement windows and on/off cohort readouts in the admin UI.
  * Added success-metric exposure recording, with automatic fallback to local rollups when analytics bindings aren’t available.
* **Bug Fixes**
  * Improved retention and pruning for local success-metric exposure rollups, including correct day-boundary behavior.
  * Updated admin display to consistently use stable user identifiers for attribution and overrides.
* **Tests**
  * Expanded end-to-end and unit coverage for success-metric UI rendering, exposure recording, metric readouts, and retention edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->