### PR TITLE
Expose RunLog seed failure stages

### DIFF
--- a/packages/worker/src/admin/run-log-legacy-seed.node.test.ts
+++ b/packages/worker/src/admin/run-log-legacy-seed.node.test.ts
@@ -196,8 +196,20 @@ function emptyParity(overrides?: Partial<LegacyParityVerifyResult>) {
 function createTrackingRpc(input?: {
 	failUserIds?: ReadonlySet<string>
 	initializedByDefault?: boolean
+	failHooks?: Partial<
+		Record<
+			| 'workflow_seed'
+			| 'workflow_verify'
+			| 'job_seed'
+			| 'job_verify'
+			| 'activation_seed'
+			| 'activation_verify',
+			ReadonlySet<string>
+		>
+	>
 }) {
 	const failUserIds = input?.failUserIds ?? new Set<string>()
+	const failHooks = input?.failHooks ?? {}
 	const initializedUsers = new Set<string>()
 	const seededJobIdsByUser = new Map<string, Set<string>>()
 	const importedWorkflowsByUser = new Map<
@@ -239,7 +251,7 @@ function createTrackingRpc(input?: {
 
 	const rpc: AdminRunLogLegacySeedRpc = {
 		async importWorkflowProjections({ userId, projections }) {
-			if (failUserIds.has(userId)) {
+			if (failUserIds.has(userId) || failHooks.workflow_seed?.has(userId)) {
 				throw new Error(`injected-workflow-import-failure:${userId}`)
 			}
 			callOrder.push('importWorkflowProjections')
@@ -260,7 +272,7 @@ function createTrackingRpc(input?: {
 			return { imported: projections.length }
 		},
 		async seedJobRunObservabilityBatch({ userId, seeds }) {
-			if (failUserIds.has(userId)) {
+			if (failUserIds.has(userId) || failHooks.job_seed?.has(userId)) {
 				throw new Error(`injected-job-seed-failure:${userId}`)
 			}
 			callOrder.push('seedJobRunObservabilityBatch')
@@ -287,7 +299,7 @@ function createTrackingRpc(input?: {
 			return { attempted: seeds.length, seeded, alreadySeeded }
 		},
 		async importActivationState({ userId, state }) {
-			if (failUserIds.has(userId)) {
+			if (failUserIds.has(userId) || failHooks.activation_seed?.has(userId)) {
 				throw new Error(`injected-activation-import-failure:${userId}`)
 			}
 			callOrder.push('importActivationState')
@@ -301,10 +313,6 @@ function createTrackingRpc(input?: {
 		},
 		async verifyLegacyParity(args) {
 			const userId = args.userId
-			if (failUserIds.has(userId)) {
-				throw new Error(`injected-verify-failure:${userId}`)
-			}
-			callOrder.push('verifyLegacyParity')
 			const workflowChecks: Array<LegacyParityWorkflowCheck> = (
 				args.workflows ?? []
 			).map((entry) =>
@@ -318,6 +326,18 @@ function createTrackingRpc(input?: {
 			const jobIds = args.jobIds ?? []
 			const packages = args.activationPackages ?? []
 			const milestones = args.activationMilestones ?? []
+			const isWorkflowVerify = workflowChecks.length > 0
+			const isJobVerify = jobIds.length > 0
+			const isActivationVerify = !isWorkflowVerify && !isJobVerify
+			if (
+				failUserIds.has(userId) ||
+				(isWorkflowVerify && failHooks.workflow_verify?.has(userId)) ||
+				(isJobVerify && failHooks.job_verify?.has(userId)) ||
+				(isActivationVerify && failHooks.activation_verify?.has(userId))
+			) {
+				throw new Error(`injected-verify-failure:${userId}`)
+			}
+			callOrder.push('verifyLegacyParity')
 			calls.verifyLegacyParity.push({
 				userId,
 				workflowCount: workflowChecks.length,
@@ -556,6 +576,8 @@ test('seed marks empty-user activation unconditional-done and reaches parity', a
 		{
 			stableUserId: userA,
 			failed: false,
+			failureStage: null,
+			failurePhase: null,
 			parity: true,
 			activationInitialized: true,
 			workflows: emptyLegacyParityBucketCounts(),
@@ -799,6 +821,8 @@ test('activation package inventory respects injectable max with +1 fail-closed',
 		expect.objectContaining({
 			stableUserId: userA,
 			failed: true,
+			failureStage: 'activation_inventory',
+			failurePhase: 'd1',
 			parity: false,
 			activationInitialized: false,
 		}),
@@ -952,13 +976,24 @@ test('partial failure continues other users and fails closed for the failing use
 	const ok = result.users.find((user) => user.stableUserId === ordered[1])
 	expect(failed).toMatchObject({
 		failed: true,
+		failureStage: 'workflow_inventory',
+		failurePhase: 'seed',
 		parity: false,
 		activationInitialized: false,
 	})
-	expect(ok).toMatchObject({ failed: false, parity: true })
+	expect(ok).toMatchObject({
+		failed: false,
+		failureStage: null,
+		failurePhase: null,
+		parity: true,
+	})
 	expect(consoleWarn).toHaveBeenCalledWith(
 		'admin-run-log-legacy-seed-user-failed',
-		expect.objectContaining({ stableUserId: ordered[0] }),
+		expect.objectContaining({
+			stableUserId: ordered[0],
+			failureStage: 'workflow_inventory',
+			failurePhase: 'seed',
+		}),
 	)
 	assertContentFree(result)
 })
@@ -1053,6 +1088,8 @@ test('missing workflow_runs relation fails user closed without empty activation 
 		{
 			stableUserId: userA,
 			failed: true,
+			failureStage: 'workflow_inventory',
+			failurePhase: 'd1',
 			parity: false,
 			activationInitialized: false,
 			workflows: emptyLegacyParityBucketCounts(),
@@ -1081,6 +1118,8 @@ test('missing jobs relation fails user closed without empty activation seed', as
 	expect(result.users[0]).toMatchObject({
 		stableUserId: userA,
 		failed: true,
+		failureStage: 'job_inventory',
+		failurePhase: 'd1',
 		parity: false,
 		activationInitialized: false,
 	})
@@ -1104,6 +1143,8 @@ test('missing activation package table fails user closed without marking initial
 	expect(result.users[0]).toMatchObject({
 		stableUserId: userA,
 		failed: true,
+		failureStage: 'activation_inventory',
+		failurePhase: 'd1',
 		parity: false,
 		activationInitialized: false,
 	})
@@ -1126,6 +1167,8 @@ test('missing activation milestones table fails user closed without marking init
 	expect(result.users[0]).toMatchObject({
 		stableUserId: userA,
 		failed: true,
+		failureStage: 'activation_inventory',
+		failurePhase: 'd1',
 		parity: false,
 		activationInitialized: false,
 	})
@@ -1150,6 +1193,8 @@ test('partial activation query failure after package rows load fails closed', as
 	expect(result.users[0]).toMatchObject({
 		stableUserId: userA,
 		failed: true,
+		failureStage: 'activation_inventory',
+		failurePhase: 'd1',
 		parity: false,
 		activationInitialized: false,
 	})
@@ -1157,3 +1202,127 @@ test('partial activation query failure after package rows load fails closed', as
 	expect(calls.importActivationState).toEqual([])
 	assertContentFree(result)
 })
+
+test('success user results expose null failureStage and failurePhase', async () => {
+	const { sqlite, db } = createSweepDb()
+	insertUser(sqlite, { stableUserId: userA })
+	insertWorkflow(sqlite, { userId: userA, id: 'wf-ok' })
+	const { rpc } = createTrackingRpc()
+	const result = await runAdminRunLogLegacySeed({
+		env: createEnv(db),
+		action: 'seed',
+		limit: 1,
+		rpc,
+	})
+	expect(result.users[0]).toMatchObject({
+		failed: false,
+		failureStage: null,
+		failurePhase: null,
+		parity: true,
+	})
+	assertContentFree(result)
+})
+
+test.each([
+	{
+		label: 'workflow seed',
+		hook: 'workflow_seed' as const,
+		setup: (sqlite: DatabaseSync) => {
+			insertUser(sqlite, { stableUserId: userA })
+			insertWorkflow(sqlite, { userId: userA, id: 'wf-fail' })
+		},
+		action: 'seed' as const,
+		expectedStage: 'workflow_inventory' as const,
+		expectedPhase: 'seed' as const,
+	},
+	{
+		label: 'workflow verify',
+		hook: 'workflow_verify' as const,
+		setup: (sqlite: DatabaseSync) => {
+			insertUser(sqlite, { stableUserId: userA })
+			insertWorkflow(sqlite, { userId: userA, id: 'wf-fail' })
+		},
+		action: 'status' as const,
+		expectedStage: 'workflow_inventory' as const,
+		expectedPhase: 'verify' as const,
+	},
+	{
+		label: 'job seed',
+		hook: 'job_seed' as const,
+		setup: (sqlite: DatabaseSync) => {
+			insertUser(sqlite, { stableUserId: userA })
+			insertJob(sqlite, { userId: userA, id: 'job-fail' })
+		},
+		action: 'seed' as const,
+		expectedStage: 'job_inventory' as const,
+		expectedPhase: 'seed' as const,
+	},
+	{
+		label: 'job verify',
+		hook: 'job_verify' as const,
+		setup: (sqlite: DatabaseSync) => {
+			insertUser(sqlite, { stableUserId: userA })
+			insertJob(sqlite, { userId: userA, id: 'job-fail' })
+		},
+		action: 'status' as const,
+		expectedStage: 'job_inventory' as const,
+		expectedPhase: 'verify' as const,
+	},
+	{
+		label: 'activation seed',
+		hook: 'activation_seed' as const,
+		setup: (sqlite: DatabaseSync) => {
+			insertUser(sqlite, { stableUserId: userA })
+		},
+		action: 'seed' as const,
+		expectedStage: 'activation_inventory' as const,
+		expectedPhase: 'seed' as const,
+	},
+	{
+		label: 'activation verify',
+		hook: 'activation_verify' as const,
+		setup: (sqlite: DatabaseSync) => {
+			insertUser(sqlite, { stableUserId: userA })
+		},
+		action: 'status' as const,
+		expectedStage: 'activation_inventory' as const,
+		expectedPhase: 'verify' as const,
+	},
+])(
+	'injected $label failure reports failureStage and failurePhase content-free',
+	async ({ hook, setup, action, expectedStage, expectedPhase }) => {
+		silenceExpectedConsoleWarns(['admin-run-log-legacy-seed-user-failed'])
+		const { sqlite, db } = createSweepDb()
+		setup(sqlite)
+		const { rpc } = createTrackingRpc({
+			failHooks: { [hook]: new Set([userA]) },
+		})
+		const result = await runAdminRunLogLegacySeed({
+			env: createEnv(db),
+			action,
+			limit: 1,
+			rpc,
+		})
+		expect(result.users[0]).toMatchObject({
+			stableUserId: userA,
+			failed: true,
+			failureStage: expectedStage,
+			failurePhase: expectedPhase,
+			parity: false,
+			activationInitialized: false,
+			workflows: emptyLegacyParityBucketCounts(),
+			jobs: emptyLegacyParityBucketCounts(),
+			activationPackages: emptyLegacyParityBucketCounts(),
+			activationMilestones: emptyLegacyParityBucketCounts(),
+		})
+		expect(consoleWarn).toHaveBeenCalledWith(
+			'admin-run-log-legacy-seed-user-failed',
+			expect.objectContaining({
+				stableUserId: userA,
+				failureStage: expectedStage,
+				failurePhase: expectedPhase,
+			}),
+		)
+		assertContentFree(result)
+	},
+)

--- a/packages/worker/src/admin/run-log-legacy-seed.ts
+++ b/packages/worker/src/admin/run-log-legacy-seed.ts
@@ -67,6 +67,13 @@ export type AdminRunLogLegacySeedEnv = {
 	RUN_LOG: DurableObjectNamespace
 }
 
+export type AdminRunLogLegacySeedFailureStage =
+	| 'workflow_inventory'
+	| 'job_inventory'
+	| 'activation_inventory'
+
+export type AdminRunLogLegacySeedFailurePhase = 'd1' | 'seed' | 'verify'
+
 export type AdminRunLogLegacySeedUserResult = {
 	stableUserId: string
 	/**
@@ -74,6 +81,10 @@ export type AdminRunLogLegacySeedUserResult = {
 	 * production evidence and must be rerun; bucket counts are zeroed.
 	 */
 	failed: boolean
+	/** Null on success; which inventory surface threw on failure. */
+	failureStage: AdminRunLogLegacySeedFailureStage | null
+	/** Null on success; which step within the surface threw on failure. */
+	failurePhase: AdminRunLogLegacySeedFailurePhase | null
 	parity: boolean
 	activationInitialized: boolean
 	workflows: LegacyParityBucketCounts
@@ -224,12 +235,51 @@ function resolveBatchSizes(
 	}
 }
 
+type AdminRunLogLegacySeedSurfaceFailure = {
+	stage: AdminRunLogLegacySeedFailureStage
+	phase: AdminRunLogLegacySeedFailurePhase
+}
+
+class AdminRunLogLegacySeedSurfaceError extends Error {
+	readonly failure: AdminRunLogLegacySeedSurfaceFailure
+
+	constructor(failure: AdminRunLogLegacySeedSurfaceFailure) {
+		super('admin-run-log-legacy-seed-surface-failure')
+		this.failure = failure
+	}
+}
+
+function isSurfaceFailure(
+	error: unknown,
+): error is AdminRunLogLegacySeedSurfaceError {
+	return error instanceof AdminRunLogLegacySeedSurfaceError
+}
+
+async function runSurfaceStep<T>(input: {
+	stage: AdminRunLogLegacySeedFailureStage
+	phase: AdminRunLogLegacySeedFailurePhase
+	run: () => Promise<T>
+}): Promise<T> {
+	try {
+		return await input.run()
+	} catch (error) {
+		if (isSurfaceFailure(error)) throw error
+		throw new AdminRunLogLegacySeedSurfaceError({
+			stage: input.stage,
+			phase: input.phase,
+		})
+	}
+}
+
 function failedUserResult(
 	stableUserId: string,
+	failure: AdminRunLogLegacySeedSurfaceFailure,
 ): AdminRunLogLegacySeedUserResult {
 	return {
 		stableUserId,
 		failed: true,
+		failureStage: failure.stage,
+		failurePhase: failure.phase,
 		parity: false,
 		activationInitialized: false,
 		workflows: emptyLegacyParityBucketCounts(),
@@ -524,11 +574,16 @@ async function processWorkflowPages(input: {
 	let activationInitialized = false
 	let startAfterId: string | null = null
 	for (;;) {
-		const rows = await fetchWorkflowPage({
-			db: input.env.APP_DB,
-			userId: input.userId,
-			pageSize: input.batchSizes.workflowImport,
-			startAfterId,
+		const rows = await runSurfaceStep({
+			stage: 'workflow_inventory',
+			phase: 'd1',
+			run: () =>
+				fetchWorkflowPage({
+					db: input.env.APP_DB,
+					userId: input.userId,
+					pageSize: input.batchSizes.workflowImport,
+					startAfterId,
+				}),
 		})
 		if (rows.length === 0) break
 
@@ -536,10 +591,15 @@ async function processWorkflowPages(input: {
 			case 'status':
 				break
 			case 'seed': {
-				await input.rpc.importWorkflowProjections({
-					env: input.env as Env,
-					userId: input.userId,
-					projections: rows.map(mapWorkflowProjection),
+				await runSurfaceStep({
+					stage: 'workflow_inventory',
+					phase: 'seed',
+					run: () =>
+						input.rpc.importWorkflowProjections({
+							env: input.env as Env,
+							userId: input.userId,
+							projections: rows.map(mapWorkflowProjection),
+						}),
 				})
 				break
 			}
@@ -551,12 +611,17 @@ async function processWorkflowPages(input: {
 			}
 		}
 
-		const verified = await verifyWorkflowChecks({
-			env: input.env,
-			userId: input.userId,
-			checks: rows.map(mapWorkflowParityCheck),
-			verifyBatchSize: input.batchSizes.verify,
-			rpc: input.rpc,
+		const verified = await runSurfaceStep({
+			stage: 'workflow_inventory',
+			phase: 'verify',
+			run: () =>
+				verifyWorkflowChecks({
+					env: input.env,
+					userId: input.userId,
+					checks: rows.map(mapWorkflowParityCheck),
+					verifyBatchSize: input.batchSizes.verify,
+					rpc: input.rpc,
+				}),
 		})
 		counts = addBucketCounts(counts, verified.counts)
 		activationInitialized =
@@ -565,7 +630,10 @@ async function processWorkflowPages(input: {
 		const lastId = rows.at(-1)?.id
 		if (!lastId || rows.length < input.batchSizes.workflowImport) break
 		if (lastId === startAfterId) {
-			throw new Error('workflow_runs keyset cursor did not advance')
+			throw new AdminRunLogLegacySeedSurfaceError({
+				stage: 'workflow_inventory',
+				phase: 'd1',
+			})
 		}
 		startAfterId = lastId
 	}
@@ -591,11 +659,16 @@ async function processJobPages(input: {
 	let activationInitialized = false
 	let startAfterId: string | null = null
 	for (;;) {
-		const rows = await fetchJobPage({
-			db: input.env.APP_DB,
-			userId: input.userId,
-			pageSize: input.batchSizes.jobSeed,
-			startAfterId,
+		const rows = await runSurfaceStep({
+			stage: 'job_inventory',
+			phase: 'd1',
+			run: () =>
+				fetchJobPage({
+					db: input.env.APP_DB,
+					userId: input.userId,
+					pageSize: input.batchSizes.jobSeed,
+					startAfterId,
+				}),
 		})
 		if (rows.length === 0) break
 
@@ -603,10 +676,15 @@ async function processJobPages(input: {
 			case 'status':
 				break
 			case 'seed': {
-				await input.rpc.seedJobRunObservabilityBatch({
-					env: input.env as Env,
-					userId: input.userId,
-					seeds: rows.map(mapJobSeed),
+				await runSurfaceStep({
+					stage: 'job_inventory',
+					phase: 'seed',
+					run: () =>
+						input.rpc.seedJobRunObservabilityBatch({
+							env: input.env as Env,
+							userId: input.userId,
+							seeds: rows.map(mapJobSeed),
+						}),
 				})
 				break
 			}
@@ -618,12 +696,17 @@ async function processJobPages(input: {
 			}
 		}
 
-		const verified = await verifyJobIds({
-			env: input.env,
-			userId: input.userId,
-			jobIds: rows.map((row) => String(row.id)),
-			verifyBatchSize: input.batchSizes.verify,
-			rpc: input.rpc,
+		const verified = await runSurfaceStep({
+			stage: 'job_inventory',
+			phase: 'verify',
+			run: () =>
+				verifyJobIds({
+					env: input.env,
+					userId: input.userId,
+					jobIds: rows.map((row) => String(row.id)),
+					verifyBatchSize: input.batchSizes.verify,
+					rpc: input.rpc,
+				}),
 		})
 		counts = addBucketCounts(counts, verified.counts)
 		activationInitialized =
@@ -632,7 +715,10 @@ async function processJobPages(input: {
 		const lastId = rows.at(-1)?.id
 		if (!lastId || rows.length < input.batchSizes.jobSeed) break
 		if (lastId === startAfterId) {
-			throw new Error('jobs keyset cursor did not advance')
+			throw new AdminRunLogLegacySeedSurfaceError({
+				stage: 'job_inventory',
+				phase: 'd1',
+			})
 		}
 		startAfterId = lastId
 	}
@@ -702,11 +788,16 @@ async function processActivation(input: {
 	activationMilestones: LegacyParityBucketCounts
 	activationInitialized: boolean
 }> {
-	const activation = await readActivationInventory({
-		db: input.env.APP_DB,
-		userId: input.userId,
-		maxPackages: input.batchSizes.activationMaxPackages,
-		maxMilestones: input.batchSizes.activationMaxMilestones,
+	const activation = await runSurfaceStep({
+		stage: 'activation_inventory',
+		phase: 'd1',
+		run: () =>
+			readActivationInventory({
+				db: input.env.APP_DB,
+				userId: input.userId,
+				maxPackages: input.batchSizes.activationMaxPackages,
+				maxMilestones: input.batchSizes.activationMaxMilestones,
+			}),
 	})
 
 	switch (input.action) {
@@ -715,10 +806,15 @@ async function processActivation(input: {
 		case 'seed':
 			// Unconditional: empty legacy activation still marks initialized so
 			// every non-deleting user can reach parity without D1 activation rows.
-			await input.rpc.importActivationState({
-				env: input.env as Env,
-				userId: input.userId,
-				state: activation,
+			await runSurfaceStep({
+				stage: 'activation_inventory',
+				phase: 'seed',
+				run: () =>
+					input.rpc.importActivationState({
+						env: input.env as Env,
+						userId: input.userId,
+						state: activation,
+					}),
 			})
 			break
 		default: {
@@ -748,11 +844,16 @@ async function processActivation(input: {
 	let milestones = emptyLegacyParityBucketCounts()
 	let activationInitialized = false
 	for (let round = 0; round < roundCount; round += 1) {
-		const result = await input.rpc.verifyLegacyParity({
-			env: input.env as Env,
-			userId: input.userId,
-			activationPackages: packageChunks[round] ?? [],
-			activationMilestones: milestoneChunks[round] ?? [],
+		const result = await runSurfaceStep({
+			stage: 'activation_inventory',
+			phase: 'verify',
+			run: () =>
+				input.rpc.verifyLegacyParity({
+					env: input.env as Env,
+					userId: input.userId,
+					activationPackages: packageChunks[round] ?? [],
+					activationMilestones: milestoneChunks[round] ?? [],
+				}),
 		})
 		packages = addBucketCounts(packages, result.activationPackages)
 		milestones = addBucketCounts(milestones, result.activationMilestones)
@@ -780,6 +881,8 @@ function toUserResult(
 	return {
 		stableUserId,
 		failed: false,
+		failureStage: null,
+		failurePhase: null,
 		parity,
 		activationInitialized: aggregated.activationInitialized,
 		workflows: aggregated.workflows,
@@ -796,50 +899,89 @@ async function processUser(input: {
 	batchSizes: AdminRunLogLegacySeedBatchSizes
 	rpc: AdminRunLogLegacySeedRpc
 }): Promise<AdminRunLogLegacySeedUserResult> {
+	let workflows: Awaited<ReturnType<typeof processWorkflowPages>>
 	try {
-		const workflows = await processWorkflowPages({
+		workflows = await processWorkflowPages({
 			env: input.env,
 			userId: input.userId,
 			action: input.action,
 			batchSizes: input.batchSizes,
 			rpc: input.rpc,
 		})
-		const jobs = await processJobPages({
-			env: input.env,
-			userId: input.userId,
-			action: input.action,
-			batchSizes: input.batchSizes,
-			rpc: input.rpc,
-		})
-		const activation = await processActivation({
-			env: input.env,
-			userId: input.userId,
-			action: input.action,
-			batchSizes: input.batchSizes,
-			rpc: input.rpc,
-		})
-
-		const aggregated: AggregatedParity = {
-			workflows: workflows.counts,
-			jobs: jobs.counts,
-			activationPackages: activation.activationPackages,
-			activationMilestones: activation.activationMilestones,
-			activationInitialized:
-				workflows.activationInitialized ||
-				jobs.activationInitialized ||
-				activation.activationInitialized,
-		}
-		return toUserResult(input.userId, aggregated)
 	} catch (error) {
-		// Fail closed for this user; never surface error text in the result.
-		// Missing D1 relations/columns are failures in this pre-drop evidence
-		// sweep — not successful empty inventory.
+		const failure = isSurfaceFailure(error)
+			? error.failure
+			: ({
+					stage: 'workflow_inventory',
+					phase: 'd1',
+				} satisfies AdminRunLogLegacySeedSurfaceFailure)
 		console.warn('admin-run-log-legacy-seed-user-failed', {
 			stableUserId: input.userId,
-			error,
+			failureStage: failure.stage,
+			failurePhase: failure.phase,
 		})
-		return failedUserResult(input.userId)
+		return failedUserResult(input.userId, failure)
 	}
+
+	let jobs: Awaited<ReturnType<typeof processJobPages>>
+	try {
+		jobs = await processJobPages({
+			env: input.env,
+			userId: input.userId,
+			action: input.action,
+			batchSizes: input.batchSizes,
+			rpc: input.rpc,
+		})
+	} catch (error) {
+		const failure = isSurfaceFailure(error)
+			? error.failure
+			: ({
+					stage: 'job_inventory',
+					phase: 'd1',
+				} satisfies AdminRunLogLegacySeedSurfaceFailure)
+		console.warn('admin-run-log-legacy-seed-user-failed', {
+			stableUserId: input.userId,
+			failureStage: failure.stage,
+			failurePhase: failure.phase,
+		})
+		return failedUserResult(input.userId, failure)
+	}
+
+	let activation: Awaited<ReturnType<typeof processActivation>>
+	try {
+		activation = await processActivation({
+			env: input.env,
+			userId: input.userId,
+			action: input.action,
+			batchSizes: input.batchSizes,
+			rpc: input.rpc,
+		})
+	} catch (error) {
+		const failure = isSurfaceFailure(error)
+			? error.failure
+			: ({
+					stage: 'activation_inventory',
+					phase: 'd1',
+				} satisfies AdminRunLogLegacySeedSurfaceFailure)
+		console.warn('admin-run-log-legacy-seed-user-failed', {
+			stableUserId: input.userId,
+			failureStage: failure.stage,
+			failurePhase: failure.phase,
+		})
+		return failedUserResult(input.userId, failure)
+	}
+
+	const aggregated: AggregatedParity = {
+		workflows: workflows.counts,
+		jobs: jobs.counts,
+		activationPackages: activation.activationPackages,
+		activationMilestones: activation.activationMilestones,
+		activationInitialized:
+			workflows.activationInitialized ||
+			jobs.activationInitialized ||
+			activation.activationInitialized,
+	}
+	return toUserResult(input.userId, aggregated)
 }
 
 /**

--- a/packages/worker/src/mcp/capabilities/admin/admin-run-log-legacy-seed.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-run-log-legacy-seed.node.test.ts
@@ -47,6 +47,8 @@ const sampleResult = {
 		{
 			stableUserId: targetUserId,
 			failed: false,
+			failureStage: null,
+			failurePhase: null,
 			parity: true,
 			activationInitialized: true,
 			workflows: emptyLegacyParityBucketCounts(),
@@ -207,4 +209,20 @@ test('admin_run_log_legacy_seed description states bounded one-shot activation',
 	expect(description).toContain(
 		String(adminRunLogLegacySeedDefaultWorkflowImportPageSize),
 	)
+})
+
+test('admin_run_log_legacy_seed output schema declares failureStage and failurePhase', () => {
+	const outputType = adminRunLogLegacySeedCapability.outputTypeDefinition ?? ''
+	expect(outputType).toContain('failureStage')
+	expect(outputType).toContain('failurePhase')
+	expect(outputType).toContain('workflow_inventory')
+	expect(outputType).toContain('job_inventory')
+	expect(outputType).toContain('activation_inventory')
+	expect(outputType).toMatch(/failureStage.*null|null.*failureStage/s)
+})
+
+test('admin_run_log_legacy_seed description mentions failureStage diagnostics', () => {
+	const description = adminRunLogLegacySeedCapability.description
+	expect(description).toContain('failureStage')
+	expect(description).toContain('failurePhase')
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-run-log-legacy-seed.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-run-log-legacy-seed.ts
@@ -31,6 +31,20 @@ const bucketCountsSchema = z.object({
 	underCount: z.number().int().nonnegative(),
 })
 
+const failureStageSchema = z
+	.enum(['workflow_inventory', 'job_inventory', 'activation_inventory'])
+	.nullable()
+	.describe(
+		'Null on success; which inventory surface threw on failure (failed users only).',
+	)
+
+const failurePhaseSchema = z
+	.enum(['d1', 'seed', 'verify'])
+	.nullable()
+	.describe(
+		'Null on success; which step within the surface threw on failure (failed users only).',
+	)
+
 const userResultSchema = z.object({
 	stableUserId: stableUserIdSchema,
 	failed: z
@@ -38,6 +52,8 @@ const userResultSchema = z.object({
 		.describe(
 			'True when this user threw (D1/RPC/cap). Failed users are not production evidence and must be rerun; bucket counts are zeroed and parity is false.',
 		),
+	failureStage: failureStageSchema,
+	failurePhase: failurePhaseSchema,
 	parity: z
 		.boolean()
 		.describe(
@@ -108,7 +124,7 @@ export const adminRunLogLegacySeedCapability = defineDomainCapability(
 	{
 		...adminMutationCapabilityAccess,
 		name: 'admin_run_log_legacy_seed',
-		description: `Admin-only non-destructive RunLog legacy expand sweep. Keyset-pages all non-deleting users (not only legacy-inventory candidates) with exact limit+1 truncation (default ${adminRunLogLegacySeedDefaultUserLimit}, max ${adminRunLogLegacySeedMaxUserLimit} users/call). \`status\` is read-only content-free parity; \`seed\` idempotently imports each D1 workflow/job page immediately (${adminRunLogLegacySeedDefaultWorkflowImportPageSize} workflow rows per D1 page/import RPC; workflows checked with minimumUpdatedAt; every job including zero legacy state), then imports activation as one bounded one-shot snapshot (packages capped at max plan saved-packages ${adminRunLogLegacySeedActivationMaxPackages}; milestones filtered to ${adminRunLogLegacySeedActivationMaxMilestones} known names with unknown/retired rows ignored; empty activation still marks initialized) and returns the same parity shape. Missing D1 relations/columns and other per-user D1/RPC failures set failed=true (parity false; not production evidence — rerun) and continue other users. Output is stable user ids, counts, booleans (including failed), cursors, and generatedAt only — never emails, names, workflow names, package ids, job ids, or user-authored content. Audited.`,
+		description: `Admin-only non-destructive RunLog legacy expand sweep. Keyset-pages all non-deleting users (not only legacy-inventory candidates) with exact limit+1 truncation (default ${adminRunLogLegacySeedDefaultUserLimit}, max ${adminRunLogLegacySeedMaxUserLimit} users/call). \`status\` is read-only content-free parity; \`seed\` idempotently imports each D1 workflow/job page immediately (${adminRunLogLegacySeedDefaultWorkflowImportPageSize} workflow rows per D1 page/import RPC; workflows checked with minimumUpdatedAt; every job including zero legacy state), then imports activation as one bounded one-shot snapshot (packages capped at max plan saved-packages ${adminRunLogLegacySeedActivationMaxPackages}; milestones filtered to ${adminRunLogLegacySeedActivationMaxMilestones} known names with unknown/retired rows ignored; empty activation still marks initialized) and returns the same parity shape. Missing D1 relations/columns and other per-user D1/RPC failures set failed=true (parity false; failureStage/failurePhase name the surface and step; not production evidence — rerun) and continue other users. Output is stable user ids, counts, booleans (including failed, failureStage, failurePhase), cursors, and generatedAt only — never emails, names, workflow names, package ids, job ids, or user-authored content. Audited.`,
 		keywords: [
 			'admin',
 			'run log',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Diagnose the one remaining production RunLog seed failure without exposing user-authored data.

## Summary

- add content-free `failureStage` and `failurePhase` fields to admin seed results
- distinguish workflow/job/activation and D1/seed/verify failures
- remove raw error objects from operator warning logs

## Testing

- focused admin/capability tests: 34 passed
- pre-push full Node/Workers and E2E suites passed
- format, lint, and typecheck passed

## System changes

No seeding semantics change; operator diagnostics only.

## Conductor report
STATUS: in-progress

What shipped: content-free seed failure staging is pushed; CI/merge/deploy and production rerun pending.

Risk self-assessment: low — additive admin output fields and safer logs.

Merged/deployed: no / no.

Scope spill: none.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e72e79d-1443-4631-93dc-cf39fd8d3e73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e72e79d-1443-4631-93dc-cf39fd8d3e73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added clear per-user diagnostics identifying where and during which step a legacy seed operation failed.
  * Improved error isolation so failures for one user do not interrupt processing for others.
  * Successful results now explicitly indicate that no failure occurred.
* **Documentation**
  * Updated capability details and output schemas to describe the new diagnostic fields.
* **Tests**
  * Added coverage for all failure stages and verification scenarios while preserving sensitive error-content redaction checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->