### PR TITLE
chore(identity): remove the legacy underscore-username tier

### DIFF
--- a/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
+++ b/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
@@ -71,8 +71,8 @@ package-app apex:
   [`security.md`](../security.md)).
 - Production deploys require wildcard DNS and a `*.kodyapps.dev/*` Worker route
   (see [`setup-manifest.md`](../setup-manifest.md)).
-- Username renames become mandatory for underscore holders before subdomain
-  hosting works.
+- The one production underscore account was renamed by hand on 2026-08-12; no
+  underscore usernames remain, so no rename affordances exist in the app.
 - `parsePackageSearchIdentity`, status probes, and author docs must recognize
   both subdomain URLs and legacy path shapes during transition.
 - Revisit per-package subdomains only if same-owner isolation becomes a reported

--- a/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
+++ b/docs/contributing/decisions/0017-per-user-package-app-subdomains.md
@@ -47,11 +47,12 @@ package-app apex:
   subdomain itself: sibling subdomains stay same-site until the PSL entry, so a
   `SameSite=Lax` cookie would otherwise attach to a cross-subdomain mutation
   from a browser holding sessions for two accounts.
-- New and changed usernames are strict DNS labels (lowercase alphanumeric +
-  hyphens; underscores banned). Recognition of stored usernames stays lenient
-  (two-tier validation) so legacy underscore accounts keep display names, public
-  lookup, and inbound email routing; they must rename before hosted apps work
-  (the app origin answers their package-app entry with a `409` rename prompt).
+- Usernames are strict DNS labels everywhere (lowercase alphanumeric + hyphens;
+  underscores banned). A two-tier lenient-recognition scheme shipped briefly to
+  protect legacy underscore accounts, but production had exactly one such
+  account; it was renamed by hand (`users.username`, `email_inbox_addresses`,
+  `saved_packages.name`) on 2026-08-12 and the lenient tier was removed the same
+  day — no legacy affordances remain.
 - `packageContext.appBasePath` on a subdomain is `/packages/{kodyId}` (no
   `/@{username}` prefix); inline non-production serving keeps the path-based
   mount. Well-behaved packages that use `hostedUrl` / `appBasePath` stay

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -152,16 +152,12 @@ from `{username}.<package-app host>` (`buildPackageAppSubdomainOrigin` in
 `document` access) never crosses accounts. The username label in the hostname
 must be a valid single DNS label: lowercase letters, digits, and hyphens only,
 3–32 characters, alphanumeric edges (`dnsSafeUsernamePattern` in
-`packages/shared/src/public-urls.ts`). Underscores are not allowed for new or
-changed usernames; accounts whose usernames still contain legacy underscores
-must rename before hosted apps work on a subdomain — the app-origin entry
-answers them with a `409` rename prompt instead of redirecting to a hostname
-nothing can serve, and hosted-URL emission falls back to the path-based shape
-for them. Recognition of _stored_ usernames elsewhere
-(`getUsernameFormatValidationError`) deliberately stays lenient so legacy
-accounts keep display names, public lookup, and inbound email routing. Wildcard
-DNS still routes invalid or nested labels to the Worker, so hostnames that are
-not exactly one valid username label fail closed with `404`.
+`packages/shared/src/public-urls.ts`). Every username satisfies this shape —
+underscores are rejected everywhere, and the pre-existing underscore accounts
+were migrated by hand on 2026-08-12 (decision 0017), so there is no lenient
+legacy tier. Wildcard DNS still routes invalid or nested labels to the Worker,
+so hostnames that are not exactly one valid username label fail closed with
+`404`.
 
 Dispatch lives in `packages/worker/src/app/package-app-origin.ts`, called first
 in the Worker `fetch` handler:

--- a/packages/mock-servers/cloudflare/wrangler.jsonc
+++ b/packages/mock-servers/cloudflare/wrangler.jsonc
@@ -6,13 +6,17 @@
 	"main": "./src/worker.ts",
 	"preview_urls": true,
 	"observability": { "enabled": true },
+	// SQLite-backed classes: Cloudflare rejects creating new key-value backed
+	// Durable Object namespaces (error 10099), and every PR preview deploys a
+	// fresh mock script that runs these migrations from scratch. Long-lived
+	// scripts already applied these tags, so the edit only affects new scripts.
 	"migrations": [
 		{
-			"new_classes": ["MockCloudflareEmailMessagesDurableObject"],
+			"new_sqlite_classes": ["MockCloudflareEmailMessagesDurableObject"],
 			"tag": "v1",
 		},
 		{
-			"new_classes": ["MockCloudflareArtifactsDurableObject"],
+			"new_sqlite_classes": ["MockCloudflareArtifactsDurableObject"],
 			"tag": "v2",
 		},
 	],

--- a/packages/shared/src/public-urls.ts
+++ b/packages/shared/src/public-urls.ts
@@ -38,10 +38,10 @@ export function buildPackageAppUrl(input: {
 export type PackageAppMount = 'user-subdomain' | 'username-path'
 
 /**
- * Usernames that can own a `{username}.` package-app subdomain: a valid DNS
- * label (lowercase letters, digits, hyphens; 3–32 chars; alphanumeric edges).
- * Legacy usernames may still contain underscores; those cannot be a hostname
- * label, so subdomain URL builders fall back to the path-based mount for them.
+ * The username shape: a valid DNS label (lowercase letters, digits, hyphens;
+ * 3–32 chars; alphanumeric edges), because every user owns a `{username}.`
+ * subdomain on the package-app domain. Also used to validate subdomain labels
+ * from wildcard-routed hostnames, which can be arbitrary strings.
  */
 export const dnsSafeUsernamePattern = /^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$/
 
@@ -94,9 +94,8 @@ export function buildPackageAppSubdomainUrl(input: {
 
 /**
  * Canonical browser URL for a hosted package app: the per-user subdomain of
- * the package-app origin when one is configured and the username can be a
- * hostname label, or the path-based mount on the app origin otherwise (inline
- * non-production serving, and legacy usernames that cannot own a subdomain).
+ * the package-app origin when one is configured, or the path-based mount on
+ * the app origin when a non-production deployment serves package apps inline.
  */
 export function resolveHostedPackageAppUrl(input: {
 	packageAppBaseUrl: string | null
@@ -105,7 +104,7 @@ export function resolveHostedPackageAppUrl(input: {
 	kodyId: string
 	restPath?: string | null
 }) {
-	if (input.packageAppBaseUrl && isDnsSafeUsername(input.username)) {
+	if (input.packageAppBaseUrl) {
 		return buildPackageAppSubdomainUrl({
 			packageAppOrigin: input.packageAppBaseUrl,
 			username: input.username,

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -3,7 +3,6 @@ import { createHtmlResponse } from 'remix/response/html'
 import {
 	buildPackageAppPath,
 	buildPackageAppSubdomainUrl,
-	isDnsSafeUsername,
 } from '@kody-internal/shared/public-urls.ts'
 import {
 	getAppBaseUrl,
@@ -107,25 +106,6 @@ function createUnmatchedPackageAppPathResponse() {
 			'Content-Type': 'text/plain; charset=utf-8',
 		},
 	})
-}
-
-/**
- * Terminal response for a legacy username that cannot own a subdomain
- * (underscores are not valid in hostnames). Redirecting would send the
- * browser to a hostname the wildcard certificate and routing cannot serve, so
- * fail here with the fix instead.
- */
-function createSubdomainIneligibleUsernameResponse() {
-	return new Response(
-		'Hosted package apps run on a per-user subdomain, and this username contains characters that are not allowed in domain names (such as underscores). Rename the username under Account settings, then reopen the app.',
-		{
-			status: 409,
-			headers: {
-				'Cache-Control': 'no-store',
-				'Content-Type': 'text/plain; charset=utf-8',
-			},
-		},
-	)
 }
 
 /**
@@ -245,9 +225,6 @@ async function redirectAppOriginToPackageAppOrigin(input: {
 	packageAppOrigin: string
 }) {
 	const { request, env, url, packagePath, packageAppOrigin } = input
-	if (!isDnsSafeUsername(packagePath.username)) {
-		return createSubdomainIneligibleUsernameResponse()
-	}
 	const target = buildSubdomainTarget({ packageAppOrigin, packagePath, url })
 
 	// A non-safe method reaching the app origin is not part of the normal flow
@@ -293,9 +270,6 @@ function handleApexRequest(input: {
 }) {
 	const { request, env, url, packagePath, packageAppOrigin } = input
 	if (packagePath) {
-		if (!isDnsSafeUsername(packagePath.username)) {
-			return createSubdomainIneligibleUsernameResponse()
-		}
 		const target = buildSubdomainTarget({ packageAppOrigin, packagePath, url })
 		return redirectResponse({
 			location: target.toString(),

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -329,57 +329,6 @@ test('hosted package apps move to the owner subdomain behind a single-use handof
 	).toBe('/login')
 })
 
-test('legacy underscore usernames get a rename prompt instead of a broken subdomain redirect', async () => {
-	configureOrigins({
-		packageAppBaseUrl: packageAppOrigin,
-		runtime: 'production',
-	})
-	// Ensures schema and the session secret are in place.
-	await seedOwnerSessionCookie()
-	const legacyEmail = 'legacy-owner@example.com'
-	const legacyUsername = 'legacy_owner'
-	await seedAccount({
-		db: env.APP_DB,
-		email: legacyEmail,
-		username: legacyUsername,
-	})
-	const legacySetCookie = await createAuthCookie(
-		{
-			stableUserId: await createStableUserIdFromEmail(legacyEmail),
-			email: legacyEmail,
-			rememberMe: false,
-		},
-		true,
-	)
-	const legacyCookie = legacySetCookie.split(';')[0] ?? ''
-
-	// The app-origin entry terminates with the fix instead of redirecting to a
-	// hostname the wildcard certificate and routing cannot serve.
-	const entryResponse = await workerFetch(
-		`${appOrigin}/@${legacyUsername}/packages/demo`,
-		{ headers: { Cookie: legacyCookie } },
-	)
-	expect(entryResponse.status).toBe(409)
-	expect(entryResponse.headers.get('Location')).toBeNull()
-	await expect(entryResponse.text()).resolves.toContain('Rename the username')
-
-	// Legacy apex URLs for such accounts terminate the same way.
-	const apexResponse = await workerFetch(
-		`${packageAppOrigin}/@${legacyUsername}/packages/demo`,
-	)
-	expect(apexResponse.status).toBe(409)
-
-	// And an underscore hostname is never a valid user subdomain.
-	const subdomainResponse = await workerFetch(
-		`https://${legacyUsername}.packages.isolated.test/packages/demo`,
-		{ headers: { Cookie: legacyCookie } },
-	)
-	expect(subdomainResponse.status).toBe(404)
-	await expect(subdomainResponse.text()).resolves.toBe(
-		buildUnmatchedPackageAppOriginPathMessage(),
-	)
-})
-
 test('package apps stay inline on the app origin when no package-app origin is configured', async () => {
 	configureOrigins({ packageAppBaseUrl: undefined, runtime: 'preview' })
 	const sessionCookie = await seedOwnerSessionCookie()

--- a/packages/worker/src/identity/platform-account-creation.ts
+++ b/packages/worker/src/identity/platform-account-creation.ts
@@ -3,7 +3,7 @@ import { userExistsByUsername } from '#worker/identity/generated-username.ts'
 import { normalizeEmail } from '#worker/identity/normalize-email.ts'
 import { isReservedUsername } from '#worker/identity/reserved-usernames.ts'
 import {
-	getDnsSafeUsernameValidationError,
+	getUsernameFormatValidationError,
 	normalizeUsername,
 } from '#worker/identity/username.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -54,10 +54,7 @@ export async function createPlatformAccount(input: {
 	}
 
 	const username = normalizeUsername(input.username)
-	// Platform accounts are new accounts too: their usernames must be strict
-	// DNS labels so they can own a package-app subdomain (they only bypass the
-	// reserved-list restriction, not the format rules).
-	const formatError = getDnsSafeUsernameValidationError(username)
+	const formatError = getUsernameFormatValidationError(username)
 	if (formatError) {
 		throw new PlatformAccountCreateError('invalid_username', formatError)
 	}

--- a/packages/worker/src/identity/username.node.test.ts
+++ b/packages/worker/src/identity/username.node.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'vitest'
 import {
-	getDnsSafeUsernameValidationError,
 	getUsernameFormatValidationError,
 	getUsernameValidationError,
 	resolveDisplayName,
@@ -8,26 +7,19 @@ import {
 	usernameRequirements,
 } from './username.ts'
 
-test('new and changed usernames must be DNS labels (no underscores)', () => {
-	expect(getDnsSafeUsernameValidationError('some_user')).toBe(
+test('usernames must be DNS labels (no underscores)', () => {
+	expect(getUsernameFormatValidationError('some_user')).toBe(
 		usernameRequirements,
 	)
 	expect(getUsernameValidationError('user_name')).toBe(usernameRequirements)
-	expect(getDnsSafeUsernameValidationError('some-user')).toBeNull()
-	expect(getUsernameValidationError('some-user')).toBeNull()
-})
-
-test('existing usernames with legacy underscores are still recognized', () => {
-	// Recognition of stored usernames stays lenient so legacy accounts keep
-	// display names, public lookup, and inbound email routing; only subdomain
-	// hosting and new-username validation require the strict DNS-label shape.
-	expect(getUsernameFormatValidationError('some_user')).toBeNull()
 	expect(getUsernameFormatValidationError('has space')).toBe(
 		usernameRequirements,
 	)
+	expect(getUsernameFormatValidationError('some-user')).toBeNull()
+	expect(getUsernameValidationError('some-user')).toBeNull()
 	expect(
-		resolveDisplayName({ email: 'legacy@example.com', username: 'some_user' }),
-	).toBe('some_user')
+		resolveDisplayName({ email: 'user@example.com', username: 'some_user' }),
+	).toBe('user')
 })
 
 test('usernameFromEmail maps underscores in the email local part to hyphens', () => {

--- a/packages/worker/src/identity/username.ts
+++ b/packages/worker/src/identity/username.ts
@@ -4,41 +4,18 @@ import { getReservedUsernameError } from '#worker/identity/reserved-usernames.ts
 export const usernameRequirements =
 	'Username must be 3 to 32 characters, use only letters, numbers, and hyphens, and start and end with a letter or number.'
 
-/**
- * The shape usernames could take before the underscore ban. Existing accounts
- * may still carry underscores, so *recognition* of stored usernames (display
- * names, public user lookup, inbound email routing, `/@{username}` path
- * parsing) stays lenient — otherwise those accounts would silently lose every
- * username-addressed surface, not just hosted package-app subdomains.
- */
-const legacyUsernamePattern = /^[a-z0-9](?:[a-z0-9_-]{1,30}[a-z0-9])$/
-
 export function normalizeUsername(value: unknown) {
 	return typeof value === 'string' ? value.trim().toLowerCase() : ''
 }
 
 /**
- * Recognition gate for usernames that may already exist in the database.
- * Accepts the legacy underscore shape; use
- * `getDnsSafeUsernameValidationError` when validating a new or changed
- * username or a package-app subdomain label.
+ * Every username is a valid DNS label (`dnsSafeUsernamePattern` from
+ * `@kody-internal/shared/public-urls.ts`): each user owns a `{username}.`
+ * subdomain on the package-app domain. There is no lenient legacy shape —
+ * the underscore-era usernames were migrated out of production on
+ * 2026-08-12 (decision 0017).
  */
 export function getUsernameFormatValidationError(username: string) {
-	if (!username) {
-		return 'Username is required.'
-	}
-	if (!legacyUsernamePattern.test(username)) {
-		return usernameRequirements
-	}
-	return null
-}
-
-/**
- * Strict DNS-label validation (`dnsSafeUsernamePattern` from
- * `@kody-internal/shared/public-urls.ts`) for new/changed usernames and
- * package-app subdomain labels. Rejects the legacy underscore shape.
- */
-export function getDnsSafeUsernameValidationError(username: string) {
 	if (!username) {
 		return 'Username is required.'
 	}
@@ -76,9 +53,8 @@ export function resolveDisplayName(input: { email: string; username: string }) {
 		: input.username
 }
 
-/** Validation for a new or changed username: strict DNS label + reserved list. */
 export function getUsernameValidationError(username: string) {
-	const formatError = getDnsSafeUsernameValidationError(username)
+	const formatError = getUsernameFormatValidationError(username)
 	if (formatError) {
 		return formatError
 	}

--- a/packages/worker/src/mcp/capabilities/packages/package-app-fetch.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-app-fetch.ts
@@ -1,8 +1,5 @@
 import { bytesToBase64 } from '@kody-internal/shared/base64.ts'
-import {
-	isDnsSafeUsername,
-	resolveHostedPackageAppUrl,
-} from '@kody-internal/shared/public-urls.ts'
+import { resolveHostedPackageAppUrl } from '@kody-internal/shared/public-urls.ts'
 import { z } from 'zod'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
@@ -412,16 +409,11 @@ export const packageAppFetchCapability = defineDomainCapability(
 				kodyId: savedPackage.kodyId,
 				restPath: restPath === '/' ? null : restPath,
 			})
-			// Mount matches how resolveHostedPackageAppUrl addressed the app:
-			// legacy usernames that cannot own a subdomain keep the path mount.
 			const packagePath: PackageAppPath = {
 				username: owner.ownerScope,
 				kodyId: savedPackage.kodyId,
 				restPath: restPathOnly,
-				mount:
-					packageAppOrigin && isDnsSafeUsername(owner.ownerScope)
-						? 'user-subdomain'
-						: 'username-path',
+				mount: packageAppOrigin ? 'user-subdomain' : 'username-path',
 			}
 
 			const requestHeaders = collectSafeRequestHeaders(args.headers)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Kent's call: no legacy affordances for underscore usernames. The two-tier validation from #1395/#1396 (lenient recognition of stored usernames, strict DNS labels for new ones) existed to protect existing underscore accounts — but production has exactly one, and it has now been migrated, so the lenient tier guards nobody and is pure legacy residue.

## Summary

- **Production migration (already done, verified):** the single underscore account `debs_obrien` (user 42, 2 stock platform forks, 1 inbox alias, no community listings, no `debs-obrien` collision) was renamed by hand via the D1 API: `users.username`, `email_inbox_addresses.address`/`local_part`, and both `saved_packages.name` values → `debs-obrien`. A post-migration sweep confirms zero underscore usernames, package scopes, or inbox locals remain.
- `getUsernameFormatValidationError` is strict (DNS label) again and is the only username format rule; `getDnsSafeUsernameValidationError` and the lenient legacy pattern are removed.
- The 409 "rename your username" response on the package-app entry is removed (unreachable: underscore paths no longer parse).
- `resolveHostedPackageAppUrl` no longer falls back to the path mount for non-DNS-safe usernames; `package_app_fetch` mount selection simplifies accordingly.
- `dnsSafeUsernamePattern` / `isDnsSafeUsername` stay in `packages/shared/src/public-urls.ts` as the single source of truth — still needed to validate subdomain labels from wildcard-routed hostnames, which are arbitrary strings.
- Docs and decision 0017 record the one-time manual migration instead of the two-tier scheme (including the stale Consequences bullet CodeRabbit caught).
- **Drive-by CI unblock:** the mock cloudflare preview worker's DO migrations switch from `new_classes` to `new_sqlite_classes`. Cloudflare now rejects creating key-value backed DO namespaces (error 10099), and every PR preview deploys a fresh mock script that runs these migrations from scratch — preview resource deploys were failing repo-wide (first seen on this PR's preview). Long-lived scripts already applied tags v1/v2 and are unaffected.

**Known residual (self-healing):** the `package.json` files inside her two Artifacts repos still say `@debs_obrien/...`; her next publish fails scope validation with a clear message prompting the fix. They are unmodified platform forks. Kent may want to give Debbie a heads-up that her handle is now `debs-obrien`.

## Testing

- `npm run validate` green (E2E was an infra flake — workerd webserver crash — and passed on re-run; Nx flagged the task flaky).
- Updated: identity unit tests (strict-everywhere incl. `resolveDisplayName` fallback), removed the legacy-owner workers test; the full subdomain/handoff/host-label workers suite and search-identity/app-base-url/auth/account-profile suites pass unchanged otherwise.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67a9ab1e-b7f4-4fd0-964d-be419b961636?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67a9ab1e-b7f4-4fd0-964d-be419b961636&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized username validation to allow only lowercase letters, numbers, and hyphens.
  * Removed legacy underscore username handling and migration prompts.
  * Improved hosted package-app routing with consistent subdomain behavior.
  * Invalid or nested hostname labels now fail safely with a `404` response.

* **Documentation**
  * Updated security and architecture guidance to reflect strict DNS-safe username requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->