### PR TITLE
fix(health): retry transient D1 blips in status component checks

### DIFF
--- a/packages/worker/src/app/handlers/health-components-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/health-components-handler.node.test.ts
@@ -75,6 +75,46 @@ test('collectHealthComponents reports healthy, failed, and unavailable bindings'
 	}
 })
 
+test('D1 checks retry transient blips but fail fast on other errors', async () => {
+	let auditAttempts = 0
+	const bindings = createHealthyBindings()
+	bindings.AUDIT_DB = {
+		prepare: () => ({
+			first: async () => {
+				auditAttempts += 1
+				if (auditAttempts === 1) {
+					throw new Error('D1_ERROR: Network connection lost.')
+				}
+				return { 1: 1 }
+			},
+		}),
+	} as unknown as D1Database
+	const recovered = await collectHealthComponents(bindings)
+	expect(auditAttempts).toBe(2)
+	expect(recovered.ok).toBe(true)
+	expect(
+		recovered.components.find((component) => component.id === 'audit_db'),
+	).toMatchObject({ ok: true })
+
+	consoleWarn.mockImplementation(() => {})
+	let appAttempts = 0
+	const failingBindings = createHealthyBindings()
+	failingBindings.APP_DB = {
+		prepare: () => ({
+			first: async () => {
+				appAttempts += 1
+				throw new Error('no such table: users')
+			},
+		}),
+	} as unknown as D1Database
+	const failed = await collectHealthComponents(failingBindings)
+	expect(appAttempts).toBe(1)
+	expect(failed.ok).toBe(false)
+	expect(
+		failed.components.find((component) => component.id === 'app_db'),
+	).toMatchObject({ ok: false, error: 'error' })
+})
+
 test('health components handler memoizes, coalesces in-flight work, and returns 503 on failure', async () => {
 	let prepareCalls = 0
 	const bindings = createHealthyBindings()

--- a/packages/worker/src/app/handlers/health-components.ts
+++ b/packages/worker/src/app/handlers/health-components.ts
@@ -1,5 +1,6 @@
 import { type Action } from 'remix/router'
 import { type routes } from '#app/routes.ts'
+import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { type AppEnv } from '#worker/env-schema.ts'
 
 /**
@@ -12,6 +13,17 @@ import { type AppEnv } from '#worker/env-schema.ts'
 
 const componentCheckTimeoutMs = 3_000
 const resultCacheTtlMs = 10_000
+
+/**
+ * Transient D1 blips (SQLITE_BUSY, "Network connection lost", opaque
+ * "internal error; reference = …") are tolerated with retries on every
+ * production D1 path, so a single blip must not register as component
+ * downtime on the public status page — the mostly idle audit database was
+ * losing uptime to exactly these. Three attempts with the standard backoff
+ * (worst case ~450ms of sleep) stay well inside the 3s check timeout, so
+ * sustained unavailability still fails the check.
+ */
+const d1CheckRetryOptions = { maxAttempts: 3 } as const
 
 export const healthComponentIds = [
 	'app_db',
@@ -95,11 +107,23 @@ export async function collectHealthComponents(
 	const components = await Promise.all([
 		runComponentCheck(
 			'app_db',
-			appDb ? () => appDb.prepare('SELECT 1').first() : null,
+			appDb
+				? () =>
+						runD1WithRetry(
+							() => appDb.prepare('SELECT 1').first(),
+							d1CheckRetryOptions,
+						)
+				: null,
 		),
 		runComponentCheck(
 			'audit_db',
-			auditDb ? () => auditDb.prepare('SELECT 1').first() : null,
+			auditDb
+				? () =>
+						runD1WithRetry(
+							() => auditDb.prepare('SELECT 1').first(),
+							d1CheckRetryOptions,
+						)
+				: null,
 		),
 		runComponentCheck(
 			'kv',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[status.heykody.dev](https://status.heykody.dev/) shows the Audit database at 99.84% uptime over 90 days while every other component sits at 100%, with no incidents recorded. That pattern — roughly 200 failed one-minute samples spread over 90 days, never two in a row — is the signature of isolated transient failures, not outages.

## Investigation

- The status worker probes `GET /health/components` once per minute; the main worker answers by running a bare `SELECT 1` against each D1 binding with a 3s timeout and **no retry** (`packages/worker/src/app/handlers/health-components.ts`).
- The codebase already knows D1 emits transient, retryable blips — SQLITE_BUSY, `D1_ERROR: Network connection lost.`, and opaque `internal error; reference = …` platform faults. Every production D1 path tolerates them via `runD1WithRetry` (`packages/worker/src/d1-retry.ts`), and #930/#952/#953/#954 even drop them from Sentry as known platform noise. The health check was the one D1 caller without that tolerance.
- Each blip becomes one failed sample in the status store's daily uptime rollup. With the incident threshold at 2 consecutive failures, isolated blips dent the uptime number without ever opening an incident — exactly what the status page shows.
- Why only `audit_db`? `AUDIT_DB` is nearly idle: it only sees writes on auth events and an hourly retention prune, so the minutely health probe is frequently the first query against a cold/idle database, which is where transport blips concentrate. `APP_DB` is kept warm by constant app traffic.

## Fix

Wrap the two D1 component checks in `runD1WithRetry`, capped at 3 attempts (worst case ~450ms of backoff sleep) so retries stay well inside the existing 3s check timeout. Known-transient blips get absorbed the same way they are everywhere else; genuine sustained unavailability (or any non-retryable error) still fails the check, and the 3s timeout remains the backstop. KV and R2 checks are unchanged — there is no evidence of flakiness there.

## Testing

- New test: an `audit_db` check that throws `D1_ERROR: Network connection lost.` once and then succeeds reports the component healthy (2 attempts observed); a non-retryable `app_db` error still fails on the first attempt with `error: 'error'`.
- `npm run validate` passes end to end (544 test files / 1878 tests, e2e included).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `915b12af` · **Head:** `4aff239c`

**Classification:** extends — changes the behavior of the `/health/components` component checks (part of `app-ui`); no primitives added, no schema or route changes.

### Primitives touched

| Primitive     | Group    | Impact                                                                   |
| ------------- | -------- | ------------------------------------------------------------------------ |
| `app-ui`      | surfaces | extends — D1 health checks now retry known-transient D1 errors           |
| `d1-app-db`   | storage  | composes — probed via retried `SELECT 1` (unchanged binding)             |
| `audit-d1`    | storage  | composes — probed via retried `SELECT 1` (unchanged binding)             |
| `status-page` | surfaces | context — consumes `/health/components`; no code change in this PR       |

### System map

The status worker's minutely probe flows through the health handler into both D1 databases; this PR adds bounded retry on those two hops.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	statusPage["status-page<br/>Public status page"]:::untouched
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	auditD1["audit-d1<br/>Audit database"]:::touched
	statusPage -->|"GET /health/components (minutely probe)"| appUi
	appUi -->|"SELECT 1 via runD1WithRetry (3 attempts)"| d1AppDb
	appUi -->|"SELECT 1 via runD1WithRetry (3 attempts)"| auditD1
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d4bcd8e-7a5b-46c7-91b2-cd81d11c90a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d4bcd8e-7a5b-46c7-91b2-cd81d11c90a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

