### PR TITLE
Polish package discovery and publish responses

### DIFF
--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -252,9 +252,14 @@ test('community package flow works end-to-end through capability handlers', asyn
 		{ query: 'community flow integration', limit: 10 },
 		forkerCtx,
 	)
+	expect(searchResult.outcome).toBe('matches')
 	expect(
 		searchResult.matches.some((match) => match.listing_id === listingId),
 	).toBe(true)
+	expect(
+		searchResult.matches.find((match) => match.listing_id === listingId)
+			?.relevance,
+	).toBeGreaterThanOrEqual(0.2)
 
 	const getResult = await communityGetCapability.handler(
 		{ listing_id: listingId },

--- a/packages/worker/src/community/community-scoring.node.test.ts
+++ b/packages/worker/src/community/community-scoring.node.test.ts
@@ -166,6 +166,7 @@ test('community scoring and search rank listings and filter by query', async () 
 	expect(githubResults.map((listing) => listing.kodyId)).toEqual([
 		'github-triage',
 	])
+	expect(githubResults[0]?.relevance).toBeGreaterThanOrEqual(0.2)
 	expect(mockModule.listCommunityListingCandidates).toHaveBeenCalledWith(
 		expect.anything(),
 		{
@@ -181,6 +182,7 @@ test('community scoring and search rank listings and filter by query', async () 
 		limit: 10,
 	})
 	expect(mealResults.map((listing) => listing.kodyId)).toEqual(['meal-planner'])
+	expect(mealResults[0]?.relevance).toBeGreaterThanOrEqual(0.2)
 
 	const gibberishResults = await searchCommunityListings({
 		env: createEnv(),
@@ -188,6 +190,13 @@ test('community scoring and search rank listings and filter by query', async () 
 		limit: 10,
 	})
 	expect(gibberishResults).toEqual([])
+
+	const unrelatedResults = await searchCommunityListings({
+		env: createEnv(),
+		query: 'text to speech audio narration',
+		limit: 10,
+	})
+	expect(unrelatedResults).toEqual([])
 
 	const allResults = await searchCommunityListings({
 		env: createEnv(),
@@ -198,6 +207,7 @@ test('community scoring and search rank listings and filter by query', async () 
 		'github-triage',
 		'meal-planner',
 	])
+	expect(allResults.every((listing) => listing.relevance === null)).toBe(true)
 })
 
 test('trusted-first community search promotes a trusted relevance rank 13 before limiting', async () => {

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -77,6 +77,7 @@ import {
 import {
 	type CommunityForkActor,
 	type CommunityListingRecord,
+	type CommunityListingSearchResult,
 	type CommunityListingWithAggregates,
 	type CommunityActivityKind,
 	type CommunityRatingRecord,
@@ -96,6 +97,11 @@ const intentHeadingPattern = /^##\s+intent\b/im
 // unrelated text (~0.10). Related lexical hits use lexical > 0; vector-only
 // semantic matches on listing documents tend to land above ~0.12.
 export const COMMUNITY_SEARCH_VECTOR_MATCH_THRESHOLD = 0.12
+
+// The vector threshold is only a broad candidate gate. Deterministic embeddings
+// can put unrelated documents above it, so require stronger blended query fit
+// before returning a ranked search result.
+export const COMMUNITY_SEARCH_MIN_RELEVANCE = 0.2
 
 // Community search/browse never scores more than this many listings in
 // memory; candidates are pre-filtered and recency-ordered in SQL. This is
@@ -735,7 +741,7 @@ export async function searchCommunityListings(input: {
 	limit: number
 	trustedFirst?: boolean
 	resultFilter?: (listing: CommunityListingWithAggregates) => boolean
-}): Promise<Array<CommunityListingWithAggregates>> {
+}): Promise<Array<CommunityListingSearchResult>> {
 	const trimmedQuery = input.query.trim()
 	let listings = await listCommunityListingCandidates(input.env.APP_DB, {
 		includeDelisted: false,
@@ -750,7 +756,10 @@ export async function searchCommunityListings(input: {
 		const relevanceOrdered = withAggregates.sort(
 			compareCommunityListingsByBayesianAndPublishedAt,
 		)
-		return finalizeCommunitySearchResults(relevanceOrdered, input)
+		return finalizeCommunitySearchResults(
+			relevanceOrdered.map((listing) => ({ ...listing, relevance: null })),
+			input,
+		)
 	}
 	const matchesQuery = (listing: CommunityListingRecord) =>
 		isCommunityListingSearchMatch({
@@ -790,25 +799,28 @@ export async function searchCommunityListings(input: {
 			ratingCount: listing.ratingCount,
 		})
 		return {
-			listing,
-			score: blended * bayesian,
+			listing: { ...listing, relevance: blended },
+			rankScore: blended * bayesian,
 		}
 	})
 
 	const relevanceOrdered = scored
-		.sort((left, right) => right.score - left.score)
+		.filter(
+			(entry) => entry.listing.relevance >= COMMUNITY_SEARCH_MIN_RELEVANCE,
+		)
+		.sort((left, right) => right.rankScore - left.rankScore)
 		.map((entry) => entry.listing)
 	return finalizeCommunitySearchResults(relevanceOrdered, input)
 }
 
 function finalizeCommunitySearchResults(
-	relevanceOrdered: Array<CommunityListingWithAggregates>,
+	relevanceOrdered: Array<CommunityListingSearchResult>,
 	input: {
 		limit: number
 		trustedFirst?: boolean
 		resultFilter?: (listing: CommunityListingWithAggregates) => boolean
 	},
-): Array<CommunityListingWithAggregates> {
+): Array<CommunityListingSearchResult> {
 	const filtered = input.resultFilter
 		? relevanceOrdered.filter(input.resultFilter)
 		: relevanceOrdered

--- a/packages/worker/src/community/types.ts
+++ b/packages/worker/src/community/types.ts
@@ -133,6 +133,10 @@ export type CommunityStargazer = {
 export type CommunityListingWithAggregates = CommunityListingRecord &
 	CommunityListingAggregates
 
+export type CommunityListingSearchResult = CommunityListingWithAggregates & {
+	relevance: number | null
+}
+
 export const communityActivityKinds = ['fork', 'rating'] as const
 
 export type CommunityActivityKind = (typeof communityActivityKinds)[number]

--- a/packages/worker/src/mcp/capabilities/community/search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/community/search.node.test.ts
@@ -1,0 +1,81 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	searchCommunityListings: vi.fn(),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	searchCommunityListings: (...args: Array<unknown>) =>
+		mockModule.searchCommunityListings(...args),
+}))
+
+const { communitySearchCapability } = await import('./search.ts')
+
+function createContext() {
+	return {
+		env: {} as Env,
+		callerContext: {
+			baseUrl: 'https://kody.test',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				username: 'user',
+				displayName: 'User',
+			},
+			remoteConnectors: null,
+			storageContext: null,
+			repoContext: null,
+		},
+	}
+}
+
+test('community search labels unrelated queries and exposes relevance for matches', async () => {
+	mockModule.searchCommunityListings.mockResolvedValueOnce([])
+
+	const noMatchResult = await communitySearchCapability.handler(
+		{ query: 'text to speech audio narration', limit: 10 },
+		createContext(),
+	)
+
+	expect(noMatchResult).toEqual({
+		outcome: 'no_matches',
+		guidance: expect.stringContaining(
+			'No community packages met the relevance floor',
+		),
+		matches: [],
+	})
+
+	mockModule.searchCommunityListings.mockResolvedValueOnce([
+		{
+			id: 'listing-github',
+			kodyId: 'github-triage',
+			name: '@kody/github-triage',
+			description: 'Triage GitHub issues automatically',
+			tags: ['github', 'triage'],
+			trusted: true,
+			relevance: 0.64,
+			averageStars: 4.5,
+			ratingCount: 8,
+			averageAdaptationEffort: 2,
+			forkCount: 3,
+			starCount: 4,
+		},
+	])
+
+	const matchResult = await communitySearchCapability.handler(
+		{ query: 'github issue triage', limit: 10 },
+		createContext(),
+	)
+
+	expect(matchResult).toEqual({
+		outcome: 'matches',
+		guidance: expect.any(String),
+		matches: [
+			expect.objectContaining({
+				listing_id: 'listing-github',
+				kody_id: 'github-triage',
+				relevance: 0.64,
+			}),
+		],
+	})
+})

--- a/packages/worker/src/mcp/capabilities/community/search.ts
+++ b/packages/worker/src/mcp/capabilities/community/search.ts
@@ -10,6 +10,9 @@ import {
 	toCommunityListingAggregatesOutput,
 } from './shared.ts'
 
+const communitySearchNoMatchGuidance =
+	'No community packages met the relevance floor for this query. Rephrase with the provider, data source, or concrete workflow you need; if nothing close exists, create a new package instead of adapting an unrelated result.'
+
 export const communitySearchCapability = defineDomainCapability(
 	capabilityDomainNames.community,
 	{
@@ -41,6 +44,7 @@ export const communitySearchCapability = defineDomainCapability(
 				.describe('Maximum number of matches to return (default 10, max 50).'),
 		}),
 		outputSchema: z.object({
+			outcome: z.enum(['matches', 'no_matches']),
 			guidance: z.string(),
 			matches: z.array(communitySearchMatchSchema),
 		}),
@@ -51,8 +55,12 @@ export const communitySearchCapability = defineDomainCapability(
 				query: args.query,
 				limit: args.limit ?? 10,
 			})
+			const noMatches = Boolean(args.query.trim()) && listings.length === 0
 			return {
-				guidance: communitySearchGuidance,
+				outcome: noMatches ? ('no_matches' as const) : ('matches' as const),
+				guidance: noMatches
+					? `${communitySearchNoMatchGuidance} ${communitySearchGuidance}`
+					: communitySearchGuidance,
 				matches: listings.map((listing) => ({
 					listing_id: listing.id,
 					name: listing.name,
@@ -61,6 +69,7 @@ export const communitySearchCapability = defineDomainCapability(
 					tags: listing.tags,
 					owner_anonymous: true as const,
 					trusted: listing.trusted,
+					relevance: listing.relevance,
 					...toCommunityListingAggregatesOutput(listing),
 					public_url: buildCommunityPublicUrl(
 						ctx.callerContext.baseUrl,

--- a/packages/worker/src/mcp/capabilities/community/shared.ts
+++ b/packages/worker/src/mcp/capabilities/community/shared.ts
@@ -76,6 +76,14 @@ export const communitySearchMatchSchema =
 		tags: z.array(z.string()),
 		owner_anonymous: z.literal(true),
 		trusted: communityTrustedFieldSchema,
+		relevance: z
+			.number()
+			.min(0)
+			.max(1)
+			.nullable()
+			.describe(
+				'Blended lexical and vector query relevance from 0 to 1; null when browsing with an empty query.',
+			),
 		public_url: z.string(),
 	})
 

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -71,6 +71,7 @@ function setupDefaultMocks() {
 		kodyId: 'demo-package',
 		name: '@kentcdodds/demo-package',
 		sourceId: 'source-1',
+		hasApp: false,
 	})
 	mockModule.getEntitySourceByIdForUser.mockResolvedValue({
 		id: 'source-1',
@@ -133,6 +134,7 @@ function createContext(
 				},
 			},
 			DYNAMIC_CALLABLE_WORKFLOWS: {},
+			PACKAGE_APP_BASE_URL: 'https://packages.kody.test',
 		} as unknown as Env,
 		callerContext: {
 			baseUrl: 'https://kody.test',
@@ -160,7 +162,9 @@ test('publishExternalPush publishes HEAD and rebuilds bundle artifacts per targe
 		status: 'published',
 		previous_commit: 'commit-old',
 		published_commit: 'commit-new',
-		manifest: {},
+		manifest: {
+			kody: { app: { entry: './src/app.ts' } },
+		},
 		checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
 	})
 
@@ -172,6 +176,7 @@ test('publishExternalPush publishes HEAD and rebuilds bundle artifacts per targe
 	expect(publishedResult.status).toBe('published')
 	expect(publishedResult).toEqual(
 		expect.objectContaining({
+			hosted_app_url: 'https://packages.kody.test/@user/packages/demo-package',
 			static_dependents: expect.objectContaining({
 				total: 0,
 				items: [],
@@ -252,6 +257,13 @@ test('publishExternalPush handles already_published branches, stale dependents, 
 		},
 	]
 	setupDefaultMocks()
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		kodyId: 'demo-package',
+		name: '@kentcdodds/demo-package',
+		sourceId: 'source-1',
+		hasApp: true,
+	})
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',
 		commit: 'commit-old',
@@ -269,6 +281,7 @@ test('publishExternalPush handles already_published branches, stale dependents, 
 	expect(alreadyPublished).toEqual({
 		status: 'already_published',
 		published_commit: 'commit-old',
+		hosted_app_url: 'https://packages.kody.test/@user/packages/demo-package',
 		static_dependents: expect.objectContaining({
 			total: 0,
 			stale: 0,
@@ -669,6 +682,7 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 	expect(alreadyPublished).toEqual({
 		status: 'already_published',
 		published_commit: 'commit-new',
+		hosted_app_url: null,
 		static_dependents: expect.objectContaining({
 			total: 0,
 			stale: 0,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { canonicalJsonStringify } from '@kody-internal/shared/canonical-json.ts'
+import { buildPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
@@ -11,6 +12,8 @@ import {
 	getErrorMessage,
 } from '@kody-internal/shared/error-message.ts'
 import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
+import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
+import { resolvePublicUsername } from '#worker/identity/user-lookup.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import {
 	getStaticPackageDependentsSummary,
@@ -219,6 +222,7 @@ const outputSchema = z.discriminatedUnion('status', [
 	z.object({
 		status: z.literal('already_published'),
 		published_commit: z.string().nullable(),
+		hosted_app_url: z.string().nullable(),
 		static_dependents: staticDependentsSchema,
 		pending_secret_package_approvals: pendingPackageSecretApprovalsSchema,
 	}),
@@ -245,6 +249,7 @@ const outputSchema = z.discriminatedUnion('status', [
 		published_commit: z.string(),
 		manifest: z.unknown(),
 		checks: z.array(checkSchema),
+		hosted_app_url: z.string().nullable(),
 		static_dependents: staticDependentsSchema,
 		pending_secret_package_approvals: pendingPackageSecretApprovalsSchema,
 	}),
@@ -259,6 +264,41 @@ const outputSchema = z.discriminatedUnion('status', [
 ])
 
 type PublishExternalPushResult = z.infer<typeof outputSchema>
+
+function manifestDeclaresApp(manifest: unknown) {
+	if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+		return false
+	}
+	const kody = Reflect.get(manifest, 'kody')
+	return (
+		Boolean(kody) &&
+		typeof kody === 'object' &&
+		!Array.isArray(kody) &&
+		Reflect.get(kody, 'app') !== undefined
+	)
+}
+
+async function resolvePublishedHostedAppUrl(input: {
+	env: Env
+	baseUrl: string
+	ownerScope: string
+	ownerEmail: string
+	kodyId: string
+	hasApp: boolean
+}) {
+	if (!input.hasApp) return null
+	const username = await resolvePublicUsername({
+		db: input.env.APP_DB,
+		username: input.ownerScope,
+		email: input.ownerEmail,
+	})
+	if (!username) return null
+	return buildPackageAppUrl({
+		origin: getPackageAppBaseUrl({ env: input.env }) ?? input.baseUrl,
+		username,
+		kodyId: input.kodyId,
+	})
+}
 
 function readSecretMountsFromPackageJson(content: string | undefined) {
 	if (!content) return null
@@ -379,9 +419,12 @@ async function runExternalPublishAttempt(input: {
 	env: Env
 	baseUrl: string
 	ownerUserId: string
+	ownerScope: string
+	ownerEmail: string
 	expectedPackageScope: string
 	packageId: string
 	kodyId: string
+	hasApp: boolean
 	source: {
 		id: string
 		repo_id: string
@@ -433,6 +476,14 @@ async function runExternalPublishAttempt(input: {
 				})
 				return {
 					...result,
+					hosted_app_url: await resolvePublishedHostedAppUrl({
+						env: input.env,
+						baseUrl: input.baseUrl,
+						ownerScope: input.ownerScope,
+						ownerEmail: input.ownerEmail,
+						kodyId: input.kodyId,
+						hasApp: input.hasApp,
+					}),
 					static_dependents: await getPublishStaticDependents({
 						db: input.env.APP_DB,
 						userId: input.ownerUserId,
@@ -463,6 +514,14 @@ async function runExternalPublishAttempt(input: {
 			})
 			return {
 				...result,
+				hosted_app_url: await resolvePublishedHostedAppUrl({
+					env: input.env,
+					baseUrl: input.baseUrl,
+					ownerScope: input.ownerScope,
+					ownerEmail: input.ownerEmail,
+					kodyId: input.kodyId,
+					hasApp: manifestDeclaresApp(result.manifest),
+				}),
 				static_dependents: await getPublishStaticDependents({
 					db: input.env.APP_DB,
 					userId: input.ownerUserId,
@@ -516,7 +575,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 	{
 		name: 'package_publish_external_push',
 		description:
-			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically. Common cases return the full synchronous result. If the publish exceeds the inline budget (~55s), the work is dispatched once to a durable workflow (idempotent per acting caller plus the full semantic publish input, including force/overwrite flags) and this capability returns status dispatched with a workflow_id to poll via workflow_run_list instead of hanging until an opaque execute timeout.',
+			'Publish the current Artifacts git HEAD for a saved package after a package_get_git_remote clone/edit/push workflow and server-side checks pass. Non-fast-forward publishes require explicit destructive overwrite confirmation and a verified restorable backup snapshot. Published and already_published responses include hosted_app_url when the package declares an app, plus bounded static dependent metadata so agents can decide whether stale kody:@ bundled snapshots need inspection or dependent republish; Kody does not republish dependents automatically. Common cases return the full synchronous result. If the publish exceeds the inline budget (~55s), the work is dispatched once to a durable workflow (idempotent per acting caller plus the full semantic publish input, including force/overwrite flags) and this capability returns status dispatched with a workflow_id to poll via workflow_run_list instead of hanging until an opaque execute timeout.',
 		keywords: ['package', 'publish', 'git', 'artifacts', 'external', 'push'],
 		readOnly: false,
 		idempotent: true,
@@ -531,14 +590,15 @@ export const publishExternalPushCapability = defineDomainCapability(
 				args.package_scope,
 			)
 			const expectedPackageScope = owner.ownerScope
-			const { packageId, kodyId, source } = await resolveOwnedPackageSource({
-				db: ctx.env.APP_DB,
-				userId: owner.ownerUserId,
-				args: {
-					package_id: args.package_id,
-					kody_id: args.kody_id,
-				},
-			})
+			const { packageId, kodyId, hasApp, source } =
+				await resolveOwnedPackageSource({
+					db: ctx.env.APP_DB,
+					userId: owner.ownerUserId,
+					args: {
+						package_id: args.package_id,
+						kody_id: args.kody_id,
+					},
+				})
 			const head = await resolveArtifactSourceHead(ctx.env, source.repo_id)
 			const newCommit = head.commit
 			if (!newCommit) {
@@ -551,9 +611,12 @@ export const publishExternalPushCapability = defineDomainCapability(
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
 				ownerUserId: owner.ownerUserId,
+				ownerScope: owner.ownerScope,
+				ownerEmail: owner.ownerEmail,
 				expectedPackageScope,
 				packageId,
 				kodyId,
+				hasApp,
 				source: { id: source.id, repo_id: source.repo_id },
 				newCommit,
 				allowForce: args.allow_force,

--- a/packages/worker/src/mcp/capabilities/packages/resolve-package-source.ts
+++ b/packages/worker/src/mcp/capabilities/packages/resolve-package-source.ts
@@ -30,6 +30,7 @@ export async function resolveOwnedPackageSource(input: {
 	packageId: string
 	kodyId: string
 	name: string
+	hasApp: boolean
 	source: EntitySourceRow
 }> {
 	requireExactlyOnePackageSourceIdentity(input.args)
@@ -58,6 +59,7 @@ export async function resolveOwnedPackageSource(input: {
 		packageId: savedPackage.id,
 		kodyId: savedPackage.kodyId,
 		name: savedPackage.name,
+		hasApp: savedPackage.hasApp,
 		source,
 	}
 }

--- a/packages/worker/src/mcp/tools/search-format-helpers.ts
+++ b/packages/worker/src/mcp/tools/search-format-helpers.ts
@@ -35,14 +35,25 @@ export const inlineCapabilityInputTypeMaxLength = 500
 
 export function compactCapabilityInputTypeDefinition(
 	inputTypeDefinition: string,
-	maxLength = inlineCapabilityInputTypeMaxLength,
+	options: {
+		maxLength?: number
+		requiredInputFields?: ReadonlyArray<string>
+	} = {},
 ): { definition: string; truncated: boolean } {
+	const maxLength = options.maxLength ?? inlineCapabilityInputTypeMaxLength
 	const collapsed = formatInlineTypeDefinition(inputTypeDefinition)
 	if (collapsed.length <= maxLength) {
 		return { definition: collapsed, truncated: false }
 	}
+	const requiredFields = options.requiredInputFields ?? []
+	const requiredFieldsMarker =
+		requiredFields.length > 0
+			? ` /* required fields: ${requiredFields.join(', ')} */`
+			: ''
+	const suffix = `...${requiredFieldsMarker}`
+	const prefixLength = Math.max(0, maxLength - suffix.length)
 	return {
-		definition: `${collapsed.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`,
+		definition: `${collapsed.slice(0, prefixLength).trimEnd()}${suffix}`,
 		truncated: true,
 	}
 }

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -1035,6 +1035,21 @@ test('search formatting inlines top capability call shapes, related ops, and pac
 	)
 	expect(compact.definition.endsWith('...')).toBe(true)
 
+	const requiredFieldAtEnd = compactCapabilityInputTypeDefinition(
+		`type LongMemoryInput = { ${Array.from(
+			{ length: 40 },
+			(_, index) => `optional_field_${index}?: string`,
+		).join('; ')}; verified_by_agent: true }`,
+		{ requiredInputFields: ['verified_by_agent'] },
+	)
+	expect(requiredFieldAtEnd.truncated).toBe(true)
+	expect(requiredFieldAtEnd.definition.length).toBeLessThanOrEqual(
+		inlineCapabilityInputTypeMaxLength,
+	)
+	expect(requiredFieldAtEnd.definition).toContain(
+		'required fields: verified_by_agent',
+	)
+
 	const listMarkdown = formatSearchMarkdown({
 		matches: [
 			{

--- a/packages/worker/src/mcp/tools/search-related-capabilities.ts
+++ b/packages/worker/src/mcp/tools/search-related-capabilities.ts
@@ -24,6 +24,7 @@ export function attachTopCapabilityCallShapes(input: {
 		if (!spec?.inputTypeDefinition) continue
 		const compact = compactCapabilityInputTypeDefinition(
 			spec.inputTypeDefinition,
+			{ requiredInputFields: spec.requiredInputFields },
 		)
 		match.inputTypeDefinition = compact.definition
 		if (compact.truncated) {

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -1364,7 +1364,7 @@ test('searchUnified inlines call shapes for the top three capability matches onl
 		name: 'openapi:widgets:createwidget',
 		inputTypeDefinitionTruncated: true,
 	})
-	expect(topMatch?.inputTypeDefinition?.endsWith('...')).toBe(true)
+	expect(topMatch?.inputTypeDefinition).toContain('required fields: name')
 
 	const nonTruncatedTop = await searchUnified({
 		env: {} as Env,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Prevent MCP agents from guessing hosted app URLs, treating unrelated community listings as confident matches, or missing required capability inputs after inline type truncation. This addresses verified field-report findings K-09, K-10, and K-08-truncation.

## Summary

- return nullable `hosted_app_url` from published and already-published external package publishes
- expose community result relevance and an explicit `no_matches` outcome below a query-fit floor
- preserve required input names when compact capability call shapes exceed the inline budget

## Testing

- targeted node suites: 37 tests passed
- community workers flow: 2 tests passed
- pre-push unit suite and Playwright: 1,938 unit/Workers tests and 7 E2E tests passed
- `npm run validate`: passed
- PR CI: Workers, E2E, MCP, Node, Static, and Validate passed
- production deployment: passed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1916ffea` · **Head:** `e6fea36d`

**Classification:** extends — changes three existing MCP-facing contracts without adding a new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — publish success responses include canonical hosted app URLs |
| `community-listings` | assistant | extends — search applies a relevance floor and exposes match confidence |
| `mcp-server` | surfaces | extends — compact call shapes preserve required field names |

### System map

Package publish and community discovery return safer agent-facing metadata through the MCP endpoint; capability search keeps required inputs visible within its compact response budget.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	communityListings["community-listings<br/>Community package listings"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	savedPackages -->|"hosted_app_url on publish success"| mcpServer
	communityListings -->|"outcome + relevance-filtered matches"| mcpServer
	mcpServer -->|"required-field-preserving call shapes"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| package publish | no hosted app link | canonical nullable `hosted_app_url` |
| community search | ranked list without confidence | explicit outcome and 0–1 relevance |
| compact call shape | blind 500-character slice | required field names reserved in truncation marker |

</details>

<!-- system-recap:end -->

## Conductor report

Track D report: STATUS(done); PR https://github.com/kentcdodds/kody/pull/1310; merged commit `17fd0bc8dc5e67e6a90b9abcb4012862e8dbe79c`; production deploy https://github.com/kentcdodds/kody/actions/runs/31244325423 succeeded; evidence: `npm run validate`, all PR CI jobs, 1,938 unit/Workers tests, 7 E2E tests, and focused regression suites passed; nothing remains.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed27c918-dffd-4503-a1be-1d96c32c8ec5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed27c918-dffd-4503-a1be-1d96c32c8ec5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

