### PR TITLE
Drop the Discover onboarding step: the what-is-kody guide owns discovery, linked from the homepage hero

### DIFF
--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -1,4 +1,5 @@
 import { type Handle, css } from 'remix/ui'
+import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
 import { HeroStage } from '#client/hero-stage.tsx'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
@@ -96,6 +97,7 @@ export function HomeRoute(handle: Handle) {
 	let needsOnboarding = false
 	let emailVerified = false
 	let loggedIn = false
+	let discoveryPrompt = ''
 	let onboardingStatus: 'idle' | 'loading' | 'ready' = 'idle'
 	const loadLatch = createRouteLoadLatch()
 
@@ -103,6 +105,7 @@ export function HomeRoute(handle: Handle) {
 		needsOnboarding = payload?.needsOnboarding === true
 		emailVerified = payload?.emailVerified === true
 		loggedIn = payload?.loggedIn === true
+		discoveryPrompt = payload?.discoveryPrompt ?? ''
 		onboardingStatus = 'ready'
 	}
 
@@ -195,11 +198,29 @@ export function HomeRoute(handle: Handle) {
 					</div>
 					<p data-rise style={{ '--rise': '3' }} mix={css(heroHintCss)}>
 						Not sure what you&apos;d use it for?{' '}
-						<a href={`${onboardingPath}#discovery`} mix={css(inlineLinkCss)}>
-							Ask your agent with the discovery prompt
-						</a>{' '}
-						— no account needed.
+						<a href="/guides/what-is-kody" mix={css(inlineLinkCss)}>
+							Read what Kody can do
+						</a>
+						{discoveryPrompt ? (
+							<>
+								{' '}
+								— or copy one prompt and let your agent tell you. No account
+								needed.
+							</>
+						) : (
+							<> — no account needed.</>
+						)}
 					</p>
+					{discoveryPrompt ? (
+						<div data-rise style={{ '--rise': '3.2' }} mix={css(heroHintCss)}>
+							<CopyTextButton
+								value={discoveryPrompt}
+								idleLabel="Copy the discovery prompt"
+								variant="ghost"
+								size="sm"
+							/>
+						</div>
+					) : null}
 					<div data-rise style={{ '--rise': '1.5' }} mix={css(heroArtCss)}>
 						<HeroStage
 							size="landing"

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -51,20 +51,19 @@ import {
 /**
  * Onboarding wizard, ported from the redesign prototype
  * (`landing/onboarding.html`): shirt-pattern head, four-step stepper
- * (Discover · Connect your agent · See it work · Install a starter package), one surface
+ * (Connect your agent · See it work · Install a starter package), one surface
  * panel at a time with hand-tilted mascot art, and the BYOK argument folded
  * behind a disclosure. All server state (prompts, MCP URL, featured
  * listings, hasMcpClient / first-win polling) stays in the route state —
  * this is a restyle, not a rearchitecture.
  */
 
-type OnboardingStep = 1 | 2 | 3 | 4
+type OnboardingStep = 1 | 2 | 3
 
 const onboardingSteps = [
-	{ number: 1, label: 'Discover', hash: 'discovery' },
-	{ number: 2, label: 'Connect your agent', hash: 'connect-agent' },
-	{ number: 3, label: 'See it work', hash: 'first-win' },
-	{ number: 4, label: 'Install a starter package', hash: 'starter-packages' },
+	{ number: 1, label: 'Connect your agent', hash: 'connect-agent' },
+	{ number: 2, label: 'See it work', hash: 'first-win' },
+	{ number: 3, label: 'Install a starter package', hash: 'starter-packages' },
 ] as const satisfies ReadonlyArray<{
 	number: OnboardingStep
 	label: string
@@ -116,7 +115,6 @@ export function OnboardingRoute(handle: Handle) {
 	let loggedIn = false
 	let mcpServerUrl = ''
 	let setupPrompt = ''
-	let discoveryPrompt = ''
 	let introEmailPrompt = ''
 	let introEmailLookupPrompt = ''
 	let memoryPrompt = ''
@@ -141,7 +139,6 @@ export function OnboardingRoute(handle: Handle) {
 		loggedIn = payload.loggedIn
 		mcpServerUrl = payload.mcpServerUrl
 		setupPrompt = payload.setupPrompt
-		discoveryPrompt = payload.discoveryPrompt
 		introEmailPrompt = payload.introEmailPrompt
 		introEmailLookupPrompt = payload.introEmailLookupPrompt
 		memoryPrompt = payload.memoryPrompt
@@ -161,16 +158,16 @@ export function OnboardingRoute(handle: Handle) {
 		status = 'ready'
 		message = null
 		if (!initializedStep) {
-			activeStep = hasFirstWin ? 4 : payload.hasMcpClient ? 3 : 1
+			activeStep = hasFirstWin ? 3 : payload.hasMcpClient ? 2 : 1
 			initializedStep = true
 		} else if (!wasConnected && payload.hasMcpClient && !hasFirstWin) {
 			panelAnimationArmed = true
-			activeStep = 3
-			updateStepHash(3)
+			activeStep = 2
+			updateStepHash(2)
 		} else if (!wasFirstWin && hasFirstWin) {
 			panelAnimationArmed = true
-			activeStep = 4
-			updateStepHash(4)
+			activeStep = 3
+			updateStepHash(3)
 		}
 	}
 
@@ -388,7 +385,11 @@ export function OnboardingRoute(handle: Handle) {
 					</h1>
 					<p data-rise style={{ '--rise': '1' }}>
 						Connect any MCP-capable AI agent to your Kody account, then ask it
-						to help you set things up.
+						to help you set things up. New here?{' '}
+						<a href="/guides/what-is-kody" mix={css(headerGuideLinkCss)}>
+							Read what Kody can do
+						</a>{' '}
+						first.
 					</p>
 				</header>
 
@@ -407,8 +408,8 @@ export function OnboardingRoute(handle: Handle) {
 							{onboardingSteps.map((step) => {
 								const isActive = activeStep === step.number
 								const isComplete =
-									(step.number < 3 && hasMcpClient) ||
-									(step.number === 3 && hasFirstWin)
+									(step.number === 1 && hasMcpClient) ||
+									(step.number === 2 && hasFirstWin)
 								return (
 									<button
 										key={step.number}
@@ -439,68 +440,6 @@ export function OnboardingRoute(handle: Handle) {
 
 						{activeStep === 1 ? (
 							<section
-								id="discovery"
-								aria-labelledby="discovery-title"
-								data-testid="onboarding-discovery"
-								mix={[css(wizardPanelCss), panelEntrance()]}
-							>
-								<div mix={css(panelHeadCss)}>
-									<div>
-										<p mix={css(panelKickerCss)}>Step 1 · Optional</p>
-										<h2
-											id="discovery-title"
-											tabIndex={-1}
-											mix={css(panelTitleCss)}
-										>
-											Discover what Kody can do
-										</h2>
-									</div>
-									<img
-										data-panel-art
-										src="/images/kody-agent-briefing.webp"
-										width={627}
-										height={627}
-										loading="lazy"
-										alt="Kody holding up a checklist card with both paws"
-										style={{ '--tilt': '-2.5deg' }}
-										mix={css(panelArtCss)}
-									/>
-								</div>
-								<p mix={css(panelLedeCss)}>
-									Paste this into any AI agent that can fetch a URL or search
-									the web — ChatGPT, Claude, Grok, or whatever you already use.
-									It reads Kody&apos;s docs, interviews you, and suggests
-									concrete automations. You can also skip this and connect
-									directly.
-								</p>
-								<figure mix={css(promptBlockCss)}>
-									<blockquote>{discoveryPrompt}</blockquote>
-								</figure>
-								<div mix={css(panelActionsCss)}>
-									<CopyTextButton
-										value={discoveryPrompt}
-										idleLabel="Copy discovery prompt"
-										variant="pill"
-									/>
-									<button
-										type="button"
-										mix={[
-											css(ghostActionButtonCss),
-											on('click', () => selectStep(2)),
-										]}
-									>
-										Skip discovery
-									</button>
-								</div>
-								<WizardNavigation
-									activeStep={activeStep}
-									onSelectStep={selectStep}
-								/>
-							</section>
-						) : null}
-
-						{activeStep === 2 ? (
-							<section
 								id="connect-agent"
 								aria-labelledby="connect-title"
 								data-testid="onboarding-connect-agent"
@@ -508,7 +447,7 @@ export function OnboardingRoute(handle: Handle) {
 							>
 								<div mix={css(panelHeadCss)}>
 									<div>
-										<p mix={css(panelKickerCss)}>Step 2</p>
+										<p mix={css(panelKickerCss)}>Step 1</p>
 										<h2
 											id="connect-title"
 											tabIndex={-1}
@@ -556,7 +495,7 @@ export function OnboardingRoute(handle: Handle) {
 							</section>
 						) : null}
 
-						{activeStep === 3 ? (
+						{activeStep === 2 ? (
 							<section
 								id="first-win"
 								aria-labelledby="first-win-title"
@@ -565,7 +504,7 @@ export function OnboardingRoute(handle: Handle) {
 							>
 								<div mix={css(panelHeadCss)}>
 									<div>
-										<p mix={css(panelKickerCss)}>Step 3</p>
+										<p mix={css(panelKickerCss)}>Step 2</p>
 										<h2
 											id="first-win-title"
 											tabIndex={-1}
@@ -676,7 +615,7 @@ export function OnboardingRoute(handle: Handle) {
 							</section>
 						) : null}
 
-						{activeStep === 4 ? (
+						{activeStep === 3 ? (
 							<section
 								id="starter-packages"
 								aria-labelledby="starters-title"
@@ -685,7 +624,7 @@ export function OnboardingRoute(handle: Handle) {
 							>
 								<div mix={css(panelHeadCss)}>
 									<div>
-										<p mix={css(panelKickerCss)}>Step 4</p>
+										<p mix={css(panelKickerCss)}>Step 3</p>
 										<h2
 											id="starters-title"
 											tabIndex={-1}
@@ -779,7 +718,7 @@ function WizardNavigation(
 				? ((handle.props.activeStep - 1) as OnboardingStep)
 				: null
 		const nextStep =
-			handle.props.activeStep < 4
+			handle.props.activeStep < 3
 				? ((handle.props.activeStep + 1) as OnboardingStep)
 				: null
 
@@ -1085,6 +1024,12 @@ const panelLedeCss = {
 }
 
 /* Nested surfaces step down to the page ground so they read as wells. */
+const headerGuideLinkCss = {
+	color: colors.primaryText,
+	textDecorationThickness: '1.5px',
+	textUnderlineOffset: '3px',
+}
+
 const promptBlockCss = {
 	margin: 0,
 	minWidth: 0,
@@ -1106,12 +1051,6 @@ const promptBlockCss = {
 		borderRadius: radius.card,
 		padding: '1.1rem 1.3rem',
 	},
-}
-
-const panelActionsCss = {
-	display: 'flex',
-	flexWrap: 'wrap' as const,
-	gap: '0.6rem',
 }
 
 const firstWinGridCss = {
@@ -1148,8 +1087,6 @@ const firstWinGuidanceCss = {
 	fontSize: '0.94rem',
 	lineHeight: 1.55,
 }
-
-const ghostActionButtonCss = getGhostButtonCss()
 
 /* One-time authorization callout: the only hard-edged warning on the page. */
 const authNoteCss = {

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -886,7 +886,7 @@ const errorMessageCss = {
 const wizardStepsCss = {
 	marginTop: 'clamp(2.2rem, 5vw, 3.2rem)',
 	display: 'grid',
-	gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+	gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
 	gap: '0.8rem',
 	'@media (max-width: 900px)': {
 		gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Discover step made onboarding four steps of work before any setup began, and its content duplicated what the `what-is-kody` guide already serves. This PR removes the step and gives the homepage the either/or instead.

- **Onboarding wizard is three steps**: Connect your agent · See it work · Install a starter package. Step numbering, completion checks, auto-advance (connect → step 2, first win → step 3), hash deep-links, and wizard navigation bounds all renumbered; the discovery panel, its prompt state, and now-unused styles removed. The header gains a quiet "New here? Read what Kody can do first." link for people who land directly.
- **Homepage hero** replaces the old `#discovery` deep-link hint with the either/or: "Read what Kody can do" links to `/guides/what-is-kody`, and a small "Copy the discovery prompt" button (fed by the existing onboarding payload's `discoveryPrompt`, which the home loader already fetches) lets visitors paste one prompt into their agent instead — still no account needed.
- The guide already carries the full discovery flow (its "Try it" prompt stays in sync with `buildDiscoveryPrompt` via the existing docs-sync test), so no server or docs changes were needed — this is a client-only diff.

## Testing

- `npm run typecheck`, lint, and 346 client+app node tests green; full pre-push suite (unit + workers + e2e) green on push.
- Recorded browser walkthrough: hero hint with working copy state → guide page with the Try it prompt → three-step wizard with the header guide link, stepping through all panels.

<a href="https://cursor.com/agents/bc-69e33c92-b0cb-4ece-9b0e-bda64e9bd7c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_discovery_link_and_three_step_onboarding.mp4"><img src="https://cursor.com/artifacts/c/art-acb660c5-c26a-454a-9796-ad1a051a19d8" alt="homepage_discovery_link_and_three_step_onboarding.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `84e9632d` · **Head:** `e148a779`

**Classification:** composes — client-only changes inside `app-ui`: removes the Discover wizard panel and repoints the homepage hero at the existing `what-is-kody` guide and the payload's existing `discoveryPrompt`. No routes, storage, capabilities, or server code change.

### Primitives touched

| Primitive | Group    | Impact                                                                             |
| --------- | -------- | ----------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — 3-step wizard; hero links `/guides/what-is-kody` + copies `discoveryPrompt` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69e33c92-b0cb-4ece-9b0e-bda64e9bd7c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69e33c92-b0cb-4ece-9b0e-bda64e9bd7c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copy button for onboarding prompts on the home page.
  * Added links to the onboarding guide from the home and onboarding screens.
  * Onboarding now presents a streamlined three-step setup flow.

* **Improvements**
  * Simplified onboarding navigation, progress indicators, and completion states.
  * Removed the previous discovery step and related messaging.
  * Home-page guidance now adapts based on whether a discovery prompt is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->