### PR TITLE
Offer top built-in integrations in onboarding step 3

### DIFF
--- a/packages/worker/client/routes/onboarding-payload.ts
+++ b/packages/worker/client/routes/onboarding-payload.ts
@@ -1,5 +1,8 @@
 import { type OnboardingFeaturedListing } from '#universal/community-public-types.ts'
-import { type OnboardingChecklistLoaderData } from '#universal/loader-data.ts'
+import {
+	type OnboardingBuiltInProvider,
+	type OnboardingChecklistLoaderData,
+} from '#universal/loader-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 
 /**
@@ -20,6 +23,7 @@ export type OnboardingPayload = {
 	emailVerified: boolean
 	needsOnboarding: boolean
 	featuredListings: Array<OnboardingFeaturedListing>
+	builtInProviders: Array<OnboardingBuiltInProvider>
 	checklist: OnboardingChecklistLoaderData | null
 }
 

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -807,9 +807,7 @@ export function OnboardingRoute(handle: Handle) {
 										data-testid="onboarding-built-in-integrations"
 										mix={css(builtInCalloutCss)}
 									>
-										<p mix={css(builtInLabelCss)}>
-											Use a built-in integration
-										</p>
+										<p mix={css(builtInLabelCss)}>Use a built-in integration</p>
 										<p mix={css(builtInLedeCss)}>
 											Connect in one click — Kody hosts the provider app, so
 											there is nothing to register.
@@ -892,7 +890,7 @@ export function OnboardingRoute(handle: Handle) {
 
 						{/* Outside the wizard panels on purpose: the prototype keeps the
 					    BYOK disclosure visible on every step. */}
-						{renderByokDetails()}
+						{renderByokDetails(builtInProviders.length > 0)}
 
 						{loggedIn ? null : (
 							<p mix={css(authLinksCss)}>
@@ -975,7 +973,7 @@ function WizardNavigation(
  * prototype's onboarding-specific framing ("Why there's no one-click
  * connect"); the integrations page keeps its own `byok-explainer` copy.
  */
-function renderByokDetails() {
+function renderByokDetails(hasBuiltIns: boolean) {
 	return (
 		<details mix={css(byokDetailsCss)}>
 			<summary mix={css(byokSummaryCss)}>Bring your own API keys</summary>
@@ -993,12 +991,14 @@ function renderByokDetails() {
 				/>
 				<div>
 					<h2 id="byok-note-title" mix={css(byokTitleCss)}>
-						Why there&apos;s no one-click connect
+						{hasBuiltIns
+							? 'Why bring your own keys?'
+							: "Why there's no one-click connect"}
 					</h2>
 					<p mix={css(byokCopyCss)}>
-						Kody never asks a company for access on your behalf. You create the
-						connection yourself, and your agent walks you through it, so it is
-						completely yours: your app, your scopes, no middleman.
+						{hasBuiltIns
+							? 'Built-in integrations run on an app Kody hosts, for a fast start. For everything else — or for full control — you create the connection yourself, and your agent walks you through it, so it is completely yours: your app, your scopes, no middleman.'
+							: 'Kody never asks a company for access on your behalf. You create the connection yourself, and your agent walks you through it, so it is completely yours: your app, your scopes, no middleman.'}
 					</p>
 					<dl mix={css(byokCompareCss)}>
 						<div>

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -15,7 +15,10 @@ import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
-import { type OnboardingChecklistLoaderData } from '#universal/loader-data.ts'
+import {
+	type OnboardingBuiltInProvider,
+	type OnboardingChecklistLoaderData,
+} from '#universal/loader-data.ts'
 import { type OnboardingFeaturedListing } from '#universal/community-public-types.ts'
 import {
 	fetchOnboardingPayload,
@@ -127,6 +130,7 @@ export function OnboardingRoute(handle: Handle) {
 	let hasSavedMemory = false
 	let hasFirstWin = false
 	let featuredListings: Array<OnboardingFeaturedListing> = []
+	let builtInProviders: Array<OnboardingBuiltInProvider> = []
 	let checklist: OnboardingChecklistLoaderData | null = null
 	let checklistHidden = false
 	let activeStep: OnboardingStep = 1
@@ -183,6 +187,7 @@ export function OnboardingRoute(handle: Handle) {
 		// reply that arrived outside it never skips the earlier sub-steps.
 		hasFirstWin = hasSentWelcomeEmail && hasFirstHello && hasSavedMemory
 		featuredListings = payload.featuredListings ?? []
+		builtInProviders = payload.builtInProviders ?? []
 		checklist = payload.checklist
 		if (payload.checklist?.dismissed) checklistHidden = true
 		status = 'ready'
@@ -797,6 +802,49 @@ export function OnboardingRoute(handle: Handle) {
 										mix={css(panelArtCss)}
 									/>
 								</div>
+								{builtInProviders.length > 0 ? (
+									<div
+										data-testid="onboarding-built-in-integrations"
+										mix={css(builtInCalloutCss)}
+									>
+										<p mix={css(builtInLabelCss)}>
+											Use a built-in integration
+										</p>
+										<p mix={css(builtInLedeCss)}>
+											Connect in one click — Kody hosts the provider app, so
+											there is nothing to register.
+										</p>
+										<ul mix={css(builtInListCss)}>
+											{builtInProviders.map((provider) => (
+												<li key={provider.slug}>
+													<a
+														href={`/connect/oauth?provider=${encodeURIComponent(provider.slug)}`}
+														mix={css(builtInLinkCss)}
+													>
+														{provider.logoPath ? (
+															<img
+																src={provider.logoPath}
+																alt=""
+																width={20}
+																height={20}
+																loading="lazy"
+																mix={css(builtInLogoCss)}
+															/>
+														) : null}
+														{provider.label}
+													</a>
+												</li>
+											))}
+										</ul>
+										<p mix={css(builtInByoCss)}>
+											Want scopes or rate limits Kody's app does not offer?{' '}
+											<a href="/connect/oauth" mix={css(primaryLinkCss)}>
+												Bring your own OAuth app
+											</a>{' '}
+											for more power.
+										</p>
+									</div>
+								) : null}
 								<p mix={css(panelLedeCss)}>
 									{featuredListings.length > 0
 										? 'These packages were reviewed by an admin and support one-click install here. After install, use Copy prompt so your agent can finish any remaining setup — or pick Choose your own adventure to explore with your agent instead.'
@@ -1426,6 +1474,69 @@ function connectStatusContent(input: {
 		/>,
 		<strong key="label">{input.waitingLabel}</strong>,
 	]
+}
+
+/* Built-in integrations: an accent well above the starter grid so the
+   one-click path reads first, with BYO as the power-user footnote. */
+const builtInCalloutCss = {
+	...getAccentCalloutCss(),
+	display: 'grid',
+	gap: '0.55rem',
+}
+
+const builtInLabelCss = {
+	margin: 0,
+	font: `700 0.78rem/1 ${typography.fontFamilyBody}`,
+	letterSpacing: '0.06em',
+	textTransform: 'uppercase' as const,
+	color: colors.primaryText,
+}
+
+const builtInLedeCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: '0.94rem',
+	lineHeight: 1.55,
+}
+
+const builtInListCss = {
+	listStyle: 'none',
+	margin: 0,
+	padding: 0,
+	display: 'flex',
+	flexWrap: 'wrap' as const,
+	gap: '0.6rem',
+}
+
+const builtInLinkCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.45rem',
+	padding: '0.5rem 0.95rem',
+	borderRadius: radius.full,
+	backgroundColor: colors.surface,
+	boxShadow: `inset 0 0 0 1.5px ${colors.border}`,
+	color: colors.text,
+	fontWeight: 600,
+	textDecoration: 'none',
+	transition: `box-shadow ${transitions.fast}, transform ${transitions.fast}`,
+	[hoverMq]: {
+		'&:hover': {
+			boxShadow: `inset 0 0 0 1.5px ${colors.primary}`,
+			transform: 'translateY(-1px)',
+		},
+	},
+}
+
+const builtInLogoCss = {
+	display: 'block',
+	borderRadius: '4px',
+}
+
+const builtInByoCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: '0.9rem',
 }
 
 /* Starter packages: compact centered cards; the DIY card breaks the grid

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -61,6 +61,7 @@ test('onboarding serves public setup content to anonymous visitors', async () =>
 		emailVerified: false,
 		needsOnboarding: true,
 		featuredListings: [],
+		builtInProviders: [],
 		checklist: null,
 	})
 })

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -9,7 +9,12 @@ import {
 import { normalizeRedirectTo } from '#app/auth-redirect.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { loadOnboardingFeaturedListings } from '#app/community-data.ts'
-import { type OnboardingChecklistLoaderData } from '#universal/loader-data.ts'
+import { buildPlatformOauthAppLogoPath } from '#worker/integrations/platform-app-logo.ts'
+import { listTopPlatformAppsByUse } from '#worker/integrations/platform-apps.ts'
+import {
+	type OnboardingBuiltInProvider,
+	type OnboardingChecklistLoaderData,
+} from '#universal/loader-data.ts'
 import {
 	loadOnboardingData,
 	loadPublicOnboardingData,
@@ -50,6 +55,31 @@ async function loadHasSentWelcomeEmail(
 	return await userHasSentWelcomeEmail({ env, userId })
 }
 
+const onboardingBuiltInProviderLimit = 3
+
+/**
+ * Top enabled built-in integrations by adoption, offered as one-click
+ * connects in the wizard. Fails open to an empty list so a D1 blip (or a
+ * deployment with no platform apps) never breaks the onboarding payload.
+ */
+export async function loadOnboardingBuiltInProviders(
+	env: Env,
+): Promise<Array<OnboardingBuiltInProvider>> {
+	try {
+		const apps = await listTopPlatformAppsByUse({
+			db: env.APP_DB,
+			limit: onboardingBuiltInProviderLimit,
+		})
+		return apps.map((app) => ({
+			slug: app.slug,
+			label: app.label ?? app.slug,
+			logoPath: buildPlatformOauthAppLogoPath(app),
+		}))
+	} catch {
+		return []
+	}
+}
+
 function redirectUnverifiedToPending(request: Request) {
 	const requestUrl = new URL(request.url)
 	const redirectTo = normalizeRedirectTo(
@@ -74,6 +104,7 @@ export function createOnboardingHandler(env: Env) {
 						requestUrl: request.url,
 					}),
 					featuredListings: await loadOnboardingFeaturedListings(env, request),
+					builtInProviders: await loadOnboardingBuiltInProviders(env),
 				}
 				return renderAppPage({
 					request,
@@ -92,6 +123,7 @@ export function createOnboardingHandler(env: Env) {
 				stableUserId: user.mcpUser.userId,
 				emailVerified: user.emailVerified,
 				featuredListings: await loadOnboardingFeaturedListings(env, request),
+				builtInProviders: await loadOnboardingBuiltInProviders(env),
 			})
 			;[onboarding.checklist, onboarding.hasSentWelcomeEmail] =
 				await Promise.all([
@@ -123,6 +155,7 @@ export function createOnboardingApiHandler(env: Env) {
 						requestUrl: request.url,
 					}),
 					featuredListings: await loadOnboardingFeaturedListings(env, request),
+					builtInProviders: await loadOnboardingBuiltInProviders(env),
 				})
 			}
 
@@ -136,6 +169,9 @@ export function createOnboardingApiHandler(env: Env) {
 				emailVerified: user.emailVerified,
 				featuredListings: user.emailVerified
 					? await loadOnboardingFeaturedListings(env, request)
+					: [],
+				builtInProviders: user.emailVerified
+					? await loadOnboardingBuiltInProviders(env)
 					: [],
 			})
 			if (user.emailVerified) {

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -56,6 +56,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		emailVerified: false,
 		needsOnboarding: true,
 		featuredListings: [],
+		builtInProviders: [],
 		checklist: null,
 	})
 
@@ -85,6 +86,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		emailVerified: true,
 		needsOnboarding: true,
 		featuredListings: [],
+		builtInProviders: [],
 		checklist: null,
 	})
 

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -1,6 +1,7 @@
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { type OnboardingFeaturedListing } from '#universal/community-public-types.ts'
 import {
+	type OnboardingBuiltInProvider,
 	type OnboardingChecklistLoaderData,
 	type OnboardingLoaderData,
 } from '#universal/loader-data.ts'
@@ -121,6 +122,7 @@ export function loadPublicOnboardingData(input: {
 		emailVerified: false,
 		needsOnboarding: true,
 		featuredListings: [],
+		builtInProviders: [],
 		checklist: null,
 	}
 }
@@ -135,6 +137,8 @@ export async function loadOnboardingData(input: {
 	 * worker Env); this module stays narrow so it is trivially testable.
 	 */
 	featuredListings?: Array<OnboardingFeaturedListing>
+	/** Top enabled built-in integrations, loaded by the handler. */
+	builtInProviders?: Array<OnboardingBuiltInProvider>
 	/** Derived progress checklist, computed by the handler. */
 	checklist?: OnboardingChecklistLoaderData | null
 }): Promise<OnboardingLoaderData> {
@@ -174,6 +178,9 @@ export async function loadOnboardingData(input: {
 		emailVerified: input.emailVerified,
 		needsOnboarding,
 		featuredListings: input.emailVerified ? (input.featuredListings ?? []) : [],
+		builtInProviders: input.emailVerified
+			? (input.builtInProviders ?? [])
+			: [],
 		// Computed by the handler alongside the checklist probes.
 		hasSentWelcomeEmail: false,
 		checklist: input.checklist ?? null,

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -178,9 +178,7 @@ export async function loadOnboardingData(input: {
 		emailVerified: input.emailVerified,
 		needsOnboarding,
 		featuredListings: input.emailVerified ? (input.featuredListings ?? []) : [],
-		builtInProviders: input.emailVerified
-			? (input.builtInProviders ?? [])
-			: [],
+		builtInProviders: input.emailVerified ? (input.builtInProviders ?? []) : [],
 		// Computed by the handler alongside the checklist probes.
 		hasSentWelcomeEmail: false,
 		checklist: input.checklist ?? null,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -331,6 +331,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		emailVerified: false,
 		needsOnboarding: true,
 		featuredListings: [],
+		builtInProviders: [],
 		checklist: null,
 	})
 	expect(accountHtml).toContain('Verify your email')

--- a/packages/worker/src/integrations/platform-apps.node.test.ts
+++ b/packages/worker/src/integrations/platform-apps.node.test.ts
@@ -8,6 +8,7 @@ import {
 	getPlatformOauthAppBySlug,
 	getPlatformOauthAppClientSecret,
 	listPlatformOauthApps,
+	listTopPlatformAppsByUse,
 	upsertPlatformOauthApp,
 } from './platform-apps.ts'
 
@@ -256,6 +257,39 @@ test('deletePlatformOauthApp refuses while user connections reference the app', 
 		.prepare('DELETE FROM user_integrations WHERE user_id = ?')
 		.run('user-1')
 	expect(await deletePlatformOauthApp({ db, slug: 'github' })).toBe(true)
+})
+
+test('listTopPlatformAppsByUse orders enabled apps by connection count and hides disabled', async () => {
+	const { sqlite, db, env } = createHarness()
+	for (const slug of ['github', 'google', 'notion', 'slack']) {
+		await upsertPlatformOauthApp({
+			db,
+			env,
+			app: {
+				...baseGithubApp,
+				slug,
+				enabled: slug !== 'slack',
+			},
+		})
+	}
+	const insertConnection = sqlite.prepare(
+		`INSERT INTO user_integrations (
+			user_id, name, app_slug, platform_app_slug, access_token_secret_name
+		) VALUES (?, ?, NULL, ?, ?)`,
+	)
+	// google: 2 connections, notion: 1, github: 0, slack (disabled): 3.
+	insertConnection.run('user-1', 'google', 'google', 'googleAccessToken')
+	insertConnection.run('user-2', 'google', 'google', 'googleAccessToken')
+	insertConnection.run('user-1', 'notion', 'notion', 'notionAccessToken')
+	insertConnection.run('user-1', 'slack', 'slack', 'slackAccessToken')
+	insertConnection.run('user-2', 'slack', 'slack', 'slackAccessToken')
+	insertConnection.run('user-3', 'slack', 'slack', 'slackAccessToken')
+
+	const top = await listTopPlatformAppsByUse({ db, limit: 3 })
+	expect(top.map((app) => app.slug)).toEqual(['google', 'notion', 'github'])
+
+	const topTwo = await listTopPlatformAppsByUse({ db, limit: 2 })
+	expect(topTwo.map((app) => app.slug)).toEqual(['google', 'notion'])
 })
 
 test('user_integrations enforces exactly one of app_slug / platform_app_slug', async () => {

--- a/packages/worker/src/integrations/platform-apps.ts
+++ b/packages/worker/src/integrations/platform-apps.ts
@@ -88,6 +88,32 @@ export async function listPlatformOauthApps(input: {
 	return (result.results ?? []).map(mapPlatformOauthAppRow)
 }
 
+/**
+ * Enabled platform apps ordered by adoption (user connection count), for
+ * surfaces that highlight the most-used built-ins first. Ties fall back to
+ * creation order so a fresh deployment shows a stable list.
+ */
+export async function listTopPlatformAppsByUse(input: {
+	db: D1Database
+	limit: number
+}): Promise<Array<PlatformOauthApp>> {
+	const result = await input.db
+		.prepare(
+			`SELECT ${platformAppSelectColumns},
+				(
+					SELECT count(*) FROM user_integrations
+					WHERE user_integrations.platform_app_slug = platform_oauth_apps.slug
+				) AS connection_count
+			FROM platform_oauth_apps
+			WHERE enabled = 1
+			ORDER BY connection_count DESC, created_at ASC, slug ASC
+			LIMIT ?`,
+		)
+		.bind(input.limit)
+		.all<PlatformOauthAppRow>()
+	return (result.results ?? []).map(mapPlatformOauthAppRow)
+}
+
 export async function getPlatformOauthAppBySlug(input: {
 	db: D1Database
 	slug: string

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -695,6 +695,13 @@ export type AccountConnectionsLoaderData = {
 	availableProviders: Array<{ id: string; label: string }>
 }
 
+/** One-click built-in integration offered during onboarding. */
+export type OnboardingBuiltInProvider = {
+	slug: string
+	label: string
+	logoPath: string | null
+}
+
 export type OnboardingLoaderData = {
 	ok: true
 	loggedIn: boolean
@@ -713,6 +720,8 @@ export type OnboardingLoaderData = {
 	needsOnboarding: boolean
 	/** Admin-featured trusted listings offered as one-click starter installs. */
 	featuredListings: Array<OnboardingFeaturedListing>
+	/** Top enabled platform (built-in) integrations by use, for one-click connect. */
+	builtInProviders: Array<OnboardingBuiltInProvider>
 	/** Derived progress checklist; null when logged out. */
 	checklist: OnboardingChecklistLoaderData | null
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Onboarding step 3 ("Install a starter package") now opens with a **Use a built-in integration** callout when the deployment has enabled platform OAuth apps: the top three by user connection count render as one-click connect pills (logo + label) linking to `/connect/oauth?provider={slug}`, followed by a "Bring your own OAuth app for more power" line for users who want their own scopes and rate limits. The block hides entirely when no platform apps are enabled.

## How

- `listTopPlatformAppsByUse` in `platform-apps.ts`: enabled apps ordered by `user_integrations` connection count (ties by creation order), covered by a unit test that also checks disabled apps are excluded.
- `builtInProviders` on the onboarding payload (`OnboardingBuiltInProvider`: slug, label, logoPath), loaded fail-open in the onboarding handler so a D1 blip or an empty deployment never breaks the page. Anonymous visitors get the list too; unverified logged-in users get the same empty gating as `featuredListings`.
- Step 3 panel renders the accent-well callout above the starter grid (`data-testid="onboarding-built-in-integrations"`).

## Testing

- `npm run validate` green (new ordering test, updated payload fixtures).
- Verified in the browser against seeded local platform apps (3 enabled + 1 disabled): the block shows GitHub/Google/Notion, hides disabled Slack, and the GitHub pill lands on the prefilled built-in connect page ("no OAuth app setup needed").

![Onboarding step 3 with built-in integrations block](https://cursor.com/artifacts/c/art-6fa22ad3-b269-4907-86ab-048ce855b479)

<a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_built_in_integrations_demo.mp4"><img src="https://cursor.com/artifacts/c/art-03123761-5f4e-4dd9-80d5-592c359fcad6" alt="onboarding_built_in_integrations_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a one-click integrations callout to onboarding when built-in providers are available.
  - Providers now include direct OAuth setup links and may display logos.
  - Added a “Bring Your Own OAuth” fallback for custom integrations.
  - Onboarding displays up to three enabled, popular platform providers.
  - BYOK guidance now adapts based on available built-in providers.

- **Bug Fixes**
  - Provider information is only shown in authenticated onboarding flows for verified accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->