### PR TITLE
fix(sentry): filter injected window.__firefox__ browser noise (KODY-CLOUDFLARE-3G)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -3,6 +3,7 @@ import {
 	filterBrowserAbortSentryEvent,
 	filterBrowserSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
+	filterFirefoxInjectedApiNoiseSentryEvent,
 } from './sentry-browser-filters.ts'
 
 test('browser Sentry filters drop AbortError and Firefox Xray noise and keep real errors', () => {
@@ -135,6 +136,107 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 					{
 						type: 'Error',
 						value: 'Permission denied to access property "childNodes"',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	// Injected window.__firefox__ bridge misses (reader / media helpers).
+	expect(
+		filterFirefoxInjectedApiNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.__firefox__.reader')",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterFirefoxInjectedApiNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.__firefox__.refresh_youtube_quality_2E41B6CA94114F3CB0CAF4E4DA93D5A8')",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterFirefoxInjectedApiNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: __firefox__",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterFirefoxInjectedApiNoiseSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: 'something else' }],
+				},
+			},
+			new TypeError(
+				"undefined is not an object (evaluating 'window.__firefox__.reader')",
+			),
+		),
+	).toBeNull()
+	expect(
+		filterFirefoxInjectedApiNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "undefined is not an object (evaluating 'window.foo.bar')",
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterFirefoxInjectedApiNoiseSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: somethingElse",
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"undefined is not an object (evaluating 'window.__firefox__.reader')",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: __firefox__",
 					},
 				],
 			},

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -126,6 +126,52 @@ export function filterFirefoxDomPermissionDeniedSentryEvent<
 	return event
 }
 
+/**
+ * Firefox (and some WebKit browsers that inject Firefox-compat shims) expose a
+ * privileged `window.__firefox__` bridge for reader mode / media helpers.
+ * Injected page scripts sometimes evaluate that bridge before it exists, which
+ * surfaces as unhandled `onerror` noise such as:
+ *   - TypeError: undefined is not an object (evaluating 'window.__firefox__.reader')
+ *   - TypeError: undefined is not an object (evaluating 'window.__firefox__.refresh_youtube_quality_…')
+ *   - ReferenceError: Can't find variable: __firefox__
+ *
+ * Signature from production issues KODY-CLOUDFLARE-3G / 3E / 3F. Not present in
+ * app source — not actionable. Match only messages that name `__firefox__`
+ * specifically; never blanket-drop TypeError / ReferenceError.
+ */
+const firefoxInjectedApiNoiseMessage =
+	/(?:undefined is not an object \(evaluating ['"]window\.__firefox__\.[^'"]+['"]\)|Can't find variable: __firefox__|__firefox__ is not defined)/
+
+export function isFirefoxInjectedApiNoiseMessage(message: string) {
+	return firefoxInjectedApiNoiseMessage.test(message)
+}
+
+export function isFirefoxInjectedApiNoiseError(error: unknown) {
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isFirefoxInjectedApiNoiseMessage(error.message)
+}
+
+export function isFirefoxInjectedApiNoiseSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isFirefoxInjectedApiNoiseError(originalException)) return true
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' && isFirefoxInjectedApiNoiseMessage(message),
+	)
+}
+
+export function filterFirefoxInjectedApiNoiseSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isFirefoxInjectedApiNoiseSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -137,6 +183,11 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	if (
 		filterFirefoxDomPermissionDeniedSentryEvent(event, originalException) ===
 		null
+	) {
+		return null
+	}
+	if (
+		filterFirefoxInjectedApiNoiseSentryEvent(event, originalException) === null
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-client.ts
+++ b/packages/worker/client/sentry-client.ts
@@ -1,6 +1,7 @@
 import {
 	isBrowserAbortError,
 	isFirefoxDomPermissionDeniedError,
+	isFirefoxInjectedApiNoiseError,
 } from '#client/sentry-browser-filters.ts'
 import {
 	parseSentryClientConfig,
@@ -44,7 +45,11 @@ let onWindowError: ((event: ErrorEvent) => void) | null = null
 let onUnhandledRejection: ((event: PromiseRejectionEvent) => void) | null = null
 
 function shouldIgnoreBufferedError(error: unknown) {
-	return isBrowserAbortError(error) || isFirefoxDomPermissionDeniedError(error)
+	return (
+		isBrowserAbortError(error) ||
+		isFirefoxDomPermissionDeniedError(error) ||
+		isFirefoxInjectedApiNoiseError(error)
+	)
 }
 
 function enqueueBufferedError(error: unknown) {

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -29,8 +29,10 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		replaysSessionSampleRate: 0,
 		replaysOnErrorSampleRate: 1.0,
 		// Drop expected browser noise (AbortError aborts, Firefox DOM
-		// permission-denied from Replay/hydration on restricted nodes) —
-		// see filterBrowserSentryEvent / KODY-CLOUDFLARE-23 / issue 7639685398.
+		// permission-denied from Replay/hydration on restricted nodes,
+		// injected window.__firefox__ bridge misses) — see
+		// filterBrowserSentryEvent / KODY-CLOUDFLARE-23 / 7639685398 /
+		// KODY-CLOUDFLARE-3G.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

**Superseded — do not merge.** Standing down in favor of #1164.

Three triage agents raced on the same Brave/iOS injected-global Sentry cluster and each opened a PR touching `sentry-browser-filters.ts`. Merging more than one will conflict.

## Decision

Keep **[#1164](https://github.com/kentcdodds/kody/pull/1164)** (earliest; covers `window.ethereum.*` and `__firefox__`, including the 3G signatures `window.__firefox__.reader` / `refresh_youtube_quality_…` and sibling 3F `Can't find variable: __firefox__`).

Also overlapping: [#1165](https://github.com/kentcdodds/kody/pull/1165) (3F) — already stood down for #1164.

This PR (#1166) only filters `__firefox__` and is a strict subset of #1164.

## Original findings (historical)

- [KODY-CLOUDFLARE-3G](https://kent-c-dodds-tech-llc.sentry.io/issues/7648833423/): unhandled `onerror` on `/pricing` from injected `window.__firefox__.*` access
- Zero `__firefox__` references in app source — not a product bug
- Outcome intended: **filtered** via client `beforeSend` (now owned by #1164)

## Testing

- Unit tests on this branch covered the three production `__firefox__` signatures (superseded by #1164’s broader suite)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-853b0169-78fd-4bc1-9f36-bdcb137daf26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-853b0169-78fd-4bc1-9f36-bdcb137daf26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced error-reporting noise by filtering Firefox-injected API errors.
  * Preserved reporting for unrelated errors and original exceptions.
  * Added coverage for reader, media-helper, missing-bridge, and related Firefox error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->