### PR TITLE
fix(sentry): drop DO storage operation timeout resets (KODY-CLOUDFLARE-3M)

### DIFF
--- a/packages/worker/src/jobs/execution-safety.node.test.ts
+++ b/packages/worker/src/jobs/execution-safety.node.test.ts
@@ -178,6 +178,13 @@ test('transient platform failures back off the same occurrence while permanent o
 			),
 		),
 	).toBe(true)
+	expect(
+		isTransientJobExecutionError(
+			new Error(
+				'Durable Object storage operation exceeded timeout which caused object to be reset.',
+			),
+		),
+	).toBe(true)
 	expect(isTransientJobExecutionError(new Error('user code failed'))).toBe(
 		false,
 	)

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -6,6 +6,7 @@ import {
 	durableObjectCodeUpdatedResetMessage,
 	durableObjectIsolateCpuResetMessage,
 	durableObjectIsolateMemoryResetMessage,
+	durableObjectStorageOperationTimeoutResetMessage,
 	executorSandboxTimeoutMessage,
 	filterSentryEvent,
 } from './sentry-options.ts'
@@ -235,9 +236,9 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	).not.toBeNull()
 
 	// Bare Cloudflare DO platform resets (memory / CPU / deploy-time code
-	// update / blockConcurrencyWhile timeout / storage object-reset) are
-	// transient — one representative form per family, plus an
-	// `Error:`-prefixed variant and a missing trailing period. Wrapped
+	// update / blockConcurrencyWhile timeout / storage-op timeout / storage
+	// object-reset) are transient — one representative form per family, plus
+	// an `Error:`-prefixed variant and a missing trailing period. Wrapped
 	// recovery failures and unreferenced storage resets must stay visible.
 	expect(
 		filterSentryEvent({
@@ -274,6 +275,31 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 				values: [
 					{
 						value: `Error: ${durableObjectBlockConcurrencyWhileTimeoutResetMessage}`,
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: `Error: ${durableObjectStorageOperationTimeoutResetMessage}`,
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: durableObjectStorageOperationTimeoutResetMessage.replace(
+							/\.$/,
+							'',
+						),
 					},
 				],
 			},

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -119,13 +119,14 @@ export function filterExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
  * RPC/alarm (for example cron `oauth_purge_expired` → OAuthPurgeCoordinator),
  * when `blockConcurrencyWhile` exceeds its ~30s deadlock timeout (for
  * example PartyServer awaiting MCP Agent `onStart` via `getServerByName` →
- * `setName`), or when DO SQLite storage hits an opaque internal fault and
- * resets the object, the platform surfaces one of these errors to the caller.
- * The next call gets a fresh isolate / storage handle; app-level retry of
- * non-idempotent work is still unsafe, and moving heavy Agent/MCP startup out
- * of `onStart` is an architectural change outside a triage fix. Match only
- * the bare platform strings (plus the storage form that requires a support
- * `reference =` token) so wrapped failures such as exhausted
+ * `setName`), when a DO SQLite storage operation exceeds the platform timeout
+ * and resets the object, or when DO SQLite storage hits an opaque internal
+ * fault and resets the object, the platform surfaces one of these errors to
+ * the caller. The next call gets a fresh isolate / storage handle; app-level
+ * retry of non-idempotent work is still unsafe, and moving heavy Agent/MCP
+ * startup out of `onStart` is an architectural change outside a triage fix.
+ * Match only the bare platform strings (plus the storage form that requires
+ * a support `reference =` token) so wrapped failures such as exhausted
  * `package_publish_external_push` recovery messages stay visible.
  */
 export const durableObjectIsolateMemoryResetMessage =
@@ -139,6 +140,14 @@ export const durableObjectCodeUpdatedResetMessage =
 
 export const durableObjectBlockConcurrencyWhileTimeoutResetMessage =
 	'A call to blockConcurrencyWhile() in a Durable Object waited for too long. The call was canceled and the Durable Object was reset.'
+
+/**
+ * Cloudflare Durable Object SQLite storage operation timeout that resets the
+ * object (KODY-CLOUDFLARE-3M). Same platform-reset class as memory/CPU /
+ * blockConcurrencyWhile timeouts — not an application defect.
+ */
+export const durableObjectStorageOperationTimeoutResetMessage =
+	'Durable Object storage operation exceeded timeout which caused object to be reset.'
 
 /**
  * Cloudflare Durable Object SQLite storage opaque platform fault with a
@@ -171,6 +180,7 @@ export function isDurableObjectIsolateResetMessage(message: string) {
 		normalized === durableObjectIsolateCpuResetMessage ||
 		normalized === durableObjectCodeUpdatedResetMessage ||
 		normalized === durableObjectBlockConcurrencyWhileTimeoutResetMessage ||
+		normalized === durableObjectStorageOperationTimeoutResetMessage ||
 		isDurableObjectStorageObjectResetMessage(message)
 	)
 }
@@ -240,9 +250,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// paths; see filterUserModuleBundlerFailureSentryEvent and
 		// filterExecutorSandboxTimeoutSentryEvent. Bare Cloudflare Durable
 		// Object platform reset strings (memory/CPU limits, deploy-time code
-		// updates, blockConcurrencyWhile timeouts, and DO storage
-		// object-reset with a support reference) are dropped the same way —
-		// see filterDurableObjectIsolateResetSentryEvent.
+		// updates, blockConcurrencyWhile timeouts, DO storage operation
+		// timeouts, and DO storage object-reset with a support reference) are
+		// dropped the same way — see filterDurableObjectIsolateResetSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare Durable Object storage-operation timeout resets from opening/regrowing Sentry issues. Same class of platform blip already filtered for memory/CPU/code-update/`blockConcurrencyWhile`/opaque storage-reset faults.

## Summary

- Match the bare platform string `Durable Object storage operation exceeded timeout which caused object to be reset.` in the existing DO isolate-reset Sentry filter
- Classify that message as a transient job execution error (via shared `isDurableObjectIsolateResetMessage`) so scheduled work can back off
- Cover both paths with unit tests

Sentry: [KODY-CLOUDFLARE-3M](https://kent-c-dodds-tech-llc.sentry.io/issues/7650465248/) — one production `/mcp` event during `withAccountWriteLease` → `Object.write`; ~30s wall time matches the platform storage-op timeout. Not reasonably fixable in app code.

## Testing

- `npm test -- packages/worker/src/sentry-options.node.test.ts packages/worker/src/jobs/execution-safety.node.test.ts` (5 passed)
- Pre-commit hook ran typecheck + migrations:check

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fe1ca277` · **Head:** `2abda0f5`

**Classification:** composes — extends an existing Sentry `beforeSend` allowlist with one exact Cloudflare platform string; jobs transient classification reuses the same helper.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `jobs` | assistant | composes — test only; transient detection via shared DO-reset helper |
| _(unmatched)_ `sentry-options.ts` | observability | composes — narrow `beforeSend` drop for one platform reset string |

### System map

_Platform DO storage-op timeout surfaces on `/mcp` write lease; filter drops Sentry noise and jobs treat it as transient._

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
  mcp["/mcp request"] --> lease["withAccountWriteLease"]
  lease --> write["write callback / DO storage"]
  write -->|"storage op timeout → DO reset"| err["platform Error"]
  err --> sentry["Sentry beforeSend"]
  err --> jobs["isTransientJobExecutionError"]
  sentry -->|exact message match| drop["drop event"]
  jobs -->|same helper| retry["backoff / retry"]
  style sentry fill:#d4edda,stroke:#2f6f3e,color:#000
  style drop fill:#d4edda,stroke:#2f6f3e,color:#000
  style jobs fill:#d4edda,stroke:#2f6f3e,color:#000
  style retry fill:#d4edda,stroke:#2f6f3e,color:#000
  style mcp fill:#e9ecef,stroke:#666,color:#000
  style lease fill:#e9ecef,stroke:#666,color:#000
  style write fill:#e9ecef,stroke:#666,color:#000
  style err fill:#e9ecef,stroke:#666,color:#000
```

### Risk callouts

- Exact-string match only (plus existing `Error:` / trailing-period normalization); wrapped recovery messages stay visible
- No auth, isolation, billing, or migration surface

### Reviewer focus

1. Confirm the Sentry exception value matches the new constant exactly
2. Confirm we should not broaden to substring match of all "Durable Object storage …" messages

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30aae0b1-6352-4018-bdee-5b6be00ac713?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30aae0b1-6352-4018-bdee-5b6be00ac713&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Durable Object storage-operation timeouts so they are correctly recognized as transient execution failures.
  - Updated error detection for timeout reset messages, including variants with or without an `Error:` prefix and trailing period.
  - Enhanced monitoring classification for these reset conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->