### PR TITLE
fix(mcp): treat missing community listing as caller error

### DIFF
--- a/packages/worker/src/mcp/capabilities/community/get.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/community/get.node.test.ts
@@ -1,0 +1,47 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mocks = vi.hoisted(() => ({
+	getCommunityListingWithAggregates: vi.fn(),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	getCommunityListingWithAggregates: (...args: Array<unknown>) =>
+		mocks.getCommunityListingWithAggregates(...args),
+}))
+
+const { communityGetCapability } = await import('./get.ts')
+
+function createContext() {
+	return {
+		env: { APP_DB: {} } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-alice',
+				email: 'alice@example.com',
+				displayName: 'Alice',
+				username: 'alice',
+			},
+		}),
+	}
+}
+
+test('community_get throws McpCallerError when the listing is missing', async () => {
+	mocks.getCommunityListingWithAggregates.mockResolvedValue(null)
+
+	await expect(
+		communityGetCapability.handler(
+			{ listing_id: 'missing-listing' },
+			createContext(),
+		),
+	).rejects.toBeInstanceOf(McpCallerError)
+
+	await expect(
+		communityGetCapability.handler(
+			{ listing_id: 'missing-listing' },
+			createContext(),
+		),
+	).rejects.toThrow('Community listing not found.')
+})

--- a/packages/worker/src/mcp/capabilities/community/get.ts
+++ b/packages/worker/src/mcp/capabilities/community/get.ts
@@ -6,6 +6,7 @@ import { listCommunityStargazersForListing } from '#worker/community/social-serv
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { callerContextFields } from '#mcp/observability.ts'
 import {
 	buildCommunityOwnerProfileUrl,
@@ -77,7 +78,9 @@ export const communityGetCapability = defineDomainCapability(
 				includeDelisted: false,
 			})
 			if (!listing) {
-				throw new Error('Community listing not found.')
+				// Missing / delisted listing ids are routine agent turns, not
+				// platform defects — keep them on mcp-event and out of Sentry.
+				throw new McpCallerError('Community listing not found.')
 			}
 			const ownerUsername = resolveCommunityOwnerUsername(listing.name)
 			const ownerRow = await getUserSocialRowByUsername(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop routine `community_get` misses (missing/delisted listing ids) from opening Sentry platform-bug issues.

## Summary

- `community_get` now throws `McpCallerError` when the listing is not found (same message).
- MCP observability already keeps `McpCallerError` on `mcp-event` and out of Sentry.
- Fixes [KODY-CLOUDFLARE-47](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7660564819/).

## Testing

- [x] `packages/worker/src/mcp/capabilities/community/get.node.test.ts` (missing listing → `McpCallerError`)
- [x] `npm run validate`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c6d9536a` · **Head:** `1fffcaba`

**Classification:** composes — wires existing `McpCallerError` classification into the `community_get` not-found path; no new primitives or schema changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | composes — not-found uses `McpCallerError` |
| `mcp-server` | surfaces | composes — caller-error path for capability failures |

### System map

Missing/delisted listing ids classify as caller-fixable MCP failures instead of Sentry platform bugs.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	communityListings["community-listings<br/>Community package listings"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	communityListings -->|"throw McpCallerError on missing listing"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-187546ad-9516-4681-a490-876a5c511991?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-187546ad-9516-4681-a490-876a5c511991&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a community listing is missing or delisted.
  * Users now receive a clear “Community listing not found.” message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->