### PR TITLE
Fix sender-rule mock typing

### DIFF
--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-sender-rule-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-sender-rule-capabilities.node.test.ts
@@ -8,9 +8,9 @@ import {
 } from '#worker/test-support/audit-log-spy.ts'
 
 const mocks = vi.hoisted(() => ({
-	listEmailSenderRules: vi.fn(),
-	upsertEmailSenderRule: vi.fn(),
-	deleteEmailSenderRule: vi.fn(),
+	listEmailSenderRules: vi.fn<typeof EmailSenderRules.listEmailSenderRules>(),
+	upsertEmailSenderRule: vi.fn<typeof EmailSenderRules.upsertEmailSenderRule>(),
+	deleteEmailSenderRule: vi.fn<typeof EmailSenderRules.deleteEmailSenderRule>(),
 }))
 
 vi.mock('#worker/email/sender-rules.ts', async (importOriginal) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock main validation and production deploy after PR #1195 by satisfying the static mock-typing rule introduced on the moving base.

## Summary

- add explicit sender-rule function types to three Vitest mocks
- no production behavior changes

## Testing

- pre-commit typecheck/migration checks passed
- pre-push full Node/Workers and E2E suites passed

## System changes

None. Test-only typing fix.

## Conductor report
STATUS: in-progress

What shipped: test-only static validation fix is pushed; CI/merge/deploy pending.

Risk self-assessment: low — type-only test mock annotations.

Merged/deployed: no / no.

Scope spill: this moving-main failure blocked deployment of the RunLog seed verification capability.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e72e79d-1443-4631-93dc-cf39fd8d3e73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e72e79d-1443-4631-93dc-cf39fd8d3e73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved type safety for email sender rule test mocks without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->