### PR TITLE
fix(squash): accept documented pre-ledger ghost rows in the bookkeeping guard

Co-authored-by: Kent C. Dodds <me+github@kentcdodds.com>

### DIFF
--- a/tools/ci/reset-migration-bookkeeping.node.test.ts
+++ b/tools/ci/reset-migration-bookkeeping.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import {
 	classifyMigrationBookkeeping,
 	parseArgs,
+	preSquashGhostMigrationNames,
 	preSquashMigrationNames,
 	squashedInitMigrationName,
 } from './reset-migration-bookkeeping.ts'
@@ -33,6 +34,28 @@ test('exactly the frozen pre-squash set classifies as pre-squash', () => {
 	expect(classifyMigrationBookkeeping(shuffled)).toEqual({
 		state: 'pre-squash',
 	})
+})
+
+test('pre-ledger ghost rows are accepted alongside the frozen set', () => {
+	expect(
+		classifyMigrationBookkeeping([
+			...preSquashMigrationNames,
+			...preSquashGhostMigrationNames,
+		]),
+	).toEqual({ state: 'pre-squash' })
+	expect(
+		classifyMigrationBookkeeping([
+			...preSquashMigrationNames,
+			'0006-drop-mock-request-tables.sql',
+		]),
+	).toEqual({ state: 'pre-squash' })
+	// Ghosts alone do not excuse missing history.
+	const withoutFinal = preSquashMigrationNames.slice(0, -1)
+	const result = classifyMigrationBookkeeping([
+		...withoutFinal,
+		...preSquashGhostMigrationNames,
+	])
+	expect(result.state).toBe('unexpected')
 })
 
 test('a missing pre-squash migration is refused with a set diff', () => {

--- a/tools/ci/reset-migration-bookkeeping.ts
+++ b/tools/ci/reset-migration-bookkeeping.ts
@@ -186,6 +186,26 @@ export const preSquashMigrationNames: ReadonlyArray<string> = [
 	'0144-drop-jobs-observability-columns.sql',
 ]
 
+/**
+ * Pre-ledger bookkeeping ghosts: rows that exist in long-lived databases
+ * (production) because a migration file was applied and then renamed or
+ * deleted before the migration ledger froze history. Wrangler keys applied
+ * migrations by filename, so the old name's row survives. Provenance:
+ *
+ * - `0006-drop-mock-request-tables.sql` — applied, then renamed to
+ *   `0007-drop-mock-request-tables.sql` when `0006-ui-artifacts.sql` took
+ *   the prefix (PR #29); production holds rows for both names.
+ * - `0039-source-rescue-events.sql` — applied, then deleted by the source
+ *   rescue revert (PR #531); `0040-drop-source-rescue-events.sql` removed
+ *   its tables and the 0039 row remained.
+ *
+ * Databases may hold any subset of these in addition to the frozen set.
+ */
+export const preSquashGhostMigrationNames: ReadonlyArray<string> = [
+	'0006-drop-mock-request-tables.sql',
+	'0039-source-rescue-events.sql',
+]
+
 export type BookkeepingClassification =
 	| { state: 'fresh' }
 	| { state: 'squashed' }
@@ -206,8 +226,11 @@ export function classifyMigrationBookkeeping(
 	}
 	const applied = new Set(appliedNames)
 	const expected = new Set(preSquashMigrationNames)
+	const ghosts = new Set(preSquashGhostMigrationNames)
 	const missing = [...expected].filter((name) => !applied.has(name)).sort()
-	const extra = [...applied].filter((name) => !expected.has(name)).sort()
+	const extra = [...applied]
+		.filter((name) => !expected.has(name) && !ghosts.has(name))
+		.sort()
 	if (missing.length === 0 && extra.length === 0) {
 		return { state: 'pre-squash' }
 	}


### PR DESCRIPTION
Co-authored-by: Kent C. Dodds <me+github@kentcdodds.com>
## Intent

Unblock the production half of the migration squash (#1227, the #1069 finale). The first production deploy of `1790b943` **failed closed exactly as designed**: the deterministic bookkeeping guard found two rows in production's `d1_migrations` that the frozen ledger-derived set doesn't contain, refused with an exact set diff, and stopped the deploy before `migrations apply` ran. Production is untouched — same schema, pre-squash bookkeeping still in place.

## Summary

- add documented `preSquashGhostMigrationNames` to the guard — exactly two names, with git-archaeology provenance in comments:
  - `0006-drop-mock-request-tables.sql` — applied to production, then **renamed** to `0007-drop-mock-request-tables.sql` when `0006-ui-artifacts.sql` took the prefix (PR #29, `R100` rename); production holds rows for both names
  - `0039-source-rescue-events.sql` — applied, then **deleted** by the source-rescue revert (PR #531); `0040-drop-source-rescue-events.sql` dropped its tables and the bookkeeping row survived
- classification accepts the frozen 145-name set plus any subset of the ghosts as `pre-squash`; anything else still refuses
- ghosts cannot mask missing history — a set missing any real migration stays `unexpected` (unit-tested)

Wrangler keys applied migrations by filename, so pre-ledger-era renames/deletes leave orphan rows in long-lived databases. These two have zero schema effect.

## Testing

- guard unit tests 11/11 green (ghost acceptance, partial-ghost acceptance, ghosts-don't-excuse-missing-history)
- format + typecheck green
- production evidence: the failed deploy log for `1790b943` shows `Missing vs frozen pre-squash set: (none)` and exactly these two extras — no other drift
- after merge, the deploy on this SHA re-runs the guard; expected log: `verified all 145 pre-squash migrations are applied` -> Time Travel anchor -> reset -> re-verify -> `migrations apply` no-ops

## System changes

Same classification as #1227's recap: extends `ci-deploy-pipeline` (the temporary bookkeeping guard step) only — no schema or primitive behavior change. Refs #1069, #1227.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gate that decides whether a destructive `d1_migrations` rewrite runs during deploy; scope is narrow (two known ghost names) and covered by tests, but misclassification could still block or incorrectly allow a reset.
> 
> **Overview**
> The migration squash **bookkeeping guard** (`classifyMigrationBookkeeping`) no longer treats certain legacy `d1_migrations` rows as "extra" when the frozen pre-squash set is otherwise complete.
> 
> It introduces **`preSquashGhostMigrationNames`** (`0006-drop-mock-request-tables.sql`, `0039-source-rescue-events.sql`) with comments explaining rename/delete history on long-lived DBs. **Extra** names are now anything not in the frozen set **and** not in the ghost allowlist; missing frozen migrations still fail, and ghosts alone cannot substitute for incomplete history.
> 
> Tests cover the full frozen set plus ghosts (or a single ghost), and assert incomplete history with ghosts stays **unexpected**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27a7312d1a3531da9b011633f7c5139725bf1f9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration reset validation for databases containing recognized legacy migration entries.
  * Valid pre-squash migration states are now accepted without being flagged for unexpected extras.
  * Missing required migrations are still correctly reported, even when legacy entries are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->