### PR TITLE
Preserve community fork provenance across republish

### DIFF
--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -599,6 +599,14 @@ package summary. Ranked **search** excludes hidden packages unless the caller
 passes **`includeHiddenPackages: true`**. Known-id **`entity`** lookups still
 resolve hidden packages.
 
+Those two package capabilities also return community-fork provenance:
+**`source_listing_id`** is the listing the package was forked from,
+**`listing_current`** reports whether that ID is still an active listing, and
+**`listing_kody_id`** is the source listing's recorded `kody.id`. All three are
+`null` for self-authored packages. If a source is unpublished, `listing_current`
+becomes `false`; republishing the same source package moves prior forks to the
+new listing ID.
+
 ## Author a saved package via direct git push
 
 Saved package source is backed by a Cloudflare Artifacts git repository. You can

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -9,7 +9,10 @@ import { communityReportCapability } from '#mcp/capabilities/community/report.ts
 import { communitySearchCapability } from '#mcp/capabilities/community/search.ts'
 import { communitySetFeaturedCapability } from '#mcp/capabilities/community/set-featured.ts'
 import { communitySetTrustedCapability } from '#mcp/capabilities/community/set-trusted.ts'
+import { communityUnpublishCapability } from '#mcp/capabilities/community/unpublish.ts'
 import { communityContentWarning } from '#mcp/capabilities/community/shared.ts'
+import { getPackageCapability } from '#mcp/capabilities/packages/get-package.ts'
+import { listPackagesCapability } from '#mcp/capabilities/packages/list-packages.ts'
 import { callerCanAccessCapability } from '#mcp/capabilities/access-control.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import {
@@ -664,6 +667,29 @@ test('one-click install publishes clean listings and keeps unresolvable forks in
 		kody_id: cleanKodyId,
 		source_id: installed.sourceId,
 	})
+	const installedPackage = await getPackageCapability.handler(
+		{ package_id: installed.packageId },
+		createCapabilityContext(testEnv, installer),
+	)
+	expect(installedPackage).toMatchObject({
+		source_listing_id: cleanListing.listing_id,
+		listing_current: true,
+		listing_kody_id: cleanKodyId,
+	})
+	const installerPackages = await listPackagesCapability.handler(
+		{},
+		createCapabilityContext(testEnv, installer),
+	)
+	expect(installerPackages.packages).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				package_id: installed.packageId,
+				source_listing_id: cleanListing.listing_id,
+				listing_current: true,
+				listing_kody_id: cleanKodyId,
+			}),
+		]),
+	)
 
 	// A listing whose code imports another user's scope cannot auto-publish:
 	// the fork stays inert with the failing checks reported for follow-up.
@@ -710,5 +736,53 @@ test('one-click install publishes clean listings and keeps unresolvable forks in
 	expect(inertSource).toEqual({
 		id: adaptationRequired.sourceId,
 		user_id: installer.userId,
+	})
+
+	await communityUnpublishCapability.handler(
+		{ listing_id: cleanListing.listing_id },
+		ownerCtx,
+	)
+	const packageAfterUnpublish = await getPackageCapability.handler(
+		{ package_id: installed.packageId },
+		createCapabilityContext(testEnv, installer),
+	)
+	expect(packageAfterUnpublish).toMatchObject({
+		source_listing_id: cleanListing.listing_id,
+		listing_current: false,
+		listing_kody_id: cleanKodyId,
+	})
+
+	const republishedListing = await communityPublishCapability.handler(
+		{ package_id: `package-clean-${unique}` },
+		ownerCtx,
+	)
+	expect(republishedListing.listing_id).not.toBe(cleanListing.listing_id)
+
+	const packageAfterRepublish = await getPackageCapability.handler(
+		{ package_id: installed.packageId },
+		createCapabilityContext(testEnv, installer),
+	)
+	expect(packageAfterRepublish).toMatchObject({
+		source_listing_id: republishedListing.listing_id,
+		listing_current: true,
+		listing_kody_id: cleanKodyId,
+	})
+	await communityRateCapability.handler(
+		{
+			listing_id: republishedListing.listing_id,
+			stars: 5,
+			adaptation_effort: 1,
+			note: 'Still useful after republishing',
+		},
+		createCapabilityContext(testEnv, installer),
+	)
+	const republishedDetail = await communityGetCapability.handler(
+		{ listing_id: republishedListing.listing_id },
+		createCapabilityContext(testEnv, installer),
+	)
+	expect(republishedDetail).toMatchObject({
+		rating_count: 1,
+		average_stars: 5,
+		fork_count: 1,
 	})
 }, 120_000)

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -19,6 +19,7 @@ const mockModule = vi.hoisted(() => ({
 	deleteCommunityStarsByListingId: vi.fn(),
 	writeCommunitySnapshot: vi.fn(),
 	insertCommunityListing: vi.fn(),
+	repointOrphanedCommunityForksToListing: vi.fn(),
 	updateCommunityListing: vi.fn(),
 	getCommunityForkByListingAndUser: vi.fn(),
 	getCommunityForkByForkedPackageId: vi.fn(),
@@ -106,6 +107,8 @@ vi.mock('./repo.ts', async (importOriginal) => {
 			mockModule.countCommunityForksByListingIds(...args),
 		insertCommunityListing: (...args: Array<unknown>) =>
 			mockModule.insertCommunityListing(...args),
+		repointOrphanedCommunityForksToListing: (...args: Array<unknown>) =>
+			mockModule.repointOrphanedCommunityForksToListing(...args),
 		updateCommunityListing: (...args: Array<unknown>) =>
 			mockModule.updateCommunityListing(...args),
 		getCommunityForkByListingAndUser: (...args: Array<unknown>) =>

--- a/packages/worker/src/community/repo.ts
+++ b/packages/worker/src/community/repo.ts
@@ -641,6 +641,37 @@ export async function insertCommunityFork(
 		.run()
 }
 
+export async function repointOrphanedCommunityForksToListing(
+	db: D1Database,
+	input: {
+		listingId: string
+		listingName: string
+		listingKodyId: string
+	},
+): Promise<number> {
+	const result = await db
+		.prepare(
+			`UPDATE community_forks
+			SET listing_id = ?
+			WHERE listing_id != ?
+				AND listing_name = ?
+				AND listing_kody_id = ?
+				AND NOT EXISTS (
+					SELECT 1
+					FROM community_listings
+					WHERE community_listings.id = community_forks.listing_id
+				)`,
+		)
+		.bind(
+			input.listingId,
+			input.listingId,
+			input.listingName,
+			input.listingKodyId,
+		)
+		.run()
+	return result.meta.changes ?? 0
+}
+
 export async function getCommunityForkByListingAndUser(
 	db: D1Database,
 	input: {

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -46,6 +46,7 @@ import {
 	listCommunityListingCandidates,
 	listCommunityReports as listCommunityReportsFromDb,
 	listFeaturedCommunityListings as listFeaturedCommunityListingsFromDb,
+	repointOrphanedCommunityForksToListing,
 	resolveCommunityReportRow,
 	setCommunityListingFeaturedAt,
 	setCommunityListingStatus,
@@ -480,6 +481,16 @@ export async function publishCommunityListing(input: {
 			published_at: now,
 		})
 	}
+
+	// Unpublish intentionally deletes the listing row while preserving fork
+	// provenance. The surviving row does not retain owner/package ids, so the
+	// narrowest historical lineage key available is an orphaned listing id plus
+	// the exact scoped package name and kody.id captured at fork time.
+	await repointOrphanedCommunityForksToListing(input.env.APP_DB, {
+		listingId,
+		listingName: savedPackage.name,
+		listingKodyId: savedPackage.kodyId,
+	})
 
 	try {
 		await writeCommunitySnapshot(input.env.BUNDLE_ARTIFACTS_KV, snapshot)

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -1,14 +1,14 @@
 import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
-	getSavedPackageById: vi.fn(),
+	getSavedPackageWithCommunityProvenanceById: vi.fn(),
 	loadPackageManifestBySourceId: vi.fn(),
 	resolvePackageOwnerContext: vi.fn(),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
-	getSavedPackageById: (...args: Array<unknown>) =>
-		mockModule.getSavedPackageById(...args),
+	getSavedPackageWithCommunityProvenanceById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageWithCommunityProvenanceById(...args),
 }))
 
 vi.mock('#worker/package-registry/source.ts', () => ({
@@ -69,9 +69,9 @@ function createCallerContext(input?: {
 }
 
 test('getPackageCapability returns export metadata for owner and delegated package scopes', async () => {
-	mockModule.getSavedPackageById.mockReset()
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
 	mockModule.loadPackageManifestBySourceId.mockReset()
-	mockModule.getSavedPackageById.mockResolvedValue({
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockResolvedValue({
 		id: 'package-1',
 		userId: 'user-1',
 		name: '@kentcdodds/discord-gateway',
@@ -83,6 +83,9 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 		hasApp: true,
 		hidden: false,
 		isPrivate: false,
+		sourceListingId: 'listing-1',
+		listingCurrent: true,
+		listingKodyId: 'upstream-discord-gateway',
 		createdAt: '2026-04-25T00:00:00.000Z',
 		updatedAt: '2026-04-26T00:00:00.000Z',
 	})
@@ -121,6 +124,9 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 		tags: ['discord'],
 		has_app: true,
 		source_id: 'source-1',
+		source_listing_id: 'listing-1',
+		listing_current: true,
+		listing_kody_id: 'upstream-discord-gateway',
 		created_at: '2026-04-25T00:00:00.000Z',
 		updated_at: '2026-04-26T00:00:00.000Z',
 		exports: [
@@ -161,7 +167,9 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 			},
 		],
 	})
-	expect(mockModule.getSavedPackageById).toHaveBeenCalledWith(
+	expect(
+		mockModule.getSavedPackageWithCommunityProvenanceById,
+	).toHaveBeenCalledWith(
 		expect.anything(),
 		expect.objectContaining({ userId: 'user-1', packageId: 'package-1' }),
 	)
@@ -173,10 +181,10 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 	})
 
 	// Delegated package_scope loads and builds invocation URLs for the owner.
-	mockModule.getSavedPackageById.mockReset()
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
 	mockModule.loadPackageManifestBySourceId.mockReset()
 	mockModule.resolvePackageOwnerContext.mockClear()
-	mockModule.getSavedPackageById.mockResolvedValue({
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockResolvedValue({
 		id: 'package-1',
 		userId: 'platform-owner',
 		name: '@kody/discord-gateway',
@@ -188,6 +196,9 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 		hasApp: false,
 		hidden: false,
 		isPrivate: false,
+		sourceListingId: null,
+		listingCurrent: null,
+		listingKodyId: null,
 		createdAt: '2026-04-25T00:00:00.000Z',
 		updatedAt: '2026-04-26T00:00:00.000Z',
 	})
@@ -220,7 +231,9 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 		expect.objectContaining({ userId: 'user-1' }),
 		'kody',
 	)
-	expect(mockModule.getSavedPackageById).toHaveBeenCalledWith(
+	expect(
+		mockModule.getSavedPackageWithCommunityProvenanceById,
+	).toHaveBeenCalledWith(
 		expect.anything(),
 		expect.objectContaining({
 			userId: 'platform-owner',

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -11,7 +11,7 @@ import {
 	packageScopeInputDescription,
 	resolvePackageOwnerContext,
 } from '#worker/package-registry/package-owner.ts'
-import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { getSavedPackageWithCommunityProvenanceById } from '#worker/package-registry/repo.ts'
 import {
 	buildPlainRepoPromotionErrorMessage,
 	findPlainRepoPromotionHint,
@@ -24,7 +24,7 @@ export const getPackageCapability = defineDomainCapability(
 	{
 		name: 'package_get',
 		description:
-			'Load one saved package metadata record for the signed-in user, including ready-to-import export specifiers and canonical owner-scoped external invocation URLs for each export.',
+			'Load one saved package metadata record for the signed-in user, including community-fork source listing provenance, ready-to-import export specifiers, and canonical owner-scoped external invocation URLs for each export.',
 		keywords: [
 			'package',
 			'get',
@@ -54,10 +54,13 @@ export const getPackageCapability = defineDomainCapability(
 				user,
 				args.package_scope,
 			)
-			const saved = await getSavedPackageById(ctx.env.APP_DB, {
-				userId: owner.ownerUserId,
-				packageId: args.package_id,
-			})
+			const saved = await getSavedPackageWithCommunityProvenanceById(
+				ctx.env.APP_DB,
+				{
+					userId: owner.ownerUserId,
+					packageId: args.package_id,
+				},
+			)
 			if (!saved) {
 				const plainRepo = await findPlainRepoPromotionHint(ctx.env.APP_DB, {
 					userId: owner.ownerUserId,
@@ -91,6 +94,9 @@ export const getPackageCapability = defineDomainCapability(
 				has_app: saved.hasApp,
 				hidden: saved.hidden,
 				source_id: saved.sourceId,
+				source_listing_id: saved.sourceListingId,
+				listing_current: saved.listingCurrent,
+				listing_kody_id: saved.listingKodyId,
 				created_at: saved.createdAt,
 				updated_at: saved.updatedAt,
 				exports: (projection.exports ?? []).map((exportDetail) => ({

--- a/packages/worker/src/mcp/capabilities/packages/list-packages.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-packages.ts
@@ -6,15 +6,18 @@ import {
 	packageScopeInputDescription,
 	resolvePackageOwnerContext,
 } from '#worker/package-registry/package-owner.ts'
-import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
-import { packageSummarySchema, toPackageSummary } from './shared.ts'
+import { listSavedPackagesWithCommunityProvenanceByUserId } from '#worker/package-registry/repo.ts'
+import {
+	packageSummaryWithCommunityProvenanceSchema,
+	toPackageSummaryWithCommunityProvenance,
+} from './shared.ts'
 
 export const listPackagesCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
 		name: 'package_list',
 		description:
-			'List saved packages for the signed-in user so agents can discover package ids and kody ids for later execution, editing, or UI opening.',
+			'List saved packages for the signed-in user, including community-fork source listing provenance, so agents can discover package ids and kody ids for later execution, editing, or UI opening.',
 		keywords: ['package', 'list', 'saved packages'],
 		readOnly: true,
 		idempotent: true,
@@ -27,7 +30,7 @@ export const listPackagesCapability = defineDomainCapability(
 				.describe(packageScopeInputDescription),
 		}),
 		outputSchema: z.object({
-			packages: z.array(packageSummarySchema),
+			packages: z.array(packageSummaryWithCommunityProvenanceSchema),
 		}),
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
@@ -36,11 +39,14 @@ export const listPackagesCapability = defineDomainCapability(
 				user,
 				args.package_scope,
 			)
-			const packages = await listSavedPackagesByUserId(ctx.env.APP_DB, {
-				userId: owner.ownerUserId,
-			})
+			const packages = await listSavedPackagesWithCommunityProvenanceByUserId(
+				ctx.env.APP_DB,
+				{
+					userId: owner.ownerUserId,
+				},
+			)
 			return {
-				packages: packages.map(toPackageSummary),
+				packages: packages.map(toPackageSummaryWithCommunityProvenance),
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod'
-import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import {
+	type SavedPackageRecord,
+	type SavedPackageWithCommunityProvenanceRecord,
+} from '#worker/package-registry/types.ts'
 
 export const packageFileSchema = z.object({
 	path: z
@@ -27,6 +30,28 @@ export const packageSummarySchema = z.object({
 	created_at: z.string(),
 	updated_at: z.string(),
 })
+
+export const packageSummaryWithCommunityProvenanceSchema =
+	packageSummarySchema.extend({
+		source_listing_id: z
+			.string()
+			.nullable()
+			.describe(
+				'Community listing id this package was forked from, or null for a self-authored package.',
+			),
+		listing_current: z
+			.boolean()
+			.nullable()
+			.describe(
+				'Whether the source community listing id currently resolves to an active listing, or null for a self-authored package.',
+			),
+		listing_kody_id: z
+			.string()
+			.nullable()
+			.describe(
+				'Original community listing kody.id recorded when this package was forked, or null for a self-authored package.',
+			),
+	})
 
 export const pendingPackageSecretApprovalsSchema = z
 	.object({
@@ -66,6 +91,17 @@ export function toPackageSummary(savedPackage: SavedPackageRecord) {
 		source_id: savedPackage.sourceId,
 		created_at: savedPackage.createdAt,
 		updated_at: savedPackage.updatedAt,
+	}
+}
+
+export function toPackageSummaryWithCommunityProvenance(
+	savedPackage: SavedPackageWithCommunityProvenanceRecord,
+) {
+	return {
+		...toPackageSummary(savedPackage),
+		source_listing_id: savedPackage.sourceListingId,
+		listing_current: savedPackage.listingCurrent,
+		listing_kody_id: savedPackage.listingKodyId,
 	}
 }
 
@@ -132,9 +168,10 @@ export const packageExportSurfaceSchema = z.object({
 		),
 })
 
-export const packageDetailSchema = packageSummarySchema.extend({
-	exports: z.array(packageExportSurfaceSchema),
-})
+export const packageDetailSchema =
+	packageSummaryWithCommunityProvenanceSchema.extend({
+		exports: z.array(packageExportSurfaceSchema),
+	})
 
 export const packageInvocationTokenMetadataSchema = z.object({
 	token_id: z

--- a/packages/worker/src/package-registry/repo.ts
+++ b/packages/worker/src/package-registry/repo.ts
@@ -1,7 +1,11 @@
 import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
 import { buildLengthSafeVectorId } from '#worker/vectorize/vector-ids.ts'
-import { type SavedPackageRecord, type SavedPackageRow } from './types.ts'
+import {
+	type SavedPackageRecord,
+	type SavedPackageRow,
+	type SavedPackageWithCommunityProvenanceRecord,
+} from './types.ts'
 
 const maxSqlBindingsPerChunk = 90
 
@@ -9,8 +13,27 @@ export function savedPackageVectorId(packageId: string) {
 	return buildLengthSafeVectorId({ prefix: 'package', rawId: packageId })
 }
 
-const savedPackageSelectColumns = `id, user_id, name, kody_id, description, tags_json, search_text,
-				source_id, has_app, hidden, is_private, created_at, updated_at`
+const savedPackageSelectColumns = `saved_packages.id, saved_packages.user_id, saved_packages.name,
+				saved_packages.kody_id, saved_packages.description, saved_packages.tags_json,
+				saved_packages.search_text, saved_packages.source_id, saved_packages.has_app,
+				saved_packages.hidden, saved_packages.is_private, saved_packages.created_at,
+				saved_packages.updated_at`
+
+const savedPackageCommunityProvenanceSelectColumns = `${savedPackageSelectColumns},
+				community_forks.listing_id AS source_listing_id,
+				CASE
+					WHEN community_forks.id IS NULL THEN NULL
+					WHEN community_listings.id IS NULL THEN 0
+					ELSE 1
+				END AS listing_current,
+				community_forks.listing_kody_id AS listing_kody_id`
+
+const savedPackageCommunityProvenanceJoins = `LEFT JOIN community_forks
+				ON community_forks.forked_package_id = saved_packages.id
+				AND community_forks.forker_user_id = saved_packages.user_id
+			LEFT JOIN community_listings
+				ON community_listings.id = community_forks.listing_id
+				AND community_listings.status = 'active'`
 
 function mapSavedPackageRow(row: Record<string, unknown>): SavedPackageRecord {
 	return {
@@ -33,6 +56,30 @@ function mapSavedPackageRow(row: Record<string, unknown>): SavedPackageRecord {
 			row['is_private'] === true,
 		createdAt: String(row['created_at']),
 		updatedAt: String(row['updated_at']),
+	}
+}
+
+function mapSavedPackageWithCommunityProvenanceRow(
+	row: Record<string, unknown>,
+): SavedPackageWithCommunityProvenanceRecord {
+	const savedPackage = mapSavedPackageRow(row)
+	if (row['source_listing_id'] == null) {
+		return {
+			...savedPackage,
+			sourceListingId: null,
+			listingCurrent: null,
+			listingKodyId: null,
+		}
+	}
+	return {
+		...savedPackage,
+		sourceListingId: String(row['source_listing_id']),
+		listingCurrent:
+			row['listing_current'] === 1 ||
+			row['listing_current'] === '1' ||
+			row['listing_current'] === true,
+		listingKodyId:
+			row['listing_kody_id'] == null ? null : String(row['listing_kody_id']),
 	}
 }
 export async function insertSavedPackage(
@@ -166,6 +213,25 @@ export async function getSavedPackageById(
 	return row ? mapSavedPackageRow(row) : null
 }
 
+export async function getSavedPackageWithCommunityProvenanceById(
+	db: D1Database,
+	input: {
+		userId: string
+		packageId: string
+	},
+): Promise<SavedPackageWithCommunityProvenanceRecord | null> {
+	const row = await db
+		.prepare(
+			`SELECT ${savedPackageCommunityProvenanceSelectColumns}
+			FROM saved_packages
+			${savedPackageCommunityProvenanceJoins}
+			WHERE saved_packages.id = ? AND saved_packages.user_id = ?`,
+		)
+		.bind(input.packageId, input.userId)
+		.first<Record<string, unknown>>()
+	return row ? mapSavedPackageWithCommunityProvenanceRow(row) : null
+}
+
 export async function getSavedPackageByKodyId(
 	db: D1Database,
 	input: {
@@ -218,6 +284,25 @@ export async function listSavedPackagesByUserId(
 		.bind(input.userId)
 		.all<Record<string, unknown>>()
 	return (rows.results ?? []).map(mapSavedPackageRow)
+}
+
+export async function listSavedPackagesWithCommunityProvenanceByUserId(
+	db: D1Database,
+	input: {
+		userId: string
+	},
+): Promise<Array<SavedPackageWithCommunityProvenanceRecord>> {
+	const rows = await db
+		.prepare(
+			`SELECT ${savedPackageCommunityProvenanceSelectColumns}
+			FROM saved_packages
+			${savedPackageCommunityProvenanceJoins}
+			WHERE saved_packages.user_id = ?
+			ORDER BY saved_packages.updated_at DESC`,
+		)
+		.bind(input.userId)
+		.all<Record<string, unknown>>()
+	return (rows.results ?? []).map(mapSavedPackageWithCommunityProvenanceRow)
 }
 
 export async function listSavedPackagesByKodyIds(

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -280,3 +280,12 @@ export type SavedPackageRecord = {
 	createdAt: string
 	updatedAt: string
 }
+
+export type SavedPackageCommunityProvenance = {
+	sourceListingId: string | null
+	listingCurrent: boolean | null
+	listingKodyId: string | null
+}
+
+export type SavedPackageWithCommunityProvenanceRecord = SavedPackageRecord &
+	SavedPackageCommunityProvenance


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Expose community-fork provenance through package APIs and preserve that lineage when a source listing is unpublished and later republished.

## Summary

- add source listing provenance to `package_list` and `package_get`
- re-point only orphaned forks matching the republished package's exact scoped name and `kody.id`
- cover unpublish → stale provenance → republish → prior forker rating in the Workers integration flow
- document the new package return fields

## Testing

- `npx vitest run packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts packages/worker/src/community/community-service.node.test.ts --project node-unit` — 21 passed
- `npx vitest run packages/worker/src/community/community-flow.workers.test.ts --project workers-unit` — 2 passed
- `npm run validate` — passed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `be5e29d5` · **Head:** `0cea9461`

**Classification:** extends — package API contracts gain provenance fields and community listing republish behavior repairs orphaned fork lineage.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — package list/detail expose fork provenance |
| `community-listings` | assistant | extends — republish re-points matching orphaned forks |

### System map

Package reads join saved packages to fork/listing metadata; republishing heals preserved fork rows before the new listing is returned.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	communityListings["community-listings<br/>Community package listings"]:::extended
	savedPackages -->|"package_list/package_get provenance join"| communityListings
	communityListings -->|"repoint exact matching orphaned fork rows"| savedPackages
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
Before: package APIs omit fork origin; unpublish leaves fork rows on a dead listing id.
After: package APIs report source_listing_id/listing_current/listing_kody_id; republish moves matching orphaned forks to the new listing id.
```

### Invariants

- Per-user package reads keep the saved-package owner/forker join constraint.
- Republish repair requires an orphaned listing plus exact scoped package name and `kody.id`; live or unrelated forks are untouched.

</details>

<!-- system-recap:end -->

## Conductor report

Status: implementation and local validation complete; PR review/CI pending.

Evidence: 21 focused node tests passed, both community Workers workflow tests passed, and the authoritative `npm run validate` gate completed successfully.

Remains: mark ready, wait for CI and AI review, address valid feedback, squash-merge, and watch deployment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a315aac-999b-4fb4-a0f9-6f0dd2f998f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a315aac-999b-4fb4-a0f9-6f0dd2f998f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

