### PR TITLE
Scale DR exporter staging and incremental R2 capture

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -112,13 +112,13 @@ were already gone or moved).
 
 Contract: `packages/shared/src/backup-staging.ts`.
 
-| Prefix                          | Mutability       | Contents                                                                     |
-| ------------------------------- | ---------------- | ---------------------------------------------------------------------------- |
-| `daily/d1/...`, `weekly/d1/...` | Immutable        | Signed D1 SQL + schema-v2 D1 manifests                                       |
-| `staging/{day}/...`             | Mutable          | Production exporter progress, indexes, NDJSON dumps, `exporter/summary.json` |
-| `daily/full/{day}/...`          | Immutable        | Sealed copy of staged indexes/dumps + Ed25519 full-backup manifest           |
-| `blobs/sha256/{hash}`           | Immutable        | Deduplicated email MIME, community assets, published source snapshots        |
-| `escrow/`                       | Operator-managed | Sealed `SECRET_STORE_KEY` blob (`escrow/secret-store-key.v1.json`)           |
+| Prefix                          | Mutability       | Contents                                                                                                  |
+| ------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
+| `daily/d1/...`, `weekly/d1/...` | Immutable        | Signed D1 SQL + schema-v2 D1 manifests                                                                    |
+| `staging/{day}/...`             | Mutable          | Production exporter cursor progress, chunked phase output, indexes, NDJSON dumps, `exporter/summary.json` |
+| `daily/full/{day}/...`          | Immutable        | Sealed copy of staged indexes/dumps + Ed25519 full-backup manifest                                        |
+| `blobs/sha256/{hash}`           | Immutable        | Deduplicated email MIME, community assets, published source snapshots                                     |
+| `escrow/`                       | Operator-managed | Sealed `SECRET_STORE_KEY` blob (`escrow/secret-store-key.v1.json`)                                        |
 
 ### Capture lanes
 
@@ -138,9 +138,25 @@ Contract: `packages/shared/src/backup-staging.ts`.
      are skipped with a warning in the staging summary; the same summary also
      warns when a `StorageRunner` dump exceeds the 16 MiB buffer ceiling and is
      skipped — review dashboard warnings before treating a sealed day as
-     complete)
+     complete). An object whose key, size, ETag, and uploaded timestamp match
+     the latest retained sealed-day index reuses that index entry and
+     content-addressed blob without downloading or hashing the source object.
+     Missing, malformed, or checksum-mismatched sealed indexes fall back to the
+     full download and hash path.
    - **Published artifacts** — `BUNDLE_ARTIFACTS_KV` published source snapshots
      for rows in `entity_sources` with a `published_commit`
+   - **Resumable phase state** — `exporter/progress.json` contains phase
+     cursors, counters, a bounded index-entry tail, and conditional-write
+     revision data. Storage dump pages and storage, R2, and artifact index
+     entries are written under `exporter/chunks/` as bounded NDJSON objects.
+     Finalization reads those chunks and emits the stable storage, R2, and
+     artifact index contracts referenced by `exporter/summary.json`. Chunk
+     objects are content-addressed linked lists whose head keys and counts live
+     in progress. Stale writers can therefore leave only unreferenced chunks;
+     they cannot overwrite chunks selected by a newer lease. Progress updates
+     retain `If-Match` ownership semantics. Canonical per-day dumps, indexes,
+     and the completion summary are create-only; a resumed writer adopts an
+     already completed object instead of replacing it.
 3. **Seal** — Control plane verifies staged checksums against
    `staging/{day}/exporter/summary.json`, requires a verified same-day D1
    manifest, copies staged files under `daily/full/{day}/...`, and signs a

--- a/packages/worker/src/dr/exporter-inventory.ts
+++ b/packages/worker/src/dr/exporter-inventory.ts
@@ -1,0 +1,95 @@
+import { buildPackageServiceStorageId } from '#worker/package-runtime/package-service.ts'
+import { listPlatformStorageBuckets } from '#worker/storage-buckets/service.ts'
+import { encodeStorageIdentity } from '#worker/dr/storage-identity.ts'
+
+export type StorageInventoryEntry = {
+	userId: string
+	storageId: string
+	identity: string
+}
+
+export type ArtifactInventoryEntry = {
+	sourceId: string
+	userId: string
+	entityKind: string
+	entityId: string
+	publishedCommit: string
+}
+
+/**
+ * Platform-wide StorageRunner inventory.
+ *
+ * Deliberate exception to per-user scoping: this operator-level DR exporter
+ * iterates every user's storage ids so the sealed day can rebuild the whole
+ * platform. Do not copy this pattern into user-facing read/write paths.
+ */
+export async function listPlatformStorageInventory(
+	db: D1Database,
+): Promise<Array<StorageInventoryEntry>> {
+	// Platform-wide DR has only a D1Database (no per-user Env / network), so
+	// service buckets come from projected `package_service_states` rather than
+	// package manifests. Ad-hoc / execute buckets come from the authoritative
+	// `user_storage_buckets` registry via `listPlatformStorageBuckets`.
+	const [jobRows, archivedRows, registeredBuckets, serviceRows] =
+		await Promise.all([
+			db
+				.prepare(
+					`SELECT user_id AS userId, storage_id AS storageId
+					FROM jobs WHERE storage_id IS NOT NULL`,
+				)
+				.all<{ userId: string; storageId: string }>(),
+			db
+				.prepare(
+					`SELECT user_id AS userId, storage_id AS storageId
+					FROM archived_job_artifacts WHERE storage_id IS NOT NULL`,
+				)
+				.all<{ userId: string; storageId: string }>(),
+			listPlatformStorageBuckets({ db }),
+			db
+				.prepare(
+					`SELECT DISTINCT user_id AS userId, package_id AS packageId,
+						service_name AS serviceName
+					FROM package_service_states`,
+				)
+				.all<{
+					userId: string
+					packageId: string
+					serviceName: string
+				}>(),
+		])
+
+	const seen = new Set<string>()
+	const inventory: Array<StorageInventoryEntry> = []
+	function push(userId: string, storageId: string) {
+		const identity = encodeStorageIdentity(userId, storageId)
+		if (seen.has(identity)) return
+		seen.add(identity)
+		inventory.push({ userId, storageId, identity })
+	}
+	for (const row of jobRows.results ?? []) push(row.userId, row.storageId)
+	for (const row of archivedRows.results ?? []) push(row.userId, row.storageId)
+	for (const row of registeredBuckets) push(row.userId, row.storageId)
+	for (const row of serviceRows.results ?? []) {
+		push(
+			row.userId,
+			buildPackageServiceStorageId(row.packageId, row.serviceName),
+		)
+	}
+	inventory.sort((left, right) => left.identity.localeCompare(right.identity))
+	return inventory
+}
+
+export async function listPlatformArtifactInventory(
+	db: D1Database,
+): Promise<Array<ArtifactInventoryEntry>> {
+	const result = await db
+		.prepare(
+			`SELECT id AS sourceId, user_id AS userId, entity_kind AS entityKind,
+				entity_id AS entityId, published_commit AS publishedCommit
+			FROM entity_sources
+			WHERE published_commit IS NOT NULL AND trim(published_commit) != ''
+			ORDER BY id ASC`,
+		)
+		.all<ArtifactInventoryEntry>()
+	return result.results ?? []
+}

--- a/packages/worker/src/dr/exporter-schedule.ts
+++ b/packages/worker/src/dr/exporter-schedule.ts
@@ -1,0 +1,40 @@
+import { readDrBackupS3Config } from '#worker/dr/backup-s3.ts'
+
+/**
+ * Nightly DR export window: roughly 00:30–06:10 UTC on the worker's
+ * every-5-minute cron (~68 ticks × 20 s ≈ 22 minutes of staging work).
+ * Ticks outside this window are skipped so daytime traffic is not competing
+ * with a full-platform export. Completed days exit cheaply through the
+ * summary-object check.
+ */
+export function shouldRunDrExportCron(now: Date) {
+	const minutes = now.getUTCHours() * 60 + now.getUTCMinutes()
+	return minutes >= 30 && minutes <= 6 * 60 + 10
+}
+
+/**
+ * One cron tick after the export window closes (06:15–06:19 UTC). The
+ * watchdog fails loudly (lane failure → Sentry) when the night's staging
+ * summary is missing, because the exporter itself never errors when it
+ * merely runs out of window.
+ */
+export function shouldRunDrExportWatchdogCron(now: Date) {
+	const minutes = now.getUTCHours() * 60 + now.getUTCMinutes()
+	return minutes >= 6 * 60 + 15 && minutes < 6 * 60 + 20
+}
+
+export function isDrExportConfigured(
+	env: Pick<
+		Env,
+		| 'DR_EXPORT_ENABLED'
+		| 'DR_BACKUP_ACCOUNT_ID'
+		| 'DR_BACKUP_BUCKET_NAME'
+		| 'DR_BACKUP_ACCESS_KEY_ID'
+		| 'DR_BACKUP_SECRET_ACCESS_KEY'
+	>,
+) {
+	return (
+		env.DR_EXPORT_ENABLED?.trim() === 'true' &&
+		readDrBackupS3Config(env) !== null
+	)
+}

--- a/packages/worker/src/dr/exporter-staging.ts
+++ b/packages/worker/src/dr/exporter-staging.ts
@@ -1,0 +1,225 @@
+import { parseBackupFullManifest } from '@kody-internal/shared/backup-full-manifest.ts'
+import {
+	sealedFullManifestKey,
+	stagingPrefix,
+	type BackupR2BucketLabel,
+	type R2IndexEntry,
+} from '@kody-internal/shared/backup-staging.ts'
+import {
+	DrBackupPreconditionFailedError,
+	type DrBackupS3Client,
+} from '#worker/dr/backup-s3.ts'
+import { sha256Hex } from '#worker/dr/sha256.ts'
+
+export type IncrementalR2IndexEntry = R2IndexEntry & {
+	etag: string
+	uploaded: string
+}
+
+export function stagingChunkKey(
+	day: string,
+	kind: 'storage-index' | 'artifacts-index',
+) {
+	return `${stagingPrefix(day)}exporter/chunks/${kind}/`
+}
+
+export function stagingStorageDumpChunkKey(day: string, identity: string) {
+	return `${stagingPrefix(day)}exporter/chunks/storage-dump/${encodeURIComponent(identity)}/`
+}
+
+export function stagingR2IndexChunkKey(
+	day: string,
+	label: BackupR2BucketLabel,
+) {
+	return `${stagingPrefix(day)}exporter/chunks/r2-index/${label}/`
+}
+
+type ChunkMetadata = {
+	__drExporterChunk: {
+		previousKey: string | null
+	}
+}
+
+export async function putLinkedChunk(input: {
+	s3: DrBackupS3Client
+	keyPrefix: string
+	entriesBody: string
+	previousKey: string | null
+}) {
+	const metadata = {
+		__drExporterChunk: { previousKey: input.previousKey },
+	} satisfies ChunkMetadata
+	const body = `${JSON.stringify(metadata)}\n${input.entriesBody}`
+	const key = `${input.keyPrefix}${await sha256Hex(body)}.ndjson`
+	try {
+		await input.s3.put(key, body, {
+			contentType: 'application/x-ndjson',
+			ifNoneMatch: '*',
+		})
+	} catch (error) {
+		if (!(error instanceof DrBackupPreconditionFailedError)) throw error
+		const existing = await input.s3.getText(key)
+		if (existing?.text !== body) {
+			throw new Error(`DR exporter content-addressed chunk mismatch: ${key}`)
+		}
+	}
+	return key
+}
+
+export async function putImmutableOutput(input: {
+	s3: DrBackupS3Client
+	key: string
+	body: string
+	contentType: string
+}) {
+	try {
+		await input.s3.put(input.key, input.body, {
+			contentType: input.contentType,
+			ifNoneMatch: '*',
+		})
+		return input.body
+	} catch (error) {
+		if (!(error instanceof DrBackupPreconditionFailedError)) throw error
+		const existing = await input.s3.getText(input.key)
+		if (!existing) {
+			throw new Error(`DR exporter immutable output disappeared: ${input.key}`)
+		}
+		return existing.text
+	}
+}
+
+function parseNdjsonEntries<T>(body: string): Array<T> {
+	return body
+		.split('\n')
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as T)
+}
+
+function parseChunk(body: string) {
+	const newlineIndex = body.indexOf('\n')
+	if (newlineIndex < 0) throw new Error('DR exporter chunk metadata is missing')
+	const metadata = JSON.parse(body.slice(0, newlineIndex)) as unknown
+	if (
+		!metadata ||
+		typeof metadata !== 'object' ||
+		Array.isArray(metadata) ||
+		!('__drExporterChunk' in metadata)
+	) {
+		throw new Error('DR exporter chunk metadata is invalid')
+	}
+	const chunk = (metadata as ChunkMetadata).__drExporterChunk
+	if (
+		!chunk ||
+		(chunk.previousKey !== null && typeof chunk.previousKey !== 'string')
+	) {
+		throw new Error('DR exporter chunk link is invalid')
+	}
+	return {
+		previousKey: chunk.previousKey,
+		entriesBody: body.slice(newlineIndex + 1),
+	}
+}
+
+export async function readLinkedChunkBody(input: {
+	s3: DrBackupS3Client
+	headKey: string | null
+	chunkCount: number
+}) {
+	const bodies: Array<string> = []
+	let key = input.headKey
+	for (let index = 0; index < input.chunkCount; index += 1) {
+		if (!key) throw new Error('DR exporter chunk chain ended early')
+		const chunk = await input.s3.getText(key)
+		if (!chunk) {
+			throw new Error(`DR exporter chunk missing: ${key}`)
+		}
+		const parsed = parseChunk(chunk.text)
+		bodies.push(parsed.entriesBody)
+		key = parsed.previousKey
+	}
+	if (key !== null) throw new Error('DR exporter chunk chain exceeds its count')
+	return bodies.reverse().join('')
+}
+
+export async function readLinkedChunkEntries<T>(input: {
+	s3: DrBackupS3Client
+	headKey: string | null
+	chunkCount: number
+}): Promise<Array<T>> {
+	return parseNdjsonEntries<T>(await readLinkedChunkBody(input))
+}
+
+function previousUtcDay(day: string, daysBack: number) {
+	const date = new Date(`${day}T00:00:00.000Z`)
+	date.setUTCDate(date.getUTCDate() - daysBack)
+	return date.toISOString().slice(0, 10)
+}
+
+export async function resolvePreviousSealedDay(input: {
+	s3: DrBackupS3Client
+	day: string
+	lookbackDays: number
+}) {
+	for (let daysBack = 1; daysBack <= input.lookbackDays; daysBack += 1) {
+		const candidate = previousUtcDay(input.day, daysBack)
+		const manifest = await input.s3.getText(sealedFullManifestKey(candidate))
+		if (!manifest) continue
+		try {
+			const parsed = parseBackupFullManifest(
+				JSON.parse(manifest.text) as unknown,
+			)
+			if (parsed.payload.day === candidate) return candidate
+		} catch {
+			// A malformed object is not eligible as a sealed incremental base.
+		}
+	}
+	return null
+}
+
+function parseIncrementalR2Index(body: string) {
+	const entries = new Map<string, IncrementalR2IndexEntry>()
+	for (const value of parseNdjsonEntries<unknown>(body)) {
+		if (!value || typeof value !== 'object' || Array.isArray(value)) continue
+		const entry = value as Record<string, unknown>
+		if (
+			typeof entry.key !== 'string' ||
+			typeof entry.size !== 'number' ||
+			typeof entry.sha256 !== 'string' ||
+			!/^[0-9a-f]{64}$/.test(entry.sha256) ||
+			typeof entry.etag !== 'string' ||
+			typeof entry.uploaded !== 'string'
+		) {
+			continue
+		}
+		entries.set(entry.key, entry as IncrementalR2IndexEntry)
+	}
+	return entries
+}
+
+export async function loadPreviousR2Index(input: {
+	s3: DrBackupS3Client
+	day: string | null
+	label: BackupR2BucketLabel
+}) {
+	if (!input.day) return new Map<string, IncrementalR2IndexEntry>()
+	const manifestText = await input.s3.getText(sealedFullManifestKey(input.day))
+	if (!manifestText) return new Map<string, IncrementalR2IndexEntry>()
+	try {
+		const manifest = parseBackupFullManifest(
+			JSON.parse(manifestText.text) as unknown,
+		)
+		const file = manifest.payload.r2Indexes[input.label]
+		if (!file) return new Map<string, IncrementalR2IndexEntry>()
+		const index = await input.s3.getText(file.objectKey)
+		if (!index) return new Map<string, IncrementalR2IndexEntry>()
+		if (
+			new TextEncoder().encode(index.text).byteLength !== file.bytes ||
+			(await sha256Hex(index.text)) !== file.sha256
+		) {
+			return new Map<string, IncrementalR2IndexEntry>()
+		}
+		return parseIncrementalR2Index(index.text)
+	} catch {
+		return new Map<string, IncrementalR2IndexEntry>()
+	}
+}

--- a/packages/worker/src/dr/exporter.node.test.ts
+++ b/packages/worker/src/dr/exporter.node.test.ts
@@ -1,6 +1,8 @@
 import { expect, test, vi } from 'vitest'
 import {
 	backupBlobKey,
+	sealedFullManifestKey,
+	sealedFullPrefix,
 	stagingR2IndexKey,
 	stagingStorageDumpKey,
 	stagingSummaryKey,
@@ -290,7 +292,7 @@ test('exporter resumes from progress cursor across ticks when budget is exhauste
 		pageSize: 250,
 		estimatedBytes: 1,
 	})
-	const { client } = createMemoryS3()
+	const { client, objects } = createMemoryS3()
 	let nowMs = 1_000_000
 	const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
 	const originalPut = client.put.bind(client)
@@ -332,6 +334,14 @@ test('exporter resumes from progress cursor across ticks when budget is exhauste
 		expect(tick1.timeBudgetExhausted).toBe(true)
 		expect(tick1.summaryWritten).toBe(false)
 		expect(tick1.storageDumpsCompleted).toBe(1)
+		const progressAfterFirstTick = JSON.parse(
+			(await client.getText('staging/2026-07-23/exporter/progress.json'))!.text,
+		) as Record<string, unknown>
+		expect(progressAfterFirstTick).not.toHaveProperty('storageEntries')
+		expect(progressAfterFirstTick).not.toHaveProperty('artifactEntries')
+		expect(progressAfterFirstTick).not.toHaveProperty('storagePartialNdjson')
+		expect(progressAfterFirstTick).not.toHaveProperty('r2PartialNdjson')
+		expect(progressAfterFirstTick.storagePendingEntries).toHaveLength(1)
 
 		nowMs = 1_000_000
 		const tick2 = await runDrExportTick({
@@ -342,6 +352,11 @@ test('exporter resumes from progress cursor across ticks when budget is exhauste
 		})
 		expect(tick2.summaryWritten).toBe(true)
 		expect(storageMocks.exportStorage.mock.calls.length).toBe(2)
+		expect(
+			[...objects.keys()].some((key) =>
+				key.startsWith('staging/2026-07-23/exporter/chunks/storage-index/'),
+			),
+		).toBe(true)
 	} finally {
 		dateNow.mockRestore()
 	}
@@ -488,26 +503,28 @@ test('exporter skips oversized storage dumps with a summary warning', async () =
 
 test('exporter aborts quietly when progress If-Match precondition fails', async () => {
 	storageMocks.exportStorage.mockReset()
-	storageMocks.exportStorage.mockResolvedValue({
-		entries: [{ key: 'k', value: 1 }],
+	let storedValue = 1
+	storageMocks.exportStorage.mockImplementation(async () => ({
+		entries: [{ key: 'k', value: storedValue }],
 		truncated: false,
 		nextStartAfter: null,
 		pageSize: 250,
 		estimatedBytes: 1,
-	})
+	}))
 	const { client } = createMemoryS3()
 	const originalPut = client.put.bind(client)
 	let progressPuts = 0
 	client.put = async (key, body, options) => {
 		if (key.includes('exporter/progress.json')) {
 			progressPuts += 1
-			if (progressPuts === 1) {
-				return originalPut(key, body, options)
+			if (progressPuts === 2) {
+				throw new DrBackupPreconditionFailedError(key)
 			}
-			throw new DrBackupPreconditionFailedError(key)
 		}
 		return originalPut(key, body, options)
 	}
+	let nowMs = 1_000_000
+	const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
 	const env = {
 		DR_EXPORT_ENABLED: 'true',
 		DR_BACKUP_ACCOUNT_ID: 'acct',
@@ -523,14 +540,39 @@ test('exporter aborts quietly when progress If-Match precondition fails', async 
 		STORAGE_RUNNER: {},
 	} as unknown as Env
 
-	const result = await runDrExportTick({
-		env,
-		now: new Date('2026-07-23T01:00:00.000Z'),
-		timeBudgetMs: 60_000,
-		s3: client,
-	})
-	expect(result.skipped).toBe(true)
-	expect(result.reason).toBe('progress-precondition-failed')
+	try {
+		const result = await runDrExportTick({
+			env,
+			now: new Date('2026-07-23T01:00:00.000Z'),
+			timeBudgetMs: 60_000,
+			s3: client,
+		})
+		expect(result.skipped).toBe(true)
+		expect(result.reason).toBe('progress-precondition-failed')
+
+		// The failed tick wrote a complete immutable dump before losing
+		// progress ownership. Once its lease expires, changed source bytes can
+		// produce a new orphaned chunk while resume adopts the first complete
+		// dump and finishes rather than conflicting forever.
+		storedValue = 2
+		nowMs += 3 * 60_000
+		const resumed = await runDrExportTick({
+			env,
+			now: new Date('2026-07-23T01:05:00.000Z'),
+			timeBudgetMs: 60_000,
+			s3: client,
+		})
+		expect(resumed.summaryWritten).toBe(true)
+		const identity = encodeStorageIdentity('user-a', 'job:1')
+		const dump = await client.getText(
+			stagingStorageDumpKey('2026-07-23', identity),
+		)
+		expect(JSON.parse(dump!.text.trim())).toMatchObject({
+			valueJson: JSON.stringify(1),
+		})
+	} finally {
+		dateNow.mockRestore()
+	}
 })
 
 test('R2 export does not duplicate index lines across budget interruptions', async () => {
@@ -600,6 +642,7 @@ test('R2 export does not duplicate index lines across budget interruptions', asy
 	let nowMs = 1_000_000
 	const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
 	const originalPut = client.put.bind(client)
+	let exhaustedAfterFirstPage = false
 	client.put = async (key, body, options) => {
 		const result = await originalPut(key, body, options)
 		// After the first R2 list page is persisted (cursor advanced), exhaust
@@ -607,8 +650,10 @@ test('R2 export does not duplicate index lines across budget interruptions', asy
 		if (
 			key.includes('exporter/progress.json') &&
 			typeof body === 'string' &&
-			body.includes('"r2ListCursor":"page-2"')
+			body.includes('"r2ListCursor":"page-2"') &&
+			!exhaustedAfterFirstPage
 		) {
+			exhaustedAfterFirstPage = true
 			nowMs += 50_000
 		}
 		return result
@@ -660,6 +705,156 @@ test('R2 export does not duplicate index lines across budget interruptions', asy
 	} finally {
 		dateNow.mockRestore()
 	}
+})
+
+test('R2 export reuses unchanged objects from the latest sealed index', async () => {
+	storageMocks.exportStorage.mockReset()
+	storageMocks.exportStorage.mockResolvedValue({
+		entries: [],
+		truncated: false,
+		nextStartAfter: null,
+		pageSize: 250,
+		estimatedBytes: 0,
+	})
+	const unchangedBytes = new TextEncoder().encode('unchanged')
+	const changedBytes = new TextEncoder().encode('changed-now')
+	const unchangedDigest = await sha256Hex(unchangedBytes)
+	const oldChangedDigest = await sha256Hex('changed-before')
+	const uploaded = new Date('2026-07-20T12:00:00.000Z')
+	const previousIndexBody = [
+		{
+			key: 'unchanged',
+			size: unchangedBytes.byteLength,
+			sha256: unchangedDigest,
+			etag: 'etag-unchanged',
+			uploaded: uploaded.toISOString(),
+		},
+		{
+			key: 'changed',
+			size: changedBytes.byteLength,
+			sha256: oldChangedDigest,
+			etag: 'etag-before',
+			uploaded: uploaded.toISOString(),
+		},
+	]
+		.map((entry) => `${JSON.stringify(entry)}\n`)
+		.join('')
+	const previousIndexKey = `${sealedFullPrefix('2026-07-22')}r2-index/email-blobs.ndjson`
+	const { client } = createMemoryS3()
+	await client.put(previousIndexKey, previousIndexBody)
+	await client.put(backupBlobKey(unchangedDigest), unchangedBytes)
+	await client.put(
+		sealedFullManifestKey('2026-07-22'),
+		JSON.stringify({
+			schemaVersion: 1,
+			payload: {
+				schemaVersion: 1,
+				day: '2026-07-22',
+				d1ManifestKey: 'daily/d1/2026-07-22/manifest.json',
+				d1ManifestSha256: 'a'.repeat(64),
+				storageIndex: {
+					objectKey: `${sealedFullPrefix('2026-07-22')}storage-index.json`,
+					bytes: 0,
+					sha256: 'b'.repeat(64),
+				},
+				r2Indexes: {
+					'email-blobs': {
+						objectKey: previousIndexKey,
+						bytes: new TextEncoder().encode(previousIndexBody).byteLength,
+						sha256: await sha256Hex(previousIndexBody),
+					},
+				},
+				artifactsIndex: {
+					objectKey: `${sealedFullPrefix('2026-07-22')}artifacts-index.json`,
+					bytes: 0,
+					sha256: 'c'.repeat(64),
+				},
+				sealedAt: '2026-07-22T06:30:00.000Z',
+				buildCommit: 'abcdef1',
+				signing: { algorithm: 'Ed25519', keyId: 'test-key' },
+			},
+			signature: {
+				algorithm: 'Ed25519',
+				keyId: 'test-key',
+				value: 'test-signature',
+			},
+		}),
+	)
+	const get = vi.fn(async (key: string) => {
+		const bytes =
+			key === 'unchanged'
+				? unchangedBytes
+				: key === 'changed'
+					? changedBytes
+					: null
+		if (!bytes) return null
+		return {
+			arrayBuffer: async () =>
+				bytes.buffer.slice(
+					bytes.byteOffset,
+					bytes.byteOffset + bytes.byteLength,
+				),
+		}
+	})
+	const emailBucket = {
+		async list() {
+			return {
+				objects: [
+					{
+						key: 'unchanged',
+						size: unchangedBytes.byteLength,
+						uploaded,
+						etag: 'etag-unchanged',
+					},
+					{
+						key: 'changed',
+						size: changedBytes.byteLength,
+						uploaded,
+						etag: 'etag-now',
+					},
+				],
+				truncated: false,
+				cursor: '',
+			}
+		},
+		get,
+	} as unknown as R2Bucket
+	const env = {
+		DR_EXPORT_ENABLED: 'true',
+		DR_BACKUP_ACCOUNT_ID: 'acct',
+		DR_BACKUP_BUCKET_NAME: 'bucket',
+		DR_BACKUP_ACCESS_KEY_ID: 'key',
+		DR_BACKUP_SECRET_ACCESS_KEY: 'secret',
+		APP_DB: createDb({}),
+		EMAIL_BLOBS: emailBucket,
+		COMMUNITY_ASSETS: createR2({}),
+		BUNDLE_ARTIFACTS_KV: { get: async () => null },
+		STORAGE_RUNNER: {},
+	} as unknown as Env
+
+	const result = await runDrExportTick({
+		env,
+		now: new Date('2026-07-23T01:00:00.000Z'),
+		timeBudgetMs: 60_000,
+		s3: client,
+	})
+	expect(result.summaryWritten).toBe(true)
+	expect(get).toHaveBeenCalledTimes(1)
+	expect(get).toHaveBeenCalledWith('changed')
+	const currentIndex = (await client.getText(
+		stagingR2IndexKey('2026-07-23', 'email-blobs'),
+	))!.text
+	const entries = currentIndex
+		.trim()
+		.split('\n')
+		.map((line) => JSON.parse(line) as { key: string; sha256: string })
+	expect(entries).toEqual([
+		expect.objectContaining({ key: 'unchanged', sha256: unchangedDigest }),
+		expect.objectContaining({
+			key: 'changed',
+			sha256: await sha256Hex(changedBytes),
+		}),
+	])
 })
 
 test('DR inventory includes registry buckets and package_service_states services', async () => {
@@ -715,22 +910,35 @@ test('watchdog passes on a written summary and fails loudly on an incomplete nig
 		'staging/2026-07-23/exporter/progress.json',
 		new TextEncoder().encode(
 			JSON.stringify({
-				schemaVersion: 1,
+				schemaVersion: 2,
 				day: '2026-07-23',
 				startedAt: '2026-07-23T00:30:00.000Z',
 				phase: 'artifacts',
 				revision: 42,
+				leaseId: null,
+				leaseExpiresAt: null,
 				storageIndex: 10,
 				storagePageStartAfter: null,
-				storagePartialNdjson: '',
+				storagePartialIdentity: null,
+				storageDumpChunkCount: 0,
+				storageDumpChunkHead: null,
 				storagePartialEntryCount: 0,
-				storageEntries: [],
+				storagePartialBytes: 0,
+				storageEntryChunkCount: 0,
+				storageEntryChunkHead: null,
+				storagePendingEntries: [],
 				r2LabelIndex: 2,
 				r2ListCursor: null,
-				r2PartialNdjson: '',
+				r2ChunkCount: 0,
+				r2ChunkHead: null,
+				r2FinalPageReady: false,
 				r2Completed: {},
+				previousSealedDayResolved: true,
+				previousSealedDay: null,
 				artifactsIndex: 7,
-				artifactEntries: [],
+				artifactEntryChunkCount: 0,
+				artifactEntryChunkHead: null,
+				artifactPendingEntries: [],
 				blobsWritten: 0,
 				blobsReused: 0,
 				warnings: [],

--- a/packages/worker/src/dr/exporter.ts
+++ b/packages/worker/src/dr/exporter.ts
@@ -11,16 +11,13 @@ import {
 	type ArtifactsIndex,
 	type ArtifactsIndexEntry,
 	type BackupR2BucketLabel,
-	type R2IndexEntry,
 	type StagingFileSummary,
 	type StagingSummary,
 	type StorageDumpEntry,
 	type StorageIndex,
 	type StorageIndexEntry,
 } from '@kody-internal/shared/backup-staging.ts'
-import { buildPackageServiceStorageId } from '#worker/package-runtime/package-service.ts'
 import { buildPublishedSourceSnapshotKvKey } from '#worker/package-runtime/published-runtime-artifacts.ts'
-import { listPlatformStorageBuckets } from '#worker/storage-buckets/service.ts'
 import { storageRunnerRpc } from '#worker/storage-runner.ts'
 import {
 	createDrBackupS3Client,
@@ -29,15 +26,46 @@ import {
 	type DrBackupS3Client,
 } from '#worker/dr/backup-s3.ts'
 import { sha256Hex } from '#worker/dr/sha256.ts'
-import { encodeStorageIdentity } from '#worker/dr/storage-identity.ts'
+import {
+	loadPreviousR2Index,
+	putImmutableOutput,
+	putLinkedChunk,
+	readLinkedChunkBody,
+	readLinkedChunkEntries,
+	resolvePreviousSealedDay,
+	stagingChunkKey,
+	stagingR2IndexChunkKey,
+	stagingStorageDumpChunkKey,
+	type IncrementalR2IndexEntry,
+} from '#worker/dr/exporter-staging.ts'
+import {
+	listPlatformArtifactInventory,
+	listPlatformStorageInventory,
+	type ArtifactInventoryEntry,
+	type StorageInventoryEntry,
+} from '#worker/dr/exporter-inventory.ts'
+import {
+	isDrExportConfigured,
+	shouldRunDrExportCron,
+} from '#worker/dr/exporter-schedule.ts'
+
+export { listPlatformStorageInventory } from '#worker/dr/exporter-inventory.ts'
+export {
+	isDrExportConfigured,
+	shouldRunDrExportCron,
+	shouldRunDrExportWatchdogCron,
+} from '#worker/dr/exporter-schedule.ts'
 
 export const drExportRunTimeBudgetMs = 20_000
 /** Skip individual R2 objects larger than this (full-buffer ceiling). */
 export const drExportMaxObjectBytes = 25 * 1024 * 1024
-/** Cap for in-progress storage NDJSON carried inside progress.json. */
+/** Cap for an assembled storage dump before it is admitted to the index. */
 export const drExportMaxStorageDumpBufferBytes = 16 * 1024 * 1024
 const storageExportPageSize = 250
-const exporterProgressSchemaVersion = 1 as const
+const indexChunkEntryLimit = 100
+const previousSealedDayLookbackDays = 35
+const progressLeaseDurationMs = 2 * 60_000
+const exporterProgressSchemaVersion = 2 as const
 
 export type DrExporterPhase =
 	| 'storage'
@@ -53,6 +81,8 @@ export type DrExporterProgress = {
 	phase: DrExporterPhase
 	/** Monotonic counter bumped on every progress persist. */
 	revision: number
+	leaseId: string | null
+	leaseExpiresAt: string | null
 	/**
 	 * Count of storage identities completed or skipped. The inventory is
 	 * re-listed every tick and can drift mid-run (jobs registering new
@@ -71,18 +101,29 @@ export type DrExporterProgress = {
 	 * identity resets the partial state.
 	 */
 	storagePartialIdentity?: string | null
-	/** Accumulated NDJSON for the in-progress storage dump (resumed pages). */
-	storagePartialNdjson: string
+	/** Number of page chunks written for the in-progress storage dump. */
+	storageDumpChunkCount: number
+	storageDumpChunkHead: string | null
 	storagePartialEntryCount: number
-	storageEntries: Array<StorageIndexEntry>
+	storagePartialBytes: number
+	storageEntryChunkCount: number
+	storageEntryChunkHead: string | null
+	/** Bounded tail; full chunks live under exporter/chunks/storage-index/. */
+	storagePendingEntries: Array<StorageIndexEntry>
 	/** Index into backupR2BucketLabels. */
 	r2LabelIndex: number
 	r2ListCursor: string | null
-	/** Accumulated NDJSON for the in-progress R2 bucket index. */
-	r2PartialNdjson: string
+	r2ChunkCount: number
+	r2ChunkHead: string | null
+	r2FinalPageReady: boolean
 	r2Completed: Partial<Record<BackupR2BucketLabel, StagingFileSummary>>
+	previousSealedDayResolved: boolean
+	previousSealedDay: string | null
 	artifactsIndex: number
-	artifactEntries: Array<ArtifactsIndexEntry>
+	artifactEntryChunkCount: number
+	artifactEntryChunkHead: string | null
+	/** Bounded tail; full chunks live under exporter/chunks/artifacts-index/. */
+	artifactPendingEntries: Array<ArtifactsIndexEntry>
 	blobsWritten: number
 	blobsReused: number
 	warnings: Array<string>
@@ -109,20 +150,6 @@ export type DrExportTickResult = {
 	summaryWritten: boolean
 }
 
-type StorageInventoryEntry = {
-	userId: string
-	storageId: string
-	identity: string
-}
-
-type ArtifactInventoryEntry = {
-	sourceId: string
-	userId: string
-	entityKind: string
-	entityId: string
-	publishedCommit: string
-}
-
 function stagingProgressKey(day: string) {
 	return `${stagingPrefix(day)}exporter/progress.json`
 }
@@ -135,48 +162,6 @@ function utf8ByteLength(value: string) {
 	return new TextEncoder().encode(value).byteLength
 }
 
-/**
- * Nightly DR export window: roughly 00:30–06:10 UTC on the worker's
- * every-5-minute cron (~68 ticks × 20 s ≈ 22 minutes of staging work).
- * Ticks outside this window are skipped so daytime traffic is not competing
- * with a full-platform export. The original 00:30–02:10 window never
- * finished a night's staging at production scale (the exporter was still in
- * the artifacts phase every day), so no `exporter/summary.json` was ever
- * written and no day could be sealed. Completed days exit cheaply via the
- * `already-complete` check.
- */
-export function shouldRunDrExportCron(now: Date) {
-	const minutes = now.getUTCHours() * 60 + now.getUTCMinutes()
-	return minutes >= 30 && minutes <= 6 * 60 + 10
-}
-
-/**
- * One cron tick after the export window closes (06:15–06:19 UTC). The
- * watchdog fails loudly (lane failure → Sentry) when the night's staging
- * summary is missing, because the exporter itself never errors when it
- * merely runs out of window.
- */
-export function shouldRunDrExportWatchdogCron(now: Date) {
-	const minutes = now.getUTCHours() * 60 + now.getUTCMinutes()
-	return minutes >= 6 * 60 + 15 && minutes < 6 * 60 + 20
-}
-
-export function isDrExportConfigured(
-	env: Pick<
-		Env,
-		| 'DR_EXPORT_ENABLED'
-		| 'DR_BACKUP_ACCOUNT_ID'
-		| 'DR_BACKUP_BUCKET_NAME'
-		| 'DR_BACKUP_ACCESS_KEY_ID'
-		| 'DR_BACKUP_SECRET_ACCESS_KEY'
-	>,
-) {
-	return (
-		env.DR_EXPORT_ENABLED?.trim() === 'true' &&
-		readDrBackupS3Config(env) !== null
-	)
-}
-
 function createInitialProgress(day: string, now: Date): DrExporterProgress {
 	return {
 		schemaVersion: exporterProgressSchemaVersion,
@@ -184,18 +169,30 @@ function createInitialProgress(day: string, now: Date): DrExporterProgress {
 		startedAt: now.toISOString(),
 		phase: 'storage',
 		revision: 0,
+		leaseId: null,
+		leaseExpiresAt: null,
 		storageIndex: 0,
 		storagePageStartAfter: null,
 		storagePartialIdentity: null,
-		storagePartialNdjson: '',
+		storageDumpChunkCount: 0,
+		storageDumpChunkHead: null,
 		storagePartialEntryCount: 0,
-		storageEntries: [],
+		storagePartialBytes: 0,
+		storageEntryChunkCount: 0,
+		storageEntryChunkHead: null,
+		storagePendingEntries: [],
 		r2LabelIndex: 0,
 		r2ListCursor: null,
-		r2PartialNdjson: '',
+		r2ChunkCount: 0,
+		r2ChunkHead: null,
+		r2FinalPageReady: false,
 		r2Completed: {},
+		previousSealedDayResolved: false,
+		previousSealedDay: null,
 		artifactsIndex: 0,
-		artifactEntries: [],
+		artifactEntryChunkCount: 0,
+		artifactEntryChunkHead: null,
+		artifactPendingEntries: [],
 		blobsWritten: 0,
 		blobsReused: 0,
 		warnings: [],
@@ -242,82 +239,40 @@ function ndjsonLine(value: unknown) {
 	return `${JSON.stringify(value)}\n`
 }
 
-/**
- * Platform-wide StorageRunner inventory.
- *
- * Deliberate exception to per-user scoping: this operator-level DR exporter
- * iterates every user's storage ids so the sealed day can rebuild the whole
- * platform. Do not copy this pattern into user-facing read/write paths.
- */
-export async function listPlatformStorageInventory(
-	db: D1Database,
-): Promise<Array<StorageInventoryEntry>> {
-	// Platform-wide DR has only a D1Database (no per-user Env / network), so
-	// service buckets come from projected `package_service_states` rather than
-	// package manifests. Ad-hoc / execute buckets come from the authoritative
-	// `user_storage_buckets` registry via `listPlatformStorageBuckets`.
-	const [jobRows, archivedRows, registeredBuckets, serviceRows] =
-		await Promise.all([
-			db
-				.prepare(
-					`SELECT user_id AS userId, storage_id AS storageId
-					FROM jobs WHERE storage_id IS NOT NULL`,
-				)
-				.all<{ userId: string; storageId: string }>(),
-			db
-				.prepare(
-					`SELECT user_id AS userId, storage_id AS storageId
-					FROM archived_job_artifacts WHERE storage_id IS NOT NULL`,
-				)
-				.all<{ userId: string; storageId: string }>(),
-			listPlatformStorageBuckets({ db }),
-			db
-				.prepare(
-					`SELECT DISTINCT user_id AS userId, package_id AS packageId,
-						service_name AS serviceName
-					FROM package_service_states`,
-				)
-				.all<{
-					userId: string
-					packageId: string
-					serviceName: string
-				}>(),
-		])
-
-	const seen = new Set<string>()
-	const inventory: Array<StorageInventoryEntry> = []
-	const push = (userId: string, storageId: string) => {
-		const identity = encodeStorageIdentity(userId, storageId)
-		if (seen.has(identity)) return
-		seen.add(identity)
-		inventory.push({ userId, storageId, identity })
-	}
-	for (const row of jobRows.results ?? []) push(row.userId, row.storageId)
-	for (const row of archivedRows.results ?? []) push(row.userId, row.storageId)
-	for (const row of registeredBuckets) push(row.userId, row.storageId)
-	for (const row of serviceRows.results ?? []) {
-		push(
-			row.userId,
-			buildPackageServiceStorageId(row.packageId, row.serviceName),
-		)
-	}
-	inventory.sort((left, right) => left.identity.localeCompare(right.identity))
-	return inventory
+function ndjsonEntryCount(body: string) {
+	return body.split('\n').filter(Boolean).length
 }
 
-export async function listPlatformArtifactInventory(
-	db: D1Database,
-): Promise<Array<ArtifactInventoryEntry>> {
-	const result = await db
-		.prepare(
-			`SELECT id AS sourceId, user_id AS userId, entity_kind AS entityKind,
-				entity_id AS entityId, published_commit AS publishedCommit
-			FROM entity_sources
-			WHERE published_commit IS NOT NULL AND trim(published_commit) != ''
-			ORDER BY id ASC`,
-		)
-		.all<ArtifactInventoryEntry>()
-	return result.results ?? []
+async function flushStorageEntryChunk(input: {
+	s3: DrBackupS3Client
+	progress: DrExporterProgress
+}) {
+	if (input.progress.storagePendingEntries.length === 0) return
+	const body = input.progress.storagePendingEntries.map(ndjsonLine).join('')
+	input.progress.storageEntryChunkHead = await putLinkedChunk({
+		s3: input.s3,
+		keyPrefix: stagingChunkKey(input.progress.day, 'storage-index'),
+		entriesBody: body,
+		previousKey: input.progress.storageEntryChunkHead,
+	})
+	input.progress.storageEntryChunkCount += 1
+	input.progress.storagePendingEntries = []
+}
+
+async function flushArtifactEntryChunk(input: {
+	s3: DrBackupS3Client
+	progress: DrExporterProgress
+}) {
+	if (input.progress.artifactPendingEntries.length === 0) return
+	const body = input.progress.artifactPendingEntries.map(ndjsonLine).join('')
+	input.progress.artifactEntryChunkHead = await putLinkedChunk({
+		s3: input.s3,
+		keyPrefix: stagingChunkKey(input.progress.day, 'artifacts-index'),
+		entriesBody: body,
+		previousKey: input.progress.artifactEntryChunkHead,
+	})
+	input.progress.artifactEntryChunkCount += 1
+	input.progress.artifactPendingEntries = []
 }
 
 async function putBlobIfAbsent(input: {
@@ -361,6 +316,11 @@ function r2BindingForLabel(
  * on PutObject (412 PreconditionFailed on conflict).
  */
 async function persistProgress(s3: DrBackupS3Client, session: ProgressSession) {
+	if (session.progress.leaseId) {
+		session.progress.leaseExpiresAt = new Date(
+			Date.now() + progressLeaseDurationMs,
+		).toISOString()
+	}
 	session.progress.revision += 1
 	const body = JSON.stringify(session.progress)
 	const key = stagingProgressKey(session.progress.day)
@@ -402,8 +362,10 @@ const oversizedStorageDumpWarningPrefix = 'storage dump too large: '
 function resetPartialStorageState(progress: DrExporterProgress) {
 	progress.storagePageStartAfter = null
 	progress.storagePartialIdentity = null
-	progress.storagePartialNdjson = ''
+	progress.storageDumpChunkCount = 0
+	progress.storageDumpChunkHead = null
 	progress.storagePartialEntryCount = 0
+	progress.storagePartialBytes = 0
 }
 
 function skipOversizedStorageDump(
@@ -415,11 +377,20 @@ function skipOversizedStorageDump(
 	resetPartialStorageState(progress)
 }
 
-function collectHandledStorageIdentities(progress: DrExporterProgress) {
-	const handled = new Set(
-		progress.storageEntries.map((entry) => entry.storageId),
-	)
-	for (const warning of progress.warnings) {
+async function collectHandledStorageIdentities(input: {
+	s3: DrBackupS3Client
+	progress: DrExporterProgress
+}) {
+	const chunkEntries = await readLinkedChunkEntries<StorageIndexEntry>({
+		s3: input.s3,
+		headKey: input.progress.storageEntryChunkHead,
+		chunkCount: input.progress.storageEntryChunkCount,
+	})
+	const handled = new Set([
+		...chunkEntries.map((entry) => entry.storageId),
+		...input.progress.storagePendingEntries.map((entry) => entry.storageId),
+	])
+	for (const warning of input.progress.warnings) {
 		if (warning.startsWith(oversizedStorageDumpWarningPrefix)) {
 			handled.add(warning.slice(oversizedStorageDumpWarningPrefix.length))
 		}
@@ -443,12 +414,22 @@ async function exportStoragePhase(input: {
 	// which shifts positions in the sorted list. A positional cursor then
 	// dumps the same identity twice — producing duplicate storage-index
 	// entries that later wedge sealing — or silently skips identities.
-	const handledIdentities = collectHandledStorageIdentities(progress)
+	const handledIdentities = await collectHandledStorageIdentities({
+		s3,
+		progress,
+	})
+	let inventoryIndex = 0
 	for (;;) {
 		if (Date.now() - input.startedAtMs >= input.timeBudgetMs) return true
-		const item = inventory.find(
-			(candidate) => !handledIdentities.has(candidate.identity),
-		)
+		let item: StorageInventoryEntry | undefined
+		while (inventoryIndex < inventory.length) {
+			const candidate = inventory[inventoryIndex]!
+			inventoryIndex += 1
+			if (!handledIdentities.has(candidate.identity)) {
+				item = candidate
+				break
+			}
+		}
 		if (!item) break
 		if (progress.storagePartialIdentity !== item.identity) {
 			// The persisted partial page state belongs to a different (drifted)
@@ -464,16 +445,18 @@ async function exportStoragePhase(input: {
 			pageSize: storageExportPageSize,
 			startAfter: progress.storagePageStartAfter,
 		})
+		let pageBody = ''
 		for (const entry of page.entries) {
 			const dumpEntry = {
 				key: entry.key,
 				valueJson: JSON.stringify(entry.value),
 			} satisfies StorageDumpEntry
-			progress.storagePartialNdjson += ndjsonLine(dumpEntry)
+			pageBody += ndjsonLine(dumpEntry)
 			progress.storagePartialEntryCount += 1
 		}
+		const pageBytes = utf8ByteLength(pageBody)
 		if (
-			utf8ByteLength(progress.storagePartialNdjson) >
+			progress.storagePartialBytes + pageBytes >
 			drExportMaxStorageDumpBufferBytes
 		) {
 			skipOversizedStorageDump(progress, item.identity)
@@ -481,28 +464,51 @@ async function exportStoragePhase(input: {
 			await persistProgress(s3, session)
 			continue
 		}
+		if (pageBody.length > 0) {
+			progress.storageDumpChunkHead = await putLinkedChunk({
+				s3,
+				keyPrefix: stagingStorageDumpChunkKey(progress.day, item.identity),
+				entriesBody: pageBody,
+				previousKey: progress.storageDumpChunkHead,
+			})
+			progress.storageDumpChunkCount += 1
+			progress.storagePartialBytes += pageBytes
+		}
 		if (page.truncated && page.nextStartAfter) {
 			progress.storagePageStartAfter = page.nextStartAfter
 			await persistProgress(s3, session)
 			continue
 		}
 		const objectKey = stagingStorageDumpKey(progress.day, item.identity)
-		const body = progress.storagePartialNdjson
-		await s3.put(objectKey, body, { contentType: 'application/x-ndjson' })
-		const summary = await fileSummary(objectKey, body)
-		progress.storageEntries.push({
+		const body = await readLinkedChunkBody({
+			s3,
+			headKey: progress.storageDumpChunkHead,
+			chunkCount: progress.storageDumpChunkCount,
+		})
+		const storedBody = await putImmutableOutput({
+			s3,
+			key: objectKey,
+			body,
+			contentType: 'application/x-ndjson',
+		})
+		const summary = await fileSummary(objectKey, storedBody)
+		progress.storagePendingEntries.push({
 			storageId: item.identity,
 			objectKey,
-			entryCount: progress.storagePartialEntryCount,
+			entryCount: ndjsonEntryCount(storedBody),
 			bytes: summary.bytes,
 			sha256: summary.sha256,
 		})
+		if (progress.storagePendingEntries.length >= indexChunkEntryLimit) {
+			await flushStorageEntryChunk({ s3, progress })
+		}
 		handledIdentities.add(item.identity)
 		progress.storageIndex += 1
 		resetPartialStorageState(progress)
 		input.counts.storageDumpsCompleted += 1
 		await persistProgress(s3, session)
 	}
+	await flushStorageEntryChunk({ s3, progress })
 	progress.phase = 'r2'
 	await persistProgress(s3, session)
 	return false
@@ -518,57 +524,121 @@ async function exportR2Phase(input: {
 }): Promise<boolean> {
 	const { session, s3, env } = input
 	const { progress } = session
+	if (!progress.previousSealedDayResolved) {
+		progress.previousSealedDay = await resolvePreviousSealedDay({
+			s3,
+			day: progress.day,
+			lookbackDays: previousSealedDayLookbackDays,
+		})
+		progress.previousSealedDayResolved = true
+		await persistProgress(s3, session)
+	}
 	while (progress.r2LabelIndex < backupR2BucketLabels.length) {
-		if (Date.now() - input.startedAtMs >= input.timeBudgetMs) return true
 		const label = backupR2BucketLabels[progress.r2LabelIndex]!
 		const bucket = r2BindingForLabel(env, label)
-		const listed = await bucket.list({
-			cursor: progress.r2ListCursor ?? undefined,
-			limit: 100,
-		})
-		// Finish the whole list page before checking the tick budget. Persisting
-		// mid-page without advancing r2ListCursor would re-append the same
-		// NDJSON index lines on the next tick. List pages are bounded (≤100).
-		for (const object of listed.objects) {
-			if (object.size > drExportMaxObjectBytes) {
-				progress.warnings.push(
-					`Skipped ${label} object ${object.key}: size ${object.size} exceeds ${drExportMaxObjectBytes} bytes`,
-				)
-				input.counts.r2ObjectsProcessed += 1
-				continue
+		if (!progress.r2FinalPageReady) {
+			const previousEntries = await loadPreviousR2Index({
+				s3,
+				day: progress.previousSealedDay,
+				label,
+			})
+			for (;;) {
+				if (Date.now() - input.startedAtMs >= input.timeBudgetMs) return true
+				const listed = await bucket.list({
+					cursor: progress.r2ListCursor ?? undefined,
+					limit: 100,
+				})
+				// Finish the whole list page before checking the tick budget.
+				// Persisting mid-page without advancing r2ListCursor would replay
+				// its index lines. List pages are bounded (≤100).
+				let pageIndexBody = ''
+				for (const object of listed.objects) {
+					if (object.size > drExportMaxObjectBytes) {
+						progress.warnings.push(
+							`Skipped ${label} object ${object.key}: size ${object.size} exceeds ${drExportMaxObjectBytes} bytes`,
+						)
+						input.counts.r2ObjectsProcessed += 1
+						continue
+					}
+					const uploaded = object.uploaded.toISOString()
+					const previous = previousEntries.get(object.key)
+					if (
+						previous &&
+						previous.size === object.size &&
+						previous.etag === object.etag &&
+						previous.uploaded === uploaded &&
+						(await s3.head(backupBlobKey(previous.sha256))).exists
+					) {
+						const indexEntry = {
+							key: object.key,
+							size: object.size,
+							sha256: previous.sha256,
+							etag: object.etag,
+							uploaded,
+						} satisfies IncrementalR2IndexEntry
+						pageIndexBody += ndjsonLine(indexEntry)
+						progress.blobsReused += 1
+						input.counts.r2ObjectsProcessed += 1
+						continue
+					}
+					const body = await bucket.get(object.key)
+					if (!body) {
+						progress.warnings.push(
+							`Missing ${label} object during export: ${object.key}`,
+						)
+						input.counts.r2ObjectsProcessed += 1
+						continue
+					}
+					const bytes = new Uint8Array(await body.arrayBuffer())
+					const digest = await sha256Hex(bytes)
+					await putBlobIfAbsent({ s3, sha256: digest, bytes, progress })
+					const indexEntry = {
+						key: object.key,
+						size: bytes.byteLength,
+						sha256: digest,
+						etag: object.etag,
+						uploaded,
+					} satisfies IncrementalR2IndexEntry
+					pageIndexBody += ndjsonLine(indexEntry)
+					input.counts.r2ObjectsProcessed += 1
+				}
+				if (pageIndexBody.length > 0) {
+					progress.r2ChunkHead = await putLinkedChunk({
+						s3,
+						keyPrefix: stagingR2IndexChunkKey(progress.day, label),
+						entriesBody: pageIndexBody,
+						previousKey: progress.r2ChunkHead,
+					})
+					progress.r2ChunkCount += 1
+				}
+				if (listed.truncated) {
+					progress.r2ListCursor = listed.cursor
+					await persistProgress(s3, session)
+					continue
+				}
+				progress.r2FinalPageReady = true
+				await persistProgress(s3, session)
+				break
 			}
-			const body = await bucket.get(object.key)
-			if (!body) {
-				progress.warnings.push(
-					`Missing ${label} object during export: ${object.key}`,
-				)
-				input.counts.r2ObjectsProcessed += 1
-				continue
-			}
-			const bytes = new Uint8Array(await body.arrayBuffer())
-			const digest = await sha256Hex(bytes)
-			await putBlobIfAbsent({ s3, sha256: digest, bytes, progress })
-			const indexEntry = {
-				key: object.key,
-				size: bytes.byteLength,
-				sha256: digest,
-			} satisfies R2IndexEntry
-			progress.r2PartialNdjson += ndjsonLine(indexEntry)
-			input.counts.r2ObjectsProcessed += 1
-		}
-		if (listed.truncated) {
-			progress.r2ListCursor = listed.cursor
-			await persistProgress(s3, session)
-			if (Date.now() - input.startedAtMs >= input.timeBudgetMs) return true
-			continue
 		}
 		const objectKey = stagingR2IndexKey(progress.day, label)
-		const body = progress.r2PartialNdjson
-		await s3.put(objectKey, body, { contentType: 'application/x-ndjson' })
-		progress.r2Completed[label] = await fileSummary(objectKey, body)
+		const body = await readLinkedChunkBody({
+			s3,
+			headKey: progress.r2ChunkHead,
+			chunkCount: progress.r2ChunkCount,
+		})
+		const storedBody = await putImmutableOutput({
+			s3,
+			key: objectKey,
+			body,
+			contentType: 'application/x-ndjson',
+		})
+		progress.r2Completed[label] = await fileSummary(objectKey, storedBody)
 		progress.r2LabelIndex += 1
 		progress.r2ListCursor = null
-		progress.r2PartialNdjson = ''
+		progress.r2ChunkCount = 0
+		progress.r2ChunkHead = null
+		progress.r2FinalPageReady = false
 		await persistProgress(s3, session)
 	}
 	progress.phase = 'artifacts'
@@ -607,7 +677,7 @@ async function exportArtifactsPhase(input: {
 		const bytes = new TextEncoder().encode(snapshotText)
 		const digest = await sha256Hex(bytes)
 		await putBlobIfAbsent({ s3, sha256: digest, bytes, progress })
-		progress.artifactEntries.push({
+		progress.artifactPendingEntries.push({
 			sourceId: item.sourceId,
 			entityKind: item.entityKind,
 			entityId: item.entityId,
@@ -615,10 +685,14 @@ async function exportArtifactsPhase(input: {
 			publishedCommit: item.publishedCommit,
 			snapshotSha256: digest,
 		})
+		if (progress.artifactPendingEntries.length >= indexChunkEntryLimit) {
+			await flushArtifactEntryChunk({ s3, progress })
+		}
 		progress.artifactsIndex += 1
 		input.counts.artifactsProcessed += 1
 		await persistProgress(s3, session)
 	}
+	await flushArtifactEntryChunk({ s3, progress })
 	progress.phase = 'finalize'
 	await persistProgress(s3, session)
 	return false
@@ -632,29 +706,48 @@ async function finalizeExport(input: {
 }): Promise<StagingSummary> {
 	const { session, s3, env, now } = input
 	const { progress } = session
+	const storageEntries = await readLinkedChunkEntries<StorageIndexEntry>({
+		s3,
+		headKey: progress.storageEntryChunkHead,
+		chunkCount: progress.storageEntryChunkCount,
+	})
 	const storageIndexBody = JSON.stringify({
 		schemaVersion: backupStagingSchemaVersion,
 		day: progress.day,
-		entries: progress.storageEntries,
+		entries: storageEntries,
 	} satisfies StorageIndex)
 	const storageIndexKey = stagingStorageIndexKey(progress.day)
-	await s3.put(storageIndexKey, storageIndexBody, {
+	const storedStorageIndexBody = await putImmutableOutput({
+		s3,
+		key: storageIndexKey,
+		body: storageIndexBody,
 		contentType: 'application/json',
 	})
-	const storageIndex = await fileSummary(storageIndexKey, storageIndexBody)
+	const storageIndex = await fileSummary(
+		storageIndexKey,
+		storedStorageIndexBody,
+	)
 
+	const artifactEntries = await readLinkedChunkEntries<ArtifactsIndexEntry>({
+		s3,
+		headKey: progress.artifactEntryChunkHead,
+		chunkCount: progress.artifactEntryChunkCount,
+	})
 	const artifactsIndexBody = JSON.stringify({
 		schemaVersion: backupStagingSchemaVersion,
 		day: progress.day,
-		entries: progress.artifactEntries,
+		entries: artifactEntries,
 	} satisfies ArtifactsIndex)
 	const artifactsIndexKey = stagingArtifactsIndexKey(progress.day)
-	await s3.put(artifactsIndexKey, artifactsIndexBody, {
+	const storedArtifactsIndexBody = await putImmutableOutput({
+		s3,
+		key: artifactsIndexKey,
+		body: artifactsIndexBody,
 		contentType: 'application/json',
 	})
 	const artifactsIndex = await fileSummary(
 		artifactsIndexKey,
-		artifactsIndexBody,
+		storedArtifactsIndexBody,
 	)
 
 	const summary: StagingSummary = {
@@ -670,7 +763,10 @@ async function finalizeExport(input: {
 		blobsReused: progress.blobsReused,
 		warnings: progress.warnings,
 	}
-	await s3.put(stagingSummaryKey(progress.day), JSON.stringify(summary), {
+	await putImmutableOutput({
+		s3,
+		key: stagingSummaryKey(progress.day),
+		body: JSON.stringify(summary),
 		contentType: 'application/json',
 	})
 	progress.phase = 'done'
@@ -728,6 +824,17 @@ export async function runDrExportTick(input: {
 	let timeBudgetExhausted = false
 
 	try {
+		const leaseExpiresAtMs = Date.parse(progress.leaseExpiresAt ?? '')
+		if (
+			progress.leaseId &&
+			Number.isFinite(leaseExpiresAtMs) &&
+			leaseExpiresAtMs > Date.now()
+		) {
+			return empty('progress-lease-active')
+		}
+		progress.leaseId = crypto.randomUUID()
+		await persistProgress(s3, session)
+
 		if (progress.phase === 'storage') {
 			const inventory = await listPlatformStorageInventory(input.env.APP_DB)
 			timeBudgetExhausted = await exportStoragePhase({
@@ -767,6 +874,9 @@ export async function runDrExportTick(input: {
 			await finalizeExport({ env: input.env, s3, session, now })
 			summaryWritten = true
 		}
+		progress.leaseId = null
+		progress.leaseExpiresAt = null
+		await persistProgress(s3, session)
 
 		const result: DrExportTickResult = {
 			day,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #1069

## Conductor report

### What changed
- Replaced unbounded phase-entry arrays and partial NDJSON in `progress.json` with bounded tails plus content-addressed linked NDJSON chunks. Progress now carries cursors, counts, chain heads, and a short conditional-write lease.
- Made canonical per-day dumps, indexes, and completion summaries create-only so stale or resumed writers adopt complete objects rather than overwrite them.
- Reuses R2 entries when key, size, ETag, and uploaded timestamp match the latest retained sealed-day index and the referenced content-addressed blob still exists. Missing or invalid prior indexes fall back to download, SHA-256, and conditional blob dedupe.
- Preserved final storage/R2/artifact index shapes, checksum summaries, identity-driven storage resume, watchdog behavior, and downstream Ed25519 sealing/restore contracts.

### Verification
- Rebased onto current `main`; all PR checks pass: Static, Node, Workers, MCP, Playwright E2E, preview resources, and aggregate Validate.
- Local `npm run validate` passed before rebase. The post-rebase run hit three unrelated timeout flakes under parallel contention; each timed-out Node, MCP, and Playwright case passed sequentially, and split CI passed the same suites on the rebased commit.
- Focused exporter suite passes 9 tests, including interrupted resume, inventory drift, orphaned-chunk recovery, R2 page resume, and unchanged-R2 reuse.
- Two independent final reviews found no merge-blocking correctness or maintainability issues.

### Residual risk
- The exporter verifies the prior sealed manifest shape and referenced-index checksum, but does not independently verify its Ed25519 signature because the production Worker has no manifest verifying-key binding. The `daily/full` source is immutable bucket-locked, and control-plane seal/restore paths continue to verify signatures.
- This changes DR staging/resume mechanics. Kent should validate the first production sealed day and run a manual isolated restore drill before treating the new lane as proven. Spot-check that unchanged email/community blobs avoid source GETs while changed blobs remain restorable.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `bfe039aa` · **Head:** `0f5b5384`

**Classification:** extends — changes the production backup control plane's staging, resume, and incremental R2 behavior without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | extends — chunked phase state, fenced resume, differential R2 capture |
| `durable-storage` | assistant | context — StorageRunner inventory and dumps retain their existing contract |

### System map

Nightly capture reads canonical storage through the backup exporter, stages resumable chunks, and preserves the sealed-day contract.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	durableStorage["durable-storage<br/>Durable storage buckets"]:::untouched
	backupControlPlane["backup-control-plane<br/>Production backup control plane"]:::extended
	durableStorage -->|"identity-scoped exportStorage pages"| backupControlPlane
	backupControlPlane -->|"chunk heads, checksummed indexes, immutable summary"| backupControlPlane
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cron as Nightly exporter
	participant Source as StorageRunner / source R2
	participant DR as DR staging bucket
	participant Seal as Sealing control plane
	Cron->>DR: acquire conditional progress lease
	Cron->>Source: list page / export identity
	Cron->>DR: append content-addressed NDJSON chunk
	Cron->>DR: persist cursor, count, and chain head
	Cron->>DR: materialize create-only canonical indexes + summary
	Seal->>DR: verify checksums, blobs, and signed full manifest
```

### Invariants

- Storage identities remain user-namespaced and inventory drift remains identity-driven.
- SHA-256 blob addressing and destination existence checks remain fail-safe.
- `exporter/summary.json` remains the final completion marker; the incomplete-night watchdog remains active.
- Sealed-day manifests remain Ed25519-signed and restore consumes the existing final index contracts.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-885f35bf-e604-4e49-9444-2fc62b741cab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-885f35bf-e604-4e49-9444-2fc62b741cab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

