### PR TITLE
style: fix oxfmt violations in synced skill docs

### DIFF
--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -53,11 +53,12 @@ this in every kickoff.
 blocked — the agent wakes the conductor:
 
 ```javascript
-import { createRun } from 'kody:@kentcdodds/cursor/runs'
+import { createRun } from "kody:@kentcdodds/cursor/runs";
 await createRun({
-	agentId: '<CONDUCTOR_AGENT_ID>',
-	prompt: '<track> report: STATUS; shipped (PR links); evidence; remains + gate times.',
-})
+  agentId: "<CONDUCTOR_AGENT_ID>",
+  prompt:
+    "<track> report: STATUS; shipped (PR links); evidence; remains + gate times.",
+});
 ```
 
 Get your id from cursor-cloud `run-info` and paste it into kickoffs. Also keep
@@ -71,13 +72,13 @@ re-dispatch.
 **Time gates → one-shot jobs**, not `sleep`:
 
 ```javascript
-import { kody } from 'kody:runtime'
+import { kody } from "kody:runtime";
 await kody.job_schedule({
-	name: 'wake-<track>-after-<gate>',
-	description: 'Resume <track> when <gate> elapses.',
-	schedule: { type: 'once', run_at: '<ISO datetime>' },
-	code: "import { createRun } from 'kody:@kentcdodds/cursor/runs'\nexport default async function main() { return await createRun({ agentId: '<AGENT_ID>', prompt: '<gate> elapsed; verify evidence, then proceed.' }) }",
-})
+  name: "wake-<track>-after-<gate>",
+  description: "Resume <track> when <gate> elapses.",
+  schedule: { type: "once", run_at: "<ISO datetime>" },
+  code: "import { createRun } from 'kody:@kentcdodds/cursor/runs'\nexport default async function main() { return await createRun({ agentId: '<AGENT_ID>', prompt: '<gate> elapsed; verify evidence, then proceed.' }) }",
+});
 ```
 
 Schedule the same against your own agent id so the program survives session
@@ -106,20 +107,20 @@ Load with `skill_get` and embed when useful: `orchestrate` (in-track fan-out),
 ## Spawn sketch
 
 ```javascript
-import { createAgent } from 'kody:@kentcdodds/cursor/agents'
-import { createRun } from 'kody:@kentcdodds/cursor/runs'
+import { createAgent } from "kody:@kentcdodds/cursor/agents";
+import { createRun } from "kody:@kentcdodds/cursor/runs";
 
 export default async function main() {
-	const { agent } = await createAgent({
-		model: 'gpt-5.6-sol',
-		repository: 'https://github.com/owner/repo',
-		ref: 'main',
-		autoCreatePR: true,
-		name: 'track-short-name',
-		prompt: '…self-contained kickoff with report-back + your conductor id…',
-	})
-	// await createRun({ agentId: agent.id, prompt: 'follow-up…' })
-	return agent
+  const { agent } = await createAgent({
+    model: "gpt-5.6-sol",
+    repository: "https://github.com/owner/repo",
+    ref: "main",
+    autoCreatePR: true,
+    name: "track-short-name",
+    prompt: "…self-contained kickoff with report-back + your conductor id…",
+  });
+  // await createRun({ agentId: agent.id, prompt: 'follow-up…' })
+  return agent;
 }
 ```
 

--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -30,8 +30,8 @@ Do not spawn a one-agent "fleet."
 - **Tracks implement by default.** Hand `orchestrate` only for clear parallel
   ROI inside a track. Sequential slices → one implementer.
 - **Risk posture in every kickoff.** Pre-launch / small-N: evidence or canary
-  gates, soak ≤1h unless the user opts in. No 24h calendar gates for
-  reversible steps. Production / irreversible: say so and raise the bar.
+  gates, soak ≤1h unless the user opts in. No 24h calendar gates for reversible
+  steps. Production / irreversible: say so and raise the bar.
 - **Expand owns contract.** No `STATUS: done` after expand-only — same kickoff
   or a scheduled wake with an owner.
 - **Stop when the goal is met.** Cleanup/drop is a later ask unless the user
@@ -45,24 +45,24 @@ Do not spawn a one-agent "fleet."
 ## Invariants
 
 **PR ownership.** Every code-changing agent pushes and creates/updates its own
-PR via Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before its
-final response. Never have Kody/workflows/github create the initial PR. State
-this in every kickoff.
+PR via Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before its final
+response. Never have Kody/workflows/github create the initial PR. State this in
+every kickoff.
 
 **Report-back (wake-ups, not polling).** End of every run — done, partial, or
 blocked — the agent wakes the conductor:
 
 ```javascript
-import { createRun } from "kody:@kentcdodds/cursor/runs";
+import { createRun } from 'kody:@kentcdodds/cursor/runs'
 await createRun({
-  agentId: "<CONDUCTOR_AGENT_ID>",
-  prompt:
-    "<track> report: STATUS; shipped (PR links); evidence; remains + gate times.",
-});
+	agentId: '<CONDUCTOR_AGENT_ID>',
+	prompt:
+		'<track> report: STATUS; shipped (PR links); evidence; remains + gate times.',
+})
 ```
 
-Get your id from cursor-cloud `run-info` and paste it into kickoffs. Also keep
-a `## Conductor report` section on each PR (durable record).
+Get your id from cursor-cloud `run-info` and paste it into kickoffs. Also keep a
+`## Conductor report` section on each PR (durable record).
 
 Topology: `createRun` wake-ups work only if the conductor is an API-created
 cloud agent. An interactive chat conductor rejects them (400) — use Discord (or
@@ -72,17 +72,17 @@ re-dispatch.
 **Time gates → one-shot jobs**, not `sleep`:
 
 ```javascript
-import { kody } from "kody:runtime";
+import { kody } from 'kody:runtime'
 await kody.job_schedule({
-  name: "wake-<track>-after-<gate>",
-  description: "Resume <track> when <gate> elapses.",
-  schedule: { type: "once", run_at: "<ISO datetime>" },
-  code: "import { createRun } from 'kody:@kentcdodds/cursor/runs'\nexport default async function main() { return await createRun({ agentId: '<AGENT_ID>', prompt: '<gate> elapsed; verify evidence, then proceed.' }) }",
-});
+	name: 'wake-<track>-after-<gate>',
+	description: 'Resume <track> when <gate> elapses.',
+	schedule: { type: 'once', run_at: '<ISO datetime>' },
+	code: "import { createRun } from 'kody:@kentcdodds/cursor/runs'\nexport default async function main() { return await createRun({ agentId: '<AGENT_ID>', prompt: '<gate> elapsed; verify evidence, then proceed.' }) }",
+})
 ```
 
-Schedule the same against your own agent id so the program survives session
-end. Cancel superseded jobs with `job_delete`.
+Schedule the same against your own agent id so the program survives session end.
+Cancel superseded jobs with `job_delete`.
 
 ## Loop
 
@@ -91,10 +91,10 @@ end. Cancel superseded jobs with `job_delete`.
 3. Partition by **file conflict**, not theme. Name each track's out-of-scope
    (what siblings own). One track after partition → demote.
 4. Size agents: implementer by default; `orchestrate` only when fan-out pays.
-5. State shipping policy + risk posture + PR invariant + report-back (with
-   your real agent id) + falsifiable done-definition in every kickoff.
-6. Dispatch, then **end your turn**. Wake-ups/jobs drive the loop. Poll only
-   for silent agents. Verify claims against main before acting.
+5. State shipping policy + risk posture + PR invariant + report-back (with your
+   real agent id) + falsifiable done-definition in every kickoff.
+6. Dispatch, then **end your turn**. Wake-ups/jobs drive the loop. Poll only for
+   silent agents. Verify claims against main before acting.
 7. Nudge idle agents with `createRun` (409 while mid-run — retry or schedule).
    New scope → nearest idle owner; spawn only for new territory.
 8. Final QA is yours — grep main, check deploys. Never report done from claims.
@@ -102,25 +102,26 @@ end. Cancel superseded jobs with `job_delete`.
 ## Companions
 
 Load with `skill_get` and embed when useful: `orchestrate` (in-track fan-out),
-`ship-pr` (merge authority). Skip when the track is small or PRs are review-only.
+`ship-pr` (merge authority). Skip when the track is small or PRs are
+review-only.
 
 ## Spawn sketch
 
 ```javascript
-import { createAgent } from "kody:@kentcdodds/cursor/agents";
-import { createRun } from "kody:@kentcdodds/cursor/runs";
+import { createAgent } from 'kody:@kentcdodds/cursor/agents'
+import { createRun } from 'kody:@kentcdodds/cursor/runs'
 
 export default async function main() {
-  const { agent } = await createAgent({
-    model: "gpt-5.6-sol",
-    repository: "https://github.com/owner/repo",
-    ref: "main",
-    autoCreatePR: true,
-    name: "track-short-name",
-    prompt: "…self-contained kickoff with report-back + your conductor id…",
-  });
-  // await createRun({ agentId: agent.id, prompt: 'follow-up…' })
-  return agent;
+	const { agent } = await createAgent({
+		model: 'gpt-5.6-sol',
+		repository: 'https://github.com/owner/repo',
+		ref: 'main',
+		autoCreatePR: true,
+		name: 'track-short-name',
+		prompt: '…self-contained kickoff with report-back + your conductor id…',
+	})
+	// await createRun({ agentId: agent.id, prompt: 'follow-up…' })
+	return agent
 }
 ```
 

--- a/.agents/skills/orchestrate/SKILL.md
+++ b/.agents/skills/orchestrate/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Orchestrate sub-agents for large tasks inside a single environment: plan,
   delegate coding to cheap/fast models, parallelize the critical path, keep
   reviews lean, and close every loop. Use when acting as an orchestrator or
-  writing a kickoff for one. Prefer implement when fan-out does not clearly
-  pay. For multi-environment fleets, use conduct instead.
+  writing a kickoff for one. Prefer implement when fan-out does not clearly pay.
+  For multi-environment fleets, use conduct instead.
 ---
 
 # Orchestrate
@@ -31,7 +31,8 @@ optimized for cheap/fast execution.
 1. Plan, delegate, integrate, ship. Bulk-code only when fan-out costs more.
 2. Frontier model orchestrates; cheap/fast models implement (prefer Grok 4.5 /
    `composer-2.5-fast` for mechanical work).
-3. Critical path first; parallelize non-conflicting files; serialize shared ones.
+3. Critical path first; parallelize non-conflicting files; serialize shared
+   ones.
 4. **You do final QA.** Never declare done from sub-agent claims.
 
 ## Fan-out (when it pays)

--- a/.agents/skills/orchestrate/SKILL.md
+++ b/.agents/skills/orchestrate/SKILL.md
@@ -22,7 +22,7 @@ optimized for cheap/fast execution.
   beat one implementer. Sequential slices → implement (or one implementer).
 - **No orchestration theater.** Ban review → recheck → final → CI-watch chains
   per slice. **One** hard-to-reverse review before merge.
-- **One CI wait path** — parent `gh pr checks` *or* a ci-watcher, not both.
+- **One CI wait path** — parent `gh pr checks` _or_ a ci-watcher, not both.
 - **Targeted tests while iterating;** full validate before ready-for-review.
 - Close loops yourself — don't leave humans as the relay.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Runs `oxfmt` over `.agents/skills/conduct/SKILL.md` and `.agents/skills/orchestrate/SKILL.md`, which were merged in #1175 with formatting violations, breaking the `✨ Format` check on main and skipping production deploys.

## Why now

Main is red and blocking the email-migration drop chain (#1174/#1176) from deploying. Fix-forward, docs-only, no behavior change.

## Verification

`npm run format:check` passes locally on this branch (was failing on the two files above).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de79dd20-4e77-4947-ab7b-cd9927cd3457?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de79dd20-4e77-4947-ab7b-cd9927cd3457&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and clarified wording across Conduct and Orchestrate guidance.
  * Updated presentation of kickoff instructions, CI wait paths, role guidance, scheduling steps, and related examples.
  * No changes to functionality, behavior, or policy content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->