### PR TITLE
fix(sentry): filter offline remote connectors; accept audit id 0

### DIFF
--- a/packages/worker/src/audit-log.node.test.ts
+++ b/packages/worker/src/audit-log.node.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
-import { logAuditEvent } from './audit-log.ts'
+import { logAuditEvent, queryAuditLog } from './audit-log.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
@@ -110,4 +110,28 @@ test('audit writes retry transient errors and report dedicated sink failures', a
 		failedSinks: ['AUDIT_DB'],
 		errors: [expect.any(Error)],
 	})
+})
+
+test('queryAuditLog returns explicit SQLite zero rowids', async () => {
+	const audit = createAuditDb()
+	audit.sqlite
+		.prepare(
+			`INSERT INTO audit_events (id, category, action, result, timestamp)
+			 VALUES (0, 'admin', 'legacy_seed', 'success', '2026-01-01T00:00:00.000Z')`,
+		)
+		.run()
+
+	const result = await queryAuditLog(audit.db, {
+		action: 'legacy_seed',
+		limit: 10,
+	})
+	expect(result.total).toBe(1)
+	expect(result.events).toEqual([
+		expect.objectContaining({
+			id: 0,
+			action: 'legacy_seed',
+			category: 'admin',
+			result: 'success',
+		}),
+	])
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-audit-log-query.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-audit-log-query.ts
@@ -58,7 +58,9 @@ const inputSchema = z.object({
 })
 
 const auditLogEntrySchema = z.object({
-	id: z.number().int().positive(),
+	// SQLite INTEGER PRIMARY KEY allows explicit id=0; AUTOINCREMENT starts at
+	// 1 for app writes, but legacy/manual rows must still parse.
+	id: z.number().int().nonnegative(),
 	category: z.enum(auditEventCategories),
 	action: z.string(),
 	result: z.enum(auditEventResults),

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -655,6 +655,47 @@ test('admin capabilities list and get account metadata and query sanitized audit
 	])
 })
 
+test('admin_audit_log_query accepts SQLite zero rowids through output parse', async () => {
+	const { db, auditEvents } = createAdminCapabilityTestDb({
+		users: [
+			adminTestUser({
+				id: 1,
+				username: 'admin',
+				email: 'admin@example.com',
+				created_at: '2026-01-01 00:00:00',
+				updated_at: '2026-01-02 00:00:00',
+			}),
+		],
+		userRoles: [{ user_id: 1, role_name: 'admin' }],
+	})
+	auditEvents.push({
+		id: 0,
+		category: 'admin',
+		action: 'legacy_seed',
+		result: 'success',
+		email_hash: null,
+		ip_hash: null,
+		client_id: null,
+		path: null,
+		reason: null,
+		timestamp: '2026-01-01T00:00:00.000Z',
+	})
+	const ctx = createAdminCapabilityContext(db)
+
+	const audit = await adminAuditLogQueryCapability.handler(
+		{ action: 'legacy_seed', limit: 10 },
+		ctx,
+	)
+	expect(audit.events).toEqual([
+		expect.objectContaining({
+			id: 0,
+			action: 'legacy_seed',
+			category: 'admin',
+			result: 'success',
+		}),
+	])
+})
+
 test('admin system email capabilities read only system-owned mail and audit reads', async () => {
 	const { db, auditEvents } = createAdminCapabilityTestDb({
 		users: [

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -213,9 +213,23 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 				}),
 			}),
 		})
+
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'remote:home:bond_shade_set_position',
+			domain: 'remote:home',
+			capabilitySource: 'remote-connector',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage:
+				'The connector "home" is not connected. Kody cannot use this connector until it reconnects. Ask the user to start or reconnect the connector and then try again.',
+			cause: new Error(
+				'The connector "home" is not connected. Kody cannot use this connector until it reconnects. Ask the user to start or reconnect the connector and then try again.',
+			),
+		})
 	})
 
-	expect(payloads).toHaveLength(11)
+	expect(payloads).toHaveLength(12)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',
@@ -262,9 +276,23 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			},
 			cause: new Error('no such table: notes: SQLITE_ERROR'),
 		})
+
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'remote:home:bond_shade_set_position',
+			domain: 'remote:home',
+			capabilitySource: 'remote-connector',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage:
+				'Remote capability "home:bond_shade_set_position" failed: timeout',
+			cause: new Error(
+				'Remote capability "home:bond_shade_set_position" failed: timeout',
+			),
+		})
 	})
 
-	expect(sentryMock.captureException).toHaveBeenCalledTimes(3)
+	expect(sentryMock.captureException).toHaveBeenCalledTimes(4)
 	expect(sentryMock.captureException).toHaveBeenNthCalledWith(
 		1,
 		expect.objectContaining({ message: 'platform handler blew up' }),
@@ -277,6 +305,13 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 		3,
 		expect.objectContaining({
 			message: 'no such table: notes: SQLITE_ERROR',
+		}),
+	)
+	expect(sentryMock.captureException).toHaveBeenNthCalledWith(
+		4,
+		expect.objectContaining({
+			message:
+				'Remote capability "home:bond_shade_set_position" failed: timeout',
 		}),
 	)
 	expect(sentryMock.scope.setLevel).toHaveBeenCalledWith('error')

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -3,6 +3,7 @@ import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
+import { isRemoteConnectorUnavailableMessage } from '#worker/remote-connector/status.ts'
 import { isRepoLargeFileMessage } from '#worker/repo/large-file-policy.ts'
 import { isUserCodeError } from '#worker/user-code-error.ts'
 import { isMcpCallerError } from './caller-error.ts'
@@ -110,6 +111,18 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 		getErrorCauseChain(cause).some(
 			(entry) =>
 				entry instanceof Error && isRepoLargeFileMessage(entry.message),
+		)
+	) {
+		return true
+	}
+	// Offline / empty / session-unavailable remote connectors throw a plain
+	// Error with a stable guidance message. Agents reconnect; keep volume on
+	// mcp-event lines.
+	if (
+		getErrorCauseChain(cause).some(
+			(entry) =>
+				entry instanceof Error &&
+				isRemoteConnectorUnavailableMessage(entry.message),
 		)
 	) {
 		return true

--- a/packages/worker/src/remote-connector/status.node.test.ts
+++ b/packages/worker/src/remote-connector/status.node.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest'
+import {
+	formatRemoteConnectorUnavailableMessage,
+	isRemoteConnectorUnavailableMessage,
+	type RemoteConnectorStatus,
+} from './status.ts'
+
+function status(
+	partial: Pick<RemoteConnectorStatus, 'state' | 'message' | 'toolCount'> &
+		Partial<RemoteConnectorStatus>,
+): RemoteConnectorStatus {
+	return {
+		connectorId: 'home',
+		connected: partial.state === 'connected',
+		connectedAt: null,
+		lastSeenAt: null,
+		error: null,
+		...partial,
+	}
+}
+
+test('isRemoteConnectorUnavailableMessage matches guidance phrases and ignores connected-tool failures', () => {
+	const disconnected = formatRemoteConnectorUnavailableMessage(
+		status({
+			state: 'disconnected',
+			toolCount: 0,
+			message: 'The connector "home" is not connected.',
+		}),
+	)
+	const emptyTools = formatRemoteConnectorUnavailableMessage(
+		status({
+			state: 'connected',
+			toolCount: 0,
+			message:
+				'The connector "home" is connected, but it has not exposed any tools yet.',
+		}),
+	)
+	const unavailable = formatRemoteConnectorUnavailableMessage(
+		status({
+			state: 'unavailable',
+			toolCount: 0,
+			message: 'The connector "home" is unavailable in this session.',
+		}),
+	)
+
+	expect(isRemoteConnectorUnavailableMessage(disconnected)).toBe(true)
+	expect(isRemoteConnectorUnavailableMessage(emptyTools)).toBe(true)
+	expect(isRemoteConnectorUnavailableMessage(unavailable)).toBe(true)
+	expect(
+		isRemoteConnectorUnavailableMessage(
+			'Remote capability "home:bond_shade_set_position" failed: timeout',
+		),
+	).toBe(false)
+	expect(
+		isRemoteConnectorUnavailableMessage(
+			'Kody could not determine the status for the connector "home".',
+		),
+	).toBe(false)
+})

--- a/packages/worker/src/remote-connector/status.ts
+++ b/packages/worker/src/remote-connector/status.ts
@@ -72,6 +72,24 @@ function createErrorStatus(
 	}
 }
 
+/**
+ * Stable phrases from `formatRemoteConnectorUnavailableMessage`. MCP
+ * observability and Sentry `beforeSend` depend on them so offline / empty /
+ * unauthenticated connector states stay on structured `mcp-event` logs and
+ * out of Sentry (caller-clearable user state, not platform defects).
+ */
+const remoteConnectorUnavailablePhrases = [
+	'Kody cannot use this connector until it reconnects',
+	'Capabilities from this connector cannot be searched or used until it exposes tools',
+	'Kody cannot use this connector from this session',
+] as const
+
+export function isRemoteConnectorUnavailableMessage(message: string) {
+	return remoteConnectorUnavailablePhrases.some((phrase) =>
+		message.includes(phrase),
+	)
+}
+
 export function formatRemoteConnectorUnavailableMessage(
 	status: RemoteConnectorStatus,
 ) {

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -142,6 +142,31 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		filterSentryEvent({ message: executorSandboxTimeoutMessage }),
 	).toBeNull()
 
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'The connector "home" is not connected. Kody cannot use this connector until it reconnects. Ask the user to start or reconnect the connector and then try again.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Remote capability "home:bond_shade_set_position" failed: timeout',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+
 	const platformBuildFailure = {
 		exception: {
 			values: [

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -3,6 +3,7 @@ import { type ErrorEvent, type EventHint } from '@sentry/core'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 import { isEntitlementLimitError } from './entitlements/errors.ts'
 import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
+import { isRemoteConnectorUnavailableMessage } from './remote-connector/status.ts'
 import { isUserCodeError } from './user-code-error.ts'
 
 function sentryEventMessages(event: ErrorEvent) {
@@ -110,6 +111,25 @@ export function isExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
 
 export function filterExecutorSandboxTimeoutSentryEvent(event: ErrorEvent) {
 	if (!isExecutorSandboxTimeoutSentryEvent(event)) return event
+	return null
+}
+
+/**
+ * Offline / empty / session-unavailable remote connectors are caller-clearable
+ * user state (reconnect the connector). MCP observability already skips them
+ * via `isCallerFailure`; this `beforeSend` gate is the backstop for any other
+ * capture path that still forwards the plain Error message.
+ */
+export function isRemoteConnectorUnavailableSentryEvent(event: ErrorEvent) {
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isRemoteConnectorUnavailableMessage(message),
+	)
+}
+
+export function filterRemoteConnectorUnavailableSentryEvent(event: ErrorEvent) {
+	if (!isRemoteConnectorUnavailableSentryEvent(event)) return event
 	return null
 }
 
@@ -226,6 +246,7 @@ export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	// String-match backstops for paths that cannot yet be marked.
 	if (filterUserModuleBundlerFailureSentryEvent(event) === null) return null
 	if (filterExecutorSandboxTimeoutSentryEvent(event) === null) return null
+	if (filterRemoteConnectorUnavailableSentryEvent(event) === null) return null
 	if (filterDurableObjectIsolateResetSentryEvent(event) === null) return null
 	return event
 }
@@ -263,7 +284,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// account policy, still visible on structured `mcp-event` logs. Bundler
 		// / sandbox-timeout string matches remain as backstops for unmarked
 		// paths; see filterUserModuleBundlerFailureSentryEvent and
-		// filterExecutorSandboxTimeoutSentryEvent. Bare Cloudflare Durable
+		// filterExecutorSandboxTimeoutSentryEvent. Offline remote-connector
+		// guidance messages are dropped the same way — see
+		// filterRemoteConnectorUnavailableSentryEvent. Bare Cloudflare Durable
 		// Object platform reset strings (memory/CPU limits, deploy-time code
 		// updates, blockConcurrencyWhile timeouts, DO storage operation
 		// timeouts, and DO storage object-reset with a support reference) are


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop two unrelated production Sentry failures from a deploy-window backfill batch: offline remote-connector guidance noise (issue 7659311570) and `admin_audit_log_query` output parse failures on SQLite `id = 0` (KODY-CLOUDFLARE-42). Sibling KODY-CLOUDFLARE-41 is already fixed by #1301 and is not part of this diff.

## Summary

- Treat remote-connector unavailable guidance messages as caller-clearable: skip Sentry via MCP `isCallerFailure` and a `beforeSend` backstop; keep `mcp-event` logs.
- Relax `admin_audit_log_query` event `id` from `.positive()` to `.nonnegative()` so explicit SQLite zero rowids parse successfully.
- Tests cover phrase matching, observability/Sentry drop vs keep, and zero-rowid query/capability paths.

## Testing

- `npx vitest run` on `status.node.test.ts`, `observability.node.test.ts`, `sentry-options.node.test.ts`, `admin-capabilities.node.test.ts`, `audit-log.node.test.ts` (15 passed)
- Full `npm run validate` pending in this PR

## Sibling dispositions (Sentry)

| Issue | Outcome |
| --- | --- |
| 7659311570 (connector not connected) | filtered — this PR |
| 7659575592 / KODY-CLOUDFLARE-41 (DO code reset mid publish) | already fixed in #1301 (`8d5f6fff`) — resolve in that commit |
| 7659609626 / KODY-CLOUDFLARE-42 (ZodError audit id) | fixed — this PR |

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8d5f6fff` · **Head:** `86d156e1`

**Classification:** composes — Sentry/MCP observability wiring plus a permissive one-line admin output-schema fix; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `remote-connectors` | assistant | composes — unavailable-message classifier |
| `connector-ingress` | surfaces | composes — same status helpers |
| `mcp-server` | surfaces | composes — `isCallerFailure` skip path |
| `rbac` | auth | composes — admin audit output accepts `id >= 0` |

### System map

Offline remote-connector capability failures and admin audit query output parse both flow through MCP observability; this PR drops the former from Sentry and lets zero rowids pass output schema.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	remoteConnectors["remote-connectors<br/>Remote connectors"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	rbac["rbac<br/>Role-based access control"]:::touched
	sentryOpts["sentry-options<br/>beforeSend filters"]:::touched
	remoteConnectors -->|"unavailable phrase match"| mcpServer
	mcpServer -->|"skip Sentry caller failure"| sentryOpts
	rbac -->|"admin_audit_log_query id nonnegative"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-539d5020-787b-485e-be96-1baaae84f170?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-539d5020-787b-485e-be96-1baaae84f170&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved audit log entries with a SQLite row ID of `0`, including their metadata.
  * Improved handling of unavailable remote connectors by excluding expected disconnection errors from error monitoring.
  * Continued reporting unexpected remote capability failures, such as timeouts, for investigation.
* **Tests**
  * Added coverage for audit log querying, remote connector status detection, observability, and error filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->