### PR TITLE
fix(services): return 404 for undeclared package-service DO starts

### DIFF
--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -259,6 +259,63 @@ test('projectPackageServiceStatus maps stopping to running for entitlement slots
 	expect(projectPackageServiceStatus('error')).toBe('error')
 })
 
+test('package service start returns 404 for undeclared service names', async () => {
+	resetMocks()
+	mockModule.getSavedPackageById.mockResolvedValue(savedPackage)
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		manifest: {
+			kody: {
+				id: 'email-received-subscriber',
+				services: {},
+			},
+		},
+		files: {},
+		source: {
+			published_commit: 'abc123',
+		},
+	})
+
+	const created = await createPackageServiceInstance({
+		APP_DB: {},
+	} as Env)
+	const start = await created.instance.fetch(
+		new Request('https://package-service.invalid/service/start', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				binding: {
+					...serviceBinding,
+					kodyId: 'email-received-subscriber',
+					serviceName: 'email-agent-processor',
+				},
+			}),
+		}),
+	)
+	expect(start.status).toBe(404)
+	expect(await start.text()).toBe(
+		'Saved package "email-received-subscriber" does not define service "email-agent-processor".',
+	)
+
+	const newlineName = 'email-agent\nprocessor'
+	const newlineStart = await created.instance.fetch(
+		new Request('https://package-service.invalid/service/start', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				binding: {
+					...serviceBinding,
+					kodyId: 'email-received-subscriber',
+					serviceName: newlineName,
+				},
+			}),
+		}),
+	)
+	expect(newlineStart.status).toBe(404)
+	expect(await newlineStart.text()).toBe(
+		`Saved package "email-received-subscriber" does not define service "${newlineName}".`,
+	)
+})
+
 test('package service start and stop project liveness into package_service_states', async () => {
 	resetMocks()
 	vi.useFakeTimers()

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -297,6 +297,20 @@ async function loadSavedPackageService(input: {
 	}
 }
 
+function isPackageServiceCallerLookupError(error: unknown) {
+	if (!(error instanceof Error)) return false
+	return (
+		error.message ===
+			'Saved package was not found for package service operations.' ||
+		// [\s\S] so service/package ids with embedded newlines still match;
+		// otherwise fetch() would rethrow and Sentry DO instrumentation would
+		// treat a caller mistake as an unhandled platform failure.
+		/^Saved package "[\s\S]+" does not define service "[\s\S]+"\.$/.test(
+			error.message,
+		)
+	)
+}
+
 async function readPackageServiceRpcResponse<T>(
 	response: Response,
 ): Promise<T> {
@@ -1223,19 +1237,34 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		if (!binding) {
 			return new Response('Missing package service binding.', { status: 400 })
 		}
-		if (request.method === 'POST' && url.pathname.endsWith('/start')) {
-			return await this.handleStartRequest({ binding })
+		try {
+			if (request.method === 'POST' && url.pathname.endsWith('/start')) {
+				return await this.handleStartRequest({ binding })
+			}
+			if (request.method === 'POST' && url.pathname.endsWith('/status')) {
+				return await this.handleStatusRequest({ binding })
+			}
+			if (request.method === 'POST' && url.pathname.endsWith('/stop')) {
+				return await this.handleStopRequest({ binding })
+			}
+			if (request.method === 'POST' && url.pathname.endsWith('/purge')) {
+				return await this.handlePurgeRequest({ binding })
+			}
+			return new Response('Not found', { status: 404 })
+		} catch (error) {
+			// Caller mistakes (undeclared service name, deleted package) must
+			// return an error Response. Throwing here is reported by the DO
+			// Sentry instrumentation as an unhandled platform failure.
+			if (isPackageServiceCallerLookupError(error)) {
+				return new Response(
+					error instanceof Error
+						? error.message
+						: 'Package service request failed.',
+					{ status: 404 },
+				)
+			}
+			throw error
 		}
-		if (request.method === 'POST' && url.pathname.endsWith('/status')) {
-			return await this.handleStatusRequest({ binding })
-		}
-		if (request.method === 'POST' && url.pathname.endsWith('/stop')) {
-			return await this.handleStopRequest({ binding })
-		}
-		if (request.method === 'POST' && url.pathname.endsWith('/purge')) {
-			return await this.handlePurgeRequest({ binding })
-		}
-		return new Response('Not found', { status: 404 })
 	}
 
 	async alarm() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close the Durable Object hole left after #1159 so undeclared package-service starts cannot open unhandled Sentry DO issues (KODY issue 7648315524 / KODY-CLOUDFLARE-3C).

## Summary

- #1159 already validates `package.json#kody.services` on MCP `service_start` / `service_get` and throws `McpCallerError`.
- This PR hardens the Package Service Durable Object: undeclared service / missing package lookup errors on `/start` (and other fetch paths) return HTTP 404 instead of throwing, so Cloudflare DO Sentry instrumentation does not treat caller mistakes as platform failures.
- Root cause of 7648315524: agent called `service_start` for export `./services/email-agent-processor` on `email-received-subscriber`, which has no `kody.services` entry.
- Sibling 7648315734 (KODY-CLOUDFLARE-3D) was fixed in #1159.

## Testing

- `npx vitest run packages/worker/src/package-runtime/package-service.node.test.ts -t "undeclared service"`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends package-services</b> (low risk: error-path only)</summary>

**Mode:** recap · **Base:** `main` @ `a482a0dc` · **Head:** `cc38697a`

**Classification:** extends — narrow DO error-path change; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-services` | assistant | extends — undeclared/missing lookup on DO fetch returns 404 Response |
| `package-runtime` | runtime | composes — tests only |

### System map

Defense in depth after #1159: if anything still hits PackageService DO with an undeclared name, respond 404 instead of an unhandled throw.

```mermaid
flowchart LR
  caller["MCP / package-app / RPC"] --> doFetch["PackageService DO fetch"]
  doFetch -->|"undeclared / missing pkg"| resp404["HTTP 404 Response"]
  doFetch -->|"ok"| run["handle start/status/stop"]
```

### Risk and invariants

- **Overall risk:** low — only changes failure responses for caller lookup mistakes; successful service runs unchanged.
- **Invariants:** per-user isolation unchanged; no auth, billing, migration, or DR surface.
- **Rollout notes:** resolve Sentry 7648315524 in the merge commit after deploy; sibling 7648315734 handled by #1159.

### Docs

_No docs changes._

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5d54b55-639c-43ee-a506-91de8040444e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5d54b55-639c-43ee-a506-91de8040444e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service startup now verifies that the requested service is declared in the package manifest before checking status or starting it.
  * Requests for missing or undeclared services now return a clear HTTP 404 error.
  * Persistent-service entitlements are evaluated using the validated service declaration.
  * Added regression coverage for invalid service-start requests and package lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->