### PR TITLE
Server-render /connect/oauth and sweep pages that fetched initial data client-side

### DIFF
--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -4,7 +4,6 @@ import {
 } from '@kody-internal/shared/url-hosts.ts'
 import {
 	type AccountIntegrationDetailLoaderData,
-	type AccountSecretsLoaderData,
 	type ConnectOauthExistingConnection,
 	type ConnectOauthLoaderData,
 } from '#universal/loader-data.ts'
@@ -149,6 +148,10 @@ export async function connectOauthRouteLoader(
 				response.ok && payload?.ok
 					? (payload.existingConnection ?? null)
 					: null,
+			hasStoredClientSecret:
+				response.ok && payload?.ok
+					? (payload.hasStoredClientSecret ?? false)
+					: false,
 		},
 	}
 }
@@ -172,7 +175,9 @@ export function ConnectOauthRoute(handle: Handle) {
 
 	// The real status arrives once the query config and any stored/built-in
 	// provider config resolve; starting on "Ready to connect." flashed a
-	// misleading state on slow connections.
+	// misleading state on slow connections. Provider visits resolve during
+	// render from SSR-embedded / SPA-preloaded loader data, so this fallback
+	// only shows on callback returns and loader-failure refetches.
 	let statusMessage = 'Loading provider configuration…'
 	let statusTone: StatusTone = 'info'
 	let currentStep: 'setup' | 'connect' | 'callback' | 'success' = 'setup'
@@ -210,6 +215,9 @@ export function ConnectOauthRoute(handle: Handle) {
 	let approvingAllHosts = false
 	let submitting = false
 	let initialLoadStarted = false
+	let routeDataApplied = false
+	/** Server-computed redirect URI so SSR renders the card `window` builds. */
+	let ssrRedirectUri: string | null = null
 	let clientIdInput = ''
 	let clientSecretInput = ''
 	let hasStoredClientId = false
@@ -271,10 +279,13 @@ export function ConnectOauthRoute(handle: Handle) {
 		}
 	}
 
-	const readQueryConfig = (): ConnectOauthQueryConfig | null => {
-		hasConfigError = false
-		if (typeof window === 'undefined') return null
-		const url = new URL(window.location.href)
+	type QueryConfigResult =
+		| { ok: true; value: ConnectOauthQueryConfig }
+		| { ok: false; error: string }
+
+	// Pure so it can run during render (SSR included) without touching
+	// component state; callers apply the error to status themselves.
+	const readQueryConfig = (url: URL): QueryConfigResult => {
 		const readRequired = (key: string) => {
 			const value = url.searchParams.get(key)
 			return value && value.trim() ? value.trim() : null
@@ -288,21 +299,18 @@ export function ConnectOauthRoute(handle: Handle) {
 		const tokenUrl = readOptional('tokenUrl')
 		const apiBaseUrl = parseOptionalUrl(readOptional('apiBaseUrl'))
 		if (!provider) {
-			hasConfigError = true
-			setStatus('Missing required OAuth configuration parameters.', 'error')
-			return null
+			return {
+				ok: false,
+				error: 'Missing required OAuth configuration parameters.',
+			}
 		}
 		const authorizeHost = authorizeUrl ? safeParseHost(authorizeUrl) : null
 		if (authorizeUrl && (!isSafeExternalUrl(authorizeUrl) || !authorizeHost)) {
-			hasConfigError = true
-			setStatus('Authorize URL must be valid.', 'error')
-			return null
+			return { ok: false, error: 'Authorize URL must be valid.' }
 		}
 		const tokenHost = tokenUrl ? safeParseHost(tokenUrl) : null
 		if (tokenUrl && !tokenHost) {
-			hasConfigError = true
-			setStatus('Token URL must be valid when provided.', 'error')
-			return null
+			return { ok: false, error: 'Token URL must be valid when provided.' }
 		}
 		const rawFlow = readOptional('flow')?.toLowerCase() ?? null
 		const flow: OAuthFlow | null =
@@ -322,9 +330,7 @@ export function ConnectOauthRoute(handle: Handle) {
 		const dashboardUrl = parseOptionalUrl(readOptional('dashboardUrl'))
 		const providerKey = normalizeProviderKey(provider)
 		if (!providerKey) {
-			hasConfigError = true
-			setStatus('Provider must contain letters or numbers.', 'error')
-			return null
+			return { ok: false, error: 'Provider must contain letters or numbers.' }
 		}
 		const providerSetupInstructions = parseProviderSetupInstructions(
 			readOptional('providerSetupInstructions'),
@@ -334,21 +340,24 @@ export function ConnectOauthRoute(handle: Handle) {
 			...parseAllowedHosts(readOptional('allowedHosts')),
 		])
 		return {
-			provider,
-			providerKey,
-			authorizeHost,
-			authorizeUrl,
-			tokenUrl,
-			apiBaseUrl,
-			scopes,
-			flow,
-			usePkce,
-			tokenExchangeStyle,
-			scopeSeparator,
-			extraAuthorizeParams,
-			providerSetupInstructions,
-			dashboardUrl,
-			allowedHosts,
+			ok: true,
+			value: {
+				provider,
+				providerKey,
+				authorizeHost,
+				authorizeUrl,
+				tokenUrl,
+				apiBaseUrl,
+				scopes,
+				flow,
+				usePkce,
+				tokenExchangeStyle,
+				scopeSeparator,
+				extraAuthorizeParams,
+				providerSetupInstructions,
+				dashboardUrl,
+				allowedHosts,
+			},
 		}
 	}
 
@@ -366,7 +375,7 @@ export function ConnectOauthRoute(handle: Handle) {
 	}
 
 	const getRedirectUri = (): string => {
-		if (typeof window === 'undefined') return ''
+		if (typeof window === 'undefined') return ssrRedirectUri ?? ''
 		return `${window.location.origin}${window.location.pathname}`
 	}
 
@@ -461,29 +470,13 @@ export function ConnectOauthRoute(handle: Handle) {
 		return true
 	}
 
-	const listSecrets = async () => {
-		const response = await fetch('/account/secrets.json', {
-			method: 'GET',
-			headers: {
-				Accept: 'application/json',
-			},
-			credentials: 'include',
-		})
-		if (redirectToLoginOn401(response)) return null
-		const payload = (await response.json().catch(() => null)) as Pick<
-			AccountSecretsLoaderData,
-			'ok' | 'secrets'
-		> | null
-		if (
-			!response.ok ||
-			payload?.ok !== true ||
-			!Array.isArray(payload.secrets)
-		) {
-			return null
-		}
-		return payload.secrets
-	}
-
+	/**
+	 * Fallback fetch mirroring the loader/SSR payload — only runs when a
+	 * navigation committed without loader data (loader failure, or callback
+	 * returns that lost their sessionStorage snapshot). Captures the
+	 * built-in flag and stored-secret existence the same way the loader
+	 * data path does.
+	 */
 	const readExistingIntegrationConfig = async (
 		queryConfig: ConnectOauthQueryConfig,
 	): Promise<StoredIntegrationConfig | null> => {
@@ -508,25 +501,22 @@ export function ConnectOauthRoute(handle: Handle) {
 		if (!response.ok || payload?.ok !== true) return null
 		builtInAvailable = payload.builtInAvailable ?? false
 		existingConnection = payload.existingConnection ?? null
+		hasStoredClientSecret = payload.hasStoredClientSecret === true
 		if (!payload.integration) return null
 		return toStoredIntegrationConfig(payload.integration)
 	}
 
-	const initializeSetupState = async (nextConfig: ConnectOauthConfig) => {
-		const secrets = nextConfig.clientSecretSecretName
-			? await listSecrets()
-			: null
+	// Sync so provider visits can render their real setup / ready state in
+	// the same pass that resolved `config` (SSR included). Callers set
+	// `hasStoredClientSecret` from server data beforehand.
+	const applySetupState = (nextConfig: ConnectOauthConfig) => {
 		clientIdInput = nextConfig.clientId
 		clientSecretInput = ''
 		hasStoredClientId = Boolean(nextConfig.clientId.trim())
-		hasStoredClientSecret = Boolean(
-			nextConfig.clientSecretSecretName &&
-			secrets?.some(
-				(secret) =>
-					secret.scope === 'user' &&
-					secret.name === nextConfig.clientSecretSecretName,
-			),
-		)
+		// Existence is only meaningful when this connection actually uses a
+		// user-held client secret (confidential, non-platform).
+		hasStoredClientSecret =
+			Boolean(nextConfig.clientSecretSecretName) && hasStoredClientSecret
 		revealStoredClientSecretField = false
 		const setupStatus = summarizeStoredSetupState({
 			flow: nextConfig.flow,
@@ -535,23 +525,21 @@ export function ConnectOauthRoute(handle: Handle) {
 			platform: Boolean(nextConfig.platformAppSlug),
 		})
 		if (setupStatus.isReady) {
-			setStatus(
-				nextConfig.platformAppSlug
-					? 'Built-in integration — no OAuth app setup needed. Ready to connect.'
-					: existingIntegrationConfig
-						? 'Loaded your existing integration config and client credentials. Ready to connect.'
-						: 'Loaded your existing OAuth client configuration. Ready to connect.',
-			)
-			setStep('connect')
+			statusMessage = nextConfig.platformAppSlug
+				? 'Built-in integration — no OAuth app setup needed. Ready to connect.'
+				: existingIntegrationConfig
+					? 'Loaded your existing integration config and client credentials. Ready to connect.'
+					: 'Loaded your existing OAuth client configuration. Ready to connect.'
+			statusTone = 'info'
+			currentStep = 'connect'
 			return
 		}
 		const missingDetails = formatMissingSetupFields(setupStatus.missingFields)
-		setStatus(
-			existingIntegrationConfig
-				? `Loaded your existing integration config. ${missingDetails}`
-				: missingDetails,
-		)
-		setStep('setup')
+		statusMessage = existingIntegrationConfig
+			? `Loaded your existing integration config. ${missingDetails}`
+			: missingDetails
+		statusTone = 'info'
+		currentStep = 'setup'
 	}
 
 	const saveSecret = async (
@@ -1157,48 +1145,80 @@ export function ConnectOauthRoute(handle: Handle) {
 		)
 	}
 
+	/**
+	 * Resolve config from SSR-embedded / SPA-preloaded loader data during
+	 * render, so the page paints its final layout in the same pass that
+	 * receives the data — server render included — instead of flashing
+	 * "Loading provider configuration…" and shifting content after a
+	 * client-side fetch. Callback returns (`code`/`error`) restore their
+	 * config from sessionStorage in the queued task; only the redirect URI,
+	 * built-in flag, and existing-connection summary apply here.
+	 */
+	const applyRouteLoaderData = (currentHref: string) => {
+		if (routeDataApplied) return
+		const url = new URL(currentHref, 'https://kody.local')
+		const routeData = tryConsumeRouteLoaderData(
+			handle,
+			'connectOauth',
+			currentHref,
+		)
+		if (!routeData) return
+		routeDataApplied = true
+		ssrRedirectUri = routeData.redirectUri ?? null
+		builtInAvailable = routeData.builtInAvailable ?? false
+		existingConnection = routeData.existingConnection ?? null
+		if (url.searchParams.get('code') || url.searchParams.get('error')) {
+			return
+		}
+		const parsed = readQueryConfig(url)
+		if (!parsed.ok) {
+			hasConfigError = true
+			statusMessage = parsed.error
+			statusTone = 'error'
+			return
+		}
+		const storedIntegration =
+			routeData.provider === parsed.value.providerKey && routeData.integration
+				? toStoredIntegrationConfig(routeData.integration)
+				: null
+		existingIntegrationConfig = storedIntegration
+		const nextConfig = mergeConnectOauthConfig({
+			queryConfig: parsed.value,
+			storedIntegration,
+		})
+		if (!nextConfig) {
+			hasConfigError = true
+			statusMessage = 'Missing required OAuth configuration parameters.'
+			statusTone = 'error'
+			return
+		}
+		config = nextConfig
+		hasStoredClientSecret = routeData.hasStoredClientSecret === true
+		applySetupState(nextConfig)
+	}
+
 	handle.queueTask(async () => {
 		if (initialLoadStarted) return
 		initialLoadStarted = true
 		try {
-			// SSR-embedded on direct visits, loader-prefetched on SPA
-			// navigations; the integrations fetch below only runs as a
-			// fallback (e.g. callback returns that lost sessionStorage).
-			const routeData = tryConsumeRouteLoaderData(
-				handle,
-				'connectOauth',
-				readCurrentRouterHref(handle),
-			)
-			if (routeData) {
-				builtInAvailable = routeData.builtInAvailable ?? false
-				existingConnection = routeData.existingConnection ?? null
-			}
-			const preloadedIntegrationFor = (providerKey: string) =>
-				routeData && routeData.provider === providerKey
-					? routeData.integration
-					: undefined
-			const resolveExistingIntegration = async (
-				queryConfig: ConnectOauthQueryConfig,
-			): Promise<StoredIntegrationConfig | null> => {
-				const preloaded = preloadedIntegrationFor(queryConfig.providerKey)
-				if (preloaded !== undefined) {
-					return preloaded ? toStoredIntegrationConfig(preloaded) : null
-				}
-				return readExistingIntegrationConfig(queryConfig)
-			}
 			const callback = readCallback()
 			if (callback.kind === 'success' || callback.kind === 'error') {
 				const storedConfig = readStoredConfig()
-				const queryConfig = storedConfig ? null : readQueryConfig()
-				const nextConfig =
-					storedConfig ??
-					(queryConfig
+				let nextConfig = storedConfig
+				if (!nextConfig) {
+					// The sessionStorage snapshot was lost; rebuild from the
+					// query (when the provider redirect kept it) plus the
+					// stored integration record.
+					const parsed = readQueryConfig(new URL(window.location.href))
+					nextConfig = parsed.ok
 						? mergeConnectOauthConfig({
-								queryConfig,
-								storedIntegration:
-									await resolveExistingIntegration(queryConfig),
+								queryConfig: parsed.value,
+								storedIntegration: await readExistingIntegrationConfig(
+									parsed.value,
+								),
 							})
-						: null)
+						: null
+				}
 				if (!nextConfig) {
 					setStatus('Missing required OAuth configuration parameters.', 'error')
 					return
@@ -1210,24 +1230,33 @@ export function ConnectOauthRoute(handle: Handle) {
 				}
 				return
 			}
-			const queryConfig = readQueryConfig()
-			if (!queryConfig) {
-				setStatus('Missing required OAuth configuration parameters.', 'error')
-				return
+			if (!config && !hasConfigError) {
+				// The navigation committed without loader data (loader
+				// failure or an aborted prefetch): fall back to the same
+				// fetch the loader performs.
+				const parsed = readQueryConfig(new URL(window.location.href))
+				if (!parsed.ok) {
+					hasConfigError = true
+					setStatus(parsed.error, 'error')
+					return
+				}
+				const existingIntegration = await readExistingIntegrationConfig(
+					parsed.value,
+				)
+				existingIntegrationConfig = existingIntegration
+				const nextConfig = mergeConnectOauthConfig({
+					queryConfig: parsed.value,
+					storedIntegration: existingIntegration,
+				})
+				if (!nextConfig) {
+					hasConfigError = true
+					setStatus('Missing required OAuth configuration parameters.', 'error')
+					return
+				}
+				config = nextConfig
+				applySetupState(nextConfig)
+				update()
 			}
-			const existingIntegration = await resolveExistingIntegration(queryConfig)
-			existingIntegrationConfig = existingIntegration
-			const nextConfig = mergeConnectOauthConfig({
-				queryConfig,
-				storedIntegration: existingIntegration,
-			})
-			if (!nextConfig) {
-				hasConfigError = true
-				setStatus('Missing required OAuth configuration parameters.', 'error')
-				return
-			}
-			config = nextConfig
-			await initializeSetupState(nextConfig)
 			// Built-in integrations have nothing for the user to review or
 			// fill in, so a plain ?provider=<slug> visit (the onboarding
 			// cards, docs links) goes straight into the provider's authorize
@@ -1237,15 +1266,15 @@ export function ConnectOauthRoute(handle: Handle) {
 			// different-app connection never auto-starts: the user confirms
 			// or renames first.
 			if (
-				nextConfig.platformAppSlug &&
+				config?.platformAppSlug &&
 				currentStep === 'connect' &&
 				!wouldReplaceDifferentApp()
 			) {
-				setStatus(`Redirecting to ${nextConfig.provider} to authorize…`)
+				setStatus(`Redirecting to ${config.provider} to authorize…`)
 				await handleConnect()
 			}
 		} catch (error) {
-			// Initial integration/secrets reads use fetch(); a transient network
+			// Initial integration reads use fetch(); a transient network
 			// failure must not escape queueTask as unhandledrejection.
 			setStatus(
 				formatConnectOauthCaughtError(
@@ -1258,6 +1287,7 @@ export function ConnectOauthRoute(handle: Handle) {
 	})
 
 	return () => {
+		applyRouteLoaderData(readCurrentRouterHref(handle))
 		if (!config) {
 			return (
 				<section mix={css(pageCss)}>

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -216,6 +216,13 @@ export function ConnectOauthRoute(handle: Handle) {
 	let submitting = false
 	let initialLoadStarted = false
 	let routeDataApplied = false
+	/**
+	 * Normalized pathname+search the current resolution state belongs to.
+	 * SPA navigations to a different connect URL (another provider, a
+	 * platform lane switch) reset and re-resolve instead of keeping the
+	 * previous provider's config on screen.
+	 */
+	let resolvedHref: string | null = null
 	/** Server-computed redirect URI so SSR renders the card `window` builds. */
 	let ssrRedirectUri: string | null = null
 	let clientIdInput = ''
@@ -223,6 +230,34 @@ export function ConnectOauthRoute(handle: Handle) {
 	let hasStoredClientId = false
 	let hasStoredClientSecret = false
 	let revealStoredClientSecretField = false
+
+	const normalizeConnectHref = (href: string) => {
+		const url = new URL(href, 'https://kody.local')
+		return `${url.pathname}${url.search}`
+	}
+
+	// Back to the pre-resolution defaults so a new connect URL resolves from
+	// scratch (loader data first, fallback fetch otherwise).
+	const resetResolutionState = () => {
+		routeDataApplied = false
+		initialLoadStarted = false
+		resolvedHref = null
+		config = null
+		existingIntegrationConfig = null
+		existingConnection = null
+		builtInAvailable = false
+		hasStoredClientSecret = false
+		hasConfigError = false
+		replaceConfirmed = false
+		renameInput = ''
+		hostApprovalLinks = []
+		nextSteps = null
+		accessTokenSaved = false
+		refreshTokenSaved = false
+		currentStep = 'setup'
+		statusMessage = 'Loading provider configuration…'
+		statusTone = 'info'
+	}
 
 	const update = () => handle.update()
 
@@ -816,8 +851,9 @@ export function ConnectOauthRoute(handle: Handle) {
 								mix={[
 									on('click', () => {
 										const name = renameInput.trim() || renameSuggestion
-										// Full document load: the connect flow
-										// initializes per document load.
+										// Full document load: the renamed connect
+										// auto-starts the provider redirect, which is
+										// simplest from a fresh document.
 										window.location.assign(
 											`/connect/oauth?provider=${encodeURIComponent(name)}&platform=${encodeURIComponent(config!.platformAppSlug!)}`,
 										)
@@ -851,10 +887,9 @@ export function ConnectOauthRoute(handle: Handle) {
 					href={`/connect/oauth?provider=${encodeURIComponent(config.providerKey)}&platform=1`}
 					mix={[
 						css(primaryLinkCss),
-						// Full document load on purpose: this page's init
-						// (config resolution, built-in auto-start) runs per
-						// document load, and a same-route SPA swap reuses the
-						// mounted instance without re-running it.
+						// Full document load on purpose: switching lanes may
+						// auto-start the provider redirect, and that is
+						// simplest to reason about from a fresh document.
 						on('click', (event) => {
 							event.preventDefault()
 							window.location.assign(event.currentTarget.href)
@@ -1197,9 +1232,16 @@ export function ConnectOauthRoute(handle: Handle) {
 		applySetupState(nextConfig)
 	}
 
-	handle.queueTask(async () => {
+	// Queued from render (once per resolved href): callback handling, the
+	// loader-failure fallback refetch, and the built-in auto-start.
+	const initializeVisit = async () => {
 		if (initialLoadStarted) return
 		initialLoadStarted = true
+		// Bail after awaits when the user has SPA-navigated to a different
+		// connect URL mid-flight: the reset re-queues a fresh task for it.
+		const taskHref = resolvedHref
+		const hrefStillCurrent = () =>
+			taskHref === normalizeConnectHref(readCurrentRouterHref(handle))
 		try {
 			const callback = readCallback()
 			if (callback.kind === 'success' || callback.kind === 'error') {
@@ -1243,6 +1285,7 @@ export function ConnectOauthRoute(handle: Handle) {
 				const existingIntegration = await readExistingIntegrationConfig(
 					parsed.value,
 				)
+				if (!hrefStillCurrent()) return
 				existingIntegrationConfig = existingIntegration
 				const nextConfig = mergeConnectOauthConfig({
 					queryConfig: parsed.value,
@@ -1266,6 +1309,7 @@ export function ConnectOauthRoute(handle: Handle) {
 			// different-app connection never auto-starts: the user confirms
 			// or renames first.
 			if (
+				hrefStillCurrent() &&
 				config?.platformAppSlug &&
 				currentStep === 'connect' &&
 				!wouldReplaceDifferentApp()
@@ -1284,10 +1328,29 @@ export function ConnectOauthRoute(handle: Handle) {
 				'error',
 			)
 		}
-	})
+	}
 
 	return () => {
-		applyRouteLoaderData(readCurrentRouterHref(handle))
+		const currentHref = readCurrentRouterHref(handle)
+		const normalizedHref = normalizeConnectHref(currentHref)
+		// An in-app navigation to a different connect URL (another provider,
+		// a platform lane switch) re-resolves from scratch instead of keeping
+		// the previous provider's page. Callback flows are terminal — their
+		// URL is rewritten via history.replaceState — and never reset.
+		if (
+			resolvedHref !== null &&
+			resolvedHref !== normalizedHref &&
+			!connectOauthHandled
+		) {
+			resetResolutionState()
+		}
+		if (resolvedHref === null) {
+			resolvedHref = normalizedHref
+		}
+		applyRouteLoaderData(currentHref)
+		if (!initialLoadStarted && typeof document !== 'undefined') {
+			handle.queueTask(initializeVisit)
+		}
 		if (!config) {
 			return (
 				<section mix={css(pageCss)}>

--- a/packages/worker/src/app/account-integrations-data.ts
+++ b/packages/worker/src/app/account-integrations-data.ts
@@ -3,9 +3,11 @@ import {
 	type AccountOauthAppListItem,
 	type ConnectOauthExistingConnection,
 } from '#universal/loader-data.ts'
+import { normalizeProviderKey } from '@kody-internal/shared/url-hosts.ts'
 import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { toOauthAppPublic } from '#mcp/capabilities/integrations/oauth-app-shared.ts'
 import { canonicalIntegrationName } from '#mcp/capabilities/integrations/integration-shared.ts'
+import { listSecrets } from '#mcp/secrets/service.ts'
 import {
 	findOauthAppForProviderSetup,
 	getAvailablePlatformApp,
@@ -308,6 +310,32 @@ export async function loadExistingConnectionSummary(
 	})
 	if (!joined) return null
 	return { lane: joined.lane, appSlug: joined.app.slug }
+}
+
+/**
+ * True when the user already stores the client-secret secret the connect
+ * page would use for `name`: the stored integration's secret name when
+ * present, else the page's default `<providerKey>ClientSecret`. Embedded in
+ * loader data so the page renders its setup / ready state without a
+ * follow-up secrets fetch.
+ */
+export async function hasStoredConnectClientSecret(
+	env: Env,
+	user: AuthenticatedUser,
+	name: string,
+	record: AccountIntegrationRecord | null,
+): Promise<boolean> {
+	const secretName =
+		record?.clientSecretSecretName?.trim() ||
+		`${normalizeProviderKey(name)}ClientSecret`
+	const secrets = await listSecrets({
+		env,
+		userId: user.mcpUser.userId,
+		scope: 'user',
+	})
+	return secrets.some(
+		(secret) => secret.scope === 'user' && secret.name === secretName,
+	)
 }
 
 /**

--- a/packages/worker/src/app/handlers/account-integrations.node.test.ts
+++ b/packages/worker/src/app/handlers/account-integrations.node.test.ts
@@ -491,6 +491,9 @@ test('integrations API returns one connection by name for the connect OAuth flow
 		ok: true,
 		builtInAvailable: false,
 		existingConnection: { lane: 'user', appSlug: 'github' },
+		// The mocked secrets list is empty, so the stored `githubClientSecret`
+		// name resolves to "not stored yet".
+		hasStoredClientSecret: false,
 		integration: {
 			name: 'github',
 			appSlug: 'github',
@@ -534,6 +537,7 @@ test('integrations API returns null when a named connection is missing', async (
 		ok: true,
 		builtInAvailable: false,
 		existingConnection: null,
+		hasStoredClientSecret: false,
 		integration: null,
 	})
 })

--- a/packages/worker/src/app/handlers/account-integrations.ts
+++ b/packages/worker/src/app/handlers/account-integrations.ts
@@ -7,6 +7,7 @@ import {
 } from '@kody-internal/shared/url-hosts.ts'
 import {
 	hasAlternativeBuiltInApp,
+	hasStoredConnectClientSecret,
 	loadAccountIntegrationByName,
 	loadAccountIntegrationsData,
 	loadExistingConnectionSummary,
@@ -96,15 +97,18 @@ export function createAccountIntegrationsApiHandler(env: Env) {
 									: undefined,
 						},
 					)
-					const [builtInAvailable, existingConnection] = await Promise.all([
-						hasAlternativeBuiltInApp(env, name, integration),
-						loadExistingConnectionSummary(env, user, name),
-					])
+					const [builtInAvailable, existingConnection, hasStoredClientSecret] =
+						await Promise.all([
+							hasAlternativeBuiltInApp(env, name, integration),
+							loadExistingConnectionSummary(env, user, name),
+							hasStoredConnectClientSecret(env, user, name, integration),
+						])
 					return jsonResponse({
 						ok: true,
 						integration,
 						builtInAvailable,
 						existingConnection,
+						hasStoredClientSecret,
 					})
 				}
 				const appSlug = searchParams.get('appSlug')?.trim()

--- a/packages/worker/src/app/handlers/account-passkeys.ts
+++ b/packages/worker/src/app/handlers/account-passkeys.ts
@@ -15,6 +15,7 @@ import {
 	type PasskeyRow,
 } from '#app/passkeys.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { type AccountPasskeysLoaderData } from '#universal/loader-data.ts'
 import { type routes } from '#universal/routes.ts'
 
 export function createAccountPasskeysHandler(env: Env) {
@@ -26,10 +27,16 @@ export function createAccountPasskeysHandler(env: Env) {
 				return user
 			}
 
+			// Embed the same payload the .json endpoint serves so the page
+			// server-renders its real state instead of "Loading passkeys…"
+			// plus a client fetch.
 			return renderAppPage({
 				request,
 				env,
 				title: 'Passkeys',
+				loaderData: {
+					accountPasskeys: await loadPasskeysPayload(env.APP_DB, user.userId),
+				},
 			})
 		},
 	} satisfies Action<typeof routes.accountPasskeys>
@@ -140,7 +147,10 @@ function displayPasskeyName(passkey: PasskeyRow) {
 	})
 }
 
-async function loadPasskeysPayload(db: D1Database, userId: number) {
+async function loadPasskeysPayload(
+	db: D1Database,
+	userId: number,
+): Promise<AccountPasskeysLoaderData> {
 	const passkeys = await listPasskeysForUser(db, userId)
 	return {
 		ok: true,

--- a/packages/worker/src/app/handlers/account-two-factor.ts
+++ b/packages/worker/src/app/handlers/account-two-factor.ts
@@ -5,6 +5,7 @@ import { getRequestIp, logAuditEvent } from '#worker/audit-log.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { type AccountTwoFactorLoaderData } from '#universal/loader-data.ts'
 import { type routes } from '#universal/routes.ts'
 import {
 	cancelTwoFactorSetup,
@@ -27,10 +28,16 @@ export function createAccountTwoFactorHandler(env: Env) {
 				return user
 			}
 
+			// Embed the same payload the .json endpoint serves so the page
+			// server-renders its real state instead of "Loading two-factor
+			// status…" plus a client fetch.
 			return renderAppPage({
 				request,
 				env,
 				title: 'Two-factor authentication',
+				loaderData: {
+					accountTwoFactor: await loadTwoFactorStatus(env.APP_DB, user.userId),
+				},
 			})
 		},
 	} satisfies Action<typeof routes.accountTwoFactor>
@@ -221,7 +228,10 @@ export function createAccountTwoFactorApiHandler(env: Env) {
 	} satisfies Action<typeof routes.accountTwoFactorApi>
 }
 
-async function loadTwoFactorStatus(db: D1Database, userId: number) {
+async function loadTwoFactorStatus(
+	db: D1Database,
+	userId: number,
+): Promise<AccountTwoFactorLoaderData> {
 	return {
 		ok: true,
 		enabled: await isTwoFactorEnabled(db, userId),

--- a/packages/worker/src/app/handlers/connect-oauth.node.test.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.node.test.ts
@@ -11,6 +11,7 @@ const mockModule = vi.hoisted(() => ({
 	loadAccountIntegrationByName: vi.fn<() => Promise<unknown>>(),
 	hasAlternativeBuiltInApp: vi.fn<() => Promise<boolean>>(),
 	loadExistingConnectionSummary: vi.fn<() => Promise<unknown>>(),
+	hasStoredConnectClientSecret: vi.fn<() => Promise<boolean>>(),
 	renderAppPage: vi.fn<(input: unknown) => Promise<Response>>(),
 }))
 
@@ -31,6 +32,8 @@ vi.mock('#app/account-integrations-data.ts', () => ({
 		mockModule.hasAlternativeBuiltInApp(...args),
 	loadExistingConnectionSummary: (...args: Array<unknown>) =>
 		mockModule.loadExistingConnectionSummary(...args),
+	hasStoredConnectClientSecret: (...args: Array<unknown>) =>
+		mockModule.hasStoredConnectClientSecret(...args),
 }))
 
 vi.mock('#app/ssr-render.tsx', () => ({
@@ -90,6 +93,7 @@ test('provider visits embed the integration record as SSR loader data', async ()
 
 	mockModule.hasAlternativeBuiltInApp.mockResolvedValue(false)
 	mockModule.loadExistingConnectionSummary.mockResolvedValue(null)
+	mockModule.hasStoredConnectClientSecret.mockResolvedValue(true)
 
 	await createConnectOauthHandler(env).handler(
 		new RequestContext(
@@ -112,6 +116,10 @@ test('provider visits embed the integration record as SSR loader data', async ()
 					integration: record,
 					builtInAvailable: false,
 					existingConnection: null,
+					hasStoredClientSecret: true,
+					// Server-computed so SSR renders the Redirect URI card
+					// before `window` exists.
+					redirectUri: 'https://example.com/connect/oauth',
 				},
 			},
 		}),
@@ -130,6 +138,7 @@ test('platform=1 forces the built-in lookup', async () => {
 	})
 	mockModule.hasAlternativeBuiltInApp.mockResolvedValue(false)
 	mockModule.loadExistingConnectionSummary.mockResolvedValue(null)
+	mockModule.hasStoredConnectClientSecret.mockResolvedValue(false)
 	mockModule.renderAppPage.mockResolvedValue(new Response('ok'))
 
 	await createConnectOauthHandler(env).handler(
@@ -162,7 +171,7 @@ test('platform=1 forces the built-in lookup', async () => {
 	)
 })
 
-test('callback returns render without loader data', async () => {
+test('callback returns embed only the redirect URI, not an integration lookup', async () => {
 	const env = {} as Env
 	mockModule.requirePageSession.mockResolvedValue(null)
 	mockModule.loadAccountIntegrationByName.mockClear()
@@ -174,7 +183,18 @@ test('callback returns render without loader data', async () => {
 		),
 	)
 	expect(mockModule.loadAccountIntegrationByName).not.toHaveBeenCalled()
+	// Config is restored from sessionStorage client-side; the redirect URI
+	// still embeds so the SSR shell renders the Redirect URI card.
 	expect(mockModule.renderAppPage).toHaveBeenCalledWith(
-		expect.not.objectContaining({ loaderData: expect.anything() }),
+		expect.objectContaining({
+			loaderData: {
+				connectOauth: {
+					ok: true,
+					provider: null,
+					integration: null,
+					redirectUri: 'https://example.com/connect/oauth',
+				},
+			},
+		}),
 	)
 })

--- a/packages/worker/src/app/handlers/connect-oauth.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.ts
@@ -2,12 +2,14 @@ import { type Action } from 'remix/router'
 import { normalizeProviderKey } from '@kody-internal/shared/url-hosts.ts'
 import {
 	hasAlternativeBuiltInApp,
+	hasStoredConnectClientSecret,
 	loadAccountIntegrationByName,
 	loadExistingConnectionSummary,
 } from '#app/account-integrations-data.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { requirePageSession } from '#app/page-auth.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
+import { joinAppUrl } from '#worker/app-base-url.ts'
 import { type ConnectOauthLoaderData } from '#universal/loader-data.ts'
 import { type routes } from '#universal/routes.ts'
 
@@ -26,23 +28,33 @@ export function isBareConnectOauthVisit(url: URL): boolean {
 }
 
 /**
- * SSR prefill for `?provider=` visits: the same record the
- * `/account/integrations.json?name=` endpoint serves, embedded so a direct
- * navigation renders (and auto-starts built-ins) without a client fetch.
- * Callback returns (`code`/`error`) restore config from sessionStorage, so
- * their query carries no provider and nothing is loaded.
+ * SSR prefill embedded for every rendered visit so the page paints its final
+ * layout server-side. `?provider=` visits carry the same record the
+ * `/account/integrations.json?name=` endpoint serves (plus whether the
+ * client-secret secret already exists), so a direct navigation renders (and
+ * auto-starts built-ins) without a client fetch. Callback returns
+ * (`code`/`error`) restore config from sessionStorage, so their query
+ * carries no provider and only the redirect URI is embedded.
  */
 async function loadConnectOauthLoaderData(
 	env: Env,
 	request: Request,
 	requestUrl: URL,
-): Promise<ConnectOauthLoaderData | null> {
+): Promise<ConnectOauthLoaderData> {
+	const redirectUri = joinAppUrl({
+		env,
+		path: requestUrl.pathname,
+		requestUrl: request.url,
+	})
 	const provider = requestUrl.searchParams.get('provider')?.trim()
-	if (!provider) return null
-	const providerKey = normalizeProviderKey(provider)
-	if (!providerKey) return null
+	const providerKey = provider ? normalizeProviderKey(provider) : ''
+	if (!providerKey) {
+		return { ok: true, provider: null, integration: null, redirectUri }
+	}
 	const user = await readAuthenticatedAppUser(request, env)
-	if (!user) return null
+	if (!user) {
+		return { ok: true, provider: null, integration: null, redirectUri }
+	}
 	// `platform=1` forces the built-in of the same name; `platform=<slug>`
 	// connects that built-in under a different connection name.
 	const platformParam = requestUrl.searchParams.get('platform')?.trim()
@@ -58,16 +70,20 @@ async function loadConnectOauthLoaderData(
 					: undefined,
 		},
 	)
-	const [builtInAvailable, existingConnection] = await Promise.all([
-		hasAlternativeBuiltInApp(env, providerKey, integration),
-		loadExistingConnectionSummary(env, user, providerKey),
-	])
+	const [builtInAvailable, existingConnection, hasStoredClientSecret] =
+		await Promise.all([
+			hasAlternativeBuiltInApp(env, providerKey, integration),
+			loadExistingConnectionSummary(env, user, providerKey),
+			hasStoredConnectClientSecret(env, user, providerKey, integration),
+		])
 	return {
 		ok: true,
 		provider: providerKey,
 		integration,
 		builtInAvailable,
 		existingConnection,
+		hasStoredClientSecret,
+		redirectUri,
 	}
 }
 
@@ -92,7 +108,7 @@ export function createConnectOauthHandler(env: Env) {
 				request,
 				env,
 				title: 'Connect OAuth',
-				...(connectOauth ? { loaderData: { connectOauth } } : {}),
+				loaderData: { connectOauth },
 			})
 		},
 	} satisfies Action<typeof routes.connectOauth>

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -1,6 +1,9 @@
 import { type Action } from 'remix/router'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import { loadOnboardingData } from '#app/onboarding-data.ts'
+import {
+	loadOnboardingData,
+	loadPublicOnboardingData,
+} from '#app/onboarding-data.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
 
@@ -10,7 +13,19 @@ export function createHomeHandler(env: Env) {
 		async handler({ request }) {
 			const user = await readAuthenticatedAppUser(request, env)
 			if (!user) {
-				return renderAppPage({ request, env })
+				// Anonymous visits still embed the public onboarding payload so
+				// the hero's discovery-prompt copy renders server-side instead
+				// of popping in after a client /onboarding.json fetch.
+				return renderAppPage({
+					request,
+					env,
+					loaderData: {
+						onboarding: loadPublicOnboardingData({
+							env,
+							requestUrl: request.url,
+						}),
+					},
+				})
 			}
 
 			const onboarding = await loadOnboardingData({

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -669,6 +669,64 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 	expect(html).toContain('https://example.com/connect/oauth')
 	expect(html).toContain('https://accounts.google.com/o/oauth2/v2/auth')
 	expect(html).not.toContain('Loading provider configuration')
+	// Ready state renders the plain Connect button (also proves the
+	// replace-state assertion below is not vacuous about serialization).
+	expect(html).toContain('>Connect google</button>')
+
+	// A built-in connect that would replace a user-lane connection under the
+	// same name server-renders the replace confirmation and withholds the
+	// plain Connect button (the client also skips auto-start in this state).
+	const replaceResponse = await renderAppPage({
+		request: new Request(
+			'https://example.com/connect/oauth?provider=google&platform=1',
+		),
+		env,
+		loaderData: {
+			connectOauth: {
+				ok: true,
+				provider: 'google',
+				integration: {
+					name: 'google',
+					appSlug: 'google',
+					provider: 'google',
+					appLabel: 'Google',
+					accountLabel: null,
+					tokenUrl: 'https://oauth2.googleapis.com/token',
+					apiBaseUrl: 'https://www.googleapis.com',
+					flow: 'pkce',
+					usePkce: true,
+					clientId: 'platform-google-client',
+					clientSecretSecretName: null,
+					accessTokenSecretName: 'googleAccessToken',
+					refreshTokenSecretName: 'googleRefreshToken',
+					requiredHosts: ['oauth2.googleapis.com'],
+					authorization: {
+						authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+						scopes: ['openid'],
+						scopeSeparator: null,
+						extraAuthorizeParams: {},
+					},
+					platform: true,
+					platformAllowedScopes: ['openid'],
+					platformDescription: 'Send-only Gmail access.',
+					createdAt: '2026-01-01T00:00:00.000Z',
+					updatedAt: '2026-01-01T00:00:00.000Z',
+				},
+				builtInAvailable: false,
+				existingConnection: { lane: 'user', appSlug: 'google' },
+				hasStoredClientSecret: false,
+				redirectUri: 'https://example.com/connect/oauth',
+			},
+		},
+	})
+	expect(replaceResponse.status).toBe(200)
+	const replaceHtml = await readResponseText(replaceResponse)
+	expect(replaceHtml).toContain('data-testid="connect-replace-confirm"')
+	expect(replaceHtml).toContain('your own OAuth app')
+	// Operator-authored description renders under the provider name.
+	expect(replaceHtml).toContain('Send-only Gmail access.')
+	expect(replaceHtml).not.toContain('Loading provider configuration')
+	expect(replaceHtml).not.toContain('>Connect google</button>')
 })
 
 test('renderAppPage renders the redesigned landing page shell', async () => {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -586,6 +586,63 @@ test('renderAppPage server-renders signed-in oauth authorize without a session c
 	expect(html).not.toContain('Loading authorization details')
 })
 
+test('renderAppPage server-renders connect-oauth provider visits without a loading flash', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = createTestEnv(createUserTestDb([]))
+
+	// A stored user-lane confidential google connection whose client secret
+	// already exists: the page must SSR straight into "ready to connect"
+	// with the Redirect URI card, not "Loading provider configuration…".
+	const response = await renderAppPage({
+		request: new Request('https://example.com/connect/oauth?provider=google'),
+		env,
+		loaderData: {
+			connectOauth: {
+				ok: true,
+				provider: 'google',
+				integration: {
+					name: 'google',
+					appSlug: 'google',
+					provider: 'google',
+					appLabel: 'Google',
+					accountLabel: null,
+					tokenUrl: 'https://oauth2.googleapis.com/token',
+					apiBaseUrl: 'https://www.googleapis.com',
+					flow: 'confidential',
+					usePkce: false,
+					clientId: 'google-client-id-value',
+					clientSecretSecretName: 'googleClientSecret',
+					accessTokenSecretName: 'googleAccessToken',
+					refreshTokenSecretName: 'googleRefreshToken',
+					requiredHosts: ['oauth2.googleapis.com', 'www.googleapis.com'],
+					authorization: {
+						authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+						scopes: ['openid', 'email', 'profile'],
+						scopeSeparator: null,
+						extraAuthorizeParams: { access_type: 'offline' },
+					},
+					createdAt: '2026-01-01T00:00:00.000Z',
+					updatedAt: '2026-01-01T00:00:00.000Z',
+				},
+				builtInAvailable: false,
+				hasStoredClientSecret: true,
+				redirectUri: 'https://example.com/connect/oauth',
+			},
+		},
+	})
+
+	expect(response.status).toBe(200)
+	const html = await readResponseText(response)
+	expect(html).toContain('Connect google')
+	expect(html).toContain(
+		'Loaded your existing integration config and client credentials. Ready to connect.',
+	)
+	expect(html).toContain('https://example.com/connect/oauth')
+	expect(html).toContain('https://accounts.google.com/o/oauth2/v2/auth')
+	expect(html).not.toContain('Loading provider configuration')
+})
+
 test('renderAppPage renders the redesigned landing page shell', async () => {
 	resetDataCacheForTests()
 	setAuthSessionSecret(testCookieSecret)

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -7,6 +7,9 @@ import {
 	type AuthSession,
 } from '#app/auth-session.ts'
 import { createAccountHandler } from '#app/handlers/account.ts'
+import { createAccountPasskeysHandler } from '#app/handlers/account-passkeys.ts'
+import { createAccountTwoFactorHandler } from '#app/handlers/account-two-factor.ts'
+import { createHomeHandler } from '#app/handlers/home.ts'
 import { createCommunityHandler } from '#app/handlers/community.tsx'
 import { createCommunityDetailHandler } from '#app/handlers/community-detail.tsx'
 import { createOnboardingHandler } from '#app/handlers/onboarding.ts'
@@ -340,6 +343,31 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(accountHtml).not.toContain('Connect your AI agent')
 	expect(accountHtml).toContain('/pending-verification')
 
+	// Two-factor and passkeys embed the same payload their .json endpoints
+	// serve, so the page server-renders its real state instead of a loading
+	// placeholder plus a client fetch.
+	const twoFactorResponse = await runHtmlHandler(
+		createAccountTwoFactorHandler(env),
+		new Request('https://example.com/account/two-factor', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(twoFactorResponse.status).toBe(200)
+	const twoFactorHtml = await readResponseText(twoFactorResponse)
+	expect(twoFactorHtml).toContain('Two-factor authentication is disabled')
+	expect(twoFactorHtml).not.toContain('Loading two-factor status')
+
+	const passkeysResponse = await runHtmlHandler(
+		createAccountPasskeysHandler(env),
+		new Request('https://example.com/account/passkeys', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(passkeysResponse.status).toBe(200)
+	const passkeysHtml = await readResponseText(passkeysResponse)
+	expect(passkeysHtml).toContain('No passkeys yet')
+	expect(passkeysHtml).not.toContain('Loading passkeys')
+
 	const accountLinkedResponse = await runHtmlHandler(
 		createAccountHandler(env),
 		new Request('https://example.com/account?oauthLinked=google', {
@@ -662,6 +690,18 @@ test('renderAppPage renders the redesigned landing page shell', async () => {
 	expect(html).toContain('aria-label="Footer"')
 	expect(html).toContain('aria-label="Dark mode"')
 	expect(html).toContain('id="invite"')
+
+	// The anonymous home handler embeds the public onboarding payload, so
+	// the hero's discovery-prompt copy renders server-side instead of
+	// popping in after a client /onboarding.json fetch.
+	const anonymousHomeResponse = await runHtmlHandler(
+		createHomeHandler(env),
+		new Request('https://example.com/'),
+	)
+	expect(anonymousHomeResponse.status).toBe(200)
+	const anonymousHomeHtml = await readResponseText(anonymousHomeResponse)
+	expect(anonymousHomeHtml).toContain('Copy the discovery prompt')
+	expect(anonymousHomeHtml).toContain('Join the waiting list')
 })
 
 test('renderAppPage renders the redesigned pricing page', async () => {

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -866,6 +866,13 @@ export type AccountIntegrationDetailLoaderData = {
 	builtInAvailable?: boolean
 	/** See {@link ConnectOauthExistingConnection}. */
 	existingConnection?: ConnectOauthExistingConnection | null
+	/**
+	 * True when the user already stores the client-secret secret the connect
+	 * page would use for this name (the stored integration's secret name,
+	 * else `<providerKey>ClientSecret`). Lets the page render its setup /
+	 * ready state without a follow-up secrets fetch.
+	 */
+	hasStoredClientSecret?: boolean
 }
 
 /**
@@ -880,8 +887,8 @@ export type ConnectOauthExistingConnection = {
 /**
  * /connect/oauth prefill for `?provider=` visits: the stored or built-in
  * record the page merges into its config. `provider` is the normalized key
- * the record was resolved for; null on callback and bare visits, which have
- * nothing to prefetch.
+ * the record was resolved for; null on callback visits, which restore config
+ * from sessionStorage instead.
  */
 export type ConnectOauthLoaderData = {
 	ok: true
@@ -891,6 +898,14 @@ export type ConnectOauthLoaderData = {
 	builtInAvailable?: boolean
 	/** See {@link ConnectOauthExistingConnection}. */
 	existingConnection?: ConnectOauthExistingConnection | null
+	/** See {@link AccountIntegrationDetailLoaderData.hasStoredClientSecret}. */
+	hasStoredClientSecret?: boolean
+	/**
+	 * Absolute redirect (callback) URI for this deployment — the page URL
+	 * without query — so SSR can render the Redirect URI card before the
+	 * browser can compute it from `window.location`.
+	 */
+	redirectUri?: string
 }
 
 export type AccountMcpServerListItem = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Visiting `https://heykody.app/connect/oauth?provider=google` painted three different layouts in sequence (see the devtools screenshots in the report):

1. Server HTML: "Connect OAuth" + "Loading provider configuration…" with no Redirect URI card
2. After hydration: the Redirect URI card pops in (`getRedirectUri()` returned `''` during SSR)
3. After a client-side `fetch('/account/integrations.json?name=…')` (and a second `fetch('/account/secrets.json')`): the real "Connect google" page

[#1306](https://github.com/kentcdodds/kody/pull/1306) fixed this class of problem for `/oauth/authorize` (the MCP consent screen), not for `/connect/oauth` — this page's server handler already embedded the loader data, but the route only consumed it inside a client-only `handle.queueTask`, so the SSR pass and the first hydrated paint both rendered the loading fallback.

## Fix: /connect/oauth

- `ConnectOauthRoute` now resolves its config **synchronously during render** via `tryConsumeRouteLoaderData` (the `applyRouteLoaderData`-at-top-of-render pattern the account routes already use), so the server HTML, the hydration pass, and SPA navigations (whose loaders preload before the navigation commits) all paint the final layout with no flash and no layout shift.
- The server now also embeds:
  - `redirectUri` (computed via `joinAppUrl`) so the Redirect URI card renders in the server HTML — including on OAuth callback returns;
  - `hasStoredClientSecret` (stored integration's secret name, else `<providerKey>ClientSecret`), which removes the follow-up `/account/secrets.json` fetch entirely.
- `/account/integrations.json?name=` returns `hasStoredClientSecret` too, so the SPA route loader and the fallback refetch carry the same data.
- The queued task now only handles what is genuinely client-only: OAuth callback returns (sessionStorage), the loader-failure fallback refetch, and the built-in auto-start redirect.
- Resolution state is keyed to the normalized href: an in-app navigation to a different `/connect/oauth` query (another provider, a platform lane switch) resets and re-resolves instead of keeping the previous provider's page (fixes Bugbot's finding; callback flows are terminal and never reset).

## Rebased over #1357 / #1361 — behaviors preserved

Rebased onto main after [#1361](https://github.com/kentcdodds/kody/pull/1361) landed; the synchronous-render refactor threads all of its behaviors through:

- The loader data (`connectOauth` embed, SPA loader, and fallback refetch) carries `builtInAvailable` **and** `existingConnection`, applied during render so `wouldReplaceDifferentApp()` is correct at SSR time.
- The replace-before-overwrite confirmation server-renders (with the plain Connect button withheld) and still suppresses the built-in auto-start; the `platform=<slug>` rename lane and `platform=1` param are untouched.
- Operator `platformDescription` renders under the provider name in the server HTML.
- New SSR test covers exactly this intersection: a `platform=1` visit over a user-lane connection renders `data-testid="connect-replace-confirm"`, the description, and no Connect button.

## Sweep: other pages fetching initial data client-side

Audited every route in `packages/worker/client/routes/` (server embed × SPA loader × sync consumption). Three more pages had the same class of problem — their routes already consumed loader data synchronously, but the page handlers never embedded it:

- `/account/two-factor` always painted "Loading two-factor status…" then fetched `/account/two-factor.json`. Now embeds the same payload.
- `/account/passkeys` always painted "Loading passkeys…" then fetched `/account/passkeys.json`. Now embeds the same payload.
- Anonymous `/` (home) popped in the hero's discovery-prompt copy after a client `/onboarding.json` fetch (signed-in visits already embedded it). Now embeds `loadPublicOnboardingData(...)`.

Verified OK (already following the pattern): all other account/admin/blog/community/onboarding routes. Intentionally left client-side: community-detail stargazers and admin per-user usage drill-down (secondary content), plus genuinely client-only data (sessionStorage callback state, Turnstile widgets).

## Testing

- `npm run validate` fully green after the rebase and the Bugbot fix (format, lint, typecheck, node + workers unit, MCP, e2e, builds, checks).
- New SSR tests: connect-oauth provider visit renders the ready page ("Connect google", Redirect URI card, Connect button) with no loading text; the replace-confirmation state renders server-side with the Connect button withheld; two-factor renders "Two-factor authentication is disabled"; passkeys renders "No passkeys yet"; anonymous home renders "Copy the discovery prompt".
- Live dev-server checks (`curl` as a signed-in user) confirm the pages return their real content in the initial HTML.
- Manual browser test with screen recording: reloading `/connect/oauth?provider=github&…` twice shows zero loading flash or layout shift.

<a href="https://cursor.com/agents/bc-0fe65067-a430-4a54-bb47-a8e99152715f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnect_oauth_reload_no_loading_flash.mp4"><img src="https://cursor.com/artifacts/c/art-9c021f83-1629-4f3a-bcda-d55644021a72" alt="connect_oauth_reload_no_loading_flash.mp4" /></a>

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends a primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/ssr-connect-oauth-loader-data-715f`

**Classification:** extends — the connect-oauth page's loader-data contract gains `redirectUri` and `hasStoredClientSecret`, the route moves from post-hydration data consumption to render-time consumption (threading #1361's `existingConnection` / replace confirmation through), and three page handlers gain SSR loader-data embeds. No primitives added.

### Primitives touched

| Primitive | Group    | Impact                                                                                       |
| --------- | -------- | -------------------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — `/connect/oauth` SSR embed + render-time loader-data consumption; SSR embeds added for `/account/two-factor`, `/account/passkeys`, anonymous `/`; richer `/account/integrations.json?name=` payload |

### System map

Pages resolve their initial data during server render from embedded loader data instead of refetching it client-side after hydration.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	appUi -->|"connect-oauth handler embeds integration + redirectUri + hasStoredClientSecret + existingConnection"| d1AppDb
	appUi -->|"two-factor / passkeys handlers embed their .json payloads"| d1AppDb
	appUi -->|"integrations.json?name= adds hasStoredClientSecret (secret_entries lookup)"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
Before: SSR "Loading provider configuration…" → hydration adds Redirect URI card
        → fetch integrations.json → fetch secrets.json → real page (3 layout shifts)
After:  SSR renders the final page (status, Redirect URI, provider details, setup/connect
        step, replace confirmation when applicable) → hydration paints identical HTML
        → no client fetches on the happy path
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fe65067-a430-4a54-bb47-a8e99152715f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fe65067-a430-4a54-bb47-a8e99152715f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth connection setup now loads faster with preloaded configuration and redirect information.
  * Existing client-secret availability is detected automatically during integration setup.
  * OAuth callback recovery and provider changes are handled more reliably.
  * Passkey, two-factor, and public onboarding pages now display server-rendered content immediately.

* **Bug Fixes**
  * Prevented outdated asynchronous setup results from replacing current configuration.
  * Improved error visibility for OAuth callbacks and initialization failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->