### PR TITLE
Reject repo source files over 10 MiB with hosting guidance

### DIFF
--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -574,6 +574,15 @@ create and edit it with a normal git client without round-tripping each file
 change through `package_save` or `repo_run_commands`. This lane supports binary
 assets, which `package_save` and repo sessions do not.
 
+Keep individual files under 10 MiB. Publish checks reject any file over that
+per-file limit (and any source root over the aggregate publish caps) with
+guidance to host the file on storage you manage — for example Cloudflare R2,
+Amazon S3, Dropbox, or Google Drive — and commit a small link or pointer file
+instead. Kody never rewrites your files into pointers for you. The Artifacts
+remote itself also fails pushes above roughly 32 MiB of pack content with a
+raw HTTP 413 before Kody is involved, so oversized files can fail at
+`git push` with an unhelpful error even before publish checks run.
+
 1. Mint a short-lived remote credential:
 
    ```json

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.ts
@@ -76,7 +76,7 @@ export const getGitRemoteCapability = defineDomainCapability(
 	{
 		name: 'package_get_git_remote',
 		description:
-			'Start or continue the git lane for saved packages: mint a short-lived Cloudflare Artifacts git remote so coding agents with local filesystem/git access can clone into a temporary directory, edit normally (including binary assets), push, and publish with package_publish_external_push. Pass `create: true` with a new `kody_id` to register a stub saved package and mint its remote in one call, so new packages can be authored via clone-edit-push instead of package_save file blobs. Write access verifies the current package source has a restorable backup snapshot before clone/edit/publish.',
+			'Start or continue the git lane for saved packages: mint a short-lived Cloudflare Artifacts git remote so coding agents with local filesystem/git access can clone into a temporary directory, edit normally (including binary assets), push, and publish with package_publish_external_push. Pass `create: true` with a new `kody_id` to register a stub saved package and mint its remote in one call, so new packages can be authored via clone-edit-push instead of package_save file blobs. Write access verifies the current package source has a restorable backup snapshot before clone/edit/publish. Keep individual files under 10 MiB: publish rejects larger files with external-hosting guidance (commit a link or pointer instead), and the Artifacts remote itself fails pushes above ~32 MiB of pack content with a raw HTTP 413.',
 		keywords: [
 			'package',
 			'create',

--- a/packages/worker/src/mcp/capabilities/packages/save-package-entitlements.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package-entitlements.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import type * as sourceSafetyPolicyModule from '#worker/repo/source-safety-policy.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#worker/entitlements/plans.ts'
+import { maxRepoSourceFileBytes } from '#worker/repo/large-file-policy.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 
@@ -397,6 +398,38 @@ test('package_save does not gate updates to an existing package at the limit', a
 
 	expect(mockModule.ensureEntitySource).toHaveBeenCalled()
 	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalled()
+})
+
+test('package_save rejects a file over the per-file repo size limit with hosting guidance', async () => {
+	const email = 'planned@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const db = createDatabase({
+		users: [
+			{ email, plan: 'max', username: 'planned', stable_user_id: userId },
+		],
+	})
+	setupPersistenceMocks()
+	const ctx = createHandlerContext({ db, userId, email })
+
+	const files = [
+		...buildPackageFiles('oversized-package', 'planned'),
+		{
+			path: 'assets/dataset.csv',
+			content: 'x'.repeat(maxRepoSourceFileBytes + 1),
+		},
+	]
+	const error = await savePackageCapability.handler({ files }, ctx).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+
+	expect(error).toBeInstanceOf(Error)
+	const message = (error as Error).message
+	expect(message).toContain('"assets/dataset.csv"')
+	expect(message).toContain('per-file limit')
+	expect(message).toContain('Cloudflare R2')
+	expect(mockModule.ensureEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
 })
 
 test('package_save responses steer coding agents toward the git lane', async () => {

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -8,6 +8,10 @@ import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
 import { getEntitySourceByEntity } from '#worker/repo/entity-sources.ts'
 import {
+	buildRepoLargeFileMessage,
+	findOversizedRepoSourceFile,
+} from '#worker/repo/large-file-policy.ts'
+import {
 	assertPackageSourceOverwriteAllowed,
 	assertPackagePrivateVisibilityChangeAllowed,
 	defaultPackagePrivateGuidance,
@@ -171,6 +175,10 @@ export const savePackageCapability = defineDomainCapability(
 				throw new McpCallerError(
 					'Saved packages require a root package.json file.',
 				)
+			}
+			const oversizedFile = findOversizedRepoSourceFile(Object.entries(files))
+			if (oversizedFile) {
+				throw new McpCallerError(buildRepoLargeFileMessage(oversizedFile))
 			}
 			const expectedPackageScope = owner.ownerScope
 			const existing =

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -33,6 +33,7 @@ import {
 	runRepoChecks,
 } from './checks.ts'
 import { isolatedBundleChunkSize } from './isolated-check-phases.ts'
+import { maxRepoSourceFileBytes } from './large-file-policy.ts'
 
 type MockSnapshot = {
 	read: ReturnType<typeof vi.fn>
@@ -238,6 +239,31 @@ test('runRepoChecks fails when the source root exceeds publish size caps', async
 		expect.objectContaining({ kind: 'manifest', ok: true }),
 		expect.objectContaining({ kind: 'bundle', ok: false }),
 	])
+})
+
+test('runRepoChecks fails a single file over the per-file limit with hosting guidance', async () => {
+	const oversized = 'x'.repeat(maxRepoSourceFileBytes + 1)
+	const result = await runChecksOnWorkspaceFiles(
+		new Map<string, string>([
+			[
+				'package.json',
+				createPackageManifest({
+					packageName: '@kody/one-large-file',
+					kodyId: 'one-large-file',
+					description: 'Exceeds the per-file publish limit',
+				}),
+			],
+			['src/index.ts', 'export const ready = true\n'],
+			['assets/dataset.csv', oversized],
+		]),
+	)
+	expect(result.ok).toBe(false)
+	expect(result.sourceFiles).toEqual({})
+	const bundleCheck = result.results.find((check) => check.kind === 'bundle')
+	expect(bundleCheck?.ok).toBe(false)
+	expect(bundleCheck?.message).toContain('"assets/dataset.csv"')
+	expect(bundleCheck?.message).toContain('per-file limit')
+	expect(bundleCheck?.message).toContain('Cloudflare R2')
 })
 
 test('runRepoChecks keeps non-code source files for publish snapshots while excluding git internals', async () => {

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -43,6 +43,10 @@ import {
 	isolatedBundleChunkSize,
 	type IsolatedCheckPhaseRunner,
 } from './isolated-check-phases.ts'
+import {
+	buildRepoLargeFileMessage,
+	maxRepoSourceFileBytes,
+} from './large-file-policy.ts'
 import { normalizeRepoWorkspacePath } from './manifest.ts'
 
 export type RepoCheckKind =
@@ -1162,7 +1166,17 @@ export async function runRepoChecks(input: {
 					message: `Repo checks aborted: source root "${sourceRoot || '/'}" contains more than the ${repoChecksSourceMaxFiles}-file publish check limit. Remove files that should not be published (for example build output, vendored dependencies, or data files) and run the checks again.`,
 				}
 			}
-			totalBytes += encoder.encode(content).byteLength
+			const fileBytes = encoder.encode(content).byteLength
+			if (fileBytes > maxRepoSourceFileBytes) {
+				return {
+					ok: false as const,
+					message: `Repo checks aborted: ${buildRepoLargeFileMessage({
+						path,
+						byteLength: fileBytes,
+					})}`,
+				}
+			}
+			totalBytes += fileBytes
 			if (totalBytes > repoChecksSourceMaxTotalBytes) {
 				return {
 					ok: false as const,

--- a/packages/worker/src/repo/large-file-policy.node.test.ts
+++ b/packages/worker/src/repo/large-file-policy.node.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest'
+import {
+	buildRepoLargeFileMessage,
+	findOversizedRepoSourceFile,
+	maxRepoSourceFileBytes,
+	measureRepoSourceFileBytes,
+} from './large-file-policy.ts'
+
+test('measureRepoSourceFileBytes counts UTF-8 bytes, not code units', () => {
+	expect(measureRepoSourceFileBytes('abc')).toBe(3)
+	// U+1F600 encodes to 4 UTF-8 bytes but 2 UTF-16 code units.
+	expect(measureRepoSourceFileBytes('😀')).toBe(4)
+})
+
+test('findOversizedRepoSourceFile returns the first file over the limit', () => {
+	const within = 'x'.repeat(maxRepoSourceFileBytes)
+	const over = 'x'.repeat(maxRepoSourceFileBytes + 1)
+	expect(
+		findOversizedRepoSourceFile([
+			['src/index.ts', 'export default async function main() {}\n'],
+			['assets/ok.txt', within],
+		]),
+	).toBeNull()
+	expect(
+		findOversizedRepoSourceFile([
+			['assets/ok.txt', within],
+			['assets/too-big.txt', over],
+		]),
+	).toEqual({
+		path: 'assets/too-big.txt',
+		byteLength: maxRepoSourceFileBytes + 1,
+	})
+})
+
+test('buildRepoLargeFileMessage names the file, sizes, and hosting guidance', () => {
+	const message = buildRepoLargeFileMessage({
+		path: 'assets/video-notes.md',
+		byteLength: 12 * 1024 * 1024,
+	})
+	expect(message).toContain('"assets/video-notes.md"')
+	expect(message).toContain('12.0 MiB')
+	expect(message).toContain('10.0 MiB per-file limit')
+	expect(message).toContain('Cloudflare R2')
+	expect(message).toContain('link or pointer file')
+})

--- a/packages/worker/src/repo/large-file-policy.ts
+++ b/packages/worker/src/repo/large-file-policy.ts
@@ -1,0 +1,55 @@
+/**
+ * Per-file size policy for repo-backed source (saved packages and jobs).
+ *
+ * Repos store versioned text source, not large assets: Cloudflare Artifacts
+ * rejects push packs above ~32 MiB of decompressed content with a raw HTTP
+ * 413, and publish checks materialize the whole source root in Durable
+ * Object memory (see `repoChecksSourceMaxTotalBytes` in checks.ts). Gating
+ * each file well below those ceilings keeps every failure on a Kody surface
+ * with an actionable message instead of an opaque git or memory error.
+ *
+ * Files are never rewritten into pointers opaquely — the gate rejects with
+ * guidance and the user decides where the large file lives.
+ */
+export const maxRepoSourceFileBytes = 10 * 1024 * 1024
+
+const encoder = new TextEncoder()
+
+export function measureRepoSourceFileBytes(content: string) {
+	return encoder.encode(content).byteLength
+}
+
+function formatMiB(bytes: number) {
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`
+}
+
+export function buildRepoLargeFileMessage(input: {
+	path: string
+	byteLength: number
+}) {
+	return (
+		`"${input.path}" is ${formatMiB(input.byteLength)}, which is over the ` +
+		`${formatMiB(maxRepoSourceFileBytes)} per-file limit for repo-backed source. ` +
+		'Repos store versioned source and small assets, not large files. ' +
+		'Host the file on storage you manage (for example Cloudflare R2, Amazon S3, ' +
+		'Dropbox, or Google Drive) and commit a small link or pointer file instead.'
+	)
+}
+
+/**
+ * Returns the first oversized file entry, or null when every file is within
+ * the per-file limit. Callers decide how to surface the failure (check
+ * result, caller error, or RPC error) but must use
+ * `buildRepoLargeFileMessage` for the user-facing text.
+ */
+export function findOversizedRepoSourceFile(
+	files: Iterable<readonly [path: string, content: string]>,
+) {
+	for (const [path, content] of files) {
+		const byteLength = measureRepoSourceFileBytes(content)
+		if (byteLength > maxRepoSourceFileBytes) {
+			return { path, byteLength }
+		}
+	}
+	return null
+}

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -403,6 +403,7 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 const { RepoSession } = await import('./repo-session-do.ts')
 const { deleteRepoSession, insertRepoSession } =
 	await import('./repo-sessions.ts')
+const { maxRepoSourceFileBytes } = await import('./large-file-policy.ts')
 
 function createDurableObjectState() {
 	const storageState = new Map<string, unknown>()
@@ -759,6 +760,26 @@ test('runCommands applies git apply patches (modify, delete, and rename)', async
 			content: 'export const name = "new"\n',
 		}),
 	)
+})
+
+test('applyEdits rejects a write over the per-file repo size limit with hosting guidance', async () => {
+	setCommonSessionFixtures()
+	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
+
+	await expect(
+		repoSession.applyEdits({
+			sessionId: 'session-1',
+			userId: 'user-1',
+			edits: [
+				{
+					kind: 'write',
+					path: 'assets/dataset.csv',
+					content: 'x'.repeat(maxRepoSourceFileBytes + 1),
+				},
+			],
+		}),
+	).rejects.toThrow(/"assets\/dataset\.csv".*per-file limit.*Cloudflare R2/s)
+	expect(mockModule.workspaceWriteFile).not.toHaveBeenCalled()
 })
 
 test('runCommands rejects publish without checks for direct RPC callers', async () => {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -104,6 +104,11 @@ import {
 	parseRepoGitCommands,
 } from './repo-session-commands.ts'
 import { createIsomorphicGitFs } from './isomorphic-git-fs.ts'
+import {
+	buildRepoLargeFileMessage,
+	maxRepoSourceFileBytes,
+	measureRepoSourceFileBytes,
+} from './large-file-policy.ts'
 
 const repoSessionWorkspacePrefix = '/session'
 const lastCheckStatusStorageKey = 'repo-session:last-check-status'
@@ -746,15 +751,22 @@ class RepoSessionBase extends DurableObject<Env> {
 					repoSessionWorkspacePrefix,
 				)
 				switch (edit.kind) {
-					case 'write':
+					case 'write': {
 						if (typeof edit.content !== 'string') {
 							throw new Error('repo session write edits require content.')
+						}
+						const byteLength = measureRepoSourceFileBytes(edit.content)
+						if (byteLength > maxRepoSourceFileBytes) {
+							throw new Error(
+								buildRepoLargeFileMessage({ path: edit.path, byteLength }),
+							)
 						}
 						return {
 							kind: 'write' as const,
 							path,
 							content: edit.content,
 						}
+					}
 					case 'replace':
 						if (typeof edit.search !== 'string') {
 							throw new Error('repo session replace edits require search.')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a per-file 10 MiB size gate for repo-backed source (saved packages and jobs) with one canonical, actionable error message. Files are never rewritten into pointers — the gate rejects and the user decides where the large file lives.

## Why

Cloudflare Artifacts rejects push packs above ~32 MiB of decompressed content with a raw HTTP 413 (empirically verified: 30 MiB random data pushes in ~4 min, 31 MiB fails with a 500 after ~4 min, 35+ MiB fails fast with 413 — including a 200 MB file of zeros, so the cap is on decompressed content and compression does not help). Publish checks also materialize the source root in Durable Object memory. Without a Kody-side gate, users who try to commit large files hit opaque git plumbing errors ("RPC failed; HTTP 413 … Everything up-to-date") or slow 500s instead of guidance.

## How

New `packages/worker/src/repo/large-file-policy.ts` owns the threshold (`maxRepoSourceFileBytes` = 10 MiB), the byte measurement, and the single message builder (per the repo convention of one user-facing message per policy). Wired into all three write/publish lanes:

- **`package_save`** rejects oversized files up front with `McpCallerError` before any Artifacts write.
- **Repo session `applyEdits`** (backing `repo_write_file`) rejects oversized write edits before planning.
- **`runRepoChecks`** aborts when any collected source file exceeds the limit — this is the authoritative gate and automatically covers session publish, external git-push publish (`package_publish_external_push`), and community fork installs, following the existing 2,000-file / 15 MiB aggregate cap pattern.

The git lane cannot be intercepted mid-push (Artifacts owns that HTTP exchange), so `package_get_git_remote`'s description and `docs/use/packages.md` now warn about both the Kody per-file limit and the raw Artifacts 413.

## Testing

- New `large-file-policy.node.test.ts` (byte measurement incl. multi-byte UTF-8, first-oversized-file detection, message content).
- `checks.node.test.ts`: per-file abort with hosting guidance.
- `save-package-entitlements.node.test.ts`: `package_save` rejects before `ensureEntitySource`/`syncArtifactSourceSnapshot`.
- `repo-session-do.node.test.ts`: `applyEdits` rejects before any workspace write.
- Full `npm run validate` green: 556 test files, 1916 passed / 4 skipped.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/repo-large-file-gate-6db6`

**Classification:** extends — two primitives gain a new per-file size contract on their write/publish paths; no new primitives.

### Primitives touched

| Primitive        | Group     | Impact                                                                                       |
| ---------------- | --------- | -------------------------------------------------------------------------------------------- |
| `repo-sessions`  | runtime   | extends — `applyEdits` and `runRepoChecks` now reject files over 10 MiB with hosting guidance |
| `saved-packages` | assistant | extends — `package_save` rejects oversized files; `package_get_git_remote` documents the limit |

### System map

Oversized file writes are rejected at each entry lane before reaching Artifacts; publish checks are the authoritative gate for the git lane.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::untouched
	savedPackages -->|"package_save per-file gate (McpCallerError)"| artifactsRepos
	repoSessions -->|"applyEdits write gate"| artifactsRepos
	repoSessions -->|"runRepoChecks per-file abort on publish"| artifactsRepos
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Lane                                   | Before                                              | After                                                |
| -------------------------------------- | --------------------------------------------------- | ---------------------------------------------------- |
| `package_save` with an 11 MiB file     | Accepted (until 15 MiB aggregate publish cap)       | Rejected immediately with hosting guidance           |
| `repo_write_file` with an 11 MiB file  | Written to session overlay                          | Rejected before planning, no workspace mutation      |
| git push + publish with an 11 MiB file | Publish checks pass if total < 15 MiB               | `checks_failed` naming the file, sizes, alternatives |
| git push of a 35 MiB file              | Raw Artifacts HTTP 413 (unchanged — documented now) | Same, now documented in capability text and docs     |

</details>

<!-- system-recap:end -->

## Conductor report

Implemented directly in this environment per the conduct skill's demotion rule (single repo, file-overlapping tracks). This is slice 1 of 2; slice 2 (file-level repo session API replacing `repo_run_commands`) lands separately after this merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a270e474-6981-44b4-8878-b8e2d0436db6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a270e474-6981-44b4-8878-b8e2d0436db6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 10 MiB per-file limit for repository source files.
  - Added clear guidance to host oversized files externally, including Cloudflare R2 recommendations.
  - Documented aggregate source limits and approximate 32 MiB Artifacts push limits.

- **Bug Fixes**
  - Oversized files are now rejected during package saves, repository checks, and workspace edits.
  - Prevented invalid oversized content from being persisted or synchronized.
  - Error messages identify the affected file, its size, the applicable limit, and recommended next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->