### PR TITLE
Send built-in connects straight into the provider authorize flow

### DIFF
--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -104,7 +104,10 @@ export function ConnectOauthRoute(handle: Handle) {
 		}
 	}
 
-	let statusMessage = 'Ready to connect.'
+	// The real status arrives once the query config and any stored/built-in
+	// provider config resolve; starting on "Ready to connect." flashed a
+	// misleading state on slow connections.
+	let statusMessage = 'Loading provider configuration…'
 	let statusTone: StatusTone = 'info'
 	let currentStep: 'setup' | 'connect' | 'callback' | 'success' = 'setup'
 	let config: ConnectOauthConfig | null = null
@@ -983,6 +986,16 @@ export function ConnectOauthRoute(handle: Handle) {
 			}
 			config = nextConfig
 			await initializeSetupState(nextConfig)
+			// Built-in integrations have nothing for the user to review or
+			// fill in, so a plain ?provider=<slug> visit (the onboarding
+			// cards, docs links) goes straight into the provider's authorize
+			// flow. Callback returns never reach this branch — code and
+			// error visits take the callback path — so a denial cannot
+			// loop back into an auto-start.
+			if (nextConfig.platformAppSlug && currentStep === 'connect') {
+				setStatus(`Redirecting to ${nextConfig.provider} to authorize…`)
+				await handleConnect()
+			}
 		} catch (error) {
 			// Initial integration/secrets reads use fetch(); a transient network
 			// failure must not escape queueTask as unhandledrejection.

--- a/packages/worker/src/app/account-integrations-data.node.test.ts
+++ b/packages/worker/src/app/account-integrations-data.node.test.ts
@@ -6,6 +6,7 @@ import {
 	upsertIntegration,
 	upsertOauthAppWithoutConnection,
 } from '#worker/integrations/service.ts'
+import { upsertPlatformOauthApp } from '#worker/integrations/platform-apps.ts'
 import {
 	loadAccountIntegrationByName,
 	loadAccountIntegrationsData,
@@ -242,6 +243,113 @@ test('loadAccountIntegrationByName covers setup prefill, reconnect, and exact-sl
 		appSlug: 'notion',
 		clientId: 'notion-client-from-setup',
 	})
+})
+
+test('endpoint-incomplete user records defer to an enabled built-in of the same name', async () => {
+	const { env } = createEnv()
+	const userId = 'user-platform-priority'
+	const platformEnv = {
+		...env,
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+	} as Env
+
+	await upsertPlatformOauthApp({
+		db: env.APP_DB,
+		env: platformEnv,
+		app: {
+			slug: 'github',
+			clientId: 'platform-github-client',
+			clientSecret: 'platform-github-secret',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			flow: 'confidential',
+			defaultScopes: ['read:user'],
+		},
+	})
+
+	// API-use-only connection (the shape agents save: token endpoint and API
+	// base, no authorize URL). It cannot drive the connect page, so the
+	// built-in wins.
+	await upsertIntegration({
+		env,
+		userId,
+		config: {
+			name: 'github',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+			clientId: 'user-github-client',
+			clientSecretSecretName: 'githubClientSecret',
+			accessTokenSecretName: 'githubAccessToken',
+			refreshTokenSecretName: null,
+			requiredHosts: ['api.github.com'],
+		},
+	})
+	const deferred = await loadAccountIntegrationByName(
+		env,
+		fakeUser(userId),
+		'github',
+	)
+	expect(deferred).toMatchObject({
+		name: 'github',
+		platform: true,
+		clientId: 'platform-github-client',
+		authorization: {
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+		},
+	})
+
+	// A complete bring-your-own record still wins over the built-in.
+	await upsertIntegration({
+		env,
+		userId,
+		config: {
+			name: 'github',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+			clientId: 'user-github-client',
+			clientSecretSecretName: 'githubClientSecret',
+			accessTokenSecretName: 'githubAccessToken',
+			refreshTokenSecretName: null,
+			requiredHosts: ['api.github.com'],
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+				scopes: ['repo'],
+				scopeSeparator: null,
+				extraAuthorizeParams: {},
+			},
+		},
+	})
+	const byoWins = await loadAccountIntegrationByName(
+		env,
+		fakeUser(userId),
+		'github',
+	)
+	expect(byoWins?.clientId).toBe('user-github-client')
+	expect(byoWins?.platform ?? false).toBe(false)
+
+	// No built-in for the slug: the incomplete record still returns so the
+	// setup form can prefill what exists.
+	await upsertIntegration({
+		env,
+		userId,
+		config: {
+			name: 'linear',
+			tokenUrl: 'https://api.linear.app/oauth/token',
+			flow: 'confidential',
+			clientId: 'user-linear-client',
+			accessTokenSecretName: 'linearAccessToken',
+			refreshTokenSecretName: null,
+		},
+	})
+	const noFallback = await loadAccountIntegrationByName(
+		env,
+		fakeUser(userId),
+		'linear',
+	)
+	expect(noFallback?.clientId).toBe('user-linear-client')
+	expect(noFallback?.platform ?? false).toBe(false)
 })
 
 test('loadAccountIntegrationsData includes OAuth apps with their connections', async () => {

--- a/packages/worker/src/app/account-integrations-data.ts
+++ b/packages/worker/src/app/account-integrations-data.ts
@@ -214,18 +214,42 @@ export async function loadAccountOauthAppBySlug(
 	)
 }
 
+/**
+ * True when the record carries the endpoints the connect page needs to run
+ * an authorize → token exchange flow. Records created for API use only
+ * (agents typically save tokenUrl and apiBaseUrl but no authorize URL)
+ * cannot, and would dead-end the page on "missing configuration".
+ */
+function recordCanDriveConnectFlow(record: AccountIntegrationRecord): boolean {
+	return Boolean(
+		record.authorization?.authorizeUrl?.trim() && record.tokenUrl?.trim(),
+	)
+}
+
 export async function loadAccountIntegrationByName(
 	env: Env,
 	user: AuthenticatedUser,
 	name: string,
 ): Promise<AccountIntegrationRecord | null> {
+	// A user-lane record still wins when it can actually drive the flow (the
+	// bring-your-own override); an endpoint-incomplete one defers to an
+	// enabled built-in of the same name instead of dead-ending the page.
+	const platformFallback = async () => {
+		const platformApp = await getAvailablePlatformApp({ env, slug: name })
+		return platformApp ? toPlatformAppPrefillRecord(platformApp, name) : null
+	}
+
 	// 1. Existing connection (reconnect) — connection name, not app slug.
 	const joined = await getJoinedIntegration({
 		env,
 		userId: user.mcpUser.userId,
 		name,
 	})
-	if (joined) return toAccountIntegrationRecord(joined)
+	if (joined) {
+		const record = toAccountIntegrationRecord(joined)
+		if (recordCanDriveConnectFlow(record)) return record
+		return (await platformFallback()) ?? record
+	}
 
 	// 2–3. Exact app slug, else field-wise provider-family prefill (shared
 	// client id across github/github-kent, shared google app, etc.).
@@ -234,11 +258,13 @@ export async function loadAccountIntegrationByName(
 		userId: user.mcpUser.userId,
 		name,
 	})
-	if (prefill) return toAppOnlyIntegrationRecord(prefill, name)
+	if (prefill) {
+		const record = toAppOnlyIntegrationRecord(prefill, name)
+		if (recordCanDriveConnectFlow(record)) return record
+		return (await platformFallback()) ?? record
+	}
 
 	// 4. Platform (built-in) app: the user needs no OAuth app of their own, so
 	// the connect flow can skip client-credential setup entirely.
-	const platformApp = await getAvailablePlatformApp({ env, slug: name })
-	if (!platformApp) return null
-	return toPlatformAppPrefillRecord(platformApp, name)
+	return platformFallback()
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Clicking Connect on a built-in integration should land the user on the provider's consent screen, not an intermediate Kody page. Two fixes and one polish:

1. **Lookup fallback** (`loadAccountIntegrationByName`): a user-lane record that cannot drive the connect flow (no authorize URL — the shape agents save for API use: `tokenUrl` + `apiBaseUrl` only) now defers to an enabled built-in of the same name. Previously that record won the lookup and the config merge failed with "Missing required OAuth configuration parameters" — the reported production bug for accounts with a pre-existing `github` connection. Complete bring-your-own records still win (the BYO override), and when no built-in exists the incomplete record still prefills the setup form as before.
2. **Auto-start** (`connect-oauth.tsx`): when the resolved config is platform-lane and ready, the page immediately builds the authorize URL and redirects — `?provider=github` becomes a straight pass-through into GitHub's flow. Callback returns (`code`/`error`) take a different branch, so a denial cannot loop back into an auto-start.
3. The pre-resolution status reads "Loading provider configuration…" instead of flashing "Ready to connect."

Persistence already handled the lane conversion: connecting the built-in over an old user-lane row upserts it to the platform lane and cleans up the orphaned user app.

## Testing

- New data-loader test: incomplete record defers to the built-in; complete BYO record still wins; incomplete record with no built-in still prefills.
- `npm run validate` green.
- Verified in the browser for both scenarios — an account seeded with an API-only `github` row (the production regression) and a clean account clicking the onboarding card. Both auto-redirect into GitHub's real sign-in/authorize flow:

![Auto-redirect landing on GitHub](https://cursor.com/artifacts/c/art-f22c339c-d710-4f06-a1e1-df72f786d542)

<a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplatform_connect_auto_redirect_demo.mp4"><img src="https://cursor.com/artifacts/c/art-6edd14b5-5849-42e3-bc35-2acab56c751d" alt="platform_connect_auto_redirect_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth setup now automatically begins authorization when a built-in integration is ready to connect.
  * Provider visits display a clear “Loading provider configuration…” status while setup is initialized.
  * Incomplete integration settings can use an available built-in provider configuration when appropriate.
* **Bug Fixes**
  * Improved handling of OAuth callback visits so they continue through the callback flow.
  * Provider setup now reliably uses valid authorization and token endpoints, including fallback configurations when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->