### PR TITLE
Allow staging confidential platform apps without a client secret

### DIFF
--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -147,6 +147,13 @@ domain, all audited via `auditAdminCapabilityInvocation`:
 | `admin_platform_oauth_app_list`   | Includes `hasClientSecret` and per-app user connection counts                            |
 | `admin_platform_oauth_app_delete` | Fails while user connections reference the app — disable (`enabled = 0`) instead         |
 
+Confidential apps require a stored client secret only while `enabled`. An agent
+can therefore stage a complete provider config through `save` with
+`enabled: false` and a placeholder client id; the operator pastes the real
+client id and secret in `/admin/platform-integrations` and enables it. The
+enable transition re-validates, so a secretless confidential app can never
+become reachable.
+
 ## Where credentials live
 
 | Field                         | Storage                                       | Notes                                      |

--- a/packages/worker/src/integrations/platform-apps.node.test.ts
+++ b/packages/worker/src/integrations/platform-apps.node.test.ts
@@ -152,15 +152,61 @@ test('partial saves retain omitted fields instead of clearing them', async () =>
 	expect(cleared.requiredHosts).toEqual([])
 })
 
-test('confidential flow requires a client secret', async () => {
+test('confidential flow requires a client secret only while enabled', async () => {
 	const { db, env } = createHarness()
+	// Enabled (default) without a secret is rejected.
 	await expect(
 		upsertPlatformOauthApp({
 			db,
 			env,
 			app: { ...baseGithubApp, clientSecret: null },
 		}),
-	).rejects.toThrow('Confidential flow requires a client secret.')
+	).rejects.toThrow('Confidential flow requires a client secret')
+
+	// Staged provisioning: a disabled app saves without a secret so an
+	// operator can paste credentials later.
+	const staged = await upsertPlatformOauthApp({
+		db,
+		env,
+		app: { ...baseGithubApp, clientSecret: null, enabled: false },
+	})
+	expect(staged.enabled).toBe(false)
+	expect(staged.hasClientSecret).toBe(false)
+
+	// Enabling it while the secret is still missing is rejected, including
+	// through a partial save that omits clientSecret (retain-on-omit keeps
+	// the absent secret).
+	await expect(
+		upsertPlatformOauthApp({
+			db,
+			env,
+			app: {
+				slug: baseGithubApp.slug,
+				clientId: baseGithubApp.clientId,
+				tokenUrl: baseGithubApp.tokenUrl,
+				authorizeUrl: baseGithubApp.authorizeUrl,
+				flow: 'confidential',
+				enabled: true,
+			},
+		}),
+	).rejects.toThrow('Confidential flow requires a client secret')
+
+	// Once the secret lands, enabling works.
+	const live = await upsertPlatformOauthApp({
+		db,
+		env,
+		app: {
+			slug: baseGithubApp.slug,
+			clientId: baseGithubApp.clientId,
+			tokenUrl: baseGithubApp.tokenUrl,
+			authorizeUrl: baseGithubApp.authorizeUrl,
+			flow: 'confidential',
+			clientSecret: 'late-pasted-secret',
+			enabled: true,
+		},
+	})
+	expect(live.enabled).toBe(true)
+	expect(live.hasClientSecret).toBe(true)
 })
 
 test('allowedScopes always contains defaultScopes and disabled apps hide from the default list', async () => {

--- a/packages/worker/src/integrations/platform-apps.ts
+++ b/packages/worker/src/integrations/platform-apps.ts
@@ -165,8 +165,20 @@ export async function upsertPlatformOauthApp(input: {
 						input.env,
 						input.app.clientSecret.trim(),
 					)
-	if (input.app.flow === 'confidential' && !clientSecretEncrypted) {
-		throw new Error('Confidential flow requires a client secret.')
+	const enabled =
+		input.app.enabled === undefined
+			? (existing?.enabled ?? 1)
+			: input.app.enabled
+				? 1
+				: 0
+	// Disabled apps may omit the secret so an agent can stage the full
+	// provider config through MCP and an operator pastes credentials (and
+	// enables) later; the secret becomes mandatory the moment the app is
+	// reachable by users.
+	if (enabled && input.app.flow === 'confidential' && !clientSecretEncrypted) {
+		throw new Error(
+			'Confidential flow requires a client secret before the app can be enabled. Save it with enabled: false to stage the config first.',
+		)
 	}
 
 	const now = new Date().toISOString()
@@ -248,11 +260,7 @@ export async function upsertPlatformOauthApp(input: {
 			input.app.requiredHosts === undefined
 				? (existing?.required_hosts_json ?? '[]')
 				: JSON.stringify(input.app.requiredHosts),
-			input.app.enabled === undefined
-				? (existing?.enabled ?? 1)
-				: input.app.enabled
-					? 1
-					: 0,
+			enabled,
 			existing?.created_at ?? now,
 			now,
 		)

--- a/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
@@ -31,7 +31,7 @@ const inputSchema = z
 			.nullable()
 			.optional()
 			.describe(
-				'Plaintext client secret; stored encrypted and never returned by any capability. Omit to keep the stored value, pass null to clear it (public PKCE apps).',
+				'Plaintext client secret; stored encrypted and never returned by any capability. Omit to keep the stored value, pass null to clear it (public PKCE apps). Confidential apps may stage without a secret while enabled is false — the operator pastes credentials in /admin/platform-integrations before enabling.',
 			),
 		tokenUrl: z.string().url(),
 		authorizeUrl: z.string().url(),
@@ -53,7 +53,9 @@ const inputSchema = z
 		enabled: z
 			.boolean()
 			.optional()
-			.describe('Disabled apps are hidden from users and reject new connects.'),
+			.describe(
+				'Disabled apps are hidden from users and reject new connects. Defaults to enabled on create; pass false to stage a confidential app before its client secret exists.',
+			),
 		logoBase64: z
 			.string()
 			.nullable()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Relaxes `upsertPlatformOauthApp` validation: a confidential platform OAuth app requires a stored client secret only while it is **enabled**. Disabled apps can be saved secretless.

## Why

This enables agent-driven provisioning: an agent scaffolds the entire provider config through `admin_platform_oauth_app_save` (endpoints, flow, scopes, hosts, logo) with `enabled: false` and a placeholder client id, and the operator only pastes the real client id + secret in `/admin/platform-integrations` and enables it. Previously the save was rejected outright, forcing placeholder secrets into the encrypted store — which then read as "secret stored" and could be forgotten.

## Safety

- New apps default to enabled, so staging requires an explicit `enabled: false`.
- The enable transition re-validates, including partial saves that omit `clientSecret` (retain-on-omit keeps the absent secret), so a secretless confidential app can never become user-reachable. Covered by a new lifecycle test: stage secretless → enable rejected → paste secret + enable succeeds.
- Disabled apps were already hidden from users and rejected connects, so nothing user-facing changes.

## Docs

- Capability descriptions for `clientSecret` / `enabled` teach the staged workflow.
- `docs/contributing/architecture/integrations.md` admin-provisioning section documents the invariant.

## Testing

`npm run validate` green (typecheck, lint, format, Node + Workers unit suites).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Confidential OAuth apps can now be staged while disabled without a client secret.
  * Enabling a confidential app requires a valid client secret and revalidates its configuration.
  * OAuth app setup guidance now clarifies enabled defaults and staging options.

* **Bug Fixes**
  * Prevented incomplete confidential apps from becoming reachable when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->