### PR TITLE
fix(sentry): filter Firefox __firefox__ bridge noise (KODY-CLOUDFLARE-3F)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -2,10 +2,11 @@ import { expect, test } from 'vitest'
 import {
 	filterBrowserAbortSentryEvent,
 	filterBrowserSentryEvent,
+	filterFirefoxBridgeNoiseSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
 } from './sentry-browser-filters.ts'
 
-test('browser Sentry filters drop AbortError and Firefox Xray noise and keep real errors', () => {
+test('browser Sentry filters drop AbortError, Firefox Xray, and __firefox__ bridge noise and keep real errors', () => {
 	// AbortError family (including originalException), but not timeout/network.
 	expect(
 		filterBrowserAbortSentryEvent({
@@ -110,6 +111,94 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 		}),
 	).not.toBeNull()
 
+	// Firefox bridge / reader-mode `__firefox__` noise (KODY-CLOUDFLARE-3F / 3E).
+	expect(
+		filterFirefoxBridgeNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: __firefox__",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterFirefoxBridgeNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.__firefox__.reader')",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterFirefoxBridgeNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: '__firefox__ is not defined',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterFirefoxBridgeNoiseSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: 'something else' }],
+				},
+			},
+			new ReferenceError("Can't find variable: __firefox__"),
+		),
+	).toBeNull()
+	// Must not drop unrelated ReferenceError / TypeError / messages that only
+	// mention "firefox" without the bridge identifier.
+	expect(
+		filterFirefoxBridgeNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: updateCurrentEntry",
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterFirefoxBridgeNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'n.updateCurrentEntry')",
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterFirefoxBridgeNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'firefox reader failed',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+
 	const realBug = {
 		exception: {
 			values: [{ type: 'TypeError', value: 'TypeError: Failed to fetch' }],
@@ -135,6 +224,31 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 					{
 						type: 'Error',
 						value: 'Permission denied to access property "childNodes"',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: __firefox__",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.__firefox__.reader')",
 					},
 				],
 			},

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -126,6 +126,50 @@ export function filterFirefoxDomPermissionDeniedSentryEvent<
 	return event
 }
 
+/**
+ * Firefox (including Firefox-for-iOS / WebKit shells) exposes
+ * `window.__firefox__` for reader mode and the content bridge. Injected or
+ * browser-internal scripts reference it; when the bridge is absent they throw
+ * ReferenceError / TypeError that Sentry's global onerror captures as in-app
+ * "global code" with no app frames. Kody app source never mentions
+ * `__firefox__` (KODY-CLOUDFLARE-3F / 3E).
+ *
+ * Match only messages that name `__firefox__` with these known wordings —
+ * never blanket-drop ReferenceError or TypeError.
+ */
+const firefoxBridgeNoiseMessage =
+	/(?:Can't find variable:\s*__firefox__|__firefox__ is not defined|undefined is not an object \(evaluating ['"]window\.__firefox__|null is not an object \(evaluating ['"]window\.__firefox__)/
+
+export function isFirefoxBridgeNoiseMessage(message: string) {
+	return firefoxBridgeNoiseMessage.test(message)
+}
+
+export function isFirefoxBridgeNoiseError(error: unknown) {
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isFirefoxBridgeNoiseMessage(error.message)
+}
+
+export function isFirefoxBridgeNoiseSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isFirefoxBridgeNoiseError(originalException)) return true
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' && isFirefoxBridgeNoiseMessage(message),
+	)
+}
+
+export function filterFirefoxBridgeNoiseSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isFirefoxBridgeNoiseSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -138,6 +182,9 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 		filterFirefoxDomPermissionDeniedSentryEvent(event, originalException) ===
 		null
 	) {
+		return null
+	}
+	if (filterFirefoxBridgeNoiseSentryEvent(event, originalException) === null) {
 		return null
 	}
 	return event

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -1,5 +1,6 @@
 import {
 	isBrowserAbortError,
+	isFirefoxBridgeNoiseError,
 	isFirefoxDomPermissionDeniedError,
 } from '#client/sentry-browser-filters.ts'
 import {
@@ -44,7 +45,11 @@ let onWindowError: ((event: ErrorEvent) => void) | null = null
 let onUnhandledRejection: ((event: PromiseRejectionEvent) => void) | null = null
 
 function shouldIgnoreBufferedError(error: unknown) {
-	return isBrowserAbortError(error) || isFirefoxDomPermissionDeniedError(error)
+	return (
+		isBrowserAbortError(error) ||
+		isFirefoxDomPermissionDeniedError(error) ||
+		isFirefoxBridgeNoiseError(error)
+	)
 }
 
 function enqueueBufferedError(error: unknown) {

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -29,8 +29,10 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		replaysSessionSampleRate: 0,
 		replaysOnErrorSampleRate: 1.0,
 		// Drop expected browser noise (AbortError aborts, Firefox DOM
-		// permission-denied from Replay/hydration on restricted nodes) —
-		// see filterBrowserSentryEvent / KODY-CLOUDFLARE-23 / issue 7639685398.
+		// permission-denied from Replay/hydration on restricted nodes,
+		// Firefox `__firefox__` bridge / reader-mode ReferenceError+TypeError) —
+		// see filterBrowserSentryEvent / KODY-CLOUDFLARE-23 / 7639685398 /
+		// KODY-CLOUDFLARE-3F / 3E.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

**Superseded — do not merge.** Stand down in favor of #1164.

Three triage agents spawned for the same Brave/iOS injected-global Sentry cluster and opened competing PRs that all touch `sentry-browser-filters.ts`. Merging more than one will conflict.

## Decision

Keep **[#1164](https://github.com/kentcdodds/kody/pull/1164)** (earliest; covers both `window.ethereum.*` and `__firefox__` signatures for issues 7648833360 + 7648833403).

Also overlapping: [#1166](https://github.com/kentcdodds/kody/pull/1166) (KODY-CLOUDFLARE-3G, `__firefox__` only) — should close as duplicate of #1164 as well.

This PR (#1165) only filters `__firefox__` and is a strict subset of #1164.

## Original summary (historical)

- Production: `ReferenceError: Can't find variable: __firefox__` on `heykody.dev` / `/pricing`, `global code` only, no app frames.
- App source has zero `__firefox__` references — browser/injected bridge noise.

## Testing

- `npm test -- packages/worker/client/sentry-browser-filters.node.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43e6b330-5cc2-4758-99fe-a81a2b6bbb6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43e6b330-5cc2-4758-99fe-a81a2b6bbb6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

