### PR TITLE
fix(client): prevent blank and stalled SPA navigations

### DIFF
--- a/packages/worker/client/client-router-recovery.node.test.ts
+++ b/packages/worker/client/client-router-recovery.node.test.ts
@@ -1,0 +1,79 @@
+import { consoleError } from '#worker/test-support/console-spies.ts'
+import { expect, test, vi } from 'vitest'
+
+const lazyRouteMocks = vi.hoisted(() => {
+	let preloadCallCount = 0
+	let rejectRetry: ((reason?: unknown) => void) | null = null
+	const preloadClientRouteModules = vi.fn(() => {
+		preloadCallCount++
+		if (preloadCallCount === 1) {
+			return Promise.reject(new Error('first chunk failure'))
+		}
+		return new Promise<void>((_resolve, reject) => {
+			rejectRetry = reject
+		})
+	})
+
+	return {
+		preloadClientRouteModules,
+		failRetry() {
+			if (!rejectRetry) throw new Error('Chunk retry has not started')
+			rejectRetry(new Error('second chunk failure'))
+		},
+	}
+})
+
+vi.mock('./lazy-route.tsx', () => ({
+	isClientRouteModuleCached: () => false,
+	listenToLazyRouteLoads: () => {},
+	preloadClientRouteModules: lazyRouteMocks.preloadClientRouteModules,
+}))
+
+import { navigate, registerRouteLoaders } from './client-router.tsx'
+
+test('a loader error waits for chunk retry failure before recovering with full navigation', async () => {
+	const previousWindow = globalThis.window
+	const assign = vi.fn<() => void>()
+	const pushState = vi.fn<() => void>()
+	globalThis.window = {
+		history: { pushState },
+		location: {
+			href: 'https://kody.local/',
+			origin: 'https://kody.local',
+			pathname: '/',
+			search: '',
+			hash: '',
+			assign,
+		},
+	} as unknown as Window & typeof globalThis
+	consoleError.mockImplementation(() => {})
+	registerRouteLoaders({
+		'/lazy': async () => {
+			throw new Error('loader failed')
+		},
+	})
+
+	try {
+		navigate('/lazy')
+		await vi.waitFor(() => {
+			expect(lazyRouteMocks.preloadClientRouteModules).toHaveBeenCalledTimes(2)
+		})
+
+		expect(pushState).not.toHaveBeenCalled()
+		expect(assign).not.toHaveBeenCalled()
+
+		lazyRouteMocks.failRetry()
+		await vi.waitFor(() => {
+			expect(assign).toHaveBeenCalledWith('/lazy')
+		})
+
+		expect(pushState).not.toHaveBeenCalled()
+		expect(consoleError).toHaveBeenCalledWith(
+			'Route chunk preload failed:',
+			expect.any(Error),
+		)
+	} finally {
+		registerRouteLoaders({})
+		globalThis.window = previousWindow
+	}
+})

--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -1,11 +1,16 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import {
 	isSameShellAreaNavigation,
 	matchRoute,
 	matchRouteLoader,
+	navigate,
+	navigationTimeoutMs,
+	registerRouteLoaders,
+	Router,
 	shouldRouterHandleClick,
 	type RouteLoader,
 } from './client-router.tsx'
+import { communityArea } from './lazy-route.tsx'
 
 test('client route and loader matching prefer specific static routes over dynamic parents', () => {
 	const tokenDetailRoute = 'token-detail-route' as unknown as JSX.Element
@@ -137,6 +142,63 @@ test('same-origin hash links are intercepted so scroll restoration can reach the
 		} as unknown as HTMLAnchorElement
 		expect(shouldRouterHandleClick(click, externalAnchor)).toBe(false)
 	} finally {
+		globalThis.window = previousWindow
+	}
+})
+
+test('the router holds the previous route until a cold destination module is cached', async () => {
+	let url = '/pricing'
+	const pricingRoute = 'pricing-route' as unknown as JSX.Element
+	const communityRoute = 'community-route' as unknown as JSX.Element
+	const render = Router({
+		props: {
+			routes: {
+				'/pricing': pricingRoute,
+				'/community': communityRoute,
+			},
+		},
+		signal: new AbortController().signal,
+		update: vi.fn(),
+		context: {
+			get: () => ({ url, ssrUrl: '/pricing' }),
+		},
+	} as never)
+
+	expect(render()).toBe(pricingRoute)
+	url = '/community'
+	expect(render()).toBe(pricingRoute)
+
+	await communityArea.load()
+	expect(render()).toBe(communityRoute)
+})
+
+test('a navigation that exceeds the timeout falls back to a full document navigation', async () => {
+	vi.useFakeTimers()
+	const previousWindow = globalThis.window
+	const assign = vi.fn()
+	globalThis.window = {
+		location: {
+			href: 'https://kody.local/',
+			origin: 'https://kody.local',
+			pathname: '/',
+			search: '',
+			hash: '',
+			assign,
+		},
+	} as unknown as Window & typeof globalThis
+	registerRouteLoaders({
+		'/stuck': () => new Promise(() => {}),
+	})
+
+	try {
+		navigate('/stuck')
+		await vi.advanceTimersByTimeAsync(navigationTimeoutMs)
+
+		expect(assign).toHaveBeenCalledWith('/stuck')
+	} finally {
+		registerRouteLoaders({})
+		vi.clearAllTimers()
+		vi.useRealTimers()
 		globalThis.window = previousWindow
 	}
 })

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -665,6 +665,12 @@ async function runNavigationWithLoader(
 			commitNavigation(nextPath, finish)
 		}
 	} catch {
+		// Promise.all rejects as soon as the loader fails, even if the lazy chunk
+		// retry is still pending. Do not commit under the destination URL until
+		// that retry settles: Router intentionally keeps the previous route
+		// mounted while the chunk is cold, so committing early would also prevent
+		// the destination LazyRoute from mounting and running its own recovery.
+		await preloadPromise
 		if (signal.aborted) return
 		if (chunkLoadFailed) {
 			// The loader also failed, but the missing chunk is what makes SPA

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -7,7 +7,11 @@ import {
 	prefetchRouteOnIntent,
 	takePrefetchedRouteResult,
 } from './intent-prefetch.ts'
-import { preloadClientRouteModules } from './lazy-route.tsx'
+import {
+	isClientRouteModuleCached,
+	listenToLazyRouteLoads,
+	preloadClientRouteModules,
+} from './lazy-route.tsx'
 import {
 	markNavigationDataStale,
 	setPreloadedNavigationData,
@@ -58,6 +62,7 @@ type NavigationRunOptions = {
 } & RouterNavigateOptions
 
 const clientRouteOrigin = 'https://kody.local'
+export const navigationTimeoutMs = 10_000
 const routeMatchers = new WeakMap<
 	Record<string, JSX.Element>,
 	ReturnType<typeof createRouteMatcher>
@@ -565,6 +570,17 @@ async function runNavigationWithLoader(
 	const navigationEndDetail = createNavigationEventDetail(nextPath, options)
 	const loader = matchRouteLoader(destination)
 	activeNavigationPath = nextPath
+	const timeoutId = globalThis.setTimeout(() => {
+		// A newer navigation aborts this one and owns recovery. Only the active
+		// navigation may force the browser away from the current document.
+		if (signal.aborted || navigationAbortController !== abortController) return
+		abortController.abort()
+		dispatchNavigationEnd({
+			...navigationEndDetail,
+			preventScrollReset: true,
+		})
+		window.location.assign(nextPath)
+	}, navigationTimeoutMs)
 
 	// Adopt an intent prefetch when one is pending or fresh for this
 	// destination; otherwise run the loader now. Tying the prefetch to this
@@ -673,6 +689,7 @@ async function runNavigationWithLoader(
 			commitNavigation(nextPath, finish)
 		}
 	} finally {
+		globalThis.clearTimeout(timeoutId)
 		// A superseding navigation owns the marker now; only clear our own.
 		if (navigationAbortController === abortController) {
 			activeNavigationPath = null
@@ -953,8 +970,13 @@ type RouterHandle = Pick<Handle, 'signal' | 'update' | 'context'> & {
 }
 
 export function Router(handle: RouterHandle) {
+	let renderedRouteElement: JSX.Element | null = null
+
 	if (typeof document !== 'undefined') {
 		listenToRouterNavigation(handle, () => {
+			void handle.update()
+		})
+		listenToLazyRouteLoads(handle, () => {
 			void handle.update()
 		})
 	}
@@ -968,7 +990,20 @@ export function Router(handle: RouterHandle) {
 
 		const path = readRouterPathname(handle)
 		const routeElement = matchRoute(path, handle.props.routes)
-		if (routeElement) return routeElement
+		if (routeElement) {
+			// Navigation normally preloads lazy areas before commit. If a loader
+			// fails early or another edge case commits first, keep the previous
+			// route mounted until the destination chunk reports that it is ready.
+			if (
+				renderedRouteElement &&
+				!isClientRouteModuleCached(readRouterUrl(handle))
+			) {
+				return renderedRouteElement
+			}
+			renderedRouteElement = routeElement
+			return routeElement
+		}
+		renderedRouteElement = null
 		return handle.props.fallback ?? null
 	}
 }

--- a/packages/worker/client/lazy-route.node.test.ts
+++ b/packages/worker/client/lazy-route.node.test.ts
@@ -96,7 +96,6 @@ test('a cold lazy route renders a fallback and retries once before full navigati
 
 		expect(loadModule).toHaveBeenCalledTimes(2)
 		expect(assign).toHaveBeenCalledWith('/community?q=tools#results')
-		expect(update).not.toHaveBeenCalled()
 	} finally {
 		vi.clearAllTimers()
 		vi.useRealTimers()

--- a/packages/worker/client/lazy-route.node.test.ts
+++ b/packages/worker/client/lazy-route.node.test.ts
@@ -1,5 +1,9 @@
-import { expect, test } from 'vitest'
-import { clientRouteAreaNameForPath } from '#client/lazy-route.tsx'
+import { expect, test, vi } from 'vitest'
+import {
+	clientRouteAreaNameForPath,
+	createLazyRoute,
+	createLazyRouteArea,
+} from '#client/lazy-route.tsx'
 import { clientRouteLoaders, clientRoutes } from '#client/routes/index.tsx'
 import { oauthPaths } from '#universal/oauth-paths.ts'
 import { routePattern } from '#universal/route-pattern.ts'
@@ -52,5 +56,50 @@ test('every non-eager route pattern resolves to a registered lazy area', () => {
 				`lazy pattern ${pattern} must be registered`,
 			).not.toBeNull()
 		}
+	}
+})
+
+test('a cold lazy route renders a fallback and retries once before full navigation recovery', async () => {
+	vi.useFakeTimers()
+	const previousWindow = globalThis.window
+	const assign = vi.fn()
+	globalThis.window = {
+		location: {
+			pathname: '/community',
+			search: '?q=tools',
+			hash: '#results',
+			assign,
+		},
+	} as unknown as Window & typeof globalThis
+
+	try {
+		const loadModule = vi.fn<() => Promise<{ value: JSX.Element }>>()
+		loadModule.mockRejectedValue(new Error('chunk unavailable'))
+		const area = createLazyRouteArea(loadModule)
+		let queuedTask: ((signal: AbortSignal) => Promise<void> | void) | undefined
+		const update = vi.fn()
+		const LazyRoute = createLazyRoute(area)
+		const render = LazyRoute({
+			props: {
+				render: (module) => module.value,
+			},
+			queueTask(task) {
+				queuedTask = task
+			},
+			update,
+		} as never)
+
+		expect(render()).not.toBeNull()
+		expect(queuedTask).toBeTypeOf('function')
+
+		await queuedTask?.(new AbortController().signal)
+
+		expect(loadModule).toHaveBeenCalledTimes(2)
+		expect(assign).toHaveBeenCalledWith('/community?q=tools#results')
+		expect(update).not.toHaveBeenCalled()
+	} finally {
+		vi.clearAllTimers()
+		vi.useRealTimers()
+		globalThis.window = previousWindow
 	}
 })

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -1,9 +1,11 @@
-import { type Handle } from 'remix/ui'
+import { addEventListeners, css, type Handle } from 'remix/ui'
 import { createMultiMatcher } from 'remix/route-pattern/match'
 import { oauthPaths } from '#universal/oauth-paths.ts'
 import { routePattern } from '#universal/route-pattern.ts'
 import { routes } from '#universal/routes.ts'
+import { colors, spacing } from '#universal/styles/tokens.ts'
 import { type RouteLoader } from './route-loader.ts'
+import { createSpinDelay } from './spin-delay.ts'
 import type * as accountAreaExports from './routes/account-area.ts'
 import type * as adminAreaExports from './routes/admin-area.ts'
 import type * as blogAreaExports from './routes/blog-area.ts'
@@ -14,6 +16,8 @@ export type LazyRouteArea<TModule> = {
 	load: () => Promise<TModule>
 	getCached: () => TModule | null
 }
+
+const lazyRouteEvents = new EventTarget()
 
 export function createLazyRouteArea<TModule>(
 	loadModule: () => Promise<TModule>,
@@ -28,6 +32,7 @@ export function createLazyRouteArea<TModule>(
 				pending = loadModule()
 					.then((module) => {
 						cached = module
+						lazyRouteEvents.dispatchEvent(new Event('load'))
 						return module
 					})
 					.finally(() => {
@@ -95,40 +100,70 @@ type LazyRouteRenderProps<TModule> = {
  * keeps `TModule` in the `render` callback (JSX generics on `Handle` props
  * do not infer through `<LazyRoute area={...} />`).
  *
- * Reads the module-level cache synchronously; when cold, kicks off `load()`
- * and returns null until the chunk arrives. SSR, hydration, and SPA
- * navigation preload the matching area before commit, so the async path is a
- * safety net.
+ * Reads the module-level cache synchronously; when cold, kicks off `load()` and
+ * renders a delayed content-area fallback until the chunk arrives. SSR,
+ * hydration, and SPA navigation preload the matching area before commit, so
+ * the async path is a safety net.
  */
 type LazyRouteComponent<TModule> = (
 	handle: Handle<LazyRouteRenderProps<TModule>>,
-) => () => JSX.Element | null
+) => () => JSX.Element
 
 export function createLazyRoute<TModule>(
 	area: LazyRouteArea<TModule>,
 ): LazyRouteComponent<TModule> {
 	return function LazyRoute(handle: Handle<LazyRouteRenderProps<TModule>>) {
 		let loadStarted = false
+		const spinDelay = createSpinDelay(handle)
 
 		return () => {
 			const { render } = handle.props
 			const module = area.getCached()
-			if (module) return render(module)
+			if (module) {
+				spinDelay.setLoading(false)
+				return render(module)
+			}
 
 			if (!loadStarted) {
 				loadStarted = true
+				spinDelay.setLoading(true)
 				handle.queueTask(async (signal) => {
 					try {
 						await area.load()
 					} catch {
-						return
+						try {
+							await area.load()
+						} catch {
+							if (signal.aborted || typeof window === 'undefined') return
+							window.location.assign(
+								`${window.location.pathname}${window.location.search}${window.location.hash}`,
+							)
+							return
+						}
 					}
 					if (signal.aborted) return
 					handle.update()
 				})
 			}
 
-			return null
+			return (
+				<section
+					aria-busy="true"
+					aria-label="Loading page"
+					mix={css({
+						minHeight: '12rem',
+						display: 'grid',
+						placeItems: 'center',
+						color: colors.textMuted,
+					})}
+				>
+					{spinDelay.isShowing ? (
+						<p role="status" mix={css({ margin: 0, padding: spacing.lg })}>
+							Loading page…
+						</p>
+					) : null}
+				</section>
+			)
 		}
 	}
 }
@@ -160,6 +195,7 @@ type PreloadArea = {
 	/** Chunk name of the area barrel (matches the built `assets/<name>-<hash>.js`). */
 	name: string
 	load: () => Promise<unknown>
+	getCached: () => unknown | null
 }
 
 const preloadMatcher = createMultiMatcher<PreloadArea>()
@@ -213,7 +249,11 @@ registerPreloadPatterns(
 		routePattern(routes.accountEmailDetail),
 		routePattern(routes.accountTwoFactor),
 	],
-	{ name: 'account-area', load: accountArea.load },
+	{
+		name: 'account-area',
+		load: accountArea.load,
+		getCached: accountArea.getCached,
+	},
 )
 
 registerPreloadPatterns(
@@ -233,7 +273,7 @@ registerPreloadPatterns(
 		routePattern(routes.adminPlatformFeedback),
 		routePattern(routes.adminSystemEmail),
 	],
-	{ name: 'admin-area', load: adminArea.load },
+	{ name: 'admin-area', load: adminArea.load, getCached: adminArea.getCached },
 )
 
 registerPreloadPatterns(
@@ -243,7 +283,11 @@ registerPreloadPatterns(
 		routePattern(routes.profile),
 		routePattern(routes.timeline),
 	],
-	{ name: 'community-area', load: communityArea.load },
+	{
+		name: 'community-area',
+		load: communityArea.load,
+		getCached: communityArea.getCached,
+	},
 )
 
 registerPreloadPatterns(
@@ -253,7 +297,7 @@ registerPreloadPatterns(
 		routePattern(routes.guides),
 		routePattern(routes.guideDetail),
 	],
-	{ name: 'blog-area', load: blogArea.load },
+	{ name: 'blog-area', load: blogArea.load, getCached: blogArea.getCached },
 )
 
 registerPreloadPatterns(
@@ -262,8 +306,26 @@ registerPreloadPatterns(
 		routePattern(routes.connectOauth),
 		oauthPaths.authorize,
 	],
-	{ name: 'onboarding-area', load: onboardingArea.load },
+	{
+		name: 'onboarding-area',
+		load: onboardingArea.load,
+		getCached: onboardingArea.getCached,
+	},
 )
+
+export function isClientRouteModuleCached(pathnameWithSearch: string) {
+	const url = new URL(pathnameWithSearch, clientRouteOrigin)
+	const match = preloadMatcher.match(url)
+	return match ? match.data.getCached() !== null : true
+}
+
+export function listenToLazyRouteLoads(
+	handle: Pick<Handle, 'signal'>,
+	listener: () => void,
+) {
+	if (typeof document === 'undefined') return
+	addEventListeners(lazyRouteEvents, handle.signal, { load: listener })
+}
 
 /**
  * Warms the lazy route chunk for `pathnameWithSearch` (pathname + search).

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -120,7 +120,15 @@ export function CommunityRoute(handle: Handle) {
 					/>
 				</header>
 
-				<Frame name={COMMUNITY_LISTINGS_TARGET} src={frameSrc} />
+				<Frame
+					name={COMMUNITY_LISTINGS_TARGET}
+					src={frameSrc}
+					fallback={
+						<p role="status" mix={css(communityFrameFallbackCss)}>
+							Loading community packages…
+						</p>
+					}
+				/>
 
 				<div mix={css(communityCloseCss)}>
 					<p>
@@ -265,6 +273,14 @@ const communityCloseCss = {
 		color: colors.textMuted,
 		fontSize: '0.98rem',
 	},
+}
+
+const communityFrameFallbackCss = {
+	minHeight: '16rem',
+	display: 'grid',
+	placeItems: 'center',
+	margin: 0,
+	color: colors.textMuted,
 }
 
 const closeButtonCss = mergeCss(getGhostButtonCss(), {

--- a/packages/worker/client/spin-delay.ts
+++ b/packages/worker/client/spin-delay.ts
@@ -1,5 +1,3 @@
-import { type Handle } from 'remix/ui'
-
 type SpinDelayState = 'IDLE' | 'DELAY' | 'DISPLAY' | 'EXPIRE'
 
 type SpinDelayOptions = {
@@ -14,7 +12,10 @@ const defaultOptions = {
 	ssr: true,
 } as const satisfies Required<SpinDelayOptions>
 
-export function createSpinDelay(handle: Handle, options?: SpinDelayOptions) {
+export function createSpinDelay(
+	handle: { update: () => unknown },
+	options?: SpinDelayOptions,
+) {
 	const resolvedOptions = {
 		...defaultOptions,
 		...options,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep heykody.app client-side navigation responsive and recoverable when route chunks or loaders are slow, hung, or unavailable.

## Summary

- hold the previously rendered route until a cold lazy destination is cached
- render a spin-delayed content fallback and retry lazy chunk imports once before full navigation recovery
- keep loader-error navigation uncommitted until the destination chunk retry settles, preventing a stale route at the new URL
- force a full document navigation after a 10-second loader timeout
- add a loading fallback for the community listings frame
- cover cold-route, chunk-failure, post-loader-error recovery, and timeout behavior in client unit tests

## Testing

- `npx vitest run --project node-unit packages/worker/client/client-router-recovery.node.test.ts packages/worker/client/client-router.node.test.ts packages/worker/client/lazy-route.node.test.ts` — 8 passed
- `npm run validate` — passed (593 files, 2,015 tests, and Playwright; one two-factor E2E attempt retried and passed)
- PR CI — all required checks passed, including Node, Workers, E2E, MCP, Static, Bugbot, and CodeRabbit
- Manual SPA navigation: Pricing → Blog retained visible main content and fully loaded the lazy Blog route

<a href="https://cursor.com/agents/bc-c245cf5b-878f-42f9-87e3-67053e856329/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcold_blog_navigation_stays_visible_trimmed.mp4"><img src="https://cursor.com/artifacts/c/art-119a8fd8-c9a8-4740-b7c0-a99d5e283aae" alt="cold_blog_navigation_stays_visible_trimmed.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `be5e29d5` · **Head:** `b9a8d26a`

**Classification:** extends — changes browser navigation failure handling and community-frame loading behavior; no primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — holds prior routes, retries chunks, waits for retry outcomes, and times out stalled navigation |
| `community-listings` | assistant | extends — renders an explicit frame loading fallback |

### System map

SPA navigation now keeps the current browser app route visible until destination code is ready, while community listings expose their own loading state.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	communityListings["community-listings<br/>Community package listings"]:::extended
	appUi -->|"lazy route hold + frame fallback"| communityListings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart LR
	click["SPA navigation"] --> load["loader + lazy chunk retry"]
	load -->|"ready"| commit["commit destination route"]
	load -->|"chunk fails twice"| document["full document navigation"]
	load -->|"10s timeout"| document
	commit --> frame["community frame fallback while streaming"]
```

</details>

<!-- system-recap:end -->

## Conductor report

- **Status:** DONE — squash-merged as `45a249ce`; valid Bugbot stale-route finding fixed
- **Evidence:** focused tests 8/8; full validation 2,015/2,015; [main CI green](https://github.com/kentcdodds/kody/actions/runs/31421784472); [production deploy succeeded](https://github.com/kentcdodds/kody/actions/runs/31422712594); production `/health` reports `eee75d1f`, which contains the merge
- **Remains:** nothing
- **Reporting note:** conductor `createRun` returned 409 after the required one-minute retry; this full report was posted here and to Discord channel `1491568683737157683`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c245cf5b-878f-42f9-87e3-67053e856329?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c245cf5b-878f-42f9-87e3-67053e856329&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer loading indicators while route and community content loads.
  - Navigation now preserves the current page until the destination is ready.
  - Added automatic recovery and retry handling for failed route loads.

- **Bug Fixes**
  - Navigation now falls back to a full-page redirect if loading takes too long.
  - Improved handling of persistent route-loading failures, including retaining URL query and hash details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->