### PR TITLE
Stop copy-prompt tooltip jitter and show existing forks

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -106,9 +106,12 @@ badge on the detail page, the admin-only toggle
 (`POST /community/:listingId/feature.json`, audited), the admin-only
 `community_set_featured` capability, and the onboarding "Install a starter
 package" step (square-card grid with in-place Install, then Copy prompt for
-agent setup, plus a trailing Choose your own adventure card). `community_get`
-exposes the effective `featured` flag. Onboarding loads up to 12 featured
-listings.
+agent setup, plus a trailing Choose your own adventure card). Signed-in
+onboarding, `/community` cards, and listing detail overlay a per-request
+`viewerInstall` when the viewer already has a matching `kody_id` saved package
+or a `community_forks` row for that listing, so those surfaces show Copy prompt
+instead of Install. `community_get` exposes the effective `featured` flag.
+Onboarding loads up to 12 featured listings.
 
 Reports survive listing deletion via denormalized listing name and owner on the
 report row.

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -127,12 +127,15 @@ Only after publish does the package become a live saved package in your account.
 Each listing detail page has an **Install** button for signed-in users. Featured
 starter packages on `/onboarding` appear as a square-card grid with one-click
 install without leaving the page: after install, **Copy prompt** gives your
-agent a short setup prompt. A trailing **Choose your own adventure** card copies
-an open-ended setup prompt when you want to explore or build something custom
-instead. Install forks the listing into your account and, when the fork passes
-the same publish checks a repo session would run, publishes it immediately as a
-live saved package. **Publishing activates the package right away** — declared
-jobs are scheduled and `autoStart` services start.
+agent a short setup prompt. If you already have a saved package with the same
+`kody_id`, or a fork of that listing, onboarding, listing cards, and the detail
+page show **Copy prompt** / **Installed** (or **Forked**) instead of Install. A
+trailing **Choose your own adventure** card copies an open-ended setup prompt
+when you want to explore or build something custom instead. Install forks the
+listing into your account and, when the fork passes the same publish checks a
+repo session would run, publishes it immediately as a live saved package.
+**Publishing activates the package right away** — declared jobs are scheduled
+and `autoStart` services start.
 
 - **Untrusted listings** show a warning first: no admin has reviewed the code,
   and installing runs it in your account. You must explicitly confirm. Direct

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -33,6 +33,7 @@ import {
 import {
 	type PublicCommunityListing,
 	type PublicCommunityStargazer,
+	type ViewerListingInstall,
 } from '#universal/community-public-types.ts'
 import { type CommunityStargazersLoaderData } from '#universal/loader-data.ts'
 import { formatCommunityPublishedDate } from '#universal/community-display.ts'
@@ -56,6 +57,7 @@ type CommunityDetailApiPayload = {
 	viewerIsAdmin: boolean
 	forkPrompt: string
 	starredByViewer: boolean
+	viewerInstall: ViewerListingInstall | null
 }
 
 type CommunityInstallApiPayload = {
@@ -155,6 +157,7 @@ export async function communityDetailRouteLoader(
 			readmeContent: payload.listing.readmeContent,
 			starCount: payload.listing.starCount,
 			starredByViewer: payload.starredByViewer,
+			viewerInstall: payload.viewerInstall,
 		},
 	}
 }
@@ -176,6 +179,7 @@ export function CommunityDetailRoute(handle: Handle) {
 	let installState: 'idle' | 'confirming' | 'submitting' | 'error' = 'idle'
 	let installMessage: string | null = null
 	let installOutcome: CommunityInstallOutcome | null = null
+	let existingInstall: ViewerListingInstall | null = null
 	let readmeContent: string | null = null
 	let shellStatus: 'loading' | 'ready' | 'error' = 'loading'
 	let shellLoadRequestId = 0
@@ -252,6 +256,7 @@ export function CommunityDetailRoute(handle: Handle) {
 			installState = 'idle'
 			installMessage = null
 			installOutcome = null
+			existingInstall = payload.viewerInstall
 			readmeContent = payload.listing.readmeContent
 			starCount = payload.listing.starCount
 			starredByViewer = payload.starredByViewer
@@ -582,6 +587,7 @@ export function CommunityDetailRoute(handle: Handle) {
 		installState = 'idle'
 		installMessage = null
 		installOutcome = null
+		existingInstall = routeData.viewerInstall
 		readmeContent = routeData.readmeContent
 		starCount = routeData.starCount
 		starredByViewer = routeData.starredByViewer
@@ -657,6 +663,17 @@ export function CommunityDetailRoute(handle: Handle) {
 			: showShellReady
 				? ''
 				: 'Loading community package details…'
+		const shownInstall = installOutcome
+			? { ...installOutcome, existing: false }
+			: existingInstall
+				? {
+						status: existingInstall.status,
+						targetName: existingInstall.targetName,
+						agentPrompt: existingInstall.agentPrompt,
+						failedChecks: [] as Array<{ kind: string; message: string }>,
+						existing: true,
+					}
+				: null
 
 		return (
 			<article mix={css(detailArticleCss)}>
@@ -694,61 +711,74 @@ export function CommunityDetailRoute(handle: Handle) {
 							data-testid="community-install"
 						>
 							<h2 id="install-title">One-click install</h2>
-							{installOutcome ? (
-								<>
-									{installOutcome.status === 'installed' ? (
-										<>
-											<p data-testid="community-install-success" role="status">
-												Installed as {installOutcome.targetName}. Any jobs or
-												auto-start services the package declares are now active.
-											</p>
-											<p>
-												<a
-													href={routes.accountPackages.href()}
-													mix={css(inlineLinkCss)}
-												>
-													View it in your packages
-												</a>
-											</p>
-											<p>
-												Give this prompt to your agent to finish any remaining
-												setup (secrets, connections, a first test run):
-											</p>
-										</>
-									) : (
-										<>
-											<p
-												data-testid="community-install-adaptation"
-												role="status"
+							{shownInstall ? (
+								shownInstall.status === 'installed' ? (
+									<>
+										<p data-testid="community-install-success" role="status">
+											{shownInstall.existing
+												? 'Already installed as'
+												: 'Installed as'}{' '}
+											{shownInstall.targetName}.
+											{shownInstall.existing
+												? ''
+												: ' Any jobs or auto-start services the package declares are now active.'}
+										</p>
+										<p>
+											<a
+												href={routes.accountPackages.href()}
+												mix={css(inlineLinkCss)}
 											>
-												Forked as {installOutcome.targetName}, but it needs
-												adaptation before it can run in your account.
-											</p>
-											{installOutcome.failedChecks.length > 0 ? (
-												<ul mix={css(checkListCss)}>
-													{installOutcome.failedChecks.map((check) => (
-														<li key={check.kind}>
-															{check.kind}: {check.message}
-														</li>
-													))}
-												</ul>
-											) : null}
-											<p>
-												Give this prompt to your agent to adapt and publish it:
-											</p>
-										</>
-									)}
-									<div mix={css(promptGroupCss)}>
-										<blockquote mix={css(promptBlockCss)}>
-											{installOutcome.agentPrompt}
-										</blockquote>
-										<CopyTextButton
-											value={installOutcome.agentPrompt}
-											idleLabel="Copy prompt"
-											variant="pill"
-										/>
-									</div>
-								</>
+												View it in your packages
+											</a>
+										</p>
+										<p>
+											Give this prompt to your agent to finish any remaining
+											setup (secrets, connections, a first test run):
+										</p>
+										<div mix={css(promptGroupCss)}>
+											<blockquote mix={css(promptBlockCss)}>
+												{shownInstall.agentPrompt}
+											</blockquote>
+											<CopyTextButton
+												value={shownInstall.agentPrompt}
+												idleLabel="Copy prompt"
+												variant="pill"
+											/>
+										</div>
+									</>
+								) : (
+									<>
+										<p data-testid="community-install-adaptation" role="status">
+											{shownInstall.existing
+												? 'Already forked as'
+												: 'Forked as'}{' '}
+											{shownInstall.targetName}, but it needs adaptation before
+											it can run in your account.
+										</p>
+										{shownInstall.failedChecks.length > 0 ? (
+											<ul mix={css(checkListCss)}>
+												{shownInstall.failedChecks.map((check) => (
+													<li key={check.kind}>
+														{check.kind}: {check.message}
+													</li>
+												))}
+											</ul>
+										) : null}
+										<p>
+											Give this prompt to your agent to adapt and publish it:
+										</p>
+										<div mix={css(promptGroupCss)}>
+											<blockquote mix={css(promptBlockCss)}>
+												{shownInstall.agentPrompt}
+											</blockquote>
+											<CopyTextButton
+												value={shownInstall.agentPrompt}
+												idleLabel="Copy prompt"
+												variant="pill"
+											/>
+										</div>
+									</>
+								)
 							) : (
 								<>
 									<p>

--- a/packages/worker/client/routes/onboarding-diy-card.tsx
+++ b/packages/worker/client/routes/onboarding-diy-card.tsx
@@ -1,12 +1,11 @@
 import { type Handle, css } from 'remix/ui'
-import * as popover from 'remix/ui/popover'
 import { writeClipboardText } from '#client/clipboard.ts'
 import { on } from '#client/event-mixin.ts'
 import { colors, typography } from '#universal/styles/tokens.ts'
 import {
 	starterCardCss,
+	starterCopyPromptTooltipCss,
 	starterGhostButtonCss,
-	starterTooltipSurfaceCss,
 } from '#client/routes/onboarding-starter-card.tsx'
 
 type OnboardingDiyCardProps = {
@@ -24,17 +23,6 @@ const copyPromptTooltip =
 export function OnboardingDiyCard(handle: Handle<OnboardingDiyCardProps>) {
 	let copyState: 'idle' | 'copied' | 'error' = 'idle'
 	let copyResetTimerId: ReturnType<typeof setTimeout> | null = null
-	let tooltipOpen = false
-
-	function openTooltip() {
-		tooltipOpen = true
-		handle.update()
-	}
-
-	function closeTooltip() {
-		tooltipOpen = false
-		handle.update()
-	}
 
 	async function copyPrompt() {
 		try {
@@ -63,46 +51,22 @@ export function OnboardingDiyCard(handle: Handle<OnboardingDiyCardProps>) {
 					integration, explore, and build something custom.
 				</span>
 			</div>
-			<popover.Context>
-				<button
-					type="button"
-					aria-describedby="onboarding-diy-prompt-tip"
-					disabled={!handle.props.setupPrompt}
-					mix={[
-						css(starterGhostButtonCss),
-						popover.anchor({ placement: 'top' }),
-						popover.focusOnHide(),
-						on('click', () => void copyPrompt()),
-						on('pointerenter', openTooltip),
-						on('pointerleave', closeTooltip),
-						on('focus', openTooltip),
-						on('blur', closeTooltip),
-					]}
-					data-testid="onboarding-diy-copy"
-				>
-					{copyState === 'copied'
-						? 'Copied'
-						: copyState === 'error'
-							? 'Copy failed'
-							: 'Copy prompt'}
-				</button>
-				<div
-					id="onboarding-diy-prompt-tip"
-					role="tooltip"
-					mix={[
-						css(starterTooltipSurfaceCss),
-						popover.surface({
-							open: tooltipOpen,
-							closeOnAnchorClick: false,
-							onHide() {
-								closeTooltip()
-							},
-						}),
-					]}
-				>
+			<button
+				type="button"
+				aria-describedby="onboarding-diy-prompt-tip"
+				disabled={!handle.props.setupPrompt}
+				mix={[css(diyCopyButtonCss), on('click', () => void copyPrompt())]}
+				data-testid="onboarding-diy-copy"
+			>
+				{copyState === 'copied'
+					? 'Copied'
+					: copyState === 'error'
+						? 'Copy failed'
+						: 'Copy prompt'}
+				<span id="onboarding-diy-prompt-tip" role="tooltip">
 					{copyPromptTooltip}
-				</div>
-			</popover.Context>
+				</span>
+			</button>
 		</li>
 	)
 }
@@ -139,4 +103,9 @@ const diyDescriptionCss = {
 	color: colors.textMuted,
 	fontSize: '0.88rem',
 	lineHeight: 1.45,
+}
+
+const diyCopyButtonCss = {
+	...starterGhostButtonCss,
+	...starterCopyPromptTooltipCss,
 }

--- a/packages/worker/client/routes/onboarding-starter-card.tsx
+++ b/packages/worker/client/routes/onboarding-starter-card.tsx
@@ -1,5 +1,4 @@
 import { type Handle, css } from 'remix/ui'
-import * as popover from 'remix/ui/popover'
 import { routes } from '#universal/routes.ts'
 import { type OnboardingFeaturedListing } from '#universal/community-public-types.ts'
 import { CommunityListingIcon } from '#universal/community-listing-icon.tsx'
@@ -53,18 +52,6 @@ export function OnboardingStarterCard(
 	let errorMessage: string | null = null
 	let copyState: 'idle' | 'copied' | 'error' = 'idle'
 	let copyResetTimerId: ReturnType<typeof setTimeout> | null = null
-	let tooltipOpen = false
-
-	function openTooltip() {
-		if (!agentPrompt) return
-		tooltipOpen = true
-		handle.update()
-	}
-
-	function closeTooltip() {
-		tooltipOpen = false
-		handle.update()
-	}
 
 	async function submitInstall() {
 		const { listing, loggedIn } = handle.props
@@ -129,10 +116,9 @@ export function OnboardingStarterCard(
 		}
 	}
 
-	async function copyPrompt() {
-		if (!agentPrompt) return
+	async function copyPrompt(prompt: string) {
 		try {
-			await writeClipboardText(agentPrompt)
+			await writeClipboardText(prompt)
 			copyState = 'copied'
 		} catch {
 			copyState = 'error'
@@ -150,6 +136,16 @@ export function OnboardingStarterCard(
 	return () => {
 		const { listing } = handle.props
 		const detailHref = routes.communityDetail.href({ listingId: listing.id })
+		const existingInstall = listing.viewerInstall ?? null
+		const readyPrompt = agentPrompt ?? existingInstall?.agentPrompt ?? null
+		const readyStatus =
+			statusMessage ??
+			(existingInstall
+				? existingInstall.status === 'installed'
+					? `Installed as ${existingInstall.targetName}.`
+					: `Forked as ${existingInstall.targetName}; needs adaptation before it can run.`
+				: null)
+		const showCopyPrompt = readyPrompt != null
 
 		return (
 			<li
@@ -168,46 +164,28 @@ export function OnboardingStarterCard(
 						{listing.description}
 					</span>
 				</a>
-				{phase === 'ready' && agentPrompt ? (
-					<popover.Context>
-						<button
-							type="button"
-							aria-describedby={`onboarding-starter-prompt-tip-${listing.id}`}
-							mix={[
-								css(copyPromptButtonCss),
-								popover.anchor({ placement: 'top' }),
-								popover.focusOnHide(),
-								on('click', () => void copyPrompt()),
-								on('pointerenter', openTooltip),
-								on('pointerleave', closeTooltip),
-								on('focus', openTooltip),
-								on('blur', closeTooltip),
-							]}
-							data-testid={`onboarding-starter-copy-${listing.id}`}
-						>
-							{copyState === 'copied'
-								? 'Copied'
-								: copyState === 'error'
-									? 'Copy failed'
-									: 'Copy prompt'}
-						</button>
-						<div
+				{showCopyPrompt ? (
+					<button
+						type="button"
+						aria-describedby={`onboarding-starter-prompt-tip-${listing.id}`}
+						mix={[
+							css(copyPromptButtonCss),
+							on('click', () => void copyPrompt(readyPrompt)),
+						]}
+						data-testid={`onboarding-starter-copy-${listing.id}`}
+					>
+						{copyState === 'copied'
+							? 'Copied'
+							: copyState === 'error'
+								? 'Copy failed'
+								: 'Copy prompt'}
+						<span
 							id={`onboarding-starter-prompt-tip-${listing.id}`}
 							role="tooltip"
-							mix={[
-								css(tooltipSurfaceCss),
-								popover.surface({
-									open: tooltipOpen,
-									closeOnAnchorClick: false,
-									onHide() {
-										closeTooltip()
-									},
-								}),
-							]}
 						>
 							{copyPromptTooltip}
-						</div>
-					</popover.Context>
+						</span>
+					</button>
 				) : (
 					<button
 						type="button"
@@ -221,13 +199,13 @@ export function OnboardingStarterCard(
 						{phase === 'installing' ? 'Installing…' : 'Install'}
 					</button>
 				)}
-				{statusMessage ? (
+				{readyStatus ? (
 					<p
 						mix={css(starterStatusCss)}
 						role="status"
 						data-testid={`onboarding-starter-status-${listing.id}`}
 					>
-						{statusMessage}
+						{readyStatus}
 					</p>
 				) : null}
 				{errorMessage ? (
@@ -321,9 +299,59 @@ export const starterGhostButtonCss = {
 	...starterActionButtonSizeCss,
 }
 
+/*
+ * CSS hover/focus tooltip instead of remix/ui popover: a top-layer popover
+ * that flips into another card's Copy prompt steals pointer events and
+ * jitters between vertically stacked starters. The tip is
+ * `pointer-events: none` so it never becomes a hover target.
+ */
+export const starterCopyPromptTooltipCss = {
+	position: 'relative' as const,
+	'& [role="tooltip"]': {
+		position: 'absolute' as const,
+		left: '50%',
+		bottom: 'calc(100% + 0.45rem)',
+		transform: 'translateX(-50%)',
+		width: 'max-content',
+		maxWidth: 'min(16rem, calc(100vw - 2rem))',
+		padding: `${spacing.xs} ${spacing.sm}`,
+		borderRadius: radius.md,
+		backgroundColor: colors.surface,
+		color: colors.text,
+		fontSize: typography.fontSize.sm,
+		fontWeight: 400,
+		lineHeight: 1.4,
+		textAlign: 'left' as const,
+		boxShadow: shadows.md,
+		border: `1px solid ${colors.border}`,
+		pointerEvents: 'none' as const,
+		opacity: 0,
+		visibility: 'hidden' as const,
+		zIndex: 2,
+	},
+	'& [role="tooltip"]::after': {
+		content: '""',
+		position: 'absolute' as const,
+		top: '100%',
+		left: '50%',
+		transform: 'translateX(-50%)',
+		border: '6px solid transparent',
+		borderTopColor: colors.surface,
+	},
+	[`${hoverMq} &:hover [role="tooltip"]`]: {
+		opacity: 1,
+		visibility: 'visible' as const,
+	},
+	'&:focus-visible [role="tooltip"]': {
+		opacity: 1,
+		visibility: 'visible' as const,
+	},
+}
+
 const copyPromptButtonCss = {
 	...getPillButtonCss(),
 	...starterActionButtonSizeCss,
+	...starterCopyPromptTooltipCss,
 }
 
 /* Install confirmation pops in like the wizard checks. */
@@ -342,17 +370,3 @@ const starterErrorCss = {
 	color: colors.error,
 	textWrap: 'pretty' as const,
 }
-
-export const starterTooltipSurfaceCss = {
-	maxWidth: '16rem',
-	padding: `${spacing.xs} ${spacing.sm}`,
-	borderRadius: radius.md,
-	backgroundColor: colors.surface,
-	color: colors.text,
-	fontSize: typography.fontSize.sm,
-	lineHeight: 1.4,
-	boxShadow: shadows.md,
-	border: `1px solid ${colors.border}`,
-}
-
-const tooltipSurfaceCss = starterTooltipSurfaceCss

--- a/packages/worker/src/app/community-data.node.test.ts
+++ b/packages/worker/src/app/community-data.node.test.ts
@@ -150,6 +150,14 @@ test('community index overlays matching kody_id installs for signed-in viewers',
 		targetName: '@burhan/github',
 		agentPrompt: buildExistingInstallPrompt({ targetName: '@burhan/github' }),
 	})
+	expect(mockModule.listSavedPackagesByKodyIds).toHaveBeenCalledWith(
+		undefined,
+		expect.objectContaining({ userId: 'viewer-1' }),
+	)
+	expect(mockModule.listCommunityForksByListingIdsAndUser).toHaveBeenCalledWith(
+		undefined,
+		expect.objectContaining({ userId: 'viewer-1' }),
+	)
 })
 
 test('onboarding featured listings overlay inert forks as adaptation_required', async () => {
@@ -200,4 +208,28 @@ test('anonymous community index omits viewerInstall', async () => {
 	)
 	expect(data.listings[0]?.viewerInstall).toBeUndefined()
 	expect(mockModule.listSavedPackagesByKodyIds).not.toHaveBeenCalled()
+})
+
+test('community index stays public when viewer auth lookup fails', async () => {
+	resetDataCacheForTests()
+	mockModule.listSavedPackagesByKodyIds.mockReset()
+	mockModule.readAuthenticatedAppUser.mockRejectedValue(
+		new Error('Missing COOKIE_SECRET for session signing.'),
+	)
+	mockModule.listCommunityListingsWithAggregates.mockResolvedValue([
+		sampleListing,
+	])
+	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+	const data = await loadCommunityIndexData(
+		{} as Env,
+		new Request('https://example.com/community'),
+	)
+	expect(data.ok).toBe(true)
+	expect(data.listings).toHaveLength(1)
+	expect(data.listings[0]?.id).toBe('listing-github')
+	expect(data.listings[0]?.viewerInstall).toBeUndefined()
+	expect(mockModule.listSavedPackagesByKodyIds).not.toHaveBeenCalled()
+	expect(consoleError).toHaveBeenCalled()
+	consoleError.mockRestore()
 })

--- a/packages/worker/src/app/community-data.node.test.ts
+++ b/packages/worker/src/app/community-data.node.test.ts
@@ -1,0 +1,203 @@
+import { expect, test, vi } from 'vitest'
+import { type PublicCommunityListing } from '#universal/community-public-types.ts'
+import { resetDataCacheForTests } from './data-cache.ts'
+import {
+	composeCommunityDetailLoaderData,
+	loadCommunityIndexData,
+	loadOnboardingFeaturedListings,
+} from './community-data.ts'
+import {
+	buildExistingAdaptPrompt,
+	buildExistingInstallPrompt,
+	toPublicCommunityListing,
+} from './community-public.ts'
+import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
+
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn(),
+	listCommunityListingsWithAggregates: vi.fn(),
+	searchCommunityListings: vi.fn(),
+	listFeaturedCommunityListingsWithAggregates: vi.fn(),
+	listCommunityForksByListingIdsAndUser: vi.fn(),
+	listSavedPackagesByKodyIds: vi.fn(),
+	listSavedPackagesByIds: vi.fn(),
+	getMcpUserPackageScope: vi.fn(),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	listCommunityListingsWithAggregates: (...args: Array<unknown>) =>
+		mockModule.listCommunityListingsWithAggregates(...args),
+	searchCommunityListings: (...args: Array<unknown>) =>
+		mockModule.searchCommunityListings(...args),
+	listFeaturedCommunityListingsWithAggregates: (...args: Array<unknown>) =>
+		mockModule.listFeaturedCommunityListingsWithAggregates(...args),
+	getCommunityListingWithAggregates: vi.fn(),
+}))
+
+vi.mock('#worker/community/repo.ts', () => ({
+	listCommunityForksByListingIdsAndUser: (...args: Array<unknown>) =>
+		mockModule.listCommunityForksByListingIdsAndUser(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByKodyIds: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByKodyIds(...args),
+	listSavedPackagesByIds: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByIds(...args),
+}))
+
+vi.mock('#worker/package-registry/user-scope.ts', () => ({
+	getMcpUserPackageScope: (...args: Array<unknown>) =>
+		mockModule.getMcpUserPackageScope(...args),
+}))
+
+const sampleListing = {
+	id: 'listing-github',
+	ownerUserId: 'owner-mcp-id',
+	packageId: 'pkg-1',
+	sourceId: 'src-1',
+	kodyId: 'github',
+	name: '@kody/github',
+	description: 'GitHub helpers.',
+	tags: ['github'],
+	searchText: null,
+	readmeContent: '# README',
+	license: 'MIT',
+	pinnedCommit: 'abc1234567890',
+	iconCommit: 'abc1234567890',
+	status: 'active',
+	trustedCommit: 'abc1234567890',
+	trustedAt: '2026-01-02T00:00:00.000Z',
+	trusted: true,
+	featuredAt: '2026-01-03T00:00:00.000Z',
+	featured: true,
+	createdAt: '2026-01-01T00:00:00.000Z',
+	updatedAt: '2026-01-01T00:00:00.000Z',
+	publishedAt: '2026-01-01T00:00:00.000Z',
+	averageStars: 4.5,
+	ratingCount: 2,
+	averageAdaptationEffort: 3,
+	forkCount: 1,
+	starCount: 0,
+} satisfies CommunityListingWithAggregates
+
+const publicListing = toPublicCommunityListing(sampleListing)
+
+function signedInUser() {
+	return {
+		mcpUser: { userId: 'viewer-1', username: 'burhan' },
+		roles: [],
+	}
+}
+
+test('composeCommunityDetailLoaderData includes viewerInstall when present', () => {
+	resetDataCacheForTests()
+	const viewerInstall = {
+		status: 'installed' as const,
+		targetName: '@burhan/github',
+		agentPrompt: buildExistingInstallPrompt({ targetName: '@burhan/github' }),
+	}
+	const listing: PublicCommunityListing = { ...publicListing, viewerInstall }
+	expect(
+		composeCommunityDetailLoaderData({
+			listing,
+			loggedIn: true,
+			viewerInstall,
+		}),
+	).toMatchObject({
+		ok: true,
+		loggedIn: true,
+		starredByViewer: false,
+		viewerInstall,
+		listing: expect.objectContaining({
+			id: 'listing-github',
+			viewerInstall,
+		}),
+	})
+})
+
+test('community index overlays matching kody_id installs for signed-in viewers', async () => {
+	resetDataCacheForTests()
+	mockModule.listSavedPackagesByKodyIds.mockReset()
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(signedInUser())
+	mockModule.listCommunityListingsWithAggregates.mockResolvedValue([
+		sampleListing,
+	])
+	mockModule.getMcpUserPackageScope.mockResolvedValue('burhan')
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([
+		{
+			id: 'pkg-github',
+			kodyId: 'github',
+			name: '@burhan/github',
+			sourceId: 'src-github',
+		},
+	])
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+
+	const data = await loadCommunityIndexData(
+		{} as Env,
+		new Request('https://example.com/community'),
+	)
+	expect(data.listings).toHaveLength(1)
+	expect(data.listings[0]?.viewerInstall).toEqual({
+		status: 'installed',
+		targetName: '@burhan/github',
+		agentPrompt: buildExistingInstallPrompt({ targetName: '@burhan/github' }),
+	})
+})
+
+test('onboarding featured listings overlay inert forks as adaptation_required', async () => {
+	resetDataCacheForTests()
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(signedInUser())
+	mockModule.listFeaturedCommunityListingsWithAggregates.mockResolvedValue([
+		sampleListing,
+	])
+	mockModule.getMcpUserPackageScope.mockResolvedValue('burhan')
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([
+		{
+			listingId: 'listing-github',
+			targetKodyId: 'github',
+			forkedPackageId: 'pkg-inert',
+			forkedSourceId: 'src-inert',
+			createdAt: '2026-08-01T00:00:00.000Z',
+		},
+	])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([])
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+
+	const listings = await loadOnboardingFeaturedListings(
+		{} as Env,
+		new Request('https://example.com/onboarding'),
+	)
+	expect(listings).toHaveLength(1)
+	expect(listings[0]?.viewerInstall).toEqual({
+		status: 'adaptation_required',
+		targetName: '@burhan/github',
+		agentPrompt: buildExistingAdaptPrompt({
+			targetName: '@burhan/github',
+			sourceId: 'src-inert',
+		}),
+	})
+})
+
+test('anonymous community index omits viewerInstall', async () => {
+	resetDataCacheForTests()
+	mockModule.listSavedPackagesByKodyIds.mockReset()
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	mockModule.listCommunityListingsWithAggregates.mockResolvedValue([
+		sampleListing,
+	])
+
+	const data = await loadCommunityIndexData(
+		{} as Env,
+		new Request('https://example.com/community'),
+	)
+	expect(data.listings[0]?.viewerInstall).toBeUndefined()
+	expect(mockModule.listSavedPackagesByKodyIds).not.toHaveBeenCalled()
+})

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -99,12 +99,12 @@ export async function loadCommunityIndexData(
 		},
 	)
 
-	const user = await readAuthenticatedAppUser(request, env)
+	const user = await readOptionalAuthenticatedViewer(request, env)
 	return {
 		ok: true,
 		listings: await overlayViewerInstallsOnListings({
 			env,
-			user: user?.mcpUser ?? null,
+			user,
 			listings,
 		}),
 		query: query || null,
@@ -135,10 +135,10 @@ export async function loadOnboardingFeaturedListings(
 				return rows.map(toOnboardingFeaturedListing)
 			},
 		)
-		const user = await readAuthenticatedAppUser(request, env)
+		const user = await readOptionalAuthenticatedViewer(request, env)
 		return overlayViewerInstallsOnListings({
 			env,
-			user: user?.mcpUser ?? null,
+			user,
 			listings,
 		})
 	} catch (error) {
@@ -203,7 +203,7 @@ async function loadCommunityDetailDataUncached(
 	const ownerProfilePublic = ownerRow?.profile_visibility === 'public'
 	const ownerUserId = ownerRow ? resolveUserStableId(ownerRow) : null
 
-	const user = await readAuthenticatedAppUser(request, env)
+	const user = await readOptionalAuthenticatedAppUser(request, env)
 	const viewerUserId = user?.mcpUser.userId ?? null
 	const viewerIsOwner =
 		viewerUserId != null && ownerUserId != null && viewerUserId === ownerUserId
@@ -268,6 +268,23 @@ export function composeCommunityDetailLoaderData(input: {
 		starredByViewer: input.starredByViewer ?? false,
 		viewerInstall: input.viewerInstall ?? null,
 	}
+}
+
+/**
+ * Public listing pages stay up when session parsing or user lookup fails.
+ * Viewer overlays are optional; anonymous listings are the safe fallback.
+ */
+async function readOptionalAuthenticatedAppUser(request: Request, env: Env) {
+	try {
+		return await readAuthenticatedAppUser(request, env)
+	} catch (error) {
+		console.error('Failed to resolve authenticated viewer for listings:', error)
+		return null
+	}
+}
+
+async function readOptionalAuthenticatedViewer(request: Request, env: Env) {
+	return (await readOptionalAuthenticatedAppUser(request, env))?.mcpUser ?? null
 }
 
 async function overlayViewerInstallsOnListings<

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -1,10 +1,13 @@
+import { type McpUserContext } from '@kody-internal/shared/chat.ts'
 import { readPositiveInt } from '#worker/query-params.ts'
 import {
 	buildForkPrompt,
 	toOnboardingFeaturedListing,
 	toPublicCommunityListing,
+	toViewerListingInstall,
 	type OnboardingFeaturedListing,
 	type PublicCommunityListing,
+	type ViewerListingInstall,
 } from '#app/community-public.ts'
 import {
 	buildCommunityDetailListingCacheKey,
@@ -18,6 +21,7 @@ import {
 } from '#universal/loader-data.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { setRequestDataCacheLookup } from '#app/request-cache.ts'
+import { listCommunityForksByListingIdsAndUser } from '#worker/community/repo.ts'
 import {
 	listCommunityListingsWithAggregates,
 	listFeaturedCommunityListingsWithAggregates,
@@ -29,6 +33,12 @@ import {
 	getUserFollow,
 	getUserSocialRowByUsername,
 } from '#worker/community/social-repo.ts'
+import { resolveViewerListingInstalls } from '#worker/community/viewer-install.ts'
+import {
+	listSavedPackagesByIds,
+	listSavedPackagesByKodyIds,
+} from '#worker/package-registry/repo.ts'
+import { getMcpUserPackageScope } from '#worker/package-registry/user-scope.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 
 const defaultCommunityListLimit = 50
@@ -89,9 +99,14 @@ export async function loadCommunityIndexData(
 		},
 	)
 
+	const user = await readAuthenticatedAppUser(request, env)
 	return {
 		ok: true,
-		listings,
+		listings: await overlayViewerInstallsOnListings({
+			env,
+			user: user?.mcpUser ?? null,
+			listings,
+		}),
 		query: query || null,
 	}
 }
@@ -108,12 +123,23 @@ export async function loadOnboardingFeaturedListings(
 		onboardingFeaturedListingLimit,
 	)
 	try {
-		return await loadWithCommunityCache(env, request, cacheKey, async () => {
-			const rows = await listFeaturedCommunityListingsWithAggregates({
-				env,
-				limit: onboardingFeaturedListingLimit,
-			})
-			return rows.map(toOnboardingFeaturedListing)
+		const listings = await loadWithCommunityCache(
+			env,
+			request,
+			cacheKey,
+			async () => {
+				const rows = await listFeaturedCommunityListingsWithAggregates({
+					env,
+					limit: onboardingFeaturedListingLimit,
+				})
+				return rows.map(toOnboardingFeaturedListing)
+			},
+		)
+		const user = await readAuthenticatedAppUser(request, env)
+		return overlayViewerInstallsOnListings({
+			env,
+			user: user?.mcpUser ?? null,
+			listings,
 		})
 	} catch (error) {
 		console.error('Failed to load onboarding featured listings:', error)
@@ -181,28 +207,39 @@ async function loadCommunityDetailDataUncached(
 	const viewerUserId = user?.mcpUser.userId ?? null
 	const viewerIsOwner =
 		viewerUserId != null && ownerUserId != null && viewerUserId === ownerUserId
-	const [starredByViewer, viewerFollowsOwner] = await Promise.all([
-		user != null
-			? getCommunityStar(env.APP_DB, {
-					listingId,
-					userId: user.mcpUser.userId,
-				})
-			: false,
-		user != null && ownerUserId != null && ownerProfilePublic && !viewerIsOwner
-			? getUserFollow(env.APP_DB, {
-					followerUserId: user.mcpUser.userId,
-					followeeUserId: ownerUserId,
-				})
-			: false,
-	])
+	const [starredByViewer, viewerFollowsOwner, viewerInstalls] =
+		await Promise.all([
+			user != null
+				? getCommunityStar(env.APP_DB, {
+						listingId,
+						userId: user.mcpUser.userId,
+					})
+				: false,
+			user != null &&
+			ownerUserId != null &&
+			ownerProfilePublic &&
+			!viewerIsOwner
+				? getUserFollow(env.APP_DB, {
+						followerUserId: user.mcpUser.userId,
+						followeeUserId: ownerUserId,
+					})
+				: false,
+			loadViewerListingInstalls({
+				env,
+				user: user?.mcpUser ?? null,
+				listings: [{ id: listing.id, kodyId: listing.kodyId }],
+			}),
+		])
+	const viewerInstall = viewerInstalls.get(listing.id) ?? null
 	return composeCommunityDetailLoaderData({
-		listing,
+		listing: viewerInstall ? { ...listing, viewerInstall } : listing,
 		loggedIn: Boolean(user),
 		viewerIsAdmin: user?.roles.includes('admin') ?? false,
 		starredByViewer,
 		ownerProfilePublic,
 		viewerFollowsOwner,
 		viewerIsOwner,
+		viewerInstall,
 	})
 }
 
@@ -214,6 +251,7 @@ export function composeCommunityDetailLoaderData(input: {
 	ownerProfilePublic?: boolean
 	viewerFollowsOwner?: boolean
 	viewerIsOwner?: boolean
+	viewerInstall?: ViewerListingInstall | null
 }): CommunityDetailLoaderData {
 	return {
 		ok: true,
@@ -228,5 +266,91 @@ export function composeCommunityDetailLoaderData(input: {
 			listingId: input.listing.id,
 		}),
 		starredByViewer: input.starredByViewer ?? false,
+		viewerInstall: input.viewerInstall ?? null,
+	}
+}
+
+async function overlayViewerInstallsOnListings<
+	T extends { id: string; kodyId: string },
+>(input: {
+	env: Env
+	user: McpUserContext | null
+	listings: Array<T>
+}): Promise<Array<T>> {
+	if (input.user == null || input.listings.length === 0) {
+		return input.listings
+	}
+	const viewerInstalls = await loadViewerListingInstalls({
+		env: input.env,
+		user: input.user,
+		listings: input.listings,
+	})
+	if (viewerInstalls.size === 0) return input.listings
+	return input.listings.map((listing) => {
+		const viewerInstall = viewerInstalls.get(listing.id)
+		return viewerInstall ? { ...listing, viewerInstall } : listing
+	})
+}
+
+/**
+ * Viewer overlay is per-request and never written into the public listing
+ * cache. Failures stay empty so a fork/package lookup blip cannot take down
+ * onboarding or community browse.
+ */
+async function loadViewerListingInstalls(input: {
+	env: Env
+	user: McpUserContext | null
+	listings: Array<{ id: string; kodyId: string }>
+}): Promise<Map<string, ViewerListingInstall>> {
+	if (input.user == null || input.listings.length === 0) {
+		return new Map()
+	}
+	try {
+		const listingIds = input.listings.map((listing) => listing.id)
+		const kodyIds = input.listings.map((listing) => listing.kodyId)
+		const [packageScope, forks, savedByKody] = await Promise.all([
+			getMcpUserPackageScope(input.env.APP_DB, input.user),
+			listCommunityForksByListingIdsAndUser(input.env.APP_DB, {
+				listingIds,
+				userId: input.user.userId,
+			}),
+			listSavedPackagesByKodyIds(input.env.APP_DB, {
+				userId: input.user.userId,
+				kodyIds,
+			}),
+		])
+		const missingPackageIds = [
+			...new Set(
+				forks
+					.map((fork) => fork.forkedPackageId)
+					.filter(
+						(packageId) =>
+							!savedByKody.some(
+								(savedPackage) => savedPackage.id === packageId,
+							),
+					),
+			),
+		]
+		const savedByForkId =
+			missingPackageIds.length === 0
+				? []
+				: await listSavedPackagesByIds(input.env.APP_DB, {
+						userId: input.user.userId,
+						packageIds: missingPackageIds,
+					})
+		const resolved = resolveViewerListingInstalls({
+			listings: input.listings,
+			packageScope,
+			savedPackages: [...savedByKody, ...savedByForkId],
+			forks,
+		})
+		const viewerInstalls = new Map<string, ViewerListingInstall>()
+		for (const [listingId, install] of resolved) {
+			viewerInstalls.set(listingId, toViewerListingInstall(install))
+		}
+		return viewerInstalls
+	} catch (error) {
+		console.error('Failed to load viewer listing installs:', error)
+		return new Map()
 	}
 }

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -139,6 +139,21 @@ export function CommunityDetailContent(
 						Featured
 					</span>
 				) : null}
+				{listing.viewerInstall ? (
+					<span
+						data-testid="community-detail-viewer-install-badge"
+						title={
+							listing.viewerInstall.status === 'installed'
+								? `Installed in your account as ${listing.viewerInstall.targetName}.`
+								: `Forked in your account as ${listing.viewerInstall.targetName}; still needs adaptation.`
+						}
+						mix={css(badgeCss)}
+					>
+						{listing.viewerInstall.status === 'installed'
+							? 'Installed'
+							: 'Forked'}
+					</span>
+				) : null}
 			</header>
 
 			<p data-rise style={{ '--rise': '2' }} mix={css(detailSubCss)}>

--- a/packages/worker/src/app/community-listings-content.tsx
+++ b/packages/worker/src/app/community-listings-content.tsx
@@ -65,13 +65,32 @@ export function CommunityListingsContent(
 										{renderCommunityListingName(listing.name)}
 									</a>
 								</h2>
-								{listing.trusted ? (
-									<span
-										data-testid={`community-listing-trusted-${listing.id}`}
-										title="An admin reviewed this exact version and marked it trusted."
-										mix={css(trustedBadgeCss)}
-									>
-										Trusted
+								{listing.trusted || listing.viewerInstall ? (
+									<span mix={css(listingBadgeGroupCss)}>
+										{listing.trusted ? (
+											<span
+												data-testid={`community-listing-trusted-${listing.id}`}
+												title="An admin reviewed this exact version and marked it trusted."
+												mix={css(communityBadgePillCss)}
+											>
+												Trusted
+											</span>
+										) : null}
+										{listing.viewerInstall ? (
+											<span
+												data-testid={`community-listing-viewer-install-${listing.id}`}
+												title={
+													listing.viewerInstall.status === 'installed'
+														? `Installed in your account as ${listing.viewerInstall.targetName}.`
+														: `Forked in your account as ${listing.viewerInstall.targetName}; still needs adaptation.`
+												}
+												mix={css(communityBadgePillCss)}
+											>
+												{listing.viewerInstall.status === 'installed'
+													? 'Installed'
+													: 'Forked'}
+											</span>
+										) : null}
 									</span>
 								) : null}
 							</div>
@@ -227,9 +246,12 @@ export const communityBadgePillCss = {
 	cursor: 'help',
 }
 
-const trustedBadgeCss = {
-	...communityBadgePillCss,
+const listingBadgeGroupCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: '0.35rem',
 	marginLeft: 'auto',
+	flex: 'none',
 }
 
 const listingDescriptionCss = {

--- a/packages/worker/src/app/community-public.ts
+++ b/packages/worker/src/app/community-public.ts
@@ -5,6 +5,7 @@ import {
 	type PublicCommunityProfile,
 	type PublicCommunityStargazer,
 	type PublicProfilePackageItem,
+	type ViewerListingInstall,
 } from '#universal/community-public-types.ts'
 import { routes } from '#universal/routes.ts'
 import {
@@ -22,6 +23,7 @@ import {
 export {
 	type OnboardingFeaturedListing,
 	type PublicCommunityListing,
+	type ViewerListingInstall,
 } from '#universal/community-public-types.ts'
 export {
 	buildUserAvatarUrl,
@@ -169,4 +171,39 @@ export function buildInstallAdaptPrompt(input: {
 	sourceId: string
 }) {
 	return `I one-click installed the community package "${input.targetName}" on Kody, but it needs adaptation before it can be published. The fork is an inert source in my account (source_id: ${input.sourceId}). Open it with repo_open_session, do a read-only safety review of all files, fix the failing publish checks — re-implement or remove any cross-scope kody:@ imports — rewrite the README Intent section for my goals, then publish with repo_publish_session.`
+}
+
+export function buildExistingInstallPrompt(input: { targetName: string }) {
+	return `I already have the community package "${input.targetName}" in my Kody account. Call package_get for it and read its README, then walk me through any remaining setup: create required secrets or OAuth connections, approve package secret access if prompted, and run a quick test to confirm it works.`
+}
+
+export function buildExistingAdaptPrompt(input: {
+	targetName: string
+	sourceId: string
+}) {
+	return `I already forked the community package "${input.targetName}" on Kody, but it still needs adaptation before it can be published. The fork is an inert source in my account (source_id: ${input.sourceId}). Open it with repo_open_session, do a read-only safety review of all files, fix the failing publish checks — re-implement or remove any cross-scope kody:@ imports — rewrite the README Intent section for my goals, then publish with repo_publish_session.`
+}
+
+export function toViewerListingInstall(input: {
+	status: 'installed' | 'adaptation_required'
+	targetName: string
+	sourceId: string
+}): ViewerListingInstall {
+	if (input.status === 'installed') {
+		return {
+			status: input.status,
+			targetName: input.targetName,
+			agentPrompt: buildExistingInstallPrompt({
+				targetName: input.targetName,
+			}),
+		}
+	}
+	return {
+		status: input.status,
+		targetName: input.targetName,
+		agentPrompt: buildExistingAdaptPrompt({
+			targetName: input.targetName,
+			sourceId: input.sourceId,
+		}),
+	}
 }

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -7,6 +7,10 @@ const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
 	getUserSocialRowByUsername: vi.fn(),
 	getUserFollow: vi.fn(),
+	listCommunityForksByListingIdsAndUser: vi.fn(),
+	listSavedPackagesByKodyIds: vi.fn(),
+	listSavedPackagesByIds: vi.fn(),
+	getMcpUserPackageScope: vi.fn(),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -27,6 +31,23 @@ vi.mock('#worker/community/social-repo.ts', () => ({
 	getUserFollow: (...args: Array<unknown>) => mockModule.getUserFollow(...args),
 	getUserSocialRowByUsername: (...args: Array<unknown>) =>
 		mockModule.getUserSocialRowByUsername(...args),
+}))
+
+vi.mock('#worker/community/repo.ts', () => ({
+	listCommunityForksByListingIdsAndUser: (...args: Array<unknown>) =>
+		mockModule.listCommunityForksByListingIdsAndUser(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByKodyIds: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByKodyIds(...args),
+	listSavedPackagesByIds: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByIds(...args),
+}))
+
+vi.mock('#worker/package-registry/user-scope.ts', () => ({
+	getMcpUserPackageScope: (...args: Array<unknown>) =>
+		mockModule.getMcpUserPackageScope(...args),
 }))
 
 const sampleListing = {
@@ -64,6 +85,10 @@ const env = {} as Env
 test('community detail handler returns bare detail frame HTML for target header', async () => {
 	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([])
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+	mockModule.getMcpUserPackageScope.mockResolvedValue('viewer')
 	mockModule.getUserSocialRowByUsername.mockResolvedValue({
 		profile_visibility: 'public',
 		stable_user_id: 'owner-mcp-id',
@@ -121,9 +146,18 @@ test('community detail handler returns bare detail frame HTML for target header'
 		stable_user_id: 'owner-mcp-id',
 	})
 	mockModule.readAuthenticatedAppUser.mockResolvedValue({
-		mcpUser: { userId: 'viewer-mcp-id' },
+		mcpUser: { userId: 'viewer-mcp-id', username: 'burhan' },
 		roles: [],
 	})
+	mockModule.getMcpUserPackageScope.mockResolvedValue('burhan')
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([
+		{
+			id: 'pkg-github',
+			kodyId: 'github-triage',
+			name: '@burhan/github-triage',
+			sourceId: 'src-github',
+		},
+	])
 	const signedInResponse = await handler.handler({
 		request: new Request('https://example.com/community/listing-1', {
 			headers: { 'x-remix-target': 'community-detail' },
@@ -133,6 +167,10 @@ test('community detail handler returns bare detail frame HTML for target header'
 	} as never)
 	const signedInHtml = await signedInResponse.text()
 	expect(signedInHtml).toContain('data-testid="community-detail-owner-follow"')
+	expect(signedInHtml).toContain(
+		'data-testid="community-detail-viewer-install-badge"',
+	)
+	expect(signedInHtml).toContain('Installed')
 	expect(signedInHtml).toContain('name="follow"')
 	expect(signedInHtml).toContain('name="returnTo"')
 	expect(signedInHtml).toContain('/profiles/kentcdodds/follow.json')

--- a/packages/worker/src/app/handlers/community-detail.tsx
+++ b/packages/worker/src/app/handlers/community-detail.tsx
@@ -68,6 +68,7 @@ export function createCommunityDetailHandler(env: Env) {
 						readmeContent: detail.listing.readmeContent,
 						starCount: detail.listing.starCount,
 						starredByViewer: detail.starredByViewer,
+						viewerInstall: detail.viewerInstall,
 					},
 				},
 			})

--- a/packages/worker/src/app/handlers/community.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community.frame.node.test.ts
@@ -5,6 +5,11 @@ import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
 const mockModule = vi.hoisted(() => ({
 	listCommunityListingsWithAggregates: vi.fn(),
 	searchCommunityListings: vi.fn(),
+	readAuthenticatedAppUser: vi.fn(),
+	listCommunityForksByListingIdsAndUser: vi.fn(),
+	listSavedPackagesByKodyIds: vi.fn(),
+	listSavedPackagesByIds: vi.fn(),
+	getMcpUserPackageScope: vi.fn(),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -12,6 +17,28 @@ vi.mock('#worker/community/service.ts', () => ({
 		mockModule.listCommunityListingsWithAggregates(...args),
 	searchCommunityListings: (...args: Array<unknown>) =>
 		mockModule.searchCommunityListings(...args),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#worker/community/repo.ts', () => ({
+	listCommunityForksByListingIdsAndUser: (...args: Array<unknown>) =>
+		mockModule.listCommunityForksByListingIdsAndUser(...args),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByKodyIds: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByKodyIds(...args),
+	listSavedPackagesByIds: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByIds(...args),
+}))
+
+vi.mock('#worker/package-registry/user-scope.ts', () => ({
+	getMcpUserPackageScope: (...args: Array<unknown>) =>
+		mockModule.getMcpUserPackageScope(...args),
 }))
 
 const sampleListing = {
@@ -47,6 +74,7 @@ const sampleListing = {
 const env = {} as Env
 
 test('community page handler returns bare listings frame HTML for target header', async () => {
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
 	mockModule.listCommunityListingsWithAggregates.mockResolvedValue([
 		sampleListing,
 	])
@@ -67,4 +95,35 @@ test('community page handler returns bare listings frame HTML for target header'
 	expect(html).toContain('data-testid="community-listing-icon-card"')
 	expect(html).toContain('/community/listing-1/icon/abc1234567890')
 	expect(html).not.toContain('<html')
+	expect(html).not.toContain(
+		'data-testid="community-listing-viewer-install-listing-1"',
+	)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		mcpUser: { userId: 'viewer-1', username: 'burhan' },
+		roles: [],
+	})
+	mockModule.getMcpUserPackageScope.mockResolvedValue('burhan')
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([
+		{
+			id: 'pkg-github',
+			kodyId: 'github-triage',
+			name: '@burhan/github-triage',
+			sourceId: 'src-github',
+		},
+	])
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+	const signedInResponse = await handler.handler({
+		request: new Request('https://example.com/community', {
+			headers: { 'x-remix-target': 'community-listings' },
+		}),
+		params: {},
+		url: new URL('https://example.com/community'),
+	} as never)
+	const signedInHtml = await signedInResponse.text()
+	expect(signedInHtml).toContain(
+		'data-testid="community-listing-viewer-install-listing-1"',
+	)
+	expect(signedInHtml).toContain('Installed')
 })

--- a/packages/worker/src/app/handlers/community.node.test.ts
+++ b/packages/worker/src/app/handlers/community.node.test.ts
@@ -5,6 +5,7 @@ import { type CommunityListingWithAggregates } from '#worker/community/types.ts'
 const mockModule = vi.hoisted(() => ({
 	listCommunityListingsWithAggregates: vi.fn(),
 	searchCommunityListings: vi.fn(),
+	readAuthenticatedAppUser: vi.fn(),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -12,6 +13,11 @@ vi.mock('#worker/community/service.ts', () => ({
 		mockModule.listCommunityListingsWithAggregates(...args),
 	searchCommunityListings: (...args: Array<unknown>) =>
 		mockModule.searchCommunityListings(...args),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
 }))
 
 const sampleListing = {
@@ -47,6 +53,7 @@ const sampleListing = {
 const env = {} as Env
 
 test('community API lists active listings and searches when q is provided', async () => {
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
 	mockModule.listCommunityListingsWithAggregates.mockResolvedValue([
 		sampleListing,
 	])

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -14,8 +14,17 @@ import {
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn(),
+}))
+
 vi.mock('#app/ssr-render.tsx', () => ({
 	renderAppPage: vi.fn(async () => new Response('ok')),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
 }))
 
 vi.mock('#worker/community/service.ts', () => ({
@@ -23,6 +32,7 @@ vi.mock('#worker/community/service.ts', () => ({
 }))
 
 test('onboarding serves public setup content to anonymous visitors', async () => {
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
 	setAuthSessionSecret(testCookieSecret)
 	const env = { COOKIE_SECRET: testCookieSecret } as Env
 

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -725,6 +725,37 @@ export async function listCommunityForksByListingAndUser(
 	return (result.results ?? []).map((row) => mapCommunityForkRow(row))
 }
 
+export async function listCommunityForksByListingIdsAndUser(
+	db: D1Database,
+	input: {
+		listingIds: Array<string>
+		userId: string
+	},
+): Promise<Array<CommunityForkRecord>> {
+	if (input.listingIds.length === 0) return []
+	const uniqueListingIds = [...new Set(input.listingIds)]
+	const forks: Array<CommunityForkRecord> = []
+	for (const idChunk of chunkArray(
+		uniqueListingIds,
+		maxSqlBindingsPerChunk - 1,
+	)) {
+		const placeholders = idChunk.map(() => '?').join(', ')
+		const rows = await db
+			.prepare(
+				`SELECT ${communityForkSelectColumns}
+				FROM community_forks
+				WHERE forker_user_id = ? AND listing_id IN (${placeholders})
+				ORDER BY created_at ASC`,
+			)
+			.bind(input.userId, ...idChunk)
+			.all<Record<string, unknown>>()
+		for (const row of rows.results ?? []) {
+			forks.push(mapCommunityForkRow(row))
+		}
+	}
+	return forks
+}
+
 export async function countCommunityForksByListingIds(
 	db: D1Database,
 	listingIds: Array<string>,

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -725,6 +725,10 @@ export async function listCommunityForksByListingAndUser(
 	return (result.results ?? []).map((row) => mapCommunityForkRow(row))
 }
 
+/**
+ * Viewer forks for a set of listings. `ORDER BY created_at` applies inside
+ * each D1 chunk only; callers that need a global order must sort themselves.
+ */
 export async function listCommunityForksByListingIdsAndUser(
 	db: D1Database,
 	input: {

--- a/packages/worker/src/community/viewer-install.node.test.ts
+++ b/packages/worker/src/community/viewer-install.node.test.ts
@@ -7,6 +7,7 @@ test('resolveViewerListingInstalls prefers matching kody_id, then listing forks'
 		{ id: 'listing-cloudflare', kodyId: 'cloudflare' },
 		{ id: 'listing-notion', kodyId: 'notion' },
 		{ id: 'listing-slack', kodyId: 'slack' },
+		{ id: 'listing-dropbox', kodyId: 'dropbox' },
 	]
 
 	const resolved = resolveViewerListingInstalls({
@@ -48,6 +49,20 @@ test('resolveViewerListingInstalls prefers matching kody_id, then listing forks'
 				forkedSourceId: 'src-notion-old',
 				createdAt: '2026-07-01T00:00:00.000Z',
 			},
+			{
+				listingId: 'listing-dropbox',
+				targetKodyId: 'older-dropbox',
+				forkedPackageId: 'pkg-dropbox-old',
+				forkedSourceId: 'src-dropbox-old',
+				createdAt: '2026-06-01T00:00:00.000Z',
+			},
+			{
+				listingId: 'listing-dropbox',
+				targetKodyId: 'my-dropbox',
+				forkedPackageId: 'pkg-dropbox-new',
+				forkedSourceId: 'src-dropbox-new',
+				createdAt: '2026-08-03T00:00:00.000Z',
+			},
 		],
 	})
 
@@ -67,4 +82,9 @@ test('resolveViewerListingInstalls prefers matching kody_id, then listing forks'
 		sourceId: 'src-notion',
 	})
 	expect(resolved.has('listing-slack')).toBe(false)
+	expect(resolved.get('listing-dropbox')).toEqual({
+		status: 'adaptation_required',
+		targetName: '@burhan/my-dropbox',
+		sourceId: 'src-dropbox-new',
+	})
 })

--- a/packages/worker/src/community/viewer-install.node.test.ts
+++ b/packages/worker/src/community/viewer-install.node.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'vitest'
+import { resolveViewerListingInstalls } from './viewer-install.ts'
+
+test('resolveViewerListingInstalls prefers matching kody_id, then listing forks', () => {
+	const listings = [
+		{ id: 'listing-github', kodyId: 'github' },
+		{ id: 'listing-cloudflare', kodyId: 'cloudflare' },
+		{ id: 'listing-notion', kodyId: 'notion' },
+		{ id: 'listing-slack', kodyId: 'slack' },
+	]
+
+	const resolved = resolveViewerListingInstalls({
+		listings,
+		packageScope: 'burhan',
+		savedPackages: [
+			{
+				id: 'pkg-github',
+				kodyId: 'github',
+				name: '@burhan/github',
+				sourceId: 'src-github',
+			},
+			{
+				id: 'pkg-notion-custom',
+				kodyId: 'my-notion',
+				name: '@burhan/my-notion',
+				sourceId: 'src-notion',
+			},
+		],
+		forks: [
+			{
+				listingId: 'listing-cloudflare',
+				targetKodyId: 'cloudflare',
+				forkedPackageId: 'pkg-cf-inert',
+				forkedSourceId: 'src-cf',
+				createdAt: '2026-08-01T00:00:00.000Z',
+			},
+			{
+				listingId: 'listing-notion',
+				targetKodyId: 'my-notion',
+				forkedPackageId: 'pkg-notion-custom',
+				forkedSourceId: 'src-notion',
+				createdAt: '2026-08-02T00:00:00.000Z',
+			},
+			{
+				listingId: 'listing-notion',
+				targetKodyId: 'older-notion',
+				forkedPackageId: 'pkg-notion-old',
+				forkedSourceId: 'src-notion-old',
+				createdAt: '2026-07-01T00:00:00.000Z',
+			},
+		],
+	})
+
+	expect(resolved.get('listing-github')).toEqual({
+		status: 'installed',
+		targetName: '@burhan/github',
+		sourceId: 'src-github',
+	})
+	expect(resolved.get('listing-cloudflare')).toEqual({
+		status: 'adaptation_required',
+		targetName: '@burhan/cloudflare',
+		sourceId: 'src-cf',
+	})
+	expect(resolved.get('listing-notion')).toEqual({
+		status: 'installed',
+		targetName: '@burhan/my-notion',
+		sourceId: 'src-notion',
+	})
+	expect(resolved.has('listing-slack')).toBe(false)
+})

--- a/packages/worker/src/community/viewer-install.ts
+++ b/packages/worker/src/community/viewer-install.ts
@@ -1,0 +1,104 @@
+export type ViewerInstallListingRef = {
+	id: string
+	kodyId: string
+}
+
+export type ViewerInstallSavedPackage = {
+	id: string
+	kodyId: string
+	name: string
+	sourceId: string
+}
+
+export type ViewerInstallFork = {
+	listingId: string
+	targetKodyId: string
+	forkedPackageId: string
+	forkedSourceId: string
+	createdAt: string
+}
+
+export type ResolvedViewerListingInstall = {
+	status: 'installed' | 'adaptation_required'
+	targetName: string
+	sourceId: string
+}
+
+function compareCreatedAtDesc(left: string, right: string) {
+	if (left === right) return 0
+	return left > right ? -1 : 1
+}
+
+function scopedPackageName(packageScope: string, kodyId: string) {
+	return `@${packageScope}/${kodyId}`
+}
+
+/**
+ * Pick the viewer's existing install/fork for each listing.
+ *
+ * A saved package whose `kody_id` matches the listing wins (that is the
+ * default one-click target, and a second install would collide). Otherwise
+ * use a `community_forks` row for the listing: a live saved package for that
+ * fork counts as installed; an inert source still needs adaptation.
+ */
+export function resolveViewerListingInstalls(input: {
+	listings: Array<ViewerInstallListingRef>
+	packageScope: string
+	savedPackages: Array<ViewerInstallSavedPackage>
+	forks: Array<ViewerInstallFork>
+}): Map<string, ResolvedViewerListingInstall> {
+	const savedByKodyId = new Map<string, ViewerInstallSavedPackage>()
+	const savedById = new Map<string, ViewerInstallSavedPackage>()
+	for (const savedPackage of input.savedPackages) {
+		savedByKodyId.set(savedPackage.kodyId, savedPackage)
+		savedById.set(savedPackage.id, savedPackage)
+	}
+
+	const forksByListingId = new Map<string, Array<ViewerInstallFork>>()
+	for (const fork of input.forks) {
+		const existing = forksByListingId.get(fork.listingId)
+		if (existing) existing.push(fork)
+		else forksByListingId.set(fork.listingId, [fork])
+	}
+	for (const forks of forksByListingId.values()) {
+		forks.sort((left, right) =>
+			compareCreatedAtDesc(left.createdAt, right.createdAt),
+		)
+	}
+
+	const resolved = new Map<string, ResolvedViewerListingInstall>()
+	for (const listing of input.listings) {
+		const savedByKody = savedByKodyId.get(listing.kodyId)
+		if (savedByKody) {
+			resolved.set(listing.id, {
+				status: 'installed',
+				targetName: savedByKody.name,
+				sourceId: savedByKody.sourceId,
+			})
+			continue
+		}
+
+		const listingForks = forksByListingId.get(listing.id)
+		if (!listingForks || listingForks.length === 0) continue
+		const matchingKodyFork = listingForks.find(
+			(fork) => fork.targetKodyId === listing.kodyId,
+		)
+		const fork = matchingKodyFork ?? listingForks[0]
+		if (!fork) continue
+		const forkedSaved = savedById.get(fork.forkedPackageId)
+		if (forkedSaved) {
+			resolved.set(listing.id, {
+				status: 'installed',
+				targetName: forkedSaved.name,
+				sourceId: forkedSaved.sourceId,
+			})
+			continue
+		}
+		resolved.set(listing.id, {
+			status: 'adaptation_required',
+			targetName: scopedPackageName(input.packageScope, fork.targetKodyId),
+			sourceId: fork.forkedSourceId,
+		})
+	}
+	return resolved
+}

--- a/packages/worker/src/package-registry/repo.ts
+++ b/packages/worker/src/package-registry/repo.ts
@@ -1,6 +1,9 @@
+import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
 import { buildLengthSafeVectorId } from '#worker/vectorize/vector-ids.ts'
 import { type SavedPackageRecord, type SavedPackageRow } from './types.ts'
+
+const maxSqlBindingsPerChunk = 90
 
 export function savedPackageVectorId(packageId: string) {
 	return buildLengthSafeVectorId({ prefix: 'package', rawId: packageId })
@@ -215,6 +218,63 @@ export async function listSavedPackagesByUserId(
 		.bind(input.userId)
 		.all<Record<string, unknown>>()
 	return (rows.results ?? []).map(mapSavedPackageRow)
+}
+
+export async function listSavedPackagesByKodyIds(
+	db: D1Database,
+	input: {
+		userId: string
+		kodyIds: Array<string>
+	},
+): Promise<Array<SavedPackageRecord>> {
+	if (input.kodyIds.length === 0) return []
+	const uniqueKodyIds = [...new Set(input.kodyIds)]
+	const packages: Array<SavedPackageRecord> = []
+	for (const idChunk of chunkArray(uniqueKodyIds, maxSqlBindingsPerChunk - 1)) {
+		const placeholders = idChunk.map(() => '?').join(', ')
+		const rows = await db
+			.prepare(
+				`SELECT ${savedPackageSelectColumns}
+				FROM saved_packages
+				WHERE user_id = ? AND kody_id IN (${placeholders})`,
+			)
+			.bind(input.userId, ...idChunk)
+			.all<Record<string, unknown>>()
+		for (const row of rows.results ?? []) {
+			packages.push(mapSavedPackageRow(row))
+		}
+	}
+	return packages
+}
+
+export async function listSavedPackagesByIds(
+	db: D1Database,
+	input: {
+		userId: string
+		packageIds: Array<string>
+	},
+): Promise<Array<SavedPackageRecord>> {
+	if (input.packageIds.length === 0) return []
+	const uniquePackageIds = [...new Set(input.packageIds)]
+	const packages: Array<SavedPackageRecord> = []
+	for (const idChunk of chunkArray(
+		uniquePackageIds,
+		maxSqlBindingsPerChunk - 1,
+	)) {
+		const placeholders = idChunk.map(() => '?').join(', ')
+		const rows = await db
+			.prepare(
+				`SELECT ${savedPackageSelectColumns}
+				FROM saved_packages
+				WHERE user_id = ? AND id IN (${placeholders})`,
+			)
+			.bind(input.userId, ...idChunk)
+			.all<Record<string, unknown>>()
+		for (const row of rows.results ?? []) {
+			packages.push(mapSavedPackageRow(row))
+		}
+	}
+	return packages
 }
 
 export type SavedPackageSearchSort = 'updated' | 'created' | 'name'

--- a/packages/worker/universal/community-public-types.ts
+++ b/packages/worker/universal/community-public-types.ts
@@ -1,4 +1,14 @@
 /**
+ * Signed-in viewer's existing fork/install of a community listing. Present
+ * only on viewer-specific payloads (never cached with public listing rows).
+ */
+export type ViewerListingInstall = {
+	status: 'installed' | 'adaptation_required'
+	targetName: string
+	agentPrompt: string
+}
+
+/**
  * Public listing shape shared by server loaders/handlers and client routes.
  * Keep this module dependency-free so it can live in the universal layer.
  */
@@ -23,6 +33,11 @@ export type PublicCommunityListing = {
 	averageAdaptationEffort: number | null
 	forkCount: number
 	starCount: number
+	/**
+	 * Set only for signed-in viewers after a per-request overlay. Public
+	 * listing cache rows omit this field.
+	 */
+	viewerInstall?: ViewerListingInstall | null
 }
 
 export type ProfileVisibility = 'public' | 'private'
@@ -84,4 +99,6 @@ export type OnboardingFeaturedListing = {
 	description: string
 	iconUrl: string
 	tags: Array<string>
+	/** Set only for signed-in viewers who already forked or installed this listing. */
+	viewerInstall?: ViewerListingInstall | null
 }

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -6,6 +6,7 @@ import {
 	type PublicCommunityProfile,
 	type PublicCommunityStargazer,
 	type PublicProfilePackageItem,
+	type ViewerListingInstall,
 } from '#universal/community-public-types.ts'
 import { type PermissionString, type RoleName } from '#universal/permissions.ts'
 import { type AdminFeatureFlag } from '#universal/feature-flags/types.ts'
@@ -86,6 +87,8 @@ export type CommunityDetailLoaderData = {
 	viewerIsAdmin: boolean
 	forkPrompt: string
 	starredByViewer: boolean
+	/** Existing fork/install for the signed-in viewer, when one exists. */
+	viewerInstall: ViewerListingInstall | null
 }
 
 /** SSR-embedded shell data for client-only regions on the detail page. */
@@ -102,6 +105,7 @@ export type CommunityDetailShellLoaderData = {
 	readmeContent: string | null
 	starCount: number
 	starredByViewer: boolean
+	viewerInstall: ViewerListingInstall | null
 }
 
 export type ProfileLoaderData = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Onboarding Copy prompt tooltips were jittering between vertically stacked starter cards (e.g. `@kody/github` and `@kody/cloudflare`). Remix UI popovers flip into nearby buttons and steal hover, so those tips now use CSS hover/focus tooltips with `pointer-events: none`.

Signed-in viewers who already have a matching `kody_id` saved package or a fork of the listing now see **Copy prompt** / **Installed** (or **Forked**) instead of Install on onboarding, community search cards, and listing detail.

## Changes

- Replace `remix/ui/popover` on onboarding Copy prompt buttons with CSS tooltips that cannot become hover targets.
- Overlay a per-request `viewerInstall` from saved packages (`kody_id`) and `community_forks` without putting viewer state in the public listing cache.
- Show Installed / Forked badges on `/community` cards and listing detail, and prefill Copy prompt + agent prompt when a fork already exists.
- Docs: usage and contributing community-package pages.

## Tests

- `resolveViewerListingInstalls` prefers matching `kody_id`, then listing forks.
- Community index / onboarding featured loaders overlay viewer installs for signed-in users and omit them for anonymous visitors.
- Frame HTML includes Installed badges for signed-in viewers.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1916ffea` · **Head:** `1a2cdcde`

**Classification:** extends — viewer-install overlay changes community listing payloads and UI; saved-package lookup gains batch kody_id/id helpers.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — CSS copy-prompt tooltips; viewerInstall on onboarding/detail/search UI |
| `community-listings` | assistant | extends — per-request viewerInstall overlay from forks + matching kody_id |
| `saved-packages` | assistant | extends — batch `listSavedPackagesByKodyIds` / `listSavedPackagesByIds` |

### System map

Signed-in community browse loads public listings, then overlays the viewer's existing fork/install so onboarding and listing UI show Copy prompt instead of Install.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	communityListings["community-listings<br/>Community package listings"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	appUi -->|"onboarding + /community + detail Copy prompt"| communityListings
	communityListings -->|"viewerInstall from forks + kody_id"| savedPackages
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant UI as Onboarding / community UI
	participant Loader as community-data
	participant Forks as community_forks
	participant Pkgs as saved_packages
	UI->>Loader: load featured / index / detail
	Loader->>Forks: list forks for viewer + listing ids
	Loader->>Pkgs: list packages by kody_id / fork package ids
	Loader-->>UI: viewerInstall overlay (Copy prompt)
```

### Before / after

**Onboarding Copy prompt tooltip**

```diff
- remix/ui popover (top-layer, can flip onto another card and steal hover)
+ CSS hover/focus tooltip with pointer-events: none
```

**Signed-in listing surfaces**

```diff
- Always show Install until the user clicks it in this session
+ If matching kody_id or listing fork exists: Copy prompt + Installed/Forked
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ced490ff-c8aa-495c-a6ab-be1d28597c54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ced490ff-c8aa-495c-a6ab-be1d28597c54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Community listings and detail pages now show whether a package is **Installed** or **Forked**.
  - Existing installations offer **Copy prompt** or setup guidance instead of duplicate installation.
  - Onboarding cards display existing install status and provide prompts immediately.
  - Anonymous visitors continue to see no viewer-specific install information.

- **Documentation**
  - Updated community package and onboarding guidance for install statuses, copy prompts, and setup options.

- **Tests**
  - Added coverage for authenticated, anonymous, installed, forked, and adaptation-required scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->