### PR TITLE
fix(sentry): filter Twitter in-app browser CONFIG ReferenceError

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -7,6 +7,7 @@ import {
 	filterFathomRemoveChildNullSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
 	filterMetaMaskExtensionSentryEvent,
+	filterTwitterInAppBrowserConfigSentryEvent,
 } from './sentry-browser-filters.ts'
 
 test('browser Sentry filters drop AbortError and Firefox Xray noise and keep real errors', () => {
@@ -293,6 +294,74 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 								{
 									filename:
 										'chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	// Twitter/X iOS in-app browser chrome CONFIG (issue 7659616372 /
+	// KODY-CLOUDFLARE-43). Requires both the CONFIG wording and a chrome
+	// stack function — bare CONFIG ReferenceErrors from app code stay.
+	expect(
+		filterTwitterInAppBrowserConfigSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: CONFIG",
+						stacktrace: {
+							frames: [
+								{
+									function: 'updateFooterPositions',
+									filename: 'https://heykody.app/',
+								},
+								{
+									function: 'updateGapFiller',
+									filename: 'https://heykody.app/',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterTwitterInAppBrowserConfigSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: "Can't find variable: CONFIG",
+						stacktrace: {
+							frames: [
+								{
+									function: 'boot',
+									filename: 'https://heykody.app/assets/entry.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'ReferenceError',
+						value: 'CONFIG is not defined',
+						stacktrace: {
+							frames: [
+								{
+									function: 'updateGapFiller',
+									abs_path: 'https://heykody.app/',
 								},
 							],
 						},

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -7,6 +7,7 @@ type SentryStackFrame = {
 	filename?: string
 	abs_path?: string
 	absPath?: string
+	function?: string
 }
 
 type SentryExceptionValue = {
@@ -43,6 +44,18 @@ function sentryEventStackFrameUrls(event: SentryErrorEventLike) {
 		}
 	}
 	return urls
+}
+
+function sentryEventStackFrameFunctions(event: SentryErrorEventLike) {
+	const names: Array<string> = []
+	for (const value of event.exception?.values ?? []) {
+		for (const frame of value.stacktrace?.frames ?? []) {
+			if (typeof frame.function === 'string' && frame.function.length > 0) {
+				names.push(frame.function)
+			}
+		}
+	}
+	return names
 }
 
 /**
@@ -369,6 +382,68 @@ export function filterMetaMaskExtensionSentryEvent<
 	return event
 }
 
+/**
+ * Twitter/X iOS in-app browser chrome (`updateFooterPositions` /
+ * `updateGapFiller`) references a host-page `CONFIG` global that Kody never
+ * defines. WebKit reports it as an unhandled `ReferenceError` attributed to
+ * the document URL (no Twitter bundle frames). Signature from production
+ * issue 7659616372 / KODY-CLOUDFLARE-43 (browser tag "Twitter 11.82").
+ *
+ * Match is intentionally narrow: CONFIG ReferenceError wording AND a stack
+ * frame named `updateFooterPositions` or `updateGapFiller`. Never
+ * blanket-drop bare `CONFIG` ReferenceErrors from app code.
+ */
+const twitterInAppBrowserConfigMessage =
+	/^(?:ReferenceError:\s*)?(?:Can'?t find variable: CONFIG|Cannot find variable: CONFIG|CONFIG is not defined)\.?$/i
+
+const twitterInAppBrowserChromeFunctions = new Set([
+	'updateFooterPositions',
+	'updateGapFiller',
+])
+
+export function isTwitterInAppBrowserConfigMessage(message: string) {
+	return twitterInAppBrowserConfigMessage.test(message.trim())
+}
+
+export function isTwitterInAppBrowserChromeStackFunction(name: string) {
+	return twitterInAppBrowserChromeFunctions.has(name)
+}
+
+export function isTwitterInAppBrowserConfigError(error: unknown) {
+	if (typeof error === 'string') {
+		return isTwitterInAppBrowserConfigMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isTwitterInAppBrowserConfigMessage(error.message)
+}
+
+export function isTwitterInAppBrowserConfigSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	const hasConfigMessage =
+		isTwitterInAppBrowserConfigError(originalException) ||
+		sentryEventMessages(event).some(
+			(message) =>
+				typeof message === 'string' &&
+				isTwitterInAppBrowserConfigMessage(message),
+		)
+	if (!hasConfigMessage) return false
+	return sentryEventStackFrameFunctions(event).some(
+		isTwitterInAppBrowserChromeStackFunction,
+	)
+}
+
+export function filterTwitterInAppBrowserConfigSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isTwitterInAppBrowserConfigSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -399,6 +474,12 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 		return null
 	}
 	if (filterMetaMaskExtensionSentryEvent(event, originalException) === null) {
+		return null
+	}
+	if (
+		filterTwitterInAppBrowserConfigSentryEvent(event, originalException) ===
+		null
+	) {
 		return null
 	}
 	return event

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -31,11 +31,13 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// Drop expected browser noise (AbortError aborts, Firefox DOM
 		// permission-denied from Replay/hydration on restricted nodes,
 		// injected wallet/`__firefox__` globals, Fathom beacon
-		// removeChild-on-null, and Chrome extension IPC "Object Not Found
-		// Matching Id…") — see filterBrowserSentryEvent /
-		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S /
-		// issues 7639685398, 7648833360, 7648833403, 7653117289,
-		// 7655189301.
+		// removeChild-on-null, Chrome extension IPC "Object Not Found
+		// Matching Id…", MetaMask inpage connect failures, and Twitter/X
+		// in-app browser chrome `CONFIG` ReferenceErrors) — see
+		// filterBrowserSentryEvent / KODY-CLOUDFLARE-23 /
+		// KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S / KODY-CLOUDFLARE-3X /
+		// KODY-CLOUDFLARE-43 / issues 7639685398, 7648833360, 7648833403,
+		// 7653117289, 7655189301, 7658961865, 7659616372.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Twitter/X iOS in-app browser chrome from reporting non-actionable `CONFIG` ReferenceErrors into Sentry for heykody.app.

## Summary

- Browser tag on the event was **Twitter 11.82** (iPhone); stack frames `updateFooterPositions` / `updateGapFiller` are not in this repo.
- Added a narrow client `beforeSend` filter: CONFIG ReferenceError wording **and** those chrome stack function names (KODY-CLOUDFLARE-43 / issue 7659616372).
- Bare CONFIG ReferenceErrors from app code still report.

## Testing

- `npx vitest run packages/worker/client/sentry-browser-filters.node.test.ts`
- `npm run validate` (passed locally)

## System changes

Low-risk `app-ui` compose: existing browser Sentry filter chain only.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fbe699b0` · **Head:** `f6ba335a`

**Classification:** composes — adds a narrow predicate to the existing browser Sentry `beforeSend` filter chain; no new primitives or contracts.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — client Sentry filter for Twitter/X in-app browser CONFIG noise |

### System map

Browser errors from the Twitter/X iOS webview hit the client Sentry SDK and are dropped when they match the chrome CONFIG signature.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser UI"]:::touched
	sentry["Sentry browser SDK<br/>beforeSend"]:::untouched
	appUi -->|"filterTwitterInAppBrowserConfigSentryEvent"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0015ef0e-0b3c-44f5-9c5f-9bc3198d4a6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0015ef0e-0b3c-44f5-9c5f-9bc3198d4a6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from Twitter/X iOS in-app browser `CONFIG` errors in error monitoring.
  * Preserved reporting for unrelated errors and stack traces.
  * Improved filtering for equivalent browser error messages.
* **Documentation**
  * Updated error-monitoring documentation to reflect the additional filtered browser errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->