### PR TITLE
perf(community): speed up fork/install preflight, checks, and projection

### DIFF
--- a/packages/worker/src/app/handlers/community-install.node.test.ts
+++ b/packages/worker/src/app/handlers/community-install.node.test.ts
@@ -7,7 +7,16 @@ const mockModule = vi.hoisted(() => ({
 	getCommunityListingById: vi.fn(),
 	installCommunityListing: vi.fn(),
 	getMcpUserPackageScope: vi.fn(),
+	waitUntil: vi.fn(),
 }))
+
+vi.mock('cloudflare:workers', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('cloudflare:workers')>()
+	return {
+		...actual,
+		waitUntil: (...args: Array<unknown>) => mockModule.waitUntil(...args),
+	}
+})
 
 vi.mock('#app/authenticated-user.ts', () => ({
 	readAuthenticatedAppUser: (...args: Array<unknown>) =>
@@ -120,6 +129,9 @@ test('community install POST enforces gates and maps install outcomes', async ()
 			// The acknowledgement is bound to the commit the listing pinned
 			// when the handler checked trust.
 			expectedPinnedCommit: 'commit-1',
+			// cloudflare:workers waitUntil — defers search-index / retriever
+			// projection work off the install response critical path.
+			waitUntil: expect.any(Function),
 		}),
 	)
 

--- a/packages/worker/src/app/handlers/community-install.ts
+++ b/packages/worker/src/app/handlers/community-install.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { type Action } from 'remix/router'
+import { waitUntil } from 'cloudflare:workers'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import {
@@ -82,6 +83,10 @@ export function createCommunityInstallApiPostHandler(env: Env) {
 					// decision was made against so a concurrent republish cannot
 					// activate content the user never saw.
 					expectedPinnedCommit: listing.pinnedCommit,
+					// Projection already supports deferred search-index upsert and
+					// retriever-cache refresh; without waitUntil those await on the
+					// install response and stretch one-click / onboarding latency.
+					waitUntil,
 				})
 				if (result.status === 'adaptation_required') {
 					return jsonResponse({

--- a/packages/worker/src/community/install.node.test.ts
+++ b/packages/worker/src/community/install.node.test.ts
@@ -229,4 +229,60 @@ test('install overlaps Artifacts persist with publish checks', async () => {
 	resolvePersist?.()
 	resolveChecks?.()
 	await expect(installPromise).resolves.toMatchObject({ status: 'installed' })
+
+	let persistFinished = false
+	let persistStarted = false
+	const checksFailPersistGate = new Promise<void>((resolve) => {
+		resolvePersist = resolve
+	})
+	mockModule.prepareCommunityFork.mockResolvedValue(preparedFork())
+	mockModule.persistPreparedCommunityFork.mockImplementation(async () => {
+		persistStarted = true
+		await checksFailPersistGate
+		persistFinished = true
+		return forkResult()
+	})
+	mockModule.runRepoChecks.mockRejectedValue(
+		new Error('isolated check isolate reset'),
+	)
+	mockModule.refreshSavedPackageProjection.mockClear()
+	const checksThrowPromise = installCommunityListing(installInput())
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (persistStarted) break
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	}
+	expect(persistStarted).toBe(true)
+	expect(persistFinished).toBe(false)
+	resolvePersist?.()
+	await expect(checksThrowPromise).rejects.toThrow(
+		'isolated check isolate reset',
+	)
+	expect(persistFinished).toBe(true)
+	expect(mockModule.refreshSavedPackageProjection).not.toHaveBeenCalled()
+
+	let checksFinished = false
+	let checksStarted = false
+	const persistFailChecksGate = new Promise<void>((resolve) => {
+		resolveChecks = resolve
+	})
+	mockModule.prepareCommunityFork.mockResolvedValue(preparedFork())
+	mockModule.persistPreparedCommunityFork.mockRejectedValue(
+		new Error('artifact bootstrap failed'),
+	)
+	mockModule.runRepoChecks.mockImplementation(async () => {
+		checksStarted = true
+		await persistFailChecksGate
+		checksFinished = true
+		return { ok: true, results: [] }
+	})
+	const persistThrowPromise = installCommunityListing(installInput())
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (checksStarted) break
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	}
+	expect(checksStarted).toBe(true)
+	expect(checksFinished).toBe(false)
+	resolveChecks?.()
+	await expect(persistThrowPromise).rejects.toThrow('artifact bootstrap failed')
+	expect(checksFinished).toBe(true)
 })

--- a/packages/worker/src/community/install.node.test.ts
+++ b/packages/worker/src/community/install.node.test.ts
@@ -1,14 +1,17 @@
 import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
-	forkCommunityListing: vi.fn(),
+	prepareCommunityFork: vi.fn(),
+	persistPreparedCommunityFork: vi.fn(),
 	runRepoChecks: vi.fn(),
 	refreshSavedPackageProjection: vi.fn(),
 }))
 
 vi.mock('./service.ts', () => ({
-	forkCommunityListing: (...args: Array<unknown>) =>
-		mockModule.forkCommunityListing(...args),
+	prepareCommunityFork: (...args: Array<unknown>) =>
+		mockModule.prepareCommunityFork(...args),
+	persistPreparedCommunityFork: (...args: Array<unknown>) =>
+		mockModule.persistPreparedCommunityFork(...args),
 }))
 
 vi.mock('#worker/repo/checks.ts', () => ({
@@ -24,6 +27,27 @@ import { installCommunityListing } from './install.ts'
 
 const env = { APP_DB: {} as D1Database } as Env
 
+function preparedFork() {
+	return {
+		env,
+		baseUrl: 'https://kody.test',
+		userId: 'user-b',
+		listingId: 'listing-1',
+		listingName: '@owner/demo',
+		listingKodyId: 'demo',
+		originCommit: 'commit-1',
+		actor: 'human' as const,
+		packageId: 'package-1',
+		targetKodyId: 'demo',
+		targetName: '@userb/demo',
+		files: {
+			'package.json': '{"name":"@userb/demo"}',
+			'src/index.ts': 'export default async function main() {}',
+		},
+		crossScopeReferences: [],
+	}
+}
+
 function forkResult() {
 	return {
 		forkId: 'fork-1',
@@ -34,10 +58,7 @@ function forkResult() {
 		originCommit: 'commit-1',
 		crossScopeReferences: [],
 		filesCount: 2,
-		files: {
-			'package.json': '{"name":"@userb/demo"}',
-			'src/index.ts': 'export default async function main() {}',
-		},
+		files: preparedFork().files,
 	}
 }
 
@@ -54,7 +75,9 @@ function installInput() {
 }
 
 test('install publishes clean forks, keeps failed checks inert, and propagates errors', async () => {
-	mockModule.forkCommunityListing.mockResolvedValue(forkResult())
+	const prepared = preparedFork()
+	mockModule.prepareCommunityFork.mockResolvedValue(prepared)
+	mockModule.persistPreparedCommunityFork.mockResolvedValue(forkResult())
 	mockModule.runRepoChecks.mockResolvedValue({
 		ok: true,
 		results: [{ kind: 'manifest', ok: true, message: 'ok' }],
@@ -73,7 +96,7 @@ test('install publishes clean forks, keeps failed checks inert, and propagates e
 	})
 	// The user's trust/acknowledgement decision is pinned to the commit they
 	// saw, so a concurrent republish cannot swap in unreviewed content.
-	expect(mockModule.forkCommunityListing).toHaveBeenCalledWith(
+	expect(mockModule.prepareCommunityFork).toHaveBeenCalledWith(
 		expect.objectContaining({ expectedPinnedCommit: 'commit-1' }),
 	)
 	expect(mockModule.runRepoChecks).toHaveBeenCalledWith(
@@ -106,11 +129,13 @@ test('install publishes clean forks, keeps failed checks inert, and propagates e
 		userEmail: 'userb@example.com',
 		packageId: 'package-1',
 		sourceId: 'source-1',
+		sourceFiles: prepared.files,
 		waitUntil: undefined,
 	})
 
 	const waitUntil = vi.fn()
-	mockModule.forkCommunityListing.mockResolvedValue(forkResult())
+	mockModule.prepareCommunityFork.mockResolvedValue(preparedFork())
+	mockModule.persistPreparedCommunityFork.mockResolvedValue(forkResult())
 	mockModule.runRepoChecks.mockResolvedValue({
 		ok: true,
 		results: [{ kind: 'manifest', ok: true, message: 'ok' }],
@@ -118,10 +143,14 @@ test('install publishes clean forks, keeps failed checks inert, and propagates e
 	mockModule.refreshSavedPackageProjection.mockClear()
 	await installCommunityListing({ ...installInput(), waitUntil })
 	expect(mockModule.refreshSavedPackageProjection).toHaveBeenCalledWith(
-		expect.objectContaining({ waitUntil }),
+		expect.objectContaining({ waitUntil, sourceFiles: prepared.files }),
 	)
 
-	mockModule.forkCommunityListing.mockResolvedValue({
+	mockModule.prepareCommunityFork.mockResolvedValue({
+		...preparedFork(),
+		crossScopeReferences: [{ file: 'src/index.ts', specifier: 'kody:@usera/' }],
+	})
+	mockModule.persistPreparedCommunityFork.mockResolvedValue({
 		...forkResult(),
 		crossScopeReferences: [{ file: 'src/index.ts', specifier: 'kody:@usera/' }],
 	})
@@ -150,14 +179,15 @@ test('install publishes clean forks, keeps failed checks inert, and propagates e
 	})
 	expect(mockModule.refreshSavedPackageProjection).not.toHaveBeenCalled()
 
-	mockModule.forkCommunityListing.mockRejectedValueOnce(
+	mockModule.prepareCommunityFork.mockRejectedValueOnce(
 		new Error('banned from community participation'),
 	)
 	await expect(installCommunityListing(installInput())).rejects.toThrow(
 		'banned from community participation',
 	)
 
-	mockModule.forkCommunityListing.mockResolvedValue(forkResult())
+	mockModule.prepareCommunityFork.mockResolvedValue(preparedFork())
+	mockModule.persistPreparedCommunityFork.mockResolvedValue(forkResult())
 	mockModule.runRepoChecks.mockResolvedValue({ ok: true, results: [] })
 	mockModule.refreshSavedPackageProjection.mockRejectedValue(
 		new Error('saved_packages entitlement exceeded'),
@@ -165,4 +195,38 @@ test('install publishes clean forks, keeps failed checks inert, and propagates e
 	await expect(installCommunityListing(installInput())).rejects.toThrow(
 		'saved_packages entitlement exceeded',
 	)
+})
+
+test('install overlaps Artifacts persist with publish checks', async () => {
+	let resolvePersist: (() => void) | undefined
+	const persistGate = new Promise<void>((resolve) => {
+		resolvePersist = resolve
+	})
+	let resolveChecks: (() => void) | undefined
+	const checksGate = new Promise<void>((resolve) => {
+		resolveChecks = resolve
+	})
+	const started: Array<string> = []
+	mockModule.prepareCommunityFork.mockResolvedValue(preparedFork())
+	mockModule.persistPreparedCommunityFork.mockImplementation(async () => {
+		started.push('persist')
+		await persistGate
+		return forkResult()
+	})
+	mockModule.runRepoChecks.mockImplementation(async () => {
+		started.push('checks')
+		await checksGate
+		return { ok: true, results: [] }
+	})
+	mockModule.refreshSavedPackageProjection.mockResolvedValue(undefined)
+
+	const installPromise = installCommunityListing(installInput())
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (started.includes('persist') && started.includes('checks')) break
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	}
+	expect(started).toEqual(expect.arrayContaining(['persist', 'checks']))
+	resolvePersist?.()
+	resolveChecks?.()
+	await expect(installPromise).resolves.toMatchObject({ status: 'installed' })
 })

--- a/packages/worker/src/community/install.ts
+++ b/packages/worker/src/community/install.ts
@@ -1,7 +1,10 @@
 import { refreshSavedPackageProjection } from '#worker/package-registry/service.ts'
 import { runRepoChecks, type RepoCheckResult } from '#worker/repo/checks.ts'
 import { normalizeRepoWorkspacePath } from '#worker/repo/manifest.ts'
-import { forkCommunityListing } from './service.ts'
+import {
+	persistPreparedCommunityFork,
+	prepareCommunityFork,
+} from './service.ts'
 import { type CommunityForkActor, type CrossScopeReference } from './types.ts'
 
 type InstallProgressUpdate = {
@@ -20,6 +23,22 @@ async function reportInstallProgress(
 ) {
 	if (!reportProgress) return
 	await reportProgress(update)
+}
+
+function logInstallPhaseTiming(input: {
+	phase: string
+	durationMs: number
+	listingId: string
+	packageId?: string
+	filesCount?: number
+	status?: string
+}) {
+	console.info(
+		JSON.stringify({
+			message: 'community-phase-timing',
+			...input,
+		}),
+	)
 }
 
 type InstallForkSummary = {
@@ -87,12 +106,14 @@ export async function installCommunityListing(input: {
 	waitUntil?: (promise: Promise<unknown>) => void
 	reportProgress?: ReportInstallProgress
 }): Promise<InstallCommunityListingResult> {
+	const installStartedAt = Date.now()
 	await reportInstallProgress(input.reportProgress, {
 		progress: 1,
 		total: 4,
 		message: 'Forking the listing into your account — source sync inbound…',
 	})
-	const fork = await forkCommunityListing({
+	const prepareStartedAt = Date.now()
+	const prepared = await prepareCommunityFork({
 		env: input.env,
 		baseUrl: input.baseUrl,
 		userId: input.userId,
@@ -102,6 +123,45 @@ export async function installCommunityListing(input: {
 		expectedPinnedCommit: input.expectedPinnedCommit,
 		actor: input.actor ?? 'human',
 	})
+	logInstallPhaseTiming({
+		phase: 'install-prepare',
+		durationMs: Date.now() - prepareStartedAt,
+		listingId: input.listingId,
+		packageId: prepared.packageId,
+		filesCount: Object.keys(prepared.files).length,
+	})
+
+	// Community snapshots are always rooted at package.json (community publish
+	// reads the owner package's source root), and forked entity sources are
+	// created with the default manifest path and root — see ensureEntitySource
+	// in persistPreparedCommunityFork.
+	await reportInstallProgress(input.reportProgress, {
+		progress: 2,
+		total: 4,
+		message:
+			'Typechecking and bundling npm deps — overlapping Artifacts bootstrap…',
+	})
+	const overlapStartedAt = Date.now()
+	const [fork, checks] = await Promise.all([
+		persistPreparedCommunityFork(prepared),
+		runRepoChecks({
+			workspace: createSnapshotFilesWorkspace(prepared.files),
+			manifestPath: 'package.json',
+			sourceRoot: '/',
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			expectedPackageScope: input.expectedPackageScope,
+		}),
+	])
+	logInstallPhaseTiming({
+		phase: 'install-persist-and-checks',
+		durationMs: Date.now() - overlapStartedAt,
+		listingId: input.listingId,
+		packageId: fork.packageId,
+		filesCount: fork.filesCount,
+		status: checks.ok ? 'checks-ok' : 'checks-failed',
+	})
 	const summary: InstallForkSummary = {
 		forkId: fork.forkId,
 		packageId: fork.packageId,
@@ -110,32 +170,19 @@ export async function installCommunityListing(input: {
 		targetName: fork.targetName,
 		originCommit: fork.originCommit,
 	}
-
-	// Community snapshots are always rooted at package.json (community publish
-	// reads the owner package's source root), and forked entity sources are
-	// created with the default manifest path and root — see ensureEntitySource
-	// in forkCommunityListing.
-	await reportInstallProgress(input.reportProgress, {
-		progress: 2,
-		total: 4,
-		message:
-			'Typechecking and bundling npm deps — the same gates a publish would run…',
-	})
-	const checks = await runRepoChecks({
-		workspace: createSnapshotFilesWorkspace(fork.files),
-		manifestPath: 'package.json',
-		sourceRoot: '/',
-		env: input.env,
-		baseUrl: input.baseUrl,
-		userId: input.userId,
-		expectedPackageScope: input.expectedPackageScope,
-	})
 	if (!checks.ok) {
 		await reportInstallProgress(input.reportProgress, {
 			progress: 4,
 			total: 4,
 			message:
 				'Checks need a human/agent touch — keeping the fork inert for adaptation.',
+		})
+		logInstallPhaseTiming({
+			phase: 'install-total',
+			durationMs: Date.now() - installStartedAt,
+			listingId: input.listingId,
+			packageId: fork.packageId,
+			status: 'adaptation_required',
 		})
 		return {
 			...summary,
@@ -150,6 +197,7 @@ export async function installCommunityListing(input: {
 		total: 4,
 		message: 'Publishing and indexing — almost ready to invoke…',
 	})
+	const projectionStartedAt = Date.now()
 	await refreshSavedPackageProjection({
 		env: input.env,
 		baseUrl: input.baseUrl,
@@ -157,12 +205,26 @@ export async function installCommunityListing(input: {
 		userEmail: input.userEmail,
 		packageId: fork.packageId,
 		sourceId: fork.sourceId,
+		sourceFiles: prepared.files,
 		waitUntil: input.waitUntil,
+	})
+	logInstallPhaseTiming({
+		phase: 'install-projection',
+		durationMs: Date.now() - projectionStartedAt,
+		listingId: input.listingId,
+		packageId: fork.packageId,
 	})
 	await reportInstallProgress(input.reportProgress, {
 		progress: 4,
 		total: 4,
 		message: 'Installed. Your new package is live.',
+	})
+	logInstallPhaseTiming({
+		phase: 'install-total',
+		durationMs: Date.now() - installStartedAt,
+		listingId: input.listingId,
+		packageId: fork.packageId,
+		status: 'installed',
 	})
 	return {
 		...summary,

--- a/packages/worker/src/community/install.ts
+++ b/packages/worker/src/community/install.ts
@@ -142,26 +142,52 @@ export async function installCommunityListing(input: {
 			'Typechecking and bundling npm deps — overlapping Artifacts bootstrap…',
 	})
 	const overlapStartedAt = Date.now()
-	const [fork, checks] = await Promise.all([
-		persistPreparedCommunityFork(prepared),
-		runRepoChecks({
-			workspace: createSnapshotFilesWorkspace(prepared.files),
-			manifestPath: 'package.json',
-			sourceRoot: '/',
-			env: input.env,
-			baseUrl: input.baseUrl,
-			userId: input.userId,
-			expectedPackageScope: input.expectedPackageScope,
-		}),
+	const persistPromise = persistPreparedCommunityFork(prepared)
+	const checksPromise = runRepoChecks({
+		workspace: createSnapshotFilesWorkspace(prepared.files),
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		env: input.env,
+		baseUrl: input.baseUrl,
+		userId: input.userId,
+		expectedPackageScope: input.expectedPackageScope,
+	})
+	// Overlap is safe only if both sides finish before we return. Promise.all
+	// would reject as soon as checks throw and abandon an in-flight persist,
+	// leaving a fork the client never received (retry then collides).
+	const [persistSettled, checksSettled] = await Promise.allSettled([
+		persistPromise,
+		checksPromise,
 	])
 	logInstallPhaseTiming({
 		phase: 'install-persist-and-checks',
 		durationMs: Date.now() - overlapStartedAt,
 		listingId: input.listingId,
-		packageId: fork.packageId,
-		filesCount: fork.filesCount,
-		status: checks.ok ? 'checks-ok' : 'checks-failed',
+		packageId:
+			persistSettled.status === 'fulfilled'
+				? persistSettled.value.packageId
+				: prepared.packageId,
+		filesCount:
+			persistSettled.status === 'fulfilled'
+				? persistSettled.value.filesCount
+				: Object.keys(prepared.files).length,
+		status:
+			persistSettled.status === 'rejected'
+				? 'persist-failed'
+				: checksSettled.status === 'rejected'
+					? 'checks-threw'
+					: checksSettled.value.ok
+						? 'checks-ok'
+						: 'checks-failed',
 	})
+	if (persistSettled.status === 'rejected') {
+		throw persistSettled.reason
+	}
+	if (checksSettled.status === 'rejected') {
+		throw checksSettled.reason
+	}
+	const fork = persistSettled.value
+	const checks = checksSettled.value
 	const summary: InstallForkSummary = {
 		forkId: fork.forkId,
 		packageId: fork.packageId,

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -990,20 +990,20 @@ export async function forkCommunityListing(input: {
 	 */
 	actor?: CommunityForkActor | null
 }): Promise<ForkCommunityListingResult> {
-	await assertNotCommunityBanned(input.env.APP_DB, input.userId)
-
-	const listing = await getCommunityListingById(input.env.APP_DB, {
-		listingId: input.listingId,
-		includeDelisted: false,
-	})
+	// Ban check, listing row, and pinned KV snapshot are independent reads —
+	// overlapping them shaves fork preflight latency before the Artifacts
+	// bootstrap (the dominant cost) begins.
+	const [, listing, snapshot] = await Promise.all([
+		assertNotCommunityBanned(input.env.APP_DB, input.userId),
+		getCommunityListingById(input.env.APP_DB, {
+			listingId: input.listingId,
+			includeDelisted: false,
+		}),
+		readCommunitySnapshot(input.env.BUNDLE_ARTIFACTS_KV, input.listingId),
+	])
 	if (!listing) {
 		throw new Error(`Community listing "${input.listingId}" was not found.`)
 	}
-
-	const snapshot = await readCommunitySnapshot(
-		input.env.BUNDLE_ARTIFACTS_KV,
-		input.listingId,
-	)
 	if (!snapshot) {
 		throw new Error(
 			`Community listing snapshot for "${input.listingId}" was not found.`,
@@ -1029,27 +1029,28 @@ export async function forkCommunityListing(input: {
 		expectedPackageScope: input.expectedPackageScope,
 		targetKodyId,
 	})
-	const existingByKody = await getSavedPackageByKodyId(input.env.APP_DB, {
-		userId: input.userId,
-		kodyId: targetKodyId,
-	})
-	const existingByName = await getSavedPackageByName(input.env.APP_DB, {
-		userId: input.userId,
-		name: rewrittenManifest.targetName,
-	})
+	const [existingByKody, existingByName, existingForks, platformUsernames] =
+		await Promise.all([
+			getSavedPackageByKodyId(input.env.APP_DB, {
+				userId: input.userId,
+				kodyId: targetKodyId,
+			}),
+			getSavedPackageByName(input.env.APP_DB, {
+				userId: input.userId,
+				name: rewrittenManifest.targetName,
+			}),
+			listCommunityForksByListingAndUser(input.env.APP_DB, {
+				listingId: input.listingId,
+				userId: input.userId,
+			}),
+			listPlatformAccountUsernames(input.env.APP_DB),
+		])
 	if (existingByKody || existingByName) {
 		throw new CommunityActionError(
 			`You already have a saved package with kody id "${targetKodyId}". Pass a different kody_id to fork this listing.`,
 		)
 	}
 
-	const existingForks = await listCommunityForksByListingAndUser(
-		input.env.APP_DB,
-		{
-			listingId: input.listingId,
-			userId: input.userId,
-		},
-	)
 	const collidingFork = existingForks.find(
 		(fork) => fork.targetKodyId === targetKodyId,
 	)
@@ -1072,7 +1073,7 @@ export async function forkCommunityListing(input: {
 		expectedPackageScope: input.expectedPackageScope,
 		// Platform scopes (e.g. @kody) resolve live for every caller; forks
 		// keep those references instead of rewriting them.
-		allowedForeignScopes: await listPlatformAccountUsernames(input.env.APP_DB),
+		allowedForeignScopes: platformUsernames,
 	})
 
 	const packageId = crypto.randomUUID()

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -86,6 +86,7 @@ import {
 	type CommunityRatingRecord,
 	type CommunityReportRecord,
 	type CommunityReportResolutionAction,
+	type CrossScopeReference,
 	type ForkCommunityListingResult,
 } from './types.ts'
 
@@ -969,7 +970,7 @@ export async function getCommunityActivityForAdmin(input: {
 	return activity
 }
 
-export async function forkCommunityListing(input: {
+export type PrepareCommunityForkInput = {
 	env: Env
 	baseUrl: string
 	userId: string
@@ -989,7 +990,47 @@ export async function forkCommunityListing(input: {
 	 * can separate what a user chose from what their agent did on its own.
 	 */
 	actor?: CommunityForkActor | null
-}): Promise<ForkCommunityListingResult> {
+}
+
+export type PreparedCommunityFork = {
+	env: Env
+	baseUrl: string
+	userId: string
+	listingId: string
+	listingName: string
+	listingKodyId: string
+	originCommit: string
+	actor: CommunityForkActor | null
+	packageId: string
+	targetKodyId: string
+	targetName: string
+	files: Record<string, string>
+	crossScopeReferences: Array<CrossScopeReference>
+}
+
+function logCommunityPhaseTiming(input: {
+	phase: string
+	durationMs: number
+	listingId?: string
+	packageId?: string
+	filesCount?: number
+}) {
+	console.info(
+		JSON.stringify({
+			message: 'community-phase-timing',
+			...input,
+		}),
+	)
+}
+
+/**
+ * Rewrite the listing snapshot and run collision checks without touching
+ * Artifacts. One-click install overlaps the subsequent git bootstrap with
+ * publish checks against these in-memory files.
+ */
+export async function prepareCommunityFork(
+	input: PrepareCommunityForkInput,
+): Promise<PreparedCommunityFork> {
 	// Ban check, listing row, and pinned KV snapshot are independent reads —
 	// overlapping them shaves fork preflight latency before the Artifacts
 	// bootstrap (the dominant cost) begins.
@@ -1076,66 +1117,105 @@ export async function forkCommunityListing(input: {
 		allowedForeignScopes: platformUsernames,
 	})
 
-	const packageId = crypto.randomUUID()
-	const ensuredSource = await ensureEntitySource({
-		db: input.env.APP_DB,
+	return {
 		env: input.env,
+		baseUrl: input.baseUrl,
 		userId: input.userId,
+		listingId: input.listingId,
+		listingName: listing.name,
+		listingKodyId: listing.kodyId,
+		originCommit: listing.pinnedCommit,
+		actor: input.actor ?? null,
+		packageId: crypto.randomUUID(),
+		targetKodyId,
+		targetName: rewrittenManifest.targetName,
+		files: rewrittenFiles,
+		crossScopeReferences,
+	}
+}
+
+/**
+ * Create the Artifacts repo, sync the rewritten snapshot, and insert the
+ * inert `community_forks` row. Callers that already hold a prepared fork
+ * (one-click install) can overlap this with `runRepoChecks`.
+ */
+export async function persistPreparedCommunityFork(
+	prepared: PreparedCommunityFork,
+): Promise<ForkCommunityListingResult> {
+	const persistStartedAt = Date.now()
+	const ensuredSource = await ensureEntitySource({
+		db: prepared.env.APP_DB,
+		env: prepared.env,
+		userId: prepared.userId,
 		entityKind: 'package',
-		entityId: packageId,
+		entityId: prepared.packageId,
 		requirePersistence: true,
 	})
 	try {
 		await syncArtifactSourceSnapshot({
-			env: input.env,
-			baseUrl: input.baseUrl,
-			userId: input.userId,
+			env: prepared.env,
+			baseUrl: prepared.baseUrl,
+			userId: prepared.userId,
 			sourceId: ensuredSource.id,
-			files: rewrittenFiles,
+			files: prepared.files,
 			bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
 		})
 
 		const forkId = crypto.randomUUID()
-		await insertCommunityFork(input.env.APP_DB, {
+		await insertCommunityFork(prepared.env.APP_DB, {
 			id: forkId,
-			listing_id: input.listingId,
-			forker_user_id: input.userId,
-			origin_commit: listing.pinnedCommit,
-			forked_package_id: packageId,
+			listing_id: prepared.listingId,
+			forker_user_id: prepared.userId,
+			origin_commit: prepared.originCommit,
+			forked_package_id: prepared.packageId,
 			forked_source_id: ensuredSource.id,
-			target_kody_id: targetKodyId,
-			listing_name: listing.name,
-			listing_kody_id: listing.kodyId,
-			actor: input.actor ?? null,
+			target_kody_id: prepared.targetKodyId,
+			listing_name: prepared.listingName,
+			listing_kody_id: prepared.listingKodyId,
+			actor: prepared.actor,
 		})
 		await enqueueRecordedCommunityActivity({
-			env: input.env,
+			env: prepared.env,
 			kind: 'fork',
 			activityId: forkId,
 		})
 
 		invalidateCommunityPublicCache()
+		logCommunityPhaseTiming({
+			phase: 'fork-persist',
+			durationMs: Date.now() - persistStartedAt,
+			listingId: prepared.listingId,
+			packageId: prepared.packageId,
+			filesCount: Object.keys(prepared.files).length,
+		})
 
 		return {
 			forkId,
-			packageId,
+			packageId: prepared.packageId,
 			sourceId: ensuredSource.id,
-			targetKodyId,
-			targetName: rewrittenManifest.targetName,
-			originCommit: listing.pinnedCommit,
-			crossScopeReferences,
-			filesCount: Object.keys(rewrittenFiles).length,
-			files: rewrittenFiles,
+			targetKodyId: prepared.targetKodyId,
+			targetName: prepared.targetName,
+			originCommit: prepared.originCommit,
+			crossScopeReferences: prepared.crossScopeReferences,
+			filesCount: Object.keys(prepared.files).length,
+			files: prepared.files,
 		}
 	} catch (error) {
 		await cleanupFailedCommunityFork({
-			env: input.env,
-			userId: input.userId,
+			env: prepared.env,
+			userId: prepared.userId,
 			sourceId: ensuredSource.id,
-			packageId,
+			packageId: prepared.packageId,
 		})
 		throw error
 	}
+}
+
+export async function forkCommunityListing(
+	input: PrepareCommunityForkInput,
+): Promise<ForkCommunityListingResult> {
+	const prepared = await prepareCommunityFork(input)
+	return await persistPreparedCommunityFork(prepared)
 }
 
 export type AdoptCommunityForkResult = {

--- a/packages/worker/src/package-registry/service.node.test.ts
+++ b/packages/worker/src/package-registry/service.node.test.ts
@@ -42,6 +42,7 @@ const mockModule = vi.hoisted(() => ({
 	listJobRowsByUserId: vi.fn(),
 	loadPackageManifestBySourceId: vi.fn(),
 	loadPackageSourceBySourceId: vi.fn(),
+	loadPackageSourceFromFiles: vi.fn(),
 	packageServiceRpc: vi.fn(),
 	syncJobManagerAlarm: vi.fn(),
 	syncPackageJobsForPackage: vi.fn(),
@@ -131,6 +132,8 @@ vi.mock('./source.ts', () => ({
 		mockModule.loadPackageManifestBySourceId(...args),
 	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
 		mockModule.loadPackageSourceBySourceId(...args),
+	loadPackageSourceFromFiles: (...args: Array<unknown>) =>
+		mockModule.loadPackageSourceFromFiles(...args),
 }))
 
 vi.mock('./vectorize.ts', () => ({
@@ -252,6 +255,7 @@ function setupDefaultMocks() {
 	mockModule.clearStorage.mockReset()
 	mockModule.clearStorage.mockResolvedValue({ ok: true as const })
 	mockModule.listJobRowsByUserId.mockResolvedValue([])
+	mockModule.loadPackageSourceFromFiles.mockReset()
 }
 
 test('refreshSavedPackageProjection defers search-index upsert and retriever cache via waitUntil', async () => {
@@ -307,6 +311,60 @@ test('refreshSavedPackageProjection defers search-index upsert and retriever cac
 	expect(waitUntilPromises.length).toBeGreaterThanOrEqual(1)
 	await Promise.all(waitUntilPromises)
 	expect(mockModule.refreshPackageRetrieverManifestCache).toHaveBeenCalled()
+})
+
+test('refreshSavedPackageProjection uses caller-supplied source files instead of reloading KV', async () => {
+	setupDefaultMocks()
+	const env = createEnv()
+	const sourceFiles = {
+		'package.json': '{"name":"@kentcdodds/shade-automation"}',
+		'src/index.ts': 'export default async function main() {}',
+	}
+	mockModule.loadPackageSourceFromFiles.mockResolvedValue({
+		manifest: {
+			name: '@kentcdodds/shade-automation',
+			kody: {
+				id: 'shade-automation',
+				description: 'Shade automation package',
+				tags: ['home'],
+			},
+		},
+		files: sourceFiles,
+		source: { id: 'source-1' },
+	})
+	mockModule.getSavedPackageById.mockResolvedValue({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/shade-automation',
+		kodyId: 'shade-automation',
+		description: 'Old description',
+		tags: ['home'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		createdAt: '2026-04-20T00:00:00.000Z',
+		updatedAt: '2026-04-20T00:00:00.000Z',
+	})
+
+	await refreshSavedPackageProjection({
+		env,
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-1',
+		packageId: 'package-1',
+		sourceId: 'source-1',
+		sourceFiles,
+	})
+
+	expect(mockModule.loadPackageSourceFromFiles).toHaveBeenCalledWith({
+		env,
+		userId: 'user-1',
+		sourceId: 'source-1',
+		files: sourceFiles,
+	})
+	expect(mockModule.loadPackageSourceBySourceId).not.toHaveBeenCalled()
+	expect(mockModule.buildPublishedPackageArtifacts).toHaveBeenCalled()
 })
 
 test('refreshSavedPackageProjection syncs the job manager only when package jobs change', async () => {

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -18,6 +18,7 @@ import {
 import {
 	loadPackageManifestBySourceId,
 	loadPackageSourceBySourceId,
+	loadPackageSourceFromFiles,
 } from './source.ts'
 import {
 	type AuthoredPackageJson,
@@ -220,6 +221,11 @@ export async function refreshSavedPackageProjection(input: {
 	packageId: string
 	sourceId: string
 	rebuildArtifacts?: boolean
+	/**
+	 * When the caller already holds the published file set (one-click install
+	 * just forked these into the source), skip the KV/Artifacts reload.
+	 */
+	sourceFiles?: Record<string, string>
 	waitUntil?: (promise: Promise<unknown>) => void
 }) {
 	return await withAccountWriteLease({
@@ -228,19 +234,26 @@ export async function refreshSavedPackageProjection(input: {
 		env: input.env,
 		async write() {
 			const shouldRebuildArtifacts = input.rebuildArtifacts ?? true
-			const loaded = shouldRebuildArtifacts
-				? await loadPackageSourceBySourceId({
+			const loaded = input.sourceFiles
+				? await loadPackageSourceFromFiles({
 						env: input.env,
-						baseUrl: input.baseUrl,
 						userId: input.userId,
 						sourceId: input.sourceId,
+						files: input.sourceFiles,
 					})
-				: await loadPackageManifestBySourceId({
-						env: input.env,
-						baseUrl: input.baseUrl,
-						userId: input.userId,
-						sourceId: input.sourceId,
-					})
+				: shouldRebuildArtifacts
+					? await loadPackageSourceBySourceId({
+							env: input.env,
+							baseUrl: input.baseUrl,
+							userId: input.userId,
+							sourceId: input.sourceId,
+						})
+					: await loadPackageManifestBySourceId({
+							env: input.env,
+							baseUrl: input.baseUrl,
+							userId: input.userId,
+							sourceId: input.sourceId,
+						})
 			const row = toSavedPackageInsertRow({
 				packageId: input.packageId,
 				userId: input.userId,
@@ -341,10 +354,10 @@ export async function refreshSavedPackageProjection(input: {
 				createdAt: existing?.createdAt ?? refreshedAt,
 				updatedAt: refreshedAt,
 			} satisfies SavedPackageRecord
-			const loadedFiles: Record<string, string> | null =
-				shouldRebuildArtifacts && 'files' in loaded
-					? (loaded.files as Record<string, string>)
-					: null
+			const loadedFiles: Record<string, string> | null = shouldRebuildArtifacts
+				? (input.sourceFiles ??
+					('files' in loaded ? (loaded.files as Record<string, string>) : null))
+				: null
 			if (loadedFiles) {
 				// Artifacts stay on the hot path: invoke needs them immediately
 				// and there is no safe cold-build substitute for a fresh publish.

--- a/packages/worker/src/package-registry/source.node.test.ts
+++ b/packages/worker/src/package-registry/source.node.test.ts
@@ -22,8 +22,11 @@ vi.mock('#worker/repo/published-source.ts', () => ({
 		mockModule.loadPublishedEntityManifest(...args),
 }))
 
-const { loadPackageSourceBySourceId, loadPackageManifestBySourceId } =
-	await import('./source.ts')
+const {
+	loadPackageSourceBySourceId,
+	loadPackageManifestBySourceId,
+	loadPackageSourceFromFiles,
+} = await import('./source.ts')
 
 function createPackageSourceRow(input: {
 	id: string
@@ -439,4 +442,37 @@ test('loadPackageManifestBySourceId retries transient D1 export errors on the so
 
 	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(2)
 	expect(mockModule.loadPublishedEntityManifest).toHaveBeenCalledTimes(1)
+})
+
+test('loadPackageSourceFromFiles parses the caller file set without reading KV', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.loadPublishedEntitySource.mockReset()
+	mockModule.getEntitySourceById.mockResolvedValue(
+		createPackageSourceRow({
+			id: 'source-from-files',
+			publishedCommit: 'commit-fork-1',
+		}),
+	)
+	const files = {
+		'package.json': JSON.stringify({
+			name: '@kentcdodds/example-package',
+			exports: { '.': './index.js' },
+			kody: {
+				id: 'example-package',
+				description: 'Example package',
+			},
+		}),
+		'index.js': 'export default async function main() { return "ok" }\n',
+	}
+
+	const loaded = await loadPackageSourceFromFiles({
+		env: { APP_DB: {} } as Env,
+		userId: 'user-1',
+		sourceId: 'source-from-files',
+		files,
+	})
+
+	expect(loaded.files).toEqual(files)
+	expect(loaded.manifest.kody.id).toBe('example-package')
+	expect(mockModule.loadPublishedEntitySource).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/package-registry/source.node.test.ts
+++ b/packages/worker/src/package-registry/source.node.test.ts
@@ -476,3 +476,31 @@ test('loadPackageSourceFromFiles parses the caller file set without reading KV',
 	expect(loaded.manifest.kody.id).toBe('example-package')
 	expect(mockModule.loadPublishedEntitySource).not.toHaveBeenCalled()
 })
+
+test('loadPackageSourceFromFiles rejects a source owned by another user', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		...createPackageSourceRow({
+			id: 'source-from-files',
+			publishedCommit: 'commit-fork-1',
+		}),
+		user_id: 'user-2',
+	})
+	await expect(
+		loadPackageSourceFromFiles({
+			env: { APP_DB: {} } as Env,
+			userId: 'user-1',
+			sourceId: 'source-from-files',
+			files: {
+				'package.json': JSON.stringify({
+					name: '@kentcdodds/example-package',
+					exports: { '.': './index.js' },
+					kody: {
+						id: 'example-package',
+						description: 'Example package',
+					},
+				}),
+			},
+		}),
+	).rejects.toThrow('was not found')
+})

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -150,6 +150,30 @@ async function loadPackageSourceUncached(input: {
 	})
 }
 
+export async function loadPackageSourceFromFiles(input: {
+	env: Env
+	userId: string
+	sourceId: string
+	files: Record<string, string>
+}): Promise<LoadedPackageSource> {
+	const source = await loadPackageSourceRowForUser({
+		env: input.env,
+		userId: input.userId,
+		sourceId: input.sourceId,
+	})
+	return finalizeLoadedSource({
+		source,
+		manifest: parsePackageManifest({
+			source,
+			content: getManifestContent({
+				source,
+				files: input.files,
+			}),
+		}),
+		files: input.files,
+	})
+}
+
 export async function loadPackageSourceBySourceId(input: {
 	env: Env
 	baseUrl: string

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.node.test.ts
@@ -619,3 +619,106 @@ test('rebuildPublishedPackageArtifacts uses builder dependency metadata instead 
 		),
 	).toEqual(['[]', '[]'])
 })
+
+test('rebuildPublishedPackageArtifacts overlaps a bounded number of target builds', async () => {
+	mockModule.getPublishedBundleArtifactByIdentity.mockReset()
+	mockModule.insertPublishedBundleArtifactRow.mockReset()
+	mockModule.writePublishedBundleArtifact.mockReset()
+	mockModule.getPublishedBundleArtifactByIdentity.mockResolvedValue(null)
+	mockModule.writePublishedBundleArtifact.mockResolvedValue('kv:key')
+	mockModule.insertPublishedBundleArtifactRow.mockResolvedValue(undefined)
+
+	let resolveGate: (() => void) | undefined
+	const gate = new Promise<void>((resolve) => {
+		resolveGate = resolve
+	})
+	let inFlight = 0
+	let maxInFlight = 0
+	const track = async (entryPoint: string, prefix: string) => {
+		inFlight += 1
+		maxInFlight = Math.max(maxInFlight, inFlight)
+		await gate
+		inFlight -= 1
+		return {
+			mainModule: `dist/${prefix}${entryPoint.replaceAll('/', '_')}.js`,
+			modules: {
+				[`dist/${prefix}${entryPoint.replaceAll('/', '_')}.js`]:
+					'export default async function run() { return "ok" }',
+			},
+			dependencies: [],
+		}
+	}
+	const buildAppBundle = vi.fn()
+	const buildModuleBundle = vi.fn(
+		async ({ entryPoint }: { entryPoint: string }) => track(entryPoint, ''),
+	)
+	const buildImportableModuleBundle = vi.fn(
+		async ({ entryPoint }: { entryPoint: string }) =>
+			track(entryPoint, 'importable_'),
+	)
+
+	const rebuildPromise = rebuildPublishedPackageArtifacts({
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {
+				get: async () => null,
+				put: async () => undefined,
+				delete: async () => undefined,
+			},
+		} as unknown as Env,
+		userId: 'user-1',
+		source: {
+			id: 'source-1',
+			user_id: 'user-1',
+			entity_kind: 'package',
+			entity_id: 'pkg-1',
+			repo_id: 'repo-1',
+			published_commit: 'commit-1',
+			indexed_commit: null,
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-04-30T00:00:00.000Z',
+			updated_at: '2026-04-30T00:00:00.000Z',
+		},
+		savedPackage: {
+			id: 'pkg-1',
+			userId: 'user-1',
+			name: '@kentcdodds/multi-export',
+			kodyId: 'multi-export',
+			description: 'Multi-export package',
+			tags: [],
+			searchText: null,
+			sourceId: 'source-1',
+			hasApp: false,
+			hidden: false,
+			isPrivate: false,
+			createdAt: '2026-04-30T00:00:00.000Z',
+			updatedAt: '2026-04-30T00:00:00.000Z',
+		},
+		manifest: {
+			name: '@kentcdodds/multi-export',
+			exports: {
+				'.': './src/index.ts',
+				'./hello': './src/hello.ts',
+			},
+			kody: {
+				id: 'multi-export',
+				description: 'Multi-export package',
+			},
+		},
+		buildAppBundle,
+		buildModuleBundle,
+		buildImportableModuleBundle,
+	})
+
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (maxInFlight >= 2) break
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	}
+	expect(maxInFlight).toBeGreaterThanOrEqual(2)
+	expect(maxInFlight).toBeLessThanOrEqual(2)
+	resolveGate?.()
+	await rebuildPromise
+	expect(buildModuleBundle).toHaveBeenCalledTimes(2)
+	expect(buildImportableModuleBundle).toHaveBeenCalledTimes(2)
+})

--- a/packages/worker/src/package-runtime/published-bundle-artifacts.ts
+++ b/packages/worker/src/package-runtime/published-bundle-artifacts.ts
@@ -317,6 +317,34 @@ export async function persistPublishedPackageArtifactTarget(
 	})
 }
 
+/**
+ * Cap concurrent esbuild-wasm rebuilds so a many-export package cannot stack
+ * isolate heap the way fully sequential rebuilds used to stretch wall time.
+ * Two at a time cuts typical 4-target publishes roughly in half without
+ * reopening the session-DO memory failure in kentcdodds/kody#987.
+ */
+const publishedPackageArtifactRebuildConcurrency = 2
+
+async function mapWithConcurrency<T>(
+	items: ReadonlyArray<T>,
+	concurrency: number,
+	mapper: (item: T) => Promise<void>,
+) {
+	if (items.length === 0) return
+	const limit = Math.max(1, Math.min(concurrency, items.length))
+	let nextIndex = 0
+	async function worker() {
+		while (nextIndex < items.length) {
+			const index = nextIndex
+			nextIndex += 1
+			const item = items[index]
+			if (item === undefined) return
+			await mapper(item)
+		}
+	}
+	await Promise.all(Array.from({ length: limit }, () => worker()))
+}
+
 export async function rebuildPublishedPackageArtifacts(
 	input: {
 		env: Env
@@ -326,18 +354,22 @@ export async function rebuildPublishedPackageArtifacts(
 		manifest: AuthoredPackageJson
 	} & PublishedPackageArtifactBuilders,
 ) {
-	for (const target of collectPublishedPackageArtifactTargets(input.manifest)) {
-		await persistPublishedPackageArtifactTarget({
-			env: input.env,
-			userId: input.userId,
-			source: input.source,
-			savedPackage: input.savedPackage,
-			target,
-			buildAppBundle: input.buildAppBundle,
-			buildModuleBundle: input.buildModuleBundle,
-			buildImportableModuleBundle: input.buildImportableModuleBundle,
-		})
-	}
+	await mapWithConcurrency(
+		collectPublishedPackageArtifactTargets(input.manifest),
+		publishedPackageArtifactRebuildConcurrency,
+		async (target) => {
+			await persistPublishedPackageArtifactTarget({
+				env: input.env,
+				userId: input.userId,
+				source: input.source,
+				savedPackage: input.savedPackage,
+				target,
+				buildAppBundle: input.buildAppBundle,
+				buildModuleBundle: input.buildModuleBundle,
+				buildImportableModuleBundle: input.buildImportableModuleBundle,
+			})
+		},
+	)
 }
 
 export async function deletePublishedArtifactsForSource(input: {

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -1631,9 +1631,14 @@ test('heavy check phases run in throwaway isolates when the env has the bindings
 	mockModule.createFileSystemSnapshot.mockResolvedValue(snapshot)
 
 	const phaseRequests: Array<Record<string, unknown>> = []
+	let resolveGate: (() => void) | undefined
+	const gate = new Promise<void>((resolve) => {
+		resolveGate = resolve
+	})
 	const stub = {
 		runIsolatedCheckPhase: vi.fn(async (request: Record<string, unknown>) => {
 			phaseRequests.push(request)
+			await gate
 			return request.phase === 'typecheck'
 				? { ok: true, message: 'No semantic diagnostics (isolated).' }
 				: { ok: true, message: 'chunk ok' }
@@ -1652,7 +1657,7 @@ test('heavy check phases run in throwaway isolates when the env has the bindings
 		BUNDLE_ARTIFACTS_KV: kv,
 	} as unknown as Env
 
-	const result = await runRepoChecks({
+	const resultPromise = runRepoChecks({
 		workspace: {
 			async readFile(path: string) {
 				return files.get(path) ?? null
@@ -1667,6 +1672,36 @@ test('heavy check phases run in throwaway isolates when the env has the bindings
 		baseUrl: '/',
 		userId: 'user-123',
 	})
+
+	// Wait until typecheck and every bundle chunk have started while the
+	// gate is still closed — proves isolated phases fan out, not sequence.
+	let stableCallCount = 0
+	let stableTicks = 0
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		const callCount = stub.runIsolatedCheckPhase.mock.calls.length
+		const phases = phaseRequests.map((request) => request.phase)
+		const hasTypecheck = phases.includes('typecheck')
+		const hasBundle = phases.includes('bundle-chunk')
+		if (hasTypecheck && hasBundle && callCount === stableCallCount) {
+			stableTicks += 1
+			if (stableTicks >= 3) break
+		} else {
+			stableCallCount = callCount
+			stableTicks = 0
+		}
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	}
+	expect(phaseRequests.some((request) => request.phase === 'typecheck')).toBe(
+		true,
+	)
+	expect(
+		phaseRequests.some((request) => request.phase === 'bundle-chunk'),
+	).toBe(true)
+	const startedPhaseCount = stub.runIsolatedCheckPhase.mock.calls.length
+	expect(startedPhaseCount).toBeGreaterThan(1)
+	resolveGate?.()
+	const result = await resultPromise
+	expect(stub.runIsolatedCheckPhase.mock.calls.length).toBe(startedPhaseCount)
 
 	expect(result.ok).toBe(true)
 	// The staged snapshot is written once with a TTL and cleaned up after.

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -33,7 +33,10 @@ import {
 	repoChecksSourceMaxTotalBytes,
 	runRepoChecks,
 } from './checks.ts'
-import { isolatedBundleChunkSize } from './isolated-check-phases.ts'
+import {
+	isolatedBundleChunkConcurrency,
+	isolatedBundleChunkSize,
+} from './isolated-check-phases.ts'
 import { maxRepoSourceFileBytes } from './large-file-policy.ts'
 
 type MockSnapshot = {
@@ -1635,10 +1638,22 @@ test('heavy check phases run in throwaway isolates when the env has the bindings
 	const gate = new Promise<void>((resolve) => {
 		resolveGate = resolve
 	})
+	let bundleChunksInFlight = 0
+	let maxBundleChunksInFlight = 0
 	const stub = {
 		runIsolatedCheckPhase: vi.fn(async (request: Record<string, unknown>) => {
 			phaseRequests.push(request)
+			if (request.phase === 'bundle-chunk') {
+				bundleChunksInFlight += 1
+				maxBundleChunksInFlight = Math.max(
+					maxBundleChunksInFlight,
+					bundleChunksInFlight,
+				)
+			}
 			await gate
+			if (request.phase === 'bundle-chunk') {
+				bundleChunksInFlight -= 1
+			}
 			return request.phase === 'typecheck'
 				? { ok: true, message: 'No semantic diagnostics (isolated).' }
 				: { ok: true, message: 'chunk ok' }
@@ -1673,8 +1688,9 @@ test('heavy check phases run in throwaway isolates when the env has the bindings
 		userId: 'user-123',
 	})
 
-	// Wait until typecheck and every bundle chunk have started while the
+	// Wait until typecheck and the first bundle chunks have started while the
 	// gate is still closed — proves isolated phases fan out, not sequence.
+	// Remaining chunks stay queued until a slot frees (concurrency cap).
 	let stableCallCount = 0
 	let stableTicks = 0
 	for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -1699,9 +1715,21 @@ test('heavy check phases run in throwaway isolates when the env has the bindings
 	).toBe(true)
 	const startedPhaseCount = stub.runIsolatedCheckPhase.mock.calls.length
 	expect(startedPhaseCount).toBeGreaterThan(1)
+	expect(startedPhaseCount).toBeLessThanOrEqual(
+		1 + isolatedBundleChunkConcurrency,
+	)
+	expect(maxBundleChunksInFlight).toBeGreaterThanOrEqual(1)
+	expect(maxBundleChunksInFlight).toBeLessThanOrEqual(
+		isolatedBundleChunkConcurrency,
+	)
 	resolveGate?.()
 	const result = await resultPromise
-	expect(stub.runIsolatedCheckPhase.mock.calls.length).toBe(startedPhaseCount)
+	expect(stub.runIsolatedCheckPhase.mock.calls.length).toBeGreaterThan(
+		startedPhaseCount,
+	)
+	expect(maxBundleChunksInFlight).toBeLessThanOrEqual(
+		isolatedBundleChunkConcurrency,
+	)
 
 	expect(result.ok).toBe(true)
 	// The staged snapshot is written once with a TTL and cleaned up after.

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1076,25 +1076,32 @@ async function runChunkedBundleValidation(input: {
 	userId: string
 	entryPoints: Array<PackageBundleTarget>
 }) {
-	const failures: Array<string> = []
+	const chunks: Array<Array<PackageBundleTarget>> = []
 	for (
 		let start = 0;
 		start < input.entryPoints.length;
 		start += isolatedBundleChunkSize
 	) {
-		const chunk = input.entryPoints.slice(
-			start,
-			start + isolatedBundleChunkSize,
+		chunks.push(
+			input.entryPoints.slice(start, start + isolatedBundleChunkSize),
 		)
-		const outcome = await input.runner.run({
-			phase: 'bundle-chunk',
-			stagingKey: input.stagingKey,
-			baseUrl: input.baseUrl,
-			userId: input.userId,
-			bundleTargets: chunk,
-		})
-		if (!outcome.ok) failures.push(outcome.message)
 	}
+	// Each chunk runs in its own throwaway isolate, so fan-out is safe and
+	// cuts wall time for multi-export packages (community install / publish).
+	const outcomes = await Promise.all(
+		chunks.map((bundleTargets) =>
+			input.runner.run({
+				phase: 'bundle-chunk',
+				stagingKey: input.stagingKey,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				bundleTargets,
+			}),
+		),
+	)
+	const failures = outcomes
+		.filter((outcome) => !outcome.ok)
+		.map((outcome) => outcome.message)
 	return {
 		ok: failures.length === 0,
 		message:
@@ -1313,7 +1320,7 @@ export async function runRepoChecks(input: {
 	let typecheckResult: RepoCheckResult
 	let bundleCheckResult: { ok: boolean; message: string }
 	try {
-		typecheckResult = await (async (): Promise<RepoCheckResult> => {
+		const runTypecheckPhase = async (): Promise<RepoCheckResult> => {
 			if (missingCallableTypecheckTargets.length > 0) {
 				return {
 					kind: 'typecheck',
@@ -1357,38 +1364,60 @@ export async function runRepoChecks(input: {
 							targets: callableTypecheckTargets,
 						})
 			return { kind: 'typecheck', ...outcome }
-		})()
+		}
 
-		bundleCheckResult =
-			missingBundleTargets.length > 0
-				? {
-						ok: false,
-						message: formatBundleCheckMessage({
-							missingEntryPoints: missingBundleTargets,
-							targetCount: bundleTargets.length,
-						}),
-					}
-				: bundleContext
-					? isolatedRunner && stagingKey
-						? await runChunkedBundleValidation({
-								runner: isolatedRunner,
-								stagingKey,
-								baseUrl: bundleContext.baseUrl,
-								userId: bundleContext.userId,
-								entryPoints: bundleTargets,
-							})
-						: await validatePackageBundles({
-								...bundleContext,
-								sourceFiles,
-								entryPoints: bundleTargets,
-							})
-					: {
-							ok: true,
-							message: formatBundleCheckMessage({
-								missingEntryPoints: missingBundleTargets,
-								targetCount: bundleTargets.length,
-							}),
-						}
+		const runBundlePhase = async (): Promise<{
+			ok: boolean
+			message: string
+		}> => {
+			if (missingBundleTargets.length > 0) {
+				return {
+					ok: false,
+					message: formatBundleCheckMessage({
+						missingEntryPoints: missingBundleTargets,
+						targetCount: bundleTargets.length,
+					}),
+				}
+			}
+			if (!bundleContext) {
+				return {
+					ok: true,
+					message: formatBundleCheckMessage({
+						missingEntryPoints: missingBundleTargets,
+						targetCount: bundleTargets.length,
+					}),
+				}
+			}
+			if (isolatedRunner && stagingKey) {
+				return await runChunkedBundleValidation({
+					runner: isolatedRunner,
+					stagingKey,
+					baseUrl: bundleContext.baseUrl,
+					userId: bundleContext.userId,
+					entryPoints: bundleTargets,
+				})
+			}
+			return await validatePackageBundles({
+				...bundleContext,
+				sourceFiles,
+				entryPoints: bundleTargets,
+			})
+		}
+
+		// Isolated phases use separate throwaway isolates, so overlapping them
+		// (and overlapping bundle chunks) does not stack DO heap the way the
+		// inline fallback would. Keep the inline path sequential: typecheck
+		// first so its disposable heap never sits on top of resident
+		// esbuild-wasm memory.
+		if (isolatedRunner && stagingKey) {
+			;[typecheckResult, bundleCheckResult] = await Promise.all([
+				runTypecheckPhase(),
+				runBundlePhase(),
+			])
+		} else {
+			typecheckResult = await runTypecheckPhase()
+			bundleCheckResult = await runBundlePhase()
+		}
 	} finally {
 		if (isolatedRunner && stagingKey) {
 			await isolatedRunner.discard(stagingKey)

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1082,9 +1082,7 @@ async function runChunkedBundleValidation(input: {
 		start < input.entryPoints.length;
 		start += isolatedBundleChunkSize
 	) {
-		chunks.push(
-			input.entryPoints.slice(start, start + isolatedBundleChunkSize),
-		)
+		chunks.push(input.entryPoints.slice(start, start + isolatedBundleChunkSize))
 	}
 	// Each chunk runs in its own throwaway isolate, so fan-out is safe and
 	// cuts wall time for multi-export packages (community install / publish).

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -44,6 +44,7 @@ import {
 } from './repo-kody-execution.ts'
 import {
 	createIsolatedCheckPhaseRunner,
+	isolatedBundleChunkConcurrency,
 	isolatedBundleChunkSize,
 	type IsolatedCheckPhaseRunner,
 } from './isolated-check-phases.ts'
@@ -1069,6 +1070,34 @@ export async function runPackageTypecheckLanguageService(input: {
 	}
 }
 
+async function mapPool<T, R>(
+	items: ReadonlyArray<T>,
+	concurrency: number,
+	mapper: (item: T) => Promise<R>,
+): Promise<Array<R>> {
+	if (items.length === 0) return []
+	const limit = Math.max(1, Math.min(concurrency, items.length))
+	const results: Array<R> = []
+	let nextIndex = 0
+	let firstError: unknown
+	async function worker() {
+		while (nextIndex < items.length) {
+			const index = nextIndex
+			nextIndex += 1
+			const item = items[index]
+			if (item === undefined) return
+			try {
+				results[index] = await mapper(item)
+			} catch (error) {
+				firstError ??= error
+			}
+		}
+	}
+	await Promise.all(Array.from({ length: limit }, () => worker()))
+	if (firstError !== undefined) throw firstError
+	return results
+}
+
 async function runChunkedBundleValidation(input: {
 	runner: IsolatedCheckPhaseRunner
 	stagingKey: string
@@ -1084,10 +1113,13 @@ async function runChunkedBundleValidation(input: {
 	) {
 		chunks.push(input.entryPoints.slice(start, start + isolatedBundleChunkSize))
 	}
-	// Each chunk runs in its own throwaway isolate, so fan-out is safe and
-	// cuts wall time for multi-export packages (community install / publish).
-	const outcomes = await Promise.all(
-		chunks.map((bundleTargets) =>
+	// Each chunk runs in its own throwaway isolate. Cap how many of those
+	// isolates one check request starts together so a many-export package
+	// cannot stampede Durable Object capacity.
+	const outcomes = await mapPool(
+		chunks,
+		isolatedBundleChunkConcurrency,
+		(bundleTargets) =>
 			input.runner.run({
 				phase: 'bundle-chunk',
 				stagingKey: input.stagingKey,
@@ -1095,7 +1127,6 @@ async function runChunkedBundleValidation(input: {
 				userId: input.userId,
 				bundleTargets,
 			}),
-		),
 	)
 	const failures = outcomes
 		.filter((outcome) => !outcome.ok)
@@ -1408,10 +1439,20 @@ export async function runRepoChecks(input: {
 		// first so its disposable heap never sits on top of resident
 		// esbuild-wasm memory.
 		if (isolatedRunner && stagingKey) {
-			;[typecheckResult, bundleCheckResult] = await Promise.all([
-				runTypecheckPhase(),
-				runBundlePhase(),
+			const typecheckPromise = runTypecheckPhase()
+			const bundlePromise = runBundlePhase()
+			const [typecheckSettled, bundleSettled] = await Promise.allSettled([
+				typecheckPromise,
+				bundlePromise,
 			])
+			if (typecheckSettled.status === 'rejected') {
+				throw typecheckSettled.reason
+			}
+			if (bundleSettled.status === 'rejected') {
+				throw bundleSettled.reason
+			}
+			typecheckResult = typecheckSettled.value
+			bundleCheckResult = bundleSettled.value
 		} else {
 			typecheckResult = await runTypecheckPhase()
 			bundleCheckResult = await runBundlePhase()

--- a/packages/worker/src/repo/isolated-check-phases.ts
+++ b/packages/worker/src/repo/isolated-check-phases.ts
@@ -35,6 +35,12 @@ const stagingTtlSeconds = 15 * 60
  * fan-out modest for typical packages.
  */
 export const isolatedBundleChunkSize = 4
+/**
+ * Max throwaway isolates running bundle chunks at once. Chunk size bounds
+ * work *inside* one isolate; this bounds how many of those isolates a single
+ * check request may start together.
+ */
+export const isolatedBundleChunkConcurrency = 2
 
 export type IsolatedCheckPhaseRequest =
 	| {

--- a/packages/worker/src/repo/isolated-check-phases.ts
+++ b/packages/worker/src/repo/isolated-check-phases.ts
@@ -15,6 +15,8 @@ import {
  *
  * - phases never stack their peak memory on top of the session isolate or
  *   each other (esbuild-wasm memory in particular never shrinks once grown),
+ * - callers may overlap typecheck with bundle chunks (and overlap chunks with
+ *   each other) without stacking DO heap — `runRepoChecks` does this,
  * - a package too large for even a single phase surfaces as a failed check
  *   with an actionable message instead of an opaque isolate reset, and
  * - the throwaway instances never touch their own Durable Object storage, so


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated community fork / one-click install latency for onboarding starter packages. **Package size is not the dominant cost** — Artifacts repo bootstrap is a ~7s fixed floor even for a 3-file package. This PR lands the low-risk backend wins on the remaining critical path.

## Measured timings (production via Kody MCP, Kent account)

Temporary tiny package (`3` files, no npm deps) vs existing listings, **before** this PR:

| Path | Package | Files | Wall time |
| --- | --- | ---: | ---: |
| `community_fork` (inert) | tiny (temp) cold | 3 | **7.7s** |
| `community_fork` | tiny warm | 3 | **7.2s** |
| `community_fork` | `@kody/github` | 16 | **6.9s** |
| `community_fork` | `@kentcdodds/raycast` | 6 | **6.3s** |
| `package_save` (create tiny) | tiny | 3 | **10.3s** |
| Agent activate after fork | tiny | 3 | open **4.3s** + checks **5.0s** + publish **12.1s** ≈ **21.5s** |
| End-to-end agent fork→invoke | tiny | 3 | ≈ **29s** (+ invoke **0.4s**) |

Hypothesis check: smaller packages help only a little on fork itself. Fork wall time is dominated by `ensureEntitySource` + `syncArtifactSourceSnapshot` → RepoSession `bootstrapSource` (git init/write/push/note), not file count.

One-click install is fork persist + `runRepoChecks` + `refreshSavedPackageProjection`. Previously those ran strictly in series (~7s + ~5s + ~12s). This PR overlaps persist with checks and skips the KV reload on projection.

## Root causes and what landed

1. **Artifacts bootstrap fixed cost (~7s)** — still the floor for MCP `community_fork`. Snapshot-first / lazy-git is a larger design change (repos are the base primitive; ADR 0003) and is **not** in this PR.
2. **Install persist and checks were serial** — **fixed:** `prepareCommunityFork` then overlap persist with `runRepoChecks` so the ~5s checks hide under the ~7s bootstrap. Both sides **settle** before the install returns, so a checks throw cannot abandon an in-flight persist.
3. **Isolated check phases were sequential** — **fixed:** typecheck + bundle chunks fan out in throwaway isolates (inline path stays sequential for memory). Bundle-chunk isolates are capped at **2** concurrent, and sibling phases settle before staging discard.
4. **Projection reloaded KV then rebuilt artifacts serially** — **fixed:** pass `sourceFiles` from the fork; rebuild up to **2** published artifact targets at a time (4-target tiny publish was ~12s sequential).
5. **One-click install never passed `waitUntil`** — **fixed:** search-index upsert + retriever cache leave the response path.
6. **Fork preflight D1/KV reads were serial** — **fixed:** overlapped.
7. **Structured timing** — **fixed:** `community-phase-timing` JSON logs on prepare / persist / checks / projection.

## UX mitigations (separate from backend speed)

- Start fork/install, immediately show the copy-prompt / “agent next step” while the request finishes (current UI already fakes progress words).
- Prefer featured **tiny** starters so checks/publish stay small even though the fork floor remains ~7s.
- Optimistic “Installed — activating…” after the fork row exists, before projection finishes (invoke must still wait for artifacts).

## Follow-up (not in this PR)

Snapshot-first / lazy-git bootstrap: write the KV published snapshot + D1 fork row first; materialize Artifacts git on first `repo_open_session`. Biggest remaining win; higher risk against repo-as-base-primitive.

## Cleanup

Created temporary community listing + forks in Kent’s account for measurement; unpublished/deleted afterward. No `perf-fork-*` saved packages remain.

## Test plan

- [x] `npm run test:node --` focused suites: install, community-service, package-registry service/source, published-bundle-artifacts, checks, community-install handler
- [ ] CI green on `43b527ba` (Bugbot: settle install persist when overlapping checks throw)
- [ ] Manual: one-click install a featured/trusted listing; response should not wait on search-index upsert

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4e2f43a9` · **Head:** `43b527ba`

**Classification:** extends — community install overlaps persist with checks, projection can skip KV reload, isolated check phases and artifact rebuilds fan out with bounded concurrency. No new primitives. Fork stays inert until publish; trust/secret policy unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — parallel preflight; overlap persist+checks and settle both; `waitUntil` on install |
| `saved-packages` | assistant | extends — projection accepts in-memory `sourceFiles` |
| `repo-sessions` | runtime | extends — isolated typecheck/bundle in parallel; chunk isolates capped at 2; settle before discard |
| `bundle-artifacts-kv` | storage | extends — rebuild up to two published artifacts concurrently |

### System map

One-click install prepares the rewritten snapshot, then overlaps Artifacts bootstrap with publish checks before projecting from those same files.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	communityListings["community-listings<br/>Community package listings"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	bundleArtifactsKv["bundle-artifacts-kv<br/>Bundle artifacts KV"]:::extended
	communityListings -->|"prepare fork then persist ∥ checks"| repoSessions
	communityListings -->|"install waitUntil"| savedPackages
	savedPackages -->|"sourceFiles skip KV reload"| savedPackages
	savedPackages -->|"rebuild 2 artifact targets at a time"| bundleArtifactsKv
	repoSessions -->|"isolated typecheck ∥ capped bundle chunks"| repoSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant UI as Install UI
	participant H as community-install handler
	participant P as prepareCommunityFork
	participant S as persistPreparedCommunityFork
	participant C as runRepoChecks
	participant R as refreshSavedPackageProjection
	UI->>H: POST /community/:id/install.json
	H->>P: overlap ban+listing+snapshot+collisions
	P-->>H: rewritten files
	par Artifacts bootstrap
		H->>S: ensureEntitySource + git sync
	and Publish checks
		H->>C: isolated typecheck ∥ bundle (chunk cap 2)
	end
	Note over H,S: both sides settle before return
	H->>R: projection with sourceFiles + waitUntil
	R-->>UI: installed
```

### Invariants

- Fork remains inert until publish/install projection; no MCP install capability added.
- Untrusted install still requires acknowledgement; secret/adoption policy unchanged.
- Inline (non-isolated) checks stay sequential to avoid stacking esbuild-wasm heap.
- Isolated bundle-chunk throwaway isolates are capped at 2; sibling phases settle before staging KV discard.
- Install persist and checks both settle before the response, so a checks throw cannot abandon an in-flight fork.
- Artifact rebuild concurrency is capped at 2 for the same memory reason.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community installations now continue search-index and cache updates in the background after the installation response.
  * Installation progress includes clearer phase updates and timing information.

* **Performance**
  * Community setup, repository validation, and package artifact processing now run compatible tasks concurrently, reducing completion time.

* **Bug Fixes**
  * Projection refreshes use the prepared installation files for more consistent results.

* **Tests**
  * Expanded coverage verifies concurrency, deferred updates, installation failures, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->