### PR TITLE
fix(mcp): retry and filter opaque Cloudflare internal errors on repo_open_session

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/repo-open-session.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-open-session.node.test.ts
@@ -5,6 +5,8 @@ import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#universal/plans.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { buildSourceRecoveryProblemMessage } from '#worker/repo/source-safety-policy.ts'
+import { cloudflareOpaqueInternalErrorMessage } from '#worker/sentry-options.ts'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { repoOpenSessionInputSchema } from './repo-shared.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -438,4 +440,115 @@ test('repo_open_session allows below-max usage and denies at the max plan ceilin
 		current: maxLimit,
 	})
 	expect(deniedRpc.openSession).not.toHaveBeenCalled()
+})
+
+test('repo_open_session retries opaque Cloudflare internal errors with a fresh session id', async () => {
+	consoleWarn.mockImplementation(() => {})
+	resetMocks()
+	const email = 'opaque-internal@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const env = {
+		APP_DB: createEntitlementsDatabase({
+			users: [{ email, plan: 'pro', stable_user_id: userId }],
+			repoSessionCount: 0,
+		}),
+	} as Env
+	const ctx = {
+		env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId,
+				email,
+				displayName: 'Opaque Internal User',
+			},
+		}),
+	}
+	mockModule.getActiveRepoSessionByConversation.mockResolvedValue(null)
+	mockModule.getSavedPackageByKodyId.mockResolvedValue(
+		createSavedPackageRow(userId),
+	)
+	mockModule.getEntitySourceByIdForUser.mockResolvedValue(
+		createPackageSourceRow(userId),
+	)
+	const openRpc = createRepoRpc()
+	openRpc.openSession
+		.mockRejectedValueOnce(new Error(cloudflareOpaqueInternalErrorMessage))
+		.mockResolvedValueOnce(createOpenSessionResult())
+	mockModule.repoSessionRpc.mockReturnValue(openRpc)
+
+	const opened = await repoOpenSessionCapability.handler(
+		{
+			target: { kind: 'package', kody_id: 'triage-github-pr' },
+		},
+		ctx,
+	)
+
+	expect(opened.id).toBe('session-new')
+	expect(openRpc.openSession).toHaveBeenCalledTimes(2)
+	const firstSessionId = openRpc.openSession.mock.calls[0]?.[0]?.sessionId
+	const secondSessionId = openRpc.openSession.mock.calls[1]?.[0]?.sessionId
+	expect(typeof firstSessionId).toBe('string')
+	expect(typeof secondSessionId).toBe('string')
+	expect(firstSessionId).not.toBe(secondSessionId)
+	expect(mockModule.repoSessionRpc).toHaveBeenCalledTimes(2)
+	expect(consoleWarn).toHaveBeenCalledWith(
+		expect.stringContaining(
+			'repo_open_session transient Cloudflare opaque internal error',
+		),
+	)
+})
+
+test('repo_open_session rethrows after opaque Cloudflare internal error retries are exhausted', async () => {
+	consoleWarn.mockImplementation(() => {})
+	resetMocks()
+	const email = 'opaque-exhausted@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const env = {
+		APP_DB: createEntitlementsDatabase({
+			users: [{ email, plan: 'pro', stable_user_id: userId }],
+			repoSessionCount: 0,
+		}),
+	} as Env
+	const ctx = {
+		env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId,
+				email,
+				displayName: 'Opaque Exhausted User',
+			},
+		}),
+	}
+	mockModule.getActiveRepoSessionByConversation.mockResolvedValue(null)
+	mockModule.getSavedPackageByKodyId.mockResolvedValue(
+		createSavedPackageRow(userId),
+	)
+	mockModule.getEntitySourceByIdForUser.mockResolvedValue(
+		createPackageSourceRow(userId),
+	)
+	const openRpc = createRepoRpc()
+	openRpc.openSession.mockRejectedValue(
+		new Error(cloudflareOpaqueInternalErrorMessage),
+	)
+	mockModule.repoSessionRpc.mockReturnValue(openRpc)
+
+	const error = await repoOpenSessionCapability
+		.handler(
+			{
+				target: { kind: 'package', kody_id: 'triage-github-pr' },
+			},
+			ctx,
+		)
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+
+	expect(error).toMatchObject({
+		message: cloudflareOpaqueInternalErrorMessage,
+	})
+	// Initial attempt + two delayed retries.
+	expect(openRpc.openSession).toHaveBeenCalledTimes(3)
 })

--- a/packages/worker/src/mcp/capabilities/repo/repo-open-session.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-open-session.ts
@@ -4,17 +4,50 @@ import { defineDomainCapability } from '#mcp/capabilities/define-domain-capabili
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
 import { assertWithinEntitlement } from '#worker/entitlements/service.ts'
+import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
 import { getActiveRepoSessionByConversation } from '#worker/repo/repo-sessions.ts'
 import {
 	buildPublishedCommitHeadMismatchCallerMessage,
 	isPublishedCommitHeadMismatchMessage,
 } from '#worker/repo/source-safety-policy.ts'
-import {
-	repoOpenSessionOutputSchema,
-	repoOpenSessionInputSchema,
-} from './repo-shared.ts'
-import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+import { isCloudflareOpaqueInternalErrorMessage } from '#worker/sentry-options.ts'
 import { resolveRepoSourceReference } from './repo-resolve-target.ts'
+import {
+	repoOpenSessionInputSchema,
+	repoOpenSessionOutputSchema,
+} from './repo-shared.ts'
+
+const openSessionTransientRetryDelaysMs = [100, 500] as const
+
+function createRepoSessionId() {
+	return (
+		crypto.randomUUID?.() ??
+		`repo-session-${Date.now().toString(36)}-${Math.random()
+			.toString(36)
+			.slice(2, 10)}`
+	)
+}
+
+function delay(ms: number) {
+	return new Promise<void>((resolve) => {
+		setTimeout(resolve, ms)
+	})
+}
+
+function mapOpenSessionError(error: unknown): never {
+	const message = getErrorMessage(error)
+	// Unpublished git-lane pushes leave HEAD ahead of published_commit
+	// until package_publish_external_push (or reconcile) lands. Keep the
+	// safety gate, but classify it as a caller precondition so Sentry
+	// does not open platform-bug issues for expected workflow state.
+	if (isPublishedCommitHeadMismatchMessage(message)) {
+		throw new McpCallerError(
+			buildPublishedCommitHeadMismatchCallerMessage(message),
+			{ cause: error },
+		)
+	}
+	throw error
+}
 
 export const repoOpenSessionCapability = defineDomainCapability(
 	capabilityDomainNames.repo,
@@ -66,11 +99,6 @@ export const repoOpenSessionCapability = defineDomainCapability(
 					resolved_target: requested.resolvedTarget,
 				}
 			}
-			const sessionId =
-				crypto.randomUUID?.() ??
-				`repo-session-${Date.now().toString(36)}-${Math.random()
-					.toString(36)
-					.slice(2, 10)}`
 
 			await assertWithinEntitlement({
 				db: ctx.env.APP_DB,
@@ -79,30 +107,47 @@ export const repoOpenSessionCapability = defineDomainCapability(
 				resource: 'repo_sessions',
 			})
 
+			// Opaque Cloudflare platform internals (KODY-CLOUDFLARE-4H) are brief
+			// infrastructure blips with no app signature. Each attempt uses a
+			// fresh session id / DO so a partial prior attempt cannot poison the
+			// retry; abandoned branches are swept by repo-session cleanup.
 			let session
-			try {
-				session = await repoSessionRpc(ctx.env, sessionId).openSession({
-					sessionId,
-					sourceId: requested.source.id,
-					userId: user.userId,
-					baseUrl: ctx.callerContext.baseUrl,
-					conversationId: args.conversation_id ?? null,
-					sourceRoot: args.source_root ?? requested.source.source_root,
-					defaultBranch: args.default_branch ?? null,
-				})
-			} catch (error) {
-				const message = getErrorMessage(error)
-				// Unpublished git-lane pushes leave HEAD ahead of published_commit
-				// until package_publish_external_push (or reconcile) lands. Keep the
-				// safety gate, but classify it as a caller precondition so Sentry
-				// does not open platform-bug issues for expected workflow state.
-				if (isPublishedCommitHeadMismatchMessage(message)) {
-					throw new McpCallerError(
-						buildPublishedCommitHeadMismatchCallerMessage(message),
-						{ cause: error },
+			let attempt = 0
+			for (;;) {
+				const sessionId = createRepoSessionId()
+				try {
+					session = await repoSessionRpc(ctx.env, sessionId).openSession({
+						sessionId,
+						sourceId: requested.source.id,
+						userId: user.userId,
+						baseUrl: ctx.callerContext.baseUrl,
+						conversationId: args.conversation_id ?? null,
+						sourceRoot: args.source_root ?? requested.source.source_root,
+						defaultBranch: args.default_branch ?? null,
+					})
+					break
+				} catch (error) {
+					const message = getErrorMessage(error)
+					const retryDelayMs = openSessionTransientRetryDelaysMs[attempt]
+					if (
+						retryDelayMs === undefined ||
+						!isCloudflareOpaqueInternalErrorMessage(message)
+					) {
+						mapOpenSessionError(error)
+					}
+					console.warn(
+						JSON.stringify({
+							message:
+								'repo_open_session transient Cloudflare opaque internal error',
+							sourceId: requested.source.id,
+							attempt: attempt + 1,
+							nextDelayMs: retryDelayMs,
+							errorMessage: message,
+						}),
 					)
+					await delay(retryDelayMs)
+					attempt += 1
 				}
-				throw error
 			}
 			return {
 				...session,

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'vitest'
 import { EntitlementLimitError } from './entitlements/errors.ts'
 import { isUserCodeError, UserCodeError } from './user-code-error.ts'
 import {
+	cloudflareArtifactsOpaqueInternalErrorMessage,
+	cloudflareOpaqueInternalErrorMessage,
 	durableObjectBlockConcurrencyWhileTimeoutResetMessage,
 	durableObjectCodeUpdatedResetMessage,
 	durableObjectIsolateCpuResetMessage,
@@ -11,6 +13,7 @@ import {
 	executorSandboxTimeoutMessageExplanation,
 	executorSandboxTimeoutMessagePrefix,
 	filterSentryEvent,
+	isCloudflareOpaqueInternalErrorMessage,
 	isDurableObjectIsolateResourceLimitResetMessage,
 } from './sentry-options.ts'
 
@@ -103,6 +106,44 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		exception: { values: [{ value: 'internal error' }] },
 	}
 	expect(filterSentryEvent(bareInternalError)).toBe(bareInternalError)
+
+	// Exact opaque Cloudflare / Artifacts internal-error sentences are platform
+	// blips (KODY-CLOUDFLARE-4H). Bare `internal error` above stays visible;
+	// wrapped recovery text must also stay visible.
+	expect(
+		isCloudflareOpaqueInternalErrorMessage(
+			cloudflareOpaqueInternalErrorMessage,
+		),
+	).toBe(true)
+	expect(
+		isCloudflareOpaqueInternalErrorMessage(
+			cloudflareArtifactsOpaqueInternalErrorMessage.replace(/\.$/, ''),
+		),
+	).toBe(true)
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [{ value: cloudflareOpaqueInternalErrorMessage }],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [{ value: `Error: ${cloudflareOpaqueInternalErrorMessage}` }],
+			},
+		}),
+	).toBeNull()
+	const wrappedOpaqueInternal = {
+		exception: {
+			values: [
+				{
+					value: `repo_open_session could not recover: ${cloudflareOpaqueInternalErrorMessage}`,
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(wrappedOpaqueInternal)).toBe(wrappedOpaqueInternal)
 
 	const bareObjectReset = {
 		exception: {

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -272,6 +272,56 @@ export function filterDurableObjectIsolateResetSentryEvent(event: ErrorEvent) {
 	return null
 }
 
+/**
+ * Bare Cloudflare platform "internal error" with no support reference and no
+ * app context. Observed on `repo_open_session` when Durable Object / Artifacts
+ * infrastructure fails opaquely (KODY-CLOUDFLARE-4H). Distinct from D1/DO
+ * storage resets that carry `reference = <id>`, and from bare `internal error`
+ * which stays Sentry-visible because it is too short to attribute safely.
+ *
+ * Also matches Artifacts `INTERNAL_ERROR` (10400) wording from the public docs.
+ * Require the exact sentence (optional trailing period / `Error:` prefix) so
+ * wrapped recovery messages stay visible.
+ */
+export const cloudflareOpaqueInternalErrorMessage =
+	'An internal error occurred.'
+
+export const cloudflareArtifactsOpaqueInternalErrorMessage =
+	'An unexpected internal error occurred.'
+
+function normalizeCloudflareOpaqueInternalErrorMessage(message: string) {
+	const withoutErrorPrefix = message.trim().replace(/^Error:\s*/i, '')
+	return withoutErrorPrefix.endsWith('.')
+		? withoutErrorPrefix
+		: `${withoutErrorPrefix}.`
+}
+
+export function isCloudflareOpaqueInternalErrorMessage(message: string) {
+	const normalized = normalizeCloudflareOpaqueInternalErrorMessage(message)
+	return (
+		normalized === cloudflareOpaqueInternalErrorMessage ||
+		normalized === cloudflareArtifactsOpaqueInternalErrorMessage
+	)
+}
+
+export function isCloudflareOpaqueInternalErrorSentryEvent(event: ErrorEvent) {
+	const messages = sentryEventMessages(event).filter(
+		(message): message is string =>
+			typeof message === 'string' && message.trim().length > 0,
+	)
+	return (
+		messages.length > 0 &&
+		messages.every((message) => isCloudflareOpaqueInternalErrorMessage(message))
+	)
+}
+
+export function filterCloudflareOpaqueInternalErrorSentryEvent(
+	event: ErrorEvent,
+) {
+	if (!isCloudflareOpaqueInternalErrorSentryEvent(event)) return event
+	return null
+}
+
 export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	// Marker first: primary mechanism for user-authored failures.
 	if (filterUserCodeErrorSentryEvent(event, hint) === null) return null
@@ -282,6 +332,8 @@ export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	if (filterExecutorSandboxTimeoutSentryEvent(event) === null) return null
 	if (filterRemoteConnectorUnavailableSentryEvent(event) === null) return null
 	if (filterDurableObjectIsolateResetSentryEvent(event) === null) return null
+	if (filterCloudflareOpaqueInternalErrorSentryEvent(event) === null)
+		return null
 	return event
 }
 
@@ -325,6 +377,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// updates, blockConcurrencyWhile timeouts, DO storage operation
 		// timeouts, and DO storage object-reset with a support reference) are
 		// dropped the same way — see filterDurableObjectIsolateResetSentryEvent.
+		// Exact opaque Cloudflare "An internal error occurred." (and Artifacts
+		// INTERNAL_ERROR wording) with no support reference are dropped the
+		// same way — see filterCloudflareOpaqueInternalErrorSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry

- Issue: [KODY-CLOUDFLARE-4H](https://kent-c-dodds-tech-llc.sentry.io/issues/7662400417/)
- Signature: `Error: An internal error occurred.`
- Capability: `repo_open_session` → `RepoSession.openSession`
- Evidence: 7 events / 1 user in a 4-minute burst on 2026-08-09; no recurrence since. Message is not thrown by app code (90d Sentry search finds only this issue). Stack stops at the DO RPC; breadcrumbs show successful Artifacts/git ops for prior `repo_get`, then entitlement COUNT, then the opaque failure inside `openSession`.

## Root cause

Cloudflare platform infrastructure returned the bare opaque sentence `An internal error occurred.` (no support `reference =`, no app wrapper). Same class of non-actionable transient platform blip already filtered for D1/DO storage resets — but those matchers require a reference token or a known DO-reset phrase, so this sentence still opened a Sentry issue.

## Fix

1. **Retry** `repo_open_session` up to twice (100ms / 500ms backoff) when `openSession` fails with that exact opaque Cloudflare / Artifacts INTERNAL_ERROR wording, each attempt with a fresh session id / DO.
2. **Filter** the exact bare sentences in `beforeSend` (`An internal error occurred.` and Artifacts docs wording `An unexpected internal error occurred.`), with optional `Error:` prefix / trailing period — wrapped recovery text stays visible; bare `internal error` stays visible (existing rule).

## Testing

- `sentry-options.node.test.ts`: drops exact opaque sentences; keeps wrapped / bare `internal error`
- `repo-open-session.node.test.ts`: recovers on retry with a new session id; rethrows after 3 attempts

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `07e245eb` · **Head:** `ec654d83`

**Classification:** composes — observability filter plus retry wiring around existing `repo_open_session` / `REPO_SESSION` open path; no capability contract, storage schema, or auth changes.

### Primitives touched

| Primitive              | Group     | Impact                                                                 |
| ---------------------- | --------- | ---------------------------------------------------------------------- |
| `capability-registry`  | assistant | composes — retries opaque CF internal errors on `repo_open_session`    |
| `repo-sessions`        | runtime   | composes — fresh session id per retry; abandoned branches still swept  |

### System map

`repo_open_session` retries brief Cloudflare opaque internal errors before surfacing them, and Sentry `beforeSend` drops the bare platform sentence.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	sentryOpts["sentry-options<br/>beforeSend filters"]:::untouched
	capabilityRegistry -->|"repo_open_session retries opaque CF internal error with fresh session id"| repoSessions
	capabilityRegistry -->|"exhausted bare An internal error occurred. dropped in beforeSend"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cap as repo_open_session
	participant DO as REPO_SESSION DO
	participant Sentry as beforeSend
	Cap->>DO: openSession(sessionId A)
	DO-->>Cap: Error An internal error occurred.
	Cap->>DO: openSession(sessionId B) after backoff
	alt recovered
		DO-->>Cap: session info
	else exhausted
		Cap-->>Sentry: captureException bare message
		Sentry-->>Sentry: drop exact opaque sentence
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a39a2030-4f9a-45ae-a30d-6b444c81c84d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a39a2030-4f9a-45ae-a30d-6b444c81c84d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session opening reliability by retrying transient Cloudflare internal errors with fresh sessions.
  * Preserved clear error handling for published-commit mismatches.
  * Reduced noisy error reporting by filtering standalone, opaque Cloudflare and Artifacts internal-error events while retaining meaningful diagnostic messages.

* **Tests**
  * Added coverage for session retries, retry exhaustion, and internal-error filtering variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->