### PR TITLE
Onboarding checklist polish: final-step placement, font-sized provider icons, "Hey Kody" prompt prefixes

### DIFF
--- a/packages/worker/client/provider-icons.tsx
+++ b/packages/worker/client/provider-icons.tsx
@@ -5,14 +5,14 @@ import { type Handle } from 'remix/ui'
  * suggestions. Inlined as SVG (no external assets) so they server-render with
  * the buttons and inherit sizing and color from the surrounding text.
  */
-const iconSize = '1.25em'
+const defaultIconSize = '1.25em'
 
-function renderGitHubIcon() {
+function renderGitHubIcon(size: string) {
 	return (
 		<svg
 			viewBox="0 0 16 16"
-			width={iconSize}
-			height={iconSize}
+			width={size}
+			height={size}
 			aria-hidden="true"
 			fill="currentColor"
 		>
@@ -21,14 +21,9 @@ function renderGitHubIcon() {
 	)
 }
 
-function renderGoogleIcon() {
+function renderGoogleIcon(size: string) {
 	return (
-		<svg
-			viewBox="0 0 24 24"
-			width={iconSize}
-			height={iconSize}
-			aria-hidden="true"
-		>
+		<svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true">
 			<path
 				fill="#4285F4"
 				d="M23.49 12.27c0-.79-.07-1.54-.19-2.27H12v4.51h6.47c-.29 1.48-1.14 2.73-2.4 3.58v3h3.86c2.26-2.09 3.56-5.17 3.56-8.82z"
@@ -49,12 +44,12 @@ function renderGoogleIcon() {
 	)
 }
 
-function renderXIcon() {
+function renderXIcon(size: string) {
 	return (
 		<svg
 			viewBox="0 0 24 24"
-			width={iconSize}
-			height={iconSize}
+			width={size}
+			height={size}
 			aria-hidden="true"
 			fill="currentColor"
 		>
@@ -63,14 +58,9 @@ function renderXIcon() {
 	)
 }
 
-function renderSlackIcon() {
+function renderSlackIcon(size: string) {
 	return (
-		<svg
-			viewBox="0 0 24 24"
-			width={iconSize}
-			height={iconSize}
-			aria-hidden="true"
-		>
+		<svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true">
 			<path
 				fill="#E01E5A"
 				d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522z"
@@ -91,12 +81,12 @@ function renderSlackIcon() {
 	)
 }
 
-function renderSpotifyIcon() {
+function renderSpotifyIcon(size: string) {
 	return (
 		<svg
 			viewBox="0 0 24 24"
-			width={iconSize}
-			height={iconSize}
+			width={size}
+			height={size}
 			aria-hidden="true"
 			fill="#1DB954"
 		>
@@ -105,12 +95,12 @@ function renderSpotifyIcon() {
 	)
 }
 
-function renderNotionIcon() {
+function renderNotionIcon(size: string) {
 	return (
 		<svg
 			viewBox="0 0 100 100"
-			width={iconSize}
-			height={iconSize}
+			width={size}
+			height={size}
 			aria-hidden="true"
 			fill="currentColor"
 		>
@@ -119,12 +109,12 @@ function renderNotionIcon() {
 	)
 }
 
-function renderDiscordIcon() {
+function renderDiscordIcon(size: string) {
 	return (
 		<svg
 			viewBox="0 0 24 24"
-			width={iconSize}
-			height={iconSize}
+			width={size}
+			height={size}
 			aria-hidden="true"
 			fill="#5865F2"
 		>
@@ -133,7 +123,7 @@ function renderDiscordIcon() {
 	)
 }
 
-const providerIconRenderers: Record<string, () => JSX.Element> = {
+const providerIconRenderers: Record<string, (size: string) => JSX.Element> = {
 	github: renderGitHubIcon,
 	google: renderGoogleIcon,
 	x: renderXIcon,
@@ -143,6 +133,15 @@ const providerIconRenderers: Record<string, () => JSX.Element> = {
 	discord: renderDiscordIcon,
 }
 
-export function ProviderIcon(handle: Handle<{ providerId: string }>) {
-	return () => providerIconRenderers[handle.props.providerId]?.() ?? null
+export function ProviderIcon(
+	handle: Handle<{
+		providerId: string
+		/** Icon box size; inline-with-text usages should pass `1em`. */
+		size?: string
+	}>,
+) {
+	return () =>
+		providerIconRenderers[handle.props.providerId]?.(
+			handle.props.size ?? defaultIconSize,
+		) ?? null
 }

--- a/packages/worker/client/routes/onboarding-checklist.tsx
+++ b/packages/worker/client/routes/onboarding-checklist.tsx
@@ -176,7 +176,7 @@ export function OnboardingChecklistCard(
 														href={provider.href}
 														mix={css(integrationProviderLinkCss)}
 													>
-														<ProviderIcon providerId={provider.id} />
+														<ProviderIcon providerId={provider.id} size="1em" />
 														{provider.label}
 													</a>
 													{index < integrationGuideProviders.length - 2

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -398,16 +398,6 @@ export function OnboardingRoute(handle: Handle) {
 							})}
 						</nav>
 
-						{shouldShowOnboardingChecklist(checklist) && !checklistHidden ? (
-							<OnboardingChecklistCard
-								checklist={checklist!}
-								onDismissed={() => {
-									checklistHidden = true
-									handle.update()
-								}}
-							/>
-						) : null}
-
 						{activeStep === 1 ? (
 							<section
 								id="discovery"
@@ -662,6 +652,19 @@ export function OnboardingRoute(handle: Handle) {
 										Browse all community packages
 									</a>
 								</p>
+								{/* The last step doubles as the "what's left" recap, so the
+								    derived checklist lives here instead of distracting from
+								    the earlier steps. */}
+								{shouldShowOnboardingChecklist(checklist) &&
+								!checklistHidden ? (
+									<OnboardingChecklistCard
+										checklist={checklist!}
+										onDismissed={() => {
+											checklistHidden = true
+											handle.update()
+										}}
+									/>
+								) : null}
 								<WizardNavigation
 									activeStep={activeStep}
 									onSelectStep={selectStep}

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -66,12 +66,12 @@ export function buildDiscoveryPrompt(input: {
  * mail; the agent reads it when asked; nothing answers by itself).
  */
 export function buildIntroEmailPrompt() {
-	return 'Send me a welcome email introducing yourself, and invite me to reply to it.'
+	return 'Hey Kody, send me a welcome email introducing yourself, and invite me to reply to it.'
 }
 
 /** Second first-win prompt: start durable memory with a tiny interview. */
 export function buildMemoryPrompt() {
-	return 'Ask me a couple of questions about who I am and what I work with, then remember what matters.'
+	return 'Hey Kody, ask me a couple of questions about who I am and what I work with, then remember what matters.'
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up polish to #1266 from design review of the live pages:

- **Checklist placement**: the "Your setup checklist" card no longer renders between the stepper and every panel (it distracted from the current step); it now lives only inside the final "Install a starter package" panel, where it doubles as the what's-left recap.
- **Provider icons**: `ProviderIcon` gains an optional `size` prop; the checklist's "Try Google, GitHub, Spotify, or Notion" row passes `1em` so the marks sit at text height instead of oversized. Other surfaces keep the existing `1.25em` default.
- **Prompts**: both first-win prompts now start with "Hey Kody, " so the receiving agent immediately knows the request is for its Kody MCP connection.

## Testing

- `npm run typecheck`, lint, and client node tests green; full pre-push suite (unit + workers + e2e) green on push.
- Verified in the browser: step 1 shows no checklist; step 4 shows it below the starter cards with text-height icons; `/onboarding.json` serves the prefixed prompts.

![Step 4 checklist with font-sized provider icons](https://cursor.com/artifacts/c/art-46932ee7-da26-47e3-898c-1a717e3ed3f1)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fcbe1fdc` · **Head:** `9fc8e2f6`

**Classification:** composes — client-only presentation changes inside `app-ui` (checklist placement, icon sizing prop) plus two prompt-string edits in `onboarding-data.ts`. No routes, storage, or capability changes.

### Primitives touched

| Primitive      | Group    | Impact                                                        |
| -------------- | -------- | ------------------------------------------------------------- |
| `app-ui`       | surfaces | composes — moves the checklist card into step 4; `ProviderIcon` size prop |
| `app-sessions` | auth     | composes — "Hey Kody, " prefixes on the two first-win prompts |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69e33c92-b0cb-4ece-9b0e-bda64e9bd7c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69e33c92-b0cb-4ece-9b0e-bda64e9bd7c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Provider icons now support flexible sizing for better alignment across the interface.
  * Updated onboarding links with appropriately sized provider icons.
* **Onboarding**
  * Moved the onboarding checklist to the final starter-packages step, alongside community-package links and navigation.
  * Updated onboarding instructions with clearer, more conversational guidance for sending the welcome email and starting memory collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->