### PR TITLE
Add decision record 0015: wait on Skills over MCP (SEP-2640)

### DIFF
--- a/docs/contributing/decisions/0015-skills-over-mcp-wait.md
+++ b/docs/contributing/decisions/0015-skills-over-mcp-wait.md
@@ -1,0 +1,45 @@
+# 0015: Wait on Skills over MCP (SEP-2640); serve skill content via packages
+
+- **Status:** accepted
+- **Date:** 2026-08-10
+
+## Context
+
+An early user requested support for
+[SEP-2640 "Skills Extension"](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)
+(extension id `io.modelcontextprotocol/skills`): serving Agent Skills over MCP
+as `skill://` resources with `skills/list` / `skills/get` discovery methods. As
+of 2026-08 the SEP is an open draft whose wire format has changed materially
+twice, OpenAI's only shipped support is a snapshot importer in the ChatGPT
+plugin-submission flow (not live serving from a connected per-user server), and
+Claude Code does not consume MCP-served skills end-to-end. Kody's MCP surface is
+deliberately two tools (`search` + `execute`) with no Resources primitive,
+served across the dual-lane setup in
+[0005](./0005-mcp-dual-lane-stateless-migration.md); neither the frozen legacy
+SDK v1 lane nor the SDK v2 stateless lane supports registering the extension's
+custom JSON-RPC methods today. Packages cannot implement it either: they extend
+the capability graph behind search/execute and cannot touch the protocol
+surface.
+
+## Decision
+
+Do not implement SEP-2640 now — neither as a platform primitive nor via a
+package (the latter is architecturally impossible). Skill-shaped content is
+served through the existing compact surface instead: skills authored as package
+files, discovered via `search`, read via `execute` (the `coding_guide_get`
+progressive-disclosure pattern).
+
+## Consequences
+
+- The MCP surface stays two tools; no Resources support, extension negotiation,
+  digest/index machinery, or per-lane custom-method plumbing.
+- Hosts that only consume skills via the SEP-2640 wire format will not see
+  Kody-hosted skills; hosts that speak search/execute lose nothing.
+- Revisit when **all** of: (1) SEP-2640 is merged (leaves draft), (2) a host
+  Kody users actually connect from (Claude/Claude Code, Cursor, ChatGPT live
+  connections) consumes MCP-served skills live from a connected server rather
+  than a submission-time snapshot, and (3) the SDK v2 lane supports the
+  extension's custom methods — ideally after the legacy lane retires per 0005.
+  The preferred future shape is a thin protocol adapter that projects
+  package-backed skill directories as `skill://` resources, keeping packages as
+  the source of truth.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -34,3 +34,4 @@ behavior (see [documentation principles](../documentation.md)).
 - [0012 — Client-safe shared code lives in `#universal/*`](./0012-universal-layer.md)
 - [0013 — Synthetic package requests for post-publish verification](./0013-synthetic-package-requests.md)
 - [0014 — Platform scopes resolve live in package imports](./0014-platform-live-packages.md)
+- [0015 — Wait on Skills over MCP (SEP-2640); serve skill content via packages](./0015-skills-over-mcp-wait.md)


### PR DESCRIPTION
## Intent

An early user (Cameron Pak) asked whether Kody should support "Skills over MCP" ([SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)), noting OpenAI and mcp-use are backing it. This PR records the evaluated decision so the question has a durable answer in the decisions index before it comes up again.

## Summary

- Adds [ADR 0015](docs/contributing/decisions/0015-skills-over-mcp-wait.md): **wait** on SEP-2640 — do not implement it as a platform primitive now, and note that a community package architecturally cannot implement it (packages extend the capability graph behind `search`/`execute` and cannot register resources, extension capabilities, or the `skills/list` / `skills/get` custom JSON-RPC methods).
- Records the concrete revisit triggers: SEP merged out of draft, a host Kody users actually connect from consuming MCP-served skills live (OpenAI's shipped support is a snapshot importer in the plugin-submission flow; Claude Code does not consume MCP-served skills end-to-end), and SDK v2 lane support for the extension's custom methods — ideally after the legacy lane retires per [ADR 0005](docs/contributing/decisions/0005-mcp-dual-lane-stateless-migration.md).
- Names the preferred future shape: a thin protocol adapter projecting package-backed skill directories as `skill://` resources, keeping packages as the source of truth.
- Links the record from the decisions index.

Research basis (as of 2026-08-10): the SEP-2640 PR discussion and spec text, the Skills Over MCP Working Group charter, OpenAI's ChatGPT plugin-submission skill import announcement (2026-08-04), and the `@olaservo/ext-skills` v1 reference SDK.

## Testing

- `npm run validate`: all jobs green except two e2e specs (`social-login`, `two-factor`) that failed when the wrangler web server died mid-suite under the fully concurrent run — unrelated to this docs-only change; both pass when re-run (`npm run test:e2e:run -- e2e/social-login.spec.ts e2e/two-factor.spec.ts` → 2 passed). A formatting issue in the new file was fixed with `oxfmt` and re-verified with `oxfmt --check`.
- `docs:check-temporal` passed (decision records are exempt but the run was green regardless).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `0f673673` · **Head:** `d56d4d66`

**Classification:** composes — documentation-only. The primitives classifier matched no primitives for this diff (2 files under `docs/contributing/decisions/`); no code, schema, or MCP surface changes. This records a decision **not** to add a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_  | —     | docs-only decision record |

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no code, schema, or MCP surface changes.
> 
> **Overview**
> Adds **ADR 0015** documenting that Kody will **not** implement [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) Skills over MCP (`skill://`, `skills/list` / `skills/get`) as a platform feature or via packages, because packages cannot extend the MCP protocol beyond `search`/`execute`.
> 
> The record states skill-like content should continue through **package files** plus existing **`search` / `execute`** (e.g. `coding_guide_get`), lists **revisit criteria** (SEP merged, a real host consuming live MCP skills, SDK v2 custom-method support), and notes a possible future **thin adapter** from package-backed skills to `skill://` resources. The decisions **index** gains a link to the new file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d56d4d66d3982801d34b3a354147a3d0002ea708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->