### PR TITLE
fix(sentry): filter injected ethereum/__firefox__ browser noise

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import {
 	filterBrowserAbortSentryEvent,
+	filterBrowserInjectedGlobalNoiseSentryEvent,
 	filterBrowserSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
 } from './sentry-browser-filters.ts'
@@ -110,6 +111,96 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 		}),
 	).not.toBeNull()
 
+	// Injected wallet / Firefox-iOS bridge globals only (issue 7648833360).
+	expect(
+		filterBrowserInjectedGlobalNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserInjectedGlobalNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.__firefox__.reader')",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserInjectedGlobalNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.__firefox__.refresh_youtube_quality_2E41B6CA94114F3CB0CAF4E4DA93D5A8')",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserInjectedGlobalNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: __firefox__",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserInjectedGlobalNoiseSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: 'something else' }],
+				},
+			},
+			new TypeError(
+				"undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')",
+			),
+		),
+	).toBeNull()
+	expect(
+		filterBrowserInjectedGlobalNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.someAppApi.foo')",
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserInjectedGlobalNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: ethereum",
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+
 	const realBug = {
 		exception: {
 			values: [{ type: 'TypeError', value: 'TypeError: Failed to fetch' }],
@@ -135,6 +226,19 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 					{
 						type: 'Error',
 						value: 'Permission denied to access property "childNodes"',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')",
 					},
 				],
 			},

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -126,6 +126,61 @@ export function filterFirefoxDomPermissionDeniedSentryEvent<
 	return event
 }
 
+/**
+ * Wallet / browser-injected globals that throw from page `global code`, not
+ * from Kody bundles (no app code references these). Production signatures from
+ * Brave iOS issue 7648833360 and sibling 7648833403:
+ * - `undefined is not an object (evaluating 'window.ethereum…')`
+ * - `undefined is not an object (evaluating 'window.__firefox__…')`
+ * - `Can't find variable: __firefox__`
+ *
+ * Match is intentionally narrow: only these injected-global access patterns.
+ * Never blanket-drop TypeError / ReferenceError.
+ */
+export function isBrowserInjectedGlobalNoiseMessage(message: string) {
+	const withoutTypePrefix = message
+		.trim()
+		.replace(/^(?:TypeError|ReferenceError):\s*/i, '')
+	return (
+		/^undefined is not an object \(evaluating ['"]window\.(?:ethereum|__firefox__)\./i.test(
+			withoutTypePrefix,
+		) ||
+		/^Can'?t find variable: __firefox__\.?$/i.test(withoutTypePrefix) ||
+		/^Cannot find variable: __firefox__\.?$/i.test(withoutTypePrefix) ||
+		/^__firefox__ is not defined\.?$/i.test(withoutTypePrefix)
+	)
+}
+
+export function isBrowserInjectedGlobalNoiseError(error: unknown) {
+	if (typeof error === 'string') {
+		return isBrowserInjectedGlobalNoiseMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isBrowserInjectedGlobalNoiseMessage(error.message)
+}
+
+export function isBrowserInjectedGlobalNoiseSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isBrowserInjectedGlobalNoiseError(originalException)) return true
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isBrowserInjectedGlobalNoiseMessage(message),
+	)
+}
+
+export function filterBrowserInjectedGlobalNoiseSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isBrowserInjectedGlobalNoiseSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -136,6 +191,12 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	}
 	if (
 		filterFirefoxDomPermissionDeniedSentryEvent(event, originalException) ===
+		null
+	) {
+		return null
+	}
+	if (
+		filterBrowserInjectedGlobalNoiseSentryEvent(event, originalException) ===
 		null
 	) {
 		return null

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -1,5 +1,6 @@
 import {
 	isBrowserAbortError,
+	isBrowserInjectedGlobalNoiseError,
 	isFirefoxDomPermissionDeniedError,
 } from '#client/sentry-browser-filters.ts'
 import {
@@ -44,7 +45,11 @@ let onWindowError: ((event: ErrorEvent) => void) | null = null
 let onUnhandledRejection: ((event: PromiseRejectionEvent) => void) | null = null
 
 function shouldIgnoreBufferedError(error: unknown) {
-	return isBrowserAbortError(error) || isFirefoxDomPermissionDeniedError(error)
+	return (
+		isBrowserAbortError(error) ||
+		isFirefoxDomPermissionDeniedError(error) ||
+		isBrowserInjectedGlobalNoiseError(error)
+	)
 }
 
 function enqueueBufferedError(error: unknown) {

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -29,8 +29,9 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		replaysSessionSampleRate: 0,
 		replaysOnErrorSampleRate: 1.0,
 		// Drop expected browser noise (AbortError aborts, Firefox DOM
-		// permission-denied from Replay/hydration on restricted nodes) —
-		// see filterBrowserSentryEvent / KODY-CLOUDFLARE-23 / issue 7639685398.
+		// permission-denied from Replay/hydration on restricted nodes, and
+		// injected wallet/`__firefox__` globals) — see filterBrowserSentryEvent
+		// / KODY-CLOUDFLARE-23 / issues 7639685398, 7648833360, 7648833403.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry issue [7648833360](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7648833360/) (`window.ethereum.selectedAddress`) and siblings [7648833403](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7648833403/) / [7648833423](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7648833423/) (`__firefox__`) are Brave iOS page `global code` throws from wallet / Firefox-bridge injected globals — not Kody bundles.

Adds a narrow client `beforeSend` filter (and matching pre-SDK buffer ignore) for those exact message shapes.

**Outcome:** filtered — squash-merged; competing #1165/#1166 stood down as subsets.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `802e658a` · **Head:** `6585f652` (merged as `0f7d759`)

**Classification:** composes — extends the existing browser Sentry filter wiring in `app-ui` only; no new primitives or contracts.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — narrow `beforeSend` / buffer drop for injected-global noise |

### System map

Browser Sentry init already runs `filterBrowserSentryEvent`; this PR adds one more drop predicate for wallet/`__firefox__` injection messages.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app UI"]:::touched
	appUi -->|"beforeSend + buffer ignore"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22d90f6b-0967-441f-b5b8-9c35dc4f988d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22d90f6b-0967-441f-b5b8-9c35dc4f988d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reports caused by browser-injected wallet and Firefox bridge scripts.
  * Preserved reporting for genuine application errors and unrelated browser issues.
  * Applied the filtering consistently to captured and buffered client errors.

* **Tests**
  * Added coverage for injected browser errors, original exceptions, and unaffected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->