### PR TITLE
Add a copyable Activity prompt for reviewing open errors

### DIFF
--- a/docs/use/activity.md
+++ b/docs/use/activity.md
@@ -23,6 +23,9 @@ detail view.
 
 ## Ask your agent
 
+`/account/activity` includes a short copyable prompt that tells your agent to
+review open errors and recommend whether to ignore, resolve, or fix them.
+
 The MCP **`runs`** domain reads and triages the same data:
 
 - **`run_summary`** — “is anything broken?” open-error totals (plus ignored /

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -1,5 +1,6 @@
 import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
+import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
 import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
@@ -47,6 +48,12 @@ import {
 } from '#client/styles/style-primitives.ts'
 
 const selectCss = getSelectCss()
+
+const activityErrorReviewPrompt = [
+	'Look at my open Kody activity errors.',
+	'Start with run_summary, then run_list for open errors, and run_get on the ones that matter.',
+	'Explain each failure and recommend whether to ignore it, mark it resolved, or fix something.',
+].join(' ')
 
 const accountActivityApiPath = '/account/activity.json'
 const activityRoute = createListDetailRoute('/account/activity')
@@ -451,6 +458,32 @@ export function AccountActivityRoute(handle: Handle) {
 					description="Failures and recent runs across jobs, packages, apps, and other surfaces — with the logs you need to diagnose them."
 					currentHref={currentHref}
 				/>
+				<figure
+					mix={css({
+						display: 'grid',
+						gap: spacing.sm,
+						justifyItems: 'start',
+						margin: 0,
+						maxWidth: '46rem',
+					})}
+				>
+					<blockquote
+						mix={css({
+							margin: 0,
+							color: colors.textMuted,
+							fontSize: typography.fontSize.sm,
+							lineHeight: 1.5,
+						})}
+					>
+						{activityErrorReviewPrompt}
+					</blockquote>
+					<CopyTextButton
+						value={activityErrorReviewPrompt}
+						idleLabel="Copy prompt"
+						variant="ghost"
+						size="sm"
+					/>
+				</figure>
 
 				{status === 'loading' ? (
 					<p mix={css({ color: colors.textMuted, margin: 0 })}>

--- a/packages/worker/tsconfig-client.json
+++ b/packages/worker/tsconfig-client.json
@@ -36,6 +36,7 @@
 		"./src/app/blog-display.ts",
 		"./src/app/document-head.ts",
 		"./src/app/loader-data.ts",
+		"./src/app/account-plan-display.ts",
 		"./src/app/safe-redirect.ts",
 		"./src/app/signup-mode.ts",
 		"./src/identity/permissions.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give signed-in users a brief, copyable prompt on Activity so their agent can inspect open errors and recommend what to do with them.

## Summary

- `/account/activity` shows a short prompt under the page description plus a Copy prompt button.
- The prompt points the agent at `run_summary`, open-error `run_list`, and `run_get`, then asks for ignore / resolve / fix recommendations.
- Usage docs mention the copyable prompt.
- Also includes the client typecheck include for `account-plan-display.ts`, which billing/usage already import.

## Testing

- Local UI check on `/account/activity` after login.
- `tsc -b packages/worker/tsconfig-client.json --noEmit`
- CI Validate / Preview on this PR.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `430a738e` · **Head:** `67162e99`

**Classification:** composes — no primitives added or changed; this PR adds copyable Activity prompt copy in the existing account UI.

### Primitives touched

| Primitive | Group    | Impact |
| --------- | -------- | ------ |
| `app-ui`  | surfaces | composes — Activity header prompt + copy button |

### System map

Activity still reads the same run-record surface; the header now offers a pasteable agent prompt that uses existing `runs` capabilities.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	appUi -->|"copyable Activity error prompt"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cc7a10e-da2f-4b0e-9bce-1cce30ce2541?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cc7a10e-da2f-4b0e-9bce-1cce30ce2541&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

