### PR TITLE
Optimize inbound delivery reconciliation scans

### DIFF
--- a/packages/worker/migrations/0123-inbound-delivery-effect-indexes.sql
+++ b/packages/worker/migrations/0123-inbound-delivery-effect-indexes.sql
@@ -1,0 +1,94 @@
+-- Keep scheduled inbound-effect reconciliation and durable usage aggregation
+-- off the retained JSON event ledger. A default of 1 safely covers received
+-- events written by an older Worker between this migration and the deploy;
+-- partial indexes exclude unrelated delivery-event rows.
+
+ALTER TABLE email_delivery_events
+ADD COLUMN needs_effect_reconcile INTEGER NOT NULL DEFAULT 1
+CHECK (needs_effect_reconcile IN (0, 1));
+
+ALTER TABLE email_delivery_events
+ADD COLUMN usage_effect_recorded_at TEXT;
+
+ALTER TABLE email_delivery_events
+ADD COLUMN usage_month TEXT;
+
+ALTER TABLE email_delivery_events
+ADD COLUMN usage_bytes INTEGER;
+
+ALTER TABLE email_delivery_events
+ADD COLUMN usage_duration_ms INTEGER;
+
+UPDATE email_delivery_events
+SET
+	usage_effect_recorded_at = json_extract(
+		detail_json,
+		'$.usageEffectRecordedAt'
+	),
+	usage_month = COALESCE(
+		json_extract(detail_json, '$.usageMonth'),
+		(
+			SELECT substr(
+				COALESCE(message.received_at, message.created_at),
+				1,
+				7
+			)
+			FROM email_messages message
+			WHERE message.id = email_delivery_events.message_id
+				AND message.user_id = email_delivery_events.user_id
+		)
+	),
+	usage_bytes = COALESCE(
+		json_extract(detail_json, '$.usageBytes'),
+		(
+			SELECT COALESCE(message.raw_size, 0)
+			FROM email_messages message
+			WHERE message.id = email_delivery_events.message_id
+				AND message.user_id = email_delivery_events.user_id
+		)
+	),
+	usage_duration_ms = COALESCE(
+		json_extract(detail_json, '$.usageDurationMs'),
+		0
+	)
+WHERE provider = 'cloudflare-email-routing'
+	AND event_type = 'received'
+	AND json_extract(detail_json, '$.usageEffectRecordedAt') IS NOT NULL;
+
+UPDATE email_delivery_events
+SET needs_effect_reconcile = CASE
+	WHEN provider = 'cloudflare-email-routing'
+		AND event_type = 'received'
+		AND json_extract(detail_json, '$.fingerprint') IS NOT NULL
+		AND (
+			(
+				json_extract(detail_json, '$.usageEffectRecordedAt') IS NULL
+				AND json_extract(detail_json, '$.usageEffectSuppressedAt') IS NULL
+			)
+			OR (
+				json_extract(detail_json, '$.subscriptionEffectState') IS NULL
+				OR json_extract(
+					detail_json,
+					'$.subscriptionEffectState'
+				) NOT IN ('complete', 'dead-letter')
+			)
+			OR (
+				json_extract(detail_json, '$.usageEffectRecordedAt') IS NOT NULL
+				AND (usage_month IS NULL OR usage_bytes IS NULL)
+			)
+		)
+	THEN 1
+	ELSE 0
+END;
+
+CREATE INDEX IF NOT EXISTS idx_email_delivery_events_pending_effects
+ON email_delivery_events(user_id, created_at)
+WHERE provider = 'cloudflare-email-routing'
+	AND event_type = 'received'
+	AND needs_effect_reconcile = 1;
+
+CREATE INDEX IF NOT EXISTS idx_email_delivery_events_recorded_usage_month
+ON email_delivery_events(usage_month, user_id)
+WHERE provider = 'cloudflare-email-routing'
+	AND event_type = 'received'
+	AND usage_effect_recorded_at IS NOT NULL;

--- a/packages/worker/migrations/0123-inbound-delivery-effect-indexes.sql
+++ b/packages/worker/migrations/0123-inbound-delivery-effect-indexes.sql
@@ -75,6 +75,18 @@ SET needs_effect_reconcile = CASE
 			OR (
 				json_extract(detail_json, '$.usageEffectRecordedAt') IS NOT NULL
 				AND (usage_month IS NULL OR usage_bytes IS NULL)
+				AND (
+					(
+						json_extract(detail_json, '$.usageMonth') IS NOT NULL
+						AND json_extract(detail_json, '$.usageBytes') IS NOT NULL
+					)
+					OR EXISTS (
+						SELECT 1
+						FROM email_messages message
+						WHERE message.id = email_delivery_events.message_id
+							AND message.user_id = email_delivery_events.user_id
+					)
+				)
 			)
 		)
 	THEN 1

--- a/packages/worker/src/email/inbound-delivery-effect-indexes-migration.node.test.ts
+++ b/packages/worker/src/email/inbound-delivery-effect-indexes-migration.node.test.ts
@@ -220,6 +220,11 @@ test('migration preserves durable inbound usage while indexing month reads', () 
 			'cloudflare-email-routing', 'received',
 			'{"fingerprint":"a","usageEffectRecordedAt":"2026-08-01T00:00:00.000Z","usageDurationMs":45,"subscriptionEffectState":"complete"}',
 			'2026-07-31T23:59:59.000Z'
+		), (
+			'event-unhydratable', NULL, 'user-2',
+			'cloudflare-email-routing', 'received',
+			'{"fingerprint":"b","usageEffectRecordedAt":"2026-08-01T00:00:00.000Z","subscriptionEffectState":"complete"}',
+			'2026-07-31T23:59:59.000Z'
 		);
 	`)
 	const legacy = db
@@ -241,7 +246,16 @@ test('migration preserves durable inbound usage while indexing month reads', () 
 			FROM email_delivery_events
 			WHERE provider = 'cloudflare-email-routing'
 				AND event_type = 'received'
-				AND json_extract(detail_json, '$.usageEffectRecordedAt') IS NOT NULL`,
+				AND json_extract(detail_json, '$.usageEffectRecordedAt') IS NOT NULL
+				AND COALESCE(
+					json_extract(detail_json, '$.usageMonth'),
+					(
+						SELECT substr(COALESCE(message.received_at, message.created_at), 1, 7)
+						FROM email_messages message
+						WHERE message.id = email_delivery_events.message_id
+							AND message.user_id = email_delivery_events.user_id
+					)
+				) IN ('2026-07', '2026-06')`,
 		)
 		.all()
 
@@ -263,6 +277,15 @@ test('migration preserves durable inbound usage while indexing month reads', () 
 		)
 		.all()
 	expect(indexed).toEqual(legacy)
+	expect(
+		db
+			.prepare(
+				`SELECT needs_effect_reconcile
+				FROM email_delivery_events
+				WHERE id = 'event-unhydratable'`,
+			)
+			.get(),
+	).toEqual({ needs_effect_reconcile: 0 })
 
 	const plans = db
 		.prepare(

--- a/packages/worker/src/email/inbound-delivery-effect-indexes-migration.node.test.ts
+++ b/packages/worker/src/email/inbound-delivery-effect-indexes-migration.node.test.ts
@@ -1,0 +1,275 @@
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migration = readFileSync(
+	new URL(
+		'../../migrations/0123-inbound-delivery-effect-indexes.sql',
+		import.meta.url,
+	),
+	'utf8',
+)
+
+const effectDuePredicate = `
+	provider = 'cloudflare-email-routing'
+	AND event_type = 'received'
+	AND json_extract(detail_json, '$.fingerprint') IS NOT NULL
+	AND (
+		(
+			json_extract(detail_json, '$.usageEffectRecordedAt') IS NULL
+			AND json_extract(detail_json, '$.usageEffectSuppressedAt') IS NULL
+			AND (
+				json_extract(detail_json, '$.usageEffectRetryAt') IS NULL
+				OR json_extract(detail_json, '$.usageEffectRetryAt') <= ?
+			)
+			AND (
+				json_extract(detail_json, '$.usageEffectLease') IS NULL
+				OR json_extract(detail_json, '$.usageEffectLeaseAt') < ?
+			)
+		)
+		OR (
+			(
+				json_extract(detail_json, '$.subscriptionEffectState') IS NULL
+				OR json_extract(
+					detail_json,
+					'$.subscriptionEffectState'
+				) NOT IN ('complete', 'dead-letter')
+			)
+			AND (
+				json_extract(detail_json, '$.subscriptionEffectRetryAt') IS NULL
+				OR json_extract(detail_json, '$.subscriptionEffectRetryAt') <= ?
+			)
+			AND (
+				json_extract(detail_json, '$.subscriptionEffectState') != 'processing'
+				OR json_extract(detail_json, '$.subscriptionEffectLeaseAt') < ?
+			)
+		)
+	)
+`
+
+test('indexed inbound effect path preserves the legacy due set', () => {
+	const db = new DatabaseSync(':memory:')
+	db.exec(`
+		CREATE TABLE email_messages (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			raw_size INTEGER NOT NULL DEFAULT 0,
+			received_at TEXT,
+			created_at TEXT NOT NULL
+		);
+		CREATE TABLE email_delivery_events (
+			id TEXT PRIMARY KEY,
+			message_id TEXT,
+			user_id TEXT,
+			provider TEXT NOT NULL,
+			event_type TEXT NOT NULL,
+			detail_json TEXT NOT NULL DEFAULT '{}',
+			created_at TEXT NOT NULL
+		);
+	`)
+	const insert = db.prepare(`
+		INSERT INTO email_delivery_events (
+			id, message_id, user_id, provider, event_type, detail_json, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`)
+	const createdAt = '2026-07-30T00:00:00.000Z'
+	const rows = [
+		{
+			id: 'usage-due',
+			detail: { fingerprint: 'a', subscriptionEffectState: 'complete' },
+		},
+		{
+			id: 'usage-retry-future',
+			detail: {
+				fingerprint: 'b',
+				usageEffectRetryAt: '2026-08-01T01:00:00.000Z',
+				subscriptionEffectState: 'complete',
+			},
+		},
+		{
+			id: 'subscription-due',
+			detail: {
+				fingerprint: 'c',
+				usageEffectRecordedAt: '2026-07-31T00:00:00.000Z',
+				usageMonth: '2026-07',
+				usageBytes: 30,
+				subscriptionEffectState: 'pending',
+			},
+		},
+		{
+			id: 'subscription-lease-fresh',
+			detail: {
+				fingerprint: 'd',
+				usageEffectRecordedAt: '2026-07-31T00:00:00.000Z',
+				usageMonth: '2026-07',
+				usageBytes: 40,
+				subscriptionEffectState: 'processing',
+				subscriptionEffectLeaseAt: '2026-07-31T00:59:00.000Z',
+			},
+		},
+		{
+			id: 'complete',
+			detail: {
+				fingerprint: 'e',
+				usageEffectRecordedAt: '2026-07-31T00:00:00.000Z',
+				usageMonth: '2026-07',
+				usageBytes: 50,
+				subscriptionEffectState: 'complete',
+			},
+		},
+		{
+			id: 'dead-letter',
+			detail: {
+				fingerprint: 'f',
+				usageEffectRecordedAt: '2026-07-31T00:00:00.000Z',
+				usageMonth: '2026-07',
+				usageBytes: 60,
+				subscriptionEffectState: 'dead-letter',
+			},
+		},
+		{
+			id: 'unrelated-received',
+			provider: 'test',
+			detail: { fingerprint: 'g' },
+		},
+		{
+			id: 'missing-fingerprint',
+			detail: { subscriptionEffectState: 'pending' },
+		},
+	]
+	for (const row of rows) {
+		insert.run(
+			row.id,
+			null,
+			`user-${row.id}`,
+			row.provider ?? 'cloudflare-email-routing',
+			'received',
+			JSON.stringify(row.detail),
+			createdAt,
+		)
+	}
+	const dueParameters = [
+		'2026-07-31T01:00:00.000Z',
+		'2026-07-31T00:55:00.000Z',
+		'2026-07-31T01:00:00.000Z',
+		'2026-07-31T00:55:00.000Z',
+	] as const
+	const legacyDue = db
+		.prepare(`SELECT id FROM email_delivery_events WHERE ${effectDuePredicate}`)
+		.all(...dueParameters)
+
+	db.exec(`BEGIN; ${migration} COMMIT;`)
+
+	const indexedDue = db
+		.prepare(
+			`SELECT id FROM email_delivery_events
+			WHERE needs_effect_reconcile = 1
+				AND ${effectDuePredicate}`,
+		)
+		.all(...dueParameters)
+	expect(indexedDue).toEqual(legacyDue)
+	expect(indexedDue).toEqual([{ id: 'usage-due' }, { id: 'subscription-due' }])
+
+	const plans = db
+		.prepare(
+			`EXPLAIN QUERY PLAN
+			SELECT id FROM email_delivery_events
+			WHERE needs_effect_reconcile = 1
+				AND ${effectDuePredicate}`,
+		)
+		.all(...dueParameters) as Array<{ detail: string }>
+	expect(plans.map((row) => row.detail).join('\n')).toContain(
+		'idx_email_delivery_events_pending_effects',
+	)
+})
+
+test('migration preserves durable inbound usage while indexing month reads', () => {
+	const db = new DatabaseSync(':memory:')
+	db.exec(`
+		CREATE TABLE email_messages (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			raw_size INTEGER NOT NULL DEFAULT 0,
+			received_at TEXT,
+			created_at TEXT NOT NULL
+		);
+		CREATE TABLE email_delivery_events (
+			id TEXT PRIMARY KEY,
+			message_id TEXT,
+			user_id TEXT,
+			provider TEXT NOT NULL,
+			event_type TEXT NOT NULL,
+			detail_json TEXT NOT NULL DEFAULT '{}',
+			created_at TEXT NOT NULL
+		);
+		INSERT INTO email_messages (
+			id, user_id, raw_size, received_at, created_at
+		) VALUES (
+			'message-1', 'user-1', 321,
+			'2026-07-31T23:59:59.000Z', '2026-07-31T23:59:59.000Z'
+		);
+		INSERT INTO email_delivery_events (
+			id, message_id, user_id, provider, event_type, detail_json, created_at
+		) VALUES (
+			'event-1', 'message-1', 'user-1',
+			'cloudflare-email-routing', 'received',
+			'{"fingerprint":"a","usageEffectRecordedAt":"2026-08-01T00:00:00.000Z","usageDurationMs":45,"subscriptionEffectState":"complete"}',
+			'2026-07-31T23:59:59.000Z'
+		);
+	`)
+	const legacy = db
+		.prepare(
+			`SELECT
+				user_id,
+				json_extract(detail_json, '$.usageEffectRecordedAt') AS recorded_at,
+				COALESCE(
+					json_extract(detail_json, '$.usageMonth'),
+					(
+						SELECT substr(COALESCE(message.received_at, message.created_at), 1, 7)
+						FROM email_messages message
+						WHERE message.id = email_delivery_events.message_id
+							AND message.user_id = email_delivery_events.user_id
+					)
+				) AS month,
+				COALESCE(json_extract(detail_json, '$.usageBytes'), 321) AS bytes,
+				COALESCE(json_extract(detail_json, '$.usageDurationMs'), 0) AS duration_ms
+			FROM email_delivery_events
+			WHERE provider = 'cloudflare-email-routing'
+				AND event_type = 'received'
+				AND json_extract(detail_json, '$.usageEffectRecordedAt') IS NOT NULL`,
+		)
+		.all()
+
+	db.exec(`BEGIN; ${migration} COMMIT;`)
+
+	const indexed = db
+		.prepare(
+			`SELECT
+				user_id,
+				usage_effect_recorded_at AS recorded_at,
+				usage_month AS month,
+				usage_bytes AS bytes,
+				usage_duration_ms AS duration_ms
+			FROM email_delivery_events
+			WHERE provider = 'cloudflare-email-routing'
+				AND event_type = 'received'
+				AND usage_effect_recorded_at IS NOT NULL
+				AND usage_month IN ('2026-07', '2026-06')`,
+		)
+		.all()
+	expect(indexed).toEqual(legacy)
+
+	const plans = db
+		.prepare(
+			`EXPLAIN QUERY PLAN
+			SELECT user_id FROM email_delivery_events
+			WHERE provider = 'cloudflare-email-routing'
+				AND event_type = 'received'
+				AND usage_effect_recorded_at IS NOT NULL
+				AND usage_month IN ('2026-07', '2026-06')`,
+		)
+		.all() as Array<{ detail: string }>
+	expect(plans.map((row) => row.detail).join('\n')).toContain(
+		'idx_email_delivery_events_recorded_usage_month',
+	)
+})

--- a/packages/worker/src/email/inbound-delivery-effect-indexes-migration.node.test.ts
+++ b/packages/worker/src/email/inbound-delivery-effect-indexes-migration.node.test.ts
@@ -155,7 +155,11 @@ test('indexed inbound effect path preserves the legacy due set', () => {
 		'2026-07-31T00:55:00.000Z',
 	] as const
 	const legacyDue = db
-		.prepare(`SELECT id FROM email_delivery_events WHERE ${effectDuePredicate}`)
+		.prepare(
+			`SELECT id FROM email_delivery_events
+			WHERE ${effectDuePredicate}
+			ORDER BY id`,
+		)
 		.all(...dueParameters)
 
 	db.exec(`BEGIN; ${migration} COMMIT;`)
@@ -164,11 +168,12 @@ test('indexed inbound effect path preserves the legacy due set', () => {
 		.prepare(
 			`SELECT id FROM email_delivery_events
 			WHERE needs_effect_reconcile = 1
-				AND ${effectDuePredicate}`,
+				AND ${effectDuePredicate}
+			ORDER BY id`,
 		)
 		.all(...dueParameters)
 	expect(indexedDue).toEqual(legacyDue)
-	expect(indexedDue).toEqual([{ id: 'usage-due' }, { id: 'subscription-due' }])
+	expect(indexedDue).toEqual([{ id: 'subscription-due' }, { id: 'usage-due' }])
 
 	const plans = db
 		.prepare(

--- a/packages/worker/src/email/inbound-delivery.ts
+++ b/packages/worker/src/email/inbound-delivery.ts
@@ -852,14 +852,20 @@ export async function markInboundDeliveryReceived(input: {
 	}
 	delete detail.storageLease
 	delete detail.storageLeaseAt
+	const usageEffectComplete =
+		detail.usageEffectRecordedAt != null ||
+		detail.usageEffectSuppressedAt != null
+	const subscriptionEffectComplete =
+		detail.subscriptionEffectState === 'complete' ||
+		detail.subscriptionEffectState === 'dead-letter'
 	const result = await input.db
 		.prepare(
 			`UPDATE email_delivery_events
 			SET message_id = ?,
 				event_type = 'received',
 				detail_json = ?,
-				needs_effect_reconcile = 1,
-				usage_effect_recorded_at = NULL,
+				needs_effect_reconcile = ?,
+				usage_effect_recorded_at = ?,
 				usage_month = ?,
 				usage_bytes = ?,
 				usage_duration_ms = ?
@@ -871,6 +877,8 @@ export async function markInboundDeliveryReceived(input: {
 		.bind(
 			input.delivery.messageId,
 			JSON.stringify(detail),
+			usageEffectComplete && subscriptionEffectComplete ? 0 : 1,
+			detail.usageEffectRecordedAt ?? null,
 			detail.usageMonth,
 			detail.usageBytes,
 			detail.usageDurationMs,

--- a/packages/worker/src/email/inbound-delivery.ts
+++ b/packages/worker/src/email/inbound-delivery.ts
@@ -855,7 +855,14 @@ export async function markInboundDeliveryReceived(input: {
 	const result = await input.db
 		.prepare(
 			`UPDATE email_delivery_events
-			SET message_id = ?, event_type = 'received', detail_json = ?
+			SET message_id = ?,
+				event_type = 'received',
+				detail_json = ?,
+				needs_effect_reconcile = 1,
+				usage_effect_recorded_at = NULL,
+				usage_month = ?,
+				usage_bytes = ?,
+				usage_duration_ms = ?
 			WHERE id = ?
 				AND user_id = ?
 				AND json_extract(detail_json, '$.state') = 'storing'
@@ -864,6 +871,9 @@ export async function markInboundDeliveryReceived(input: {
 		.bind(
 			input.delivery.messageId,
 			JSON.stringify(detail),
+			detail.usageMonth,
+			detail.usageBytes,
+			detail.usageDurationMs,
 			input.delivery.deliveryId,
 			input.delivery.userId,
 			input.delivery.storageLease,

--- a/packages/worker/src/email/inbound-effects.ts
+++ b/packages/worker/src/email/inbound-effects.ts
@@ -77,10 +77,29 @@ async function recordInboundUsageEffect(input: {
 				),
 				input.env.APP_DB.prepare(
 					`UPDATE email_delivery_events
-					SET detail_json = json_remove(
-						json_set(detail_json, '$.usageEffectRecordedAt', ?),
-						'$.usageEffectRetryAt'
-					)
+					SET
+						detail_json = json_remove(
+							json_set(
+								detail_json,
+								'$.usageEffectRecordedAt', ?,
+								'$.usageMonth', ?,
+								'$.usageBytes', ?,
+								'$.usageDurationMs', ?
+							),
+							'$.usageEffectRetryAt'
+						),
+						usage_effect_recorded_at = ?,
+						usage_month = ?,
+						usage_bytes = ?,
+						usage_duration_ms = ?,
+						needs_effect_reconcile = CASE
+							WHEN json_extract(
+								detail_json,
+								'$.subscriptionEffectState'
+							) IN ('complete', 'dead-letter')
+							THEN 0
+							ELSE 1
+						END
 					WHERE id = ?
 						AND user_id = ?
 						AND event_type = 'received'
@@ -93,6 +112,13 @@ async function recordInboundUsageEffect(input: {
 						AND (? IS NULL OR json_extract(detail_json, '$.finalizationToken') = ?)`,
 				).bind(
 					input.now.toISOString(),
+					month,
+					Math.round(input.usageBytes),
+					Math.round(input.durationMs ?? 0),
+					input.now.toISOString(),
+					month,
+					Math.round(input.usageBytes),
+					Math.round(input.durationMs ?? 0),
 					input.deliveryId,
 					input.userId,
 					input.now.toISOString(),
@@ -112,7 +138,26 @@ async function recordInboundUsageEffect(input: {
 			// best-effort metering semantics without poisoning the outbox.
 			await input.env.APP_DB.prepare(
 				`UPDATE email_delivery_events
-				SET detail_json = json_set(detail_json, '$.usageEffectRecordedAt', ?)
+				SET
+					detail_json = json_set(
+						detail_json,
+						'$.usageEffectRecordedAt', ?,
+						'$.usageMonth', ?,
+						'$.usageBytes', ?,
+						'$.usageDurationMs', ?
+					),
+					usage_effect_recorded_at = ?,
+					usage_month = ?,
+					usage_bytes = ?,
+					usage_duration_ms = ?,
+					needs_effect_reconcile = CASE
+						WHEN json_extract(
+							detail_json,
+							'$.subscriptionEffectState'
+						) IN ('complete', 'dead-letter')
+						THEN 0
+						ELSE 1
+					END
 				WHERE id = ?
 					AND user_id = ?
 					AND event_type = 'received'
@@ -122,6 +167,13 @@ async function recordInboundUsageEffect(input: {
 			)
 				.bind(
 					input.now.toISOString(),
+					month,
+					Math.round(input.usageBytes),
+					Math.round(input.durationMs ?? 0),
+					input.now.toISOString(),
+					month,
+					Math.round(input.usageBytes),
+					Math.round(input.durationMs ?? 0),
 					input.deliveryId,
 					input.userId,
 					finalizationToken,
@@ -133,10 +185,29 @@ async function recordInboundUsageEffect(input: {
 	}
 	await input.env.APP_DB.prepare(
 		`UPDATE email_delivery_events
-		SET detail_json = json_remove(
-			json_set(detail_json, '$.usageEffectRecordedAt', ?),
-			'$.usageEffectRetryAt'
-		)
+		SET
+			detail_json = json_remove(
+				json_set(
+					detail_json,
+					'$.usageEffectRecordedAt', ?,
+					'$.usageMonth', ?,
+					'$.usageBytes', ?,
+					'$.usageDurationMs', ?
+				),
+				'$.usageEffectRetryAt'
+			),
+			usage_effect_recorded_at = ?,
+			usage_month = ?,
+			usage_bytes = ?,
+			usage_duration_ms = ?,
+			needs_effect_reconcile = CASE
+				WHEN json_extract(
+					detail_json,
+					'$.subscriptionEffectState'
+				) IN ('complete', 'dead-letter')
+				THEN 0
+				ELSE 1
+			END
 		WHERE id = ?
 			AND user_id = ?
 			AND event_type = 'received'
@@ -146,6 +217,13 @@ async function recordInboundUsageEffect(input: {
 	)
 		.bind(
 			input.now.toISOString(),
+			input.usageMonth,
+			Math.round(input.usageBytes),
+			Math.round(input.durationMs ?? 0),
+			input.now.toISOString(),
+			input.usageMonth,
+			Math.round(input.usageBytes),
+			Math.round(input.durationMs ?? 0),
 			input.deliveryId,
 			input.userId,
 			finalizationToken,
@@ -200,11 +278,21 @@ async function processInboundDeliveryEffectsWithLeaseHeld(input: {
 	if (!message) {
 		await input.env.APP_DB.prepare(
 			`UPDATE email_delivery_events
-			SET detail_json = json_set(
-				detail_json,
-				'$.subscriptionEffectState', 'complete',
-				'$.subscriptionEffectMissingMessageAt', ?
-			)
+			SET
+				detail_json = json_set(
+					detail_json,
+					'$.subscriptionEffectState', 'complete',
+					'$.subscriptionEffectMissingMessageAt', ?
+				),
+				needs_effect_reconcile = CASE
+					WHEN usage_effect_recorded_at IS NOT NULL
+						OR json_extract(
+							detail_json,
+							'$.usageEffectSuppressedAt'
+						) IS NOT NULL
+					THEN 0
+					ELSE 1
+				END
 			WHERE id = ?
 				AND user_id = ?
 				AND event_type = 'received'
@@ -275,20 +363,30 @@ async function processInboundDeliveryEffectsWithLeaseHeld(input: {
 		) {
 			await input.env.APP_DB.prepare(
 				`UPDATE email_delivery_events
-				SET detail_json = json_remove(
-					json_remove(
+				SET
+					detail_json = json_remove(
 						json_remove(
-							json_set(
-								detail_json,
-								'$.subscriptionEffectState', 'complete',
-								'$.subscriptionEffectSuppressedQuarantineAt', ?
+							json_remove(
+								json_set(
+									detail_json,
+									'$.subscriptionEffectState', 'complete',
+									'$.subscriptionEffectSuppressedQuarantineAt', ?
+								),
+								'$.subscriptionEffectLease'
 							),
-							'$.subscriptionEffectLease'
+							'$.subscriptionEffectLeaseAt'
 						),
-						'$.subscriptionEffectLeaseAt'
+						'$.subscriptionEffectRetryAt'
 					),
-					'$.subscriptionEffectRetryAt'
-				)
+					needs_effect_reconcile = CASE
+						WHEN usage_effect_recorded_at IS NOT NULL
+							OR json_extract(
+								detail_json,
+								'$.usageEffectSuppressedAt'
+							) IS NOT NULL
+						THEN 0
+						ELSE 1
+					END
 				WHERE id = ?
 					AND user_id = ?
 					AND json_extract(detail_json, '$.subscriptionEffectLease') = ?`,
@@ -313,16 +411,26 @@ async function processInboundDeliveryEffectsWithLeaseHeld(input: {
 		}
 		await input.env.APP_DB.prepare(
 			`UPDATE email_delivery_events
-			SET detail_json = json_remove(
-				json_remove(
+			SET
+				detail_json = json_remove(
 					json_remove(
-						json_set(detail_json, '$.subscriptionEffectState', 'complete'),
-						'$.subscriptionEffectLease'
+						json_remove(
+							json_set(detail_json, '$.subscriptionEffectState', 'complete'),
+							'$.subscriptionEffectLease'
+						),
+						'$.subscriptionEffectLeaseAt'
 					),
-					'$.subscriptionEffectLeaseAt'
+					'$.subscriptionEffectRetryAt'
 				),
-				'$.subscriptionEffectRetryAt'
-			)
+				needs_effect_reconcile = CASE
+					WHEN usage_effect_recorded_at IS NOT NULL
+						OR json_extract(
+							detail_json,
+							'$.usageEffectSuppressedAt'
+						) IS NOT NULL
+					THEN 0
+					ELSE 1
+				END
 			WHERE id = ?
 				AND user_id = ?
 				AND json_extract(detail_json, '$.subscriptionEffectLease') = ?`,
@@ -338,20 +446,33 @@ async function processInboundDeliveryEffectsWithLeaseHeld(input: {
 		const deadLettered = failure.deadLettered
 		await input.env.APP_DB.prepare(
 			`UPDATE email_delivery_events
-			SET detail_json = json_remove(
-				json_remove(
-					json_set(
-						detail_json,
-						'$.subscriptionEffectState', ?,
-						'$.subscriptionEffectRetryAt', ?,
-						'$.subscriptionEffectAttemptCount', ?,
-						'$.subscriptionEffectLastError', ?,
-						'$.subscriptionEffectDeadLetterAt', ?
+			SET
+				detail_json = json_remove(
+					json_remove(
+						json_set(
+							detail_json,
+							'$.subscriptionEffectState', ?,
+							'$.subscriptionEffectRetryAt', ?,
+							'$.subscriptionEffectAttemptCount', ?,
+							'$.subscriptionEffectLastError', ?,
+							'$.subscriptionEffectDeadLetterAt', ?
+						),
+						'$.subscriptionEffectLease'
 					),
-					'$.subscriptionEffectLease'
+					'$.subscriptionEffectLeaseAt'
 				),
-				'$.subscriptionEffectLeaseAt'
-			)
+				needs_effect_reconcile = CASE
+					WHEN ?
+						AND (
+							usage_effect_recorded_at IS NOT NULL
+							OR json_extract(
+								detail_json,
+								'$.usageEffectSuppressedAt'
+							) IS NOT NULL
+						)
+					THEN 0
+					ELSE 1
+				END
 			WHERE id = ?
 				AND user_id = ?
 				AND json_extract(detail_json, '$.subscriptionEffectLease') = ?`,
@@ -364,6 +485,7 @@ async function processInboundDeliveryEffectsWithLeaseHeld(input: {
 				nextAttempt,
 				error instanceof Error ? error.message : String(error),
 				deadLettered ? now.toISOString() : null,
+				deadLettered,
 				delivery.deliveryId,
 				input.userId,
 				effectLease,
@@ -411,6 +533,7 @@ export async function reconcileInboundDeliveryEffectsForUser(input: {
 		WHERE user_id = ?
 			AND provider = 'cloudflare-email-routing'
 			AND event_type = 'received'
+			AND needs_effect_reconcile = 1
 			AND json_extract(detail_json, '$.fingerprint') IS NOT NULL
 			AND (
 				(

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -2657,13 +2657,22 @@ test('scheduled sweep cleans quiet-user orphans and recovers partial commits', a
 	const effects = await env.APP_DB.prepare(
 		`SELECT
 			json_extract(detail_json, '$.usageEffectRecordedAt') AS usage_at,
-			json_extract(detail_json, '$.subscriptionEffectState') AS subscription_state
+			json_extract(detail_json, '$.subscriptionEffectState') AS subscription_state,
+			needs_effect_reconcile,
+			usage_effect_recorded_at
 		FROM email_delivery_events WHERE id = ? AND user_id = ?`,
 	)
 		.bind(partial.deliveryId, partial.userId)
-		.first<{ usage_at: string; subscription_state: string }>()
+		.first<{
+			usage_at: string
+			subscription_state: string
+			needs_effect_reconcile: number
+			usage_effect_recorded_at: string
+		}>()
 	expect(effects?.usage_at).toEqual(expect.any(String))
 	expect(effects?.subscription_state).toBe('complete')
+	expect(effects?.needs_effect_reconcile).toBe(0)
+	expect(effects?.usage_effect_recorded_at).toBe(effects?.usage_at)
 	expect(
 		await sweepStaleInboundDeliveries({
 			env: createInboundEnv(),

--- a/packages/worker/src/email/reconcile-inbound-deliveries.ts
+++ b/packages/worker/src/email/reconcile-inbound-deliveries.ts
@@ -70,6 +70,7 @@ export async function sweepStaleInboundDeliveries(input: {
 				FROM email_delivery_events
 				WHERE provider = 'cloudflare-email-routing'
 					AND event_type = 'received'
+					AND needs_effect_reconcile = 1
 					AND json_extract(detail_json, '$.fingerprint') IS NOT NULL
 					AND (
 						(

--- a/packages/worker/src/email/test-schema.ts
+++ b/packages/worker/src/email/test-schema.ts
@@ -146,8 +146,25 @@ ON email_sender_rules(user_id, kind, value);`,
 	provider_message_id TEXT,
 	provider_event_id TEXT,
 	detail_json TEXT NOT NULL DEFAULT '{}',
+	needs_effect_reconcile INTEGER NOT NULL DEFAULT 1 CHECK (
+		needs_effect_reconcile IN (0, 1)
+	),
+	usage_effect_recorded_at TEXT,
+	usage_month TEXT,
+	usage_bytes INTEGER,
+	usage_duration_ms INTEGER,
 	created_at TEXT NOT NULL
 );`,
+		`CREATE INDEX IF NOT EXISTS idx_email_delivery_events_pending_effects
+ON email_delivery_events(user_id, created_at)
+WHERE provider = 'cloudflare-email-routing'
+	AND event_type = 'received'
+	AND needs_effect_reconcile = 1;`,
+		`CREATE INDEX IF NOT EXISTS idx_email_delivery_events_recorded_usage_month
+ON email_delivery_events(usage_month, user_id)
+WHERE provider = 'cloudflare-email-routing'
+	AND event_type = 'received'
+	AND usage_effect_recorded_at IS NOT NULL;`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_email_messages_provider_message_id
 ON email_messages(provider_message_id)
 WHERE direction = 'outbound'

--- a/packages/worker/src/usage/aggregate-rollups.node.test.ts
+++ b/packages/worker/src/usage/aggregate-rollups.node.test.ts
@@ -363,8 +363,11 @@ test('aggregateUsageRollups merges current and previous Analytics months with du
 	)
 	expect(query).toContain('GROUP BY blob1, blob2')
 	expect(selects[0]?.sql).not.toContain('JOIN email_messages')
-	expect(selects[0]?.sql).toContain(`'$.usageMonth'`)
-	expect(selects[0]?.sql).toContain(`'$.usageBytes'`)
+	expect(selects[0]?.sql).not.toContain('json_extract')
+	expect(selects[0]?.sql).toContain(
+		'event.usage_effect_recorded_at IS NOT NULL',
+	)
+	expect(selects[0]?.sql).toContain('event.usage_month IN (?, ?)')
 	expect(selects[0]?.params).toEqual(['2026-07', '2026-06'])
 
 	expect(batches).toHaveLength(1)

--- a/packages/worker/src/usage/aggregate-rollups.ts
+++ b/packages/worker/src/usage/aggregate-rollups.ts
@@ -296,6 +296,7 @@ export async function readIdempotentInboundEmailUsage(input: {
 						usage_effect_recorded_at IS NULL
 						OR usage_month IS NULL
 						OR usage_bytes IS NULL
+						OR usage_duration_ms IS NULL
 					)
 					AND (
 						(

--- a/packages/worker/src/usage/aggregate-rollups.ts
+++ b/packages/worker/src/usage/aggregate-rollups.ts
@@ -186,9 +186,38 @@ export async function readIdempotentInboundEmailUsage(input: {
 		input.db
 			.prepare(
 				`UPDATE email_delivery_events
-				SET detail_json = json_set(
-					detail_json,
-					'$.usageMonth', COALESCE(
+				SET
+					detail_json = json_set(
+						detail_json,
+						'$.usageMonth', COALESCE(
+							json_extract(detail_json, '$.usageMonth'),
+							(
+								SELECT substr(
+									COALESCE(message.received_at, message.created_at),
+									1,
+									7
+								)
+								FROM email_messages message
+								WHERE message.id = email_delivery_events.message_id
+									AND message.user_id = email_delivery_events.user_id
+							)
+						),
+						'$.usageBytes', COALESCE(
+							json_extract(detail_json, '$.usageBytes'),
+							(
+								SELECT COALESCE(message.raw_size, 0)
+								FROM email_messages message
+								WHERE message.id = email_delivery_events.message_id
+									AND message.user_id = email_delivery_events.user_id
+							)
+						)
+					),
+					usage_effect_recorded_at = COALESCE(
+						usage_effect_recorded_at,
+						json_extract(detail_json, '$.usageEffectRecordedAt')
+					),
+					usage_month = COALESCE(
+						usage_month,
 						json_extract(detail_json, '$.usageMonth'),
 						(
 							SELECT substr(
@@ -201,7 +230,8 @@ export async function readIdempotentInboundEmailUsage(input: {
 								AND message.user_id = email_delivery_events.user_id
 						)
 					),
-					'$.usageBytes', COALESCE(
+					usage_bytes = COALESCE(
+						usage_bytes,
 						json_extract(detail_json, '$.usageBytes'),
 						(
 							SELECT COALESCE(message.raw_size, 0)
@@ -209,10 +239,47 @@ export async function readIdempotentInboundEmailUsage(input: {
 							WHERE message.id = email_delivery_events.message_id
 								AND message.user_id = email_delivery_events.user_id
 						)
-					)
-				)
+					),
+					usage_duration_ms = COALESCE(
+						usage_duration_ms,
+						json_extract(detail_json, '$.usageDurationMs'),
+						0
+					),
+					needs_effect_reconcile = CASE
+						WHEN json_extract(
+							detail_json,
+							'$.subscriptionEffectState'
+						) IN ('complete', 'dead-letter')
+							AND COALESCE(
+								usage_month,
+								json_extract(detail_json, '$.usageMonth'),
+								(
+									SELECT substr(
+										COALESCE(message.received_at, message.created_at),
+										1,
+										7
+									)
+									FROM email_messages message
+									WHERE message.id = email_delivery_events.message_id
+										AND message.user_id = email_delivery_events.user_id
+								)
+							) IS NOT NULL
+							AND COALESCE(
+								usage_bytes,
+								json_extract(detail_json, '$.usageBytes'),
+								(
+									SELECT COALESCE(message.raw_size, 0)
+									FROM email_messages message
+									WHERE message.id = email_delivery_events.message_id
+										AND message.user_id = email_delivery_events.user_id
+								)
+							) IS NOT NULL
+						THEN 0
+						ELSE 1
+					END
 				WHERE provider = 'cloudflare-email-routing'
 					AND event_type = 'received'
+					AND needs_effect_reconcile = 1
 					AND (
 						email_delivery_events.user_id = 'system:email'
 						OR EXISTS (
@@ -226,13 +293,20 @@ export async function readIdempotentInboundEmailUsage(input: {
 						'$.usageEffectRecordedAt'
 					) IS NOT NULL
 					AND (
-						json_extract(detail_json, '$.usageMonth') IS NULL
-						OR json_extract(detail_json, '$.usageBytes') IS NULL
+						usage_effect_recorded_at IS NULL
+						OR usage_month IS NULL
+						OR usage_bytes IS NULL
 					)
-					AND EXISTS (
-						SELECT 1 FROM email_messages message
-						WHERE message.id = email_delivery_events.message_id
-							AND message.user_id = email_delivery_events.user_id
+					AND (
+						(
+							json_extract(detail_json, '$.usageMonth') IS NOT NULL
+							AND json_extract(detail_json, '$.usageBytes') IS NOT NULL
+						)
+						OR EXISTS (
+							SELECT 1 FROM email_messages message
+							WHERE message.id = email_delivery_events.message_id
+								AND message.user_id = email_delivery_events.user_id
+						)
 					)`,
 			)
 			.bind()
@@ -244,16 +318,16 @@ export async function readIdempotentInboundEmailUsage(input: {
 				`SELECT
 					event.user_id,
 					'email_received' AS metric,
-					json_extract(event.detail_json, '$.usageMonth') AS month,
+					event.usage_month AS month,
 					COUNT(*) AS event_count,
 					0 AS error_count,
 					SUM(COALESCE(
-						json_extract(event.detail_json, '$.usageDurationMs'),
+						event.usage_duration_ms,
 						0
 					)) AS total_duration_ms,
 					0 AS total_cpu_ms,
 					SUM(COALESCE(
-						json_extract(event.detail_json, '$.usageBytes'),
+						event.usage_bytes,
 						0
 					)) AS total_bytes
 				FROM email_delivery_events event
@@ -267,14 +341,8 @@ export async function readIdempotentInboundEmailUsage(input: {
 								AND deleting_at IS NULL
 						)
 					)
-					AND json_extract(
-						event.detail_json,
-						'$.usageEffectRecordedAt'
-					) IS NOT NULL
-					AND json_extract(
-						event.detail_json,
-						'$.usageMonth'
-					) IN (?, ?)
+					AND event.usage_effect_recorded_at IS NOT NULL
+					AND event.usage_month IN (?, ?)
 				GROUP BY event.user_id, month`,
 			)
 			.bind(...input.months)

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -506,7 +506,7 @@
 		},
 		{
 			"filename": "0123-inbound-delivery-effect-indexes.sql",
-			"sha256": "ddd8b7f7c8b4ee760d2ca6b0a1116724b286ac0c57277e976b5ef578fd9f61d2"
+			"sha256": "eb972cefd3ebf6c692b75600c27a68df9c401e113700bb9b1d4e0a62ea31bc13"
 		}
 	]
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -503,6 +503,10 @@
 		{
 			"filename": "0122-user-d1-storage-bytes.sql",
 			"sha256": "1fd69b59afdee9db70dacc043c326ec00aaa5825ce57865168e8977f3064004d"
+		},
+		{
+			"filename": "0123-inbound-delivery-effect-indexes.sql",
+			"sha256": "ddd8b7f7c8b4ee760d2ca6b0a1116724b286ac0c57277e976b5ef578fd9f61d2"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #1069

## Summary

- add indexed effect-reconciliation state and scalar durable usage fields to inbound delivery events
- backfill retained events in migration `0123` and keep fields synchronized on receive/effect completion
- bound reconciliation and usage hydration to pending rows, and read rollup months through an indexed scalar path
- prove the indexed due set matches the legacy JSON predicate and both query plans use the new partial indexes

## Verification

- `npm run validate` passed after the final review fixes and latest-main rebase
- pre-push: 498 test files / 1712 tests passed
- migration tests prove legacy-vs-indexed due-set equivalence and verify both partial indexes with `EXPLAIN QUERY PLAN`
- [CI Validate](https://github.com/kentcdodds/kody/actions/runs/30607378903/job/91082998254) and preview migration/deployment passed
- [production deployment](https://github.com/kentcdodds/kody/actions/runs/30607955011) passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8da7861` · **Head:** `3540d0a`

**Classification:** extends — changes the persisted inbound-event shape and the scheduled reconciliation/usage query paths without adding a new system primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `email` | assistant | extends — maintains indexed effect and usage state with the JSON delivery ledger |
| `d1-app-db` | storage | extends — migration `0123` adds/backfills scalar columns and partial indexes |
| `scheduled-cron` | surfaces | extends — stale delivery discovery scans only indexed pending events |
| `usage-metering` | storage | extends — durable inbound usage reads indexed month fields instead of JSON |

### System map

Inbound receipt persists pending effect state in D1; scheduled reconciliation and usage aggregation consume separate partial indexes over that state.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	email["email<br/>Email"]:::extended
	cron["scheduled-cron<br/>Scheduled handler"]:::extended
	usage["usage-metering<br/>Usage metering"]:::extended
	db["d1-app-db<br/>D1 app database"]:::extended
	email -->|"needs_effect_reconcile + scalar usage writes"| db
	cron -->|"partial pending-effects index"| db
	usage -->|"recorded usage-month partial index"| db
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Five-minute sweep scans all retained received-event JSON | Sweep scans only `needs_effect_reconcile = 1` partial-index entries, then applies the same due predicate |
| Hourly usage hydration/aggregation discovers fields through JSON | Hydration is pending-index bounded; aggregation seeks indexed scalar `usage_month` rows |

### Invariants

- Every reconciliation read and write remains scoped by `user_id`; global discovery returns owner IDs before per-user processing.
- JSON delivery details remain synchronized for compatibility while indexed columns drive cron discovery.

</details>

<!-- system-recap:end -->

## Conductor report

- Status: merged via squash as `5385ffba` and deployed successfully to production.
- What I verified: full `npm run validate`, all node/workers unit tests, legacy-vs-indexed due-set equivalence, partial-index query plans, recovered-effect flag cleanup, legacy usage hydration, clean preview migration/deploy, and the production deploy.
- Scope spill: `tools/migration-ledger.json` updated as required; `inbound-effects.ts` and `inbound.workers.test.ts` were touched only to maintain and verify the new flag. No sibling-owned implementation files changed.
- Kent decisions: none.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1854f80e-db13-4984-abb5-7c25ea1ef6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1854f80e-db13-4984-abb5-7c25ea1ef6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved inbound email usage tracking with normalized usage details, including month, bytes, and duration.
  * Added more reliable reconciliation of email delivery effects and usage records.
* **Performance**
  * Optimized pending-effect reconciliation and usage aggregation queries.
* **Bug Fixes**
  * Preserved and restored usage data during reconciliation, including records derived from related messages.
  * Improved handling of completed, failed, quarantined, and missing-message delivery states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->