### PR TITLE
feat(status): surface relevant Cloudflare provider incidents

### DIFF
--- a/packages/status/email-policy.node.test.ts
+++ b/packages/status/email-policy.node.test.ts
@@ -113,3 +113,48 @@ test('composed emails carry component names, status page link, and escape html',
 	})
 	expect(opened.subject).toContain('App & API')
 })
+
+test('outage emails annotate active relevant Cloudflare incidents', () => {
+	const providerIncidents = [
+		{
+			id: 'inc-r2',
+			name: 'R2 Availability Issues',
+			status: 'investigating',
+			impact: 'minor',
+			shortlink: 'https://stspg.io/r2',
+			updatedAt: '2026-08-07T19:00:00.000Z',
+			affectedComponents: ['R2'],
+		},
+	]
+	const opened = composeStatusEmail({
+		kind: 'incident_opened',
+		openIncidents: [openIncident()],
+		statusPageUrl: 'https://status.heykody.dev',
+		now: baseNow,
+		providerIncidents,
+	})
+	expect(opened.text).toContain(
+		'Possibly related Cloudflare incident: R2 Availability Issues (investigating)',
+	)
+	expect(opened.html).toContain('Possibly related Cloudflare incident')
+
+	const reminder = composeStatusEmail({
+		kind: 'daily_reminder',
+		openIncidents: [openIncident()],
+		statusPageUrl: 'https://status.heykody.dev',
+		now: baseNow,
+		providerIncidents,
+	})
+	expect(reminder.text).toContain(
+		'Possibly related Cloudflare incident: R2 Availability Issues (investigating)',
+	)
+
+	const allClear = composeStatusEmail({
+		kind: 'all_clear',
+		openIncidents: [],
+		statusPageUrl: 'https://status.heykody.dev',
+		now: baseNow,
+		providerIncidents,
+	})
+	expect(allClear.text).not.toContain('Possibly related Cloudflare incident')
+})

--- a/packages/status/email-policy.ts
+++ b/packages/status/email-policy.ts
@@ -1,4 +1,9 @@
-import { statusComponentName, type StatusComponentId } from './status-types.ts'
+import { formatProviderIncidentAnnotation } from './provider-incidents.ts'
+import {
+	statusComponentName,
+	type ProviderIncident,
+	type StatusComponentId,
+} from './status-types.ts'
 
 /**
  * Operator alert policy:
@@ -85,23 +90,29 @@ export function composeStatusEmail(input: {
 	openIncidents: Array<OpenIncidentSummary>
 	statusPageUrl: string
 	now: number
+	providerIncidents?: Array<ProviderIncident> | null
 }): StatusEmailContent {
 	const componentNames = input.openIncidents
 		.map((incident) => statusComponentName(incident.component))
 		.join(', ')
 	const incidentLines = describeIncidents(input.openIncidents)
+	const providerAnnotation =
+		input.kind === 'all_clear'
+			? null
+			: formatProviderIncidentAnnotation(input.providerIncidents ?? [])
+	const providerBlock = providerAnnotation ? `\n\n${providerAnnotation}` : ''
 	const footerText = `Status page: ${input.statusPageUrl}`
 	const footerHtml = `<p><a href="${escapeHtml(input.statusPageUrl)}">Open the status page</a></p>`
 
 	switch (input.kind) {
 		case 'incident_opened': {
 			const subject = `[kody status] Incident: ${componentNames} down`
-			const text = `An incident is affecting kody.\n\n${incidentLines}\n\nYou will get at most one reminder per day while this is unresolved, and an all-clear email once everything recovers.\n\n${footerText}`
+			const text = `An incident is affecting kody.\n\n${incidentLines}${providerBlock}\n\nYou will get at most one reminder per day while this is unresolved, and an all-clear email once everything recovers.\n\n${footerText}`
 			return { subject, text, html: toHtml(text, footerHtml) }
 		}
 		case 'daily_reminder': {
 			const subject = `[kody status] Reminder: incident still unresolved (${componentNames})`
-			const text = `An incident affecting kody is still unresolved.\n\n${incidentLines}\n\n${footerText}`
+			const text = `An incident affecting kody is still unresolved.\n\n${incidentLines}${providerBlock}\n\n${footerText}`
 			return { subject, text, html: toHtml(text, footerHtml) }
 		}
 		case 'all_clear': {

--- a/packages/status/provider-incidents.node.test.ts
+++ b/packages/status/provider-incidents.node.test.ts
@@ -1,0 +1,180 @@
+import { expect, test } from 'vitest'
+import {
+	fetchRelevantProviderIncidents,
+	filterRelevantProviderIncidents,
+	formatProviderIncidentAnnotation,
+	parseProviderIncidentCache,
+	parseProviderIncidentsPayload,
+	providerIncidentCacheStaleMs,
+	serializeProviderIncidentCache,
+	type ProviderIncident,
+} from './provider-incidents.ts'
+
+const r2Incident = {
+	id: 'inc-r2',
+	name: 'R2 Availability Issues',
+	status: 'investigating',
+	impact: 'minor',
+	shortlink: 'https://stspg.io/r2',
+	updated_at: '2026-08-07T19:00:00.000Z',
+	components: [{ id: 'hb7g5sq2zz0h', name: 'R2' }],
+	incident_updates: [
+		{
+			affected_components: [
+				{
+					code: 'hb7g5sq2zz0h',
+					name: 'Cloudflare Sites and Services - R2',
+				},
+			],
+		},
+	],
+}
+
+const streamIncident = {
+	id: 'inc-stream',
+	name: 'Stream hiccup',
+	status: 'identified',
+	impact: 'major',
+	shortlink: 'https://stspg.io/stream',
+	updated_at: '2026-08-07T18:00:00.000Z',
+	components: [{ id: 'stream-id', name: 'Stream' }],
+}
+
+const popIncident = {
+	id: 'inc-pop',
+	name: 'PoP degradation',
+	status: 'monitoring',
+	impact: 'minor',
+	shortlink: 'https://stspg.io/pop',
+	updated_at: '2026-08-07T17:00:00.000Z',
+	components: [{ id: 'ams', name: 'Amsterdam, Netherlands - (AMS)' }],
+}
+
+function providerIncident(
+	overrides: Partial<ProviderIncident> = {},
+): ProviderIncident {
+	return {
+		id: 'inc-r2',
+		name: 'R2 Availability Issues',
+		status: 'investigating',
+		impact: 'minor',
+		shortlink: 'https://stspg.io/r2',
+		updatedAt: '2026-08-07T19:00:00.000Z',
+		affectedComponents: ['R2'],
+		...overrides,
+	}
+}
+
+test('filters Cloudflare incidents to products kody runs on', () => {
+	const filtered = filterRelevantProviderIncidents([
+		r2Incident,
+		streamIncident,
+		popIncident,
+		{
+			id: 'inc-workers',
+			name: 'Workers elevated errors',
+			status: 'identified',
+			impact: 'major',
+			shortlink: 'https://stspg.io/workers',
+			updated_at: '2026-08-07T16:00:00.000Z',
+			components: [],
+			incident_updates: [
+				{
+					affected_components: [
+						{ name: 'Cloudflare Sites and Services - Workers' },
+						{ name: 'Cloudflare Sites and Services - Stream' },
+					],
+				},
+			],
+		},
+	])
+	expect(filtered.map((incident) => incident.id)).toEqual([
+		'inc-r2',
+		'inc-workers',
+	])
+	expect(filtered[0]?.affectedComponents).toEqual(['R2'])
+	expect(filtered[1]?.affectedComponents).toEqual(['Workers'])
+	expect(
+		parseProviderIncidentsPayload({ incidents: [streamIncident] }),
+	).toEqual([])
+})
+
+test('provider incident fetch fails soft on timeout, http errors, and bad JSON', async () => {
+	const timedOut = await fetchRelevantProviderIncidents({
+		timeoutMs: 5,
+		fetcher: async () =>
+			await new Promise(() => {
+				/* never resolves */
+			}),
+	})
+	expect(timedOut.ok).toBe(false)
+	expect(timedOut.incidents).toEqual([])
+
+	const httpError = await fetchRelevantProviderIncidents({
+		fetcher: async () => new Response('nope', { status: 503 }),
+	})
+	expect(httpError).toEqual({
+		ok: false,
+		incidents: [],
+		error: 'HTTP 503',
+	})
+
+	const badJson = await fetchRelevantProviderIncidents({
+		fetcher: async () =>
+			new Response('not-json', {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+	})
+	expect(badJson.ok).toBe(false)
+
+	const okEmpty = await fetchRelevantProviderIncidents({
+		fetcher: async () =>
+			Response.json({
+				incidents: [streamIncident, popIncident],
+			}),
+	})
+	expect(okEmpty).toEqual({ ok: true, incidents: [] })
+
+	const okRelevant = await fetchRelevantProviderIncidents({
+		fetcher: async () => Response.json({ incidents: [r2Incident] }),
+	})
+	expect(okRelevant.ok).toBe(true)
+	expect(okRelevant.incidents).toHaveLength(1)
+	expect(okRelevant.incidents[0]?.name).toBe('R2 Availability Issues')
+})
+
+test('provider incident cache parses within TTL and rejects stale or corrupt entries', () => {
+	const now = Date.UTC(2026, 7, 7, 20, 0, 0)
+	const fresh = serializeProviderIncidentCache({
+		fetchedAt: now - 30_000,
+		incidents: [providerIncident()],
+	})
+	expect(parseProviderIncidentCache(fresh, now)?.[0]?.name).toBe(
+		'R2 Availability Issues',
+	)
+	expect(
+		parseProviderIncidentCache(fresh, now + providerIncidentCacheStaleMs + 1),
+	).toBeNull()
+	expect(parseProviderIncidentCache('not-json', now)).toBeNull()
+	expect(parseProviderIncidentCache(null, now)).toBeNull()
+})
+
+test('outage email annotation names active Cloudflare incidents', () => {
+	expect(formatProviderIncidentAnnotation([])).toBeNull()
+	expect(
+		formatProviderIncidentAnnotation([
+			providerIncident(),
+			providerIncident({
+				id: 'inc-d1',
+				name: 'D1 query errors',
+				status: 'monitoring',
+			}),
+		]),
+	).toBe(
+		[
+			'Possibly related Cloudflare incident: R2 Availability Issues (investigating)',
+			'Possibly related Cloudflare incident: D1 query errors (monitoring)',
+		].join('\n'),
+	)
+})

--- a/packages/status/provider-incidents.node.test.ts
+++ b/packages/status/provider-incidents.node.test.ts
@@ -100,48 +100,54 @@ test('filters Cloudflare incidents to products kody runs on', () => {
 })
 
 test('provider incident fetch fails soft on timeout, http errors, and bad JSON', async () => {
-	const timedOut = await fetchRelevantProviderIncidents({
-		timeoutMs: 5,
-		fetcher: async () =>
-			await new Promise(() => {
-				/* never resolves */
-			}),
-	})
-	expect(timedOut.ok).toBe(false)
-	expect(timedOut.incidents).toEqual([])
+	const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	try {
+		const timedOut = await fetchRelevantProviderIncidents({
+			timeoutMs: 5,
+			fetcher: async () =>
+				await new Promise(() => {
+					/* never resolves */
+				}),
+		})
+		expect(timedOut.ok).toBe(false)
+		expect(timedOut.incidents).toEqual([])
 
-	const httpError = await fetchRelevantProviderIncidents({
-		fetcher: async () => new Response('nope', { status: 503 }),
-	})
-	expect(httpError).toEqual({
-		ok: false,
-		incidents: [],
-		error: 'HTTP 503',
-	})
+		const httpError = await fetchRelevantProviderIncidents({
+			fetcher: async () => new Response('nope', { status: 503 }),
+		})
+		expect(httpError).toEqual({
+			ok: false,
+			incidents: [],
+			error: 'HTTP 503',
+		})
 
-	const badJson = await fetchRelevantProviderIncidents({
-		fetcher: async () =>
-			new Response('not-json', {
-				status: 200,
-				headers: { 'Content-Type': 'application/json' },
-			}),
-	})
-	expect(badJson.ok).toBe(false)
+		const badJson = await fetchRelevantProviderIncidents({
+			fetcher: async () =>
+				new Response('not-json', {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				}),
+		})
+		expect(badJson.ok).toBe(false)
 
-	const okEmpty = await fetchRelevantProviderIncidents({
-		fetcher: async () =>
-			Response.json({
-				incidents: [streamIncident, popIncident],
-			}),
-	})
-	expect(okEmpty).toEqual({ ok: true, incidents: [] })
+		const okEmpty = await fetchRelevantProviderIncidents({
+			fetcher: async () =>
+				Response.json({
+					incidents: [streamIncident, popIncident],
+				}),
+		})
+		expect(okEmpty).toEqual({ ok: true, incidents: [] })
 
-	const okRelevant = await fetchRelevantProviderIncidents({
-		fetcher: async () => Response.json({ incidents: [r2Incident] }),
-	})
-	expect(okRelevant.ok).toBe(true)
-	expect(okRelevant.incidents).toHaveLength(1)
-	expect(okRelevant.incidents[0]?.name).toBe('R2 Availability Issues')
+		const okRelevant = await fetchRelevantProviderIncidents({
+			fetcher: async () => Response.json({ incidents: [r2Incident] }),
+		})
+		expect(okRelevant.ok).toBe(true)
+		expect(okRelevant.incidents).toHaveLength(1)
+		expect(okRelevant.incidents[0]?.name).toBe('R2 Availability Issues')
+		expect(consoleWarn).toHaveBeenCalled()
+	} finally {
+		consoleWarn.mockRestore()
+	}
 })
 
 test('provider incident cache parses within TTL and rejects stale or corrupt entries', () => {

--- a/packages/status/provider-incidents.node.test.ts
+++ b/packages/status/provider-incidents.node.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import {
 	fetchRelevantProviderIncidents,
 	filterRelevantProviderIncidents,

--- a/packages/status/provider-incidents.node.test.ts
+++ b/packages/status/provider-incidents.node.test.ts
@@ -1,11 +1,13 @@
 import { expect, test, vi } from 'vitest'
 import {
+	cloudflareStatusPageUrl,
 	fetchRelevantProviderIncidents,
 	filterRelevantProviderIncidents,
 	formatProviderIncidentAnnotation,
 	parseProviderIncidentCache,
 	parseProviderIncidentsPayload,
 	providerIncidentCacheStaleMs,
+	sanitizeProviderIncidentShortlink,
 	serializeProviderIncidentCache,
 	type ProviderIncident,
 } from './provider-incidents.ts'
@@ -179,6 +181,32 @@ test('provider incident cache parses within TTL and rejects stale or corrupt ent
 		],
 	})
 	expect(parseProviderIncidentCache(incomplete, now)).toEqual([])
+
+	const futureDated = serializeProviderIncidentCache({
+		fetchedAt: now + 60_000,
+		incidents: [providerIncident()],
+	})
+	expect(parseProviderIncidentCache(futureDated, now)).toBeNull()
+})
+
+test('provider shortlinks are restricted to Cloudflare Statuspage HTTPS hosts', () => {
+	expect(sanitizeProviderIncidentShortlink('https://stspg.io/r2')).toBe(
+		'https://stspg.io/r2',
+	)
+	expect(sanitizeProviderIncidentShortlink('javascript:alert(1)')).toBe(
+		cloudflareStatusPageUrl,
+	)
+	expect(sanitizeProviderIncidentShortlink('https://evil.example/phish')).toBe(
+		cloudflareStatusPageUrl,
+	)
+
+	const filtered = filterRelevantProviderIncidents([
+		{
+			...r2Incident,
+			shortlink: 'javascript:alert(1)',
+		},
+	])
+	expect(filtered[0]?.shortlink).toBe(cloudflareStatusPageUrl)
 })
 
 test('outage email annotation names active Cloudflare incidents', () => {

--- a/packages/status/provider-incidents.node.test.ts
+++ b/packages/status/provider-incidents.node.test.ts
@@ -164,6 +164,21 @@ test('provider incident cache parses within TTL and rejects stale or corrupt ent
 	).toBeNull()
 	expect(parseProviderIncidentCache('not-json', now)).toBeNull()
 	expect(parseProviderIncidentCache(null, now)).toBeNull()
+
+	const incomplete = JSON.stringify({
+		fetchedAt: now - 1_000,
+		incidents: [
+			{
+				id: 'inc-partial',
+				name: 'Missing fields',
+				status: 'investigating',
+				impact: 'minor',
+				shortlink: 'https://stspg.io/x',
+				// updatedAt / affectedComponents omitted on purpose
+			},
+		],
+	})
+	expect(parseProviderIncidentCache(incomplete, now)).toEqual([])
 })
 
 test('outage email annotation names active Cloudflare incidents', () => {

--- a/packages/status/provider-incidents.ts
+++ b/packages/status/provider-incidents.ts
@@ -104,6 +104,26 @@ export function isRelevantCloudflareComponentName(name: string): boolean {
 	return relevantNameSet.has(name)
 }
 
+const allowedProviderIncidentHosts = new Set([
+	'www.cloudflarestatus.com',
+	'cloudflarestatus.com',
+	'stspg.io',
+])
+
+/** Only HTTPS Statuspage / shortlink hosts are safe to put in page hrefs. */
+export function sanitizeProviderIncidentShortlink(raw: string): string {
+	try {
+		const url = new URL(raw.trim())
+		if (url.protocol !== 'https:') return cloudflareStatusPageUrl
+		if (!allowedProviderIncidentHosts.has(url.hostname.toLowerCase())) {
+			return cloudflareStatusPageUrl
+		}
+		return url.toString()
+	} catch {
+		return cloudflareStatusPageUrl
+	}
+}
+
 export function filterRelevantProviderIncidents(
 	incidents: Array<StatuspageIncident>,
 ): Array<ProviderIncident> {
@@ -121,10 +141,9 @@ export function filterRelevantProviderIncidents(
 			name: incident.name.trim(),
 			status: incident.status?.trim() || 'unknown',
 			impact: incident.impact?.trim() || 'unknown',
-			shortlink:
-				typeof incident.shortlink === 'string' && incident.shortlink.trim()
-					? incident.shortlink.trim()
-					: cloudflareStatusPageUrl,
+			shortlink: sanitizeProviderIncidentShortlink(
+				typeof incident.shortlink === 'string' ? incident.shortlink : '',
+			),
 			updatedAt:
 				typeof incident.updated_at === 'string' && incident.updated_at
 					? incident.updated_at
@@ -176,26 +195,45 @@ export function parseProviderIncidentCache(
 	) {
 		return null
 	}
-	if (now - cache.fetchedAt > maxAgeMs) return null
+	const ageMs = now - cache.fetchedAt
+	if (ageMs < 0 || ageMs > maxAgeMs) return null
 	if (!Array.isArray(cache.incidents)) return null
-	return cache.incidents.filter(isProviderIncident)
+	const incidents: Array<ProviderIncident> = []
+	for (const entry of cache.incidents) {
+		const incident = normalizeCachedProviderIncident(entry)
+		if (incident) incidents.push(incident)
+	}
+	return incidents
 }
 
-function isProviderIncident(value: unknown): value is ProviderIncident {
-	if (value === null || typeof value !== 'object') return false
+function normalizeCachedProviderIncident(
+	value: unknown,
+): ProviderIncident | null {
+	if (value === null || typeof value !== 'object') return null
 	const incident = value as Partial<ProviderIncident>
-	return (
-		typeof incident.id === 'string' &&
-		typeof incident.name === 'string' &&
-		typeof incident.status === 'string' &&
-		typeof incident.impact === 'string' &&
-		typeof incident.shortlink === 'string' &&
-		typeof incident.updatedAt === 'string' &&
-		Array.isArray(incident.affectedComponents) &&
-		incident.affectedComponents.every(
+	if (
+		typeof incident.id !== 'string' ||
+		typeof incident.name !== 'string' ||
+		typeof incident.status !== 'string' ||
+		typeof incident.impact !== 'string' ||
+		typeof incident.shortlink !== 'string' ||
+		typeof incident.updatedAt !== 'string' ||
+		!Array.isArray(incident.affectedComponents) ||
+		!incident.affectedComponents.every(
 			(component) => typeof component === 'string',
 		)
-	)
+	) {
+		return null
+	}
+	return {
+		id: incident.id,
+		name: incident.name,
+		status: incident.status,
+		impact: incident.impact,
+		shortlink: sanitizeProviderIncidentShortlink(incident.shortlink),
+		updatedAt: incident.updatedAt,
+		affectedComponents: incident.affectedComponents,
+	}
 }
 
 export type FetchProviderIncidentsOptions = {

--- a/packages/status/provider-incidents.ts
+++ b/packages/status/provider-incidents.ts
@@ -1,0 +1,270 @@
+/**
+ * Cloudflare Statuspage feed for products kody actually runs on.
+ *
+ * This is corroborating context only — Cloudflare's public status page lags
+ * reality and must never gate or suppress kody's own probe-based alerts.
+ * Fetch failures are fail-soft: callers get an empty list and keep serving.
+ */
+
+export const cloudflareStatusIncidentsUrl =
+	'https://www.cloudflarestatus.com/api/v2/incidents/unresolved.json'
+
+export const cloudflareStatusPageUrl = 'https://www.cloudflarestatus.com'
+
+/** Exact Statuspage component names for products kody depends on. */
+export const relevantCloudflareComponentNames = [
+	'Workers',
+	'D1',
+	'R2',
+	'Workers KV',
+	'Durable Objects',
+	'Queues',
+	'Vectorize',
+	'Email Routing',
+	'Access',
+] as const
+
+const relevantNameSet = new Set<string>(relevantCloudflareComponentNames)
+
+export const providerIncidentFetchTimeoutMs = 2500
+export const providerIncidentCacheTtlMs = 60_000
+/** Keep a slightly stale cache across one missed cron tick / flaky API. */
+export const providerIncidentCacheStaleMs = 5 * 60_000
+
+export type ProviderIncidentStatus =
+	| 'investigating'
+	| 'identified'
+	| 'monitoring'
+	| 'postmortem'
+	| 'resolved'
+	| 'scheduled'
+	| 'in_progress'
+	| 'verifying'
+	| 'completed'
+	| string
+
+export type ProviderIncident = {
+	id: string
+	name: string
+	status: ProviderIncidentStatus
+	impact: string
+	shortlink: string
+	updatedAt: string
+	affectedComponents: Array<string>
+}
+
+type StatuspageComponent = {
+	id?: string
+	name?: string
+}
+
+type StatuspageIncident = {
+	id?: string
+	name?: string
+	status?: string
+	impact?: string
+	shortlink?: string
+	updated_at?: string
+	components?: Array<StatuspageComponent>
+	incident_updates?: Array<{
+		affected_components?: Array<{ code?: string; name?: string }>
+	}>
+}
+
+type StatuspageIncidentsResponse = {
+	incidents?: Array<StatuspageIncident>
+}
+
+function componentNameFromStatuspageLabel(label: string): string {
+	const separator = ' - '
+	const index = label.lastIndexOf(separator)
+	if (index === -1) return label.trim()
+	return label.slice(index + separator.length).trim()
+}
+
+function collectAffectedComponentNames(
+	incident: StatuspageIncident,
+): Array<string> {
+	const names = new Set<string>()
+	for (const component of incident.components ?? []) {
+		if (typeof component.name === 'string' && component.name.trim()) {
+			names.add(component.name.trim())
+		}
+	}
+	for (const update of incident.incident_updates ?? []) {
+		for (const affected of update.affected_components ?? []) {
+			if (typeof affected.name !== 'string' || !affected.name.trim()) continue
+			names.add(componentNameFromStatuspageLabel(affected.name))
+		}
+	}
+	return [...names]
+}
+
+export function isRelevantCloudflareComponentName(name: string): boolean {
+	return relevantNameSet.has(name)
+}
+
+export function filterRelevantProviderIncidents(
+	incidents: Array<StatuspageIncident>,
+): Array<ProviderIncident> {
+	const filtered: Array<ProviderIncident> = []
+	for (const incident of incidents) {
+		if (typeof incident.id !== 'string' || !incident.id) continue
+		if (typeof incident.name !== 'string' || !incident.name.trim()) continue
+		const affectedComponents = collectAffectedComponentNames(incident)
+		const relevantAffected = affectedComponents.filter(
+			isRelevantCloudflareComponentName,
+		)
+		if (relevantAffected.length === 0) continue
+		filtered.push({
+			id: incident.id,
+			name: incident.name.trim(),
+			status: incident.status?.trim() || 'unknown',
+			impact: incident.impact?.trim() || 'unknown',
+			shortlink:
+				typeof incident.shortlink === 'string' && incident.shortlink.trim()
+					? incident.shortlink.trim()
+					: cloudflareStatusPageUrl,
+			updatedAt:
+				typeof incident.updated_at === 'string' && incident.updated_at
+					? incident.updated_at
+					: new Date(0).toISOString(),
+			affectedComponents: relevantAffected,
+		})
+	}
+	return filtered
+}
+
+export function parseProviderIncidentsPayload(
+	payload: unknown,
+): Array<ProviderIncident> {
+	if (payload === null || typeof payload !== 'object') return []
+	const incidents = (payload as StatuspageIncidentsResponse).incidents
+	if (!Array.isArray(incidents)) return []
+	return filterRelevantProviderIncidents(incidents)
+}
+
+export type ProviderIncidentCache = {
+	fetchedAt: number
+	incidents: Array<ProviderIncident>
+}
+
+export function serializeProviderIncidentCache(
+	cache: ProviderIncidentCache,
+): string {
+	return JSON.stringify(cache)
+}
+
+export function parseProviderIncidentCache(
+	raw: string | null,
+	now: number,
+	options: { maxAgeMs?: number } = {},
+): Array<ProviderIncident> | null {
+	if (raw === null) return null
+	const maxAgeMs = options.maxAgeMs ?? providerIncidentCacheStaleMs
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw) as unknown
+	} catch {
+		return null
+	}
+	if (parsed === null || typeof parsed !== 'object') return null
+	const cache = parsed as Partial<ProviderIncidentCache>
+	if (
+		typeof cache.fetchedAt !== 'number' ||
+		!Number.isFinite(cache.fetchedAt)
+	) {
+		return null
+	}
+	if (now - cache.fetchedAt > maxAgeMs) return null
+	if (!Array.isArray(cache.incidents)) return null
+	return cache.incidents.filter(
+		(incident): incident is ProviderIncident =>
+			incident !== null &&
+			typeof incident === 'object' &&
+			typeof incident.id === 'string' &&
+			typeof incident.name === 'string' &&
+			typeof incident.status === 'string' &&
+			typeof incident.impact === 'string' &&
+			typeof incident.shortlink === 'string',
+	)
+}
+
+export type FetchProviderIncidentsOptions = {
+	fetcher?: typeof fetch
+	timeoutMs?: number
+	url?: string
+}
+
+export type FetchProviderIncidentsResult =
+	| { ok: true; incidents: Array<ProviderIncident> }
+	| { ok: false; incidents: Array<ProviderIncident>; error: string }
+
+/**
+ * Fetches unresolved Cloudflare incidents and filters to kody-relevant
+ * products. Never throws: network / timeout / parse failures return
+ * `{ ok: false }` so callers can keep a still-fresh cache.
+ */
+export async function fetchRelevantProviderIncidents(
+	options: FetchProviderIncidentsOptions = {},
+): Promise<FetchProviderIncidentsResult> {
+	const fetcher = options.fetcher ?? fetch
+	const timeoutMs = options.timeoutMs ?? providerIncidentFetchTimeoutMs
+	const url = options.url ?? cloudflareStatusIncidentsUrl
+	const controller = new AbortController()
+	let timer: ReturnType<typeof setTimeout> | undefined
+	const timeout = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => {
+			controller.abort()
+			reject(
+				new Error(`provider incidents fetch timed out after ${timeoutMs}ms`),
+			)
+		}, timeoutMs)
+	})
+	try {
+		const response = await Promise.race([
+			fetcher(url, {
+				method: 'GET',
+				headers: { Accept: 'application/json' },
+				signal: controller.signal,
+			}),
+			timeout,
+		])
+		if (!response.ok) {
+			const error = `HTTP ${response.status}`
+			console.warn(
+				'status-provider-incidents-http',
+				JSON.stringify({ status: response.status }),
+			)
+			return { ok: false, incidents: [], error }
+		}
+		const payload: unknown = await Promise.race([
+			response.json().catch(() => null),
+			timeout,
+		])
+		if (payload === null) {
+			const error = 'invalid JSON'
+			console.warn('status-provider-incidents-fetch-failed', error)
+			return { ok: false, incidents: [], error }
+		}
+		return { ok: true, incidents: parseProviderIncidentsPayload(payload) }
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error)
+		console.warn('status-provider-incidents-fetch-failed', detail)
+		return { ok: false, incidents: [], error: detail }
+	} finally {
+		if (timer !== undefined) clearTimeout(timer)
+	}
+}
+
+export function formatProviderIncidentAnnotation(
+	incidents: Array<ProviderIncident>,
+): string | null {
+	if (incidents.length === 0) return null
+	return incidents
+		.map(
+			(incident) =>
+				`Possibly related Cloudflare incident: ${incident.name} (${incident.status})`,
+		)
+		.join('\n')
+}

--- a/packages/status/provider-incidents.ts
+++ b/packages/status/provider-incidents.ts
@@ -178,15 +178,23 @@ export function parseProviderIncidentCache(
 	}
 	if (now - cache.fetchedAt > maxAgeMs) return null
 	if (!Array.isArray(cache.incidents)) return null
-	return cache.incidents.filter(
-		(incident): incident is ProviderIncident =>
-			incident !== null &&
-			typeof incident === 'object' &&
-			typeof incident.id === 'string' &&
-			typeof incident.name === 'string' &&
-			typeof incident.status === 'string' &&
-			typeof incident.impact === 'string' &&
-			typeof incident.shortlink === 'string',
+	return cache.incidents.filter(isProviderIncident)
+}
+
+function isProviderIncident(value: unknown): value is ProviderIncident {
+	if (value === null || typeof value !== 'object') return false
+	const incident = value as Partial<ProviderIncident>
+	return (
+		typeof incident.id === 'string' &&
+		typeof incident.name === 'string' &&
+		typeof incident.status === 'string' &&
+		typeof incident.impact === 'string' &&
+		typeof incident.shortlink === 'string' &&
+		typeof incident.updatedAt === 'string' &&
+		Array.isArray(incident.affectedComponents) &&
+		incident.affectedComponents.every(
+			(component) => typeof component === 'string',
+		)
 	)
 }
 

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -19,6 +19,24 @@ deploys, code, or database are broken (see decision record 0004).
   lasts, one all-clear when everything has recovered, all under a daily cap
   (`STATUS_ALERT_DAILY_LIMIT`).
 
+## Provider incidents (Cloudflare)
+
+Each cron tick also fetches Cloudflare's public Statuspage feed
+(`incidents/unresolved.json`, no auth, short timeout) and caches a filtered
+subset in the Durable Object (~60s refresh, stale-tolerant for a few minutes).
+Only incidents whose affected components intersect products kody runs on are
+kept: Workers, D1, R2, Workers KV, Durable Objects, Queues, Vectorize, Email
+Routing, and Access. Regional PoPs, Stream, Magic Transit, and other unrelated
+products are dropped.
+
+When that filtered list is non-empty, the status page renders a clearly
+separated **Provider incidents (Cloudflare)** section. It is provider-declared
+context only — never merged into kody's measured health or uptime numbers. If
+the Statuspage API is slow or unreachable, the page omits the section (fail
+soft). Outage alert emails get one annotation line per active relevant incident
+(`Possibly related Cloudflare incident: …`); alerts are never gated or
+suppressed based on provider status.
+
 ## Routes
 
 | Path           | Purpose                               |

--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -32,6 +32,7 @@ function snapshot(overrides: Partial<StatusSnapshot> = {}): StatusSnapshot {
 		),
 		openIncidents: [],
 		recentIncidents: [],
+		providerIncidents: null,
 		buildCommit: 'abc123',
 		...overrides,
 	}
@@ -97,4 +98,36 @@ test('status page renders components, incidents, unknown state, and escapes deta
 		}),
 	)
 	expect(unknown).toMatch(/not available|no data/i)
+})
+
+test('status page renders provider incidents separately and omits them when absent', () => {
+	const without = renderStatusPage(snapshot({ providerIncidents: null }))
+	expect(without).not.toContain('Provider incidents (Cloudflare)')
+
+	const empty = renderStatusPage(snapshot({ providerIncidents: [] }))
+	expect(empty).not.toContain('Provider incidents (Cloudflare)')
+
+	const withProvider = renderStatusPage(
+		snapshot({
+			overallStatus: 'operational',
+			providerIncidents: [
+				{
+					id: 'inc-r2',
+					name: 'R2 Availability Issues',
+					status: 'investigating',
+					impact: 'minor',
+					shortlink: 'https://stspg.io/r2',
+					updatedAt: '2026-08-07T19:00:00.000Z',
+					affectedComponents: ['R2'],
+				},
+			],
+		}),
+	)
+	expect(withProvider).toContain('Provider incidents (Cloudflare)')
+	expect(withProvider).toContain('R2 Availability Issues')
+	expect(withProvider).toContain('investigating')
+	expect(withProvider).toContain('minor')
+	expect(withProvider).toContain('https://stspg.io/r2')
+	expect(withProvider).toContain('for context only')
+	expect(withProvider).toContain('All systems operational')
 })

--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -128,6 +128,26 @@ test('status page renders provider incidents separately and omits them when abse
 	expect(withProvider).toContain('investigating')
 	expect(withProvider).toContain('minor')
 	expect(withProvider).toContain('https://stspg.io/r2')
+	expect(withProvider).toContain('affects R2')
+	expect(withProvider).toContain('updated 2026-08-07T19:00:00.000Z')
 	expect(withProvider).toContain('for context only')
 	expect(withProvider).toContain('All systems operational')
+
+	const unsafeLink = renderStatusPage(
+		snapshot({
+			providerIncidents: [
+				{
+					id: 'inc-r2',
+					name: 'R2 Availability Issues',
+					status: 'investigating',
+					impact: 'minor',
+					shortlink: 'javascript:alert(1)',
+					updatedAt: '2026-08-07T19:00:00.000Z',
+					affectedComponents: ['R2'],
+				},
+			],
+		}),
+	)
+	expect(unsafeLink).not.toContain('javascript:alert')
+	expect(unsafeLink).toContain('https://www.cloudflarestatus.com')
 })

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -1,4 +1,7 @@
-import { cloudflareStatusPageUrl } from './provider-incidents.ts'
+import {
+	cloudflareStatusPageUrl,
+	sanitizeProviderIncidentShortlink,
+} from './provider-incidents.ts'
 import {
 	type ComponentSnapshot,
 	type IncidentView,
@@ -210,17 +213,18 @@ function renderProviderIncident(incident: ProviderIncident): string {
 		incident.affectedComponents.length > 0
 			? ` · affects ${escapeHtml(incident.affectedComponents.join(', '))}`
 			: ''
+	const href = sanitizeProviderIncidentShortlink(incident.shortlink)
 	return `<div class="provider-incident">
 	<div class="provider-incident-title">${escapeHtml(incident.name)}</div>
 	<div class="provider-incident-meta">${escapeHtml(incident.status)} · ${escapeHtml(incident.impact)} impact${components}</div>
-	<div class="provider-incident-meta"><a href="${escapeHtml(incident.shortlink)}">Cloudflare status</a> · updated ${escapeHtml(incident.updatedAt)}</div>
+	<div class="provider-incident-meta"><a href="${escapeHtml(href)}">Cloudflare status</a> · updated ${escapeHtml(incident.updatedAt)}</div>
 </div>`
 }
 
 function renderProviderIncidentsSection(
-	incidents: Array<ProviderIncident> | null,
+	incidents: Array<ProviderIncident> | null | undefined,
 ): string {
-	if (incidents === null || incidents.length === 0) return ''
+	if (incidents == null || incidents.length === 0) return ''
 	return `<section class="provider-section" aria-label="Provider incidents from Cloudflare">
 	<h2>Provider incidents (Cloudflare)</h2>
 	<p class="provider-lead">Declared by Cloudflare on <a href="${escapeHtml(cloudflareStatusPageUrl)}">cloudflarestatus.com</a>. Separate from kody's measured component health — for context only.</p>

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -1,6 +1,8 @@
+import { cloudflareStatusPageUrl } from './provider-incidents.ts'
 import {
 	type ComponentSnapshot,
 	type IncidentView,
+	type ProviderIncident,
 	type StatusSnapshot,
 } from './status-types.ts'
 
@@ -107,6 +109,25 @@ h1 { font-size: 1.5rem; margin: 0; }
 .incident.resolved { border-left-color: var(--ok); }
 .incident-title { font-weight: 600; }
 .incident-meta { color: var(--muted); font-size: 0.85rem; }
+.provider-section {
+	margin: 2rem 0 1rem;
+	padding: 1rem 1.25rem;
+	border: 1px dashed var(--border);
+	border-radius: 0.75rem;
+	background: color-mix(in srgb, var(--card) 85%, var(--partial));
+}
+.provider-section h2 { margin: 0 0 0.35rem; }
+.provider-lead { color: var(--muted); font-size: 0.85rem; margin: 0 0 0.75rem; }
+.provider-incident {
+	border-left: 3px solid var(--partial);
+	border-radius: 0 0.5rem 0.5rem 0;
+	padding: 0.5rem 0.75rem;
+	margin: 0.75rem 0 0;
+	background: var(--card);
+}
+.provider-incident-title { font-weight: 600; }
+.provider-incident-meta { color: var(--muted); font-size: 0.85rem; }
+.provider-incident a { color: inherit; }
 h2 { font-size: 1.1rem; margin: 2rem 0 0.75rem; }
 footer { margin-top: 2.5rem; color: var(--muted); font-size: 0.85rem; }
 footer a { color: inherit; }
@@ -184,6 +205,29 @@ function renderIncident(incident: IncidentView): string {
 </div>`
 }
 
+function renderProviderIncident(incident: ProviderIncident): string {
+	const components =
+		incident.affectedComponents.length > 0
+			? ` · affects ${escapeHtml(incident.affectedComponents.join(', '))}`
+			: ''
+	return `<div class="provider-incident">
+	<div class="provider-incident-title">${escapeHtml(incident.name)}</div>
+	<div class="provider-incident-meta">${escapeHtml(incident.status)} · ${escapeHtml(incident.impact)} impact${components}</div>
+	<div class="provider-incident-meta"><a href="${escapeHtml(incident.shortlink)}">Cloudflare status</a> · updated ${escapeHtml(incident.updatedAt)}</div>
+</div>`
+}
+
+function renderProviderIncidentsSection(
+	incidents: Array<ProviderIncident> | null,
+): string {
+	if (incidents === null || incidents.length === 0) return ''
+	return `<section class="provider-section" aria-label="Provider incidents from Cloudflare">
+	<h2>Provider incidents (Cloudflare)</h2>
+	<p class="provider-lead">Declared by Cloudflare on <a href="${escapeHtml(cloudflareStatusPageUrl)}">cloudflarestatus.com</a>. Separate from kody's measured component health — for context only.</p>
+	${incidents.map(renderProviderIncident).join('\n')}
+</section>`
+}
+
 export function renderStatusPage(snapshot: StatusSnapshot): string {
 	const banner = bannerFor(snapshot)
 	const components = snapshot.components.map(renderComponent).join('\n')
@@ -191,6 +235,9 @@ export function renderStatusPage(snapshot: StatusSnapshot): string {
 		snapshot.openIncidents.length > 0
 			? `<h2>Open incidents</h2>${snapshot.openIncidents.map(renderIncident).join('\n')}`
 			: ''
+	const providerIncidents = renderProviderIncidentsSection(
+		snapshot.providerIncidents,
+	)
 	const recentIncidents =
 		snapshot.recentIncidents.length > 0
 			? `<h2>Past incidents</h2>${snapshot.recentIncidents.map(renderIncident).join('\n')}`
@@ -213,6 +260,7 @@ export function renderStatusPage(snapshot: StatusSnapshot): string {
 	<div class="banner ${banner.kind}">${escapeHtml(banner.label)}</div>
 	${components}
 	${openIncidents}
+	${providerIncidents}
 	${recentIncidents}
 	<footer>
 		Probes run every minute from an independently deployed worker.

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -13,6 +13,12 @@ import {
 } from './incidents.ts'
 import { runAllProbes } from './probes.ts'
 import {
+	fetchRelevantProviderIncidents,
+	parseProviderIncidentCache,
+	serializeProviderIncidentCache,
+	type ProviderIncident,
+} from './provider-incidents.ts'
+import {
 	statusComponentName,
 	statusComponents,
 	type ComponentDayStat,
@@ -23,6 +29,8 @@ import {
 	type StatusComponentId,
 	type StatusSnapshot,
 } from './status-types.ts'
+
+const providerIncidentsMetaKey = 'provider_incidents_cache'
 
 export type StatusWorkerEnv = {
 	STATUS_STORE: DurableObjectNamespace<StatusStore>
@@ -288,6 +296,7 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 			openIncidents,
 			statusPageUrl: this.env.STATUS_PAGE_URL,
 			now,
+			providerIncidents: this.readProviderIncidents(now),
 		})
 		const result = await sendAlertEmail(
 			{
@@ -351,6 +360,30 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 		)
 	}
 
+	private readProviderIncidents(now: number): Array<ProviderIncident> | null {
+		return parseProviderIncidentCache(
+			this.getMeta(providerIncidentsMetaKey),
+			now,
+		)
+	}
+
+	private async refreshProviderIncidents(now: number): Promise<void> {
+		const result = await fetchRelevantProviderIncidents()
+		if (!result.ok) {
+			// Keep any still-fresh cache so a hammered Statuspage API does not
+			// blank the section mid-incident. Stale entries age out via
+			// parseProviderIncidentCache.
+			return
+		}
+		this.setMeta(
+			providerIncidentsMetaKey,
+			serializeProviderIncidentCache({
+				fetchedAt: now,
+				incidents: result.incidents,
+			}),
+		)
+	}
+
 	async runProbes(): Promise<void> {
 		const outcomes = await runAllProbes({
 			primaryOrigin: this.env.PRIMARY_ORIGIN,
@@ -360,6 +393,7 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 		for (const outcome of outcomes) {
 			this.recordOutcome(outcome, now)
 		}
+		await this.refreshProviderIncidents(now)
 		await this.maybeSendAlert(now)
 		this.prune(now)
 	}
@@ -382,6 +416,7 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 			components,
 			openIncidents: this.listIncidents('open'),
 			recentIncidents: this.listIncidents('resolved'),
+			providerIncidents: this.readProviderIncidents(now),
 			buildCommit: this.env.BUILD_COMMIT ?? null,
 		}
 	}

--- a/packages/status/status-types.ts
+++ b/packages/status/status-types.ts
@@ -3,6 +3,10 @@
  * state, and the snapshot shape the public page renders.
  */
 
+import  { type ProviderIncident } from './provider-incidents.ts'
+
+export type { ProviderIncident }
+
 export const statusComponents = [
 	{ id: 'app', name: 'App & API' },
 	{ id: 'mcp', name: 'MCP endpoint' },
@@ -63,5 +67,11 @@ export type StatusSnapshot = {
 	components: Array<ComponentSnapshot>
 	openIncidents: Array<IncidentView>
 	recentIncidents: Array<IncidentView>
+	/**
+	 * Cloudflare Statuspage incidents that affect products kody runs on.
+	 * Null when the feed is unavailable or the cache is too stale — the page
+	 * omits the provider section in that case (fail-soft).
+	 */
+	providerIncidents: Array<ProviderIncident> | null
 	buildCommit: string | null
 }

--- a/packages/status/status-types.ts
+++ b/packages/status/status-types.ts
@@ -3,7 +3,7 @@
  * state, and the snapshot shape the public page renders.
  */
 
-import  { type ProviderIncident } from './provider-incidents.ts'
+import { type ProviderIncident } from './provider-incidents.ts'
 
 export type { ProviderIncident }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related to #1092 (alerting independence).

## Summary

During the 2026-08-07 audit-DB probe timeout, Cloudflare had an active R2 availability incident — but the status page couldn't show that context, leaving "is this us or the platform?" unanswerable at a glance.

This PR adds provider-incident context to the status worker (entirely within `packages/status/`):

- **Filtered fetch** of Cloudflare's public Statuspage API (`/api/v2/incidents/unresolved.json`), keeping only incidents whose components intersect what kody runs on (Workers, D1, R2, KV, Durable Objects, Queues, Vectorize, Email Routing, Access); regional/product noise excluded.
- **Fetched on the existing per-minute cron tick**, cached in `StatusStore`; the render path reads the cache only.
- **Clearly-separated "Provider incidents (Cloudflare)" section** on the status page — provider-declared context, never merged into kody's measured component health or uptime numbers; links to cloudflarestatus.com. Hidden when no relevant incidents are active (the expected steady state).
- **Fail-soft everywhere**: the fetch never throws (bounded timeout, abort, parse guards return `{ ok: false }`); a stale-but-present cache keeps rendering; the page renders without the section when nothing is available.
- **Alert-email annotation**: outage emails gain one line — "Possibly related Cloudflare incident: <name> (<status>)" — when a relevant provider incident is active. Kody's own probes remain the only alerting trigger.
- Tests for filtering, fail-soft paths, page rendering, and email annotation; readme section added.

## Conductor report

Status: in review. Track agent (Grok 4.5) completed the implementation; PR creation was blocked by the Cursor manual-approval gate, so the conductor created this PR from the pushed branch. Track agent resumes the ship-pr deploy loop: CI + AI reviewers → squash-merge → verify the path-filtered `status:deploy` job and the live page at status.heykody.dev.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fbfafda-6d4d-4c9b-b0b6-1f9a8a767ca8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fbfafda-6d4d-4c9b-b0b6-1f9a8a767ca8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare incident monitoring to the status page, including affected components, impact, current status, update time, and source links.
  * Added incident context to outage notifications and daily reminders.
  * Provider incidents are cached and displayed separately from measured service health.
* **Bug Fixes**
  * Provider monitoring failures now degrade gracefully without suppressing outage alerts or status information.
* **Documentation**
  * Documented provider incident monitoring, caching, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->