### PR TITLE
Cancel Stripe billing when deleting an account

### DIFF
--- a/packages/worker/src/app/account-deletion.node.test.ts
+++ b/packages/worker/src/app/account-deletion.node.test.ts
@@ -2,6 +2,7 @@ import { quoteSqlIdentifier } from '@kody-internal/shared/sql-literals.ts'
 import { readdirSync, readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
+import * as stripeClient from '#worker/billing/stripe-client.ts'
 import {
 	AccountDeletionCleanupError,
 	AccountDeletionInventoryError,
@@ -15,7 +16,10 @@ import {
 	AccountDeletionWritersActiveError,
 	assertAccountWritable,
 } from '#worker/account/deletion-state.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	consoleError,
+	consoleWarn,
+} from '#worker/test-support/console-spies.ts'
 
 type RowMap = Record<string, Array<Record<string, unknown>>>
 
@@ -290,6 +294,17 @@ function createTestDb(
 									.filter((row) => Number(row['id']) === numericId)
 									.map((row) => ({
 										avatar_key: row['avatar_key'] ?? null,
+									}))
+								return { results: results as Array<T>, meta: { changes: 0 } }
+							}
+							if (
+								lower === 'select stripe_customer_id from users where id = ?'
+							) {
+								const numericId = Number(params[0])
+								results = (rows.users ?? [])
+									.filter((row) => Number(row['id']) === numericId)
+									.map((row) => ({
+										stripe_customer_id: row['stripe_customer_id'] ?? null,
 									}))
 								return { results: results as Array<T>, meta: { changes: 0 } }
 							}
@@ -1433,6 +1448,136 @@ test('deleteUserAccount cascades user-scoped rows for the requested user', async
 		userId: userAaa,
 	})
 	expect(result.warnings).toEqual([])
+})
+
+test('account deletion cancels Stripe billing and remains non-blocking on Stripe failures', async () => {
+	const listSubscriptions = vi.spyOn(stripeClient, 'listSubscriptions')
+	const cancelSubscription = vi.spyOn(stripeClient, 'cancelSubscription')
+	const deleteCustomer = vi.spyOn(stripeClient, 'deleteCustomer')
+	try {
+		listSubscriptions.mockResolvedValue([
+			{
+				id: 'sub_active',
+				status: 'active',
+				cancel_at: null,
+				items: { data: [{ price: { id: 'price_pro' } }] },
+			},
+			{
+				id: 'sub_trialing',
+				status: 'trialing',
+				cancel_at: null,
+				items: { data: [{ price: { id: 'price_pro' } }] },
+			},
+			{
+				id: 'sub_canceled',
+				status: 'canceled',
+				cancel_at: null,
+				items: { data: [{ price: { id: 'price_pro' } }] },
+			},
+		])
+		cancelSubscription.mockResolvedValue(undefined)
+		deleteCustomer.mockResolvedValue(undefined)
+		const { db, rows } = createTestDb({
+			users: [
+				{
+					id: 1,
+					email: 'pro@example.com',
+					stable_user_id: 'user-pro',
+					stripe_customer_id: 'cus_pro',
+				},
+			],
+		})
+
+		const result = await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(db),
+			dbUserId: 1,
+			mcpUserId: 'user-pro',
+		})
+
+		expect(listSubscriptions).toHaveBeenCalledWith(
+			expect.any(Object),
+			'cus_pro',
+		)
+		expect(cancelSubscription).toHaveBeenCalledTimes(2)
+		expect(cancelSubscription).toHaveBeenCalledWith(
+			expect.any(Object),
+			'sub_active',
+		)
+		expect(cancelSubscription).toHaveBeenCalledWith(
+			expect.any(Object),
+			'sub_trialing',
+		)
+		expect(deleteCustomer).toHaveBeenCalledWith(expect.any(Object), 'cus_pro')
+		expect(rows.users).toEqual([])
+		expect(result.warnings).toEqual([])
+
+		listSubscriptions.mockRejectedValue(
+			new Error('Stripe subscriptions unavailable'),
+		)
+		deleteCustomer.mockRejectedValue(new Error('Stripe customer unavailable'))
+		cancelSubscription.mockClear()
+		consoleError.mockImplementation(() => {})
+		const { db: failureDb, rows: failureRows } = createTestDb({
+			users: [
+				{
+					id: 2,
+					email: 'failure@example.com',
+					stable_user_id: 'user-stripe-failure',
+					stripe_customer_id: 'cus_failure',
+				},
+			],
+		})
+
+		const failureResult = await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(failureDb),
+			dbUserId: 2,
+			mcpUserId: 'user-stripe-failure',
+		})
+
+		expect(deleteCustomer).toHaveBeenLastCalledWith(
+			expect.any(Object),
+			'cus_failure',
+		)
+		expect(cancelSubscription).not.toHaveBeenCalled()
+		expect(failureRows.users).toEqual([])
+		expect(failureResult.warnings).toEqual([
+			expect.stringContaining('Stripe customer cleanup failed'),
+		])
+		expect(consoleError).toHaveBeenCalledOnce()
+		expect(consoleError).toHaveBeenCalledWith(
+			'account_deletion_stripe_cleanup_failed',
+			expect.objectContaining({
+				userId: 'user-stripe-failure',
+				error: expect.any(AggregateError),
+			}),
+		)
+
+		listSubscriptions.mockClear()
+		deleteCustomer.mockClear()
+		const { db: freeDb, rows: freeRows } = createTestDb({
+			users: [
+				{
+					id: 3,
+					email: 'free@example.com',
+					stable_user_id: 'user-free',
+					stripe_customer_id: null,
+				},
+			],
+		})
+		await deleteUserAccount({
+			env: createSuccessfulDeletionEnv(freeDb),
+			dbUserId: 3,
+			mcpUserId: 'user-free',
+		})
+		expect(listSubscriptions).not.toHaveBeenCalled()
+		expect(deleteCustomer).not.toHaveBeenCalled()
+		expect(freeRows.users).toEqual([])
+	} finally {
+		listSubscriptions.mockRestore()
+		cancelSubscription.mockRestore()
+		deleteCustomer.mockRestore()
+		consoleError.mockReset()
+	}
 })
 
 test('deleteUserAccount revokes OAuth grants and fails closed on critical cleanup errors', async () => {

--- a/packages/worker/src/app/account-deletion.ts
+++ b/packages/worker/src/app/account-deletion.ts
@@ -1,4 +1,9 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import {
+	cancelSubscription,
+	deleteCustomer,
+	listSubscriptions,
+} from '#worker/billing/stripe-client.ts'
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
 import { purgeJobManagerForUser } from '#worker/jobs/manager-client.ts'
 import { jobVectorId } from '#mcp/jobs-vectorize.ts'
@@ -121,6 +126,7 @@ type UserPackageServiceSnapshot = {
 }
 
 type UserDeletionInventory = {
+	stripeCustomerId: string | null
 	vectorIds: Array<string>
 	storageIds: Array<string>
 	bundleKvKeys: Array<string>
@@ -134,6 +140,11 @@ type UserDeletionInventory = {
 	packageServices: Array<UserPackageServiceSnapshot>
 	communityListings: Array<AccountCommunityListingSnapshot>
 }
+
+const stripeSubscriptionStatusesCanceledOnAccountDeletion = new Set([
+	'active',
+	'trialing',
+])
 
 export class AccountDeletionInventoryError extends Error {
 	readonly inventoryErrors: ReadonlyArray<string>
@@ -190,6 +201,15 @@ async function listUserVectorIds(env: Env, userId: string) {
 		}
 	}
 	return ids
+}
+
+async function getUserStripeCustomerId(env: Env, dbUserId: number) {
+	const row = await env.APP_DB.prepare(
+		`SELECT stripe_customer_id FROM users WHERE id = ?`,
+	)
+		.bind(dbUserId)
+		.first<{ stripe_customer_id: string | null }>()
+	return row?.stripe_customer_id?.trim() || null
 }
 
 async function listUserStorageIds(
@@ -354,6 +374,7 @@ async function collectUserDeletionInventory(input: {
 		return [] as Array<UserPackageServiceSnapshot>
 	})
 	const [
+		stripeCustomerId,
 		vectorIds,
 		storageIds,
 		r2Inventory,
@@ -364,6 +385,10 @@ async function collectUserDeletionInventory(input: {
 		mcpServers,
 		mcpAgentSessions,
 	] = await Promise.all([
+		getUserStripeCustomerId(input.env, input.dbUserId).catch((error) => {
+			recordInventoryError('Stripe customer id', error)
+			return null
+		}),
 		listUserVectorIds(input.env, input.userId).catch((error) => {
 			recordInventoryError('vector ids', error)
 			return [] as Array<string>
@@ -428,6 +453,7 @@ async function collectUserDeletionInventory(input: {
 		throw new AccountDeletionInventoryError(inventoryErrors)
 	}
 	return {
+		stripeCustomerId,
 		vectorIds,
 		storageIds,
 		bundleKvKeys,
@@ -440,6 +466,48 @@ async function collectUserDeletionInventory(input: {
 		mcpAgentSessions,
 		packageServices,
 		communityListings: r2Inventory.communityListings,
+	}
+}
+
+async function cancelSubscriptionsAndDeleteStripeCustomer(input: {
+	env: Env
+	customerId: string
+}) {
+	const failures: Array<unknown> = []
+	try {
+		const subscriptions = await listSubscriptions(input.env, input.customerId)
+		for (const subscription of subscriptions) {
+			if (
+				!stripeSubscriptionStatusesCanceledOnAccountDeletion.has(
+					subscription.status,
+				)
+			) {
+				continue
+			}
+			try {
+				await cancelSubscription(input.env, subscription.id)
+			} catch (error) {
+				failures.push(error)
+			}
+		}
+	} catch (error) {
+		failures.push(error)
+	}
+
+	// Customer deletion is still attempted when listing or canceling a
+	// subscription fails. Stripe customer deletion also cancels active
+	// subscriptions, so this is the most important final cleanup attempt.
+	try {
+		await deleteCustomer(input.env, input.customerId)
+	} catch (error) {
+		failures.push(error)
+	}
+
+	if (failures.length > 0) {
+		throw new AggregateError(
+			failures,
+			`Stripe account cleanup encountered ${failures.length} failure(s).`,
+		)
 	}
 }
 
@@ -1125,6 +1193,22 @@ export async function deleteUserAccount(input: {
 
 	if (warnings.length > 0) {
 		throw new AccountDeletionCleanupError(warnings, result)
+	}
+
+	if (inventory.stripeCustomerId) {
+		try {
+			await cancelSubscriptionsAndDeleteStripeCustomer({
+				env: input.env,
+				customerId: inventory.stripeCustomerId,
+			})
+		} catch (error) {
+			const warning = `Stripe customer cleanup failed during account deletion: ${getErrorMessage(error)}`
+			warnings.push(warning)
+			console.error('account_deletion_stripe_cleanup_failed', {
+				userId: input.mcpUserId,
+				error,
+			})
+		}
 	}
 
 	try {

--- a/packages/worker/src/billing/stripe-client.node.test.ts
+++ b/packages/worker/src/billing/stripe-client.node.test.ts
@@ -2,8 +2,10 @@ import { expect, test, vi } from 'vitest'
 import { silenceExpectedConsoleErrors } from '#worker/test-support/console-spies.ts'
 import {
 	BillingNotConfiguredError,
+	cancelSubscription,
 	createBillingPortalSession,
 	createCheckoutSession,
+	deleteCustomer,
 	getCheckoutSession,
 	listSubscriptions,
 	StripeApiError,
@@ -198,6 +200,33 @@ test('stripe client request contracts for checkout, subscriptions, and portal', 
 		const body = new URLSearchParams(String(portalInit?.body))
 		expect(body.get('customer')).toBe('cus_portal')
 		expect(body.get('return_url')).toBe('https://app.example.com/account')
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('stripe client immediately cancels subscriptions and deletes customers', async () => {
+	const fetchMock = vi
+		.fn()
+		.mockResolvedValueOnce(
+			jsonResponse({ id: 'sub_active', status: 'canceled' }),
+		)
+		.mockResolvedValueOnce(jsonResponse({ id: 'cus_delete', deleted: true }))
+	vi.stubGlobal('fetch', fetchMock)
+	try {
+		const env = { STRIPE_SECRET_KEY: 'sk_test_secret' }
+		await cancelSubscription(env, 'sub_active')
+		await deleteCustomer(env, 'cus_delete')
+
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(fetchMock.mock.calls[0]).toEqual([
+			'https://api.stripe.com/v1/subscriptions/sub_active',
+			expect.objectContaining({ method: 'DELETE' }),
+		])
+		expect(fetchMock.mock.calls[1]).toEqual([
+			'https://api.stripe.com/v1/customers/cus_delete',
+			expect.objectContaining({ method: 'DELETE' }),
+		])
 	} finally {
 		vi.unstubAllGlobals()
 	}

--- a/packages/worker/src/billing/stripe-client.node.test.ts
+++ b/packages/worker/src/billing/stripe-client.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test, vi } from 'vitest'
-import { silenceExpectedConsoleErrors } from '#worker/test-support/console-spies.ts'
+import {
+	consoleError,
+	silenceExpectedConsoleErrors,
+} from '#worker/test-support/console-spies.ts'
 import {
 	BillingNotConfiguredError,
 	cancelSubscription,
@@ -227,8 +230,22 @@ test('stripe client immediately cancels subscriptions and deletes customers', as
 			'https://api.stripe.com/v1/customers/cus_delete',
 			expect.objectContaining({ method: 'DELETE' }),
 		])
+
+		consoleError.mockImplementation(() => {})
+		fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'unavailable' }, 503))
+		await expect(
+			deleteCustomer(env, 'cus_sensitive_identifier'),
+		).rejects.toBeInstanceOf(StripeApiError)
+		expect(consoleError).toHaveBeenCalledWith('stripe_api_error', {
+			status: 503,
+			path: '/v1/customers/<redacted>',
+		})
+		expect(JSON.stringify(consoleError.mock.calls)).not.toContain(
+			'cus_sensitive_identifier',
+		)
 	} finally {
 		vi.unstubAllGlobals()
+		consoleError.mockReset()
 	}
 })
 

--- a/packages/worker/src/billing/stripe-client.ts
+++ b/packages/worker/src/billing/stripe-client.ts
@@ -6,6 +6,7 @@
  */
 import {
 	array,
+	boolean,
 	nullable,
 	number,
 	object,
@@ -74,6 +75,16 @@ const billingPortalSessionSchema = object({
 	url: string(),
 })
 
+const canceledSubscriptionSchema = object({
+	id: string(),
+	status: string(),
+})
+
+const deletedCustomerSchema = object({
+	id: string(),
+	deleted: boolean(),
+})
+
 export type StripeCheckoutSession = InferOutput<typeof checkoutSessionSchema>
 export type StripeSubscription = InferOutput<typeof subscriptionSchema>
 
@@ -93,7 +104,7 @@ function requireStripeSecretKey(env: StripeEnv) {
 async function stripeRequest(
 	env: StripeEnv,
 	input: {
-		method: 'GET' | 'POST'
+		method: 'DELETE' | 'GET' | 'POST'
 		path: string
 		query?: Record<string, string>
 		form?: Record<string, string>
@@ -127,10 +138,11 @@ async function stripeRequest(
 
 	const response = await fetch(url.toString(), init)
 	const text = await response.text()
-	// Checkout session paths embed the session id; keep ids out of logs.
+	// Resource paths embed customer, subscription, or session ids; keep them
+	// out of logs while preserving the endpoint name for reconciliation.
 	const loggablePath = input.path.replace(
-		/(checkout\/sessions\/)[^/?]+/,
-		'$1<redacted>',
+		/(checkout\/sessions|customers|subscriptions)\/[^/?]+/,
+		'$1/<redacted>',
 	)
 	let body: unknown = null
 	if (text) {
@@ -302,6 +314,56 @@ export async function listSubscriptions(
 		})
 	}
 	return parsed.value.data
+}
+
+/**
+ * Immediately cancels a subscription. Account deletion intentionally does not
+ * use cancel_at_period_end because the user is relinquishing portal access and
+ * all account state.
+ */
+export async function cancelSubscription(
+	env: StripeEnv,
+	subscriptionId: string,
+): Promise<void> {
+	const trimmed = subscriptionId.trim()
+	if (!trimmed) {
+		throw new StripeApiError('Subscription id is required.', { status: 400 })
+	}
+	const body = await stripeRequest(env, {
+		method: 'DELETE',
+		path: `/v1/subscriptions/${encodeURIComponent(trimmed)}`,
+	})
+	const parsed = parseSafe(canceledSubscriptionSchema, body)
+	if (!parsed.success || parsed.value.status !== 'canceled') {
+		throw new StripeApiError('Unexpected Stripe canceled subscription shape.', {
+			status: 502,
+		})
+	}
+}
+
+/**
+ * Permanently deletes a Stripe customer after its active subscriptions have
+ * been canceled, preventing future invoices for an account that no longer
+ * exists in Kody.
+ */
+export async function deleteCustomer(
+	env: StripeEnv,
+	customerId: string,
+): Promise<void> {
+	const trimmed = customerId.trim()
+	if (!trimmed) {
+		throw new StripeApiError('Customer id is required.', { status: 400 })
+	}
+	const body = await stripeRequest(env, {
+		method: 'DELETE',
+		path: `/v1/customers/${encodeURIComponent(trimmed)}`,
+	})
+	const parsed = parseSafe(deletedCustomerSchema, body)
+	if (!parsed.success || !parsed.value.deleted) {
+		throw new StripeApiError('Unexpected Stripe deleted customer shape.', {
+			status: 502,
+		})
+	}
 }
 
 export async function createBillingPortalSession(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #1069

## Summary
- immediately cancel active and trialing Stripe subscriptions before account deletion
- delete the Stripe customer so no future invoices can be generated
- keep deletion non-blocking on Stripe failures while logging and returning a reconciliation warning
- skip Stripe calls cleanly for users without a customer

## Verification
- `npm run validate` green locally (1,712 unit tests and 19 Playwright tests passed)
- final post-rebase CI validation green across static, Node, Workers, MCP, and Playwright jobs
- targeted Stripe/deletion tests cover successful cleanup, free users, non-blocking API failures, and resource-ID redaction
- production deploy healthcheck and smoke check passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ffc26e41` · **Head:** `81ed1c4b`

**Classification:** extends — account deletion now coordinates immediate Stripe subscription and customer cleanup while preserving deletion availability.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — deletion snapshots billing identity and performs best-effort cleanup before removing the user row |
| `billing` | auth | extends — adds immediate subscription cancellation and customer deletion REST operations |

### System map

Account deletion flows from the authenticated app deletion orchestrator through Stripe billing cleanup before the user row is removed.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	billing["billing<br/>Stripe billing"]:::extended
	appUi -->|"cancel active subscriptions and delete customer before D1 user deletion"| billing
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Stripe cleanup uses the customer ID scoped to the deleting database user.
- Stripe failures are logged and surfaced as warnings but cannot block user-initiated deletion.
- Free users without a Stripe customer do not make Stripe API requests.

</details>

<!-- system-recap:end -->

## Conductor report
- Status: merged as `bfe039aa` and successfully deployed to production.
- What I verified: direct Stripe DELETE request contracts; mocked account deletion success, free-user no-op, non-blocking failure behavior, and log redaction; authoritative local validation; final post-rebase CI; production healthcheck and smoke check.
- Scope spill: none; only the two owned implementation files and their existing test files changed.
- Kent decisions: immediate cancellation is used because deleted users lose portal access; Stripe failures favor completing deletion and emit a reconciliation signal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57aa7b4a-3907-41d6-8a36-728dbf173e73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57aa7b4a-3907-41d6-8a36-728dbf173e73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account deletion now cancels active or trialing billing subscriptions and removes associated billing customer records.
  * Already-canceled subscriptions and accounts without billing records are handled automatically.
* **Bug Fixes**
  * Billing cleanup failures are logged as warnings and no longer prevent the rest of the account deletion process from completing.
  * Billing requests now validate deletion responses and protect sensitive identifiers in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->