### PR TITLE
fix(sentry): filter bare MCP Agent session teardown abort (KODY-CLOUDFLARE-4K)

### DIFF
--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -150,7 +150,9 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	// Bare Agents MCP session teardown abort (`ctx.abort("destroyed")`) —
 	// KODY-CLOUDFLARE-4K. Wrapped "stream was destroyed" forms stay visible.
 	expect(
-		isMcpAgentSessionDestroyedAbortMessage(mcpAgentSessionDestroyedAbortMessage),
+		isMcpAgentSessionDestroyedAbortMessage(
+			mcpAgentSessionDestroyedAbortMessage,
+		),
 	).toBe(true)
 	expect(isMcpAgentSessionDestroyedAbortMessage('Error: destroyed')).toBe(true)
 	expect(isMcpAgentSessionDestroyedAbortMessage('destroyed.')).toBe(true)
@@ -173,9 +175,7 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	).toBeNull()
 	const wrappedDestroyed = {
 		exception: {
-			values: [
-				{ value: 'Cannot call write after a stream was destroyed' },
-			],
+			values: [{ value: 'Cannot call write after a stream was destroyed' }],
 		},
 	}
 	expect(filterSentryEvent(wrappedDestroyed)).toBe(wrappedDestroyed)

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -15,6 +15,8 @@ import {
 	filterSentryEvent,
 	isCloudflareOpaqueInternalErrorMessage,
 	isDurableObjectIsolateResourceLimitResetMessage,
+	isMcpAgentSessionDestroyedAbortMessage,
+	mcpAgentSessionDestroyedAbortMessage,
 } from './sentry-options.ts'
 
 test('filterSentryEvent drops expected platform and caller noise and keeps real errors', () => {
@@ -144,6 +146,39 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		},
 	}
 	expect(filterSentryEvent(wrappedOpaqueInternal)).toBe(wrappedOpaqueInternal)
+
+	// Bare Agents MCP session teardown abort (`ctx.abort("destroyed")`) —
+	// KODY-CLOUDFLARE-4K. Wrapped "stream was destroyed" forms stay visible.
+	expect(
+		isMcpAgentSessionDestroyedAbortMessage(mcpAgentSessionDestroyedAbortMessage),
+	).toBe(true)
+	expect(isMcpAgentSessionDestroyedAbortMessage('Error: destroyed')).toBe(true)
+	expect(isMcpAgentSessionDestroyedAbortMessage('destroyed.')).toBe(true)
+	expect(
+		isMcpAgentSessionDestroyedAbortMessage(
+			'Cannot call write after a stream was destroyed',
+		),
+	).toBe(false)
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [{ value: mcpAgentSessionDestroyedAbortMessage }],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: { values: [{ value: 'Error: destroyed' }] },
+		}),
+	).toBeNull()
+	const wrappedDestroyed = {
+		exception: {
+			values: [
+				{ value: 'Cannot call write after a stream was destroyed' },
+			],
+		},
+	}
+	expect(filterSentryEvent(wrappedDestroyed)).toBe(wrappedDestroyed)
 
 	const bareObjectReset = {
 		exception: {

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -322,6 +322,50 @@ export function filterCloudflareOpaqueInternalErrorSentryEvent(
 	return null
 }
 
+/**
+ * Bare Durable Object abort reason from Cloudflare Agents MCP session
+ * teardown (`ctx.abort("destroyed")` inside `Agent.destroy()` /
+ * `_cf_scheduleDestroy`). Observed on `/mcp` when a Streamable-HTTP client
+ * DELETEs its session (or a concurrent request races the abort) —
+ * KODY-CLOUDFLARE-4K. Same class as other DO platform-reset strings: not an
+ * application defect. Match only the exact abort token (optional `Error:`
+ * prefix / trailing period) so wrapped forms such as "stream was destroyed"
+ * or "Cannot call write after a stream was destroyed" stay Sentry-visible.
+ */
+export const mcpAgentSessionDestroyedAbortMessage = 'destroyed'
+
+function normalizeMcpAgentSessionDestroyedAbortMessage(message: string) {
+	const withoutErrorPrefix = message.trim().replace(/^Error:\s*/i, '')
+	return withoutErrorPrefix.endsWith('.')
+		? withoutErrorPrefix.slice(0, -1)
+		: withoutErrorPrefix
+}
+
+export function isMcpAgentSessionDestroyedAbortMessage(message: string) {
+	return (
+		normalizeMcpAgentSessionDestroyedAbortMessage(message) ===
+		mcpAgentSessionDestroyedAbortMessage
+	)
+}
+
+export function isMcpAgentSessionDestroyedAbortSentryEvent(event: ErrorEvent) {
+	const messages = sentryEventMessages(event).filter(
+		(message): message is string =>
+			typeof message === 'string' && message.trim().length > 0,
+	)
+	return (
+		messages.length > 0 &&
+		messages.every((message) => isMcpAgentSessionDestroyedAbortMessage(message))
+	)
+}
+
+export function filterMcpAgentSessionDestroyedAbortSentryEvent(
+	event: ErrorEvent,
+) {
+	if (!isMcpAgentSessionDestroyedAbortSentryEvent(event)) return event
+	return null
+}
+
 export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	// Marker first: primary mechanism for user-authored failures.
 	if (filterUserCodeErrorSentryEvent(event, hint) === null) return null
@@ -333,6 +377,8 @@ export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	if (filterRemoteConnectorUnavailableSentryEvent(event) === null) return null
 	if (filterDurableObjectIsolateResetSentryEvent(event) === null) return null
 	if (filterCloudflareOpaqueInternalErrorSentryEvent(event) === null)
+		return null
+	if (filterMcpAgentSessionDestroyedAbortSentryEvent(event) === null)
 		return null
 	return event
 }
@@ -380,6 +426,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// Exact opaque Cloudflare "An internal error occurred." (and Artifacts
 		// INTERNAL_ERROR wording) with no support reference are dropped the
 		// same way — see filterCloudflareOpaqueInternalErrorSentryEvent.
+		// Bare Durable Object abort token `destroyed` from Agents MCP session
+		// teardown (`ctx.abort("destroyed")`) is dropped the same way — see
+		// filterMcpAgentSessionDestroyedAbortSentryEvent.
 		beforeSend: filterSentryEvent,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-4K](https://kent-c-dodds-tech-llc.sentry.io/issues/7664607775/) (`Error: destroyed` on `/mcp`) is the Durable Object abort reason from Cloudflare Agents MCP session teardown (`ctx.abort("destroyed")` inside `Agent.destroy()` / `_cf_scheduleDestroy`). One production event; not an application defect.

This PR adds a narrow `beforeSend` filter that drops only the bare abort token (`destroyed`, optional `Error:` prefix / trailing period), matching the existing platform-noise filters. Wrapped messages such as "Cannot call write after a stream was destroyed" stay visible.

## Evidence

- Stack: `handleMcpRequest` → account write lease → Agents `mcp/utils` (legacy/sessionful MCP lane)
- Cloudflare agents maintainers documented this exact `Uncaught Error: destroyed` as DO `abort("destroyed")` on session DELETE ([cloudflare/agents#456](https://github.com/cloudflare/agents/issues/456))
- Repo already on `agents@0.20.1` with `DESTROY_ALARM_DELAY_MS`; residual races still surface the bare abort string to Sentry

## Test plan

- [x] `vitest run packages/worker/src/sentry-options.node.test.ts`
- [ ] CI `npm run validate` (via PR checks)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `328a45d7` · **Head:** `b8d18e70`

**Classification:** composes — no primitives added or changed; this PR only wires an observability `beforeSend` filter for known MCP Agent DO abort noise.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none matched)_ | — | unmatched: `packages/worker/src/sentry-options.ts` (+ tests) — Worker Sentry `beforeSend` filter only |

### System map

MCP session DELETE aborts the session Durable Object; the Worker Sentry wrapper previously forwarded the bare abort token.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	sentryFilter["sentry-options<br/>Worker beforeSend"]:::touched
	mcpServer -->|"session DELETE / DO abort"| sentryFilter
	sentryFilter -->|"drop bare destroyed token"| drop["filtered"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Client
	participant MCP as /mcp Worker
	participant DO as McpAgent DO
	participant Sentry
	Client->>MCP: DELETE session
	MCP->>DO: destroy / _cf_scheduleDestroy
	DO-->>MCP: ctx.abort("destroyed")
	MCP-->>Sentry: Error: destroyed
	Note over Sentry: beforeSend drops bare token
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d877911-dd42-468b-92f7-32045d9e8117?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d877911-dd42-468b-92f7-32045d9e8117&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from Sentry by filtering expected MCP session teardown abort messages.
  * Preserved visibility for unrelated or wrapped stream-destruction errors.
  * Added coverage for supported message formats, including prefixes and punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->