### PR TITLE
fix(connect-oauth): catch fetch network errors (KODY-CLOUDFLARE-3P)

### DIFF
--- a/packages/worker/client/routes/connect-oauth-config.ts
+++ b/packages/worker/client/routes/connect-oauth-config.ts
@@ -452,6 +452,38 @@ export function summarizeStoredSetupState(input: {
 }
 
 /**
+ * Browser `fetch()` network failures that reject as TypeError. Exact strings
+ * only — Firefox (KODY-CLOUDFLARE-3P), Chromium, and WebKit — so unrelated
+ * TypeErrors still surface their own message.
+ */
+export function isBrowserFetchNetworkError(error: unknown): boolean {
+	if (!(error instanceof TypeError)) return false
+	const message = error.message.trim().replace(/^TypeError:\s*/i, '')
+	return (
+		message === 'NetworkError when attempting to fetch resource.' ||
+		message === 'Failed to fetch' ||
+		message === 'Load failed'
+	)
+}
+
+/**
+ * Map caught client errors to in-page status text. Network fetch TypeErrors
+ * become a stable UX string so they never need to escape as unhandledrejection.
+ */
+export function formatConnectOauthCaughtError(
+	error: unknown,
+	fallback: string,
+): string {
+	if (isBrowserFetchNetworkError(error)) {
+		return 'Network error. Please try again.'
+	}
+	if (error instanceof Error && error.message.trim()) {
+		return error.message
+	}
+	return fallback
+}
+
+/**
  * Distinguish real Kody session expiry (401 Unauthorized) from provider token
  * exchange failures that historically leaked through as HTTP 401.
  */

--- a/packages/worker/client/routes/connect-oauth-config.ts
+++ b/packages/worker/client/routes/connect-oauth-config.ts
@@ -477,9 +477,8 @@ export function formatConnectOauthCaughtError(
 	if (isBrowserFetchNetworkError(error)) {
 		return 'Network error. Please try again.'
 	}
-	if (error instanceof Error && error.message.trim()) {
-		return error.message
-	}
+	const message = error instanceof Error ? error.message.trim() : ''
+	if (message) return message
 	return fallback
 }
 

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -4,7 +4,9 @@ import {
 	createCodeChallenge,
 	createCodeVerifier,
 	decodeBase64Payload,
+	formatConnectOauthCaughtError,
 	formatOAuthExchangeFailure,
+	isBrowserFetchNetworkError,
 	isMostlyPrintable,
 	isOAuthExchangeSessionExpired,
 	isSafeExternalUrl,
@@ -869,4 +871,29 @@ test('PKCE helpers match RFC 7636 S256 vector and current verifier shape', async
 	await expect(createCodeChallenge(verifier)).resolves.toMatch(
 		/^[A-Za-z0-9_-]+$/,
 	)
+})
+
+test('browser fetch network TypeErrors map to a stable in-page status (KODY-CLOUDFLARE-3P)', () => {
+	const firefox = new TypeError(
+		'NetworkError when attempting to fetch resource.',
+	)
+	const chromium = new TypeError('Failed to fetch')
+	const webkit = new TypeError('Load failed')
+	expect(isBrowserFetchNetworkError(firefox)).toBe(true)
+	expect(isBrowserFetchNetworkError(chromium)).toBe(true)
+	expect(isBrowserFetchNetworkError(webkit)).toBe(true)
+	expect(isBrowserFetchNetworkError(new TypeError('null is not an object'))).toBe(
+		false,
+	)
+	expect(isBrowserFetchNetworkError(new Error('Failed to fetch'))).toBe(false)
+	expect(formatConnectOauthCaughtError(firefox, 'fallback')).toBe(
+		'Network error. Please try again.',
+	)
+	expect(formatConnectOauthCaughtError(chromium, 'fallback')).toBe(
+		'Network error. Please try again.',
+	)
+	expect(
+		formatConnectOauthCaughtError(new Error('Unable to save secret.'), 'fallback'),
+	).toBe('Unable to save secret.')
+	expect(formatConnectOauthCaughtError('nope', 'fallback')).toBe('fallback')
 })

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -886,6 +886,9 @@ test('browser fetch network TypeErrors map to a stable in-page status (KODY-CLOU
 		isBrowserFetchNetworkError(new TypeError('null is not an object')),
 	).toBe(false)
 	expect(isBrowserFetchNetworkError(new Error('Failed to fetch'))).toBe(false)
+	expect(
+		isBrowserFetchNetworkError(new TypeError('TypeError: Failed to fetch')),
+	).toBe(true)
 	expect(formatConnectOauthCaughtError(firefox, 'fallback')).toBe(
 		'Network error. Please try again.',
 	)

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -882,9 +882,9 @@ test('browser fetch network TypeErrors map to a stable in-page status (KODY-CLOU
 	expect(isBrowserFetchNetworkError(firefox)).toBe(true)
 	expect(isBrowserFetchNetworkError(chromium)).toBe(true)
 	expect(isBrowserFetchNetworkError(webkit)).toBe(true)
-	expect(isBrowserFetchNetworkError(new TypeError('null is not an object'))).toBe(
-		false,
-	)
+	expect(
+		isBrowserFetchNetworkError(new TypeError('null is not an object')),
+	).toBe(false)
 	expect(isBrowserFetchNetworkError(new Error('Failed to fetch'))).toBe(false)
 	expect(formatConnectOauthCaughtError(firefox, 'fallback')).toBe(
 		'Network error. Please try again.',
@@ -893,7 +893,10 @@ test('browser fetch network TypeErrors map to a stable in-page status (KODY-CLOU
 		'Network error. Please try again.',
 	)
 	expect(
-		formatConnectOauthCaughtError(new Error('Unable to save secret.'), 'fallback'),
+		formatConnectOauthCaughtError(
+			new Error('Unable to save secret.'),
+			'fallback',
+		),
 	).toBe('Unable to save secret.')
 	expect(formatConnectOauthCaughtError('nope', 'fallback')).toBe('fallback')
 })

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -622,7 +622,10 @@ export function ConnectOauthRoute(handle: Handle) {
 			// fetch() TypeError (Firefox NetworkError / Chromium Failed to fetch)
 			// must not escape as unhandledrejection — KODY-CLOUDFLARE-3P.
 			setStatus(
-				formatConnectOauthCaughtError(error, 'Network error. Please try again.'),
+				formatConnectOauthCaughtError(
+					error,
+					'Network error. Please try again.',
+				),
 				'error',
 			)
 		} finally {
@@ -732,7 +735,10 @@ export function ConnectOauthRoute(handle: Handle) {
 			// Same class as setup submit: token exchange / save fetch failures
 			// must surface in-page, not as unhandledrejection (KODY-CLOUDFLARE-3P).
 			setStatus(
-				formatConnectOauthCaughtError(error, 'Network error. Please try again.'),
+				formatConnectOauthCaughtError(
+					error,
+					'Network error. Please try again.',
+				),
 				'error',
 			)
 			setStep('connect')
@@ -917,10 +923,7 @@ export function ConnectOauthRoute(handle: Handle) {
 							})
 						: null)
 				if (!nextConfig) {
-					setStatus(
-						'Missing required OAuth configuration parameters.',
-						'error',
-					)
+					setStatus('Missing required OAuth configuration parameters.', 'error')
 					return
 				}
 				config = nextConfig
@@ -953,7 +956,10 @@ export function ConnectOauthRoute(handle: Handle) {
 			// Initial integration/secrets reads use fetch(); a transient network
 			// failure must not escape queueTask as unhandledrejection.
 			setStatus(
-				formatConnectOauthCaughtError(error, 'Network error. Please try again.'),
+				formatConnectOauthCaughtError(
+					error,
+					'Network error. Please try again.',
+				),
 				'error',
 			)
 		}

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -47,6 +47,7 @@ import {
 	type StoredIntegrationConfig,
 	createCodeChallenge,
 	createCodeVerifier,
+	formatConnectOauthCaughtError,
 	formatMissingSetupFields,
 	formatOAuthExchangeFailure,
 	isSafeExternalUrl,
@@ -150,7 +151,7 @@ export function ConnectOauthRoute(handle: Handle) {
 			setStatus('All hosts approved.', 'info')
 		} catch (error) {
 			setStatus(
-				error instanceof Error ? error.message : 'Unable to approve all hosts.',
+				formatConnectOauthCaughtError(error, 'Unable to approve all hosts.'),
 				'error',
 			)
 		} finally {
@@ -617,6 +618,13 @@ export function ConnectOauthRoute(handle: Handle) {
 			hasStoredClientId = true
 			setStatus('Saved OAuth client configuration.', 'info')
 			setStep('connect')
+		} catch (error) {
+			// fetch() TypeError (Firefox NetworkError / Chromium Failed to fetch)
+			// must not escape as unhandledrejection — KODY-CLOUDFLARE-3P.
+			setStatus(
+				formatConnectOauthCaughtError(error, 'Network error. Please try again.'),
+				'error',
+			)
 		} finally {
 			submitting = false
 			update()
@@ -632,7 +640,7 @@ export function ConnectOauthRoute(handle: Handle) {
 			window.location.assign(url)
 		} catch (error) {
 			setStatus(
-				error instanceof Error ? error.message : 'Unable to start OAuth.',
+				formatConnectOauthCaughtError(error, 'Unable to start OAuth.'),
 				'error',
 			)
 		} finally {
@@ -644,79 +652,91 @@ export function ConnectOauthRoute(handle: Handle) {
 	const handleCallback = async () => {
 		if (!config) return
 		setStep('callback')
-		const callback = readCallback()
-		if (callback.kind !== 'none') {
-			window.history.replaceState(null, '', getRedirectUri())
-		}
-		if (callback.kind === 'error') {
+		try {
+			const callback = readCallback()
+			if (callback.kind !== 'none') {
+				window.history.replaceState(null, '', getRedirectUri())
+			}
+			if (callback.kind === 'error') {
+				setStatus(
+					callback.description || `OAuth error: ${callback.error}`,
+					'error',
+				)
+				setStep('connect')
+				return
+			}
+			if (callback.kind !== 'success') return
+			const valid = validateState(
+				getStateKey(config.providerKey),
+				callback.state,
+			)
+			if (!valid) {
+				setStatus('State mismatch. Restart the OAuth flow.', 'error')
+				setStep('connect')
+				return
+			}
+			const exchange = await exchangeOAuthCode(config, callback.code)
+			if (!exchange.ok) {
+				setStatus(exchange.error, 'error')
+				setStep(
+					exchange.error.includes('client ID') ||
+						exchange.error.includes('client secret')
+						? 'setup'
+						: 'connect',
+				)
+				return
+			}
+			const callbackUrl = window.location.href
+			const response = await fetch('/account/secrets.json', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					action: 'connect_oauth',
+					provider: config.provider,
+					callbackUrl,
+					authorizeUrl: config.authorizeUrl,
+					tokenUrl: config.tokenUrl,
+					apiBaseUrl: config.apiBaseUrl,
+					scopes: config.scopes,
+					scopeSeparator: config.scopeSeparator,
+					extraAuthorizeParams: config.extraAuthorizeParams,
+					flow: config.flow,
+					usePkce: config.usePkce,
+					tokenExchangeStyle: config.tokenExchangeStyle,
+					clientId: config.clientId,
+					clientSecretSecretName: config.clientSecretSecretName,
+					allowedHosts: config.allowedHosts,
+					accessTokenSecretName: config.accessTokenSecretName,
+					refreshTokenSecretName: config.refreshTokenSecretName,
+					tokenPayload: exchange.data,
+				}),
+			})
+			if (redirectToLoginOn401(response)) return
+			const payload = await response.json().catch(() => null)
+			if (!response.ok || payload?.ok !== true) {
+				setStatus(payload?.error || 'Unable to save OAuth tokens.', 'error')
+				setStep('connect')
+				return
+			}
+			accessTokenSaved = payload.accessTokenSaved === true
+			refreshTokenSaved = payload.refreshTokenSaved === true
+			setHostApprovalLinks(parseHostApprovalLinks(payload.hostApprovalLinks))
+			setNextSteps(parseConnectOauthNextSteps(payload.nextSteps))
+			setStatus('OAuth tokens saved.', 'info')
+			setStep('success')
+		} catch (error) {
+			// Same class as setup submit: token exchange / save fetch failures
+			// must surface in-page, not as unhandledrejection (KODY-CLOUDFLARE-3P).
 			setStatus(
-				callback.description || `OAuth error: ${callback.error}`,
+				formatConnectOauthCaughtError(error, 'Network error. Please try again.'),
 				'error',
 			)
 			setStep('connect')
-			return
 		}
-		if (callback.kind !== 'success') return
-		const valid = validateState(getStateKey(config.providerKey), callback.state)
-		if (!valid) {
-			setStatus('State mismatch. Restart the OAuth flow.', 'error')
-			setStep('connect')
-			return
-		}
-		const exchange = await exchangeOAuthCode(config, callback.code)
-		if (!exchange.ok) {
-			setStatus(exchange.error, 'error')
-			setStep(
-				exchange.error.includes('client ID') ||
-					exchange.error.includes('client secret')
-					? 'setup'
-					: 'connect',
-			)
-			return
-		}
-		const callbackUrl = window.location.href
-		const response = await fetch('/account/secrets.json', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				Accept: 'application/json',
-			},
-			credentials: 'include',
-			body: JSON.stringify({
-				action: 'connect_oauth',
-				provider: config.provider,
-				callbackUrl,
-				authorizeUrl: config.authorizeUrl,
-				tokenUrl: config.tokenUrl,
-				apiBaseUrl: config.apiBaseUrl,
-				scopes: config.scopes,
-				scopeSeparator: config.scopeSeparator,
-				extraAuthorizeParams: config.extraAuthorizeParams,
-				flow: config.flow,
-				usePkce: config.usePkce,
-				tokenExchangeStyle: config.tokenExchangeStyle,
-				clientId: config.clientId,
-				clientSecretSecretName: config.clientSecretSecretName,
-				allowedHosts: config.allowedHosts,
-				accessTokenSecretName: config.accessTokenSecretName,
-				refreshTokenSecretName: config.refreshTokenSecretName,
-				tokenPayload: exchange.data,
-			}),
-		})
-		if (redirectToLoginOn401(response)) return
-		const payload = await response.json().catch(() => null)
-		if (!response.ok || payload?.ok !== true) {
-			setStatus(payload?.error || 'Unable to save OAuth tokens.', 'error')
-			setStep('connect')
-			return
-		}
-		accessTokenSaved = payload.accessTokenSaved === true
-		refreshTokenSaved = payload.refreshTokenSaved === true
-		setHostApprovalLinks(parseHostApprovalLinks(payload.hostApprovalLinks))
-		setNextSteps(parseConnectOauthNextSteps(payload.nextSteps))
-		setStatus('OAuth tokens saved.', 'info')
-		setStep('success')
-		return
 	}
 
 	const renderRedirectUriCard = () => {
@@ -882,48 +902,61 @@ export function ConnectOauthRoute(handle: Handle) {
 	handle.queueTask(async () => {
 		if (initialLoadStarted) return
 		initialLoadStarted = true
-		const callback = readCallback()
-		if (callback.kind === 'success' || callback.kind === 'error') {
-			const storedConfig = readStoredConfig()
-			const queryConfig = storedConfig ? null : readQueryConfig()
-			const nextConfig =
-				storedConfig ??
-				(queryConfig
-					? mergeConnectOauthConfig({
-							queryConfig,
-							storedIntegration:
-								await readExistingIntegrationConfig(queryConfig),
-						})
-					: null)
+		try {
+			const callback = readCallback()
+			if (callback.kind === 'success' || callback.kind === 'error') {
+				const storedConfig = readStoredConfig()
+				const queryConfig = storedConfig ? null : readQueryConfig()
+				const nextConfig =
+					storedConfig ??
+					(queryConfig
+						? mergeConnectOauthConfig({
+								queryConfig,
+								storedIntegration:
+									await readExistingIntegrationConfig(queryConfig),
+							})
+						: null)
+				if (!nextConfig) {
+					setStatus(
+						'Missing required OAuth configuration parameters.',
+						'error',
+					)
+					return
+				}
+				config = nextConfig
+				if (!connectOauthHandled) {
+					connectOauthHandled = true
+					await handleCallback()
+				}
+				return
+			}
+			const queryConfig = readQueryConfig()
+			if (!queryConfig) {
+				setStatus('Missing required OAuth configuration parameters.', 'error')
+				return
+			}
+			const existingIntegration =
+				await readExistingIntegrationConfig(queryConfig)
+			existingIntegrationConfig = existingIntegration
+			const nextConfig = mergeConnectOauthConfig({
+				queryConfig,
+				storedIntegration: existingIntegration,
+			})
 			if (!nextConfig) {
+				hasConfigError = true
 				setStatus('Missing required OAuth configuration parameters.', 'error')
 				return
 			}
 			config = nextConfig
-			if (!connectOauthHandled) {
-				connectOauthHandled = true
-				await handleCallback()
-			}
-			return
+			await initializeSetupState(nextConfig)
+		} catch (error) {
+			// Initial integration/secrets reads use fetch(); a transient network
+			// failure must not escape queueTask as unhandledrejection.
+			setStatus(
+				formatConnectOauthCaughtError(error, 'Network error. Please try again.'),
+				'error',
+			)
 		}
-		const queryConfig = readQueryConfig()
-		if (!queryConfig) {
-			setStatus('Missing required OAuth configuration parameters.', 'error')
-			return
-		}
-		const existingIntegration = await readExistingIntegrationConfig(queryConfig)
-		existingIntegrationConfig = existingIntegration
-		const nextConfig = mergeConnectOauthConfig({
-			queryConfig,
-			storedIntegration: existingIntegration,
-		})
-		if (!nextConfig) {
-			hasConfigError = true
-			setStatus('Missing required OAuth configuration parameters.', 'error')
-			return
-		}
-		config = nextConfig
-		await initializeSetupState(nextConfig)
 	})
 
 	return () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Firefox `TypeError: NetworkError when attempting to fetch resource.` on `/connect/oauth` from escaping as an unhandledrejection into Sentry (KODY-CLOUDFLARE-3P / issue 7650916891).

## Summary

- Production event: single Firefox 153 unhandledrejection on `https://heykody.dev/connect/oauth` after a UI click; empty stack; no siblings with the same signature.
- Root cause in code: setup submit, OAuth callback, and initial `queueTask` load call `fetch()` without a catch. Async handler rejections surface as `onunhandledrejection` (same mechanism as the Sentry event). `handleConnect` / host-approval already caught.
- Fix: catch those paths and map browser fetch network TypeErrors (Firefox `NetworkError…`, Chromium `Failed to fetch`, WebKit `Load failed`) to the existing in-page status string `Network error. Please try again.` — same UX as login / oauth-authorize.
- Intentionally **not** a Sentry `beforeSend` filter: browser filters already keep `Failed to fetch` reportable so unhandled fetch bugs stay visible.

## Testing

- `npm test -- packages/worker/client/routes/connect-oauth.node.test.ts` (11 passed)
- Focused `oxfmt` on touched files
- Full `npm run validate` was green except format (fixed); re-running CI on this PR

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** composes — no new primitives; `app-ui` connect-oauth handlers catch fetch failures the same way login already does.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — catch + status mapping on existing `/connect/oauth` fetches |

### System map

Connect-oauth client fetches that used to reject unhandled now set in-page status instead of reaching Sentry via `onunhandledrejection`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>/connect/oauth"]:::touched
	secretsApi["account secrets API<br/>/account/secrets.json"]:::untouched
	sentryTunnel["sentry-tunnel<br/>client envelopes"]:::untouched
	appUi -->|"fetch (setup / callback / load)"| secretsApi
	appUi -->|"caught TypeError → status message"| appUi
	appUi -.->|"no unhandledrejection"| sentryTunnel
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Case | Before | After |
| --- | --- | --- |
| Firefox `NetworkError when attempting to fetch resource.` during connect-oauth fetch | Unhandledrejection → Sentry | In-page `Network error. Please try again.` |
| Real non-network errors in those handlers | Mixed / sometimes unhandled | Still shown via `error.message` when present |

### Invariants

No change to per-user isolation, OAuth token handling, or auth surfaces beyond catching network failures in the UI.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9d437f4-5a34-494b-b0c7-487996471945?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9d437f4-5a34-494b-b0c7-487996471945&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth connection error handling across setup, sign-in, callback, and initial loading flows.
  - Browser network failures now display a clear retry message.
  - Other errors preserve their specific messages or use an appropriate fallback instead of causing unhandled failures.
  - Added coverage for network-error behavior across major browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->