### PR TITLE
fix(header): stop the closed mobile menu swallowing taps

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -100,3 +100,38 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 		page.getByRole('row', { name: 'Saved packages 25 100 200' }),
 	).toBeVisible()
 })
+
+test.describe('mobile menu', () => {
+	test.use({ viewport: { width: 390, height: 844 } })
+
+	test('closed menu does not intercept taps where it used to be', async ({
+		page,
+	}) => {
+		await page.goto('/')
+
+		const toggle = page.getByRole('button', { name: 'Menu' })
+		const panel = page.locator('#site-menu')
+
+		await toggle.click()
+		await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+		const pricingLink = panel.getByRole('link', { name: 'Pricing' })
+		await expect(pricingLink).toBeVisible()
+		const linkBox = await pricingLink.boundingBox()
+		if (!linkBox) throw new Error('expected the open menu link to have a box')
+
+		await toggle.click()
+		await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+		// Playwright counts `opacity: 0` as visible but `display: none` as not,
+		// so this fails if the closed panel is still an invisible tap target
+		// (regression: the panel kept `display: grid` when closed, and taps in
+		// the area the menu had covered kept landing on its links).
+		await expect(panel).not.toBeVisible()
+
+		// Tap where the Pricing link was; the page underneath must receive it.
+		await page.mouse.click(
+			linkBox.x + linkBox.width / 2,
+			linkBox.y + linkBox.height / 2,
+		)
+		await expect(page).toHaveURL('/')
+	})
+})

--- a/packages/worker/client/site-header.tsx
+++ b/packages/worker/client/site-header.tsx
@@ -378,7 +378,9 @@ const menuPanelCss = {
 	overflowY: 'auto' as const,
 	margin: 0,
 	padding: '0.5rem',
-	display: 'grid',
+	// No base `display`: a closed popover must keep the UA's `display: none`,
+	// or the invisible fixed panel keeps swallowing taps where the menu was.
+	// The `display … allow-discrete` transition holds `grid` through the exit.
 	gap: '0.35rem',
 	border: `1.5px solid ${colors.border}`,
 	borderRadius: '18px',
@@ -391,6 +393,7 @@ const menuPanelCss = {
 	transformOrigin: 'top center',
 	transition: `opacity 180ms ${transitions.easeOut}, translate 180ms ${transitions.easeOut}, scale 180ms ${transitions.easeOut}, display 180ms allow-discrete, overlay 180ms allow-discrete`,
 	'&:popover-open': {
+		display: 'grid',
 		opacity: 1,
 		translate: '0 0',
 		scale: '1',
@@ -414,8 +417,12 @@ const menuPanelCss = {
 		scale: 'none',
 		transition: `opacity 120ms ${transitions.easeOut}, display 120ms allow-discrete, overlay 120ms allow-discrete`,
 	},
-	// Desktop never sees it; the inline nav is the menu there.
-	'@media (min-width: 821px)': { display: 'none' },
+	// Desktop never sees it; the inline nav is the menu there. `:popover-open`
+	// is repeated so this outranks the open state's `display: grid`.
+	'@media (min-width: 821px)': {
+		display: 'none',
+		'&:popover-open': { display: 'none' },
+	},
 }
 
 const menuGroupCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, after opening and closing the header menu, taps in the area the menu had covered still landed on the menu's links — as if the menu were invisibly still there.

## Cause

The redesign's menu panel (`packages/worker/client/site-header.tsx`) set `display: grid` unconditionally on the popover element. Author styles beat the UA stylesheet's `display: none` for closed popovers, so the closed panel remained a `position: fixed`, `opacity: 0` overlay across the top of the page, intercepting every tap in that region.

## Fix

- `display: grid` moved into `&:popover-open`, so the closed panel falls back to the UA's `display: none`. The existing `display 180ms allow-discrete` transition still holds the panel visible through its exit animation, and `@starting-style` keeps the entrance.
- The desktop `@media (min-width: 821px)` guard repeats `&:popover-open` so it continues to outrank the open state's higher-specificity `display: grid`.

## Testing

New regression test in `e2e/smoke.spec.ts` at a 390×844 viewport: open the menu, close it, assert the panel is not visible (Playwright counts `opacity: 0` as visible but `display: none` as not, so this fails exactly when the panel is a ghost tap target), then tap the closed menu's old Pricing-link coordinates and assert the URL is unchanged.

- Verified the test fails against the unfixed header (panel still "visible" when closed) and passes with the fix.
- Full local E2E suite: 8 passed. `format:check`, `lint`, `typecheck` clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ec262ff-a18e-4b37-83bd-e77db0aa8ade?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ec262ff-a18e-4b37-83bd-e77db0aa8ade&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile menu behavior so closed menus are properly hidden and open menus display correctly.
  * Ensured desktop layouts hide the mobile menu, including when it is open.

* **Tests**
  * Added end-to-end coverage for opening and closing the mobile menu, checking its expanded state, and confirming link-area interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->