### PR TITLE
Show production commit on status page with GitHub link

### DIFF
--- a/packages/status/probes.node.test.ts
+++ b/packages/status/probes.node.test.ts
@@ -27,7 +27,9 @@ const packageAppOrigin = 'https://kodyapps.dev'
 
 function healthyRoutes(): Record<string, FakeRoute> {
 	return {
-		[`${primaryOrigin}/health`]: { body: { ok: true, commitSha: 'abc' } },
+		[`${primaryOrigin}/health`]: {
+			body: { ok: true, commitSha: 'abc123def4567890abcdef1234567890abcdef12' },
+		},
 		[`${primaryOrigin}/mcp`]: {
 			status: 401,
 			headers: { 'WWW-Authenticate': 'Bearer resource_metadata="..."' },
@@ -56,21 +58,24 @@ async function probe(routes: Record<string, FakeRoute>) {
 }
 
 function outcome(
-	outcomes: Awaited<ReturnType<typeof runAllProbes>>,
+	result: Awaited<ReturnType<typeof runAllProbes>>,
 	component: string,
 ) {
-	return outcomes.find((entry) => entry.component === component)
+	return result.outcomes.find((entry) => entry.component === component)
 }
 
 test('a fully healthy pass reports every component ok', async () => {
-	const outcomes = await probe(healthyRoutes())
-	expect(outcomes.map((entry) => entry.component).toSorted()).toEqual(
+	const result = await probe(healthyRoutes())
+	expect(result.outcomes.map((entry) => entry.component).toSorted()).toEqual(
 		[...statusComponentIds].toSorted(),
 	)
-	for (const entry of outcomes) {
+	for (const entry of result.outcomes) {
 		expect(entry.ok, `${entry.component} should be ok`).toBe(true)
 	}
-	expect(outcome(outcomes, 'app_db')?.latencyMs).toBe(4)
+	expect(outcome(result, 'app_db')?.latencyMs).toBe(4)
+	expect(result.productionCommitSha).toBe(
+		'abc123def4567890abcdef1234567890abcdef12',
+	)
 })
 
 test('probe failures isolate to the affected component and map error details', async () => {

--- a/packages/status/probes.ts
+++ b/packages/status/probes.ts
@@ -65,32 +65,51 @@ async function timedFetch(
 	}
 }
 
+type AppHealthBody = {
+	ok?: boolean
+	commitSha?: string
+}
+
+function readProductionCommitSha(body: AppHealthBody | null): string | null {
+	const commitSha = body?.commitSha?.trim()
+	if (!commitSha || !/^[0-9a-f]{7,40}$/i.test(commitSha)) return null
+	return commitSha.toLowerCase()
+}
+
 async function probeApp(
 	fetcher: typeof fetch,
 	primaryOrigin: string,
-): Promise<ProbeOutcome> {
+): Promise<{ outcome: ProbeOutcome; productionCommitSha: string | null }> {
 	const result = await timedFetch(fetcher, `${primaryOrigin}/health`)
 	if (!result.response) {
 		return {
-			component: 'app',
-			ok: false,
-			latencyMs: result.latencyMs,
-			detail: result.error,
+			outcome: {
+				component: 'app',
+				ok: false,
+				latencyMs: result.latencyMs,
+				detail: result.error,
+			},
+			productionCommitSha: null,
 		}
 	}
+	let body: AppHealthBody | null = null
 	let bodyOk = false
 	try {
-		const body = (await result.response.json()) as { ok?: boolean }
+		body = (await result.response.json()) as AppHealthBody
 		bodyOk = body.ok === true
 	} catch {
+		body = null
 		bodyOk = false
 	}
 	const ok = result.response.ok && bodyOk
 	return {
-		component: 'app',
-		ok,
-		latencyMs: result.latencyMs,
-		detail: ok ? null : `HTTP ${result.response.status}`,
+		outcome: {
+			component: 'app',
+			ok,
+			latencyMs: result.latencyMs,
+			detail: ok ? null : `HTTP ${result.response.status}`,
+		},
+		productionCommitSha: readProductionCommitSha(body),
 	}
 }
 
@@ -184,9 +203,14 @@ async function probeStorageComponents(
 	})
 }
 
+export type ProbeRunResult = {
+	outcomes: Array<ProbeOutcome>
+	productionCommitSha: string | null
+}
+
 export async function runAllProbes(
 	config: ProbeConfig,
-): Promise<Array<ProbeOutcome>> {
+): Promise<ProbeRunResult> {
 	const fetcher = config.fetcher ?? fetch
 	const [app, mcp, packageApps, storage] = await Promise.all([
 		probeApp(fetcher, config.primaryOrigin),
@@ -194,7 +218,7 @@ export async function runAllProbes(
 		probePackageApps(fetcher, config.packageAppOrigin),
 		probeStorageComponents(fetcher, config.primaryOrigin),
 	])
-	const outcomes = [app, mcp, packageApps, ...storage]
+	const outcomes = [app.outcome, mcp, packageApps, ...storage]
 	const covered = new Set(outcomes.map((outcome) => outcome.component))
 	for (const component of statusComponentIds) {
 		if (!covered.has(component)) {
@@ -206,5 +230,5 @@ export async function runAllProbes(
 			})
 		}
 	}
-	return outcomes
+	return { outcomes, productionCommitSha: app.productionCommitSha }
 }

--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -33,7 +33,7 @@ function snapshot(overrides: Partial<StatusSnapshot> = {}): StatusSnapshot {
 		openIncidents: [],
 		recentIncidents: [],
 		providerIncidents: null,
-		buildCommit: 'abc123',
+		productionCommit: 'abc123def4567890abcdef1234567890abcdef12',
 		...overrides,
 	}
 }
@@ -44,6 +44,11 @@ test('status page renders components, incidents, unknown state, and escapes deta
 		expect(healthy).toContain(component.name.replaceAll('&', '&amp;'))
 	}
 	expect(healthy).toContain('99.98% uptime')
+	expect(healthy).toContain('Production commit')
+	expect(healthy).toContain(
+		'https://github.com/kentcdodds/kody/commit/abc123def4567890abcdef1234567890abcdef12',
+	)
+	expect(healthy).toContain('>abc123d<')
 	expect(healthy).toContain('http-equiv="refresh"')
 	expect(healthy).toMatch(/operational|All systems/i)
 
@@ -132,6 +137,9 @@ test('status page renders provider incidents separately and omits them when abse
 	expect(withProvider).toContain('updated 2026-08-07T19:00:00.000Z')
 	expect(withProvider).toContain('for context only')
 	expect(withProvider).toContain('All systems operational')
+
+	const withoutCommit = renderStatusPage(snapshot({ productionCommit: null }))
+	expect(withoutCommit).not.toContain('Production commit')
 
 	const unsafeLink = renderStatusPage(
 		snapshot({

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -221,6 +221,20 @@ function renderProviderIncident(incident: ProviderIncident): string {
 </div>`
 }
 
+/** Public GitHub repository for the main kody worker (production deploys). */
+const productionRepo = 'kentcdodds/kody'
+
+function productionCommitLink(commitSha: string): string {
+	const shortSha = commitSha.slice(0, 7)
+	const href = `https://github.com/${productionRepo}/commit/${escapeHtml(commitSha)}`
+	return `<a href="${href}">${escapeHtml(shortSha)}</a>`
+}
+
+function renderProductionCommit(commitSha: string | null): string {
+	if (!commitSha) return ''
+	return `Production commit ${productionCommitLink(commitSha)} · `
+}
+
 function renderProviderIncidentsSection(
 	incidents: Array<ProviderIncident> | null | undefined,
 ): string {
@@ -267,7 +281,7 @@ export function renderStatusPage(snapshot: StatusSnapshot): string {
 	${providerIncidents}
 	${recentIncidents}
 	<footer>
-		Probes run every minute from an independently deployed worker.
+		${renderProductionCommit(snapshot.productionCommit)}Probes run every minute from an independently deployed worker.
 		<a href="https://heykody.app">heykody.app</a> ·
 		<a href="/status.json">JSON</a>
 	</footer>

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -31,6 +31,7 @@ import {
 } from './status-types.ts'
 
 const providerIncidentsMetaKey = 'provider_incidents_cache'
+const productionCommitMetaKey = 'production_commit_sha'
 
 export type StatusWorkerEnv = {
 	STATUS_STORE: DurableObjectNamespace<StatusStore>
@@ -385,11 +386,14 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 	}
 
 	async runProbes(): Promise<void> {
-		const outcomes = await runAllProbes({
+		const { outcomes, productionCommitSha } = await runAllProbes({
 			primaryOrigin: this.env.PRIMARY_ORIGIN,
 			packageAppOrigin: this.env.PACKAGE_APP_ORIGIN,
 		})
 		const now = Date.now()
+		if (productionCommitSha) {
+			this.setMeta(productionCommitMetaKey, productionCommitSha)
+		}
 		for (const outcome of outcomes) {
 			this.recordOutcome(outcome, now)
 		}
@@ -417,7 +421,7 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 			openIncidents: this.listIncidents('open'),
 			recentIncidents: this.listIncidents('resolved'),
 			providerIncidents: this.readProviderIncidents(now),
-			buildCommit: this.env.BUILD_COMMIT ?? null,
+			productionCommit: this.getMeta(productionCommitMetaKey),
 		}
 	}
 

--- a/packages/status/status-types.ts
+++ b/packages/status/status-types.ts
@@ -73,5 +73,6 @@ export type StatusSnapshot = {
 	 * omits the provider section in that case (fail-soft).
 	 */
 	providerIncidents: Array<ProviderIncident> | null
-	buildCommit: string | null
+	/** Latest `commitSha` reported by production `GET /health` (main worker). */
+	productionCommit: string | null
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The status page now shows which commit is live in production and links to it on GitHub.

## What changed

- Each probe pass reads `commitSha` from production `GET /health` (already returned by the main worker as `APP_COMMIT_SHA`).
- The last known SHA is persisted in the status Durable Object so it stays visible even if a probe fails.
- The page footer renders **Production commit** with a short SHA linked to `github.com/kentcdodds/kody/commit/…`.
- `/status.json` exposes the same field as `productionCommit`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends status-page</b> (medium risk)</summary>

**Touches:** `status-page` (surfaces)

**Risk:** Medium — extends the public status snapshot and page rendering; no main-worker or deploy changes.

**Invariants:** None implicated (global operational telemetry only).

```mermaid
flowchart LR
  probe[Status prober cron] --> health["GET /health"]
  health --> commitSha[commitSha]
  commitSha --> meta[(Status DO meta)]
  meta --> page[status.heykody.dev footer]
  page --> github[GitHub commit link]
```

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ab4cb66-02a6-4c68-ad1f-0a9a266f99be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ab4cb66-02a6-4c68-ad1f-0a9a266f99be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status pages now display the latest production commit as a shortened, clickable repository link.
  * The production commit is shown only when available and is omitted otherwise.
  * Status data now reflects the commit reported by the production health endpoint.

* **Bug Fixes**
  * Improved validation and normalization of production commit information from health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->