### PR TITLE
Add GitHub Copilot to onboarding MCP client tabs

### DIFF
--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -1,8 +1,9 @@
 # Connect your agent
 
 Kody is an MCP server. You use it from Cursor, ChatGPT, Codex, Claude Desktop,
-Grok, Claude Code, OpenCode, VS Code, or any other AI agent that supports MCP —
-not from a separate Kody chat app.
+Grok, Claude Code, OpenCode, GitHub Copilot (VS Code or CLI), the GitHub Copilot
+app, or any other AI agent that supports MCP — not from a separate Kody chat
+app.
 
 The in-app Get started page (`/onboarding`) has tabs with client-specific
 instructions and copyable config snippets for the host you are on.
@@ -48,15 +49,22 @@ MCP URL and setup prompt.
   with an `[mcp_servers.kody]` `url` entry.
 - **OpenCode** — Add a `mcp.kody` remote entry in `opencode.json`
   (`"type": "remote"`).
-- **VS Code** — Use `.vscode/mcp.json` with root key `servers` (not
-  `mcpServers`) and `"type": "http"`.
+- **Copilot** — In VS Code, use `.vscode/mcp.json` with root key `servers` (not
+  `mcpServers`) and `"type": "http"`, then Agent mode in Copilot Chat. In
+  Copilot CLI, run
+  `copilot mcp add --transport http kody <url>` or merge a `mcpServers` entry
+  into `~/.copilot/mcp-config.json` (CLI does not read `.vscode/mcp.json`).
+- **Copilot App** — In the GitHub Copilot app, open settings → **MCP Servers**
+  and add a custom remote HTTP server with the MCP URL. Servers from Copilot
+  CLI or repository MCP config are also available in the app.
 
 ### Coding vs non-coding agents
 
 Using Kody packages works great with non-coding agents such as Claude Desktop,
-ChatGPT, and Grok. For creating or editing packages, a coding agent (Cursor,
-Claude Code, Codex, VS Code, OpenCode, and similar) is usually smoother because
-those hosts can edit files and iterate on code more easily.
+ChatGPT, Grok, and the GitHub Copilot app. For creating or editing packages, a
+coding agent (Cursor, Claude Code, Codex, Copilot, OpenCode, and similar) is
+usually smoother because those hosts can edit files and iterate on code more
+easily.
 
 ## Install a starter or build your own
 

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -51,12 +51,12 @@ MCP URL and setup prompt.
   (`"type": "remote"`).
 - **Copilot** — In VS Code, use `.vscode/mcp.json` with root key `servers` (not
   `mcpServers`) and `"type": "http"`, then Agent mode in Copilot Chat. In
-  Copilot CLI, run
-  `copilot mcp add --transport http kody <url>` or merge a `mcpServers` entry
-  into `~/.copilot/mcp-config.json` (CLI does not read `.vscode/mcp.json`).
+  Copilot CLI, run `copilot mcp add --transport http kody <url>` or merge a
+  `mcpServers` entry into `~/.copilot/mcp-config.json` (CLI does not read
+  `.vscode/mcp.json`).
 - **Copilot App** — In the GitHub Copilot app, open settings → **MCP Servers**
-  and add a custom remote HTTP server with the MCP URL. Servers from Copilot
-  CLI or repository MCP config are also available in the app.
+  and add a custom remote HTTP server with the MCP URL. Servers from Copilot CLI
+  or repository MCP config are also available in the app.
 
 ### Coding vs non-coding agents
 

--- a/packages/worker/client/routes/onboarding-banner.tsx
+++ b/packages/worker/client/routes/onboarding-banner.tsx
@@ -78,7 +78,7 @@ export function renderOnboardingBanner(options?: OnboardingBannerOptions) {
 				>
 					{showChecklistProgress && nextLabel
 						? `Next up: ${nextLabel}`
-						: 'Kody works through MCP. Add this deployment as an MCP server in Cursor, Claude, or any MCP-capable agent, then ask your agent to help you get set up.'}
+						: 'Kody works through MCP. Add this deployment as an MCP server in Cursor, Claude, Copilot, or any MCP-capable agent, then ask your agent to help you get set up.'}
 				</p>
 			</div>
 			<a

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -5,6 +5,8 @@ import {
 	buildClaudeCodeAddCommand,
 	buildClaudeCodeMcpJson,
 	buildCodexMcpToml,
+	buildCopilotCliAddCommand,
+	buildCopilotCliMcpJson,
 	buildCursorInstallUrl,
 	buildCursorMcpJson,
 	buildKodyAppIconUrl,
@@ -13,6 +15,8 @@ import {
 	buildVsCodeMcpJson,
 	chatGptDeveloperModeGuideUrl,
 	codingAgentPackageHint,
+	copilotAppCustomizeGuideUrl,
+	copilotCliMcpGuideUrl,
 	grokConnectorsUrl,
 	grokCustomMcpGuideUrl,
 	type McpClientKind,
@@ -295,14 +299,17 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 				</>
 			)
 		}
-		case 'vscode': {
+		case 'copilot': {
 			const vsCodeJson = buildVsCodeMcpJson(mcpServerUrl)
 			const installUrl = buildVsCodeInstallUrl(mcpServerUrl)
+			const copilotCliCommand = buildCopilotCliAddCommand(mcpServerUrl)
+			const copilotCliJson = buildCopilotCliMcpJson(mcpServerUrl)
 			return (
 				<>
 					<p>
-						Install Kody directly, create or edit <code>.vscode/mcp.json</code>{' '}
-						in your workspace, or open user MCP config via the{' '}
+						<strong>In VS Code (Copilot Chat):</strong> install Kody directly,
+						create or edit <code>.vscode/mcp.json</code> in your workspace, or
+						open user MCP config via the{' '}
 						<strong>MCP: Open User Configuration</strong> command. VS Code uses
 						the root key <code>servers</code>, not <code>mcpServers</code>:
 					</p>
@@ -318,7 +325,82 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						Use Agent mode in Copilot Chat so MCP tools are available, then
 						complete OAuth when VS Code opens it.
 					</p>
+					<p>
+						<strong>In Copilot CLI:</strong> add a remote HTTP server (writes{' '}
+						<code>~/.copilot/mcp-config.json</code>). Copilot CLI does not read{' '}
+						<code>.vscode/mcp.json</code>:
+					</p>
+					<CopyCard
+						label="copilot CLI"
+						value={copilotCliCommand}
+						copyLabel="Copy command"
+						variant="pill"
+						lang="sh"
+					/>
+					<p>
+						Or merge this into <code>~/.copilot/mcp-config.json</code> (root key{' '}
+						<code>mcpServers</code>):
+					</p>
+					<CopyCard
+						label="~/.copilot/mcp-config.json"
+						value={copilotCliJson}
+						copyLabel="Copy JSON"
+						lang="json"
+					/>
+					<p>
+						See GitHub&apos;s{' '}
+						<a
+							href={copilotCliMcpGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Copilot CLI MCP docs
+						</a>{' '}
+						for details. For the desktop GitHub Copilot app, use the{' '}
+						<strong>Copilot App</strong> tab.
+					</p>
 					<ClientNote>{codingAgentPackageHint}</ClientNote>
+				</>
+			)
+		}
+		case 'copilot-app': {
+			const copilotCliJson = buildCopilotCliMcpJson(mcpServerUrl)
+			return (
+				<>
+					<p>
+						In the GitHub Copilot app, open settings and go to{' '}
+						<strong>MCP Servers</strong>. Add a custom remote HTTP server with
+						this MCP URL, then complete OAuth when the app opens it:
+					</p>
+					<CopyCard
+						label="MCP URL"
+						value={mcpServerUrl}
+						copyLabel="Copy MCP URL"
+						variant="pill"
+					/>
+					<p>
+						Servers you already configured for Copilot CLI (or in a repository)
+						are also available in the app. You can merge this into{' '}
+						<code>~/.copilot/mcp-config.json</code> instead:
+					</p>
+					<CopyCard
+						label="~/.copilot/mcp-config.json"
+						value={copilotCliJson}
+						copyLabel="Copy JSON"
+						lang="json"
+					/>
+					<p>
+						See GitHub&apos;s{' '}
+						<a
+							href={copilotAppCustomizeGuideUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							Copilot app customization docs
+						</a>{' '}
+						for MCP Servers, skills, and plugins.
+					</p>
+					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)
 		}
@@ -339,8 +421,9 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 					<p>
 						Config file shapes differ by host. If your client expects a JSON{' '}
 						<code>mcpServers</code> map with a <code>url</code> field, start
-						from the Cursor snippet; if it uses <code>servers</code> with{' '}
-						<code>type: &quot;http&quot;</code>, use the VS Code snippet.
+						from the Cursor or Copilot CLI snippet; if it uses{' '}
+						<code>servers</code> with <code>type: &quot;http&quot;</code>, use
+						the Copilot (VS Code) snippet.
 					</p>
 				</>
 			)

--- a/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.node.test.ts
@@ -3,6 +3,8 @@ import {
 	buildClaudeCodeAddCommand,
 	buildClaudeCodeMcpJson,
 	buildCodexMcpToml,
+	buildCopilotCliAddCommand,
+	buildCopilotCliMcpJson,
 	buildCursorInstallUrl,
 	buildCursorMcpJson,
 	buildKodyAppIconUrl,
@@ -23,12 +25,19 @@ test('onboarding MCP client builders emit the structured configs each host expec
 		'grok',
 		'claude-code',
 		'opencode',
-		'vscode',
+		'copilot',
+		'copilot-app',
 		'other',
 	])
 	expect(
 		mcpClientTabs.filter((tab) => tab.isNonCodingAgent).map((tab) => tab.id),
-	).toEqual(['chatgpt', 'claude-desktop', 'grok'])
+	).toEqual(['chatgpt', 'claude-desktop', 'grok', 'copilot-app'])
+	expect(mcpClientTabs.find((tab) => tab.id === 'copilot')?.label).toBe(
+		'Copilot',
+	)
+	expect(mcpClientTabs.find((tab) => tab.id === 'copilot-app')?.label).toBe(
+		'Copilot App',
+	)
 
 	expect(JSON.parse(buildCursorMcpJson(mcpServerUrl))).toEqual({
 		mcpServers: {
@@ -48,6 +57,17 @@ test('onboarding MCP client builders emit the structured configs each host expec
 	expect(buildClaudeCodeAddCommand(mcpServerUrl)).toContain(mcpServerUrl)
 	expect(JSON.parse(buildVsCodeMcpJson(mcpServerUrl))).toEqual({
 		servers: {
+			kody: {
+				type: 'http',
+				url: mcpServerUrl,
+			},
+		},
+	})
+	expect(buildCopilotCliAddCommand(mcpServerUrl)).toBe(
+		`copilot mcp add --transport http kody ${mcpServerUrl}`,
+	)
+	expect(JSON.parse(buildCopilotCliMcpJson(mcpServerUrl))).toEqual({
+		mcpServers: {
 			kody: {
 				type: 'http',
 				url: mcpServerUrl,

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -11,7 +11,8 @@ export type McpClientKind =
 	| 'grok'
 	| 'claude-code'
 	| 'opencode'
-	| 'vscode'
+	| 'copilot'
+	| 'copilot-app'
 	| 'other'
 
 export type McpClientTab = {
@@ -29,9 +30,18 @@ export const mcpClientTabs = [
 	{ id: 'grok', label: 'Grok', isNonCodingAgent: true },
 	{ id: 'claude-code', label: 'Claude Code', isNonCodingAgent: false },
 	{ id: 'opencode', label: 'OpenCode', isNonCodingAgent: false },
-	{ id: 'vscode', label: 'VS Code', isNonCodingAgent: false },
+	{ id: 'copilot', label: 'Copilot', isNonCodingAgent: false },
+	{ id: 'copilot-app', label: 'Copilot App', isNonCodingAgent: true },
 	{ id: 'other', label: 'Other', isNonCodingAgent: false },
 ] as const satisfies ReadonlyArray<McpClientTab>
+
+/** GitHub docs for adding MCP servers in Copilot CLI (also used by the app). */
+export const copilotCliMcpGuideUrl =
+	'https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers'
+
+/** GitHub docs for MCP in the GitHub Copilot app. */
+export const copilotAppCustomizeGuideUrl =
+	'https://docs.github.com/en/copilot/how-tos/github-copilot-app/customize-github-copilot-app'
 
 export const chatGptDeveloperModeGuideUrl =
 	'https://developers.openai.com/api/docs/guides/developer-mode'
@@ -47,7 +57,7 @@ export function buildKodyAppIconUrl(mcpServerUrl: string) {
 }
 
 export const nonCodingAgentNote =
-	'Using Kody packages works great with non-coding agents. For creating or editing packages, a coding agent such as Cursor, Claude Code, Codex, VS Code, or OpenCode is usually smoother — those hosts can edit files and iterate on code more easily.'
+	'Using Kody packages works great with non-coding agents. For creating or editing packages, a coding agent such as Cursor, Claude Code, Codex, Copilot, or OpenCode is usually smoother — those hosts can edit files and iterate on code more easily.'
 
 export const codingAgentPackageHint =
 	'Coding agents are the best fit when you want to create or edit Kody packages. Once a package exists, non-coding agents can use it just fine.'
@@ -112,6 +122,26 @@ export function buildClaudeCodeAddCommand(mcpServerUrl: string) {
 export function buildVsCodeMcpJson(mcpServerUrl: string) {
 	return prettyJson({
 		servers: {
+			kody: {
+				type: 'http',
+				url: mcpServerUrl,
+			},
+		},
+	})
+}
+
+/** Copilot CLI one-shot remote HTTP add (writes `~/.copilot/mcp-config.json`). */
+export function buildCopilotCliAddCommand(mcpServerUrl: string) {
+	return `copilot mcp add --transport http kody ${mcpServerUrl}`
+}
+
+/**
+ * Copilot CLI / Copilot app user config (`~/.copilot/mcp-config.json`).
+ * Root key is `mcpServers` — Copilot CLI does not read `.vscode/mcp.json`.
+ */
+export function buildCopilotCliMcpJson(mcpServerUrl: string) {
+	return prettyJson({
+		mcpServers: {
 			kody: {
 				type: 'http',
 				url: mcpServerUrl,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make GitHub Copilot discoverable in Get started onboarding. Copilot users previously only saw a “VS Code” tab with a one-line Agent-mode mention, and the Copilot App had no path at all.

## Summary

- Renamed the **VS Code** tab to **Copilot**, covering:
  - VS Code Copilot Chat (`.vscode/mcp.json` + install deep link + Agent mode)
  - Copilot CLI (`copilot mcp add` + `~/.copilot/mcp-config.json`)
- Added a **Copilot App** tab (settings → MCP Servers, plus shared CLI config)
- Mirrored client notes in `docs/use/connect-your-agent.md`
- Mentioned Copilot in the onboarding banner copy

Intentionally omitted Copilot cloud agent / code review on github.com: GitHub does not support OAuth remote MCP there today, so guiding users would set a false expectation.

## Testing

- `npm run test -- packages/worker/client/routes/onboarding-mcp-clients.node.test.ts`
- `npm run validate` (local green)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

### Primitives

| Primitive | Group | Classification | What changed |
| --- | --- | --- | --- |
| `app-ui` | surfaces | composes | Onboarding MCP client picker: Copilot (IDE+CLI) + Copilot App tabs and copy |

### Risk

**Low** — copy/config snippets and tab wiring only; no auth, MCP protocol, or account isolation changes.

### Diagram

```mermaid
flowchart LR
  onboarding["/onboarding connect step"] --> copilotTab["Copilot tab"]
  onboarding --> copilotAppTab["Copilot App tab"]
  copilotTab --> vscode["VS Code .vscode/mcp.json"]
  copilotTab --> cli["Copilot CLI ~/.copilot/mcp-config.json"]
  copilotAppTab --> appSettings["App MCP Servers settings"]
  copilotAppTab --> cli
  vscode --> mcp["Kody /mcp + OAuth"]
  cli --> mcp
  appSettings --> mcp
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8153ad99-f1ea-4a47-8229-038dd3f24e80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8153ad99-f1ea-4a47-8229-038dd3f24e80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GitHub Copilot and Copilot App onboarding options.
  - Added Copilot CLI setup commands and configuration guidance.
  - Added Copilot App MCP URL and shared configuration instructions.
  - Updated onboarding messaging and examples to include Copilot support.

- **Documentation**
  - Expanded connection guidance for Copilot in VS Code and the CLI.
  - Added links to Copilot setup and customization documentation.

- **Tests**
  - Added coverage for Copilot onboarding entries, labels, ordering, and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->