### PR TITLE
Add offline DR escrow unseal verification

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -294,8 +294,21 @@ Escrow model (solo):
    (`tools/disaster-recovery/seal-escrow.ts`). The escrow object is write-once;
    after a `SECRET_STORE_KEY` rotation, bump `ESCROW_KEY_VERSION` (for example
    `v2`) when re-sealing — see [Secret rotation](./secret-rotation.md).
-3. Dashboard shows whether the escrow object is present (not whether the
-   passphrase still works — test unsealing offline after each seal).
+3. Dashboard presence does not prove that the passphrase recovers the key. Copy
+   the sealed blob to an offline environment and run:
+
+   ```sh
+   node tools/disaster-recovery/unseal-escrow.ts \
+     --input /secure/input/secret-store-key.v1.json \
+     --output /secure/output/secret-store-key
+   ```
+
+   The tool reads `SECRET_ESCROW_PASSPHRASE` or prompts without echo. It creates
+   the output with mode `0600`, refuses repository paths and existing files, and
+   emits no secret metadata. Omit `--output` only when writing the recovered key
+   directly to stdout is intentional. To read from the DR bucket instead of a
+   local file, omit `--input`, set the DR bucket credentials, and select the
+   sealed object with `ESCROW_KEY_VERSION` (default `v1`).
 
 Never put the plaintext key or passphrase in manifests, tickets, logs, or the
 backup SQL. See [Secret rotation](./secret-rotation.md).
@@ -369,6 +382,9 @@ UI-down recovery:
   readiness assessment from local Ed25519 evidence envelopes
 - `node tools/disaster-recovery/seal-escrow.ts` — same seal used by
   `dr-escrow.yml` (also runnable locally with env vars)
+- `node tools/disaster-recovery/unseal-escrow.ts` — authenticated recovery from
+  a local sealed blob or the DR bucket; writes only to stdout or a new file
+  outside the repository
 
 Details:
 [`tools/disaster-recovery/readme.md`](../../tools/disaster-recovery/readme.md).
@@ -452,8 +468,9 @@ Work top-to-bottom. Leave gates false until the matching gate item is done.
 ### 6. Escrow and ongoing drills
 
 - [ ] `SECRET_ESCROW_PASSPHRASE` in password manager + GitHub secret; run
-      `dr-escrow.yml`; dashboard shows escrow present; offline unseal smoke test
-      with the passphrase.
+      `dr-escrow.yml`; dashboard shows escrow present; run
+      `node tools/disaster-recovery/unseal-escrow.ts --input <sealed-blob> --output <secure-path>`
+      against the sealed blob with the real passphrase, offline.
 - [ ] Set `DR_EXPORT_ENABLED=true` in production after staging path is proven.
 - [ ] Monthly: UI isolated D1 drill on a retained day; confirm alert paths for
       freshness failures.

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -305,7 +305,9 @@ Escrow model (solo):
 
    The tool reads `SECRET_ESCROW_PASSPHRASE` or prompts without echo. It creates
    the output with mode `0600`, refuses repository paths and existing files, and
-   emits no secret metadata. Omit `--output` only when writing the recovered key
+   emits no secret metadata. The output parent directory must already exist.
+   `ESCROW_INPUT_PATH` and `ESCROW_OUTPUT_PATH` are the environment equivalents
+   of the two flags. Omit `--output` only when writing the recovered key
    directly to stdout is intentional. To read from the DR bucket instead of a
    local file, omit `--input`, set the DR bucket credentials, and select the
    sealed object with `ESCROW_KEY_VERSION` (default `v1`).

--- a/tools/disaster-recovery/readme.md
+++ b/tools/disaster-recovery/readme.md
@@ -13,6 +13,9 @@ Also here:
 - `seal-escrow.ts` — seal `SECRET_STORE_KEY` under an operator passphrase and
   upload `escrow/secret-store-key.v1.json` (used by
   `.github/workflows/dr-escrow.yml`).
+- `unseal-escrow.ts` — recover the key from a local sealed blob or the DR
+  bucket, writing only to stdout or a new mode-`0600` file outside the
+  repository.
 
 These tools do not create, bind, overwrite, delete, cut over, or use Time Travel
 on a production D1 database.

--- a/tools/disaster-recovery/seal-escrow.node.test.ts
+++ b/tools/disaster-recovery/seal-escrow.node.test.ts
@@ -68,7 +68,7 @@ test('the operator unseal tool round-trips sealed key bytes and fails closed', a
 				'--output',
 				mismatchedOutputPath,
 			]),
-		).rejects.toThrow(/canonical escrow JSON/)
+		).rejects.toThrow(/invalid versioned shape/)
 		await expect(stat(mismatchedOutputPath)).rejects.toMatchObject({
 			code: 'ENOENT',
 		})

--- a/tools/disaster-recovery/seal-escrow.node.test.ts
+++ b/tools/disaster-recovery/seal-escrow.node.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import {
+	mkdtemp,
+	readFile,
+	rm,
+	stat,
+	symlink,
+	writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { expect, test, vi } from 'vitest'
@@ -72,6 +79,17 @@ test('the operator unseal tool round-trips sealed key bytes and fails closed', a
 		await expect(stat(mismatchedOutputPath)).rejects.toMatchObject({
 			code: 'ENOENT',
 		})
+
+		const repositoryLink = path.join(directory, 'repository-link')
+		await symlink(process.cwd(), repositoryLink, 'dir')
+		await expect(
+			unsealMain({ SECRET_ESCROW_PASSPHRASE: passphrase }, [
+				'--input',
+				inputPath,
+				'--output',
+				path.join(repositoryLink, 'recovered-secret'),
+			]),
+		).rejects.toThrow(/inside the repository/)
 	} finally {
 		await rm(directory, { recursive: true, force: true })
 	}

--- a/tools/disaster-recovery/seal-escrow.node.test.ts
+++ b/tools/disaster-recovery/seal-escrow.node.test.ts
@@ -1,28 +1,80 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { expect, test, vi } from 'vitest'
-import {
-	main,
-	putSealedEscrowBlob,
-	sealEscrowSecret,
-	unsealEscrowSecretForTests,
-} from './seal-escrow.ts'
+import { main, putSealedEscrowBlob, sealEscrowSecret } from './seal-escrow.ts'
+import { main as unsealMain, unsealEscrowSecret } from './unseal-escrow.ts'
 import {
 	backupEscrowSecretStoreKeyKey,
 	parseSealedEscrowBlob,
 } from '@kody-internal/shared/backup-staging.ts'
 
-test('sealEscrowSecret round-trips through unseal helper', () => {
+test('the operator unseal tool round-trips sealed key bytes and fails closed', async () => {
+	const secretValue = 'known-test-secret-store-key-\u0000-\u{1f512}'
+	const passphrase = 'test-only-operator-passphrase'
 	const sealed = sealEscrowSecret({
-		secretValue: 'super-secret-value-32-chars-minimum!!',
-		passphrase: 'operator-passphrase',
+		secretValue,
+		passphrase,
 		label: 'secret-store-key',
 		sealedAt: '2026-07-23T01:02:03.000Z',
 	})
 	expect(sealed.iterations).toBeGreaterThanOrEqual(600_000)
 	expect(parseSealedEscrowBlob(sealed).label).toBe('secret-store-key')
-	expect(unsealEscrowSecretForTests(sealed, 'operator-passphrase')).toBe(
-		'super-secret-value-32-chars-minimum!!',
+	expect(
+		Buffer.from(unsealEscrowSecret(sealed, passphrase), 'utf8').equals(
+			Buffer.from(secretValue, 'utf8'),
+		),
+	).toBe(true)
+	expect(() => unsealEscrowSecret(sealed, 'wrong-passphrase')).toThrow(
+		/authentication failed/,
 	)
-	expect(() => unsealEscrowSecretForTests(sealed, 'wrong-passphrase')).toThrow()
+
+	const directory = await mkdtemp(path.join(tmpdir(), 'kody-escrow-unseal-'))
+	try {
+		const inputPath = path.join(directory, 'secret-store-key.v1.json')
+		const outputPath = path.join(directory, 'recovered-secret')
+		await writeFile(inputPath, JSON.stringify(sealed), 'utf8')
+
+		await expect(
+			unsealMain({ SECRET_ESCROW_PASSPHRASE: 'wrong-passphrase' }, [
+				'--input',
+				inputPath,
+				'--output',
+				outputPath,
+			]),
+		).rejects.toThrow(/authentication failed/)
+		await expect(stat(outputPath)).rejects.toMatchObject({ code: 'ENOENT' })
+
+		await unsealMain({ SECRET_ESCROW_PASSPHRASE: passphrase }, [
+			'--input',
+			inputPath,
+			'--output',
+			outputPath,
+		])
+		expect(await readFile(outputPath, 'utf8')).toBe(secretValue)
+		expect((await stat(outputPath)).mode & 0o777).toBe(0o600)
+
+		const mismatchedPath = path.join(directory, 'mismatched.json')
+		const mismatchedOutputPath = path.join(directory, 'mismatched-output')
+		await writeFile(
+			mismatchedPath,
+			JSON.stringify({ ...sealed, schemaVersion: 2 }),
+			'utf8',
+		)
+		await expect(
+			unsealMain({ SECRET_ESCROW_PASSPHRASE: passphrase }, [
+				'--input',
+				mismatchedPath,
+				'--output',
+				mismatchedOutputPath,
+			]),
+		).rejects.toThrow(/canonical escrow JSON/)
+		await expect(stat(mismatchedOutputPath)).rejects.toMatchObject({
+			code: 'ENOENT',
+		})
+	} finally {
+		await rm(directory, { recursive: true, force: true })
+	}
 })
 
 test('main seals and uploads the default escrow key without printing secret material', async () => {

--- a/tools/disaster-recovery/seal-escrow.node.test.ts
+++ b/tools/disaster-recovery/seal-escrow.node.test.ts
@@ -60,6 +60,15 @@ test('the operator unseal tool round-trips sealed key bytes and fails closed', a
 		])
 		expect(await readFile(outputPath, 'utf8')).toBe(secretValue)
 		expect((await stat(outputPath)).mode & 0o777).toBe(0o600)
+		await expect(
+			unsealMain({ SECRET_ESCROW_PASSPHRASE: passphrase }, [
+				'--input',
+				inputPath,
+				'--output',
+				outputPath,
+			]),
+		).rejects.toMatchObject({ code: 'EEXIST' })
+		expect(await readFile(outputPath, 'utf8')).toBe(secretValue)
 
 		const mismatchedPath = path.join(directory, 'mismatched.json')
 		const mismatchedOutputPath = path.join(directory, 'mismatched-output')

--- a/tools/disaster-recovery/seal-escrow.ts
+++ b/tools/disaster-recovery/seal-escrow.ts
@@ -13,7 +13,6 @@
  */
 import {
 	createCipheriv,
-	createDecipheriv,
 	createHash,
 	createHmac,
 	pbkdf2Sync,
@@ -95,32 +94,6 @@ export function sealEscrowSecret(input: {
 		label: input.label,
 	}
 	return parseSealedEscrowBlob(sealed)
-}
-
-/** Test-only helper: reverse {@link sealEscrowSecret}. */
-export function unsealEscrowSecretForTests(
-	blob: SealedEscrowBlob,
-	passphrase: string,
-): string {
-	const parsed = parseSealedEscrowBlob(blob)
-	const salt = Buffer.from(parsed.saltBase64, 'base64')
-	const iv = Buffer.from(parsed.ivBase64, 'base64')
-	const packed = Buffer.from(parsed.ciphertextBase64, 'base64')
-	const authTag = packed.subarray(packed.length - 16)
-	const ciphertext = packed.subarray(0, packed.length - 16)
-	const key = pbkdf2Sync(
-		passphrase,
-		salt,
-		parsed.iterations,
-		keyBytes,
-		'sha256',
-	)
-	const decipher = createDecipheriv('aes-256-gcm', key, iv)
-	decipher.setAuthTag(authTag)
-	return Buffer.concat([
-		decipher.update(ciphertext),
-		decipher.final(),
-	]).toString('utf8')
 }
 
 function isWriteOnceRejection(status: number, bodyText: string) {

--- a/tools/disaster-recovery/unseal-escrow.ts
+++ b/tools/disaster-recovery/unseal-escrow.ts
@@ -317,12 +317,13 @@ export async function main(
 				secretAccessKey: requiredEnv(env, 'DR_BACKUP_SECRET_ACCESS_KEY'),
 				objectKey,
 			})
-	let blob: SealedEscrowBlob
+	let inputValue: unknown
 	try {
-		blob = parseSealedEscrowBlob(JSON.parse(body))
+		inputValue = JSON.parse(body)
 	} catch {
-		throw new Error('Sealed escrow input is not valid canonical escrow JSON')
+		throw new Error('Sealed escrow input is not valid JSON')
 	}
+	const blob: SealedEscrowBlob = parseSealedEscrowBlob(inputValue)
 	const secretValue = unsealEscrowSecret(blob, passphrase)
 	await writeRecoveredSecret(secretValue, outputPath)
 	return secretValue

--- a/tools/disaster-recovery/unseal-escrow.ts
+++ b/tools/disaster-recovery/unseal-escrow.ts
@@ -276,8 +276,15 @@ async function writeRecoveredSecret(
 
 	const resolvedOutputPath = path.resolve(outputPath)
 	const resolvedParent = await realpath(path.dirname(resolvedOutputPath))
-	const checkedOutputPath = path.join(resolvedParent, path.basename(outputPath))
-	const relativeToRepository = path.relative(repositoryRoot, checkedOutputPath)
+	const checkedOutputPath = path.join(
+		resolvedParent,
+		path.basename(resolvedOutputPath),
+	)
+	const resolvedRepositoryRoot = await realpath(repositoryRoot)
+	const relativeToRepository = path.relative(
+		resolvedRepositoryRoot,
+		checkedOutputPath,
+	)
 	if (
 		relativeToRepository === '' ||
 		(!relativeToRepository.startsWith(`..${path.sep}`) &&

--- a/tools/disaster-recovery/unseal-escrow.ts
+++ b/tools/disaster-recovery/unseal-escrow.ts
@@ -204,6 +204,7 @@ export async function getSealedEscrowBlob(input: {
 	const fetchImpl = input.fetchImpl ?? fetch
 	const response = await fetchImpl(url, {
 		method: 'GET',
+		signal: AbortSignal.timeout(30_000),
 		headers: {
 			Authorization: authorization,
 			'x-amz-content-sha256': payloadHash,
@@ -309,11 +310,6 @@ export async function main(
 	const options = parseArgs(argv)
 	const inputPath = options.inputPath ?? env.ESCROW_INPUT_PATH
 	const outputPath = options.outputPath ?? env.ESCROW_OUTPUT_PATH
-	const passphrase = env.SECRET_ESCROW_PASSPHRASE?.length
-		? env.SECRET_ESCROW_PASSPHRASE
-		: await promptForPassphrase()
-	const version = env.ESCROW_KEY_VERSION?.trim() || 'v1'
-	const objectKey = buildEscrowSecretStoreKey(version)
 
 	const body = inputPath
 		? await readFile(path.resolve(inputPath), 'utf8')
@@ -322,7 +318,9 @@ export async function main(
 				bucketName: requiredEnv(env, 'DR_BACKUP_BUCKET_NAME'),
 				accessKeyId: requiredEnv(env, 'DR_BACKUP_ACCESS_KEY_ID'),
 				secretAccessKey: requiredEnv(env, 'DR_BACKUP_SECRET_ACCESS_KEY'),
-				objectKey,
+				objectKey: buildEscrowSecretStoreKey(
+					env.ESCROW_KEY_VERSION?.trim() || 'v1',
+				),
 			})
 	let inputValue: unknown
 	try {
@@ -331,6 +329,9 @@ export async function main(
 		throw new Error('Sealed escrow input is not valid JSON')
 	}
 	const blob: SealedEscrowBlob = parseSealedEscrowBlob(inputValue)
+	const passphrase = env.SECRET_ESCROW_PASSPHRASE?.length
+		? env.SECRET_ESCROW_PASSPHRASE
+		: await promptForPassphrase()
 	const secretValue = unsealEscrowSecret(blob, passphrase)
 	await writeRecoveredSecret(secretValue, outputPath)
 	return secretValue

--- a/tools/disaster-recovery/unseal-escrow.ts
+++ b/tools/disaster-recovery/unseal-escrow.ts
@@ -1,0 +1,337 @@
+/**
+ * Recover SECRET_STORE_KEY from its sealed DR escrow blob.
+ *
+ * Usage:
+ *   node tools/disaster-recovery/unseal-escrow.ts [--input <file>] [--output <file>]
+ *
+ * Env:
+ * - SECRET_ESCROW_PASSPHRASE — operator passphrase (prompted when omitted)
+ * - ESCROW_INPUT_PATH — optional local sealed blob (equivalent to `--input`)
+ * - ESCROW_OUTPUT_PATH — optional destination outside the repository
+ * - ESCROW_KEY_VERSION — optional DR object version (default `v1`)
+ * - DR_BACKUP_ACCOUNT_ID / DR_BACKUP_BUCKET_NAME
+ * - DR_BACKUP_ACCESS_KEY_ID / DR_BACKUP_SECRET_ACCESS_KEY
+ *
+ * Without an input path, the sealed blob is read from the DR bucket. Without an
+ * output path, the recovered value is written directly to stdout. Secret
+ * material is never logged.
+ */
+import {
+	createDecipheriv,
+	createHash,
+	createHmac,
+	pbkdf2Sync,
+} from 'node:crypto'
+import { open, readFile, realpath } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { isExecutedDirectly } from '../node-runtime.ts'
+import { buildEscrowSecretStoreKey } from './seal-escrow.ts'
+import {
+	parseSealedEscrowBlob,
+	type SealedEscrowBlob,
+} from '@kody-internal/shared/backup-staging.ts'
+
+const pbkdf2Iterations = 600_000
+const saltBytes = 16
+const ivBytes = 12
+const authTagBytes = 16
+const keyBytes = 32
+const repositoryRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	'../..',
+)
+
+type CliOptions = {
+	inputPath?: string
+	outputPath?: string
+}
+
+function sha256(data: string | Buffer) {
+	return createHash('sha256').update(data).digest()
+}
+
+function hmacSha256(key: Buffer | string, data: string | Buffer) {
+	return createHmac('sha256', key).update(data).digest()
+}
+
+function encodeRfc3986(value: string) {
+	return encodeURIComponent(value).replace(
+		/[!'()*]/g,
+		(char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+	)
+}
+
+function decodeCanonicalBase64(value: string, fieldName: string): Buffer {
+	const decoded = Buffer.from(value, 'base64')
+	if (decoded.toString('base64') !== value) {
+		throw new Error(`Sealed escrow blob has invalid ${fieldName}`)
+	}
+	return decoded
+}
+
+function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
+	const value = env[name]
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new Error(`Missing required environment variable: ${name}`)
+	}
+	return value
+}
+
+export function parseArgs(argv: Array<string>): CliOptions {
+	const options: CliOptions = {}
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index]
+		switch (argument) {
+			case '--input':
+			case '--output': {
+				const value = argv[index + 1]
+				if (!value || value.startsWith('--')) {
+					throw new Error(`${argument} requires a file path`)
+				}
+				if (argument === '--input') options.inputPath = value
+				else options.outputPath = value
+				index += 1
+				break
+			}
+			default: {
+				throw new Error(`Unknown argument: ${argument}`)
+			}
+		}
+	}
+	return options
+}
+
+export function unsealEscrowSecret(blob: unknown, passphrase: string): string {
+	const parsed = parseSealedEscrowBlob(blob)
+	if (parsed.iterations !== pbkdf2Iterations) {
+		throw new Error(
+			`Unsupported sealed escrow PBKDF2 iteration count: ${parsed.iterations}`,
+		)
+	}
+
+	const salt = decodeCanonicalBase64(parsed.saltBase64, 'saltBase64')
+	const iv = decodeCanonicalBase64(parsed.ivBase64, 'ivBase64')
+	const packed = decodeCanonicalBase64(
+		parsed.ciphertextBase64,
+		'ciphertextBase64',
+	)
+	if (salt.length !== saltBytes || iv.length !== ivBytes) {
+		throw new Error('Sealed escrow blob has invalid salt or IV length')
+	}
+	if (packed.length <= authTagBytes) {
+		throw new Error('Sealed escrow blob has invalid ciphertext length')
+	}
+
+	const authTag = packed.subarray(packed.length - authTagBytes)
+	const ciphertext = packed.subarray(0, packed.length - authTagBytes)
+	const key = pbkdf2Sync(
+		passphrase,
+		salt,
+		parsed.iterations,
+		keyBytes,
+		'sha256',
+	)
+	try {
+		const decipher = createDecipheriv('aes-256-gcm', key, iv)
+		decipher.setAuthTag(authTag)
+		const plaintext = Buffer.concat([
+			decipher.update(ciphertext),
+			decipher.final(),
+		])
+		try {
+			return plaintext.toString('utf8')
+		} finally {
+			plaintext.fill(0)
+		}
+	} catch {
+		throw new Error(
+			'Escrow unseal failed: passphrase is incorrect or sealed blob authentication failed',
+		)
+	} finally {
+		key.fill(0)
+	}
+}
+
+export async function getSealedEscrowBlob(input: {
+	accountId: string
+	bucketName: string
+	accessKeyId: string
+	secretAccessKey: string
+	objectKey: string
+	fetchImpl?: typeof fetch
+}): Promise<string> {
+	const encodedKey = input.objectKey
+		.split('/')
+		.map((part) => encodeRfc3986(part))
+		.join('/')
+	const url = new URL(
+		`https://${input.accountId}.r2.cloudflarestorage.com/${encodeRfc3986(input.bucketName)}/${encodedKey}`,
+	)
+	const now = new Date()
+	const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '')
+	const dateStamp = amzDate.slice(0, 8)
+	const region = 'auto'
+	const service = 's3'
+	const payloadHash = sha256('').toString('hex')
+	const canonicalHeaders = [
+		`host:${url.host}`,
+		`x-amz-content-sha256:${payloadHash}`,
+		`x-amz-date:${amzDate}`,
+	].join('\n')
+	const signedHeaders = 'host;x-amz-content-sha256;x-amz-date'
+	const canonicalRequest = [
+		'GET',
+		url.pathname,
+		'',
+		`${canonicalHeaders}\n`,
+		signedHeaders,
+		payloadHash,
+	].join('\n')
+	const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`
+	const stringToSign = [
+		'AWS4-HMAC-SHA256',
+		amzDate,
+		credentialScope,
+		sha256(canonicalRequest).toString('hex'),
+	].join('\n')
+	const kDate = hmacSha256(`AWS4${input.secretAccessKey}`, dateStamp)
+	const kRegion = hmacSha256(kDate, region)
+	const kService = hmacSha256(kRegion, service)
+	const kSigning = hmacSha256(kService, 'aws4_request')
+	const signature = hmacSha256(kSigning, stringToSign).toString('hex')
+	const authorization = `AWS4-HMAC-SHA256 Credential=${input.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`
+	const fetchImpl = input.fetchImpl ?? fetch
+	const response = await fetchImpl(url, {
+		method: 'GET',
+		headers: {
+			Authorization: authorization,
+			'x-amz-content-sha256': payloadHash,
+			'x-amz-date': amzDate,
+		},
+	})
+	if (!response.ok) {
+		throw new Error(
+			`Escrow GET failed for ${input.objectKey}: HTTP ${response.status}`,
+		)
+	}
+	return response.text()
+}
+
+async function promptForPassphrase(): Promise<string> {
+	const input = process.stdin
+	if (!input.isTTY || typeof input.setRawMode !== 'function') {
+		throw new Error(
+			'SECRET_ESCROW_PASSPHRASE is required when stdin is not an interactive terminal',
+		)
+	}
+
+	process.stderr.write('Escrow passphrase: ')
+	input.setRawMode(true)
+	input.setEncoding('utf8')
+	input.resume()
+	return new Promise((resolve, reject) => {
+		let passphrase = ''
+		const cleanup = () => {
+			input.off('data', onData)
+			input.setRawMode(false)
+			input.pause()
+			process.stderr.write('\n')
+		}
+		const onData = (chunk: string) => {
+			for (const character of chunk) {
+				if (character === '\r' || character === '\n') {
+					cleanup()
+					if (passphrase.length === 0) {
+						reject(new Error('Escrow passphrase must not be empty'))
+					} else {
+						resolve(passphrase)
+					}
+					return
+				}
+				if (character === '\u0003') {
+					cleanup()
+					reject(new Error('Escrow unseal cancelled'))
+					return
+				}
+				if (character === '\u007f' || character === '\b') {
+					passphrase = Array.from(passphrase).slice(0, -1).join('')
+				} else {
+					passphrase += character
+				}
+			}
+		}
+		input.on('data', onData)
+	})
+}
+
+async function writeRecoveredSecret(
+	secretValue: string,
+	outputPath: string | undefined,
+): Promise<void> {
+	if (!outputPath) {
+		process.stdout.write(secretValue)
+		return
+	}
+
+	const resolvedOutputPath = path.resolve(outputPath)
+	const resolvedParent = await realpath(path.dirname(resolvedOutputPath))
+	const checkedOutputPath = path.join(resolvedParent, path.basename(outputPath))
+	const relativeToRepository = path.relative(repositoryRoot, checkedOutputPath)
+	if (
+		relativeToRepository === '' ||
+		(!relativeToRepository.startsWith(`..${path.sep}`) &&
+			relativeToRepository !== '..' &&
+			!path.isAbsolute(relativeToRepository))
+	) {
+		throw new Error('Refusing to write recovered secret inside the repository')
+	}
+
+	const output = await open(checkedOutputPath, 'wx', 0o600)
+	try {
+		await output.writeFile(secretValue, 'utf8')
+	} finally {
+		await output.close()
+	}
+}
+
+export async function main(
+	env: NodeJS.ProcessEnv = process.env,
+	argv: Array<string> = process.argv.slice(2),
+) {
+	const options = parseArgs(argv)
+	const inputPath = options.inputPath ?? env.ESCROW_INPUT_PATH
+	const outputPath = options.outputPath ?? env.ESCROW_OUTPUT_PATH
+	const passphrase = env.SECRET_ESCROW_PASSPHRASE?.length
+		? env.SECRET_ESCROW_PASSPHRASE
+		: await promptForPassphrase()
+	const version = env.ESCROW_KEY_VERSION?.trim() || 'v1'
+	const objectKey = buildEscrowSecretStoreKey(version)
+
+	const body = inputPath
+		? await readFile(path.resolve(inputPath), 'utf8')
+		: await getSealedEscrowBlob({
+				accountId: requiredEnv(env, 'DR_BACKUP_ACCOUNT_ID'),
+				bucketName: requiredEnv(env, 'DR_BACKUP_BUCKET_NAME'),
+				accessKeyId: requiredEnv(env, 'DR_BACKUP_ACCESS_KEY_ID'),
+				secretAccessKey: requiredEnv(env, 'DR_BACKUP_SECRET_ACCESS_KEY'),
+				objectKey,
+			})
+	let blob: SealedEscrowBlob
+	try {
+		blob = parseSealedEscrowBlob(JSON.parse(body))
+	} catch {
+		throw new Error('Sealed escrow input is not valid canonical escrow JSON')
+	}
+	const secretValue = unsealEscrowSecret(blob, passphrase)
+	await writeRecoveredSecret(secretValue, outputPath)
+	return secretValue
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	await main().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : String(error)
+		console.error(message)
+		process.exitCode = 1
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #1069

## Summary
- add an offline `unseal-escrow.ts` operator tool for local files and authenticated, timeout-bounded R2 reads
- fail closed on malformed blobs, version mismatches, wrong passphrases, repository output paths (including symlink aliases), and existing output files
- replace the test-only decrypt helper with a round-trip test through the real unseal implementation
- document the offline operator smoke-test command and environment equivalents

## Testing
- `npx vitest run --project node-unit tools/disaster-recovery/seal-escrow.node.test.ts` — 3 tests passed
- `npm run validate` — passed on the latest `main` rebase
- CI [`✅ Validate`](https://github.com/kentcdodds/kody/actions/runs/30606931707/job/91081630586) — passed, including the seal→unseal round-trip test

## Conductor report
Merged as `22ae3222` and [deployed successfully](https://github.com/kentcdodds/kody/actions/runs/30607514194). This closes the tooling gap for CI-safe seal→unseal verification. The production escrow smoke test remains an operator action with the real passphrase in an offline environment. Reviewer feedback hardened canonical output containment, deferred passphrase acquisition until after input validation, bounded R2 reads, and verified exclusive output creation.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8da78611` · **Head:** `4badebfb`

**Classification:** extends — adds authenticated recovery behavior to the existing production backup control-plane disaster-recovery tooling.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | extends — offline escrow decryption and R2 retrieval |

### System map

The operator selects a versioned sealed blob from a local file or R2, authenticates it with the escrow passphrase, and writes the recovered key only to an explicit secure sink.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  sealedBlob["Sealed escrow blob<br/>local file or versioned R2 object"]:::untouched
  backupControlPlane["backup-control-plane<br/>Production backup control plane"]:::extended
  secureSink["Secure output<br/>stdout or new mode-0600 file"]:::untouched
  sealedBlob -->|"canonical JSON + AES-GCM payload"| backupControlPlane
  backupControlPlane -->|"authenticated recovered SECRET_STORE_KEY"| secureSink
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Passphrase and recovered key are never logged.
- Input validates before passphrase acquisition; authentication completes before output creation.
- Output containment compares canonical real paths, including symlink aliases.
- Production secret material is excluded from tests.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f6a1984-5957-4d66-8eae-ea277501ab62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f6a1984-5957-4d66-8eae-ea277501ab62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline disaster-recovery tool to retrieve and unseal escrow data from a local file or secure storage.
  * Supports passphrase prompts, command-line options, and secure output to stdout or a protected external file.
  * Added validation for malformed data, incorrect passphrases, incompatible versions, and unsafe output locations.

* **Documentation**
  * Documented the offline unsealing procedure, recovery options, passphrase handling, and enablement checklist.

* **Tests**
  * Added end-to-end coverage for successful recovery, binary data, failures, permissions, and output safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->