### PR TITLE
fix(repo): expand brace globs before Workspace.glob in repo_search

### DIFF
--- a/packages/worker/src/repo/repo-session-search.node.test.ts
+++ b/packages/worker/src/repo/repo-session-search.node.test.ts
@@ -1,0 +1,95 @@
+import { expect, test, vi } from 'vitest'
+import {
+	expandBraceGlobs,
+	searchRepoWorkspace,
+} from './repo-session-search.ts'
+
+test('expandBraceGlobs expands brace alternatives that include wildcards', () => {
+	expect(expandBraceGlobs('/{README.md,package.json,**/README*}')).toEqual([
+		'/README.md',
+		'/package.json',
+		'/**/README*',
+	])
+	expect(expandBraceGlobs('**/*.{ts,tsx}')).toEqual(['**/*.ts', '**/*.tsx'])
+	expect(expandBraceGlobs('src/{a,{b,c}}/x')).toEqual([
+		'src/a/x',
+		'src/b/x',
+		'src/c/x',
+	])
+	expect(expandBraceGlobs('plain.txt')).toEqual(['plain.txt'])
+	expect(expandBraceGlobs('{unclosed')).toEqual(['{unclosed'])
+})
+
+test('searchRepoWorkspace accepts brace globs with nested wildcards without calling shell brace conversion', async () => {
+	const globCalls: Array<string> = []
+	const files = new Map<string, string>([
+		['/README.md', 'hello from readme'],
+		['/package.json', '{"name":"demo"}'],
+		['/docs/README.extra.md', 'hello from nested readme'],
+		['/src/index.ts', 'hello from source'],
+	])
+
+	const result = await searchRepoWorkspace({
+		root: '/',
+		pattern: 'hello',
+		glob: '/{README.md,package.json,**/README*}',
+		workspace: {
+			async glob(pattern) {
+				globCalls.push(pattern)
+				// Mimic @cloudflare/shell Workspace.glob: brace groups that still
+				// contain wildcards throw SyntaxError ("Nothing to repeat").
+				if (/\{[^}]*[*?]/.test(pattern)) {
+					throw new SyntaxError(
+						`Invalid regular expression: /^${pattern}$/: Nothing to repeat`,
+					)
+				}
+				return [...files.keys()]
+					.filter((path) => {
+						if (pattern === '/README.md') return path === '/README.md'
+						if (pattern === '/package.json') return path === '/package.json'
+						if (pattern === '/**/README*') {
+							return path === '/README.md' || path.endsWith('/README.extra.md')
+						}
+						return false
+					})
+					.map((path) => ({ path, type: 'file' }))
+			},
+			async readFile(path) {
+				return files.get(path) ?? null
+			},
+		},
+		toExternalPath(path) {
+			return path.replace(/^\//, '')
+		},
+	})
+
+	expect(globCalls).toEqual([
+		'/README.md',
+		'/package.json',
+		'/**/README*',
+	])
+	expect(result.totalFiles).toBe(2)
+	expect(result.totalMatches).toBe(2)
+	expect(result.files.map((file) => file.path).sort()).toEqual([
+		'README.md',
+		'docs/README.extra.md',
+	])
+})
+
+test('searchRepoWorkspace rejects pathological brace expansion', async () => {
+	const workspace = {
+		glob: vi.fn(async () => []),
+		readFile: vi.fn(async () => null),
+	}
+
+	await expect(
+		searchRepoWorkspace({
+			root: '/',
+			pattern: 'x',
+			glob: '{a,b}{a,b}{a,b}{a,b}{a,b}{a,b}{a,b}',
+			workspace,
+			toExternalPath: (path) => path,
+		}),
+	).rejects.toThrow(/expands to more than 64 patterns/)
+	expect(workspace.glob).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/repo/repo-session-search.node.test.ts
+++ b/packages/worker/src/repo/repo-session-search.node.test.ts
@@ -1,8 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import {
-	expandBraceGlobs,
-	searchRepoWorkspace,
-} from './repo-session-search.ts'
+import { expandBraceGlobs, searchRepoWorkspace } from './repo-session-search.ts'
 
 test('expandBraceGlobs expands brace alternatives that include wildcards', () => {
 	expect(expandBraceGlobs('/{README.md,package.json,**/README*}')).toEqual([
@@ -63,11 +60,7 @@ test('searchRepoWorkspace accepts brace globs with nested wildcards without call
 		},
 	})
 
-	expect(globCalls).toEqual([
-		'/README.md',
-		'/package.json',
-		'/**/README*',
-	])
+	expect(globCalls).toEqual(['/README.md', '/package.json', '/**/README*'])
 	expect(result.totalFiles).toBe(2)
 	expect(result.totalMatches).toBe(2)
 	expect(result.files.map((file) => file.path).sort()).toEqual([

--- a/packages/worker/src/repo/repo-session-search.node.test.ts
+++ b/packages/worker/src/repo/repo-session-search.node.test.ts
@@ -86,3 +86,11 @@ test('searchRepoWorkspace rejects pathological brace expansion', async () => {
 	).rejects.toThrow(/expands to more than 64 patterns/)
 	expect(workspace.glob).not.toHaveBeenCalled()
 })
+
+test('expandBraceGlobs rejects deeply nested single-alternative braces', () => {
+	let nested = 'x'
+	for (let index = 0; index < 20; index += 1) {
+		nested = `{${nested}}`
+	}
+	expect(() => expandBraceGlobs(nested)).toThrow(/brace nesting exceeds 16/)
+})

--- a/packages/worker/src/repo/repo-session-search.ts
+++ b/packages/worker/src/repo/repo-session-search.ts
@@ -9,6 +9,7 @@ import {
 const defaultRepoSearchLimit = 50
 const maxRepoSearchBytes = 200_000
 const maxRepoSearchRegexLength = 512
+const maxExpandedGlobPatterns = 64
 const obviousNestedQuantifierPattern =
 	/\((?:[^()\\]|\\.)*[+*{][^)]*\)(?:[+*]|\{\d+(?:,\d*)?\})/
 
@@ -19,6 +20,90 @@ function normalizeSearchLimit(limit: number | undefined) {
 
 function escapeRegex(source: string) {
 	return source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Expand brace groups into concrete globs before calling Workspace.glob.
+ *
+ * @cloudflare/shell currently splices brace alternatives into one regex group
+ * without converting nested wildcards, so a brace arm that still contains `*`
+ * or `?` throws "SyntaxError: Nothing to repeat". Expanding first keeps each
+ * alternative on the wildcard-aware path.
+ */
+export function expandBraceGlobs(pattern: string): Array<string> {
+	const open = pattern.indexOf('{')
+	if (open === -1) return [pattern]
+
+	let depth = 0
+	let close = -1
+	for (let index = open; index < pattern.length; index += 1) {
+		const character = pattern[index]
+		if (character === '{') depth += 1
+		else if (character === '}') {
+			depth -= 1
+			if (depth === 0) {
+				close = index
+				break
+			}
+		}
+	}
+	if (close === -1) return [pattern]
+
+	const prefix = pattern.slice(0, open)
+	const suffix = pattern.slice(close + 1)
+	const alternatives: Array<string> = []
+	let alternativeStart = open + 1
+	depth = 0
+	for (let index = open + 1; index < close; index += 1) {
+		const character = pattern[index]
+		if (character === '{') depth += 1
+		else if (character === '}') depth -= 1
+		else if (character === ',' && depth === 0) {
+			alternatives.push(pattern.slice(alternativeStart, index))
+			alternativeStart = index + 1
+		}
+	}
+	alternatives.push(pattern.slice(alternativeStart, close))
+
+	const expanded: Array<string> = []
+	for (const alternative of alternatives) {
+		for (const candidate of expandBraceGlobs(
+			`${prefix}${alternative}${suffix}`,
+		)) {
+			expanded.push(candidate)
+			if (expanded.length > maxExpandedGlobPatterns) {
+				throw new Error(
+					`repo_search glob expands to more than ${maxExpandedGlobPatterns} patterns.`,
+				)
+			}
+		}
+	}
+	return expanded
+}
+
+async function globWorkspaceFiles(input: {
+	workspace: {
+		glob(pattern: string): Promise<Array<{ path: string; type: string }>>
+	}
+	pattern: string
+}): Promise<Array<{ path: string; type: string }>> {
+	const patterns = expandBraceGlobs(input.pattern)
+	if (patterns.length === 1) {
+		const [onlyPattern] = patterns
+		if (onlyPattern === undefined) return []
+		return input.workspace.glob(onlyPattern)
+	}
+
+	const byPath = new Map<string, { path: string; type: string }>()
+	for (const pattern of patterns) {
+		const entries = await input.workspace.glob(pattern)
+		for (const entry of entries) {
+			byPath.set(entry.path, entry)
+		}
+	}
+	return [...byPath.values()].sort((left, right) =>
+		left.path.localeCompare(right.path),
+	)
 }
 
 function assertSafeRepoSearchRegex(pattern: string) {
@@ -149,7 +234,10 @@ export async function searchRepoWorkspace(input: {
 	const globPattern =
 		input.glob?.trim() ||
 		`${input.root.replace(/\/+$/, '')}/**/*.{ts,tsx,js,jsx,json,md,css}`
-	const files = await input.workspace.glob(globPattern)
+	const files = await globWorkspaceFiles({
+		workspace: input.workspace,
+		pattern: globPattern,
+	})
 	const matchMap = new Map<string, RepoSearchFileMatch>()
 	const outputMode = input.outputMode ?? 'content'
 	let remaining = normalizeSearchLimit(input.limit)

--- a/packages/worker/src/repo/repo-session-search.ts
+++ b/packages/worker/src/repo/repo-session-search.ts
@@ -10,6 +10,7 @@ const defaultRepoSearchLimit = 50
 const maxRepoSearchBytes = 200_000
 const maxRepoSearchRegexLength = 512
 const maxExpandedGlobPatterns = 64
+const maxBraceNestingDepth = 16
 const obviousNestedQuantifierPattern =
 	/\((?:[^()\\]|\\.)*[+*{][^)]*\)(?:[+*]|\{\d+(?:,\d*)?\})/
 
@@ -30,18 +31,26 @@ function escapeRegex(source: string) {
  * or `?` throws "SyntaxError: Nothing to repeat". Expanding first keeps each
  * alternative on the wildcard-aware path.
  */
-export function expandBraceGlobs(pattern: string): Array<string> {
+export function expandBraceGlobs(
+	pattern: string,
+	nestingDepth = 0,
+): Array<string> {
 	const open = pattern.indexOf('{')
 	if (open === -1) return [pattern]
+	if (nestingDepth >= maxBraceNestingDepth) {
+		throw new Error(
+			`repo_search glob brace nesting exceeds ${maxBraceNestingDepth} levels.`,
+		)
+	}
 
-	let depth = 0
+	let braceDepth = 0
 	let close = -1
 	for (let index = open; index < pattern.length; index += 1) {
 		const character = pattern[index]
-		if (character === '{') depth += 1
+		if (character === '{') braceDepth += 1
 		else if (character === '}') {
-			depth -= 1
-			if (depth === 0) {
+			braceDepth -= 1
+			if (braceDepth === 0) {
 				close = index
 				break
 			}
@@ -53,12 +62,12 @@ export function expandBraceGlobs(pattern: string): Array<string> {
 	const suffix = pattern.slice(close + 1)
 	const alternatives: Array<string> = []
 	let alternativeStart = open + 1
-	depth = 0
+	braceDepth = 0
 	for (let index = open + 1; index < close; index += 1) {
 		const character = pattern[index]
-		if (character === '{') depth += 1
-		else if (character === '}') depth -= 1
-		else if (character === ',' && depth === 0) {
+		if (character === '{') braceDepth += 1
+		else if (character === '}') braceDepth -= 1
+		else if (character === ',' && braceDepth === 0) {
 			alternatives.push(pattern.slice(alternativeStart, index))
 			alternativeStart = index + 1
 		}
@@ -69,6 +78,7 @@ export function expandBraceGlobs(pattern: string): Array<string> {
 	for (const alternative of alternatives) {
 		for (const candidate of expandBraceGlobs(
 			`${prefix}${alternative}${suffix}`,
+			nestingDepth + 1,
 		)) {
 			expanded.push(candidate)
 			if (expanded.length > maxExpandedGlobPatterns) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-CLOUDFLARE-39](https://kent-c-dodds-tech-llc.sentry.io/issues/7646917129/): `repo_search` crashed with `SyntaxError: Invalid regular expression … Nothing to repeat` when the `glob` argument used brace alternatives that still contained wildcards (for example `{README.md,package.json,**/README*}`).

**Root cause:** `@cloudflare/shell` `globToRegex` splices brace alternatives into a single `(?:…)` group without converting nested `*` / `**` / `?`.

**Fix:** Expand brace groups in `searchRepoWorkspace` before calling `Workspace.glob`, union the results, cap expansion at 64 patterns, and cap brace nesting depth at 16.

## Test plan

- [x] `repo-session-search.node.test.ts` covers brace expansion, the Sentry-shaped glob, expansion cap, and nesting depth cap
- [x] CI validate green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d03e332e` · **Head:** `eb85a4c9`

**Classification:** extends — `repo_search` now expands brace globs before
calling `@cloudflare/shell` Workspace.glob so wildcard arms do not hit the
shell regex bug.

### Primitives touched

| Primitive       | Group   | Impact                                                                 |
| --------------- | ------- | ---------------------------------------------------------------------- |
| `repo-sessions` | runtime | extends — brace-expand user/default globs before Workspace.glob in search |

### System map

`repo_search` expands brace globs in-process, then unions Workspace.glob results.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red =
new primitive · gray = context (unchanged, included only when an edge crosses
it).

```mermaid
flowchart LR
	repoSearch["repo_search<br/>MCP capability"]:::untouched
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	shellGlob["@cloudflare/shell<br/>Workspace.glob"]:::untouched
	repoSearch -->|"search RPC"| repoSessions
	repoSessions -->|"brace-expanded patterns"| shellGlob
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** brace glob with nested wildcards → shell builds an invalid regex →
`SyntaxError: Nothing to repeat`.

**After:** same glob expands to concrete alternatives, each globbed separately
and unioned.

### Invariants

None touched (per-user isolation, auth, billing unchanged).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-561ff45b-f223-410d-98c8-7d1a35e451bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-561ff45b-f223-410d-98c8-7d1a35e451bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace searches now support brace-style glob patterns, including nested alternatives.
  * Matching results are deduplicated and consistently sorted.
  * Expansions exceeding 64 patterns are rejected to prevent excessive searches.

* **Bug Fixes**
  * Improved repository workspace searching for complex glob patterns and unmatched braces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->