### PR TITLE
docs(skills): drop watchdog re-dispatch guidance from conduct skill

### DIFF
--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -66,8 +66,7 @@ Get your id from cursor-cloud `run-info` and paste it into kickoffs. Also keep a
 
 Topology: `createRun` wake-ups work only if the conductor is an API-created
 cloud agent. An interactive chat conductor rejects them (400) — use Discord (or
-another channel you check) as primary, plus an outer watchdog job for
-re-dispatch.
+another channel you check) as primary.
 
 **Time gates → one-shot jobs**, not `sleep`:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes the "outer watchdog job for re-dispatch" guidance from the conduct skill's report-back topology note. Interactive-conductor programs now use Discord (or another user-checked channel) as the report-back channel, full stop.

## Why

Kent flagged the watchdog pattern as a liability: scheduled jobs that nudge agents can pile up and turn into runaway watchdogs re-dispatching work nobody is supervising. The deliberate time-gate one-shot jobs (for soaks and calendar gates) are unchanged — those are explicit, single-purpose, and owned.

The matching copy stored in the Kody `@kentcdodds/skills` package is being updated in lockstep.

## Conductor report

Direct-merge requested by Kent in-session; docs-only change, `oxfmt --check` green on the touched file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a0105d8-14bd-4341-99ce-020eb1e96319?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a0105d8-14bd-4341-99ce-020eb1e96319&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated report-back guidance to prioritize Discord or another verified communication channel.
  * Removed the requirement for an external watchdog job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->