### PR TITLE
fix(client): filter Chrome extension receiving-end Sentry noise (KODY-CLOUDFLARE-4F)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -4,6 +4,7 @@ import {
 	filterBrowserInjectedGlobalNoiseSentryEvent,
 	filterBrowserSentryEvent,
 	filterChromeExtensionObjectNotFoundSentryEvent,
+	filterChromeExtensionReceivingEndMissingSentryEvent,
 	filterFathomRemoveChildNullSentryEvent,
 	filterFirefoxDomPermissionDeniedSentryEvent,
 	filterMetaMaskExtensionSentryEvent,
@@ -215,6 +216,59 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 			},
 		}),
 	).toBeNull()
+
+	// Chrome extension receiving-end missing (issue 7662064169 / KODY-CLOUDFLARE-4F).
+	expect(
+		filterChromeExtensionReceivingEndMissingSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value:
+							'Could not establish connection. Receiving end does not exist.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterChromeExtensionReceivingEndMissingSentryEvent(
+			{
+				exception: {
+					values: [{ type: 'Error', value: 'something else' }],
+				},
+			},
+			new Error(
+				'Could not establish connection. Receiving end does not exist.',
+			),
+		),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value:
+							'Error: Could not establish connection. Receiving end does not exist.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	// Nearby connection wording from app code must not be dropped.
+	expect(
+		filterChromeExtensionReceivingEndMissingSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Could not establish connection to the MCP server.',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
 
 	// MetaMask inpage.js session restore (issue 7658961865 / KODY-CLOUDFLARE-3X).
 	expect(

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -324,6 +324,59 @@ export function filterChromeExtensionObjectNotFoundSentryEvent<
 }
 
 /**
+ * Chrome/Firefox extension messaging noise: content scripts and page-injected
+ * extension code call `chrome.runtime.sendMessage` / `browser.runtime.sendMessage`
+ * when the extension's background/service worker (or another receiving end) is
+ * gone — unloaded, updated, or never registered for that tab. Chromium rejects
+ * with this exact IPC wording. The promise often surfaces on the host page with
+ * no app stack frames (Sentry attributes the culprit to the document URL).
+ *
+ * Signature from production issue 7662064169 / KODY-CLOUDFLARE-4F (Chrome on
+ * https://heykody.app/, zero frames, handled generic capture). Kody never uses
+ * `chrome.runtime` / `browser.runtime`. Match is intentionally narrow: only
+ * this exact "Could not establish connection. Receiving end does not exist"
+ * wording (optional `Error:` preface). Never blanket-drop connection errors.
+ */
+const chromeExtensionReceivingEndMissingMessage =
+	/^(?:Error:\s*)?Could not establish connection\. Receiving end does not exist\.?$/
+
+export function isChromeExtensionReceivingEndMissingMessage(message: string) {
+	return chromeExtensionReceivingEndMissingMessage.test(message.trim())
+}
+
+export function isChromeExtensionReceivingEndMissingError(error: unknown) {
+	if (typeof error === 'string') {
+		return isChromeExtensionReceivingEndMissingMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isChromeExtensionReceivingEndMissingMessage(error.message)
+}
+
+export function isChromeExtensionReceivingEndMissingSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isChromeExtensionReceivingEndMissingError(originalException)) return true
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isChromeExtensionReceivingEndMissingMessage(message),
+	)
+}
+
+export function filterChromeExtensionReceivingEndMissingSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (
+		isChromeExtensionReceivingEndMissingSentryEvent(event, originalException)
+	) {
+		return null
+	}
+	return event
+}
+
+/**
  * MetaMask (`chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/…`) injects
  * `inpage.js` into every page and tries to restore a wallet session on load.
  * When the extension's background/service worker is unavailable it rejects
@@ -533,6 +586,14 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	if (
 		filterChromeExtensionObjectNotFoundSentryEvent(event, originalException) ===
 		null
+	) {
+		return null
+	}
+	if (
+		filterChromeExtensionReceivingEndMissingSentryEvent(
+			event,
+			originalException,
+		) === null
 	) {
 		return null
 	}

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -32,14 +32,15 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// permission-denied from Replay/hydration on restricted nodes,
 		// injected wallet/`__firefox__` globals, Fathom beacon
 		// removeChild-on-null, Chrome extension IPC "Object Not Found
-		// Matching Id…", MetaMask inpage connect failures, Twitter/X
-		// in-app browser chrome `CONFIG` ReferenceErrors, and injected
-		// unguarded `meta[property='og:type']` probes from `global code`) —
-		// see filterBrowserSentryEvent / KODY-CLOUDFLARE-23 /
+		// Matching Id…", Chrome/Firefox extension "Receiving end does not
+		// exist", MetaMask inpage connect failures, Twitter/X in-app browser
+		// chrome `CONFIG` ReferenceErrors, and injected unguarded
+		// `meta[property='og:type']` probes from `global code`) — see
+		// filterBrowserSentryEvent / KODY-CLOUDFLARE-23 /
 		// KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S / KODY-CLOUDFLARE-3X /
-		// KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 / issues 7639685398,
-		// 7648833360, 7648833403, 7653117289, 7655189301, 7658961865,
-		// 7659616372, 7660258027.
+		// KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 / KODY-CLOUDFLARE-4F /
+		// issues 7639685398, 7648833360, 7648833403, 7653117289, 7655189301,
+		// 7658961865, 7659616372, 7660258027, 7662064169.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Chrome/Firefox extension messaging noise from polluting production Sentry for Kody.

## Summary

- Sentry [KODY-CLOUDFLARE-4F](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7662064169/) (`7662064169`): `Error: Could not establish connection. Receiving end does not exist.`
- Production event on `https://heykody.app/` (Chrome), **zero stack frames**, handled generic capture — classic extension `runtime.sendMessage` when the receiving end is gone.
- Kody never uses `chrome.runtime` / `browser.runtime`.
- Adds a narrow browser `beforeSend` filter (same pattern as KODY-CLOUDFLARE-3S Object Not Found) and unit coverage that nearby "connection" wording is kept.

## Testing

- `npx vitest run packages/worker/client/sentry-browser-filters.node.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `e9b6b3cc` · **Head:** `2fd463c0`

**Classification:** composes — wires one more narrow predicate into the existing browser Sentry `beforeSend` filter chain; no primitive contract change.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — drop Chromium/Firefox "Receiving end does not exist" noise |

### System map

Browser Sentry init already runs `filterBrowserSentryEvent`; this PR adds the receiving-end missing predicate to that chain.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	sentry["Sentry browser SDK"]:::untouched
	appUi -->|"beforeSend: drop receiving-end missing"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98afa430-1b8d-4c8b-b676-02ba5bd572a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98afa430-1b8d-4c8b-b676-02ba5bd572a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced noise from Chrome and Firefox extension messaging errors in error reporting.
  - Preserved reporting for similar but unrelated connection messages.

- **Documentation**
  - Expanded error-filtering documentation with additional browser noise categories and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->