### PR TITLE
fix(package-apps): take D1 and run-record begin off the warm fetch path

### DIFF
--- a/docs/contributing/architecture/invocation-overhead-guardrails.md
+++ b/docs/contributing/architecture/invocation-overhead-guardrails.md
@@ -28,14 +28,20 @@ call, not about what user code does inside the call.
   [Run records](./run-records.md)), so the durability cost is **one awaited DO
   call for claim + run-record begin and one for terminal response + run-record
   finish** — no D1 round trips at all.
+- **Package-app HTTP** (`servePackageAppRequest` / `app_fetch`) is the same
+  class of hot path as keyless invoke: a hello-world `fetch` that returns `ok`
+  should not pay tens of milliseconds of platform overhead on a warm isolate.
+  The serve path shares the invoke freshness/commit caches, and must not await
+  the run-record begin RPC before user `fetch`. Finish already upserts a
+  complete row, so a dropped `running` insert is harmless.
 
 ## Per-isolate caches and their staleness bounds
 
 The keyless `packages.invoke` contract check (saved-package row, entity-source
-row, manifest, bundle artifact) and per-run registry assembly are cached per
-isolate so a warm invoke of an already-warm package+commit performs **zero D1/KV
-loads** before dispatch. The caches come in two tiers with different correctness
-arguments (see
+row, manifest, bundle artifact) and package-app HTTP serve (saved-package row,
+entity-source row, manifest) are cached per isolate so a warm call of an
+already-warm package+commit performs **zero D1/KV loads** before dispatch. The
+caches come in two tiers with different correctness arguments (see
 `packages/worker/src/package-invocations/invoke-contract-cache.ts`):
 
 - **Freshness tier** — saved-package row and entity-source row (the row that
@@ -56,9 +62,10 @@ arguments (see
 Rules for touching these paths: publish and rebuild flows must keep using the
 uncached row/manifest loaders (`loadPackageManifestBySourceId`,
 `loadPackageSourceBySourceId`) so a rebuild can never run against a stale
-`published_commit`; every cache key must start with the owning `userId` (per
-user isolation is inviolable); and new caches on invocation paths need an
-explicit staleness bound documented here.
+`published_commit`; package-app HTTP serve must keep using the cached invoke
+loaders (`resolveSavedPackage`, `loadInvokeManifestBySourceId`); every cache key
+must start with the owning `userId` (per user isolation is inviolable); and new
+caches on invocation paths need an explicit staleness bound documented here.
 
 ## Watch the percentiles
 

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -117,7 +117,11 @@ Rules:
   fire-and-forgets `startRun` (optionally via `waitUntil`). It returns a handle
   that already carries a minted run id, `startedAt`, persistence mode, and the
   full context — or `null` when there is no user / no `RUN_LOG` binding /
-  missing context.
+  missing context. Callers that reach begin through a WorkerEntrypoint RPC
+  (package-app isolates: `packageRuntimeRunStart`) must not await that RPC on
+  the HTTP/realtime response path — kick it off, run user code, and `waitUntil`
+  begin-then-finish. A dropped `running` insert is still harmless because finish
+  upserts the terminal row.
 - **`finishRunRecord` awaits the complete-row upsert in one RPC** (`finishRun`),
   then replaces logs and enforces retention. A supplied `waitUntil` applies only
   to post-terminal observers such as `run.error.recorded`, never to the terminal

--- a/packages/worker/src/app/handlers/package-app.node.test.ts
+++ b/packages/worker/src/app/handlers/package-app.node.test.ts
@@ -25,7 +25,7 @@ const mockModule = vi.hoisted(() => ({
 	})),
 	redirectToLogin: vi.fn(() => new Response(null, { status: 302 })),
 	getAppBaseUrl: vi.fn(() => 'https://example.com'),
-	getSavedPackageByKodyId: vi.fn(async () => ({
+	resolveSavedPackage: vi.fn(async () => ({
 		id: 'package-1',
 		userId: 'user-1',
 		name: '@kody/example',
@@ -43,7 +43,7 @@ const mockModule = vi.hoisted(() => ({
 	loadPackageSourceBySourceId: vi.fn(async () => {
 		throw new Error('bundle failed')
 	}),
-	loadPackageManifestBySourceId: vi.fn(async () => {
+	loadInvokeManifestBySourceId: vi.fn(async () => {
 		throw new Error('manifest load failed')
 	}),
 	createPackageAppCallerContext: vi.fn(),
@@ -77,16 +77,16 @@ vi.mock('#worker/app-base-url.ts', () => ({
 	getAppBaseUrl: (...args: Array<unknown>) => mockModule.getAppBaseUrl(...args),
 }))
 
-vi.mock('#worker/package-registry/repo.ts', () => ({
-	getSavedPackageByKodyId: (...args: Array<unknown>) =>
-		mockModule.getSavedPackageByKodyId(...args),
-}))
-
 vi.mock('#worker/package-registry/source.ts', () => ({
 	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
 		mockModule.loadPackageSourceBySourceId(...args),
-	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
-		mockModule.loadPackageManifestBySourceId(...args),
+}))
+
+vi.mock('#worker/package-invocations/module-artifacts.ts', () => ({
+	resolveSavedPackage: (...args: Array<unknown>) =>
+		mockModule.resolveSavedPackage(...args),
+	loadInvokeManifestBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadInvokeManifestBySourceId(...args),
 }))
 
 vi.mock('#worker/package-runtime/package-app.ts', () => ({
@@ -199,7 +199,7 @@ test('handlePackageAppRequest does not report package entrypoint failures to Kod
 	resetMocks()
 	consoleError.mockImplementation(() => {})
 
-	mockModule.loadPackageManifestBySourceId.mockResolvedValueOnce({
+	mockModule.loadInvokeManifestBySourceId.mockResolvedValueOnce({
 		source: {
 			published_commit: 'commit-1',
 			manifest_path: 'package.json',
@@ -273,7 +273,7 @@ test('handlePackageAppRequest routes websocket package paths to realtime session
 test('handlePackageAppRequest forwards package code a request stripped of owner credentials', async () => {
 	resetMocks()
 
-	mockModule.loadPackageManifestBySourceId.mockResolvedValueOnce({
+	mockModule.loadInvokeManifestBySourceId.mockResolvedValueOnce({
 		source: {
 			published_commit: 'commit-1',
 			manifest_path: 'package.json',
@@ -336,5 +336,5 @@ test('handlePackageAppRequest returns not found when the URL username does not m
 	)
 
 	expect(response.status).toBe(404)
-	expect(mockModule.getSavedPackageByKodyId).not.toHaveBeenCalled()
+	expect(mockModule.resolveSavedPackage).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/capabilities/packages/package-app-fetch.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-app-fetch.ts
@@ -11,6 +11,7 @@ import {
 	packageScopeInputDescription,
 	resolvePackageOwnerContext,
 } from '#worker/package-registry/package-owner.ts'
+import { resolveSavedPackageWithFreshnessCache } from '#worker/package-invocations/invoke-contract-cache.ts'
 import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
@@ -258,15 +259,22 @@ async function resolveOwnedSavedPackage(input: {
 	packageId?: string
 	kodyId?: string
 }) {
-	if (input.packageId !== undefined) {
-		return await getSavedPackageById(input.db, {
-			userId: input.userId,
-			packageId: input.packageId,
-		})
-	}
-	return await getSavedPackageByKodyId(input.db, {
+	const packageIdOrKodyId = input.packageId ?? input.kodyId ?? ''
+	return await resolveSavedPackageWithFreshnessCache({
 		userId: input.userId,
-		kodyId: input.kodyId ?? '',
+		packageIdOrKodyId,
+		load: async () => {
+			if (input.packageId !== undefined) {
+				return await getSavedPackageById(input.db, {
+					userId: input.userId,
+					packageId: input.packageId,
+				})
+			}
+			return await getSavedPackageByKodyId(input.db, {
+				userId: input.userId,
+				kodyId: input.kodyId ?? '',
+			})
+		},
 	})
 }
 
@@ -366,6 +374,11 @@ export const packageAppFetchCapability = defineDomainCapability(
 			}
 			assertRequestBodyWithinLimit(args.body)
 
+			// Validate the path before any D1 lookup so traversal and encoding
+			// errors fail closed without warming the saved-package cache.
+			const restPath = normalizePackageAppFetchPath(args.path)
+			const restPathOnly = restPath.split(/[?#]/, 1)[0] || '/'
+
 			const owner = await resolvePackageOwnerContext(
 				ctx.env,
 				user,
@@ -396,11 +409,6 @@ export const packageAppFetchCapability = defineDomainCapability(
 				)
 			}
 
-			// The normalized path keeps any query string for the request URL; the
-			// package path's restPath is path-only (matching what URL parsing
-			// produced for browser requests).
-			const restPath = normalizePackageAppFetchPath(args.path)
-			const restPathOnly = restPath.split(/[?#]/, 1)[0] || '/'
 			const packageAppOrigin = getPackageAppBaseUrl({ env: ctx.env })
 			const hostedUrl = resolveHostedPackageAppUrl({
 				packageAppBaseUrl: packageAppOrigin,

--- a/packages/worker/src/package-invocations/invoke-contract-cache.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.ts
@@ -4,9 +4,9 @@ import { type PublishedBundleArtifact } from '#worker/package-runtime/published-
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 
 /**
- * Per-isolate caches for the `packages.invoke` contract check, so a warm
- * keyless invoke of an already-warm package+commit performs zero D1/KV loads
- * before dispatch (see
+ * Per-isolate caches for invocation hot paths (`packages.invoke` contract
+ * check and package-app HTTP serve), so a warm call of an already-warm
+ * package+commit performs zero D1/KV loads before dispatch (see
  * docs/contributing/architecture/invocation-overhead-guardrails.md).
  *
  * Two tiers with different lifetimes:

--- a/packages/worker/src/package-invocations/module-artifacts.ts
+++ b/packages/worker/src/package-invocations/module-artifacts.ts
@@ -63,7 +63,8 @@ export async function resolveSavedPackage(input: {
  * contract cache, and the manifest itself from the commit-keyed manifest
  * cache. Warm calls perform zero D1/KV loads. Publish and rebuild flows must
  * keep using `loadPackageManifestBySourceId`, which always reads the row
- * fresh.
+ * fresh. Package-app HTTP serve is an invocation hot path and uses this
+ * loader; do not switch it back to the uncached source-row read.
  */
 export async function loadInvokeManifestBySourceId(input: {
 	env: Env

--- a/packages/worker/src/package-runtime/package-app-serve.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app-serve.node.test.ts
@@ -1,0 +1,185 @@
+import { expect, test, vi } from 'vitest'
+import { servePackageAppRequest } from './package-app-serve.ts'
+
+const mockModule = vi.hoisted(() => ({
+	getSavedPackageById: vi.fn(),
+	getSavedPackageByKodyId: vi.fn(),
+	getEntitySourceById: vi.fn(),
+	loadPublishedEntityManifest: vi.fn(),
+	buildPackageAppWorker: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	getSavedPackageById: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageById(...args),
+	getSavedPackageByKodyId: (...args: Array<unknown>) =>
+		mockModule.getSavedPackageByKodyId(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceById: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceById(...args),
+}))
+
+vi.mock('#worker/repo/published-source.ts', () => ({
+	loadPublishedEntityManifest: (...args: Array<unknown>) =>
+		mockModule.loadPublishedEntityManifest(...args),
+	loadPublishedEntitySource: vi.fn(),
+}))
+
+vi.mock('#worker/package-runtime/package-app.ts', () => ({
+	createPackageAppCallerContext: async (input: {
+		user: { userId: string; email: string; displayName: string }
+	}) => ({
+		user: input.user,
+	}),
+	buildPackageAppWorker: (...args: Array<unknown>) =>
+		mockModule.buildPackageAppWorker(...args),
+}))
+
+const serveLoadMocks = [
+	['saved package by id (D1)', mockModule.getSavedPackageById],
+	['saved package by kody id (D1)', mockModule.getSavedPackageByKodyId],
+	['entity source row (D1)', mockModule.getEntitySourceById],
+	['published manifest snapshot (KV)', mockModule.loadPublishedEntityManifest],
+] as const
+
+function countServeLoads() {
+	return Object.fromEntries(
+		serveLoadMocks.map(([label, mock]) => [label, mock.mock.calls.length]),
+	)
+}
+
+function clearServeLoadCounters() {
+	for (const [, mock] of serveLoadMocks) {
+		mock.mockClear()
+	}
+}
+
+function createFixture() {
+	const sourceId = 'source-perf-app'
+	const savedPackage = {
+		id: 'pkg-perf-app',
+		userId: 'user-1',
+		name: '@kentcdodds/perf-app',
+		kodyId: 'perf-app',
+		description: 'Minimal hello-world app',
+		tags: [],
+		searchText: null,
+		sourceId,
+		hasApp: true,
+		hidden: true,
+		isPrivate: true,
+		createdAt: '2026-08-12T00:00:00.000Z',
+		updatedAt: '2026-08-12T00:00:00.000Z',
+	}
+	const source = {
+		id: sourceId,
+		user_id: 'user-1',
+		entity_kind: 'package' as const,
+		entity_id: savedPackage.id,
+		repo_id: 'repo-perf-app',
+		published_commit: 'commit-1',
+		indexed_commit: 'commit-1',
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		external_check_until: null,
+		created_at: '2026-08-12T00:00:00.000Z',
+		updated_at: '2026-08-12T00:00:00.000Z',
+	}
+	const manifestContent = JSON.stringify({
+		name: '@kentcdodds/perf-app',
+		private: true,
+		exports: { '.': './src/index.ts' },
+		kody: {
+			id: 'perf-app',
+			description: 'Minimal hello-world app',
+			app: { entry: './src/app.ts' },
+		},
+	})
+	return { savedPackage, source, manifestContent }
+}
+
+function seedFixture() {
+	const fixture = createFixture()
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+	mockModule.getSavedPackageByKodyId.mockImplementation(
+		async (_db: unknown, input: { userId: string; kodyId: string }) =>
+			input.userId === fixture.savedPackage.userId &&
+			input.kodyId === fixture.savedPackage.kodyId
+				? fixture.savedPackage
+				: null,
+	)
+	mockModule.getEntitySourceById.mockImplementation(
+		async (_db: unknown, sourceId: string) =>
+			sourceId === fixture.source.id ? fixture.source : null,
+	)
+	mockModule.loadPublishedEntityManifest.mockImplementation(
+		async (input: { sourceId: string }) => {
+			if (input.sourceId !== fixture.source.id) {
+				throw new Error(`No manifest for ${input.sourceId}`)
+			}
+			return { source: fixture.source, content: fixture.manifestContent }
+		},
+	)
+	mockModule.buildPackageAppWorker.mockResolvedValue({
+		entrypointName: 'PackageAppWorker',
+		stub: {
+			getEntrypoint: () => ({
+				async fetch() {
+					return new Response('ok')
+				},
+			}),
+		},
+	})
+	return fixture
+}
+
+async function serveHelloWorld() {
+	return await servePackageAppRequest({
+		request: new Request('https://example.com/@kentcdodds/packages/perf-app'),
+		env: {
+			APP_DB: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as Env,
+		owner: {
+			userId: 'user-1',
+			username: 'kentcdodds',
+			email: 'kent@example.com',
+			displayName: 'Kent',
+		},
+		packagePath: {
+			username: 'kentcdodds',
+			kodyId: 'perf-app',
+			restPath: '/',
+			mount: 'username-path',
+		},
+	})
+}
+
+test('a warm package-app serve performs zero D1/KV loads before dispatch', async () => {
+	seedFixture()
+
+	const cold = await serveHelloWorld()
+	expect(cold.status).toBe(200)
+	expect(await cold.text()).toBe('ok')
+	expect(mockModule.getSavedPackageByKodyId).toHaveBeenCalledTimes(1)
+	expect(mockModule.getEntitySourceById).toHaveBeenCalledTimes(1)
+	expect(mockModule.loadPublishedEntityManifest).toHaveBeenCalledTimes(1)
+	expect(mockModule.buildPackageAppWorker).toHaveBeenCalledTimes(1)
+
+	clearServeLoadCounters()
+	mockModule.buildPackageAppWorker.mockClear()
+	const warm = await serveHelloWorld()
+
+	expect(warm.status).toBe(200)
+	expect(await warm.text()).toBe('ok')
+	expect(countServeLoads()).toEqual({
+		'saved package by id (D1)': 0,
+		'saved package by kody id (D1)': 0,
+		'entity source row (D1)': 0,
+		'published manifest snapshot (KV)': 0,
+	})
+	expect(mockModule.buildPackageAppWorker).toHaveBeenCalledTimes(1)
+})

--- a/packages/worker/src/package-runtime/package-app-serve.ts
+++ b/packages/worker/src/package-runtime/package-app-serve.ts
@@ -4,11 +4,11 @@ import { createHtmlResponse } from 'remix/response/html'
 import { type PackageAppMount } from '@kody-internal/shared/public-urls.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
-import { getSavedPackageByKodyId } from '#worker/package-registry/repo.ts'
 import {
-	loadPackageManifestBySourceId,
-	loadPackageSourceBySourceId,
-} from '#worker/package-registry/source.ts'
+	loadInvokeManifestBySourceId,
+	resolveSavedPackage,
+} from '#worker/package-invocations/module-artifacts.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import {
 	buildPackageAppWorker,
 	createPackageAppCallerContext,
@@ -364,9 +364,12 @@ export async function servePackageAppRequest(input: {
 	if (owner.username !== packagePath.username) {
 		return new Response(buildPackageAppNotFoundMessage(), { status: 404 })
 	}
-	const savedPackage = await getSavedPackageByKodyId(env.APP_DB, {
+	// Same freshness-tier cache as keyless `packages.invoke`: warm serve must
+	// not pay a D1 round trip for the saved-package or entity-source row.
+	const savedPackage = await resolveSavedPackage({
+		db: env.APP_DB,
 		userId: owner.userId,
-		kodyId,
+		packageIdOrKodyId: kodyId,
 	})
 	if (!savedPackage || !savedPackage.hasApp) {
 		return new Response(buildPackageAppNotFoundMessage(), { status: 404 })
@@ -409,9 +412,8 @@ export async function servePackageAppRequest(input: {
 	let entrypoint: { fetch(request: Request): Promise<Response> }
 	try {
 		const [packageManifest, callerContext] = await Promise.all([
-			loadPackageManifestBySourceId({
+			loadInvokeManifestBySourceId({
 				env,
-				baseUrl,
 				userId: owner.userId,
 				sourceId: savedPackage.sourceId,
 			}),

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -442,14 +442,15 @@ function createPackageAppTestSource() {
 	}
 }
 
-function createPackageAppTestManifest() {
+function createPackageAppTestManifest(entry = 'app.js') {
 	return {
 		name: '@kody/example',
+		exports: { '.': `./${entry}` },
 		kody: {
 			id: 'example',
 			description: 'Example package',
 			app: {
-				entry: 'app.js',
+				entry,
 			},
 		},
 	}
@@ -872,6 +873,12 @@ test('buildPackageAppWorker persists rebuilt app artifacts with artifactName nul
 		'bundle-artifact:v1:source-1:commit-1:app:_:app.js',
 	)
 
+	const freshSource = {
+		...createPackageAppTestSource(),
+		published_commit: 'commit-2',
+	}
+	packageAppRuntimeMock.getEntitySourceById.mockResolvedValue(freshSource)
+
 	await buildPackageAppWorker({
 		env,
 		baseUrl: 'https://example.com',
@@ -903,17 +910,88 @@ test('buildPackageAppWorker persists rebuilt app artifacts with artifactName nul
 		} as never,
 	})
 
-	expect(packageAppRuntimeMock.getEntitySourceById).not.toHaveBeenCalled()
+	expect(packageAppRuntimeMock.getEntitySourceById).toHaveBeenCalledTimes(1)
 	expect(packageAppRuntimeMock.buildKodyAppBundle).toHaveBeenCalledTimes(1)
 	expect(
 		packageAppRuntimeMock.persistPublishedBundleArtifact,
 	).toHaveBeenCalledWith(
 		expect.objectContaining({
 			userId: 'user-1',
-			source,
+			source: freshSource,
 			kind: 'app',
 			artifactName: null,
 			entryPoint: 'app.js',
+		}),
+	)
+})
+
+test('an app artifact rebuild resolves its entry point from the fresh source, not the cached manifest', async () => {
+	resetPackageAppRuntimeMocks()
+	const { env } = createPackageAppTestEnv()
+	const cachedSource = createPackageAppTestSource()
+	const freshSource = {
+		...createPackageAppTestSource(),
+		published_commit: 'commit-2',
+	}
+	const staleManifest = createPackageAppTestManifest('stale.js')
+	const freshManifest = createPackageAppTestManifest('fresh.js')
+	packageAppRuntimeMock.loadPublishedBundleArtifactByIdentity.mockResolvedValue(
+		null,
+	)
+	packageAppRuntimeMock.buildKodyAppBundle.mockResolvedValue({
+		mainModule: 'dist/app.js',
+		modules: {
+			'dist/app.js':
+				'export default { fetch() { return new Response("fresh") } }',
+		},
+		dependencies: [],
+		dynamicDependencies: [],
+	})
+	packageAppRuntimeMock.persistPublishedBundleArtifact.mockResolvedValue(
+		'bundle-artifact:v1:source-1:commit-2:app:_:fresh.js',
+	)
+	packageAppRuntimeMock.getEntitySourceById.mockResolvedValue(freshSource)
+
+	await buildPackageAppWorker({
+		env,
+		baseUrl: 'https://example.com',
+		userId: 'user-1',
+		savedPackage: {
+			id: 'package-rebuild-entry',
+			kodyId: 'example-rebuild',
+			name: '@kody/example-rebuild',
+			sourceId: 'source-1',
+			publishedCommit: 'commit-1',
+			manifestPath: 'package.json',
+			sourceRoot: '/',
+		},
+		source: cachedSource,
+		manifest: staleManifest,
+		loadSourceFiles: async () => ({
+			'package.json': JSON.stringify(freshManifest),
+			'fresh.js':
+				'export default { async fetch() { return new Response("v2") } }',
+		}),
+		runtime: {
+			callerContext: {
+				user: {
+					userId: 'user-1',
+					email: 'rebuild@example.com',
+					displayName: 'Rebuild User',
+				},
+			},
+		} as never,
+	})
+
+	expect(packageAppRuntimeMock.buildKodyAppBundle).toHaveBeenCalledWith(
+		expect.objectContaining({ entryPoint: 'fresh.js' }),
+	)
+	expect(
+		packageAppRuntimeMock.persistPublishedBundleArtifact,
+	).toHaveBeenCalledWith(
+		expect.objectContaining({
+			source: freshSource,
+			entryPoint: 'fresh.js',
 		}),
 	)
 })
@@ -934,8 +1012,8 @@ test('buildPackageAppWorker rejects persisting artifacts for a source owned by a
 		dependencies: [],
 		dynamicDependencies: [],
 	})
-	// The pre-resolved source belongs to user-1, so the fast path must be
-	// skipped and the DB lookup (which finds nothing for this user) must fail.
+	// Rebuild always loads the current source row. The lookup finds nothing
+	// for this user, so persist must not run.
 	packageAppRuntimeMock.getEntitySourceById.mockResolvedValue(null)
 
 	await expect(

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -89,6 +89,120 @@ async function collectQueryParamNamesForTest(url: URL) {
 	)(url) as Array<string>
 }
 
+async function extractGeneratedRuntimeRunHelpers() {
+	const sourceText = await readFile(
+		new URL('./package-app.ts', import.meta.url),
+		'utf8',
+	)
+	const start = sourceText.indexOf(
+		'async function startRuntimeRun(runtimeBridge, input) {',
+	)
+	const end = sourceText.indexOf('\nfunction resolveRealtimeHandler', start)
+	if (start < 0 || end < 0) {
+		throw new Error('runtime run helpers were not found.')
+	}
+	return sourceText
+		.slice(start, end)
+		.replaceAll('\\\\', '\\')
+		.replaceAll('\\`', '`')
+		.replaceAll('\\${', '${')
+}
+
+async function createRuntimeRunHelpersForTest() {
+	return new Function(
+		`${await extractGeneratedRuntimeRunHelpers()}; return { startRuntimeRun, finishRuntimeRun };`,
+	)() as {
+		startRuntimeRun: (
+			runtimeBridge: {
+				packageRuntimeRunStart: (input: unknown) => Promise<unknown>
+			},
+			input: unknown,
+		) => Promise<unknown>
+		finishRuntimeRun: (
+			runtimeBridge: {
+				packageRuntimeRunFinish: (input: unknown) => Promise<unknown>
+			},
+			executionCtx: { waitUntil: (promise: Promise<unknown>) => void },
+			input: Record<string, unknown>,
+		) => void
+	}
+}
+
+test('package app fetch does not await run-record begin before user code', async () => {
+	const sourceText = await readFile(
+		new URL('./package-app.ts', import.meta.url),
+		'utf8',
+	)
+	const fetchStart = sourceText.indexOf('async fetch(request) {')
+	const realtimeStart = sourceText.indexOf(
+		'async handleRealtimeEvent(payload) {',
+	)
+	const classEnd = sourceText.indexOf('\n}\n`.trim()', realtimeStart)
+	if (fetchStart < 0 || realtimeStart < 0 || classEnd < 0) {
+		throw new Error('package app worker fetch source was not found.')
+	}
+	const fetchSource = sourceText.slice(fetchStart, realtimeStart)
+	const realtimeSource = sourceText.slice(realtimeStart, classEnd)
+	expect(fetchSource).toContain('const runtimeRun = startRuntimeRun(')
+	expect(fetchSource).not.toContain('await startRuntimeRun(')
+	expect(realtimeSource).toContain('const runtimeRun = startRuntimeRun(')
+	expect(realtimeSource).not.toContain('await startRuntimeRun(')
+})
+
+test('package app run-record finish waits for begin inside waitUntil, not on the response path', async () => {
+	const { startRuntimeRun, finishRuntimeRun } =
+		await createRuntimeRunHelpersForTest()
+	let resolveStart: ((value: { id: string }) => void) | undefined
+	const startGate = new Promise<{ id: string }>((resolve) => {
+		resolveStart = resolve
+	})
+	const startCalls: Array<unknown> = []
+	const finishCalls: Array<unknown> = []
+	const waitUntilTasks: Array<Promise<unknown>> = []
+	const runtimeBridge = {
+		packageRuntimeRunStart: async (input: unknown) => {
+			startCalls.push(input)
+			return await startGate
+		},
+		packageRuntimeRunFinish: async (input: unknown) => {
+			finishCalls.push(input)
+			return { ok: true }
+		},
+	}
+
+	const runtimeRun = startRuntimeRun(runtimeBridge, {
+		surface: 'app_fetch',
+		name: '/',
+	})
+	finishRuntimeRun(
+		runtimeBridge,
+		{
+			waitUntil: (promise) => {
+				waitUntilTasks.push(promise)
+			},
+		},
+		{
+			run: runtimeRun,
+			status: 'success',
+			metadata: { httpStatus: 200 },
+		},
+	)
+
+	expect(startCalls).toEqual([{ surface: 'app_fetch', name: '/' }])
+	expect(finishCalls).toEqual([])
+	expect(waitUntilTasks).toHaveLength(1)
+
+	resolveStart?.({ id: 'run-1' })
+	await Promise.all(waitUntilTasks)
+	expect(finishCalls).toEqual([
+		{
+			run: { id: 'run-1' },
+			status: 'success',
+			metadata: { httpStatus: 200 },
+		},
+	])
+})
+
 test('package app kody proxy supports remote namespace calls', async () => {
 	const calls: Array<{ name: string; args: unknown }> = []
 	const kody = await createKodyProxyForTest({

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -613,11 +613,27 @@ function isSyntheticPackageAppRequest(request) {
 }
 
 async function startRuntimeRun(runtimeBridge, input) {
-	return await runtimeBridge.packageRuntimeRunStart(input);
+	try {
+		return await runtimeBridge.packageRuntimeRunStart(input);
+	} catch (error) {
+		console.warn('package-app-run-record-start-failed', error);
+		return null;
+	}
 }
 
 function finishRuntimeRun(runtimeBridge, executionCtx, input) {
-	executionCtx.waitUntil(runtimeBridge.packageRuntimeRunFinish(input));
+	// Begin is a WorkerEntrypoint RPC even though beginRunRecord itself is
+	// synchronous. Await it only inside waitUntil, chained before finish, so
+	// the HTTP/realtime response is not blocked on minting the handle.
+	executionCtx.waitUntil(
+		(async () => {
+			const run = await input.run;
+			await runtimeBridge.packageRuntimeRunFinish({
+				...input,
+				run,
+			});
+		})(),
+	);
 }
 
 function resolveRealtimeHandler(userModule, facetName) {
@@ -654,7 +670,7 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 	async fetch(request) {
 		const runtimeBridge = this.env.${packageAppRuntimeBindingName};
 		const requestUrl = new URL(request.url);
-		const runtimeRun = await startRuntimeRun(runtimeBridge, {
+		const runtimeRun = startRuntimeRun(runtimeBridge, {
 			surface: 'app_fetch',
 			name: requestUrl.pathname,
 			metadata: {
@@ -709,7 +725,7 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 
 	async handleRealtimeEvent(payload) {
 		const runtimeBridge = this.env.${packageAppRuntimeBindingName};
-		const runtimeRun = await startRuntimeRun(runtimeBridge, {
+		const runtimeRun = startRuntimeRun(runtimeBridge, {
 			surface: 'app_realtime',
 			name: buildFacetName(payload?.facet),
 			sessionId: payload?.sessionId,

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -1661,19 +1661,27 @@ async function resolvePackageAppBundledArtifact(input: {
 		sourceFiles,
 		bundleLabel: `Saved package app "${input.savedPackage.kodyId}"`,
 	})
+	// The caller's manifest and source row may come from the freshness-cached
+	// invoke contract and trail a republish by up to the freshness TTL, while
+	// the source-file load above is always current. Re-derive the app entry
+	// from those files and persist against a freshly loaded source row so the
+	// bundle identity matches the commit being built.
+	const rebuildAppEntry = resolvePackageAppEntryFromSourceFiles({
+		sourceFiles,
+		savedPackage: input.savedPackage,
+	})
 	const compiled = await buildKodyAppBundle({
 		env: input.env,
 		baseUrl: input.baseUrl,
 		userId: input.userId,
 		sourceFiles,
-		entryPoint: appEntry,
+		entryPoint: rebuildAppEntry,
 		rootPackageId: input.savedPackage.id,
 		cacheKey: inMemoryCacheKey,
 	})
 	const persistableSource = await resolvePersistablePackageSource({
 		env: input.env,
 		userId: input.userId,
-		source: input.source,
 		sourceId: input.savedPackage.sourceId,
 	})
 	await persistPublishedBundleArtifact({
@@ -1682,7 +1690,7 @@ async function resolvePackageAppBundledArtifact(input: {
 		source: persistableSource,
 		kind: 'app',
 		artifactName: null,
-		entryPoint: appEntry,
+		entryPoint: rebuildAppEntry,
 		mainModule: compiled.mainModule,
 		modules: compiled.modules,
 		dependencies: compiled.dependencies,
@@ -1694,6 +1702,24 @@ async function resolvePackageAppBundledArtifact(input: {
 		},
 	})
 	return compiled
+}
+
+function resolvePackageAppEntryFromSourceFiles(input: {
+	sourceFiles: Record<string, string>
+	savedPackage: { kodyId: string; manifestPath: string }
+}) {
+	const appEntry = getPackageAppEntryPath(
+		resolvePackageAppManifest({
+			sourceFiles: input.sourceFiles,
+			savedPackage: input.savedPackage,
+		}),
+	)
+	if (!appEntry) {
+		throw new Error(
+			`Saved package "${input.savedPackage.kodyId}" does not define kody.app.entry.`,
+		)
+	}
+	return appEntry
 }
 
 async function resolvePackageAppSourceFiles(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Package apps felt slow. A hello-world `fetch` that returns `ok` confirmed that: **~113ms warm platform overhead** vs **~0ms** for keyless `packages.invoke` of a trivial export. This PR removes the two host costs that do not belong on the response path.

## Probe

Hidden private package `perf-app-tiny-a287` (`package_id` `6143a543-ef4c-482d-a1c4-a6e236feaa91`): default export `{ ok: true }`, app handler `return new Response('ok')`. Timed from execute against production:

| Surface | Cold | Warm avg (n=7) |
| --- | ---: | ---: |
| `packages.invoke` ping | 184ms | ~0ms |
| `package_app_fetch` `ok` | 2230ms | **113ms** (103–124ms) |

User code is not the bottleneck. Two host costs were on every warm hit:

1. **Uncached D1** for the saved-package row and entity-source row (invoke already has a 15s freshness cache; apps skipped it).
2. **Awaited WorkerEntrypoint RPC** for `packageRuntimeRunStart` before user `fetch`. `beginRunRecord` is synchronous and fire-and-forgets the `running` insert; finish already upserts the terminal row. The isolate hop was the cost.

## Summary

- Package-app serve uses `resolveSavedPackage` + `loadInvokeManifestBySourceId` (same freshness/commit caches as keyless invoke). Warm serve now does **zero D1/KV loads** before dispatch.
- Generated app worker kicks off run-record begin without `await`, runs user `fetch`/`onRealtimeEvent`, and `waitUntil`s begin-then-finish. Start RPC failures no longer fail the HTTP response.
- `package_app_fetch` shares the saved-package freshness cache and validates the path before any D1 lookup.
- On published artifact miss, rebuild re-derives `kody.app.entry` from the loaded files and persists against a freshly loaded source row (same as invoke), so a stale freshness-cached manifest cannot poison the previous commit's bundle identity.
- Guardrails docs now treat package-app HTTP as an invocation hot path.

Remaining warm cost after this (not in this PR): `APP_LOADER.get` per request (stubs are request-bound; worker options are already cached) plus isolate `import()` of the user module.

## Testing

- `vitest` node-unit for package-app serve/worker, handler, `package_app_fetch`, and invoke-contract-cache
- Pre-push: 2036 node+workers unit tests, 7 Playwright e2e
- Production probe numbers above (before this change; re-measure `perf-app-tiny-a287` after deploy)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4e2f43a9` · **Head:** `189e5312`

**Classification:** extends — package-app HTTP now shares the invoke freshness cache and no longer awaits run-record begin on the response path.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-apps` | assistant | extends — generated worker defers begin RPC into `waitUntil`; artifact rebuild persists against the fresh source |
| `package-runtime` | runtime | extends — serve path uses invoke freshness/commit caches |
| `saved-packages` | assistant | extends — `package_app_fetch` shares the cache; path validation before D1 |
| `app-ui` | surfaces | composes — handler tests only |

### System map

Warm package-app HTTP now resolves the saved package and manifest through the invoke freshness cache, then runs user `fetch` without waiting for the run-record begin RPC. Artifact misses rebuild against the current published source, not the cached row.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	packageApps["package-apps<br/>Package apps"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::extended
	appUi["app-ui<br/>Browser app"]:::touched
	savedPackages -->|"15s freshness cache on serve + package_app_fetch"| packageRuntime
	packageRuntime -->|"loadInvokeManifestBySourceId"| packageApps
	packageApps -->|"begin RPC waitUntil-chained before finish"| packageRuntime
	packageApps -->|"rebuild persist uses fresh source row"| packageRuntime
	appUi -->|"handlePackageAppRequest still calls serve"| packageRuntime
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Browser
	participant Serve as servePackageAppRequest
	participant Cache as invoke freshness cache
	participant Isolate as PackageAppWorker
	participant Bridge as packageRuntimeRunStart
	Browser->>Serve: GET /packages/{kodyId}/
	Serve->>Cache: resolveSavedPackage + loadInvokeManifest
	Note over Cache: warm: zero D1/KV
	Serve->>Isolate: entrypoint.fetch
	Isolate-->>Bridge: startRuntimeRun (not awaited)
	Isolate->>Isolate: user fetch()
	Isolate-->>Browser: Response
	Isolate->>Bridge: waitUntil begin then finish
```

### Before / after

**Warm hello-world `app_fetch` (production probe, before this PR):** ~113ms platform overhead vs ~0ms keyless invoke.

**Warm serve D1/KV (this PR's node test):** zero saved-package, source-row, and manifest loads before dispatch.

**Artifact miss after republish:** rebuild entry and persist identity come from the freshly loaded source, matching invoke.

### Invariants

Cache keys still start with the owning `userId`. Publish/rebuild keep using uncached `loadPackageManifestBySourceId`. A dropped `running` insert remains harmless because finish upserts the terminal row. Artifact hits may still serve the stale commit for up to the freshness TTL.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da35b1be-dad7-4cc2-b8ec-e997baf6a287?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da35b1be-dad7-4cc2-b8ec-e997baf6a287&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved package app response times by serving warm requests without additional database or cache reads.
  * Added caching for saved packages and invocation manifests.

* **Reliability**
  * Package app requests and realtime interactions now continue even if run-record initialization fails.
  * Run completion is handled asynchronously to avoid delaying responses.

* **Tests**
  * Added coverage for warm-cache behavior, non-blocking run tracking, and deferred run completion.

* **Documentation**
  * Updated architecture guidance for package app performance, caching, and run-record handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->