### PR TITLE
feat(client): dot-matrix loader + rotating stage words on install buttons

### DIFF
--- a/packages/worker/client/action-button-loader.tsx
+++ b/packages/worker/client/action-button-loader.tsx
@@ -1,0 +1,172 @@
+import { type Handle, css } from 'remix/ui'
+import { radius } from '#universal/styles/tokens.ts'
+import {
+	getSwapLabelCss,
+	visuallyHiddenCss,
+} from '#universal/styles/style-primitives.ts'
+
+/**
+ * The stages a one-click community install actually walks through
+ * (`installCommunityListing`): fork the snapshot into the viewer's account,
+ * run the standard package checks over it, then refresh the saved-package
+ * projection that wires up exports, jobs, and services.
+ */
+export const installProgressWords = [
+	'Forking',
+	'Copying',
+	'Checking',
+	'Bundling',
+	'Publishing',
+	'Wiring',
+] as const
+
+const defaultWordHoldMs = 2600
+
+const dotColumns = 3
+const dotRows = 3
+const dotCount = dotColumns * dotRows
+const dotIndexes = Array.from({ length: dotCount }, (_, index) => index)
+const dotSize = '4px'
+const dotGap = '2px'
+// One diagonal of the matrix lights per step, so the wave reads as a sweep
+// across the grid rather than nine dots blinking together.
+const dotWaveStepMs = 110
+const dotWaveDurationMs = 1200
+
+function getDotWaveDelayCss() {
+	const rules: Record<string, { animationDelay: string }> = {}
+	for (const index of dotIndexes) {
+		const diagonal = Math.floor(index / dotColumns) + (index % dotColumns)
+		rules[`& > span:nth-child(${index + 1})`] = {
+			animationDelay: `${diagonal * dotWaveStepMs}ms`,
+		}
+	}
+	return rules
+}
+
+const loaderCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	gap: '0.5rem',
+}
+
+/**
+ * The dots inherit `currentColor`, so the matrix picks up whatever face the
+ * button it sits in already wears (on-primary in a filled pill, body text in
+ * a ghost). Under reduced motion the wave never starts and the evenly lit
+ * grid below is the whole loader — calm, but still visibly not the idle
+ * label.
+ */
+const dotMatrixCss = {
+	display: 'grid',
+	gridTemplateColumns: `repeat(${dotColumns}, ${dotSize})`,
+	gridTemplateRows: `repeat(${dotRows}, ${dotSize})`,
+	gap: dotGap,
+	flex: 'none',
+	'& > span': {
+		borderRadius: radius.full,
+		backgroundColor: 'currentColor',
+		opacity: 0.45,
+	},
+	'@keyframes action-button-dot-wave': {
+		'0%, 70%, 100%': { opacity: 0.2, scale: '0.7' },
+		'25%': { opacity: 1, scale: '1' },
+	},
+	'@media (prefers-reduced-motion: no-preference)': {
+		'& > span': {
+			animation: `action-button-dot-wave ${dotWaveDurationMs}ms ease-in-out infinite`,
+		},
+		...getDotWaveDelayCss(),
+	},
+}
+
+// Every word stays in the same grid cell so the button keeps one width for
+// the whole wait; only the active one is painted.
+const progressWordCss = getSwapLabelCss()
+
+type ActionButtonLoaderProps = {
+	/**
+	 * Names the pending action for assistive technology ("Installing") for as
+	 * long as the work runs. The rotating word is only ever a suffix on it,
+	 * and it is the visible label when no words are given.
+	 */
+	label: string
+	/**
+	 * Rotating one-word stages. These are held on a timer, not driven by
+	 * server progress — a one-click install is a single request with no
+	 * progress stream — so they name what the operation does and stop on the
+	 * last word instead of looping or implying a percentage.
+	 */
+	words?: ReadonlyArray<string>
+	/** How long each word holds before the next one takes over. */
+	wordHoldMs?: number
+}
+
+/**
+ * The loading face of an action button: a dot-matrix wave plus an optional
+ * rotation of one-word stages. Render it as the button's children while the
+ * action is pending, and put `disabled` and `aria-busy` on the button itself.
+ */
+export function ActionButtonLoader(handle: Handle<ActionButtonLoaderProps>) {
+	let wordIndex = 0
+	let intervalId: ReturnType<typeof globalThis.setInterval> | null = null
+
+	function stopRotation() {
+		if (intervalId === null) return
+		globalThis.clearInterval(intervalId)
+		intervalId = null
+	}
+
+	// The rotation keeps running under reduced motion: swapping a word is a
+	// content change, not movement, and it is the only progress feedback left
+	// once the wave is off.
+	if (
+		typeof document !== 'undefined' &&
+		(handle.props.words?.length ?? 0) > 1
+	) {
+		intervalId = globalThis.setInterval(() => {
+			wordIndex += 1
+			if (wordIndex >= (handle.props.words?.length ?? 0) - 1) stopRotation()
+			handle.update()
+		}, handle.props.wordHoldMs ?? defaultWordHoldMs)
+		handle.signal.addEventListener('abort', stopRotation)
+	}
+
+	return () => {
+		const words = handle.props.words ?? []
+		const activeIndex = Math.min(wordIndex, words.length - 1)
+		const activeWord = words[activeIndex] ?? null
+
+		return (
+			<span mix={css(loaderCss)}>
+				<span aria-hidden="true" mix={css(dotMatrixCss)}>
+					{dotIndexes.map((index) => (
+						<span key={index} />
+					))}
+				</span>
+				{activeWord === null ? (
+					<span>{handle.props.label}</span>
+				) : (
+					<>
+						<span aria-hidden="true" mix={css(progressWordCss)}>
+							{words.map((word, index) => (
+								<span
+									key={index}
+									data-swap-label
+									data-active={index === activeIndex ? 'true' : undefined}
+								>
+									{word}
+								</span>
+							))}
+						</span>
+						<span mix={css(visuallyHiddenCss)}>{handle.props.label}</span>
+						<span role="status" aria-live="polite" mix={css(visuallyHiddenCss)}>
+							{activeWord}
+						</span>
+					</>
+				)}
+			</span>
+		)
+	}
+}

--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -11,6 +11,10 @@ import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readRouterPathname } from '#client/router-location.tsx'
 import { on } from '#client/event-mixin.ts'
+import {
+	ActionButtonLoader,
+	installProgressWords,
+} from '#client/action-button-loader.tsx'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
@@ -828,6 +832,9 @@ export function CommunityDetailRoute(handle: Handle) {
 											<div mix={css(sectionActionCss)}>
 												<button
 													disabled={installState === 'submitting'}
+													aria-busy={
+														installState === 'submitting' ? 'true' : undefined
+													}
 													mix={[
 														on('click', () => {
 															if (trusted) {
@@ -841,9 +848,14 @@ export function CommunityDetailRoute(handle: Handle) {
 														css(pillButtonCss),
 													]}
 												>
-													{installState === 'submitting'
-														? 'Installing…'
-														: 'Install'}
+													{installState === 'submitting' ? (
+														<ActionButtonLoader
+															label="Installing"
+															words={installProgressWords}
+														/>
+													) : (
+														'Install'
+													)}
 												</button>
 											</div>
 										)

--- a/packages/worker/client/routes/onboarding-starter-card.tsx
+++ b/packages/worker/client/routes/onboarding-starter-card.tsx
@@ -4,6 +4,10 @@ import { type OnboardingFeaturedListing } from '#universal/community-public-type
 import { CommunityListingIcon } from '#universal/community-listing-icon.tsx'
 import { writeClipboardText } from '#client/clipboard.ts'
 import { on } from '#client/event-mixin.ts'
+import {
+	ActionButtonLoader,
+	installProgressWords,
+} from '#client/action-button-loader.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
 	colors,
@@ -211,13 +215,21 @@ export function OnboardingStarterCard(
 					<button
 						type="button"
 						disabled={phase === 'installing'}
+						aria-busy={phase === 'installing' ? 'true' : undefined}
 						mix={[
 							css(isRow ? rowInstallButtonCss : installButtonCss),
 							on('click', () => void submitInstall()),
 						]}
 						data-testid={`onboarding-starter-install-${listing.id}`}
 					>
-						{phase === 'installing' ? 'Installing…' : 'Install'}
+						{phase === 'installing' ? (
+							<ActionButtonLoader
+								label="Installing"
+								words={installProgressWords}
+							/>
+						) : (
+							'Install'
+						)}
 					</button>
 				)}
 				{readyStatus ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

A one-click community install can sit silent for ~20 seconds while the fork, the
package checks, and the projection refresh run. Today the only feedback is the
button label flipping to "Installing…", which reads as a frozen page. Cameron
Pak's onboarding feedback called this out, and Kent asked for a dot-matrix
loading state in the spirit of the matrix-style loaders Cameron pointed at, plus
a rotation of one-word progress texts to keep the wait interesting.

## Summary

- New shared `ActionButtonLoader`
  (`packages/worker/client/action-button-loader.tsx`): a 3×3 dot matrix whose
  wave sweeps one diagonal at a time, plus an optional rotation of one-word
  stages. The dots are `currentColor`, so the loader wears whatever face the
  button it sits in already has (on-primary in a filled pill, body text in a
  ghost) and needs no per-theme styling.
- `installProgressWords` names the stages a one-click install actually walks
  through in `installCommunityListing` (`Forking`, `Copying`, `Checking`,
  `Bundling`, `Publishing`, `Wiring`). They are time-held and decorative — the
  install is a single fetch with no progress stream — so the rotation stops on
  the last word rather than looping or implying a percentage.
- Adopted on the community one-click Install button (`community-detail.tsx`,
  `installState === 'submitting'`) and the onboarding starter-card install
  (`onboarding-starter-card.tsx`, `phase === 'installing'`). Both buttons now
  carry `aria-busy` alongside the existing `disabled`.
- **Reduced motion:** the wave lives entirely inside
  `@media (prefers-reduced-motion: no-preference)`, so under `reduce` the matrix
  is an evenly lit static grid. The word rotation keeps running there on purpose
  — swapping a word is a content change, not movement, and it is the only
  progress feedback left once the wave is off.
- **Accessibility:** the dots and the visible word stack are `aria-hidden`; a
  visually hidden label ("Installing") names the button for the whole wait, and a
  visually hidden `role="status"` / `aria-live="polite"` region announces each
  stage. Every word is stacked in one grid cell (the existing `getSwapLabelCss()`
  primitive), so the button holds one width for the whole wait instead of
  jittering on each swap.

## Testing

`npm run validate` — green (the known-flaky two-factor e2e case passed on retry).

Everything below was captured against the real dev server (`npm run dev`) with a
seeded trusted + featured community listing, driving the real install buttons.
The install request is held open by a Playwright route handler so the ~20s
pending state can be photographed deterministically; nothing about the button's
own state machine is stubbed.

**Idle → loading (light), and the same loading state in dark mode:**

![One-click install section: idle Install button, loading state with dot matrix and Forking, and the loading state in dark mode](https://cursor.com/artifacts/c/art-8fd83028-49f5-4599-a1d6-377db0a1e94f)

**Dot-matrix wave + word rotation on the community Install button:**

<a href="https://cursor.com/agents/bc-390a1232-7dec-4374-8ab3-535c7b83b654/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finstall_loader_dot_matrix.mp4"><img src="https://cursor.com/artifacts/c/art-148e2ccd-2db7-494e-a2bf-1dc61f1fe00e" alt="install_loader_dot_matrix.mp4" /></a>

**Onboarding starter-card install (second call site):**

![Onboarding starter card with the install button showing the dot matrix loader and the word Forking](https://cursor.com/artifacts/c/art-08732ae0-7e66-4de4-a8ca-8ef926ba016a)

**Reduced motion** (`prefers-reduced-motion: reduce` emulated). The dots hold
still while the words keep advancing:

<a href="https://cursor.com/agents/bc-390a1232-7dec-4374-8ab3-535c7b83b654/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finstall_loader_reduced_motion.mp4"><img src="https://cursor.com/artifacts/c/art-09aad401-4459-4cae-9cd7-e1dc49fc9d80" alt="install_loader_reduced_motion.mp4" /></a>

Because "no animation" is hard to prove from a recording, it was also checked
deterministically — `Element.getAnimations()` per dot plus eight screenshots of
the dot grid taken 170ms apart:

```
default motion: matched=false
  animations: ["action-button-dot-wave" x9]
  frame hashes: 8 unique of 8
reduced motion: matched=true
  animations: ["" x9]          (no animations attached)
  frame hashes: 1 unique of 8  (byte-identical frames)
```

Accessibility tree while pending (Playwright aria snapshot) — the name stays
"Installing" while the live region carries the stage, and the stacked words never
leak into the name:

```
- button "Installing" [disabled]:      (aria-busy="true")
  - text: Installing
  - status: Forking
    ... 2.6s later ...
  - status: Copying
```

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `89cf0b4b` · **Head:** `e8a3697b`

**Classification:** composes — no primitives added or changed. A new shared
client component plus two call sites; no routes, handlers, schema, or storage
touched.

### Primitives touched

| Primitive             | Group     | Impact                                                                     |
| --------------------- | --------- | -------------------------------------------------------------------------- |
| `app-ui`              | surfaces  | composes — new `action-button-loader.tsx`, adopted in the starter card      |
| `community-listings`  | assistant | composes — one-click Install button renders the loader while submitting     |

### System map

The loader is a pure client-side rendering change: two existing install buttons
swap their pending label for the shared loader, while the install request itself
is untouched.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red =
new primitive · gray = context (unchanged, included only when an edge crosses
it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	communityListings["community-listings<br/>Community package listings"]:::touched
	installApi["POST /community/:listingId/install.json"]:::untouched
	appUi -->|"ActionButtonLoader as onboarding starter-card pending children"| communityListings
	communityListings -->|"unchanged single fetch; loader is time-based only"| installApi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```diff
- {installState === 'submitting' ? 'Installing…' : 'Install'}
+ {installState === 'submitting' ? (
+   <ActionButtonLoader label="Installing" words={installProgressWords} />
+ ) : 'Install'}
```

</details>

<!-- system-recap:end -->

## Conductor report

**Track:** dot-matrix action-button loading state + one-word progress texts.

- **Status:** shipped and squash-merged (`01b509c0`); production deploy watched.
- **Shipped:** shared `ActionButtonLoader` + adoption on both install buttons
  (community detail, onboarding starter card).
- **Gates:** local `npm run validate` green; PR CI fully green (Static, Node,
  Workers, MCP, E2E, Validate, Preview deploy).
- **AI review:** Cursor Bugbot ran and reported no findings. CodeRabbit could not
  run — it hit an account-level free-OSS review quota ("review limit reached"),
  and a re-request after the quota window did not produce a review. Merged on
  Bugbot green plus green CI under the granted medium-risk merge authority.
- **Evidence:** videos + screenshots above, from the real dev server with a
  seeded trusted/featured listing; reduced-motion and accessibility claims backed
  by the deterministic checks above.
- **Untouched (sibling-owned):** `onboarding.tsx` and the rest of the onboarding
  wizard, MCP server code, docs/guides. E2E specs unchanged (none asserted the
  old button labels).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-390a1232-7dec-4374-8ab3-535c7b83b654?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-390a1232-7dec-4374-8ab3-535c7b83b654&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

