### PR TITLE
feat(mcp): progress notifications, onboarding prompts, install hot-path

### DIFF
--- a/packages/worker/migrations/0007-saved-package-search-index-debt.sql
+++ b/packages/worker/migrations/0007-saved-package-search-index-debt.sql
@@ -1,0 +1,15 @@
+-- Durable debt for deferred saved-package vector upserts. When publish/install
+-- moves `upsertSavedPackageVector` off the response critical path via
+-- waitUntil, a row is written first so an isolate death or deferred failure
+-- cannot leave search silently stale. Capability reindex clears debt after a
+-- successful upsert; failures keep the row and report to Sentry.
+CREATE TABLE saved_package_search_index_debt (
+	package_id TEXT PRIMARY KEY NOT NULL,
+	user_id TEXT NOT NULL,
+	last_error TEXT,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_saved_package_search_index_debt_user_id
+ON saved_package_search_index_debt(user_id);

--- a/packages/worker/migrations/0007-saved-package-search-index-debt.sql
+++ b/packages/worker/migrations/0007-saved-package-search-index-debt.sql
@@ -3,9 +3,14 @@
 -- waitUntil, a row is written first so an isolate death or deferred failure
 -- cannot leave search silently stale. Capability reindex clears debt after a
 -- successful upsert; failures keep the row and report to Sentry.
+-- `generation` + `embed_text` make deferred upserts monotonic: a reconcile
+-- loop always upserts the latest queued text, and only the matching
+-- generation may clear debt.
 CREATE TABLE saved_package_search_index_debt (
 	package_id TEXT PRIMARY KEY NOT NULL,
 	user_id TEXT NOT NULL,
+	generation INTEGER NOT NULL DEFAULT 0,
+	embed_text TEXT NOT NULL,
 	last_error TEXT,
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -247,6 +247,14 @@ export const accountUserDataTargets: ReadonlyArray<UserScopedDataTarget> = [
 	{ kind: 'user_id', table: 'repo_sessions' },
 	{ kind: 'user_id', table: 'user_repos' },
 	{ kind: 'user_id', table: 'saved_packages' },
+	{
+		kind: 'user_id',
+		table: 'saved_package_search_index_debt',
+		includeInExport: false,
+		surface: 'saved_package_search_index_debt',
+		reason:
+			'Operational search-index reconcile debt omitted from portable export; account deletion removes outstanding debt rows.',
+	},
 	{ kind: 'user_id', table: 'entity_source_artifacts_push_subscriptions' },
 	{ kind: 'user_id', table: 'entity_sources' },
 	{

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -1,4 +1,9 @@
-import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import {
+	buildDiscoveryPrompt,
+	buildFirstWinPrompt,
+	buildMcpServerUrl,
+	buildOnboardingSetupPrompt,
+} from '#worker/onboarding-prompts.ts'
 import { type OnboardingFeaturedListing } from '#universal/community-public-types.ts'
 import {
 	type OnboardingBuiltInProvider,
@@ -7,7 +12,12 @@ import {
 	type OnboardingWelcomeEmail,
 } from '#universal/loader-data.ts'
 
-const mcpServerPath = '/mcp'
+export {
+	buildDiscoveryPrompt,
+	buildFirstWinPrompt,
+	buildMcpServerUrl,
+	buildOnboardingSetupPrompt,
+}
 
 type OnboardingEnv = {
 	APP_BASE_URL?: string | null
@@ -17,74 +27,6 @@ type OnboardingEnv = {
 			options?: { cursor?: string },
 		): Promise<{ items: Array<unknown>; cursor?: string }>
 	}
-}
-
-export function buildMcpServerUrl(input: {
-	env: Pick<OnboardingEnv, 'APP_BASE_URL'>
-	requestUrl: string | URL
-}) {
-	return `${getAppBaseUrl({
-		env: input.env,
-		requestUrl: input.requestUrl,
-	})}${mcpServerPath}`
-}
-
-export function buildOnboardingSetupPrompt() {
-	return [
-		'Help me get started with Kody.',
-		'First, briefly explain what Kody can do for me in plain language.',
-		'Then help me connect one integration I care about: check coding_guide_get for a matching provider guide (for example provider_github or provider_google) and follow it; otherwise use search and the official guides to find the right setup steps, walk me through the connect or secrets flow, and verify the connection with a small ad hoc execute smoke test.',
-		'Do not create any packages until the integration works — start with ad hoc execute calls.',
-		'Once the integration works, check community_search for a trusted community package that is close to what I want, fork or adapt it (community_fork, or point me at one-click install on /onboarding or the listing detail), and only create a new package if nothing suitable exists.',
-	].join(' ')
-}
-
-/**
- * Discovery prompt for people who have not connected (or signed up) yet. It
- * only assumes the agent can fetch a URL: the interview steering lives in
- * the `what-is-kody` guide itself (as embedded notes for agents), so the
- * prompt stays short enough to read before pasting. The parenthetical
- * identifies this deployment (heykody.app in production).
- */
-export function buildDiscoveryPrompt(input: {
-	env: Pick<OnboardingEnv, 'APP_BASE_URL'>
-	requestUrl: string | URL
-}) {
-	const origin = getAppBaseUrl({
-		env: input.env,
-		requestUrl: input.requestUrl,
-	})
-	return [
-		`I'm deciding whether Kody (${origin}) would be useful for me.`,
-		`Read ${origin}/guides/what-is-kody and then interview me to find out what Kody could do for me.`,
-		"Don't set anything up yet — this works before I have an account.",
-	].join(' ')
-}
-
-/**
- * The whole first win in one paste: the agent owns the loop (send the welcome
- * email, hand off to the person's own inbox, look the reply up when they say
- * so, save memories), and the steering for each part lives in the `first-win`
- * guide as embedded notes for agents rather than in the prompt.
- *
- * Address the connected Kody server rather than "Hey Kody" — some hosts treat
- * that as impersonation / prompt injection and skip MCP tools. The no-polling
- * sentence stays in the prompt too, because an agent that busy-waits for the
- * reply is the failure people notice first.
- */
-export function buildFirstWinPrompt(input: {
-	env: Pick<OnboardingEnv, 'APP_BASE_URL'>
-	requestUrl: string | URL
-}) {
-	const origin = getAppBaseUrl({
-		env: input.env,
-		requestUrl: input.requestUrl,
-	})
-	return [
-		`Ask the connected Kody server to read ${origin}/guides/first-win and then walk me through my first win with Kody, one step at a time.`,
-		'Start by sending the welcome email, then tell me exactly what to do in my own inbox.',
-		"Do not poll or wait for my reply — I'll come back to this chat and tell you when I have replied.",
-	].join(' ')
 }
 
 /**

--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -45,6 +45,8 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 		`CREATE TABLE IF NOT EXISTS saved_package_search_index_debt (
 			package_id TEXT PRIMARY KEY NOT NULL,
 			user_id TEXT NOT NULL,
+			generation INTEGER NOT NULL DEFAULT 0,
+			embed_text TEXT NOT NULL,
 			last_error TEXT,
 			created_at TEXT NOT NULL,
 			updated_at TEXT NOT NULL

--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -42,6 +42,15 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 			ON saved_packages(user_id, name)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_packages_source_id
 			ON saved_packages(source_id)`,
+		`CREATE TABLE IF NOT EXISTS saved_package_search_index_debt (
+			package_id TEXT PRIMARY KEY NOT NULL,
+			user_id TEXT NOT NULL,
+			last_error TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_saved_package_search_index_debt_user_id
+			ON saved_package_search_index_debt(user_id)`,
 		`CREATE TABLE IF NOT EXISTS entity_sources (
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL,

--- a/packages/worker/src/community/install.node.test.ts
+++ b/packages/worker/src/community/install.node.test.ts
@@ -109,6 +109,18 @@ test('install publishes clean forks, keeps failed checks inert, and propagates e
 		waitUntil: undefined,
 	})
 
+	const waitUntil = vi.fn()
+	mockModule.forkCommunityListing.mockResolvedValue(forkResult())
+	mockModule.runRepoChecks.mockResolvedValue({
+		ok: true,
+		results: [{ kind: 'manifest', ok: true, message: 'ok' }],
+	})
+	mockModule.refreshSavedPackageProjection.mockClear()
+	await installCommunityListing({ ...installInput(), waitUntil })
+	expect(mockModule.refreshSavedPackageProjection).toHaveBeenCalledWith(
+		expect.objectContaining({ waitUntil }),
+	)
+
 	mockModule.forkCommunityListing.mockResolvedValue({
 		...forkResult(),
 		crossScopeReferences: [{ file: 'src/index.ts', specifier: 'kody:@usera/' }],

--- a/packages/worker/src/community/install.node.test.ts
+++ b/packages/worker/src/community/install.node.test.ts
@@ -106,6 +106,7 @@ test('install publishes clean forks, keeps failed checks inert, and propagates e
 		userEmail: 'userb@example.com',
 		packageId: 'package-1',
 		sourceId: 'source-1',
+		waitUntil: undefined,
 	})
 
 	mockModule.forkCommunityListing.mockResolvedValue({

--- a/packages/worker/src/community/install.ts
+++ b/packages/worker/src/community/install.ts
@@ -4,6 +4,24 @@ import { normalizeRepoWorkspacePath } from '#worker/repo/manifest.ts'
 import { forkCommunityListing } from './service.ts'
 import { type CommunityForkActor, type CrossScopeReference } from './types.ts'
 
+type InstallProgressUpdate = {
+	progress: number
+	total?: number
+	message?: string
+}
+
+type ReportInstallProgress = (
+	update: InstallProgressUpdate,
+) => void | Promise<void>
+
+async function reportInstallProgress(
+	reportProgress: ReportInstallProgress | null | undefined,
+	update: InstallProgressUpdate,
+) {
+	if (!reportProgress) return
+	await reportProgress(update)
+}
+
 type InstallForkSummary = {
 	forkId: string
 	packageId: string
@@ -66,7 +84,14 @@ export async function installCommunityListing(input: {
 	 * The MCP capability passes `agent` when it drives an install itself.
 	 */
 	actor?: CommunityForkActor | null
+	waitUntil?: (promise: Promise<unknown>) => void
+	reportProgress?: ReportInstallProgress
 }): Promise<InstallCommunityListingResult> {
+	await reportInstallProgress(input.reportProgress, {
+		progress: 1,
+		total: 4,
+		message: 'Forking the listing into your account — source sync inbound…',
+	})
 	const fork = await forkCommunityListing({
 		env: input.env,
 		baseUrl: input.baseUrl,
@@ -90,6 +115,12 @@ export async function installCommunityListing(input: {
 	// reads the owner package's source root), and forked entity sources are
 	// created with the default manifest path and root — see ensureEntitySource
 	// in forkCommunityListing.
+	await reportInstallProgress(input.reportProgress, {
+		progress: 2,
+		total: 4,
+		message:
+			'Typechecking and bundling npm deps — the same gates a publish would run…',
+	})
 	const checks = await runRepoChecks({
 		workspace: createSnapshotFilesWorkspace(fork.files),
 		manifestPath: 'package.json',
@@ -100,6 +131,12 @@ export async function installCommunityListing(input: {
 		expectedPackageScope: input.expectedPackageScope,
 	})
 	if (!checks.ok) {
+		await reportInstallProgress(input.reportProgress, {
+			progress: 4,
+			total: 4,
+			message:
+				'Checks need a human/agent touch — keeping the fork inert for adaptation.',
+		})
 		return {
 			...summary,
 			status: 'adaptation_required',
@@ -108,6 +145,11 @@ export async function installCommunityListing(input: {
 		}
 	}
 
+	await reportInstallProgress(input.reportProgress, {
+		progress: 3,
+		total: 4,
+		message: 'Publishing and indexing — almost ready to invoke…',
+	})
 	await refreshSavedPackageProjection({
 		env: input.env,
 		baseUrl: input.baseUrl,
@@ -115,6 +157,12 @@ export async function installCommunityListing(input: {
 		userEmail: input.userEmail,
 		packageId: fork.packageId,
 		sourceId: fork.sourceId,
+		waitUntil: input.waitUntil,
+	})
+	await reportInstallProgress(input.reportProgress, {
+		progress: 4,
+		total: 4,
+		message: 'Installed. Your new package is live.',
 	})
 	return {
 		...summary,

--- a/packages/worker/src/mcp/capabilities/community/fork.ts
+++ b/packages/worker/src/mcp/capabilities/community/fork.ts
@@ -9,6 +9,7 @@ import {
 	communityForkNextSteps,
 	crossScopeReferenceSchema,
 } from './shared.ts'
+import { reportCapabilityProgress } from '#mcp/progress.ts'
 
 export const communityForkCapability = defineDomainCapability(
 	capabilityDomainNames.community,
@@ -48,6 +49,12 @@ export const communityForkCapability = defineDomainCapability(
 				ctx.env.APP_DB,
 				user,
 			)
+			await reportCapabilityProgress(ctx.reportProgress, {
+				progress: 1,
+				total: 2,
+				message:
+					'Forking the community listing into your scope — photocopy whirring…',
+			})
 			const result = await forkCommunityListing({
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
@@ -56,6 +63,12 @@ export const communityForkCapability = defineDomainCapability(
 				listingId: args.listing_id,
 				kodyId: args.kody_id,
 				actor: 'agent',
+			})
+			await reportCapabilityProgress(ctx.reportProgress, {
+				progress: 2,
+				total: 2,
+				message:
+					'Fork ready as an inert source — review, then publish when it looks good.',
 			})
 			return {
 				fork_id: result.forkId,

--- a/packages/worker/src/mcp/capabilities/meta/execute.ts
+++ b/packages/worker/src/mcp/capabilities/meta/execute.ts
@@ -276,6 +276,8 @@ export const executeCapability = defineDomainCapability(
 								}
 							: undefined,
 						runRecordHandle: claimedRunHandle,
+						waitUntil: ctx.waitUntil,
+						reportProgress: ctx.reportProgress,
 						runRecord: {
 							surface: 'execute',
 							name: null,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -38,6 +38,10 @@ import {
 import { loadPublishedEntitySource } from '#worker/repo/published-source.ts'
 import { pendingPackageSecretApprovalsSchema } from './shared.ts'
 import { resolveOwnedPackageSource } from './resolve-package-source.ts'
+import {
+	reportCapabilityProgress,
+	type McpReportProgress,
+} from '#mcp/progress.ts'
 
 const inputSchema = z.object({
 	package_id: z.string().min(1).optional(),
@@ -489,6 +493,7 @@ async function runExternalPublishAttempt(input: {
 	allowForce: boolean
 	destructiveOverwriteConfirmed: boolean
 	signal?: AbortSignal
+	reportProgress?: McpReportProgress
 }): Promise<Exclude<PublishExternalPushResult, { status: 'dispatched' }>> {
 	const maxAttempts = externalPublishRetryDelaysMs.length + 1
 	let lastTransientError: unknown = null
@@ -500,6 +505,14 @@ async function runExternalPublishAttempt(input: {
 				? `external-publish-${input.source.id}`
 				: `external-publish-${input.source.id}-retry-${attempt}`
 		try {
+			await reportCapabilityProgress(input.reportProgress, {
+				progress: attempt,
+				total: maxAttempts + 1,
+				message:
+					attempt === 1
+						? 'Publishing from Artifacts HEAD — running checks and promoting the commit…'
+						: `Publish attempt ${attempt}/${maxAttempts} — giving the repo another nudge…`,
+			})
 			const result = await repoSessionRpc(
 				input.env,
 				sessionId,
@@ -522,6 +535,12 @@ async function runExternalPublishAttempt(input: {
 						`Package "${input.packageId}" is already published, but no published commit is available to rebuild artifacts.`,
 					)
 				}
+				await reportCapabilityProgress(input.reportProgress, {
+					progress: maxAttempts + 1,
+					total: maxAttempts + 1,
+					message:
+						'Already published — rebuilding artifacts so invoke stays fresh…',
+				})
 				await rebuildPublishedPackageArtifactsViaRepoSession({
 					env: input.env,
 					rpcSessionId: sessionId,
@@ -570,6 +589,12 @@ async function runExternalPublishAttempt(input: {
 			if (result.status !== 'published') {
 				return result
 			}
+			await reportCapabilityProgress(input.reportProgress, {
+				progress: maxAttempts + 1,
+				total: maxAttempts + 1,
+				message:
+					'Checks passed — rebuilding published artifacts and indexing dependents…',
+			})
 			await rebuildPublishedPackageArtifactsViaRepoSession({
 				env: input.env,
 				rpcSessionId: sessionId,
@@ -698,6 +723,7 @@ export const publishExternalPushCapability = defineDomainCapability(
 				newCommit,
 				allowForce: args.allow_force,
 				destructiveOverwriteConfirmed: args.confirm_destructive_overwrite,
+				reportProgress: ctx.reportProgress,
 			}
 
 			if (!shouldEscalateExternalPublish(ctx.callerContext.executionOrigin)) {

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -34,9 +34,8 @@ import {
 	packageScopeInputDescription,
 	resolvePackageOwnerContext,
 } from '#worker/package-registry/package-owner.ts'
-import { buildSavedPackageEmbedText } from '#worker/package-registry/embed.ts'
-import { upsertSavedPackageVector } from '#worker/package-registry/vectorize.ts'
 import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
+import { reportCapabilityProgress } from '#mcp/progress.ts'
 import { assertWithinEntitlement } from '#worker/entitlements/service.ts'
 import {
 	buildPendingPackageSecretApprovalsSummary,
@@ -280,6 +279,11 @@ export const savePackageCapability = defineDomainCapability(
 					throw error
 				}
 			}
+			await reportCapabilityProgress(ctx.reportProgress, {
+				progress: 1,
+				total: 4,
+				message: 'Syncing your package source — filing bits into the vault…',
+			})
 			await syncArtifactSourceSnapshot({
 				env: ctx.env,
 				userId: owner.ownerUserId,
@@ -308,20 +312,27 @@ export const savePackageCapability = defineDomainCapability(
 					created_at: now,
 					updated_at: now,
 				})
-				await upsertSavedPackageVector(ctx.env, {
-					packageId,
-					userId: owner.ownerUserId,
-					embedText: buildSavedPackageEmbedText(manifest),
-				})
 			}
+			await reportCapabilityProgress(ctx.reportProgress, {
+				progress: 2,
+				total: 4,
+				message:
+					'Publishing the saved-package projection — jobs, artifacts, and a tidy D1 row…',
+			})
 			const refreshed = await refreshSavedPackageProjection({
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
 				userId: owner.ownerUserId,
 				packageId,
 				sourceId: ensuredSource.id,
+				waitUntil: ctx.waitUntil,
 			})
 			const saved = refreshed.record
+			await reportCapabilityProgress(ctx.reportProgress, {
+				progress: 3,
+				total: 4,
+				message: 'Checking pending secret approvals — no spoilers, just gates…',
+			})
 			const pendingSecretApprovals =
 				await buildPendingPackageSecretApprovalsSummary({
 					env: ctx.env,
@@ -338,6 +349,11 @@ export const savePackageCapability = defineDomainCapability(
 						storageId: null,
 					},
 				})
+			await reportCapabilityProgress(ctx.reportProgress, {
+				progress: 4,
+				total: 4,
+				message: 'Package save complete — ready when you are.',
+			})
 			return {
 				package_id: saved.id,
 				kody_id: saved.kodyId,

--- a/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
@@ -34,9 +34,11 @@ export const repoPublishSessionCapability = defineDomainCapability(
 				sessionId: args.session_id,
 				userId: user.userId,
 			})
+			const isPackageSession = sessionInfo.entity_type === 'package'
+			const progressTotal = isPackageSession ? 3 : 2
 			await reportCapabilityProgress(ctx.reportProgress, {
 				progress: 1,
-				total: 3,
+				total: progressTotal,
 				message:
 					'Running publish checks on the session tree — lint, typecheck, the works…',
 			})
@@ -52,10 +54,10 @@ export const repoPublishSessionCapability = defineDomainCapability(
 					args.confirm_private_visibility_change,
 			})
 			if (result.status === 'ok') {
-				if (sessionInfo.entity_type === 'package') {
+				if (isPackageSession) {
 					await reportCapabilityProgress(ctx.reportProgress, {
 						progress: 2,
-						total: 3,
+						total: progressTotal,
 						message:
 							'Rebuilding published package artifacts — bundling for the big leagues…',
 					})
@@ -70,7 +72,7 @@ export const repoPublishSessionCapability = defineDomainCapability(
 					})
 					await reportCapabilityProgress(ctx.reportProgress, {
 						progress: 3,
-						total: 3,
+						total: progressTotal,
 						message: 'Repo session published. Ship it.',
 					})
 					return {
@@ -94,6 +96,11 @@ export const repoPublishSessionCapability = defineDomainCapability(
 				const shapedFields = buildPlainRepoPackageShapedFields({
 					packageShaped,
 				})
+				await reportCapabilityProgress(ctx.reportProgress, {
+					progress: progressTotal,
+					total: progressTotal,
+					message: 'Repo session published. Ship it.',
+				})
 				return {
 					status: 'ok' as const,
 					session_id: result.sessionId,
@@ -103,6 +110,12 @@ export const repoPublishSessionCapability = defineDomainCapability(
 				}
 			}
 			if (result.status === 'checks_outdated') {
+				await reportCapabilityProgress(ctx.reportProgress, {
+					progress: progressTotal,
+					total: progressTotal,
+					message:
+						'Publish checks are stale — refresh the session tree and try again.',
+				})
 				return {
 					status: 'checks_outdated' as const,
 					session_id: result.sessionId,
@@ -110,6 +123,12 @@ export const repoPublishSessionCapability = defineDomainCapability(
 					message: result.message,
 				}
 			}
+			await reportCapabilityProgress(ctx.reportProgress, {
+				progress: progressTotal,
+				total: progressTotal,
+				message:
+					'The published base moved out from under this session — rebase, then retry.',
+			})
 			return {
 				status: 'base_moved' as const,
 				session_id: result.sessionId,

--- a/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-publish-session.ts
@@ -13,6 +13,7 @@ import {
 	repoPublishSessionOutputSchema,
 } from './repo-shared.ts'
 import { rebuildPublishedPackageArtifactsViaRepoSession } from './package-artifact-rebuild.ts'
+import { reportCapabilityProgress } from '#mcp/progress.ts'
 
 export const repoPublishSessionCapability = defineDomainCapability(
 	capabilityDomainNames.repo,
@@ -33,6 +34,12 @@ export const repoPublishSessionCapability = defineDomainCapability(
 				sessionId: args.session_id,
 				userId: user.userId,
 			})
+			await reportCapabilityProgress(ctx.reportProgress, {
+				progress: 1,
+				total: 3,
+				message:
+					'Running publish checks on the session tree — lint, typecheck, the works…',
+			})
 			const result = await session.publishSession({
 				sessionId: args.session_id,
 				userId: user.userId,
@@ -46,6 +53,12 @@ export const repoPublishSessionCapability = defineDomainCapability(
 			})
 			if (result.status === 'ok') {
 				if (sessionInfo.entity_type === 'package') {
+					await reportCapabilityProgress(ctx.reportProgress, {
+						progress: 2,
+						total: 3,
+						message:
+							'Rebuilding published package artifacts — bundling for the big leagues…',
+					})
 					await rebuildPublishedPackageArtifactsViaRepoSession({
 						env: ctx.env,
 						rpcSessionId: args.session_id,
@@ -54,6 +67,11 @@ export const repoPublishSessionCapability = defineDomainCapability(
 						userId: user.userId,
 						publishedCommit: result.publishedCommit,
 						baseUrl: ctx.callerContext.baseUrl,
+					})
+					await reportCapabilityProgress(ctx.reportProgress, {
+						progress: 3,
+						total: 3,
+						message: 'Repo session published. Ship it.',
 					})
 					return {
 						status: 'ok' as const,

--- a/packages/worker/src/mcp/capabilities/types.ts
+++ b/packages/worker/src/mcp/capabilities/types.ts
@@ -4,12 +4,24 @@ import { type PermissionString, type RoleName } from '#universal/permissions.ts'
 import { type FeatureFlagKey } from '#universal/feature-flags/registry.ts'
 import { type CapabilityDomain } from './domain-metadata.ts'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { type McpReportProgress } from '#mcp/progress.ts'
 
 export const emptyCapabilityInputSchema = z.object({})
 
 export type CapabilityContext = {
 	env: Env
 	callerContext: McpCallerContext
+	/**
+	 * Best-effort MCP `notifications/progress` reporter when the client sent
+	 * `_meta.progressToken`. Absent for non-MCP callers and when the client
+	 * did not request progress.
+	 */
+	reportProgress?: McpReportProgress
+	/**
+	 * Prefer scheduling non-critical post-response work here (typically
+	 * `ctx.waitUntil`) so publish/install responses stay snappy.
+	 */
+	waitUntil?: (promise: Promise<unknown>) => void
 }
 
 export type CapabilityResult = unknown

--- a/packages/worker/src/mcp/mcp-registration-agent.ts
+++ b/packages/worker/src/mcp/mcp-registration-agent.ts
@@ -2,10 +2,12 @@ import { type McpServer as McpServerV1 } from '@modelcontextprotocol/sdk/server/
 import { type McpServer as McpServerV2 } from '@modelcontextprotocol/server'
 import {
 	type CallToolResult,
+	type GetPromptResult,
 	type ToolAnnotations,
 } from '@modelcontextprotocol/sdk/types.js'
 import { type z } from 'zod'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { type McpToolCallExtra } from './progress.ts'
 
 /**
  * Tool icon metadata (protocol revision 2025-11-25, SEP-973). Advertised by
@@ -28,31 +30,53 @@ export type McpToolConfig = {
 	icons?: Array<McpToolIcon>
 }
 
+export type McpPromptConfig = {
+	title?: string
+	description?: string
+	argsSchema?: Record<string, z.ZodType>
+}
+
 /**
- * The registration surface kody's tools use, satisfied by both MCP server
- * generations: `@modelcontextprotocol/sdk` v1 (`McpAgent` Durable Object
- * lane, 2025-era protocol revisions) and `@modelcontextprotocol/server` v2
- * (stateless lane, 2026-07-28). Both accept the raw-shape config form with
- * a callback returning content + structured content, so one registration
+ * The registration surface kody's tools and prompts use, satisfied by both
+ * MCP server generations: `@modelcontextprotocol/sdk` v1 (`McpAgent`
+ * Durable Object lane, 2025-era protocol revisions) and
+ * `@modelcontextprotocol/server` v2 (stateless lane, 2026-07-28). Both
+ * accept the raw-shape config form with a callback returning content +
+ * structured content (tools) or prompt messages, so one registration
  * definition backs both lanes and they can never drift apart.
  *
- * The callback parameter is typed `never` so any concrete argument type is
- * accepted; call sites annotate their args explicitly and the concrete
- * server validates inputs against `inputSchema` at runtime.
+ * Tool callbacks accept an optional second argument so handlers can read
+ * `_meta.progressToken` and emit `notifications/progress` (SDK v1
+ * `RequestHandlerExtra` / SDK v2 `ServerContext`). The args parameter is
+ * typed `never` so any concrete argument type is accepted; call sites
+ * annotate their args explicitly and the concrete server validates inputs
+ * against `inputSchema` at runtime.
  */
 export type McpToolServer = {
 	registerTool(
 		name: string,
 		config: McpToolConfig,
-		cb: (args: never) => CallToolResult | Promise<CallToolResult>,
+		cb: (
+			args: never,
+			extra?: McpToolCallExtra,
+		) => CallToolResult | Promise<CallToolResult>,
+	): unknown
+	registerPrompt(
+		name: string,
+		config: McpPromptConfig,
+		cb: (
+			args: never,
+			extra?: McpToolCallExtra,
+		) => GetPromptResult | Promise<GetPromptResult>,
 	): unknown
 }
 
 /**
  * Bridge one concrete server generation onto the shared registration
  * surface. Runtime-compatible by construction (both generations implement
- * the raw-shape `registerTool` form); the cast only bridges the two SDKs'
- * incompatible generic signatures, which TypeScript cannot relate directly.
+ * the raw-shape `registerTool` / `registerPrompt` forms); the cast only
+ * bridges the two SDKs' incompatible generic signatures, which TypeScript
+ * cannot relate directly.
  */
 export function asMcpToolServer(server: McpServerV1 | McpServerV2) {
 	return server as unknown as McpToolServer

--- a/packages/worker/src/mcp/progress.node.test.ts
+++ b/packages/worker/src/mcp/progress.node.test.ts
@@ -76,7 +76,7 @@ test('reportExecutePhaseProgress maps serverTiming phase names', async () => {
 	await reportExecutePhaseProgress(reportProgress, 'hydrate')
 	expect(reportProgress).toHaveBeenCalledWith({
 		progress: 2,
-		total: 5,
+		total: 4,
 		message: executeProgressPhaseMessages.hydrate,
 	})
 })

--- a/packages/worker/src/mcp/progress.node.test.ts
+++ b/packages/worker/src/mcp/progress.node.test.ts
@@ -1,0 +1,88 @@
+import { expect, test, vi } from 'vitest'
+import {
+	createProgressReporter,
+	executeProgressPhaseMessages,
+	reportCapabilityProgress,
+	reportExecutePhaseProgress,
+} from './progress.ts'
+
+test('createProgressReporter returns null without a progress token or sender', () => {
+	expect(createProgressReporter(undefined)).toBeNull()
+	expect(createProgressReporter({})).toBeNull()
+	expect(
+		createProgressReporter({
+			_meta: { progressToken: 'tok-1' },
+		}),
+	).toBeNull()
+	expect(
+		createProgressReporter({
+			sendNotification: vi.fn(),
+		}),
+	).toBeNull()
+})
+
+test('createProgressReporter uses SDK v1 sendNotification', async () => {
+	const sendNotification = vi.fn().mockResolvedValue(undefined)
+	const report = createProgressReporter({
+		_meta: { progressToken: 'tok-v1' },
+		sendNotification,
+	})
+	expect(report).not.toBeNull()
+	await report!({ progress: 2, total: 5, message: 'halfway' })
+	expect(sendNotification).toHaveBeenCalledWith({
+		method: 'notifications/progress',
+		params: {
+			progressToken: 'tok-v1',
+			progress: 2,
+			total: 5,
+			message: 'halfway',
+		},
+	})
+})
+
+test('createProgressReporter uses SDK v2 mcpReq.notify', async () => {
+	const notify = vi.fn().mockResolvedValue(undefined)
+	const report = createProgressReporter({
+		mcpReq: {
+			_meta: { progressToken: 42 },
+			notify,
+		},
+	})
+	expect(report).not.toBeNull()
+	await report!({ progress: 1, message: 'starting' })
+	expect(notify).toHaveBeenCalledWith({
+		method: 'notifications/progress',
+		params: {
+			progressToken: 42,
+			progress: 1,
+			message: 'starting',
+		},
+	})
+})
+
+test('createProgressReporter swallows notify failures', async () => {
+	const notify = vi.fn().mockRejectedValue(new Error('stream closed'))
+	const report = createProgressReporter({
+		mcpReq: {
+			_meta: { progressToken: 'tok' },
+			notify,
+		},
+	})
+	await expect(report!({ progress: 1 })).resolves.toBeUndefined()
+})
+
+test('reportExecutePhaseProgress maps serverTiming phase names', async () => {
+	const reportProgress = vi.fn().mockResolvedValue(undefined)
+	await reportExecutePhaseProgress(reportProgress, 'hydrate')
+	expect(reportProgress).toHaveBeenCalledWith({
+		progress: 2,
+		total: 5,
+		message: executeProgressPhaseMessages.hydrate,
+	})
+})
+
+test('reportCapabilityProgress no-ops when reporter is missing', async () => {
+	await expect(
+		reportCapabilityProgress(null, { progress: 1, message: 'nope' }),
+	).resolves.toBeUndefined()
+})

--- a/packages/worker/src/mcp/progress.ts
+++ b/packages/worker/src/mcp/progress.ts
@@ -1,0 +1,142 @@
+/**
+ * Dual-lane progress reporting for MCP tool handlers.
+ *
+ * Both SDK generations pass a second callback argument that can carry a
+ * client `progressToken` plus a way to send `notifications/progress`:
+ * - SDK v1 (`McpAgent` DO lane): `RequestHandlerExtra.sendNotification`
+ * - SDK v2 (stateless 2026 lane): `ServerContext.mcpReq.notify`
+ *
+ * Tools normalize that shape once here so execute / capabilities stay
+ * lane-agnostic and SDK-v2-migration-safe (issue #1191).
+ */
+
+export type McpProgressUpdate = {
+	progress: number
+	total?: number
+	message?: string
+}
+
+export type McpReportProgress = (update: McpProgressUpdate) => Promise<void>
+
+export type McpProgressToken = string | number
+
+type McpProgressNotification = {
+	method: 'notifications/progress'
+	params: {
+		progressToken: McpProgressToken
+		progress: number
+		total?: number
+		message?: string
+	}
+}
+
+/**
+ * Minimal dual-lane tool-call context. Call sites pass whatever the concrete
+ * SDK handed them; unknown / missing fields simply disable progress.
+ */
+export type McpToolCallExtra = {
+	_meta?: {
+		progressToken?: McpProgressToken
+		[key: string]: unknown
+	}
+	sendNotification?: (notification: McpProgressNotification) => Promise<void>
+	mcpReq?: {
+		_meta?: {
+			progressToken?: McpProgressToken
+			[key: string]: unknown
+		}
+		notify?: (notification: McpProgressNotification) => Promise<void>
+	}
+}
+
+function resolveProgressToken(
+	extra: McpToolCallExtra | null | undefined,
+): McpProgressToken | null {
+	const token =
+		extra?._meta?.progressToken ?? extra?.mcpReq?._meta?.progressToken
+	if (token === undefined || token === null) return null
+	return token
+}
+
+function resolveProgressSender(
+	extra: McpToolCallExtra | null | undefined,
+): ((notification: McpProgressNotification) => Promise<void>) | null {
+	if (typeof extra?.sendNotification === 'function') {
+		return extra.sendNotification.bind(extra)
+	}
+	if (typeof extra?.mcpReq?.notify === 'function') {
+		return extra.mcpReq.notify.bind(extra.mcpReq)
+	}
+	return null
+}
+
+/**
+ * Build a best-effort progress reporter. Returns `null` when the client did
+ * not send a progress token or the transport cannot notify. Failed notifies
+ * are swallowed so a disconnected SSE stream never fails the tool call.
+ */
+export function createProgressReporter(
+	extra: McpToolCallExtra | null | undefined,
+): McpReportProgress | null {
+	const progressToken = resolveProgressToken(extra)
+	const send = resolveProgressSender(extra)
+	if (progressToken === null || send === null) return null
+
+	return async (update) => {
+		try {
+			await send({
+				method: 'notifications/progress',
+				params: {
+					progressToken,
+					progress: update.progress,
+					...(update.total === undefined ? {} : { total: update.total }),
+					...(update.message === undefined ? {} : { message: update.message }),
+				},
+			})
+		} catch {
+			// Client may have dropped the stream; keep the tool running.
+		}
+	}
+}
+
+/** Human-friendly (slightly playful) labels for execute `serverTiming` phases. */
+export const executeProgressPhaseMessages = {
+	bundle: 'Tying the execute bundle with a tidy little bow…',
+	hydrate: 'Hydrating modules — pouring a shot of runtime espresso…',
+	'provider-assembly':
+		'Laying out the toolbox so capabilities are within reach…',
+	sandbox: 'Stepping into the sandbox — shoes off, code on…',
+	run: 'Running your module — fingers crossed, coffee nearby…',
+} as const
+
+export type ExecuteProgressPhase = keyof typeof executeProgressPhaseMessages
+
+const executeProgressPhaseOrder = [
+	'bundle',
+	'hydrate',
+	'provider-assembly',
+	'sandbox',
+	'run',
+] as const satisfies ReadonlyArray<ExecuteProgressPhase>
+
+export async function reportExecutePhaseProgress(
+	reportProgress: McpReportProgress | null | undefined,
+	phase: ExecuteProgressPhase,
+) {
+	if (!reportProgress) return
+	const index = executeProgressPhaseOrder.indexOf(phase)
+	await reportProgress({
+		progress: index < 0 ? 0 : index + 1,
+		total: executeProgressPhaseOrder.length,
+		message: executeProgressPhaseMessages[phase],
+	})
+}
+
+/** No-op helper so call sites can always `await reportProgress?.(…)` safely. */
+export async function reportCapabilityProgress(
+	reportProgress: McpReportProgress | null | undefined,
+	update: McpProgressUpdate,
+) {
+	if (!reportProgress) return
+	await reportProgress(update)
+}

--- a/packages/worker/src/mcp/progress.ts
+++ b/packages/worker/src/mcp/progress.ts
@@ -106,17 +106,16 @@ export const executeProgressPhaseMessages = {
 	'provider-assembly':
 		'Laying out the toolbox so capabilities are within reach…',
 	sandbox: 'Stepping into the sandbox — shoes off, code on…',
-	run: 'Running your module — fingers crossed, coffee nearby…',
 } as const
 
 export type ExecuteProgressPhase = keyof typeof executeProgressPhaseMessages
 
+/** Client progress order must match emission order (never move backward). */
 const executeProgressPhaseOrder = [
 	'bundle',
 	'hydrate',
 	'provider-assembly',
 	'sandbox',
-	'run',
 ] as const satisfies ReadonlyArray<ExecuteProgressPhase>
 
 export async function reportExecutePhaseProgress(

--- a/packages/worker/src/mcp/register-prompts.node.test.ts
+++ b/packages/worker/src/mcp/register-prompts.node.test.ts
@@ -1,0 +1,62 @@
+import { expect, test, vi } from 'vitest'
+import { registerPrompts } from './register-prompts.ts'
+import {
+	buildDiscoveryPrompt,
+	buildFirstWinPrompt,
+	buildOnboardingSetupPrompt,
+} from '#worker/onboarding-prompts.ts'
+
+test('registerPrompts advertises the templated onboarding prompts', async () => {
+	const registerPrompt = vi.fn()
+	const agent = {
+		server: { registerPrompt },
+		getEnv: () => ({ APP_BASE_URL: 'https://kody.test' }) as Env,
+		getCallerContext: () => ({
+			baseUrl: 'https://kody.test',
+			user: null,
+		}),
+		requireDomain: () => 'https://kody.test',
+		getLoopbackExports: () => ({}) as never,
+	}
+
+	await registerPrompts(agent as never)
+
+	expect(registerPrompt).toHaveBeenCalledTimes(3)
+	const names = registerPrompt.mock.calls.map((call) => call[0])
+	expect(names).toEqual([
+		'onboarding_setup',
+		'onboarding_discovery',
+		'onboarding_first_win',
+	])
+
+	const setupResult = await registerPrompt.mock.calls[0]![2]!()
+	expect(setupResult).toEqual({
+		description: 'Kody onboarding setup prompt',
+		messages: [
+			{
+				role: 'user',
+				content: {
+					type: 'text',
+					text: buildOnboardingSetupPrompt(),
+				},
+			},
+		],
+	})
+
+	const discoveryResult = await registerPrompt.mock.calls[1]![2]!()
+	expect(discoveryResult.messages[0]?.content).toEqual({
+		type: 'text',
+		text: buildDiscoveryPrompt({
+			env: { APP_BASE_URL: 'https://kody.test' },
+			requestUrl: 'https://kody.test',
+		}),
+	})
+
+	const firstWinResult = await registerPrompt.mock.calls[2]![2]!()
+	expect(firstWinResult.messages[0]?.content.text).toBe(
+		buildFirstWinPrompt({
+			env: { APP_BASE_URL: 'https://kody.test' },
+			requestUrl: 'https://kody.test',
+		}),
+	)
+})

--- a/packages/worker/src/mcp/register-prompts.ts
+++ b/packages/worker/src/mcp/register-prompts.ts
@@ -1,0 +1,80 @@
+import {
+	buildDiscoveryPrompt,
+	buildFirstWinPrompt,
+	buildOnboardingSetupPrompt,
+} from '#worker/onboarding-prompts.ts'
+import { type McpRegistrationAgent } from './mcp-registration-agent.ts'
+
+function textPromptResult(input: { description: string; text: string }) {
+	return {
+		description: input.description,
+		messages: [
+			{
+				role: 'user' as const,
+				content: {
+					type: 'text' as const,
+					text: input.text,
+				},
+			},
+		],
+	}
+}
+
+/**
+ * Register the templated onboarding prompts so MCP clients (Claude, etc.)
+ * can list/get them natively. Keep the tool surface compact — these are
+ * user-invoked prompts, not new tools.
+ */
+export async function registerPrompts(agent: McpRegistrationAgent) {
+	agent.server.registerPrompt(
+		'onboarding_setup',
+		{
+			title: 'Kody setup',
+			description:
+				'Get started with Kody: explain what it can do, connect one integration, verify with execute, then fork or create a package only if needed.',
+		},
+		() =>
+			textPromptResult({
+				description: 'Kody onboarding setup prompt',
+				text: buildOnboardingSetupPrompt(),
+			}),
+	)
+
+	agent.server.registerPrompt(
+		'onboarding_discovery',
+		{
+			title: 'Is Kody useful for me?',
+			description:
+				'Pre-account discovery interview. Asks the agent to read the what-is-kody guide and interview you — no setup yet.',
+		},
+		() => {
+			const requestUrl = agent.requireDomain()
+			return textPromptResult({
+				description: 'Kody discovery prompt',
+				text: buildDiscoveryPrompt({
+					env: agent.getEnv(),
+					requestUrl,
+				}),
+			})
+		},
+	)
+
+	agent.server.registerPrompt(
+		'onboarding_first_win',
+		{
+			title: 'First win',
+			description:
+				'Agent-driven first win: send the welcome email, wait for the person to reply from their inbox, then look it up and save memories. No polling.',
+		},
+		() => {
+			const requestUrl = agent.requireDomain()
+			return textPromptResult({
+				description: 'Kody first-win prompt',
+				text: buildFirstWinPrompt({
+					env: agent.getEnv(),
+					requestUrl,
+				}),
+			})
+		},
+	)
+}

--- a/packages/worker/src/mcp/register-tools.ts
+++ b/packages/worker/src/mcp/register-tools.ts
@@ -1,8 +1,10 @@
 import { type McpRegistrationAgent } from './mcp-registration-agent.ts'
+import { registerPrompts } from './register-prompts.ts'
 import { registerExecuteTool } from './tools/execute.ts'
 import { registerSearchTool } from './tools/search.ts'
 
 export async function registerTools(agent: McpRegistrationAgent) {
 	await registerSearchTool(agent)
 	await registerExecuteTool(agent)
+	await registerPrompts(agent)
 }

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -93,6 +93,10 @@ import {
 } from '#worker/mcp-client/status.ts'
 import { mcpServerKodyName } from '#worker/mcp-client/mcp-domain-id.ts'
 import { listEnabledMcpServerRefsCached } from '#worker/mcp-client/settings-service.ts'
+import {
+	reportExecutePhaseProgress,
+	type McpReportProgress,
+} from '#mcp/progress.ts'
 
 type ExecuteServerTimingEntry = {
 	name: string
@@ -246,6 +250,8 @@ async function buildKodyToolContext(
 		workflowTools?: PackageWorkflowTools
 		skipCapabilityRegistry?: boolean
 		capabilityRegistry?: BuiltCapabilityRegistry
+		reportProgress?: McpReportProgress
+		waitUntil?: (promise: Promise<unknown>) => void
 	},
 ): Promise<{
 	tools: AdditionalKodyTools
@@ -319,6 +325,10 @@ async function buildKodyToolContext(
 						{
 							env,
 							callerContext,
+							...(options?.reportProgress
+								? { reportProgress: options.reportProgress }
+								: {}),
+							...(options?.waitUntil ? { waitUntil: options.waitUntil } : {}),
 						},
 					)
 				} finally {
@@ -585,6 +595,8 @@ export async function buildKodyProvider(
 		workflowTools?: PackageWorkflowTools
 		skipCapabilityRegistry?: boolean
 		capabilityRegistry?: BuiltCapabilityRegistry
+		reportProgress?: McpReportProgress
+		waitUntil?: (promise: Promise<unknown>) => void
 	},
 ): Promise<ResolvedProvider> {
 	const { tools, remoteConnectors, mcpServers, openApiProviders } =
@@ -691,6 +703,11 @@ export async function runModuleWithRegistry(
 		 * `running`.
 		 */
 		waitUntil?: (promise: Promise<unknown>) => void
+		/**
+		 * Optional MCP progress reporter (from `_meta.progressToken`). Emits
+		 * human-friendly phase messages aligned with `serverTiming` names.
+		 */
+		reportProgress?: McpReportProgress
 	},
 ): Promise<
 	ExecuteResult & {
@@ -700,6 +717,8 @@ export async function runModuleWithRegistry(
 > {
 	const userId = callerContext.user?.userId ?? ''
 	const serverTiming: Array<{ name: string; durationMs: number }> = []
+	const reportProgress = options?.reportProgress
+	await reportExecutePhaseProgress(reportProgress, 'bundle')
 	const bundleStartedAtMs = Date.now()
 	const bundled = await buildKodyModuleBundle({
 		env,
@@ -727,6 +746,7 @@ export async function runModuleWithRegistry(
 			})
 		}
 	}
+	await reportExecutePhaseProgress(reportProgress, 'run')
 	const runStartedAtMs = Date.now()
 	const result = await runBundledModuleWithRegistry(
 		env,
@@ -750,6 +770,8 @@ export async function runModuleWithRegistry(
 			packageInvokeTools: options?.packageInvokeTools,
 			packageEventTools: options?.packageEventTools,
 			conversationId: options?.conversationId ?? null,
+			reportProgress,
+			waitUntil: options?.waitUntil,
 		},
 	)
 	// The bundled run reports its own sub-phases (hydrate, provider-assembly,
@@ -839,6 +861,7 @@ export async function runBundledModuleWithRegistry(
 		 * itself is always awaited.
 		 */
 		waitUntil?: (promise: Promise<unknown>) => void
+		reportProgress?: McpReportProgress
 	},
 ): Promise<
 	ExecuteResult & {
@@ -848,6 +871,7 @@ export async function runBundledModuleWithRegistry(
 > {
 	const runServerTiming: Array<ExecuteServerTimingEntry> = []
 	const secretRedactor = createExecutionSecretRedactor()
+	const reportProgress = options?.reportProgress
 	const normalizedStorageContext = normalizeStorageContext(
 		callerContext.storageContext ?? null,
 	)
@@ -924,6 +948,7 @@ export async function runBundledModuleWithRegistry(
 		// Hydration can install additional published-package sources (literal
 		// dynamic `import("kody:@...")` targets); keep a reference so error
 		// rewriting below scans the same module graph the sandbox executed.
+		await reportExecutePhaseProgress(reportProgress, 'hydrate')
 		const hydrateStartedAtMs = Date.now()
 		const { modules: hydratedModules, dynamicDependencyPackageIds } =
 			await hydrateKodyRuntimeModules({
@@ -949,6 +974,7 @@ export async function runBundledModuleWithRegistry(
 				conversationId: agentConversationId,
 			})
 		}
+		await reportExecutePhaseProgress(reportProgress, 'provider-assembly')
 		const providerAssemblyStartedAtMs = Date.now()
 		const grantedPackageStorageIds = collectPackageStorageGrantIds({
 			packageContext: options?.packageContext ?? null,
@@ -1022,6 +1048,8 @@ export async function runBundledModuleWithRegistry(
 			workflowTools,
 			skipCapabilityRegistry: options?.skipCapabilityRegistry,
 			capabilityRegistry: options?.capabilityRegistry,
+			reportProgress,
+			waitUntil: options?.waitUntil,
 		})
 		runServerTiming.push({
 			name: 'provider-assembly',
@@ -1105,6 +1133,7 @@ ${runtimeHelperRuntimePropertySource}
 				provider,
 				...createRuntimeHelperExtraProviders(runtimeHelperContext),
 			]
+			await reportExecutePhaseProgress(reportProgress, 'sandbox')
 			const sandboxStartedAtMs = Date.now()
 			const result = await executor.execute(wrapped, providers)
 			runServerTiming.push({

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -746,7 +746,6 @@ export async function runModuleWithRegistry(
 			})
 		}
 	}
-	await reportExecutePhaseProgress(reportProgress, 'run')
 	const runStartedAtMs = Date.now()
 	const result = await runBundledModuleWithRegistry(
 		env,
@@ -774,8 +773,9 @@ export async function runModuleWithRegistry(
 			waitUntil: options?.waitUntil,
 		},
 	)
-	// The bundled run reports its own sub-phases (hydrate, provider-assembly,
-	// sandbox); `run` is their enclosing wall-clock span.
+	// Sub-phases (hydrate → provider-assembly → sandbox) report inside the
+	// bundled run so progress stays monotonic. `run` is only the enclosing
+	// serverTiming wall-clock span, not a client progress step.
 	serverTiming.push(...(result.serverTiming ?? []), {
 		name: 'run',
 		durationMs: Date.now() - runStartedAtMs,

--- a/packages/worker/src/mcp/stateless-lane.mcp-e2e.test.ts
+++ b/packages/worker/src/mcp/stateless-lane.mcp-e2e.test.ts
@@ -4,6 +4,7 @@ import {
 	createTestDatabase,
 	startDevServer,
 } from '../../../../tools/mcp-test-support.ts'
+import { executeProgressPhaseMessages } from './progress.ts'
 
 /**
  * One smoke journey for the stateless 2026-07-28 lane: a real SDK v2 client
@@ -36,4 +37,56 @@ test('pinned 2026-07-28 client negotiates the stateless lane and calls search', 
 	expect(searchResult.structuredContent).toMatchObject({
 		conversationId: expect.any(String),
 	})
+})
+
+test('stateless lane lists onboarding prompts and emits execute progress', async () => {
+	await using database = await createTestDatabase()
+	await using server = await startDevServer(database.persistDir)
+	await using modern = await createModernMcpClient(
+		server.origin,
+		database.user,
+		{ persistDir: database.persistDir },
+	)
+
+	const prompts = await modern.client.listPrompts()
+	const promptNames = prompts.prompts.map((prompt) => prompt.name).sort()
+	expect(promptNames).toEqual([
+		'onboarding_discovery',
+		'onboarding_first_win',
+		'onboarding_setup',
+	])
+
+	const setupPrompt = await modern.client.getPrompt({
+		name: 'onboarding_setup',
+	})
+	expect(setupPrompt.messages[0]?.content).toMatchObject({
+		type: 'text',
+		text: expect.stringContaining('Help me get started with Kody.'),
+	})
+
+	const progressMessages: Array<string> = []
+	const executeResult = await modern.client.callTool(
+		{
+			name: 'execute',
+			arguments: {
+				code: `export default async function main() { return { ok: true } }`,
+			},
+		},
+		{
+			onprogress: (progress) => {
+				if (typeof progress.message === 'string') {
+					progressMessages.push(progress.message)
+				}
+			},
+		},
+	)
+	expect(executeResult.isError ?? false).toBe(false)
+	expect(progressMessages.length).toBeGreaterThan(0)
+	expect(progressMessages).toContain(executeProgressPhaseMessages.bundle)
+	expect(progressMessages).toEqual(
+		expect.arrayContaining([
+			executeProgressPhaseMessages.hydrate,
+			executeProgressPhaseMessages.sandbox,
+		]),
+	)
 })

--- a/packages/worker/src/mcp/tools/execute.node.test.ts
+++ b/packages/worker/src/mcp/tools/execute.node.test.ts
@@ -910,3 +910,55 @@ test('execute tool claims a keyed run, passes the handle, and returns runId', as
 		result: { spawned: true },
 	})
 })
+
+test('execute tool threads a progress reporter when the client sends progressToken', async () => {
+	const [, , handler] = await getExecuteRegistration()
+	mockModule.runModuleWithRegistry.mockResolvedValueOnce({
+		result: { ok: true },
+		logs: [],
+	})
+	const notify = vi.fn().mockResolvedValue(undefined)
+	await (
+		handler as (
+			input: { code: string },
+			extra?: {
+				mcpReq?: {
+					_meta?: { progressToken?: string }
+					notify?: (notification: unknown) => Promise<void>
+				}
+			},
+		) => Promise<unknown>
+	)(
+		{ code: 'export default async () => ({ ok: true })' },
+		{
+			mcpReq: {
+				_meta: { progressToken: 'progress-1' },
+				notify,
+			},
+		},
+	)
+	expect(mockModule.runModuleWithRegistry).toHaveBeenLastCalledWith(
+		expect.anything(),
+		expect.anything(),
+		'export default async () => ({ ok: true })',
+		undefined,
+		expect.objectContaining({
+			reportProgress: expect.any(Function),
+		}),
+	)
+	const options = mockModule.runModuleWithRegistry.mock.calls.at(-1)?.[4] as {
+		reportProgress?: (update: {
+			progress: number
+			message?: string
+		}) => Promise<void>
+	}
+	await options.reportProgress?.({ progress: 1, message: 'bundle time' })
+	expect(notify).toHaveBeenCalledWith({
+		method: 'notifications/progress',
+		params: {
+			progressToken: 'progress-1',
+			progress: 1,
+			message: 'bundle time',
+		},
+	})
+})

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -22,6 +22,7 @@ import {
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
 import { runModuleWithRegistry } from '#mcp/run-kody-registry.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
+import { createProgressReporter, type McpToolCallExtra } from '#mcp/progress.ts'
 import {
 	callerContextFields,
 	errorFields,
@@ -217,31 +218,35 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 			},
 			annotations: executeTool.annotations,
 		},
-		async ({
-			code,
-			params,
-			storageId,
-			writable,
-			responseLimit,
-			conversationId,
-			memoryContext,
-			idempotencyKey,
-		}: {
-			code: string
-			params?: Record<string, unknown>
-			storageId?: string
-			writable?: boolean
-			responseLimit?: number
-			conversationId?: string
-			memoryContext?: z.infer<typeof memoryContextInputField>
-			idempotencyKey?: string
-		}) => {
+		async (
+			{
+				code,
+				params,
+				storageId,
+				writable,
+				responseLimit,
+				conversationId,
+				memoryContext,
+				idempotencyKey,
+			}: {
+				code: string
+				params?: Record<string, unknown>
+				storageId?: string
+				writable?: boolean
+				responseLimit?: number
+				conversationId?: string
+				memoryContext?: z.infer<typeof memoryContextInputField>
+				idempotencyKey?: string
+			},
+			toolExtra?: McpToolCallExtra,
+		) => {
 			const timingStart = startToolTiming()
 			const env = agent.getEnv()
 			// Hand terminal run-record writes and nested-invocation
 			// observability to the Durable Object's waitUntil so they stop
 			// serializing the execute response they observe.
 			const waitUntil = agent.waitUntil?.bind(agent)
+			const reportProgress = createProgressReporter(toolExtra)
 			const baseCallerContext = agent.getCallerContext()
 			const resolvedStorageId = storageId?.trim() || null
 			const callerContext = {
@@ -439,6 +444,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 									conversationId: resolvedConversationId,
 									runRecordHandle: claimedRunHandle,
 									waitUntil,
+									reportProgress: reportProgress ?? undefined,
 									runRecord: {
 										surface: 'execute',
 										name: null,
@@ -867,7 +873,7 @@ async function resolveRawFetchHostNudges(input: {
 	})
 	if (typeof statefulAgent.setState === 'function') {
 		statefulAgent.setState({
-			...(statefulAgent.state ?? {}),
+			...statefulAgent.state,
 			rawFetchHostNudges: applied.state,
 		})
 	}

--- a/packages/worker/src/onboarding-prompts.ts
+++ b/packages/worker/src/onboarding-prompts.ts
@@ -1,0 +1,79 @@
+import { getAppBaseUrl } from '#worker/app-base-url.ts'
+
+/**
+ * Templated onboarding prompts shared by the browser onboarding UI and MCP
+ * `prompts/list` + `prompts/get`. Lives in `#worker/*` so both the app layer
+ * and MCP registration can import it without crossing import boundaries.
+ */
+
+type OnboardingPromptEnv = {
+	APP_BASE_URL?: string | null
+}
+
+export function buildMcpServerUrl(input: {
+	env: OnboardingPromptEnv
+	requestUrl: string | URL
+}) {
+	return `${getAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})}/mcp`
+}
+
+export function buildOnboardingSetupPrompt() {
+	return [
+		'Help me get started with Kody.',
+		'First, briefly explain what Kody can do for me in plain language.',
+		'Then help me connect one integration I care about: check coding_guide_get for a matching provider guide (for example provider_github or provider_google) and follow it; otherwise use search and the official guides to find the right setup steps, walk me through the connect or secrets flow, and verify the connection with a small ad hoc execute smoke test.',
+		'Do not create any packages until the integration works — start with ad hoc execute calls.',
+		'Once the integration works, check community_search for a trusted community package that is close to what I want, fork or adapt it (community_fork, or point me at one-click install on /onboarding or the listing detail), and only create a new package if nothing suitable exists.',
+	].join(' ')
+}
+
+/**
+ * Discovery prompt for people who have not connected (or signed up) yet. It
+ * only assumes the agent can fetch a URL: the interview steering lives in
+ * the `what-is-kody` guide itself (as embedded notes for agents), so the
+ * prompt stays short enough to read before pasting. The parenthetical
+ * identifies this deployment (heykody.app in production).
+ */
+export function buildDiscoveryPrompt(input: {
+	env: OnboardingPromptEnv
+	requestUrl: string | URL
+}) {
+	const origin = getAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
+	return [
+		`I'm deciding whether Kody (${origin}) would be useful for me.`,
+		`Read ${origin}/guides/what-is-kody and then interview me to find out what Kody could do for me.`,
+		"Don't set anything up yet — this works before I have an account.",
+	].join(' ')
+}
+
+/**
+ * The whole first win in one paste: the agent owns the loop (send the welcome
+ * email, hand off to the person's own inbox, look the reply up when they say
+ * so, save memories), and the steering for each part lives in the `first-win`
+ * guide as embedded notes for agents rather than in the prompt.
+ *
+ * Address the connected Kody server rather than "Hey Kody" — some hosts treat
+ * that as impersonation / prompt injection and skip MCP tools. The no-polling
+ * sentence stays in the prompt too, because an agent that busy-waits for the
+ * reply is the failure people notice first.
+ */
+export function buildFirstWinPrompt(input: {
+	env: OnboardingPromptEnv
+	requestUrl: string | URL
+}) {
+	const origin = getAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
+	return [
+		`Ask the connected Kody server to read ${origin}/guides/first-win and then walk me through my first win with Kody, one step at a time.`,
+		'Start by sending the welcome email, then tell me exactly what to do in my own inbox.',
+		"Do not poll or wait for my reply — I'll come back to this chat and tell you when I have replied.",
+	].join(' ')
+}

--- a/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
@@ -14,6 +14,7 @@ const mockModule = vi.hoisted(() => ({
 	isCapabilitySearchOffline: vi.fn(),
 	listSavedPackagesPage: vi.fn(),
 	loadPublishedEntityManifest: vi.fn(),
+	clearSavedPackageSearchIndexDebt: vi.fn(),
 }))
 
 vi.mock('#worker/vectorize/embedding.ts', () => ({
@@ -47,6 +48,11 @@ vi.mock('./repo.ts', () => ({
 	savedPackageVectorId: (packageId: string) => `package_${packageId}`,
 }))
 
+vi.mock('./search-index-debt.ts', () => ({
+	clearSavedPackageSearchIndexDebt: (...args: Array<unknown>) =>
+		mockModule.clearSavedPackageSearchIndexDebt(...args),
+}))
+
 const { reindexSavedPackageVectors } = await import('./package-reindex.ts')
 
 const exportError = () => new Error(`D1_ERROR: ${d1LongRunningExportMessage}.`)
@@ -58,6 +64,8 @@ function resetMocks() {
 	mockModule.getEntitySourceById.mockReset()
 	mockModule.isCapabilitySearchOffline.mockReset()
 	mockModule.listSavedPackagesPage.mockReset()
+	mockModule.clearSavedPackageSearchIndexDebt.mockReset()
+	mockModule.clearSavedPackageSearchIndexDebt.mockResolvedValue(undefined)
 	mockModule.loadPublishedEntityManifest.mockReset()
 }
 

--- a/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
@@ -175,6 +175,7 @@ test('saved package reindex retries transient D1 export errors then reports exha
 					error: `D1_ERROR: ${d1LongRunningExportMessage}.`,
 				},
 			],
+			failedIds: ['package_pkg-1'],
 			error: '1 saved package vector(s) failed to reindex',
 		})
 		for (let attempt = 1; attempt < d1LockRetryMaxAttempts; attempt++) {

--- a/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
@@ -15,6 +15,7 @@ const mockModule = vi.hoisted(() => ({
 	listSavedPackagesPage: vi.fn(),
 	loadPublishedEntityManifest: vi.fn(),
 	clearSavedPackageSearchIndexDebt: vi.fn(),
+	getSavedPackageSearchIndexDebtGeneration: vi.fn(),
 }))
 
 vi.mock('#worker/vectorize/embedding.ts', () => ({
@@ -51,6 +52,8 @@ vi.mock('./repo.ts', () => ({
 vi.mock('./search-index-debt.ts', () => ({
 	clearSavedPackageSearchIndexDebt: (...args: Array<unknown>) =>
 		mockModule.clearSavedPackageSearchIndexDebt(...args),
+	getSavedPackageSearchIndexDebtGeneration: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageSearchIndexDebtGeneration(...args),
 }))
 
 const { reindexSavedPackageVectors } = await import('./package-reindex.ts')
@@ -66,6 +69,8 @@ function resetMocks() {
 	mockModule.listSavedPackagesPage.mockReset()
 	mockModule.clearSavedPackageSearchIndexDebt.mockReset()
 	mockModule.clearSavedPackageSearchIndexDebt.mockResolvedValue(undefined)
+	mockModule.getSavedPackageSearchIndexDebtGeneration.mockReset()
+	mockModule.getSavedPackageSearchIndexDebtGeneration.mockResolvedValue(null)
 	mockModule.loadPublishedEntityManifest.mockReset()
 }
 

--- a/packages/worker/src/package-registry/package-reindex.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex.node.test.ts
@@ -12,6 +12,7 @@ const mockModule = vi.hoisted(() => ({
 	isCapabilitySearchOffline: vi.fn(),
 	listSavedPackagesPage: vi.fn(),
 	loadPackageManifestBySourceId: vi.fn(),
+	clearSavedPackageSearchIndexDebt: vi.fn(),
 }))
 
 vi.mock('#worker/vectorize/embedding.ts', () => ({
@@ -39,6 +40,11 @@ vi.mock('./source.ts', () => ({
 		mockModule.loadPackageManifestBySourceId(...args),
 }))
 
+vi.mock('./search-index-debt.ts', () => ({
+	clearSavedPackageSearchIndexDebt: (...args: Array<unknown>) =>
+		mockModule.clearSavedPackageSearchIndexDebt(...args),
+}))
+
 const { reindexSavedPackageVectors } = await import('./package-reindex.ts')
 
 function resetMocks() {
@@ -48,6 +54,8 @@ function resetMocks() {
 	mockModule.isCapabilitySearchOffline.mockReset()
 	mockModule.listSavedPackagesPage.mockReset()
 	mockModule.loadPackageManifestBySourceId.mockReset()
+	mockModule.clearSavedPackageSearchIndexDebt.mockReset()
+	mockModule.clearSavedPackageSearchIndexDebt.mockResolvedValue(undefined)
 }
 
 function buildSavedPackage(id: string) {

--- a/packages/worker/src/package-registry/package-reindex.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex.node.test.ts
@@ -13,6 +13,7 @@ const mockModule = vi.hoisted(() => ({
 	listSavedPackagesPage: vi.fn(),
 	loadPackageManifestBySourceId: vi.fn(),
 	clearSavedPackageSearchIndexDebt: vi.fn(),
+	getSavedPackageSearchIndexDebtGeneration: vi.fn(),
 }))
 
 vi.mock('#worker/vectorize/embedding.ts', () => ({
@@ -43,6 +44,8 @@ vi.mock('./source.ts', () => ({
 vi.mock('./search-index-debt.ts', () => ({
 	clearSavedPackageSearchIndexDebt: (...args: Array<unknown>) =>
 		mockModule.clearSavedPackageSearchIndexDebt(...args),
+	getSavedPackageSearchIndexDebtGeneration: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageSearchIndexDebtGeneration(...args),
 }))
 
 const { reindexSavedPackageVectors } = await import('./package-reindex.ts')
@@ -56,6 +59,8 @@ function resetMocks() {
 	mockModule.loadPackageManifestBySourceId.mockReset()
 	mockModule.clearSavedPackageSearchIndexDebt.mockReset()
 	mockModule.clearSavedPackageSearchIndexDebt.mockResolvedValue(undefined)
+	mockModule.getSavedPackageSearchIndexDebtGeneration.mockReset()
+	mockModule.getSavedPackageSearchIndexDebtGeneration.mockResolvedValue(null)
 }
 
 function buildSavedPackage(id: string) {

--- a/packages/worker/src/package-registry/package-reindex.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex.node.test.ts
@@ -220,6 +220,7 @@ test('saved package reindex skips failed manifest loads and continues the batch'
 				error: 'manifest missing',
 			},
 		],
+		failedIds: ['package_pkg-bad'],
 		warning: '1 saved package vector(s) failed to reindex',
 	})
 
@@ -237,6 +238,33 @@ test('saved package reindex skips failed manifest loads and continues the batch'
 			},
 		},
 	])
+})
+
+test('saved package reindex keeps debt for failed vectors beyond the failure sample cap', async () => {
+	resetMocks()
+	consoleError.mockImplementation(() => {})
+	mockModule.getCapabilityVectorIndex.mockReturnValue({ upsert: vi.fn() })
+	mockModule.isCapabilitySearchOffline.mockReturnValue(false)
+	mockModule.loadPackageManifestBySourceId.mockResolvedValue({
+		manifest: { name: '@user/pkg' },
+	})
+	mockModule.buildSavedPackageEmbedText.mockReturnValue('manifest embed')
+	mockModule.embedTextsForVectorize.mockRejectedValue(new Error('ai down'))
+	const packages = Array.from({ length: 25 }, (_, index) =>
+		buildSavedPackage(`pkg-${String(index).padStart(2, '0')}`),
+	)
+	mockModule.listSavedPackagesPage.mockResolvedValue(packages)
+
+	await expect(
+		reindexSavedPackageVectors({ APP_DB: {} } as Env, {
+			baseUrl: 'https://kody.example.com',
+		}),
+	).resolves.toMatchObject({
+		upserted: 0,
+		failed: 25,
+	})
+
+	expect(mockModule.clearSavedPackageSearchIndexDebt).not.toHaveBeenCalled()
 })
 
 test('saved package reindex retries a transient D1 export error on page listing', async () => {

--- a/packages/worker/src/package-registry/package-reindex.ts
+++ b/packages/worker/src/package-registry/package-reindex.ts
@@ -84,6 +84,7 @@ export async function reindexSavedPackageVectors(
 				upserted: 0,
 				failed: loadFailures.length,
 				failures: loadFailures,
+				failedIds: loadFailures.map((failure) => failure.id),
 			})
 		}
 		if (candidates.length > 0) {
@@ -94,8 +95,10 @@ export async function reindexSavedPackageVectors(
 				candidates,
 			})
 			pageResults.push(pageResult)
+			// Prefer uncapped failedIds (failures is a capped sample for messages).
 			const failedIds = new Set(
-				(pageResult.failures ?? []).map((failure) => failure.id),
+				pageResult.failedIds ??
+					(pageResult.failures ?? []).map((failure) => failure.id),
 			)
 			// Self-heal deferred upsert debt: a successful reindex means search
 			// is current again, so drop the durable failure marker.

--- a/packages/worker/src/package-registry/package-reindex.ts
+++ b/packages/worker/src/package-registry/package-reindex.ts
@@ -14,6 +14,7 @@ import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { buildSavedPackageEmbedText } from './embed.ts'
 import { listSavedPackagesPage, savedPackageVectorId } from './repo.ts'
+import { clearSavedPackageSearchIndexDebt } from './search-index-debt.ts'
 import { loadPackageManifestBySourceId } from './source.ts'
 
 // Saved packages are reindexed in keyset-paged batches so memory stays
@@ -86,14 +87,27 @@ export async function reindexSavedPackageVectors(
 			})
 		}
 		if (candidates.length > 0) {
-			pageResults.push(
-				await reindexVectorCandidates({
-					env,
-					index,
-					kind: 'saved package',
-					candidates,
-				}),
+			const pageResult = await reindexVectorCandidates({
+				env,
+				index,
+				kind: 'saved package',
+				candidates,
+			})
+			pageResults.push(pageResult)
+			const failedIds = new Set(
+				(pageResult.failures ?? []).map((failure) => failure.id),
 			)
+			// Self-heal deferred upsert debt: a successful reindex means search
+			// is current again, so drop the durable failure marker.
+			for (const row of rows) {
+				const vectorId = savedPackageVectorId(row.id)
+				if (failedIds.has(vectorId)) continue
+				if (loadFailures.some((failure) => failure.id === vectorId)) continue
+				await clearSavedPackageSearchIndexDebt({
+					db: env.APP_DB,
+					packageId: row.id,
+				})
+			}
 		}
 		if (rows.length < reindexPageSize) break
 		afterId = rows[rows.length - 1]!.id

--- a/packages/worker/src/package-registry/package-reindex.ts
+++ b/packages/worker/src/package-registry/package-reindex.ts
@@ -14,7 +14,10 @@ import { runD1WithRetry } from '#worker/d1-retry.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { buildSavedPackageEmbedText } from './embed.ts'
 import { listSavedPackagesPage, savedPackageVectorId } from './repo.ts'
-import { clearSavedPackageSearchIndexDebt } from './search-index-debt.ts'
+import {
+	clearSavedPackageSearchIndexDebt,
+	getSavedPackageSearchIndexDebtGeneration,
+} from './search-index-debt.ts'
 import { loadPackageManifestBySourceId } from './source.ts'
 
 // Saved packages are reindexed in keyset-paged batches so memory stays
@@ -88,6 +91,18 @@ export async function reindexSavedPackageVectors(
 			})
 		}
 		if (candidates.length > 0) {
+			// Snapshot debt generations before upsert so a concurrent publish
+			// that bumps generation is not wiped by post-page cleanup.
+			const debtGenerations = new Map<string, number>()
+			for (const row of rows) {
+				const generation = await getSavedPackageSearchIndexDebtGeneration({
+					db: env.APP_DB,
+					packageId: row.id,
+				})
+				if (generation !== null) {
+					debtGenerations.set(row.id, generation)
+				}
+			}
 			const pageResult = await reindexVectorCandidates({
 				env,
 				index,
@@ -100,15 +115,17 @@ export async function reindexSavedPackageVectors(
 				pageResult.failedIds ??
 					(pageResult.failures ?? []).map((failure) => failure.id),
 			)
-			// Self-heal deferred upsert debt: a successful reindex means search
-			// is current again, so drop the durable failure marker.
+			// Self-heal deferred upsert debt observed before this page upsert.
 			for (const row of rows) {
 				const vectorId = savedPackageVectorId(row.id)
 				if (failedIds.has(vectorId)) continue
 				if (loadFailures.some((failure) => failure.id === vectorId)) continue
+				const generation = debtGenerations.get(row.id)
+				if (generation === undefined) continue
 				await clearSavedPackageSearchIndexDebt({
 					db: env.APP_DB,
 					packageId: row.id,
+					generation,
 				})
 			}
 		}

--- a/packages/worker/src/package-registry/search-index-debt.node.test.ts
+++ b/packages/worker/src/package-registry/search-index-debt.node.test.ts
@@ -22,11 +22,16 @@ import {
 	scheduleSavedPackageSearchIndexUpsert,
 } from './search-index-debt.ts'
 
+type DebtRow = {
+	packageId: string
+	userId: string
+	generation: number
+	embedText: string
+	lastError: string | null
+}
+
 function createDebtDb() {
-	const rows = new Map<
-		string,
-		{ packageId: string; userId: string; lastError: string | null }
-	>()
+	const rows = new Map<string, DebtRow>()
 	return {
 		rows,
 		db: {
@@ -39,18 +44,64 @@ function createDebtDb() {
 									sql.includes('INSERT INTO saved_package_search_index_debt')
 								) {
 									const packageId = String(values[0])
+									const existing = rows.get(packageId)
 									rows.set(packageId, {
 										packageId,
 										userId: String(values[1]),
-										lastError: values[2] == null ? null : String(values[2]),
+										generation: existing ? existing.generation + 1 : 1,
+										embedText: String(values[2]),
+										lastError: values[3] == null ? null : String(values[3]),
 									})
+								}
+								if (
+									sql.includes('UPDATE saved_package_search_index_debt') &&
+									sql.includes('last_error')
+								) {
+									const packageId = String(values[2])
+									const generation = Number(values[3])
+									const existing = rows.get(packageId)
+									if (existing && existing.generation === generation) {
+										rows.set(packageId, {
+											...existing,
+											lastError: String(values[0]),
+										})
+									}
 								}
 								if (
 									sql.includes('DELETE FROM saved_package_search_index_debt')
 								) {
-									rows.delete(String(values[0]))
+									const packageId = String(values[0])
+									if (sql.includes('AND generation')) {
+										const generation = Number(values[1])
+										const existing = rows.get(packageId)
+										if (existing?.generation === generation) {
+											rows.delete(packageId)
+										}
+									} else {
+										rows.delete(packageId)
+									}
 								}
 								return { success: true }
+							},
+							async first() {
+								if (sql.includes('SELECT generation FROM')) {
+									const packageId = String(values[0])
+									const existing = rows.get(packageId)
+									return existing ? { generation: existing.generation } : null
+								}
+								if (sql.includes('SELECT package_id, user_id, generation')) {
+									const packageId = String(values[0])
+									const existing = rows.get(packageId)
+									return existing
+										? {
+												package_id: existing.packageId,
+												user_id: existing.userId,
+												generation: existing.generation,
+												embed_text: existing.embedText,
+											}
+										: null
+								}
+								return null
 							},
 							async all() {
 								return { results: [...rows.values()] }
@@ -86,14 +137,16 @@ test('scheduleSavedPackageSearchIndexUpsert defers via waitUntil and clears debt
 	await schedulePromise
 	expect(rows.has('pkg-1')).toBe(true)
 	expect(waitUntilPromises).toHaveLength(1)
-	expect(mockModule.upsertSavedPackageVector).toHaveBeenCalledWith(
-		expect.anything(),
-		{
-			packageId: 'pkg-1',
-			userId: 'user-1',
-			embedText: 'hello',
-		},
-	)
+	await vi.waitFor(() => {
+		expect(mockModule.upsertSavedPackageVector).toHaveBeenCalledWith(
+			expect.anything(),
+			{
+				packageId: 'pkg-1',
+				userId: 'user-1',
+				embedText: 'hello',
+			},
+		)
+	})
 	resolveUpsert?.()
 	await waitUntilPromises[0]
 	expect(rows.has('pkg-1')).toBe(false)
@@ -116,20 +169,82 @@ test('scheduleSavedPackageSearchIndexUpsert keeps debt and reports to Sentry on 
 	expect(rows.get('pkg-2')).toMatchObject({
 		packageId: 'pkg-2',
 		userId: 'user-2',
+		generation: 1,
 		lastError: 'vectorize down',
 	})
 	expect(mockModule.captureException).toHaveBeenCalled()
 	expect(consoleError).toHaveBeenCalled()
 })
 
+test('out-of-order publishes keep the newest embed text and debt generation', async () => {
+	let resolveFirstUpsert: (() => void) | undefined
+	let upsertCalls = 0
+	mockModule.upsertSavedPackageVector.mockReset()
+	mockModule.upsertSavedPackageVector.mockImplementation(async () => {
+		upsertCalls += 1
+		if (upsertCalls === 1) {
+			await new Promise<void>((resolve) => {
+				resolveFirstUpsert = resolve
+			})
+		}
+	})
+	const { db, rows } = createDebtDb()
+	const waitUntilPromises: Array<Promise<unknown>> = []
+	const waitUntil = (promise: Promise<unknown>) => {
+		waitUntilPromises.push(promise)
+	}
+
+	await scheduleSavedPackageSearchIndexUpsert({
+		env: { APP_DB: db } as Env,
+		packageId: 'pkg-race',
+		userId: 'user-1',
+		embedText: 'older',
+		waitUntil,
+	})
+	await scheduleSavedPackageSearchIndexUpsert({
+		env: { APP_DB: db } as Env,
+		packageId: 'pkg-race',
+		userId: 'user-1',
+		embedText: 'newer',
+		waitUntil,
+	})
+	expect(rows.get('pkg-race')).toMatchObject({
+		generation: 2,
+		embedText: 'newer',
+	})
+	// Coalesced to one in-flight reconcile.
+	await vi.waitFor(() => {
+		expect(mockModule.upsertSavedPackageVector).toHaveBeenCalledTimes(1)
+	})
+	expect(mockModule.upsertSavedPackageVector).toHaveBeenNthCalledWith(
+		1,
+		expect.anything(),
+		expect.objectContaining({ embedText: 'older' }),
+	)
+
+	resolveFirstUpsert?.()
+	await waitUntilPromises[0]
+	await waitUntilPromises[1]
+
+	expect(mockModule.upsertSavedPackageVector).toHaveBeenCalledTimes(2)
+	expect(mockModule.upsertSavedPackageVector).toHaveBeenNthCalledWith(
+		2,
+		expect.anything(),
+		expect.objectContaining({ embedText: 'newer' }),
+	)
+	expect(rows.has('pkg-race')).toBe(false)
+})
+
 test('mark and clear debt helpers round-trip', async () => {
 	const { db, rows } = createDebtDb()
-	await markSavedPackageSearchIndexDebt({
+	const generation = await markSavedPackageSearchIndexDebt({
 		db,
 		packageId: 'pkg-3',
 		userId: 'user-3',
+		embedText: 'pending text',
 		lastError: 'pending',
 	})
+	expect(generation).toBe(1)
 	expect(rows.get('pkg-3')?.lastError).toBe('pending')
 	await clearSavedPackageSearchIndexDebt({ db, packageId: 'pkg-3' })
 	expect(rows.has('pkg-3')).toBe(false)

--- a/packages/worker/src/package-registry/search-index-debt.node.test.ts
+++ b/packages/worker/src/package-registry/search-index-debt.node.test.ts
@@ -246,6 +246,65 @@ test('mark and clear debt helpers round-trip', async () => {
 	})
 	expect(generation).toBe(1)
 	expect(rows.get('pkg-3')?.lastError).toBe('pending')
-	await clearSavedPackageSearchIndexDebt({ db, packageId: 'pkg-3' })
+	await clearSavedPackageSearchIndexDebt({
+		db,
+		packageId: 'pkg-3',
+		generation,
+	})
 	expect(rows.has('pkg-3')).toBe(false)
+})
+
+test('reconcile upserts under the debt row owner, not the scheduler userId', async () => {
+	let resolveFirstUpsert: (() => void) | undefined
+	let upsertCalls = 0
+	mockModule.upsertSavedPackageVector.mockReset()
+	mockModule.upsertSavedPackageVector.mockImplementation(async () => {
+		upsertCalls += 1
+		if (upsertCalls === 1) {
+			await new Promise<void>((resolve) => {
+				resolveFirstUpsert = resolve
+			})
+		}
+	})
+	const { db, rows } = createDebtDb()
+	const waitUntilPromises: Array<Promise<unknown>> = []
+	const waitUntil = (promise: Promise<unknown>) => {
+		waitUntilPromises.push(promise)
+	}
+
+	await scheduleSavedPackageSearchIndexUpsert({
+		env: { APP_DB: db } as Env,
+		packageId: 'pkg-owner',
+		userId: 'user-a',
+		embedText: 'from-a',
+		waitUntil,
+	})
+	await scheduleSavedPackageSearchIndexUpsert({
+		env: { APP_DB: db } as Env,
+		packageId: 'pkg-owner',
+		userId: 'user-b',
+		embedText: 'from-b',
+		waitUntil,
+	})
+	expect(rows.get('pkg-owner')).toMatchObject({
+		userId: 'user-b',
+		embedText: 'from-b',
+		generation: 2,
+	})
+
+	resolveFirstUpsert?.()
+	await waitUntilPromises[0]
+	await waitUntilPromises[1]
+
+	expect(mockModule.upsertSavedPackageVector).toHaveBeenCalledTimes(2)
+	expect(mockModule.upsertSavedPackageVector).toHaveBeenNthCalledWith(
+		1,
+		expect.anything(),
+		expect.objectContaining({ userId: 'user-a', embedText: 'from-a' }),
+	)
+	expect(mockModule.upsertSavedPackageVector).toHaveBeenNthCalledWith(
+		2,
+		expect.anything(),
+		expect.objectContaining({ userId: 'user-b', embedText: 'from-b' }),
+	)
 })

--- a/packages/worker/src/package-registry/search-index-debt.node.test.ts
+++ b/packages/worker/src/package-registry/search-index-debt.node.test.ts
@@ -1,0 +1,136 @@
+import { expect, test, vi } from 'vitest'
+import { consoleError } from '#worker/test-support/console-spies.ts'
+
+const mockModule = vi.hoisted(() => ({
+	upsertSavedPackageVector: vi.fn(),
+	captureException: vi.fn(),
+}))
+
+vi.mock('./vectorize.ts', () => ({
+	upsertSavedPackageVector: (...args: Array<unknown>) =>
+		mockModule.upsertSavedPackageVector(...args),
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+	captureException: (...args: Array<unknown>) =>
+		mockModule.captureException(...args),
+}))
+
+import {
+	clearSavedPackageSearchIndexDebt,
+	markSavedPackageSearchIndexDebt,
+	scheduleSavedPackageSearchIndexUpsert,
+} from './search-index-debt.ts'
+
+function createDebtDb() {
+	const rows = new Map<
+		string,
+		{ packageId: string; userId: string; lastError: string | null }
+	>()
+	return {
+		rows,
+		db: {
+			prepare(sql: string) {
+				return {
+					bind(...values: Array<unknown>) {
+						return {
+							async run() {
+								if (
+									sql.includes('INSERT INTO saved_package_search_index_debt')
+								) {
+									const packageId = String(values[0])
+									rows.set(packageId, {
+										packageId,
+										userId: String(values[1]),
+										lastError: values[2] == null ? null : String(values[2]),
+									})
+								}
+								if (
+									sql.includes('DELETE FROM saved_package_search_index_debt')
+								) {
+									rows.delete(String(values[0]))
+								}
+								return { success: true }
+							},
+							async all() {
+								return { results: [...rows.values()] }
+							},
+						}
+					},
+				}
+			},
+		} as unknown as D1Database,
+	}
+}
+
+test('scheduleSavedPackageSearchIndexUpsert defers via waitUntil and clears debt on success', async () => {
+	let resolveUpsert: (() => void) | undefined
+	mockModule.upsertSavedPackageVector.mockReset()
+	mockModule.upsertSavedPackageVector.mockImplementation(
+		() =>
+			new Promise<void>((resolve) => {
+				resolveUpsert = resolve
+			}),
+	)
+	const { db, rows } = createDebtDb()
+	const waitUntilPromises: Array<Promise<unknown>> = []
+	const schedulePromise = scheduleSavedPackageSearchIndexUpsert({
+		env: { APP_DB: db } as Env,
+		packageId: 'pkg-1',
+		userId: 'user-1',
+		embedText: 'hello',
+		waitUntil: (promise) => {
+			waitUntilPromises.push(promise)
+		},
+	})
+	await schedulePromise
+	expect(rows.has('pkg-1')).toBe(true)
+	expect(waitUntilPromises).toHaveLength(1)
+	expect(mockModule.upsertSavedPackageVector).toHaveBeenCalledWith(
+		expect.anything(),
+		{
+			packageId: 'pkg-1',
+			userId: 'user-1',
+			embedText: 'hello',
+		},
+	)
+	resolveUpsert?.()
+	await waitUntilPromises[0]
+	expect(rows.has('pkg-1')).toBe(false)
+})
+
+test('scheduleSavedPackageSearchIndexUpsert keeps debt and reports to Sentry on failure', async () => {
+	consoleError.mockImplementation(() => {})
+	mockModule.upsertSavedPackageVector.mockReset()
+	mockModule.captureException.mockReset()
+	mockModule.upsertSavedPackageVector.mockRejectedValue(
+		new Error('vectorize down'),
+	)
+	const { db, rows } = createDebtDb()
+	await scheduleSavedPackageSearchIndexUpsert({
+		env: { APP_DB: db } as Env,
+		packageId: 'pkg-2',
+		userId: 'user-2',
+		embedText: 'hello',
+	})
+	expect(rows.get('pkg-2')).toMatchObject({
+		packageId: 'pkg-2',
+		userId: 'user-2',
+		lastError: 'vectorize down',
+	})
+	expect(mockModule.captureException).toHaveBeenCalled()
+	expect(consoleError).toHaveBeenCalled()
+})
+
+test('mark and clear debt helpers round-trip', async () => {
+	const { db, rows } = createDebtDb()
+	await markSavedPackageSearchIndexDebt({
+		db,
+		packageId: 'pkg-3',
+		userId: 'user-3',
+		lastError: 'pending',
+	})
+	expect(rows.get('pkg-3')?.lastError).toBe('pending')
+	await clearSavedPackageSearchIndexDebt({ db, packageId: 'pkg-3' })
+	expect(rows.has('pkg-3')).toBe(false)
+})

--- a/packages/worker/src/package-registry/search-index-debt.ts
+++ b/packages/worker/src/package-registry/search-index-debt.ts
@@ -1,0 +1,145 @@
+import * as Sentry from '@sentry/cloudflare'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import { upsertSavedPackageVector } from './vectorize.ts'
+
+/**
+ * Deferred saved-package vector upserts must not fail silently. Before
+ * scheduling work on `waitUntil`, mark debt; clear it on success; keep it
+ * (with the error) on failure and report to Sentry. Capability reindex also
+ * clears debt after a successful upsert so search converges even if the
+ * original waitUntil never ran.
+ */
+
+export async function markSavedPackageSearchIndexDebt(input: {
+	db: D1Database
+	packageId: string
+	userId: string
+	lastError?: string | null
+}) {
+	const now = new Date().toISOString()
+	await input.db
+		.prepare(
+			`INSERT INTO saved_package_search_index_debt (
+				package_id, user_id, last_error, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT(package_id) DO UPDATE SET
+				user_id = excluded.user_id,
+				last_error = excluded.last_error,
+				updated_at = excluded.updated_at`,
+		)
+		.bind(input.packageId, input.userId, input.lastError ?? null, now, now)
+		.run()
+}
+
+export async function clearSavedPackageSearchIndexDebt(input: {
+	db: D1Database
+	packageId: string
+}) {
+	await input.db
+		.prepare(`DELETE FROM saved_package_search_index_debt WHERE package_id = ?`)
+		.bind(input.packageId)
+		.run()
+}
+
+export async function listSavedPackageSearchIndexDebt(input: {
+	db: D1Database
+	limit: number
+}): Promise<Array<{ packageId: string; userId: string }>> {
+	const rows = await input.db
+		.prepare(
+			`SELECT package_id, user_id
+			FROM saved_package_search_index_debt
+			ORDER BY updated_at ASC
+			LIMIT ?`,
+		)
+		.bind(input.limit)
+		.all<{ package_id: string; user_id: string }>()
+	return (rows.results ?? []).map((row) => ({
+		packageId: row.package_id,
+		userId: row.user_id,
+	}))
+}
+
+function logSavedPackageSearchIndexError(input: {
+	packageId: string
+	userId: string
+	error: unknown
+}) {
+	console.error(
+		JSON.stringify({
+			message: 'saved package search index upsert failed',
+			packageId: input.packageId,
+			userId: input.userId,
+			error: getErrorMessage(input.error),
+		}),
+	)
+	Sentry.captureException(input.error, {
+		tags: {
+			scope: 'saved-package-search-index',
+			action: 'upsert',
+		},
+		extra: {
+			packageId: input.packageId,
+			userId: input.userId,
+		},
+	})
+}
+
+/**
+ * Upsert the package vector after the response when `waitUntil` is available;
+ * otherwise await (same observability either way). Debt is marked before the
+ * work starts so a dropped waitUntil still leaves a reconcile target.
+ */
+export async function scheduleSavedPackageSearchIndexUpsert(input: {
+	env: Env
+	packageId: string
+	userId: string
+	embedText: string
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	await markSavedPackageSearchIndexDebt({
+		db: input.env.APP_DB,
+		packageId: input.packageId,
+		userId: input.userId,
+	})
+
+	const task = (async () => {
+		await upsertSavedPackageVector(input.env, {
+			packageId: input.packageId,
+			userId: input.userId,
+			embedText: input.embedText,
+		})
+		await clearSavedPackageSearchIndexDebt({
+			db: input.env.APP_DB,
+			packageId: input.packageId,
+		})
+	})().catch(async (error: unknown) => {
+		try {
+			await markSavedPackageSearchIndexDebt({
+				db: input.env.APP_DB,
+				packageId: input.packageId,
+				userId: input.userId,
+				lastError: getErrorMessage(error),
+			})
+		} catch (debtError) {
+			console.error(
+				JSON.stringify({
+					message: 'failed to persist search index debt after upsert failure',
+					packageId: input.packageId,
+					error: getErrorMessage(debtError),
+				}),
+			)
+		}
+		logSavedPackageSearchIndexError({
+			packageId: input.packageId,
+			userId: input.userId,
+			error,
+		})
+	})
+
+	if (input.waitUntil) {
+		input.waitUntil(task)
+		return
+	}
+	await task
+}

--- a/packages/worker/src/package-registry/search-index-debt.ts
+++ b/packages/worker/src/package-registry/search-index-debt.ts
@@ -8,36 +8,124 @@ import { upsertSavedPackageVector } from './vectorize.ts'
  * (with the error) on failure and report to Sentry. Capability reindex also
  * clears debt after a successful upsert so search converges even if the
  * original waitUntil never ran.
+ *
+ * Each schedule bumps a per-package `generation` and stores the latest
+ * `embed_text`. An in-flight reconcile (coalesced per isolate) re-reads the
+ * debt row after every upsert so a newer publish wins; stale completions
+ * cannot clear newer debt.
  */
+
+type SearchIndexDebtRow = {
+	packageId: string
+	userId: string
+	generation: number
+	embedText: string
+}
+
+/** Coalesce concurrent schedules for the same package in one isolate. */
+const inFlightReconciles = new Map<string, Promise<void>>()
 
 export async function markSavedPackageSearchIndexDebt(input: {
 	db: D1Database
 	packageId: string
 	userId: string
+	embedText: string
 	lastError?: string | null
-}) {
+}): Promise<number> {
 	const now = new Date().toISOString()
 	await input.db
 		.prepare(
 			`INSERT INTO saved_package_search_index_debt (
-				package_id, user_id, last_error, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?)
+				package_id, user_id, generation, embed_text, last_error, created_at, updated_at
+			) VALUES (?, ?, 1, ?, ?, ?, ?)
 			ON CONFLICT(package_id) DO UPDATE SET
 				user_id = excluded.user_id,
+				generation = saved_package_search_index_debt.generation + 1,
+				embed_text = excluded.embed_text,
 				last_error = excluded.last_error,
 				updated_at = excluded.updated_at`,
 		)
-		.bind(input.packageId, input.userId, input.lastError ?? null, now, now)
+		.bind(
+			input.packageId,
+			input.userId,
+			input.embedText,
+			input.lastError ?? null,
+			now,
+			now,
+		)
 		.run()
+	const row = await input.db
+		.prepare(
+			`SELECT generation FROM saved_package_search_index_debt WHERE package_id = ?`,
+		)
+		.bind(input.packageId)
+		.first<{ generation: number }>()
+	return row?.generation ?? 1
 }
 
 export async function clearSavedPackageSearchIndexDebt(input: {
 	db: D1Database
 	packageId: string
+	generation?: number
 }) {
+	if (input.generation === undefined) {
+		await input.db
+			.prepare(
+				`DELETE FROM saved_package_search_index_debt WHERE package_id = ?`,
+			)
+			.bind(input.packageId)
+			.run()
+		return
+	}
 	await input.db
-		.prepare(`DELETE FROM saved_package_search_index_debt WHERE package_id = ?`)
+		.prepare(
+			`DELETE FROM saved_package_search_index_debt
+			WHERE package_id = ? AND generation = ?`,
+		)
+		.bind(input.packageId, input.generation)
+		.run()
+}
+
+async function readSavedPackageSearchIndexDebt(input: {
+	db: D1Database
+	packageId: string
+}): Promise<SearchIndexDebtRow | null> {
+	const row = await input.db
+		.prepare(
+			`SELECT package_id, user_id, generation, embed_text
+			FROM saved_package_search_index_debt
+			WHERE package_id = ?`,
+		)
 		.bind(input.packageId)
+		.first<{
+			package_id: string
+			user_id: string
+			generation: number
+			embed_text: string
+		}>()
+	if (!row) return null
+	return {
+		packageId: row.package_id,
+		userId: row.user_id,
+		generation: row.generation,
+		embedText: row.embed_text,
+	}
+}
+
+async function recordSavedPackageSearchIndexDebtFailure(input: {
+	db: D1Database
+	packageId: string
+	generation: number
+	lastError: string
+}) {
+	const now = new Date().toISOString()
+	await input.db
+		.prepare(
+			`UPDATE saved_package_search_index_debt
+			SET last_error = ?, updated_at = ?
+			WHERE package_id = ? AND generation = ?`,
+		)
+		.bind(input.lastError, now, input.packageId, input.generation)
 		.run()
 }
 
@@ -85,6 +173,72 @@ function logSavedPackageSearchIndexError(input: {
 	})
 }
 
+async function reconcileSavedPackageSearchIndex(input: {
+	env: Env
+	packageId: string
+	userId: string
+}) {
+	let failureGeneration: number | null = null
+	try {
+		for (;;) {
+			const row = await readSavedPackageSearchIndexDebt({
+				db: input.env.APP_DB,
+				packageId: input.packageId,
+			})
+			if (!row) return
+			failureGeneration = row.generation
+			await upsertSavedPackageVector(input.env, {
+				packageId: input.packageId,
+				userId: input.userId,
+				embedText: row.embedText,
+			})
+			const latest = await readSavedPackageSearchIndexDebt({
+				db: input.env.APP_DB,
+				packageId: input.packageId,
+			})
+			if (!latest) return
+			if (latest.generation !== row.generation) {
+				// A newer publish queued fresher embed text; loop.
+				continue
+			}
+			await clearSavedPackageSearchIndexDebt({
+				db: input.env.APP_DB,
+				packageId: input.packageId,
+				generation: row.generation,
+			})
+			const remaining = await readSavedPackageSearchIndexDebt({
+				db: input.env.APP_DB,
+				packageId: input.packageId,
+			})
+			if (!remaining) return
+		}
+	} catch (error: unknown) {
+		try {
+			if (failureGeneration !== null) {
+				await recordSavedPackageSearchIndexDebtFailure({
+					db: input.env.APP_DB,
+					packageId: input.packageId,
+					generation: failureGeneration,
+					lastError: getErrorMessage(error),
+				})
+			}
+		} catch (debtError) {
+			console.error(
+				JSON.stringify({
+					message: 'failed to persist search index debt after upsert failure',
+					packageId: input.packageId,
+					error: getErrorMessage(debtError),
+				}),
+			)
+		}
+		logSavedPackageSearchIndexError({
+			packageId: input.packageId,
+			userId: input.userId,
+			error,
+		})
+	}
+}
+
 /**
  * Upsert the package vector after the response when `waitUntil` is available;
  * otherwise await (same observability either way). Debt is marked before the
@@ -101,41 +255,27 @@ export async function scheduleSavedPackageSearchIndexUpsert(input: {
 		db: input.env.APP_DB,
 		packageId: input.packageId,
 		userId: input.userId,
+		embedText: input.embedText,
 	})
 
-	const task = (async () => {
-		await upsertSavedPackageVector(input.env, {
-			packageId: input.packageId,
-			userId: input.userId,
-			embedText: input.embedText,
-		})
-		await clearSavedPackageSearchIndexDebt({
-			db: input.env.APP_DB,
-			packageId: input.packageId,
-		})
-	})().catch(async (error: unknown) => {
-		try {
-			await markSavedPackageSearchIndexDebt({
-				db: input.env.APP_DB,
-				packageId: input.packageId,
-				userId: input.userId,
-				lastError: getErrorMessage(error),
-			})
-		} catch (debtError) {
-			console.error(
-				JSON.stringify({
-					message: 'failed to persist search index debt after upsert failure',
-					packageId: input.packageId,
-					error: getErrorMessage(debtError),
-				}),
-			)
+	const existing = inFlightReconciles.get(input.packageId)
+	if (existing) {
+		if (input.waitUntil) {
+			input.waitUntil(existing)
+			return
 		}
-		logSavedPackageSearchIndexError({
-			packageId: input.packageId,
-			userId: input.userId,
-			error,
-		})
+		await existing
+		return
+	}
+
+	const task = reconcileSavedPackageSearchIndex({
+		env: input.env,
+		packageId: input.packageId,
+		userId: input.userId,
+	}).finally(() => {
+		inFlightReconciles.delete(input.packageId)
 	})
+	inFlightReconciles.set(input.packageId, task)
 
 	if (input.waitUntil) {
 		input.waitUntil(task)

--- a/packages/worker/src/package-registry/search-index-debt.ts
+++ b/packages/worker/src/package-registry/search-index-debt.ts
@@ -66,17 +66,8 @@ export async function markSavedPackageSearchIndexDebt(input: {
 export async function clearSavedPackageSearchIndexDebt(input: {
 	db: D1Database
 	packageId: string
-	generation?: number
+	generation: number
 }) {
-	if (input.generation === undefined) {
-		await input.db
-			.prepare(
-				`DELETE FROM saved_package_search_index_debt WHERE package_id = ?`,
-			)
-			.bind(input.packageId)
-			.run()
-		return
-	}
 	await input.db
 		.prepare(
 			`DELETE FROM saved_package_search_index_debt
@@ -84,6 +75,20 @@ export async function clearSavedPackageSearchIndexDebt(input: {
 		)
 		.bind(input.packageId, input.generation)
 		.run()
+}
+
+/** Read current debt generation, or null when no debt row exists. */
+export async function getSavedPackageSearchIndexDebtGeneration(input: {
+	db: D1Database
+	packageId: string
+}): Promise<number | null> {
+	const row = await input.db
+		.prepare(
+			`SELECT generation FROM saved_package_search_index_debt WHERE package_id = ?`,
+		)
+		.bind(input.packageId)
+		.first<{ generation: number }>()
+	return row?.generation ?? null
 }
 
 async function readSavedPackageSearchIndexDebt(input: {
@@ -176,9 +181,9 @@ function logSavedPackageSearchIndexError(input: {
 async function reconcileSavedPackageSearchIndex(input: {
 	env: Env
 	packageId: string
-	userId: string
 }) {
 	let failureGeneration: number | null = null
+	let failureUserId: string | null = null
 	try {
 		for (;;) {
 			const row = await readSavedPackageSearchIndexDebt({
@@ -187,9 +192,13 @@ async function reconcileSavedPackageSearchIndex(input: {
 			})
 			if (!row) return
 			failureGeneration = row.generation
+			failureUserId = row.userId
+			// Always upsert under the debt row owner — never the scheduling
+			// caller's userId — so a coalesced reconcile cannot write one
+			// user's embed text into another namespace if ownership changed.
 			await upsertSavedPackageVector(input.env, {
 				packageId: input.packageId,
-				userId: input.userId,
+				userId: row.userId,
 				embedText: row.embedText,
 			})
 			const latest = await readSavedPackageSearchIndexDebt({
@@ -233,7 +242,7 @@ async function reconcileSavedPackageSearchIndex(input: {
 		}
 		logSavedPackageSearchIndexError({
 			packageId: input.packageId,
-			userId: input.userId,
+			userId: failureUserId ?? 'unknown',
 			error,
 		})
 	}
@@ -271,7 +280,6 @@ export async function scheduleSavedPackageSearchIndexUpsert(input: {
 	const task = reconcileSavedPackageSearchIndex({
 		env: input.env,
 		packageId: input.packageId,
-		userId: input.userId,
 	}).finally(() => {
 		inFlightReconciles.delete(input.packageId)
 	})

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -47,6 +47,7 @@ const mockModule = vi.hoisted(() => ({
 	syncPackageJobsForPackage: vi.fn(),
 	updateSavedPackage: vi.fn(),
 	upsertSavedPackageVector: vi.fn(),
+	scheduleSavedPackageSearchIndexUpsert: vi.fn(),
 	cleanupArtifactReposForPackage: vi.fn(),
 	deleteAllPackageScopedSecrets: vi.fn(),
 	removeAllSecretApprovalsForPackage: vi.fn(),
@@ -139,6 +140,11 @@ vi.mock('./vectorize.ts', () => ({
 		mockModule.upsertSavedPackageVector(...args),
 }))
 
+vi.mock('./search-index-debt.ts', () => ({
+	scheduleSavedPackageSearchIndexUpsert: (...args: Array<unknown>) =>
+		mockModule.scheduleSavedPackageSearchIndexUpsert(...args),
+}))
+
 vi.mock('#worker/jobs/repo.ts', () => ({
 	deleteJobRow: (...args: Array<unknown>) => mockModule.deleteJobRow(...args),
 	listJobRowsByUserId: (...args: Array<unknown>) =>
@@ -213,6 +219,7 @@ function setupDefaultMocks() {
 	mockModule.buildPackageSearchProjection.mockReturnValue(createProjection())
 	mockModule.buildSavedPackageEmbedText.mockReturnValue('saved package embed')
 	mockModule.upsertSavedPackageVector.mockResolvedValue(undefined)
+	mockModule.scheduleSavedPackageSearchIndexUpsert.mockResolvedValue(undefined)
 	mockModule.buildPublishedPackageArtifacts.mockResolvedValue(undefined)
 	mockModule.syncPackageJobsForPackage.mockResolvedValue(false)
 	mockModule.syncJobManagerAlarm.mockResolvedValue(undefined)
@@ -244,6 +251,61 @@ function setupDefaultMocks() {
 	mockModule.clearStorage.mockResolvedValue({ ok: true as const })
 	mockModule.listJobRowsByUserId.mockResolvedValue([])
 }
+
+test('refreshSavedPackageProjection defers search-index upsert and retriever cache via waitUntil', async () => {
+	setupDefaultMocks()
+	const env = createEnv()
+	const waitUntilPromises: Array<Promise<unknown>> = []
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		manifest: {
+			name: '@kentcdodds/shade-automation',
+			kody: {
+				id: 'shade-automation',
+				description: 'Shade automation package',
+				tags: ['home'],
+			},
+		},
+		files: { 'package.json': '{}' },
+		source: { id: 'source-1' },
+	})
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/shade-automation',
+		kodyId: 'shade-automation',
+		description: 'Old description',
+		tags: ['home'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		createdAt: '2026-04-20T00:00:00.000Z',
+		updatedAt: '2026-04-20T00:00:00.000Z',
+	})
+
+	await refreshSavedPackageProjection({
+		env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		packageId: 'package-1',
+		sourceId: 'source-1',
+		waitUntil: (promise) => {
+			waitUntilPromises.push(promise)
+		},
+	})
+
+	expect(mockModule.scheduleSavedPackageSearchIndexUpsert).toHaveBeenCalledWith(
+		expect.objectContaining({
+			packageId: 'package-1',
+			userId: 'user-1',
+			waitUntil: expect.any(Function),
+		}),
+	)
+	expect(waitUntilPromises.length).toBeGreaterThanOrEqual(1)
+	await Promise.all(waitUntilPromises)
+	expect(mockModule.refreshPackageRetrieverManifestCache).toHaveBeenCalled()
+})
 
 test('refreshSavedPackageProjection syncs the job manager only when package jobs change', async () => {
 	setupDefaultMocks()

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -19,10 +19,8 @@ import {
 	type SavedPackageRecord,
 	type SavedPackageRow,
 } from './types.ts'
-import {
-	deleteSavedPackageVector,
-	upsertSavedPackageVector,
-} from './vectorize.ts'
+import { deleteSavedPackageVector } from './vectorize.ts'
+import { scheduleSavedPackageSearchIndexUpsert } from './search-index-debt.ts'
 import { deleteJobRow, listJobRowsByUserId } from '#worker/jobs/repo.ts'
 import { syncJobManagerAlarm } from '#worker/jobs/manager-client.ts'
 import { rebuildPublishedPackageArtifacts } from '#worker/package-runtime/published-bundle-artifacts.ts'
@@ -302,11 +300,6 @@ export async function refreshSavedPackageProjection(input: {
 				})
 				await insertSavedPackage(input.env.APP_DB, row)
 			}
-			await upsertSavedPackageVector(input.env, {
-				packageId: input.packageId,
-				userId: input.userId,
-				embedText: buildSavedPackageEmbedText(loaded.manifest),
-			})
 			const refreshedAt = new Date().toISOString()
 			const savedPackage = {
 				id: input.packageId,
@@ -330,6 +323,8 @@ export async function refreshSavedPackageProjection(input: {
 					? (loaded.files as Record<string, string>)
 					: null
 			if (loadedFiles) {
+				// Artifacts stay on the hot path: invoke needs them immediately
+				// and there is no safe cold-build substitute for a fresh publish.
 				await rebuildPublishedPackageArtifacts({
 					env: input.env,
 					userId: input.userId,
@@ -375,21 +370,37 @@ export async function refreshSavedPackageProjection(input: {
 					},
 				})
 			}
-			try {
-				await refreshPackageRetrieverManifestCache({
-					env: input.env,
-					userId: input.userId,
-					source: loaded.source,
-					savedPackage,
-					manifest: loaded.manifest,
-				})
-			} catch (error) {
+			// Vector upsert is searchable but not needed for the publish
+			// response. Defer via waitUntil with durable debt + Sentry so a
+			// failure cannot leave search silently stale.
+			await scheduleSavedPackageSearchIndexUpsert({
+				env: input.env,
+				packageId: input.packageId,
+				userId: input.userId,
+				embedText: buildSavedPackageEmbedText(loaded.manifest),
+				waitUntil: input.waitUntil,
+			})
+			const retrieverCacheTask = refreshPackageRetrieverManifestCache({
+				env: input.env,
+				userId: input.userId,
+				source: loaded.source,
+				savedPackage,
+				manifest: loaded.manifest,
+			}).catch((error: unknown) => {
 				logPackageRetrieverProjectionError({
 					action: 'refresh',
 					packageId: input.packageId,
 					error,
 				})
+			})
+			if (input.waitUntil) {
+				input.waitUntil(retrieverCacheTask)
+			} else {
+				await retrieverCacheTask
 			}
+			// Jobs + auto-start stay on the hot path: a deferred failure would
+			// leave schedules/services silently inactive until the next publish,
+			// and there is no dedicated reconcile for that yet.
 			const { syncPackageJobsForPackage } =
 				await import('#worker/jobs/service.ts')
 			const schedulerStateChanged = await syncPackageJobsForPackage({

--- a/packages/worker/src/vectorize/reindex-batches.node.test.ts
+++ b/packages/worker/src/vectorize/reindex-batches.node.test.ts
@@ -60,6 +60,7 @@ test('reindexVectorCandidates isolates failed embedding items and upserts the re
 					error: 'embedding input rejected',
 				},
 			],
+			failedIds: ['bad-1'],
 			warning: '1 test vector(s) failed to reindex',
 		})
 
@@ -82,6 +83,33 @@ test('reindexVectorCandidates isolates failed embedding items and upserts the re
 		expect(consoleError).toHaveBeenCalledWith(
 			expect.stringContaining('capability vector reindex skipped vector'),
 		)
+	} finally {
+		consoleError.mockRestore()
+	}
+})
+
+test('reindexVectorCandidates keeps uncapped failedIds beyond the failure sample cap', async () => {
+	mockModule.embedTextsForVectorize.mockReset()
+	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+	mockModule.embedTextsForVectorize.mockRejectedValue(new Error('ai down'))
+	const candidates = Array.from({ length: 25 }, (_, index) => ({
+		id: `bad-${index}`,
+		text: `text-${index}`,
+		namespace: 'user-a',
+		metadata: { kind: 'test' as const },
+	}))
+
+	try {
+		const result = await reindexVectorCandidates({
+			env: {} as Env,
+			index: { upsert: vi.fn() } as unknown as VectorizeIndex,
+			kind: 'test',
+			candidates,
+		})
+		expect(result.failed).toBe(25)
+		expect(result.failures).toHaveLength(20)
+		expect(result.failedIds).toHaveLength(25)
+		expect(result.failedIds?.[24]).toBe('bad-24')
 	} finally {
 		consoleError.mockRestore()
 	}

--- a/packages/worker/src/vectorize/reindex-batches.node.test.ts
+++ b/packages/worker/src/vectorize/reindex-batches.node.test.ts
@@ -108,8 +108,9 @@ test('reindexVectorCandidates keeps uncapped failedIds beyond the failure sample
 		})
 		expect(result.failed).toBe(25)
 		expect(result.failures).toHaveLength(20)
-		expect(result.failedIds).toHaveLength(25)
-		expect(result.failedIds?.[24]).toBe('bad-24')
+		expect(result.failedIds).toEqual(
+			candidates.map((candidate) => candidate.id),
+		)
 	} finally {
 		consoleError.mockRestore()
 	}

--- a/packages/worker/src/vectorize/reindex-batches.ts
+++ b/packages/worker/src/vectorize/reindex-batches.ts
@@ -21,7 +21,10 @@ export type VectorReindexResult = {
 	failed?: number
 	warning?: string
 	error?: string
+	/** Capped sample of failures for operator-facing messages. */
 	failures?: Array<VectorReindexFailure>
+	/** Uncapped failed candidate ids for reconciliation (e.g. debt cleanup). */
+	failedIds?: Array<string>
 }
 
 const upsertBatchSize = 16
@@ -36,11 +39,18 @@ export function mergeVectorReindexResults(
 	let upserted = 0
 	let failed = 0
 	const failures: Array<VectorReindexFailure> = []
+	const failedIds: Array<string> = []
+	const seenFailedIds = new Set<string>()
 	for (const result of results) {
 		upserted += result.upserted
 		failed += result.failed ?? 0
 		for (const failure of result.failures ?? []) {
 			if (failures.length < maxReportedFailures) failures.push(failure)
+		}
+		for (const failedId of result.failedIds ?? []) {
+			if (seenFailedIds.has(failedId)) continue
+			seenFailedIds.add(failedId)
+			failedIds.push(failedId)
 		}
 	}
 	if (failed === 0) return { upserted }
@@ -49,6 +59,7 @@ export function mergeVectorReindexResults(
 		upserted,
 		failed,
 		failures,
+		...(failedIds.length > 0 ? { failedIds } : {}),
 		...(upserted === 0 ? { error: message } : { warning: message }),
 	}
 }
@@ -62,6 +73,7 @@ export async function reindexVectorCandidates(input: {
 	let upserted = 0
 	let failed = 0
 	const failures: Array<VectorReindexFailure> = []
+	const failedIds: Array<string> = []
 
 	function recordFailure(input_: {
 		candidate: VectorReindexCandidate
@@ -69,6 +81,7 @@ export async function reindexVectorCandidates(input: {
 		error: unknown
 	}) {
 		failed += 1
+		failedIds.push(input_.candidate.id)
 		const failure = {
 			id: input_.candidate.id,
 			phase: input_.phase,
@@ -141,6 +154,7 @@ export async function reindexVectorCandidates(input: {
 		upserted,
 		failed,
 		failures,
+		failedIds,
 	}
 	const message = `${failed} ${input.kind} vector(s) failed to reindex`
 	if (upserted === 0 && input.candidates.length > 0) {

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -30,7 +30,7 @@
 		},
 		{
 			"filename": "0007-saved-package-search-index-debt.sql",
-			"sha256": "844c408bb1abae49abb1ad8b514957573559ce2972dc15c84eef2b36ce682757"
+			"sha256": "62922faee72e96170009bd0410649a9404fc1678f571438d78f62aaaba89ac07"
 		}
 	]
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -27,6 +27,10 @@
 		{
 			"filename": "0006-platform-oauth-app-description.sql",
 			"sha256": "546c2d705915aa098dd3642d65d0e6fed48e8f201b71afb4725b8e10fbdf3728"
+		},
+		{
+			"filename": "0007-saved-package-search-index-debt.sql",
+			"sha256": "844c408bb1abae49abb1ad8b514957573559ce2972dc15c84eef2b36ce682757"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Address Cameron Pak onboarding feedback: long package install/publish waits sat silent (~20s), and onboarding prompts were only web-pasteable. This track adds MCP `notifications/progress` on the execute hot path, registers templated onboarding prompts natively, and moves non-essential post-publish search work off the response critical path without silent failure.

## Summary

- **MCP progress:** Widen `McpToolServer.registerTool` so handlers receive SDK v1/v2 extras; `createProgressReporter` emits `notifications/progress` when `_meta.progressToken` is present. Threaded through `execute` → `runModuleWithRegistry` → capability `ctx.reportProgress`. Monotonic phase messages on execute `bundle` → `hydrate` → `provider-assembly` → `sandbox`, plus slow capabilities and one-click install phases.
- **MCP prompts:** Register `onboarding_setup`, `onboarding_discovery`, `onboarding_first_win` via `prompts/list` + `prompts/get` (builders in `#worker/onboarding-prompts.ts`). Aligned with main's first-win onboarding. No new tools.
- **Hot-path deferral:** `refreshSavedPackageProjection` defers vector upsert + retriever cache via `waitUntil`. Artifacts rebuild and job sync stay on the hot path.

### Failure-observability design (deferred search index)

1. Mark durable `saved_package_search_index_debt` (migration `0007`) with bumped `generation` + `embed_text` before deferring.
2. Coalesced reconcile upserts under the **debt row owner**; only matching generation clears debt.
3. Failures keep debt + `last_error` + Sentry (`scope: saved-package-search-index`).
4. Reindex snapshots generations before page upsert and clears only those generations; uses uncapped `failedIds`.
5. Retriever cache refresh keeps soft-fail Sentry path.

## Conductor report

- **Status:** SHIPPED
- **Shipped:** https://github.com/kentcdodds/kody/pull/1370 (squash-merged as `1171132`)
- **Evidence:** Validate https://github.com/kentcdodds/kody/actions/runs/31383901521 green; Deploy https://github.com/kentcdodds/kody/actions/runs/31384371417 success; Discord summary posted.
- **Remains:** none for this track.
- **Gate times:** none.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Merged:** `1171132`

**Classification:** extends — MCP progress/prompts + deferred saved-package search indexing with D1 debt.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-825954ab-82bd-47ea-bf99-47eae458ea88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-825954ab-82bd-47ea-bf99-47eae458ea88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added progress updates for MCP execution, package publishing, community forks, installations, and saved-package actions.
  * Added onboarding prompts for setup, discovery, welcome emails, and reply lookups.
* **Improvements**
  * Deferred saved-package search indexing now runs in the background and retries failed updates.
  * Added background-processing support across supported operations.
* **Bug Fixes**
  * Improved tracking and recovery of search-index update failures without blocking primary workflows.
  * Improved reporting of partial vector reindexing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->