### PR TITLE
docs: ADR 0002 — data-placement rubric (D1 / per-user DO / Analytics Engine)

### DIFF
--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -31,7 +31,9 @@ to become.
   state, percentage rollouts, and per-user overrides, managed at
   `/admin/feature-flags`.
 - [Data Storage](./data-storage.md): what is stored in D1, KV, and Durable
-  Objects.
+  Objects. The rubric for choosing between D1, a per-user Durable Object, and
+  Analytics Engine is recorded in decision record
+  [0002 — Data placement](../decisions/0002-data-placement.md).
 - [Usage Metering](./usage-metering.md): per-user usage events, the
   `recordUsage()` helper contract, and the D1 rollup table.
 - [Invocation overhead guardrails](./invocation-overhead-guardrails.md):

--- a/docs/contributing/decisions/0002-data-placement.md
+++ b/docs/contributing/decisions/0002-data-placement.md
@@ -1,0 +1,120 @@
+# 0002: Data placement — D1, per-user Durable Objects, Analytics Engine
+
+- **Status:** accepted
+- **Date:** 2026-07-31
+
+## Context
+
+The single shared D1 database (`APP_DB`) is the system's scaling bottleneck:
+global single-writer semantics and a 10 GB cap shared by all users. The July
+2026 scalability review audited hot invocation paths and found awaited per-call
+D1 writes on all of them:
+
+- daily entitlement counter upserts on every execute call and on every sandbox
+  outbound fetch;
+- account-write-lease fencing — 2–5 statements on every guarded mutation via
+  `withAccountWriteLease`;
+- per-run activation milestone upserts
+  (`packages/worker/src/usage/activation.ts`);
+- per-lifecycle `workflow_runs` projection writes;
+- an uncached per-call plan read in `assertWithinEntitlement`.
+
+Precedent for the fix already existed: run history moved to the per-user
+`RunLog` Durable Object (migration `0112-drop-package-invocations.sql` dropped
+`package_invocations`; `webhook_deliveries` and the `package_runtime_*` tables
+were dropped the same way in `0099-drop-run-history-legacy.sql`).
+
+The question: which storage system should each kind of data live in, so the
+answer does not get re-derived (inconsistently) in every PR?
+
+## Decision
+
+Place data by access pattern.
+
+**D1 (`APP_DB`)** when any of these hold:
+
+- the data is found by something other than the owner's `userId` — login by
+  email, username-based email routing, token-hash webhook ingress;
+- invariants span entities or tables — the publish transaction over
+  `entity_sources` + `saved_packages` + KV snapshots; secrets grants
+  referencing package ids;
+- it is low-write configuration read by many surfaces (cached);
+- fleet-wide operational queries matter; or
+- it is a cross-user enumeration/deletion index (`user_storage_buckets`,
+  `mcp_agent_sessions`) — Durable Objects cannot be enumerated.
+
+**A per-user Durable Object** when the data is high-write, always addressed by
+the owner's `userId`, has owner-local invariants, and is read on the owner's
+own request path: quota counters, deletion fencing, run history, activation
+milestones, mailboxes, live sessions. A per-user DO converts D1's global 10 GB
+/ global single writer into 10 GB and a serialized writer **per user**.
+Serialization is the correctness mechanism for counters and a throughput
+ceiling everywhere else — do not put everything for a user behind one DO.
+
+**Analytics Engine** when the data is append-only telemetry with
+reporting-grade reads inside AE's retention window: admin insights aggregates,
+delivery-event analytics, usage events. Never for request-path reads (query
+latency is seconds); never for data needing retention beyond AE's window — the
+180-day audit trail goes to a separate dedicated audit D1 instead.
+
+**Already-settled homes**, unchanged by this record: blobs in R2, OAuth
+provider state and published-source snapshots in KV, vectors in Vectorize with
+per-user namespaces plus `userId` metadata as defense in depth.
+
+### The five forces behind the rubric
+
+- **Lookup direction** — a DO is addressable only by its name; D1 rows by any
+  indexed column.
+- **Transactional boundaries** — DO atomicity is per-object; D1 gives
+  multi-table batches.
+- **Read topology** — a DO lives in one location; D1 reads can replicate and
+  batch.
+- **Serialization** — per-user actor ordering is a feature for quota state and
+  a liability for throughput.
+- **Operations** — fleet-wide SQL, shared migrations, and enumeration exist
+  only in D1, so every DO move must build export/purge RPCs and any needed
+  index.
+
+### Standing rules
+
+- New awaited D1 writes on hot invocation paths require a budget justification
+  (extends
+  [invocation overhead guardrails](../architecture/invocation-overhead-guardrails.md))
+  and should first consider DO/AE placement.
+- Every storage move extends account deletion/export coverage
+  (`packages/worker/src/account/account-user-owned-surfaces.ts` and the
+  guardrail tests) as part of the move, not as a follow-up.
+- Any admin view depending on a cross-user SELECT of moved data must be
+  redesigned (AE or point reads) in the same change.
+
+## Consequences
+
+Concrete placements decided by the review (implemented by concurrent tracks;
+the placements are the decision, independent of any track's merge state):
+
+- **Per-user meter DO:** entitlement daily counters, `d1_storage_bytes`
+  accounting, service liveness, deletion fence.
+- **RunLog DO:** `workflow_runs` projection, jobs `last_run_*` observability,
+  activation milestones.
+- **Analytics Engine:** admin insight aggregates, delivery-event analytics,
+  conversation-use signals where reporting-only.
+- **Separate audit D1:** `audit_events` (180-day retention outlives AE's
+  window).
+- **Vectorize:** per-user namespaces, keeping the `userId` metadata filter as
+  defense in depth.
+- **Per-user mailbox DO** for email metadata: planned second wave.
+
+Deliberately stays in D1: users/auth, secrets/values/integrations config,
+publish pointers and package projections, community tables, jobs schedule
+metadata, webhook endpoints, deletion indexes.
+
+Costs accepted: every DO move gives up fleet-wide SQL over that data and must
+ship its own export/purge RPCs plus any enumeration index it still needs;
+per-user DOs introduce a serialized writer per user (a per-user throughput
+ceiling to watch); expand/contract discipline means moved D1 tables stay
+dual-written until production verification, with retirement migrations in
+follow-ups.
+
+Revisit if Cloudflare materially changes the constraints (multi-writer or
+larger D1, DO enumeration, AE retention/latency), or if a per-user DO becomes a
+measured throughput bottleneck on an owner's own request path.

--- a/docs/contributing/decisions/0002-data-placement.md
+++ b/docs/contributing/decisions/0002-data-placement.md
@@ -36,30 +36,30 @@ Place data by access pattern.
 - the data is found by something other than the owner's `userId` — login by
   email, username-based email routing, token-hash webhook ingress;
 - invariants span entities or tables — the publish transaction over
-  `entity_sources` + `saved_packages` + KV snapshots; secrets grants
-  referencing package ids;
+  `entity_sources` + `saved_packages` + KV snapshots; secrets grants referencing
+  package ids;
 - it is low-write configuration read by many surfaces (cached);
 - fleet-wide operational queries matter; or
 - it is a cross-user enumeration/deletion index (`user_storage_buckets`,
   `mcp_agent_sessions`) — Durable Objects cannot be enumerated.
 
 **A per-user Durable Object** when the data is high-write, always addressed by
-the owner's `userId`, has owner-local invariants, and is read on the owner's
-own request path: quota counters, deletion fencing, run history, activation
-milestones, mailboxes, live sessions. A per-user DO converts D1's global 10 GB
-/ global single writer into 10 GB and a serialized writer **per user**.
-Serialization is the correctness mechanism for counters and a throughput
-ceiling everywhere else — do not put everything for a user behind one DO.
+the owner's `userId`, has owner-local invariants, and is read on the owner's own
+request path: quota counters, deletion fencing, run history, activation
+milestones, mailboxes, live sessions. A per-user DO converts D1's global 10 GB /
+global single writer into 10 GB and a serialized writer **per user**.
+Serialization is the correctness mechanism for counters and a throughput ceiling
+everywhere else — do not put everything for a user behind one DO.
 
-**Analytics Engine** when the data is append-only telemetry with
-reporting-grade reads inside AE's retention window: admin insights aggregates,
-delivery-event analytics, usage events. Never for request-path reads (query
-latency is seconds); never for data needing retention beyond AE's window — the
-180-day audit trail goes to a separate dedicated audit D1 instead.
+**Analytics Engine** when the data is append-only telemetry with reporting-grade
+reads inside AE's retention window: admin insights aggregates, delivery-event
+analytics, usage events. Never for request-path reads (query latency is
+seconds); never for data needing retention beyond AE's window — the 180-day
+audit trail goes to a separate dedicated audit D1 instead.
 
-**Already-settled homes**, unchanged by this record: blobs in R2, OAuth
-provider state and published-source snapshots in KV, vectors in Vectorize with
-per-user namespaces plus `userId` metadata as defense in depth.
+**Already-settled homes**, unchanged by this record: blobs in R2, OAuth provider
+state and published-source snapshots in KV, vectors in Vectorize with per-user
+namespaces plus `userId` metadata as defense in depth.
 
 ### The five forces behind the rubric
 
@@ -69,11 +69,10 @@ per-user namespaces plus `userId` metadata as defense in depth.
   multi-table batches.
 - **Read topology** — a DO lives in one location; D1 reads can replicate and
   batch.
-- **Serialization** — per-user actor ordering is a feature for quota state and
-  a liability for throughput.
-- **Operations** — fleet-wide SQL, shared migrations, and enumeration exist
-  only in D1, so every DO move must build export/purge RPCs and any needed
-  index.
+- **Serialization** — per-user actor ordering is a feature for quota state and a
+  liability for throughput.
+- **Operations** — fleet-wide SQL, shared migrations, and enumeration exist only
+  in D1, so every DO move must build export/purge RPCs and any needed index.
 
 ### Standing rules
 
@@ -89,8 +88,8 @@ per-user namespaces plus `userId` metadata as defense in depth.
 
 ## Consequences
 
-Concrete placements decided by the review (implemented by concurrent tracks;
-the placements are the decision, independent of any track's merge state):
+Concrete placements decided by the review (implemented by concurrent tracks; the
+placements are the decision, independent of any track's merge state):
 
 - **Per-user meter DO:** entitlement daily counters, `d1_storage_bytes`
   accounting, service liveness, deletion fence.
@@ -115,6 +114,6 @@ ceiling to watch); expand/contract discipline means moved D1 tables stay
 dual-written until production verification, with retirement migrations in
 follow-ups.
 
-Revisit if Cloudflare materially changes the constraints (multi-writer or
-larger D1, DO enumeration, AE retention/latency), or if a per-user DO becomes a
+Revisit if Cloudflare materially changes the constraints (multi-writer or larger
+D1, DO enumeration, AE retention/latency), or if a per-user DO becomes a
 measured throughput bottleneck on an owner's own request path.

--- a/docs/contributing/decisions/0002-data-placement.md
+++ b/docs/contributing/decisions/0002-data-placement.md
@@ -85,6 +85,13 @@ namespaces plus `userId` metadata as defense in depth.
   guardrail tests) as part of the move, not as a follow-up.
 - Any admin view depending on a cross-user SELECT of moved data must be
   redesigned (AE or point reads) in the same change.
+- Shared storage does not relax per-user isolation. User-owned data in every
+  home — packages, jobs, secrets, values, memories, remote connectors, email
+  inboxes, durable storage — stays scoped by `userId` (and every Durable Object
+  backing user-owned state stays namespaced by `userId`); cross-user access is
+  limited to the documented operator/admin indexes and reporting aggregates. The
+  full isolation contract lives in
+  [data storage](../architecture/data-storage.md).
 
 ## Consequences
 

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -20,3 +20,4 @@ behavior (see [documentation principles](../documentation.md)).
 ## Records
 
 - [0001 — No user-facing package versioning or import pins](./0001-no-package-versioning.md)
+- [0002 — Data placement: D1, per-user Durable Objects, Analytics Engine](./0002-data-placement.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Records the data-placement rubric decided during the July 2026 scalability review as decision record [`docs/contributing/decisions/0002-data-placement.md`](../blob/main/docs/contributing/decisions/0002-data-placement.md):

- **Context:** the shared D1 (`APP_DB`) is the scaling bottleneck (global single writer, shared 10 GB cap); the audit found awaited per-call D1 writes on hot paths (entitlement counter upserts, `withAccountWriteLease` fencing, activation upserts, `workflow_runs` projections, uncached plan read in `assertWithinEntitlement`); precedent existed in the RunLog DO move (migrations 0099/0112).
- **Decision:** the rubric — D1 when data is found by something other than the owner's `userId`, spans entities/tables, is cached low-write config, needs fleet-wide queries, or is a cross-user enumeration/deletion index; a per-user Durable Object when data is high-write, `userId`-addressed, owner-local, read on the owner's own path; Analytics Engine for append-only reporting-grade telemetry within AE's retention window; R2/KV/Vectorize homes unchanged. Plus the five forces (lookup direction, transactional boundaries, read topology, serialization, operations) and the standing rules (budget justification for new awaited hot-path D1 writes, deletion/export coverage in the same move, admin cross-user SELECT redesign in the same change, per-user isolation held in every storage home).
- **Consequences:** the concrete placements (per-user meter DO, RunLog DO consolidation, AE reporting, separate audit D1, Vectorize per-user namespaces, mailbox DO second wave) and what deliberately stays in D1.

## Notes for review

- The task brief assumed no ADR directory existed and proposed `docs/contributing/architecture/decisions/0001-...`. The repo already has an ADR system at `docs/contributing/decisions/` (template, index, numbering, temporal-check exemption in `tools/check-docs-temporal-language.ts`), so this record lands there as **0002** instead of creating a parallel directory. The existing index already documents the naming convention.
- Linked from `docs/contributing/architecture/index.md` (Data Storage bullet) and the decisions index.
- `npm run primitives:check` needs no change: it validates that paths listed in `primitives.yaml` resolve; new docs don't require registration and this PR reshapes no primitive.
- Docs only; no code changes. Sibling tracks implement the placements concurrently.
- Review feedback addressed: added the per-user isolation standing rule (CodeRabbit's one actionable comment).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk, docs only)</summary>

**Mode:** recap · **Base:** `main` @ `915db38` · **Head:** `5050df9`

**Classification:** composes — documentation-only change; the classifier matches no primitive code roots and no primitive is added or reshaped. The ADR documents placement rules for existing storage primitives.

### Primitives touched

| Primitive          | Group   | Impact                                                       |
| ------------------ | ------- | ------------------------------------------------------------ |
| _(none)_           | —       | docs only — ADR 0002 + two index links                       |

### System map

The ADR records which storage primitive each kind of data belongs to; all nodes are unchanged context.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	adr["ADR 0002<br/>Data placement record"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	durableStorage["durable-storage<br/>Durable storage buckets"]:::untouched
	usageMetering["usage-metering<br/>Usage metering"]:::untouched
	vectorizeSearch["vectorize-search<br/>Vectorize search"]:::untouched
	adr -->|"stays: identity/config/indexes; rule: budget-justified hot-path writes"| d1AppDb
	adr -->|"moves: counters, fencing, run history, milestones to per-user DOs"| durableStorage
	adr -->|"moves: reporting aggregates to Analytics Engine"| usageMetering
	adr -->|"confirms: per-user namespaces + userId metadata"| vectorizeSearch
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

## Conductor report

- **STATUS:** done
- **What shipped:** ADR 0002 (`docs/contributing/decisions/0002-data-placement.md`) capturing the data-placement rubric (D1 vs per-user Durable Objects vs Analytics Engine, with R2/KV/Vectorize homes), the five forces, standing rules (including per-user isolation from review feedback), and the concrete placements; linked from the decisions index and the architecture index.
- **Deviation from brief:** the repo already had an ADR directory at `docs/contributing/decisions/` (template, index, ADR 0001), so this landed there as 0002 instead of creating `docs/contributing/architecture/decisions/0001-...`. That directory is also the one exempted from `docs:check-temporal`, which point-in-time ADRs require. `npm run primitives:check` needed no change.
- **Risk:** low — docs-only, no code or primitive changes.
- **Merged/deployed:** yes — squash-merged as [96b41d9](https://github.com/kentcdodds/kody/commit/96b41d91ee977fdce6f58cc4dea93625d598a3b5); production deploy succeeded ([deploy run](https://github.com/kentcdodds/kody/actions/runs/30675809094)). `npm run validate` green locally; all CI checks green.
- **Scope spill:** none — no sibling-owned files touched; `data-storage.md` untouched (only the architecture index gained a link).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c6a6c69-b923-4ecc-8847-80df85c19d72?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c6a6c69-b923-4ecc-8847-80df85c19d72&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record documenting data-storage placement across supported storage services.
  * Documented criteria, scalability considerations, operational guidance, data assignments, and conditions for revisiting the decision.
  * Linked the new decision record from the architecture documentation and decision index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->