### PR TITLE
Remove legacy raw package app storage buckets

### DIFF
--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -233,6 +233,7 @@ rule.
 - `admin_package_scope_grant_revoke`
 - `admin_package_scope_grant_list`
 - `admin_package_storage_audit`
+- `admin_package_storage_cleanup`
 - `admin_audit_log_query`
 - `admin_user_usage`
 - `admin_feature_flag_list`

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -799,8 +799,6 @@ Storage ids are also stable strings. Changing a form strands the old bucket:
   job run scratch.
 - `package:{encodeURIComponent(packageId)}` — package bucket behind
   `packageStorage()` / `buildPackageStorageId(packageId)`.
-- Raw saved package id (no prefix) — legacy package-app root ambient bucket;
-  distinct from `package:{...}`. New app code uses `packageStorage()`.
 - `{packageId}:facet:{facetName}` — package-app facet StorageRunner buckets.
 - `{packageId}:{exportName}:{name}` — package-app internal Durable Object
   namespace StorageRunner buckets.

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -217,16 +217,16 @@ Restore rebuilds these; do not treat them as recovery media:
 - R2 restore puts sealed objects back by key; it does not sweep orphans that
   appeared after the sealed day.
 - **StorageRunner inventory** unions authoritative D1 sources: `jobs`,
-  `archived_job_artifacts`, `saved_packages` (app packages), the
-  `user_storage_buckets` registry (including ad-hoc / execute buckets), and
-  `package_service_states` (projected service storage ids). Platform DR has only
-  a `D1Database`, so it does **not** walk package manifests or enumerate
-  `RunLog` Durable Objects. A service whose Durable Object never projected into
-  `package_service_states` is therefore absent from sealed-day inventory until
-  it heartbeats or transitions; account deletion/export cover those via manifest
-  enumeration. Buckets known only inside a user's `RunLog` (and never registered
-  in `user_storage_buckets` or an entity table) remain outside DR inventory by
-  design — RunLog is observability, not a canonical store.
+  `archived_job_artifacts`, the `user_storage_buckets` registry (including
+  ad-hoc / execute buckets), and `package_service_states` (projected service
+  storage ids). Platform DR has only a `D1Database`, so it does **not** walk
+  package manifests or enumerate `RunLog` Durable Objects. A service whose
+  Durable Object never projected into `package_service_states` is therefore
+  absent from sealed-day inventory until it heartbeats or transitions; account
+  deletion/export cover those via manifest enumeration. Buckets known only
+  inside a user's `RunLog` (and never registered in `user_storage_buckets` or an
+  entity table) remain outside DR inventory by design — RunLog is observability,
+  not a canonical store.
 
 ## Credentials and Access
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -286,8 +286,6 @@ Treat package apps like Worker-style modules:
 - package app entry is declared by `kody.app.entry`
 - durable package data uses `packageStorage()` (same
   `buildPackageStorageId(packageId)` bucket as other package surfaces)
-- package apps also bind a legacy app-root ambient bucket to the raw saved
-  package id; new app code uses `packageStorage()`
 - Durable Objects / facets are app-only realtime/coordination buckets under the
   package namespace, not the persistence mechanism and not separate saved
   primitives

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -329,18 +329,13 @@ consequences:
   package that is not the running package and not statically imported by the
   bundle, use keyless `packages.invoke` so its own runtime does the reading.
 
-Package apps also have a legacy app-root ambient bucket bound to the raw saved
-package id (a different bucket from `package:{...}`). Existing published apps
-may still run against it; new app code uses `packageStorage()` like every other
-package surface.
-
 ### Ambient `storage` in package code
 
-Package exports, subscription handlers, and retrievers do not bind ambient
-`storage`. In those contexts ambient `storage` is `undefined`; guard-less access
-fails with a structured `runtime_helper_unbound` error whose remedy points at
-`packageStorage()`, the one way package code reaches its bucket (same interface,
-same bucket).
+Saved-package runtimes, including apps, exports, subscription handlers, and
+retrievers, do not bind ambient `storage`. In those contexts ambient `storage`
+is `undefined`; guard-less access fails with a structured
+`runtime_helper_unbound` error whose remedy points at `packageStorage()`, the
+one way package code reaches its bucket (same interface, same bucket).
 
 Repo checks fail when package source imports ambient `storage` from
 `kody:runtime` (type-only imports and `.d.ts` files are exempt).

--- a/packages/worker/src/account/export.node.test.ts
+++ b/packages/worker/src/account/export.node.test.ts
@@ -850,8 +850,8 @@ test('durable object discovery pages high-cardinality storage ids without nested
 					return {
 						async all<T>() {
 							if (query.includes('SELECT id FROM (')) {
-								const afterId = String(params[4])
-								const limit = Number(params[5])
+								const afterId = String(params[3])
+								const limit = Number(params[4])
 								const rows = ids
 									.filter((id) => id > afterId)
 									.slice(0, limit)

--- a/packages/worker/src/account/export.ts
+++ b/packages/worker/src/account/export.ts
@@ -473,12 +473,10 @@ const exportStorageIdBaseSql = `SELECT id FROM (
 		WHERE user_id = ? AND storage_id IS NOT NULL
 	UNION SELECT storage_id FROM user_storage_buckets
 		WHERE user_id = ?
-	UNION SELECT id FROM saved_packages
-		WHERE user_id = ? AND has_app = 1
 )`
 
 function exportStorageIdBaseParams(userId: string) {
-	return [userId, userId, userId, userId] as const
+	return [userId, userId, userId] as const
 }
 
 function tryDecodeURIComponent(value: string) {

--- a/packages/worker/src/account/export.ts
+++ b/packages/worker/src/account/export.ts
@@ -2044,7 +2044,6 @@ export async function readAccountExportSection(input: {
 						input.mcpUserId,
 						input.mcpUserId,
 						input.mcpUserId,
-						input.mcpUserId,
 						afterId,
 						pageSize + 1,
 					)

--- a/packages/worker/src/account/user-inventory.ts
+++ b/packages/worker/src/account/user-inventory.ts
@@ -164,7 +164,6 @@ export async function listAccountUserStorageIds(input: {
 		jobRows,
 		archivedRows,
 		bucketIds,
-		packageRows,
 		packageServices,
 		runRecordStorageIds,
 	] = await Promise.all([
@@ -182,11 +181,6 @@ export async function listAccountUserStorageIds(input: {
 			env: input.env,
 			userId: input.userId,
 		}),
-		input.env.APP_DB.prepare(
-			`SELECT id FROM saved_packages WHERE user_id = ? AND has_app = 1`,
-		)
-			.bind(input.userId)
-			.all<{ id: string }>(),
 		input.packageServices
 			? Promise.resolve([...input.packageServices])
 			: listAccountUserPackageServices(input),
@@ -196,7 +190,6 @@ export async function listAccountUserStorageIds(input: {
 		...(jobRows.results ?? []).map((row) => row.storage_id),
 		...(archivedRows.results ?? []).map((row) => row.storage_id),
 		...bucketIds,
-		...(packageRows.results ?? []).map((row) => row.id),
 		...packageServices.map((service) =>
 			buildPackageServiceStorageId(service.packageId, service.serviceName),
 		),

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1349,7 +1349,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		jobVectorId(packageJobId),
 		'package_pkg-1',
 	])
-	expect(clearStorageMock).toHaveBeenCalledTimes(7)
+	expect(clearStorageMock).toHaveBeenCalledTimes(6)
 	expect(purgeJobManagerMock).toHaveBeenCalledTimes(1)
 	expect(purgeRepoSessionMock).toHaveBeenCalledWith({
 		sessionId: 'rs-1',

--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -1424,7 +1424,7 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 	)
 	expect(result.deletedVectors).toBe(5)
 	expect(result.clearedDurableObjects).toMatchObject({
-		storageRunners: 7,
+		storageRunners: 6,
 		runLogs: 1,
 		jobManagers: 1,
 		repoSessions: 1,

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.node.test.ts
@@ -74,16 +74,13 @@ test('admin package storage audit route requires admin and returns the report JS
 	const handler = createAdminPackageStorageAuditApiHandler(env)
 	const report = {
 		ok: true as const,
-		packages: [],
-		orphanAppBuckets: [],
+		legacyBuckets: [],
 		nextStartAfter: null,
 		totals: {
-			appPackages: 0,
+			legacyBuckets: 0,
 			nonEmptyLegacyBuckets: 0,
-			packagesWithAmbientImports: 0,
-			orphanAppBuckets: 0,
+			probeErrors: 0,
 			truncated: false,
-			orphanTruncated: false,
 		},
 	}
 
@@ -112,7 +109,6 @@ test('admin package storage audit route requires admin and returns the report JS
 	await expect(response.json()).resolves.toEqual(report)
 	expect(mockModule.buildPackageStorageAuditReport).toHaveBeenCalledWith({
 		env,
-		baseUrl: 'https://example.com',
 		limit: 50,
 		startAfter: cursor,
 	})
@@ -126,16 +122,13 @@ test('admin package storage audit route clamps limit and applies the default', a
 	)
 	mockModule.buildPackageStorageAuditReport.mockResolvedValue({
 		ok: true,
-		packages: [],
-		orphanAppBuckets: [],
+		legacyBuckets: [],
 		nextStartAfter: null,
 		totals: {
-			appPackages: 0,
+			legacyBuckets: 0,
 			nonEmptyLegacyBuckets: 0,
-			packagesWithAmbientImports: 0,
-			orphanAppBuckets: 0,
+			probeErrors: 0,
 			truncated: false,
-			orphanTruncated: false,
 		},
 	})
 

--- a/packages/worker/src/app/handlers/admin-package-storage-audit.ts
+++ b/packages/worker/src/app/handlers/admin-package-storage-audit.ts
@@ -27,7 +27,6 @@ export function createAdminPackageStorageAuditApiHandler(env: Env) {
 				const startAfter = url.searchParams.get('startAfter')
 				const report = await buildPackageStorageAuditReport({
 					env,
-					baseUrl: url.origin,
 					limit,
 					startAfter,
 				})

--- a/packages/worker/src/dr/exporter.ts
+++ b/packages/worker/src/dr/exporter.ts
@@ -256,7 +256,7 @@ export async function listPlatformStorageInventory(
 	// service buckets come from projected `package_service_states` rather than
 	// package manifests. Ad-hoc / execute buckets come from the authoritative
 	// `user_storage_buckets` registry via `listPlatformStorageBuckets`.
-	const [jobRows, archivedRows, registeredBuckets, packageRows, serviceRows] =
+	const [jobRows, archivedRows, registeredBuckets, serviceRows] =
 		await Promise.all([
 			db
 				.prepare(
@@ -271,12 +271,6 @@ export async function listPlatformStorageInventory(
 				)
 				.all<{ userId: string; storageId: string }>(),
 			listPlatformStorageBuckets({ db }),
-			db
-				.prepare(
-					`SELECT user_id AS userId, id AS storageId
-					FROM saved_packages WHERE has_app = 1`,
-				)
-				.all<{ userId: string; storageId: string }>(),
 			db
 				.prepare(
 					`SELECT DISTINCT user_id AS userId, package_id AS packageId,
@@ -301,7 +295,6 @@ export async function listPlatformStorageInventory(
 	for (const row of jobRows.results ?? []) push(row.userId, row.storageId)
 	for (const row of archivedRows.results ?? []) push(row.userId, row.storageId)
 	for (const row of registeredBuckets) push(row.userId, row.storageId)
-	for (const row of packageRows.results ?? []) push(row.userId, row.storageId)
 	for (const row of serviceRows.results ?? []) {
 		push(
 			row.userId,

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-storage-audit.node.test.ts
@@ -35,20 +35,17 @@ function createContext(roles: Array<string>) {
 
 const emptyReport = {
 	ok: true as const,
-	packages: [],
-	orphanAppBuckets: [],
+	legacyBuckets: [],
 	nextStartAfter: null as string | null,
 	totals: {
-		appPackages: 0,
+		legacyBuckets: 0,
 		nonEmptyLegacyBuckets: 0,
-		packagesWithAmbientImports: 0,
-		orphanAppBuckets: 0,
+		probeErrors: 0,
 		truncated: false,
-		orphanTruncated: false,
 	},
 }
 
-test('admin package storage audit requires admin and returns the platform-wide report', async () => {
+test('admin package storage audit requires admin and returns legacy inventory', async () => {
 	await expect(
 		adminPackageStorageAuditCapability.handler({}, createContext(['user'])),
 	).rejects.toThrow('lacks required role "admin"')
@@ -64,33 +61,30 @@ test('admin package storage audit requires admin and returns the platform-wide r
 
 	const nextStartAfter = JSON.stringify({
 		userId: 'user-a',
-		packageId: 'pkg-1',
+		storageId: 'pkg-1',
 	})
 	mocks.buildPackageStorageAuditReport.mockResolvedValue({
 		...emptyReport,
-		packages: [
+		legacyBuckets: [
 			{
 				userId: 'user-a',
-				packageId: 'pkg-1',
-				kodyId: 'demo',
-				legacyBucketBytes: 8192,
-				legacyBucketProbeError: null,
-				ambientStorageImportFiles: ['app.ts'],
-				sourceScanError: null,
+				storageId: 'pkg-1',
+				lastSeenAt: '2026-07-01T00:00:00.000Z',
+				estimatedBytes: 8192,
+				probeError: null,
 			},
 		],
 		nextStartAfter,
 		totals: {
 			...emptyReport.totals,
-			appPackages: 1,
+			legacyBuckets: 1,
 			nonEmptyLegacyBuckets: 1,
-			packagesWithAmbientImports: 1,
 			truncated: true,
 		},
 	})
 
 	const ctx = createContext(['admin'])
-	const cursor = JSON.stringify({ userId: 'user-a', packageId: 'pkg-0' })
+	const cursor = JSON.stringify({ userId: 'user-a', storageId: 'pkg-0' })
 	const result = await adminPackageStorageAuditCapability.handler(
 		{ limit: 25, start_after: cursor },
 		ctx,
@@ -98,25 +92,13 @@ test('admin package storage audit requires admin and returns the platform-wide r
 
 	expect(mocks.buildPackageStorageAuditReport).toHaveBeenCalledWith({
 		env: ctx.env,
-		baseUrl: 'https://heykody.dev',
 		limit: 25,
 		startAfter: cursor,
 	})
 	expect(result).toMatchObject({
-		ok: true,
 		nextStartAfter,
-		packages: [
-			expect.objectContaining({
-				packageId: 'pkg-1',
-				ambientStorageImportFiles: ['app.ts'],
-			}),
-		],
-		totals: {
-			appPackages: 1,
-			nonEmptyLegacyBuckets: 1,
-			packagesWithAmbientImports: 1,
-			truncated: true,
-		},
+		legacyBuckets: [{ storageId: 'pkg-1', estimatedBytes: 8192 }],
+		totals: { legacyBuckets: 1, nonEmptyLegacyBuckets: 1, truncated: true },
 	})
 	expect(auditEventSummaries()).toEqual([
 		'mcp_capability_denied:failure',
@@ -137,9 +119,4 @@ test('admin package storage audit defaults limit and rejects values above max', 
 		adminPackageStorageAuditCapability.handler({ limit: 501 }, ctx),
 	).rejects.toThrow()
 	expect(mocks.buildPackageStorageAuditReport).toHaveBeenCalledTimes(1)
-
-	await adminPackageStorageAuditCapability.handler({ limit: 500 }, ctx)
-	expect(mocks.buildPackageStorageAuditReport).toHaveBeenLastCalledWith(
-		expect.objectContaining({ limit: 500 }),
-	)
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-storage-cleanup.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-storage-cleanup.node.test.ts
@@ -1,0 +1,69 @@
+import { expect, test, vi } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import {
+	auditEventSummaries,
+	logAuditEventSpy,
+} from '#worker/test-support/audit-log-spy.ts'
+
+const mocks = vi.hoisted(() => ({
+	cleanupLegacyPackageStorageBuckets: vi.fn(),
+}))
+
+vi.mock('#worker/package-storage-audit/service.ts', () => ({
+	defaultPackageStorageAuditLimit: 200,
+	maxPackageStorageAuditLimit: 500,
+	cleanupLegacyPackageStorageBuckets: mocks.cleanupLegacyPackageStorageBuckets,
+}))
+
+const { adminPackageStorageCleanupCapability } =
+	await import('./admin-package-storage-cleanup.ts')
+
+function createContext(roles: Array<string>) {
+	return {
+		env: { APP_DB: {} as D1Database } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'admin-user',
+				username: 'admin',
+				email: 'admin@example.com',
+				roles,
+			},
+		}),
+	}
+}
+
+test('admin package storage cleanup requires admin and reports cleared buckets', async () => {
+	await expect(
+		adminPackageStorageCleanupCapability.handler({}, createContext(['user'])),
+	).rejects.toThrow('lacks required role "admin"')
+	expect(mocks.cleanupLegacyPackageStorageBuckets).not.toHaveBeenCalled()
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			action: 'mcp_capability_denied',
+			result: 'failure',
+		}),
+	)
+
+	const report = {
+		ok: true as const,
+		buckets: [{ userId: 'user-a', storageId: 'pkg-1', cleared: true }],
+		nextStartAfter: null,
+		totals: { cleared: 1, failed: 0, truncated: false },
+	}
+	mocks.cleanupLegacyPackageStorageBuckets.mockResolvedValue(report)
+	const ctx = createContext(['admin'])
+
+	await expect(
+		adminPackageStorageCleanupCapability.handler({ limit: 25 }, ctx),
+	).resolves.toEqual(report)
+	expect(mocks.cleanupLegacyPackageStorageBuckets).toHaveBeenCalledWith({
+		env: ctx.env,
+		limit: 25,
+		startAfter: undefined,
+	})
+	expect(auditEventSummaries()).toEqual([
+		'mcp_capability_denied:failure',
+		'admin_package_storage_cleanup:success',
+	])
+})

--- a/packages/worker/src/mcp/capabilities/admin/admin-package-storage-cleanup.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-package-storage-cleanup.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import {
-	buildPackageStorageAuditReport,
+	cleanupLegacyPackageStorageBuckets,
 	defaultPackageStorageAuditLimit,
 	InvalidStartAfterCursorError,
 	maxPackageStorageAuditLimit,
@@ -13,46 +13,41 @@ import {
 	auditAdminCapabilityInvocation,
 } from './admin-shared.ts'
 
-const legacyBucketSchema = z.object({
-	userId: z.string(),
-	storageId: z.string(),
-	lastSeenAt: z.string(),
-	estimatedBytes: z.number().nullable(),
-	probeError: z.string().nullable(),
-})
-
 const outputSchema = z.object({
 	ok: z.literal(true),
-	legacyBuckets: z.array(legacyBucketSchema),
-	nextStartAfter: z
-		.string()
-		.nullable()
-		.describe(
-			'Opaque keyset cursor for the next page when truncated; null when complete.',
-		),
+	buckets: z.array(
+		z.object({
+			userId: z.string(),
+			storageId: z.string(),
+			cleared: z.boolean(),
+		}),
+	),
+	nextStartAfter: z.string().nullable(),
 	totals: z.object({
-		legacyBuckets: z.number().int().nonnegative(),
-		nonEmptyLegacyBuckets: z.number().int().nonnegative(),
-		probeErrors: z.number().int().nonnegative(),
+		cleared: z.number().int().nonnegative(),
+		failed: z.number().int().nonnegative(),
 		truncated: z.boolean(),
 	}),
 })
 
-export const adminPackageStorageAuditCapability = defineDomainCapability(
+export const adminPackageStorageCleanupCapability = defineDomainCapability(
 	capabilityDomainNames.admin,
 	{
 		...adminCapabilityAccess,
-		name: 'admin_package_storage_audit',
+		name: 'admin_package_storage_cleanup',
 		description:
-			'Verify whether any legacy raw-package-id app StorageRunner buckets remain in the platform inventory. Admin-only and not user-scoped; reports bucket sizes but never bucket contents. Page with limit + start_after / nextStartAfter.',
+			'Clear legacy raw-package-id app StorageRunner buckets and unregister them from the platform inventory. Admin-only, destructive, and bounded; page with limit + start_after / nextStartAfter until truncated is false.',
 		keywords: [
 			'admin',
 			'package',
 			'storage',
-			'audit',
+			'cleanup',
 			'legacy bucket',
-			'verification',
+			'migration',
 		],
+		readOnly: false,
+		idempotent: true,
+		destructive: true,
 		inputSchema: z.object({
 			limit: z
 				.number()
@@ -61,24 +56,24 @@ export const adminPackageStorageAuditCapability = defineDomainCapability(
 				.max(maxPackageStorageAuditLimit)
 				.optional()
 				.describe(
-					`Max legacy inventory buckets to audit. Defaults to ${String(defaultPackageStorageAuditLimit)} and maxes at ${String(maxPackageStorageAuditLimit)}.`,
+					`Max legacy inventory buckets to clear. Defaults to ${String(defaultPackageStorageAuditLimit)} and maxes at ${String(maxPackageStorageAuditLimit)}.`,
 				),
 			start_after: z
 				.string()
 				.min(1)
 				.optional()
 				.describe(
-					'Opaque keyset cursor from a prior nextStartAfter; resumes after that package.',
+					'Opaque keyset cursor from a prior nextStartAfter; resumes after that bucket.',
 				),
 		}),
 		outputSchema,
 		async handler(args, ctx) {
 			return auditAdminCapabilityInvocation(
 				ctx,
-				'admin_package_storage_audit',
+				'admin_package_storage_cleanup',
 				async () => {
 					try {
-						return await buildPackageStorageAuditReport({
+						return await cleanupLegacyPackageStorageBuckets({
 							env: ctx.env,
 							limit: args.limit ?? defaultPackageStorageAuditLimit,
 							startAfter: args.start_after,

--- a/packages/worker/src/mcp/capabilities/admin/domain.ts
+++ b/packages/worker/src/mcp/capabilities/admin/domain.ts
@@ -13,6 +13,7 @@ import { adminPackageScopeGrantCreateCapability } from './admin-package-scope-gr
 import { adminPackageScopeGrantListCapability } from './admin-package-scope-grant-list.ts'
 import { adminPackageScopeGrantRevokeCapability } from './admin-package-scope-grant-revoke.ts'
 import { adminPackageStorageAuditCapability } from './admin-package-storage-audit.ts'
+import { adminPackageStorageCleanupCapability } from './admin-package-storage-cleanup.ts'
 import { adminPlatformAccountCreateCapability } from './admin-platform-account-create.ts'
 import { adminPlatformFeedbackGetCapability } from './admin-platform-feedback-get.ts'
 import { adminPlatformFeedbackListCapability } from './admin-platform-feedback-list.ts'
@@ -70,6 +71,7 @@ export const adminDomain = defineDomain({
 		adminPackageCodemodApplyCapability,
 		adminPackageCodemodRevertCapability,
 		adminPackageStorageAuditCapability,
+		adminPackageStorageCleanupCapability,
 		adminAuditLogQueryCapability,
 		adminUserUsageCapability,
 		adminFeatureFlagListCapability,

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -140,12 +140,12 @@ async function listPackageOwnedStorageIdsFromInventory(input: {
 	})
 }
 
-async function clearPackageOwnedStorageBucket(input: {
+export async function clearPackageOwnedStorageBucket(input: {
 	env: Env
 	userId: string
 	packageId: string
 	storageId: string
-}) {
+}): Promise<boolean> {
 	let storageCleared = false
 	try {
 		await storageRunnerRpc({
@@ -165,13 +165,14 @@ async function clearPackageOwnedStorageBucket(input: {
 			}),
 		)
 	}
-	if (!storageCleared) return
+	if (!storageCleared) return false
 	try {
 		await input.env.APP_DB.prepare(
 			`DELETE FROM user_storage_buckets WHERE user_id = ? AND storage_id = ?`,
 		)
 			.bind(input.userId, input.storageId)
 			.run()
+		return true
 	} catch (error) {
 		console.warn(
 			JSON.stringify({
@@ -182,6 +183,7 @@ async function clearPackageOwnedStorageBucket(input: {
 				error: getErrorMessage(error),
 			}),
 		)
+		return false
 	}
 }
 

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -38,7 +38,7 @@ async function extractCreateKodyProxySource() {
 		'utf8',
 	)
 	const start = sourceText.indexOf('function createKodyProxy(runtimeBridge) {')
-	const end = sourceText.indexOf('\nfunction createStorageProxy', start)
+	const end = sourceText.indexOf('\nfunction createRealtimeProxy', start)
 	if (start < 0 || end < 0) {
 		throw new Error('createKodyProxy source was not found.')
 	}
@@ -945,9 +945,10 @@ test('package app worker source binds __kodyPackageStorage in createRuntime', as
 	expect(sourceText).toContain('runtimeBridge.packageStorageSet({')
 	expect(sourceText).toContain('runtimeBridge.packageStorageDelete({')
 	expect(sourceText).toContain('runtimeBridge.packageStorageClear({')
-	expect(sourceText).toContain(
-		'storage: createStorageProxy(runtimeBridge, packageId),',
-	)
+	expect(sourceText).toContain('storage: undefined,')
+	expect(sourceText).not.toContain('function createStorageProxy(')
+	expect(sourceText).not.toContain("case 'storage_get':")
+	expect(sourceText).not.toContain("case 'storage_clear':")
 })
 
 test('package app runtime bridge packageStorage methods grant by provenance and deny others', async () => {
@@ -1009,7 +1010,7 @@ test('package app runtime bridge packageStorage methods grant by provenance and 
 	).rejects.toThrow('packageStorage requires a non-empty package id.')
 })
 
-test('package app runtime bridge raw storage methods are namespace-locked to the app package id', async () => {
+test('package app runtime bridge raw storage methods only allow internal app buckets', async () => {
 	const { bridge } = createPackageAppRuntimeBridgeForTest()
 	const getValue = vi.fn(async () => ({ value: 'owned' }))
 	const setValue = vi.fn(async () => ({ ok: true }))
@@ -1036,9 +1037,6 @@ test('package app runtime bridge raw storage methods are namespace-locked to the
 	).mockResolvedValue(undefined)
 
 	await expect(
-		bridge.storageGet({ storageId: 'package-1', key: 'root' }),
-	).resolves.toEqual({ value: 'owned' })
-	await expect(
 		bridge.storageGet({
 			storageId: 'package-1:facet:main',
 			key: 'facet',
@@ -1051,12 +1049,14 @@ test('package app runtime bridge raw storage methods are namespace-locked to the
 			value: 1,
 		}),
 	).resolves.toEqual({ ok: true })
-	expect(getStorageRunner).toHaveBeenCalledWith('package-1')
 	expect(getStorageRunner).toHaveBeenCalledWith('package-1:facet:main')
 	expect(getStorageRunner).toHaveBeenCalledWith('package-1:Counter:instance-a')
 
 	const outsideNamespaceError =
 		/outside this app's namespace[\s\S]*packageStorage\(\)/
+	await expect(
+		bridge.storageGet({ storageId: 'package-1', key: 'legacy-root' }),
+	).rejects.toThrow(outsideNamespaceError)
 	await expect(
 		bridge.storageGet({
 			storageId: buildPackageStorageId('victim-package'),
@@ -1076,7 +1076,7 @@ test('package app runtime bridge raw storage methods are namespace-locked to the
 	await expect(
 		bridge.storageGet({ storageId: '   ', key: 'x' }),
 	).rejects.toThrow('Package app storage requires a non-empty storage id.')
-	expect(getStorageRunner).toHaveBeenCalledTimes(4)
+	expect(getStorageRunner).toHaveBeenCalledTimes(2)
 })
 
 test('buildPackageAppWorker passes packageStorage grant ids from root, static, and dynamic deps', async () => {

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -1076,7 +1076,7 @@ test('package app runtime bridge raw storage methods only allow internal app buc
 	await expect(
 		bridge.storageGet({ storageId: '   ', key: 'x' }),
 	).rejects.toThrow('Package app storage requires a non-empty storage id.')
-	expect(getStorageRunner).toHaveBeenCalledTimes(2)
+	expect(getStorageRunner).toHaveBeenCalledTimes(3)
 })
 
 test('buildPackageAppWorker passes packageStorage grant ids from root, static, and dynamic deps', async () => {

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -177,44 +177,6 @@ function createKodyProxy(runtimeBridge) {
 	});
 }
 
-function createStorageProxy(runtimeBridge, storageId) {
-	return {
-		id: storageId,
-		get: async (key) =>
-			(await runtimeBridge.storageGet({
-				storageId,
-				key,
-			})).value,
-		list: async (options = {}) =>
-			await runtimeBridge.storageList({
-				storageId,
-				...options,
-			}),
-		sql: async (query, params = []) =>
-			await runtimeBridge.storageSql({
-				storageId,
-				query,
-				params,
-				writable: true,
-			}),
-		set: async (key, value) =>
-			await runtimeBridge.storageSet({
-				storageId,
-				key,
-				value,
-			}),
-		delete: async (key) =>
-			await runtimeBridge.storageDelete({
-				storageId,
-				key,
-			}),
-		clear: async () =>
-			await runtimeBridge.storageClear({
-				storageId,
-			}),
-	}
-}
-
 function createRealtimeProxy(runtimeBridge) {
 	return {
 		emit: async (sessionId, data) =>
@@ -523,7 +485,7 @@ function createRuntime(runtimeBridge, packageContext) {
 				}
 	return {
 		kody: createKodyProxy(runtimeBridge),
-		storage: createStorageProxy(runtimeBridge, packageId),
+		storage: undefined,
 		__kodyPackageStorage: (storagePackageId) => ({
 			id: 'package:' + encodeURIComponent(storagePackageId),
 			get: async (key) =>
@@ -877,10 +839,10 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 
 	/**
 	 * Security model for package-app storage:
-	 * - Raw `storage*` methods are namespace-locked to this app's own buckets
-	 *   (`packageId` and `${packageId}:…`). The bridge stub is reachable from
+	 * - Raw `storage*` methods are namespace-locked to this app's internal
+	 *   `${packageId}:…` buckets. The bridge stub is reachable from
 	 *   user code via `Object.create(env)`, so these methods must never accept
-	 *   arbitrary same-user ids (`package:…`, `job:…`, other package roots).
+	 *   arbitrary same-user ids (`package:…`, raw package ids, `job:…`).
 	 * - `package:{…}` durable buckets are reached only through the
 	 *   grant-validated `packageStorage*` methods (`assertPackageStorageGranted`
 	 *   from bundler-controlled provenance).
@@ -891,15 +853,12 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			throw new Error('Package app storage requires a non-empty storage id.')
 		}
 		const packageId = this.ctx.props.packageId
-		if (
-			normalizedStorageId === packageId ||
-			normalizedStorageId.startsWith(`${packageId}:`)
-		) {
+		if (normalizedStorageId.startsWith(`${packageId}:`)) {
 			return normalizedStorageId
 		}
 		throw new Error(
 			`Package app storage id "${normalizedStorageId}" is outside this app's namespace. ` +
-				`Raw storage methods only accept "${packageId}" or ids prefixed with "${packageId}:". ` +
+				`Raw storage methods only accept ids prefixed with "${packageId}:". ` +
 				'Saved-package durable buckets use packageStorage() and are gated by bundler provenance grants.',
 		)
 	}
@@ -989,73 +948,9 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 
 	async callCapability(input: { name: string; args?: unknown }) {
 		const name = input.name.trim()
-		switch (name) {
-			case 'storage_get':
-				return await this.storageGet({
-					storageId: this.ctx.props.packageId,
-					key:
-						typeof input.args === 'object' &&
-						input.args !== null &&
-						'key' in input.args
-							? String((input.args as { key: unknown }).key ?? '')
-							: '',
-				})
-			case 'storage_list':
-				return await this.storageList({
-					storageId: this.ctx.props.packageId,
-					...(typeof input.args === 'object' && input.args !== null
-						? (input.args as Record<string, unknown>)
-						: {}),
-				})
-			case 'storage_sql':
-				return await this.storageSql({
-					storageId: this.ctx.props.packageId,
-					query:
-						typeof input.args === 'object' &&
-						input.args !== null &&
-						'query' in input.args
-							? String((input.args as { query: unknown }).query ?? '')
-							: '',
-					params:
-						typeof input.args === 'object' &&
-						input.args !== null &&
-						Array.isArray((input.args as { params?: unknown }).params)
-							? ((input.args as { params: Array<unknown> }).params ?? [])
-							: [],
-					writable: true,
-				})
-			case 'storage_set':
-				return await this.storageSet({
-					storageId: this.ctx.props.packageId,
-					key:
-						typeof input.args === 'object' &&
-						input.args !== null &&
-						'key' in input.args
-							? String((input.args as { key: unknown }).key ?? '')
-							: '',
-					value:
-						typeof input.args === 'object' && input.args !== null
-							? (input.args as { value?: unknown }).value
-							: undefined,
-				})
-			case 'storage_delete':
-				return await this.storageDelete({
-					storageId: this.ctx.props.packageId,
-					key:
-						typeof input.args === 'object' &&
-						input.args !== null &&
-						'key' in input.args
-							? String((input.args as { key: unknown }).key ?? '')
-							: '',
-				})
-			case 'storage_clear':
-				return await this.storageClear({
-					storageId: this.ctx.props.packageId,
-				})
-		}
 		const { capabilityMap } = await getCapabilityRegistryForContext({
 			env: this.env,
-			callerContext: this.createCallerContext(this.ctx.props.packageId),
+			callerContext: this.createCallerContext(null),
 		})
 		const capability = capabilityMap[name]
 		if (!capability) {
@@ -1065,7 +960,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			(input.args ?? {}) as Record<string, unknown>,
 			{
 				env: this.env,
-				callerContext: this.createCallerContext(this.ctx.props.packageId),
+				callerContext: this.createCallerContext(null),
 			},
 		)
 	}
@@ -1804,7 +1699,7 @@ async function buildPackageAppWorkerOptionsUncached(input: {
 							sessionId: null,
 							appId: input.savedPackage.id,
 							packageId: input.savedPackage.id,
-							storageId: input.savedPackage.id,
+							storageId: null,
 						},
 					},
 				})
@@ -1897,7 +1792,7 @@ export async function createPackageAppCallerContext(input: {
 			sessionId: null,
 			appId: input.packageId,
 			packageId: input.packageId,
-			storageId: input.packageId,
+			storageId: null,
 		},
 	})
 }

--- a/packages/worker/src/package-storage-audit/service.node.test.ts
+++ b/packages/worker/src/package-storage-audit/service.node.test.ts
@@ -1,214 +1,104 @@
 import { expect, test, vi } from 'vitest'
+import type * as PackageRegistryService from '#worker/package-registry/service.ts'
 import type * as StorageRunnerModule from '#worker/storage-runner.ts'
 
-const mockModule = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => ({
+	clearPackageOwnedStorageBucket: vi.fn(),
 	storageRunnerRpc: vi.fn(),
-	loadPackageSourceBySourceId: vi.fn(),
 }))
+
+vi.mock('#worker/package-registry/service.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof PackageRegistryService>()
+	return {
+		...actual,
+		clearPackageOwnedStorageBucket: (...args: Array<unknown>) =>
+			mocks.clearPackageOwnedStorageBucket(...args),
+	}
+})
 
 vi.mock('#worker/storage-runner.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof StorageRunnerModule>()
 	return {
 		...actual,
 		storageRunnerRpc: (...args: Array<unknown>) =>
-			mockModule.storageRunnerRpc(...args),
+			mocks.storageRunnerRpc(...args),
 	}
 })
 
-vi.mock('#worker/package-registry/source.ts', () => ({
-	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
-		mockModule.loadPackageSourceBySourceId(...args),
-}))
-
-type SavedPackageRow = {
-	userId: string
-	packageId: string
-	kodyId: string
-	sourceId: string
-	hasApp: number
-}
-
-type StorageBucketRow = {
+type BucketRow = {
 	userId: string
 	storageId: string
 	kind: string
 	lastSeenAt: string
 }
 
-function packageOwnershipKey(userId: string, packageId: string) {
-	return `${userId}\0${packageId}`
-}
-
-function comparePackageKeys(
-	left: { userId: string; packageId: string },
-	right: { userId: string; packageId: string },
+function compareBucketKeys(
+	left: Pick<BucketRow, 'userId' | 'storageId'>,
+	right: Pick<BucketRow, 'userId' | 'storageId'>,
 ) {
 	const byUser = left.userId.localeCompare(right.userId)
-	if (byUser !== 0) return byUser
-	return left.packageId.localeCompare(right.packageId)
+	return byUser === 0 ? left.storageId.localeCompare(right.storageId) : byUser
 }
 
-function createAuditTestEnv(input: {
-	packages: Array<SavedPackageRow>
-	buckets: Array<StorageBucketRow>
-}) {
-	function normalize(query: string) {
-		return query.replace(/\s+/g, ' ').trim().toLowerCase()
-	}
-
-	function createStatement(query: string, params: Array<unknown> = []) {
-		const normalized = normalize(query)
-		return {
-			bind(...nextParams: Array<unknown>) {
-				return createStatement(query, nextParams)
-			},
-			async first() {
-				throw new Error(`Unsupported first query: ${query}`)
-			},
-			async all<T>() {
-				if (
-					normalized.includes('from saved_packages') &&
-					normalized.includes('has_app = 1')
-				) {
-					const hasKeyset = normalized.includes('user_id > ?')
-					const limit = Number(
-						params[hasKeyset ? 3 : 0] ?? input.packages.length,
-					)
-					const startAfter = hasKeyset
-						? {
-								userId: String(params[0]),
-								packageId: String(params[2]),
-							}
-						: null
-					const rows = input.packages
-						.filter((row) => row.hasApp === 1)
-						.filter((row) =>
-							startAfter ? comparePackageKeys(row, startAfter) > 0 : true,
-						)
-						.sort(comparePackageKeys)
-						.slice(0, limit)
-						.map((row) => ({
-							userId: row.userId,
-							packageId: row.packageId,
-							kodyId: row.kodyId,
-							sourceId: row.sourceId,
-						}))
-					return {
-						results: rows,
-						meta: { changes: 0 },
-					} as { results: Array<T>; meta: { changes: number } }
-				}
-				if (
-					normalized.includes('from user_storage_buckets b') &&
-					normalized.includes("kind = 'app'") &&
-					normalized.includes('p.user_id = b.user_id')
-				) {
-					const limit = Number(params[0] ?? Number.POSITIVE_INFINITY)
-					const ownedKeys = new Set(
-						input.packages.map((row) =>
-							packageOwnershipKey(row.userId, row.packageId),
-						),
-					)
-					const rows = input.buckets
-						.filter(
-							(row) =>
-								row.kind === 'app' &&
-								!ownedKeys.has(packageOwnershipKey(row.userId, row.storageId)),
-						)
-						.sort((left, right) => {
-							const byUser = left.userId.localeCompare(right.userId)
-							if (byUser !== 0) return byUser
-							return left.storageId.localeCompare(right.storageId)
-						})
-						.slice(0, limit)
-						.map((row) => ({
-							userId: row.userId,
-							storageId: row.storageId,
-							lastSeenAt: row.lastSeenAt,
-						}))
-					return {
-						results: rows,
-						meta: { changes: 0 },
-					} as { results: Array<T>; meta: { changes: number } }
-				}
-				throw new Error(`Unsupported all query: ${query}`)
-			},
-			async run() {
-				throw new Error(`Unsupported run query: ${query}`)
-			},
-		}
-	}
-
+function createAuditEnv(buckets: Array<BucketRow>) {
 	return {
 		APP_DB: {
 			prepare(query: string) {
-				return createStatement(query)
+				const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind(...params: Array<unknown>) {
+						return {
+							async all<T>() {
+								if (
+									!normalized.includes('from user_storage_buckets') ||
+									!normalized.includes("kind = 'app'")
+								) {
+									throw new Error(`Unsupported query: ${query}`)
+								}
+								const hasCursor = normalized.includes('user_id > ?')
+								const cursor = hasCursor
+									? {
+											userId: String(params[0]),
+											storageId: String(params[2]),
+										}
+									: null
+								const limit = Number(params[hasCursor ? 3 : 0])
+								const rows = buckets
+									.filter((row) => row.kind === 'app')
+									.filter((row) =>
+										cursor ? compareBucketKeys(row, cursor) > 0 : true,
+									)
+									.sort(compareBucketKeys)
+									.slice(0, limit)
+									.map(({ userId, storageId, lastSeenAt }) => ({
+										userId,
+										storageId,
+										lastSeenAt,
+									}))
+								return { results: rows as Array<T> }
+							},
+						}
+					},
+				}
 			},
 		},
 	} as unknown as Env
 }
 
-const { buildPackageStorageAuditReport } = await import('./service.ts')
-
-function stubEstimate(bytes: number | Error) {
+function estimate(bytes: number | Error) {
 	return {
-		getEstimatedBytes: async () => {
+		async getEstimatedBytes() {
 			if (bytes instanceof Error) throw bytes
 			return { estimatedBytes: bytes }
 		},
 	}
 }
 
-function neverResolves<T>(): Promise<T> {
-	return new Promise(() => {})
-}
+const { buildPackageStorageAuditReport, cleanupLegacyPackageStorageBuckets } =
+	await import('./service.ts')
 
-test('package storage audit report probes legacy buckets, ambient imports, and orphans', async () => {
-	const packages: Array<SavedPackageRow> = [
-		{
-			userId: 'user-a',
-			packageId: 'pkg-empty',
-			kodyId: 'empty-app',
-			sourceId: 'source-empty',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-a',
-			packageId: 'pkg-data',
-			kodyId: 'data-app',
-			sourceId: 'source-data',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-b',
-			packageId: 'pkg-ambient',
-			kodyId: 'ambient-app',
-			sourceId: 'source-ambient',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-b',
-			packageId: 'pkg-probe-error',
-			kodyId: 'probe-error-app',
-			sourceId: 'source-probe-error',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-b',
-			packageId: 'pkg-scan-error',
-			kodyId: 'scan-error-app',
-			sourceId: 'source-scan-error',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-a',
-			packageId: 'pkg-no-app',
-			kodyId: 'no-app',
-			sourceId: 'source-no-app',
-			hasApp: 0,
-		},
-	]
-	const buckets: Array<StorageBucketRow> = [
+test('package storage audit verifies only registered legacy app buckets', async () => {
+	const env = createAuditEnv([
 		{
 			userId: 'user-a',
 			storageId: 'pkg-empty',
@@ -216,251 +106,126 @@ test('package storage audit report probes legacy buckets, ambient imports, and o
 			lastSeenAt: '2026-07-01T00:00:00.000Z',
 		},
 		{
-			userId: 'user-z',
-			storageId: 'deleted-pkg',
-			kind: 'app',
+			userId: 'user-a',
+			storageId: 'job:keep',
+			kind: 'job',
 			lastSeenAt: '2026-07-02T00:00:00.000Z',
 		},
 		{
-			// Cross-user collision: storage_id matches user-b's package, but the
-			// bucket belongs to user-a, so it must still count as an orphan.
-			userId: 'user-a',
-			storageId: 'pkg-ambient',
+			userId: 'user-b',
+			storageId: 'pkg-data',
 			kind: 'app',
-			lastSeenAt: '2026-07-02T12:00:00.000Z',
-		},
-		{
-			userId: 'user-a',
-			storageId: 'job:still-here',
-			kind: 'job',
 			lastSeenAt: '2026-07-03T00:00:00.000Z',
 		},
-	]
-	const env = createAuditTestEnv({ packages, buckets })
-
-	mockModule.storageRunnerRpc.mockImplementation(
-		(input: { storageId: string }) => {
-			if (input.storageId === 'pkg-empty') return stubEstimate(4096)
-			if (input.storageId === 'pkg-data') return stubEstimate(8192)
-			if (input.storageId === 'pkg-ambient') return stubEstimate(4096)
-			if (input.storageId === 'pkg-probe-error') {
-				return stubEstimate(new Error('DO unavailable'))
-			}
-			if (input.storageId === 'pkg-scan-error') return stubEstimate(4096)
-			throw new Error(`Unexpected storageId: ${input.storageId}`)
-		},
-	)
-	mockModule.loadPackageSourceBySourceId.mockImplementation(
-		async (input: { sourceId: string }) => {
-			if (
-				input.sourceId === 'source-empty' ||
-				input.sourceId === 'source-data' ||
-				input.sourceId === 'source-probe-error'
-			) {
-				return {
-					files: {
-						'index.ts': `import { packageStorage } from 'kody:runtime'\nexport const x = packageStorage()\n`,
-					},
-				}
-			}
-			if (input.sourceId === 'source-ambient') {
-				return {
-					files: {
-						'app.ts': `import { storage } from 'kody:runtime'\nexport const read = () => storage.get('k')\n`,
-						'helpers.ts': `import { kody } from 'kody:runtime'\nexport const noop = () => kody\n`,
-					},
-				}
-			}
-			if (input.sourceId === 'source-scan-error') {
-				throw new Error('source missing')
-			}
-			throw new Error(`Unexpected sourceId: ${input.sourceId}`)
-		},
+	])
+	mocks.storageRunnerRpc.mockImplementation((input: { storageId: string }) =>
+		estimate(input.storageId === 'pkg-empty' ? 4096 : 8192),
 	)
 
-	const body = await buildPackageStorageAuditReport({
-		env,
-		baseUrl: 'https://example.com',
-		limit: 200,
-	})
-	expect(body).toMatchObject({
+	const report = await buildPackageStorageAuditReport({ env, limit: 200 })
+
+	expect(report).toEqual({
 		ok: true,
-		nextStartAfter: null,
-		totals: {
-			appPackages: 5,
-			nonEmptyLegacyBuckets: 1,
-			packagesWithAmbientImports: 1,
-			orphanAppBuckets: 2,
-			truncated: false,
-			orphanTruncated: false,
-		},
-		orphanAppBuckets: [
+		legacyBuckets: [
 			{
 				userId: 'user-a',
-				storageId: 'pkg-ambient',
-				lastSeenAt: '2026-07-02T12:00:00.000Z',
+				storageId: 'pkg-empty',
+				lastSeenAt: '2026-07-01T00:00:00.000Z',
+				estimatedBytes: 4096,
+				probeError: null,
 			},
 			{
-				userId: 'user-z',
-				storageId: 'deleted-pkg',
-				lastSeenAt: '2026-07-02T00:00:00.000Z',
+				userId: 'user-b',
+				storageId: 'pkg-data',
+				lastSeenAt: '2026-07-03T00:00:00.000Z',
+				estimatedBytes: 8192,
+				probeError: null,
 			},
 		],
-	})
-
-	const byId = new Map(body.packages.map((row) => [row.packageId, row]))
-	expect(byId.get('pkg-empty')).toMatchObject({
-		userId: 'user-a',
-		kodyId: 'empty-app',
-		legacyBucketBytes: 4096,
-		legacyBucketProbeError: null,
-		ambientStorageImportFiles: [],
-		sourceScanError: null,
-	})
-	expect(byId.get('pkg-data')).toMatchObject({
-		legacyBucketBytes: 8192,
-		legacyBucketProbeError: null,
-		ambientStorageImportFiles: [],
-		sourceScanError: null,
-	})
-	expect(byId.get('pkg-ambient')).toMatchObject({
-		userId: 'user-b',
-		legacyBucketBytes: 4096,
-		ambientStorageImportFiles: ['app.ts'],
-		sourceScanError: null,
-	})
-	expect(byId.get('pkg-probe-error')).toMatchObject({
-		legacyBucketBytes: null,
-		legacyBucketProbeError: 'DO unavailable',
-		ambientStorageImportFiles: [],
-		sourceScanError: null,
-	})
-	expect(byId.get('pkg-scan-error')).toMatchObject({
-		legacyBucketBytes: 4096,
-		legacyBucketProbeError: null,
-		ambientStorageImportFiles: [],
-		sourceScanError: 'source missing',
-	})
-
-	for (const call of mockModule.storageRunnerRpc.mock.calls) {
-		const arg = call[0] as { userId: string; storageId: string }
-		const pkg = packages.find((row) => row.packageId === arg.storageId)
-		expect(pkg).toBeTruthy()
-		expect(arg.userId).toBe(pkg?.userId)
-	}
-})
-
-test('package storage audit report supports limit truncation and keyset paging', async () => {
-	const packages = Array.from({ length: 4 }, (_, index) => ({
-		userId: 'user-a',
-		packageId: `pkg-${String(index)}`,
-		kodyId: `app-${String(index)}`,
-		sourceId: `source-${String(index)}`,
-		hasApp: 1 as const,
-	}))
-	const env = createAuditTestEnv({ packages, buckets: [] })
-	mockModule.storageRunnerRpc.mockImplementation(() => stubEstimate(0))
-	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
-		files: { 'index.ts': 'export const ok = true\n' },
-	})
-
-	const page1 = await buildPackageStorageAuditReport({
-		env,
-		baseUrl: 'https://example.com',
-		limit: 2,
-	})
-	expect(page1).toMatchObject({
-		ok: true,
-		packages: [{ packageId: 'pkg-0' }, { packageId: 'pkg-1' }],
-		nextStartAfter: JSON.stringify({
-			userId: 'user-a',
-			packageId: 'pkg-1',
-		}),
-		totals: {
-			appPackages: 2,
-			nonEmptyLegacyBuckets: 0,
-			packagesWithAmbientImports: 0,
-			orphanAppBuckets: 0,
-			truncated: true,
-			orphanTruncated: false,
-		},
-	})
-
-	const page2 = await buildPackageStorageAuditReport({
-		env,
-		baseUrl: 'https://example.com',
-		limit: 2,
-		startAfter: page1.nextStartAfter,
-	})
-	expect(page2).toMatchObject({
-		ok: true,
-		packages: [{ packageId: 'pkg-2' }, { packageId: 'pkg-3' }],
 		nextStartAfter: null,
 		totals: {
-			appPackages: 2,
+			legacyBuckets: 2,
+			nonEmptyLegacyBuckets: 1,
+			probeErrors: 0,
 			truncated: false,
 		},
 	})
+	expect(mocks.storageRunnerRpc).toHaveBeenCalledTimes(2)
 })
 
-test('package storage audit deadlines hanging probes and source scans', async () => {
-	const packages: Array<SavedPackageRow> = [
-		{
+test('package storage audit supports keyset paging and probe deadlines', async () => {
+	const env = createAuditEnv(
+		Array.from({ length: 3 }, (_, index) => ({
 			userId: 'user-a',
-			packageId: 'pkg-hang-probe',
-			kodyId: 'hang-probe',
-			sourceId: 'source-ok',
-			hasApp: 1,
-		},
-		{
-			userId: 'user-a',
-			packageId: 'pkg-hang-scan',
-			kodyId: 'hang-scan',
-			sourceId: 'source-hang',
-			hasApp: 1,
-		},
-	]
-	const env = createAuditTestEnv({ packages, buckets: [] })
-	mockModule.storageRunnerRpc.mockImplementation(
-		(input: { storageId: string }) => {
-			if (input.storageId === 'pkg-hang-probe') {
-				return { getEstimatedBytes: () => neverResolves() }
-			}
-			return stubEstimate(4096)
-		},
+			storageId: `pkg-${String(index)}`,
+			kind: 'app',
+			lastSeenAt: '2026-07-01T00:00:00.000Z',
+		})),
 	)
-	mockModule.loadPackageSourceBySourceId.mockImplementation(
-		async (input: { sourceId: string }) => {
-			if (input.sourceId === 'source-hang') return neverResolves()
-			return {
-				files: { 'index.ts': 'export const ok = true\n' },
-			}
-		},
+	mocks.storageRunnerRpc.mockImplementation((input: { storageId: string }) =>
+		input.storageId === 'pkg-1'
+			? { getEstimatedBytes: () => new Promise(() => {}) }
+			: estimate(4096),
 	)
 
-	const report = await buildPackageStorageAuditReport({
+	const first = await buildPackageStorageAuditReport({
 		env,
-		baseUrl: 'https://example.com',
-		limit: 10,
-		budgets: {
-			legacyBucketProbeMs: 20,
-			sourceScanMs: 20,
-		},
+		limit: 2,
+		budgets: { legacyBucketProbeMs: 10 },
+	})
+	expect(first.nextStartAfter).toBe(
+		JSON.stringify({ userId: 'user-a', storageId: 'pkg-1' }),
+	)
+	expect(first.totals).toEqual({
+		legacyBuckets: 2,
+		nonEmptyLegacyBuckets: 0,
+		probeErrors: 1,
+		truncated: true,
 	})
 
-	expect(report.packages).toHaveLength(2)
-	expect(report.nextStartAfter).toBeNull()
-	const byId = new Map(report.packages.map((row) => [row.packageId, row]))
-	expect(byId.get('pkg-hang-probe')).toMatchObject({
-		legacyBucketBytes: null,
-		legacyBucketProbeError: 'timed out after 20ms',
-		ambientStorageImportFiles: [],
-		sourceScanError: null,
+	const second = await buildPackageStorageAuditReport({
+		env,
+		limit: 2,
+		startAfter: first.nextStartAfter,
 	})
-	expect(byId.get('pkg-hang-scan')).toMatchObject({
-		legacyBucketBytes: 4096,
-		legacyBucketProbeError: null,
-		ambientStorageImportFiles: [],
-		sourceScanError: 'timed out after 20ms',
+	expect(second.legacyBuckets.map((row) => row.storageId)).toEqual(['pkg-2'])
+	expect(second.nextStartAfter).toBeNull()
+})
+
+test('legacy package storage cleanup clears buckets through package cleanup machinery', async () => {
+	const env = createAuditEnv([
+		{
+			userId: 'user-a',
+			storageId: 'pkg-ok',
+			kind: 'app',
+			lastSeenAt: '2026-07-01T00:00:00.000Z',
+		},
+		{
+			userId: 'user-b',
+			storageId: 'pkg-failed',
+			kind: 'app',
+			lastSeenAt: '2026-07-02T00:00:00.000Z',
+		},
+	])
+	mocks.clearPackageOwnedStorageBucket.mockImplementation(
+		async (input: { storageId: string }) => input.storageId === 'pkg-ok',
+	)
+
+	const report = await cleanupLegacyPackageStorageBuckets({ env, limit: 200 })
+
+	expect(report).toEqual({
+		ok: true,
+		buckets: [
+			{ userId: 'user-a', storageId: 'pkg-ok', cleared: true },
+			{ userId: 'user-b', storageId: 'pkg-failed', cleared: false },
+		],
+		nextStartAfter: null,
+		totals: { cleared: 1, failed: 1, truncated: false },
+	})
+	expect(mocks.clearPackageOwnedStorageBucket).toHaveBeenCalledWith({
+		env,
+		userId: 'user-a',
+		packageId: 'pkg-ok',
+		storageId: 'pkg-ok',
 	})
 })

--- a/packages/worker/src/package-storage-audit/service.ts
+++ b/packages/worker/src/package-storage-audit/service.ts
@@ -1,7 +1,6 @@
 import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
-import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
-import { collectAmbientStorageImportFiles } from '#worker/repo/checks.ts'
+import { clearPackageOwnedStorageBucket } from '#worker/package-registry/service.ts'
 import {
 	emptyStorageRunnerEstimatedBytes,
 	storageRunnerRpc,
@@ -10,124 +9,155 @@ import {
 export const defaultPackageStorageAuditLimit = 200
 export const maxPackageStorageAuditLimit = 500
 export const defaultLegacyBucketProbeTimeoutMs = 10_000
-export const defaultSourceScanTimeoutMs = 20_000
-const maxOrphanAppBuckets = 500
 const maxConcurrentPackageAuditProbes = 5
 
-export type PackageStorageAuditPackageRow = {
-	userId: string
-	packageId: string
-	kodyId: string
-	legacyBucketBytes: number | null
-	legacyBucketProbeError: string | null
-	ambientStorageImportFiles: Array<string>
-	sourceScanError: string | null
-}
-
-export type PackageStorageAuditOrphanBucket = {
+export type PackageStorageAuditBucketRow = {
 	userId: string
 	storageId: string
 	lastSeenAt: string
+	estimatedBytes: number | null
+	probeError: string | null
 }
 
 export type PackageStorageAuditReport = {
 	ok: true
-	packages: Array<PackageStorageAuditPackageRow>
-	orphanAppBuckets: Array<PackageStorageAuditOrphanBucket>
+	legacyBuckets: Array<PackageStorageAuditBucketRow>
 	nextStartAfter: string | null
 	totals: {
-		appPackages: number
+		legacyBuckets: number
 		nonEmptyLegacyBuckets: number
-		packagesWithAmbientImports: number
-		orphanAppBuckets: number
+		probeErrors: number
 		truncated: boolean
-		orphanTruncated: boolean
 	}
 }
 
 export type PackageStorageAuditBudgets = {
 	legacyBucketProbeMs?: number
-	sourceScanMs?: number
 }
 
-type AppPackageRow = {
-	userId: string
-	packageId: string
-	kodyId: string
-	sourceId: string
+export type PackageStorageCleanupReport = {
+	ok: true
+	buckets: Array<{
+		userId: string
+		storageId: string
+		cleared: boolean
+	}>
+	nextStartAfter: string | null
+	totals: {
+		cleared: number
+		failed: number
+		truncated: boolean
+	}
 }
 
 type PackageStorageAuditCursor = {
 	userId: string
-	packageId: string
+	storageId: string
 }
 
 type ResolvedBudgets = {
 	legacyBucketProbeMs: number
-	sourceScanMs: number
 }
 
 export async function buildPackageStorageAuditReport(input: {
 	env: Env
-	baseUrl: string
 	limit: number
 	startAfter?: string | null
 	budgets?: PackageStorageAuditBudgets
 }): Promise<PackageStorageAuditReport> {
 	const cursor = parseStartAfterCursor(input.startAfter)
 	const budgets = resolveBudgets(input.budgets)
-	const [appPackagePage, orphanPage] = await Promise.all([
-		listAppPackagesForAudit({
-			db: input.env.APP_DB,
-			limit: input.limit,
-			startAfter: cursor,
-		}),
-		listOrphanAppBuckets({ db: input.env.APP_DB }),
-	])
+	const bucketPage = await listLegacyBucketsForAudit({
+		db: input.env.APP_DB,
+		limit: input.limit,
+		startAfter: cursor,
+	})
 
-	const packages: Array<PackageStorageAuditPackageRow> = []
+	const legacyBuckets: Array<PackageStorageAuditBucketRow> = []
 	for (const chunk of chunkArray(
-		appPackagePage.rows,
+		bucketPage.rows,
 		maxConcurrentPackageAuditProbes,
 	)) {
 		const chunkRows = await Promise.all(
 			chunk.map((row) =>
-				auditAppPackage({
+				auditLegacyBucket({
 					env: input.env,
-					baseUrl: input.baseUrl,
 					row,
 					budgets,
 				}),
 			),
 		)
-		packages.push(...chunkRows)
+		legacyBuckets.push(...chunkRows)
 	}
 
-	const lastRow = packages.at(-1)
+	const lastRow = legacyBuckets.at(-1)
 	return {
 		ok: true,
-		packages,
-		orphanAppBuckets: orphanPage.rows,
+		legacyBuckets,
 		nextStartAfter:
-			appPackagePage.truncated && lastRow
+			bucketPage.truncated && lastRow
 				? encodeStartAfterCursor({
 						userId: lastRow.userId,
-						packageId: lastRow.packageId,
+						storageId: lastRow.storageId,
 					})
 				: null,
 		totals: {
-			appPackages: packages.length,
-			nonEmptyLegacyBuckets: packages.filter(
+			legacyBuckets: legacyBuckets.length,
+			nonEmptyLegacyBuckets: legacyBuckets.filter(
 				(row) =>
-					row.legacyBucketBytes != null &&
-					row.legacyBucketBytes > emptyStorageRunnerEstimatedBytes,
+					row.estimatedBytes != null &&
+					row.estimatedBytes > emptyStorageRunnerEstimatedBytes,
 			).length,
-			packagesWithAmbientImports: packages.filter(
-				(row) => row.ambientStorageImportFiles.length > 0,
-			).length,
-			orphanAppBuckets: orphanPage.rows.length,
-			truncated: appPackagePage.truncated,
-			orphanTruncated: orphanPage.truncated,
+			probeErrors: legacyBuckets.filter((row) => row.probeError != null).length,
+			truncated: bucketPage.truncated,
+		},
+	}
+}
+
+export async function cleanupLegacyPackageStorageBuckets(input: {
+	env: Env
+	limit: number
+	startAfter?: string | null
+}): Promise<PackageStorageCleanupReport> {
+	const bucketPage = await listLegacyBucketsForAudit({
+		db: input.env.APP_DB,
+		limit: input.limit,
+		startAfter: parseStartAfterCursor(input.startAfter),
+	})
+	const buckets: PackageStorageCleanupReport['buckets'] = []
+	for (const chunk of chunkArray(
+		bucketPage.rows,
+		maxConcurrentPackageAuditProbes,
+	)) {
+		const chunkResults = await Promise.all(
+			chunk.map(async (row) => ({
+				userId: row.userId,
+				storageId: row.storageId,
+				cleared: await clearPackageOwnedStorageBucket({
+					env: input.env,
+					userId: row.userId,
+					packageId: row.storageId,
+					storageId: row.storageId,
+				}),
+			})),
+		)
+		buckets.push(...chunkResults)
+	}
+	const lastRow = buckets.at(-1)
+	return {
+		ok: true,
+		buckets,
+		nextStartAfter:
+			bucketPage.truncated && lastRow
+				? encodeStartAfterCursor({
+						userId: lastRow.userId,
+						storageId: lastRow.storageId,
+					})
+				: null,
+		totals: {
+			cleared: buckets.filter((row) => row.cleared).length,
+			failed: buckets.filter((row) => !row.cleared).length,
+			truncated: bucketPage.truncated,
 		},
 	}
 }
@@ -138,14 +168,13 @@ function resolveBudgets(
 	return {
 		legacyBucketProbeMs:
 			budgets?.legacyBucketProbeMs ?? defaultLegacyBucketProbeTimeoutMs,
-		sourceScanMs: budgets?.sourceScanMs ?? defaultSourceScanTimeoutMs,
 	}
 }
 
 function encodeStartAfterCursor(cursor: PackageStorageAuditCursor) {
 	return JSON.stringify({
 		userId: cursor.userId,
-		packageId: cursor.packageId,
+		storageId: cursor.storageId,
 	})
 }
 
@@ -170,17 +199,17 @@ function parseStartAfterCursor(
 		typeof parsed !== 'object' ||
 		Array.isArray(parsed) ||
 		typeof (parsed as { userId?: unknown }).userId !== 'string' ||
-		typeof (parsed as { packageId?: unknown }).packageId !== 'string' ||
+		typeof (parsed as { storageId?: unknown }).storageId !== 'string' ||
 		(parsed as { userId: string }).userId.length === 0 ||
-		(parsed as { packageId: string }).packageId.length === 0
+		(parsed as { storageId: string }).storageId.length === 0
 	) {
 		throw new InvalidStartAfterCursorError(
-			'Invalid startAfter cursor: expected { userId, packageId } strings.',
+			'Invalid startAfter cursor: expected { userId, storageId } strings.',
 		)
 	}
 	return {
 		userId: (parsed as { userId: string }).userId,
-		packageId: (parsed as { packageId: string }).packageId,
+		storageId: (parsed as { storageId: string }).storageId,
 	}
 }
 
@@ -205,40 +234,46 @@ async function withDeadline<T>(
 	}
 }
 
-async function listAppPackagesForAudit(input: {
+type LegacyBucketInventoryRow = {
+	userId: string
+	storageId: string
+	lastSeenAt: string
+}
+
+async function listLegacyBucketsForAudit(input: {
 	db: D1Database
 	limit: number
 	startAfter: PackageStorageAuditCursor | null
-}): Promise<{ rows: Array<AppPackageRow>; truncated: boolean }> {
+}): Promise<{ rows: Array<LegacyBucketInventoryRow>; truncated: boolean }> {
 	const result = input.startAfter
 		? await input.db
 				.prepare(
-					`SELECT user_id AS userId, id AS packageId, kody_id AS kodyId,
-						source_id AS sourceId
-					FROM saved_packages
-					WHERE has_app = 1
-						AND (user_id > ? OR (user_id = ? AND id > ?))
-					ORDER BY user_id ASC, id ASC
+					`SELECT user_id AS userId, storage_id AS storageId,
+						last_seen_at AS lastSeenAt
+					FROM user_storage_buckets
+					WHERE kind = 'app'
+						AND (user_id > ? OR (user_id = ? AND storage_id > ?))
+					ORDER BY user_id ASC, storage_id ASC
 					LIMIT ?`,
 				)
 				.bind(
 					input.startAfter.userId,
 					input.startAfter.userId,
-					input.startAfter.packageId,
+					input.startAfter.storageId,
 					input.limit + 1,
 				)
-				.all<AppPackageRow>()
+				.all<LegacyBucketInventoryRow>()
 		: await input.db
 				.prepare(
-					`SELECT user_id AS userId, id AS packageId, kody_id AS kodyId,
-						source_id AS sourceId
-					FROM saved_packages
-					WHERE has_app = 1
-					ORDER BY user_id ASC, id ASC
+					`SELECT user_id AS userId, storage_id AS storageId,
+						last_seen_at AS lastSeenAt
+					FROM user_storage_buckets
+					WHERE kind = 'app'
+					ORDER BY user_id ASC, storage_id ASC
 					LIMIT ?`,
 				)
 				.bind(input.limit + 1)
-				.all<AppPackageRow>()
+				.all<LegacyBucketInventoryRow>()
 	const rows = result.results ?? []
 	const truncated = rows.length > input.limit
 	return {
@@ -247,68 +282,28 @@ async function listAppPackagesForAudit(input: {
 	}
 }
 
-async function listOrphanAppBuckets(input: { db: D1Database }): Promise<{
-	rows: Array<PackageStorageAuditOrphanBucket>
-	truncated: boolean
-}> {
-	const result = await input.db
-		.prepare(
-			`SELECT b.user_id AS userId, b.storage_id AS storageId,
-				b.last_seen_at AS lastSeenAt
-			FROM user_storage_buckets b
-			LEFT JOIN saved_packages p
-				ON p.id = b.storage_id AND p.user_id = b.user_id
-			WHERE b.kind = 'app' AND p.id IS NULL
-			ORDER BY b.user_id ASC, b.storage_id ASC
-			LIMIT ?`,
-		)
-		.bind(maxOrphanAppBuckets + 1)
-		.all<PackageStorageAuditOrphanBucket>()
-	const rows = result.results ?? []
-	const truncated = rows.length > maxOrphanAppBuckets
-	return {
-		rows: truncated ? rows.slice(0, maxOrphanAppBuckets) : rows,
-		truncated,
-	}
-}
-
-async function auditAppPackage(input: {
+async function auditLegacyBucket(input: {
 	env: Env
-	baseUrl: string
-	row: AppPackageRow
+	row: LegacyBucketInventoryRow
 	budgets: ResolvedBudgets
-}): Promise<PackageStorageAuditPackageRow> {
-	const [legacyProbe, sourceScan] = await Promise.all([
-		probeLegacyBucketBytes({
-			env: input.env,
-			userId: input.row.userId,
-			packageId: input.row.packageId,
-			timeoutMs: input.budgets.legacyBucketProbeMs,
-		}),
-		scanAmbientStorageImports({
-			env: input.env,
-			baseUrl: input.baseUrl,
-			userId: input.row.userId,
-			sourceId: input.row.sourceId,
-			timeoutMs: input.budgets.sourceScanMs,
-		}),
-	])
-
-	return {
+}): Promise<PackageStorageAuditBucketRow> {
+	const probe = await probeLegacyBucketBytes({
+		env: input.env,
 		userId: input.row.userId,
-		packageId: input.row.packageId,
-		kodyId: input.row.kodyId,
-		legacyBucketBytes: legacyProbe.bytes,
-		legacyBucketProbeError: legacyProbe.error,
-		ambientStorageImportFiles: sourceScan.files,
-		sourceScanError: sourceScan.error,
+		storageId: input.row.storageId,
+		timeoutMs: input.budgets.legacyBucketProbeMs,
+	})
+	return {
+		...input.row,
+		estimatedBytes: probe.bytes,
+		probeError: probe.error,
 	}
 }
 
 async function probeLegacyBucketBytes(input: {
 	env: Env
 	userId: string
-	packageId: string
+	storageId: string
 	timeoutMs: number
 }): Promise<{ bytes: number | null; error: string | null }> {
 	try {
@@ -316,38 +311,12 @@ async function probeLegacyBucketBytes(input: {
 			storageRunnerRpc({
 				env: input.env,
 				userId: input.userId,
-				storageId: input.packageId,
+				storageId: input.storageId,
 			}).getEstimatedBytes(),
 			input.timeoutMs,
 		)
 		return { bytes: estimate.estimatedBytes, error: null }
 	} catch (error) {
 		return { bytes: null, error: getErrorMessage(error) }
-	}
-}
-
-async function scanAmbientStorageImports(input: {
-	env: Env
-	baseUrl: string
-	userId: string
-	sourceId: string
-	timeoutMs: number
-}): Promise<{ files: Array<string>; error: string | null }> {
-	try {
-		const loaded = await withDeadline(
-			loadPackageSourceBySourceId({
-				env: input.env,
-				baseUrl: input.baseUrl,
-				userId: input.userId,
-				sourceId: input.sourceId,
-			}),
-			input.timeoutMs,
-		)
-		return {
-			files: collectAmbientStorageImportFiles(loaded.files),
-			error: null,
-		}
-	} catch (error) {
-		return { files: [], error: getErrorMessage(error) }
 	}
 }

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -947,10 +947,10 @@ export function collectAmbientStorageImportFiles(
  * imported into another context. This only runs where repo checks run — new
  * session check runs, session/external publishes, and community fork installs
  * — so already-published artifacts are never re-validated retroactively.
- * Stage two of the ambient-storage removal plan: #817 shipped the advisory
- * nudge, this fails new publishes, and a follow-up removes the ambient
- * binding from package invocation contexts once an operator audit of
- * published artifacts confirms no remaining usage.
+ * Final guard from the ambient-storage removal: #817 shipped the advisory,
+ * then this check began failing new publishes. The package runtime no longer
+ * binds ambient storage, so this keeps package code portable across every
+ * package surface and points authors at the canonical package bucket.
  */
 function buildLintCheck(sourceFiles: Record<string, string>): {
 	ok: boolean

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -1068,9 +1068,8 @@ export function createStorageKodyTools(input: {
 /**
  * Durable storage id of a saved package's own bucket. Reached via
  * `packageStorage()` from every package surface (invocations, jobs, services,
- * and package apps). Ambient `storage` is not bound on this id for package
- * invocations; apps still expose a legacy ambient `storage` proxy on the raw
- * package id for published compatibility, which is a different bucket.
+ * and package apps). Saved-package runtimes do not bind ambient `storage` to
+ * this bucket; bundler provenance grants access through `packageStorage()`.
  */
 export function buildPackageStorageId(packageId: string) {
 	return `package:${encodeURIComponent(packageId)}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1024
Part of #1069

## Summary
- removes package-app ambient `storage`, flat `kody.storage_*` aliases, and raw package-id caller bindings
- removes raw app ids from account export/deletion and disaster-recovery inventory discovery
- reduces `admin_package_storage_audit` to an inventory-backed zero-legacy verification and adds bounded `admin_package_storage_cleanup`
- removes the retired storage surface from contributor and package docs

## Production data decision
The raw `morning-briefing` bucket contained four report keys. Three had newer versions in the canonical package bucket. The only unique key, `report:2026-06-24` (36,271 JSON bytes), was copied and read-back verified in `package:630292e1-5ea7-478c-b96e-f7f5e04a0b36`; the overlapping keys were stale. This targeted one-shot migration avoided general lazy migration machinery for a single bucket. No D1 migration was needed because cleanup cleared each StorageRunner before deleting its inventory row.

## Validation
- `npm run validate`: passed
- pre-push Node + Workers suites: 1,691 passed
- pre-push Playwright: 19 passed
- [PR CI](https://github.com/kentcdodds/kody/actions/runs/30596778775): passed
- [main CI](https://github.com/kentcdodds/kody/actions/runs/30596987523): passed
- [production deploy](https://github.com/kentcdodds/kody/actions/runs/30597190219): passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d8ddf4ac` · **Head:** `a65a6f1c`

**Classification:** extends — removes a legacy package-app storage contract and adds an operator cleanup action; no primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-apps` | assistant | extends — ambient raw-id storage is no longer bound |
| `package-runtime` | runtime | extends — package apps use provenance-gated `packageStorage()` only |
| `durable-storage` | assistant | extends — legacy inventory can be audited and cleared |
| `account-export` | assistant | extends — raw app ids are no longer synthesized |
| `backup-control-plane` | storage | extends — raw app ids are no longer synthesized |
| `rbac` | auth | composes — cleanup is admin-only and audited |
| `saved-packages` | assistant | composes — reuses package-deletion bucket cleanup |
| `repo-sessions` | runtime | composes — publish lint remains the permanent guard |

### System map

Package apps now reach package-owned data only through the canonical bucket; admins clear the retired raw buckets through existing deletion machinery.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	packageApps["package-apps<br/>Package apps"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	durableStorage["durable-storage<br/>Durable storage buckets"]:::extended
	rbac["rbac<br/>Role-based access control"]:::touched
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	accountExport["account-export<br/>Account data export"]:::extended
	backup["backup-control-plane<br/>Production backup control plane"]:::extended
	packageApps -->|"packageStorage() only"| packageRuntime
	packageRuntime -->|"package:{encoded id}"| durableStorage
	rbac -->|"admin_package_storage_cleanup"| savedPackages
	savedPackages -->|"clear DO, then unregister row"| durableStorage
	accountExport -->|"inventory rows only"| durableStorage
	backup -->|"inventory rows only"| durableStorage
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Apps could bind raw `{packageId}` storage | Apps use `package:{encodeURIComponent(packageId)}` via `packageStorage()` |
| Audit synthesized every `has_app` package | Audit lists only remaining `kind='app'` legacy inventory |
| Export/DR synthesized raw app ids | Export/DR use authoritative inventory |

### Invariants

Every lookup and cleanup remains scoped by both `userId` and `storageId`; cleanup deletes inventory only after that user's Durable Object clears successfully.

</details>

<!-- system-recap:end -->

## Conductor report
Status: done

Merged as `63b32781c1854227a053701cff4ca37baa197242` and deployed successfully. The targeted migration preserved the only unique legacy report. The production cleanup cleared all 9 raw-id buckets with 0 failures and removed their inventory rows. Final production verification:

```json
{
  "ok": true,
  "legacyBuckets": [],
  "nextStartAfter": null,
  "totals": {
    "legacyBuckets": 0,
    "nonEmptyLegacyBuckets": 0,
    "probeErrors": 0,
    "truncated": false
  }
}
```

Scope spill: account export/deletion and DR inventory were updated because they otherwise continued synthesizing and reading raw app ids. `packages/worker/src/index.ts` and migrations were not touched. No decisions needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bf7535c-88fc-4d5f-8f61-38b3d1fd2296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bf7535c-88fc-4d5f-8f61-38b3d1fd2296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

