### PR TITLE
fix(sentry): drop DO storage object-reset blips (KODY-CLOUDFLARE-3H)

### DIFF
--- a/packages/worker/src/jobs/execution-safety.node.test.ts
+++ b/packages/worker/src/jobs/execution-safety.node.test.ts
@@ -171,6 +171,13 @@ test('transient platform failures back off the same occurrence while permanent o
 			),
 		),
 	).toBe(true)
+	expect(
+		isTransientJobExecutionError(
+			new Error(
+				'Internal error in Durable Object storage caused object to be reset; reference = 849rqmf61lg3qbmtb3j6moc4',
+			),
+		),
+	).toBe(true)
 	expect(isTransientJobExecutionError(new Error('user code failed'))).toBe(
 		false,
 	)

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -235,9 +235,10 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	).not.toBeNull()
 
 	// Bare Cloudflare DO platform resets (memory / CPU / deploy-time code
-	// update / blockConcurrencyWhile timeout) are transient — one
-	// representative form per family, plus an `Error:`-prefixed variant and a
-	// missing trailing period. Wrapped recovery failures must stay visible.
+	// update / blockConcurrencyWhile timeout / storage object-reset) are
+	// transient — one representative form per family, plus an
+	// `Error:`-prefixed variant and a missing trailing period. Wrapped
+	// recovery failures and unreferenced storage resets must stay visible.
 	expect(
 		filterSentryEvent({
 			exception: {
@@ -278,6 +279,30 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 			},
 		}),
 	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Internal error in Durable Object storage caused object to be reset; reference = 849rqmf61lg3qbmtb3j6moc4',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Error: Internal error in Durable Object storage caused object to be reset; reference = 849rqmf61lg3qbmtb3j6moc4',
+					},
+				],
+			},
+		}),
+	).toBeNull()
 
 	const exhaustedPublishRecovery = {
 		exception: {
@@ -290,6 +315,20 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	}
 	expect(filterSentryEvent(exhaustedPublishRecovery)).toBe(
 		exhaustedPublishRecovery,
+	)
+
+	const unreferencedDoStorageReset = {
+		exception: {
+			values: [
+				{
+					value:
+						'Internal error in Durable Object storage caused object to be reset',
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(unreferencedDoStorageReset)).toBe(
+		unreferencedDoStorageReset,
 	)
 
 	const unrelatedDoFailure = {

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -117,13 +117,15 @@ export function filterExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
  * Exact Cloudflare Durable Object platform-reset messages. When a DO hits its
  * memory or CPU limit, when a deploy replaces DO code under an in-flight
  * RPC/alarm (for example cron `oauth_purge_expired` → OAuthPurgeCoordinator),
- * or when `blockConcurrencyWhile` exceeds its ~30s deadlock timeout (for
+ * when `blockConcurrencyWhile` exceeds its ~30s deadlock timeout (for
  * example PartyServer awaiting MCP Agent `onStart` via `getServerByName` →
- * `setName`), the platform resets the isolate and surfaces one of these
- * errors to the caller. The next call gets a fresh isolate; app-level retry
- * is unsafe for non-idempotent jobs, and moving heavy Agent/MCP startup out
+ * `setName`), or when DO SQLite storage hits an opaque internal fault and
+ * resets the object, the platform surfaces one of these errors to the caller.
+ * The next call gets a fresh isolate / storage handle; app-level retry of
+ * non-idempotent work is still unsafe, and moving heavy Agent/MCP startup out
  * of `onStart` is an architectural change outside a triage fix. Match only
- * the bare platform strings so wrapped failures such as exhausted
+ * the bare platform strings (plus the storage form that requires a support
+ * `reference =` token) so wrapped failures such as exhausted
  * `package_publish_external_push` recovery messages stay visible.
  */
 export const durableObjectIsolateMemoryResetMessage =
@@ -138,11 +140,28 @@ export const durableObjectCodeUpdatedResetMessage =
 export const durableObjectBlockConcurrencyWhileTimeoutResetMessage =
 	'A call to blockConcurrencyWhile() in a Durable Object waited for too long. The call was canceled and the Durable Object was reset.'
 
+/**
+ * Cloudflare Durable Object SQLite storage opaque platform fault with a
+ * support reference, e.g.
+ * `Internal error in Durable Object storage caused object to be reset; reference = <id>`.
+ * Same class as D1's `Internal error in D1 DB storage caused object to be
+ * reset` (see `d1-retry.ts`): not an application defect — DO storage hit an
+ * internal fault. Require `reference =` and this exact phrasing so bare /
+ * unrelated "Durable Object storage …" messages stay Sentry-visible.
+ */
+const durableObjectStorageObjectResetPattern =
+	/^internal error in Durable Object storage caused object to be reset;\s*reference\s*=\s*[A-Za-z0-9]+$/i
+
 function normalizeDurableObjectIsolateResetMessage(message: string) {
 	const withoutErrorPrefix = message.trim().replace(/^Error:\s*/i, '')
 	return withoutErrorPrefix.endsWith('.')
 		? withoutErrorPrefix
 		: `${withoutErrorPrefix}.`
+}
+
+export function isDurableObjectStorageObjectResetMessage(message: string) {
+	const withoutErrorPrefix = message.trim().replace(/^Error:\s*/i, '')
+	return durableObjectStorageObjectResetPattern.test(withoutErrorPrefix)
 }
 
 export function isDurableObjectIsolateResetMessage(message: string) {
@@ -151,7 +170,8 @@ export function isDurableObjectIsolateResetMessage(message: string) {
 		normalized === durableObjectIsolateMemoryResetMessage ||
 		normalized === durableObjectIsolateCpuResetMessage ||
 		normalized === durableObjectCodeUpdatedResetMessage ||
-		normalized === durableObjectBlockConcurrencyWhileTimeoutResetMessage
+		normalized === durableObjectBlockConcurrencyWhileTimeoutResetMessage ||
+		isDurableObjectStorageObjectResetMessage(message)
 	)
 }
 
@@ -220,8 +240,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// paths; see filterUserModuleBundlerFailureSentryEvent and
 		// filterExecutorSandboxTimeoutSentryEvent. Bare Cloudflare Durable
 		// Object platform reset strings (memory/CPU limits, deploy-time code
-		// updates, and blockConcurrencyWhile timeouts) are dropped the same
-		// way — see filterDurableObjectIsolateResetSentryEvent.
+		// updates, blockConcurrencyWhile timeouts, and DO storage
+		// object-reset with a support reference) are dropped the same way —
+		// see filterDurableObjectIsolateResetSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters Sentry noise from [KODY-CLOUDFLARE-3H](https://kent-c-dodds-tech-llc.sentry.io/issues/7649525410/) (`Error: Internal error in Durable Object storage caused object to be reset; reference = 849rqmf61lg3qbmtb3j6moc4`).

One production event fired during a JobManager alarm (`runDueJobsForUser` → `withAccountWriteLease` → `acquireDoAccountWriteLeaseAndWrite`) when Cloudflare Durable Object storage returned an opaque internal fault with support reference `849rqmf61lg3qbmtb3j6moc4`. This is transient DO storage backend unavailability, not an application bug — the same class already handled for D1 storage object-reset (#954) and bare DO isolate resets (#962).

This PR extends the existing DO platform-reset matcher so:

1. `beforeSend` (`filterDurableObjectIsolateResetSentryEvent`) drops bare DO storage object-reset events that include a support `reference =` token
2. `isTransientJobExecutionError` classifies the same message as transient so scheduled jobs can back off the occurrence (same path as isolate memory/CPU resets)

The matcher still requires `reference = <token>` and the exact Cloudflare phrasing, so bare `"Internal error in Durable Object storage caused object to be reset"` and unrelated `"Durable Object storage failed"` messages stay Sentry-visible. Wrapped recovery failures remain visible via the existing every-message-is-bare-reset rule.

Siblings (client Navigation API, connector errors, OAuth, storage entitlement, etc.) do not share this root cause and are left alone.

## Test plan

- [x] `sentry-options.node.test.ts` drops referenced DO storage object-reset (with and without `Error:` prefix); keeps unreferenced / unrelated DO storage wording
- [x] `execution-safety.node.test.ts` treats referenced DO storage object-reset as transient
- [ ] CI `npm run validate` green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `49aa4b30` · **Head:** `bf877396`

**Classification:** composes — observability-only `beforeSend` filter plus reuse of the existing job transient-error path; no new primitives or storage contracts.

### Primitives touched

| Primitive | Group     | Impact                                                                 |
| --------- | --------- | ---------------------------------------------------------------------- |
| `jobs`    | assistant | composes — tests that DO storage object-reset is transient like isolate resets |

Unmatched (observability wiring): `packages/worker/src/sentry-options.ts` (+ tests).

### System map

Job alarm write-lease hits a Cloudflare DO storage blip; Sentry drops the bare referenced message and jobs treat it as transient.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	jobs["jobs<br/>Scheduled jobs"]:::touched
	sentryFilter["sentry-options<br/>beforeSend filters"]:::touched
	jobs -->|"isTransientJobExecutionError via isDurableObjectIsolateResetMessage"| sentryFilter
	sentryFilter -->|"drop bare DO storage object-reset + reference"| sentryFilter
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3926b8f-19e9-40c4-98ac-f5d0dcbe34ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3926b8f-19e9-40c4-98ac-f5d0dcbe34ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Durable Object storage reset errors that include support references.
  * These expected platform failures are now classified appropriately and filtered from error reporting.
  * Storage reset errors without a valid reference remain visible for investigation.
* **Tests**
  * Expanded coverage for referenced and `Error:`-prefixed storage reset messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->