### PR TITLE
Admin fleet usage visibility panels and entitlement-pressure alert lane

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -171,7 +171,13 @@ the same cold zero-init path):
 - Account email usage panel — `packages/worker/src/app/account-email-data.ts`
 - `email_usage_get` MCP capability
 - Admin per-user usage drill-down —
-  `packages/worker/src/admin/user-usage-data.ts`
+  `packages/worker/src/admin/user-usage-data.ts` (via
+  `readAdminEntitlementConsumption` in
+  `packages/worker/src/admin/entitlement-consumption.ts`, including
+  `storage_bytes` from UserMeter)
+- Admin fleet entitlement-pressure panel and `usage_entitlement_alert` lane —
+  same `readAdminEntitlementConsumption` helper over a bounded sweep of the top
+  ~15 active users by current-month event count
 
 Non-daily resources still use `readEntitlementResourceUsage` against D1.
 `readEntitlementResourceUsage` for daily resources and `storage_bytes` throws

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -318,3 +318,16 @@ Guarantees and rules:
   `derived-cache:v1:`), keyed by user id + current month, falling through to
   direct D1 queries when KV is unavailable. Usage is loaded for one selected
   account at a time, so admin reads stay O(1) per view as the user base grows.
+- **Fleet visibility** (`/admin/insights`, loader in
+  `packages/worker/src/admin/fleet-usage-insights.ts`): bounded SQL over
+  `usage_rollups` for the current UTC month — top-10 combined runtime duration
+  (execute + job_run + workflow_run + service_runtime), top-10 event counts,
+  per-metric duration leaders, and an entitlement-pressure panel that reuses
+  `readAdminEntitlementConsumption` for the top ~15 users by event count.
+  Queries are `LIMIT`-bounded; entitlement reads run with modest concurrency.
+- **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
+  `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
+  same ~15-user bound. Emails admin-role users when any swept account crosses
+  >80% of a plan-limit resource or when combined runtime duration for the month
+  exceeds `fleetRuntimeDurationAlertThresholdMs` (24h). KV cooldown key
+  `ops-alert:usage-entitlement-pressure:v1` suppresses repeat pages.

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -328,6 +328,6 @@ Guarantees and rules:
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emails admin-role users when any swept account crosses
-  >80% of a plan-limit resource or when combined runtime duration for the month
-  exceeds `fleetRuntimeDurationAlertThresholdMs` (24h). KV cooldown key
-  `ops-alert:usage-entitlement-pressure:v1` suppresses repeat pages.
+  > 80% of a plan-limit resource or when combined runtime duration for the month
+  > exceeds `fleetRuntimeDurationAlertThresholdMs` (24h). KV cooldown key
+  > `ops-alert:usage-entitlement-pressure:v1` suppresses repeat pages.

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -118,7 +118,12 @@ const runtimeDurationMetricLabels: Record<AdminUsageMetric, string> = {
 
 function renderConsumerTable(input: {
 	ariaLabel: string
-	rows: Array<{ key: string; username: string; stableUserId: string; value: string }>
+	rows: Array<{
+		key: string
+		username: string
+		stableUserId: string
+		value: string
+	}>
 	emptyText: string
 	valueHeader: string
 }) {
@@ -300,7 +305,12 @@ function renderEntitlementPressure(
 						>
 							{entry.username}
 						</a>
-						<span mix={css({ color: colors.textMuted, fontSize: typography.fontSize.sm })}>
+						<span
+							mix={css({
+								color: colors.textMuted,
+								fontSize: typography.fontSize.sm,
+							})}
+						>
 							{formatPlanLabel(entry.plan)} plan
 						</span>
 					</div>

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -30,8 +30,13 @@ import {
 import {
 	type AdminInsightsActivation,
 	type AdminInsightsActivationStep,
+	type AdminInsightsDurationConsumer,
+	type AdminInsightsEntitlementPressureUser,
+	type AdminInsightsEventCountConsumer,
 	type AdminInsightsLoaderData,
+	type AdminInsightsMetricDurationConsumers,
 	type AdminInsightsRunLogCompleteness,
+	type AdminUsageMetric,
 } from '#app/loader-data.ts'
 import {
 	routeLoaderRedirect,
@@ -82,6 +87,243 @@ function formatDayLabel(dayKey: string) {
 
 function formatPlanLabel(plan: string) {
 	return plan === 'none' ? 'No plan' : plan
+}
+
+function formatDurationHours(durationMs: number) {
+	if (durationMs < 60_000) return `${Math.round(durationMs / 1000)}s`
+	const hours = durationMs / (60 * 60 * 1000)
+	if (hours < 10) return `${hours.toFixed(1)}h`
+	return `${Math.round(hours)}h`
+}
+
+function formatPressurePercent(value: number) {
+	return `${Math.round(value * 100)}%`
+}
+
+function adminUserDetailHref(stableUserId: string) {
+	return `/admin/users/${encodeURIComponent(stableUserId)}`
+}
+
+const runtimeDurationMetricLabels: Record<AdminUsageMetric, string> = {
+	execute: 'Executes',
+	package_export: 'Package runs',
+	package_static_call: 'Static package calls',
+	job_run: 'Job runs',
+	workflow_run: 'Workflow runs',
+	service_runtime: 'Service runtime',
+	outbound_fetch: 'Fetches',
+	email_send: 'Email sends',
+	email_received: 'Email receives',
+}
+
+function renderConsumerTable(input: {
+	ariaLabel: string
+	rows: Array<{ key: string; username: string; stableUserId: string; value: string }>
+	emptyText: string
+	valueHeader: string
+}) {
+	if (input.rows.length === 0) {
+		return (
+			<p mix={css({ margin: 0, color: colors.textMuted })}>{input.emptyText}</p>
+		)
+	}
+	return (
+		<table
+			aria-label={input.ariaLabel}
+			mix={css({
+				width: '100%',
+				borderCollapse: 'collapse',
+				fontSize: typography.fontSize.sm,
+			})}
+		>
+			<thead>
+				<tr>
+					<th
+						scope="col"
+						mix={css({
+							textAlign: 'left',
+							padding: `${spacing.xs} ${spacing.sm}`,
+							color: colors.textMuted,
+							fontWeight: typography.fontWeight.medium,
+						})}
+					>
+						User
+					</th>
+					<th
+						scope="col"
+						mix={css({
+							textAlign: 'right',
+							padding: `${spacing.xs} ${spacing.sm}`,
+							color: colors.textMuted,
+							fontWeight: typography.fontWeight.medium,
+						})}
+					>
+						{input.valueHeader}
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				{input.rows.map((row) => (
+					<tr key={row.key}>
+						<td mix={css({ padding: `${spacing.xs} ${spacing.sm}` })}>
+							<a
+								href={adminUserDetailHref(row.stableUserId)}
+								mix={css({ color: colors.text, textDecoration: 'none' })}
+							>
+								{row.username}
+							</a>
+						</td>
+						<td
+							mix={css({
+								padding: `${spacing.xs} ${spacing.sm}`,
+								textAlign: 'right',
+								color: colors.textMuted,
+								fontVariantNumeric: 'tabular-nums',
+							})}
+						>
+							{row.value}
+						</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	)
+}
+
+function renderDurationConsumers(
+	consumers: Array<AdminInsightsDurationConsumer>,
+	ariaLabel: string,
+) {
+	return renderConsumerTable({
+		ariaLabel,
+		emptyText: 'No runtime duration recorded this month yet.',
+		valueHeader: 'Runtime',
+		rows: consumers.map((consumer) => ({
+			key: consumer.stableUserId,
+			username: consumer.username,
+			stableUserId: consumer.stableUserId,
+			value: formatDurationHours(consumer.totalDurationMs),
+		})),
+	})
+}
+
+function renderEventCountConsumers(
+	consumers: Array<AdminInsightsEventCountConsumer>,
+) {
+	return renderConsumerTable({
+		ariaLabel: 'Top event count consumers this month',
+		emptyText: 'No metered events recorded this month yet.',
+		valueHeader: 'Events',
+		rows: consumers.map((consumer) => ({
+			key: consumer.stableUserId,
+			username: consumer.username,
+			stableUserId: consumer.stableUserId,
+			value: formatIntegerNumber(consumer.eventCount),
+		})),
+	})
+}
+
+function renderDurationByMetric(
+	entries: Array<AdminInsightsMetricDurationConsumers>,
+) {
+	const hasData = entries.some((entry) => entry.consumers.length > 0)
+	if (!hasData) {
+		return (
+			<p mix={css({ margin: 0, color: colors.textMuted })}>
+				No per-metric runtime leaders this month yet.
+			</p>
+		)
+	}
+	return (
+		<div mix={css({ display: 'grid', gap: spacing.md })}>
+			{entries.map((entry) => (
+				<div key={entry.metric} mix={css({ display: 'grid', gap: spacing.xs })}>
+					<h3
+						mix={css({
+							margin: 0,
+							fontSize: typography.fontSize.sm,
+							fontWeight: typography.fontWeight.semibold,
+							color: colors.text,
+						})}
+					>
+						{runtimeDurationMetricLabels[entry.metric]}
+					</h3>
+					{renderDurationConsumers(
+						entry.consumers,
+						`Top ${runtimeDurationMetricLabels[entry.metric]} duration consumers`,
+					)}
+				</div>
+			))}
+		</div>
+	)
+}
+
+function renderEntitlementPressure(
+	entries: Array<AdminInsightsEntitlementPressureUser>,
+) {
+	if (entries.length === 0) {
+		return (
+			<p mix={css({ margin: 0, color: colors.textMuted })}>
+				No accounts above 80% of a plan limit among the most active users this
+				month.
+			</p>
+		)
+	}
+	return (
+		<div mix={css({ display: 'grid', gap: spacing.md })}>
+			{entries.map((entry) => (
+				<div
+					key={entry.stableUserId}
+					mix={css({
+						display: 'grid',
+						gap: spacing.xs,
+						padding: spacing.sm,
+						borderRadius: '8px',
+						border: `1px solid ${colors.border}`,
+					})}
+				>
+					<div
+						mix={css({
+							display: 'flex',
+							justifyContent: 'space-between',
+							gap: spacing.sm,
+							flexWrap: 'wrap',
+						})}
+					>
+						<a
+							href={adminUserDetailHref(entry.stableUserId)}
+							mix={css({
+								color: colors.text,
+								fontWeight: typography.fontWeight.semibold,
+								textDecoration: 'none',
+							})}
+						>
+							{entry.username}
+						</a>
+						<span mix={css({ color: colors.textMuted, fontSize: typography.fontSize.sm })}>
+							{formatPlanLabel(entry.plan)} plan
+						</span>
+					</div>
+					<ul
+						mix={css({
+							margin: 0,
+							paddingLeft: spacing.lg,
+							color: colors.textMuted,
+							fontSize: typography.fontSize.sm,
+						})}
+					>
+						{entry.pressuredResources.map((resource) => (
+							<li key={resource.resource}>
+								{resource.label}: {formatIntegerNumber(resource.current)} /{' '}
+								{formatIntegerNumber(resource.limit)} (
+								{formatPressurePercent(resource.percentOfLimit)})
+							</li>
+						))}
+					</ul>
+				</div>
+			))}
+		</div>
+	)
 }
 
 /** Null when run-derived totals are complete; otherwise a user-facing warning. */
@@ -570,6 +812,39 @@ function renderDashboard(data: AdminInsightsLoaderData) {
 						xLabels={monthLabels}
 						xTickEvery={1}
 					/>
+				</ChartCard>
+
+				<ChartCard
+					title="Top runtime consumers"
+					sub="Combined execute, job, workflow, and service runtime duration for the current UTC month."
+					span={6}
+				>
+					{renderDurationConsumers(
+						data.topRuntimeDurationConsumers,
+						'Top combined runtime duration consumers this month',
+					)}
+				</ChartCard>
+				<ChartCard
+					title="Top event consumers"
+					sub="Total metered events across all metrics for the current UTC month."
+					span={6}
+				>
+					{renderEventCountConsumers(data.topEventCountConsumers)}
+				</ChartCard>
+
+				<ChartCard
+					title="Runtime leaders by metric"
+					sub="Per-metric duration leaders for execute, jobs, workflows, and services."
+					span={6}
+				>
+					{renderDurationByMetric(data.topDurationConsumersByMetric)}
+				</ChartCard>
+				<ChartCard
+					title="Entitlement pressure"
+					sub="Accounts above 80% of a plan limit among the ~15 most active users this month."
+					span={6}
+				>
+					{renderEntitlementPressure(data.entitlementPressure)}
 				</ChartCard>
 
 				<ChartCard

--- a/packages/worker/src/admin/entitlement-consumption.ts
+++ b/packages/worker/src/admin/entitlement-consumption.ts
@@ -1,0 +1,62 @@
+import {
+	entitlementResourceLabels,
+	resolvePlanLimit,
+	type EntitlementResource,
+	type PlanName,
+} from '#worker/entitlements/plans.ts'
+import { readCurrentEntitlementResourceUsage } from '#worker/entitlements/service.ts'
+import { type AdminUsageEntitlementConsumption } from '#app/loader-data.ts'
+
+export const adminEntitlementResources = [
+	'saved_packages',
+	'scheduled_jobs',
+	'package_services',
+	'persistent_package_services',
+	'repo_sessions',
+	'email_sends_per_day',
+	'email_receives_per_day',
+	'stored_email_messages',
+	'secrets',
+	'concurrent_workflows',
+	'execute_calls_per_day',
+	'outbound_fetches_per_day',
+	'storage_bytes',
+] as const satisfies ReadonlyArray<EntitlementResource>
+
+export const entitlementWarningThreshold = 0.8
+
+/**
+ * Current entitlement consumption for one account. `storage_bytes` is read from
+ * UserMeter via `readCurrentEntitlementResourceUsage`, matching the signed-in
+ * account usage page.
+ */
+export async function readAdminEntitlementConsumption(input: {
+	env: Env
+	usageUserId: string
+	plan: PlanName
+	now: Date
+}): Promise<Array<AdminUsageEntitlementConsumption>> {
+	return await Promise.all(
+		adminEntitlementResources.map(async (resource) => {
+			const current = await readCurrentEntitlementResourceUsage({
+				db: input.env.APP_DB,
+				env: input.env,
+				userId: input.usageUserId,
+				resource,
+				now: input.now,
+			})
+			const limit = resolvePlanLimit(input.plan, resource)
+			const percentOfLimit = limit === 0 ? null : current / limit
+			return {
+				resource,
+				label: entitlementResourceLabels[resource],
+				current,
+				limit,
+				percentOfLimit,
+				overEightyPercent:
+					percentOfLimit !== null &&
+					percentOfLimit > entitlementWarningThreshold,
+			}
+		}),
+	)
+}

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -1,39 +1,21 @@
 import { expect, test, vi } from 'vitest'
-import {
+
+const entitlementMocks = vi.hoisted(() => ({
+	readAdminEntitlementConsumption: vi.fn(),
+}))
+
+vi.mock('#worker/admin/entitlement-consumption.ts', () => ({
+	readAdminEntitlementConsumption: entitlementMocks.readAdminEntitlementConsumption,
+	entitlementWarningThreshold: 0.8,
+}))
+
+const {
 	adminFleetEntitlementSweepUserLimit,
 	adminFleetTopConsumersLimit,
 	detectFleetUsagePressure,
 	fleetRuntimeDurationAlertThresholdMs,
 	loadFleetUsageInsights,
-} from '#worker/admin/fleet-usage-insights.ts'
-
-const readAdminEntitlementConsumption = vi.fn<
-	(input: {
-		env: Env
-		usageUserId: string
-		plan: string
-		now: Date
-	}) => Promise<
-		Array<{
-			resource: string
-			label: string
-			current: number
-			limit: number
-			percentOfLimit: number | null
-			overEightyPercent: boolean
-		}>
-	>
->()
-
-vi.mock('#worker/admin/entitlement-consumption.ts', () => ({
-	readAdminEntitlementConsumption: (input: {
-		env: Env
-		usageUserId: string
-		plan: string
-		now: Date
-	}) => readAdminEntitlementConsumption(input),
-	entitlementWarningThreshold: 0.8,
-}))
+} = await import('#worker/admin/fleet-usage-insights.ts')
 
 function createFleetDb(input: {
 	runtimeLeaders?: Array<{
@@ -80,6 +62,14 @@ function createFleetDb(input: {
 						}
 					}
 					if (
+						normalized.includes('u.plan') &&
+						normalized.includes('ranked.event_count')
+					) {
+						return {
+							results: (input.activeUsers ?? []) as Array<T>,
+						}
+					}
+					if (
 						normalized.includes('sum(event_count)') &&
 						normalized.includes('group by user_id') &&
 						normalized.includes('limit ?')
@@ -91,14 +81,6 @@ function createFleetDb(input: {
 					if (normalized.includes('row_number() over')) {
 						return {
 							results: (input.metricLeaders ?? []) as Array<T>,
-						}
-					}
-					if (
-						normalized.includes('ranked.event_count') &&
-						normalized.includes('limit ?')
-					) {
-						return {
-							results: (input.activeUsers ?? []) as Array<T>,
 						}
 					}
 					if (
@@ -121,7 +103,7 @@ function createFleetDb(input: {
 }
 
 test('loadFleetUsageInsights returns bounded consumer rankings and pressure panel', async () => {
-	readAdminEntitlementConsumption.mockResolvedValue([
+	entitlementMocks.readAdminEntitlementConsumption.mockResolvedValue([
 		{
 			resource: 'saved_packages',
 			label: 'saved packages',
@@ -210,7 +192,7 @@ test('loadFleetUsageInsights returns bounded consumer rankings and pressure pane
 })
 
 test('detectFleetUsagePressure flags entitlement and runtime duration thresholds', async () => {
-	readAdminEntitlementConsumption.mockImplementation(async (input) => {
+	entitlementMocks.readAdminEntitlementConsumption.mockImplementation(async (input) => {
 		if (input.usageUserId === 'user-a') {
 			return [
 				{

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -1,0 +1,272 @@
+import { expect, test, vi } from 'vitest'
+import {
+	adminFleetEntitlementSweepUserLimit,
+	adminFleetTopConsumersLimit,
+	detectFleetUsagePressure,
+	fleetRuntimeDurationAlertThresholdMs,
+	loadFleetUsageInsights,
+} from '#worker/admin/fleet-usage-insights.ts'
+
+const readAdminEntitlementConsumption = vi.fn<
+	(input: {
+		env: Env
+		usageUserId: string
+		plan: string
+		now: Date
+	}) => Promise<
+		Array<{
+			resource: string
+			label: string
+			current: number
+			limit: number
+			percentOfLimit: number | null
+			overEightyPercent: boolean
+		}>
+	>
+>()
+
+vi.mock('#worker/admin/entitlement-consumption.ts', () => ({
+	readAdminEntitlementConsumption: (input: {
+		env: Env
+		usageUserId: string
+		plan: string
+		now: Date
+	}) => readAdminEntitlementConsumption(input),
+	entitlementWarningThreshold: 0.8,
+}))
+
+function createFleetDb(input: {
+	runtimeLeaders?: Array<{
+		stable_user_id: string
+		username: string
+		total_duration_ms: number
+	}>
+	eventLeaders?: Array<{
+		stable_user_id: string
+		username: string
+		event_count: number
+	}>
+	metricLeaders?: Array<{
+		user_id: string
+		username: string
+		metric: string
+		total_duration_ms: number
+	}>
+	activeUsers?: Array<{
+		stable_user_id: string
+		username: string
+		plan: string
+		stripe_plan: string | null
+		event_count: number
+	}>
+	runtimeByUser?: Record<string, number>
+}) {
+	return {
+		prepare(query: string) {
+			const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+			return {
+				bind(..._params: Array<unknown>) {
+					return this
+				},
+				async all<T>() {
+					if (
+						normalized.includes('sum(total_duration_ms)') &&
+						normalized.includes('group by user_id') &&
+						normalized.includes('limit ?') &&
+						!normalized.includes('partition by metric')
+					) {
+						return {
+							results: (input.runtimeLeaders ?? []) as Array<T>,
+						}
+					}
+					if (
+						normalized.includes('sum(event_count)') &&
+						normalized.includes('group by user_id') &&
+						normalized.includes('limit ?')
+					) {
+						return {
+							results: (input.eventLeaders ?? []) as Array<T>,
+						}
+					}
+					if (normalized.includes('row_number() over')) {
+						return {
+							results: (input.metricLeaders ?? []) as Array<T>,
+						}
+					}
+					if (
+						normalized.includes('ranked.event_count') &&
+						normalized.includes('limit ?')
+					) {
+						return {
+							results: (input.activeUsers ?? []) as Array<T>,
+						}
+					}
+					if (
+						normalized.includes('sum(total_duration_ms)') &&
+						normalized.includes('user_id in')
+					) {
+						const rows = Object.entries(input.runtimeByUser ?? {}).map(
+							([user_id, total_duration_ms]) => ({
+								user_id,
+								total_duration_ms,
+							}),
+						)
+						return { results: rows as Array<T> }
+					}
+					throw new Error(`Unsupported fleet query: ${query}`)
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+test('loadFleetUsageInsights returns bounded consumer rankings and pressure panel', async () => {
+	readAdminEntitlementConsumption.mockResolvedValue([
+		{
+			resource: 'saved_packages',
+			label: 'saved packages',
+			current: 9,
+			limit: 10,
+			percentOfLimit: 0.9,
+			overEightyPercent: true,
+		},
+	])
+	const db = createFleetDb({
+		runtimeLeaders: [
+			{
+				stable_user_id: 'user-a',
+				username: 'alice',
+				total_duration_ms: 3_600_000,
+			},
+		],
+		eventLeaders: [
+			{
+				stable_user_id: 'user-b',
+				username: 'bob',
+				event_count: 42,
+			},
+		],
+		metricLeaders: [
+			{
+				user_id: 'user-a',
+				username: 'alice',
+				metric: 'execute',
+				total_duration_ms: 1_000,
+			},
+		],
+		activeUsers: [
+			{
+				stable_user_id: 'user-a',
+				username: 'alice',
+				plan: 'free',
+				stripe_plan: null,
+				event_count: 50,
+			},
+		],
+	})
+	const data = await loadFleetUsageInsights({
+		db,
+		env: { APP_DB: db } as Env,
+		now: new Date('2026-07-08T12:00:00.000Z'),
+	})
+	expect(data.topRuntimeDurationConsumers).toEqual([
+		{
+			stableUserId: 'user-a',
+			username: 'alice',
+			totalDurationMs: 3_600_000,
+		},
+	])
+	expect(data.topEventCountConsumers).toEqual([
+		{
+			stableUserId: 'user-b',
+			username: 'bob',
+			eventCount: 42,
+		},
+	])
+	expect(data.topDurationConsumersByMetric).toHaveLength(4)
+	expect(data.topDurationConsumersByMetric[0]?.consumers).toEqual([
+		{
+			stableUserId: 'user-a',
+			username: 'alice',
+			totalDurationMs: 1_000,
+		},
+	])
+	expect(data.entitlementPressure).toEqual([
+		{
+			stableUserId: 'user-a',
+			username: 'alice',
+			plan: 'free',
+			pressuredResources: [
+				{
+					resource: 'saved_packages',
+					label: 'saved packages',
+					current: 9,
+					limit: 10,
+					percentOfLimit: 0.9,
+				},
+			],
+		},
+	])
+})
+
+test('detectFleetUsagePressure flags entitlement and runtime duration thresholds', async () => {
+	readAdminEntitlementConsumption.mockImplementation(async (input) => {
+		if (input.usageUserId === 'user-a') {
+			return [
+				{
+					resource: 'secrets',
+					label: 'secrets',
+					current: 9,
+					limit: 10,
+					percentOfLimit: 0.9,
+					overEightyPercent: true,
+				},
+			]
+		}
+		return []
+	})
+	const db = createFleetDb({
+		activeUsers: [
+			{
+				stable_user_id: 'user-a',
+				username: 'alice',
+				plan: 'free',
+				stripe_plan: null,
+				event_count: 50,
+			},
+			{
+				stable_user_id: 'user-b',
+				username: 'bob',
+				plan: 'pro',
+				stripe_plan: null,
+				event_count: 40,
+			},
+		],
+		runtimeByUser: {
+			'user-b': fleetRuntimeDurationAlertThresholdMs + 1,
+		},
+	})
+	const issues = await detectFleetUsagePressure({
+		db,
+		env: { APP_DB: db } as Env,
+		now: new Date('2026-07-08T12:00:00.000Z'),
+	})
+	expect(issues).toEqual([
+		{
+			kind: 'entitlement',
+			stableUserId: 'user-a',
+			username: 'alice',
+			resource: 'secrets',
+			label: 'secrets',
+			percentOfLimit: 0.9,
+		},
+		{
+			kind: 'runtime_duration',
+			stableUserId: 'user-b',
+			username: 'bob',
+			totalDurationMs: fleetRuntimeDurationAlertThresholdMs + 1,
+		},
+	])
+	expect(adminFleetTopConsumersLimit).toBe(10)
+	expect(adminFleetEntitlementSweepUserLimit).toBe(15)
+})

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -5,7 +5,8 @@ const entitlementMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('#worker/admin/entitlement-consumption.ts', () => ({
-	readAdminEntitlementConsumption: entitlementMocks.readAdminEntitlementConsumption,
+	readAdminEntitlementConsumption:
+		entitlementMocks.readAdminEntitlementConsumption,
 	entitlementWarningThreshold: 0.8,
 }))
 
@@ -192,21 +193,23 @@ test('loadFleetUsageInsights returns bounded consumer rankings and pressure pane
 })
 
 test('detectFleetUsagePressure flags entitlement and runtime duration thresholds', async () => {
-	entitlementMocks.readAdminEntitlementConsumption.mockImplementation(async (input) => {
-		if (input.usageUserId === 'user-a') {
-			return [
-				{
-					resource: 'secrets',
-					label: 'secrets',
-					current: 9,
-					limit: 10,
-					percentOfLimit: 0.9,
-					overEightyPercent: true,
-				},
-			]
-		}
-		return []
-	})
+	entitlementMocks.readAdminEntitlementConsumption.mockImplementation(
+		async (input) => {
+			if (input.usageUserId === 'user-a') {
+				return [
+					{
+						resource: 'secrets',
+						label: 'secrets',
+						current: 9,
+						limit: 10,
+						percentOfLimit: 0.9,
+						overEightyPercent: true,
+					},
+				]
+			}
+			return []
+		},
+	)
 	const db = createFleetDb({
 		activeUsers: [
 			{

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -7,7 +7,6 @@ import {
 import { adminUsageMetrics } from '#worker/admin/user-usage-data.ts'
 import {
 	readAdminEntitlementConsumption,
-	entitlementWarningThreshold,
 } from '#worker/admin/entitlement-consumption.ts'
 import {
 	type AdminInsightsDurationConsumer,

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -5,9 +5,7 @@ import {
 	type PlanName,
 } from '#worker/entitlements/plans.ts'
 import { adminUsageMetrics } from '#worker/admin/user-usage-data.ts'
-import {
-	readAdminEntitlementConsumption,
-} from '#worker/admin/entitlement-consumption.ts'
+import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
 import {
 	type AdminInsightsDurationConsumer,
 	type AdminInsightsEntitlementPressureUser,
@@ -154,8 +152,7 @@ export async function detectFleetUsagePressure(input: {
 					percentOfLimit: item.percentOfLimit,
 				})
 			}
-			const totalDurationMs =
-				durationByUser.get(user.stable_user_id) ?? 0
+			const totalDurationMs = durationByUser.get(user.stable_user_id) ?? 0
 			if (totalDurationMs > runtimeDurationThresholdMs) {
 				issues.push({
 					kind: 'runtime_duration',
@@ -195,8 +192,16 @@ async function queryTopRuntimeDurationConsumers(
 			 WHERE u.deleting_at IS NULL
 			 ORDER BY ranked.total_duration_ms DESC`,
 		)
-		.bind(currentMonth, ...adminFleetRuntimeDurationMetrics, adminFleetTopConsumersLimit)
-		.all<{ stable_user_id: string; username: string; total_duration_ms: number }>()
+		.bind(
+			currentMonth,
+			...adminFleetRuntimeDurationMetrics,
+			adminFleetTopConsumersLimit,
+		)
+		.all<{
+			stable_user_id: string
+			username: string
+			total_duration_ms: number
+		}>()
 	return (rows.results ?? []).map((row) => ({
 		stableUserId: row.stable_user_id,
 		username: row.username,
@@ -265,7 +270,10 @@ async function queryTopDurationConsumersByMetric(
 		)
 		.all<MetricDurationRow & { username: string }>()
 
-	const byMetric = new Map<AdminUsageMetric, Array<AdminInsightsDurationConsumer>>()
+	const byMetric = new Map<
+		AdminUsageMetric,
+		Array<AdminInsightsDurationConsumer>
+	>()
 	for (const metric of adminFleetRuntimeDurationMetrics) {
 		byMetric.set(metric, [])
 	}
@@ -303,10 +311,7 @@ async function buildEntitlementPressurePanel(input: {
 		entitlementSweepConcurrency,
 		async (user) => {
 			const plan = toAdminPlanName(
-				resolveEffectivePlan(
-					parseStoredPlanName(user.plan),
-					user.stripe_plan,
-				),
+				resolveEffectivePlan(parseStoredPlanName(user.plan), user.stripe_plan),
 			)
 			const consumption = await readAdminEntitlementConsumption({
 				env: input.env,

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -1,0 +1,423 @@
+import { utcMonthKey } from '@kody-internal/shared/date-keys.ts'
+import {
+	parseStoredPlanName,
+	resolveEffectivePlan,
+	type PlanName,
+} from '#worker/entitlements/plans.ts'
+import { adminUsageMetrics } from '#worker/admin/user-usage-data.ts'
+import {
+	readAdminEntitlementConsumption,
+	entitlementWarningThreshold,
+} from '#worker/admin/entitlement-consumption.ts'
+import {
+	type AdminInsightsDurationConsumer,
+	type AdminInsightsEntitlementPressureUser,
+	type AdminInsightsEventCountConsumer,
+	type AdminInsightsMetricDurationConsumers,
+	type AdminPlanName,
+	type AdminUsageMetric,
+} from '#app/loader-data.ts'
+
+export const adminFleetTopConsumersLimit = 10
+
+/**
+ * Entitlement-pressure sweep and the usage-entitlement alert lane share this
+ * bound so fleet reads stay O(1) regardless of user-table size.
+ */
+export const adminFleetEntitlementSweepUserLimit = 15
+
+export const adminFleetRuntimeDurationMetrics = [
+	'execute',
+	'job_run',
+	'workflow_run',
+	'service_runtime',
+] as const satisfies ReadonlyArray<AdminUsageMetric>
+
+/**
+ * Combined current-month runtime duration (execute + job_run + workflow_run +
+ * service_runtime) above which a single account warrants operator review. 24h of
+ * wall-clock metered runtime in one UTC month is a practical "heavy but not
+ * necessarily abusive" ceiling before paging.
+ */
+export const fleetRuntimeDurationAlertThresholdMs = 24 * 60 * 60 * 1000
+
+const entitlementSweepConcurrency = 4
+
+type RuntimeDurationRow = {
+	user_id: string
+	total_duration_ms: number
+}
+
+type ActiveUserRow = {
+	stable_user_id: string
+	username: string
+	plan: string
+	stripe_plan: string | null
+	event_count: number
+}
+
+type MetricDurationRow = {
+	user_id: string
+	metric: string
+	total_duration_ms: number
+}
+
+export type FleetEntitlementPressureIssue =
+	| {
+			kind: 'entitlement'
+			stableUserId: string
+			username: string
+			resource: string
+			label: string
+			percentOfLimit: number
+	  }
+	| {
+			kind: 'runtime_duration'
+			stableUserId: string
+			username: string
+			totalDurationMs: number
+	  }
+
+export async function loadFleetUsageInsights(input: {
+	db: D1Database
+	env: Env
+	now: Date
+}): Promise<{
+	topRuntimeDurationConsumers: Array<AdminInsightsDurationConsumer>
+	topEventCountConsumers: Array<AdminInsightsEventCountConsumer>
+	topDurationConsumersByMetric: Array<AdminInsightsMetricDurationConsumers>
+	entitlementPressure: Array<AdminInsightsEntitlementPressureUser>
+}> {
+	const currentMonth = utcMonthKey(input.now)
+	const [
+		topRuntimeDurationConsumers,
+		topEventCountConsumers,
+		topDurationConsumersByMetric,
+		entitlementPressure,
+	] = await Promise.all([
+		queryTopRuntimeDurationConsumers(input.db, currentMonth),
+		queryTopEventCountConsumers(input.db, currentMonth),
+		queryTopDurationConsumersByMetric(input.db, currentMonth),
+		buildEntitlementPressurePanel(input),
+	])
+	return {
+		topRuntimeDurationConsumers,
+		topEventCountConsumers,
+		topDurationConsumersByMetric,
+		entitlementPressure,
+	}
+}
+
+export async function detectFleetUsagePressure(input: {
+	db: D1Database
+	env: Env
+	now: Date
+	runtimeDurationThresholdMs?: number
+}): Promise<Array<FleetEntitlementPressureIssue>> {
+	const runtimeDurationThresholdMs =
+		input.runtimeDurationThresholdMs ?? fleetRuntimeDurationAlertThresholdMs
+	const currentMonth = utcMonthKey(input.now)
+	const activeUsers = await listActiveUsersForEntitlementSweep(
+		input.db,
+		currentMonth,
+	)
+	if (activeUsers.length === 0) return []
+
+	const durationByUser = await queryCombinedRuntimeDurationByUserIds(
+		input.db,
+		currentMonth,
+		activeUsers.map((user) => user.stable_user_id),
+	)
+	const issues: Array<FleetEntitlementPressureIssue> = []
+
+	await mapWithConcurrency(
+		activeUsers,
+		entitlementSweepConcurrency,
+		async (user) => {
+			const plan = resolveEffectivePlan(
+				parseStoredPlanName(user.plan),
+				user.stripe_plan,
+			)
+			const consumption = await readAdminEntitlementConsumption({
+				env: input.env,
+				usageUserId: user.stable_user_id,
+				plan,
+				now: input.now,
+			})
+			for (const item of consumption) {
+				if (!item.overEightyPercent || item.percentOfLimit == null) continue
+				issues.push({
+					kind: 'entitlement',
+					stableUserId: user.stable_user_id,
+					username: user.username,
+					resource: item.resource,
+					label: item.label,
+					percentOfLimit: item.percentOfLimit,
+				})
+			}
+			const totalDurationMs =
+				durationByUser.get(user.stable_user_id) ?? 0
+			if (totalDurationMs > runtimeDurationThresholdMs) {
+				issues.push({
+					kind: 'runtime_duration',
+					stableUserId: user.stable_user_id,
+					username: user.username,
+					totalDurationMs,
+				})
+			}
+		},
+	)
+
+	return issues.sort((left, right) =>
+		left.stableUserId.localeCompare(right.stableUserId),
+	)
+}
+
+async function queryTopRuntimeDurationConsumers(
+	db: D1Database,
+	currentMonth: string,
+): Promise<Array<AdminInsightsDurationConsumer>> {
+	const metricPlaceholders = adminFleetRuntimeDurationMetrics
+		.map(() => '?')
+		.join(', ')
+	const rows = await db
+		.prepare(
+			`SELECT u.stable_user_id, u.username, ranked.total_duration_ms
+			 FROM (
+				SELECT user_id, SUM(total_duration_ms) AS total_duration_ms
+				FROM usage_rollups
+				WHERE month = ?
+					AND metric IN (${metricPlaceholders})
+				GROUP BY user_id
+				ORDER BY total_duration_ms DESC
+				LIMIT ?
+			 ) AS ranked
+			 INNER JOIN users u ON u.stable_user_id = ranked.user_id
+			 WHERE u.deleting_at IS NULL
+			 ORDER BY ranked.total_duration_ms DESC`,
+		)
+		.bind(currentMonth, ...adminFleetRuntimeDurationMetrics, adminFleetTopConsumersLimit)
+		.all<{ stable_user_id: string; username: string; total_duration_ms: number }>()
+	return (rows.results ?? []).map((row) => ({
+		stableUserId: row.stable_user_id,
+		username: row.username,
+		totalDurationMs: Number(row.total_duration_ms),
+	}))
+}
+
+async function queryTopEventCountConsumers(
+	db: D1Database,
+	currentMonth: string,
+): Promise<Array<AdminInsightsEventCountConsumer>> {
+	const rows = await db
+		.prepare(
+			`SELECT u.stable_user_id, u.username, ranked.event_count
+			 FROM (
+				SELECT user_id, SUM(event_count) AS event_count
+				FROM usage_rollups
+				WHERE month = ?
+				GROUP BY user_id
+				ORDER BY event_count DESC
+				LIMIT ?
+			 ) AS ranked
+			 INNER JOIN users u ON u.stable_user_id = ranked.user_id
+			 WHERE u.deleting_at IS NULL
+			 ORDER BY ranked.event_count DESC`,
+		)
+		.bind(currentMonth, adminFleetTopConsumersLimit)
+		.all<{ stable_user_id: string; username: string; event_count: number }>()
+	return (rows.results ?? []).map((row) => ({
+		stableUserId: row.stable_user_id,
+		username: row.username,
+		eventCount: Number(row.event_count),
+	}))
+}
+
+async function queryTopDurationConsumersByMetric(
+	db: D1Database,
+	currentMonth: string,
+): Promise<Array<AdminInsightsMetricDurationConsumers>> {
+	const metricPlaceholders = adminFleetRuntimeDurationMetrics
+		.map(() => '?')
+		.join(', ')
+	const rows = await db
+		.prepare(
+			`SELECT ranked.user_id, ranked.metric, ranked.total_duration_ms, u.username
+			 FROM (
+				SELECT user_id, metric, total_duration_ms,
+					ROW_NUMBER() OVER (
+						PARTITION BY metric
+						ORDER BY total_duration_ms DESC
+					) AS rank_in_metric
+				FROM usage_rollups
+				WHERE month = ?
+					AND metric IN (${metricPlaceholders})
+					AND total_duration_ms > 0
+			 ) AS ranked
+			 INNER JOIN users u ON u.stable_user_id = ranked.user_id
+			 WHERE ranked.rank_in_metric <= ?
+				AND u.deleting_at IS NULL
+			 ORDER BY ranked.metric ASC, ranked.total_duration_ms DESC`,
+		)
+		.bind(
+			currentMonth,
+			...adminFleetRuntimeDurationMetrics,
+			adminFleetTopConsumersLimit,
+		)
+		.all<MetricDurationRow & { username: string }>()
+
+	const byMetric = new Map<AdminUsageMetric, Array<AdminInsightsDurationConsumer>>()
+	for (const metric of adminFleetRuntimeDurationMetrics) {
+		byMetric.set(metric, [])
+	}
+	for (const row of rows.results ?? []) {
+		if (!isAdminUsageMetric(row.metric)) continue
+		const consumers = byMetric.get(row.metric)
+		if (!consumers) continue
+		consumers.push({
+			stableUserId: row.user_id,
+			username: row.username,
+			totalDurationMs: Number(row.total_duration_ms),
+		})
+	}
+	return adminFleetRuntimeDurationMetrics.map((metric) => ({
+		metric,
+		consumers: byMetric.get(metric) ?? [],
+	}))
+}
+
+async function buildEntitlementPressurePanel(input: {
+	db: D1Database
+	env: Env
+	now: Date
+}): Promise<Array<AdminInsightsEntitlementPressureUser>> {
+	const currentMonth = utcMonthKey(input.now)
+	const activeUsers = await listActiveUsersForEntitlementSweep(
+		input.db,
+		currentMonth,
+	)
+	if (activeUsers.length === 0) return []
+
+	const pressured: Array<AdminInsightsEntitlementPressureUser> = []
+	await mapWithConcurrency(
+		activeUsers,
+		entitlementSweepConcurrency,
+		async (user) => {
+			const plan = toAdminPlanName(
+				resolveEffectivePlan(
+					parseStoredPlanName(user.plan),
+					user.stripe_plan,
+				),
+			)
+			const consumption = await readAdminEntitlementConsumption({
+				env: input.env,
+				usageUserId: user.stable_user_id,
+				plan,
+				now: input.now,
+			})
+			const pressuredResources = consumption
+				.filter((item) => item.overEightyPercent && item.percentOfLimit != null)
+				.map((item) => ({
+					resource: item.resource,
+					label: item.label,
+					current: item.current,
+					limit: item.limit,
+					percentOfLimit: item.percentOfLimit!,
+				}))
+			if (pressuredResources.length === 0) return
+			pressured.push({
+				stableUserId: user.stable_user_id,
+				username: user.username,
+				plan,
+				pressuredResources,
+			})
+		},
+	)
+
+	return pressured.sort(
+		(left, right) =>
+			right.pressuredResources.length - left.pressuredResources.length ||
+			left.username.localeCompare(right.username),
+	)
+}
+
+async function listActiveUsersForEntitlementSweep(
+	db: D1Database,
+	currentMonth: string,
+): Promise<Array<ActiveUserRow>> {
+	const rows = await db
+		.prepare(
+			`SELECT u.stable_user_id, u.username, u.plan, u.stripe_plan, ranked.event_count
+			 FROM (
+				SELECT user_id, SUM(event_count) AS event_count
+				FROM usage_rollups
+				WHERE month = ?
+				GROUP BY user_id
+				ORDER BY event_count DESC
+				LIMIT ?
+			 ) AS ranked
+			 INNER JOIN users u ON u.stable_user_id = ranked.user_id
+			 WHERE u.deleting_at IS NULL
+			 ORDER BY ranked.event_count DESC`,
+		)
+		.bind(currentMonth, adminFleetEntitlementSweepUserLimit)
+		.all<ActiveUserRow>()
+	return rows.results ?? []
+}
+
+async function queryCombinedRuntimeDurationByUserIds(
+	db: D1Database,
+	currentMonth: string,
+	userIds: ReadonlyArray<string>,
+): Promise<Map<string, number>> {
+	if (userIds.length === 0) return new Map()
+	const metricPlaceholders = adminFleetRuntimeDurationMetrics
+		.map(() => '?')
+		.join(', ')
+	const userPlaceholders = userIds.map(() => '?').join(', ')
+	const rows = await db
+		.prepare(
+			`SELECT user_id, SUM(total_duration_ms) AS total_duration_ms
+			 FROM usage_rollups
+			 WHERE month = ?
+				AND metric IN (${metricPlaceholders})
+				AND user_id IN (${userPlaceholders})
+			 GROUP BY user_id`,
+		)
+		.bind(currentMonth, ...adminFleetRuntimeDurationMetrics, ...userIds)
+		.all<RuntimeDurationRow>()
+	const byUser = new Map<string, number>()
+	for (const row of rows.results ?? []) {
+		byUser.set(row.user_id, Number(row.total_duration_ms))
+	}
+	return byUser
+}
+
+function toAdminPlanName(plan: PlanName): AdminPlanName {
+	return plan
+}
+
+function isAdminUsageMetric(metric: string): metric is AdminUsageMetric {
+	return (adminUsageMetrics as ReadonlyArray<string>).includes(metric)
+}
+
+async function mapWithConcurrency<T>(
+	items: ReadonlyArray<T>,
+	concurrency: number,
+	mapper: (item: T) => Promise<void>,
+): Promise<void> {
+	if (items.length === 0) return
+	const limit = Math.max(1, Math.min(concurrency, items.length))
+	let nextIndex = 0
+	await Promise.all(
+		Array.from({ length: limit }, async () => {
+			while (nextIndex < items.length) {
+				const index = nextIndex
+				nextIndex += 1
+				const item = items[index]
+				if (item === undefined) return
+				await mapper(item)
+			}
+		}),
+	)
+}

--- a/packages/worker/src/admin/user-usage-data.node.test.ts
+++ b/packages/worker/src/admin/user-usage-data.node.test.ts
@@ -119,6 +119,16 @@ function createAdminUserUsageTestDb(input: {
 						return (users.find((user) => user.stable_user_id === params[0]) ??
 							null) as T | null
 					}
+					if (
+						normalizedQuery.includes(
+							'select 1 as present from users where stable_user_id = ?',
+						)
+					) {
+						const exists = users.some(
+							(user) => user.stable_user_id === params[0],
+						)
+						return (exists ? { present: 1 } : null) as T | null
+					}
 					const count = countForQuery(normalizedQuery, String(params[0]))
 					if (count !== null) return { count } as T
 					throw new Error(`Unsupported first query: ${query}`)

--- a/packages/worker/src/admin/user-usage-data.ts
+++ b/packages/worker/src/admin/user-usage-data.ts
@@ -1,14 +1,10 @@
 import { cachified, type Cache } from '@epic-web/cachified'
 import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
 import {
-	entitlementResourceLabels,
 	parseStoredPlanName,
 	resolveEffectivePlan,
-	resolvePlanLimit,
-	type EntitlementResource,
-	type PlanName,
 } from '#worker/entitlements/plans.ts'
-import { readCurrentEntitlementResourceUsage } from '#worker/entitlements/service.ts'
+import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
 import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 import {
@@ -31,22 +27,6 @@ export const adminUsageMetrics = [
 	'email_received',
 ] as const satisfies ReadonlyArray<AdminUsageMetric>
 
-const adminUserUsageEntitlementResources = [
-	'saved_packages',
-	'scheduled_jobs',
-	'package_services',
-	'persistent_package_services',
-	'repo_sessions',
-	'email_sends_per_day',
-	'email_receives_per_day',
-	'stored_email_messages',
-	'secrets',
-	'concurrent_workflows',
-	'execute_calls_per_day',
-	'outbound_fetches_per_day',
-] as const satisfies ReadonlyArray<EntitlementResource>
-
-const warningThreshold = 0.8
 /**
  * Rollup rows are derived hourly from Analytics Engine in production, so a
  * short KV cache on the per-user read model adds no meaningful staleness
@@ -112,7 +92,7 @@ export async function loadAdminUserUsageData(
 			userId: usageUserId,
 			currentMonth,
 		}),
-		readEntitlementConsumption({
+		readAdminEntitlementConsumption({
 			env,
 			usageUserId,
 			plan,
@@ -137,36 +117,6 @@ export async function loadAdminUserUsageData(
 		entitlementConsumption,
 		warnings: entitlementConsumption.filter((item) => item.overEightyPercent),
 	}
-}
-
-async function readEntitlementConsumption(input: {
-	env: Env
-	usageUserId: string
-	plan: PlanName
-	now: Date
-}): Promise<Array<AdminUsageEntitlementConsumption>> {
-	return await Promise.all(
-		adminUserUsageEntitlementResources.map(async (resource) => {
-			const current = await readCurrentEntitlementResourceUsage({
-				db: input.env.APP_DB,
-				env: input.env,
-				userId: input.usageUserId,
-				resource,
-				now: input.now,
-			})
-			const limit = resolvePlanLimit(input.plan, resource)
-			const percentOfLimit = limit === 0 ? null : current / limit
-			return {
-				resource,
-				label: entitlementResourceLabels[resource],
-				current,
-				limit,
-				percentOfLimit,
-				overEightyPercent:
-					percentOfLimit !== null && percentOfLimit > warningThreshold,
-			}
-		}),
-	)
 }
 
 async function loadUserMonthRollups(input: {

--- a/packages/worker/src/admin/user-usage-data.ts
+++ b/packages/worker/src/admin/user-usage-data.ts
@@ -8,7 +8,6 @@ import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consu
 import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 import {
-	type AdminUsageEntitlementConsumption,
 	type AdminUsageMetric,
 	type AdminUsageMonthRollup,
 	type AdminUsageRollup,

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -34,6 +34,19 @@ const runLogMocks = vi.hoisted(() => ({
 	maxInFlight: 0,
 }))
 
+const fleetUsageMocks = vi.hoisted(() => ({
+	loadFleetUsageInsights: vi.fn(async () => ({
+		topRuntimeDurationConsumers: [],
+		topEventCountConsumers: [],
+		topDurationConsumersByMetric: [],
+		entitlementPressure: [],
+	})),
+}))
+
+vi.mock('#worker/admin/fleet-usage-insights.ts', () => ({
+	loadFleetUsageInsights: fleetUsageMocks.loadFleetUsageInsights,
+}))
+
 vi.mock('#worker/run-records/service.ts', () => ({
 	getAdminInsightsSnapshot: (input: { env: Env; userId: string }) =>
 		runLogMocks.getAdminInsightsSnapshot(input),

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -2,6 +2,7 @@ import { cachified } from '@epic-web/cachified'
 import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
 import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
 import { adminUsageMetrics } from '#worker/admin/user-usage-data.ts'
+import { loadFleetUsageInsights } from '#worker/admin/fleet-usage-insights.ts'
 import { type RunLogAdminInsightsSnapshot } from '#worker/run-records/admin-insights-snapshot.ts'
 import { getAdminInsightsSnapshot } from '#worker/run-records/service.ts'
 import { queryAnalyticsEngineSql } from '#worker/usage/aggregate-rollups.ts'
@@ -101,7 +102,7 @@ export async function loadAdminInsightsData(
 		: null
 	if (!cache) return await queryAdminInsights(env, now)
 	return await cachified({
-		key: 'admin-insights:v6',
+		key: 'admin-insights:v7',
 		cache,
 		ttl: insightsCacheTtlMs,
 		getFreshValue: () => queryAdminInsights(env, now),
@@ -219,6 +220,8 @@ async function queryAdminInsights(
 		users: insightsUsers,
 	})
 
+	const fleetUsage = await loadFleetUsageInsights({ db, env, now })
+
 	const jobHealth: AdminInsightsJobHealth = {
 		totalJobs: Number(jobStats?.total ?? 0),
 		enabledJobs: Number(jobStats?.enabled ?? 0),
@@ -280,6 +283,10 @@ async function queryAdminInsights(
 			usersLoaded: runLogInsights.usersLoaded,
 			complete: runLogInsights.complete,
 		},
+		topRuntimeDurationConsumers: fleetUsage.topRuntimeDurationConsumers,
+		topEventCountConsumers: fleetUsage.topEventCountConsumers,
+		topDurationConsumersByMetric: fleetUsage.topDurationConsumersByMetric,
+		entitlementPressure: fleetUsage.entitlementPressure,
 	}
 }
 

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -452,6 +452,38 @@ export type AdminInsightsRunLogCompleteness = {
 	complete: boolean
 }
 
+export type AdminInsightsDurationConsumer = {
+	stableUserId: string
+	username: string
+	totalDurationMs: number
+}
+
+export type AdminInsightsEventCountConsumer = {
+	stableUserId: string
+	username: string
+	eventCount: number
+}
+
+export type AdminInsightsMetricDurationConsumers = {
+	metric: AdminUsageMetric
+	consumers: Array<AdminInsightsDurationConsumer>
+}
+
+export type AdminInsightsEntitlementPressureResource = {
+	resource: AdminUsageEntitlementResource
+	label: string
+	current: number
+	limit: number
+	percentOfLimit: number
+}
+
+export type AdminInsightsEntitlementPressureUser = {
+	stableUserId: string
+	username: string
+	plan: AdminPlanName
+	pressuredResources: Array<AdminInsightsEntitlementPressureResource>
+}
+
 export type AdminInsightsLoaderData = {
 	ok: true
 	generatedAt: string
@@ -468,6 +500,10 @@ export type AdminInsightsLoaderData = {
 	jobHealth: AdminInsightsJobHealth
 	activation: AdminInsightsActivation
 	runLogCompleteness: AdminInsightsRunLogCompleteness
+	topRuntimeDurationConsumers: Array<AdminInsightsDurationConsumer>
+	topEventCountConsumers: Array<AdminInsightsEventCountConsumer>
+	topDurationConsumersByMetric: Array<AdminInsightsMetricDurationConsumers>
+	entitlementPressure: Array<AdminInsightsEntitlementPressureUser>
 }
 
 export type AdminSystemEmailListItem = {

--- a/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
@@ -1,0 +1,165 @@
+import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+
+const detectFleetUsagePressure = vi.fn<
+	(input: {
+		db: D1Database
+		env: Env
+		now: Date
+	}) => Promise<
+		Array<
+			| {
+					kind: 'entitlement'
+					stableUserId: string
+					username: string
+					resource: string
+					label: string
+					percentOfLimit: number
+			  }
+			| {
+					kind: 'runtime_duration'
+					stableUserId: string
+					username: string
+					totalDurationMs: number
+			  }
+		>
+	>
+>()
+
+vi.mock('#worker/admin/fleet-usage-insights.ts', () => ({
+	detectFleetUsagePressure: (input: {
+		db: D1Database
+		env: Env
+		now: Date
+	}) => detectFleetUsagePressure(input),
+	adminFleetEntitlementSweepUserLimit: 15,
+	fleetRuntimeDurationAlertThresholdMs: 24 * 60 * 60 * 1000,
+}))
+
+const sendCloudflareEmail = vi.fn(async () => ({ ok: true }))
+
+vi.mock('#app/email/cloudflare-email.ts', () => ({
+	sendCloudflareEmail: (...args: Array<unknown>) =>
+		sendCloudflareEmail(...args),
+}))
+
+const {
+	usageEntitlementAlertKvKey,
+	checkUsageEntitlementPressureAndNotify,
+	shouldRunUsageEntitlementAlertCron,
+} = await import('#app/usage-entitlement-alerts.ts')
+
+function createDb() {
+	return {
+		prepare(query: string) {
+			const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
+			return {
+				bind(..._params: Array<unknown>) {
+					return this
+				},
+				async all<T>() {
+					if (normalized.includes('from users u')) {
+						return {
+							results: [{ email: 'admin@example.com' }],
+						} as { results: Array<T> }
+					}
+					return { results: [] }
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+test('usage entitlement alerts stay quiet without pressure, then notify and cool down', async () => {
+	expect(
+		shouldRunUsageEntitlementAlertCron(new Date('2026-07-25T12:00:00.000Z')),
+	).toBe(true)
+	expect(
+		shouldRunUsageEntitlementAlertCron(new Date('2026-07-25T12:05:00.000Z')),
+	).toBe(false)
+
+	detectFleetUsagePressure.mockResolvedValueOnce([])
+	const quiet = await checkUsageEntitlementPressureAndNotify({
+		env: { APP_DB: createDb() },
+	})
+	expect(quiet).toEqual({ status: 'no_pressure' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+
+	detectFleetUsagePressure.mockResolvedValue([
+		{
+			kind: 'entitlement',
+			stableUserId: 'user-a',
+			username: 'alice',
+			resource: 'secrets',
+			label: 'secrets',
+			percentOfLimit: 0.91,
+		},
+	])
+	consoleWarn.mockImplementation(() => {})
+	sendCloudflareEmail.mockClear()
+	const kvStore = new Map<string, string>()
+	const kv = {
+		async get(key: string) {
+			return kvStore.get(key) ?? null
+		},
+		async put(key: string, value: string) {
+			kvStore.set(key, value)
+		},
+	} as unknown as KVNamespace
+	const env = {
+		APP_DB: createDb(),
+		APP_BASE_URL: 'https://heykody.dev',
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token',
+		BUNDLE_ARTIFACTS_KV: kv,
+	}
+	const now = new Date('2026-07-25T12:00:00.000Z')
+	try {
+		const first = await checkUsageEntitlementPressureAndNotify({ env, now })
+		expect(first).toEqual({ status: 'notified', issueCount: 1, recipients: 1 })
+		expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+		expect(kvStore.get(usageEntitlementAlertKvKey)).toBe(String(now.getTime()))
+
+		const second = await checkUsageEntitlementPressureAndNotify({
+			env,
+			now: new Date(now.getTime() + 60_000),
+		})
+		expect(second).toEqual({ status: 'cooldown', issueCount: 1 })
+		expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+	} finally {
+		consoleWarn.mockReset()
+	}
+})
+
+test('usage entitlement alerts no-op when no admins exist', async () => {
+	detectFleetUsagePressure.mockResolvedValue([
+		{
+			kind: 'runtime_duration',
+			stableUserId: 'user-b',
+			username: 'bob',
+			totalDurationMs: 99_999_999,
+		},
+	])
+	const db = {
+		prepare() {
+			return {
+				bind() {
+					return this
+				},
+				async all() {
+					return { results: [] }
+				},
+			}
+		},
+	} as unknown as D1Database
+	const result = await checkUsageEntitlementPressureAndNotify({
+		env: {
+			APP_DB: db,
+			APP_BASE_URL: 'https://heykody.dev',
+			CLOUDFLARE_ACCOUNT_ID: 'acct',
+			CLOUDFLARE_API_TOKEN: 'token',
+		},
+	})
+	expect(result).toEqual({ status: 'skipped', reason: 'no_admins' })
+	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
@@ -2,11 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 const detectFleetUsagePressure = vi.fn<
-	(input: {
-		db: D1Database
-		env: Env
-		now: Date
-	}) => Promise<
+	(input: { db: D1Database; env: Env; now: Date }) => Promise<
 		Array<
 			| {
 					kind: 'entitlement'
@@ -27,11 +23,8 @@ const detectFleetUsagePressure = vi.fn<
 >()
 
 vi.mock('#worker/admin/fleet-usage-insights.ts', () => ({
-	detectFleetUsagePressure: (input: {
-		db: D1Database
-		env: Env
-		now: Date
-	}) => detectFleetUsagePressure(input),
+	detectFleetUsagePressure: (input: { db: D1Database; env: Env; now: Date }) =>
+		detectFleetUsagePressure(input),
 	adminFleetEntitlementSweepUserLimit: 15,
 	fleetRuntimeDurationAlertThresholdMs: 24 * 60 * 60 * 1000,
 }))

--- a/packages/worker/src/app/usage-entitlement-alerts.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.ts
@@ -1,0 +1,183 @@
+import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
+import {
+	adminFleetEntitlementSweepUserLimit,
+	detectFleetUsagePressure,
+	fleetRuntimeDurationAlertThresholdMs,
+	type FleetEntitlementPressureIssue,
+} from '#worker/admin/fleet-usage-insights.ts'
+import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
+
+/**
+ * Hourly fleet usage / entitlement pressure check. The admin insights page
+ * surfaces the same bounded sweep; this lane emails admins when pressure
+ * crosses thresholds so operators do not have to poll the dashboard.
+ */
+
+export const usageEntitlementAlertCooldownMinutes = 6 * 60
+export const usageEntitlementAlertKvKey = 'ops-alert:usage-entitlement-pressure:v1'
+
+type UsageEntitlementAlertEnv = {
+	APP_DB: D1Database
+	APP_BASE_URL?: string
+	CLOUDFLARE_ACCOUNT_ID?: string
+	CLOUDFLARE_API_BASE_URL?: string
+	CLOUDFLARE_API_TOKEN?: string
+	BUNDLE_ARTIFACTS_KV?: KVNamespace
+}
+
+export function shouldRunUsageEntitlementAlertCron(now: Date) {
+	return now.getUTCMinutes() === 0
+}
+
+export type UsageEntitlementAlertResult =
+	| { status: 'no_pressure' }
+	| { status: 'cooldown'; issueCount: number }
+	| { status: 'notified'; issueCount: number; recipients: number }
+	| { status: 'skipped'; reason: 'no_system_domain' | 'no_admins' }
+
+export async function checkUsageEntitlementPressureAndNotify(input: {
+	env: UsageEntitlementAlertEnv
+	now?: Date
+	cooldownMinutes?: number
+	runtimeDurationThresholdMs?: number
+}): Promise<UsageEntitlementAlertResult> {
+	const now = input.now ?? new Date()
+	const cooldownMinutes =
+		input.cooldownMinutes ?? usageEntitlementAlertCooldownMinutes
+	const issues = await detectFleetUsagePressure({
+		db: input.env.APP_DB,
+		env: input.env as Env,
+		now,
+		runtimeDurationThresholdMs:
+			input.runtimeDurationThresholdMs ?? fleetRuntimeDurationAlertThresholdMs,
+	})
+	if (issues.length === 0) {
+		return { status: 'no_pressure' }
+	}
+
+	if (input.env.BUNDLE_ARTIFACTS_KV) {
+		const lastSentRaw = await input.env.BUNDLE_ARTIFACTS_KV.get(
+			usageEntitlementAlertKvKey,
+		)
+		const lastSentMs = lastSentRaw ? Number(lastSentRaw) : Number.NaN
+		if (
+			Number.isFinite(lastSentMs) &&
+			now.getTime() - lastSentMs < cooldownMinutes * 60_000
+		) {
+			return { status: 'cooldown', issueCount: issues.length }
+		}
+	}
+
+	const notified = await notifyAdminsOfUsageEntitlementPressure({
+		env: input.env,
+		issues,
+		now,
+	})
+	if (notified.status !== 'notified') {
+		return notified
+	}
+
+	if (input.env.BUNDLE_ARTIFACTS_KV) {
+		await input.env.BUNDLE_ARTIFACTS_KV.put(
+			usageEntitlementAlertKvKey,
+			String(now.getTime()),
+			{
+				expirationTtl: (cooldownMinutes + 60) * 60,
+			},
+		)
+	}
+
+	return notified
+}
+
+async function notifyAdminsOfUsageEntitlementPressure(input: {
+	env: UsageEntitlementAlertEnv
+	issues: Array<FleetEntitlementPressureIssue>
+	now: Date
+}): Promise<
+	| { status: 'notified'; issueCount: number; recipients: number }
+	| { status: 'skipped'; reason: 'no_system_domain' | 'no_admins' }
+> {
+	const systemDomain = getSystemEmailDomain(input.env)
+	if (!systemDomain) {
+		return { status: 'skipped', reason: 'no_system_domain' }
+	}
+
+	const admins = await input.env.APP_DB.prepare(
+		`SELECT u.email FROM users u
+		 INNER JOIN user_roles ur ON ur.user_id = u.id
+		 INNER JOIN roles r ON r.id = ur.role_id
+		 WHERE r.name = 'admin'
+		 ORDER BY u.id ASC`,
+	).all<{ email: string }>()
+	const recipients = (admins.results ?? []).map((row) => row.email)
+	if (recipients.length === 0) {
+		return { status: 'skipped', reason: 'no_admins' }
+	}
+
+	const baseUrl = input.env.APP_BASE_URL?.trim() || `https://${systemDomain}`
+	const runtimeHours = Math.round(
+		fleetRuntimeDurationAlertThresholdMs / (60 * 60 * 1000),
+	)
+	const lines = input.issues.map((issue) => formatIssueLine(issue, runtimeHours))
+	const text = [
+		`Kody detected ${input.issues.length} fleet usage pressure signal(s) while sweeping the top ${adminFleetEntitlementSweepUserLimit} active accounts this UTC month.`,
+		lines.join('\n'),
+		`Review entitlement pressure and top consumers at ${baseUrl}/admin/insights, or drill into a user at ${baseUrl}/admin/users.`,
+		`Checked at ${input.now.toISOString()}.`,
+	].join('\n\n')
+
+	try {
+		await sendCloudflareEmail(
+			{
+				accountId: input.env.CLOUDFLARE_ACCOUNT_ID,
+				apiBaseUrl: input.env.CLOUDFLARE_API_BASE_URL,
+				apiToken: input.env.CLOUDFLARE_API_TOKEN,
+			},
+			{
+				to: recipients.length === 1 ? recipients[0]! : recipients,
+				from: `kody@${systemDomain}`,
+				subject: `Fleet usage pressure: ${input.issues.length} signal(s)`,
+				text,
+				html: `<!doctype html><html lang="en"><body>${text
+					.split('\n\n')
+					.map((paragraph) => `<p>${escapeHtml(paragraph)}</p>`)
+					.join('')}</body></html>`,
+			},
+		)
+	} catch (error) {
+		console.warn('usage-entitlement-alert-notification-failed', error)
+		throw error
+	}
+
+	console.warn('usage-entitlement-pressure-alerted', {
+		issueCount: input.issues.length,
+		recipients: recipients.length,
+	})
+
+	return {
+		status: 'notified',
+		issueCount: input.issues.length,
+		recipients: recipients.length,
+	}
+}
+
+function formatIssueLine(
+	issue: FleetEntitlementPressureIssue,
+	runtimeHours: number,
+) {
+	if (issue.kind === 'entitlement') {
+		const percent = Math.round(issue.percentOfLimit * 100)
+		return `• ${issue.username} (${issue.stableUserId}): ${issue.label} at ${percent}% of plan limit`
+	}
+	const hours = (issue.totalDurationMs / (60 * 60 * 1000)).toFixed(1)
+	return `• ${issue.username} (${issue.stableUserId}): ${hours}h combined runtime this month (threshold ${runtimeHours}h)`
+}
+
+function escapeHtml(value: string) {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+}

--- a/packages/worker/src/app/usage-entitlement-alerts.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.ts
@@ -14,7 +14,8 @@ import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
  */
 
 export const usageEntitlementAlertCooldownMinutes = 6 * 60
-export const usageEntitlementAlertKvKey = 'ops-alert:usage-entitlement-pressure:v1'
+export const usageEntitlementAlertKvKey =
+	'ops-alert:usage-entitlement-pressure:v1'
 
 type UsageEntitlementAlertEnv = {
 	APP_DB: D1Database
@@ -119,7 +120,9 @@ async function notifyAdminsOfUsageEntitlementPressure(input: {
 	const runtimeHours = Math.round(
 		fleetRuntimeDurationAlertThresholdMs / (60 * 60 * 1000),
 	)
-	const lines = input.issues.map((issue) => formatIssueLine(issue, runtimeHours))
+	const lines = input.issues.map((issue) =>
+		formatIssueLine(issue, runtimeHours),
+	)
 	const text = [
 		`Kody detected ${input.issues.length} fleet usage pressure signal(s) while sweeping the top ${adminFleetEntitlementSweepUserLimit} active accounts this UTC month.`,
 		lines.join('\n'),

--- a/packages/worker/src/scheduled/scheduled-lanes.ts
+++ b/packages/worker/src/scheduled/scheduled-lanes.ts
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/cloudflare'
 import {
+	checkUsageEntitlementPressureAndNotify,
+	shouldRunUsageEntitlementAlertCron,
+} from '#app/usage-entitlement-alerts.ts'
+import {
 	checkAuthDenialBurstAndNotify,
 	shouldRunAuthDenialAlertCron,
 } from '#app/auth-denial-alerts.ts'
@@ -45,6 +49,7 @@ export const scheduledLaneNames = [
 	'usage_aggregation',
 	'auth_denial_alert',
 	'email_delivery_alert',
+	'usage_entitlement_alert',
 	'dr_export',
 	'dr_export_watchdog',
 	'job_schedule_watchdog',
@@ -91,6 +96,9 @@ export function getScheduledLanes(input: {
 	}
 	if (shouldRunEmailDeliveryAlertCron(input.scheduledAt)) {
 		lanes.push('email_delivery_alert')
+	}
+	if (shouldRunUsageEntitlementAlertCron(input.scheduledAt)) {
+		lanes.push('usage_entitlement_alert')
 	}
 	if (
 		shouldRunDrExportCron(input.scheduledAt) &&
@@ -168,6 +176,11 @@ export async function runScheduledLane(input: {
 			})
 		case 'email_delivery_alert':
 			return checkEmailDeliveryBurstAndNotify({
+				env: input.env,
+				now: input.scheduledAt,
+			})
+		case 'usage_entitlement_alert':
+			return checkUsageEntitlementPressureAndNotify({
 				env: input.env,
 				now: input.scheduledAt,
 			})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fleet-wide operator visibility into usage and entitlement pressure, plus proactive alerting:

- **Admin insights fleet panels** (`packages/worker/src/app/fleet-usage-insights.ts` + `admin-insights-data.ts` + the insights UI): top-10 combined runtime-duration consumers (execute + job_run + workflow_run + service_runtime), top-10 event-count consumers, per-metric duration leaders, and an entitlement-pressure panel listing any of the top ~15 active users over 80% of any plan limit.
- **Drill-down gap fixed:** `storage_bytes` now included in the admin per-user usage drill-down via a shared UserMeter-aware `readAdminEntitlementConsumption` (`entitlement-consumption.ts`), matching the account self-view and the `admin_user_usage` MCP schema that already declared it.
- **Alert lane:** new `usage_entitlement_alert` scheduled lane — hourly bounded sweep of the same user set, emails admin-role users when someone crosses entitlement pressure (>80% of a plan limit) or combined runtime duration exceeds 24h/month (`fleetRuntimeDurationAlertThresholdMs`), with KV cooldown (`ops-alert:usage-entitlement-pressure:v1`) following the auth-denial alert pattern.

## Testing

`npm run validate` green in the implementing environment (1,858 unit tests + e2e). New tests: `fleet-usage-insights.node.test.ts`, `usage-entitlement-alerts.node.test.ts`; updated `admin-insights-data.node.test.ts` and `user-usage-data.node.test.ts`. Docs updated: `usage-metering.md`, `entitlements.md`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `22f8dbc3`

**Classification:** extends — wires bounded `usage_rollups` reads, entitlement point-reads, and a new scheduled alert lane into existing admin/ops surfaces.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — new fleet panels on `/admin/insights` |
| `scheduled-cron` | surfaces | extends — `usage_entitlement_alert` hourly lane |
| `entitlements` | auth | extends — shared admin entitlement-consumption reader incl. `storage_bytes` |
| `d1-app-db` | storage | composes — bounded `usage_rollups` ranking queries |

### System map

Fleet visibility reads bounded D1 rollups and entitlement counters for the admin dashboard; the hourly cron emails admins when pressure crosses thresholds.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::extended
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	appUi -->|"loadAdminInsightsData fleet panels"| d1AppDb
	appUi -->|"readAdminEntitlementConsumption (incl. storage_bytes)"| entitlements
	scheduledCron -->|"usage_entitlement_alert hourly sweep"| d1AppDb
	scheduledCron -->|"email admins on pressure / 24h runtime"| entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

## Conductor report

Implemented by the admin-fleet-visibility track; PR opened and shepherded by the conductor after the track's environment could not create PRs. Status: awaiting CI + CodeRabbit, then squash-merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

