### PR TITLE
Navigate list/detail sidebars through real links that preserve scroll

### DIFF
--- a/e2e/admin-rbac.spec.ts
+++ b/e2e/admin-rbac.spec.ts
@@ -73,7 +73,7 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 
 	await page.goto(`/admin/users?q=rbac-${runId}`)
 	await expect(
-		page.getByRole('button', { name: memberUser.username }),
+		page.getByRole('link', { name: memberUser.username }),
 	).toBeVisible()
 	await expect(page.getByText(memberUser.email)).toBeVisible()
 	await expect(page.getByText('memberPrivateSecret')).toHaveCount(0)
@@ -92,13 +92,13 @@ test('admin RBAC controls access, role assignment, and privacy boundaries', asyn
 	expect(JSON.stringify(memberRecord)).not.toContain('memberPrivateSecret')
 	expect(JSON.stringify(memberRecord)).not.toContain('super-secret-value')
 
-	await page.getByRole('button', { name: memberUser.username }).click()
+	await page.getByRole('link', { name: memberUser.username }).click()
 	await expect(page.getByText('Account metadata only')).toBeVisible()
 	await expect(page.getByText('memberPrivateSecret')).toHaveCount(0)
 	await expect(page.getByText('super-secret-value')).toHaveCount(0)
 
 	await page.goto(`/admin/users?q=rbac-${runId}`)
-	await page.getByRole('button', { name: memberUser.username }).click()
+	await page.getByRole('link', { name: memberUser.username }).click()
 	const roleSelect = page.getByLabel('Role', { exact: true })
 	await roleSelect.selectOption('admin')
 	await page.getByRole('button', { name: 'Assign', exact: true }).click()

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -239,7 +239,17 @@ export function matchRoute(
 	)
 }
 
-function shouldHandleClick(event: MouseEvent, anchor: HTMLAnchorElement) {
+/**
+ * True when the router will intercept this anchor click and run an SPA
+ * navigation (plain left-click on a same-origin, non-download, self-target
+ * link). Components that reset local state before an in-page navigation use
+ * this so modified clicks (open in new tab, download) leave the current page
+ * untouched.
+ */
+export function shouldRouterHandleClick(
+	event: MouseEvent,
+	anchor: HTMLAnchorElement,
+) {
 	if (event.defaultPrevented) return false
 	if (event.button !== 0) return false
 	if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
@@ -259,7 +269,7 @@ function handleDocumentClick(event: MouseEvent) {
 	const target = event.target as Element | null
 	const anchor = target?.closest('a') as HTMLAnchorElement | null
 	if (!anchor || typeof window === 'undefined') return
-	if (!shouldHandleClick(event, anchor)) return
+	if (!shouldRouterHandleClick(event, anchor)) return
 
 	event.preventDefault()
 	const destination = new URL(anchor.href, window.location.href)

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -20,7 +20,7 @@ import {
 	accountManagementNarrowMq,
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementShell,
 	AccountManagementSidebar,
@@ -683,17 +683,13 @@ export function AccountActivityRoute(handle: Handle) {
 											<AccountManagementList>
 												{runs.map((item) => (
 													<li key={item.id}>
-														<AccountManagementListItemButton
+														<AccountManagementListItemLink
+															href={activityRoute.buildDetailHref(
+																item.id,
+																filterSearch,
+															)}
 															active={selection.selectedId === item.id}
-															onClick={() => {
-																setMessage(null)
-																navigate(
-																	activityRoute.buildDetailHref(
-																		item.id,
-																		filterSearch,
-																	),
-																)
-															}}
+															onNavigate={() => setMessage(null)}
 														>
 															<span
 																mix={css({
@@ -753,7 +749,7 @@ export function AccountActivityRoute(handle: Handle) {
 																	{item.errorMessage}
 																</span>
 															) : null}
-														</AccountManagementListItemButton>
+														</AccountManagementListItemLink>
 													</li>
 												))}
 											</AccountManagementList>

--- a/packages/worker/client/routes/account-email.tsx
+++ b/packages/worker/client/routes/account-email.tsx
@@ -3,7 +3,7 @@ import { formatNullableTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { Tab, TabList, TabPanel, Tabs } from 'remix/ui/tabs'
 import { on } from '#client/event-mixin.ts'
-import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { replaceLocation } from '#client/replace-location.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
@@ -16,7 +16,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -494,19 +494,15 @@ export function AccountEmailRoute(handle: Handle) {
 											<AccountManagementList>
 												{data.messages.map((emailMessage) => (
 													<li key={emailMessage.id} mix={css({ minWidth: 0 })}>
-														<AccountManagementListItemButton
+														<AccountManagementListItemLink
+															href={emailRoute.buildDetailHref(
+																emailMessage.id,
+																getCurrentSearch(),
+															)}
 															active={
 																selectedMessageId === emailMessage.id ||
 																selectedMessage?.id === emailMessage.id
 															}
-															onClick={() => {
-																navigate(
-																	emailRoute.buildDetailHref(
-																		emailMessage.id,
-																		getCurrentSearch(),
-																	),
-																)
-															}}
 														>
 															<div
 																mix={css({
@@ -576,7 +572,7 @@ export function AccountEmailRoute(handle: Handle) {
 																	</span>
 																) : null}
 															</span>
-														</AccountManagementListItemButton>
+														</AccountManagementListItemLink>
 													</li>
 												))}
 											</AccountManagementList>

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -6,7 +6,7 @@ import {
 } from '#app/loader-data.ts'
 import { routes } from '#app/routes.ts'
 import { type Handle, css } from 'remix/ui'
-import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
@@ -27,7 +27,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -513,44 +513,39 @@ export function AccountIntegrationsRoute(handle: Handle) {
 														key={group.appSlug}
 														mix={css({ display: 'grid', gap: spacing.xs })}
 													>
-														<button
-															type="button"
-															mix={[
-																on('click', () => {
-																	navigate(
-																		buildOauthAppHref(
-																			group.appSlug,
-																			getCurrentSearch(),
-																		),
-																	)
-																}),
-																css({
-																	display: 'grid',
-																	gap: spacing.xs,
-																	padding: `${spacing.xs} ${spacing.sm}`,
-																	border: 'none',
-																	borderRadius: radius.md,
-																	backgroundColor: appActive
-																		? colors.primarySoftest
-																		: 'transparent',
-																	color: colors.text,
-																	textAlign: 'left',
-																	cursor: 'pointer',
-																	transition: `background-color ${transitions.fast}, scale ${transitions.fast}`,
-																	// Selecting a connection swaps the panel
-																	// beside this list, which is easy to miss —
-																	// the press itself has to register.
-																	'&:active': { scale: '0.98' },
-																	[hoverMq]: {
-																		'&:hover': {
-																			backgroundColor: colors.primarySoftest,
-																		},
+														<a
+															href={buildOauthAppHref(
+																group.appSlug,
+																getCurrentSearch(),
+															)}
+															data-prevent-scroll-reset
+															mix={css({
+																display: 'grid',
+																gap: spacing.xs,
+																padding: `${spacing.xs} ${spacing.sm}`,
+																border: 'none',
+																borderRadius: radius.md,
+																backgroundColor: appActive
+																	? colors.primarySoftest
+																	: 'transparent',
+																color: colors.text,
+																textAlign: 'left',
+																textDecoration: 'none',
+																cursor: 'pointer',
+																transition: `background-color ${transitions.fast}, scale ${transitions.fast}`,
+																// Selecting a connection swaps the panel
+																// beside this list, which is easy to miss —
+																// the press itself has to register.
+																'&:active': { scale: '0.98' },
+																[hoverMq]: {
+																	'&:hover': {
+																		backgroundColor: colors.primarySoftest,
 																	},
-																	'@media (prefers-reduced-motion: reduce)': {
-																		'&:active': { scale: 'none' },
-																	},
-																}),
-															]}
+																},
+																'@media (prefers-reduced-motion: reduce)': {
+																	'&:active': { scale: 'none' },
+																},
+															})}
 														>
 															<strong
 																mix={css({
@@ -571,25 +566,21 @@ export function AccountIntegrationsRoute(handle: Handle) {
 																	? `${group.connections.length} connections · shared OAuth app`
 																	: 'OAuth app'}
 															</span>
-														</button>
+														</a>
 														<AccountManagementList>
 															{group.connections.map((integration) => (
 																<li
 																	key={integration.name}
 																	mix={css({ minWidth: 0 })}
 																>
-																	<AccountManagementListItemButton
+																	<AccountManagementListItemLink
+																		href={integrationsRoute.buildDetailHref(
+																			integration.name,
+																			getCurrentSearch(),
+																		)}
 																		active={
 																			selection.selectedId === integration.name
 																		}
-																		onClick={() => {
-																			navigate(
-																				integrationsRoute.buildDetailHref(
-																					integration.name,
-																					getCurrentSearch(),
-																				),
-																			)
-																		}}
 																	>
 																		<strong
 																			mix={css({
@@ -633,7 +624,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 																				{appTitle}
 																			</span>
 																		)}
-																	</AccountManagementListItemButton>
+																	</AccountManagementListItemLink>
 																</li>
 															))}
 														</AccountManagementList>
@@ -646,42 +637,37 @@ export function AccountIntegrationsRoute(handle: Handle) {
 												key={app.slug}
 												mix={css({ display: 'grid', gap: spacing.xs })}
 											>
-												<button
-													type="button"
-													mix={[
-														on('click', () => {
-															navigate(
-																buildOauthAppHref(app.slug, getCurrentSearch()),
-															)
-														}),
-														css({
-															display: 'grid',
-															gap: spacing.xs,
-															padding: `${spacing.xs} ${spacing.sm}`,
-															border: 'none',
-															borderRadius: radius.md,
-															backgroundColor:
-																selectedAppSlug === app.slug
-																	? colors.primarySoftest
-																	: 'transparent',
-															color: colors.text,
-															textAlign: 'left',
-															cursor: 'pointer',
-															transition: `background-color ${transitions.fast}, scale ${transitions.fast}`,
-															// Selecting an app swaps the panel beside this
-															// list, which is easy to miss — the press itself
-															// has to register.
-															'&:active': { scale: '0.98' },
-															[hoverMq]: {
-																'&:hover': {
-																	backgroundColor: colors.primarySoftest,
-																},
+												<a
+													href={buildOauthAppHref(app.slug, getCurrentSearch())}
+													data-prevent-scroll-reset
+													mix={css({
+														display: 'grid',
+														gap: spacing.xs,
+														padding: `${spacing.xs} ${spacing.sm}`,
+														border: 'none',
+														borderRadius: radius.md,
+														backgroundColor:
+															selectedAppSlug === app.slug
+																? colors.primarySoftest
+																: 'transparent',
+														color: colors.text,
+														textAlign: 'left',
+														textDecoration: 'none',
+														cursor: 'pointer',
+														transition: `background-color ${transitions.fast}, scale ${transitions.fast}`,
+														// Selecting an app swaps the panel beside this
+														// list, which is easy to miss — the press itself
+														// has to register.
+														'&:active': { scale: '0.98' },
+														[hoverMq]: {
+															'&:hover': {
+																backgroundColor: colors.primarySoftest,
 															},
-															'@media (prefers-reduced-motion: reduce)': {
-																'&:active': { scale: 'none' },
-															},
-														}),
-													]}
+														},
+														'@media (prefers-reduced-motion: reduce)': {
+															'&:active': { scale: 'none' },
+														},
+													})}
 												>
 													<strong
 														mix={css({
@@ -700,7 +686,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 													>
 														OAuth app · no connections yet
 													</span>
-												</button>
+												</a>
 											</div>
 										))}
 									</div>
@@ -814,6 +800,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 															connection.name,
 															getCurrentSearch(),
 														)}
+														data-prevent-scroll-reset
 														mix={css(primaryLinkCss)}
 													>
 														{connection.accountLabel?.trim() || connection.name}

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -27,7 +27,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -709,20 +709,17 @@ export function AccountJobsRoute(handle: Handle) {
 									<AccountManagementList>
 										{filteredJobs.map((item) => (
 											<li key={item.id}>
-												<AccountManagementListItemButton
+												<AccountManagementListItemLink
+													href={jobsRoute.buildDetailHref(
+														item.id,
+														getCurrentSearch(),
+													)}
 													active={selection.selectedId === item.id}
 													disabled={isMutating}
-													onClick={() => {
-														if (isMutating) return
+													onNavigate={() => {
 														deleteJobCheck.reset()
 														editing = false
 														setMessage(null)
-														navigate(
-															jobsRoute.buildDetailHref(
-																item.id,
-																getCurrentSearch(),
-															),
-														)
 													}}
 												>
 													<span
@@ -820,7 +817,7 @@ export function AccountJobsRoute(handle: Handle) {
 													>
 														{statusLabel(item)}
 													</span>
-												</AccountManagementListItemButton>
+												</AccountManagementListItemLink>
 											</li>
 										))}
 									</AccountManagementList>

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -1,6 +1,7 @@
 import { css, type Handle } from 'remix/ui'
 import { routes } from '#app/routes.ts'
 import { on } from '#client/event-mixin.ts'
+import { shouldRouterHandleClick } from '#client/client-router.tsx'
 import {
 	colors,
 	radius,
@@ -677,28 +678,52 @@ export function AccountManagementSearchField(
 	)
 }
 
-type AccountManagementListItemButtonProps = {
+type AccountManagementListItemLinkProps = {
+	href: string
 	active: boolean
 	disabled?: boolean
-	onClick: () => void
+	/**
+	 * Pre-navigation state resets (clear messages, collapse delete
+	 * confirmations). Runs only for clicks the router intercepts as an SPA
+	 * navigation, so open-in-new-tab clicks leave the current pane untouched.
+	 */
+	onNavigate?: () => void
 	children: AccountManagementSlot
 }
 
-export function AccountManagementListItemButton(
-	handle: Handle<AccountManagementListItemButtonProps>,
+/**
+ * List/detail sidebar entry rendered as a real link: middle/cmd-click opens
+ * the record in a new tab, hover warms the destination loader, and
+ * `data-prevent-scroll-reset` keeps the page's scroll position when the
+ * detail pane swaps in. While `disabled`, the `href` is dropped so the router
+ * ignores clicks mid-mutation.
+ */
+export function AccountManagementListItemLink(
+	handle: Handle<AccountManagementListItemLinkProps>,
 ) {
 	return () => (
-		<button
-			type="button"
-			disabled={handle.props.disabled}
+		<a
+			href={handle.props.disabled ? undefined : handle.props.href}
+			data-prevent-scroll-reset
 			aria-current={handle.props.active ? 'true' : undefined}
+			aria-disabled={handle.props.disabled ? 'true' : undefined}
 			mix={[
-				on('click', handle.props.onClick),
+				on('click', (event: MouseEvent) => {
+					if (handle.props.disabled || !handle.props.onNavigate) return
+					if (
+						!(event.currentTarget instanceof HTMLAnchorElement) ||
+						!shouldRouterHandleClick(event, event.currentTarget)
+					) {
+						return
+					}
+					handle.props.onNavigate()
+				}),
 				css({
 					width: '100%',
 					minWidth: 0,
 					maxWidth: '100%',
 					textAlign: 'left',
+					textDecoration: 'none',
 					display: 'grid',
 					gap: spacing.xs,
 					padding: spacing.md,
@@ -719,7 +744,7 @@ export function AccountManagementListItemButton(
 			]}
 		>
 			{handle.props.children}
-		</button>
+		</a>
 	)
 }
 

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -20,7 +20,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -461,19 +461,16 @@ export function AccountMcpServersRoute(handle: Handle) {
 									<AccountManagementList>
 										{filteredServers.map((item) => (
 											<li key={item.id}>
-												<AccountManagementListItemButton
+												<AccountManagementListItemLink
+													href={mcpServersRoute.buildDetailHref(
+														item.id,
+														getCurrentSearch(),
+													)}
 													active={selection.selectedId === item.id}
 													disabled={isMutating}
-													onClick={() => {
-														if (isMutating) return
+													onNavigate={() => {
 														deleteServerCheck.reset()
 														setMessage(null)
-														navigate(
-															mcpServersRoute.buildDetailHref(
-																item.id,
-																getCurrentSearch(),
-															),
-														)
 													}}
 												>
 													<strong>{item.name}</strong>
@@ -488,7 +485,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 															? ` · ${item.toolCount} tool${item.toolCount === 1 ? '' : 's'}`
 															: ''}
 													</span>
-												</AccountManagementListItemButton>
+												</AccountManagementListItemLink>
 											</li>
 										))}
 									</AccountManagementList>

--- a/packages/worker/client/routes/account-memories.tsx
+++ b/packages/worker/client/routes/account-memories.tsx
@@ -24,7 +24,7 @@ import { matchesSearchQuery } from '#client/search-filter.ts'
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -401,19 +401,16 @@ export function AccountMemoriesRoute(handle: Handle) {
 									<AccountManagementList>
 										{filteredMemories.map((item) => (
 											<li key={item.id} mix={css({ minWidth: 0 })}>
-												<AccountManagementListItemButton
+												<AccountManagementListItemLink
+													href={memoriesRoute.buildDetailHref(
+														item.id,
+														getCurrentSearch(),
+													)}
 													active={selection.selectedId === item.id}
 													disabled={isMutating}
-													onClick={() => {
-														if (isMutating) return
+													onNavigate={() => {
 														deleteMode = null
 														setMessage(null)
-														navigate(
-															memoriesRoute.buildDetailHref(
-																item.id,
-																getCurrentSearch(),
-															),
-														)
 													}}
 												>
 													<strong
@@ -453,7 +450,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 													>
 														{item.summary}
 													</span>
-												</AccountManagementListItemButton>
+												</AccountManagementListItemLink>
 											</li>
 										))}
 									</AccountManagementList>

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -48,7 +48,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -942,12 +942,6 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		editMode = !token.revokedAt
 		message = null
 		messageTone = 'info'
-		syncRouterLocation(
-			packageInvocationTokensRoute.buildDetailHref(
-				token.id,
-				getCurrentSearch(),
-			),
-		)
 		handle.update()
 	}
 
@@ -1072,13 +1066,14 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 											const isSelected = effectiveSelectedTokenId === token.id
 											return (
 												<li key={token.id} mix={css({ minWidth: 0 })}>
-													<AccountManagementListItemButton
+													<AccountManagementListItemLink
+														href={packageInvocationTokensRoute.buildDetailHref(
+															token.id,
+															getCurrentSearch(),
+														)}
 														active={isSelected}
 														disabled={isMutating}
-														onClick={() => {
-															if (isMutating) return
-															selectToken(token)
-														}}
+														onNavigate={() => selectToken(token)}
 													>
 														<div
 															mix={css({
@@ -1132,7 +1127,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 														>
 															Exports: {formatScope(token.exportNames)}
 														</span>
-													</AccountManagementListItemButton>
+													</AccountManagementListItemLink>
 												</li>
 											)
 										})}

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -931,15 +931,17 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 		}
 	}
 
-	function selectToken(token: AccountPackageInvocationTokenListItem) {
-		selectedTokenId = token.id
-		editorState = token.revokedAt
-			? createEmptyEditorState()
-			: createEditorStateFromToken(token)
-		lastNewTokenQueryKey = ''
+	/**
+	 * Local cleanup when a sidebar link starts navigating to another token.
+	 * Editor state is deliberately NOT seeded here: until the navigation
+	 * commits, the URL (and therefore `getCurrentSelectedTokenId`) still
+	 * points at the previous token, and a save during that window would write
+	 * the new token's editor fields onto the old token. `applyPayload`
+	 * initializes the editor from the committed payload instead.
+	 */
+	function resetTokenSelectionState() {
 		revokeConfirm = false
 		deleteTokenCheck.reset()
-		editMode = !token.revokedAt
 		message = null
 		messageTone = 'info'
 		handle.update()
@@ -1073,7 +1075,7 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 														)}
 														active={isSelected}
 														disabled={isMutating}
-														onNavigate={() => selectToken(token)}
+														onNavigate={resetTokenSelectionState}
 													>
 														<div
 															mix={css({

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -1,7 +1,7 @@
 import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
-import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { replaceLocation } from '#client/replace-location.ts'
 import {
@@ -23,7 +23,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -432,16 +432,12 @@ export function AccountPackagesRoute(handle: Handle) {
 									<AccountManagementList>
 										{packages.map((pkg) => (
 											<li key={pkg.id} mix={css({ minWidth: 0 })}>
-												<AccountManagementListItemButton
+												<AccountManagementListItemLink
+													href={packagesRoute.buildDetailHref(
+														pkg.id,
+														getCurrentSearch(),
+													)}
 													active={activePackageId === pkg.id}
-													onClick={() => {
-														navigate(
-															packagesRoute.buildDetailHref(
-																pkg.id,
-																getCurrentSearch(),
-															),
-														)
-													}}
 												>
 													<div
 														mix={css({
@@ -496,7 +492,7 @@ export function AccountPackagesRoute(handle: Handle) {
 															{pkg.description}
 														</span>
 													) : null}
-												</AccountManagementListItemButton>
+												</AccountManagementListItemLink>
 											</li>
 										))}
 										{hasMore ? (

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -21,7 +21,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -647,15 +647,11 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 	}
 
 	function selectConnector(connector: RemoteConnectorListItem) {
-		if (saveState !== 'idle') return
 		editorState = createEditorStateFromConnector(connector)
 		syncedSelectionKey = `id:${connector.id}`
 		deleteConnectorCheck.reset()
 		showSharedSecret = false
 		message = null
-		syncRouterLocation(
-			remoteConnectorsRoute.buildDetailHref(connector.id, getCurrentSearch()),
-		)
 		handle.update()
 	}
 
@@ -825,10 +821,14 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 									<AccountManagementList>
 										{filteredConnectors.map((connector) => (
 											<li key={connector.id}>
-												<AccountManagementListItemButton
+												<AccountManagementListItemLink
+													href={remoteConnectorsRoute.buildDetailHref(
+														connector.id,
+														getCurrentSearch(),
+													)}
 													active={selection.selectedId === connector.id}
 													disabled={isMutating}
-													onClick={() => selectConnector(connector)}
+													onNavigate={() => selectConnector(connector)}
 												>
 													<strong>{connectorLabel(connector)}</strong>
 													<span
@@ -843,7 +843,7 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 															? 'Secret saved'
 															: 'Missing secret'}
 													</span>
-												</AccountManagementListItemButton>
+												</AccountManagementListItemLink>
 											</li>
 										))}
 									</AccountManagementList>

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -61,7 +61,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -1366,15 +1366,10 @@ export function AccountSecretsRoute(handle: Handle) {
 										const isActive = activeSecretId === secret.id
 										return (
 											<li key={secret.id} mix={css({ minWidth: 0 })}>
-												<AccountManagementListItemButton
+												<AccountManagementListItemLink
+													href={buildSecretHref(secret, getCurrentSearch())}
 													active={isActive}
 													disabled={isMutating}
-													onClick={() => {
-														if (isMutating) return
-														navigate(
-															buildSecretHref(secret, getCurrentSearch()),
-														)
-													}}
 												>
 													<div
 														mix={css({
@@ -1431,7 +1426,7 @@ export function AccountSecretsRoute(handle: Handle) {
 															{secret.description}
 														</span>
 													) : null}
-												</AccountManagementListItemButton>
+												</AccountManagementListItemLink>
 											</li>
 										)
 									})}

--- a/packages/worker/client/routes/account-values.tsx
+++ b/packages/worker/client/routes/account-values.tsx
@@ -20,7 +20,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementSearchField,
 	AccountManagementShell,
@@ -395,13 +395,9 @@ export function AccountValuesRoute(handle: Handle) {
 		}
 	}
 
-	function selectValue(entry: AccountValueListItem) {
-		if (saveState !== 'idle') return
+	function resetSelectionState() {
 		deleteValueCheck.reset()
 		setMessage(null)
-		syncRouterLocation(
-			valuesRoute.buildDetailHref(entry.id, getCurrentSearch()),
-		)
 		handle.update()
 	}
 
@@ -545,10 +541,14 @@ export function AccountValuesRoute(handle: Handle) {
 									<AccountManagementList>
 										{filteredValues.map((entry) => (
 											<li key={entry.id}>
-												<AccountManagementListItemButton
+												<AccountManagementListItemLink
+													href={valuesRoute.buildDetailHref(
+														entry.id,
+														getCurrentSearch(),
+													)}
 													active={selection.selectedId === entry.id}
 													disabled={isMutating}
-													onClick={() => selectValue(entry)}
+													onNavigate={resetSelectionState}
 												>
 													<strong>{entry.name}</strong>
 													<span
@@ -563,7 +563,7 @@ export function AccountValuesRoute(handle: Handle) {
 													>
 														{entry.valuePreview || entry.description || '—'}
 													</span>
-												</AccountManagementListItemButton>
+												</AccountManagementListItemLink>
 											</li>
 										))}
 									</AccountManagementList>

--- a/packages/worker/client/routes/admin-platform-feedback.tsx
+++ b/packages/worker/client/routes/admin-platform-feedback.tsx
@@ -2,7 +2,7 @@ import {
 	formatNullableTimestamp,
 	formatTimestamp,
 } from '#client/format-timestamp.ts'
-import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
@@ -30,7 +30,7 @@ import { type Handle, css } from 'remix/ui'
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementShell,
 	AccountManagementSidebar,
@@ -386,13 +386,9 @@ export function AdminPlatformFeedbackRoute(handle: Handle) {
 												const isActive = selectedFeedbackId === feedback.id
 												return (
 													<li key={feedback.id} mix={css({ minWidth: 0 })}>
-														<AccountManagementListItemButton
+														<AccountManagementListItemLink
+															href={buildFeedbackHref(currentHref, feedback.id)}
 															active={isActive}
-															onClick={() => {
-																navigate(
-																	buildFeedbackHref(currentHref, feedback.id),
-																)
-															}}
 														>
 															<strong
 																mix={css({
@@ -430,7 +426,7 @@ export function AdminPlatformFeedbackRoute(handle: Handle) {
 																	{feedback.summary_untrusted}
 																</span>
 															) : null}
-														</AccountManagementListItemButton>
+														</AccountManagementListItemLink>
 													</li>
 												)
 											})}

--- a/packages/worker/client/routes/admin-users.tsx
+++ b/packages/worker/client/routes/admin-users.tsx
@@ -1,7 +1,7 @@
 import { formatTimestamp } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
-import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { replaceLocation } from '#client/replace-location.ts'
 import {
 	createInfiniteList,
@@ -24,7 +24,7 @@ import {
 import {
 	AccountManagementLayout,
 	AccountManagementList,
-	AccountManagementListItemButton,
+	AccountManagementListItemLink,
 	AccountManagementMessage,
 	AccountManagementPanel,
 	AccountManagementSearchField,
@@ -772,13 +772,10 @@ export function AdminUsersRoute(handle: Handle) {
 									<AccountManagementList>
 										{users.map((user) => (
 											<li key={user.stableUserId} mix={css({ minWidth: 0 })}>
-												<AccountManagementListItemButton
+												<AccountManagementListItemLink
+													href={buildUserDetailHref(user.stableUserId)}
 													active={selectedStableUserId === user.stableUserId}
 													disabled={isMutating}
-													onClick={() => {
-														if (isMutating) return
-														navigate(buildUserDetailHref(user.stableUserId))
-													}}
 												>
 													<strong mix={css({ display: 'block' })}>
 														{user.username}
@@ -803,7 +800,7 @@ export function AdminUsersRoute(handle: Handle) {
 															? user.roles.join(', ')
 															: 'No roles'}
 													</span>
-												</AccountManagementListItemButton>
+												</AccountManagementListItemLink>
 											</li>
 										))}
 										{hasMore ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Selecting a record in the account/admin list/detail views should not scroll the page back to the top. The client router already supports React Router-style scroll preservation via `data-prevent-scroll-reset` on intercepted anchors (see `docs/contributing/architecture/request-lifecycle.md`); the list/detail sidebars just never used it — their entries were `<button>`s calling `navigate()` programmatically.

## Summary

- `AccountManagementListItemButton` is now `AccountManagementListItemLink`: a real `<a>` carrying `data-prevent-scroll-reset`, so selecting a record keeps the scroll position and gains link semantics for free (middle/cmd-click opens in a new tab, hover warms the destination loader via intent prefetch). While `disabled`, the `href` is dropped so clicks mid-mutation do nothing.
- Pre-navigation state resets (clearing messages, collapsing delete confirmations, seeding editor state) move to an `onNavigate` callback gated on the newly exported `shouldRouterHandleClick`, so modified clicks that open a new tab leave the current pane untouched.
- All 13 list/detail routes updated: account memories, secrets, values, jobs, packages, package invocation tokens, MCP servers, remote connectors, integrations, email, activity, admin users, and admin platform feedback.
- The integrations sidebar's OAuth-app group headers become anchors with the attribute too, and the detail pane's connection links pick it up, so every intra-view selection behaves consistently.
- `e2e/admin-rbac.spec.ts` selectors updated from `getByRole('button', ...)` to `getByRole('link', ...)` for the users list.

## Testing

- `npm run validate` green locally (typecheck, lint, format, 554 unit test files / 1902 tests, Playwright e2e suite including the updated `admin-rbac` spec).
- Manual browser verification: seeded 14 secrets, scrolled `/account/secrets` to `window.scrollY ≈ 439`, clicked through several sidebar entries — detail pane swaps while the scroll position stays put (previously it jumped to the top).

<a href="https://cursor.com/agents/bc-69730d73-c82a-4712-aab3-0819097416ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsecrets_scroll_preserved_demo_trimmed.mp4"><img src="https://cursor.com/artifacts/c/art-2b190ab5-d214-45c4-a128-4bfd87dcf4db" alt="secrets_scroll_preserved_demo_trimmed.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `bc4dbfb2` · **Head:** `08bbbba3`

**Classification:** composes — no primitives added or changed; this PR wires the router's existing `data-prevent-scroll-reset` handling into the app-ui list/detail views.

### Primitives touched

| Primitive | Group    | Impact                                                                    |
| --------- | -------- | ------------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — list/detail sidebar entries become anchors using the router's existing scroll-preservation attribute |

### System map

List/detail sidebar clicks now flow through router-intercepted anchors instead of programmatic `navigate()` calls, reusing the router's existing scroll restoration.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appUi -->|"anchors with data-prevent-scroll-reset in 13 list/detail routes"| appUi

	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Aspect | Before | After |
| ------ | ------ | ----- |
| Sidebar entry element | `<button>` + `navigate(href)` | `<a href data-prevent-scroll-reset>` |
| Scroll on select | jumps to top | preserved |
| New tab / prefetch | unavailable | native middle/cmd-click, hover intent prefetch |
| Disabled while mutating | `disabled` attribute | `href` dropped + `aria-disabled` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69730d73-c82a-4712-aab3-0819097416ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69730d73-c82a-4712-aab3-0819097416ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated account and administration list entries to use standard links for navigation.
  * Preserved active styling, query parameters, scroll position, and UI cleanup when opening details.
  * Improved browser behaviors such as opening links in new tabs and copying link destinations.
  * Maintained fast in-app navigation while supporting normal browser link behavior.

* **Tests**
  * Updated admin access-control tests to verify user entries through links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->