### PR TITLE
Fail closed for production package app origin isolation

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -398,9 +398,11 @@ app origin has no code path that reads it, and the package-app origin has no
 first-party routes. Every request re-resolves the account from D1
 (`resolvePackageAppOwnerByStableUserId`) and fails closed for unknown, deleting,
 or suspended accounts, and for sessions issued at or before
-`users.password_changed_at` — the same rules browser sessions follow.
-Deployments with `PACKAGE_APP_BASE_URL` unset never mint either credential; they
-serve package apps inline behind `kody_session`.
+`users.password_changed_at` — the same rules browser sessions follow. Confirmed
+local, preview, and test runtimes with `PACKAGE_APP_BASE_URL` unset never mint
+either credential; they serve package apps inline behind `kody_session`.
+Production requires a separate registrable package-app origin and returns `500`
+instead of falling back inline when that configuration is missing or unsafe.
 
 ## Account secret reveal
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -26,8 +26,7 @@ is only the fallback for background work with no request URL.
 
 Requests are handled in this order:
 
-0. Package-app host isolation (before everything else, when
-   `PACKAGE_APP_BASE_URL` is set — see
+0. Package-app host isolation (before everything else — see
    [Hosted package app origin isolation](../security.md#hosted-package-app-origin-isolation)):
    - On the **package-app origin**, only `/@{username}/packages/*` is served
      (plus the handoff-token exchange on those same paths). `/` redirects to the
@@ -35,7 +34,10 @@ Requests are handled in this order:
    - On the **app origin**, `/@{username}/packages/*` never executes package
      code: safe methods redirect to the package-app origin with a handoff token,
      other methods get a `307` to the same path there.
-   - When `PACKAGE_APP_BASE_URL` is unset (local dev, preview, tests) this step
+   - Production package-app requests fail with `500` when `PACKAGE_APP_BASE_URL`
+     is missing or is not on a separate registrable domain from `APP_BASE_URL`;
+     package code never executes inline.
+   - In confirmed local, preview, and test runtimes, an unset package-app origin
      is a no-op and package apps are served inline at step 9 below.
 1. Protected resource metadata (base path only, before `OAuthProvider`):
    - `/.well-known/oauth-protected-resource` (`GET` / `HEAD` / `OPTIONS`)
@@ -71,7 +73,8 @@ Requests are handled in this order:
      (they do not enter this Worker list). That includes OpenAI Apps domain
      verification at `/.well-known/openai-apps-challenge`.
 9. Hosted package apps served inline on the app origin
-   (`/@{username}/packages/*`), only when `PACKAGE_APP_BASE_URL` is unset.
+   (`/@{username}/packages/*`), only in confirmed non-production runtimes when
+   `PACKAGE_APP_BASE_URL` is unset.
 10. App server routes:
     - Everything else is handled by `packages/worker/src/app/handler.ts`
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -83,8 +83,8 @@ Optional Wrangler `var` (public, non-secret; see
 
 ## Hosted package app origin
 
-Optional Wrangler `var` (public, non-secret; see
-`packages/worker/src/app-base-url.ts` and
+Wrangler `var` (public and non-secret; required in production, optional in
+confirmed non-production runtimes; see `packages/worker/src/app-base-url.ts` and
 `packages/worker/src/app/package-app-origin.ts`):
 
 - `PACKAGE_APP_BASE_URL` — the origin that hosted package apps are served from.
@@ -94,8 +94,12 @@ Optional Wrangler `var` (public, non-secret; see
   [setup-manifest.md](./setup-manifest.md)). It **must be a separate registrable
   domain** from `APP_BASE_URL`: that is what makes author-supplied package code
   cross-site, so the `SameSite=Lax` `kody_session` cookie never reaches it.
-  Preview, tests, and E2E leave it unset and keep serving package apps inline on
-  the app origin at `/@{username}/packages/*`.
+  Production origin validation also requires `APP_BASE_URL` so this relationship
+  can be checked at runtime. Production returns `500` for package-app requests
+  when this value is missing, invalid, equal to `APP_BASE_URL`, or on the same
+  registrable domain; it never falls back to inline serving. Preview, tests, and
+  E2E may leave it unset and keep serving package apps inline on the app origin
+  at `/@{username}/packages/*`.
 
   `npm run dev` runs the **production** Wrangler environment, so the committed
   production value reaches local dev too; `getPackageAppBaseUrl` ignores an

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -151,13 +151,15 @@ in the Worker `fetch` handler:
   terminates in a `403` that links back to the app origin, so a browser that
   refuses the cookie fails visibly instead of ping-ponging between hosts.
 
-When no package-app origin resolves — preview, tests, E2E, and `npm run dev`,
-which ignores an origin a local server cannot answer on — package apps keep
-being served inline on the app origin by `handlePackageAppRequest`. That path is
-still credential-stripped, but it is same-origin, so **do not treat a local run
-as representative of the production isolation boundary**. To exercise the
-two-origin flow locally, set
-`PACKAGE_APP_BASE_URL=http://packages.localhost:<port>` in
+Production fails closed with `500` before executing package code when
+`PACKAGE_APP_BASE_URL` is missing, invalid, equal to `APP_BASE_URL`, or on the
+same registrable domain. There is no production inline fallback.
+
+Preview, tests, E2E, and `npm run dev` may keep serving package apps inline when
+no package-app origin resolves. That path is still credential-stripped, but it
+is same-origin, so **do not treat a non-production inline run as representative
+of the production isolation boundary**. To exercise the two-origin flow locally,
+set `PACKAGE_APP_BASE_URL=http://packages.localhost:<port>` in
 `packages/worker/.env`.
 
 The cross-site handoff (how the owner is recognized on the package-app origin

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -98,9 +98,10 @@ This project uses the following resources:
     origin so author-supplied package code is cross-site. Do not point it at a
     subdomain of the app origin, and do not host anything first-party on it. See
     [Hosted package app origin isolation](./security.md#hosted-package-app-origin-isolation).
-  - Forks that do not register a second domain simply leave
-    `PACKAGE_APP_BASE_URL` unset; package apps then serve inline on the app
-    origin, which is weaker isolation.
+  - Production forks must register a second domain and set
+    `PACKAGE_APP_BASE_URL`; package-app requests return `500` when it is missing
+    or not on a separate registrable domain. Confirmed local, preview, and test
+    runtimes may leave it unset and use inline serving.
 - Workers Observability OTLP destination (account-level)
   - Workers automatic tracing is enabled via `observability.traces` in
     `packages/worker/wrangler.jsonc`; traces are viewable in the Workers
@@ -242,12 +243,12 @@ automatically:
   Most request-scoped app/MCP URLs use the inbound request origin so OAuth
   metadata matches the host the client connected to. Password reset email sends
   require this value and use `kody@<hostname>` as the sender.)
-- `PACKAGE_APP_BASE_URL` (optional Wrangler `var`; origin for hosted package
-  apps. Production sets `https://kodyapps.dev` in
-  `packages/worker/wrangler.jsonc`, and the deploy attaches that host as a
-  Workers custom domain from the generated config (see the Cloudflare resources
-  list above). Must be a **separate registrable domain** from `APP_BASE_URL` —
-  see
+- `PACKAGE_APP_BASE_URL` (Wrangler `var`; required in production and optional
+  for confirmed local/preview/test runtimes; origin for hosted package apps.
+  Production sets `https://kodyapps.dev` in `packages/worker/wrangler.jsonc`,
+  and the deploy attaches that host as a Workers custom domain from the
+  generated config (see the Cloudflare resources list above). Must be a
+  **separate registrable domain** from `APP_BASE_URL` — see
   [Hosted package app origin isolation](./security.md#hosted-package-app-origin-isolation).
   Local dev ignores any value it cannot serve itself, and preview/test leave it
   unset, so those keep serving package apps inline on the app origin. Point it

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -353,6 +353,12 @@ A package app is optional.
 When `package.json#kody.app` is present, the package is hosted under the package
 app route.
 
+Production-hosted package apps run on Kody's separate `kodyapps.dev` origin, not
+on the signed-in app origin. Opening an app from Kody performs a short-lived
+session handoff to that origin. Package author JavaScript cannot use the
+first-party `kody_session` cookie or call authenticated Kody pages as the
+signed-in user.
+
 Use the package app model when the package needs:
 
 - interactive UI

--- a/packages/worker/src/app-base-url.node.test.ts
+++ b/packages/worker/src/app-base-url.node.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { getAppBaseUrl, getPackageAppBaseUrl } from './app-base-url.ts'
+import {
+	getAppBaseUrl,
+	getPackageAppBaseUrl,
+	getPackageAppOriginConfigurationError,
+} from './app-base-url.ts'
 
 test('getAppBaseUrl prefers the request origin when present', () => {
 	expect(
@@ -95,4 +99,41 @@ test('the package-app origin is configurable and never resolves as the app origi
 	expect(
 		getAppBaseUrl({ env, requestUrl: 'https://heykody.dev/@me/packages/x' }),
 	).toBe('https://heykody.dev')
+})
+
+test('production package-app origin configuration requires a separate registrable domain', () => {
+	expect(
+		getPackageAppOriginConfigurationError({
+			APP_BASE_URL: 'https://heykody.dev',
+			SENTRY_ENVIRONMENT: 'preview',
+		}),
+	).toBeNull()
+
+	expect(
+		getPackageAppOriginConfigurationError({
+			APP_BASE_URL: 'https://heykody.dev',
+			SENTRY_ENVIRONMENT: 'production',
+		}),
+	).toContain('requires PACKAGE_APP_BASE_URL')
+
+	for (const packageAppBaseUrl of [
+		'https://heykody.dev',
+		'https://apps.heykody.dev',
+	]) {
+		expect(
+			getPackageAppOriginConfigurationError({
+				APP_BASE_URL: 'https://heykody.dev',
+				PACKAGE_APP_BASE_URL: packageAppBaseUrl,
+				SENTRY_ENVIRONMENT: 'production',
+			}),
+		).toContain('separate registrable domain')
+	}
+
+	expect(
+		getPackageAppOriginConfigurationError({
+			APP_BASE_URL: 'https://heykody.dev',
+			PACKAGE_APP_BASE_URL: 'https://kodyapps.dev',
+			SENTRY_ENVIRONMENT: 'production',
+		}),
+	).toBeNull()
 })

--- a/packages/worker/src/app-base-url.ts
+++ b/packages/worker/src/app-base-url.ts
@@ -1,3 +1,6 @@
+import { getDomain } from 'tldts'
+import { isNonProductionRuntime } from '#app/deployment-env.ts'
+
 const DEFAULT_APP_BASE_URL = 'https://heykody.dev'
 
 type PackageAppBaseUrlEnv = {
@@ -7,6 +10,10 @@ type PackageAppBaseUrlEnv = {
 
 type AppBaseUrlEnv = PackageAppBaseUrlEnv & {
 	APP_BASE_URL?: string | null
+}
+
+export type PackageAppOriginEnv = AppBaseUrlEnv & {
+	SENTRY_ENVIRONMENT?: string | undefined
 }
 
 function isLocallyServableHostname(hostname: string) {
@@ -20,12 +27,12 @@ function isLocallyServableHostname(hostname: string) {
 
 /**
  * Resolve the origin hosted package apps are served from, or `null` when the
- * deployment serves them inline on the app origin.
+ * a non-production deployment serves them inline on the app origin.
  *
- * Production sets `PACKAGE_APP_BASE_URL` to a separate registrable domain so
+ * Production must set `PACKAGE_APP_BASE_URL` to a separate registrable domain so
  * author-supplied package code is cross-site from the first-party app origin
  * and can never receive the owner's `kody_session` cookie. Preview, tests, and
- * E2E leave it unset and keep the path-based same-origin behavior.
+ * E2E may leave it unset and keep the path-based same-origin behavior.
  *
  * `npm run dev` runs against the **production** Wrangler environment, so the
  * committed production value reaches local dev too. A local server cannot serve
@@ -54,6 +61,47 @@ export function getPackageAppBaseUrl(input: { env: PackageAppBaseUrlEnv }) {
 		// same-origin behavior instead of routing to a bogus host.
 		return null
 	}
+}
+
+function getRegistrableDomain(url: URL) {
+	return getDomain(url.hostname) ?? url.hostname.toLowerCase()
+}
+
+/**
+ * Return a clear production configuration failure instead of allowing package
+ * apps to fall back to the first-party origin.
+ */
+export function getPackageAppOriginConfigurationError(
+	env: PackageAppOriginEnv,
+) {
+	if (isNonProductionRuntime(env)) return null
+
+	const packageAppOrigin = getPackageAppBaseUrl({ env })
+	if (!packageAppOrigin) {
+		return 'Production requires PACKAGE_APP_BASE_URL to be set to a valid, separate registrable origin.'
+	}
+
+	const configuredAppBaseUrl = env.APP_BASE_URL?.trim()
+	if (!configuredAppBaseUrl) {
+		return 'Production requires APP_BASE_URL when hosted package apps are enabled.'
+	}
+
+	let appOrigin: string
+	try {
+		appOrigin = new URL(configuredAppBaseUrl).origin
+	} catch {
+		return 'Production requires APP_BASE_URL to be a valid origin when hosted package apps are enabled.'
+	}
+	const packageAppUrl = new URL(packageAppOrigin)
+	const appUrl = new URL(appOrigin)
+	if (
+		packageAppUrl.origin === appUrl.origin ||
+		getRegistrableDomain(packageAppUrl) === getRegistrableDomain(appUrl)
+	) {
+		return 'Production requires PACKAGE_APP_BASE_URL to use a separate registrable domain from APP_BASE_URL.'
+	}
+
+	return null
 }
 
 /**

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -104,6 +104,7 @@ vi.mock('#worker/package-runtime/realtime-session.ts', () => ({
 }))
 
 const { handlePackageAppRequest } = await import('./package-app.ts')
+const nonProductionEnv = { SENTRY_ENVIRONMENT: 'test' } as Env
 
 function resetMocks() {
 	vi.clearAllMocks()
@@ -117,7 +118,7 @@ test('handlePackageAppRequest reports host setup failures with helpful responses
 		new Request(
 			'https://example.com/@test-user/packages/example/report?tab=errors',
 		),
-		{} as Env,
+		nonProductionEnv,
 	)
 
 	expect(response.status).toBe(500)
@@ -170,7 +171,7 @@ test('handlePackageAppRequest reports host setup failures with helpful responses
 		new Request('https://example.com/@test-user/packages/example/api/data', {
 			headers: { accept: 'application/json' },
 		}),
-		{} as Env,
+		nonProductionEnv,
 	)
 
 	expect(apiResponse.status).toBe(500)
@@ -222,7 +223,7 @@ test('handlePackageAppRequest does not report package entrypoint failures to Kod
 
 	const response = await handlePackageAppRequest(
 		new Request('https://example.com/@test-user/packages/example'),
-		{} as Env,
+		nonProductionEnv,
 	)
 
 	expect(response.status).toBe(500)
@@ -251,7 +252,7 @@ test('handlePackageAppRequest routes websocket package paths to realtime session
 		},
 	)
 
-	const response = await handlePackageAppRequest(request, {} as Env)
+	const response = await handlePackageAppRequest(request, nonProductionEnv)
 
 	expect(response.status).toBe(200)
 	expect(mockModule.packageRealtimeConnect).toHaveBeenCalledTimes(1)
@@ -307,7 +308,7 @@ test('handlePackageAppRequest forwards package code a request stripped of owner 
 			},
 			body: JSON.stringify({ note: 'hello' }),
 		}),
-		{} as Env,
+		nonProductionEnv,
 	)
 
 	expect(response.status).toBe(200)
@@ -331,7 +332,7 @@ test('handlePackageAppRequest returns not found when the URL username does not m
 
 	const response = await handlePackageAppRequest(
 		new Request('https://example.com/@other-user/packages/example'),
-		{} as Env,
+		nonProductionEnv,
 	)
 
 	expect(response.status).toBe(404)

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -3,10 +3,7 @@ import { html } from 'remix/html-template'
 import { createHtmlResponse } from 'remix/response/html'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { redirectToLoginWhenUnauthenticated } from '#app/auth-redirect.ts'
-import {
-	getAppBaseUrl,
-	getPackageAppOriginConfigurationError,
-} from '#worker/app-base-url.ts'
+import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { type PackageAppOwner } from '#app/package-app-owner.ts'
 import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
@@ -437,11 +434,8 @@ export async function servePackageAppRequest(input: {
  */
 export async function handlePackageAppRequest(request: Request, env: Env) {
 	if (!isNonProductionRuntime(env)) {
-		const configurationError =
-			getPackageAppOriginConfigurationError(env) ??
-			'Inline package-app serving is disabled in production.'
 		return new Response(
-			`Hosted package apps are unavailable. ${configurationError}`,
+			'Hosted package apps are unavailable. Inline package-app serving is disabled in production.',
 			{
 				status: 500,
 				headers: {

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -3,7 +3,11 @@ import { html } from 'remix/html-template'
 import { createHtmlResponse } from 'remix/response/html'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { redirectToLoginWhenUnauthenticated } from '#app/auth-redirect.ts'
-import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import {
+	getAppBaseUrl,
+	getPackageAppOriginConfigurationError,
+} from '#worker/app-base-url.ts'
+import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { type PackageAppOwner } from '#app/package-app-owner.ts'
 import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
 import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
@@ -49,8 +53,8 @@ export type PackageAppPath = NonNullable<ReturnType<typeof parsePackageAppPath>>
 // Credentials that must never reach author-supplied package code. `Cookie`
 // carries the owner's `kody_session`, `Authorization` carries MCP bearer tokens,
 // and the `X-Kody-*` family is worker-internal auth (connector session keys and
-// user ids). Stripping is unconditional: it is required when package apps share
-// the app origin and harmless when they are served cross-site.
+// user ids). Stripping is unconditional as defense in depth and is also required
+// for the non-production inline serving path.
 const strippedPackageRequestHeaders = [
 	'cookie',
 	'authorization',
@@ -277,10 +281,9 @@ function createPackageAppErrorResponse(input: {
 /**
  * Serve a hosted package app for an already-authenticated owner.
  *
- * The owner is resolved by the caller because the two hosting modes authenticate
- * differently: inline (same-origin) mode uses the `kody_session` cookie, and the
- * package-app origin uses its own host-scoped `kody_pkg_session` cookie (see
- * `packages/worker/src/app/package-app-origin.ts`).
+ * The owner is resolved by the caller because the package-app origin uses its
+ * own host-scoped `kody_pkg_session` cookie, while the non-production inline
+ * mode uses the `kody_session` cookie (see `package-app-origin.ts`).
  */
 export async function servePackageAppRequest(input: {
 	request: Request
@@ -433,6 +436,22 @@ export async function servePackageAppRequest(input: {
  * is never reached — see `packages/worker/src/app/package-app-origin.ts`.
  */
 export async function handlePackageAppRequest(request: Request, env: Env) {
+	if (!isNonProductionRuntime(env)) {
+		const configurationError =
+			getPackageAppOriginConfigurationError(env) ??
+			'Inline package-app serving is disabled in production.'
+		return new Response(
+			`Hosted package apps are unavailable. ${configurationError}`,
+			{
+				status: 500,
+				headers: {
+					'Cache-Control': 'no-store',
+					'Content-Type': 'text/plain; charset=utf-8',
+				},
+			},
+		)
+	}
+
 	const requestUrl = new URL(request.url)
 	const packagePath = parsePackageAppPath(requestUrl.pathname)
 	if (!packagePath) {

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -1,6 +1,10 @@
 import { html } from 'remix/html-template'
 import { createHtmlResponse } from 'remix/response/html'
-import { getAppBaseUrl, getPackageAppBaseUrl } from '#worker/app-base-url.ts'
+import {
+	getAppBaseUrl,
+	getPackageAppBaseUrl,
+	getPackageAppOriginConfigurationError,
+} from '#worker/app-base-url.ts'
 import { redirectToLoginWhenUnauthenticated } from '#app/auth-redirect.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { isSecureRequest } from '#app/auth-session.ts'
@@ -24,8 +28,8 @@ import { wantsJson } from '#worker/utils.ts'
 /**
  * Host-based isolation for hosted package apps.
  *
- * Package apps execute author-supplied HTML/JS. While they were served from the
- * app origin, that code was same-site with `kody_session`: a package page could
+ * Package apps execute author-supplied HTML/JS. If they were served from the app
+ * origin, that code would be same-site with `kody_session`: a package page could
  * call first-party endpoints with the owner's credentials, and the owner's
  * cookie was forwarded into the package worker. Serving them from a separate
  * registrable domain (`PACKAGE_APP_BASE_URL`) makes them cross-site, so the
@@ -66,6 +70,16 @@ function redirectResponse(input: {
 	})
 	if (input.setCookie) headers.append('Set-Cookie', input.setCookie)
 	return new Response(null, { status: input.status, headers })
+}
+
+function createPackageAppOriginConfigurationErrorResponse(message: string) {
+	return new Response(`Hosted package apps are unavailable. ${message}`, {
+		status: 500,
+		headers: {
+			'Cache-Control': 'no-store',
+			'Content-Type': 'text/plain; charset=utf-8',
+		},
+	})
 }
 
 /**
@@ -262,19 +276,24 @@ async function handleRequestOnPackageAppOrigin(input: {
 /**
  * Route a request according to the configured package-app origin.
  *
- * Returns `null` when the deployment has no separate package-app origin, or when
- * the request is ordinary first-party traffic on the app origin — both cases
- * fall through to the normal worker pipeline.
+ * Returns `null` when a non-production deployment has no separate package-app
+ * origin, or when the request is ordinary first-party traffic on the app origin.
+ * A production package-app request with unsafe origin configuration fails closed.
  */
 export async function handlePackageAppOriginRequest(
 	request: Request,
 	env: Env,
 ) {
+	const url = new URL(request.url)
+	const packagePath = parsePackageAppPath(url.pathname)
+	const configurationError = getPackageAppOriginConfigurationError(env)
+	if (configurationError && packagePath) {
+		return createPackageAppOriginConfigurationErrorResponse(configurationError)
+	}
+
 	const packageAppOrigin = getPackageAppBaseUrl({ env })
 	if (!packageAppOrigin) return null
 
-	const url = new URL(request.url)
-	const packagePath = parsePackageAppPath(url.pathname)
 	if (url.origin === packageAppOrigin) {
 		return await handleRequestOnPackageAppOrigin({
 			request,

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -2,7 +2,10 @@ import { env, exports } from 'cloudflare:workers'
 import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { expect, test } from 'vitest'
 import { createAuthCookie, setAuthSessionSecret } from '#app/auth-session.ts'
-import { createPackageCodeRequest } from '#app/handlers/package-app.ts'
+import {
+	createPackageCodeRequest,
+	handlePackageAppRequest,
+} from '#app/handlers/package-app.ts'
 import { packageAppHandoffQueryParam } from '#app/package-app-handoff.ts'
 import {
 	ensurePackageSubscriptionTestSchema,
@@ -14,7 +17,7 @@ import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 // Different ports on purpose: swapping origins by mutating a `URL` keeps the
 // original port, and identical ports would hide that.
 const appOrigin = 'https://app.kody.test:8788'
-const packageAppOrigin = 'https://packages.kody.test'
+const packageAppOrigin = 'https://packages.isolated.test'
 const ownerEmail = 'pkg-owner@example.com'
 const ownerUsername = 'pkg-owner'
 
@@ -22,10 +25,14 @@ const ownerUsername = 'pkg-owner'
  * The generated `Env` types pin production var literals, so origin overrides go
  * through a mutable view of the same object the worker handler receives.
  */
-function configureOrigins(input: { packageAppBaseUrl?: string }) {
+function configureOrigins(input: {
+	packageAppBaseUrl?: string
+	runtime: 'production' | 'preview'
+}) {
 	const mutableEnv = env as unknown as Record<string, string | undefined>
 	mutableEnv.APP_BASE_URL = appOrigin
 	mutableEnv.PACKAGE_APP_BASE_URL = input.packageAppBaseUrl
+	mutableEnv.SENTRY_ENVIRONMENT = input.runtime
 }
 
 async function workerFetch(
@@ -93,7 +100,10 @@ function cookieValue(setCookieHeader: string) {
 }
 
 test('hosted package apps move to the package-app origin behind a single-use handoff', async () => {
-	configureOrigins({ packageAppBaseUrl: packageAppOrigin })
+	configureOrigins({
+		packageAppBaseUrl: packageAppOrigin,
+		runtime: 'production',
+	})
 	const sessionCookie = await seedOwnerSessionCookie()
 
 	// 1. The app origin never executes package code: it mints a handoff token and
@@ -231,7 +241,7 @@ test('hosted package apps move to the package-app origin behind a single-use han
 })
 
 test('package apps stay inline on the app origin when no package-app origin is configured', async () => {
-	configureOrigins({ packageAppBaseUrl: undefined })
+	configureOrigins({ packageAppBaseUrl: undefined, runtime: 'preview' })
 	const sessionCookie = await seedOwnerSessionCookie()
 
 	const response = await workerFetch(
@@ -241,6 +251,41 @@ test('package apps stay inline on the app origin when no package-app origin is c
 	// Served inline (no cross-origin redirect); the saved package does not exist.
 	expect(response.status).toBe(404)
 	await expect(response.text()).resolves.toBe('Saved package app not found.')
+})
+
+test('production package apps fail closed when origin isolation is missing or unsafe', async () => {
+	for (const packageAppBaseUrl of [
+		undefined,
+		appOrigin,
+		'https://packages.kody.test',
+	]) {
+		configureOrigins({ packageAppBaseUrl, runtime: 'production' })
+		const response = await workerFetch(
+			`${appOrigin}/@${ownerUsername}/packages/demo`,
+		)
+
+		expect(response.status).toBe(500)
+		expect(response.headers.get('Cache-Control')).toBe('no-store')
+		expect(response.headers.get('Location')).toBeNull()
+		await expect(response.text()).resolves.toContain(
+			'Hosted package apps are unavailable.',
+		)
+	}
+
+	// Defense in depth: even a future routing regression cannot call the inline
+	// handler in production when the separate origin itself is configured safely.
+	configureOrigins({
+		packageAppBaseUrl: packageAppOrigin,
+		runtime: 'production',
+	})
+	const inlineResponse = await handlePackageAppRequest(
+		new Request(`${appOrigin}/@${ownerUsername}/packages/demo`),
+		env,
+	)
+	expect(inlineResponse.status).toBe(500)
+	await expect(inlineResponse.text()).resolves.toContain(
+		'Inline package-app serving is disabled in production.',
+	)
 })
 
 test('createPackageCodeRequest drops credential headers in the workers runtime', async () => {

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -174,10 +174,11 @@ export const EnvSchema = object({
 		'Missing MCP_CLIENT_HUB binding for user-added MCP server connections.',
 	),
 	APP_BASE_URL: optionalUrlStringSchema,
-	// Origin that hosted package apps are served from. Set in production only
-	// (a separate registrable domain) so author-supplied package code is
-	// cross-site from the app origin; unset locally/preview/test keeps the
-	// same-origin path-based behavior. See docs/contributing/security.md.
+	// Origin that hosted package apps are served from. Required in production
+	// and must use a separate registrable domain so author-supplied package code
+	// is cross-site from the app origin. It may be unset locally/preview/test,
+	// where the same-origin path-based behavior remains available.
+	// See docs/contributing/security.md.
 	PACKAGE_APP_BASE_URL: optionalUrlStringSchema,
 	USER_EMAIL_DOMAIN: optionalNonEmptyStringSchema,
 	APP_COMMIT_SHA: optionalCommitShaSchema,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -353,9 +353,9 @@ const appHandler = withCors({
 			})
 		}
 
-		// Inline (same-origin) package apps. Deployments that configure
-		// PACKAGE_APP_BASE_URL never reach this branch: handlePackageAppOriginRequest
-		// redirects these paths to the package-app origin first.
+		// Non-production inline package apps. Production requests normally redirect
+		// in handlePackageAppOriginRequest; this handler independently returns 500
+		// rather than executing package code if that routing invariant is broken.
 		if (isPackageAppRequestPath(url.pathname)) {
 			return handlePackageAppRequest(request, env)
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- refuse production package-app requests when `PACKAGE_APP_BASE_URL` is missing, invalid, or not cross-site from `APP_BASE_URL`
- retain inline serving only for positively identified local, preview, and test runtimes
- add routing and policy regressions plus document the production isolation contract

Part of #1069

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `30b51c31` · **Head:** `00dcc5ad`

**Classification:** extends — production package-app routing now enforces the existing cross-origin security boundary at runtime.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — package-app routes fail closed unless production origin isolation is safe |
| `scheduled-cron` | surfaces | composes — the shared Worker entrypoint retains its early package-app dispatch |

### System map

Package-app requests cross from the first-party app host to the isolated hosted-app origin only after runtime policy validates separate registrable domains.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	workerEntry["scheduled-cron<br/>Scheduled handler"]:::touched
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	workerEntry -->|"early package-app origin guard"| appUi
	appUi -->|"302 handoff only with cross-site configuration"| packageOrigin["Isolated package-app origin"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Missing/unsafe production package-app origin could fall through to inline execution | Production package-app routes return a no-store `500`; author JS never executes on the app origin |
| Inline route trusted routing order alone | Inline handler independently rejects every production runtime |

### Invariants

- Author-supplied package app JavaScript never executes on the first-party app origin in production.
- Production package-app and app URLs must use separate registrable domains.

</details>

<!-- system-recap:end -->

## Conductor report

- **Status:** done
- **Verified:** `npm run validate` and post-merge CI pass. Production deploy `30606232474` completed successfully; `https://heykody.dev/health` reports merge commit `ffc26e4136fc4257fd78903a1c597ee7d5c0f203`, app-origin package requests enter the isolated login/handoff flow, and `https://kodyapps.dev/` exposes only the package-app host behavior. Regression coverage proves missing, same-origin, same-site, and direct inline-handler production requests fail closed.
- **Scope spill:** documentation consistency updates in security, environment, setup, request lifecycle, authentication, and end-user package notes; no sibling-owned `index.ts` region was changed beyond the package-app routing comment.
- **Kent decision:** confirm production keeps `PACKAGE_APP_BASE_URL=https://kodyapps.dev` (separate from `APP_BASE_URL=https://heykody.dev`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-774f874f-46fc-4ed5-bf80-9e1ea86c76b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-774f874f-46fc-4ed5-bf80-9e1ea86c76b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

