### PR TITLE
Use a fixed white plate behind uploaded logos

### DIFF
--- a/packages/worker/client/routes/admin-platform-integrations.tsx
+++ b/packages/worker/client/routes/admin-platform-integrations.tsx
@@ -16,6 +16,7 @@ import {
 	fieldLabelCss,
 	getDangerPillCss,
 	getGhostButtonCss,
+	getLogoWellCss,
 	getPillButtonCss,
 	getSelectCss,
 } from '#universal/styles/style-primitives.ts'
@@ -762,39 +763,64 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 						/>
 					</label>
 					{isEditing && editingApp?.logoPath ? (
-						<label
+						<div
 							mix={css({
-								...fieldCss,
 								display: 'flex',
-								flexDirection: 'row',
 								alignItems: 'center',
-								gap: spacing.sm,
+								gap: spacing.md,
+								flexWrap: 'wrap',
 							})}
 						>
-							<input
-								name="removeLogo"
-								type="checkbox"
-								checked={removeLogoChecked}
-								disabled={actionState !== 'idle'}
-								mix={[
-									css({
-										width: '1.25rem',
-										height: '1.25rem',
-										accentColor: colors.primary,
-									}),
-									on('change', (event) => {
-										const input = event.currentTarget
-										if (!(input instanceof HTMLInputElement)) return
-										removeLogoChecked = input.checked
-										if (removeLogoChecked) {
-											pendingLogoBase64 = undefined
-										}
-										handle.update()
-									}),
-								]}
-							/>
-							<span mix={css(fieldLabelCss)}>Remove logo</span>
-						</label>
+							<span
+								mix={css(getLogoWellCss({ size: '2.5rem', radius: '10px' }))}
+							>
+								<img
+									src={editingApp.logoPath}
+									alt=""
+									width={32}
+									height={32}
+									mix={css({
+										display: 'block',
+										width: '1.75rem',
+										height: '1.75rem',
+										objectFit: 'contain',
+									})}
+								/>
+							</span>
+							<label
+								mix={css({
+									...fieldCss,
+									display: 'flex',
+									flexDirection: 'row',
+									alignItems: 'center',
+									gap: spacing.sm,
+								})}
+							>
+								<input
+									name="removeLogo"
+									type="checkbox"
+									checked={removeLogoChecked}
+									disabled={actionState !== 'idle'}
+									mix={[
+										css({
+											width: '1.25rem',
+											height: '1.25rem',
+											accentColor: colors.primary,
+										}),
+										on('change', (event) => {
+											const input = event.currentTarget
+											if (!(input instanceof HTMLInputElement)) return
+											removeLogoChecked = input.checked
+											if (removeLogoChecked) {
+												pendingLogoBase64 = undefined
+											}
+											handle.update()
+										}),
+									]}
+								/>
+								<span mix={css(fieldLabelCss)}>Remove logo</span>
+							</label>
+						</div>
 					) : null}
 					<label
 						mix={css({

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -50,6 +50,7 @@ import {
 import {
 	getAccentCalloutCss,
 	getGhostButtonCss,
+	getLogoWellCss,
 	getPillButtonCss,
 	hoverMq,
 	inlineSpinnerCss,
@@ -1557,15 +1558,9 @@ const providerCardLinkCss = {
 	minWidth: 0,
 }
 
-/* Same rounded well as CommunityListingIcon size="starter". */
+/* Same rounded white logo plate as CommunityListingIcon size="starter". */
 const providerIconWellCss = {
-	display: 'grid',
-	placeItems: 'center',
-	width: '3.2rem',
-	height: '3.2rem',
-	borderRadius: '12px',
-	border: `1px solid ${colors.border}`,
-	backgroundColor: colors.surface,
+	...getLogoWellCss({ size: '3.2rem', radius: '12px' }),
 	marginBottom: '0.2rem',
 	transition: `border-color 160ms ${transitions.easeOut}`,
 }

--- a/packages/worker/universal/community-listing-icon.tsx
+++ b/packages/worker/universal/community-listing-icon.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource remix/ui */
 /** @jsxRuntime automatic */
 import { type Handle, css } from 'remix/ui'
-import { colors } from '#universal/styles/tokens.ts'
+import { getLogoWellCss } from '#universal/styles/style-primitives.ts'
 import { type PublicCommunityListing } from '#universal/community-public-types.ts'
 
 type CommunityListingIconProps = {
@@ -21,6 +21,8 @@ const iconWellBySize = {
  * `.pkg-icon-lg` grammar). The image is served per pinned commit by the
  * community icon endpoint, which already falls back to a rendered initial
  * when a package publishes no icon — so the well always has a photo to fill.
+ * The well is a fixed white plate so dark or colorful marks stay readable in
+ * both light and dark UI themes.
  */
 export function CommunityListingIcon(
 	handle: Handle<CommunityListingIconProps>,
@@ -31,15 +33,8 @@ export function CommunityListingIcon(
 	return () => (
 		<span
 			mix={css({
-				flex: 'none',
+				...getLogoWellCss(well),
 				display: 'block',
-				width: well.size,
-				height: well.size,
-				borderRadius: well.radius,
-				backgroundColor: isDetail ? colors.surface : colors.background,
-				border: `${well.borderWidth} solid ${colors.border}`,
-				overflow: 'hidden',
-				boxSizing: 'border-box' as const,
 			})}
 			data-testid={`community-listing-icon-${size}`}
 		>

--- a/packages/worker/universal/styles/logo-well.node.test.ts
+++ b/packages/worker/universal/styles/logo-well.node.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+import { getLogoWellCss } from '#universal/styles/style-primitives.ts'
+import { colors } from '#universal/styles/tokens.ts'
+
+test('logo wells use a fixed white plate so marks stay readable in dark mode', () => {
+	const well = getLogoWellCss({ size: '3.2rem', radius: '12px' })
+
+	expect(well.backgroundColor).toBe('#ffffff')
+	expect(well.backgroundColor).toBe(colors.logoWell)
+	expect(well.color).toBe(colors.logoWellInk)
+	expect(well.backgroundColor).not.toBe(colors.surface)
+	expect(well.backgroundColor).not.toBe(colors.background)
+})

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -978,3 +978,30 @@ export function getAlertCardCss(type: 'error' | 'info' = 'info') {
 		fontSize: typography.fontSize.sm,
 	}
 }
+
+/**
+ * Rounded plate behind uploaded or third-party logos. Always white (and
+ * dark ink for `currentColor` marks) so logos that were authored for a
+ * light field stay legible in dark mode without per-logo theme variants.
+ */
+export function getLogoWellCss(
+	options: {
+		size: string
+		radius: string
+		borderWidth?: string
+	} = { size: '3.2rem', radius: '12px' },
+) {
+	return {
+		display: 'grid',
+		placeItems: 'center',
+		flex: 'none',
+		boxSizing: 'border-box' as const,
+		width: options.size,
+		height: options.size,
+		borderRadius: options.radius,
+		border: `${options.borderWidth ?? '1px'} solid ${colors.border}`,
+		backgroundColor: colors.logoWell,
+		color: colors.logoWellInk,
+		overflow: 'hidden' as const,
+	}
+}

--- a/packages/worker/universal/styles/tokens.ts
+++ b/packages/worker/universal/styles/tokens.ts
@@ -19,6 +19,14 @@ export const colors = {
 	onDanger: 'var(--color-on-danger)',
 	error: 'var(--color-danger)',
 	errorHover: 'var(--color-danger-hover)',
+	/**
+	 * Fixed white plate behind uploaded / third-party logos so dark marks
+	 * (GitHub, monochrome SVGs) stay readable in dark mode and colorful
+	 * marks stay consistent across themes. Not a theme variable on purpose.
+	 */
+	logoWell: '#ffffff',
+	/** Ink for `currentColor` marks sitting on {@link colors.logoWell}. */
+	logoWellInk: '#111111',
 } as const
 
 // Typography tokens


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third-party / user-uploaded logos (and built-in provider marks) now sit on a fixed white plate so dark-mode themes don’t swallow black marks (e.g. GitHub onboarding).

Shared `getLogoWellCss` + `colors.logoWell` / `logoWellInk`. Applied to onboarding connect cards, community listing icons, and the admin platform-integration logo preview.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d7f51175` · **Head:** `47070eb4`

**Classification:** composes — no primitives added or changed; this PR wires existing UI tokens into logo wells.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — white logo plate on onboarding, community icons, admin preview |

### System map

Logo wells in app UI compose shared style tokens so uploaded marks stay readable in dark mode.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>App UI"]:::touched
	appUi -->|"getLogoWellCss + logoWell tokens"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart LR
	tokens["tokens.logoWell / logoWellInk"] --> well["getLogoWellCss"]
	well -->|"providerIconWellCss"| onboarding["onboarding connect cards"]
	well -->|"community listing icon"| community["community-listing-icon"]
	well -->|"logo preview wrap"| admin["admin platform integrations"]
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87b86af0-268c-44bd-b09a-13f4bbb47faa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87b86af0-268c-44bd-b09a-13f4bbb47faa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logo previews when editing integrations, with an option to remove existing logos.
  * Standardized logo presentation across onboarding and community listings with centered, readable logo wells.
* **Style**
  * Introduced consistent logo backgrounds, borders, sizing, and theme-safe contrast.
* **Tests**
  * Added coverage to verify logo wells use the correct colors and preserve configured styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->