### PR TITLE
perf: remove shared D1 write hot paths

### DIFF
--- a/packages/worker/src/account/deletion-state.node.test.ts
+++ b/packages/worker/src/account/deletion-state.node.test.ts
@@ -209,7 +209,7 @@ test('detached work spawned inside write re-acquires after the outer lease relea
 	})
 	releaseOuter()
 	await detached
-	expect(countLeaseRows(sqlite)).toBe(2)
+	expect(countLeaseRows(sqlite)).toBe(0)
 	expect(await listActiveAccountWriteLeases(db, 'user-a')).toHaveLength(0)
 	expect(
 		sqlite.prepare(`SELECT active_write_count FROM users WHERE id = 1`).get(),
@@ -229,9 +229,54 @@ test('sequential sibling leases each acquire after the previous released', async
 		db,
 		stableUserId: 'user-a',
 		async write() {
-			expect(countLeaseRows(sqlite)).toBe(2)
+			expect(countLeaseRows(sqlite)).toBe(1)
 			expect(await listActiveAccountWriteLeases(db, 'user-a')).toHaveLength(1)
 		},
 	})
 	expect(await listActiveAccountWriteLeases(db, 'user-a')).toHaveLength(0)
+	expect(countLeaseRows(sqlite)).toBe(0)
+})
+
+test('waitUntil moves lease release off the response path', async () => {
+	let finishRelease: () => void = () => undefined
+	const releaseGate = new Promise<void>((resolve) => {
+		finishRelease = resolve
+	})
+	let updateCount = 0
+	const db = {
+		prepare() {
+			return {
+				bind() {
+					return {
+						async run() {
+							updateCount++
+							if (updateCount === 1) {
+								return { meta: { changes: 1 } }
+							}
+							await releaseGate
+							return { meta: { changes: 1 } }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+	let releasePromise: Promise<unknown> | undefined
+
+	const result = await withAccountWriteLease({
+		db,
+		stableUserId: 'user-a',
+		waitUntil(promise) {
+			releasePromise = promise
+		},
+		async write() {
+			return 'response'
+		},
+	})
+
+	expect(result).toBe('response')
+	expect(updateCount).toBe(2)
+	expect(releasePromise).toBeDefined()
+	finishRelease()
+	await releasePromise
 })

--- a/packages/worker/src/account/deletion-state.ts
+++ b/packages/worker/src/account/deletion-state.ts
@@ -167,7 +167,7 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 		holder: input.holder ?? 'unspecified',
 		acquiredAt: utcSqliteTimestamp(),
 	}
-	const [inserted, counted] = await input.db.batch([
+	const prepareLeaseInsert = () =>
 		input.db
 			.prepare(
 				`INSERT INTO account_write_leases (
@@ -177,7 +177,8 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 				FROM users
 				WHERE stable_user_id = ? AND deleting_at IS NULL`,
 			)
-			.bind(lease.token, lease.holder, lease.acquiredAt, lease.stableUserId),
+			.bind(lease.token, lease.holder, lease.acquiredAt, lease.stableUserId)
+	const prepareWriteCountIncrement = () =>
 		input.db
 			.prepare(
 				`UPDATE users
@@ -189,8 +190,38 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 							AND released_at IS NULL
 					)`,
 			)
-			.bind(lease.stableUserId, lease.token, lease.stableUserId),
-	])
+			.bind(lease.stableUserId, lease.token, lease.stableUserId)
+	let inserted: D1Result<unknown>
+	let counted: D1Result<unknown>
+	try {
+		const results = await input.db.batch([
+			prepareLeaseInsert(),
+			prepareWriteCountIncrement(),
+		])
+		if (!results[0] || !results[1]) {
+			throw new Error('Account write lease batch returned incomplete results.')
+		}
+		inserted = results[0]
+		counted = results[1]
+	} catch {
+		// A D1 batch can commit and still lose its response. Reconcile by token;
+		// if it did not commit, retain the old sequential fallback so test and
+		// local adapters that reject batch calls still preserve deletion fencing.
+		const held = await input.db
+			.prepare(
+				`SELECT 1 AS held FROM account_write_leases
+				WHERE token = ? AND user_id = ? AND released_at IS NULL`,
+			)
+			.bind(lease.token, lease.stableUserId)
+			.first<{ held: number }>()
+		if (held?.held === 1) {
+			inserted = { meta: { changes: 1 } } as D1Result<unknown>
+			counted = { meta: { changes: 1 } } as D1Result<unknown>
+		} else {
+			inserted = await prepareLeaseInsert().run()
+			counted = await prepareWriteCountIncrement().run()
+		}
+	}
 	if (
 		(inserted?.meta.changes ?? 0) !== 1 ||
 		(counted?.meta.changes ?? 0) !== 1
@@ -211,7 +242,7 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 	} finally {
 		input.frame.active = false
 		const release = async () => {
-			const [decremented, deleted] = await input.db.batch([
+			const prepareWriteCountDecrement = () =>
 				input.db
 					.prepare(
 						`UPDATE users
@@ -223,16 +254,39 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 								AND released_at IS NULL
 						)`,
 					)
-					.bind(lease.stableUserId, lease.token, lease.stableUserId),
+					.bind(lease.stableUserId, lease.token, lease.stableUserId)
+			const prepareLeaseDelete = () =>
 				input.db
 					.prepare(
 						`DELETE FROM account_write_leases
 						WHERE token = ? AND user_id = ? AND released_at IS NULL`,
 					)
-					.bind(lease.token, lease.stableUserId),
-			])
-			if ((decremented?.meta.changes ?? 0) !== (deleted?.meta.changes ?? 0)) {
-				throw new Error('Account write lease release was inconsistent.')
+					.bind(lease.token, lease.stableUserId)
+			try {
+				await input.db.batch([
+					prepareWriteCountDecrement(),
+					prepareLeaseDelete(),
+				])
+			} catch {
+				const held = await input.db
+					.prepare(
+						`SELECT 1 AS held FROM account_write_leases
+						WHERE token = ? AND user_id = ? AND released_at IS NULL`,
+					)
+					.bind(lease.token, lease.stableUserId)
+					.first<{ held: number }>()
+				if (held?.held !== 1) return
+				const deleted = await prepareLeaseDelete().run()
+				if ((deleted.meta.changes ?? 0) === 1) {
+					await input.db
+						.prepare(
+							`UPDATE users
+							SET active_write_count = MAX(active_write_count - 1, 0)
+							WHERE stable_user_id = ?`,
+						)
+						.bind(lease.stableUserId)
+						.run()
+				}
 			}
 		}
 		const releasePromise = release()

--- a/packages/worker/src/account/deletion-state.ts
+++ b/packages/worker/src/account/deletion-state.ts
@@ -106,6 +106,7 @@ export async function withAccountWriteLease<T>(input: {
 	db: D1Database
 	stableUserId: string
 	holder?: string
+	waitUntil?: (promise: Promise<unknown>) => void
 	write: () => Promise<T>
 }) {
 	const heldLeases = heldAccountWriteLeaseStorage.getStore()
@@ -128,6 +129,7 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 	db: D1Database
 	stableUserId: string
 	holder?: string
+	waitUntil?: (promise: Promise<unknown>) => void
 	frame: AccountWriteLeaseFrame
 	write: () => Promise<T>
 }) {
@@ -147,7 +149,7 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 			return await input.write()
 		} finally {
 			input.frame.active = false
-			await input.db
+			const release = input.db
 				.prepare(
 					`UPDATE users
 					SET active_write_count = MAX(active_write_count - 1, 0)
@@ -155,6 +157,8 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 				)
 				.bind(input.stableUserId)
 				.run()
+			if (input.waitUntil) input.waitUntil(release)
+			else await release
 		}
 	}
 	const lease: AccountWriteLease = {
@@ -163,30 +167,30 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 		holder: input.holder ?? 'unspecified',
 		acquiredAt: utcSqliteTimestamp(),
 	}
-	const inserted = await input.db
-		.prepare(
-			`INSERT INTO account_write_leases (
-				token, user_id, holder, acquired_at
+	const [inserted, counted] = await input.db.batch([
+		input.db
+			.prepare(
+				`INSERT INTO account_write_leases (
+					token, user_id, holder, acquired_at
+				)
+				SELECT ?, stable_user_id, ?, ?
+				FROM users
+				WHERE stable_user_id = ? AND deleting_at IS NULL`,
 			)
-			SELECT ?, stable_user_id, ?, ?
-			FROM users
-			WHERE stable_user_id = ? AND deleting_at IS NULL`,
-		)
-		.bind(lease.token, lease.holder, lease.acquiredAt, lease.stableUserId)
-		.run()
-	const counted = await input.db
-		.prepare(
-			`UPDATE users
-			SET active_write_count = active_write_count + 1
-			WHERE stable_user_id = ?
-				AND EXISTS (
-					SELECT 1 FROM account_write_leases
-					WHERE token = ? AND user_id = ?
-						AND released_at IS NULL
-				)`,
-		)
-		.bind(lease.stableUserId, lease.token, lease.stableUserId)
-		.run()
+			.bind(lease.token, lease.holder, lease.acquiredAt, lease.stableUserId),
+		input.db
+			.prepare(
+				`UPDATE users
+				SET active_write_count = active_write_count + 1
+				WHERE stable_user_id = ?
+					AND EXISTS (
+						SELECT 1 FROM account_write_leases
+						WHERE token = ? AND user_id = ?
+							AND released_at IS NULL
+					)`,
+			)
+			.bind(lease.stableUserId, lease.token, lease.stableUserId),
+	])
 	if (
 		(inserted?.meta.changes ?? 0) !== 1 ||
 		(counted?.meta.changes ?? 0) !== 1
@@ -206,25 +210,34 @@ async function acquireAccountWriteLeaseAndWrite<T>(input: {
 		return result
 	} finally {
 		input.frame.active = false
-		const releasedAt = utcSqliteTimestamp()
-		const released = await input.db
-			.prepare(
-				`UPDATE account_write_leases
-				SET released_at = ?
-				WHERE token = ? AND user_id = ? AND released_at IS NULL`,
-			)
-			.bind(releasedAt, lease.token, lease.stableUserId)
-			.run()
-		if ((released.meta.changes ?? 0) === 1) {
-			await input.db
-				.prepare(
-					`UPDATE users
+		const release = async () => {
+			const [decremented, deleted] = await input.db.batch([
+				input.db
+					.prepare(
+						`UPDATE users
 					SET active_write_count = MAX(active_write_count - 1, 0)
-					WHERE stable_user_id = ?`,
-				)
-				.bind(lease.stableUserId)
-				.run()
+					WHERE stable_user_id = ?
+						AND EXISTS (
+							SELECT 1 FROM account_write_leases
+							WHERE token = ? AND user_id = ?
+								AND released_at IS NULL
+						)`,
+					)
+					.bind(lease.stableUserId, lease.token, lease.stableUserId),
+				input.db
+					.prepare(
+						`DELETE FROM account_write_leases
+						WHERE token = ? AND user_id = ? AND released_at IS NULL`,
+					)
+					.bind(lease.token, lease.stableUserId),
+			])
+			if ((decremented?.meta.changes ?? 0) !== (deleted?.meta.changes ?? 0)) {
+				throw new Error('Account write lease release was inconsistent.')
+			}
 		}
+		const releasePromise = release()
+		if (input.waitUntil) input.waitUntil(releasePromise)
+		else await releasePromise
 	}
 }
 
@@ -257,7 +270,7 @@ export async function repairAccountWriteLease(input: {
 	}
 	const now = utcSqliteTimestamp()
 	const repairId = crypto.randomUUID()
-	const [audited, decremented, released] = await input.db.batch([
+	const [audited, decremented, deleted] = await input.db.batch([
 		input.db
 			.prepare(
 				`INSERT INTO account_write_lease_repairs (
@@ -297,17 +310,16 @@ export async function repairAccountWriteLease(input: {
 			),
 		input.db
 			.prepare(
-				`UPDATE account_write_leases
-				SET released_at = ?
+				`DELETE FROM account_write_leases
 				WHERE token = ? AND user_id = ? AND acquired_at = ?
 					AND released_at IS NULL`,
 			)
-			.bind(now, input.token, input.stableUserId, input.expectedAcquiredAt),
+			.bind(input.token, input.stableUserId, input.expectedAcquiredAt),
 	])
 	if (
 		(audited?.meta.changes ?? 0) !== 1 ||
 		(decremented?.meta.changes ?? 0) !== 1 ||
-		(released?.meta.changes ?? 0) !== 1
+		(deleted?.meta.changes ?? 0) !== 1
 	) {
 		throw new Error('Active account write lease did not match repair request.')
 	}

--- a/packages/worker/src/app/rate-limit.node.test.ts
+++ b/packages/worker/src/app/rate-limit.node.test.ts
@@ -1,0 +1,61 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import {
+	authRateLimitConfig,
+	checkAuthRateLimit,
+	checkRateLimit,
+} from './rate-limit.ts'
+
+test('D1 rate limiting cleans up only the key being checked', async () => {
+	vi.useFakeTimers()
+	vi.setSystemTime(new Date('2026-07-31T04:00:00.000Z'))
+	const sqlite = new DatabaseSync(':memory:')
+	const db = createD1FromSqlite(sqlite)
+
+	await checkRateLimit(db, 'auth:ip:current', authRateLimitConfig)
+	sqlite
+		.prepare(`INSERT INTO _rate_limits (key, ts) VALUES (?, ?)`)
+		.run('webhook:user:other', 1)
+	sqlite
+		.prepare(`INSERT INTO _rate_limits (key, ts) VALUES (?, ?)`)
+		.run('auth:ip:current', 1)
+
+	await expect(
+		checkRateLimit(db, 'auth:ip:current', authRateLimitConfig),
+	).resolves.toEqual({ allowed: true, retryAfterSeconds: null })
+	expect(
+		sqlite
+			.prepare(`SELECT key, ts FROM _rate_limits ORDER BY id`)
+			.all()
+			.filter((row) => row.ts === 1),
+	).toEqual([{ key: 'webhook:user:other', ts: 1 }])
+
+	vi.useRealTimers()
+})
+
+test('auth binding preserves the ten requests per sixty seconds contract', async () => {
+	let requests = 0
+	const limit = vi.fn(async ({ key }: RateLimitOptions) => {
+		expect(key).toBe('auth:ip:198.51.100.42')
+		requests++
+		return { success: requests <= authRateLimitConfig.maxRequests }
+	})
+	const env = {
+		AUTH_RATE_LIMITER: { limit },
+		APP_DB: null as unknown as D1Database,
+	}
+
+	for (let index = 0; index < authRateLimitConfig.maxRequests; index++) {
+		await expect(
+			checkAuthRateLimit(env, 'auth:ip:198.51.100.42'),
+		).resolves.toEqual({ allowed: true, retryAfterSeconds: null })
+	}
+	await expect(
+		checkAuthRateLimit(env, 'auth:ip:198.51.100.42'),
+	).resolves.toEqual({
+		allowed: false,
+		retryAfterSeconds: authRateLimitConfig.windowSeconds,
+	})
+	expect(limit).toHaveBeenCalledTimes(11)
+})

--- a/packages/worker/src/app/rate-limit.ts
+++ b/packages/worker/src/app/rate-limit.ts
@@ -8,6 +8,11 @@ type RateLimitResult = {
 	retryAfterSeconds: number | null
 }
 
+type AuthRateLimitEnv = {
+	APP_DB: D1Database
+	AUTH_RATE_LIMITER?: RateLimit
+}
+
 const initializedDbs = new WeakSet<D1Database>()
 
 async function ensureRateLimitTable(db: D1Database) {
@@ -47,7 +52,9 @@ export async function checkRateLimit(
 	const windowStart = now - config.windowSeconds
 
 	const results = await db.batch([
-		db.prepare(`DELETE FROM _rate_limits WHERE ts <= ?`).bind(windowStart),
+		db
+			.prepare(`DELETE FROM _rate_limits WHERE key = ? AND ts <= ?`)
+			.bind(key, windowStart),
 		db
 			.prepare(
 				`INSERT INTO _rate_limits (key, ts)
@@ -91,4 +98,24 @@ export async function releaseRateLimit(db: D1Database, key: string) {
 export const authRateLimitConfig: RateLimitConfig = {
 	maxRequests: 10,
 	windowSeconds: 60,
+}
+
+/**
+ * Uses Cloudflare's per-location rate-limit binding on deployed auth ingress,
+ * keeping a D1 fallback for local development, tests, and self-hosted configs.
+ */
+export async function checkAuthRateLimit(
+	env: AuthRateLimitEnv,
+	key: string,
+): Promise<RateLimitResult> {
+	if (!env.AUTH_RATE_LIMITER) {
+		return checkRateLimit(env.APP_DB, key, authRateLimitConfig)
+	}
+	const result = await env.AUTH_RATE_LIMITER.limit({ key })
+	return result.success
+		? { allowed: true, retryAfterSeconds: null }
+		: {
+				allowed: false,
+				retryAfterSeconds: authRateLimitConfig.windowSeconds,
+			}
 }

--- a/packages/worker/src/email/inbound.workers.test.ts
+++ b/packages/worker/src/email/inbound.workers.test.ts
@@ -1105,14 +1105,16 @@ test('ambiguous quota-ledger batch response charges one delivery exactly once', 
 		email: accountEmail,
 		username,
 	})
-	let batchResponseFailed = false
+	let batchCalls = 0
 	const ambiguousDb = new Proxy(env.APP_DB, {
 		get(target, property, receiver) {
 			if (property === 'batch') {
 				return async (statements: Parameters<D1Database['batch']>[0]) => {
+					batchCalls++
 					const result = await target.batch(statements)
-					if (!batchResponseFailed) {
-						batchResponseFailed = true
+					// The account-write lease acquire is the first batch. Lose the
+					// response from the following quota-ledger batch.
+					if (batchCalls === 2) {
 						throw new Error('simulated quota batch response loss')
 					}
 					return result
@@ -2681,15 +2683,15 @@ test('insertEmailMessageWithAttachments cleans message and blob when attachment 
 	await insertWritableEmailTestUser(userId)
 	const messageId = crypto.randomUUID()
 	const key = emailRawMimeKey(userId, messageId)
-	// Fail only the first batch (attachment insert). Message cleanup also
-	// uses db.batch and must still run.
-	let attachmentBatchFailed = false
+	// Lease acquire/release use the first two batches. Fail only the following
+	// attachment insert; message cleanup also uses db.batch and must still run.
+	let batchCalls = 0
 	const failingDb = new Proxy(env.APP_DB, {
 		get(target, property, receiver) {
 			if (property === 'batch') {
 				return async (statements: Parameters<D1Database['batch']>[0]) => {
-					if (!attachmentBatchFailed) {
-						attachmentBatchFailed = true
+					batchCalls++
+					if (batchCalls === 3) {
 						throw new Error('simulated attachment insert failure')
 					}
 					return target.batch(statements)
@@ -2742,10 +2744,13 @@ test('attachment cleanup failure with remaining row is acknowledged without retr
 	await insertWritableEmailTestUser(userId)
 	const messageId = crypto.randomUUID()
 	const key = emailRawMimeKey(userId, messageId)
+	let batchCalls = 0
 	const failingDb = new Proxy(env.APP_DB, {
 		get(target, property, receiver) {
 			if (property === 'batch') {
-				return async () => {
+				return async (statements: Parameters<D1Database['batch']>[0]) => {
+					batchCalls++
+					if (batchCalls <= 2) return target.batch(statements)
 					throw new Error('simulated attachment and cleanup batch failure')
 				}
 			}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -39,7 +39,7 @@ import {
 } from './webhooks/http.ts'
 import { withCors } from './utils.ts'
 import { normalizeRedirectTo } from '#app/auth-redirect.ts'
-import { checkRateLimit, authRateLimitConfig } from '#app/rate-limit.ts'
+import { checkAuthRateLimit } from '#app/rate-limit.ts'
 import { getRequestIp } from '#worker/audit-log.ts'
 import { handleCapabilityReindexRequest } from './capability-maintenance.ts'
 import { handleExecuteSmokeRequest } from './execute-maintenance.ts'
@@ -231,11 +231,7 @@ const appHandler = withCors({
 		if (request.method === 'POST' && rateLimitedAuthPaths.has(url.pathname)) {
 			const ip = getRequestIp(request) ?? 'unknown'
 			const rateLimitKey = `auth:ip:${ip}`
-			const result = await checkRateLimit(
-				env.APP_DB,
-				rateLimitKey,
-				authRateLimitConfig,
-			)
+			const result = await checkAuthRateLimit(env, rateLimitKey)
 			if (!result.allowed) {
 				// A non-JSON social-login start is a document navigation, so a
 				// JSON 429 body would render as raw text; bounce back to the

--- a/packages/worker/src/mcp-auth-user-context.node.test.ts
+++ b/packages/worker/src/mcp-auth-user-context.node.test.ts
@@ -20,11 +20,15 @@ type GrantUserRow = {
 	display_name: string | null
 	stable_user_id: string
 	deleting_at?: string | null
+	email_verified_at?: string | null
+	suspended_at?: string | null
 }
 
 function createMockAppDb(options: {
 	row?: GrantUserRow | null
 	reject?: Error
+	connectorRows?: Array<{ instance_id: string }>
+	onConnectorQuery?: () => void
 }) {
 	const queries: Array<{ sql: string; params: Array<unknown> }> = []
 	const db = {
@@ -43,6 +47,14 @@ function createMockAppDb(options: {
 								return (options.row ?? null) as T | null
 							}
 							throw new Error(`Unsupported query: ${sql}`)
+						},
+						async all<T>() {
+							options.onConnectorQuery?.()
+							return {
+								results: (options.connectorRows ?? []) as Array<T>,
+								success: true,
+								meta: {},
+							}
 						},
 					}
 				},
@@ -75,15 +87,22 @@ test('buildMcpUserContextFromGrantProps resolves by stable id, refreshes profile
 			displayName: 'stale display',
 		}),
 	).resolves.toEqual({
-		userId: 'stable-admin-id',
-		email: 'current@example.com',
-		username: 'admin',
-		displayName: 'Admin Display',
-		roles: ['admin'],
-		permissions: ['read:user:any', 'read:role:any'],
+		user: {
+			userId: 'stable-admin-id',
+			email: 'current@example.com',
+			username: 'admin',
+			displayName: 'Admin Display',
+			roles: ['admin'],
+			permissions: ['read:user:any', 'read:role:any'],
+		},
+		emailVerified: false,
+		suspended: false,
+		remoteConnectors: [],
 	})
-	expect(refreshed.queries).toHaveLength(1)
+	expect(refreshed.queries).toHaveLength(2)
 	expect(refreshed.queries[0]?.params).toEqual(['stable-admin-id'])
+	expect(refreshed.queries[0]?.sql).toContain('email_verified_at')
+	expect(refreshed.queries[0]?.sql).toContain('suspended_at')
 	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledWith(
 		refreshed.db,
 		42,
@@ -113,12 +132,17 @@ test('buildMcpUserContextFromGrantProps resolves by stable id, refreshes profile
 			},
 		),
 	).resolves.toEqual({
-		userId: 'stable-original',
-		email: 'original-owner@example.com',
-		username: 'original',
-		displayName: 'original',
-		roles: ['user'],
-		permissions: [],
+		user: {
+			userId: 'stable-original',
+			email: 'original-owner@example.com',
+			username: 'original',
+			displayName: 'original',
+			roles: ['user'],
+			permissions: [],
+		},
+		emailVerified: false,
+		suspended: false,
+		remoteConnectors: [],
 	})
 	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledWith(
 		staleEmailOwnedElsewhere.db,
@@ -143,12 +167,17 @@ test('buildMcpUserContextFromGrantProps resolves by stable id, refreshes profile
 			userId: 'legacy-id',
 		}),
 	).resolves.toEqual({
-		userId: 'legacy-id',
-		email: 'resolved@example.com',
-		username: 'resolved',
-		displayName: 'resolved',
-		roles: ['user'],
-		permissions: [],
+		user: {
+			userId: 'legacy-id',
+			email: 'resolved@example.com',
+			username: 'resolved',
+			displayName: 'resolved',
+			roles: ['user'],
+			permissions: [],
+		},
+		emailVerified: false,
+		suspended: false,
+		remoteConnectors: [],
 	})
 	expect(emailOmitted.queries[0]?.params).toEqual(['legacy-id'])
 
@@ -192,4 +221,71 @@ test('buildMcpUserContextFromGrantProps resolves by stable id, refreshes profile
 	).rejects.toThrow('D1 unavailable')
 	expect(consoleError).toHaveBeenCalled()
 	expect(mockModule.getUserRolesAndPermissions).toHaveBeenCalledTimes(3)
+})
+
+test('MCP auth reads account gates once, loads roles and connectors in parallel, and caches connector refs', async () => {
+	let resolveRoles: (value: {
+		roles: Array<string>
+		permissions: Array<string>
+	}) => void = () => undefined
+	const roles = new Promise<{
+		roles: Array<string>
+		permissions: Array<string>
+	}>((resolve) => {
+		resolveRoles = resolve
+	})
+	let rolesStarted = false
+	let connectorStarted = false
+	mockModule.getUserRolesAndPermissions.mockImplementationOnce(() => {
+		rolesStarted = true
+		return roles
+	})
+	const account = createMockAppDb({
+		row: {
+			id: 12,
+			email: 'verified@example.com',
+			username: 'verified',
+			display_name: null,
+			stable_user_id: 'verified-id',
+			email_verified_at: '2026-07-31 04:00:00',
+			suspended_at: null,
+		},
+		connectorRows: [{ instance_id: 'home' }],
+		onConnectorQuery() {
+			connectorStarted = true
+		},
+	})
+
+	const pending = buildMcpUserContextFromGrantProps(
+		{ APP_DB: account.db } as Env,
+		{ userId: 'verified-id' },
+	)
+	await vi.waitFor(() => {
+		expect(rolesStarted).toBe(true)
+		expect(connectorStarted).toBe(true)
+	})
+	resolveRoles({ roles: ['user'], permissions: [] })
+	await expect(pending).resolves.toMatchObject({
+		emailVerified: true,
+		suspended: false,
+		remoteConnectors: [{ instanceId: 'home' }],
+	})
+
+	mockModule.getUserRolesAndPermissions.mockResolvedValueOnce({
+		roles: ['user'],
+		permissions: [],
+	})
+	await buildMcpUserContextFromGrantProps({ APP_DB: account.db } as Env, {
+		userId: 'verified-id',
+	})
+	expect(
+		account.queries.filter(({ sql }) =>
+			sql.toLowerCase().includes('remote_connector_settings'),
+		),
+	).toHaveLength(1)
+	expect(
+		account.queries.filter(({ sql }) =>
+			sql.toLowerCase().includes('from users'),
+		),
+	).toHaveLength(2)
 })

--- a/packages/worker/src/mcp-auth-user-context.ts
+++ b/packages/worker/src/mcp-auth-user-context.ts
@@ -4,6 +4,9 @@ import {
 	getUsernameFormatValidationError,
 } from '#worker/identity/username.ts'
 import { type McpUserContext } from '@kody-internal/shared/chat.ts'
+import { type RemoteConnectorRef } from '@kody-internal/shared/remote-connectors.ts'
+import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
+import { listAttachedRemoteConnectorRefs } from './remote-connector/settings-service.ts'
 
 type McpOAuthGrantProps = {
 	userId?: unknown
@@ -19,6 +22,41 @@ type GrantUserRow = {
 	display_name: string | null
 	stable_user_id: string
 	deleting_at: string | null
+	email_verified_at: string | null
+	suspended_at: string | null
+}
+
+export type McpAuthUserContext = {
+	user: McpUserContext
+	emailVerified: boolean
+	suspended: boolean
+	remoteConnectors: ReadonlyArray<RemoteConnectorRef>
+}
+
+export const attachedRemoteConnectorRefsCacheTtlMs = 30_000
+const attachedRemoteConnectorRefsCacheLimit = 200
+const attachedRemoteConnectorRefsCaches = new WeakMap<
+	D1Database,
+	PromiseLruCache<ReadonlyArray<RemoteConnectorRef>>
+>()
+
+function listAttachedRemoteConnectorRefsCached(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+}) {
+	let cache = attachedRemoteConnectorRefsCaches.get(input.env.APP_DB)
+	if (!cache) {
+		cache = new PromiseLruCache<ReadonlyArray<RemoteConnectorRef>>({
+			ttlMs: attachedRemoteConnectorRefsCacheTtlMs,
+			limit: attachedRemoteConnectorRefsCacheLimit,
+		})
+		attachedRemoteConnectorRefsCaches.set(input.env.APP_DB, cache)
+	}
+	return cache.getOrCreate({
+		cacheKey: input.userId,
+		create: async () =>
+			Object.freeze(await listAttachedRemoteConnectorRefs(input)),
+	})
 }
 
 function buildBaseUserFromGrant(
@@ -54,7 +92,7 @@ function buildBaseUserFromGrant(
 export async function buildMcpUserContextFromGrantProps(
 	env: Env,
 	grantProps: McpOAuthGrantProps,
-): Promise<McpUserContext | null> {
+): Promise<McpAuthUserContext | null> {
 	if (!grantProps || typeof grantProps.userId !== 'string') {
 		return null
 	}
@@ -67,7 +105,8 @@ export async function buildMcpUserContextFromGrantProps(
 	// never continue through stale OAuth grant metadata.
 	try {
 		const row = await env.APP_DB.prepare(
-			`SELECT id, email, username, display_name, stable_user_id, deleting_at
+			`SELECT id, email, username, display_name, stable_user_id,
+				deleting_at, email_verified_at, suspended_at
 			 FROM users
 			 WHERE stable_user_id = ?`,
 		)
@@ -86,21 +125,26 @@ export async function buildMcpUserContextFromGrantProps(
 			username ||
 			(email ? displayNameFromEmail(email) : baseUser.displayName)
 
-		const { roles, permissions } = await getUserRolesAndPermissions(
-			env.APP_DB,
-			row.id,
-		)
+		const [{ roles, permissions }, remoteConnectors] = await Promise.all([
+			getUserRolesAndPermissions(env.APP_DB, row.id),
+			listAttachedRemoteConnectorRefsCached({ env, userId }),
+		])
 
 		return {
-			userId,
-			email,
-			displayName,
-			...(username ? { username } : {}),
-			roles,
-			permissions,
+			user: {
+				userId,
+				email,
+				displayName,
+				...(username ? { username } : {}),
+				roles,
+				permissions,
+			},
+			emailVerified: Boolean(row.email_verified_at),
+			suspended: Boolean(row.suspended_at),
+			remoteConnectors,
 		}
 	} catch (error) {
-		console.error('Failed to load roles for MCP user context:', error)
+		console.error('Failed to load MCP auth user context:', error)
 		throw error
 	}
 }

--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -2,10 +2,8 @@ import {
 	type OAuthHelpers,
 	type TokenSummary,
 } from '@cloudflare/workers-oauth-provider'
-import { isAccountSuspended } from '#app/account-suspension.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { getRequestIp } from '#worker/audit-log.ts'
-import { isAccountEmailVerified } from '#worker/identity/email-verification-state.ts'
 import { buildMcpUserContextFromGrantProps } from './mcp-auth-user-context.ts'
 import {
 	type McpAuthDenialReason,
@@ -14,7 +12,6 @@ import {
 import { withAccountWriteLease } from '#worker/account/deletion-state.ts'
 import { createMcpCallerContext, type McpServerProps } from './mcp/context.ts'
 import { oauthScopes } from './oauth-handlers.ts'
-import { listAttachedRemoteConnectorRefs } from './remote-connector/settings-service.ts'
 
 export const mcpResourcePath = '/mcp'
 export const protectedResourceMetadataPath =
@@ -179,23 +176,18 @@ export async function handleMcpRequest({
 
 	const context = ctx as OAuthExecutionContext
 	const grantProps = tokenSummary.grant.props ?? null
-	const mcpUser = await buildMcpUserContextFromGrantProps(env, grantProps)
+	const authContext = await buildMcpUserContextFromGrantProps(env, grantProps)
 
 	// Fail-closed email verification gate: every MCP request must map to an
 	// account whose email is verified. Tokens without an identifiable user
-	// are rejected too, since verification cannot be established for them.
-	// A D1 failure inside `isAccountEmailVerified` propagates as an error
-	// instead of silently allowing access.
-	if (!mcpUser) {
+	// are rejected too, since verification cannot be established for them. The
+	// context loader reads identity, verification, and suspension in one query.
+	if (!authContext) {
 		await recordRejection('unidentified_grant')
 		return createEmailVerificationRequiredResponse(origin)
 	}
-	const emailVerified = await isAccountEmailVerified({
-		db: env.APP_DB,
-		email: mcpUser.email,
-		stableUserId: mcpUser.userId,
-	})
-	if (!emailVerified) {
+	const { user: mcpUser, remoteConnectors } = authContext
+	if (!authContext.emailVerified) {
 		await recordRejection('email_unverified', mcpUser.email)
 		return createEmailVerificationRequiredResponse(origin)
 	}
@@ -204,31 +196,24 @@ export async function handleMcpRequest({
 	// suspended account keeps its OAuth grants (stateless tokens cannot be
 	// revoked individually) but every MCP request is rejected until an
 	// admin clears the suspension.
-	const suspended = await isAccountSuspended({
-		db: env.APP_DB,
-		email: mcpUser.email,
-		stableUserId: mcpUser.userId,
-	})
-	if (suspended) {
+	if (authContext.suspended) {
 		await recordRejection('account_suspended', mcpUser.email)
 		return createAccountSuspendedResponse()
 	}
 
-	const remoteConnectors = await listAttachedRemoteConnectorRefs({
-		env,
-		userId: mcpUser.userId,
-	})
 	const props: OAuthContextProps = createMcpCallerContext({
 		baseUrl: origin,
 		executionOrigin: 'interactive',
 		user: mcpUser,
-		remoteConnectors,
+		remoteConnectors: [...remoteConnectors],
 	})
 	context.props = props
 
 	return await withAccountWriteLease({
 		db: env.APP_DB,
 		stableUserId: mcpUser.userId,
+		holder: `mcp:${request.method} ${url.pathname}`,
+		waitUntil: ctx.waitUntil.bind(ctx),
 		write: async () =>
 			await fetchMcp(
 				request,

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -69,6 +69,8 @@ type MockAccountRow = {
 	display_name: string | null
 	stable_user_id: string
 	email_verified_at: string | null
+	deleting_at?: string | null
+	suspended_at?: string | null
 }
 
 type VerificationLookupKind =
@@ -94,6 +96,8 @@ type MockDbOptions = {
 	auditInserts?: Array<Array<unknown>>
 	// Optional sink for which verification SQL shapes were exercised.
 	verificationLookups?: Array<VerificationLookupKind>
+	// Optional sink for consolidated users SELECTs.
+	userSelects?: Array<string>
 }
 
 function createMockDb(options: MockDbOptions = {}) {
@@ -147,6 +151,7 @@ function createMockDb(options: MockDbOptions = {}) {
 					normalized.includes('where stable_user_id') &&
 					normalized.includes('select id')
 				if (isProfileLookup) {
+					options.userSelects?.push(normalized)
 					if (!boundStableUserId) return null
 					if (options.accountByStableId !== undefined) {
 						if (
@@ -168,6 +173,8 @@ function createMockDb(options: MockDbOptions = {}) {
 						display_name: null,
 						stable_user_id: defaultStableUserId,
 						email_verified_at: verifiedAt,
+						deleting_at: null,
+						suspended_at: options.suspendedAt ?? null,
 					} satisfies MockAccountRow
 				}
 				if (normalized.includes('select suspended_at from users')) {
@@ -370,9 +377,11 @@ test('mcp request enforces token audience and forwards caller props', async () =
 		audience: `https://example.com${mcpResourcePath}`,
 	}
 	const verificationLookups: Array<VerificationLookupKind> = []
+	const userSelects: Array<string> = []
 	const verifiedDb: MockDbOptions = {
 		emailVerifiedAt: new Date(0).toISOString(),
 		verificationLookups,
+		userSelects,
 	}
 
 	const invalidResponse = await handleMcpRequest({
@@ -423,10 +432,10 @@ test('mcp request enforces token audience and forwards caller props', async () =
 		storageContext: null,
 		user: { userId: 'user' },
 	})
-	// MCP grant props carry email + stable userId, so verification must use the
-	// paired lookup — never the browser-session email-only SQL shape.
-	expect(verificationLookups).toContain('email_and_stable_user_id')
-	expect(verificationLookups).not.toContain('email_only')
+	expect(userSelects).toHaveLength(1)
+	expect(userSelects[0]).toContain('email_verified_at')
+	expect(userSelects[0]).toContain('suspended_at')
+	expect(verificationLookups).toHaveLength(0)
 
 	const withConnectorResponse = await handleMcpRequest({
 		request,
@@ -487,7 +496,7 @@ test('mcp request enforces token audience and forwards caller props', async () =
 		}),
 	).rejects.toThrow('D1 unavailable')
 	expect(consoleError).toHaveBeenCalledWith(
-		'Failed to load roles for MCP user context:',
+		'Failed to load MCP auth user context:',
 		expect.any(Error),
 	)
 })
@@ -605,7 +614,7 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 	const fallbackEmail = 'fallback@example.com'
 	const stableUserId = await createStableUserIdFromEmail(fallbackEmail)
 	const verifiedAt = new Date(0).toISOString()
-	const fallbackVerificationLookups: Array<VerificationLookupKind> = []
+	const fallbackUserSelects: Array<string> = []
 	const fallbackResponse = await handleMcpRequest({
 		request,
 		env: createEnv(
@@ -623,7 +632,7 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 					stable_user_id: stableUserId,
 					email_verified_at: verifiedAt,
 				},
-				verificationLookups: fallbackVerificationLookups,
+				userSelects: fallbackUserSelects,
 			},
 		),
 		ctx: createContext(),
@@ -631,6 +640,7 @@ test('mcp request rejects unverified and unidentifiable accounts fail-closed', a
 	})
 	expect(fallbackResponse.status).toBe(200)
 	expect(fetchMcpCalled).toBe(true)
-	expect(fallbackVerificationLookups).toContain('email_and_stable_user_id')
-	expect(fallbackVerificationLookups).not.toContain('email_only')
+	expect(fallbackUserSelects).toHaveLength(1)
+	expect(fallbackUserSelects[0]).toContain('email_verified_at')
+	expect(fallbackUserSelects[0]).toContain('suspended_at')
 })

--- a/packages/worker/src/mcp/memory/service.node.test.ts
+++ b/packages/worker/src/mcp/memory/service.node.test.ts
@@ -531,8 +531,9 @@ test('acknowledgeSurfacedMemories writes suppressions and last_accessed in one b
 		memoryIds: [created.memory.id],
 	})
 
-	expect(testDb.batches).toHaveLength(1)
-	expect(testDb.batches[0]).toHaveLength(2)
+	// Lease acquire, acknowledgement, and lease release are each atomic batches.
+	expect(testDb.batches).toHaveLength(3)
+	expect(testDb.batches.every((batch) => batch.length === 2)).toBe(true)
 	expect(
 		testDb.suppressions.get(`user-123:conv-ack-batch:${created.memory.id}`),
 	).toMatchObject({

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -4,6 +4,7 @@
 	"compatibility_date": "2026-04-16",
 	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
 	"main": "./src/index.ts",
+	"minify": true,
 	"upload_source_maps": true,
 	"rules": [
 		{
@@ -109,6 +110,16 @@
 	},
 	"env": {
 		"production": {
+			"ratelimits": [
+				{
+					"name": "AUTH_RATE_LIMITER",
+					"namespace_id": "1001",
+					"simple": {
+						"limit": 10,
+						"period": 60,
+					},
+				},
+			],
 			// Replaces the top-level observability block (wrangler env keys
 			// override wholesale, so "enabled" is restated): same tracing,
 			// plus the account-level Sentry OTLP export destination
@@ -327,6 +338,16 @@
 			},
 		},
 		"preview": {
+			"ratelimits": [
+				{
+					"name": "AUTH_RATE_LIMITER",
+					"namespace_id": "1002",
+					"simple": {
+						"limit": 10,
+						"period": 60,
+					},
+				},
+			],
 			"worker_loaders": [
 				{
 					"binding": "LOADER",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- delete released account write leases, atomically batch lease bookkeeping, and defer MCP release through `waitUntil`
- move auth ingress to Cloudflare's 10 requests / 60 seconds rate-limit binding while scoping D1 fallback cleanup by key
- consolidate MCP identity, verification, and suspension into one users read; parallelize roles/connectors and cache connector refs for 30 seconds
- minify production Worker bundles

Part of #1069

## Verification
- `npm run validate` — green
- production `npm run build` — green; Wrangler recognized `AUTH_RATE_LIMITER` at 10 requests / 60 seconds and produced a 26,371 KiB upload (7,610 KiB gzip)
- unit suites — 1,714 passing
- MCP E2E — 3 passing
- Playwright E2E — 19 passing
- rebased on latest `main`; pre-push unit and Playwright suites remained green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ffc26e41` · **Head:** `44854f73`

**Classification:** extends — changes authentication ingress, MCP authorization loading, and D1 write-lease behavior without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — auth POSTs use the edge rate-limit binding with a scoped D1 fallback |
| `mcp-oauth` | auth | extends — one account read plus parallel cached connector/RBAC loading |
| `mcp-server` | surfaces | composes — existing memory tests account for atomic lease batches |
| `email` | assistant | composes — fault injection targets domain batches after lease batching |
| `d1-app-db` | storage | extends — leases are deleted on release and acquire/release bookkeeping is batched |

### System map

Auth ingress moves rate limiting off shared D1, while MCP requests consolidate identity reads and shorten synchronous lease work.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	mcpOauth["mcp-oauth<br/>MCP OAuth"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	d1["d1-app-db<br/>D1 app database"]:::extended
	edge["Cloudflare rate-limit binding"]:::untouched
	appUi -->|"10 requests / 60 seconds per IP"| edge
	appUi -->|"key-scoped fallback cleanup"| d1
	mcpOauth -->|"single users SELECT + batched write lease"| d1
	mcpOauth -->|"authorized caller props"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| Lease release | retained released row | deletes row and decrements counter atomically |
| Auth limit | global D1 cleanup/write | edge binding; key-scoped D1 fallback |
| MCP account gates | three users reads | one users read |
| Connector refs | D1 every request | per-user 30-second cache |
| Worker bundle | unminified | minified with source maps |

### Invariants

- `no-per-event-shared-writes`: deployed auth ingress no longer writes the shared D1 limiter on every request.
- Every lease, account, role, and connector lookup remains scoped by stable `userId`.

</details>

<!-- system-recap:end -->

## Conductor report
- status: done
- verified: authoritative local validation and production Worker build are green; targeted lease deletion, rate-limit parity, consolidated MCP auth, and batch-failure coverage pass; latest-main rebase remained green under pre-push tests
- scope spill: updated email and memory fault-injection assertions because atomic lease acquire/release adds batches around their domain writes
- decisions needed from Kent: none
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73adf002-5eb2-4fb2-a6fe-a632c4261bae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73adf002-5eb2-4fb2-a6fe-a632c4261bae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

