### PR TITLE
Fix retriever timeout run observability

### DIFF
--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -16,6 +16,7 @@ import {
 	createExecuteExecutor,
 	createExecutorModuleSource,
 	createExecutorSandboxTimeoutMessage,
+	createNamedExecutionError,
 	createToolDispatchers,
 	extractRawContent,
 	formatExecutionOutput,
@@ -518,6 +519,43 @@ test('createExecuteExecutor returns sandbox timeout when Loader evaluate hangs',
 	expect(result.error).toContain('Execution timed out after 40ms:')
 	expect(result.result).toBeUndefined()
 	expect(Date.now() - startedAtMs).toBeLessThan(500)
+})
+
+test('createExecuteExecutor drains logs from an evaluation that settles just after the host timeout', async () => {
+	const timeoutMessage = createExecutorSandboxTimeoutMessage(20)
+	const loader = {
+		get(_id: string, factory: () => FakeWorkerOptions) {
+			factory()
+			return {
+				getEntrypoint() {
+					return {
+						async evaluate() {
+							await new Promise((resolve) => setTimeout(resolve, 40))
+							return {
+								result: undefined,
+								error: timeoutMessage,
+								logs: ['started context lookup'],
+							}
+						},
+					}
+				},
+			}
+		},
+	} as unknown as Env['LOADER']
+
+	const result = await createExecuteExecutor({
+		env: createExecutorTestEnv(loader),
+		exports: createExecutorTestExports(),
+		gatewayProps: createGatewayProps('drain-user'),
+		timeoutMs: 20,
+	}).execute('async () => "never"', [{ name: 'kody', fns: {} }])
+
+	expect(result).toEqual({
+		result: undefined,
+		error: timeoutMessage,
+		logs: ['started context lookup'],
+	})
+	expect(createNamedExecutionError(result.error).name).toBe('TimeoutError')
 })
 
 test('createExecuteExecutor aborts an in-flight abort-aware dispatcher on timeout', async () => {

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -63,6 +63,7 @@ const dynamicWorkerCacheKeyVersion = 3
 // Async-local state shares that budget with nested evaluations while keeping
 // unrelated requests out of the same queue.
 const maxConcurrentDynamicWorkerEvaluationsPerRequest = 4
+const hostEvaluationDrainGraceMs = 100
 const dynamicWorkerCapacityErrorMessages = [
 	'Too many concurrent dynamic workers',
 	'Dynamic worker concurrency limit exceeded: each request may have up to 4 concurrent dynamic worker invocations.',
@@ -165,6 +166,11 @@ type DynamicWorkerEvaluationContext = {
 	depth: number
 }
 
+class HostEvaluationTimeoutError<T> extends Error {
+	name = 'TimeoutError'
+	evaluationResult?: T
+}
+
 const dynamicWorkerEvaluationGateStorage =
 	new AsyncLocalStorage<DynamicWorkerEvaluationContext>()
 
@@ -262,7 +268,11 @@ export async function raceWithHostEvaluationDeadline<T>(
 		) {
 			timeoutId = setTimeout(
 				() =>
-					abortWith(new Error(createExecutorSandboxTimeoutMessage(timeoutMs))),
+					abortWith(
+						new HostEvaluationTimeoutError<T>(
+							createExecutorSandboxTimeoutMessage(timeoutMs),
+						),
+					),
 				Math.max(1, timeoutMs),
 			)
 		}
@@ -271,8 +281,22 @@ export async function raceWithHostEvaluationDeadline<T>(
 			if (externalSignal.aborted) onExternalAbort()
 		}
 	})
+	const evaluationPromise = Promise.resolve().then(
+		async () => await evaluate(controller.signal),
+	)
 	try {
-		return await Promise.race([evaluate(controller.signal), timeoutPromise])
+		return await Promise.race([evaluationPromise, timeoutPromise])
+	} catch (error) {
+		if (error instanceof HostEvaluationTimeoutError) {
+			const drained = await settleWithin(
+				evaluationPromise,
+				hostEvaluationDrainGraceMs,
+			)
+			if (drained.status === 'fulfilled') {
+				error.evaluationResult = drained.value
+			}
+		}
+		throw error
 	} finally {
 		if (timeoutId !== undefined) {
 			clearTimeout(timeoutId)
@@ -280,6 +304,44 @@ export async function raceWithHostEvaluationDeadline<T>(
 		externalSignal?.removeEventListener('abort', onExternalAbort)
 		rejectDeadline = undefined
 	}
+}
+
+async function settleWithin<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+): Promise<PromiseSettledResult<T> | { status: 'timed-out' }> {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			promise.then(
+				(value): PromiseFulfilledResult<T> => ({
+					status: 'fulfilled',
+					value,
+				}),
+				(reason): PromiseRejectedResult => ({
+					status: 'rejected',
+					reason,
+				}),
+			),
+			new Promise<{ status: 'timed-out' }>((resolve) => {
+				timeoutId = setTimeout(
+					() => resolve({ status: 'timed-out' }),
+					timeoutMs,
+				)
+			}),
+		])
+	} finally {
+		if (timeoutId !== undefined) clearTimeout(timeoutId)
+	}
+}
+
+export function createNamedExecutionError(error: unknown) {
+	const message = getErrorMessage(error)
+	const namedError = new Error(message)
+	if (isExecutorSandboxTimeoutMessage(message)) {
+		namedError.name = 'TimeoutError'
+	}
+	return namedError
 }
 
 async function runWithDynamicWorkerEvaluationPermit<T>(
@@ -554,10 +616,16 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 					const message = getErrorMessage(error)
 					if (isExecutorSandboxTimeoutMessage(message)) {
 						outcome = 'error'
+						const drainedResponse =
+							error instanceof HostEvaluationTimeoutError
+								? (error.evaluationResult as
+										| Awaited<ReturnType<DynamicWorkerEntrypoint['evaluate']>>
+										| undefined)
+								: undefined
 						return {
 							result: undefined,
-							error: message,
-							logs: [],
+							error: drainedResponse?.error ?? message,
+							logs: drainedResponse?.logs ?? [],
 						}
 					}
 					throw error

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -1688,6 +1688,14 @@ test('runModuleWithRegistry redacts secret keys and survives cyclic results', as
 				}
 				errorResult.cause = errorResult
 
+				if (returnRewriteFailure) {
+					return {
+						result: undefined,
+						error:
+							'Secret "spotifyAccessToken" is not allowed for capability "secret_set"',
+						logs: ['fresh-access-token before rewrite failure'],
+					}
+				}
 				return {
 					result: {
 						objectResult,
@@ -1698,12 +1706,8 @@ test('runModuleWithRegistry redacts secret keys and survives cyclic results', as
 				}
 			},
 		} as never)
-
-	try {
-		const result = await runModuleWithRegistry(
-			env,
-			callerContext,
-			`import { kody } from 'kody:runtime'
+	let returnRewriteFailure = false
+	const code = `import { kody } from 'kody:runtime'
 
 export default async function run() {
 	await kody.secret_set({
@@ -1711,8 +1715,10 @@ export default async function run() {
 		value: 'fresh-access-token',
 	})
 	return null
-}`,
-		)
+}`
+
+	try {
+		const result = await runModuleWithRegistry(env, callerContext, code)
 		const sanitized = result.result as {
 			objectResult: Record<string, unknown>
 			arrayResult: Array<unknown>
@@ -1731,6 +1737,43 @@ export default async function run() {
 		expect(sanitized.errorResult.cause).toBe(sanitized.errorResult)
 
 		expect(result.logs).toEqual(['[REDACTED SECRET] log'])
+
+		const runRecords = await import('#worker/run-records/service.ts')
+		const handle = {
+			id: 'run-redaction-catch',
+			userId: 'user-123',
+			startedAt: '2026-08-10T00:00:00.000Z',
+			persistence: 'on-failure' as const,
+			context: { surface: 'execute' as const },
+		}
+		const beginSpy = vi
+			.spyOn(runRecords, 'beginRunRecord')
+			.mockReturnValue(handle)
+		const finishSpy = vi
+			.spyOn(runRecords, 'finishRunRecord')
+			.mockResolvedValue(true)
+		const resolveSecretSpy = vi
+			.spyOn(secretService, 'resolveSecret')
+			.mockRejectedValue(new Error('post-execution rewrite failed'))
+		returnRewriteFailure = true
+		try {
+			await expect(
+				runModuleWithRegistry(env, callerContext, code, undefined, {
+					runRecord: { surface: 'execute' },
+				}),
+			).rejects.toThrow('post-execution rewrite failed')
+			expect(finishSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					handle,
+					status: 'error',
+					logs: ['[REDACTED SECRET] before rewrite failure'],
+				}),
+			)
+		} finally {
+			resolveSecretSpy.mockRestore()
+			finishSpy.mockRestore()
+			beginSpy.mockRestore()
+		}
 	} finally {
 		createExecuteExecutorSpy.mockRestore()
 		getRegistrySpy.mockRestore()

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2706,13 +2706,19 @@ test('runBundledModuleWithRegistry finishes execute run records on failure only'
 				logs: ['success log'],
 			}),
 		)
+		expect(handle.context.metadata).toEqual(
+			expect.objectContaining({
+				conversationId: 'conv-1',
+				sandboxMs: expect.any(Number),
+			}),
+		)
 		expect(persistedStatuses).toEqual([])
 
 		beginSpy.mockClear()
 		finishSpy.mockClear()
 		executeResult = {
 			result: undefined,
-			error: 'boom',
+			error: mcpExecutor.createExecutorSandboxTimeoutMessage(2_500),
 			logs: ['failure log'],
 		}
 		const failure = await runBundledModuleWithRegistry(
@@ -2730,13 +2736,18 @@ test('runBundledModuleWithRegistry finishes execute run records on failure only'
 				},
 			},
 		)
-		expect(failure.error).toBe('boom')
+		expect(failure.error).toBe(
+			mcpExecutor.createExecutorSandboxTimeoutMessage(2_500),
+		)
 		expect(finishSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
 				handle,
 				status: 'error',
 				logs: ['failure log'],
-				error: 'boom',
+				error: expect.objectContaining({
+					name: 'TimeoutError',
+					message: mcpExecutor.createExecutorSandboxTimeoutMessage(2_500),
+				}),
 			}),
 		)
 		expect(persistedStatuses).toEqual(['error'])

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -1158,8 +1158,8 @@ ${runtimeHelperRuntimePropertySource}
 					}
 				}
 			}
-			capturedLogs = result.logs
 			const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
+			capturedLogs = sanitizedResult.logs
 			if (!result.error) {
 				await finishObservedRun({
 					status: 'success',

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -10,7 +10,10 @@ import {
 import { exports as workerExports } from 'cloudflare:workers'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { normalizeRemoteConnectorRefs } from '@kody-internal/shared/remote-connectors.ts'
-import { createExecuteExecutor } from '#mcp/executor.ts'
+import {
+	createExecuteExecutor,
+	createNamedExecutionError,
+} from '#mcp/executor.ts'
 import { type RawFetchHostSink } from '#mcp/raw-fetch-host-nudge.ts'
 import {
 	getAdditionalPropertiesSchema,
@@ -896,6 +899,7 @@ export async function runBundledModuleWithRegistry(
 		})
 	let runRecordFinished = false
 	let exposeRunId = runRecordHandle?.persistence === 'eager'
+	let capturedLogs: Array<string> | undefined
 	// The metering span covers the whole bundled run (module hydration,
 	// provider assembly, and sandbox execution) so pre-executor failures are
 	// still counted as failed package runs.
@@ -1135,11 +1139,26 @@ ${runtimeHelperRuntimePropertySource}
 			]
 			await reportExecutePhaseProgress(reportProgress, 'sandbox')
 			const sandboxStartedAtMs = Date.now()
-			const result = await executor.execute(wrapped, providers)
-			runServerTiming.push({
-				name: 'sandbox',
-				durationMs: Date.now() - sandboxStartedAtMs,
-			})
+			let result: ExecuteResult
+			try {
+				result = await executor.execute(wrapped, providers)
+			} finally {
+				const sandboxMs = Date.now() - sandboxStartedAtMs
+				runServerTiming.push({
+					name: 'sandbox',
+					durationMs: sandboxMs,
+				})
+				if (runRecordHandle) {
+					runRecordHandle.context = {
+						...runRecordHandle.context,
+						metadata: {
+							...runRecordHandle.context.metadata,
+							sandboxMs,
+						},
+					}
+				}
+			}
+			capturedLogs = result.logs
 			const sanitizedResult = secretRedactor.sanitizeExecuteResult(result)
 			if (!result.error) {
 				await finishObservedRun({
@@ -1170,7 +1189,7 @@ ${runtimeHelperRuntimePropertySource}
 			await finishObservedRun({
 				status: 'error',
 				logs: finalResult.logs ?? [],
-				error: finalResult.error,
+				error: createNamedExecutionError(finalResult.error),
 			})
 			await recordPackageExportUsage('error')
 			return withRunId(finalResult)
@@ -1178,6 +1197,7 @@ ${runtimeHelperRuntimePropertySource}
 			if (!runRecordFinished) {
 				await finishObservedRun({
 					status: 'error',
+					logs: capturedLogs,
 					error,
 				})
 			}
@@ -1187,6 +1207,7 @@ ${runtimeHelperRuntimePropertySource}
 		if (!runRecordFinished) {
 			await finishObservedRun({
 				status: 'error',
+				logs: capturedLogs,
 				error,
 			})
 		}

--- a/packages/worker/src/package-retrievers/service.node.test.ts
+++ b/packages/worker/src/package-retrievers/service.node.test.ts
@@ -107,11 +107,13 @@ test('runPackageRetrievers soft-fails a timed-out retriever and keeps healthy re
 		packageId: 'pkg-healthy',
 		kodyId: 'healthy-pkg',
 		retrieverKey: 'notes',
+		scopes: ['context'],
 	})
 	const stalled = createRetrieverEntry({
 		packageId: 'pkg-stalled',
 		kodyId: 'stalled-pkg',
 		retrieverKey: 'inbox',
+		scopes: ['context'],
 	})
 	mockFns.listPackageRetrieversForScope.mockResolvedValue([healthy, stalled])
 	mockFns.getSavedPackageById.mockImplementation(
@@ -169,7 +171,7 @@ test('runPackageRetrievers soft-fails a timed-out retriever and keeps healthy re
 		env: { APP_DB: {}, BUNDLE_ARTIFACTS_KV: {} } as Env,
 		baseUrl: 'https://example.com',
 		userId: 'user-1',
-		scope: 'search',
+		scope: 'context',
 		query: 'notes',
 	})
 
@@ -185,4 +187,12 @@ test('runPackageRetrievers soft-fails a timed-out retriever and keeps healthy re
 	expect(run.warnings[0]).toMatch(/stalled-pkg\/inbox/)
 	expect(run.warnings[0]).toMatch(/timed out/i)
 	expect(consoleError).toHaveBeenCalledTimes(1)
+	expect(mockFns.runBundledModuleWithRegistry).toHaveBeenCalledTimes(2)
+	for (const call of mockFns.runBundledModuleWithRegistry.mock.calls) {
+		expect(call[4]).toEqual(
+			expect.objectContaining({
+				executorTimeoutMs: 2_500,
+			}),
+		)
+	}
 })

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -20,11 +20,12 @@ const defaultSearchLimit = 5
 const defaultContextLimit = 2
 const maxSearchLimit = 20
 const maxContextLimit = 3
-// Retrievers are optional enrichment. Keep budgets short so a slow package
-// cannot dominate search/execute wall time, but leave enough headroom for cold
-// isolate + packageStorage work. Individual failures must not fail the tool.
+// Retrievers are optional enrichment. Keep budgets bounded so a slow package
+// cannot dominate search/execute wall time, while leaving context retrievers
+// enough headroom for cold isolate + packageStorage work. Individual failures
+// must not fail the tool.
 const defaultSearchTimeoutMs = 3_000
-const defaultContextTimeoutMs = 1_000
+const defaultContextTimeoutMs = 2_500
 const maxSearchTimeoutMs = 5_000
 const maxContextTimeoutMs = 3_000
 const maxResultSummaryLength = 1_000

--- a/packages/worker/src/run-records/service.node.test.ts
+++ b/packages/worker/src/run-records/service.node.test.ts
@@ -61,11 +61,14 @@ test('finishRunRecord dispatches run.error.recorded only for persisted non-subsc
 		context: { surface: 'job', name: 'daily', jobId: 'job-1' },
 	})
 	expect(errorHandle).not.toBeNull()
+	const timeoutError = new Error('Execution timed out after 2.5s')
+	timeoutError.name = 'TimeoutError'
 	await finishRunRecord({
 		env,
 		handle: errorHandle,
 		status: 'error',
-		error: new Error('boom'),
+		logs: ['started context lookup'],
+		error: timeoutError,
 	})
 	expect(mocks.finishRun).toHaveBeenCalledTimes(1)
 	expect(mocks.dispatchRunErrorSubscriptionEvents).toHaveBeenCalledWith(
@@ -75,11 +78,22 @@ test('finishRunRecord dispatches run.error.recorded only for persisted non-subsc
 				id: errorHandle!.id,
 				status: 'error',
 				surface: 'job',
-				errorName: 'Error',
-				errorMessage: 'boom',
+				errorName: 'TimeoutError',
+				errorMessage: 'Execution timed out after 2.5s',
 			}),
 		}),
 	)
+	expect(mocks.finishRun).toHaveBeenCalledWith({
+		run: expect.objectContaining({
+			errorName: 'TimeoutError',
+		}),
+		logs: [
+			expect.objectContaining({
+				level: 'log',
+				message: 'started context lookup',
+			}),
+		],
+	})
 
 	mocks.dispatchRunErrorSubscriptionEvents.mockClear()
 	const successHandle = beginRunRecord({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make context retriever timeout runs reliable and diagnosable by allowing realistic cold-start work and preserving pre-timeout sandbox evidence without persisting secret-bearing raw logs.

## Summary

- raise the default context retriever sandbox budget from 1,000 ms to 2,500 ms (3,000 ms maximum unchanged)
- drain a host-timed-out evaluation for up to 100 ms and retain returned logs/error detail
- persist string execution failures as named errors (`TimeoutError` for sandbox deadlines)
- include `sandboxMs` in run metadata and preserve secret-redacted captured logs through registry catches

## Testing

- `npm run validate` — passed after the review fix (592 test files / 2,012 tests, 8 E2E, MCP suite, typecheck, lint, formatting, builds, and repository checks)
- focused run-registry regression suite — 16 passed, including post-execution fallback-log redaction

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `be5e29d5` · **Head:** `45219845`

**Classification:** extends — changes timeout handling and run-observability behavior without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — bounded post-timeout evaluation drain |
| `capabilities-execute` | runtime | extends — records sandbox timing and named errors; redacts fallback logs |
| `run-records` | storage | extends — retains timeout logs and meaningful error names |

### System map

Retriever execution flows through the sandbox deadline into per-user run history; this change preserves late-arriving diagnostic evidence while applying the existing secret redactor before every persistence path.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::extended
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	runRecords["run-records<br/>Run records"]:::extended
	mcpServer -->|"2.5s context budget + 100ms bounded drain"| capabilitiesExecute
	capabilitiesExecute -->|"redacted logs, TimeoutError, sandboxMs"| runRecords
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| context default 1,000 ms | context default 2,500 ms |
| host timeout fabricates `logs: []` | host timeout drains up to 100 ms for sandbox logs |
| timeout persisted as `Unknown` | timeout persisted as `TimeoutError` |
| total duration only | total duration plus `metadata.sandboxMs` |
| catch fallback could persist raw logs | catch fallback persists secret-redacted logs |

### Invariants

- `state-vs-history` remains intact: timing and logs are observational run history only.
- `no-per-event-shared-writes` remains intact: run data stays in the per-user RunLog Durable Object.
- `no-secrets-in-chat` is preserved across both normal and exceptional log-persistence paths.

</details>

<!-- system-recap:end -->

## Conductor report

- **Status:** DONE — squash-merged as `a5ccaed75c9c30966cc46d8262a6f6df0284ac76` and deployed to production
- **Evidence:** valid CodeRabbit fallback-log secret-redaction finding fixed with a post-execution throw regression; `npm run validate` passed after the fix in 4m55s (592 files / 2,012 tests, 8 E2E); [PR CI green](https://github.com/kentcdodds/kody/actions/runs/31421194968); [main validation green](https://github.com/kentcdodds/kody/actions/runs/31421784472); [production deploy green](https://github.com/kentcdodds/kody/actions/runs/31422712594) with healthcheck and execute smoke passing
- **Remains:** nothing
- **Reporting note:** direct `createRun` delivery to conductor `bc-36e11e67-e3f1-480c-ae42-5ad11ee70204` returned 409 twice (initial + required one-minute retry), so this full fallback report is recorded here and in Discord channel `1491568683737157683` (message `1536452481620377611`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91fd3bd7-6857-45a4-8868-dc7a010daf54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91fd3bd7-6857-45a4-8868-dc7a010daf54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling so delayed execution results preserve their specific timeout error type and logs.
  * Run records now retain timeout details, execution logs, and sandbox duration when executions fail or time out.
  * Increased the default context retrieval timeout to 2,500 milliseconds for more reliable bundled retrievals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->