### PR TITLE
fix(mcp): keep missing repo_tree paths out of Sentry

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/repo-tree.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-tree.node.test.ts
@@ -1,0 +1,124 @@
+import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mocks = vi.hoisted(() => ({
+	repoSessionRpc: vi.fn(),
+}))
+
+vi.mock('#worker/repo/repo-session-do.ts', () => ({
+	repoSessionRpc: (...args: Array<unknown>) => mocks.repoSessionRpc(...args),
+}))
+
+const { repoTreeCapability } = await import('./repo-tree.ts')
+
+function createContext() {
+	return {
+		env: {} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-alice',
+				email: 'alice@example.com',
+				displayName: 'Alice',
+			},
+		}),
+	}
+}
+
+test('repo_tree maps missing-path ENOENT to McpCallerError', async () => {
+	const tree = vi.fn().mockRejectedValue(
+		Object.assign(
+			new Error('ENOENT: no such file or directory: /session/docs'),
+			{ code: 'ENOENT' },
+		),
+	)
+	mocks.repoSessionRpc.mockReturnValue({ tree })
+
+	const error = await repoTreeCapability
+		.handler(
+			{
+				session_id: 'session-1',
+				path: 'docs',
+			},
+			createContext(),
+		)
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+
+	expect(error).toBeInstanceOf(McpCallerError)
+	expect(error).toMatchObject({
+		message: 'Path "docs" was not found in the repo session workspace.',
+	})
+	expect(tree).toHaveBeenCalledWith({
+		sessionId: 'session-1',
+		userId: 'user-alice',
+		path: 'docs',
+		maxDepth: undefined,
+	})
+})
+
+test('repo_tree still surfaces non-ENOENT failures as plain errors', async () => {
+	const tree = vi
+		.fn()
+		.mockRejectedValue(new Error('Repo session "session-1" was not found.'))
+	mocks.repoSessionRpc.mockReturnValue({ tree })
+
+	const error = await repoTreeCapability
+		.handler({ session_id: 'session-1' }, createContext())
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+
+	expect(error).toBeInstanceOf(Error)
+	expect(error).not.toBeInstanceOf(McpCallerError)
+	expect(error).toMatchObject({
+		message: 'Repo session "session-1" was not found.',
+	})
+})
+
+test('repo_tree summarizes an existing subtree', async () => {
+	const tree = vi.fn().mockResolvedValue({
+		path: '',
+		name: 'session',
+		type: 'directory',
+		size: 0,
+		children: [
+			{
+				path: 'README.md',
+				name: 'README.md',
+				type: 'file',
+				size: 12,
+			},
+			{
+				path: 'src',
+				name: 'src',
+				type: 'directory',
+				size: 0,
+				children: [
+					{
+						path: 'src/index.ts',
+						name: 'index.ts',
+						type: 'file',
+						size: 40,
+					},
+				],
+			},
+		],
+	})
+	mocks.repoSessionRpc.mockReturnValue({ tree })
+
+	await expect(
+		repoTreeCapability.handler({ session_id: 'session-1' }, createContext()),
+	).resolves.toEqual({
+		path: '',
+		files: 2,
+		directories: 2,
+		symlinks: 0,
+		total_bytes: 52,
+		max_depth: 2,
+	})
+})

--- a/packages/worker/src/mcp/capabilities/repo/repo-tree.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-tree.node.test.ts
@@ -27,12 +27,14 @@ function createContext() {
 }
 
 test('repo_tree maps missing-path ENOENT to McpCallerError', async () => {
-	const tree = vi.fn().mockRejectedValue(
-		Object.assign(
-			new Error('ENOENT: no such file or directory: /session/docs'),
-			{ code: 'ENOENT' },
-		),
-	)
+	const tree = vi
+		.fn()
+		.mockRejectedValue(
+			Object.assign(
+				new Error('ENOENT: no such file or directory: /session/docs'),
+				{ code: 'ENOENT' },
+			),
+		)
 	mocks.repoSessionRpc.mockReturnValue({ tree })
 
 	const error = await repoTreeCapability

--- a/packages/worker/src/mcp/capabilities/repo/repo-tree.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-tree.node.test.ts
@@ -62,6 +62,43 @@ test('repo_tree maps missing-path ENOENT to McpCallerError', async () => {
 	})
 })
 
+test('repo_tree maps ENOENT errors in a cause chain to McpCallerError', async () => {
+	const missingPathError = Object.assign(
+		new Error('ENOENT: no such file or directory: /session/tests'),
+		{ code: 'ENOENT' },
+	)
+	const tree = vi.fn().mockRejectedValue(
+		Object.assign(new Error('Repository tree RPC failed.'), {
+			cause: missingPathError,
+		}),
+	)
+	mocks.repoSessionRpc.mockReturnValue({ tree })
+
+	const error = await repoTreeCapability
+		.handler(
+			{
+				session_id: 'session-1',
+				path: 'tests',
+			},
+			createContext(),
+		)
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+
+	expect(error).toBeInstanceOf(McpCallerError)
+	expect(error).toMatchObject({
+		message: 'Path "tests" was not found in the repo session workspace.',
+	})
+	expect(tree).toHaveBeenCalledWith({
+		sessionId: 'session-1',
+		userId: 'user-alice',
+		path: 'tests',
+		maxDepth: undefined,
+	})
+})
+
 test('repo_tree still surfaces non-ENOENT failures as plain errors', async () => {
 	const tree = vi
 		.fn()

--- a/packages/worker/src/mcp/capabilities/repo/repo-tree.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-tree.ts
@@ -1,7 +1,9 @@
+import { getErrorCauseChain, getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { repoSessionIdSchema } from './repo-shared.ts'
 
@@ -46,17 +48,46 @@ export const repoTreeCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
-			const result = await repoSessionRpc(ctx.env, args.session_id).tree({
-				sessionId: args.session_id,
-				userId: user.userId,
-				path: args.path ?? null,
-				maxDepth: args.max_depth,
-			})
-			const summary = summarizeTree(result)
-			return summary
+			let result
+			try {
+				result = await repoSessionRpc(ctx.env, args.session_id).tree({
+					sessionId: args.session_id,
+					userId: user.userId,
+					path: args.path ?? null,
+					maxDepth: args.max_depth,
+				})
+			} catch (error) {
+				// Agents often probe common subpaths (docs/, tests/, …) that are
+				// absent. Missing-path ENOENT is a caller-correctable miss, not a
+				// platform defect — keep it on mcp-event and out of Sentry.
+				if (isRepoTreeMissingPathError(error)) {
+					const pathLabel = args.path?.trim() || '.'
+					throw new McpCallerError(
+						`Path "${pathLabel}" was not found in the repo session workspace.`,
+						{ cause: error },
+					)
+				}
+				throw error
+			}
+			return summarizeTree(result)
 		},
 	},
 )
+
+function isRepoTreeMissingPathError(error: unknown) {
+	return getErrorCauseChain(error).some((entry) => {
+		if (!(entry instanceof Error)) return false
+		if (
+			'code' in entry &&
+			typeof entry.code === 'string' &&
+			entry.code === 'ENOENT'
+		) {
+			return true
+		}
+		const message = getErrorMessage(entry)
+		return /^ENOENT\b/i.test(message)
+	})
+}
 
 function summarizeTree(node: {
 	path: string

--- a/packages/worker/src/mcp/capabilities/repo/repo-tree.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-tree.ts
@@ -1,4 +1,7 @@
-import { getErrorCauseChain, getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import {
+	getErrorCauseChain,
+	getErrorMessage,
+} from '@kody-internal/shared/error-message.ts'
 import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop routine `repo_tree` probes of missing subpaths from opening Sentry platform-bug issues.

## Summary

- Agents often call `repo_tree` on common subpaths (`docs/`, `tests/`, `.github/`, …) that do not exist in the session workspace.
- Those calls threw raw workspace `ENOENT` errors, which MCP observability reported to Sentry as handled handler failures.
- `repo_tree` now maps missing-path `ENOENT` to `McpCallerError` with a clear path-not-found message, so they stay on `mcp-event` and out of Sentry (same pattern as #1318 / #1059).
- Fixes https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7660643612/

## Testing

- [x] `packages/worker/src/mcp/capabilities/repo/repo-tree.node.test.ts` (ENOENT → `McpCallerError`; nested cause ENOENT; non-ENOENT still plain Error; happy-path summary)
- [x] Prior Validate green on `5c391ba3` (Node/Workers/MCP/E2E/Static)
- [ ] CI green on latest commit

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `969e1038` · **Head:** `39133459`

**Classification:** composes — wires existing `McpCallerError` classification into the `repo_tree` missing-path path; no new primitives or schema changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | composes — `repo_tree` missing-path uses `McpCallerError` |

### System map

Missing session subpaths from `repo_tree` classify as caller-correctable MCP failures instead of Sentry platform bugs.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	capabilityRegistry -->|"throw McpCallerError on missing tree path"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52dbfa10-48e7-4cd2-b12e-4bd03a71464c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52dbfa10-48e7-4cd2-b12e-4bd03a71464c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository tree error handling for missing paths, providing clearer error details.
  * Preserved existing behavior for other repository access failures.

* **Tests**
  * Added coverage for missing paths, unexpected errors, invalid requests, and repository subtree summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->