### PR TITLE
fix(ci): deregister queue consumers before deleting preview Workers

### DIFF
--- a/tools/ci/preview-resources.ts
+++ b/tools/ci/preview-resources.ts
@@ -11,6 +11,7 @@ import {
 	listD1Databases,
 	listCloudflareQueues,
 	listKvNamespaces,
+	removeCloudflareQueueConsumers,
 	runWrangler,
 	truncateWithSuffix,
 	writeGeneratedWranglerConfig,
@@ -438,9 +439,18 @@ async function cleanupPreviewResources(options: CliOptions) {
 		apiToken: apiToken ?? 'dry-run-token',
 		dryRun: options.dryRun,
 	}
-	// Workers must go first: Cloudflare refuses to delete a queue that is
-	// still referenced by a Worker binding (400 "Cannot delete queue ...
-	// still referenced by a binding in a Worker").
+	// Order matters, both directions: a Worker cannot be deleted while it is
+	// registered as a queue consumer (code 10064), and a queue cannot be
+	// deleted while a Worker still binds it as a producer (400 "still
+	// referenced by a binding in a Worker"). So: consumers → Workers → queues.
+	await removeCloudflareQueueConsumers({
+		...queueClient,
+		name: webhookDispatchQueueName,
+	})
+	await removeCloudflareQueueConsumers({
+		...queueClient,
+		name: webhookDispatchDeadLetterQueueName,
+	})
 	deletePreviewWorkers(options.workerName, options.dryRun)
 	await deleteCloudflareQueue({
 		...queueClient,

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -16,6 +16,7 @@ import {
 	isRetryableCloudflareApiError,
 	isWranglerNotFoundOutput,
 	parseJsonc,
+	removeCloudflareQueueConsumers,
 	writeGeneratedWranglerConfig,
 } from './resource-utils.ts'
 
@@ -583,6 +584,95 @@ test('deleteCloudflareQueue removes an existing queue by id', async () => {
 		'https://api.cloudflare.com/client/v4/accounts/account-1/queues/queue-preview',
 		expect.objectContaining({ method: 'DELETE' }),
 	)
+})
+
+test('removeCloudflareQueueConsumers deregisters each consumer by id', async () => {
+	consoleError.mockImplementation(() => {})
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{
+						queue_id: 'queue-preview',
+						queue_name: 'kody-pr-123-webhook-dispatch',
+					},
+				],
+				result_info: { total_pages: 1 },
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{ consumer_id: 'consumer-1', script: 'kody-pr-123', type: 'worker' },
+				],
+			}),
+		)
+		.mockResolvedValueOnce(Response.json({ success: true, result: null }))
+
+	await removeCloudflareQueueConsumers({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		name: 'kody-pr-123-webhook-dispatch',
+		dryRun: false,
+		fetcher,
+	})
+
+	expect(fetcher).toHaveBeenNthCalledWith(
+		2,
+		'https://api.cloudflare.com/client/v4/accounts/account-1/queues/queue-preview/consumers',
+		expect.objectContaining({ method: 'GET' }),
+	)
+	expect(fetcher).toHaveBeenNthCalledWith(
+		3,
+		'https://api.cloudflare.com/client/v4/accounts/account-1/queues/queue-preview/consumers/consumer-1',
+		expect.objectContaining({ method: 'DELETE' }),
+	)
+})
+
+test('removeCloudflareQueueConsumers is a no-op for a missing queue or empty consumer list', async () => {
+	consoleError.mockImplementation(() => {})
+	const missingQueueFetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(
+		Response.json({
+			success: true,
+			result: [],
+			result_info: { total_pages: 1 },
+		}),
+	)
+	await removeCloudflareQueueConsumers({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		name: 'kody-pr-123-webhook-dispatch',
+		dryRun: false,
+		fetcher: missingQueueFetcher,
+	})
+	expect(missingQueueFetcher).toHaveBeenCalledTimes(1)
+
+	const emptyConsumersFetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{
+						queue_id: 'queue-preview',
+						queue_name: 'kody-pr-123-webhook-dispatch',
+					},
+				],
+				result_info: { total_pages: 1 },
+			}),
+		)
+		.mockResolvedValueOnce(Response.json({ success: true, result: [] }))
+	await removeCloudflareQueueConsumers({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		name: 'kody-pr-123-webhook-dispatch',
+		dryRun: false,
+		fetcher: emptyConsumersFetcher,
+	})
+	expect(emptyConsumersFetcher).toHaveBeenCalledTimes(2)
 })
 
 const queueStillReferencedResponse = () =>

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -458,6 +458,59 @@ export async function ensureCloudflareQueue(input: {
 	}
 }
 
+type CloudflareQueueConsumer = {
+	consumer_id: string
+	script?: string
+}
+
+/**
+ * Deregister every consumer of a queue. Cloudflare refuses to delete a
+ * Worker while it is registered as a queue consumer (code 10064), so
+ * preview cleanup must remove the consumers before the Worker scripts.
+ */
+export async function removeCloudflareQueueConsumers(input: {
+	accountId: string
+	apiToken: string
+	name: string
+	dryRun: boolean
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+}) {
+	if (input.dryRun) {
+		console.error(`[dry-run] remove Queue consumers: ${input.name}`)
+		return
+	}
+	const queue = (await listCloudflareQueues(input)).find(
+		(candidate) => candidate.queue_name === input.name,
+	)
+	if (!queue) {
+		console.error(
+			`Queue already deleted (no consumers to remove): ${input.name}`,
+		)
+		return
+	}
+	const payload = await cloudflareApiRequest<Array<CloudflareQueueConsumer>>({
+		...input,
+		pathname: `/queues/${queue.queue_id}/consumers`,
+	})
+	const consumers = payload.result ?? []
+	if (consumers.length === 0) {
+		console.error(`Queue has no consumers: ${input.name}`)
+		return
+	}
+	for (const consumer of consumers) {
+		await cloudflareApiRequest({
+			...input,
+			pathname: `/queues/${queue.queue_id}/consumers/${consumer.consumer_id}`,
+			method: 'DELETE',
+		})
+		console.error(
+			`Removed Queue consumer: ${input.name} <- ${consumer.script ?? consumer.consumer_id}`,
+		)
+	}
+}
+
 /**
  * Cloudflare returns this 400 while a Worker still binds the queue. Deleting
  * the Worker first is required, but the binding release propagates


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#1335 reordered preview cleanup to delete Workers before queues, which fixed the "Cannot delete queue ... still referenced by a binding in a Worker" 400. Its own PR-close cleanup run then surfaced the other half of the constraint ([run 31295739946](https://github.com/kentcdodds/kody/actions/runs/31295739946)):

```
Cannot delete this Worker as it is a consumer for a Queue.
Remove it from the Queue's consumers first, then retry. [code: 10064]
```

The dependency is circular at the resource level: the Worker cannot be deleted while registered as a queue **consumer**, and the queue cannot be deleted while the Worker still binds it as a **producer**. The only valid sequence is consumers → Workers → queues.

## What

- `tools/ci/resource-utils.ts`: new `removeCloudflareQueueConsumers` — finds the queue, lists its consumers (`GET /queues/{queue_id}/consumers`), and deregisters each (`DELETE /queues/{queue_id}/consumers/{consumer_id}`). No-op when the queue is already gone or has no consumers. The API shape (`consumer_id`, `script`) was verified against the live orphaned `kody-pr-1335` queues.
- `tools/ci/preview-resources.ts`: cleanup now runs consumer removal for both webhook-dispatch queues before `deletePreviewWorkers`, then deletes the queues (keeping the binding-release retry from #1335 as defense).
- Unit tests cover the deregistration call sequence and both no-op paths.

## Validation

- `npx vitest run tools/ci --project node-unit`: 29 passed
- `npm run format:check` (after `format`), `npm run lint`, `npm run typecheck`: green
- `cleanup --dry-run` order: remove consumers → delete Workers → delete queues → R2/KV/D1
- After merge, this will be exercised for real by dispatching cleanup for the ~13 orphaned preview stacks (`kody-pr-998`… `kody-pr-1335`)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk, CI-only)</summary>

**Mode:** recap · **Base:** `main` @ `6a269c86` · **Head:** `5d4a8cf7`

**Classification:** composes — no runtime primitives touched (classifier: 0 matched paths). Changes are confined to CI preview-resource tooling (`tools/ci/`) and its tests.

### Primitives touched

None. CI-infrastructure paths only.

### Change flow

```mermaid
flowchart LR
	prClosed["PR closed event"]:::untouched
	cleanup["preview-resources.ts cleanup"]:::extended
	consumers["Queue consumer registrations"]:::untouched
	workers["Cloudflare Workers (preview)"]:::untouched
	queues["Cloudflare Queues (preview)"]:::untouched
	prClosed --> cleanup
	cleanup -->|"1. DELETE /queues/:id/consumers/:cid"| consumers
	cleanup -->|"2. wrangler delete (now unblocked)"| workers
	cleanup -->|"3. DELETE /queues/:id with binding-release retry"| queues
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d405b04e-9a74-4998-ae4f-4bdc06fbbfa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d405b04e-9a74-4998-ae4f-4bdc06fbbfa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview environment cleanup by removing queue consumers before deleting Workers and queues.
  * Prevented cleanup failures caused by queues that still have active consumers.
* **Tests**
  * Added coverage for consumer removal, missing queues, empty consumer lists, and dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->