### PR TITLE
fix(mcp): keep user storage SQL mistakes off Sentry (KODY-CLOUDFLARE-44)

### DIFF
--- a/packages/worker/src/mcp/capabilities/storage/storage-query.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/storage/storage-query.node.test.ts
@@ -1,0 +1,76 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	sqlQuery: vi.fn(),
+}))
+
+vi.mock('#worker/storage-runner.ts', () => ({
+	assertStorageRunnerWriteWithinEntitlement: vi.fn(),
+	isReadOnlyStorageSqlQuery: (query: string) =>
+		query.trim().toLowerCase().startsWith('select'),
+	storageRunnerRpc: () => ({
+		sqlQuery: (...args: Array<unknown>) => mockModule.sqlQuery(...args),
+	}),
+}))
+
+vi.mock('#worker/entitlements/service.ts', () => ({
+	estimateEntitlementStorageSqlWriteBytes: () => 0,
+}))
+
+const { storageQueryCapability } = await import('./storage-query.ts')
+
+function createCallerContext() {
+	return createMcpCallerContext({
+		baseUrl: 'https://example.com',
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'User',
+		},
+	})
+}
+
+test('storage_query wraps Durable Object SQL caller mistakes as McpCallerError', async () => {
+	mockModule.sqlQuery.mockRejectedValueOnce(
+		new Error('no such table: articles: SQLITE_ERROR'),
+	)
+
+	await expect(
+		storageQueryCapability.handler(
+			{
+				storage_id: 'storage-1',
+				query: 'SELECT * FROM articles',
+			},
+			{
+				env: {} as Env,
+				callerContext: createCallerContext(),
+			} as never,
+		),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message === 'no such table: articles: SQLITE_ERROR',
+	)
+})
+
+test('storage_query rethrows unrelated platform failures unchanged', async () => {
+	const platformError = new Error(
+		'Durable Object reset because its code was updated.',
+	)
+	mockModule.sqlQuery.mockRejectedValueOnce(platformError)
+
+	await expect(
+		storageQueryCapability.handler(
+			{
+				storage_id: 'storage-1',
+				query: 'SELECT 1',
+			},
+			{
+				env: {} as Env,
+				callerContext: createCallerContext(),
+			} as never,
+		),
+	).rejects.toBe(platformError)
+})

--- a/packages/worker/src/mcp/capabilities/storage/storage-query.ts
+++ b/packages/worker/src/mcp/capabilities/storage/storage-query.ts
@@ -1,14 +1,17 @@
 import { z } from 'zod'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	assertStorageRunnerWriteWithinEntitlement,
 	isReadOnlyStorageSqlQuery,
 	storageRunnerRpc,
 } from '#worker/storage-runner.ts'
 import { estimateEntitlementStorageSqlWriteBytes } from '#worker/entitlements/service.ts'
+import { isUserStorageSqlCallerMessage } from '#worker/storage-sql-caller-error.ts'
 import { storageIdSchema } from './shared.ts'
 
 const outputSchema = z.object({
@@ -64,25 +67,35 @@ export const storageQueryCapability = defineDomainCapability(
 					}),
 				})
 			}
-			const result = await storageRunnerRpc({
-				env: ctx.env,
-				userId: user.userId,
-				storageId: args.storage_id,
-			}).sqlQuery({
-				query: args.query,
-				params: args.params,
-				writable,
-			})
-			return {
-				ok: true as const,
-				storage_id: args.storage_id,
-				query: args.query,
-				columns: result.columns,
-				rows: result.rows,
-				row_count: result.rowCount,
-				rows_read: result.rowsRead,
-				rows_written: result.rowsWritten,
-				writable,
+			try {
+				const result = await storageRunnerRpc({
+					env: ctx.env,
+					userId: user.userId,
+					storageId: args.storage_id,
+				}).sqlQuery({
+					query: args.query,
+					params: args.params,
+					writable,
+				})
+				return {
+					ok: true as const,
+					storage_id: args.storage_id,
+					query: args.query,
+					columns: result.columns,
+					rows: result.rows,
+					row_count: result.rowCount,
+					rows_read: result.rowsRead,
+					rows_written: result.rowsWritten,
+					writable,
+				}
+			} catch (error) {
+				// User SQL / policy mistakes against their bucket — keep them on
+				// mcp-event and out of Sentry (KODY-CLOUDFLARE-44).
+				const message = getErrorMessage(error)
+				if (isUserStorageSqlCallerMessage(message)) {
+					throw new McpCallerError(message, { cause: error })
+				}
+				throw error
 			}
 		},
 	},

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -227,9 +227,27 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 				'The connector "home" is not connected. Kody cannot use this connector until it reconnects. Ask the user to start or reconnect the connector and then try again.',
 			),
 		})
+
+		// User SQL against a storage bucket (KODY-CLOUDFLARE-44). Plain Error
+		// form — Durable Object RPC loses subclass identity.
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'storage_query',
+			domain: 'storage',
+			capabilitySource: 'builtin',
+			conversationId: 'conv-storage-1',
+			storageId: 'storage-notes-1',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage: 'no such table: notes: SQLITE_ERROR',
+			context: {
+				sqlPreview: 'SELECT * FROM notes LIMIT 1',
+			},
+			cause: new Error('no such table: notes: SQLITE_ERROR'),
+		})
 	})
 
-	expect(payloads).toHaveLength(12)
+	expect(payloads).toHaveLength(13)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',
@@ -263,22 +281,6 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 
 		logMcpEvent({
 			...callerFailureBase,
-			capabilityName: 'storage_query',
-			domain: 'storage',
-			capabilitySource: 'builtin',
-			conversationId: 'conv-storage-1',
-			storageId: 'storage-notes-1',
-			failurePhase: 'handler',
-			errorName: 'Error',
-			errorMessage: 'no such table: notes: SQLITE_ERROR',
-			context: {
-				sqlPreview: 'SELECT * FROM notes LIMIT 1',
-			},
-			cause: new Error('no such table: notes: SQLITE_ERROR'),
-		})
-
-		logMcpEvent({
-			...callerFailureBase,
 			capabilityName: 'remote:home:bond_shade_set_position',
 			domain: 'remote:home',
 			capabilitySource: 'remote-connector',
@@ -292,7 +294,7 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 		})
 	})
 
-	expect(sentryMock.captureException).toHaveBeenCalledTimes(4)
+	expect(sentryMock.captureException).toHaveBeenCalledTimes(3)
 	expect(sentryMock.captureException).toHaveBeenNthCalledWith(
 		1,
 		expect.objectContaining({ message: 'platform handler blew up' }),
@@ -303,12 +305,6 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 	)
 	expect(sentryMock.captureException).toHaveBeenNthCalledWith(
 		3,
-		expect.objectContaining({
-			message: 'no such table: notes: SQLITE_ERROR',
-		}),
-	)
-	expect(sentryMock.captureException).toHaveBeenNthCalledWith(
-		4,
 		expect.objectContaining({
 			message:
 				'Remote capability "home:bond_shade_set_position" failed: timeout',
@@ -323,16 +319,6 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			hasUser: true,
 			errorMessage: 'platform handler blew up',
 			detail: undefined,
-		}),
-	)
-	expect(sentryMock.scope.setContext).toHaveBeenCalledWith(
-		'mcp',
-		expect.objectContaining({
-			conversationId: 'conv-storage-1',
-			storageId: 'storage-notes-1',
-			detail: {
-				sqlPreview: 'SELECT * FROM notes LIMIT 1',
-			},
 		}),
 	)
 	expect(sentryMock.captureMessage).not.toHaveBeenCalled()

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -5,6 +5,7 @@ import { CommunityActionError } from '#worker/community/errors.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { isRemoteConnectorUnavailableMessage } from '#worker/remote-connector/status.ts'
 import { isRepoLargeFileMessage } from '#worker/repo/large-file-policy.ts'
+import { isUserStorageSqlCallerMessage } from '#worker/storage-sql-caller-error.ts'
 import { isUserCodeError } from '#worker/user-code-error.ts'
 import { isMcpCallerError } from './caller-error.ts'
 
@@ -123,6 +124,18 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 			(entry) =>
 				entry instanceof Error &&
 				isRemoteConnectorUnavailableMessage(entry.message),
+		)
+	) {
+		return true
+	}
+	// User-authored SQL against a storage bucket (missing tables/columns,
+	// constraints, read-only policy). storage_query wraps these as
+	// McpCallerError; this message match covers plain Errors that still
+	// arrive via RPC without subclass identity.
+	if (
+		getErrorCauseChain(cause).some(
+			(entry) =>
+				entry instanceof Error && isUserStorageSqlCallerMessage(entry.message),
 		)
 	) {
 		return true

--- a/packages/worker/src/storage-sql-caller-error.node.test.ts
+++ b/packages/worker/src/storage-sql-caller-error.node.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest'
+import { isUserStorageSqlCallerMessage } from './storage-sql-caller-error.ts'
+
+test('isUserStorageSqlCallerMessage matches Durable Object SQL caller mistakes', () => {
+	expect(
+		isUserStorageSqlCallerMessage('no such table: articles: SQLITE_ERROR'),
+	).toBe(true)
+	expect(
+		isUserStorageSqlCallerMessage('no such column: title: SQLITE_ERROR'),
+	).toBe(true)
+	expect(
+		isUserStorageSqlCallerMessage(
+			'UNIQUE constraint failed: notes.id: SQLITE_CONSTRAINT',
+		),
+	).toBe(true)
+	expect(
+		isUserStorageSqlCallerMessage('storage.sql requires a non-empty query.'),
+	).toBe(true)
+	expect(
+		isUserStorageSqlCallerMessage(
+			'storage.sql params only support strings, numbers, booleans, and null.',
+		),
+	).toBe(true)
+	expect(
+		isUserStorageSqlCallerMessage(
+			'Read-only storage.sql only allows a single SELECT, EXPLAIN, or schema PRAGMA statement. Pass writable: true to allow multi-statement or mutating queries.',
+		),
+	).toBe(true)
+})
+
+test('isUserStorageSqlCallerMessage leaves platform lock and unrelated errors alone', () => {
+	expect(
+		isUserStorageSqlCallerMessage(
+			'D1_ERROR: NOSENTRY database is locked: SQLITE_BUSY',
+		),
+	).toBe(false)
+	expect(
+		isUserStorageSqlCallerMessage('database is locked: SQLITE_LOCKED'),
+	).toBe(false)
+	expect(isUserStorageSqlCallerMessage('platform handler blew up')).toBe(false)
+	expect(isUserStorageSqlCallerMessage('no such table: users')).toBe(false)
+})

--- a/packages/worker/src/storage-sql-caller-error.ts
+++ b/packages/worker/src/storage-sql-caller-error.ts
@@ -1,0 +1,20 @@
+/**
+ * Caller-clearable failures from user-authored SQL against a durable storage
+ * bucket (storage_query / storage.sql). Cloudflare Durable Object SQL surfaces
+ * SQLite failures as `<detail>: SQLITE_<CODE>` (for example
+ * `no such table: articles: SQLITE_ERROR`). Policy denials thrown by
+ * storage-runner before exec use stable `storage.sql …` / `Read-only
+ * storage.sql …` prefixes.
+ *
+ * Transient lock codes (BUSY / LOCKED) stay out of this matcher so platform
+ * contention is not mislabeled as a caller mistake.
+ */
+const userStorageSqliteErrorPattern =
+	/:\s*SQLITE_(?!BUSY\b|LOCKED\b)[A-Z0-9_]+\s*$/
+
+export function isUserStorageSqlCallerMessage(message: string) {
+	if (userStorageSqliteErrorPattern.test(message)) return true
+	if (message.startsWith('storage.sql ')) return true
+	if (message.startsWith('Read-only storage.sql ')) return true
+	return false
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Sentry from opening platform issues when agents run bad SQL against a user storage bucket (missing tables/columns, constraints, read-only policy denials).

## Summary

Fixes [KODY-CLOUDFLARE-44](https://kent-c-dodds-tech-llc.sentry.io/issues/7659620555/).

- `storage_query` against a missing table (`no such table: articles: SQLITE_ERROR`) is a **caller SQL mistake**, not a platform schema bug.
- Wrap Durable Object `SQLITE_*` failures (except BUSY/LOCKED) and `storage.sql` policy denials as `McpCallerError`.
- Skip the same signatures in MCP `isCallerFailure` so plain Errors that survive RPC stay on `mcp-event` logs only.

**Sibling [KODY-CLOUDFLARE-45](https://kent-c-dodds-tech-llc.sentry.io/issues/7659872394/) ("Blocking Operation")** does **not** share this root cause — it is a one-off Sentry performance warning about long-running DO subrequest spans with incomplete payload (`missing contexts.trace.span_id`). Handled separately as ignore.

## Testing

- Focused unit tests: storage-sql-caller-error, observability, storage-query (pass)
- Unit/lint/typecheck/mcp/format gates: pass locally
- E2E: first validate run flaked (oauth/connection refused); re-run passed 7/7

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `fbe699b0` · **Head:** `e654bf11`

**Classification:** extends — MCP observability treats user storage SQL failures as non-Sentry caller mistakes; `storage_query` wraps them as `McpCallerError`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `durable-storage` | assistant | extends — `storage_query` wraps DO SQLITE_* / policy denials as `McpCallerError` |
| `mcp-server` | surfaces | extends — `isCallerFailure` skips user storage SQL signatures |

### System map

Caller SQL mistakes against a storage bucket stay on mcp-event logs and out of Sentry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
  durableStorage["durable-storage<br/>Durable storage buckets"]:::extended
  mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
  durableStorage -->|"wrap SQLITE_* / storage.sql policy as McpCallerError"| mcpServer
  mcpServer -->|"isCallerFailure skips Sentry"| mcpServer
  classDef touched fill:#1a7f37,color:#fff
  classDef extended fill:#9a6700,color:#fff
  classDef added fill:#cf222e,color:#fff
  classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23d82678-dabb-44fd-ad13-1b81c5a64817?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23d82678-dabb-44fd-ad13-1b81c5a64817&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage query errors so user-correctable SQL issues are reported clearly while platform failures remain unchanged.
  * Prevented user-authored storage SQL errors from being sent to error monitoring.
  * Preserved handling for transient database lock and busy conditions.

* **Tests**
  * Added coverage for storage query error classification and monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->