### PR TITLE
docs: close out the UserMeter expand-phase language

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -232,8 +232,7 @@ Durable Object export behavior:
   columns were dropped by migration 0139; authoritative storage bytes live in
   UserMeter. Retention is self-enforced inside the DO (seven UTC days of counter
   and inbound-delivery-claim rows); storage-byte and package-service liveness
-  rows are not time-pruned. See
-  [Entitlements](./entitlements.md#usermeter-expand-phase).
+  rows are not time-pruned. See [Entitlements](./entitlements.md#usermeter).
 - `Mailbox` is the sole authoritative USER email graph export. It exports
   threads, messages, attachments, and delivery events through the account-export
   `mailbox` section (`exportMailbox` RPC; keyset pagination with prefixed
@@ -290,7 +289,7 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   `storage_bytes_state` (schema v4) drives storage-byte enforcement;
   `package_service_states` (schema v5) is the authoritative running-count source
   for `package_services` / `service_start` — see
-  [Entitlements](./entitlements.md#usermeter-expand-phase). Migration 0135
+  [Entitlements](./entitlements.md#usermeter). Migration 0135
   removed every retired Mailbox parity, replay, backfill, and soak column and
   its discovery index. A post-deploy production `pragma_table_xinfo('users')`
   query for `mailbox_parity_%` columns returned zero rows, so no follow-up
@@ -607,7 +606,7 @@ SQLite ownership (schema version tracked in `user_meter_meta`; current version
   retired mirror, dropped by migration 0139; the reconcile lane sweeps by
   `stable_user_id` keyset from `d1_storage_reconcile_cursor`. StorageRunner
   bucket estimates stay outside this row (see
-  [Entitlements](./entitlements.md#usermeter-expand-phase)).
+  [Entitlements](./entitlements.md#usermeter)).
 - `package_service_states` — per-service liveness rows (`package_id`,
   `service_name`, `status`, `started_at`, `source_updated_at`, monotonic
   `revision`, `updated_at`; primary key `(package_id, service_name)`). Added in
@@ -643,7 +642,7 @@ account export/deletion inventory paths never read or write
 `#1133` / `#1134`, then migration `0126-drop-entitlement-daily-counters.sql`).
 The final live schema has no table or day index; `admin_user_meter_parity`
 reports meter-only daily counts. See
-[Entitlements](./entitlements.md#usermeter-expand-phase).
+[Entitlements](./entitlements.md#usermeter).
 
 **Daily cold bootstrap:** a missing `(resource, day)` row returns
 `needs_bootstrap`. The service calls `initialize({ count: 0 })` with
@@ -975,7 +974,7 @@ via `durableObjectNameFromParts`); domain helpers such as
 - `UserMeter` — `userMeterDurableObjectName(userId)` → `idFromName(userId)`. One
   daily-entitlement meter DO per user (untrimmed stable id, same as `RunLog`),
   plus optional schema-v4 D1 storage-byte shadow and schema-v5 package-service
-  liveness shadow. See [Entitlements](./entitlements.md#usermeter-expand-phase).
+  liveness shadow. See [Entitlements](./entitlements.md#usermeter).
 - `StripePlanRefresh` — `stripePlanRefreshDurableObjectName(userId)` →
   `idFromName(userId)`. One ephemeral, one-shot reconciliation alarm per user;
   checkout and subscription webhook activity arm it as a backstop to the
@@ -1049,7 +1048,7 @@ Bindings are configured per environment in `packages/worker/wrangler.jsonc`
 - `RUN_LOG` (Durable Objects; per-user run records — see
   [Run records](./run-records.md))
 - `USER_METER` (Durable Objects; per-user daily entitlement counters — see
-  [Entitlements](./entitlements.md#usermeter-expand-phase))
+  [Entitlements](./entitlements.md#usermeter))
 - `STRIPE_PLAN_REFRESH` (Durable Objects; per-user, activity-driven Stripe plan
   reconciliation alarms)
 - `MAILBOX` (Durable Objects; sole per-user email graph, inbound-ledger,
@@ -1438,10 +1437,9 @@ post-deploy `POST /__maintenance/reindex-capabilities` sweep keyset-pages every
 memory, job, and saved package from D1 (200 rows per page) and upserts it into
 the owner's namespace; it also rebuilds builtins in their reserved namespace.
 The deploy is not considered migrated until every phase reports no `error` or
-`failed` vectors. Remove the default-namespace read in a follow-up contract
-deploy only after a production full sweep succeeds and the next deploy confirms
-normal namespaced search. Vectors are derived from D1, so no canonical data is
-moved or deleted during this migration.
+`failed` vectors. Search paths query only per-account namespaces (plus the
+reserved builtin namespace); no default-namespace read remains. Vectors are
+derived from D1, so no canonical data is moved or deleted during reindexing.
 
 ### `entity_sources` and package import contracts
 

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -289,12 +289,12 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   `storage_bytes_state` (schema v4) drives storage-byte enforcement;
   `package_service_states` (schema v5) is the authoritative running-count source
   for `package_services` / `service_start` — see
-  [Entitlements](./entitlements.md#usermeter). Migration 0135
-  removed every retired Mailbox parity, replay, backfill, and soak column and
-  its discovery index. A post-deploy production `pragma_table_xinfo('users')`
-  query for `mailbox_parity_%` columns returned zero rows, so no follow-up
-  `DROP COLUMN` migration is required. Inbound email routing does not
-  reverse-resolve stable ids at all — it uses the indexed username lookup
+  [Entitlements](./entitlements.md#usermeter). Migration 0135 removed every
+  retired Mailbox parity, replay, backfill, and soak column and its discovery
+  index. A post-deploy production `pragma_table_xinfo('users')` query for
+  `mailbox_parity_%` columns returned zero rows, so no follow-up `DROP COLUMN`
+  migration is required. Inbound email routing does not reverse-resolve stable
+  ids at all — it uses the indexed username lookup
   (`findPublicUserIdentityByUsername`). Contextless paths resolve stable ids
   with one indexed point read on `users.stable_user_id` (for example
   `findUserAccountByStableUserId`).

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -114,9 +114,9 @@ two compute surfaces `usage-metering.md` already observes:
 Both consume only when the context has a `userId`, matching the usage-metering
 rule that events without an owning user are skipped. Daily consumption is
 authoritative in the per-user `UserMeter` Durable Object; see
-[UserMeter (expand phase)](#usermeter-expand-phase).
+[UserMeter](#usermeter).
 
-## UserMeter (expand phase)
+## UserMeter
 
 Daily rate-style resources (`email_sends_per_day`, `email_receives_per_day`,
 `execute_calls_per_day`, `outbound_fetches_per_day`) are **authoritative in the
@@ -147,7 +147,7 @@ point gate. All callers (including email paths) supply `env`; UserMeter is
 authoritative for all lease acquire/held/release/count operations. D1
 `account_write_leases` is quiescent — no new rows are written and the table is
 not queried on any runtime path. See
-[Account-deletion write fencing — UserMeter authority](#account-deletion-write-fencing--usermeter-authority-expand-phase-slice-5-phase-b).
+[Account-deletion write fencing — UserMeter authority](#account-deletion-write-fencing--usermeter-authority-contract-complete-2026-08-03).
 
 StorageRunner bucket `estimatedBytes` and the per-bucket inventory in
 `user_storage_buckets` stay a **separate** quota component. StorageRunner write
@@ -668,7 +668,7 @@ Rules:
      physical cross-surface sum via `calculateUserD1StorageBytes` and applies it
      to UserMeter via a revision-guarded CAS (never clobbers a live
      reservation); no byte values are written back to D1 — see
-     [UserMeter (expand phase)](#usermeter-expand-phase).
+     [UserMeter](#usermeter).
 
   2. **StorageRunner bucket estimates (separate):** each bucket exposes
      `estimatedBytes`; inventory rows persist the latest measurement on


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Final docs pass for the post-cutover contract program: the storage, package-service, write-lease, and daily-counter contracts are all complete, so the architecture docs should stop describing UserMeter as mid-expand.

## Summary

- Retitle `## UserMeter (expand phase)` to `## UserMeter` and update all nine `#usermeter-expand-phase` anchors across `entitlements.md` and `data-storage.md`
- Fix the stale write-fencing anchor that still pointed at the pre-contract heading
- Rewrite the Vectorize migration note that described a pending "remove the default-namespace read" contract step — search paths are namespaced-only in code today

## Testing

- `npm run docs:check-temporal` green; format green; docs-only change (CI Validate covers the rest)

## System recap

```text
SYSTEM RECAP
mode: recap
overall: composes
risk: Low (docs only)
paths:
  - docs/contributing/architecture/entitlements.md
  - docs/contributing/architecture/data-storage.md
```

## Conductor report

STATUS: ready pending CI. Last wave of the cleanup program.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ac34c46-4d65-4213-9ad3-206664b60671?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ac34c46-4d65-4213-9ad3-206664b60671&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated storage documentation links to use the current UserMeter reference.
  * Clarified that namespaced Vectorize search is active and no longer uses the default namespace.
  * Updated entitlement documentation links to reference the renamed UserMeter section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->