### PR TITLE
Add configurable signup gateway and bot protection

### DIFF
--- a/e2e/invite-signup-verification.spec.ts
+++ b/e2e/invite-signup-verification.spec.ts
@@ -134,9 +134,8 @@ test('admin invite signup and email verification happy path', async ({
 	).toHaveCount(0)
 
 	await page.context().clearCookies()
-	await page.goto('/signup')
+	await page.goto('/signup?invite=')
 	clearAuthRateLimitsInE2eDatabase()
-	await page.getByRole('button', { name: 'I have a code' }).click()
 	await page.getByLabel('Username').fill(invitedUsername)
 	await page.getByLabel('Email').fill(invitedEmail)
 	await page.getByLabel('Password').fill(invitedPassword)

--- a/e2e/waiting-list-signup.spec.ts
+++ b/e2e/waiting-list-signup.spec.ts
@@ -15,7 +15,7 @@ test('waiting list signup from home banner and signup page', async ({
 		banner.getByText("You're on the list. We'll be in touch."),
 	).toBeVisible()
 
-	await page.goto('/signup')
+	await page.goto('/signup?panel=waiting-list')
 	await expect(
 		page.getByRole('region', { name: 'Join the waiting list' }),
 	).toHaveCount(0)

--- a/packages/worker/client/public-form-protection.ts
+++ b/packages/worker/client/public-form-protection.ts
@@ -1,0 +1,70 @@
+export const honeypotFieldName = 'website'
+export const turnstileResponseFieldName = 'turnstileToken'
+export const turnstileWidgetClassName = 'kody-turnstile'
+
+type TurnstileApi = {
+	render(
+		container: HTMLElement,
+		options: { sitekey: string; 'response-field-name': string },
+	): string
+}
+
+let turnstileScriptPromise: Promise<TurnstileApi> | null = null
+
+function getTurnstileApi() {
+	return (window as typeof window & { turnstile?: TurnstileApi }).turnstile
+}
+
+function loadTurnstileScript() {
+	const existingApi = getTurnstileApi()
+	if (existingApi) return Promise.resolve(existingApi)
+	if (turnstileScriptPromise) return turnstileScriptPromise
+
+	turnstileScriptPromise = new Promise<TurnstileApi>((resolve, reject) => {
+		const existingScript = document.querySelector<HTMLScriptElement>(
+			'script[data-kody-turnstile]',
+		)
+		const script = existingScript ?? document.createElement('script')
+		const handleLoad = () => {
+			const api = getTurnstileApi()
+			if (api) resolve(api)
+			else reject(new Error('Turnstile API did not initialize.'))
+		}
+		script.addEventListener('load', handleLoad, { once: true })
+		script.addEventListener(
+			'error',
+			() => reject(new Error('Turnstile script failed to load.')),
+			{ once: true },
+		)
+		if (!existingScript) {
+			script.src =
+				'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+			script.async = true
+			script.defer = true
+			script.dataset.kodyTurnstile = 'true'
+			document.head.append(script)
+		}
+	})
+	return turnstileScriptPromise
+}
+
+export async function renderTurnstileWidgets(siteKey: string | null) {
+	if (!siteKey || typeof document === 'undefined') return
+	const api = await loadTurnstileScript()
+	for (const container of document.querySelectorAll<HTMLElement>(
+		`.${turnstileWidgetClassName}:not([data-turnstile-rendered])`,
+	)) {
+		container.dataset.turnstileRendered = 'true'
+		api.render(container, {
+			sitekey: siteKey,
+			'response-field-name': turnstileResponseFieldName,
+		})
+	}
+}
+
+export function readPublicFormProtection(formData: FormData) {
+	return {
+		website: String(formData.get(honeypotFieldName) ?? ''),
+		turnstileToken: String(formData.get(turnstileResponseFieldName) ?? ''),
+	}
+}

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -29,7 +29,7 @@ import {
 	renderTurnstileWidgets,
 	turnstileWidgetClassName,
 } from '#client/public-form-protection.ts'
-import { type SignupMode } from '#worker/env-schema.ts'
+import { type SignupMode } from '#app/signup-mode.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import { resolvePasswordAuthRedirect } from '#client/routes/resolve-password-auth-redirect.ts'
 import {

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -155,8 +155,12 @@ export function LoginRoute(handle: Handle) {
 
 	listenToRouterNavigation(handle, () => {
 		if (!routePath) return
-		if (getPathname(handle) !== routePath) {
-			resetAuthState()
+		const nextPath = getPathname(handle)
+		if (nextPath === routePath) return
+		routePath = nextPath
+		resetAuthState()
+		if (getAuthModeFromPathname(nextPath) === 'signup') {
+			applySignupSearch(getSearchParams(handle))
 		}
 	})
 
@@ -583,7 +587,7 @@ export function LoginRoute(handle: Handle) {
 									required
 									autoFocus
 									autoComplete="username"
-									pattern="[A-Za-z0-9][A-Za-z0-9_-]{1,30}[A-Za-z0-9]"
+									pattern={'[A-Za-z0-9][A-Za-z0-9_\\-]{1,30}[A-Za-z0-9]'}
 									title="Use 3 to 32 letters, numbers, hyphens, or underscores. Start and end with a letter or number."
 									placeholder="kent"
 									mix={css(inputCss)}

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -19,10 +19,17 @@ import {
 import { getOauthLoginErrorMessage } from '#app/oauth-login-errors.ts'
 import { fetchSessionInfo, type SessionStatus } from '#client/session.ts'
 import {
-	fetchEnabledAuthProviders,
+	fetchPublicAuthConfig,
 	startSocialSignIn,
 	type AuthProviderInfo,
 } from '#client/social-sign-in.ts'
+import {
+	honeypotFieldName,
+	readPublicFormProtection,
+	renderTurnstileWidgets,
+	turnstileWidgetClassName,
+} from '#client/public-form-protection.ts'
+import { type SignupMode } from '#worker/env-schema.ts'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import { resolvePasswordAuthRedirect } from '#client/routes/resolve-password-auth-redirect.ts'
 import {
@@ -42,7 +49,7 @@ import {
 
 type AuthMode = 'login' | 'signup'
 type AuthStatus = 'idle' | 'submitting' | 'success' | 'error'
-type SignupPanel = 'waiting-list' | 'invite'
+type SignupPanel = 'waiting-list' | 'invite' | 'open'
 
 function shouldOpenInviteSignup(searchParams: URLSearchParams) {
 	if (searchParams.has('code') || searchParams.has('invite')) return true
@@ -58,8 +65,13 @@ function readPrefillInviteCode(searchParams: URLSearchParams) {
 	return ''
 }
 
-function resolveSignupPanel(searchParams: URLSearchParams): SignupPanel {
-	return shouldOpenInviteSignup(searchParams) ? 'invite' : 'waiting-list'
+function resolveSignupPanel(
+	searchParams: URLSearchParams,
+	signupMode: SignupMode,
+): SignupPanel {
+	if (shouldOpenInviteSignup(searchParams)) return 'invite'
+	if (searchParams.get('panel') === 'waiting-list') return 'waiting-list'
+	return signupMode === 'waitlist' ? 'waiting-list' : signupMode
 }
 
 function buildAuthPath(mode: AuthMode, redirectTo: string | null) {
@@ -92,11 +104,11 @@ export async function authProvidersRouteLoader(
 	_url: URL,
 	signal: AbortSignal,
 ): Promise<RouteLoaderResult> {
-	const providers = await fetchEnabledAuthProviders(signal)
+	const config = await fetchPublicAuthConfig(signal)
 	// A failed fetch yields no loader data, so the route's fallback fetch
 	// retries instead of rendering a permanently button-less page.
-	if (!providers) return {}
-	return { authProviders: { ok: true, providers } }
+	if (!config) return {}
+	return { authProviders: { ok: true, ...config } }
 }
 
 export function LoginRoute(handle: Handle) {
@@ -105,13 +117,18 @@ export function LoginRoute(handle: Handle) {
 	let sessionStatus: SessionStatus = 'idle'
 	let sessionEmail = ''
 	let authProviders: Array<AuthProviderInfo> = []
+	let signupMode: SignupMode = 'invite'
+	let turnstileSiteKey: string | null = null
 	// True once the provider list came from SSR-embedded or SPA-preloaded
 	// loader data (the normal paths); the client fetch is a fallback only.
 	let authProvidersReady = false
 	let activeMode = getCurrentAuthMode(handle)
 	let routePath: string | null = null
 	let activeSignupSearch = readRouterSearch(handle)
-	let signupPanel: SignupPanel = resolveSignupPanel(getSearchParams(handle))
+	let signupPanel: SignupPanel = resolveSignupPanel(
+		getSearchParams(handle),
+		signupMode,
+	)
 	let prefillInviteCode = readPrefillInviteCode(getSearchParams(handle))
 
 	function setState(nextStatus: AuthStatus, nextMessage: string | null = null) {
@@ -126,7 +143,7 @@ export function LoginRoute(handle: Handle) {
 	}
 
 	function applySignupSearch(searchParams: URLSearchParams) {
-		signupPanel = resolveSignupPanel(searchParams)
+		signupPanel = resolveSignupPanel(searchParams, signupMode)
 		prefillInviteCode = readPrefillInviteCode(searchParams)
 	}
 
@@ -147,9 +164,9 @@ export function LoginRoute(handle: Handle) {
 		if (sessionStatus !== 'idle') return
 		sessionStatus = 'loading'
 
-		const [session, providers] = await Promise.all([
+		const [session, config] = await Promise.all([
 			fetchSessionInfo(signal),
-			authProvidersReady ? null : fetchEnabledAuthProviders(signal),
+			authProvidersReady ? null : fetchPublicAuthConfig(signal),
 		])
 		if (signal.aborted) {
 			// Hydration re-renders abort in-flight queued tasks; reset so the
@@ -158,8 +175,11 @@ export function LoginRoute(handle: Handle) {
 			return
 		}
 		sessionEmail = session?.email ?? ''
-		if (providers && !authProvidersReady) {
-			authProviders = providers
+		if (config && !authProvidersReady) {
+			authProviders = config.providers
+			signupMode = config.signupMode
+			turnstileSiteKey = config.turnstileSiteKey
+			applySignupSearch(getSearchParams(handle))
 			authProvidersReady = true
 		}
 
@@ -179,6 +199,7 @@ export function LoginRoute(handle: Handle) {
 		const formData = new FormData(form)
 		const firstName = String(formData.get('firstName') ?? '').trim()
 		const email = String(formData.get('email') ?? '').trim()
+		const protection = readPublicFormProtection(formData)
 
 		if (!firstName || !email) {
 			setState('error', 'First name and email are required.')
@@ -192,7 +213,7 @@ export function LoginRoute(handle: Handle) {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				credentials: 'include',
-				body: JSON.stringify({ firstName, email }),
+				body: JSON.stringify({ firstName, email, ...protection }),
 			})
 			const payload = await response.json().catch(() => null)
 
@@ -229,6 +250,7 @@ export function LoginRoute(handle: Handle) {
 		const inviteCode =
 			mode === 'signup' ? String(formData.get('inviteCode') ?? '').trim() : ''
 		const rememberMe = mode === 'login' && formData.get('rememberMe') === 'on'
+		const protection = readPublicFormProtection(formData)
 
 		if (!email || !password) {
 			setState('error', 'Email and password are required.')
@@ -251,6 +273,7 @@ export function LoginRoute(handle: Handle) {
 					password,
 					mode,
 					rememberMe,
+					...protection,
 					...(mode === 'signup'
 						? {
 								username,
@@ -299,10 +322,17 @@ export function LoginRoute(handle: Handle) {
 					inviteCode = inviteInput.value.trim() || null
 				}
 			}
+			const authForm = document.querySelector<HTMLFormElement>(
+				'form[data-public-auth-form]',
+			)
+			const protection = authForm
+				? readPublicFormProtection(new FormData(authForm))
+				: { website: '', turnstileToken: '' }
 			const errorMessage = await startSocialSignIn(
 				providerId,
 				getCurrentRedirectTo(handle),
 				inviteCode,
+				protection,
 			)
 			if (errorMessage) {
 				setState('error', errorMessage)
@@ -345,6 +375,12 @@ export function LoginRoute(handle: Handle) {
 			const rememberMeInput = document.querySelector('input[name="rememberMe"]')
 			const rememberMe =
 				rememberMeInput instanceof HTMLInputElement && rememberMeInput.checked
+			const authForm = document.querySelector<HTMLFormElement>(
+				'form[data-public-auth-form]',
+			)
+			const protection = authForm
+				? readPublicFormProtection(new FormData(authForm))
+				: { website: '', turnstileToken: '' }
 
 			const verificationResponse = await fetch('/webauthn/authentication', {
 				method: 'POST',
@@ -353,6 +389,7 @@ export function LoginRoute(handle: Handle) {
 				body: JSON.stringify({
 					response: authenticationResponse,
 					rememberMe,
+					...protection,
 				}),
 			})
 			const verificationPayload = await verificationResponse
@@ -390,8 +427,14 @@ export function LoginRoute(handle: Handle) {
 			)
 			if (routeData) {
 				authProviders = routeData.providers
+				signupMode = routeData.signupMode
+				turnstileSiteKey = routeData.turnstileSiteKey
+				applySignupSearch(getSearchParams(handle))
 				authProvidersReady = true
 			}
+		}
+		if (typeof document !== 'undefined' && turnstileSiteKey) {
+			handle.queueTask(() => renderTurnstileWidgets(turnstileSiteKey))
 		}
 		if (typeof document !== 'undefined' && sessionStatus === 'idle') {
 			handle.queueTask(loadSessionAndProviders)
@@ -431,7 +474,9 @@ export function LoginRoute(handle: Handle) {
 		const description = showWaitingList
 			? 'Kody is built for people who want to own their automations. Join the waitlist for an invite.'
 			: isSignup
-				? 'Use your invite code to create an account and start building automations you own.'
+				? showInviteSignup
+					? 'Use your invite code to create an account and start building automations you own.'
+					: 'Create an account and start building automations you own.'
 				: 'Log in to keep building automations you own.'
 		const submitLabel = isSignup ? 'Create account' : 'Sign in'
 		const toggleLabel = isSignup
@@ -459,6 +504,14 @@ export function LoginRoute(handle: Handle) {
 				) : null}
 				{showWaitingList ? (
 					<form mix={[css(cardCss), on('submit', handleWaitingListSubmit)]}>
+						<input
+							type="text"
+							name={honeypotFieldName}
+							tabIndex={-1}
+							autoComplete="off"
+							aria-hidden="true"
+							mix={css(honeypotCss)}
+						/>
 						<label mix={css(fieldCss)}>
 							<span mix={css(fieldLabelCss)}>First name</span>
 							<input
@@ -472,6 +525,9 @@ export function LoginRoute(handle: Handle) {
 								mix={css(inputCss)}
 							/>
 						</label>
+						{turnstileSiteKey ? (
+							<div class={turnstileWidgetClassName}></div>
+						) : null}
 						<label mix={css(fieldCss)}>
 							<span mix={css(fieldLabelCss)}>Email</span>
 							<input
@@ -490,21 +546,31 @@ export function LoginRoute(handle: Handle) {
 						>
 							{isSubmitting ? 'Joining...' : 'Join waiting list'}
 						</button>
-						{message ? (
-							<p
-								aria-live="polite"
-								mix={css({
-									color: status === 'error' ? colors.error : colors.text,
-									fontSize: typography.fontSize.sm,
-								})}
-							>
-								{message}
-							</p>
-						) : null}
+						<p
+							aria-live="polite"
+							role={status === 'error' ? 'alert' : undefined}
+							mix={css({
+								color: status === 'error' ? colors.error : colors.text,
+								fontSize: typography.fontSize.sm,
+							})}
+						>
+							{message ?? ''}
+						</p>
 					</form>
 				) : (
-					<form mix={[css(cardCss), on('submit', handleSubmit)]}>
-						{showInviteSignup ? (
+					<form
+						data-public-auth-form
+						mix={[css(cardCss), on('submit', handleSubmit)]}
+					>
+						<input
+							type="text"
+							name={honeypotFieldName}
+							tabIndex={-1}
+							autoComplete="off"
+							aria-hidden="true"
+							mix={css(honeypotCss)}
+						/>
+						{isSignup ? (
 							<label mix={css(fieldCss)}>
 								<span mix={css(fieldLabelCss)}>Username</span>
 								<input
@@ -526,7 +592,7 @@ export function LoginRoute(handle: Handle) {
 								type="email"
 								name="email"
 								required
-								autoFocus={!showInviteSignup}
+								autoFocus={!isSignup}
 								autoComplete="email"
 								placeholder="you@example.com"
 								mix={css(inputCss)}
@@ -538,9 +604,7 @@ export function LoginRoute(handle: Handle) {
 								type="password"
 								name="password"
 								required
-								autoComplete={
-									showInviteSignup ? 'new-password' : 'current-password'
-								}
+								autoComplete={isSignup ? 'new-password' : 'current-password'}
 								placeholder="At least 8 characters"
 								mix={css(inputCss)}
 							/>
@@ -557,6 +621,9 @@ export function LoginRoute(handle: Handle) {
 									mix={css(inputCss)}
 								/>
 							</label>
+						) : null}
+						{turnstileSiteKey ? (
+							<div class={turnstileWidgetClassName}></div>
 						) : null}
 						{!isSignup ? (
 							<label
@@ -618,17 +685,16 @@ export function LoginRoute(handle: Handle) {
 								Sign in with a passkey
 							</button>
 						) : null}
-						{message ? (
-							<p
-								aria-live="polite"
-								mix={css({
-									color: status === 'error' ? colors.error : colors.text,
-									fontSize: typography.fontSize.sm,
-								})}
-							>
-								{message}
-							</p>
-						) : null}
+						<p
+							aria-live="polite"
+							role={status === 'error' ? 'alert' : undefined}
+							mix={css({
+								color: status === 'error' ? colors.error : colors.text,
+								fontSize: typography.fontSize.sm,
+							})}
+						>
+							{message ?? ''}
+						</p>
 					</form>
 				)}
 				{isSignup ? (
@@ -724,4 +790,12 @@ const providerButtonCss = {
 const actionLinkCss = {
 	...primaryLinkCss,
 	textAlign: 'left' as const,
+}
+
+const honeypotCss = {
+	position: 'absolute' as const,
+	left: '-10000px',
+	width: '1px',
+	height: '1px',
+	overflow: 'hidden' as const,
 }

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -503,7 +503,10 @@ export function LoginRoute(handle: Handle) {
 					</p>
 				) : null}
 				{showWaitingList ? (
-					<form mix={[css(cardCss), on('submit', handleWaitingListSubmit)]}>
+					<form
+						key="waiting-list"
+						mix={[css(cardCss), on('submit', handleWaitingListSubmit)]}
+					>
 						<input
 							type="text"
 							name={honeypotFieldName}
@@ -559,6 +562,7 @@ export function LoginRoute(handle: Handle) {
 					</form>
 				) : (
 					<form
+						key="authentication"
 						data-public-auth-form
 						mix={[css(cardCss), on('submit', handleSubmit)]}
 					>

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -6,6 +6,13 @@ import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readRouterSearch } from '#client/router-location.tsx'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
+import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import {
+	honeypotFieldName,
+	readPublicFormProtection,
+	renderTurnstileWidgets,
+	turnstileWidgetClassName,
+} from '#client/public-form-protection.ts'
 import {
 	renderEmailVerificationPrompt,
 	requestResendVerification,
@@ -99,6 +106,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	let message: OAuthAuthorizeMessage | null = null
 	let submittingDecision: OAuthAuthorizeDecision | null = null
 	let lastSearch = ''
+	let turnstileSiteKey: string | null | undefined
 	let session: SessionInfo | null = null
 	let sessionStatus: SessionStatus = 'idle'
 	let resetCompleted = false
@@ -119,6 +127,14 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		if (description) return description
 		const error = params.get('error')
 		return error ? `Authorization error: ${error}` : null
+	}
+
+	async function loadProtectionConfig(signal: AbortSignal) {
+		if (turnstileSiteKey !== undefined) return
+		const config = await fetchPublicAuthConfig(signal)
+		if (signal.aborted) return
+		turnstileSiteKey = config?.turnstileSiteKey ?? null
+		handle.update()
 	}
 
 	async function loadInfo(requestId: number) {
@@ -279,6 +295,9 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				}
 				body.set('email', email)
 				body.set('password', password)
+				const protection = readPublicFormProtection(formData)
+				body.set('website', protection.website)
+				body.set('turnstileToken', protection.turnstileToken)
 			}
 			const response = await fetch(window.location.href, {
 				method: 'POST',
@@ -337,6 +356,12 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	}
 
 	return () => {
+		if (typeof document !== 'undefined' && turnstileSiteKey === undefined) {
+			handle.queueTask(loadProtectionConfig)
+		}
+		if (typeof document !== 'undefined' && turnstileSiteKey) {
+			handle.queueTask(() => renderTurnstileWidgets(turnstileSiteKey ?? null))
+		}
 		const currentHref = readCurrentRouterHref(handle)
 		const currentSearch = readRouterSearch(handle)
 		// Consume on every render so same-path preload-then-commit refreshes
@@ -520,6 +545,14 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 							on('submit', handleSubmit),
 						]}
 					>
+						<input
+							type="text"
+							name={honeypotFieldName}
+							tabIndex={-1}
+							autoComplete="off"
+							aria-hidden="true"
+							mix={css(honeypotCss)}
+						/>
 						{!isLoggedIn && isSessionReady ? (
 							<>
 								<label mix={css(fieldCss)}>
@@ -547,6 +580,9 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 									/>
 								</label>
 							</>
+						) : null}
+						{!isLoggedIn && turnstileSiteKey ? (
+							<div class={turnstileWidgetClassName}></div>
 						) : null}
 						<div
 							mix={css({ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' })}
@@ -583,6 +619,14 @@ const pageCss = {
 	...stackedPageCss,
 	maxWidth: '28rem',
 	margin: '0 auto',
+}
+
+const honeypotCss = {
+	position: 'absolute' as const,
+	left: '-10000px',
+	width: '1px',
+	height: '1px',
+	overflow: 'hidden' as const,
 }
 
 const headerCss = pageHeaderCss

--- a/packages/worker/client/routes/reset-password.tsx
+++ b/packages/worker/client/routes/reset-password.tsx
@@ -16,6 +16,13 @@ import {
 	primaryLinkCss,
 	stackedPageCss,
 } from '#client/styles/style-primitives.ts'
+import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import {
+	honeypotFieldName,
+	readPublicFormProtection,
+	renderTurnstileWidgets,
+	turnstileWidgetClassName,
+} from '#client/public-form-protection.ts'
 
 type ResetStatus = 'idle' | 'submitting' | 'success' | 'error'
 
@@ -26,6 +33,7 @@ function getSearchParams(handle: Handle) {
 export function ResetPasswordRoute(handle: Handle) {
 	let status: ResetStatus = 'idle'
 	let message: string | null = null
+	let turnstileSiteKey: string | null | undefined
 
 	function setState(
 		nextStatus: ResetStatus,
@@ -36,12 +44,21 @@ export function ResetPasswordRoute(handle: Handle) {
 		handle.update()
 	}
 
+	async function loadProtectionConfig(signal: AbortSignal) {
+		if (turnstileSiteKey !== undefined) return
+		const config = await fetchPublicAuthConfig(signal)
+		if (signal.aborted) return
+		turnstileSiteKey = config?.turnstileSiteKey ?? null
+		handle.update()
+	}
+
 	async function submitResetRequest(event: SubmitEvent) {
 		event.preventDefault()
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
 
 		const formData = new FormData(event.currentTarget)
 		const email = String(formData.get('email') ?? '').trim()
+		const protection = readPublicFormProtection(formData)
 		if (!email) {
 			setState('error', 'Email is required.')
 			return
@@ -52,7 +69,7 @@ export function ResetPasswordRoute(handle: Handle) {
 			const response = await fetch('/password-reset', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ email }),
+				body: JSON.stringify({ email, ...protection }),
 			})
 			const payload = await response.json().catch(() => null)
 			if (!response.ok) {
@@ -78,6 +95,7 @@ export function ResetPasswordRoute(handle: Handle) {
 
 		const formData = new FormData(event.currentTarget)
 		const password = String(formData.get('password') ?? '')
+		const protection = readPublicFormProtection(formData)
 		if (!password) {
 			setState('error', 'Password is required.')
 			return
@@ -88,7 +106,7 @@ export function ResetPasswordRoute(handle: Handle) {
 			const response = await fetch('/password-reset/confirm', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ token, password }),
+				body: JSON.stringify({ token, password, ...protection }),
 			})
 			const payload = await response.json().catch(() => null)
 			if (!response.ok) {
@@ -106,6 +124,12 @@ export function ResetPasswordRoute(handle: Handle) {
 	}
 
 	return () => {
+		if (typeof document !== 'undefined' && turnstileSiteKey === undefined) {
+			handle.queueTask(loadProtectionConfig)
+		}
+		if (typeof document !== 'undefined' && turnstileSiteKey) {
+			handle.queueTask(() => renderTurnstileWidgets(turnstileSiteKey ?? null))
+		}
 		const searchParams = getSearchParams(handle)
 		const token = String(searchParams.get('token') ?? '').trim()
 		const mode = token ? 'confirm' : 'request'
@@ -137,6 +161,14 @@ export function ResetPasswordRoute(handle: Handle) {
 						),
 					]}
 				>
+					<input
+						type="text"
+						name={honeypotFieldName}
+						tabIndex={-1}
+						autoComplete="off"
+						aria-hidden="true"
+						mix={css(honeypotCss)}
+					/>
 					{mode === 'confirm' ? (
 						<label mix={css(fieldCss)}>
 							<span mix={css(fieldLabelCss)}>New password</span>
@@ -164,6 +196,9 @@ export function ResetPasswordRoute(handle: Handle) {
 							/>
 						</label>
 					)}
+					{turnstileSiteKey ? (
+						<div class={turnstileWidgetClassName}></div>
+					) : null}
 					<button
 						type="submit"
 						disabled={isSubmitting}
@@ -207,3 +242,11 @@ const pageCss = {
 }
 
 const primaryButtonCss = getPrimaryButtonCss({ size: 'lg', weight: 'semibold' })
+
+const honeypotCss = {
+	position: 'absolute' as const,
+	left: '-10000px',
+	width: '1px',
+	height: '1px',
+	overflow: 'hidden' as const,
+}

--- a/packages/worker/client/routes/verify.tsx
+++ b/packages/worker/client/routes/verify.tsx
@@ -14,6 +14,13 @@ import {
 	pageTitleCss,
 	stackedPageCss,
 } from '#client/styles/style-primitives.ts'
+import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import {
+	honeypotFieldName,
+	readPublicFormProtection,
+	renderTurnstileWidgets,
+	turnstileWidgetClassName,
+} from '#client/public-form-protection.ts'
 
 function normalizeRedirectTo(value: string | null) {
 	if (!value) return null
@@ -31,6 +38,15 @@ function buildLoginHref(redirectTo: string | null) {
 export function VerifyRoute(handle: Handle) {
 	let status: 'idle' | 'submitting' = 'idle'
 	let message: string | null = null
+	let turnstileSiteKey: string | null | undefined
+
+	async function loadProtectionConfig(signal: AbortSignal) {
+		if (turnstileSiteKey !== undefined) return
+		const config = await fetchPublicAuthConfig(signal)
+		if (signal.aborted) return
+		turnstileSiteKey = config?.turnstileSiteKey ?? null
+		handle.update()
+	}
 
 	function getRedirectTo() {
 		const params = new URLSearchParams(readRouterSearch(handle))
@@ -43,6 +59,7 @@ export function VerifyRoute(handle: Handle) {
 
 		const formData = new FormData(event.currentTarget)
 		const code = String(formData.get('code') ?? '').trim()
+		const protection = readPublicFormProtection(formData)
 		if (!code) {
 			message = 'Enter the 6-digit code from your authenticator app.'
 			handle.update()
@@ -58,7 +75,7 @@ export function VerifyRoute(handle: Handle) {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				credentials: 'include',
-				body: JSON.stringify({ code }),
+				body: JSON.stringify({ code, ...protection }),
 			})
 			const payload = await response.json().catch(() => null)
 			if (!response.ok || !payload?.ok) {
@@ -84,6 +101,12 @@ export function VerifyRoute(handle: Handle) {
 	}
 
 	return () => {
+		if (typeof document !== 'undefined' && turnstileSiteKey === undefined) {
+			handle.queueTask(loadProtectionConfig)
+		}
+		if (typeof document !== 'undefined' && turnstileSiteKey) {
+			handle.queueTask(() => renderTurnstileWidgets(turnstileSiteKey ?? null))
+		}
 		const isSubmitting = status === 'submitting'
 
 		return (
@@ -96,6 +119,14 @@ export function VerifyRoute(handle: Handle) {
 					</p>
 				</header>
 				<form mix={[css(cardCss), on('submit', handleSubmit)]}>
+					<input
+						type="text"
+						name={honeypotFieldName}
+						tabIndex={-1}
+						autoComplete="off"
+						aria-hidden="true"
+						mix={css(honeypotCss)}
+					/>
 					<label mix={css(fieldCss)}>
 						<span mix={css(fieldLabelCss)}>Verification code</span>
 						<input
@@ -110,6 +141,9 @@ export function VerifyRoute(handle: Handle) {
 							mix={css(inputCss)}
 						/>
 					</label>
+					{turnstileSiteKey ? (
+						<div class={turnstileWidgetClassName}></div>
+					) : null}
 					<button
 						type="submit"
 						disabled={isSubmitting}
@@ -146,3 +180,11 @@ const pageCss = {
 }
 
 const primaryButtonCss = getPrimaryButtonCss({ size: 'lg', weight: 'semibold' })
+
+const honeypotCss = {
+	position: 'absolute' as const,
+	left: '-10000px',
+	width: '1px',
+	height: '1px',
+	overflow: 'hidden' as const,
+}

--- a/packages/worker/client/social-sign-in.ts
+++ b/packages/worker/client/social-sign-in.ts
@@ -1,4 +1,11 @@
+import { type SignupMode } from '#worker/env-schema.ts'
+
 export type AuthProviderInfo = { id: string; label: string }
+export type PublicAuthConfig = {
+	providers: Array<AuthProviderInfo>
+	signupMode: SignupMode
+	turnstileSiteKey: string | null
+}
 
 export function buildProviderStartPath(
 	providerId: string,
@@ -20,6 +27,13 @@ export function buildProviderStartPath(
 export async function fetchEnabledAuthProviders(
 	signal?: AbortSignal,
 ): Promise<Array<AuthProviderInfo> | null> {
+	const config = await fetchPublicAuthConfig(signal)
+	return config?.providers ?? null
+}
+
+export async function fetchPublicAuthConfig(
+	signal?: AbortSignal,
+): Promise<PublicAuthConfig | null> {
 	try {
 		const response = await fetch('/auth/providers.json', {
 			headers: { Accept: 'application/json' },
@@ -27,14 +41,24 @@ export async function fetchEnabledAuthProviders(
 		})
 		const payload = await response.json().catch(() => null)
 		if (!response.ok || payload?.ok !== true) return null
-		const providers = Array.isArray(payload.providers) ? payload.providers : []
-		return providers.filter(
+		const providers = (
+			Array.isArray(payload.providers) ? payload.providers : []
+		).filter(
 			(provider: unknown): provider is AuthProviderInfo =>
 				typeof provider === 'object' &&
 				provider !== null &&
 				typeof (provider as AuthProviderInfo).id === 'string' &&
 				typeof (provider as AuthProviderInfo).label === 'string',
 		)
+		const signupMode: SignupMode =
+			payload.signupMode === 'open' || payload.signupMode === 'waitlist'
+				? payload.signupMode
+				: 'invite'
+		const turnstileSiteKey =
+			typeof payload.turnstileSiteKey === 'string'
+				? payload.turnstileSiteKey
+				: null
+		return { providers, signupMode, turnstileSiteKey }
 	} catch {
 		return null
 	}
@@ -54,13 +78,21 @@ export async function startSocialSignIn(
 	providerId: string,
 	redirectTo: string | null,
 	inviteCode: string | null = null,
+	protection: { website: string; turnstileToken: string } = {
+		website: '',
+		turnstileToken: '',
+	},
 ): Promise<string | null> {
 	const response = await fetch(
 		buildProviderStartPath(providerId, redirectTo, inviteCode),
 		{
 			method: 'POST',
-			headers: { Accept: 'application/json' },
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
 			credentials: 'include',
+			body: JSON.stringify(protection),
 		},
 	)
 	const payload = await response.json().catch(() => null)

--- a/packages/worker/client/social-sign-in.ts
+++ b/packages/worker/client/social-sign-in.ts
@@ -1,4 +1,4 @@
-import { type SignupMode } from '#worker/env-schema.ts'
+import { type SignupMode } from '#app/signup-mode.ts'
 
 export type AuthProviderInfo = { id: string; label: string }
 export type PublicAuthConfig = {

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -12,6 +12,13 @@ import {
 	spacing,
 	typography,
 } from '#client/styles/tokens.ts'
+import { fetchPublicAuthConfig } from '#client/social-sign-in.ts'
+import {
+	honeypotFieldName,
+	readPublicFormProtection,
+	renderTurnstileWidgets,
+	turnstileWidgetClassName,
+} from '#client/public-form-protection.ts'
 
 type WaitlistStatus = 'idle' | 'submitting' | 'success' | 'error'
 
@@ -22,6 +29,7 @@ type WaitlistStatus = 'idle' | 'submitting' | 'success' | 'error'
 export function WaitlistBanner(handle: Handle) {
 	let status: WaitlistStatus = 'idle'
 	let message: string | null = null
+	let turnstileSiteKey: string | null | undefined
 
 	function setState(
 		nextStatus: WaitlistStatus,
@@ -29,6 +37,14 @@ export function WaitlistBanner(handle: Handle) {
 	) {
 		status = nextStatus
 		message = nextMessage
+		handle.update()
+	}
+
+	async function loadProtectionConfig(signal: AbortSignal) {
+		if (turnstileSiteKey !== undefined) return
+		const config = await fetchPublicAuthConfig(signal)
+		if (signal.aborted) return
+		turnstileSiteKey = config?.turnstileSiteKey ?? null
 		handle.update()
 	}
 
@@ -40,6 +56,7 @@ export function WaitlistBanner(handle: Handle) {
 		const formData = new FormData(form)
 		const firstName = String(formData.get('firstName') ?? '').trim()
 		const email = String(formData.get('email') ?? '').trim()
+		const protection = readPublicFormProtection(formData)
 
 		if (!firstName || !email) {
 			setState('error', 'First name and email are required.')
@@ -53,7 +70,7 @@ export function WaitlistBanner(handle: Handle) {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				credentials: 'include',
-				body: JSON.stringify({ firstName, email }),
+				body: JSON.stringify({ firstName, email, ...protection }),
 			})
 			const payload = await response.json().catch(() => null)
 
@@ -78,6 +95,12 @@ export function WaitlistBanner(handle: Handle) {
 	}
 
 	return () => {
+		if (typeof document !== 'undefined' && turnstileSiteKey === undefined) {
+			handle.queueTask(loadProtectionConfig)
+		}
+		if (typeof document !== 'undefined' && turnstileSiteKey) {
+			handle.queueTask(() => renderTurnstileWidgets(turnstileSiteKey ?? null))
+		}
 		const isSubmitting = status === 'submitting'
 		const isSuccess = status === 'success'
 
@@ -103,6 +126,14 @@ export function WaitlistBanner(handle: Handle) {
 								waitlist for an invite.
 							</p>
 							<form mix={[css(formCss), on('submit', handleSubmit)]}>
+								<input
+									type="text"
+									name={honeypotFieldName}
+									tabIndex={-1}
+									autoComplete="off"
+									aria-hidden="true"
+									mix={css(honeypotCss)}
+								/>
 								<label mix={css(nameFieldCss)}>
 									<span mix={css(visuallyHiddenCss)}>First name</span>
 									<input
@@ -135,21 +166,23 @@ export function WaitlistBanner(handle: Handle) {
 										{isSubmitting ? 'Joining…' : 'Join'}
 									</button>
 								</div>
+								{turnstileSiteKey ? (
+									<div class={turnstileWidgetClassName}></div>
+								) : null}
 							</form>
-							{message ? (
-								<p
-									aria-live="polite"
-									mix={css({
-										margin: 0,
-										color: colors.error,
-										fontSize: typography.fontSize.xs,
-										width: '100%',
-										textAlign: 'center' as const,
-									})}
-								>
-									{message}
-								</p>
-							) : null}
+							<p
+								aria-live="polite"
+								role={status === 'error' ? 'alert' : undefined}
+								mix={css({
+									margin: 0,
+									color: colors.error,
+									fontSize: typography.fontSize.xs,
+									width: '100%',
+									textAlign: 'center' as const,
+								})}
+							>
+								{message ?? ''}
+							</p>
 						</>
 					)}
 				</div>
@@ -293,4 +326,9 @@ const visuallyHiddenCss = {
 	clip: 'rect(0, 0, 0, 0)',
 	whiteSpace: 'nowrap' as const,
 	border: 0,
+}
+
+const honeypotCss = {
+	...visuallyHiddenCss,
+	left: '-10000px',
 }

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -35,7 +35,7 @@ function createAuthRequest(
 
 function createAuthTestContext(
 	options: {
-		signupEnabled?: boolean
+		signupMode?: 'invite' | 'open' | 'waitlist'
 		failRoleAssignment?: boolean
 		emailConfigured?: boolean
 	} = {},
@@ -46,16 +46,8 @@ function createAuthTestContext(
 	const handler = createAuthHandler({
 		COOKIE_SECRET: testCookieSecret,
 		APP_DB: testDb.db,
-		// SENTRY_ENVIRONMENT defaults to 'production' (signups blocked).
-		// Pass `signupEnabled: true` to put the handler in the 'test' env
-		// that mirrors the wrangler `test`/`preview` envs.
-		...(options.signupEnabled
-			? {
-					SENTRY_ENVIRONMENT: 'test' as const,
-				}
-			: {
-					SENTRY_ENVIRONMENT: 'production' as const,
-				}),
+		SIGNUP_MODE: options.signupMode ?? 'invite',
+		SENTRY_ENVIRONMENT: 'production',
 		...(options.emailConfigured
 			? {
 					CLOUDFLARE_ACCOUNT_ID: 'cf-account-test',
@@ -363,7 +355,7 @@ test('auth handler login and signup workflow', async () => {
 	// Production signups must actually deliver the verification email, so
 	// the production context gets a (stubbed) configured Cloudflare sender.
 	const productionContext = createAuthTestContext({ emailConfigured: true })
-	const signupContext = createAuthTestContext({ signupEnabled: true })
+	const signupContext = createAuthTestContext({ signupMode: 'open' })
 	stubCloudflareEmailFetch({ ok: true })
 
 	const invalidJsonResponse = await productionContext.request('{')
@@ -602,7 +594,7 @@ test('auth handler login and signup workflow', async () => {
 
 test('signup fails when the default user role cannot be assigned', async () => {
 	const context = createAuthTestContext({
-		signupEnabled: true,
+		signupMode: 'open',
 		failRoleAssignment: true,
 	})
 
@@ -631,7 +623,7 @@ test('signup rolls back when the verification email cannot be sent', async () =>
 	consoleError.mockImplementation(() => {})
 	consoleWarn.mockImplementation(() => {})
 	const context = createAuthTestContext({
-		signupEnabled: true,
+		signupMode: 'open',
 		emailConfigured: true,
 	})
 	stubCloudflareEmailFetch({ ok: false, message: 'delivery refused' })

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -47,7 +47,10 @@ function createAuthTestContext(
 		COOKIE_SECRET: testCookieSecret,
 		APP_DB: testDb.db,
 		SIGNUP_MODE: options.signupMode ?? 'invite',
-		SENTRY_ENVIRONMENT: 'production',
+		SENTRY_ENVIRONMENT:
+			options.signupMode === 'open'
+				? ('test' as const)
+				: ('production' as const),
 		...(options.emailConfigured
 			? {
 					CLOUDFLARE_ACCOUNT_ID: 'cf-account-test',

--- a/packages/worker/src/app/handlers/auth-page.ts
+++ b/packages/worker/src/app/handlers/auth-page.ts
@@ -5,10 +5,8 @@ import {
 } from '#app/oauth-providers.ts'
 import { loadSessionInfo } from '#app/session-info.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
-import {
-	getSignupMode,
-	getTurnstileSiteKey,
-} from '#app/public-form-protection.ts'
+import { getTurnstileSiteKey } from '#app/public-form-protection.ts'
+import { getSignupMode } from '#app/signup-mode.ts'
 
 export function createAuthPageHandler(
 	env: Env,

--- a/packages/worker/src/app/handlers/auth-page.ts
+++ b/packages/worker/src/app/handlers/auth-page.ts
@@ -5,6 +5,10 @@ import {
 } from '#app/oauth-providers.ts'
 import { loadSessionInfo } from '#app/session-info.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import {
+	getSignupMode,
+	getTurnstileSiteKey,
+} from '#app/public-form-protection.ts'
 
 export function createAuthPageHandler(
 	env: Env,
@@ -47,6 +51,8 @@ export function createAuthPageHandler(
 				loaderData: {
 					authProviders: {
 						ok: true,
+						signupMode: getSignupMode(env),
+						turnstileSiteKey: getTurnstileSiteKey(env),
 						providers: getEnabledOauthProviders(env).map((provider) => ({
 							id: provider,
 							label: oauthProviderDefinitions[provider].label,

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -138,6 +138,7 @@ function createAppEnv(
 		APP_DB: db,
 		COOKIE_SECRET: testCookieSecret,
 		SENTRY_ENVIRONMENT: 'test',
+		SIGNUP_MODE: 'open',
 		GITHUB_CLIENT_ID: 'github-client-id-test',
 		GITHUB_CLIENT_SECRET: 'github-client-secret-test',
 		GOOGLE_CLIENT_ID: 'google-client-id-test',
@@ -193,6 +194,8 @@ test('providers api lists only configured providers', async () => {
 	)
 	expect(await allEnabled.json()).toEqual({
 		ok: true,
+		signupMode: 'open',
+		turnstileSiteKey: null,
 		providers: [
 			{ id: 'github', label: 'GitHub' },
 			{ id: 'google', label: 'Google' },
@@ -213,6 +216,8 @@ test('providers api lists only configured providers', async () => {
 	)
 	expect(await githubOnly.json()).toEqual({
 		ok: true,
+		signupMode: 'open',
+		turnstileSiteKey: null,
 		providers: [{ id: 'github', label: 'GitHub' }],
 	})
 })
@@ -794,7 +799,7 @@ function mockGithubProfileExchange(email = 'octo@example.com') {
 test('production OAuth signup is invite-gated while existing connections still log in', async () => {
 	const missingInvite = createMigratedDb()
 	const missingInviteEnv = createAppEnv(missingInvite.db, {
-		SENTRY_ENVIRONMENT: 'production',
+		SIGNUP_MODE: 'invite',
 	})
 	mockGithubProfileExchange()
 	const missingStart = await startProviderFlow(
@@ -820,7 +825,7 @@ test('production OAuth signup is invite-gated while existing connections still l
 
 	const invalidInvite = createMigratedDb()
 	const invalidInviteEnv = createAppEnv(invalidInvite.db, {
-		SENTRY_ENVIRONMENT: 'production',
+		SIGNUP_MODE: 'invite',
 	})
 	mockGithubProfileExchange()
 	const invalidStart = await startProviderFlow(
@@ -846,7 +851,7 @@ test('production OAuth signup is invite-gated while existing connections still l
 
 	const invitedSignup = createMigratedDb()
 	const invitedEnv = createAppEnv(invitedSignup.db, {
-		SENTRY_ENVIRONMENT: 'production',
+		SIGNUP_MODE: 'invite',
 	})
 	seedInvite(invitedSignup.sqlite, 'SOCIAL-INVITE')
 	mockGithubProfileExchange('social-invited@example.com')
@@ -893,7 +898,7 @@ test('production OAuth signup is invite-gated while existing connections still l
 
 	const existingLogin = createMigratedDb()
 	const existingEnv = createAppEnv(existingLogin.db, {
-		SENTRY_ENVIRONMENT: 'production',
+		SIGNUP_MODE: 'invite',
 	})
 	await seedUser(existingLogin.sqlite, {
 		id: 11,

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -60,10 +60,10 @@ import {
 	resolveUserStableId,
 } from '#worker/user-id.ts'
 import {
-	getSignupMode,
 	getTurnstileSiteKey,
 	verifyPublicFormProtection,
 } from '#app/public-form-protection.ts'
+import { getSignupMode } from '#app/signup-mode.ts'
 
 /**
  * Accounts created through social login have no usable password until the

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -9,7 +9,6 @@ import {
 	readAuthSessionResult,
 } from '#app/auth-session.ts'
 import { getUniqueConstraintField } from '#worker/database-errors.ts'
-import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
 import { getAvailableUsernameFromBase } from '#worker/identity/generated-username.ts'
 import {
@@ -60,6 +59,11 @@ import {
 	createStableUserIdFromEmail,
 	resolveUserStableId,
 } from '#worker/user-id.ts'
+import {
+	getSignupMode,
+	getTurnstileSiteKey,
+	verifyPublicFormProtection,
+} from '#app/public-form-protection.ts'
 
 /**
  * Accounts created through social login have no usable password until the
@@ -109,10 +113,6 @@ function prefersJsonResponse(request: Request) {
 	)
 }
 
-function isInviteRequiredForSignup(env: Env) {
-	return !isNonProductionRuntime(env)
-}
-
 function inviteFailureToOauthError(
 	reason: InviteConsumeFailureReason,
 ): OauthLoginErrorCode {
@@ -140,6 +140,8 @@ export function createAuthProvidersApiHandler(env: Env) {
 		async handler() {
 			return jsonResponse({
 				ok: true,
+				signupMode: getSignupMode(env),
+				turnstileSiteKey: getTurnstileSiteKey(env),
 				providers: getEnabledOauthProviders(env).map((provider) => ({
 					id: provider,
 					label: oauthProviderDefinitions[provider].label,
@@ -156,6 +158,20 @@ export function createAuthProviderStartHandler(env: Env) {
 			const wantsJson = prefersJsonResponse(request)
 			const redirectTo = normalizeRedirectTo(url.searchParams.get('redirectTo'))
 			const inviteCode = normalizeInviteCode(url.searchParams.get('inviteCode'))
+			const { session } = await readAuthSessionResult(request)
+
+			if (!session) {
+				const body = (await request
+					.clone()
+					.json()
+					.catch(() => ({}))) as Record<string, unknown>
+				const protection = await verifyPublicFormProtection({
+					env,
+					request,
+					body: typeof body === 'object' && body !== null ? body : {},
+				})
+				if (!protection.ok) return protection.response
+			}
 
 			function startError(code: OauthLoginErrorCode) {
 				if (wantsJson) {
@@ -457,7 +473,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				consumedInvitePlan = null
 			}
 
-			const inviteRequired = isInviteRequiredForSignup(env)
+			const inviteRequired = getSignupMode(env) !== 'open'
 			const inviteCodeFromState = loginState.inviteCode
 			if (inviteRequired || normalizeInviteCode(inviteCodeFromState)) {
 				const inviteResult = await consumeInviteCode({

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -45,10 +45,8 @@ import {
 } from '@kody-internal/shared/password-hash.ts'
 import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
 import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
-import {
-	getSignupMode,
-	verifyPublicFormProtection,
-} from '#app/public-form-protection.ts'
+import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
+import { getSignupMode } from '#app/signup-mode.ts'
 
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -44,15 +44,14 @@ import {
 	verifyPassword,
 } from '@kody-internal/shared/password-hash.ts'
 import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
-import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
+import {
+	getSignupMode,
+	verifyPublicFormProtection,
+} from '#app/public-form-protection.ts'
 
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]
-
-function isInviteRequiredForSignup(env: Env) {
-	return !isNonProductionRuntime(env)
-}
 
 const authRequestSchema = object({
 	email: string(),
@@ -79,6 +78,16 @@ export function createAuthHandler(env: Env) {
 					{ status: 400 },
 				)
 			}
+
+			const protection = await verifyPublicFormProtection({
+				env,
+				request,
+				body:
+					typeof body === 'object' && body !== null
+						? (body as Record<string, unknown>)
+						: {},
+			})
+			if (!protection.ok) return protection.response
 
 			const parsedBody = parseSafe(authRequestSchema, body)
 			if (!parsedBody.success) {
@@ -220,7 +229,7 @@ export function createAuthHandler(env: Env) {
 					consumedInvitePlan = null
 				}
 
-				const inviteRequired = isInviteRequiredForSignup(env)
+				const inviteRequired = getSignupMode(env) !== 'open'
 				if (inviteRequired || normalizeInviteCode(inviteCode)) {
 					const inviteResult = await consumeInviteCode({
 						db: env.APP_DB,

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -17,6 +17,7 @@ import { type routes } from '#app/routes.ts'
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
+import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 
 const resetRequestSchema = object({
 	email: string(),
@@ -84,6 +85,15 @@ export function createPasswordResetRequestHandler(env: Env) {
 					{ status: 400 },
 				)
 			}
+			const protection = await verifyPublicFormProtection({
+				env,
+				request,
+				body:
+					typeof body === 'object' && body !== null
+						? (body as Record<string, unknown>)
+						: {},
+			})
+			if (!protection.ok) return protection.response
 			const parsed = parseSafe(resetRequestSchema, body)
 			const requestIp = getRequestIp(request) ?? undefined
 			const normalizedEmail = parsed.success
@@ -196,6 +206,15 @@ export function createPasswordResetConfirmHandler(env: Env) {
 					{ status: 400 },
 				)
 			}
+			const protection = await verifyPublicFormProtection({
+				env,
+				request,
+				body:
+					typeof body === 'object' && body !== null
+						? (body as Record<string, unknown>)
+						: {},
+			})
+			if (!protection.ok) return protection.response
 			const parsed = parseSafe(resetConfirmSchema, body)
 			const requestIp = getRequestIp(request) ?? undefined
 			const token = parsed.success ? parsed.value.token.trim() : ''

--- a/packages/worker/src/app/handlers/waiting-list.ts
+++ b/packages/worker/src/app/handlers/waiting-list.ts
@@ -12,6 +12,7 @@ import { normalizeEmail } from '#worker/identity/normalize-email.ts'
 import { checkRateLimit, releaseRateLimit } from '#app/rate-limit.ts'
 import { type routes } from '#app/routes.ts'
 import { jsonResponse } from '#worker/json-response.ts'
+import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 
 export const waitingListRateLimitConfig = {
 	maxRequests: 5,
@@ -48,6 +49,16 @@ export function createWaitingListHandler(env: Env) {
 			} catch {
 				return jsonResponse({ ok: false, error: 'Invalid JSON payload.' }, 400)
 			}
+
+			const protection = await verifyPublicFormProtection({
+				env,
+				request,
+				body:
+					typeof body === 'object' && body !== null
+						? (body as Record<string, unknown>)
+						: {},
+			})
+			if (!protection.ok) return protection.response
 
 			const parsedBody = parseSafe(waitingListRequestSchema, body)
 			if (!parsedBody.success) {

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -12,6 +12,7 @@ import {
 	type RoleName,
 } from '#worker/identity/permissions.ts'
 import { type AdminFeatureFlag } from '#worker/feature-flags/types.ts'
+import { type SignupMode } from '#worker/env-schema.ts'
 
 export type { ProfileVisibility }
 export type { AdminFeatureFlag }
@@ -1184,6 +1185,8 @@ export type AccountEmailLoaderData = {
 export type AuthProvidersLoaderData = {
 	ok: true
 	providers: Array<{ id: string; label: string }>
+	signupMode: SignupMode
+	turnstileSiteKey: string | null
 }
 
 export type OAuthAuthorizeLoaderData =

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -12,7 +12,7 @@ import {
 	type RoleName,
 } from '#worker/identity/permissions.ts'
 import { type AdminFeatureFlag } from '#worker/feature-flags/types.ts'
-import { type SignupMode } from '#worker/env-schema.ts'
+import { type SignupMode } from '#app/signup-mode.ts'
 
 export type { ProfileVisibility }
 export type { AdminFeatureFlag }

--- a/packages/worker/src/app/public-form-protection.node.test.ts
+++ b/packages/worker/src/app/public-form-protection.node.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+	getSignupMode,
+	getTurnstileSiteKey,
+	verifyPublicFormProtection,
+} from '#app/public-form-protection.ts'
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+test('signup mode and Turnstile configuration default closed and degrade gracefully', async () => {
+	expect(getSignupMode({} as Pick<Env, 'SIGNUP_MODE'>)).toBe('invite')
+	expect(
+		getSignupMode({
+			SIGNUP_MODE: 'open',
+		} as Pick<Env, 'SIGNUP_MODE'>),
+	).toBe('open')
+	expect(
+		getTurnstileSiteKey({
+			TURNSTILE_SITE_KEY: 'site-key',
+		} as Pick<Env, 'TURNSTILE_SITE_KEY' | 'TURNSTILE_SECRET_KEY'>),
+	).toBeNull()
+
+	const request = new Request('https://example.com/auth', {
+		method: 'POST',
+		headers: { 'CF-Connecting-IP': '203.0.113.10' },
+	})
+	const unconfigured = await verifyPublicFormProtection({
+		env: {},
+		request,
+		body: {},
+	})
+	expect(unconfigured).toEqual({ ok: true })
+
+	const honeypot = await verifyPublicFormProtection({
+		env: {},
+		request,
+		body: { website: 'https://spam.example' },
+	})
+	expect(honeypot.ok).toBe(false)
+	if (honeypot.ok) throw new Error('Expected honeypot rejection.')
+	expect(honeypot.response.status).toBe(400)
+})
+
+test('configured Turnstile requires and verifies a token server-side', async () => {
+	const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+		expect(init.method).toBe('POST')
+		const body = new URLSearchParams(String(init.body))
+		expect(body.get('secret')).toBe('secret-key')
+		expect(body.get('response')).toBe('valid-token')
+		expect(body.get('remoteip')).toBe('203.0.113.11')
+		return Response.json({ success: true })
+	})
+	vi.stubGlobal('fetch', fetchSpy)
+	const env = {
+		TURNSTILE_SITE_KEY: 'site-key',
+		TURNSTILE_SECRET_KEY: 'secret-key',
+	}
+	const request = new Request('https://example.com/auth', {
+		method: 'POST',
+		headers: { 'CF-Connecting-IP': '203.0.113.11' },
+	})
+
+	const missing = await verifyPublicFormProtection({
+		env,
+		request,
+		body: {},
+	})
+	expect(missing.ok).toBe(false)
+	if (missing.ok) throw new Error('Expected missing-token rejection.')
+	expect(missing.response.status).toBe(400)
+	expect(fetchSpy).not.toHaveBeenCalled()
+
+	const verified = await verifyPublicFormProtection({
+		env,
+		request,
+		body: { turnstileToken: 'valid-token' },
+	})
+	expect(verified).toEqual({ ok: true })
+	expect(fetchSpy).toHaveBeenCalledOnce()
+})

--- a/packages/worker/src/app/public-form-protection.node.test.ts
+++ b/packages/worker/src/app/public-form-protection.node.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, expect, test, vi } from 'vitest'
 import {
-	getSignupMode,
 	getTurnstileSiteKey,
 	verifyPublicFormProtection,
 } from '#app/public-form-protection.ts'
+import { getSignupMode } from '#app/signup-mode.ts'
 
 afterEach(() => {
 	vi.unstubAllGlobals()

--- a/packages/worker/src/app/public-form-protection.ts
+++ b/packages/worker/src/app/public-form-protection.ts
@@ -1,0 +1,96 @@
+import { getRequestIp } from '#worker/audit-log.ts'
+import { signupModes, type SignupMode } from '#worker/env-schema.ts'
+
+export const honeypotFieldName = 'website'
+export const turnstileResponseFieldName = 'turnstileToken'
+
+type PublicFormBody = Record<string, unknown>
+
+function readTrimmedString(body: PublicFormBody, fieldName: string) {
+	const value = body[fieldName]
+	return typeof value === 'string' ? value.trim() : ''
+}
+
+export function getSignupMode(env: Pick<Env, 'SIGNUP_MODE'>): SignupMode {
+	const mode = env.SIGNUP_MODE
+	return signupModes.includes(mode) ? mode : 'invite'
+}
+
+export function getTurnstileSiteKey(
+	env: Pick<Env, 'TURNSTILE_SITE_KEY' | 'TURNSTILE_SECRET_KEY'>,
+) {
+	const siteKey = env.TURNSTILE_SITE_KEY?.trim()
+	const secretKey = env.TURNSTILE_SECRET_KEY?.trim()
+	return siteKey && secretKey ? siteKey : null
+}
+
+export type PublicFormProtectionResult =
+	| { ok: true }
+	| { ok: false; response: Response }
+
+export async function verifyPublicFormProtection(input: {
+	env: Pick<Env, 'TURNSTILE_SITE_KEY' | 'TURNSTILE_SECRET_KEY'>
+	request: Request
+	body: PublicFormBody
+}): Promise<PublicFormProtectionResult> {
+	if (readTrimmedString(input.body, honeypotFieldName)) {
+		return {
+			ok: false,
+			response: Response.json(
+				{ error: 'Unable to submit this form.' },
+				{ status: 400 },
+			),
+		}
+	}
+
+	const siteKey = input.env.TURNSTILE_SITE_KEY?.trim()
+	const secretKey = input.env.TURNSTILE_SECRET_KEY?.trim()
+	// Turnstile is deliberately opt-in so local development, previews, and tests
+	// continue to work. A partial configuration also stays disabled because the
+	// browser cannot produce a usable token without the public site key.
+	if (!siteKey || !secretKey) return { ok: true }
+
+	const token = readTrimmedString(input.body, turnstileResponseFieldName)
+	if (!token) {
+		return {
+			ok: false,
+			response: Response.json(
+				{ error: 'Please complete the human verification challenge.' },
+				{ status: 400 },
+			),
+		}
+	}
+
+	const verificationBody = new URLSearchParams({
+		secret: secretKey,
+		response: token,
+	})
+	const requestIp = getRequestIp(input.request)
+	if (requestIp) verificationBody.set('remoteip', requestIp)
+
+	try {
+		const response = await fetch(
+			'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body: verificationBody,
+			},
+		)
+		const payload = (await response.json().catch(() => null)) as {
+			success?: unknown
+		} | null
+		if (response.ok && payload?.success === true) return { ok: true }
+	} catch {
+		// The challenge is configured, so a verification outage must not turn
+		// into an authentication bypass.
+	}
+
+	return {
+		ok: false,
+		response: Response.json(
+			{ error: 'Human verification failed. Please try again.' },
+			{ status: 400 },
+		),
+	}
+}

--- a/packages/worker/src/app/public-form-protection.ts
+++ b/packages/worker/src/app/public-form-protection.ts
@@ -1,5 +1,4 @@
 import { getRequestIp } from '#worker/audit-log.ts'
-import { signupModes, type SignupMode } from '#worker/env-schema.ts'
 
 export const honeypotFieldName = 'website'
 export const turnstileResponseFieldName = 'turnstileToken'
@@ -9,11 +8,6 @@ type PublicFormBody = Record<string, unknown>
 function readTrimmedString(body: PublicFormBody, fieldName: string) {
 	const value = body[fieldName]
 	return typeof value === 'string' ? value.trim() : ''
-}
-
-export function getSignupMode(env: Pick<Env, 'SIGNUP_MODE'>): SignupMode {
-	const mode = env.SIGNUP_MODE
-	return signupModes.includes(mode) ? mode : 'invite'
 }
 
 export function getTurnstileSiteKey(

--- a/packages/worker/src/app/security-headers.ts
+++ b/packages/worker/src/app/security-headers.ts
@@ -32,6 +32,8 @@
  *   privacy-preserving, no cookies. The beacon script loads from
  *   `https://static.cloudflareinsights.com` (`script-src`) and POSTs to
  *   `https://cloudflareinsights.com` (`connect-src`).
+ * - Cloudflare Turnstile loads its explicit-render API and challenge iframe
+ *   from `https://challenges.cloudflare.com` when both keys are configured.
  * - `worker-src 'self' blob:` exists for Sentry Session Replay's compression
  *   Web Worker, which is created from a blob URL. Spawning a blob worker
  *   already requires script execution, which `script-src 'self'` still gates,
@@ -46,8 +48,9 @@ const contentSecurityPolicy = [
 	"img-src 'self' data: blob: https://cdn.usefathom.com",
 	"font-src 'self' data:",
 	"style-src 'self' 'unsafe-inline'",
-	"script-src 'self' https://cdn.usefathom.com https://static.cloudflareinsights.com",
-	"connect-src 'self' https://cloudflareinsights.com",
+	"script-src 'self' https://cdn.usefathom.com https://static.cloudflareinsights.com https://challenges.cloudflare.com",
+	"connect-src 'self' https://cloudflareinsights.com https://challenges.cloudflare.com",
+	'frame-src https://challenges.cloudflare.com',
 	"worker-src 'self' blob:",
 ].join('; ')
 

--- a/packages/worker/src/app/signup-mode.ts
+++ b/packages/worker/src/app/signup-mode.ts
@@ -1,0 +1,9 @@
+export const signupModes = ['invite', 'open', 'waitlist'] as const
+export type SignupMode = (typeof signupModes)[number]
+
+export function getSignupMode(env: { SIGNUP_MODE?: SignupMode }): SignupMode {
+	const mode = env.SIGNUP_MODE
+	return mode === 'open' || mode === 'waitlist' || mode === 'invite'
+		? mode
+		: 'invite'
+}

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -6,6 +6,9 @@ import {
 	type InferOutput,
 } from 'remix/data-schema'
 
+export const signupModes = ['invite', 'open', 'waitlist'] as const
+export type SignupMode = (typeof signupModes)[number]
+
 const d1DatabaseSchema = createSchema<unknown, D1Database>((value, context) => {
 	if (value) {
 		return { value: value as D1Database }
@@ -53,6 +56,17 @@ const optionalNonEmptyStringSchema = createSchema<unknown, string | undefined>(
 		return { value: trimmed.length > 0 ? trimmed : undefined }
 	},
 )
+
+const signupModeSchema = createSchema<unknown, SignupMode>((value, context) => {
+	if (value === undefined || value === '') return { value: 'invite' }
+	if (typeof value === 'string' && signupModes.includes(value as SignupMode)) {
+		return { value: value as SignupMode }
+	}
+	return fail(
+		`SIGNUP_MODE must be one of: ${signupModes.join(', ')}`,
+		context.path,
+	)
+})
 
 const optionalUrlStringSchema = createSchema<unknown, string | undefined>(
 	(value, context) => {
@@ -174,6 +188,13 @@ export const EnvSchema = object({
 		'Missing MCP_CLIENT_HUB binding for user-added MCP server connections.',
 	),
 	APP_BASE_URL: optionalUrlStringSchema,
+	// Public account creation posture. `invite` is the safe default; switching
+	// to `open` is an explicit deployment configuration change.
+	SIGNUP_MODE: signupModeSchema,
+	// Turnstile remains disabled unless both keys are configured, preserving
+	// local development, preview deployments, and tests.
+	TURNSTILE_SITE_KEY: optionalNonEmptyStringSchema,
+	TURNSTILE_SECRET_KEY: optionalNonEmptyStringSchema,
 	// Origin that hosted package apps are served from. Required in production
 	// and must use a separate registrable domain so author-supplied package code
 	// is cross-site from the app origin. It may be unset locally/preview/test,

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -5,9 +5,7 @@ import {
 	string,
 	type InferOutput,
 } from 'remix/data-schema'
-
-export const signupModes = ['invite', 'open', 'waitlist'] as const
-export type SignupMode = (typeof signupModes)[number]
+import { signupModes, type SignupMode } from '#app/signup-mode.ts'
 
 const d1DatabaseSchema = createSchema<unknown, D1Database>((value, context) => {
 	if (value) {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -93,6 +93,7 @@ import {
 } from '#worker/jobs/job-schedule-watchdog.ts'
 import { handleDrRestoreRequest } from '#worker/dr/dr-restore.ts'
 import { OAuthPurgeCoordinator } from './oauth-purge.ts'
+import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 
 export {
 	RepoSession,
@@ -141,6 +142,11 @@ const rateLimitedAuthPaths = new Set([
 	'/password-reset/confirm',
 	'/verify/2fa.json',
 	'/account/two-factor.json',
+	'/webauthn/authentication',
+])
+
+const protectedPublicJsonFormPaths = new Set([
+	'/verify/2fa.json',
 	'/webauthn/authentication',
 ])
 
@@ -274,6 +280,22 @@ const appHandler = withCors({
 			}
 		}
 
+		if (
+			request.method === 'POST' &&
+			protectedPublicJsonFormPaths.has(url.pathname)
+		) {
+			const body = (await request
+				.clone()
+				.json()
+				.catch(() => ({}))) as Record<string, unknown>
+			const protection = await verifyPublicFormProtection({
+				env,
+				request,
+				body: typeof body === 'object' && body !== null ? body : {},
+			})
+			if (!protection.ok) return protection.response
+		}
+
 		if (url.pathname === '/__maintenance/reindex-capabilities') {
 			return handleCapabilityReindexRequest(request, env)
 		}
@@ -303,6 +325,25 @@ const appHandler = withCors({
 
 		if (url.pathname === oauthPaths.authorize) {
 			try {
+				if (
+					request.method === 'POST' &&
+					request.headers
+						.get('Content-Type')
+						?.includes('application/x-www-form-urlencoded')
+				) {
+					const formData = await request.clone().formData()
+					// Only the signed-out inline-login form accepts credentials.
+					// Signed-in approval/denial posts remain protected by session
+					// and OAuth request state rather than a public bot challenge.
+					if (formData.has('email') || formData.has('password')) {
+						const protection = await verifyPublicFormProtection({
+							env,
+							request,
+							body: Object.fromEntries(formData),
+						})
+						if (!protection.ok) return protection.response
+					}
+				}
 				return await handleAuthorizeRequest(request, env)
 			} catch (error) {
 				Sentry.captureException(error)

--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -35,6 +35,7 @@
 		"./src/app/document-head.ts",
 		"./src/app/loader-data.ts",
 		"./src/app/safe-redirect.ts",
+		"./src/app/signup-mode.ts",
 		"./src/identity/permissions.ts",
 		"./src/feature-flags/registry.ts",
 		"./src/feature-flags/types.ts",

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -293,6 +293,7 @@
 			},
 			"vars": {
 				"SENTRY_ENVIRONMENT": "production",
+				"SIGNUP_MODE": "invite",
 				// JSON number on purpose: buildSentryOptions reads the raw
 				// runtime env and only honors a number here (string secrets
 				// are ignored). 0 disables Sentry SDK trace sampling because
@@ -471,6 +472,7 @@
 			},
 			"vars": {
 				"SENTRY_ENVIRONMENT": "preview",
+				"SIGNUP_MODE": "invite",
 				"ARTIFACTS_NAMESPACE": "preview",
 				"DR_EXPORT_ENABLED": "",
 				"DR_BACKUP_ACCOUNT_ID": "",
@@ -584,6 +586,7 @@
 			],
 			"vars": {
 				"SENTRY_ENVIRONMENT": "test",
+				"SIGNUP_MODE": "open",
 				"ARTIFACTS_NAMESPACE": "default",
 				"COOKIE_SECRET": "LOCAL_AND_PREVIEW_COOKIE_SECRET_32_CHARS_MINIMUM",
 				"SECRET_STORE_KEY": "LOCAL_TEST_SECRET_STORE_KEY_32_CHARS_MINIMUM_OK",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #1069

## Summary
- add `SIGNUP_MODE=invite|open|waitlist` with a safe `invite` default and make password/social signup plus the signup UI read it
- add honeypot and optional Cloudflare Turnstile protection to unauthenticated credential and waitlist forms while preserving existing atomic IP rate limits
- keep status/error live regions mounted so assistive technology announces updates

## Launch requirement
Before changing `SIGNUP_MODE` to `open`, Kent must configure both `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` in production. Turnstile intentionally stays disabled when either key is absent so local, preview, and test environments continue to work.

## Walkthrough
<a href="https://cursor.com/agents/bc-dbcca989-e6a4-48c8-b81f-d0c8973c7f2b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsignup_gateway_working_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-74e0aa34-8fe5-442c-b0a4-7f776e462f15" alt="signup_gateway_working_walkthrough.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `22ae3222` · **Head:** `c2a207da`

**Classification:** extends — changes the public authentication/session contract and browser form behavior; no new system primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — signup modes, Turnstile widgets, honeypots, persistent live regions |
| `app-sessions` | auth | extends — config-driven signup admission and server-side bot verification |
| `scheduled-cron` | surfaces | composes — the shared worker entry applies protection to inline OAuth/passkey form posts; cron behavior is unchanged |

### System map

Public forms carry honeypot and Turnstile responses through auth handlers before existing signup, login, waitlist, reset, and session flows execute.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::touched
	appUi -->|"SIGNUP_MODE panel + protected form payloads"| appSessions
	scheduledCron -->|"public OAuth/passkey request guard"| appSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| production behavior hardcoded invite-only | `SIGNUP_MODE` controls invite, open, or waitlist posture |
| public forms rely on IP rate limits | existing rate limits plus honeypot and optional Turnstile siteverify |
| live status regions mount with their message | login/waitlist regions stay mounted and update text |

</details>

<!-- system-recap:end -->

## Conductor report
- status: done
- verified: `npm run validate` passed; 24 focused server tests pass after rebasing; signup/invite/waitlist Playwright journeys pass; manual walkthrough confirms invite default, server rejection without a code, persistent error state, and waitlist switching
- scope spill: narrowly updated password reset, OAuth authorize, 2FA, CSP, deployment config, and E2E coverage because the requirement covers every unauthenticated POST form
- decisions needed from Kent: add `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` before setting `SIGNUP_MODE=open`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbcca989-e6a4-48c8-b81f-d0c8973c7f2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbcca989-e6a4-48c8-b81f-d0c8973c7f2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

