### PR TITLE
Wire the $20/month Pro price id into production config

### DIFF
--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -411,11 +411,11 @@
 				// to the kody_plan metadata fallback. Checkout sessions are
 				// created server-side for authenticated users (no public
 				// Payment Link). STRIPE_STANDARD_PRICE_ID carries the
-				// original $5/month price id (pre-rename Pro). Add
-				// STRIPE_PRO_PRICE_ID here once the $20/month Pro price
-				// exists in Stripe; until then the Pro tier renders but is
-				// not purchasable.
+				// original $5/month price id (pre-rename Pro, on the "Kody
+				// Standard" product). STRIPE_PRO_PRICE_ID is the $20/month
+				// price on the "Kody Pro" product.
 				"STRIPE_STANDARD_PRICE_ID": "price_1Tv3W2LAQpAnsYszSr4PGBkE",
+				"STRIPE_PRO_PRICE_ID": "price_1U1AISLAQpAnsYszIQvRJNhl",
 				// Disaster-recovery exporter → locked R2 bucket in the KCD
 				// (DR) account. The companion S3 credentials are Worker
 				// secrets set out-of-band via the Cloudflare API.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `STRIPE_PRO_PRICE_ID: price_1U1AISLAQpAnsYszIQvRJNhl` to the production env block in `packages/worker/wrangler.jsonc`, activating Pro checkout on the billing page.

## Stripe setup (done via the owner's Stripe account, live mode)

- Existing product `prod_UusVot04vmPRHi` renamed **"Kody Pro" → "Kody Standard"** with `kody_plan: standard` metadata; its $5/month price `price_1Tv3W2LAQpAnsYszSr4PGBkE` (already committed as `STRIPE_STANDARD_PRICE_ID`) renamed to "Kody Standard monthly". Existing subscriptions unaffected.
- New product **"Kody Pro"** (`prod_V1ChgPPenrxsAX`, `kody_plan: pro`) created with a $20/month USD recurring default price `price_1U1AISLAQpAnsYszIQvRJNhl` (verified live mode, active, `unit_amount: 2000`, monthly).

Config-only change; price-id → plan resolution shipped and was tested in #1242.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `7a81d6ef` · **Head:** `67b2e6a2`

**Classification:** composes — one committed production Wrangler var; no code changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `billing` | auth | composes — `STRIPE_PRO_PRICE_ID` var enables Pro checkout via existing resolution |

</details>

<!-- system-recap:end -->

## Conductor report

Stripe objects created and verified by the conductor via the owner-approved `@kentcdodds/stripe` package. Status: awaiting CI, then squash-merge and deploy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added the production Stripe Pro plan price configuration for the $20/month subscription.
  * Clarified plan details in the production configuration while preserving the existing Standard plan settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->