### PR TITLE
Temporary: cold-start experiment — worker-bundler/esbuild.wasm removed from upload

### DIFF
--- a/tools/build-worker-bundler-modules.ts
+++ b/tools/build-worker-bundler-modules.ts
@@ -111,6 +111,25 @@ async function buildStampContent(bundlerPackageDir: string) {
 
 /** Idempotent: skips the esbuild work when the stamp is already current. */
 export async function ensureWorkerBundlerModules() {
+	// COLD-START EXPERIMENT (temporary branch, do not merge): emit tiny throwing
+	// stubs and skip the esbuild.wasm copy so the preview deploy carries no
+	// worker-bundler weight at all. Repo checks are intentionally broken here;
+	// this exists purely to measure upload-size impact on cold start.
+	await mkdir(generatedDir, { recursive: true })
+	const stub = (name: string) =>
+		`export function ${name}() { throw new Error('worker-bundler disabled for cold-start experiment') }\n`
+	await writeFile(
+		path.join(generatedDir, 'worker-bundler.mjs'),
+		stub('createFileSystemSnapshot') + stub('createWorker'),
+	)
+	await writeFile(
+		path.join(generatedDir, 'worker-bundler-typescript.mjs'),
+		stub('createTypescriptLanguageService'),
+	)
+	await writeFile(stampPath, JSON.stringify({ hash: 'experiment-stub' }))
+}
+
+async function unusedOriginalImplementation() {
 	const bundlerPackageDir = resolveWorkerBundlerDistDir()
 	const stampContent = await buildStampContent(bundlerPackageDir)
 	if ((await readStamp()) === stampContent) return
@@ -140,6 +159,7 @@ export async function ensureWorkerBundlerModules() {
 	)
 	await writeFile(stampPath, stampContent)
 }
+void unusedOriginalImplementation
 
 if (isExecutedDirectly(import.meta.url)) {
 	await ensureWorkerBundlerModules()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Temporary experiment PR — **do not merge**. Stubs the generated worker-bundler modules and skips the `esbuild.wasm` copy so the preview worker's total upload drops from 28.3 MB to 10.8 MB (gzip 7.9 → 3.1 MB) with the main module unchanged. Repo checks are intentionally broken on this preview. Purpose: measure how much of the isolate cold start is attributable to the additional-module upload weight, to size the value of moving repo tooling into a separate worker. Will be closed after measurement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffe2bdac-d01d-4dfe-bbee-77fd73c2b315?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffe2bdac-d01d-4dfe-bbee-77fd73c2b315&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker bundling behavior to use explicit fallback stubs when the bundler modules are unavailable.
  * Added an experiment marker to help identify builds using this fallback behavior.
  * No changes to the public API or user-facing application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->