### PR TITLE
Add decision records (ADRs) with template and 0001 on package versioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   what needs explicit validation.
 
 - Project intent and scope:
-  - [docs/contributing/project-intent.md](./docs/contributing/project-intent.md)
+- [docs/contributing/project-intent.md](./docs/contributing/project-intent.md)
+- Decision records (check before proposing something already decided against):
+- [docs/contributing/decisions/index.md](./docs/contributing/decisions/index.md)
 - Setup, checks, docs maintenance, preview deploys, and seeding:
   - [docs/contributing/setup.md](./docs/contributing/setup.md)
 - Code style conventions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,9 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   what needs explicit validation.
 
 - Project intent and scope:
-- [docs/contributing/project-intent.md](./docs/contributing/project-intent.md)
+  [docs/contributing/project-intent.md](./docs/contributing/project-intent.md)
 - Decision records (check before proposing something already decided against):
-- [docs/contributing/decisions/index.md](./docs/contributing/decisions/index.md)
+  [docs/contributing/decisions/index.md](./docs/contributing/decisions/index.md)
 - Setup, checks, docs maintenance, preview deploys, and seeding:
   - [docs/contributing/setup.md](./docs/contributing/setup.md)
 - Code style conventions:

--- a/docs/contributing/decisions/0000-template.md
+++ b/docs/contributing/decisions/0000-template.md
@@ -1,0 +1,19 @@
+# NNNN: Short decision title
+
+- **Status:** accepted <!-- accepted | superseded by [NNNN](./NNNN-slug.md) -->
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What question or situation forced the decision. A few sentences on the relevant
+system state and constraints, with links to code or docs.
+
+## Decision
+
+What was decided, in one or two sentences. Decisions **not** to build something
+count and should be recorded.
+
+## Consequences
+
+What follows: what stays simple, what gets harder, and what would trigger
+revisiting. When a preferred future shape is known, name it.

--- a/docs/contributing/decisions/0001-no-package-versioning.md
+++ b/docs/contributing/decisions/0001-no-package-versioning.md
@@ -1,0 +1,49 @@
+# 0001: No user-facing package versioning or import pins
+
+- **Status:** accepted
+- **Date:** 2026-07-31
+
+## Context
+
+Every saved package is a real git repo on Cloudflare Artifacts with full commit
+history, publish notes (readable via `repo_show_publish_note`), and a clonable
+remote (`package_get_git_remote`). Runtime surfaces — `packages.invoke`,
+package-owned jobs, apps, services, and webhooks — always resolve the package's
+current `entity_sources.published_commit`, and published bundles for non-current
+commits are pruned after 30 days. Static cross-package imports
+(`kody:@scope/pkg/export`) snapshot the dependency's published commit at the
+dependent's publish time and refresh only when the dependent republishes; the
+platform never auto-republishes dependents.
+
+The question: should packages get product-level versioning (semver releases, a
+versions UI, runnable old versions), and should cross-package imports support an
+explicit version/tag/commit pin?
+
+## Decision
+
+No to both. History, diffing, and rollback are served by the package's git repo.
+Cross-package imports keep the implicit "snapshot at publish, refresh on
+republish" contract, with no pin syntax in specifiers or
+`package.json#kody.dependencies`.
+
+Rationale: the consumer of a personal package is almost always its own author,
+so there is no downstream consumer needing a semver stability contract; the one
+cross-user surface (community forks) already pins by commit
+(`community_listings.pinned_commit`, `community_forks.origin_commit`); and
+pinned old versions would escape fleet package codemods, which keep published
+trees healthy precisely because platform APIs evolve.
+
+## Consequences
+
+- Runtime resolution stays single-pointer (current published commit), and
+  published-bundle retention stays at 30 days for non-current commits.
+- Users who want stability can tag commits in their package repo (labels for
+  humans, never read by the platform), hold off republishing a dependent until
+  ready, or fork a dependency into a frozen copy under another name.
+- Surfacing what already exists — a publish-history view backed by `git log`
+  plus publish notes, or a one-click "revert to this publish" — remains open and
+  cheap; it is UX over existing plumbing, not a versioning system.
+- If real demand for import pins appears, the preferred shape is commit-SHA pins
+  declared in `package.json#kody.dependencies` (not new specifier grammar),
+  resolved by rebuilding from Artifacts at that commit, with a staleness warning
+  in repo checks.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -1,0 +1,22 @@
+# Decision records
+
+Short architecture decision records (ADRs) for choices that shape the platform,
+including decisions **not** to build something. Check here before proposing a
+change that may already have been decided.
+
+Decision records are point-in-time documents, so they are exempt from
+`npm run docs:check-temporal`; everything else in `docs/` describes current
+behavior (see [documentation principles](../documentation.md)).
+
+## Adding a record
+
+1. Copy [`0000-template.md`](./0000-template.md) to the next number with a short
+   kebab-case slug (for example `0002-some-decision.md`).
+2. Keep it to roughly half a page: context, decision, consequences.
+3. When a later record changes a decision, mark the old one `superseded by NNNN`
+   rather than editing or deleting it.
+4. Add the record to the list below.
+
+## Records
+
+- [0001 — No user-facing package versioning or import pins](./0001-no-package-versioning.md)

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -23,9 +23,11 @@ notes.
 
 **Exceptions.** Migration and rotation guides (for example
 [`secret-rotation.md`](./secret-rotation.md)) may use ordered steps across
-deploy phases. Outside those procedures, still describe the current design in
-plain language. Quoted validation errors and runtime messages should match what
-the product returns, even when the wording contrasts with older manifest shapes.
+deploy phases, and [decision records](./decisions/index.md) are point-in-time
+documents by design. Outside those procedures, still describe the current design
+in plain language. Quoted validation errors and runtime messages should match
+what the product returns, even when the wording contrasts with older manifest
+shapes.
 
 **Stay lightweight but valuable.** Prefer small, accurate pages over large stale
 ones. **Garden** docs when behavior changes: update or delete sections in the

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -6,6 +6,8 @@ style, tests, MCP capabilities, and runtime architecture.
 ## Setup and workflow
 
 - [Getting started](./getting-started.md), [project intent](./project-intent.md)
+- [Decision records](./decisions/index.md) (ADRs, including decisions **not** to
+  build something)
 - [Setup](./setup.md), [environment variables](./environment-variables.md),
   [setup manifest](./setup-manifest.md)
 - [Optional Cloudflare offerings](./cloudflare-offerings.md)

--- a/tools/check-docs-temporal-language.node.test.ts
+++ b/tools/check-docs-temporal-language.node.test.ts
@@ -139,6 +139,7 @@ test.each([
 })
 
 test('exempts principles and migration pages and scans discovered docs', async () => {
+	expect(exemptRelativePrefixes).toContain('docs/contributing/decisions/')
 	for (const relativePath of [
 		...exemptRelativePaths,
 		...exemptRelativePrefixes.map((prefix) => `${prefix}0001-example.md`),

--- a/tools/check-docs-temporal-language.node.test.ts
+++ b/tools/check-docs-temporal-language.node.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from 'vitest'
 import {
 	checkDocumentationTemporalLanguage,
 	exemptRelativePaths,
+	exemptRelativePrefixes,
 	findTemporalLanguageMatches,
 	listDocumentationPaths,
 	stripMarkdownCode,
@@ -138,7 +139,10 @@ test.each([
 })
 
 test('exempts principles and migration pages and scans discovered docs', async () => {
-	for (const relativePath of exemptRelativePaths) {
+	for (const relativePath of [
+		...exemptRelativePaths,
+		...exemptRelativePrefixes.map((prefix) => `${prefix}0001-example.md`),
+	]) {
 		expect(
 			findTemporalLanguageMatches({
 				relativePath,

--- a/tools/check-docs-temporal-language.ts
+++ b/tools/check-docs-temporal-language.ts
@@ -21,6 +21,11 @@ export const exemptRelativePaths = new Set([
 	'docs/contributing/secret-rotation.md',
 ])
 
+/** Directories whose pages are intentionally point-in-time records. */
+export const exemptRelativePrefixes: ReadonlyArray<string> = [
+	'docs/contributing/decisions/',
+]
+
 /**
  * Changelog-style phrases to flag in durable documentation.
  * Keep this list narrow and aligned with docs/contributing/documentation.md.
@@ -150,7 +155,10 @@ export function findTemporalLanguageMatches(input: {
 	content: string
 }): TemporalLanguageMatch[] {
 	const relativePath = input.relativePath.replaceAll('\\', '/')
-	if (exemptRelativePaths.has(relativePath)) {
+	if (
+		exemptRelativePaths.has(relativePath) ||
+		exemptRelativePrefixes.some((prefix) => relativePath.startsWith(prefix))
+	) {
 		return []
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a lightweight architecture decision record (ADR) system under `docs/contributing/decisions/` so platform-shaping choices — especially decisions **not** to build something — are recorded instead of re-litigated.

- `docs/contributing/decisions/index.md` — what ADRs are, how to add one, and the record list
- `docs/contributing/decisions/0000-template.md` — half-page template (Status / Date / Context / Decision / Consequences)
- `docs/contributing/decisions/0001-no-package-versioning.md` — first real record: no user-facing package versioning and no cross-package import pins, with the rationale (git history on Artifacts already covers history/rollback; the package author is the consumer; community forks already pin by commit; pinned old versions would escape fleet codemods) and the preferred future shape if import-pin demand ever materializes
- Links the folder from `docs/contributing/index.md` and `AGENTS.md` (agents should check it before proposing something already decided against)
- Exempts `docs/contributing/decisions/` from `npm run docs:check-temporal` via a new `exemptRelativePrefixes` list in `tools/check-docs-temporal-language.ts` (decision records are point-in-time documents by design), with test coverage, and notes the exception in `docs/contributing/documentation.md`

## Why

Came out of a discussion on whether to add versioning to users' packages (answer: no). Decisions like that had no durable home, so the same question would inevitably resurface.

## Verification

- `npm run format:check`, `npm run lint`, `npm run typecheck` — pass
- `npm run docs:check-temporal` — passes with the new folder exempted
- `npx vitest run tools/check-docs-temporal-language.node.test.ts` — 16 tests pass, including the new prefix-exemption case and a fixed assertion that the decisions prefix is configured
- `npm run primitives:check` and `npm run migrations:check` — pass

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `3320dad0` · **Head:** `05a0fe2b`

**Classification:** composes — no primitives added or changed. The classifier matches zero primitives for this diff: it touches contributor documentation and the docs temporal-language validation tool only. No runtime, storage, or capability code changes.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_  | —     | Docs under `docs/contributing/decisions/` plus an exemption list in `tools/check-docs-temporal-language.ts` (validation tooling, not a mapped primitive) |

### Before / after

```text
Before: docs/check-temporal exemptions = 2 exact file paths
After:  + exemptRelativePrefixes = ['docs/contributing/decisions/']
        (decision records are point-in-time documents by design)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc039c7f-a24d-40eb-a79c-08f5ad73ccb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc039c7f-a24d-40eb-a79c-08f5ad73ccb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision records section with an index, contribution guidance, and reusable decision template.
  * Documented the decision against product-level package versioning and cross-package import pins.
  * Updated contributor documentation navigation and reformatted existing guidance without changing its meaning.

* **Tests**
  * Expanded documentation checks to support exempt paths and directory prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->