### PR TITLE
Auto-check onboarding step 3 for email reply + memory

### DIFF
--- a/packages/worker/client/routes/onboarding-checklist.node.test.ts
+++ b/packages/worker/client/routes/onboarding-checklist.node.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'vitest'
+import { isOnboardingChecklistItemDone } from '#client/routes/onboarding-checklist.tsx'
+
+test('isOnboardingChecklistItemDone reads derived checklist signals', () => {
+	expect(isOnboardingChecklistItemDone(null, 'first-hello')).toBe(false)
+	expect(
+		isOnboardingChecklistItemDone(
+			{
+				dismissed: false,
+				items: [
+					{ id: 'first-hello', done: true },
+					{ id: 'save-memory', done: false },
+				],
+			},
+			'first-hello',
+		),
+	).toBe(true)
+	expect(
+		isOnboardingChecklistItemDone(
+			{
+				dismissed: false,
+				items: [
+					{ id: 'first-hello', done: true },
+					{ id: 'save-memory', done: false },
+				],
+			},
+			'save-memory',
+		),
+	).toBe(false)
+})

--- a/packages/worker/client/routes/onboarding-checklist.tsx
+++ b/packages/worker/client/routes/onboarding-checklist.tsx
@@ -67,6 +67,14 @@ export function getFirstUndoneChecklistItemLabel(
 	return undone ? onboardingChecklistItemLabels[undone.id] : null
 }
 
+/** True when the derived checklist marks the given item done. */
+export function isOnboardingChecklistItemDone(
+	checklist: OnboardingChecklistLoaderData | null | undefined,
+	id: OnboardingChecklistItemId,
+): boolean {
+	return checklist?.items.some((item) => item.id === id && item.done) ?? false
+}
+
 type OnboardingChecklistCardProps = {
 	checklist: OnboardingChecklistLoaderData
 	onDismissed?: () => void

--- a/packages/worker/client/routes/onboarding-payload.ts
+++ b/packages/worker/client/routes/onboarding-payload.ts
@@ -14,6 +14,7 @@ export type OnboardingPayload = {
 	setupPrompt: string
 	discoveryPrompt: string
 	introEmailPrompt: string
+	introEmailLookupPrompt: string
 	memoryPrompt: string
 	hasMcpClient: boolean
 	emailVerified: boolean

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -25,6 +25,7 @@ import {
 import { OnboardingDiyCard } from '#client/routes/onboarding-diy-card.tsx'
 import {
 	OnboardingChecklistCard,
+	isOnboardingChecklistItemDone,
 	shouldShowOnboardingChecklist,
 } from '#client/routes/onboarding-checklist.tsx'
 import { OnboardingMcpClientTabs } from '#client/routes/onboarding-mcp-client-tabs.tsx'
@@ -53,8 +54,8 @@ import {
  * (Discover · Connect your agent · See it work · Install a starter package), one surface
  * panel at a time with hand-tilted mascot art, and the BYOK argument folded
  * behind a disclosure. All server state (prompts, MCP URL, featured
- * listings, hasMcpClient polling) stays exactly as before — this is a
- * restyle, not a rearchitecture.
+ * listings, hasMcpClient / first-win polling) stays in the route state —
+ * this is a restyle, not a rearchitecture.
  */
 
 type OnboardingStep = 1 | 2 | 3 | 4
@@ -117,8 +118,12 @@ export function OnboardingRoute(handle: Handle) {
 	let setupPrompt = ''
 	let discoveryPrompt = ''
 	let introEmailPrompt = ''
+	let introEmailLookupPrompt = ''
 	let memoryPrompt = ''
 	let hasMcpClient = false
+	let hasFirstHello = false
+	let hasSavedMemory = false
+	let hasFirstWin = false
 	let featuredListings: Array<OnboardingFeaturedListing> = []
 	let checklist: OnboardingChecklistLoaderData | null = null
 	let checklistHidden = false
@@ -132,25 +137,40 @@ export function OnboardingRoute(handle: Handle) {
 
 	function applyPayload(payload: OnboardingPayload) {
 		const wasConnected = hasMcpClient
+		const wasFirstWin = hasFirstWin
 		loggedIn = payload.loggedIn
 		mcpServerUrl = payload.mcpServerUrl
 		setupPrompt = payload.setupPrompt
 		discoveryPrompt = payload.discoveryPrompt
 		introEmailPrompt = payload.introEmailPrompt
+		introEmailLookupPrompt = payload.introEmailLookupPrompt
 		memoryPrompt = payload.memoryPrompt
 		hasMcpClient = payload.hasMcpClient
+		hasFirstHello = isOnboardingChecklistItemDone(
+			payload.checklist,
+			'first-hello',
+		)
+		hasSavedMemory = isOnboardingChecklistItemDone(
+			payload.checklist,
+			'save-memory',
+		)
+		hasFirstWin = hasFirstHello && hasSavedMemory
 		featuredListings = payload.featuredListings ?? []
 		checklist = payload.checklist
 		if (payload.checklist?.dismissed) checklistHidden = true
 		status = 'ready'
 		message = null
 		if (!initializedStep) {
-			activeStep = payload.hasMcpClient ? 3 : 1
+			activeStep = hasFirstWin ? 4 : payload.hasMcpClient ? 3 : 1
 			initializedStep = true
-		} else if (!wasConnected && payload.hasMcpClient) {
+		} else if (!wasConnected && payload.hasMcpClient && !hasFirstWin) {
 			panelAnimationArmed = true
 			activeStep = 3
 			updateStepHash(3)
+		} else if (!wasFirstWin && hasFirstWin) {
+			panelAnimationArmed = true
+			activeStep = 4
+			updateStepHash(4)
 		}
 	}
 
@@ -243,9 +263,10 @@ export function OnboardingRoute(handle: Handle) {
 		}
 	}
 
-	// Users typically keep this page open while their MCP client runs the
-	// OAuth flow, so poll the same JSON endpoint until a grant shows up and
-	// collapse the completed steps without requiring a manual refresh.
+	// Users typically keep this page open while their MCP client runs OAuth
+	// and while they finish the first-win prompts, so poll the same JSON
+	// endpoint until those signals land and collapse completed steps without
+	// a manual refresh.
 	//
 	// The interval must stay clear of 5000ms: workerd's HTTP server closes
 	// idle keep-alive connections after exactly 5s (kj pipeline timeout), so
@@ -253,12 +274,12 @@ export function OnboardingRoute(handle: Handle) {
 	// that race's "Network connection lost" ProxyWorker error into a fatal
 	// dev-server exit (cloudflare/workers-sdk#14926). Polling faster than 5s
 	// keeps the connection warm so the race never happens.
-	const mcpConnectionPollIntervalMs = 4000
+	const onboardingProgressPollIntervalMs = 4000
 	let pollIntervalId: ReturnType<typeof setInterval> | undefined
 	let pollInFlight = false
 
-	async function pollForMcpConnection() {
-		if (hasMcpClient) {
+	async function pollOnboardingProgress() {
+		if (hasFirstWin) {
 			clearInterval(pollIntervalId)
 			return
 		}
@@ -268,7 +289,23 @@ export function OnboardingRoute(handle: Handle) {
 		pollInFlight = true
 		try {
 			const payload = await fetchOnboardingPayload(handle.signal)
-			if (handle.signal.aborted || !payload?.hasMcpClient) return
+			if (handle.signal.aborted || !payload) return
+			const nextHasMcpClient = payload.hasMcpClient
+			const nextHasFirstHello = isOnboardingChecklistItemDone(
+				payload.checklist,
+				'first-hello',
+			)
+			const nextHasSavedMemory = isOnboardingChecklistItemDone(
+				payload.checklist,
+				'save-memory',
+			)
+			if (
+				nextHasMcpClient === hasMcpClient &&
+				nextHasFirstHello === hasFirstHello &&
+				nextHasSavedMemory === hasSavedMemory
+			) {
+				return
+			}
 			applyPayload(payload)
 			handle.update()
 		} catch {
@@ -280,8 +317,8 @@ export function OnboardingRoute(handle: Handle) {
 
 	if (typeof document !== 'undefined') {
 		pollIntervalId = setInterval(
-			pollForMcpConnection,
-			mcpConnectionPollIntervalMs,
+			pollOnboardingProgress,
+			onboardingProgressPollIntervalMs,
 		)
 		handle.signal.addEventListener('abort', () => clearInterval(pollIntervalId))
 		window.addEventListener('hashchange', handleHashChange)
@@ -369,7 +406,9 @@ export function OnboardingRoute(handle: Handle) {
 						<nav aria-label="Onboarding steps" mix={css(wizardStepsCss)}>
 							{onboardingSteps.map((step) => {
 								const isActive = activeStep === step.number
-								const isComplete = hasMcpClient && step.number < 3
+								const isComplete =
+									(step.number < 3 && hasMcpClient) ||
+									(step.number === 3 && hasFirstWin)
 								return (
 									<button
 										key={step.number}
@@ -556,17 +595,50 @@ export function OnboardingRoute(handle: Handle) {
 								</div>
 								<p mix={css(panelLedeCss)}>
 									Paste these into your connected agent — Kody stores what
-									lands, and your agent reads it back when you ask.
+									lands, and your agent reads it back when you ask. This step
+									checks off once both are done.
 								</p>
 								<div mix={css(firstWinGridCss)}>
 									<article mix={css(firstWinCardCss)}>
-										<h3 mix={css(firstWinCardTitleCss)}>Say hello</h3>
+										<div mix={css(firstWinCardHeadCss)}>
+											<h3 mix={css(firstWinCardTitleCss)}>Say hello</h3>
+											{loggedIn ? (
+												<div
+													mix={css(connectStatusCss)}
+													role="status"
+													aria-live="polite"
+													data-connected={
+														hasFirstHello ? 'true' : undefined
+													}
+													data-testid="onboarding-first-hello-status"
+												>
+													{hasFirstHello ? (
+														<>
+															<span
+																mix={css(connectCheckCss)}
+																aria-hidden="true"
+															>
+																✓
+															</span>
+															<strong>Reply received</strong>
+														</>
+													) : (
+														<>
+															<span
+																mix={css(inlineSpinnerCss)}
+																aria-hidden="true"
+															/>
+															<strong>Waiting for your reply…</strong>
+														</>
+													)}
+												</div>
+											) : null}
+										</div>
 										<p mix={css(firstWinGuidanceCss)}>
-											Paste this into your connected agent; Kody emails you from
-											your own Kody address within a minute. When it lands,
-											reply to it — then ask your agent what you said. Kody
-											stores your reply; nothing answers by itself until your
-											agent reads it.
+											1. Paste the first prompt so Kody emails you from your
+											own Kody address. 2. Reply to that email. 3. Paste the
+											second prompt so your agent looks up your reply — Kody
+											stores mail; nothing answers by itself until you ask.
 										</p>
 										<figure mix={css(promptBlockCss)}>
 											<blockquote>{introEmailPrompt}</blockquote>
@@ -576,15 +648,56 @@ export function OnboardingRoute(handle: Handle) {
 											idleLabel="Copy hello prompt"
 											variant="pill"
 										/>
+										<figure mix={css(promptBlockCss)}>
+											<blockquote>{introEmailLookupPrompt}</blockquote>
+										</figure>
+										<CopyTextButton
+											value={introEmailLookupPrompt}
+											idleLabel="Copy lookup prompt"
+											variant="pill"
+										/>
 									</article>
 									<article mix={css(firstWinCardCss)}>
-										<h3 mix={css(firstWinCardTitleCss)}>
-											Teach Kody about you
-										</h3>
+										<div mix={css(firstWinCardHeadCss)}>
+											<h3 mix={css(firstWinCardTitleCss)}>
+												Teach Kody about you
+											</h3>
+											{loggedIn ? (
+												<div
+													mix={css(connectStatusCss)}
+													role="status"
+													aria-live="polite"
+													data-connected={
+														hasSavedMemory ? 'true' : undefined
+													}
+													data-testid="onboarding-save-memory-status"
+												>
+													{hasSavedMemory ? (
+														<>
+															<span
+																mix={css(connectCheckCss)}
+																aria-hidden="true"
+															>
+																✓
+															</span>
+															<strong>Memory saved</strong>
+														</>
+													) : (
+														<>
+															<span
+																mix={css(inlineSpinnerCss)}
+																aria-hidden="true"
+															/>
+															<strong>Waiting for a saved memory…</strong>
+														</>
+													)}
+												</div>
+											) : null}
+										</div>
 										<p mix={css(firstWinGuidanceCss)}>
-											Your agent will ask a couple of questions and save durable
-											memories that follow you across every agent connected to
-											your account.
+											Paste this into your connected agent. It will ask a
+											couple of questions and save durable memories that follow
+											you across every agent connected to your account.
 										</p>
 										<figure mix={css(promptBlockCss)}>
 											<blockquote>{memoryPrompt}</blockquote>
@@ -1055,6 +1168,11 @@ const firstWinCardCss = {
 	border: `1.5px solid ${colors.border}`,
 	borderRadius: radius.card,
 	minWidth: 0,
+}
+
+const firstWinCardHeadCss = {
+	display: 'grid',
+	gap: '0.65rem',
 }
 
 const firstWinCardTitleCss = {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -607,9 +607,7 @@ export function OnboardingRoute(handle: Handle) {
 													mix={css(connectStatusCss)}
 													role="status"
 													aria-live="polite"
-													data-connected={
-														hasFirstHello ? 'true' : undefined
-													}
+													data-connected={hasFirstHello ? 'true' : undefined}
 													data-testid="onboarding-first-hello-status"
 												>
 													{hasFirstHello ? (
@@ -635,10 +633,10 @@ export function OnboardingRoute(handle: Handle) {
 											) : null}
 										</div>
 										<p mix={css(firstWinGuidanceCss)}>
-											1. Paste the first prompt so Kody emails you from your
-											own Kody address. 2. Reply to that email. 3. Paste the
-											second prompt so your agent looks up your reply — Kody
-											stores mail; nothing answers by itself until you ask.
+											1. Paste the first prompt so Kody emails you from your own
+											Kody address. 2. Reply to that email. 3. Paste the second
+											prompt so your agent looks up your reply — Kody stores
+											mail; nothing answers by itself until you ask.
 										</p>
 										<figure mix={css(promptBlockCss)}>
 											<blockquote>{introEmailPrompt}</blockquote>
@@ -667,9 +665,7 @@ export function OnboardingRoute(handle: Handle) {
 													mix={css(connectStatusCss)}
 													role="status"
 													aria-live="polite"
-													data-connected={
-														hasSavedMemory ? 'true' : undefined
-													}
+													data-connected={hasSavedMemory ? 'true' : undefined}
 													data-testid="onboarding-save-memory-status"
 												>
 													{hasSavedMemory ? (
@@ -695,9 +691,9 @@ export function OnboardingRoute(handle: Handle) {
 											) : null}
 										</div>
 										<p mix={css(firstWinGuidanceCss)}>
-											Paste this into your connected agent. It will ask a
-											couple of questions and save durable memories that follow
-											you across every agent connected to your account.
+											Paste this into your connected agent. It will ask a couple
+											of questions and save durable memories that follow you
+											across every agent connected to your account.
 										</p>
 										<figure mix={css(promptBlockCss)}>
 											<blockquote>{memoryPrompt}</blockquote>

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -7,6 +7,7 @@ import {
 } from '#app/handlers/onboarding.ts'
 import {
 	buildDiscoveryPrompt,
+	buildIntroEmailLookupPrompt,
 	buildIntroEmailPrompt,
 	buildMemoryPrompt,
 	buildOnboardingSetupPrompt,
@@ -45,6 +46,7 @@ test('onboarding serves public setup content to anonymous visitors', async () =>
 			requestUrl: 'https://example.com/onboarding.json',
 		}),
 		introEmailPrompt: buildIntroEmailPrompt(),
+		introEmailLookupPrompt: buildIntroEmailLookupPrompt(),
 		memoryPrompt: buildMemoryPrompt(),
 		hasMcpClient: false,
 		emailVerified: false,

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -669,6 +669,8 @@ export type OnboardingLoaderData = {
 	discoveryPrompt: string
 	/** First-win prompt: welcome email that invites a reply. */
 	introEmailPrompt: string
+	/** First-win follow-up: ask the agent to read the user's reply. */
+	introEmailLookupPrompt: string
 	/** First-win prompt: tiny interview that seeds durable memories. */
 	memoryPrompt: string
 	hasMcpClient: boolean

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import {
 	buildDiscoveryPrompt,
+	buildIntroEmailLookupPrompt,
 	buildIntroEmailPrompt,
 	buildMcpServerUrl,
 	buildMemoryPrompt,
@@ -26,6 +27,9 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		}),
 	).toContain('https://preview.example')
 
+	// After the welcome reply, the lookup prompt is the explicit second paste.
+	expect(buildIntroEmailLookupPrompt().toLowerCase()).toContain('look up')
+
 	expect(
 		loadPublicOnboardingData({
 			env: { APP_BASE_URL: 'https://heykody.dev' },
@@ -41,6 +45,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 			requestUrl: 'https://heykody.dev/onboarding',
 		}),
 		introEmailPrompt: buildIntroEmailPrompt(),
+		introEmailLookupPrompt: buildIntroEmailLookupPrompt(),
 		memoryPrompt: buildMemoryPrompt(),
 		hasMcpClient: false,
 		emailVerified: false,
@@ -69,6 +74,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 			requestUrl: 'https://heykody.dev/onboarding',
 		}),
 		introEmailPrompt: buildIntroEmailPrompt(),
+		introEmailLookupPrompt: buildIntroEmailLookupPrompt(),
 		memoryPrompt: buildMemoryPrompt(),
 		hasMcpClient: false,
 		emailVerified: true,
@@ -116,6 +122,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		setupPrompt: '',
 		// First-win prompts need a verified email (they send/store real data).
 		introEmailPrompt: '',
+		introEmailLookupPrompt: '',
 		memoryPrompt: '',
 		// Discovery needs no verified email or MCP host, so it is never gated.
 		discoveryPrompt: buildDiscoveryPrompt({

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -69,6 +69,15 @@ export function buildIntroEmailPrompt() {
 	return 'Hey Kody, send me a welcome email introducing yourself, and invite me to reply to it.'
 }
 
+/**
+ * Follow-up after the user replies to the welcome email. Kept separate from
+ * the send prompt so the UI can show "reply, then ask your agent to look it
+ * up" as an explicit second paste.
+ */
+export function buildIntroEmailLookupPrompt() {
+	return 'Hey Kody, look up my reply to your welcome email and tell me what I said.'
+}
+
 /** Second first-win prompt: start durable memory with a tiny interview. */
 export function buildMemoryPrompt() {
 	return 'Hey Kody, ask me a couple of questions about who I am and what I work with, then remember what matters.'
@@ -110,6 +119,7 @@ export function loadPublicOnboardingData(input: {
 			requestUrl: input.requestUrl,
 		}),
 		introEmailPrompt: buildIntroEmailPrompt(),
+		introEmailLookupPrompt: buildIntroEmailLookupPrompt(),
 		memoryPrompt: buildMemoryPrompt(),
 		hasMcpClient: false,
 		emailVerified: false,
@@ -161,6 +171,9 @@ export async function loadOnboardingData(input: {
 			requestUrl: input.requestUrl,
 		}),
 		introEmailPrompt: input.emailVerified ? buildIntroEmailPrompt() : '',
+		introEmailLookupPrompt: input.emailVerified
+			? buildIntroEmailLookupPrompt()
+			: '',
 		memoryPrompt: input.emailVerified ? buildMemoryPrompt() : '',
 		hasMcpClient,
 		emailVerified: input.emailVerified,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -325,6 +325,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		setupPrompt: '',
 		discoveryPrompt: expect.stringContaining('what-is-kody'),
 		introEmailPrompt: '',
+		introEmailLookupPrompt: '',
 		memoryPrompt: '',
 		hasMcpClient: false,
 		emailVerified: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Step 3 ("See it work") now polls like step 2 and auto-checks when both first-win signals land: an inbound email reply (`first-hello`) and a saved memory (`save-memory`). Each prompt card shows a waiting spinner / completed check, and the email card makes the post-reply lookup step explicit with a second copyable prompt.

## Changes

- Keep polling `/onboarding.json` until first-win is complete (not only until MCP connects)
- Mark stepper step 3 complete and auto-advance to step 4 when both checklist items are done
- Add per-prompt status pills on the email and memory cards
- Add `introEmailLookupPrompt` ("look up my reply…") so the reply → ask-agent flow is obvious
- Small helper + tests for reading checklist done state

## Risk

Medium — onboarding UX / progress wiring only; uses existing derived checklist signals, no storage or auth contract changes beyond a new prompt field on the onboarding payload.

Local `npm run validate` passed after a format fix (format/lint/typecheck/unit/e2e/mcp).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/onboarding-step3-auto-check-bd6e`

**Classification:** extends — onboarding UI now polls and auto-advances from derived checklist signals, and the onboarding loader payload gains `introEmailLookupPrompt`.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — step-3 polling, per-prompt spinners, auto-check / advance |
| `app-sessions` | auth | composes — onboarding payload builder adds a static follow-up prompt field |

### System map

Onboarding polls the JSON payload, reads checklist done flags, and updates step-3 UI / stepper completion without a manual refresh.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Remix UI surfaces"]:::extended
	appSessions["app-sessions<br/>Browser sessions"]:::touched
	appUi -->|"poll /onboarding.json"| appSessions
	appSessions -->|"checklist + lookup prompt"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant OnboardingUI as Onboarding UI
	participant API as /onboarding.json
	User->>OnboardingUI: paste hello / memory prompts
	loop every 4s until first-win
		OnboardingUI->>API: fetch payload
		API-->>OnboardingUI: hasMcpClient + checklist items
		OnboardingUI->>OnboardingUI: update spinners / checks
	end
	OnboardingUI->>OnboardingUI: mark step 3 complete, advance to step 4
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| Polling | Stops once MCP grant appears | Continues until `first-hello` + `save-memory` |
| Step 3 UI | Static prompts | Spinner/check per prompt + lookup copy prompt |
| Stepper | Steps 1–2 check on MCP connect | Step 3 also checks when first-win completes |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7263e11f-412b-4f85-ad6c-c3d5ec04bd6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7263e11f-412b-4f85-ad6c-c3d5ec04bd6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved onboarding progress tracking for “Say hello” and “Teach Kody about you” milestones.
  * Added live completion statuses and a follow-up prompt to help users find and reply to the introductory email.
  * Onboarding now advances automatically as first-win milestones are completed.

* **Bug Fixes**
  * Improved progress updates so onboarding remains accurate during completion checks.

* **Tests**
  * Added coverage for checklist completion states and onboarding prompt data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->