### PR TITLE
Bound RunLog parity SQL batches

### DIFF
--- a/packages/worker/src/admin/run-log-legacy-seed.node.test.ts
+++ b/packages/worker/src/admin/run-log-legacy-seed.node.test.ts
@@ -19,6 +19,7 @@ import {
 import { activationMilestoneValues } from '#worker/run-records/package-activation-state.ts'
 import {
 	emptyLegacyParityBucketCounts,
+	legacyParityVerifyMaxBatch,
 	type LegacyParityVerifyResult,
 	type LegacyParityWorkflowCheck,
 } from '#worker/run-records/legacy-parity.ts'
@@ -706,19 +707,22 @@ test('default workflow import page size paginates large inventories without all-
 		0,
 		callOrder.indexOf('importActivationState'),
 	)
-	expect(workflowPhase.length).toBe(calls.importWorkflowProjections.length * 2)
-	for (
-		let index = 0;
-		index < calls.importWorkflowProjections.length;
-		index += 1
-	) {
-		expect(workflowPhase[index * 2]).toBe('importWorkflowProjections')
-		expect(workflowPhase[index * 2 + 1]).toBe('verifyLegacyParity')
+	let importSteps = 0
+	let verifySteps = 0
+	for (const step of workflowPhase) {
+		if (step === 'importWorkflowProjections') {
+			importSteps += 1
+		} else {
+			expect(step).toBe('verifyLegacyParity')
+			verifySteps += 1
+		}
 	}
+	expect(importSteps).toBe(calls.importWorkflowProjections.length)
+	expect(verifySteps).toBeGreaterThan(importSteps)
 	expect(
 		calls.verifyLegacyParity
 			.filter((call) => call.workflowCount > 0)
-			.every((call) => call.workflowCount <= pageSize),
+			.every((call) => call.workflowCount <= legacyParityVerifyMaxBatch),
 	).toBe(true)
 	assertContentFree(result)
 })

--- a/packages/worker/src/admin/run-log-legacy-seed.ts
+++ b/packages/worker/src/admin/run-log-legacy-seed.ts
@@ -42,7 +42,9 @@ export const adminRunLogLegacySeedDefaultUserLimit = 1
 /**
  * Default workflow_runs D1 page size and per-import RPC batch for admin sweeps.
  * Kept well below the RunLog DO hard cap so large inventories paginate through
- * multiple import+verify rounds instead of one oversized RPC.
+ * multiple import+verify rounds instead of one oversized RPC. Verify chunks
+ * separately at {@link legacyParityVerifyMaxBatch} because parity SQL IN lists
+ * share the DO binding budget.
  */
 export const adminRunLogLegacySeedDefaultWorkflowImportPageSize = 250
 
@@ -111,7 +113,7 @@ export type AdminRunLogLegacySeedBatchSizes = {
 	workflowImport: number
 	/** Max job seeds per D1 page / seed RPC (default 500). */
 	jobSeed: number
-	/** Max entries per verifyLegacyParity array (default 500). */
+	/** Max entries per verifyLegacyParity array (default 100). */
 	verify: number
 	/**
 	 * Max activation package rows in the one-shot snapshot (default

--- a/packages/worker/src/run-records/legacy-parity.node.test.ts
+++ b/packages/worker/src/run-records/legacy-parity.node.test.ts
@@ -95,8 +95,10 @@ test('legacyParitySqlInPlaceholders stays within the hard batch bound', () => {
 	expect(
 		legacyParitySqlInPlaceholders(legacyParityVerifyMaxBatch).split(', '),
 	).toHaveLength(legacyParityVerifyMaxBatch)
-	expect(() => legacyParitySqlInPlaceholders(0)).toThrow(/1\.\.500/)
+	expect(() => legacyParitySqlInPlaceholders(0)).toThrow(
+		new RegExp(`1\\.\\.${legacyParityVerifyMaxBatch}`),
+	)
 	expect(() =>
 		legacyParitySqlInPlaceholders(legacyParityVerifyMaxBatch + 1),
-	).toThrow(/1\.\.500/)
+	).toThrow(new RegExp(`1\\.\\.${legacyParityVerifyMaxBatch}`))
 })

--- a/packages/worker/src/run-records/legacy-parity.ts
+++ b/packages/worker/src/run-records/legacy-parity.ts
@@ -14,9 +14,10 @@ import {
 
 /**
  * Hard cap for each input array on {@link verifyLegacyParity}. Oversized
- * batches fail closed rather than silently slicing.
+ * batches fail closed rather than silently slicing. Kept at 100 for the RunLog
+ * DO SQL binding budget (each bucket may emit an IN (?, …) query).
  */
-export const legacyParityVerifyMaxBatch = 500
+export const legacyParityVerifyMaxBatch = 100
 
 export type LegacyParityWorkflowCheck = {
 	id: string

--- a/packages/worker/src/run-records/legacy-parity.workers.test.ts
+++ b/packages/worker/src/run-records/legacy-parity.workers.test.ts
@@ -240,7 +240,7 @@ test(
 				userId,
 				seeds: oversizedSeeds,
 			}),
-		).rejects.toThrow(/at most 500/)
+		).rejects.toThrow(new RegExp(`at most ${jobRunObservabilitySeedMaxBatch}`))
 
 		const oversizedJobIds = Array.from(
 			{ length: legacyParityVerifyMaxBatch + 1 },
@@ -252,7 +252,7 @@ test(
 				userId,
 				jobIds: oversizedJobIds,
 			}),
-		).rejects.toThrow(/at most 500/)
+		).rejects.toThrow(new RegExp(`at most ${legacyParityVerifyMaxBatch}`))
 
 		const denyListTargets = [
 			secretWorkflowName,
@@ -534,6 +534,56 @@ test('verifyLegacyParity fails closed on malformed workflow minimumUpdatedAt thr
 		underCount: 4,
 	})
 	expect(report.parity).toBe(false)
+})
+
+test('verifyLegacyParity verifies a full workflow batch and rejects one over the cap', async () => {
+	const userId = uniqueUserId('wf-max-batch')
+	const workflowIds = Array.from(
+		{ length: legacyParityVerifyMaxBatch },
+		(_, index) => `wf-max-${String(index).padStart(3, '0')}`,
+	)
+
+	await importWorkflowProjections({
+		env,
+		userId,
+		projections: workflowIds.map((id, index) => ({
+			id,
+			bindingName: 'DYNAMIC_CALLABLE_WORKFLOWS',
+			sourceType: 'inline',
+			workflowName: 'batch',
+			idempotencyKey: `key-${index}`,
+			runAt: '2026-07-31T20:00:00.000Z',
+			status: 'complete',
+			createdAt: '2026-07-31T20:00:00.000Z',
+			updatedAt: '2026-07-31T20:00:05.000Z',
+			completedAt: '2026-07-31T20:00:05.000Z',
+			lastError: null,
+		})),
+	})
+
+	const parity = await verifyLegacyParity({
+		env,
+		userId,
+		workflows: workflowIds,
+	})
+	expect(parity.workflows).toEqual({
+		matched: legacyParityVerifyMaxBatch,
+		missing: 0,
+		underCount: 0,
+	})
+	expect(parity.parity).toBe(true)
+
+	const oversizedWorkflowIds = Array.from(
+		{ length: legacyParityVerifyMaxBatch + 1 },
+		(_, index) => `wf-over-${index}`,
+	)
+	await expect(
+		verifyLegacyParity({
+			env,
+			userId,
+			workflows: oversizedWorkflowIds,
+		}),
+	).rejects.toThrow(new RegExp(`at most ${legacyParityVerifyMaxBatch}`))
 })
 
 test('upsertWorkflowProjection rows remain visible to importWorkflowProjections batch seeding', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Complete production RunLog seed verification for the user whose workflow parity failed on a 250-ID SQL batch.

## Summary

- lower the content-free parity RPC hard/default batch from 500 to 100
- keep workflow import pages at 250
- verify 100 real workflow projections in one Workers RPC and reject 101 before SQL
- ensure the 501-workflow admin sweep verifies in 100-row chunks

## Testing

- pre-push full Node/Workers: 557 files, 1,911 tests passed
- pre-push E2E: 7 tests passed
- focused parity/admin tests, typecheck, format, and lint passed

## System changes

No storage or seeding semantic change; SQL binding-budget guard only.

## Conductor report
STATUS: in-progress

What shipped: parity SQL bound fix is pushed; CI/merge/deploy and production rerun pending.

Risk self-assessment: low — smaller bounded admin verification batches.

Merged/deployed: no / no.

Scope spill: none.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e72e79d-1443-4631-93dc-cf39fd8d3e73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e72e79d-1443-4631-93dc-cf39fd8d3e73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

