### PR TITLE
fix(services): keep undeclared service_start off Sentry (KODY-CLOUDFLARE-3D)

### DIFF
--- a/packages/worker/src/mcp/capabilities/services/service-get.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-get.ts
@@ -5,6 +5,7 @@ import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	normalizePackageServiceStatus,
 	packageServiceStatusSchema,
+	requireDeclaredPackageService,
 	requirePackageServiceContext,
 } from './shared.ts'
 
@@ -32,9 +33,16 @@ export const serviceGetCapability = defineDomainCapability(
 			})
 			if (!serviceContext.service) {
 				throw new McpCallerError(
-					`Package service "${args.service_name}" was not found.`,
+					`Package service "${args.service_name}" was not found for this package.`,
 				)
 			}
+			await requireDeclaredPackageService({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				savedPackage: serviceContext.savedPackage,
+				userId: serviceContext.user.userId,
+				serviceName: args.service_name,
+			})
 			return normalizePackageServiceStatus(
 				await serviceContext.service.status(),
 			)

--- a/packages/worker/src/mcp/capabilities/services/service-start.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-start.node.test.ts
@@ -210,10 +210,7 @@ test('service_start rejects undeclared services as McpCallerError', async () => 
 	}))
 
 	const error = await serviceStartCapability
-		.handler(
-			{ service_name: 'email-agent-processor' },
-			{ env, callerContext },
-		)
+		.handler({ service_name: 'email-agent-processor' }, { env, callerContext })
 		.then(
 			() => null,
 			(thrown: unknown) => thrown,

--- a/packages/worker/src/mcp/capabilities/services/service-start.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-start.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
@@ -177,6 +178,53 @@ async function seedRunningServicesInMeter(
 	}
 }
 
+test('service_start rejects undeclared services as McpCallerError', async () => {
+	const email = 'undeclared@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const env = {
+		APP_DB: createEntitlementsTestDb({
+			users: [{ email, plan: 'pro' }],
+		}),
+	} as Env
+	const callerContext = createPlanUserCallerContext({ userId, email })
+	const start = vi.fn(async () => ({ ok: true }))
+
+	mockModule.getSavedPackageById.mockResolvedValue(
+		createSavedPackage({ userId }),
+	)
+	mockModule.listSavedPackageServices.mockResolvedValue({
+		savedPackage: {
+			id: 'package-123',
+			kodyId: 'example',
+		},
+		services: [],
+	})
+	mockModule.packageServiceRpc.mockImplementation(() => ({
+		status: async () => ({
+			package_id: 'package-123',
+			kody_id: 'example',
+			service_name: 'email-agent-processor',
+			status: 'idle',
+		}),
+		start,
+	}))
+
+	const error = await serviceStartCapability
+		.handler(
+			{ service_name: 'email-agent-processor' },
+			{ env, callerContext },
+		)
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+	expect(error).toBeInstanceOf(McpCallerError)
+	expect(error).toMatchObject({
+		message: expect.stringMatching(/was not found for this package/),
+	})
+	expect(start).not.toHaveBeenCalled()
+})
+
 test('service_start denies persistent services for free plan users', async () => {
 	const email = 'planned@example.com'
 	const userId = await createStableUserIdFromEmail(email)
@@ -261,8 +309,9 @@ test('service_start skips enforcement when the service is already running', asyn
 	if (limit === null) {
 		throw new Error('Expected a numeric pro package service limit.')
 	}
-	// Enforcement is skipped entirely when the service is already running;
-	// USER_METER and running service count are not consulted.
+	// Entitlement enforcement is skipped when the service is already running;
+	// USER_METER and running service count are not consulted. Declaration
+	// lookup still runs so undeclared names stay on McpCallerError.
 	const env = {
 		APP_DB: createEntitlementsTestDb({ users: [{ email, plan: 'pro' }] }),
 	} as Env
@@ -271,6 +320,7 @@ test('service_start skips enforcement when the service is already running', asyn
 	mockModule.getSavedPackageById.mockResolvedValue(
 		createSavedPackage({ userId }),
 	)
+	mockDeclaredServices('bounded')
 	mockServiceRpc({
 		status: 'running',
 		startResult: {
@@ -292,7 +342,7 @@ test('service_start skips enforcement when the service is already running', asyn
 		run_id: 'run-123',
 		already_running: true,
 	})
-	expect(mockModule.listSavedPackageServices).not.toHaveBeenCalled()
+	expect(mockModule.listSavedPackageServices).toHaveBeenCalledOnce()
 })
 
 test('service_start lets a stale running row for the same service restart at the limit', async () => {

--- a/packages/worker/src/mcp/capabilities/services/service-start.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-start.ts
@@ -1,13 +1,14 @@
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	assertWithinEntitlement,
 	countRunningPackageServices,
 } from '#worker/entitlements/service.ts'
 import {
+	requireDeclaredPackageService,
 	requirePackageServiceContext,
-	resolveDeclaredPackageService,
 } from './shared.ts'
 
 const inputSchema = z.object({
@@ -28,7 +29,7 @@ export const serviceStartCapability = defineDomainCapability(
 	{
 		name: 'service_start',
 		description:
-			'Start a package service instance and return the latest execution result.',
+			'Start a package service declared under package.json#kody.services and return the latest execution result.',
 		keywords: ['service', 'start', 'package service', 'runtime'],
 		readOnly: false,
 		idempotent: false,
@@ -43,20 +44,23 @@ export const serviceStartCapability = defineDomainCapability(
 				explicitPackageId: args.package_id,
 			})
 			if (!serviceContext.service) {
-				throw new Error(
+				throw new McpCallerError(
 					`Package service "${args.service_name}" was not found for this package.`,
 				)
 			}
+			// Validate the manifest declaration before RPC so typos / export-vs-
+			// service mixups stay on McpCallerError instead of bubbling from the
+			// Durable Object as an unhandled platform Error (Sentry noise).
+			const declaredService = await requireDeclaredPackageService({
+				env: ctx.env,
+				callerContext: ctx.callerContext,
+				savedPackage: serviceContext.savedPackage,
+				userId: serviceContext.user.userId,
+				serviceName: args.service_name,
+			})
 			const currentStatus = await serviceContext.service.status()
 			if (currentStatus.status !== 'running') {
-				const declaredService = await resolveDeclaredPackageService({
-					env: ctx.env,
-					callerContext: ctx.callerContext,
-					savedPackage: serviceContext.savedPackage,
-					userId: serviceContext.user.userId,
-					serviceName: args.service_name,
-				})
-				if (declaredService?.mode === 'persistent') {
+				if (declaredService.mode === 'persistent') {
 					await assertWithinEntitlement({
 						db: ctx.env.APP_DB,
 						userId: serviceContext.user.userId,

--- a/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
@@ -186,6 +186,21 @@ test('package service capabilities list, tolerate status failures, and delegate 
 
 	resetMocks()
 	mockModule.getSavedPackageById.mockResolvedValue(createSavedPackage())
+	mockModule.listSavedPackageServices.mockResolvedValue({
+		savedPackage: {
+			id: 'package-123',
+			kodyId: 'example',
+		},
+		services: [
+			{
+				name: 'realtime-supervisor',
+				entry: 'services/realtime-supervisor.ts',
+				autoStart: false,
+				mode: 'bounded',
+				timeoutMs: null,
+			},
+		],
+	})
 	mockModule.packageServiceRpc.mockImplementation(() => ({
 		status: async () => ({
 			package_id: 'package-123',
@@ -291,4 +306,54 @@ test('package service capabilities list, tolerate status failures, and delegate 
 	expect(unknownPackageError).toMatchObject({
 		message: expect.stringMatching(/Saved package was not found/),
 	})
+})
+
+test('undeclared service get/start throw McpCallerError without RPC', async () => {
+	resetMocks()
+	mockModule.getSavedPackageById.mockResolvedValue(createSavedPackage())
+	mockModule.listSavedPackageServices.mockResolvedValue({
+		savedPackage: {
+			id: 'package-123',
+			kodyId: 'example',
+		},
+		services: [],
+	})
+	const start = vi.fn(async () => ({ ok: true }))
+	const status = vi.fn(async () => ({
+		package_id: 'package-123',
+		kody_id: 'example',
+		service_name: 'email-agent-processor',
+		status: 'idle',
+	}))
+	mockModule.packageServiceRpc.mockImplementation(() => ({ start, status }))
+
+	const env = {
+		APP_DB: {} as D1Database,
+	} as Env
+	const callerContext = createCallerContext()
+
+	const getError = await serviceGetCapability
+		.handler(
+			{ service_name: 'email-agent-processor' },
+			{ env, callerContext },
+		)
+		.catch((caught: unknown) => caught)
+	expect(getError).toBeInstanceOf(McpCallerError)
+	expect(getError).toMatchObject({
+		message: expect.stringMatching(/was not found for this package/),
+	})
+	expect(status).not.toHaveBeenCalled()
+
+	const startError = await serviceStartCapability
+		.handler(
+			{ service_name: 'email-agent-processor' },
+			{ env, callerContext },
+		)
+		.catch((caught: unknown) => caught)
+	expect(startError).toBeInstanceOf(McpCallerError)
+	expect(startError).toMatchObject({
+		message: expect.stringMatching(/was not found for this package/),
+	})
+	expect(start).not.toHaveBeenCalled()
+	expect(status).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts
@@ -333,10 +333,7 @@ test('undeclared service get/start throw McpCallerError without RPC', async () =
 	const callerContext = createCallerContext()
 
 	const getError = await serviceGetCapability
-		.handler(
-			{ service_name: 'email-agent-processor' },
-			{ env, callerContext },
-		)
+		.handler({ service_name: 'email-agent-processor' }, { env, callerContext })
 		.catch((caught: unknown) => caught)
 	expect(getError).toBeInstanceOf(McpCallerError)
 	expect(getError).toMatchObject({
@@ -345,10 +342,7 @@ test('undeclared service get/start throw McpCallerError without RPC', async () =
 	expect(status).not.toHaveBeenCalled()
 
 	const startError = await serviceStartCapability
-		.handler(
-			{ service_name: 'email-agent-processor' },
-			{ env, callerContext },
-		)
+		.handler({ service_name: 'email-agent-processor' }, { env, callerContext })
 		.catch((caught: unknown) => caught)
 	expect(startError).toBeInstanceOf(McpCallerError)
 	expect(startError).toMatchObject({

--- a/packages/worker/src/mcp/capabilities/services/shared.ts
+++ b/packages/worker/src/mcp/capabilities/services/shared.ts
@@ -80,6 +80,31 @@ export async function resolveDeclaredPackageService(input: {
 	}
 }
 
+/**
+ * Resolve a service declared under package.json#kody.services, or throw a
+ * caller-clearable error. Agents routinely invent service names (or confuse
+ * package exports with declared services); keep those off Sentry.
+ */
+export async function requireDeclaredPackageService(input: {
+	env: Env
+	callerContext: McpCallerContext
+	savedPackage: {
+		id: string
+		sourceId: string
+		kodyId?: string
+	}
+	userId: string
+	serviceName: string
+}) {
+	const service = await resolveDeclaredPackageService(input)
+	if (!service) {
+		throw new McpCallerError(
+			`Package service "${input.serviceName}" was not found for this package.`,
+		)
+	}
+	return service
+}
+
 export async function requirePackageServiceContext(input: {
 	env: Env
 	callerContext: McpCallerContext


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop agent typos / export-vs-service mixups on `service_start` from opening platform Sentry issues (KODY-CLOUDFLARE-3D and sibling 3C).

## Summary

- Root cause: `email-received-subscriber` has a package export `./services/email-agent-processor` but no `package.json#kody.services` entry. `service_start` built an RPC stub without checking the manifest, so the Durable Object threw a plain `Error` that MCP reported to Sentry.
- Fix: validate the declared service via `requireDeclaredPackageService` before RPC on `service_start` / `service_get`, and throw `McpCallerError` so observability keeps these on `mcp-event` only.
- Sibling: KODY-CLOUDFLARE-3C (`loadSavedPackageService`) is the same undeclared-service start path.

## Testing

- `npx vitest run packages/worker/src/mcp/capabilities/services/service-start.node.test.ts packages/worker/src/mcp/capabilities/services/services-domain.node.test.ts`
- Reproduced in production execute: `service_list` empty, `service_start({ service_name: 'email-agent-processor' })` returned the Sentry message.
- CI: Static / Node / Workers / MCP green; E2E flake on unrelated `admin-rbac` duplicate-key console warning (rerunning).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `3afd2008` · **Head:** `769dd49d`

**Classification:** composes — isolated caller-error wiring on existing service MCP capabilities; no new primitives or DO contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | composes — `service_start` / `service_get` require declared `kody.services` and throw `McpCallerError` |

### System map

Caller mistakes are rejected at the MCP capability layer before package-service RPC, so they never surface as unhandled DO errors in Sentry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	packageServices["package-services<br/>Package services"]:::untouched
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	capabilityRegistry -->|"requireDeclaredPackageService before start/get"| packageServices
	capabilityRegistry -->|"McpCallerError skips Sentry"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant ServiceStart as service_start
	participant Manifest as listSavedPackageServices
	participant DO as package-service DO
	Agent->>ServiceStart: service_name not in kody.services
	ServiceStart->>Manifest: resolve declaration
	Manifest-->>ServiceStart: missing
	ServiceStart-->>Agent: McpCallerError (no Sentry)
	Note over DO: RPC not called
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| `service_start` undeclared name | DO throws plain `Error` → Sentry | `McpCallerError` before RPC |
| `service_get` undeclared name | returned idle status stub | `McpCallerError` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-208bc72d-31ef-4e21-8f4b-996cedb8192e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-208bc72d-31ef-4e21-8f4b-996cedb8192e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service operations now verify that requested services are declared by the package before proceeding.
  * Undeclared services return clearer caller-facing errors and no longer trigger service actions.
  * Service lookup errors now identify when a service is missing from the package.
  * Existing service status and entitlement checks continue to work for properly declared services.
* **Tests**
  * Added coverage for rejected undeclared service lookups and start requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->