### PR TITLE
fix(client): filter Fathom removeChild-on-null Sentry noise (KODY-CLOUDFLARE-3Q)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -3,6 +3,7 @@ import {
 	filterBrowserAbortSentryEvent,
 	filterBrowserInjectedGlobalNoiseSentryEvent,
 	filterBrowserSentryEvent,
+	filterFathomRemoveChildNullSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
 } from './sentry-browser-filters.ts'
 
@@ -239,6 +240,110 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 						type: 'TypeError',
 						value:
 							"undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')",
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	// Fathom beacon removeChild-on-null only when a usefathom.com frame is present
+	// (issue 7653117289 / KODY-CLOUDFLARE-3Q).
+	expect(
+		filterFathomRemoveChildNullSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of null (reading 'removeChild')",
+						stacktrace: {
+							frames: [
+								{
+									filename: '/script.js',
+									abs_path: 'https://cdn.usefathom.com/script.js',
+									function: 'HTMLImageElement.<anonymous>',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterFathomRemoveChildNullSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"TypeError: Cannot read properties of null (reading 'removeChild')",
+						stacktrace: {
+							frames: [
+								{
+									filename: 'https://cdn.usefathom.com/script.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	// Same message without a Fathom frame must stay (could be app code).
+	expect(
+		filterFathomRemoveChildNullSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of null (reading 'removeChild')",
+						stacktrace: {
+							frames: [
+								{
+									filename: '/assets/app-chunk.js',
+									abs_path: 'https://heykody.dev/assets/app-chunk.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	// Fathom frame with a different error must stay.
+	expect(
+		filterFathomRemoveChildNullSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of null (reading 'foo')",
+						stacktrace: {
+							frames: [
+								{
+									abs_path: 'https://cdn.usefathom.com/script.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of null (reading 'removeChild')",
+						stacktrace: {
+							frames: [
+								{
+									abs_path: 'https://cdn.usefathom.com/script.js',
+								},
+							],
+						},
 					},
 				],
 			},

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -310,6 +310,26 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 			},
 		}),
 	).not.toBeNull()
+	// Pathname/substring lookalike on a non-Fathom host must stay.
+	expect(
+		filterFathomRemoveChildNullSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of null (reading 'removeChild')",
+						stacktrace: {
+							frames: [
+								{
+									abs_path: 'https://heykody.dev/cdn.usefathom.com/script.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
 	// Fathom frame with a different error must stay.
 	expect(
 		filterFathomRemoveChildNullSentryEvent({

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -218,14 +218,21 @@ export function filterBrowserInjectedGlobalNoiseSentryEvent<
 const fathomRemoveChildNullMessage =
 	/^(?:TypeError:\s*)?Cannot read propert(?:y|ies) of null \(reading ['"]removeChild['"]\)$/
 
-const fathomScriptUrlPattern = /cdn\.usefathom\.com\//i
+const fathomAnalyticsHostname = 'cdn.usefathom.com'
 
 export function isFathomRemoveChildNullMessage(message: string) {
 	return fathomRemoveChildNullMessage.test(message.trim())
 }
 
 export function isFathomAnalyticsStackFrameUrl(url: string) {
-	return fathomScriptUrlPattern.test(url)
+	try {
+		return (
+			new URL(url, 'https://sentry.invalid').hostname ===
+			fathomAnalyticsHostname
+		)
+	} catch {
+		return false
+	}
 }
 
 export function isFathomRemoveChildNullSentryEvent(

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -3,9 +3,18 @@
  * tests can exercise the predicates with plain event shapes.
  */
 
+type SentryStackFrame = {
+	filename?: string
+	abs_path?: string
+	absPath?: string
+}
+
 type SentryExceptionValue = {
 	type?: string
 	value?: string
+	stacktrace?: {
+		frames?: Array<SentryStackFrame>
+	}
 }
 
 export type SentryErrorEventLike = {
@@ -20,6 +29,20 @@ function sentryEventMessages(event: SentryErrorEventLike) {
 		event.message,
 		...(event.exception?.values?.map((value) => value.value) ?? []),
 	]
+}
+
+function sentryEventStackFrameUrls(event: SentryErrorEventLike) {
+	const urls: Array<string> = []
+	for (const value of event.exception?.values ?? []) {
+		for (const frame of value.stacktrace?.frames ?? []) {
+			for (const candidate of [frame.abs_path, frame.absPath, frame.filename]) {
+				if (typeof candidate === 'string' && candidate.length > 0) {
+					urls.push(candidate)
+				}
+			}
+		}
+	}
+	return urls
 }
 
 /**
@@ -181,6 +204,48 @@ export function filterBrowserInjectedGlobalNoiseSentryEvent<
 	return event
 }
 
+/**
+ * Fathom Analytics (`cdn.usefathom.com/script.js`) tracks pageviews with a
+ * temporary `<img>` beacon and removes it from `load`/`error` handlers via
+ * `img.parentNode.removeChild(img)`. When the beacon was already detached
+ * (SPA navigation / soft reload), `parentNode` is null and Chromium throws.
+ * Signature from production issue 7653117289 / KODY-CLOUDFLARE-3Q.
+ *
+ * Match is intentionally narrow: removeChild-on-null TypeError text AND a
+ * stack frame from the Fathom CDN. Never blanket-drop removeChild errors from
+ * app code.
+ */
+const fathomRemoveChildNullMessage =
+	/^(?:TypeError:\s*)?Cannot read propert(?:y|ies) of null \(reading ['"]removeChild['"]\)$/
+
+const fathomScriptUrlPattern = /cdn\.usefathom\.com\//i
+
+export function isFathomRemoveChildNullMessage(message: string) {
+	return fathomRemoveChildNullMessage.test(message.trim())
+}
+
+export function isFathomAnalyticsStackFrameUrl(url: string) {
+	return fathomScriptUrlPattern.test(url)
+}
+
+export function isFathomRemoveChildNullSentryEvent(
+	event: SentryErrorEventLike,
+) {
+	const hasRemoveChildNull = sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' && isFathomRemoveChildNullMessage(message),
+	)
+	if (!hasRemoveChildNull) return false
+	return sentryEventStackFrameUrls(event).some(isFathomAnalyticsStackFrameUrl)
+}
+
+export function filterFathomRemoveChildNullSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T): T | null {
+	if (isFathomRemoveChildNullSentryEvent(event)) return null
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -199,6 +264,9 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 		filterBrowserInjectedGlobalNoiseSentryEvent(event, originalException) ===
 		null
 	) {
+		return null
+	}
+	if (filterFathomRemoveChildNullSentryEvent(event) === null) {
 		return null
 	}
 	return event

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -32,8 +32,8 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// permission-denied from Replay/hydration on restricted nodes,
 		// injected wallet/`__firefox__` globals, and Fathom beacon
 		// removeChild-on-null) — see filterBrowserSentryEvent /
-		// KODY-CLOUDFLARE-23 / issues 7639685398, 7648833360, 7648833403,
-		// 7653117289.
+		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / issues 7639685398,
+		// 7648833360, 7648833403, 7653117289.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -29,9 +29,11 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		replaysSessionSampleRate: 0,
 		replaysOnErrorSampleRate: 1.0,
 		// Drop expected browser noise (AbortError aborts, Firefox DOM
-		// permission-denied from Replay/hydration on restricted nodes, and
-		// injected wallet/`__firefox__` globals) — see filterBrowserSentryEvent
-		// / KODY-CLOUDFLARE-23 / issues 7639685398, 7648833360, 7648833403.
+		// permission-denied from Replay/hydration on restricted nodes,
+		// injected wallet/`__firefox__` globals, and Fathom beacon
+		// removeChild-on-null) — see filterBrowserSentryEvent /
+		// KODY-CLOUDFLARE-23 / issues 7639685398, 7648833360, 7648833403,
+		// 7653117289.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters browser Sentry noise from **KODY-CLOUDFLARE-3Q** (`7653117289`).

Fathom Analytics (`cdn.usefathom.com/script.js`) inserts a temporary `<img>` beacon and removes it in `load`/`error` handlers via `img.parentNode.removeChild(img)`. After SPA navigation the beacon can already be detached, so `parentNode` is null and Chromium throws:

`TypeError: Cannot read properties of null (reading 'removeChild')`

Sentry's `browserapierrors.addEventListener` wrapper captures that third-party throw. Not a Kody product bug and not reasonably fixable in app code (external script).

### Change

- Add `filterFathomRemoveChildNullSentryEvent` in `sentry-browser-filters.ts`
- Match requires **both** the Chromium removeChild-on-null TypeError text **and** a stack frame whose hostname is `cdn.usefathom.com` (so real app `removeChild` bugs still report)
- Wire into `filterBrowserSentryEvent`; unit tests cover drop / keep / hostname lookalike cases

### Outcome

**filtered** — ship this filter, then ignore the Sentry issue so it stops paging.

No sibling unresolved issues share this Fathom / removeChild signature.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `bd33593e` · **Head:** `2888b905`

**Classification:** composes — narrow browser `beforeSend` filter on the existing client Sentry path; no new primitives or contracts.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — extends client Sentry noise filter list only                |

### System map

Browser errors still flow through the existing client Sentry init; this PR only drops one third-party Fathom signature in `beforeSend`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	sentry["Sentry browser SDK<br/>beforeSend"]:::untouched
	appUi -->|"filterFathomRemoveChildNullSentryEvent"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77b61193-45a9-48e1-a9de-2165563fa554?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77b61193-45a9-48e1-a9de-2165563fa554&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced browser error noise by filtering a specific Fathom Analytics `removeChild` error.
  * Continued reporting similar application errors and unrelated analytics errors normally.
  * Improved browser error filtering for events with nested exception stack frames.
  * Added coverage to help ensure valid browser errors remain visible in monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->