### PR TITLE
perf(entitlements): cache enforcement plan lookups

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -16,8 +16,9 @@ Module: `packages/worker/src/entitlements/`
   `resolveEffectivePlan(manual, stripe)`.
 - `errors.ts` — the one typed error (`EntitlementLimitError`) and the one
   user-facing message builder every enforcement point uses.
-- `service.ts` — `getUserPlan`, `assertWithinEntitlement`, built-in D1 usage
-  counters, and the daily-counter helpers for rate-style limits.
+- `service.ts` — `getUserPlan`, `getCachedUserPlan` (60s TTL enforcement cache),
+  `assertWithinEntitlement`, built-in D1 usage counters, and the daily-counter
+  helpers for rate-style limits.
 
 ## Plan model
 
@@ -189,6 +190,16 @@ use stable-id reverse resolution. `findUserAccountByStableUserId` in
 `service.ts` remains available for other contextless paths that need email /
 verified-state (for example the outbound fetch gateway), mirroring
 `findUserAccount` in `email/platform-address.ts`.
+
+**Enforcement plan cache:** `assertWithinEntitlement` resolves the plan limit
+via `getCachedUserPlan`, which wraps `getUserPlan` behind a 60-second per-isolate
+TTL cache keyed by D1 binding and `(stable_user_id, normalized email)`. Cache
+entries share the lookup semantics above; failures are never cached. Built-in
+usage counters and any `getCurrent` override are read fresh on every call, so
+only the plan limit can be stale — a plan change may take up to ~60s to bind at
+enforcement points while current usage stays accurate. Surfaces that display the
+user's plan (billing UI, email usage) should keep calling `getUserPlan`
+directly.
 
 ## The error shape
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -192,14 +192,14 @@ verified-state (for example the outbound fetch gateway), mirroring
 `findUserAccount` in `email/platform-address.ts`.
 
 **Enforcement plan cache:** `assertWithinEntitlement` resolves the plan limit
-via `getCachedUserPlan`, which wraps `getUserPlan` behind a 60-second per-isolate
-TTL cache keyed by D1 binding and `(stable_user_id, normalized email)`. Cache
-entries share the lookup semantics above; failures are never cached. Built-in
-usage counters and any `getCurrent` override are read fresh on every call, so
-only the plan limit can be stale — a plan change may take up to ~60s to bind at
-enforcement points while current usage stays accurate. Surfaces that display the
-user's plan (billing UI, email usage) should keep calling `getUserPlan`
-directly.
+via `getCachedUserPlan`, which wraps `getUserPlan` behind a 60-second
+per-isolate TTL cache keyed by D1 binding and
+`(stable_user_id, normalized email)`. Cache entries share the lookup semantics
+above; failures are never cached. Built-in usage counters and any `getCurrent`
+override are read fresh on every call, so only the plan limit can be stale — a
+plan change may take up to ~60s to bind at enforcement points while current
+usage stays accurate. Surfaces that display the user's plan (billing UI, email
+usage) should keep calling `getUserPlan` directly.
 
 ## The error shape
 

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -596,6 +596,58 @@ test('assertWithinEntitlement passes under the limit, throws at it, and enforces
 	expect(error.message).toBe(buildEntitlementLimitMessage(error.details))
 })
 
+test('assertWithinEntitlement reuses cached plan within TTL while still enforcing usage', async () => {
+	const userId = await createStableUserIdFromEmail(plannedEmail)
+	const freeLimit = planLimits.free.maxScheduledJobs
+	const counts = { jobs: freeLimit - 1 }
+	const { db, queries } = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: 'free', stable_user_id: userId }],
+		counts,
+	})
+	const planQueries = () =>
+		queries.filter((query) =>
+			query.sql.includes('email = ? AND stable_user_id = ?'),
+		)
+	const usageQueries = () =>
+		queries.filter((query) => query.sql.includes('FROM jobs'))
+
+	await assertWithinEntitlement({
+		db,
+		userId,
+		email: plannedEmail,
+		resource: 'scheduled_jobs',
+	})
+	await assertWithinEntitlement({
+		db,
+		userId,
+		email: plannedEmail,
+		resource: 'scheduled_jobs',
+	})
+	expect(planQueries()).toHaveLength(1)
+	expect(usageQueries()).toHaveLength(2)
+
+	counts.jobs = freeLimit
+	const denied = await assertWithinEntitlement({
+		db,
+		userId,
+		email: plannedEmail,
+		resource: 'scheduled_jobs',
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(denied instanceof EntitlementLimitError)) {
+		throw new Error('Expected an EntitlementLimitError.')
+	}
+	expect(denied.details).toMatchObject({
+		plan: 'free',
+		limit: freeLimit,
+		current: freeLimit,
+	})
+	expect(planQueries()).toHaveLength(1)
+	expect(usageQueries()).toHaveLength(3)
+})
+
 test('assertWithinEntitlement enforces free concurrent workflow limit without email', async () => {
 	const freeLimit = planLimits.free.maxConcurrentWorkflows
 	const { db } = createEntitlementsTestDb({

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -791,8 +791,9 @@ export type AssertWithinEntitlementInput = {
 	/**
 	 * Account email of the acting user when available. When present, plan
 	 * lookup requires the email + stable-id pair. When absent (package-job /
-	 * workflow contexts with `email: ''`), {@link getUserPlan} reverse-resolves
-	 * by stable userId; unknown accounts still fail closed to `free`.
+	 * workflow contexts with `email: ''`), {@link getCachedUserPlan}
+	 * reverse-resolves by stable userId; unknown accounts still fail closed
+	 * to `free`.
 	 */
 	email: string | null | undefined
 	resource: EntitlementResource
@@ -812,7 +813,9 @@ export type AssertWithinEntitlementInput = {
 export async function assertWithinEntitlement(
 	input: AssertWithinEntitlementInput,
 ): Promise<void> {
-	const plan = await getUserPlan(input.db, {
+	// Cached plan resolution: quota limit lookup tolerates short-TTL
+	// staleness; usage counters below stay fresh on every call.
+	const plan = await getCachedUserPlan(input.db, {
 		userId: input.userId,
 		email: input.email,
 	})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- route `assertWithinEntitlement` through the existing 60-second plan cache
- keep usage reads fresh on every enforcement call
- cover repeated enforcement calls and document the bounded plan staleness

## Validation

- `npm run validate` — passed on Node 26
- targeted entitlement node suite — 27 passed
- E2E suite — 20 passed (one unrelated social-login flake on the first full run; clean isolated rerun and clean final full validation)
- [post-merge validation](https://github.com/kentcdodds/kody/actions/runs/30671783262) — passed
- [production deployment](https://github.com/kentcdodds/kody/actions/runs/30671994329) — passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends Plans & entitlements</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `915db38a` · **Head:** `7d5d7774`

**Classification:** extends — enforcement plan lookup behavior now uses the existing bounded cache; entitlement limits and usage reads are unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | Identity & auth | extends — cached plan resolution for enforcement |

### System map

Entitlement enforcement resolves the acting user's plan through a short-lived cache before reading current usage.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	entitlements -->|"cached users plan read; fresh usage read"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Every `assertWithinEntitlement` call reads the plan from D1 | Repeated calls within 60 seconds reuse the plan; usage remains fresh |

### Invariants

- plan and usage lookups remain scoped by stable user id
- unknown users continue to fail closed to the free plan

</details>

<!-- system-recap:end -->

## Conductor report

- **STATUS:** done
- **What shipped:** cached `assertWithinEntitlement` plan reads with a 60-second TTL; fresh usage enforcement and error semantics are preserved.
- **Risk:** low — reuses an existing cache already used by daily quota consumption; bounded plan-change staleness is documented and tested.
- **Merged/deployed:** yes / yes; [PR #1111](https://github.com/kentcdodds/kody/pull/1111), [post-merge validation](https://github.com/kentcdodds/kody/actions/runs/30671783262), and [production deploy](https://github.com/kentcdodds/kody/actions/runs/30671994329) all completed successfully.
- **Sibling-track spill:** none.
- **Track dependency:** the UserMeter daily-counter migration and D1 mirror retirement remain follow-up work; mirror retirement is gated on reporting-off-d1 being merged and verified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a432e2a1-c426-4168-93e7-cbbb63545282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a432e2a1-c426-4168-93e7-cbbb63545282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved entitlement checks by reusing recently resolved plan information while keeping usage data current.
  * Plan lookups are refreshed after a short cache period, and failed lookups are not retained.

* **Bug Fixes**
  * Entitlement limits continue to be enforced correctly when usage reaches its limit.

* **Documentation**
  * Clarified entitlement caching behavior and plan-resolution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->