### PR TITLE
test(email): assert parity purge linearizability

### DIFF
--- a/packages/worker/src/email/mailbox-retention.workers.test.ts
+++ b/packages/worker/src/email/mailbox-retention.workers.test.ts
@@ -639,12 +639,20 @@ test('parity purge serializes a queued mirror with its retention alarm', async (
 	await expect(queuedMirror).resolves.toEqual({ ok: true, accepted: true })
 
 	expect(await mailbox.getMessage({ messageId: beforePurge.id })).toBeNull()
-	expect(await mailbox.getMessage({ messageId: queued.id })).toMatchObject({
-		id: queued.id,
-	})
-	await runInDurableObject(stub, async (_instance: Mailbox, state) => {
-		expect(await state.storage.getAlarm()).not.toBeNull()
-	})
+	const queuedMessage = await mailbox.getMessage({ messageId: queued.id })
+	const alarm = await runInDurableObject(
+		stub,
+		async (_instance: Mailbox, state) => state.storage.getAlarm(),
+	)
+	// Either operation may acquire the gate first. If purge wins, the queued
+	// mirror survives and must arm retention. If mirror wins, purge removes it.
+	// The forbidden pre-fix interleaving was a surviving message with no alarm.
+	if (queuedMessage) {
+		expect(queuedMessage).toMatchObject({ id: queued.id })
+		expect(alarm).not.toBeNull()
+	} else {
+		expect(alarm).toBeNull()
+	}
 })
 
 test('Mailbox retention selects one message per turn and revalidates before deletion', async () => {


### PR DESCRIPTION
## Summary

Makes the parity-purge concurrency test assert the actual serialized invariant instead of assuming which queued operation acquires the Durable Object gate first.

- purge-first: queued mirror survives and retention alarm is armed
- mirror-first: purge removes the queued message
- forbidden state remains: surviving message with no alarm

## Verification

- retention Workers suite passed 5 consecutive isolated runs
- fixes the post-merge Workers failure from https://github.com/kentcdodds/kody/actions/runs/30768226985

## Conductor report

- **STATUS:** in-progress
- **Sequence step:** 3 deploy-gate hotfix
- **Risk:** low, test-only
- **Merged/deployed:** no
- **Next:** green CI, self-merge, deploy step 3, then fresh step-4 branch

> Cursor ManagePullRequest was pinned to the original run branch; this clean hotfix PR uses the authenticated Kent helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to mailbox retention Workers coverage; no production code paths modified.
> 
> **Overview**
> Updates the **parity purge serializes a queued mirror with its retention alarm** Workers test so it checks the real serialized outcome instead of assuming the queued `mirrorMessage` always wins the Durable Object gate over `purgeForParityRebuild`.
> 
> After both operations finish, the test branches on whether the queued message still exists: if it does, retention alarm must be set; if purge removed it, alarm must be cleared. That explicitly rejects the bad pre-fix case—a message left in storage with no alarm—while allowing either purge-first or mirror-first ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e94541a17897dfbfdd961b3043f1598bc69ac9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retention cleanup behavior when purge operations run concurrently.
  * Ensured retention alarms accurately reflect whether queued messages survive or are removed during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->