### PR TITLE
fix(status): keep uptime bars inside cards on mobile

### DIFF
--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -45,6 +45,10 @@ test('status page renders components, incidents, unknown state, and escapes deta
 	expect(healthy).toContain('99.98% uptime')
 	expect(healthy).toContain('http-equiv="refresh"')
 	expect(healthy).toMatch(/operational|All systems/i)
+	// Mobile phones cannot fit 90×2px bars + gaps; bars must be allowed to shrink.
+	expect(healthy).toMatch(/\.bar\s*\{[^}]*min-width:\s*0/)
+	expect(healthy).toMatch(/\.bars\s*\{[^}]*overflow:\s*hidden/)
+	expect(healthy).not.toMatch(/\.bar\s*\{[^}]*min-width:\s*2px/)
 
 	const down = renderStatusPage(
 		snapshot({

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -64,8 +64,10 @@ h1 { font-size: 1.5rem; margin: 0; }
 	border-radius: 0.75rem;
 	padding: 1rem 1.25rem;
 	margin-bottom: 1rem;
+	overflow: hidden;
+	min-width: 0;
 }
-.component { display: flex; flex-direction: column; gap: 0.5rem; }
+.component { display: flex; flex-direction: column; gap: 0.5rem; min-width: 0; }
 .component-header { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
 .component-name { font-weight: 600; }
 .component-meta { color: var(--muted); font-size: 0.85rem; }
@@ -73,12 +75,34 @@ h1 { font-size: 1.5rem; margin: 0; }
 .dot.operational { background: var(--ok); }
 .dot.down { background: var(--down); }
 .dot.unknown { background: var(--unknown); }
-.bars { display: flex; gap: 2px; height: 2rem; align-items: stretch; }
-.bar { flex: 1 1 0; border-radius: 1px; background: var(--ok); min-width: 2px; }
+/* 90 day bars: allow shrink below 2px so the row fits phone content widths
+ * (iPhone ~321px after padding; min-width:2px + gaps overflowed). */
+.bars {
+	display: flex;
+	gap: 2px;
+	height: 2rem;
+	align-items: stretch;
+	min-width: 0;
+	overflow: hidden;
+}
+.bar {
+	flex: 1 1 0;
+	border-radius: 1px;
+	background: var(--ok);
+	min-width: 0;
+}
 .bar.empty { background: var(--border); }
 .bar.partial { background: var(--partial); }
 .bar.bad { background: var(--down); }
-.bars-legend { display: flex; justify-content: space-between; color: var(--muted); font-size: 0.75rem; }
+.bars-legend {
+	display: flex;
+	justify-content: space-between;
+	gap: 0.5rem;
+	color: var(--muted);
+	font-size: 0.75rem;
+	min-width: 0;
+}
+.bars-legend span { min-width: 0; overflow-wrap: anywhere; }
 .incident { border-left: 3px solid var(--down); padding-left: 0.75rem; margin: 0.75rem 0; }
 .incident.resolved { border-left-color: var(--ok); }
 .incident-title { font-weight: 600; }

--- a/packages/worker/src/email/inbound-due-owners.ts
+++ b/packages/worker/src/email/inbound-due-owners.ts
@@ -156,8 +156,11 @@ export async function loadInboundDueOwnersHealth(input: {
 	}
 }
 
-export function getMailboxInboundDueAt(sql: SqlStorage): string | null {
-	const nowMs = Date.now()
+export function getMailboxInboundDueAt(
+	sql: SqlStorage,
+	now: Date = new Date(),
+): string | null {
+	const nowMs = now.getTime()
 	const candidates: Array<string> = []
 	const stale = sql
 		.exec<{

--- a/packages/worker/src/email/inbound-due-owners.ts
+++ b/packages/worker/src/email/inbound-due-owners.ts
@@ -158,9 +158,9 @@ export async function loadInboundDueOwnersHealth(input: {
 
 export function getMailboxInboundDueAt(
 	sql: SqlStorage,
-	now: Date = new Date(),
+	now?: Date,
 ): string | null {
-	const nowMs = now.getTime()
+	const nowMs = (now ?? new Date()).getTime()
 	const candidates: Array<string> = []
 	const stale = sql
 		.exec<{

--- a/packages/worker/src/email/mailbox-do.ts
+++ b/packages/worker/src/email/mailbox-do.ts
@@ -820,6 +820,7 @@ class MailboxBase extends DurableObject<Env> implements MailboxRpc {
 
 	async getInboundDueWorkHint(input: {
 		ownerId: string
+		now?: string
 	}): Promise<{ dueAt: string | null }> {
 		return this.inbound.getInboundDueWorkHint(input)
 	}

--- a/packages/worker/src/email/mailbox-inbound-commands.ts
+++ b/packages/worker/src/email/mailbox-inbound-commands.ts
@@ -306,6 +306,13 @@ export class MailboxInboundCommands {
 		input: Parameters<MailboxRpc['getInboundDueWorkHint']>[0],
 	) {
 		this.store.assertOwner(input.ownerId)
-		return { dueAt: getMailboxInboundDueAt(this.ctx.storage.sql) }
+		let now: Date | undefined
+		if (input.now != null) {
+			const parsed = Date.parse(input.now)
+			if (Number.isFinite(parsed)) now = new Date(parsed)
+		}
+		return {
+			dueAt: getMailboxInboundDueAt(this.ctx.storage.sql, now),
+		}
 	}
 }

--- a/packages/worker/src/email/mailbox-maintenance-commands.ts
+++ b/packages/worker/src/email/mailbox-maintenance-commands.ts
@@ -82,7 +82,10 @@ export class MailboxMaintenanceCommands {
 	}
 
 	private nextAlarmDueAtMs(nowMs: number = Date.now()) {
-		const inboundDueAt = getMailboxInboundDueAt(this.ctx.storage.sql)
+		const inboundDueAt = getMailboxInboundDueAt(
+			this.ctx.storage.sql,
+			new Date(nowMs),
+		)
 		const inboundDueAtMs =
 			inboundDueAt == null ? null : Date.parse(inboundDueAt)
 		const dueTimes = [

--- a/packages/worker/src/email/mailbox-types.ts
+++ b/packages/worker/src/email/mailbox-types.ts
@@ -650,6 +650,8 @@ type MailboxCoreRpc = {
 	}) => Promise<MailboxRunRetentionNowResult>
 	getInboundDueWorkHint: (input: {
 		ownerId: string
+		/** Optional clock for due-at clamping; defaults to wall clock. */
+		now?: string
 	}) => Promise<{ dueAt: string | null }>
 	purge: () => Promise<{ ok: true }>
 }

--- a/packages/worker/src/email/reconcile-inbound-deliveries.ts
+++ b/packages/worker/src/email/reconcile-inbound-deliveries.ts
@@ -212,7 +212,10 @@ export async function sweepStaleInboundDeliveries(input: {
 				const hint = await mailboxRpc({
 					env: input.env,
 					userId,
-				}).getInboundDueWorkHint({ ownerId: userId })
+				}).getInboundDueWorkHint({
+					ownerId: userId,
+					now: now.toISOString(),
+				})
 				await replaceInboundDueOwnerHint({
 					db: input.env.APP_DB,
 					userId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On iPhone-width viewports, the 90-day uptime bars on [status.heykody.dev](https://status.heykody.dev) overflowed past the card edge (reported in https://x.com/i/status/2084909856432275934).

Each bar had `min-width: 2px` with a 2px gap, so 90 days needed ~358px while the card content area is only ~321px after page/card padding. Bars now shrink (`min-width: 0`) and the row clips inside the card.

Also unblocks Workers CI: `getMailboxInboundDueAt` was clamping stale delivery due-ats with wall-clock `Date.now()` even when sweeps injected a frozen `now`, so once real time passed the fixture’s `created_at+48h` the due-owners test failed.

## Test plan

- [x] Unit test asserts CSS no longer pins bars to 2px min-width and sets overflow clipping
- [ ] After deploy: open status.heykody.dev at ~390px width and confirm bars stay inside cards
- [ ] Workers CI green (inbound due-owners sweep test)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `865304b0` · **Head:** `17dd55bd`

**Classification:** extends — status page CSS for mobile bar fit; inbound due-at clamp honors injected sweep clock.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `status-page` | surfaces | extends — bar/card CSS so uptime rows no longer overflow on mobile |
| (email inbound due owners) | — | extends — `getMailboxInboundDueAt` / sweep hint use injectable `now` |

### System map

Status worker HTML CSS plus a small inbound due-at clock consistency fix needed for CI.

**Legend:** green = composes · amber = extended · red = new · gray = context.

```mermaid
flowchart LR
	statusPage["status-page<br/>Public status page"]:::extended
	browser["Browser<br/>mobile viewport"]:::untouched
	browser -->|"GET /"| statusPage
	classDef extended fill:#9a6700,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** `.bar { min-width: 2px }` + gaps made the 90-day flex row wider than the card on iPhone widths. Separately, due-at clamping ignored sweep `now`.

**After:** bars may shrink (`min-width: 0`), `.bars` / `.card` clip overflow; due-at clamp uses the same clock as the sweep.

### Risk and invariants

- **Risk:** medium (public status surface + inbound due hint path).
- **Invariants:** status page remains independently deployed; due-at wall-clock behavior unchanged when `now` is omitted.

### Docs / decisions

- None required.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-207ec661-71e0-476a-a271-f3f2a5285500?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-207ec661-71e0-476a-a271-f3f2a5285500&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status page responsiveness on narrow screens.
  * Prevented horizontal overflow in cards, charts, and legends.
  * Allowed chart bars and legend text to adapt gracefully to limited space.
  * Improved the accuracy and consistency of inbound email due-time scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->