### PR TITLE
Make agent-action liability abundantly clear

### DIFF
--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -30,6 +30,11 @@ or client secret needed. Agents can list the available built-in apps with
 **`integration_platform_app_list`**. Tokens for a built-in connection are stored
 as your own secrets, the same as any other integration.
 
+Built-in or not, a connection authorizes _your_ agent — and any code you run or
+install — to act as you on that provider. Kody does not control or supervise
+what your agent does with the access you grant; scope connections deliberately
+and revoke ones you no longer use. See the [Terms](/terms).
+
 ## Placeholders in `fetch` and capability inputs
 
 Outbound **`fetch`** can include placeholders such as **`{{secret:tokenName}}`**

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -1199,10 +1199,10 @@ export function ConnectOauthRoute(handle: Handle) {
 							</p>
 						) : null}
 						<p mix={css(descriptionCss)}>
-							Connecting authorizes your agent — and any code you run or
-							install — to act as you on {config.provider} with the scopes you
-							grant. Kody does not control or supervise what your agent does
-							with this access; that responsibility is yours. See the{' '}
+							Connecting authorizes your agent — and any code you run or install
+							— to act as you on {config.provider} with the scopes you grant.
+							Kody does not control or supervise what your agent does with this
+							access; that responsibility is yours. See the{' '}
 							<a href="/terms" target="_blank" rel="noreferrer noopener">
 								Terms
 							</a>

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -1198,6 +1198,16 @@ export function ConnectOauthRoute(handle: Handle) {
 									: '.'}
 							</p>
 						) : null}
+						<p mix={css(descriptionCss)}>
+							Connecting authorizes your agent — and any code you run or
+							install — to act as you on {config.provider} with the scopes you
+							grant. Kody does not control or supervise what your agent does
+							with this access; that responsibility is yours. See the{' '}
+							<a href="/terms" target="_blank" rel="noreferrer noopener">
+								Terms
+							</a>
+							.
+						</p>
 						<button
 							type="button"
 							disabled={submitting}

--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -68,6 +68,36 @@ export function TermsRoute(_handle: Handle) {
 			</section>
 
 			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Your agent, your access</h2>
+				<p mix={css(descriptionCss)}>
+					Kody is a set of primitives — code execution, packages, scheduled
+					jobs, secrets, email, and integrations — that you and the AI agents
+					you connect direct. Kody does not control, review, or supervise what
+					your agent (or the AI models behind it) does with those primitives,
+					and makes no guarantees about the instructions it will follow or the
+					actions it will take.
+				</p>
+				<p mix={css(descriptionCss)}>
+					When you connect an integration — whether a built-in one that Kody
+					hosts the provider registration for, or one you register yourself —
+					or store a secret, you are authorizing your agent and any code you
+					run to act as you with that access. Actions taken with your tokens,
+					keys, and connections are your actions: messages sent, data read,
+					changed, or deleted, purchases made, and anything else your agent
+					does on a third-party service. Those services also have their own
+					terms, which you are responsible for honoring.
+				</p>
+				<p mix={css(descriptionCss)}>
+					Scope access deliberately: grant only the scopes you need, review
+					packages before installing them, and revoke connections you no
+					longer use (from Account settings and from the provider&apos;s
+					side). To the fullest extent the law permits, Kody and its operator
+					are not liable for what your agent, or code you run or install, does
+					with the access you grant it.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
 				<h2 mix={css(cardTitleCss)}>Plans, billing, and refunds</h2>
 				<p mix={css(descriptionCss)}>
 					The Free plan costs nothing. Paid subscriptions renew through Stripe
@@ -127,8 +157,11 @@ export function TermsRoute(_handle: Handle) {
 					To the fullest extent the law permits, Kody and its operator will not
 					be liable for indirect, incidental, special, consequential, exemplary,
 					or punitive damages, or for lost profits, data, goodwill, or business.
-					Our total liability for any claim is limited to the amount you paid
-					Kody during the 12 months before the event giving rise to the claim.
+					This includes damages arising from actions your agent, or code you
+					run or install, takes with integrations, secrets, or other access
+					you grant it — on Kody or on third-party services. Our total
+					liability for any claim is limited to the amount you paid Kody
+					during the 12 months before the event giving rise to the claim.
 					These limits do not apply where the law does not allow them.
 				</p>
 			</section>

--- a/packages/worker/client/routes/terms.tsx
+++ b/packages/worker/client/routes/terms.tsx
@@ -79,21 +79,21 @@ export function TermsRoute(_handle: Handle) {
 				</p>
 				<p mix={css(descriptionCss)}>
 					When you connect an integration — whether a built-in one that Kody
-					hosts the provider registration for, or one you register yourself —
-					or store a secret, you are authorizing your agent and any code you
-					run to act as you with that access. Actions taken with your tokens,
-					keys, and connections are your actions: messages sent, data read,
-					changed, or deleted, purchases made, and anything else your agent
-					does on a third-party service. Those services also have their own
-					terms, which you are responsible for honoring.
+					hosts the provider registration for, or one you register yourself — or
+					store a secret, you are authorizing your agent and any code you run to
+					act as you with that access. Actions taken with your tokens, keys, and
+					connections are your actions: messages sent, data read, changed, or
+					deleted, purchases made, and anything else your agent does on a
+					third-party service. Those services also have their own terms, which
+					you are responsible for honoring.
 				</p>
 				<p mix={css(descriptionCss)}>
 					Scope access deliberately: grant only the scopes you need, review
-					packages before installing them, and revoke connections you no
-					longer use (from Account settings and from the provider&apos;s
-					side). To the fullest extent the law permits, Kody and its operator
-					are not liable for what your agent, or code you run or install, does
-					with the access you grant it.
+					packages before installing them, and revoke connections you no longer
+					use (from Account settings and from the provider&apos;s side). To the
+					fullest extent the law permits, Kody and its operator are not liable
+					for what your agent, or code you run or install, does with the access
+					you grant it.
 				</p>
 			</section>
 
@@ -157,12 +157,12 @@ export function TermsRoute(_handle: Handle) {
 					To the fullest extent the law permits, Kody and its operator will not
 					be liable for indirect, incidental, special, consequential, exemplary,
 					or punitive damages, or for lost profits, data, goodwill, or business.
-					This includes damages arising from actions your agent, or code you
-					run or install, takes with integrations, secrets, or other access
-					you grant it — on Kody or on third-party services. Our total
-					liability for any claim is limited to the amount you paid Kody
-					during the 12 months before the event giving rise to the claim.
-					These limits do not apply where the law does not allow them.
+					This includes damages arising from actions your agent, or code you run
+					or install, takes with integrations, secrets, or other access you
+					grant it — on Kody or on third-party services. Our total liability for
+					any claim is limited to the amount you paid Kody during the 12 months
+					before the event giving rise to the claim. These limits do not apply
+					where the law does not allow them.
 				</p>
 			</section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kody is a set of primitives and makes no guarantees about what a user's agent does with them. This PR makes that — and the resulting liability posture — explicit in three places:

1. **Terms** (`terms.tsx`): a new **"Your agent, your access"** section between "Acceptable use" and "Plans, billing, and refunds". Three paragraphs: Kody does not control, review, or supervise agents or the models behind them; connecting an integration (built-in or BYO) or storing a secret authorizes the user's agent and any code they run to act as them, and those actions are their actions on third-party services (whose own terms they must honor); and a disclaimer that the operator is not liable for what the agent or installed code does with granted access. The existing "Limits on liability" section now also names agent actions with granted access explicitly.
2. **Point of grant** (`connect-oauth.tsx`): a short note above the Connect button — "Connecting authorizes your agent — and any code you run or install — to act as you on {provider}... Kody does not control or supervise what your agent does with this access; that responsibility is yours." — linking to the Terms. This covers both lanes since every connect flows through this card.
3. **Docs** (`docs/use/secrets-and-values.md`): the built-in integrations section carries the same responsibility line.

## Notes

- Plain-language drafting consistent with the existing terms style; the pre-existing bracketed placeholders (age requirement, governing law) are untouched and still await operator confirmation. A lawyer review before opening signups broadly is still advisable.

## Testing

`npm run validate` green. Both surfaces verified in the browser:

![Terms: Your agent, your access section](https://cursor.com/artifacts/c/art-52879efd-f878-4e4d-87e9-02e1a8b716cb)

![Connect page responsibility note above the Connect button](https://cursor.com/artifacts/c/art-5e87a08a-62bb-42de-99c4-51553066de31)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

