### PR TITLE
fix(sentry): drop entitlement limit errors from issue reporting

### DIFF
--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -36,6 +36,7 @@ const { logMcpEvent } = await import('./observability.ts')
 const { McpCallerError } = await import('./caller-error.ts')
 const { PackageSecretAccessDeniedError } =
 	await import('./secrets/package-access.ts')
+const { EntitlementLimitError } = await import('#worker/entitlements/errors.ts')
 const { UserCodeError } = await import('#worker/user-code-error.ts')
 
 function captureMcpEvents(run: () => void) {
@@ -160,9 +161,47 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 				'Secret "x-kodykoalaAccessToken" is not allowed for package "x".',
 			),
 		})
+
+		const entitlementLimitError = new EntitlementLimitError({
+			resource: 'storage_bytes',
+			plan: 'free',
+			limit: 67_108_864,
+			current: 449_966_219,
+			upgradeHint:
+				'Remove or finish existing storage bytes you no longer need, or upgrade your plan at /account/billing.',
+		})
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'storage_query',
+			domain: 'storage',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'EntitlementLimitError',
+			errorMessage: entitlementLimitError.message,
+			cause: entitlementLimitError,
+		})
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'job_schedule_once',
+			domain: 'jobs',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage: 'Scheduling failed.',
+			cause: new Error('Scheduling failed.', {
+				cause: new EntitlementLimitError({
+					resource: 'scheduled_jobs',
+					plan: 'free',
+					limit: 10,
+					current: 46,
+					upgradeHint:
+						'Remove or finish existing scheduled jobs you no longer need, or upgrade your plan at /account/billing.',
+				}),
+			}),
+		})
 	})
 
-	expect(payloads).toHaveLength(8)
+	expect(payloads).toHaveLength(10)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/cloudflare'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
+import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { isUserCodeError } from '#worker/user-code-error.ts'
 import { isMcpCallerError } from './caller-error.ts'
 
@@ -75,6 +77,10 @@ export function errorFields(error: unknown): {
  * Failures the caller caused and can fix. They stay on the structured
  * `mcp-event` log line; sending them to Sentry creates issues that look like
  * platform bugs and trip triage automation.
+ *
+ * Plan-limit denials (`EntitlementLimitError`) belong here too: the user can
+ * clean up or upgrade, and volume is still visible on `mcp-event` lines if a
+ * spike ever needs investigation.
  */
 function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	// Sandbox failures come from caller-supplied module code (bad Notion
@@ -84,6 +90,7 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	if (payload.failurePhase === 'parse_input') return true
 	if (payload.callerError) return true
 	if (isUserCodeError(cause)) return true
+	if (getErrorCauseChain(cause).some(isEntitlementLimitError)) return true
 	return isMcpCallerError(cause)
 }
 

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { EntitlementLimitError } from './entitlements/errors.ts'
 import { isUserCodeError, UserCodeError } from './user-code-error.ts'
 import {
 	durableObjectBlockConcurrencyWhileTimeoutResetMessage,
@@ -187,6 +188,51 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).toBe(platformEvent)
 	expect(filterSentryEvent(platformEvent)).toBe(platformEvent)
+
+	// Plan-limit denials are account policy, not platform defects. Match the
+	// typed originalException (including wrappers) and the serialized type
+	// name when the instance is gone.
+	const entitlementLimitError = new EntitlementLimitError({
+		resource: 'storage_bytes',
+		plan: 'free',
+		limit: 67_108_864,
+		current: 449_966_219,
+		upgradeHint:
+			'Remove or finish existing storage bytes you no longer need, or upgrade your plan at /account/billing.',
+	})
+	const entitlementEvent = {
+		exception: {
+			values: [
+				{
+					type: 'EntitlementLimitError',
+					value: entitlementLimitError.message,
+				},
+			],
+		},
+	}
+	expect(
+		filterSentryEvent(entitlementEvent, {
+			originalException: entitlementLimitError,
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent(entitlementEvent, {
+			originalException: new Error('handler failed', {
+				cause: entitlementLimitError,
+			}),
+		}),
+	).toBeNull()
+	expect(filterSentryEvent(entitlementEvent)).toBeNull()
+	expect(
+		filterSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: entitlementLimitError.message }],
+				},
+			},
+			{ originalException: new Error(entitlementLimitError.message) },
+		),
+	).not.toBeNull()
 
 	// Bare Cloudflare DO platform resets (memory / CPU / deploy-time code
 	// update / blockConcurrencyWhile timeout) are transient — one

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -1,5 +1,7 @@
 import { type CloudflareOptions } from '@sentry/cloudflare'
 import { type ErrorEvent, type EventHint } from '@sentry/core'
+import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
+import { isEntitlementLimitError } from './entitlements/errors.ts'
 import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
 import { isUserCodeError } from './user-code-error.ts'
 
@@ -30,6 +32,36 @@ export function filterUserCodeErrorSentryEvent(
 ) {
 	if (isUserCodeError(hint?.originalException)) return null
 	return _event
+}
+
+/**
+ * Plan-limit denials are expected account policy outcomes (clean up usage or
+ * upgrade), not platform defects. MCP observability already skips them via
+ * `isCallerFailure`; this `beforeSend` gate is the backstop for any other
+ * capture path that still forwards the typed error.
+ */
+export function isEntitlementLimitErrorSentryEvent(
+	event: ErrorEvent,
+	hint?: EventHint,
+) {
+	if (
+		getErrorCauseChain(hint?.originalException).some(isEntitlementLimitError)
+	) {
+		return true
+	}
+	return (
+		event.exception?.values?.some(
+			(value) => value.type === 'EntitlementLimitError',
+		) ?? false
+	)
+}
+
+export function filterEntitlementLimitErrorSentryEvent(
+	event: ErrorEvent,
+	hint?: EventHint,
+) {
+	if (!isEntitlementLimitErrorSentryEvent(event, hint)) return event
+	return null
 }
 
 /**
@@ -144,6 +176,7 @@ export function filterDurableObjectIsolateResetSentryEvent(event: ErrorEvent) {
 export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	// Marker first: primary mechanism for user-authored failures.
 	if (filterUserCodeErrorSentryEvent(event, hint) === null) return null
+	if (filterEntitlementLimitErrorSentryEvent(event, hint) === null) return null
 	if (filterRetryableD1LockSentryEvent(event) === null) return null
 	// String-match backstops for paths that cannot yet be marked.
 	if (filterUserModuleBundlerFailureSentryEvent(event) === null) return null
@@ -180,9 +213,11 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// regress Sentry issues.
 		//
 		// User-authored failures are dropped primarily via `UserCodeError`
-		// (`filterUserCodeErrorSentryEvent`). Bundler / sandbox-timeout string
-		// matches remain as backstops for unmarked paths; see
-		// filterUserModuleBundlerFailureSentryEvent and
+		// (`filterUserCodeErrorSentryEvent`). Plan-limit denials
+		// (`EntitlementLimitError`) are dropped the same way — expected
+		// account policy, still visible on structured `mcp-event` logs. Bundler
+		// / sandbox-timeout string matches remain as backstops for unmarked
+		// paths; see filterUserModuleBundlerFailureSentryEvent and
 		// filterExecutorSandboxTimeoutSentryEvent. Bare Cloudflare Durable
 		// Object platform reset strings (memory/CPU limits, deploy-time code
 		// updates, and blockConcurrencyWhile timeouts) are dropped the same


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry

- Issue: [7644296748](https://kent-c-dodds-tech-llc.sentry.io/issues/7644296748/) — `EntitlementLimitError` storage bytes plan limit (28 events, free plan over quota)
- Sibling: [7643914715](https://kent-c-dodds-tech-llc.sentry.io/issues/7643914715/) — scheduled jobs plan limit
- Culprit: `assertWithinEntitlement` via MCP capability handlers (`storage_query`, `job_schedule_once`)

## Root cause

Not a platform bug. MCP `logMcpEvent` reports handler failures to Sentry unless they are classified as caller failures (`McpCallerError`, `UserCodeError`, sandbox/parse_input). `EntitlementLimitError` is an expected plan-limit denial the user can clear (clean up usage or upgrade), but it was not in that set — so routine quota hits opened and escalated Sentry issues and tripped triage.

## Fix

Treat entitlement limit errors as caller failures in MCP observability (still logged on structured `mcp-event` lines for volume signal) and add a `beforeSend` backstop for any other capture path that forwards the typed error. Real platform failures remain reportable.

## Status

- Outcome: **filtered**
- After merge/deploy: ignore the existing Sentry issues

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `30a5bc46` · **Head:** `32b1ed53`

**Classification:** composes — no primitives added or reshaped; MCP observability and worker Sentry `beforeSend` gain entitlement-limit drop paths using the existing typed error.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | composes — entitlement denials stay on `mcp-event`, off Sentry |

### System map

MCP capability plan-limit denials are classified as caller failures before Sentry capture; worker `beforeSend` drops any remaining typed `EntitlementLimitError` envelopes.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	sentryOpts["worker Sentry beforeSend<br/>sentry-options.ts"]:::touched
	mcpServer -->|"EntitlementLimitError skipped in isCallerFailure"| mcpServer
	mcpServer -->|"typed entitlement capture still hit beforeSend"| sentryOpts
	sentryOpts -->|"filterEntitlementLimitErrorSentryEvent drops"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Event | Before | After |
| --- | --- | --- |
| `EntitlementLimitError` from MCP capability handler | Sentry issue + `mcp-event` | `mcp-event` only |
| Wrapped entitlement cause chain | Reported | Dropped |
| Real MCP/platform handler failures | Reported | Unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5be868d1-5796-442c-91d7-1a29ee54cbd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5be868d1-5796-442c-91d7-1a29ee54cbd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

