### PR TITLE
Add AI-placeholder callout to every blog post

### DIFF
--- a/packages/worker/client/routes/blog-post.tsx
+++ b/packages/worker/client/routes/blog-post.tsx
@@ -1,5 +1,9 @@
 import { type Handle, type RemixNode, css } from 'remix/ui'
-import { BLOG_AUTHOR_NAME, formatBlogPostDate } from '#app/blog-display.ts'
+import {
+	BLOG_AUTHOR_NAME,
+	BLOG_PLACEHOLDER_CALLOUT,
+	formatBlogPostDate,
+} from '#app/blog-display.ts'
 import { type BlogPostLoaderData } from '#app/loader-data.ts'
 import { routes } from '#app/routes.ts'
 import { renderMarkdownNodes } from '#client/markdown-view.tsx'
@@ -13,7 +17,12 @@ import {
 } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
-import { colors, transitions, typography } from '#client/styles/tokens.ts'
+import {
+	colors,
+	radius,
+	transitions,
+	typography,
+} from '#client/styles/tokens.ts'
 import {
 	getPillButtonCss,
 	pageHeadCss,
@@ -23,10 +32,11 @@ import {
 /**
  * Blog post, ported from the redesign prototype (`landing/blog-post.html`).
  * A 43rem editorial measure: back link → post head (display title + meta,
- * page-open rise) → `.prose` body rendered from the server's markdown
- * catalog → quiet foot (read-next pointer + Kody greeting + waitlist
- * button). Nothing here hardcodes post content — body, dates, and the
- * read-next pointer all come from the blog API.
+ * page-open rise) → AI-placeholder callout → `.prose` body rendered from
+ * the server's markdown catalog → quiet foot (read-next pointer + Kody
+ * greeting + waitlist button). Nothing here hardcodes post content — body,
+ * dates, and the read-next pointer all come from the blog API. The
+ * placeholder callout is template chrome until Kent rewrites each post.
  */
 
 export function getSlugFromPathname(pathname: string) {
@@ -233,6 +243,15 @@ export function BlogPostRoute(handle: Handle) {
 							</p>
 						</header>
 
+						<aside
+							data-rise
+							style={{ '--rise': '3' }}
+							mix={css(placeholderCalloutCss)}
+							role="note"
+						>
+							<p>{BLOG_PLACEHOLDER_CALLOUT}</p>
+						</aside>
+
 						<div mix={css(proseCss)}>{renderPostBody(post.body)}</div>
 
 						<footer mix={css(postFootCss)}>
@@ -332,6 +351,22 @@ const postStatusCss = {
 	margin: 'clamp(1.8rem, 4vw, 2.5rem) 0 0',
 	color: colors.textMuted,
 	fontSize: '0.98rem',
+}
+
+const placeholderCalloutCss = {
+	marginTop: 'clamp(1.4rem, 3vw, 2rem)',
+	padding: '1rem 1.15rem',
+	border: `1.5px solid ${colors.border}`,
+	borderRadius: radius.card,
+	backgroundColor: colors.surface,
+	'& p': {
+		margin: 0,
+		color: colors.textMuted,
+		fontSize: '0.95rem',
+		lineHeight: 1.5,
+		maxWidth: '62ch',
+		textWrap: 'pretty' as const,
+	},
 }
 
 /* ---------- post foot: read next + the standing invitation ---------- */

--- a/packages/worker/src/app/blog-display.ts
+++ b/packages/worker/src/app/blog-display.ts
@@ -21,3 +21,6 @@ export function formatBlogPostDate(date: string) {
 }
 
 export const BLOG_AUTHOR_NAME = 'Kent C. Dodds'
+
+export const BLOG_PLACEHOLDER_CALLOUT =
+	"This post is a placeholder and was written by AI. It's probably still useful, but if you're reading this it's because Kent hasn't yet gotten the chance to come back around and write it himself. Feel free to ping him and remind him he still needs to write the blog posts."

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -20,7 +20,10 @@ import {
 	listBlogPosts,
 	toBlogPostSummary,
 } from '#worker/blog/catalog.ts'
-import { formatBlogPostDate } from '#app/blog-display.ts'
+import {
+	BLOG_PLACEHOLDER_CALLOUT,
+	formatBlogPostDate,
+} from '#app/blog-display.ts'
 import { resetDataCacheForTests } from '#app/data-cache.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 
@@ -704,6 +707,7 @@ test('renderAppPage renders the redesigned blog post', async () => {
 	expect(html).toContain(post!.title)
 	expect(html).toContain('Kent C. Dodds')
 	expect(html).toContain(formatBlogPostDate(post!.date))
+	expect(html).toContain(BLOG_PLACEHOLDER_CALLOUT)
 	// Markdown body renders in the prose voice: authored `##` stays h2 (not
 	// the README demotion to h4) and first-party links skip the ugc rel.
 	expect(html).toMatch(/<h2[^>]*>/)


### PR DESCRIPTION
## Summary

- Show a quiet callout at the top of every public blog post so readers know the current posts are AI-written placeholders until Kent rewrites them.
- Keep the copy in shared blog-display chrome rather than duplicating it across every markdown file.

## Test plan

- [x] `npx vitest run packages/worker/src/app/ssr-render.node.test.ts --project node-unit`
- [ ] Confirm a live `/blog/:slug` page shows the callout under the title/meta and above the prose body
- [ ] Confirm the blog index and RSS feed are unchanged

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `a6c03420` · **Head:** `1cf65447`

**Classification:** extends — blog post pages gain shared AI-placeholder chrome; no new primitive and no API/storage contract change.

### Primitives touched

| Primitive | Group    | Impact                                                                  |
| --------- | -------- | ----------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — blog post template renders a shared placeholder callout above the markdown body |

### System map

Public blog posts still load through the existing Remix blog route; this PR only adds template chrome on the post page.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appUi -->|"blog post template callout"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	visit["GET /blog/:slug"] --> head["Title + author + date"]
	head --> callout["AI placeholder callout"]
	callout --> body["Markdown prose"]
	body --> foot["Read next + waitlist CTA"]
```

### Before / after

**Before:** post head immediately followed by markdown body.

**After:** post head → shared placeholder callout → markdown body.

</details>

<!-- system-recap:end -->
Made with [Cursor](https://cursor.com)
