### PR TITLE
fix(integrations): refresh platform OAuth host snapshots

### DIFF
--- a/packages/worker/migrations/0008-refresh-google-platform-hosts.sql
+++ b/packages/worker/migrations/0008-refresh-google-platform-hosts.sql
@@ -1,0 +1,27 @@
+-- Platform OAuth app connections snapshot required hosts when they are created.
+-- Bring existing Google connections forward to the operator-owned app's current
+-- defaults without removing any connection-specific hosts. User-owned OAuth
+-- app connections have a NULL platform_app_slug and are intentionally excluded.
+UPDATE user_integrations
+SET required_hosts_json = (
+	SELECT json_group_array(host)
+	FROM (
+		SELECT value AS host
+		FROM json_each(user_integrations.required_hosts_json)
+		UNION
+		SELECT value AS host
+		FROM json_each(
+			(
+				SELECT required_hosts_json
+				FROM platform_oauth_apps
+				WHERE slug = user_integrations.platform_app_slug
+			)
+		)
+		ORDER BY host
+	)
+)
+WHERE platform_app_slug IN (
+	SELECT slug
+	FROM platform_oauth_apps
+	WHERE provider = 'google' OR slug = 'google-platform'
+);

--- a/packages/worker/src/integrations/integration-host-refresh-migration.node.test.ts
+++ b/packages/worker/src/integrations/integration-host-refresh-migration.node.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+const migrationFileName = '0008-refresh-google-platform-hosts.sql'
+
+function applyMigrationsBeforeHostRefresh(db: DatabaseSync) {
+	for (const fileName of readdirSync(migrationsDirectory)
+		.filter(
+			(fileName) => fileName.endsWith('.sql') && fileName < migrationFileName,
+		)
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
+	}
+}
+
+test('Google platform host backfill is additive, lane-specific, and idempotent', () => {
+	const sqlite = new DatabaseSync(':memory:')
+	applyMigrationsBeforeHostRefresh(sqlite)
+	sqlite.exec(`
+		INSERT INTO platform_oauth_apps (
+			slug, provider, client_id, token_url, authorize_url, flow,
+			required_hosts_json
+		) VALUES (
+			'google-platform', 'google', 'google-client',
+			'https://oauth2.googleapis.com/token',
+			'https://accounts.google.com/o/oauth2/v2/auth', 'confidential',
+			'["openidconnect.googleapis.com","www.googleapis.com"]'
+		);
+		INSERT INTO user_oauth_apps (
+			user_id, slug, provider, client_id, token_url, flow
+		) VALUES (
+			'user-custom', 'google', 'google', 'custom-client',
+			'https://oauth2.googleapis.com/token', 'pkce'
+		);
+		INSERT INTO user_integrations (
+			user_id, name, app_slug, platform_app_slug, required_hosts_json,
+			access_token_secret_name
+		) VALUES
+			(
+				'user-platform', 'google', NULL, 'google-platform',
+				'["user-added.example.com","www.googleapis.com"]', 'googleAccessToken'
+			),
+			(
+				'user-custom', 'google', 'google', NULL,
+				'["custom-only.example.com"]', 'customGoogleAccessToken'
+			);
+	`)
+	const migration = readFileSync(
+		new URL(migrationFileName, migrationsDirectory),
+		'utf8',
+	)
+
+	sqlite.exec(migration)
+	sqlite.exec(migration)
+
+	const rows = sqlite
+		.prepare(
+			`SELECT user_id, required_hosts_json
+			FROM user_integrations
+			ORDER BY user_id`,
+		)
+		.all() as Array<{ user_id: string; required_hosts_json: string }>
+	expect(
+		rows.map((row) => ({
+			userId: row.user_id,
+			requiredHosts: JSON.parse(row.required_hosts_json),
+		})),
+	).toEqual([
+		{
+			userId: 'user-custom',
+			requiredHosts: ['custom-only.example.com'],
+		},
+		{
+			userId: 'user-platform',
+			requiredHosts: [
+				'openidconnect.googleapis.com',
+				'user-added.example.com',
+				'www.googleapis.com',
+			],
+		},
+	])
+})

--- a/packages/worker/src/integrations/repo.ts
+++ b/packages/worker/src/integrations/repo.ts
@@ -445,6 +445,32 @@ export async function upsertIntegrationConnection(input: {
 		.run()
 }
 
+export async function addPlatformIntegrationRequiredHosts(input: {
+	db: D1Database
+	userId: string
+	name: string
+	hosts: Array<string>
+}): Promise<void> {
+	await input.db
+		.prepare(
+			`UPDATE user_integrations
+			SET required_hosts_json = (
+				SELECT json_group_array(host)
+				FROM (
+					SELECT value AS host
+					FROM json_each(user_integrations.required_hosts_json)
+					UNION
+					SELECT value AS host
+					FROM json_each(?)
+					ORDER BY host
+				)
+			)
+			WHERE user_id = ? AND name = ? AND platform_app_slug IS NOT NULL`,
+		)
+		.bind(JSON.stringify(input.hosts), input.userId, input.name)
+		.run()
+}
+
 export async function deleteIntegrationConnection(input: {
 	db: D1Database
 	userId: string

--- a/packages/worker/src/integrations/service.node.test.ts
+++ b/packages/worker/src/integrations/service.node.test.ts
@@ -824,10 +824,11 @@ test('findOauthAppForProviderSetup prefers an exact-slug setup app over family p
 })
 
 function createPlatformEnv() {
-	const { env } = createEnv()
+	const base = createEnv()
 	return {
+		...base,
 		env: {
-			...env,
+			...base.env,
 			SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
 		} as Pick<Env, 'APP_DB' | 'SECRET_STORE_KEY'>,
 	}
@@ -982,4 +983,67 @@ test('upsertPlatformIntegration enforces connect policy, hides secrets, and dele
 			accessTokenSecretName: 'githubAccessToken',
 		}),
 	).rejects.toThrow('Platform integration "github" is not available.')
+})
+
+test('loading a platform integration adds current app hosts without removing connection hosts', async () => {
+	const { env, sqlite } = createPlatformEnv()
+	const app = await provisionGithubPlatformApp(env)
+	await upsertPlatformIntegration({
+		env,
+		userId: 'user-stale-platform-hosts',
+		platformAppSlug: app.slug,
+		scopes: [],
+		accessTokenSecretName: 'githubAccessToken',
+	})
+	sqlite
+		.prepare(
+			`UPDATE user_integrations
+			SET required_hosts_json = ?
+			WHERE user_id = ? AND name = ?`,
+		)
+		.run(
+			JSON.stringify(['api.github.com', 'user-added.example.com']),
+			'user-stale-platform-hosts',
+			'github',
+		)
+	await upsertPlatformOauthApp({
+		db: env.APP_DB,
+		env,
+		app: {
+			slug: app.slug,
+			clientId: app.clientId,
+			tokenUrl: app.tokenUrl,
+			authorizeUrl: app.authorizeUrl,
+			apiBaseUrl: app.apiBaseUrl,
+			flow: app.flow,
+			requiredHosts: ['api.github.com', 'uploads.github.com'],
+		},
+	})
+
+	const loaded = await getIntegration({
+		env,
+		userId: 'user-stale-platform-hosts',
+		name: 'github',
+	})
+
+	expect(loaded?.requiredHosts).toEqual([
+		'api.github.com',
+		'uploads.github.com',
+		'user-added.example.com',
+	])
+	expect(
+		JSON.parse(
+			(
+				sqlite
+					.prepare(
+						`SELECT required_hosts_json
+						FROM user_integrations
+						WHERE user_id = ? AND name = ?`,
+					)
+					.get('user-stale-platform-hosts', 'github') as {
+					required_hosts_json: string
+				}
+			).required_hosts_json,
+		),
+	).toEqual(['api.github.com', 'uploads.github.com', 'user-added.example.com'])
 })

--- a/packages/worker/src/integrations/service.ts
+++ b/packages/worker/src/integrations/service.ts
@@ -13,6 +13,7 @@ import {
 	type PlatformOauthApp,
 } from './platform-apps.ts'
 import {
+	addPlatformIntegrationRequiredHosts,
 	countConnectionsForApp,
 	deleteIntegrationConnection,
 	deleteOauthApp,
@@ -116,7 +117,10 @@ export function toPlatformIntegrationConfig(
 			clientSecretSecretName: null,
 			accessTokenSecretName: connection.accessTokenSecretName,
 			refreshTokenSecretName: connection.refreshTokenSecretName,
-			requiredHosts: connection.requiredHosts,
+			requiredHosts: normalizeAllowedHosts([
+				...connection.requiredHosts,
+				...app.requiredHosts,
+			]),
 			tokenExchangeStyle: app.tokenExchangeStyle,
 			authorization: {
 				authorizeUrl: app.authorizeUrl,
@@ -148,10 +152,7 @@ export async function listIntegrations(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
 }): Promise<Array<IntegrationConfig>> {
-	const rows = await listJoinedIntegrationsForUser({
-		db: input.env.APP_DB,
-		userId: input.userId,
-	})
+	const rows = await listJoinedIntegrations(input)
 	return rows.map(toJoinedIntegrationConfig)
 }
 
@@ -159,10 +160,15 @@ export async function listJoinedIntegrations(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
 }): Promise<Array<JoinedIntegration>> {
-	return listJoinedIntegrationsForUser({
+	const joined = await listJoinedIntegrationsForUser({
 		db: input.env.APP_DB,
 		userId: input.userId,
 	})
+	return Promise.all(
+		joined.map((entry) =>
+			refreshPlatformIntegrationRequiredHosts(input.env.APP_DB, entry),
+		),
+	)
 }
 
 export async function getIntegration(input: {
@@ -186,11 +192,45 @@ export async function getJoinedIntegration(input: {
 }): Promise<JoinedIntegration | null> {
 	const name = canonicalIntegrationName(input.name)
 	if (!name) return null
-	return getJoinedIntegrationByName({
+	const joined = await getJoinedIntegrationByName({
 		db: input.env.APP_DB,
 		userId: input.userId,
 		name,
 	})
+	if (!joined) return null
+	return refreshPlatformIntegrationRequiredHosts(input.env.APP_DB, joined)
+}
+
+async function refreshPlatformIntegrationRequiredHosts(
+	db: D1Database,
+	joined: JoinedIntegration,
+): Promise<JoinedIntegration> {
+	if (joined.lane === 'user') return joined
+	const requiredHosts = normalizeAllowedHosts([
+		...joined.connection.requiredHosts,
+		...joined.app.requiredHosts,
+	])
+	if (
+		requiredHosts.length === joined.connection.requiredHosts.length &&
+		requiredHosts.every(
+			(host, index) => host === joined.connection.requiredHosts[index],
+		)
+	) {
+		return joined
+	}
+	await addPlatformIntegrationRequiredHosts({
+		db,
+		userId: joined.connection.userId,
+		name: joined.connection.name,
+		hosts: joined.app.requiredHosts,
+	})
+	return {
+		...joined,
+		connection: {
+			...joined.connection,
+			requiredHosts,
+		},
+	}
 }
 
 export async function upsertIntegration(input: {

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -31,6 +31,10 @@
 		{
 			"filename": "0007-saved-package-search-index-debt.sql",
 			"sha256": "62922faee72e96170009bd0410649a9404fc1678f571438d78f62aaaba89ac07"
+		},
+		{
+			"filename": "0008-refresh-google-platform-hosts.sql",
+			"sha256": "0fcb55e9e026bd33be47aceb728e31fbb79cb5b3a9a7c9f007a5209a48f0ac12"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep platform OAuth connection host allowlists additive and current when operator defaults gain hosts, including the Google OIDC userinfo host reported in platform feedback `5c259460-2286-43ce-9ffb-b8f5f007b45c`.

## Summary

- Self-heal platform-lane connection snapshots whenever integrations are loaded by unioning current platform-app hosts and persisting the additive result.
- Preserve connection-specific hosts; user-lane custom integrations are excluded.
- Backfill existing Google platform connections from their current operator-owned app defaults with an idempotent D1 migration.
- Cover stale snapshot healing, user-added host preservation, migration lane isolation, and migration idempotence.

## Testing

- `npm run validate` passed: 593 test files / 2,013 tests, 8 Playwright tests, 3 MCP files / 5 tests, plus format, lint, typecheck, builds, migrations, primitives, deploy guardrails, and docs checks.
- Commit hook `npm run test:push` also passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `be5e29d5` · **Head:** `d4562a4f`

**Classification:** extends — changes OAuth integration host snapshot behavior and adds an additive D1 data migration; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `integrations` | assistant | extends — platform connection loads union current app hosts into snapshots |
| `d1-app-db` | storage | extends — idempotent Google platform connection backfill |

### System map

Platform OAuth defaults now flow additively into per-user connection snapshots both during migration and at runtime load.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	integrations["integrations<br/>OAuth integrations"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
	integrations -->|"union current required hosts on load"| d1AppDb
	d1AppDb -->|"backfill Google platform snapshots"| integrations
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Platform host defaults were snapshotted only at connect time. | Loads add current platform hosts and persist the union. |
| Older Google connections could omit `openidconnect.googleapis.com`. | Migration unions all current Google platform defaults into existing platform-lane rows. |

### Invariants

- `integration-host-allowlist`: additions take effect before OAuth tokens can be attached to requests.
- `per-user-isolation`: runtime writes remain scoped by `user_id` and connection name.
- Connection-specific hosts are preserved; user-lane custom integrations are untouched.

</details>

<!-- system-recap:end -->

## Conductor report

- **Status:** implementation and authoritative local validation complete; PR review/CI pending.
- **Evidence:** commit `d4562a4f`; `npm run validate` green (593 test files, 2,013 tests, 8 E2E, 5 MCP tests).
- **Remains:** mark ready, wait for CI and AI review, address valid feedback, merge, and watch deployment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22a954cc-60c7-4ee0-9169-8a2f1e1ac06f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22a954cc-60c7-4ee0-9169-8a2f1e1ac06f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

