### PR TITLE
Tighten profile package cards and set site tab-size to 2

### DIFF
--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -1,4 +1,5 @@
 import { type Handle, css, on } from 'remix/ui'
+import { adminGrantDiffersFromSubscription } from '#app/account-plan-display.ts'
 import {
 	type AccountBillingLoaderData,
 	type AdminPlanName,
@@ -34,6 +35,7 @@ import {
 	getGhostButtonCss,
 	getPillButtonCss,
 	layoutMaxWidths,
+	mutedLinkCss,
 	primaryLinkCss,
 } from '#client/styles/style-primitives.ts'
 
@@ -351,19 +353,21 @@ export function AccountBillingRoute(handle: Handle) {
 		const showManageCta = Boolean(
 			billing?.configured && billing.hasStripeCustomer,
 		)
-		const currentPlanItems =
-			billing && billing.manualPlan !== billing.stripePlan
-				? [
-						{
-							label: 'Granted plan',
-							value: formatPlanLabel(billing.manualPlan, 'Free'),
-						},
-						{
-							label: 'Subscription plan',
-							value: formatPlanLabel(billing.stripePlan, 'None'),
-						},
-					]
-				: []
+		const planSourcesDiffer =
+			billing != null &&
+			adminGrantDiffersFromSubscription(billing.manualPlan, billing.stripePlan)
+		const currentPlanItems = planSourcesDiffer
+			? [
+					{
+						label: 'Granted plan',
+						value: formatPlanLabel(billing.manualPlan, 'Free'),
+					},
+					{
+						label: 'Subscription plan',
+						value: formatPlanLabel(billing.stripePlan, 'None'),
+					},
+				]
+			: []
 
 		return (
 			<AccountManagementShell maxWidth={layoutMaxWidths.content}>
@@ -411,16 +415,13 @@ export function AccountBillingRoute(handle: Handle) {
 							</AccountManagementMessage>
 						) : null}
 
-						<AccountManagementPanel
-							title="Current plan"
-							description="Your effective plan is the higher of any admin grant and your Stripe subscription."
-						>
+						<AccountManagementPanel title="Current plan">
 							<div
 								mix={css({
 									display: 'flex',
 									flexWrap: 'wrap',
-									alignItems: 'center',
-									gap: spacing.sm,
+									alignItems: 'baseline',
+									gap: `${spacing.sm} ${spacing.md}`,
 								})}
 							>
 								<p
@@ -438,12 +439,21 @@ export function AccountBillingRoute(handle: Handle) {
 										{statusInfo.label}
 									</span>
 								) : null}
+								<a href={billing.usageHref} mix={css(mutedLinkCss)}>
+									view usage
+								</a>
 							</div>
 							{statusInfo && statusInfo.tone !== 'action' ? (
 								<p mix={css(descriptionCss)}>{statusInfo.detail}</p>
 							) : null}
 							{currentPlanItems.length > 0 ? (
-								<MetadataGrid items={currentPlanItems} />
+								<>
+									<p mix={css(descriptionCss)}>
+										Your effective plan is the higher of any admin grant and
+										your Stripe subscription.
+									</p>
+									<MetadataGrid items={currentPlanItems} />
+								</>
 							) : null}
 							{billing.cancelAt ? (
 								<p mix={css(descriptionCss)}>
@@ -451,26 +461,21 @@ export function AccountBillingRoute(handle: Handle) {
 									{formatCancelDate(billing.cancelAt)}.
 								</p>
 							) : null}
-							<p mix={css(descriptionCss)}>
-								Upgrades and payment changes apply after Stripe confirms them
-								(usually within a few seconds via webhooks). Refresh this page
-								if the plan looks stale.
-							</p>
 						</AccountManagementPanel>
 
-						<AccountManagementPanel
-							title="Actions"
-							description="Open the Stripe portal or check entitlement use."
-						>
-							<div
-								mix={css({
-									display: 'flex',
-									flexWrap: 'wrap',
-									gap: spacing.sm,
-									alignItems: 'center',
-								})}
+						{showManageCta ? (
+							<AccountManagementPanel
+								title="Actions"
+								description="Open the Stripe portal for payment methods, invoices, and cancellation."
 							>
-								{showManageCta ? (
+								<div
+									mix={css({
+										display: 'flex',
+										flexWrap: 'wrap',
+										gap: spacing.sm,
+										alignItems: 'center',
+									})}
+								>
 									<a
 										href={billingPortalPath}
 										mix={css({
@@ -484,20 +489,9 @@ export function AccountBillingRoute(handle: Handle) {
 									>
 										Manage subscription
 									</a>
-								) : null}
-								<a
-									href={billing.usageHref}
-									mix={css({
-										...secondaryButtonCss,
-										display: 'inline-block',
-										textDecoration: 'none',
-										textAlign: 'center',
-									})}
-								>
-									View usage
-								</a>
-							</div>
-						</AccountManagementPanel>
+								</div>
+							</AccountManagementPanel>
+						) : null}
 
 						<AccountManagementPanel
 							title="Plans"

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -1,4 +1,5 @@
 import { type Handle, css } from 'remix/ui'
+import { adminGrantDiffersFromSubscription } from '#app/account-plan-display.ts'
 import {
 	type AccountUsageEntitlementConsumption,
 	type AccountUsageLoaderData,
@@ -252,20 +253,44 @@ export function AccountUsageRoute(handle: Handle) {
 				) : null}
 				{usage ? (
 					<>
-						<AccountManagementPanel
-							title="Plan"
-							description="Effective plan after combining any granted plan with your Stripe subscription."
-						>
-							<MetadataGrid
-								items={[
-									{
-										label: 'Effective plan',
-										value: formatPlanLabel(usage.plan),
-									},
-									{ label: 'Usage day (UTC)', value: usage.today },
-								]}
-							/>
-							<p mix={css({ margin: `${spacing.sm} 0 0` })}>
+						<AccountManagementPanel title="Plan">
+							<p
+								mix={css({
+									margin: 0,
+									fontSize: typography.fontSize.lg,
+									fontWeight: typography.fontWeight.semibold,
+									color: colors.text,
+								})}
+							>
+								Current plan: {formatPlanLabel(usage.plan)}
+							</p>
+							{adminGrantDiffersFromSubscription(
+								usage.manualPlan,
+								usage.stripePlan,
+							) ? (
+								<>
+									<p mix={css(descriptionCss)}>
+										Your effective plan is the higher of any admin grant and
+										your Stripe subscription.
+									</p>
+									<MetadataGrid
+										items={[
+											{
+												label: 'Granted plan',
+												value: formatPlanLabel(usage.manualPlan),
+											},
+											{
+												label: 'Subscription plan',
+												value: usage.stripePlan
+													? formatPlanLabel(usage.stripePlan)
+													: 'None',
+											},
+										]}
+									/>
+								</>
+							) : null}
+							<p mix={css(descriptionCss)}>Usage day (UTC): {usage.today}</p>
+							<p mix={css({ margin: 0 })}>
 								<a href={billingPath} mix={css(primaryLinkCss)}>
 									Manage billing
 								</a>

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -474,6 +474,16 @@ const tabPanelCss = {
 		borderRadius: '6px',
 		padding: '0.1em 0.4em',
 	},
+	// Snippet wells render Shiki as `<pre><code>`. Without this reset the
+	// inline-code chip above paints a gray pill around every wrapped line.
+	'& pre code': {
+		font: 'inherit',
+		color: 'inherit',
+		backgroundColor: 'transparent',
+		border: 'none',
+		borderRadius: 0,
+		padding: 0,
+	},
 	// Enters via @starting-style so a fast host-switch retargets the
 	// in-flight transition instead of restarting keyframes from zero.
 	'@media (prefers-reduced-motion: no-preference)': {
@@ -543,6 +553,14 @@ const snippetPreCss = {
 		wordBreak: 'break-word' as const,
 		backgroundColor: 'transparent',
 		overflow: 'visible' as const,
+	},
+	'& pre code': {
+		font: 'inherit',
+		color: 'inherit',
+		backgroundColor: 'transparent',
+		border: 'none',
+		borderRadius: 0,
+		padding: 0,
 	},
 }
 

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -118,6 +118,9 @@
 	--color-danger-hover-dark: oklch(0.7 0.17 25);
 	--color-on-danger-dark: oklch(0.2 0.05 25);
 
+	/* Tab stops in code and other preformatted text. Browsers default to 8. */
+	tab-size: 2;
+
 	/* Typography */
 	--font-display: 'Bricolage Grotesque', system-ui, sans-serif;
 	--font-body: 'Wix Madefor Text', system-ui, sans-serif;

--- a/packages/worker/src/app/account-plan-display.node.test.ts
+++ b/packages/worker/src/app/account-plan-display.node.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+import { adminGrantDiffersFromSubscription } from '#app/account-plan-display.ts'
+
+test('adminGrantDiffersFromSubscription hides the usual subscriber and free cases', () => {
+	expect(adminGrantDiffersFromSubscription('free', null)).toBe(false)
+	expect(adminGrantDiffersFromSubscription('free', 'pro')).toBe(false)
+	expect(adminGrantDiffersFromSubscription('pro', 'pro')).toBe(false)
+	expect(adminGrantDiffersFromSubscription('standard', 'standard')).toBe(false)
+
+	expect(adminGrantDiffersFromSubscription('max', null)).toBe(true)
+	expect(adminGrantDiffersFromSubscription('max', 'pro')).toBe(true)
+	expect(adminGrantDiffersFromSubscription('pro', null)).toBe(true)
+	expect(adminGrantDiffersFromSubscription('pro', 'standard')).toBe(true)
+})

--- a/packages/worker/src/app/account-plan-display.ts
+++ b/packages/worker/src/app/account-plan-display.ts
@@ -1,0 +1,13 @@
+import { type AdminPlanName } from '#app/loader-data.ts'
+
+/**
+ * True when an admin grant is a deliberate non-free override that does not
+ * match the Stripe subscription. Ordinary subscribers keep `users.plan =
+ * 'free'` with their paid tier only on `stripe_plan`; that is not a split.
+ */
+export function adminGrantDiffersFromSubscription(
+	manualPlan: AdminPlanName,
+	stripePlan: AdminPlanName | null,
+) {
+	return manualPlan !== 'free' && stripePlan !== manualPlan
+}

--- a/packages/worker/src/app/account-usage-data.node.test.ts
+++ b/packages/worker/src/app/account-usage-data.node.test.ts
@@ -105,6 +105,8 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 	})
 	expect(baseline?.ok).toBe(true)
 	expect(baseline?.plan).toBe('free')
+	expect(baseline?.manualPlan).toBe('free')
+	expect(baseline?.stripePlan).toBe(null)
 	expect(baseline?.today).toBe('2026-07-25')
 	expect(currentFor(baseline, 'saved_packages')?.current).toBe(2)
 	expect(currentFor(baseline, 'concurrent_workflows')?.current).toBe(0)
@@ -211,4 +213,34 @@ test('loadAccountUsageData returns plan rows and authoritative UserMeter daily c
 		now,
 	})
 	expect(currentFor(storageData, 'storage_bytes')?.current).toBe(4_321)
+
+	const { db: grantDb } = createUsageTestDb({
+		userId: 12,
+		email: 'usage-grant@example.com',
+		plan: 'max',
+		stripePlan: null,
+	})
+	const grantData = await loadAccountUsageData({
+		env: withUsageEnv({ APP_DB: grantDb }) as Env,
+		userId: 12,
+		now,
+	})
+	expect(grantData?.plan).toBe('max')
+	expect(grantData?.manualPlan).toBe('max')
+	expect(grantData?.stripePlan).toBe(null)
+
+	const { db: subscribedDb } = createUsageTestDb({
+		userId: 13,
+		email: 'usage-sub@example.com',
+		plan: 'free',
+		stripePlan: 'pro',
+	})
+	const subscribedData = await loadAccountUsageData({
+		env: withUsageEnv({ APP_DB: subscribedDb }) as Env,
+		userId: 13,
+		now,
+	})
+	expect(subscribedData?.plan).toBe('pro')
+	expect(subscribedData?.manualPlan).toBe('free')
+	expect(subscribedData?.stripePlan).toBe('pro')
 })

--- a/packages/worker/src/app/account-usage-data.ts
+++ b/packages/worker/src/app/account-usage-data.ts
@@ -1,5 +1,6 @@
 import {
 	parseStoredPlanName,
+	parseStripePlanName,
 	resolveEffectivePlan,
 } from '#worker/entitlements/plans.ts'
 import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapshot.ts'
@@ -33,10 +34,8 @@ export async function loadAccountUsageData(input: {
 		.first<UsageUserRow>()
 	if (!row) return null
 
-	const plan = resolveEffectivePlan(
-		parseStoredPlanName(row.plan),
-		row.stripe_plan,
-	)
+	const manualPlan = parseStoredPlanName(row.plan)
+	const plan = resolveEffectivePlan(manualPlan, row.stripe_plan)
 	const usageUserId = resolveUserStableId(row)
 	const snapshot = await readEntitlementUsageSnapshot({
 		db: input.env.APP_DB,
@@ -49,6 +48,8 @@ export async function loadAccountUsageData(input: {
 	return {
 		ok: true,
 		plan: snapshot.plan,
+		manualPlan,
+		stripePlan: parseStripePlanName(row.stripe_plan),
 		today: snapshot.today,
 		entitlementConsumption: snapshot.resources.map(toAccountUsageRow),
 		warnings: snapshot.warnings.map(toAccountUsageRow),

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -1365,6 +1365,8 @@ export type AccountUsageEntitlementConsumption = {
 export type AccountUsageLoaderData = {
 	ok: true
 	plan: AdminPlanName
+	manualPlan: AdminPlanName
+	stripePlan: AdminPlanName | null
 	today: string
 	entitlementConsumption: Array<AccountUsageEntitlementConsumption>
 	warnings: Array<AccountUsageEntitlementConsumption>

--- a/packages/worker/src/app/profile-content.node.test.ts
+++ b/packages/worker/src/app/profile-content.node.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'vitest'
+import { renderProfileContentHtml } from '#app/profile-content.tsx'
+import {
+	type PublicCommunityProfile,
+	type PublicProfilePackageItem,
+} from '#app/community-public-types.ts'
+
+const profile = {
+	username: 'kody',
+	displayName: 'Kody',
+	bio: null,
+	avatarUrl: null,
+	visibility: 'public',
+	joinedAt: '2026-01-01T00:00:00.000Z',
+	followerCount: 0,
+	followingCount: 0,
+	publicPackageCount: 2,
+	listingCount: 1,
+} satisfies PublicCommunityProfile
+
+const listedPackage = {
+	name: '@kody/fathom-analytics',
+	kodyId: 'fathom-analytics',
+	description: 'Read Fathom Analytics site stats.',
+	tags: ['fathom', 'analytics'],
+	updatedAt: '2026-07-28T00:00:00.000Z',
+	communityListingId: 'listing-1',
+} satisfies PublicProfilePackageItem
+
+const unpublishedPackage = {
+	name: '@kody/notes',
+	kodyId: 'notes',
+	description: 'Private notes helper.',
+	tags: [],
+	updatedAt: '2026-07-01T00:00:00.000Z',
+	communityListingId: null,
+} satisfies PublicProfilePackageItem
+
+test('profile packages link the name, drop the kody id and view listing, and fork via an icon', async () => {
+	const html = await renderProfileContentHtml({
+		profile,
+		packages: [listedPackage, unpublishedPackage],
+		activity: [],
+		query: null,
+		isSelf: false,
+	})
+
+	expect(html).toContain('href="/community/listing-1"')
+	expect(html).toContain('@kody/')
+	expect(html.match(/fathom-analytics/g)).toHaveLength(1)
+	expect(html).not.toContain('View listing')
+	expect(html).not.toContain('>Fork<')
+	expect(html).toContain('href="/community/listing-1#fork-title"')
+	expect(html).toContain('title="fork"')
+	expect(html).toContain('aria-label="fork"')
+	expect(html).toContain('Not published')
+	expect(html.match(/aria-label="fork"/g)).toHaveLength(1)
+})

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -160,9 +160,7 @@ export function ProfileContent(handle: Handle<ProfileContentProps>) {
 										{pkg.communityListingId ? (
 											<span mix={css(communityBadgeCss)}>Community</span>
 										) : (
-											<span mix={css(unpublishedBadgeCss)}>
-												Not published
-											</span>
+											<span mix={css(unpublishedBadgeCss)}>Not published</span>
 										)}
 									</div>
 									{pkg.description ? (

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -7,6 +7,7 @@ import {
 	formatCommunityActivityDate,
 } from '#app/community-activity-display.ts'
 import { formatCommunityPublishedDate } from '#app/community-display.ts'
+import { renderCommunityListingName } from '#app/community-listing-name.tsx'
 import {
 	type PublicCommunityActivityItem,
 	type PublicCommunityProfile,
@@ -14,10 +15,17 @@ import {
 } from '#app/community-public-types.ts'
 import { routes } from '#app/routes.ts'
 import { UserAvatar } from '#app/user-avatar.tsx'
-import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
+import {
+	colors,
+	radius,
+	spacing,
+	transitions,
+	typography,
+} from '#client/styles/tokens.ts'
 import {
 	cardCss,
 	descriptionCss,
+	hoverMq,
 	mutedLinkCss,
 	pageDescriptionCss,
 	pageHeaderCss,
@@ -30,6 +38,29 @@ export type ProfileContentProps = {
 	activity: Array<PublicCommunityActivityItem>
 	query: string | null
 	isSelf: boolean
+}
+
+function renderForkIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="16"
+			height="16"
+			aria-hidden="true"
+			focusable={false}
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<circle cx="12" cy="18" r="3" />
+			<circle cx="6" cy="6" r="3" />
+			<circle cx="18" cy="6" r="3" />
+			<path d="M18 9v2c0 .6-.4 1-1 1H7c-.6 0-1-.4-1-1V9" />
+			<path d="M12 12v3" />
+		</svg>
+	)
 }
 
 export function ProfileContent(handle: Handle<ProfileContentProps>) {
@@ -96,54 +127,62 @@ export function ProfileContent(handle: Handle<ProfileContentProps>) {
 					</p>
 				) : (
 					<ul mix={css(packageListCss)}>
-						{packages.map((pkg) => (
-							<li key={pkg.kodyId} mix={css(cardCss)}>
-								<div mix={css(packageHeadingCss)}>
-									<h3 mix={css(packageNameCss)}>{pkg.name}</h3>
-									{pkg.communityListingId ? (
-										<span mix={css(communityBadgeCss)}>Community</span>
-									) : (
-										<span mix={css(unpublishedBadgeCss)}>Not published</span>
-									)}
-								</div>
-								<p mix={css(mutedCss)}>{pkg.kodyId}</p>
-								{pkg.description ? (
-									<p mix={css(descriptionCss)}>{pkg.description}</p>
-								) : null}
-								{pkg.tags.length > 0 ? (
-									<ul mix={css(tagListCss)}>
-										{pkg.tags.map((tag) => (
-											<li key={tag} mix={css(tagPillCss)}>
-												{tag}
-											</li>
-										))}
-									</ul>
-								) : null}
-								<p mix={css(mutedCss)}>
-									Updated {formatCommunityPublishedDate(pkg.updatedAt)}
-								</p>
-								{pkg.communityListingId ? (
-									<p mix={css(packageActionsCss)}>
-										<a
-											href={routes.communityDetail.href({
-												listingId: pkg.communityListingId,
-											})}
-											mix={css(mutedLinkCss)}
-										>
-											View listing
-										</a>
-										<a
-											href={routes.communityDetail.href({
-												listingId: pkg.communityListingId,
-											})}
-											mix={css(mutedLinkCss)}
-										>
-											Fork
-										</a>
+						{packages.map((pkg) => {
+							const listingHref = pkg.communityListingId
+								? routes.communityDetail.href({
+										listingId: pkg.communityListingId,
+									})
+								: null
+							return (
+								<li key={pkg.kodyId} mix={css(cardCss)}>
+									<div mix={css(packageHeadingCss)}>
+										<div mix={css(packageTitleGroupCss)}>
+											{listingHref ? (
+												<a
+													href={`${listingHref}#fork-title`}
+													title="fork"
+													aria-label="fork"
+													mix={css(forkButtonCss)}
+												>
+													{renderForkIcon()}
+												</a>
+											) : null}
+											<h3 mix={css(packageNameCss)}>
+												{listingHref ? (
+													<a href={listingHref} mix={css(packageNameLinkCss)}>
+														{renderCommunityListingName(pkg.name)}
+													</a>
+												) : (
+													renderCommunityListingName(pkg.name)
+												)}
+											</h3>
+										</div>
+										{pkg.communityListingId ? (
+											<span mix={css(communityBadgeCss)}>Community</span>
+										) : (
+											<span mix={css(unpublishedBadgeCss)}>
+												Not published
+											</span>
+										)}
+									</div>
+									{pkg.description ? (
+										<p mix={css(descriptionCss)}>{pkg.description}</p>
+									) : null}
+									{pkg.tags.length > 0 ? (
+										<ul mix={css(tagListCss)}>
+											{pkg.tags.map((tag) => (
+												<li key={tag} mix={css(tagPillCss)}>
+													{tag}
+												</li>
+											))}
+										</ul>
+									) : null}
+									<p mix={css(mutedCss)}>
+										Updated {formatCommunityPublishedDate(pkg.updatedAt)}
 									</p>
-								) : null}
-							</li>
-						))}
+								</li>
+							)
+						})}
 					</ul>
 				)}
 			</section>
@@ -265,12 +304,51 @@ const packageHeadingCss = {
 	flexWrap: 'wrap' as const,
 }
 
+const packageTitleGroupCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.sm,
+	minWidth: 0,
+	flex: '1 1 auto',
+}
+
 const packageNameCss = {
 	margin: 0,
 	fontSize: typography.fontSize.base,
 	fontWeight: typography.fontWeight.semibold,
 	color: colors.text,
 	overflowWrap: 'anywhere' as const,
+	minWidth: 0,
+}
+
+const packageNameLinkCss = {
+	color: 'inherit',
+	textDecoration: 'none',
+	'&:hover': {
+		color: colors.primaryText,
+	},
+}
+
+const forkButtonCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	flex: 'none',
+	width: '1.75rem',
+	height: '1.75rem',
+	borderRadius: radius.md,
+	border: `1px solid ${colors.border}`,
+	backgroundColor: 'transparent',
+	color: colors.textMuted,
+	textDecoration: 'none',
+	transition: `color ${transitions.fast}, border-color ${transitions.fast}, background-color ${transitions.fast}`,
+	[hoverMq]: {
+		'&:hover': {
+			color: colors.primaryText,
+			borderColor: colors.primaryText,
+			backgroundColor: colors.primarySoftest,
+		},
+	},
 }
 
 const communityBadgeCss = {
@@ -307,12 +385,6 @@ const tagPillCss = {
 	backgroundColor: colors.primarySoftest,
 	color: colors.primaryText,
 	fontSize: typography.fontSize.sm,
-}
-
-const packageActionsCss = {
-	display: 'flex',
-	gap: spacing.md,
-	margin: 0,
 }
 
 const activityListCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make public profile package cards less noisy, stop code blocks from indenting at the browser default tab width of 8, remove gray chip backgrounds on onboarding MCP snippets, and simplify billing/usage plan copy when grant and subscription are the same.

## Summary

- Profile package cards now use the package name as the listing link.
- Removed the redundant kody-id subtitle and the "View listing" action.
- Fork is a compact icon button to the left of the name, with a `fork` tooltip, linking to the listing fork section.
- Site-wide `tab-size: 2` on `:root` so preformatted code matches the rest of the product.
- Onboarding MCP snippet wells no longer inherit inline-code gray chips on `<pre><code>` lines.
- Billing and usage show a single current-plan line for ordinary users; grant vs subscription only appears when an admin grant is a non-free override.

## Testing

- Focused node tests: profile content, plan display helper, usage/billing data
- Local `npm run format:check` after oxfmt on `profile-content.tsx`
- Manual: profile cards, onboarding MCP snippets, billing/usage plan panels

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `84e9632d` · **Head:** `833db1fa`

**Classification:** composes — no primitives added or changed; this PR restyles profile cards, global tab stops, onboarding snippets, and billing/usage plan copy.

### Primitives touched

| Primitive | Group    | Impact |
| --------- | -------- | ------ |
| `app-ui`  | surfaces | composes — profile cards, tab-size, onboarding snippets, billing/usage plan UI |

### System map

Public profile frames still render through app-ui. Billing and usage read existing plan fields and only expand grant vs subscription when an admin grant is a non-free override.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	appUi -->|"profile package name + fork icon"| appUi
	appUi -->|"tab-size 2 + snippet chip reset"| appUi
	appUi -->|"billing/usage current plan copy"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Profile package card**

- Before: name + kody id + "View listing" + "Fork" text links
- After: fork icon · linked name · Community badge

**Billing / usage plan**

- Before: always explained combining grant + subscription
- After: single current plan for ordinary users; split only for non-free admin grants

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cc7a10e-da2f-4b0e-9bce-1cce30ce2541?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cc7a10e-da2f-4b0e-9bce-1cce30ce2541&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned package entries on public profiles for a cleaner, more compact layout.
  - Published package names now link directly to their community listings.
  - Added an inline fork action with a recognizable fork icon and improved accessibility.
  - Removed package IDs and streamlined listing and fork controls.

- **Style**
  - Improved package title, link, and fork-control styling, including hover behavior.
  - Standardized indentation and syntax-highlighted code-block styling for clearer formatted content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->