### PR TITLE
Add public legal and pricing pages

### DIFF
--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -42,8 +42,7 @@ Read in order for a full tour, or jump to a topic.
   finite limits enforced for each plan
 - [Mutating actions and confirmations](./mutating-actions.md)
 - [Privacy](./privacy.md) — what Kody stores and what deployment admins can see
-  (Terms and Acceptable Use are in-app at
-  [`/terms`](https://heykody.dev/terms))
+  (Terms and Acceptable Use are in-app at [`/terms`](https://heykody.dev/terms))
 - [Troubleshooting](./troubleshooting.md)
 - [Memory and conversation context](./memory.md)
 - [Community Project mark](./community-project-mark.md) — logo for unofficial

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -38,9 +38,12 @@ Read in order for a full tour, or jump to a topic.
   provider POSTs to a saved-package export
 - [Activity](./activity.md) — failures and recent runs for jobs, apps, webhooks,
   and other runtimes (`/account/activity` and the `runs` MCP capabilities)
+- [Plans and pricing](https://heykody.dev/pricing) — Free and Pro prices and the
+  finite limits enforced for each plan
 - [Mutating actions and confirmations](./mutating-actions.md)
 - [Privacy](./privacy.md) — what Kody stores and what deployment admins can see
-  (Terms and Acceptable Use are in-app at `/terms`)
+  (Terms and Acceptable Use are in-app at
+  [`/terms`](https://heykody.dev/terms))
 - [Troubleshooting](./troubleshooting.md)
 - [Memory and conversation context](./memory.md)
 - [Community Project mark](./community-project-mark.md) — logo for unofficial

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -1,5 +1,12 @@
 # Troubleshooting
 
+## Contact support
+
+For help with the hosted Kody service at `heykody.dev`, email
+[`support@heykody.dev`](mailto:support@heykody.dev). Operators of other Kody
+deployments receive support mail at `support@<apex>`, where `<apex>` is the
+deployment's `APP_BASE_URL` hostname.
+
 ## MCP requests fail with `email_verification_required`
 
 Kody requires a verified account email before any MCP access, including OAuth

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -58,4 +58,12 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', { name: 'What an admin can never see' }),
 	).toBeVisible()
+
+	await page.goto('/pricing')
+	await expect(page.getByRole('heading', { name: 'Pricing' })).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Free' })).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Pro' })).toBeVisible()
+	await expect(
+		page.getByRole('row', { name: 'Saved packages 25 100' }),
+	).toBeVisible()
 })

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -235,6 +235,9 @@ export function App(handle: Handle<AppProps>) {
 								<a href="/blog" mix={css(primaryLinkCss)}>
 									Blog
 								</a>
+								<a href="/pricing" mix={css(primaryLinkCss)}>
+									Pricing
+								</a>
 								{isLoggedIn ? (
 									<a href="/timeline" mix={css(primaryLinkCss)}>
 										Timeline

--- a/packages/worker/client/lazy-route.node.test.ts
+++ b/packages/worker/client/lazy-route.node.test.ts
@@ -15,6 +15,7 @@ const eagerPatterns = new Set([
 	routePattern(routes.home),
 	routePattern(routes.login),
 	routePattern(routes.signup),
+	routePattern(routes.pricing),
 	routePattern(routes.privacy),
 	routePattern(routes.terms),
 	routePattern(routes.resetPassword),

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -21,6 +21,7 @@ import {
 	PendingVerificationRoute,
 	pendingVerificationRouteLoader,
 } from './pending-verification.tsx'
+import { PricingRoute } from './pricing.tsx'
 import { PrivacyRoute } from './privacy.tsx'
 import { TermsRoute } from './terms.tsx'
 import { OAuthCallbackRoute } from './oauth-callback.tsx'
@@ -434,6 +435,7 @@ export const clientRoutes = {
 		<LazyOnboardingRoute render={(m) => <m.OnboardingRoute />} />
 	),
 	[routePattern(routes.pendingVerification)]: <PendingVerificationRoute />,
+	[routePattern(routes.pricing)]: <PricingRoute />,
 	[routePattern(routes.privacy)]: <PrivacyRoute />,
 	[routePattern(routes.terms)]: <TermsRoute />,
 	[routePattern(routes.signup)]: <LoginRoute />,

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -1,0 +1,255 @@
+import { type Handle, css } from 'remix/ui'
+import {
+	planLimits,
+	type PlanLimits,
+} from '#worker/entitlements/plans.ts'
+import {
+	colors,
+	radius,
+	spacing,
+	typography,
+} from '#client/styles/tokens.ts'
+import {
+	cardCss,
+	descriptionCss,
+	mutedLinkCss,
+	pageDescriptionCss,
+	pageHeaderCss,
+	pageTitleCss,
+	primaryLinkCss,
+	stackedPageCss,
+} from '#client/styles/style-primitives.ts'
+
+type LimitRow = {
+	label: string
+	format?: (value: number) => string
+	key: keyof PlanLimits
+}
+
+const count = new Intl.NumberFormat('en-US')
+
+const limitRows: ReadonlyArray<LimitRow> = [
+	{ label: 'Saved packages', key: 'maxSavedPackages' },
+	{ label: 'Scheduled jobs', key: 'maxScheduledJobs' },
+	{ label: 'Running package services', key: 'maxPackageServices' },
+	{
+		label: 'Persistent package services',
+		key: 'packageServicePersistentAllowed',
+		format: (value) => (value === 1 ? 'Allowed' : 'Not included'),
+	},
+	{ label: 'Active repo sessions', key: 'maxRepoSessions' },
+	{ label: 'Email sends per day', key: 'maxEmailSendsPerDay' },
+	{ label: 'Email receives per day', key: 'maxEmailReceivesPerDay' },
+	{ label: 'Stored email messages', key: 'maxStoredEmailMessages' },
+	{
+		label: 'Maximum email message size',
+		key: 'maxEmailMessageBytes',
+		format: formatBytes,
+	},
+	{ label: 'Stored secrets', key: 'maxSecrets' },
+	{
+		label: 'Durable storage',
+		key: 'maxStorageBytes',
+		format: formatBytes,
+	},
+	{ label: 'Concurrent workflows', key: 'maxConcurrentWorkflows' },
+	{ label: 'Execute calls per day', key: 'maxExecuteCallsPerDay' },
+	{ label: 'Outbound fetches per day', key: 'maxOutboundFetchesPerDay' },
+]
+
+export function PricingRoute(_handle: Handle) {
+	return () => (
+		<section mix={css(pageCss)}>
+			<header mix={css(pageHeaderCss)}>
+				<h1 mix={css(pageTitleCss)}>Pricing</h1>
+				<p mix={css(pageDescriptionCss)}>
+					Start free. Pro is $5 per month when you need more room to run.
+				</p>
+			</header>
+
+			<div mix={css(planGridCss)}>
+				<section mix={css(planCardCss)}>
+					<div>
+						<h2 mix={css(planTitleCss)}>Free</h2>
+						<p mix={css(priceCss)}>$0</p>
+					</div>
+					<p mix={css(descriptionCss)}>
+						Enough to build useful automations and find out whether Kody earns
+						a place in your setup.
+					</p>
+					<a href="/signup" mix={css(primaryLinkCss)}>
+						Create a free account
+					</a>
+				</section>
+
+				<section mix={css(proPlanCardCss)}>
+					<div>
+						<h2 mix={css(planTitleCss)}>Pro</h2>
+						<p mix={css(priceCss)}>$5/month</p>
+					</div>
+					<p mix={css(descriptionCss)}>
+						Higher daily volume, more running services, and persistent package
+						services.
+					</p>
+					<a href="/account/billing" mix={css(primaryLinkCss)}>
+						Upgrade in Account settings
+					</a>
+				</section>
+			</div>
+
+			<section mix={css(cardCss)}>
+				<div>
+					<h2 mix={css(planTitleCss)}>Plan limits</h2>
+					<p mix={css(descriptionCss)}>
+						Every limit is finite. These values come directly from the limits
+						Kody enforces.
+					</p>
+				</div>
+				<div mix={css(tableWrapperCss)}>
+					<table mix={css(tableCss)}>
+						<thead>
+							<tr>
+								<th scope="col" mix={css(headerCellCss)}>
+									Resource
+								</th>
+								<th scope="col" mix={css(numericHeaderCellCss)}>
+									Free
+								</th>
+								<th scope="col" mix={css(numericHeaderCellCss)}>
+									Pro
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{limitRows.map((row) => (
+								<tr key={row.key}>
+									<th scope="row" mix={css(bodyHeaderCellCss)}>
+										{row.label}
+									</th>
+									<td mix={css(numericCellCss)}>
+										{formatLimit(row, planLimits.free)}
+									</td>
+									<td mix={css(numericCellCss)}>
+										{formatLimit(row, planLimits.pro)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(planTitleCss)}>Invite and admin plans</h2>
+				<p mix={css(descriptionCss)}>
+					Max is a finite, invite-only plan assigned by a Kody administrator; it
+					is not available for self-serve purchase. Some partners may also
+					receive an admin-assigned Partner plan.
+				</p>
+			</section>
+
+			<p mix={css({ margin: 0 })}>
+				<a href="/privacy" mix={css(mutedLinkCss)}>
+					Privacy
+				</a>
+				{' · '}
+				<a href="/terms" mix={css(mutedLinkCss)}>
+					Terms
+				</a>
+				{' · '}
+				<a href="/" mix={css(mutedLinkCss)}>
+					Back home
+				</a>
+			</p>
+		</section>
+	)
+}
+
+function formatLimit(row: LimitRow, limits: PlanLimits): string {
+	const value = limits[row.key]
+	return row.format ? row.format(value) : count.format(value)
+}
+
+function formatBytes(value: number): string {
+	const mebibyte = 1024 * 1024
+	const gibibyte = 1024 * mebibyte
+	if (value >= gibibyte) return `${count.format(value / gibibyte)} GiB`
+	return `${count.format(value / mebibyte)} MiB`
+}
+
+const pageCss = {
+	...stackedPageCss,
+	maxWidth: '64rem',
+	margin: '0 auto',
+}
+
+const planGridCss = {
+	display: 'grid',
+	gridTemplateColumns: 'repeat(auto-fit, minmax(min(18rem, 100%), 1fr))',
+	gap: spacing.lg,
+}
+
+const planCardCss = {
+	...cardCss,
+	alignContent: 'space-between',
+}
+
+const proPlanCardCss = {
+	...planCardCss,
+	borderColor: colors.primary,
+	backgroundColor: colors.primarySoftest,
+}
+
+const planTitleCss = {
+	margin: 0,
+	color: colors.text,
+	fontSize: typography.fontSize.lg,
+	fontWeight: typography.fontWeight.semibold,
+}
+
+const priceCss = {
+	margin: `${spacing.xs} 0 0`,
+	color: colors.primaryText,
+	fontSize: typography.fontSize.xl,
+	fontWeight: typography.fontWeight.bold,
+}
+
+const tableWrapperCss = {
+	overflowX: 'auto' as const,
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.md,
+}
+
+const tableCss = {
+	width: '100%',
+	borderCollapse: 'collapse' as const,
+	fontSize: typography.fontSize.sm,
+}
+
+const headerCellCss = {
+	padding: spacing.sm,
+	textAlign: 'left' as const,
+	color: colors.textMuted,
+	borderBottom: `1px solid ${colors.border}`,
+}
+
+const numericHeaderCellCss = {
+	...headerCellCss,
+	textAlign: 'right' as const,
+}
+
+const bodyHeaderCellCss = {
+	padding: spacing.sm,
+	textAlign: 'left' as const,
+	color: colors.text,
+	fontWeight: typography.fontWeight.normal,
+	borderBottom: `1px solid ${colors.border}`,
+}
+
+const numericCellCss = {
+	padding: spacing.sm,
+	textAlign: 'right' as const,
+	color: colors.text,
+	whiteSpace: 'nowrap' as const,
+	borderBottom: `1px solid ${colors.border}`,
+}

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -1,14 +1,6 @@
 import { type Handle, css } from 'remix/ui'
-import {
-	planLimits,
-	type PlanLimits,
-} from '#worker/entitlements/plans.ts'
-import {
-	colors,
-	radius,
-	spacing,
-	typography,
-} from '#client/styles/tokens.ts'
+import { planLimits, type PlanLimits } from '#worker/entitlements/plans.ts'
+import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	cardCss,
 	descriptionCss,
@@ -74,8 +66,8 @@ export function PricingRoute(_handle: Handle) {
 						<p mix={css(priceCss)}>$0</p>
 					</div>
 					<p mix={css(descriptionCss)}>
-						Enough to build useful automations and find out whether Kody earns
-						a place in your setup.
+						Enough to build useful automations and find out whether Kody earns a
+						place in your setup.
 					</p>
 					<a href="/signup" mix={css(primaryLinkCss)}>
 						Create a free account

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -17,9 +17,22 @@ export function PrivacyRoute(_handle: Handle) {
 			<header mix={css(pageHeaderCss)}>
 				<h1 mix={css(pageTitleCss)}>Privacy</h1>
 				<p mix={css(pageDescriptionCss)}>
-					How Kody stores your data and what a deployment admin can see.
+					What Kody collects, why it is needed, and the choices you have.
 				</p>
 			</header>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Who is responsible for your data</h2>
+				<p mix={css(descriptionCss)}>
+					Kent C. Dodds, operator of Kody at heykody.dev, is the data controller
+					for the hosted service. You can reach the operator at{' '}
+					<a href="mailto:support@heykody.dev" mix={css(mutedLinkCss)}>
+						support@heykody.dev
+					</a>
+					. A separately operated Kody deployment has its own operator and data
+					controller.
+				</p>
+			</section>
 
 			<section mix={css(cardCss)}>
 				<h2 mix={css(cardTitleCss)}>What Kody stores per account</h2>
@@ -148,6 +161,82 @@ export function PrivacyRoute(_handle: Handle) {
 			</section>
 
 			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>How long Kody keeps data</h2>
+				<p mix={css(descriptionCss)}>
+					Account content such as packages, secrets, values, memories, jobs, and
+					durable storage remains available while your account and that content
+					exist. You can delete individual content or the whole account. Some
+					operational records have fixed cleanup periods:
+				</p>
+				<ul mix={css(listCss)}>
+					<li>Email delivery events: 90 days</li>
+					<li>Email messages and their attachments: 365 days</li>
+					<li>
+						Completed workflow runs and conversation-suppression records: 90
+						days
+					</li>
+					<li>
+						Resolved or dismissed platform feedback: 365 days after its last
+						update; open or triaged feedback remains until it is resolved,
+						dismissed, or the account is deleted
+					</li>
+					<li>Audit events: 180 days</li>
+					<li>Feature-flag exposure records: 90 days</li>
+					<li>Daily entitlement counters: 400 days</li>
+					<li>Monthly usage rollups: 24 months</li>
+					<li>Stripe webhook event records: 30 days</li>
+					<li>
+						Non-current published bundle artifacts: at least 30 days, then
+						eligible for removal when no active source or repo session needs
+						them
+					</li>
+				</ul>
+				<p mix={css(descriptionCss)}>
+					Deletion from a subprocessor&apos;s backups or logs follows that
+					subprocessor&apos;s own retention cycle. Records may be kept longer
+					when required by law, needed to resolve a dispute, or necessary to
+					protect the service from abuse.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Service providers</h2>
+				<p mix={css(descriptionCss)}>
+					Kody uses these subprocessors to run the hosted service. They process
+					only the data needed for their role:
+				</p>
+				<ul mix={css(listCss)}>
+					<li>
+						Cloudflare — application hosting, database, object storage, email
+						delivery, security, and network infrastructure
+					</li>
+					<li>Stripe — paid subscriptions, billing, and payment records</li>
+					<li>
+						Kit — waitlist and product email subscriptions when you submit your
+						email for those purposes
+					</li>
+					<li>
+						Sentry — application error reporting and operational diagnostics
+					</li>
+					<li>Fathom — privacy-focused website traffic analytics</li>
+				</ul>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Your choices and rights</h2>
+				<p mix={css(descriptionCss)}>
+					Use Account settings to export a copy of your Kody data or delete your
+					account. You can also ask to access, correct, delete, restrict, or
+					receive your personal data, or object to its processing, by emailing{' '}
+					<a href="mailto:support@heykody.dev" mix={css(mutedLinkCss)}>
+						support@heykody.dev
+					</a>
+					. Which rights apply depends on where you live. We may need to verify
+					your identity before acting on a request.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
 				<h2 mix={css(cardTitleCss)}>Deployment operator access</h2>
 				<p mix={css(descriptionCss)}>
 					Role-based access controls the application surface. Whoever operates
@@ -159,6 +248,10 @@ export function PrivacyRoute(_handle: Handle) {
 			</section>
 
 			<p mix={css({ margin: 0 })}>
+				<a href="/pricing" mix={css(mutedLinkCss)}>
+					Pricing
+				</a>
+				{' · '}
 				<a href="/terms" mix={css(mutedLinkCss)}>
 					Terms
 				</a>

--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -17,16 +17,19 @@ export function TermsRoute(_handle: Handle) {
 			<header mix={css(pageHeaderCss)}>
 				<h1 mix={css(pageTitleCss)}>Terms and Acceptable Use</h1>
 				<p mix={css(pageDescriptionCss)}>
-					Simple rules for using this Kody deployment while it is invite-gated.
+					The plain-spoken agreement for creating an account and using Kody.
 				</p>
 			</header>
 
 			<section mix={css(cardCss)}>
-				<h2 mix={css(cardTitleCss)}>The service</h2>
+				<h2 mix={css(cardTitleCss)}>Who runs Kody</h2>
 				<p mix={css(descriptionCss)}>
-					Kody is a multi-user personal assistant platform. Access may be
-					invite-only. Features, plans, and limits can change as the product
-					evolves. The service is provided as-is without warranties.
+					Kody at heykody.dev is operated by Kent C. Dodds. Questions about
+					these terms or the service can go to{' '}
+					<a href="mailto:support@heykody.dev" mix={css(mutedLinkCss)}>
+						support@heykody.dev
+					</a>
+					.
 				</p>
 			</section>
 
@@ -35,8 +38,14 @@ export function TermsRoute(_handle: Handle) {
 				<p mix={css(descriptionCss)}>
 					You are responsible for activity under your account, including agents
 					and packages you connect or run. Keep credentials and secrets private.
-					Do not share invite codes publicly. You may export or delete your
-					account data from Account settings.
+					Give us accurate account information, and tell us promptly if you
+					think someone else has access. You may export or delete your account
+					data from Account settings.
+				</p>
+				<p mix={css(descriptionCss)}>
+					<strong>Age requirement needing confirmation:</strong> you must be at
+					least [13/16 — Kent to confirm] and legally able to agree to these
+					terms. If local law requires parental consent, you must have it.
 				</p>
 			</section>
 
@@ -59,6 +68,28 @@ export function TermsRoute(_handle: Handle) {
 			</section>
 
 			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Plans, billing, and refunds</h2>
+				<p mix={css(descriptionCss)}>
+					The Free plan costs nothing. Paid subscriptions renew through Stripe
+					at the price and interval shown when you subscribe. You can manage or
+					cancel a subscription from Account settings. Plan limits are listed on
+					the{' '}
+					<a href="/pricing" mix={css(mutedLinkCss)}>
+						Pricing
+					</a>{' '}
+					page.
+				</p>
+				<p mix={css(descriptionCss)}>
+					There are no automatic refunds. If something went wrong, email{' '}
+					<a href="mailto:support@heykody.dev" mix={css(mutedLinkCss)}>
+						support@heykody.dev
+					</a>
+					. Refund requests are considered case by case. Taxes and payment
+					processor terms may also apply.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
 				<h2 mix={css(cardTitleCss)}>Content and packages</h2>
 				<p mix={css(descriptionCss)}>
 					You retain rights to content you create. Community listings you
@@ -74,22 +105,64 @@ export function TermsRoute(_handle: Handle) {
 				<p mix={css(descriptionCss)}>
 					Operators may suspend or terminate accounts that violate these terms,
 					threaten platform reputation (including email sending), or put other
-					users at risk. You may delete your account at any time.
+					users at risk. When practical, we will explain the reason. You may
+					delete your account at any time.
 				</p>
 			</section>
 
 			<section mix={css(cardCss)}>
-				<h2 mix={css(cardTitleCss)}>Privacy</h2>
+				<h2 mix={css(cardTitleCss)}>The service is provided as-is</h2>
 				<p mix={css(descriptionCss)}>
-					How data is stored and what operators can see is described on the{' '}
+					Kody is provided “as is” and “as available.” To the fullest extent the
+					law permits, we make no warranties, including warranties of
+					merchantability, fitness for a particular purpose, non-infringement,
+					or uninterrupted or error-free operation. Keep your own copies of
+					anything you cannot afford to lose.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Limits on liability</h2>
+				<p mix={css(descriptionCss)}>
+					To the fullest extent the law permits, Kody and its operator will not
+					be liable for indirect, incidental, special, consequential, exemplary,
+					or punitive damages, or for lost profits, data, goodwill, or business.
+					Our total liability for any claim is limited to the amount you paid
+					Kody during the 12 months before the event giving rise to the claim.
+					These limits do not apply where the law does not allow them.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Governing law</h2>
+				<p mix={css(descriptionCss)}>
+					<strong>Kent must confirm before launch:</strong> these terms are
+					governed by the laws of [STATE/COUNTRY], without regard to
+					conflict-of-law rules, and disputes must be brought in the courts
+					located in [COUNTY, STATE/COUNTRY], unless applicable law requires
+					otherwise.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Privacy and changes</h2>
+				<p mix={css(descriptionCss)}>
+					The{' '}
 					<a href="/privacy" mix={css(mutedLinkCss)}>
 						Privacy
 					</a>{' '}
-					page.
+					page explains how Kody handles data. We may update these terms by
+					posting the revised terms here. We will give reasonable notice of
+					material changes when practical. Continuing to use Kody after a change
+					takes effect means you accept the revised terms.
 				</p>
 			</section>
 
 			<p mix={css({ margin: 0 })}>
+				<a href="/pricing" mix={css(mutedLinkCss)}>
+					Pricing
+				</a>
+				{' · '}
 				<a href="/privacy" mix={css(mutedLinkCss)}>
 					Privacy
 				</a>

--- a/packages/worker/src/app/account-suspension.ts
+++ b/packages/worker/src/app/account-suspension.ts
@@ -13,7 +13,7 @@ import { normalizeEmail } from '#worker/identity/normalize-email.ts'
 import { normalizeStableUserId } from '#worker/user-id.ts'
 
 export const accountSuspendedMessage =
-	'This account is suspended. Contact the operator of this Kody deployment to appeal.'
+	'This account is suspended. Email support@heykody.dev to appeal.'
 
 export type AccountRestrictions = {
 	suspendedAt: string | null

--- a/packages/worker/src/app/document-head.node.test.ts
+++ b/packages/worker/src/app/document-head.node.test.ts
@@ -21,6 +21,7 @@ test('resolveDocumentHead covers static titles, dynamic OG, fallbacks, and absol
 	expect(resolveDocumentTitle('/community')).toBe('Community packages')
 	expect(resolveDocumentTitle('/timeline')).toBe('Timeline')
 	expect(resolveDocumentTitle('/admin/users')).toBe('Admin users')
+	expect(resolveDocumentTitle('/pricing')).toBe('Pricing')
 	expect(resolveDocumentTitle('/privacy')).toBe('Privacy')
 	expect(resolveDocumentTitle('/terms')).toBe('Terms')
 

--- a/packages/worker/src/app/document-head.ts
+++ b/packages/worker/src/app/document-head.ts
@@ -248,6 +248,7 @@ const routeDocumentHeads = {
 		'Get started',
 	),
 	[routePattern(routes.pendingVerification)]: titleOnly('Verify your email'),
+	[routePattern(routes.pricing)]: publicPageHead('pricing', 'Pricing'),
 	[routePattern(routes.privacy)]: publicPageHead('privacy', 'Privacy'),
 	[routePattern(routes.terms)]: publicPageHead('terms', 'Terms'),
 	[routePattern(routes.resetPassword)]: publicPageHead(

--- a/packages/worker/src/app/handlers/pricing.ts
+++ b/packages/worker/src/app/handlers/pricing.ts
@@ -1,0 +1,15 @@
+import { type Action } from 'remix/router'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import { type routes } from '#app/routes.ts'
+
+export function createPricingHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			return renderAppPage({
+				request,
+				env,
+			})
+		},
+	} satisfies Action<typeof routes.pricing>
+}

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -171,6 +171,7 @@ import {
 	createOnboardingApiHandler,
 	createOnboardingHandler,
 } from '#app/handlers/onboarding.ts'
+import { createPricingHandler } from '#app/handlers/pricing.ts'
 import { createPrivacyHandler } from '#app/handlers/privacy.ts'
 import { createTermsHandler } from '#app/handlers/terms.ts'
 import { createResetPasswordHandler } from '#app/handlers/reset-password.ts'
@@ -222,6 +223,7 @@ export function createAppRouter(env: Env) {
 			blogPost: createBlogPostHandler(env),
 			blogPostApi: createBlogPostApiHandler(env),
 			blogPostOgImage: createBlogPostOgImageHandler(env),
+			pricing: createPricingHandler(env),
 			privacy: createPrivacyHandler(env),
 			terms: createTermsHandler(env),
 			onboarding: createOnboardingHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -141,6 +141,7 @@ export const routes = route({
 	sentryTunnel: post('/sentry-tunnel'),
 	login: '/login',
 	ogPageImage: '/og/:page.png',
+	pricing: '/pricing',
 	privacy: '/privacy',
 	terms: '/terms',
 	onboarding: '/onboarding',

--- a/packages/worker/src/email/outbound-abuse.ts
+++ b/packages/worker/src/email/outbound-abuse.ts
@@ -24,7 +24,7 @@ import { type EmailDeliveryStatus } from './types.ts'
 export const outboundEmailBouncePauseThresholdPerDay = 5
 
 export const emailOutboundPausedMessage =
-	'Outbound email is paused for this account after spam complaints or repeated bounces. Contact the operator of this Kody deployment to have it reviewed and re-enabled.'
+	'Outbound email is paused for this account after spam complaints or repeated bounces. Email support@heykody.dev to have it reviewed and re-enabled.'
 
 type OutboundAbuseEnv = Pick<
 	Env,

--- a/packages/worker/src/og/pages.ts
+++ b/packages/worker/src/og/pages.ts
@@ -60,6 +60,13 @@ export const publicOgPages = {
 		ogDescription: 'Sign up to start using kody.',
 		path: '/signup',
 	},
+	pricing: {
+		imageTitle: 'Simple Kody pricing',
+		imageSubtitle: 'Start free. Pro is $5 per month when you need more room.',
+		ogTitle: 'Pricing — Kody',
+		ogDescription: 'Compare the Free and Pro plans and their finite limits.',
+		path: '/pricing',
+	},
 	privacy: {
 		imageTitle: 'Privacy',
 		imageSubtitle:

--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -38,6 +38,7 @@
 		"./src/identity/permissions.ts",
 		"./src/feature-flags/registry.ts",
 		"./src/feature-flags/types.ts",
+		"./src/entitlements/plans.ts",
 		"./src/usage/event-types.ts",
 		"./src/og/pages.ts"
 	],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #1069

## Summary

- rewrite public Terms for open signup and paid subscriptions, including acceptable use, billing/refunds, warranties, liability, contact, and explicit legal placeholders
- expand Privacy with controller identity, subprocessors, retention periods, and self-service/privacy-rights instructions
- add a public `/pricing` route whose Free/Pro comparison reads enforced values directly from `planLimits`
- publish `support@heykody.dev` in support docs and account/email restriction messages

## Verification

- `npm run validate` passed: formatting, lint, typecheck, 1,710 unit/Workers tests, 19 Playwright tests, 3 MCP E2E tests, backup build, primitive/migration checks, and temporal-language docs check
- focused route/title tests passed
- manual browser walkthrough confirmed pricing, terms, and privacy content and navigation
- [main CI passed](https://github.com/kentcdodds/kody/actions/runs/30606403858), the PR was squash-merged, and the [production deploy passed](https://github.com/kentcdodds/kody/actions/runs/30606607073)
- live smoke check confirmed [`https://heykody.dev/pricing`](https://heykody.dev/pricing) contains the Free/Pro comparison and enforced values

<a href="https://cursor.com/agents/bc-971e283f-6901-4f3f-8df9-84d99cb8030e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_pricing_terms_privacy_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-fa03da57-556e-4d9e-ae25-2518123fafb7" alt="public_pricing_terms_privacy_walkthrough.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `30b51c31` · **Head:** `cc326caa`

**Classification:** extends — adds a public route and changes public/legal and restriction-message behavior without adding a system primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — public pricing route, navigation, legal copy, and metadata |
| `email` | assistant | composes — points the existing abuse-pause message to public support |

### System map

Public visitors reach legal and pricing pages through the browser app; pricing reads the same finite limits used by entitlement enforcement.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	email["email<br/>Email"]:::touched
	appUi -->|"GET /pricing, /terms, /privacy"| appUi
	email -->|"pause message links support@heykody.dev"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Invite-gated terms and no public plan comparison | Public-signup terms and `/pricing` sourced from enforced plan limits |
| Privacy omitted processors and several retention periods | Controller, subprocessors, retention, and rights are explicit |
| Restriction messages said “contact the operator” | Messages give the hosted support address |

</details>

<!-- system-recap:end -->

## Conductor report

- **Status:** Shipped — PR squash-merged and production deployment verified.
- **What I verified:** `npm run validate` is green, including the temporal-language check and a Playwright smoke assertion that `/pricing` renders enforced Free/Pro values. Main CI and production deployment passed. A live request to `heykody.dev/pricing` confirmed the deployed plan comparison.
- **Scope spill:** Minimal route wiring required `client/routes/index.tsx`, `app/router.ts`, a pricing handler, document metadata/OG registry, the global app nav, the client TypeScript file list, and eager-route invariant registration. Focused smoke/title tests were updated. No login/auth handler or account-deletion file was touched.
- **Kent decisions:** Confirm the minimum age (`13` or `16`), governing law and venue, and whether the controller should be Kent personally or a legal entity. Review the no-automatic-refunds/case-by-case support policy and liability cap wording.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-971e283f-6901-4f3f-8df9-84d99cb8030e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-971e283f-6901-4f3f-8df9-84d99cb8030e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

