### PR TITLE
Redirect bare /connect/oauth visits to the OAuth guide

### DIFF
--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -90,6 +90,20 @@ type OAuthCallback =
 export function ConnectOauthRoute(handle: Handle) {
 	type StatusTone = 'info' | 'warn' | 'error'
 
+	// Mirrors the server-side bare-visit redirect for SPA-internal
+	// navigations: no provider, no callback code, and no provider error
+	// means there is no flow to set up or resume here.
+	if (typeof window !== 'undefined') {
+		const params = new URLSearchParams(window.location.search)
+		if (
+			!params.get('provider') &&
+			!params.get('code') &&
+			!params.get('error')
+		) {
+			window.location.replace('/guides/oauth')
+		}
+	}
+
 	let statusMessage = 'Ready to connect.'
 	let statusTone: StatusTone = 'info'
 	let currentStep: 'setup' | 'connect' | 'callback' | 'success' = 'setup'

--- a/packages/worker/src/app/handlers/connect-oauth.node.test.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.node.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest'
+import { RequestContext } from 'remix/router'
+import {
+	createConnectOauthHandler,
+	isBareConnectOauthVisit,
+} from '#app/handlers/connect-oauth.ts'
+
+test('bare /connect/oauth visits redirect to the OAuth guide', async () => {
+	const env = {} as Env
+	const response = await createConnectOauthHandler(env).handler(
+		new RequestContext(new Request('https://example.com/connect/oauth')),
+	)
+	expect(response.status).toBe(302)
+	expect(response.headers.get('location')).toBe(
+		'https://example.com/guides/oauth',
+	)
+})
+
+test('provider, callback, and denial visits are not bare', () => {
+	const bare = (search: string) =>
+		isBareConnectOauthVisit(
+			new URL(`https://example.com/connect/oauth${search}`),
+		)
+	expect(bare('')).toBe(true)
+	expect(bare('?state=abc')).toBe(true)
+	// Agent-built setup URLs and built-in connects.
+	expect(bare('?provider=github')).toBe(false)
+	// The provider's success redirect strips the config query; sessionStorage
+	// restores it client-side.
+	expect(bare('?code=auth-code&state=abc')).toBe(false)
+	// The provider's denial redirect carries error instead of code.
+	expect(bare('?error=access_denied&state=abc')).toBe(false)
+})
+
+test('anonymous visits with a provider still hit the session gate', async () => {
+	const env = {} as Env
+	const response = await createConnectOauthHandler(env).handler(
+		new RequestContext(
+			new Request('https://example.com/connect/oauth?provider=github'),
+		),
+	)
+	expect(response.status).toBe(302)
+	expect(response.headers.get('location')).toContain('/login')
+})

--- a/packages/worker/src/app/handlers/connect-oauth.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.ts
@@ -3,10 +3,28 @@ import { requirePageSession } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
 
+/**
+ * Every working visit to /connect/oauth carries at least one of these:
+ * `provider` (agent-built setup URLs and built-in connects), `code` (the
+ * provider's success redirect — config is restored from sessionStorage, so
+ * the query has no provider), or `error` (the provider's denial redirect).
+ * A visit with none of them has no flow to resume — someone typed the URL
+ * or followed a bare link — so the OAuth guide is the useful destination.
+ * Checked before the session gate: the guide is public.
+ */
+export function isBareConnectOauthVisit(url: URL): boolean {
+	const params = url.searchParams
+	return !params.get('provider') && !params.get('code') && !params.get('error')
+}
+
 export function createConnectOauthHandler(env: Env) {
 	return {
 		middleware: [],
 		async handler({ request }) {
+			const requestUrl = new URL(request.url)
+			if (isBareConnectOauthVisit(requestUrl)) {
+				return Response.redirect(new URL('/guides/oauth', requestUrl), 302)
+			}
 			const sessionRedirect = await requirePageSession(request)
 			if (sessionRedirect) {
 				return sessionRedirect


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`/connect/oauth` with no meaningful query parameters now 302s to `/guides/oauth` instead of rendering the blank config form.

## Why

Every working visit to the page carries at least one of three parameters: `provider` (agent-built setup URLs and built-in connects), `code` (the provider's success redirect — the redirect URI strips the config query, which sessionStorage restores client-side), or `error` (the provider's denial redirect, e.g. `access_denied`). A visit with none of them has no flow to set up or resume — someone typed the URL or followed a bare link — and the blank form assumes an agent is driving. The guide explains how to actually use the page.

## How

- `isBareConnectOauthVisit` in the server handler, checked **before** the session gate (the guide is public, so anonymous bare visitors skip the login bounce).
- The client route mirrors the check for SPA-internal navigations.
- Handler tests cover all three param shapes plus the bare redirect and the still-gated provider visit.

## Testing

`npm run validate` green. Live smoke test on the dev server: bare visit → `302 /guides/oauth`; `?provider=github` (anonymous) → 302 to login as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for visitors who open the OAuth connection page without required connection details, redirecting them to the OAuth guide.
  * Preserved existing handling for valid OAuth callbacks and configured connection flows.
  * Anonymous visits with a provider specified continue through the login flow.

* **Bug Fixes**
  * Prevented incomplete OAuth visits from reaching the standard connection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->