### PR TITLE
Server-render the connect-oauth prefill; prefetch on SPA navigation

### DIFF
--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -5,10 +5,18 @@ import {
 import {
 	type AccountIntegrationDetailLoaderData,
 	type AccountSecretsLoaderData,
+	type ConnectOauthLoaderData,
 } from '#universal/loader-data.ts'
 import { type Handle, css } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import {
+	type RouteLoaderResult,
+	routeLoaderRedirect,
+} from '#client/route-loader.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import {
 	buildHostApprovalRequestUrl,
@@ -86,6 +94,54 @@ type OAuthCallback =
 	| { kind: 'none' }
 	| { kind: 'error'; error: string; description: string | null }
 	| { kind: 'success'; code: string; state: string | null }
+
+const emptyConnectOauthLoaderData: ConnectOauthLoaderData = {
+	ok: true,
+	provider: null,
+	integration: null,
+}
+
+/**
+ * SPA-navigation prefetch mirroring the server handler's SSR embed: the
+ * stored or built-in record for `?provider=` visits, resolved before the
+ * route renders. Callback returns (`code`/`error`) restore config from
+ * sessionStorage and bare visits redirect server-side, so both prefetch
+ * nothing.
+ */
+export async function connectOauthRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const params = url.searchParams
+	const provider = params.get('provider')?.trim()
+	if (!provider || params.get('code') || params.get('error')) {
+		return { connectOauth: emptyConnectOauthLoaderData }
+	}
+	const providerKey = normalizeProviderKey(provider)
+	if (!providerKey) {
+		return { connectOauth: emptyConnectOauthLoaderData }
+	}
+	const response = await fetch(
+		`/account/integrations.json?name=${encodeURIComponent(providerKey)}`,
+		{
+			headers: { Accept: 'application/json' },
+			credentials: 'include',
+			signal,
+		},
+	)
+	if (response.status === 401) {
+		return routeLoaderRedirect('/login')
+	}
+	const payload = await readJson<AccountIntegrationDetailLoaderData>(response)
+	return {
+		connectOauth: {
+			ok: true,
+			provider: providerKey,
+			integration:
+				response.ok && payload?.ok ? (payload.integration ?? null) : null,
+		},
+	}
+}
 
 export function ConnectOauthRoute(handle: Handle) {
 	type StatusTone = 'info' | 'warn' | 'error'
@@ -943,6 +999,27 @@ export function ConnectOauthRoute(handle: Handle) {
 		if (initialLoadStarted) return
 		initialLoadStarted = true
 		try {
+			// SSR-embedded on direct visits, loader-prefetched on SPA
+			// navigations; the integrations fetch below only runs as a
+			// fallback (e.g. callback returns that lost sessionStorage).
+			const routeData = tryConsumeRouteLoaderData(
+				handle,
+				'connectOauth',
+				readCurrentRouterHref(handle),
+			)
+			const preloadedIntegrationFor = (providerKey: string) =>
+				routeData && routeData.provider === providerKey
+					? routeData.integration
+					: undefined
+			const resolveExistingIntegration = async (
+				queryConfig: ConnectOauthQueryConfig,
+			): Promise<StoredIntegrationConfig | null> => {
+				const preloaded = preloadedIntegrationFor(queryConfig.providerKey)
+				if (preloaded !== undefined) {
+					return preloaded ? toStoredIntegrationConfig(preloaded) : null
+				}
+				return readExistingIntegrationConfig(queryConfig)
+			}
 			const callback = readCallback()
 			if (callback.kind === 'success' || callback.kind === 'error') {
 				const storedConfig = readStoredConfig()
@@ -953,7 +1030,7 @@ export function ConnectOauthRoute(handle: Handle) {
 						? mergeConnectOauthConfig({
 								queryConfig,
 								storedIntegration:
-									await readExistingIntegrationConfig(queryConfig),
+									await resolveExistingIntegration(queryConfig),
 							})
 						: null)
 				if (!nextConfig) {
@@ -972,8 +1049,7 @@ export function ConnectOauthRoute(handle: Handle) {
 				setStatus('Missing required OAuth configuration parameters.', 'error')
 				return
 			}
-			const existingIntegration =
-				await readExistingIntegrationConfig(queryConfig)
+			const existingIntegration = await resolveExistingIntegration(queryConfig)
 			existingIntegrationConfig = existingIntegration
 			const nextConfig = mergeConnectOauthConfig({
 				queryConfig,

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -269,6 +269,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		onboardingArea,
 		(m) => m.onboardingRouteLoader,
 	),
+	[routePattern(routes.connectOauth)]: lazyRouteLoader(
+		onboardingArea,
+		(m) => m.connectOauthRouteLoader,
+	),
 	[routePattern(routes.pendingVerification)]: pendingVerificationRouteLoader,
 }
 

--- a/packages/worker/client/routes/onboarding-area.ts
+++ b/packages/worker/client/routes/onboarding-area.ts
@@ -1,4 +1,4 @@
-export { ConnectOauthRoute } from './connect-oauth.tsx'
+export { ConnectOauthRoute, connectOauthRouteLoader } from './connect-oauth.tsx'
 export { OnboardingRoute, onboardingRouteLoader } from './onboarding.tsx'
 export {
 	OAuthAuthorizeRoute,

--- a/packages/worker/src/app/handlers/connect-oauth.node.test.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.node.test.ts
@@ -1,9 +1,35 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { RequestContext } from 'remix/router'
 import {
 	createConnectOauthHandler,
 	isBareConnectOauthVisit,
 } from '#app/handlers/connect-oauth.ts'
+
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn<() => Promise<unknown>>(),
+	requirePageSession: vi.fn<() => Promise<Response | null>>(),
+	loadAccountIntegrationByName: vi.fn<() => Promise<unknown>>(),
+	renderAppPage: vi.fn<(input: unknown) => Promise<Response>>(),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#app/page-auth.ts', () => ({
+	requirePageSession: (...args: Array<unknown>) =>
+		mockModule.requirePageSession(...args),
+}))
+
+vi.mock('#app/account-integrations-data.ts', () => ({
+	loadAccountIntegrationByName: (...args: Array<unknown>) =>
+		mockModule.loadAccountIntegrationByName(...args),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: (input: unknown) => mockModule.renderAppPage(input),
+}))
 
 test('bare /connect/oauth visits redirect to the OAuth guide', async () => {
 	const env = {} as Env
@@ -34,6 +60,9 @@ test('provider, callback, and denial visits are not bare', () => {
 
 test('anonymous visits with a provider still hit the session gate', async () => {
 	const env = {} as Env
+	mockModule.requirePageSession.mockResolvedValue(
+		Response.redirect('https://example.com/login', 302),
+	)
 	const response = await createConnectOauthHandler(env).handler(
 		new RequestContext(
 			new Request('https://example.com/connect/oauth?provider=github'),
@@ -41,4 +70,51 @@ test('anonymous visits with a provider still hit the session gate', async () => 
 	)
 	expect(response.status).toBe(302)
 	expect(response.headers.get('location')).toContain('/login')
+})
+
+test('provider visits embed the integration record as SSR loader data', async () => {
+	const env = {} as Env
+	const record = { name: 'github', platform: true }
+	mockModule.requirePageSession.mockResolvedValue(null)
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		mcpUser: { userId: 'user-1' },
+	})
+	mockModule.loadAccountIntegrationByName.mockResolvedValue(record)
+	mockModule.renderAppPage.mockResolvedValue(new Response('ok'))
+
+	await createConnectOauthHandler(env).handler(
+		new RequestContext(
+			new Request('https://example.com/connect/oauth?provider=GitHub'),
+		),
+	)
+	// The provider param normalizes before the lookup, matching the client.
+	expect(mockModule.loadAccountIntegrationByName).toHaveBeenCalledWith(
+		env,
+		expect.anything(),
+		'github',
+	)
+	expect(mockModule.renderAppPage).toHaveBeenCalledWith(
+		expect.objectContaining({
+			loaderData: {
+				connectOauth: { ok: true, provider: 'github', integration: record },
+			},
+		}),
+	)
+})
+
+test('callback returns render without loader data', async () => {
+	const env = {} as Env
+	mockModule.requirePageSession.mockResolvedValue(null)
+	mockModule.loadAccountIntegrationByName.mockClear()
+	mockModule.renderAppPage.mockResolvedValue(new Response('ok'))
+
+	await createConnectOauthHandler(env).handler(
+		new RequestContext(
+			new Request('https://example.com/connect/oauth?code=auth-code&state=abc'),
+		),
+	)
+	expect(mockModule.loadAccountIntegrationByName).not.toHaveBeenCalled()
+	expect(mockModule.renderAppPage).toHaveBeenCalledWith(
+		expect.not.objectContaining({ loaderData: expect.anything() }),
+	)
 })

--- a/packages/worker/src/app/handlers/connect-oauth.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.ts
@@ -1,6 +1,10 @@
 import { type Action } from 'remix/router'
+import { normalizeProviderKey } from '@kody-internal/shared/url-hosts.ts'
+import { loadAccountIntegrationByName } from '#app/account-integrations-data.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { requirePageSession } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { type ConnectOauthLoaderData } from '#universal/loader-data.ts'
 import { type routes } from '#universal/routes.ts'
 
 /**
@@ -17,6 +21,31 @@ export function isBareConnectOauthVisit(url: URL): boolean {
 	return !params.get('provider') && !params.get('code') && !params.get('error')
 }
 
+/**
+ * SSR prefill for `?provider=` visits: the same record the
+ * `/account/integrations.json?name=` endpoint serves, embedded so a direct
+ * navigation renders (and auto-starts built-ins) without a client fetch.
+ * Callback returns (`code`/`error`) restore config from sessionStorage, so
+ * their query carries no provider and nothing is loaded.
+ */
+async function loadConnectOauthLoaderData(
+	env: Env,
+	request: Request,
+	requestUrl: URL,
+): Promise<ConnectOauthLoaderData | null> {
+	const provider = requestUrl.searchParams.get('provider')?.trim()
+	if (!provider) return null
+	const providerKey = normalizeProviderKey(provider)
+	if (!providerKey) return null
+	const user = await readAuthenticatedAppUser(request, env)
+	if (!user) return null
+	return {
+		ok: true,
+		provider: providerKey,
+		integration: await loadAccountIntegrationByName(env, user, providerKey),
+	}
+}
+
 export function createConnectOauthHandler(env: Env) {
 	return {
 		middleware: [],
@@ -29,10 +58,16 @@ export function createConnectOauthHandler(env: Env) {
 			if (sessionRedirect) {
 				return sessionRedirect
 			}
+			const connectOauth = await loadConnectOauthLoaderData(
+				env,
+				request,
+				requestUrl,
+			)
 			return renderAppPage({
 				request,
 				env,
 				title: 'Connect OAuth',
+				...(connectOauth ? { loaderData: { connectOauth } } : {}),
 			})
 		},
 	} satisfies Action<typeof routes.connectOauth>

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -857,6 +857,18 @@ export type AccountIntegrationDetailLoaderData = {
 	integration: AccountIntegrationListItem | null
 }
 
+/**
+ * /connect/oauth prefill for `?provider=` visits: the stored or built-in
+ * record the page merges into its config. `provider` is the normalized key
+ * the record was resolved for; null on callback and bare visits, which have
+ * nothing to prefetch.
+ */
+export type ConnectOauthLoaderData = {
+	ok: true
+	provider: string | null
+	integration: AccountIntegrationListItem | null
+}
+
 export type AccountMcpServerListItem = {
 	id: string
 	name: string
@@ -1397,6 +1409,7 @@ export type AppLoaderData = {
 	accountProfile?: AccountProfileLoaderData
 	accountConnections?: AccountConnectionsLoaderData
 	onboarding?: OnboardingLoaderData
+	connectOauth?: ConnectOauthLoaderData
 	pendingVerification?: PendingVerificationLoaderData
 	accountTwoFactor?: AccountTwoFactorLoaderData
 	accountPasskeys?: AccountPasskeysLoaderData


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`/connect/oauth?provider=` resolved its stored/built-in record with a client-side fetch after render. It now follows the app-wide loader pattern:

- **Direct visits**: `createConnectOauthHandler` embeds the same record `/account/integrations.json?name=` serves as SSR loader data (`connectOauth` key; provider param normalized with the same shared `normalizeProviderKey` the client uses), so the page renders — and built-ins auto-start — with zero client data fetches.
- **SPA navigations**: a new `connectOauthRouteLoader` (registered in `clientRouteLoaders` on the onboarding lazy chunk) prefetches the record before the route renders, redirecting to `/login` on 401.
- The in-component fetch survives only as a fallback for callback returns that lost their sessionStorage config — callbacks carry no `provider` param, so neither the embed nor the loader covers them by design.

## Testing

- Handler tests: SSR embed shape and normalized lookup for `?provider=` visits, no loader data on callback returns, plus the existing bare-redirect and session-gate cases.
- `npm run validate` green.
- Verified against the dev server request log during browser checks: a direct visit produced one `GET /connect/oauth` and **no** `integrations.json` request; an SPA navigation from the onboarding card produced exactly one loader-driven `integrations.json` request before render. Both paths auto-redirect into GitHub's authorize flow.

<a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnect_oauth_ssr_and_spa_loader_demo.mp4"><img src="https://cursor.com/artifacts/c/art-636c69fb-1157-45cd-bd5e-bbb5f9c4d9ad" alt="connect_oauth_ssr_and_spa_loader_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

