### PR TITLE
fix(run-log): stop redundant run_log_meta SELECTs (KODY-CLOUDFLARE-3T)

### DIFF
--- a/packages/worker/src/run-records/continuity-and-retention.workers.test.ts
+++ b/packages/worker/src/run-records/continuity-and-retention.workers.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { RunLog } from './run-log-do.ts'
+import { seedRunLogMeta } from './run-log-meta-test-seed.ts'
 import {
 	finishRunRecord,
 	beginRunRecord,
@@ -32,14 +33,11 @@ function silenceExpectedConsoleWarns(substrings: Array<string>) {
 
 async function armRetentionOnNextFinish(userId: string) {
 	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
-	await runInDurableObject(stub, async (instance: RunLog, state) => {
+	await runInDurableObject(stub, async (instance: RunLog) => {
 		expect(instance).toBeInstanceOf(RunLog)
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
-			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			'finishes_since_retention',
-			runRecordRetentionEveryNFinishes - 1,
-		)
+		seedRunLogMeta(instance, {
+			finishesSinceRetention: runRecordRetentionEveryNFinishes - 1,
+		})
 	})
 }
 

--- a/packages/worker/src/run-records/dedicated-state.workers.test.ts
+++ b/packages/worker/src/run-records/dedicated-state.workers.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { RunLog } from './run-log-do.ts'
+import { seedRunLogMeta } from './run-log-meta-test-seed.ts'
 import {
 	beginRunRecord,
 	claimPackageInvocationRecord,
@@ -48,22 +49,12 @@ function silenceExpectedConsoleWarns(substrings: Array<string>) {
 
 async function armRetentionOnNextFinish(userId: string, runCount?: number) {
 	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
-	await runInDurableObject(stub, async (instance: RunLog, state) => {
+	await runInDurableObject(stub, async (instance: RunLog) => {
 		expect(instance).toBeInstanceOf(RunLog)
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
-			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			'finishes_since_retention',
-			runRecordRetentionEveryNFinishes - 1,
-		)
-		if (typeof runCount === 'number') {
-			state.storage.sql.exec(
-				`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
-				ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-				'run_count',
-				runCount,
-			)
-		}
+		seedRunLogMeta(instance, {
+			finishesSinceRetention: runRecordRetentionEveryNFinishes - 1,
+			runCount,
+		})
 	})
 }
 
@@ -852,11 +843,7 @@ test('retention prunes runs but never dedicated workflow/job/activation state', 
 		for (let i = 0; i < 5; i += 1) {
 			insertAgedRun(state, { id: `aged-${i}`, startedAt: agedStartedAt })
 		}
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES ('run_count', ?)
-			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			5,
-		)
+		seedRunLogMeta(instance, { runCount: 5 })
 	})
 	await armRetentionOnNextFinish(userId, 5)
 
@@ -890,7 +877,7 @@ test('retention prunes runs but never dedicated workflow/job/activation state', 
 	])
 
 	// Excess-count prune also leaves dedicated state alone.
-	await runInDurableObject(stub, async (_instance: RunLog, state) => {
+	await runInDurableObject(stub, async (instance: RunLog, state) => {
 		const now = new Date().toISOString()
 		for (let i = 0; i < runRecordMaxRunsPerUser + 10; i += 1) {
 			insertAgedRun(state, {
@@ -898,16 +885,10 @@ test('retention prunes runs but never dedicated workflow/job/activation state', 
 				startedAt: now,
 			})
 		}
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES ('run_count', ?)
-			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			runRecordMaxRunsPerUser + 10,
-		)
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES ('finishes_since_retention', ?)
-			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			runRecordRetentionEveryNFinishes - 1,
-		)
+		seedRunLogMeta(instance, {
+			runCount: runRecordMaxRunsPerUser + 10,
+			finishesSinceRetention: runRecordRetentionEveryNFinishes - 1,
+		})
 	})
 	const excessHandle = beginRunRecord({
 		env,

--- a/packages/worker/src/run-records/invocation-ledger.workers.test.ts
+++ b/packages/worker/src/run-records/invocation-ledger.workers.test.ts
@@ -3,6 +3,7 @@ import { runInDurableObject } from 'cloudflare:test'
 import { expect, test } from 'vitest'
 import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
 import { RunLog } from './run-log-do.ts'
+import { seedRunLogMeta } from './run-log-meta-test-seed.ts'
 import {
 	claimPackageInvocationRecord,
 	clearRunRecords,
@@ -371,13 +372,10 @@ test('DO-local retention prunes terminal ledger rows after 90 days and keeps in-
 	})
 
 	// Arm retention so the next finish runs a full pass.
-	await runInDurableObject(stub, async (_instance: RunLog, state) => {
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
-			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			'finishes_since_retention',
-			runRecordRetentionEveryNFinishes - 1,
-		)
+	await runInDurableObject(stub, async (instance: RunLog) => {
+		seedRunLogMeta(instance, {
+			finishesSinceRetention: runRecordRetentionEveryNFinishes - 1,
+		})
 	})
 	const claimed = await claimPackageInvocationRecord({
 		env,

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -461,6 +461,16 @@ class RunLogBase extends DurableObject<Env> {
 	 * row's due-time instead of trusting a stale idle conclusion.
 	 */
 	private retentionIdleConfirmed = false
+	/**
+	 * In-isolate memo for `run_log_meta` counters. Durable Object handlers are
+	 * single-threaded and these keys are only written through setMeta helpers
+	 * below, so repeated getRunCount / getFinishesSinceRetention in one jsrpc
+	 * (finish → retention → alarm arming) can reuse the loaded value instead of
+	 * re-issuing identical SELECTs (Sentry "Inefficient Database Queries").
+	 * Cleared on schema init / clearAll so SQL rebuild paths reload fresh.
+	 */
+	private runCountCache: number | null = null
+	private finishesSinceRetentionCache: number | null = null
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env)
@@ -475,6 +485,10 @@ class RunLogBase extends DurableObject<Env> {
 	}
 
 	private initializeSchema() {
+		// Schema rebuild (clearAll / DR restore / warm-migration tests) may
+		// rewrite storage under us; drop counter memos so the next read reloads.
+		this.runCountCache = null
+		this.finishesSinceRetentionCache = null
 		this.ctx.storage.sql.exec(`
 			CREATE TABLE IF NOT EXISTS run_log_meta (
 				key TEXT PRIMARY KEY NOT NULL,
@@ -707,10 +721,18 @@ class RunLogBase extends DurableObject<Env> {
 			key,
 			value,
 		)
+		if (key === metaRunCountKey) this.runCountCache = value
+		if (key === metaFinishesSinceRetentionKey) {
+			this.finishesSinceRetentionCache = value
+		}
 	}
 
 	private ensureRunCountMeta() {
-		if (this.getMeta(metaRunCountKey) != null) return
+		const existing = this.getMeta(metaRunCountKey)
+		if (existing != null) {
+			this.runCountCache = existing
+			return
+		}
 		const countRow = this.ctx.storage.sql
 			.exec<{ n: number }>(`SELECT COUNT(*) AS n FROM runs`)
 			.one()
@@ -720,7 +742,10 @@ class RunLogBase extends DurableObject<Env> {
 	}
 
 	private getRunCount() {
-		return this.getMeta(metaRunCountKey) ?? 0
+		if (this.runCountCache == null) {
+			this.runCountCache = this.getMeta(metaRunCountKey) ?? 0
+		}
+		return this.runCountCache
 	}
 
 	private adjustRunCount(delta: number) {
@@ -729,7 +754,11 @@ class RunLogBase extends DurableObject<Env> {
 	}
 
 	private getFinishesSinceRetention() {
-		return this.getMeta(metaFinishesSinceRetentionKey) ?? 0
+		if (this.finishesSinceRetentionCache == null) {
+			this.finishesSinceRetentionCache =
+				this.getMeta(metaFinishesSinceRetentionKey) ?? 0
+		}
+		return this.finishesSinceRetentionCache
 	}
 
 	private setFinishesSinceRetention(value: number) {
@@ -2147,17 +2176,32 @@ class RunLogBase extends DurableObject<Env> {
 			updatedAt,
 			creatingWorkflowProjectionStatus,
 		)
-		const projection = await this.getWorkflowProjection({ id: input.id })
-		if (!projection) {
-			throw new Error(
-				`Workflow projection "${input.id}" disappeared after reservation.`,
-			)
+		// Build from the write inputs — we already SELECT'd this id above and
+		// DO execution is serialized, so a second identical projection SELECT
+		// would only add redundant query spans.
+		const projection: WorkflowProjectionRecord = {
+			id: input.id,
+			bindingName: input.bindingName,
+			sourceType: input.sourceType,
+			packageId: input.packageId ?? null,
+			kodyId: input.kodyId ?? null,
+			sourceId: input.sourceId ?? null,
+			workflowName: input.workflowName,
+			exportName: input.exportName ?? null,
+			idempotencyKey: input.idempotencyKey,
+			runAt: input.runAt,
+			planDate: input.planDate ?? null,
+			status: creatingWorkflowProjectionStatus,
+			createdAt,
+			updatedAt,
+			completedAt: null,
+			lastError: null,
 		}
 		this.retentionIdleConfirmed = false
 		await this.ensureRetentionAlarm()
 		return {
 			countBeforeReservation,
-			reserved: projection.status === creatingWorkflowProjectionStatus,
+			reserved: true,
 			inserted,
 			projection,
 		}
@@ -2166,14 +2210,13 @@ class RunLogBase extends DurableObject<Env> {
 	async deleteWorkflowProjectionIfCreating(input: {
 		id: string
 	}): Promise<{ deleted: boolean }> {
-		this.ctx.storage.sql.exec(
+		const deleted = this.ctx.storage.sql.exec(
 			`DELETE FROM workflow_projections
 			WHERE id = ? AND COALESCE(status, '') = ?`,
 			input.id,
 			creatingWorkflowProjectionStatus,
-		)
-		const remaining = await this.getWorkflowProjection({ id: input.id })
-		return { deleted: remaining === null }
+		).rowsWritten
+		return { deleted: deleted > 0 }
 	}
 
 	async upsertJobRunObservability(
@@ -2869,6 +2912,8 @@ class RunLogBase extends DurableObject<Env> {
 		await this.ctx.storage.deleteAll()
 		this.retentionAlarmArmed = false
 		this.retentionIdleConfirmed = true
+		this.runCountCache = null
+		this.finishesSinceRetentionCache = null
 		this.initializeSchema()
 		this.setMeta(metaRunCountKey, 0)
 		this.setMeta(metaFinishesSinceRetentionKey, 0)

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -727,6 +727,22 @@ class RunLogBase extends DurableObject<Env> {
 		}
 	}
 
+	/**
+	 * `setMeta` updates counter memos eagerly so hot paths skip re-SELECTs.
+	 * When those writes run inside `transactionSync`, a later failure rolls
+	 * SQL back but would leave the memos ahead of storage — drop them before
+	 * rethrowing so the next read reloads.
+	 */
+	private transactionSyncWithMetaCache<T>(fn: () => T): T {
+		try {
+			return this.ctx.storage.transactionSync(fn)
+		} catch (error) {
+			this.runCountCache = null
+			this.finishesSinceRetentionCache = null
+			throw error
+		}
+	}
+
 	private ensureRunCountMeta() {
 		const existing = this.getMeta(metaRunCountKey)
 		if (existing != null) {
@@ -1660,7 +1676,7 @@ class RunLogBase extends DurableObject<Env> {
 		// One transaction for run upsert + logs + job observability + activation
 		// so a mid-unit SQL failure cannot leave a terminal run that suppresses
 		// missing derived side effects. Alarm / async retention stay outside.
-		this.ctx.storage.transactionSync(() => {
+		this.transactionSyncWithMetaCache(() => {
 			this.upsertRun(input.run, 'replace')
 			this.replaceLogs(input.run.id, input.logs)
 			if (!existed) {
@@ -1818,7 +1834,7 @@ class RunLogBase extends DurableObject<Env> {
 		// Alarm scheduling stays outside.
 		let ledgerUpdated = false
 		let current: PackageInvocationLedgerRecord | null = null
-		this.ctx.storage.transactionSync(() => {
+		this.transactionSyncWithMetaCache(() => {
 			current = this.getInvocationLedgerRowById(input.invocationId)
 			ledgerUpdated =
 				current != null &&
@@ -2176,32 +2192,20 @@ class RunLogBase extends DurableObject<Env> {
 			updatedAt,
 			creatingWorkflowProjectionStatus,
 		)
-		// Build from the write inputs — we already SELECT'd this id above and
-		// DO execution is serialized, so a second identical projection SELECT
-		// would only add redundant query spans.
-		const projection: WorkflowProjectionRecord = {
-			id: input.id,
-			bindingName: input.bindingName,
-			sourceType: input.sourceType,
-			packageId: input.packageId ?? null,
-			kodyId: input.kodyId ?? null,
-			sourceId: input.sourceId ?? null,
-			workflowName: input.workflowName,
-			exportName: input.exportName ?? null,
-			idempotencyKey: input.idempotencyKey,
-			runAt: input.runAt,
-			planDate: input.planDate ?? null,
-			status: creatingWorkflowProjectionStatus,
-			createdAt,
-			updatedAt,
-			completedAt: null,
-			lastError: null,
+		// Re-read: ON CONFLICT may no-op when status is not `creating` (e.g.
+		// null), and for existing creating rows only `updated_at` changes —
+		// so the persisted row is the source of truth, not `input`.
+		const projection = await this.getWorkflowProjection({ id: input.id })
+		if (!projection) {
+			throw new Error(
+				`Workflow projection "${input.id}" disappeared after reservation.`,
+			)
 		}
 		this.retentionIdleConfirmed = false
 		await this.ensureRetentionAlarm()
 		return {
 			countBeforeReservation,
-			reserved: true,
+			reserved: projection.status === creatingWorkflowProjectionStatus,
 			inserted,
 			projection,
 		}

--- a/packages/worker/src/run-records/run-log-meta-test-seed.ts
+++ b/packages/worker/src/run-records/run-log-meta-test-seed.ts
@@ -1,0 +1,25 @@
+import type { RunLog } from './run-log-do.ts'
+
+type RunLogMetaMutator = {
+	setMeta(key: string, value: number): void
+}
+
+/**
+ * Seed `run_log_meta` through the DO write path so in-isolate counter caches
+ * stay coherent. Raw SQL inserts bypass `setMeta` and leave stale memos.
+ */
+export function seedRunLogMeta(
+	instance: RunLog,
+	input: {
+		finishesSinceRetention?: number
+		runCount?: number
+	},
+) {
+	const meta = instance as unknown as RunLogMetaMutator
+	if (typeof input.finishesSinceRetention === 'number') {
+		meta.setMeta('finishes_since_retention', input.finishesSinceRetention)
+	}
+	if (typeof input.runCount === 'number') {
+		meta.setMeta('run_count', input.runCount)
+	}
+}

--- a/packages/worker/src/run-records/run-log-meta-test-seed.ts
+++ b/packages/worker/src/run-records/run-log-meta-test-seed.ts
@@ -1,5 +1,3 @@
-import type { RunLog } from './run-log-do.ts'
-
 type RunLogMetaMutator = {
 	setMeta(key: string, value: number): void
 }
@@ -9,13 +7,13 @@ type RunLogMetaMutator = {
  * stay coherent. Raw SQL inserts bypass `setMeta` and leave stale memos.
  */
 export function seedRunLogMeta(
-	instance: RunLog,
+	instance: object,
 	input: {
 		finishesSinceRetention?: number
 		runCount?: number
 	},
 ) {
-	const meta = instance as unknown as RunLogMetaMutator
+	const meta = instance as RunLogMetaMutator
 	if (typeof input.finishesSinceRetention === 'number') {
 		meta.setMeta('finishes_since_retention', input.finishesSinceRetention)
 	}

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -967,6 +967,64 @@ test('run_log_meta counters reuse the in-isolate cache across repeated reads', a
 					.toArray()[0]?.value,
 			),
 		).toBe(4)
+
+		// Rolled-back setMeta must not leave the memo ahead of SQL.
+		const metaTx = instance as unknown as {
+			transactionSyncWithMetaCache: <T>(fn: () => T) => T
+			setMeta: (key: string, value: number) => void
+		}
+		expect(() =>
+			metaTx.transactionSyncWithMetaCache(() => {
+				metaTx.setMeta('run_count', 99)
+				throw new Error('force-rollback')
+			}),
+		).toThrow('force-rollback')
+		expect(
+			Number(
+				state.storage.sql
+					.exec<{ value: number }>(
+						`SELECT value FROM run_log_meta WHERE key = 'run_count' LIMIT 1`,
+					)
+					.toArray()[0]?.value,
+			),
+		).toBe(10)
+
+		await instance.startRun({
+			run: {
+				id: 'meta-cache-after-rollback',
+				surface: 'job',
+				status: 'running',
+				name: 'meta-rollback',
+				packageId: null,
+				kodyId: null,
+				sourceId: null,
+				publishedCommit: null,
+				storageId: null,
+				jobId: null,
+				workflowId: null,
+				invocationId: null,
+				sessionId: null,
+				idempotencyKey: null,
+				parentRunId: null,
+				startedAt: new Date().toISOString(),
+				finishedAt: null,
+				durationMs: null,
+				errorName: null,
+				errorMessage: null,
+				metadataJson: '{}',
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		})
+		expect(
+			Number(
+				state.storage.sql
+					.exec<{ value: number }>(
+						`SELECT value FROM run_log_meta WHERE key = 'run_count' LIMIT 1`,
+					)
+					.toArray()[0]?.value,
+			),
+		).toBe(11)
 	})
 })
 

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -7,6 +7,7 @@ import { buildKodyModuleBundle } from '#worker/package-runtime/module-graph.ts'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
 import { RunLog } from './run-log-do.ts'
+import { seedRunLogMeta } from './run-log-meta-test-seed.ts'
 import {
 	abandonRunRecord,
 	beginRunRecord,
@@ -53,22 +54,12 @@ async function drainWaitUntil(pending: Array<Promise<unknown>>) {
 
 async function armRetentionOnNextFinish(userId: string, runCount?: number) {
 	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
-	await runInDurableObject(stub, async (instance: RunLog, state) => {
+	await runInDurableObject(stub, async (instance: RunLog) => {
 		expect(instance).toBeInstanceOf(RunLog)
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
-			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			'finishes_since_retention',
-			runRecordRetentionEveryNFinishes - 1,
-		)
-		if (typeof runCount === 'number') {
-			state.storage.sql.exec(
-				`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
-				ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-				'run_count',
-				runCount,
-			)
-		}
+		seedRunLogMeta(instance, {
+			finishesSinceRetention: runRecordRetentionEveryNFinishes - 1,
+			runCount,
+		})
 	})
 }
 
@@ -797,12 +788,7 @@ test('alarm lifecycle: fresh arm, self-termination when idle, re-arm after idle,
 			expiredStartedAt,
 			'first-run',
 		)
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
-				ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			'finishes_since_retention',
-			0,
-		)
+		seedRunLogMeta(instance, { finishesSinceRetention: 0 })
 		await state.storage.deleteAlarm()
 		await instance.alarm()
 	})
@@ -847,12 +833,7 @@ test('alarm lifecycle: fresh arm, self-termination when idle, re-arm after idle,
 			expiredStartedAt,
 			runId,
 		)
-		state.storage.sql.exec(
-			`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
-				ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-			'finishes_since_retention',
-			0,
-		)
+		seedRunLogMeta(instance, { finishesSinceRetention: 0 })
 		await state.storage.deleteAlarm()
 		await instance.alarm()
 	})
@@ -900,6 +881,93 @@ test('run recording degrades to a warning instead of failing the observed run', 
 	const page = await listRunRecords({ env, userId })
 	expect(page.runs).toHaveLength(1)
 	expect(page.runs[0]?.status).toBe('success')
+})
+
+test('run_log_meta counters reuse the in-isolate cache across repeated reads', async () => {
+	const userId = uniqueUserId('meta-cache')
+	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
+
+	// Two finishes → run_count memo should be 2 after the second write path.
+	for (const label of ['a', 'b'] as const) {
+		const handle = beginRunRecord({
+			env,
+			userId,
+			context: baseContext({ surface: 'job', name: `meta-${label}` }),
+		})
+		await finishRunRecord({ env, handle, status: 'success' })
+	}
+
+	await runInDurableObject(stub, async (instance: RunLog, state) => {
+		expect(instance).toBeInstanceOf(RunLog)
+		const before = state.storage.sql
+			.exec<{ value: number }>(
+				`SELECT value FROM run_log_meta WHERE key = 'run_count' LIMIT 1`,
+			)
+			.toArray()[0]
+		expect(Number(before?.value)).toBe(2)
+
+		// Corrupt storage under the memo. The next adjust must use the cached
+		// 2 (+1 → 3), not the corrupted SQL value.
+		state.storage.sql.exec(
+			`UPDATE run_log_meta SET value = 999999 WHERE key = 'run_count'`,
+		)
+
+		await instance.startRun({
+			run: {
+				id: 'meta-cache-third',
+				surface: 'job',
+				status: 'running',
+				name: 'meta-c',
+				packageId: null,
+				kodyId: null,
+				sourceId: null,
+				publishedCommit: null,
+				storageId: null,
+				jobId: null,
+				workflowId: null,
+				invocationId: null,
+				sessionId: null,
+				idempotencyKey: null,
+				parentRunId: null,
+				startedAt: new Date().toISOString(),
+				finishedAt: null,
+				durationMs: null,
+				errorName: null,
+				errorMessage: null,
+				metadataJson: '{}',
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		})
+
+		const after = state.storage.sql
+			.exec<{ value: number }>(
+				`SELECT value FROM run_log_meta WHERE key = 'run_count' LIMIT 1`,
+			)
+			.toArray()[0]
+		expect(Number(after?.value)).toBe(3)
+
+		// Seeds go through setMeta so the memo and SQL stay aligned.
+		seedRunLogMeta(instance, { runCount: 10, finishesSinceRetention: 4 })
+		expect(
+			Number(
+				state.storage.sql
+					.exec<{ value: number }>(
+						`SELECT value FROM run_log_meta WHERE key = 'run_count' LIMIT 1`,
+					)
+					.toArray()[0]?.value,
+			),
+		).toBe(10)
+		expect(
+			Number(
+				state.storage.sql
+					.exec<{ value: number }>(
+						`SELECT value FROM run_log_meta WHERE key = 'finishes_since_retention' LIMIT 1`,
+					)
+					.toArray()[0]?.value,
+			),
+		).toBe(4)
+	})
 })
 
 test('clearRunRecords empties the Durable Object', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fix Sentry performance issue [KODY-CLOUDFLARE-3T](https://kent-c-dodds-tech-llc.sentry.io/issues/7656668804/) ("Inefficient Database Queries" on `jsrpc`): repeated identical `SELECT value FROM run_log_meta WHERE key = ?` within a single RunLog Durable Object call.

## Summary

- Memoize hot `run_log_meta` counters (`run_count`, `finishes_since_retention`) in-isolate on the RunLog DO. Handlers are single-threaded and these keys are only written through `setMeta`, so finish → retention → alarm-arming can reuse loaded values instead of re-querying.
- Clear those memos when a `transactionSync` that may have called `setMeta` rolls back (`transactionSyncWithMetaCache`).
- Use `rowsWritten` for `deleteWorkflowProjectionIfCreating` (no follow-up SELECT).
- Test seeds write meta through `seedRunLogMeta` / `setMeta`; workers test covers memo reuse and rollback invalidation.

Seer pointed at `kentcdodds/kentcdodds.com`; the real culprit is `packages/worker/src/run-records/run-log-do.ts` in this repo.

## Testing

- `npm run test:workers` on run-records suites: passed (including new meta-cache + rollback cases).
- Local `npm run validate` passed after the typecheck fix.
- Prior CI Node/E2E failures were GitHub Actions "Service Unavailable" downloading actions — unrelated to this diff; re-running on latest push.

## Risk / merge

**extends / medium** — RunLog DO counter bookkeeping on per-user durable storage. Clear root cause and tests; leaving open for review rather than autonomous merge.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `34614dc1` · **Head:** `bc3b4e33`

**Classification:** extends — RunLog in-isolate meta counter memoization with transaction-safe invalidation; no new primitives.

### Primitives touched

| Primitive     | Group   | Impact                                                                 |
| ------------- | ------- | ---------------------------------------------------------------------- |
| `run-records` | storage | extends — cache `run_log_meta` counters; invalidate on tx rollback |

### System map

Hot finish/retention paths re-read the same `run_log_meta` keys; this PR memos them inside the RunLog DO and drops the memo if a storage transaction rolls back.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	jsrpc["jsrpc<br/>DO RPC entry"]:::untouched
	runRecords["run-records<br/>Run records"]:::extended
	jsrpc -->|"finishRun / ensureRetentionAlarm"| runRecords
	runRecords -->|"memoized run_log_meta; clear on tx rollback"| runRecords
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Caller as Worker / jsrpc
	participant RunLog as RunLog DO
	participant Meta as run_log_meta SQL
	Caller->>RunLog: finishRun
	RunLog->>Meta: SELECT/UPDATE via setMeta (cache updated)
	alt transaction rolls back
		RunLog->>RunLog: clear runCount/finishes caches
	else commit
		RunLog->>RunLog: reuse caches in retention/alarm paths
	end
```

### Invariants

Per-user RunLog isolation unchanged: cache is isolate-local to the DO that owns the user's storage; no cross-user reads.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eedc93fb-d756-4802-b43e-d4cad7552746?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedc93fb-d756-4802-b43e-d4cad7552746&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved run-log metadata access by caching retention and run-count values.
  * Reduced unnecessary storage reads during workflow projection operations.

* **Reliability**
  * Kept metadata caches synchronized when values are updated, cleared, or transactions fail.
  * Improved consistency when removing workflow projections.

* **Tests**
  * Added coverage verifying cached counters remain consistent and resilient to direct storage changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->