### PR TITLE
Remove transition fallbacks left over from the tier restructure and migration squash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
         run: |
-          node tools/ci/reset-migration-bookkeeping.ts --remote --config "$WRANGLER_CONFIG"
           node ./wrangler-env.ts d1 migrations apply APP_DB --remote --config "$WRANGLER_CONFIG"
           node ./wrangler-env.ts d1 migrations apply AUDIT_DB --remote --config "$WRANGLER_CONFIG"
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -145,7 +145,6 @@ jobs:
           CLOUDFLARE_ENV: preview
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
         run: |
-          node tools/ci/reset-migration-bookkeeping.ts --remote --config "$WRANGLER_CONFIG"
           node ./wrangler-env.ts d1 migrations apply APP_DB --remote --config "$WRANGLER_CONFIG"
           node ./wrangler-env.ts d1 migrations apply AUDIT_DB --remote --config "$WRANGLER_CONFIG"
 

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -11,8 +11,8 @@ Module: `packages/worker/src/entitlements/`
 - `plans.ts` — plan names (`free`, `standard`, `pro`, `max`), the `PlanLimits`
   config per plan, `max` email caps (`maxPlanEmailLimits`), the
   `EntitlementResource` registry, `resolvePlanLimit(plan, resource)`,
-  `resolveEmailResourceLimit(plan, resource)`, `getPlanRank`, `parsePlanName`
-  (strict, untrusted input), `parseStoredPlanName` (stored-column reads), and
+  `getPlanRank`, `parsePlanName` (strict, untrusted input),
+  `parseStoredPlanName` (stored-column reads), and
   `resolveEffectivePlan(manual, stripe)`.
 - `errors.ts` — the one typed error (`EntitlementLimitError`) and the one
   user-facing message builder every enforcement point uses.
@@ -30,19 +30,14 @@ The plan registry in `plans.ts` includes `free`, `standard`, `pro`, and `max`.
 Every plan has finite numeric limits for every resource; there are no uncapped
 tiers and no env-var backstops.
 
-Follow-up: emergency admin-only `unlimited` is intentionally deferred until a
-follow-up deployment after `0083-plan-default-free.sql` completes its residual
-sweep. Until then the live registry stays finite `max` only.
+There is deliberately no uncapped plan; the live registry stays finite `max`
+only.
 
-`users.plan` and `invites.plan` are NOT NULL TEXT columns. Historical migrations
-(`0046-invites-email-verification.sql`, `0065-invite-plans.sql`, and
-`0081-plan-not-null.sql`) left the DDL default as `'unlimited'` through
-`0082-rename-unlimited-plan-to-max.sql`, which renames stored `'unlimited'` rows
-to `'max'` but does not change the column default. Migration
-`0083-plan-default-free.sql` reconciles migration-window residual `'unlimited'`
-to `'max'`, fails closed if any remain, and rebuilds both columns as NOT NULL
-DEFAULT `'free'`. **Live DDL defaults and writers always persist a known plan
-name (never NULL); normal creation and reset paths default to `free`.**
+`users.plan` and `invites.plan` are NOT NULL TEXT columns with DDL default
+`'free'` and CHECK constraints for the registered names (squashed baseline plus
+`0002-restructure-plan-tiers.sql`). **Live DDL defaults and writers always
+persist a known plan name (never NULL); normal creation and reset paths default
+to `free`.**
 
 **Write and default:** `resolvePlanWrite` maps nullish admin/API inputs to
 `free`, which is the default for new accounts, invites without an explicit plan,
@@ -53,8 +48,8 @@ resets. Explicit `max` remains a valid deliberate assignment.
 registered names. Reads use strict `parseStoredPlanName`: known names pass
 through unchanged, while a value that violates the storage contract throws
 without including the raw value or user data. Untrusted admin/API input uses
-`parsePlanName` so typos, unknown strings, and residual `'unlimited'` are
-rejected as validation failures.
+`parsePlanName` so typos, unknown strings, and retired plan names are rejected
+as validation failures.
 
 Migration `0002-restructure-plan-tiers.sql` maps the former `pro` tier to
 `standard`, the former `partner` tier to `pro`, and rebuilds both CHECK
@@ -62,7 +57,7 @@ constraints for the current registry.
 
 `users.stripe_plan` stays nullable because it is Stripe-derived; `max` is
 manual-only — admin-visible, not paid or public — and never written from Stripe
-(`parseStripePlanName` rejects it, as well as residual `'unlimited'`).
+(`parseStripePlanName` rejects it, along with any retired or unknown name).
 
 `resolveEffectivePlan(manual, stripe)` compares a non-null manual plan (after
 `parseStoredPlanName`) with `users.stripe_plan`. Manual `max` always wins over
@@ -74,11 +69,12 @@ Stripe; otherwise the higher-ranked of the two is returned. Unknown or null
 The `max` plan is the operator/manual ceiling: a high finite tier admins assign
 deliberately. It is not a public or Stripe-purchasable plan. Email resources use
 `maxPlanEmailLimits` because inbound volume is attacker-controlled and outbound
-sending is an outreach-abuse surface — use `resolveEmailResourceLimit` to read
-those caps. The caps stay finite but dominate every other plan's email limits,
-so granting `max` never reduces email capacity (`email_message_bytes` stays at
-standard/pro parity because the per-message ceiling is a platform bound, not a
-scalable quota). All other resources use the ordinary `planLimits.max` numbers.
+sending is an outreach-abuse surface — `resolvePlanLimit` resolves those caps
+like any other limit. The caps stay finite but dominate every other plan's email
+limits, so granting `max` never reduces email capacity (`email_message_bytes`
+stays at standard/pro parity because the per-message ceiling is a platform
+bound, not a scalable quota). All other resources use the ordinary
+`planLimits.max` numbers.
 
 | Resource                      | Limit     |
 | ----------------------------- | --------- |
@@ -379,26 +375,18 @@ reconcile lane, cold-drift correction, and the parity report.
 
 ## Schema history
 
-Migration `0080-backfill-unlimited-plan.sql` backfilled pre-existing NULL
-`users.plan` / `invites.plan` rows to `'unlimited'` (the former top-tier
-sentinel). Migration `0081-plan-not-null.sql` reconciles any residual NULLs and
-rebuilds both columns as NOT NULL DEFAULT `'unlimited'`. Migration
-`0082-rename-unlimited-plan-to-max.sql` renames stored `'unlimited'` plan values
-to `'max'` on `users.plan` and `invites.plan` only; it does not touch
-`users.stripe_plan`, unknown plan strings, or the DDL default. Migration
-`0083-plan-default-free.sql` reconciles migration-window residual `'unlimited'`
-to `'max'`, fails closed if any remain, and rebuilds `users` and `invites` with
-NOT NULL DEFAULT `'free'`. Migration `0113-plan-check-constraints.sql` verifies
-that every stored plan is registered, then rebuilds both tables with CHECK
-constraints for the plan registry at that point. Migration
-`0002-restructure-plan-tiers.sql` renames stored tier values and replaces those
-constraints with `free`, `standard`, `pro`, and `max`.
+The pre-squash plan-column evolution (NULL rows → `'unlimited'` backfill → NOT
+NULL → `'unlimited'` renamed to `'max'` → DEFAULT `'free'` → CHECK constraints)
+is collapsed into the squashed baseline; the individual migration files live in
+Git history only. Post-squash, `0002-restructure-plan-tiers.sql` renames stored
+`pro` to `standard` and `partner` to `pro` (on `users.plan`,
+`users.stripe_plan`, and `invites.plan`) and rebuilds both CHECK constraints for
+`free`, `standard`, `pro`, and `max`.
 
 ## Assigning plans
 
 New accounts start with `users.plan = 'free'` unless the consumed invite carries
-another plan. Migration `0065-invite-plans.sql` adds `invites.plan` (NOT NULL
-DEFAULT `'free'` after `0083-plan-default-free.sql`; writers and admin UI
+another plan via `invites.plan` (NOT NULL DEFAULT `'free'`; writers and admin UI
 default to `free`). Password and social signup read the consumed invite's stored
 plan with `parseStoredPlanName` and copy it onto `users.plan`; missing or
 omitted invite plans are written as `free` via `resolvePlanWrite`. Admin-created
@@ -675,7 +663,7 @@ Use `getCurrent` only when the built-in D1 counter cannot express the resource.
 | `email_sends_per_day`         | `sendOutboundEmail` (`consumeDailyEntitlement`; plan limit from `resolvePlanLimit`)                                                                                                                                                   |
 | `email_receives_per_day`      | `handleInboundEmail` (`consumeDailyEntitlement`; same plan limits; refund only on `RetryableInboundStorageError`)                                                                                                                     |
 | `stored_email_messages`       | `handleInboundEmail` before storage (`assertWithinEntitlement`; `max` caps from `planLimits.max`)                                                                                                                                     |
-| `email_message_bytes`         | `handleInboundEmail` before quota/parse (per-message raw size via `resolveEmailResourceLimit`)                                                                                                                                        |
+| `email_message_bytes`         | `handleInboundEmail` before quota/parse (per-message raw size via `resolvePlanLimit`)                                                                                                                                                 |
 | `secrets`                     | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts`                                                                                                                                                      |
 | `concurrent_workflows`        | `createDynamicCallableWorkflow` (`reserveWorkflowProjectionSlot` + `assertWithinEntitlement` getCurrent; `max` = 5,000)                                                                                                               |
 | `storage_bytes`               | UserMeter DO reserve via `assertWithinStorageBytesEntitlement` (atomic `reserveStorageBytes`; cold zero-init bootstrap; required `env.USER_METER`); StorageRunner write tools/app RPCs (`getCurrent` check-only for bucket component) |
@@ -735,10 +723,10 @@ without repeatedly enumerating inactive users. `/account/billing` arms the same
 backstop and still refreshes on every view so non-persisted `cancel_at` /
 `subscriptionStatus` stay current. If checkout cannot arm its backstop, a failed
 immediate refresh remains an error so the caller or Stripe webhook retries
-instead of acknowledging an unrecoverable stale projection. Migration
-`0066-stripe-billing.sql` adds `stripe_customer_id` (unique partial index),
-`stripe_plan`, and `stripe_plan_refreshed_at`; Wrangler migration `v23` adds the
-alarm DO class without moving canonical billing data out of D1.
+instead of acknowledging an unrecoverable stale projection. The
+`stripe_customer_id` (unique partial index), `stripe_plan`, and
+`stripe_plan_refreshed_at` columns ship in the squashed baseline; the alarm DO
+class exists without moving canonical billing data out of D1.
 
 Published prices: Free $0, Standard $5/mo, Pro $20/mo. Env vars and deploy
 wiring are documented in
@@ -746,16 +734,14 @@ wiring are documented in
 
 ## Related tables and coordination
 
-- `users.plan` — added by the invite-signup migration
-  (`0046-invites-email-verification.sql`); NOT NULL DEFAULT `'free'` after
-  `0083-plan-default-free.sql` (writers default to `free`). The entitlements
-  module is the consumer of that column (manual / invite / admin grant).
-- `invites.plan` — signup plan from migration `0065-invite-plans.sql`; NOT NULL
-  DEFAULT `'free'` after `0083-plan-default-free.sql` (writers and admin UI
+- `users.plan` — NOT NULL DEFAULT `'free'` (squashed baseline plus the 0002 tier
+  rename). The entitlements module is the consumer of that column (manual /
+  invite / admin grant).
+- `invites.plan` — signup plan; NOT NULL DEFAULT `'free'` (writers and admin UI
   default to `free`). Applied to `users.plan` when the invite is consumed at
   signup via `parseStoredPlanName` and `resolvePlanWrite`.
 - `users.stripe_customer_id`, `users.stripe_plan`,
-  `users.stripe_plan_refreshed_at` — Stripe billing columns from migration
-  `0066-stripe-billing.sql`; owned by `packages/worker/src/billing/`, read by
-  `getUserPlan` via `resolveEffectivePlan`. `stripe_plan` stays nullable because
-  it is Stripe-derived; `max` is manual-only.
+  `users.stripe_plan_refreshed_at` — Stripe billing columns owned by
+  `packages/worker/src/billing/`, read by `getUserPlan` via
+  `resolveEffectivePlan`. `stripe_plan` stays nullable because it is
+  Stripe-derived; `max` is manual-only.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -142,9 +142,11 @@ Quick notes for getting a local kody environment running.
   schema plus migration-seeded platform rows); the pre-squash files remain in
   Git history only. `tools/ci/reset-migration-bookkeeping.ts` is the
   deterministic guard that rewrote `d1_migrations` bookkeeping in existing
-  databases (production, preview, and local state dirs) — it verifies the
-  applied set matches the frozen pre-squash list exactly before touching
-  anything, and no-ops on fresh or already-squashed databases.
+  databases — it verifies the applied set matches the frozen pre-squash list
+  exactly before touching anything, and no-ops on fresh or already-squashed
+  databases. Production and preview settled post-squash on 2026-08-05, so the
+  guard now runs only for local applies (pre-squash developer state dirs);
+  delete it once those have died out.
 
 ## Documentation maintenance
 

--- a/packages/worker/src/app/account-email-data.node.test.ts
+++ b/packages/worker/src/app/account-email-data.node.test.ts
@@ -65,7 +65,7 @@ vi.mock('#worker/entitlements/plans.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof EntitlementPlans>()
 	return {
 		...actual,
-		resolveEmailResourceLimit: vi.fn(() => 100),
+		resolvePlanLimit: vi.fn(() => 100),
 	}
 })
 

--- a/packages/worker/src/app/account-email-data.ts
+++ b/packages/worker/src/app/account-email-data.ts
@@ -27,10 +27,7 @@ import {
 	type EmailMessageRecord,
 	type EmailProcessingStatus,
 } from '#worker/email/types.ts'
-import {
-	resolveEmailResourceLimit,
-	type PlanName,
-} from '#worker/entitlements/plans.ts'
+import { resolvePlanLimit, type PlanName } from '#worker/entitlements/plans.ts'
 import {
 	getUserPlan,
 	readCurrentEntitlementResourceUsage,
@@ -264,17 +261,17 @@ async function loadUsage(input: {
 		day: utcDayKey(now),
 		stored_messages: {
 			count: storedMessages,
-			limit: resolveEmailResourceLimit(plan, 'stored_email_messages'),
+			limit: resolvePlanLimit(plan, 'stored_email_messages'),
 		},
 		sends_today: {
 			count: sendsToday,
-			limit: resolveEmailResourceLimit(plan, 'email_sends_per_day'),
+			limit: resolvePlanLimit(plan, 'email_sends_per_day'),
 		},
 		receives_today: {
 			count: receivesToday,
-			limit: resolveEmailResourceLimit(plan, 'email_receives_per_day'),
+			limit: resolvePlanLimit(plan, 'email_receives_per_day'),
 		},
-		max_message_bytes: resolveEmailResourceLimit(plan, 'email_message_bytes'),
+		max_message_bytes: resolvePlanLimit(plan, 'email_message_bytes'),
 	}
 }
 

--- a/packages/worker/src/app/handlers/account-email.node.test.ts
+++ b/packages/worker/src/app/handlers/account-email.node.test.ts
@@ -63,7 +63,7 @@ const mockModule = vi.hoisted(() => ({
 	isAccountEmailVerified: vi.fn(async () => true),
 	getUserPlan: vi.fn(async () => 'free' as const),
 	readEntitlementResourceUsage: vi.fn(async () => 2),
-	resolveEmailResourceLimit: vi.fn((_plan: string, resource: string) => {
+	resolvePlanLimit: vi.fn((_plan: string, resource: string) => {
 		switch (resource) {
 			case 'stored_email_messages':
 				return 100
@@ -185,8 +185,8 @@ vi.mock('#worker/entitlements/plans.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof EntitlementPlans>()
 	return {
 		...actual,
-		resolveEmailResourceLimit: (...args: Array<unknown>) =>
-			mockModule.resolveEmailResourceLimit(...(args as [string, string])),
+		resolvePlanLimit: (...args: Array<unknown>) =>
+			mockModule.resolvePlanLimit(...(args as [string, string])),
 	}
 })
 

--- a/packages/worker/src/billing/billing-config.node.test.ts
+++ b/packages/worker/src/billing/billing-config.node.test.ts
@@ -126,11 +126,12 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			env,
 		),
 	).toEqual({
-		stripePlan: 'standard',
+		stripePlan: 'pro',
 		cancelAt: null,
 		subscriptionStatus: 'active',
 	})
 
+	// Retired plan names in metadata contribute nothing.
 	expect(
 		resolveSubscriptionPlan(
 			[
@@ -143,7 +144,7 @@ test('resolveSubscriptionPlan maps active price and metadata plans with soonest 
 			env,
 		),
 	).toEqual({
-		stripePlan: 'pro',
+		stripePlan: null,
 		cancelAt: null,
 		subscriptionStatus: 'active',
 	})

--- a/packages/worker/src/billing/billing-config.ts
+++ b/packages/worker/src/billing/billing-config.ts
@@ -117,11 +117,10 @@ function planFromSubscription(
 	}
 	if (matchedStandardPrice) return 'standard'
 
-	// Price ids are the current, unambiguous source of truth. `kody_plan`
-	// metadata was written before the tier rename, so old partner means new
-	// pro and old pro means standard.
+	// Price ids are the primary, unambiguous source of truth; `kody_plan`
+	// metadata is the fallback for subscriptions whose price id rotated.
 	const metadataPlan = subscription.metadata?.['kody_plan']
-	return parseStripePlanName(metadataPlan, { legacyMetadata: true })
+	return parseStripePlanName(metadataPlan)
 }
 
 function pickSubscriptionStatus(

--- a/packages/worker/src/email/inbound.ts
+++ b/packages/worker/src/email/inbound.ts
@@ -5,7 +5,7 @@ import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import {
 	parseStoredPlanName,
 	resolveEffectivePlan,
-	resolveEmailResourceLimit,
+	resolvePlanLimit,
 } from '#worker/entitlements/plans.ts'
 import {
 	assertWithinEntitlement,
@@ -457,7 +457,7 @@ export async function handleInboundEmail(
 								ownerId: userId,
 							}),
 					})
-					const receiveLimit = resolveEmailResourceLimit(
+					const receiveLimit = resolvePlanLimit(
 						account.plan,
 						'email_receives_per_day',
 					)
@@ -511,10 +511,7 @@ export async function handleInboundEmail(
 					const chargeResult = await authority.charge({
 						delivery: chargeCandidate,
 						plan: account.plan,
-						limit: resolveEmailResourceLimit(
-							account.plan,
-							'email_receives_per_day',
-						),
+						limit: resolvePlanLimit(account.plan, 'email_receives_per_day'),
 						now: quotaNow,
 					})
 					claimedDelivery = chargeResult.delivery

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -673,13 +673,12 @@ test('plan registry, ranks, and limits match the published tier contract', () =>
 	})
 })
 
-test('Stripe plan parsing separates current stored values from legacy metadata', () => {
+test('Stripe plan parsing accepts registered purchasable names only', () => {
 	expect(parseStripePlanName('standard')).toBe('standard')
 	expect(parseStripePlanName('pro')).toBe('pro')
 	expect(parseStripePlanName('partner')).toBeNull()
+	expect(parseStripePlanName('unlimited')).toBeNull()
 	expect(parseStripePlanName('max')).toBeNull()
-	expect(parseStripePlanName('partner', { legacyMetadata: true })).toBe('pro')
-	expect(parseStripePlanName('pro', { legacyMetadata: true })).toBe('standard')
 })
 
 test('persistent package services use finite concurrent counts', async () => {

--- a/packages/worker/src/entitlements/plans.ts
+++ b/packages/worker/src/entitlements/plans.ts
@@ -7,11 +7,10 @@
  * indicate schema corruption and throw instead of granting a plan. Untrusted
  * admin/API input uses {@link parsePlanName} so invalid input can be rejected
  * without throwing. Stripe metadata uses {@link parseStripePlanName}, which
- * rejects `max` (manual-only) and residual `'unlimited'`.
+ * rejects `max` (manual-only).
  *
- * Follow-up: emergency admin-only `unlimited` is intentionally deferred until
- * a follow-up deployment after 0083's residual sweep. Until then the live
- * registry is finite `max` only.
+ * There is deliberately no uncapped plan: the live registry is finite `max`
+ * only.
  */
 
 export const planNames = ['free', 'standard', 'pro', 'max'] as const
@@ -20,7 +19,7 @@ export type PlanName = (typeof planNames)[number]
 
 /**
  * Strict plan-name parser for untrusted admin/API input validation.
- * Unknown strings, typos, residual `'unlimited'`, nullish values, and
+ * Unknown strings, typos, retired plan names, nullish values, and
  * non-strings return null so callers can reject them.
  */
 export function parsePlanName(value: unknown): PlanName | null {
@@ -44,24 +43,12 @@ export function parseStoredPlanName(value: unknown): PlanName {
 }
 
 /**
- * Parse a current Stripe plan name or legacy `kody_plan` subscription
- * metadata. `max` is manual-only (never purchasable or Stripe-sourced).
- * Legacy metadata predates the tier rename, so old `partner` maps to new
- * `pro` and old `pro` maps to `standard`. Current `users.stripe_plan` values
- * are parsed without that compatibility mapping.
+ * Parse a plan name that may come from Stripe subscription metadata
+ * (`kody_plan`) or `users.stripe_plan`. `max` is manual-only (never
+ * purchasable or Stripe-sourced); unknown values contribute nothing.
  */
-export function parseStripePlanName(
-	value: unknown,
-	options: { legacyMetadata?: boolean } = {},
-): PlanName | null {
-	const normalizedValue = options.legacyMetadata
-		? value === 'partner'
-			? 'pro'
-			: value === 'pro'
-				? 'standard'
-				: value
-		: value
-	const plan = parsePlanName(normalizedValue)
+export function parseStripePlanName(value: unknown): PlanName | null {
+	const plan = parsePlanName(value)
 	return plan === 'max' ? null : plan
 }
 
@@ -102,7 +89,7 @@ export function getPlanRank(plan: PlanName): number {
  * - Manual arg is a non-null {@link PlanName} (callers resolve stored values
  *   with {@link parseStoredPlanName} first).
  * - Higher-ranked of manual and stripe plans wins (`max` ranks highest).
- * - Unknown/NULL/`max`/residual `'unlimited'` stripe_plan contributes nothing.
+ * - Unknown, NULL, `max`, or retired stripe_plan values contribute nothing.
  */
 export function resolveEffectivePlan(
 	manualPlan: PlanName,
@@ -216,8 +203,6 @@ export const maxPlanEmailLimits = {
 	stored_email_messages: 100_000,
 	email_message_bytes: 768 * 1024,
 } as const satisfies Partial<Record<EntitlementResource, number>>
-
-export type MaxPlanEmailResource = keyof typeof maxPlanEmailLimits
 
 /**
  * Initial limit numbers are conservative placeholders chosen before usage
@@ -336,24 +321,6 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		// 50× pro (40_000) → 2_000_000.
 		maxOutboundFetchesPerDay: 2_000_000,
 	},
-}
-
-export function isMaxPlanEmailResource(
-	resource: EntitlementResource,
-): resource is MaxPlanEmailResource {
-	return resource in maxPlanEmailLimits
-}
-
-/**
- * Resolve the effective limit for an email resource under a plan. The
- * `max` plan uses {@link maxPlanEmailLimits} as its email caps; other plans
- * use their ordinary plan limits.
- */
-export function resolveEmailResourceLimit(
-	plan: PlanName,
-	resource: MaxPlanEmailResource,
-): number {
-	return resolvePlanLimit(plan, resource)
 }
 
 /**

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
@@ -2,10 +2,7 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { emptyCapabilityInputSchema } from '#mcp/capabilities/types.ts'
-import {
-	planNames,
-	resolveEmailResourceLimit,
-} from '#worker/entitlements/plans.ts'
+import { planNames, resolvePlanLimit } from '#worker/entitlements/plans.ts'
 import {
 	getUserPlan,
 	readCurrentEntitlementResourceUsage,
@@ -76,20 +73,17 @@ export const emailUsageGetCapability = defineDomainCapability(
 				day: utcDayKey(now),
 				stored_messages: {
 					count: storedMessages,
-					limit: resolveEmailResourceLimit(plan, 'stored_email_messages'),
+					limit: resolvePlanLimit(plan, 'stored_email_messages'),
 				},
 				sends_today: {
 					count: sendsToday,
-					limit: resolveEmailResourceLimit(plan, 'email_sends_per_day'),
+					limit: resolvePlanLimit(plan, 'email_sends_per_day'),
 				},
 				receives_today: {
 					count: receivesToday,
-					limit: resolveEmailResourceLimit(plan, 'email_receives_per_day'),
+					limit: resolvePlanLimit(plan, 'email_receives_per_day'),
 				},
-				max_message_bytes: resolveEmailResourceLimit(
-					plan,
-					'email_message_bytes',
-				),
+				max_message_bytes: resolvePlanLimit(plan, 'email_message_bytes'),
 			}
 		},
 	},

--- a/tools/ci/reset-migration-bookkeeping.ts
+++ b/tools/ci/reset-migration-bookkeeping.ts
@@ -7,9 +7,12 @@
  * `d1_migrations` bookkeeping table must be rewritten so Wrangler treats the
  * squashed baseline as already applied.
  *
- * Run BEFORE `wrangler d1 migrations apply APP_DB` (preview and production
- * deploy workflows, and local applies via tools/apply-local-app-migrations).
- * Exactly three database states are accepted:
+ * Runs BEFORE `wrangler d1 migrations apply APP_DB` for local applies via
+ * tools/apply-local-app-migrations, so developer state dirs created before
+ * the squash still get their bookkeeping rewritten. The production and
+ * preview databases settled post-squash on 2026-08-05 and their deploy
+ * workflow invocations have been removed. Exactly three database states are
+ * accepted:
  *
  * 1. fresh — no `d1_migrations` table or zero rows: nothing to do; the
  *    regular apply bootstraps the squashed baseline.
@@ -23,8 +26,8 @@
  * is the deterministic "do we still have exactly the migrations we should"
  * check that gates the destructive bookkeeping rewrite.
  *
- * Once production and preview have both settled post-squash, the workflow
- * invocations of this script can be removed.
+ * Once pre-squash local developer state dirs have died out, the local
+ * invocation and this script can be deleted entirely.
  */
 
 import { spawnSync } from 'node:child_process'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes three fallback layers that production evidence shows are dead, plus the stale docs that described them:

1. **Legacy Stripe metadata mapping** (`parseStripePlanName`'s `legacyMetadata` option mapping old `partner`→`pro` / `pro`→`standard`): verified against live Stripe — the account has exactly one active subscription (GratiText, unrelated to Kody) and **zero subscriptions carry `kody_plan` metadata**, so no pre-rename metadata exists anywhere. The metadata fallback itself stays (with current names) for price-id rotation; only the rename-compat mapping is gone.
2. **Migration-bookkeeping guard invocations in CI** (`tools/ci/reset-migration-bookkeeping.ts` calls in `deploy.yml` and `preview.yml`): the tool's own header promised removal "once production and preview have both settled post-squash" — both now classify as post-squash steady state on every run (baseline + migrations 0002/0003). The **local** invocation stays, since developer state dirs created before the 2026-08-04 squash may still need the rewrite; the tool header and `setup.md` now document that remaining role and the final deletion condition.
3. **`resolveEmailResourceLimit` / `isMaxPlanEmailResource` / `MaxPlanEmailResource`**: since the max email caps moved into `planLimits.max` directly, the wrapper was a pure alias of `resolvePlanLimit` and the type guard had no production callers. Call sites in `inbound.ts`, `account-email-data.ts`, and `email-usage-get.ts` now use `resolvePlanLimit`.

Also sweeps stale prose: the "deferred until 0083's residual sweep" follow-up note, `residual 'unlimited'` mentions, and pre-squash migration file references in `entitlements.md` (those files exist only in Git history since the squash).

## Evidence

- Stripe: `listSubscriptions` (live) → 1 active subscription, `metadata: {}`, GratiText price — no Kody subscriptions, no `kody_plan` metadata.
- CI: every deploy/preview run since the guard fix logs the post-squash steady state; production D1 bookkeeping is `{0001-squashed-init, 0002, 0003}`.
- `npm run validate` fully green locally (all 12 jobs).

Net: −57 lines.

## Review feedback disposition

CodeRabbit suggested also updating the header comment inside `packages/worker/migrations/0001-squashed-init.sql` (it still mentions the workflow invocations). Deliberately **not** applied: the migration ledger enforces baseline immutability by content hash (`tools/check-migrations.ts` fails with "Baseline migrations are immutable" on any edit), so the applied file's comment stays as a historical artifact. The living docs (`setup.md`, the tool header) carry the current state.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8a1411c8` · **Head:** `e0f59ace`

**Classification:** composes — deletes dead compatibility paths and rewires call sites to the canonical helper; no behavioral change for any live data shape.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | composes — `parseStripePlanName` simplified; email-limit wrapper removed in favor of `resolvePlanLimit` |
| `billing` | auth | composes — metadata fallback keeps current names only |
| `scheduled-cron` | surfaces | composes — no change to lanes; CI migration steps drop the settled squash guard |

### System map

Email enforcement and billing metadata parsing now call the canonical plan-limit and plan-name helpers directly; CI migration applies run without the settled squash guard.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	email["email<br/>Email"]:::touched
	billing["billing<br/>Stripe billing"]:::touched
	entitlements["entitlements<br/>Plans & entitlements"]:::touched
	email -->|"resolvePlanLimit replaces resolveEmailResourceLimit"| entitlements
	billing -->|"parseStripePlanName without legacy mapping"| entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

## Conductor report

Cleanup pass following the tiers/entitlements program; evidence gathered from live Stripe and CI run history before each removal. One MCP CI job flaked on a miniflare network error and passed on rerun. Status: merged after green CI and review disposition.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ab3dbc-8c01-4a37-8958-a678ae7ef302&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Standardized email usage limits across stored messages, sending, receiving, and message size.
  * Subscription plans now rely on current plan names and pricing identifiers; retired and legacy plan names are no longer recognized.
  * The `unlimited` plan terminology has been removed in favor of finite plan limits and free-plan defaults.

* **Documentation**
  * Updated entitlement, billing, and migration guidance to reflect the current baseline and local development workflow.

* **Chores**
  * Simplified production and preview migration workflows by removing obsolete bookkeeping steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->