### PR TITLE
Add a friendly browser landing page for the MCP endpoint

### DIFF
--- a/packages/worker/src/mcp-auth.ts
+++ b/packages/worker/src/mcp-auth.ts
@@ -85,6 +85,43 @@ function createUnauthorizedResponse(origin: string) {
 	)
 }
 
+function acceptsMediaType(accept: string, mediaType: string) {
+	return accept.split(',').some((range) => {
+		const [type, ...parameters] = range.trim().split(';')
+		if (type?.trim() !== mediaType) return false
+		const quality = parameters
+			.map((parameter) => parameter.trim())
+			.find((parameter) => parameter.startsWith('q='))
+		return quality ? Number(quality.slice(2)) > 0 : true
+	})
+}
+
+function isBrowserMcpNavigation(request: Request) {
+	if (request.method !== 'GET' || request.headers.has('Authorization')) {
+		return false
+	}
+	const accept = request.headers.get('Accept')?.toLowerCase()
+	if (!accept) return false
+	return (
+		acceptsMediaType(accept, 'text/html') &&
+		!accept.includes('text/event-stream') &&
+		!accept.includes('application/json')
+	)
+}
+
+function createMcpBrowserLandingResponse(request: Request) {
+	const onboardingUrl = new URL('/onboarding', request.url).toString()
+	return new Response(
+		`<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Kody MCP endpoint</title></head><body><main style="font-family:system-ui,sans-serif;max-width:36rem;margin:4rem auto;padding:0 1rem"><p style="font-size:.8rem;letter-spacing:.08em;text-transform:uppercase;color:#57606a">Kody secure connection</p><h1>This endpoint is for AI agents</h1><p>You’ve reached Kody’s MCP endpoint. AI agents use this address to connect to Kody, so there isn’t anything to browse here.</p><p><a href="${onboardingUrl}">Follow the guide to connect your agent</a></p></main></body></html>`,
+		{
+			headers: {
+				'Cache-Control': 'no-store',
+				'Content-Type': 'text/html; charset=utf-8',
+			},
+		},
+	)
+}
+
 export function createEmailVerificationRequiredResponse(origin: string) {
 	return Response.json(
 		{
@@ -147,6 +184,10 @@ export async function handleMcpRequest({
 			ip: getRequestIp(request),
 			path: url.pathname,
 		})
+	}
+
+	if (isBrowserMcpNavigation(request)) {
+		return createMcpBrowserLandingResponse(request)
 	}
 
 	// Rejections before a grant resolves are deliberately not audited. They are

--- a/packages/worker/src/mcp-auth.workers.test.ts
+++ b/packages/worker/src/mcp-auth.workers.test.ts
@@ -349,6 +349,80 @@ async function handleMcpRequestAndDrain(
 	return response
 }
 
+test('mcp endpoint serves browser guidance without changing protocol auth challenges', async () => {
+	const origin = 'https://example.com'
+	const env = createEnv(createHelpers())
+	const fetchMcp = () => {
+		throw new Error(
+			'Unauthenticated requests must not reach the MCP transport.',
+		)
+	}
+
+	const browserResponse = await handleMcpRequestAndDrain({
+		request: new Request(`${origin}${mcpResourcePath}`, {
+			headers: {
+				Accept:
+					'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+			},
+		}),
+		env,
+		ctx: createContext(),
+		fetchMcp,
+	})
+	expect(browserResponse.status).toBe(200)
+	expect(browserResponse.headers.get('Content-Type')).toBe(
+		'text/html; charset=utf-8',
+	)
+	expect(await browserResponse.text()).toContain(
+		'href="https://example.com/onboarding"',
+	)
+	expect(browserResponse.headers.get('WWW-Authenticate')).toBeNull()
+
+	const protocolRequests = [
+		new Request(`${origin}${mcpResourcePath}`, {
+			headers: { Accept: 'text/event-stream' },
+		}),
+		new Request(`${origin}${mcpResourcePath}`, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'initialize',
+			}),
+		}),
+		new Request(`${origin}${mcpResourcePath}`, {
+			headers: {
+				Accept: 'text/html',
+				Authorization: 'Bearer invalid-token',
+			},
+		}),
+	]
+
+	for (const request of protocolRequests) {
+		const response = await handleMcpRequestAndDrain({
+			request,
+			env,
+			ctx: createContext(),
+			fetchMcp,
+		})
+		expect(response.status).toBe(401)
+		expect(response.headers.get('Content-Type')).toMatch(/application\/json/)
+		expect(await response.json()).toEqual({
+			error: 'invalid_token',
+			error_description:
+				'Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer.',
+		})
+		expectAuthenticateHeader(
+			response.headers.get('WWW-Authenticate') ?? '',
+			origin,
+		)
+	}
+})
+
 test('protected resource metadata and auth challenge resolve origin consistently', async () => {
 	const requestOrigin = 'https://example.com'
 	const workersDevOrigin = 'https://kody-production.kentcdodds.workers.dev'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Prevent non-technical users from seeing a raw OAuth error when they paste Kody's MCP URL into a browser, without changing MCP protocol behavior.

## Summary

- Serve a small Kody-branded HTML explanation for unauthenticated browser GET navigations to `/mcp`.
- Link to the request origin's `/onboarding` guide.
- Preserve the existing JSON OAuth challenge for SSE, JSON-RPC POST, and token-bearing requests.

## Testing

- `npm run validate` — passed (1,920 unit/Workers tests, 3 MCP tests, E2E, lint, format, types, build, and repository checks).
- `npm run test:workers -- packages/worker/src/mcp-auth.workers.test.ts` — 5 tests passed.
- Ready-for-review CI — all Static, Node, Workers, MCP, E2E, Validate, preview, and CodeRabbit checks passed.
- Local dev-server curl:

```console
$ curl -i -H 'Accept: text/html' http://localhost:3742/mcp
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Cache-Control: no-store

...<a href="http://localhost:3742/onboarding">Follow the guide to connect your agent</a>...

$ curl -i -H 'Accept: text/event-stream' http://localhost:3742/mcp
HTTP/1.1 401 Unauthorized
Content-Type: application/json
WWW-Authenticate: Bearer resource_metadata="http://localhost:3742/.well-known/oauth-protected-resource" scope="profile email"

{"error":"invalid_token","error_description":"Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer."}

$ curl -i -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' \
  --data '{"jsonrpc":"2.0","id":1,"method":"initialize"}' http://localhost:3742/mcp
HTTP/1.1 401 Unauthorized
Content-Type: application/json
WWW-Authenticate: Bearer resource_metadata="http://localhost:3742/.well-known/oauth-protected-resource" scope="profile email"

{"error":"invalid_token","error_description":"Authentication required. Obtain an access token via OAuth and retry with Authorization: Bearer."}
```

<a href="https://cursor.com/agents/bc-705b0dbc-f765-4029-98d6-ff77c2f5811e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_browser_landing_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-3dd49813-1a46-42ce-8d81-5c63e0be036b" alt="mcp_browser_landing_walkthrough.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a4c25471` · **Head:** `84f2baf8`

**Classification:** extends — this changes the unauthenticated browser response at the OAuth-protected MCP entrypoint while preserving protocol challenges.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-oauth` | auth | extends — HTML response for anonymous browser navigation only |

### System map

Browser GETs receive guidance while MCP transport requests continue through the existing OAuth challenge path.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	browser["Browser navigation"]:::untouched
	mcpOAuth["mcp-oauth<br/>MCP OAuth"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::untouched
	onboarding["app-ui<br/>Browser app (Remix 3)"]:::untouched
	browser -->|"GET /mcp, Accept: text/html"| mcpOAuth
	mcpOAuth -->|"200 HTML link"| onboarding
	mcpServer -->|"SSE, JSON-RPC, bearer requests unchanged"| mcpOAuth
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Request | Before | After |
| --- | --- | --- |
| Anonymous browser GET | `401` JSON OAuth challenge | `200` HTML guidance |
| SSE / JSON-RPC / token-bearing request | Existing OAuth/MCP behavior | Unchanged |

</details>

<!-- system-recap:end -->

## Conductor report

Status: merged and verified, but production rollout is blocked by a pre-existing cross-track migration gate.

Evidence: [PR #1185](https://github.com/kentcdodds/kody/pull/1185) squash-merged as `89ac5513`; local authoritative gate and all ready-for-review/post-merge CI passed; curl and browser walkthrough prove the HTML/protocol split.

What remains: [production deploy run 30859923182](https://github.com/kentcdodds/kody/actions/runs/30859923182) failed before Worker upload because migration `0135-drop-legacy-email-graph.sql` from [PR #1174](https://github.com/kentcdodds/kody/pull/1174) correctly rejected missing/mismatched destructive-drop approval data (`CHECK constraint failed: value = 1`). Production remains on the previous build until Track Email's fresh backup/approval procedure succeeds and deploy is rerun.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-705b0dbc-f765-4029-98d6-ff77c2f5811e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-705b0dbc-f765-4029-98d6-ff77c2f5811e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser-friendly onboarding page for unauthenticated visits to the MCP endpoint.
  * The page guides visitors to `/onboarding` without displaying an authentication challenge.

* **Bug Fixes**
  * Preserved consistent JSON authentication errors for API, streaming, and token-authenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->