### PR TITLE
Fix first-win Send detection, Claude prompt copy, and listing badge alignment

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -112,8 +112,8 @@ onboarding, `/community` cards, and listing detail overlay a per-request
 or a `community_forks` row for that listing, so those surfaces show Copy prompt
 instead of Install. Listing cards and detail place Trusted / Installed / Forked
 badges on a row under the title so wrapping `@scope/name` stays aligned.
-`community_get` exposes the effective `featured` flag.
-Onboarding loads up to 12 featured listings.
+`community_get` exposes the effective `featured` flag. Onboarding loads up to 12
+featured listings.
 
 Reports survive listing deletion via denormalized listing name and owner on the
 report row.

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -110,7 +110,9 @@ agent setup, plus a trailing Choose your own adventure card). Signed-in
 onboarding, `/community` cards, and listing detail overlay a per-request
 `viewerInstall` when the viewer already has a matching `kody_id` saved package
 or a `community_forks` row for that listing, so those surfaces show Copy prompt
-instead of Install. `community_get` exposes the effective `featured` flag.
+instead of Install. Listing cards and detail place Trusted / Installed / Forked
+badges on a row under the title so wrapping `@scope/name` stays aligned.
+`community_get` exposes the effective `featured` flag.
 Onboarding loads up to 12 featured listings.
 
 Reports survive listing deletion via denormalized listing name and owner on the

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -131,13 +131,13 @@ agent a short setup prompt. If you already have a saved package with the same
 `kody_id`, or a fork of that listing, onboarding, listing cards, and the detail
 page show **Copy prompt** / **Installed** (or **Forked**) instead of Install.
 Listing cards and the detail page place **Trusted** / **Installed** (or
-**Forked**) badges on their own row under the package name. A trailing
-**Choose your own adventure** card copies an open-ended setup prompt
-when you want to explore or build something custom instead. Install forks the
-listing into your account and, when the fork passes the same publish checks a
-repo session would run, publishes it immediately as a live saved package.
-**Publishing activates the package right away** — declared jobs are scheduled
-and `autoStart` services start.
+**Forked**) badges on their own row under the package name. A trailing **Choose
+your own adventure** card copies an open-ended setup prompt when you want to
+explore or build something custom instead. Install forks the listing into your
+account and, when the fork passes the same publish checks a repo session would
+run, publishes it immediately as a live saved package. **Publishing activates
+the package right away** — declared jobs are scheduled and `autoStart` services
+start.
 
 - **Untrusted listings** show a warning first: no admin has reviewed the code,
   and installing runs it in your account. You must explicitly confirm. Direct

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -129,8 +129,10 @@ starter packages on `/onboarding` appear as a square-card grid with one-click
 install without leaving the page: after install, **Copy prompt** gives your
 agent a short setup prompt. If you already have a saved package with the same
 `kody_id`, or a fork of that listing, onboarding, listing cards, and the detail
-page show **Copy prompt** / **Installed** (or **Forked**) instead of Install. A
-trailing **Choose your own adventure** card copies an open-ended setup prompt
+page show **Copy prompt** / **Installed** (or **Forked**) instead of Install.
+Listing cards and the detail page place **Trusted** / **Installed** (or
+**Forked**) badges on their own row under the package name. A trailing
+**Choose your own adventure** card copies an open-ended setup prompt
 when you want to explore or build something custom instead. Install forks the
 listing into your account and, when the fork passes the same publish checks a
 repo session would run, publishes it immediately as a live saved package.

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -28,7 +28,10 @@ MCP URL and setup prompt.
 - **Cursor** — Add a remote MCP server from Customize, or merge a
   `mcpServers.kody.url` entry into `~/.cursor/mcp.json` / `.cursor/mcp.json`.
 - **Claude Desktop** — Use Settings → Connectors (custom connector + MCP URL).
-  Remote servers are not configured through `claude_desktop_config.json`.
+  Remote servers are not configured through `claude_desktop_config.json`. After
+  connecting, start a new chat and ask Claude to list Kody tools before the
+  first task — Claude Desktop often does not bind MCP tools until that next
+  turn.
 - **Grok** — On [grok.com/connectors](https://grok.com/connectors), click **New
   Connector**, select **Custom**, and paste the MCP URL. Complete OAuth when
   prompted. For Grok Business and Enterprise, a team admin must first add this

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -14,6 +14,7 @@ import {
 	buildVsCodeInstallUrl,
 	buildVsCodeMcpJson,
 	chatGptDeveloperModeGuideUrl,
+	claudeDesktopToolHint,
 	codingAgentPackageHint,
 	copilotAppCustomizeGuideUrl,
 	copilotCliMcpGuideUrl,
@@ -211,6 +212,7 @@ function renderPanelContent(kind: McpClientKind, mcpServerUrl: string) {
 						copyLabel="Copy MCP URL"
 						variant="pill"
 					/>
+					<ClientNote>{claudeDesktopToolHint}</ClientNote>
 					<ClientNote>{nonCodingAgentNote}</ClientNote>
 				</>
 			)

--- a/packages/worker/client/routes/onboarding-mcp-clients.ts
+++ b/packages/worker/client/routes/onboarding-mcp-clients.ts
@@ -59,6 +59,10 @@ export function buildKodyAppIconUrl(mcpServerUrl: string) {
 export const nonCodingAgentNote =
 	'Using Kody packages works great with non-coding agents. For creating or editing packages, a coding agent such as Cursor, Claude Code, Codex, Copilot, or OpenCode is usually smoother — those hosts can edit files and iterate on code more easily.'
 
+/** Claude Desktop often does not bind MCP tools until the next turn. */
+export const claudeDesktopToolHint =
+	'After connecting, start a new chat and ask Claude to list Kody tools before the first task. Claude Desktop often does not bind MCP tools until that next turn.'
+
 export const codingAgentPackageHint =
 	'Coding agents are the best fit when you want to create or edit Kody packages. Once a package exists, non-coding agents can use it just fine.'
 

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -332,8 +332,9 @@ export function OnboardingRoute(handle: Handle) {
 			return (
 				<div mix={css(firstWinContentCss)}>
 					<p mix={css(firstWinGuidanceCss)}>
-						Paste this into your connected agent — Kody emails you from your own
-						Kody address within a minute.
+						Paste this into your connected agent. This step completes when Kody
+						records the send — usually within a minute, even if your personal
+						inbox already has the message.
 					</p>
 					<figure mix={css(promptBlockCss)}>
 						<blockquote>{introEmailPrompt}</blockquote>
@@ -350,8 +351,9 @@ export function OnboardingRoute(handle: Handle) {
 			return (
 				<div mix={css(firstWinContentCss)}>
 					<p mix={css(firstWinGuidanceCss)}>
-						Email sent. Open it and reply with your answers — about thirty
-						seconds. This page moves on when your reply lands.
+						Kody recorded the send. Open the welcome email and reply with your
+						answers — about thirty seconds. This page moves on when your reply
+						lands in Kody.
 					</p>
 					<p mix={css(firstWinGuidanceCss)}>
 						<a
@@ -371,7 +373,7 @@ export function OnboardingRoute(handle: Handle) {
 			<div mix={css(firstWinContentCss)}>
 				<p mix={css(firstWinGuidanceCss)}>
 					Reply received. Paste this so your agent reads it and saves what
-					matters.
+					matters as memories.
 				</p>
 				<figure mix={css(promptBlockCss)}>
 					<blockquote>{introEmailLookupPrompt}</blockquote>

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -68,6 +68,43 @@ export function CommunityDetailContent(
 				<CommunityListingIcon listing={listing} size="detail" />
 				<div mix={css(headTextCss)}>
 					<h1>{renderCommunityListingName(listing.name)}</h1>
+					{listing.trusted || listing.featured || listing.viewerInstall ? (
+						<span mix={css(detailBadgeGroupCss)}>
+							{listing.trusted ? (
+								<span
+									data-testid="community-detail-trusted-badge"
+									title="An admin reviewed this exact version and marked it trusted."
+									mix={css(badgeCss)}
+								>
+									Trusted
+								</span>
+							) : null}
+							{listing.featured ? (
+								<span
+									data-testid="community-detail-featured-badge"
+									title="An admin featured this package as an onboarding starter install."
+									mix={css(badgeCss)}
+								>
+									Featured
+								</span>
+							) : null}
+							{listing.viewerInstall ? (
+								<span
+									data-testid="community-detail-viewer-install-badge"
+									title={
+										listing.viewerInstall.status === 'installed'
+											? `Installed in your account as ${listing.viewerInstall.targetName}.`
+											: `Forked in your account as ${listing.viewerInstall.targetName}; still needs adaptation.`
+									}
+									mix={css(badgeCss)}
+								>
+									{listing.viewerInstall.status === 'installed'
+										? 'Installed'
+										: 'Forked'}
+								</span>
+							) : null}
+						</span>
+					) : null}
 					<p mix={css(ownerLineCss)}>
 						<span>
 							by{' '}
@@ -121,39 +158,6 @@ export function CommunityDetailContent(
 							: null}
 					</p>
 				</div>
-				{listing.trusted ? (
-					<span
-						data-testid="community-detail-trusted-badge"
-						title="An admin reviewed this exact version and marked it trusted."
-						mix={css(badgeCss)}
-					>
-						Trusted
-					</span>
-				) : null}
-				{listing.featured ? (
-					<span
-						data-testid="community-detail-featured-badge"
-						title="An admin featured this package as an onboarding starter install."
-						mix={css(badgeCss)}
-					>
-						Featured
-					</span>
-				) : null}
-				{listing.viewerInstall ? (
-					<span
-						data-testid="community-detail-viewer-install-badge"
-						title={
-							listing.viewerInstall.status === 'installed'
-								? `Installed in your account as ${listing.viewerInstall.targetName}.`
-								: `Forked in your account as ${listing.viewerInstall.targetName}; still needs adaptation.`
-						}
-						mix={css(badgeCss)}
-					>
-						{listing.viewerInstall.status === 'installed'
-							? 'Installed'
-							: 'Forked'}
-					</span>
-				) : null}
 			</header>
 
 			<p data-rise style={{ '--rise': '2' }} mix={css(detailSubCss)}>
@@ -339,12 +343,16 @@ const backLinkCss = {
 const detailHeadCss = {
 	marginTop: '1.8rem',
 	display: 'flex',
-	alignItems: 'center',
+	alignItems: 'flex-start',
 	gap: '1.1rem',
 }
 
 const headTextCss = {
 	minWidth: 0,
+	flex: 1,
+	display: 'flex',
+	flexDirection: 'column' as const,
+	gap: '0.45rem',
 	'& h1': {
 		margin: 0,
 		fontSize: 'clamp(1.7rem, 4vw, 2.4rem)',
@@ -355,11 +363,18 @@ const headTextCss = {
 	},
 }
 
+const detailBadgeGroupCss = {
+	display: 'flex',
+	alignItems: 'center',
+	flexWrap: 'wrap' as const,
+	gap: '0.35rem',
+}
+
 const ownerLineCss = {
 	display: 'flex',
 	alignItems: 'center',
 	gap: '0.45rem',
-	margin: '0.25rem 0 0',
+	margin: 0,
 	color: colors.textMuted,
 	fontSize: '0.95rem',
 }
@@ -420,7 +435,6 @@ const ownerFollowButtonCss = {
 
 const badgeCss = {
 	...communityBadgePillCss,
-	alignSelf: 'center',
 }
 
 const detailSubCss = {

--- a/packages/worker/src/app/community-listings-content.tsx
+++ b/packages/worker/src/app/community-listings-content.tsx
@@ -55,44 +55,46 @@ export function CommunityListingsContent(
 						>
 							<div mix={css(listingHeadCss)}>
 								<CommunityListingIcon listing={listing} size="card" />
-								<h2 mix={css(listingNameCss)}>
-									<a
-										href={routes.communityDetail.href({
-											listingId: listing.id,
-										})}
-										mix={css(listingLinkCss)}
-									>
-										{renderCommunityListingName(listing.name)}
-									</a>
-								</h2>
-								{listing.trusted || listing.viewerInstall ? (
-									<span mix={css(listingBadgeGroupCss)}>
-										{listing.trusted ? (
-											<span
-												data-testid={`community-listing-trusted-${listing.id}`}
-												title="An admin reviewed this exact version and marked it trusted."
-												mix={css(communityBadgePillCss)}
-											>
-												Trusted
-											</span>
-										) : null}
-										{listing.viewerInstall ? (
-											<span
-												data-testid={`community-listing-viewer-install-${listing.id}`}
-												title={
-													listing.viewerInstall.status === 'installed'
-														? `Installed in your account as ${listing.viewerInstall.targetName}.`
-														: `Forked in your account as ${listing.viewerInstall.targetName}; still needs adaptation.`
-												}
-												mix={css(communityBadgePillCss)}
-											>
-												{listing.viewerInstall.status === 'installed'
-													? 'Installed'
-													: 'Forked'}
-											</span>
-										) : null}
-									</span>
-								) : null}
+								<div mix={css(listingTitleBlockCss)}>
+									<h2 mix={css(listingNameCss)}>
+										<a
+											href={routes.communityDetail.href({
+												listingId: listing.id,
+											})}
+											mix={css(listingLinkCss)}
+										>
+											{renderCommunityListingName(listing.name)}
+										</a>
+									</h2>
+									{listing.trusted || listing.viewerInstall ? (
+										<span mix={css(listingBadgeGroupCss)}>
+											{listing.trusted ? (
+												<span
+													data-testid={`community-listing-trusted-${listing.id}`}
+													title="An admin reviewed this exact version and marked it trusted."
+													mix={css(communityBadgePillCss)}
+												>
+													Trusted
+												</span>
+											) : null}
+											{listing.viewerInstall ? (
+												<span
+													data-testid={`community-listing-viewer-install-${listing.id}`}
+													title={
+														listing.viewerInstall.status === 'installed'
+															? `Installed in your account as ${listing.viewerInstall.targetName}.`
+															: `Forked in your account as ${listing.viewerInstall.targetName}; still needs adaptation.`
+													}
+													mix={css(communityBadgePillCss)}
+												>
+													{listing.viewerInstall.status === 'installed'
+														? 'Installed'
+														: 'Forked'}
+												</span>
+											) : null}
+										</span>
+									) : null}
+								</div>
 							</div>
 							<p
 								mix={css(listingDescriptionCss)}
@@ -203,8 +205,16 @@ const listingCardCss = mergeCss(getSurfaceCardCss({ interactive: true }), {
 
 const listingHeadCss = {
 	display: 'flex',
-	alignItems: 'center',
+	alignItems: 'flex-start',
 	gap: '0.7rem',
+}
+
+const listingTitleBlockCss = {
+	minWidth: 0,
+	flex: 1,
+	display: 'flex',
+	flexDirection: 'column' as const,
+	gap: '0.4rem',
 }
 
 const listingNameCss = {
@@ -249,9 +259,8 @@ export const communityBadgePillCss = {
 const listingBadgeGroupCss = {
 	display: 'flex',
 	alignItems: 'center',
+	flexWrap: 'wrap' as const,
 	gap: '0.35rem',
-	marginLeft: 'auto',
-	flex: 'none',
 }
 
 const listingDescriptionCss = {

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -171,6 +171,9 @@ test('community detail handler returns bare detail frame HTML for target header'
 		'data-testid="community-detail-viewer-install-badge"',
 	)
 	expect(signedInHtml).toContain('Installed')
+	expect(
+		signedInHtml.indexOf('data-testid="community-detail-viewer-install-badge"'),
+	).toBeGreaterThan(signedInHtml.indexOf('</h1>'))
 	expect(signedInHtml).toContain('name="follow"')
 	expect(signedInHtml).toContain('name="returnTo"')
 	expect(signedInHtml).toContain('/profiles/kentcdodds/follow.json')

--- a/packages/worker/src/app/handlers/community.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community.frame.node.test.ts
@@ -126,4 +126,9 @@ test('community page handler returns bare listings frame HTML for target header'
 		'data-testid="community-listing-viewer-install-listing-1"',
 	)
 	expect(signedInHtml).toContain('Installed')
+	expect(
+		signedInHtml.indexOf(
+			'data-testid="community-listing-viewer-install-listing-1"',
+		),
+	).toBeGreaterThan(signedInHtml.indexOf('</h2>'))
 })

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -1,10 +1,10 @@
-import { countInternalUserEmailMessages } from '#worker/email/mailbox-internal-read.ts'
 import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import {
 	deriveOnboardingChecklist,
 	dismissOnboardingChecklist,
 	readOnboardingChecklistDismissed,
+	userHasSentWelcomeEmail,
 } from '#mcp/onboarding-checklist.ts'
 import { normalizeRedirectTo } from '#app/auth-redirect.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
@@ -40,20 +40,14 @@ export async function loadChecklist(
 }
 
 /**
- * First-win Send sub-step signal: any stored outbound mail means the welcome
- * email went out. Fails open to false so a Mailbox blip never breaks the
- * onboarding payload.
+ * First-win Send sub-step: successful `email_send` or stored outbound mail.
+ * Fails open to false so a Mailbox or UserMeter blip never breaks the payload.
  */
 async function loadHasSentWelcomeEmail(
 	env: Env,
 	userId: string,
 ): Promise<boolean> {
-	const outbound = await countInternalUserEmailMessages({
-		env,
-		ownerId: userId,
-		filters: { direction: 'outbound' },
-	}).catch(() => 0)
-	return outbound > 0
+	return await userHasSentWelcomeEmail({ env, userId })
 }
 
 function redirectUnverifiedToPending(request: Request) {

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -27,7 +27,13 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 	).toContain('https://preview.example')
 
 	// After the welcome reply, the lookup prompt is the explicit second paste.
+	expect(buildIntroEmailPrompt().toLowerCase()).toContain(
+		'connected kody server',
+	)
+	expect(buildIntroEmailPrompt().toLowerCase()).not.toContain('hey kody')
 	expect(buildIntroEmailLookupPrompt().toLowerCase()).toContain('look up')
+	expect(buildIntroEmailLookupPrompt().toLowerCase()).toContain('memories')
+	expect(buildIntroEmailLookupPrompt().toLowerCase()).not.toContain('hey kody')
 
 	expect(
 		loadPublicOnboardingData({

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -62,21 +62,21 @@ export function buildDiscoveryPrompt(input: {
 /**
  * First-win mini-wizard, sub-step 1 (Send): one email carries both the
  * introduction and a thirty-second interview, so a single reply exercises
- * the storage-first email model and seeds durable memory. The "use Kody MCP
- * to" prefix routes the request explicitly — "Hey Kody" alone is not enough
- * for some models to pick the right tool.
+ * the storage-first email model and seeds durable memory. Address the
+ * connected Kody server rather than "Hey Kody" — some hosts treat that as
+ * impersonation / prompt injection and skip MCP tools.
  */
 export function buildIntroEmailPrompt() {
-	return 'Hey Kody, use Kody MCP to send me a welcome email introducing yourself and asking me my name, what I do for work, and what I do for fun. Invite me to reply.'
+	return 'Ask the connected Kody server to send me a welcome email introducing itself and asking my name, what I do for work, and what I do for fun. Invite me to reply.'
 }
 
 /**
  * First-win mini-wizard, sub-step 3 (Remember): after the reply lands, the
  * agent reads it out of Kody's stored mail and turns the answers into
- * durable memories in one paste.
+ * durable memories (not values) in one paste.
  */
 export function buildIntroEmailLookupPrompt() {
-	return 'Hey Kody, use Kody MCP to look up my reply to your welcome email and remember what matters about me.'
+	return 'Ask the connected Kody server to look up my reply to the welcome email and save what matters about me as memories.'
 }
 
 /**

--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -666,10 +666,6 @@ export async function sendOutboundEmail(
 			resource: 'email_sends_per_day',
 			now: entitlementNow,
 		})
-		recordEmailReportingEvent(input.env, {
-			userId: input.userId,
-			eventType: 'email_send',
-		})
 
 		const now = entitlementNow.toISOString()
 		const inboxId = original?.inboxId ?? input.inboxId ?? null
@@ -791,6 +787,10 @@ export async function sendOutboundEmail(
 			)
 			throw error
 		}
+		recordEmailReportingEvent(input.env, {
+			userId: input.userId,
+			eventType: 'email_send',
+		})
 		await mailbox.upsertDeliveryEvent({
 			ownerId: input.userId,
 			event: outboundDeliveryEvent({

--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -15,6 +15,7 @@ import {
 	assertWithinStorageBytesEntitlement,
 	consumeDailyEntitlement,
 	estimateEntitlementStorageEntryBytes,
+	refundDailyEntitlement,
 } from '#worker/entitlements/service.ts'
 import { recordUsage } from '#worker/usage/record-usage.ts'
 import { normalizeEmailAddress } from './address.ts'
@@ -656,94 +657,101 @@ export async function sendOutboundEmail(
 		})
 
 		// Atomic check-and-increment via UserMeter (sole daily authority).
+		const entitlementNow = new Date()
 		await consumeDailyEntitlement({
 			db: input.env.APP_DB,
 			env: input.env,
 			userId: input.userId,
 			email: sender.accountEmail,
 			resource: 'email_sends_per_day',
+			now: entitlementNow,
 		})
 		recordEmailReportingEvent(input.env, {
 			userId: input.userId,
 			eventType: 'email_send',
 		})
 
-		const now = new Date().toISOString()
+		const now = entitlementNow.toISOString()
 		const inboxId = original?.inboxId ?? input.inboxId ?? null
 		const existingThreadId = original?.threadId ?? input.threadId ?? null
-		const existingThread = existingThreadId
-			? await mailbox.getThread({ threadId: existingThreadId })
-			: null
-		if (existingThreadId && !existingThread) {
-			throw new Error(`Email thread was not found: ${existingThreadId}`)
-		}
-		const thread: MailboxThreadInput = existingThread
-			? {
-					...existingThread,
-					subjectNormalized: existingThread.subjectNormalized ?? '',
-					lastMessageAt:
-						existingThread.lastMessageAt > now
-							? existingThread.lastMessageAt
-							: now,
-					updatedAt: now,
-				}
-			: {
-					id: crypto.randomUUID(),
-					inboxId,
-					subjectNormalized: subject.toLowerCase(),
-					rootMessageIdHeader: input.inReplyToHeader ?? null,
-					lastMessageAt: now,
-					createdAt: now,
-					updatedAt: now,
-				}
+		let storedAttachments: Awaited<
+			ReturnType<typeof storeOutboundAttachments>
+		> = []
 		const messageId = crypto.randomUUID()
 		const providerHeaders = buildProviderHeaders(storedHeaders)
-		const message: MailboxMessageInput = {
-			id: messageId,
-			direction: 'outbound',
-			inboxId,
-			threadId: thread.id,
-			senderIdentityId: senderIdentity.id,
-			fromAddress: from,
-			envelopeFrom: from,
-			toAddresses: to,
-			ccAddresses: [],
-			bccAddresses: [],
-			replyToAddresses: input.replyTo
-				? [normalizeEmailAddress(input.replyTo)].filter(
-						(value): value is string => typeof value === 'string',
-					)
-				: [],
-			subject,
-			messageIdHeader,
-			inReplyToHeader: input.inReplyToHeader ?? null,
-			references: input.references ?? [],
-			headers: storedHeaders,
-			authResults: null,
-			textBody: text,
-			htmlBody: html,
-			rawMimeKey: null,
-			rawSize: 0,
-			processingStatus: 'stored',
-			classification: 'accepted',
-			classificationReason: null,
-			providerMessageId: null,
-			deliveryStatus: null,
-			deliveryStatusAt: null,
-			error: null,
-			receivedAt: null,
-			sentAt: null,
-			createdAt: now,
-			updatedAt: now,
-		}
-		const storedAttachments = await storeOutboundAttachments({
-			blobs: input.env.EMAIL_BLOBS,
-			userId: input.userId,
-			messageId: message.id,
-			attachments,
-			now,
-		})
+		let thread: MailboxThreadInput
+		let message: MailboxMessageInput
 		try {
+			const existingThread = existingThreadId
+				? await mailbox.getThread({ threadId: existingThreadId })
+				: null
+			if (existingThreadId && !existingThread) {
+				throw new Error(`Email thread was not found: ${existingThreadId}`)
+			}
+			thread = existingThread
+				? {
+						...existingThread,
+						subjectNormalized: existingThread.subjectNormalized ?? '',
+						lastMessageAt:
+							existingThread.lastMessageAt > now
+								? existingThread.lastMessageAt
+								: now,
+						updatedAt: now,
+					}
+				: {
+						id: crypto.randomUUID(),
+						inboxId,
+						subjectNormalized: subject.toLowerCase(),
+						rootMessageIdHeader: input.inReplyToHeader ?? null,
+						lastMessageAt: now,
+						createdAt: now,
+						updatedAt: now,
+					}
+			message = {
+				id: messageId,
+				direction: 'outbound',
+				inboxId,
+				threadId: thread.id,
+				senderIdentityId: senderIdentity.id,
+				fromAddress: from,
+				envelopeFrom: from,
+				toAddresses: to,
+				ccAddresses: [],
+				bccAddresses: [],
+				replyToAddresses: input.replyTo
+					? [normalizeEmailAddress(input.replyTo)].filter(
+							(value): value is string => typeof value === 'string',
+						)
+					: [],
+				subject,
+				messageIdHeader,
+				inReplyToHeader: input.inReplyToHeader ?? null,
+				references: input.references ?? [],
+				headers: storedHeaders,
+				authResults: null,
+				textBody: text,
+				htmlBody: html,
+				rawMimeKey: null,
+				rawSize: 0,
+				processingStatus: 'stored',
+				classification: 'accepted',
+				classificationReason: null,
+				providerMessageId: null,
+				deliveryStatus: null,
+				deliveryStatusAt: null,
+				error: null,
+				receivedAt: null,
+				sentAt: null,
+				createdAt: now,
+				updatedAt: now,
+			}
+			storedAttachments = await storeOutboundAttachments({
+				blobs: input.env.EMAIL_BLOBS,
+				userId: input.userId,
+				messageId: message.id,
+				attachments,
+				now,
+			})
 			const graph = await mailbox.upsertMessageGraph({
 				ownerId: input.userId,
 				thread,
@@ -754,6 +762,18 @@ export async function sendOutboundEmail(
 				throw new Error('Outbound Mailbox graph rejected the message.')
 			}
 		} catch (error) {
+			await refundDailyEntitlement({
+				db: input.env.APP_DB,
+				env: input.env,
+				userId: input.userId,
+				resource: 'email_sends_per_day',
+				now: entitlementNow,
+			}).catch((refundError: unknown) => {
+				console.warn(
+					'email-outbound-send-entitlement-refund-failed',
+					refundError,
+				)
+			})
 			await Promise.all(
 				storedAttachments
 					.filter((attachment) => attachment.storageKey != null)

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -1095,6 +1095,34 @@ test('sendOutboundEmail increments the daily counter when under the plan limit',
 	expect(await readDailyEmailSendCounter(userId)).toBe(1)
 }, 30_000)
 
+test('sendOutboundEmail refunds the daily counter when mailbox storage fails before a copy is stored', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const email = `refund-${crypto.randomUUID()}@example.com`
+	const userId = await createStableUserIdFromEmail(email)
+	await seedVerifiedAccount({ email, plan: 'pro' })
+	expect(await readDailyEmailSendCounter(userId)).toBe(0)
+
+	await expect(
+		sendOutboundEmail({
+			env: createBindingSendEnv(),
+			userId,
+			accountEmail: email,
+			recipientPolicy: 'self',
+			subject: 'Hello from Kody',
+			text: 'Body',
+			threadId: 'missing-thread',
+		}),
+	).rejects.toThrow('Email thread was not found: missing-thread')
+
+	expect(await readDailyEmailSendCounter(userId)).toBe(0)
+	expect(
+		await mailboxRpc({ env, userId }).listMessages({
+			direction: 'outbound',
+			limit: 5,
+		}),
+	).toMatchObject({ messages: [] })
+}, 30_000)
+
 test('sendOutboundEmail caps max-plan users at the email daily backstop', async () => {
 	await ensureEmailTestSchema(env.APP_DB)
 

--- a/packages/worker/src/email/outbound.workers.test.ts
+++ b/packages/worker/src/email/outbound.workers.test.ts
@@ -1099,8 +1099,10 @@ test('sendOutboundEmail refunds the daily counter when mailbox storage fails bef
 	await ensureEmailTestSchema(env.APP_DB)
 	const email = `refund-${crypto.randomUUID()}@example.com`
 	const userId = await createStableUserIdFromEmail(email)
+	const limit = planLimits.pro.maxEmailSendsPerDay
+	if (limit === null) throw new Error('Expected a numeric pro email limit.')
 	await seedVerifiedAccount({ email, plan: 'pro' })
-	expect(await readDailyEmailSendCounter(userId)).toBe(0)
+	await seedDailyEmailSendCounter(userId, limit - 1)
 
 	await expect(
 		sendOutboundEmail({
@@ -1114,13 +1116,21 @@ test('sendOutboundEmail refunds the daily counter when mailbox storage fails bef
 		}),
 	).rejects.toThrow('Email thread was not found: missing-thread')
 
-	expect(await readDailyEmailSendCounter(userId)).toBe(0)
+	expect(await readDailyEmailSendCounter(userId)).toBe(limit - 1)
 	expect(
 		await mailboxRpc({ env, userId }).listMessages({
 			direction: 'outbound',
 			limit: 5,
 		}),
 	).toMatchObject({ messages: [] })
+
+	// Without the refund, this send would hit the plan limit.
+	const result = await sendSelfNotification({
+		userId,
+		accountEmail: email,
+	})
+	expect(result.status).toBe('sent')
+	expect(await readDailyEmailSendCounter(userId)).toBe(limit)
 }, 30_000)
 
 test('sendOutboundEmail caps max-plan users at the email daily backstop', async () => {

--- a/packages/worker/src/mcp/onboarding-checklist.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.node.test.ts
@@ -126,11 +126,13 @@ test('search onboarding notice points at /onboarding and goes quiet after dismis
 })
 
 test('first-win Send is done when email_send meter counts even without mailbox', async () => {
-	const { env, seed } = createEnv()
 	const now = new Date('2026-08-08T15:00:00.000Z')
+	const fresh = createEnv()
+	expect(await userHasSentWelcomeEmail({ env: fresh.env, userId, now })).toBe(
+		false,
+	)
 
-	expect(await userHasSentWelcomeEmail({ env, userId, now })).toBe(false)
-
+	const { env, seed } = createEnv()
 	await seed({
 		userId,
 		resource: 'email_sends_per_day',

--- a/packages/worker/src/mcp/onboarding-checklist.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.node.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
@@ -10,6 +11,7 @@ import {
 	deriveOnboardingChecklist,
 	dismissOnboardingChecklist,
 	readOnboardingChecklistDismissed,
+	userHasSentWelcomeEmail,
 } from './onboarding-checklist.ts'
 
 const migrationsDirectory = new URL('../../migrations/', import.meta.url)
@@ -17,10 +19,11 @@ const migrationsDirectory = new URL('../../migrations/', import.meta.url)
 function createEnv() {
 	const sqlite = new DatabaseSync(':memory:')
 	applyRepositoryMigrations(sqlite, migrationsDirectory)
-	const { env: meterEnv } = createInMemoryUserMeterEnv()
+	const { env: meterEnv, seed } = createInMemoryUserMeterEnv()
 	// MAILBOX is deliberately absent: the mailbox probe must fail open.
 	return {
 		env: { APP_DB: createD1FromSqlite(sqlite), ...meterEnv } as Env,
+		seed,
 	}
 }
 
@@ -120,4 +123,22 @@ test('search onboarding notice points at /onboarding and goes quiet after dismis
 			baseUrl: 'https://kody.example',
 		}),
 	).toBe(null)
+})
+
+test('first-win Send is done when email_send meter counts even without mailbox', async () => {
+	const { env, seed } = createEnv()
+	const now = new Date('2026-08-08T15:00:00.000Z')
+
+	expect(await userHasSentWelcomeEmail({ env, userId, now })).toBe(false)
+
+	await seed({
+		userId,
+		resource: 'email_sends_per_day',
+		day: utcDayKey(now),
+		count: 1,
+	})
+	expect(await userHasSentWelcomeEmail({ env, userId, now })).toBe(true)
+	expect(
+		await userHasSentWelcomeEmail({ env, userId: 'b'.repeat(64), now }),
+	).toBe(false)
 })

--- a/packages/worker/src/mcp/onboarding-checklist.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.ts
@@ -37,8 +37,10 @@ export type OnboardingChecklistEnv = Pick<Env, 'APP_DB'> &
  * First-win Send sub-step: a successful `email_send` (UserMeter daily count)
  * or any stored outbound mailbox copy. Meter covers the case where Hotmail
  * already received the message but the mailbox mirror lagged; mailbox covers
- * sends from a previous UTC day after the daily meter resets. Probe failures
- * fail open to false so a Mailbox or UserMeter blip never marks Send done.
+ * sends from a previous UTC day after the daily meter resets. Failed mailbox
+ * stores refund the meter before throwing, so a rejected send cannot mark
+ * Send done. Probe failures fail open to false so a Mailbox or UserMeter
+ * blip never marks Send done.
  */
 export async function userHasSentWelcomeEmail(input: {
 	env: OnboardingChecklistEnv

--- a/packages/worker/src/mcp/onboarding-checklist.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.ts
@@ -34,6 +34,36 @@ export type OnboardingChecklistEnv = Pick<Env, 'APP_DB'> &
 	EntitlementUsageEnv & { MAILBOX: Env['MAILBOX'] }
 
 /**
+ * First-win Send sub-step: a successful `email_send` (UserMeter daily count)
+ * or any stored outbound mailbox copy. Meter covers the case where Hotmail
+ * already received the message but the mailbox mirror lagged; mailbox covers
+ * sends from a previous UTC day after the daily meter resets. Probe failures
+ * fail open to false so a Mailbox or UserMeter blip never marks Send done.
+ */
+export async function userHasSentWelcomeEmail(input: {
+	env: OnboardingChecklistEnv
+	userId: string
+	now?: Date
+}): Promise<boolean> {
+	const now = input.now ?? new Date()
+	const [outboundMail, emailSendsToday] = await Promise.all([
+		countInternalUserEmailMessages({
+			env: input.env,
+			ownerId: input.userId,
+			filters: { direction: 'outbound' },
+		}).catch(() => 0),
+		readCurrentEntitlementResourceUsage({
+			db: input.env.APP_DB,
+			env: input.env,
+			userId: input.userId,
+			resource: 'email_sends_per_day',
+			now,
+		}).catch(() => 0),
+	])
+	return outboundMail > 0 || emailSendsToday > 0
+}
+
+/**
  * Compute the checklist from existing signals: one Mailbox DO count (stored
  * INBOUND mail — the welcome email alone is outbound, so "exchange a first
  * email" only completes once the user's reply lands), and three cheap D1

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -672,7 +672,7 @@ export type OnboardingLoaderData = {
 	introEmailPrompt: string
 	/** First-win remember prompt: read the reply and save memories. */
 	introEmailLookupPrompt: string
-	/** True when any outbound mail exists (first-win Send sub-step done). */
+	/** True when a successful email_send or stored outbound mail exists (Send done). */
 	hasSentWelcomeEmail: boolean
 	hasMcpClient: boolean
 	emailVerified: boolean


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make onboarding's "See it work" Send step, first-win prompts, Claude Desktop setup, and community listing badges match what early users actually see after connecting an agent.

## Summary

- **Send completes on `email_send` or stored outbound mail.** Hotmail can already have the welcome message while Kody's mailbox mirror lagged. First-win Send counts a successful UserMeter `email_sends_per_day` increment **or** any stored outbound copy, and the waiting copy talks about Kody recording the send.
- **Failed mailbox stores refund the send meter.** `email_send` consumed the daily entitlement before writing the outbound copy; if that store fails, the meter is refunded so onboarding cannot advance to Reply on a rejected send.
- **First-win prompts address the connected Kody server.** "Hey Kody, use Kody MCP…" looked like impersonation / prompt injection to Claude. Send and Remember prompts now ask the connected Kody server to send/read mail and save **memories** (not values).
- **Claude Desktop hint.** After connecting, start a new chat and ask Claude to list Kody tools before the first task — Desktop often does not bind MCP tools until that next turn.
- **Listing badges under the title.** Trusted / Installed (or Forked) sit on their own row under wrapping `@scope/name` on community cards and detail, instead of crowding the icon+name row.

## Testing

- `packages/worker/src/mcp/onboarding-checklist.node.test.ts`
- `packages/worker/src/app/onboarding-data.node.test.ts`
- `packages/worker/src/app/handlers/community.frame.node.test.ts`
- `packages/worker/src/app/handlers/community-detail.frame.node.test.ts`
- `packages/worker/src/email/outbound.workers.test.ts` (refund path)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/onboarding-first-win-and-card-alignment-7c54`

**Classification:** extends — first-win Send now composes UserMeter + Mailbox, outbound send refunds the meter on pre-store failure, and onboarding / community UI contracts change.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — first-win copy, Claude Desktop hint, listing badge layout |
| `app-sessions` | auth | extends — Send/Remember prompt strings on `/onboarding` |
| `mcp-server` | surfaces | extends — `userHasSentWelcomeEmail` counts `email_send` or outbound mail |
| `community-listings` | assistant | extends — Trusted/Installed badges under wrapping titles |
| `email` | assistant | extends — refund `email_sends_per_day` if mailbox store fails before a copy exists |
| `user-meter` | storage | composes — daily `email_sends_per_day` read / refund for Send-done |
| `mailbox` | storage | composes — outbound message count still counts as Send-done |

### System map

First-win Send and community listing badges flow from the Remix onboarding/community UI through the onboarding checklist into UserMeter and Mailbox; outbound send refunds the meter if Mailbox storage fails first.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	appSessions["app-sessions<br/>Browser sessions"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	communityListings["community-listings<br/>Community package listings"]:::extended
	email["email<br/>Email primitives"]:::extended
	userMeter["user-meter<br/>UserMeter DO"]:::touched
	mailbox["mailbox<br/>Mailbox DO"]:::touched
	appUi -->|"first-win prompts + Claude hint"| appSessions
	appUi -->|"Trusted/Installed under title"| communityListings
	appSessions -->|"hasSentWelcomeEmail"| mcpServer
	mcpServer -->|"email_sends_per_day"| userMeter
	mcpServer -->|"outbound count"| mailbox
	email -->|"consume then store"| mailbox
	email -->|"refund if store fails"| userMeter
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| First-win Send | any stored outbound mail | `email_send` meter **or** stored outbound mail |
| Failed outbound store | meter stayed consumed | meter refunded before throw |
| Send / Remember prompts | "Hey Kody, use Kody MCP…" | "Ask the connected Kody server…" + save memories |
| Claude Desktop tab | connector URL only | also: new chat, list Kody tools first |
| Listing / detail badges | same row as wrapping `@scope/name` | own row under the title |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ced490ff-c8aa-495c-a6ab-be1d28597c54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ced490ff-c8aa-495c-a6ab-be1d28597c54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Community listings and detail pages display Trusted, Installed, and Forked badges beneath package names with improved wrapping.
  - Claude Desktop onboarding explains how to start a chat and discover available tools.
  - First-win onboarding prompts more clearly describe sending, replying, and saving memories.

- **Bug Fixes**
  - Welcome-email completion recognizes successful sends or stored outbound email activity.
  - Failed outbound email storage restores the daily sending allowance and cleans up attachments.

- **Documentation**
  - Clarified community badges, featured listings, Claude Desktop setup, and email-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->