### PR TITLE
fix(email): avoid DO SQLite LIKE 50-byte limit in mailbox search (KODY-CLOUDFLARE-3J)

### DIFF
--- a/packages/worker/src/email/mailbox-mappers.ts
+++ b/packages/worker/src/email/mailbox-mappers.ts
@@ -58,10 +58,6 @@ function parseOptionalJsonRecord(value: string | null) {
 	}
 }
 
-export function escapeLikePattern(value: string) {
-	return value.replaceAll(/[\\%_]/g, (character) => `\\${character}`)
-}
-
 function requirePersistedEnum<T extends string>(
 	values: ReadonlyArray<T>,
 	value: unknown,

--- a/packages/worker/src/email/mailbox-store.ts
+++ b/packages/worker/src/email/mailbox-store.ts
@@ -37,7 +37,6 @@ import {
 import { emailAttachmentBlobKey, emailRawMimeKey } from './blob-keys.ts'
 import {
 	boundedEmailBody,
-	escapeLikePattern,
 	mapMailboxAttachmentRow,
 	mapMailboxMessageRow,
 	mapMailboxThreadRow,
@@ -76,13 +75,15 @@ function buildMailboxMessageFilterClauses(input: {
 	const clauses: Array<string> = ['1 = 1']
 	const params: Array<SqlStorageValue> = []
 	if (typeof input.query === 'string') {
-		const pattern = `%${escapeLikePattern(input.query.trim().toLowerCase())}%`
+		// Substring match via INSTR — DO SQLite rejects LIKE/GLOB patterns over
+		// 50 bytes (Cloudflare limit), and MCP allows queries up to 256 chars.
+		const needle = input.query.trim().toLowerCase()
 		clauses.push(`(
-			LOWER(subject) LIKE ? ESCAPE '\\'
-			OR LOWER(from_address) LIKE ? ESCAPE '\\'
-			OR LOWER(COALESCE(envelope_from, '')) LIKE ? ESCAPE '\\'
+			INSTR(LOWER(subject), ?) > 0
+			OR INSTR(LOWER(from_address), ?) > 0
+			OR INSTR(LOWER(COALESCE(envelope_from, '')), ?) > 0
 		)`)
-		params.push(pattern, pattern, pattern)
+		params.push(needle, needle, needle)
 	}
 	if (input.inboxId) {
 		clauses.push('inbox_id = ?')

--- a/packages/worker/src/email/repo-search.workers.test.ts
+++ b/packages/worker/src/email/repo-search.workers.test.ts
@@ -107,6 +107,33 @@ test('Mailbox search treats LIKE wildcards in the query literally', async () => 
 	).toEqual([literalUnderscore])
 }, 30_000)
 
+test('Mailbox search accepts queries longer than DO SQLite LIKE 50-byte limit', async () => {
+	const userId = uniqueUserId('search-long')
+	// DO SQLite caps LIKE/GLOB patterns at 50 bytes; `%…%` wrapping used to
+	// 500 any needle longer than ~48 chars (KODY-CLOUDFLARE-3J).
+	const longNeedle =
+		'quarterly-invoice-reconciliation-status-update-2026-08'
+	expect(longNeedle.length).toBeGreaterThan(48)
+	const matchId = await insertMessage({
+		userId,
+		sequence: 1,
+		subject: `Please review ${longNeedle} before Friday`,
+		fromAddress: 'billing@acme.example',
+	})
+	await insertMessage({
+		userId,
+		sequence: 2,
+		subject: 'Unrelated short note',
+		fromAddress: 'friend@example.net',
+	})
+
+	const results = await rpcFor(userId).searchMessages({
+		query: longNeedle,
+		limit: 25,
+	})
+	expect(results.messages.map((message) => message.id)).toEqual([matchId])
+}, 30_000)
+
 test('Mailbox search applies filters and result limits', async () => {
 	const userId = uniqueUserId('search-filters')
 	const inboxId = `inbox-${crypto.randomUUID()}`

--- a/packages/worker/src/email/repo-search.workers.test.ts
+++ b/packages/worker/src/email/repo-search.workers.test.ts
@@ -110,9 +110,8 @@ test('Mailbox search treats LIKE wildcards in the query literally', async () => 
 test('Mailbox search accepts queries longer than DO SQLite LIKE 50-byte limit', async () => {
 	const userId = uniqueUserId('search-long')
 	// DO SQLite caps LIKE/GLOB patterns at 50 bytes; `%…%` wrapping used to
-	// 500 any needle longer than ~48 chars (KODY-CLOUDFLARE-3J).
-	const longNeedle =
-		'quarterly-invoice-reconciliation-status-update-2026-08'
+	// fail once the wrapped pattern exceeds 50 bytes (KODY-CLOUDFLARE-3J).
+	const longNeedle = 'quarterly-invoice-reconciliation-status-update-2026-08'
 	expect(longNeedle.length).toBeGreaterThan(48)
 	const matchId = await insertMessage({
 		userId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop `email_message_search` from 500ing on longer queries against Mailbox DO SQLite (KODY-CLOUDFLARE-3J).

## Summary

- Root cause: Cloudflare DO SQLite caps LIKE/GLOB patterns at 50 bytes; mailbox search wrapped needles as `%…%`, so queries longer than ~48 characters threw `LIKE or GLOB pattern too complex`.
- Fix: use `INSTR(LOWER(column), ?) > 0` for the documented case-insensitive substring match (literal `%` / `_` preserved).
- Added workers regression for a needle longer than the old LIKE limit.

## Testing

- `npm run test:workers -- packages/worker/src/email/repo-search.workers.test.ts` (4 passed)
- `npm run validate` (passed)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d8c2fc0a` · **Head:** `4de1b51b`

**Classification:** composes — isolated mailbox search bug fix; same substring contract, INSTR instead of LIKE so DO SQLite's 50-byte pattern cap cannot 500 long queries.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mailbox` | storage | composes — `searchMessages` / count filter uses INSTR substring match |
| `email` | assistant | composes — workers regression for long needles |

### System map

_MCP `email_message_search` → owner mailbox RPC → Mailbox DO SQL filter; long needles no longer build LIKE patterns._

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
  MCP["email_message_search"]:::green
  Reader["owner-email-reader"]:::gray
  Store["MailboxStore filter"]:::green
  DOSQL["DO SQLite INSTR"]:::gray
  MCP --> Reader --> Store --> DOSQL
  classDef green fill:#1b4332,stroke:#95d5b2,color:#f8fff9
  classDef gray fill:#3d4451,stroke:#9aa3b2,color:#f5f7fa
  classDef amber fill:#5c3d0a,stroke:#f0c14a,color:#fff8e1
  classDef red fill:#5c1a1a,stroke:#f5a3a3,color:#fff5f5
```

### Risk

Low — clear Cloudflare limit root cause, behavior matches documented substring search, covered by workers test; no auth, isolation, billing, or migration changes.

### Invariants

No invariant changes. Per-user mailbox isolation unchanged (still owner-scoped DO SQL).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fa05fc7-6bbd-4910-bd0b-de8751607b56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fa05fc7-6bbd-4910-bd0b-de8751607b56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mailbox message search for longer queries.
  * Search now matches subject and sender details more reliably while avoiding unrelated results.
  * Search terms are handled more consistently, including mixed-case queries and surrounding spaces.

* **Tests**
  * Added coverage confirming that searches exceeding previous length limitations return the correct matching message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->