### PR TITLE
Sweep abandoned repo sessions after 7 idle days and raise session limits 10×

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -84,7 +84,7 @@ those caps. All other resources use the ordinary `planLimits.max` numbers.
 | `saved_packages`              | 10,000      |
 | `package_services`            | 1,000       |
 | `persistent_package_services` | 1 (allowed) |
-| `repo_sessions`               | 2,000       |
+| `repo_sessions`               | 20,000      |
 | `secrets`                     | 10,000      |
 | `storage_bytes`               | 100 GiB     |
 | `execute_calls_per_day`       | 500,000     |

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -242,7 +242,11 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		// Long-lived compute. Unchanged, and persistent services stay off.
 		maxPackageServices: 1,
 		packageServicePersistentAllowed: 0,
-		maxRepoSessions: 5,
+		// Sessions are cheap (D1 row + dormant DO workspace + Artifacts
+		// branch) and the 7-day abandoned-session sweep keeps idle ones from
+		// accumulating, so the caps are sized for agent workflows that open
+		// a session per conversation rather than for genuine concurrency.
+		maxRepoSessions: 50,
 		// notify-self and reply-to-stored only, so the outreach-abuse surface
 		// is small; a daily digest plus a few alerts should not hit the wall.
 		maxEmailSendsPerDay: 10,
@@ -264,7 +268,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxScheduledJobs: 50,
 		maxPackageServices: 10,
 		packageServicePersistentAllowed: 1,
-		maxRepoSessions: 20,
+		maxRepoSessions: 200,
 		maxEmailSendsPerDay: 200,
 		maxEmailReceivesPerDay: 1000,
 		maxStoredEmailMessages: 10_000,
@@ -281,7 +285,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxScheduledJobs: 100,
 		maxPackageServices: 20,
 		packageServicePersistentAllowed: 1,
-		maxRepoSessions: 40,
+		maxRepoSessions: 400,
 		maxEmailSendsPerDay: 500,
 		maxEmailReceivesPerDay: 2000,
 		maxStoredEmailMessages: 25_000,
@@ -303,8 +307,8 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxPackageServices: 1_000,
 		// Same finite 0/1 gate as pro (1 = persistent services allowed).
 		packageServicePersistentAllowed: 1,
-		// 100× pro (20) → 2_000.
-		maxRepoSessions: 2_000,
+		// 100× pro (200) → 20_000.
+		maxRepoSessions: 20_000,
 		// Inherited abuse caps (not 100× pro); see maxPlanEmailLimits.
 		maxEmailSendsPerDay: maxPlanEmailLimits.email_sends_per_day,
 		maxEmailReceivesPerDay: maxPlanEmailLimits.email_receives_per_day,

--- a/packages/worker/src/repo/repo-session-cleanup.node.test.ts
+++ b/packages/worker/src/repo/repo-session-cleanup.node.test.ts
@@ -35,7 +35,7 @@ test('repo session branch cleanup deletes expired and abandoned session branches
 		expect.anything(),
 		{
 			now: '2026-06-24T20:00:00.000Z',
-			abandonedBefore: '2026-02-24T20:00:00.000Z',
+			abandonedBefore: '2026-06-17T20:00:00.000Z',
 			limit: 10,
 		},
 	)

--- a/packages/worker/src/repo/repo-session-cleanup.ts
+++ b/packages/worker/src/repo/repo-session-cleanup.ts
@@ -3,7 +3,14 @@ import { listRepoSessionsForBranchCleanup } from './repo-sessions.ts'
 import { repoSessionRpc } from './repo-session-do.ts'
 
 const defaultCleanupBatchSize = 50
-const abandonedSessionRetentionMs = 120 * 24 * 60 * 60 * 1000
+/**
+ * Active sessions untouched for this long are considered abandoned and hard
+ * deleted (branch + D1 row + DO workspace). Every session operation bumps
+ * `updated_at`, so this is idle time, not age — but unpublished work in a
+ * swept session is unrecoverable, so the window stays generous relative to
+ * a working session's natural cadence.
+ */
+const abandonedSessionRetentionMs = 7 * 24 * 60 * 60 * 1000
 
 export type RepoSessionBranchCleanupResult = {
 	checked: number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two coordinated repo-session policy changes:

1. **Abandoned-session sweep: 120 → 7 idle days.** The `repo_session_cleanup` lane (every 5 minutes) hard-deletes active sessions whose `updated_at` is older than the retention window. Every session operation bumps `updated_at` via `touchRepoSession`, so this is idle time, not age — a session in any active use is never swept. Published/discarded retention stays at 14 days.
2. **`repo_sessions` plan limits raised 10×:** free 5 → 50, pro 20 → 200, partner 40 → 400, max 2,000 → 20,000 (keeps the 100×-pro derivation).

## Why

Production data: the operator account alone had 217 active sessions, ~100 of them touched within the last 7 days, 28 in the last day — agents open a session per conversation and essentially never call `repo_discard_session`, and the 120-day backstop meant nothing ever got cleaned. The two changes work together: the 7-day sweep keeps the active count honest (idle sessions cost a D1 row, a dormant DO workspace, and an Artifacts branch — cheap but unmetered), and the 10× caps stop agent workflows from hitting the entitlement wall mid-conversation.

## Trade-off (deliberate)

A session untouched for 7 days is hard-deleted along with any unpublished work — `repo_commit` is local to the DO workspace, so uncommitted edits and local-only commits in a swept session are unrecoverable. Accepted for now: 7 idle days on a conversation-scoped editing session is a dead conversation. A possible follow-up is a checkpoint-push of workspace state to the `sessions/*` branch before deletion, turning the sweep into an archive.

## Changes

- `packages/worker/src/repo/repo-session-cleanup.ts` — `abandonedSessionRetentionMs` 120d → 7d, with rationale comment.
- `packages/worker/src/entitlements/plans.ts` — `maxRepoSessions` ×10 on all four plans.
- `packages/worker/src/repo/repo-session-cleanup.node.test.ts` — expected `abandonedBefore` cutoff updated for the 7-day window.
- `docs/contributing/architecture/entitlements.md` — max-plan table row.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `89185bf6` · **Head:** `00ba095a`

**Classification:** extends — changes the retention contract of the repo-session cleanup lane and the `entitlements` plan-limit values; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repos` | assistant | extends — abandoned active-session sweep window 120d → 7d idle |
| `entitlements` | auth | extends — `repo_sessions` limits ×10 on all plans |

### System map

The scheduled cleanup lane sweeps idle-active repo sessions on a shorter window; session opening checks the raised entitlement caps.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::untouched
	repos["repos<br/>Repos"]:::extended
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	scheduledCron -->|"repo_session_cleanup lane: abandoned cutoff now updated_at ≤ now − 7d"| repos
	repos -->|"repo_open_session checks maxRepoSessions (now 10×)"| entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
abandonedSessionRetentionMs: 120 days → 7 days (idle, keyed on updated_at)
maxRepoSessions: free 5 → 50 · pro 20 → 200 · partner 40 → 400 · max 2_000 → 20_000
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased repository session quotas across all plans, including 100× the Pro allowance for the Max plan.
  - Abandoned repository sessions are now automatically removed after 7 days of inactivity.

- **Documentation**
  - Updated plan entitlement documentation to reflect the new session limits and Max plan calculation.
  - Clarified session cleanup timing and its permanent removal of abandoned session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->