### PR TITLE
Tighten free-tier ceilings and add daily job-run quota

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -93,13 +93,14 @@ bound, not a scalable quota). All other resources use the ordinary
 | `storage_bytes`               | 100 GiB   |
 | `execute_calls_per_day`       | 500,000   |
 | `outbound_fetches_per_day`    | 2,000,000 |
+| `job_runs_per_day`            | 1,000,000 |
 
 ## Compute rate limits
 
-`execute_calls_per_day` and `outbound_fetches_per_day` are daily-counter
-resources (same mechanism as `email_sends_per_day`, consumed atomically with
-`consumeDailyEntitlement`). They close the metering → enforcement loop for the
-two compute surfaces `usage-metering.md` already observes:
+`execute_calls_per_day`, `outbound_fetches_per_day`, and `job_runs_per_day` are
+daily-counter resources (same mechanism as `email_sends_per_day`, consumed
+atomically with `consumeDailyEntitlement`). They close the metering →
+enforcement loop for the compute surfaces `usage-metering.md` already observes:
 
 - **Execute calls** are consumed at the top of the MCP `execute` tool handler
   (`packages/worker/src/mcp/tools/execute.ts`) before any bundling or sandbox
@@ -113,8 +114,12 @@ two compute surfaces `usage-metering.md` already observes:
   via `findUserAccountByStableUserId` so the caller's real plan binds. Genuinely
   accountless synthetic contexts resolve to `free` so missing identity plumbing
   cannot grant elevated quotas.
+- **Job runs** are consumed at the top of `executeJobOnce`
+  (`packages/worker/src/jobs/service.ts`) after caller-context resolution and
+  before sandbox work, so over-limit ticks fail cheaply. This is separate from
+  `scheduled_jobs` (how many job rows an account may own).
 
-Both consume only when the context has a `userId`, matching the usage-metering
+These consume only when the context has a `userId`, matching the usage-metering
 rule that events without an owning user are skipped. Daily consumption is
 authoritative in the per-user `UserMeter` Durable Object; see
 [UserMeter](#usermeter).
@@ -122,10 +127,11 @@ authoritative in the per-user `UserMeter` Durable Object; see
 ## UserMeter
 
 Daily rate-style resources (`email_sends_per_day`, `email_receives_per_day`,
-`execute_calls_per_day`, `outbound_fetches_per_day`) are **authoritative in the
-per-user `UserMeter` Durable Object** (`USER_METER` binding). Code lives in
-`packages/worker/src/entitlements/user-meter-do.ts` and `user-meter-client.ts`;
-storage layout and naming are documented in [Data storage](./data-storage.md).
+`execute_calls_per_day`, `outbound_fetches_per_day`, `job_runs_per_day`) are
+**authoritative in the per-user `UserMeter` Durable Object** (`USER_METER`
+binding). Code lives in `packages/worker/src/entitlements/user-meter-do.ts` and
+`user-meter-client.ts`; storage layout and naming are documented in
+[Data storage](./data-storage.md).
 
 **D1 payload storage bytes** (`storage_bytes`) are **authoritative in
 UserMeter**. `assertWithinStorageBytesEntitlement` uses atomic DO
@@ -685,6 +691,9 @@ Use `getCurrent` only when the built-in D1 counter cannot express the resource.
 | `email_message_bytes`         | `handleInboundEmail` before quota/parse (per-message raw size via `resolvePlanLimit`)                                                                                                                                                 |
 | `secrets`                     | new-entry branch of `saveSecret` in `packages/worker/src/mcp/secrets/service.ts`                                                                                                                                                      |
 | `concurrent_workflows`        | `createDynamicCallableWorkflow` (`reserveWorkflowProjectionSlot` + `assertWithinEntitlement` getCurrent; `max` = 5,000)                                                                                                               |
+| `execute_calls_per_day`       | MCP `execute` tool handler (`consumeDailyEntitlement` before bundling/sandbox)                                                                                                                                                        |
+| `outbound_fetches_per_day`    | `executeGatewayFetch` (`consumeDailyEntitlement` before secret expansion)                                                                                                                                                             |
+| `job_runs_per_day`            | `executeJobOnce` (`consumeDailyEntitlement` before sandbox work; cron, interval, and run-now)                                                                                                                                         |
 | `storage_bytes`               | UserMeter DO reserve via `assertWithinStorageBytesEntitlement` (atomic `reserveStorageBytes`; cold zero-init bootstrap; required `env.USER_METER`); StorageRunner write tools/app RPCs (`getCurrent` check-only for bucket component) |
 
 ## Billing

--- a/docs/use/workflows.md
+++ b/docs/use/workflows.md
@@ -53,7 +53,7 @@ Calling `create` again with the same explicit `idempotencyKey` and matching
 workflow identity for the same user returns the existing workflow instead of
 starting a duplicate. Choose keys that include the logical job identity, for
 example `storage-sweep:2026-05-08`. Kody enforces a finite per-user concurrent
-workflow limit from the account plan (free 3, standard 50, pro 100, max 5000);
+workflow limit from the account plan (free 2, standard 50, pro 100, max 5000);
 if the cap is reached, `workflows.create` returns a clear quota error.
 
 Use `workflow_run_list` to inspect recent workflow runs and statuses, and

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -66,6 +66,7 @@ const limitGroups: ReadonlyArray<LimitGroup> = [
 			{ label: 'Concurrent workflows', key: 'maxConcurrentWorkflows' },
 			{ label: 'Execute calls per day', key: 'maxExecuteCallsPerDay' },
 			{ label: 'Outbound fetches per day', key: 'maxOutboundFetchesPerDay' },
+			{ label: 'Job runs per day', key: 'maxJobRunsPerDay' },
 		],
 	},
 	{

--- a/packages/worker/src/admin/entitlement-consumption.ts
+++ b/packages/worker/src/admin/entitlement-consumption.ts
@@ -20,6 +20,7 @@ export const adminEntitlementResources = [
 	'concurrent_workflows',
 	'execute_calls_per_day',
 	'outbound_fetches_per_day',
+	'job_runs_per_day',
 	'storage_bytes',
 ] as const satisfies ReadonlyArray<EntitlementResource>
 

--- a/packages/worker/src/admin/user-meter-parity.node.test.ts
+++ b/packages/worker/src/admin/user-meter-parity.node.test.ts
@@ -142,6 +142,7 @@ test('loadAdminUserMeterParityReport verifies daily, storage, and deletion state
 		['email_receives_per_day', 5],
 		['execute_calls_per_day', 11],
 		['outbound_fetches_per_day', 7],
+		['job_runs_per_day', 0],
 	])
 	assertNoLeaseSecrets(report)
 })

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -177,6 +177,7 @@ async function readMeterDailyCount(input: {
 		| 'email_receives_per_day'
 		| 'execute_calls_per_day'
 		| 'outbound_fetches_per_day'
+		| 'job_runs_per_day'
 	now: Date
 }) {
 	const result = await userMeterRpc({

--- a/packages/worker/src/entitlements/resource-visibility.ts
+++ b/packages/worker/src/entitlements/resource-visibility.ts
@@ -133,6 +133,13 @@ export const entitlementResourceVisibility: Record<
 			'Sandbox outbound HTTP fetches through the fetch gateway today (UTC).',
 		howToReduce: 'Fetch less from user code today, or upgrade your plan.',
 	},
+	job_runs_per_day: {
+		group: 'daily',
+		kind: 'counter',
+		whatCounts:
+			'Scheduled job executions today (UTC), including failed attempts and run-now.',
+		howToReduce: 'Run fewer jobs today, space them out, or upgrade your plan.',
+	},
 }
 
 /** All entitlement resources in display order (grouped). */
@@ -141,6 +148,7 @@ export const accountUsageEntitlementResources = [
 	'email_receives_per_day',
 	'execute_calls_per_day',
 	'outbound_fetches_per_day',
+	'job_runs_per_day',
 	'repos',
 	'saved_packages',
 	'scheduled_jobs',

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -757,6 +757,7 @@ export async function readEntitlementResourceUsage(input: {
 		case 'email_receives_per_day':
 		case 'execute_calls_per_day':
 		case 'outbound_fetches_per_day':
+		case 'job_runs_per_day':
 			// Authoritative daily counters live in UserMeter. Callers must use
 			// consumeDailyEntitlement / readDailyEntitlementResourceUsage /
 			// readCurrentEntitlementResourceUsage — the retired D1 mirror is gone.

--- a/packages/worker/src/entitlements/user-meter-do.ts
+++ b/packages/worker/src/entitlements/user-meter-do.ts
@@ -15,6 +15,7 @@ export const dailyEntitlementResources = [
 	'email_receives_per_day',
 	'execute_calls_per_day',
 	'outbound_fetches_per_day',
+	'job_runs_per_day',
 ] as const satisfies ReadonlyArray<EntitlementResource>
 
 export type DailyEntitlementResource =

--- a/packages/worker/src/entitlements/user-meter.workers.test.ts
+++ b/packages/worker/src/entitlements/user-meter.workers.test.ts
@@ -738,6 +738,7 @@ test('UserMeter storage RPCs, authoritative export state, and purge work additiv
 		'email_receives_per_day',
 		'email_sends_per_day',
 		'execute_calls_per_day',
+		'job_runs_per_day',
 		'outbound_fetches_per_day',
 	] as const) {
 		await meter.initialize({
@@ -770,11 +771,19 @@ test('UserMeter storage RPCs, authoritative export state, and purge work additiv
 		startAfter: firstPage.nextStartAfter,
 	})
 	expect(secondPage.counters).toHaveLength(2)
-	expect(secondPage.truncated).toBe(false)
-	expect(secondPage.nextStartAfter).toBeNull()
+	expect(secondPage.truncated).toBe(true)
+	expect(secondPage.nextStartAfter).toEqual(expect.any(String))
 	expect(secondPage.storageBytesState).toBeNull()
 	expect(secondPage.packageServiceStates).toBeNull()
 	expect(secondPage.deletionState).toBeNull()
+
+	const thirdPage = await meter.exportCounters({
+		pageSize: 2,
+		startAfter: secondPage.nextStartAfter,
+	})
+	expect(thirdPage.counters).toHaveLength(1)
+	expect(thirdPage.truncated).toBe(false)
+	expect(thirdPage.nextStartAfter).toBeNull()
 
 	await expect(meter.purge()).resolves.toEqual({ ok: true })
 	expect(await meter.readStorageBytes()).toEqual({

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1728,6 +1728,84 @@ test('createJob enforces scheduled job entitlements for plan users and denies at
 	})
 })
 
+test('executeJobOnce enforces job_runs_per_day before sandbox work', async () => {
+	// Usage rollup writes are best-effort and fail against this fake env.
+	silenceIncidentalRuntimeWarnings()
+	const { utcDayKey } = await import('@kody-internal/shared/date-keys.ts')
+	const { parseEntitlementLimitMessage } = await import(
+		'#worker/entitlements/errors.ts'
+	)
+	const callerContext = createBaseCallerContext()
+	const userId = callerContext.user.userId
+	// Matches the module-level resolveBackgroundMcpUser mock email.
+	const email = `${userId}@example.com`
+	const meter = createInMemoryUserMeterEnv()
+	const env = createJobServiceTestEnv(
+		{
+			APP_DB: createDatabase({
+				users: [{ email, plan: 'free', stable_user_id: userId }],
+			}),
+		},
+		meter,
+	)
+	const limit = planLimits.free.maxJobRunsPerDay
+	await meter.seed({
+		userId,
+		resource: 'job_runs_per_day',
+		day: utcDayKey(),
+		count: limit,
+	})
+
+	const executeSpy = vi.spyOn(
+		await import('#mcp/run-kody-registry.ts'),
+		'runBundledModuleWithRegistry',
+	)
+	const job: JobRecord = {
+		version: 1,
+		id: 'job-run-quota',
+		userId,
+		name: 'Quota job',
+		sourceId: 'source-job-run-quota',
+		publishedCommit: null,
+		storageId: 'job:job-run-quota',
+		schedule: { type: 'interval', every: '1h' },
+		timezone: 'UTC',
+		enabled: true,
+		killSwitchEnabled: false,
+		preserved: false,
+		expiresAt: null,
+		createdAt: '2026-08-08T00:00:00.000Z',
+		updatedAt: '2026-08-08T00:00:00.000Z',
+		nextRunAt: '2026-08-08T13:00:00.000Z',
+		runCount: 0,
+		successCount: 0,
+		errorCount: 0,
+	}
+
+	try {
+		const outcome = await executeJobOnce({
+			env,
+			job,
+			callerContext,
+		})
+		expect(outcome.execution.ok).toBe(false)
+		if (outcome.execution.ok) {
+			throw new Error('Expected job_runs_per_day denial.')
+		}
+		const details = parseEntitlementLimitMessage(outcome.execution.error)
+		expect(details).toMatchObject({
+			code: 'entitlement_limit_exceeded',
+			resource: 'job_runs_per_day',
+			plan: 'free',
+			limit,
+			current: limit,
+		})
+		expect(executeSpy).not.toHaveBeenCalled()
+	} finally {
+		executeSpy.mockRestore()
+	}
+})
+
 test('blank-email package context uses the max plan for storage writes and nested job scheduling', async () => {
 	const email = 'package-owner@example.com'
 	const userId = await createStableUserIdFromEmail(email)

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1732,9 +1732,12 @@ test('executeJobOnce enforces job_runs_per_day before sandbox work', async () =>
 	// Usage rollup writes are best-effort and fail against this fake env.
 	silenceIncidentalRuntimeWarnings()
 	const { utcDayKey } = await import('@kody-internal/shared/date-keys.ts')
-	const { parseEntitlementLimitMessage } = await import(
-		'#worker/entitlements/errors.ts'
-	)
+	const { parseEntitlementLimitMessage } =
+		await import('#worker/entitlements/errors.ts')
+	const usageModule = await import('#worker/usage/record-usage.ts')
+	const recordUsageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockResolvedValue(undefined)
 	const callerContext = createBaseCallerContext()
 	const userId = callerContext.user.userId
 	// Matches the module-level resolveBackgroundMcpUser mock email.
@@ -1801,8 +1804,10 @@ test('executeJobOnce enforces job_runs_per_day before sandbox work', async () =>
 			current: limit,
 		})
 		expect(executeSpy).not.toHaveBeenCalled()
+		expect(recordUsageSpy).not.toHaveBeenCalled()
 	} finally {
 		executeSpy.mockRestore()
+		recordUsageSpy.mockRestore()
 	}
 })
 

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -58,6 +58,7 @@ import {
 	type PersistedJobCallerContext,
 } from './types.ts'
 import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'
+import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import {
 	assertWithinEntitlement,
 	consumeDailyEntitlement,
@@ -1297,7 +1298,13 @@ export async function executeJobOnce(input: {
 					error: formatJobError(error),
 					logs: [],
 				}
-				completedOccurrence = true
+				// Daily job-run quota denials happen before sandbox work.
+				// Still return an error outcome so schedules advance, but do
+				// not emit job_run usage or else every post-limit tick
+				// inflates rollups while the UserMeter counter stays capped.
+				if (!isEntitlementLimitError(error)) {
+					completedOccurrence = true
+				}
 			} finally {
 				finished = new Date()
 				durationMs = Math.max(0, finished.valueOf() - started.valueOf())

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -60,6 +60,7 @@ import {
 import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'
 import {
 	assertWithinEntitlement,
+	consumeDailyEntitlement,
 	readEntitlementResourceUsage,
 } from '#worker/entitlements/service.ts'
 import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
@@ -1248,6 +1249,16 @@ export async function executeJobOnce(input: {
 						},
 						repoContext: input.callerContext.repoContext ?? null,
 					}
+					// Daily job-run quota before sandbox work so over-limit
+					// ticks cost nothing. Failed attempts still count.
+					await consumeDailyEntitlement({
+						db: input.env.APP_DB,
+						env: input.env,
+						userId: input.job.userId,
+						email: backgroundUser.email,
+						resource: 'job_runs_per_day',
+						waitUntil: input.waitUntil,
+					})
 					const result = await runRepoBackedJob({
 						env: input.env,
 						job: input.job,

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
@@ -36,6 +36,7 @@ const entitlementResourceSchema = z.enum([
 	'storage_bytes',
 	'execute_calls_per_day',
 	'outbound_fetches_per_day',
+	'job_runs_per_day',
 ])
 
 const planSchema = z.enum(planNames)

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -322,6 +322,7 @@ export type AdminUsageEntitlementResource =
 	| 'storage_bytes'
 	| 'execute_calls_per_day'
 	| 'outbound_fetches_per_day'
+	| 'job_runs_per_day'
 
 export type AdminPlanName = 'free' | 'standard' | 'pro' | 'max'
 

--- a/packages/worker/universal/plans.ts
+++ b/packages/worker/universal/plans.ts
@@ -144,6 +144,12 @@ export type PlanLimits = {
 	 * reputation for the whole deployment.
 	 */
 	maxOutboundFetchesPerDay: number
+	/**
+	 * Maximum scheduled-job executions per UTC day (cron, interval, and
+	 * run-now). Separate from `maxScheduledJobs` (how many job rows you may
+	 * own) so a handful of minutely jobs cannot burn unbounded compute.
+	 */
+	maxJobRunsPerDay: number
 }
 
 export const entitlementResources = [
@@ -162,6 +168,7 @@ export const entitlementResources = [
 	'concurrent_workflows',
 	'execute_calls_per_day',
 	'outbound_fetches_per_day',
+	'job_runs_per_day',
 ] as const
 
 export type EntitlementResource = (typeof entitlementResources)[number]
@@ -183,6 +190,7 @@ export const entitlementResourceLabels: Record<EntitlementResource, string> = {
 	concurrent_workflows: 'concurrent workflows',
 	execute_calls_per_day: 'execute calls per day',
 	outbound_fetches_per_day: 'outbound fetches per day',
+	job_runs_per_day: 'job runs per day',
 }
 
 /**
@@ -217,32 +225,21 @@ export const maxPlanEmailLimits = {
  * use {@link maxPlanEmailLimits} abuse caps instead.
  */
 export const planLimits: Record<PlanName, PlanLimits> = {
-	// Free is deliberately generous on *counts* and unchanged on *rates*.
-	//
-	// Counts (packages, jobs, secrets, repo sessions) are close to free to
-	// serve — a handful of D1 rows — and they are exactly what stands between
-	// someone and the moment the product makes sense, which is the second or
-	// third automation rather than the first. Rates and long-lived compute
-	// (execute calls, outbound fetches, inbound mail, workflows, services) are
-	// the real cost and abuse surfaces and stay where they were.
-	//
-	// The old ceilings ran out during setup rather than after conviction. Five
-	// secrets is the clearest case: one OAuth integration commonly needs three
-	// (client secret, access token, refresh token), so five allowed barely one
-	// and a half integrations on a product whose whole point is holding
-	// credentials safely.
+	// Free stays roomy for setup (packages, secrets, a handful of jobs) and
+	// tighter on rates / live compute — the real cost and the upgrade story.
+	// Secrets stay at 25 because one OAuth integration commonly needs three
+	// entries (client secret, access token, refresh token).
 	free: {
 		maxRepos: 20,
-		maxSavedPackages: 25,
-		maxScheduledJobs: 10,
+		maxSavedPackages: 15,
+		maxScheduledJobs: 5,
 		// Long-lived compute. Persistent services stay off.
 		maxPackageServices: 1,
 		maxPersistentPackageServices: 0,
 		// Sessions are cheap (D1 row + dormant DO workspace + Artifacts
 		// branch) and the 7-day abandoned-session sweep keeps idle ones from
-		// accumulating, so the caps are sized for agent workflows that open
-		// a session per conversation rather than for genuine concurrency.
-		maxRepoSessions: 50,
+		// accumulating; sized for a few agent conversations, not dozens.
+		maxRepoSessions: 15,
 		// notify-self and reply-to-stored only, so the outreach-abuse surface
 		// is small; a daily digest plus a few alerts should not hit the wall.
 		maxEmailSendsPerDay: 10,
@@ -251,12 +248,12 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxStoredEmailMessages: 500,
 		maxEmailMessageBytes: 256 * 1024,
 		maxSecrets: 25,
-		maxStorageBytes: 64 * 1024 * 1024,
-		// Compute. Unchanged.
-		maxConcurrentWorkflows: 3,
-		// The primary cost meter. Unchanged.
-		maxExecuteCallsPerDay: 500,
-		maxOutboundFetchesPerDay: 2_000,
+		maxStorageBytes: 16 * 1024 * 1024,
+		// Concurrent active runs (not lifetime or daily).
+		maxConcurrentWorkflows: 2,
+		maxExecuteCallsPerDay: 250,
+		maxOutboundFetchesPerDay: 1_000,
+		maxJobRunsPerDay: 500,
 	},
 	standard: {
 		maxRepos: 200,
@@ -274,6 +271,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxConcurrentWorkflows: 50,
 		maxExecuteCallsPerDay: 5_000,
 		maxOutboundFetchesPerDay: 20_000,
+		maxJobRunsPerDay: 10_000,
 	},
 	pro: {
 		maxRepos: 400,
@@ -291,6 +289,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxConcurrentWorkflows: 100,
 		maxExecuteCallsPerDay: 10_000,
 		maxOutboundFetchesPerDay: 40_000,
+		maxJobRunsPerDay: 20_000,
 	},
 	max: {
 		// 25× pro (400) → 10_000.
@@ -320,6 +319,8 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxExecuteCallsPerDay: 500_000,
 		// 50× pro (40_000) → 2_000_000.
 		maxOutboundFetchesPerDay: 2_000_000,
+		// 50× pro (20_000) → 1_000_000.
+		maxJobRunsPerDay: 1_000_000,
 	},
 }
 
@@ -363,6 +364,8 @@ export function resolvePlanLimit(
 			return limits.maxExecuteCallsPerDay
 		case 'outbound_fetches_per_day':
 			return limits.maxOutboundFetchesPerDay
+		case 'job_runs_per_day':
+			return limits.maxJobRunsPerDay
 		default: {
 			const exhaustive: never = resource
 			throw new Error(`Unknown entitlement resource: ${String(exhaustive)}`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies the upper-bound free-tier adjustments we discussed, and clarifies that **concurrent workflows = simultaneous active runs** (not lifetime or daily).

### Free tier changes

| Resource | Before | After |
|---|---:|---:|
| Saved packages | 25 | **15** |
| Scheduled jobs | 10 | **5** |
| Secrets | 25 | **25** (unchanged) |
| Repo sessions | 50 | **15** |
| Storage | 64 MB | **16 MB** |
| Concurrent workflows | 3 | **2** |
| Execute calls / day | 500 | **250** |
| Outbound fetches / day | 2,000 | **1,000** |
| Job runs / day | ∞ | **500** (new) |

Also adds `job_runs_per_day` for Standard (10k), Pro (20k), and Max (1M), enforced in `executeJobOnce` before sandbox work.

### Why

Current fleet usage sits well under these ceilings. The important new control is daily job runs: slot count alone allowed a few minutely jobs to burn unbounded compute.

### Testing

- Focused node-unit: `packages/worker/src/jobs/service.node.test.ts` (includes quota denial + no `recordUsage` on denial) and `packages/worker/src/admin/user-meter-parity.node.test.ts`
- Follow-up commit addresses Static format failure, Node parity expectation, and Bugbot medium finding (quota denials no longer inflate `job_run` usage rollups)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `67503c51` · **Head:** `ae86c6d9`

**Classification:** extends — free plan limit numbers change; new `job_runs_per_day` daily entitlement is enforced on job execution via UserMeter.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — free ceilings + new `job_runs_per_day` resource |
| `user-meter` | storage | extends — daily counter registry includes `job_runs_per_day` |
| `jobs` | assistant | extends — `executeJobOnce` consumes daily job-run quota; quota denials skip `job_run` usage |
| `app-ui` | surfaces | composes — pricing table reads new limit key |
| `rbac` | auth | composes — admin usage schema lists new resource |

### System map

Job ticks and plan UI now flow through the updated entitlement registry and UserMeter daily counters.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	jobs["jobs<br/>Scheduled jobs"]:::extended
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	userMeter["user-meter<br/>User meter"]:::extended
	appUi["app-ui<br/>Browser app"]:::touched
	jobs -->|"consumeDailyEntitlement job_runs_per_day"| entitlements
	entitlements -->|"UserMeter daily counter"| userMeter
	appUi -->|"pricing reads planLimits"| entitlements
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
free.maxSavedPackages: 25 → 15
free.maxScheduledJobs: 10 → 5
free.maxRepoSessions: 50 → 15
free.maxStorageBytes: 64MB → 16MB
free.maxConcurrentWorkflows: 3 → 2
free.maxExecuteCallsPerDay: 500 → 250
free.maxOutboundFetchesPerDay: 2000 → 1000
job_runs_per_day: (none) → free 500 / standard 10k / pro 20k / max 1M
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10435067-78d2-48aa-87e0-74db424535c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10435067-78d2-48aa-87e0-74db424535c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan-based daily job-run quotas, including visibility in compute limits and account usage.
  * Job executions are now blocked when the daily quota is reached.
  * Failed and manually triggered runs are included in daily usage tracking.
* **Changes**
  * Reduced the free-plan concurrent workflow limit from 3 to 2.
  * Updated plan entitlement and usage documentation to reflect the new limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->