### PR TITLE
Point the MCP Registry entry at heykody.app

### DIFF
--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
 	"title": "Kody",
 	"description": "Personal assistant MCP server with search, execute, packages, jobs, secrets, and integrations.",
 	"version": "1.0.0",
-	"websiteUrl": "https://heykody.dev",
+	"websiteUrl": "https://heykody.app",
 	"repository": {
 		"url": "https://github.com/kentcdodds/kody",
 		"source": "github"
@@ -12,7 +12,7 @@
 	"remotes": [
 		{
 			"type": "streamable-http",
-			"url": "https://heykody.dev/mcp"
+			"url": "https://heykody.app/mcp"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1280, deliberately split out: merging this republishes `server.json` to the MCP Registry (`.github/workflows/publish-mcp-registry.yml` triggers on `server.json` changes to `main`), so it had to wait until `heykody.app` was attached, serving, and canonical.

That's now true — `APP_BASE_URL=https://heykody.app` with `heykody.dev` dual-served as a legacy host and browser-GET redirects enabled — so the registry entry can advertise `websiteUrl: https://heykody.app` and the MCP remote `https://heykody.app/mcp`. Existing clients pointed at `https://heykody.dev/mcp` keep working indefinitely (`/mcp` is never redirected).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `44b445e5` · **Head:** `ce2bb60c`

**Classification:** composes — a two-line metadata change to the published MCP Registry entry; no code paths touched. The only primitive affected is the `mcp-server` surface's public discovery metadata.

### Primitives touched

| Primitive    | Group    | Impact                                              |
| ------------ | -------- | --------------------------------------------------- |
| `mcp-server` | surfaces | composes — registry entry URL moves to heykody.app  |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01e21ce8-0ad4-4f1d-aac4-2a50dcefa108?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01e21ce8-0ad4-4f1d-aac4-2a50dcefa108&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the server website and streamable HTTP remote URLs to use the `heykody.app` domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->