### PR TITLE
docs(packages): correct removed helper behavior

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -262,11 +262,13 @@ dispatch without being republished.
 
 **Unsupported helpers:** `packages.invokeChecked`, `packages.check`, and literal
 dynamic `import("kody:@...")` are not available. `packages.invoke` subsumes both
-helpers because checking is not optional or separate. The sandbox prelude throws
-teaching errors for `check` / `invokeChecked`, the bundler rewrites literal
-dynamic kody imports to a teaching error, and publish checks fail on all three
-with the replacement named (`deprecated-invocation-usage.ts`, shared with the
-permanent `0002-static-first-invocation` repair codemod). See
+helpers because checking is not optional or separate. Publish checks fail on all
+three unsupported forms with the replacement named
+(`deprecated-invocation-usage.ts`), and the bundler rewrites literal dynamic
+kody imports to a teaching error. The runtime `packages` helper exposes only
+`invoke`, so accessing `check` or `invokeChecked` throws a normal `TypeError`.
+The permanent `0002-static-first-invocation` repair codemod remains available.
+See
 [Invocation overhead guardrails](./architecture/invocation-overhead-guardrails.md)
 for the performance budget that keeps the keyless path honest.
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -264,9 +264,10 @@ package-mounted secrets (`kody.secretMounts`), and its own `packages` helper.
 
 **Unsupported helpers:** `packages.invokeChecked`, `packages.check`, and literal
 dynamic `import("kody:@...")` are not available. Package publish checks reject
-them permanently, and runtime teaching errors name the supported replacement.
-`packages.invoke` performs the contract check inline, and the static/dynamic
-rules above cover literal dynamic import cases. The
+all three with the supported replacement named. At runtime, the `packages`
+helper exposes only `invoke`, so accessing `check` or `invokeChecked` throws a
+normal `TypeError`. `packages.invoke` performs the contract check inline, and
+the static/dynamic rules above cover literal dynamic import cases. The
 `0002-static-first-invocation` package codemod remains available to repair
 `invokeChecked` call sites mechanically.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep package documentation aligned with the runtime helper contract shipped in #1309.

## Summary

- Clarify that publish checks reject `packages.check`, `packages.invokeChecked`, and literal dynamic Kody imports while naming replacements.
- Document that the runtime `packages` helper exposes only `invoke`, so removed properties produce a normal `TypeError` rather than teaching errors.
- Preserve the bundler rewrite and repair codemod guidance.

## Testing

- `npm run validate`: passed.
- Pre-push checks: passed.
- PR CI: passed; the AI reviewer was rate-limited and produced no feedback.
- Production deployment: passed ([run](https://github.com/kentcdodds/kody/actions/runs/31243470872)).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `e52578a` · **Head:** `2b32759`

**Classification:** composes — documentation-only correction; no runtime primitive or invariant changes.

### Primitives touched

None. The diff updates contributor and usage documentation only.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90d4cf9e-cad4-46bd-a0ea-0f9e03489457?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90d4cf9e-cad4-46bd-a0ea-0f9e03489457&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

