### PR TITLE
Lead onboarding step 3 with built-in integration cards

### DIFF
--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -33,7 +33,7 @@ as your own secrets, the same as any other integration.
 Built-in or not, a connection authorizes _your_ agent — and any code you run or
 install — to act as you on that provider. Kody does not control or supervise
 what your agent does with the access you grant; scope connections deliberately
-and revoke ones you no longer use. See the [Terms](/terms).
+and revoke unused ones. See the [Terms](/terms).
 
 ## Placeholders in `fetch` and capability inputs
 

--- a/packages/worker/client/routes/onboarding-diy-card.tsx
+++ b/packages/worker/client/routes/onboarding-diy-card.tsx
@@ -6,10 +6,13 @@ import {
 	starterCardCss,
 	starterCopyPromptTooltipCss,
 	starterGhostButtonCss,
+	starterRowCss,
 } from '#client/routes/onboarding-starter-card.tsx'
 
 type OnboardingDiyCardProps = {
 	setupPrompt: string
+	/** `row` matches the compact "Advanced" starter list. */
+	variant?: 'card' | 'row'
 }
 
 const copyPromptTooltip =
@@ -41,34 +44,43 @@ export function OnboardingDiyCard(handle: Handle<OnboardingDiyCardProps>) {
 		}, 2000)
 	}
 
-	return () => (
-		<li mix={css(diyCardCss)} data-testid="onboarding-diy-card">
-			<div mix={css(diyBodyCss)}>
-				<em mix={css(diyEyebrowCss)}>Build it yourself</em>
-				<strong mix={css(diyTitleCss)}>Choose your own adventure</strong>
-				<span mix={css(diyDescriptionCss)}>
-					Skip the starters and ask your agent what Kody can do — connect an
-					integration, explore, and build something custom.
-				</span>
-			</div>
-			<button
-				type="button"
-				aria-describedby="onboarding-diy-prompt-tip"
-				disabled={!handle.props.setupPrompt}
-				mix={[css(diyCopyButtonCss), on('click', () => void copyPrompt())]}
-				data-testid="onboarding-diy-copy"
+	return () => {
+		const isRow = handle.props.variant === 'row'
+		return (
+			<li
+				mix={css(isRow ? diyRowCss : diyCardCss)}
+				data-testid="onboarding-diy-card"
 			>
-				{copyState === 'copied'
-					? 'Copied'
-					: copyState === 'error'
-						? 'Copy failed'
-						: 'Copy prompt'}
-				<span id="onboarding-diy-prompt-tip" role="tooltip">
-					{copyPromptTooltip}
-				</span>
-			</button>
-		</li>
-	)
+				<div mix={css(isRow ? diyRowBodyCss : diyBodyCss)}>
+					<em mix={css(diyEyebrowCss)}>Build it yourself</em>
+					<strong mix={css(diyTitleCss)}>Choose your own adventure</strong>
+					<span mix={css(diyDescriptionCss)}>
+						Skip the starters and ask your agent what Kody can do — connect an
+						integration, explore, and build something custom.
+					</span>
+				</div>
+				<button
+					type="button"
+					aria-describedby="onboarding-diy-prompt-tip"
+					disabled={!handle.props.setupPrompt}
+					mix={[
+						css(isRow ? diyRowCopyButtonCss : diyCopyButtonCss),
+						on('click', () => void copyPrompt()),
+					]}
+					data-testid="onboarding-diy-copy"
+				>
+					{copyState === 'copied'
+						? 'Copied'
+						: copyState === 'error'
+							? 'Copy failed'
+							: 'Copy prompt'}
+					<span id="onboarding-diy-prompt-tip" role="tooltip">
+						{copyPromptTooltip}
+					</span>
+				</button>
+			</li>
+		)
+	}
 }
 
 const diyCardCss = {
@@ -108,4 +120,27 @@ const diyDescriptionCss = {
 const diyCopyButtonCss = {
 	...starterGhostButtonCss,
 	...starterCopyPromptTooltipCss,
+}
+
+const diyRowCss = {
+	...starterRowCss,
+	borderStyle: 'dashed' as const,
+	backgroundColor: `oklch(from ${colors.primary} l c h / 0.07)`,
+}
+
+const diyRowBodyCss = {
+	flex: 1,
+	display: 'grid',
+	gap: '0.1rem',
+	minWidth: 'min(16rem, 100%)',
+	textAlign: 'left' as const,
+	justifyItems: 'start',
+}
+
+const diyRowCopyButtonCss = {
+	...starterGhostButtonCss,
+	...starterCopyPromptTooltipCss,
+	width: 'auto',
+	flex: 'none',
+	fontSize: '0.9rem',
 }

--- a/packages/worker/client/routes/onboarding-starter-card.tsx
+++ b/packages/worker/client/routes/onboarding-starter-card.tsx
@@ -22,6 +22,12 @@ import {
 type OnboardingStarterCardProps = {
 	listing: OnboardingFeaturedListing
 	loggedIn: boolean
+	/**
+	 * `card`: the centered grid tile (default). `row`: the compact list item
+	 * used when built-in integrations own the step-3 spotlight and starter
+	 * packages demote to an "Advanced" list.
+	 */
+	variant?: 'card' | 'row'
 }
 
 type InstallApiPayload = {
@@ -135,6 +141,7 @@ export function OnboardingStarterCard(
 
 	return () => {
 		const { listing } = handle.props
+		const isRow = handle.props.variant === 'row'
 		const detailHref = routes.communityDetail.href({ listingId: listing.id })
 		const existingInstall = listing.viewerInstall ?? null
 		const readyPrompt = agentPrompt ?? existingInstall?.agentPrompt ?? null
@@ -149,27 +156,41 @@ export function OnboardingStarterCard(
 
 		return (
 			<li
-				mix={css(starterCardCss)}
+				mix={css(isRow ? starterRowCss : starterCardCss)}
 				data-testid={`onboarding-starter-${listing.id}`}
 			>
 				<a
 					href={detailHref}
 					target="_blank"
 					rel="noreferrer noopener"
-					mix={css(starterCardLinkCss)}
+					mix={css(isRow ? starterRowLinkCss : starterCardLinkCss)}
 				>
-					<CommunityListingIcon listing={listing} size="starter" />
-					<strong mix={css(starterCardNameCss)}>{listing.name}</strong>
-					<span mix={css(starterCardDescriptionCss)}>
-						{listing.description}
-					</span>
+					<CommunityListingIcon
+						listing={listing}
+						size={isRow ? 'card' : 'starter'}
+					/>
+					{isRow ? (
+						<span mix={css(starterRowTextCss)}>
+							<strong mix={css(starterCardNameCss)}>{listing.name}</strong>
+							<span mix={css(starterCardDescriptionCss)}>
+								{listing.description}
+							</span>
+						</span>
+					) : (
+						<>
+							<strong mix={css(starterCardNameCss)}>{listing.name}</strong>
+							<span mix={css(starterCardDescriptionCss)}>
+								{listing.description}
+							</span>
+						</>
+					)}
 				</a>
 				{showCopyPrompt ? (
 					<button
 						type="button"
 						aria-describedby={`onboarding-starter-prompt-tip-${listing.id}`}
 						mix={[
-							css(copyPromptButtonCss),
+							css(isRow ? rowCopyPromptButtonCss : copyPromptButtonCss),
 							on('click', () => void copyPrompt(readyPrompt)),
 						]}
 						data-testid={`onboarding-starter-copy-${listing.id}`}
@@ -191,7 +212,7 @@ export function OnboardingStarterCard(
 						type="button"
 						disabled={phase === 'installing'}
 						mix={[
-							css(installButtonCss),
+							css(isRow ? rowInstallButtonCss : installButtonCss),
 							on('click', () => void submitInstall()),
 						]}
 						data-testid={`onboarding-starter-install-${listing.id}`}
@@ -201,7 +222,7 @@ export function OnboardingStarterCard(
 				)}
 				{readyStatus ? (
 					<p
-						mix={css(starterStatusCss)}
+						mix={css(isRow ? starterRowStatusCss : starterStatusCss)}
 						role="status"
 						data-testid={`onboarding-starter-status-${listing.id}`}
 					>
@@ -210,7 +231,7 @@ export function OnboardingStarterCard(
 				) : null}
 				{errorMessage ? (
 					<p
-						mix={css(starterErrorCss)}
+						mix={css(isRow ? starterRowErrorCss : starterErrorCss)}
 						role="alert"
 						data-testid={`onboarding-starter-error-${listing.id}`}
 					>
@@ -354,6 +375,57 @@ const copyPromptButtonCss = {
 	...starterCopyPromptTooltipCss,
 }
 
+/* Compact "Advanced" list row: icon + text left, action right, status wraps
+   to a full-width line beneath. */
+export const starterRowCss = {
+	display: 'flex',
+	flexWrap: 'wrap' as const,
+	alignItems: 'center',
+	gap: '0.7rem 0.9rem',
+	backgroundColor: colors.background,
+	border: `1.5px solid ${colors.border}`,
+	borderRadius: radius.card,
+	padding: '0.7rem 0.9rem',
+	minWidth: 0,
+	transition: `border-color 160ms ${transitions.easeOut}`,
+	[hoverMq]: {
+		'&:hover': {
+			borderColor: colors.primary,
+		},
+		'&:hover a strong': {
+			color: colors.primaryText,
+		},
+	},
+}
+
+const starterRowLinkCss = {
+	flex: 1,
+	display: 'flex',
+	alignItems: 'center',
+	gap: '0.7rem',
+	textDecoration: 'none',
+	color: 'inherit',
+	minWidth: 'min(16rem, 100%)',
+}
+
+const starterRowTextCss = {
+	display: 'grid',
+	gap: '0.1rem',
+	minWidth: 0,
+	textAlign: 'left' as const,
+}
+
+const rowActionButtonSizeCss = {
+	width: 'auto',
+	flex: 'none',
+	fontSize: '0.9rem',
+}
+
+const rowInstallButtonCss = {
+	...getPillButtonCss(),
+	...rowActionButtonSizeCss,
+}
+
 /* Install confirmation pops in like the wizard checks. */
 const starterStatusCss = {
 	margin: 0,
@@ -369,4 +441,22 @@ const starterErrorCss = {
 	...starterStatusCss,
 	color: colors.error,
 	textWrap: 'pretty' as const,
+}
+
+const rowCopyPromptButtonCss = {
+	...getPillButtonCss(),
+	...rowActionButtonSizeCss,
+	...starterCopyPromptTooltipCss,
+}
+
+const starterRowStatusCss = {
+	...starterStatusCss,
+	flexBasis: '100%',
+	textAlign: 'left' as const,
+}
+
+const starterRowErrorCss = {
+	...starterErrorCss,
+	flexBasis: '100%',
+	textAlign: 'left' as const,
 }

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -32,7 +32,11 @@ import {
 	shouldShowOnboardingChecklist,
 } from '#client/routes/onboarding-checklist.tsx'
 import { OnboardingMcpClientTabs } from '#client/routes/onboarding-mcp-client-tabs.tsx'
-import { OnboardingStarterCard } from '#client/routes/onboarding-starter-card.tsx'
+import {
+	OnboardingStarterCard,
+	starterCardCss,
+} from '#client/routes/onboarding-starter-card.tsx'
+import { ProviderIcon } from '#client/provider-icons.tsx'
 import {
 	onboardingPath,
 	resolveOnboardingPendingVerificationPath,
@@ -55,11 +59,16 @@ import {
 /**
  * Onboarding wizard, ported from the redesign prototype
  * (`landing/onboarding.html`): shirt-pattern head, four-step stepper
- * (Connect your agent · See it work · Install a starter package), one surface
+ * (Connect your agent · See it work · Connect your tools), one surface
  * panel at a time with hand-tilted mascot art, and the BYOK argument folded
  * behind a disclosure. All server state (prompts, MCP URL, featured
  * listings, hasMcpClient / first-win polling) stays in the route state —
  * this is a restyle, not a rearchitecture.
+ *
+ * Step 3 leads with built-in integration cards (the path of least
+ * resistance) when the deployment has any enabled; starter packages demote
+ * to a compact "Advanced" list. With no built-ins, packages keep the card
+ * grid.
  */
 
 type OnboardingStep = 1 | 2 | 3
@@ -70,7 +79,7 @@ type FirstWinSubStep = 1 | 2 | 3
 const onboardingSteps = [
 	{ number: 1, label: 'Connect your agent', hash: 'connect-agent' },
 	{ number: 2, label: 'See it work', hash: 'first-win' },
-	{ number: 3, label: 'Install a starter package', hash: 'starter-packages' },
+	{ number: 3, label: 'Connect your tools', hash: 'starter-packages' },
 ] as const satisfies ReadonlyArray<{
 	number: OnboardingStep
 	label: string
@@ -788,7 +797,7 @@ export function OnboardingRoute(handle: Handle) {
 											tabIndex={-1}
 											mix={css(panelTitleCss)}
 										>
-											Install a starter package
+											Connect your tools
 										</h2>
 									</div>
 									<img
@@ -803,33 +812,44 @@ export function OnboardingRoute(handle: Handle) {
 									/>
 								</div>
 								{builtInProviders.length > 0 ? (
-									<div
-										data-testid="onboarding-built-in-integrations"
-										mix={css(builtInCalloutCss)}
-									>
-										<p mix={css(builtInLabelCss)}>Use a built-in integration</p>
-										<p mix={css(builtInLedeCss)}>
-											Connect in one click — Kody hosts the provider app, so
-											there is nothing to register.
+									<>
+										<p mix={css(panelLedeCss)}>
+											Connect a built-in integration in one click — Kody hosts
+											the provider app, so there is nothing to register.
 										</p>
-										<ul mix={css(builtInListCss)}>
+										<ul
+											mix={css(starterGridCss)}
+											data-testid="onboarding-built-in-integrations"
+										>
 											{builtInProviders.map((provider) => (
-												<li key={provider.slug}>
+												<li key={provider.slug} mix={css(providerCardCss)}>
 													<a
 														href={`/connect/oauth?provider=${encodeURIComponent(provider.slug)}`}
-														mix={css(builtInLinkCss)}
+														mix={css(providerCardLinkCss)}
 													>
-														{provider.logoPath ? (
-															<img
-																src={provider.logoPath}
-																alt=""
-																width={20}
-																height={20}
-																loading="lazy"
-																mix={css(builtInLogoCss)}
-															/>
-														) : null}
-														{provider.label}
+														<span mix={css(providerIconWellCss)}>
+															{provider.logoPath ? (
+																<img
+																	src={provider.logoPath}
+																	alt=""
+																	width={30}
+																	height={30}
+																	loading="lazy"
+																	mix={css(providerLogoCss)}
+																/>
+															) : (
+																<ProviderIcon
+																	providerId={provider.slug}
+																	size="30"
+																/>
+															)}
+														</span>
+														<strong mix={css(providerCardNameCss)}>
+															{provider.label}
+														</strong>
+														<span mix={css(providerConnectPillCss)}>
+															Connect
+														</span>
 													</a>
 												</li>
 											))}
@@ -841,33 +861,71 @@ export function OnboardingRoute(handle: Handle) {
 											</a>{' '}
 											for more power.
 										</p>
-									</div>
-								) : null}
-								<p mix={css(panelLedeCss)}>
-									{featuredListings.length > 0
-										? 'These packages were reviewed by an admin and support one-click install here. After install, use Copy prompt so your agent can finish any remaining setup — or pick Choose your own adventure to explore with your agent instead.'
-										: 'No featured starters are available right now. Copy the Choose your own adventure prompt to explore with your agent, or browse community packages.'}
-								</p>
-								<ul mix={css(starterGridCss)}>
-									{featuredListings.map((listing) => (
-										<OnboardingStarterCard
-											key={listing.id}
-											listing={listing}
-											loggedIn={loggedIn}
-										/>
-									))}
-									<OnboardingDiyCard setupPrompt={setupPrompt} />
-								</ul>
-								<p mix={css({ margin: '0.2rem 0 0' })}>
-									<a
-										href="/community"
-										target="_blank"
-										rel="noreferrer noopener"
-										mix={css(primaryLinkCss)}
-									>
-										Browse all community packages
-									</a>
-								</p>
+										<div mix={css(advancedSectionCss)}>
+											<p mix={css(advancedLabelCss)}>
+												Starter packages
+												<span mix={css(advancedBadgeCss)}>Advanced</span>
+											</p>
+											<p mix={css(advancedLedeCss)}>
+												{featuredListings.length > 0
+													? 'Admin-reviewed packages with one-click install. After install, use Copy prompt so your agent can finish any remaining setup.'
+													: 'No featured starters are available right now. Copy the Choose your own adventure prompt to explore with your agent, or browse community packages.'}
+											</p>
+											<ul mix={css(starterListCss)}>
+												{featuredListings.map((listing) => (
+													<OnboardingStarterCard
+														key={listing.id}
+														listing={listing}
+														loggedIn={loggedIn}
+														variant="row"
+													/>
+												))}
+												<OnboardingDiyCard
+													setupPrompt={setupPrompt}
+													variant="row"
+												/>
+											</ul>
+											<p mix={css({ margin: '0.2rem 0 0' })}>
+												<a
+													href="/community"
+													target="_blank"
+													rel="noreferrer noopener"
+													mix={css(primaryLinkCss)}
+												>
+													Browse all community packages
+												</a>
+											</p>
+										</div>
+									</>
+								) : (
+									<>
+										<p mix={css(panelLedeCss)}>
+											{featuredListings.length > 0
+												? 'These packages were reviewed by an admin and support one-click install here. After install, use Copy prompt so your agent can finish any remaining setup — or pick Choose your own adventure to explore with your agent instead.'
+												: 'No featured starters are available right now. Copy the Choose your own adventure prompt to explore with your agent, or browse community packages.'}
+										</p>
+										<ul mix={css(starterGridCss)}>
+											{featuredListings.map((listing) => (
+												<OnboardingStarterCard
+													key={listing.id}
+													listing={listing}
+													loggedIn={loggedIn}
+												/>
+											))}
+											<OnboardingDiyCard setupPrompt={setupPrompt} />
+										</ul>
+										<p mix={css({ margin: '0.2rem 0 0' })}>
+											<a
+												href="/community"
+												target="_blank"
+												rel="noreferrer noopener"
+												mix={css(primaryLinkCss)}
+											>
+												Browse all community packages
+											</a>
+										</p>
+									</>
+								)}
 								{/* The last step doubles as the "what's left" recap, so the
 								    derived checklist lives here instead of distracting from
 								    the earlier steps. */}
@@ -1476,67 +1534,106 @@ function connectStatusContent(input: {
 	]
 }
 
-/* Built-in integrations: an accent well above the starter grid so the
-   one-click path reads first, with BYO as the power-user footnote. */
-const builtInCalloutCss = {
-	...getAccentCalloutCss(),
-	display: 'grid',
-	gap: '0.55rem',
+/* Built-in integrations lead step 3 as full cards — the path of least
+   resistance reads first, with BYO as the power-user footnote. */
+const providerCardCss = {
+	...starterCardCss,
 }
 
-const builtInLabelCss = {
-	margin: 0,
-	font: `700 0.78rem/1 ${typography.fontFamilyBody}`,
-	letterSpacing: '0.06em',
-	textTransform: 'uppercase' as const,
-	color: colors.primaryText,
-}
-
-const builtInLedeCss = {
-	margin: 0,
-	color: colors.textMuted,
-	fontSize: '0.94rem',
-	lineHeight: 1.55,
-}
-
-const builtInListCss = {
-	listStyle: 'none',
-	margin: 0,
-	padding: 0,
+const providerCardLinkCss = {
+	flex: 1,
 	display: 'flex',
-	flexWrap: 'wrap' as const,
-	gap: '0.6rem',
-}
-
-const builtInLinkCss = {
-	display: 'inline-flex',
+	flexDirection: 'column' as const,
 	alignItems: 'center',
-	gap: '0.45rem',
-	padding: '0.5rem 0.95rem',
-	borderRadius: radius.full,
-	backgroundColor: colors.surface,
-	boxShadow: `inset 0 0 0 1.5px ${colors.border}`,
-	color: colors.text,
-	fontWeight: 600,
+	gap: '0.65rem',
 	textDecoration: 'none',
-	transition: `box-shadow ${transitions.fast}, transform ${transitions.fast}`,
-	[hoverMq]: {
-		'&:hover': {
-			boxShadow: `inset 0 0 0 1.5px ${colors.primary}`,
-			transform: 'translateY(-1px)',
-		},
-	},
+	color: 'inherit',
+	minWidth: 0,
 }
 
-const builtInLogoCss = {
+/* Same rounded well as CommunityListingIcon size="starter". */
+const providerIconWellCss = {
+	display: 'grid',
+	placeItems: 'center',
+	width: '3.2rem',
+	height: '3.2rem',
+	borderRadius: '12px',
+	border: `1px solid ${colors.border}`,
+	backgroundColor: colors.surface,
+	marginBottom: '0.2rem',
+	transition: `border-color 160ms ${transitions.easeOut}`,
+}
+
+const providerLogoCss = {
 	display: 'block',
 	borderRadius: '4px',
+}
+
+const providerCardNameCss = {
+	color: colors.text,
+	fontWeight: 650,
+	fontSize: '0.98rem',
+}
+
+const providerConnectPillCss = {
+	...getPillButtonCss(),
+	marginTop: 'auto',
+	width: '100%',
+	fontSize: '0.95rem',
+	textAlign: 'center' as const,
 }
 
 const builtInByoCss = {
 	margin: 0,
 	color: colors.textMuted,
 	fontSize: '0.9rem',
+}
+
+/* Starter packages demote to a labeled "Advanced" list under the cards. */
+const advancedSectionCss = {
+	display: 'grid',
+	gap: '0.55rem',
+	marginTop: '0.6rem',
+	paddingTop: '1.1rem',
+	borderTop: `1px solid ${colors.border}`,
+}
+
+const advancedLabelCss = {
+	margin: 0,
+	display: 'flex',
+	alignItems: 'center',
+	gap: '0.5rem',
+	font: `700 0.78rem/1 ${typography.fontFamilyBody}`,
+	letterSpacing: '0.06em',
+	textTransform: 'uppercase' as const,
+	color: colors.textMuted,
+}
+
+const advancedBadgeCss = {
+	display: 'inline-block',
+	padding: '0.18rem 0.5rem',
+	borderRadius: radius.full,
+	border: `1px solid ${colors.border}`,
+	backgroundColor: colors.surface,
+	font: `700 0.68rem/1 ${typography.fontFamilyBody}`,
+	letterSpacing: '0.06em',
+	color: colors.textMuted,
+}
+
+const advancedLedeCss = {
+	margin: 0,
+	color: colors.textMuted,
+	fontSize: '0.92rem',
+	lineHeight: 1.55,
+	maxWidth: '68ch',
+}
+
+const starterListCss = {
+	listStyle: 'none',
+	margin: '0.2rem 0 0',
+	padding: 0,
+	display: 'grid',
+	gap: '0.6rem',
 }
 
 /* Starter packages: compact centered cards; the DIY card breaks the grid

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -55,7 +55,7 @@ async function loadHasSentWelcomeEmail(
 	return await userHasSentWelcomeEmail({ env, userId })
 }
 
-const onboardingBuiltInProviderLimit = 3
+const onboardingBuiltInProviderLimit = 6
 
 /**
  * Top enabled built-in integrations by adoption, offered as one-click


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Swaps the emphasis in onboarding step 3 so the path of least resistance reads first:

- **Built-in integrations are now the primary card grid** — the top **six** enabled platform apps by use (up from three), each card with the provider logo in a rounded well (falling back to the built-in `ProviderIcon` set), the label, and a "Connect" pill linking to `/connect/oauth?provider={slug}`. The "Bring your own OAuth app" line sits under the grid.
- **Starter packages demote to a compact list** under a small-caps "Starter packages" label with an "Advanced" badge: `OnboardingStarterCard` and `OnboardingDiyCard` gain a `row` variant (icon + text left, Install/Copy action right, status wrapping beneath) that reuses all the existing install/copy logic and test ids.
- **The step retitles** from "Install a starter package" to "Connect your tools" (stepper + panel title; hash unchanged so deep links keep working).
- Deployments with **no enabled built-ins keep the original layout** — package cards as the grid under the original lede.

## Testing

- `npm run validate` green (also fixed a docs temporal-language check hit: the built-ins doc line from #1348 said "no longer use", which the checker reads as rollout language; reworded to "unused ones").
- Verified in the browser against six seeded local providers: card grid renders GitHub/Google/Notion/Slack/Discord/Spotify with icons, the GitHub card lands on the built-in connect page, and the advanced section shows the compact list treatment with the DIY row.

![Step 3 leading with six provider cards](https://cursor.com/artifacts/c/art-fcffefa9-e3a5-487e-9790-7ed96d4dfaa7)

![Advanced starter packages list below the cards](https://cursor.com/artifacts/c/art-c66d337c-6c46-44fd-9da7-cf87608aedd2)

<a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_builtins_first_redesign_demo.mp4"><img src="https://cursor.com/artifacts/c/art-13d99257-ba18-49b7-9ae1-21bd08bb1dea" alt="onboarding_builtins_first_redesign_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned onboarding step 3 as “Connect your tools.”
  * Added prominent built-in integration cards with logos, status indicators, and direct OAuth connections.
  * Added an Advanced section with compact starter-package rows.
  * Increased the number of built-in integrations shown from three to six.

* **Documentation**
  * Updated host-approval guidance to recommend revoking unused connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->