### PR TITLE
fix: make package app routes and runs diagnosable

### DIFF
--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -65,6 +65,23 @@ This package exists to ...
 Keep the section concise. It should explain why the package exists and what
 success means for the user, not duplicate every implementation detail.
 
+## Package app routing
+
+Hosted package apps are mounted at `/@username/packages/<kody-id>/<path>`. The
+app receives only `/<path>` in its fetch request. Root-relative links such as
+`/audio/123` therefore escape the mount and are not routed back to the package
+app.
+
+Import `packageContext` from `kody:runtime` and build every in-app link,
+redirect, share/email URL, and OAuth callback against its public base:
+
+- `packageContext.hostedUrl` is the full public URL of the app mount.
+- `packageContext.appBasePath` is the origin-relative mount path.
+
+Kody derives both fields from the package's current serving username and
+`kody.id`, including after a rename or fork. Do not hard-code either path
+segment.
+
 ## `kody.description` (short public tagline)
 
 `package.json#kody.description` is a **short public tagline**, not a feature

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -360,6 +360,32 @@ session handoff to that origin. Package author JavaScript cannot use the
 first-party `kody_session` cookie or call authenticated Kody pages as the
 signed-in user.
 
+Package app URLs follow this mount contract:
+`/@username/packages/<kody-id>/<path>`. Kody removes the mount before forwarding
+the request, so an app sees `/<path>`. A root-relative browser URL such as
+`/audio/123` escapes the mount and is not dispatched to the app. Build in-app
+links, redirects, shared links, email links, and OAuth callback URLs against the
+public base exposed by `packageContext`:
+
+```ts
+import { packageContext } from 'kody:runtime'
+
+if (!packageContext?.hostedUrl) {
+	throw new Error('This module must run as a package app.')
+}
+
+const audioUrl = new URL(
+	`${packageContext.appBasePath}/audio/123`,
+	packageContext.hostedUrl,
+)
+```
+
+For package apps, `packageContext.hostedUrl` is the full public URL of the app
+mount and `packageContext.appBasePath` is its origin-relative mount path. Both
+are derived from the username and `kody.id` currently serving the package, so
+they remain correct after a rename or fork. Other saved-package runtime surfaces
+may omit these app-specific fields.
+
 Use the package app model when the package needs:
 
 - interactive UI

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -384,6 +384,8 @@ export async function servePackageAppRequest(input: {
 			},
 			runtime: {
 				callerContext,
+				servingUsername: packagePath.username,
+				hostedOrigin: requestUrl.origin,
 			},
 		})
 		entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName)

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -82,6 +82,19 @@ function createPackageAppOriginConfigurationErrorResponse(message: string) {
 	})
 }
 
+function createUnmatchedPackageAppPathResponse() {
+	return new Response(
+		'Package app URL not found. Package app URLs use /@username/packages/<kody-id>/<path>. Requests outside a package app mount are not dispatched to any app.',
+		{
+			status: 404,
+			headers: {
+				'Cache-Control': 'no-store',
+				'Content-Type': 'text/plain; charset=utf-8',
+			},
+		},
+	)
+}
+
 /**
  * Terminal response for a package-app request with no usable package-app
  * session. Deliberately not a redirect back to the app origin: only the visitor
@@ -211,7 +224,7 @@ async function handleRequestOnPackageAppOrigin(input: {
 		if (url.pathname === '/') {
 			return redirectResponse({ location: `${appBaseUrl}/`, status: 302 })
 		}
-		return new Response('Not Found', { status: 404 })
+		return createUnmatchedPackageAppPathResponse()
 	}
 
 	const handoffToken = url.searchParams.get(packageAppHandoffQueryParam)

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -220,7 +220,11 @@ test('hosted package apps move to the package-app origin behind a single-use han
 			headers: { Cookie: `${packageSessionCookie}; ${sessionCookie}` },
 		})
 		expect(response.status, `expected 404 for ${path}`).toBe(404)
-		await expect(response.text()).resolves.toBe('Not Found')
+		const body = await response.text()
+		expect(body).toContain('/@username/packages/<kody-id>/<path>')
+		expect(body).toContain(
+			'Requests outside a package app mount are not dispatched to any app.',
+		)
 	}
 
 	// 8. The bare package-app origin is a plausible bookmark; send it home.

--- a/packages/worker/src/mcp/package-app-storage.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/package-app-storage.mcp-e2e.test.ts
@@ -27,6 +27,10 @@ type AppStorageResponse = {
 	bucketId: string
 	read: unknown
 	sqlRows: Array<Record<string, unknown>>
+	packageContext: {
+		appBasePath: string
+		hostedUrl: string
+	}
 }
 
 function readExecuteResult<T>(toolResult: CallToolResult): T {
@@ -67,7 +71,7 @@ function buildPackageFiles(username: string) {
 		},
 		{
 			path: 'src/app.ts',
-			content: `import { packageStorage } from 'kody:runtime'
+			content: `import { packageContext, packageStorage } from 'kody:runtime'
 
 export default {
 	async fetch() {
@@ -87,7 +91,8 @@ export default {
 			bucketId: storage.id,
 			read,
 			sqlRows: sqlResult.rows,
-		})
+			packageContext,
+		}, { status: 201 })
 	},
 }
 `,
@@ -128,7 +133,8 @@ export default async function main(input) {
 		const expectedBucketId = `package:${encodeURIComponent(packageId)}`
 
 		const cookie = await createAppSessionCookie(server.origin, database.user)
-		const appUrl = `${server.origin}/@${username}/packages/${kodyId}`
+		const appBasePath = `/@${username}/packages/${kodyId}`
+		const appUrl = `${server.origin}${appBasePath}?audio=1`
 
 		const firstResponse = await fetch(appUrl, {
 			headers: { Cookie: cookie, Accept: 'application/json' },
@@ -138,11 +144,15 @@ export default async function main(input) {
 		expect(
 			firstResponse.status,
 			`first app fetch failed: ${firstBodyText}`,
-		).toBe(200)
+		).toBe(201)
 		const firstBody = JSON.parse(firstBodyText) as AppStorageResponse
 		expect(firstBody.bucketId).toBe(expectedBucketId)
 		expect(firstBody.read).toBe(markerValue)
 		expect(firstBody.sqlRows).toEqual([{ id: 1, note: markerValue }])
+		expect(firstBody.packageContext).toMatchObject({
+			appBasePath,
+			hostedUrl: `${server.origin}${appBasePath}`,
+		})
 
 		const secondResponse = await fetch(appUrl, {
 			headers: { Cookie: cookie, Accept: 'application/json' },
@@ -152,7 +162,7 @@ export default async function main(input) {
 		expect(
 			secondResponse.status,
 			`second app fetch failed: ${secondBodyText}`,
-		).toBe(200)
+		).toBe(201)
 		const secondBody = JSON.parse(secondBodyText) as AppStorageResponse
 		expect(secondBody.bucketId).toBe(expectedBucketId)
 		expect(secondBody.read).toBe(markerValue)

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -65,6 +65,27 @@ async function createWorkflowsProxyForTest(runtimeBridge: unknown) {
 	}
 }
 
+async function collectQueryParamNamesForTest(url: URL) {
+	const sourceText = await readFile(
+		new URL('./package-app.ts', import.meta.url),
+		'utf8',
+	)
+	const start = sourceText.indexOf('function collectQueryParamNames(url) {')
+	const end = sourceText.indexOf('\n\nasync function startRuntimeRun', start)
+	if (start < 0 || end < 0) {
+		throw new Error('collectQueryParamNames source was not found.')
+	}
+	const functionSource = sourceText
+		.slice(start, end)
+		.replaceAll('\\\\', '\\')
+		.replaceAll('\\`', '`')
+		.replaceAll('\\${', '${')
+	return new Function(
+		'url',
+		`${functionSource}; return collectQueryParamNames(url);`,
+	)(url) as Array<string>
+}
+
 test('package app kody proxy supports remote namespace calls', async () => {
 	const calls: Array<{ name: string; args: unknown }> = []
 	const kody = await createKodyProxyForTest({
@@ -653,8 +674,19 @@ test('package app worker exposes its public mount and records fetch query and re
 		hostedUrl: 'https://packages.kody.test/@serving-owner/packages/renamed-app',
 	})
 	const wrapperSource = workerOptions?.modules['package-app-entry.js']
-	expect(wrapperSource).toContain('queryString: requestUrl.search')
+	expect(wrapperSource).toContain(
+		'queryParamNames: collectQueryParamNames(requestUrl)',
+	)
 	expect(wrapperSource).toContain('httpStatus: response.status')
+
+	const queryParamNames = await collectQueryParamNamesForTest(
+		new URL(
+			'https://packages.kody.test/callback?audio=1&code=oauth-code-secret&state=oauth-state-secret&audio=2',
+		),
+	)
+	expect(queryParamNames).toEqual(['audio', 'code', 'state'])
+	expect(JSON.stringify(queryParamNames)).not.toContain('oauth-code-secret')
+	expect(JSON.stringify(queryParamNames)).not.toContain('oauth-state-secret')
 })
 
 test('createPackageAppWorkerId changes when compatibility settings change', async () => {
@@ -992,7 +1024,7 @@ test('package app runtime bridge adds response status to finish metadata', async
 			packageId: 'package-1',
 			metadata: {
 				method: 'GET',
-				queryString: '?audio=1',
+				queryParamNames: ['audio', 'code', 'state'],
 			},
 		},
 	}
@@ -1012,7 +1044,7 @@ test('package app runtime bridge adds response status to finish metadata', async
 				...runHandle.context,
 				metadata: {
 					method: 'GET',
-					queryString: '?audio=1',
+					queryParamNames: ['audio', 'code', 'state'],
 					httpStatus: 201,
 				},
 			},

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -585,6 +585,78 @@ test('buildPackageAppWorker aligns dynamic worker compatibility with shared opti
 	expect(factory?.()).toMatchObject(createDynamicWorkerCompatibilityOptions())
 })
 
+test('package app worker exposes its public mount and records fetch query and response status', async () => {
+	resetPackageAppRuntimeMocks()
+	const { env } = createPackageAppTestEnv()
+	packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity.mockResolvedValue(
+		{
+			row: {
+				id: 'artifact-row-public-context',
+				artifactName: null,
+				entryPoint: 'app.js',
+			},
+			artifact: {
+				mainModule: 'dist/app.js',
+				modules: {
+					'dist/app.js':
+						'export default { fetch() { return new Response("ok", { status: 201 }) } }',
+				},
+				dependencies: [],
+				dynamicDependencies: [],
+			},
+		},
+	)
+
+	await buildPackageAppWorker({
+		env,
+		baseUrl: 'https://app.kody.test',
+		userId: 'user-public-context',
+		savedPackage: {
+			id: 'package-public-context',
+			kodyId: 'renamed-app',
+			name: '@current-owner/renamed-app',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			manifestPath: 'package.json',
+			sourceRoot: '/',
+		},
+		source: createPackageAppTestSource(),
+		manifest: createPackageAppTestManifest(),
+		runtime: {
+			callerContext: {
+				user: {
+					email: 'owner@example.com',
+					displayName: 'Owner',
+				},
+			} as never,
+			servingUsername: 'serving-owner',
+			hostedOrigin: 'https://packages.kody.test',
+		},
+	})
+
+	const loader = env.APP_LOADER as unknown as {
+		get: ReturnType<typeof vi.fn>
+	}
+	const factory = loader.get.mock.calls[0]?.[1] as
+		| (() => {
+				env: Record<string, unknown>
+				modules: Record<string, string>
+		  })
+		| undefined
+	const workerOptions = factory?.()
+	expect(workerOptions?.env['__kodyPackageContext']).toEqual({
+		packageId: 'package-public-context',
+		kodyId: 'renamed-app',
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		appBasePath: '/@serving-owner/packages/renamed-app',
+		hostedUrl: 'https://packages.kody.test/@serving-owner/packages/renamed-app',
+	})
+	const wrapperSource = workerOptions?.modules['package-app-entry.js']
+	expect(wrapperSource).toContain('queryString: requestUrl.search')
+	expect(wrapperSource).toContain('httpStatus: response.status')
+})
+
 test('createPackageAppWorkerId changes when compatibility settings change', async () => {
 	const cacheKey = JSON.stringify([
 		'user-compat-id',
@@ -905,6 +977,50 @@ test('package app runtime bridge redacts resolved secrets from run record logs a
 	}
 	expect(JSON.stringify(finishInput.logs)).not.toContain(secretValue)
 	expect(finishInput.error.message).not.toContain(secretValue)
+})
+
+test('package app runtime bridge adds response status to finish metadata', async () => {
+	resetPackageAppRuntimeMocks()
+	const { bridge, waitUntilTasks } = createPackageAppRuntimeBridgeForTest()
+	const runHandle = {
+		id: 'run-status',
+		userId: 'user-1',
+		startedAt: '2026-07-26T00:00:00.000Z',
+		persistence: 'eager' as const,
+		context: {
+			surface: 'app_fetch' as const,
+			packageId: 'package-1',
+			metadata: {
+				method: 'GET',
+				queryString: '?audio=1',
+			},
+		},
+	}
+
+	await bridge.packageRuntimeRunFinish({
+		run: runHandle,
+		status: 'success',
+		metadata: { httpStatus: 201 },
+	})
+	await Promise.all(waitUntilTasks)
+
+	expect(packageAppRuntimeMock.finishRunRecord).toHaveBeenCalledWith({
+		env: {},
+		handle: {
+			...runHandle,
+			context: {
+				...runHandle.context,
+				metadata: {
+					method: 'GET',
+					queryString: '?audio=1',
+					httpStatus: 201,
+				},
+			},
+		},
+		status: 'success',
+		error: undefined,
+		logs: undefined,
+	})
 })
 
 test('package app runtime bridge redacts secrets from Error instances in finish payload', async () => {

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -598,6 +598,10 @@ function createConsoleLogCapture() {
 	};
 }
 
+function collectQueryParamNames(url) {
+	return [...new Set(url.searchParams.keys())];
+}
+
 async function startRuntimeRun(runtimeBridge, input) {
 	return await runtimeBridge.packageRuntimeRunStart(input);
 }
@@ -645,7 +649,7 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 			name: requestUrl.pathname,
 			metadata: {
 				method: request.method,
-				queryString: requestUrl.search,
+				queryParamNames: collectQueryParamNames(requestUrl),
 			},
 		});
 		const consoleCapture = createConsoleLogCapture();

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -66,6 +66,11 @@ import {
 	type RunRecordLogInput,
 	type RunTerminalStatus,
 } from '#worker/run-records/types.ts'
+import {
+	buildPackageAppPath,
+	buildPackageAppUrl,
+} from '@kody-internal/shared/public-urls.ts'
+import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
 
 const packageAppEntrypointName = 'PackageAppWorker'
 const packageAppRuntimeBindingName = 'KODY_RUNTIME'
@@ -634,11 +639,13 @@ function resolveRealtimeHandler(userModule, facetName) {
 export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 	async fetch(request) {
 		const runtimeBridge = this.env.${packageAppRuntimeBindingName};
+		const requestUrl = new URL(request.url);
 		const runtimeRun = await startRuntimeRun(runtimeBridge, {
 			surface: 'app_fetch',
-			name: new URL(request.url).pathname,
+			name: requestUrl.pathname,
 			metadata: {
 				method: request.method,
+				queryString: requestUrl.search,
 			},
 		});
 		const consoleCapture = createConsoleLogCapture();
@@ -666,6 +673,9 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 			finishRuntimeRun(runtimeBridge, this.ctx, {
 				run: runtimeRun,
 				status: 'success',
+				metadata: {
+					httpStatus: response.status,
+				},
 				logs: consoleCapture.logs,
 			});
 			return response;
@@ -929,12 +939,26 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		status: RunTerminalStatus
 		error?: unknown
 		logs?: Array<RunRecordLogInput>
+		metadata?: Record<string, unknown>
 	}) {
 		const logs = redactRunRecordLogs(input.logs, this.secretRedactor)
 		const error = redactRunRecordError(input.error, this.secretRedactor)
+		const handle =
+			input.run && input.metadata
+				? {
+						...input.run,
+						context: {
+							...input.run.context,
+							metadata: {
+								...input.run.context.metadata,
+								...input.metadata,
+							},
+						},
+					}
+				: input.run
 		const finishPromise = finishRunRecord({
 			env: this.env,
-			handle: input.run,
+			handle,
 			status: input.status,
 			error,
 			logs,
@@ -1422,6 +1446,8 @@ function createPackageAppWorkerCacheKey(input: {
 	sourceId: string
 	publishedCommit: string | null
 	baseUrl: string
+	appBasePath: string
+	hostedUrl: string
 	callerEmail: string
 	callerDisplayName: string
 }) {
@@ -1435,9 +1461,48 @@ function createPackageAppWorkerCacheKey(input: {
 		input.sourceId,
 		input.publishedCommit,
 		input.baseUrl,
+		input.appBasePath,
+		input.hostedUrl,
 		input.callerEmail,
 		input.callerDisplayName,
 	])
+}
+
+function getUsernameFromPackageName(packageName: string) {
+	const separatorIndex = packageName.indexOf('/')
+	if (!packageName.startsWith('@') || separatorIndex <= 1) {
+		throw new Error(
+			`Saved package name "${packageName}" must include a username scope.`,
+		)
+	}
+	return packageName.slice(1, separatorIndex)
+}
+
+function buildPackageAppPublicContext(input: {
+	env: Env
+	baseUrl: string
+	savedPackage: { kodyId: string; name: string }
+	runtime: {
+		servingUsername?: string
+		hostedOrigin?: string
+	}
+}) {
+	const username =
+		input.runtime.servingUsername ??
+		getUsernameFromPackageName(input.savedPackage.name)
+	const origin =
+		input.runtime.hostedOrigin ??
+		getPackageAppBaseUrl({ env: input.env }) ??
+		input.baseUrl
+	const publicUrlInput = {
+		origin,
+		username,
+		kodyId: input.savedPackage.kodyId,
+	}
+	return {
+		appBasePath: buildPackageAppPath(publicUrlInput),
+		hostedUrl: buildPackageAppUrl(publicUrlInput),
+	}
 }
 
 function resolvePackageAppManifest(input: {
@@ -1618,8 +1683,11 @@ async function buildPackageAppWorkerOptionsUncached(input: {
 	sourceFiles?: Record<string, string>
 	runtime: {
 		callerContext: ReturnType<typeof createMcpCallerContext>
+		servingUsername?: string
+		hostedOrigin?: string
 	}
 }): Promise<PackageAppWorkerOptions> {
+	const publicContext = buildPackageAppPublicContext(input)
 	const manifest = resolvePackageAppManifest({
 		manifest: input.manifest,
 		source: input.source,
@@ -1686,6 +1754,7 @@ async function buildPackageAppWorkerOptionsUncached(input: {
 				kodyId: input.savedPackage.kodyId,
 				sourceId: input.savedPackage.sourceId,
 				publishedCommit: input.savedPackage.publishedCommit,
+				...publicContext,
 			},
 		},
 		globalOutbound: workerExports?.KodyFetchGateway
@@ -1725,8 +1794,11 @@ export async function buildPackageAppWorker(input: {
 	sourceFiles?: Record<string, string>
 	runtime: {
 		callerContext: ReturnType<typeof createMcpCallerContext>
+		servingUsername?: string
+		hostedOrigin?: string
 	}
 }) {
+	const publicContext = buildPackageAppPublicContext(input)
 	const cacheKey = createPackageAppWorkerCacheKey({
 		userId: input.userId,
 		packageId: input.savedPackage.id,
@@ -1734,6 +1806,7 @@ export async function buildPackageAppWorker(input: {
 		sourceId: input.savedPackage.sourceId,
 		publishedCommit: input.savedPackage.publishedCommit,
 		baseUrl: input.baseUrl,
+		...publicContext,
 		callerEmail: input.runtime.callerContext.user?.email ?? '',
 		callerDisplayName:
 			input.runtime.callerContext.user?.displayName ??

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -387,7 +387,12 @@ declare const secretHeaders: KodySecretHeadersRuntime;
 declare function oauthClientCredentials(
   input: KodyOauthClientCredentialsInput,
 ): Promise<Record<string, unknown>>;
-declare const packageContext: { packageId: string; kodyId: string } | null;
+declare const packageContext: {
+  packageId: string;
+  kodyId: string;
+  appBasePath?: string;
+  hostedUrl?: string;
+} | null;
 declare const serviceContext: { serviceName: string } | null;
 declare const packages: KodyPackagesRuntime | null;
 declare const email: KodyEmailRuntime;
@@ -421,7 +426,12 @@ declare module "kody:runtime" {
   export function oauthClientCredentials(
     input: KodyOauthClientCredentialsInput,
   ): Promise<Record<string, unknown>>;
-  export const packageContext: { packageId: string; kodyId: string } | null;
+  export const packageContext: {
+    packageId: string;
+    kodyId: string;
+    appBasePath?: string;
+    hostedUrl?: string;
+  } | null;
   export const serviceContext: { serviceName: string } | null;
   export const packages: KodyPackagesRuntime | null;
   export const storage: ${


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make hosted package apps self-aware of their public mount and make routing/run failures actionable, addressing field-report findings K-02, K-03, and K-06.

## Summary

- expose `hostedUrl` and `appBasePath` through package apps' `packageContext`, derived from the current serving username, Kody id, and origin
- replace unmatched package-app-origin bare 404s with the package URL contract
- retain app fetch query parameter names (never values) and terminal HTTP response status in run metadata
- document mount-relative link construction in package usage and authoring guidance

## Testing

- focused Node: 25 tests passed
- focused Workers: 4 tests passed
- real-worker MCP package app: 1 test passed
- `npm run validate` passed after implementation and again after reviewer fix
- post-fix CI passed: Node, Workers, E2E, MCP, static, preview, CodeRabbit, and Bugbot
- production deploy passed its healthcheck and execute smoke check

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1916ffea` · **Head:** `b4159e58`

**Classification:** extends — package app runtime context, routing diagnostics, and run-record metadata contracts change; no primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-apps` | assistant | extends — public mount context and fetch observability |
| `package-runtime` | runtime | extends — generated app worker context and finish metadata |
| `app-ui` | surfaces | extends — diagnostic package-origin 404 |
| `repo-sessions` | runtime | extends — authored package runtime type declarations |
| `mcp-server` | surfaces | composes — end-to-end package app runtime coverage |

### System map

A hosted request is parsed by the browser-app routing layer, enters the package runtime with its public mount context, and writes richer run metadata.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	packageApps["package-apps<br/>Package apps"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	runRecords["run-records<br/>Run records"]:::untouched
	appUi -->|"serving username, origin, and mounted path"| packageApps
	packageApps -->|"hostedUrl + appBasePath runtime context"| packageRuntime
	packageRuntime -->|"query parameter names + terminal httpStatus"| runRecords
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Contract | Before | After |
| --- | --- | --- |
| App public base | unavailable to package code | `packageContext.hostedUrl` and `appBasePath` |
| Escaped mount | bare `Not Found` | diagnostic 404 with URL contract |
| `app_fetch` history | pathname + method | pathname + method + query parameter names + HTTP status |

</details>

<!-- system-recap:end -->

## Conductor report

Track B report: STATUS(done); PR https://github.com/kentcdodds/kody/pull/1308; merged commit 0407c4b4cb20cf67c477d858ef886340d0aee13d; deploy result success https://github.com/kentcdodds/kody/actions/runs/31244778124; evidence: CodeRabbit privacy finding fixed, local validate green, post-fix CI/CodeRabbit/Bugbot green, production healthcheck and execute smoke check passed; remains: none.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f99e7425-6983-4ac4-b72d-cd060e431d67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f99e7425-6983-4ac4-b72d-cd060e431d67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package apps now receive public routing details, including their hosted URL and app base path.
  * Links, redirects, sharing URLs, and OAuth callbacks can use consistent package app routing information.
  * Runtime results include query parameter names and successful HTTP response status metadata.

* **Bug Fixes**
  * Unmatched requests on package app origins now return a clear explanatory 404 response instead of a generic message.

* **Documentation**
  * Added guidance covering package app mount paths, URL handling, and routing context availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->