### PR TITLE
fix(dr): retry transient R2 5xx on backup S3 client

### DIFF
--- a/packages/worker/src/dr/backup-s3.node.test.ts
+++ b/packages/worker/src/dr/backup-s3.node.test.ts
@@ -1,0 +1,142 @@
+import { expect, test, vi } from 'vitest'
+import {
+	createDrBackupS3Client,
+	DrBackupPreconditionFailedError,
+	isTransientDrBackupHttpStatus,
+	readDrBackupS3Config,
+} from './backup-s3.ts'
+
+const config = {
+	accountId: 'acct',
+	bucketName: 'backups',
+	accessKeyId: 'key',
+	secretAccessKey: 'secret',
+}
+
+function jsonResponse(
+	status: number,
+	body = '',
+	headers: Record<string, string> = {},
+) {
+	return new Response(body, { status, headers })
+}
+
+test('isTransientDrBackupHttpStatus matches platform blips only', () => {
+	expect(isTransientDrBackupHttpStatus(429)).toBe(true)
+	expect(isTransientDrBackupHttpStatus(500)).toBe(true)
+	expect(isTransientDrBackupHttpStatus(502)).toBe(true)
+	expect(isTransientDrBackupHttpStatus(503)).toBe(true)
+	expect(isTransientDrBackupHttpStatus(504)).toBe(true)
+	expect(isTransientDrBackupHttpStatus(400)).toBe(false)
+	expect(isTransientDrBackupHttpStatus(403)).toBe(false)
+	expect(isTransientDrBackupHttpStatus(404)).toBe(false)
+	expect(isTransientDrBackupHttpStatus(412)).toBe(false)
+	expect(isTransientDrBackupHttpStatus(200)).toBe(false)
+})
+
+test('put retries transient HTTP 500 then succeeds', async () => {
+	const fetchImpl = vi
+		.fn()
+		.mockResolvedValueOnce(jsonResponse(500, 'blip'))
+		.mockResolvedValueOnce(jsonResponse(200, '', { etag: '"etag-1"' }))
+
+	const client = createDrBackupS3Client(config, fetchImpl as typeof fetch, {
+		maxAttempts: 3,
+		baseDelayMs: 1,
+	})
+	await expect(
+		client.put('staging/day/exporter/progress.json', '{}', {
+			contentType: 'application/json',
+			ifMatch: '"prev"',
+		}),
+	).resolves.toEqual({ etag: '"etag-1"' })
+	expect(fetchImpl).toHaveBeenCalledTimes(2)
+	const secondInit = fetchImpl.mock.calls[1]?.[0] as Request
+	expect(secondInit.method).toBe('PUT')
+	expect(secondInit.headers.get('If-Match')).toBe('"prev"')
+})
+
+test('put does not retry precondition failures', async () => {
+	const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(412, 'conflict'))
+	const client = createDrBackupS3Client(config, fetchImpl as typeof fetch, {
+		maxAttempts: 4,
+		baseDelayMs: 1,
+	})
+	await expect(
+		client.put('staging/day/exporter/progress.json', '{}', {
+			ifMatch: '"prev"',
+		}),
+	).rejects.toBeInstanceOf(DrBackupPreconditionFailedError)
+	expect(fetchImpl).toHaveBeenCalledTimes(1)
+})
+
+test('put retries transport errors then surfaces exhausted failures', async () => {
+	const fetchImpl = vi
+		.fn()
+		.mockRejectedValueOnce(new TypeError('network down'))
+		.mockResolvedValueOnce(jsonResponse(500, 'still bad'))
+		.mockResolvedValueOnce(jsonResponse(500, 'still bad'))
+
+	const client = createDrBackupS3Client(config, fetchImpl as typeof fetch, {
+		maxAttempts: 3,
+		baseDelayMs: 1,
+	})
+	await expect(client.put('key', 'body')).rejects.toThrow(
+		'DR backup PUT failed for key: HTTP 500',
+	)
+	expect(fetchImpl).toHaveBeenCalledTimes(3)
+})
+
+test('head and getText retry transient 503 responses', async () => {
+	const headFetch = vi
+		.fn()
+		.mockResolvedValueOnce(jsonResponse(503))
+		.mockResolvedValueOnce(jsonResponse(200, '', { etag: '"h"' }))
+	const headClient = createDrBackupS3Client(
+		config,
+		headFetch as typeof fetch,
+		{ maxAttempts: 2, baseDelayMs: 1 },
+	)
+	await expect(headClient.head('blob')).resolves.toEqual({
+		exists: true,
+		status: 200,
+		etag: '"h"',
+	})
+
+	const getFetch = vi
+		.fn()
+		.mockResolvedValueOnce(jsonResponse(503, 'busy'))
+		.mockResolvedValueOnce(jsonResponse(200, '{"ok":true}', { etag: '"g"' }))
+	const getClient = createDrBackupS3Client(config, getFetch as typeof fetch, {
+		maxAttempts: 2,
+		baseDelayMs: 1,
+	})
+	await expect(getClient.getText('progress.json')).resolves.toEqual({
+		text: '{"ok":true}',
+		etag: '"g"',
+	})
+})
+
+test('readDrBackupS3Config requires all fields', () => {
+	expect(
+		readDrBackupS3Config({
+			DR_BACKUP_ACCOUNT_ID: 'a',
+			DR_BACKUP_BUCKET_NAME: 'b',
+			DR_BACKUP_ACCESS_KEY_ID: 'c',
+			DR_BACKUP_SECRET_ACCESS_KEY: 'd',
+		}),
+	).toEqual({
+		accountId: 'a',
+		bucketName: 'b',
+		accessKeyId: 'c',
+		secretAccessKey: 'd',
+	})
+	expect(
+		readDrBackupS3Config({
+			DR_BACKUP_ACCOUNT_ID: 'a',
+			DR_BACKUP_BUCKET_NAME: '',
+			DR_BACKUP_ACCESS_KEY_ID: 'c',
+			DR_BACKUP_SECRET_ACCESS_KEY: 'd',
+		}),
+	).toBeNull()
+})

--- a/packages/worker/src/dr/backup-s3.node.test.ts
+++ b/packages/worker/src/dr/backup-s3.node.test.ts
@@ -87,7 +87,7 @@ test('put retries transport errors then surfaces exhausted failures', async () =
 	expect(fetchImpl).toHaveBeenCalledTimes(3)
 })
 
-test('head and getText retry transient 503 responses', async () => {
+test('head, getText, and getBytes retry transient 503 responses', async () => {
 	const headFetch = vi
 		.fn()
 		.mockResolvedValueOnce(jsonResponse(503))
@@ -101,6 +101,7 @@ test('head and getText retry transient 503 responses', async () => {
 		status: 200,
 		etag: '"h"',
 	})
+	expect(headFetch).toHaveBeenCalledTimes(2)
 
 	const getFetch = vi
 		.fn()
@@ -114,6 +115,21 @@ test('head and getText retry transient 503 responses', async () => {
 		text: '{"ok":true}',
 		etag: '"g"',
 	})
+	expect(getFetch).toHaveBeenCalledTimes(2)
+
+	const bytesFetch = vi
+		.fn()
+		.mockResolvedValueOnce(jsonResponse(503, 'busy'))
+		.mockResolvedValueOnce(jsonResponse(200, 'abc', { etag: '"b"' }))
+	const bytesClient = createDrBackupS3Client(
+		config,
+		bytesFetch as typeof fetch,
+		{ maxAttempts: 2, baseDelayMs: 1 },
+	)
+	await expect(bytesClient.getBytes('blob.bin')).resolves.toEqual(
+		new Uint8Array([97, 98, 99]),
+	)
+	expect(bytesFetch).toHaveBeenCalledTimes(2)
 })
 
 test('readDrBackupS3Config requires all fields', () => {

--- a/packages/worker/src/dr/backup-s3.node.test.ts
+++ b/packages/worker/src/dr/backup-s3.node.test.ts
@@ -92,11 +92,10 @@ test('head and getText retry transient 503 responses', async () => {
 		.fn()
 		.mockResolvedValueOnce(jsonResponse(503))
 		.mockResolvedValueOnce(jsonResponse(200, '', { etag: '"h"' }))
-	const headClient = createDrBackupS3Client(
-		config,
-		headFetch as typeof fetch,
-		{ maxAttempts: 2, baseDelayMs: 1 },
-	)
+	const headClient = createDrBackupS3Client(config, headFetch as typeof fetch, {
+		maxAttempts: 2,
+		baseDelayMs: 1,
+	})
 	await expect(headClient.head('blob')).resolves.toEqual({
 		exists: true,
 		status: 200,

--- a/packages/worker/src/dr/backup-s3.ts
+++ b/packages/worker/src/dr/backup-s3.ts
@@ -42,6 +42,28 @@ export type DrBackupS3Client = {
 	) => Promise<{ etag: string | null }>
 }
 
+/** R2/S3 platform blips observed on PutObject (and siblings) during cron ticks. */
+export const drBackupS3RetryMaxAttempts = 4
+export const drBackupS3RetryBaseDelayMs = 150
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Transient R2/S3 HTTP statuses worth retrying. 412 stays non-retryable so
+ * conditional progress.json ownership conflicts surface immediately.
+ */
+export function isTransientDrBackupHttpStatus(status: number) {
+	return (
+		status === 429 ||
+		status === 500 ||
+		status === 502 ||
+		status === 503 ||
+		status === 504
+	)
+}
+
 function objectUrl(config: DrBackupS3Config, key: string) {
 	const encodedKey = key
 		.split('/')
@@ -55,9 +77,21 @@ function readEtag(response: Response): string | null {
 	return etag && etag.length > 0 ? etag : null
 }
 
+async function drainResponseBody(response: Response) {
+	try {
+		await response.arrayBuffer()
+	} catch {
+		// Best-effort: free the connection before the next attempt.
+	}
+}
+
 export function createDrBackupS3Client(
 	config: DrBackupS3Config,
 	fetchImpl: typeof fetch = fetch,
+	options?: {
+		maxAttempts?: number
+		baseDelayMs?: number
+	},
 ): DrBackupS3Client {
 	const aws = new AwsClient({
 		accessKeyId: config.accessKeyId,
@@ -65,15 +99,43 @@ export function createDrBackupS3Client(
 		service: 's3',
 		region: 'auto',
 	})
+	const maxAttempts = options?.maxAttempts ?? drBackupS3RetryMaxAttempts
+	const baseDelayMs = options?.baseDelayMs ?? drBackupS3RetryBaseDelayMs
 
 	async function signedFetch(key: string, init?: RequestInit) {
 		const request = await aws.sign(objectUrl(config, key), init)
 		return fetchImpl(request)
 	}
 
+	/**
+	 * Retry transport / platform blips. Conditional headers are preserved on
+	 * each attempt: a phantom success that still 412s on retry is handled by
+	 * callers as `DrBackupPreconditionFailedError` (safe skip / resume).
+	 */
+	async function signedFetchWithRetry(key: string, init?: RequestInit) {
+		let lastError: unknown
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			try {
+				const response = await signedFetch(key, init)
+				if (
+					!isTransientDrBackupHttpStatus(response.status) ||
+					attempt === maxAttempts
+				) {
+					return response
+				}
+				await drainResponseBody(response)
+			} catch (error) {
+				lastError = error
+				if (attempt === maxAttempts) throw error
+			}
+			await sleep(baseDelayMs * 2 ** (attempt - 1))
+		}
+		throw lastError ?? new Error('DR backup request failed after retries')
+	}
+
 	return {
 		async head(key) {
-			const response = await signedFetch(key, { method: 'HEAD' })
+			const response = await signedFetchWithRetry(key, { method: 'HEAD' })
 			if (response.status === 404) {
 				return { exists: false, status: response.status, etag: null }
 			}
@@ -89,7 +151,7 @@ export function createDrBackupS3Client(
 			}
 		},
 		async getText(key) {
-			const response = await signedFetch(key, { method: 'GET' })
+			const response = await signedFetchWithRetry(key, { method: 'GET' })
 			if (response.status === 404) return null
 			if (!response.ok) {
 				throw new Error(
@@ -102,7 +164,7 @@ export function createDrBackupS3Client(
 			}
 		},
 		async getBytes(key) {
-			const response = await signedFetch(key, { method: 'GET' })
+			const response = await signedFetchWithRetry(key, { method: 'GET' })
 			if (response.status === 404) return null
 			if (!response.ok) {
 				throw new Error(
@@ -121,7 +183,7 @@ export function createDrBackupS3Client(
 			if (options.ifNoneMatch) {
 				headers['If-None-Match'] = options.ifNoneMatch
 			}
-			const response = await signedFetch(key, {
+			const response = await signedFetchWithRetry(key, {
 				method: 'PUT',
 				headers,
 				body: body as BodyInit,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE issue 7643617296](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7643617296/): `DR backup PUT failed for staging/…/exporter/progress.json: HTTP 500`.

In the failing production tick, two conditional `progress.json` PUTs succeeded (HTTP 200), then the next PUT in the same `exportArtifactsPhase` got an R2 S3 API HTTP 500. That aborted the entire `dr_export` scheduled lane. Progress already written is durable, and the next cron tick resumes — but the tick wastes its remaining budget and pages Sentry for a platform blip.

**Fix:** `createDrBackupS3Client` now retries transient HTTP statuses (`429`, `500`, `502`, `503`, `504`) and transport errors with exponential backoff (same shape as D1 lock retry). `412` precondition failures stay non-retryable so overlapping progress ownership still skips cleanly.

**Merge gate:** touches `backup-control-plane` / disaster-recovery surface — leaving open for review; do not auto-merge.

## Test plan

- [x] `npx vitest run packages/worker/src/dr/backup-s3.node.test.ts`
- [x] CI `npm run validate` equivalent (Validate aggregate green on prior head; re-running after getBytes test)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6d0dc439` · **Head:** `66b13836`

**Classification:** extends — changes `backup-control-plane` R2 S3 client behavior to retry transient platform failures before failing the nightly exporter tick.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | extends — retry 429/5xx + transport blips on DR backup S3 HEAD/GET/PUT |

### System map

Nightly `dr_export` cron persists `progress.json` via the signed R2 S3 client; transient R2 500s are retried inside that client instead of failing the scheduled lane.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
	scheduled["Worker scheduled<br/>dr_export lane"]:::untouched
	exporter["runDrExportTick<br/>persistProgress"]:::untouched
	s3Client["DrBackupS3Client<br/>signedFetchWithRetry"]:::extended
	r2["R2 S3 API<br/>progress.json"]:::untouched
	scheduled --> exporter --> s3Client --> r2
	classDef extended fill:#9a6700,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** a single R2 PutObject HTTP 500 during `persistProgress` threw, aborted the `dr_export` lane, and opened a Sentry issue even when prior puts in the same tick succeeded.

**After:** the S3 client retries 429/5xx and transport errors with short backoff; exhausted failures still throw (and still alert). Conditional `412` conflicts remain immediate non-retries.

### Risk

Medium — disaster-recovery write path. Retries are idempotent for conditional puts (phantom success → next attempt `412` → existing skip path). Left open for human review; not auto-merged.

### Test gaps

No live R2 integration test; coverage is unit-level with an injected `fetch` stub (HEAD/GET text/GET bytes/PUT, plus non-retry of 412).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57850d87-dc70-4b39-99de-96303642e297?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57850d87-dc70-4b39-99de-96303642e297&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of S3/R2 backup operations by automatically retrying transient failures.
  * Added exponential backoff for retry attempts across upload, metadata, and download requests.
  * Preserved immediate handling for non-retryable precondition failures.
  * Improved handling of failed responses and exhausted retry attempts.

* **Tests**
  * Added comprehensive coverage for retry behavior, transport failures, response metadata, and required configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->