### PR TITLE
fix(mcp): keep OAuth token-refresh caller state out of Sentry (KODY-CLOUDFLARE-4J)

### DIFF
--- a/packages/worker/src/integrations/token-refresh.node.test.ts
+++ b/packages/worker/src/integrations/token-refresh.node.test.ts
@@ -10,7 +10,10 @@ import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.t
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import { upsertPlatformOauthApp } from './platform-apps.ts'
 import { upsertIntegration, upsertPlatformIntegration } from './service.ts'
-import { refreshIntegrationTokens } from './token-refresh.ts'
+import {
+	IntegrationTokenRefreshCallerError,
+	refreshIntegrationTokens,
+} from './token-refresh.ts'
 
 const migrationsDirectory = new URL('../../migrations/', import.meta.url)
 
@@ -144,7 +147,127 @@ test('platform-lane refresh uses the decrypted shared client secret and persists
 			userId: 'user-no-refresh',
 			name: 'github',
 		}),
-	).rejects.toThrow('does not define a refresh token secret name')
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof IntegrationTokenRefreshCallerError &&
+			error.message.includes('does not define a refresh token secret name') &&
+			error.message.includes('/connect/oauth?provider=github'),
+	)
+})
+
+test('provider HTTP 4xx refresh rejection is a caller error with reconnect guidance', async () => {
+	const { env } = createHarness()
+	const userId = 'user-google-invalid-grant'
+	await upsertPlatformOauthApp({
+		db: env.APP_DB,
+		env,
+		app: {
+			slug: 'google',
+			clientId: 'platform-google-client-id',
+			clientSecret: 'platform-google-client-secret-value',
+			tokenUrl: 'https://oauth2.googleapis.com/token',
+			authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+			apiBaseUrl: 'https://www.googleapis.com',
+			flow: 'confidential',
+		},
+	})
+	await upsertPlatformIntegration({
+		env,
+		userId,
+		platformAppSlug: 'google',
+		scopes: [],
+		accessTokenSecretName: 'googleAccessToken',
+		refreshTokenSecretName: 'googleRefreshToken',
+	})
+	await seedUserTokens(env, userId, 'google')
+
+	const fetchMock = vi.fn(
+		async () =>
+			new Response(
+				JSON.stringify({
+					error: 'invalid_grant',
+					error_description: 'Token has been expired or revoked.',
+				}),
+				{
+					status: 400,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			),
+	)
+	vi.stubGlobal('fetch', fetchMock)
+	try {
+		await expect(
+			refreshIntegrationTokens({
+				env,
+				userId,
+				name: 'google',
+			}),
+		).rejects.toSatisfy(
+			(error: unknown) =>
+				error instanceof IntegrationTokenRefreshCallerError &&
+				error.message.includes(
+					'Token refresh was rejected for integration "google" with HTTP 400',
+				) &&
+				error.message.includes('invalid_grant') &&
+				error.message.includes('/connect/oauth?provider=google'),
+		)
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('provider HTTP 5xx refresh failure stays a plain Error for Sentry visibility', async () => {
+	const { env } = createHarness()
+	const userId = 'user-google-provider-outage'
+	await upsertPlatformOauthApp({
+		db: env.APP_DB,
+		env,
+		app: {
+			slug: 'google',
+			clientId: 'platform-google-client-id',
+			clientSecret: 'platform-google-client-secret-value',
+			tokenUrl: 'https://oauth2.googleapis.com/token',
+			authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+			apiBaseUrl: 'https://www.googleapis.com',
+			flow: 'confidential',
+		},
+	})
+	await upsertPlatformIntegration({
+		env,
+		userId,
+		platformAppSlug: 'google',
+		scopes: [],
+		accessTokenSecretName: 'googleAccessToken',
+		refreshTokenSecretName: 'googleRefreshToken',
+	})
+	await seedUserTokens(env, userId, 'google')
+
+	const fetchMock = vi.fn(
+		async () =>
+			new Response(JSON.stringify({ error: 'server_error' }), {
+				status: 503,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+	)
+	vi.stubGlobal('fetch', fetchMock)
+	try {
+		await expect(
+			refreshIntegrationTokens({
+				env,
+				userId,
+				name: 'google',
+			}),
+		).rejects.toSatisfy(
+			(error: unknown) =>
+				error instanceof Error &&
+				!(error instanceof IntegrationTokenRefreshCallerError) &&
+				error.message.includes(
+					'Token refresh failed for integration "google" with HTTP 503',
+				),
+		)
+	} finally {
+		vi.unstubAllGlobals()
+	}
 })
 
 async function approveSecretHosts(

--- a/packages/worker/src/integrations/token-refresh.node.test.ts
+++ b/packages/worker/src/integrations/token-refresh.node.test.ts
@@ -12,6 +12,7 @@ import { upsertPlatformOauthApp } from './platform-apps.ts'
 import { upsertIntegration, upsertPlatformIntegration } from './service.ts'
 import {
 	IntegrationTokenRefreshCallerError,
+	integrationTokenRefreshCallerMarker,
 	refreshIntegrationTokens,
 } from './token-refresh.ts'
 
@@ -151,7 +152,8 @@ test('platform-lane refresh uses the decrypted shared client secret and persists
 		(error: unknown) =>
 			error instanceof IntegrationTokenRefreshCallerError &&
 			error.message.includes('does not define a refresh token secret name') &&
-			error.message.includes('/connect/oauth?provider=github'),
+			error.message.includes('/connect/oauth?provider=github') &&
+			error.message.includes(integrationTokenRefreshCallerMarker),
 	)
 })
 
@@ -209,7 +211,8 @@ test('provider HTTP 4xx refresh rejection is a caller error with reconnect guida
 					'Token refresh was rejected for integration "google" with HTTP 400',
 				) &&
 				error.message.includes('invalid_grant') &&
-				error.message.includes('/connect/oauth?provider=google'),
+				error.message.includes('/connect/oauth?provider=google') &&
+				error.message.includes(integrationTokenRefreshCallerMarker),
 		)
 	} finally {
 		vi.unstubAllGlobals()
@@ -324,8 +327,13 @@ test('user-lane refresh resolves the client secret from the user secret store', 
 	try {
 		await expect(
 			refreshIntegrationTokens({ env, userId, name: 'google' }),
-		).rejects.toThrow(
-			'Secret "googleRefreshToken" is not approved for host "oauth2.googleapis.com"',
+		).rejects.toSatisfy(
+			(error: unknown) =>
+				error instanceof IntegrationTokenRefreshCallerError &&
+				error.message.includes(
+					'Secret "googleRefreshToken" is not approved for host "oauth2.googleapis.com"',
+				) &&
+				error.message.includes(integrationTokenRefreshCallerMarker),
 		)
 		expect(fetchMock).not.toHaveBeenCalled()
 

--- a/packages/worker/src/integrations/token-refresh.ts
+++ b/packages/worker/src/integrations/token-refresh.ts
@@ -26,23 +26,22 @@ export class IntegrationTokenRefreshCallerError extends Error {
 }
 
 /**
- * Stable phrases from `refreshIntegrationTokens` caller errors. MCP
- * observability and Sentry `beforeSend` depend on them so reconnectable
- * OAuth state stays on structured `mcp-event` logs and out of Sentry.
+ * Trailing marker on every `IntegrationTokenRefreshCallerError` message. MCP
+ * observability and Sentry `beforeSend` match this so reconnectable OAuth
+ * state stays on structured `mcp-event` logs and out of Sentry — without
+ * over-matching unrelated "Integration …" strings elsewhere.
  */
-const integrationTokenRefreshCallerPhrases = [
-	'does not define a refresh token secret name',
-	'Refresh token secret "',
-	'Client secret for integration "',
-	'is not approved for host',
-	'Token refresh was rejected for integration "',
-	'did not return an access_token',
-	'Reconnect at /connect/oauth?provider=',
-] as const
+export const integrationTokenRefreshCallerMarker =
+	'(integration_token_refresh caller state)'
 
 export function isIntegrationTokenRefreshCallerMessage(message: string) {
-	return integrationTokenRefreshCallerPhrases.some((phrase) =>
-		message.includes(phrase),
+	return message.includes(integrationTokenRefreshCallerMarker)
+}
+
+function callerRefreshError(message: string, options?: ErrorOptions) {
+	return new IntegrationTokenRefreshCallerError(
+		`${message} ${integrationTokenRefreshCallerMarker}`,
+		options,
 	)
 }
 
@@ -85,27 +84,25 @@ export async function refreshIntegrationTokens(input: {
 		name: input.name,
 	})
 	if (!joined) {
-		throw new IntegrationTokenRefreshCallerError(
-			`Integration "${input.name}" was not found.`,
-		)
+		throw callerRefreshError(`Integration "${input.name}" was not found.`)
 	}
 	const { app, connection } = joined
 	const reconnectPath = connectOauthPath(connection.name)
 	const clientId = app.clientId.trim()
 	if (!clientId) {
-		throw new IntegrationTokenRefreshCallerError(
+		throw callerRefreshError(
 			`Integration "${connection.name}" does not define a client id. Reconnect at ${reconnectPath}.`,
 		)
 	}
 	const refreshTokenSecretName = connection.refreshTokenSecretName?.trim() ?? ''
 	if (!refreshTokenSecretName) {
-		throw new IntegrationTokenRefreshCallerError(
+		throw callerRefreshError(
 			`Integration "${connection.name}" does not define a refresh token secret name. This connection cannot refresh; reconnect at ${reconnectPath} if the provider issues a refresh token, or stop calling integration_token_refresh for this integration.`,
 		)
 	}
 	const accessTokenSecretName = connection.accessTokenSecretName.trim()
 	if (!accessTokenSecretName) {
-		throw new IntegrationTokenRefreshCallerError(
+		throw callerRefreshError(
 			`Integration "${connection.name}" does not define an access token secret name. Reconnect at ${reconnectPath}.`,
 		)
 	}
@@ -118,7 +115,7 @@ export async function refreshIntegrationTokens(input: {
 	// rows, so no user-secret allowlist applies.
 	const tokenHost = safeParseHost(app.tokenUrl)
 	if (!tokenHost) {
-		throw new IntegrationTokenRefreshCallerError(
+		throw callerRefreshError(
 			`Integration "${connection.name}" has an invalid token URL.`,
 		)
 	}
@@ -128,7 +125,7 @@ export async function refreshIntegrationTokens(input: {
 	) => {
 		if (joined.lane !== 'user') return
 		if (allowedHosts.includes(tokenHost)) return
-		throw new IntegrationTokenRefreshCallerError(
+		throw callerRefreshError(
 			`Secret "${secretName}" is not approved for host "${tokenHost}". Approve the host on /account/secrets before refreshing this integration.`,
 		)
 	}
@@ -141,7 +138,7 @@ export async function refreshIntegrationTokens(input: {
 		storageContext,
 	})
 	if (!refreshTokenSecret.found || !refreshTokenSecret.value) {
-		throw new IntegrationTokenRefreshCallerError(
+		throw callerRefreshError(
 			`Refresh token secret "${refreshTokenSecretName}" was not found. Reconnect at ${reconnectPath}.`,
 		)
 	}
@@ -165,7 +162,7 @@ export async function refreshIntegrationTokens(input: {
 				const clientSecretSecretName =
 					joined.app.clientSecretSecretName?.trim() ?? ''
 				if (!clientSecretSecretName) {
-					throw new IntegrationTokenRefreshCallerError(
+					throw callerRefreshError(
 						`Integration "${connection.name}" uses confidential flow but does not define a client secret secret name.`,
 					)
 				}
@@ -193,7 +190,7 @@ export async function refreshIntegrationTokens(input: {
 			}
 		}
 		if (!clientSecret) {
-			throw new IntegrationTokenRefreshCallerError(
+			throw callerRefreshError(
 				`Client secret for integration "${connection.name}" was not found.`,
 			)
 		}
@@ -234,7 +231,7 @@ export async function refreshIntegrationTokens(input: {
 		// state the user (or operator) clears by reconnecting — not a platform
 		// defect worth a Sentry issue. 5xx stays a plain Error for visibility.
 		if (response.status >= 400 && response.status < 500) {
-			throw new IntegrationTokenRefreshCallerError(
+			throw callerRefreshError(
 				`Token refresh was rejected for integration "${connection.name}" with HTTP ${response.status}${detailSuffix}. Reconnect at ${reconnectPath}.`,
 			)
 		}
@@ -243,7 +240,7 @@ export async function refreshIntegrationTokens(input: {
 		)
 	}
 	if (!payload || typeof payload.access_token !== 'string') {
-		throw new IntegrationTokenRefreshCallerError(
+		throw callerRefreshError(
 			`Token refresh for integration "${connection.name}" did not return an access_token. Reconnect at ${reconnectPath}.`,
 		)
 	}

--- a/packages/worker/src/integrations/token-refresh.ts
+++ b/packages/worker/src/integrations/token-refresh.ts
@@ -13,6 +13,57 @@ export type IntegrationTokenRefreshResult = {
 }
 
 /**
+ * Caller-clearable token-refresh failures: missing refresh token on the
+ * connection, revoked/expired provider grant (HTTP 4xx), host-approval gaps,
+ * and similar reconnectable state. MCP capabilities re-wrap this as
+ * `McpCallerError` so agents get a clear next step and Sentry stays quiet.
+ */
+export class IntegrationTokenRefreshCallerError extends Error {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options)
+		this.name = 'IntegrationTokenRefreshCallerError'
+	}
+}
+
+/**
+ * Stable phrases from `refreshIntegrationTokens` caller errors. MCP
+ * observability and Sentry `beforeSend` depend on them so reconnectable
+ * OAuth state stays on structured `mcp-event` logs and out of Sentry.
+ */
+const integrationTokenRefreshCallerPhrases = [
+	'does not define a refresh token secret name',
+	'Refresh token secret "',
+	'Client secret for integration "',
+	'is not approved for host',
+	'Token refresh was rejected for integration "',
+	'did not return an access_token',
+	'Reconnect at /connect/oauth?provider=',
+] as const
+
+export function isIntegrationTokenRefreshCallerMessage(message: string) {
+	return integrationTokenRefreshCallerPhrases.some((phrase) =>
+		message.includes(phrase),
+	)
+}
+
+function connectOauthPath(integrationName: string) {
+	return `/connect/oauth?provider=${encodeURIComponent(integrationName)}`
+}
+
+function formatProviderTokenError(payload: Record<string, unknown> | null) {
+	if (!payload) return null
+	const error =
+		typeof payload.error === 'string' ? payload.error.trim().slice(0, 80) : ''
+	const description =
+		typeof payload.error_description === 'string'
+			? payload.error_description.trim().slice(0, 200)
+			: ''
+	if (!error && !description) return null
+	if (error && description) return `${error}: ${description}`
+	return error || description
+}
+
+/**
  * Host-side OAuth token refresh. Runs entirely in the Worker: the refresh
  * token and client secret are materialized here (never in the sandbox), the
  * provider response is parsed here, and only fresh token *values* are written
@@ -34,25 +85,28 @@ export async function refreshIntegrationTokens(input: {
 		name: input.name,
 	})
 	if (!joined) {
-		throw new Error(`Integration "${input.name}" was not found.`)
+		throw new IntegrationTokenRefreshCallerError(
+			`Integration "${input.name}" was not found.`,
+		)
 	}
 	const { app, connection } = joined
+	const reconnectPath = connectOauthPath(connection.name)
 	const clientId = app.clientId.trim()
 	if (!clientId) {
-		throw new Error(
-			`Integration "${connection.name}" does not define a client id.`,
+		throw new IntegrationTokenRefreshCallerError(
+			`Integration "${connection.name}" does not define a client id. Reconnect at ${reconnectPath}.`,
 		)
 	}
 	const refreshTokenSecretName = connection.refreshTokenSecretName?.trim() ?? ''
 	if (!refreshTokenSecretName) {
-		throw new Error(
-			`Integration "${connection.name}" does not define a refresh token secret name.`,
+		throw new IntegrationTokenRefreshCallerError(
+			`Integration "${connection.name}" does not define a refresh token secret name. This connection cannot refresh; reconnect at ${reconnectPath} if the provider issues a refresh token, or stop calling integration_token_refresh for this integration.`,
 		)
 	}
 	const accessTokenSecretName = connection.accessTokenSecretName.trim()
 	if (!accessTokenSecretName) {
-		throw new Error(
-			`Integration "${connection.name}" does not define an access token secret name.`,
+		throw new IntegrationTokenRefreshCallerError(
+			`Integration "${connection.name}" does not define an access token secret name. Reconnect at ${reconnectPath}.`,
 		)
 	}
 
@@ -64,7 +118,7 @@ export async function refreshIntegrationTokens(input: {
 	// rows, so no user-secret allowlist applies.
 	const tokenHost = safeParseHost(app.tokenUrl)
 	if (!tokenHost) {
-		throw new Error(
+		throw new IntegrationTokenRefreshCallerError(
 			`Integration "${connection.name}" has an invalid token URL.`,
 		)
 	}
@@ -74,7 +128,7 @@ export async function refreshIntegrationTokens(input: {
 	) => {
 		if (joined.lane !== 'user') return
 		if (allowedHosts.includes(tokenHost)) return
-		throw new Error(
+		throw new IntegrationTokenRefreshCallerError(
 			`Secret "${secretName}" is not approved for host "${tokenHost}". Approve the host on /account/secrets before refreshing this integration.`,
 		)
 	}
@@ -87,8 +141,8 @@ export async function refreshIntegrationTokens(input: {
 		storageContext,
 	})
 	if (!refreshTokenSecret.found || !refreshTokenSecret.value) {
-		throw new Error(
-			`Refresh token secret "${refreshTokenSecretName}" was not found.`,
+		throw new IntegrationTokenRefreshCallerError(
+			`Refresh token secret "${refreshTokenSecretName}" was not found. Reconnect at ${reconnectPath}.`,
 		)
 	}
 	assertUserSecretAllowedForTokenHost(
@@ -111,7 +165,7 @@ export async function refreshIntegrationTokens(input: {
 				const clientSecretSecretName =
 					joined.app.clientSecretSecretName?.trim() ?? ''
 				if (!clientSecretSecretName) {
-					throw new Error(
+					throw new IntegrationTokenRefreshCallerError(
 						`Integration "${connection.name}" uses confidential flow but does not define a client secret secret name.`,
 					)
 				}
@@ -139,7 +193,7 @@ export async function refreshIntegrationTokens(input: {
 			}
 		}
 		if (!clientSecret) {
-			throw new Error(
+			throw new IntegrationTokenRefreshCallerError(
 				`Client secret for integration "${connection.name}" was not found.`,
 			)
 		}
@@ -174,13 +228,23 @@ export async function refreshIntegrationTokens(input: {
 		unknown
 	> | null
 	if (!response.ok) {
+		const providerDetail = formatProviderTokenError(payload)
+		const detailSuffix = providerDetail ? ` (${providerDetail})` : ''
+		// Provider 4xx is almost always revoked/expired grant or bad client
+		// state the user (or operator) clears by reconnecting — not a platform
+		// defect worth a Sentry issue. 5xx stays a plain Error for visibility.
+		if (response.status >= 400 && response.status < 500) {
+			throw new IntegrationTokenRefreshCallerError(
+				`Token refresh was rejected for integration "${connection.name}" with HTTP ${response.status}${detailSuffix}. Reconnect at ${reconnectPath}.`,
+			)
+		}
 		throw new Error(
-			`Token refresh failed for integration "${connection.name}" with HTTP ${response.status}.`,
+			`Token refresh failed for integration "${connection.name}" with HTTP ${response.status}${detailSuffix}.`,
 		)
 	}
 	if (!payload || typeof payload.access_token !== 'string') {
-		throw new Error(
-			`Token refresh for integration "${connection.name}" did not return an access_token.`,
+		throw new IntegrationTokenRefreshCallerError(
+			`Token refresh for integration "${connection.name}" did not return an access_token. Reconnect at ${reconnectPath}.`,
 		)
 	}
 

--- a/packages/worker/src/mcp/capabilities/integrations/integration-token-refresh.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-token-refresh.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
-import { refreshIntegrationTokens } from '#worker/integrations/token-refresh.ts'
+import {
+	IntegrationTokenRefreshCallerError,
+	refreshIntegrationTokens,
+} from '#worker/integrations/token-refresh.ts'
 
 const inputSchema = z.object({
 	name: z
@@ -43,16 +47,25 @@ export const integrationTokenRefreshCapability = defineDomainCapability(
 		outputSchema,
 		async handler(args, ctx: CapabilityContext) {
 			const user = requireMcpUser(ctx.callerContext)
-			const result = await refreshIntegrationTokens({
-				env: ctx.env,
-				userId: user.userId,
-				userEmail: user.email,
-				name: args.name,
-			})
-			return {
-				ok: true as const,
-				refreshedAt: result.refreshedAt,
-				refreshTokenRotated: result.refreshTokenRotated,
+			try {
+				const result = await refreshIntegrationTokens({
+					env: ctx.env,
+					userId: user.userId,
+					userEmail: user.email,
+					name: args.name,
+				})
+				return {
+					ok: true as const,
+					refreshedAt: result.refreshedAt,
+					refreshTokenRotated: result.refreshTokenRotated,
+				}
+			} catch (error) {
+				// Missing refresh token, revoked grant (HTTP 4xx), host-approval
+				// gaps — caller-clearable reconnect state, not platform defects.
+				if (error instanceof IntegrationTokenRefreshCallerError) {
+					throw new McpCallerError(error.message, { cause: error })
+				}
+				throw error
 			}
 		},
 	},

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -306,9 +306,25 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 				'MCP server capability "supermemory:listMemories" failed: ProtocolError: Structured content does not match the tool\'s output schema',
 			),
 		})
+
+		// OAuth token refresh caller state (KODY-CLOUDFLARE-4J): revoked grant
+		// or connection without a refresh token. Plain Error message match.
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'integration_token_refresh',
+			domain: 'integrations',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'Error',
+			errorMessage:
+				'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google.',
+			cause: new Error(
+				'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google.',
+			),
+		})
 	})
 
-	expect(payloads).toHaveLength(17)
+	expect(payloads).toHaveLength(18)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -317,9 +317,9 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			failurePhase: 'handler',
 			errorName: 'Error',
 			errorMessage:
-				'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google.',
+				'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google. (integration_token_refresh caller state)',
 			cause: new Error(
-				'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google.',
+				'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google. (integration_token_refresh caller state)',
 			),
 		})
 	})

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -14,6 +14,7 @@ import {
 	isPrivateVisibilityChangeConfirmationMessage,
 } from '#worker/repo/source-safety-policy.ts'
 import { isUserStorageSqlCallerMessage } from '#worker/storage-sql-caller-error.ts'
+import { isIntegrationTokenRefreshCallerMessage } from '#worker/integrations/token-refresh.ts'
 import { isUserCodeError } from '#worker/user-code-error.ts'
 import { isMcpCallerError } from './caller-error.ts'
 
@@ -172,6 +173,18 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 				entry instanceof Error &&
 				(isDestructiveOverwriteConfirmationMessage(entry.message) ||
 					isPrivateVisibilityChangeConfirmationMessage(entry.message)),
+		)
+	) {
+		return true
+	}
+	// OAuth token refresh preconditions and provider 4xx rejections
+	// (revoked/expired grant, connection without a refresh token). Agents
+	// reconnect at /connect/oauth; keep volume on mcp-event lines.
+	if (
+		getErrorCauseChain(cause).some(
+			(entry) =>
+				entry instanceof Error &&
+				isIntegrationTokenRefreshCallerMessage(entry.message),
 		)
 	) {
 		return true

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -226,6 +226,46 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).not.toBeNull()
 
+	// OAuth token-refresh caller state (KODY-CLOUDFLARE-4J).
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Integration "linkedin" does not define a refresh token secret name. This connection cannot refresh; reconnect at /connect/oauth?provider=linkedin if the provider issues a refresh token, or stop calling integration_token_refresh for this integration.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	// Provider 5xx keeps the "Token refresh failed …" wording and must stay
+	// visible in Sentry.
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Token refresh failed for integration "google" with HTTP 503 (server_error).',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+
 	const platformBuildFailure = {
 		exception: {
 			values: [

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -226,14 +226,15 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		}),
 	).not.toBeNull()
 
-	// OAuth token-refresh caller state (KODY-CLOUDFLARE-4J).
+	// OAuth token-refresh caller state (KODY-CLOUDFLARE-4J). The trailing
+	// marker is the stable beforeSend match for every caller-error constructor.
 	expect(
 		filterSentryEvent({
 			exception: {
 				values: [
 					{
 						value:
-							'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google.',
+							'Token refresh was rejected for integration "google" with HTTP 400 (invalid_grant: Token has been expired or revoked.). Reconnect at /connect/oauth?provider=google. (integration_token_refresh caller state)',
 					},
 				],
 			},
@@ -245,14 +246,50 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 				values: [
 					{
 						value:
-							'Integration "linkedin" does not define a refresh token secret name. This connection cannot refresh; reconnect at /connect/oauth?provider=linkedin if the provider issues a refresh token, or stop calling integration_token_refresh for this integration.',
+							'Integration "linkedin" does not define a refresh token secret name. This connection cannot refresh; reconnect at /connect/oauth?provider=linkedin if the provider issues a refresh token, or stop calling integration_token_refresh for this integration. (integration_token_refresh caller state)',
 					},
 				],
 			},
 		}),
 	).toBeNull()
-	// Provider 5xx keeps the "Token refresh failed …" wording and must stay
-	// visible in Sentry.
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Integration "missing" was not found. (integration_token_refresh caller state)',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Integration "broken" has an invalid token URL. (integration_token_refresh caller state)',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Integration "broken" uses confidential flow but does not define a client secret secret name. (integration_token_refresh caller state)',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	// Provider 5xx keeps the "Token refresh failed …" wording (no marker) and
+	// must stay visible in Sentry.
 	expect(
 		filterSentryEvent({
 			exception: {
@@ -260,6 +297,18 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 					{
 						value:
 							'Token refresh failed for integration "google" with HTTP 503 (server_error).',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	// Unrelated Integration-not-found strings without the marker must stay.
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: 'Integration "spotify" was not found.',
 					},
 				],
 			},

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -3,6 +3,7 @@ import { type ErrorEvent, type EventHint } from '@sentry/core'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 import { isEntitlementLimitError } from './entitlements/errors.ts'
 import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
+import { isIntegrationTokenRefreshCallerMessage } from './integrations/token-refresh.ts'
 import { isRemoteConnectorUnavailableMessage } from './remote-connector/status.ts'
 import { isUserCodeError } from './user-code-error.ts'
 
@@ -164,6 +165,27 @@ export function isRemoteConnectorUnavailableSentryEvent(event: ErrorEvent) {
 
 export function filterRemoteConnectorUnavailableSentryEvent(event: ErrorEvent) {
 	if (!isRemoteConnectorUnavailableSentryEvent(event)) return event
+	return null
+}
+
+/**
+ * OAuth token-refresh caller state (no refresh token on the connection,
+ * provider HTTP 4xx / invalid_grant, missing secrets). MCP observability
+ * already skips them via `isCallerFailure`; this `beforeSend` gate is the
+ * backstop for any other capture path that still forwards the plain Error.
+ */
+export function isIntegrationTokenRefreshCallerSentryEvent(event: ErrorEvent) {
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isIntegrationTokenRefreshCallerMessage(message),
+	)
+}
+
+export function filterIntegrationTokenRefreshCallerSentryEvent(
+	event: ErrorEvent,
+) {
+	if (!isIntegrationTokenRefreshCallerSentryEvent(event)) return event
 	return null
 }
 
@@ -331,6 +353,8 @@ export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	if (filterUserModuleBundlerFailureSentryEvent(event) === null) return null
 	if (filterExecutorSandboxTimeoutSentryEvent(event) === null) return null
 	if (filterRemoteConnectorUnavailableSentryEvent(event) === null) return null
+	if (filterIntegrationTokenRefreshCallerSentryEvent(event) === null)
+		return null
 	if (filterDurableObjectIsolateResetSentryEvent(event) === null) return null
 	if (filterCloudflareOpaqueInternalErrorSentryEvent(event) === null)
 		return null
@@ -372,7 +396,10 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// paths; see filterUserModuleBundlerFailureSentryEvent and
 		// filterExecutorSandboxTimeoutSentryEvent. Offline remote-connector
 		// guidance messages are dropped the same way — see
-		// filterRemoteConnectorUnavailableSentryEvent. Bare Cloudflare Durable
+		// filterRemoteConnectorUnavailableSentryEvent. OAuth token-refresh
+		// caller state (missing refresh token, provider 4xx / invalid_grant)
+		// is dropped the same way — see
+		// filterIntegrationTokenRefreshCallerSentryEvent. Bare Cloudflare Durable
 		// Object platform reset strings (memory/CPU limits, deploy-time code
 		// updates, blockConcurrencyWhile timeouts, DO storage operation
 		// timeouts, and DO storage object-reset with a support reference) are


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-4J](https://kent-c-dodds-tech-llc.sentry.io/issues/7662842923/) grouped reconnectable OAuth refresh failures as platform bugs:

- Google refresh rejected with HTTP 400 (`invalid_grant` / expired or revoked consent)
- Connections without a refresh token (e.g. GitHub, LinkedIn) when something still calls `integration_token_refresh`

These are caller-clearable account/connection state, not Worker defects. This PR classifies them as `IntegrationTokenRefreshCallerError` (every message ends with a shared `(integration_token_refresh caller state)` marker), re-wraps as `McpCallerError` from `integration_token_refresh`, matches the marker in `isCallerFailure`, and adds a `beforeSend` backstop. Messages include truncated provider `error` / `error_description` and a `/connect/oauth?provider=…` reconnect path. Provider HTTP 5xx keeps the old "failed" wording (no marker) and still reports to Sentry.

**Merge note:** CI green; left open for Kent — medium risk / OAuth auth surface. After squash-merge + deploy, resolve the Sentry issue in the merge commit.

## Test plan

- [x] `token-refresh.node.test.ts` — missing refresh token → caller error; HTTP 400 → caller error with reconnect + marker; HTTP 503 → plain Error; host-approval → caller error
- [x] `observability.node.test.ts` — refresh rejection message stays off Sentry
- [x] `sentry-options.node.test.ts` — beforeSend drops marker messages (incl. missing integration / invalid URL / missing client-secret-name); keeps 5xx and unmarked Integration-not-found
- [x] `npm run validate` (local) + CI ✅ Validate / Node / Workers / MCP / E2E / Static

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `328a45d7` · **Head:** `a30f5e7e`

**Classification:** extends — changes how OAuth token-refresh failures are classified for MCP observability and Sentry; reconnectable 4xx / missing refresh-token state leaves issue reporting, while provider 5xx stays visible.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `integrations` | assistant | extends — `IntegrationTokenRefreshCallerError` + shared marker for preconditions and provider 4xx; reconnect guidance in messages |
| `mcp-server` | surfaces | extends — `isCallerFailure` matches the token-refresh caller marker |
| _(unmatched)_ `sentry-options` | — | composes — `beforeSend` backstop for the same marker |

### System map

Token refresh failures flow from the integrations capability through MCP observability; this PR stops reconnectable cases from opening Sentry issues while keeping provider outages visible.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	integrations["integrations<br/>OAuth integrations"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	sentryOpts["sentry-options<br/>beforeSend filters"]:::touched
	integrations -->|"caller 4xx / missing refresh token"| mcpServer
	mcpServer -->|"isCallerFailure skip"| sentryOpts
	integrations -->|"marker phrase backstop"| sentryOpts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Touches OAuth token refresh (auth/credentials path). No change to how tokens are materialized, exchanged, or persisted — only error classification and agent-facing guidance.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a33eb07c-caba-4e55-9857-c58a57681a76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a33eb07c-caba-4e55-9857-c58a57681a76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth token refresh error handling with clearer reconnect guidance.
  - Provider 4xx responses now include actionable error details.
  - Malformed token responses are reported as caller-resolvable errors.
  - Provider 5xx failures continue to be surfaced for monitoring and investigation.
  - Caller-resolvable refresh failures are excluded from Sentry while remaining available in application event logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->