### PR TITLE
fix(ops): quiet operator fleet runtime pages and fix // admin alert URLs

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -328,6 +328,10 @@ Guarantees and rules:
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emails admin-role users when any swept account crosses
-  > 80% of a plan-limit resource or when combined runtime duration for the month
-  > exceeds `fleetRuntimeDurationAlertThresholdMs` (24h). KV cooldown key
-  > `ops-alert:usage-entitlement-pressure:v1` suppresses repeat pages.
+  > 80% of a plan-limit resource, or when a **non-admin** account's combined
+  execute + job_run + workflow_run duration for the month exceeds
+  `fleetRuntimeDurationAlertThresholdMs` (24h). Persistent `service_runtime` and
+  admin-role dogfooding stay on `/admin/insights` rankings but do not page.
+  KV cooldown key `ops-alert:usage-entitlement-pressure:v1` suppresses repeat
+  pages. Admin email links are built with `joinAppUrl` so a trailing slash on
+  `APP_BASE_URL` cannot produce `https://host//admin/…`.

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -327,11 +327,11 @@ Guarantees and rules:
   Queries are `LIMIT`-bounded; entitlement reads run with modest concurrency.
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
-  same ~15-user bound. Emails admin-role users when any swept account crosses
-  > 80% of a plan-limit resource, or when a **non-admin** account's combined
-  execute + job_run + workflow_run duration for the month exceeds
+  same ~15-user bound. Emails admin-role users when any swept account is above
+  80% of a plan-limit resource, or when a non-admin account's combined execute,
+  job_run, and workflow_run duration for the month exceeds
   `fleetRuntimeDurationAlertThresholdMs` (24h). Persistent `service_runtime` and
-  admin-role dogfooding stay on `/admin/insights` rankings but do not page.
+  admin-role dogfooding stay on `/admin/insights` rankings but do not page. The
   KV cooldown key `ops-alert:usage-entitlement-pressure:v1` suppresses repeat
   pages. Admin email links are built with `joinAppUrl` so a trailing slash on
   `APP_BASE_URL` cannot produce `https://host//admin/…`.

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -11,6 +11,7 @@ vi.mock('#worker/admin/entitlement-consumption.ts', () => ({
 }))
 
 const {
+	adminFleetRuntimeDurationAlertMetrics,
 	detectFleetUsagePressure,
 	fleetRuntimeDurationAlertThresholdMs,
 	loadFleetUsageInsights,
@@ -41,12 +42,20 @@ function createFleetDb(input: {
 		event_count: number
 	}>
 	runtimeByUser?: Record<string, number>
+	adminUserIds?: Array<string>
+	onDurationQueryBind?: (params: Array<unknown>) => void
 }) {
 	return {
 		prepare(query: string) {
 			const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
 			return {
-				bind(..._params: Array<unknown>) {
+				bind(...params: Array<unknown>) {
+					if (
+						normalized.includes('sum(total_duration_ms)') &&
+						normalized.includes('user_id in')
+					) {
+						input.onDurationQueryBind?.(params)
+					}
 					return this
 				},
 				async all<T>() {
@@ -66,6 +75,16 @@ function createFleetDb(input: {
 					) {
 						return {
 							results: (input.activeUsers ?? []) as Array<T>,
+						}
+					}
+					if (
+						normalized.includes("r.name = 'admin'") &&
+						normalized.includes('stable_user_id')
+					) {
+						return {
+							results: (input.adminUserIds ?? []).map((stable_user_id) => ({
+								stable_user_id,
+							})) as Array<T>,
 						}
 					}
 					if (
@@ -205,9 +224,22 @@ test('detectFleetUsagePressure flags entitlement and runtime duration thresholds
 					},
 				]
 			}
+			if (input.usageUserId === 'user-admin') {
+				return [
+					{
+						resource: 'saved_packages',
+						label: 'saved packages',
+						current: 9_001,
+						limit: 10_000,
+						percentOfLimit: 0.9001,
+						overEightyPercent: true,
+					},
+				]
+			}
 			return []
 		},
 	)
+	let durationQueryBind: Array<unknown> | undefined
 	const db = createFleetDb({
 		activeUsers: [
 			{
@@ -224,9 +256,21 @@ test('detectFleetUsagePressure flags entitlement and runtime duration thresholds
 				stripe_plan: null,
 				event_count: 40,
 			},
+			{
+				stable_user_id: 'user-admin',
+				username: 'kentcdodds',
+				plan: 'max',
+				stripe_plan: null,
+				event_count: 90,
+			},
 		],
+		adminUserIds: ['user-admin'],
 		runtimeByUser: {
 			'user-b': fleetRuntimeDurationAlertThresholdMs + 1,
+			'user-admin': fleetRuntimeDurationAlertThresholdMs * 2,
+		},
+		onDurationQueryBind(params) {
+			durationQueryBind = params
 		},
 	})
 	const issues = await detectFleetUsagePressure({
@@ -244,10 +288,26 @@ test('detectFleetUsagePressure flags entitlement and runtime duration thresholds
 			percentOfLimit: 0.9,
 		},
 		{
+			kind: 'entitlement',
+			stableUserId: 'user-admin',
+			username: 'kentcdodds',
+			resource: 'saved_packages',
+			label: 'saved packages',
+			percentOfLimit: 0.9001,
+		},
+		{
 			kind: 'runtime_duration',
 			stableUserId: 'user-b',
 			username: 'bob',
 			totalDurationMs: fleetRuntimeDurationAlertThresholdMs + 1,
 		},
+	])
+	expect(adminFleetRuntimeDurationAlertMetrics).toEqual([
+		'execute',
+		'job_run',
+		'workflow_run',
+	])
+	expect(durationQueryBind?.slice(1, 4)).toEqual([
+		...adminFleetRuntimeDurationAlertMetrics,
 	])
 })

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -31,10 +31,23 @@ export const adminFleetRuntimeDurationMetrics = [
 ] as const satisfies ReadonlyArray<AdminUsageMetric>
 
 /**
- * Combined current-month runtime duration (execute + job_run + workflow_run +
- * service_runtime) above which a single account warrants operator review. 24h of
- * wall-clock metered runtime in one UTC month is a practical "heavy but not
- * necessarily abusive" ceiling before paging.
+ * Runtime metrics that can page operators. Persistent `service_runtime` is
+ * wall-clock time a package service stayed up — one always-on service crosses
+ * 24h in a single day — so it stays on the insights rankings but is excluded
+ * from the alert total.
+ */
+export const adminFleetRuntimeDurationAlertMetrics = [
+	'execute',
+	'job_run',
+	'workflow_run',
+] as const satisfies ReadonlyArray<AdminUsageMetric>
+
+/**
+ * Combined current-month execute + job_run + workflow_run duration above which
+ * a non-admin account warrants operator review. 24h of metered sandbox / job /
+ * workflow wall-clock in one UTC month is a practical "heavy but not
+ * necessarily abusive" ceiling before paging. Admin accounts are omitted from
+ * this signal so operator dogfooding does not page the on-call roster.
  */
 export const fleetRuntimeDurationAlertThresholdMs = 24 * 60 * 60 * 1000
 
@@ -120,11 +133,15 @@ export async function detectFleetUsagePressure(input: {
 	)
 	if (activeUsers.length === 0) return []
 
-	const durationByUser = await queryCombinedRuntimeDurationByUserIds(
-		input.db,
-		currentMonth,
-		activeUsers.map((user) => user.stable_user_id),
-	)
+	const [durationByUser, adminUserIds] = await Promise.all([
+		queryCombinedRuntimeDurationByUserIds(
+			input.db,
+			currentMonth,
+			activeUsers.map((user) => user.stable_user_id),
+			adminFleetRuntimeDurationAlertMetrics,
+		),
+		listAdminStableUserIds(input.db),
+	])
 	const issues: Array<FleetEntitlementPressureIssue> = []
 
 	await mapWithConcurrency(
@@ -152,6 +169,7 @@ export async function detectFleetUsagePressure(input: {
 					percentOfLimit: item.percentOfLimit,
 				})
 			}
+			if (adminUserIds.has(user.stable_user_id)) return
 			const totalDurationMs = durationByUser.get(user.stable_user_id) ?? 0
 			if (totalDurationMs > runtimeDurationThresholdMs) {
 				issues.push({
@@ -369,15 +387,28 @@ async function listActiveUsersForEntitlementSweep(
 	return rows.results ?? []
 }
 
+async function listAdminStableUserIds(db: D1Database) {
+	const rows = await db
+		.prepare(
+			`SELECT u.stable_user_id
+			 FROM users u
+			 INNER JOIN user_roles ur ON ur.user_id = u.id
+			 INNER JOIN roles r ON r.id = ur.role_id
+			 WHERE r.name = 'admin'
+				AND u.deleting_at IS NULL`,
+		)
+		.all<{ stable_user_id: string }>()
+	return new Set((rows.results ?? []).map((row) => row.stable_user_id))
+}
+
 async function queryCombinedRuntimeDurationByUserIds(
 	db: D1Database,
 	currentMonth: string,
 	userIds: ReadonlyArray<string>,
+	metrics: ReadonlyArray<AdminUsageMetric> = adminFleetRuntimeDurationMetrics,
 ): Promise<Map<string, number>> {
 	if (userIds.length === 0) return new Map()
-	const metricPlaceholders = adminFleetRuntimeDurationMetrics
-		.map(() => '?')
-		.join(', ')
+	const metricPlaceholders = metrics.map(() => '?').join(', ')
 	const userPlaceholders = userIds.map(() => '?').join(', ')
 	const rows = await db
 		.prepare(
@@ -388,7 +419,7 @@ async function queryCombinedRuntimeDurationByUserIds(
 				AND user_id IN (${userPlaceholders})
 			 GROUP BY user_id`,
 		)
-		.bind(currentMonth, ...adminFleetRuntimeDurationMetrics, ...userIds)
+		.bind(currentMonth, ...metrics, ...userIds)
 		.all<RuntimeDurationRow>()
 	const byUser = new Map<string, number>()
 	for (const row of rows.results ?? []) {

--- a/packages/worker/src/app-base-url.node.test.ts
+++ b/packages/worker/src/app-base-url.node.test.ts
@@ -3,6 +3,7 @@ import {
 	getAppBaseUrl,
 	getPackageAppBaseUrl,
 	getPackageAppOriginConfigurationError,
+	joinAppUrl,
 } from './app-base-url.ts'
 
 test('getAppBaseUrl prefers the request origin when present', () => {
@@ -40,6 +41,21 @@ test('getAppBaseUrl falls back to APP_BASE_URL then heykody.dev', () => {
 			requestUrl: null,
 		}),
 	).toBe('https://heykody.dev')
+})
+
+test('joinAppUrl strips a trailing slash on APP_BASE_URL', () => {
+	expect(
+		joinAppUrl({
+			env: { APP_BASE_URL: 'https://heykody.dev/' },
+			path: '/admin/insights',
+		}),
+	).toBe('https://heykody.dev/admin/insights')
+	expect(
+		joinAppUrl({
+			env: { APP_BASE_URL: 'https://heykody.dev' },
+			path: 'admin/users',
+		}),
+	).toBe('https://heykody.dev/admin/users')
 })
 
 test('the package-app origin is configurable and never resolves as the app origin', () => {

--- a/packages/worker/src/app-base-url.ts
+++ b/packages/worker/src/app-base-url.ts
@@ -142,3 +142,22 @@ export function getAppBaseUrl(input: {
 
 	return DEFAULT_APP_BASE_URL
 }
+
+/**
+ * Join a first-party app path onto the public origin. Cron and email
+ * call sites must use this (or `getAppBaseUrl` + a path) instead of
+ * `${APP_BASE_URL}/…`, because production `APP_BASE_URL` may include a
+ * trailing slash and would otherwise emit `https://host//path`.
+ */
+export function joinAppUrl(input: {
+	env: AppBaseUrlEnv
+	path: string
+	requestUrl?: string | URL | null
+}) {
+	const origin = getAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
+	const path = input.path.startsWith('/') ? input.path : `/${input.path}`
+	return `${origin}${path}`
+}

--- a/packages/worker/src/app/auth-denial-alerts.node.test.ts
+++ b/packages/worker/src/app/auth-denial-alerts.node.test.ts
@@ -77,7 +77,7 @@ test('auth denial burst alerts stay quiet below threshold, then notify and cool 
 	const env = {
 		APP_DB: createDb(80),
 		AUDIT_DB: createDb(80),
-		APP_BASE_URL: 'https://heykody.dev',
+		APP_BASE_URL: 'https://heykody.dev/',
 		CLOUDFLARE_ACCOUNT_ID: 'acct',
 		CLOUDFLARE_API_TOKEN: 'token',
 		BUNDLE_ARTIFACTS_KV: kv,
@@ -91,6 +91,9 @@ test('auth denial burst alerts stay quiet below threshold, then notify and cool 
 		})
 		expect(first).toEqual({ status: 'notified', count: 80, recipients: 1 })
 		expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+		const payload = sendCloudflareEmail.mock.calls[0]?.[1] as { text: string }
+		expect(payload.text).toContain('https://heykody.dev/admin/insights')
+		expect(payload.text).not.toContain('heykody.dev//')
 		expect(kvStore.get(authDenialAlertKvKey)).toBe(String(now.getTime()))
 		expect(consoleWarn).toHaveBeenCalledWith(
 			'auth-denial-burst-alerted',

--- a/packages/worker/src/app/auth-denial-alerts.ts
+++ b/packages/worker/src/app/auth-denial-alerts.ts
@@ -1,4 +1,5 @@
 import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
+import { joinAppUrl } from '#worker/app-base-url.ts'
 import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
 
 /**
@@ -134,11 +135,14 @@ async function notifyAdminsOfAuthDenialBurst(input: {
 		return { status: 'skipped', reason: 'no_admins' }
 	}
 
-	const baseUrl = input.env.APP_BASE_URL?.trim() || `https://${systemDomain}`
+	const insightsUrl = joinAppUrl({
+		env: input.env,
+		path: '/admin/insights',
+	})
 	const text = [
 		`Kody recorded ${input.count} MCP auth denials in the last ${input.windowMinutes} minutes (threshold ${input.threshold}).`,
 		'A single denial is routine; a burst can mean permission probing or a compromised account.',
-		`Review the failure charts at ${baseUrl}/admin/insights and query auth failures with admin_audit_log_query.`,
+		`Review the failure charts at ${insightsUrl} and query auth failures with admin_audit_log_query.`,
 		`Checked at ${input.now.toISOString()}.`,
 	].join('\n\n')
 

--- a/packages/worker/src/app/email-delivery-alerts.node.test.ts
+++ b/packages/worker/src/app/email-delivery-alerts.node.test.ts
@@ -70,7 +70,7 @@ test('thin delivery alert signals notify once per cooldown window', async () => 
 	} as unknown as KVNamespace
 	const env = {
 		APP_DB: createDb(35),
-		APP_BASE_URL: 'https://heykody.dev',
+		APP_BASE_URL: 'https://heykody.dev/',
 		USER_EMAIL_DOMAIN: 'mail.heykody.dev',
 		BUNDLE_ARTIFACTS_KV: kv,
 	}
@@ -79,6 +79,9 @@ test('thin delivery alert signals notify once per cooldown window', async () => 
 		await expect(
 			checkEmailDeliveryBurstAndNotify({ env, now, threshold: 20 }),
 		).resolves.toEqual({ status: 'notified', count: 35, recipients: 1 })
+		const payload = sendCloudflareEmail.mock.calls[0]?.[1] as { text: string }
+		expect(payload.text).toContain('https://heykody.dev/admin/insights')
+		expect(payload.text).not.toContain('heykody.dev//')
 		expect(kvStore.get(emailDeliveryAlertKvKey)).toBe(String(now.getTime()))
 		await expect(
 			checkEmailDeliveryBurstAndNotify({

--- a/packages/worker/src/app/email-delivery-alerts.ts
+++ b/packages/worker/src/app/email-delivery-alerts.ts
@@ -1,4 +1,5 @@
 import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
+import { joinAppUrl } from '#worker/app-base-url.ts'
 import { pruneDeliveryAlertEvents } from '#worker/email/delivery-alert-events.ts'
 import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
 
@@ -83,10 +84,13 @@ export async function checkEmailDeliveryBurstAndNotify(input: {
 	if (recipients.length === 0) {
 		return { status: 'skipped', reason: 'no_admins' }
 	}
-	const baseUrl = input.env.APP_BASE_URL?.trim() || `https://${systemDomain}`
+	const insightsUrl = joinAppUrl({
+		env: input.env,
+		path: '/admin/insights',
+	})
 	const text = [
 		`Kody recorded ${count} bounced or complained email outcomes in the last ${windowMinutes} minutes (threshold ${threshold}).`,
-		`Review Email delivery health at ${baseUrl}/admin/insights.`,
+		`Review Email delivery health at ${insightsUrl}.`,
 		`Checked at ${now.toISOString()}.`,
 	].join('\n\n')
 	const sent = await sendCloudflareEmail(

--- a/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.node.test.ts
@@ -101,7 +101,7 @@ test('usage entitlement alerts stay quiet without pressure, then notify and cool
 	} as unknown as KVNamespace
 	const env = {
 		APP_DB: createDb(),
-		APP_BASE_URL: 'https://heykody.dev',
+		APP_BASE_URL: 'https://heykody.dev/',
 		CLOUDFLARE_ACCOUNT_ID: 'acct',
 		CLOUDFLARE_API_TOKEN: 'token',
 		BUNDLE_ARTIFACTS_KV: kv,
@@ -111,6 +111,12 @@ test('usage entitlement alerts stay quiet without pressure, then notify and cool
 		const first = await checkUsageEntitlementPressureAndNotify({ env, now })
 		expect(first).toEqual({ status: 'notified', issueCount: 1, recipients: 1 })
 		expect(sendCloudflareEmail).toHaveBeenCalledTimes(1)
+		const payload = sendCloudflareEmail.mock.calls[0]?.[1] as {
+			text: string
+		}
+		expect(payload.text).toContain('https://heykody.dev/admin/insights')
+		expect(payload.text).toContain('https://heykody.dev/admin/users')
+		expect(payload.text).not.toContain('https://heykody.dev//')
 		expect(kvStore.get(usageEntitlementAlertKvKey)).toBe(String(now.getTime()))
 
 		const second = await checkUsageEntitlementPressureAndNotify({
@@ -148,11 +154,48 @@ test('usage entitlement alerts no-op when no admins exist', async () => {
 	const result = await checkUsageEntitlementPressureAndNotify({
 		env: {
 			APP_DB: db,
-			APP_BASE_URL: 'https://heykody.dev',
+			APP_BASE_URL: 'https://heykody.dev/',
 			CLOUDFLARE_ACCOUNT_ID: 'acct',
 			CLOUDFLARE_API_TOKEN: 'token',
 		},
 	})
 	expect(result).toEqual({ status: 'skipped', reason: 'no_admins' })
 	expect(sendCloudflareEmail).not.toHaveBeenCalled()
+})
+
+test('usage entitlement alerts describe execute/job/workflow runtime without double-slash links', async () => {
+	detectFleetUsagePressure.mockResolvedValue([
+		{
+			kind: 'runtime_duration',
+			stableUserId: 'user-b',
+			username: 'bob',
+			totalDurationMs: 90_000_000,
+		},
+	])
+	consoleWarn.mockImplementation(() => {})
+	try {
+		const result = await checkUsageEntitlementPressureAndNotify({
+			env: {
+				APP_DB: createDb(),
+				APP_BASE_URL: 'https://heykody.dev/',
+				CLOUDFLARE_ACCOUNT_ID: 'acct',
+				CLOUDFLARE_API_TOKEN: 'token',
+			},
+			now: new Date('2026-08-06T23:00:40.000Z'),
+		})
+		expect(result).toEqual({ status: 'notified', issueCount: 1, recipients: 1 })
+		const payload = sendCloudflareEmail.mock.calls[0]?.[1] as {
+			text: string
+			html: string
+		}
+		expect(payload.text).toContain(
+			'25.0h execute/job/workflow runtime this month (threshold 24h)',
+		)
+		expect(payload.text).toContain('https://heykody.dev/admin/insights')
+		expect(payload.text).toContain('https://heykody.dev/admin/users')
+		expect(payload.text).not.toContain('heykody.dev//')
+		expect(payload.html).not.toContain('heykody.dev//')
+	} finally {
+		consoleWarn.mockReset()
+	}
 })

--- a/packages/worker/src/app/usage-entitlement-alerts.ts
+++ b/packages/worker/src/app/usage-entitlement-alerts.ts
@@ -5,6 +5,7 @@ import {
 	fleetRuntimeDurationAlertThresholdMs,
 	type FleetEntitlementPressureIssue,
 } from '#worker/admin/fleet-usage-insights.ts'
+import { joinAppUrl } from '#worker/app-base-url.ts'
 import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
 
 /**
@@ -116,7 +117,14 @@ async function notifyAdminsOfUsageEntitlementPressure(input: {
 		return { status: 'skipped', reason: 'no_admins' }
 	}
 
-	const baseUrl = input.env.APP_BASE_URL?.trim() || `https://${systemDomain}`
+	const insightsUrl = joinAppUrl({
+		env: input.env,
+		path: '/admin/insights',
+	})
+	const usersUrl = joinAppUrl({
+		env: input.env,
+		path: '/admin/users',
+	})
 	const runtimeHours = Math.round(
 		fleetRuntimeDurationAlertThresholdMs / (60 * 60 * 1000),
 	)
@@ -126,7 +134,7 @@ async function notifyAdminsOfUsageEntitlementPressure(input: {
 	const text = [
 		`Kody detected ${input.issues.length} fleet usage pressure signal(s) while sweeping the top ${adminFleetEntitlementSweepUserLimit} active accounts this UTC month.`,
 		lines.join('\n'),
-		`Review entitlement pressure and top consumers at ${baseUrl}/admin/insights, or drill into a user at ${baseUrl}/admin/users.`,
+		`Review entitlement pressure and top consumers at ${insightsUrl}, or drill into a user at ${usersUrl}.`,
 		`Checked at ${input.now.toISOString()}.`,
 	].join('\n\n')
 
@@ -174,7 +182,7 @@ function formatIssueLine(
 		return `• ${issue.username} (${issue.stableUserId}): ${issue.label} at ${percent}% of plan limit`
 	}
 	const hours = (issue.totalDurationMs / (60 * 60 * 1000)).toFixed(1)
-	return `• ${issue.username} (${issue.stableUserId}): ${hours}h combined runtime this month (threshold ${runtimeHours}h)`
+	return `• ${issue.username} (${issue.stableUserId}): ${hours}h execute/job/workflow runtime this month (threshold ${runtimeHours}h)`
 }
 
 function escapeHtml(value: string) {

--- a/packages/worker/src/email/outbound-abuse.ts
+++ b/packages/worker/src/email/outbound-abuse.ts
@@ -13,6 +13,7 @@
 
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
+import { joinAppUrl } from '#worker/app-base-url.ts'
 import { mailboxRpc } from './mailbox-client.ts'
 import { getSystemEmailDomain } from './platform-address.ts'
 import { type EmailDeliveryStatus } from './types.ts'
@@ -178,7 +179,7 @@ async function notifyAdminsOfOutboundEmailPause(input: {
 		const text = [
 			`Outbound email was automatically paused for user "${username}" after ${reason}.`,
 			'The account can still receive mail and use every other capability; only outbound sending is blocked.',
-			`Review the delivery history and clear the pause from ${input.env.APP_BASE_URL?.trim() || `https://${systemDomain}`}/admin/users if this was a false positive.`,
+			`Review the delivery history and clear the pause from ${joinAppUrl({ env: input.env, path: '/admin/users' })} if this was a false positive.`,
 		].join('\n\n')
 		await sendCloudflareEmail(
 			{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Interpret and tune the new fleet usage pressure email so operator dogfooding (especially `kentcdodds`) does not page the admin roster all month, and fix the broken `https://heykody.dev//admin/…` links in those emails.

## Summary

- The email is an **ops early-warning**, not a plan breach or hard limit. It fires when the hourly sweep of the top 15 active accounts this UTC month sees either:
  - a resource at **above 80% of a plan limit**, or
  - combined runtime above **24h**.
- Kent's notice was the second kind: **24.2h combined runtime** vs a **24h** threshold on Aug 6. That is expected dogfooding, not abuse. Because the threshold is monthly and cooldown is 6h, the same signal would keep emailing for the rest of August.
- Runtime paging now **skips admin-role accounts** and **excludes persistent `service_runtime` wall-clock** (one always-on service crosses 24h in a day). Entitlement-pressure pages still fire for every swept account, including admins. Insights rankings are unchanged.
- Admin email links now go through `joinAppUrl`, which uses `getAppBaseUrl().origin`, so a trailing slash on `APP_BASE_URL` no longer produces `https://heykody.dev//admin/insights`.

## Testing

- Focused unit tests: `app-base-url`, `fleet-usage-insights`, `usage-entitlement-alerts`, `email-delivery-alerts`, `auth-denial-alerts` (12 passing).
- Full `npm run validate`: lint, typecheck, unit, e2e, mcp, builds, primitives, migrations, deploy-guardrails, and docs all passed. Format failed once on wrapping in `usage-metering.md`; that is fixed and `oxfmt --check` is clean on the file.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `84e9632d` · **Head:** `9acd4df2`

**Classification:** extends — operator alert URL construction and fleet runtime-pressure detection change behavior; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — usage / delivery alert emails join admin URLs via `joinAppUrl` |
| `scheduled-cron` | surfaces | extends — auth-denial alert emails use the same URL join |
| `email` | assistant | extends — outbound-pause admin review link uses `joinAppUrl` |
| `usage-metering` | storage | extends (unmatched admin path) — runtime-duration pages ignore admins and `service_runtime` |

### System map

Hourly ops emails now resolve first-party admin links through the app origin helper, and the fleet pressure detector stops paging admin dogfooding / always-on service wall-clock.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::extended
	appUi["app-ui<br/>Browser app"]:::extended
	email["email<br/>Email"]:::extended
	usageMetering["usage-metering<br/>Usage metering"]:::extended
	scheduledCron -->|"hourly usage_entitlement_alert lane"| appUi
	appUi -->|"detectFleetUsagePressure skips admin runtime + service_runtime"| usageMetering
	appUi -->|"joinAppUrl admin/insights and admin/users"| email
	scheduledCron -->|"auth denial burst review link"| email
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cron as usage_entitlement_alert
	participant Detect as detectFleetUsagePressure
	participant Mail as admin email
	Cron->>Detect: sweep top 15 active users
	Detect-->>Cron: entitlement issues (all users)
	Detect-->>Cron: runtime issues (non-admin, no service_runtime)
	Cron->>Mail: joinAppUrl(/admin/insights|/admin/users)
```

### Before / after

```text
Before: `${APP_BASE_URL}/admin/insights` → https://heykody.dev//admin/insights
After:  joinAppUrl({ path: '/admin/insights' }) → https://heykody.dev/admin/insights

Before: any swept account with execute+job+workflow+service > 24h pages
After:  admin accounts never page on runtime; service_runtime excluded; entitlement pages unchanged
```

### Invariants

Per-user isolation is unchanged. Admin exclusion is role-gated operator policy on the alert lane only; insights still show every account's usage.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef378742-96ad-4617-8ae3-8137faaff505?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef378742-96ad-4617-8ae3-8137faaff505&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage entitlement alerts now evaluate non-admin runtime against execute, job, and workflow durations.
  * Admin runtime activity remains visible in usage rankings without triggering runtime alerts.
  * Admin notification links now remain correctly formatted when the application URL includes a trailing slash.
  * Updated alert messages to clearly identify the relevant runtime categories.

* **Tests**
  * Expanded coverage for runtime alert behavior, administrator exclusions, URL formatting, and notification links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->