### PR TITLE
fix(ci): retry Cloudflare queue API blips in production ensure

### DIFF
--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -5,6 +5,7 @@ import {
 	ensureEmailSendingEventSubscription,
 	ensureR2Bucket,
 	fail,
+	listCloudflareQueues,
 	listD1Databases,
 	listKvNamespaces,
 	parseJsonc,
@@ -486,77 +487,73 @@ async function ensureProductionResources(options: CliOptions) {
 			'Missing CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_ZONE_ID, or CLOUDFLARE_API_TOKEN for Queue provisioning.',
 		)
 	}
-	const emailDeliveryQueue = await ensureCloudflareQueue({
+	const queueClient = {
 		accountId: accountId ?? 'dry-run-account',
 		apiToken: apiToken ?? 'dry-run-token',
-		name: bindings.emailDeliveryQueueName,
 		dryRun: options.dryRun,
+	}
+	const existingQueues = options.dryRun
+		? []
+		: await listCloudflareQueues(queueClient)
+	const emailDeliveryQueue = await ensureCloudflareQueue({
+		...queueClient,
+		name: bindings.emailDeliveryQueueName,
+		existingQueues,
 	})
 	const emailDeliveryDeadLetterQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.emailDeliveryDeadLetterQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const artifactsRepoEventsQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.artifactsRepoEventsQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const artifactsRepoEventsDeadLetterQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.artifactsRepoEventsDeadLetterQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const platformFeedbackDispatchQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.platformFeedbackDispatchQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const platformFeedbackDispatchDeadLetterQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.platformFeedbackDispatchDeadLetterQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const communityActivityDispatchQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.communityActivityDispatchQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const communityActivityDispatchDeadLetterQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.communityActivityDispatchDeadLetterQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const scheduledDispatchQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.scheduledDispatchQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const scheduledDispatchDeadLetterQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.scheduledDispatchDeadLetterQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const packageEventsDispatchQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.packageEventsDispatchQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const packageEventsDispatchDeadLetterQueue = await ensureCloudflareQueue({
-		accountId: accountId ?? 'dry-run-account',
-		apiToken: apiToken ?? 'dry-run-token',
+		...queueClient,
 		name: bindings.packageEventsDispatchDeadLetterQueueName,
-		dryRun: options.dryRun,
+		existingQueues,
 	})
 	const emailSendingDomain = resolveEmailSendingDomain(options.dryRun)
 	const emailEventSubscription = await ensureEmailSendingEventSubscription({

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -6,10 +6,12 @@ import { expect, test, vi } from 'vitest'
 import { consoleError } from '#worker/test-support/console-spies.ts'
 
 import {
+	cloudflareApiRequest,
 	emailSendingEventTypes,
 	ensureArtifactsAccountEventSubscription,
 	ensureCloudflareQueue,
 	ensureEmailSendingEventSubscription,
+	isRetryableCloudflareApiError,
 	isWranglerNotFoundOutput,
 	parseJsonc,
 	parseR2BucketListOutput,
@@ -291,6 +293,24 @@ test('Queue and Email Sending subscription ensure creates and reconciles Cloudfl
 		}),
 	)
 
+	const listedQueues = [
+		{ queue_id: 'queue-existing', queue_name: 'kody-email-delivery' },
+	]
+	const reusedQueueFetch = vi.fn<typeof fetch>()
+	const reusedQueue = await ensureCloudflareQueue({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		name: 'kody-email-delivery',
+		dryRun: false,
+		existingQueues: listedQueues,
+		fetcher: reusedQueueFetch,
+	})
+	expect(reusedQueue).toEqual({
+		id: 'queue-existing',
+		name: 'kody-email-delivery',
+	})
+	expect(reusedQueueFetch).not.toHaveBeenCalled()
+
 	const subscriptionFetch = vi
 		.fn<typeof fetch>()
 		.mockResolvedValueOnce(
@@ -410,6 +430,53 @@ test('Queue and Email Sending subscription ensure creates and reconciles Cloudfl
 		},
 		events: [...emailSendingEventTypes],
 	})
+})
+
+test('Cloudflare API requests retry gateway HTML/text blips then succeed', async () => {
+	consoleError.mockImplementation(() => {})
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			new Response(
+				'upstream connect error or disconnect/reset before headers. reset reason: connection termination',
+				{ status: 502, statusText: 'Bad Gateway' },
+			),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: {
+					queue_id: 'queue-1',
+					queue_name: 'kody-email-delivery',
+				},
+			}),
+		)
+	const payload = await cloudflareApiRequest({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		pathname: '/queues',
+		method: 'POST',
+		body: { queue_name: 'kody-email-delivery' },
+		fetcher,
+		sleep: async () => {},
+	})
+	expect(payload.result).toEqual({
+		queue_id: 'queue-1',
+		queue_name: 'kody-email-delivery',
+	})
+	expect(fetcher).toHaveBeenCalledTimes(2)
+	expect(
+		isRetryableCloudflareApiError(
+			new Error(
+				'Malformed Cloudflare response (502) for /queues: upstream connect error or disconnect/reset before headers. reset reason: connection termination',
+			),
+		),
+	).toBe(true)
+	expect(
+		isRetryableCloudflareApiError(
+			new Error('Cloudflare API request failed (400): invalid queue name'),
+		),
+	).toBe(false)
 })
 
 test('ensureArtifactsAccountEventSubscription creates account-level lifecycle subscription', async () => {

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -465,6 +465,31 @@ test('Cloudflare API requests retry gateway HTML/text blips then succeed', async
 		queue_name: 'kody-email-delivery',
 	})
 	expect(fetcher).toHaveBeenCalledTimes(2)
+
+	const nullBodyFetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(new Response('null', { status: 200 }))
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: {
+					queue_id: 'queue-2',
+					queue_name: 'kody-email-delivery',
+				},
+			}),
+		)
+	const nullBodyPayload = await cloudflareApiRequest({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		pathname: '/queues?page=1&per_page=100',
+		fetcher: nullBodyFetcher,
+		sleep: async () => {},
+	})
+	expect(nullBodyPayload.result).toEqual({
+		queue_id: 'queue-2',
+		queue_name: 'kody-email-delivery',
+	})
+	expect(nullBodyFetcher).toHaveBeenCalledTimes(2)
 	expect(
 		isRetryableCloudflareApiError(
 			new Error(

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -324,9 +324,8 @@ async function cloudflareApiRequestOnce<T>(input: CloudflareApiRequestInput) {
 	const url = `${baseUrl.replace(/\/$/, '')}/accounts/${encodeURIComponent(input.accountId)}${input.pathname}`
 	const abortController = new AbortController()
 	const timeout = setTimeout(() => abortController.abort(), 30_000)
-	let response: Response
 	try {
-		response = await (input.fetcher ?? fetch)(url, {
+		const response = await (input.fetcher ?? fetch)(url, {
 			method: input.method ?? 'GET',
 			headers: {
 				Authorization: `Bearer ${input.apiToken}`,
@@ -336,30 +335,30 @@ async function cloudflareApiRequestOnce<T>(input: CloudflareApiRequestInput) {
 			...(input.body ? { body: JSON.stringify(input.body) } : {}),
 			signal: abortController.signal,
 		})
+		const text = await response.text()
+		let payload: CloudflareApiEnvelope<T>
+		try {
+			payload = JSON.parse(text) as CloudflareApiEnvelope<T>
+		} catch {
+			const preview = text.trim().slice(0, 200) || '(empty body)'
+			throw new Error(
+				`Malformed Cloudflare response (${response.status}) for ${input.pathname}: ${preview}`,
+			)
+		}
+		if (
+			!response.ok ||
+			payload.success !== true ||
+			payload.result === undefined
+		) {
+			const error = payload.errors?.[0]
+			throw new Error(
+				`Cloudflare API request failed (${response.status}): ${error?.message ?? error?.code ?? input.pathname}`,
+			)
+		}
+		return payload
 	} finally {
 		clearTimeout(timeout)
 	}
-	const text = await response.text()
-	let payload: CloudflareApiEnvelope<T>
-	try {
-		payload = JSON.parse(text) as CloudflareApiEnvelope<T>
-	} catch {
-		const preview = text.trim().slice(0, 200) || '(empty body)'
-		throw new Error(
-			`Malformed Cloudflare response (${response.status}) for ${input.pathname}: ${preview}`,
-		)
-	}
-	if (
-		!response.ok ||
-		payload.success !== true ||
-		payload.result === undefined
-	) {
-		const error = payload.errors?.[0]
-		throw new Error(
-			`Cloudflare API request failed (${response.status}): ${error?.message ?? error?.code ?? input.pathname}`,
-		)
-	}
-	return payload
 }
 
 export async function cloudflareApiRequest<T>(

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -32,9 +32,32 @@ export type CloudflareApiEnvelope<T> = {
 	result_info?: { total_pages?: number; cursor?: string }
 }
 
-type CloudflareQueue = {
+export type CloudflareQueue = {
 	queue_id: string
 	queue_name: string
+}
+
+const cloudflareApiRetryMaxAttempts = 4
+const cloudflareApiRetryBaseDelayMs = 250
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+export function isRetryableCloudflareApiError(error: unknown) {
+	if (!(error instanceof Error)) return false
+	if (error.name === 'AbortError') return true
+	const message = error.message
+	return (
+		message.includes('Malformed Cloudflare response') ||
+		message.includes('upstream connect error') ||
+		message.includes('Cloudflare API request failed (429)') ||
+		/Cloudflare API request failed \(5\d\d\)/.test(message) ||
+		message.includes('fetch failed') ||
+		message.includes('ECONNRESET') ||
+		message.includes('ETIMEDOUT') ||
+		message.includes('socket hang up')
+	)
 }
 
 type CloudflareEventSubscription = {
@@ -284,7 +307,7 @@ export function deleteR2Bucket({
 	console.error(`Deleted R2 bucket: ${name}`)
 }
 
-export async function cloudflareApiRequest<T>(input: {
+type CloudflareApiRequestInput = {
 	accountId: string
 	apiToken: string
 	pathname: string
@@ -292,7 +315,11 @@ export async function cloudflareApiRequest<T>(input: {
 	body?: Record<string, unknown>
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
-}) {
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+}
+
+async function cloudflareApiRequestOnce<T>(input: CloudflareApiRequestInput) {
 	const baseUrl = input.apiBaseUrl ?? 'https://api.cloudflare.com/client/v4'
 	const url = `${baseUrl.replace(/\/$/, '')}/accounts/${encodeURIComponent(input.accountId)}${input.pathname}`
 	const abortController = new AbortController()
@@ -312,7 +339,16 @@ export async function cloudflareApiRequest<T>(input: {
 	} finally {
 		clearTimeout(timeout)
 	}
-	const payload = (await response.json()) as CloudflareApiEnvelope<T>
+	const text = await response.text()
+	let payload: CloudflareApiEnvelope<T>
+	try {
+		payload = JSON.parse(text) as CloudflareApiEnvelope<T>
+	} catch {
+		const preview = text.trim().slice(0, 200) || '(empty body)'
+		throw new Error(
+			`Malformed Cloudflare response (${response.status}) for ${input.pathname}: ${preview}`,
+		)
+	}
 	if (
 		!response.ok ||
 		payload.success !== true ||
@@ -326,11 +362,35 @@ export async function cloudflareApiRequest<T>(input: {
 	return payload
 }
 
-async function listCloudflareQueues(input: {
+export async function cloudflareApiRequest<T>(
+	input: CloudflareApiRequestInput,
+) {
+	const maxAttempts = input.maxAttempts ?? cloudflareApiRetryMaxAttempts
+	const wait = input.sleep ?? sleep
+	let lastError: unknown
+	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+		try {
+			return await cloudflareApiRequestOnce<T>(input)
+		} catch (error) {
+			lastError = error
+			if (!isRetryableCloudflareApiError(error) || attempt === maxAttempts) {
+				throw error
+			}
+			console.error(
+				`Retrying Cloudflare API ${input.method ?? 'GET'} ${input.pathname} (attempt ${attempt + 1}/${maxAttempts})`,
+			)
+			await wait(cloudflareApiRetryBaseDelayMs * 2 ** (attempt - 1))
+		}
+	}
+	throw lastError
+}
+
+export async function listCloudflareQueues(input: {
 	accountId: string
 	apiToken: string
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
 }) {
 	const queues: Array<CloudflareQueue> = []
 	let page = 1
@@ -354,31 +414,54 @@ export async function ensureCloudflareQueue(input: {
 	dryRun: boolean
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+	existingQueues?: Array<CloudflareQueue>
 }) {
 	if (input.dryRun) {
 		console.error(`[dry-run] ensure Queue: ${input.name}`)
 		return { id: `dry-run-${input.name}`, name: input.name }
 	}
-	const existing = (await listCloudflareQueues(input)).find(
-		(queue) => queue.queue_name === input.name,
-	)
+	const queues = input.existingQueues ?? (await listCloudflareQueues(input))
+	const existing = queues.find((queue) => queue.queue_name === input.name)
 	if (existing) {
 		console.error(`Queue exists: ${existing.queue_name} (${existing.queue_id})`)
 		return { id: existing.queue_id, name: existing.queue_name }
 	}
-	const payload = await cloudflareApiRequest<CloudflareQueue>({
-		...input,
-		pathname: '/queues',
-		method: 'POST',
-		body: { queue_name: input.name },
-	})
-	if (!payload.result?.queue_id || !payload.result.queue_name) {
-		throw new Error(`Cloudflare created Queue without an id: ${input.name}`)
+	try {
+		const payload = await cloudflareApiRequest<CloudflareQueue>({
+			...input,
+			pathname: '/queues',
+			method: 'POST',
+			body: { queue_name: input.name },
+		})
+		if (!payload.result?.queue_id || !payload.result.queue_name) {
+			throw new Error(`Cloudflare created Queue without an id: ${input.name}`)
+		}
+		input.existingQueues?.push(payload.result)
+		console.error(
+			`Created Queue: ${payload.result.queue_name} (${payload.result.queue_id})`,
+		)
+		return { id: payload.result.queue_id, name: payload.result.queue_name }
+	} catch (error) {
+		let refreshed: Array<CloudflareQueue>
+		try {
+			refreshed = await listCloudflareQueues(input)
+		} catch {
+			throw error
+		}
+		const created = refreshed.find((queue) => queue.queue_name === input.name)
+		if (!created) throw error
+		if (
+			input.existingQueues &&
+			!input.existingQueues.some((queue) => queue.queue_id === created.queue_id)
+		) {
+			input.existingQueues.push(created)
+		}
+		console.error(
+			`Queue exists after create retry: ${created.queue_name} (${created.queue_id})`,
+		)
+		return { id: created.queue_id, name: created.queue_name }
 	}
-	console.error(
-		`Created Queue: ${payload.result.queue_name} (${payload.result.queue_id})`,
-	)
-	return { id: payload.result.queue_id, name: payload.result.queue_name }
 }
 
 async function listCloudflareEventSubscriptions(input: {

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -336,15 +336,25 @@ async function cloudflareApiRequestOnce<T>(input: CloudflareApiRequestInput) {
 			signal: abortController.signal,
 		})
 		const text = await response.text()
-		let payload: CloudflareApiEnvelope<T>
+		const preview = text.trim().slice(0, 200) || '(empty body)'
+		let parsed: unknown
 		try {
-			payload = JSON.parse(text) as CloudflareApiEnvelope<T>
+			parsed = JSON.parse(text)
 		} catch {
-			const preview = text.trim().slice(0, 200) || '(empty body)'
 			throw new Error(
 				`Malformed Cloudflare response (${response.status}) for ${input.pathname}: ${preview}`,
 			)
 		}
+		if (
+			parsed === null ||
+			typeof parsed !== 'object' ||
+			Array.isArray(parsed)
+		) {
+			throw new Error(
+				`Malformed Cloudflare response (${response.status}) for ${input.pathname}: ${preview}`,
+			)
+		}
+		const payload = parsed as CloudflareApiEnvelope<T>
 		if (
 			!response.ok ||
 			payload.success !== true ||


### PR DESCRIPTION
## Summary
- Production deploy failed in **Ensure production resources** when Cloudflare's Queues list API returned a non-JSON gateway reset (`upstream connect error…`) and `response.json()` crashed the step.
- Immediate unblock: reran the failed production deploy; it succeeded.
- Durable fix: parse Cloudflare API bodies as text first, retry transient 429/5xx/malformed/upstream errors, list queues once per ensure run, and recover creates that succeed after a dropped response.

## Test plan
- [x] `npx vitest run --config vitest.node.config.ts tools/ci/resource-utils.node.test.ts`
- [x] Production deploy rerun of https://github.com/kentcdodds/kody/actions/runs/31183742350 is green
- [ ] Validate + merge this hardening so the next deploy does not fail the same way

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `2e62de1a` · **Head:** `0c883a86`

**Classification:** extends — production queue ensure now retries Cloudflare gateway blips and lists queues once instead of once per binding.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `email-delivery-queue` | storage | extends — shared production queue ensure retries malformed/5xx Cloudflare responses and reuses one queue listing for all production queues |

Unmatched paths: `tools/ci/resource-utils.ts` and its node test (shared Cloudflare API helper used by production queue ensure; not a separate primitive).

### System map

Production deploy ensure talks to the Cloudflare Queues API through the shared CI helper; this PR makes that hop retry-safe and cheaper.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	emailDeliveryQueue["email-delivery-queue<br/>Email delivery event queue"]:::extended
	emailDeliveryQueue -->|"GET /queues once + retry malformed upstream resets"| emailDeliveryQueue
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Deploy as Production deploy
	participant Ensure as production-resources.ts
	participant Api as Cloudflare Queues API
	Deploy->>Ensure: ensure --out-config
	Ensure->>Api: GET /queues (once)
	alt gateway text / 429 / 5xx
		Api-->>Ensure: non-JSON upstream reset
		Ensure->>Api: retry with backoff
	end
	Api-->>Ensure: queue list
	Ensure->>Ensure: match all production queue names locally
```

</details>

<!-- system-recap:end -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Cloudflare queue provisioning by reusing existing queues and reducing unnecessary API requests.
  * Added automatic retries for temporary Cloudflare API failures, including transient server errors and malformed responses.
  * Prevented duplicate queue creation when provisioning requests overlap or recover after an error.
  * Improved reliability when queue creation encounters intermittent service issues.

* **Tests**
  * Added coverage for queue reuse, retryable failures, and non-retryable errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->