### PR TITLE
Bound RunLog seed workflow batches

### DIFF
--- a/packages/worker/src/admin/run-log-legacy-seed.node.test.ts
+++ b/packages/worker/src/admin/run-log-legacy-seed.node.test.ts
@@ -11,6 +11,7 @@ import {
 	adminRunLogLegacySeedActivationMaxMilestones,
 	adminRunLogLegacySeedActivationMaxPackages,
 	adminRunLogLegacySeedDefaultUserLimit,
+	adminRunLogLegacySeedDefaultWorkflowImportPageSize,
 	adminRunLogLegacySeedMaxUserLimit,
 	runAdminRunLogLegacySeed,
 	type AdminRunLogLegacySeedRpc,
@@ -21,6 +22,7 @@ import {
 	type LegacyParityVerifyResult,
 	type LegacyParityWorkflowCheck,
 } from '#worker/run-records/legacy-parity.ts'
+import { workflowProjectionImportMaxBatch } from '#worker/run-records/workflow-projection.ts'
 
 const userA = testStableUserIdFromEmail('runlog-a@example.com')
 const userB = testStableUserIdFromEmail('runlog-b@example.com')
@@ -639,6 +641,63 @@ test('multi-batch workflows/jobs process pages incrementally without all-row acc
 			),
 		).toBe(true)
 	}
+	assertContentFree(result)
+})
+
+test('default workflow import page size paginates large inventories without all-row accumulation', async () => {
+	expect(adminRunLogLegacySeedDefaultWorkflowImportPageSize).toBe(250)
+	expect(adminRunLogLegacySeedDefaultWorkflowImportPageSize).toBeLessThan(
+		workflowProjectionImportMaxBatch,
+	)
+
+	const workflowCount = 501
+	const pageSize = adminRunLogLegacySeedDefaultWorkflowImportPageSize
+	const { sqlite, db } = createSweepDb()
+	insertUser(sqlite, { stableUserId: userA })
+	for (let index = 0; index < workflowCount; index += 1) {
+		insertWorkflow(sqlite, {
+			userId: userA,
+			id: `wf-${String(index).padStart(4, '0')}`,
+		})
+	}
+
+	const { rpc, calls, callOrder } = createTrackingRpc()
+	const result = await runAdminRunLogLegacySeed({
+		env: createEnv(db),
+		action: 'seed',
+		limit: 1,
+		rpc,
+	})
+
+	expect(result.users[0]?.parity).toBe(true)
+	expect(result.users[0]?.workflows.matched).toBe(workflowCount)
+	expect(calls.importWorkflowProjections.length).toBeGreaterThan(1)
+	expect(calls.importWorkflowProjections.map((call) => call.count)).toEqual([
+		pageSize,
+		pageSize,
+		workflowCount - pageSize * 2,
+	])
+	expect(
+		calls.importWorkflowProjections.every((call) => call.count <= pageSize),
+	).toBe(true)
+	const workflowPhase = callOrder.slice(
+		0,
+		callOrder.indexOf('importActivationState'),
+	)
+	expect(workflowPhase.length).toBe(calls.importWorkflowProjections.length * 2)
+	for (
+		let index = 0;
+		index < calls.importWorkflowProjections.length;
+		index += 1
+	) {
+		expect(workflowPhase[index * 2]).toBe('importWorkflowProjections')
+		expect(workflowPhase[index * 2 + 1]).toBe('verifyLegacyParity')
+	}
+	expect(
+		calls.verifyLegacyParity
+			.filter((call) => call.workflowCount > 0)
+			.every((call) => call.workflowCount <= pageSize),
+	).toBe(true)
 	assertContentFree(result)
 })
 

--- a/packages/worker/src/admin/run-log-legacy-seed.ts
+++ b/packages/worker/src/admin/run-log-legacy-seed.ts
@@ -23,7 +23,6 @@ import {
 	seedJobRunObservabilityBatch,
 	verifyLegacyParity,
 	workflowBindingNames,
-	workflowProjectionImportMaxBatch,
 	type ActivationMilestone,
 	type ActivationStateImport,
 	type JobRunObservabilitySeedInput,
@@ -39,6 +38,13 @@ export const adminRunLogLegacySeedMaxUserLimit = 5
 
 /** Default page size — one user so a max-plan activation snapshot stays cheap. */
 export const adminRunLogLegacySeedDefaultUserLimit = 1
+
+/**
+ * Default workflow_runs D1 page size and per-import RPC batch for admin sweeps.
+ * Kept well below the RunLog DO hard cap so large inventories paginate through
+ * multiple import+verify rounds instead of one oversized RPC.
+ */
+export const adminRunLogLegacySeedDefaultWorkflowImportPageSize = 250
 
 /**
  * One-shot activation package-row hard cap: maximum product plan saved-package
@@ -90,7 +96,7 @@ export type AdminRunLogLegacySeedResult =
 	| ({ action: 'seed' } & AdminRunLogLegacySeedPageFields)
 
 export type AdminRunLogLegacySeedBatchSizes = {
-	/** Max workflow projections per D1 page / import RPC (default DO hard cap). */
+	/** Max workflow projections per D1 page / import RPC (default 250). */
 	workflowImport: number
 	/** Max job seeds per D1 page / seed RPC (default 500). */
 	jobSeed: number
@@ -123,7 +129,7 @@ const defaultRpc: AdminRunLogLegacySeedRpc = {
 }
 
 const defaultBatchSizes: AdminRunLogLegacySeedBatchSizes = {
-	workflowImport: workflowProjectionImportMaxBatch,
+	workflowImport: adminRunLogLegacySeedDefaultWorkflowImportPageSize,
 	jobSeed: jobRunObservabilitySeedMaxBatch,
 	verify: legacyParityVerifyMaxBatch,
 	activationMaxPackages: adminRunLogLegacySeedActivationMaxPackages,

--- a/packages/worker/src/mcp/capabilities/admin/admin-run-log-legacy-seed.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-run-log-legacy-seed.node.test.ts
@@ -5,6 +5,7 @@ import {
 	adminRunLogLegacySeedActivationMaxMilestones,
 	adminRunLogLegacySeedActivationMaxPackages,
 	adminRunLogLegacySeedDefaultUserLimit,
+	adminRunLogLegacySeedDefaultWorkflowImportPageSize,
 	adminRunLogLegacySeedMaxUserLimit,
 } from '#worker/admin/run-log-legacy-seed.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
@@ -202,5 +203,8 @@ test('admin_run_log_legacy_seed description states bounded one-shot activation',
 	)
 	expect(description).toContain(
 		`default ${adminRunLogLegacySeedDefaultUserLimit}`,
+	)
+	expect(description).toContain(
+		String(adminRunLogLegacySeedDefaultWorkflowImportPageSize),
 	)
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-run-log-legacy-seed.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-run-log-legacy-seed.ts
@@ -3,6 +3,7 @@ import {
 	adminRunLogLegacySeedActivationMaxMilestones,
 	adminRunLogLegacySeedActivationMaxPackages,
 	adminRunLogLegacySeedDefaultUserLimit,
+	adminRunLogLegacySeedDefaultWorkflowImportPageSize,
 	adminRunLogLegacySeedMaxUserLimit,
 	runAdminRunLogLegacySeed,
 } from '#worker/admin/run-log-legacy-seed.ts'
@@ -107,7 +108,7 @@ export const adminRunLogLegacySeedCapability = defineDomainCapability(
 	{
 		...adminMutationCapabilityAccess,
 		name: 'admin_run_log_legacy_seed',
-		description: `Admin-only non-destructive RunLog legacy expand sweep. Keyset-pages all non-deleting users (not only legacy-inventory candidates) with exact limit+1 truncation (default ${adminRunLogLegacySeedDefaultUserLimit}, max ${adminRunLogLegacySeedMaxUserLimit} users/call). \`status\` is read-only content-free parity; \`seed\` idempotently imports each D1 workflow/job page immediately (workflows checked with minimumUpdatedAt; every job including zero legacy state), then imports activation as one bounded one-shot snapshot (packages capped at max plan saved-packages ${adminRunLogLegacySeedActivationMaxPackages}; milestones filtered to ${adminRunLogLegacySeedActivationMaxMilestones} known names with unknown/retired rows ignored; empty activation still marks initialized) and returns the same parity shape. Missing D1 relations/columns and other per-user D1/RPC failures set failed=true (parity false; not production evidence — rerun) and continue other users. Output is stable user ids, counts, booleans (including failed), cursors, and generatedAt only — never emails, names, workflow names, package ids, job ids, or user-authored content. Audited.`,
+		description: `Admin-only non-destructive RunLog legacy expand sweep. Keyset-pages all non-deleting users (not only legacy-inventory candidates) with exact limit+1 truncation (default ${adminRunLogLegacySeedDefaultUserLimit}, max ${adminRunLogLegacySeedMaxUserLimit} users/call). \`status\` is read-only content-free parity; \`seed\` idempotently imports each D1 workflow/job page immediately (${adminRunLogLegacySeedDefaultWorkflowImportPageSize} workflow rows per D1 page/import RPC; workflows checked with minimumUpdatedAt; every job including zero legacy state), then imports activation as one bounded one-shot snapshot (packages capped at max plan saved-packages ${adminRunLogLegacySeedActivationMaxPackages}; milestones filtered to ${adminRunLogLegacySeedActivationMaxMilestones} known names with unknown/retired rows ignored; empty activation still marks initialized) and returns the same parity shape. Missing D1 relations/columns and other per-user D1/RPC failures set failed=true (parity false; not production evidence — rerun) and continue other users. Output is stable user ids, counts, booleans (including failed), cursors, and generatedAt only — never emails, names, workflow names, package ids, job ids, or user-authored content. Audited.`,
 		keywords: [
 			'admin',
 			'run log',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Complete production RunLog seed parity for the one active user whose 2,382 workflow projections exceeded the admin sweep’s single-import operational budget.

## Summary

- set the admin sweep workflow page/import default to 250 rows
- keep the underlying RunLog DO hard cap unchanged
- verify 501 workflow rows complete in three bounded import/verify rounds using production defaults

## Testing

- pre-push full Node/Workers suite: 553 files, 1,905 tests passed
- pre-push E2E: 7 tests passed
- focused admin seed tests, typecheck, format, and lint passed

## System changes

No contract change. This only lowers the operator sweep’s per-RPC batch size.

## Conductor report
STATUS: in-progress

What shipped: production-operability batch tuning is pushed; CI/AI review, merge/deploy, and rerun of the failed production user remain.

Risk self-assessment: low — bounded admin-only batch-size reduction with unchanged idempotent semantics.

Merged/deployed: no / no.

Scope spill: none.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e72e79d-1443-4631-93dc-cf39fd8d3e73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e72e79d-1443-4631-93dc-cf39fd8d3e73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

