### PR TITLE
Fix preview CI: stop using unpaginated R2 bucket list as existence oracle

### DIFF
--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -12,10 +12,10 @@ import {
 	ensureArtifactsAccountEventSubscription,
 	ensureCloudflareQueue,
 	ensureEmailSendingEventSubscription,
+	isR2BucketAlreadyExistsOutput,
 	isRetryableCloudflareApiError,
 	isWranglerNotFoundOutput,
 	parseJsonc,
-	parseR2BucketListOutput,
 	writeGeneratedWranglerConfig,
 } from './resource-utils.ts'
 
@@ -362,20 +362,18 @@ test('writeGeneratedWranglerConfig keeps legacy app hosts attached during a doma
 	}
 })
 
-test('parseR2BucketListOutput reads bucket names from labelled wrangler output', () => {
-	const output = [
-		'Listing buckets...',
-		'name:           kody-email-blobs',
-		'creation_date:  2026-07-01T00:00:00.000Z',
-		'',
-		'name:           kody-pr-42-email-blobs',
-		'creation_date:  2026-07-02T00:00:00.000Z',
-	].join('\n')
-	expect(parseR2BucketListOutput(output)).toEqual([
-		'kody-email-blobs',
-		'kody-pr-42-email-blobs',
-	])
-	expect(parseR2BucketListOutput('')).toEqual([])
+test('isR2BucketAlreadyExistsOutput recognizes Wrangler bucket-exists errors', () => {
+	expect(
+		isR2BucketAlreadyExistsOutput(
+			'✘ [ERROR] A request to the Cloudflare API (/accounts/abc/r2/buckets) failed.\n\n' +
+				'  The bucket you tried to create already exists, and you own it. [code: 10004]',
+		),
+	).toBe(true)
+	expect(isR2BucketAlreadyExistsOutput('[code: 10004]')).toBe(true)
+	expect(
+		isR2BucketAlreadyExistsOutput('Authentication error [code: 10000]'),
+	).toBe(false)
+	expect(isR2BucketAlreadyExistsOutput('')).toBe(false)
 })
 
 test('Queue and Email Sending subscription ensure creates and reconciles Cloudflare resources', async () => {

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -215,35 +215,17 @@ export function deleteWorkerScript({
 	fail(`Failed to delete Worker script: ${name}`)
 }
 
-const ansiEscape = String.fromCharCode(27)
-
 /**
- * `wrangler r2 bucket list` has no JSON output; it prints labelled-value
- * blocks (`name: <bucket>` / `creation_date: ...`). Parse the bucket
- * names out of that listing. Piped wrangler output is normally
- * color-free, but ANSI sequences are stripped defensively.
+ * The Cloudflare API behind `wrangler r2 bucket list` returns a single
+ * unpaginated page, so once an account holds more buckets than one page the
+ * listing silently omits some of them. Never use the list as an existence
+ * oracle; rely on the create/delete outcome for the specific bucket instead.
  */
-export function parseR2BucketListOutput(output: string): Array<string> {
-	const names: Array<string> = []
-	for (const line of output.split('\n')) {
-		const plain = line
-			.split(ansiEscape)
-			.map((part, index) =>
-				index === 0 ? part : part.replace(/^\[[0-9;]*m/, ''),
-			)
-			.join('')
-		const match = /^name:\s*(\S+)\s*$/.exec(plain.trim())
-		if (match?.[1]) names.push(match[1])
-	}
-	return names
-}
-
-export function listR2BucketNames(): Array<string> {
-	const result = runWrangler(['r2', 'bucket', 'list'], { quiet: true })
-	if (result.status !== 0) {
-		fail('Failed to list R2 buckets (wrangler r2 bucket list).')
-	}
-	return parseR2BucketListOutput(result.stdout)
+export function isR2BucketAlreadyExistsOutput(output: string) {
+	return (
+		output.includes('[code: 10004]') ||
+		output.toLowerCase().includes('already exists')
+	)
 }
 
 export function ensureR2Bucket({
@@ -258,23 +240,24 @@ export function ensureR2Bucket({
 		return { name }
 	}
 
-	if (listR2BucketNames().includes(name)) {
+	const createResult = runWrangler(['r2', 'bucket', 'create', name], {
+		quiet: true,
+	})
+	if (createResult.status === 0) {
+		console.error(`Created R2 bucket: ${name}`)
+		return { name }
+	}
+
+	const output = `${createResult.stdout}${createResult.stderr}`.trim()
+	if (isR2BucketAlreadyExistsOutput(output)) {
 		console.error(`R2 bucket exists: ${name}`)
 		return { name }
 	}
 
-	const createResult = runWrangler(['r2', 'bucket', 'create', name], {
-		quiet: true,
-	})
-	if (createResult.status !== 0) {
-		fail(`Failed to create R2 bucket: ${name}`)
+	if (output) {
+		console.error(output)
 	}
-
-	if (!listR2BucketNames().includes(name)) {
-		fail(`Created R2 bucket "${name}" but could not find it via list.`)
-	}
-	console.error(`Created R2 bucket: ${name}`)
-	return { name }
+	fail(`Failed to create R2 bucket: ${name}`)
 }
 
 export function deleteR2Bucket({
@@ -289,22 +272,24 @@ export function deleteR2Bucket({
 		return
 	}
 
-	if (!listR2BucketNames().includes(name)) {
+	const result = runWrangler(['r2', 'bucket', 'delete', name], { quiet: true })
+	if (result.status === 0) {
+		console.error(`Deleted R2 bucket: ${name}`)
+		return
+	}
+
+	const output = `${result.stdout}${result.stderr}`.trim()
+	if (isWranglerNotFoundOutput(output)) {
 		console.error(`R2 bucket already deleted: ${name}`)
 		return
 	}
 
-	const result = runWrangler(['r2', 'bucket', 'delete', name], { quiet: true })
-	if (result.status !== 0) {
-		// R2 refuses to delete non-empty buckets and wrangler has no purge
-		// command; a leftover preview bucket is preferable to a failed
-		// cleanup run, so warn instead of failing the workflow.
-		console.error(
-			`Warning: failed to delete R2 bucket ${name} (it may not be empty); it must be cleaned up manually.`,
-		)
-		return
-	}
-	console.error(`Deleted R2 bucket: ${name}`)
+	// R2 refuses to delete non-empty buckets and wrangler has no purge
+	// command; a leftover preview bucket is preferable to a failed
+	// cleanup run, so warn instead of failing the workflow.
+	console.error(
+		`Warning: failed to delete R2 bucket ${name} (it may not be empty); it must be cleaned up manually.`,
+	)
 }
 
 type CloudflareApiRequestInput = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The 🔎 Deploy Preview Resources check fails once the Cloudflare account holds more R2 buckets than one API page (observed on [PR #1328](https://github.com/kentcdodds/kody/pull/1328): first run "Created R2 bucket … but could not find it via list", rerun "already exists [code: 10004]"). `wrangler r2 bucket list` calls `GET /accounts/:id/r2/buckets` without pagination, so the listing silently omits buckets, and preview cleanup deliberately warns-and-continues on non-empty buckets, so the account accumulates them over time. The list can therefore never be trusted as an existence oracle.

## Summary

- `ensureR2Bucket`: attempt `r2 bucket create` directly; treat the Cloudflare "bucket already exists, and you own it" error (`code: 10004`) as success. Removes both the list pre-check and the list post-create verification.
- `deleteR2Bucket`: attempt `r2 bucket delete` directly; treat not-found output as already-deleted; keep the existing warn-don't-fail behavior for non-empty buckets. This also fixes silent cleanup skips for buckets missing from the truncated listing.
- Remove now-unused `listR2BucketNames` / `parseR2BucketListOutput` and replace the parser unit test with one for the new `isR2BucketAlreadyExistsOutput` helper.

## Testing

- `npx vitest run tools/ci/resource-utils.node.test.ts` — 9 tests pass.
- `npm run lint` — no new warnings.
- Pre-push hook (full unit + e2e suites) passed on push.
- The 🔎 Deploy Preview Resources check on this PR exercises the changed code path directly against the affected Cloudflare account.

## System changes

CI-tooling only (`tools/ci/`); no runtime primitives touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6be7b75-a683-4051-95d4-7ed109842995?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6be7b75-a683-4051-95d4-7ed109842995&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved R2 bucket creation to handle existing buckets without failing.
  * Improved R2 bucket deletion to recognize already-removed buckets and continue gracefully when deletion is unsuccessful.
  * Increased reliability by using direct bucket operations instead of relying on bucket listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->