### PR TITLE
feat(community): follow owners from package details and seed welcome follows

### DIFF
--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -81,9 +81,9 @@ Anyone can browse `/community` and open `/community/:listingId`. Detail pages
 show metadata, aggregate ratings, **star count** (stargazers — distinct from 1–5
 ratings), fork count, the README (not the full source tree), and a dynamically
 generated Open Graph image (1200×630). When the owner keeps a
-[public profile](./community-profiles.md), the listing links to `/@username`.
-Private owners still show as `@username` with a lock that explains the profile
-is private.
+[public profile](./community-profiles.md), the listing links to `/@username` and
+shows a follow control next to the username. Private owners still show as
+`@username` with a lock that explains the profile is private.
 
 Each detail page includes a **copyable prompt** you can hand to your agent to
 start a fork. You can also ask your agent to use `community_search` or

--- a/docs/use/community-profiles.md
+++ b/docs/use/community-profiles.md
@@ -58,8 +58,9 @@ private) through `community_profile_get` / `community_profile_update`.
 ## Following and the timeline
 
 Signed-in users can follow public profiles with no approval step. Private
-profiles reject follows. New accounts automatically follow `@kody` when that
-profile exists and is public. You can unfollow afterward.
+profiles reject follows. New accounts automatically follow `@kody` and
+`@kentcdodds` when those profiles exist and are public. You can unfollow
+afterward.
 
 `/timeline` (signed-in) lists public activity from accounts you follow, newest
 first. Timeline item types:

--- a/docs/use/community-profiles.md
+++ b/docs/use/community-profiles.md
@@ -58,7 +58,8 @@ private) through `community_profile_get` / `community_profile_update`.
 ## Following and the timeline
 
 Signed-in users can follow public profiles with no approval step. Private
-profiles reject follows.
+profiles reject follows. New accounts automatically follow `@kody` when that
+profile exists and is public. You can unfollow afterward.
 
 `/timeline` (signed-in) lists public activity from accounts you follow, newest
 first. Timeline item types:

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -96,6 +96,20 @@ function getCurrentListingId(handle: Handle) {
 	return getListingIdFromPathname(readRouterPathname(handle))
 }
 
+function buildCommunityDetailFrameSrc(href: string) {
+	const url = new URL(href, 'http://localhost')
+	const listingId = getListingIdFromPathname(url.pathname)
+	if (!listingId) return url.pathname
+	const followError = url.searchParams.get('followError')
+	if (!followError) return routes.communityDetail.href({ listingId })
+	const frameUrl = new URL(
+		routes.communityDetail.href({ listingId }),
+		'http://localhost',
+	)
+	frameUrl.searchParams.set('followError', followError)
+	return `${frameUrl.pathname}${frameUrl.search}`
+}
+
 export async function communityDetailRouteLoader(
 	url: URL,
 	signal: AbortSignal,
@@ -105,7 +119,7 @@ export async function communityDetailRouteLoader(
 		throw new Error('Community listing not found.')
 	}
 
-	const frameSrc = routes.communityDetail.href({ listingId })
+	const frameSrc = buildCommunityDetailFrameSrc(`${url.pathname}${url.search}`)
 	const shellPromise = fetch(routes.communityDetailApi.href({ listingId }), {
 		headers: { Accept: 'application/json' },
 		signal,
@@ -539,7 +553,7 @@ export function CommunityDetailRoute(handle: Handle) {
 		const frame = handle.frames.get(COMMUNITY_DETAIL_TARGET)
 		if (!frame) return
 
-		const nextSrc = routes.communityDetail.href({ listingId })
+		const nextSrc = buildCommunityDetailFrameSrc(readCurrentRouterHref(handle))
 		if (frame.src !== nextSrc) {
 			frame.src = nextSrc
 		}
@@ -630,7 +644,7 @@ export function CommunityDetailRoute(handle: Handle) {
 			handle.queueTask(loadDetailShell)
 		}
 
-		const frameSrc = routes.communityDetail.href({ listingId })
+		const frameSrc = buildCommunityDetailFrameSrc(currentHref)
 
 		// Never show another listing's shell data: even if an in-flight fetch
 		// for the previous listing resolves late, mismatched ids render the

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -26,8 +26,10 @@ import {
 } from '#worker/community/service.ts'
 import {
 	getCommunityStar,
+	getUserFollow,
 	getUserSocialRowByUsername,
 } from '#worker/community/social-repo.ts'
+import { resolveUserStableId } from '#worker/user-id.ts'
 
 const defaultCommunityListLimit = 50
 const onboardingFeaturedListingLimit = 12
@@ -173,41 +175,58 @@ async function loadCommunityDetailDataUncached(
 		listing.ownerUsername,
 	)
 	const ownerProfilePublic = ownerRow?.profile_visibility === 'public'
+	const ownerUserId = ownerRow ? resolveUserStableId(ownerRow) : null
 
 	const user = await readAuthenticatedAppUser(request, env)
-	const starredByViewer =
+	const viewerUserId = user?.mcpUser.userId ?? null
+	const viewerIsOwner =
+		viewerUserId != null && ownerUserId != null && viewerUserId === ownerUserId
+	const [starredByViewer, viewerFollowsOwner] = await Promise.all([
 		user != null
-			? await getCommunityStar(env.APP_DB, {
+			? getCommunityStar(env.APP_DB, {
 					listingId,
 					userId: user.mcpUser.userId,
 				})
-			: false
-	return composeCommunityDetailLoaderData(
+			: false,
+		user != null && ownerUserId != null && ownerProfilePublic && !viewerIsOwner
+			? getUserFollow(env.APP_DB, {
+					followerUserId: user.mcpUser.userId,
+					followeeUserId: ownerUserId,
+				})
+			: false,
+	])
+	return composeCommunityDetailLoaderData({
 		listing,
-		Boolean(user),
-		user?.roles.includes('admin') ?? false,
+		loggedIn: Boolean(user),
+		viewerIsAdmin: user?.roles.includes('admin') ?? false,
 		starredByViewer,
 		ownerProfilePublic,
-	)
+		viewerFollowsOwner,
+		viewerIsOwner,
+	})
 }
 
-export function composeCommunityDetailLoaderData(
-	listing: PublicCommunityListing,
-	loggedIn: boolean,
-	viewerIsAdmin = false,
-	starredByViewer = false,
-	ownerProfilePublic = false,
-): CommunityDetailLoaderData {
+export function composeCommunityDetailLoaderData(input: {
+	listing: PublicCommunityListing
+	loggedIn: boolean
+	viewerIsAdmin?: boolean
+	starredByViewer?: boolean
+	ownerProfilePublic?: boolean
+	viewerFollowsOwner?: boolean
+	viewerIsOwner?: boolean
+}): CommunityDetailLoaderData {
 	return {
 		ok: true,
-		listing,
-		ownerProfilePublic,
-		loggedIn,
-		viewerIsAdmin,
+		listing: input.listing,
+		ownerProfilePublic: input.ownerProfilePublic ?? false,
+		viewerFollowsOwner: input.viewerFollowsOwner ?? false,
+		viewerIsOwner: input.viewerIsOwner ?? false,
+		loggedIn: input.loggedIn,
+		viewerIsAdmin: input.viewerIsAdmin ?? false,
 		forkPrompt: buildForkPrompt({
-			name: listing.name,
-			listingId: listing.id,
+			name: input.listing.name,
+			listingId: input.listing.id,
 		}),
-		starredByViewer,
+		starredByViewer: input.starredByViewer ?? false,
 	}
 }

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -37,6 +37,7 @@ export type CommunityDetailContentProps = {
 	viewerFollowsOwner: boolean
 	viewerIsOwner: boolean
 	returnTo: string
+	followError: string | null
 }
 
 export function CommunityDetailContent(
@@ -49,6 +50,7 @@ export function CommunityDetailContent(
 		viewerFollowsOwner,
 		viewerIsOwner,
 		returnTo,
+		followError,
 	} = handle.props
 
 	return () => (
@@ -114,6 +116,7 @@ export function CommunityDetailContent(
 									loggedIn,
 									viewerFollowsOwner,
 									returnTo,
+									followError,
 								})
 							: null}
 					</p>
@@ -203,6 +206,7 @@ function renderOwnerFollowControl(input: {
 	loggedIn: boolean
 	viewerFollowsOwner: boolean
 	returnTo: string
+	followError: string | null
 }) {
 	if (!input.loggedIn) {
 		const loginHref = `${routes.login.href()}?redirectTo=${encodeURIComponent(input.returnTo)}`
@@ -220,32 +224,43 @@ function renderOwnerFollowControl(input: {
 	}
 
 	return (
-		<form
-			method="post"
-			action={routes.profileFollowApiPost.href({ username: input.username })}
-			mix={css(ownerFollowFormCss)}
-		>
-			<input
-				type="hidden"
-				name="follow"
-				value={String(!input.viewerFollowsOwner)}
-			/>
-			<input type="hidden" name="returnTo" value={input.returnTo} />
-			<button
-				type="submit"
-				title={input.viewerFollowsOwner ? 'Unfollow' : 'Follow'}
-				data-testid="community-detail-owner-follow"
-				data-following={input.viewerFollowsOwner ? 'true' : 'false'}
-				mix={css(ownerFollowButtonCss)}
+		<span mix={css(ownerFollowControlCss)}>
+			<form
+				method="post"
+				action={routes.profileFollowApiPost.href({ username: input.username })}
+				mix={css(ownerFollowFormCss)}
 			>
-				{renderFollowGlyph(input.viewerFollowsOwner)}
-				<span mix={css(visuallyHiddenCss)}>
-					{input.viewerFollowsOwner
-						? `Unfollow @${input.username}`
-						: `Follow @${input.username}`}
+				<input
+					type="hidden"
+					name="follow"
+					value={String(!input.viewerFollowsOwner)}
+				/>
+				<input type="hidden" name="returnTo" value={input.returnTo} />
+				<button
+					type="submit"
+					title={input.viewerFollowsOwner ? 'Unfollow' : 'Follow'}
+					data-testid="community-detail-owner-follow"
+					data-following={input.viewerFollowsOwner ? 'true' : 'false'}
+					mix={css(ownerFollowButtonCss)}
+				>
+					{renderFollowGlyph(input.viewerFollowsOwner)}
+					<span mix={css(visuallyHiddenCss)}>
+						{input.viewerFollowsOwner
+							? `Unfollow @${input.username}`
+							: `Follow @${input.username}`}
+					</span>
+				</button>
+			</form>
+			{input.followError ? (
+				<span
+					role="alert"
+					data-testid="community-detail-owner-follow-error"
+					mix={css(ownerFollowErrorCss)}
+				>
+					{input.followError}
 				</span>
-			</button>
-		</form>
+			) : null}
+		</span>
 	)
 }
 
@@ -352,9 +367,21 @@ const ownerPrivateLockCss = {
 	cursor: 'help',
 }
 
+const ownerFollowControlCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.45rem',
+	minWidth: 0,
+}
+
 const ownerFollowFormCss = {
 	display: 'inline-flex',
 	margin: 0,
+}
+
+const ownerFollowErrorCss = {
+	color: colors.danger,
+	fontSize: '0.85rem',
 }
 
 const ownerFollowButtonCss = {

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -33,12 +33,23 @@ import { colors } from '#client/styles/tokens.ts'
 export type CommunityDetailContentProps = {
 	listing: PublicCommunityListing
 	ownerProfilePublic: boolean
+	loggedIn: boolean
+	viewerFollowsOwner: boolean
+	viewerIsOwner: boolean
+	returnTo: string
 }
 
 export function CommunityDetailContent(
 	handle: Handle<CommunityDetailContentProps>,
 ) {
-	const { listing, ownerProfilePublic } = handle.props
+	const {
+		listing,
+		ownerProfilePublic,
+		loggedIn,
+		viewerFollowsOwner,
+		viewerIsOwner,
+		returnTo,
+	} = handle.props
 
 	return () => (
 		<div data-testid="community-detail-frame">
@@ -55,46 +66,56 @@ export function CommunityDetailContent(
 				<CommunityListingIcon listing={listing} size="detail" />
 				<div mix={css(headTextCss)}>
 					<h1>{renderCommunityListingName(listing.name)}</h1>
-					<p>
-						by{' '}
-						{ownerProfilePublic ? (
-							<a
-								href={routes.profile.href({
-									username: listing.ownerUsername,
-								})}
-								mix={css(ownerLinkCss)}
-							>
-								@{listing.ownerUsername}
-							</a>
-						) : (
-							<>
-								@{listing.ownerUsername}
-								<span
-									data-testid="community-detail-owner-private"
-									title="This profile is private"
-									mix={css(ownerPrivateLockCss)}
+					<p mix={css(ownerLineCss)}>
+						<span>
+							by{' '}
+							{ownerProfilePublic ? (
+								<a
+									href={routes.profile.href({
+										username: listing.ownerUsername,
+									})}
+									mix={css(ownerLinkCss)}
 								>
-									<svg
-										viewBox="0 0 16 16"
-										width="0.9em"
-										height="0.9em"
-										aria-hidden="true"
-										focusable={false}
-										fill="none"
-										stroke="currentColor"
-										strokeWidth="1.5"
-										strokeLinecap="round"
-										strokeLinejoin="round"
+									@{listing.ownerUsername}
+								</a>
+							) : (
+								<>
+									@{listing.ownerUsername}
+									<span
+										data-testid="community-detail-owner-private"
+										title="This profile is private"
+										mix={css(ownerPrivateLockCss)}
 									>
-										<rect x="3.5" y="7.2" width="9" height="6.3" rx="1.4" />
-										<path d="M5.4 7.2V5.4a2.6 2.6 0 0 1 5.2 0v1.8" />
-									</svg>
-									<span mix={css(visuallyHiddenCss)}>
-										This profile is private
+										<svg
+											viewBox="0 0 16 16"
+											width="0.9em"
+											height="0.9em"
+											aria-hidden="true"
+											focusable={false}
+											fill="none"
+											stroke="currentColor"
+											strokeWidth="1.5"
+											strokeLinecap="round"
+											strokeLinejoin="round"
+										>
+											<rect x="3.5" y="7.2" width="9" height="6.3" rx="1.4" />
+											<path d="M5.4 7.2V5.4a2.6 2.6 0 0 1 5.2 0v1.8" />
+										</svg>
+										<span mix={css(visuallyHiddenCss)}>
+											This profile is private
+										</span>
 									</span>
-								</span>
-							</>
-						)}
+								</>
+							)}
+						</span>
+						{ownerProfilePublic && !viewerIsOwner
+							? renderOwnerFollowControl({
+									username: listing.ownerUsername,
+									loggedIn,
+									viewerFollowsOwner,
+									returnTo,
+								})
+							: null}
 					</p>
 				</div>
 				{listing.trusted ? (
@@ -177,6 +198,93 @@ export function CommunityDetailContent(
 	)
 }
 
+function renderOwnerFollowControl(input: {
+	username: string
+	loggedIn: boolean
+	viewerFollowsOwner: boolean
+	returnTo: string
+}) {
+	if (!input.loggedIn) {
+		const loginHref = `${routes.login.href()}?redirectTo=${encodeURIComponent(input.returnTo)}`
+		return (
+			<a
+				href={loginHref}
+				title="Follow"
+				data-testid="community-detail-owner-follow"
+				mix={css(ownerFollowButtonCss)}
+			>
+				{renderFollowGlyph(false)}
+				<span mix={css(visuallyHiddenCss)}>Follow @{input.username}</span>
+			</a>
+		)
+	}
+
+	return (
+		<form
+			method="post"
+			action={routes.profileFollowApiPost.href({ username: input.username })}
+			mix={css(ownerFollowFormCss)}
+		>
+			<input
+				type="hidden"
+				name="follow"
+				value={String(!input.viewerFollowsOwner)}
+			/>
+			<input type="hidden" name="returnTo" value={input.returnTo} />
+			<button
+				type="submit"
+				title={input.viewerFollowsOwner ? 'Unfollow' : 'Follow'}
+				data-testid="community-detail-owner-follow"
+				data-following={input.viewerFollowsOwner ? 'true' : 'false'}
+				mix={css(ownerFollowButtonCss)}
+			>
+				{renderFollowGlyph(input.viewerFollowsOwner)}
+				<span mix={css(visuallyHiddenCss)}>
+					{input.viewerFollowsOwner
+						? `Unfollow @${input.username}`
+						: `Follow @${input.username}`}
+				</span>
+			</button>
+		</form>
+	)
+}
+
+function renderFollowGlyph(following: boolean) {
+	return following ? (
+		<svg
+			viewBox="0 0 16 16"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			focusable={false}
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<circle cx="8" cy="8" r="5.4" />
+			<path d="M5.3 8.1 7.1 9.9 10.8 6.1" />
+		</svg>
+	) : (
+		<svg
+			viewBox="0 0 16 16"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			focusable={false}
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<circle cx="8" cy="8" r="5.4" />
+			<path d="M8 5.2v5.6M5.2 8h5.6" />
+		</svg>
+	)
+}
+
 export async function renderCommunityDetailContentHtml(
 	props: CommunityDetailContentProps,
 ) {
@@ -215,11 +323,15 @@ const headTextCss = {
 		lineHeight: 1.05,
 		overflowWrap: 'anywhere' as const,
 	},
-	'& p': {
-		margin: '0.25rem 0 0',
-		color: colors.textMuted,
-		fontSize: '0.95rem',
-	},
+}
+
+const ownerLineCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: '0.45rem',
+	margin: '0.25rem 0 0',
+	color: colors.textMuted,
+	fontSize: '0.95rem',
 }
 
 const ownerLinkCss = {
@@ -238,6 +350,30 @@ const ownerPrivateLockCss = {
 	color: colors.textMuted,
 	verticalAlign: 'middle',
 	cursor: 'help',
+}
+
+const ownerFollowFormCss = {
+	display: 'inline-flex',
+	margin: 0,
+}
+
+const ownerFollowButtonCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	width: '1.55rem',
+	height: '1.55rem',
+	padding: 0,
+	border: `1px solid ${colors.border}`,
+	borderRadius: '999px',
+	backgroundColor: 'transparent',
+	color: colors.textMuted,
+	textDecoration: 'none',
+	cursor: 'pointer',
+	'&:hover': {
+		color: colors.primaryText,
+		borderColor: colors.primaryText,
+	},
 }
 
 const badgeCss = {

--- a/packages/worker/src/app/frames/community-detail.ts
+++ b/packages/worker/src/app/frames/community-detail.ts
@@ -21,6 +21,10 @@ registerFrame(COMMUNITY_DETAIL_TARGET, {
 		return renderCommunityDetailContentHtml({
 			listing: detail.listing,
 			ownerProfilePublic: detail.ownerProfilePublic,
+			loggedIn: detail.loggedIn,
+			viewerFollowsOwner: detail.viewerFollowsOwner,
+			viewerIsOwner: detail.viewerIsOwner,
+			returnTo: routes.communityDetail.href({ listingId }),
 		})
 	},
 })

--- a/packages/worker/src/app/frames/community-detail.ts
+++ b/packages/worker/src/app/frames/community-detail.ts
@@ -25,6 +25,7 @@ registerFrame(COMMUNITY_DETAIL_TARGET, {
 			viewerFollowsOwner: detail.viewerFollowsOwner,
 			viewerIsOwner: detail.viewerIsOwner,
 			returnTo: routes.communityDetail.href({ listingId }),
+			followError: new URL(request.url).searchParams.get('followError'),
 		})
 	},
 })

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -64,6 +64,7 @@ import {
 	verifyPublicFormProtection,
 } from '#app/public-form-protection.ts'
 import { getSignupMode } from '#app/signup-mode.ts'
+import { followDefaultWelcomeAccount } from '#worker/community/welcome-follow.ts'
 
 /**
  * Accounts created through social login have no usable password until the
@@ -585,6 +586,10 @@ export function createAuthProviderCallbackHandler(env: Env) {
 			await maybeTagKitSubscriberOnSignup({
 				env,
 				email,
+			})
+			await followDefaultWelcomeAccount({
+				db: env.APP_DB,
+				followerUserId: stableUserId,
 			})
 
 			void logAuditEvent({

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -64,7 +64,7 @@ import {
 	verifyPublicFormProtection,
 } from '#app/public-form-protection.ts'
 import { getSignupMode } from '#app/signup-mode.ts'
-import { followDefaultWelcomeAccount } from '#worker/community/welcome-follow.ts'
+import { followDefaultWelcomeAccounts } from '#worker/community/welcome-follow.ts'
 
 /**
  * Accounts created through social login have no usable password until the
@@ -587,7 +587,7 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				env,
 				email,
 			})
-			await followDefaultWelcomeAccount({
+			await followDefaultWelcomeAccounts({
 				db: env.APP_DB,
 				followerUserId: stableUserId,
 			})

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -47,7 +47,7 @@ import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts
 import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 import { getSignupMode } from '#app/signup-mode.ts'
-import { followDefaultWelcomeAccount } from '#worker/community/welcome-follow.ts'
+import { followDefaultWelcomeAccounts } from '#worker/community/welcome-follow.ts'
 
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]
@@ -427,7 +427,7 @@ export function createAuthHandler(env: Env) {
 					env,
 					email: normalizedEmail,
 				})
-				await followDefaultWelcomeAccount({
+				await followDefaultWelcomeAccounts({
 					db: env.APP_DB,
 					followerUserId: record.stableUserId,
 				})

--- a/packages/worker/src/app/handlers/auth.ts
+++ b/packages/worker/src/app/handlers/auth.ts
@@ -47,6 +47,7 @@ import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts
 import { maybeTagKitSubscriberOnSignup } from '#app/kit-signup.ts'
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 import { getSignupMode } from '#app/signup-mode.ts'
+import { followDefaultWelcomeAccount } from '#worker/community/welcome-follow.ts'
 
 const authModes = ['login', 'signup'] as const
 type AuthMode = (typeof authModes)[number]
@@ -425,6 +426,10 @@ export function createAuthHandler(env: Env) {
 				await maybeTagKitSubscriberOnSignup({
 					env,
 					email: normalizedEmail,
+				})
+				await followDefaultWelcomeAccount({
+					db: env.APP_DB,
+					followerUserId: record.stableUserId,
 				})
 
 				const cookie = await createAuthCookie(

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -6,6 +6,7 @@ const mockModule = vi.hoisted(() => ({
 	getCommunityListingWithAggregates: vi.fn(),
 	readAuthenticatedAppUser: vi.fn(),
 	getUserSocialRowByUsername: vi.fn(),
+	getUserFollow: vi.fn(),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -23,6 +24,7 @@ vi.mock('#app/authenticated-user.ts', () => ({
 
 vi.mock('#worker/community/social-repo.ts', () => ({
 	getCommunityStar: vi.fn().mockResolvedValue(false),
+	getUserFollow: (...args: Array<unknown>) => mockModule.getUserFollow(...args),
 	getUserSocialRowByUsername: (...args: Array<unknown>) =>
 		mockModule.getUserSocialRowByUsername(...args),
 }))
@@ -64,7 +66,9 @@ test('community detail handler returns bare detail frame HTML for target header'
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
 	mockModule.getUserSocialRowByUsername.mockResolvedValue({
 		profile_visibility: 'public',
+		stable_user_id: 'owner-mcp-id',
 	})
+	mockModule.getUserFollow.mockResolvedValue(false)
 
 	const handler = createCommunityDetailHandler(env)
 	const publicResponse = await handler.handler({
@@ -83,6 +87,9 @@ test('community detail handler returns bare detail frame HTML for target header'
 	expect(publicHtml).toContain('/community/listing-1/icon/abc1234567890')
 	expect(publicHtml).toContain('href="/@kentcdodds"')
 	expect(publicHtml).toContain('>@kentcdodds</a>')
+	expect(publicHtml).toContain('data-testid="community-detail-owner-follow"')
+	expect(publicHtml).toContain('title="Follow"')
+	expect(publicHtml).toContain('/login?redirectTo=%2Fcommunity%2Flisting-1')
 	expect(publicHtml).not.toContain(
 		'data-testid="community-detail-owner-private"',
 	)
@@ -91,6 +98,7 @@ test('community detail handler returns bare detail frame HTML for target header'
 
 	mockModule.getUserSocialRowByUsername.mockResolvedValue({
 		profile_visibility: 'private',
+		stable_user_id: 'owner-mcp-id',
 	})
 	const privateResponse = await handler.handler({
 		request: new Request('https://example.com/community/listing-1', {
@@ -104,4 +112,41 @@ test('community detail handler returns bare detail frame HTML for target header'
 	expect(privateHtml).toContain('data-testid="community-detail-owner-private"')
 	expect(privateHtml).toContain('title="This profile is private"')
 	expect(privateHtml).not.toContain('href="/@kentcdodds"')
+	expect(privateHtml).not.toContain(
+		'data-testid="community-detail-owner-follow"',
+	)
+
+	mockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+		stable_user_id: 'owner-mcp-id',
+	})
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		mcpUser: { userId: 'viewer-mcp-id' },
+		roles: [],
+	})
+	const signedInResponse = await handler.handler({
+		request: new Request('https://example.com/community/listing-1', {
+			headers: { 'x-remix-target': 'community-detail' },
+		}),
+		params: { listingId: 'listing-1' },
+		url: new URL('https://example.com/community/listing-1'),
+	} as never)
+	const signedInHtml = await signedInResponse.text()
+	expect(signedInHtml).toContain('data-testid="community-detail-owner-follow"')
+	expect(signedInHtml).toContain('name="follow"')
+	expect(signedInHtml).toContain('name="returnTo"')
+	expect(signedInHtml).toContain('/profiles/kentcdodds/follow.json')
+	expect(signedInHtml).toContain('title="Follow"')
+
+	mockModule.getUserFollow.mockResolvedValue(true)
+	const followingResponse = await handler.handler({
+		request: new Request('https://example.com/community/listing-1', {
+			headers: { 'x-remix-target': 'community-detail' },
+		}),
+		params: { listingId: 'listing-1' },
+		url: new URL('https://example.com/community/listing-1'),
+	} as never)
+	const followingHtml = await followingResponse.text()
+	expect(followingHtml).toContain('data-following="true"')
+	expect(followingHtml).toContain('title="Unfollow"')
 })

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -149,4 +149,22 @@ test('community detail handler returns bare detail frame HTML for target header'
 	const followingHtml = await followingResponse.text()
 	expect(followingHtml).toContain('data-following="true"')
 	expect(followingHtml).toContain('title="Unfollow"')
+
+	const followErrorResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/community/listing-1?followError=You%20cannot%20follow%20yourself.',
+			{
+				headers: { 'x-remix-target': 'community-detail' },
+			},
+		),
+		params: { listingId: 'listing-1' },
+		url: new URL(
+			'https://example.com/community/listing-1?followError=You%20cannot%20follow%20yourself.',
+		),
+	} as never)
+	const followErrorHtml = await followErrorResponse.text()
+	expect(followErrorHtml).toContain(
+		'data-testid="community-detail-owner-follow-error"',
+	)
+	expect(followErrorHtml).toContain('You cannot follow yourself.')
 })

--- a/packages/worker/src/app/handlers/profile.node.test.ts
+++ b/packages/worker/src/app/handlers/profile.node.test.ts
@@ -287,6 +287,26 @@ test('profile follow POST enforces auth and toggles follow', async () => {
 	mockModule.followCommunityUser.mockRejectedValue(
 		new CommunityActionError('You cannot follow yourself.'),
 	)
+	const formError = await handler.handler({
+		request: new Request('https://example.com/profiles/alice/follow.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				follow: 'true',
+				returnTo: '/community/listing-1',
+			}),
+		}),
+		params: { username: 'alice' },
+		url: new URL('https://example.com/profiles/alice/follow.json'),
+	} as never)
+	expect(formError.status).toBe(303)
+	expect(formError.headers.get('Location')).toBe(
+		'/community/listing-1?followError=You+cannot+follow+yourself.',
+	)
+
+	mockModule.followCommunityUser.mockRejectedValue(
+		new CommunityActionError('You cannot follow yourself.'),
+	)
 	const errorResponse = await handler.handler({
 		request: new Request('https://example.com/profiles/alice/follow.json', {
 			method: 'POST',

--- a/packages/worker/src/app/handlers/profile.node.test.ts
+++ b/packages/worker/src/app/handlers/profile.node.test.ts
@@ -269,6 +269,21 @@ test('profile follow POST enforces auth and toggles follow', async () => {
 	expect(unfollow.status).toBe(200)
 	expect(await unfollow.json()).toEqual({ ok: true, following: false })
 
+	const formFollow = await handler.handler({
+		request: new Request('https://example.com/profiles/alice/follow.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				follow: 'true',
+				returnTo: '/community/listing-1',
+			}),
+		}),
+		params: { username: 'alice' },
+		url: new URL('https://example.com/profiles/alice/follow.json'),
+	} as never)
+	expect(formFollow.status).toBe(303)
+	expect(formFollow.headers.get('Location')).toBe('/community/listing-1')
+
 	mockModule.followCommunityUser.mockRejectedValue(
 		new CommunityActionError('You cannot follow yourself.'),
 	)

--- a/packages/worker/src/app/handlers/profile.tsx
+++ b/packages/worker/src/app/handlers/profile.tsx
@@ -35,6 +35,15 @@ function readSafeReturnTo(value: FormDataEntryValue | null) {
 	return normalizeRedirectTo(value)
 }
 
+function redirectWithFollowError(returnTo: string, message: string) {
+	const url = new URL(returnTo, 'https://kody.invalid')
+	url.searchParams.set('followError', message.slice(0, 200))
+	return new Response(null, {
+		status: 303,
+		headers: { Location: `${url.pathname}${url.search}${url.hash}` },
+	})
+}
+
 export function createProfileHandler(env: Env) {
 	return {
 		middleware: [],
@@ -245,14 +254,17 @@ export function createProfileFollowApiPostHandler(env: Env) {
 			} catch (error) {
 				if (error instanceof CommunityActionError) {
 					if (returnTo) {
-						return new Response(null, {
-							status: 303,
-							headers: { Location: returnTo },
-						})
+						return redirectWithFollowError(returnTo, error.message)
 					}
 					return jsonResponse({ ok: false, error: error.message }, 400)
 				}
 				console.error('Profile follow update failed:', error)
+				if (returnTo) {
+					return redirectWithFollowError(
+						returnTo,
+						'Unable to update follow status.',
+					)
+				}
 				return jsonResponse(
 					{ ok: false, error: 'Unable to update follow status.' },
 					500,

--- a/packages/worker/src/app/handlers/profile.tsx
+++ b/packages/worker/src/app/handlers/profile.tsx
@@ -5,6 +5,7 @@ import { handleFrameRequest } from '#app/frame-registry.ts'
 import '#app/frame-registrations.ts'
 import { loadProfileData } from '#app/profile-data.ts'
 import { type routes } from '#app/routes.ts'
+import { normalizeRedirectTo } from '#app/safe-redirect.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
 import { getUserAvatarObject } from '#worker/community/avatar.ts'
@@ -21,6 +22,18 @@ import { parseOgTheme } from '#worker/og/palette.ts'
 const followBodySchema = z.object({
 	follow: z.boolean(),
 })
+
+function parseBooleanFormField(value: FormDataEntryValue | null) {
+	if (typeof value !== 'string') return null
+	if (value === 'true') return true
+	if (value === 'false') return false
+	return null
+}
+
+function readSafeReturnTo(value: FormDataEntryValue | null) {
+	if (typeof value !== 'string') return null
+	return normalizeRedirectTo(value)
+}
 
 export function createProfileHandler(env: Env) {
 	return {
@@ -177,14 +190,39 @@ export function createProfileFollowApiPostHandler(env: Env) {
 				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
 			}
 
-			const body = await request.json().catch(() => null)
-			const parsed = followBodySchema.safeParse(body)
-			if (!parsed.success) {
-				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
+			const contentType = request.headers.get('content-type') ?? ''
+			let follow: boolean | null = null
+			let returnTo: string | null = null
+			if (contentType.includes('application/json')) {
+				const body = await request.json().catch(() => null)
+				const parsed = followBodySchema.safeParse(body)
+				if (!parsed.success) {
+					return jsonResponse(
+						{ ok: false, error: 'Invalid request body.' },
+						400,
+					)
+				}
+				follow = parsed.data.follow
+			} else {
+				const form = await request.formData().catch(() => null)
+				if (!form) {
+					return jsonResponse(
+						{ ok: false, error: 'Invalid request body.' },
+						400,
+					)
+				}
+				follow = parseBooleanFormField(form.get('follow'))
+				returnTo = readSafeReturnTo(form.get('returnTo'))
+				if (follow == null) {
+					return jsonResponse(
+						{ ok: false, error: 'Invalid request body.' },
+						400,
+					)
+				}
 			}
 
 			try {
-				if (parsed.data.follow) {
+				if (follow) {
 					await followCommunityUser({
 						env,
 						followerUserId: user.mcpUser.userId,
@@ -197,9 +235,21 @@ export function createProfileFollowApiPostHandler(env: Env) {
 						followeeUsername: params.username,
 					})
 				}
-				return jsonResponse({ ok: true, following: parsed.data.follow })
+				if (returnTo) {
+					return new Response(null, {
+						status: 303,
+						headers: { Location: returnTo },
+					})
+				}
+				return jsonResponse({ ok: true, following: follow })
 			} catch (error) {
 				if (error instanceof CommunityActionError) {
+					if (returnTo) {
+						return new Response(null, {
+							status: 303,
+							headers: { Location: returnTo },
+						})
+					}
 					return jsonResponse({ ok: false, error: error.message }, 400)
 				}
 				console.error('Profile follow update failed:', error)

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -79,6 +79,10 @@ export type CommunityDetailLoaderData = {
 	listing: PublicCommunityListing
 	/** True when `/@owner` is publicly reachable. */
 	ownerProfilePublic: boolean
+	/** True when the signed-in viewer follows the listing owner. */
+	viewerFollowsOwner: boolean
+	/** True when the signed-in viewer owns this listing. */
+	viewerIsOwner: boolean
 	loggedIn: boolean
 	viewerIsAdmin: boolean
 	forkPrompt: string

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -53,6 +53,7 @@ vi.mock('#worker/community/social-repo.ts', async (importOriginal) => {
 	return {
 		...actual,
 		getCommunityStar: vi.fn().mockResolvedValue(false),
+		getUserFollow: vi.fn().mockResolvedValue(false),
 		getUserSocialRowByUsername: (...args: Array<unknown>) =>
 			communityMockModule.getUserSocialRowByUsername(...args),
 	}
@@ -638,6 +639,7 @@ test('community detail SSR renders the redesigned article', async () => {
 	)
 	communityMockModule.getUserSocialRowByUsername.mockResolvedValue({
 		profile_visibility: 'public',
+		stable_user_id: 'owner-mcp-id',
 	})
 
 	const response = await createCommunityDetailHandler(env).handler({
@@ -658,6 +660,7 @@ test('community detail SSR renders the redesigned article', async () => {
 	expect(html).toContain('by ')
 	expect(html).toContain('href="/@kentcdodds"')
 	expect(html).toContain('>@kentcdodds</a>')
+	expect(html).toContain('data-testid="community-detail-owner-follow"')
 	expect(html).not.toContain('data-testid="community-detail-owner-private"')
 	expect(html).toContain('data-testid="community-detail-trusted-badge"')
 	expect(html).toContain('License')

--- a/packages/worker/src/community/welcome-follow.node.test.ts
+++ b/packages/worker/src/community/welcome-follow.node.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import { followDefaultWelcomeAccount } from './welcome-follow.ts'
+
+type FakeUser = {
+	username: string
+	stable_user_id: string
+	profile_visibility: 'public' | 'private'
+}
+
+function createFakeDb(input: {
+	kody?: FakeUser | null
+	onInsert?: (followerUserId: string, followeeUserId: string) => void
+	failLookup?: boolean
+}) {
+	return {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async first() {
+							if (input.failLookup) throw new Error('db down')
+							if (
+								query.includes('FROM users') &&
+								query.includes('username = ?')
+							) {
+								if (String(params[0]) !== 'kody' || !input.kody) return null
+								return {
+									id: 1,
+									username: input.kody.username,
+									email: 'kody@example.com',
+									stable_user_id: input.kody.stable_user_id,
+									display_name: null,
+									bio: null,
+									avatar_key: null,
+									profile_visibility: input.kody.profile_visibility,
+									created_at: '2026-01-01T00:00:00.000Z',
+								}
+							}
+							return null
+						},
+						async run() {
+							if (query.includes('INSERT INTO user_follows')) {
+								input.onInsert?.(String(params[0]), String(params[1]))
+								return { meta: { changes: 1, last_row_id: 0 } }
+							}
+							return { meta: { changes: 0, last_row_id: 0 } }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+test('followDefaultWelcomeAccount follows public @kody and ignores missing/private/self', async () => {
+	const inserts: Array<[string, string]> = []
+	const publicDb = createFakeDb({
+		kody: {
+			username: 'kody',
+			stable_user_id: 'stable-kody',
+			profile_visibility: 'public',
+		},
+		onInsert: (followerUserId, followeeUserId) => {
+			inserts.push([followerUserId, followeeUserId])
+		},
+	})
+	await followDefaultWelcomeAccount({
+		db: publicDb,
+		followerUserId: 'stable-new-user',
+	})
+	expect(inserts).toEqual([['stable-new-user', 'stable-kody']])
+
+	const missingDb = createFakeDb({ kody: null })
+	await followDefaultWelcomeAccount({
+		db: missingDb,
+		followerUserId: 'stable-new-user',
+	})
+
+	const privateDb = createFakeDb({
+		kody: {
+			username: 'kody',
+			stable_user_id: 'stable-kody',
+			profile_visibility: 'private',
+		},
+		onInsert: () => {
+			throw new Error('should not insert for private @kody')
+		},
+	})
+	await followDefaultWelcomeAccount({
+		db: privateDb,
+		followerUserId: 'stable-new-user',
+	})
+
+	const selfDb = createFakeDb({
+		kody: {
+			username: 'kody',
+			stable_user_id: 'stable-kody',
+			profile_visibility: 'public',
+		},
+		onInsert: () => {
+			throw new Error('should not self-follow @kody')
+		},
+	})
+	await followDefaultWelcomeAccount({
+		db: selfDb,
+		followerUserId: 'stable-kody',
+	})
+
+	consoleWarn.mockImplementation(() => {})
+	const failingDb = createFakeDb({ failLookup: true })
+	await followDefaultWelcomeAccount({
+		db: failingDb,
+		followerUserId: 'stable-new-user',
+	})
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'Failed to auto-follow @kody for new user:',
+		expect.any(Error),
+	)
+})

--- a/packages/worker/src/community/welcome-follow.node.test.ts
+++ b/packages/worker/src/community/welcome-follow.node.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
-import { followDefaultWelcomeAccount } from './welcome-follow.ts'
+import { followDefaultWelcomeAccounts } from './welcome-follow.ts'
 
 type FakeUser = {
 	username: string
@@ -9,10 +9,11 @@ type FakeUser = {
 }
 
 function createFakeDb(input: {
-	kody?: FakeUser | null
+	users?: Record<string, FakeUser | null>
 	onInsert?: (followerUserId: string, followeeUserId: string) => void
 	failLookup?: boolean
 }) {
+	const users = input.users ?? {}
 	return {
 		prepare(query: string) {
 			return {
@@ -24,16 +25,18 @@ function createFakeDb(input: {
 								query.includes('FROM users') &&
 								query.includes('username = ?')
 							) {
-								if (String(params[0]) !== 'kody' || !input.kody) return null
+								const username = String(params[0])
+								const user = users[username]
+								if (!user) return null
 								return {
 									id: 1,
-									username: input.kody.username,
-									email: 'kody@example.com',
-									stable_user_id: input.kody.stable_user_id,
+									username: user.username,
+									email: `${user.username}@example.com`,
+									stable_user_id: user.stable_user_id,
 									display_name: null,
 									bio: null,
 									avatar_key: null,
-									profile_visibility: input.kody.profile_visibility,
+									profile_visibility: user.profile_visibility,
 									created_at: '2026-01-01T00:00:00.000Z',
 								}
 							}
@@ -53,68 +56,100 @@ function createFakeDb(input: {
 	} as unknown as D1Database
 }
 
-test('followDefaultWelcomeAccount follows public @kody and ignores missing/private/self', async () => {
+test('followDefaultWelcomeAccounts follows public @kody and @kentcdodds', async () => {
 	const inserts: Array<[string, string]> = []
 	const publicDb = createFakeDb({
-		kody: {
-			username: 'kody',
-			stable_user_id: 'stable-kody',
-			profile_visibility: 'public',
+		users: {
+			kody: {
+				username: 'kody',
+				stable_user_id: 'stable-kody',
+				profile_visibility: 'public',
+			},
+			kentcdodds: {
+				username: 'kentcdodds',
+				stable_user_id: 'stable-kent',
+				profile_visibility: 'public',
+			},
 		},
 		onInsert: (followerUserId, followeeUserId) => {
 			inserts.push([followerUserId, followeeUserId])
 		},
 	})
-	await followDefaultWelcomeAccount({
+	await followDefaultWelcomeAccounts({
 		db: publicDb,
 		followerUserId: 'stable-new-user',
 	})
-	expect(inserts).toEqual([['stable-new-user', 'stable-kody']])
+	expect(inserts).toEqual([
+		['stable-new-user', 'stable-kody'],
+		['stable-new-user', 'stable-kent'],
+	])
 
-	const missingDb = createFakeDb({ kody: null })
-	await followDefaultWelcomeAccount({
+	const missingDb = createFakeDb({ users: {} })
+	await followDefaultWelcomeAccounts({
 		db: missingDb,
 		followerUserId: 'stable-new-user',
 	})
 
-	const privateDb = createFakeDb({
-		kody: {
-			username: 'kody',
-			stable_user_id: 'stable-kody',
-			profile_visibility: 'private',
+	const privateKentInserts: Array<[string, string]> = []
+	const privateKentDb = createFakeDb({
+		users: {
+			kody: {
+				username: 'kody',
+				stable_user_id: 'stable-kody',
+				profile_visibility: 'public',
+			},
+			kentcdodds: {
+				username: 'kentcdodds',
+				stable_user_id: 'stable-kent',
+				profile_visibility: 'private',
+			},
 		},
-		onInsert: () => {
-			throw new Error('should not insert for private @kody')
+		onInsert: (followerUserId, followeeUserId) => {
+			privateKentInserts.push([followerUserId, followeeUserId])
 		},
 	})
-	await followDefaultWelcomeAccount({
-		db: privateDb,
+	await followDefaultWelcomeAccounts({
+		db: privateKentDb,
 		followerUserId: 'stable-new-user',
 	})
+	expect(privateKentInserts).toEqual([['stable-new-user', 'stable-kody']])
 
 	const selfDb = createFakeDb({
-		kody: {
-			username: 'kody',
-			stable_user_id: 'stable-kody',
-			profile_visibility: 'public',
+		users: {
+			kody: {
+				username: 'kody',
+				stable_user_id: 'stable-kody',
+				profile_visibility: 'public',
+			},
+			kentcdodds: {
+				username: 'kentcdodds',
+				stable_user_id: 'stable-kent',
+				profile_visibility: 'public',
+			},
 		},
-		onInsert: () => {
-			throw new Error('should not self-follow @kody')
+		onInsert: (_followerUserId, followeeUserId) => {
+			if (followeeUserId === 'stable-kent') {
+				throw new Error('should not self-follow @kentcdodds')
+			}
 		},
 	})
-	await followDefaultWelcomeAccount({
+	await followDefaultWelcomeAccounts({
 		db: selfDb,
-		followerUserId: 'stable-kody',
+		followerUserId: 'stable-kent',
 	})
 
 	consoleWarn.mockImplementation(() => {})
 	const failingDb = createFakeDb({ failLookup: true })
-	await followDefaultWelcomeAccount({
+	await followDefaultWelcomeAccounts({
 		db: failingDb,
 		followerUserId: 'stable-new-user',
 	})
 	expect(consoleWarn).toHaveBeenCalledWith(
 		'Failed to auto-follow @kody for new user:',
+		expect.any(Error),
+	)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'Failed to auto-follow @kentcdodds for new user:',
 		expect.any(Error),
 	)
 })

--- a/packages/worker/src/community/welcome-follow.ts
+++ b/packages/worker/src/community/welcome-follow.ts
@@ -1,0 +1,30 @@
+import { resolveUserStableId } from '#worker/user-id.ts'
+import { getUserSocialRowByUsername, insertUserFollow } from './social-repo.ts'
+
+export const defaultWelcomeFollowUsername = 'kody'
+
+/**
+ * Best-effort follow of the platform `@kody` account after signup. Missing,
+ * private, or self `@kody` accounts are ignored so account creation never
+ * fails on social-graph setup.
+ */
+export async function followDefaultWelcomeAccount(input: {
+	db: D1Database
+	followerUserId: string
+}): Promise<void> {
+	try {
+		const followee = await getUserSocialRowByUsername(
+			input.db,
+			defaultWelcomeFollowUsername,
+		)
+		if (!followee || followee.profile_visibility === 'private') return
+		const followeeUserId = resolveUserStableId(followee)
+		if (followeeUserId === input.followerUserId) return
+		await insertUserFollow(input.db, {
+			followerUserId: input.followerUserId,
+			followeeUserId,
+		})
+	} catch (error) {
+		console.warn('Failed to auto-follow @kody for new user:', error)
+	}
+}

--- a/packages/worker/src/community/welcome-follow.ts
+++ b/packages/worker/src/community/welcome-follow.ts
@@ -1,30 +1,29 @@
 import { resolveUserStableId } from '#worker/user-id.ts'
 import { getUserSocialRowByUsername, insertUserFollow } from './social-repo.ts'
 
-export const defaultWelcomeFollowUsername = 'kody'
+export const defaultWelcomeFollowUsernames = ['kody', 'kentcdodds'] as const
 
 /**
- * Best-effort follow of the platform `@kody` account after signup. Missing,
- * private, or self `@kody` accounts are ignored so account creation never
- * fails on social-graph setup.
+ * Best-effort follows after signup so new timelines are not empty. Missing,
+ * private, or self accounts are skipped so account creation never fails on
+ * social-graph setup.
  */
-export async function followDefaultWelcomeAccount(input: {
+export async function followDefaultWelcomeAccounts(input: {
 	db: D1Database
 	followerUserId: string
 }): Promise<void> {
-	try {
-		const followee = await getUserSocialRowByUsername(
-			input.db,
-			defaultWelcomeFollowUsername,
-		)
-		if (!followee || followee.profile_visibility === 'private') return
-		const followeeUserId = resolveUserStableId(followee)
-		if (followeeUserId === input.followerUserId) return
-		await insertUserFollow(input.db, {
-			followerUserId: input.followerUserId,
-			followeeUserId,
-		})
-	} catch (error) {
-		console.warn('Failed to auto-follow @kody for new user:', error)
+	for (const username of defaultWelcomeFollowUsernames) {
+		try {
+			const followee = await getUserSocialRowByUsername(input.db, username)
+			if (!followee || followee.profile_visibility === 'private') continue
+			const followeeUserId = resolveUserStableId(followee)
+			if (followeeUserId === input.followerUserId) continue
+			await insertUserFollow(input.db, {
+				followerUserId: input.followerUserId,
+				followeeUserId,
+			})
+		} catch (error) {
+			console.warn(`Failed to auto-follow @${username} for new user:`, error)
+		}
 	}
 }

--- a/packages/worker/src/identity/admin-user-creation.ts
+++ b/packages/worker/src/identity/admin-user-creation.ts
@@ -14,7 +14,7 @@ import {
 	normalizeUsername,
 } from '#worker/identity/username.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
-import { followDefaultWelcomeAccount } from '#worker/community/welcome-follow.ts'
+import { followDefaultWelcomeAccounts } from '#worker/community/welcome-follow.ts'
 
 const adminCreatedNoUsablePasswordHash = 'admin_created_no_usable_password'
 
@@ -181,7 +181,7 @@ export async function adminCreateUserWithPasswordSetup(input: {
 		)
 	}
 
-	await followDefaultWelcomeAccount({
+	await followDefaultWelcomeAccounts({
 		db: input.db,
 		followerUserId: stableUserId,
 	})

--- a/packages/worker/src/identity/admin-user-creation.ts
+++ b/packages/worker/src/identity/admin-user-creation.ts
@@ -14,6 +14,7 @@ import {
 	normalizeUsername,
 } from '#worker/identity/username.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { followDefaultWelcomeAccount } from '#worker/community/welcome-follow.ts'
 
 const adminCreatedNoUsablePasswordHash = 'admin_created_no_usable_password'
 
@@ -179,6 +180,11 @@ export async function adminCreateUserWithPasswordSetup(input: {
 			error instanceof Error ? error.message : 'Unable to create setup link.',
 		)
 	}
+
+	await followDefaultWelcomeAccount({
+		db: input.db,
+		followerUserId: stableUserId,
+	})
 
 	return {
 		userId,

--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -35,6 +35,7 @@
 		"./src/app/community-display.ts",
 		"./src/app/blog-display.ts",
 		"./src/app/document-head.ts",
+		"./src/app/account-plan-display.ts",
 		"./src/app/loader-data.ts",
 		"./src/app/safe-redirect.ts",
 		"./src/app/signup-mode.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make it easy to follow a community package owner from the listing page, and give new accounts a useful timeline by auto-following `@kody` and `@kentcdodds`.

## Summary

- Public listing owners now have a circle-plus follow button next to `@username`.
- If the viewer already follows them, the control switches to a circle-checkmark with an Unfollow tooltip.
- Signed-out visitors are sent to login and returned to the listing.
- Failed follow form posts return to the listing with a visible `followError`.
- Password signup, OAuth signup, and admin-created users best-effort follow public `@kody` and `@kentcdodds`.

## Testing

- Focused node tests for detail frame SSR, profile follow form POST, welcome-follow helper, auth signup, and admin user creation.
- Worker unit suite: 1892 passed.
- Playwright e2e: first pre-push run hit a local worker crash (`ECONNREFUSED` / miniflare disconnect); retry passed all 8 specs.

## System changes

See the system recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ce270b13` · **Head:** `0896202e`

**Classification:** extends — listing detail now exposes follow state and a follow control, and new-account creation seeds follow edges to `@kody` and `@kentcdodds`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — community detail frame renders a follow/unfollow icon next to public owners |
| `app-sessions` | auth | extends — password and OAuth signup auto-follow `@kody` and `@kentcdodds` |
| `community-listings` | assistant | extends — detail loader includes owner follow state for the viewer |
| `community-social` | assistant | extends — welcome-follow helper and follow form POST from listing pages |

### System map

Listing detail looks up whether the viewer follows the owner, then posts through the existing profile follow endpoint. New accounts insert best-effort follows of public `@kody` and `@kentcdodds`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	communityListings["community-listings<br/>Community package listings"]:::extended
	communitySocial["community-social<br/>Community profiles and social graph"]:::extended
	appUi -->|"owner follow form POST"| communitySocial
	communityListings -->|"viewerFollowsOwner on detail load"| communitySocial
	appSessions -->|"signup auto-follow @kody and @kentcdodds"| communitySocial
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Browser
	participant DetailFrame
	participant FollowApi
	participant Signup
	Browser->>DetailFrame: GET /community/:listingId
	DetailFrame-->>Browser: public owner + follow icon
	Browser->>FollowApi: POST /profiles/:username/follow.json
	alt follow succeeds
		FollowApi-->>Browser: 303 back to listing
	else follow fails
		FollowApi-->>Browser: 303 listing?followError=...
	end
	Signup->>FollowApi: best-effort follow @kody and @kentcdodds
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Listing owner line | username / private lock only | public owners also get follow / following icon |
| New account creation | no default follows | auto-follows public `@kody` and `@kentcdodds` |
| Follow API | JSON only | also accepts form POST + `returnTo` / `followError` redirect |

### Invariants

- `community-social-privacy`: follow control is omitted for private owners and for the viewer’s own listing. Welcome follow skips missing, private, or self `@kody` / `@kentcdodds`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af042b6b-0be1-46c7-838f-10defbac1ccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af042b6b-0be1-46c7-838f-10defbac1ccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

