### PR TITLE
Mini-wizard pills: viewed-step highlight, click-to-jump, and new-tab onboarding links

### DIFF
--- a/packages/worker/client/routes/onboarding-checklist.tsx
+++ b/packages/worker/client/routes/onboarding-checklist.tsx
@@ -171,7 +171,20 @@ export function OnboardingChecklistCard(
 									{item.done || !href ? (
 										<span mix={css(checklistLabelCss)}>{label}</span>
 									) : (
-										<a href={href} mix={css(checklistLinkCss)}>
+										<a
+											href={href}
+											// Hash links move within onboarding itself; everything
+											// else opens elsewhere and must not eat this tab.
+											target={
+												href.startsWith(onboardingPath) ? undefined : '_blank'
+											}
+											rel={
+												href.startsWith(onboardingPath)
+													? undefined
+													: 'noreferrer noopener'
+											}
+											mix={css(checklistLinkCss)}
+										>
 											{label}
 										</a>
 									)}
@@ -182,6 +195,8 @@ export function OnboardingChecklistCard(
 												<span key={provider.id} mix={css(providerEntryCss)}>
 													<a
 														href={provider.href}
+														target="_blank"
+														rel="noreferrer noopener"
 														mix={css(integrationProviderLinkCss)}
 													>
 														<ProviderIcon providerId={provider.id} size="1em" />

--- a/packages/worker/client/routes/onboarding-starter-card.tsx
+++ b/packages/worker/client/routes/onboarding-starter-card.tsx
@@ -156,7 +156,12 @@ export function OnboardingStarterCard(
 				mix={css(starterCardCss)}
 				data-testid={`onboarding-starter-${listing.id}`}
 			>
-				<a href={detailHref} mix={css(starterCardLinkCss)}>
+				<a
+					href={detailHref}
+					target="_blank"
+					rel="noreferrer noopener"
+					mix={css(starterCardLinkCss)}
+				>
 					<CommunityListingIcon listing={listing} size="starter" />
 					<strong mix={css(starterCardNameCss)}>{listing.name}</strong>
 					<span mix={css(starterCardDescriptionCss)}>

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -287,8 +287,12 @@ export function OnboardingRoute(handle: Handle) {
 					const waiting = loggedIn && step.number === waitingStep && !done
 					return (
 						<li key={step.number}>
-							<span
-								mix={css(firstWinStepPillCss)}
+							<button
+								type="button"
+								mix={[
+									css(firstWinStepPillCss),
+									on('click', () => selectFirstWinStep(step.number)),
+								]}
 								data-state={done ? 'done' : waiting ? 'waiting' : undefined}
 								aria-current={step.number === shown ? 'step' : undefined}
 							>
@@ -305,7 +309,7 @@ export function OnboardingRoute(handle: Handle) {
 									)}
 								</span>
 								<span>{step.label}</span>
-							</span>
+							</button>
 						</li>
 					)
 				})}
@@ -350,7 +354,12 @@ export function OnboardingRoute(handle: Handle) {
 						seconds. This page moves on when your reply lands.
 					</p>
 					<p mix={css(firstWinGuidanceCss)}>
-						<a href="/account/email" mix={css(primaryLinkCss)}>
+						<a
+							href="/account/email"
+							target="_blank"
+							rel="noreferrer noopener"
+							mix={css(primaryLinkCss)}
+						>
 							Open your Kody inbox
 						</a>{' '}
 						to see the stored copy.
@@ -568,7 +577,12 @@ export function OnboardingRoute(handle: Handle) {
 					<p data-rise style={{ '--rise': '1' }}>
 						Connect any MCP-capable AI agent to your Kody account, then ask it
 						to help you set things up. New here?{' '}
-						<a href="/guides/what-is-kody" mix={css(headerGuideLinkCss)}>
+						<a
+							href="/guides/what-is-kody"
+							target="_blank"
+							rel="noreferrer noopener"
+							mix={css(headerGuideLinkCss)}
+						>
 							Read what Kody can do
 						</a>{' '}
 						first.
@@ -797,7 +811,12 @@ export function OnboardingRoute(handle: Handle) {
 									<OnboardingDiyCard setupPrompt={setupPrompt} />
 								</ul>
 								<p mix={css({ margin: '0.2rem 0 0' })}>
-									<a href="/community" mix={css(primaryLinkCss)}>
+									<a
+										href="/community"
+										target="_blank"
+										rel="noreferrer noopener"
+										mix={css(primaryLinkCss)}
+									>
 										Browse all community packages
 									</a>
 								</p>
@@ -1242,13 +1261,24 @@ const firstWinStepPillCss = {
 	border: `1.5px solid ${colors.border}`,
 	borderRadius: '999px',
 	whiteSpace: 'nowrap' as const,
-	'&[data-state="waiting"]': {
-		borderColor: colors.primary,
-		color: colors.text,
+	cursor: 'pointer',
+	transition: 'border-color 120ms ease, color 120ms ease',
+	[hoverMq]: {
+		'&:hover': {
+			borderColor: `oklch(from ${colors.primary} l c h / 0.6)`,
+			color: colors.text,
+		},
 	},
 	'&[data-state="done"]': {
 		borderColor: `oklch(from ${colors.primary} l c h / 0.5)`,
 		color: colors.primaryText,
+	},
+	// The highlight tracks the sub-step being VIEWED (Next/Back can peek
+	// ahead of the signals); the spinner alone marks the one being waited
+	// on. Declared last so viewing a done pill still reads as current.
+	'&[aria-current="step"]': {
+		borderColor: colors.primary,
+		color: colors.text,
 	},
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three follow-ups to the See-it-work mini-wizard (#1290), all about not losing people mid-flow:

- **Viewed-pill highlight.** The green border now tracks the sub-step being *viewed* (`aria-current`), not the one being waited on. Next/Back and pill clicks move the highlight; the spinner stays put on the signal-waited sub-step, so "where am I looking" and "what is Kody waiting for" read independently. Declared after the done state so a viewed done pill still reads as current.
- **Clickable pills.** Each pill is now a button that jumps straight to that sub-step (same view-only peek semantics as Next/Back — signal-driven advances still snap the view back). Pills get pointer cursor and a hover border.
- **New-tab links.** Every link that leaves the onboarding flow (`Open your Kody inbox`, the header what-is-kody guide, `Browse all community packages`, starter-card detail links, checklist item links, and the provider guide links) opens with `target="_blank" rel="noreferrer noopener"` so the wizard tab keeps its place. Two deliberate exceptions: checklist links that point at onboarding's own `#hash` sections navigate in place, and the logged-out signup/login links stay same-tab because they are the way *into* onboarding, not a detour.

## Testing

- `npm run typecheck`, lint, and client node tests green locally; full pre-push suite (unit + workers + e2e) green on push.
- Recorded browser walkthrough: initial Send state (highlight + spinner), direct pill clicks to Remember and Reply, the inbox link opening in a new tab with wizard state intact after closing it, then Next/Back walking the highlight Remember → Reply → Send.

<a href="https://cursor.com/agents/bc-69e33c92-b0cb-4ece-9b0e-bda64e9bd7c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmini_wizard_clickable_pills_new_tab_links_demo.mp4"><img src="https://cursor.com/artifacts/c/art-78cef92e-238a-4838-bab9-4bce5cfab174" alt="mini_wizard_clickable_pills_new_tab_links_demo.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `2ae1ea79` · **Head:** `327373d1`

**Classification:** extends — presentation-and-navigation-only changes inside `app-ui`; no payload, storage, route, or capability changes.

### Primitives touched

| Primitive | Group    | Impact                                                                                  |
| --------- | -------- | --------------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — viewed-pill highlight, clickable sub-step pills, `_blank` targets on onboarding links |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69e33c92-b0cb-4ece-9b0e-bda64e9bd7c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69e33c92-b0cb-4ece-9b0e-bda64e9bd7c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

