### PR TITLE
fix(mcp): keep integration_save create-field gaps off Sentry

### DIFF
--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
@@ -164,7 +165,26 @@ test('mergeIntegrationConfig and integration_save create a new app + connection 
 			},
 			{ env: createEnv().env, callerContext: caller('user-123') },
 		),
-	).rejects.toThrow(/missing or invalid required fields/i)
+	).rejects.toThrow(McpCallerError)
+
+	await expect(
+		integrationSaveCapability.handler(
+			{
+				name: 'slack',
+				tokenUrl: 'https://slack.com/api/oauth.v2.access',
+				flow: 'confidential',
+				clientId: 'slack-client-id',
+				// accessTokenSecretName omitted — create requires it
+			},
+			{ env: createEnv().env, callerContext: caller('user-123') },
+		),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			/Cannot create integration "slack".*accessTokenSecretName/i.test(
+				error.message,
+			),
+	)
 })
 
 test('integration_save reuses an existing app when credentials match and preserves unspecified fields on partial update', async () => {

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
@@ -165,7 +165,11 @@ test('mergeIntegrationConfig and integration_save create a new app + connection 
 			},
 			{ env: createEnv().env, callerContext: caller('user-123') },
 		),
-	).rejects.toThrow(McpCallerError)
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			/missing or invalid required fields/i.test(error.message),
+	)
 
 	await expect(
 		integrationSaveCapability.handler(

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
@@ -3,6 +3,7 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	getIntegration,
 	upsertIntegration,
@@ -90,7 +91,9 @@ function createNewIntegrationConfig(
 				return `${field}: ${issue.message}`
 			})
 			.join(', ')
-		throw new Error(
+		// Create-time field gaps are caller-fixable (agents omit required
+		// secrets names); keep them off Sentry via McpCallerError.
+		throw new McpCallerError(
 			`Cannot create integration "${args.name}": missing or invalid required fields — ${details}`,
 		)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Sentry triage noise from agent mistakes when creating OAuth integrations without required secret field names (KODY-CLOUDFLARE-3N).

## Summary

- `integration_save` create-time Zod failures (missing `accessTokenSecretName`, etc.) now throw `McpCallerError` instead of a plain `Error`.
- MCP observability already skips caller failures, so these stay on `mcp-event` logs and out of Sentry.
- Same error message text; agents can still fix and retry.

## Testing

- `integration-save.node.test.ts` (includes Slack-shaped missing `accessTokenSecretName` case; pins message + type)
- Pre-push gate: unit + workers unit + e2e (all green)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `a3ea47af` · **Head:** `783c5479`

**Classification:** composes — wires the existing `McpCallerError` / MCP observability skip path into create-time validation; no new primitives or schema changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `integrations` | assistant | composes — throw `McpCallerError` for create-field gaps |

### System map

Agent calls `integration_save` with incomplete create args; the capability rejects with a caller error that observability keeps off Sentry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	integrations["integrations<br/>OAuth integrations"]:::touched
	mcpObs["mcp-observability<br/>MCP failure capture"]:::untouched
	integrations -->|"McpCallerError on create gaps"| mcpObs
	mcpObs -->|"isCallerFailure skips Sentry"| drop["dropped"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d2d3c73-4561-4ca3-b274-54d1c5c3a761?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d2d3c73-4561-4ca3-b274-54d1c5c3a761&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation errors when creating integrations with missing or invalid required fields.
  * Confidential integrations now clearly identify when an access token secret name is missing.
  * Validation failures are reported with more specific caller-facing error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->