### PR TITLE
feat(runs): ignore/resolve retained run errors

### DIFF
--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -363,10 +363,10 @@ rows may also carry soft triage (`error_triage`: `ignored` | `resolved`, plus
 optional `triage_note`, `triaged_at`, `triaged_by`). Triage is non-destructive:
 error name/message/logs stay put; Activity and `run_list` default to
 `error_triage=open` so handled noise drops out of the default view;
-`run_summary.errors` counts only open errors and exposes separate
-`ignored` / `resolved` totals. Terminal `finishRun` upserts preserve triage on
-error finishes and clear it if a row somehow finishes non-error. Schema version
-10 on the RunLog DO.
+`run_summary.errors` counts only open errors and exposes separate `ignored` /
+`resolved` totals. Terminal `finishRun` upserts preserve triage on error
+finishes and clear it if a row somehow finishes non-error. Schema version 10 on
+the RunLog DO.
 
 ## Reading the data
 

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -15,8 +15,9 @@ last-run error, duration, or counters). Those neighbors are covered in
 
 A run record is one execution attempt on a named **surface**: status (`running`
 / `success` / `error`), optional package/job/workflow identifiers, start and
-finish timestamps, duration, truncated error fields, JSON metadata, and up to
-200 captured log lines.
+finish timestamps, duration, truncated error fields, optional soft error triage
+(`error_triage`: `ignored` / `resolved`, plus note / who / when — separate from
+execution status), JSON metadata, and up to 200 captured log lines.
 
 Package ownership is optional. Ad-hoc MCP `execute`, standalone `kody.json`
 jobs, and inline workflows have no `package_id`; the record still lands under
@@ -24,9 +25,9 @@ the signed-in user. That optionality is why run records are not shaped as
 package-scoped debug rows.
 
 Code lives in `packages/worker/src/run-records/` (types, worker service, and the
-`RunLog` Durable Object). MCP read capabilities live under
-`packages/worker/src/mcp/capabilities/runs/`. The account UI is
-`/account/activity`.
+`RunLog` Durable Object). MCP capabilities live under
+`packages/worker/src/mcp/capabilities/runs/` (list/get/summary plus soft triage
+via `run_update`). The account UI is `/account/activity`.
 
 ## Surfaces
 
@@ -355,11 +356,24 @@ retention anchors only. Package services heartbeat `package_service_states`.
 History browsers (`/account/activity`, `run_list` / `run_get` / `run_summary`)
 read `RunLog`.
 
+## Soft error triage
+
+Execution `status` stays `running` / `success` / `error`. Retained **error**
+rows may also carry soft triage (`error_triage`: `ignored` | `resolved`, plus
+optional `triage_note`, `triaged_at`, `triaged_by`). Triage is non-destructive:
+error name/message/logs stay put; Activity and `run_list` default to
+`error_triage=open` so handled noise drops out of the default view;
+`run_summary.errors` counts only open errors and exposes separate
+`ignored` / `resolved` totals. Terminal `finishRun` upserts preserve triage on
+error finishes and clear it if a row somehow finishes non-error. Schema version
+10 on the RunLog DO.
+
 ## Reading the data
 
-- UI: `/account/activity` (failures-first by default; filters, 7-day summary,
-  log viewer, cursor pagination). `/account/jobs` recent runs link into it.
-- MCP domain `runs`: `run_list`, `run_get`, `run_summary`.
+- UI: `/account/activity` (open failures first by default; status / triage /
+  surface filters, 7-day summary with ignored/resolved counts, log viewer,
+  cursor pagination). `/account/jobs` recent runs link into it.
+- MCP domain `runs`: `run_list`, `run_get`, `run_summary`, `run_update`.
 - Account export: section `run_records` pages through the user’s `RunLog`.
 - Account deletion: `clearAll` on the user’s `RunLog` stub (deletes every DO
   table — runs, ledger, and dedicated state — then reinitializes schema).

--- a/docs/use/activity.md
+++ b/docs/use/activity.md
@@ -27,8 +27,8 @@ The MCP **`runs`** domain reads and triages the same data:
 
 - **`run_summary`** — “is anything broken?” open-error totals (plus ignored /
   resolved counts) and per-surface breakdown
-- **`run_list`** — filtered history (by surface, status, job, package, time,
-  and `error_triage`; defaults to **open**, hiding ignored/resolved)
+- **`run_list`** — filtered history (by surface, status, job, package, time, and
+  `error_triage`; defaults to **open**, hiding ignored/resolved)
 - **`run_get`** — one run plus its log lines and triage fields
 - **`run_update`** — mark a retained **error** run as `ignored` or `resolved`
   (or `open` to clear triage), with an optional note — non-destructive soft

--- a/docs/use/activity.md
+++ b/docs/use/activity.md
@@ -6,28 +6,36 @@ agent) can see what happened.
 
 ## Where to look
 
-Open **`/account/activity`** while signed in. The page defaults to **failures
-first**, with:
+Open **`/account/activity`** while signed in. The page defaults to **open
+failures first**, with:
 
-- a short summary of recent totals and errors
-- filters by status and runtime surface (jobs, webhooks, package apps, services,
-  workflows, and others)
-- a detail view with captured log lines
+- a short summary of recent totals, open errors, and ignored/resolved counts
+- filters by status, triage (open / ignored / resolved / all), and runtime
+  surface (jobs, webhooks, package apps, services, workflows, and others)
+- a detail view with captured log lines and any triage note
 - cursor pagination for older pages
+
+Ignored and resolved error runs stay in history but are hidden from the default
+view so soft-failures and already-fixed noise do not clutter Activity.
 
 From **`/account/jobs`**, each job’s recent runs link into the same Activity
 detail view.
 
 ## Ask your agent
 
-The MCP **`runs`** domain reads the same data:
+The MCP **`runs`** domain reads and triages the same data:
 
-- **`run_summary`** — “is anything broken?” totals and per-surface breakdown
-- **`run_list`** — filtered history (by surface, status, job, package, time)
-- **`run_get`** — one run plus its log lines
+- **`run_summary`** — “is anything broken?” open-error totals (plus ignored /
+  resolved counts) and per-surface breakdown
+- **`run_list`** — filtered history (by surface, status, job, package, time,
+  and `error_triage`; defaults to **open**, hiding ignored/resolved)
+- **`run_get`** — one run plus its log lines and triage fields
+- **`run_update`** — mark a retained **error** run as `ignored` or `resolved`
+  (or `open` to clear triage), with an optional note — non-destructive soft
+  triage; error details stay intact
 
-Search for “runs”, “failures”, or “why did my job stop working” if your host
-does not surface those names yet.
+Search for “runs”, “failures”, “ignore this error”, or “why did my job stop
+working” if your host does not surface those names yet.
 
 ## What is retained
 

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -473,9 +473,7 @@ export function AccountActivityRoute(handle: Handle) {
 								{ label: 'Open errors', value: String(readySummary.errors) },
 								{
 									label: 'Ignored / resolved',
-									value: String(
-										readySummary.ignored + readySummary.resolved,
-									),
+									value: String(readySummary.ignored + readySummary.resolved),
 								},
 								{ label: 'Running now', value: String(readySummary.running) },
 							].map((item) => (
@@ -503,8 +501,7 @@ export function AccountActivityRoute(handle: Handle) {
 											fontSize: typography.fontSize.xl,
 											fontWeight: typography.fontWeight.semibold,
 											color:
-												item.label === 'Open errors' &&
-												readySummary.errors > 0
+												item.label === 'Open errors' && readySummary.errors > 0
 													? colors.error
 													: colors.text,
 										})}

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -175,8 +175,11 @@ function readTriageFilter(href: string): AccountActivityTriageFilter {
 	return match?.value ?? 'open'
 }
 
-function triageLabel(triage: AccountActivityRunListItem['errorTriage']) {
-	switch (triage) {
+function triageLabel(
+	run: Pick<AccountActivityRunListItem, 'status' | 'errorTriage'>,
+) {
+	if (run.status !== 'error') return '—'
+	switch (run.errorTriage) {
 		case 'ignored':
 			return 'Ignored'
 		case 'resolved':
@@ -184,7 +187,7 @@ function triageLabel(triage: AccountActivityRunListItem['errorTriage']) {
 		case null:
 			return 'Open'
 		default: {
-			const exhaustive: never = triage
+			const exhaustive: never = run.errorTriage
 			return exhaustive
 		}
 	}
@@ -757,7 +760,7 @@ export function AccountActivityRoute(handle: Handle) {
 											},
 											{
 												label: 'Triage',
-												value: triageLabel(detail.errorTriage),
+												value: triageLabel(detail),
 											},
 											{
 												label: 'Triage note',
@@ -768,6 +771,10 @@ export function AccountActivityRoute(handle: Handle) {
 												value: detail.triagedAt
 													? formatTimestamp(detail.triagedAt)
 													: '—',
+											},
+											{
+												label: 'Triaged by',
+												value: detail.triagedBy ?? '—',
 											},
 											{
 												label: 'Surface',

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -32,6 +32,7 @@ import {
 	type AccountActivityStatusFilter,
 	type AccountActivitySurfaceFilter,
 	type AccountActivitySummary,
+	type AccountActivityTriageFilter,
 } from '#app/loader-data.ts'
 import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import {
@@ -56,6 +57,16 @@ const statusFilterOptions: Array<{
 	{ value: 'error', label: 'Errors' },
 	{ value: 'all', label: 'All' },
 	{ value: 'running', label: 'Running' },
+]
+
+const triageFilterOptions: Array<{
+	value: AccountActivityTriageFilter
+	label: string
+}> = [
+	{ value: 'open', label: 'Open' },
+	{ value: 'ignored', label: 'Ignored' },
+	{ value: 'resolved', label: 'Resolved' },
+	{ value: 'all', label: 'All triage' },
 ]
 
 const surfaceFilterOptions: Array<{
@@ -156,13 +167,38 @@ function readSurfaceFilter(href: string): AccountActivitySurfaceFilter {
 	return match?.value ?? 'all'
 }
 
+function readTriageFilter(href: string): AccountActivityTriageFilter {
+	const params = new URL(href, 'http://localhost').searchParams
+	const value =
+		params.get('error_triage')?.trim() ?? params.get('triage')?.trim()
+	const match = triageFilterOptions.find((option) => option.value === value)
+	return match?.value ?? 'open'
+}
+
+function triageLabel(triage: AccountActivityRunListItem['errorTriage']) {
+	switch (triage) {
+		case 'ignored':
+			return 'Ignored'
+		case 'resolved':
+			return 'Resolved'
+		case null:
+			return 'Open'
+		default: {
+			const exhaustive: never = triage
+			return exhaustive
+		}
+	}
+}
+
 function buildActivitySearch(input: {
 	status: AccountActivityStatusFilter
 	surface: AccountActivitySurfaceFilter
+	triage: AccountActivityTriageFilter
 }) {
 	const params = new URLSearchParams()
 	if (input.status !== 'error') params.set('status', input.status)
 	if (input.surface !== 'all') params.set('surface', input.surface)
+	if (input.triage !== 'open') params.set('error_triage', input.triage)
 	const search = params.toString()
 	return search ? `?${search}` : ''
 }
@@ -171,7 +207,8 @@ function getDataLatchKey(href: string) {
 	const selection = activityRoute.getSelection(href)
 	const status = readStatusFilter(href)
 	const surface = readSurfaceFilter(href)
-	const filterKey = `${status}:${surface}`
+	const triage = readTriageFilter(href)
+	const filterKey = `${status}:${surface}:${triage}`
 	return selection.selectedId
 		? `/account/activity/${encodeURIComponent(selection.selectedId)}?${filterKey}`
 		: `/account/activity?${filterKey}`
@@ -181,9 +218,11 @@ function buildActivityApiRequestUrl(href: string, cursor?: string | null) {
 	const requestUrl = new URL(accountActivityApiPath, 'http://localhost')
 	const status = readStatusFilter(href)
 	const surface = readSurfaceFilter(href)
+	const triage = readTriageFilter(href)
 	if (status !== 'error') requestUrl.searchParams.set('status', status)
 	else requestUrl.searchParams.set('status', 'error')
 	if (surface !== 'all') requestUrl.searchParams.set('surface', surface)
+	if (triage !== 'open') requestUrl.searchParams.set('error_triage', triage)
 	const selectedRunId = activityRoute.getSelection(href).selectedId
 	if (selectedRunId) {
 		requestUrl.searchParams.set('selected', selectedRunId)
@@ -337,12 +376,14 @@ export function AccountActivityRoute(handle: Handle) {
 	function updateFilters(input: {
 		status?: AccountActivityStatusFilter
 		surface?: AccountActivitySurfaceFilter
+		triage?: AccountActivityTriageFilter
 	}) {
 		const href = getCurrentHref()
 		const selection = activityRoute.getSelection(href)
 		const search = buildActivitySearch({
 			status: input.status ?? readStatusFilter(href),
 			surface: input.surface ?? readSurfaceFilter(href),
+			triage: input.triage ?? readTriageFilter(href),
 		})
 		if (selection.selectedId) {
 			navigate(activityRoute.buildDetailHref(selection.selectedId, search))
@@ -370,9 +411,11 @@ export function AccountActivityRoute(handle: Handle) {
 		const selection = activityRoute.getSelection(currentHref)
 		const statusFilter = readStatusFilter(currentHref)
 		const surfaceFilter = readSurfaceFilter(currentHref)
+		const triageFilter = readTriageFilter(currentHref)
 		const filterSearch = buildActivitySearch({
 			status: statusFilter,
 			surface: surfaceFilter,
+			triage: triageFilter,
 		})
 		const detail =
 			selectedRun && selectedRun.id === selection.selectedId
@@ -390,7 +433,10 @@ export function AccountActivityRoute(handle: Handle) {
 			!waitingForDetail &&
 			status === 'ready'
 		const emptyBecauseErrors =
-			statusFilter === 'error' && surfaceFilter === 'all' && runs.length === 0
+			statusFilter === 'error' &&
+			surfaceFilter === 'all' &&
+			triageFilter === 'open' &&
+			runs.length === 0
 		const emptyBecauseFilters = runs.length === 0 && !emptyBecauseErrors
 		const readySummary = status === 'ready' ? summary : null
 
@@ -424,7 +470,13 @@ export function AccountActivityRoute(handle: Handle) {
 						>
 							{[
 								{ label: 'Runs (7 days)', value: String(readySummary.total) },
-								{ label: 'Errors', value: String(readySummary.errors) },
+								{ label: 'Open errors', value: String(readySummary.errors) },
+								{
+									label: 'Ignored / resolved',
+									value: String(
+										readySummary.ignored + readySummary.resolved,
+									),
+								},
 								{ label: 'Running now', value: String(readySummary.running) },
 							].map((item) => (
 								<div
@@ -451,7 +503,8 @@ export function AccountActivityRoute(handle: Handle) {
 											fontSize: typography.fontSize.xl,
 											fontWeight: typography.fontWeight.semibold,
 											color:
-												item.label === 'Errors' && readySummary.errors > 0
+												item.label === 'Open errors' &&
+												readySummary.errors > 0
 													? colors.error
 													: colors.text,
 										})}
@@ -478,7 +531,7 @@ export function AccountActivityRoute(handle: Handle) {
 							sidebar={
 								<AccountManagementSidebar
 									title="Runs"
-									description="Default view shows errors. Change filters to browse all recorded runs."
+									description="Default view shows open errors. Ignored/resolved noise is hidden until you change triage."
 								>
 									<div
 										mix={css({
@@ -538,6 +591,35 @@ export function AccountActivityRoute(handle: Handle) {
 												]}
 											>
 												{surfaceFilterOptions.map((option) => (
+													<option key={option.value} value={option.value}>
+														{option.label}
+													</option>
+												))}
+											</select>
+										</label>
+										<label mix={[css(fieldCss), css({ gridColumn: '1 / -1' })]}>
+											<span mix={css(fieldLabelCss)}>Triage</span>
+											<select
+												data-field-ring
+												aria-label="Triage filter"
+												value={triageFilter}
+												mix={[
+													on('change', (event) => {
+														const value = event.currentTarget
+															.value as AccountActivityTriageFilter
+														if (
+															!triageFilterOptions.some(
+																(option) => option.value === value,
+															)
+														) {
+															return
+														}
+														updateFilters({ triage: value })
+													}),
+													css(selectCss),
+												]}
+											>
+												{triageFilterOptions.map((option) => (
 													<option key={option.value} value={option.value}>
 														{option.label}
 													</option>
@@ -675,6 +757,20 @@ export function AccountActivityRoute(handle: Handle) {
 														{statusLabel(detail.status)}
 													</span>
 												),
+											},
+											{
+												label: 'Triage',
+												value: triageLabel(detail.errorTriage),
+											},
+											{
+												label: 'Triage note',
+												value: detail.triageNote ?? '—',
+											},
+											{
+												label: 'Triaged at',
+												value: detail.triagedAt
+													? formatTimestamp(detail.triagedAt)
+													: '—',
 											},
 											{
 												label: 'Surface',

--- a/packages/worker/src/account/export.node.test.ts
+++ b/packages/worker/src/account/export.node.test.ts
@@ -1564,6 +1564,8 @@ test('account export includes run_records section with runs, ledger, and dedicat
 					since: '1970-01-01T00:00:00.000Z',
 					total: 1,
 					errors: 0,
+					ignored: 0,
+					resolved: 0,
 					running: 0,
 					bySurface: [],
 				}),

--- a/packages/worker/src/app/account-activity-data.node.test.ts
+++ b/packages/worker/src/app/account-activity-data.node.test.ts
@@ -59,6 +59,10 @@ function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
 		durationMs: 1000,
 		errorName: 'Error',
 		errorMessage: 'boom',
+		errorTriage: null,
+		triageNote: null,
+		triagedAt: null,
+		triagedBy: null,
 		metadata: {},
 		logCount: 2,
 		...overrides,
@@ -71,15 +75,17 @@ test('activity helpers parse filters and prefer path selected run ids', () => {
 	).toEqual({
 		statusFilter: 'error',
 		surfaceFilter: 'all',
+		triageFilter: 'open',
 		cursor: null,
 	})
 	expect(
 		readAccountActivityFilters(
-			'https://example.com/account/activity?status=all&surface=job&cursor=abc',
+			'https://example.com/account/activity?status=all&surface=job&cursor=abc&error_triage=ignored',
 		),
 	).toEqual({
 		statusFilter: 'all',
 		surfaceFilter: 'job',
+		triageFilter: 'ignored',
 		cursor: 'abc',
 	})
 	expect(statusFilterToRunStatus('error')).toBe('error')
@@ -111,6 +117,8 @@ test('loadAccountActivityData maps filters, summary, pagination, detail, and cur
 		since: '2026-07-19T12:00:00.000Z',
 		total: 4,
 		errors: 1,
+		ignored: 0,
+		resolved: 0,
 		running: 0,
 		bySurface: [{ surface: 'job', total: 4, errors: 1 }],
 	})
@@ -160,6 +168,7 @@ test('loadAccountActivityData maps filters, summary, pagination, detail, and cur
 			status: 'error',
 			surface: 'job',
 			since: '2026-07-19T12:00:00.000Z',
+			errorTriage: 'open',
 		},
 		limit: 25,
 		cursor: null,
@@ -173,9 +182,12 @@ test('loadAccountActivityData maps filters, summary, pagination, detail, and cur
 		ok: true,
 		statusFilter: 'error',
 		surfaceFilter: 'job',
+		triageFilter: 'open',
 		summary: {
 			total: 4,
 			errors: 1,
+			ignored: 0,
+			resolved: 0,
 			running: 0,
 		},
 		nextCursor: 'cursor-2',
@@ -219,6 +231,7 @@ test('loadAccountActivityData maps filters, summary, pagination, detail, and cur
 				status: null,
 				surface: null,
 				since: '2026-07-19T12:00:00.000Z',
+				errorTriage: 'open',
 			},
 			cursor: 'page-2',
 		}),

--- a/packages/worker/src/app/account-activity-data.ts
+++ b/packages/worker/src/app/account-activity-data.ts
@@ -5,11 +5,14 @@ import {
 	summarizeRunRecords,
 } from '#worker/run-records/service.ts'
 import {
+	type RunErrorTriage,
+	type RunErrorTriageFilter,
 	type RunLogLevel,
 	type RunRecord,
 	type RunRecordLog,
 	type RunStatus,
 	type RunSurface,
+	runErrorTriageFilterValues,
 	runRecordRetentionDays,
 	runSurfaceValues,
 } from '#worker/run-records/types.ts'
@@ -35,6 +38,10 @@ export const accountActivitySurfaceFilterValues = [
 export type AccountActivitySurfaceFilter =
 	(typeof accountActivitySurfaceFilterValues)[number]
 
+export const accountActivityTriageFilterValues = runErrorTriageFilterValues
+
+export type AccountActivityTriageFilter = RunErrorTriageFilter
+
 export type AccountActivityRunListItem = {
 	id: string
 	surface: RunSurface
@@ -45,6 +52,7 @@ export type AccountActivityRunListItem = {
 	durationMs: number | null
 	errorName: string | null
 	errorMessage: string | null
+	errorTriage: RunErrorTriage | null
 	packageId: string | null
 	jobId: string | null
 	logCount: number
@@ -67,6 +75,9 @@ export type AccountActivityRunDetail = AccountActivityRunListItem & {
 	sessionId: string | null
 	idempotencyKey: string | null
 	parentRunId: string | null
+	triageNote: string | null
+	triagedAt: string | null
+	triagedBy: string | null
 	metadata: Record<string, unknown>
 	logs: Array<AccountActivityRunLog>
 }
@@ -75,6 +86,8 @@ export type AccountActivitySummary = {
 	since: string
 	total: number
 	errors: number
+	ignored: number
+	resolved: number
 	running: number
 }
 
@@ -82,6 +95,7 @@ export type AccountActivityLoaderData = {
 	ok: true
 	statusFilter: AccountActivityStatusFilter
 	surfaceFilter: AccountActivitySurfaceFilter
+	triageFilter: AccountActivityTriageFilter
 	summary: AccountActivitySummary
 	runs: Array<AccountActivityRunListItem>
 	nextCursor: string | null
@@ -114,6 +128,15 @@ export function isAccountActivitySurfaceFilter(
 	)
 }
 
+export function isAccountActivityTriageFilter(
+	value: string | null | undefined,
+): value is AccountActivityTriageFilter {
+	return (
+		typeof value === 'string' &&
+		(accountActivityTriageFilterValues as ReadonlyArray<string>).includes(value)
+	)
+}
+
 export function readAccountActivitySelectedRunId(
 	requestUrl: string,
 	pathRunId?: string,
@@ -140,6 +163,10 @@ export function readAccountActivityFilters(requestUrl: string) {
 	const url = new URL(requestUrl, 'http://localhost')
 	const statusRaw = url.searchParams.get('status')?.trim() ?? null
 	const surfaceRaw = url.searchParams.get('surface')?.trim() ?? null
+	const triageRaw =
+		url.searchParams.get('error_triage')?.trim() ??
+		url.searchParams.get('triage')?.trim() ??
+		null
 	const cursor = url.searchParams.get('cursor')?.trim() || null
 	return {
 		statusFilter: isAccountActivityStatusFilter(statusRaw)
@@ -148,6 +175,9 @@ export function readAccountActivityFilters(requestUrl: string) {
 		surfaceFilter: isAccountActivitySurfaceFilter(surfaceRaw)
 			? surfaceRaw
 			: ('all' satisfies AccountActivitySurfaceFilter),
+		triageFilter: isAccountActivityTriageFilter(triageRaw)
+			? triageRaw
+			: ('open' satisfies AccountActivityTriageFilter),
 		cursor,
 	}
 }
@@ -187,6 +217,7 @@ function toListItem(run: RunRecord): AccountActivityRunListItem {
 		durationMs: run.durationMs,
 		errorName: run.errorName,
 		errorMessage: run.errorMessage,
+		errorTriage: run.errorTriage,
 		packageId: run.packageId,
 		jobId: run.jobId,
 		logCount: run.logCount,
@@ -208,6 +239,9 @@ function toDetail(
 		sessionId: run.sessionId,
 		idempotencyKey: run.idempotencyKey,
 		parentRunId: run.parentRunId,
+		triageNote: run.triageNote,
+		triagedAt: run.triagedAt,
+		triagedBy: run.triagedBy,
 		metadata: run.metadata,
 		logs: logs
 			.slice()
@@ -238,9 +272,8 @@ export async function loadAccountActivityData(input: {
 		input.request.url,
 		input.pathRunId,
 	)
-	const { statusFilter, surfaceFilter, cursor } = readAccountActivityFilters(
-		input.request.url,
-	)
+	const { statusFilter, surfaceFilter, triageFilter, cursor } =
+		readAccountActivityFilters(input.request.url)
 	const since = summarySince(now)
 
 	const [summary, page, selectedRecord] = await Promise.all([
@@ -256,6 +289,7 @@ export async function loadAccountActivityData(input: {
 				status: statusFilterToRunStatus(statusFilter),
 				surface: surfaceFilterToRunSurface(surfaceFilter),
 				since,
+				errorTriage: triageFilter,
 			},
 			limit: defaultPageSize,
 			cursor,
@@ -273,10 +307,13 @@ export async function loadAccountActivityData(input: {
 		ok: true,
 		statusFilter,
 		surfaceFilter,
+		triageFilter,
 		summary: {
 			since: summary.since,
 			total: summary.total,
 			errors: summary.errors,
+			ignored: summary.ignored,
+			resolved: summary.resolved,
 			running: summary.running,
 		},
 		runs: page.runs.map(toListItem),

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -1032,6 +1032,12 @@ export type AccountActivitySurfaceFilter =
 	| 'retriever'
 	| 'webhook'
 
+export type AccountActivityTriageFilter =
+	| 'open'
+	| 'ignored'
+	| 'resolved'
+	| 'all'
+
 export type AccountActivityRunListItem = {
 	id: string
 	surface: Exclude<AccountActivitySurfaceFilter, 'all'>
@@ -1042,6 +1048,7 @@ export type AccountActivityRunListItem = {
 	durationMs: number | null
 	errorName: string | null
 	errorMessage: string | null
+	errorTriage: 'ignored' | 'resolved' | null
 	packageId: string | null
 	jobId: string | null
 	logCount: number
@@ -1064,6 +1071,9 @@ export type AccountActivityRunDetail = AccountActivityRunListItem & {
 	sessionId: string | null
 	idempotencyKey: string | null
 	parentRunId: string | null
+	triageNote: string | null
+	triagedAt: string | null
+	triagedBy: string | null
 	metadata: { [key: string]: AccountLoaderJsonValue }
 	logs: Array<AccountActivityRunLog>
 }
@@ -1072,6 +1082,8 @@ export type AccountActivitySummary = {
 	since: string
 	total: number
 	errors: number
+	ignored: number
+	resolved: number
 	running: number
 }
 
@@ -1079,6 +1091,7 @@ export type AccountActivityLoaderData = {
 	ok: true
 	statusFilter: AccountActivityStatusFilter
 	surfaceFilter: AccountActivitySurfaceFilter
+	triageFilter: AccountActivityTriageFilter
 	summary: AccountActivitySummary
 	runs: Array<AccountActivityRunListItem>
 	nextCursor: string | null

--- a/packages/worker/src/mcp/capabilities/runs/domain.ts
+++ b/packages/worker/src/mcp/capabilities/runs/domain.ts
@@ -3,10 +3,12 @@ import { capabilityDomainNames } from '../domain-metadata.ts'
 import { runGetCapability } from './run-get.ts'
 import { runListCapability } from './run-list.ts'
 import { runSummaryCapability } from './run-summary.ts'
+import { runUpdateCapability } from './run-update.ts'
 
 export const runsDomain = defineDomain({
 	name: capabilityDomainNames.runs,
-	description: 'User-level execution history for debugging failed runtimes.',
+	description:
+		'User-level execution history for debugging failed runtimes, including soft triage (ignore/resolve) for retained errors.',
 	keywords: [
 		'runs',
 		'history',
@@ -19,6 +21,14 @@ export const runsDomain = defineDomain({
 		'jobs',
 		'webhooks',
 		'package apps',
+		'ignored',
+		'resolved',
+		'triage',
 	],
-	capabilities: [runListCapability, runGetCapability, runSummaryCapability],
+	capabilities: [
+		runListCapability,
+		runGetCapability,
+		runSummaryCapability,
+		runUpdateCapability,
+	],
 })

--- a/packages/worker/src/mcp/capabilities/runs/run-get.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-get.ts
@@ -30,7 +30,7 @@ export const runGetCapability = defineDomainCapability(
 	{
 		name: 'run_get',
 		description:
-			'Load one retained run with its captured log lines, error details, and (when available) a bounded metadata.result snapshot of the handler return value — useful for webhook deliveries, package exports, and keyed execute recovery. Records are retained about 30 days, capped per user, and pruned failure-last. Key-less successful ad-hoc execute runs are not stored; execute failures and execute calls that supplied an idempotencyKey are retained.',
+			'Load one retained run with its captured log lines, error details, soft triage fields (error_triage / note / who / when), and (when available) a bounded metadata.result snapshot of the handler return value — useful for webhook deliveries, package exports, and keyed execute recovery. Works for ignored/resolved runs too. Records are retained about 30 days, capped per user, and pruned failure-last. Key-less successful ad-hoc execute runs are not stored; execute failures and execute calls that supplied an idempotencyKey are retained.',
 		keywords: [
 			'run',
 			'logs',
@@ -41,6 +41,9 @@ export const runGetCapability = defineDomainCapability(
 			'trace',
 			'stack',
 			'why did it fail',
+			'ignored',
+			'resolved',
+			'triage',
 		],
 		readOnly: true,
 		idempotent: true,

--- a/packages/worker/src/mcp/capabilities/runs/run-list.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-list.ts
@@ -5,6 +5,7 @@ import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { listRunRecords } from '#worker/run-records/service.ts'
 import {
 	formatRunRecord,
+	runErrorTriageFilterSchema,
 	runListLimitSchema,
 	runRecordSchema,
 	runStatusSchema,
@@ -37,6 +38,11 @@ const inputSchema = z.object({
 		.describe(
 			'Optional ISO 8601 lower bound on started_at (inclusive), for example 2026-07-01T00:00:00.000Z.',
 		),
+	error_triage: runErrorTriageFilterSchema
+		.optional()
+		.describe(
+			'Soft error-triage filter. Defaults to open (hides ignored/resolved noise). Use ignored, resolved, or all to inspect triaged runs.',
+		),
 	limit: runListLimitSchema,
 	cursor: z
 		.string()
@@ -60,7 +66,7 @@ export const runListCapability = defineDomainCapability(
 	{
 		name: 'run_list',
 		description:
-			'List recent execution history across jobs, webhooks, package apps, services, workflows, and other runtimes so you can debug failures, crashes, and "why did my job stop working" questions. Key-less successful ad-hoc execute runs are intentionally not recorded (only execute failures are, plus execute calls that supplied an idempotencyKey); every other surface records both success and error. Terminal rows may include a bounded metadata.result snapshot. Records are retained about 30 days, capped per user, and pruned failure-last (successes drop before errors).',
+			'List recent execution history across jobs, webhooks, package apps, services, workflows, and other runtimes so you can debug failures, crashes, and "why did my job stop working" questions. Key-less successful ad-hoc execute runs are intentionally not recorded (only execute failures are, plus execute calls that supplied an idempotencyKey); every other surface records both success and error. Terminal rows may include a bounded metadata.result snapshot. By default, ignored/resolved error runs are hidden (error_triage defaults to open); use run_update to triage noise, or pass error_triage all/ignored/resolved to inspect those rows. Records are retained about 30 days, capped per user, and pruned failure-last (successes drop before errors).',
 		keywords: [
 			'run',
 			'runs',
@@ -77,6 +83,9 @@ export const runListCapability = defineDomainCapability(
 			'package app',
 			'observability',
 			'trace',
+			'ignored',
+			'resolved',
+			'triage',
 		],
 		readOnly: true,
 		idempotent: true,
@@ -94,6 +103,7 @@ export const runListCapability = defineDomainCapability(
 					packageId: args.package_id ?? null,
 					jobId: args.job_id ?? null,
 					since: args.since ?? null,
+					errorTriage: args.error_triage ?? 'open',
 				},
 				limit: args.limit ?? null,
 				cursor: args.cursor ?? null,

--- a/packages/worker/src/mcp/capabilities/runs/run-summary.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-summary.ts
@@ -20,7 +20,7 @@ export const runSummaryCapability = defineDomainCapability(
 	{
 		name: 'run_summary',
 		description:
-			'Summarize recent run totals, error count, still-running count, and per-surface breakdown to answer "is anything broken?" before drilling into run_list or run_get. Successful ad-hoc execute runs are not recorded (only execute failures count); other surfaces include both. Records are retained about 30 days, capped per user, and pruned failure-last.',
+			'Summarize recent run totals, open error count (excluding ignored/resolved), ignored/resolved counts, still-running count, and per-surface breakdown to answer "is anything broken?" before drilling into run_list or run_get. Use run_update to mark handled error noise. Successful ad-hoc execute runs are not recorded (only execute failures count); other surfaces include both. Records are retained about 30 days, capped per user, and pruned failure-last.',
 		keywords: [
 			'summary',
 			'health',
@@ -31,6 +31,9 @@ export const runSummaryCapability = defineDomainCapability(
 			'overview',
 			'debug',
 			'observability',
+			'ignored',
+			'resolved',
+			'triage',
 		],
 		readOnly: true,
 		idempotent: true,

--- a/packages/worker/src/mcp/capabilities/runs/run-update.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-update.ts
@@ -58,30 +58,31 @@ export const runUpdateCapability = defineDomainCapability(
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
 			const errorTriage = args.triage === 'open' ? null : args.triage
-			try {
-				const run = await updateRunErrorTriage({
-					env: ctx.env,
-					userId: user.userId,
-					runId: args.run_id,
-					errorTriage,
-					triageNote: args.note,
-				})
-				if (!run) {
-					throw new McpCallerError(`Run "${args.run_id}" was not found.`)
+			const outcome = await updateRunErrorTriage({
+				env: ctx.env,
+				userId: user.userId,
+				runId: args.run_id,
+				errorTriage,
+				triageNote: args.note,
+			})
+			if (!outcome.ok) {
+				switch (outcome.reason) {
+					case 'not_found':
+					case 'unavailable':
+						throw new McpCallerError(`Run "${args.run_id}" was not found.`)
+					case 'not_error':
+						throw new McpCallerError(
+							`Run "${outcome.runId}" has status "${outcome.status}"; only error runs can be ignored or resolved.`,
+						)
+					default: {
+						const exhaustive: never = outcome
+						throw new McpCallerError(
+							`Unexpected triage outcome: ${JSON.stringify(exhaustive)}`,
+						)
+					}
 				}
-				return { run: formatRunRecord(run) }
-			} catch (error) {
-				if (error instanceof McpCallerError) throw error
-				const message =
-					error instanceof Error ? error.message : 'Failed to update run triage.'
-				if (
-					message.includes('only error runs can be ignored or resolved') ||
-					message.includes('was not found')
-				) {
-					throw new McpCallerError(message)
-				}
-				throw error
 			}
+			return { run: formatRunRecord(outcome.run) }
 		},
 	},
 )

--- a/packages/worker/src/mcp/capabilities/runs/run-update.ts
+++ b/packages/worker/src/mcp/capabilities/runs/run-update.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { updateRunErrorTriage } from '#worker/run-records/service.ts'
+import {
+	formatRunRecord,
+	runErrorTriageUpdateSchema,
+	runRecordSchema,
+	runTriageNoteSchema,
+} from './shared.ts'
+
+const inputSchema = z.object({
+	run_id: z
+		.string()
+		.min(1)
+		.describe(
+			'Run id from run_list, run_get, job_get recent_runs, or another run reference.',
+		),
+	triage: runErrorTriageUpdateSchema.describe(
+		'Set soft triage on a retained error run: ignored (noise / soft-failure), resolved (already fixed), or open (clear triage and show it again in default listings). Does not delete the run or change error_name / error_message.',
+	),
+	note: runTriageNoteSchema,
+})
+
+const outputSchema = z.object({
+	run: runRecordSchema,
+})
+
+export const runUpdateCapability = defineDomainCapability(
+	capabilityDomainNames.runs,
+	{
+		name: 'run_update',
+		description:
+			'Mark a retained error run as ignored or resolved (or clear triage back to open) so Activity / run_list / run_summary can hide already-handled noise without deleting history. Only error runs accept ignored/resolved; original error details stay intact. Optional note records why. Default run_list and run_summary hide ignored/resolved errors — pass error_triage "all", "ignored", or "resolved" on run_list to inspect them.',
+		keywords: [
+			'run',
+			'update',
+			'triage',
+			'ignore',
+			'ignored',
+			'resolve',
+			'resolved',
+			'reopen',
+			'open',
+			'dismiss',
+			'noise',
+			'activity',
+			'failure',
+			'error',
+		],
+		readOnly: false,
+		idempotent: true,
+		destructive: false,
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx) {
+			const user = requireMcpUser(ctx.callerContext)
+			const errorTriage = args.triage === 'open' ? null : args.triage
+			try {
+				const run = await updateRunErrorTriage({
+					env: ctx.env,
+					userId: user.userId,
+					runId: args.run_id,
+					errorTriage,
+					triageNote: args.note,
+				})
+				if (!run) {
+					throw new McpCallerError(`Run "${args.run_id}" was not found.`)
+				}
+				return { run: formatRunRecord(run) }
+			} catch (error) {
+				if (error instanceof McpCallerError) throw error
+				const message =
+					error instanceof Error ? error.message : 'Failed to update run triage.'
+				if (
+					message.includes('only error runs can be ignored or resolved') ||
+					message.includes('was not found')
+				) {
+					throw new McpCallerError(message)
+				}
+				throw error
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/runs/runs.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/runs/runs.workers.test.ts
@@ -9,6 +9,7 @@ import {
 import { runGetCapability } from './run-get.ts'
 import { runListCapability } from './run-list.ts'
 import { runSummaryCapability } from './run-summary.ts'
+import { runUpdateCapability } from './run-update.ts'
 
 // Each RunLog Durable Object RPC costs ~400ms in the vitest workers pool (the
 // production finish path measures ~0.4ms), and these tests make ~20 of them.
@@ -84,6 +85,12 @@ test(
 		).rejects.toThrow(/Authenticated MCP user/)
 		await expect(
 			runSummaryCapability.handler({}, { env, callerContext }),
+		).rejects.toThrow(/Authenticated MCP user/)
+		await expect(
+			runUpdateCapability.handler(
+				{ run_id: 'missing', triage: 'ignored' },
+				{ env, callerContext },
+			),
 		).rejects.toThrow(/Authenticated MCP user/)
 	},
 	runLogSuiteTimeoutMs,
@@ -214,6 +221,153 @@ test(
 		)
 		expect(otherSummary.total).toBe(0)
 		expect(otherSummary.errors).toBe(0)
+		expect(otherSummary.ignored).toBe(0)
+		expect(otherSummary.resolved).toBe(0)
+	},
+	runLogSuiteTimeoutMs,
+)
+
+test(
+	'run_update triage: set/list/filter/summary/reopen and preserve error details',
+	async () => {
+		const ownerId = uniqueUserId('triage')
+		const ownerContext = buildCallerContext({
+			userId: ownerId,
+			email: `${ownerId}@example.com`,
+		})
+		const startedAtBase = Date.now() - 60_000
+		await finishRun({
+			userId: ownerId,
+			id: 'err-open',
+			startedAt: new Date(startedAtBase).toISOString(),
+			context: baseContext({ surface: 'job', name: 'keep-open' }),
+			status: 'error',
+			error: new Error('still broken'),
+		})
+		await finishRun({
+			userId: ownerId,
+			id: 'err-noise',
+			startedAt: new Date(startedAtBase + 1000).toISOString(),
+			context: baseContext({ surface: 'job', name: 'soft-fail' }),
+			status: 'error',
+			error: new Error('expected flake'),
+		})
+		await finishRun({
+			userId: ownerId,
+			id: 'ok-run',
+			startedAt: new Date(startedAtBase + 2000).toISOString(),
+			context: baseContext({ surface: 'job', name: 'ok' }),
+			status: 'success',
+		})
+
+		const ignored = await runUpdateCapability.handler(
+			{
+				run_id: 'err-noise',
+				triage: 'ignored',
+				note: 'known flake',
+			},
+			{ env, callerContext: ownerContext },
+		)
+		expect(ignored.run).toMatchObject({
+			id: 'err-noise',
+			status: 'error',
+			error_message: 'expected flake',
+			error_triage: 'ignored',
+			triage_note: 'known flake',
+			triaged_by: ownerId,
+		})
+		expect(ignored.run.triaged_at).toBeTruthy()
+
+		// A later finish must preserve soft triage (INSERT OR REPLACE used to wipe it).
+		await finishRun({
+			userId: ownerId,
+			id: 'err-noise',
+			startedAt: new Date(startedAtBase + 1000).toISOString(),
+			context: baseContext({ surface: 'job', name: 'soft-fail' }),
+			status: 'error',
+			error: new Error('expected flake'),
+		})
+		const afterFinish = await runGetCapability.handler(
+			{ run_id: 'err-noise' },
+			{ env, callerContext: ownerContext },
+		)
+		expect(afterFinish.run).toMatchObject({
+			error_triage: 'ignored',
+			triage_note: 'known flake',
+			triaged_by: ownerId,
+			error_message: 'expected flake',
+		})
+
+		await expect(
+			runUpdateCapability.handler(
+				{ run_id: 'ok-run', triage: 'resolved' },
+				{ env, callerContext: ownerContext },
+			),
+		).rejects.toThrow(/only error runs/)
+
+		const defaultList = await runListCapability.handler(
+			{ status: 'error' },
+			{ env, callerContext: ownerContext },
+		)
+		expect(defaultList.runs.map((run) => run.id)).toEqual(['err-open'])
+
+		const ignoredList = await runListCapability.handler(
+			{ error_triage: 'ignored' },
+			{ env, callerContext: ownerContext },
+		)
+		expect(ignoredList.runs.map((run) => run.id)).toEqual(['err-noise'])
+
+		const allList = await runListCapability.handler(
+			{ error_triage: 'all', status: 'error' },
+			{ env, callerContext: ownerContext },
+		)
+		expect(allList.runs.map((run) => run.id).sort()).toEqual([
+			'err-noise',
+			'err-open',
+		])
+
+		const resolved = await runUpdateCapability.handler(
+			{ run_id: 'err-noise', triage: 'resolved', note: 'fixed upstream' },
+			{ env, callerContext: ownerContext },
+		)
+		expect(resolved.run.error_triage).toBe('resolved')
+		expect(resolved.run.triage_note).toBe('fixed upstream')
+		expect(resolved.run.error_message).toBe('expected flake')
+
+		const summary = await runSummaryCapability.handler(
+			{},
+			{ env, callerContext: ownerContext },
+		)
+		expect(summary.errors).toBe(1)
+		expect(summary.ignored).toBe(0)
+		expect(summary.resolved).toBe(1)
+
+		const reopened = await runUpdateCapability.handler(
+			{ run_id: 'err-noise', triage: 'open' },
+			{ env, callerContext: ownerContext },
+		)
+		expect(reopened.run).toMatchObject({
+			error_triage: null,
+			triage_note: null,
+			triaged_at: null,
+			triaged_by: null,
+			error_message: 'expected flake',
+		})
+
+		const afterReopen = await runSummaryCapability.handler(
+			{},
+			{ env, callerContext: ownerContext },
+		)
+		expect(afterReopen.errors).toBe(2)
+		expect(afterReopen.ignored).toBe(0)
+		expect(afterReopen.resolved).toBe(0)
+
+		const detail = await runGetCapability.handler(
+			{ run_id: 'err-noise' },
+			{ env, callerContext: ownerContext },
+		)
+		expect(detail.run.error_triage).toBeNull()
+		expect(detail.run.error_message).toBe('expected flake')
 	},
 	runLogSuiteTimeoutMs,
 )

--- a/packages/worker/src/mcp/capabilities/runs/runs.workers.test.ts
+++ b/packages/worker/src/mcp/capabilities/runs/runs.workers.test.ts
@@ -334,13 +334,23 @@ test(
 		expect(resolved.run.triage_note).toBe('fixed upstream')
 		expect(resolved.run.error_message).toBe('expected flake')
 
+		// Omitting note must preserve the existing triage note across the DO RPC.
+		const keepNote = await runUpdateCapability.handler(
+			{ run_id: 'err-noise', triage: 'ignored' },
+			{ env, callerContext: ownerContext },
+		)
+		expect(keepNote.run).toMatchObject({
+			error_triage: 'ignored',
+			triage_note: 'fixed upstream',
+		})
+
 		const summary = await runSummaryCapability.handler(
 			{},
 			{ env, callerContext: ownerContext },
 		)
 		expect(summary.errors).toBe(1)
-		expect(summary.ignored).toBe(0)
-		expect(summary.resolved).toBe(1)
+		expect(summary.ignored).toBe(1)
+		expect(summary.resolved).toBe(0)
 
 		const reopened = await runUpdateCapability.handler(
 			{ run_id: 'err-noise', triage: 'open' },

--- a/packages/worker/src/mcp/capabilities/runs/shared.ts
+++ b/packages/worker/src/mcp/capabilities/runs/shared.ts
@@ -4,6 +4,9 @@ import {
 	type RunRecordLog,
 	type RunRecordSummary,
 	type RunRecordSurfaceSummary,
+	runErrorTriageFilterValues,
+	runErrorTriageMaxNoteLength,
+	runErrorTriageValues,
 	runLogLevelValues,
 	runRecordDefaultPageSize,
 	runRecordMaxPageSize,
@@ -14,6 +17,17 @@ import {
 export const runSurfaceSchema = z.enum(runSurfaceValues)
 
 export const runStatusSchema = z.enum(runStatusValues)
+
+export const runErrorTriageSchema = z.enum(runErrorTriageValues)
+
+export const runErrorTriageFilterSchema = z.enum(runErrorTriageFilterValues)
+
+/** Wire values for `run_update`: set triage or reopen (`open`). */
+export const runErrorTriageUpdateSchema = z.enum([
+	'ignored',
+	'resolved',
+	'open',
+])
 
 export const runRecordSchema = z.object({
 	id: z.string(),
@@ -36,6 +50,14 @@ export const runRecordSchema = z.object({
 	duration_ms: z.number().int().nonnegative().nullable(),
 	error_name: z.string().nullable(),
 	error_message: z.string().nullable(),
+	error_triage: runErrorTriageSchema
+		.nullable()
+		.describe(
+			'Soft triage for error runs: ignored, resolved, or null when open / not an error.',
+		),
+	triage_note: z.string().nullable(),
+	triaged_at: z.string().nullable(),
+	triaged_by: z.string().nullable(),
 	metadata: z.record(z.string(), z.unknown()),
 	log_count: z.number().int().nonnegative(),
 })
@@ -57,7 +79,21 @@ export const runRecordSurfaceSummarySchema = z.object({
 export const runRecordSummarySchema = z.object({
 	since: z.string(),
 	total: z.number().int().nonnegative(),
-	errors: z.number().int().nonnegative(),
+	errors: z
+		.number()
+		.int()
+		.nonnegative()
+		.describe('Open (not ignored/resolved) error count.'),
+	ignored: z
+		.number()
+		.int()
+		.nonnegative()
+		.describe('Error runs marked ignored.'),
+	resolved: z
+		.number()
+		.int()
+		.nonnegative()
+		.describe('Error runs marked resolved.'),
 	running: z.number().int().nonnegative(),
 	by_surface: z.array(runRecordSurfaceSummarySchema),
 })
@@ -70,6 +106,14 @@ export const runListLimitSchema = z
 	.optional()
 	.describe(
 		`Page size (default ${runRecordDefaultPageSize}, max ${runRecordMaxPageSize}).`,
+	)
+
+export const runTriageNoteSchema = z
+	.string()
+	.max(runErrorTriageMaxNoteLength)
+	.optional()
+	.describe(
+		`Optional note (at most ${runErrorTriageMaxNoteLength} characters). Omit to preserve the current note when setting ignored/resolved; pass an empty string to clear it. Cleared automatically when triage is set to open.`,
 	)
 
 export function formatRunRecord(
@@ -96,6 +140,10 @@ export function formatRunRecord(
 		duration_ms: run.durationMs,
 		error_name: run.errorName,
 		error_message: run.errorMessage,
+		error_triage: run.errorTriage,
+		triage_note: run.triageNote,
+		triaged_at: run.triagedAt,
+		triaged_by: run.triagedBy,
 		metadata: run.metadata,
 		log_count: run.logCount,
 	}
@@ -130,6 +178,8 @@ export function formatRunRecordSummary(
 		since: summary.since,
 		total: summary.total,
 		errors: summary.errors,
+		ignored: summary.ignored,
+		resolved: summary.resolved,
 		running: summary.running,
 		by_surface: summary.bySurface.map(formatRunRecordSurfaceSummary),
 	}

--- a/packages/worker/src/run-records/dedicated-state.workers.test.ts
+++ b/packages/worker/src/run-records/dedicated-state.workers.test.ts
@@ -1184,8 +1184,8 @@ function jobRunObservabilityColumnNames(state: DurableObjectState) {
 		.map((row) => String(row.name))
 }
 
-test('fresh schema v9 creates the final job_run_observability contract', async () => {
-	const userId = uniqueUserId('schema-v9-fresh')
+test('fresh schema v10 creates the final job_run_observability contract', async () => {
+	const userId = uniqueUserId('schema-v10-fresh')
 	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
 	await runInDurableObject(stub, async (instance: RunLog, state) => {
 		expect(instance).toBeInstanceOf(RunLog)
@@ -1194,7 +1194,7 @@ test('fresh schema v9 creates the final job_run_observability contract', async (
 				`SELECT value FROM run_log_meta WHERE key = 'schema_version' LIMIT 1`,
 			)
 			.toArray()[0]
-		expect(Number(version?.value)).toBe(9)
+		expect(Number(version?.value)).toBe(10)
 
 		expect(jobRunObservabilityColumnNames(state)).toEqual([
 			'job_id',
@@ -1207,29 +1207,42 @@ test('fresh schema v9 creates the final job_run_observability contract', async (
 			'error_count',
 			'updated_at',
 		])
+		expect(
+			state.storage.sql
+				.exec<{ name: string }>(`PRAGMA table_info(runs)`)
+				.toArray()
+				.map((row) => String(row.name)),
+		).toEqual(
+			expect.arrayContaining([
+				'error_triage',
+				'triage_note',
+				'triaged_at',
+				'triaged_by',
+			]),
+		)
 	})
 
 	const updated = await upsertJobRunObservability({
 		env,
 		userId,
 		outcome: {
-			jobId: 'job-v9',
+			jobId: 'job-v10',
 			status: 'error',
 			ranAt: '2026-08-01T01:00:00.000Z',
-			error: 'fresh-v9',
+			error: 'fresh-v10',
 		},
 	})
 	expect(updated).toMatchObject({
-		jobId: 'job-v9',
+		jobId: 'job-v10',
 		runCount: 1,
 		successCount: 0,
 		errorCount: 1,
 		lastRunStatus: 'error',
-		lastRunError: 'fresh-v9',
+		lastRunError: 'fresh-v10',
 	})
 })
 
-test('warm schema v7 and v8 objects upgrade to v9 without losing job data', async () => {
+test('warm schema v7 and v8 objects upgrade to v10 without losing job data', async () => {
 	const retiredColumn = ['legacy', 'seeded'].join('_')
 	for (const installedVersion of [7, 8]) {
 		const userId = uniqueUserId(`schema-v${installedVersion}-warm`)
@@ -1289,7 +1302,7 @@ test('warm schema v7 and v8 objects upgrade to v9 without losing job data', asyn
 					`SELECT value FROM run_log_meta WHERE key = 'schema_version' LIMIT 1`,
 				)
 				.toArray()[0]
-			expect(Number(version?.value)).toBe(9)
+			expect(Number(version?.value)).toBe(10)
 			expect(jobRunObservabilityColumnNames(state)).toEqual([
 				'job_id',
 				'last_run_at',
@@ -1336,6 +1349,109 @@ test('warm schema v7 and v8 objects upgrade to v9 without losing job data', asyn
 			lastRunError: 'preserved error',
 		})
 	}
+})
+
+test('warm schema v9 objects upgrade to v10 with error triage columns', async () => {
+	const userId = uniqueUserId('schema-v9-warm-triage')
+	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
+	await runInDurableObject(stub, async (instance: RunLog, state) => {
+		expect(instance).toBeInstanceOf(RunLog)
+		await state.storage.deleteAll()
+
+		state.storage.sql.exec(`
+			CREATE TABLE run_log_meta (
+				key TEXT PRIMARY KEY NOT NULL,
+				value INTEGER NOT NULL
+			)
+		`)
+		state.storage.sql.exec(
+			`INSERT INTO run_log_meta (key, value) VALUES ('schema_version', 9)`,
+		)
+		state.storage.sql.exec(`
+			CREATE TABLE runs (
+				id TEXT PRIMARY KEY NOT NULL,
+				surface TEXT NOT NULL,
+				status TEXT NOT NULL,
+				name TEXT,
+				package_id TEXT,
+				package_kody_id TEXT,
+				source_id TEXT,
+				published_commit TEXT,
+				storage_id TEXT,
+				job_id TEXT,
+				workflow_id TEXT,
+				invocation_id TEXT,
+				session_id TEXT,
+				idempotency_key TEXT,
+				parent_run_id TEXT,
+				started_at TEXT NOT NULL,
+				finished_at TEXT,
+				duration_ms INTEGER,
+				error_name TEXT,
+				error_message TEXT,
+				metadata_json TEXT NOT NULL DEFAULT '{}',
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)
+		`)
+		state.storage.sql.exec(
+			`INSERT INTO runs (
+				id, surface, status, name, started_at, finished_at, duration_ms,
+				error_name, error_message, metadata_json, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?)`,
+			'run-warm-v9',
+			'execute',
+			'error',
+			'warm-v9',
+			'2026-07-01T00:00:00.000Z',
+			'2026-07-01T00:00:01.000Z',
+			1000,
+			'Error',
+			'preserved',
+			'2026-07-01T00:00:00.000Z',
+			'2026-07-01T00:00:01.000Z',
+		)
+
+		const proto = Object.getPrototypeOf(instance) as {
+			initializeSchema: () => void
+		}
+		proto.initializeSchema.call(instance)
+
+		const version = state.storage.sql
+			.exec<{ value: number }>(
+				`SELECT value FROM run_log_meta WHERE key = 'schema_version' LIMIT 1`,
+			)
+			.toArray()[0]
+		expect(Number(version?.value)).toBe(10)
+		expect(
+			state.storage.sql
+				.exec<{ name: string }>(`PRAGMA table_info(runs)`)
+				.toArray()
+				.map((row) => String(row.name)),
+		).toEqual(
+			expect.arrayContaining([
+				'error_triage',
+				'triage_note',
+				'triaged_at',
+				'triaged_by',
+			]),
+		)
+		expect(
+			state.storage.sql
+				.exec<Record<string, SqlStorageValue>>(
+					`SELECT id, status, error_message, error_triage, triage_note
+					FROM runs WHERE id = ?`,
+					'run-warm-v9',
+				)
+				.one(),
+		).toEqual({
+			id: 'run-warm-v9',
+			status: 'error',
+			error_message: 'preserved',
+			error_triage: null,
+			triage_note: null,
+		})
+	})
 })
 
 test('getAdminInsightsSnapshot returns content-free workflow, job, and activation aggregates', async () => {

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -2615,10 +2615,7 @@ class RunLogBase extends DurableObject<Env> {
 			.toArray()[0]
 		if (!existing) return { ok: false, reason: 'not_found' }
 
-		const current = mapRunRow(
-			existing,
-			Number(existing['log_count'] ?? 0) || 0,
-		)
+		const current = mapRunRow(existing, Number(existing['log_count'] ?? 0) || 0)
 		const nextTriage = input.errorTriage
 		if (nextTriage != null && current.status !== 'error') {
 			return {

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -203,6 +203,11 @@ export type UpdateRunErrorTriageInput = {
 	triagedBy: string
 }
 
+export type UpdateRunErrorTriageResult =
+	| { ok: true; run: RunRecord }
+	| { ok: false; reason: 'not_found' }
+	| { ok: false; reason: 'not_error'; status: RunStatus; runId: string }
+
 type ExportRunsInput = {
 	pageSize: number
 	startAfter?: string | null
@@ -2592,10 +2597,12 @@ class RunLogBase extends DurableObject<Env> {
 	 * Soft-triage a retained error run. Does not delete or rewrite error
 	 * details. Only `status = 'error'` rows accept ignored/resolved; reopen
 	 * (`errorTriage: null`) clears triage on any retained row that has it.
+	 * Returns a result object instead of throwing so RPC callers can map
+	 * caller errors without uncaught DO promise rejections.
 	 */
 	async updateRunErrorTriage(
 		input: UpdateRunErrorTriageInput,
-	): Promise<RunRecord | null> {
+	): Promise<UpdateRunErrorTriageResult> {
 		const existing = this.ctx.storage.sql
 			.exec<Record<string, SqlStorageValue>>(
 				`SELECT r.*,
@@ -2606,7 +2613,7 @@ class RunLogBase extends DurableObject<Env> {
 				input.runId,
 			)
 			.toArray()[0]
-		if (!existing) return null
+		if (!existing) return { ok: false, reason: 'not_found' }
 
 		const current = mapRunRow(
 			existing,
@@ -2614,9 +2621,12 @@ class RunLogBase extends DurableObject<Env> {
 		)
 		const nextTriage = input.errorTriage
 		if (nextTriage != null && current.status !== 'error') {
-			throw new Error(
-				`Run "${input.runId}" has status "${current.status}"; only error runs can be ignored or resolved.`,
-			)
+			return {
+				ok: false,
+				reason: 'not_error',
+				status: current.status,
+				runId: input.runId,
+			}
 		}
 
 		const now = new Date().toISOString()
@@ -2669,8 +2679,11 @@ class RunLogBase extends DurableObject<Env> {
 				input.runId,
 			)
 			.toArray()[0]
-		if (!updated) return null
-		return mapRunRow(updated, Number(updated['log_count'] ?? 0) || 0)
+		if (!updated) return { ok: false, reason: 'not_found' }
+		return {
+			ok: true,
+			run: mapRunRow(updated, Number(updated['log_count'] ?? 0) || 0),
+		}
 	}
 
 	async listStorageIds(): Promise<Array<string>> {
@@ -3146,7 +3159,7 @@ export type RunLogRpc = DurableObjectPitrRpc & {
 	listRuns: (input: ListRunsInput) => Promise<RunRecordPage>
 	updateRunErrorTriage: (
 		input: UpdateRunErrorTriageInput,
-	) => Promise<RunRecord | null>
+	) => Promise<UpdateRunErrorTriageResult>
 	getRun: (input: {
 		runId: string
 	}) => Promise<{ run: RunRecord; logs: Array<RunRecordLog> } | null>

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -762,9 +762,7 @@ class RunLogBase extends DurableObject<Env> {
 			'triaged_by',
 		] as const) {
 			try {
-				this.ctx.storage.sql.exec(
-					`ALTER TABLE runs ADD COLUMN ${column} TEXT`,
-				)
+				this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN ${column} TEXT`)
 			} catch {
 				// Column already present on a partially migrated object.
 			}

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -749,15 +749,26 @@ class RunLogBase extends DurableObject<Env> {
 	}
 
 	/**
-	 * Soft error-triage columns for Activity noise control. Idempotent when a
-	 * warm object somehow re-enters schema init: SQLite rejects duplicate
-	 * ADD COLUMN, so we only run under the version gate above.
+	 * Soft error-triage columns for Activity noise control. Warm objects may
+	 * already have these columns when CREATE TABLE IF NOT EXISTS ran against
+	 * the current DDL before the version gate called this helper — ignore
+	 * duplicate-column errors so re-entry stays idempotent.
 	 */
 	private migrateRunsErrorTriageForV10() {
-		this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN error_triage TEXT`)
-		this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN triage_note TEXT`)
-		this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN triaged_at TEXT`)
-		this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN triaged_by TEXT`)
+		for (const column of [
+			'error_triage',
+			'triage_note',
+			'triaged_at',
+			'triaged_by',
+		] as const) {
+			try {
+				this.ctx.storage.sql.exec(
+					`ALTER TABLE runs ADD COLUMN ${column} TEXT`,
+				)
+			} catch {
+				// Column already present on a partially migrated object.
+			}
+		}
 	}
 
 	private getMeta(key: string): number | null {

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -31,6 +31,8 @@ import {
 	workflowProjectionReservationStatuses,
 } from './workflow-projection.ts'
 import {
+	type RunErrorTriage,
+	type RunErrorTriageFilter,
 	type RunLogLevel,
 	type RunRecord,
 	type RunRecordLog,
@@ -39,6 +41,8 @@ import {
 	type RunStatus,
 	type RunSurface,
 	packageInvocationLedgerRetentionDays,
+	runErrorTriageMaxNoteLength,
+	runErrorTriageValues,
 	runRecordMaxJsonBytes,
 	runRecordMaxLogEntriesPerRun,
 	runRecordMaxRunsPerUser,
@@ -65,7 +69,7 @@ const metaRunCountKey = 'run_count'
 const metaFinishesSinceRetentionKey = 'finishes_since_retention'
 const metaSchemaVersionKey = 'schema_version'
 /** Bump when initializeSchema's DDL set changes; warm objects skip DDL. */
-const runLogSchemaVersion = 9
+const runLogSchemaVersion = 10
 
 /**
  * Cursor namespaces for `exportRuns` phases after the raw run-id phase.
@@ -182,8 +186,21 @@ type ListRunsInput = {
 	jobId?: string | null
 	name?: string | null
 	since?: string | null
+	errorTriage?: RunErrorTriageFilter | null
 	limit: number
 	cursor?: string | null
+}
+
+export type UpdateRunErrorTriageInput = {
+	runId: string
+	/** `null` clears triage (reopen). */
+	errorTriage: RunErrorTriage | null
+	/**
+	 * `undefined` preserves the current note; `null` or empty clears it.
+	 * Ignored when clearing triage (note is always cleared on reopen).
+	 */
+	triageNote?: string | null
+	triagedBy: string
 }
 
 type ExportRunsInput = {
@@ -297,12 +314,18 @@ function normalizePageSize(pageSize: number | undefined, fallback: number) {
 	return Math.min(Math.max(requested, 1), runRecordMaxPageSize)
 }
 
+function isRunErrorTriage(value: string): value is RunErrorTriage {
+	return (runErrorTriageValues as ReadonlyArray<string>).includes(value)
+}
+
 function mapRunRow(
 	row: Record<string, SqlStorageValue>,
 	logCount: number,
 ): RunRecord {
 	const surface = String(row['surface'] ?? '')
 	const status = String(row['status'] ?? '')
+	const rawTriage =
+		row['error_triage'] == null ? null : String(row['error_triage'])
 	return {
 		id: String(row['id']),
 		surface: (isRunSurface(surface) ? surface : 'execute') as RunSurface,
@@ -331,6 +354,10 @@ function mapRunRow(
 		errorName: row['error_name'] == null ? null : String(row['error_name']),
 		errorMessage:
 			row['error_message'] == null ? null : String(row['error_message']),
+		errorTriage: rawTriage && isRunErrorTriage(rawTriage) ? rawTriage : null,
+		triageNote: row['triage_note'] == null ? null : String(row['triage_note']),
+		triagedAt: row['triaged_at'] == null ? null : String(row['triaged_at']),
+		triagedBy: row['triaged_by'] == null ? null : String(row['triaged_by']),
 		metadata: parseJsonRecord(row['metadata_json']),
 		logCount,
 	}
@@ -522,9 +549,16 @@ class RunLogBase extends DurableObject<Env> {
 				error_message TEXT,
 				metadata_json TEXT NOT NULL DEFAULT '{}',
 				created_at TEXT NOT NULL,
-				updated_at TEXT NOT NULL
+				updated_at TEXT NOT NULL,
+				error_triage TEXT,
+				triage_note TEXT,
+				triaged_at TEXT,
+				triaged_by TEXT
 			)
 		`)
+		if (installedVersion != null && installedVersion < 10) {
+			this.migrateRunsErrorTriageForV10()
+		}
 		this.ctx.storage.sql.exec(
 			`CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at DESC, id DESC)`,
 		)
@@ -704,6 +738,18 @@ class RunLogBase extends DurableObject<Env> {
 		})
 	}
 
+	/**
+	 * Soft error-triage columns for Activity noise control. Idempotent when a
+	 * warm object somehow re-enters schema init: SQLite rejects duplicate
+	 * ADD COLUMN, so we only run under the version gate above.
+	 */
+	private migrateRunsErrorTriageForV10() {
+		this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN error_triage TEXT`)
+		this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN triage_note TEXT`)
+		this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN triaged_at TEXT`)
+		this.ctx.storage.sql.exec(`ALTER TABLE runs ADD COLUMN triaged_by TEXT`)
+	}
+
 	private getMeta(key: string): number | null {
 		const row = this.ctx.storage.sql
 			.exec<{ value: number }>(
@@ -837,6 +883,9 @@ class RunLogBase extends DurableObject<Env> {
 
 	private upsertRun(run: RunLogRowInput, mode: 'ignore' | 'replace') {
 		const metadataJson = clampMetadataJson(run.metadataJson || '{}')
+		// New rows start with open triage (NULL). On conflict, preserve soft
+		// triage for error finishes; clear it when the terminal status is not
+		// error so success/running rows never stay hidden behind stale triage.
 		const statement =
 			mode === 'ignore'
 				? `INSERT OR IGNORE INTO runs (
@@ -844,15 +893,53 @@ class RunLogBase extends DurableObject<Env> {
 					published_commit, storage_id, job_id, workflow_id, invocation_id,
 					session_id, idempotency_key, parent_run_id, started_at, finished_at,
 					duration_ms, error_name, error_message, metadata_json, created_at,
-					updated_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-				: `INSERT OR REPLACE INTO runs (
+					updated_at, error_triage, triage_note, triaged_at, triaged_by
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL)`
+				: `INSERT INTO runs (
 					id, surface, status, name, package_id, package_kody_id, source_id,
 					published_commit, storage_id, job_id, workflow_id, invocation_id,
 					session_id, idempotency_key, parent_run_id, started_at, finished_at,
 					duration_ms, error_name, error_message, metadata_json, created_at,
-					updated_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					updated_at, error_triage, triage_note, triaged_at, triaged_by
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL)
+				ON CONFLICT(id) DO UPDATE SET
+					surface = excluded.surface,
+					status = excluded.status,
+					name = excluded.name,
+					package_id = excluded.package_id,
+					package_kody_id = excluded.package_kody_id,
+					source_id = excluded.source_id,
+					published_commit = excluded.published_commit,
+					storage_id = excluded.storage_id,
+					job_id = excluded.job_id,
+					workflow_id = excluded.workflow_id,
+					invocation_id = excluded.invocation_id,
+					session_id = excluded.session_id,
+					idempotency_key = excluded.idempotency_key,
+					parent_run_id = excluded.parent_run_id,
+					started_at = excluded.started_at,
+					finished_at = excluded.finished_at,
+					duration_ms = excluded.duration_ms,
+					error_name = excluded.error_name,
+					error_message = excluded.error_message,
+					metadata_json = excluded.metadata_json,
+					updated_at = excluded.updated_at,
+					error_triage = CASE
+						WHEN excluded.status = 'error' THEN runs.error_triage
+						ELSE NULL
+					END,
+					triage_note = CASE
+						WHEN excluded.status = 'error' THEN runs.triage_note
+						ELSE NULL
+					END,
+					triaged_at = CASE
+						WHEN excluded.status = 'error' THEN runs.triaged_at
+						ELSE NULL
+					END,
+					triaged_by = CASE
+						WHEN excluded.status = 'error' THEN runs.triaged_by
+						ELSE NULL
+					END`
 		this.ctx.storage.sql.exec(
 			statement,
 			run.id,
@@ -2363,6 +2450,21 @@ class RunLogBase extends DurableObject<Env> {
 			clauses.push('r.started_at >= ?')
 			params.push(input.since)
 		}
+		const errorTriage = input.errorTriage ?? null
+		if (errorTriage === 'open') {
+			// Hide ignored/resolved noise; successes and running rows have NULL
+			// triage and remain visible.
+			clauses.push('r.error_triage IS NULL')
+		} else if (errorTriage === 'ignored') {
+			clauses.push(`r.error_triage = 'ignored'`)
+		} else if (errorTriage === 'resolved') {
+			clauses.push(`r.error_triage = 'resolved'`)
+		} else if (errorTriage === 'all' || errorTriage == null) {
+			// No triage filter.
+		} else {
+			const exhaustive: never = errorTriage
+			throw new Error(`Unhandled error triage filter: ${String(exhaustive)}`)
+		}
 		if (input.cursor) {
 			const cursor = decodeCursor(input.cursor)
 			if (cursor) {
@@ -2432,10 +2534,21 @@ class RunLogBase extends DurableObject<Env> {
 		this.reconcileStaleRunning()
 		const since = input.since
 		const totals = this.ctx.storage.sql
-			.exec<{ total: number; errors: number; running: number }>(
+			.exec<{
+				total: number
+				errors: number
+				ignored: number
+				resolved: number
+				running: number
+			}>(
 				`SELECT
 					COUNT(*) AS total,
-					SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS errors,
+					SUM(CASE
+						WHEN status = 'error' AND error_triage IS NULL THEN 1
+						ELSE 0
+					END) AS errors,
+					SUM(CASE WHEN error_triage = 'ignored' THEN 1 ELSE 0 END) AS ignored,
+					SUM(CASE WHEN error_triage = 'resolved' THEN 1 ELSE 0 END) AS resolved,
 					SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running
 				FROM runs
 				WHERE started_at >= ?`,
@@ -2447,7 +2560,10 @@ class RunLogBase extends DurableObject<Env> {
 				`SELECT
 					surface,
 					COUNT(*) AS total,
-					SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS errors
+					SUM(CASE
+						WHEN status = 'error' AND error_triage IS NULL THEN 1
+						ELSE 0
+					END) AS errors
 				FROM runs
 				WHERE started_at >= ?
 				GROUP BY surface
@@ -2459,6 +2575,8 @@ class RunLogBase extends DurableObject<Env> {
 			since,
 			total: Number(totals.total ?? 0) || 0,
 			errors: Number(totals.errors ?? 0) || 0,
+			ignored: Number(totals.ignored ?? 0) || 0,
+			resolved: Number(totals.resolved ?? 0) || 0,
 			running: Number(totals.running ?? 0) || 0,
 			bySurface: bySurfaceRows.map((row) => ({
 				surface: (isRunSurface(row.surface)
@@ -2468,6 +2586,91 @@ class RunLogBase extends DurableObject<Env> {
 				errors: Number(row.errors ?? 0) || 0,
 			})),
 		}
+	}
+
+	/**
+	 * Soft-triage a retained error run. Does not delete or rewrite error
+	 * details. Only `status = 'error'` rows accept ignored/resolved; reopen
+	 * (`errorTriage: null`) clears triage on any retained row that has it.
+	 */
+	async updateRunErrorTriage(
+		input: UpdateRunErrorTriageInput,
+	): Promise<RunRecord | null> {
+		const existing = this.ctx.storage.sql
+			.exec<Record<string, SqlStorageValue>>(
+				`SELECT r.*,
+					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
+				FROM runs r
+				WHERE r.id = ?
+				LIMIT 1`,
+				input.runId,
+			)
+			.toArray()[0]
+		if (!existing) return null
+
+		const current = mapRunRow(
+			existing,
+			Number(existing['log_count'] ?? 0) || 0,
+		)
+		const nextTriage = input.errorTriage
+		if (nextTriage != null && current.status !== 'error') {
+			throw new Error(
+				`Run "${input.runId}" has status "${current.status}"; only error runs can be ignored or resolved.`,
+			)
+		}
+
+		const now = new Date().toISOString()
+		let triageNote: string | null
+		let triagedAt: string | null
+		let triagedBy: string | null
+		if (nextTriage == null) {
+			triageNote = null
+			triagedAt = null
+			triagedBy = null
+		} else {
+			if (input.triageNote === undefined) {
+				triageNote = current.triageNote
+			} else if (input.triageNote == null) {
+				triageNote = null
+			} else {
+				const trimmed = input.triageNote.trim()
+				triageNote =
+					trimmed.length === 0
+						? null
+						: trimmed.slice(0, runErrorTriageMaxNoteLength)
+			}
+			triagedAt = now
+			triagedBy = input.triagedBy.trim() || null
+		}
+
+		this.ctx.storage.sql.exec(
+			`UPDATE runs
+			SET error_triage = ?,
+				triage_note = ?,
+				triaged_at = ?,
+				triaged_by = ?,
+				updated_at = ?
+			WHERE id = ?`,
+			nextTriage,
+			triageNote,
+			triagedAt,
+			triagedBy,
+			now,
+			input.runId,
+		)
+
+		const updated = this.ctx.storage.sql
+			.exec<Record<string, SqlStorageValue>>(
+				`SELECT r.*,
+					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
+				FROM runs r
+				WHERE r.id = ?
+				LIMIT 1`,
+				input.runId,
+			)
+			.toArray()[0]
+		if (!updated) return null
+		return mapRunRow(updated, Number(updated['log_count'] ?? 0) || 0)
 	}
 
 	async listStorageIds(): Promise<Array<string>> {
@@ -2941,6 +3144,9 @@ export type RunLogRpc = DurableObjectPitrRpc & {
 		logs: Array<RunLogEntryInput>
 	}) => Promise<{ ok: true }>
 	listRuns: (input: ListRunsInput) => Promise<RunRecordPage>
+	updateRunErrorTriage: (
+		input: UpdateRunErrorTriageInput,
+	) => Promise<RunRecord | null>
 	getRun: (input: {
 		runId: string
 	}) => Promise<{ run: RunRecord; logs: Array<RunRecordLog> } | null>

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -196,8 +196,13 @@ export type UpdateRunErrorTriageInput = {
 	/** `null` clears triage (reopen). */
 	errorTriage: RunErrorTriage | null
 	/**
-	 * `undefined` preserves the current note; `null` or empty clears it.
-	 * Ignored when clearing triage (note is always cleared on reopen).
+	 * When true, keep the existing note (used when the caller omitted `note`
+	 * so RPC cannot rely on `undefined` surviving structured clone).
+	 */
+	preserveTriageNote?: boolean
+	/**
+	 * `null` or empty clears the note. Ignored when `preserveTriageNote` is
+	 * true, and cleared automatically when reopening (`errorTriage: null`).
 	 */
 	triageNote?: string | null
 	triagedBy: string
@@ -2635,7 +2640,7 @@ class RunLogBase extends DurableObject<Env> {
 			triagedAt = null
 			triagedBy = null
 		} else {
-			if (input.triageNote === undefined) {
+			if (input.preserveTriageNote) {
 				triageNote = current.triageNote
 			} else if (input.triageNote == null) {
 				triageNote = null

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -391,6 +391,8 @@ test('summarizeRunRecords returns totals and per-surface error counts', async ()
 	})
 	expect(summary.total).toBe(5)
 	expect(summary.errors).toBe(3)
+	expect(summary.ignored).toBe(0)
+	expect(summary.resolved).toBe(0)
 	expect(summary.running).toBe(0)
 	expect(summary.bySurface).toEqual(
 		expect.arrayContaining([

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -528,10 +528,15 @@ export async function listRunRecords(input: {
 	})
 }
 
+export type UpdateRunErrorTriageOutcome =
+	| { ok: true; run: RunRecord }
+	| { ok: false; reason: 'not_found' }
+	| { ok: false; reason: 'not_error'; status: RunStatus; runId: string }
+	| { ok: false; reason: 'unavailable' }
+
 /**
  * Soft-triage a retained error run (`ignored` / `resolved`) or clear triage
  * (`errorTriage: null`). Non-destructive: error details stay on the record.
- * Returns `null` when the run is missing from this user's RunLog.
  */
 export async function updateRunErrorTriage(input: {
 	env: Env
@@ -539,8 +544,8 @@ export async function updateRunErrorTriage(input: {
 	runId: string
 	errorTriage: RunErrorTriage | null
 	triageNote?: string | null
-}): Promise<RunRecord | null> {
-	if (!runLogBinding(input.env)) return null
+}): Promise<UpdateRunErrorTriageOutcome> {
+	if (!runLogBinding(input.env)) return { ok: false, reason: 'unavailable' }
 	return await runLogRpc({
 		env: input.env,
 		userId: input.userId,

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -23,6 +23,7 @@ import {
 	type WorkflowProjectionUpsertInput,
 } from './workflow-projection.ts'
 import {
+	type RunErrorTriage,
 	type RunRecord,
 	type RunRecordContext,
 	type RunRecordFilter,
@@ -521,8 +522,33 @@ export async function listRunRecords(input: {
 		jobId: normalizeOptionalString(input.filter?.jobId),
 		name: normalizeOptionalString(input.filter?.name),
 		since: normalizeOptionalString(input.filter?.since),
+		errorTriage: input.filter?.errorTriage ?? null,
 		limit,
 		cursor: input.cursor ?? null,
+	})
+}
+
+/**
+ * Soft-triage a retained error run (`ignored` / `resolved`) or clear triage
+ * (`errorTriage: null`). Non-destructive: error details stay on the record.
+ * Returns `null` when the run is missing from this user's RunLog.
+ */
+export async function updateRunErrorTriage(input: {
+	env: Env
+	userId: string
+	runId: string
+	errorTriage: RunErrorTriage | null
+	triageNote?: string | null
+}): Promise<RunRecord | null> {
+	if (!runLogBinding(input.env)) return null
+	return await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).updateRunErrorTriage({
+		runId: input.runId,
+		errorTriage: input.errorTriage,
+		triageNote: input.triageNote,
+		triagedBy: input.userId,
 	})
 }
 
@@ -802,6 +828,8 @@ export async function summarizeRunRecords(input: {
 			since,
 			total: 0,
 			errors: 0,
+			ignored: 0,
+			resolved: 0,
 			running: 0,
 			bySurface: [],
 		}

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -546,13 +546,17 @@ export async function updateRunErrorTriage(input: {
 	triageNote?: string | null
 }): Promise<UpdateRunErrorTriageOutcome> {
 	if (!runLogBinding(input.env)) return { ok: false, reason: 'unavailable' }
+	// Treat omitted / undefined note as preserve. Pass an explicit boolean over
+	// DO RPC so we do not depend on `undefined` surviving structured clone.
+	const preserveTriageNote = input.triageNote === undefined
 	return await runLogRpc({
 		env: input.env,
 		userId: input.userId,
 	}).updateRunErrorTriage({
 		runId: input.runId,
 		errorTriage: input.errorTriage,
-		triageNote: input.triageNote,
+		preserveTriageNote,
+		triageNote: preserveTriageNote ? null : (input.triageNote ?? null),
 		triagedBy: input.userId,
 	})
 }

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -37,6 +37,31 @@ export type RunStatus = (typeof runStatusValues)[number]
 
 export type RunTerminalStatus = Exclude<RunStatus, 'running'>
 
+/**
+ * Soft triage for retained **error** runs. Separate from {@link RunStatus}
+ * (execution outcome). `null` means open / not triaged. Ignored and resolved
+ * runs keep their original error fields; triage only changes Activity noise.
+ */
+export const runErrorTriageValues = ['ignored', 'resolved'] as const
+
+export type RunErrorTriage = (typeof runErrorTriageValues)[number]
+
+/**
+ * List/summary filter over {@link RunErrorTriage}. `open` = not ignored or
+ * resolved (default for user-facing Activity / `run_list`).
+ */
+export const runErrorTriageFilterValues = [
+	'open',
+	'ignored',
+	'resolved',
+	'all',
+] as const
+
+export type RunErrorTriageFilter = (typeof runErrorTriageFilterValues)[number]
+
+/** Max length for optional triage notes set via `run_update`. */
+export const runErrorTriageMaxNoteLength = 2000
+
 export const runLogLevelValues = [
 	'debug',
 	'info',
@@ -161,6 +186,15 @@ export type RunRecord = {
 	durationMs: number | null
 	errorName: string | null
 	errorMessage: string | null
+	/**
+	 * Soft triage for error runs (`ignored` / `resolved`). `null` when open or
+	 * when the run is not an error.
+	 */
+	errorTriage: RunErrorTriage | null
+	triageNote: string | null
+	triagedAt: string | null
+	/** User id of whoever last set triage (account owner or agent acting for them). */
+	triagedBy: string | null
 	metadata: Record<string, unknown>
 	logCount: number
 }
@@ -196,6 +230,11 @@ export type RunRecordFilter = {
 	name?: string | null
 	/** ISO 8601 lower bound on `startedAt`, inclusive. */
 	since?: string | null
+	/**
+	 * Soft error-triage filter. Omit / `null` means no triage filter (all runs).
+	 * User-facing `run_list` and Activity pass `open` by default.
+	 */
+	errorTriage?: RunErrorTriageFilter | null
 }
 
 export type RunRecordPage = {
@@ -207,13 +246,19 @@ export type RunRecordPage = {
 export type RunRecordSurfaceSummary = {
 	surface: RunSurface
 	total: number
+	/** Open (not ignored/resolved) error count for this surface. */
 	errors: number
 }
 
 export type RunRecordSummary = {
 	since: string
 	total: number
+	/** Open (not ignored/resolved) error count — “is anything broken?”. */
 	errors: number
+	/** Error runs marked ignored. */
+	ignored: number
+	/** Error runs marked resolved. */
+	resolved: number
 	running: number
 	bySurface: Array<RunRecordSurfaceSummary>
 }


### PR DESCRIPTION
## Intent

Activity and `run_*` history were read-only, so soft-failures, agent experiments, and already-fixed errors stayed in the default failure view until retention pruned them. This adds soft triage so users and agents can mark retained error runs as ignored or resolved without deleting history.

## Summary

- Persist soft triage on RunLog rows (`error_triage`: `ignored` / `resolved`, plus optional note / who / when); keep execution `status` and error details intact
- Add MCP `run_update` to set triage to `ignored`, `resolved`, or `open` (reopen)
- Default `run_list` and Activity to `error_triage=open` (hide handled noise); `run_summary.errors` counts open errors and exposes `ignored` / `resolved`
- Activity UI: triage filter, open-error summary, triage fields on detail
- Docs: `docs/use/activity.md` and architecture `run-records.md`
- Tests for set / list / filter / summary / reopen / finish-preserves-triage

## Testing

- `npm run typecheck`
- `nx run worker:test-node -- packages/worker/src/app/account-activity-data.node.test.ts`
- `nx run worker:test-workers -- packages/worker/src/mcp/capabilities/runs/runs.workers.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `915b12af` · **Head:** `677237ef`

**Classification:** extends — soft error triage on run records (schema, MCP `run_update`, list/summary defaults) and Activity filters for open vs ignored/resolved noise.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `run-records` | storage | extends — `error_triage` columns, `run_update`, open-default filters |
| `app-ui` | surfaces | extends — Activity triage filter + summary/detail triage fields |

### System map

Agents and Activity mark retained error runs ignored/resolved in the per-user RunLog; default listings and summaries hide that noise while keeping history.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	runRecords["run-records<br/>Run records"]:::extended
	appUi["app-ui<br/>Browser app"]:::extended
	mcpServer -->|"run_update / run_list error_triage"| runRecords
	appUi -->|"Activity open-default filter + detail"| runRecords
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| RunLog `runs` | execution `status` only | + `error_triage` / note / who / when (schema v10) |
| MCP | `run_list` / `run_get` / `run_summary` (read-only) | + `run_update`; list defaults `error_triage=open`; summary exposes `ignored`/`resolved` |
| Activity | errors-first, no triage | open errors first; triage filter; detail shows triage |

### Invariants

- Per-user isolation unchanged (RunLog still keyed by `userId`).
- Soft triage is non-destructive: original error fields and logs remain.

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches per-user RunLog DO schema migration and finish upsert semantics; behavior change for default Activity/MCP listings (handled errors hidden until filters change).
> 
> **Overview**
> Adds **soft error triage** on retained run records so handled failures can be hidden from the default view without deleting history or changing execution `status`.
> 
> **RunLog (schema v10)** stores `error_triage` (`ignored` / `resolved`), optional note, who, and when on error rows. `finishRun` upserts now preserve triage on error finishes and clear it on non-error terminals (replacing naive `INSERT OR REPLACE` behavior). List and summary queries default to **open** errors (`error_triage IS NULL`); `errors` counts open only, with separate `ignored` / `resolved` totals.
> 
> **MCP `runs`**: new **`run_update`** to set triage or reopen (`open`); **`run_list`** accepts `error_triage` (defaults to `open`); **`run_get`** / **`run_summary`** expose triage fields and revised error semantics.
> 
> **Activity** (`/account/activity`): triage filter in URL/API (`error_triage`, default open), “open errors” and ignored/resolved summary tiles, and triage metadata on run detail. Loader/types and docs updated accordingly.
> 
> Tests cover schema migration v9→v10, MCP triage flows, Activity filter wiring, and finish-preserves-triage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97387a30386c15f7f838a00194951c43e87d0f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added error triage for failed runs, allowing them to be marked as ignored or resolved with notes.
  - Activity views now support triage filters and display triage details and summary counts.
  - Run listings and summaries distinguish open, ignored, and resolved errors.
  - Added MCP support for updating run triage and filtering runs by triage status.

- **Documentation**
  - Updated activity, run records, and MCP documentation with triage workflows and filtering guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->