### PR TITLE
fix(client): filter Chrome extension IPC Object Not Found Sentry noise (KODY-CLOUDFLARE-3S)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -3,6 +3,7 @@ import {
 	filterBrowserAbortSentryEvent,
 	filterBrowserInjectedGlobalNoiseSentryEvent,
 	filterBrowserSentryEvent,
+	filterChromeExtensionObjectNotFoundSentryEvent,
 	filterFathomRemoveChildNullSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
 } from './sentry-browser-filters.ts'
@@ -199,6 +200,56 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 								},
 							],
 						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	// Chrome extension IPC object-not-found (issue 7655189301 / KODY-CLOUDFLARE-3S).
+	expect(
+		filterChromeExtensionObjectNotFoundSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'UnhandledRejection',
+						value:
+							'Non-Error promise rejection captured with value: Object Not Found Matching Id:3, MethodName:update, ParamCount:4',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterChromeExtensionObjectNotFoundSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'UnhandledRejection', value: 'something else' }],
+				},
+			},
+			'Object Not Found Matching Id:2, MethodName:update, ParamCount:4',
+		),
+	).toBeNull()
+	expect(
+		filterChromeExtensionObjectNotFoundSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'UnhandledRejection',
+						value: 'Object Not Found Matching Id:missing, MethodName:update',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'UnhandledRejection',
+						value:
+							'Non-Error promise rejection captured with value: Object Not Found Matching Id:3, MethodName:update, ParamCount:4',
 					},
 				],
 			},

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -253,6 +253,56 @@ export function filterFathomRemoveChildNullSentryEvent<
 	return event
 }
 
+/**
+ * Chrome extension messaging noise: when an extension calls a Chrome API
+ * (e.g. `tabs.update`) against an object id that no longer exists, Chromium
+ * rejects with this exact IPC wording. The rejected promise is often
+ * unhandled, so Sentry's `onunhandledrejection` handler captures it as a
+ * non-Error rejection on the host page — with no app stack frames.
+ *
+ * Signature from production issue 7655189301 / KODY-CLOUDFLARE-3S (breadcrumb
+ * showed an antifingerprint extension injecting into heykody.dev). Match is
+ * intentionally narrow: only this Chrome "Object Not Found Matching Id…,
+ * MethodName…, ParamCount…" form (optionally wrapped by Sentry's Non-Error
+ * rejection preface). Never blanket-drop UnhandledRejection.
+ */
+const chromeExtensionObjectNotFoundMessage =
+	/(?:^|\b)Object Not Found Matching Id:\d+, MethodName:\w+, ParamCount:\d+\b/
+
+export function isChromeExtensionObjectNotFoundMessage(message: string) {
+	return chromeExtensionObjectNotFoundMessage.test(message.trim())
+}
+
+export function isChromeExtensionObjectNotFoundError(error: unknown) {
+	if (typeof error === 'string') {
+		return isChromeExtensionObjectNotFoundMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isChromeExtensionObjectNotFoundMessage(error.message)
+}
+
+export function isChromeExtensionObjectNotFoundSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isChromeExtensionObjectNotFoundError(originalException)) return true
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isChromeExtensionObjectNotFoundMessage(message),
+	)
+}
+
+export function filterChromeExtensionObjectNotFoundSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isChromeExtensionObjectNotFoundSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -274,6 +324,14 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 		return null
 	}
 	if (filterFathomRemoveChildNullSentryEvent(event) === null) {
+		return null
+	}
+	if (
+		filterChromeExtensionObjectNotFoundSentryEvent(
+			event,
+			originalException,
+		) === null
+	) {
 		return null
 	}
 	return event

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -327,10 +327,8 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 		return null
 	}
 	if (
-		filterChromeExtensionObjectNotFoundSentryEvent(
-			event,
-			originalException,
-		) === null
+		filterChromeExtensionObjectNotFoundSentryEvent(event, originalException) ===
+		null
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -30,10 +30,12 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		replaysOnErrorSampleRate: 1.0,
 		// Drop expected browser noise (AbortError aborts, Firefox DOM
 		// permission-denied from Replay/hydration on restricted nodes,
-		// injected wallet/`__firefox__` globals, and Fathom beacon
-		// removeChild-on-null) — see filterBrowserSentryEvent /
-		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / issues 7639685398,
-		// 7648833360, 7648833403, 7653117289.
+		// injected wallet/`__firefox__` globals, Fathom beacon
+		// removeChild-on-null, and Chrome extension IPC "Object Not Found
+		// Matching Id…") — see filterBrowserSentryEvent /
+		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S /
+		// issues 7639685398, 7648833360, 7648833403, 7653117289,
+		// 7655189301.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry issue [KODY-CLOUDFLARE-3S](https://kent-c-dodds-tech-llc.sentry.io/issues/7655189301/) captures unhandled promise rejections on `https://heykody.dev/` with:

`Object Not Found Matching Id:N, MethodName:update, ParamCount:4`

This is Chromium extension messaging noise (an antifingerprint extension breadcrumb appears on the event). There are no in-app stack frames — the rejected Chrome API promise bubbles to `window.onunhandledrejection` and Sentry's browser SDK reports it as app error.

**Outcome:** `filtered` — add a narrow client `beforeSend` predicate matching only that Chrome IPC signature (same pattern as AbortError / Firefox Xray / injected-global / Fathom filters).

## Changes

- `packages/worker/client/sentry-browser-filters.ts` — `filterChromeExtensionObjectNotFoundSentryEvent`
- Wired into `filterBrowserSentryEvent` + `sentry-init.ts` comment
- Unit tests for positive/negative cases

## Test plan

- [x] Unit tests for the new filter signature
- [x] `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `69f10ac9` · **Head:** `cc2da1b9`

**Classification:** composes — narrow browser Sentry `beforeSend` filter using the existing client noise-filter pattern; no primitive contracts changed.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — drop Chrome extension IPC unhandledrejection noise in client Sentry |

### System map

_Browser SDK `beforeSend` drops Chromium extension "Object Not Found Matching Id…" rejections before they open Sentry issues._

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context.

```mermaid
flowchart LR
  page["heykody.dev page"] --> ext["Browser extension IPC"]
  ext -->|"unhandledrejection"| sdk["@sentry/browser"]
  sdk --> filter["filterBrowserSentryEvent"]
  filter -->|"Chrome Object Not Found match"| drop["drop event"]
  filter -->|"other errors"| sentry["Sentry"]
  style filter fill:#216e4e,color:#fff
  style drop fill:#6b7280,color:#fff
  style ext fill:#6b7280,color:#fff
```

### Risk notes

- Low risk: message-signature filter only; false-positive risk is low because the Chrome IPC wording is highly specific.
- Does not touch auth, isolation, billing, migrations, or DR.

### Review focus

1. Is the regex narrow enough (Id + MethodName + ParamCount required)?
2. Should any sibling UnhandledRejection patterns share this filter later?

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f55e3865-c860-41dd-95ba-c98ae0f3c02d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f55e3865-c860-41dd-95ba-c98ae0f3c02d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced Sentry noise by filtering Chrome extension “Object Not Found Matching Id” errors from browser error reports.
  * Preserved unrelated and incomplete error reports to maintain accurate monitoring and troubleshooting.

* **Documentation**
  * Updated error-filtering documentation to clarify which browser-generated and extension-related noise is excluded from monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->