### PR TITLE
fix(community): keep rate-before-fork mistakes off Sentry

### DIFF
--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -11,6 +11,7 @@ import { communitySetFeaturedCapability } from '#mcp/capabilities/community/set-
 import { communitySetTrustedCapability } from '#mcp/capabilities/community/set-trusted.ts'
 import { communityContentWarning } from '#mcp/capabilities/community/shared.ts'
 import { callerCanAccessCapability } from '#mcp/capabilities/access-control.ts'
+import { CommunityActionError } from '#worker/community/errors.ts'
 import {
 	banCommunityUser,
 	listFeaturedCommunityListingsWithAggregates,
@@ -308,7 +309,7 @@ test('community package flow works end-to-end through capability handlers', asyn
 			},
 			reporterCtx,
 		),
-	).rejects.toThrow('rate after forking')
+	).rejects.toThrow('Fork this community listing before rating it.')
 
 	await communityRateCapability.handler(
 		{

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -309,7 +309,11 @@ test('community package flow works end-to-end through capability handlers', asyn
 			},
 			reporterCtx,
 		),
-	).rejects.toThrow('Fork this community listing before rating it.')
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityActionError &&
+			error.message === 'Fork this community listing before rating it.',
+	)
 
 	await communityRateCapability.handler(
 		{

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { CommunityActionError } from './errors.ts'
 import type * as CommunityRepo from './repo.ts'
 import { type CommunityListingRecord } from './types.ts'
 
@@ -797,7 +798,7 @@ test('rateCommunityListing rejects owner self-ratings and persists valid ratings
 			stars: 5,
 			adaptationEffort: 2,
 		}),
-	).rejects.toThrow()
+	).rejects.toBeInstanceOf(CommunityActionError)
 	expect(mockModule.upsertCommunityRating).not.toHaveBeenCalled()
 
 	mockModule.getCommunityForkByListingAndUser.mockResolvedValue({
@@ -835,6 +836,27 @@ test('rateCommunityListing rejects owner self-ratings and persists valid ratings
 		kind: 'rating',
 		activityId: 'rating-1',
 	})
+})
+
+test('rateCommunityListing rejects ratings without a prior fork as CommunityActionError', async () => {
+	mockModule.getCommunityBan.mockResolvedValue(null)
+	mockModule.getCommunityListingById.mockResolvedValue(sampleListing())
+	mockModule.getCommunityForkByListingAndUser.mockResolvedValue(null)
+
+	await expect(
+		rateCommunityListing({
+			env: createEnv(),
+			userId: 'user-2',
+			listingId: 'listing-1',
+			stars: 4,
+			adaptationEffort: 2,
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityActionError &&
+			error.message === 'Fork this community listing before rating it.',
+	)
+	expect(mockModule.upsertCommunityRating).not.toHaveBeenCalled()
 })
 
 test('forkCommunityListing creates inert source without saved package row', async () => {

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -1127,7 +1127,9 @@ export async function rateCommunityListing(input: {
 		includeDelisted: false,
 	})
 	if (!listing) {
-		throw new Error(`Community listing "${input.listingId}" was not found.`)
+		throw new CommunityActionError(
+			`Community listing "${input.listingId}" was not found.`,
+		)
 	}
 	if (listing.ownerUserId === input.userId) {
 		throw new CommunityActionError('You cannot rate your own listing.')
@@ -1138,7 +1140,10 @@ export async function rateCommunityListing(input: {
 		userId: input.userId,
 	})
 	if (!fork) {
-		throw new Error('rate after forking')
+		// Precondition the agent can clear: fork first, then rate.
+		throw new CommunityActionError(
+			'Fork this community listing before rating it.',
+		)
 	}
 
 	const rating = await upsertCommunityRating(input.env.APP_DB, {

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -36,6 +36,7 @@ const { logMcpEvent } = await import('./observability.ts')
 const { McpCallerError } = await import('./caller-error.ts')
 const { PackageSecretAccessDeniedError } =
 	await import('./secrets/package-access.ts')
+const { CommunityActionError } = await import('#worker/community/errors.ts')
 const { EntitlementLimitError } = await import('#worker/entitlements/errors.ts')
 const { UserCodeError } = await import('#worker/user-code-error.ts')
 
@@ -162,6 +163,19 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			),
 		})
 
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'community_rate',
+			domain: 'community',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'CommunityActionError',
+			errorMessage: 'Fork this community listing before rating it.',
+			cause: new CommunityActionError(
+				'Fork this community listing before rating it.',
+			),
+		})
+
 		const entitlementLimitError = new EntitlementLimitError({
 			resource: 'storage_bytes',
 			plan: 'free',
@@ -201,7 +215,7 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 		})
 	})
 
-	expect(payloads).toHaveLength(10)
+	expect(payloads).toHaveLength(11)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/cloudflare'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
+import { CommunityActionError } from '#worker/community/errors.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { isUserCodeError } from '#worker/user-code-error.ts'
 import { isMcpCallerError } from './caller-error.ts'
@@ -91,6 +92,15 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	if (payload.callerError) return true
 	if (isUserCodeError(cause)) return true
 	if (getErrorCauseChain(cause).some(isEntitlementLimitError)) return true
+	// Community preconditions (rate before fork, self-rate, banned, …) are
+	// caller-clearable; keep them on mcp-event and out of Sentry.
+	if (
+		getErrorCauseChain(cause).some(
+			(entry) => entry instanceof CommunityActionError,
+		)
+	) {
+		return true
+	}
 	return isMcpCallerError(cause)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-3A](https://kent-c-dodds-tech-llc.sentry.io/issues/7646932220/) (`Error: rate after forking` in `rateCommunityListing`) was a routine `community_rate` precondition: the agent rated a listing without forking first. The service threw a plain `Error`, so MCP observability reported it as a platform bug.

This PR:

- throws `CommunityActionError` for missing listing / rate-before-fork (clearer message: "Fork this community listing before rating it.")
- treats `CommunityActionError` as a caller failure in MCP observability so these stay on `mcp-event` logs and out of Sentry
- adds/updates unit + flow coverage

No siblings share this root cause.

## Risk / merge

**composes** (low risk): wiring of existing error typing + observability skip; no auth/isolation/billing/migrations. Safe to squash-merge once CI is green.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `eda6b824` · **Head:** `3202d6a5`

**Classification:** composes — no primitives added or changed; types an expected community precondition as `CommunityActionError` and skips it in MCP Sentry reporting.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `community-listings` | assistant | composes — throw typed caller error for rate-before-fork |
| `mcp-server` | surfaces | composes — treat `CommunityActionError` as caller failure |

### System map

_Agent calls `community_rate` without a prior fork → service throws typed caller error → MCP observability logs `mcp-event` and skips Sentry._

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
  agent[Agent / community_rate] --> rate[rateCommunityListing]
  rate -->|no fork row| err[CommunityActionError]
  err --> obs[MCP observability]
  obs -->|caller failure| log[mcp-event log only]
  obs -.->|skipped| sentry[Sentry]
  classDef composes fill:#d1fae5,stroke:#065f46
  class rate,err,obs,log composes
  classDef context fill:#f3f4f6,stroke:#6b7280
  class agent,sentry context
```

### Invariants

- No change to per-user isolation, auth, billing, or storage.
- Agents still receive a clear error; only Sentry reporting changes.

### Review focus

1. Confirm `CommunityActionError` is the right shared type for MCP skip (vs wrapping only at the capability boundary).
2. Message clarity for agents: "Fork this community listing before rating it."

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99d707e7-f98a-45fc-add0-0e614440da05?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99d707e7-f98a-45fc-add0-0e614440da05&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved community listing rating errors with clearer guidance when a listing must be forked first.
  - Prevented ratings from being saved when the required fork is missing.
  - Improved handling and reporting of expected community action errors in MCP observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->