### PR TITLE
fix(email): ignore runtime _rate_limits in 0135 inventory

### DIFF
--- a/packages/worker/migrations/0135-drop-legacy-email-graph.sql
+++ b/packages/worker/migrations/0135-drop-legacy-email-graph.sql
@@ -617,6 +617,9 @@ FROM (
 	WHERE type = 'table'
 		AND name NOT LIKE 'sqlite_%'
 		AND name NOT LIKE '\_cf\_%' ESCAPE '\'
+		-- Runtime auth throttle scratch table (packages/worker/src/app/rate-limit.ts),
+		-- not migration-managed schema.
+		AND name != '_rate_limits'
 	ORDER BY name
 );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production deploy of [#1174](https://github.com/kentcdodds/kody/pull/1174) failed at `Apply D1 Migrations` with `CHECK constraint failed: value = 1` on migration `0135`.

Root cause: live APP_DB has the runtime auth throttle table `_rate_limits` (created by `packages/worker/src/app/rate-limit.ts`), which was not in 0135's frozen migration-managed table inventory.

Fix: exclude `_rate_limits` from that inventory scan (same class of exclusion as `_cf_%`).

A valid signed drop approval is already in prod (expires ~`2026-08-04T00:30:57Z`). After this merges, re-run production deploy before that window ends (or mint a fresh pre-drop approval).

## Test plan

- [x] Focused wrangler/node migration tests pass
- [ ] CI green
- [ ] Redeploy production and confirm 0135 applies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ac34c46-4d65-4213-9ad3-206664b60671?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ac34c46-4d65-4213-9ad3-206664b60671&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated schema validation to ignore the internal `_rate_limits` runtime table, preventing false validation failures while preserving other schema checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->