### PR TITLE
Isolate per-user vectors with Vectorize namespaces

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -879,14 +879,15 @@ deterministic so upserts and deletes target the same vector.
 - Builtin capabilities: id is the capability name in namespace
   `__kody_builtin__`, with metadata `{ kind: 'builtin', domain }`.
 
-The namespace migration uses expand/contract reads. Each query first searches
-the intended namespace. If that namespace returns no matches, it repeats the
-same metadata-filtered query against the legacy default namespace. The
+The namespace migration uses expand/contract reads. Each query searches both the
+intended namespace and the legacy default namespace with the same metadata
+filter, then deduplicates, ranks, and limits the combined matches. This keeps
+partially reindexed accounts complete without weakening user isolation. The
 post-deploy `POST /__maintenance/reindex-capabilities` sweep keyset-pages every
 memory, job, and saved package from D1 (200 rows per page) and upserts it into
 the owner's namespace; it also rebuilds builtins in their reserved namespace.
 The deploy is not considered migrated until every phase reports no `error` or
-`failed` vectors. Remove the default-namespace fallback in a follow-up contract
+`failed` vectors. Remove the default-namespace read in a follow-up contract
 deploy only after a production full sweep succeeds and the next deploy confirms
 normal namespaced search. Vectors are derived from D1, so no canonical data is
 moved or deleted during this migration.

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -853,26 +853,43 @@ the same user-owned D1 rows used by account deletion.
 
 ### Vectorize metadata contracts
 
-Vector ids and metadata are conventional and require reindexing when changed.
+Vector ids, namespaces, and metadata are conventional and require reindexing
+when changed. User-owned vectors use the account's 64-character stable user id
+as their Vectorize namespace. Builtin capability vectors use the reserved
+`__kody_builtin__` namespace; stable user ids are lowercase SHA-256 hex, so the
+reserved value cannot collide with an account. Namespace filtering is the
+primary isolation boundary and is applied by Vectorize before search. The
+`userId` metadata filter remains mandatory on every user-owned query as
+defense-in-depth.
+
 User-owned ids must also stay within Cloudflare Vectorize's 64-byte id limit:
 builders first emit the legacy passthrough form when it fits, then fall back to
 `{prefix}_sha256:{truncatedHexDigest}` for overlong raw ids. Length checks are
 UTF-8 byte checks, not JavaScript string-length checks, and the digest form is
 deterministic so upserts and deletes target the same vector.
 
-- Memories: `memory_{memoryId}` with metadata
+- Memories: `memory_{memoryId}` in namespace `{userId}`, with metadata
   `{ kind: 'memory', userId, status, category? }`. Memory ids are UUID-like, so
   search parses only the passthrough `memory_` form back to the D1 id.
 - Jobs: `job_{jobId}` or `job_sha256:{digest}` with metadata
-  `{ kind: 'job', userId }`. Package-owned job ids
+  `{ kind: 'job', userId }` in namespace `{userId}`. Package-owned job ids
   `package-job:{packageId}:{jobName}` often need the digest form.
 - Saved packages: `package_{packageId}` or `package_sha256:{digest}` with
-  metadata `{ kind: 'package', userId }`.
-- Builtin capabilities: id is the capability name with metadata
-  `{ kind: 'builtin', domain }`.
+  metadata `{ kind: 'package', userId }` in namespace `{userId}`.
+- Builtin capabilities: id is the capability name in namespace
+  `__kody_builtin__`, with metadata `{ kind: 'builtin', domain }`.
 
-Every user-owned Vectorize query must filter by `userId`; capability vectors are
-global built-in metadata and are rebuilt through the maintenance reindex path.
+The namespace migration uses expand/contract reads. Each query first searches
+the intended namespace. If that namespace returns no matches, it repeats the
+same metadata-filtered query against the legacy default namespace. The
+post-deploy `POST /__maintenance/reindex-capabilities` sweep keyset-pages every
+memory, job, and saved package from D1 (200 rows per page) and upserts it into
+the owner's namespace; it also rebuilds builtins in their reserved namespace.
+The deploy is not considered migrated until every phase reports no `error` or
+`failed` vectors. Remove the default-namespace fallback in a follow-up contract
+deploy only after a production full sweep succeeds and the next deploy confirms
+normal namespaced search. Vectors are derived from D1, so no canonical data is
+moved or deleted during this migration.
 
 ### `entity_sources` and package import contracts
 

--- a/packages/worker/src/jobs/job-reindex.node.test.ts
+++ b/packages/worker/src/jobs/job-reindex.node.test.ts
@@ -91,6 +91,7 @@ test('job reindex keeps package job vector ids under the Vectorize limit', async
 		{
 			id: vectorId,
 			values: [0.4, 0.5, 0.6],
+			namespace: 'user-1',
 			metadata: { kind: 'job', userId: 'user-1' },
 		},
 	])

--- a/packages/worker/src/jobs/job-reindex.ts
+++ b/packages/worker/src/jobs/job-reindex.ts
@@ -7,6 +7,7 @@ import {
 	reindexVectorCandidates,
 	type VectorReindexResult,
 } from '#worker/vectorize/reindex-batches.ts'
+import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { buildJobEmbedText } from '#mcp/jobs-embed.ts'
 import { jobVectorId } from '#mcp/jobs-vectorize.ts'
 import { runD1WithRetry } from '#worker/d1-retry.ts'
@@ -50,6 +51,7 @@ export async function reindexJobVectors(
 						sourceId: view.sourceId,
 						publishedCommit: view.publishedCommit,
 					}),
+					namespace: userVectorNamespace(row.user_id),
 					metadata: { kind: 'job', userId: row.user_id },
 				}
 			})

--- a/packages/worker/src/mcp/capabilities/capability-reindex.ts
+++ b/packages/worker/src/mcp/capabilities/capability-reindex.ts
@@ -4,6 +4,7 @@ import {
 	reindexVectorCandidates,
 	type VectorReindexResult,
 } from '#worker/vectorize/reindex-batches.ts'
+import { BUILTIN_VECTOR_NAMESPACE } from '#worker/vectorize/vector-namespaces.ts'
 import { type CapabilitySpec } from './types.ts'
 
 export async function reindexCapabilityVectors(
@@ -22,6 +23,7 @@ export async function reindexCapabilityVectors(
 		candidates: Object.values(specs).map((spec) => ({
 			id: spec.name,
 			text: buildCapabilityEmbedText(spec),
+			namespace: BUILTIN_VECTOR_NAMESPACE,
 			metadata: { domain: spec.domain, kind: 'builtin' },
 		})),
 	})

--- a/packages/worker/src/mcp/capabilities/capability-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.node.test.ts
@@ -101,8 +101,9 @@ test('capability Vectorize stays builtin-scoped, query-embed-only, and lexical-o
 	expect(embeddedTexts).toEqual([query])
 	expect(capturedFilters).toEqual([
 		{ domain: { $eq: 'meta' }, kind: { $eq: CAPABILITY_VECTOR_KIND } },
+		{ domain: { $eq: 'meta' }, kind: { $eq: CAPABILITY_VECTOR_KIND } },
 	])
-	expect(capturedNamespaces).toEqual([BUILTIN_VECTOR_NAMESPACE])
+	expect(capturedNamespaces).toEqual([BUILTIN_VECTOR_NAMESPACE, undefined])
 	expect(result.matches.map((match) => match.name)).toContain(
 		'oauth_redirect_helper',
 	)

--- a/packages/worker/src/mcp/capabilities/capability-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.node.test.ts
@@ -3,6 +3,7 @@ import {
 	CAPABILITY_EMBEDDING_DIMENSIONS,
 	deterministicEmbedding,
 } from '#worker/vectorize/embedding.ts'
+import { BUILTIN_VECTOR_NAMESPACE } from '#worker/vectorize/vector-namespaces.ts'
 import {
 	CAPABILITY_VECTOR_KIND,
 	buildCapabilityVectorMetadataFilter,
@@ -31,6 +32,7 @@ function spec(name: string, description: string): CapabilitySpec {
 function onlineEnv(matches: Array<{ id: string; score: number }>) {
 	const embeddedTexts: Array<string> = []
 	const capturedFilters: Array<Record<string, unknown> | undefined> = []
+	const capturedNamespaces: Array<string | undefined> = []
 	const env = {
 		SENTRY_ENVIRONMENT: 'production',
 		AI: {
@@ -49,14 +51,15 @@ function onlineEnv(matches: Array<{ id: string; score: number }>) {
 		CAPABILITY_VECTOR_INDEX: {
 			async query(
 				_values: Array<number>,
-				options: { filter?: Record<string, unknown> },
+				options: { filter?: Record<string, unknown>; namespace?: string },
 			) {
 				capturedFilters.push(options.filter)
+				capturedNamespaces.push(options.namespace)
 				return { matches }
 			},
 		},
 	} as unknown as Env
-	return { env, embeddedTexts, capturedFilters }
+	return { env, embeddedTexts, capturedFilters, capturedNamespaces }
 }
 
 test('capability Vectorize stays builtin-scoped, query-embed-only, and lexical-only for misses', async () => {
@@ -81,7 +84,7 @@ test('capability Vectorize stays builtin-scoped, query-embed-only, and lexical-o
 			'oauth redirect uri provider registration guide for configuring providers.',
 		),
 	}
-	const { env, embeddedTexts, capturedFilters } = onlineEnv([
+	const { env, embeddedTexts, capturedFilters, capturedNamespaces } = onlineEnv([
 		{ id: 'package_pkg-1', score: 0.99 },
 		{ id: 'capability_noise_a', score: 0.41 },
 	])
@@ -97,6 +100,7 @@ test('capability Vectorize stays builtin-scoped, query-embed-only, and lexical-o
 	expect(capturedFilters).toEqual([
 		{ domain: { $eq: 'meta' }, kind: { $eq: CAPABILITY_VECTOR_KIND } },
 	])
+	expect(capturedNamespaces).toEqual([BUILTIN_VECTOR_NAMESPACE])
 	expect(result.matches.map((match) => match.name)).toContain(
 		'oauth_redirect_helper',
 	)

--- a/packages/worker/src/mcp/capabilities/capability-search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.node.test.ts
@@ -84,10 +84,12 @@ test('capability Vectorize stays builtin-scoped, query-embed-only, and lexical-o
 			'oauth redirect uri provider registration guide for configuring providers.',
 		),
 	}
-	const { env, embeddedTexts, capturedFilters, capturedNamespaces } = onlineEnv([
-		{ id: 'package_pkg-1', score: 0.99 },
-		{ id: 'capability_noise_a', score: 0.41 },
-	])
+	const { env, embeddedTexts, capturedFilters, capturedNamespaces } = onlineEnv(
+		[
+			{ id: 'package_pkg-1', score: 0.99 },
+			{ id: 'capability_noise_a', score: 0.41 },
+		],
+	)
 	const result = await searchCapabilities({
 		env,
 		query,

--- a/packages/worker/src/mcp/capabilities/capability-search.ts
+++ b/packages/worker/src/mcp/capabilities/capability-search.ts
@@ -15,6 +15,10 @@ import {
 	sortIdsByScore,
 	tokenizeSearchText,
 } from '#worker/vectorize/scoring.ts'
+import {
+	BUILTIN_VECTOR_NAMESPACE,
+	queryVectorizeWithNamespaceFallback,
+} from '#worker/vectorize/vector-namespaces.ts'
 
 /**
  * Indexed metadata `kind` for builtin capability vectors in the shared
@@ -222,10 +226,15 @@ export async function searchCapabilities(input: {
 			input.vectorMetadataFilter,
 		)
 
-		const vecMatches = await vectorIndex.query(qVec, {
-			topK,
-			returnMetadata: 'none',
-			filter,
+		const vecMatches = await queryVectorizeWithNamespaceFallback({
+			index: vectorIndex,
+			vector: qVec,
+			namespace: BUILTIN_VECTOR_NAMESPACE,
+			options: {
+				topK,
+				returnMetadata: 'none',
+				filter,
+			},
 		})
 		const fromIndex: Array<string> = []
 		const seen = new Set<string>()

--- a/packages/worker/src/mcp/jobs-vectorize.node.test.ts
+++ b/packages/worker/src/mcp/jobs-vectorize.node.test.ts
@@ -54,6 +54,7 @@ test('job vectors use the same length-safe id for upsert and delete', async () =
 		{
 			id: vectorId,
 			values: [0.1, 0.2, 0.3],
+			namespace: 'user-1',
 			metadata: { kind: 'job', userId: 'user-1' },
 		},
 	])

--- a/packages/worker/src/mcp/jobs-vectorize.ts
+++ b/packages/worker/src/mcp/jobs-vectorize.ts
@@ -3,6 +3,7 @@ import {
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#worker/vectorize/embedding.ts'
+import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { buildLengthSafeVectorId } from '#worker/vectorize/vector-ids.ts'
 
 export function jobVectorId(jobId: string): string {
@@ -24,6 +25,7 @@ export async function upsertJobVector(
 		{
 			id: jobVectorId(input.jobId),
 			values,
+			namespace: userVectorNamespace(input.userId),
 			metadata: { kind: 'job', userId: input.userId },
 		},
 	])

--- a/packages/worker/src/mcp/memory/memory-reindex.ts
+++ b/packages/worker/src/mcp/memory/memory-reindex.ts
@@ -7,6 +7,7 @@ import {
 	reindexVectorCandidates,
 	type VectorReindexResult,
 } from '#worker/vectorize/reindex-batches.ts'
+import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { buildMemoryEmbedTextFromRow } from './memory-embed.ts'
 import { listMemoriesPage } from './repo.ts'
@@ -46,6 +47,7 @@ export async function reindexMemoryVectors(
 				candidates: rows.map((row) => ({
 					id: memoryVectorId(row.id),
 					text: buildMemoryEmbedTextFromRow(row),
+					namespace: userVectorNamespace(row.user_id),
 					metadata: {
 						kind: 'memory',
 						userId: row.user_id,

--- a/packages/worker/src/mcp/memory/memory-search.ts
+++ b/packages/worker/src/mcp/memory/memory-search.ts
@@ -11,6 +11,10 @@ import {
 	reciprocalRankFusion,
 	sortIdsByScore,
 } from '#worker/vectorize/scoring.ts'
+import {
+	queryVectorizeWithNamespaceFallback,
+	userVectorNamespace,
+} from '#worker/vectorize/vector-namespaces.ts'
 import { getRawIdFromPassthroughVectorId } from '#worker/vectorize/vector-ids.ts'
 import { parseJsonStringArray } from '@kody-internal/shared/json-parsing.ts'
 import { buildMemoryEmbedTextFromRow } from './memory-embed.ts'
@@ -45,10 +49,15 @@ export async function queryMemoryVectorIds(input: {
 	const index = getCapabilityVectorIndex(input.env)
 	if (!index || !input.userId) return []
 	const queryVector = await embedTextForVectorize(input.env, input.query)
-	const vectorMatches = await index.query(queryVector, {
-		topK: input.topK,
-		returnMetadata: 'none',
-		filter: buildMemoryVectorFilter(input),
+	const vectorMatches = await queryVectorizeWithNamespaceFallback({
+		index,
+		vector: queryVector,
+		namespace: userVectorNamespace(input.userId),
+		options: {
+			topK: input.topK,
+			returnMetadata: 'none',
+			filter: buildMemoryVectorFilter(input),
+		},
 	})
 	const memoryIds: Array<string> = []
 	const seen = new Set<string>()
@@ -117,14 +126,19 @@ export async function searchMemories(input: {
 		const index = getCapabilityVectorIndex(input.env)!
 		const queryVector = await embedTextForVectorize(input.env, query)
 		const topK = Math.min(Math.max(ids.length, input.limit * 5), 100)
-		const vectorMatches = await index.query(queryVector, {
-			topK,
-			returnMetadata: 'none',
-			filter: buildMemoryVectorFilter({
-				userId: input.userId,
-				statuses: input.statuses,
-				category: input.category,
-			}),
+		const vectorMatches = await queryVectorizeWithNamespaceFallback({
+			index,
+			vector: queryVector,
+			namespace: userVectorNamespace(input.userId),
+			options: {
+				topK,
+				returnMetadata: 'none',
+				filter: buildMemoryVectorFilter({
+					userId: input.userId,
+					statuses: input.statuses,
+					category: input.category,
+				}),
+			},
 		})
 		const seen = new Set<string>()
 		const fromIndex: Array<string> = []

--- a/packages/worker/src/mcp/memory/memory-vectorize.ts
+++ b/packages/worker/src/mcp/memory/memory-vectorize.ts
@@ -3,6 +3,7 @@ import {
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#worker/vectorize/embedding.ts'
+import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { buildLengthSafeVectorId } from '#worker/vectorize/vector-ids.ts'
 import { type MemoryStatus } from './types.ts'
 
@@ -27,6 +28,7 @@ export async function upsertMemoryVector(
 		{
 			id: memoryVectorId(input.memoryId),
 			values,
+			namespace: userVectorNamespace(input.userId),
 			metadata: {
 				kind: 'memory',
 				userId: input.userId,

--- a/packages/worker/src/mcp/memory/service.node.test.ts
+++ b/packages/worker/src/mcp/memory/service.node.test.ts
@@ -639,6 +639,7 @@ test('memory search online queries Vectorize first and hydrates vector hits by i
 
 	const vectorQueryCalls: Array<{
 		topK: number
+		namespace?: string
 		filter?: Record<string, unknown>
 	}> = []
 	const runtimeEnv = {
@@ -648,7 +649,11 @@ test('memory search online queries Vectorize first and hydrates vector hits by i
 		CAPABILITY_VECTOR_INDEX: {
 			async query(
 				_values: Array<number>,
-				options: { topK: number; filter?: Record<string, unknown> },
+				options: {
+					topK: number
+					namespace?: string
+					filter?: Record<string, unknown>
+				},
 			) {
 				vectorQueryCalls.push(options)
 				return {
@@ -669,6 +674,7 @@ test('memory search online queries Vectorize first and hydrates vector hits by i
 	// query happens inside the fusion step.
 	expect(vectorQueryCalls).toHaveLength(1)
 	expect(vectorQueryCalls[0]).toMatchObject({
+		namespace: 'user-123',
 		filter: {
 			kind: { $eq: 'memory' },
 			userId: { $eq: 'user-123' },

--- a/packages/worker/src/mcp/memory/service.node.test.ts
+++ b/packages/worker/src/mcp/memory/service.node.test.ts
@@ -670,9 +670,9 @@ test('memory search online queries Vectorize first and hydrates vector hits by i
 		limit: 5,
 	})
 
-	// One Vectorize query with user/kind/status metadata filters; no second
-	// query happens inside the fusion step.
-	expect(vectorQueryCalls).toHaveLength(1)
+	// The migration reads both the user namespace and legacy default namespace
+	// with identical user/kind/status metadata filters.
+	expect(vectorQueryCalls).toHaveLength(2)
 	expect(vectorQueryCalls[0]).toMatchObject({
 		namespace: 'user-123',
 		filter: {
@@ -681,6 +681,10 @@ test('memory search online queries Vectorize first and hydrates vector hits by i
 			status: { $in: ['active', 'archived'] },
 		},
 	})
+	expect(vectorQueryCalls[1]).toMatchObject({
+		filter: vectorQueryCalls[0]!.filter,
+	})
+	expect(vectorQueryCalls[1]).not.toHaveProperty('namespace')
 	const matchedIds = result.matches.map((match) => match.id)
 	expect(matchedIds).toContain('memory-old-vector-hit')
 	expect(matchedIds).toContain('memory-recent')

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -10,6 +10,10 @@ import {
 	reciprocalRankFusion,
 	sortIdsByScore,
 } from '#worker/vectorize/scoring.ts'
+import {
+	queryVectorizeWithNamespaceFallback,
+	userVectorNamespace,
+} from '#worker/vectorize/vector-namespaces.ts'
 import { buildExternalPackageInvocationDescriptor } from '#worker/package-invocations/public-url.ts'
 import {
 	buildPackageSearchDocument,
@@ -140,12 +144,17 @@ async function queryPackageVectorScores(input: {
 			(await embedTextForVectorize(input.env, input.query))),
 	]
 	const topK = Math.min(Math.max(input.rows.length, input.limit * 5), 100)
-	const vectorMatches = await index.query(queryVector, {
-		topK,
-		returnMetadata: 'none',
-		filter: {
-			kind: { $eq: 'package' },
-			userId: { $eq: input.userId },
+	const vectorMatches = await queryVectorizeWithNamespaceFallback({
+		index,
+		vector: queryVector,
+		namespace: userVectorNamespace(input.userId),
+		options: {
+			topK,
+			returnMetadata: 'none',
+			filter: {
+				kind: { $eq: 'package' },
+				userId: { $eq: input.userId },
+			},
 		},
 	})
 	const scores = new Map<string, number>()

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1196,7 +1196,7 @@ test('searchUnified degrades to lexical package ranking when the vector query th
 	})
 
 	expect(result.offline).toBe(false)
-	expect(packageVectorQueryAttempts).toBe(1)
+	expect(packageVectorQueryAttempts).toBe(2)
 	expect(
 		result.matches.some(
 			(match) => match.type === 'package' && match.packageId === 'pkg-inbox',
@@ -1548,7 +1548,7 @@ test('searchUnified shares query embedding, fail-closes package isolation, and k
 	})
 	expect(aiRunCount).toBe(1)
 	expect(maxInFlightQueries).toBeGreaterThanOrEqual(2)
-	expect(packageQueryCount).toBe(1)
+	expect(packageQueryCount).toBe(2)
 	expect(capturedFilters).toContainEqual(
 		expect.objectContaining({
 			kind: { $eq: 'package' },
@@ -2065,13 +2065,13 @@ test('online search ranks remote, MCP, and OpenAPI Sonos operations above real c
 		expect(valueProviderIndex).toBeGreaterThan(exactValueIndex)
 	}
 
-	expect(capturedFilters).toHaveLength(cases.length * 7)
+	expect(capturedFilters).toHaveLength(cases.length * 10)
 	expect(
 		capturedFilters.filter(
 			(filter) =>
 				(filter as { kind?: { $eq?: string } }).kind?.$eq === 'builtin',
 		),
-	).toHaveLength(cases.length * 3)
+	).toHaveLength(cases.length * 6)
 	expect(
 		capturedFilters.filter(
 			(filter) =>

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -2065,7 +2065,7 @@ test('online search ranks remote, MCP, and OpenAPI Sonos operations above real c
 		expect(valueProviderIndex).toBeGreaterThan(exactValueIndex)
 	}
 
-	expect(capturedFilters).toHaveLength(cases.length * 5)
+	expect(capturedFilters).toHaveLength(cases.length * 7)
 	expect(
 		capturedFilters.filter(
 			(filter) =>
@@ -2077,7 +2077,7 @@ test('online search ranks remote, MCP, and OpenAPI Sonos operations above real c
 			(filter) =>
 				(filter as { kind?: { $eq?: string } }).kind?.$eq === 'package',
 		),
-	).toHaveLength(cases.length * 2)
+	).toHaveLength(cases.length * 4)
 	expect(aiRunCount).toBe(cases.length * 3)
 })
 

--- a/packages/worker/src/package-registry/package-reindex.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex.node.test.ts
@@ -222,6 +222,7 @@ test('saved package reindex skips failed manifest loads and continues the batch'
 		{
 			id: 'package_pkg-good',
 			values: [0.4, 0.5, 0.6],
+			namespace: 'user-1',
 			metadata: {
 				kind: 'package',
 				userId: 'user-1',

--- a/packages/worker/src/package-registry/package-reindex.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex.node.test.ts
@@ -127,6 +127,7 @@ test('saved package reindex embeds full manifests with user-scoped metadata', as
 		{
 			id: 'package_pkg-1',
 			values: [0.1, 0.2, 0.3],
+			namespace: 'user-1',
 			metadata: {
 				kind: 'package',
 				userId: 'user-1',

--- a/packages/worker/src/package-registry/package-reindex.ts
+++ b/packages/worker/src/package-registry/package-reindex.ts
@@ -9,6 +9,7 @@ import {
 	type VectorReindexFailure,
 	type VectorReindexResult,
 } from '#worker/vectorize/reindex-batches.ts'
+import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { buildSavedPackageEmbedText } from './embed.ts'
@@ -54,6 +55,7 @@ export async function reindexSavedPackageVectors(
 				candidates.push({
 					id: savedPackageVectorId(row.id),
 					text: buildSavedPackageEmbedText(manifest),
+					namespace: userVectorNamespace(row.userId),
 					metadata: {
 						kind: 'package',
 						userId: row.userId,

--- a/packages/worker/src/package-registry/vectorize.ts
+++ b/packages/worker/src/package-registry/vectorize.ts
@@ -3,6 +3,7 @@ import {
 	getCapabilityVectorIndex,
 	isCapabilitySearchOffline,
 } from '#worker/vectorize/embedding.ts'
+import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
 import { savedPackageVectorId } from './repo.ts'
 
 export async function upsertSavedPackageVector(
@@ -20,6 +21,7 @@ export async function upsertSavedPackageVector(
 		{
 			id: savedPackageVectorId(input.packageId),
 			values,
+			namespace: userVectorNamespace(input.userId),
 			metadata: {
 				kind: 'package',
 				userId: input.userId,

--- a/packages/worker/src/vectorize/reindex-batches.node.test.ts
+++ b/packages/worker/src/vectorize/reindex-batches.node.test.ts
@@ -30,9 +30,24 @@ test('reindexVectorCandidates isolates failed embedding items and upserts the re
 				index: { upsert } as unknown as VectorizeIndex,
 				kind: 'test',
 				candidates: [
-					{ id: 'good-1', text: 'alpha', metadata: { kind: 'test' } },
-					{ id: 'bad-1', text: 'bad', metadata: { kind: 'test' } },
-					{ id: 'good-2', text: 'beta', metadata: { kind: 'test' } },
+					{
+						id: 'good-1',
+						text: 'alpha',
+						namespace: 'user-a',
+						metadata: { kind: 'test' },
+					},
+					{
+						id: 'bad-1',
+						text: 'bad',
+						namespace: 'user-a',
+						metadata: { kind: 'test' },
+					},
+					{
+						id: 'good-2',
+						text: 'beta',
+						namespace: 'user-b',
+						metadata: { kind: 'test' },
+					},
 				],
 			}),
 		).resolves.toEqual({
@@ -52,6 +67,7 @@ test('reindexVectorCandidates isolates failed embedding items and upserts the re
 			{
 				id: 'good-1',
 				values: [5],
+				namespace: 'user-a',
 				metadata: { kind: 'test' },
 			},
 		])
@@ -59,6 +75,7 @@ test('reindexVectorCandidates isolates failed embedding items and upserts the re
 			{
 				id: 'good-2',
 				values: [4],
+				namespace: 'user-b',
 				metadata: { kind: 'test' },
 			},
 		])
@@ -83,8 +100,18 @@ test('reindexVectorCandidates marks a phase fatal when every vector fails', asyn
 				index: { upsert: vi.fn() } as unknown as VectorizeIndex,
 				kind: 'test',
 				candidates: [
-					{ id: 'bad-1', text: 'alpha', metadata: { kind: 'test' } },
-					{ id: 'bad-2', text: 'beta', metadata: { kind: 'test' } },
+					{
+						id: 'bad-1',
+						text: 'alpha',
+						namespace: 'user-a',
+						metadata: { kind: 'test' },
+					},
+					{
+						id: 'bad-2',
+						text: 'beta',
+						namespace: 'user-b',
+						metadata: { kind: 'test' },
+					},
 				],
 			}),
 		).resolves.toMatchObject({

--- a/packages/worker/src/vectorize/reindex-batches.ts
+++ b/packages/worker/src/vectorize/reindex-batches.ts
@@ -12,6 +12,7 @@ export type VectorReindexFailure = {
 export type VectorReindexCandidate = {
 	id: string
 	text: string
+	namespace: string
 	metadata: Record<string, VectorizeVectorMetadata>
 }
 
@@ -116,6 +117,7 @@ export async function reindexVectorCandidates(input: {
 				batch.map((candidate, index_) => ({
 					id: candidate.id,
 					values: embeddings[index_]!,
+					namespace: candidate.namespace,
 					metadata: candidate.metadata,
 				})),
 			)

--- a/packages/worker/src/vectorize/vector-namespaces.node.test.ts
+++ b/packages/worker/src/vectorize/vector-namespaces.node.test.ts
@@ -53,6 +53,7 @@ test('user namespace queries merge partial reindex results and deny cross-user v
 	])
 	const options = {
 		topK: 2,
+		namespace: userB,
 		filter: {
 			kind: { $eq: 'package' },
 			userId: { $eq: userA },

--- a/packages/worker/src/vectorize/vector-namespaces.node.test.ts
+++ b/packages/worker/src/vectorize/vector-namespaces.node.test.ts
@@ -7,6 +7,7 @@ import {
 
 type TestVector = {
 	id: string
+	score: number
 	namespace?: string
 	userId?: string
 }
@@ -20,22 +21,38 @@ function createVectorIndex(vectors: ReadonlyArray<TestVector>) {
 			const matches = vectors
 				.filter((vector) => vector.namespace === options?.namespace)
 				.filter((vector) => !expectedUserId || vector.userId === expectedUserId)
-				.map((vector) => ({ id: vector.id, score: 1 }))
+				.map((vector) => ({ id: vector.id, score: vector.score }))
 			return { matches, count: matches.length }
 		},
 	)
 	return { index: { query } as unknown as VectorizeIndex, query }
 }
 
-test('user namespace queries deny cross-user vectors and fall back to legacy metadata-scoped vectors', async () => {
+test('user namespace queries merge partial reindex results and deny cross-user vectors', async () => {
 	const userA = 'a'.repeat(64)
 	const userB = 'b'.repeat(64)
 	const { index, query } = createVectorIndex([
-		{ id: 'package-user-b', namespace: userB, userId: userB },
-		{ id: 'package-user-a-legacy', userId: userA },
+		{
+			id: 'package-user-a-namespaced',
+			score: 0.8,
+			namespace: userA,
+			userId: userA,
+		},
+		{
+			id: 'package-user-a-namespaced',
+			score: 0.7,
+			userId: userA,
+		},
+		{ id: 'package-user-a-legacy', score: 0.9, userId: userA },
+		{
+			id: 'package-user-b',
+			score: 0.99,
+			namespace: userB,
+			userId: userB,
+		},
 	])
 	const options = {
-		topK: 10,
+		topK: 2,
 		filter: {
 			kind: { $eq: 'package' },
 			userId: { $eq: userA },
@@ -50,7 +67,11 @@ test('user namespace queries deny cross-user vectors and fall back to legacy met
 			options,
 		}),
 	).resolves.toMatchObject({
-		matches: [{ id: 'package-user-a-legacy' }],
+		matches: [
+			{ id: 'package-user-a-legacy', score: 0.9 },
+			{ id: 'package-user-a-namespaced', score: 0.8 },
+		],
+		count: 2,
 	})
 	expect(query).toHaveBeenNthCalledWith(
 		1,
@@ -60,29 +81,9 @@ test('user namespace queries deny cross-user vectors and fall back to legacy met
 	expect(query).toHaveBeenNthCalledWith(
 		2,
 		[0.1, 0.2],
-		expect.not.objectContaining({ namespace: expect.anything() }),
+		expect.objectContaining({ filter: options.filter }),
 	)
-	expect(
-		query.mock.results.flatMap((result) =>
-			result.type === 'return' ? [result.value] : [],
-		),
-	).toHaveLength(2)
-
-	query.mockClear()
-	const namespaced = createVectorIndex([
-		{ id: 'package-user-a', namespace: userA, userId: userA },
-		{ id: 'package-user-b', namespace: userB, userId: userB },
-	])
-	await expect(
-		queryVectorizeWithNamespaceFallback({
-			index: namespaced.index,
-			vector: [0.1, 0.2],
-			namespace: userVectorNamespace(userA),
-			options,
-		}),
-	).resolves.toMatchObject({
-		matches: [{ id: 'package-user-a' }],
-	})
-	expect(namespaced.query).toHaveBeenCalledTimes(1)
+	expect(query.mock.calls[1]?.[1]).not.toHaveProperty('namespace')
+	expect(query).toHaveBeenCalledTimes(2)
 	expect(BUILTIN_VECTOR_NAMESPACE).not.toMatch(/^[a-f0-9]{64}$/)
 })

--- a/packages/worker/src/vectorize/vector-namespaces.node.test.ts
+++ b/packages/worker/src/vectorize/vector-namespaces.node.test.ts
@@ -1,0 +1,90 @@
+import { expect, test, vi } from 'vitest'
+import {
+	BUILTIN_VECTOR_NAMESPACE,
+	queryVectorizeWithNamespaceFallback,
+	userVectorNamespace,
+} from './vector-namespaces.ts'
+
+type TestVector = {
+	id: string
+	namespace?: string
+	userId?: string
+}
+
+function createVectorIndex(vectors: ReadonlyArray<TestVector>) {
+	const query = vi.fn(
+		async (_vector: Array<number>, options?: VectorizeQueryOptions) => {
+			const expectedUserId = (
+				options?.filter?.['userId'] as { $eq?: string } | undefined
+			)?.$eq
+			const matches = vectors
+				.filter((vector) => vector.namespace === options?.namespace)
+				.filter(
+					(vector) => !expectedUserId || vector.userId === expectedUserId,
+				)
+				.map((vector) => ({ id: vector.id, score: 1 }))
+			return { matches, count: matches.length }
+		},
+	)
+	return { index: { query } as unknown as VectorizeIndex, query }
+}
+
+test('user namespace queries deny cross-user vectors and fall back to legacy metadata-scoped vectors', async () => {
+	const userA = 'a'.repeat(64)
+	const userB = 'b'.repeat(64)
+	const { index, query } = createVectorIndex([
+		{ id: 'package-user-b', namespace: userB, userId: userB },
+		{ id: 'package-user-a-legacy', userId: userA },
+	])
+	const options = {
+		topK: 10,
+		filter: {
+			kind: { $eq: 'package' },
+			userId: { $eq: userA },
+		},
+	} satisfies VectorizeQueryOptions
+
+	await expect(
+		queryVectorizeWithNamespaceFallback({
+			index,
+			vector: [0.1, 0.2],
+			namespace: userVectorNamespace(userA),
+			options,
+		}),
+	).resolves.toMatchObject({
+		matches: [{ id: 'package-user-a-legacy' }],
+	})
+	expect(query).toHaveBeenNthCalledWith(
+		1,
+		[0.1, 0.2],
+		expect.objectContaining({ namespace: userA, filter: options.filter }),
+	)
+	expect(query).toHaveBeenNthCalledWith(
+		2,
+		[0.1, 0.2],
+		expect.not.objectContaining({ namespace: expect.anything() }),
+	)
+	expect(
+		query.mock.results.flatMap((result) =>
+			result.type === 'return' ? [result.value] : [],
+		),
+	).toHaveLength(2)
+
+	query.mockClear()
+	const namespaced = createVectorIndex([
+		{ id: 'package-user-a', namespace: userA, userId: userA },
+		{ id: 'package-user-b', namespace: userB, userId: userB },
+	])
+	await expect(
+		queryVectorizeWithNamespaceFallback({
+			index: namespaced.index,
+			vector: [0.1, 0.2],
+			namespace: userVectorNamespace(userA),
+			options,
+		}),
+	).resolves.toMatchObject({
+		matches: [{ id: 'package-user-a' }],
+	})
+	expect(namespaced.query).toHaveBeenCalledTimes(1)
+	expect(BUILTIN_VECTOR_NAMESPACE).not.toMatch(/^[a-f0-9]{64}$/)
+})

--- a/packages/worker/src/vectorize/vector-namespaces.node.test.ts
+++ b/packages/worker/src/vectorize/vector-namespaces.node.test.ts
@@ -19,9 +19,7 @@ function createVectorIndex(vectors: ReadonlyArray<TestVector>) {
 			)?.$eq
 			const matches = vectors
 				.filter((vector) => vector.namespace === options?.namespace)
-				.filter(
-					(vector) => !expectedUserId || vector.userId === expectedUserId,
-				)
+				.filter((vector) => !expectedUserId || vector.userId === expectedUserId)
 				.map((vector) => ({ id: vector.id, score: 1 }))
 			return { matches, count: matches.length }
 		},

--- a/packages/worker/src/vectorize/vector-namespaces.ts
+++ b/packages/worker/src/vectorize/vector-namespaces.ts
@@ -1,0 +1,31 @@
+/**
+ * Stable user ids are lowercase SHA-256 hex strings. This reserved value
+ * contains non-hex characters, so it cannot collide with an account namespace.
+ */
+export const BUILTIN_VECTOR_NAMESPACE = '__kody_builtin__'
+
+export function userVectorNamespace(userId: string): string {
+	return userId
+}
+
+/**
+ * Expand-phase read path for the namespace migration. New vectors are queried
+ * first; the legacy default namespace is consulted only when the new namespace
+ * has no matches. Metadata filters stay identical on both reads.
+ *
+ * Remove this fallback after production's full capability reindex reports that
+ * every user-owned vector was upserted into its user namespace.
+ */
+export async function queryVectorizeWithNamespaceFallback(input: {
+	index: VectorizeIndex
+	vector: ReadonlyArray<number>
+	namespace: string
+	options: VectorizeQueryOptions
+}): Promise<VectorizeMatches> {
+	const namespacedMatches = await input.index.query([...input.vector], {
+		...input.options,
+		namespace: input.namespace,
+	})
+	if (namespacedMatches.matches.length > 0) return namespacedMatches
+	return input.index.query([...input.vector], input.options)
+}

--- a/packages/worker/src/vectorize/vector-namespaces.ts
+++ b/packages/worker/src/vectorize/vector-namespaces.ts
@@ -9,9 +9,9 @@ export function userVectorNamespace(userId: string): string {
 }
 
 /**
- * Expand-phase read path for the namespace migration. New vectors are queried
- * first; the legacy default namespace is consulted only when the new namespace
- * has no matches. Metadata filters stay identical on both reads.
+ * Expand-phase read path for the namespace migration. Queries both the new
+ * namespace and the legacy default namespace so partially reindexed users keep
+ * complete results. Metadata filters stay identical on both reads.
  *
  * Remove this fallback after production's full capability reindex reports that
  * every user-owned vector was upserted into its user namespace.
@@ -22,10 +22,28 @@ export async function queryVectorizeWithNamespaceFallback(input: {
 	namespace: string
 	options: VectorizeQueryOptions
 }): Promise<VectorizeMatches> {
-	const namespacedMatches = await input.index.query([...input.vector], {
-		...input.options,
-		namespace: input.namespace,
-	})
-	if (namespacedMatches.matches.length > 0) return namespacedMatches
-	return input.index.query([...input.vector], input.options)
+	const [namespacedMatches, legacyMatches] = await Promise.all([
+		input.index.query([...input.vector], {
+			...input.options,
+			namespace: input.namespace,
+		}),
+		input.index.query([...input.vector], input.options),
+	])
+	const matchById = new Map<string, VectorizeMatch>()
+	for (const match of [
+		...namespacedMatches.matches,
+		...legacyMatches.matches,
+	]) {
+		const existing = matchById.get(match.id)
+		if (!existing || match.score > existing.score) {
+			matchById.set(match.id, match)
+		}
+	}
+	const topK =
+		input.options.topK ??
+		Math.max(namespacedMatches.matches.length, legacyMatches.matches.length)
+	const matches = [...matchById.values()]
+		.sort((left, right) => right.score - left.score)
+		.slice(0, topK)
+	return { matches, count: matches.length }
 }

--- a/packages/worker/src/vectorize/vector-namespaces.ts
+++ b/packages/worker/src/vectorize/vector-namespaces.ts
@@ -22,12 +22,14 @@ export async function queryVectorizeWithNamespaceFallback(input: {
 	namespace: string
 	options: VectorizeQueryOptions
 }): Promise<VectorizeMatches> {
+	const queryOptions = { ...input.options }
+	delete queryOptions.namespace
 	const [namespacedMatches, legacyMatches] = await Promise.all([
 		input.index.query([...input.vector], {
-			...input.options,
+			...queryOptions,
 			namespace: input.namespace,
 		}),
-		input.index.query([...input.vector], input.options),
+		input.index.query([...input.vector], queryOptions),
 	])
 	const matchById = new Map<string, VectorizeMatch>()
 	for (const match of [
@@ -40,7 +42,7 @@ export async function queryVectorizeWithNamespaceFallback(input: {
 		}
 	}
 	const topK =
-		input.options.topK ??
+		queryOptions.topK ??
 		Math.max(namespacedMatches.matches.length, legacyMatches.matches.length)
 	const matches = [...matchById.values()]
 		.sort((left, right) => right.score - left.score)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- write package, memory, and job vectors into stable per-user Vectorize namespaces
- query both namespaced and legacy-default vectors during migration, preserving userId metadata filters while merging/deduplicating ranked results
- rebuild all derived vectors into namespaces through the existing post-deploy maintenance sweep
- document the expand/contract migration and fallback removal gate

## Testing
- `npm run validate` — passed on `b6903978`
- focused cross-user/partial-reindex suite — passed
- CI — 9 checks passed, 0 failures
- production healthcheck, execute smoke check, and Vectorize reindex — passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `915db38a` · **Head:** `b6903978`

**Classification:** extends — changes the Vectorize storage and query isolation contract without adding a new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `vectorize-search` | storage | extends — namespaces become the primary per-user isolation boundary |
| `capability-registry` | assistant | extends — builtins move to a reserved namespace |
| `saved-packages` | assistant | composes — package vector reads/writes use the namespace contract |
| `jobs` | assistant | composes — job vectors reindex into owner namespaces |
| `mcp-server` | surfaces | composes — memory and unified-search paths pass namespaces |

### System map

User-owned vector writes and reads now cross the MCP/package/job surfaces into owner-specific Vectorize partitions; maintenance rebuilds the derived corpus from D1.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	jobs["jobs<br/>Scheduled jobs"]:::touched
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	vectorizeSearch["vectorize-search<br/>Vectorize search"]:::extended
	mcpServer -->|"memory dual-read + namespace/userId guards"| vectorizeSearch
	savedPackages -->|"package namespaced write + migration dual-read"| vectorizeSearch
	jobs -->|"job upsert/reindex in owner namespace"| vectorizeSearch
	capabilityRegistry -->|"builtin reserved namespace + migration dual-read"| vectorizeSearch
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Per-user isolation: Vectorize applies the namespace before search; the existing `userId` metadata filter remains on both user-owned migration reads.
- Migration completeness: namespaced and legacy matches are merged, deduplicated, reranked, and bounded to `topK` during a partial sweep.
- Canonical data remains in D1; vectors are derived and safe to rebuild.

</details>

<!-- system-recap:end -->

## Conductor report
- **STATUS:** done
- **What shipped:** Per-user namespace writes, safe mixed-partition dual reads, full maintenance reindex integration, cross-user/partial-reindex tests, and updated Vectorize storage contracts.
- **Risk:** medium — this changes a security-relevant derived-search isolation contract, but preserves metadata defense-in-depth and does not move or delete canonical data.
- **Merged/deployed:** yes — [PR #1110](https://github.com/kentcdodds/kody/pull/1110) squash-merged as `1c6dce74`; [production deploy](https://github.com/kentcdodds/kody/actions/runs/30672964254) passed, including healthcheck, smoke check, and Vectorize reindex.
- **Sibling-track scope spill:** none
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c414f41-5e39-47bc-bcff-63674a914966?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c414f41-5e39-47bc-bcff-63674a914966&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-user vector namespaces for memories, jobs, packages, and other user-owned data.
  - Added a dedicated namespace for built-in capability vectors.
  - Added temporary fallback support for legacy vectors during migration.

- **Bug Fixes**
  - Improved search isolation and filtering to prevent other users’ vectors from appearing.

- **Documentation**
  - Documented vector namespaces, metadata requirements, identifier mappings, and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->