### PR TITLE
Normalize Slack-shaped OAuth token exchange payloads

### DIFF
--- a/packages/worker/src/app/handlers/account-secrets.ts
+++ b/packages/worker/src/app/handlers/account-secrets.ts
@@ -51,6 +51,8 @@ import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import {
 	buildOAuthTokenExchangeFailurePayload,
 	buildOAuthTokenExchangeRequest,
+	isOAuthTokenExchangeSoftFailure,
+	normalizeOAuthTokenExchangePayload,
 	oauthTokenExchangeFailureHttpStatus,
 	resolveTokenExchangeStyle,
 	type TokenExchangeStyle,
@@ -777,7 +779,19 @@ async function handleOAuthExchangeAction(input: {
 			oauthTokenExchangeFailureHttpStatus(),
 		)
 	}
-	return jsonResponse(payloadRecord, response.status)
+	if (isOAuthTokenExchangeSoftFailure(payloadRecord)) {
+		return jsonResponse(
+			buildOAuthTokenExchangeFailurePayload({
+				providerStatus: response.status,
+				payload: payloadRecord,
+			}),
+			oauthTokenExchangeFailureHttpStatus(),
+		)
+	}
+	return jsonResponse(
+		normalizeOAuthTokenExchangePayload(payloadRecord),
+		response.status,
+	)
 }
 
 async function saveIntegrationConfig(input: {

--- a/packages/worker/src/integrations/oauth-token-exchange.node.test.ts
+++ b/packages/worker/src/integrations/oauth-token-exchange.node.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'vitest'
 import {
 	buildOAuthTokenExchangeFailurePayload,
 	buildOAuthTokenExchangeRequest,
+	isOAuthTokenExchangeSoftFailure,
+	normalizeOAuthTokenExchangePayload,
 	oauthTokenExchangeFailureHttpStatus,
 	resolveTokenExchangeStyle,
 } from './oauth-token-exchange.ts'
@@ -195,4 +197,51 @@ test('token exchange style resolves Canva basic-form and keeps PKCE code_verifie
 			style: 'basic-form',
 		}),
 	).toThrow('basic-form token exchange requires client_id in params.')
+})
+
+test('normalizeOAuthTokenExchangePayload hoists Slack authed_user tokens', () => {
+	// Slack user-scope-only apps: no top-level access_token at all.
+	const userOnly = normalizeOAuthTokenExchangePayload({
+		ok: true,
+		app_id: 'A0123',
+		authed_user: {
+			id: 'U0123',
+			scope: 'channels:history,chat:write',
+			access_token: 'xoxp-user-token',
+			token_type: 'user',
+		},
+		team: { id: 'T0123', name: 'Acme' },
+	})
+	expect(userOnly.access_token).toBe('xoxp-user-token')
+	expect(userOnly.token_type).toBe('user')
+	expect(userOnly.scope).toBe('channels:history,chat:write')
+	// The original nested record survives for callers that want it.
+	expect(userOnly.authed_user).toMatchObject({ id: 'U0123' })
+
+	// A present top-level token (Slack bot token, standard providers) is
+	// never overwritten by the nested user token.
+	const botAndUser = normalizeOAuthTokenExchangePayload({
+		ok: true,
+		access_token: 'xoxb-bot-token',
+		token_type: 'bot',
+		authed_user: { id: 'U0123', access_token: 'xoxp-user-token' },
+	})
+	expect(botAndUser.access_token).toBe('xoxb-bot-token')
+	expect(botAndUser.token_type).toBe('bot')
+
+	// Standard OAuth payloads pass through untouched.
+	const standard = { access_token: 'token', refresh_token: 'refresh' }
+	expect(normalizeOAuthTokenExchangePayload(standard)).toBe(standard)
+	const noToken = { error: 'invalid_grant' }
+	expect(normalizeOAuthTokenExchangePayload(noToken)).toBe(noToken)
+})
+
+test('isOAuthTokenExchangeSoftFailure detects Slack ok:false payloads', () => {
+	expect(
+		isOAuthTokenExchangeSoftFailure({ ok: false, error: 'invalid_code' }),
+	).toBe(true)
+	expect(
+		isOAuthTokenExchangeSoftFailure({ ok: true, access_token: 'xoxp-token' }),
+	).toBe(false)
+	expect(isOAuthTokenExchangeSoftFailure({ access_token: 'token' })).toBe(false)
 })

--- a/packages/worker/src/integrations/oauth-token-exchange.ts
+++ b/packages/worker/src/integrations/oauth-token-exchange.ts
@@ -148,6 +148,60 @@ function formUrlEncodeBasicCredential(value: string) {
 	return encodeURIComponent(value).replace(/%20/g, '+')
 }
 
+const hoistedAuthedUserFields = [
+	'access_token',
+	'refresh_token',
+	'expires_in',
+	'token_type',
+	'scope',
+] as const
+
+/**
+ * Normalizes provider-specific success payload shapes to the standard OAuth
+ * top-level fields. Slack's `oauth.v2.access` nests user tokens under
+ * `authed_user` (top-level `access_token` is the bot token, absent for
+ * user-scope-only apps); hoisting the nested fields keeps token persistence
+ * provider-agnostic. Present top-level fields are never overwritten.
+ */
+export function normalizeOAuthTokenExchangePayload(
+	payload: Record<string, unknown>,
+): Record<string, unknown> {
+	const topLevelToken = payload.access_token
+	if (typeof topLevelToken === 'string' && topLevelToken.trim()) {
+		return payload
+	}
+	const authedUser = payload.authed_user
+	if (
+		!authedUser ||
+		typeof authedUser !== 'object' ||
+		Array.isArray(authedUser)
+	) {
+		return payload
+	}
+	const nested = authedUser as Record<string, unknown>
+	const nestedToken = nested.access_token
+	if (typeof nestedToken !== 'string' || !nestedToken.trim()) {
+		return payload
+	}
+	const hoisted: Record<string, unknown> = { ...payload }
+	for (const field of hoistedAuthedUserFields) {
+		if (hoisted[field] === undefined && nested[field] !== undefined) {
+			hoisted[field] = nested[field]
+		}
+	}
+	return hoisted
+}
+
+/**
+ * Slack reports token-endpoint failures as `{ ok: false, error }` with
+ * HTTP 200, so a status check alone misses them.
+ */
+export function isOAuthTokenExchangeSoftFailure(
+	payload: Record<string, unknown>,
+): boolean {
+	return payload.ok === false
+}
+
 /**
  * Provider token-endpoint failures must not reuse HTTP 401 — the connect UI
  * treats 401 from `/account/secrets.json` as an expired Kody session.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two small normalizations in the host-side `/connect/oauth` token exchange, in `oauth-token-exchange.ts` + `handleOAuthExchangeAction`:

1. **`authed_user` hoisting.** Slack's `oauth.v2.access` nests user tokens under `authed_user` — top-level `access_token` is the bot token, and is absent entirely for user-scope-only apps. The exchange response now hoists `access_token` / `refresh_token` / `expires_in` / `token_type` / `scope` from `authed_user` to the standard top-level names when the top level lacks a token, never overwriting present fields. Standard OAuth payloads pass through untouched (same object identity).
2. **`ok: false` soft failures.** Slack reports token-endpoint failures as `{ ok: false, error }` with HTTP 200; these now map to the standard exchange-failure response (502 + provider error string) instead of surfacing downstream as a confusing "payload did not include an access_token".

## Why

Community data shows `@kody/slack` is the most-adopted integration package (4 forks, 2 stars) — each fork today means a user registering their own Slack app. This unblocks a platform (built-in) Slack app configured with `user_scope` via `extraAuthorizeParams`, keeping token persistence provider-agnostic downstream.

## Testing

Unit tests for both helpers (user-scope-only hoisting, bot-token non-overwrite, standard payload passthrough, soft-failure detection). `npm run validate` green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth token exchange handling for Slack-style responses.
  * Preserved valid top-level tokens while recovering tokens nested in user details.
  * Correctly identifies soft failures returned with successful HTTP responses.
  * Supports standard, tokenless, and failure payloads without altering their expected structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->