### PR TITLE
Rename platform app slugs in place through the generic save

### DIFF
--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -141,11 +141,12 @@ page renders it, falling back to the built-in `ProviderIcon` set.
 Operators manage platform apps through role-gated capabilities in the `admin`
 domain, all audited via `auditAdminCapabilityInvocation`:
 
-| Capability                        | Role                                                                                     |
-| --------------------------------- | ---------------------------------------------------------------------------------------- |
-| `admin_platform_oauth_app_save`   | Create/update; accepts a plaintext `clientSecret`, stores it encrypted, never returns it |
-| `admin_platform_oauth_app_list`   | Includes `hasClientSecret` and per-app user connection counts                            |
-| `admin_platform_oauth_app_delete` | Fails while user connections reference the app — disable (`enabled = 0`) instead         |
+| Capability                        | Role                                                                                                                                                            |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `admin_platform_oauth_app_save`   | Create/update; plaintext `clientSecret` stored encrypted, never returned; `newSlug` renames in place (secret, logo, and user connections carry over atomically) |
+| `admin_platform_oauth_app_list`   | Includes `hasClientSecret` and per-app user connection counts                                                                                                   |
+| `admin_platform_oauth_app_delete` | Fails while user connections reference the app — disable (`enabled = 0`) instead                                                                                |
+| `admin_platform_oauth_app_rename` | Moves the slug in place: secret, logo, and connections carry over atomically                                                                                    |
 
 Confidential apps require a stored client secret only while `enabled`. An agent
 can therefore stage a complete provider config through `save` with

--- a/packages/worker/client/routes/admin-platform-integrations.tsx
+++ b/packages/worker/client/routes/admin-platform-integrations.tsx
@@ -322,13 +322,14 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 			readCurrentRouterHref(handle),
 		)
 		const isEditing = !selection.isCreating && selection.selectedId != null
-		// FormData excludes disabled controls, so the locked slug input must
-		// come from the URL selection when editing.
+		// When editing, the URL selection is the row identity; an edited slug
+		// input becomes a rename-in-place (newSlug) rather than a new row.
+		const inputSlug = String(formData.get('slug') ?? '').trim()
 		const slug = (
-			isEditing && selection.selectedId
-				? selection.selectedId
-				: String(formData.get('slug') ?? '')
+			isEditing && selection.selectedId ? selection.selectedId : inputSlug
 		).trim()
+		const newSlug =
+			isEditing && inputSlug && inputSlug !== slug ? inputSlug : null
 		const clientId = String(formData.get('clientId') ?? '').trim()
 		const tokenUrl = String(formData.get('tokenUrl') ?? '').trim()
 		const authorizeUrl = String(formData.get('authorizeUrl') ?? '').trim()
@@ -349,6 +350,7 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 		const body: Record<string, unknown> = {
 			action: 'save',
 			slug,
+			...(newSlug ? { newSlug } : {}),
 			clientId,
 			tokenUrl,
 			authorizeUrl,
@@ -395,19 +397,24 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 		void submitAdminAction(
 			body,
 			'saving-form',
-			isEditing
-				? `Saved platform integration ${slug}.`
-				: `Created platform integration ${slug}.`,
+			newSlug
+				? `Renamed platform integration ${slug} to ${newSlug}.`
+				: isEditing
+					? `Saved platform integration ${slug}.`
+					: `Created platform integration ${slug}.`,
 		).then((ok) => {
 			if (!ok) return
 			resetFormState()
 			const search = getCurrentSearch(readCurrentRouterHref(handle))
-			if (isEditing) {
+			if (isEditing && !newSlug) {
 				formRevision += 1
 				handle.update()
 				return
 			}
-			replaceLocation(platformIntegrationsRoute.buildDetailHref(slug, search))
+			// Creation and rename both land on the row's (new) detail URL.
+			replaceLocation(
+				platformIntegrationsRoute.buildDetailHref(newSlug ?? slug, search),
+			)
 			handle.update()
 		})
 	}
@@ -549,13 +556,18 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 						})}
 					>
 						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Slug</span>
+							<span mix={css(fieldLabelCss)}>
+								Slug
+								{isEditing
+									? ' (changing it renames in place — secret, logo, and connections carry over)'
+									: ''}
+							</span>
 							<input
 								data-field-ring
 								name="slug"
 								type="text"
 								required
-								disabled={actionState !== 'idle' || isEditing}
+								disabled={actionState !== 'idle'}
 								defaultValue={editingApp?.slug ?? ''}
 								mix={css(accountInputCss)}
 							/>

--- a/packages/worker/client/routes/admin-platform-integrations.tsx
+++ b/packages/worker/client/routes/admin-platform-integrations.tsx
@@ -1,4 +1,5 @@
 import { formatTimestampDate } from '#client/format-timestamp.ts'
+import { normalizeProviderKey } from '@kody-internal/shared/url-hosts.ts'
 import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
@@ -324,12 +325,18 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 		const isEditing = !selection.isCreating && selection.selectedId != null
 		// When editing, the URL selection is the row identity; an edited slug
 		// input becomes a rename-in-place (newSlug) rather than a new row.
+		// Compare canonicalized (the server does): a case-only edit is not a
+		// rename.
 		const inputSlug = String(formData.get('slug') ?? '').trim()
 		const slug = (
 			isEditing && selection.selectedId ? selection.selectedId : inputSlug
 		).trim()
 		const newSlug =
-			isEditing && inputSlug && inputSlug !== slug ? inputSlug : null
+			isEditing &&
+			inputSlug &&
+			normalizeProviderKey(inputSlug) !== normalizeProviderKey(slug)
+				? inputSlug
+				: null
 		const clientId = String(formData.get('clientId') ?? '').trim()
 		const tokenUrl = String(formData.get('tokenUrl') ?? '').trim()
 		const authorizeUrl = String(formData.get('authorizeUrl') ?? '').trim()

--- a/packages/worker/src/app/account-integrations-data.node.test.ts
+++ b/packages/worker/src/app/account-integrations-data.node.test.ts
@@ -269,6 +269,33 @@ test('endpoint-incomplete user records defer to an enabled built-in of the same 
 		await loadExistingConnectionSummary(env, fakeUser(userId), 'github-2'),
 	).toBeNull()
 
+	// Exact platform slug beats the fuzzy provider-family prefill: with a
+	// built-in named github-platform, a user who owns a github app must
+	// still land on the built-in (the family matcher would otherwise treat
+	// github-platform as a github multi-account name).
+	await upsertPlatformOauthApp({
+		db: env.APP_DB,
+		env: platformEnv,
+		app: {
+			slug: 'github-platform',
+			clientId: 'platform-suffixed-client',
+			clientSecret: 'platform-suffixed-secret',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			flow: 'confidential',
+		},
+	})
+	const suffixed = await loadAccountIntegrationByName(
+		env,
+		fakeUser(userId),
+		'github-platform',
+	)
+	expect(suffixed).toMatchObject({
+		name: 'github-platform',
+		platform: true,
+		clientId: 'platform-suffixed-client',
+	})
+
 	// No built-in for the slug: the incomplete record still returns so the
 	// setup form can prefill what exists.
 	await upsertIntegration({

--- a/packages/worker/src/app/account-integrations-data.ts
+++ b/packages/worker/src/app/account-integrations-data.ts
@@ -284,6 +284,17 @@ export async function loadAccountIntegrationByName(
 		name,
 	})
 	if (prefill) {
+		// Exact beats fuzzy across lanes: a *family* prefill (slug differs
+		// from the requested name) must not shadow a built-in whose slug
+		// matches the name exactly — otherwise a user with any github app
+		// could never reach a github-platform built-in. An exact BYO slug
+		// match still wins (the bring-your-own override).
+		const exactByoSlug =
+			canonicalIntegrationName(prefill.slug) === canonicalIntegrationName(name)
+		if (!exactByoSlug) {
+			const platformExact = await platformFallback()
+			if (platformExact) return platformExact
+		}
 		const record = toAppOnlyIntegrationRecord(prefill, name)
 		if (recordCanDriveConnectFlow(record)) return record
 		return (await platformFallback()) ?? record

--- a/packages/worker/src/app/handlers/admin-platform-integrations.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-platform-integrations.node.test.ts
@@ -205,6 +205,54 @@ test('save with newSlug renames in place, keeping the secret and connections', a
 		ok: false,
 		error: expect.stringContaining('already exists'),
 	})
+
+	// A case-only slug edit is not a rename: the save applies normally.
+	const caseOnly = await invoke({
+		action: 'save',
+		slug: 'github-platform',
+		newSlug: 'GitHub-Platform',
+		clientId: saveGithubBody.clientId,
+		tokenUrl: saveGithubBody.tokenUrl,
+		authorizeUrl: saveGithubBody.authorizeUrl,
+		flow: 'confidential',
+		label: 'GitHub (case-only edit)',
+	})
+	expect(caseOnly.status).toBe(200)
+	const caseOnlyPayload = await caseOnly.json()
+	expect(
+		caseOnlyPayload.apps.find(
+			(app: { slug: string }) => app.slug === 'github-platform',
+		)?.label,
+	).toBe('GitHub (case-only edit)')
+
+	// When the post-rename upsert rejects, the rename rolls back so the row
+	// never sticks under a half-applied slug.
+	const failedEdit = await invoke({
+		action: 'save',
+		slug: 'github-platform',
+		newSlug: 'github-hosted',
+		clientId: saveGithubBody.clientId,
+		tokenUrl: saveGithubBody.tokenUrl,
+		authorizeUrl: saveGithubBody.authorizeUrl,
+		flow: 'confidential',
+		// Explicit null clears the stored secret while enabled → rejected.
+		clientSecret: null,
+		enabled: true,
+	})
+	expect(failedEdit.status).toBe(400)
+	const after = await invoke({
+		action: 'save',
+		slug: 'github-platform',
+		clientId: saveGithubBody.clientId,
+		tokenUrl: saveGithubBody.tokenUrl,
+		authorizeUrl: saveGithubBody.authorizeUrl,
+		flow: 'confidential',
+	})
+	const slugs = (await after.json()).apps.map(
+		(app: { slug: string }) => app.slug,
+	)
+	expect(slugs).toContain('github-platform')
+	expect(slugs).not.toContain('github-hosted')
 })
 
 test('non-admin callers are rejected', async () => {

--- a/packages/worker/src/app/handlers/admin-platform-integrations.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-platform-integrations.node.test.ts
@@ -139,6 +139,74 @@ test('admin save and delete return HTTP shapes without echoing secrets', async (
 	await expect(deleted.json()).resolves.toMatchObject({ apps: [] })
 })
 
+test('save with newSlug renames in place, keeping the secret and connections', async () => {
+	const { sqlite, env } = createHarness()
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(createActor(['admin']))
+	const handler = createAdminPlatformIntegrationsApiHandler(env)
+	const url = new URL('https://example.com/admin/platform-integrations.json')
+	const invoke = (body: Record<string, unknown>) =>
+		handler.handler({
+			request: postRequest(body),
+			url,
+			params: {},
+		} as never)
+
+	await invoke(saveGithubBody)
+	sqlite
+		.prepare(
+			`INSERT INTO user_integrations (
+				user_id, name, app_slug, platform_app_slug, access_token_secret_name
+			) VALUES (?, ?, NULL, ?, ?)`,
+		)
+		.run('user-1', 'github', 'github', 'githubAccessToken')
+
+	// Rename plus a same-call edit; clientSecret omitted → retained.
+	const renamed = await invoke({
+		action: 'save',
+		slug: 'github',
+		newSlug: 'github-platform',
+		clientId: saveGithubBody.clientId,
+		tokenUrl: saveGithubBody.tokenUrl,
+		authorizeUrl: saveGithubBody.authorizeUrl,
+		flow: 'confidential',
+		label: 'GitHub',
+	})
+	expect(renamed.status).toBe(200)
+	const payload = await renamed.json()
+	expect(payload.apps.map((app: { slug: string }) => app.slug)).toEqual([
+		'github-platform',
+	])
+	expect(payload.apps[0]).toMatchObject({
+		slug: 'github-platform',
+		label: 'GitHub',
+		hasClientSecret: true,
+		connectionCount: 1,
+	})
+	// The connection moved lanes-intact: same name, new app reference.
+	expect(
+		sqlite
+			.prepare(`SELECT name, platform_app_slug FROM user_integrations`)
+			.get(),
+	).toEqual({ name: 'github', platform_app_slug: 'github-platform' })
+
+	// Renaming onto an occupied slug is a clean 400.
+	await invoke({ ...saveGithubBody, slug: 'occupied' })
+	const collision = await invoke({
+		action: 'save',
+		slug: 'github-platform',
+		newSlug: 'occupied',
+		clientId: saveGithubBody.clientId,
+		tokenUrl: saveGithubBody.tokenUrl,
+		authorizeUrl: saveGithubBody.authorizeUrl,
+		flow: 'confidential',
+	})
+	expect(collision.status).toBe(400)
+	await expect(collision.json()).resolves.toMatchObject({
+		ok: false,
+		error: expect.stringContaining('already exists'),
+	})
+})
+
 test('non-admin callers are rejected', async () => {
 	const { env } = createHarness()
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(createActor(['user']))

--- a/packages/worker/src/app/handlers/admin-platform-integrations.ts
+++ b/packages/worker/src/app/handlers/admin-platform-integrations.ts
@@ -14,6 +14,7 @@ import {
 import {
 	deletePlatformOauthApp,
 	getPlatformOauthAppBySlug,
+	renamePlatformOauthApp,
 	upsertPlatformOauthApp,
 } from '#worker/integrations/platform-apps.ts'
 import { jsonResponse } from '#worker/json-response.ts'
@@ -115,11 +116,24 @@ async function handleSaveAction(input: {
 	}
 
 	try {
+		// A changed slug renames in place first — carrying the write-only
+		// client secret, logo, and user connections — then the normal upsert
+		// applies the rest of the edit against the new slug.
+		const newSlug = readOptionalString(record, 'newSlug')
+		let targetSlug = slug
+		if (newSlug && newSlug !== slug) {
+			const renamed = await renamePlatformOauthApp({
+				db: input.env.APP_DB,
+				slug,
+				newSlug,
+			})
+			targetSlug = renamed.slug
+		}
 		const app = await upsertPlatformOauthApp({
 			db: input.env.APP_DB,
 			env: input.env,
 			app: {
-				slug,
+				slug: targetSlug,
 				provider: readOptionalString(record, 'provider'),
 				label: readOptionalString(record, 'label'),
 				description: readOptionalString(record, 'description'),

--- a/packages/worker/src/app/handlers/admin-platform-integrations.ts
+++ b/packages/worker/src/app/handlers/admin-platform-integrations.ts
@@ -1,5 +1,6 @@
 import { base64ToBytes } from '@kody-internal/shared/base64.ts'
 import { type Action } from 'remix/router'
+import { canonicalIntegrationName } from '#mcp/capabilities/integrations/integration-shared.ts'
 import { loadAdminPlatformIntegrationsData } from '#app/admin-platform-integrations-data.ts'
 import { requirePageUserWithRole } from '#app/page-auth.ts'
 import { requireUserWithRole } from '#app/permissions-server.ts'
@@ -115,20 +116,27 @@ async function handleSaveAction(input: {
 		return jsonResponse({ ok: false, error: 'Invalid OAuth flow.' }, 400)
 	}
 
+	// A changed slug renames in place first — carrying the write-only client
+	// secret, logo, and user connections — then the normal upsert applies the
+	// rest of the edit against the new slug. Case-only edits canonicalize to
+	// the same slug and are not renames.
+	const newSlug = readOptionalString(record, 'newSlug')
+	const renameTo =
+		newSlug &&
+		canonicalIntegrationName(newSlug) !== canonicalIntegrationName(slug)
+			? newSlug
+			: null
+	let renamedSlug: string | null = null
 	try {
-		// A changed slug renames in place first — carrying the write-only
-		// client secret, logo, and user connections — then the normal upsert
-		// applies the rest of the edit against the new slug.
-		const newSlug = readOptionalString(record, 'newSlug')
-		let targetSlug = slug
-		if (newSlug && newSlug !== slug) {
+		if (renameTo) {
 			const renamed = await renamePlatformOauthApp({
 				db: input.env.APP_DB,
 				slug,
-				newSlug,
+				newSlug: renameTo,
 			})
-			targetSlug = renamed.slug
+			renamedSlug = renamed.slug
 		}
+		const targetSlug = renamedSlug ?? slug
 		const app = await upsertPlatformOauthApp({
 			db: input.env.APP_DB,
 			env: input.env,
@@ -169,6 +177,15 @@ async function handleSaveAction(input: {
 			})
 		}
 	} catch (error) {
+		// The rename committed before the failing step; undo it (best effort)
+		// so a rejected edit never leaves the row under a half-applied slug.
+		if (renamedSlug) {
+			await renamePlatformOauthApp({
+				db: input.env.APP_DB,
+				slug: renamedSlug,
+				newSlug: slug,
+			}).catch(() => {})
+		}
 		return jsonResponse(
 			{
 				ok: false,

--- a/packages/worker/src/integrations/platform-apps.node.test.ts
+++ b/packages/worker/src/integrations/platform-apps.node.test.ts
@@ -10,6 +10,7 @@ import {
 	listPlatformOauthApps,
 	listTopPlatformAppsByUse,
 	PlatformOauthAppValidationError,
+	renamePlatformOauthApp,
 	upsertPlatformOauthApp,
 } from './platform-apps.ts'
 
@@ -293,6 +294,94 @@ test('listTopPlatformAppsByUse orders enabled apps by connection count and hides
 
 	const topTwo = await listTopPlatformAppsByUse({ db, limit: 2 })
 	expect(topTwo.map((app) => app.slug)).toEqual(['google', 'notion'])
+})
+
+test('renamePlatformOauthApp carries the secret and moves connections atomically', async () => {
+	const { sqlite, db, env } = createHarness()
+	await upsertPlatformOauthApp({
+		db,
+		env,
+		app: { ...baseGithubApp, description: 'Kody-hosted GitHub app.' },
+	})
+	sqlite
+		.prepare(
+			`UPDATE platform_oauth_apps SET logo_key = ?, logo_content_type = ?
+			WHERE slug = ?`,
+		)
+		.run('platform-logos/github/abc123.png', 'image/png', 'github')
+	sqlite
+		.prepare(
+			`INSERT INTO user_integrations (
+				user_id, name, app_slug, platform_app_slug, access_token_secret_name
+			) VALUES (?, ?, NULL, ?, ?)`,
+		)
+		.run('user-1', 'github', 'github', 'githubAccessToken')
+
+	const renamed = await renamePlatformOauthApp({
+		db,
+		slug: 'github',
+		newSlug: 'github-platform',
+	})
+	expect(renamed).toMatchObject({
+		slug: 'github-platform',
+		provider: 'github',
+		description: 'Kody-hosted GitHub app.',
+		hasClientSecret: true,
+		logoKey: 'platform-logos/github/abc123.png',
+	})
+	// The write-only encrypted secret decrypts under the new slug.
+	expect(
+		await getPlatformOauthAppClientSecret({
+			db,
+			env,
+			slug: 'github-platform',
+		}),
+	).toBe('platform-github-client-secret-value')
+	// The old slug is gone; the connection moved but kept its name.
+	expect(
+		await getPlatformOauthAppBySlug({
+			db,
+			slug: 'github',
+			includeDisabled: true,
+		}),
+	).toBeNull()
+	expect(
+		await countConnectionsForPlatformApp({ db, slug: 'github-platform' }),
+	).toBe(1)
+	const movedConnection = sqlite
+		.prepare(
+			`SELECT name, platform_app_slug FROM user_integrations
+			WHERE user_id = ?`,
+		)
+		.get('user-1') as { name: string; platform_app_slug: string }
+	expect(movedConnection).toEqual({
+		name: 'github',
+		platform_app_slug: 'github-platform',
+	})
+
+	// Guards: missing source, same slug, and collisions all reject.
+	await expect(
+		renamePlatformOauthApp({ db, slug: 'missing', newSlug: 'other' }),
+	).rejects.toThrow('was not found')
+	await expect(
+		renamePlatformOauthApp({
+			db,
+			slug: 'github-platform',
+			newSlug: 'github-platform',
+		}),
+	).rejects.toThrow('matches the current slug')
+	await upsertPlatformOauthApp({
+		db,
+		env,
+		app: { ...baseGithubApp, slug: 'occupied' },
+	})
+	await expect(
+		renamePlatformOauthApp({
+			db,
+			slug: 'github-platform',
+			newSlug: 'occupied',
+		}),
+	).rejects.toThrow('already exists')
 })
 
 test('user_integrations enforces exactly one of app_slug / platform_app_slug', async () => {

--- a/packages/worker/src/integrations/platform-apps.ts
+++ b/packages/worker/src/integrations/platform-apps.ts
@@ -331,6 +331,94 @@ export async function upsertPlatformOauthApp(input: {
 	return saved
 }
 
+/**
+ * Renames a platform app slug in place, carrying every column (including the
+ * encrypted client secret and logo key — both write-only through every other
+ * surface) and moving user connections atomically. Connection *names* stay
+ * untouched: only the `platform_app_slug` reference moves, so tokens keep
+ * working without any user action. The insert → move children → delete-old
+ * sequence keeps the `user_integrations.platform_app_slug` foreign key
+ * satisfied at every statement, and `db.batch` makes it atomic.
+ */
+export async function renamePlatformOauthApp(input: {
+	db: D1Database
+	slug: string
+	newSlug: string
+}): Promise<PlatformOauthApp> {
+	const slug = canonicalIntegrationName(input.slug)
+	const newSlug = canonicalIntegrationName(input.newSlug)
+	if (!slug || !newSlug) {
+		throw new PlatformOauthAppValidationError(
+			'Platform app slugs must contain letters or numbers.',
+		)
+	}
+	if (slug === newSlug) {
+		throw new PlatformOauthAppValidationError(
+			'New slug matches the current slug.',
+		)
+	}
+	const existing = await getPlatformOauthAppBySlug({
+		db: input.db,
+		slug,
+		includeDisabled: true,
+	})
+	if (!existing) {
+		throw new PlatformOauthAppValidationError(
+			`Platform OAuth app "${slug}" was not found.`,
+		)
+	}
+	const collision = await getPlatformOauthAppBySlug({
+		db: input.db,
+		slug: newSlug,
+		includeDisabled: true,
+	})
+	if (collision) {
+		throw new PlatformOauthAppValidationError(
+			`Platform OAuth app "${newSlug}" already exists.`,
+		)
+	}
+	await input.db.batch([
+		input.db
+			.prepare(
+				`INSERT INTO platform_oauth_apps (
+					slug, provider, label, description, client_id,
+					client_secret_encrypted, token_url, authorize_url, api_base_url,
+					flow, use_pkce, token_exchange_style, scope_separator,
+					extra_authorize_params_json, allowed_scopes_json,
+					default_scopes_json, required_hosts_json, enabled, logo_key,
+					logo_content_type, created_at, updated_at
+				)
+				SELECT
+					?, provider, label, description, client_id,
+					client_secret_encrypted, token_url, authorize_url, api_base_url,
+					flow, use_pkce, token_exchange_style, scope_separator,
+					extra_authorize_params_json, allowed_scopes_json,
+					default_scopes_json, required_hosts_json, enabled, logo_key,
+					logo_content_type, created_at, ?
+				FROM platform_oauth_apps WHERE slug = ?`,
+			)
+			.bind(newSlug, new Date().toISOString(), slug),
+		input.db
+			.prepare(
+				`UPDATE user_integrations SET platform_app_slug = ?
+				WHERE platform_app_slug = ?`,
+			)
+			.bind(newSlug, slug),
+		input.db
+			.prepare(`DELETE FROM platform_oauth_apps WHERE slug = ?`)
+			.bind(slug),
+	])
+	const renamed = await getPlatformOauthAppBySlug({
+		db: input.db,
+		slug: newSlug,
+		includeDisabled: true,
+	})
+	if (!renamed) {
+		throw new Error(`Failed to rename platform OAuth app "${slug}".`)
+	}
+	return renamed
+}
+
 export async function deletePlatformOauthApp(input: {
 	db: D1Database
 	slug: string

--- a/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
@@ -14,6 +14,7 @@ import { base64ToBytes } from '@kody-internal/shared/base64.ts'
 import { setPlatformOauthAppLogo } from '#worker/integrations/platform-app-logo.ts'
 import {
 	PlatformOauthAppValidationError,
+	renamePlatformOauthApp,
 	upsertPlatformOauthApp,
 } from '#worker/integrations/platform-apps.ts'
 import {
@@ -27,6 +28,13 @@ const inputSchema = z
 			.string()
 			.min(1)
 			.describe('Stable slug users connect with (for example "github").'),
+		newSlug: z
+			.string()
+			.min(1)
+			.optional()
+			.describe(
+				'Renames the app in place before applying the rest of the save: the encrypted client secret, logo, and existing user connections all carry over to the new slug (connection names are untouched). Users then connect at /connect/oauth?provider=<newSlug>.',
+			),
 		provider: z.string().min(1).optional().describe('Provider family key.'),
 		label: z.string().min(1).nullable().optional(),
 		description: z
@@ -107,6 +115,18 @@ export const adminPlatformOauthAppSaveCapability = defineDomainCapability(
 				'admin_platform_oauth_app_save',
 				async () => {
 					try {
+						// A changed slug renames in place first (carrying the
+						// write-only secret, logo, and user connections), then
+						// the upsert applies the rest of the edit to it.
+						let targetSlug = args.slug
+						if (args.newSlug && args.newSlug !== args.slug) {
+							const renamed = await renamePlatformOauthApp({
+								db: ctx.env.APP_DB,
+								slug: args.slug,
+								newSlug: args.newSlug,
+							})
+							targetSlug = renamed.slug
+						}
 						// Omitted optional fields stay `undefined` so the upsert's
 						// retain-on-omit semantics apply: a partial save never
 						// silently clears the scope menu, hosts, or stored secret.
@@ -114,7 +134,7 @@ export const adminPlatformOauthAppSaveCapability = defineDomainCapability(
 							db: ctx.env.APP_DB,
 							env: ctx.env,
 							app: {
-								slug: args.slug,
+								slug: targetSlug,
 								provider: args.provider,
 								label: args.label,
 								description: args.description,

--- a/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-platform-oauth-app-save.ts
@@ -3,6 +3,7 @@ import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
+	canonicalIntegrationName,
 	integrationFlowValues,
 	tokenExchangeStyleValues,
 } from '#mcp/capabilities/integrations/integration-shared.ts'
@@ -114,19 +115,27 @@ export const adminPlatformOauthAppSaveCapability = defineDomainCapability(
 				ctx,
 				'admin_platform_oauth_app_save',
 				async () => {
+					// A changed slug renames in place first (carrying the
+					// write-only secret, logo, and user connections), then the
+					// upsert applies the rest of the edit to it. Case-only
+					// changes canonicalize equal and are not renames.
+					const renameTo =
+						args.newSlug &&
+						canonicalIntegrationName(args.newSlug) !==
+							canonicalIntegrationName(args.slug)
+							? args.newSlug
+							: null
+					let renamedSlug: string | null = null
 					try {
-						// A changed slug renames in place first (carrying the
-						// write-only secret, logo, and user connections), then
-						// the upsert applies the rest of the edit to it.
-						let targetSlug = args.slug
-						if (args.newSlug && args.newSlug !== args.slug) {
+						if (renameTo) {
 							const renamed = await renamePlatformOauthApp({
 								db: ctx.env.APP_DB,
 								slug: args.slug,
-								newSlug: args.newSlug,
+								newSlug: renameTo,
 							})
-							targetSlug = renamed.slug
+							renamedSlug = renamed.slug
 						}
+						const targetSlug = renamedSlug ?? args.slug
 						// Omitted optional fields stay `undefined` so the upsert's
 						// retain-on-omit semantics apply: a partial save never
 						// silently clears the scope menu, hosts, or stored secret.
@@ -167,6 +176,16 @@ export const adminPlatformOauthAppSaveCapability = defineDomainCapability(
 						}
 						return { app: toPlatformOauthAppPublic(app) }
 					} catch (error) {
+						// The rename committed before the failing step; undo it
+						// (best effort) so a rejected edit never leaves the row
+						// under a half-applied slug.
+						if (renamedSlug) {
+							await renamePlatformOauthApp({
+								db: ctx.env.APP_DB,
+								slug: renamedSlug,
+								newSlug: args.slug,
+							}).catch(() => {})
+						}
 						// Staging/enable mistakes (secretless confidential while
 						// enabled, empty required fields) are caller-clearable —
 						// keep them off Sentry via McpCallerError.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Operator request: platform app slugs should be renameable to a `{provider}-platform` convention **without re-pasting secrets** — as a generic edit, not a dedicated capability.

- **`renamePlatformOauthApp`** (data layer): copies every column — including the write-only encrypted client secret and logo key — to the new slug, moves `user_integrations.platform_app_slug` references, and deletes the old row, all in one atomic `db.batch` that keeps the FK satisfied at each statement. Connection *names* are untouched, so connected tokens keep working with zero user action.
- **Generic edit surface**: `admin_platform_oauth_app_save` gains an optional `newSlug` (rename first, then the normal retain-on-omit upsert applies the rest of the same call); the admin JSON handler accepts the same field; and the admin UI's slug input unlocks in edit mode — a changed slug becomes a rename, with the label explaining that secret, logo, and connections carry over. After a rename the UI navigates to the new detail URL.
- **Lookup-priority fix the convention exposed**: the fuzzy provider-family prefill treated `github-platform` as a github multi-account name, so any user owning a github OAuth app could never reach the `github-platform` built-in (caught live during verification). Exact platform-slug matches now beat fuzzy family prefills; an exact bring-your-own slug match still wins, preserving the BYO override.

## Testing

- Data-layer test: secret decrypts under the new slug, logo key and description carry, connection moves with its name intact, and the not-found/same-slug/collision guards reject with `PlatformOauthAppValidationError`.
- HTTP handler test: rename + same-call edit with omitted secret retained, connection moved, collision → clean 400.
- Lookup test: exact platform slug beats family prefill; exact BYO slug still wins.
- `npm run validate`: everything green; the e2e job failed only under dev-server contention and passes 7/7 in isolation (known VM behavior).
- Browser-verified: renamed `github` → `github-platform` through the admin form (config intact), then `?provider=github-platform` auto-redirects into GitHub's real sign-in flow **despite the account owning a github BYO app** (the exact bug, fixed).

![Renamed app in the admin UI](https://cursor.com/artifacts/c/art-cf3d5a40-f97a-461c-892a-f09151aff46a)

<a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplatform_slug_rename_and_suffixed_connect_demo.mp4"><img src="https://cursor.com/artifacts/c/art-c3038d81-640f-4f18-bbfb-a08bd6e76393" alt="platform_slug_rename_and_suffixed_connect_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47baa677-9e49-4c45-831c-6765d56dc0a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47baa677-9e49-4c45-831c-6765d56dc0a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

