### PR TITLE
feat(community): link public owners on package details

### DIFF
--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -82,6 +82,8 @@ show metadata, aggregate ratings, **star count** (stargazers — distinct from 1
 ratings), fork count, the README (not the full source tree), and a dynamically
 generated Open Graph image (1200×630). When the owner keeps a
 [public profile](./community-profiles.md), the listing links to `/@username`.
+Private owners still show as `@username` with a lock that explains the profile
+is private.
 
 Each detail page includes a **copyable prompt** you can hand to your agent to
 start a fork. You can also ask your agent to use `community_search` or

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -51,6 +51,7 @@ import { UserAvatar } from '#app/user-avatar.tsx'
 type CommunityDetailApiPayload = {
 	ok: true
 	listing: PublicCommunityListing
+	ownerProfilePublic: boolean
 	loggedIn: boolean
 	viewerIsAdmin: boolean
 	forkPrompt: string

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -24,7 +24,10 @@ import {
 	searchCommunityListings,
 	getCommunityListingWithAggregates,
 } from '#worker/community/service.ts'
-import { getCommunityStar } from '#worker/community/social-repo.ts'
+import {
+	getCommunityStar,
+	getUserSocialRowByUsername,
+} from '#worker/community/social-repo.ts'
 
 const defaultCommunityListLimit = 50
 const onboardingFeaturedListingLimit = 12
@@ -165,6 +168,12 @@ async function loadCommunityDetailDataUncached(
 
 	if (!listing) return null
 
+	const ownerRow = await getUserSocialRowByUsername(
+		env.APP_DB,
+		listing.ownerUsername,
+	)
+	const ownerProfilePublic = ownerRow?.profile_visibility === 'public'
+
 	const user = await readAuthenticatedAppUser(request, env)
 	const starredByViewer =
 		user != null
@@ -178,6 +187,7 @@ async function loadCommunityDetailDataUncached(
 		Boolean(user),
 		user?.roles.includes('admin') ?? false,
 		starredByViewer,
+		ownerProfilePublic,
 	)
 }
 
@@ -186,10 +196,12 @@ export function composeCommunityDetailLoaderData(
 	loggedIn: boolean,
 	viewerIsAdmin = false,
 	starredByViewer = false,
+	ownerProfilePublic = false,
 ): CommunityDetailLoaderData {
 	return {
 		ok: true,
 		listing,
+		ownerProfilePublic,
 		loggedIn,
 		viewerIsAdmin,
 		forkPrompt: buildForkPrompt({

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -17,6 +17,7 @@ import {
 	communityTagPillCss,
 } from '#app/community-listings-content.tsx'
 import { routes } from '#app/routes.ts'
+import { visuallyHiddenCss } from '#client/styles/style-primitives.ts'
 import { colors } from '#client/styles/tokens.ts'
 
 /**
@@ -31,12 +32,13 @@ import { colors } from '#client/styles/tokens.ts'
 
 export type CommunityDetailContentProps = {
 	listing: PublicCommunityListing
+	ownerProfilePublic: boolean
 }
 
 export function CommunityDetailContent(
 	handle: Handle<CommunityDetailContentProps>,
 ) {
-	const { listing } = handle.props
+	const { listing, ownerProfilePublic } = handle.props
 
 	return () => (
 		<div data-testid="community-detail-frame">
@@ -53,7 +55,47 @@ export function CommunityDetailContent(
 				<CommunityListingIcon listing={listing} size="detail" />
 				<div mix={css(headTextCss)}>
 					<h1>{renderCommunityListingName(listing.name)}</h1>
-					<p>by @{listing.ownerUsername}</p>
+					<p>
+						by{' '}
+						{ownerProfilePublic ? (
+							<a
+								href={routes.profile.href({
+									username: listing.ownerUsername,
+								})}
+								mix={css(ownerLinkCss)}
+							>
+								@{listing.ownerUsername}
+							</a>
+						) : (
+							<>
+								@{listing.ownerUsername}
+								<span
+									data-testid="community-detail-owner-private"
+									title="This profile is private"
+									mix={css(ownerPrivateLockCss)}
+								>
+									<svg
+										viewBox="0 0 16 16"
+										width="0.9em"
+										height="0.9em"
+										aria-hidden="true"
+										focusable={false}
+										fill="none"
+										stroke="currentColor"
+										strokeWidth="1.5"
+										strokeLinecap="round"
+										strokeLinejoin="round"
+									>
+										<rect x="3.5" y="7.2" width="9" height="6.3" rx="1.4" />
+										<path d="M5.4 7.2V5.4a2.6 2.6 0 0 1 5.2 0v1.8" />
+									</svg>
+									<span mix={css(visuallyHiddenCss)}>
+										This profile is private
+									</span>
+								</span>
+							</>
+						)}
+					</p>
 				</div>
 				{listing.trusted ? (
 					<span
@@ -178,6 +220,24 @@ const headTextCss = {
 		color: colors.textMuted,
 		fontSize: '0.95rem',
 	},
+}
+
+const ownerLinkCss = {
+	color: colors.textMuted,
+	fontWeight: 550,
+	textDecoration: 'none',
+	'&:hover': {
+		color: colors.primaryText,
+	},
+}
+
+const ownerPrivateLockCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	marginLeft: '0.35rem',
+	color: colors.textMuted,
+	verticalAlign: 'middle',
+	cursor: 'help',
 }
 
 const badgeCss = {

--- a/packages/worker/src/app/frames/community-detail.ts
+++ b/packages/worker/src/app/frames/community-detail.ts
@@ -18,6 +18,9 @@ registerFrame(COMMUNITY_DETAIL_TARGET, {
 		if (!detail) {
 			return ''
 		}
-		return renderCommunityDetailContentHtml({ listing: detail.listing })
+		return renderCommunityDetailContentHtml({
+			listing: detail.listing,
+			ownerProfilePublic: detail.ownerProfilePublic,
+		})
 	},
 })

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -83,7 +83,9 @@ test('community detail handler returns bare detail frame HTML for target header'
 	expect(publicHtml).toContain('/community/listing-1/icon/abc1234567890')
 	expect(publicHtml).toContain('href="/@kentcdodds"')
 	expect(publicHtml).toContain('>@kentcdodds</a>')
-	expect(publicHtml).not.toContain('data-testid="community-detail-owner-private"')
+	expect(publicHtml).not.toContain(
+		'data-testid="community-detail-owner-private"',
+	)
 	expect(publicHtml).toContain('data-testid="community-detail-forks"')
 	expect(publicHtml).not.toContain('<html')
 

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -5,6 +5,7 @@ import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
 const mockModule = vi.hoisted(() => ({
 	getCommunityListingWithAggregates: vi.fn(),
 	readAuthenticatedAppUser: vi.fn(),
+	getUserSocialRowByUsername: vi.fn(),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -22,6 +23,8 @@ vi.mock('#app/authenticated-user.ts', () => ({
 
 vi.mock('#worker/community/social-repo.ts', () => ({
 	getCommunityStar: vi.fn().mockResolvedValue(false),
+	getUserSocialRowByUsername: (...args: Array<unknown>) =>
+		mockModule.getUserSocialRowByUsername(...args),
 }))
 
 const sampleListing = {
@@ -59,22 +62,44 @@ const env = {} as Env
 test('community detail handler returns bare detail frame HTML for target header', async () => {
 	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	mockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+	})
 
 	const handler = createCommunityDetailHandler(env)
-	const response = await handler.handler({
+	const publicResponse = await handler.handler({
 		request: new Request('https://example.com/community/listing-1', {
 			headers: { 'x-remix-target': 'community-detail' },
 		}),
 		params: { listingId: 'listing-1' },
 		url: new URL('https://example.com/community/listing-1'),
 	} as never)
-	const html = await response.text()
+	const publicHtml = await publicResponse.text()
 
-	expect(response.status).toBe(200)
-	expect(response.headers.get('Cache-Control')).toBe('no-store')
-	expect(html).toContain('data-testid="community-detail-frame"')
-	expect(html).toContain('data-testid="community-listing-icon-detail"')
-	expect(html).toContain('/community/listing-1/icon/abc1234567890')
-	expect(html).toContain('data-testid="community-detail-forks"')
-	expect(html).not.toContain('<html')
+	expect(publicResponse.status).toBe(200)
+	expect(publicResponse.headers.get('Cache-Control')).toBe('no-store')
+	expect(publicHtml).toContain('data-testid="community-detail-frame"')
+	expect(publicHtml).toContain('data-testid="community-listing-icon-detail"')
+	expect(publicHtml).toContain('/community/listing-1/icon/abc1234567890')
+	expect(publicHtml).toContain('href="/@kentcdodds"')
+	expect(publicHtml).toContain('>@kentcdodds</a>')
+	expect(publicHtml).not.toContain('data-testid="community-detail-owner-private"')
+	expect(publicHtml).toContain('data-testid="community-detail-forks"')
+	expect(publicHtml).not.toContain('<html')
+
+	mockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'private',
+	})
+	const privateResponse = await handler.handler({
+		request: new Request('https://example.com/community/listing-1', {
+			headers: { 'x-remix-target': 'community-detail' },
+		}),
+		params: { listingId: 'listing-1' },
+		url: new URL('https://example.com/community/listing-1'),
+	} as never)
+	const privateHtml = await privateResponse.text()
+	expect(privateHtml).toContain('by @kentcdodds')
+	expect(privateHtml).toContain('data-testid="community-detail-owner-private"')
+	expect(privateHtml).toContain('title="This profile is private"')
+	expect(privateHtml).not.toContain('href="/@kentcdodds"')
 })

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -50,6 +50,8 @@ export type CommunityIndexLoaderData = {
 export type CommunityDetailLoaderData = {
 	ok: true
 	listing: PublicCommunityListing
+	/** True when `/@owner` is publicly reachable. */
+	ownerProfilePublic: boolean
 	loggedIn: boolean
 	viewerIsAdmin: boolean
 	forkPrompt: string

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -45,9 +45,8 @@ vi.mock('#worker/community/service.ts', () => ({
 }))
 
 vi.mock('#worker/community/social-repo.ts', async (importOriginal) => {
-	const actual = await importOriginal<
-		typeof import('#worker/community/social-repo.ts')
-	>()
+	const actual =
+		await importOriginal<typeof import('#worker/community/social-repo.ts')>()
 	return {
 		...actual,
 		getCommunityStar: vi.fn().mockResolvedValue(false),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -30,6 +30,7 @@ const communityMockModule = vi.hoisted(() => ({
 	listCommunityListingsWithAggregates: vi.fn(),
 	searchCommunityListings: vi.fn(),
 	getCommunityListingWithAggregates: vi.fn(),
+	getUserSocialRowByUsername: vi.fn(),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -42,6 +43,18 @@ vi.mock('#worker/community/service.ts', () => ({
 	reportCommunityListing: vi.fn(),
 	listFeaturedCommunityListingsWithAggregates: vi.fn(async () => []),
 }))
+
+vi.mock('#worker/community/social-repo.ts', async (importOriginal) => {
+	const actual = await importOriginal<
+		typeof import('#worker/community/social-repo.ts')
+	>()
+	return {
+		...actual,
+		getCommunityStar: vi.fn().mockResolvedValue(false),
+		getUserSocialRowByUsername: (...args: Array<unknown>) =>
+			communityMockModule.getUserSocialRowByUsername(...args),
+	}
+})
 
 const sampleListing = {
 	id: 'listing-1',
@@ -621,6 +634,9 @@ test('community detail SSR renders the redesigned article', async () => {
 	communityMockModule.getCommunityListingWithAggregates.mockResolvedValue(
 		detailListing,
 	)
+	communityMockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+	})
 
 	const response = await createCommunityDetailHandler(env).handler({
 		request: new Request('https://example.com/community/listing-detail-1'),
@@ -637,7 +653,10 @@ test('community detail SSR renders the redesigned article', async () => {
 	expect(html).toContain('data-testid="community-listing-icon-detail"')
 	expect(html).toContain('/community/listing-detail-1/icon/abc1234567890')
 	expect(html).toContain('@kentcdodds/<wbr />github-triage')
-	expect(html).toContain('by @kentcdodds')
+	expect(html).toContain('by ')
+	expect(html).toContain('href="/@kentcdodds"')
+	expect(html).toContain('>@kentcdodds</a>')
+	expect(html).not.toContain('data-testid="community-detail-owner-private"')
 	expect(html).toContain('data-testid="community-detail-trusted-badge"')
 	expect(html).toContain('License')
 	expect(html).toContain('MIT')

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -262,6 +262,22 @@ test('community package flow works end-to-end through capability handlers', asyn
 	)
 	expect(getResult.readme_untrusted).toContain('## Intent')
 	expect(getResult.content_warning).toBe(communityContentWarning)
+	expect(getResult.owner_username).toBe('usera')
+	expect(getResult.owner_profile_url).toBe(`${baseUrl}/@usera`)
+
+	await runSql(
+		`UPDATE users SET profile_visibility = 'private' WHERE stable_user_id = ?`,
+		owner.userId,
+	)
+	const privateOwnerGet = await communityGetCapability.handler(
+		{ listing_id: listingId },
+		forkerCtx,
+	)
+	expect(privateOwnerGet.owner_profile_url).toBeNull()
+	await runSql(
+		`UPDATE users SET profile_visibility = 'public' WHERE stable_user_id = ?`,
+		owner.userId,
+	)
 
 	const forkResult = await communityForkCapability.handler(
 		{ listing_id: listingId },

--- a/packages/worker/src/community/social-service.ts
+++ b/packages/worker/src/community/social-service.ts
@@ -177,6 +177,9 @@ export async function updateCommunityProfile(input: {
 		numericUserId: input.numericUserId,
 		...patch,
 	})
+	if (patch.visibility !== undefined) {
+		invalidateCommunityPublicCache()
+	}
 }
 
 export async function followCommunityUser(input: {

--- a/packages/worker/src/community/social-service.workers.test.ts
+++ b/packages/worker/src/community/social-service.workers.test.ts
@@ -1,5 +1,9 @@
 import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
+import {
+	getCommunityPublicCacheVersion,
+	resetDataCacheForTests,
+} from '#app/data-cache.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { CommunityActionError } from './errors.ts'
 import { ensureCommunityFlowSchema } from './community-flow-test-schema.ts'
@@ -421,6 +425,8 @@ test('updateCommunityProfile validates display name and bio bounds', async () =>
 		}),
 	).rejects.toThrow(/Bio must be at most 500/)
 
+	resetDataCacheForTests()
+	const versionBeforeVisibilityChange = getCommunityPublicCacheVersion()
 	await updateCommunityProfile({
 		env,
 		numericUserId: user.numericId,
@@ -428,6 +434,9 @@ test('updateCommunityProfile validates display name and bio bounds', async () =>
 		bio: '  Hello world  ',
 		visibility: 'private',
 	})
+	expect(getCommunityPublicCacheVersion()).toBe(
+		versionBeforeVisibilityChange + 1,
+	)
 	const profile = await getCommunityProfileByUsername({
 		env,
 		username: user.username,
@@ -439,13 +448,21 @@ test('updateCommunityProfile validates display name and bio bounds', async () =>
 		visibility: 'private',
 	})
 
+	const versionBeforePublicRestore = getCommunityPublicCacheVersion()
 	await updateCommunityProfile({
 		env,
 		numericUserId: user.numericId,
 		displayName: '   ',
 		bio: '',
+	})
+	expect(getCommunityPublicCacheVersion()).toBe(versionBeforePublicRestore)
+
+	await updateCommunityProfile({
+		env,
+		numericUserId: user.numericId,
 		visibility: 'public',
 	})
+	expect(getCommunityPublicCacheVersion()).toBe(versionBeforePublicRestore + 1)
 	const cleared = await getCommunityProfileByUsername({
 		env,
 		username: user.username,

--- a/packages/worker/src/mcp/capabilities/community/get.ts
+++ b/packages/worker/src/mcp/capabilities/community/get.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { buildUserAvatarUrl } from '#worker/community/public-urls.ts'
 import { getCommunityListingWithAggregates } from '#worker/community/service.ts'
+import { getUserSocialRowByUsername } from '#worker/community/social-repo.ts'
 import { listCommunityStargazersForListing } from '#worker/community/social-service.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
@@ -56,7 +57,7 @@ export const communityGetCapability = defineDomainCapability(
 			trusted: communityTrustedFieldSchema,
 			featured: communityFeaturedFieldSchema,
 			owner_username: z.string(),
-			owner_profile_url: z.string(),
+			owner_profile_url: z.string().nullable(),
 			public_url: z.string(),
 			published_at: z.string(),
 			readme_untrusted: z.string().nullable(),
@@ -79,6 +80,11 @@ export const communityGetCapability = defineDomainCapability(
 				throw new Error('Community listing not found.')
 			}
 			const ownerUsername = resolveCommunityOwnerUsername(listing.name)
+			const ownerRow = await getUserSocialRowByUsername(
+				ctx.env.APP_DB,
+				ownerUsername,
+			)
+			const ownerProfilePublic = ownerRow?.profile_visibility === 'public'
 			const { totalStars, stargazers } =
 				await listCommunityStargazersForListing({
 					env: ctx.env,
@@ -97,10 +103,9 @@ export const communityGetCapability = defineDomainCapability(
 				trusted: listing.trusted,
 				featured: listing.featured,
 				owner_username: ownerUsername,
-				owner_profile_url: buildCommunityOwnerProfileUrl(
-					baseUrl,
-					ownerUsername,
-				),
+				owner_profile_url: ownerProfilePublic
+					? buildCommunityOwnerProfileUrl(baseUrl, ownerUsername)
+					: null,
 				public_url: buildCommunityPublicUrl(baseUrl, listing.id),
 				published_at: listing.publishedAt,
 				...toCommunityListingAggregatesOutput(listing),

--- a/packages/worker/src/mcp/capabilities/community/social-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/community/social-capabilities.node.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
 	getProfileActivity: vi.fn(),
 	listPublicProfilePackages: vi.fn(),
 	getUserSocialRowByStableId: vi.fn(),
+	getUserSocialRowByUsername: vi.fn(),
 	getCommunityListingWithAggregates: vi.fn(),
 }))
 
@@ -56,6 +57,8 @@ vi.mock('#worker/community/social-service.ts', () => ({
 vi.mock('#worker/community/social-repo.ts', () => ({
 	getUserSocialRowByStableId: (...args: Array<unknown>) =>
 		mocks.getUserSocialRowByStableId(...args),
+	getUserSocialRowByUsername: (...args: Array<unknown>) =>
+		mocks.getUserSocialRowByUsername(...args),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -349,6 +352,9 @@ test('community star/unstar, starred_list, timeline, and listing stargazers', as
 		],
 	})
 	mocks.getCommunityListingWithAggregates.mockResolvedValue(makeListing())
+	mocks.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+	})
 	mocks.listStarredCommunityListings.mockResolvedValue([makeListing()])
 	mocks.getCommunityTimeline.mockResolvedValue([makeActivity()])
 
@@ -380,11 +386,22 @@ test('community star/unstar, starred_list, timeline, and listing stargazers', as
 	expect(detail).toMatchObject({
 		listing_id: 'listing-1',
 		star_count: 3,
+		owner_username: 'bob',
+		owner_profile_url: 'https://example.com/@bob',
 		stargazers: {
 			total_stars: 4,
 			recent_stargazers: [{ username: 'alice' }],
 		},
 	})
+
+	mocks.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'private',
+	})
+	const privateDetail = await communityGetCapability.handler(
+		{ listing_id: 'listing-1' },
+		createContext(),
+	)
+	expect(privateDetail.owner_profile_url).toBeNull()
 
 	const starredList = await communityStarredListCapability.handler(
 		{},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Community package details should make it obvious whether the listing owner has a public profile, without linking into a private `/@username` page that 404s.

## Summary

- On `/community/:listingId`, public owners' `@username` links to `/@username`.
- Private owners still show `@username`, plus a lock with a “This profile is private” tooltip (and visually hidden text).
- `community_get.owner_profile_url` is now `null` when the owner profile is private.
- Changing profile visibility invalidates the community public cache so detail SSR does not keep a stale link/lock state.

## Testing

- Focused node tests for community detail SSR/frame and `community_get`.
- Focused workers tests for community flow + profile update cache invalidation.
- Full `npm run validate`: format was the only local failure (fixed and pushed); lint, typecheck, unit, e2e, mcp, and remaining gates passed.

## System changes

See the system recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `915b12af` · **Head:** `a1772e85`

**Classification:** extends — listing detail and `community_get` now consult profile visibility, and visibility updates invalidate the public community cache.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — community detail frame links public owners and shows a lock for private ones |
| `community-listings` | assistant | extends — `community_get.owner_profile_url` is nullable for private owners |
| `community-social` | assistant | extends — visibility updates invalidate community public cache |

### System map

Community detail SSR and `community_get` look up owner profile visibility, then either link to `/@username` or withhold that public profile surface.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	communityListings["community-listings<br/>Community package listings"]:::extended
	communitySocial["community-social<br/>Community profiles and social graph"]:::extended
	appUi -->|"detail frame owner link or lock"| communitySocial
	communityListings -->|"community_get owner_profile_url"| communitySocial
	communitySocial -->|"visibility change invalidates public cache"| communityListings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Browser
	participant DetailFrame
	participant SocialRepo
	participant CommunityGet
	Browser->>DetailFrame: GET /community/:listingId
	DetailFrame->>SocialRepo: getUserSocialRowByUsername(owner)
	alt profile public
		DetailFrame-->>Browser: link to /@username
	else profile private
		DetailFrame-->>Browser: @username + lock tooltip
	end
	CommunityGet->>SocialRepo: getUserSocialRowByUsername(owner)
	alt profile public
		CommunityGet-->>CommunityGet: owner_profile_url
	else profile private
		CommunityGet-->>CommunityGet: owner_profile_url = null
	end
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Detail author line | plain `by @username` | public → `/@username` link; private → lock + tooltip |
| `community_get.owner_profile_url` | always `/@username` | `null` when private |
| Profile visibility update | no community cache invalidation | invalidates public community cache |

### Invariants

- `community-social-privacy`: private profiles stay off public social surfaces. The listing still shows the scoped `@username` (already public via the package name) but does not link to `/@username`.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af042b6b-0be1-46c7-838f-10defbac1ccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af042b6b-0be1-46c7-838f-10defbac1ccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community owners with public profiles now appear as clickable profile links.
  * Private owners remain visible by username with a lock indicator and accessible privacy label.
  * Community details now omit profile links for private owners across supported integrations.
* **Bug Fixes**
  * Profile visibility changes now refresh public community data promptly.
* **Documentation**
  * Updated community package documentation to explain private-owner display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->