### PR TITLE
Codemod run lifecycle hygiene: heartbeat, failed/abandoned statuses, stale reconciliation, admin attribution

### DIFF
--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -201,6 +201,26 @@ step matched zero packages.
 Per-package failures are **isolated**; one package error does not abort sibling
 items in the same run step.
 
+### Run lifecycle
+
+Runs are created as `running` and end `completed` only when a caller pages until
+`nextCursor` is null. The other transitions keep the ledger honest when paging
+stops early:
+
+- **Heartbeat** — every step re-asserts `running` and bumps the run's
+  `updated_at`, so `updated_at` doubles as a liveness signal. Continuing a
+  `failed` or `abandoned` run reopens it.
+- **`failed`** — written when a step throws at the run level (paging, ledger
+  writes); per-item failures never fail the run.
+- **`abandoned`** — written when the admin UI stops a run (stop button, step
+  ceiling, stuck cursor) via `POST /admin/codemods/run/stop.json`, or by lazy
+  reconciliation: loading the admin history marks `running` runs whose heartbeat
+  is older than one hour. There is no scheduled sweeper; abandoned callers
+  (closed tabs, agents that stopped paging) are caught on the next history load.
+
+Abandoned and failed **apply** runs can still hold `applied` items; revert
+accepts them (the admin UI only blocks revert while a run is `running`).
+
 ### Safety rails
 
 - **`skipped_unpublished`** — packages with no published commit are skipped.
@@ -231,7 +251,8 @@ not in the ledger tables.
 
 **`package_codemod_runs`:** `id`, `codemod_id`, `mode`, `scope_user_id` (`NULL`
 for fleet runs), `initiated_by_user_id`, `filters_json`, `status` (`running` |
-`completed` | `failed`), `revert_of_run_id`, `created_at`, `updated_at`.
+`completed` | `failed` | `abandoned`), `revert_of_run_id`, `created_at`,
+`updated_at`.
 
 **`package_codemod_run_items`:** `id`, `run_id`, `user_id`, `package_id`,
 `kody_id`, `status`, `before_commit`, `after_commit`, `changed_paths_json`,

--- a/packages/worker/client/routes/admin-codemods.tsx
+++ b/packages/worker/client/routes/admin-codemods.tsx
@@ -55,6 +55,7 @@ type LiveRunItem = {
 
 const adminCodemodsApiPath = '/admin/codemods.json'
 const adminCodemodsRunApiPath = '/admin/codemods/run.json'
+const adminCodemodsRunStopApiPath = '/admin/codemods/run/stop.json'
 const maxRunSteps = 200
 
 const runModes = [
@@ -313,6 +314,25 @@ export function AdminCodemodsRoute(handle: Handle) {
 		return body
 	}
 
+	// Best-effort: without this, a run whose paging loop stops client-side
+	// (stop button, step ceiling, stuck cursor) stays `running` in the ledger
+	// forever. Server-side stale reconciliation is the fallback.
+	async function markRunStopped(runId: string) {
+		try {
+			await fetch(adminCodemodsRunStopApiPath, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({ runId }),
+			})
+		} catch {
+			// The stale-run sweep on the next history load covers this.
+		}
+	}
+
 	async function postRunStep(body: Record<string, unknown>) {
 		const response = await fetch(adminCodemodsRunApiPath, {
 			method: 'POST',
@@ -364,6 +384,7 @@ export function AdminCodemodsRoute(handle: Handle) {
 		try {
 			for (;;) {
 				if (stopRequested) {
+					if (runId) await markRunStopped(runId)
 					runPhase = 'complete'
 					message = `Stopped ${input.mode} for ${input.codemodId}${liveRunId ? ` (run ${liveRunId})` : ''} after ${stepCount} step(s).`
 					messageTone = 'info'
@@ -372,6 +393,7 @@ export function AdminCodemodsRoute(handle: Handle) {
 					return
 				}
 				if (stepCount >= maxRunSteps) {
+					if (runId) await markRunStopped(runId)
 					runPhase = 'error'
 					message = `Stopped after ${maxRunSteps} steps without completing. Resume later with the same run id if needed.`
 					messageTone = 'error'
@@ -418,6 +440,7 @@ export function AdminCodemodsRoute(handle: Handle) {
 					previousCursor !== undefined &&
 					previousCursor === step.nextCursor
 				) {
+					if (runId) await markRunStopped(runId)
 					runPhase = 'error'
 					message = `Codemod run stopped: cursor did not advance (${step.nextCursor}).`
 					messageTone = 'error'
@@ -712,7 +735,7 @@ export function AdminCodemodsRoute(handle: Handle) {
 											name="revertOfRunId"
 											type="text"
 											required
-											placeholder="completed apply run id"
+											placeholder="prior apply run id"
 											value={revertOfRunId}
 											disabled={!canMutate}
 											mix={[
@@ -880,10 +903,12 @@ export function AdminCodemodsRoute(handle: Handle) {
 										<thead>
 											<tr>
 												<th mix={css(cellCss)}>Created</th>
+												<th mix={css(cellCss)}>Run</th>
 												<th mix={css(cellCss)}>Codemod</th>
 												<th mix={css(cellCss)}>Mode</th>
 												<th mix={css(cellCss)}>Status</th>
 												<th mix={css(cellCss)}>Scope</th>
+												<th mix={css(cellCss)}>Initiated by</th>
 												<th mix={css(cellCss)}>Actions</th>
 											</tr>
 										</thead>
@@ -892,12 +917,25 @@ export function AdminCodemodsRoute(handle: Handle) {
 												const revertConfirmActive =
 													pendingConfirmKey ===
 													getConfirmKey('revert-history', run.id)
+												// Abandoned and failed apply runs can hold applied
+												// items too; only an actively-paging run is off
+												// limits for revert.
 												const canRevert =
-													run.mode === 'apply' && run.status === 'completed'
+													run.mode === 'apply' && run.status !== 'running'
 												return (
 													<tr key={run.id}>
 														<td mix={css(cellCss)}>
 															{formatNullableTimestamp(run.createdAt)}
+														</td>
+														<td mix={css(cellCss)}>
+															<code
+																title={run.id}
+																mix={css({
+																	fontSize: typography.fontSize.sm,
+																})}
+															>
+																{run.id.slice(0, 8)}
+															</code>
 														</td>
 														<td mix={css(cellCss)}>
 															<code
@@ -913,6 +951,7 @@ export function AdminCodemodsRoute(handle: Handle) {
 														<td mix={css(cellCss)}>
 															{run.scopeUserId ?? 'fleet'}
 														</td>
+														<td mix={css(cellCss)}>{run.initiatedByUserId}</td>
 														<td mix={css(cellCss)}>
 															<div
 																mix={css({

--- a/packages/worker/src/app/handlers/admin-codemods.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-codemods.node.test.ts
@@ -456,6 +456,7 @@ test('admin codemods stop POST requires admin and marks running runs abandoned',
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(
 		createAdminActor(['admin']),
 	)
+	mockModule.updatePackageCodemodRunStatus.mockResolvedValue(1)
 	const missingRunId = await handler.handler(createStopRequest({}))
 	expect(missingRunId.status).toBe(400)
 
@@ -493,7 +494,7 @@ test('admin codemods stop POST requires admin and marks running runs abandoned',
 	})
 	expect(mockModule.updatePackageCodemodRunStatus).toHaveBeenCalledWith(
 		env.APP_DB,
-		{ id: 'run-1', status: 'abandoned' },
+		{ id: 'run-1', status: 'abandoned', expectedStatus: 'running' },
 	)
 	expect(logAuditEventSpy).toHaveBeenCalledWith(
 		expect.objectContaining({
@@ -506,4 +507,20 @@ test('admin codemods stop POST requires admin and marks running runs abandoned',
 				'run_id=run-1;codemod_id=0001-ambient-storage-to-package-storage;mode=scan',
 		}),
 	)
+
+	// Race: the run completed between the read and the conditional write; the
+	// stop endpoint reports the winning status instead of overwriting it.
+	logAuditEventSpy.mockClear()
+	mockModule.updatePackageCodemodRunStatus.mockResolvedValue(0)
+	mockModule.getPackageCodemodRunById
+		.mockResolvedValueOnce({ ...sampleRun, status: 'running' })
+		.mockResolvedValueOnce({ ...sampleRun, status: 'completed' })
+	const lostRace = await handler.handler(createStopRequest({ runId: 'run-1' }))
+	expect(lostRace.status).toBe(200)
+	await expect(lostRace.json()).resolves.toEqual({
+		ok: true,
+		runId: 'run-1',
+		status: 'completed',
+	})
+	expect(logAuditEventSpy).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/app/handlers/admin-codemods.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-codemods.node.test.ts
@@ -15,6 +15,8 @@ const mockModule = vi.hoisted(() => ({
 	listPackageCodemodRuns: vi.fn(),
 	listPackageCodemodRunItems: vi.fn(),
 	getPackageCodemodRunById: vi.fn(),
+	markAbandonedPackageCodemodRuns: vi.fn(),
+	updatePackageCodemodRunStatus: vi.fn(),
 	runPackageCodemodStep: vi.fn(),
 }))
 
@@ -47,6 +49,10 @@ vi.mock('#worker/package-codemods/ledger.ts', () => ({
 		mockModule.listPackageCodemodRunItems(...args),
 	getPackageCodemodRunById: (...args: Array<unknown>) =>
 		mockModule.getPackageCodemodRunById(...args),
+	markAbandonedPackageCodemodRuns: (...args: Array<unknown>) =>
+		mockModule.markAbandonedPackageCodemodRuns(...args),
+	updatePackageCodemodRunStatus: (...args: Array<unknown>) =>
+		mockModule.updatePackageCodemodRunStatus(...args),
 }))
 
 vi.mock('#worker/package-codemods/engine.ts', () => ({
@@ -86,8 +92,11 @@ function createTestEnv() {
 	} as unknown as Env
 }
 
-const { createAdminCodemodsApiHandler, createAdminCodemodsRunApiHandler } =
-	await import('./admin-codemods.ts')
+const {
+	createAdminCodemodsApiHandler,
+	createAdminCodemodsRunApiHandler,
+	createAdminCodemodsRunStopApiHandler,
+} = await import('./admin-codemods.ts')
 
 function createGetRequest(search = '') {
 	const url = new URL(`https://example.com/admin/codemods.json${search}`)
@@ -103,6 +112,22 @@ function createGetRequest(search = '') {
 
 function createRunRequest(body: unknown) {
 	const url = new URL('https://example.com/admin/codemods/run.json')
+	return {
+		request: new Request(url, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(body),
+		}),
+		params: {},
+		url,
+	} as never
+}
+
+function createStopRequest(body: unknown) {
+	const url = new URL('https://example.com/admin/codemods/run/stop.json')
 	return {
 		request: new Request(url, {
 			method: 'POST',
@@ -164,6 +189,7 @@ test('admin codemods GET requires admin and returns codemods plus recent runs', 
 		},
 	])
 	mockModule.listPackageCodemodRuns.mockResolvedValue([sampleRun])
+	mockModule.markAbandonedPackageCodemodRuns.mockResolvedValue(0)
 
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
 	const unauthorized = await handler.handler(createGetRequest())
@@ -193,6 +219,14 @@ test('admin codemods GET requires admin and returns codemods plus recent runs', 
 	expect(mockModule.listPackageCodemodRuns).toHaveBeenCalledWith(env.APP_DB, {
 		limit: 50,
 	})
+	const reconcileCall =
+		mockModule.markAbandonedPackageCodemodRuns.mock.calls.at(-1) as
+			| [unknown, { updatedBefore: string }]
+			| undefined
+	expect(reconcileCall?.[0]).toBe(env.APP_DB)
+	const cutoffMs = Date.parse(reconcileCall![1].updatedBefore)
+	expect(Date.now() - cutoffMs).toBeGreaterThanOrEqual(60 * 60 * 1000 - 1)
+	expect(Date.now() - cutoffMs).toBeLessThan(2 * 60 * 60 * 1000)
 })
 
 test('admin codemods GET with runId returns paged run items', async () => {
@@ -398,4 +432,78 @@ test('admin codemods run POST rejects invalid requests and allows omitted filter
 	)?.[0] as { filters?: unknown } | undefined
 	expect(omittedCall).toBeDefined()
 	expect(omittedCall).not.toHaveProperty('filters')
+})
+
+test('admin codemods stop POST requires admin and marks running runs abandoned', async () => {
+	const env = createTestEnv()
+	const handler = createAdminCodemodsRunStopApiHandler(env)
+	logAuditEventSpy.mockClear()
+	mockModule.updatePackageCodemodRunStatus.mockClear()
+	mockModule.updatePackageCodemodRunStatus.mockResolvedValue(undefined)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	const unauthorized = await handler.handler(
+		createStopRequest({ runId: 'run-1' }),
+	)
+	expect(unauthorized.status).toBe(401)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['user']),
+	)
+	const forbidden = await handler.handler(createStopRequest({ runId: 'run-1' }))
+	expect(forbidden.status).toBe(403)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(
+		createAdminActor(['admin']),
+	)
+	const missingRunId = await handler.handler(createStopRequest({}))
+	expect(missingRunId.status).toBe(400)
+
+	mockModule.getPackageCodemodRunById.mockResolvedValue(null)
+	const notFound = await handler.handler(
+		createStopRequest({ runId: 'run-missing' }),
+	)
+	expect(notFound.status).toBe(404)
+
+	mockModule.getPackageCodemodRunById.mockResolvedValue({
+		...sampleRun,
+		status: 'completed',
+	})
+	const alreadyTerminal = await handler.handler(
+		createStopRequest({ runId: 'run-1' }),
+	)
+	expect(alreadyTerminal.status).toBe(200)
+	await expect(alreadyTerminal.json()).resolves.toEqual({
+		ok: true,
+		runId: 'run-1',
+		status: 'completed',
+	})
+	expect(mockModule.updatePackageCodemodRunStatus).not.toHaveBeenCalled()
+
+	mockModule.getPackageCodemodRunById.mockResolvedValue({
+		...sampleRun,
+		status: 'running',
+	})
+	const stopped = await handler.handler(createStopRequest({ runId: 'run-1' }))
+	expect(stopped.status).toBe(200)
+	await expect(stopped.json()).resolves.toEqual({
+		ok: true,
+		runId: 'run-1',
+		status: 'abandoned',
+	})
+	expect(mockModule.updatePackageCodemodRunStatus).toHaveBeenCalledWith(
+		env.APP_DB,
+		{ id: 'run-1', status: 'abandoned' },
+	)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'admin',
+			action: 'package_codemod_run_stop',
+			result: 'success',
+			email: 'admin@example.com',
+			path: '/admin/codemods/run/stop.json',
+			reason:
+				'run_id=run-1;codemod_id=0001-ambient-storage-to-package-storage;mode=scan',
+		}),
+	)
 })

--- a/packages/worker/src/app/handlers/admin-codemods.ts
+++ b/packages/worker/src/app/handlers/admin-codemods.ts
@@ -242,10 +242,21 @@ export function createAdminCodemodsRunStopApiHandler(env: Env) {
 				if (run.status !== 'running') {
 					return jsonResponse({ ok: true, runId, status: run.status })
 				}
-				await updatePackageCodemodRunStatus(env.APP_DB, {
+				// Conditional on the row still being `running` so a concurrent
+				// engine step that just completed the run is not overwritten.
+				const changed = await updatePackageCodemodRunStatus(env.APP_DB, {
 					id: runId,
 					status: 'abandoned',
+					expectedStatus: 'running',
 				})
+				if (changed === 0) {
+					const current = await getPackageCodemodRunById(env.APP_DB, runId)
+					return jsonResponse({
+						ok: true,
+						runId,
+						status: current?.status ?? run.status,
+					})
+				}
 				const requestIp = getRequestIp(request) ?? undefined
 				void logAuditEvent({
 					category: 'admin',

--- a/packages/worker/src/app/handlers/admin-codemods.ts
+++ b/packages/worker/src/app/handlers/admin-codemods.ts
@@ -23,6 +23,8 @@ import {
 	getPackageCodemodRunById,
 	listPackageCodemodRunItems,
 	listPackageCodemodRuns,
+	markAbandonedPackageCodemodRuns,
+	updatePackageCodemodRunStatus,
 } from '#worker/package-codemods/ledger.ts'
 import {
 	getPackageCodemodById,
@@ -33,6 +35,10 @@ import { readPositiveInt } from '#worker/query-params.ts'
 const recentRunsLimit = 50
 const defaultRunItemsLimit = 50
 const maxRunItemsLimit = 200
+// Every engine step re-asserts `running` (heartbeat), and a step is a single
+// Workers request, so a `running` run untouched for this long has no caller
+// paging it anymore.
+const staleRunningRunThresholdMs = 60 * 60 * 1000
 
 const packageCodemodRunModes = [
 	'scan',
@@ -44,6 +50,14 @@ const packageCodemodRunModes = [
 export async function loadAdminCodemodsData(
 	env: Env,
 ): Promise<AdminCodemodsLoaderData> {
+	// Lazy reconciliation instead of a scheduled sweeper: viewing the admin
+	// history is the moment stale `running` rows would mislead, so mark them
+	// `abandoned` right before listing.
+	await markAbandonedPackageCodemodRuns(env.APP_DB, {
+		updatedBefore: new Date(
+			Date.now() - staleRunningRunThresholdMs,
+		).toISOString(),
+	})
 	const [codemods, runs] = await Promise.all([
 		Promise.resolve(listPackageCodemods()),
 		listPackageCodemodRuns(env.APP_DB, { limit: recentRunsLimit }),
@@ -193,6 +207,62 @@ export function createAdminCodemodsRunApiHandler(env: Env) {
 			}
 		},
 	} satisfies Action<typeof routes.adminCodemodsRunApi>
+}
+
+export function createAdminCodemodsRunStopApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, url }) {
+			try {
+				if (request.method !== 'POST') {
+					return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+				}
+				const actor = await requireUserWithRole(request, env, 'admin')
+				const body = await request.json().catch(() => null)
+				if (!body || typeof body !== 'object') {
+					return jsonResponse(
+						{ ok: false, error: 'Invalid request body.' },
+						400,
+					)
+				}
+				const runId = readNonEmptyTrimmedString(body, 'runId')
+				if (!runId) {
+					return jsonResponse({ ok: false, error: 'runId is required.' }, 400)
+				}
+				const run = await getPackageCodemodRunById(env.APP_DB, runId)
+				if (!run) {
+					return jsonResponse(
+						{
+							ok: false,
+							error: `Package codemod run "${runId}" was not found.`,
+						},
+						404,
+					)
+				}
+				if (run.status !== 'running') {
+					return jsonResponse({ ok: true, runId, status: run.status })
+				}
+				await updatePackageCodemodRunStatus(env.APP_DB, {
+					id: runId,
+					status: 'abandoned',
+				})
+				const requestIp = getRequestIp(request) ?? undefined
+				void logAuditEvent({
+					category: 'admin',
+					action: 'package_codemod_run_stop',
+					result: 'success',
+					email: actor.email,
+					ip: requestIp,
+					path: url.pathname,
+					reason: `run_id=${runId};codemod_id=${run.codemodId};mode=${run.mode}`,
+				})
+				return jsonResponse({ ok: true, runId, status: 'abandoned' })
+			} catch (error) {
+				if (error instanceof Response) return error
+				throw error
+			}
+		},
+	} satisfies Action<typeof routes.adminCodemodsRunStopApi>
 }
 
 type ParseRunBodyResult =

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -225,7 +225,7 @@ export type AdminCodemodRunListItem = {
 	scopeUserId: string | null
 	initiatedByUserId: string
 	filtersJson: string
-	status: 'running' | 'completed' | 'failed'
+	status: 'running' | 'completed' | 'failed' | 'abandoned'
 	revertOfRunId: string | null
 	createdAt: string
 	updatedAt: string

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -21,6 +21,7 @@ import {
 	createAdminCodemodsApiHandler,
 	createAdminCodemodsHandler,
 	createAdminCodemodsRunApiHandler,
+	createAdminCodemodsRunStopApiHandler,
 } from '#app/handlers/admin-codemods.ts'
 import {
 	createAdminRolesApiHandler,
@@ -332,6 +333,7 @@ export function createAppRouter(env: Env) {
 			adminCodemods: createAdminCodemodsHandler(env),
 			adminCodemodsApi: createAdminCodemodsApiHandler(env),
 			adminCodemodsRunApi: createAdminCodemodsRunApiHandler(env),
+			adminCodemodsRunStopApi: createAdminCodemodsRunStopApiHandler(env),
 			adminRoles: createAdminRolesHandler(env),
 			adminRolesApi: createAdminRolesApiHandler(env),
 			adminCommunityReports: createAdminCommunityReportsHandler(env),

--- a/packages/worker/src/app/routes.ts
+++ b/packages/worker/src/app/routes.ts
@@ -97,6 +97,7 @@ export const routes = route({
 	adminCodemods: '/admin/codemods',
 	adminCodemodsApi: '/admin/codemods.json',
 	adminCodemodsRunApi: post('/admin/codemods/run.json'),
+	adminCodemodsRunStopApi: post('/admin/codemods/run/stop.json'),
 	adminCommunityReports: '/admin/community-reports',
 	adminCommunityReportsApi: '/admin/community-reports.json',
 	adminCommunityReportsApiPost: post('/admin/community-reports.json'),

--- a/packages/worker/src/package-codemods/engine.node.test.ts
+++ b/packages/worker/src/package-codemods/engine.node.test.ts
@@ -9,6 +9,7 @@ import {
 	getPackageCodemodRunItemById,
 	insertPackageCodemodRunItem,
 	listPackageCodemodRunItems,
+	listPackageCodemodRuns,
 	packageCodemodLedgerTextBounds,
 } from './ledger.ts'
 
@@ -1168,6 +1169,83 @@ test('package codemod fleet revert applies packageIds filters and leaves others 
 	expect(
 		await getPackageCodemodRunItemById(env.APP_DB, 'item-pkg-keep-b'),
 	).toMatchObject({ status: 'applied' })
+})
+
+test('package codemod step-level throw marks the run failed instead of leaving it running', async () => {
+	resetMocks()
+	const { env } = createEnv()
+	mocks.listSavedPackagesPage.mockRejectedValue(new Error('paging boom'))
+
+	await expect(
+		runPackageCodemodStep({
+			env,
+			baseUrl: 'https://example.com',
+			initiatedByUserId: 'admin-1',
+			codemodId,
+			mode: 'scan',
+			scope: { kind: 'fleet' },
+			limit: 5,
+		}),
+	).rejects.toThrow('paging boom')
+
+	// The step threw before returning a runId, so look the run up directly.
+	const runs = await listPackageCodemodRuns(env.APP_DB, { limit: 10 })
+	expect(runs).toHaveLength(1)
+	expect(runs[0]).toMatchObject({ status: 'failed' })
+})
+
+test('package codemod continuation steps heartbeat the run and reopen abandoned runs', async () => {
+	resetMocks()
+	const { env } = createEnv()
+	const pkgA = savedPackage({
+		id: 'hb-a',
+		userId: 'user-1',
+		kodyId: 'hb-a',
+		sourceId: 'source-hb-a',
+	})
+	const pkgB = savedPackage({
+		id: 'hb-b',
+		userId: 'user-1',
+		kodyId: 'hb-b',
+		sourceId: 'source-hb-b',
+	})
+	mocks.listSavedPackagesByUserId.mockResolvedValue([pkgA, pkgB])
+	mocks.loadPackageSourceBySourceId.mockImplementation(
+		async (input: { sourceId: string; userId: string }) =>
+			loadedSource({
+				files: cleanFiles(),
+				publishedCommit: `commit-${input.sourceId}`,
+				repoId: input.sourceId,
+				sourceId: input.sourceId,
+				userId: input.userId,
+			}),
+	)
+
+	await createPackageCodemodRun(env.APP_DB, {
+		id: 'run-heartbeat',
+		codemodId,
+		mode: 'scan',
+		scopeUserId: 'user-1',
+		initiatedByUserId: 'admin-1',
+		status: 'abandoned',
+		createdAt: '2026-07-30T10:00:00.000Z',
+		updatedAt: '2026-07-30T10:00:00.000Z',
+	})
+
+	const step = await runPackageCodemodStep({
+		env,
+		baseUrl: 'https://example.com',
+		initiatedByUserId: 'admin-1',
+		codemodId,
+		mode: 'scan',
+		scope: { kind: 'user', userId: 'user-1' },
+		runId: 'run-heartbeat',
+		limit: 1,
+	})
+	expect(step.nextCursor).not.toBeNull()
+	const reopened = await getPackageCodemodRunById(env.APP_DB, 'run-heartbeat')
+	expect(reopened).toMatchObject({ status: 'running' })
+	expect(reopened!.updatedAt > '2026-07-30T10:00:00.000Z').toBe(true)
 })
 
 test('package codemod step rejects a cursor without a runId', async () => {

--- a/packages/worker/src/package-codemods/engine.ts
+++ b/packages/worker/src/package-codemods/engine.ts
@@ -351,6 +351,17 @@ async function ensureRun(input: {
 				`Package codemod run "${input.runId}" filters do not match the requested filters.`,
 			)
 		}
+		if (existing.status !== 'completed') {
+			// Heartbeat: every continuation step re-asserts `running` and bumps
+			// `updated_at`, so stale-run reconciliation only marks runs nobody is
+			// paging. This also reopens runs previously marked failed or
+			// abandoned when a caller resumes them.
+			await updatePackageCodemodRunStatus(input.env.APP_DB, {
+				id: existing.id,
+				status: 'running',
+			})
+			return { ...existing, status: 'running' }
+		}
 		return existing
 	}
 	return await createPackageCodemodRun(input.env.APP_DB, {
@@ -1177,69 +1188,86 @@ export async function runPackageCodemodStep(input: {
 		filters: input.filters,
 		revertOfRunId: input.revertOfRunId,
 	})
-	const subscriptionCache = createPackageCodemodSubscriptionCache()
-	if (input.mode === 'revert') {
-		return await processRevertStep({
-			env: input.env,
-			baseUrl: input.baseUrl,
-			codemod,
-			run,
-			scope: input.scope,
-			cursor: input.cursor ?? null,
-			limit,
-			waitUntil: input.waitUntil,
-			subscriptionCache,
-		})
-	}
-
-	const { packages, nextCursor } = await listCandidatePackages({
-		env: input.env,
-		scope: input.scope,
-		filters: input.filters,
-		cursor: input.cursor ?? null,
-		limit,
-	})
-	const items: Array<PackageCodemodRunItemResult> = []
-	const summary: Partial<Record<PackageCodemodItemStatus, number>> = {}
-	for (const savedPackage of packages) {
-		let result: PersistedItemResult
-		try {
-			result = await processPackageForMode({
+	try {
+		const subscriptionCache = createPackageCodemodSubscriptionCache()
+		if (input.mode === 'revert') {
+			return await processRevertStep({
 				env: input.env,
 				baseUrl: input.baseUrl,
-				mode: input.mode,
 				codemod,
-				savedPackage,
-				runId: run.id,
+				run,
+				scope: input.scope,
+				cursor: input.cursor ?? null,
+				limit,
 				waitUntil: input.waitUntil,
 				subscriptionCache,
 			})
-		} catch (error) {
-			result = emptyItemResult({
-				itemId: crypto.randomUUID(),
-				userId: savedPackage.userId,
-				packageId: savedPackage.id,
-				kodyId: savedPackage.kodyId,
-				status: 'failed',
-				error: getErrorMessage(error),
+		}
+
+		const { packages, nextCursor } = await listCandidatePackages({
+			env: input.env,
+			scope: input.scope,
+			filters: input.filters,
+			cursor: input.cursor ?? null,
+			limit,
+		})
+		const items: Array<PackageCodemodRunItemResult> = []
+		const summary: Partial<Record<PackageCodemodItemStatus, number>> = {}
+		for (const savedPackage of packages) {
+			let result: PersistedItemResult
+			try {
+				result = await processPackageForMode({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					mode: input.mode,
+					codemod,
+					savedPackage,
+					runId: run.id,
+					waitUntil: input.waitUntil,
+					subscriptionCache,
+				})
+			} catch (error) {
+				result = emptyItemResult({
+					itemId: crypto.randomUUID(),
+					userId: savedPackage.userId,
+					packageId: savedPackage.id,
+					kodyId: savedPackage.kodyId,
+					status: 'failed',
+					error: getErrorMessage(error),
+				})
+			}
+			await persistItem(input.env, result, run.id)
+			items.push(toPublicItem(result))
+			incrementSummary(summary, result.status)
+		}
+		if (nextCursor == null) {
+			await updatePackageCodemodRunStatus(input.env.APP_DB, {
+				id: run.id,
+				status: 'completed',
 			})
 		}
-		await persistItem(input.env, result, run.id)
-		items.push(toPublicItem(result))
-		incrementSummary(summary, result.status)
-	}
-	if (nextCursor == null) {
-		await updatePackageCodemodRunStatus(input.env.APP_DB, {
-			id: run.id,
-			status: 'completed',
-		})
-	}
-	return {
-		runId: run.id,
-		codemodId: input.codemodId,
-		mode: input.mode,
-		items,
-		nextCursor,
-		summary,
+		return {
+			runId: run.id,
+			codemodId: input.codemodId,
+			mode: input.mode,
+			items,
+			nextCursor,
+			summary,
+		}
+	} catch (error) {
+		// Per-package failures are isolated above; only step-level failures
+		// (paging, ledger writes, unexpected throws) reach here. Without this
+		// the run would sit in `running` forever, since the caller never gets
+		// a cursor back to continue with. A later continuation step reopens
+		// the run via the ensureRun heartbeat.
+		try {
+			await updatePackageCodemodRunStatus(input.env.APP_DB, {
+				id: run.id,
+				status: 'failed',
+			})
+		} catch {
+			// Best-effort: surface the original step error, not the status write.
+		}
+		throw error
 	}
 }

--- a/packages/worker/src/package-codemods/ledger.node.test.ts
+++ b/packages/worker/src/package-codemods/ledger.node.test.ts
@@ -9,6 +9,7 @@ import {
 	insertPackageCodemodRunItem,
 	listPackageCodemodRunItems,
 	listPackageCodemodRuns,
+	markAbandonedPackageCodemodRuns,
 	updatePackageCodemodRunStatus,
 } from './ledger.ts'
 
@@ -164,4 +165,66 @@ test('package codemod ledger pages runs and items with filters', async () => {
 	expect(
 		await getPackageCodemodRunItemById(db, 'item-1', { userId: 'user-2' }),
 	).toBeNull()
+})
+
+test('package codemod ledger marks only stale running runs abandoned', async () => {
+	const { db } = createLedgerDb()
+
+	await createPackageCodemodRun(db, {
+		id: 'run-stale-running',
+		codemodId: '0001-ambient-storage-to-package-storage',
+		mode: 'scan',
+		scopeUserId: null,
+		initiatedByUserId: 'admin-1',
+		createdAt: '2026-07-30T10:00:00.000Z',
+		updatedAt: '2026-07-30T10:00:00.000Z',
+	})
+	await createPackageCodemodRun(db, {
+		id: 'run-fresh-running',
+		codemodId: '0001-ambient-storage-to-package-storage',
+		mode: 'scan',
+		scopeUserId: null,
+		initiatedByUserId: 'admin-1',
+		createdAt: '2026-07-30T10:00:00.000Z',
+		updatedAt: '2026-07-30T12:30:00.000Z',
+	})
+	await createPackageCodemodRun(db, {
+		id: 'run-stale-completed',
+		codemodId: '0001-ambient-storage-to-package-storage',
+		mode: 'apply',
+		scopeUserId: null,
+		initiatedByUserId: 'admin-1',
+		status: 'completed',
+		createdAt: '2026-07-30T10:00:00.000Z',
+		updatedAt: '2026-07-30T10:00:00.000Z',
+	})
+
+	const marked = await markAbandonedPackageCodemodRuns(db, {
+		updatedBefore: '2026-07-30T12:00:00.000Z',
+		updatedAt: '2026-07-30T13:00:00.000Z',
+	})
+	expect(marked).toBe(1)
+	expect(await getPackageCodemodRunById(db, 'run-stale-running')).toMatchObject(
+		{
+			status: 'abandoned',
+			updatedAt: '2026-07-30T13:00:00.000Z',
+		},
+	)
+	expect(await getPackageCodemodRunById(db, 'run-fresh-running')).toMatchObject(
+		{
+			status: 'running',
+			updatedAt: '2026-07-30T12:30:00.000Z',
+		},
+	)
+	expect(
+		await getPackageCodemodRunById(db, 'run-stale-completed'),
+	).toMatchObject({
+		status: 'completed',
+		updatedAt: '2026-07-30T10:00:00.000Z',
+	})
+
+	const noneLeft = await markAbandonedPackageCodemodRuns(db, {
+		updatedBefore: '2026-07-30T12:00:00.000Z',
+	})
+	expect(noneLeft).toBe(0)
 })

--- a/packages/worker/src/package-codemods/ledger.node.test.ts
+++ b/packages/worker/src/package-codemods/ledger.node.test.ts
@@ -227,4 +227,25 @@ test('package codemod ledger marks only stale running runs abandoned', async () 
 		updatedBefore: '2026-07-30T12:00:00.000Z',
 	})
 	expect(noneLeft).toBe(0)
+
+	// Conditional status write: a run that already left `running` is not
+	// overwritten when the caller expected `running`.
+	const missedRace = await updatePackageCodemodRunStatus(db, {
+		id: 'run-stale-completed',
+		status: 'abandoned',
+		expectedStatus: 'running',
+	})
+	expect(missedRace).toBe(0)
+	expect(
+		await getPackageCodemodRunById(db, 'run-stale-completed'),
+	).toMatchObject({ status: 'completed' })
+	const wonRace = await updatePackageCodemodRunStatus(db, {
+		id: 'run-fresh-running',
+		status: 'abandoned',
+		expectedStatus: 'running',
+	})
+	expect(wonRace).toBe(1)
+	expect(await getPackageCodemodRunById(db, 'run-fresh-running')).toMatchObject(
+		{ status: 'abandoned' },
+	)
 })

--- a/packages/worker/src/package-codemods/ledger.ts
+++ b/packages/worker/src/package-codemods/ledger.ts
@@ -5,7 +5,11 @@ import {
 } from '@kody-internal/shared/backup-restore-safety.ts'
 import { type PackageCodemodFinding } from './types.ts'
 
-export type PackageCodemodRunStatus = 'running' | 'completed' | 'failed'
+export type PackageCodemodRunStatus =
+	| 'running'
+	| 'completed'
+	| 'failed'
+	| 'abandoned'
 
 export type PackageCodemodRunRecord = {
 	id: string
@@ -124,7 +128,10 @@ function mapRunRow(row: Record<string, unknown>): PackageCodemodRunRecord {
 		initiatedByUserId: String(row['initiated_by_user_id']),
 		filtersJson: String(row['filters_json'] ?? '{}'),
 		status:
-			status === 'completed' || status === 'failed' || status === 'running'
+			status === 'completed' ||
+			status === 'failed' ||
+			status === 'running' ||
+			status === 'abandoned'
 				? status
 				: 'failed',
 		revertOfRunId:
@@ -238,6 +245,31 @@ export async function updatePackageCodemodRunStatus(
 		)
 		.bind(input.status, updatedAt, input.id)
 		.run()
+}
+
+/**
+ * Mark `running` runs whose heartbeat (`updated_at`) predates the cutoff as
+ * `abandoned`. Completion only happens when a caller pages to the end, so
+ * runs whose caller stopped paging (closed tab, stopped agent) otherwise sit
+ * in `running` forever. Returns the number of runs marked.
+ */
+export async function markAbandonedPackageCodemodRuns(
+	db: D1Database,
+	input: {
+		updatedBefore: string
+		updatedAt?: string
+	},
+): Promise<number> {
+	const updatedAt = input.updatedAt ?? new Date().toISOString()
+	const result = await db
+		.prepare(
+			`UPDATE package_codemod_runs
+			SET status = 'abandoned', updated_at = ?
+			WHERE status = 'running' AND updated_at < ?`,
+		)
+		.bind(updatedAt, input.updatedBefore)
+		.run()
+	return result.meta.changes ?? 0
 }
 
 export async function getPackageCodemodRunById(

--- a/packages/worker/src/package-codemods/ledger.ts
+++ b/packages/worker/src/package-codemods/ledger.ts
@@ -228,23 +228,34 @@ export async function createPackageCodemodRun(
 	}
 }
 
+/**
+ * Set a run's status. When `expectedStatus` is given the write only applies
+ * while the row still has that status, so a read-check-write caller (e.g. the
+ * admin stop endpoint) cannot overwrite a concurrent transition. Returns the
+ * number of rows changed.
+ */
 export async function updatePackageCodemodRunStatus(
 	db: D1Database,
 	input: {
 		id: string
 		status: PackageCodemodRunStatus
+		expectedStatus?: PackageCodemodRunStatus
 		updatedAt?: string
 	},
-) {
+): Promise<number> {
 	const updatedAt = input.updatedAt ?? new Date().toISOString()
-	await db
+	const statusCondition = input.expectedStatus != null ? ' AND status = ?' : ''
+	const params: Array<unknown> = [input.status, updatedAt, input.id]
+	if (input.expectedStatus != null) params.push(input.expectedStatus)
+	const result = await db
 		.prepare(
 			`UPDATE package_codemod_runs
 			SET status = ?, updated_at = ?
-			WHERE id = ?`,
+			WHERE id = ?${statusCondition}`,
 		)
-		.bind(input.status, updatedAt, input.id)
+		.bind(...params)
 		.run()
+	return result.meta.changes ?? 0
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the `/admin/codemods` history showing runs stuck in `running` forever and makes agent/user-initiated runs attributable at a glance.

## Background

The admin history was full of `running` runs nobody remembered triggering. Investigation: they were legitimate — fleet scans run by agents during the codemod rollout program (e.g. the #1048 gate-evidence scan promised in #1056) plus self-scoped `package_codemod_*` MCP runs — but the ledger had no way to leave `running` unless a caller paged to the end:

- Run-level `failed` existed in the type but was never written; a step-level throw left the run `running` forever.
- The admin UI's Stop button, 200-step ceiling, and stuck-cursor bail-out all stopped paging client-side without touching the ledger.
- There was no watchdog or reconciliation, and the history table showed neither run ids nor who initiated a run.

## What this changes

**Engine (`packages/worker/src/package-codemods/engine.ts`)**

- Step-level throws after run creation now mark the run `failed` (best-effort, original error still propagates). Per-item failures remain isolated and never fail the run.
- Every continuation step re-asserts `running` and bumps `updated_at`, making `updated_at` a liveness heartbeat. This also reopens `failed`/`abandoned` runs when a caller resumes paging (statuses are liveness bookkeeping, not enforcement — runs stay resumable by design).

**Ledger (`packages/worker/src/package-codemods/ledger.ts`)**

- New run status `abandoned` (no migration needed; the column is TEXT).
- New `markAbandonedPackageCodemodRuns` — marks `running` runs whose heartbeat predates a cutoff as `abandoned`.
- `updatePackageCodemodRunStatus` gains an optional `expectedStatus` guard (conditional SQL transition) and returns the changed-row count.

**Admin surface (`packages/worker/src/app/handlers/admin-codemods.ts`, `client/routes/admin-codemods.tsx`)**

- Lazy stale-run reconciliation: loading the admin history first marks `running` runs with a heartbeat older than 1 hour as `abandoned` — no cron/sweeper needed, and it cleans up the existing stuck production rows on the first page view after deploy.
- New audit-logged `POST /admin/codemods/run/stop.json`: the Stop button, step ceiling, and stuck-cursor paths now mark the run `abandoned` server-side instead of silently leaving it `running`. The transition is conditional on the run still being `running`, so a concurrently completed run is never overwritten.
- Run history gains **Run** (short id, full id on hover) and **Initiated by** columns, so future "who ran this?" questions answer themselves.
- Revert is now offered for any non-`running` apply run (abandoned/failed apply runs can hold `applied` items too; the engine and MCP revert already accepted them, and per-item drift checks plus DO-serialized publishes bound interleaving).

**Docs:** `docs/contributing/package-codemods.md` gains a "Run lifecycle" section and the updated status union.

## Testing

- New node tests: stale-marking boundary conditions and conditional status transitions (ledger), step-throw → `failed` and heartbeat/reopen (engine), reconciliation call + stop endpoint auth/idempotency/race/audit (handler). 17 tests green in the three touched suites.
- Full `npm run validate` green locally; ✅ Validate green in CI on the final head (`31128427218`) after the GitHub Actions outage cleared enough to run.
- Manual demo on a seeded local dev server: stale `running` fixture rows (mirroring the stuck production runs) flip to `abandoned` on the first admin page load, fresh `running` and `completed` rows untouched, new Run/Initiated-by columns with full-id tooltip.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `915b12af` · **Head:** `1631ee99`

**Classification:** extends — the `package-codemods` run-status contract gains `abandoned`, a heartbeat, and terminal transitions; no new primitives.

### Primitives touched

| Primitive          | Group     | Impact                                                                 |
| ------------------ | --------- | ---------------------------------------------------------------------- |
| `package-codemods` | assistant | extends — run status union + heartbeat + failed/abandoned transitions |
| `app-ui`           | surfaces  | extends — new stop route/endpoint, history columns, revert gating     |
| `rbac`             | auth      | composes — stop endpoint reuses `requireUserWithRole('admin')` + audit |
| `d1-app-db`        | storage   | composes — status/`updated_at` writes to existing ledger tables       |

### System map

Stop and stale-reconciliation flow from the admin UI through the codemod ledger; the engine writes `failed` and heartbeats on its own steps.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	rbac["rbac<br/>Role-based access control"]:::touched
	packageCodemods["package-codemods<br/>Package codemods"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::touched
	appUi -->|"POST /admin/codemods/run/stop.json (audit-logged, conditional on running)"| packageCodemods
	appUi -->|"requireUserWithRole('admin')"| rbac
	appUi -->|"GET /admin/codemods.json marks stale running runs abandoned"| packageCodemods
	packageCodemods -->|"heartbeat + failed/abandoned on package_codemod_runs"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
Before: run status running | completed | failed; 'failed' never written;
        completion only when a caller paged to nextCursor == null; stops,
        crashes, and abandoned agents left runs 'running' forever; history
        showed no run id or initiator.
After:  running | completed | failed | abandoned; step throws write 'failed';
        steps heartbeat updated_at and reopen resumed runs; admin stop
        endpoint (conditional transition) + 1h lazy stale reconciliation
        write 'abandoned'; history shows run id + initiated-by; revert
        allowed for non-running applies.
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3cdb292-837c-4c02-b858-35960e2a9648?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3cdb292-837c-4c02-b858-35960e2a9648&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to stop active codemod runs from the admin interface.
  - Stale runs are automatically marked as abandoned after approximately one hour.
  - Run history now shows abandoned statuses, shortened run IDs, and initiating user IDs.
  - Abandoned and failed runs can be reverted.

- **Bug Fixes**
  - Codemod step failures now correctly mark runs as failed.
  - Continued runs refresh their activity timestamp and can resume abandoned runs.

- **Documentation**
  - Documented run lifecycle states, stop behavior, reconciliation, and revert support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->