### PR TITLE
fix(admin): keep mailbox canary not-found off Sentry

### DIFF
--- a/packages/worker/src/admin/mailbox-maintenance.node.test.ts
+++ b/packages/worker/src/admin/mailbox-maintenance.node.test.ts
@@ -61,6 +61,7 @@ const {
 	adminMailboxMaintenanceRetentionMaxLimit,
 	listUsersForAdminMailboxRetention,
 	loadAdminMailboxMaintenanceStatus,
+	AdminMailboxMessageNotFoundError,
 	runAdminMailboxMaintenanceDeleteMessage,
 	runAdminMailboxMaintenanceReconcile,
 	runAdminMailboxMaintenanceRetention,
@@ -743,8 +744,11 @@ test('delete_message enforces owner isolation and verifies D1/R2 linkage aggrega
 			stableUserId: ownerA,
 			messageId: messageB,
 		}),
-	).rejects.toThrow(
-		`Email message not found for stable_user_id=${ownerA} message_id=${messageB}`,
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof AdminMailboxMessageNotFoundError &&
+			error.message ===
+				`Email message not found for stable_user_id=${ownerA} message_id=${messageB}`,
 	)
 	await expect(
 		runAdminMailboxMaintenanceDeleteMessage({
@@ -752,8 +756,11 @@ test('delete_message enforces owner isolation and verifies D1/R2 linkage aggrega
 			stableUserId: ownerA,
 			messageId: 'missing-message',
 		}),
-	).rejects.toThrow(
-		`Email message not found for stable_user_id=${ownerA} message_id=missing-message`,
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof AdminMailboxMessageNotFoundError &&
+			error.message ===
+				`Email message not found for stable_user_id=${ownerA} message_id=missing-message`,
 	)
 	expect(
 		await getEmailMessageById({

--- a/packages/worker/src/admin/mailbox-maintenance.ts
+++ b/packages/worker/src/admin/mailbox-maintenance.ts
@@ -634,6 +634,21 @@ export async function runAdminMailboxMaintenanceRetention(input: {
 }
 
 /**
+ * Missing or foreign target for owner-scoped canary delete. Callers supplied
+ * an id that does not resolve under the given owner fence — not a platform
+ * defect. The MCP capability maps this to `McpCallerError` so it stays on
+ * `mcp-event` and out of Sentry.
+ */
+export class AdminMailboxMessageNotFoundError extends Error {
+	constructor(input: { stableUserId: string; messageId: string }) {
+		super(
+			`Email message not found for stable_user_id=${input.stableUserId} message_id=${input.messageId}`,
+		)
+		this.name = 'AdminMailboxMessageNotFoundError'
+	}
+}
+
+/**
  * Owner-scoped single-message delete for accelerated Mailbox coverage canaries.
  * Verifies ownership via getEmailMessageById, deletes through
  * deleteEmailMessageById with an expectedUserId fence, then confirms D1
@@ -653,9 +668,10 @@ export async function runAdminMailboxMaintenanceDeleteMessage(input: {
 		messageId: input.messageId,
 	})
 	if (!message) {
-		throw new Error(
-			`Email message not found for stable_user_id=${input.stableUserId} message_id=${input.messageId}`,
-		)
+		throw new AdminMailboxMessageNotFoundError({
+			stableUserId: input.stableUserId,
+			messageId: input.messageId,
+		})
 	}
 
 	const deletion = await deleteEmailMessageById({

--- a/packages/worker/src/mcp/capabilities/admin/admin-mailbox-maintenance.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-mailbox-maintenance.node.test.ts
@@ -5,7 +5,11 @@ import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.t
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 import type * as MailboxMaintenance from '#worker/admin/mailbox-maintenance.ts'
-import { adminMailboxMaintenanceRetentionMaxLimit } from '#worker/admin/mailbox-maintenance.ts'
+import {
+	AdminMailboxMessageNotFoundError,
+	adminMailboxMaintenanceRetentionMaxLimit,
+} from '#worker/admin/mailbox-maintenance.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 
 const mockModule = vi.hoisted(() => ({
 	logAuditEvent: vi.fn(async () => undefined),
@@ -336,4 +340,40 @@ test('admin_mailbox_maintenance delete_message is audited with ids and schema-bo
 			ctx,
 		),
 	).rejects.toThrow()
+})
+
+test('admin_mailbox_maintenance delete_message maps missing targets to McpCallerError', async () => {
+	const ctx = createAdminCtx()
+	const stableUserId = testStableUserIdFromEmail('missing-target@example.com')
+	const messageId = 'already-gone'
+	const notFound = new AdminMailboxMessageNotFoundError({
+		stableUserId,
+		messageId,
+	})
+	mockModule.runAdminMailboxMaintenanceDeleteMessage.mockRejectedValueOnce(
+		notFound,
+	)
+
+	await expect(
+		adminMailboxMaintenanceCapability.handler(
+			{
+				action: 'delete_message',
+				stable_user_id: stableUserId,
+				message_id: messageId,
+			},
+			ctx,
+		),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message === notFound.message &&
+			error.cause === notFound,
+	)
+	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(
+		expect.objectContaining({
+			action: 'admin_mailbox_maintenance',
+			result: 'failure',
+			reason: notFound.message,
+		}),
+	)
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-mailbox-maintenance.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-mailbox-maintenance.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import {
+	AdminMailboxMessageNotFoundError,
 	adminMailboxMaintenanceMaxBatchSize,
 	adminMailboxMaintenanceRetentionMaxLimit,
 	loadAdminMailboxMaintenanceStatus,
@@ -7,6 +8,7 @@ import {
 	runAdminMailboxMaintenanceReconcile,
 	runAdminMailboxMaintenanceRetention,
 } from '#worker/admin/mailbox-maintenance.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
@@ -265,12 +267,21 @@ export const adminMailboxMaintenanceCapability = defineDomainCapability(
 							}
 						}
 						case 'delete_message': {
-							const result = await runAdminMailboxMaintenanceDeleteMessage({
-								env: ctx.env,
-								stableUserId: args.stable_user_id,
-								messageId: args.message_id,
-							})
-							return { action: 'delete_message' as const, result }
+							try {
+								const result = await runAdminMailboxMaintenanceDeleteMessage({
+									env: ctx.env,
+									stableUserId: args.stable_user_id,
+									messageId: args.message_id,
+								})
+								return { action: 'delete_message' as const, result }
+							} catch (error) {
+								// Missing/foreign canary targets are caller-supplied ids that
+								// do not resolve — keep them off Sentry via McpCallerError.
+								if (error instanceof AdminMailboxMessageNotFoundError) {
+									throw new McpCallerError(error.message, { cause: error })
+								}
+								throw error
+							}
 						}
 						default: {
 							const exhaustive: never = args


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-3B](https://kent-c-dodds-tech-llc.sentry.io/issues/7647060809/) fired when admin `delete_message` rejected a missing/foreign canary target. That rejection is correct ownership fencing, but it threw a plain `Error`, so MCP observability reported a caller-clearable miss as a platform bug.

This PR introduces `AdminMailboxMessageNotFoundError` in the shared helper and maps it to `McpCallerError` at the capability boundary so those failures stay on `mcp-event` and out of Sentry. Delete semantics are unchanged.

## Test plan

- [x] Unit: owner isolation / not-found throws `AdminMailboxMessageNotFoundError`
- [x] Unit: capability maps missing targets to `McpCallerError` and audits failure
- [ ] `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** composes — wires the existing `McpCallerError` observability gate onto the canary not-found path; no delete behavior or auth boundary change.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `rbac` | auth | composes — admin capability error classification only |

### System map

_Canary delete not-found stays an MCP caller failure instead of a Sentry platform issue._

**Legend:** green = composes (wiring only) · amber = extended · gray = context.

```mermaid
flowchart LR
  adminCall["admin_mailbox_maintenance<br/>delete_message"] --> helper["runAdminMailboxMaintenanceDeleteMessage"]
  helper -->|"missing/foreign"| typedErr["AdminMailboxMessageNotFoundError"]
  typedErr --> mapCaller["capability maps to<br/>McpCallerError"]
  mapCaller --> mcpEvent["mcp-event failure log"]
  mapCaller -.->|filtered| sentry["Sentry"]
  classDef composes fill:#bbf7d0,stroke:#166534,color:#14532d
  classDef context fill:#f3f4f6,stroke:#6b7280,color:#374151
  class adminCall,helper,typedErr,mapCaller,mcpEvent composes
  class sentry context
```

### Risk callouts

- No change to ownership fence or delete inventory verification.
- Only missing/foreign canary targets are reclassified; unexpected delete failures still report to Sentry.

### Docs

- none — internal error-classification wiring

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc3b9776-db87-490f-9467-34e0ebcd0600?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc3b9776-db87-490f-9467-34e0ebcd0600&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when attempting to delete messages that are missing or inaccessible.
  - Clearer failure details are now provided, including appropriate audit records for unsuccessful deletion attempts.
  - Existing unexpected errors continue to be handled without being obscured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->