### PR TITLE
Fix background package caller identity resolution

### DIFF
--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -10,7 +10,6 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 	await ensureUsersTestSchema({
 		db,
 		columns: [
-			'display_name',
 			'bio',
 			'avatar_key',
 			'profile_visibility',

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -276,7 +276,9 @@ test('getUserPlan resolves plans, defaults unresolved contexts to free, and reje
 		],
 	})
 	expect(await getUserPlan(db, { userId: 'user-1', email: null })).toBe('free')
-	expect(await getUserPlan(db, { userId: 'user-1', email: '' })).toBe('free')
+	expect(await getUserPlan(db, { userId: 'user-1', email: undefined })).toBe(
+		'free',
+	)
 	expect(await getUserPlan(db, { userId: 'user-1', email: plannedEmail })).toBe(
 		'free',
 	)
@@ -289,13 +291,12 @@ test('getUserPlan resolves plans, defaults unresolved contexts to free, and reje
 	expect(queries.at(-1)?.sql).toContain('email = ? AND stable_user_id = ?')
 	expect(queries.at(-1)?.params).toEqual([plannedEmail, userId])
 
-	// Package-job / workflow contexts persist email: '' — reverse-resolve by
-	// stable userId so entitlement checks use the real plan (not free).
-	expect(await getUserPlan(db, { userId, email: null })).toBe('pro')
-	expect(await getUserPlan(db, { userId, email: '' })).toBe('pro')
-	expect(await getUserPlan(db, { userId, email: '   ' })).toBe('pro')
-	expect(queries.at(-1)?.sql).toContain('FROM users WHERE stable_user_id = ?')
-	expect(queries.at(-1)?.params).toEqual([userId])
+	// Missing account emails fail closed without reverse-resolving identity.
+	const queryCount = queries.length
+	expect(await getUserPlan(db, { userId, email: null })).toBe('free')
+	expect(await getUserPlan(db, { userId, email: undefined })).toBe('free')
+	expect(await getUserPlan(db, { userId, email: '   ' })).toBe('free')
+	expect(queries).toHaveLength(queryCount)
 
 	// Mismatched email/stable-id pairs fail closed without warning.
 	expect(
@@ -562,7 +563,7 @@ test('assertWithinEntitlement enforces concurrent workflow limits without email 
 	await assertWithinEntitlement({
 		db: underMax.db,
 		userId,
-		email: '',
+		email: plannedEmail,
 		resource: 'concurrent_workflows',
 		getCurrent: async () => freeLimit,
 	})
@@ -573,7 +574,7 @@ test('assertWithinEntitlement enforces concurrent workflow limits without email 
 	const maxDenial = await assertWithinEntitlement({
 		db: atMax.db,
 		userId,
-		email: null,
+		email: plannedEmail,
 		resource: 'concurrent_workflows',
 		getCurrent: async () => maxLimit,
 	}).then(

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -33,13 +33,11 @@ const stableUserIdPattern = /^[a-f0-9]{64}$/i
  * strict {@link parseStoredPlanName} validation and throw if D1 violates the
  * plan CHECK constraint.
  *
- * The MCP `userId` is the account's stored `users.stable_user_id`. When an
- * email is provided, lookup requires the email + stable id pair so a
- * mismatched caller context cannot resolve another account's plan. When email
- * is absent (package-job / workflow / webhook contexts that persist
- * `email: ''`), reverse-resolve by stable userId alone so those paths enforce
- * the account's real plan instead of silently using `free`. Non-hex userIds
- * short-circuit without touching D1.
+ * The MCP `userId` is the account's stored `users.stable_user_id`. Lookup
+ * requires the real account email + stable id pair so a mismatched caller
+ * context cannot resolve another account's plan. Missing emails fail closed
+ * to `free` without a reverse lookup. Non-hex userIds short-circuit without
+ * touching D1.
  *
  * Effective plan = f(manual users.plan, users.stripe_plan): the higher-ranked
  * of the manual grant and Stripe subscription plan is returned (`max` ranks
@@ -53,17 +51,13 @@ export async function getUserPlan(
 	const email = input.email?.trim().toLowerCase()
 	if (!input.userId) return 'free'
 	if (!stableUserIdPattern.test(input.userId)) return 'free'
-	const row = email
-		? await db
-				.prepare(
-					`SELECT plan, stripe_plan FROM users WHERE email = ? AND stable_user_id = ?`,
-				)
-				.bind(email, input.userId)
-				.first<{ plan: string; stripe_plan: string | null }>()
-		: await db
-				.prepare(`SELECT plan, stripe_plan FROM users WHERE stable_user_id = ?`)
-				.bind(input.userId)
-				.first<{ plan: string; stripe_plan: string | null }>()
+	if (!email) return 'free'
+	const row = await db
+		.prepare(
+			`SELECT plan, stripe_plan FROM users WHERE email = ? AND stable_user_id = ?`,
+		)
+		.bind(email, input.userId)
+		.first<{ plan: string; stripe_plan: string | null }>()
 	if (!row) return 'free'
 	return resolveEffectivePlan(parseStoredPlanName(row.plan), row.stripe_plan)
 }
@@ -146,8 +140,6 @@ export async function getCachedUserPlan(
 	const email = input.email?.trim().toLowerCase()
 	if (!input.userId) return 'free'
 	if (!stableUserIdPattern.test(input.userId)) return 'free'
-	// Empty email is a distinct cache key from any concrete email; both paths
-	// share getUserPlan's reverse-resolve / pair-match semantics.
 	return await cachedUserPlans.getOrCreate(
 		db,
 		`${input.userId}\n${email ?? ''}`,
@@ -1025,11 +1017,8 @@ export type AssertWithinEntitlementInput = {
 	db: D1Database
 	userId: string
 	/**
-	 * Account email of the acting user when available. When present, plan
-	 * lookup requires the email + stable-id pair. When absent (package-job /
-	 * workflow contexts with `email: ''`), {@link getCachedUserPlan}
-	 * reverse-resolves by stable userId; unknown accounts still fail closed
-	 * to `free`.
+	 * Real account email of the acting user. Plan lookup requires the email +
+	 * stable-id pair; absent or unknown identities fail closed to `free`.
 	 */
 	email: string | null | undefined
 	resource: EntitlementResource

--- a/packages/worker/src/identity/background-mcp-user.ts
+++ b/packages/worker/src/identity/background-mcp-user.ts
@@ -1,0 +1,84 @@
+import { type McpUserContext } from '@kody-internal/shared/chat.ts'
+import { resolveDisplayName } from './username.ts'
+
+const backgroundMcpUserCacheTtlMs = 60_000
+const backgroundMcpUserCacheMaxEntries = 1_000
+
+type BackgroundMcpUserCacheEntry = {
+	value: Promise<McpUserContext>
+	expiresAtMs: number
+}
+
+const backgroundMcpUserCachesByDb = new WeakMap<
+	D1Database,
+	Map<string, BackgroundMcpUserCacheEntry>
+>()
+
+async function loadBackgroundMcpUser(
+	db: D1Database,
+	userId: string,
+): Promise<McpUserContext> {
+	const user = await db
+		.prepare(
+			`SELECT email, username, display_name
+			 FROM users
+			 WHERE stable_user_id = ?`,
+		)
+		.bind(userId)
+		.first<{
+			email: string
+			username: string
+			display_name: string | null
+		}>()
+	if (!user) {
+		throw new Error(`Background MCP user was not found: ${userId}`)
+	}
+	const profileDisplayName = user.display_name?.trim()
+	return {
+		userId,
+		email: user.email,
+		username: user.username,
+		displayName:
+			profileDisplayName ||
+			resolveDisplayName({
+				email: user.email,
+				username: user.username,
+			}),
+	}
+}
+
+/**
+ * Resolve account identity for background execution from its stable user id.
+ *
+ * The short per-binding cache deduplicates nested and bursty package calls
+ * while allowing account profile changes to propagate without isolate-wide
+ * invalidation machinery. Rejected reads are evicted immediately.
+ */
+export async function resolveBackgroundMcpUser(
+	db: D1Database,
+	userId: string,
+): Promise<McpUserContext> {
+	let cache = backgroundMcpUserCachesByDb.get(db)
+	if (!cache) {
+		cache = new Map()
+		backgroundMcpUserCachesByDb.set(db, cache)
+	}
+	const nowMs = Date.now()
+	const existing = cache.get(userId)
+	if (existing && existing.expiresAtMs > nowMs) {
+		return await existing.value
+	}
+	const value = loadBackgroundMcpUser(db, userId)
+	value.catch(() => {
+		if (cache.get(userId)?.value === value) cache.delete(userId)
+	})
+	if (cache.size >= backgroundMcpUserCacheMaxEntries) {
+		const oldestKey = cache.keys().next().value
+		if (oldestKey !== undefined) cache.delete(oldestKey)
+	}
+	cache.set(userId, {
+		value,
+		expiresAtMs: nowMs + backgroundMcpUserCacheTtlMs,
+	})
+	return await value
+}

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -92,6 +92,15 @@ vi.mock('./manager-client.ts', () => ({
 		jobManagerMockModule.getJobManagerDebugState(...args),
 }))
 
+vi.mock('#worker/identity/background-mcp-user.ts', () => ({
+	resolveBackgroundMcpUser: async (_db: D1Database, userId: string) => ({
+		userId,
+		email: `${userId}@example.com`,
+		username: userId,
+		displayName: userId,
+	}),
+}))
+
 vi.mock('#worker/storage-runner.ts', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>
 	return {

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -58,6 +58,7 @@ import {
 } from './types.ts'
 import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'
 import { assertWithinEntitlement } from '#worker/entitlements/service.ts'
+import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { assertPublishedSourceCanRebuildWithoutInstallingDeps } from '#worker/package-runtime/published-source-dependencies.ts'
 import {
@@ -632,20 +633,16 @@ async function cleanupAdHocJobSource(input: {
 	})
 }
 
-function createPackageJobCallerContext(input: {
+async function createPackageJobCallerContext(input: {
+	db: D1Database
 	baseUrl: string
 	userId: string
 	packageId: string
-}): PersistedJobCallerContext {
+}): Promise<PersistedJobCallerContext> {
 	return createMcpCallerContext({
 		baseUrl: input.baseUrl,
 		executionOrigin: 'background',
-		user: {
-			userId: input.userId,
-			email: '',
-			username: undefined,
-			displayName: `package:${input.packageId}`,
-		},
+		user: await resolveBackgroundMcpUser(input.db, input.userId),
 		storageContext: {
 			sessionId: null,
 			appId: input.packageId,
@@ -714,7 +711,8 @@ export async function syncPackageJobsForPackage(input: {
 						userId: input.userId,
 						job: updated,
 						callerContextJson: serializeCallerContext(
-							createPackageJobCallerContext({
+							await createPackageJobCallerContext({
+								db: input.env.APP_DB,
 								baseUrl: input.baseUrl,
 								userId: input.userId,
 								packageId: input.packageId,
@@ -756,7 +754,8 @@ export async function syncPackageJobsForPackage(input: {
 					userId: input.userId,
 					job: created,
 					callerContextJson: serializeCallerContext(
-						createPackageJobCallerContext({
+						await createPackageJobCallerContext({
+							db: input.env.APP_DB,
 							baseUrl: input.baseUrl,
 							userId: input.userId,
 							packageId: input.packageId,

--- a/packages/worker/src/package-invocations/background-identity.workers.test.ts
+++ b/packages/worker/src/package-invocations/background-identity.workers.test.ts
@@ -34,7 +34,13 @@ test('subscription execution exposes the owner account identity to meta_get_curr
 			stable_user_id
 		) VALUES (?, ?, ?, ?, ?)`,
 	)
-		.bind('subscription-owner', email, displayName, 'test-password-hash', userId)
+		.bind(
+			'subscription-owner',
+			email,
+			displayName,
+			'test-password-hash',
+			userId,
+		)
 		.run()
 
 	mocks.ensureModuleArtifact.mockResolvedValue({

--- a/packages/worker/src/package-invocations/background-identity.workers.test.ts
+++ b/packages/worker/src/package-invocations/background-identity.workers.test.ts
@@ -1,0 +1,138 @@
+import { env } from 'cloudflare:workers'
+import { expect, test, vi } from 'vitest'
+import { metaGetCurrentUserCapability } from '#mcp/capabilities/meta/meta-get-current-user.ts'
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { ensureUsersTestSchema } from '#worker/users-test-schema.ts'
+import { runSavedPackageModuleOnce } from './module-execution.ts'
+
+const mocks = vi.hoisted(() => ({
+	ensureModuleArtifact: vi.fn(),
+	runBundledModuleWithRegistry: vi.fn(),
+}))
+
+vi.mock('./module-artifacts.ts', async (importOriginal) => ({
+	...(await importOriginal<typeof import('./module-artifacts.ts')>()),
+	ensureModuleArtifact: mocks.ensureModuleArtifact,
+}))
+
+vi.mock('#mcp/run-kody-registry.ts', async (importOriginal) => ({
+	...(await importOriginal<typeof import('#mcp/run-kody-registry.ts')>()),
+	runBundledModuleWithRegistry: mocks.runBundledModuleWithRegistry,
+}))
+
+test('subscription execution exposes the owner account identity to meta_get_current_user', async () => {
+	const userId = 'a'.repeat(64)
+	const email = 'subscription-owner@example.com'
+	const displayName = 'Subscription Owner'
+	await ensureUsersTestSchema({ db: env.APP_DB, columns: ['display_name'] })
+	await env.APP_DB.prepare(
+		`INSERT INTO users (
+			username,
+			email,
+			display_name,
+			password_hash,
+			stable_user_id
+		) VALUES (?, ?, ?, ?, ?)`,
+	)
+		.bind('subscription-owner', email, displayName, 'test-password-hash', userId)
+		.run()
+
+	mocks.ensureModuleArtifact.mockResolvedValue({
+		artifact: {
+			version: 1,
+			kind: 'module',
+			artifactName: 'subscription:email.message.received',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			entryPoint: 'src/email-message-received.ts',
+			mainModule: 'dist/subscription.js',
+			modules: {
+				'dist/subscription.js':
+					'export default async function main() { return null }',
+			},
+			dependencies: [],
+			packageContext: {
+				packageId: 'package-1',
+				kodyId: 'article-to-audio',
+				sourceId: 'source-1',
+			},
+			serviceContext: null,
+			createdAt: '2026-08-08T00:00:00.000Z',
+		},
+		source: {
+			id: 'source-1',
+			user_id: userId,
+			entity_kind: 'package',
+			entity_id: 'package-1',
+			repo_id: 'repo-1',
+			published_commit: 'commit-1',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-08-08T00:00:00.000Z',
+			updated_at: '2026-08-08T00:00:00.000Z',
+		},
+	})
+	mocks.runBundledModuleWithRegistry.mockImplementation(
+		async (_env: Env, callerContext: McpCallerContext) => ({
+			result: await metaGetCurrentUserCapability.handler(
+				{},
+				{ env, callerContext },
+			),
+			logs: [],
+		}),
+	)
+
+	const outcome = await runSavedPackageModuleOnce({
+		env,
+		baseUrl: 'https://kody.dev',
+		actor: {
+			tokenId: 'internal:email-subscriptions',
+			userId,
+		},
+		savedPackage: {
+			id: 'package-1',
+			userId,
+			name: '@example/article-to-audio',
+			kodyId: 'article-to-audio',
+			description: 'Article to audio',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-1',
+			hasApp: false,
+			hidden: false,
+			isPrivate: true,
+			createdAt: '2026-08-08T00:00:00.000Z',
+			updatedAt: '2026-08-08T00:00:00.000Z',
+		},
+		invocationName: 'subscription:email.message.received',
+		moduleSelector: {
+			kind: 'subscription',
+			topic: 'email.message.received',
+		},
+		params: { event: 'email.message.received' },
+		idempotencyKey: null,
+		invocationId: null,
+		source: 'email',
+		topic: 'email.message.received',
+		notFoundCode: 'subscription_not_found',
+		toolFactories: {
+			createPackageRuntimeInvokeTools: vi.fn(() => ({}) as never),
+			createPackageEventTools: vi.fn(() => ({}) as never),
+		},
+	})
+
+	expect(outcome).toMatchObject({
+		kind: 'completed',
+		response: {
+			status: 200,
+			body: {
+				result: {
+					user_id: userId,
+					email,
+					display_name: displayName,
+				},
+			},
+		},
+	})
+})

--- a/packages/worker/src/package-invocations/background-identity.workers.test.ts
+++ b/packages/worker/src/package-invocations/background-identity.workers.test.ts
@@ -24,7 +24,7 @@ test('subscription execution exposes the owner account identity to meta_get_curr
 	const userId = 'a'.repeat(64)
 	const email = 'subscription-owner@example.com'
 	const displayName = 'Subscription Owner'
-	await ensureUsersTestSchema({ db: env.APP_DB, columns: ['display_name'] })
+	await ensureUsersTestSchema({ db: env.APP_DB })
 	await env.APP_DB.prepare(
 		`INSERT INTO users (
 			username,

--- a/packages/worker/src/package-invocations/common.ts
+++ b/packages/worker/src/package-invocations/common.ts
@@ -19,8 +19,7 @@ import { type PackageInvocationStoredResponse } from './repo.ts'
 export type PackageInvocationTokenScope = {
 	tokenId: string
 	userId: string
-	email: string
-	displayName: string
+	email?: string
 	packageIds?: Array<string>
 	packageKodyIds?: Array<string>
 	exportNames?: Array<string>
@@ -47,8 +46,6 @@ export type PackageInvocationResponse = PackageInvocationStoredResponse
 export type PackageInvocationActor = {
 	tokenId: string
 	userId: string
-	email: string
-	displayName: string
 	remoteConnectors?: Array<RemoteConnectorRef> | null
 }
 

--- a/packages/worker/src/package-invocations/http-invoke.ts
+++ b/packages/worker/src/package-invocations/http-invoke.ts
@@ -69,8 +69,6 @@ export async function invokePackageExportForExecuteRuntime(input: {
 	baseUrl: string
 	caller: {
 		userId: string
-		email: string
-		displayName: string
 		remoteConnectors?: Array<RemoteConnectorRef> | null
 	}
 	request: PackageInvocationRequest
@@ -118,8 +116,6 @@ export async function invokePackageExportForExecuteRuntime(input: {
 	const actor = {
 		tokenId: internalExecuteRuntimeInvokeTokenId,
 		userId: input.caller.userId,
-		email: input.caller.email,
-		displayName: input.caller.displayName || input.caller.email || 'execute',
 		remoteConnectors: input.caller.remoteConnectors ?? null,
 	}
 	const shared = {
@@ -155,8 +151,6 @@ export async function invokePackageExportForPackageRuntime(input: {
 	baseUrl: string
 	caller: {
 		userId: string
-		email: string
-		displayName: string
 		remoteConnectors?: Array<RemoteConnectorRef> | null
 		packageContext: PackageRuntimeContext
 	}
@@ -198,10 +192,6 @@ export async function invokePackageExportForPackageRuntime(input: {
 		actor: {
 			tokenId: `${internalPackageRuntimeInvokeTokenId}:${input.caller.packageContext.packageId}`,
 			userId: input.caller.userId,
-			email: input.caller.email,
-			displayName:
-				input.caller.displayName ||
-				`package:${input.caller.packageContext.kodyId}`,
 			remoteConnectors: input.caller.remoteConnectors ?? null,
 		},
 		savedPackage,
@@ -313,8 +303,6 @@ export async function invokePackageExportWithToolFactories(input: {
 		actor: {
 			tokenId: input.token.tokenId,
 			userId: input.token.userId,
-			email: input.token.email,
-			displayName: input.token.displayName,
 			remoteConnectors: input.token.remoteConnectors ?? null,
 		},
 		savedPackage,

--- a/packages/worker/src/package-invocations/http.node.test.ts
+++ b/packages/worker/src/package-invocations/http.node.test.ts
@@ -395,7 +395,6 @@ test('package invocation API validates requests and invokes exports with scoped 
 			tokenId: 'discord-gateway',
 			userId: expectedUserId,
 			email: 'me@example.com',
-			displayName: 'me',
 			packageIds: [],
 			packageKodyIds: ['discord-gateway'],
 			exportNames: ['./dispatch-message-created'],

--- a/packages/worker/src/package-invocations/http.ts
+++ b/packages/worker/src/package-invocations/http.ts
@@ -149,7 +149,6 @@ async function resolveTokenScope(input: {
 		tokenId: record.id,
 		userId: record.user_id,
 		email: record.email,
-		displayName: record.display_name,
 		packageIds: record.packageIds,
 		packageKodyIds: record.packageKodyIds,
 		exportNames: record.exportNames,

--- a/packages/worker/src/package-invocations/module-execution.ts
+++ b/packages/worker/src/package-invocations/module-execution.ts
@@ -13,6 +13,7 @@ import {
 	getEmailMessageWithAttachmentsById,
 } from '#worker/email/service.ts'
 import { getInternalEmailMessageById } from '#worker/email/mailbox-internal-read.ts'
+import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
 import {
 	buildPackageInvocationStorageId,
 	createRepoContext,
@@ -135,12 +136,10 @@ export async function runSavedPackageModuleOnce(
 		const callerContext = createMcpCallerContext({
 			baseUrl: input.baseUrl,
 			executionOrigin: 'background',
-			user: {
-				userId: input.actor.userId,
-				email: input.actor.email,
-				username: undefined,
-				displayName: input.actor.displayName,
-			},
+			user: await resolveBackgroundMcpUser(
+				input.env.APP_DB,
+				input.actor.userId,
+			),
 			storageContext: {
 				sessionId: null,
 				appId: input.savedPackage.id,

--- a/packages/worker/src/package-invocations/runtime-tool-factories.ts
+++ b/packages/worker/src/package-invocations/runtime-tool-factories.ts
@@ -114,8 +114,6 @@ function createPackageInvokeTools(input: {
 					baseUrl: input.baseUrl,
 					caller: {
 						userId: user.userId,
-						email: user.email ?? '',
-						displayName: user.displayName ?? '',
 						remoteConnectors: input.callerContext.remoteConnectors ?? null,
 						packageContext,
 					},
@@ -137,8 +135,6 @@ function createPackageInvokeTools(input: {
 					baseUrl: input.baseUrl,
 					caller: {
 						userId: user.userId,
-						email: user.email ?? '',
-						displayName: user.displayName ?? '',
 						remoteConnectors: input.callerContext.remoteConnectors ?? null,
 					},
 					request: {

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -102,6 +102,15 @@ vi.mock('#worker/run-records/package-subscriptions.ts', () => ({
 		repoMockModule.dispatchRunErrorSubscriptionEvents(...args),
 }))
 
+vi.mock('#worker/identity/background-mcp-user.ts', () => ({
+	resolveBackgroundMcpUser: async (_db: D1Database, userId: string) => ({
+		userId,
+		email: 'owner@example.com',
+		username: 'owner',
+		displayName: 'Owner',
+	}),
+}))
+
 type FakeLedgerRow = {
 	id: string
 	tokenId: string
@@ -1679,8 +1688,8 @@ test('execute runtime invoke invokes target package with execute provenance', as
 	expect(runCall?.[1]).toMatchObject({
 		user: {
 			userId: 'user-123',
-			email: 'me@example.com',
-			displayName: 'Me',
+			email: 'owner@example.com',
+			displayName: 'Owner',
 		},
 		storageContext: {
 			appId: 'pkg-subscriber',
@@ -2571,7 +2580,8 @@ test('invokePackageSubscription uses the normal capability registry with package
 			baseUrl: 'https://kody.dev',
 			user: expect.objectContaining({
 				userId: 'user-123',
-				displayName: 'package:discord-gateway',
+				email: 'owner@example.com',
+				displayName: 'Owner',
 			}),
 			storageContext: {
 				sessionId: null,

--- a/packages/worker/src/package-invocations/service.ts
+++ b/packages/worker/src/package-invocations/service.ts
@@ -138,7 +138,6 @@ export async function invokePackageSubscription(input: {
 	idempotencyKey: string
 	source?: string | null
 	actorTokenId?: string
-	actorDisplayName?: string
 	runtimeInvokeDepth?: number
 	waitUntil?: (promise: Promise<unknown>) => void
 }) {

--- a/packages/worker/src/package-invocations/subscription-dispatch.ts
+++ b/packages/worker/src/package-invocations/subscription-dispatch.ts
@@ -228,7 +228,6 @@ export async function deliverPackageEventWithToolFactories(input: {
 				}),
 				source: `package:${message.source.kodyId}`,
 				actorTokenId: `${internalPackageEventSubscriptionTokenId}:${message.source.packageId}`,
-				actorDisplayName: `package:${message.source.kodyId}`,
 				runtimeInvokeDepth: message.invokeDepth,
 				toolFactories: input.toolFactories,
 				waitUntil: input.waitUntil,
@@ -420,7 +419,6 @@ export async function invokePackageSubscriptionWithToolFactories(input: {
 	idempotencyKey: string
 	source?: string | null
 	actorTokenId?: string
-	actorDisplayName?: string
 	runtimeInvokeDepth?: number
 	toolFactories: PackageRuntimeToolFactories
 	waitUntil?: (promise: Promise<unknown>) => void
@@ -441,9 +439,6 @@ export async function invokePackageSubscriptionWithToolFactories(input: {
 		actor: {
 			tokenId: input.actorTokenId ?? internalEmailSubscriptionTokenId,
 			userId: input.savedPackage.userId,
-			email: '',
-			displayName:
-				input.actorDisplayName ?? `package:${input.savedPackage.kodyId}`,
 		},
 		savedPackage: input.savedPackage,
 		invocationName: buildPackageSubscriptionArtifactName(topic),

--- a/packages/worker/src/package-retrievers/service.node.test.ts
+++ b/packages/worker/src/package-retrievers/service.node.test.ts
@@ -37,6 +37,15 @@ vi.mock('#worker/package-invocations/service.ts', () => ({
 	createPackageRuntimeInvokeTools: mockFns.createPackageRuntimeInvokeTools,
 }))
 
+vi.mock('#worker/identity/background-mcp-user.ts', () => ({
+	resolveBackgroundMcpUser: async (_db: D1Database, userId: string) => ({
+		userId,
+		email: `${userId}@example.com`,
+		username: userId,
+		displayName: userId,
+	}),
+}))
+
 function createRetrieverEntry(input: {
 	packageId: string
 	kodyId: string

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -2,6 +2,7 @@ import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { runWithDynamicWorkerEvaluationBudget } from '#mcp/executor.ts'
 import { runBundledModuleWithRegistry } from '#mcp/run-kody-registry.ts'
+import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
@@ -144,12 +145,7 @@ async function invokeRetriever(input: {
 	const callerContext = createMcpCallerContext({
 		baseUrl: input.baseUrl,
 		executionOrigin: 'background',
-		user: {
-			userId: input.userId,
-			email: '',
-			username: undefined,
-			displayName: '',
-		},
+		user: await resolveBackgroundMcpUser(input.env.APP_DB, input.userId),
 		storageContext: {
 			sessionId: null,
 			appId: input.entry.packageId,

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -10,6 +10,7 @@ import {
 import { persistPublishedSourceSnapshot } from './published-runtime-artifacts.ts'
 import { persistPublishedBundleArtifact } from './published-bundle-artifacts.ts'
 import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidental-runtime-warnings.ts'
+import { ensureUsersTestSchema } from '#worker/users-test-schema.ts'
 
 async function runSql(sql: string, ...values: Array<unknown>) {
 	await env.APP_DB.prepare(sql)
@@ -314,6 +315,15 @@ test(
 		await ensureSavedPackageArtifactSchema()
 		const unique = crypto.randomUUID()
 		const userId = `user-${unique}`
+		await ensureUsersTestSchema({ db: env.APP_DB })
+		await runSql(
+			`INSERT INTO users (username, email, password_hash, stable_user_id)
+			 VALUES (?, ?, ?, ?)`,
+			`worker-${unique}`,
+			`worker-${unique}@example.com`,
+			'test-password-hash',
+			userId,
+		)
 		const sourceId = `source-${unique}`
 		const packageId = `pkg-${unique}`
 		const publishedCommit = `commit-${unique}`

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -64,6 +64,15 @@ vi.mock('#worker/package-invocations/service.ts', () => ({
 		mockModule.createPackageRuntimeInvokeTools(...args),
 }))
 
+vi.mock('#worker/identity/background-mcp-user.ts', () => ({
+	resolveBackgroundMcpUser: async (_db: D1Database, userId: string) => ({
+		userId,
+		email: `${userId}@example.com`,
+		username: userId,
+		displayName: userId,
+	}),
+}))
+
 const usageModule = await import('#worker/usage/record-usage.ts')
 const recordUsageSpy = vi.spyOn(usageModule, 'recordUsage')
 

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/cloudflare'
 import { DurableObject } from 'cloudflare:workers'
 import { z } from 'zod'
 import { createMcpCallerContext } from '#mcp/context.ts'
+import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
 import {
 	userMeterNamespace,
 	userMeterRpc,
@@ -950,12 +951,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		const callerContext = createMcpCallerContext({
 			baseUrl: binding.baseUrl,
 			executionOrigin: 'background',
-			user: {
-				userId: binding.userId,
-				email: '',
-				username: undefined,
-				displayName: `package:${binding.packageId}`,
-			},
+			user: await resolveBackgroundMcpUser(this.env.APP_DB, binding.userId),
 			storageContext: {
 				sessionId: null,
 				appId: binding.packageId,

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -2248,8 +2248,8 @@ test('createDynamicCallableWorkflow enforces concurrent workflow entitlements ac
 	})
 	expect(allowed.ok).toBe(true)
 
-	// Package jobs persist email: '' — reverse-resolve by stable userId so a
-	// max-plan account is not wrongly capped at the free concurrent limit.
+	// Background workflow callers carry the real account email, so a max-plan
+	// account is not wrongly capped at the free concurrent limit.
 	runRecordMocks.resetProjections()
 	await seedActiveWorkflowProjections({ userId, count: freeLimit })
 	const maxAllowed = await createDynamicCallableWorkflow({
@@ -2261,7 +2261,7 @@ test('createDynamicCallableWorkflow enforces concurrent workflow entitlements ac
 			RUN_LOG: {} as DurableObjectNamespace,
 		} as Env,
 		userId,
-		userEmail: '',
+		userEmail: email,
 		body: {
 			...body,
 			idempotencyKey: 'plan-limit-blank-email-max-key',

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -292,6 +292,15 @@ vi.mock('#mcp/run-kody-registry.ts', () => ({
 		invocationMocks.runModuleWithRegistry(...args),
 }))
 
+vi.mock('#worker/identity/background-mcp-user.ts', () => ({
+	resolveBackgroundMcpUser: async (_db: D1Database, userId: string) => ({
+		userId,
+		email: `${userId}@example.com`,
+		username: userId,
+		displayName: userId,
+	}),
+}))
+
 vi.mock('#worker/run-records/service.ts', () => ({
 	beginRunRecord: (...args: Array<unknown>) =>
 		runRecordMocks.beginRunRecord(...args),

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -1578,10 +1578,7 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 						env: this.env,
 					}),
 					executionOrigin: 'background',
-					user: await resolveBackgroundMcpUser(
-						this.env.APP_DB,
-						payload.userId,
-					),
+					user: await resolveBackgroundMcpUser(this.env.APP_DB, payload.userId),
 					storageContext: payload.packageContext
 						? {
 								sessionId: null,

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -27,6 +27,7 @@ import {
 import { listAttachedRemoteConnectorRefs } from '#worker/remote-connector/settings-service.ts'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
 import { assertWithinEntitlement } from '#worker/entitlements/service.ts'
+import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
 import {
 	beginRunRecord,
@@ -1494,8 +1495,6 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 				token: {
 					tokenId: packageWorkflowTokenId,
 					userId: payload.userId,
-					email: '',
-					displayName: `package:${payload.packageId}`,
 					packageIds: [payload.packageId],
 					packageKodyIds: [payload.kodyId],
 					exportNames: [payload.exportName],
@@ -1579,12 +1578,10 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 						env: this.env,
 					}),
 					executionOrigin: 'background',
-					user: {
-						userId: payload.userId,
-						email: '',
-						username: undefined,
-						displayName: `workflow:${payload.workflowName}`,
-					},
+					user: await resolveBackgroundMcpUser(
+						this.env.APP_DB,
+						payload.userId,
+					),
 					storageContext: payload.packageContext
 						? {
 								sessionId: null,

--- a/packages/worker/src/package-runtime/realtime-session.ts
+++ b/packages/worker/src/package-runtime/realtime-session.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from 'cloudflare:workers'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { buildFacetName } from '#mcp/app-runner-facet-names.ts'
+import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
 import { getSavedPackageById } from '#worker/package-registry/repo.ts'
 import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
 import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
@@ -313,12 +314,10 @@ async function resolvePackageAppWorkerBuildInput(input: {
 	const callerContext = createMcpCallerContext({
 		baseUrl: input.binding.baseUrl,
 		executionOrigin: 'background',
-		user: {
-			userId: input.binding.userId,
-			email: '',
-			username: undefined,
-			displayName: `package:${input.binding.packageId}`,
-		},
+		user: await resolveBackgroundMcpUser(
+			input.env.APP_DB,
+			input.binding.userId,
+		),
 		storageContext: {
 			sessionId: null,
 			appId: input.binding.packageId,

--- a/packages/worker/src/users-test-schema.ts
+++ b/packages/worker/src/users-test-schema.ts
@@ -20,7 +20,6 @@ export type UsersTestSchemaColumn =
 	| 'stripe_customer_id'
 	| 'stripe_plan'
 	| 'stripe_plan_refreshed_at'
-	| 'display_name'
 	| 'bio'
 	| 'avatar_key'
 	| 'profile_visibility'
@@ -57,9 +56,10 @@ const timestampColumns = [
 
 /**
  * Mirrors migrations 0052 + 0075 (`stable_user_id` NOT NULL + unique index),
- * 0081 + 0083 (`plan` NOT NULL DEFAULT `'free'`), account deletion/suspension
- * state, and the account write lease counters. Non-historical seeds may set
- * `'max'` or `'free'` explicitly when plan matters.
+ * 0081 + 0083 (`plan` NOT NULL DEFAULT `'free'`), account
+ * deletion/suspension state, profile display names, and the account write
+ * lease counters. Non-historical seeds may set `'max'` or `'free'` explicitly
+ * when plan matters.
  */
 const alwaysAdditiveColumns: Record<string, UsersColumnDefinition> = {
 	// Preexisting shared tables: ALTER ADD COLUMN cannot express NOT NULL
@@ -71,6 +71,7 @@ const alwaysAdditiveColumns: Record<string, UsersColumnDefinition> = {
 	email_outbound_paused_at: { create: 'TEXT' },
 	active_write_count: { create: 'INTEGER NOT NULL DEFAULT 0' },
 	active_write_expires_at: { create: 'TEXT' },
+	display_name: { create: 'TEXT' },
 }
 
 /**
@@ -88,7 +89,6 @@ const optionalColumns: Record<UsersTestSchemaColumn, UsersColumnDefinition> = {
 	stripe_customer_id: { create: 'TEXT' },
 	stripe_plan: { create: 'TEXT' },
 	stripe_plan_refreshed_at: { create: 'TEXT' },
-	display_name: { create: 'TEXT' },
 	bio: { create: 'TEXT' },
 	avatar_key: { create: 'TEXT' },
 	profile_visibility: {

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -255,8 +255,6 @@ async function dispatchWebhookInvocation(input: {
 		token: {
 			tokenId: `internal:webhook:${input.endpoint.id}`,
 			userId: input.endpoint.userId,
-			email: '',
-			displayName: `webhook:${input.packageKodyId}:${input.endpoint.webhookName}`,
 			packageIds: [input.endpoint.packageId],
 			packageKodyIds: [input.packageKodyId],
 			exportNames: [input.exportName],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fix field-report finding K-01 so package-owned background executions expose the owner's real account identity instead of fabricated empty-email contexts.

## Summary

- remove caller-supplied email and display name from package invocation actors
- resolve canonical email, username, and display name from the users table by stable user ID with a bounded 60-second per-D1-binding cache
- use resolved account identity for subscriptions, jobs, workflows, services, retrievers, webhooks, and realtime sessions
- remove entitlement fallback behavior that reverse-resolved callers with missing emails
- preserve token IDs for credential attribution and package/workflow labels in run metadata rather than user identity

## Testing

- `npm run validate` — green (1,934 unit/Workers tests, 4 MCP tests, 7 Playwright tests)
- focused node suites — 89 passed
- focused Workers regression — verifies a subscription module execution calls real `meta_get_current_user` and returns the stored owner email/display name
- `rg "email: ''" packages/worker/src` — no matches

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1916ffea` · **Head:** `cfe7c7cb`

**Classification:** extends — background execution identity construction now resolves canonical account fields from D1, changing the caller-context contract across package-owned surfaces.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-events-dispatch-queue` | storage | extends — subscription actors carry attribution only |
| `jobs` | assistant | extends — persisted package-job contexts use canonical identity |
| `workflows` | assistant | extends — workflow contexts use canonical identity |
| `package-services` | assistant | extends — service contexts use canonical identity |
| `realtime-sessions` | assistant | extends — realtime contexts use canonical identity |
| `webhooks` | assistant | extends — webhook tokens no longer fabricate identity |
| `entitlements` | auth | extends — missing-email callers fail closed without reverse lookup |

### System map

Background package surfaces resolve the stable user ID through one cached D1 identity lookup before constructing the MCP caller context.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	surfaces["jobs / workflows / webhooks / services / realtime<br/>Package-owned background surfaces"]:::extended
	dispatch["package-events-dispatch-queue<br/>Package events dispatch queue"]:::extended
	identity["canonical background identity<br/>Cached users-table resolver"]:::extended
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	surfaces -->|"stable userId"| identity
	dispatch -->|"stable userId + token attribution"| identity
	identity -->|"real email, username, display name"| surfaces
	identity -->|"email + stable-id plan check"| entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

- Per-user isolation remains keyed by the stable user ID.
- Credential attribution remains in `tokenId`; package labels remain run metadata rather than account identity.

</details>

<!-- system-recap:end -->

## Conductor report

Track A report: STATUS(done); PR https://github.com/kentcdodds/kody/pull/1307; merged? yes, squash commit `9a8ef157ff92cdfd69fb143a9be6ea30595bc530`; deploy status success via https://github.com/kentcdodds/kody/actions/runs/31244325423 (superseding main commit `17fd0bc8` contains Track A); evidence: `npm run validate` green, all PR CI green, K-01 Workers regression green, and production deploy green; remains: none.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc969f5c-6d5e-48e6-992a-5636d335cde5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc969f5c-6d5e-48e6-992a-5636d335cde5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

