### PR TITLE
fix: retry package publish on deploy-time Durable Object code resets

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -726,7 +726,9 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 	mockModule.rebuildPublishedPackageArtifact
 		.mockRejectedValueOnce(
 			new Error('rebuild target failed', {
-				cause: new Error('Durable Object exceeded its CPU time limit'),
+				cause: new Error(
+					'Durable Object exceeded its CPU time limit and was reset.',
+				),
 			}),
 		)
 		.mockResolvedValueOnce({
@@ -744,4 +746,52 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 	expect(recoveredAfterRebuildReset.status).toBe('already_published')
 	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(2)
 	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
+
+	// Deploy-time DO resets use "Durable Object reset because…" (no "was").
+	// The old substring matcher missed that form and skipped retries entirely.
+	setupDefaultMocks()
+	mockModule.publishFromExternalRef.mockClear()
+	mockModule.rebuildPublishedPackageArtifact.mockClear()
+	consoleWarn.mockClear()
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([
+		rebuildTarget,
+	])
+	mockModule.publishFromExternalRef
+		.mockResolvedValueOnce({
+			status: 'published',
+			previous_commit: 'commit-old',
+			published_commit: 'commit-new',
+			manifest: {},
+			checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+		})
+		.mockResolvedValueOnce({
+			status: 'already_published',
+			published_commit: 'commit-new',
+		})
+	mockModule.rebuildPublishedPackageArtifact
+		.mockRejectedValueOnce(
+			new Error(
+				'Package source publish succeeded, but bundle artifact rebuild failed.',
+				{
+					cause: new Error(
+						'Durable Object reset because its code was updated.',
+					),
+				},
+			),
+		)
+		.mockResolvedValueOnce({
+			ok: true,
+			target: rebuildTarget,
+			kvKey: 'bundle-key',
+		})
+
+	const recoveredAfterCodeUpdatedReset =
+		await publishExternalPushCapability.handler(
+			{ package_id: 'package-1' },
+			createContext(),
+		)
+	expect(recoveredAfterCodeUpdatedReset.status).toBe('already_published')
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(2)
+	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
 })

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -10,6 +10,7 @@ import {
 	errorCauseChainIncludes,
 	getErrorMessage,
 } from '@kody-internal/shared/error-message.ts'
+import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
 	getStaticPackageDependentsSummary,
@@ -55,13 +56,10 @@ export default async function main(params = {}) {
 }`
 
 function isTransientDurableObjectResetError(error: unknown) {
-	return errorCauseChainIncludes(
-		error,
-		(message) =>
-			message.includes('Durable Object exceeded its CPU time limit') ||
-			message.includes("Durable Object's isolate exceeded its memory limit") ||
-			message.includes('Durable Object was reset'),
-	)
+	// Exact platform reset strings (including deploy "code was updated").
+	// Substring matching on "Durable Object was reset" misses that form —
+	// Cloudflare says "Durable Object reset because…" with no "was".
+	return errorCauseChainIncludes(error, isDurableObjectIsolateResetMessage)
 }
 
 function logExternalPublishRetry(input: {

--- a/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
@@ -102,7 +102,9 @@ test('runner touches staging TTL, fans out one target per throwaway DO, and maps
 	})
 
 	runIsolatedArtifactRebuild.mockRejectedValueOnce(
-		new Error("Durable Object's isolate exceeded its memory limit and was reset."),
+		new Error(
+			"Durable Object's isolate exceeded its memory limit and was reset.",
+		),
 	)
 	const resetOutcome = await runner.run({
 		stagingKey,

--- a/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.node.test.ts
@@ -102,7 +102,7 @@ test('runner touches staging TTL, fans out one target per throwaway DO, and maps
 	})
 
 	runIsolatedArtifactRebuild.mockRejectedValueOnce(
-		new Error("Durable Object's isolate exceeded its memory limit"),
+		new Error("Durable Object's isolate exceeded its memory limit and was reset."),
 	)
 	const resetOutcome = await runner.run({
 		stagingKey,
@@ -114,6 +114,20 @@ test('runner touches staging TTL, fans out one target per throwaway DO, and maps
 	expect(resetOutcome.ok).toBe(false)
 	expect(resetOutcome.message).toContain('memory or CPU limits')
 	expect(resetOutcome.target).toEqual(target)
+
+	// Deploy resets must not be remapped to "package too large" — callers retry.
+	runIsolatedArtifactRebuild.mockRejectedValueOnce(
+		new Error('Durable Object reset because its code was updated.'),
+	)
+	await expect(
+		runner.run({
+			stagingKey,
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-1',
+			target,
+		}),
+	).rejects.toThrow('Durable Object reset because its code was updated.')
 
 	await runner.discard(stagingKey)
 	expect(del).toHaveBeenCalledWith(stagingKey)

--- a/packages/worker/src/repo/isolated-artifact-rebuild.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.ts
@@ -1,5 +1,6 @@
 import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
 import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import { isDurableObjectIsolateResourceLimitResetMessage } from '#worker/sentry-options.ts'
 
 /**
  * Heavy published-package artifact rebuilds run in fresh, throwaway
@@ -80,13 +81,12 @@ export type IsolatedArtifactRebuildRunner = {
 	discard(stagingKey: string): Promise<void>
 }
 
-function isDurableObjectResetError(error: unknown) {
+function isDurableObjectResourceLimitResetError(error: unknown) {
+	// Remap only memory/CPU limits to the "package too large" outcome.
+	// Deploy resets ("code was updated") must propagate so publish can retry.
 	return errorCauseChainIncludes(
 		error,
-		(message) =>
-			message.includes('Durable Object exceeded its CPU time limit') ||
-			message.includes("Durable Object's isolate exceeded its memory limit") ||
-			message.includes('Durable Object was reset'),
+		isDurableObjectIsolateResourceLimitResetMessage,
 	)
 }
 
@@ -134,7 +134,7 @@ export function createIsolatedArtifactRebuildRunner(
 			try {
 				return await stub.runIsolatedArtifactRebuild(request)
 			} catch (error) {
-				if (isDurableObjectResetError(error)) {
+				if (isDurableObjectResourceLimitResetError(error)) {
 					return {
 						ok: false,
 						message:

--- a/packages/worker/src/repo/isolated-check-phases.ts
+++ b/packages/worker/src/repo/isolated-check-phases.ts
@@ -1,4 +1,5 @@
 import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
+import { isDurableObjectIsolateResourceLimitResetMessage } from '#worker/sentry-options.ts'
 import {
 	type PackageBundleTarget,
 	type PackageCallableTypecheckTarget,
@@ -86,13 +87,11 @@ export type IsolatedCheckPhaseRunner = {
 	discard(stagingKey: string): Promise<void>
 }
 
-function isDurableObjectResetError(error: unknown) {
+function isDurableObjectResourceLimitResetError(error: unknown) {
+	// Remap only memory/CPU limits. Deploy resets must keep propagating.
 	return errorCauseChainIncludes(
 		error,
-		(message) =>
-			message.includes('Durable Object exceeded its CPU time limit') ||
-			message.includes("Durable Object's isolate exceeded its memory limit") ||
-			message.includes('Durable Object was reset'),
+		isDurableObjectIsolateResourceLimitResetMessage,
 	)
 }
 
@@ -143,7 +142,7 @@ export function createIsolatedCheckPhaseRunner(
 			try {
 				return await stub.runIsolatedCheckPhase(request)
 			} catch (error) {
-				if (isDurableObjectResetError(error)) {
+				if (isDurableObjectResourceLimitResetError(error)) {
 					return {
 						ok: false,
 						message:

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -9,7 +9,31 @@ import {
 	durableObjectStorageOperationTimeoutResetMessage,
 	executorSandboxTimeoutMessage,
 	filterSentryEvent,
+	isDurableObjectIsolateResourceLimitResetMessage,
 } from './sentry-options.ts'
+
+test('isDurableObjectIsolateResourceLimitResetMessage is memory/CPU only', () => {
+	expect(
+		isDurableObjectIsolateResourceLimitResetMessage(
+			durableObjectIsolateMemoryResetMessage,
+		),
+	).toBe(true)
+	expect(
+		isDurableObjectIsolateResourceLimitResetMessage(
+			durableObjectIsolateCpuResetMessage,
+		),
+	).toBe(true)
+	expect(
+		isDurableObjectIsolateResourceLimitResetMessage(
+			durableObjectCodeUpdatedResetMessage,
+		),
+	).toBe(false)
+	expect(
+		isDurableObjectIsolateResourceLimitResetMessage(
+			durableObjectBlockConcurrencyWhileTimeoutResetMessage,
+		),
+	).toBe(false)
+})
 
 test('filterSentryEvent drops expected platform and caller noise and keeps real errors', () => {
 	expect(

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -173,11 +173,26 @@ export function isDurableObjectStorageObjectResetMessage(message: string) {
 	return durableObjectStorageObjectResetPattern.test(withoutErrorPrefix)
 }
 
-export function isDurableObjectIsolateResetMessage(message: string) {
+/**
+ * Memory/CPU isolate resets only. Isolated throwaway runners remap these to
+ * actionable "package too large" outcomes; deploy resets ("code was updated")
+ * and other platform resets must keep propagating so idempotent callers can
+ * retry on a fresh isolate.
+ */
+export function isDurableObjectIsolateResourceLimitResetMessage(
+	message: string,
+) {
 	const normalized = normalizeDurableObjectIsolateResetMessage(message)
 	return (
 		normalized === durableObjectIsolateMemoryResetMessage ||
-		normalized === durableObjectIsolateCpuResetMessage ||
+		normalized === durableObjectIsolateCpuResetMessage
+	)
+}
+
+export function isDurableObjectIsolateResetMessage(message: string) {
+	const normalized = normalizeDurableObjectIsolateResetMessage(message)
+	return (
+		isDurableObjectIsolateResourceLimitResetMessage(message) ||
 		normalized === durableObjectCodeUpdatedResetMessage ||
 		normalized === durableObjectBlockConcurrencyWhileTimeoutResetMessage ||
 		normalized === durableObjectStorageOperationTimeoutResetMessage ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry

- Issue: [7659236280](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7659236280/)
- Sibling: [7659575592](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7659575592/) (same deploy-time DO reset during artifact rebuild)
- Signature: `Package source publish succeeded, but bundle artifact rebuild failed… Failed: Durable Object reset because its code was updated.`
- Capability: `package_publish_external_push`

## Root cause

Cloudflare's deploy-time Durable Object reset string is:

`Durable Object reset because its code was updated.`

`package_publish_external_push` treated only messages containing `Durable Object was reset` (plus memory/CPU substrings) as transient. That substring does **not** appear in the code-updated form (no `was`), so rebuild failures during a worker deploy were thrown immediately instead of retrying on a fresh session.

Isolated throwaway rebuild/check runners had the same loose matcher for remapping resets to "package too large". Deploy resets must not be remapped — they need to propagate so the publish retry path can recover.

## Fix

- Publish retry detection now uses the shared exact `isDurableObjectIsolateResetMessage` matcher (same as job transient classification), which already includes the code-updated string.
- Isolated artifact rebuild / check-phase remappers only remap memory/CPU resource-limit resets via a new `isDurableObjectIsolateResourceLimitResetMessage` helper; code-updated and other platform resets propagate unchanged.

## Testing

- `publish-external-push.node.test.ts`: recovers when a rebuild fails with the code-updated reset cause
- `isolated-artifact-rebuild.node.test.ts`: memory remaps; code-updated rethrows
- `sentry-options.node.test.ts`: resource-limit helper is memory/CPU only

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `45085b97` · **Head:** `f775d8e1`

**Classification:** composes — observability/retry wiring only; no capability contract, storage, or auth changes. Publish already retried other DO resets; this closes the matcher gap for deploy-time code updates.

### Primitives touched

| Primitive        | Group     | Impact                                                                 |
| ---------------- | --------- | ---------------------------------------------------------------------- |
| `saved-packages` | assistant | composes — retry matcher covers deploy-time DO code-updated resets     |
| `repo-sessions`  | runtime   | composes — isolated remappers stay memory/CPU-only so deploy resets propagate |

### System map

External package publish rebuilds retry on Cloudflare deploy-time DO resets instead of failing the capability immediately.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	sentryOpts["sentry-options<br/>DO reset matchers"]:::untouched
	savedPackages -->|"package_publish_external_push retries via isDurableObjectIsolateResetMessage"| sentryOpts
	repoSessions -->|"isolated rebuild/check remap only memory/CPU via isDurableObjectIsolateResourceLimitResetMessage"| sentryOpts
	savedPackages -->|"rebuild via throwaway REPO_SESSION DO"| repoSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cap as package_publish_external_push
	participant Rebuild as isolated artifact rebuild
	participant DO as REPO_SESSION DO
	Cap->>Rebuild: rebuild targets after publish
	Rebuild->>DO: runIsolatedArtifactRebuild
	DO-->>Rebuild: Durable Object reset because its code was updated
	Note over Rebuild: code-updated not remapped
	Rebuild-->>Cap: error with cause
	Note over Cap: classified transient; retry fresh session
	Cap->>Rebuild: retry attempt
	Rebuild-->>Cap: success
```

### Before / after

| Reset form | Before | After |
| --- | --- | --- |
| `…code was updated.` during rebuild | no retry; Sentry via MCP failure | retried (up to 3 attempts) |
| memory/CPU on throwaway isolate | remapped to "package too large" | unchanged |
| exhausted retries | MCP failure + Sentry (wrapped) | unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e89af86-acb9-4a61-8cdb-bb0a117b47b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e89af86-acb9-4a61-8cdb-bb0a117b47b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transient deployment resets during publishing and artifact rebuilding, allowing operations to retry reliably.
  * Prevented deployment-related resets from being incorrectly reported as package-size failures.
  * Preserved actionable package-size errors for genuine memory and CPU resource-limit resets.
  * Improved isolated check failure handling for deployment and resource-limit scenarios.

* **Tests**
  * Added coverage for retry behavior, reset classification, and accurate error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->