### PR TITLE
refactor: drop cutover-audit priority and retired daily-mirror parity

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -645,7 +645,7 @@ account export/deletion inventory paths never read or write
 `entitlement_daily_counters`. The three-deploy retirement is complete (Workers
 `#1133` / `#1134`, then migration `0126-drop-entitlement-daily-counters.sql`).
 The final live schema has no table or day index; `admin_user_meter_parity`
-reports `daily.mirrorRetired: true` (meter counts only). See
+reports meter-only daily counts. See
 [Entitlements](./entitlements.md#usermeter-expand-phase).
 
 **Daily cold bootstrap:** a missing `(resource, day)` row returns
@@ -723,10 +723,10 @@ backfill. USER write entry points fail closed when the marker is absent;
 intentionally blocks the migration; account-deletion cleanup must finish before
 operators retry deployment. The same migration adds two non-payload coordination
 surfaces: `email_inbound_due_owners` provides bounded owner discovery for
-scheduled inbound reconciliation. Due live-work reasons sort before the seeded
-`cutover-audit` backlog, then by due time and owner, with 25 owners processed
-per tick. `email_delivery_alert_events` preserves short-lived bounced/complained
-signals for operator burst alerts.
+scheduled inbound reconciliation, ordered by due time and owner with 25 owners
+processed per tick (the seeded one-shot `cutover-audit` backlog drained during
+cutover). `email_delivery_alert_events` preserves short-lived
+bounced/complained signals for operator burst alerts.
 
 Migration `0135-drop-legacy-email-graph.sql` removed the shared D1
 `email_threads`, `email_messages`, `email_attachments`, and
@@ -1530,7 +1530,7 @@ Current retention policies:
   writes and detached runtime inventory. No scheduled retention disposition or
   pending-drop coverage remains. Daily counter retention lives in the per-user
   `UserMeter` DO (`userMeterDailyCounterRetentionDays`);
-  `admin_user_meter_parity` reports `daily.mirrorRetired: true`.
+  `admin_user_meter_parity` reports meter-only daily counts.
 - `usage_rollups`: per user/metric/month rollups keep 24 months by `month` key;
   raw Analytics Engine usage events follow platform retention.
 - `feature_flag_exposure_rollups`: local-dev/test flag exposure rollups keep 90

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -725,8 +725,8 @@ operators retry deployment. The same migration adds two non-payload coordination
 surfaces: `email_inbound_due_owners` provides bounded owner discovery for
 scheduled inbound reconciliation, ordered by due time and owner with 25 owners
 processed per tick (the seeded one-shot `cutover-audit` backlog drained during
-cutover). `email_delivery_alert_events` preserves short-lived
-bounced/complained signals for operator burst alerts.
+cutover). `email_delivery_alert_events` preserves short-lived bounced/complained
+signals for operator burst alerts.
 
 Migration `0135-drop-legacy-email-graph.sql` removed the shared D1
 `email_threads`, `email_messages`, `email_attachments`, and

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -413,19 +413,19 @@ storage, package-service, and write-fencing sections above.
 **Daily-counter mirror (retired):** live schema has no
 `entitlement_daily_counters` table (Workers `#1133` / `#1134`, then migration
 `0126-drop-entitlement-daily-counters.sql`). Admin parity reports meter-only
-daily counts. Production scans across 38 users showed zero daily mismatches
-with Analytics Engine reporting active before the drop.
+daily counts. Production scans across 38 users showed zero daily mismatches with
+Analytics Engine reporting active before the drop.
 
 ### Admin UserMeter parity gates (`admin_user_meter_parity`)
 
 Production verification uses the admin-only read-only capability
 `admin_user_meter_parity` (input: `stable_user_id`). It compares
 production-shaped D1 rows for one account against direct UserMeter RPCs and
-never bootstraps or writes parity state. The daily section is meter-only (the
-D1 mirror is dropped, so no comparison fields exist). Opening a cold UserMeter
-stub may still run Durable Object constructor schema maintenance and
-opportunistic stale daily-counter pruning. Cold meter rows surface as
-`needsBootstrap` with `meterCount`/`meterBytes` null.
+never bootstraps or writes parity state. The daily section is meter-only (the D1
+mirror is dropped, so no comparison fields exist). Opening a cold UserMeter stub
+may still run Durable Object constructor schema maintenance and opportunistic
+stale daily-counter pruning. Cold meter rows surface as `needsBootstrap` with
+`meterCount`/`meterBytes` null.
 
 Interpret the structured report as independent gates:
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -166,9 +166,9 @@ surfaces, retention, and account export/deletion never read or write
 `entitlement_daily_counters`. The three-deploy retirement is complete: Worker
 `#1133` stopped mirror writes, `#1134` detached runtime inventory, and migration
 `0126-drop-entitlement-daily-counters.sql` dropped the table and day index.
-`admin_user_meter_parity` reports `daily.mirrorRetired: true` (meter counts
-only; `d1Count`/`delta` null). Analytics Engine remains the production reporting
-path for email send/receive aggregates.
+`admin_user_meter_parity` reports meter-only daily counts (no D1 comparison
+fields exist). Analytics Engine remains the production reporting path for email
+send/receive aggregates.
 
 **Point-read surfaces** call `readDailyEntitlementResourceUsage` (UserMeter with
 the same cold zero-init path):
@@ -412,27 +412,26 @@ storage, package-service, and write-fencing sections above.
 
 **Daily-counter mirror (retired):** live schema has no
 `entitlement_daily_counters` table (Workers `#1133` / `#1134`, then migration
-`0126-drop-entitlement-daily-counters.sql`). Admin parity reports
-`daily.mirrorRetired: true` (meter counts only). Production scans across 38
-users showed zero daily mismatches with Analytics Engine reporting active before
-the drop.
+`0126-drop-entitlement-daily-counters.sql`). Admin parity reports meter-only
+daily counts. Production scans across 38 users showed zero daily mismatches
+with Analytics Engine reporting active before the drop.
 
 ### Admin UserMeter parity gates (`admin_user_meter_parity`)
 
 Production verification uses the admin-only read-only capability
 `admin_user_meter_parity` (input: `stable_user_id`). It compares
 production-shaped D1 rows for one account against direct UserMeter RPCs and
-never bootstraps or writes parity state. With `daily.mirrorRetired: true`, the
-report returns meter counts only with `d1Count`/`delta` null and each resource
-`parity: true`. Opening a cold UserMeter stub may still run Durable Object
-constructor schema maintenance and opportunistic stale daily-counter pruning.
-Cold meter rows surface as `needsBootstrap` with `meterCount`/`meterBytes` null.
+never bootstraps or writes parity state. The daily section is meter-only (the
+D1 mirror is dropped, so no comparison fields exist). Opening a cold UserMeter
+stub may still run Durable Object constructor schema maintenance and
+opportunistic stale daily-counter pruning. Cold meter rows surface as
+`needsBootstrap` with `meterCount`/`meterBytes` null.
 
 Interpret the structured report as independent gates:
 
 | Gate                     | Pass condition                                                                                                                                                                                                                                                                      |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Daily counters (UTC day) | `daily.mirrorRetired: true`: report meter counts only; `d1Count`/`delta` are null, each of the four daily resources has `parity: true`, and `mismatchCount === 0` (no D1 comparison).                                                                                               |
+| Daily counters (UTC day) | Meter-only reads: each of the four daily resources reports `meterCount` (null with `needsBootstrap: true` on cold accounts). No D1 comparison exists.                                                                                                                               |
 | Storage bytes            | `storage.parity` — D1 `users.d1_storage_bytes` equals UserMeter `readStorageBytes` (not `needsBootstrap`).                                                                                                                                                                          |
 | Package services         | `packageServices.parity` — inventory mismatch category counts are all zero (`d1Only` / `meterOnly` / `statusMismatch` / `startedAtMismatch` / `sourceUpdatedAtMismatch`), fresh-running counts match under the shared 24h stale window, and the meter page walk is not `truncated`. |
 | Deletion tombstone       | `deletion.deletingAtParity` — D1 `users.deleting_at` matches the meter tombstone.                                                                                                                                                                                                   |
@@ -883,6 +882,6 @@ in [`../environment-variables.md`](../environment-variables.md).
   `0055-retention-indexes.sql`, and dropped by
   `0126-drop-entitlement-daily-counters.sql` after stages 1/2 stopped mirror
   writes and detached runtime inventory. Final live schema has no table or day
-  index; `admin_user_meter_parity` reports `daily.mirrorRetired: true`. Daily
+  index; `admin_user_meter_parity` reports meter-only daily counts. Daily
   counters are authoritative in the per-user `UserMeter` DO; account export uses
   UserMeter RPCs.

--- a/packages/worker/src/admin/user-meter-parity.node.test.ts
+++ b/packages/worker/src/admin/user-meter-parity.node.test.ts
@@ -33,14 +33,6 @@ function createParityTestDb() {
 			created_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z',
 			updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z'
 		);
-		CREATE TABLE entitlement_daily_counters (
-			user_id TEXT NOT NULL,
-			resource TEXT NOT NULL,
-			day TEXT NOT NULL,
-			count INTEGER NOT NULL DEFAULT 0,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (user_id, resource, day)
-		);
 		CREATE TABLE package_service_states (
 			user_id TEXT NOT NULL,
 			package_id TEXT NOT NULL,
@@ -132,7 +124,6 @@ async function seedMeterParityBaseline(input: {
 function seedD1ParityBaseline(input: {
 	sqlite: DatabaseSync
 	stableUserId: string
-	dailyCounts: Record<(typeof dailyEntitlementResources)[number], number>
 	storageBytes: number
 	packageServices?: Array<{
 		packageId: string
@@ -148,21 +139,6 @@ function seedD1ParityBaseline(input: {
 		d1StorageBytes: input.storageBytes,
 		deletingAt: input.deletingAt ?? null,
 	})
-	for (const resource of dailyEntitlementResources) {
-		input.sqlite
-			.prepare(
-				`INSERT INTO entitlement_daily_counters (
-					user_id, resource, day, count, updated_at
-				) VALUES (?, ?, ?, ?, ?)`,
-			)
-			.run(
-				input.stableUserId,
-				resource,
-				day,
-				input.dailyCounts[resource],
-				now.toISOString(),
-			)
-	}
 	for (const service of input.packageServices ?? []) {
 		input.sqlite
 			.prepare(
@@ -240,7 +216,6 @@ test('loadAdminUserMeterParityReport reports full parity across daily/storage/se
 	seedD1ParityBaseline({
 		sqlite,
 		stableUserId,
-		dailyCounts,
 		storageBytes: 4096,
 		packageServices: [
 			{
@@ -286,8 +261,6 @@ test('loadAdminUserMeterParityReport reports full parity across daily/storage/se
 		stableUserId,
 		daily: {
 			day,
-			mirrorRetired: false,
-			mismatchCount: 0,
 		},
 		storage: {
 			d1Bytes: 4096,
@@ -322,7 +295,17 @@ test('loadAdminUserMeterParityReport reports full parity across daily/storage/se
 		},
 	})
 	expect(report?.daily.resources).toHaveLength(4)
-	expect(report?.daily.resources.every((row) => row.parity)).toBe(true)
+	expect(
+		report?.daily.resources.map((row) => [row.resource, row.meterCount]),
+	).toEqual([
+		['email_sends_per_day', 3],
+		['email_receives_per_day', 5],
+		['execute_calls_per_day', 11],
+		['outbound_fetches_per_day', 7],
+	])
+	expect(report?.daily.resources.every((row) => !row.needsBootstrap)).toBe(
+		true,
+	)
 	assertNoLeaseSecrets(report)
 })
 
@@ -338,7 +321,6 @@ test('loadAdminUserMeterParityReport D1 lease rows are quiescent; activeLeaseCou
 	seedD1ParityBaseline({
 		sqlite,
 		stableUserId,
-		dailyCounts,
 		storageBytes: 0,
 	})
 	// A quiescent D1 lease row: not queried by parity; does not affect activeLeaseCount.
@@ -376,13 +358,6 @@ test('loadAdminUserMeterParityReport classifies mismatches and needsBootstrap wi
 	const { sqlite, db } = createParityTestDb()
 	const meter = createInMemoryUserMeterEnv()
 	insertUser(sqlite, { stableUserId, d1StorageBytes: 100 })
-	sqlite
-		.prepare(
-			`INSERT INTO entitlement_daily_counters (
-				user_id, resource, day, count, updated_at
-			) VALUES (?, 'email_sends_per_day', ?, 9, ?)`,
-		)
-		.run(stableUserId, day, now.toISOString())
 	sqlite
 		.prepare(
 			`INSERT INTO package_service_states (
@@ -429,28 +404,23 @@ test('loadAdminUserMeterParityReport classifies mismatches and needsBootstrap wi
 		stableUserId,
 		now,
 	})
-	expect(report?.daily.mismatchCount).toBe(4)
 	expect(
 		report?.daily.resources.find(
 			(row) => row.resource === 'email_sends_per_day',
 		),
-	).toMatchObject({
-		d1Count: 9,
+	).toEqual({
+		resource: 'email_sends_per_day',
 		meterCount: 2,
 		needsBootstrap: false,
-		delta: 7,
-		parity: false,
 	})
 	expect(
 		report?.daily.resources.find(
 			(row) => row.resource === 'email_receives_per_day',
 		),
-	).toMatchObject({
-		d1Count: 0,
+	).toEqual({
+		resource: 'email_receives_per_day',
 		meterCount: null,
 		needsBootstrap: true,
-		delta: null,
-		parity: false,
 	})
 	expect(report?.storage).toMatchObject({
 		d1Bytes: 100,
@@ -575,7 +545,6 @@ test('loadAdminUserMeterParityReport fails closed on repeated package-service cu
 	seedD1ParityBaseline({
 		sqlite,
 		stableUserId,
-		dailyCounts,
 		storageBytes: 0,
 	})
 	await seedMeterParityBaseline({
@@ -623,170 +592,6 @@ test('loadAdminUserMeterParityReport fails closed on repeated package-service cu
 	)
 	expect(report?.packageServices).toMatchObject({
 		truncated: true,
-		parity: false,
-	})
-	expect(report?.deletion).toMatchObject({
-		d1DeletingAt: null,
-		meterDeletingAt: null,
-		deletingAtParity: true,
-		activeLeaseCount: 0,
-	})
-})
-
-test('loadAdminUserMeterParityReport reports mirrorRetired when entitlement_daily_counters is absent', async () => {
-	const sqlite = new DatabaseSync(':memory:')
-	sqlite.exec(`
-		CREATE TABLE users (
-			id INTEGER PRIMARY KEY,
-			stable_user_id TEXT UNIQUE NOT NULL,
-			username TEXT NOT NULL,
-			email TEXT NOT NULL,
-			d1_storage_bytes INTEGER NOT NULL DEFAULT 0,
-			deleting_at TEXT,
-			created_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z',
-			updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z'
-		);
-		CREATE TABLE package_service_states (
-			user_id TEXT NOT NULL,
-			package_id TEXT NOT NULL,
-			service_name TEXT NOT NULL,
-			status TEXT NOT NULL CHECK (status IN ('running', 'idle', 'stopped', 'error')),
-			started_at TEXT,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (user_id, package_id, service_name)
-		);
-		CREATE TABLE account_write_leases (
-			token TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
-			holder TEXT NOT NULL,
-			acquired_at TEXT NOT NULL,
-			released_at TEXT
-		);
-	`)
-	const db = createD1FromSqlite(sqlite)
-	const meter = createInMemoryUserMeterEnv()
-	insertUser(sqlite, { stableUserId, d1StorageBytes: 0 })
-	const meterStub = userMeterRpc({ env: meter.env, userId: stableUserId })
-	await meterStub.initialize({
-		resource: 'email_sends_per_day',
-		day,
-		count: 4,
-		updatedAt: now.toISOString(),
-	})
-	await meterStub.initializeStorageBytes({
-		bytes: 0,
-		updatedAt: now.toISOString(),
-	})
-
-	const report = await loadAdminUserMeterParityReport({
-		db,
-		env: meter.env,
-		stableUserId,
-		now,
-	})
-	expect(report?.daily).toMatchObject({
-		mirrorRetired: true,
-		mismatchCount: 0,
-	})
-	expect(
-		report?.daily.resources.find(
-			(row) => row.resource === 'email_sends_per_day',
-		),
-	).toMatchObject({
-		d1Count: null,
-		meterCount: 4,
-		delta: null,
-		parity: true,
-	})
-	expect(report?.deletion).toMatchObject({
-		d1DeletingAt: null,
-		meterDeletingAt: null,
-		deletingAtParity: true,
-		activeLeaseCount: 0,
-	})
-})
-
-test('loadAdminUserMeterParityReport still compares D1 daily counts when mirror table exists', async () => {
-	const sqlite = new DatabaseSync(':memory:')
-	sqlite.exec(`
-		CREATE TABLE users (
-			id INTEGER PRIMARY KEY,
-			stable_user_id TEXT UNIQUE NOT NULL,
-			username TEXT NOT NULL,
-			email TEXT NOT NULL,
-			password_hash TEXT,
-			d1_storage_bytes INTEGER NOT NULL DEFAULT 0,
-			deleting_at TEXT,
-			active_write_count INTEGER NOT NULL DEFAULT 0,
-			created_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z',
-			updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z'
-		);
-		CREATE TABLE entitlement_daily_counters (
-			user_id TEXT NOT NULL,
-			resource TEXT NOT NULL,
-			day TEXT NOT NULL,
-			count INTEGER NOT NULL DEFAULT 0,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (user_id, resource, day)
-		);
-		CREATE TABLE package_service_states (
-			user_id TEXT NOT NULL,
-			package_id TEXT NOT NULL,
-			service_name TEXT NOT NULL,
-			status TEXT NOT NULL CHECK (status IN ('running', 'idle', 'stopped', 'error')),
-			started_at TEXT,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (user_id, package_id, service_name)
-		);
-		CREATE TABLE account_write_leases (
-			token TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
-			holder TEXT NOT NULL,
-			acquired_at TEXT NOT NULL,
-			released_at TEXT
-		);
-	`)
-	const db = createD1FromSqlite(sqlite)
-	const meter = createInMemoryUserMeterEnv()
-	insertUser(sqlite, { stableUserId, d1StorageBytes: 0 })
-	for (const resource of dailyEntitlementResources) {
-		sqlite
-			.prepare(
-				`INSERT INTO entitlement_daily_counters (
-					user_id, resource, day, count, updated_at
-				) VALUES (?, ?, ?, ?, ?)`,
-			)
-			.run(stableUserId, resource, day, 1, now.toISOString())
-	}
-	const meterStub = userMeterRpc({ env: meter.env, userId: stableUserId })
-	for (const resource of dailyEntitlementResources) {
-		await meterStub.initialize({
-			resource,
-			day,
-			count: resource === 'email_sends_per_day' ? 9 : 1,
-			updatedAt: now.toISOString(),
-		})
-	}
-	await meterStub.initializeStorageBytes({
-		bytes: 0,
-		updatedAt: now.toISOString(),
-	})
-	const report = await loadAdminUserMeterParityReport({
-		db,
-		env: meter.env,
-		stableUserId,
-		now,
-	})
-	expect(report?.daily.mirrorRetired).toBe(false)
-	expect(report?.daily.mismatchCount).toBe(1)
-	expect(
-		report?.daily.resources.find(
-			(row) => row.resource === 'email_sends_per_day',
-		),
-	).toMatchObject({
-		d1Count: 1,
-		meterCount: 9,
-		delta: -8,
 		parity: false,
 	})
 	expect(report?.deletion).toMatchObject({

--- a/packages/worker/src/admin/user-meter-parity.node.test.ts
+++ b/packages/worker/src/admin/user-meter-parity.node.test.ts
@@ -303,9 +303,7 @@ test('loadAdminUserMeterParityReport reports full parity across daily/storage/se
 		['execute_calls_per_day', 11],
 		['outbound_fetches_per_day', 7],
 	])
-	expect(report?.daily.resources.every((row) => !row.needsBootstrap)).toBe(
-		true,
-	)
+	expect(report?.daily.resources.every((row) => !row.needsBootstrap)).toBe(true)
 	assertNoLeaseSecrets(report)
 })
 

--- a/packages/worker/src/admin/user-meter-parity.ts
+++ b/packages/worker/src/admin/user-meter-parity.ts
@@ -21,25 +21,10 @@ export const userMeterParityInventoryMaxRows = planLimits.max.maxPackageServices
 /** Page size for UserMeter list RPCs (matches DO max export/list page). */
 export const userMeterParityPageSize = 500
 
-type DailyResourceParity = {
+type DailyResourceRead = {
 	resource: DailyEntitlementResource
-	/**
-	 * D1 mirror count for the current UTC day. `null` when
-	 * `daily.mirrorRetired` is true (table dropped / comparison retired).
-	 */
-	d1Count: number | null
 	meterCount: number | null
 	needsBootstrap: boolean
-	/**
-	 * `d1Count - meterCount` when both sides are present; `null` when the
-	 * mirror is retired or the meter still needs bootstrap.
-	 */
-	delta: number | null
-	/**
-	 * When the mirror is active: true iff counts match. When
-	 * `mirrorRetired`, always true (no D1 comparison is claimed).
-	 */
-	parity: boolean
 }
 
 type StorageParity = {
@@ -82,16 +67,14 @@ type DeletionParity = {
 export type AdminUserMeterParityReport = {
 	generatedAt: string
 	stableUserId: string
+	/**
+	 * Daily counters are UserMeter-only. The D1
+	 * `entitlement_daily_counters` mirror was dropped by migration 0126, so
+	 * this section reports meter counts without any D1 comparison.
+	 */
 	daily: {
 		day: string
-		/**
-		 * True when D1 `entitlement_daily_counters` is absent (retired). The
-		 * daily gate then reports meter counts only and does not claim a D1
-		 * comparison (`d1Count`/`delta` are null; `parity` stays true).
-		 */
-		mirrorRetired: boolean
-		resources: Array<DailyResourceParity>
-		mismatchCount: number
+		resources: Array<DailyResourceRead>
 	}
 	storage: StorageParity
 	packageServices: PackageServicesParity
@@ -126,66 +109,14 @@ async function userExists(db: D1Database, stableUserId: string) {
 	return row != null
 }
 
-/**
- * Detect retirement without querying the missing table. Uses sqlite_master
- * only (safe when the table has already been dropped).
- */
-async function isEntitlementDailyCountersMirrorRetired(
-	db: D1Database,
-): Promise<boolean> {
-	const row = await db
-		.prepare(
-			`SELECT 1 AS present
-			FROM sqlite_master
-			WHERE type = 'table' AND name = 'entitlement_daily_counters'`,
-		)
-		.first<{ present: number }>()
-	return row == null
-}
-
-async function readD1DailyCounts(input: {
-	db: D1Database
-	stableUserId: string
-	day: string
-}): Promise<Map<DailyEntitlementResource, number>> {
-	const rows = await input.db
-		.prepare(
-			`SELECT resource, count
-			FROM entitlement_daily_counters
-			WHERE user_id = ? AND day = ?`,
-		)
-		.bind(input.stableUserId, input.day)
-		.all<{ resource: string; count: number }>()
-	const counts = new Map<DailyEntitlementResource, number>()
-	for (const resource of dailyEntitlementResources) {
-		counts.set(resource, 0)
-	}
-	for (const row of rows.results ?? []) {
-		if (
-			(dailyEntitlementResources as ReadonlyArray<string>).includes(
-				row.resource,
-			)
-		) {
-			counts.set(
-				row.resource as DailyEntitlementResource,
-				Math.max(0, Number(row.count ?? 0)),
-			)
-		}
-	}
-	return counts
-}
-
-async function readDailyParity(input: {
-	db: D1Database
+async function readDailyMeterCounts(input: {
 	env: UserMeterEnv
 	stableUserId: string
 	day: string
 	generatedAt: string
 }): Promise<AdminUserMeterParityReport['daily']> {
-	const mirrorRetired = await isEntitlementDailyCountersMirrorRetired(input.db)
-	const d1Counts = mirrorRetired ? null : await readD1DailyCounts(input)
 	const meter = userMeterRpc({ env: input.env, userId: input.stableUserId })
-	const resources: Array<DailyResourceParity> = []
+	const resources: Array<DailyResourceRead> = []
 	for (const resource of dailyEntitlementResources) {
 		const meterRead = await meter.read({
 			resource,
@@ -193,42 +124,13 @@ async function readDailyParity(input: {
 			now: input.generatedAt,
 		})
 		const needsBootstrap = meterRead.outcome === 'needs_bootstrap'
-		const meterCount = needsBootstrap ? null : meterRead.count
-		if (mirrorRetired) {
-			resources.push({
-				resource,
-				d1Count: null,
-				meterCount,
-				needsBootstrap,
-				delta: null,
-				// Mirror comparison is retired; do not claim a D1 mismatch.
-				parity: true,
-			})
-			continue
-		}
-		const d1Count = d1Counts?.get(resource) ?? 0
-		const { delta, parity } = countDeltaParity({
-			d1Value: d1Count,
-			meterValue: meterCount,
-			needsBootstrap,
-		})
 		resources.push({
 			resource,
-			d1Count,
-			meterCount,
+			meterCount: needsBootstrap ? null : meterRead.count,
 			needsBootstrap,
-			delta,
-			parity,
 		})
 	}
-	return {
-		day: input.day,
-		mirrorRetired,
-		resources,
-		mismatchCount: mirrorRetired
-			? 0
-			: resources.filter((row) => !row.parity).length,
-	}
+	return { day: input.day, resources }
 }
 
 async function readStorageParity(input: {
@@ -487,8 +389,7 @@ export async function loadAdminUserMeterParityReport(input: {
 	const day = utcDayKey(now)
 
 	const [daily, storage, packageServices, deletion] = await Promise.all([
-		readDailyParity({
-			db: input.db,
+		readDailyMeterCounts({
 			env: input.env,
 			stableUserId,
 			day,

--- a/packages/worker/src/email/inbound-due-owners.ts
+++ b/packages/worker/src/email/inbound-due-owners.ts
@@ -35,12 +35,6 @@ export async function hintInboundDueOwner(input: {
 			ON CONFLICT(user_id) DO UPDATE SET
 				due_at = MIN(email_inbound_due_owners.due_at, excluded.due_at),
 				reason = CASE
-					WHEN email_inbound_due_owners.reason != 'cutover-audit'
-						AND excluded.reason = 'cutover-audit'
-					THEN email_inbound_due_owners.reason
-					WHEN email_inbound_due_owners.reason = 'cutover-audit'
-						AND excluded.reason != 'cutover-audit'
-					THEN excluded.reason
 					WHEN excluded.due_at <= email_inbound_due_owners.due_at
 					THEN excluded.reason
 					ELSE email_inbound_due_owners.reason
@@ -93,10 +87,7 @@ export async function listDueInboundOwners(input: {
 			`SELECT user_id, due_at, reason, attempt_count
 			FROM email_inbound_due_owners
 			WHERE due_at <= ?
-			ORDER BY
-				CASE WHEN reason = 'cutover-audit' THEN 1 ELSE 0 END ASC,
-				due_at ASC,
-				user_id ASC
+			ORDER BY due_at ASC, user_id ASC
 			LIMIT ?`,
 		)
 		.bind(

--- a/packages/worker/src/email/inbound-due-owners.workers.test.ts
+++ b/packages/worker/src/email/inbound-due-owners.workers.test.ts
@@ -104,21 +104,21 @@ test('due-owner discovery is bounded and ordered without a users scan', async ()
 	])
 })
 
-test('live due work precedes and cannot starve behind a bounded cutover audit backlog', async () => {
+test('due-owner drain is bounded and ordered by due time', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
 	const now = new Date('2026-08-03T12:00:00.000Z')
-	const auditDueAt = '2026-08-03T11:00:00.000Z'
-	const liveDueAt = '2026-08-03T11:59:00.000Z'
-	const liveUserId = `live-${crypto.randomUUID()}`
+	const backlogDueAt = '2026-08-03T11:00:00.000Z'
+	const latestDueAt = '2026-08-03T11:59:00.000Z'
+	const latestUserId = `latest-${crypto.randomUUID()}`
 	await env.APP_DB.batch([
 		...Array.from({ length: 100 }, (_, index) =>
 			env.APP_DB.prepare(
 				`INSERT INTO email_inbound_due_owners (
 						user_id, due_at, reason, attempt_count, last_error, updated_at
-					) VALUES (?, ?, 'cutover-audit', 0, NULL, ?)`,
+					) VALUES (?, ?, 'scheduled-refresh', 0, NULL, ?)`,
 			).bind(
-				`audit-${String(index).padStart(3, '0')}-${crypto.randomUUID()}`,
-				auditDueAt,
+				`backlog-${String(index).padStart(3, '0')}-${crypto.randomUUID()}`,
+				backlogDueAt,
 				now.toISOString(),
 			),
 		),
@@ -126,15 +126,8 @@ test('live due work precedes and cannot starve behind a bounded cutover audit ba
 			`INSERT INTO email_inbound_due_owners (
 					user_id, due_at, reason, attempt_count, last_error, updated_at
 				) VALUES (?, ?, 'mailbox-due-work', 0, NULL, ?)`,
-		).bind(liveUserId, liveDueAt, now.toISOString()),
+		).bind(latestUserId, latestDueAt, now.toISOString()),
 	])
-	await hintInboundDueOwner({
-		db: env.APP_DB,
-		userId: liveUserId,
-		dueAt: auditDueAt,
-		reason: 'cutover-audit',
-		now,
-	})
 
 	const batchSizes: Array<number> = []
 	const drainedUserIds: Array<string> = []
@@ -152,47 +145,86 @@ test('live due work precedes and cannot starve behind a bounded cutover audit ba
 		)
 	}
 
-	expect(drainedUserIds[0]).toBe(liveUserId)
+	expect(drainedUserIds.at(-1)).toBe(latestUserId)
 	expect(batchSizes).toEqual([25, 25, 25, 25, 1])
 	expect(drainedUserIds).toHaveLength(101)
 })
 
-test('sweep time budget processes live work before an older cutover audit', async () => {
+test('hint upsert keeps the earliest due time and its reason', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
 	const now = new Date('2026-08-03T12:00:00.000Z')
-	const auditEmail = `budget-audit-${crypto.randomUUID()}@example.test`
-	const liveEmail = `budget-live-${crypto.randomUUID()}@example.test`
-	const auditUserId = await createStableUserIdFromEmail(auditEmail)
-	const liveUserId = await createStableUserIdFromEmail(liveEmail)
+	const userId = `hint-merge-${crypto.randomUUID()}`
+	await hintInboundDueOwner({
+		db: env.APP_DB,
+		userId,
+		dueAt: '2026-08-03T11:30:00.000Z',
+		reason: 'mailbox-due-work',
+		now,
+	})
+	// A later hint never moves the due time forward or replaces the reason.
+	await hintInboundDueOwner({
+		db: env.APP_DB,
+		userId,
+		dueAt: '2026-08-03T11:45:00.000Z',
+		reason: 'scheduled-refresh',
+		now,
+	})
+	// An earlier hint wins both the due time and the reason.
+	await hintInboundDueOwner({
+		db: env.APP_DB,
+		userId,
+		dueAt: '2026-08-03T11:15:00.000Z',
+		reason: 'scheduled-refresh',
+		now,
+	})
+	expect(
+		await env.APP_DB.prepare(
+			`SELECT due_at, reason FROM email_inbound_due_owners WHERE user_id = ?`,
+		)
+			.bind(userId)
+			.first(),
+	).toEqual({
+		due_at: '2026-08-03T11:15:00.000Z',
+		reason: 'scheduled-refresh',
+	})
+})
+
+test('sweep time budget defers later owners to the next pass', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const now = new Date('2026-08-03T12:00:00.000Z')
+	const earlierEmail = `budget-earlier-${crypto.randomUUID()}@example.test`
+	const laterEmail = `budget-later-${crypto.randomUUID()}@example.test`
+	const earlierUserId = await createStableUserIdFromEmail(earlierEmail)
+	const laterUserId = await createStableUserIdFromEmail(laterEmail)
 	await env.APP_DB.batch([
 		env.APP_DB.prepare(
 			`INSERT INTO users (
 				username, email, password_hash, stable_user_id
 			) VALUES (?, ?, 'hash', ?)`,
-		).bind(`audit-${crypto.randomUUID()}`, auditEmail, auditUserId),
+		).bind(`earlier-${crypto.randomUUID()}`, earlierEmail, earlierUserId),
 		env.APP_DB.prepare(
 			`INSERT INTO users (
 				username, email, password_hash, stable_user_id
 			) VALUES (?, ?, 'hash', ?)`,
-		).bind(`live-${crypto.randomUUID()}`, liveEmail, liveUserId),
+		).bind(`later-${crypto.randomUUID()}`, laterEmail, laterUserId),
 	])
 	await replaceInboundDueOwnerHint({
 		db: env.APP_DB,
-		userId: auditUserId,
+		userId: earlierUserId,
 		dueAt: '2026-08-03T10:00:00.000Z',
-		reason: 'cutover-audit',
+		reason: 'scheduled-refresh',
 		now,
 	})
 	await replaceInboundDueOwnerHint({
 		db: env.APP_DB,
-		userId: liveUserId,
+		userId: laterUserId,
 		dueAt: '2026-08-03T11:00:00.000Z',
 		reason: 'mailbox-due-work',
 		now,
 	})
 	await Promise.all([
-		rpcFor(auditUserId).getInboundDueWorkHint({ ownerId: auditUserId }),
-		rpcFor(liveUserId).getInboundDueWorkHint({ ownerId: liveUserId }),
+		rpcFor(earlierUserId).getInboundDueWorkHint({ ownerId: earlierUserId }),
+		rpcFor(laterUserId).getInboundDueWorkHint({ ownerId: laterUserId }),
 	])
 	const clockValues = [0, 0, 10_001, 10_001]
 
@@ -213,14 +245,14 @@ test('sweep time budget processes live work before an older cutover audit', asyn
 		WHERE user_id IN (?, ?)
 		ORDER BY user_id`,
 	)
-		.bind(auditUserId, liveUserId)
+		.bind(earlierUserId, laterUserId)
 		.all<{ user_id: string; reason: string }>()
 	expect(rows.results).toEqual([
-		{ user_id: auditUserId, reason: 'cutover-audit' },
+		{ user_id: laterUserId, reason: 'mailbox-due-work' },
 	])
 })
 
-test('cutover audit sweep clears a healthy Mailbox and retains its next due work', async () => {
+test('sweep clears a healthy Mailbox hint and retains pending due work', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
 	const now = new Date('2026-08-03T12:00:00.000Z')
 	const dueAt = now.toISOString()
@@ -245,7 +277,7 @@ test('cutover audit sweep clears a healthy Mailbox and retains its next due work
 			db: env.APP_DB,
 			userId,
 			dueAt,
-			reason: 'cutover-audit',
+			reason: 'scheduled-refresh',
 			now,
 		})
 		await rpcFor(userId).getInboundDueWorkHint({ ownerId: userId })

--- a/packages/worker/src/email/reconcile-inbound-deliveries.ts
+++ b/packages/worker/src/email/reconcile-inbound-deliveries.ts
@@ -148,12 +148,10 @@ export async function sweepStaleInboundDeliveries(input: {
 		...userRows.map((row) => ({
 			user_id: row.userId,
 			due_at: row.dueAt,
-			priority: row.reason === 'cutover-audit' ? 1 : 0,
 		})),
-		...(systemDue ? [{ ...systemDue, priority: 0 }] : []),
+		...(systemDue ? [systemDue] : []),
 	].sort(
 		(left, right) =>
-			left.priority - right.priority ||
 			left.due_at.localeCompare(right.due_at) ||
 			left.user_id.localeCompare(right.user_id),
 	)

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -124,13 +124,13 @@ export type PlanLimits = {
 	maxEmailSendsPerDay: number
 	/** Maximum stored inbound email receipts per UTC day. */
 	maxEmailReceivesPerDay: number
-	/** Maximum stored email messages (rows in email_messages). */
+	/** Maximum stored email messages (Mailbox DO email_messages rows). */
 	maxStoredEmailMessages: number
 	/**
 	 * Maximum raw MIME bytes for a single stored email message. Hard
 	 * platform bound: raw MIME lives in EMAIL_BLOBS, but extracted text/html
-	 * bodies are still stored on the email_messages row (worst case ~2x
-	 * raw), and D1 caps rows at 2 MB — so keep this well under ~1 MB
+	 * bodies are still stored on the Mailbox email_messages row (worst case
+	 * ~2x raw), and SQLite rows cap at 2 MB — so keep this well under ~1 MB
 	 * regardless of plan.
 	 */
 	maxEmailMessageBytes: number

--- a/packages/worker/src/mcp/capabilities/admin/admin-mailbox-maintenance.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-mailbox-maintenance.ts
@@ -130,7 +130,7 @@ const deleteMessageResultSchema = z.object({
 	allCapturedBlobsAbsent: z
 		.boolean()
 		.describe(
-			'True when every authoritative Mailbox or owner-fenced D1 fallback blob key is absent via head.',
+			'True when every captured authoritative Mailbox blob key is absent via head.',
 		),
 })
 

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-meter-parity.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-meter-parity.node.test.ts
@@ -38,14 +38,6 @@ function createCapabilityTestDb() {
 			created_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z',
 			updated_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z'
 		);
-		CREATE TABLE entitlement_daily_counters (
-			user_id TEXT NOT NULL,
-			resource TEXT NOT NULL,
-			day TEXT NOT NULL,
-			count INTEGER NOT NULL DEFAULT 0,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (user_id, resource, day)
-		);
 		CREATE TABLE package_service_states (
 			user_id TEXT NOT NULL,
 			package_id TEXT NOT NULL,
@@ -117,7 +109,9 @@ test('admin_user_meter_parity returns null for missing users and omits lease sec
 		ctx,
 	)
 	expect(present.report?.stableUserId).toBe(stableUserId)
-	expect(present.report?.daily.mirrorRetired).toBe(false)
+	expect(
+		present.report?.daily.resources.every((row) => row.needsBootstrap),
+	).toBe(true)
 	expect(present.report?.deletion.deletingAtParity).toBe(true)
 	expect(present.report?.deletion.activeLeaseCount).toBe(1)
 	expect(mockModule.logAuditEvent).toHaveBeenCalledWith(

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-meter-parity.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-meter-parity.ts
@@ -11,13 +11,10 @@ import {
 
 const dailyResourceSchema = z.enum(dailyEntitlementResources)
 
-const dailyResourceParitySchema = z.object({
+const dailyResourceReadSchema = z.object({
 	resource: dailyResourceSchema,
-	d1Count: z.number().int().nonnegative().nullable(),
 	meterCount: z.number().int().nonnegative().nullable(),
 	needsBootstrap: z.boolean(),
-	delta: z.number().int().nullable(),
-	parity: z.boolean(),
 })
 
 const storageParitySchema = z.object({
@@ -69,16 +66,14 @@ const deletionParitySchema = z.object({
 const reportSchema = z.object({
 	generatedAt: z.string(),
 	stableUserId: stableUserIdSchema,
-	daily: z.object({
-		day: z.string(),
-		mirrorRetired: z
-			.boolean()
-			.describe(
-				'True when D1 entitlement_daily_counters is absent. Daily gate then reports meter counts only; d1Count/delta are null and parity stays true (no D1 comparison).',
-			),
-		resources: z.array(dailyResourceParitySchema),
-		mismatchCount: z.number().int().nonnegative(),
-	}),
+	daily: z
+		.object({
+			day: z.string(),
+			resources: z.array(dailyResourceReadSchema),
+		})
+		.describe(
+			'UserMeter-only daily counter reads. The D1 entitlement_daily_counters mirror was dropped by migration 0126; no D1 comparison exists.',
+		),
 	storage: storageParitySchema,
 	packageServices: packageServicesParitySchema,
 	deletion: deletionParitySchema,
@@ -98,20 +93,17 @@ export const adminUserMeterParityCapability = defineDomainCapability(
 		...adminCapabilityAccess,
 		name: 'admin_user_meter_parity',
 		description:
-			'Read-only production verification report for one user: UserMeter daily counters plus D1↔UserMeter parity for storage bytes, package-service liveness, and deletion state. Daily rows report meter counts only when `mirrorRetired: true`. Deletion parity reports `deletingAtParity` (D1 vs meter tombstone) and `activeLeaseCount` (active DO write leases in UserMeter; D1 account_write_leases is quiescent and not queried). Never bootstraps or writes parity state; returns counts and parity only (no lease tokens/holders or email content). Admin-only.',
+			'Read-only production verification report for one user: UserMeter daily counter reads (meter-only; the D1 mirror is dropped) plus D1↔UserMeter parity for storage bytes, package-service liveness, and deletion state. Deletion parity reports `deletingAtParity` (D1 vs meter tombstone) and `activeLeaseCount` (active DO write leases in UserMeter; D1 account_write_leases is quiescent and not queried). Never bootstraps or writes parity state; returns counts and parity only (no lease tokens/holders or email content). Admin-only.',
 		keywords: [
 			'admin',
 			'user meter',
 			'parity',
-			'cutover',
 			'daily counters',
 			'storage bytes',
 			'package services',
 			'write leases',
 			'deletion',
-			'mirror',
 			'bootstrap',
-			'retired',
 		],
 		inputSchema,
 		outputSchema,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove dead migration-era special-casing left behind after the Mailbox legacy graph drop (0135) and the daily-counter mirror drop (0126).

## Summary

- `email_inbound_due_owners`: drop `cutover-audit` reason special-casing from the hint upsert, list ordering, and sweep priority — the seeded audit backlog was required empty by 0135 and no writer produces that reason anymore. Pure due-time ordering now.
- `admin_user_meter_parity`: daily section is meter-only. The `entitlement_daily_counters` D1 mirror was dropped by 0126 in production, so the `mirrorRetired` probe and the D1 comparison branch were dead code kept alive only by test fixtures that recreated the dropped table.
- Stale wording fixes: mailbox delete-message blob description no longer claims a "D1 fallback blob key"; plan limit comments now reference Mailbox DO SQLite instead of D1 rows.
- Docs updated to match (`entitlements.md`, `data-storage.md`).

The physical `idx_email_inbound_due_owners_priority_due_at` expression index stays (created by immutable migration 0133; unused by the simplified queries and harmless).

## Testing

- `user-meter-parity.node.test.ts` + `admin-user-meter-parity.node.test.ts`: 7 passed
- `inbound-due-owners.workers.test.ts`: 6 passed (tests rewritten for pure due-time ordering, hint merge semantics, and budget deferral)
- `npm run typecheck` green; full validate in CI

## System recap

```text
SYSTEM RECAP
mode: recap
overall: composes
risk: Low
primitives:
  - email inbound reconciliation (due-owner ordering simplification)
  - admin capabilities (parity report daily section reshape)
paths:
  - packages/worker/src/email/inbound-due-owners.ts
  - packages/worker/src/email/reconcile-inbound-deliveries.ts
  - packages/worker/src/admin/user-meter-parity.ts
  - packages/worker/src/mcp/capabilities/admin/*
notes:
  - Net -288 lines; removes dead branches only reachable by recreating dropped tables
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ac34c46-4d65-4213-9ad3-206664b60671?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ac34c46-4d65-4213-9ad3-206664b60671&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Daily usage reporting now shows meter counts and bootstrap status without legacy comparison data.
  * Inbound reconciliation work is ordered consistently by due time and owner for more predictable processing.
  * Clarified storage limits, email message handling, and administrative reporting behavior in the documentation.
* **Bug Fixes**
  * Removed outdated mirror-related reporting and prioritization behavior from administrative tools.
  * Improved handling of pending inbound work during bounded reconciliation sweeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->