### PR TITLE
Keep onboarding first-win card content from stretching

### DIFF
--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -1067,6 +1067,10 @@ const firstWinCardCss = {
 	border: `1.5px solid ${colors.border}`,
 	borderRadius: radius.card,
 	minWidth: 0,
+	// Parent grid stretches both cards to equal height. Keep auto tracks at
+	// content size so leftover space does not inflate pills/buttons in the
+	// shorter column.
+	alignContent: 'start',
 }
 
 const firstWinCardHeadCss = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Keep onboarding step-3 cards equal height, but stop CSS Grid from stretching auto tracks to fill leftover space in the shorter column.
- Fixes the inflated “Memory saved” status pill and “Copy memory prompt” button when the Say hello card has more content.

## Test plan

- [x] Unit + e2e (pre-push; e2e flaked once on webserver crash, passed on retry)
- [ ] Manually open onboarding step 3 with both cards complete and confirm pill/button heights match while cards stay equal height

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b1f639df` · **Head:** `961c2808`

**Classification:** composes — layout-only CSS on an existing onboarding surface; no primitive contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — `align-content: start` on first-win cards |

### System map

Equal-height first-win cards keep natural-sized inner tracks so shared status/copy controls do not stretch in the shorter column.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appUi -->|"firstWinCardCss align-content:start"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Step-3 first-win cards | Equal height; shorter column’s pill/button stretched | Equal height; content stays natural size |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87b86af0-268c-44bd-b09a-13f4bbb47faa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87b86af0-268c-44bd-b09a-13f4bbb47faa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

