### PR TITLE
Fix waitlist join jumping the page to the top

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -200,9 +200,13 @@ pending after a short delay.
 The app shell also mounts **scroll restoration** for SPA navigations. The router
 saves each history entry's window scroll position, restores it on back/forward,
 scrolls to hash targets when present, and otherwise scrolls new navigations to
-the top after the destination route commits. Preserve the current scroll for a
-specific intercepted link or form with `data-prevent-scroll-reset`, or for
-programmatic navigation with `navigate(to, { preventScrollReset: true })`.
+the top after the destination route commits. Same-document hash links (for
+example the landing page's `#invite` waitlist CTA) are intercepted like other
+same-origin links so restoration can scroll to the target — native fragment
+scrolling is disabled while history scroll restoration is `manual`. Preserve the
+current scroll for a specific intercepted link or form with
+`data-prevent-scroll-reset`, or for programmatic navigation with
+`navigate(to, { preventScrollReset: true })`.
 
 Full page navigations occur for:
 

--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -3,6 +3,7 @@ import {
 	isSameShellAreaNavigation,
 	matchRoute,
 	matchRouteLoader,
+	shouldRouterHandleClick,
 	type RouteLoader,
 } from './client-router.tsx'
 
@@ -94,4 +95,48 @@ test('view transitions are skipped only when a navigation stays inside one shell
 
 	// A path that merely starts with the area's characters is a different area.
 	expect(isSameShellAreaNavigation('/account', '/accounts-payable')).toBe(false)
+})
+
+test('same-origin hash links are intercepted so scroll restoration can reach them', () => {
+	const previousWindow = globalThis.window
+	globalThis.window = {
+		location: {
+			href: 'https://kody.local/',
+			origin: 'https://kody.local',
+		},
+	} as Window & typeof globalThis
+
+	try {
+		const click = {
+			defaultPrevented: false,
+			button: 0,
+			metaKey: false,
+			altKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+		} as MouseEvent
+		const hashAnchor = {
+			target: '',
+			hasAttribute: () => false,
+			getAttribute: (name: string) => (name === 'href' ? '#invite' : null),
+		} as unknown as HTMLAnchorElement
+		expect(shouldRouterHandleClick(click, hashAnchor)).toBe(true)
+
+		const sameDocumentHashAnchor = {
+			target: '',
+			hasAttribute: () => false,
+			getAttribute: (name: string) => (name === 'href' ? '/#invite' : null),
+		} as unknown as HTMLAnchorElement
+		expect(shouldRouterHandleClick(click, sameDocumentHashAnchor)).toBe(true)
+
+		const externalAnchor = {
+			target: '',
+			hasAttribute: () => false,
+			getAttribute: (name: string) =>
+				name === 'href' ? 'https://example.com/#invite' : null,
+		} as unknown as HTMLAnchorElement
+		expect(shouldRouterHandleClick(click, externalAnchor)).toBe(false)
+	} finally {
+		globalThis.window = previousWindow
+	}
 })

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -143,7 +143,11 @@ function notify(onSwapped?: () => void) {
 		isSameShellAreaNavigation(
 			lastNotifiedDocumentPath,
 			getCurrentDocumentPath(),
-		)
+		) ||
+		// Hash-only moves stay on the same document. A view transition would
+		// snapshot the page and fight scroll restoration (the landing waitlist
+		// CTA is `#invite`).
+		getCurrentDocumentPath() === lastNotifiedDocumentPath
 	) {
 		void swapDom(onSwapped)
 		return
@@ -258,7 +262,7 @@ export function shouldRouterHandleClick(
 	if (anchor.hasAttribute('download')) return false
 
 	const href = anchor.getAttribute('href')
-	if (!href || href.startsWith('#')) return false
+	if (!href) return false
 
 	const destination = new URL(href, window.location.href)
 	if (destination.origin !== window.location.origin) return false
@@ -299,8 +303,8 @@ function getPrefetchableLink(
 	const destination = new URL(href, window.location.href)
 	if (destination.origin !== window.location.origin) return null
 	if (
-		getPathWithSearchAndHashFromUrl(destination) ===
-		getCurrentPathWithSearchAndHash()
+		`${destination.pathname}${destination.search}` ===
+		`${window.location.pathname}${window.location.search}`
 	) {
 		return null
 	}
@@ -900,7 +904,21 @@ async function navigateInternal(to: string, options?: NavigationRunOptions) {
 	const nextPath = getPathWithSearchAndHashFromUrl(destination)
 	const currentPath = getCurrentPathWithSearchAndHash()
 
-	if (nextPath === currentPath) return
+	if (nextPath === currentPath) {
+		// Re-activating the current hash (hero "Join the waiting list" while
+		// already at `/#invite`) must still scroll to the target. Native
+		// fragment clicks do that; a no-op here would leave the viewport stuck.
+		if (destination.hash) {
+			dispatchNavigationEnd(
+				createNavigationEventDetail(nextPath, {
+					...options,
+					historyAction: 'replace',
+					skipPushState: true,
+				}),
+			)
+		}
+		return
+	}
 
 	const sameDocumentLocation =
 		`${destination.pathname}${destination.search}` ===

--- a/packages/worker/client/intent-prefetch.node.test.ts
+++ b/packages/worker/client/intent-prefetch.node.test.ts
@@ -100,6 +100,11 @@ test('intent prefetch reuses in-flight runs, aborts superseded hrefs, and retrie
 	prefetchRouteOnIntent('/account', retry.loader, accountUrl)
 	expect(retry.calls).toHaveLength(1)
 	expect(takePrefetchedRouteResult('/account')).not.toBeNull()
+
+	abortIntentPrefetch()
+	const hashed = createDeferredLoader()
+	prefetchRouteOnIntent('/account#invite', hashed.loader, accountUrl)
+	expect(takePrefetchedRouteResult('/account')).not.toBeNull()
 })
 
 test('settled intent prefetches expire and restart on the next intent', async () => {

--- a/packages/worker/client/intent-prefetch.ts
+++ b/packages/worker/client/intent-prefetch.ts
@@ -13,7 +13,7 @@ export const maxPrefetchAgeMs = 30_000
 
 function normalizePrefetchHref(href: string) {
 	const url = new URL(href, routerHrefOrigin)
-	return `${url.pathname}${url.search}${url.hash}`
+	return `${url.pathname}${url.search}`
 }
 
 // Monotonic clock: freshness math must not break when the wall clock is

--- a/packages/worker/client/loader-data-context.node.test.ts
+++ b/packages/worker/client/loader-data-context.node.test.ts
@@ -14,8 +14,9 @@ import {
 test('loader href helpers normalize URLs and compare pathname and search', () => {
 	expect(normalizeRouterHref('/community?q=beta')).toBe('/community?q=beta')
 	expect(normalizeRouterHref('https://kody.local/community?q=beta#top')).toBe(
-		'/community?q=beta#top',
+		'/community?q=beta',
 	)
+	expect(hrefMatchesSsrUrl('/#invite', '/')).toBe(true)
 
 	expect(hrefMatchesSsrUrl('/community?q=beta', '/community?q=beta')).toBe(true)
 	expect(

--- a/packages/worker/client/loader-data-context.tsx
+++ b/packages/worker/client/loader-data-context.tsx
@@ -12,7 +12,7 @@ const routerHrefOrigin = 'https://kody.local'
 
 export function normalizeRouterHref(href: string) {
 	const url = new URL(href, routerHrefOrigin)
-	return `${url.pathname}${url.search}${url.hash}`
+	return `${url.pathname}${url.search}`
 }
 
 export function hrefMatchesSsrUrl(currentHref: string, ssrUrl: string) {
@@ -36,8 +36,9 @@ export function AppLoaderDataProvider(
 
 /**
  * Returns SSR-embedded loader data for `key` only when `currentHref` matches
- * the document's SSR URL and this key has not been consumed yet. Successful
- * reads mark the key consumed so SPA navigations always refetch.
+ * the document's SSR URL (pathname + search; hashes are ignored) and this key
+ * has not been consumed yet. Successful reads mark the key consumed so SPA
+ * navigations always refetch.
  *
  * Callers must run their own URL/path guards **before** calling this helper.
  * Consumption is irreversible; if a guard rejects after a successful read the

--- a/packages/worker/client/navigation-data.node.test.ts
+++ b/packages/worker/client/navigation-data.node.test.ts
@@ -76,6 +76,26 @@ test('preloaded navigation data is consumed once for matching hrefs and replaced
 	setPreloadedNavigationData('/account', {
 		accountProfile: {
 			ok: true,
+			email: 'kody@example.com',
+			emailVerified: true,
+			username: 'kody',
+			displayName: 'Kody',
+		},
+	})
+	expect(
+		tryConsumePreloadedLoaderData('accountProfile', '/account#invite'),
+	).toEqual({
+		ok: true,
+		email: 'kody@example.com',
+		emailVerified: true,
+		username: 'kody',
+		displayName: 'Kody',
+	})
+
+	clearPreloadedNavigationData()
+	setPreloadedNavigationData('/account', {
+		accountProfile: {
+			ok: true,
 			email: 'first@example.com',
 			emailVerified: true,
 			username: 'first',

--- a/packages/worker/client/navigation-data.ts
+++ b/packages/worker/client/navigation-data.ts
@@ -4,7 +4,7 @@ const routerHrefOrigin = 'https://kody.local'
 
 function normalizeNavigationHref(href: string) {
 	const url = new URL(href, routerHrefOrigin)
-	return `${url.pathname}${url.search}${url.hash}`
+	return `${url.pathname}${url.search}`
 }
 
 let preloadedSlot: { href: string; data: Partial<AppLoaderData> } | null = null

--- a/packages/worker/client/route-load-latch.node.test.ts
+++ b/packages/worker/client/route-load-latch.node.test.ts
@@ -77,3 +77,14 @@ test('applied route loader data suppresses the fallback fetch', () => {
 		}),
 	).toBe(false)
 })
+
+test('in-page hashes are the same data location as pathname plus search', () => {
+	const latch = createRouteLoadLatch()
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/' })).toBe(true)
+	latch.markLoaded('/')
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/#invite' })).toBe(false)
+	expect(latch.isLoadedFor('/#invite')).toBe(true)
+	expect(
+		latch.needsLoad({ ...baseInput, currentHref: '/?ref=blog#invite' }),
+	).toBe(true)
+})

--- a/packages/worker/client/route-load-latch.ts
+++ b/packages/worker/client/route-load-latch.ts
@@ -1,3 +1,10 @@
+const latchHrefOrigin = 'https://kody.local'
+
+function toLatchKey(href: string) {
+	const url = new URL(href, latchHrefOrigin)
+	return `${url.pathname}${url.search}`
+}
+
 /**
  * Href latch for client routes that fetch their own data. Tracks which
  * location the data was last loaded for, and which location last failed so a
@@ -5,6 +12,9 @@
  * navigating away and back (previously a failure latched these routes into a
  * permanent error state because the loaded-href marker was set before the
  * fetch resolved).
+ *
+ * Keys are pathname+search only. In-page hashes (`/#invite`, onboarding step
+ * hashes) are scroll/UI state, not a new data location.
  */
 export function createRouteLoadLatch() {
 	let lastLoadedHref = ''
@@ -14,22 +24,23 @@ export function createRouteLoadLatch() {
 	return {
 		/** Record a successful load (or applied preloaded data) for `href`. */
 		markLoaded(href: string) {
-			lastLoadedHref = href
+			lastLoadedHref = toLatchKey(href)
 			lastFailedHref = null
 		},
 		/** Record a failed load so renders stop re-queuing for this `href`. */
 		markFailed(href: string) {
-			lastFailedHref = href
+			const key = toLatchKey(href)
+			lastFailedHref = key
 			// A failure supersedes any earlier success for the same location;
 			// otherwise a failed refresh would leave the route latched as
 			// loaded and never refetch after navigating away and back.
-			if (lastLoadedHref === href) {
+			if (lastLoadedHref === key) {
 				lastLoadedHref = ''
 			}
 		},
 		/** Whether the last successful load matches `href`. */
 		isLoadedFor(href: string) {
-			return lastLoadedHref === href
+			return lastLoadedHref === toLatchKey(href)
 		},
 		/**
 		 * Whether the route must queue a data load this render pass. Call once
@@ -43,8 +54,9 @@ export function createRouteLoadLatch() {
 		}) {
 			// The failure latch only guards retry loops for the location that
 			// failed; leaving it (or coming back) must allow a fresh attempt.
-			if (input.currentHref !== lastSeenHref) {
-				lastSeenHref = input.currentHref
+			const currentHref = toLatchKey(input.currentHref)
+			if (currentHref !== lastSeenHref) {
+				lastSeenHref = currentHref
 				lastFailedHref = null
 			}
 			// A stale-refresh signal is one-shot (the caller consumes it from
@@ -56,9 +68,9 @@ export function createRouteLoadLatch() {
 			return (
 				!input.appliedRouteData &&
 				(input.isLoading ||
-					input.currentHref !== lastLoadedHref ||
+					currentHref !== lastLoadedHref ||
 					input.needsStaleRefresh) &&
-				input.currentHref !== lastFailedHref
+				currentHref !== lastFailedHref
 			)
 		},
 	}

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -458,6 +458,7 @@ function WaitlistForm(handle: Handle) {
 
 	async function handleSubmit(event: SubmitEvent) {
 		event.preventDefault()
+		if (status === 'submitting') return
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
 		const form = event.currentTarget
 
@@ -596,7 +597,8 @@ function WaitlistForm(handle: Handle) {
 							/>
 							<button
 								type="submit"
-								disabled={isSubmitting}
+								aria-disabled={isSubmitting ? 'true' : undefined}
+								aria-busy={isSubmitting ? 'true' : undefined}
 								mix={css(waitlistSubmitCss)}
 							>
 								<span
@@ -647,7 +649,13 @@ const pillButtonCss = getPillButtonCss()
 
 /* The submit pill keeps both labels grid-stacked in one cell, so swapping to
    "Joining…" never changes the button's size — the swap is a blur crossfade. */
-const waitlistSubmitCss = mergeCss(getPillButtonCss(), getSwapLabelCss())
+const waitlistSubmitCss = mergeCss(getPillButtonCss(), getSwapLabelCss(), {
+	'&[aria-disabled="true"]': {
+		cursor: 'progress',
+		opacity: 0.7,
+		transform: 'none',
+	},
+})
 
 const codeLinkCss = {
 	...inlineLinkCss,

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -655,6 +655,12 @@ const waitlistSubmitCss = mergeCss(getPillButtonCss(), getSwapLabelCss(), {
 		opacity: 0.7,
 		transform: 'none',
 	},
+	[hoverMq]: {
+		'&[aria-disabled="true"]:hover, &[aria-disabled="true"]:active': {
+			transform: 'none',
+			boxShadow: 'none',
+		},
+	},
 })
 
 const codeLinkCss = {

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -224,6 +224,7 @@ export function LoginRoute(handle: Handle) {
 
 	async function handleWaitingListSubmit(event: SubmitEvent) {
 		event.preventDefault()
+		if (status === 'submitting' || status === 'success') return
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
 		const form = event.currentTarget
 
@@ -662,7 +663,10 @@ export function LoginRoute(handle: Handle) {
 								{renderStatusMessage()}
 								<button
 									type="submit"
-									disabled={isSubmitting || status === 'success'}
+									aria-disabled={
+										isSubmitting || status === 'success' ? 'true' : undefined
+									}
+									aria-busy={isSubmitting ? 'true' : undefined}
 									mix={css(authSubmitCss)}
 								>
 									<span
@@ -1173,7 +1177,7 @@ const formMessageCss = {
 
 const authSubmitCss = mergeCss(getPillButtonCss(), getSwapLabelCss(), {
 	marginTop: '0.3rem',
-	'&:disabled': {
+	'&:disabled, &[aria-disabled="true"]': {
 		opacity: 0.7,
 		cursor: 'progress',
 		transform: 'none',

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -43,6 +43,7 @@ import {
 	getLanternGlowCss,
 	getPillButtonCss,
 	getSwapLabelCss,
+	hoverMq,
 	mergeCss,
 	visuallyHiddenCss,
 } from '#client/styles/style-primitives.ts'
@@ -662,7 +663,7 @@ export function LoginRoute(handle: Handle) {
 								) : null}
 								{renderStatusMessage()}
 								<button
-									type="submit"
+									type={status === 'success' ? 'button' : 'submit'}
 									aria-disabled={
 										isSubmitting || status === 'success' ? 'true' : undefined
 									}
@@ -1181,6 +1182,12 @@ const authSubmitCss = mergeCss(getPillButtonCss(), getSwapLabelCss(), {
 		opacity: 0.7,
 		cursor: 'progress',
 		transform: 'none',
+	},
+	[hoverMq]: {
+		'&[aria-disabled="true"]:hover, &[aria-disabled="true"]:active': {
+			transform: 'none',
+			boxShadow: 'none',
+		},
 	},
 })
 

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -2,7 +2,9 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import {
 	getPillButtonCss,
+	hoverMq,
 	layoutMaxWidths,
+	mergeCss,
 	pageGutter,
 } from '#client/styles/style-primitives.ts'
 import { colors, transitions, typography } from '#client/styles/tokens.ts'
@@ -345,8 +347,7 @@ const errorCss = {
 	textAlign: 'center' as const,
 }
 
-const pillSubmitCss = {
-	...getPillButtonCss(),
+const pillSubmitCss = mergeCss(getPillButtonCss(), {
 	fontSize: '0.9rem',
 	padding: '0.4rem 1.15rem',
 	whiteSpace: 'nowrap' as const,
@@ -355,11 +356,17 @@ const pillSubmitCss = {
 		opacity: 0.7,
 		transform: 'none',
 	},
+	[hoverMq]: {
+		'&[aria-disabled="true"]:hover, &[aria-disabled="true"]:active': {
+			transform: 'none',
+			boxShadow: 'none',
+		},
+	},
 	[stackMq]: {
 		gridColumn: '1 / -1',
 		justifyContent: 'center',
 	},
-}
+})
 
 const visuallyHiddenCss = {
 	position: 'absolute' as const,

--- a/packages/worker/client/waitlist-banner.tsx
+++ b/packages/worker/client/waitlist-banner.tsx
@@ -45,6 +45,7 @@ export function WaitlistBanner(handle: Handle) {
 
 	async function handleSubmit(event: SubmitEvent) {
 		event.preventDefault()
+		if (status === 'submitting') return
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
 		const form = event.currentTarget
 
@@ -168,7 +169,8 @@ export function WaitlistBanner(handle: Handle) {
 									/>
 									<button
 										type="submit"
-										disabled={isSubmitting}
+										aria-disabled={isSubmitting ? 'true' : undefined}
+										aria-busy={isSubmitting ? 'true' : undefined}
 										mix={css(pillSubmitCss)}
 									>
 										{isSubmitting ? 'Joining…' : 'Join'}
@@ -348,6 +350,11 @@ const pillSubmitCss = {
 	fontSize: '0.9rem',
 	padding: '0.4rem 1.15rem',
 	whiteSpace: 'nowrap' as const,
+	'&[aria-disabled="true"]': {
+		cursor: 'progress',
+		opacity: 0.7,
+		transform: 'none',
+	},
 	[stackMq]: {
 		gridColumn: '1 / -1',
 		justifyContent: 'center',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the public waitlist CTA from jumping the page back to the top when someone clicks it.

## Summary

- Intercept same-document hash links such as the landing `#invite` waitlist button through the SPA router so scroll restoration can scroll to the target. Native fragment scrolling does nothing while history scroll restoration is `manual`.
- Skip view transitions on hash-only moves so they do not fight that scroll.
- Re-clicking the current hash still re-scrolls to the section.
- Treat hashes as scroll/UI state, not a new data location, for route load latches, embedded/preloaded loader data, and intent prefetch.
- Keep waitlist submit buttons focusable while joining (`aria-disabled` / `aria-busy` instead of `disabled`) so disabling the control cannot drop focus to the document and scroll to the top.
- Review follow-up: override pill hover/active transforms for aria-disabled waitlist buttons, and switch the signup success control off `type="submit"`.

## Testing

- `npm run validate` passed locally on the initial revision.
- Push-hook e2e: 7 passed on both commits.
- CI on `6433086c`: Validate + Preview green ([Validate](https://github.com/kentcdodds/kody/actions/runs/31202434001), [Preview](https://github.com/kentcdodds/kody/actions/runs/31202433631)).
- Manual: hero **Join the waiting list** on `http://localhost:3742/` scrolls to `#invite` / Equip your agent form instead of jumping to the top.

![Landing hero Join the waiting list button](https://cursor.com/artifacts/c/art-32bbd404-becb-4fa5-b709-1065d5a8536d)
![After click, invite waitlist section at /#invite](https://cursor.com/artifacts/c/art-08a047a0-834d-43ee-936f-bc3611f5030d)
<a href="https://cursor.com/agents/bc-7d57503d-a6d7-4d0b-9dea-9c065a2fbfef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_join_waitlist_scrolls_to_invite.mp4"><img src="https://cursor.com/artifacts/c/art-afd4c8cf-3698-45d7-8dfa-bb681df9b190" alt="landing_join_waitlist_scrolls_to_invite.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `fa91d2c9` · **Head:** `6433086c`

**Classification:** extends — SPA hash navigation and waitlist submit focus behavior change inside the browser app.

### Primitives touched

| Primitive | Group    | Impact                                                           |
| --------- | -------- | ---------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — hash-link scroll restoration and waitlist submit focus |

### System map

Landing and signup waitlist CTAs stay in the browser app: hash links now use SPA scroll restoration, and waitlist submits no longer disable the focused button.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appUi -->|"#invite click -> scroll restoration"| appUi
	appUi -->|"waitlist submit stays focused"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant Router as client-router
	participant Scroll as scroll-restoration
	User->>Router: click Join the waiting list (#invite)
	Router->>Router: intercept same-document hash
	Router->>Scroll: navigationend hash target
	Scroll->>User: scroll #invite into view
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d57503d-a6d7-4d0b-9dea-9c065a2fbfef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d57503d-a6d7-4d0b-9dea-9c065a2fbfef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved same-page hash navigation with scroll restoration for back/forward navigation, hash targets, and top-of-page fallback.
  - Hash-only navigation now reuses existing route data and avoids unnecessary loading or view transitions.
  - Same-origin fragment links are handled consistently, while external links continue to navigate normally.

- **Bug Fixes**
  - Prevented duplicate waitlist submissions during processing or after successful submission.
  - Added clearer submitting states with accessibility indicators and visual feedback.

- **Documentation**
  - Documented scroll restoration and hash-navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->