### PR TITLE
Keep confidential platform OAuth staging mistakes off Sentry

### DIFF
--- a/packages/worker/src/integrations/platform-apps.node.test.ts
+++ b/packages/worker/src/integrations/platform-apps.node.test.ts
@@ -9,6 +9,7 @@ import {
 	getPlatformOauthAppClientSecret,
 	listPlatformOauthApps,
 	listTopPlatformAppsByUse,
+	PlatformOauthAppValidationError,
 	upsertPlatformOauthApp,
 } from './platform-apps.ts'
 
@@ -155,14 +156,15 @@ test('partial saves retain omitted fields instead of clearing them', async () =>
 
 test('confidential flow requires a client secret only while enabled', async () => {
 	const { db, env } = createHarness()
-	// Enabled (default) without a secret is rejected.
+	// Enabled (default) without a secret is rejected as a validation error
+	// (MCP re-wraps this as McpCallerError so it stays off Sentry).
 	await expect(
 		upsertPlatformOauthApp({
 			db,
 			env,
 			app: { ...baseGithubApp, clientSecret: null },
 		}),
-	).rejects.toThrow('Confidential flow requires a client secret')
+	).rejects.toBeInstanceOf(PlatformOauthAppValidationError)
 
 	// Staged provisioning: a disabled app saves without a secret so an
 	// operator can paste credentials later.
@@ -190,7 +192,7 @@ test('confidential flow requires a client secret only while enabled', async () =
 				enabled: true,
 			},
 		}),
-	).rejects.toThrow('Confidential flow requires a client secret')
+	).rejects.toBeInstanceOf(PlatformOauthAppValidationError)
 
 	// Once the secret lands, enabling works.
 	const live = await upsertPlatformOauthApp({

--- a/packages/worker/src/integrations/platform-apps.ts
+++ b/packages/worker/src/integrations/platform-apps.ts
@@ -10,6 +10,19 @@ import {
 } from '#mcp/capabilities/integrations/integration-shared.ts'
 
 /**
+ * Operator-fixable input rejection while saving a platform OAuth app
+ * (missing required fields, enabling a confidential app without a secret).
+ * MCP capabilities re-wrap this as `McpCallerError` so agent staging mistakes
+ * stay on `mcp-event` lines and out of Sentry.
+ */
+export class PlatformOauthAppValidationError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'PlatformOauthAppValidationError'
+	}
+}
+
+/**
  * Operator-provisioned built-in OAuth apps shared across every user.
  *
  * The client secret is stored encrypted in `platform_oauth_apps` and is
@@ -170,16 +183,22 @@ export async function upsertPlatformOauthApp(input: {
 }): Promise<PlatformOauthApp> {
 	const slug = canonicalIntegrationName(input.app.slug)
 	if (!slug) {
-		throw new Error('Platform app slug must contain letters or numbers.')
+		throw new PlatformOauthAppValidationError(
+			'Platform app slug must contain letters or numbers.',
+		)
 	}
 	const clientId = input.app.clientId.trim()
 	if (!clientId) {
-		throw new Error('Client id is required.')
+		throw new PlatformOauthAppValidationError('Client id is required.')
 	}
 	const tokenUrl = input.app.tokenUrl.trim()
 	const authorizeUrl = input.app.authorizeUrl.trim()
-	if (!tokenUrl) throw new Error('Token URL is required.')
-	if (!authorizeUrl) throw new Error('Authorize URL is required.')
+	if (!tokenUrl) {
+		throw new PlatformOauthAppValidationError('Token URL is required.')
+	}
+	if (!authorizeUrl) {
+		throw new PlatformOauthAppValidationError('Authorize URL is required.')
+	}
 
 	const existing = await getPlatformOauthAppRowBySlug({ db: input.db, slug })
 	const clientSecretEncrypted =
@@ -202,7 +221,7 @@ export async function upsertPlatformOauthApp(input: {
 	// enables) later; the secret becomes mandatory the moment the app is
 	// reachable by users.
 	if (enabled && input.app.flow === 'confidential' && !clientSecretEncrypted) {
-		throw new Error(
+		throw new PlatformOauthAppValidationError(
 			'Confidential flow requires a client secret before the app can be enabled. Save it with enabled: false to stage the config first.',
 		)
 	}

--- a/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-capabilities.node.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 
 // These tests assert real `audit_events` rows written through the actual
@@ -151,4 +152,59 @@ test('save keeps the stored secret on update and can disable an app', async () =
 			slug: 'github',
 		}),
 	).resolves.toBe('platform-github-client-secret-value')
+})
+
+test('enabling a confidential app without a client secret is an McpCallerError', async () => {
+	const { ctx, auditSqlite } = createHarness()
+	await expect(
+		adminPlatformOauthAppSaveCapability.handler(
+			{
+				slug: 'github',
+				clientId: saveInput.clientId,
+				clientSecret: null,
+				tokenUrl: saveInput.tokenUrl,
+				authorizeUrl: saveInput.authorizeUrl,
+				flow: 'confidential',
+			},
+			ctx,
+		),
+	).rejects.toBeInstanceOf(McpCallerError)
+
+	const staged = await adminPlatformOauthAppSaveCapability.handler(
+		{
+			slug: 'github',
+			clientId: saveInput.clientId,
+			clientSecret: null,
+			tokenUrl: saveInput.tokenUrl,
+			authorizeUrl: saveInput.authorizeUrl,
+			flow: 'confidential',
+			enabled: false,
+		},
+		ctx,
+	)
+	expect(staged.app.enabled).toBe(false)
+
+	await expect(
+		adminPlatformOauthAppSaveCapability.handler(
+			{
+				slug: 'github',
+				clientId: saveInput.clientId,
+				tokenUrl: saveInput.tokenUrl,
+				authorizeUrl: saveInput.authorizeUrl,
+				flow: 'confidential',
+				enabled: true,
+			},
+			ctx,
+		),
+	).rejects.toBeInstanceOf(McpCallerError)
+
+	const failures = auditSqlite
+		.prepare(
+			`SELECT action, result FROM audit_events WHERE result = 'failure' ORDER BY id ASC`,
+		)
+		.all() as Array<{ action: string; result: string }>
+	expect(failures).toEqual([
+		{ action: 'admin_platform_oauth_app_save', result: 'failure' },
+		{ action: 'admin_platform_oauth_app_save', result: 'failure' },
+	])
 })

--- a/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
@@ -11,7 +12,10 @@ import {
 } from '#mcp/capabilities/integrations/platform-app-shared.ts'
 import { base64ToBytes } from '@kody-internal/shared/base64.ts'
 import { setPlatformOauthAppLogo } from '#worker/integrations/platform-app-logo.ts'
-import { upsertPlatformOauthApp } from '#worker/integrations/platform-apps.ts'
+import {
+	PlatformOauthAppValidationError,
+	upsertPlatformOauthApp,
+} from '#worker/integrations/platform-apps.ts'
 import {
 	adminMutationCapabilityAccess,
 	auditAdminCapabilityInvocation,
@@ -94,44 +98,54 @@ export const adminPlatformOauthAppSaveCapability = defineDomainCapability(
 				ctx,
 				'admin_platform_oauth_app_save',
 				async () => {
-					// Omitted optional fields stay `undefined` so the upsert's
-					// retain-on-omit semantics apply: a partial save never
-					// silently clears the scope menu, hosts, or stored secret.
-					let app = await upsertPlatformOauthApp({
-						db: ctx.env.APP_DB,
-						env: ctx.env,
-						app: {
-							slug: args.slug,
-							provider: args.provider,
-							label: args.label,
-							clientId: args.clientId,
-							clientSecret: args.clientSecret,
-							tokenUrl: args.tokenUrl,
-							authorizeUrl: args.authorizeUrl,
-							apiBaseUrl: args.apiBaseUrl,
-							flow: args.flow,
-							usePkce: args.usePkce,
-							tokenExchangeStyle: args.tokenExchangeStyle,
-							scopeSeparator: args.scopeSeparator,
-							extraAuthorizeParams: args.extraAuthorizeParams,
-							allowedScopes: args.allowedScopes,
-							defaultScopes: args.defaultScopes,
-							requiredHosts: args.requiredHosts,
-							enabled: args.enabled,
-						},
-					})
-					if (args.logoBase64 !== undefined) {
-						app = await setPlatformOauthAppLogo({
+					try {
+						// Omitted optional fields stay `undefined` so the upsert's
+						// retain-on-omit semantics apply: a partial save never
+						// silently clears the scope menu, hosts, or stored secret.
+						let app = await upsertPlatformOauthApp({
 							db: ctx.env.APP_DB,
 							env: ctx.env,
-							slug: app.slug,
-							sourceBytes:
-								args.logoBase64 === null
-									? null
-									: base64ToBytes(args.logoBase64),
+							app: {
+								slug: args.slug,
+								provider: args.provider,
+								label: args.label,
+								clientId: args.clientId,
+								clientSecret: args.clientSecret,
+								tokenUrl: args.tokenUrl,
+								authorizeUrl: args.authorizeUrl,
+								apiBaseUrl: args.apiBaseUrl,
+								flow: args.flow,
+								usePkce: args.usePkce,
+								tokenExchangeStyle: args.tokenExchangeStyle,
+								scopeSeparator: args.scopeSeparator,
+								extraAuthorizeParams: args.extraAuthorizeParams,
+								allowedScopes: args.allowedScopes,
+								defaultScopes: args.defaultScopes,
+								requiredHosts: args.requiredHosts,
+								enabled: args.enabled,
+							},
 						})
+						if (args.logoBase64 !== undefined) {
+							app = await setPlatformOauthAppLogo({
+								db: ctx.env.APP_DB,
+								env: ctx.env,
+								slug: app.slug,
+								sourceBytes:
+									args.logoBase64 === null
+										? null
+										: base64ToBytes(args.logoBase64),
+							})
+						}
+						return { app: toPlatformOauthAppPublic(app) }
+					} catch (error) {
+						// Staging/enable mistakes (secretless confidential while
+						// enabled, empty required fields) are caller-clearable —
+						// keep them off Sentry via McpCallerError.
+						if (error instanceof PlatformOauthAppValidationError) {
+							throw new McpCallerError(error.message, { cause: error })
+						}
+						throw error
 					}
-					return { app: toPlatformOauthAppPublic(app) }
 				},
 				{
 					successReason: ({ app }) => `platform_oauth_app=${app.slug}`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to #1345 / Sentry [KODY-CLOUDFLARE-4G](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7662130627/): classify caller-fixable `upsertPlatformOauthApp` rejects as `PlatformOauthAppValidationError`, and re-wrap them as `McpCallerError` in `admin_platform_oauth_app_save`.

## Why

The single production event was an agent enabling a confidential platform app without a client secret (release before #1345). Staging without a secret while `enabled: false` already works; enabling without a secret is still a valid reject, but it must not open Sentry issues that look like platform bugs and trip triage.

## Testing

- Node unit: confidential secret lifecycle asserts `PlatformOauthAppValidationError`
- Node unit: capability path asserts `McpCallerError` for enable-without-secret (default and staged→enable)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `9faafa09` · **Head:** `307b0445`

**Classification:** composes — wires the existing `McpCallerError` / caller-failure observability path onto platform OAuth app input validation; no new primitives or auth semantics.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `integrations` | assistant | composes — typed validation error for secretless confidential enable |
| `rbac` | auth | composes — admin save capability re-wraps validation as `McpCallerError` |

### System map

Admin MCP save validates platform OAuth apps and keeps staging mistakes off Sentry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	rbac["rbac<br/>Admin MCP save"]:::touched
	integrations["integrations<br/>Platform OAuth apps"]:::touched
	rbac -->|"upsert + wrap validation"| integrations
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc8e2f10-f5ec-4e44-899f-355b8c801eed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc8e2f10-f5ec-4e44-899f-355b8c801eed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for platform OAuth app settings, including required identifiers, URLs, and client secrets.
  * Prevented confidential OAuth apps from being enabled without a client secret.
  * Displayed clearer, actionable errors when OAuth app configuration is invalid.
  * Preserved the ability to save apps in a disabled state while configuration is completed.
  * Recorded failed OAuth app enablement attempts in the audit log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->