### PR TITLE
feat(package-apps): per-user subdomains on the package-app domain

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -381,13 +381,13 @@ the app origin mints `<base64url payload>.<HMAC-SHA256>`:
   the binding is missing; signature, expiry, and the path binding always fail
   closed.
 
-It travels in the `__kody_handoff` query parameter of a cross-origin redirect
-to the owner's package-app subdomain, which is why it is deliberately this weak.
-A token in a URL is exposed to browser history, referrers, and anything that
-logs URLs; the subdomain redirects straight to the same URL without it, which
-reduces that exposure but cannot eliminate it. The 60-second expiry and the
-single-use burn are what bound the damage when a token does leak. A request that
-still carries the parameter is rewritten without it before package code sees it.
+It travels in the `__kody_handoff` query parameter of a cross-origin redirect to
+the owner's package-app subdomain, which is why it is deliberately this weak. A
+token in a URL is exposed to browser history, referrers, and anything that logs
+URLs; the subdomain redirects straight to the same URL without it, which reduces
+that exposure but cannot eliminate it. The 60-second expiry and the single-use
+burn are what bound the damage when a token does leak. A request that still
+carries the parameter is rewritten without it before package code sees it.
 
 **Package-app session cookie**
 (`packages/worker/src/app/package-app-session.ts`). Exchanging a valid token on

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -404,6 +404,10 @@ the owner's subdomain sets `__Host-kody_pkg_session` on secure requests (plain
   substitution
 - the `__Host-` prefix on secure requests forbids a `Domain` attribute, so
   sibling subdomains cannot plant a shadow cookie under this name
+- sibling subdomains are still same-site (until the Public Suffix List entry),
+  so mutating requests additionally require any `Origin` header to match the
+  subdomain itself — see the same-site paragraph in
+  [security.md](../security.md#hosted-package-app-origin-isolation)
 
 It authorizes hosted package-app serving for one account on that account's
 subdomain and nothing else: the app origin has no code path that reads it, and

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -357,8 +357,10 @@ Hosted package apps run on their own registrable domain in production
 (`PACKAGE_APP_BASE_URL`) so author-supplied code is cross-site from the app
 origin — see
 [Hosted package app origin isolation](../security.md#hosted-package-app-origin-isolation)
-for why. That means `kody_session` never reaches them, so the package-app origin
-needs its own, deliberately smaller credential.
+for why. Production serves each owner's apps on a per-user subdomain of that
+domain (`https://{username}.kodyapps.dev/packages/{kodyId}/...`); the apex only
+redirects. That means `kody_session` never reaches them, so the package-app
+subdomain needs its own, deliberately smaller credential.
 
 **Handoff token** (`packages/worker/src/app/package-app-handoff.ts`). When a
 signed-in owner requests `/@{username}/packages/{kodyId}/...` on the app origin,
@@ -368,7 +370,7 @@ the app origin mints `<base64url payload>.<HMAC-SHA256>`:
   (`kody-package-app-handoff:v2`), so it is not interchangeable with any other
   signed value
 - payload binds `{ stableUserId, username, kodyId, exp, jti }`; the package-app
-  origin rejects a token whose `username`/`kodyId` do not match the requested
+  subdomain rejects a token whose `username`/`kodyId` do not match the requested
   path
 - 60 second lifetime
 - single use: `jti` is burned in `BUNDLE_ARTIFACTS_KV` for 60 seconds on first
@@ -379,17 +381,18 @@ the app origin mints `<base64url payload>.<HMAC-SHA256>`:
   the binding is missing; signature, expiry, and the path binding always fail
   closed.
 
-It travels in the `__kody_handoff` query parameter of a cross-origin redirect,
-which is why it is deliberately this weak. A token in a URL is exposed to
-browser history, referrers, and anything that logs URLs; the package-app origin
-redirects straight to the same URL without it, which reduces that exposure but
-cannot eliminate it. The 60-second expiry and the single-use burn are what bound
-the damage when a token does leak. A request that still carries the parameter is
-rewritten without it before package code sees it.
+It travels in the `__kody_handoff` query parameter of a cross-origin redirect
+to the owner's package-app subdomain, which is why it is deliberately this weak.
+A token in a URL is exposed to browser history, referrers, and anything that
+logs URLs; the subdomain redirects straight to the same URL without it, which
+reduces that exposure but cannot eliminate it. The 60-second expiry and the
+single-use burn are what bound the damage when a token does leak. A request that
+still carries the parameter is rewritten without it before package code sees it.
 
 **Package-app session cookie**
-(`packages/worker/src/app/package-app-session.ts`). Exchanging a valid token
-sets `kody_pkg_session` on the package-app origin:
+(`packages/worker/src/app/package-app-session.ts`). Exchanging a valid token on
+the owner's subdomain sets `__Host-kody_pkg_session` on secure requests (plain
+`kody_pkg_session` on insecure local HTTP only):
 
 - `httpOnly: true`, `sameSite: 'Lax'`, `path: '/'`, `secure` per request
 - 12 hour max age
@@ -399,17 +402,21 @@ sets `kody_pkg_session` on the package-app origin:
 - payload is `{ v, stableUserId, pkgUsername, issuedAt }` — a shape the app
   session schema rejects, so the two cannot be confused even by name
   substitution
+- the `__Host-` prefix on secure requests forbids a `Domain` attribute, so
+  sibling subdomains cannot plant a shadow cookie under this name
 
-It authorizes hosted package-app serving for one account and nothing else: the
-app origin has no code path that reads it, and the package-app origin has no
-first-party routes. Every request re-resolves the account from D1
-(`resolvePackageAppOwnerByStableUserId`) and fails closed for unknown, deleting,
-or suspended accounts, and for sessions issued at or before
-`users.password_changed_at` — the same rules browser sessions follow. Confirmed
-local, preview, and test runtimes with `PACKAGE_APP_BASE_URL` unset never mint
-either credential; they serve package apps inline behind `kody_session`.
-Production requires a separate registrable package-app origin and returns `500`
-instead of falling back inline when that configuration is missing or unsafe.
+It authorizes hosted package-app serving for one account on that account's
+subdomain and nothing else: the app origin has no code path that reads it, and
+the package-app domain has no first-party routes. Every request re-resolves the
+account from D1 (`resolvePackageAppOwnerByStableUserId`) and fails closed for
+unknown, deleting, or suspended accounts, for sessions issued at or before
+`users.password_changed_at` — the same rules browser sessions follow — and when
+the session account's username does not match the subdomain label and requested
+package path. Confirmed local, preview, and test runtimes with
+`PACKAGE_APP_BASE_URL` unset never mint either credential; they serve package
+apps inline behind `kody_session`. Production requires a separate registrable
+package-app origin and returns `500` instead of falling back inline when that
+configuration is missing or unsafe.
 
 ## Account secret reveal
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -31,10 +31,10 @@ Requests are handled in this order:
    - On the **package-app apex**, no package code runs: `/` redirects to the app
      origin; legacy `/@{username}/packages/*` redirects to the owning user's
      subdomain; everything else is `404`.
-   - On a **per-user package-app subdomain**
-     (`{username}.<package-app host>`), only `/packages/{kodyId}/*` for that
-     hostname's username is served (plus the handoff-token exchange on those same
-     paths). `/` redirects to the app origin; every other path is `404`.
+   - On a **per-user package-app subdomain** (`{username}.<package-app host>`),
+     only `/packages/{kodyId}/*` for that hostname's username is served (plus
+     the handoff-token exchange on those same paths). `/` redirects to the app
+     origin; every other path is `404`.
    - On the **app origin**, `/@{username}/packages/*` never executes package
      code: safe methods redirect to the owner's package-app subdomain with a
      handoff token, other methods get a `307` to that subdomain.

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -28,12 +28,16 @@ Requests are handled in this order:
 
 0. Package-app host isolation (before everything else — see
    [Hosted package app origin isolation](../security.md#hosted-package-app-origin-isolation)):
-   - On the **package-app origin**, only `/@{username}/packages/*` is served
-     (plus the handoff-token exchange on those same paths). `/` redirects to the
-     app origin; every other path is `404`.
+   - On the **package-app apex**, no package code runs: `/` redirects to the app
+     origin; legacy `/@{username}/packages/*` redirects to the owning user's
+     subdomain; everything else is `404`.
+   - On a **per-user package-app subdomain**
+     (`{username}.<package-app host>`), only `/packages/{kodyId}/*` for that
+     hostname's username is served (plus the handoff-token exchange on those same
+     paths). `/` redirects to the app origin; every other path is `404`.
    - On the **app origin**, `/@{username}/packages/*` never executes package
-     code: safe methods redirect to the package-app origin with a handoff token,
-     other methods get a `307` to the same path there.
+     code: safe methods redirect to the owner's package-app subdomain with a
+     handoff token, other methods get a `307` to that subdomain.
    - Production package-app requests fail with `500` when `PACKAGE_APP_BASE_URL`
      is missing or is not on a separate registrable domain from `APP_BASE_URL`;
      package code never executes inline.

--- a/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
+++ b/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
@@ -31,22 +31,23 @@ block `{username}.kodyapps.dev` for affected accounts.
 Serve production hosted package apps on **per-user subdomains** of the
 package-app apex:
 
-- Public URL shape:
-  `https://{username}.kodyapps.dev/packages/{kodyId}/{path}`
+- Public URL shape: `https://{username}.kodyapps.dev/packages/{kodyId}/{path}`
 - The apex (`kodyapps.dev`) serves no package code: `/` redirects to the app
   origin; legacy `/@user/packages/...` paths redirect to the owning subdomain;
   everything else `404`s.
 - The app-origin path `/@{username}/packages/...` remains the authenticated
   entry point and redirects into the handoff on the owner's subdomain.
-- Package-app session cookies on secure requests use the `__Host-kody_pkg_session`
-  name so browsers reject any variant with a `Domain` attribute (cookie-tossing
-  defense before Public Suffix List entry). Insecure local HTTP keeps plain
-  `kody_pkg_session`.
+- Package-app session cookies on secure requests use the
+  `__Host-kody_pkg_session` name so browsers reject any variant with a `Domain`
+  attribute (cookie-tossing defense before Public Suffix List entry). Insecure
+  local HTTP keeps plain `kody_pkg_session`.
 - Serving requires session account username == subdomain label == path owner
   (fixation defense).
-- Usernames are strict DNS labels (lowercase alphanumeric + hyphens; underscores
-  banned). Accounts with legacy underscore usernames must rename before hosted
-  apps work.
+- New and changed usernames are strict DNS labels (lowercase alphanumeric +
+  hyphens; underscores banned). Recognition of stored usernames stays lenient
+  (two-tier validation) so legacy underscore accounts keep display names, public
+  lookup, and inbound email routing; they must rename before hosted apps work
+  (the app origin answers their package-app entry with a `409` rename prompt).
 - `packageContext.appBasePath` on a subdomain is `/packages/{kodyId}` (no
   `/@{username}` prefix); inline non-production serving keeps the path-based
   mount. Well-behaved packages that use `hostedUrl` / `appBasePath` stay
@@ -69,5 +70,5 @@ package-app apex:
   hosting works.
 - `parsePackageSearchIdentity`, status probes, and author docs must recognize
   both subdomain URLs and legacy path shapes during transition.
-- Revisit per-package subdomains only if same-owner isolation becomes a
-  reported abuse vector or a product requirement.
+- Revisit per-package subdomains only if same-owner isolation becomes a reported
+  abuse vector or a product requirement.

--- a/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
+++ b/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
@@ -1,0 +1,73 @@
+# 0017: Per-user subdomains for hosted package apps
+
+- **Status:** accepted
+- **Date:** 2026-08-11
+
+## Context
+
+Hosted package apps execute author-supplied HTML and JavaScript. Production
+already isolates them from the first-party app origin via a separate registrable
+domain (`PACKAGE_APP_BASE_URL`, `kodyapps.dev`) and credential stripping, but
+every owner's apps still shared one origin on that domain. One user's package
+could reach another user's `kody_pkg_session`-authorized endpoints from the
+browser — a smaller blast radius than first-party access, but not zero.
+
+Alternatives considered:
+
+- **Stay on one shared package-app origin.** Simpler DNS and routing, but
+  user-to-user browser isolation remains incomplete.
+- **Per-package subdomains** (`{kodyId}.kodyapps.dev`). Stronger same-owner
+  isolation, but multiplies DNS/certificate surface and complicates the handoff
+  and `packageContext` contract for every package.
+- **Path-only isolation with stricter CSP on package apps.** Would still leave
+  same-origin cookie and storage sharing; CSP cannot be applied to author code
+  without breaking real apps.
+
+Usernames had allowed underscores, which are invalid in DNS labels and would
+block `{username}.kodyapps.dev` for affected accounts.
+
+## Decision
+
+Serve production hosted package apps on **per-user subdomains** of the
+package-app apex:
+
+- Public URL shape:
+  `https://{username}.kodyapps.dev/packages/{kodyId}/{path}`
+- The apex (`kodyapps.dev`) serves no package code: `/` redirects to the app
+  origin; legacy `/@user/packages/...` paths redirect to the owning subdomain;
+  everything else `404`s.
+- The app-origin path `/@{username}/packages/...` remains the authenticated
+  entry point and redirects into the handoff on the owner's subdomain.
+- Package-app session cookies on secure requests use the `__Host-kody_pkg_session`
+  name so browsers reject any variant with a `Domain` attribute (cookie-tossing
+  defense before Public Suffix List entry). Insecure local HTTP keeps plain
+  `kody_pkg_session`.
+- Serving requires session account username == subdomain label == path owner
+  (fixation defense).
+- Usernames are strict DNS labels (lowercase alphanumeric + hyphens; underscores
+  banned). Accounts with legacy underscore usernames must rename before hosted
+  apps work.
+- `packageContext.appBasePath` on a subdomain is `/packages/{kodyId}` (no
+  `/@{username}` prefix); inline non-production serving keeps the path-based
+  mount. Well-behaved packages that use `hostedUrl` / `appBasePath` stay
+  transparent.
+- Untrusted markdown refuses `/packages/...` links on any host in addition to
+  `/@...`.
+- **Same-user package-to-package isolation is deliberately deferred:** two
+  packages of one owner still share that owner's subdomain origin.
+- **Operational follow-up:** submit `kodyapps.dev` to the Public Suffix List
+  (`_psl` TXT record + PR to publicsuffix/list) for defense-in-depth.
+
+## Consequences
+
+- User-to-user browser isolation for hosted apps is complete; same-owner
+  cross-package reachability remains an accepted residual risk (documented in
+  [`security.md`](../security.md)).
+- Production deploys require wildcard DNS and a `*.kodyapps.dev/*` Worker route
+  (see [`setup-manifest.md`](../setup-manifest.md)).
+- Username renames become mandatory for underscore holders before subdomain
+  hosting works.
+- `parsePackageSearchIdentity`, status probes, and author docs must recognize
+  both subdomain URLs and legacy path shapes during transition.
+- Revisit per-package subdomains only if same-owner isolation becomes a
+  reported abuse vector or a product requirement.

--- a/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
+++ b/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
@@ -43,6 +43,10 @@ package-app apex:
   local HTTP keeps plain `kody_pkg_session`.
 - Serving requires session account username == subdomain label == path owner
   (fixation defense).
+- Mutating requests on a subdomain require any `Origin` header to match the
+  subdomain itself: sibling subdomains stay same-site until the PSL entry, so a
+  `SameSite=Lax` cookie would otherwise attach to a cross-subdomain mutation
+  from a browser holding sessions for two accounts.
 - New and changed usernames are strict DNS labels (lowercase alphanumeric +
   hyphens; underscores banned). Recognition of stored usernames stays lenient
   (two-tier validation) so legacy underscore accounts keep display names, public

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -36,3 +36,4 @@ behavior (see [documentation principles](../documentation.md)).
 - [0014 — Platform scopes resolve live in package imports](./0014-platform-live-packages.md)
 - [0015 — Wait on Skills over MCP (SEP-2640); serve skill content via packages](./0015-skills-over-mcp-wait.md)
 - [0016 — Extract the package runtime and jobs lanes into separate workers](./0016-mono-worker-extraction.md)
+- [0017 — Per-user subdomains for hosted package apps](./0017-per-user-package-app-subdomains.md)

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -120,17 +120,17 @@ confirmed non-production runtimes; see `packages/worker/src/app-base-url.ts` and
   `custom_domain` routes for the apex and a wildcard for per-user subdomains so
   Cloudflare provisions DNS and edge certificates (see
   [setup-manifest.md](./setup-manifest.md)). Each owner's apps are addressed at
-  `https://{username}.<apex-host>/packages/{kodyId}/...`; the apex itself
-  serves only redirects (legacy `/@user/packages/...` paths to the owning
-  subdomain, `/` to the app origin). It **must be a separate registrable domain**
-  from `APP_BASE_URL`: that is what makes author-supplied package code
-  cross-site, so the `SameSite=Lax` `kody_session` cookie never reaches it.
-  Production origin validation also requires `APP_BASE_URL` so this relationship
-  can be checked at runtime. Production returns `500` for package-app requests
-  when this value is missing, invalid, equal to `APP_BASE_URL`, or on the same
-  registrable domain; it never falls back to inline serving. Preview, tests, and
-  E2E may leave it unset and keep serving package apps inline on the app origin
-  at `/@{username}/packages/*`.
+  `https://{username}.<apex-host>/packages/{kodyId}/...`; the apex itself serves
+  only redirects (legacy `/@user/packages/...` paths to the owning subdomain,
+  `/` to the app origin). It **must be a separate registrable domain** from
+  `APP_BASE_URL`: that is what makes author-supplied package code cross-site, so
+  the `SameSite=Lax` `kody_session` cookie never reaches it. Production origin
+  validation also requires `APP_BASE_URL` so this relationship can be checked at
+  runtime. Production returns `500` for package-app requests when this value is
+  missing, invalid, equal to `APP_BASE_URL`, or on the same registrable domain;
+  it never falls back to inline serving. Preview, tests, and E2E may leave it
+  unset and keep serving package apps inline on the app origin at
+  `/@{username}/packages/*`.
 
   `npm run dev` runs the **production** Wrangler environment, so the committed
   production value reaches local dev too; `getPackageAppBaseUrl` ignores an

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -114,12 +114,16 @@ Wrangler `var` (public and non-secret; required in production, optional in
 confirmed non-production runtimes; see `packages/worker/src/app-base-url.ts` and
 `packages/worker/src/app/package-app-origin.ts`):
 
-- `PACKAGE_APP_BASE_URL` — the origin that hosted package apps are served from.
-  Production sets `https://kodyapps.dev` in `packages/worker/wrangler.jsonc`,
-  and the deploy derives a Workers `custom_domain` route from it so Cloudflare
-  provisions DNS and the edge certificate (see
-  [setup-manifest.md](./setup-manifest.md)). It **must be a separate registrable
-  domain** from `APP_BASE_URL`: that is what makes author-supplied package code
+- `PACKAGE_APP_BASE_URL` — the **apex** origin of the package-app domain that
+  hosted package apps are served from. Production sets `https://kodyapps.dev` in
+  `packages/worker/wrangler.jsonc`, and the deploy derives Workers
+  `custom_domain` routes for the apex and a wildcard for per-user subdomains so
+  Cloudflare provisions DNS and edge certificates (see
+  [setup-manifest.md](./setup-manifest.md)). Each owner's apps are addressed at
+  `https://{username}.<apex-host>/packages/{kodyId}/...`; the apex itself
+  serves only redirects (legacy `/@user/packages/...` paths to the owning
+  subdomain, `/` to the app origin). It **must be a separate registrable domain**
+  from `APP_BASE_URL`: that is what makes author-supplied package code
   cross-site, so the `SameSite=Lax` `kody_session` cookie never reaches it.
   Production origin validation also requires `APP_BASE_URL` so this relationship
   can be checked at runtime. Production returns `500` for package-app requests

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -116,21 +116,23 @@ confirmed non-production runtimes; see `packages/worker/src/app-base-url.ts` and
 
 - `PACKAGE_APP_BASE_URL` — the **apex** origin of the package-app domain that
   hosted package apps are served from. Production sets `https://kodyapps.dev` in
-  `packages/worker/wrangler.jsonc`, and the deploy derives Workers
-  `custom_domain` routes for the apex and a wildcard for per-user subdomains so
-  Cloudflare provisions DNS and edge certificates (see
-  [setup-manifest.md](./setup-manifest.md)). Each owner's apps are addressed at
-  `https://{username}.<apex-host>/packages/{kodyId}/...`; the apex itself serves
-  only redirects (legacy `/@user/packages/...` paths to the owning subdomain,
-  `/` to the app origin). It **must be a separate registrable domain** from
-  `APP_BASE_URL`: that is what makes author-supplied package code cross-site, so
-  the `SameSite=Lax` `kody_session` cookie never reaches it. Production origin
-  validation also requires `APP_BASE_URL` so this relationship can be checked at
-  runtime. Production returns `500` for package-app requests when this value is
-  missing, invalid, equal to `APP_BASE_URL`, or on the same registrable domain;
-  it never falls back to inline serving. Preview, tests, and E2E may leave it
-  unset and keep serving package apps inline on the app origin at
-  `/@{username}/packages/*`.
+  `packages/worker/wrangler.jsonc`, and the deploy derives a Workers
+  `custom_domain` route for the apex (which provisions its DNS and certificate)
+  plus a wildcard **zone route** (`*.<apex-host>/*`) for per-user subdomains —
+  Cloudflare custom domains cannot be wildcards, and zone routes do not create
+  DNS records, so production CI ensures the proxied wildcard DNS record
+  separately (see [setup-manifest.md](./setup-manifest.md)). Each owner's apps
+  are addressed at `https://{username}.<apex-host>/packages/{kodyId}/...`; the
+  apex itself serves only redirects (legacy `/@user/packages/...` paths to the
+  owning subdomain, `/` to the app origin). It **must be a separate registrable
+  domain** from `APP_BASE_URL`: that is what makes author-supplied package code
+  cross-site, so the `SameSite=Lax` `kody_session` cookie never reaches it.
+  Production origin validation also requires `APP_BASE_URL` so this relationship
+  can be checked at runtime. Production returns `500` for package-app requests
+  when this value is missing, invalid, equal to `APP_BASE_URL`, or on the same
+  registrable domain; it never falls back to inline serving. Preview, tests, and
+  E2E may leave it unset and keep serving package apps inline on the app origin
+  at `/@{username}/packages/*`.
 
   `npm run dev` runs the **production** Wrangler environment, so the committed
   production value reaches local dev too; `getPackageAppBaseUrl` ignores an

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -197,12 +197,24 @@ username, the subdomain label, and the path's owner username to all match
 `packages/worker/src/package-runtime/package-app-serve.ts`), so a handoff minted
 for one account cannot authorize another user's subdomain.
 
+Sibling subdomains also stay **same-site** with each other until the domain is
+on the Public Suffix List, so a `SameSite=Lax` cookie still attaches to their
+cross-origin requests. In a browser holding sessions for two accounts (a shared
+machine), one user's package code could otherwise send a credentialed mutating
+request to the other user's app — CORS blocks the response, not the side effect.
+Mutating requests on a subdomain therefore require any `Origin` header to match
+the subdomain itself; requests without one (non-browser clients, synthetic
+dispatch) authenticate through their own paths. Same-site credentialed GETs
+remain possible until the PSL entry lands; package apps must not mutate on GET,
+which HTTP already demands.
+
 - **No redirect cycle:** the app origin only ever redirects _to_ a package-app
   subdomain, the apex only redirects to a subdomain or the app origin, and a
-  subdomain only ever redirects within itself (to drop a consumed token from the
-  URL). A package-app request with no usable session terminates in a `403` that
-  links back to the app origin, so a browser that refuses the cookie fails
-  visibly instead of ping-ponging between hosts.
+  subdomain only redirects within itself to drop a consumed token from the URL
+  (plus its bare `/`, which goes home to the app origin — a terminal hop, not
+  part of the handoff). A package-app request with no usable session terminates
+  in a `403` that links back to the app origin, so a browser that refuses the
+  cookie fails visibly instead of ping-ponging between hosts.
 
 Production fails closed with `500` before executing package code when
 `PACKAGE_APP_BASE_URL` is missing, invalid, equal to `APP_BASE_URL`, or on the

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -50,8 +50,8 @@ package-app surfaces:
    links), and links are restricted to absolute `http:`/`https:`/`mailto:` URLs
    with `/@...` user-scope paths and `/packages/...` package-app mount paths
    refused on any host so a README can never point viewers at hosted package
-   endpoints. Never render third-party markdown via an HTML
-   string, `innerHTML`, or a markdown-to-HTML renderer.
+   endpoints. Never render third-party markdown via an HTML string, `innerHTML`,
+   or a markdown-to-HTML renderer.
 9. **Package code never receives first-party credentials, and never executes on
    the app origin in production.** Every request handed to package code goes
    through `createPackageCodeRequest`
@@ -135,10 +135,9 @@ covered too.
 
 **2. A separate registrable domain (production).** `PACKAGE_APP_BASE_URL`
 (production Worker var, `https://kodyapps.dev` — the apex; the deploy attaches
-that host to the Worker as a Cloudflare custom domain plus a wildcard zone
-route for per-user subdomains — see
-[`setup-manifest.md`](./setup-manifest.md)) makes package
-apps cross-site from the app origin, so the `SameSite=Lax`, `HttpOnly`
+that host to the Worker as a Cloudflare custom domain plus a wildcard zone route
+for per-user subdomains — see [`setup-manifest.md`](./setup-manifest.md)) makes
+package apps cross-site from the app origin, so the `SameSite=Lax`, `HttpOnly`
 `kody_session` cookie never attaches to them and cross-origin `fetch` from
 package pages has no CORS grant (`withCors` only reflects same-origin, plus
 `/mcp`). It must stay a **separate registrable domain**: a subdomain of the app
@@ -152,11 +151,17 @@ from `{username}.<package-app host>` (`buildPackageAppSubdomainOrigin` in
 `packages/shared/src/public-urls.ts`), so browser state (cookies, storage,
 `document` access) never crosses accounts. The username label in the hostname
 must be a valid single DNS label: lowercase letters, digits, and hyphens only,
-3–32 characters, alphanumeric edges (`packages/worker/src/identity/username.ts`).
-Underscores are not allowed; accounts whose usernames still contain underscores
-must rename before hosted apps work on a subdomain. Wildcard DNS still routes
-invalid or nested labels to the Worker, so hostnames that are not exactly one
-valid username label fail closed with `404`.
+3–32 characters, alphanumeric edges (`dnsSafeUsernamePattern` in
+`packages/shared/src/public-urls.ts`). Underscores are not allowed for new or
+changed usernames; accounts whose usernames still contain legacy underscores
+must rename before hosted apps work on a subdomain — the app-origin entry
+answers them with a `409` rename prompt instead of redirecting to a hostname
+nothing can serve, and hosted-URL emission falls back to the path-based shape
+for them. Recognition of _stored_ usernames elsewhere
+(`getUsernameFormatValidationError`) deliberately stays lenient so legacy
+accounts keep display names, public lookup, and inbound email routing. Wildcard
+DNS still routes invalid or nested labels to the Worker, so hostnames that are
+not exactly one valid username label fail closed with `404`.
 
 Dispatch lives in `packages/worker/src/app/package-app-origin.ts`, called first
 in the Worker `fetch` handler:
@@ -168,11 +173,12 @@ in the Worker `fetch` handler:
 - **Package-app apex** (`kodyapps.dev`): serves no package code. `/` redirects
   to the app origin. Legacy path-based URLs (`/@{username}/packages/*`) redirect
   (`302`/`307`) to the owning user's subdomain. Everything else — including
-  `/account/*`, `/login`, `/mcp`, and the `/@{username}/api/package-invocations/*`,
-  `/connectors/*`, `/webhooks/*` machine APIs — is `404`. Those APIs stay on the
-  app origin on purpose: they are authenticated by their own bearer tokens or
-  URL secrets, they are never called by package browser code, and hosting them
-  on the package-app domain would only widen its surface.
+  `/account/*`, `/login`, `/mcp`, and the
+  `/@{username}/api/package-invocations/*`, `/connectors/*`, `/webhooks/*`
+  machine APIs — is `404`. Those APIs stay on the app origin on purpose: they
+  are authenticated by their own bearer tokens or URL secrets, they are never
+  called by package browser code, and hosting them on the package-app domain
+  would only widen its surface.
 - **Per-user package-app subdomain** (`{username}.kodyapps.dev`): serves only
   `/packages/{kodyId}/*` for that hostname's username label. `/` redirects to
   the app origin; every other path is `404`.
@@ -187,8 +193,9 @@ insecure origins. The `__Host-` prefix requires `Secure`, `Path=/`, and no
 cross-subdomain cookie tossing even before the package-app domain is on the
 Public Suffix List. Serving additionally requires the resolved session account's
 username, the subdomain label, and the path's owner username to all match
-(`servePackageAppRequest` in `packages/worker/src/package-runtime/package-app-serve.ts`),
-so a handoff minted for one account cannot authorize another user's subdomain.
+(`servePackageAppRequest` in
+`packages/worker/src/package-runtime/package-app-serve.ts`), so a handoff minted
+for one account cannot authorize another user's subdomain.
 
 - **No redirect cycle:** the app origin only ever redirects _to_ a package-app
   subdomain, the apex only redirects to a subdomain or the app origin, and a
@@ -227,11 +234,11 @@ cannot link into either origin's package surface.
 
 **Out of scope (deliberate).** User-to-user isolation is complete: each owner's
 apps run on a distinct origin. Two packages owned by the **same** user still
-share that user's subdomain origin, so one of that owner's package apps can reach
-another's `__Host-kody_pkg_session`-authorized endpoints from the browser. That
-is a smaller blast radius than first-party access (all of it stays inside one
-owner's own data, since serving is `userId`-scoped and the session is bound to
-one account), but it is not zero.
+share that user's subdomain origin, so one of that owner's package apps can
+reach another's `__Host-kody_pkg_session`-authorized endpoints from the browser.
+That is a smaller blast radius than first-party access (all of it stays inside
+one owner's own data, since serving is `userId`-scoped and the session is bound
+to one account), but it is not zero.
 
 **Operational follow-up (not code).** Submit `kodyapps.dev` to the
 [Public Suffix List](https://publicsuffix.org/submit/) for defense-in-depth

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -21,10 +21,11 @@ package-app surfaces:
    applies `packages/worker/src/app/security-headers.ts`. Never add
    `'unsafe-inline'` to the CSP `script-src`.
 2. **Untrusted surfaces stay off the strict CSP.** Hosted package apps
-   (`/@username/packages/*`) execute author-supplied HTML/JS and intentionally
-   do not use the first-party CSP. Do not "unify" the two. Because they have no
-   CSP backstop, their isolation comes from the origin they run on and the
-   credentials they never receive — see invariant 9.
+   (`https://{username}.<package-app host>/packages/*` in production, or
+   `/@username/packages/*` when served inline) execute author-supplied HTML/JS
+   and intentionally do not use the first-party CSP. Do not "unify" the two.
+   Because they have no CSP backstop, their isolation comes from the origin they
+   run on and the credentials they never receive — see invariant 9.
 3. **Developer-only routes fail closed.** Anything that runs attacker-authored
    content or aids debugging must be gated behind `isNonProductionRuntime`
    (`packages/worker/src/app/deployment-env.ts`) so it is unreachable in
@@ -47,8 +48,9 @@ package-app surfaces:
    builds JSX from an allowlist of `marked` lexer tokens: raw HTML renders as
    escaped text, no resource-loading elements are ever emitted (images become
    links), and links are restricted to absolute `http:`/`https:`/`mailto:` URLs
-   with `/@...` user-scope paths refused so a README can never point viewers at
-   hosted package endpoints. Never render third-party markdown via an HTML
+   with `/@...` user-scope paths and `/packages/...` package-app mount paths
+   refused on any host so a README can never point viewers at hosted package
+   endpoints. Never render third-party markdown via an HTML
    string, `innerHTML`, or a markdown-to-HTML renderer.
 9. **Package code never receives first-party credentials, and never executes on
    the app origin in production.** Every request handed to package code goes
@@ -97,15 +99,19 @@ need their own looser policies to run author-authored code.
 
 ## Hosted package app origin isolation
 
-Hosted package apps (`/@{username}/packages/{kodyId}/...`) execute
-author-supplied HTML, JS, and worker code. Anything that shares an origin with
-them is inside their reach, and they get no CSP backstop (invariant 2), so the
-origin boundary _is_ the control.
+Hosted package apps execute author-supplied HTML, JS, and worker code. In
+production they run on per-user subdomains of the package-app domain
+(`https://{username}.kodyapps.dev/packages/{kodyId}/...`); confirmed
+non-production runtimes may serve them inline on the app origin at
+`/@{username}/packages/{kodyId}/...` instead. Anything that shares an origin
+with a package app is inside its reach, and package apps get no CSP backstop
+(invariant 2), so the origin boundary _is_ the control.
 
-**Threat model.** Author-supplied package code must not act as the owner. If
-package apps shared the app origin and the handler forwarded a clone of the
-original request into the package worker, author code would have two ways to act
-as the owner:
+**Threat model.** Author-supplied package code must not act as the owner, and
+one user's package apps must not reach another user's browser state. If package
+apps shared the app origin and the handler forwarded a clone of the original
+request into the package worker, author code would have two ways to act as the
+owner:
 
 - server-side, the forwarded request would carry the owner's `kody_session`
   cookie (and any `Authorization` header), so package code could read it and
@@ -114,8 +120,10 @@ as the owner:
   `fetch('/account/secrets.json', { credentials: 'include' })` from author JS
   and read the owner's secrets or mutate their account.
 
-That is a real vulnerability, not an accepted risk. Two independent controls
-close it.
+If every user's package apps shared one origin on the package-app domain, one
+owner's package could also read or plant cookies and call same-origin endpoints
+for another owner's packages. That is a real vulnerability, not an accepted
+risk. Three independent controls close it.
 
 **1. Credential stripping (always on).** `createPackageCodeRequest` builds the
 request package code sees without `Cookie`, `Authorization`,
@@ -126,37 +134,68 @@ headers. This holds regardless of hosting mode, so local dev and preview are
 covered too.
 
 **2. A separate registrable domain (production).** `PACKAGE_APP_BASE_URL`
-(production Worker var, `https://kodyapps.dev`; the deploy attaches that host to
-the Worker as a Cloudflare custom domain — see
-[`setup-manifest.md`](./setup-manifest.md)) makes package apps cross-site from
-the app origin, so the `SameSite=Lax`, `HttpOnly` `kody_session` cookie never
-attaches to them and cross-origin `fetch` from package pages has no CORS grant
-(`withCors` only reflects same-origin, plus `/mcp`). It must stay a **separate
-registrable domain**: a subdomain of the app origin would still be same-site for
-cookie purposes. `getPackageAppBaseUrl` (`packages/worker/src/app-base-url.ts`)
-resolves it, and `getAppBaseUrl` refuses to resolve the package-app origin as
-the app origin so package runtime callbacks and first-party links always point
-back at the app.
+(production Worker var, `https://kodyapps.dev` — the apex; the deploy attaches
+that host to the Worker as a Cloudflare custom domain plus a wildcard zone
+route for per-user subdomains — see
+[`setup-manifest.md`](./setup-manifest.md)) makes package
+apps cross-site from the app origin, so the `SameSite=Lax`, `HttpOnly`
+`kody_session` cookie never attaches to them and cross-origin `fetch` from
+package pages has no CORS grant (`withCors` only reflects same-origin, plus
+`/mcp`). It must stay a **separate registrable domain**: a subdomain of the app
+origin would still be same-site for cookie purposes. `getPackageAppBaseUrl`
+(`packages/worker/src/app-base-url.ts`) resolves the apex origin, and
+`getAppBaseUrl` refuses to resolve the package-app origin as the app origin so
+package runtime callbacks and first-party links always point back at the app.
+
+**3. Per-user subdomains (production).** Each owner's hosted apps are served
+from `{username}.<package-app host>` (`buildPackageAppSubdomainOrigin` in
+`packages/shared/src/public-urls.ts`), so browser state (cookies, storage,
+`document` access) never crosses accounts. The username label in the hostname
+must be a valid single DNS label: lowercase letters, digits, and hyphens only,
+3–32 characters, alphanumeric edges (`packages/worker/src/identity/username.ts`).
+Underscores are not allowed; accounts whose usernames still contain underscores
+must rename before hosted apps work on a subdomain. Wildcard DNS still routes
+invalid or nested labels to the Worker, so hostnames that are not exactly one
+valid username label fail closed with `404`.
 
 Dispatch lives in `packages/worker/src/app/package-app-origin.ts`, called first
 in the Worker `fetch` handler:
 
 - **App origin, `/@{username}/packages/*`:** never executes package code. Safe
-  methods redirect (`302`) to the same path on the package-app origin with a
-  handoff token; other methods get a `307` to that origin. Unauthenticated
-  visitors are sent to `/login` on the app origin first.
-- **Package-app origin:** serves only `/@{username}/packages/*`. `/` redirects
-  to the app origin; everything else (including `/account/*`, `/login`, `/mcp`,
-  and the `/@{username}/api/package-invocations/*`, `/connectors/*`,
-  `/webhooks/*` machine APIs) is `404`. Those APIs stay on the app origin on
-  purpose: they are authenticated by their own bearer tokens or URL secrets,
-  they are never called by package browser code, and hosting them on the
-  package-app origin would only widen its surface.
-- **No redirect cycle:** the app origin only ever redirects _to_ the package-app
-  origin, and the package-app origin only ever redirects within itself (to drop
-  a consumed token from the URL). A package-app request with no usable session
-  terminates in a `403` that links back to the app origin, so a browser that
-  refuses the cookie fails visibly instead of ping-ponging between hosts.
+  methods redirect (`302`) to the owner's package-app subdomain with a handoff
+  token; other methods get a `307` to that subdomain. Unauthenticated visitors
+  are sent to `/login` on the app origin first.
+- **Package-app apex** (`kodyapps.dev`): serves no package code. `/` redirects
+  to the app origin. Legacy path-based URLs (`/@{username}/packages/*`) redirect
+  (`302`/`307`) to the owning user's subdomain. Everything else — including
+  `/account/*`, `/login`, `/mcp`, and the `/@{username}/api/package-invocations/*`,
+  `/connectors/*`, `/webhooks/*` machine APIs — is `404`. Those APIs stay on the
+  app origin on purpose: they are authenticated by their own bearer tokens or
+  URL secrets, they are never called by package browser code, and hosting them
+  on the package-app domain would only widen its surface.
+- **Per-user package-app subdomain** (`{username}.kodyapps.dev`): serves only
+  `/packages/{kodyId}/*` for that hostname's username label. `/` redirects to
+  the app origin; every other path is `404`.
+
+**Handoff session and fixation defense.** The app origin mints a short-lived
+single-use handoff token; the owner's subdomain exchanges it for a host-scoped
+package-app session cookie (`packages/worker/src/app/package-app-session.ts`).
+On secure requests the cookie is named `__Host-kody_pkg_session`; plain HTTP
+local dev uses `kody_pkg_session` because browsers refuse `__Host-` cookies on
+insecure origins. The `__Host-` prefix requires `Secure`, `Path=/`, and no
+`Domain` attribute, so browsers reject any variant with a `Domain` — this blocks
+cross-subdomain cookie tossing even before the package-app domain is on the
+Public Suffix List. Serving additionally requires the resolved session account's
+username, the subdomain label, and the path's owner username to all match
+(`servePackageAppRequest` in `packages/worker/src/package-runtime/package-app-serve.ts`),
+so a handoff minted for one account cannot authorize another user's subdomain.
+
+- **No redirect cycle:** the app origin only ever redirects _to_ a package-app
+  subdomain, the apex only redirects to a subdomain or the app origin, and a
+  subdomain only ever redirects within itself (to drop a consumed token from the
+  URL). A package-app request with no usable session terminates in a `403` that
+  links back to the app origin, so a browser that refuses the cookie fails
+  visibly instead of ping-ponging between hosts.
 
 Production fails closed with `500` before executing package code when
 `PACKAGE_APP_BASE_URL` is missing, invalid, equal to `APP_BASE_URL`, or on the
@@ -169,28 +208,38 @@ of the production isolation boundary**. To exercise the two-origin flow locally,
 set `PACKAGE_APP_BASE_URL=http://packages.localhost:<port>` in
 `packages/worker/.env`.
 
-The cross-site handoff (how the owner is recognized on the package-app origin
+The cross-site handoff (how the owner is recognized on the package-app subdomain
 without giving package code a first-party session) is documented in
 [`architecture/authentication.md`](./architecture/authentication.md#package-app-origin-handoff).
 
-Because the package-app origin is one of this deployment's own origins, code
-that decides whether a URL is "ours" must accept both.
+Because hosted package apps are served from this deployment's own origins, code
+that decides whether a URL is "ours" must accept every production shape.
 `parsePackageSearchIdentity`
 (`packages/worker/src/mcp/tools/package-search-identity.ts`) accepts a
-`/@{username}/packages/{kodyId}` URL on either origin — so a URL copied out of a
-running package app resolves to that package — while `/account/*` paths stay
-app-origin only, since the package-app origin does not serve them. Untrusted
-markdown is the opposite case: `getSafeMarkdownLinkHref` refuses any `/@...`
-user-scope path regardless of host, so a community README cannot link into
-either origin's package surface.
+`https://{username}.<package-app host>/packages/{kodyId}` URL, a
+`/@{username}/packages/{kodyId}` URL on the app or package-app apex, and
+`/account/packages/{packageId}` on the app origin — so a URL copied out of a
+running package app resolves to that package — while other `/account/*` paths
+stay app-origin only. Untrusted markdown is the opposite case:
+`getSafeMarkdownLinkHref` refuses any `/@...` user-scope path and any
+`/packages/...` package-app mount path regardless of host, so a community README
+cannot link into either origin's package surface.
 
-Out of scope here: per-user subdomains (`{username}.kodyapps.dev`) would
-additionally isolate one user's package apps from another's, and one package
-from another. Every package app for every user shares the `kodyapps.dev` origin,
-so package A can reach package B's `kody_pkg_session`-authorized endpoints from
-the browser. That is a smaller blast radius than first-party access (all of it
-stays inside one owner's own data, since serving is `userId`-scoped and the
-session is bound to one account), but it is not zero.
+**Out of scope (deliberate).** User-to-user isolation is complete: each owner's
+apps run on a distinct origin. Two packages owned by the **same** user still
+share that user's subdomain origin, so one of that owner's package apps can reach
+another's `__Host-kody_pkg_session`-authorized endpoints from the browser. That
+is a smaller blast radius than first-party access (all of it stays inside one
+owner's own data, since serving is `userId`-scoped and the session is bound to
+one account), but it is not zero.
+
+**Operational follow-up (not code).** Submit `kodyapps.dev` to the
+[Public Suffix List](https://publicsuffix.org/submit/) for defense-in-depth
+(sibling subdomains treated as separate registrable domains by browsers). That
+requires a `_psl` TXT record on the zone and a PR to
+[publicsuffix/list](https://github.com/publicsuffix/list) by the domain owner.
+The `__Host-` cookie is the primary cookie-tossing control; PSL entry is an
+additional layer.
 
 ## Auth rate limiting
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -108,19 +108,20 @@ This project uses the following resources:
     `https://{username}.kodyapps.dev/packages/{kodyId}/...`; the apex stays
     attached for legacy redirects (`/@user/packages/...` → per-user subdomain,
     `/` → app origin).
-  - **Wildcard DNS (one-time per zone).** Zone routes do not create DNS
-    records. Production CI (`tools/ci/production-resources.ts ensure`) idempotently
-    ensures a proxied wildcard record in the package-app zone:
-    `*.kodyapps.dev` → AAAA `100::` (orange-cloud proxied). The deploy token
-    needs **DNS:Edit** on that zone (in addition to Workers deploy permissions).
-    Forks must create the zone and either run `ensure` or add the record
-    manually before the first per-user-subdomain deploy.
+  - **Wildcard DNS (one-time per zone).** Zone routes do not create DNS records.
+    Production CI (`tools/ci/production-resources.ts ensure`) idempotently
+    ensures a proxied wildcard record in the package-app zone: `*.kodyapps.dev`
+    → AAAA `100::` (orange-cloud proxied). The deploy token needs **DNS:Edit**
+    on that zone (in addition to Workers deploy permissions). Forks must create
+    the zone and either run `ensure` or add the record manually before the first
+    per-user-subdomain deploy.
   - **Wildcard zone route.** `writeGeneratedWranglerConfig`
-    (`tools/ci/resource-utils.ts`) also publishes `{ pattern:
-    "*.kodyapps.dev/*", zone_name: "kodyapps.dev" }` alongside the apex
-    `custom_domain` route. Cloudflare custom domains cannot be wildcards, so
-    per-user hosts use a zone route instead. Cloudflare Universal SSL covers one
-    wildcard label (`*.kodyapps.dev`), which is enough for `{username}.kodyapps.dev`.
+    (`tools/ci/resource-utils.ts`) also publishes
+    `{ pattern: "*.kodyapps.dev/*", zone_name: "kodyapps.dev" }` alongside the
+    apex `custom_domain` route. Cloudflare custom domains cannot be wildcards,
+    so per-user hosts use a zone route instead. Cloudflare Universal SSL covers
+    one wildcard label (`*.kodyapps.dev`), which is enough for
+    `{username}.kodyapps.dev`.
   - The attach happens on deploy, but the routes are **generated, not
     committed**: `writeGeneratedWranglerConfig` derives one `custom_domain`
     route per base-URL var (`APP_BASE_URL`, `APP_LEGACY_HOSTS`, and

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -103,25 +103,42 @@ This project uses the following resources:
 - Second registrable domain for hosted package apps
   - Production: `kodyapps.dev` (zone in the same Cloudflare account, on
     Cloudflare nameservers), attached to the production Worker as a Workers
-    **custom domain**, which provisions the DNS record and edge certificate.
+    **custom domain**, which provisions the apex DNS record and edge
+    certificate. Per-user package apps are served from
+    `https://{username}.kodyapps.dev/packages/{kodyId}/...`; the apex stays
+    attached for legacy redirects (`/@user/packages/...` → per-user subdomain,
+    `/` → app origin).
+  - **Wildcard DNS (one-time per zone).** Zone routes do not create DNS
+    records. Production CI (`tools/ci/production-resources.ts ensure`) idempotently
+    ensures a proxied wildcard record in the package-app zone:
+    `*.kodyapps.dev` → AAAA `100::` (orange-cloud proxied). The deploy token
+    needs **DNS:Edit** on that zone (in addition to Workers deploy permissions).
+    Forks must create the zone and either run `ensure` or add the record
+    manually before the first per-user-subdomain deploy.
+  - **Wildcard zone route.** `writeGeneratedWranglerConfig`
+    (`tools/ci/resource-utils.ts`) also publishes `{ pattern:
+    "*.kodyapps.dev/*", zone_name: "kodyapps.dev" }` alongside the apex
+    `custom_domain` route. Cloudflare custom domains cannot be wildcards, so
+    per-user hosts use a zone route instead. Cloudflare Universal SSL covers one
+    wildcard label (`*.kodyapps.dev`), which is enough for `{username}.kodyapps.dev`.
   - The attach happens on deploy, but the routes are **generated, not
-    committed**: `writeGeneratedWranglerConfig` (`tools/ci/resource-utils.ts`)
-    derives one `custom_domain` route per base-URL var (`APP_BASE_URL`,
-    `APP_LEGACY_HOSTS`, and `PACKAGE_APP_BASE_URL`) while writing
+    committed**: `writeGeneratedWranglerConfig` derives one `custom_domain`
+    route per base-URL var (`APP_BASE_URL`, `APP_LEGACY_HOSTS`, and
+    `PACKAGE_APP_BASE_URL`) plus the wildcard zone route while writing
     `packages/worker/wrangler-production.generated.json`. Those vars are the
     single source of truth for both the hosts the Worker routes on and the
     domains the deploy attaches, so the two cannot drift.
-  - **`routes` replaces the Worker's whole custom-domain set — it does not add
-    to it.** Omitting a previously attached custom domain detaches that origin
-    and deletes its DNS record. The generator therefore always lists the app
-    origin alongside the package-app origin, and fails the deploy when
-    `PACKAGE_APP_BASE_URL` is set without `APP_BASE_URL` rather than publishing
-    a partial set. Any domain attached out-of-band must be added here before the
-    next deploy, or that deploy will remove it. During a domain migration the
-    previous app host must therefore be listed in the `APP_LEGACY_HOSTS`
-    repository variable (comma-separated bare hostnames, e.g. `heykody.dev`)
-    before `APP_BASE_URL` flips to the new domain, so the old origin stays
-    attached and dual-served.
+  - **`routes` replaces the Worker's whole route set — it does not add to it.**
+    Omitting a previously attached custom domain detaches that origin and
+    deletes its DNS record. The generator therefore always lists the app origin
+    alongside the package-app apex and wildcard zone route, and fails the deploy
+    when `PACKAGE_APP_BASE_URL` is set without `APP_BASE_URL` rather than
+    publishing a partial set. Any domain attached out-of-band must be added here
+    before the next deploy, or that deploy will remove it. During a domain
+    migration the previous app host must therefore be listed in the
+    `APP_LEGACY_HOSTS` repository variable (comma-separated bare hostnames, e.g.
+    `heykody.dev`) before `APP_BASE_URL` flips to the new domain, so the old
+    origin stays attached and dual-served.
   - Publishing routes also flips `workers_dev` to `false`, which silently drops
     the `<name>.<subdomain>.workers.dev` trigger (Cloudflare then answers that
     hostname with error 1042). The generator sets `workers_dev: true` alongside
@@ -309,9 +326,11 @@ automatically:
 - `PACKAGE_APP_BASE_URL` (Wrangler `var`; required in production and optional
   for confirmed local/preview/test runtimes; origin for hosted package apps.
   Production sets `https://kodyapps.dev` in `packages/worker/wrangler.jsonc`,
-  and the deploy attaches that host as a Workers custom domain from the
-  generated config (see the Cloudflare resources list above). Must be a
-  **separate registrable domain** from `APP_BASE_URL` — see
+  and the deploy attaches that apex as a Workers custom domain plus a wildcard
+  zone route (`*.kodyapps.dev/*`) from the generated config (see the Cloudflare
+  resources list above). Per-user apps use `{username}.kodyapps.dev` subdomains;
+  production CI ensures the proxied wildcard DNS record. Must be a **separate
+  registrable domain** from `APP_BASE_URL` — see
   [Hosted package app origin isolation](./security.md#hosted-package-app-origin-isolation).
   Local dev ignores any value it cannot serve itself, and preview/test leave it
   unset, so those keep serving package apps inline on the app origin. Point it

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -69,12 +69,11 @@ success means for the user, not duplicate every implementation detail.
 
 Production-hosted package apps live at
 `https://{username}.kodyapps.dev/packages/<kody-id>/<path>` (the username is in
-the hostname; the path mount is `/packages/<kody-id>`). Confirmed
-non-production runtimes may serve inline on the app origin at
-`/@username/packages/<kody-id>/<path>` instead. The app receives only
-`/<path>` in its fetch request in both cases. Root-relative links such as
-`/audio/123` therefore escape the mount and are not routed back to the package
-app.
+the hostname; the path mount is `/packages/<kody-id>`). Confirmed non-production
+runtimes may serve inline on the app origin at
+`/@username/packages/<kody-id>/<path>` instead. The app receives only `/<path>`
+in its fetch request in both cases. Root-relative links such as `/audio/123`
+therefore escape the mount and are not routed back to the package app.
 
 Import `packageContext` from `kody:runtime` and build every in-app link,
 redirect, share/email URL, and OAuth callback against its public base:
@@ -93,7 +92,9 @@ const audioUrl = new URL(
 ```
 
 - `packageContext.hostedUrl` is the full public URL of the app mount.
-- `packageContext.appBasePath` is the origin-relative mount path (`/packages/<kody-id>` on a subdomain, `/@username/packages/<kody-id>` when inline).
+- `packageContext.appBasePath` is the origin-relative mount path
+  (`/packages/<kody-id>` on a subdomain, `/@username/packages/<kody-id>` when
+  inline).
 
 Kody derives both fields from the package's current serving username and
 `kody.id`, including after a rename or fork. Do not hard-code either path

--- a/docs/guides/package-authoring.md
+++ b/docs/guides/package-authoring.md
@@ -67,8 +67,12 @@ success means for the user, not duplicate every implementation detail.
 
 ## Package app routing
 
-Hosted package apps are mounted at `/@username/packages/<kody-id>/<path>`. The
-app receives only `/<path>` in its fetch request. Root-relative links such as
+Production-hosted package apps live at
+`https://{username}.kodyapps.dev/packages/<kody-id>/<path>` (the username is in
+the hostname; the path mount is `/packages/<kody-id>`). Confirmed
+non-production runtimes may serve inline on the app origin at
+`/@username/packages/<kody-id>/<path>` instead. The app receives only
+`/<path>` in its fetch request in both cases. Root-relative links such as
 `/audio/123` therefore escape the mount and are not routed back to the package
 app.
 
@@ -89,7 +93,7 @@ const audioUrl = new URL(
 ```
 
 - `packageContext.hostedUrl` is the full public URL of the app mount.
-- `packageContext.appBasePath` is the origin-relative mount path.
+- `packageContext.appBasePath` is the origin-relative mount path (`/packages/<kody-id>` on a subdomain, `/@username/packages/<kody-id>` when inline).
 
 Kody derives both fields from the package's current serving username and
 `kody.id`, including after a rename or fork. Do not hard-code either path

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -369,11 +369,11 @@ When `package.json#kody.app` is present, the package is hosted under the package
 app route.
 
 Production-hosted package apps run on per-user subdomains of Kody's separate
-`kodyapps.dev` domain (`https://{username}.kodyapps.dev/packages/<kody-id>/...`),
-not on the signed-in app origin. Opening an app from Kody performs a short-lived
-session handoff to that subdomain. Package author JavaScript cannot use the
-first-party `kody_session` cookie or call authenticated Kody pages as the
-signed-in user.
+`kodyapps.dev` domain
+(`https://{username}.kodyapps.dev/packages/<kody-id>/...`), not on the signed-in
+app origin. Opening an app from Kody performs a short-lived session handoff to
+that subdomain. Package author JavaScript cannot use the first-party
+`kody_session` cookie or call authenticated Kody pages as the signed-in user.
 
 Package app URLs follow the mount contract: on a subdomain the public path is
 `/packages/<kody-id>/<path>` (the username lives in the hostname). Kody strips
@@ -381,9 +381,10 @@ that mount before forwarding, so root-relative links such as `/audio/123` escape
 the app. Build in-app links, redirects, shared links, email links, and OAuth
 callbacks against `packageContext.hostedUrl` and `packageContext.appBasePath`
 (derived from the serving username and `kody.id` — `/packages/<kody-id>` on a
-subdomain, `/@username/packages/<kody-id>` when served inline in non-production).
-See [Package app routing](../guides/package-authoring.md#package-app-routing)
-for the authoring example. Other saved-package runtime surfaces may omit these
+subdomain, `/@username/packages/<kody-id>` when served inline in
+non-production). See
+[Package app routing](../guides/package-authoring.md#package-app-routing) for
+the authoring example. Other saved-package runtime surfaces may omit these
 app-specific fields.
 
 Use the package app model when the package needs:

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -368,17 +368,20 @@ A package app is optional.
 When `package.json#kody.app` is present, the package is hosted under the package
 app route.
 
-Production-hosted package apps run on Kody's separate `kodyapps.dev` origin, not
-on the signed-in app origin. Opening an app from Kody performs a short-lived
-session handoff to that origin. Package author JavaScript cannot use the
+Production-hosted package apps run on per-user subdomains of Kody's separate
+`kodyapps.dev` domain (`https://{username}.kodyapps.dev/packages/<kody-id>/...`),
+not on the signed-in app origin. Opening an app from Kody performs a short-lived
+session handoff to that subdomain. Package author JavaScript cannot use the
 first-party `kody_session` cookie or call authenticated Kody pages as the
 signed-in user.
 
-Package app URLs follow the mount contract
-`/@username/packages/<kody-id>/<path>`: Kody strips the mount before forwarding,
-so root-relative links escape the app. Build in-app links, redirects, shared
-links, email links, and OAuth callbacks against `packageContext.hostedUrl` and
-`packageContext.appBasePath` (derived from the serving username and `kody.id`).
+Package app URLs follow the mount contract: on a subdomain the public path is
+`/packages/<kody-id>/<path>` (the username lives in the hostname). Kody strips
+that mount before forwarding, so root-relative links such as `/audio/123` escape
+the app. Build in-app links, redirects, shared links, email links, and OAuth
+callbacks against `packageContext.hostedUrl` and `packageContext.appBasePath`
+(derived from the serving username and `kody.id` — `/packages/<kody-id>` on a
+subdomain, `/@username/packages/<kody-id>` when served inline in non-production).
 See [Package app routing](../guides/package-authoring.md#package-app-routing)
 for the authoring example. Other saved-package runtime surfaces may omit these
 app-specific fields.

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -61,10 +61,10 @@ identity when it resolves for the signed-in user. Kody also recognizes
 current-origin `/account/packages/:packageId` URLs, owner-matching
 `/@username/packages/:kodyId` URLs, and per-user package-app subdomain URLs
 (`https://{username}.<package-app host>/packages/:kodyId`) — so a URL copied
-from an open app resolves too.
-Exact package identities never compete with semantic capability results. Hidden
-exact query matches still require `includeHiddenPackages: true`; exact `entity`
-lookup by UUID or `kody.id` ignores the hidden discovery preference.
+from an open app resolves too. Exact package identities never compete with
+semantic capability results. Hidden exact query matches still require
+`includeHiddenPackages: true`; exact `entity` lookup by UUID or `kody.id`
+ignores the hidden discovery preference.
 
 When a tool call also includes **`memoryContext`**, Kody may include relevant
 long-term memory metadata in structured content, but broad query markdown stays

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -58,9 +58,10 @@ error listing the available domains. The `search` meta capability (usable inside
 
 An entire saved-package UUID or `kody.id` is treated as an exact package
 identity when it resolves for the signed-in user. Kody also recognizes
-current-origin `/account/packages/:packageId` URLs and owner-matching
-`/@username/packages/:kodyId` URLs — including the hosted package-app domain a
-package app actually runs on, so a URL copied from an open app resolves too.
+current-origin `/account/packages/:packageId` URLs, owner-matching
+`/@username/packages/:kodyId` URLs, and per-user package-app subdomain URLs
+(`https://{username}.<package-app host>/packages/:kodyId`) — so a URL copied
+from an open app resolves too.
 Exact package identities never compete with semantic capability results. Hidden
 exact query matches still require `includeHiddenPackages: true`; exact `entity`
 lookup by UUID or `kody.id` ignores the hidden discovery preference.

--- a/packages/shared/src/public-urls.ts
+++ b/packages/shared/src/public-urls.ts
@@ -2,16 +2,19 @@ export function buildUsernamePathPrefix(username: string) {
 	return `/@${encodeURIComponent(username.trim())}`
 }
 
+function buildRestPathSuffix(restPath: string | null | undefined) {
+	const trimmed = restPath?.trim()
+	return trimmed ? `/${trimmed.replace(/^\/+/, '')}` : ''
+}
+
 export function buildPackageAppPath(input: {
 	username: string
 	kodyId: string
 	restPath?: string | null
 }) {
-	const restPath = input.restPath?.trim()
-	const suffix = restPath ? `/${restPath.replace(/^\/+/, '')}` : ''
 	return `${buildUsernamePathPrefix(input.username)}/packages/${encodeURIComponent(
 		input.kodyId.trim(),
-	)}${suffix}`
+	)}${buildRestPathSuffix(input.restPath)}`
 }
 
 export function buildPackageAppUrl(input: {
@@ -21,6 +24,88 @@ export function buildPackageAppUrl(input: {
 	restPath?: string | null
 }) {
 	return `${input.origin.trim().replace(/\/+$/, '')}${buildPackageAppPath(input)}`
+}
+
+/**
+ * How a package-app URL addresses its package:
+ *
+ * - `user-subdomain`: `https://{username}.<package-app host>/packages/{kodyId}`
+ *   — the production shape, where the username lives in the hostname.
+ * - `username-path`: `/@{username}/packages/{kodyId}` — the app-origin entry
+ *   point (which redirects into the handoff) and the non-production inline
+ *   serving shape.
+ */
+export type PackageAppMount = 'user-subdomain' | 'username-path'
+
+/**
+ * Path for a hosted package app on its per-user package-app subdomain. The
+ * username lives in the hostname there, so the path carries only the package
+ * mount: `/packages/{kodyId}/{rest}`.
+ */
+export function buildPackageAppSubdomainPath(input: {
+	kodyId: string
+	restPath?: string | null
+}) {
+	return `/packages/${encodeURIComponent(input.kodyId.trim())}${buildRestPathSuffix(
+		input.restPath,
+	)}`
+}
+
+/**
+ * Origin of one user's package-app subdomain: `{username}.` prefixed onto the
+ * configured package-app origin's hostname, preserving scheme and port.
+ *
+ * The username must already satisfy the username format rules (lowercase DNS
+ * label); this function does not re-validate it.
+ */
+export function buildPackageAppSubdomainOrigin(input: {
+	packageAppOrigin: string
+	username: string
+}) {
+	const username = input.username.trim().toLowerCase()
+	if (!username) {
+		throw new Error('Username is required to build a package-app subdomain.')
+	}
+	const url = new URL(input.packageAppOrigin)
+	url.hostname = `${username}.${url.hostname}`
+	return url.origin
+}
+
+export function buildPackageAppSubdomainUrl(input: {
+	packageAppOrigin: string
+	username: string
+	kodyId: string
+	restPath?: string | null
+}) {
+	return `${buildPackageAppSubdomainOrigin(input)}${buildPackageAppSubdomainPath(input)}`
+}
+
+/**
+ * Canonical browser URL for a hosted package app: the per-user subdomain of
+ * the package-app origin when one is configured, or the path-based mount on
+ * the app origin when a non-production deployment serves package apps inline.
+ */
+export function resolveHostedPackageAppUrl(input: {
+	packageAppBaseUrl: string | null
+	appBaseUrl: string
+	username: string
+	kodyId: string
+	restPath?: string | null
+}) {
+	if (input.packageAppBaseUrl) {
+		return buildPackageAppSubdomainUrl({
+			packageAppOrigin: input.packageAppBaseUrl,
+			username: input.username,
+			kodyId: input.kodyId,
+			restPath: input.restPath,
+		})
+	}
+	return buildPackageAppUrl({
+		origin: input.appBaseUrl,
+		username: input.username,
+		kodyId: input.kodyId,
+		restPath: input.restPath,
+	})
 }
 
 export const packageInvocationRootExportRouteSegment = '__root__'

--- a/packages/shared/src/public-urls.ts
+++ b/packages/shared/src/public-urls.ts
@@ -38,6 +38,18 @@ export function buildPackageAppUrl(input: {
 export type PackageAppMount = 'user-subdomain' | 'username-path'
 
 /**
+ * Usernames that can own a `{username}.` package-app subdomain: a valid DNS
+ * label (lowercase letters, digits, hyphens; 3–32 chars; alphanumeric edges).
+ * Legacy usernames may still contain underscores; those cannot be a hostname
+ * label, so subdomain URL builders fall back to the path-based mount for them.
+ */
+export const dnsSafeUsernamePattern = /^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$/
+
+export function isDnsSafeUsername(username: string) {
+	return dnsSafeUsernamePattern.test(username.trim())
+}
+
+/**
  * Path for a hosted package app on its per-user package-app subdomain. The
  * username lives in the hostname there, so the path carries only the package
  * mount: `/packages/{kodyId}/{rest}`.
@@ -82,8 +94,9 @@ export function buildPackageAppSubdomainUrl(input: {
 
 /**
  * Canonical browser URL for a hosted package app: the per-user subdomain of
- * the package-app origin when one is configured, or the path-based mount on
- * the app origin when a non-production deployment serves package apps inline.
+ * the package-app origin when one is configured and the username can be a
+ * hostname label, or the path-based mount on the app origin otherwise (inline
+ * non-production serving, and legacy usernames that cannot own a subdomain).
  */
 export function resolveHostedPackageAppUrl(input: {
 	packageAppBaseUrl: string | null
@@ -92,7 +105,7 @@ export function resolveHostedPackageAppUrl(input: {
 	kodyId: string
 	restPath?: string | null
 }) {
-	if (input.packageAppBaseUrl) {
+	if (input.packageAppBaseUrl && isDnsSafeUsername(input.username)) {
 		return buildPackageAppSubdomainUrl({
 			packageAppOrigin: input.packageAppBaseUrl,
 			username: input.username,

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -212,15 +212,13 @@ test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths',
 			'https://mallory.kodyapps.dev/packages/tracker/app',
 		),
 	).toBe(null)
-	expect(getSafeMarkdownLinkHref('https://other.example/packages/x')).toBe(
+	expect(getSafeMarkdownLinkHref('https://other.example/packages/x')).toBe(null)
+	expect(getSafeMarkdownLinkHref('https://other.example//packages/x')).toBe(
 		null,
 	)
-	expect(
-		getSafeMarkdownLinkHref('https://other.example//packages/x'),
-	).toBe(null)
-	expect(
-		getSafeMarkdownLinkHref('https://other.example/%70ackages/x'),
-	).toBe(null)
+	expect(getSafeMarkdownLinkHref('https://other.example/%70ackages/x')).toBe(
+		null,
+	)
 	// Paths that merely contain (not start with) a `packages` segment stay
 	// allowed — only the mount shape is refused.
 	expect(

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -201,4 +201,29 @@ test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths',
 	expect(getSafeMarkdownLinkHref('https://example.com/a%20b')).toBe(
 		'https://example.com/a%20b',
 	)
+	// The per-user package-app subdomain mounts apps at `/packages/...`, so
+	// that path shape is refused on every host too (this module cannot know
+	// the deployment's package-app domain; same trade-off as the `/@` rule).
+	expect(
+		getSafeMarkdownLinkHref('https://mallory.kodyapps.dev/packages/tracker'),
+	).toBe(null)
+	expect(
+		getSafeMarkdownLinkHref(
+			'https://mallory.kodyapps.dev/packages/tracker/app',
+		),
+	).toBe(null)
+	expect(getSafeMarkdownLinkHref('https://other.example/packages/x')).toBe(
+		null,
+	)
+	expect(
+		getSafeMarkdownLinkHref('https://other.example//packages/x'),
+	).toBe(null)
+	expect(
+		getSafeMarkdownLinkHref('https://other.example/%70ackages/x'),
+	).toBe(null)
+	// Paths that merely contain (not start with) a `packages` segment stay
+	// allowed — only the mount shape is refused.
+	expect(
+		getSafeMarkdownLinkHref('https://github.com/orgs/example/packages'),
+	).toBe('https://github.com/orgs/example/packages')
 })

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -13,12 +13,14 @@
  *   markup. Unknown languages fall back to escaped plaintext.
  * - No resource-loading elements are emitted (`<img>`, `<iframe>`, media,
  *   etc.), so a README can never make a viewer's browser issue requests —
- *   including to hosted package endpoints (`/@username/packages/*`), which
- *   execute author-controlled code. Images render as plain links instead.
+ *   including to hosted package endpoints (`/@username/packages/*` and the
+ *   per-user subdomain mount `/packages/*`), which execute author-controlled
+ *   code. Images render as plain links instead.
  * - Links must be absolute `http:`/`https:`/`mailto:` URLs. Relative URLs
  *   (which would resolve against this origin) and URLs whose path points at a
- *   user scope (`/@...`) render as plain text. Allowed links open in a new
- *   tab with `rel="noopener noreferrer nofollow ugc"`.
+ *   hosted package surface (`/@...` or `/packages/...`) render as plain text.
+ *   Allowed links open in a new tab with `rel="noopener noreferrer nofollow
+ *   ugc"`.
  *
  * The first-party CSP (`security-headers.ts`) blocks off-site scripts,
  * images, and connections as defense in depth; this module must stay safe
@@ -76,12 +78,17 @@ const defaultRenderOptions: ResolvedRenderOptions = {
 }
 
 /**
- * True when the URL's path could reach a user scope (`/@...`, where hosted
- * package apps live). Deliberately over-matches: repeated leading slashes
- * collapse (the worker routes with `split('/').filter(Boolean)`, so
- * `//@user` still reaches package apps) and percent-encoding is decoded
- * repeatedly (`/%40user`, `/%2540user`) before checking. Undecodable paths
- * are treated as user-scope so ambiguity always fails closed.
+ * True when the URL's path could reach a hosted package surface: a user scope
+ * (`/@...`) on any host, or a package-app mount (`/packages/...`, the path
+ * shape served on per-user package-app subdomains). Deliberately
+ * over-matches: it refuses these path shapes on *every* host because this
+ * module cannot know the deployment's package-app domain (the same trade-off
+ * the `/@` rule already makes for hosts like `medium.com/@author`). Repeated
+ * leading slashes collapse (the worker routes with
+ * `split('/').filter(Boolean)`, so `//@user` still reaches package apps) and
+ * percent-encoding is decoded repeatedly (`/%40user`, `/%2540user`) before
+ * checking. Undecodable paths are treated as user-scope so ambiguity always
+ * fails closed.
  */
 function hasUserScopePath(url: URL): boolean {
 	let pathname = url.pathname
@@ -98,7 +105,12 @@ function hasUserScopePath(url: URL): boolean {
 		if (pass >= 4) return true
 		pathname = decoded
 	}
-	return pathname.replace(/^\/+/, '').startsWith('@')
+	const normalized = pathname.replace(/^\/+/, '')
+	return (
+		normalized.startsWith('@') ||
+		normalized === 'packages' ||
+		normalized.startsWith('packages/')
+	)
 }
 
 /**

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -735,8 +735,8 @@ export function AccountRoute(handle: Handle) {
 										data-field-ring
 										required
 										autoComplete="username"
-										pattern="[A-Za-z0-9][A-Za-z0-9_-]{1,30}[A-Za-z0-9]"
-										title="Use 3 to 32 letters, numbers, hyphens, or underscores. Start and end with a letter or number."
+										pattern="[A-Za-z0-9][A-Za-z0-9-]{1,30}[A-Za-z0-9]"
+										title="Use 3 to 32 letters, numbers, and hyphens. Start and end with a letter or number."
 										value={draftUsername}
 										mix={[
 											css(accountInputCss),

--- a/packages/worker/client/routes/login.tsx
+++ b/packages/worker/client/routes/login.tsx
@@ -711,8 +711,8 @@ export function LoginRoute(handle: Handle) {
 											required
 											autoFocus
 											autoComplete="username"
-											pattern={'[A-Za-z0-9][A-Za-z0-9_\\-]{1,30}[A-Za-z0-9]'}
-											title="Use 3 to 32 letters, numbers, hyphens, or underscores. Start and end with a letter or number."
+											pattern={'[A-Za-z0-9][A-Za-z0-9\\-]{1,30}[A-Za-z0-9]'}
+											title="Use 3 to 32 letters, numbers, and hyphens. Start and end with a letter or number."
 											placeholder="kent"
 											data-field-ring
 											mix={css(authInputCss)}

--- a/packages/worker/src/app-base-url.node.test.ts
+++ b/packages/worker/src/app-base-url.node.test.ts
@@ -136,7 +136,10 @@ test('the package-app origin is configurable and never resolves as the app origi
 		getAppBaseUrl({ env, requestUrl: 'https://kodyapps.dev/@me/packages/x' }),
 	).toBe('https://heykody.dev')
 	expect(
-		getAppBaseUrl({ env, requestUrl: 'https://user-me.kodyapps.dev/packages/x' }),
+		getAppBaseUrl({
+			env,
+			requestUrl: 'https://user-me.kodyapps.dev/packages/x',
+		}),
 	).toBe('https://heykody.dev')
 	expect(
 		getAppBaseUrl({ env, requestUrl: 'https://heykody.dev/@me/packages/x' }),

--- a/packages/worker/src/app-base-url.node.test.ts
+++ b/packages/worker/src/app-base-url.node.test.ts
@@ -5,6 +5,7 @@ import {
 	getPackageAppBaseUrl,
 	getPackageAppOriginConfigurationError,
 	joinAppUrl,
+	parsePackageAppRequestHost,
 } from './app-base-url.ts'
 
 test('getAppBaseUrl prefers the request origin when present', () => {
@@ -129,13 +130,58 @@ test('the package-app origin is configurable and never resolves as the app origi
 		PACKAGE_APP_BASE_URL: 'https://kodyapps.dev',
 	}
 	// Package runtime callbacks and first-party links resolved while serving a
-	// package app must point at the app origin, never at the package-app host.
+	// package app must point at the app origin, never at the package-app host —
+	// neither the bare origin nor a per-user subdomain.
 	expect(
 		getAppBaseUrl({ env, requestUrl: 'https://kodyapps.dev/@me/packages/x' }),
 	).toBe('https://heykody.dev')
 	expect(
+		getAppBaseUrl({ env, requestUrl: 'https://user-me.kodyapps.dev/packages/x' }),
+	).toBe('https://heykody.dev')
+	expect(
 		getAppBaseUrl({ env, requestUrl: 'https://heykody.dev/@me/packages/x' }),
 	).toBe('https://heykody.dev')
+})
+
+test('parsePackageAppRequestHost classifies apex, user subdomains, and rejects everything else', () => {
+	const env = { PACKAGE_APP_BASE_URL: 'https://kodyapps.dev' }
+	const parse = (url: string) =>
+		parsePackageAppRequestHost({ env, url: new URL(url) })
+
+	expect(parse('https://kodyapps.dev/anything')).toEqual({ kind: 'apex' })
+	expect(parse('https://kentcdodds.kodyapps.dev/packages/demo')).toEqual({
+		kind: 'user-subdomain',
+		username: 'kentcdodds',
+	})
+	// Hostnames the wildcard route still delivers, but that no user can own.
+	for (const url of [
+		// Nested labels.
+		'https://a.b.kodyapps.dev/',
+		// Not a valid username label (too short / invalid characters).
+		'https://xy.kodyapps.dev/',
+		'https://bad_label.kodyapps.dev/',
+		// Wrong scheme for the configured origin.
+		'http://kentcdodds.kodyapps.dev/',
+	]) {
+		expect(parse(url), url).toEqual({ kind: 'unrecognized-subdomain' })
+	}
+	// Not the package-app domain at all.
+	for (const url of [
+		'https://heykody.dev/',
+		'https://evil-kodyapps.dev/',
+		'https://kodyapps.dev.attacker.example/',
+		// Same hostname on another scheme/port is another local service.
+		'http://kodyapps.dev/',
+	]) {
+		expect(parse(url), url).toBeNull()
+	}
+	// No configured package-app origin: nothing classifies.
+	expect(
+		parsePackageAppRequestHost({
+			env: {},
+			url: new URL('https://kentcdodds.kodyapps.dev/'),
+		}),
+	).toBeNull()
 })
 
 test('production package-app origin configuration requires a separate registrable domain', () => {

--- a/packages/worker/src/app-base-url.node.test.ts
+++ b/packages/worker/src/app-base-url.node.test.ts
@@ -165,6 +165,10 @@ test('parsePackageAppRequestHost classifies apex, user subdomains, and rejects e
 		'https://bad_label.kodyapps.dev/',
 		// Wrong scheme for the configured origin.
 		'http://kentcdodds.kodyapps.dev/',
+		// Trailing DNS dots resolve to the same host but survive in
+		// URL.hostname; letting them fall through would route them first-party.
+		'https://kodyapps.dev./',
+		'https://kentcdodds.kodyapps.dev./',
 	]) {
 		expect(parse(url), url).toEqual({ kind: 'unrecognized-subdomain' })
 	}

--- a/packages/worker/src/app-base-url.ts
+++ b/packages/worker/src/app-base-url.ts
@@ -1,5 +1,7 @@
 import { getDomain } from 'tldts'
+import { buildPackageAppSubdomainOrigin } from '@kody-internal/shared/public-urls.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
+import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
 
 const DEFAULT_APP_BASE_URL = 'https://heykody.app'
 
@@ -67,6 +69,54 @@ function getRegistrableDomain(url: URL) {
 	return getDomain(url.hostname) ?? url.hostname.toLowerCase()
 }
 
+export type PackageAppRequestHost =
+	/** The bare package-app origin: serves only redirects, never package code. */
+	| { kind: 'apex' }
+	/** One user's package-app subdomain: `{username}.<package-app host>`. */
+	| { kind: 'user-subdomain'; username: string }
+	/**
+	 * A hostname under the package-app domain that is not a valid single
+	 * username label (nested labels, invalid characters, wrong scheme/port).
+	 * Wildcard DNS still routes it here, so it must fail closed.
+	 */
+	| { kind: 'unrecognized-subdomain' }
+
+/**
+ * Classify a request URL against the configured package-app origin.
+ *
+ * Returns `null` when no package-app origin resolves or when the URL is not
+ * on the package-app domain at all (ordinary first-party traffic).
+ */
+export function parsePackageAppRequestHost(input: {
+	env: PackageAppBaseUrlEnv
+	url: URL
+}): PackageAppRequestHost | null {
+	const packageAppOrigin = getPackageAppBaseUrl({ env: input.env })
+	if (!packageAppOrigin) return null
+
+	const base = new URL(packageAppOrigin)
+	const hostname = input.url.hostname.toLowerCase()
+	if (hostname === base.hostname) {
+		// Same hostname on a different scheme/port is another local service, not
+		// the package-app origin (matches the previous exact-origin behavior).
+		return input.url.origin === base.origin ? { kind: 'apex' } : null
+	}
+	if (!hostname.endsWith(`.${base.hostname}`)) return null
+
+	const label = hostname.slice(0, -(base.hostname.length + 1))
+	if (label.includes('.') || getUsernameFormatValidationError(label)) {
+		return { kind: 'unrecognized-subdomain' }
+	}
+	const expectedOrigin = buildPackageAppSubdomainOrigin({
+		packageAppOrigin,
+		username: label,
+	})
+	if (input.url.origin !== expectedOrigin) {
+		return { kind: 'unrecognized-subdomain' }
+	}
+	return { kind: 'user-subdomain', username: label }
+}
+
 /**
  * Return a clear production configuration failure instead of allowing package
  * apps to fall back to the first-party origin.
@@ -112,9 +162,10 @@ export function getPackageAppOriginConfigurationError(
  * Fall back to `APP_BASE_URL`, then the production default, for background work
  * (workflows, email, etc.) that has no inbound request.
  *
- * Requests that arrived on the package-app origin are treated as having no
- * usable request origin: that host only serves author-supplied package apps, so
- * first-party links and package runtime callbacks must point at the app origin.
+ * Requests that arrived on the package-app domain (the bare origin or any
+ * per-user subdomain) are treated as having no usable request origin: those
+ * hosts only serve author-supplied package apps, so first-party links and
+ * package runtime callbacks must point at the app origin.
  */
 export function getAppBaseUrl(input: {
 	env: AppBaseUrlEnv
@@ -122,9 +173,9 @@ export function getAppBaseUrl(input: {
 }) {
 	if (input.requestUrl != null && input.requestUrl !== '') {
 		try {
-			const requestOrigin = new URL(input.requestUrl).origin
-			if (requestOrigin !== getPackageAppBaseUrl({ env: input.env })) {
-				return requestOrigin
+			const requestUrl = new URL(input.requestUrl)
+			if (!parsePackageAppRequestHost({ env: input.env, url: requestUrl })) {
+				return requestUrl.origin
 			}
 		} catch {
 			// Fall through to configured / default origin.

--- a/packages/worker/src/app-base-url.ts
+++ b/packages/worker/src/app-base-url.ts
@@ -1,7 +1,9 @@
 import { getDomain } from 'tldts'
-import { buildPackageAppSubdomainOrigin } from '@kody-internal/shared/public-urls.ts'
+import {
+	buildPackageAppSubdomainOrigin,
+	isDnsSafeUsername,
+} from '@kody-internal/shared/public-urls.ts'
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
-import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
 
 const DEFAULT_APP_BASE_URL = 'https://heykody.app'
 
@@ -104,7 +106,9 @@ export function parsePackageAppRequestHost(input: {
 	if (!hostname.endsWith(`.${base.hostname}`)) return null
 
 	const label = hostname.slice(0, -(base.hostname.length + 1))
-	if (label.includes('.') || getUsernameFormatValidationError(label)) {
+	// Strict DNS-label check: legacy underscore usernames cannot own a
+	// subdomain, and nested labels never match.
+	if (label.includes('.') || !isDnsSafeUsername(label)) {
 		return { kind: 'unrecognized-subdomain' }
 	}
 	const expectedOrigin = buildPackageAppSubdomainOrigin({

--- a/packages/worker/src/app-base-url.ts
+++ b/packages/worker/src/app-base-url.ts
@@ -97,13 +97,21 @@ export function parsePackageAppRequestHost(input: {
 	if (!packageAppOrigin) return null
 
 	const base = new URL(packageAppOrigin)
-	const hostname = input.url.hostname.toLowerCase()
+	const rawHostname = input.url.hostname.toLowerCase()
+	// `URL.hostname` preserves a trailing DNS dot, and `kodyapps.dev.` is the
+	// same host as `kodyapps.dev` to resolvers. Letting the dotted form fall
+	// through would route it as first-party traffic, so it fails closed as an
+	// unrecognized package-app host instead.
+	const hadTrailingDot = rawHostname.endsWith('.')
+	const hostname = rawHostname.replace(/\.+$/, '')
 	if (hostname === base.hostname) {
+		if (hadTrailingDot) return { kind: 'unrecognized-subdomain' }
 		// Same hostname on a different scheme/port is another local service, not
 		// the package-app origin (matches the previous exact-origin behavior).
 		return input.url.origin === base.origin ? { kind: 'apex' } : null
 	}
 	if (!hostname.endsWith(`.${base.hostname}`)) return null
+	if (hadTrailingDot) return { kind: 'unrecognized-subdomain' }
 
 	const label = hostname.slice(0, -(base.hostname.length + 1))
 	// Strict DNS-label check: legacy underscore usernames cannot own a

--- a/packages/worker/src/app/handlers/account-profile.node.test.ts
+++ b/packages/worker/src/app/handlers/account-profile.node.test.ts
@@ -280,7 +280,7 @@ test('account profile API updates username for the signed-in user', async () => 
 				packageId: 'pkg-1',
 				kodyId: 'demo',
 				previousName: '@current-user/demo',
-				nextName: '@next_user/demo',
+				nextName: '@next-user/demo',
 				publishedCommit: 'abc',
 				changedPaths: ['package.json'],
 				shouldRepublishCommunityListing: true,
@@ -302,7 +302,7 @@ test('account profile API updates username for the signed-in user', async () => 
 				rememberMe: false,
 			},
 			method: 'POST',
-			body: { username: 'Next_User' },
+			body: { username: 'Next-User' },
 		}),
 	)
 
@@ -310,20 +310,20 @@ test('account profile API updates username for the signed-in user', async () => 
 	expect(await response.json()).toMatchObject({
 		ok: true,
 		email: 'current-user@example.com',
-		username: 'next_user',
-		displayName: 'next_user',
+		username: 'next-user',
+		displayName: 'next-user',
 		bio: null,
 		profileVisibility: 'public',
 		packagesUpdated: 1,
 		communityListingsRepublished: 1,
-		packageUpdateMessage: 'Updated 1 package to the new @next_user scope.',
+		packageUpdateMessage: 'Updated 1 package to the new @next-user scope.',
 	})
-	expect(testDb.users.get(1)?.username).toBe('next_user')
+	expect(testDb.users.get(1)?.username).toBe('next-user')
 	expect(mockModule.updateCommunityProfile).not.toHaveBeenCalled()
 	expect(mocks.updatePackagesForUsernameChange).toHaveBeenCalledWith(
 		expect.objectContaining({
 			previousUsername: 'current-user',
-			nextUsername: 'next_user',
+			nextUsername: 'next-user',
 		}),
 	)
 	expect(
@@ -395,7 +395,7 @@ test('account profile API rejects username changes when package updates fail', a
 				rememberMe: false,
 			},
 			method: 'POST',
-			body: { username: 'next_user' },
+			body: { username: 'next-user' },
 		}),
 	)
 

--- a/packages/worker/src/app/handlers/auth-handler.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-handler.node.test.ts
@@ -502,7 +502,7 @@ test('auth handler login and signup workflow', async () => {
 	expect(invalidUsernameResponse.status).toBe(400)
 	expect(await invalidUsernameResponse.json()).toEqual({
 		error:
-			'Username must be 3 to 32 characters, use only letters, numbers, hyphens, or underscores, and start and end with a letter or number.',
+			'Username must be 3 to 32 characters, use only letters, numbers, and hyphens, and start and end with a letter or number.',
 	})
 
 	// Reserved usernames double as reserved email local parts

--- a/packages/worker/src/app/handlers/package-app.ts
+++ b/packages/worker/src/app/handlers/package-app.ts
@@ -7,6 +7,7 @@ import {
 	createPackageCodeRequest,
 	isPackageAppRequestPath,
 	parsePackageAppPath,
+	parsePackageAppSubdomainPath,
 	servePackageAppRequest,
 	type PackageAppPath,
 } from '#worker/package-runtime/package-app-serve.ts'
@@ -15,6 +16,7 @@ export {
 	createPackageCodeRequest,
 	isPackageAppRequestPath,
 	parsePackageAppPath,
+	parsePackageAppSubdomainPath,
 	servePackageAppRequest,
 	type PackageAppPath,
 }

--- a/packages/worker/src/app/package-app-handoff.node.test.ts
+++ b/packages/worker/src/app/package-app-handoff.node.test.ts
@@ -143,16 +143,40 @@ test('the package-app session cookie is not interchangeable with the app session
 	resetAuthSessionSecretForTests()
 	const env = createTestEnv()
 
+	// Secure requests get the `__Host-` prefixed name, which browsers only
+	// accept host-only (`Secure`, no `Domain`, `Path=/`): a sibling package-app
+	// subdomain cannot toss a `Domain`-wide cookie under this name.
 	const setCookie = await createPackageAppSessionCookie({
 		env,
 		session: { stableUserId: ownerStableUserId, username: 'owner' },
 		secure: true,
 	})
-	expect(setCookie).toContain('kody_pkg_session=')
+	expect(setCookie).toContain('__Host-kody_pkg_session=')
 	expect(setCookie).toContain('HttpOnly')
 	expect(setCookie).toContain('SameSite=Lax')
 	expect(setCookie).toContain('Secure')
 	expect(setCookie).toContain('Path=/')
+	expect(setCookie).not.toContain('Domain=')
+
+	// Plain-HTTP local development falls back to an unprefixed name because
+	// browsers refuse `__Host-` cookies on insecure origins.
+	const insecureSetCookie = await createPackageAppSessionCookie({
+		env,
+		session: { stableUserId: ownerStableUserId, username: 'owner' },
+		secure: false,
+	})
+	expect(insecureSetCookie).toContain('kody_pkg_session=')
+	expect(insecureSetCookie).not.toContain('__Host-')
+	await expect(
+		readPackageAppSession({
+			request: new Request('http://owner.packages.localhost/packages/x', {
+				headers: { Cookie: insecureSetCookie.split(';')[0] ?? '' },
+			}),
+			env,
+		}),
+	).resolves.toMatchObject({
+		session: { stableUserId: ownerStableUserId, username: 'owner' },
+	})
 
 	const cookiePair = setCookie.split(';')[0] ?? ''
 	const [, cookieValue] = cookiePair.split('=')
@@ -160,7 +184,7 @@ test('the package-app session cookie is not interchangeable with the app session
 
 	await expect(
 		readPackageAppSession({
-			request: new Request('https://kodyapps.dev/@owner/packages/x', {
+			request: new Request('https://owner.kodyapps.dev/packages/x', {
 				headers: { Cookie: cookiePair },
 			}),
 			env,

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -3,6 +3,7 @@ import { createHtmlResponse } from 'remix/response/html'
 import {
 	buildPackageAppPath,
 	buildPackageAppSubdomainUrl,
+	isDnsSafeUsername,
 } from '@kody-internal/shared/public-urls.ts'
 import {
 	getAppBaseUrl,
@@ -106,6 +107,25 @@ function createUnmatchedPackageAppPathResponse() {
 			'Content-Type': 'text/plain; charset=utf-8',
 		},
 	})
+}
+
+/**
+ * Terminal response for a legacy username that cannot own a subdomain
+ * (underscores are not valid in hostnames). Redirecting would send the
+ * browser to a hostname the wildcard certificate and routing cannot serve, so
+ * fail here with the fix instead.
+ */
+function createSubdomainIneligibleUsernameResponse() {
+	return new Response(
+		'Hosted package apps run on a per-user subdomain, and this username contains characters that are not allowed in domain names (such as underscores). Rename the username under Account settings, then reopen the app.',
+		{
+			status: 409,
+			headers: {
+				'Cache-Control': 'no-store',
+				'Content-Type': 'text/plain; charset=utf-8',
+			},
+		},
+	)
 }
 
 /**
@@ -225,6 +245,9 @@ async function redirectAppOriginToPackageAppOrigin(input: {
 	packageAppOrigin: string
 }) {
 	const { request, env, url, packagePath, packageAppOrigin } = input
+	if (!isDnsSafeUsername(packagePath.username)) {
+		return createSubdomainIneligibleUsernameResponse()
+	}
 	const target = buildSubdomainTarget({ packageAppOrigin, packagePath, url })
 
 	// A non-safe method reaching the app origin is not part of the normal flow
@@ -270,11 +293,13 @@ function handleApexRequest(input: {
 }) {
 	const { request, env, url, packagePath, packageAppOrigin } = input
 	if (packagePath) {
+		if (!isDnsSafeUsername(packagePath.username)) {
+			return createSubdomainIneligibleUsernameResponse()
+		}
 		const target = buildSubdomainTarget({ packageAppOrigin, packagePath, url })
 		return redirectResponse({
 			location: target.toString(),
-			status:
-				request.method === 'GET' || request.method === 'HEAD' ? 302 : 307,
+			status: request.method === 'GET' || request.method === 'HEAD' ? 302 : 307,
 		})
 	}
 	if (url.pathname === '/') {

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -1,9 +1,14 @@
 import { html } from 'remix/html-template'
 import { createHtmlResponse } from 'remix/response/html'
 import {
+	buildPackageAppPath,
+	buildPackageAppSubdomainUrl,
+} from '@kody-internal/shared/public-urls.ts'
+import {
 	getAppBaseUrl,
 	getPackageAppBaseUrl,
 	getPackageAppOriginConfigurationError,
+	parsePackageAppRequestHost,
 } from '#worker/app-base-url.ts'
 import { redirectToLoginWhenUnauthenticated } from '#app/auth-redirect.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
@@ -21,6 +26,7 @@ import {
 import {
 	type PackageAppPath,
 	parsePackageAppPath,
+	parsePackageAppSubdomainPath,
 	servePackageAppRequest,
 } from '#app/handlers/package-app.ts'
 import { buildUnmatchedPackageAppOriginPathMessage } from '#worker/package-runtime/package-app-synthetic.ts'
@@ -36,22 +42,31 @@ import { wantsJson } from '#worker/utils.ts'
  * registrable domain (`PACKAGE_APP_BASE_URL`) makes them cross-site, so the
  * `SameSite=Lax` session cookie never attaches.
  *
- * That leaves the app origin as the only host that can authenticate the owner,
- * so it mints a short-lived single-use handoff token and the package-app origin
- * exchanges it for its own host-scoped session cookie.
+ * Within that domain, every user gets their own subdomain
+ * (`{username}.<package-app host>`), so one user's package apps are a
+ * different origin from every other user's: browser state (cookies, storage,
+ * `document` access) never crosses accounts. The bare package-app origin (the
+ * apex) serves no package code at all — it only redirects legacy path-based
+ * URLs to the owning user's subdomain and sends the bare origin home.
  *
- * The two origins never redirect to each other in a cycle: the app origin only
- * ever redirects *to* the package-app origin, and the package-app origin only
- * ever redirects within itself (dropping a consumed token from the URL). A
- * request that arrives without a usable session gets a terminal 403 with a link
- * back to the app origin, so a browser that refuses the cookie fails visibly
- * instead of bouncing between hosts.
+ * The app origin is the only host that can authenticate the owner, so it mints
+ * a short-lived single-use handoff token and the user's package-app subdomain
+ * exchanges it for its own host-scoped session cookie (named with the
+ * `__Host-` prefix on secure requests so sibling subdomains cannot shadow it).
+ *
+ * The origins never redirect to each other in a cycle: the app origin only
+ * ever redirects *to* a package-app subdomain, the apex only redirects to a
+ * subdomain or the app origin, and a subdomain only ever redirects within
+ * itself (dropping a consumed token from the URL). A request that arrives
+ * without a usable session gets a terminal 403 with a link back to the app
+ * origin, so a browser that refuses the cookie fails visibly instead of
+ * bouncing between hosts.
  *
  * `/@{username}/api/package-invocations/*`, `/@{username}/connectors/*`, and
  * `/@{username}/webhooks/*` deliberately stay on the app origin: they are
  * machine APIs authenticated by their own bearer tokens or shared secrets, they
  * are never called by package browser code, and moving them would widen the
- * package-app origin's surface for no benefit. They 404 here.
+ * package-app domain's surface for no benefit. They 404 here.
  */
 
 function withoutHandoffToken(url: URL) {
@@ -91,6 +106,49 @@ function createUnmatchedPackageAppPathResponse() {
 			'Content-Type': 'text/plain; charset=utf-8',
 		},
 	})
+}
+
+/**
+ * The subdomain URL a package-app path is canonically served from, carrying
+ * over the request's query string (minus any handoff token).
+ */
+function buildSubdomainTarget(input: {
+	packageAppOrigin: string
+	packagePath: PackageAppPath
+	url: URL
+}) {
+	const target = new URL(
+		buildPackageAppSubdomainUrl({
+			packageAppOrigin: input.packageAppOrigin,
+			username: input.packagePath.username,
+			kodyId: input.packagePath.kodyId,
+			restPath:
+				input.packagePath.restPath === '/' ? null : input.packagePath.restPath,
+		}),
+	)
+	target.search = withoutHandoffToken(input.url).search
+	return target
+}
+
+/**
+ * The app-origin entry URL for a package app: the path-based mount that
+ * authenticates the owner and starts a fresh handoff.
+ */
+function buildAppOriginEntryUrl(input: {
+	appBaseUrl: string
+	packagePath: PackageAppPath
+	url: URL
+}) {
+	const entry = new URL(
+		`${input.appBaseUrl.replace(/\/+$/, '')}${buildPackageAppPath({
+			username: input.packagePath.username,
+			kodyId: input.packagePath.kodyId,
+			restPath:
+				input.packagePath.restPath === '/' ? null : input.packagePath.restPath,
+		})}`,
+	)
+	entry.search = withoutHandoffToken(input.url).search
+	return entry
 }
 
 /**
@@ -154,17 +212,10 @@ function createPackageAppSessionRequiredResponse(input: {
 	)
 }
 
-// Built with the URL constructor rather than by assigning `protocol`/`host`:
-// those setters keep the original port, so swapping origins by mutation turns
-// `http://localhost:8787/x` into `https://kodyapps.dev:8787/x`.
-function replaceOrigin(input: { url: URL; origin: string }) {
-	return new URL(`${input.url.pathname}${input.url.search}`, input.origin)
-}
-
 /**
- * Mint a handoff token for the signed-in owner and send them to the package-app
- * origin. The app origin never executes package code once `PACKAGE_APP_BASE_URL`
- * is configured.
+ * Mint a handoff token for the signed-in owner and send them to their
+ * package-app subdomain. The app origin never executes package code once
+ * `PACKAGE_APP_BASE_URL` is configured.
  */
 async function redirectAppOriginToPackageAppOrigin(input: {
 	request: Request
@@ -174,15 +225,13 @@ async function redirectAppOriginToPackageAppOrigin(input: {
 	packageAppOrigin: string
 }) {
 	const { request, env, url, packagePath, packageAppOrigin } = input
-	const target = replaceOrigin({
-		url: withoutHandoffToken(url),
-		origin: packageAppOrigin,
-	})
+	const target = buildSubdomainTarget({ packageAppOrigin, packagePath, url })
 
 	// A non-safe method reaching the app origin is not part of the normal flow
-	// (package pages are loaded from, and post back to, the package-app origin).
-	// Preserve the method and let the package-app origin authorize it with its
-	// own session rather than minting a token for a request we cannot replay.
+	// (package pages are loaded from, and post back to, the package-app
+	// subdomain). Preserve the method and let the subdomain authorize it with
+	// its own session rather than minting a token for a request we cannot
+	// replay.
 	if (request.method !== 'GET' && request.method !== 'HEAD') {
 		return redirectResponse({ location: target.toString(), status: 307 })
 	}
@@ -207,18 +256,53 @@ async function redirectAppOriginToPackageAppOrigin(input: {
 	return redirectResponse({ location: target.toString(), status: 302 })
 }
 
-async function handleRequestOnPackageAppOrigin(input: {
+/**
+ * The bare package-app origin serves no package code: it sends the bare origin
+ * home and redirects legacy path-based package URLs to the owning user's
+ * subdomain. Everything else fails closed.
+ */
+function handleApexRequest(input: {
 	request: Request
 	env: Env
 	url: URL
 	packagePath: PackageAppPath | null
+	packageAppOrigin: string
 }) {
-	const { request, env, url, packagePath } = input
+	const { request, env, url, packagePath, packageAppOrigin } = input
+	if (packagePath) {
+		const target = buildSubdomainTarget({ packageAppOrigin, packagePath, url })
+		return redirectResponse({
+			location: target.toString(),
+			status:
+				request.method === 'GET' || request.method === 'HEAD' ? 302 : 307,
+		})
+	}
+	if (url.pathname === '/') {
+		return redirectResponse({
+			location: `${getAppBaseUrl({ env })}/`,
+			status: 302,
+		})
+	}
+	return createUnmatchedPackageAppPathResponse()
+}
+
+async function handleUserSubdomainRequest(input: {
+	request: Request
+	env: Env
+	url: URL
+	username: string
+}) {
+	const { request, env, url, username } = input
 	const appBaseUrl = getAppBaseUrl({ env })
+	const packagePath = parsePackageAppSubdomainPath({
+		pathname: url.pathname,
+		username,
+	})
 
 	if (!packagePath) {
-		// Nothing first-party is reachable here. The bare origin is a plausible
-		// typo or bookmark, so send it home; everything else fails closed.
+		// Nothing first-party is reachable here. The bare subdomain is a
+		// plausible typo or bookmark, so send it home; everything else fails
+		// closed.
 		if (url.pathname === '/') {
 			return redirectResponse({ location: `${appBaseUrl}/`, status: 302 })
 		}
@@ -263,17 +347,14 @@ async function handleRequestOnPackageAppOrigin(input: {
 	if (!owner) {
 		return createPackageAppSessionRequiredResponse({
 			request,
-			appOriginUrl: replaceOrigin({
-				url: withoutHandoffToken(url),
-				origin: appBaseUrl,
-			}),
+			appOriginUrl: buildAppOriginEntryUrl({ appBaseUrl, packagePath, url }),
 		})
 	}
 
 	// A token that reaches here is stale, forged, or for another package, so it is
-	// worthless — but it is still an internal auth artifact, and package code has
-	// no business seeing one. Serve the request as if it never carried a token,
-	// including when the parameter is present but empty.
+	// still worthless — but it is still an internal auth artifact, and package code
+	// has no business seeing one. Serve the request as if it never carried a
+	// token, including when the parameter is present but empty.
 	return await servePackageAppRequest({
 		request: url.searchParams.has(packageAppHandoffQueryParam)
 			? new Request(withoutHandoffToken(url), request)
@@ -296,22 +377,40 @@ export async function handlePackageAppOriginRequest(
 	env: Env,
 ) {
 	const url = new URL(request.url)
+	const requestHost = parsePackageAppRequestHost({ env, url })
 	const packagePath = parsePackageAppPath(url.pathname)
 	const configurationError = getPackageAppOriginConfigurationError(env)
-	if (configurationError && packagePath) {
+	if (configurationError && (packagePath || requestHost)) {
 		return createPackageAppOriginConfigurationErrorResponse(configurationError)
 	}
 
 	const packageAppOrigin = getPackageAppBaseUrl({ env })
 	if (!packageAppOrigin) return null
 
-	if (url.origin === packageAppOrigin) {
-		return await handleRequestOnPackageAppOrigin({
-			request,
-			env,
-			url,
-			packagePath,
-		})
+	if (requestHost) {
+		switch (requestHost.kind) {
+			case 'apex':
+				return handleApexRequest({
+					request,
+					env,
+					url,
+					packagePath,
+					packageAppOrigin,
+				})
+			case 'user-subdomain':
+				return await handleUserSubdomainRequest({
+					request,
+					env,
+					url,
+					username: requestHost.username,
+				})
+			case 'unrecognized-subdomain':
+				return createUnmatchedPackageAppPathResponse()
+			default: {
+				requestHost satisfies never
+				return createUnmatchedPackageAppPathResponse()
+			}
+		}
 	}
 	if (!packagePath) return null
 

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -334,6 +334,31 @@ async function handleUserSubdomainRequest(input: {
 		return createUnmatchedPackageAppPathResponse()
 	}
 
+	// Sibling package-app subdomains are same-site, so until the package-app
+	// domain is on the Public Suffix List a `SameSite=Lax` session cookie still
+	// attaches to their cross-origin requests. A browser that holds sessions
+	// for two accounts (shared machine, multiple sign-ins) could therefore let
+	// one user's package code send a credentialed mutating request to another
+	// user's app — CORS blocks the response, not the side effect. Mutating
+	// browser requests must originate from this subdomain itself; requests
+	// without an `Origin` header (non-browser clients, synthetic dispatch)
+	// authenticate through their own paths and are unaffected.
+	if (request.method !== 'GET' && request.method !== 'HEAD') {
+		const originHeader = request.headers.get('Origin')
+		if (originHeader !== null && originHeader !== url.origin) {
+			return new Response(
+				'Cross-origin mutating requests to a package-app subdomain are not allowed.',
+				{
+					status: 403,
+					headers: {
+						'Cache-Control': 'no-store',
+						'Content-Type': 'text/plain; charset=utf-8',
+					},
+				},
+			)
+		}
+	}
+
 	const handoffToken = url.searchParams.get(packageAppHandoffQueryParam)
 	if (handoffToken) {
 		const claims = await consumePackageAppHandoffToken({

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -24,6 +24,9 @@ const appOrigin = 'https://app.kody.test:8788'
 const packageAppOrigin = 'https://packages.isolated.test'
 const ownerEmail = 'pkg-owner@example.com'
 const ownerUsername = 'pkg-owner'
+// Hosted package apps are served from the owner's own subdomain of the
+// package-app origin; the bare origin only redirects.
+const ownerPackageAppOrigin = `https://${ownerUsername}.packages.isolated.test`
 
 /**
  * The generated `Env` types pin production var literals, so origin overrides go
@@ -103,7 +106,7 @@ function cookieValue(setCookieHeader: string) {
 	return setCookieHeader.split(';')[0] ?? ''
 }
 
-test('hosted package apps move to the package-app origin behind a single-use handoff', async () => {
+test('hosted package apps move to the owner subdomain behind a single-use handoff', async () => {
 	configureOrigins({
 		packageAppBaseUrl: packageAppOrigin,
 		runtime: 'production',
@@ -111,7 +114,8 @@ test('hosted package apps move to the package-app origin behind a single-use han
 	const sessionCookie = await seedOwnerSessionCookie()
 
 	// 1. The app origin never executes package code: it mints a handoff token and
-	// redirects to the package-app origin, preserving path and query.
+	// redirects to the owner's package-app subdomain, where the username lives in
+	// the hostname and the path carries only the package mount. Query preserved.
 	const appOriginResponse = await workerFetch(
 		`${appOrigin}/@${ownerUsername}/packages/demo/report?tab=1`,
 		{ headers: { Cookie: sessionCookie } },
@@ -120,28 +124,30 @@ test('hosted package apps move to the package-app origin behind a single-use han
 	const handoffLocation = new URL(
 		appOriginResponse.headers.get('Location') ?? '',
 	)
-	expect(handoffLocation.origin).toBe(packageAppOrigin)
-	expect(handoffLocation.pathname).toBe(
-		`/@${ownerUsername}/packages/demo/report`,
-	)
+	expect(handoffLocation.origin).toBe(ownerPackageAppOrigin)
+	expect(handoffLocation.pathname).toBe('/packages/demo/report')
 	expect(handoffLocation.searchParams.get('tab')).toBe('1')
 	const handoffToken = handoffLocation.searchParams.get(
 		packageAppHandoffQueryParam,
 	)
 	expect(handoffToken).toBeTruthy()
 
-	// 2. The package-app origin exchanges the token for its own host-scoped
-	// cookie, then bounces to the clean URL so the token stops travelling.
+	// 2. The owner subdomain exchanges the token for its own host-scoped cookie,
+	// then bounces to the clean URL so the token stops travelling. The secure
+	// cookie uses the `__Host-` prefix, so browsers refuse any variant carrying a
+	// `Domain` attribute (cookie tossing from sibling subdomains).
 	const handoffResponse = await workerFetch(handoffLocation)
 	expect(handoffResponse.status).toBe(302)
 	const packageSessionCookieHeader =
 		handoffResponse.headers.get('Set-Cookie') ?? ''
-	expect(packageSessionCookieHeader).toContain('kody_pkg_session=')
+	expect(packageSessionCookieHeader).toContain('__Host-kody_pkg_session=')
 	expect(packageSessionCookieHeader).toContain('HttpOnly')
 	expect(packageSessionCookieHeader).toContain('SameSite=Lax')
 	expect(packageSessionCookieHeader).toContain('Secure')
+	expect(packageSessionCookieHeader).toContain('Path=/')
+	expect(packageSessionCookieHeader).not.toContain('Domain=')
 	const cleanLocation = new URL(handoffResponse.headers.get('Location') ?? '')
-	expect(cleanLocation.origin).toBe(packageAppOrigin)
+	expect(cleanLocation.origin).toBe(ownerPackageAppOrigin)
 	expect(cleanLocation.searchParams.has(packageAppHandoffQueryParam)).toBe(
 		false,
 	)
@@ -195,6 +201,8 @@ test('hosted package apps move to the package-app origin behind a single-use han
 	// 6. Replaying the consumed token is refused, and so is any request without a
 	// package-app session. Both terminate here (never a redirect back to the app
 	// origin) so a browser that drops the cookie cannot ping-pong between hosts.
+	// The terminal page links to the app-origin entry path that restarts the
+	// handoff.
 	for (const request of [handoffLocation, cleanLocation]) {
 		const rejected = await workerFetch(request)
 		expect(rejected.status).toBe(403)
@@ -211,31 +219,79 @@ test('hosted package apps move to the package-app origin behind a single-use han
 		error: 'Package app session required',
 	})
 
-	// 7. Nothing first-party is reachable on the package-app origin.
-	for (const path of [
-		'/account/secrets.json',
-		'/login',
-		'/mcp',
-		'/session',
-		`/@${ownerUsername}/api/package-invocations/demo`,
-		`/@${ownerUsername}/connectors/home/instance`,
-	]) {
-		const response = await workerFetch(`${packageAppOrigin}${path}`, {
-			headers: { Cookie: `${packageSessionCookie}; ${sessionCookie}` },
-		})
-		expect(response.status, `expected 404 for ${path}`).toBe(404)
-		const body = await response.text()
-		expect(body).toContain('/@username/packages/<kody-id>/<path>')
-		expect(body).toBe(buildUnmatchedPackageAppOriginPathMessage())
+	// 7. The session is bound to one account and the subdomain names the account:
+	// the owner's cookie on another user's subdomain never serves package code.
+	const crossUserResponse = await workerFetch(
+		'https://other-user.packages.isolated.test/packages/demo',
+		{ headers: { Cookie: packageSessionCookie } },
+	)
+	expect(crossUserResponse.status).toBe(404)
+	await expect(crossUserResponse.text()).resolves.toBe(
+		buildPackageAppNotFoundMessage(),
+	)
+
+	// 8. Nothing first-party is reachable on the package-app domain — neither on
+	// the bare origin nor on a user subdomain.
+	for (const origin of [packageAppOrigin, ownerPackageAppOrigin]) {
+		for (const path of [
+			'/account/secrets.json',
+			'/login',
+			'/mcp',
+			'/session',
+			`/@${ownerUsername}/api/package-invocations/demo`,
+			`/@${ownerUsername}/connectors/home/instance`,
+		]) {
+			const response = await workerFetch(`${origin}${path}`, {
+				headers: { Cookie: `${packageSessionCookie}; ${sessionCookie}` },
+			})
+			expect(response.status, `expected 404 for ${origin}${path}`).toBe(404)
+			const body = await response.text()
+			expect(body).toBe(buildUnmatchedPackageAppOriginPathMessage())
+		}
 	}
 
-	// 8. The bare package-app origin is a plausible bookmark; send it home.
-	const rootResponse = await workerFetch(`${packageAppOrigin}/`)
-	expect(rootResponse.status).toBe(302)
-	expect(rootResponse.headers.get('Location')).toBe(`${appOrigin}/`)
+	// 9. Hostnames under the package-app domain that are not a valid username
+	// label fail closed: wildcard DNS routes them here, but nothing serves.
+	for (const badHost of [
+		'https://nested.label.packages.isolated.test',
+		'https://Bad_Label.packages.isolated.test',
+		'https://xy.packages.isolated.test',
+	]) {
+		const response = await workerFetch(`${badHost}/packages/demo`, {
+			headers: { Cookie: packageSessionCookie },
+		})
+		expect(response.status, `expected 404 for ${badHost}`).toBe(404)
+		await expect(response.text()).resolves.toBe(
+			buildUnmatchedPackageAppOriginPathMessage(),
+		)
+	}
 
-	// 9. The package-app session is not an app session: the app origin refuses it
-	// and sends the visitor to log in.
+	// 10. Legacy path-based URLs on the bare package-app origin redirect to the
+	// owning user's subdomain (dropping any handoff token, keeping the query).
+	const legacyUrl = new URL(
+		`${packageAppOrigin}/@${ownerUsername}/packages/demo/report?tab=1`,
+	)
+	legacyUrl.searchParams.set(packageAppHandoffQueryParam, 'stale-token')
+	const legacyResponse = await workerFetch(legacyUrl)
+	expect(legacyResponse.status).toBe(302)
+	const legacyLocation = new URL(legacyResponse.headers.get('Location') ?? '')
+	expect(legacyLocation.origin).toBe(ownerPackageAppOrigin)
+	expect(legacyLocation.pathname).toBe('/packages/demo/report')
+	expect(legacyLocation.searchParams.get('tab')).toBe('1')
+	expect(legacyLocation.searchParams.has(packageAppHandoffQueryParam)).toBe(
+		false,
+	)
+
+	// 11. The bare package-app origin and a bare user subdomain are plausible
+	// bookmarks; send them home.
+	for (const origin of [packageAppOrigin, ownerPackageAppOrigin]) {
+		const rootResponse = await workerFetch(`${origin}/`)
+		expect(rootResponse.status).toBe(302)
+		expect(rootResponse.headers.get('Location')).toBe(`${appOrigin}/`)
+	}
+
+	// 12. The package-app session is not an app session: the app origin refuses
+	// it and sends the visitor to log in.
 	const appOriginWithPackageCookie = await workerFetch(
 		`${appOrigin}/@${ownerUsername}/packages/demo`,
 		{ headers: { Cookie: packageSessionCookie } },
@@ -296,10 +352,10 @@ test('production package apps fail closed when origin isolation is missing or un
 
 test('createPackageCodeRequest drops credential headers in the workers runtime', async () => {
 	const packageCodeRequest = createPackageCodeRequest(
-		new Request(`${packageAppOrigin}/@${ownerUsername}/packages/demo/save`, {
+		new Request(`${ownerPackageAppOrigin}/packages/demo/save`, {
 			method: 'POST',
 			headers: {
-				Cookie: 'kody_session=owner; kody_pkg_session=package',
+				Cookie: 'kody_session=owner; __Host-kody_pkg_session=package',
 				Authorization: 'Bearer owner-token',
 				'Proxy-Authorization': 'Basic owner',
 				'X-Kody-Connector-Session-Key': 'internal',
@@ -307,10 +363,10 @@ test('createPackageCodeRequest drops credential headers in the workers runtime',
 			},
 			body: JSON.stringify({ hello: 'world' }),
 		}),
-		new URL(`${packageAppOrigin}/save`),
+		new URL(`${ownerPackageAppOrigin}/save`),
 	)
 
-	expect(packageCodeRequest.url).toBe(`${packageAppOrigin}/save`)
+	expect(packageCodeRequest.url).toBe(`${ownerPackageAppOrigin}/save`)
 	expect(packageCodeRequest.headers.get('Cookie')).toBeNull()
 	expect(packageCodeRequest.headers.get('Authorization')).toBeNull()
 	expect(packageCodeRequest.headers.get('Proxy-Authorization')).toBeNull()

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -302,6 +302,57 @@ test('hosted package apps move to the owner subdomain behind a single-use handof
 	).toBe('/login')
 })
 
+test('legacy underscore usernames get a rename prompt instead of a broken subdomain redirect', async () => {
+	configureOrigins({
+		packageAppBaseUrl: packageAppOrigin,
+		runtime: 'production',
+	})
+	// Ensures schema and the session secret are in place.
+	await seedOwnerSessionCookie()
+	const legacyEmail = 'legacy-owner@example.com'
+	const legacyUsername = 'legacy_owner'
+	await seedAccount({
+		db: env.APP_DB,
+		email: legacyEmail,
+		username: legacyUsername,
+	})
+	const legacySetCookie = await createAuthCookie(
+		{
+			stableUserId: await createStableUserIdFromEmail(legacyEmail),
+			email: legacyEmail,
+			rememberMe: false,
+		},
+		true,
+	)
+	const legacyCookie = legacySetCookie.split(';')[0] ?? ''
+
+	// The app-origin entry terminates with the fix instead of redirecting to a
+	// hostname the wildcard certificate and routing cannot serve.
+	const entryResponse = await workerFetch(
+		`${appOrigin}/@${legacyUsername}/packages/demo`,
+		{ headers: { Cookie: legacyCookie } },
+	)
+	expect(entryResponse.status).toBe(409)
+	expect(entryResponse.headers.get('Location')).toBeNull()
+	await expect(entryResponse.text()).resolves.toContain('Rename the username')
+
+	// Legacy apex URLs for such accounts terminate the same way.
+	const apexResponse = await workerFetch(
+		`${packageAppOrigin}/@${legacyUsername}/packages/demo`,
+	)
+	expect(apexResponse.status).toBe(409)
+
+	// And an underscore hostname is never a valid user subdomain.
+	const subdomainResponse = await workerFetch(
+		`https://${legacyUsername}.packages.isolated.test/packages/demo`,
+		{ headers: { Cookie: legacyCookie } },
+	)
+	expect(subdomainResponse.status).toBe(404)
+	await expect(subdomainResponse.text()).resolves.toBe(
+		buildUnmatchedPackageAppOriginPathMessage(),
+	)
+})
+
 test('package apps stay inline on the app origin when no package-app origin is configured', async () => {
 	configureOrigins({ packageAppBaseUrl: undefined, runtime: 'preview' })
 	const sessionCookie = await seedOwnerSessionCookie()

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -230,6 +230,33 @@ test('hosted package apps move to the owner subdomain behind a single-use handof
 		buildPackageAppNotFoundMessage(),
 	)
 
+	// 7b. Sibling subdomains are same-site, so a Lax cookie would attach to
+	// their cross-origin requests. A mutating request whose Origin is not this
+	// subdomain is rejected before any package code runs, even with a valid
+	// session; a same-origin mutation passes through to serving.
+	const crossOriginPost = await workerFetch(cleanLocation, {
+		method: 'POST',
+		headers: {
+			Cookie: packageSessionCookie,
+			Origin: 'https://other-user.packages.isolated.test',
+		},
+	})
+	expect(crossOriginPost.status).toBe(403)
+	await expect(crossOriginPost.text()).resolves.toContain(
+		'Cross-origin mutating requests',
+	)
+	const sameOriginPost = await workerFetch(cleanLocation, {
+		method: 'POST',
+		headers: {
+			Cookie: packageSessionCookie,
+			Origin: ownerPackageAppOrigin,
+		},
+	})
+	expect(sameOriginPost.status).toBe(404)
+	await expect(sameOriginPost.text()).resolves.toBe(
+		buildPackageAppNotFoundMessage(),
+	)
+
 	// 8. Nothing first-party is reachable on the package-app domain — neither on
 	// the bare origin nor on a user subdomain.
 	for (const origin of [packageAppOrigin, ownerPackageAppOrigin]) {

--- a/packages/worker/src/app/package-app-session.ts
+++ b/packages/worker/src/app/package-app-session.ts
@@ -3,7 +3,7 @@ import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
 import { isStableUserId } from '#worker/user-id.ts'
 
 /**
- * Host-scoped session for the package-app origin.
+ * Host-scoped session for one user's package-app subdomain.
  *
  * This cookie is deliberately *not* `kody_session`:
  *
@@ -13,11 +13,22 @@ import { isStableUserId } from '#worker/user-id.ts'
  *   session even if it were replayed under the other name;
  * - a different payload shape, so it cannot satisfy the app session schema.
  *
- * It authorizes hosted package-app access for one user on the package-app
- * origin and nothing else.
+ * On secure requests the cookie is named with the `__Host-` prefix, which
+ * browsers only accept when it is `Secure`, has no `Domain` attribute, and
+ * has `Path=/`. That makes the cookie provably host-only: a package app on a
+ * sibling subdomain cannot plant a `Domain=.<package-app domain>` cookie under
+ * this name (cookie tossing), even before the package-app domain is on the
+ * Public Suffix List. Plain-HTTP local development falls back to an
+ * unprefixed name because browsers refuse `__Host-` cookies on insecure
+ * origins.
+ *
+ * It authorizes hosted package-app access for one user on that user's
+ * package-app subdomain and nothing else; serving additionally requires the
+ * session's username to match the subdomain being requested.
  */
 
-const packageAppSessionCookieName = 'kody_pkg_session'
+const securePackageAppSessionCookieName = '__Host-kody_pkg_session'
+const insecurePackageAppSessionCookieName = 'kody_pkg_session'
 const packageAppSessionMaxAgeSeconds = 60 * 60 * 12
 const packageAppSessionSecretPurpose = 'kody-package-app-session:v2'
 
@@ -38,35 +49,50 @@ export type ParsedPackageAppSession = {
 	issuedAt: number
 }
 
-let cachedCookie: {
+let cachedCookies: {
 	sourceSecret: string
-	cookie: ReturnType<typeof createCookie>
+	secureCookie: ReturnType<typeof createCookie>
+	insecureCookie: ReturnType<typeof createCookie>
 } | null = null
 
-async function getPackageAppSessionCookie(env: Env) {
+async function getPackageAppSessionCookies(env: Env) {
 	const secret = env.COOKIE_SECRET?.trim()
 	if (!secret) {
 		throw new Error('Missing COOKIE_SECRET for package app session signing.')
 	}
-	if (cachedCookie?.sourceSecret === secret) return cachedCookie.cookie
+	if (cachedCookies?.sourceSecret === secret) return cachedCookies
 
 	const derivedSecret = await sha256Base64Url(
 		`${packageAppSessionSecretPurpose}:${secret}`,
 	)
-	const cookie = createCookie(packageAppSessionCookieName, {
+	const sharedOptions = {
 		httpOnly: true,
-		sameSite: 'Lax',
+		sameSite: 'Lax' as const,
 		path: '/',
 		maxAge: packageAppSessionMaxAgeSeconds,
 		secrets: [derivedSecret],
-	})
-	cachedCookie = { sourceSecret: secret, cookie }
-	return cookie
+	}
+	cachedCookies = {
+		sourceSecret: secret,
+		secureCookie: createCookie(securePackageAppSessionCookieName, {
+			...sharedOptions,
+			secure: true,
+		}),
+		insecureCookie: createCookie(insecurePackageAppSessionCookieName, {
+			...sharedOptions,
+		}),
+	}
+	return cachedCookies
+}
+
+async function getPackageAppSessionCookie(env: Env, secure: boolean) {
+	const cookies = await getPackageAppSessionCookies(env)
+	return secure ? cookies.secureCookie : cookies.insecureCookie
 }
 
 /** Clears the derived cookie cache so tests can swap secrets. */
 export function resetPackageAppSessionCookieForTests() {
-	cachedCookie = null
+	cachedCookies = null
 }
 
 function isStoredPackageAppSession(
@@ -91,7 +117,7 @@ export async function createPackageAppSessionCookie(input: {
 	secure: boolean
 	now?: number
 }) {
-	const cookie = await getPackageAppSessionCookie(input.env)
+	const cookie = await getPackageAppSessionCookie(input.env, input.secure)
 	return await cookie.serialize(
 		JSON.stringify({
 			v: 2,
@@ -107,7 +133,7 @@ export async function destroyPackageAppSessionCookie(input: {
 	env: Env
 	secure: boolean
 }) {
-	const cookie = await getPackageAppSessionCookie(input.env)
+	const cookie = await getPackageAppSessionCookie(input.env, input.secure)
 	return await cookie.serialize('', {
 		secure: input.secure,
 		maxAge: 0,
@@ -115,17 +141,10 @@ export async function destroyPackageAppSessionCookie(input: {
 	})
 }
 
-export async function readPackageAppSession(input: {
-	request: Request
-	env: Env
-}): Promise<ParsedPackageAppSession | null> {
-	const cookieHeader = input.request.headers.get('Cookie')
-	if (!cookieHeader) return null
-
-	const cookie = await getPackageAppSessionCookie(input.env)
-	const stored = await cookie.parse(cookieHeader)
+function parseStoredPackageAppSession(
+	stored: unknown,
+): ParsedPackageAppSession | null {
 	if (!stored || typeof stored !== 'string') return null
-
 	try {
 		const parsed: unknown = JSON.parse(stored)
 		if (!isStoredPackageAppSession(parsed)) return null
@@ -139,4 +158,21 @@ export async function readPackageAppSession(input: {
 	} catch {
 		return null
 	}
+}
+
+export async function readPackageAppSession(input: {
+	request: Request
+	env: Env
+}): Promise<ParsedPackageAppSession | null> {
+	const cookieHeader = input.request.headers.get('Cookie')
+	if (!cookieHeader) return null
+
+	const cookies = await getPackageAppSessionCookies(input.env)
+	const secureSession = parseStoredPackageAppSession(
+		await cookies.secureCookie.parse(cookieHeader),
+	)
+	if (secureSession) return secureSession
+	return parseStoredPackageAppSession(
+		await cookies.insecureCookie.parse(cookieHeader),
+	)
 }

--- a/packages/worker/src/identity/generated-username.ts
+++ b/packages/worker/src/identity/generated-username.ts
@@ -24,7 +24,7 @@ export async function getAvailableUsernameFromBase(
 	// Provider handles may contain characters the username format rejects;
 	// map them the same way usernameFromEmail maps email local parts.
 	const normalizedBase = normalizeUsername(base)
-		.replace(/[^a-z0-9_-]+/g, '-')
+		.replace(/[^a-z0-9-]+/g, '-')
 		.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '')
 		.slice(0, 32)
 		.replace(/[^a-z0-9]+$/g, '')
@@ -37,7 +37,7 @@ export async function getAvailableUsernameFromBase(
 	}
 
 	const prefix =
-		(normalizedBase || 'user').slice(0, 27).replace(/[-_]+$/g, '') || 'user'
+		(normalizedBase || 'user').slice(0, 27).replace(/-+$/g, '') || 'user'
 	for (let suffix = 2; suffix <= 100; suffix += 1) {
 		const candidate = `${prefix}-${suffix}`
 		if (

--- a/packages/worker/src/identity/platform-account-creation.ts
+++ b/packages/worker/src/identity/platform-account-creation.ts
@@ -3,7 +3,7 @@ import { userExistsByUsername } from '#worker/identity/generated-username.ts'
 import { normalizeEmail } from '#worker/identity/normalize-email.ts'
 import { isReservedUsername } from '#worker/identity/reserved-usernames.ts'
 import {
-	getUsernameFormatValidationError,
+	getDnsSafeUsernameValidationError,
 	normalizeUsername,
 } from '#worker/identity/username.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -54,7 +54,10 @@ export async function createPlatformAccount(input: {
 	}
 
 	const username = normalizeUsername(input.username)
-	const formatError = getUsernameFormatValidationError(username)
+	// Platform accounts are new accounts too: their usernames must be strict
+	// DNS labels so they can own a package-app subdomain (they only bypass the
+	// reserved-list restriction, not the format rules).
+	const formatError = getDnsSafeUsernameValidationError(username)
 	if (formatError) {
 		throw new PlatformAccountCreateError('invalid_username', formatError)
 	}

--- a/packages/worker/src/identity/username.node.test.ts
+++ b/packages/worker/src/identity/username.node.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest'
+import {
+	getUsernameFormatValidationError,
+	usernameFromEmail,
+	usernameRequirements,
+} from './username.ts'
+
+test('username format validation rejects underscores', () => {
+	expect(getUsernameFormatValidationError('some_user')).toBe(
+		usernameRequirements,
+	)
+	expect(getUsernameFormatValidationError('user_name')).toBe(
+		usernameRequirements,
+	)
+})
+
+test('usernameFromEmail maps underscores in the email local part to hyphens', () => {
+	expect(usernameFromEmail('some_user@example.com')).toBe('some-user')
+})

--- a/packages/worker/src/identity/username.node.test.ts
+++ b/packages/worker/src/identity/username.node.test.ts
@@ -1,17 +1,33 @@
 import { expect, test } from 'vitest'
 import {
+	getDnsSafeUsernameValidationError,
 	getUsernameFormatValidationError,
+	getUsernameValidationError,
+	resolveDisplayName,
 	usernameFromEmail,
 	usernameRequirements,
 } from './username.ts'
 
-test('username format validation rejects underscores', () => {
-	expect(getUsernameFormatValidationError('some_user')).toBe(
+test('new and changed usernames must be DNS labels (no underscores)', () => {
+	expect(getDnsSafeUsernameValidationError('some_user')).toBe(
 		usernameRequirements,
 	)
-	expect(getUsernameFormatValidationError('user_name')).toBe(
+	expect(getUsernameValidationError('user_name')).toBe(usernameRequirements)
+	expect(getDnsSafeUsernameValidationError('some-user')).toBeNull()
+	expect(getUsernameValidationError('some-user')).toBeNull()
+})
+
+test('existing usernames with legacy underscores are still recognized', () => {
+	// Recognition of stored usernames stays lenient so legacy accounts keep
+	// display names, public lookup, and inbound email routing; only subdomain
+	// hosting and new-username validation require the strict DNS-label shape.
+	expect(getUsernameFormatValidationError('some_user')).toBeNull()
+	expect(getUsernameFormatValidationError('has space')).toBe(
 		usernameRequirements,
 	)
+	expect(
+		resolveDisplayName({ email: 'legacy@example.com', username: 'some_user' }),
+	).toBe('some_user')
 })
 
 test('usernameFromEmail maps underscores in the email local part to hyphens', () => {

--- a/packages/worker/src/identity/username.ts
+++ b/packages/worker/src/identity/username.ts
@@ -1,20 +1,48 @@
+import { dnsSafeUsernamePattern } from '@kody-internal/shared/public-urls.ts'
 import { getReservedUsernameError } from '#worker/identity/reserved-usernames.ts'
 
 export const usernameRequirements =
 	'Username must be 3 to 32 characters, use only letters, numbers, and hyphens, and start and end with a letter or number.'
 
-/** Valid DNS label for `{username}.` on the package-app domain: lowercase, 3–32 chars, alphanumeric edges, hyphens only. */
-const usernamePattern = /^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$/
+/**
+ * The shape usernames could take before the underscore ban. Existing accounts
+ * may still carry underscores, so *recognition* of stored usernames (display
+ * names, public user lookup, inbound email routing, `/@{username}` path
+ * parsing) stays lenient — otherwise those accounts would silently lose every
+ * username-addressed surface, not just hosted package-app subdomains.
+ */
+const legacyUsernamePattern = /^[a-z0-9](?:[a-z0-9_-]{1,30}[a-z0-9])$/
 
 export function normalizeUsername(value: unknown) {
 	return typeof value === 'string' ? value.trim().toLowerCase() : ''
 }
 
+/**
+ * Recognition gate for usernames that may already exist in the database.
+ * Accepts the legacy underscore shape; use
+ * `getDnsSafeUsernameValidationError` when validating a new or changed
+ * username or a package-app subdomain label.
+ */
 export function getUsernameFormatValidationError(username: string) {
 	if (!username) {
 		return 'Username is required.'
 	}
-	if (!usernamePattern.test(username)) {
+	if (!legacyUsernamePattern.test(username)) {
+		return usernameRequirements
+	}
+	return null
+}
+
+/**
+ * Strict DNS-label validation (`dnsSafeUsernamePattern` from
+ * `@kody-internal/shared/public-urls.ts`) for new/changed usernames and
+ * package-app subdomain labels. Rejects the legacy underscore shape.
+ */
+export function getDnsSafeUsernameValidationError(username: string) {
+	if (!username) {
+		return 'Username is required.'
+	}
+	if (!dnsSafeUsernamePattern.test(username)) {
 		return usernameRequirements
 	}
 	return null
@@ -48,8 +76,9 @@ export function resolveDisplayName(input: { email: string; username: string }) {
 		: input.username
 }
 
+/** Validation for a new or changed username: strict DNS label + reserved list. */
 export function getUsernameValidationError(username: string) {
-	const formatError = getUsernameFormatValidationError(username)
+	const formatError = getDnsSafeUsernameValidationError(username)
 	if (formatError) {
 		return formatError
 	}

--- a/packages/worker/src/identity/username.ts
+++ b/packages/worker/src/identity/username.ts
@@ -1,9 +1,10 @@
 import { getReservedUsernameError } from '#worker/identity/reserved-usernames.ts'
 
 export const usernameRequirements =
-	'Username must be 3 to 32 characters, use only letters, numbers, hyphens, or underscores, and start and end with a letter or number.'
+	'Username must be 3 to 32 characters, use only letters, numbers, and hyphens, and start and end with a letter or number.'
 
-const usernamePattern = /^[a-z0-9](?:[a-z0-9_-]{1,30}[a-z0-9])$/
+/** Valid DNS label for `{username}.` on the package-app domain: lowercase, 3–32 chars, alphanumeric edges, hyphens only. */
+const usernamePattern = /^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$/
 
 export function normalizeUsername(value: unknown) {
 	return typeof value === 'string' ? value.trim().toLowerCase() : ''
@@ -27,7 +28,7 @@ export function usernameFromEmail(email: string) {
 	const localPart = email.split('@')[0] ?? 'user'
 	const normalized = localPart
 		.toLowerCase()
-		.replace(/[^a-z0-9_-]+/g, '-')
+		.replace(/[^a-z0-9-]+/g, '-')
 		.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '')
 	const truncated = normalized
 		.slice(0, 32)

--- a/packages/worker/src/mcp/capabilities/packages/package-app-fetch.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-app-fetch.node.test.ts
@@ -37,15 +37,6 @@ vi.mock('#worker/app-base-url.ts', () => ({
 }))
 
 vi.mock('#worker/package-runtime/package-app-serve.ts', () => ({
-	parsePackageAppPath: (pathname: string) => {
-		const match = pathname.match(/^\/@([^/]+)\/packages\/([^/]+)(\/.*)?$/)
-		if (!match) return null
-		return {
-			username: decodeURIComponent(match[1] ?? ''),
-			kodyId: decodeURIComponent(match[2] ?? ''),
-			restPath: match[3] || '/',
-		}
-	},
 	servePackageAppRequest: (...args: Array<unknown>) =>
 		mockModule.servePackageAppRequest(...args),
 }))
@@ -152,13 +143,14 @@ test('package_app_fetch dispatches synthetic in-process app requests against hos
 				username: 'kody',
 				kodyId: 'demo-app',
 				restPath: '/api/health',
+				mount: 'user-subdomain',
 			},
 		}),
 	)
 	const request = mockModule.servePackageAppRequest.mock.calls[0]?.[0]?.request
 	expect(request).toBeInstanceOf(Request)
 	expect(request.url).toBe(
-		'https://apps.example.com/@kody/packages/demo-app/api/health',
+		'https://kody.apps.example.com/packages/demo-app/api/health',
 	)
 	expect(request.headers.get('Host')).toBeNull()
 	expect(request.headers.get('CF-Ray')).toBeNull()

--- a/packages/worker/src/mcp/capabilities/packages/package-app-fetch.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-app-fetch.ts
@@ -1,5 +1,8 @@
 import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
-import { resolveHostedPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
+import {
+	isDnsSafeUsername,
+	resolveHostedPackageAppUrl,
+} from '@kody-internal/shared/public-urls.ts'
 import { z } from 'zod'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
@@ -409,11 +412,16 @@ export const packageAppFetchCapability = defineDomainCapability(
 				kodyId: savedPackage.kodyId,
 				restPath: restPath === '/' ? null : restPath,
 			})
+			// Mount matches how resolveHostedPackageAppUrl addressed the app:
+			// legacy usernames that cannot own a subdomain keep the path mount.
 			const packagePath: PackageAppPath = {
 				username: owner.ownerScope,
 				kodyId: savedPackage.kodyId,
 				restPath: restPathOnly,
-				mount: packageAppOrigin ? 'user-subdomain' : 'username-path',
+				mount:
+					packageAppOrigin && isDnsSafeUsername(owner.ownerScope)
+						? 'user-subdomain'
+						: 'username-path',
 			}
 
 			const requestHeaders = collectSafeRequestHeaders(args.headers)

--- a/packages/worker/src/mcp/capabilities/packages/package-app-fetch.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-app-fetch.ts
@@ -1,5 +1,5 @@
 import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
-import { buildPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
+import { resolveHostedPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
 import { z } from 'zod'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
@@ -20,8 +20,8 @@ import {
 	findPlainRepoPromotionHint,
 } from '#worker/repo/user-repos.ts'
 import {
-	parsePackageAppPath,
 	servePackageAppRequest,
+	type PackageAppPath,
 } from '#worker/package-runtime/package-app-serve.ts'
 import {
 	packageAppFetchCapabilityName,
@@ -396,20 +396,24 @@ export const packageAppFetchCapability = defineDomainCapability(
 				)
 			}
 
+			// The normalized path keeps any query string for the request URL; the
+			// package path's restPath is path-only (matching what URL parsing
+			// produced for browser requests).
 			const restPath = normalizePackageAppFetchPath(args.path)
-			const packageAppOrigin =
-				getPackageAppBaseUrl({ env: ctx.env }) ?? ctx.callerContext.baseUrl
-			const hostedUrl = buildPackageAppUrl({
-				origin: packageAppOrigin,
+			const restPathOnly = restPath.split(/[?#]/, 1)[0] || '/'
+			const packageAppOrigin = getPackageAppBaseUrl({ env: ctx.env })
+			const hostedUrl = resolveHostedPackageAppUrl({
+				packageAppBaseUrl: packageAppOrigin,
+				appBaseUrl: ctx.callerContext.baseUrl,
 				username: owner.ownerScope,
 				kodyId: savedPackage.kodyId,
-				restPath,
+				restPath: restPath === '/' ? null : restPath,
 			})
-			const packagePath = parsePackageAppPath(new URL(hostedUrl).pathname)
-			if (!packagePath) {
-				throw new McpCallerError(
-					'Could not resolve a hosted package app path for this package.',
-				)
+			const packagePath: PackageAppPath = {
+				username: owner.ownerScope,
+				kodyId: savedPackage.kodyId,
+				restPath: restPathOnly,
+				mount: packageAppOrigin ? 'user-subdomain' : 'username-path',
 			}
 
 			const requestHeaders = collectSafeRequestHeaders(args.headers)

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -183,7 +183,7 @@ test('publishExternalPush publishes HEAD and rebuilds bundle artifacts per targe
 	expect(publishedResult.status).toBe('published')
 	expect(publishedResult).toEqual(
 		expect.objectContaining({
-			hosted_app_url: 'https://packages.kody.test/@user/packages/demo-package',
+			hosted_app_url: 'https://user.packages.kody.test/packages/demo-package',
 			test_hints: {
 				app: 'package_app_fetch({ kody_id: "demo-package" })',
 				subscriptions: [
@@ -298,7 +298,7 @@ test('publishExternalPush handles already_published branches, stale dependents, 
 	expect(alreadyPublished).toEqual({
 		status: 'already_published',
 		published_commit: 'commit-old',
-		hosted_app_url: 'https://packages.kody.test/@user/packages/demo-package',
+		hosted_app_url: 'https://user.packages.kody.test/packages/demo-package',
 		static_dependents: expect.objectContaining({
 			total: 0,
 			stale: 0,

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { canonicalJsonStringify } from '@kody-internal/shared/canonical-json.ts'
-import { buildPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
+import { resolveHostedPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
@@ -352,8 +352,9 @@ async function resolvePublishedHostedAppUrl(input: {
 		email: input.ownerEmail,
 	})
 	if (!username) return null
-	return buildPackageAppUrl({
-		origin: getPackageAppBaseUrl({ env: input.env }) ?? input.baseUrl,
+	return resolveHostedPackageAppUrl({
+		packageAppBaseUrl: getPackageAppBaseUrl({ env: input.env }),
+		appBaseUrl: input.baseUrl,
 		username,
 		kodyId: input.kodyId,
 	})

--- a/packages/worker/src/mcp/tools/package-search-identity.node.test.ts
+++ b/packages/worker/src/mcp/tools/package-search-identity.node.test.ts
@@ -116,6 +116,35 @@ test('package identity parser accepts exact ids and current-origin URLs and reje
 			query: 'https://kodyapps.dev/@user/packages/daily-notes/report?tab=1',
 		}),
 	).toEqual({ kind: 'not-package-identity' })
+
+	// The canonical hosted URL is the caller's per-user subdomain, where the
+	// username lives in the hostname and the path carries only the mount.
+	expect(
+		parsePackageSearchIdentity({
+			...hosted,
+			query: 'https://user.kodyapps.dev/packages/daily-notes?tab=source#top',
+		}),
+	).toEqual({ kind: 'kody-id', value: 'daily-notes', authoritative: true })
+	expect(
+		parsePackageSearchIdentity({
+			...hosted,
+			query: 'https://user.kodyapps.dev/packages/daily-notes/report?tab=1',
+		}),
+	).toEqual({ kind: 'not-package-identity' })
+	for (const query of [
+		// Another user's subdomain, even for the same kody id.
+		'https://other.kodyapps.dev/packages/daily-notes',
+		// Nested labels are never a user subdomain.
+		'https://a.user.kodyapps.dev/packages/daily-notes',
+		// Embedded credentials stay refused on the subdomain form too.
+		'https://user:password@user.kodyapps.dev/packages/daily-notes',
+		// Wrong scheme for the configured package-app origin.
+		'http://user.kodyapps.dev/packages/daily-notes',
+	]) {
+		expect(parsePackageSearchIdentity({ ...hosted, query }), query).toEqual({
+			kind: 'invalid-package-identity',
+		})
+	}
 	// The app origin keeps working, and relative URLs still resolve against it.
 	expect(
 		parsePackageSearchIdentity({

--- a/packages/worker/src/mcp/tools/package-search-identity.ts
+++ b/packages/worker/src/mcp/tools/package-search-identity.ts
@@ -1,3 +1,4 @@
+import { buildPackageAppSubdomainOrigin } from '@kody-internal/shared/public-urls.ts'
 import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
 import { type SearchMatch } from '#mcp/tools/search-format.ts'
 import {
@@ -66,7 +67,7 @@ function parsePackageUrl(input: {
 			? { kind: 'invalid-package-identity' }
 			: { kind: 'not-package-identity' }
 	}
-	// Hosted package apps are served from their own origin in production, so the
+	// Hosted package apps are served from their own domain in production, so the
 	// URL a user copies out of the address bar is on that host, not the app host.
 	// Both are this deployment's own origins; anything else is another site's URL
 	// and must not resolve to one of this user's packages.
@@ -80,6 +81,39 @@ function parsePackageUrl(input: {
 	}
 
 	const parts = url.pathname.split('/').filter(Boolean)
+
+	// Per-user subdomain form: `https://{username}.<package-app host>/packages/{kodyId}`.
+	if (packageAppOrigin) {
+		const packageAppBase = new URL(packageAppOrigin)
+		const hostname = url.hostname.toLowerCase()
+		if (
+			hostname !== packageAppBase.hostname &&
+			hostname.endsWith(`.${packageAppBase.hostname}`)
+		) {
+			const isSubdomainPackagePath =
+				parts.length === 2 && parts[0] === 'packages'
+			if (!isSubdomainPackagePath) return { kind: 'not-package-identity' }
+			const label = hostname.slice(0, -(packageAppBase.hostname.length + 1))
+			const kodyId = safelyDecodePathSegment(parts[1] ?? '')
+			if (
+				label.includes('.') ||
+				getUsernameFormatValidationError(label) ||
+				url.origin !==
+					buildPackageAppSubdomainOrigin({
+						packageAppOrigin,
+						username: label,
+					}) ||
+				url.username.length > 0 ||
+				url.password.length > 0 ||
+				!kodyId ||
+				!kodyPackageIdPattern.test(kodyId) ||
+				label !== input.username
+			) {
+				return { kind: 'invalid-package-identity' }
+			}
+			return { kind: 'kody-id', value: kodyId, authoritative: true }
+		}
+	}
 	const isAccountPackagePath =
 		parts.length === 3 && parts[0] === 'account' && parts[1] === 'packages'
 	const isHostedPackagePath =

--- a/packages/worker/src/mcp/tools/package-search-identity.ts
+++ b/packages/worker/src/mcp/tools/package-search-identity.ts
@@ -1,4 +1,7 @@
-import { buildPackageAppSubdomainOrigin } from '@kody-internal/shared/public-urls.ts'
+import {
+	buildPackageAppSubdomainOrigin,
+	isDnsSafeUsername,
+} from '@kody-internal/shared/public-urls.ts'
 import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
 import { type SearchMatch } from '#mcp/tools/search-format.ts'
 import {
@@ -97,7 +100,7 @@ function parsePackageUrl(input: {
 			const kodyId = safelyDecodePathSegment(parts[1] ?? '')
 			if (
 				label.includes('.') ||
-				getUsernameFormatValidationError(label) ||
+				!isDnsSafeUsername(label) ||
 				url.origin !==
 					buildPackageAppSubdomainOrigin({
 						packageAppOrigin,

--- a/packages/worker/src/mcp/tools/search-detail.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-detail.node.test.ts
@@ -278,7 +278,7 @@ test('resolveEntityDetail hostedUrl uses PACKAGE_APP_BASE_URL when configured', 
 
 	expect(detail).toMatchObject({
 		type: 'package',
-		hostedUrl: 'https://kodyapps.dev/@kentcdodds/packages/demo',
+		hostedUrl: 'https://kentcdodds.kodyapps.dev/packages/demo',
 		baseUrl: 'https://heykody.dev',
 	})
 })

--- a/packages/worker/src/mcp/tools/search-detail.ts
+++ b/packages/worker/src/mcp/tools/search-detail.ts
@@ -1,4 +1,4 @@
-import { buildPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
+import { resolveHostedPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { type McpRegistrationAgent } from '#mcp/mcp-registration-agent.ts'
 import {
@@ -85,8 +85,7 @@ export async function resolveEntityDetail(input: {
 			userId: platformFallback?.ownerUserId ?? input.userId,
 			sourceId: record.sourceId,
 		})
-		const packageAppOrigin =
-			getPackageAppBaseUrl({ env }) ?? input.callerContext.baseUrl
+		const packageAppOrigin = getPackageAppBaseUrl({ env })
 		const ownerUsername = platformFallback?.platformScope ?? input.username
 		return {
 			type: 'package' as const,
@@ -101,8 +100,9 @@ export async function resolveEntityDetail(input: {
 			platformScope: platformFallback?.platformScope ?? null,
 			hostedUrl:
 				record.hasApp && ownerUsername
-					? buildPackageAppUrl({
-							origin: packageAppOrigin,
+					? resolveHostedPackageAppUrl({
+							packageAppBaseUrl: packageAppOrigin,
+							appBaseUrl: input.callerContext.baseUrl,
 							username: ownerUsername,
 							kodyId: record.kodyId,
 						})

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -423,7 +423,6 @@ export const packageSearchEntityPlugin = {
 		)
 	},
 	formatSlimMatch({ match, baseUrl, packageAppBaseUrl, username }) {
-		const hostedAppOrigin = packageAppBaseUrl ?? baseUrl
 		const rootImportUsage = buildPackageRootImportUsage(match.name)
 		const actionMatches = (match.actionMatches ?? []).map((actionMatch) => {
 			const importSpecifier = buildPackageImportSpecifier(
@@ -481,7 +480,12 @@ export const packageSearchEntityPlugin = {
 			hostedUrl: (() => {
 				const hostedUsername = match.platformScope ?? username
 				return match.hasApp && hostedUsername
-					? buildPackageHostedUrl(hostedAppOrigin, hostedUsername, match.kodyId)
+					? buildPackageHostedUrl({
+							packageAppBaseUrl: packageAppBaseUrl ?? null,
+							appBaseUrl: baseUrl,
+							username: hostedUsername,
+							kodyId: match.kodyId,
+						})
 					: null
 			})(),
 			readmeSnippet: match.readmeSnippet

--- a/packages/worker/src/mcp/tools/search-format-helpers.ts
+++ b/packages/worker/src/mcp/tools/search-format-helpers.ts
@@ -3,18 +3,19 @@ import { McpCallerError } from '#mcp/caller-error.ts'
 import { buildKodyCapabilityAccessor } from '#mcp/kody-capability-accessors.ts'
 import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
 import { type PackageJobSchedule } from '#worker/package-registry/types.ts'
-import { buildPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
+import { resolveHostedPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
 
 import { type SearchEntityType } from './search-format-types.ts'
 
 export { buildKodyCapabilityAccessor } from '#mcp/kody-capability-accessors.ts'
 
-export function buildPackageHostedUrl(
-	baseUrl: string,
-	username: string,
-	kodyId: string,
-) {
-	return buildPackageAppUrl({ origin: baseUrl, username, kodyId })
+export function buildPackageHostedUrl(input: {
+	packageAppBaseUrl: string | null
+	appBaseUrl: string
+	username: string
+	kodyId: string
+}) {
+	return resolveHostedPackageAppUrl(input)
 }
 
 export function buildEntityRef(id: string, type: SearchEntityType) {

--- a/packages/worker/src/package-runtime/package-app-serve.ts
+++ b/packages/worker/src/package-runtime/package-app-serve.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/cloudflare'
 import { html } from 'remix/html-template'
 import { createHtmlResponse } from 'remix/response/html'
+import { type PackageAppMount } from '@kody-internal/shared/public-urls.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
 import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
@@ -29,7 +30,16 @@ export type PackageAppServeOwner = {
 	displayName: string
 }
 
-export function parsePackageAppPath(pathname: string) {
+export { type PackageAppMount }
+
+export type PackageAppPath = {
+	username: string
+	kodyId: string
+	restPath: string
+	mount: PackageAppMount
+}
+
+export function parsePackageAppPath(pathname: string): PackageAppPath | null {
 	const parts = pathname.split('/').filter(Boolean)
 	const rawUsername = parts[0]?.startsWith('@') ? parts[0].slice(1) : ''
 	if (!rawUsername || parts[1] !== 'packages') return null
@@ -48,14 +58,40 @@ export function parsePackageAppPath(pathname: string) {
 		username,
 		kodyId,
 		restPath: parts.length > 3 ? `/${parts.slice(3).join('/')}` : '/',
+		mount: 'username-path',
+	}
+}
+
+/**
+ * Parse the path shape served on a per-user package-app subdomain, where the
+ * username comes from the hostname and the path is `/packages/{kodyId}/{rest}`.
+ * The caller must already have validated the subdomain's username label.
+ */
+export function parsePackageAppSubdomainPath(input: {
+	pathname: string
+	username: string
+}): PackageAppPath | null {
+	const parts = input.pathname.split('/').filter(Boolean)
+	if (parts[0] !== 'packages') return null
+	const rawKodyId = parts[1]?.trim()
+	if (!rawKodyId) return null
+	let kodyId: string
+	try {
+		kodyId = decodeURIComponent(rawKodyId)
+	} catch {
+		return null
+	}
+	return {
+		username: input.username,
+		kodyId,
+		restPath: parts.length > 2 ? `/${parts.slice(2).join('/')}` : '/',
+		mount: 'user-subdomain',
 	}
 }
 
 export function isPackageAppRequestPath(pathname: string) {
 	return parsePackageAppPath(pathname) !== null
 }
-
-export type PackageAppPath = NonNullable<ReturnType<typeof parsePackageAppPath>>
 
 // Credentials that must never reach author-supplied package code. `Cookie`
 // carries the owner's `kody_session`, `Authorization` carries MCP bearer tokens,
@@ -418,6 +454,7 @@ export async function servePackageAppRequest(input: {
 				callerContext,
 				servingUsername: packagePath.username,
 				hostedOrigin: requestUrl.origin,
+				mount: packagePath.mount,
 			},
 		})
 		entrypoint = appWorker.stub.getEntrypoint(appWorker.entrypointName)

--- a/packages/worker/src/package-runtime/package-app-synthetic.ts
+++ b/packages/worker/src/package-runtime/package-app-synthetic.ts
@@ -23,5 +23,5 @@ export function buildPackageAppNotFoundMessage() {
 }
 
 export function buildUnmatchedPackageAppOriginPathMessage() {
-	return `Package app URL not found. Package app URLs use /@username/packages/<kody-id>/<path>. Requests outside a package app mount are not dispatched to any app. To exercise a declared package app fetch handler over MCP, use ${packageAppFetchCapabilityName} instead.`
+	return `Package app URL not found. Hosted package apps are served from https://<username>.<package-app-domain>/packages/<kody-id>/<path> (legacy /@username/packages/<kody-id> URLs on the bare package-app domain redirect there). Requests outside a package app mount are not dispatched to any app. To exercise a declared package app fetch handler over MCP, use ${packageAppFetchCapabilityName} instead.`
 }

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -68,7 +68,9 @@ import {
 } from '#worker/run-records/types.ts'
 import {
 	buildPackageAppPath,
-	buildPackageAppUrl,
+	buildPackageAppSubdomainPath,
+	resolveHostedPackageAppUrl,
+	type PackageAppMount,
 } from '@kody-internal/shared/public-urls.ts'
 import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
 import {
@@ -1498,23 +1500,39 @@ function buildPackageAppPublicContext(input: {
 	runtime: {
 		servingUsername?: string
 		hostedOrigin?: string
+		mount?: PackageAppMount
 	}
 }) {
 	const username =
 		input.runtime.servingUsername ??
 		getUsernameFromPackageName(input.savedPackage.name)
-	const origin =
-		input.runtime.hostedOrigin ??
-		getPackageAppBaseUrl({ env: input.env }) ??
-		input.baseUrl
-	const publicUrlInput = {
-		origin,
-		username,
-		kodyId: input.savedPackage.kodyId,
+	const { kodyId } = input.savedPackage
+	if (input.runtime.hostedOrigin) {
+		// Request-scoped: the mount the request actually arrived on. On a
+		// per-user subdomain the username lives in the hostname, so the app is
+		// mounted at `/packages/{kodyId}`; inline serving keeps the
+		// `/@{username}` path prefix.
+		const appBasePath =
+			input.runtime.mount === 'user-subdomain'
+				? buildPackageAppSubdomainPath({ kodyId })
+				: buildPackageAppPath({ username, kodyId })
+		return {
+			appBasePath,
+			hostedUrl: `${input.runtime.hostedOrigin.replace(/\/+$/, '')}${appBasePath}`,
+		}
 	}
+	// Background/synthetic callers get the canonical hosted URL: the per-user
+	// subdomain when a package-app origin is configured, the inline path-based
+	// mount otherwise.
+	const hostedUrl = resolveHostedPackageAppUrl({
+		packageAppBaseUrl: getPackageAppBaseUrl({ env: input.env }),
+		appBaseUrl: input.baseUrl,
+		username,
+		kodyId,
+	})
 	return {
-		appBasePath: buildPackageAppPath(publicUrlInput),
-		hostedUrl: buildPackageAppUrl(publicUrlInput),
+		appBasePath: new URL(hostedUrl).pathname,
+		hostedUrl,
 	}
 }
 
@@ -1698,6 +1716,7 @@ async function buildPackageAppWorkerOptionsUncached(input: {
 		callerContext: ReturnType<typeof createMcpCallerContext>
 		servingUsername?: string
 		hostedOrigin?: string
+		mount?: PackageAppMount
 	}
 }): Promise<PackageAppWorkerOptions> {
 	const publicContext = buildPackageAppPublicContext(input)
@@ -1809,6 +1828,7 @@ export async function buildPackageAppWorker(input: {
 		callerContext: ReturnType<typeof createMcpCallerContext>
 		servingUsername?: string
 		hostedOrigin?: string
+		mount?: PackageAppMount
 	}
 }) {
 	const publicContext = buildPackageAppPublicContext(input)

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -3,6 +3,7 @@ import {
 	ensureArtifactsAccountEventSubscription,
 	ensureCloudflareQueue,
 	ensureEmailSendingEventSubscription,
+	ensurePackageAppWildcardDnsRecord,
 	ensureR2Bucket,
 	fail,
 	isValidBareHostname,
@@ -53,6 +54,7 @@ type ResolvedProductionBindings = {
 	webhookDispatchQueueName: string
 	webhookDispatchDeadLetterQueueName: string
 	committedUserEmailDomain: string | null
+	packageAppHostname: string | null
 }
 
 function parseArgs(argv: Array<string>): {
@@ -458,6 +460,29 @@ async function resolveProductionBindings({
 			? committedUserEmailDomainRaw.trim().toLowerCase().replace(/\.$/, '')
 			: null
 
+	const packageAppBaseUrlRaw =
+		productionVars && typeof productionVars === 'object'
+			? (productionVars as Record<string, unknown>).PACKAGE_APP_BASE_URL
+			: undefined
+	let packageAppHostname: string | null = null
+	if (
+		typeof packageAppBaseUrlRaw === 'string' &&
+		packageAppBaseUrlRaw.trim().length > 0
+	) {
+		try {
+			packageAppHostname = new URL(packageAppBaseUrlRaw.trim()).hostname
+		} catch {
+			fail(
+				`wrangler config "${wranglerConfigPath}" has an invalid "env.production.vars.PACKAGE_APP_BASE_URL": ${packageAppBaseUrlRaw}`,
+			)
+		}
+		if (!packageAppHostname) {
+			fail(
+				`wrangler config "${wranglerConfigPath}" has "env.production.vars.PACKAGE_APP_BASE_URL" without a hostname: ${packageAppBaseUrlRaw}`,
+			)
+		}
+	}
+
 	const resolved: ResolvedProductionBindings = {
 		workerName,
 		d1DatabaseName,
@@ -471,6 +496,7 @@ async function resolveProductionBindings({
 		communityAssetsBucketName,
 		emailBlobsBucketName,
 		committedUserEmailDomain,
+		packageAppHostname,
 		...queueResources,
 	}
 
@@ -627,6 +653,15 @@ async function ensureProductionResources(options: CliOptions) {
 			queueId: artifactsRepoEventsQueue.id,
 			dryRun: options.dryRun,
 		})
+
+	if (bindings.packageAppHostname) {
+		await ensurePackageAppWildcardDnsRecord({
+			accountId: accountId ?? 'dry-run-account',
+			apiToken: apiToken ?? 'dry-run-token',
+			packageAppHostname: bindings.packageAppHostname,
+			dryRun: options.dryRun,
+		})
+	}
 
 	const generatedConfigPath = await writeGeneratedWranglerConfig({
 		baseConfigPath: options.wranglerConfigPath,

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -930,6 +930,13 @@ test('ensurePackageAppWildcardDnsRecord creates a proxied wildcard AAAA record',
 		'https://api.cloudflare.com/client/v4/zones?name=kodyapps.dev&account.id=account-1&status=active',
 		expect.objectContaining({ method: 'GET' }),
 	)
+	// The list query is name-only on purpose: a type filter would hide
+	// conflicting A/CNAME records at the wildcard name.
+	expect(fetcher).toHaveBeenNthCalledWith(
+		2,
+		`https://api.cloudflare.com/client/v4/zones/zone-kodyapps/dns_records?name=${encodeURIComponent('*.kodyapps.dev')}`,
+		expect.objectContaining({ method: 'GET' }),
+	)
 	expect(fetcher).toHaveBeenNthCalledWith(
 		3,
 		'https://api.cloudflare.com/client/v4/zones/zone-kodyapps/dns_records',
@@ -944,6 +951,50 @@ test('ensurePackageAppWildcardDnsRecord creates a proxied wildcard AAAA record',
 			}),
 		}),
 	)
+})
+
+test('ensurePackageAppWildcardDnsRecord fails on a conflicting record of another type', async () => {
+	consoleError.mockImplementation(() => {})
+	const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+		throw new Error('process.exit called')
+	}) as never)
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [{ id: 'zone-kodyapps', name: 'kodyapps.dev' }],
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{
+						id: 'dns-conflicting',
+						type: 'CNAME',
+						name: '*.kodyapps.dev',
+						content: 'somewhere-else.example',
+						proxied: false,
+					},
+				],
+			}),
+		)
+
+	await expect(
+		ensurePackageAppWildcardDnsRecord({
+			accountId: 'account-1',
+			apiToken: 'token-1',
+			packageAppHostname: 'kodyapps.dev',
+			dryRun: false,
+			fetcher,
+		}),
+	).rejects.toThrow('process.exit called')
+	expect(consoleError).toHaveBeenCalledWith(
+		expect.stringContaining('found CNAME somewhere-else.example'),
+	)
+	expect(fetcher).toHaveBeenCalledTimes(2)
+	exit.mockRestore()
 })
 
 test('ensurePackageAppWildcardDnsRecord reuses an existing proxied wildcard record', async () => {

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -997,6 +997,56 @@ test('ensurePackageAppWildcardDnsRecord fails on a conflicting record of another
 	exit.mockRestore()
 })
 
+test('ensurePackageAppWildcardDnsRecord fails on a conflict even when the required record exists', async () => {
+	consoleError.mockImplementation(() => {})
+	const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+		throw new Error('process.exit called')
+	}) as never)
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [{ id: 'zone-kodyapps', name: 'kodyapps.dev' }],
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{
+						id: 'dns-required',
+						type: 'AAAA',
+						name: '*.kodyapps.dev',
+						content: '100::',
+						proxied: true,
+					},
+					{
+						id: 'dns-stray',
+						type: 'A',
+						name: '*.kodyapps.dev',
+						content: '192.0.2.1',
+						proxied: false,
+					},
+				],
+			}),
+		)
+
+	await expect(
+		ensurePackageAppWildcardDnsRecord({
+			accountId: 'account-1',
+			apiToken: 'token-1',
+			packageAppHostname: 'kodyapps.dev',
+			dryRun: false,
+			fetcher,
+		}),
+	).rejects.toThrow('process.exit called')
+	expect(consoleError).toHaveBeenCalledWith(
+		expect.stringContaining('found A 192.0.2.1'),
+	)
+	exit.mockRestore()
+})
+
 test('ensurePackageAppWildcardDnsRecord reuses an existing proxied wildcard record', async () => {
 	consoleError.mockImplementation(() => {})
 	const fetcher = vi

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -12,6 +12,7 @@ import {
 	ensureArtifactsAccountEventSubscription,
 	ensureCloudflareQueue,
 	ensureEmailSendingEventSubscription,
+	ensurePackageAppWildcardDnsRecord,
 	isR2BucketAlreadyExistsOutput,
 	isRetryableCloudflareApiError,
 	isWranglerNotFoundOutput,
@@ -80,7 +81,11 @@ test('writeGeneratedWranglerConfig preserves migrations and copies environment a
 						migrations_dir: string
 					}>
 					r2_buckets?: Array<{ binding: string; bucket_name: string }>
-					routes?: Array<{ pattern: string; custom_domain?: boolean }>
+					routes?: Array<{
+						pattern: string
+						custom_domain?: boolean
+						zone_name?: string
+					}>
 					workers_dev?: boolean
 					vars?: Record<string, unknown>
 				}
@@ -135,11 +140,16 @@ test('writeGeneratedWranglerConfig preserves migrations and copies environment a
 		const packageAppBaseUrl =
 			productionConfig.env?.production?.vars?.PACKAGE_APP_BASE_URL
 		expect(typeof packageAppBaseUrl).toBe('string')
+		const packageAppHostname = new URL(String(packageAppBaseUrl)).hostname
 		expect(productionConfig.env?.production?.routes).toEqual([
 			{ pattern: 'heykody.dev', custom_domain: true },
 			{
-				pattern: new URL(String(packageAppBaseUrl)).hostname,
+				pattern: packageAppHostname,
 				custom_domain: true,
+			},
+			{
+				pattern: `*.${packageAppHostname}/*`,
+				zone_name: packageAppHostname,
 			},
 		])
 		// Publishing routes otherwise drops the workers.dev trigger.
@@ -187,7 +197,11 @@ test('writeGeneratedWranglerConfig preserves migrations and copies environment a
 							dead_letter_queue: string
 						}>
 					}
-					routes?: Array<{ pattern: string; custom_domain?: boolean }>
+					routes?: Array<{
+						pattern: string
+						custom_domain?: boolean
+						zone_name?: string
+					}>
 				}
 			}
 		}>(await readFile(previewOutPath, 'utf8'))
@@ -301,18 +315,27 @@ test('writeGeneratedWranglerConfig keeps legacy app hosts attached during a doma
 		const config = parseJsonc<{
 			env?: {
 				production?: {
-					routes?: Array<{ pattern: string; custom_domain?: boolean }>
+					routes?: Array<{
+						pattern: string
+						custom_domain?: boolean
+						zone_name?: string
+					}>
 					vars?: Record<string, unknown>
 				}
 			}
 		}>(await readFile(outPath, 'utf8'))
 		const packageAppBaseUrl = config.env?.production?.vars?.PACKAGE_APP_BASE_URL
+		const packageAppHostname = new URL(String(packageAppBaseUrl)).hostname
 		expect(config.env?.production?.routes).toEqual([
 			{ pattern: 'heykody.app', custom_domain: true },
 			{ pattern: 'heykody.dev', custom_domain: true },
 			{
-				pattern: new URL(String(packageAppBaseUrl)).hostname,
+				pattern: packageAppHostname,
 				custom_domain: true,
+			},
+			{
+				pattern: `*.${packageAppHostname}/*`,
+				zone_name: packageAppHostname,
 			},
 		])
 
@@ -863,6 +886,100 @@ test('ensureArtifactsAccountEventSubscription creates account-level lifecycle su
 			}),
 		}),
 	)
+})
+
+test('ensurePackageAppWildcardDnsRecord creates a proxied wildcard AAAA record', async () => {
+	consoleError.mockImplementation(() => {})
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [{ id: 'zone-kodyapps', name: 'kodyapps.dev' }],
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [],
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: {
+					id: 'dns-wildcard',
+					type: 'AAAA',
+					name: '*.kodyapps.dev',
+					content: '100::',
+					proxied: true,
+				},
+			}),
+		)
+
+	await ensurePackageAppWildcardDnsRecord({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		packageAppHostname: 'kodyapps.dev',
+		dryRun: false,
+		fetcher,
+	})
+
+	expect(fetcher).toHaveBeenNthCalledWith(
+		1,
+		'https://api.cloudflare.com/client/v4/zones?name=kodyapps.dev&account.id=account-1&status=active',
+		expect.objectContaining({ method: 'GET' }),
+	)
+	expect(fetcher).toHaveBeenNthCalledWith(
+		3,
+		'https://api.cloudflare.com/client/v4/zones/zone-kodyapps/dns_records',
+		expect.objectContaining({
+			method: 'POST',
+			body: JSON.stringify({
+				type: 'AAAA',
+				name: '*.kodyapps.dev',
+				content: '100::',
+				proxied: true,
+				ttl: 1,
+			}),
+		}),
+	)
+})
+
+test('ensurePackageAppWildcardDnsRecord reuses an existing proxied wildcard record', async () => {
+	consoleError.mockImplementation(() => {})
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [{ id: 'zone-kodyapps', name: 'kodyapps.dev' }],
+			}),
+		)
+		.mockResolvedValueOnce(
+			Response.json({
+				success: true,
+				result: [
+					{
+						id: 'dns-existing',
+						type: 'AAAA',
+						name: '*.kodyapps.dev',
+						content: '100::',
+						proxied: true,
+					},
+				],
+			}),
+		)
+
+	await ensurePackageAppWildcardDnsRecord({
+		accountId: 'account-1',
+		apiToken: 'token-1',
+		packageAppHostname: 'kodyapps.dev',
+		dryRun: false,
+		fetcher,
+	})
+
+	expect(fetcher).toHaveBeenCalledTimes(2)
 })
 
 test('writeGeneratedWranglerConfig rejects invalid environment asset config', async () => {

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { parse as parsePublicSuffix } from 'tldts'
 import { resolveLocalBinary } from '../node-runtime.ts'
 
 type WranglerEnvName = 'preview' | 'production'
@@ -377,6 +378,237 @@ export async function cloudflareApiRequest<T>(
 		}
 	}
 	throw lastError
+}
+
+type CloudflareRootApiRequestInput = {
+	apiToken: string
+	pathname: string
+	method?: 'GET' | 'POST' | 'PATCH' | 'DELETE'
+	body?: Record<string, unknown>
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+	maxAttempts?: number
+}
+
+async function cloudflareRootApiRequestOnce<T>(
+	input: CloudflareRootApiRequestInput,
+) {
+	const baseUrl = input.apiBaseUrl ?? 'https://api.cloudflare.com/client/v4'
+	const url = `${baseUrl.replace(/\/$/, '')}${input.pathname}`
+	const abortController = new AbortController()
+	const timeout = setTimeout(() => abortController.abort(), 30_000)
+	try {
+		const response = await (input.fetcher ?? fetch)(url, {
+			method: input.method ?? 'GET',
+			headers: {
+				Authorization: `Bearer ${input.apiToken}`,
+				Accept: 'application/json',
+				...(input.body ? { 'Content-Type': 'application/json' } : {}),
+			},
+			...(input.body ? { body: JSON.stringify(input.body) } : {}),
+			signal: abortController.signal,
+		})
+		const text = await response.text()
+		const preview = text.trim().slice(0, 200) || '(empty body)'
+		let parsed: unknown
+		try {
+			parsed = JSON.parse(text)
+		} catch {
+			throw new Error(
+				`Malformed Cloudflare response (${response.status}) for ${input.pathname}: ${preview}`,
+			)
+		}
+		if (
+			parsed === null ||
+			typeof parsed !== 'object' ||
+			Array.isArray(parsed)
+		) {
+			throw new Error(
+				`Malformed Cloudflare response (${response.status}) for ${input.pathname}: ${preview}`,
+			)
+		}
+		const payload = parsed as CloudflareApiEnvelope<T>
+		if (
+			!response.ok ||
+			payload.success !== true ||
+			payload.result === undefined
+		) {
+			const error = payload.errors?.[0]
+			throw new Error(
+				`Cloudflare API request failed (${response.status}): ${error?.message ?? error?.code ?? input.pathname}`,
+			)
+		}
+		return payload
+	} finally {
+		clearTimeout(timeout)
+	}
+}
+
+async function cloudflareRootApiRequest<T>(input: CloudflareRootApiRequestInput) {
+	const maxAttempts = input.maxAttempts ?? cloudflareApiRetryMaxAttempts
+	const wait = input.sleep ?? sleep
+	let lastError: unknown
+	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+		try {
+			return await cloudflareRootApiRequestOnce<T>(input)
+		} catch (error) {
+			lastError = error
+			if (!isRetryableCloudflareApiError(error) || attempt === maxAttempts) {
+				throw error
+			}
+			console.error(
+				`Retrying Cloudflare API ${input.method ?? 'GET'} ${input.pathname} (attempt ${attempt + 1}/${maxAttempts})`,
+			)
+			await wait(cloudflareApiRetryBaseDelayMs * 2 ** (attempt - 1))
+		}
+	}
+	throw lastError
+}
+
+type CloudflareZoneSummary = {
+	id: string
+	name: string
+}
+
+type CloudflareDnsRecord = {
+	id: string
+	type: string
+	name: string
+	content: string
+	proxied?: boolean
+}
+
+const packageAppWildcardDnsContent = '100::'
+
+export function readPackageAppZoneName(packageAppHostname: string) {
+	const parsed = parsePublicSuffix(packageAppHostname)
+	return parsed.domain ?? null
+}
+
+export function packageAppWildcardRoutePattern(packageAppHostname: string) {
+	return `*.${packageAppHostname}/*`
+}
+
+export function packageAppWildcardDnsRecordName(packageAppHostname: string) {
+	return `*.${packageAppHostname}`
+}
+
+async function lookupCloudflareZoneId(input: {
+	accountId: string
+	apiToken: string
+	zoneName: string
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+}) {
+	const payload = await cloudflareRootApiRequest<Array<CloudflareZoneSummary>>({
+		apiToken: input.apiToken,
+		apiBaseUrl: input.apiBaseUrl,
+		fetcher: input.fetcher,
+		sleep: input.sleep,
+		pathname: `/zones?name=${encodeURIComponent(input.zoneName)}&account.id=${encodeURIComponent(input.accountId)}&status=active`,
+	})
+	const zones = payload.result ?? []
+	const zone = zones.find((entry) => entry.name === input.zoneName)
+	return zone?.id ?? null
+}
+
+function isPackageAppWildcardDnsRecord(input: {
+	record: CloudflareDnsRecord
+	wildcardRecordName: string
+}) {
+	return (
+		input.record.type === 'AAAA' &&
+		input.record.name === input.wildcardRecordName &&
+		input.record.content === packageAppWildcardDnsContent &&
+		input.record.proxied === true
+	)
+}
+
+export async function ensurePackageAppWildcardDnsRecord(input: {
+	accountId: string
+	apiToken: string
+	packageAppHostname: string
+	dryRun: boolean
+	apiBaseUrl?: string
+	fetcher?: typeof fetch
+	sleep?: (ms: number) => Promise<void>
+}) {
+	const zoneName = readPackageAppZoneName(input.packageAppHostname)
+	if (!zoneName) {
+		return fail(
+			`Could not derive a registrable zone name from PACKAGE_APP_BASE_URL host "${input.packageAppHostname}". Use a hostname on a public suffix (for example kodyapps.dev).`,
+		)
+	}
+	const wildcardRecordName = packageAppWildcardDnsRecordName(
+		input.packageAppHostname,
+	)
+	if (input.dryRun) {
+		console.error(
+			`[dry-run] ensure package-app wildcard DNS: ${wildcardRecordName} AAAA ${packageAppWildcardDnsContent} (proxied) in zone ${zoneName}`,
+		)
+		return
+	}
+
+	const zoneId = await lookupCloudflareZoneId({
+		accountId: input.accountId,
+		apiToken: input.apiToken,
+		zoneName,
+		apiBaseUrl: input.apiBaseUrl,
+		fetcher: input.fetcher,
+		sleep: input.sleep,
+	})
+	if (!zoneId) {
+		return fail(
+			`Package-app zone "${zoneName}" was not found in Cloudflare account ${input.accountId}. Create the zone, add a proxied wildcard DNS record (${wildcardRecordName} AAAA ${packageAppWildcardDnsContent}), then re-run deploy. See docs/contributing/setup-manifest.md.`,
+		)
+	}
+
+	const listed = await cloudflareRootApiRequest<Array<CloudflareDnsRecord>>({
+		apiToken: input.apiToken,
+		apiBaseUrl: input.apiBaseUrl,
+		fetcher: input.fetcher,
+		sleep: input.sleep,
+		pathname: `/zones/${encodeURIComponent(zoneId)}/dns_records?name=${encodeURIComponent(wildcardRecordName)}&type=AAAA`,
+	})
+	const existing = (listed.result ?? []).find((record) =>
+		isPackageAppWildcardDnsRecord({ record, wildcardRecordName }),
+	)
+	if (existing) {
+		console.error(
+			`Package-app wildcard DNS exists: ${existing.name} (${existing.id})`,
+		)
+		return
+	}
+
+	const conflicting = (listed.result ?? []).find(
+		(record) => record.name === wildcardRecordName,
+	)
+	if (conflicting) {
+		return fail(
+			`Package-app wildcard DNS record "${wildcardRecordName}" exists in zone "${zoneName}" but is not a proxied AAAA ${packageAppWildcardDnsContent} record (found ${conflicting.type} ${conflicting.content}, proxied=${String(conflicting.proxied)}). Fix it in the Cloudflare dashboard, then re-run deploy.`,
+		)
+	}
+
+	const created = await cloudflareRootApiRequest<CloudflareDnsRecord>({
+		apiToken: input.apiToken,
+		apiBaseUrl: input.apiBaseUrl,
+		fetcher: input.fetcher,
+		sleep: input.sleep,
+		pathname: `/zones/${encodeURIComponent(zoneId)}/dns_records`,
+		method: 'POST',
+		body: {
+			type: 'AAAA',
+			name: wildcardRecordName,
+			content: packageAppWildcardDnsContent,
+			proxied: true,
+			ttl: 1,
+		},
+	})
+	console.error(
+		`Created package-app wildcard DNS: ${created.result?.name} (${created.result?.id})`,
+	)
 }
 
 export async function listCloudflareQueues(input: {
@@ -1022,17 +1254,24 @@ function readLegacyHostsVar(input: {
 }
 
 /**
- * Publish the Worker's Cloudflare custom domains, derived from the environment's
+ * Publish the Worker's Cloudflare routes, derived from the environment's
  * `APP_BASE_URL`, `APP_LEGACY_HOSTS`, and `PACKAGE_APP_BASE_URL`.
  *
- * **`routes` is the complete custom-domain set for the script, not an addition to
- * it.** A deploy that lists only the package-app domain detaches the app origin
- * and deletes its DNS record, which takes production down. So the app origin is
+ * **`routes` is the complete route set for the script, not an addition to it.**
+ * A deploy that lists only the package-app domain detaches the app origin and
+ * deletes its DNS record, which takes production down. So the app origin is
  * always listed alongside the package-app origin, and a package-app origin
  * without an app origin fails the deploy instead of publishing a partial set.
  * For the same reason a domain migration must list the previous app origin in
  * `APP_LEGACY_HOSTS` when `APP_BASE_URL` moves to the new domain — otherwise
  * the first deploy after the flip detaches the old origin and deletes its DNS.
+ *
+ * Per-user hosted package apps use `{username}.<package-app-domain>` subdomains.
+ * Cloudflare **custom domains** cannot be wildcards, so the apex
+ * (`PACKAGE_APP_BASE_URL`) stays a `custom_domain` route for legacy redirects,
+ * while `*.<package-app-host>/*` is published as a **zone route** (`zone_name`
+ * is the registrable domain). Zone routes do not create DNS records — production
+ * CI ensures a proxied wildcard AAAA `100::` record exists separately.
  *
  * The routes are generated instead of committed because Wrangler resolves **local
  * dev** request URLs against the first configured route: a committed
@@ -1084,10 +1323,17 @@ function addPackageAppCustomDomainRoute(input: {
 		)
 	}
 
+	const packageAppZoneName = readPackageAppZoneName(packageAppHostname)
+	if (!packageAppZoneName) {
+		return fail(
+			`wrangler config "${input.baseConfigPath}" has "env.${input.envName}.vars.PACKAGE_APP_BASE_URL" host "${packageAppHostname}" without a registrable zone name. Use a hostname on a public suffix (for example kodyapps.dev).`,
+		)
+	}
+
 	const existingRoutes = Array.isArray(input.targetEnv.routes)
 		? (input.targetEnv.routes as Array<unknown>)
 		: []
-	const routedHostnames = new Set(
+	const existingRoutePatterns = new Set(
 		existingRoutes.flatMap((route) => {
 			if (!route || typeof route !== 'object') return []
 			const pattern = (route as Record<string, unknown>).pattern
@@ -1095,12 +1341,20 @@ function addPackageAppCustomDomainRoute(input: {
 		}),
 	)
 
-	input.targetEnv.routes = [
-		...existingRoutes,
+	const wildcardRoutePattern = packageAppWildcardRoutePattern(packageAppHostname)
+	const newRoutes: Array<Record<string, unknown>> = [
 		...[appHostname, ...legacyHostnames, packageAppHostname]
-			.filter((hostname) => !routedHostnames.has(hostname))
+			.filter((hostname) => !existingRoutePatterns.has(hostname))
 			.map((pattern) => ({ pattern, custom_domain: true })),
 	]
+	if (!existingRoutePatterns.has(wildcardRoutePattern)) {
+		newRoutes.push({
+			pattern: wildcardRoutePattern,
+			zone_name: packageAppZoneName,
+		})
+	}
+
+	input.targetEnv.routes = [...existingRoutes, ...newRoutes]
 	// Publishing routes flips `workers_dev` to false, which removed the
 	// `<name>.<subdomain>.workers.dev` trigger the deploy previously kept as a
 	// backup access path (and that MCP clients may be pointed at). Ask for it
@@ -1110,7 +1364,7 @@ function addPackageAppCustomDomainRoute(input: {
 		? `, ${legacyHostnames.join(', ')} (APP_LEGACY_HOSTS)`
 		: ''
 	console.error(
-		`Custom domain routes: ${appHostname} (APP_BASE_URL)${legacyNote}, ${packageAppHostname} (PACKAGE_APP_BASE_URL); workers.dev trigger kept`,
+		`Worker routes: ${appHostname} (APP_BASE_URL)${legacyNote}, ${packageAppHostname} (PACKAGE_APP_BASE_URL custom domain), ${wildcardRoutePattern} (zone ${packageAppZoneName}); workers.dev trigger kept`,
 	)
 }
 

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -445,7 +445,9 @@ async function cloudflareRootApiRequestOnce<T>(
 	}
 }
 
-async function cloudflareRootApiRequest<T>(input: CloudflareRootApiRequestInput) {
+async function cloudflareRootApiRequest<T>(
+	input: CloudflareRootApiRequestInput,
+) {
 	const maxAttempts = input.maxAttempts ?? cloudflareApiRetryMaxAttempts
 	const wait = input.sleep ?? sleep
 	let lastError: unknown
@@ -1341,12 +1343,15 @@ function addPackageAppCustomDomainRoute(input: {
 		}),
 	)
 
-	const wildcardRoutePattern = packageAppWildcardRoutePattern(packageAppHostname)
+	const wildcardRoutePattern =
+		packageAppWildcardRoutePattern(packageAppHostname)
 	const newRoutes: Array<Record<string, unknown>> = [
-		...[appHostname, ...legacyHostnames, packageAppHostname]
-			.filter((hostname) => !existingRoutePatterns.has(hostname))
-			.map((pattern) => ({ pattern, custom_domain: true })),
+		appHostname,
+		...legacyHostnames,
+		packageAppHostname,
 	]
+		.filter((hostname) => !existingRoutePatterns.has(hostname))
+		.map((pattern) => ({ pattern, custom_domain: true }))
 	if (!existingRoutePatterns.has(wildcardRoutePattern)) {
 		newRoutes.push({
 			pattern: wildcardRoutePattern,

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -567,12 +567,15 @@ export async function ensurePackageAppWildcardDnsRecord(input: {
 		)
 	}
 
+	// List every record type at the wildcard name: filtering to AAAA would hide
+	// a conflicting A or CNAME record and turn the actionable conflict error
+	// below into an opaque create failure.
 	const listed = await cloudflareRootApiRequest<Array<CloudflareDnsRecord>>({
 		apiToken: input.apiToken,
 		apiBaseUrl: input.apiBaseUrl,
 		fetcher: input.fetcher,
 		sleep: input.sleep,
-		pathname: `/zones/${encodeURIComponent(zoneId)}/dns_records?name=${encodeURIComponent(wildcardRecordName)}&type=AAAA`,
+		pathname: `/zones/${encodeURIComponent(zoneId)}/dns_records?name=${encodeURIComponent(wildcardRecordName)}`,
 	})
 	const existing = (listed.result ?? []).find((record) =>
 		isPackageAppWildcardDnsRecord({ record, wildcardRecordName }),

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -448,7 +448,13 @@ async function cloudflareRootApiRequestOnce<T>(
 async function cloudflareRootApiRequest<T>(
 	input: CloudflareRootApiRequestInput,
 ) {
-	const maxAttempts = input.maxAttempts ?? cloudflareApiRetryMaxAttempts
+	// Non-idempotent methods are never retried automatically: a create whose
+	// response was lost may have succeeded, and repeating it fails on the
+	// duplicate instead of converging. Callers are ensure-style, so the next
+	// deploy run reconciles an ambiguous outcome.
+	const method = input.method ?? 'GET'
+	const maxAttempts =
+		method === 'GET' ? (input.maxAttempts ?? cloudflareApiRetryMaxAttempts) : 1
 	const wait = input.sleep ?? sleep
 	let lastError: unknown
 	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -460,7 +466,7 @@ async function cloudflareRootApiRequest<T>(
 				throw error
 			}
 			console.error(
-				`Retrying Cloudflare API ${input.method ?? 'GET'} ${input.pathname} (attempt ${attempt + 1}/${maxAttempts})`,
+				`Retrying Cloudflare API ${method} ${input.pathname} (attempt ${attempt + 1}/${maxAttempts})`,
 			)
 			await wait(cloudflareApiRetryBaseDelayMs * 2 ** (attempt - 1))
 		}
@@ -577,6 +583,20 @@ export async function ensurePackageAppWildcardDnsRecord(input: {
 		sleep: input.sleep,
 		pathname: `/zones/${encodeURIComponent(zoneId)}/dns_records?name=${encodeURIComponent(wildcardRecordName)}`,
 	})
+	// Conflicts are checked before accepting the required record: a stray A,
+	// CNAME, or extra AAAA at the wildcard name must fail the deploy even when
+	// the proxied AAAA also exists, otherwise resolution stays ambiguous.
+	const conflicting = (listed.result ?? []).find(
+		(record) =>
+			record.name === wildcardRecordName &&
+			!isPackageAppWildcardDnsRecord({ record, wildcardRecordName }),
+	)
+	if (conflicting) {
+		return fail(
+			`Package-app wildcard DNS record "${wildcardRecordName}" exists in zone "${zoneName}" but is not a proxied AAAA ${packageAppWildcardDnsContent} record (found ${conflicting.type} ${conflicting.content}, proxied=${String(conflicting.proxied)}). Fix it in the Cloudflare dashboard, then re-run deploy.`,
+		)
+	}
+
 	const existing = (listed.result ?? []).find((record) =>
 		isPackageAppWildcardDnsRecord({ record, wildcardRecordName }),
 	)
@@ -585,15 +605,6 @@ export async function ensurePackageAppWildcardDnsRecord(input: {
 			`Package-app wildcard DNS exists: ${existing.name} (${existing.id})`,
 		)
 		return
-	}
-
-	const conflicting = (listed.result ?? []).find(
-		(record) => record.name === wildcardRecordName,
-	)
-	if (conflicting) {
-		return fail(
-			`Package-app wildcard DNS record "${wildcardRecordName}" exists in zone "${zoneName}" but is not a proxied AAAA ${packageAppWildcardDnsContent} record (found ${conflicting.type} ${conflicting.content}, proxied=${String(conflicting.proxied)}). Fix it in the Cloudflare dashboard, then re-run deploy.`,
-		)
 	}
 
 	const created = await cloudflareRootApiRequest<CloudflareDnsRecord>({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

One user's package apps must never share a browser origin with another user's: shared-origin cookies (`kody_pkg_session` on `kodyapps.dev`) let package A reach package B's session-authorized endpoints from the browser, the exact gap called out as "out of scope" in `docs/contributing/security.md`. This PR closes it by giving every user their own subdomain on the package-app domain and hardening the session cookie against cross-subdomain tossing.

## Summary

- Hosted package apps move from `kodyapps.dev/@{username}/packages/{kodyId}` to `https://{username}.kodyapps.dev/packages/{kodyId}` — the username lives in the hostname, so the `/@{username}` path prefix disappears on the package-app domain (routing simplification).
- The bare package-app origin serves no package code: `/` redirects to the app origin, legacy path URLs redirect (302/307) to the owning user's subdomain, everything else fails closed — including hostnames under the domain that are not a valid username label.
- The package-app session cookie becomes `__Host-kody_pkg_session` on secure requests: browsers refuse any `Domain=`-carrying variant under that name, so a sibling subdomain cannot toss or shadow it (defense that works before any Public Suffix List entry). Plain-HTTP local dev falls back to the unprefixed name. Serving requires session username == subdomain label == owner (fixation defense).
- Usernames get **two-tier validation**: new/changed usernames must be strict DNS labels (no underscores; generated usernames map `_` to `-`), while *recognition* of stored usernames stays lenient so existing underscore accounts keep display names, public lookup, and inbound email routing (Bugbot catch). Legacy-username owners get a 409 rename prompt at the package-app entry instead of a redirect to an unservable hostname, and hosted-URL emission falls back to the path-based shape for them.
- Deploy tooling publishes a wildcard zone route (`*.kodyapps.dev/*`) alongside the apex custom domain, and `production-resources ensure` idempotently provisions the proxied wildcard AAAA `100::` DNS record (zone routes do not create DNS).
- Untrusted markdown link safety also refuses `/packages/...` mount paths on every host, matching the existing `/@...` rule.
- `hostedUrl` emission (search, publish, `package_app_fetch`, `packageContext`) and search identity parsing understand the subdomain shape; inline (non-production) serving keeps the path-based mount.
- Decision record `docs/contributing/decisions/0017-per-user-package-app-subdomains.md`; security/architecture/authoring docs rewritten for the new model.

**Operational follow-ups (not in this PR):** the deploy token needs DNS:Edit on the `kodyapps.dev` zone before the first deploy; submitting `kodyapps.dev` to the [Public Suffix List](https://publicsuffix.org/submit/) is documented defense-in-depth.

## Testing

- `npm run validate` — green (format, lint, typecheck, 2043 node+workers unit tests across 603 files, Playwright E2E, MCP E2E, backup/status builds, primitives, migrations, deploy-guardrails, docs checks). One unrelated flaky passkeys E2E passed on retry.
- New/updated coverage: end-to-end workers test of the app-origin → subdomain handoff (cookie flags incl. `__Host-`/no `Domain`, replay refusal, cross-user subdomain 404, invalid-label fail-closed, legacy apex redirect, apex/subdomain first-party 404s, legacy-underscore-owner 409); host classification unit tests; subdomain search-identity parsing; two-tier username validation; wildcard route generation and idempotent DNS ensure; markdown `/packages/` link refusal.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4db2ab37` · **Head:** `bebcc4b1`

**Classification:** extends — the package-app origin-isolation contract changes shape (per-user subdomains, `__Host-` cookie, new mount path); no new primitives.

### Primitives touched

| Primitive         | Group     | Impact                                                                       |
| ----------------- | --------- | ---------------------------------------------------------------------------- |
| `package-apps`    | assistant | extends — per-user subdomain mount `/packages/{kodyId}`, new `packageContext` paths |
| `package-runtime` | runtime   | extends — `PackageAppPath.mount`, subdomain path parsing                      |
| `app-ui`          | surfaces  | extends — handoff redirects to per-user subdomain; `__Host-` session cookie; markdown link rule; two-tier DNS-label usernames |
| `mcp-server`      | surfaces  | composes — hostedUrl emission and search identity accept the subdomain shape  |

### System map

The app origin authenticates the owner and hands off to the owner's package-app subdomain, which exchanges the token for a host-only `__Host-` cookie before serving package code.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	packageApps["package-apps<br/>Package apps"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	appUi -->|"302 + handoff token to {username}.kodyapps.dev"| packageApps
	packageApps -->|"__Host-kody_pkg_session, username must match subdomain"| packageRuntime
	mcpServer -->|"hostedUrl / search identity use subdomain URLs"| packageApps
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
before: https://kodyapps.dev/@alice/packages/notes/report   (one shared origin for all users)
after:  https://alice.kodyapps.dev/packages/notes/report    (origin per user; apex only redirects)

before: Set-Cookie: kody_pkg_session=...        (host-only by convention)
after:  Set-Cookie: __Host-kody_pkg_session=... (host-only enforced by the browser)

routes before: kodyapps.dev (custom domain)
routes after:  kodyapps.dev (custom domain) + *.kodyapps.dev/* (zone route, wildcard AAAA 100:: proxied)
```

### Invariants

Strengthens per-user isolation: browser origin state (cookies, storage, `document`) is now partitioned per user on the package-app domain, and serving still requires session-username == subdomain == owner. Same-user package↔package origin sharing remains a documented, deliberately deferred residual (decision 0017).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67a9ab1e-b7f4-4fd0-964d-be419b961636?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67a9ab1e-b7f4-4fd0-964d-be419b961636&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Production package apps now use dedicated per-user subdomain URLs.
  - Legacy and inline links redirect to canonical hosted URLs.
  - Search recognizes and validates hosted package-app URLs.
  - Production infrastructure supports wildcard routing and DNS.

- **Security**
  - Improved session handoff and secure cookie protections.
  - Unsafe package links are blocked across hosted and inline paths.
  - Routing validates domains, ownership, and usernames.

- **Bug Fixes**
  - Redirects, sessions, paths, and query strings now behave consistently.

- **Documentation**
  - Updated setup, security, routing, authoring, search, and package guidance.

- **Validation**
  - New usernames now allow only letters, numbers, and hyphens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->