### PR TITLE
fix(types): include account-plan-display in the client tsconfig

### DIFF
--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -35,6 +35,7 @@
 		"./src/app/community-display.ts",
 		"./src/app/blog-display.ts",
 		"./src/app/document-head.ts",
+		"./src/app/account-plan-display.ts",
 		"./src/app/loader-data.ts",
 		"./src/app/safe-redirect.ts",
 		"./src/app/signup-mode.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock production deploy after [#1262](https://github.com/kentcdodds/kody/pull/1262). Main Validate failed typecheck because [#1260](https://github.com/kentcdodds/kody/pull/1260) added a client import of `#app/account-plan-display.ts` without listing that file in the composite client tsconfig.

## Summary

- Add `packages/worker/src/app/account-plan-display.ts` to `packages/worker/tsconfig-client.json` `include`.
- Local `tsc -b` client + worker typecheck now passes on `430a738e` + this one-liner.

## Testing

- `npx tsc -b packages/worker/tsconfig-client.json packages/worker/tsconfig-worker-typecheck.json --noEmit`

## System changes

Low-risk composite tsconfig include only. No runtime behavior change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef378742-96ad-4617-8ae3-8137faaff505?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef378742-96ad-4617-8ae3-8137faaff505&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

