### PR TITLE
fix(dr): fail closed on unrestorable D1 backups

### DIFF
--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -373,9 +373,12 @@ Hourly freshness does not SHA-256 the SQL bytes; drills do. Page yourself on
 `freshness-unrestorable` (the SQL contains statements D1 cannot import),
 `freshness-stale`, size-ceiling hits, missing manifests or required SQL stats,
 seal failures, `backup-unrestorable-statements`, or unexpected disablement of
-the enable gates. An unrestorable export never receives a canonical day
-manifest; catch-up retries can re-export the day after the oversized row or
-write path is bounded.
+the enable gates. Post-cutover unrestorable exports never receive a canonical
+day manifest; catch-up retries can re-export the day after the oversized row or
+write path is bounded. Historical bad days may already have canonical and full
+manifests; immutable media is intentionally left unchanged, so freshness,
+dashboard, drill, and production-restore gates remain essential until it ages
+out.
 
 ## Offline CLI fallback
 

--- a/docs/contributing/disaster-recovery.md
+++ b/docs/contributing/disaster-recovery.md
@@ -370,8 +370,12 @@ config, and expect users to reauthorize OAuth and remote connectors.
 | Hourly `:45`             | Control plane     | D1 freshness (identity, size ceiling, manifest age ≤26h, R2 size/ETag) + seal recent complete days |
 
 Hourly freshness does not SHA-256 the SQL bytes; drills do. Page yourself on
-`freshness-stale`, size-ceiling hits, missing manifests, seal failures,
-`backup-unrestorable-statements`, or unexpected disablement of the enable gates.
+`freshness-unrestorable` (the SQL contains statements D1 cannot import),
+`freshness-stale`, size-ceiling hits, missing manifests or required SQL stats,
+seal failures, `backup-unrestorable-statements`, or unexpected disablement of
+the enable gates. An unrestorable export never receives a canonical day
+manifest; catch-up retries can re-export the day after the oversized row or
+write path is bounded.
 
 ## Offline CLI fallback
 

--- a/packages/backup-control-plane/backup-control-plane-test-support.ts
+++ b/packages/backup-control-plane/backup-control-plane-test-support.ts
@@ -86,6 +86,7 @@ export class MemoryBucket {
 	readonly puts: Array<{ key: string; options: R2PutOptions }> = []
 	private readonly objects = new Map<string, Uint8Array>()
 	private readonly reportedSizes = new Map<string, number>()
+	private readonly failedGets = new Set<string>()
 	private nextPutRace: { key: string; bytes: Uint8Array } | undefined
 	private lockPolicyEnabled = false
 
@@ -136,6 +137,7 @@ export class MemoryBucket {
 	}
 
 	async get(key: string): Promise<R2ObjectBody | null> {
+		if (this.failedGets.has(key)) throw new Error('simulated R2 get failure')
 		const bytes = this.objects.get(key)
 		if (!bytes) return null
 		const metadata = this.metadata(key)
@@ -158,6 +160,10 @@ export class MemoryBucket {
 
 	setReportedSize(key: string, size: number): void {
 		this.reportedSizes.set(key, size)
+	}
+
+	failGetFor(key: string): void {
+		this.failedGets.add(key)
 	}
 
 	raceOnNextPut(key: string, value: string): void {

--- a/packages/backup-control-plane/backup-control-plane-test-support.ts
+++ b/packages/backup-control-plane/backup-control-plane-test-support.ts
@@ -131,6 +131,10 @@ export class MemoryBucket {
 		return this.objects.has(key) ? this.metadata(key) : null
 	}
 
+	async delete(key: string): Promise<void> {
+		this.objects.delete(key)
+	}
+
 	async get(key: string): Promise<R2ObjectBody | null> {
 		const bytes = this.objects.get(key)
 		if (!bytes) return null
@@ -342,11 +346,11 @@ export class RetryAfterCommitStep implements BackupRuntimeStep {
 
 export class CachedUploadStep implements BackupRuntimeStep {
 	private readonly cache = new Map<string, unknown>()
-	private readonly afterUpload: () => void
+	private readonly afterUpload: () => void | Promise<void>
 	private readonly afterFinalization?: () => Promise<void>
 
 	constructor(
-		afterUpload: () => void,
+		afterUpload: () => void | Promise<void>,
 		afterFinalization?: () => Promise<void>,
 	) {
 		this.afterUpload = afterUpload
@@ -371,7 +375,7 @@ export class CachedUploadStep implements BackupRuntimeStep {
 				: callback!
 		const value = await execute()
 		this.cache.set(name, value)
-		if (name === 'stream-export-to-immutable-r2') this.afterUpload()
+		if (name === 'stream-export-to-immutable-r2') await this.afterUpload()
 		if (
 			name === 'verify-stored-object-and-write-immutable-manifest' &&
 			this.afterFinalization
@@ -379,6 +383,43 @@ export class CachedUploadStep implements BackupRuntimeStep {
 			await this.afterFinalization()
 		}
 		return value
+	}
+
+	async sleep(): Promise<void> {}
+}
+
+export class PreStatsUploadStep implements BackupRuntimeStep {
+	private readonly cache = new Map<string, unknown>()
+
+	async do<T>(
+		name: string,
+		config: unknown,
+		callback: () => Promise<T>,
+	): Promise<T>
+	async do<T>(name: string, callback: () => Promise<T>): Promise<T>
+	async do<T>(
+		name: string,
+		configOrCallback: unknown,
+		callback?: () => Promise<T>,
+	): Promise<T> {
+		if (this.cache.has(name)) return this.cache.get(name) as T
+		const execute =
+			typeof configOrCallback === 'function'
+				? (configOrCallback as () => Promise<T>)
+				: callback!
+		const value = await execute()
+		const persisted =
+			name === 'stream-export-to-immutable-r2' &&
+			value !== null &&
+			typeof value === 'object'
+				? Object.fromEntries(
+						Object.entries(value).filter(
+							([key]) => key !== 'sqlStatementStats',
+						),
+					)
+				: value
+		this.cache.set(name, persisted)
+		return persisted as T
 	}
 
 	async sleep(): Promise<void> {}

--- a/packages/backup-control-plane/backup-control-plane-test-support.ts
+++ b/packages/backup-control-plane/backup-control-plane-test-support.ts
@@ -6,6 +6,11 @@ import {
 	canonicalBackupManifestPayload,
 	type BackupManifestPayload,
 } from '@kody-internal/shared/backup-manifest.ts'
+import {
+	backupSqlStatsKey,
+	backupSqlStatsSchemaVersion,
+	type BackupSqlStats,
+} from '@kody-internal/shared/backup-sql-stats.ts'
 import { type BackupRuntimeStep } from './backup-runtime.ts'
 import { type DurableExportStep } from './durable-export.ts'
 import { BackupError, objectKeyForBookmark } from './backup-policy.ts'
@@ -178,6 +183,36 @@ export const DATABASE_ID = '22222222-2222-4222-8222-222222222222'
 export const DRILL_ACCOUNT_ID = '33333333-3333-4333-8333-333333333333'
 export const BASELINE_SHA256 = 'b'.repeat(64)
 const manifestSigningKeys = generateKeyPairSync('ed25519')
+
+export function badSqlStatsFixture(
+	day: string,
+	objectKey: string,
+): BackupSqlStats {
+	return {
+		schemaVersion: backupSqlStatsSchemaVersion,
+		day,
+		objectKey,
+		maxStatementBytes: 1_495_663,
+		oversizedStatementCount: 1,
+		importStatementLimitBytes: 100_000,
+	}
+}
+
+export async function putSqlStatsFixture(
+	bucket: MemoryBucket,
+	day: string,
+	objectKey: string,
+	options: { oversized?: boolean } = {},
+): Promise<void> {
+	const stats = options.oversized
+		? badSqlStatsFixture(day, objectKey)
+		: {
+				...badSqlStatsFixture(day, objectKey),
+				maxStatementBytes: 50_000,
+				oversizedStatementCount: 0,
+			}
+	await bucket.put(backupSqlStatsKey(objectKey), JSON.stringify(stats))
+}
 
 export function environment(bucket = new MemoryBucket()): BackupEnvironment {
 	return {

--- a/packages/backup-control-plane/backup-runtime.node.test.ts
+++ b/packages/backup-control-plane/backup-runtime.node.test.ts
@@ -287,6 +287,60 @@ test('workflow retry reuses an upload committed before step persistence and writ
 	assert.ok(stats.maxStatementBytes > 0)
 })
 
+test('oversized SQL writes stats then fails retryably without a day manifest', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
+	const bucket = new MemoryBucket()
+	const env = environment(bucket)
+	const payload = backupPayload(env, new Date('2026-07-31T02:15:00Z'))
+	const objectKey = objectKeyForBookmark(payload.objectPrefix, 'bookmark-1')
+	const sql = `INSERT INTO t VALUES ('${'x'.repeat(100_001)}');`
+
+	await assert.rejects(
+		runBackupRuntime(
+			env,
+			{
+				instanceId: workflowInstanceId(DATABASE_ID, payload.day),
+				payload,
+				timestamp: new Date('2026-07-31T02:15:01Z'),
+			},
+			new CachedUploadStep(() => undefined),
+			{
+				api: {
+					fetcher: async (input) =>
+						String(input).endsWith('/export')
+							? exportEnvelope('complete')
+							: identityEnvelope(1_000),
+					sleep: async () => undefined,
+				},
+				downloadFetcher: async () =>
+					new Response(sql, {
+						headers: { 'content-length': String(sql.length) },
+					}),
+			},
+		),
+		(error: unknown) =>
+			error instanceof BackupError &&
+			error.code === 'backup-unrestorable-statements' &&
+			error.retryable,
+	)
+
+	const statsObject = await bucket.get(`${objectKey}.stats.json`)
+	assert.notEqual(statsObject, null)
+	const stats = (await statsObject!.json()) as {
+		oversizedStatementCount: number
+	}
+	assert.equal(stats.oversizedStatementCount, 1)
+	assert.equal(await bucket.head(payload.manifestKey), null)
+	const events = consoleError.mock.calls.map(([record]) =>
+		JSON.parse(String(record)),
+	) as Array<{ event: string }>
+	assert.ok(
+		events.some(({ event }) => event === 'backup-unrestorable-statements'),
+	)
+	assert.ok(events.some(({ event }) => event === 'backup-failure'))
+})
+
 test('initial upload ignores a stale cached signed URL and refreshes it in the callback', async () => {
 	const bucket = new MemoryBucket()
 	const env = environment(bucket)

--- a/packages/backup-control-plane/backup-runtime.node.test.ts
+++ b/packages/backup-control-plane/backup-runtime.node.test.ts
@@ -15,8 +15,10 @@ import {
 	CachedUploadStep,
 	DATABASE_ID,
 	MemoryBucket,
+	PreStatsUploadStep,
 	RetryAfterCommitStep,
 	RetryUploadStep,
+	badSqlStatsFixture,
 	environment,
 	exportEnvelope,
 	identityEnvelope,
@@ -339,6 +341,113 @@ test('oversized SQL writes stats then fails retryably without a day manifest', a
 		events.some(({ event }) => event === 'backup-unrestorable-statements'),
 	)
 	assert.ok(events.some(({ event }) => event === 'backup-failure'))
+})
+
+test('cached pre-stats uploads are allowed only for legacy backup days', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
+	const consoleLog = vi.spyOn(console, 'log')
+	consoleLog.mockImplementation(() => undefined)
+	const options = {
+		api: {
+			fetcher: async (input: RequestInfo | URL) =>
+				String(input).endsWith('/export')
+					? exportEnvelope('complete')
+					: identityEnvelope(1_000),
+			sleep: async () => undefined,
+		},
+		downloadFetcher: async () =>
+			new Response('valid', { headers: { 'content-length': '5' } }),
+	}
+
+	const legacyBucket = new MemoryBucket()
+	const legacyEnv = environment(legacyBucket)
+	const legacyPayload = backupPayload(
+		legacyEnv,
+		new Date('2026-07-27T02:15:00Z'),
+	)
+	await runBackupRuntime(
+		legacyEnv,
+		{
+			instanceId: workflowInstanceId(DATABASE_ID, legacyPayload.day),
+			payload: legacyPayload,
+			timestamp: new Date('2026-07-27T02:15:01Z'),
+		},
+		new PreStatsUploadStep(),
+		options,
+	)
+	assert.notEqual(await legacyBucket.head(legacyPayload.manifestKey), null)
+	const legacyEvents = consoleLog.mock.calls.map(([record]) =>
+		JSON.parse(String(record)),
+	) as Array<{ event: string }>
+	assert.ok(
+		legacyEvents.some(({ event }) => event === 'backup-stats-legacy-missing'),
+	)
+
+	const requiredBucket = new MemoryBucket()
+	const requiredEnv = environment(requiredBucket)
+	const requiredPayload = backupPayload(
+		requiredEnv,
+		new Date('2026-07-28T02:15:00Z'),
+	)
+	await assert.rejects(
+		runBackupRuntime(
+			requiredEnv,
+			{
+				instanceId: workflowInstanceId(DATABASE_ID, requiredPayload.day),
+				payload: requiredPayload,
+				timestamp: new Date('2026-07-28T02:15:01Z'),
+			},
+			new PreStatsUploadStep(),
+			options,
+		),
+		(error: unknown) =>
+			error instanceof BackupError &&
+			error.code === 'backup-sql-stats-missing' &&
+			error.retryable,
+	)
+	assert.equal(await requiredBucket.head(requiredPayload.manifestKey), null)
+})
+
+test('conflicting immutable SQL stats prevent manifest publication', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
+	const bucket = new MemoryBucket()
+	const env = environment(bucket)
+	const payload = backupPayload(env, new Date('2026-07-31T02:15:00Z'))
+	const objectKey = objectKeyForBookmark(payload.objectPrefix, 'bookmark-1')
+
+	await assert.rejects(
+		runBackupRuntime(
+			env,
+			{
+				instanceId: workflowInstanceId(DATABASE_ID, payload.day),
+				payload,
+				timestamp: new Date('2026-07-31T02:15:01Z'),
+			},
+			new CachedUploadStep(async () => {
+				await bucket.put(
+					`${objectKey}.stats.json`,
+					JSON.stringify(badSqlStatsFixture(payload.day, objectKey)),
+				)
+			}),
+			{
+				api: {
+					fetcher: async (input) =>
+						String(input).endsWith('/export')
+							? exportEnvelope('complete')
+							: identityEnvelope(1_000),
+					sleep: async () => undefined,
+				},
+				downloadFetcher: async () =>
+					new Response('valid', { headers: { 'content-length': '5' } }),
+			},
+		),
+		(error: unknown) =>
+			error instanceof BackupError &&
+			error.code === 'backup-sql-stats-conflict',
+	)
+	assert.equal(await bucket.head(payload.manifestKey), null)
 })
 
 test('initial upload ignores a stale cached signed URL and refreshes it in the callback', async () => {

--- a/packages/backup-control-plane/backup-runtime.ts
+++ b/packages/backup-control-plane/backup-runtime.ts
@@ -1,4 +1,9 @@
 import {
+	backupSqlStatsKey,
+	backupSqlStatsSchemaVersion,
+} from '@kody-internal/shared/backup-sql-stats.ts'
+
+import {
 	refreshCompletedD1Export,
 	verifySourceDatabaseIdentity,
 	type ApiOptions,
@@ -30,9 +35,8 @@ import { signBackupManifest } from './manifest-signing.ts'
 /**
  * Persist per-object statement-length statistics next to the SQL object and
  * log them. An oversized statement means the object cannot be re-imported
- * through the D1 import API (SQLITE_TOOBIG); the backup completes, but
- * the condition is logged with failure status so observability and health
- * checks can alert on an un-restorable day.
+ * through the D1 import API (SQLITE_TOOBIG), so the Workflow fails before it
+ * can publish a canonical day manifest.
  */
 async function recordSqlStatementStats(input: {
 	env: BackupEnvironment
@@ -44,6 +48,24 @@ async function recordSqlStatementStats(input: {
 	const { stats } = input
 	// Step replays from pre-stats deployments have no measurements to record.
 	if (!stats) return
+	const body = JSON.stringify({
+		schemaVersion: backupSqlStatsSchemaVersion,
+		day: input.day,
+		objectKey: input.objectKey,
+		maxStatementBytes: stats.maxStatementBytes,
+		oversizedStatementCount: stats.oversizedStatementCount,
+		importStatementLimitBytes: stats.limit,
+	})
+	// An existing object from a replayed step wins and is left alone (the prefix
+	// is under the bucket's immutable lock, which rejects puts on existing keys
+	// with error 10069 before the conditional is evaluated).
+	await input.env.BACKUP_BUCKET.put(backupSqlStatsKey(input.objectKey), body, {
+		onlyIf: { etagDoesNotMatch: '*' },
+		httpMetadata: { contentType: 'application/json' },
+	}).catch((error: unknown) => {
+		if (isBucketLockPolicyPutError(error)) return null
+		throw error
+	})
 	safeLog({
 		event: 'backup-sql-stats',
 		status: stats.oversizedStatementCount > 0 ? 'failure' : 'success',
@@ -63,26 +85,12 @@ async function recordSqlStatementStats(input: {
 			maxStatementBytes: stats.maxStatementBytes,
 			oversizedStatementCount: stats.oversizedStatementCount,
 		})
+		throw new BackupError(
+			'backup-unrestorable-statements',
+			`D1 export contains ${String(stats.oversizedStatementCount)} statement(s) above the import limit`,
+			true,
+		)
 	}
-	const body = JSON.stringify({
-		schemaVersion: 1,
-		day: input.day,
-		objectKey: input.objectKey,
-		maxStatementBytes: stats.maxStatementBytes,
-		oversizedStatementCount: stats.oversizedStatementCount,
-		importStatementLimitBytes: stats.limit,
-	})
-	// The stats object is advisory; an existing object from a replayed step
-	// wins and is left alone (the prefix is under the bucket's immutable
-	// lock, which rejects puts on existing keys with error 10069 before the
-	// conditional is evaluated).
-	await input.env.BACKUP_BUCKET.put(`${input.objectKey}.stats.json`, body, {
-		onlyIf: { etagDoesNotMatch: '*' },
-		httpMetadata: { contentType: 'application/json' },
-	}).catch((error: unknown) => {
-		if (isBucketLockPolicyPutError(error)) return null
-		throw error
-	})
 }
 
 interface BackupRuntimeEvent {
@@ -290,6 +298,18 @@ export async function runBackupRuntime(
 		const completedAt = await step.do('record-completion-time', async () =>
 			new Date().toISOString(),
 		)
+		await step.do(
+			'record-statement-stats',
+			{ retries: { limit: 2, delay: '10 seconds' }, timeout: '2 minutes' },
+			async () =>
+				recordSqlStatementStats({
+					env,
+					day: checkedPayload.day,
+					instanceId: event.instanceId,
+					objectKey: stored.objectKey,
+					stats: stored.sqlStatementStats,
+				}),
+		)
 		const unsignedManifest = {
 			source: {
 				accountId: env.SOURCE_ACCOUNT_ID,
@@ -338,18 +358,6 @@ export async function runBackupRuntime(
 				)
 				return signedManifest
 			},
-		)
-		await step.do(
-			'record-statement-stats',
-			{ retries: { limit: 2, delay: '10 seconds' }, timeout: '2 minutes' },
-			async () =>
-				recordSqlStatementStats({
-					env,
-					day: checkedPayload.day,
-					instanceId: event.instanceId,
-					objectKey: stored.objectKey,
-					stats: stored.sqlStatementStats,
-				}),
 		)
 		safeLog({
 			event: 'backup-success',

--- a/packages/backup-control-plane/backup-runtime.ts
+++ b/packages/backup-control-plane/backup-runtime.ts
@@ -1,6 +1,8 @@
 import {
 	backupSqlStatsKey,
+	backupSqlStatsRequired,
 	backupSqlStatsSchemaVersion,
+	parseBackupSqlStats,
 } from '@kody-internal/shared/backup-sql-stats.ts'
 
 import {
@@ -47,25 +49,71 @@ async function recordSqlStatementStats(input: {
 }): Promise<void> {
 	const { stats } = input
 	// Step replays from pre-stats deployments have no measurements to record.
-	if (!stats) return
-	const body = JSON.stringify({
+	if (!stats) {
+		if (backupSqlStatsRequired(input.day)) {
+			throw new BackupError(
+				'backup-sql-stats-missing',
+				`D1 SQL statement measurements are missing for ${input.day}`,
+				true,
+			)
+		}
+		safeLog({
+			event: 'backup-stats-legacy-missing',
+			status: 'stale-success',
+			day: input.day,
+			instanceId: input.instanceId,
+			objectKey: input.objectKey,
+		})
+		return
+	}
+	const persistedStats = {
 		schemaVersion: backupSqlStatsSchemaVersion,
 		day: input.day,
 		objectKey: input.objectKey,
 		maxStatementBytes: stats.maxStatementBytes,
 		oversizedStatementCount: stats.oversizedStatementCount,
 		importStatementLimitBytes: stats.limit,
-	})
+	}
+	const body = JSON.stringify(persistedStats)
 	// An existing object from a replayed step wins and is left alone (the prefix
 	// is under the bucket's immutable lock, which rejects puts on existing keys
 	// with error 10069 before the conditional is evaluated).
-	await input.env.BACKUP_BUCKET.put(backupSqlStatsKey(input.objectKey), body, {
+	const statsKey = backupSqlStatsKey(input.objectKey)
+	const putResult = await input.env.BACKUP_BUCKET.put(statsKey, body, {
 		onlyIf: { etagDoesNotMatch: '*' },
 		httpMetadata: { contentType: 'application/json' },
 	}).catch((error: unknown) => {
 		if (isBucketLockPolicyPutError(error)) return null
 		throw error
 	})
+	if (putResult === null) {
+		const existing = await input.env.BACKUP_BUCKET.get(statsKey)
+		let existingStats
+		try {
+			existingStats =
+				existing === null
+					? null
+					: parseBackupSqlStats(await existing.json<unknown>())
+		} catch {
+			existingStats = null
+		}
+		if (
+			existingStats === null ||
+			existingStats.schemaVersion !== persistedStats.schemaVersion ||
+			existingStats.day !== persistedStats.day ||
+			existingStats.objectKey !== persistedStats.objectKey ||
+			existingStats.maxStatementBytes !== persistedStats.maxStatementBytes ||
+			existingStats.oversizedStatementCount !==
+				persistedStats.oversizedStatementCount ||
+			existingStats.importStatementLimitBytes !==
+				persistedStats.importStatementLimitBytes
+		) {
+			throw new BackupError(
+				'backup-sql-stats-conflict',
+				'Existing immutable SQL stats differ from the streamed export',
+			)
+		}
+	}
 	safeLog({
 		event: 'backup-sql-stats',
 		status: stats.oversizedStatementCount > 0 ? 'failure' : 'success',

--- a/packages/backup-control-plane/backup-types.ts
+++ b/packages/backup-control-plane/backup-types.ts
@@ -73,9 +73,8 @@ export type ExportState = ExportReady | ExportPending | ExportLost
  * Statement-length statistics for one exported SQL object, measured while
  * streaming during upload. `oversizedStatementCount > 0` means the object is
  * not restorable through the D1 import API (statement too long:
- * SQLITE_TOOBIG); the backup completes, but the condition is logged as a
- * failure-status event and persisted next to the object as
- * `<objectKey>.stats.json` so dashboards and health checks can alert on it.
+ * SQLITE_TOOBIG); the condition is persisted next to the object before the
+ * Workflow fails without writing a day manifest.
  */
 export interface SqlStatementStats {
 	maxStatementBytes: number
@@ -104,8 +103,10 @@ export interface LogRecord {
 		| 'backup-failure'
 		| 'backup-sql-stats'
 		| 'backup-unrestorable-statements'
+		| 'backup-stats-legacy-missing'
 		| 'freshness-success'
 		| 'freshness-stale'
+		| 'freshness-unrestorable'
 		| 'source-size-success'
 		| 'source-size-failure'
 		| 'full-backup-sealed'

--- a/packages/backup-control-plane/control-plane-ui.node.test.ts
+++ b/packages/backup-control-plane/control-plane-ui.node.test.ts
@@ -63,4 +63,14 @@ test('dashboard renders oversized D1 SQL as not restorable with a warning', asyn
 		html,
 		/D1 SQL contains oversized statements and cannot be restored/,
 	)
+
+	await bucket.delete(`${sqlObjectKey}.stats.json`)
+	const [missingStatsStatus] = await collectDayStatuses(env, now)
+	assert.equal(missingStatsStatus?.d1Restorable, false)
+	const missingStatsHtml = await renderDashboard(env, { now })
+	assert.match(missingStatsHtml, /<td class="bad">no<\/td>/)
+	assert.match(
+		missingStatsHtml,
+		/D1 is not restorable: required SQL stats are missing/,
+	)
 })

--- a/packages/backup-control-plane/control-plane-ui.node.test.ts
+++ b/packages/backup-control-plane/control-plane-ui.node.test.ts
@@ -9,6 +9,7 @@ import {
 	environment,
 	identityEnvelope,
 	manifest,
+	putSqlStatsFixture,
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
 import { backupPayload, objectKeyForBookmark } from './backup-policy.ts'
@@ -72,5 +73,20 @@ test('dashboard renders oversized D1 SQL as not restorable with a warning', asyn
 	assert.match(
 		missingStatsHtml,
 		/D1 is not restorable: required SQL stats are missing/,
+	)
+
+	await putSqlStatsFixture(bucket, day, sqlObjectKey)
+	bucket.failGetFor(`${sqlObjectKey}.stats.json`)
+	const [statsReadFailure] = await collectDayStatuses(env, now)
+	assert.equal(statsReadFailure?.d1Verified, true)
+	assert.equal(statsReadFailure?.d1Restorable, false)
+	assert.ok(
+		statsReadFailure?.warnings.includes(
+			'D1 is not restorable: SQL stats lookup failed',
+		),
+	)
+	assert.equal(
+		statsReadFailure?.warnings.includes('D1 manifest unreadable'),
+		false,
 	)
 })

--- a/packages/backup-control-plane/control-plane-ui.node.test.ts
+++ b/packages/backup-control-plane/control-plane-ui.node.test.ts
@@ -1,44 +1,32 @@
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
 
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 
 import {
-	ACCOUNT_ID,
 	MemoryBucket,
 	badSqlStatsFixture,
 	environment,
+	identityEnvelope,
 	manifest,
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
-import { BackupError, backupPayload } from './backup-policy.ts'
+import { backupPayload, objectKeyForBookmark } from './backup-policy.ts'
+import { collectDayStatuses, renderDashboard } from './control-plane-ui.ts'
 import { putImmutableManifest } from './immutable-storage.ts'
-import { assertDrillAccountIsolated, runRestoreDrill } from './restore-drill.ts'
 
-test('restore drill refuses same account and accepts an isolated account', () => {
-	const env = environment()
-	env.DRILL_ACCOUNT_ID = ACCOUNT_ID
-	assert.throws(
-		() => assertDrillAccountIsolated(env),
-		(error: unknown) =>
-			error instanceof BackupError &&
-			error.code === 'drill-account-not-isolated',
-	)
-	assert.doesNotThrow(() => assertDrillAccountIsolated(environment()))
-})
-
-test('restore drill refuses SQL with oversized statement stats before import', async () => {
+test('dashboard renders oversized D1 SQL as not restorable with a warning', async () => {
 	const bucket = new MemoryBucket()
 	const env = environment(bucket)
 	const day = '2026-07-31'
 	const payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
 	const sql = 'CREATE TABLE t(id INTEGER);\n'
+	const sqlObjectKey = objectKeyForBookmark(payload.objectPrefix, 'bookmark-1')
 	const template = manifest({
 		bytes: sql.length,
 		sha256: createHash('sha256').update(sql).digest('hex'),
 		r2Etag: createHash('md5').update(sql).digest('hex'),
 	})
-	const sqlObjectKey = template.payload.sql.objectKey.replace('2026-07-22', day)
 	await bucket.put(sqlObjectKey, sql)
 	await bucket.put(
 		`${sqlObjectKey}.stats.json`,
@@ -59,17 +47,20 @@ test('restore drill refuses SQL with oversized statement stats before import', a
 		}),
 	)
 
-	let fetchCalls = 0
-	await assert.rejects(
-		runRestoreDrill(env, day, {
-			fetcher: async () => {
-				fetchCalls += 1
-				throw new Error('import should not start')
-			},
-		}),
-		(error: unknown) =>
-			error instanceof BackupError &&
-			error.code === 'backup-unrestorable-statements',
+	const now = new Date(`${day}T12:00:00.000Z`)
+	const [status] = await collectDayStatuses(env, now)
+	assert.equal(status?.d1Restorable, false)
+	assert.ok(
+		status?.warnings.some((warning) => warning.includes('cannot be restored')),
 	)
-	assert.equal(fetchCalls, 0)
+
+	const fetcher = vi.spyOn(globalThis, 'fetch')
+	fetcher.mockResolvedValue(identityEnvelope(1_000))
+	const html = await renderDashboard(env, { now })
+	assert.match(html, /<th>D1 restorable<\/th>/)
+	assert.match(html, /<td class="bad">no<\/td>/)
+	assert.match(
+		html,
+		/D1 SQL contains oversized statements and cannot be restored/,
+	)
 })

--- a/packages/backup-control-plane/control-plane-ui.ts
+++ b/packages/backup-control-plane/control-plane-ui.ts
@@ -201,14 +201,14 @@ export async function collectDayStatuses(
 							)
 							break
 						case 'missing':
+							d1Restorable = false
 							warnings.push(
-								'D1 restorability unknown: required SQL stats are missing',
+								'D1 is not restorable: required SQL stats are missing',
 							)
 							break
 						case 'corrupt':
-							warnings.push(
-								'D1 restorability unknown: SQL stats are unreadable',
-							)
+							d1Restorable = false
+							warnings.push('D1 is not restorable: SQL stats are unreadable')
 							break
 						default: {
 							const exhaustive: never = restorability

--- a/packages/backup-control-plane/control-plane-ui.ts
+++ b/packages/backup-control-plane/control-plane-ui.ts
@@ -15,6 +15,7 @@ import { type DrillReport } from './restore-drill.ts'
 import { type ProductionRestoreProgress } from './production-restore.ts'
 import { type RestoreConfirmToken } from './restore-confirm-token.ts'
 import { readFullManifest } from './seal-full-backup.ts'
+import { readSqlRestorability } from './sql-statement-stats.ts'
 import { type EnqueueResult } from './workflow-trigger.ts'
 
 const DASHBOARD_DAY_COUNT = 14
@@ -138,8 +139,9 @@ function statusLabel(
 	ok: boolean | null,
 	presentLabel = 'yes',
 	absentLabel = 'no',
+	unknownLabel = '—',
 ): string {
-	if (ok === null) return '—'
+	if (ok === null) return unknownLabel
 	return ok ? presentLabel : absentLabel
 }
 
@@ -147,6 +149,7 @@ export type DayStatus = {
 	day: string
 	d1Present: boolean
 	d1Verified: boolean | null
+	d1Restorable: boolean | null
 	stagingPresent: boolean
 	sealedPresent: boolean
 	sealedVerified: boolean | null
@@ -169,12 +172,50 @@ export async function collectDayStatuses(
 		).manifestKey
 		let d1Present = false
 		let d1Verified: boolean | null = null
+		let d1Restorable: boolean | null = null
 		try {
 			const manifest = await readManifest(env.BACKUP_BUCKET, d1Key)
 			d1Present = manifest !== null
 			if (manifest !== null) {
 				d1Verified = await verifyBackupManifestSignature(env, manifest)
 				if (!d1Verified) warnings.push('D1 manifest signature invalid')
+				else {
+					const restorability = await readSqlRestorability(
+						env.BACKUP_BUCKET,
+						day,
+						manifest.payload.sql.objectKey,
+					)
+					switch (restorability.kind) {
+						case 'restorable':
+							d1Restorable = true
+							break
+						case 'unrestorable':
+							d1Restorable = false
+							warnings.push(
+								'D1 SQL contains oversized statements and cannot be restored',
+							)
+							break
+						case 'legacy-unknown':
+							warnings.push(
+								'D1 restorability unknown: legacy backup has no SQL stats',
+							)
+							break
+						case 'missing':
+							warnings.push(
+								'D1 restorability unknown: required SQL stats are missing',
+							)
+							break
+						case 'corrupt':
+							warnings.push(
+								'D1 restorability unknown: SQL stats are unreadable',
+							)
+							break
+						default: {
+							const exhaustive: never = restorability
+							throw exhaustive
+						}
+					}
+				}
 			}
 		} catch {
 			d1Verified = null
@@ -205,6 +246,7 @@ export async function collectDayStatuses(
 			day,
 			d1Present,
 			d1Verified,
+			d1Restorable,
 			stagingPresent,
 			sealedPresent,
 			sealedVerified,
@@ -241,6 +283,7 @@ export async function renderDashboard(
 <td><code>${escapeHtml(day.day)}</code></td>
 <td class="${statusClass(day.d1Present)}">${escapeHtml(statusLabel(day.d1Present))}</td>
 <td class="${statusClass(day.d1Verified)}">${escapeHtml(statusLabel(day.d1Verified, 'verified', 'unverified'))}</td>
+<td class="${statusClass(day.d1Restorable)}">${escapeHtml(statusLabel(day.d1Restorable, 'yes', 'no', 'unknown'))}</td>
 <td class="${statusClass(day.stagingPresent)}">${escapeHtml(statusLabel(day.stagingPresent))}</td>
 <td class="${statusClass(day.sealedPresent)}">${escapeHtml(statusLabel(day.sealedPresent))}</td>
 <td class="${statusClass(day.sealedVerified)}">${escapeHtml(statusLabel(day.sealedVerified, 'verified', 'unverified'))}</td>
@@ -282,6 +325,7 @@ ${options.flashHtml ?? ''}
 				<th>Day</th>
 				<th>D1 manifest</th>
 				<th>D1 verified</th>
+				<th>D1 restorable</th>
 				<th>Staging</th>
 				<th>Sealed</th>
 				<th>Seal verified</th>

--- a/packages/backup-control-plane/control-plane-ui.ts
+++ b/packages/backup-control-plane/control-plane-ui.ts
@@ -6,7 +6,7 @@ import {
 } from '@kody-internal/shared/backup-staging.ts'
 
 import { isBackupEnabled, utcDay, backupPayload } from './backup-policy.ts'
-import { type BackupEnvironment } from './backup-types.ts'
+import { type BackupEnvironment, type BackupManifest } from './backup-types.ts'
 import { getD1Database } from './d1-import-api.ts'
 import { verifyBackupFullManifestSignature } from './full-manifest-signing.ts'
 import { readManifest } from './immutable-storage.ts'
@@ -173,53 +173,59 @@ export async function collectDayStatuses(
 		let d1Present = false
 		let d1Verified: boolean | null = null
 		let d1Restorable: boolean | null = null
+		let d1Manifest: BackupManifest | null = null
 		try {
-			const manifest = await readManifest(env.BACKUP_BUCKET, d1Key)
-			d1Present = manifest !== null
-			if (manifest !== null) {
-				d1Verified = await verifyBackupManifestSignature(env, manifest)
+			d1Manifest = await readManifest(env.BACKUP_BUCKET, d1Key)
+			d1Present = d1Manifest !== null
+			if (d1Manifest !== null) {
+				d1Verified = await verifyBackupManifestSignature(env, d1Manifest)
 				if (!d1Verified) warnings.push('D1 manifest signature invalid')
-				else {
-					const restorability = await readSqlRestorability(
-						env.BACKUP_BUCKET,
-						day,
-						manifest.payload.sql.objectKey,
-					)
-					switch (restorability.kind) {
-						case 'restorable':
-							d1Restorable = true
-							break
-						case 'unrestorable':
-							d1Restorable = false
-							warnings.push(
-								'D1 SQL contains oversized statements and cannot be restored',
-							)
-							break
-						case 'legacy-unknown':
-							warnings.push(
-								'D1 restorability unknown: legacy backup has no SQL stats',
-							)
-							break
-						case 'missing':
-							d1Restorable = false
-							warnings.push(
-								'D1 is not restorable: required SQL stats are missing',
-							)
-							break
-						case 'corrupt':
-							d1Restorable = false
-							warnings.push('D1 is not restorable: SQL stats are unreadable')
-							break
-						default: {
-							const exhaustive: never = restorability
-							throw exhaustive
-						}
-					}
-				}
 			}
 		} catch {
 			d1Verified = null
 			warnings.push('D1 manifest unreadable')
+		}
+		if (d1Manifest !== null && d1Verified === true) {
+			try {
+				const restorability = await readSqlRestorability(
+					env.BACKUP_BUCKET,
+					day,
+					d1Manifest.payload.sql.objectKey,
+				)
+				switch (restorability.kind) {
+					case 'restorable':
+						d1Restorable = true
+						break
+					case 'unrestorable':
+						d1Restorable = false
+						warnings.push(
+							'D1 SQL contains oversized statements and cannot be restored',
+						)
+						break
+					case 'legacy-unknown':
+						warnings.push(
+							'D1 restorability unknown: legacy backup has no SQL stats',
+						)
+						break
+					case 'missing':
+						d1Restorable = false
+						warnings.push(
+							'D1 is not restorable: required SQL stats are missing',
+						)
+						break
+					case 'corrupt':
+						d1Restorable = false
+						warnings.push('D1 is not restorable: SQL stats are unreadable')
+						break
+					default: {
+						const exhaustive: never = restorability
+						throw exhaustive
+					}
+				}
+			} catch {
+				d1Restorable = false
+				warnings.push('D1 is not restorable: SQL stats lookup failed')
+			}
 		}
 
 		const stagingPresent =

--- a/packages/backup-control-plane/freshness-check.node.test.ts
+++ b/packages/backup-control-plane/freshness-check.node.test.ts
@@ -23,6 +23,8 @@ import {
 } from './backup-control-plane-test-support.ts'
 
 test('freshness accepts matching metadata and flags size/ETag drift or missing objects', async () => {
+	const consoleLog = vi.spyOn(console, 'log')
+	consoleLog.mockImplementation(() => undefined)
 	const bucket = new MemoryBucket()
 	const env = environment(bucket)
 	const key = objectKeyForBookmark(
@@ -43,6 +45,12 @@ test('freshness accepts matching metadata and flags size/ETag drift or missing o
 	assert.equal(
 		await checkFreshness(env, new Date('2026-07-22T03:45:00Z'), identityApi()),
 		true,
+	)
+	const initialEvents = consoleLog.mock.calls.map(([record]) =>
+		JSON.parse(String(record)),
+	) as Array<{ event: string }>
+	assert.ok(
+		initialEvents.some(({ event }) => event === 'backup-stats-legacy-missing'),
 	)
 	bucket.setReportedSize(key, MAXIMUM_SINGLE_BACKUP_OBJECT_BYTES)
 	assert.equal(

--- a/packages/backup-control-plane/freshness-check.node.test.ts
+++ b/packages/backup-control-plane/freshness-check.node.test.ts
@@ -14,6 +14,7 @@ import { BackupError, objectKeyForBookmark } from './backup-policy.ts'
 import {
 	DATABASE_ID,
 	MemoryBucket,
+	badSqlStatsFixture,
 	environment,
 	identityApi,
 	identityEnvelope,
@@ -120,6 +121,53 @@ test('freshness reports malformed manifest schema as stale', async () => {
 		await checkFreshness(env, new Date('2026-07-22T03:45:00Z'), identityApi()),
 		false,
 	)
+})
+
+test('freshness reports oversized SQL with a distinct unrestorable event', async () => {
+	const consoleLog = vi.spyOn(console, 'log')
+	consoleLog.mockImplementation(() => undefined)
+	const bucket = new MemoryBucket()
+	const env = environment(bucket)
+	const day = '2026-07-31'
+	const key = objectKeyForBookmark(
+		`daily/d1/${DATABASE_ID}/${day}`,
+		'bookmark-1',
+	)
+	const stored = await storeSignedDownload(
+		bucket as unknown as R2Bucket,
+		key,
+		'https://download.example',
+		async () => new Response('valid', { headers: { 'content-length': '5' } }),
+	)
+	const template = manifest(stored)
+	await putImmutableManifest(
+		bucket as unknown as R2Bucket,
+		`daily/d1/${DATABASE_ID}/${day}/manifest.json`,
+		signedManifest({
+			...template.payload,
+			export: {
+				...template.payload.export,
+				scheduledAt: `${day}T02:15:00.000Z`,
+				startedAt: `${day}T02:15:01.000Z`,
+				completedAt: `${day}T02:16:00.000Z`,
+			},
+			sql: { ...template.payload.sql, objectKey: key },
+		}),
+	)
+	await bucket.put(
+		`${key}.stats.json`,
+		JSON.stringify(badSqlStatsFixture(day, key)),
+	)
+
+	assert.equal(
+		await checkFreshness(env, new Date(`${day}T03:45:00Z`), identityApi()),
+		false,
+	)
+	const record = JSON.parse(
+		String(consoleLog.mock.calls.at(-1)?.[0]),
+	) as Record<string, unknown>
+	assert.equal(record.event, 'freshness-unrestorable')
+	assert.equal(record.oversizedStatementCount, 1)
 })
 
 test('freshness requires a valid Ed25519 signature from the configured key', async () => {

--- a/packages/backup-control-plane/freshness-check.ts
+++ b/packages/backup-control-plane/freshness-check.ts
@@ -15,6 +15,7 @@ import {
 } from './backup-policy.ts'
 import { type BackupEnvironment } from './backup-types.ts'
 import { verifyBackupManifestSignature } from './manifest-signing.ts'
+import { readSqlRestorability } from './sql-statement-stats.ts'
 
 function latestExpectedDate(scheduledAt: Date): Date {
 	const expected = new Date(scheduledAt)
@@ -59,6 +60,10 @@ export async function checkFreshness(
 		throw error
 	}
 	let ageHours: number | undefined
+	let statsErrorCode: string | undefined
+	let unrestorableStats:
+		| { maxStatementBytes: number; oversizedStatementCount: number }
+		| undefined
 	const signatureValid =
 		manifest !== null && (await verifyBackupManifestSignature(env, manifest))
 	let stale = manifest === null || !signatureValid
@@ -70,6 +75,31 @@ export async function checkFreshness(
 		const object = validObjectKey
 			? await env.BACKUP_BUCKET.head(manifest.payload.sql.objectKey)
 			: null
+		if (validObjectKey) {
+			const restorability = await readSqlRestorability(
+				env.BACKUP_BUCKET,
+				payload.day,
+				manifest.payload.sql.objectKey,
+			)
+			switch (restorability.kind) {
+				case 'restorable':
+				case 'legacy-unknown':
+					break
+				case 'unrestorable':
+					unrestorableStats = restorability.stats
+					break
+				case 'missing':
+					statsErrorCode = 'backup-sql-stats-missing'
+					break
+				case 'corrupt':
+					statsErrorCode = 'backup-sql-stats-corrupt'
+					break
+				default: {
+					const exhaustive: never = restorability
+					throw exhaustive
+				}
+			}
+		}
 		ageHours =
 			(scheduledAt.valueOf() -
 				new Date(manifest.payload.export.completedAt).valueOf()) /
@@ -84,6 +114,8 @@ export async function checkFreshness(
 				env.SOURCE_DATABASE_ID.toLowerCase() ||
 			manifest.payload.source.databaseName !== env.SOURCE_DATABASE_NAME ||
 			!validObjectKey ||
+			unrestorableStats !== undefined ||
+			statsErrorCode !== undefined ||
 			manifest.payload.sql.bytes <= 0 ||
 			!/^[0-9a-f]{64}$/.test(manifest.payload.sql.sha256) ||
 			!manifest.payload.sql.r2Etag ||
@@ -94,12 +126,20 @@ export async function checkFreshness(
 					object.etag !== manifest.payload.sql.r2Etag))
 	}
 	safeLog({
-		event: stale ? 'freshness-stale' : 'freshness-success',
+		event:
+			unrestorableStats !== undefined
+				? 'freshness-unrestorable'
+				: stale
+					? 'freshness-stale'
+					: 'freshness-success',
 		status: stale ? 'stale-success' : 'success',
 		day: payload.day,
 		objectKey: manifest?.payload.sql.objectKey,
 		manifestKey: payload.manifestKey,
 		ageHours,
+		errorCode: statsErrorCode,
+		maxStatementBytes: unrestorableStats?.maxStatementBytes,
+		oversizedStatementCount: unrestorableStats?.oversizedStatementCount,
 	})
 	return !stale
 }

--- a/packages/backup-control-plane/freshness-check.ts
+++ b/packages/backup-control-plane/freshness-check.ts
@@ -83,7 +83,14 @@ export async function checkFreshness(
 			)
 			switch (restorability.kind) {
 				case 'restorable':
+					break
 				case 'legacy-unknown':
+					safeLog({
+						event: 'backup-stats-legacy-missing',
+						status: 'stale-success',
+						day: payload.day,
+						objectKey: manifest.payload.sql.objectKey,
+					})
 					break
 				case 'unrestorable':
 					unrestorableStats = restorability.stats

--- a/packages/backup-control-plane/immutable-storage.node.test.ts
+++ b/packages/backup-control-plane/immutable-storage.node.test.ts
@@ -162,6 +162,14 @@ test('sql statement stats measure quote-aware statement lengths during upload', 
 		oversizedStatementCount: 1,
 		limit: 10,
 	})
+
+	const exactLimitScanner = createSqlStatementScanner(10)
+	exactLimitScanner.update(new TextEncoder().encode('SELECT 12;'))
+	assert.deepEqual(exactLimitScanner.finish(), {
+		maxStatementBytes: 10,
+		oversizedStatementCount: 0,
+		limit: 10,
+	})
 })
 
 test('truncated and interrupted downloads fail retryably, then a retry succeeds', async () => {

--- a/packages/backup-control-plane/production-restore.node.test.ts
+++ b/packages/backup-control-plane/production-restore.node.test.ts
@@ -7,12 +7,13 @@ import { test, vi } from 'vitest'
 
 import {
 	MemoryBucket,
+	badSqlStatsFixture,
 	environment,
 	exportEnvelope,
 	manifest,
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
-import { backupPayload } from './backup-policy.ts'
+import { BackupError, backupPayload } from './backup-policy.ts'
 import { d1ImportForeignKeysOffPrefix } from './d1-import-api.ts'
 import { signBackupFullManifest } from './full-manifest-signing.ts'
 import { putImmutableManifest } from './immutable-storage.ts'
@@ -36,10 +37,11 @@ async function seedSealedRestoreDay(bucket: MemoryBucket, day = '2026-07-22') {
 		sha256: sha256Text(sqlBody),
 		r2Etag: sqlMd5,
 	})
-	await bucket.put(template.payload.sql.objectKey, sqlBody)
+	const sqlObjectKey = template.payload.sql.objectKey.replace('2026-07-22', day)
+	await bucket.put(sqlObjectKey, sqlBody)
 	const dayManifest = signedManifest({
 		...template.payload,
-		sql: template.payload.sql,
+		sql: { ...template.payload.sql, objectKey: sqlObjectKey },
 	})
 	await putImmutableManifest(
 		bucket as unknown as R2Bucket,
@@ -70,7 +72,7 @@ async function seedSealedRestoreDay(bucket: MemoryBucket, day = '2026-07-22') {
 		sealedFullManifestKey(day),
 		serializeBackupFullManifest(full),
 	)
-	return { env, day, preparedImportMd5 }
+	return { env, day, preparedImportMd5, sqlObjectKey }
 }
 
 test('runProductionRestore returns failed progress when dr-restore emits warnings', async () => {
@@ -153,4 +155,36 @@ test('runProductionRestore returns failed progress when dr-restore emits warning
 	assert.equal(progress.safetyExportBytes, sql.length)
 	assert.ok(safetyExportKey)
 	assert.ok(await bucket.head(safetyExportKey))
+})
+
+test('production restore refuses SQL with oversized statement stats', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
+	const bucket = new MemoryBucket()
+	const { env, day, sqlObjectKey } = await seedSealedRestoreDay(
+		bucket,
+		'2026-07-31',
+	)
+	await bucket.put(
+		`${sqlObjectKey}.stats.json`,
+		JSON.stringify(badSqlStatsFixture(day, sqlObjectKey)),
+	)
+
+	let fetchCalls = 0
+	await assert.rejects(
+		runProductionRestore(
+			env,
+			{ day, requestedAt: `${day}T12:00:00.000Z` },
+			{
+				fetcher: async () => {
+					fetchCalls += 1
+					throw new Error('restore should not start')
+				},
+			},
+		),
+		(error: unknown) =>
+			error instanceof BackupError &&
+			error.code === 'backup-unrestorable-statements',
+	)
+	assert.equal(fetchCalls, 0)
 })

--- a/packages/backup-control-plane/production-restore.ts
+++ b/packages/backup-control-plane/production-restore.ts
@@ -12,6 +12,7 @@ import { verifyBackupFullManifestSignature } from './full-manifest-signing.ts'
 import { readManifest } from './immutable-storage.ts'
 import { verifyBackupManifestSignature } from './manifest-signing.ts'
 import { readFullManifest } from './seal-full-backup.ts'
+import { assertSqlRestorable } from './sql-statement-stats.ts'
 
 export type DrRestoreChunkResponse = {
 	done: boolean
@@ -181,6 +182,11 @@ export async function validateSealedDayForRestore(
 			`D1 manifest signature invalid for ${day}`,
 		)
 	}
+	await assertSqlRestorable(
+		env.BACKUP_BUCKET,
+		day,
+		d1Manifest.payload.sql.objectKey,
+	)
 	return {
 		fullManifestKey,
 		d1ManifestKey: fullManifest.payload.d1ManifestKey,

--- a/packages/backup-control-plane/readme.md
+++ b/packages/backup-control-plane/readme.md
@@ -38,11 +38,18 @@ While streaming the upload, the runtime also measures SQL statement lengths
 ~100 KB statement limit with `statement too long: SQLITE_TOOBIG`, so an
 oversized statement means the object is not restorable through the D1 import
 API. The measurements are persisted as `<objectKey>.stats.json` next to the SQL
-object and logged as `backup-sql-stats`; an oversized count above zero
-additionally logs `backup-unrestorable-statements` with failure status. The
-backup itself completes — application write paths bound row sizes (see
-`packages/shared/src/backup-restore-safety.ts`), so a nonzero count indicates a
-new unbounded write path that must be fixed.
+object before manifest finalization and logged as `backup-sql-stats`. An
+oversized count above zero additionally logs `backup-unrestorable-statements`,
+fails the Workflow retryably, and leaves the day without a canonical manifest.
+The hourly catch-up window can then re-export the same day after the offending
+write path or row is bounded.
+
+Sealing, freshness, restore drills, production restore, and the dashboard all
+read the SQL object's stats sibling. Oversized statements prevent sealing and
+import, freshness emits `freshness-unrestorable`, and the dashboard marks the
+day's D1 media as not restorable. Missing stats are tolerated with a structured
+legacy warning only for retained objects before 2026-07-28; newer objects fail
+closed.
 
 Every canonical manifest uses schema v2 and is an Ed25519-signed envelope. Its
 signature covers deterministic canonical JSON for the SQL key, bytes, SHA-256,
@@ -143,7 +150,8 @@ Cloudflare dashboard.
 ## Integrity checks
 
 The hourly freshness check compares the immutable object's R2 size and ETag to
-the canonical manifest. Run a separate periodic restore drill that downloads the
-object, verifies its SHA-256 against the manifest, and restores it into a
-non-production D1 database. The metadata freshness check is not a replacement
-for that deep checksum and restore drill.
+the canonical manifest and requires restorable SQL statement stats for new
+backup days. Run a separate periodic restore drill that downloads the object,
+verifies its SHA-256 against the manifest, and restores it into a non-production
+D1 database. The metadata freshness check is not a replacement for that deep
+checksum and restore drill.

--- a/packages/backup-control-plane/restore-drill.ts
+++ b/packages/backup-control-plane/restore-drill.ts
@@ -9,6 +9,7 @@ import {
 import { type ApiOptions } from './d1-export-api.ts'
 import { readManifest } from './immutable-storage.ts'
 import { verifyBackupManifestSignature } from './manifest-signing.ts'
+import { assertSqlRestorable } from './sql-statement-stats.ts'
 
 export type DrillReport = {
 	day: string
@@ -92,6 +93,7 @@ export async function runRestoreDrill(
 		)
 	}
 	const sqlObjectKey = manifest.payload.sql.objectKey
+	await assertSqlRestorable(env.BACKUP_BUCKET, day, sqlObjectKey)
 	const sqlHead = await env.BACKUP_BUCKET.head(sqlObjectKey)
 	if (sqlHead === null) {
 		throw new BackupError('drill-sql-missing', `SQL object missing for ${day}`)

--- a/packages/backup-control-plane/seal-full-backup.node.test.ts
+++ b/packages/backup-control-plane/seal-full-backup.node.test.ts
@@ -17,6 +17,7 @@ import {
 	badSqlStatsFixture,
 	environment,
 	manifest,
+	putSqlStatsFixture,
 	signedManifest,
 } from './backup-control-plane-test-support.ts'
 import { BackupError, backupPayload } from './backup-policy.ts'
@@ -213,6 +214,31 @@ test('sealFullBackupDay refuses oversized SQL stats before sealing', async () =>
 		},
 	)
 	assert.equal(await bucket.head(sealedFullManifestKey(day)), null)
+})
+
+test('sealFullBackupDay reports an already-sealed unrestorable day as incomplete', async () => {
+	const bucket = new MemoryBucket()
+	const { env, day, sqlKey } = await seedCompleteDay(bucket, '2026-07-31')
+	await putSqlStatsFixture(bucket, day, sqlKey)
+	const sealed = await sealFullBackupDay(
+		env,
+		day,
+		new Date(`${day}T04:00:00.000Z`),
+	)
+	assert.equal(sealed.kind, 'sealed')
+	await bucket.put(
+		`${sqlKey}.stats.json`,
+		JSON.stringify(badSqlStatsFixture(day, sqlKey)),
+	)
+
+	assert.deepEqual(
+		await sealFullBackupDay(env, day, new Date(`${day}T04:01:00.000Z`)),
+		{
+			kind: 'incomplete',
+			day,
+			reason: 'backup-unrestorable-statements',
+		},
+	)
 })
 
 test('sealFullBackupDay fails closed when required SQL stats are missing', async () => {

--- a/packages/backup-control-plane/seal-full-backup.node.test.ts
+++ b/packages/backup-control-plane/seal-full-backup.node.test.ts
@@ -198,6 +198,8 @@ test('sealFullBackupDay fails closed on staging sha mismatch', async () => {
 })
 
 test('sealFullBackupDay refuses oversized SQL stats before sealing', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
 	const bucket = new MemoryBucket()
 	const { env, day, sqlKey } = await seedCompleteDay(bucket, '2026-07-31')
 	await bucket.put(
@@ -214,9 +216,16 @@ test('sealFullBackupDay refuses oversized SQL stats before sealing', async () =>
 		},
 	)
 	assert.equal(await bucket.head(sealedFullManifestKey(day)), null)
+	const record = JSON.parse(
+		String(consoleError.mock.calls.at(-1)?.[0]),
+	) as Record<string, unknown>
+	assert.equal(record.event, 'full-backup-seal-skipped')
+	assert.equal(record.errorCode, 'backup-unrestorable-statements')
 })
 
 test('sealFullBackupDay reports an already-sealed unrestorable day as incomplete', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
 	const bucket = new MemoryBucket()
 	const { env, day, sqlKey } = await seedCompleteDay(bucket, '2026-07-31')
 	await putSqlStatsFixture(bucket, day, sqlKey)
@@ -242,6 +251,8 @@ test('sealFullBackupDay reports an already-sealed unrestorable day as incomplete
 })
 
 test('sealFullBackupDay fails closed when required SQL stats are missing', async () => {
+	const consoleError = vi.spyOn(console, 'error')
+	consoleError.mockImplementation(() => undefined)
 	const bucket = new MemoryBucket()
 	const { env, day } = await seedCompleteDay(bucket, '2026-07-31')
 

--- a/packages/backup-control-plane/seal-full-backup.node.test.ts
+++ b/packages/backup-control-plane/seal-full-backup.node.test.ts
@@ -14,6 +14,7 @@ import { test, vi } from 'vitest'
 
 import {
 	MemoryBucket,
+	badSqlStatsFixture,
 	environment,
 	manifest,
 	signedManifest,
@@ -119,7 +120,7 @@ async function seedCompleteDay(
 		warnings: [],
 	}
 	await bucket.put(stagingSummaryKey(day), JSON.stringify(summary))
-	return { env, day }
+	return { env, day, sqlKey }
 }
 
 test('sealFullBackupDay seals a complete day and is idempotent', async () => {
@@ -191,6 +192,40 @@ test('sealFullBackupDay fails closed on staging sha mismatch', async () => {
 		sealFullBackupDay(env, day, new Date(`${day}T04:00:00.000Z`)),
 		(error: unknown) =>
 			error instanceof BackupError && error.code === 'staging-sha-mismatch',
+	)
+	assert.equal(await bucket.head(sealedFullManifestKey(day)), null)
+})
+
+test('sealFullBackupDay refuses oversized SQL stats before sealing', async () => {
+	const bucket = new MemoryBucket()
+	const { env, day, sqlKey } = await seedCompleteDay(bucket, '2026-07-31')
+	await bucket.put(
+		`${sqlKey}.stats.json`,
+		JSON.stringify(badSqlStatsFixture(day, sqlKey)),
+	)
+
+	assert.deepEqual(
+		await sealFullBackupDay(env, day, new Date(`${day}T04:00:00.000Z`)),
+		{
+			kind: 'incomplete',
+			day,
+			reason: 'backup-unrestorable-statements',
+		},
+	)
+	assert.equal(await bucket.head(sealedFullManifestKey(day)), null)
+})
+
+test('sealFullBackupDay fails closed when required SQL stats are missing', async () => {
+	const bucket = new MemoryBucket()
+	const { env, day } = await seedCompleteDay(bucket, '2026-07-31')
+
+	assert.deepEqual(
+		await sealFullBackupDay(env, day, new Date(`${day}T04:00:00.000Z`)),
+		{
+			kind: 'incomplete',
+			day,
+			reason: 'backup-sql-stats-missing',
+		},
 	)
 	assert.equal(await bucket.head(sealedFullManifestKey(day)), null)
 })

--- a/packages/backup-control-plane/seal-full-backup.ts
+++ b/packages/backup-control-plane/seal-full-backup.ts
@@ -343,6 +343,16 @@ export type SealDayResult =
 	| { kind: 'sealed'; day: string; manifestKey: string; alreadySealed: boolean }
 	| { kind: 'incomplete'; day: string; reason: string }
 
+function incompleteForSqlStats(day: string, reason: string): SealDayResult {
+	safeLog({
+		event: 'full-backup-seal-skipped',
+		status: 'failure',
+		day,
+		errorCode: reason,
+	})
+	return { kind: 'incomplete', day, reason }
+}
+
 export async function sealFullBackupDay(
 	env: BackupEnvironment,
 	day: string,
@@ -383,15 +393,11 @@ export async function sealFullBackupDay(
 			})
 			break
 		case 'unrestorable':
-			return {
-				kind: 'incomplete',
-				day,
-				reason: 'backup-unrestorable-statements',
-			}
+			return incompleteForSqlStats(day, 'backup-unrestorable-statements')
 		case 'missing':
-			return { kind: 'incomplete', day, reason: 'backup-sql-stats-missing' }
+			return incompleteForSqlStats(day, 'backup-sql-stats-missing')
 		case 'corrupt':
-			return { kind: 'incomplete', day, reason: 'backup-sql-stats-corrupt' }
+			return incompleteForSqlStats(day, 'backup-sql-stats-corrupt')
 		default: {
 			const exhaustive: never = restorability
 			throw exhaustive

--- a/packages/backup-control-plane/seal-full-backup.ts
+++ b/packages/backup-control-plane/seal-full-backup.ts
@@ -35,6 +35,7 @@ import {
 	readManifest,
 } from './immutable-storage.ts'
 import { verifyBackupManifestSignature } from './manifest-signing.ts'
+import { readSqlRestorability } from './sql-statement-stats.ts'
 
 const sha256Pattern = /^[0-9a-f]{64}$/
 
@@ -385,6 +386,37 @@ export async function sealFullBackupDay(
 			'd1-manifest-signature-invalid',
 			`D1 manifest signature invalid for ${day}`,
 		)
+	}
+	const restorability = await readSqlRestorability(
+		env.BACKUP_BUCKET,
+		day,
+		d1Manifest.payload.sql.objectKey,
+	)
+	switch (restorability.kind) {
+		case 'restorable':
+			break
+		case 'legacy-unknown':
+			safeLog({
+				event: 'backup-stats-legacy-missing',
+				status: 'stale-success',
+				day,
+				objectKey: d1Manifest.payload.sql.objectKey,
+			})
+			break
+		case 'unrestorable':
+			return {
+				kind: 'incomplete',
+				day,
+				reason: 'backup-unrestorable-statements',
+			}
+		case 'missing':
+			return { kind: 'incomplete', day, reason: 'backup-sql-stats-missing' }
+		case 'corrupt':
+			return { kind: 'incomplete', day, reason: 'backup-sql-stats-corrupt' }
+		default: {
+			const exhaustive: never = restorability
+			throw exhaustive
+		}
 	}
 	const d1ManifestObject = await env.BACKUP_BUCKET.get(d1Payload.manifestKey)
 	if (d1ManifestObject === null) {

--- a/packages/backup-control-plane/seal-full-backup.ts
+++ b/packages/backup-control-plane/seal-full-backup.ts
@@ -351,27 +351,6 @@ export async function sealFullBackupDay(
 	assertBackupDay(day)
 	const manifestKey = sealedFullManifestKey(day)
 	const existing = await readFullManifest(env.BACKUP_BUCKET, manifestKey)
-	if (existing !== null) {
-		if (!(await verifyBackupFullManifestSignature(env, existing))) {
-			throw new BackupError(
-				'full-manifest-signature-invalid',
-				`existing full manifest signature is invalid for ${day}`,
-			)
-		}
-		if (existing.payload.day !== day) {
-			throw new BackupError(
-				'full-manifest-day-mismatch',
-				`existing full manifest day mismatch for ${day}`,
-			)
-		}
-		safeLog({
-			event: 'full-backup-already-sealed',
-			status: 'success',
-			day,
-			manifestKey,
-		})
-		return { kind: 'sealed', day, manifestKey, alreadySealed: true }
-	}
 
 	const d1Payload = backupPayload(env, new Date(`${day}T12:00:00.000Z`))
 	const d1Manifest = await readManifest(
@@ -417,6 +396,27 @@ export async function sealFullBackupDay(
 			const exhaustive: never = restorability
 			throw exhaustive
 		}
+	}
+	if (existing !== null) {
+		if (!(await verifyBackupFullManifestSignature(env, existing))) {
+			throw new BackupError(
+				'full-manifest-signature-invalid',
+				`existing full manifest signature is invalid for ${day}`,
+			)
+		}
+		if (existing.payload.day !== day) {
+			throw new BackupError(
+				'full-manifest-day-mismatch',
+				`existing full manifest day mismatch for ${day}`,
+			)
+		}
+		safeLog({
+			event: 'full-backup-already-sealed',
+			status: 'success',
+			day,
+			manifestKey,
+		})
+		return { kind: 'sealed', day, manifestKey, alreadySealed: true }
 	}
 	const d1ManifestObject = await env.BACKUP_BUCKET.get(d1Payload.manifestKey)
 	if (d1ManifestObject === null) {

--- a/packages/backup-control-plane/sql-statement-stats.ts
+++ b/packages/backup-control-plane/sql-statement-stats.ts
@@ -1,0 +1,72 @@
+import {
+	backupSqlStatsKey,
+	backupSqlStatsRequired,
+	parseBackupSqlStats,
+	type BackupSqlStats,
+} from '@kody-internal/shared/backup-sql-stats.ts'
+
+import { BackupError } from './backup-policy.ts'
+
+export type SqlRestorability =
+	| { kind: 'restorable'; stats: BackupSqlStats }
+	| { kind: 'unrestorable'; stats: BackupSqlStats }
+	| { kind: 'legacy-unknown' }
+	| { kind: 'missing' }
+	| { kind: 'corrupt' }
+
+export async function readSqlRestorability(
+	bucket: R2Bucket,
+	day: string,
+	objectKey: string,
+): Promise<SqlRestorability> {
+	const object = await bucket.get(backupSqlStatsKey(objectKey))
+	if (object === null) {
+		return backupSqlStatsRequired(day)
+			? { kind: 'missing' }
+			: { kind: 'legacy-unknown' }
+	}
+	let stats: BackupSqlStats
+	try {
+		stats = parseBackupSqlStats(await object.json<unknown>())
+	} catch {
+		return { kind: 'corrupt' }
+	}
+	if (stats.day !== day || stats.objectKey !== objectKey) {
+		return { kind: 'corrupt' }
+	}
+	return stats.oversizedStatementCount > 0
+		? { kind: 'unrestorable', stats }
+		: { kind: 'restorable', stats }
+}
+
+export async function assertSqlRestorable(
+	bucket: R2Bucket,
+	day: string,
+	objectKey: string,
+): Promise<void> {
+	const result = await readSqlRestorability(bucket, day, objectKey)
+	switch (result.kind) {
+		case 'restorable':
+		case 'legacy-unknown':
+			return
+		case 'unrestorable':
+			throw new BackupError(
+				'backup-unrestorable-statements',
+				`D1 SQL for ${day} contains ${String(result.stats.oversizedStatementCount)} oversized statement(s)`,
+			)
+		case 'missing':
+			throw new BackupError(
+				'backup-sql-stats-missing',
+				`D1 SQL stats are missing for ${day}`,
+			)
+		case 'corrupt':
+			throw new BackupError(
+				'backup-sql-stats-corrupt',
+				`D1 SQL stats are corrupt for ${day}`,
+			)
+		default: {
+			const exhaustive: never = result
+			throw exhaustive
+		}
+	}
+}

--- a/packages/backup-control-plane/sql-statement-stats.ts
+++ b/packages/backup-control-plane/sql-statement-stats.ts
@@ -5,7 +5,7 @@ import {
 	type BackupSqlStats,
 } from '@kody-internal/shared/backup-sql-stats.ts'
 
-import { BackupError } from './backup-policy.ts'
+import { BackupError, safeLog } from './backup-policy.ts'
 
 export type SqlRestorability =
 	| { kind: 'restorable'; stats: BackupSqlStats }
@@ -47,7 +47,14 @@ export async function assertSqlRestorable(
 	const result = await readSqlRestorability(bucket, day, objectKey)
 	switch (result.kind) {
 		case 'restorable':
+			return
 		case 'legacy-unknown':
+			safeLog({
+				event: 'backup-stats-legacy-missing',
+				status: 'stale-success',
+				day,
+				objectKey,
+			})
 			return
 		case 'unrestorable':
 			throw new BackupError(

--- a/packages/backup-control-plane/sql-statement-stats.ts
+++ b/packages/backup-control-plane/sql-statement-stats.ts
@@ -4,6 +4,7 @@ import {
 	parseBackupSqlStats,
 	type BackupSqlStats,
 } from '@kody-internal/shared/backup-sql-stats.ts'
+import { d1ImportMaxStatementBytes } from '@kody-internal/shared/backup-restore-safety.ts'
 
 import { BackupError, safeLog } from './backup-policy.ts'
 
@@ -34,7 +35,8 @@ export async function readSqlRestorability(
 	if (stats.day !== day || stats.objectKey !== objectKey) {
 		return { kind: 'corrupt' }
 	}
-	return stats.oversizedStatementCount > 0
+	return stats.oversizedStatementCount > 0 ||
+		stats.maxStatementBytes > d1ImportMaxStatementBytes
 		? { kind: 'unrestorable', stats }
 		: { kind: 'restorable', stats }
 }

--- a/packages/shared/src/backup-sql-stats.node.test.ts
+++ b/packages/shared/src/backup-sql-stats.node.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
+import { d1ImportMaxStatementBytes } from './backup-restore-safety.ts'
 import {
 	backupSqlStatsRequired,
 	backupSqlStatsSchemaVersion,
@@ -18,13 +19,30 @@ test('backup SQL stats enforce the rollout cutoff and statement-limit consistenc
 		objectKey: 'daily/d1/database/2026-07-31/backup-bookmark.sql',
 		maxStatementBytes: 50_000,
 		oversizedStatementCount: 0,
-		importStatementLimitBytes: 100_000,
+		importStatementLimitBytes: d1ImportMaxStatementBytes,
 	}
 	assert.deepEqual(parseBackupSqlStats(valid), valid)
 
+	const oversized = {
+		...valid,
+		maxStatementBytes: d1ImportMaxStatementBytes + 1,
+		oversizedStatementCount: 1,
+	}
+	assert.deepEqual(parseBackupSqlStats(oversized), oversized)
+	const differentRecordedLimit = {
+		...valid,
+		importStatementLimitBytes: d1ImportMaxStatementBytes + 1,
+	}
+	assert.deepEqual(
+		parseBackupSqlStats(differentRecordedLimit),
+		differentRecordedLimit,
+	)
+
 	for (const corrupt of [
-		{ ...valid, importStatementLimitBytes: 100_001 },
-		{ ...valid, maxStatementBytes: 100_001 },
+		null,
+		{ ...valid, schemaVersion: backupSqlStatsSchemaVersion + 1 },
+		{ ...valid, importStatementLimitBytes: 0 },
+		{ ...valid, maxStatementBytes: d1ImportMaxStatementBytes + 1 },
 		{ ...valid, maxStatementBytes: 50_000, oversizedStatementCount: 1 },
 	]) {
 		assert.throws(() => parseBackupSqlStats(corrupt))

--- a/packages/shared/src/backup-sql-stats.node.test.ts
+++ b/packages/shared/src/backup-sql-stats.node.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+	backupSqlStatsRequired,
+	backupSqlStatsSchemaVersion,
+	parseBackupSqlStats,
+} from './backup-sql-stats.ts'
+
+test('backup SQL stats enforce the rollout cutoff and statement-limit consistency', () => {
+	assert.equal(backupSqlStatsRequired('2026-07-27'), false)
+	assert.equal(backupSqlStatsRequired('2026-07-28'), true)
+
+	const valid = {
+		schemaVersion: backupSqlStatsSchemaVersion,
+		day: '2026-07-31',
+		objectKey: 'daily/d1/database/2026-07-31/backup-bookmark.sql',
+		maxStatementBytes: 50_000,
+		oversizedStatementCount: 0,
+		importStatementLimitBytes: 100_000,
+	}
+	assert.deepEqual(parseBackupSqlStats(valid), valid)
+
+	for (const corrupt of [
+		{ ...valid, importStatementLimitBytes: 100_001 },
+		{ ...valid, maxStatementBytes: 100_001 },
+		{ ...valid, maxStatementBytes: 50_000, oversizedStatementCount: 1 },
+	]) {
+		assert.throws(() => parseBackupSqlStats(corrupt))
+	}
+})

--- a/packages/shared/src/backup-sql-stats.ts
+++ b/packages/shared/src/backup-sql-stats.ts
@@ -1,5 +1,3 @@
-import { d1ImportMaxStatementBytes } from './backup-restore-safety.ts'
-
 export const backupSqlStatsSchemaVersion = 1
 
 /**
@@ -42,9 +40,10 @@ export function parseBackupSqlStats(value: unknown): BackupSqlStats {
 		typeof value.objectKey !== 'string' ||
 		!isNonNegativeSafeInteger(value.maxStatementBytes) ||
 		!isNonNegativeSafeInteger(value.oversizedStatementCount) ||
-		value.importStatementLimitBytes !== d1ImportMaxStatementBytes ||
+		!Number.isSafeInteger(value.importStatementLimitBytes) ||
+		Number(value.importStatementLimitBytes) <= 0 ||
 		(value.oversizedStatementCount === 0) !==
-			Number(value.maxStatementBytes) <= d1ImportMaxStatementBytes
+			Number(value.maxStatementBytes) <= Number(value.importStatementLimitBytes)
 	) {
 		throw new Error('backup SQL stats are corrupt')
 	}

--- a/packages/shared/src/backup-sql-stats.ts
+++ b/packages/shared/src/backup-sql-stats.ts
@@ -1,3 +1,5 @@
+import { d1ImportMaxStatementBytes } from './backup-restore-safety.ts'
+
 export const backupSqlStatsSchemaVersion = 1
 
 /**
@@ -40,8 +42,9 @@ export function parseBackupSqlStats(value: unknown): BackupSqlStats {
 		typeof value.objectKey !== 'string' ||
 		!isNonNegativeSafeInteger(value.maxStatementBytes) ||
 		!isNonNegativeSafeInteger(value.oversizedStatementCount) ||
-		!Number.isSafeInteger(value.importStatementLimitBytes) ||
-		Number(value.importStatementLimitBytes) <= 0
+		value.importStatementLimitBytes !== d1ImportMaxStatementBytes ||
+		(value.oversizedStatementCount === 0) !==
+			Number(value.maxStatementBytes) <= d1ImportMaxStatementBytes
 	) {
 		throw new Error('backup SQL stats are corrupt')
 	}

--- a/packages/shared/src/backup-sql-stats.ts
+++ b/packages/shared/src/backup-sql-stats.ts
@@ -1,0 +1,49 @@
+export const backupSqlStatsSchemaVersion = 1
+
+/**
+ * SQL statement statistics became mandatory for D1 backup objects after the
+ * stats-aware control plane was deployed. Older retained objects remain
+ * usable, but a missing stats sibling on this day or later is unsafe.
+ */
+export const backupSqlStatsRequiredFromDay = '2026-07-28'
+
+export type BackupSqlStats = {
+	schemaVersion: typeof backupSqlStatsSchemaVersion
+	day: string
+	objectKey: string
+	maxStatementBytes: number
+	oversizedStatementCount: number
+	importStatementLimitBytes: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+	return Number.isSafeInteger(value) && Number(value) >= 0
+}
+
+export function backupSqlStatsKey(objectKey: string): string {
+	return `${objectKey}.stats.json`
+}
+
+export function backupSqlStatsRequired(day: string): boolean {
+	return day >= backupSqlStatsRequiredFromDay
+}
+
+export function parseBackupSqlStats(value: unknown): BackupSqlStats {
+	if (
+		!isRecord(value) ||
+		value.schemaVersion !== backupSqlStatsSchemaVersion ||
+		typeof value.day !== 'string' ||
+		typeof value.objectKey !== 'string' ||
+		!isNonNegativeSafeInteger(value.maxStatementBytes) ||
+		!isNonNegativeSafeInteger(value.oversizedStatementCount) ||
+		!Number.isSafeInteger(value.importStatementLimitBytes) ||
+		Number(value.importStatementLimitBytes) <= 0
+	) {
+		throw new Error('backup SQL stats are corrupt')
+	}
+	return value as BackupSqlStats
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent
Prevent D1 exports containing statements above Cloudflare's import limit from being published, sealed, or restored as healthy disaster-recovery media. Fixes threat T4 in #1223.

## Summary
- persist SQL statement stats before manifest finalization and fail the backup Workflow retryably when oversized statements exist
- gate full-day sealing (including already-sealed historical days), freshness, restore drills, and production restore on SQL restorability
- show D1 restorability as yes/no/unknown in the control-plane dashboard, preserving verified-manifest status when stats lookup fails
- preserve pre-stats retained media compatibility before 2026-07-28, while failing closed for newer missing, corrupt, contradictory, or currently unsafe stats
- document the operator paging signal, catch-up behavior, and historical immutable-media exception

## Testing
- targeted backup/stat regression tests: 48 passed
- `npm run typecheck`: passed
- `npm run backup:build`: passed
- `npm run validate`: passed (555 files, 1,866 tests)
- independent DR review: no remaining actionable findings after fixes
- final-head PR CI and AI reviewers: passed; all valid feedback addressed
- merged-main validation: passed after rerunning an unrelated transient `workerd` E2E crash
- [production deploy](https://github.com/kentcdodds/kody/actions/runs/30953808195): passed, including [DR backup control-plane deploy](https://github.com/kentcdodds/kody/actions/runs/30953808195/job/92142069175)

## Conductor report
Status: done

Squash-merged as `1256e8732626be3ad9f35d35041aed6f9c2ca0b0`. All Track 4 gates are live, merged-main validation is green, and the DR backup control-plane deployment succeeded. Nothing remains for this track.

## System changes
<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `63616db6` · **Head:** `d29a8b2e`

**Classification:** extends — changes the backup control plane's publication, health, sealing, and restore-safety contracts without adding a new system primitive.

### Primitives touched
| Primitive | Group | Impact |
| --- | --- | --- |
| `backup-control-plane` | storage | extends — SQL statement stats now gate manifest publication, sealing, freshness, restores, and dashboard health |

### System map
D1 export statistics now form a fail-closed gate from immutable SQL capture through every path that can label or consume backup media.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	d1Export["backup-control-plane<br/>Production backup control plane"]:::extended
	manifest["Signed day manifest"]:::untouched
	seal["Sealed full backup"]:::untouched
	restore["Drill and production restore"]:::untouched
	dashboard["Operator dashboard"]:::untouched
	d1Export -->|"stats must show zero oversized statements"| manifest
	manifest -->|"stats gate before sealing"| seal
	manifest -->|"stats gate before import"| restore
	manifest -->|"yes / no / unknown restorability"| dashboard
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants
- Post-cutover unrestorable SQL never receives a canonical day manifest.
- New backup days cannot seal or restore without valid stats; retained pre-stats days remain usable with an explicit warning.
- Historical immutable objects are not modified and are blocked at health and restore gates.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fbfafda-6d4d-4c9b-b0b6-1f9a8a767ca8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fbfafda-6d4d-4c9b-b0b6-1f9a8a767ca8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL restorability tracking for D1 backups.
  * Backups with oversized SQL statements are now rejected and marked non-restorable.
  * Restore, sealing, freshness checks, and restore drills validate SQL restorability before proceeding.
  * Dashboard statuses now show whether daily backups are restorable, with warnings for missing, corrupt, legacy, or oversized statistics.

* **Documentation**
  * Updated recovery and backup guidance for unrestorable exports and legacy statistics handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->