### PR TITLE
fix(client): MetaMask Sentry filter + serialize view transitions (3X/3Y)

### DIFF
--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -25,6 +25,10 @@ import {
 	type RouterNavigateOptions,
 	type RouterNavigationEventDetail,
 } from './router-scroll-state.ts'
+import {
+	createViewTransitionScheduler,
+	type ViewTransitionStarter,
+} from './view-transition-scheduler.ts'
 
 export { type RouteLoader } from './route-loader.ts'
 
@@ -76,8 +80,6 @@ function getCurrentDocumentPath() {
 	return `${window.location.pathname}${window.location.search}`
 }
 
-let activeViewTransition: { skipTransition(): void } | null = null
-
 /**
  * Areas whose pages sit inside a persistent shell (a sticky rail beside the
  * content). Moving between them is tab switching, not page-to-page
@@ -126,19 +128,23 @@ function swapDom(onSwapped?: () => void) {
 	)
 }
 
+function resolveViewTransitionStarter(): ViewTransitionStarter | null {
+	if (typeof document === 'undefined') return null
+	if (!('startViewTransition' in document)) return null
+	return (
+		document as Document & {
+			startViewTransition: ViewTransitionStarter
+		}
+	).startViewTransition.bind(document)
+}
+
+const viewTransitionScheduler = createViewTransitionScheduler(
+	resolveViewTransitionStarter,
+)
+
 function notify(onSwapped?: () => void) {
-	const startViewTransition =
-		'startViewTransition' in document
-			? (
-					document as Document & {
-						startViewTransition: (callback: () => Promise<void>) => {
-							skipTransition(): void
-						}
-					}
-				).startViewTransition.bind(document)
-			: null
 	if (
-		!startViewTransition ||
+		!resolveViewTransitionStarter() ||
 		matchMedia('(prefers-reduced-motion: reduce)').matches ||
 		isSameShellAreaNavigation(
 			lastNotifiedDocumentPath,
@@ -149,12 +155,16 @@ function notify(onSwapped?: () => void) {
 		// CTA is `#invite`).
 		getCurrentDocumentPath() === lastNotifiedDocumentPath
 	) {
+		// Instant path: drop any in-flight/queued VT so a superseded chain
+		// step cannot restart a transition after this swap.
+		viewTransitionScheduler.cancelPending()
 		void swapDom(onSwapped)
 		return
 	}
-	// A superseding navigation must not stack transitions.
-	activeViewTransition?.skipTransition()
-	activeViewTransition = startViewTransition(() => swapDom(onSwapped))
+	// Serialize superseding navigations: skip the active animation, then wait
+	// for its update callback to settle before starting the next transition
+	// (Chrome InvalidStateError / unhandledrejection — KODY-CLOUDFLARE-3Y).
+	viewTransitionScheduler.run(() => swapDom(onSwapped))
 }
 
 function createNavigationEventDetail(

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -6,6 +6,7 @@ import {
 	filterChromeExtensionObjectNotFoundSentryEvent,
 	filterFathomRemoveChildNullSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
+	filterMetaMaskExtensionSentryEvent,
 } from './sentry-browser-filters.ts'
 
 test('browser Sentry filters drop AbortError and Firefox Xray noise and keep real errors', () => {
@@ -225,6 +226,76 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 						type: 'UnhandledRejection',
 						value:
 							'Non-Error promise rejection captured with value: Object Not Found Matching Id:3, MethodName:update, ParamCount:4',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	// MetaMask inpage.js session restore (issue 7658961865 / KODY-CLOUDFLARE-3X).
+	expect(
+		filterMetaMaskExtensionSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'i',
+						value: 'Failed to connect to MetaMask',
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js',
+								},
+							],
+						},
+					},
+					{
+						type: 'Error',
+						value: 'MetaMask extension not found',
+						stacktrace: {
+							frames: [
+								{
+									abs_path:
+										'chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	// Message alone (no MetaMask extension frame) must not drop app errors.
+	expect(
+		filterMetaMaskExtensionSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Failed to connect to MetaMask',
+						stacktrace: {
+							frames: [{ abs_path: 'https://heykody.dev/assets/app-chunk.js' }],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'MetaMask extension not found',
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js',
+								},
+							],
+						},
 					},
 				],
 			},

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -303,6 +303,72 @@ export function filterChromeExtensionObjectNotFoundSentryEvent<
 	return event
 }
 
+/**
+ * MetaMask (`chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/…`) injects
+ * `inpage.js` into every page and tries to restore a wallet session on load.
+ * When the extension's background/service worker is unavailable it rejects
+ * with "Failed to connect to MetaMask" / "MetaMask extension not found".
+ * Signature from production issue 7658961865 / KODY-CLOUDFLARE-3X — stack is
+ * exclusively the extension; Kody never touches MetaMask.
+ *
+ * Match is intentionally narrow: MetaMask connect-failure wording AND a stack
+ * frame from MetaMask's published Chrome extension id. Never blanket-drop
+ * chrome-extension frames or wallet-related TypeErrors from app code.
+ */
+const metaMaskConnectFailureMessage =
+	/^(?:i:\s*)?(?:Failed to connect to MetaMask|MetaMask extension not found)\.?$/i
+
+/** Published MetaMask Chrome Web Store extension id. */
+const metaMaskChromeExtensionId = 'nkbihfbeogaeaoehlefnkodbefgpgknn'
+
+export function isMetaMaskConnectFailureMessage(message: string) {
+	return metaMaskConnectFailureMessage.test(message.trim())
+}
+
+export function isMetaMaskChromeExtensionStackFrameUrl(url: string) {
+	try {
+		const parsed = new URL(url, 'https://sentry.invalid')
+		return (
+			parsed.protocol === 'chrome-extension:' &&
+			parsed.hostname === metaMaskChromeExtensionId
+		)
+	} catch {
+		return false
+	}
+}
+
+export function isMetaMaskConnectFailureError(error: unknown) {
+	if (typeof error === 'string') {
+		return isMetaMaskConnectFailureMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isMetaMaskConnectFailureMessage(error.message)
+}
+
+export function isMetaMaskExtensionSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	const hasMetaMaskMessage =
+		isMetaMaskConnectFailureError(originalException) ||
+		sentryEventMessages(event).some(
+			(message) =>
+				typeof message === 'string' && isMetaMaskConnectFailureMessage(message),
+		)
+	if (!hasMetaMaskMessage) return false
+	return sentryEventStackFrameUrls(event).some(
+		isMetaMaskChromeExtensionStackFrameUrl,
+	)
+}
+
+export function filterMetaMaskExtensionSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isMetaMaskExtensionSentryEvent(event, originalException)) return null
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -330,6 +396,9 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 		filterChromeExtensionObjectNotFoundSentryEvent(event, originalException) ===
 		null
 	) {
+		return null
+	}
+	if (filterMetaMaskExtensionSentryEvent(event, originalException) === null) {
 		return null
 	}
 	return event

--- a/packages/worker/client/view-transition-scheduler.node.test.ts
+++ b/packages/worker/client/view-transition-scheduler.node.test.ts
@@ -1,0 +1,189 @@
+import { expect, test, vi } from 'vitest'
+import {
+	createViewTransitionScheduler,
+	type ViewTransitionLike,
+	type ViewTransitionStarter,
+} from './view-transition-scheduler.ts'
+
+function deferred<T = void>() {
+	let resolve!: (value: T | PromiseLike<T>) => void
+	let reject!: (reason?: unknown) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
+	return { promise, resolve, reject }
+}
+
+function fakeTransition(input: {
+	updateCallbackDone: Promise<void>
+}): ViewTransitionLike {
+	const ready = deferred<void>()
+	const finished = deferred<void>()
+	return {
+		updateCallbackDone: input.updateCallbackDone,
+		ready: ready.promise,
+		finished: finished.promise,
+		skipTransition() {
+			ready.reject(new DOMException('skipped', 'AbortError'))
+			finished.reject(
+				new DOMException(
+					'Transition was aborted because of invalid state',
+					'InvalidStateError',
+				),
+			)
+		},
+	}
+}
+
+async function waitFor(predicate: () => boolean, label: string, maxTurns = 20) {
+	for (let turn = 0; turn < maxTurns; turn++) {
+		if (predicate()) return
+		await Promise.resolve()
+	}
+	throw new Error(`timed out waiting for ${label}`)
+}
+
+test('view transition scheduler waits for the prior update callback before starting the next transition', async () => {
+	const firstCallback = deferred<void>()
+	const starts: Array<string> = []
+	const starter = vi.fn<ViewTransitionStarter>((callback) => {
+		const id = starts.length === 0 ? 'first' : 'second'
+		starts.push(id)
+		return fakeTransition({ updateCallbackDone: callback() })
+	})
+
+	const scheduler = createViewTransitionScheduler(() => starter)
+
+	scheduler.run(async () => {
+		await firstCallback.promise
+	})
+	await waitFor(() => starts.length === 1, 'first start')
+
+	scheduler.run(async () => {
+		// second swap
+	})
+
+	// Second start must not run until the first update callback settles.
+	expect(starts).toEqual(['first'])
+	expect(starter).toHaveBeenCalledTimes(1)
+
+	firstCallback.resolve()
+	await scheduler.whenIdle()
+
+	expect(starts).toEqual(['first', 'second'])
+	expect(starter).toHaveBeenCalledTimes(2)
+})
+
+test('view transition scheduler keeps only the latest pending swap under rapid superseding navigations', async () => {
+	const firstCallback = deferred<void>()
+	const swaps: Array<string> = []
+	const starter = vi.fn<ViewTransitionStarter>((callback) =>
+		fakeTransition({ updateCallbackDone: callback() }),
+	)
+
+	const scheduler = createViewTransitionScheduler(() => starter)
+	scheduler.run(async () => {
+		swaps.push('a')
+		await firstCallback.promise
+	})
+	await waitFor(() => swaps.includes('a'), 'swap a')
+
+	scheduler.run(async () => {
+		swaps.push('b')
+	})
+	scheduler.run(async () => {
+		swaps.push('c')
+	})
+
+	firstCallback.resolve()
+	await scheduler.whenIdle()
+
+	// 'a' ran as the in-flight transition; 'b' was superseded by 'c'.
+	expect(swaps).toEqual(['a', 'c'])
+	expect(starter).toHaveBeenCalledTimes(2)
+})
+
+test('view transition scheduler falls back to an instant swap when startViewTransition throws', async () => {
+	const swaps: Array<string> = []
+	const starter = vi.fn<ViewTransitionStarter>(() => {
+		throw new DOMException(
+			'Transition was aborted because of invalid state',
+			'InvalidStateError',
+		)
+	})
+
+	const scheduler = createViewTransitionScheduler(() => starter)
+	scheduler.run(async () => {
+		swaps.push('fallback')
+	})
+	await scheduler.whenIdle()
+
+	expect(swaps).toEqual(['fallback'])
+})
+
+test('view transition scheduler skips the API when startViewTransition is unavailable', async () => {
+	const swaps: Array<string> = []
+	const scheduler = createViewTransitionScheduler(() => null)
+	scheduler.run(async () => {
+		swaps.push('instant')
+	})
+	await Promise.resolve()
+	expect(swaps).toEqual(['instant'])
+})
+
+test('cancelPending drops queued swaps so an instant navigation cannot be followed by a stale VT', async () => {
+	const firstCallback = deferred<void>()
+	const swaps: Array<string> = []
+	const starter = vi.fn<ViewTransitionStarter>((callback) =>
+		fakeTransition({ updateCallbackDone: callback() }),
+	)
+
+	const scheduler = createViewTransitionScheduler(() => starter)
+	scheduler.run(async () => {
+		swaps.push('a')
+		await firstCallback.promise
+	})
+	await waitFor(() => swaps.includes('a'), 'swap a')
+
+	scheduler.run(async () => {
+		swaps.push('b-queued')
+	})
+	scheduler.cancelPending()
+	firstCallback.resolve()
+	await scheduler.whenIdle()
+
+	expect(swaps).toEqual(['a'])
+	expect(starter).toHaveBeenCalledTimes(1)
+})
+
+test('skipped transition lifecycle rejections are swallowed (no unhandledrejection)', async () => {
+	const unhandled: Array<unknown> = []
+	const onUnhandled = (reason: unknown) => {
+		unhandled.push(reason)
+	}
+	process.on('unhandledRejection', onUnhandled)
+
+	try {
+		const firstCallback = deferred<void>()
+		const starter = vi.fn<ViewTransitionStarter>((callback) =>
+			fakeTransition({ updateCallbackDone: callback() }),
+		)
+		const scheduler = createViewTransitionScheduler(() => starter)
+
+		scheduler.run(async () => {
+			await firstCallback.promise
+		})
+		await waitFor(() => starter.mock.calls.length === 1, 'first start')
+		// Supersede: skipTransition rejects ready/finished.
+		scheduler.run(async () => {})
+		firstCallback.resolve()
+		await scheduler.whenIdle()
+		// Give the event loop a turn to surface any unhandled rejections.
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(unhandled).toEqual([])
+	} finally {
+		process.off('unhandledRejection', onUnhandled)
+	}
+})

--- a/packages/worker/client/view-transition-scheduler.ts
+++ b/packages/worker/client/view-transition-scheduler.ts
@@ -1,0 +1,109 @@
+/**
+ * Serializes document.startViewTransition calls so a superseding navigation
+ * cannot call startViewTransition while a prior update callback is still
+ * pending (Chrome throws InvalidStateError — KODY-CLOUDFLARE-3Y), and so
+ * skip/abort rejections on the previous ViewTransition's lifecycle promises
+ * never surface as unhandledrejection Sentry noise.
+ */
+
+export type ViewTransitionLike = {
+	skipTransition(): void
+	readonly updateCallbackDone: Promise<void>
+	readonly ready: Promise<void>
+	readonly finished: Promise<void>
+}
+
+export type ViewTransitionStarter = (
+	callback: () => Promise<void>,
+) => ViewTransitionLike
+
+function ignoreRejection(promise: Promise<unknown>) {
+	void promise.catch(() => {})
+}
+
+export function createViewTransitionScheduler(
+	getStarter: () => ViewTransitionStarter | null,
+) {
+	let active: ViewTransitionLike | null = null
+	/** Latest swap waiting to become a view transition (latest-wins). */
+	let pendingSwap: (() => Promise<void>) | null = null
+	let draining = false
+	let chain: Promise<void> = Promise.resolve()
+
+	function skipActive() {
+		active?.skipTransition()
+		active = null
+	}
+
+	/**
+	 * Cancel in-flight and queued transitions before an instant (non-VT) swap
+	 * so a later drain cannot restart a superseded view transition.
+	 */
+	function cancelPending() {
+		pendingSwap = null
+		skipActive()
+	}
+
+	async function drain() {
+		while (pendingSwap) {
+			const next = pendingSwap
+			pendingSwap = null
+			const start = getStarter()
+			if (!start) {
+				await next()
+				continue
+			}
+			try {
+				const transition = start(next)
+				active = transition
+				// skipTransition() rejects ready/finished; swallow so they
+				// never become unhandledrejection.
+				ignoreRejection(transition.ready)
+				ignoreRejection(transition.finished)
+				await transition.updateCallbackDone.catch(() => {})
+			} catch {
+				// startViewTransition threw (e.g. InvalidStateError) — swap
+				// instantly rather than leaving the DOM on the old snapshot.
+				await next()
+			} finally {
+				active = null
+			}
+		}
+	}
+
+	function run(swap: () => Promise<void>) {
+		const startViewTransition = getStarter()
+		if (!startViewTransition) {
+			cancelPending()
+			void swap()
+			return
+		}
+
+		pendingSwap = swap
+		skipActive()
+
+		if (draining) return
+		draining = true
+		chain = chain
+			.catch(() => {})
+			.then(drain)
+			.finally(() => {
+				draining = false
+				// A notify may have landed after drain emptied pendingSwap but
+				// before draining flipped false; kick another pass if so.
+				if (pendingSwap) {
+					run(pendingSwap)
+				}
+			})
+	}
+
+	return {
+		run,
+		/** Cancel in-flight + queued transitions before an instant swap. */
+		cancelPending,
+		/** Test helper: resolves when the scheduled chain is idle. */
+		whenIdle() {
+			return chain.catch(() => {})
+		},
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry triage batch

Unrelated siblings from a deploy-burst backfill — two client fixes in this PR; DR export left as a recommendation (see below).

### KODY-CLOUDFLARE-3X — MetaMask extension noise → **filtered**

- Issue: https://kent-c-dodds-tech-llc.sentry.io/issues/7658961865/
- Stack is exclusively `chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js` (MetaMask). Visitor had a broken/unavailable MetaMask background; Kody never references MetaMask.
- **Change:** narrow `beforeSend` filter — MetaMask connect-failure message **and** MetaMask extension stack frame (same idiom as Fathom / Chrome IPC filters).

### KODY-CLOUDFLARE-3Y — View transition InvalidStateError → **fixed**

- Issue: https://kent-c-dodds-tech-llc.sentry.io/issues/7659060984/
- Rapid SPA navigations called `skipTransition()` then immediately `startViewTransition()` while the prior update callback was still pending; Chrome rejects with `InvalidStateError` (unhandledrejection).
- **Change:** `view-transition-scheduler` serializes starts (latest-wins), waits for `updateCallbackDone`, swallows skip/abort lifecycle rejections, falls back to instant swap on throw.

### KODY-CLOUDFLARE-3V — DR staging summary missing → **recommendation** (not in this PR)

- Issue: https://kent-c-dodds-tech-llc.sentry.io/issues/7658033991/
- Watchdog correctly alerted: 2026-08-07 export still in `artifacts` at window close (mailbox+run-log phases from #1231 consumed window budget). DR surface — leave for operator throughput/window decision; do not ignore (real incomplete night).

## Testing

- Unit: MetaMask filter cases + view-transition scheduler (serialize, latest-wins, cancelPending, swallow rejections, InvalidStateError fallback)
- Pre-push: 1905 unit + 7 e2e passed

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** extends — `app-ui` client router changes how superseding navigations schedule View Transitions; browser Sentry filter is additive noise-gating only.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — serialize view transitions; filter MetaMask extension noise |

### System map

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	vtApi["View Transitions API"]:::untouched
	sentry["Client Sentry beforeSend"]:::extended
	appUi -->|"scheduleViewTransition / latest-wins"| vtApi
	appUi -->|"filterMetaMaskExtensionSentryEvent"| sentry
	classDef extended fill:#9a6700,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
Before: skipTransition() + immediate startViewTransition() → InvalidStateError unhandledrejection
After:  await prior updateCallbackDone; swallow skip rejections; instant swap on throw

Before: MetaMask inpage.js failures reported to Sentry
After:  dropped when message + MetaMask chrome-extension frame match
```

### Invariants

No change to per-user isolation, auth, billing, migrations, or DR export throughput.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d237c7d-b634-47e0-9e74-9e09a8594f17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d237c7d-b634-47e0-9e74-9e09a8594f17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved animated page transitions by sequencing navigations and prioritizing the latest destination.
  * Added reliable fallback behavior when view transitions are unavailable or fail to start.
  * Instant navigations now cancel pending animations for faster page updates.

* **Bug Fixes**
  * Reduced erroneous Sentry reports caused by recognized MetaMask connection failures.
  * Preserved reporting for similarly named errors originating from other applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->