### PR TITLE
feat(mcp): bearer token support when adding remote MCP servers

### DIFF
--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -28,13 +28,17 @@ the `/mcp` endpoint (where Kody is the server) and complements remote connectors
 - **Settings service** (`packages/worker/src/mcp-client/settings-service.ts`) —
   validates names (`^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$`) and URLs (https
   required; plain http allowed only for loopback hosts), and keeps D1 and the
-  hub DO in sync.
+  hub DO in sync. Optional `bearerToken` values are normalized into an
+  `Authorization` header and stored only in the hub DO's Agents SDK
+  `server_options` (never in D1 or list/detail API responses).
 
 ## OAuth flow
 
 1. `addServer` registers the server with a callback URL of
    `<canonical-app-origin>/account/mcp-servers/oauth/callback` (from
-   `APP_BASE_URL`, not the request host) and starts connecting.
+   `APP_BASE_URL`, not the request host) and starts connecting. Optional static
+   Authorization headers from `bearerToken` are registered on the transport at
+   the same time.
 2. If the server requires OAuth, the SDK performs dynamic client registration
    and the connection parks in state `authenticating` with an `authUrl`.
 3. The user opens `authUrl` in the browser (surfaced in the account UI and by
@@ -87,11 +91,13 @@ canonical app origin and the callback path above. See
 
 ## Management surfaces
 
-- **UI**: `/account/mcp-servers` (add, authorize, reconnect, refresh tools,
-  enable/disable, remove; shows live state and discovered tools).
+- **UI**: `/account/mcp-servers` (add with optional bearer token, authorize,
+  reconnect, refresh tools, enable/disable, remove; shows live state and
+  discovered tools).
 - **Capabilities**: the `mcp_servers` domain (`mcp_server_add`,
   `mcp_server_list`, `mcp_server_reconnect`, `mcp_server_refresh`,
-  `mcp_server_remove`, `mcp_server_set_enabled`).
+  `mcp_server_remove`, `mcp_server_set_enabled`). `mcp_server_add` accepts
+  optional `bearerToken`.
 
 ## Isolation and lifecycle
 

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -11,9 +11,15 @@ This is the inverse of [connecting your agent to Kody](./connect-your-agent.md)
 1. Open [`/account/mcp-servers`](https://heykody.app/account/mcp-servers), or
    ask your agent to use `mcp_server_add` with a short kebab-case `name` and the
    server `url` (https required).
-2. If the server needs OAuth, Kody returns an authorization link. Open it, sign
+2. If the server authenticates with a static bearer token (or other
+   Authorization scheme), paste it in the optional Bearer token field — or pass
+   `bearerToken` to `mcp_server_add`. Bare tokens are sent as
+   `Authorization: Bearer <token>`; values that already include a scheme are
+   sent as-is. The credential is stored only in your private MCP client hub and
+   is never returned later.
+3. If the server needs OAuth, Kody returns an authorization link. Open it, sign
    in at the provider, and approve access.
-3. Confirm with `mcp_server_list` (or refresh the account page). Connected tools
+4. Confirm with `mcp_server_list` (or refresh the account page). Connected tools
    show up in `search` under a `mcp:<name>` domain.
 
 ## OAuth allowlists (common failure)
@@ -43,6 +49,8 @@ Kody itself does not maintain a per-provider allowlist for this flow — the
 remote authorization server does.
 
 Servers that do not use OAuth connect immediately and do not need these steps.
+Bearer-token servers also skip OAuth when the static Authorization header is
+enough for the remote server.
 
 ## Related
 

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -14,9 +14,9 @@ This is the inverse of [connecting your agent to Kody](./connect-your-agent.md)
 2. If the server authenticates with a static bearer token (or other
    Authorization scheme), paste it in the optional Bearer token field — or pass
    `bearerToken` to `mcp_server_add`. Bare tokens are sent as
-   `Authorization: Bearer <token>`; values that already include a scheme are
-   sent as-is. The credential is stored only in your private MCP client hub and
-   is never returned later.
+   `Authorization: Bearer <token>`; scheme-prefixed values and full
+   `Authorization: …` header pastes are normalized. The credential is stored
+   only in your private MCP client hub and is never returned later.
 3. If the server needs OAuth, Kody returns an authorization link. Open it, sign
    in at the provider, and approve access.
 4. Confirm with `mcp_server_list` (or refresh the account page). Connected tools

--- a/packages/shared/src/mcp-servers.node.test.ts
+++ b/packages/shared/src/mcp-servers.node.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'vitest'
 import {
 	isValidMcpServerName,
+	mcpServerAuthorizationHeaders,
+	mcpServerBearerTokenMaxLength,
+	normalizeMcpServerBearerToken,
 	normalizeMcpServerName,
 	validateMcpServerUrl,
 } from './mcp-servers.ts'
@@ -27,4 +30,30 @@ test('MCP server URLs require https except for loopback hosts', () => {
 	expect(validateMcpServerUrl('').ok).toBe(false)
 	expect(validateMcpServerUrl('not a url').ok).toBe(false)
 	expect(validateMcpServerUrl('http://example.com/mcp').ok).toBe(false)
+})
+
+test('MCP server bearer tokens normalize to Authorization header values', () => {
+	expect(normalizeMcpServerBearerToken(undefined)).toEqual({ ok: true })
+	expect(normalizeMcpServerBearerToken('')).toEqual({ ok: true })
+	expect(normalizeMcpServerBearerToken('   ')).toEqual({ ok: true })
+	expect(normalizeMcpServerBearerToken('secret-token')).toEqual({
+		ok: true,
+		authorization: 'Bearer secret-token',
+	})
+	expect(normalizeMcpServerBearerToken('Bearer already')).toEqual({
+		ok: true,
+		authorization: 'Bearer already',
+	})
+	expect(normalizeMcpServerBearerToken('token abc.def')).toEqual({
+		ok: true,
+		authorization: 'token abc.def',
+	})
+	expect(
+		normalizeMcpServerBearerToken('x'.repeat(mcpServerBearerTokenMaxLength + 1))
+			.ok,
+	).toBe(false)
+	expect(mcpServerAuthorizationHeaders(undefined)).toBeUndefined()
+	expect(mcpServerAuthorizationHeaders('Bearer secret')).toEqual({
+		Authorization: 'Bearer secret',
+	})
 })

--- a/packages/shared/src/mcp-servers.node.test.ts
+++ b/packages/shared/src/mcp-servers.node.test.ts
@@ -49,6 +49,17 @@ test('MCP server bearer tokens normalize to Authorization header values', () => 
 		authorization: 'token abc.def',
 	})
 	expect(
+		normalizeMcpServerBearerToken('Authorization: Bearer pasted-header'),
+	).toEqual({
+		ok: true,
+		authorization: 'Bearer pasted-header',
+	})
+	expect(normalizeMcpServerBearerToken('authorization:token xyz')).toEqual({
+		ok: true,
+		authorization: 'token xyz',
+	})
+	expect(normalizeMcpServerBearerToken('Authorization:').ok).toBe(false)
+	expect(
 		normalizeMcpServerBearerToken('x'.repeat(mcpServerBearerTokenMaxLength + 1))
 			.ok,
 	).toBe(false)

--- a/packages/shared/src/mcp-servers.ts
+++ b/packages/shared/src/mcp-servers.ts
@@ -5,6 +5,11 @@ export type McpServerRef = {
 
 export const mcpServerNamePattern = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/
 
+/** Upper bound for static Authorization header values stored for MCP clients. */
+export const mcpServerBearerTokenMaxLength = 8_192
+
+const authorizationSchemePattern = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+\s+\S/
+
 export function normalizeMcpServerName(name: string): string {
 	return name.trim().toLowerCase()
 }
@@ -47,4 +52,49 @@ export function validateMcpServerUrl(url: string): {
 		error:
 			'Server URL must use https (plain http is only allowed for localhost).',
 	}
+}
+
+/**
+ * Normalize an optional static MCP Authorization credential.
+ *
+ * Empty input means no header. Values that already look like an HTTP auth
+ * scheme (`Bearer …`, `token …`, etc.) are kept as-is; bare tokens become
+ * `Bearer <token>`. The result is suitable for an `Authorization` request
+ * header on every MCP client request.
+ */
+export function normalizeMcpServerBearerToken(
+	token: string | null | undefined,
+): {
+	ok: boolean
+	authorization?: string
+	error?: string
+} {
+	if (token == null) {
+		return { ok: true }
+	}
+	const trimmed = token.trim()
+	if (!trimmed) {
+		return { ok: true }
+	}
+	if (trimmed.length > mcpServerBearerTokenMaxLength) {
+		return {
+			ok: false,
+			error: `Bearer token must be at most ${mcpServerBearerTokenMaxLength} characters.`,
+		}
+	}
+	const authorization = authorizationSchemePattern.test(trimmed)
+		? trimmed
+		: `Bearer ${trimmed}`
+	return { ok: true, authorization }
+}
+
+/**
+ * Build the durable transport headers map for a normalized Authorization
+ * value, or `undefined` when no static auth header should be sent.
+ */
+export function mcpServerAuthorizationHeaders(
+	authorization: string | undefined,
+): Record<string, string> | undefined {
+	if (!authorization) return undefined
+	return { Authorization: authorization }
 }

--- a/packages/shared/src/mcp-servers.ts
+++ b/packages/shared/src/mcp-servers.ts
@@ -57,10 +57,13 @@ export function validateMcpServerUrl(url: string): {
 /**
  * Normalize an optional static MCP Authorization credential.
  *
- * Empty input means no header. Values that already look like an HTTP auth
- * scheme (`Bearer …`, `token …`, etc.) are kept as-is; bare tokens become
- * `Bearer <token>`. The result is suitable for an `Authorization` request
- * header on every MCP client request.
+ * Empty input means no header. Accepts:
+ * - bare tokens → `Bearer <token>`
+ * - scheme-prefixed values (`Bearer …`, `token …`) kept as-is
+ * - full header pastes (`Authorization: Bearer …`) with the header name stripped
+ *
+ * The result is suitable for an `Authorization` request header on every MCP
+ * client request.
  */
 export function normalizeMcpServerBearerToken(
 	token: string | null | undefined,
@@ -72,9 +75,19 @@ export function normalizeMcpServerBearerToken(
 	if (token == null) {
 		return { ok: true }
 	}
-	const trimmed = token.trim()
+	let trimmed = token.trim()
 	if (!trimmed) {
 		return { ok: true }
+	}
+	const authorizationHeaderPrefix = /^authorization\s*:\s*/i
+	if (authorizationHeaderPrefix.test(trimmed)) {
+		trimmed = trimmed.replace(authorizationHeaderPrefix, '').trim()
+	}
+	if (!trimmed) {
+		return {
+			ok: false,
+			error: 'Bearer token is required when Authorization is provided.',
+		}
 	}
 	if (trimmed.length > mcpServerBearerTokenMaxLength) {
 		return {

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -641,7 +641,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 											name="bearerToken"
 											type="password"
 											value={addBearerToken}
-											placeholder="Paste token or Authorization value"
+											placeholder="Paste token (or Bearer …)"
 											disabled={isMutating}
 											autocomplete="off"
 											mix={[
@@ -654,10 +654,11 @@ export function AccountMcpServersRoute(handle: Handle) {
 										/>
 										<span mix={css(descriptionCss)}>
 											Sent as Authorization: Bearer &lt;token&gt; on every
-											request. If you already include a scheme (Bearer, token,
-											etc.), it is used as-is. Leave blank for OAuth or
-											unauthenticated servers. The token is stored only in your
-											private MCP client hub and is never shown again.
+											request. You can paste a bare token, a scheme-prefixed
+											value (Bearer, token, etc.), or a full Authorization
+											header line. Leave blank for OAuth or unauthenticated
+											servers. The token is stored only in your private MCP
+											client hub and is never shown again.
 										</span>
 									</label>
 

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -191,6 +191,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 	let oauthCallbackUrl = ''
 	let addName = ''
 	let addUrl = ''
+	let addBearerToken = ''
 	let message: string | null = null
 	let messageTone: MessageTone = 'info'
 	const loadLatch = createRouteLoadLatch()
@@ -326,6 +327,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 		const formData = new FormData(form)
 		addName = String(formData.get('name') ?? '').trim()
 		addUrl = String(formData.get('url') ?? '').trim()
+		addBearerToken = String(formData.get('bearerToken') ?? '')
 		if (!addName) {
 			setMessage('Server name is required.', 'error')
 			handle.update()
@@ -336,11 +338,18 @@ export function AccountMcpServersRoute(handle: Handle) {
 			handle.update()
 			return
 		}
+		const bearerToken = addBearerToken.trim()
 		await postAction({
-			body: { action: 'add', name: addName, url: addUrl },
+			body: {
+				action: 'add',
+				name: addName,
+				url: addUrl,
+				...(bearerToken ? { bearerToken } : {}),
+			},
 			successMessage: (payload) => {
 				addName = ''
 				addUrl = ''
+				addBearerToken = ''
 				const added = payload.selectedServerId
 					? payload.servers.find(
 							(server) => server.id === payload.selectedServerId,
@@ -412,7 +421,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 			<AccountManagementShell>
 				<AccountPageHeader
 					title="MCP servers"
-					description="Connect remote MCP servers so their tools are available to Kody as kody.mcp capabilities. Servers that require OAuth prompt for authorization after they are added."
+					description="Connect remote MCP servers so their tools are available to Kody as kody.mcp capabilities. Use a bearer token for static Authorization, or complete OAuth when the server requires it."
 					currentHref={currentHref}
 					actions={
 						<button
@@ -569,7 +578,8 @@ export function AccountMcpServersRoute(handle: Handle) {
 										<p mix={css(descriptionCss)}>
 											Provide a short name and the server URL. Remote servers
 											must use https; Kody connects as an MCP client and
-											discovers the server&apos;s tools.
+											discovers the server&apos;s tools. For servers that use a
+											static bearer token instead of OAuth, paste it below.
 										</p>
 									</div>
 
@@ -583,6 +593,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 											placeholder="linear"
 											disabled={isMutating}
 											required
+											autocomplete="off"
 											mix={[
 												on('input', (event) => {
 													addName = event.currentTarget.value
@@ -607,6 +618,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 											placeholder="https://mcp.example.com/mcp"
 											disabled={isMutating}
 											required
+											autocomplete="off"
 											mix={[
 												on('input', (event) => {
 													addUrl = event.currentTarget.value
@@ -615,6 +627,38 @@ export function AccountMcpServersRoute(handle: Handle) {
 												css(accountInputCss),
 											]}
 										/>
+									</label>
+
+									<label mix={css(fieldCss)}>
+										<span mix={css(fieldLabelCss)}>
+											Bearer token{' '}
+											<span mix={css({ color: colors.textMuted })}>
+												(optional)
+											</span>
+										</span>
+										<input
+											data-field-ring
+											name="bearerToken"
+											type="password"
+											value={addBearerToken}
+											placeholder="Paste token or Authorization value"
+											disabled={isMutating}
+											autocomplete="off"
+											mix={[
+												on('input', (event) => {
+													addBearerToken = event.currentTarget.value
+													handle.update()
+												}),
+												css(accountInputCss),
+											]}
+										/>
+										<span mix={css(descriptionCss)}>
+											Sent as Authorization: Bearer &lt;token&gt; on every
+											request. If you already include a scheme (Bearer, token,
+											etc.), it is used as-is. Leave blank for OAuth or
+											unauthenticated servers. The token is stored only in your
+											private MCP client hub and is never shown again.
+										</span>
 									</label>
 
 									<div>

--- a/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
@@ -198,6 +198,7 @@ test('MCP servers API add action uses the canonical OAuth callback origin', asyn
 				action: 'add',
 				name: 'notion',
 				url: 'https://mcp.notion.example/mcp',
+				bearerToken: 'secret-token',
 			}),
 		}),
 		params: {},
@@ -210,6 +211,7 @@ test('MCP servers API add action uses the canonical OAuth callback origin', asyn
 			name: 'notion',
 			url: 'https://mcp.notion.example/mcp',
 			baseUrl: 'https://example.com',
+			bearerToken: 'secret-token',
 		}),
 	)
 	const payload = (await addResponse.json()) as {

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -4,7 +4,10 @@ import { type Action } from 'remix/router'
 import { loadAccountMcpServersData } from '#app/account-mcp-servers-data.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
-import { readTrimmedStringOrEmpty } from '#app/request-body.ts'
+import {
+	readNonEmptyTrimmedString,
+	readTrimmedStringOrEmpty,
+} from '#app/request-body.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import { type routes } from '#universal/routes.ts'
 import { createMcpClientHubClient } from '#worker/mcp-client/hub-client.ts'
@@ -200,6 +203,7 @@ async function handleAddAction(input: {
 		name: readTrimmedStringOrEmpty(input.body, 'name'),
 		url: readTrimmedStringOrEmpty(input.body, 'url'),
 		baseUrl: oauth.clientOrigin,
+		bearerToken: readNonEmptyTrimmedString(input.body, 'bearerToken'),
 	})
 	const payload = await loadAccountMcpServersData({
 		env: input.env,

--- a/packages/worker/src/mcp-client/hub-client.ts
+++ b/packages/worker/src/mcp-client/hub-client.ts
@@ -26,6 +26,7 @@ export type McpClientHubClient = {
 		name: string
 		url: string
 		callbackUrl: string
+		headers?: Record<string, string>
 	}): Promise<McpServerConnectResult>
 	reconnectServer(input: { serverId: string }): Promise<McpServerConnectResult>
 	refreshServer(input: { serverId: string }): Promise<McpServerConnectResult>

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -143,6 +143,12 @@ class McpClientHubBase extends DurableObject<Env> {
 		name: string
 		url: string
 		callbackUrl: string
+		/**
+		 * Optional static request headers (for example Authorization: Bearer …).
+		 * Persisted in the Agents SDK `server_options` blob alongside the server
+		 * row; never returned in snapshots.
+		 */
+		headers?: Record<string, string>
 	}): Promise<McpServerConnectResult> {
 		await this.ensureRestored()
 		const existing = this.manager.mcpConnections[input.serverId]
@@ -164,7 +170,11 @@ class McpClientHubBase extends DurableObject<Env> {
 			url: input.url,
 			name: input.name,
 			callbackUrl: input.callbackUrl,
-			transport: { type: 'auto', authProvider },
+			transport: {
+				type: 'auto',
+				authProvider,
+				...(input.headers ? { headers: input.headers } : {}),
+			},
 		})
 		const result = await this.manager.connectToServer(input.serverId)
 		if (result.state === 'connected') {

--- a/packages/worker/src/mcp-client/settings-service.node.test.ts
+++ b/packages/worker/src/mcp-client/settings-service.node.test.ts
@@ -36,6 +36,7 @@ vi.mock('./hub-client.ts', () => ({
 }))
 
 const {
+	addMcpServer,
 	clearEnabledMcpServerRefsCacheForTests,
 	enabledMcpServerRefsCacheTtlMs,
 	listEnabledMcpServerRefsCached,
@@ -122,4 +123,51 @@ test('resolveMcpServerOAuthClientUrls prefers APP_BASE_URL over the request host
 		clientOrigin: 'https://preview.example',
 		callbackUrl: 'https://preview.example/account/mcp-servers/oauth/callback',
 	})
+})
+
+test('addMcpServer forwards bearer tokens as Authorization headers to the hub', async () => {
+	clearEnabledMcpServerRefsCacheForTests()
+	mockModule.getMcpServerSettingRowByName.mockResolvedValue(null)
+	mockModule.insertMcpServerSettingRow.mockResolvedValue(undefined)
+	mockModule.hubClient.addServer.mockResolvedValue({
+		serverId: 'ignored',
+		state: 'ready',
+		authUrl: null,
+		error: null,
+		toolCount: 1,
+	})
+
+	const env = { APP_DB: {} } as Env
+	const result = await addMcpServer({
+		env,
+		userId: 'user-1',
+		name: 'linear',
+		url: 'https://mcp.example.com/mcp',
+		baseUrl: 'https://heykody.app',
+		bearerToken: 'secret-token',
+	})
+
+	expect(result.setting.name).toBe('linear')
+	expect(mockModule.hubClient.addServer).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: 'linear',
+			url: 'https://mcp.example.com/mcp',
+			callbackUrl: 'https://heykody.app/account/mcp-servers/oauth/callback',
+			headers: { Authorization: 'Bearer secret-token' },
+		}),
+	)
+	expect(mockModule.insertMcpServerSettingRow).toHaveBeenCalledWith(
+		expect.objectContaining({
+			row: expect.objectContaining({
+				name: 'linear',
+				url: 'https://mcp.example.com/mcp',
+				user_id: 'user-1',
+			}),
+		}),
+	)
+	// D1 metadata must not carry the credential.
+	const insertedRow = mockModule.insertMcpServerSettingRow.mock.calls[0]?.[0]
+		?.row as Record<string, unknown>
+	expect(insertedRow).not.toHaveProperty('bearerToken')
+	expect(JSON.stringify(insertedRow)).not.toContain('secret-token')
 })

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -1,6 +1,8 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
 	isValidMcpServerName,
+	mcpServerAuthorizationHeaders,
+	normalizeMcpServerBearerToken,
 	normalizeMcpServerName,
 	validateMcpServerUrl,
 	type McpServerRef,
@@ -145,6 +147,12 @@ export async function addMcpServer(input: {
 	name: string
 	url: string
 	baseUrl: string
+	/**
+	 * Optional static credential for servers that authenticate with a bearer
+	 * token (or other Authorization scheme) instead of OAuth. Never stored in
+	 * D1 — only forwarded into the hub DO's Agents SDK server options.
+	 */
+	bearerToken?: string | null
 }): Promise<{
 	setting: McpServerSettingMetadata
 	connection: McpServerConnectResult
@@ -154,6 +162,11 @@ export async function addMcpServer(input: {
 	if (!urlValidation.ok || !urlValidation.url) {
 		throw new Error(urlValidation.error ?? 'Server URL is invalid.')
 	}
+	const tokenValidation = normalizeMcpServerBearerToken(input.bearerToken)
+	if (!tokenValidation.ok) {
+		throw new Error(tokenValidation.error ?? 'Bearer token is invalid.')
+	}
+	const headers = mcpServerAuthorizationHeaders(tokenValidation.authorization)
 	const existing = await getMcpServerSettingRowByName({
 		db: input.env.APP_DB,
 		userId: input.userId,
@@ -185,6 +198,7 @@ export async function addMcpServer(input: {
 			name,
 			url: urlValidation.url,
 			callbackUrl: buildMcpServerOAuthCallbackUrl(input.baseUrl),
+			...(headers ? { headers } : {}),
 		})
 	} catch (error) {
 		const message = getErrorMessage(error)

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-add.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-add.ts
@@ -27,7 +27,7 @@ export const mcpServerAddCapability = defineDomainCapability(
 	{
 		name: 'mcp_server_add',
 		description:
-			'Add a remote MCP server for the signed-in user and connect to it. Servers that require OAuth return an authUrl the user must open to authorize Kody; other servers connect immediately. Connected server tools become kody.mcp["server-name"].tool_name(...) capabilities. When OAuth fails with origin or redirect URI errors, the remote authorization server must allow Kody\'s oauthClientOrigin and oauthCallbackUrl.',
+			'Add a remote MCP server for the signed-in user and connect to it. Servers that require OAuth return an authUrl the user must open to authorize Kody; other servers connect immediately. Pass bearerToken for servers that authenticate with a static Authorization header instead of (or in addition to) OAuth. Connected server tools become kody.mcp["server-name"].tool_name(...) capabilities. When OAuth fails with origin or redirect URI errors, the remote authorization server must allow Kody\'s oauthClientOrigin and oauthCallbackUrl.',
 		keywords: [
 			'mcp',
 			'server',
@@ -35,6 +35,9 @@ export const mcpServerAddCapability = defineDomainCapability(
 			'connect',
 			'client',
 			'oauth',
+			'bearer',
+			'token',
+			'authorization',
 			'remote',
 			'tools',
 			'integration',
@@ -55,9 +58,19 @@ export const mcpServerAddCapability = defineDomainCapability(
 				.describe(
 					'The remote MCP server endpoint URL. Must be https (http is only allowed for localhost during development).',
 				),
+			bearerToken: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					'Optional static credential for Authorization. Bare tokens are sent as Bearer <token>; values that already include an auth scheme (Bearer, token, etc.) are sent as-is. Stored only in the per-user MCP client hub, never returned later.',
+				),
 		}),
 		outputSchema,
-		async handler(args: { name: string; url: string }, ctx: CapabilityContext) {
+		async handler(
+			args: { name: string; url: string; bearerToken?: string },
+			ctx: CapabilityContext,
+		) {
 			const user = requireMcpUser(ctx.callerContext)
 			const oauth = resolveMcpServerOAuthClientUrls({
 				env: ctx.env,
@@ -69,6 +82,7 @@ export const mcpServerAddCapability = defineDomainCapability(
 				name: args.name,
 				url: args.url,
 				baseUrl: oauth.clientOrigin,
+				bearerToken: args.bearerToken,
 			})
 			const error = connection.error
 				? enrichMcpOAuthProviderError(connection.error, oauth)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses CAM's platform feedback: `/account/mcp-servers` only accepted name + URL, so bearer-token MCP servers could not be connected.

Adds an optional bearer token on:

- `/account/mcp-servers` add form (password field)
- Account MCP servers API (`bearerToken`)
- `mcp_server_add` capability

Normalization accepts bare tokens (`Bearer <token>`), scheme-prefixed values, and full `Authorization: …` header pastes. The credential is stored only in the per-user MCP client hub's Agents SDK `server_options` (never in D1 or list/detail responses).

## Test plan

- [x] Unit: bearer token normalization (including Authorization: header pastes)
- [x] Unit: settings service forwards Authorization headers to hub; D1 row has no token
- [x] Unit: account API add action passes `bearerToken`
- [x] CI validate green (prior commit); waiting on follow-up for paste-fix
- [ ] After merge: mark platform feedback resolved

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c7cd824` · **Head:** follow-up after Bugbot paste-fix

**Classification:** extends — MCP client add contract and account UI now accept optional static Authorization credentials.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | extends — optional `bearerToken` → durable Authorization header on hub transport |
| `app-ui` | surfaces | extends — add-server form gains optional bearer token field |

### System map

Add-server flows (UI / API / capability) now pass an optional bearer credential into the per-user MCP client hub as a durable Authorization header.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	mcpClientServers["mcp-client-servers<br/>MCP client servers"]:::extended
	appUi -->|"POST bearerToken on /account/mcp-servers.json"| mcpClientServers
	mcpClientServers -->|"transport.headers Authorization on registerServer"| mcpClientServers
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Add form | name + URL | name + URL + optional bearer token |
| `mcp_server_add` | `{ name, url }` | `{ name, url, bearerToken? }` |
| Hub `addServer` | OAuth provider only | optional `headers.Authorization` persisted in DO `server_options` |

### Invariants

Per-user isolation unchanged: credentials stay in the user-scoped MCP client hub DO and are never returned by list/detail APIs.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f23c4c9e-1b42-4386-8f03-fc0586a5002f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f23c4c9e-1b42-4386-8f03-fc0586a5002f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional bearer-token authentication for MCP server connections.
  * MCP server setup now accepts tokens through the management interface and server-add capability.
  * Tokens are normalized into Authorization headers and excluded from saved settings and snapshots.
  * OAuth remains available when static bearer-token authentication is not used.

* **Documentation**
  * Updated setup and architecture guidance for bearer tokens, HTTPS, storage, and authentication behavior.

* **Bug Fixes**
  * Improved handling of empty, prefixed, formatted, and oversized authorization values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->