### PR TITLE
Link package-owned job ownership to the package detail page

### DIFF
--- a/packages/worker/client/routes/account-jobs-filter.node.test.ts
+++ b/packages/worker/client/routes/account-jobs-filter.node.test.ts
@@ -170,4 +170,23 @@ test('account jobs filters cover active/history views and ownership', () => {
 			nowMs,
 		}).map((item) => item.id),
 	).toEqual(['failed-once'])
+
+	expect(
+		filterAccountJobs(
+			[
+				job({
+					id: 'named-package',
+					name: 'Nightly sync',
+					ownership: 'package',
+					packageName: 'State Store',
+				}),
+			],
+			{
+				view: 'all',
+				ownership: 'all',
+				search: 'state store',
+				nowMs,
+			},
+		).map((item) => item.id),
+	).toEqual(['named-package'])
 })

--- a/packages/worker/client/routes/account-jobs-filter.ts
+++ b/packages/worker/client/routes/account-jobs-filter.ts
@@ -7,6 +7,7 @@ export type FilterableAccountJob = {
 	id: string
 	name: string
 	ownership: string
+	packageName?: string | null
 	scheduleSummary: string
 	timezone: string
 	enabled: boolean
@@ -76,6 +77,7 @@ export function filterAccountJobs<Job extends FilterableAccountJob>(
 			job.name,
 			job.id,
 			job.ownership,
+			job.packageName ?? '',
 			job.scheduleSummary,
 			job.timezone,
 			job.lastRunStatus,

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -158,8 +158,30 @@ export async function accountJobsRouteLoader(
 	return { accountJobs: payload }
 }
 
-function ownershipLabel(ownership: AccountJobListItem['ownership']) {
-	return ownership === 'package' ? 'Package' : 'Ad-hoc'
+function ownershipLabel(
+	job: Pick<AccountJobListItem, 'ownership' | 'packageName'>,
+) {
+	if (job.ownership === 'package') {
+		return job.packageName ?? 'Package'
+	}
+	return 'Ad-hoc'
+}
+
+function ownershipValue(
+	job: Pick<AccountJobListItem, 'ownership' | 'packageId' | 'packageName'>,
+) {
+	if (job.ownership !== 'package') return 'Ad-hoc'
+	if (job.packageId && job.packageName) {
+		return (
+			<a
+				href={`/account/packages/${encodeURIComponent(job.packageId)}`}
+				mix={css(primaryLinkCss)}
+			>
+				{job.packageName}
+			</a>
+		)
+	}
+	return job.packageName ?? 'Package'
 }
 
 function statusLabel(
@@ -725,7 +747,7 @@ export function AccountJobsRoute(handle: Handle) {
 								),
 								ownership: (
 									<RecordChips
-										items={[ownershipLabel(item.ownership)]}
+										items={[ownershipLabel(item)]}
 										active={item.ownership === 'package'}
 									/>
 								),
@@ -757,7 +779,7 @@ export function AccountJobsRoute(handle: Handle) {
 										items={[
 											{
 												label: 'Ownership',
-												value: ownershipLabel(detail.ownership),
+												value: ownershipValue(detail),
 											},
 											{
 												label: 'Preserve',

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -542,19 +542,11 @@ export function OnboardingRoute(handle: Handle) {
 									aria-live="polite"
 									data-connected={hasMcpClient ? 'true' : undefined}
 								>
-									{hasMcpClient ? (
-										<>
-											<span mix={css(connectCheckCss)} aria-hidden="true">
-												✓
-											</span>
-											<strong>You are connected</strong>
-										</>
-									) : (
-										<>
-											<span mix={css(inlineSpinnerCss)} aria-hidden="true" />
-											<strong>Waiting for your agent to connect…</strong>
-										</>
-									)}
+									{connectStatusContent({
+										connected: hasMcpClient,
+										connectedLabel: 'You are connected',
+										waitingLabel: 'Waiting for your agent to connect…',
+									})}
 								</div>
 								<OnboardingMcpClientTabs mcpServerUrl={mcpServerUrl} />
 								<WizardNavigation
@@ -610,25 +602,11 @@ export function OnboardingRoute(handle: Handle) {
 													data-connected={hasFirstHello ? 'true' : undefined}
 													data-testid="onboarding-first-hello-status"
 												>
-													{hasFirstHello ? (
-														<>
-															<span
-																mix={css(connectCheckCss)}
-																aria-hidden="true"
-															>
-																✓
-															</span>
-															<strong>Reply received</strong>
-														</>
-													) : (
-														<>
-															<span
-																mix={css(inlineSpinnerCss)}
-																aria-hidden="true"
-															/>
-															<strong>Waiting for your reply…</strong>
-														</>
-													)}
+													{connectStatusContent({
+														connected: hasFirstHello,
+														connectedLabel: 'Reply received',
+														waitingLabel: 'Waiting for your reply…',
+													})}
 												</div>
 											) : null}
 										</div>
@@ -668,25 +646,11 @@ export function OnboardingRoute(handle: Handle) {
 													data-connected={hasSavedMemory ? 'true' : undefined}
 													data-testid="onboarding-save-memory-status"
 												>
-													{hasSavedMemory ? (
-														<>
-															<span
-																mix={css(connectCheckCss)}
-																aria-hidden="true"
-															>
-																✓
-															</span>
-															<strong>Memory saved</strong>
-														</>
-													) : (
-														<>
-															<span
-																mix={css(inlineSpinnerCss)}
-																aria-hidden="true"
-															/>
-															<strong>Waiting for a saved memory…</strong>
-														</>
-													)}
+													{connectStatusContent({
+														connected: hasSavedMemory,
+														connectedLabel: 'Memory saved',
+														waitingLabel: 'Waiting for a saved memory…',
+													})}
 												</div>
 											) : null}
 										</div>
@@ -1203,19 +1167,27 @@ const authNoteCss = {
 }
 
 /* Connection status pill: dashed while the product polls for the grant,
-   solid once the agent lands. */
+   solid once the agent lands. Height is locked to the check/spinner so
+   sibling pills in the step-3 grid stay the same size. */
 const connectStatusCss = {
-	display: 'flex',
+	display: 'inline-flex',
 	alignItems: 'center',
-	gap: '0.7rem',
+	gap: '0.55rem',
 	width: 'fit-content',
+	maxWidth: '100%',
+	boxSizing: 'border-box' as const,
 	color: colors.primaryText,
 	backgroundColor: `oklch(from ${colors.primary} l c h / 0.08)`,
 	border: `1.5px dashed oklch(from ${colors.primary} l c h / 0.45)`,
 	borderRadius: '999px',
-	padding: '0.65rem 1.2rem',
+	padding: '0.35rem 0.95rem 0.35rem 0.4rem',
+	lineHeight: 1,
 	'&[data-connected]': {
 		borderStyle: 'solid',
+	},
+	'& strong': {
+		lineHeight: 1.2,
+		fontWeight: 700,
 	},
 }
 
@@ -1223,13 +1195,47 @@ const connectCheckCss = {
 	flex: 'none',
 	display: 'grid',
 	placeItems: 'center',
+	boxSizing: 'border-box' as const,
 	width: '1.5rem',
 	height: '1.5rem',
 	borderRadius: '50%',
 	backgroundColor: colors.primary,
 	color: colors.onPrimary,
 	fontWeight: 760,
+	lineHeight: 1,
 	...wizardPopCss,
+}
+
+/** Match the check circle so waiting/connected pills share one height. */
+const connectStatusSpinnerCss = {
+	...inlineSpinnerCss,
+	width: '1.5rem',
+	height: '1.5rem',
+}
+
+function connectStatusContent(input: {
+	connected: boolean
+	connectedLabel: string
+	waitingLabel: string
+}) {
+	// Return an array (no inter-element whitespace text nodes) so flex height
+	// stays identical across sibling pills in the step-3 grid.
+	if (input.connected) {
+		return [
+			<span key="check" mix={css(connectCheckCss)} aria-hidden="true">
+				✓
+			</span>,
+			<strong key="label">{input.connectedLabel}</strong>,
+		]
+	}
+	return [
+		<span
+			key="spinner"
+			mix={css(connectStatusSpinnerCss)}
+			aria-hidden="true"
+		/>,
+		<strong key="label">{input.waitingLabel}</strong>,
+	]
 }
 
 /* Starter packages: compact centered cards; the DIY card breaks the grid

--- a/packages/worker/src/app/account-jobs-data.node.test.ts
+++ b/packages/worker/src/app/account-jobs-data.node.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+import { jobOwnershipForId, packageIdFromJobId } from './account-jobs-data.ts'
+
+test('packageIdFromJobId parses package-owned job ids', () => {
+	expect(packageIdFromJobId('job-adhoc-1')).toBeNull()
+	expect(packageIdFromJobId('package-job:')).toBeNull()
+	expect(packageIdFromJobId('package-job:pkg-only')).toBeNull()
+	expect(packageIdFromJobId('package-job::nightly')).toBeNull()
+	expect(packageIdFromJobId('package-job:pkg-1:nightly')).toBe('pkg-1')
+	expect(
+		packageIdFromJobId(
+			`package-job:b2fda105-005a-4e2b-9f22-1513b6752da2:${encodeURIComponent('state store')}`,
+		),
+	).toBe('b2fda105-005a-4e2b-9f22-1513b6752da2')
+	expect(jobOwnershipForId('package-job:pkg-1:nightly')).toBe('package')
+	expect(jobOwnershipForId('job-adhoc-1')).toBe('ad-hoc')
+})

--- a/packages/worker/src/app/account-jobs-data.ts
+++ b/packages/worker/src/app/account-jobs-data.ts
@@ -11,6 +11,7 @@ import {
 import { readJobRetentionPreferencesForUser } from '#worker/jobs/job-retention-cleanup.ts'
 import { inspectJobsForUser } from '#worker/jobs/inspect.ts'
 import { type JobSchedule, type JobView } from '#worker/jobs/types.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { listRunRecords } from '#worker/run-records/service.ts'
 
 type AuthenticatedUser = NonNullable<
@@ -23,6 +24,8 @@ export type AccountJobListItem = {
 	id: string
 	name: string
 	ownership: JobOwnership
+	packageId: string | null
+	packageName: string | null
 	scheduleSummary: string
 	scheduleType: JobSchedule['type']
 	timezone: string
@@ -99,6 +102,19 @@ export function jobOwnershipForId(jobId: string): JobOwnership {
 	return isPackageOwnedJobId(jobId) ? 'package' : 'ad-hoc'
 }
 
+/**
+ * Package job ids are `package-job:{packageId}:{encodeURIComponent(jobName)}`.
+ * Returns null for ad-hoc jobs or malformed package job ids.
+ */
+export function packageIdFromJobId(jobId: string): string | null {
+	if (!isPackageOwnedJobId(jobId)) return null
+	const rest = jobId.slice(packageJobIdPrefix.length)
+	const separatorIndex = rest.indexOf(':')
+	if (separatorIndex <= 0) return null
+	const packageId = rest.slice(0, separatorIndex).trim()
+	return packageId || null
+}
+
 export function readAccountJobsSelectedJobId(
 	requestUrl: string,
 	pathJobId?: string,
@@ -123,12 +139,16 @@ export function readAccountJobsSelectedJobId(
 
 function toListItem(
 	job: JobView,
+	packageNamesById: ReadonlyMap<string, string>,
 	inspection = buildJobInspectionOutput(job),
 ): AccountJobListItem {
+	const packageId = packageIdFromJobId(job.id)
 	return {
 		id: job.id,
 		name: job.name,
 		ownership: jobOwnershipForId(job.id),
+		packageId,
+		packageName: packageId ? (packageNamesById.get(packageId) ?? null) : null,
 		scheduleSummary: job.scheduleSummary,
 		scheduleType: job.schedule.type,
 		timezone: job.timezone,
@@ -172,6 +192,7 @@ async function toDetail(input: {
 	env: Env
 	userId: string
 	job: JobView
+	packageNamesById: ReadonlyMap<string, string>
 }): Promise<AccountJobDetail> {
 	const inspection = buildJobInspectionOutput(input.job)
 	const recentRuns = await loadRecentRunsForJob({
@@ -180,7 +201,7 @@ async function toDetail(input: {
 		jobId: input.job.id,
 	})
 	return {
-		...toListItem(input.job, inspection),
+		...toListItem(input.job, input.packageNamesById, inspection),
 		params: input.job.params ?? null,
 		schedule: input.job.schedule,
 		lastRunError: input.job.lastRunError ?? null,
@@ -218,26 +239,33 @@ export async function loadAccountJobsData(input: {
 		input.request.url,
 		input.pathJobId,
 	)
-	const inspection = await inspectJobsForUser({
-		env: input.env,
-		userId,
-	})
+	const [inspection, savedPackages, retentionPreferences] = await Promise.all([
+		inspectJobsForUser({
+			env: input.env,
+			userId,
+		}),
+		listSavedPackagesByUserId(input.env.APP_DB, { userId }),
+		readJobRetentionPreferencesForUser({
+			db: input.env.APP_DB,
+			userId,
+		}),
+	])
+	const packageNamesById = new Map(
+		savedPackages.map((savedPackage) => [savedPackage.id, savedPackage.name]),
+	)
 	const selectedRecord = selectedJobId
 		? (inspection.jobs.find((job) => job.id === selectedJobId) ?? null)
 		: null
-	const retentionPreferences = await readJobRetentionPreferencesForUser({
-		db: input.env.APP_DB,
-		userId,
-	})
 
 	return {
 		ok: true,
-		jobs: inspection.jobs.map((job) => toListItem(job)),
+		jobs: inspection.jobs.map((job) => toListItem(job, packageNamesById)),
 		selectedJob: selectedRecord
 			? await toDetail({
 					env: input.env,
 					userId,
 					job: selectedRecord,
+					packageNamesById,
 				})
 			: null,
 		selectedJobId,

--- a/packages/worker/src/app/handlers/account-jobs.node.test.ts
+++ b/packages/worker/src/app/handlers/account-jobs.node.test.ts
@@ -100,6 +100,23 @@ const mockModule = vi.hoisted(() => ({
 		failedOrNeverRanOnceDays: input.failedOrNeverRanOnceDays,
 		disabledRecurringDays: input.disabledRecurringDays,
 	})),
+	listSavedPackagesByUserId: vi.fn(async () => [
+		{
+			id: 'pkg-1',
+			userId: 'stable-user-1',
+			name: 'State Store',
+			kodyId: 'state-store',
+			description: '',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-pkg-1',
+			hasApp: false,
+			hidden: false,
+			isPrivate: true,
+			createdAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+		},
+	]),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -149,6 +166,11 @@ vi.mock('#worker/jobs/job-retention-cleanup.ts', () => ({
 vi.mock('#worker/run-records/service.ts', () => ({
 	listRunRecords: (...args: Array<unknown>) =>
 		mockModule.listRunRecords(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByUserId(...args),
 }))
 
 const { createAccountJobsApiHandler } = await import('./account-jobs.ts')
@@ -231,6 +253,8 @@ test('jobs API lists jobs with ownership and selected detail', async () => {
 			expect.objectContaining({
 				id: 'job-adhoc-1',
 				ownership: 'ad-hoc',
+				packageId: null,
+				packageName: null,
 				scheduleSummary: adHocJob.scheduleSummary,
 				scheduleType: 'cron',
 				enabled: true,
@@ -242,6 +266,8 @@ test('jobs API lists jobs with ownership and selected detail', async () => {
 			expect.objectContaining({
 				id: 'package-job:pkg-1:nightly',
 				ownership: 'package',
+				packageId: 'pkg-1',
+				packageName: 'State Store',
 				scheduleType: 'interval',
 			}),
 		],

--- a/packages/worker/src/app/loader-data.ts
+++ b/packages/worker/src/app/loader-data.ts
@@ -1002,6 +1002,8 @@ export type AccountJobListItem = {
 	id: string
 	name: string
 	ownership: AccountJobOwnership
+	packageId: string | null
+	packageName: string | null
 	scheduleSummary: string
 	scheduleType: AccountJobSchedule['type']
 	timezone: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Package-owned jobs now resolve their owning package name in the account jobs loader.
- The jobs detail **Ownership** field shows that package name as a link to `/account/packages/:id` instead of the generic “Package” label.
- The jobs list chip and search also use the package name when available.
- Onboarding step 3 status pills (“Reply received” / “Memory saved”) share one compact height via tightened styles and a shared renderer.

## Test plan

- [x] Unit: `packageIdFromJobId` parsing
- [x] Unit: jobs API returns `packageId` / `packageName` for package jobs
- [x] Unit: jobs search matches package name
- [x] `npm run test` / e2e (pre-push)
- [ ] Manually open a package-owned job on `/account/jobs` and confirm Ownership links to the package
- [ ] Manually confirm step-3 status pills match in height when both are complete

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `e3d289a9` · **Head:** `1a009360`

**Classification:** composes — no primitives added or changed; this PR wires existing package metadata into the jobs account UI and equalizes onboarding status chip styling.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — Ownership link + onboarding status pill height |
| `saved-packages` | assistant | composes — read package names for package-owned jobs |
| `jobs` | assistant | composes — parse package id from package job ids |

### System map

Jobs account UI reads saved-package names for ownership deep-links; onboarding reuses one status-pill renderer for step-3 chips.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	jobs["jobs<br/>Scheduled jobs"]:::touched
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	appUi -->|"ownership link /account/packages/:id"| savedPackages
	appUi -->|"parse package-job:{id}:…"| jobs
	appUi -->|"listSavedPackagesByUserId"| savedPackages
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Jobs detail Ownership | `Package` | Package name link → `/account/packages/:id` |
| Jobs list Ownership chip | `Package` | Package name when resolved |
| Jobs loader item | ownership only | + `packageId` / `packageName` |
| Onboarding step-3 status pills | Mismatched heights | Shared compact pill height |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87b86af0-268c-44bd-b09a-13f4bbb47faa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87b86af0-268c-44bd-b09a-13f4bbb47faa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account job listings now display package names for package-owned jobs.
  * Package names in job details link directly to their package pages when available.
  * Job search now matches package names case-insensitively.
  * Ad-hoc jobs continue to display clearly, including when package information is incomplete.

* **Bug Fixes**
  * Improved ownership classification and package identification for account jobs, including encoded and invalid job identifiers.

* **Style**
  * Improved onboarding connection-status indicators with consistent sizing, spacing, and clearer loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->