### PR TITLE
fix(ci): stop the two dominant CI failure modes (preview cleanup + E2E flake)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -177,8 +177,28 @@ jobs:
           playwright: 'true'
           worker-env: 'true'
 
+      # Wrangler's local workerd occasionally crashes mid-suite ("Broken
+      # pipe" → "Network connection lost"), which kills the Playwright
+      # webServer and fails every remaining test with ECONNREFUSED /
+      # E2eWebServerDeadError (see e2e/web-server-liveness.ts). Retry the
+      # whole suite once with a fresh server, but only when the failure
+      # matches that crash signature — genuine test failures never retry.
       - name: 🎭 Playwright E2E
-        run: npm run test:e2e:run
+        run: |
+          # No pipefail: the runner's implicit `bash -e` would abort on the
+          # failing pipeline before the flake check; PIPESTATUS captures the
+          # suite's exit code instead.
+          set -u
+          npm run test:e2e:run 2>&1 | tee e2e-attempt-1.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+          if ! grep -qE 'E2eWebServerDeadError|ERR_CONNECTION_REFUSED|ECONNREFUSED' e2e-attempt-1.log; then
+            exit "$status"
+          fi
+          echo "::warning::Playwright webServer (wrangler) died mid-suite; retrying the E2E suite once with a fresh server."
+          npm run test:e2e:run
 
       # Wrangler writes fatal mid-suite exits under WRANGLER_LOG_PATH
       # (./logs.local). Upload on failure so empty `[WebServer] ERROR` lines

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -194,7 +194,10 @@ jobs:
           if [ "$status" -eq 0 ]; then
             exit 0
           fi
-          if ! grep -qE 'E2eWebServerDeadError|ERR_CONNECTION_REFUSED|ECONNREFUSED' e2e-attempt-1.log; then
+          # Anchor connection-refused matches to the e2e webServer origin
+          # (port 3847, see playwright.config.ts) so an unrelated test
+          # failure that merely mentions a refused connection never retries.
+          if ! grep -qE 'E2eWebServerDeadError|ECONNREFUSED (127\.0\.0\.1|localhost):3847|ERR_CONNECTION_REFUSED at https?://(127\.0\.0\.1|localhost):3847' e2e-attempt-1.log; then
             exit "$status"
           fi
           echo "::warning::Playwright webServer (wrangler) died mid-suite; retrying the E2E suite once with a fresh server."

--- a/tools/ci/preview-resources.ts
+++ b/tools/ci/preview-resources.ts
@@ -438,6 +438,10 @@ async function cleanupPreviewResources(options: CliOptions) {
 		apiToken: apiToken ?? 'dry-run-token',
 		dryRun: options.dryRun,
 	}
+	// Workers must go first: Cloudflare refuses to delete a queue that is
+	// still referenced by a Worker binding (400 "Cannot delete queue ...
+	// still referenced by a binding in a Worker").
+	deletePreviewWorkers(options.workerName, options.dryRun)
 	await deleteCloudflareQueue({
 		...queueClient,
 		name: webhookDispatchQueueName,
@@ -446,7 +450,6 @@ async function cleanupPreviewResources(options: CliOptions) {
 		...queueClient,
 		name: webhookDispatchDeadLetterQueueName,
 	})
-	deletePreviewWorkers(options.workerName, options.dryRun)
 	deleteR2Bucket({ name: communityAssetsBucketName, dryRun: options.dryRun })
 	deleteR2Bucket({ name: emailBlobsBucketName, dryRun: options.dryRun })
 	deleteKvNamespace({ title: bundleArtifactsKvTitle, dryRun: options.dryRun })

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -585,6 +585,92 @@ test('deleteCloudflareQueue removes an existing queue by id', async () => {
 	)
 })
 
+const queueStillReferencedResponse = () =>
+	Response.json(
+		{
+			success: false,
+			errors: [
+				{
+					code: 11004,
+					message:
+						"Cannot delete queue 'kody-pr-123-webhook-dispatch' that is still referenced by a binding in a Worker. Unbind queue 'kody-pr-123-webhook-dispatch' from the Workers 'kody-pr-123'; then try again.",
+				},
+			],
+		},
+		{ status: 400 },
+	)
+
+test('deleteCloudflareQueue waits out the Worker binding release then deletes', async () => {
+	consoleError.mockImplementation(() => {})
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{
+						queue_id: 'queue-preview',
+						queue_name: 'kody-pr-123-webhook-dispatch',
+					},
+				],
+				result_info: { total_pages: 1 },
+			}),
+		)
+		.mockResolvedValueOnce(queueStillReferencedResponse())
+		.mockResolvedValueOnce(Response.json({ success: true, result: null }))
+	const sleep = vi.fn(async () => {})
+
+	await deleteCloudflareQueue({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		name: 'kody-pr-123-webhook-dispatch',
+		dryRun: false,
+		fetcher,
+		sleep,
+	})
+
+	expect(fetcher).toHaveBeenCalledTimes(3)
+	expect(sleep).toHaveBeenCalledTimes(1)
+	expect(fetcher).toHaveBeenNthCalledWith(
+		3,
+		'https://api.cloudflare.com/client/v4/accounts/account-1/queues/queue-preview',
+		expect.objectContaining({ method: 'DELETE' }),
+	)
+})
+
+test('deleteCloudflareQueue gives up when the binding is never released', async () => {
+	consoleError.mockImplementation(() => {})
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{
+						queue_id: 'queue-preview',
+						queue_name: 'kody-pr-123-webhook-dispatch',
+					},
+				],
+				result_info: { total_pages: 1 },
+			}),
+		)
+		.mockImplementation(async () => queueStillReferencedResponse())
+
+	await expect(
+		deleteCloudflareQueue({
+			accountId: 'account-1',
+			apiToken: 'token-1',
+			name: 'kody-pr-123-webhook-dispatch',
+			dryRun: false,
+			fetcher,
+			sleep: async () => {},
+		}),
+	).rejects.toThrow('still referenced by a binding in a Worker')
+
+	// One list call plus five delete attempts.
+	expect(fetcher).toHaveBeenCalledTimes(6)
+})
+
 test('Cloudflare API requests retry gateway HTML/text blips then succeed', async () => {
 	consoleError.mockImplementation(() => {})
 	const fetcher = vi

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -458,6 +458,22 @@ export async function ensureCloudflareQueue(input: {
 	}
 }
 
+/**
+ * Cloudflare returns this 400 while a Worker still binds the queue. Deleting
+ * the Worker first is required, but the binding release propagates
+ * asynchronously, so a just-deleted Worker can briefly keep the queue
+ * undeletable.
+ */
+export function isQueueStillReferencedError(error: unknown) {
+	return (
+		error instanceof Error &&
+		error.message.includes('still referenced by a binding in a Worker')
+	)
+}
+
+const queueBindingReleaseMaxAttempts = 5
+const queueBindingReleaseBaseDelayMs = 2_000
+
 export async function deleteCloudflareQueue(input: {
 	accountId: string
 	apiToken: string
@@ -465,6 +481,7 @@ export async function deleteCloudflareQueue(input: {
 	dryRun: boolean
 	apiBaseUrl?: string
 	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
 }) {
 	if (input.dryRun) {
 		console.error(`[dry-run] delete Queue: ${input.name}`)
@@ -477,11 +494,28 @@ export async function deleteCloudflareQueue(input: {
 		console.error(`Queue already deleted: ${input.name}`)
 		return
 	}
-	await cloudflareApiRequest({
-		...input,
-		pathname: `/queues/${queue.queue_id}`,
-		method: 'DELETE',
-	})
+	const wait = input.sleep ?? sleep
+	for (let attempt = 1; ; attempt += 1) {
+		try {
+			await cloudflareApiRequest({
+				...input,
+				pathname: `/queues/${queue.queue_id}`,
+				method: 'DELETE',
+			})
+			break
+		} catch (error) {
+			if (
+				!isQueueStillReferencedError(error) ||
+				attempt === queueBindingReleaseMaxAttempts
+			) {
+				throw error
+			}
+			console.error(
+				`Queue ${input.name} is still bound to a Worker; waiting for the binding release (attempt ${attempt + 1}/${queueBindingReleaseMaxAttempts})`,
+			)
+			await wait(queueBindingReleaseBaseDelayMs * 2 ** (attempt - 1))
+		}
+	}
 	console.error(`Deleted Queue: ${input.name} (${queue.queue_id})`)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

CI has been failing constantly. Auditing the last ~24h of runs (27 failed runs out of ~140) shows four buckets:

| Bucket | Count | Verdict |
| --- | --- | --- |
| 🧹 Cleanup Preview Resources | 6 | **Bug fixed here** — queue deleted before the Worker that binds it |
| 🎭 E2E (Validate, incl. `main` pushes) | 4 | **Flake mitigated here** — workerd crashes mid-suite, killing the web server |
| 🔎 Deploy Preview Resources | 11 | Already fixed by #1332 (R2 bucket list pagination); none since it merged |
| 🧹 Static / 🧪 Node | 6 | Genuine PR-branch failures (type errors, assertions) — CI working as intended |

## What

### Preview cleanup ordering (root-cause fix)

Since #1322 added the webhook-dispatch queues, **every** PR-close cleanup failed with:

```
Cloudflare API request failed (400): Cannot delete queue 'kody-pr-1333-webhook-dispatch'
that is still referenced by a binding in a Worker.
```

`cleanupPreviewResources` deleted the queues before `deletePreviewWorkers`. Cloudflare refuses to delete a queue still bound to a Worker, so the ordering could never succeed.

- `tools/ci/preview-resources.ts`: delete the Workers first, then the queues (verified via `cleanup --dry-run`).
- `tools/ci/resource-utils.ts`: `deleteCloudflareQueue` now retries the specific "still referenced by a binding in a Worker" 400 with backoff (5 attempts, 2s base), because the binding release after a Worker delete propagates asynchronously. All other errors still throw immediately.
- Unit tests cover both the retry-then-succeed and the give-up paths.

### E2E flake (targeted retry, signal preserved)

All four Validate E2E failures were the same crash: wrangler's local workerd dies mid-suite ("Broken pipe" → "Network connection lost" in the `e2e-wrangler-logs` artifact), and every remaining test fails with `ECONNREFUSED` / `E2eWebServerDeadError`. Two env-var mitigations already exist in `playwright.config.ts` but the crash persists upstream.

- `.github/workflows/validate.yml`: the 🎭 E2E step retries the suite **once** with a fresh server, and **only** when the first attempt's output matches the crash signature (`E2eWebServerDeadError|ERR_CONNECTION_REFUSED|ECONNREFUSED`). Genuine test failures exit immediately with the original status, so red still means broken.
- Speed tradeoff: zero cost on green runs; on a flake the retry re-runs a ~1–2 minute suite (nx caches the build-client dependency), well within the job's 15-minute timeout.
- The runner's implicit `bash -e` would abort a `pipefail` pipeline before the flake check, so the wrapper reads `PIPESTATUS` instead (all three paths tested under `bash -e`).

## Leftover resources to reap

The failed cleanups left orphaned preview stacks behind (at least `kody-pr-1328`, `kody-pr-1332`, `kody-pr-1333`, `kody-pr-1334`, and earlier). After this merges, run the 🔎 Preview workflow manually with `action=cleanup`, `target=pr`, and each `pr_number` — the fixed ordering will now delete them.

## Validation

- `npx vitest run tools/ci --project node-unit`: 27 passed
- `npm run format:check`, `npm run lint`, `npm run typecheck`: green
- `node tools/ci/preview-resources.ts cleanup --worker-name kody-pr-999 --dry-run`: Workers now precede queues
- Retry wrapper exercised under `bash -e` for pass / real-failure / flake paths

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk, CI-only)</summary>

**Mode:** recap · **Base:** `main` @ `c1cab0fc` · **Head:** `3fff0266`

**Classification:** composes — the diff touches no runtime primitives (classifier: 0 matched paths). All four changed files are CI tooling: `.github/workflows/validate.yml`, `tools/ci/preview-resources.ts`, `tools/ci/resource-utils.ts`, and its unit test. No worker code, storage schema, or user-facing surface changes.

### Primitives touched

None. Unmatched CI-infrastructure paths only: preview resource provisioning/cleanup scripts and the Validate workflow's E2E step.

### Change flow

```mermaid
flowchart LR
	prClosed["PR closed event"]:::untouched
	cleanup["preview-resources.ts cleanup"]:::extended
	workers["Cloudflare Workers (preview)"]:::untouched
	queues["Cloudflare Queues (preview)"]:::untouched
	cleanup -->|"1. delete Worker scripts first"| workers
	cleanup -->|"2. delete queues, retrying the binding-release 400"| queues
	prClosed --> cleanup
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d405b04e-9a74-4998-ae4f-4bdc06fbbfa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d405b04e-9a74-4998-ae4f-4bdc06fbbfa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview environment cleanup to remove Workers before queues, avoiding deletion conflicts.
  * Queue cleanup now retries temporary binding conflicts with progressive delays and fails clearly after repeated unsuccessful attempts.
  * End-to-end tests retry once when the local web server crashes, while other failures remain immediate.

* **Tests**
  * Added coverage for queue deletion retries, delays, and final failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->