### PR TITLE
fix(mcp): keep package_save overwrite confirmation off Sentry

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -16,6 +16,8 @@ import {
 	assertPackagePrivateVisibilityChangeAllowed,
 	defaultPackagePrivateGuidance,
 	destructiveOverwriteConfirmationDescription,
+	isDestructiveOverwriteConfirmationMessage,
+	isPrivateVisibilityChangeConfirmationMessage,
 	loadPriorPackageManifestContent,
 	privateVisibilityChangeConfirmationDescription,
 	productionPackageSourceSafetyPolicy,
@@ -240,24 +242,43 @@ export const savePackageCapability = defineDomainCapability(
 									? canonicalExistingSource
 									: ensuredSource,
 						})
-			assertPackagePrivateVisibilityChangeAllowed({
-				beforeContent: priorManifestContent,
-				afterContent: packageJsonContent,
-				isNewPackage: existing == null,
-				operation: 'package_save',
-				confirmed: args.confirm_private_visibility_change,
-			})
-			if (existing) {
-				await assertPackageSourceOverwriteAllowed({
-					env: ctx.env,
-					userId: owner.ownerUserId,
-					source:
-						canonicalExistingSource?.id === ensuredSource.id
-							? canonicalExistingSource
-							: ensuredSource,
+			try {
+				assertPackagePrivateVisibilityChangeAllowed({
+					beforeContent: priorManifestContent,
+					afterContent: packageJsonContent,
+					isNewPackage: existing == null,
 					operation: 'package_save',
-					confirmed: args.confirm_destructive_overwrite,
+					confirmed: args.confirm_private_visibility_change,
 				})
+			} catch (error) {
+				const message = getErrorMessage(error)
+				if (isPrivateVisibilityChangeConfirmationMessage(message)) {
+					throw new McpCallerError(message, { cause: error })
+				}
+				throw error
+			}
+			if (existing) {
+				try {
+					await assertPackageSourceOverwriteAllowed({
+						env: ctx.env,
+						userId: owner.ownerUserId,
+						source:
+							canonicalExistingSource?.id === ensuredSource.id
+								? canonicalExistingSource
+								: ensuredSource,
+						operation: 'package_save',
+						confirmed: args.confirm_destructive_overwrite,
+					})
+				} catch (error) {
+					const message = getErrorMessage(error)
+					// Shared policy helpers throw plain Errors; reclassify the
+					// confirmation gate so agents see McpCallerError and Sentry
+					// does not open platform-bug issues (KODY issue 7661329778).
+					if (isDestructiveOverwriteConfirmationMessage(message)) {
+						throw new McpCallerError(message, { cause: error })
+					}
+					throw error
+				}
 			}
 			await syncArtifactSourceSnapshot({
 				env: ctx.env,

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -276,6 +276,22 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			),
 		})
 
+		// package_save destructive overwrite confirmation (issue 7661329778).
+		// Plain Error from shared source-safety-policy helpers.
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'package_save',
+			domain: 'packages',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage:
+				'package_save would overwrite existing package source "aa2d1349-5ac2-4b32-8c53-df1ce0a60b37". Set confirm_destructive_overwrite: true only after the user explicitly approves destructive overwrite; Kody will also verify a restorable backup snapshot first.',
+			cause: new Error(
+				'package_save would overwrite existing package source "aa2d1349-5ac2-4b32-8c53-df1ce0a60b37". Set confirm_destructive_overwrite: true only after the user explicitly approves destructive overwrite; Kody will also verify a restorable backup snapshot first.',
+			),
+		})
+
 		// Downstream user-connected MCP server tool failure (KODY-CLOUDFLARE-4B).
 		logMcpEvent({
 			...callerFailureBase,
@@ -292,7 +308,7 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 		})
 	})
 
-	expect(payloads).toHaveLength(16)
+	expect(payloads).toHaveLength(17)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -9,6 +9,10 @@ import {
 	isRepoSearchInvalidRegexMessage,
 	isRepoSessionInactiveMessage,
 } from '#worker/repo/repo-session-caller-error.ts'
+import {
+	isDestructiveOverwriteConfirmationMessage,
+	isPrivateVisibilityChangeConfirmationMessage,
+} from '#worker/repo/source-safety-policy.ts'
 import { isUserStorageSqlCallerMessage } from '#worker/storage-sql-caller-error.ts'
 import { isUserCodeError } from '#worker/user-code-error.ts'
 import { isMcpCallerError } from './caller-error.ts'
@@ -154,6 +158,20 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 				entry instanceof Error &&
 				(isRepoSessionInactiveMessage(entry.message) ||
 					isRepoSearchInvalidRegexMessage(entry.message)),
+		)
+	) {
+		return true
+	}
+	// Package source safety confirmation gates (confirm_destructive_overwrite /
+	// confirm_private_visibility_change) throw plain Errors from shared policy
+	// helpers used by MCP capabilities and Durable Object paths. Agents re-call
+	// with the flag after explicit user approval — keep them off Sentry.
+	if (
+		getErrorCauseChain(cause).some(
+			(entry) =>
+				entry instanceof Error &&
+				(isDestructiveOverwriteConfirmationMessage(entry.message) ||
+					isPrivateVisibilityChangeConfirmationMessage(entry.message)),
 		)
 	) {
 		return true

--- a/packages/worker/src/repo/source-safety-policy.node.test.ts
+++ b/packages/worker/src/repo/source-safety-policy.node.test.ts
@@ -1,11 +1,15 @@
 import { expect, test } from 'vitest'
 import {
+	assertPackagePrivateVisibilityChangeAllowed,
 	assertPackageSourceOverwriteAllowed,
 	assertRestorablePackageSourceSnapshot,
 	buildPublishedCommitHeadMismatchCallerMessage,
 	buildSourceRecoveryProblemMessage,
 	destructiveOverwriteConfirmationField,
+	isDestructiveOverwriteConfirmationMessage,
+	isPrivateVisibilityChangeConfirmationMessage,
 	isPublishedCommitHeadMismatchMessage,
+	privateVisibilityChangeConfirmationField,
 } from './source-safety-policy.ts'
 import { type EntitySourceRow } from './types.ts'
 
@@ -96,6 +100,47 @@ test('package source overwrite requires explicit destructive confirmation before
 			operation: 'package_save',
 		}),
 	).rejects.toThrow(destructiveOverwriteConfirmationField)
+})
+
+test('destructive overwrite confirmation messages are detected for caller-error classification', async () => {
+	let message = ''
+	try {
+		await assertPackageSourceOverwriteAllowed({
+			env: createEnvWithSnapshot({ 'package.json': '{}' }),
+			userId: 'user-1',
+			source: packageSource(),
+			operation: 'package_save',
+		})
+	} catch (error) {
+		message = error instanceof Error ? error.message : String(error)
+	}
+	expect(isDestructiveOverwriteConfirmationMessage(message)).toBe(true)
+	expect(
+		isDestructiveOverwriteConfirmationMessage(
+			'package_save stopped by the production package source safety policy.',
+		),
+	).toBe(false)
+})
+
+test('private visibility confirmation messages are detected for caller-error classification', () => {
+	let message = ''
+	try {
+		assertPackagePrivateVisibilityChangeAllowed({
+			beforeContent: '{"name":"@x/y","private":true}',
+			afterContent: '{"name":"@x/y","private":false}',
+			isNewPackage: false,
+			operation: 'package_save',
+		})
+	} catch (error) {
+		message = error instanceof Error ? error.message : String(error)
+	}
+	expect(message).toContain(privateVisibilityChangeConfirmationField)
+	expect(isPrivateVisibilityChangeConfirmationMessage(message)).toBe(true)
+	expect(
+		isPrivateVisibilityChangeConfirmationMessage(
+			'package_save would overwrite existing package source "source-1".',
+		),
+	).toBe(false)
 })
 
 test('restorable package source snapshot verification rejects corrupt snapshots and accepts manifest-bearing backups', async () => {

--- a/packages/worker/src/repo/source-safety-policy.ts
+++ b/packages/worker/src/repo/source-safety-policy.ts
@@ -77,6 +77,21 @@ function buildDestructiveOverwriteConfirmationMessage(input: {
 	].join(' ')
 }
 
+/**
+ * Stable phrase from the package source overwrite confirmation gate. Agents
+ * must re-call with `confirm_destructive_overwrite: true` after explicit user
+ * approval — caller-correctable, not a platform defect. Matched by MCP
+ * observability so plain Errors from shared policy helpers stay off Sentry.
+ */
+export const destructiveOverwriteConfirmationMessagePhrase = `Set ${destructiveOverwriteConfirmationField}: true only after the user explicitly approves destructive overwrite`
+
+export function isDestructiveOverwriteConfirmationMessage(message: string) {
+	return (
+		message.includes('would overwrite existing package source') &&
+		message.includes(destructiveOverwriteConfirmationMessagePhrase)
+	)
+}
+
 export async function assertRestorablePackageSourceSnapshot(input: {
 	env: Env
 	userId: string
@@ -329,6 +344,16 @@ function buildPrivateVisibilityChangeConfirmationMessage(input: {
 		`${input.operation} would change package.json private visibility from ${describePackagePrivateField(beforeValue)} to ${describePackagePrivateField(afterValue)}.`,
 		`Set ${privateVisibilityChangeConfirmationField}: true only after the user explicitly approves the visibility change.`,
 	].join(' ')
+}
+
+/**
+ * Stable phrase from the package.json `"private"` confirmation gate. Same
+ * caller-correctable class as destructive overwrite confirmation.
+ */
+export const privateVisibilityChangeConfirmationMessagePhrase = `Set ${privateVisibilityChangeConfirmationField}: true only after the user explicitly approves`
+
+export function isPrivateVisibilityChangeConfirmationMessage(message: string) {
+	return message.includes(privateVisibilityChangeConfirmationMessagePhrase)
 }
 
 export function assertPackagePrivateVisibilityChangeAllowed(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry issue [7661329778](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7661329778/) fired when an agent called `package_save` on an existing package without `confirm_destructive_overwrite: true`. That gate is intentional caller guidance, not a platform defect — but it was thrown as a plain `Error`, so MCP observability reported it to Sentry.

This PR:

- Exports stable message matchers for destructive-overwrite and private-visibility confirmation gates
- Treats those messages as caller failures in `isCallerFailure` (same pattern as published repo sessions / invalid regex)
- Re-wraps the confirmation gates from `package_save` as `McpCallerError` for clearer agent-facing errors
- Adds unit coverage for the matchers and the observability skip

No siblings share this confirmation-gate root cause (other unresolved issues are unrelated client/OAuth/remote/DR noise).

## Test plan

- [x] `source-safety-policy.node.test.ts` — confirmation message detectors
- [x] `observability.node.test.ts` — plain Error with overwrite message is not sent to Sentry
- [x] Pre-push: full unit + e2e suite green

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `58774f86` · **Head:** `330a5fe1`

**Classification:** composes — wires the existing `isCallerFailure` / `McpCallerError` pattern around package source safety confirmation gates; no new primitives or contracts.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | composes — extend caller-failure classification |
| `saved-packages` | assistant | composes — re-wrap confirmation gates as `McpCallerError` |
| `repo-sessions` | runtime | composes — export stable confirmation message matchers |

### System map

`package_save` confirmation denials stay on `mcp-event` and off Sentry via existing caller-failure plumbing.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	savedPackages -->|"confirm gate throw"| repoSessions
	repoSessions -->|"stable confirmation phrases"| mcpServer
	mcpServer -->|"isCallerFailure skip"| sentrySkip["Sentry (not reported)"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant PackageSave as package_save
	participant Policy as source-safety-policy
	participant Obs as mcp observability
	participant Sentry
	Agent->>PackageSave: package_save without confirm_destructive_overwrite
	PackageSave->>Policy: assertPackageSourceOverwriteAllowed
	Policy-->>PackageSave: Error (confirmation message)
	PackageSave-->>Obs: McpCallerError (re-wrapped)
	Obs-->>Sentry: skipped (isCallerFailure)
	Obs-->>Agent: mcp-event failure line only
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8796327d-c90b-4249-9462-9086ba8b644e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8796327d-c90b-4249-9462-9086ba8b644e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package save error handling for private visibility changes and destructive overwrites.
  * These confirmation-related failures are now clearly reported as caller-correctable errors.
  * Prevented expected policy confirmation failures from being incorrectly sent to error monitoring.

* **Tests**
  * Added coverage for destructive overwrite and private visibility confirmation scenarios.
  * Added validation to ensure unrelated errors continue to be handled normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->