### PR TITLE
Surface the built-in lane choice; default outbound User-Agent

### DIFF
--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -121,8 +121,9 @@ export async function connectOauthRouteLoader(
 	if (!providerKey) {
 		return { connectOauth: emptyConnectOauthLoaderData }
 	}
+	const preferPlatform = params.get('platform') === '1'
 	const response = await fetch(
-		`/account/integrations.json?name=${encodeURIComponent(providerKey)}`,
+		`/account/integrations.json?name=${encodeURIComponent(providerKey)}${preferPlatform ? '&platform=1' : ''}`,
 		{
 			headers: { Accept: 'application/json' },
 			credentials: 'include',
@@ -139,6 +140,10 @@ export async function connectOauthRouteLoader(
 			provider: providerKey,
 			integration:
 				response.ok && payload?.ok ? (payload.integration ?? null) : null,
+			builtInAvailable:
+				response.ok && payload?.ok
+					? (payload.builtInAvailable ?? false)
+					: false,
 		},
 	}
 }
@@ -173,6 +178,8 @@ export function ConnectOauthRoute(handle: Handle) {
 	let hasConfigError = false
 	let connectOauthHandled = false
 	let hostApprovalLinks: Array<ConnectOauthHostApprovalLink> = []
+	/** An enabled built-in exists that this user-lane connection is not using. */
+	let builtInAvailable = false
 	let nextSteps: ConnectOauthNextSteps | null = null
 	let approvingAllHosts = false
 	let submitting = false
@@ -454,8 +461,11 @@ export function ConnectOauthRoute(handle: Handle) {
 	const readExistingIntegrationConfig = async (
 		queryConfig: ConnectOauthQueryConfig,
 	): Promise<StoredIntegrationConfig | null> => {
+		const preferPlatform =
+			typeof window !== 'undefined' &&
+			new URLSearchParams(window.location.search).get('platform') === '1'
 		const response = await fetch(
-			`/account/integrations.json?name=${encodeURIComponent(queryConfig.providerKey)}`,
+			`/account/integrations.json?name=${encodeURIComponent(queryConfig.providerKey)}${preferPlatform ? '&platform=1' : ''}`,
 			{
 				method: 'GET',
 				headers: { Accept: 'application/json' },
@@ -466,9 +476,9 @@ export function ConnectOauthRoute(handle: Handle) {
 		const payload = (await response
 			.json()
 			.catch(() => null)) as AccountIntegrationDetailLoaderData | null
-		if (!response.ok || payload?.ok !== true || !payload.integration) {
-			return null
-		}
+		if (!response.ok || payload?.ok !== true) return null
+		builtInAvailable = payload.builtInAvailable ?? false
+		if (!payload.integration) return null
 		return toStoredIntegrationConfig(payload.integration)
 	}
 
@@ -716,6 +726,39 @@ export function ConnectOauthRoute(handle: Handle) {
 			submitting = false
 			update()
 		}
+	}
+
+	/**
+	 * Shown when the current (or prospective) connection runs on the user's
+	 * own OAuth app while an enabled built-in exists for the same name. A
+	 * complete bring-your-own record wins the lookup by design, so without
+	 * this the built-in lane is invisible from the connect page.
+	 */
+	const renderBuiltInAlternative = () => {
+		if (!builtInAvailable || !config || config.platformAppSlug) return null
+		return (
+			<p mix={css(descriptionCss)}>
+				This uses your own OAuth app for {config.provider}. Prefer the hosted
+				one?{' '}
+				<a
+					href={`/connect/oauth?provider=${encodeURIComponent(config.providerKey)}&platform=1`}
+					mix={[
+						css(primaryLinkCss),
+						// Full document load on purpose: this page's init
+						// (config resolution, built-in auto-start) runs per
+						// document load, and a same-route SPA swap reuses the
+						// mounted instance without re-running it.
+						on('click', (event) => {
+							event.preventDefault()
+							window.location.assign(event.currentTarget.href)
+						}),
+					]}
+				>
+					Use the built-in {config.provider} integration instead
+				</a>{' '}
+				— connecting it replaces this connection&apos;s tokens and scopes.
+			</p>
+		)
 	}
 
 	const handleConnect = async () => {
@@ -1007,6 +1050,9 @@ export function ConnectOauthRoute(handle: Handle) {
 				'connectOauth',
 				readCurrentRouterHref(handle),
 			)
+			if (routeData) {
+				builtInAvailable = routeData.builtInAvailable ?? false
+			}
 			const preloadedIntegrationFor = (providerKey: string) =>
 				routeData && routeData.provider === providerKey
 					? routeData.integration
@@ -1187,6 +1233,7 @@ export function ConnectOauthRoute(handle: Handle) {
 							1. {existingIntegrationConfig ? 'Review' : 'Save'} OAuth client
 							configuration
 						</h2>
+						{renderBuiltInAlternative()}
 						{renderProviderInstructions()}
 						{renderAllowedHosts()}
 						<form
@@ -1293,6 +1340,7 @@ export function ConnectOauthRoute(handle: Handle) {
 						<p mix={css({ margin: 0, color: colors.text })}>
 							Start the OAuth flow. You will be redirected to the provider.
 						</p>
+						{renderBuiltInAlternative()}
 						{existingIntegrationConfig && hasStoredClientId ? (
 							<p mix={css(descriptionCss)}>
 								Using stored client ID

--- a/packages/worker/src/app/account-integrations-data.node.test.ts
+++ b/packages/worker/src/app/account-integrations-data.node.test.ts
@@ -8,6 +8,7 @@ import {
 } from '#worker/integrations/service.ts'
 import { upsertPlatformOauthApp } from '#worker/integrations/platform-apps.ts'
 import {
+	hasAlternativeBuiltInApp,
 	loadAccountIntegrationByName,
 	loadAccountIntegrationsData,
 	loadAccountOauthAppBySlug,
@@ -328,6 +329,20 @@ test('endpoint-incomplete user records defer to an enabled built-in of the same 
 	)
 	expect(byoWins?.clientId).toBe('user-github-client')
 	expect(byoWins?.platform ?? false).toBe(false)
+	// The winning BYO record shadows an enabled built-in — the connect page
+	// surfaces the alternative lane instead of hiding it.
+	expect(await hasAlternativeBuiltInApp(env, 'github', byoWins)).toBe(true)
+
+	// Explicit built-in intent overrides the BYO win.
+	const forced = await loadAccountIntegrationByName(
+		env,
+		fakeUser(userId),
+		'github',
+		{ preferPlatform: true },
+	)
+	expect(forced?.platform).toBe(true)
+	expect(forced?.clientId).toBe('platform-github-client')
+	expect(await hasAlternativeBuiltInApp(env, 'github', forced)).toBe(false)
 
 	// No built-in for the slug: the incomplete record still returns so the
 	// setup form can prefill what exists.

--- a/packages/worker/src/app/account-integrations-data.ts
+++ b/packages/worker/src/app/account-integrations-data.ts
@@ -230,6 +230,15 @@ export async function loadAccountIntegrationByName(
 	env: Env,
 	user: AuthenticatedUser,
 	name: string,
+	options?: {
+		/**
+		 * Explicit built-in intent (`platform=1` on /connect/oauth): resolve
+		 * the enabled platform app directly instead of letting a complete
+		 * bring-your-own record win. Falls back to the normal priority when
+		 * no built-in exists for the name.
+		 */
+		preferPlatform?: boolean
+	},
 ): Promise<AccountIntegrationRecord | null> {
 	// A user-lane record still wins when it can actually drive the flow (the
 	// bring-your-own override); an endpoint-incomplete one defers to an
@@ -237,6 +246,11 @@ export async function loadAccountIntegrationByName(
 	const platformFallback = async () => {
 		const platformApp = await getAvailablePlatformApp({ env, slug: name })
 		return platformApp ? toPlatformAppPrefillRecord(platformApp, name) : null
+	}
+
+	if (options?.preferPlatform) {
+		const platformRecord = await platformFallback()
+		if (platformRecord) return platformRecord
 	}
 
 	// 1. Existing connection (reconnect) — connection name, not app slug.
@@ -267,4 +281,18 @@ export async function loadAccountIntegrationByName(
 	// 4. Platform (built-in) app: the user needs no OAuth app of their own, so
 	// the connect flow can skip client-credential setup entirely.
 	return platformFallback()
+}
+
+/**
+ * True when an enabled built-in exists for `name` that the resolved record
+ * is not already using — the connect page offers it as an alternative lane.
+ */
+export async function hasAlternativeBuiltInApp(
+	env: Env,
+	name: string,
+	record: AccountIntegrationRecord | null,
+): Promise<boolean> {
+	if (record?.platform) return false
+	const platformApp = await getAvailablePlatformApp({ env, slug: name })
+	return platformApp != null
 }

--- a/packages/worker/src/app/handlers/account-integrations.node.test.ts
+++ b/packages/worker/src/app/handlers/account-integrations.node.test.ts
@@ -489,6 +489,7 @@ test('integrations API returns one connection by name for the connect OAuth flow
 	})
 	await expect(response.json()).resolves.toEqual({
 		ok: true,
+		builtInAvailable: false,
 		integration: {
 			name: 'github',
 			appSlug: 'github',
@@ -528,6 +529,7 @@ test('integrations API returns null when a named connection is missing', async (
 	expect(response.status).toBe(200)
 	await expect(response.json()).resolves.toEqual({
 		ok: true,
+		builtInAvailable: false,
 		integration: null,
 	})
 })

--- a/packages/worker/src/app/handlers/account-integrations.ts
+++ b/packages/worker/src/app/handlers/account-integrations.ts
@@ -3,6 +3,7 @@ import { jsonResponse } from '#worker/json-response.ts'
 import { type Action } from 'remix/router'
 import { safeParseHost } from '@kody-internal/shared/url-hosts.ts'
 import {
+	hasAlternativeBuiltInApp,
 	loadAccountIntegrationByName,
 	loadAccountIntegrationsData,
 	loadAccountOauthAppBySlug,
@@ -75,9 +76,21 @@ export function createAccountIntegrationsApiHandler(env: Env) {
 				const searchParams = new URL(request.url).searchParams
 				const name = searchParams.get('name')?.trim()
 				if (name) {
+					const preferPlatform = searchParams.get('platform') === '1'
+					const integration = await loadAccountIntegrationByName(
+						env,
+						user,
+						name,
+						{ preferPlatform },
+					)
 					return jsonResponse({
 						ok: true,
-						integration: await loadAccountIntegrationByName(env, user, name),
+						integration,
+						builtInAvailable: await hasAlternativeBuiltInApp(
+							env,
+							name,
+							integration,
+						),
 					})
 				}
 				const appSlug = searchParams.get('appSlug')?.trim()

--- a/packages/worker/src/app/handlers/connect-oauth.node.test.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.node.test.ts
@@ -9,6 +9,7 @@ const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn<() => Promise<unknown>>(),
 	requirePageSession: vi.fn<() => Promise<Response | null>>(),
 	loadAccountIntegrationByName: vi.fn<() => Promise<unknown>>(),
+	hasAlternativeBuiltInApp: vi.fn<() => Promise<boolean>>(),
 	renderAppPage: vi.fn<(input: unknown) => Promise<Response>>(),
 }))
 
@@ -25,6 +26,8 @@ vi.mock('#app/page-auth.ts', () => ({
 vi.mock('#app/account-integrations-data.ts', () => ({
 	loadAccountIntegrationByName: (...args: Array<unknown>) =>
 		mockModule.loadAccountIntegrationByName(...args),
+	hasAlternativeBuiltInApp: (...args: Array<unknown>) =>
+		mockModule.hasAlternativeBuiltInApp(...args),
 }))
 
 vi.mock('#app/ssr-render.tsx', () => ({
@@ -82,6 +85,8 @@ test('provider visits embed the integration record as SSR loader data', async ()
 	mockModule.loadAccountIntegrationByName.mockResolvedValue(record)
 	mockModule.renderAppPage.mockResolvedValue(new Response('ok'))
 
+	mockModule.hasAlternativeBuiltInApp.mockResolvedValue(false)
+
 	await createConnectOauthHandler(env).handler(
 		new RequestContext(
 			new Request('https://example.com/connect/oauth?provider=GitHub'),
@@ -92,13 +97,47 @@ test('provider visits embed the integration record as SSR loader data', async ()
 		env,
 		expect.anything(),
 		'github',
+		{ preferPlatform: false },
 	)
 	expect(mockModule.renderAppPage).toHaveBeenCalledWith(
 		expect.objectContaining({
 			loaderData: {
-				connectOauth: { ok: true, provider: 'github', integration: record },
+				connectOauth: {
+					ok: true,
+					provider: 'github',
+					integration: record,
+					builtInAvailable: false,
+				},
 			},
 		}),
+	)
+})
+
+test('platform=1 forces the built-in lookup', async () => {
+	const env = {} as Env
+	mockModule.requirePageSession.mockResolvedValue(null)
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		mcpUser: { userId: 'user-1' },
+	})
+	mockModule.loadAccountIntegrationByName.mockResolvedValue({
+		name: 'google',
+		platform: true,
+	})
+	mockModule.hasAlternativeBuiltInApp.mockResolvedValue(false)
+	mockModule.renderAppPage.mockResolvedValue(new Response('ok'))
+
+	await createConnectOauthHandler(env).handler(
+		new RequestContext(
+			new Request(
+				'https://example.com/connect/oauth?provider=google&platform=1',
+			),
+		),
+	)
+	expect(mockModule.loadAccountIntegrationByName).toHaveBeenLastCalledWith(
+		env,
+		expect.anything(),
+		'google',
+		{ preferPlatform: true },
 	)
 })
 

--- a/packages/worker/src/app/handlers/connect-oauth.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.ts
@@ -1,6 +1,9 @@
 import { type Action } from 'remix/router'
 import { normalizeProviderKey } from '@kody-internal/shared/url-hosts.ts'
-import { loadAccountIntegrationByName } from '#app/account-integrations-data.ts'
+import {
+	hasAlternativeBuiltInApp,
+	loadAccountIntegrationByName,
+} from '#app/account-integrations-data.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { requirePageSession } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -39,10 +42,22 @@ async function loadConnectOauthLoaderData(
 	if (!providerKey) return null
 	const user = await readAuthenticatedAppUser(request, env)
 	if (!user) return null
+	const preferPlatform = requestUrl.searchParams.get('platform') === '1'
+	const integration = await loadAccountIntegrationByName(
+		env,
+		user,
+		providerKey,
+		{ preferPlatform },
+	)
 	return {
 		ok: true,
 		provider: providerKey,
-		integration: await loadAccountIntegrationByName(env, user, providerKey),
+		integration,
+		builtInAvailable: await hasAlternativeBuiltInApp(
+			env,
+			providerKey,
+			integration,
+		),
 	}
 }
 

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -588,6 +588,36 @@ test('fetch gateway resolves path-only URLs against baseUrl', async () => {
 	expect(nested.url).toBe('https://example.com/core/log')
 })
 
+test('outbound requests get a default User-Agent; caller values win', async () => {
+	// GitHub rejects UA-less requests with an opaque 403, and workerd sends
+	// no UA by default.
+	const bare = await expandSecretPlaceholders({
+		request: new Request('https://api.github.com/user'),
+		props,
+		env,
+	})
+	expect(bare.headers.get('user-agent')).toBe('kody-agent/1.0')
+
+	const custom = await expandSecretPlaceholders({
+		request: new Request('https://api.github.com/user', {
+			headers: { 'User-Agent': 'my-package/2.0' },
+		}),
+		props,
+		env,
+	})
+	expect(custom.headers.get('user-agent')).toBe('my-package/2.0')
+
+	// The resolution-off fast path applies the same default.
+	const modeOff = await expandSecretPlaceholders({
+		request: new Request('https://api.github.com/user', {
+			headers: { 'x-kody-secret-resolution': 'off' },
+		}),
+		props,
+		env,
+	})
+	expect(modeOff.headers.get('user-agent')).toBe('kody-agent/1.0')
+})
+
 test('gateway fetch records outbound_fetch usage metering', async () => {
 	const usageModule = await import('#worker/usage/record-usage.ts')
 	const recordUsageSpy = vi

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -223,6 +223,12 @@ export async function expandSecretPlaceholders(input: {
 	env: Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>
 }) {
 	const headers = new Headers(input.request.headers)
+	// Several APIs (GitHub most prominently) reject requests without a
+	// User-Agent outright, and workerd sends none by default — bare sandbox
+	// fetches hit opaque 403s. Callers that set their own keep it.
+	if (!headers.has('user-agent')) {
+		headers.set('user-agent', 'kody-agent/1.0')
+	}
 	const baseUrl = input.props.baseUrl.trim()
 	if (!baseUrl) {
 		throw new Error('Fetch gateway requires a non-empty baseUrl in props.')

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -855,6 +855,12 @@ export type AccountIntegrationsLoaderData = {
 export type AccountIntegrationDetailLoaderData = {
 	ok: true
 	integration: AccountIntegrationListItem | null
+	/**
+	 * True when an enabled built-in app exists for the requested name and the
+	 * returned record is not already using it (the bring-your-own record won
+	 * the lookup). The connect page offers the built-in as an alternative.
+	 */
+	builtInAvailable?: boolean
 }
 
 /**
@@ -867,6 +873,8 @@ export type ConnectOauthLoaderData = {
 	ok: true
 	provider: string | null
 	integration: AccountIntegrationListItem | null
+	/** See {@link AccountIntegrationDetailLoaderData.builtInAvailable}. */
+	builtInAvailable?: boolean
 }
 
 export type AccountMcpServerListItem = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Live-testing the newly credentialed GitHub and Google built-ins (as the operator's own account) surfaced two rough edges:

### 1. The BYO-override was invisible

A complete bring-your-own record wins the connect lookup by design — but silently: clicking a built-in card reconnects the user's *own* app with zero indication. (Observed in production: the google built-in showed **0 connections** after its operator "connected" to it; his complete BYO google record had won.) Now:

- `/account/integrations.json?name=` carries `builtInAvailable` — true when an enabled built-in exists that the returned record isn't using.
- `/connect/oauth` accepts `platform=1`, which forces the built-in prefill (and therefore the auto-start into the provider's consent screen). Forwarded through the SSR embed, the SPA route loader, and the in-component fallback identically.
- The connect page shows a notice on user-lane configs when a built-in exists: "This uses your own OAuth app for {provider}. Prefer the hosted one? **Use the built-in {provider} integration instead** — connecting it replaces this connection's tokens and scopes." No silent lane conversion in either direction; the choice (and the scope trade-off) is the user's.
- The notice link forces a full document load — a same-route SPA swap reuses the mounted route instance without re-running its init, so the auto-start would never fire (caught during verification).

### 2. Bare sandbox fetches to GitHub 403'd

GitHub rejects requests without a `User-Agent` and workerd sends none, so ad-hoc agent code calling `api.github.com` through `createAuthenticatedFetch` hit an opaque administrative 403 (packages that set their own UA were unaffected). The fetch gateway now sets `kody-agent/1.0` when the caller doesn't provide one; caller values always win. Applied on both the placeholder-resolution path and the resolution-off fast path.

## Testing

- Data tests: `preferPlatform` overrides a complete BYO win; `hasAlternativeBuiltInApp` true only for user-lane records shadowing an enabled built-in.
- Handler tests: `platform=1` forwarding, `builtInAvailable` in the SSR embed shape.
- Gateway tests: default UA applied on both paths, caller UA preserved.
- Full validation green (one e2e re-run needed: the first run's failures were the e2e web server crashing from contention with the long-running dev server — all 7 pass in isolation).
- Browser-verified end to end: notice renders on a complete-BYO account, the built-in link does a full load with `platform=1` and auto-redirects into GitHub's real sign-in/authorize flow.
- Production smoke tests via MCP: platform-lane GitHub token returns `login: kentcdodds` (with UA), google userinfo 200, `integration_token_refresh` fails cleanly on refresh-token-less connections, and `refreshAccessToken` throws the platform-lane teaching error.

![Connect page notice offering the built-in alternative](https://cursor.com/artifacts/c/art-5f003102-947e-482f-9435-c473a4c2cb39)

<a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuiltin_lane_choice_flow_demo.mp4"><img src="https://cursor.com/artifacts/c/art-251cce35-6420-476e-9f06-575c6c4b39a3" alt="builtin_lane_choice_flow_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to switch from a custom OAuth app to an available hosted integration during setup and connection.
  - OAuth and integration details now indicate when a built-in alternative is available.
  - Added support for selecting the hosted integration when requested.

- **Bug Fixes**
  - Outbound requests now use `kody-agent/1.0` by default while preserving custom User-Agent values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->