### PR TITLE
Account-wide entitlement usage visibility and usage_get capability

### DIFF
--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -565,6 +565,11 @@ export function AccountBillingRoute(handle: Handle) {
 												{tier.price}
 											</span>
 											<p mix={css(descriptionCss)}>{tier.description}</p>
+											<p mix={css({ margin: 0 })}>
+												<a href="/account/usage" mix={css(primaryLinkCss)}>
+													See your current usage
+												</a>
+											</p>
 											{isCurrent || isIncluded ? (
 												<div>
 													<button

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -360,7 +360,7 @@ export function AccountUsageRoute(handle: Handle) {
 																	lineHeight: 1.4,
 																})}
 															>
-																{item.whatCounts}. {item.howToReduce}
+																{item.whatCounts} {item.howToReduce}
 															</span>
 														</div>
 													</td>

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -37,8 +37,9 @@ const usageApiPath = '/account/usage.json'
 const usagePath = '/account/usage'
 const billingPath = '/account/billing'
 
-const entitlementGroupOrder: Array<AccountUsageEntitlementConsumption['group']> =
-	['daily', 'counts', 'storage', 'limits']
+const entitlementGroupOrder: Array<
+	AccountUsageEntitlementConsumption['group']
+> = ['daily', 'counts', 'storage', 'limits']
 
 const entitlementGroupLabels: Record<
 	AccountUsageEntitlementConsumption['group'],
@@ -105,9 +106,7 @@ function isUsagePath(href: string) {
 	return new URL(href, 'http://localhost').pathname === usagePath
 }
 
-function groupEntitlementRows(
-	rows: Array<AccountUsageEntitlementConsumption>,
-) {
+function groupEntitlementRows(rows: Array<AccountUsageEntitlementConsumption>) {
 	const grouped = new Map<
 		AccountUsageEntitlementConsumption['group'],
 		Array<AccountUsageEntitlementConsumption>
@@ -126,7 +125,7 @@ function groupEntitlementRows(
 		.filter((entry) => entry.rows.length > 0)
 }
 
-function UsageProgressBar(item: AccountUsageEntitlementConsumption) {
+function renderUsageProgressBar(item: AccountUsageEntitlementConsumption) {
 	const percent = usageProgressPercent(item)
 	if (percent === null) return null
 	const barColor = item.overEightyPercent ? chartColor.amber : chartColor.blue
@@ -294,8 +293,8 @@ export function AccountUsageRoute(handle: Handle) {
 								>
 									{usage.warnings.map((item) => (
 										<li key={item.resource}>
-											<strong>{item.label}</strong>:{' '}
-											{formatCurrentValue(item)} / {formatLimitValue(item)} (
+											<strong>{item.label}</strong>: {formatCurrentValue(item)}{' '}
+											/ {formatLimitValue(item)} (
 											{formatUsagePercent(item.percentOfLimit)}).{' '}
 											{item.howToReduce}{' '}
 											<a href={billingPath} mix={css(primaryLinkCss)}>
@@ -377,8 +376,7 @@ export function AccountUsageRoute(handle: Handle) {
 															...(item.overEightyPercent
 																? {
 																		color: chartColor.amber,
-																		fontWeight:
-																			typography.fontWeight.semibold,
+																		fontWeight: typography.fontWeight.semibold,
 																	}
 																: {}),
 														})}
@@ -386,7 +384,7 @@ export function AccountUsageRoute(handle: Handle) {
 														{formatUsagePercent(item.percentOfLimit)}
 													</td>
 													<td mix={css(accountManagementTableCellCss)}>
-														<UsageProgressBar {...item} />
+														{renderUsageProgressBar(item)}
 													</td>
 												</tr>
 											))}

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -1,5 +1,6 @@
 import { type Handle, css } from 'remix/ui'
 import {
+	type AccountUsageEntitlementConsumption,
 	type AccountUsageLoaderData,
 	type AdminPlanName,
 } from '#app/loader-data.ts'
@@ -26,7 +27,7 @@ import {
 	accountManagementTableNumericCellCss,
 } from '#client/routes/account-management-components.tsx'
 import { chartColor, formatIntegerNumber } from '#client/charts/chart-theme.ts'
-import { colors, spacing, typography } from '#client/styles/tokens.ts'
+import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import {
 	descriptionCss,
 	primaryLinkCss,
@@ -34,6 +35,26 @@ import {
 
 const usageApiPath = '/account/usage.json'
 const usagePath = '/account/usage'
+const billingPath = '/account/billing'
+
+const entitlementGroupOrder: Array<AccountUsageEntitlementConsumption['group']> =
+	['daily', 'counts', 'storage', 'limits']
+
+const entitlementGroupLabels: Record<
+	AccountUsageEntitlementConsumption['group'],
+	string
+> = {
+	daily: 'Daily rates',
+	counts: 'Resource counts',
+	storage: 'Storage',
+	limits: 'Per-item limits',
+}
+
+const entitlementGroupNotes: Partial<
+	Record<AccountUsageEntitlementConsumption['group'], string>
+> = {
+	daily: 'Counters reset at UTC midnight.',
+}
 
 function formatUsagePercent(value: number | null) {
 	if (value === null) return '—'
@@ -54,12 +75,82 @@ function formatBytes(value: number) {
 }
 
 function formatUsageValue(resource: string, value: number) {
-	if (resource === 'storage_bytes') return formatBytes(value)
+	if (resource === 'storage_bytes' || resource === 'email_message_bytes') {
+		return formatBytes(value)
+	}
 	return formatIntegerNumber(value)
+}
+
+function formatCurrentValue(item: AccountUsageEntitlementConsumption) {
+	if (item.kind === 'per_unit_max') return '—'
+	if (item.kind === 'boolean_allowance') {
+		return item.limit > 0 ? 'Allowed' : 'Not on plan'
+	}
+	return formatUsageValue(item.resource, item.current)
+}
+
+function formatLimitValue(item: AccountUsageEntitlementConsumption) {
+	if (item.kind === 'boolean_allowance') {
+		return item.limit > 0 ? 'Yes' : 'No'
+	}
+	return formatUsageValue(item.resource, item.limit)
+}
+
+function usageProgressPercent(item: AccountUsageEntitlementConsumption) {
+	if (item.percentOfLimit === null) return null
+	return Math.min(100, Math.round(item.percentOfLimit * 100))
 }
 
 function isUsagePath(href: string) {
 	return new URL(href, 'http://localhost').pathname === usagePath
+}
+
+function groupEntitlementRows(
+	rows: Array<AccountUsageEntitlementConsumption>,
+) {
+	const grouped = new Map<
+		AccountUsageEntitlementConsumption['group'],
+		Array<AccountUsageEntitlementConsumption>
+	>()
+	for (const group of entitlementGroupOrder) grouped.set(group, [])
+	for (const row of rows) {
+		const bucket = grouped.get(row.group) ?? []
+		bucket.push(row)
+		grouped.set(row.group, bucket)
+	}
+	return entitlementGroupOrder
+		.map((group) => ({
+			group,
+			rows: grouped.get(group) ?? [],
+		}))
+		.filter((entry) => entry.rows.length > 0)
+}
+
+function UsageProgressBar(item: AccountUsageEntitlementConsumption) {
+	const percent = usageProgressPercent(item)
+	if (percent === null) return null
+	const barColor = item.overEightyPercent ? chartColor.amber : chartColor.blue
+	return (
+		<div
+			role="img"
+			aria-label={`${item.label}: ${formatUsagePercent(item.percentOfLimit)} of plan limit`}
+			mix={css({
+				height: '8px',
+				borderRadius: radius.md,
+				background: colors.border,
+				overflow: 'hidden',
+				minWidth: '4rem',
+			})}
+		>
+			<div
+				mix={css({
+					height: '100%',
+					width: `${percent}%`,
+					background: barColor,
+				})}
+			/>
+		</div>
+	)
 }
 
 export async function accountUsageRouteLoader(
@@ -147,12 +238,15 @@ export function AccountUsageRoute(handle: Handle) {
 		}
 
 		const usage = status === 'ready' ? data : null
+		const groupedRows = usage
+			? groupEntitlementRows(usage.entitlementConsumption)
+			: []
 
 		return (
 			<AccountManagementShell>
 				<AccountPageHeader
 					title="Usage"
-					description="Your current plan limits and how much you are using today."
+					description="Plan limits, current consumption, and what counts toward each resource."
 					currentHref={currentHref}
 				/>
 				{message ? (
@@ -179,7 +273,7 @@ export function AccountUsageRoute(handle: Handle) {
 								]}
 							/>
 							<p mix={css({ margin: `${spacing.sm} 0 0` })}>
-								<a href="/account/billing" mix={css(primaryLinkCss)}>
+								<a href={billingPath} mix={css(primaryLinkCss)}>
 									Manage billing
 								</a>
 							</p>
@@ -194,72 +288,113 @@ export function AccountUsageRoute(handle: Handle) {
 										margin: 0,
 										paddingLeft: spacing.lg,
 										display: 'grid',
-										gap: spacing.xs,
+										gap: spacing.sm,
 										color: colors.text,
 									})}
 								>
 									{usage.warnings.map((item) => (
 										<li key={item.resource}>
-											{item.label}:{' '}
-											{formatUsageValue(item.resource, item.current)} /{' '}
-											{formatUsageValue(item.resource, item.limit)} (
-											{formatUsagePercent(item.percentOfLimit)})
+											<strong>{item.label}</strong>:{' '}
+											{formatCurrentValue(item)} / {formatLimitValue(item)} (
+											{formatUsagePercent(item.percentOfLimit)}).{' '}
+											{item.howToReduce}{' '}
+											<a href={billingPath} mix={css(primaryLinkCss)}>
+												Upgrade your plan
+											</a>
 										</li>
 									))}
 								</ul>
 							</AccountManagementPanel>
 						) : null}
-						<AccountManagementPanel
-							title="Entitlement use"
-							description="Row counts and daily counters enforced against your plan. Daily counters reset at UTC midnight."
-						>
-							<div mix={css({ overflowX: 'auto' })}>
-								<table mix={css(accountManagementTableCss)}>
-									<thead>
-										<tr>
-											<th mix={css(accountManagementTableCellCss)}>Resource</th>
-											<th mix={css(accountManagementTableNumericCellCss)}>
-												In use
-											</th>
-											<th mix={css(accountManagementTableNumericCellCss)}>
-												Limit
-											</th>
-											<th mix={css(accountManagementTableNumericCellCss)}>
-												Used
-											</th>
-										</tr>
-									</thead>
-									<tbody>
-										{usage.entitlementConsumption.map((item) => (
-											<tr key={item.resource}>
-												<td mix={css(accountManagementTableCellCss)}>
-													{item.label}
-												</td>
-												<td mix={css(accountManagementTableNumericCellCss)}>
-													{formatUsageValue(item.resource, item.current)}
-												</td>
-												<td mix={css(accountManagementTableNumericCellCss)}>
-													{formatUsageValue(item.resource, item.limit)}
-												</td>
-												<td
-													mix={css({
-														...accountManagementTableNumericCellCss,
-														...(item.overEightyPercent
-															? {
-																	color: chartColor.amber,
-																	fontWeight: typography.fontWeight.semibold,
-																}
-															: {}),
-													})}
-												>
-													{formatUsagePercent(item.percentOfLimit)}
-												</td>
+						{groupedRows.map(({ group, rows }) => (
+							<AccountManagementPanel
+								key={group}
+								title={entitlementGroupLabels[group]}
+								description={
+									entitlementGroupNotes[group] ??
+									'Current use compared to your plan limit.'
+								}
+							>
+								<div mix={css({ overflowX: 'auto' })}>
+									<table mix={css(accountManagementTableCss)}>
+										<thead>
+											<tr>
+												<th mix={css(accountManagementTableCellCss)}>
+													Resource
+												</th>
+												<th mix={css(accountManagementTableNumericCellCss)}>
+													In use
+												</th>
+												<th mix={css(accountManagementTableNumericCellCss)}>
+													Limit
+												</th>
+												<th mix={css(accountManagementTableNumericCellCss)}>
+													Used
+												</th>
+												<th mix={css(accountManagementTableCellCss)}>
+													Progress
+												</th>
 											</tr>
-										))}
-									</tbody>
-								</table>
-							</div>
-						</AccountManagementPanel>
+										</thead>
+										<tbody>
+											{rows.map((item) => (
+												<tr key={item.resource}>
+													<td mix={css(accountManagementTableCellCss)}>
+														<div
+															mix={css({
+																display: 'grid',
+																gap: spacing.xs,
+															})}
+														>
+															<span
+																mix={css({
+																	fontWeight: typography.fontWeight.medium,
+																	color: colors.text,
+																})}
+															>
+																{item.label}
+															</span>
+															<span
+																mix={css({
+																	fontSize: typography.fontSize.sm,
+																	color: colors.textMuted,
+																	lineHeight: 1.4,
+																})}
+															>
+																{item.whatCounts}. {item.howToReduce}
+															</span>
+														</div>
+													</td>
+													<td mix={css(accountManagementTableNumericCellCss)}>
+														{formatCurrentValue(item)}
+													</td>
+													<td mix={css(accountManagementTableNumericCellCss)}>
+														{formatLimitValue(item)}
+													</td>
+													<td
+														mix={css({
+															...accountManagementTableNumericCellCss,
+															...(item.overEightyPercent
+																? {
+																		color: chartColor.amber,
+																		fontWeight:
+																			typography.fontWeight.semibold,
+																	}
+																: {}),
+														})}
+													>
+														{formatUsagePercent(item.percentOfLimit)}
+													</td>
+													<td mix={css(accountManagementTableCellCss)}>
+														<UsageProgressBar {...item} />
+													</td>
+												</tr>
+											))}
+										</tbody>
+									</table>
+								</div>
+							</AccountManagementPanel>
+						))}
 					</>
 				) : null}
 			</AccountManagementShell>

--- a/packages/worker/src/app/account-usage-data.node.test.ts
+++ b/packages/worker/src/app/account-usage-data.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import { accountUsageEntitlementResources } from '#worker/entitlements/resource-visibility.ts'
 import { createInMemoryRunLogUsageEnv } from '#worker/test-support/run-log-usage.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
@@ -84,7 +85,6 @@ function currentFor(
 	resource: string,
 ) {
 	return data?.entitlementConsumption.find((row) => row.resource === resource)
-		?.current
 }
 
 test('loadAccountUsageData returns plan rows and authoritative UserMeter daily counts', async () => {
@@ -106,9 +106,12 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 	expect(baseline?.ok).toBe(true)
 	expect(baseline?.plan).toBe('free')
 	expect(baseline?.today).toBe('2026-07-25')
-	expect(currentFor(baseline, 'saved_packages')).toBe(2)
-	expect(currentFor(baseline, 'concurrent_workflows')).toBe(0)
-	expect(baseline?.entitlementConsumption.length).toBeGreaterThan(5)
+	expect(currentFor(baseline, 'saved_packages')?.current).toBe(2)
+	expect(currentFor(baseline, 'concurrent_workflows')?.current).toBe(0)
+	expect(baseline?.entitlementConsumption.length).toBe(
+		accountUsageEntitlementResources.length,
+	)
+	expect(currentFor(baseline, 'repos')?.whatCounts).toMatch(/plain repos/i)
 
 	const bootstrapEmail = 'usage-bootstrap@example.com'
 	const bootstrapUserId = testStableUserIdFromEmail(bootstrapEmail)
@@ -136,9 +139,9 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 		userId: 8,
 		now,
 	})
-	expect(currentFor(bootstrapped, 'email_sends_per_day')).toBe(17)
-	expect(currentFor(bootstrapped, 'execute_calls_per_day')).toBe(91)
-	expect(currentFor(bootstrapped, 'saved_packages')).toBe(1)
+	expect(currentFor(bootstrapped, 'email_sends_per_day')?.current).toBe(17)
+	expect(currentFor(bootstrapped, 'execute_calls_per_day')?.current).toBe(91)
+	expect(currentFor(bootstrapped, 'saved_packages')?.current).toBe(1)
 
 	const meterEmail = 'usage-meter@example.com'
 	const meterUserId = testStableUserIdFromEmail(meterEmail)
@@ -180,13 +183,13 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 		userId: 9,
 		now,
 	})
-	expect(currentFor(authoritative, 'email_sends_per_day')).toBe(101)
-	expect(currentFor(authoritative, 'email_receives_per_day')).toBe(202)
-	expect(currentFor(authoritative, 'execute_calls_per_day')).toBe(303)
-	expect(currentFor(authoritative, 'outbound_fetches_per_day')).toBe(404)
-	expect(currentFor(authoritative, 'concurrent_workflows')).toBe(3)
-	expect(currentFor(authoritative, 'stored_email_messages')).toBe(7)
-	expect(currentFor(authoritative, 'saved_packages')).toBe(4)
+	expect(currentFor(authoritative, 'email_sends_per_day')?.current).toBe(101)
+	expect(currentFor(authoritative, 'email_receives_per_day')?.current).toBe(202)
+	expect(currentFor(authoritative, 'execute_calls_per_day')?.current).toBe(303)
+	expect(currentFor(authoritative, 'outbound_fetches_per_day')?.current).toBe(404)
+	expect(currentFor(authoritative, 'concurrent_workflows')?.current).toBe(3)
+	expect(currentFor(authoritative, 'stored_email_messages')?.current).toBe(7)
+	expect(currentFor(authoritative, 'saved_packages')?.current).toBe(4)
 
 	const storageEmail = 'usage-storage@example.com'
 	const storageUserId = testStableUserIdFromEmail(storageEmail)
@@ -197,7 +200,6 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 		packageCount: 0,
 	})
 	const storageEnv = withUsageEnv({ APP_DB: storageDb })
-	// storage_bytes reads from authoritative UserMeter state.
 	await storageEnv.meter.seedStorageBytes({
 		userId: storageUserId,
 		bytes: 4_321,
@@ -207,5 +209,5 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 		userId: 11,
 		now,
 	})
-	expect(currentFor(storageData, 'storage_bytes')).toBe(4_321)
+	expect(currentFor(storageData, 'storage_bytes')?.current).toBe(4_321)
 })

--- a/packages/worker/src/app/account-usage-data.node.test.ts
+++ b/packages/worker/src/app/account-usage-data.node.test.ts
@@ -186,7 +186,9 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 	expect(currentFor(authoritative, 'email_sends_per_day')?.current).toBe(101)
 	expect(currentFor(authoritative, 'email_receives_per_day')?.current).toBe(202)
 	expect(currentFor(authoritative, 'execute_calls_per_day')?.current).toBe(303)
-	expect(currentFor(authoritative, 'outbound_fetches_per_day')?.current).toBe(404)
+	expect(currentFor(authoritative, 'outbound_fetches_per_day')?.current).toBe(
+		404,
+	)
 	expect(currentFor(authoritative, 'concurrent_workflows')?.current).toBe(3)
 	expect(currentFor(authoritative, 'stored_email_messages')?.current).toBe(7)
 	expect(currentFor(authoritative, 'saved_packages')?.current).toBe(4)

--- a/packages/worker/src/app/account-usage-data.ts
+++ b/packages/worker/src/app/account-usage-data.ts
@@ -1,36 +1,13 @@
-import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import {
-	entitlementResourceLabels,
 	parseStoredPlanName,
 	resolveEffectivePlan,
-	resolvePlanLimit,
-	type EntitlementResource,
-	type PlanName,
 } from '#worker/entitlements/plans.ts'
-import { readCurrentEntitlementResourceUsage } from '#worker/entitlements/service.ts'
+import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 import {
 	type AccountUsageEntitlementConsumption,
 	type AccountUsageLoaderData,
 } from './loader-data.ts'
-
-const accountUsageEntitlementResources = [
-	'saved_packages',
-	'scheduled_jobs',
-	'package_services',
-	'persistent_package_services',
-	'repo_sessions',
-	'email_sends_per_day',
-	'email_receives_per_day',
-	'stored_email_messages',
-	'secrets',
-	'concurrent_workflows',
-	'execute_calls_per_day',
-	'outbound_fetches_per_day',
-	'storage_bytes',
-] as const satisfies ReadonlyArray<EntitlementResource>
-
-const warningThreshold = 0.8
 
 type UsageUserRow = {
 	id: number
@@ -61,7 +38,8 @@ export async function loadAccountUsageData(input: {
 		row.stripe_plan,
 	)
 	const usageUserId = resolveUserStableId(row)
-	const entitlementConsumption = await readEntitlementConsumption({
+	const snapshot = await readEntitlementUsageSnapshot({
+		db: input.env.APP_DB,
 		env: input.env,
 		usageUserId,
 		plan,
@@ -70,39 +48,28 @@ export async function loadAccountUsageData(input: {
 
 	return {
 		ok: true,
-		plan,
-		today: utcDayKey(now),
-		entitlementConsumption,
-		warnings: entitlementConsumption.filter((item) => item.overEightyPercent),
+		plan: snapshot.plan,
+		today: snapshot.today,
+		entitlementConsumption: snapshot.resources.map(toAccountUsageRow),
+		warnings: snapshot.warnings.map(toAccountUsageRow),
 	}
 }
 
-async function readEntitlementConsumption(input: {
-	env: Env
-	usageUserId: string
-	plan: PlanName
-	now: Date
-}): Promise<Array<AccountUsageEntitlementConsumption>> {
-	return await Promise.all(
-		accountUsageEntitlementResources.map(async (resource) => {
-			const current = await readCurrentEntitlementResourceUsage({
-				db: input.env.APP_DB,
-				env: input.env,
-				userId: input.usageUserId,
-				resource,
-				now: input.now,
-			})
-			const limit = resolvePlanLimit(input.plan, resource)
-			const percentOfLimit = limit === 0 ? null : current / limit
-			return {
-				resource,
-				label: entitlementResourceLabels[resource],
-				current,
-				limit,
-				percentOfLimit,
-				overEightyPercent:
-					percentOfLimit !== null && percentOfLimit > warningThreshold,
-			}
-		}),
-	)
+function toAccountUsageRow(
+	row: Awaited<
+		ReturnType<typeof readEntitlementUsageSnapshot>
+	>['resources'][number],
+): AccountUsageEntitlementConsumption {
+	return {
+		resource: row.resource,
+		label: row.label,
+		group: row.group,
+		kind: row.kind,
+		whatCounts: row.whatCounts,
+		howToReduce: row.howToReduce,
+		current: row.current,
+		limit: row.limit,
+		percentOfLimit: row.percentOfLimit,
+		overEightyPercent: row.overEightyPercent,
+	}
 }

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -1270,6 +1270,10 @@ export type AccountBillingLoaderData = {
 export type AccountUsageEntitlementConsumption = {
 	resource: string
 	label: string
+	group: 'daily' | 'counts' | 'storage' | 'limits'
+	kind: 'counter' | 'boolean_allowance' | 'per_unit_max'
+	whatCounts: string
+	howToReduce: string
 	current: number
 	limit: number
 	percentOfLimit: number | null

--- a/packages/worker/src/entitlements/resource-visibility.ts
+++ b/packages/worker/src/entitlements/resource-visibility.ts
@@ -1,0 +1,164 @@
+import type { EntitlementResource } from './plans.ts'
+
+export type EntitlementResourceGroup = 'daily' | 'counts' | 'storage' | 'limits'
+
+export type EntitlementResourceVisibilityKind =
+	| 'counter'
+	| 'boolean_allowance'
+	| 'per_unit_max'
+
+export const entitlementResourceGroupLabels: Record<
+	EntitlementResourceGroup,
+	string
+> = {
+	daily: 'Daily rates',
+	counts: 'Resource counts',
+	storage: 'Storage',
+	limits: 'Per-item limits',
+}
+
+export const entitlementResourceGroupNotes: Partial<
+	Record<EntitlementResourceGroup, string>
+> = {
+	daily: 'Counters reset at UTC midnight.',
+}
+
+export type EntitlementResourceVisibility = {
+	group: EntitlementResourceGroup
+	kind: EntitlementResourceVisibilityKind
+	whatCounts: string
+	howToReduce: string
+}
+
+/**
+ * Plain-language copy for account usage UI and the `usage_get` capability.
+ * Keep factual and terse; update when enforcement semantics change.
+ */
+export const entitlementResourceVisibility: Record<
+	EntitlementResource,
+	EntitlementResourceVisibility
+> = {
+	repos: {
+		group: 'counts',
+		kind: 'counter',
+		whatCounts: 'Plain repos you created for package and agent work.',
+		howToReduce: 'Delete repos you no longer need.',
+	},
+	saved_packages: {
+		group: 'counts',
+		kind: 'counter',
+		whatCounts: 'Saved packages published to your account.',
+		howToReduce: 'Remove packages you no longer use.',
+	},
+	scheduled_jobs: {
+		group: 'counts',
+		kind: 'counter',
+		whatCounts: 'Scheduled jobs waiting to run on a schedule.',
+		howToReduce: 'Delete jobs you no longer need.',
+	},
+	package_services: {
+		group: 'counts',
+		kind: 'counter',
+		whatCounts: 'Package services currently running.',
+		howToReduce: 'Stop services you are not using.',
+	},
+	persistent_package_services: {
+		group: 'counts',
+		kind: 'boolean_allowance',
+		whatCounts: 'Whether your plan allows persistent (long-lived) package services.',
+		howToReduce:
+			'Stop persistent services when you do not need them, or upgrade for allowance.',
+	},
+	repo_sessions: {
+		group: 'counts',
+		kind: 'counter',
+		whatCounts:
+			'Active editing sessions opened by agents against your repos.',
+		howToReduce:
+			'Discard finished sessions with repo_discard_session; idle sessions are cleaned up automatically after 7 days.',
+	},
+	email_sends_per_day: {
+		group: 'daily',
+		kind: 'counter',
+		whatCounts: 'Outbound email send attempts today (UTC).',
+		howToReduce: 'Send fewer messages today, or upgrade your plan.',
+	},
+	email_receives_per_day: {
+		group: 'daily',
+		kind: 'counter',
+		whatCounts: 'Inbound email messages accepted for storage today (UTC).',
+		howToReduce:
+			'Reduce inbound volume (filters, fewer public addresses), or upgrade your plan.',
+	},
+	stored_email_messages: {
+		group: 'counts',
+		kind: 'counter',
+		whatCounts: 'Email messages stored in your mailboxes.',
+		howToReduce: 'Delete old messages you no longer need.',
+	},
+	email_message_bytes: {
+		group: 'limits',
+		kind: 'per_unit_max',
+		whatCounts: 'Maximum raw MIME size allowed for a single stored email message.',
+		howToReduce:
+			'Keep attachments and bodies smaller, or upgrade for a higher per-message cap.',
+	},
+	secrets: {
+		group: 'counts',
+		kind: 'counter',
+		whatCounts: 'Secret entries in non-expired secret buckets.',
+		howToReduce: 'Delete secrets you no longer need.',
+	},
+	storage_bytes: {
+		group: 'storage',
+		kind: 'counter',
+		whatCounts:
+			'Durable payload bytes across D1-backed data (email bodies, values, secrets, jobs, package metadata, and similar).',
+		howToReduce: 'Delete stored content you no longer need.',
+	},
+	concurrent_workflows: {
+		group: 'counts',
+		kind: 'counter',
+		whatCounts: 'Workflow runs currently active on your account.',
+		howToReduce: 'Wait for workflows to finish or cancel runs you no longer need.',
+	},
+	execute_calls_per_day: {
+		group: 'daily',
+		kind: 'counter',
+		whatCounts: 'MCP execute tool runs today (UTC), including failed attempts.',
+		howToReduce: 'Run fewer execute calls today, or upgrade your plan.',
+	},
+	outbound_fetches_per_day: {
+		group: 'daily',
+		kind: 'counter',
+		whatCounts:
+			'Sandbox outbound HTTP fetches through the fetch gateway today (UTC).',
+		howToReduce: 'Fetch less from user code today, or upgrade your plan.',
+	},
+}
+
+/** All entitlement resources in display order (grouped). */
+export const accountUsageEntitlementResources = [
+	'email_sends_per_day',
+	'email_receives_per_day',
+	'execute_calls_per_day',
+	'outbound_fetches_per_day',
+	'repos',
+	'saved_packages',
+	'scheduled_jobs',
+	'package_services',
+	'persistent_package_services',
+	'repo_sessions',
+	'stored_email_messages',
+	'secrets',
+	'concurrent_workflows',
+	'storage_bytes',
+	'email_message_bytes',
+] as const satisfies ReadonlyArray<EntitlementResource>
+
+export const entitlementResourceGroupOrder: Array<EntitlementResourceGroup> = [
+	'daily',
+	'counts',
+	'storage',
+	'limits',
+]

--- a/packages/worker/src/entitlements/resource-visibility.ts
+++ b/packages/worker/src/entitlements/resource-visibility.ts
@@ -65,15 +65,15 @@ export const entitlementResourceVisibility: Record<
 	persistent_package_services: {
 		group: 'counts',
 		kind: 'boolean_allowance',
-		whatCounts: 'Whether your plan allows persistent (long-lived) package services.',
+		whatCounts:
+			'Whether your plan allows persistent (long-lived) package services.',
 		howToReduce:
 			'Stop persistent services when you do not need them, or upgrade for allowance.',
 	},
 	repo_sessions: {
 		group: 'counts',
 		kind: 'counter',
-		whatCounts:
-			'Active editing sessions opened by agents against your repos.',
+		whatCounts: 'Active editing sessions opened by agents against your repos.',
 		howToReduce:
 			'Discard finished sessions with repo_discard_session; idle sessions are cleaned up automatically after 7 days.',
 	},
@@ -99,7 +99,8 @@ export const entitlementResourceVisibility: Record<
 	email_message_bytes: {
 		group: 'limits',
 		kind: 'per_unit_max',
-		whatCounts: 'Maximum raw MIME size allowed for a single stored email message.',
+		whatCounts:
+			'Maximum raw MIME size allowed for a single stored email message.',
 		howToReduce:
 			'Keep attachments and bodies smaller, or upgrade for a higher per-message cap.',
 	},
@@ -120,7 +121,8 @@ export const entitlementResourceVisibility: Record<
 		group: 'counts',
 		kind: 'counter',
 		whatCounts: 'Workflow runs currently active on your account.',
-		howToReduce: 'Wait for workflows to finish or cancel runs you no longer need.',
+		howToReduce:
+			'Wait for workflows to finish or cancel runs you no longer need.',
 	},
 	execute_calls_per_day: {
 		group: 'daily',

--- a/packages/worker/src/entitlements/usage-snapshot.node.test.ts
+++ b/packages/worker/src/entitlements/usage-snapshot.node.test.ts
@@ -92,8 +92,9 @@ test('readEntitlementUsageSnapshot marks rows above 80% as warnings', async () =
 		(row) => row.resource === 'email_sends_per_day',
 	)
 	expect(sends?.overEightyPercent).toBe(true)
-	expect(snapshot.warnings.some((row) => row.resource === 'email_sends_per_day'))
-		.toBe(true)
+	expect(
+		snapshot.warnings.some((row) => row.resource === 'email_sends_per_day'),
+	).toBe(true)
 	const packages = snapshot.resources.find(
 		(row) => row.resource === 'saved_packages',
 	)

--- a/packages/worker/src/entitlements/usage-snapshot.node.test.ts
+++ b/packages/worker/src/entitlements/usage-snapshot.node.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from 'vitest'
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
+import { createInMemoryRunLogUsageEnv } from '#worker/test-support/run-log-usage.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+import { accountUsageEntitlementResources } from '#worker/entitlements/resource-visibility.ts'
+
+function withUsageEnv(env: { APP_DB: D1Database } & Record<string, unknown>) {
+	const meter = createInMemoryUserMeterEnv()
+	const runLog = createInMemoryRunLogUsageEnv()
+	return {
+		...env,
+		...meter.env,
+		...runLog.env,
+		MAILBOX: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ countMessages: async () => ({ total: 0 }) }),
+		},
+		meter,
+		runLog,
+	}
+}
+
+function createUsageTestDb(input: {
+	email: string
+	repoCount?: number
+	packageCount?: number
+}) {
+	const stableUserId = testStableUserIdFromEmail(input.email)
+	return {
+		stableUserId,
+		db: {
+			prepare(query: string) {
+				const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind(...params: Array<unknown>) {
+						return {
+							async first<T>() {
+								if (normalized.includes('from user_repos')) {
+									return { count: input.repoCount ?? 0 } as T
+								}
+								if (normalized.includes('from saved_packages')) {
+									return { count: input.packageCount ?? 0 } as T
+								}
+								if (normalized.includes('select 1 as present from users')) {
+									return { present: 1 } as T
+								}
+								if (
+									normalized.includes('count(*)') ||
+									normalized.includes('sum(')
+								) {
+									return { count: 0, total: 0, bytes: 0 } as T
+								}
+								void params
+								return null
+							},
+							async all() {
+								return { results: [] }
+							},
+						}
+					},
+				}
+			},
+		} as unknown as D1Database,
+	}
+}
+
+test('readEntitlementUsageSnapshot marks rows above 80% as warnings', async () => {
+	const now = new Date('2026-07-25T12:00:00.000Z')
+	const day = utcDayKey(now)
+	const email = 'warn@example.com'
+	const { stableUserId, db } = createUsageTestDb({
+		email,
+		packageCount: 9,
+	})
+	const env = withUsageEnv({ APP_DB: db })
+	await env.meter.seed({
+		userId: stableUserId,
+		resource: 'email_sends_per_day',
+		day,
+		count: 9,
+	})
+	const snapshot = await readEntitlementUsageSnapshot({
+		db,
+		env: env as Env,
+		usageUserId: stableUserId,
+		plan: 'free',
+		now,
+	})
+	const sends = snapshot.resources.find(
+		(row) => row.resource === 'email_sends_per_day',
+	)
+	expect(sends?.overEightyPercent).toBe(true)
+	expect(snapshot.warnings.some((row) => row.resource === 'email_sends_per_day'))
+		.toBe(true)
+	const packages = snapshot.resources.find(
+		(row) => row.resource === 'saved_packages',
+	)
+	expect(packages?.overEightyPercent).toBe(false)
+})
+
+test('readEntitlementUsageSnapshot includes all registered usage resources', async () => {
+	const email = 'all@example.com'
+	const { stableUserId, db } = createUsageTestDb({ email, repoCount: 1 })
+	const env = withUsageEnv({ APP_DB: db })
+	const snapshot = await readEntitlementUsageSnapshot({
+		db,
+		env: env as Env,
+		usageUserId: stableUserId,
+		plan: 'partner',
+	})
+	expect(snapshot.resources.map((row) => row.resource)).toEqual(
+		accountUsageEntitlementResources,
+	)
+})

--- a/packages/worker/src/entitlements/usage-snapshot.ts
+++ b/packages/worker/src/entitlements/usage-snapshot.ts
@@ -1,0 +1,86 @@
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import {
+	entitlementResourceLabels,
+	resolvePlanLimit,
+	type EntitlementResource,
+	type PlanName,
+} from './plans.ts'
+import {
+	accountUsageEntitlementResources,
+	entitlementResourceVisibility,
+	type EntitlementResourceGroup,
+	type EntitlementResourceVisibilityKind,
+} from './resource-visibility.ts'
+import { readCurrentEntitlementResourceUsage } from './service.ts'
+
+export const entitlementUsageWarningThreshold = 0.8
+
+export type EntitlementUsageSnapshotRow = {
+	resource: EntitlementResource
+	label: string
+	group: EntitlementResourceGroup
+	kind: EntitlementResourceVisibilityKind
+	whatCounts: string
+	howToReduce: string
+	current: number
+	limit: number
+	percentOfLimit: number | null
+	overEightyPercent: boolean
+}
+
+export type EntitlementUsageSnapshot = {
+	plan: PlanName
+	today: string
+	resources: Array<EntitlementUsageSnapshotRow>
+	warnings: Array<EntitlementUsageSnapshotRow>
+}
+
+export async function readEntitlementUsageSnapshot(input: {
+	db: D1Database
+	env: Env
+	usageUserId: string
+	plan: PlanName
+	now?: Date
+}): Promise<EntitlementUsageSnapshot> {
+	const now = input.now ?? new Date()
+	const resources = await Promise.all(
+		accountUsageEntitlementResources.map(async (resource) => {
+			const visibility = entitlementResourceVisibility[resource]
+			const current =
+				visibility.kind === 'per_unit_max'
+					? 0
+					: await readCurrentEntitlementResourceUsage({
+							db: input.db,
+							env: input.env,
+							userId: input.usageUserId,
+							resource,
+							now,
+						})
+			const limit = resolvePlanLimit(input.plan, resource)
+			const percentOfLimit =
+				visibility.kind === 'per_unit_max' || limit === 0
+					? null
+					: current / limit
+			return {
+				resource,
+				label: entitlementResourceLabels[resource],
+				group: visibility.group,
+				kind: visibility.kind,
+				whatCounts: visibility.whatCounts,
+				howToReduce: visibility.howToReduce,
+				current,
+				limit,
+				percentOfLimit,
+				overEightyPercent:
+					percentOfLimit !== null &&
+					percentOfLimit > entitlementUsageWarningThreshold,
+			}
+		}),
+	)
+	return {
+		plan: input.plan,
+		today: utcDayKey(now),
+		resources,
+		warnings: resources.filter((row) => row.overEightyPercent),
+	}
+}

--- a/packages/worker/src/entitlements/usage-snapshot.ts
+++ b/packages/worker/src/entitlements/usage-snapshot.ts
@@ -57,8 +57,13 @@ export async function readEntitlementUsageSnapshot(input: {
 							now,
 						})
 			const limit = resolvePlanLimit(input.plan, resource)
+			// per_unit_max compares one candidate value (no accumulating usage)
+			// and boolean_allowance limits are 0/1 allowance flags, so a
+			// current/limit ratio is meaningless for both.
 			const percentOfLimit =
-				visibility.kind === 'per_unit_max' || limit === 0
+				visibility.kind === 'per_unit_max' ||
+				visibility.kind === 'boolean_allowance' ||
+				limit === 0
 					? null
 					: current / limit
 			return {

--- a/packages/worker/src/mcp/capabilities/account/domain.ts
+++ b/packages/worker/src/mcp/capabilities/account/domain.ts
@@ -2,14 +2,24 @@ import { defineDomain } from '#mcp/capabilities/define-domain.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { accountExportManifestCapability } from './account-export-manifest.ts'
 import { accountExportSectionCapability } from './account-export-section.ts'
+import { usageGetCapability } from './usage-get.ts'
 
 export const accountDomain = defineDomain({
 	name: capabilityDomainNames.account,
 	description:
-		'Self-service account export, backup, and migration (secrets never exported).',
-	keywords: ['account', 'export', 'backup', 'migration', 'privacy'],
+		'Self-service account export, backup, migration, and entitlement usage (secrets never exported).',
+	keywords: [
+		'account',
+		'export',
+		'backup',
+		'migration',
+		'privacy',
+		'usage',
+		'quota',
+	],
 	capabilities: [
 		accountExportManifestCapability,
 		accountExportSectionCapability,
+		usageGetCapability,
 	],
 })

--- a/packages/worker/src/mcp/capabilities/account/usage-get.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/account/usage-get.node.test.ts
@@ -6,9 +6,7 @@ import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 import { usageGetCapability } from './usage-get.ts'
 
-function withUsageEnv(
-	env: { APP_DB: D1Database } & Record<string, unknown>,
-) {
+function withUsageEnv(env: { APP_DB: D1Database } & Record<string, unknown>) {
 	const meter = createInMemoryUserMeterEnv()
 	const runLog = createInMemoryRunLogUsageEnv()
 	return {
@@ -105,7 +103,9 @@ test('usage_get returns self-scoped entitlement snapshot', async () => {
 	const result = await usageGetCapability.handler({}, { env, callerContext })
 	expect(result.plan).toBe('pro')
 	expect(result.resources.length).toBe(accountUsageEntitlementResources.length)
-	const saved = result.resources.find((row) => row.resource === 'saved_packages')
+	const saved = result.resources.find(
+		(row) => row.resource === 'saved_packages',
+	)
 	expect(saved?.current).toBe(1)
 	expect(saved?.limit).toBeGreaterThan(0)
 	expect(saved?.percent).toBe(saved!.current / saved!.limit)

--- a/packages/worker/src/mcp/capabilities/account/usage-get.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/account/usage-get.node.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from 'vitest'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { accountUsageEntitlementResources } from '#worker/entitlements/resource-visibility.ts'
+import { createInMemoryRunLogUsageEnv } from '#worker/test-support/run-log-usage.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
+import { usageGetCapability } from './usage-get.ts'
+
+function withUsageEnv(
+	env: { APP_DB: D1Database } & Record<string, unknown>,
+) {
+	const meter = createInMemoryUserMeterEnv()
+	const runLog = createInMemoryRunLogUsageEnv()
+	return {
+		...env,
+		...meter.env,
+		...runLog.env,
+		MAILBOX: {
+			idFromName: (name: string) => name as unknown as DurableObjectId,
+			get: () => ({ countMessages: async () => ({ total: 0 }) }),
+		},
+		meter,
+		runLog,
+	}
+}
+
+function createUsageTestDb(input: {
+	email: string
+	plan: string
+	stripePlan?: string | null
+	packageCount?: number
+}) {
+	const stableUserId = testStableUserIdFromEmail(input.email)
+	return {
+		stableUserId,
+		db: {
+			prepare(query: string) {
+				const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+				return {
+					bind(...params: Array<unknown>) {
+						return {
+							async first<T>() {
+								if (
+									normalized.includes('from users') &&
+									normalized.includes('email')
+								) {
+									return {
+										plan: input.plan,
+										stripe_plan: input.stripePlan ?? null,
+									} as T
+								}
+								if (normalized.includes('from saved_packages')) {
+									return { count: input.packageCount ?? 0 } as T
+								}
+								if (normalized.includes('select 1 as present from users')) {
+									return { present: 1 } as T
+								}
+								if (
+									normalized.includes('count(*)') ||
+									normalized.includes('sum(')
+								) {
+									return { count: 0, total: 0, bytes: 0 } as T
+								}
+								void params
+								return null
+							},
+							async all() {
+								return { results: [] }
+							},
+						}
+					},
+				}
+			},
+		} as unknown as D1Database,
+	}
+}
+
+test('usage_get returns self-scoped entitlement snapshot', async () => {
+	const email = 'usage-get@example.com'
+	const userId = testStableUserIdFromEmail(email)
+	const { db } = createUsageTestDb({
+		email,
+		plan: 'pro',
+		packageCount: 1,
+	})
+	const meterEnv = withUsageEnv({ APP_DB: db })
+	const env = meterEnv as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: { userId, email, displayName: 'Usage' },
+	})
+
+	await expect(
+		usageGetCapability.handler(
+			{},
+			{
+				env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://example.com',
+				}),
+			},
+		),
+	).rejects.toThrow(/Authenticated MCP user/)
+
+	const result = await usageGetCapability.handler({}, { env, callerContext })
+	expect(result.plan).toBe('pro')
+	expect(result.resources.length).toBe(accountUsageEntitlementResources.length)
+	const saved = result.resources.find((row) => row.resource === 'saved_packages')
+	expect(saved?.current).toBe(1)
+	expect(saved?.limit).toBeGreaterThan(0)
+	expect(saved?.percent).toBe(saved!.current / saved!.limit)
+	expect(saved?.whatCounts).toMatch(/saved packages/i)
+})

--- a/packages/worker/src/mcp/capabilities/account/usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/account/usage-get.ts
@@ -26,14 +26,7 @@ export const usageGetCapability = defineDomainCapability(
 		name: 'usage_get',
 		description:
 			'Read the signed-in user’s entitlement usage against plan limits: per-resource current, limit, percent used, and plain-language guidance on what counts and how to reduce it.',
-		keywords: [
-			'account',
-			'usage',
-			'quota',
-			'limits',
-			'entitlements',
-			'plan',
-		],
+		keywords: ['account', 'usage', 'quota', 'limits', 'entitlements', 'plan'],
 		readOnly: true,
 		idempotent: true,
 		destructive: false,

--- a/packages/worker/src/mcp/capabilities/account/usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/account/usage-get.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
+import { planNames } from '#worker/entitlements/plans.ts'
+import { getUserPlan } from '#worker/entitlements/service.ts'
+import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
+
+const usageResourceSchema = z.object({
+	resource: z.string(),
+	label: z.string(),
+	group: z.enum(['daily', 'counts', 'storage', 'limits']),
+	kind: z.enum(['counter', 'boolean_allowance', 'per_unit_max']),
+	whatCounts: z.string(),
+	howToReduce: z.string(),
+	current: z.number().int().nonnegative(),
+	limit: z.number().int().nonnegative(),
+	percent: z.number().nullable(),
+	overEightyPercent: z.boolean(),
+})
+
+export const usageGetCapability = defineDomainCapability(
+	capabilityDomainNames.account,
+	{
+		name: 'usage_get',
+		description:
+			'Read the signed-in user’s entitlement usage against plan limits: per-resource current, limit, percent used, and plain-language guidance on what counts and how to reduce it.',
+		keywords: [
+			'account',
+			'usage',
+			'quota',
+			'limits',
+			'entitlements',
+			'plan',
+		],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		inputSchema: emptyCapabilityInputSchema,
+		outputSchema: z.object({
+			plan: z.enum(planNames),
+			/** UTC day for daily-rate counters (YYYY-MM-DD). */
+			day: z.string(),
+			resources: z.array(usageResourceSchema),
+			warnings: z.array(usageResourceSchema),
+		}),
+		async handler(_args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const db = ctx.env.APP_DB
+			const plan = await getUserPlan(db, {
+				userId: user.userId,
+				email: user.email,
+			})
+			const snapshot = await readEntitlementUsageSnapshot({
+				db,
+				env: ctx.env,
+				usageUserId: user.userId,
+				plan,
+			})
+			const mapRow = (
+				row: Awaited<
+					ReturnType<typeof readEntitlementUsageSnapshot>
+				>['resources'][number],
+			) => ({
+				resource: row.resource,
+				label: row.label,
+				group: row.group,
+				kind: row.kind,
+				whatCounts: row.whatCounts,
+				howToReduce: row.howToReduce,
+				current: row.current,
+				limit: row.limit,
+				percent: row.percentOfLimit,
+				overEightyPercent: row.overEightyPercent,
+			})
+			return {
+				plan: snapshot.plan,
+				day: snapshot.today,
+				resources: snapshot.resources.map(mapRow),
+				warnings: snapshot.warnings.map(mapRow),
+			}
+		},
+	},
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Makes it easy for a signed-in user to see what is affecting their entitlements:

- **Account usage API** (`/account/usage.json`) now returns all 15 entitlement resources, each with `group`, `kind`, `whatCounts`, `howToReduce`, `current`, `limit`, `percentOfLimit`, and `overEightyPercent`.
- **Usage page** (`packages/worker/client/routes/account-usage.tsx`): resources grouped into daily rates (with UTC-midnight reset note), counts, storage, and per-item limits; progress bars; amber >80% warnings with upgrade links to `/account/billing`; per-resource plain-language guidance on what counts and how to reduce it (e.g. discard idle repo sessions — they are also swept automatically after 7 idle days).
- **Billing page**: each plan card links "See your current usage".
- **MCP parity**: new read-only, self-scoped `usage_get` capability on the account domain returning the same snapshot, so agents can answer "what's eating my quota".

## Key files

- `packages/worker/src/entitlements/resource-visibility.ts` — visibility copy + resource ordering
- `packages/worker/src/entitlements/usage-snapshot.ts` — shared snapshot reader
- `packages/worker/src/app/account-usage-data.ts` — account loader
- `packages/worker/client/routes/account-usage.tsx` — usage page UI
- `packages/worker/src/mcp/capabilities/account/usage-get.ts` — MCP capability

## Testing

`npm run validate` green in the implementing environment (1,857 tests; one known-flaky `meta_list_capabilities` timeout passed on rerun). New tests: `usage-snapshot.node.test.ts`, `usage-get.node.test.ts`, updated `account-usage-data.node.test.ts`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `d26ae960`

**Classification:** extends — adds a user-facing read surface over the existing entitlements registry and a new self-scoped MCP capability; no enforcement changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — visibility metadata + shared usage snapshot reader (read-only) |
| `app-ui` | surfaces | extends — account usage page groups all resources with warnings and guidance |
| `capability-registry` | assistant | extends — new read-only `usage_get` account capability |

### System map

The account usage page and the new `usage_get` capability both read one shared entitlement usage snapshot; no enforcement paths change.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	appUi -->|"/account/usage.json snapshot"| entitlements
	capabilityRegistry -->|"usage_get reads same snapshot"| entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

## Conductor report

Implemented by the user-entitlement-visibility track; PR opened and shepherded by the conductor after the track's environment could not create PRs. Status: awaiting CI + CodeRabbit, then squash-merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account usage links to billing plan cards.
  * Redesigned account usage with grouped entitlement sections, progress bars, labels, and explanatory details.
  * Added clearer formatting for email, boolean, and per-item limits.
  * Added warnings near usage limits, with reduction guidance and billing links.
  * Added an account usage capability for retrieving plan limits, consumption, and warnings.
* **Bug Fixes**
  * Usage percentages are now capped appropriately, and unsupported percentage displays are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->