### PR TITLE
Add Grok as an onboarding MCP client

### DIFF
--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -30,8 +30,9 @@ MCP URL and setup prompt.
   Remote servers are not configured through `claude_desktop_config.json`.
 - **Grok** — On [grok.com/connectors](https://grok.com/connectors), click **New
   Connector**, select **Custom**, and paste the MCP URL. Complete OAuth when
-  prompted. On Grok Business and Enterprise, a team admin may need to provision
-  the connector first. See xAI's
+  prompted. For Grok Business and Enterprise, a team admin must first add this
+  custom MCP server in the cloud console; members can then connect it from the
+  Grok connectors page. See xAI's
   [custom MCP connector docs](https://docs.x.ai/grok/connectors).
 - **Claude Code** — `claude mcp add --transport http -s user kody <url>`, or a
   `.mcp.json` entry with `"type": "http"`.

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -1,8 +1,8 @@
 # Connect your agent
 
 Kody is an MCP server. You use it from Cursor, ChatGPT, Codex, Claude Desktop,
-Claude Code, OpenCode, VS Code, or any other AI agent that supports MCP — not
-from a separate Kody chat app.
+Grok, Claude Code, OpenCode, VS Code, or any other AI agent that supports MCP —
+not from a separate Kody chat app.
 
 The in-app Get started page (`/onboarding`) has tabs with client-specific
 instructions and copyable config snippets for the host you are on.
@@ -28,6 +28,11 @@ MCP URL and setup prompt.
   `mcpServers.kody.url` entry into `~/.cursor/mcp.json` / `.cursor/mcp.json`.
 - **Claude Desktop** — Use Settings → Connectors (custom connector + MCP URL).
   Remote servers are not configured through `claude_desktop_config.json`.
+- **Grok** — On [grok.com/connectors](https://grok.com/connectors), click **New
+  Connector**, select **Custom**, and paste the MCP URL. Complete OAuth when
+  prompted. On Grok Business and Enterprise, a team admin may need to provision
+  the connector first. See xAI's
+  [custom MCP connector docs](https://docs.x.ai/grok/connectors).
 - **Claude Code** — `claude mcp add --transport http -s user kody <url>`, or a
   `.mcp.json` entry with `"type": "http"`.
 - **ChatGPT** — On an
@@ -47,10 +52,10 @@ MCP URL and setup prompt.
 
 ### Coding vs non-coding agents
 
-Using Kody packages works great with non-coding agents such as Claude Desktop
-and ChatGPT. For creating or editing packages, a coding agent (Cursor, Claude
-Code, Codex, VS Code, OpenCode, and similar) is usually smoother because those
-hosts can edit files and iterate on code more easily.
+Using Kody packages works great with non-coding agents such as Claude Desktop,
+ChatGPT, and Grok. For creating or editing packages, a coding agent (Cursor,
+Claude Code, Codex, VS Code, OpenCode, and similar) is usually smoother because
+those hosts can edit files and iterate on code more easily.
 
 ## Install a starter or build your own
 

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -194,8 +194,9 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						</a>
 						, click <strong>New Connector</strong>, select{' '}
 						<strong>Custom</strong>, and paste this MCP URL. Complete OAuth when
-						Grok prompts you. On Grok Business and Enterprise, a team admin may
-						need to provision the connector first. See xAI&apos;s{' '}
+						Grok prompts you. For Grok Business and Enterprise, a team admin
+						must first add this custom MCP server in the cloud console. Members
+						can then connect it from the Grok connectors page. See xAI&apos;s{' '}
 						<a
 							href={grokCustomMcpGuideUrl}
 							target="_blank"

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -11,6 +11,8 @@ import {
 	buildVsCodeMcpJson,
 	chatGptDeveloperModeGuideUrl,
 	codingAgentPackageHint,
+	grokConnectorsUrl,
+	grokCustomMcpGuideUrl,
 	type McpClientKind,
 	mcpClientTabs,
 	nonCodingAgentNote,
@@ -168,6 +170,40 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						Customize → Connectors), add a custom connector, and paste this MCP
 						URL. Claude Desktop handles remote OAuth through that UI — do not
 						put the remote URL into <code>claude_desktop_config.json</code>.
+					</p>
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+						variant="primary"
+					/>
+					<ClientNote>{nonCodingAgentNote}</ClientNote>
+				</>
+			)
+		case 'grok':
+			return (
+				<>
+					<p mix={css(descriptionCss)}>
+						In{' '}
+						<a
+							href={grokConnectorsUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Grok.com → Connectors
+						</a>
+						, click <strong>New Connector</strong>, select{' '}
+						<strong>Custom</strong>, and paste this MCP URL. Complete OAuth when
+						Grok prompts you. On Grok Business and Enterprise, a team admin may
+						need to provision the connector first. See xAI&apos;s{' '}
+						<a
+							href={grokCustomMcpGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							custom MCP connector docs
+						</a>{' '}
+						for details.
 					</p>
 					<CopyCard
 						label="MCP URL"

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -8,6 +8,8 @@ import {
 	buildOpenCodeMcpJson,
 	buildVsCodeMcpJson,
 	chatGptDeveloperModeGuideUrl,
+	grokConnectorsUrl,
+	grokCustomMcpGuideUrl,
 	mcpClientTabs,
 } from './onboarding-mcp-clients.ts'
 
@@ -19,6 +21,7 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		'chatgpt',
 		'codex',
 		'claude-desktop',
+		'grok',
 		'claude-code',
 		'opencode',
 		'vscode',
@@ -26,7 +29,7 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	])
 	expect(
 		mcpClientTabs.filter((tab) => tab.isNonCodingAgent).map((tab) => tab.id),
-	).toEqual(['chatgpt', 'claude-desktop'])
+	).toEqual(['chatgpt', 'claude-desktop', 'grok'])
 
 	expect(JSON.parse(buildCursorMcpJson(mcpServerUrl))).toEqual({
 		mcpServers: {
@@ -72,4 +75,6 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	expect(chatGptDeveloperModeGuideUrl).toBe(
 		'https://developers.openai.com/api/docs/guides/developer-mode',
 	)
+	expect(grokConnectorsUrl).toBe('https://grok.com/connectors')
+	expect(grokCustomMcpGuideUrl).toBe('https://docs.x.ai/grok/connectors')
 })

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -8,6 +8,7 @@ export type McpClientKind =
 	| 'chatgpt'
 	| 'codex'
 	| 'claude-desktop'
+	| 'grok'
 	| 'claude-code'
 	| 'opencode'
 	| 'vscode'
@@ -25,6 +26,7 @@ export const mcpClientTabs = [
 	{ id: 'chatgpt', label: 'ChatGPT', isNonCodingAgent: true },
 	{ id: 'codex', label: 'Codex', isNonCodingAgent: false },
 	{ id: 'claude-desktop', label: 'Claude Desktop', isNonCodingAgent: true },
+	{ id: 'grok', label: 'Grok', isNonCodingAgent: true },
 	{ id: 'claude-code', label: 'Claude Code', isNonCodingAgent: false },
 	{ id: 'opencode', label: 'OpenCode', isNonCodingAgent: false },
 	{ id: 'vscode', label: 'VS Code', isNonCodingAgent: false },
@@ -33,6 +35,11 @@ export const mcpClientTabs = [
 
 export const chatGptDeveloperModeGuideUrl =
 	'https://developers.openai.com/api/docs/guides/developer-mode'
+
+/** Grok.com UI for adding a custom remote MCP connector. */
+export const grokConnectorsUrl = 'https://grok.com/connectors'
+
+export const grokCustomMcpGuideUrl = 'https://docs.x.ai/grok/connectors'
 
 /** Square favicon suitable for ChatGPT plugin / connector app icons. */
 export function buildKodyAppIconUrl(mcpServerUrl: string) {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -235,9 +235,9 @@ export function OnboardingRoute(handle: Handle) {
 								<>
 									<p mix={css(descriptionCss)}>
 										Paste this into any AI agent that can fetch a URL or search
-										the web — ChatGPT, Claude, or whatever you already use. It
-										has the agent read Kody&apos;s docs, interview you, and
-										suggest concrete automations. No account or setup needed
+										the web — ChatGPT, Claude, Grok, or whatever you already
+										use. It has the agent read Kody&apos;s docs, interview you,
+										and suggest concrete automations. No account or setup needed
 										yet.
 									</p>
 									<pre mix={css(codeBlockCss)}>{discoveryPrompt}</pre>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Grok.com to the Get started (`/onboarding`) MCP client tabs so users can connect Kody through Grok’s custom connector flow.

## Changes

- New **Grok** tab (non-coding agent) with instructions for [grok.com/connectors](https://grok.com/connectors) → New Connector → Custom, plus the MCP URL copy card
- Links to xAI’s custom MCP connector docs; notes Business/Enterprise admin provisioning
- Mirrors the same client note in `docs/use/connect-your-agent.md`
- Mentions Grok in the discovery-prompt copy on onboarding

## Testing

- Unit test updated for tab order / non-coding classification and Grok URLs
- `npm run typecheck` passed
- Pre-commit / push hooks ran the focused suite including Playwright E2E (20 passed)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `285ad37a` · **Head:** `32e761c6`

**Classification:** composes — no primitives added or changed; this PR wires existing primitives together.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### System map

Onboarding’s MCP client picker gains a Grok tab that points users at Grok.com custom connectors and the same `/mcp` URL other hosts use.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::untouched
	appUi -->|"onboarding Grok tab: copy /mcp URL"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface                         | Before                         | After                                      |
| ------------------------------- | ------------------------------ | ------------------------------------------ |
| Onboarding MCP client tabs      | No Grok entry                  | Grok tab with connector setup + MCP URL    |
| `docs/use/connect-your-agent.md`| Client list without Grok       | Grok custom-connector note included        |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-214b58b9-911e-484a-a32f-4572f178d978?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-214b58b9-911e-484a-a32f-4572f178d978&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grok as a supported MCP client during onboarding.
  * Added Grok setup instructions, OAuth guidance, connector links, and MCP URL copying.
  * Included Grok in AI agent examples and supported non-coding agent options.
  * Added guidance for business and enterprise Grok provisioning.

* **Documentation**
  * Updated the agent connection guide with Grok support, setup steps, and xAI connector resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->