### PR TITLE
Remove unused legacy barrel re-exports

### DIFF
--- a/packages/worker/src/app/permissions-server.node.test.ts
+++ b/packages/worker/src/app/permissions-server.node.test.ts
@@ -11,10 +11,13 @@ import {
 import {
 	requireUserWithPermission,
 	requireUserWithRole,
+} from '#app/permissions-server.ts'
+import {
+	type PermissionString,
+	type RoleName,
 	userHasPermission,
 	userHasRole,
-} from '#app/permissions-server.ts'
-import { type PermissionString, type RoleName } from '#universal/permissions.ts'
+} from '#universal/permissions.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'

--- a/packages/worker/src/app/permissions-server.ts
+++ b/packages/worker/src/app/permissions-server.ts
@@ -17,7 +17,6 @@ export {
 	removeAdminRolePreservingLastAdmin,
 	removeUserRole,
 } from '#worker/identity/permissions-db.ts'
-export { userHasPermission, userHasRole } from '#universal/permissions.ts'
 
 function unauthorizedResponse(request: Request) {
 	if (wantsJson(request)) {

--- a/packages/worker/src/dr/exporter.node.test.ts
+++ b/packages/worker/src/dr/exporter.node.test.ts
@@ -21,14 +21,16 @@ import {
 	drExportMaxStorageDumpBufferBytes,
 	__testOnlyCreateInitialProgress,
 	__testOnlyParseProgress,
-	listPlatformStorageInventory,
 	runDrExportTick,
 	runDrExportWatchdogTick,
 	shouldRunDrExportCatchUpCron,
 	shouldRunDrExportCron,
 	shouldRunDrExportWatchdogCron,
 } from '#worker/dr/exporter.ts'
-import { listPlatformOwnerInventory } from '#worker/dr/exporter-inventory.ts'
+import {
+	listPlatformOwnerInventory,
+	listPlatformStorageInventory,
+} from '#worker/dr/exporter-inventory.ts'
 import { encodeStorageIdentity } from '#worker/dr/storage-identity.ts'
 import {
 	DrBackupPreconditionFailedError,

--- a/packages/worker/src/dr/exporter.ts
+++ b/packages/worker/src/dr/exporter.ts
@@ -66,7 +66,6 @@ import {
 	shouldRunDrExportCron,
 } from '#worker/dr/exporter-schedule.ts'
 
-export { listPlatformStorageInventory } from '#worker/dr/exporter-inventory.ts'
 export {
 	drExportCatchUpLookbackDays,
 	isDrExportConfigured,

--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -39,10 +39,8 @@ import {
 	recordEmailReportingEvent,
 	type EmailReportingEnv,
 } from './reporting-events.ts'
-import {
-	emailAttachmentBlobKey,
-	ensurePlatformSenderIdentity,
-} from './service.ts'
+import { emailAttachmentBlobKey } from './blob-keys.ts'
+import { ensurePlatformSenderIdentity } from './repo.ts'
 import { type EmailMessageRecord, type EmailProcessingStatus } from './types.ts'
 
 type SendEmailEnv = Pick<

--- a/packages/worker/src/email/service.ts
+++ b/packages/worker/src/email/service.ts
@@ -2,7 +2,6 @@ import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
 import { isoTimestampDayKey } from '@kody-internal/shared/date-keys.ts'
 import PostalMime from 'postal-mime'
 import {
-	EmailRawMimeStorageError,
 	putEmailRawMime,
 	RetryableInboundStorageError,
 } from './email-raw-mime-store.ts'
@@ -35,10 +34,7 @@ import {
 	type ParsedInboundEmail,
 } from './types.ts'
 
-export { EmailRawMimeStorageError, RetryableInboundStorageError }
-
-export { emailAttachmentBlobKey, emailRawMimeKey } from './blob-keys.ts'
-export { ensurePlatformSenderIdentity } from './repo.ts'
+export { RetryableInboundStorageError }
 
 function nowIso() {
 	return new Date().toISOString()

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -7,12 +7,12 @@ import {
 	createMissingSecretMessage,
 	createPackageSecretAccessDeniedBatchMessage,
 } from '#mcp/secrets/errors.ts'
+import { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
 import { EntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { createUnboundRuntimeHelperMessage } from '#worker/package-runtime/unbound-runtime-helpers.ts'
 import { createStorageEstimateReadError } from '#worker/storage-estimate-error.ts'
 import {
 	createKodyRemoteProxy,
-	createKodyProviderProxySource,
 	createExecuteExecutor,
 	createExecutorModuleSource,
 	createExecutorSandboxTimeoutMessage,

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -52,8 +52,6 @@ import {
 } from '#worker/sentry-options.ts'
 import { parseStorageEstimateReadErrorMessage } from '#worker/storage-estimate-error.ts'
 
-export { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
-
 type WorkerLoopbackExports = Exclude<typeof workerExports, undefined>
 
 export const defaultExecutionResponseLimitBytes = 102_400

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -23,6 +23,7 @@ import {
 	runModuleWithRegistry,
 } from './run-kody-registry.ts'
 import * as mcpExecutor from '#mcp/executor.ts'
+import { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
 import { type KodyResolvedProvider } from '#mcp/kody-remote-types.ts'
 import { PackageSecretMountError } from '#mcp/secrets/package-access.ts'
 import * as packageAccess from '#mcp/secrets/package-access.ts'
@@ -1444,7 +1445,7 @@ test('remote connector calls round-trip through sanitized ToolDispatcher names',
 	const dispatchers = mcpExecutor.createToolDispatchers([provider], {
 		active: true,
 	})
-	const source = mcpExecutor.createKodyProviderProxySource({
+	const source = createKodyProviderProxySource({
 		providerName: provider.name,
 		remoteConnectors,
 	})

--- a/packages/worker/src/mcp/tools/search-descriptors.ts
+++ b/packages/worker/src/mcp/tools/search-descriptors.ts
@@ -17,9 +17,6 @@ import {
 	extractSearchTokens,
 } from './understand-search-query.ts'
 
-export { buildIntegrationSearchDocument } from './search-entity-plugins/integration.ts'
-export { flattenReferencedTypeFields } from './search-entity-plugins/package.ts'
-
 function buildPackageRelationTokens(
 	match: Extract<SearchMatch, { type: 'package' }>,
 ) {

--- a/packages/worker/src/package-runtime/module-graph.ts
+++ b/packages/worker/src/package-runtime/module-graph.ts
@@ -6,7 +6,6 @@ export {
 	parsePackageRuntimeModulePathPackageId,
 	refreshKodyRuntimeModules,
 } from './runtime-source-modules.ts'
-export { createPublishedBundleArtifact } from './module-graph-artifacts.ts'
 export {
 	buildKodyAppBundle,
 	buildKodyImportableModuleBundle,

--- a/packages/worker/src/remote-connector/connector-session-key.node.test.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.node.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
+import { userScopedConnectorIngressPath } from '@kody-internal/shared/remote-connectors.ts'
 import {
 	parseUserScopedConnectorRoutePath,
-	userScopedConnectorIngressPath,
 	userScopedConnectorSessionKey,
 } from './connector-session-key.ts'
 

--- a/packages/worker/src/remote-connector/connector-session-key.ts
+++ b/packages/worker/src/remote-connector/connector-session-key.ts
@@ -4,8 +4,6 @@ import {
 } from '@kody-internal/shared/remote-connectors.ts'
 import { durableObjectNameFromParts } from '#worker/user-scoped-durable-object-name.ts'
 
-export { userScopedConnectorIngressPath } from '@kody-internal/shared/remote-connectors.ts'
-
 export type UserScopedConnectorRouteMatch = {
 	username: string
 	instanceId: string

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -1180,7 +1180,6 @@ export type {
 	ActivationMilestoneRecord,
 	PackageRunSuccessRecord,
 } from './package-activation-state.ts'
-export { countsTowardPackageActivation } from './package-activation-state.ts'
 export type {
 	JobRunObservabilityRecord,
 	JobRunObservabilityStatus,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove unused and test-only barrel re-exports so production modules expose only their owned service APIs and callers import helpers from canonical modules.

## Summary

- remove dead re-exports from email, MCP search, package runtime, and run-record services
- retarget tests for executor proxy source, DR inventory, remote connector paths, and RBAC helpers to canonical modules
- retarget the remaining outbound email caller to canonical blob-key and repository modules
- preserve runtime behavior

## Testing

- Pre-change usage audit confirmed no production consumers through seven listed barrel paths and identified one stale same-folder email caller during full validation
- `npm run validate` — passed (590 test files, 2,046 tests, and E2E)

## Conductor report

- Track: B — legacy dead re-exports
- Status: validated; CI and squash-merge pending
- Scope: only the eight requested barrel surfaces and their canonical consumers
- Risk: low; export-surface cleanup with no runtime behavior changes

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `4f934f09` · **Head:** `fb7327a3`

**Classification:** composes — removes unused forwarding exports and points callers at existing canonical modules; no primitive behavior, storage, or invariants change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — RBAC tests import universal helpers directly |
| `backup-control-plane` | storage | composes — inventory test imports canonical inventory module |
| `connector-ingress` | surfaces | composes — route helper test imports shared implementation |
| `email` | assistant | composes — dead service forwarding exports removed and outbound imports canonical modules |
| `mcp-server` | surfaces | composes — dead search/executor forwarding exports removed |
| `package-runtime` | runtime | composes — dead artifact forwarding export removed |
| `remote-connectors` | assistant | composes — canonical shared route helper ownership retained |
| `run-records` | storage | composes — dead activation forwarding export removed |

### System map

Each touched barrel now exposes only its owned API; callers resolve helper symbols directly from existing canonical modules.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	email["email<br/>Email"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	packageRuntime["package-runtime<br/>Package runtime"]:::touched
	backupControl["backup-control-plane<br/>Production backup control plane"]:::touched
	remoteConnectors["remote-connectors<br/>Remote connectors"]:::touched
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	email -->|"outbound imports blob keys and sender identity canonically"| email
	mcpServer -->|"tests import proxy source directly"| packageRuntime
	backupControl -->|"tests import inventory directly"| backupControl
	remoteConnectors -->|"tests import shared ingress path directly"| remoteConnectors
	appUi -->|"tests import universal RBAC helpers directly"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-972e80c4-0b30-40aa-a600-93164aca6d67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-972e80c4-0b30-40aa-a600-93164aca6d67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated access to internal authorization, email, integration, connector, package, and MCP utilities through their dedicated modules.
  - Removed redundant public re-exports from worker services to clarify supported module boundaries.
  - Updated related tests to use the appropriate direct imports.

- **Tests**
  - Adjusted test imports without changing existing test behavior or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->