### PR TITLE
Raise max plan email caps above every purchasable plan

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -71,14 +71,17 @@ The `max` plan is the operator/manual ceiling: a high finite tier admins assign
 deliberately. It is not a public or Stripe-purchasable plan. Email resources use
 `maxPlanEmailLimits` because inbound volume is attacker-controlled and outbound
 sending is an outreach-abuse surface — use `resolveEmailResourceLimit` to read
-those caps. All other resources use the ordinary `planLimits.max` numbers.
+those caps. The caps stay finite but dominate every other plan's email limits,
+so granting `max` never reduces email capacity (`email_message_bytes` stays at
+pro/partner parity because the per-message ceiling is a platform bound, not a
+scalable quota). All other resources use the ordinary `planLimits.max` numbers.
 
 | Resource                      | Limit       |
 | ----------------------------- | ----------- |
-| `email_sends_per_day`         | 100         |
-| `email_receives_per_day`      | 200         |
-| `stored_email_messages`       | 2,000       |
-| `email_message_bytes`         | 512 KiB     |
+| `email_sends_per_day`         | 10,000      |
+| `email_receives_per_day`      | 20,000      |
+| `stored_email_messages`       | 100,000     |
+| `email_message_bytes`         | 768 KiB     |
 | `concurrent_workflows`        | 5,000       |
 | `scheduled_jobs`              | 5,000       |
 | `saved_packages`              | 10,000      |

--- a/docs/use/email-primitives.md
+++ b/docs/use/email-primitives.md
@@ -91,8 +91,8 @@ Inbound storage is quota-gated per user:
   blocked by quota.
 - Plan users get their plan's limits. New accounts start on the `free` plan
   unless an invite assigns another tier. The operator-only `max` plan uses
-  finite email caps (100 sends/day, 200 receives/day, 2,000 stored messages, 512
-  KiB per message); it is not a public or paid tier.
+  finite email caps (10,000 sends/day, 20,000 receives/day, 100,000 stored
+  messages, 768 KiB per message); it is not a public or paid tier.
 - Quota, size, and unverified-account rejections store at most five detailed
   `rejected` delivery events per inbox per UTC day; further rejections increment
   a single daily aggregate event (with a total count and the last reason) so
@@ -120,8 +120,8 @@ Inbound storage is quota-gated per user:
   platform-assigned address, and `email_send` only delivers to the signed-in
   user's own account email. `email_reply` is the only way to address external
   recipients, and only recipients taken from stored inbound mail.
-- Outbound sends consume a per-day entitlement. The `max` plan allows 100 send
-  attempts per UTC day.
+- Outbound sends consume a per-day entitlement. The `max` plan allows 10,000
+  send attempts per UTC day.
 - A successful send request has `processing_status: "sent"`. Cloudflare delivery
   events independently populate `delivery_status` with `delivered`, `deferred`,
   `bounced`, `failed`, `rejected`, or `complained`; use

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -191,19 +191,22 @@ export const entitlementResourceLabels: Record<EntitlementResource, string> = {
 }
 
 /**
- * Inherited abuse caps for the first-class `max` plan. Email is
- * abuse-sensitive in both directions — inbound volume is
- * attacker-controlled (anyone can send to a `{username}@<platform domain>`
- * address) and outbound sending is an outreach-abuse surface — so `max` is
- * not uncapped for mail. These are intentional abuse backstops (not the
- * ordinary 100×-pro derivation used for other max ceilings) and sit between
- * the `free` and `pro` plan email limits.
+ * Email caps for the first-class `max` plan. Email is abuse-sensitive in
+ * both directions — inbound volume is attacker-controlled (anyone can send
+ * to a `{username}@<platform domain>` address) and outbound sending is an
+ * outreach-abuse surface — so `max` is not uncapped for mail. These are
+ * intentional abuse backstops (not the ordinary 100×-pro derivation used
+ * for other max ceilings), but they dominate every other plan's email
+ * limits so granting `max` never reduces a user's email capacity.
+ * `email_message_bytes` is pinned to pro/partner parity because the
+ * per-message ceiling is a platform bound (see the PlanLimits field doc),
+ * not a scalable quota.
  */
 export const maxPlanEmailLimits = {
-	email_sends_per_day: 100,
-	email_receives_per_day: 200,
-	stored_email_messages: 2_000,
-	email_message_bytes: 512 * 1024,
+	email_sends_per_day: 10_000,
+	email_receives_per_day: 20_000,
+	stored_email_messages: 100_000,
+	email_message_bytes: 768 * 1024,
 } as const satisfies Partial<Record<EntitlementResource, number>>
 
 export type MaxPlanEmailResource = keyof typeof maxPlanEmailLimits


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes the inverted email entitlements on the operator-only `max` plan. The `max` email caps previously sat *between* `free` and `pro` (100 sends/day vs pro's 200, 200 receives/day vs pro's 1,000, 2,000 stored messages vs pro's 10,000, 512 KiB per message vs pro's 768 KiB). Because `resolveEffectivePlan` lets a manual `max` grant beat a Stripe `pro` subscription, granting `max` to a paying Pro user *reduced* their email capacity.

New `maxPlanEmailLimits`:

| Resource | Before | After |
| --- | --- | --- |
| `email_sends_per_day` | 100 | 10,000 |
| `email_receives_per_day` | 200 | 20,000 |
| `stored_email_messages` | 2,000 | 100,000 |
| `email_message_bytes` | 512 KiB | 768 KiB |

The caps stay finite (email remains an abuse-sensitive surface in both directions) but now dominate every other plan, so a `max` grant is never an email downgrade. `email_message_bytes` is pinned to pro/partner parity because the per-message ceiling is a platform bound (SQLite ~2 MB row cap with worst-case ~2× extracted bodies), not a scalable quota.

## Why

Requested product decision: `max` should allow 10,000 email sends per day, and the "max is below pro on email" quirk should be gone.

## Changes

- `packages/worker/src/entitlements/plans.ts` — new `maxPlanEmailLimits` values and updated rationale comment.
- `docs/contributing/architecture/entitlements.md` — updated `max` limits table and prose.
- `docs/use/email-primitives.md` — updated user-facing cap numbers.

No enforcement logic changes; tests reference `maxPlanEmailLimits` symbolically and continue to assert that `max` is finite for email.

## Note for reviewers

Pre-existing, untouched by this PR: the inbound parser hard cap `maxRawMimeBytes = 512 KiB` (`packages/worker/src/email/parser.ts`) already undercuts pro/partner's 768 KiB `email_message_bytes` on the inbound path — an inbound message between 512 KiB and 768 KiB passes the entitlement check but fails in `readForwardableEmailRawMime` as a retryable storage error. Worth a follow-up.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7ed14323` · **Head:** `63b165f1`

**Classification:** extends — changes the `entitlements` primitive's plan-limit contract (the `max` plan's email caps); no new primitives, no logic changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — `maxPlanEmailLimits` values raised so `max` dominates every purchasable plan on email |

### System map

The change is confined to the plan registry; email enforcement points read the new caps through the existing `resolveEmailResourceLimit` / `consumeDailyEntitlement` paths.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	email["email<br/>Email"]:::untouched
	email -->|"resolveEmailResourceLimit / consumeDailyEntitlement read new max caps"| entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
maxPlanEmailLimits (max plan email caps)
  email_sends_per_day:    100      → 10_000
  email_receives_per_day: 200      → 20_000
  stored_email_messages:  2_000    → 100_000
  email_message_bytes:    512 KiB  → 768 KiB
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the `max` plan email limits, including higher daily send/receive quotas, more stored messages, and a larger per-message size cap.
  * Outbound sends for the `max` plan now allow 10,000 attempts per UTC day.
* **Documentation**
  * Updated the email plan documentation to reflect the new `max` plan quotas and message size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->