### PR TITLE
Add inline follow/unfollow next to profile usernames

### DIFF
--- a/packages/worker/client/routes/profile.tsx
+++ b/packages/worker/client/routes/profile.tsx
@@ -10,7 +10,6 @@ import {
 	listenToRouterNavigation,
 	readCurrentRouterHref,
 } from '#client/client-router.tsx'
-import { on } from '#client/event-mixin.ts'
 import { prefetchFrame } from '#client/frame-prefetch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
@@ -23,7 +22,6 @@ import {
 	fieldCss,
 	fieldLabelCss,
 	getPrimaryButtonCss,
-	getSecondaryButtonCss,
 	inputCss,
 	layoutMaxWidths,
 	mutedLinkCss,
@@ -105,8 +103,6 @@ export async function profileRouteLoader(
 export function ProfileRoute(handle: Handle) {
 	let shell: ProfileShellLoaderData | ProfileUnavailableLoaderData | null = null
 	let shellStatus: 'loading' | 'ready' | 'error' = 'loading'
-	let followState: 'idle' | 'submitting' | 'error' = 'idle'
-	let followMessage: string | null = null
 	let shellLoadedForUsername: string | null = null
 	let shellRequestedForUsername: string | null = null
 	let shellLoadRequestId = 0
@@ -153,8 +149,6 @@ export function ProfileRoute(handle: Handle) {
 				isFollowing: payload.isFollowing,
 				visibility: payload.profile.visibility,
 			}
-			followState = 'idle'
-			followMessage = null
 			shellLoadedForUsername = username
 			shellStatus = 'ready'
 			handle.update()
@@ -162,48 +156,6 @@ export function ProfileRoute(handle: Handle) {
 			if (requestId !== shellLoadRequestId) return
 			shellLoadedForUsername = username
 			shellStatus = 'error'
-			handle.update()
-		}
-	}
-
-	async function submitFollow(nextFollow: boolean) {
-		if (!shell || !shell.ok || followState === 'submitting') return
-		followState = 'submitting'
-		followMessage = null
-		handle.update()
-
-		try {
-			const response = await fetch(
-				routes.profileFollowApiPost.href({ username: shell.username }),
-				{
-					method: 'POST',
-					headers: {
-						Accept: 'application/json',
-						'Content-Type': 'application/json',
-					},
-					credentials: 'include',
-					body: JSON.stringify({ follow: nextFollow }),
-				},
-			)
-			if (response.status === 401) {
-				window.location.assign('/login')
-				return
-			}
-			const payload = await readJson<{ ok: boolean; error?: string }>(response)
-			if (!response.ok || !payload?.ok) {
-				throw new Error(payload?.error ?? 'Unable to update follow status.')
-			}
-			shell = { ...shell, isFollowing: nextFollow }
-			followState = 'idle'
-			handle.update()
-			const frame = handle.frames.get(PROFILE_TARGET)
-			if (frame) void frame.reload()
-		} catch (error) {
-			followState = 'error'
-			followMessage =
-				error instanceof Error
-					? error.message
-					: 'Unable to update follow status.'
 			handle.update()
 		}
 	}
@@ -221,9 +173,6 @@ export function ProfileRoute(handle: Handle) {
 		}
 		void frame.reload()
 	})
-
-	const primaryButtonCss = getPrimaryButtonCss()
-	const secondaryButtonCss = getSecondaryButtonCss()
 
 	return () => {
 		const username = getCurrentUsername(handle)
@@ -280,45 +229,13 @@ export function ProfileRoute(handle: Handle) {
 
 		return (
 			<section mix={css(pageCss)}>
-				{readyShell ? (
+				{readyShell?.isSelf ? (
 					<div mix={css(actionsCss)} data-testid="profile-actions">
-						{readyShell.isSelf ? (
-							<>
-								<a href={routes.account.href()} mix={css(mutedLinkCss)}>
-									Edit profile
-								</a>
-								{readyShell.visibility === 'private' ? (
-									<span mix={css(badgeCss)}>Private</span>
-								) : null}
-							</>
-						) : readyShell.loggedIn ? (
-							<button
-								type="button"
-								disabled={followState === 'submitting'}
-								mix={[
-									on('click', () => void submitFollow(!readyShell.isFollowing)),
-									css(
-										readyShell.isFollowing
-											? secondaryButtonCss
-											: primaryButtonCss,
-									),
-								]}
-							>
-								{followState === 'submitting'
-									? 'Saving…'
-									: readyShell.isFollowing
-										? 'Unfollow'
-										: 'Follow'}
-							</button>
-						) : (
-							<a href="/login" mix={css(mutedLinkCss)}>
-								Log in to follow
-							</a>
-						)}
-						{followMessage ? (
-							<p mix={css({ color: colors.danger, margin: 0 })} role="status">
-								{followMessage}
-							</p>
+						<a href={routes.account.href()} mix={css(mutedLinkCss)}>
+							Edit profile
+						</a>
+						{readyShell.visibility === 'private' ? (
+							<span mix={css(badgeCss)}>Private</span>
 						) : null}
 					</div>
 				) : null}

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -16,6 +16,7 @@ import {
 	communityTagListCss,
 	communityTagPillCss,
 } from '#app/community-listings-content.tsx'
+import { renderProfileFollowControl } from '#app/profile-follow-control.tsx'
 import { routes } from '#universal/routes.ts'
 import { visuallyHiddenCss } from '#universal/styles/style-primitives.ts'
 import { colors } from '#universal/styles/tokens.ts'
@@ -106,7 +107,7 @@ export function CommunityDetailContent(
 						</span>
 					) : null}
 					<p mix={css(ownerLineCss)}>
-						<span>
+						<span mix={css(ownerUsernameCss)}>
 							by{' '}
 							{ownerProfilePublic ? (
 								<a
@@ -148,12 +149,14 @@ export function CommunityDetailContent(
 							)}
 						</span>
 						{ownerProfilePublic && !viewerIsOwner
-							? renderOwnerFollowControl({
+							? renderProfileFollowControl({
 									username: listing.ownerUsername,
 									loggedIn,
-									viewerFollowsOwner,
+									isFollowing: viewerFollowsOwner,
 									returnTo,
 									followError,
+									testId: 'community-detail-owner-follow',
+									errorTestId: 'community-detail-owner-follow-error',
 								})
 							: null}
 					</p>
@@ -220,105 +223,6 @@ export function CommunityDetailContent(
 	)
 }
 
-function renderOwnerFollowControl(input: {
-	username: string
-	loggedIn: boolean
-	viewerFollowsOwner: boolean
-	returnTo: string
-	followError: string | null
-}) {
-	if (!input.loggedIn) {
-		const loginHref = `${routes.login.href()}?redirectTo=${encodeURIComponent(input.returnTo)}`
-		return (
-			<a
-				href={loginHref}
-				title="Follow"
-				data-testid="community-detail-owner-follow"
-				mix={css(ownerFollowButtonCss)}
-			>
-				{renderFollowGlyph(false)}
-				<span mix={css(visuallyHiddenCss)}>Follow @{input.username}</span>
-			</a>
-		)
-	}
-
-	return (
-		<span mix={css(ownerFollowControlCss)}>
-			<form
-				method="post"
-				action={routes.profileFollowApiPost.href({ username: input.username })}
-				mix={css(ownerFollowFormCss)}
-			>
-				<input
-					type="hidden"
-					name="follow"
-					value={String(!input.viewerFollowsOwner)}
-				/>
-				<input type="hidden" name="returnTo" value={input.returnTo} />
-				<button
-					type="submit"
-					title={input.viewerFollowsOwner ? 'Unfollow' : 'Follow'}
-					data-testid="community-detail-owner-follow"
-					data-following={input.viewerFollowsOwner ? 'true' : 'false'}
-					mix={css(ownerFollowButtonCss)}
-				>
-					{renderFollowGlyph(input.viewerFollowsOwner)}
-					<span mix={css(visuallyHiddenCss)}>
-						{input.viewerFollowsOwner
-							? `Unfollow @${input.username}`
-							: `Follow @${input.username}`}
-					</span>
-				</button>
-			</form>
-			{input.followError ? (
-				<span
-					role="alert"
-					data-testid="community-detail-owner-follow-error"
-					mix={css(ownerFollowErrorCss)}
-				>
-					{input.followError}
-				</span>
-			) : null}
-		</span>
-	)
-}
-
-function renderFollowGlyph(following: boolean) {
-	return following ? (
-		<svg
-			viewBox="0 0 16 16"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			focusable={false}
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		>
-			<circle cx="8" cy="8" r="5.4" />
-			<path d="M5.3 8.1 7.1 9.9 10.8 6.1" />
-		</svg>
-	) : (
-		<svg
-			viewBox="0 0 16 16"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			focusable={false}
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		>
-			<circle cx="8" cy="8" r="5.4" />
-			<path d="M8 5.2v5.6M5.2 8h5.6" />
-		</svg>
-	)
-}
-
 export async function renderCommunityDetailContentHtml(
 	props: CommunityDetailContentProps,
 ) {
@@ -371,12 +275,20 @@ const detailBadgeGroupCss = {
 }
 
 const ownerLineCss = {
-	display: 'flex',
+	display: 'inline-flex',
 	alignItems: 'center',
+	flexWrap: 'nowrap' as const,
 	gap: '0.45rem',
 	margin: 0,
 	color: colors.textMuted,
 	fontSize: '0.95rem',
+}
+
+const ownerUsernameCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	flexWrap: 'nowrap' as const,
+	minWidth: 0,
 }
 
 const ownerLinkCss = {
@@ -395,42 +307,7 @@ const ownerPrivateLockCss = {
 	color: colors.textMuted,
 	verticalAlign: 'middle',
 	cursor: 'help',
-}
-
-const ownerFollowControlCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	gap: '0.45rem',
-	minWidth: 0,
-}
-
-const ownerFollowFormCss = {
-	display: 'inline-flex',
-	margin: 0,
-}
-
-const ownerFollowErrorCss = {
-	color: colors.danger,
-	fontSize: '0.85rem',
-}
-
-const ownerFollowButtonCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	justifyContent: 'center',
-	width: '1.55rem',
-	height: '1.55rem',
-	padding: 0,
-	border: `1px solid ${colors.border}`,
-	borderRadius: '999px',
-	backgroundColor: 'transparent',
-	color: colors.textMuted,
-	textDecoration: 'none',
-	cursor: 'pointer',
-	'&:hover': {
-		color: colors.primaryText,
-		borderColor: colors.primaryText,
-	},
+	flexShrink: 0,
 }
 
 const badgeCss = {

--- a/packages/worker/src/app/frames/profile.ts
+++ b/packages/worker/src/app/frames/profile.ts
@@ -24,6 +24,10 @@ registerFrame(PROFILE_TARGET, {
 			activity: data.activity,
 			query: data.query,
 			isSelf: data.isSelf,
+			loggedIn: data.loggedIn,
+			isFollowing: data.isFollowing,
+			returnTo: routes.profile.href({ username }),
+			followError: new URL(request.url).searchParams.get('followError'),
 		})
 	},
 })

--- a/packages/worker/src/app/profile-content.node.test.ts
+++ b/packages/worker/src/app/profile-content.node.test.ts
@@ -43,6 +43,10 @@ test('profile packages link the listing name and fork via a single icon control'
 		activity: [],
 		query: null,
 		isSelf: false,
+		loggedIn: false,
+		isFollowing: false,
+		returnTo: '/@kody',
+		followError: null,
 	})
 
 	expect(html).toContain('href="/community/listing-1"')
@@ -52,4 +56,50 @@ test('profile packages link the listing name and fork via a single icon control'
 	expect(html.match(/aria-label="fork"/g)).toHaveLength(1)
 	expect(html).toContain('notes')
 	expect(html).not.toContain('href="/community/notes')
+	expect(html).toContain('data-testid="profile-follow"')
+	expect(html).toContain('title="Follow"')
+	expect(html).toContain('/login?redirectTo=%2F%40kody')
+})
+
+test('profile follow control sits next to username for signed-in viewers', async () => {
+	const html = await renderProfileContentHtml({
+		profile,
+		packages: [],
+		activity: [],
+		query: null,
+		isSelf: false,
+		loggedIn: true,
+		isFollowing: true,
+		returnTo: '/@kody',
+		followError: 'Unable to follow.',
+	})
+
+	expect(html).toContain('data-testid="profile-username"')
+	expect(html).toContain('data-testid="profile-follow"')
+	expect(html).toContain('data-following="true"')
+	expect(html).toContain('title="Unfollow"')
+	expect(html).toContain('/profiles/kody/follow.json')
+	expect(html).toContain('name="returnTo"')
+	expect(html).toContain('data-testid="profile-follow-error"')
+	expect(html).toContain('Unable to follow.')
+	expect(html.indexOf('data-testid="profile-follow"')).toBeGreaterThan(
+		html.indexOf('data-testid="profile-username"'),
+	)
+})
+
+test('own profile omits the follow control', async () => {
+	const html = await renderProfileContentHtml({
+		profile,
+		packages: [],
+		activity: [],
+		query: null,
+		isSelf: true,
+		loggedIn: true,
+		isFollowing: false,
+		returnTo: '/@kody',
+		followError: null,
+	})
+
+	expect(html).toContain('@kody')
+	expect(html).not.toContain('data-testid="profile-follow"')
 })

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -15,6 +15,7 @@ import {
 } from '#universal/community-public-types.ts'
 import { routes } from '#universal/routes.ts'
 import { UserAvatar } from '#universal/user-avatar.tsx'
+import { renderProfileFollowControl } from '#app/profile-follow-control.tsx'
 import {
 	colors,
 	radius,
@@ -38,6 +39,10 @@ export type ProfileContentProps = {
 	activity: Array<PublicCommunityActivityItem>
 	query: string | null
 	isSelf: boolean
+	loggedIn: boolean
+	isFollowing: boolean
+	returnTo: string
+	followError: string | null
 }
 
 function renderForkIcon() {
@@ -64,7 +69,17 @@ function renderForkIcon() {
 }
 
 export function ProfileContent(handle: Handle<ProfileContentProps>) {
-	const { profile, packages, activity, query, isSelf } = handle.props
+	const {
+		profile,
+		packages,
+		activity,
+		query,
+		isSelf,
+		loggedIn,
+		isFollowing,
+		returnTo,
+		followError,
+	} = handle.props
 
 	return () => (
 		<div data-testid="profile-frame">
@@ -80,8 +95,19 @@ export function ProfileContent(handle: Handle<ProfileContentProps>) {
 						<h1 mix={css(pageTitleCss)} data-testid="profile-display-name">
 							{profile.displayName}
 						</h1>
-						<p mix={css(pageDescriptionCss)} data-testid="profile-username">
-							@{profile.username}
+						<p mix={css(profileUsernameLineCss)} data-testid="profile-username">
+							<span>@{profile.username}</span>
+							{!isSelf
+								? renderProfileFollowControl({
+										username: profile.username,
+										loggedIn,
+										isFollowing,
+										returnTo,
+										followError,
+										testId: 'profile-follow',
+										errorTestId: 'profile-follow-error',
+									})
+								: null}
 						</p>
 					</div>
 				</div>
@@ -238,6 +264,14 @@ const profileHeadingCss = {
 	display: 'flex',
 	alignItems: 'center',
 	gap: spacing.md,
+}
+
+const profileUsernameLineCss = {
+	...pageDescriptionCss,
+	display: 'inline-flex',
+	alignItems: 'center',
+	flexWrap: 'nowrap' as const,
+	gap: '0.45rem',
 }
 
 const activityActorCss = {

--- a/packages/worker/src/app/profile-follow-control.tsx
+++ b/packages/worker/src/app/profile-follow-control.tsx
@@ -1,0 +1,146 @@
+/** @jsxImportSource remix/ui */
+/** @jsxRuntime automatic */
+import { css } from 'remix/ui'
+import { routes } from '#universal/routes.ts'
+import { visuallyHiddenCss } from '#universal/styles/style-primitives.ts'
+import { colors } from '#universal/styles/tokens.ts'
+
+/**
+ * Compact follow / unfollow control used next to usernames on community
+ * detail and profile frames. Logged-out viewers get a login link; signed-in
+ * viewers get a form POST to the shared profile follow API.
+ */
+export function renderProfileFollowControl(input: {
+	username: string
+	loggedIn: boolean
+	isFollowing: boolean
+	returnTo: string
+	followError: string | null
+	testId: string
+	errorTestId: string
+}) {
+	if (!input.loggedIn) {
+		const loginHref = `${routes.login.href()}?redirectTo=${encodeURIComponent(input.returnTo)}`
+		return (
+			<a
+				href={loginHref}
+				title="Follow"
+				data-testid={input.testId}
+				mix={css(followButtonCss)}
+			>
+				{renderFollowGlyph(false)}
+				<span mix={css(visuallyHiddenCss)}>Follow @{input.username}</span>
+			</a>
+		)
+	}
+
+	return (
+		<span mix={css(followControlCss)}>
+			<form
+				method="post"
+				action={routes.profileFollowApiPost.href({ username: input.username })}
+				mix={css(followFormCss)}
+			>
+				<input type="hidden" name="follow" value={String(!input.isFollowing)} />
+				<input type="hidden" name="returnTo" value={input.returnTo} />
+				<button
+					type="submit"
+					title={input.isFollowing ? 'Unfollow' : 'Follow'}
+					data-testid={input.testId}
+					data-following={input.isFollowing ? 'true' : 'false'}
+					mix={css(followButtonCss)}
+				>
+					{renderFollowGlyph(input.isFollowing)}
+					<span mix={css(visuallyHiddenCss)}>
+						{input.isFollowing
+							? `Unfollow @${input.username}`
+							: `Follow @${input.username}`}
+					</span>
+				</button>
+			</form>
+			{input.followError ? (
+				<span
+					role="alert"
+					data-testid={input.errorTestId}
+					mix={css(followErrorCss)}
+				>
+					{input.followError}
+				</span>
+			) : null}
+		</span>
+	)
+}
+
+function renderFollowGlyph(following: boolean) {
+	return following ? (
+		<svg
+			viewBox="0 0 16 16"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			focusable={false}
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<circle cx="8" cy="8" r="5.4" />
+			<path d="M5.3 8.1 7.1 9.9 10.8 6.1" />
+		</svg>
+	) : (
+		<svg
+			viewBox="0 0 16 16"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			focusable={false}
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<circle cx="8" cy="8" r="5.4" />
+			<path d="M8 5.2v5.6M5.2 8h5.6" />
+		</svg>
+	)
+}
+
+const followControlCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.45rem',
+	flexShrink: 0,
+	minWidth: 0,
+}
+
+const followFormCss = {
+	display: 'inline-flex',
+	margin: 0,
+}
+
+const followErrorCss = {
+	color: colors.danger,
+	fontSize: '0.85rem',
+}
+
+const followButtonCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	width: '1.55rem',
+	height: '1.55rem',
+	padding: 0,
+	border: `1px solid ${colors.border}`,
+	borderRadius: '999px',
+	backgroundColor: 'transparent',
+	color: colors.textMuted,
+	textDecoration: 'none',
+	cursor: 'pointer',
+	flexShrink: 0,
+	'&:hover': {
+		color: colors.primaryText,
+		borderColor: colors.primaryText,
+	},
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Shared the compact follow/unfollow glyph control used on community package detail and placed it next to `@username` on profile pages.
- Kept username + follow (and private-lock) icons on one inline row so the control sits beside the name rather than wrapping underneath.
- Removed the separate profile-shell Follow/Unfollow text button; profile pages now use the same icon control as community detail (login link when signed out).

## Test plan

- [x] Unit tests for profile frame follow control (signed out, following, own profile omitted)
- [x] Existing community detail frame follow tests still pass
- [x] Full unit suite + e2e via push hooks

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f84f38d6` · **Head:** `5cf19c40`

**Classification:** composes — reuses the existing profile follow API and social graph; this PR only wires the control into profile UI and shares layout with community detail.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — shared follow glyph next to `@username` on profile + community detail frames |

### System map

Profile and community detail frames both render the shared follow control against the existing follow POST endpoint.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	communitySocial["community-social<br/>Community profiles and social graph"]:::untouched
	appUi -->|"POST /profiles/:username/follow.json"| communitySocial
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| Community detail | Follow glyph next to `by @user` | Same control, shared module; inline-flex nowrap |
| Profile `/@user` | Text Follow/Unfollow in shell actions | Same glyph next to `@username` in the profile frame |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87b86af0-268c-44bd-b09a-13f4bbb47faa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87b86af0-268c-44bd-b09a-13f4bbb47faa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added follow and unfollow controls to profile views.
  * Logged-out visitors can sign in while preserving their return destination.
  * Follow controls display current state, accessible labels, and error messages.
  * Profile owners no longer see follow controls; private-profile indicators remain visible.
* **Bug Fixes**
  * Standardized follow controls across profile and community detail views.
* **Tests**
  * Added coverage for logged-out, signed-in, following, error, and owner scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->