### PR TITLE
fix(sentry): drop blockConcurrencyWhile DO timeout resets

### DIFF
--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { isUserCodeError, UserCodeError } from './user-code-error.ts'
 import {
+	durableObjectBlockConcurrencyWhileTimeoutResetMessage,
 	durableObjectCodeUpdatedResetMessage,
 	durableObjectIsolateCpuResetMessage,
 	durableObjectIsolateMemoryResetMessage,
@@ -188,9 +189,9 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	expect(filterSentryEvent(platformEvent)).toBe(platformEvent)
 
 	// Bare Cloudflare DO platform resets (memory / CPU / deploy-time code
-	// update) are transient — one representative form per family, plus an
-	// `Error:`-prefixed variant and a missing trailing period. Wrapped
-	// recovery failures must stay visible.
+	// update / blockConcurrencyWhile timeout) are transient — one
+	// representative form per family, plus an `Error:`-prefixed variant and a
+	// missing trailing period. Wrapped recovery failures must stay visible.
 	expect(
 		filterSentryEvent({
 			exception: {
@@ -215,6 +216,17 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 				values: [
 					{
 						value: durableObjectCodeUpdatedResetMessage.replace(/\.$/, ''),
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: `Error: ${durableObjectBlockConcurrencyWhileTimeoutResetMessage}`,
 					},
 				],
 			},

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -83,13 +83,15 @@ export function filterExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
 
 /**
  * Exact Cloudflare Durable Object platform-reset messages. When a DO hits its
- * memory or CPU limit, or when a deploy replaces DO code under an in-flight
+ * memory or CPU limit, when a deploy replaces DO code under an in-flight
  * RPC/alarm (for example cron `oauth_purge_expired` → OAuthPurgeCoordinator),
- * the platform resets the isolate and surfaces one of these errors to the
- * caller. The next call gets a fresh isolate; app-level retry is unsafe for
- * non-idempotent jobs, and moving heavy orchestration off JobManager is an
- * architectural change outside a triage fix. Match only the bare platform
- * strings so wrapped failures such as exhausted
+ * or when `blockConcurrencyWhile` exceeds its ~30s deadlock timeout (for
+ * example PartyServer awaiting MCP Agent `onStart` via `getServerByName` →
+ * `setName`), the platform resets the isolate and surfaces one of these
+ * errors to the caller. The next call gets a fresh isolate; app-level retry
+ * is unsafe for non-idempotent jobs, and moving heavy Agent/MCP startup out
+ * of `onStart` is an architectural change outside a triage fix. Match only
+ * the bare platform strings so wrapped failures such as exhausted
  * `package_publish_external_push` recovery messages stay visible.
  */
 export const durableObjectIsolateMemoryResetMessage =
@@ -100,6 +102,9 @@ export const durableObjectIsolateCpuResetMessage =
 
 export const durableObjectCodeUpdatedResetMessage =
 	'Durable Object reset because its code was updated.'
+
+export const durableObjectBlockConcurrencyWhileTimeoutResetMessage =
+	'A call to blockConcurrencyWhile() in a Durable Object waited for too long. The call was canceled and the Durable Object was reset.'
 
 function normalizeDurableObjectIsolateResetMessage(message: string) {
 	const withoutErrorPrefix = message.trim().replace(/^Error:\s*/i, '')
@@ -113,7 +118,8 @@ export function isDurableObjectIsolateResetMessage(message: string) {
 	return (
 		normalized === durableObjectIsolateMemoryResetMessage ||
 		normalized === durableObjectIsolateCpuResetMessage ||
-		normalized === durableObjectCodeUpdatedResetMessage
+		normalized === durableObjectCodeUpdatedResetMessage ||
+		normalized === durableObjectBlockConcurrencyWhileTimeoutResetMessage
 	)
 }
 
@@ -178,9 +184,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// matches remain as backstops for unmarked paths; see
 		// filterUserModuleBundlerFailureSentryEvent and
 		// filterExecutorSandboxTimeoutSentryEvent. Bare Cloudflare Durable
-		// Object platform reset strings (memory/CPU limits and deploy-time
-		// code updates) are dropped the same way — see
-		// filterDurableObjectIsolateResetSentryEvent.
+		// Object platform reset strings (memory/CPU limits, deploy-time code
+		// updates, and blockConcurrencyWhile timeouts) are dropped the same
+		// way — see filterDurableObjectIsolateResetSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry

- Issue: [7646578543](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7646578543/) — `Error: A call to blockConcurrencyWhile() in a Durable Object waited for too long. The call was canceled and the Durable Object was reset.`
- Culprit: `retryDurableObjectOperation(index)` · URL `https://heykody.dev/mcp`
- Single production event on release `f0b00c4a`

## Root cause

Not an application logic bug we can triage-fix with confidence. PartyServer runs Agent/MCP `onStart` inside `blockConcurrencyWhile` (via `getServerByName` → `setName`). Cloudflare enforces a ~30s deadlock timeout on that callback and resets the Durable Object when it is exceeded. Breadcrumbs show auth/lease D1 work finishing in ~140ms, then ~31s of silence until the platform error — consistent with a stall inside DO `onStart` (Agent restore + MCP `init`/`registerTools`).

Memory/CPU/code-update isolate resets are already dropped by `filterDurableObjectIsolateResetSentryEvent`. This timeout wording was missing from that exact-match allowlist. Moving heavy Agent/MCP startup out of `onStart` is an architectural change outside triage scope. No siblings share this root cause.

## Fix

Add `durableObjectBlockConcurrencyWhileTimeoutResetMessage` to the existing DO platform-reset `beforeSend` filter (same normalize path: optional `Error:` prefix / missing trailing period). Wrapped recovery failures still report. Unit tests cover the production signature. Sharing the helper also classifies the message as transient for job backoff.

## Status

- Outcome: **filtered**
- Squash-merged: `f165df56` (#1129)
- Production deploy: success ([run](https://github.com/kentcdodds/kody/actions/runs/30705200094))
- Sentry issue: ignored

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f0b00c4a` · **Head:** `725b56ea`

**Classification:** composes — no primitives added or reshaped; worker Sentry `beforeSend` gains one exact-message drop for `blockConcurrencyWhile` timeouts. Paths are outside the primitives taxonomy (`packages/worker/src/sentry-options.ts`).

### Primitives touched

_None matched by classifier. Observability wiring only._

### System map

MCP `/mcp` DO init failures that are bare `blockConcurrencyWhile` timeout reset strings are dropped before the Sentry envelope is sent.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcp["mcp-server<br/>/mcp request"]:::untouched
	sentryOpts["worker Sentry beforeSend<br/>sentry-options.ts"]:::touched
	mcp -->|"PartyServer onStart timeout reset string"| sentryOpts
	sentryOpts -->|"filterDurableObjectIsolateResetSentryEvent drops timeout reset"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Event | Before | After |
| --- | --- | --- |
| `A call to blockConcurrencyWhile() … Durable Object was reset.` | Reported | Dropped in `beforeSend` |
| Exhausted publish DO-reset recovery wrapper | Reported | Unchanged |
| Real DO / MCP failures | Reported | Unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd46829a-4e06-48e2-aa1f-027a1f155818?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd46829a-4e06-48e2-aa1f-027a1f155818&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting by correctly filtering Durable Object resets caused by `blockConcurrencyWhile()` timeouts.
  * Recognized both standard and `Error:`-prefixed timeout reset messages.

* **Documentation**
  * Updated reset-handling documentation to cover memory, CPU, deployment, and concurrency timeout resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->