### PR TITLE
Fix SPA titles missing from the document-head registry

### DIFF
--- a/packages/worker/client/document-head.node.test.ts
+++ b/packages/worker/client/document-head.node.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'vitest'
+import { clientRoutes } from '#client/routes/index.tsx'
+import {
+	NOT_FOUND_DOCUMENT_TITLE,
+	resolveDocumentTitle,
+} from '#universal/document-head.ts'
+
+/**
+ * SPA navigations sync `<title>` from `document-head.ts` only. SSR can still
+ * pass a `title` override into `renderAppPage`, which is why a missing registry
+ * entry shows the correct title on refresh and "Not found" on client nav.
+ * Keep every `clientRoutes` pattern registered so that mismatch cannot regress.
+ */
+
+function concretePathForPattern(pattern: string) {
+	return pattern
+		.split('/')
+		.map((segment) => {
+			if (segment.startsWith(':')) return 'sample'
+			if (segment === '*') return 'sample'
+			return segment
+		})
+		.join('/')
+}
+
+test('every client route resolves a document title other than Not found', () => {
+	const missing: Array<string> = []
+	for (const pattern of Object.keys(clientRoutes)) {
+		const pathname = concretePathForPattern(pattern)
+		const title = resolveDocumentTitle(pathname)
+		if (title === NOT_FOUND_DOCUMENT_TITLE) {
+			missing.push(pattern)
+		}
+	}
+	expect(missing, 'client routes missing document-head entries').toEqual([])
+})
+
+test('admin platform integrations SPA title matches the SSR override', () => {
+	expect(resolveDocumentTitle('/admin/platform-integrations')).toBe(
+		'Admin platform integrations',
+	)
+	expect(resolveDocumentTitle('/admin/platform-integrations/new')).toBe(
+		'Admin platform integrations',
+	)
+	expect(resolveDocumentTitle('/admin/platform-integrations/github')).toBe(
+		'Admin platform integrations',
+	)
+})
+
+test('guides SPA titles resolve from the registry and loader data', () => {
+	expect(resolveDocumentTitle('/guides')).toBe('Guides')
+	expect(resolveDocumentTitle('/guides/oauth')).toBe('Guides')
+	expect(
+		resolveDocumentTitle('/guides/oauth', {
+			guideDetail: {
+				ok: true,
+				slug: 'oauth',
+				id: 'oauth',
+				title: 'Connect with OAuth',
+				summary: 'summary',
+				category: 'platform',
+				provider: null,
+				lastVerified: null,
+				body: '# Connect with OAuth\n',
+			},
+		}),
+	).toBe('Connect with OAuth')
+})

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -161,6 +161,15 @@ const routeDocumentHeads = {
 	[routePattern(routes.adminUserDetail)]: titleOnly('Admin users'),
 	[routePattern(routes.adminInvites)]: titleOnly('Admin invites'),
 	[routePattern(routes.adminFeatureFlags)]: titleOnly('Admin feature flags'),
+	[routePattern(routes.adminPlatformIntegrations)]: titleOnly(
+		'Admin platform integrations',
+	),
+	[routePattern(routes.adminPlatformIntegrationNew)]: titleOnly(
+		'Admin platform integrations',
+	),
+	[routePattern(routes.adminPlatformIntegrationDetail)]: titleOnly(
+		'Admin platform integrations',
+	),
 	[routePattern(routes.adminCodemods)]: titleOnly('Admin codemods'),
 	[routePattern(routes.adminRoles)]: titleOnly('Admin roles'),
 	[routePattern(routes.adminCommunityReports)]: titleOnly('Community reports'),
@@ -194,6 +203,14 @@ const routeDocumentHeads = {
 				imagePath: `/blog/${post.slug}/og.png`,
 			},
 		}
+	},
+	[routePattern(routes.guides)]: titleOnly('Guides'),
+	[routePattern(routes.guideDetail)]: ({ loaderData }) => {
+		const guide = loaderData?.guideDetail
+		if (!guide?.ok) {
+			return titleOnly('Guides')
+		}
+		return titleOnly(guide.title)
 	},
 	[routePattern(routes.community)]: publicPageHead(
 		'community',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Client-side navigation to `/admin/platform-integrations` showed **Not found** in the document title, while a full refresh correctly showed **Admin platform integrations**.

This is systemic: SPA navigations only resolve titles from `document-head.ts`, while SSR can still pass a `title` override into `renderAppPage`. Routes missing from the registry therefore look correct on refresh and wrong on client nav.

### Fix

- Register admin platform integrations (list / new / detail) and guides (index / detail) in the shared document-head registry.
- Add a `clientRoutes` coverage test so a missing registry entry cannot regress to the Not found fallback.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f2b9323` · **Head:** `26b7b15`

**Classification:** composes — no primitives added or changed; wires missing pathnames into the existing document-head registry.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — SPA title registry entries + coverage test |

### System map

SPA navigation applies document head from the shared registry; missing pathnames fell through to Not found until registered.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>App UI"]:::touched
	appUi -->|"clientRoutes coverage + registry entries"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart LR
	nav["SPA navigate"] -->|"applyDocumentHead"| registry["document-head registry"]
	registry -->|"platform integrations + guides"| title["document.title"]
	ssr["SSR renderAppPage title override"] -.->|"refresh only"| title
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87b86af0-268c-44bd-b09a-13f4bbb47faa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87b86af0-268c-44bd-b09a-13f4bbb47faa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added page titles for admin platform integration pages.
  - Added titles for the guides index and individual guide pages.
  - Guide detail pages now display the loaded guide title when available, with a “Guides” fallback.

- **Bug Fixes**
  - Improved consistency of document titles across client-side and server-rendered pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->