### PR TITLE
fix(entitlements): reverse-resolve plan when package jobs omit email

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -164,36 +164,30 @@ unique index; initially from `createStableUserIdFromEmail` at signup, then
 preserved across email changes). `getUserPlan(db, { userId, email })` always
 returns a `PlanName`:
 
-1. Normalizes the email and returns `free` when email or `userId` is absent (no
-   warn).
-2. Returns `free` without touching D1 when `userId` is not a 64-char hex string.
-   Synthetic runtime contexts (package-scoped caller contexts with `email: ''`,
-   workflow-internal users, test fixtures) therefore fail closed to `free`.
-3. Reads
+1. Returns `free` when `userId` is absent (no warn).
+2. Returns `free` without touching D1 when `userId` is not a 64-char hex string
+   (test fixtures and non-account ids).
+3. When email is present: reads
    `SELECT plan, stripe_plan FROM users WHERE email = ? AND stable_user_id = ?`
    and returns `resolveEffectivePlan(parseStoredPlanName(plan), stripe_plan)`. A
    mismatched email/stable-id pair or missing row returns `free` (no warn).
+4. When email is absent/blank: reverse-resolves
+   `SELECT plan, stripe_plan FROM users WHERE stable_user_id = ?` so package-job,
+   workflow, webhook, and other background contexts that persist `email: ''`
+   still enforce the account's real plan. Missing rows return `free`.
 
-Consequence: enforcement points must have the acting user's account email
-available. Both auth surfaces provide it — app sessions expose
-`user.mcpUser.email` and MCP caller contexts expose
-`ctx.callerContext.user.email`. Code paths that genuinely have no user email
-(for example package-manifest job sync or workflow-spawned inline code) resolve
-to `free` at plan lookup. Internal callers that need a higher quota must resolve
-an actual account whose stored plan grants it; there is no implicit elevated
-synthetic context.
+Interactive surfaces still carry email (app sessions expose
+`user.mcpUser.email`, MCP caller contexts expose
+`ctx.callerContext.user.email`). Background package-runtime paths that only
+have the stable userId no longer need a separate email hydrate step for
+entitlement checks — `getUserPlan` reverse-resolves for them.
 
-One path still needs explicit account resolution: inbound email routing has no
-caller context but must enforce receive quotas. It resolves the owning account
-via the indexed username lookup (`findPublicUserIdentityByUsername`) — it does
-not reverse-resolve stable user ids. `findUserAccountByStableUserId` in
-`service.ts` remains the reverse-resolution helper for other contextless paths
-(package-runtime contexts that act with only the stable userId, mirroring
-`findUserAccount` in `email/platform-address.ts`): `users.stable_user_id` is NOT
-NULL with a unique index (migrations 0052 + 0075; written at signup from
-`createStableUserIdFromEmail`, preserved across email changes), so reverse
-lookup is always one indexed point read. Only use it on contextless paths;
-interactive surfaces already carry the email.
+Inbound email routing has no caller context and resolves the owning account via
+the indexed username lookup (`findPublicUserIdentityByUsername`) — it does not
+use stable-id reverse resolution. `findUserAccountByStableUserId` in
+`service.ts` remains available for other contextless paths that need email /
+verified-state (for example the outbound fetch gateway), mirroring
+`findUserAccount` in `email/platform-address.ts`.
 
 ## The error shape
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -172,15 +172,16 @@ returns a `PlanName`:
    and returns `resolveEffectivePlan(parseStoredPlanName(plan), stripe_plan)`. A
    mismatched email/stable-id pair or missing row returns `free` (no warn).
 4. When email is absent/blank: reverse-resolves
-   `SELECT plan, stripe_plan FROM users WHERE stable_user_id = ?` so package-job,
-   workflow, webhook, and other background contexts that persist `email: ''`
-   still enforce the account's real plan. Missing rows return `free`.
+   `SELECT plan, stripe_plan FROM users WHERE stable_user_id = ?` so
+   package-job, workflow, webhook, and other background contexts that persist
+   `email: ''` still enforce the account's real plan. Missing rows return
+   `free`.
 
 Interactive surfaces still carry email (app sessions expose
 `user.mcpUser.email`, MCP caller contexts expose
-`ctx.callerContext.user.email`). Background package-runtime paths that only
-have the stable userId no longer need a separate email hydrate step for
-entitlement checks — `getUserPlan` reverse-resolves for them.
+`ctx.callerContext.user.email`). Background package-runtime paths that only have
+the stable userId no longer need a separate email hydrate step for entitlement
+checks — `getUserPlan` reverse-resolves for them.
 
 Inbound email routing has no caller context and resolves the owning account via
 the indexed username lookup (`findPublicUserIdentityByUsername`) — it does not

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -412,9 +412,7 @@ test('getUserPlan resolves plans, defaults unresolved contexts to free, and reje
 	expect(await getUserPlan(db, { userId, email: null })).toBe('pro')
 	expect(await getUserPlan(db, { userId, email: '' })).toBe('pro')
 	expect(await getUserPlan(db, { userId, email: '   ' })).toBe('pro')
-	expect(queries.at(-1)?.sql).toContain(
-		'FROM users WHERE stable_user_id = ?',
-	)
+	expect(queries.at(-1)?.sql).toContain('FROM users WHERE stable_user_id = ?')
 	expect(queries.at(-1)?.params).toEqual([userId])
 
 	// Mismatched email/stable-id pairs fail closed without warning.

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -115,19 +115,38 @@ function createEntitlementsTestDb(
 								query.includes('SELECT plan, stripe_plan FROM users') ||
 								query.includes('SELECT plan FROM users')
 							) {
-								const email = params[0]
-								const stableUserId = params[1]
-								// Pair match is required: omitted bind params or
-								// email-only fixtures must not resolve a plan.
-								if (
-									typeof email !== 'string' ||
-									typeof stableUserId !== 'string'
-								) {
+								const isPairLookup = query.includes('email = ?')
+								if (isPairLookup) {
+									const email = params[0]
+									const stableUserId = params[1]
+									// Pair match is required: omitted bind params or
+									// email-only fixtures must not resolve a plan.
+									if (
+										typeof email !== 'string' ||
+										typeof stableUserId !== 'string'
+									) {
+										return null as T | null
+									}
+									const user = users.find(
+										(row) =>
+											row.email === email &&
+											row.stable_user_id === stableUserId,
+									)
+									return (
+										user
+											? {
+													plan: user.plan,
+													stripe_plan: user.stripe_plan ?? null,
+												}
+											: null
+									) as T | null
+								}
+								const stableUserId = params[0]
+								if (typeof stableUserId !== 'string') {
 									return null as T | null
 								}
 								const user = users.find(
-									(row) =>
-										row.email === email && row.stable_user_id === stableUserId,
+									(row) => row.stable_user_id === stableUserId,
 								)
 								return (
 									user
@@ -388,6 +407,16 @@ test('getUserPlan resolves plans, defaults unresolved contexts to free, and reje
 	expect(queries.at(-1)?.sql).toContain('email = ? AND stable_user_id = ?')
 	expect(queries.at(-1)?.params).toEqual([plannedEmail, userId])
 
+	// Package-job / workflow contexts persist email: '' — reverse-resolve by
+	// stable userId so entitlement checks use the real plan (not free).
+	expect(await getUserPlan(db, { userId, email: null })).toBe('pro')
+	expect(await getUserPlan(db, { userId, email: '' })).toBe('pro')
+	expect(await getUserPlan(db, { userId, email: '   ' })).toBe('pro')
+	expect(queries.at(-1)?.sql).toContain(
+		'FROM users WHERE stable_user_id = ?',
+	)
+	expect(queries.at(-1)?.params).toEqual([userId])
+
 	// Mismatched email/stable-id pairs fail closed without warning.
 	expect(
 		await getUserPlan(db, {
@@ -590,6 +619,44 @@ test('assertWithinEntitlement enforces free concurrent workflow limit without em
 		plan: 'free',
 		limit: freeLimit,
 		current: freeLimit,
+	})
+})
+
+test('assertWithinEntitlement reverse-resolves plan when email is blank for a real stable userId', async () => {
+	const userId = await createStableUserIdFromEmail(plannedEmail)
+	const freeLimit = planLimits.free.maxConcurrentWorkflows
+	const maxLimit = planLimits.max.maxConcurrentWorkflows
+	const underMax = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: 'max', stable_user_id: userId }],
+		counts: { workflow_runs: freeLimit },
+	})
+	await assertWithinEntitlement({
+		db: underMax.db,
+		userId,
+		email: '',
+		resource: 'concurrent_workflows',
+	})
+
+	const atMax = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: 'max', stable_user_id: userId }],
+		counts: { workflow_runs: maxLimit },
+	})
+	const error = await assertWithinEntitlement({
+		db: atMax.db,
+		userId,
+		email: null,
+		resource: 'concurrent_workflows',
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(error instanceof EntitlementLimitError)) {
+		throw new Error('Expected an EntitlementLimitError at the max ceiling.')
+	}
+	expect(error.details).toMatchObject({
+		plan: 'max',
+		limit: maxLimit,
+		current: maxLimit,
 	})
 })
 

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -47,9 +47,7 @@ export async function getUserPlan(
 				.bind(email, input.userId)
 				.first<{ plan: string; stripe_plan: string | null }>()
 		: await db
-				.prepare(
-					`SELECT plan, stripe_plan FROM users WHERE stable_user_id = ?`,
-				)
+				.prepare(`SELECT plan, stripe_plan FROM users WHERE stable_user_id = ?`)
 				.bind(input.userId)
 				.first<{ plan: string; stripe_plan: string | null }>()
 	if (!row) return 'free'

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -14,15 +14,17 @@ const stableUserIdPattern = /^[a-f0-9]{64}$/i
 
 /**
  * Resolve the effective plan for a user. Always returns a {@link PlanName}
- * (never a meaningful null): missing email/userId, invalid stable ids, and
- * no matching row resolve to `free` without warning; stored values go through
+ * (never a meaningful null): missing userId, invalid stable ids, and no
+ * matching row resolve to `free` without warning; stored values go through
  * strict {@link parseStoredPlanName} validation and throw if D1 violates the
  * plan CHECK constraint.
  *
- * The MCP `userId` is the account's stored `users.stable_user_id`. Lookup
- * requires the email + stable id pair so a mismatched caller context
- * (synthetic runtime contexts, package-scoped callers with an empty email, or
- * test fixtures) cannot resolve another account's plan. Non-hex userIds
+ * The MCP `userId` is the account's stored `users.stable_user_id`. When an
+ * email is provided, lookup requires the email + stable id pair so a
+ * mismatched caller context cannot resolve another account's plan. When email
+ * is absent (package-job / workflow / webhook contexts that persist
+ * `email: ''`), reverse-resolve by stable userId alone so those paths enforce
+ * the account's real plan instead of silently using `free`. Non-hex userIds
  * short-circuit without touching D1.
  *
  * Effective plan = f(manual users.plan, users.stripe_plan): the higher-ranked
@@ -35,14 +37,21 @@ export async function getUserPlan(
 	input: { userId: string; email: string | null | undefined },
 ): Promise<PlanName> {
 	const email = input.email?.trim().toLowerCase()
-	if (!email || !input.userId) return 'free'
+	if (!input.userId) return 'free'
 	if (!stableUserIdPattern.test(input.userId)) return 'free'
-	const row = await db
-		.prepare(
-			`SELECT plan, stripe_plan FROM users WHERE email = ? AND stable_user_id = ?`,
-		)
-		.bind(email, input.userId)
-		.first<{ plan: string; stripe_plan: string | null }>()
+	const row = email
+		? await db
+				.prepare(
+					`SELECT plan, stripe_plan FROM users WHERE email = ? AND stable_user_id = ?`,
+				)
+				.bind(email, input.userId)
+				.first<{ plan: string; stripe_plan: string | null }>()
+		: await db
+				.prepare(
+					`SELECT plan, stripe_plan FROM users WHERE stable_user_id = ?`,
+				)
+				.bind(input.userId)
+				.first<{ plan: string; stripe_plan: string | null }>()
 	if (!row) return 'free'
 	return resolveEffectivePlan(parseStoredPlanName(row.plan), row.stripe_plan)
 }
@@ -123,11 +132,13 @@ export async function getCachedUserPlan(
 	input: { userId: string; email: string | null | undefined },
 ): Promise<PlanName> {
 	const email = input.email?.trim().toLowerCase()
-	if (!email || !input.userId) return 'free'
+	if (!input.userId) return 'free'
 	if (!stableUserIdPattern.test(input.userId)) return 'free'
+	// Empty email is a distinct cache key from any concrete email; both paths
+	// share getUserPlan's reverse-resolve / pair-match semantics.
 	return await cachedUserPlans.getOrCreate(
 		db,
-		`${input.userId}\n${email}`,
+		`${input.userId}\n${email ?? ''}`,
 		async () => await getUserPlan(db, input),
 	)
 }
@@ -780,9 +791,10 @@ export type AssertWithinEntitlementInput = {
 	db: D1Database
 	userId: string
 	/**
-	 * Account email of the acting user when available. Plan lookup requires
-	 * the email + stable-id pair; when absent (synthetic runtime contexts)
-	 * {@link getUserPlan} resolves to `free`.
+	 * Account email of the acting user when available. When present, plan
+	 * lookup requires the email + stable-id pair. When absent (package-job /
+	 * workflow contexts with `email: ''`), {@link getUserPlan} reverse-resolves
+	 * by stable userId; unknown accounts still fail closed to `free`.
 	 */
 	email: string | null | undefined
 	resource: EntitlementResource

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -152,8 +152,11 @@ function createWorkflowRunsDatabase(options?: {
 							if (query.includes('SELECT plan, stripe_plan FROM users')) {
 								if (query.includes('email = ?')) {
 									const email = String(params[0] ?? '')
+									const stableUserId = String(params[1] ?? '')
 									const user = (options?.users ?? []).find(
-										(row) => row.email === email,
+										(row) =>
+											row.email === email &&
+											row.stable_user_id === stableUserId,
 									)
 									return user ? { plan: user.plan } : null
 								}

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -120,7 +120,11 @@ function createStatefulWorkflowBinding() {
 function createWorkflowRunsDatabase(options?: {
 	activeCount?: number
 	savedPackage?: Record<string, unknown> | null
-	users?: Array<{ email: string; plan: string | null }>
+	users?: Array<{
+		email: string
+		plan: string | null
+		stable_user_id?: string
+	}>
 }) {
 	const workflowRuns = new Map<string, Record<string, unknown>>()
 	const savedPackage = options?.savedPackage ?? {
@@ -145,14 +149,17 @@ function createWorkflowRunsDatabase(options?: {
 							if (query.includes('COUNT(*) AS count')) {
 								return { count: options?.activeCount ?? 0 }
 							}
-							if (
-								query.includes(
-									'SELECT plan, stripe_plan FROM users WHERE email = ?',
-								)
-							) {
-								const email = String(params[0] ?? '')
+							if (query.includes('SELECT plan, stripe_plan FROM users')) {
+								if (query.includes('email = ?')) {
+									const email = String(params[0] ?? '')
+									const user = (options?.users ?? []).find(
+										(row) => row.email === email,
+									)
+									return user ? { plan: user.plan } : null
+								}
+								const stableUserId = String(params[0] ?? '')
 								const user = (options?.users ?? []).find(
-									(row) => row.email === email,
+									(row) => row.stable_user_id === stableUserId,
 								)
 								return user ? { plan: user.plan } : null
 							}
@@ -1580,7 +1587,7 @@ test('createDynamicCallableWorkflow enforces plan concurrent workflow limits', a
 			env: {
 				APP_DB: createWorkflowRunsDatabase({
 					activeCount: limit,
-					users: [{ email, plan: 'pro' }],
+					users: [{ email, plan: 'pro', stable_user_id: userId }],
 				}),
 				DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
 			} as Env,
@@ -1610,7 +1617,7 @@ test('createDynamicCallableWorkflow enforces plan concurrent workflow limits', a
 		env: {
 			APP_DB: createWorkflowRunsDatabase({
 				activeCount: limit - 1,
-				users: [{ email, plan: 'pro' }],
+				users: [{ email, plan: 'pro', stable_user_id: userId }],
 			}),
 			DYNAMIC_CALLABLE_WORKFLOWS: createStatefulWorkflowBinding().workflow,
 		} as Env,
@@ -1622,6 +1629,26 @@ test('createDynamicCallableWorkflow enforces plan concurrent workflow limits', a
 		},
 	})
 	expect(allowed.ok).toBe(true)
+
+	// Package jobs persist email: '' — reverse-resolve by stable userId so a
+	// max-plan account is not wrongly capped at the free concurrent limit.
+	const freeLimit = planLimits.free.maxConcurrentWorkflows
+	const maxAllowed = await createDynamicCallableWorkflow({
+		env: {
+			APP_DB: createWorkflowRunsDatabase({
+				activeCount: freeLimit,
+				users: [{ email, plan: 'max', stable_user_id: userId }],
+			}),
+			DYNAMIC_CALLABLE_WORKFLOWS: createStatefulWorkflowBinding().workflow,
+		} as Env,
+		userId,
+		userEmail: '',
+		body: {
+			...body,
+			idempotencyKey: 'plan-limit-blank-email-max-key',
+		},
+	})
+	expect(maxAllowed.ok).toBe(true)
 })
 
 test('listWorkflowRunsForUser returns recent workflow statuses', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Package-owned jobs and workflow/webhook runtimes persist `email: ''`. `getUserPlan` treated that as an unresolved context and failed closed to **free**, so `nightly-release` hit the free concurrent-workflow cap (3) even though the account is on **max**.

`getUserPlan` / `getCachedUserPlan` now reverse-resolve by `stable_user_id` when email is blank, matching the fetch-gateway pattern. Pair-matched email+id lookups are unchanged.

## Test plan

- [x] Unit: blank email + real stable id resolves max/pro for entitlements and workflow create
- [x] Unit: non-hex / missing account still fails closed to free
- [ ] CI validate green
- [ ] After deploy: re-run `nightly-release` and confirm `v2026.07.31` publishes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `285ad37a` · **Head:** `d40dd6e5`

**Classification:** extends — changes plan lookup so blank-email background contexts use the account's real entitlement plan instead of free.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — `getUserPlan` reverse-resolves by stable userId when email is blank |
| `package-runtime` | runtime | composes — workflow entitlement tests cover blank-email package-job path |

### System map

Blank-email package-job / workflow creates no longer inherit the free plan ceiling.

```mermaid
flowchart LR
  job["Package job<br/>email: ''"] --> create["workflows.create"]
  create --> assert["assertWithinEntitlement"]
  assert --> plan["getUserPlan"]
  plan -->|"email blank"| rev["SELECT … WHERE stable_user_id = ?"]
  plan -->|"email present"| pair["SELECT … WHERE email = ? AND stable_user_id = ?"]
  rev --> limits["Real plan limits"]
  pair --> limits
  classDef extends fill:#f59e0b,stroke:#b45309,color:#111
  classDef composes fill:#22c55e,stroke:#15803d,color:#111
  class plan,assert,rev extends
  class job,create,pair,limits composes
```

**Invariant callout:** still user-scoped — reverse lookup keys only on the acting `stable_user_id`; mismatched email+id pairs still fail closed to free.

### Docs

- `docs/contributing/architecture/entitlements.md` — plan-lookup steps updated for blank-email reverse resolution

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4af317ab-7a8d-46b7-bb6c-1a86387a7f8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4af317ab-7a8d-46b7-bb6c-1a86387a7f8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account plan detection for background jobs and workflows when only a stable user ID is available.
  * Validates email and stable ID combinations to prevent incorrect plan assignments.
  * Accounts with missing, invalid, or unmatched identifiers now safely default to the free plan.
  * Max-plan accounts can correctly access their higher workflow concurrency limits even without an email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->