### PR TITLE
Point the onboarding BYO link at the OAuth guide

### DIFF
--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -856,10 +856,16 @@ export function OnboardingRoute(handle: Handle) {
 										</ul>
 										<p mix={css(builtInByoCss)}>
 											Want scopes or rate limits Kody's app does not offer?{' '}
-											<a href="/connect/oauth" mix={css(primaryLinkCss)}>
+											<a
+												href="/guides/oauth"
+												target="_blank"
+												rel="noreferrer noopener"
+												mix={css(primaryLinkCss)}
+											>
 												Bring your own OAuth app
 											</a>{' '}
-											for more power.
+											for more power — the guide explains how connections and
+											helper packages work.
 										</p>
 										<div mix={css(advancedSectionCss)}>
 											<p mix={css(advancedLabelCss)}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The "Bring your own OAuth app" line under the built-in provider cards in onboarding step 3 sent users to the blank `/connect/oauth` config form — a surface that assumes an agent is driving and offers no explanation. It now opens `/guides/oauth` in a new tab: the guide covering the connect flow, the exact redirect URI, PKCE vs confidential, built-in integrations, and how trusted helper packages follow a connection. The copy notes what the guide explains.

## Testing

`npm run validate` green. Verified in the browser: the link resolves to `/guides/oauth`, opens in a new tab, and the guide page renders.

![Updated BYO line under the provider cards](https://cursor.com/artifacts/c/art-90cf9eb8-e4cb-4372-ad96-3e66631ee1a6)

![OAuth guide page the link opens](https://cursor.com/artifacts/c/art-7b3de12b-1866-4166-be58-ef3ecf824405)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the built-in integrations BYO OAuth guidance with clearer connection and helper-package information.
  * OAuth guide links now open in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->