### PR TITLE
Make capability validation errors agent-readable

### DIFF
--- a/packages/worker/src/mcp/capabilities/define-capability.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/define-capability.node.test.ts
@@ -60,15 +60,17 @@ test('Zod capability validation failures identify the capability, fields, and re
 		.catch((error: unknown) => error)
 
 	expect(outputHandler).toHaveBeenCalledOnce()
-	expect(outputError).toBeInstanceOf(McpCallerError)
+	expect(outputError).toBeInstanceOf(Error)
+	expect(outputError).not.toBeInstanceOf(McpCallerError)
 	expect(outputError).toMatchObject({
 		message: expect.stringContaining(
-			'Invalid output from capability "package_save".',
+			'Capability "package_save" returned an invalid output shape.',
 		),
 		cause: expect.any(z.ZodError),
 	})
 	expect(outputError.message).toContain('package_id')
 	expect(outputError.message).toContain(
-		'Call search({ entity: "package_save:capability" }) for the exact input shape.',
+		'This is a capability implementation error; changing the input shape will not repair it.',
 	)
+	expect(outputError.message).not.toContain('Call search')
 })

--- a/packages/worker/src/mcp/capabilities/define-capability.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/define-capability.node.test.ts
@@ -1,0 +1,74 @@
+import { expect, test, vi } from 'vitest'
+import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { defineCapability } from './define-capability.ts'
+
+function createCapabilityContext() {
+	return {
+		env: {} as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+			},
+		}),
+	}
+}
+
+test('Zod capability validation failures identify the capability, fields, and repair path', async () => {
+	const inputHandler = vi.fn(async () => ({ package_id: 'github' }))
+	const inputCapability = defineCapability({
+		name: 'package_get',
+		domain: 'packages',
+		description: 'Get a package.',
+		inputSchema: z.object({ package_id: z.string() }),
+		outputSchema: z.object({ package_id: z.string() }),
+		handler: inputHandler,
+	})
+
+	const inputError = await inputCapability
+		.handler({ kody_id: 'github' }, createCapabilityContext())
+		.catch((error: unknown) => error)
+
+	expect(inputError).toBeInstanceOf(McpCallerError)
+	expect(inputError).toMatchObject({
+		message: expect.stringContaining(
+			'Invalid input for capability "package_get".',
+		),
+		cause: expect.any(z.ZodError),
+	})
+	expect(inputError.message).toContain('package_id')
+	expect(inputError.message).toContain(
+		'Call search({ entity: "package_get:capability" }) for the exact input shape.',
+	)
+	expect(inputHandler).not.toHaveBeenCalled()
+
+	const outputHandler = vi.fn(async () => ({ package_id: 123 }) as never)
+	const outputCapability = defineCapability({
+		name: 'package_save',
+		domain: 'packages',
+		description: 'Save a package.',
+		inputSchema: z.object({ package_id: z.string() }),
+		outputSchema: z.object({ package_id: z.string() }),
+		handler: outputHandler,
+	})
+
+	const outputError = await outputCapability
+		.handler({ package_id: 'github' }, createCapabilityContext())
+		.catch((error: unknown) => error)
+
+	expect(outputHandler).toHaveBeenCalledOnce()
+	expect(outputError).toBeInstanceOf(McpCallerError)
+	expect(outputError).toMatchObject({
+		message: expect.stringContaining(
+			'Invalid output from capability "package_save".',
+		),
+		cause: expect.any(z.ZodError),
+	})
+	expect(outputError.message).toContain('package_id')
+	expect(outputError.message).toContain(
+		'Call search({ entity: "package_save:capability" }) for the exact input shape.',
+	)
+})

--- a/packages/worker/src/mcp/capabilities/define-capability.ts
+++ b/packages/worker/src/mcp/capabilities/define-capability.ts
@@ -4,6 +4,7 @@ import {
 	errorFields,
 	logMcpEvent,
 } from '#mcp/observability.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import {
 	type Capability,
 	type CapabilityDefinition,
@@ -118,7 +119,12 @@ export function defineCapability<
 			try {
 				parsedArgs = inputParser(args) as InferCapabilitySchema<TInputSchema>
 			} catch (error) {
-				const { errorName, errorMessage } = errorFields(error)
+				const callerError = createCapabilityValidationError(
+					error,
+					definition.name,
+					'input',
+				)
+				const { errorName, errorMessage } = errorFields(callerError)
 				logMcpEvent({
 					category: 'mcp',
 					tool: 'capability',
@@ -131,9 +137,9 @@ export function defineCapability<
 					failurePhase: 'parse_input',
 					errorName,
 					errorMessage,
-					cause: error,
+					cause: callerError,
 				})
-				throw error
+				throw callerError
 			}
 
 			let result: Awaited<ReturnType<typeof definition.handler>>
@@ -172,7 +178,12 @@ export function defineCapability<
 				})
 				return finalized
 			} catch (error) {
-				const { errorName, errorMessage } = errorFields(error)
+				const callerError = createCapabilityValidationError(
+					error,
+					definition.name,
+					'output',
+				)
+				const { errorName, errorMessage } = errorFields(callerError)
 				logMcpEvent({
 					category: 'mcp',
 					tool: 'capability',
@@ -185,12 +196,30 @@ export function defineCapability<
 					failurePhase: 'parse_output',
 					errorName,
 					errorMessage,
-					cause: error,
+					cause: callerError,
 				})
-				throw error
+				throw callerError
 			}
 		},
 	}
+}
+
+function createCapabilityValidationError(
+	error: unknown,
+	capabilityName: string,
+	valueKind: 'input' | 'output',
+) {
+	if (!(error instanceof z.ZodError)) return error
+
+	const direction = valueKind === 'input' ? 'for' : 'from'
+	return new McpCallerError(
+		[
+			`Invalid ${valueKind} ${direction} capability "${capabilityName}".`,
+			z.prettifyError(error),
+			`Repair: Call search({ entity: "${capabilityName}:capability" }) for the exact input shape.`,
+		].join('\n'),
+		{ cause: error },
+	)
 }
 
 function mergeKeywords(

--- a/packages/worker/src/mcp/capabilities/define-capability.ts
+++ b/packages/worker/src/mcp/capabilities/define-capability.ts
@@ -178,12 +178,12 @@ export function defineCapability<
 				})
 				return finalized
 			} catch (error) {
-				const callerError = createCapabilityValidationError(
+				const validationError = createCapabilityValidationError(
 					error,
 					definition.name,
 					'output',
 				)
-				const { errorName, errorMessage } = errorFields(callerError)
+				const { errorName, errorMessage } = errorFields(validationError)
 				logMcpEvent({
 					category: 'mcp',
 					tool: 'capability',
@@ -196,9 +196,9 @@ export function defineCapability<
 					failurePhase: 'parse_output',
 					errorName,
 					errorMessage,
-					cause: callerError,
+					cause: validationError,
 				})
-				throw callerError
+				throw validationError
 			}
 		},
 	}
@@ -211,12 +211,22 @@ function createCapabilityValidationError(
 ) {
 	if (!(error instanceof z.ZodError)) return error
 
-	const direction = valueKind === 'input' ? 'for' : 'from'
-	return new McpCallerError(
+	if (valueKind === 'input') {
+		return new McpCallerError(
+			[
+				`Invalid input for capability "${capabilityName}".`,
+				z.prettifyError(error),
+				`Repair: Call search({ entity: "${capabilityName}:capability" }) for the exact input shape.`,
+			].join('\n'),
+			{ cause: error },
+		)
+	}
+
+	return new Error(
 		[
-			`Invalid ${valueKind} ${direction} capability "${capabilityName}".`,
+			`Capability "${capabilityName}" returned an invalid output shape.`,
 			z.prettifyError(error),
-			`Repair: Call search({ entity: "${capabilityName}:capability" }) for the exact input shape.`,
+			'This is a capability implementation error; changing the input shape will not repair it.',
 		].join('\n'),
 		{ cause: error },
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make Zod-backed capability input validation failures actionable for agents instead of exposing raw serialized issue arrays, while keeping invalid capability outputs reportable as server defects.

## Summary

- Wrap Zod input validation failures in `McpCallerError` with the capability name, prettified field-level issues, and a `search` repair hint.
- Format Zod output validation failures as readable system errors so observability continues reporting capability implementation bugs to Sentry.
- Preserve `parse_input` and `parse_output` observability phases.
- Cover wrong-key input and invalid output behavior with Node unit tests.

## Testing

- `npx vitest run packages/worker/src/mcp/capabilities/define-capability.node.test.ts --project node-unit` — 1 file / 1 test passed after reviewer fixes.
- PR CI — all checks green, including Node, Workers, E2E, MCP, Static, Validate, Bugbot, and CodeRabbit.
- Post-merge main validation and production deployment passed, including production healthcheck and execute smoke check.
- The authoritative local `npm run validate` passed before the reviewer adjustment. Two post-adjustment attempts were blocked by the Cloud VM's `workerd` DNS failure for `artifacts-mock.test`; the focused changed test and the equivalent split CI gates passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `be5e29d5` · **Head:** `6d5f86a2`

**Classification:** extends — changes the capability registry's runtime validation error contract without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | extends — Zod input failures become caller-readable; invalid outputs remain reportable system errors |

### System map

Capability execution enters the registry, where this change formats schema failures before they cross back to the MCP caller while preserving server-error reporting for invalid outputs.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::untouched
	capabilityRegistry["capability-registry<br/>Capability registry"]:::extended
	mcpServer -->|"execute input/output validation"| capabilityRegistry
	capabilityRegistry -->|"caller-readable input errors; reportable output errors"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Raw JSON-stringified Zod input issue array | Capability name, prettified field issues, and exact-schema search hint |
| Raw JSON-stringified Zod output issue array | Readable implementation-error message that remains eligible for Sentry |

</details>

<!-- system-recap:end -->

## Conductor report

**Status:** DONE — squash-merged and deployed.

**Evidence:** merged commit `eee75d1fc75b09020b4b685b1335c8d13991eca9`; both valid Bugbot findings fixed in `6d5f86a2`; focused regression test passed; [PR CI](https://github.com/kentcdodds/kody/actions/runs/31421130864), [post-merge main validation](https://github.com/kentcdodds/kody/actions/runs/31421784472), and [production deploy](https://github.com/kentcdodds/kody/actions/runs/31422712594) all passed. Production healthcheck, execute smoke, Sentry source-map upload, and capability-vector reindex succeeded. Discord summary message `1536452436217303100` was posted to channel `1491568683737157683`.

**Remains:** nothing. The required `createRun` report returned Cursor API 409 both initially and after the mandated one-minute retry, so this full report is recorded here and in Discord per fallback policy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d1c58b3-e8f2-4cff-a25a-d2fef84cb08a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d1c58b3-e8f2-4cff-a25a-d2fef84cb08a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid capability inputs and outputs.
  * Error messages now identify the affected capability and provide guidance for correcting validation failures.
  * Preserved detailed validation information and underlying error causes for clearer troubleshooting.
  * Prevented handlers from running when input validation fails.
  * Added clearer guidance when capability output validation fails, indicating an implementation issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->