### PR TITLE
fix(sentry): make source map uploads actually reach Sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ mock-data
 playwright-report
 test-results
 packages/worker/public/client-entry.js
+packages/worker/public/client-entry.js.map
 packages/worker/public/assets/
 packages/worker/public/client-manifest.json
 packages/worker/wrangler-preview.generated.json

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:mock-cloudflare": "node --env-file=packages/worker/.env ./wrangler-env.ts dev --local --config packages/mock-servers/cloudflare/wrangler.jsonc",
     "deploy": "node --input-type=module -e \"if (['preview','test'].includes(process.env.CLOUDFLARE_ENV ?? '')) { await import('./tools/prepare-e2e-env.ts'); }\" && npm run build && node --env-file=packages/worker/.env ./wrangler-env.ts deploy --outdir .wrangler/sentry-bundle --upload-source-maps",
     "sentry:upload-sourcemaps": "node tools/sentry-upload-sourcemaps.ts",
-    "build:client:web": "npm run clean:client && mkdir -p .tmp && esbuild packages/worker/client/entry.tsx --bundle --splitting --format=esm --target=es2022 --outdir=packages/worker/public --entry-names=client-entry --chunk-names=assets/[name]-[hash] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/ui --minify --metafile=.tmp/client-meta.json && node tools/build-client-manifest.ts",
+    "build:client:web": "npm run clean:client && mkdir -p .tmp && esbuild packages/worker/client/entry.tsx --bundle --splitting --format=esm --target=es2022 --outdir=packages/worker/public --entry-names=client-entry --chunk-names=assets/[name]-[hash] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/ui --minify --sourcemap --metafile=.tmp/client-meta.json && node tools/build-client-manifest.ts && node node_modules/@sentry/cli/bin/sentry-cli sourcemaps inject packages/worker/public",
     "build:client": "npm run build:client:web",
     "build": "nx run worker:build",
     "backup:build": "wrangler deploy --dry-run --config packages/backup-control-plane/wrangler.jsonc",

--- a/packages/worker/project.json
+++ b/packages/worker/project.json
@@ -26,6 +26,7 @@
 			"executor": "nx:run-commands",
 			"outputs": [
 				"{workspaceRoot}/packages/worker/public/client-entry.js",
+				"{workspaceRoot}/packages/worker/public/client-entry.js.map",
 				"{workspaceRoot}/packages/worker/public/assets",
 				"{workspaceRoot}/packages/worker/public/client-manifest.json"
 			],
@@ -37,6 +38,7 @@
 			"executor": "nx:run-commands",
 			"outputs": [
 				"{workspaceRoot}/packages/worker/public/client-entry.js",
+				"{workspaceRoot}/packages/worker/public/client-entry.js.map",
 				"{workspaceRoot}/packages/worker/public/assets",
 				"{workspaceRoot}/packages/worker/public/client-manifest.json"
 			],

--- a/tools/sentry-upload-sourcemaps.ts
+++ b/tools/sentry-upload-sourcemaps.ts
@@ -1,105 +1,103 @@
-import { existsSync, readdirSync } from "node:fs";
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { existsSync, readdirSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 
-const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
 // Wrangler resolves `--outdir .wrangler/sentry-bundle` against the config
 // file's directory, so with the generated production config the bundle lands
 // under packages/worker/. The repo-root path is kept as a fallback for local
 // runs where wrangler is invoked with a root-relative config.
 const workerBundleCandidates = [
-  join(root, "packages", "worker", ".wrangler", "sentry-bundle"),
-  join(root, ".wrangler", "sentry-bundle"),
-];
-const clientAssetsDir = join(root, "packages", "worker", "public");
+	join(root, 'packages', 'worker', '.wrangler', 'sentry-bundle'),
+	join(root, '.wrangler', 'sentry-bundle'),
+]
+const clientAssetsDir = join(root, 'packages', 'worker', 'public')
 
 const release =
-  process.env.SENTRY_RELEASE?.trim() ||
-  process.env.APP_COMMIT_SHA?.trim() ||
-  process.env.DEPLOY_COMMIT_SHA?.trim();
-const org = process.env.SENTRY_ORG?.trim();
-const project = process.env.SENTRY_PROJECT?.trim();
-const authToken = process.env.SENTRY_AUTH_TOKEN?.trim();
+	process.env.SENTRY_RELEASE?.trim() ||
+	process.env.APP_COMMIT_SHA?.trim() ||
+	process.env.DEPLOY_COMMIT_SHA?.trim()
+const org = process.env.SENTRY_ORG?.trim()
+const project = process.env.SENTRY_PROJECT?.trim()
+const authToken = process.env.SENTRY_AUTH_TOKEN?.trim()
 
 if (!release || !org || !project || !authToken) {
-  console.log(
-    "sentry-upload-sourcemaps: skipping (need SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT, and SENTRY_RELEASE or APP_COMMIT_SHA)",
-  );
-  process.exit(0);
+	console.log(
+		'sentry-upload-sourcemaps: skipping (need SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT, and SENTRY_RELEASE or APP_COMMIT_SHA)',
+	)
+	process.exit(0)
 }
 
 function hasSourceMaps(dir: string): boolean {
-  if (!existsSync(dir)) return false;
-  try {
-    return readdirSync(dir, { recursive: true }).some((entry) =>
-      String(entry).endsWith(".js.map"),
-    );
-  } catch {
-    return false;
-  }
+	if (!existsSync(dir)) return false
+	try {
+		return readdirSync(dir, { recursive: true }).some((entry) =>
+			String(entry).endsWith('.js.map'),
+		)
+	} catch {
+		return false
+	}
 }
 
 const sentryCliWrapper = join(
-  root,
-  "node_modules",
-  "@sentry",
-  "cli",
-  "bin",
-  "sentry-cli",
-);
+	root,
+	'node_modules',
+	'@sentry',
+	'cli',
+	'bin',
+	'sentry-cli',
+)
 
 function upload(dir: string, label: string): void {
-  console.log(`sentry-upload-sourcemaps: uploading ${label} from ${dir}`);
-  const result = spawnSync(
-    process.execPath,
-    [
-      sentryCliWrapper,
-      "sourcemaps",
-      "upload",
-      dir,
-      "--release",
-      release!,
-      "--org",
-      org!,
-      "--project",
-      project!,
-      "--auth-token",
-      authToken!,
-      "--validate",
-    ],
-    { cwd: root, stdio: "inherit" },
-  );
-  if (result.status !== 0) {
-    throw new Error(
-      `sentry-upload-sourcemaps: ${label} upload failed with status ${result.status}`,
-    );
-  }
+	console.log(`sentry-upload-sourcemaps: uploading ${label} from ${dir}`)
+	const result = spawnSync(
+		process.execPath,
+		[
+			sentryCliWrapper,
+			'sourcemaps',
+			'upload',
+			dir,
+			'--release',
+			release!,
+			'--org',
+			org!,
+			'--project',
+			project!,
+			'--auth-token',
+			authToken!,
+			'--validate',
+		],
+		{ cwd: root, stdio: 'inherit' },
+	)
+	if (result.status !== 0) {
+		throw new Error(
+			`sentry-upload-sourcemaps: ${label} upload failed with status ${result.status}`,
+		)
+	}
 }
 
-const workerBundleDir = workerBundleCandidates.find((dir) =>
-  hasSourceMaps(dir),
-);
+const workerBundleDir = workerBundleCandidates.find((dir) => hasSourceMaps(dir))
 // Credentials are configured, so a missing bundle is a broken pipeline, not
 // an optional feature — fail the deploy step loudly instead of silently
 // shipping a release whose stack traces cannot be symbolicated. (This exact
 // silent no-op hid a path mismatch for weeks.)
 if (!workerBundleDir) {
-  console.error(
-    `sentry-upload-sourcemaps: no worker bundle with source maps found (checked: ${workerBundleCandidates.join(", ")}). Run deploy with --outdir .wrangler/sentry-bundle --upload-source-maps.`,
-  );
-  process.exit(1);
+	console.error(
+		`sentry-upload-sourcemaps: no worker bundle with source maps found (checked: ${workerBundleCandidates.join(', ')}). Run deploy with --outdir .wrangler/sentry-bundle --upload-source-maps.`,
+	)
+	process.exit(1)
 }
-upload(workerBundleDir, "worker bundle");
+upload(workerBundleDir, 'worker bundle')
 
 // Client assets are built with --sourcemap and debug-id injected before
 // deploy; upload them under the same release so browser events symbolicate.
 if (hasSourceMaps(clientAssetsDir)) {
-  upload(clientAssetsDir, "client assets");
+	upload(clientAssetsDir, 'client assets')
 } else {
-  console.error(
-    "sentry-upload-sourcemaps: no client source maps in packages/worker/public (expected from build:client:web --sourcemap).",
-  );
-  process.exit(1);
+	console.error(
+		'sentry-upload-sourcemaps: no client source maps in packages/worker/public (expected from build:client:web --sourcemap).',
+	)
+	process.exit(1)
 }

--- a/tools/sentry-upload-sourcemaps.ts
+++ b/tools/sentry-upload-sourcemaps.ts
@@ -52,6 +52,9 @@ const sentryCliWrapper = join(
 
 function upload(dir: string, label: string): void {
 	console.log(`sentry-upload-sourcemaps: uploading ${label} from ${dir}`)
+	// Auth comes from the inherited SENTRY_AUTH_TOKEN env var (already
+	// validated above) rather than --auth-token, so the secret never appears
+	// in child process arguments.
 	const result = spawnSync(
 		process.execPath,
 		[
@@ -65,8 +68,6 @@ function upload(dir: string, label: string): void {
 			org!,
 			'--project',
 			project!,
-			'--auth-token',
-			authToken!,
 			'--validate',
 		],
 		{ cwd: root, stdio: 'inherit' },

--- a/tools/sentry-upload-sourcemaps.ts
+++ b/tools/sentry-upload-sourcemaps.ts
@@ -1,59 +1,105 @@
-import { existsSync } from 'node:fs'
-import { spawnSync } from 'node:child_process'
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
+import { existsSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
-const root = join(dirname(fileURLToPath(import.meta.url)), '..')
-const bundleDir = join(root, '.wrangler', 'sentry-bundle')
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Wrangler resolves `--outdir .wrangler/sentry-bundle` against the config
+// file's directory, so with the generated production config the bundle lands
+// under packages/worker/. The repo-root path is kept as a fallback for local
+// runs where wrangler is invoked with a root-relative config.
+const workerBundleCandidates = [
+  join(root, "packages", "worker", ".wrangler", "sentry-bundle"),
+  join(root, ".wrangler", "sentry-bundle"),
+];
+const clientAssetsDir = join(root, "packages", "worker", "public");
 
 const release =
-	process.env.SENTRY_RELEASE?.trim() ||
-	process.env.APP_COMMIT_SHA?.trim() ||
-	process.env.DEPLOY_COMMIT_SHA?.trim()
-const org = process.env.SENTRY_ORG?.trim()
-const project = process.env.SENTRY_PROJECT?.trim()
-const authToken = process.env.SENTRY_AUTH_TOKEN?.trim()
-
-if (!existsSync(join(bundleDir, 'index.js'))) {
-	console.warn(
-		'sentry-upload-sourcemaps: missing bundle at .wrangler/sentry-bundle (run deploy with --outdir .wrangler/sentry-bundle first)',
-	)
-	process.exit(0)
-}
+  process.env.SENTRY_RELEASE?.trim() ||
+  process.env.APP_COMMIT_SHA?.trim() ||
+  process.env.DEPLOY_COMMIT_SHA?.trim();
+const org = process.env.SENTRY_ORG?.trim();
+const project = process.env.SENTRY_PROJECT?.trim();
+const authToken = process.env.SENTRY_AUTH_TOKEN?.trim();
 
 if (!release || !org || !project || !authToken) {
-	console.log(
-		'sentry-upload-sourcemaps: skipping (need SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT, and SENTRY_RELEASE or APP_COMMIT_SHA)',
-	)
-	process.exit(0)
+  console.log(
+    "sentry-upload-sourcemaps: skipping (need SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT, and SENTRY_RELEASE or APP_COMMIT_SHA)",
+  );
+  process.exit(0);
+}
+
+function hasSourceMaps(dir: string): boolean {
+  if (!existsSync(dir)) return false;
+  try {
+    return readdirSync(dir, { recursive: true }).some((entry) =>
+      String(entry).endsWith(".js.map"),
+    );
+  } catch {
+    return false;
+  }
 }
 
 const sentryCliWrapper = join(
-	root,
-	'node_modules',
-	'@sentry',
-	'cli',
-	'bin',
-	'sentry-cli',
-)
-const args = [
-	sentryCliWrapper,
-	'sourcemaps',
-	'upload',
-	bundleDir,
-	'--release',
-	release,
-	'--org',
-	org,
-	'--project',
-	project,
-	'--auth-token',
-	authToken,
-	'--validate',
-]
+  root,
+  "node_modules",
+  "@sentry",
+  "cli",
+  "bin",
+  "sentry-cli",
+);
 
-const result = spawnSync(process.execPath, args, {
-	cwd: root,
-	stdio: 'inherit',
-})
-process.exit(result.status === null ? 1 : result.status)
+function upload(dir: string, label: string): void {
+  console.log(`sentry-upload-sourcemaps: uploading ${label} from ${dir}`);
+  const result = spawnSync(
+    process.execPath,
+    [
+      sentryCliWrapper,
+      "sourcemaps",
+      "upload",
+      dir,
+      "--release",
+      release!,
+      "--org",
+      org!,
+      "--project",
+      project!,
+      "--auth-token",
+      authToken!,
+      "--validate",
+    ],
+    { cwd: root, stdio: "inherit" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `sentry-upload-sourcemaps: ${label} upload failed with status ${result.status}`,
+    );
+  }
+}
+
+const workerBundleDir = workerBundleCandidates.find((dir) =>
+  hasSourceMaps(dir),
+);
+// Credentials are configured, so a missing bundle is a broken pipeline, not
+// an optional feature — fail the deploy step loudly instead of silently
+// shipping a release whose stack traces cannot be symbolicated. (This exact
+// silent no-op hid a path mismatch for weeks.)
+if (!workerBundleDir) {
+  console.error(
+    `sentry-upload-sourcemaps: no worker bundle with source maps found (checked: ${workerBundleCandidates.join(", ")}). Run deploy with --outdir .wrangler/sentry-bundle --upload-source-maps.`,
+  );
+  process.exit(1);
+}
+upload(workerBundleDir, "worker bundle");
+
+// Client assets are built with --sourcemap and debug-id injected before
+// deploy; upload them under the same release so browser events symbolicate.
+if (hasSourceMaps(clientAssetsDir)) {
+  upload(clientAssetsDir, "client assets");
+} else {
+  console.error(
+    "sentry-upload-sourcemaps: no client source maps in packages/worker/public (expected from build:client:web --sourcemap).",
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Sentry (Dhrumil) flagged that we are not uploading source maps, which degrades stack traces, issue grouping, and Seer RCA quality — their [sentry-fix-stack-traces skill](https://github.com/getsentry/sentry-for-ai/blob/main/src/skills/sentry-fix-stack-traces/SKILL.md) calls out exactly the failure mode found here: a missing-artifact path that fails silently.

## What was broken

**Worker bundle (path bug, silent no-op on every deploy).** The deploy workflow's "Upload Worker source maps to Sentry" step has correct credentials and the deploy passes `--outdir .wrangler/sentry-bundle --upload-source-maps` — but wrangler resolves `--outdir` against the *config file's directory*, so the bundle lands at `packages/worker/.wrangler/sentry-bundle/` while `tools/sentry-upload-sourcemaps.ts` looked in the repo root, printed a warning, and exited 0. Verified in the latest production deploy log ([run 31136500569](https://github.com/kentcdodds/kody/actions/runs/31136500569)): `sentry-upload-sourcemaps: missing bundle at .wrangler/sentry-bundle`.

**Client bundle (no source maps at all).** `build:client:web` had no `--sourcemap` flag, so browser events could never unminify regardless of upload.

## Changes

- `tools/sentry-upload-sourcemaps.ts`: finds the worker bundle in either outdir location (config-dir first, repo root fallback), requires actual `.js.map` files, and **exits 1** when credentials are set but artifacts are missing — a broken pipeline now fails the deploy step instead of silently shipping an unsymbolicatable release. Also uploads client assets (`packages/worker/public`) under the same commit-sha release.
- `package.json` `build:client:web`: adds `--sourcemap` and injects Sentry debug IDs (`sentry-cli sourcemaps inject`) after the manifest build, so deployed assets carry debug IDs and matching doesn't depend solely on release-string equality. `.map` files ship as public assets (repo is public; no secrecy concern).
- `.gitignore`: ignore the generated `client-entry.js.map`.

Release matching was already plumbed end-to-end (worker `sentry-options.ts` and the client config meta both set `release` from `APP_COMMIT_SHA`, which equals the upload release).

## Verification

- Dry-run deploy locally confirms the bundle location (`packages/worker/.wrangler/sentry-bundle/index.js{,.map}`) and the script's detection finds it (root fallback correctly false).
- `npm run build:client:web` emits maps for every chunk and injects debug IDs (verified `_sentryDebugIds` in `client-entry.js` and `debugId` in each `.js.map`).
- Without credentials the script still skips politely (local/dev unaffected).
- `npm run typecheck` and Prettier pass. `npm run validate` shows 6 failing tests in `entitlements/user-meter` and `email/inbound-*` — **pre-existing**: identical failures on `main` in this environment (workerd `jsg.Error: internal error`), untouched by this diff.

## After merge

The next production deploy uploads both artifact sets; per the skill, old events stay minified (correctly) — judge the fix on the first *new* event from that deploy, which should show readable file/line/function frames in Sentry and better Seer RCA inputs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b516ae78-73a9-4345-8513-98a31de32cc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b516ae78-73a9-4345-8513-98a31de32cc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source map handling for worker and client assets, supporting more accurate production error reporting.
  * Added clearer validation when release reporting configuration or required source maps are unavailable.
* **Chores**
  * Client builds now automatically publish source maps alongside worker assets for improved diagnostics.
  * Generated client source map files are excluded from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->