### PR TITLE
fix(sentry): drop injected og:type meta probe noise (KODY-CLOUDFLARE-46)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -7,6 +7,7 @@ import {
 	filterFathomRemoveChildNullSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
 	filterMetaMaskExtensionSentryEvent,
+	filterOgTypeMetaQuerySelectorContentSentryEvent,
 	filterTwitterInAppBrowserConfigSentryEvent,
 } from './sentry-browser-filters.ts'
 
@@ -362,6 +363,74 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 								{
 									function: 'updateGapFiller',
 									abs_path: 'https://heykody.app/',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+
+	// Injected unguarded og:type meta probe (issue 7660258027 /
+	// KODY-CLOUDFLARE-46). Requires both the Safari evaluating wording and a
+	// `global code` frame — same message from app bundles stays.
+	expect(
+		filterOgTypeMetaQuerySelectorContentSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"null is not an object (evaluating 'document.querySelector(\"meta[property='og:type']\").content')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'global code',
+									filename: '/guides/what-is-kody',
+									abs_path: 'https://heykody.app/guides/what-is-kody',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterOgTypeMetaQuerySelectorContentSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"null is not an object (evaluating 'document.querySelector(\"meta[property='og:type']\").content')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'applyDocumentHead',
+									filename: 'https://heykody.app/assets/document-head.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value:
+							"TypeError: null is not an object (evaluating 'document.querySelector(\"meta[property='og:type']\").content')",
+						stacktrace: {
+							frames: [
+								{
+									function: 'global code',
+									absPath: 'https://heykody.app/guides/what-is-kody',
 								},
 							],
 						},

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -444,6 +444,62 @@ export function filterTwitterInAppBrowserConfigSentryEvent<
 	return event
 }
 
+/**
+ * Injected page scripts (Mobile Safari / in-app browsers / content scripts)
+ * sometimes probe Open Graph tags with an unguarded
+ * `document.querySelector("meta[property='og:type']").content`. When the page
+ * has no managed OG tags (guides and many authenticated routes), WebKit throws
+ * and attributes the frame to `global code` on the document URL — never a Kody
+ * bundle. Signature from production issue 7660258027 / KODY-CLOUDFLARE-46.
+ *
+ * Kody only writes `og:type` in document-head / SSR; it never reads it this
+ * way. Match is intentionally narrow: Safari "null is not an object
+ * (evaluating 'document.querySelector(…og:type…).content')" wording AND a
+ * `global code` stack function. Never blanket-drop bare `.content` TypeErrors
+ * from app code.
+ */
+const ogTypeMetaQuerySelectorContentMessage =
+	/^(?:TypeError:\s*)?null is not an object \(evaluating ['"]document\.querySelector\([^)]*meta\[property=['"]og:type['"]\][^)]*\)\.content['"]\)$/i
+
+export function isOgTypeMetaQuerySelectorContentMessage(message: string) {
+	return ogTypeMetaQuerySelectorContentMessage.test(message.trim())
+}
+
+export function isOgTypeMetaQuerySelectorContentError(error: unknown) {
+	if (typeof error === 'string') {
+		return isOgTypeMetaQuerySelectorContentMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isOgTypeMetaQuerySelectorContentMessage(error.message)
+}
+
+export function isOgTypeMetaQuerySelectorContentSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	const hasOgTypeMessage =
+		isOgTypeMetaQuerySelectorContentError(originalException) ||
+		sentryEventMessages(event).some(
+			(message) =>
+				typeof message === 'string' &&
+				isOgTypeMetaQuerySelectorContentMessage(message),
+		)
+	if (!hasOgTypeMessage) return false
+	return sentryEventStackFrameFunctions(event).some(
+		(name) => name === 'global code',
+	)
+}
+
+export function filterOgTypeMetaQuerySelectorContentSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (isOgTypeMetaQuerySelectorContentSentryEvent(event, originalException)) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -479,6 +535,14 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	if (
 		filterTwitterInAppBrowserConfigSentryEvent(event, originalException) ===
 		null
+	) {
+		return null
+	}
+	if (
+		filterOgTypeMetaQuerySelectorContentSentryEvent(
+			event,
+			originalException,
+		) === null
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -32,12 +32,14 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// permission-denied from Replay/hydration on restricted nodes,
 		// injected wallet/`__firefox__` globals, Fathom beacon
 		// removeChild-on-null, Chrome extension IPC "Object Not Found
-		// Matching Id…", MetaMask inpage connect failures, and Twitter/X
-		// in-app browser chrome `CONFIG` ReferenceErrors) — see
-		// filterBrowserSentryEvent / KODY-CLOUDFLARE-23 /
+		// Matching Id…", MetaMask inpage connect failures, Twitter/X
+		// in-app browser chrome `CONFIG` ReferenceErrors, and injected
+		// unguarded `meta[property='og:type']` probes from `global code`) —
+		// see filterBrowserSentryEvent / KODY-CLOUDFLARE-23 /
 		// KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S / KODY-CLOUDFLARE-3X /
-		// KODY-CLOUDFLARE-43 / issues 7639685398, 7648833360, 7648833403,
-		// 7653117289, 7655189301, 7658961865, 7659616372.
+		// KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 / issues 7639685398,
+		// 7648833360, 7648833403, 7653117289, 7655189301, 7658961865,
+		// 7659616372, 7660258027.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters a one-off Mobile Safari client noise event from [KODY-CLOUDFLARE-46](https://kent-c-dodds-tech-llc.sentry.io/issues/7660258027/): injected `global code` unguardedly reading `document.querySelector("meta[property='og:type']").content` on `/guides/what-is-kody`.

## Root cause

- Stack is a single `global code` frame on the document URL (not a Kody bundle).
- App code only **writes** `og:type` in document-head / SSR; it never reads it via `querySelector`.
- Guides (and many auth routes) intentionally omit managed OG tags, so the probe throws when the meta is absent.
- Same class of browser/content-script noise as prior filters (Twitter in-app `CONFIG`, wallet/`__firefox__` globals, etc.).

## Fix

Narrow client `beforeSend` filter in `sentry-browser-filters.ts`:

1. Safari wording: `null is not an object (evaluating 'document.querySelector(…og:type…).content')`
2. Stack function must be `global code`

Unit coverage in `sentry-browser-filters.node.test.ts`.

## Status

- Squash-merged as `e93230b8`; production redeployed via [#1317](https://github.com/kentcdodds/kody/pull/1317) after a flaky post-merge E2E `ECONNREFUSED` on main blocked the first deploy.
- Sentry issue marked **ignored** (filtered outcome).
- Prod health: `01b3c1ad`.

## Risk

**Low / composes** — observability filter only; no product behavior change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `12efe549` · **Head:** `e5b8fda9`

**Classification:** composes — extends the existing browser Sentry noise filter chain only; no primitive contracts change.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — new narrow `beforeSend` drop for injected og:type probes |

### System map

Browser Sentry still boots from the client entry; this PR only adds one more drop predicate before envelopes leave the page.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appUi -->|"beforeSend: drop og:type global-code TypeError"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Injected as Injected global code
	participant Box as Browser Sentry beforeSend
	participant Sentry as Sentry ingest
	Injected->>Box: TypeError og:type querySelector.content
	Box-->>Box: match wording + global code frame
	Box--xSentry: drop event
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7df7c035-fe63-44df-91f6-17c0cfb68e6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7df7c035-fe63-44df-91f6-17c0cfb68e6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reporting from Safari-specific `og:type` metadata probes.
  * Preserved reporting for similar errors originating from application code.
  * Improved browser error filtering to consistently ignore matching probe-related events.

* **Documentation**
  * Updated error-filtering documentation with details about injected `og:type` probes and related cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->