### PR TITLE
docs: OAuth/BYOK truth pass and SIGNUP_MODE signup gating

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -64,13 +64,17 @@ request so cookie signing and verification are available to handlers.
 
 ### Signup posture and invites
 
-Production signup is invite-gated. The auth handler uses
-`packages/worker/src/app/deployment-env.ts` (`isNonProductionRuntime`) to decide
-whether an invite is required. Production wrangler env sets
-`SENTRY_ENVIRONMENT: 'production'`; `npm run dev` sets
-`WRANGLER_IS_LOCAL_DEV=true`; preview/test set `SENTRY_ENVIRONMENT` to
-`'preview'` / `'test'`. The predicate fails closed: if the runtime cannot be
-positively identified as non-production, signup requires a valid invite code.
+Signup gating is controlled by the `SIGNUP_MODE` Worker var
+(`packages/worker/universal/signup-mode.ts`), read through `getSignupMode`.
+Password and social signup require a valid invite whenever the mode is not
+`open` (`invite` and `waitlist` both gate). Wrangler sets
+`SIGNUP_MODE: 'invite'` for `production` and `preview`, and `'open'` for `test`
+(Playwright / `CLOUDFLARE_ENV=test`). Local `npm run dev` defaults to the
+`production` Wrangler env (`CLOUDFLARE_ENV` defaults to `production` in
+`wrangler-env.ts`), so invite gating applies unless you point at `test`.
+`isNonProductionRuntime` is unrelated to invite gating (it still gates Kit
+waitlist soft-fail, email-send skip when no sender is configured, and similar
+non-production shortcuts).
 
 The public `/signup` page defaults to a waiting-list form (first name + email)
 backed by `POST /waiting-list`, which upserts a Kit subscriber and tags them
@@ -117,11 +121,11 @@ The `invites` table stores operator-created invite codes:
   invite creation validates plan names with strict `parsePlanName`. See
   [Entitlements](./entitlements.md).
 
-Production signup atomically consumes an invite with a single conditional
-`UPDATE ... WHERE use_count < max_uses AND revoked_at IS NULL ...`; concurrent
-requests cannot over-use a code. Local dev, preview, and test runtimes remain
-open when no invite is supplied, but they still consume and validate an invite
-when a code is provided so E2E coverage can exercise the same path.
+When invite gating is on, signup atomically consumes an invite with a single
+conditional `UPDATE ... WHERE use_count < max_uses AND revoked_at IS NULL ...`;
+concurrent requests cannot over-use a code. The open `test` env skips the invite
+requirement when no code is supplied, but still consumes and validates a code
+when one is provided so E2E coverage can exercise the same path.
 
 Admins manage invites at `/admin/invites`. The route uses the RBAC `admin` role
 guard, not an owner-scoped content bypass. Invite creation (including optional
@@ -458,8 +462,8 @@ definitions in `packages/worker/src/app/oauth-providers.ts`.
   `/account/connections.json` (disconnect is refused when the connection is the
   only sign-in method); a provider-verified email matching an existing account
   auto-links and signs in; otherwise account creation follows the signup posture
-  (production requires a valid invite code carried from the invite signup panel;
-  non-production remains open without one)
+  (`SIGNUP_MODE !== 'open'` requires a valid invite code carried from the invite
+  signup panel; the `test` env remains open without one)
 - Buttons only render for providers whose client id/secret env vars are set;
   `MOCK_`-prefixed client ids activate an in-worker mock flow on non-production
   runtimes for dev and E2E tests

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -32,12 +32,12 @@ shared state between users.
 
 - Optimization target: a high-quality personal assistant for each individual
   signed-in user, with hard isolation between users
-- Onboarding: production signup is invite-gated by operator-created invite
-  codes. People without a code can join a Kit-backed waiting list from
-  `/signup`. Local dev, preview, and test runtimes remain open so fixtures,
-  seeds, and manual development do not need an auth-bypass path. New signups
-  must verify their email address; unverified accounts can sign in but cannot
-  send outbound email. There is still no privileged "primary user" at runtime.
+- Onboarding: signup gating is the `SIGNUP_MODE` Worker var (`invite` / `open` /
+  `waitlist`). Production and preview are `invite`; the Wrangler `test` env is
+  `open` for fixtures and E2E. People without a code can join a Kit-backed
+  waiting list from `/signup`. New signups must verify their email address;
+  unverified accounts can sign in but cannot send outbound email. There is still
+  no privileged "primary user" at runtime.
 - Tests and fixtures may seed deterministic local accounts, but seeded accounts
   are fixtures only and are not privileged at runtime
 

--- a/packages/worker/client/routes/byok-explainer.tsx
+++ b/packages/worker/client/routes/byok-explainer.tsx
@@ -82,9 +82,10 @@ function renderDiagramChip(
 }
 
 /**
- * "Bring your own keys" pitch: why Kody has no built-in integrations.
- * Shared between onboarding and the integrations page so the story stays
- * consistent everywhere people expect a built-in integration catalog.
+ * "Bring your own keys" pitch for surfaces that also offer built-ins.
+ * Matches onboarding's hasBuiltIns framing: built-ins = fast start on an app
+ * Kody hosts; BYO = full control / custom scopes. Shared with the
+ * integrations page so the story stays consistent.
  */
 export function renderByokExplainer(options?: {
 	image?: keyof typeof kodyImages
@@ -122,9 +123,10 @@ export function renderByokExplainer(options?: {
 					<div mix={css({ display: 'grid', gap: spacing.xs })}>
 						<h2 mix={css(cardTitleCss)}>Bring your own keys</h2>
 						<p mix={css(descriptionCss)}>
-							Kody never asks a company for access on your behalf. You create
-							the connection yourself — your agent walks you through it — so it
-							is completely yours: your app, your scopes, no middleman.
+							Built-in integrations run on an app Kody hosts, for a fast start.
+							For everything else — or for full control — you create the
+							connection yourself, and your agent walks you through it, so it is
+							completely yours: your app, your scopes, no middleman.
 						</p>
 					</div>
 					<div mix={css({ display: 'grid', gap: spacing.xs })}>
@@ -141,7 +143,7 @@ export function renderByokExplainer(options?: {
 							{renderDiagramChip('GitHub')}
 						</p>
 						<p mix={css(diagramRowCss)}>
-							<span mix={css(diagramLabelCss)}>Kody</span>
+							<span mix={css(diagramLabelCss)}>Kody (BYO)</span>
 							{renderDiagramChip('You')}
 							<span aria-hidden="true" mix={css(diagramArrowCss)}>
 								→
@@ -167,8 +169,9 @@ export function renderByokExplainer(options?: {
 							Kody can touch, and you can revoke it anytime.
 						</li>
 						<li>
-							<strong>No middleman.</strong> Nothing sits between you and the
-							provider — no shared app to trust or get breached.
+							<strong>Full control when you want it.</strong> Bring-your-own
+							keeps nothing between you and the provider — your app, your scopes
+							(including custom scopes outside a built-in allowlist).
 						</li>
 						<li>
 							<strong>No fixed list.</strong> If it has an API, your Kody can
@@ -176,8 +179,8 @@ export function renderByokExplainer(options?: {
 						</li>
 					</ul>
 					<p mix={css(descriptionCss)}>
-						The trade-off: a few minutes of setup instead of one click. Your
-						agent does the tedious parts.
+						Built-ins are one click. Bring-your-own takes a few minutes of
+						setup; your agent does the tedious parts.
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop docs and UI copy from steering agents into bring-your-own OAuth / wrong signup gates now that platform-hosted Google/GitHub/Slack apps are the one-click path and invite gating is `SIGNUP_MODE`.

## Summary

- **BYOK explainer** (`byok-explainer.tsx`): copy matches onboarding’s `hasBuiltIns` framing — built-ins = fast start on a Kody-hosted app; BYO = full control / custom scopes (no more “never asks a company…” / “no one click”).
- **Signup gating docs**: `authentication.md` + `project-intent.md` describe `SIGNUP_MODE` (`prod`/`preview` = `invite`, `test` = `open`) instead of `isNonProductionRuntime`.
- **Already on `main` (this track’s done-definition, not re-landed here):** provider guides lead with built-in connect (#1366); ADR 0015 SEP-2640 Skills-over-MCP wait (#1362). Discord/Notion/Spotify guides correctly stay BYO-first (no platform apps).

## Testing

- `npm run validate` green (includes docs checks)
- Pre-push: unit + Playwright E2E green after rebase onto `main`
- PR CI green; squash-merged; production deploy success

## Conductor report

- **Status:** DONE — squash-merged and production deploy succeeded
- **PR:** https://github.com/kentcdodds/kody/pull/1368 → merge `75096402`
- **CI:** https://github.com/kentcdodds/kody/actions/runs/31379557705 (PR) · https://github.com/kentcdodds/kody/actions/runs/31385926643 (main)
- **Deploy:** https://github.com/kentcdodds/kody/actions/runs/31386423409 (success)
- **Discord:** ship summary posted
- **Remaining:** none for this track

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `21e2a02e` · **Head:** `6164b212` (merged as `75096402`)

**Classification:** composes — docs and UI copy only; no primitive behavior, schema, or contract changes.

### Primitives touched

| Primitive | Group    | Impact                                                  |
| --------- | -------- | ------------------------------------------------------- |
| `app-ui`  | surfaces | composes — BYOK explainer copy on integrations surfaces |

Unmatched paths (docs only): `docs/contributing/architecture/authentication.md`, `docs/contributing/project-intent.md`.

### System map

Copy and contributing docs align with already-shipped platform OAuth and `SIGNUP_MODE` invite gating; no runtime wiring changes in this PR.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	docsAuth["contributing docs<br/>auth + project-intent"]:::untouched
	appUi -->|"BYOK explainer copy"| appUi
	docsAuth -->|"SIGNUP_MODE truth"| docsAuth
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface            | Before                                            | After                                                |
| ------------------ | ------------------------------------------------- | ---------------------------------------------------- |
| BYOK explainer     | Denies one-click / shared app                     | Built-ins = one click; BYO = control / custom scopes |
| Signup gating docs | `isNonProductionRuntime`; local/preview/test open | `SIGNUP_MODE`; prod+preview `invite`, test `open`    |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9be50f5b-e1d5-4a3e-ac43-29b94576d01e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9be50f5b-e1d5-4a3e-ac43-29b94576d01e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified signup access rules for production, preview, local development, and testing environments.
  * Documented invite requirements, waitlist signup availability, and email restrictions for unverified accounts.

* **Updated Content**
  * Refined the BYO connections explainer to highlight custom scopes, direct provider access, and greater control over integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->