### PR TITLE
fix(worker): raise subrequest limit for long MCP storage_query sessions

### DIFF
--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -46,7 +46,7 @@ Do not spawn a one-agent "fleet."
 
 **PR ownership.** Every code-changing agent pushes and creates/updates its own
 PR via Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before its final
-response. Never have Kody/workflows/github create the initial PR. State this in
+response. Never have Kody/workflows/GitHub create the initial PR. State this in
 every kickoff.
 
 **Report-back (wake-ups, not polling).** End of every run — done, partial, or

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -3,6 +3,17 @@
 	"name": "kody",
 	"compatibility_date": "2026-04-16",
 	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+	// Paid default is 10_000 subrequests/invocation. The MCP Agent Durable
+	// Object keeps a long-lived session and each mutating storage_query pays
+	// several D1 + StorageRunner RPCs (entitlement baseline, sqlQuery,
+	// estimate refresh). Production hit "Too many API requests by single
+	// Worker invocation" (Sentry 7650160242 / KODY-CLOUDFLARE-2S) during a
+	// burst of ~25 storage_query calls in one session — raise the ceiling
+	// for that long-lived DO workload. Inheritable by env.production /
+	// env.preview. https://developers.cloudflare.com/workers/wrangler/configuration/#limits
+	"limits": {
+		"subrequests": 100000,
+	},
 	"main": "./src/index.ts",
 	"minify": true,
 	"upload_source_maps": true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production MCP sessions hit Cloudflare’s per-invocation subrequest ceiling (`Too many API requests by single Worker invocation`) during bursts of mutating `storage_query` calls.

- Sentry [7650160242](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7650160242/) — `storage_query` → `StorageRunner.sqlQuery` RPC (`RpcProperty`)
- Sibling [KODY-CLOUDFLARE-2S](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7641099950/) — same error on the same capability (earlier release; full DO estimate fan-out)

Latest event showed ~25 successful `storage_query` calls in one MCP Agent session (~75 D1 queries) before the next RPC failed. Each mutating call still pays entitlement baseline D1 reads + StorageRunner RPCs + estimate refresh; on the long-lived MCP Agent DO those accumulate against the paid default of 10 000 subrequests/invocation.

## Fix

1. Raise inheritable `limits.subrequests` to `100000` in `packages/worker/wrangler.jsonc` (Cloudflare’s documented knob for long-lived DO / WebSocket workloads).
2. Format `.agents/skills/conduct/SKILL.md` and `.agents/skills/orchestrate/SKILL.md` so `format:check` passes (left failing on main after #1175).

## Risk

**Low / composes** — Worker runtime config + formatting; no auth, isolation, billing, or migration surface.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `96e0dc58` · **Head:** `876bbf6b`

**Classification:** composes — raises Cloudflare Worker subrequest ceiling; no primitive behavior or contracts change.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none matched)_ | runtime config | `wrangler.jsonc` `limits.subrequests` only |

### System map

MCP Agent long-lived sessions accumulate D1 + StorageRunner subrequests until the Worker invocation ceiling; this PR only raises that ceiling.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpAgent["MCP Agent DO<br/>long-lived session"]:::untouched
	storageQuery["storage_query<br/>mutating SQL"]:::untouched
	limits["wrangler limits.subrequests<br/>100000"]:::touched
	mcpAgent -->|"tool calls"| storageQuery
	storageQuery -->|"D1 + StorageRunner RPCs count against"| limits
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbc31ad4-5da7-4355-b19a-0fc237087b10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbc31ad4-5da7-4355-b19a-0fc237087b10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the Worker’s subrequest limit to support up to 100,000 subrequests per execution in production and preview environments.
* **Documentation**
  * Improved formatting and readability across operational guidance and workflow instructions without changing their meaning or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->