### PR TITLE
Fix RecordTable overflow; expand platform integrations editor

### DIFF
--- a/docs/contributing/decisions/0010-account-record-table/page-inventory.md
+++ b/docs/contributing/decisions/0010-account-record-table/page-inventory.md
@@ -12,17 +12,22 @@ content-layer change whether or not their layout moves).
 The record unfolds inside the table under its own row. Buttons and short control
 clusters are fine here; forms are not.
 
-| Screen                    | Record content                                             |
-| ------------------------- | ---------------------------------------------------------- |
-| `account/packages`        | 6 metadata fields, tags, search index                      |
-| `account/activity`        | metadata only                                              |
-| `account/email`           | metadata plus action buttons                               |
-| `admin/users`             | 9 metadata fields, a role cluster, two destructive actions |
-| `admin/platform-feedback` | metadata only                                              |
+| Screen                        | Record content                                             |
+| ----------------------------- | ---------------------------------------------------------- |
+| `account/packages`            | 6 metadata fields, tags, search index                      |
+| `account/activity`            | metadata only                                              |
+| `account/email`               | metadata plus action buttons                               |
+| `admin/users`                 | 9 metadata fields, a role cluster, two destructive actions |
+| `admin/platform-feedback`     | metadata only                                              |
+| `admin/platform-integrations` | edit/create form (exception: editor in expanded row)       |
 
 `admin/users` is the boundary case: the only one here with live controls, and it
 also hand-rolls a table today, so it is a replacement rather than an addition.
 If the role cluster feels wrong in use it moves to `pane`.
+
+`admin/platform-integrations` is a deliberate exception to the forms-in-pane
+rule: the expanded record is the full create/edit form rather than metadata
+below a separate card list.
 
 ## `mode: 'pane'` — record has an editor
 

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -224,6 +224,8 @@ registerPreloadPatterns(
 		routePattern(routes.adminInvites),
 		routePattern(routes.adminFeatureFlags),
 		routePattern(routes.adminPlatformIntegrations),
+		routePattern(routes.adminPlatformIntegrationNew),
+		routePattern(routes.adminPlatformIntegrationDetail),
 		routePattern(routes.adminCodemods),
 		routePattern(routes.adminRoles),
 		routePattern(routes.adminCommunityReports),

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -35,6 +35,7 @@ import {
 	RecordTableSearch,
 	RecordTableSelect,
 	recordBodyCss,
+	recordCellClamp,
 	recordStampCss,
 } from './record-table.tsx'
 import {
@@ -406,19 +407,19 @@ export function AccountPackagesRoute(handle: Handle) {
 						{ key: 'kodyId', label: 'Kody id', drop: 2 },
 						{ key: 'hasApp', label: 'App' },
 						{ key: 'tags', label: 'Tags', drop: 1 },
-						{ key: 'updated', label: 'Updated' },
+						{ key: 'updated', label: 'Updated', drop: 3 },
 					]}
 					rows={packages.map((pkg) => ({
 						id: pkg.id,
 						href: packagesRoute.buildDetailHref(pkg.id, getCurrentSearch()),
 						cells: {
-							name: pkg.name,
+							name: <span mix={css(recordCellClamp(36))}>{pkg.name}</span>,
 							kodyId: (
 								<code
 									mix={css({
 										fontSize: '0.8rem',
 										color: colors.textMuted,
-										whiteSpace: 'nowrap',
+										...recordCellClamp(28),
 									})}
 								>
 									{pkg.kodyId}

--- a/packages/worker/client/routes/admin-platform-integrations.tsx
+++ b/packages/worker/client/routes/admin-platform-integrations.tsx
@@ -1,13 +1,17 @@
-import { formatNullableTimestamp } from '#client/format-timestamp.ts'
+import { formatTimestampDate } from '#client/format-timestamp.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { replaceLocation } from '#client/replace-location.ts'
+import { matchesSearchQuery } from '#client/search-filter.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
 import {
-	cardCss,
+	cardTitleCss,
+	descriptionCss,
 	fieldCss,
 	fieldLabelCss,
 	getDangerPillCss,
@@ -17,14 +21,19 @@ import {
 } from '#universal/styles/style-primitives.ts'
 import {
 	AccountManagementMessage,
-	AccountManagementPanel,
 	AccountManagementShell,
 	AdminPageHeader,
-	MetadataGrid,
 	accountInputCss,
 	accountTextareaCss,
-	verifiedPillCss,
 } from './account-management-components.tsx'
+import {
+	RecordDot,
+	RecordTable,
+	RecordTableSearch,
+	recordBodyCss,
+	recordCellClamp,
+	recordStampCss,
+} from './record-table.tsx'
 import {
 	type AdminPlatformIntegrationApp,
 	type AdminPlatformIntegrationsLoaderData,
@@ -36,17 +45,36 @@ import {
 } from '#client/route-loader.ts'
 
 const selectCss = getSelectCss()
+const clampedCellCss = css(recordCellClamp(28))
+
+const adminPlatformIntegrationsApiPath = '/admin/platform-integrations.json'
+const platformIntegrationsRoute = createListDetailRoute(
+	'/admin/platform-integrations',
+)
+const createRecordId = '__new__'
 
 type PageStatus = 'loading' | 'ready' | 'error'
 type ActionState = 'idle' | 'saving-form' | 'toggling-enabled' | 'deleting'
 type TokenExchangeStyleOption = 'default' | 'form' | 'basic-json' | 'basic-form'
 
-const adminPlatformIntegrationsApiPath = '/admin/platform-integrations.json'
-
 function isAdminPlatformIntegrationsPath(href: string) {
-	return (
-		new URL(href, 'http://localhost').pathname ===
-		'/admin/platform-integrations'
+	return platformIntegrationsRoute.isRoutePath(href)
+}
+
+function readSearchFilter(href: string) {
+	return new URL(href, 'http://localhost').searchParams.get('q')?.trim() ?? ''
+}
+
+function buildHrefWithUpdatedSearch(href: string, search: string) {
+	const nextUrl = new URL(href, 'http://localhost')
+	if (search) nextUrl.searchParams.set('q', search)
+	else nextUrl.searchParams.delete('q')
+	return `${nextUrl.pathname}${nextUrl.search}`
+}
+
+function filterApps(apps: Array<AdminPlatformIntegrationApp>, search: string) {
+	return apps.filter((app) =>
+		matchesSearchQuery(search, [app.slug, app.provider, app.label]),
 	)
 }
 
@@ -90,16 +118,6 @@ function formatTokenExchangeStyle(
 	return 'default'
 }
 
-function enabledPillCss(enabled: boolean) {
-	return enabled
-		? verifiedPillCss
-		: {
-				...verifiedPillCss,
-				color: colors.textMuted,
-				backgroundColor: colors.border,
-			}
-}
-
 export async function adminPlatformIntegrationsRouteLoader(
 	_url: URL,
 	signal: AbortSignal,
@@ -128,15 +146,18 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 	let message: string | null = null
 	let messageTone: 'info' | 'error' = 'info'
 	let actionState: ActionState = 'idle'
-	/** Slug of the card an action is running against, for per-card labels. */
+	/** Slug of the row an action is running against, for per-row labels. */
 	let pendingSlug: string | null = null
 	let lastLoadedHref = ''
 	let loadingForHref: string | null = null
 	let lastFailedHref: string | null = null
 	let loadRequestId = 0
-	let editingApp: AdminPlatformIntegrationApp | null = null
 	let pendingLogoBase64: string | undefined = undefined
 	let removeLogoChecked = false
+
+	const primaryButtonCss = getPillButtonCss({ size: 'sm' })
+	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
+	const dangerButtonCss = getDangerPillCss({ size: 'sm' })
 
 	function applyData(payload: AdminPlatformIntegrationsLoaderData) {
 		apps = payload.apps
@@ -146,9 +167,14 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 	}
 
 	function resetFormState() {
-		editingApp = null
 		pendingLogoBase64 = undefined
 		removeLogoChecked = false
+	}
+
+	function resetSelectionState() {
+		resetFormState()
+		message = null
+		messageTone = 'info'
 	}
 
 	async function loadPlatformIntegrations() {
@@ -276,9 +302,17 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 		if (!(event.currentTarget instanceof HTMLFormElement)) return
 		const form = event.currentTarget
 		const formData = new FormData(form)
+		const selection = platformIntegrationsRoute.getSelection(
+			readCurrentRouterHref(handle),
+		)
+		const isEditing = !selection.isCreating && selection.selectedId != null
 		// FormData excludes disabled controls, so the locked slug input must
-		// come from the editing state when editing.
-		const slug = (editingApp?.slug ?? String(formData.get('slug') ?? '')).trim()
+		// come from the URL selection when editing.
+		const slug = (
+			isEditing && selection.selectedId
+				? selection.selectedId
+				: String(formData.get('slug') ?? '')
+		).trim()
 		const clientId = String(formData.get('clientId') ?? '').trim()
 		const tokenUrl = String(formData.get('tokenUrl') ?? '').trim()
 		const authorizeUrl = String(formData.get('authorizeUrl') ?? '').trim()
@@ -341,7 +375,6 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 			body.logoBase64 = pendingLogoBase64
 		}
 
-		const isEditing = editingApp !== null
 		void submitAdminAction(
 			body,
 			'saving-form',
@@ -352,6 +385,11 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 			if (!ok) return
 			form.reset()
 			resetFormState()
+			if (isEditing) {
+				handle.update()
+				return
+			}
+			replaceLocation(platformIntegrationsRoute.buildDetailHref(slug))
 			handle.update()
 		})
 	}
@@ -382,23 +420,425 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 			`Deleted platform integration ${app.slug}.`,
 		).then((ok) => {
 			if (!ok) return
-			if (editingApp?.slug === app.slug) {
-				resetFormState()
-				handle.update()
+			const selection = platformIntegrationsRoute.getSelection(
+				readCurrentRouterHref(handle),
+			)
+			resetFormState()
+			if (selection.selectedId === app.slug || selection.isCreating) {
+				replaceLocation(platformIntegrationsRoute.buildListHref())
 			}
+			handle.update()
 		})
 	}
 
-	function handleEdit(app: AdminPlatformIntegrationApp) {
-		editingApp = app
-		pendingLogoBase64 = undefined
-		removeLogoChecked = false
+	function cancelEditor() {
+		resetSelectionState()
+		replaceLocation(platformIntegrationsRoute.buildListHref())
 		handle.update()
 	}
 
-	const primaryButtonCss = getPillButtonCss({ size: 'sm' })
-	const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
-	const dangerButtonCss = getDangerPillCss({ size: 'sm' })
+	function startCreateIntegration() {
+		if (actionState !== 'idle') return
+		resetSelectionState()
+		replaceLocation(platformIntegrationsRoute.buildNewHref())
+		handle.update()
+	}
+
+	function renderIntegrationForm(
+		editingApp: AdminPlatformIntegrationApp | null,
+	) {
+		const isEditing = editingApp != null
+		const formKey =
+			isEditing && editingApp ? `edit-${editingApp.slug}` : 'create'
+
+		return (
+			<form
+				key={formKey}
+				method="post"
+				noValidate
+				mix={[on('submit', handleSaveFormSubmit), css(recordBodyCss)]}
+			>
+				<div
+					mix={css({
+						display: 'flex',
+						justifyContent: 'space-between',
+						gap: spacing.md,
+						flexWrap: 'wrap',
+						alignItems: 'flex-start',
+					})}
+				>
+					<div mix={css({ display: 'grid', gap: spacing.xs, minWidth: 0 })}>
+						<h2 mix={css(cardTitleCss)}>
+							{isEditing ? 'Edit integration' : 'Create integration'}
+						</h2>
+						<p mix={css(descriptionCss)}>
+							Save creates or updates a platform OAuth app. Omitted write-only
+							fields retain stored values.
+						</p>
+					</div>
+					{isEditing && editingApp ? (
+						<div
+							mix={css({
+								display: 'flex',
+								flexWrap: 'wrap',
+								gap: spacing.sm,
+							})}
+						>
+							<button
+								type="button"
+								disabled={actionState !== 'idle'}
+								mix={[
+									on('click', () => handleToggleEnabled(editingApp)),
+									css(secondaryButtonCss),
+								]}
+							>
+								{actionState === 'toggling-enabled' &&
+								pendingSlug === editingApp.slug
+									? 'Saving…'
+									: editingApp.enabled
+										? 'Disable'
+										: 'Enable'}
+							</button>
+							<button
+								type="button"
+								disabled={actionState !== 'idle'}
+								mix={[
+									on('click', () => handleDelete(editingApp)),
+									css(dangerButtonCss),
+								]}
+							>
+								{actionState === 'deleting' && pendingSlug === editingApp.slug
+									? 'Deleting…'
+									: 'Delete'}
+							</button>
+						</div>
+					) : null}
+				</div>
+
+				<div mix={css({ display: 'grid', gap: spacing.md })}>
+					<div
+						mix={css({
+							display: 'grid',
+							gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+							gap: spacing.md,
+							[mq.mobile]: {
+								gridTemplateColumns: 'minmax(0, 1fr)',
+							},
+						})}
+					>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Slug</span>
+							<input
+								data-field-ring
+								name="slug"
+								type="text"
+								required
+								disabled={actionState !== 'idle' || isEditing}
+								defaultValue={editingApp?.slug ?? ''}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Provider</span>
+							<input
+								data-field-ring
+								name="provider"
+								type="text"
+								disabled={actionState !== 'idle'}
+								defaultValue={editingApp?.provider ?? ''}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Label</span>
+							<input
+								data-field-ring
+								name="label"
+								type="text"
+								disabled={actionState !== 'idle'}
+								defaultValue={editingApp?.label ?? ''}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Client id</span>
+							<input
+								data-field-ring
+								name="clientId"
+								type="text"
+								required
+								disabled={actionState !== 'idle'}
+								defaultValue={editingApp?.clientId ?? ''}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Client secret</span>
+							<input
+								data-field-ring
+								name="clientSecret"
+								type="password"
+								autoComplete="new-password"
+								placeholder="unchanged when empty"
+								disabled={actionState !== 'idle'}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Flow</span>
+							<select
+								data-field-ring
+								name="flow"
+								required
+								disabled={actionState !== 'idle'}
+								mix={css(selectCss)}
+							>
+								{/* Explicit per-option selection: this renderer applies
+								    defaultValue as an attribute, which selects ignore. */}
+								<option
+									value="pkce"
+									selected={(editingApp?.flow ?? 'pkce') === 'pkce'}
+								>
+									pkce
+								</option>
+								<option
+									value="confidential"
+									selected={editingApp?.flow === 'confidential'}
+								>
+									confidential
+								</option>
+							</select>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Token exchange style</span>
+							<select
+								data-field-ring
+								name="tokenExchangeStyle"
+								disabled={actionState !== 'idle'}
+								mix={css(selectCss)}
+							>
+								{(['default', 'form', 'basic-json', 'basic-form'] as const).map(
+									(style) => (
+										<option
+											key={style}
+											value={style}
+											selected={
+												formatTokenExchangeStyle(
+													editingApp?.tokenExchangeStyle ?? null,
+												) === style
+											}
+										>
+											{style}
+										</option>
+									),
+								)}
+							</select>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Scope separator</span>
+							<input
+								data-field-ring
+								name="scopeSeparator"
+								type="text"
+								disabled={actionState !== 'idle'}
+								defaultValue={editingApp?.scopeSeparator ?? ''}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Token URL</span>
+							<input
+								data-field-ring
+								name="tokenUrl"
+								type="url"
+								required
+								disabled={actionState !== 'idle'}
+								defaultValue={editingApp?.tokenUrl ?? ''}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>Authorize URL</span>
+							<input
+								data-field-ring
+								name="authorizeUrl"
+								type="url"
+								required
+								disabled={actionState !== 'idle'}
+								defaultValue={editingApp?.authorizeUrl ?? ''}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+						<label mix={css(fieldCss)}>
+							<span mix={css(fieldLabelCss)}>API base URL</span>
+							<input
+								data-field-ring
+								name="apiBaseUrl"
+								type="url"
+								disabled={actionState !== 'idle'}
+								defaultValue={editingApp?.apiBaseUrl ?? ''}
+								mix={css(accountInputCss)}
+							/>
+						</label>
+					</div>
+					<label mix={css(fieldCss)}>
+						<span mix={css(fieldLabelCss)}>Allowed scopes</span>
+						<input
+							data-field-ring
+							name="allowedScopes"
+							type="text"
+							disabled={actionState !== 'idle'}
+							placeholder="Comma or whitespace separated"
+							defaultValue={joinList(editingApp?.allowedScopes ?? [])}
+							mix={css(accountInputCss)}
+						/>
+					</label>
+					<label mix={css(fieldCss)}>
+						<span mix={css(fieldLabelCss)}>Default scopes</span>
+						<input
+							data-field-ring
+							name="defaultScopes"
+							type="text"
+							disabled={actionState !== 'idle'}
+							placeholder="Comma or whitespace separated"
+							defaultValue={joinList(editingApp?.defaultScopes ?? [])}
+							mix={css(accountInputCss)}
+						/>
+					</label>
+					<label mix={css(fieldCss)}>
+						<span mix={css(fieldLabelCss)}>Required hosts</span>
+						<input
+							data-field-ring
+							name="requiredHosts"
+							type="text"
+							disabled={actionState !== 'idle'}
+							placeholder="Comma or whitespace separated"
+							defaultValue={joinList(editingApp?.requiredHosts ?? [])}
+							mix={css(accountInputCss)}
+						/>
+					</label>
+					<label mix={css(fieldCss)}>
+						<span mix={css(fieldLabelCss)}>Extra authorize params</span>
+						<textarea
+							data-field-ring
+							name="extraAuthorizeParams"
+							disabled={actionState !== 'idle'}
+							placeholder="key=value (one per line)"
+							defaultValue={formatExtraAuthorizeParams(
+								editingApp?.extraAuthorizeParams ?? {},
+							)}
+							mix={css(accountTextareaCss)}
+						/>
+					</label>
+					<label mix={css(fieldCss)}>
+						<span mix={css(fieldLabelCss)}>Logo</span>
+						<input
+							data-field-ring
+							name="logo"
+							type="file"
+							accept="image/svg+xml,image/png,image/jpeg,image/webp"
+							disabled={actionState !== 'idle'}
+							mix={[on('change', handleLogoFileChange), css(accountInputCss)]}
+						/>
+					</label>
+					{isEditing && editingApp?.logoPath ? (
+						<label
+							mix={css({
+								...fieldCss,
+								display: 'flex',
+								flexDirection: 'row',
+								alignItems: 'center',
+								gap: spacing.sm,
+							})}
+						>
+							<input
+								name="removeLogo"
+								type="checkbox"
+								checked={removeLogoChecked}
+								disabled={actionState !== 'idle'}
+								mix={[
+									css({
+										width: '1.25rem',
+										height: '1.25rem',
+										accentColor: colors.primary,
+									}),
+									on('change', (event) => {
+										const input = event.currentTarget
+										if (!(input instanceof HTMLInputElement)) return
+										removeLogoChecked = input.checked
+										if (removeLogoChecked) {
+											pendingLogoBase64 = undefined
+										}
+										handle.update()
+									}),
+								]}
+							/>
+							<span mix={css(fieldLabelCss)}>Remove logo</span>
+						</label>
+					) : null}
+					<label
+						mix={css({
+							...fieldCss,
+							display: 'flex',
+							flexDirection: 'row',
+							alignItems: 'center',
+							gap: spacing.sm,
+						})}
+					>
+						<input
+							name="enabled"
+							type="checkbox"
+							defaultChecked={editingApp?.enabled ?? true}
+							disabled={actionState !== 'idle'}
+							mix={css({
+								width: '1.25rem',
+								height: '1.25rem',
+								accentColor: colors.primary,
+							})}
+						/>
+						<span mix={css(fieldLabelCss)}>Enabled</span>
+					</label>
+					<div
+						mix={css({
+							display: 'flex',
+							flexWrap: 'wrap',
+							gap: spacing.sm,
+							alignItems: 'center',
+						})}
+					>
+						<button
+							type="submit"
+							disabled={actionState !== 'idle'}
+							mix={css(primaryButtonCss)}
+						>
+							{actionState === 'saving-form'
+								? 'Saving…'
+								: isEditing
+									? 'Save changes'
+									: 'Create integration'}
+						</button>
+						{isEditing ? (
+							<button
+								type="button"
+								disabled={actionState !== 'idle'}
+								mix={[on('click', cancelEditor), css(secondaryButtonCss)]}
+							>
+								Cancel edit
+							</button>
+						) : (
+							<button
+								type="button"
+								disabled={actionState !== 'idle'}
+								mix={[on('click', cancelEditor), css(secondaryButtonCss)]}
+							>
+								Cancel
+							</button>
+						)}
+					</div>
+				</div>
+			</form>
+		)
+	}
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
@@ -427,10 +867,23 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 			loadingForHref = currentHref
 			handle.queueTask(loadPlatformIntegrations)
 		}
+
+		const selection = platformIntegrationsRoute.getSelection(currentHref)
+		const search = readSearchFilter(currentHref)
+		const filteredApps = filterApps(apps, search)
+		const editingApp = selection.isCreating
+			? null
+			: (apps.find((app) => app.slug === selection.selectedId) ?? null)
 		const isMutating = actionState !== 'idle'
-		const isEditing = editingApp !== null
-		const formKey =
-			isEditing && editingApp ? `edit-${editingApp.slug}` : 'create'
+		const showEditor = selection.isCreating || editingApp != null
+		const showNotFound =
+			selection.selectedId != null &&
+			!selection.isCreating &&
+			editingApp == null &&
+			status === 'ready'
+		const tableSelectedId = selection.isCreating
+			? createRecordId
+			: selection.selectedId
 
 		return (
 			<AccountManagementShell>
@@ -449,511 +902,105 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 						{message}
 					</AccountManagementMessage>
 				) : null}
-				<div mix={css({ display: 'grid', gap: spacing.lg })}>
-					{apps.map((app) => (
-						<section
-							key={`${app.slug}:${app.updatedAt}:${app.connectionCount}`}
-							mix={css(cardCss)}
-						>
-							<div
-								mix={css({
-									display: 'flex',
-									justifyContent: 'space-between',
-									gap: spacing.md,
-									flexWrap: 'wrap',
-									alignItems: 'flex-start',
-									marginBottom: spacing.md,
-								})}
-							>
-								<div
-									mix={css({
-										display: 'flex',
-										gap: spacing.md,
-										alignItems: 'flex-start',
-										minWidth: 0,
-									})}
-								>
-									{app.logoPath ? (
-										<img
-											src={app.logoPath}
-											alt=""
-											width={32}
-											height={32}
-											mix={css({
-												width: '32px',
-												height: '32px',
-												borderRadius: '0.5rem',
-												objectFit: 'contain',
-												flexShrink: 0,
-											})}
-										/>
-									) : (
-										<div
-											aria-hidden="true"
-											mix={css({
-												width: '32px',
-												height: '32px',
-												borderRadius: '0.5rem',
-												background: colors.border,
-												flexShrink: 0,
-											})}
-										/>
-									)}
-									<div mix={css({ minWidth: 0 })}>
-										<div
-											mix={css({
-												display: 'flex',
-												flexWrap: 'wrap',
-												gap: spacing.sm,
-												alignItems: 'center',
-											})}
-										>
-											<h2
-												mix={css({
-													fontSize: typography.fontSize.lg,
-													fontWeight: typography.fontWeight.semibold,
-													margin: 0,
-												})}
-											>
-												<code mix={css({ fontSize: typography.fontSize.base })}>
-													{app.slug}
-												</code>
-											</h2>
-											<span mix={css(enabledPillCss(app.enabled))}>
-												{app.enabled ? 'Enabled' : 'Disabled'}
-											</span>
-										</div>
-										<p mix={css({ margin: 0, color: colors.textMuted })}>
-											{app.provider}
-											{app.label ? ` · ${app.label}` : ''} ·{' '}
-											{app.connectionCount} connection
-											{app.connectionCount === 1 ? '' : 's'}
-										</p>
-									</div>
-								</div>
-								<div
-									mix={css({
-										display: 'flex',
-										flexWrap: 'wrap',
-										gap: spacing.sm,
-									})}
-								>
-									<button
-										type="button"
-										disabled={isMutating}
-										mix={[
-											on('click', () => handleToggleEnabled(app)),
-											css(secondaryButtonCss),
-										]}
-									>
-										{actionState === 'toggling-enabled' &&
-										pendingSlug === app.slug
-											? 'Saving…'
-											: app.enabled
-												? 'Disable'
-												: 'Enable'}
-									</button>
-									<button
-										type="button"
-										disabled={isMutating}
-										mix={[
-											on('click', () => handleEdit(app)),
-											css(secondaryButtonCss),
-										]}
-									>
-										Edit
-									</button>
-									<button
-										type="button"
-										disabled={isMutating}
-										mix={[
-											on('click', () => handleDelete(app)),
-											css(dangerButtonCss),
-										]}
-									>
-										{actionState === 'deleting' && pendingSlug === app.slug
-											? 'Deleting…'
-											: 'Delete'}
-									</button>
-								</div>
-							</div>
-							<MetadataGrid
-								items={[
-									{
-										label: 'Client id',
-										value: app.clientId,
-									},
-									{
-										label: 'Client secret',
-										value: app.hasClientSecret ? 'secret stored' : 'no secret',
-									},
-									{
-										label: 'Flow',
-										value: app.flow,
-									},
-									{
-										label: 'Token exchange',
-										value: app.tokenExchangeStyle ?? 'default',
-									},
-									{
-										label: 'Token URL',
-										value: app.tokenUrl,
-									},
-									{
-										label: 'Authorize URL',
-										value: app.authorizeUrl,
-									},
-									{
-										label: 'API base URL',
-										value: app.apiBaseUrl ?? 'None',
-									},
-									{
-										label: 'Allowed scopes',
-										value: joinList(app.allowedScopes) || 'None',
-									},
-									{
-										label: 'Default scopes',
-										value: joinList(app.defaultScopes) || 'None',
-									},
-									{
-										label: 'Required hosts',
-										value: joinList(app.requiredHosts) || 'None',
-									},
-									{
-										label: 'Updated',
-										value: formatNullableTimestamp(app.updatedAt),
-									},
-								]}
-							/>
-						</section>
-					))}
-				</div>
-				<AccountManagementPanel
-					title={isEditing ? 'Edit integration' : 'Create integration'}
-					description="Save creates or updates a platform OAuth app. Omitted write-only fields retain stored values."
-					asForm
-					onSubmit={handleSaveFormSubmit}
-				>
-					<div key={formKey} mix={css({ display: 'grid', gap: spacing.md })}>
-						<div
-							mix={css({
-								display: 'grid',
-								gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-								gap: spacing.md,
-								[mq.mobile]: {
-									gridTemplateColumns: 'minmax(0, 1fr)',
-								},
-							})}
-						>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Slug</span>
-								<input
-									data-field-ring
-									name="slug"
-									type="text"
-									required
-									disabled={isMutating || isEditing}
-									defaultValue={editingApp?.slug ?? ''}
-									mix={css(accountInputCss)}
+				{status === 'ready' ? (
+					<RecordTable
+						mode="expand"
+						ariaLabel="Platform integrations"
+						selectedId={tableSelectedId}
+						onNavigate={() => {
+							resetSelectionState()
+						}}
+						countLabel={`${filteredApps.length} of ${apps.length} integrations`}
+						emptyLabel={
+							apps.length === 0
+								? 'No platform integrations yet. Create one to get started.'
+								: 'No integrations match the current search.'
+						}
+						toolbar={
+							<>
+								<RecordTableSearch
+									label="Search integrations"
+									placeholder="Search slug, provider, or label"
+									value={search}
+									onInput={(value) => {
+										replaceLocation(
+											buildHrefWithUpdatedSearch(currentHref, value),
+										)
+									}}
 								/>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Provider</span>
-								<input
-									data-field-ring
-									name="provider"
-									type="text"
-									disabled={isMutating}
-									defaultValue={editingApp?.provider ?? ''}
-									mix={css(accountInputCss)}
-								/>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Label</span>
-								<input
-									data-field-ring
-									name="label"
-									type="text"
-									disabled={isMutating}
-									defaultValue={editingApp?.label ?? ''}
-									mix={css(accountInputCss)}
-								/>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Client id</span>
-								<input
-									data-field-ring
-									name="clientId"
-									type="text"
-									required
-									disabled={isMutating}
-									defaultValue={editingApp?.clientId ?? ''}
-									mix={css(accountInputCss)}
-								/>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Client secret</span>
-								<input
-									data-field-ring
-									name="clientSecret"
-									type="password"
-									autoComplete="new-password"
-									placeholder="unchanged when empty"
-									disabled={isMutating}
-									mix={css(accountInputCss)}
-								/>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Flow</span>
-								<select
-									data-field-ring
-									name="flow"
-									required
-									disabled={isMutating}
-									mix={css(selectCss)}
-								>
-									{/* Explicit per-option selection: this renderer applies
-									    defaultValue as an attribute, which selects ignore. */}
-									<option
-										value="pkce"
-										selected={(editingApp?.flow ?? 'pkce') === 'pkce'}
-									>
-										pkce
-									</option>
-									<option
-										value="confidential"
-										selected={editingApp?.flow === 'confidential'}
-									>
-										confidential
-									</option>
-								</select>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Token exchange style</span>
-								<select
-									data-field-ring
-									name="tokenExchangeStyle"
-									disabled={isMutating}
-									mix={css(selectCss)}
-								>
-									{(
-										['default', 'form', 'basic-json', 'basic-form'] as const
-									).map((style) => (
-										<option
-											key={style}
-											value={style}
-											selected={
-												formatTokenExchangeStyle(
-													editingApp?.tokenExchangeStyle ?? null,
-												) === style
-											}
-										>
-											{style}
-										</option>
-									))}
-								</select>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Scope separator</span>
-								<input
-									data-field-ring
-									name="scopeSeparator"
-									type="text"
-									disabled={isMutating}
-									defaultValue={editingApp?.scopeSeparator ?? ''}
-									mix={css(accountInputCss)}
-								/>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Token URL</span>
-								<input
-									data-field-ring
-									name="tokenUrl"
-									type="url"
-									required
-									disabled={isMutating}
-									defaultValue={editingApp?.tokenUrl ?? ''}
-									mix={css(accountInputCss)}
-								/>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>Authorize URL</span>
-								<input
-									data-field-ring
-									name="authorizeUrl"
-									type="url"
-									required
-									disabled={isMutating}
-									defaultValue={editingApp?.authorizeUrl ?? ''}
-									mix={css(accountInputCss)}
-								/>
-							</label>
-							<label mix={css(fieldCss)}>
-								<span mix={css(fieldLabelCss)}>API base URL</span>
-								<input
-									data-field-ring
-									name="apiBaseUrl"
-									type="url"
-									disabled={isMutating}
-									defaultValue={editingApp?.apiBaseUrl ?? ''}
-									mix={css(accountInputCss)}
-								/>
-							</label>
-						</div>
-						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Allowed scopes</span>
-							<input
-								data-field-ring
-								name="allowedScopes"
-								type="text"
-								disabled={isMutating}
-								placeholder="Comma or whitespace separated"
-								defaultValue={joinList(editingApp?.allowedScopes ?? [])}
-								mix={css(accountInputCss)}
-							/>
-						</label>
-						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Default scopes</span>
-							<input
-								data-field-ring
-								name="defaultScopes"
-								type="text"
-								disabled={isMutating}
-								placeholder="Comma or whitespace separated"
-								defaultValue={joinList(editingApp?.defaultScopes ?? [])}
-								mix={css(accountInputCss)}
-							/>
-						</label>
-						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Required hosts</span>
-							<input
-								data-field-ring
-								name="requiredHosts"
-								type="text"
-								disabled={isMutating}
-								placeholder="Comma or whitespace separated"
-								defaultValue={joinList(editingApp?.requiredHosts ?? [])}
-								mix={css(accountInputCss)}
-							/>
-						</label>
-						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Extra authorize params</span>
-							<textarea
-								data-field-ring
-								name="extraAuthorizeParams"
-								disabled={isMutating}
-								placeholder="key=value (one per line)"
-								defaultValue={formatExtraAuthorizeParams(
-									editingApp?.extraAuthorizeParams ?? {},
-								)}
-								mix={css(accountTextareaCss)}
-							/>
-						</label>
-						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Logo</span>
-							<input
-								data-field-ring
-								name="logo"
-								type="file"
-								accept="image/svg+xml,image/png,image/jpeg,image/webp"
-								disabled={isMutating}
-								mix={[on('change', handleLogoFileChange), css(accountInputCss)]}
-							/>
-						</label>
-						{isEditing && editingApp?.logoPath ? (
-							<label
-								mix={css({
-									...fieldCss,
-									display: 'flex',
-									flexDirection: 'row',
-									alignItems: 'center',
-									gap: spacing.sm,
-								})}
-							>
-								<input
-									name="removeLogo"
-									type="checkbox"
-									checked={removeLogoChecked}
-									disabled={isMutating}
-									mix={[
-										css({
-											width: '1.25rem',
-											height: '1.25rem',
-											accentColor: colors.primary,
-										}),
-										on('change', (event) => {
-											const input = event.currentTarget
-											if (!(input instanceof HTMLInputElement)) return
-											removeLogoChecked = input.checked
-											if (removeLogoChecked) {
-												pendingLogoBase64 = undefined
-											}
-											handle.update()
-										}),
-									]}
-								/>
-								<span mix={css(fieldLabelCss)}>Remove logo</span>
-							</label>
-						) : null}
-						<label
-							mix={css({
-								...fieldCss,
-								display: 'flex',
-								flexDirection: 'row',
-								alignItems: 'center',
-								gap: spacing.sm,
-							})}
-						>
-							<input
-								name="enabled"
-								type="checkbox"
-								defaultChecked={editingApp?.enabled ?? true}
-								disabled={isMutating}
-								mix={css({
-									width: '1.25rem',
-									height: '1.25rem',
-									accentColor: colors.primary,
-								})}
-							/>
-							<span mix={css(fieldLabelCss)}>Enabled</span>
-						</label>
-						<div
-							mix={css({
-								display: 'flex',
-								flexWrap: 'wrap',
-								gap: spacing.sm,
-								alignItems: 'center',
-							})}
-						>
-							<button
-								type="submit"
-								disabled={isMutating}
-								mix={css(primaryButtonCss)}
-							>
-								{actionState === 'saving-form'
-									? 'Saving…'
-									: isEditing
-										? 'Save changes'
-										: 'Create integration'}
-							</button>
-							{isEditing ? (
 								<button
 									type="button"
 									disabled={isMutating}
 									mix={[
-										on('click', () => {
-											resetFormState()
-											handle.update()
-										}),
-										css(secondaryButtonCss),
+										on('click', startCreateIntegration),
+										css(primaryButtonCss),
 									]}
 								>
-									Cancel edit
+									Create integration
 								</button>
-							) : null}
-						</div>
-					</div>
-				</AccountManagementPanel>
+							</>
+						}
+						columns={[
+							{ key: 'slug', label: 'Slug', primary: true },
+							{ key: 'provider', label: 'Provider' },
+							{ key: 'label', label: 'Label', drop: 1 },
+							{ key: 'enabled', label: 'Enabled' },
+							{
+								key: 'connections',
+								label: 'Connections',
+								align: 'end',
+								drop: 2,
+							},
+							{ key: 'updated', label: 'Updated', drop: 3 },
+						]}
+						rows={filteredApps.map((app) => ({
+							id: app.slug,
+							href: isMutating
+								? undefined
+								: platformIntegrationsRoute.buildDetailHref(
+										app.slug,
+										new URL(currentHref, 'http://localhost').search,
+									),
+							cells: {
+								slug: (
+									<code
+										mix={css({
+											fontSize: typography.fontSize.sm,
+											...recordCellClamp(24),
+										})}
+									>
+										{app.slug}
+									</code>
+								),
+								provider: (
+									<span mix={clampedCellCss}>{app.provider || '—'}</span>
+								),
+								label: <span mix={clampedCellCss}>{app.label || '—'}</span>,
+								enabled: (
+									<RecordDot
+										active={app.enabled}
+										title={app.enabled ? 'Enabled' : 'Disabled'}
+									/>
+								),
+								connections: String(app.connectionCount),
+								updated: (
+									<span mix={css(recordStampCss)}>
+										{formatTimestampDate(app.updatedAt)}
+									</span>
+								),
+							},
+						}))}
+						record={
+							showEditor ? (
+								renderIntegrationForm(editingApp)
+							) : showNotFound ? (
+								<p mix={css({ margin: 0, color: colors.textMuted })}>
+									Platform integration not found.
+								</p>
+							) : null
+						}
+					/>
+				) : null}
 			</AccountManagementShell>
 		)
 	}

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -203,6 +203,14 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		adminArea,
 		(m) => m.adminPlatformIntegrationsRouteLoader,
 	),
+	[routePattern(routes.adminPlatformIntegrationNew)]: lazyRouteLoader(
+		adminArea,
+		(m) => m.adminPlatformIntegrationsRouteLoader,
+	),
+	[routePattern(routes.adminPlatformIntegrationDetail)]: lazyRouteLoader(
+		adminArea,
+		(m) => m.adminPlatformIntegrationsRouteLoader,
+	),
 	[routePattern(routes.adminCodemods)]: lazyRouteLoader(
 		adminArea,
 		(m) => m.adminCodemodsRouteLoader,
@@ -407,6 +415,12 @@ export const clientRoutes = {
 		<LazyAdminRoute render={(m) => <m.AdminFeatureFlagsRoute />} />
 	),
 	[routePattern(routes.adminPlatformIntegrations)]: (
+		<LazyAdminRoute render={(m) => <m.AdminPlatformIntegrationsRoute />} />
+	),
+	[routePattern(routes.adminPlatformIntegrationNew)]: (
+		<LazyAdminRoute render={(m) => <m.AdminPlatformIntegrationsRoute />} />
+	),
+	[routePattern(routes.adminPlatformIntegrationDetail)]: (
 		<LazyAdminRoute render={(m) => <m.AdminPlatformIntegrationsRoute />} />
 	),
 	[routePattern(routes.adminCodemods)]: (

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -160,3 +160,18 @@ test('record table empty and busy states keep toolbar layout stable', async () =
 	expect(busyHtml).toContain('<table')
 	expect(busyHtml).toContain('Alpha')
 })
+
+test('record table keeps wide rows reachable via horizontal overflow', async () => {
+	const html = await renderToString(
+		jsx(RecordTable, {
+			mode: 'expand',
+			ariaLabel: 'Packages',
+			columns,
+			rows,
+		}),
+	)
+
+	// Remix serializes longhands with a space after the colon.
+	expect(html).toContain('overflow-x: auto')
+	expect(html).toContain('overflow: clip')
+})

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -60,9 +60,10 @@ export type RecordTableRow = {
 
 type RecordTableProps = {
 	/**
-	 * `expand` unfolds the record inside the table under its own row (read-only
-	 * records), `pane` renders it below the table (records with an editor),
-	 * `none` is a table with no selection at all.
+	 * `expand` unfolds the record inside the table under its own row,
+	 * `pane` renders it below the table, `none` is a table with no selection.
+	 * Prefer `pane` for large editors (decision 0010); `expand` may still host
+	 * an editor when the screen deliberately keeps the form under its row.
 	 */
 	mode: 'expand' | 'pane' | 'none'
 	/**
@@ -137,7 +138,16 @@ const paneCss = {
 	...getSurfaceCardCss(),
 	padding: 0,
 	minWidth: 0,
-	overflow: 'hidden',
+	// Clip only the corners; the table scroller owns overflow so wide rows
+	// scroll instead of disappearing under the rounded card edge.
+	overflow: 'clip',
+}
+
+const tableScrollerCss = {
+	width: '100%',
+	minWidth: 0,
+	overflowX: 'auto' as const,
+	WebkitOverflowScrolling: 'touch' as const,
 }
 
 const toolbarCss = {
@@ -168,6 +178,7 @@ const countCss = {
 
 const tableCss = {
 	width: '100%',
+	minWidth: '100%',
 	borderCollapse: 'collapse' as const,
 	fontSize: typography.fontSize.sm,
 }
@@ -198,8 +209,9 @@ const cellCss = {
 /**
  * Below 620px the same `<table>` becomes a list of cards — no duplicate DOM.
  * Cells carry their own label from `data-label`; the primary cell is the
- * card's heading and keeps none. A five-column table cannot survive a phone,
- * and one that scrolls sideways is worse than no table at all.
+ * card's heading and keeps none. Column `drop` priorities shed fields first;
+ * when nowrap content still overflows the pane, the table scroller takes over
+ * with horizontal overflow rather than clipping under `overflow: hidden`.
  */
 const cardFallbackCss = {
 	'@container (max-width: 620px)': {
@@ -252,7 +264,13 @@ const primaryCellCss = {
 	...cellCss,
 	fontWeight: 620,
 	whiteSpace: 'nowrap' as const,
-	'@container (max-width: 620px)': { whiteSpace: 'normal' },
+	// Let the cell shrink so sibling columns and the scroller can claim width
+	// instead of the primary name forcing the whole table past the pane.
+	maxWidth: '28rem',
+	'@container (max-width: 620px)': {
+		whiteSpace: 'normal',
+		maxWidth: 'none',
+	},
 }
 
 const rowLinkCss = {
@@ -636,17 +654,21 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 						<p mix={css(emptyCss)}>
 							{handle.props.emptyLabel ?? 'Nothing to show yet.'}
 						</p>
-					) : capped ? (
+					) : (
 						<div
 							mix={css({
-								maxHeight: handle.props.scrollHeight ?? defaultScrollHeight,
-								overflowY: 'auto',
+								...tableScrollerCss,
+								...(capped
+									? {
+											maxHeight:
+												handle.props.scrollHeight ?? defaultScrollHeight,
+											overflowY: 'auto' as const,
+										}
+									: null),
 							})}
 						>
 							{table}
 						</div>
-					) : (
-						table
 					)}
 					{handle.props.footer ? (
 						<div mix={css(footerCss)}>{handle.props.footer}</div>

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -355,6 +355,9 @@ export function createAppRouter(env: Env) {
 			adminFeatureFlagsApi: createAdminFeatureFlagsApiHandler(env),
 			adminFeatureFlagsApiPost: createAdminFeatureFlagsApiHandler(env),
 			adminPlatformIntegrations: createAdminPlatformIntegrationsHandler(env),
+			adminPlatformIntegrationNew: createAdminPlatformIntegrationsHandler(env),
+			adminPlatformIntegrationDetail:
+				createAdminPlatformIntegrationsHandler(env),
 			adminPlatformIntegrationsApi:
 				createAdminPlatformIntegrationsApiHandler(env),
 			adminPlatformIntegrationsApiPost:

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -96,6 +96,8 @@ export const routes = route({
 	adminFeatureFlagsApi: '/admin/feature-flags.json',
 	adminFeatureFlagsApiPost: post('/admin/feature-flags.json'),
 	adminPlatformIntegrations: '/admin/platform-integrations',
+	adminPlatformIntegrationNew: '/admin/platform-integrations/new',
+	adminPlatformIntegrationDetail: '/admin/platform-integrations/:slug',
 	adminPlatformIntegrationsApi: '/admin/platform-integrations.json',
 	adminPlatformIntegrationsApiPost: post('/admin/platform-integrations.json'),
 	adminCodemods: '/admin/codemods',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixed `RecordTable` clipping wide rows by giving the table a horizontal scroller (`overflow-x: auto`), clipping the card with `overflow: clip`, and clamping primary cell names so package lists stay readable.
- Migrated `/admin/platform-integrations` onto the same `RecordTable` with `mode="expand"`, so selecting a row unfolds the create/edit form under that row (create uses `/new` as an orphaned pane below the table).
- Wired list/detail/new routes for platform integrations and documented the editor-in-expand exception in the 0010 page inventory.

## Test plan

- [x] RecordTable unit tests (contracts + overflow CSS)
- [x] Admin platform integrations handler tests
- [x] Full unit suite + e2e via push hooks
- [ ] Spot-check `/account/packages` no longer clips Tags/Updated
- [ ] Spot-check `/admin/platform-integrations` expand → edit form, Create → `/new`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `28b74f25` · **Head:** `5c948a06`

**Classification:** composes — shared RecordTable overflow fix and admin UI migration onto existing list/detail routing; no new backend primitives.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — RecordTable scroll + platform-integrations expand/edit |

### System map

Admin platform integrations and account packages both render through the shared RecordTable; detail selection stays URL-driven.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appUi -->|"RecordTable overflow-x + expand form"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| `RecordTable` | Wide rows clipped by `overflow: hidden` | Horizontal scroller + primary cell clamp |
| `/admin/platform-integrations` | Card stack + bottom create/edit panel | RecordTable expand with form under the row |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87b86af0-268c-44bd-b09a-13f4bbb47faa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87b86af0-268c-44bd-b09a-13f4bbb47faa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added searchable list and detail views for admin platform integrations.
  - Added dedicated routes for creating and editing integrations.
  - Added controls to enable, disable, delete, and manage integration logos.

- **Improvements**
  - Wide tables now scroll horizontally instead of clipping content.
  - Package names and identifiers are better truncated for compact displays.

- **Documentation**
  - Updated screen inventory and table guidance for integration editors and horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->