### PR TITLE
feat(community): return request-scoped serverTiming from community_fork

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -183,6 +183,14 @@ id to the forker's scope, scans cross-scope references, calls
 `ensureEntitySource` + `syncArtifactSourceSnapshot`, and records
 `community_forks` — **without** inserting `saved_packages`.
 
+`community_fork` returns request-scoped `serverTiming` entries
+(`{ name, durationMs }`), the same shape as `execute`. They are not written to
+D1 or Analytics Engine. Nested `bootstrap-*` phases come from the RepoSession
+Durable Object; `bootstrap-source` is the RPC wall clock, including isolate
+startup. Subtract the nested bootstrap phases from `bootstrap-source` to
+estimate cold start. `Date.now()` in Workers only advances across I/O, so
+CPU-only steps may report `0`.
+
 `rateCommunityListing` requires a prior fork row for the rater and rejects
 ratings from the listing owner. `reportCommunityListing` stores denormalized
 listing metadata for the admin queue.

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -106,6 +106,12 @@ user scopes:
 - static `kody:@originuser/...` imports
 - `package.json#kody.dependencies` entries pointing at other users' scopes
 
+The capability also returns optional **`serverTiming`** entries
+(`{ name, durationMs }`), the same shape as execute. They are request-scoped
+diagnostics, not stored metrics. `bootstrap-source` is the git bootstrap RPC
+(including Durable Object startup); nested `bootstrap-*` phases are the work
+inside that isolate.
+
 Your agent should:
 
 1. Confirm **your** intent (which may differ from the original author's).

--- a/packages/worker/src/community/community-flow.workers.test.ts
+++ b/packages/worker/src/community/community-flow.workers.test.ts
@@ -292,6 +292,25 @@ test('community package flow works end-to-end through capability handlers', asyn
 		forkerCtx,
 	)
 	expect(forkResult.target_name).toBe(`@userb/${kodyId}`)
+	expect(forkResult.serverTiming).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				name: 'prepare',
+				durationMs: expect.any(Number),
+			}),
+			expect.objectContaining({
+				name: 'artifacts-repo-ready',
+				durationMs: expect.any(Number),
+			}),
+			expect.objectContaining({
+				name: 'fork-row',
+				durationMs: expect.any(Number),
+			}),
+		]),
+	)
+	for (const entry of forkResult.serverTiming ?? []) {
+		expect(entry.durationMs).toBeGreaterThanOrEqual(0)
+	}
 	expect(forkResult.cross_scope_references).toEqual(
 		expect.arrayContaining([
 			{ file: 'src/index.ts', specifier: 'kody:@usera/' },

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -956,6 +956,10 @@ test('forkCommunityListing creates inert source without saved package row', asyn
 
 	expect(result.targetKodyId).toBe('my-discord-gateway')
 	expect(result.targetName).toBe('@jane/my-discord-gateway')
+	expect(result.serverTiming?.map((entry) => entry.name)).toEqual([
+		'prepare',
+		'fork-row',
+	])
 	expect(result.crossScopeReferences).toEqual([
 		{ file: 'package.json', specifier: '@owner/shared-utils' },
 		{ file: 'src/index.ts', specifier: 'kody:@owner/' },
@@ -964,9 +968,14 @@ test('forkCommunityListing creates inert source without saved package row', asyn
 		expect.objectContaining({
 			userId: 'user-2',
 			entityKind: 'package',
+			serverTiming: expect.any(Array),
 		}),
 	)
-	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalled()
+	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			serverTiming: expect.any(Array),
+		}),
+	)
 	expect(mockModule.insertCommunityFork).toHaveBeenCalledWith(
 		expect.anything(),
 		expect.objectContaining({

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -168,6 +168,7 @@ const {
 	reportCommunityListing,
 	searchCommunityListings,
 	forkCommunityListing,
+	persistPreparedCommunityFork,
 	adoptCommunityFork,
 } = await import('./service.ts')
 
@@ -1076,6 +1077,38 @@ test('forkCommunityListing allows repeat fork with a different kody_id', async (
 		expect.objectContaining({
 			target_kody_id: 'my-second-fork',
 		}),
+	)
+})
+
+test('persistPreparedCommunityFork skips serverTiming unless the caller opts in', async () => {
+	mockModule.ensureEntitySource.mockResolvedValue({
+		id: 'fork-source-3',
+		bootstrapAccess: { token: 'bootstrap' },
+	})
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('commit-fork-3')
+
+	const result = await persistPreparedCommunityFork({
+		env: createEnv(),
+		baseUrl: 'https://heykody.dev',
+		userId: 'user-2',
+		listingId: 'listing-1',
+		listingName: '@owner/discord-gateway',
+		listingKodyId: 'discord-gateway',
+		originCommit: 'commit-1',
+		actor: null,
+		packageId: 'package-fork-3',
+		targetKodyId: 'my-install-fork',
+		targetName: '@jane/my-install-fork',
+		files: { 'package.json': '{}' },
+		crossScopeReferences: [],
+	})
+
+	expect(result.serverTiming).toBeUndefined()
+	expect(mockModule.ensureEntitySource).toHaveBeenCalledWith(
+		expect.objectContaining({ serverTiming: undefined }),
+	)
+	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({ serverTiming: undefined }),
 	)
 })
 

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -1148,7 +1148,7 @@ export async function persistPreparedCommunityFork(
 	options?: { serverTiming?: Array<ServerTimingEntry> },
 ): Promise<ForkCommunityListingResult> {
 	const persistStartedAt = Date.now()
-	const serverTiming = options?.serverTiming ?? []
+	const serverTiming = options?.serverTiming
 	const ensuredSource = await ensureEntitySource({
 		db: prepared.env.APP_DB,
 		env: prepared.env,
@@ -1209,7 +1209,7 @@ export async function persistPreparedCommunityFork(
 			crossScopeReferences: prepared.crossScopeReferences,
 			filesCount: Object.keys(prepared.files).length,
 			files: prepared.files,
-			...(serverTiming.length > 0 ? { serverTiming } : {}),
+			...(serverTiming && serverTiming.length > 0 ? { serverTiming } : {}),
 		}
 	} catch (error) {
 		await cleanupFailedCommunityFork({

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -17,6 +17,10 @@ import { cleanupArtifactReposForPackage } from '#worker/repo/artifact-repo-clean
 import { deleteEntitySource } from '#worker/repo/entity-sources.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
+import {
+	pushServerTiming,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
 import { assertPackageNotPrivateForCommunityPublish } from '#worker/package-registry/package-private.ts'
 import { assertKodyDescriptionLength } from '#worker/package-registry/types.ts'
 import { enqueueCommunityActivityDispatch } from './activity-dispatch-queue-producer.ts'
@@ -1141,8 +1145,10 @@ export async function prepareCommunityFork(
  */
 export async function persistPreparedCommunityFork(
 	prepared: PreparedCommunityFork,
+	options?: { serverTiming?: Array<ServerTimingEntry> },
 ): Promise<ForkCommunityListingResult> {
 	const persistStartedAt = Date.now()
+	const serverTiming = options?.serverTiming ?? []
 	const ensuredSource = await ensureEntitySource({
 		db: prepared.env.APP_DB,
 		env: prepared.env,
@@ -1150,6 +1156,7 @@ export async function persistPreparedCommunityFork(
 		entityKind: 'package',
 		entityId: prepared.packageId,
 		requirePersistence: true,
+		serverTiming,
 	})
 	try {
 		await syncArtifactSourceSnapshot({
@@ -1159,25 +1166,28 @@ export async function persistPreparedCommunityFork(
 			sourceId: ensuredSource.id,
 			files: prepared.files,
 			bootstrapAccess: ensuredSource.bootstrapAccess ?? null,
+			serverTiming,
 		})
 
 		const forkId = crypto.randomUUID()
-		await insertCommunityFork(prepared.env.APP_DB, {
-			id: forkId,
-			listing_id: prepared.listingId,
-			forker_user_id: prepared.userId,
-			origin_commit: prepared.originCommit,
-			forked_package_id: prepared.packageId,
-			forked_source_id: ensuredSource.id,
-			target_kody_id: prepared.targetKodyId,
-			listing_name: prepared.listingName,
-			listing_kody_id: prepared.listingKodyId,
-			actor: prepared.actor,
-		})
-		await enqueueRecordedCommunityActivity({
-			env: prepared.env,
-			kind: 'fork',
-			activityId: forkId,
+		await pushServerTiming(serverTiming, 'fork-row', async () => {
+			await insertCommunityFork(prepared.env.APP_DB, {
+				id: forkId,
+				listing_id: prepared.listingId,
+				forker_user_id: prepared.userId,
+				origin_commit: prepared.originCommit,
+				forked_package_id: prepared.packageId,
+				forked_source_id: ensuredSource.id,
+				target_kody_id: prepared.targetKodyId,
+				listing_name: prepared.listingName,
+				listing_kody_id: prepared.listingKodyId,
+				actor: prepared.actor,
+			})
+			await enqueueRecordedCommunityActivity({
+				env: prepared.env,
+				kind: 'fork',
+				activityId: forkId,
+			})
 		})
 
 		invalidateCommunityPublicCache()
@@ -1199,6 +1209,7 @@ export async function persistPreparedCommunityFork(
 			crossScopeReferences: prepared.crossScopeReferences,
 			filesCount: Object.keys(prepared.files).length,
 			files: prepared.files,
+			...(serverTiming.length > 0 ? { serverTiming } : {}),
 		}
 	} catch (error) {
 		await cleanupFailedCommunityFork({
@@ -1214,8 +1225,11 @@ export async function persistPreparedCommunityFork(
 export async function forkCommunityListing(
 	input: PrepareCommunityForkInput,
 ): Promise<ForkCommunityListingResult> {
-	const prepared = await prepareCommunityFork(input)
-	return await persistPreparedCommunityFork(prepared)
+	const serverTiming: Array<ServerTimingEntry> = []
+	const prepared = await pushServerTiming(serverTiming, 'prepare', () =>
+		prepareCommunityFork(input),
+	)
+	return await persistPreparedCommunityFork(prepared, { serverTiming })
 }
 
 export type AdoptCommunityForkResult = {

--- a/packages/worker/src/community/types.ts
+++ b/packages/worker/src/community/types.ts
@@ -303,6 +303,11 @@ export type ForkCommunityListingResult = {
 	 * the snapshot; capability results must never expose them directly.
 	 */
 	files: Record<string, string>
+	/**
+	 * Request-scoped phase timings for this fork. Same shape as execute
+	 * `serverTiming`. Returned on the response only — not stored.
+	 */
+	serverTiming?: Array<{ name: string; durationMs: number }>
 }
 
 export type CommunityReportResolutionAction = 'dismiss' | 'delist' | 'delete'

--- a/packages/worker/src/mcp/capabilities/community/fork.ts
+++ b/packages/worker/src/mcp/capabilities/community/fork.ts
@@ -42,6 +42,17 @@ export const communityForkCapability = defineDomainCapability(
 			cross_scope_references: z.array(crossScopeReferenceSchema),
 			next_steps: z.string(),
 			content_warning: z.string(),
+			serverTiming: z
+				.array(
+					z.object({
+						name: z.string(),
+						durationMs: z.number().nonnegative(),
+					}),
+				)
+				.optional()
+				.describe(
+					'Request-scoped phase timings. Same shape as execute serverTiming. Not stored. bootstrap-source includes Durable Object startup; subtract nested bootstrap-* phases to estimate cold start.',
+				),
 		}),
 		async handler(args, ctx) {
 			const user = requireMcpUser(ctx.callerContext)
@@ -81,6 +92,9 @@ export const communityForkCapability = defineDomainCapability(
 				cross_scope_references: result.crossScopeReferences,
 				next_steps: communityForkNextSteps,
 				content_warning: communityContentWarning,
+				...(result.serverTiming && result.serverTiming.length > 0
+					? { serverTiming: result.serverTiming }
+					: {}),
 			}
 		},
 	},

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -113,6 +113,10 @@ import {
 	registerStorageBucketAndWait,
 	repoSessionStorageBucketId,
 } from '#worker/storage-buckets/service.ts'
+import {
+	pushServerTiming,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
 
 const repoSessionWorkspacePrefix = '/session'
 const lastCheckStatusStorageKey = 'repo-session:last-check-status'
@@ -1255,6 +1259,7 @@ class RepoSessionBase extends DurableObject<Env> {
 			}
 		}>
 	}): Promise<RepoSourceBootstrapResult> {
+		const serverTiming: Array<ServerTimingEntry> = []
 		const source = await getEntitySourceById(this.env.APP_DB, input.sourceId)
 		if (!source) {
 			throw new Error(`Source "${input.sourceId}" was not found.`)
@@ -1268,89 +1273,111 @@ class RepoSessionBase extends DurableObject<Env> {
 			)
 		}
 		let sourceInfo: ArtifactRepoInfo | null = null
-		let sourceAccess: { remote: string; token: string }
-		if (input.bootstrapAccess) {
-			sourceAccess = {
-				remote: input.bootstrapAccess.remote,
-				token: input.bootstrapAccess.token,
-			}
-		} else {
-			const sourceRepo = await resolveArtifactSourceRepo(
-				this.env,
-				source.repo_id,
-			)
-			sourceInfo = await sourceRepo.info()
-			sourceAccess = await ensureArtifactRepoRemote({
-				repo: sourceRepo,
-				scope: 'write',
-				pendingReconcile: buildPendingExternalReconcile(
-					this.env.APP_DB,
-					source,
-				),
-			})
-		}
+		const sourceAccess = await pushServerTiming(
+			serverTiming,
+			'bootstrap-artifact-remote',
+			async () => {
+				if (input.bootstrapAccess) {
+					return {
+						remote: input.bootstrapAccess.remote,
+						token: input.bootstrapAccess.token,
+					}
+				}
+				const sourceRepo = await resolveArtifactSourceRepo(
+					this.env,
+					source.repo_id,
+				)
+				sourceInfo = await sourceRepo.info()
+				return await ensureArtifactRepoRemote({
+					repo: sourceRepo,
+					scope: 'write',
+					pendingReconcile: buildPendingExternalReconcile(
+						this.env.APP_DB,
+						source,
+					),
+				})
+			},
+		)
 		const targetBranch =
 			input.bootstrapAccess?.defaultBranch ??
 			sourceInfo?.defaultBranch ??
 			defaultSessionBranch
-		await this.resetWorkspace()
-		await this.workspace.mkdir(repoSessionWorkspacePrefix, {
-			recursive: true,
+		await pushServerTiming(serverTiming, 'bootstrap-git-init', async () => {
+			await this.resetWorkspace()
+			await this.workspace.mkdir(repoSessionWorkspacePrefix, {
+				recursive: true,
+			})
+			await this.git.init({
+				dir: repoSessionWorkspacePrefix,
+				defaultBranch: targetBranch,
+			})
+			await this.ensureRemote({
+				name: 'source',
+				url: buildAuthenticatedArtifactsRemote({
+					remote: sourceAccess.remote,
+					token: sourceAccess.token,
+				}),
+			})
 		})
-		await this.git.init({
-			dir: repoSessionWorkspacePrefix,
-			defaultBranch: targetBranch,
-		})
-		await this.ensureRemote({
-			name: 'source',
-			url: buildAuthenticatedArtifactsRemote({
+		await pushServerTiming(serverTiming, 'bootstrap-write-files', () =>
+			this.applyWorkspaceEdits({
+				edits: input.edits as Array<RepoSessionEdit>,
+				dryRun: false,
+				rollbackOnError: true,
+			}),
+		)
+		const publishedCommit = await pushServerTiming(
+			serverTiming,
+			'bootstrap-commit',
+			async () => {
+				const commit = await this.commitIfDirty(
+					`Bootstrap source repo ${source.id}`,
+				)
+				if (!commit) {
+					throw new Error(`Source "${source.id}" bootstrap produced no commit.`)
+				}
+				await this.readManifestFromWorkspace(
+					source.manifest_path,
+					source.entity_kind,
+				)
+				return commit
+			},
+		)
+		await pushServerTiming(serverTiming, 'bootstrap-git-push', () =>
+			this.git.push({
+				dir: repoSessionWorkspacePrefix,
+				remote: 'source',
+				ref: targetBranch,
+				...buildArtifactsGitAuth({ token: sourceAccess.token }),
+			}),
+		)
+		await pushServerTiming(serverTiming, 'bootstrap-git-note', () =>
+			this.attachSourcePublishGitNote({
+				source,
+				commitOid: publishedCommit,
 				remote: sourceAccess.remote,
 				token: sourceAccess.token,
+				remoteName: 'source',
+				publishedBy: 'source_bootstrap',
+				sessionId: input.sessionId,
+				previousPublishedCommit: null,
+				scope: 'repo.bootstrapSource.publish-git-note',
 			}),
-		})
-		await this.applyWorkspaceEdits({
-			edits: input.edits as Array<RepoSessionEdit>,
-			dryRun: false,
-			rollbackOnError: true,
-		})
-		const publishedCommit = await this.commitIfDirty(
-			`Bootstrap source repo ${source.id}`,
 		)
-		if (!publishedCommit) {
-			throw new Error(`Source "${source.id}" bootstrap produced no commit.`)
-		}
-		await this.readManifestFromWorkspace(
-			source.manifest_path,
-			source.entity_kind,
+		await pushServerTiming(serverTiming, 'bootstrap-published-commit', () =>
+			updateEntitySource(this.env.APP_DB, {
+				id: source.id,
+				userId: source.user_id,
+				publishedCommit,
+				manifestPath: source.manifest_path,
+				sourceRoot: source.source_root,
+			}),
 		)
-		await this.git.push({
-			dir: repoSessionWorkspacePrefix,
-			remote: 'source',
-			ref: targetBranch,
-			...buildArtifactsGitAuth({ token: sourceAccess.token }),
-		})
-		await this.attachSourcePublishGitNote({
-			source,
-			commitOid: publishedCommit,
-			remote: sourceAccess.remote,
-			token: sourceAccess.token,
-			remoteName: 'source',
-			publishedBy: 'source_bootstrap',
-			sessionId: input.sessionId,
-			previousPublishedCommit: null,
-			scope: 'repo.bootstrapSource.publish-git-note',
-		})
-		await updateEntitySource(this.env.APP_DB, {
-			id: source.id,
-			userId: source.user_id,
-			publishedCommit,
-			manifestPath: source.manifest_path,
-			sourceRoot: source.source_root,
-		})
 		return {
 			sessionId: input.sessionId,
 			publishedCommit,
 			message: `Bootstrapped source ${source.id} in ${source.repo_id}.`,
+			serverTiming,
 		}
 	}
 

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -18,7 +18,6 @@ import {
 } from './repo-sessions.ts'
 import {
 	type ArtifactBootstrapAccess,
-	type ArtifactRepoInfo,
 	buildArtifactsGitAuth,
 	buildAuthenticatedArtifactsRemote,
 	resolveArtifactSourceHead,
@@ -1272,8 +1271,7 @@ class RepoSessionBase extends DurableObject<Env> {
 				`Source "${source.id}" already has a published commit. Use repo sessions for later edits.`,
 			)
 		}
-		let sourceInfo: ArtifactRepoInfo | null = null
-		const sourceAccess = await pushServerTiming(
+		const remoteSetup = await pushServerTiming(
 			serverTiming,
 			'bootstrap-artifact-remote',
 			async () => {
@@ -1281,14 +1279,15 @@ class RepoSessionBase extends DurableObject<Env> {
 					return {
 						remote: input.bootstrapAccess.remote,
 						token: input.bootstrapAccess.token,
+						sourceInfo: null,
 					}
 				}
 				const sourceRepo = await resolveArtifactSourceRepo(
 					this.env,
 					source.repo_id,
 				)
-				sourceInfo = await sourceRepo.info()
-				return await ensureArtifactRepoRemote({
+				const sourceInfo = await sourceRepo.info()
+				const access = await ensureArtifactRepoRemote({
 					repo: sourceRepo,
 					scope: 'write',
 					pendingReconcile: buildPendingExternalReconcile(
@@ -1296,11 +1295,16 @@ class RepoSessionBase extends DurableObject<Env> {
 						source,
 					),
 				})
+				return {
+					remote: access.remote,
+					token: access.token,
+					sourceInfo,
+				}
 			},
 		)
 		const targetBranch =
 			input.bootstrapAccess?.defaultBranch ??
-			sourceInfo?.defaultBranch ??
+			remoteSetup.sourceInfo?.defaultBranch ??
 			defaultSessionBranch
 		await pushServerTiming(serverTiming, 'bootstrap-git-init', async () => {
 			await this.resetWorkspace()
@@ -1314,8 +1318,8 @@ class RepoSessionBase extends DurableObject<Env> {
 			await this.ensureRemote({
 				name: 'source',
 				url: buildAuthenticatedArtifactsRemote({
-					remote: sourceAccess.remote,
-					token: sourceAccess.token,
+					remote: remoteSetup.remote,
+					token: remoteSetup.token,
 				}),
 			})
 		})
@@ -1348,15 +1352,15 @@ class RepoSessionBase extends DurableObject<Env> {
 				dir: repoSessionWorkspacePrefix,
 				remote: 'source',
 				ref: targetBranch,
-				...buildArtifactsGitAuth({ token: sourceAccess.token }),
+				...buildArtifactsGitAuth({ token: remoteSetup.token }),
 			}),
 		)
 		await pushServerTiming(serverTiming, 'bootstrap-git-note', () =>
 			this.attachSourcePublishGitNote({
 				source,
 				commitOid: publishedCommit,
-				remote: sourceAccess.remote,
-				token: sourceAccess.token,
+				remote: remoteSetup.remote,
+				token: remoteSetup.token,
 				remoteName: 'source',
 				publishedBy: 'source_bootstrap',
 				sessionId: input.sessionId,

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -154,6 +154,7 @@ test('ensureEntitySource returns bootstrap access for brand-new repos', async ()
 		})
 
 	try {
+		const serverTiming: Array<{ name: string; durationMs: number }> = []
 		const source = await ensureEntitySource({
 			db,
 			env: {
@@ -166,6 +167,7 @@ test('ensureEntitySource returns bootstrap access for brand-new repos', async ()
 			entityKind: 'job',
 			entityId: 'job-1',
 			sourceRoot: '/',
+			serverTiming,
 		})
 
 		expect(fetchMock).toHaveBeenCalledTimes(3)
@@ -176,6 +178,11 @@ test('ensureEntitySource returns bootstrap access for brand-new repos', async ()
 			token: 'art_v1_create?expires=1760000000',
 			expiresAt: '2025-10-09T08:53:20.000Z',
 		})
+		expect(serverTiming.map((entry) => entry.name)).toEqual([
+			'artifacts-repo-ready',
+			'entity-source-insert',
+			'artifacts-push-subscription',
+		])
 	} finally {
 		fetchMock.mockRestore()
 	}

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -11,6 +11,10 @@ import {
 	updateEntitySource,
 } from './entity-sources.ts'
 import { type EntityKind, type EntitySourceRow } from './types.ts'
+import {
+	pushServerTiming,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
 
 export type EnsuredEntitySource = EntitySourceRow & {
 	bootstrapAccess?: ArtifactBootstrapAccess | null
@@ -66,6 +70,8 @@ export async function ensureEntitySource(input: {
 	manifestPath?: string
 	sourceRoot?: string
 	requirePersistence?: boolean
+	/** Request-scoped phase timings; omitted when the caller does not collect. */
+	serverTiming?: Array<ServerTimingEntry>
 }): Promise<EnsuredEntitySource> {
 	const hasDbPrepare = hasAppDbBinding(input.db)
 	const hasArtifactsAccessResult = hasArtifactsAccess(input.env)
@@ -96,7 +102,11 @@ export async function ensureEntitySource(input: {
 		entityId: input.entityId,
 	})
 	if (existing) {
-		const repoReady = await ensureArtifactRepoReady(input.env, existing.repo_id)
+		const repoReady = await pushServerTiming(
+			input.serverTiming,
+			'artifacts-repo-ready',
+			() => ensureArtifactRepoReady(input.env, existing.repo_id),
+		)
 		const source = repoReady.recreated
 			? {
 					...existing,
@@ -113,12 +123,17 @@ export async function ensureEntitySource(input: {
 				indexedCommit: null,
 			})
 		}
-		await ensureArtifactsRepoPushSubscription({
-			env: input.env,
-			userId: existing.user_id,
-			sourceId: existing.id,
-			repoName: existing.repo_id,
-		})
+		await pushServerTiming(
+			input.serverTiming,
+			'artifacts-push-subscription',
+			() =>
+				ensureArtifactsRepoPushSubscription({
+					env: input.env,
+					userId: existing.user_id,
+					sourceId: existing.id,
+					repoName: existing.repo_id,
+				}),
+		)
 		return source
 	}
 	const row = buildEntitySourceRow({
@@ -130,14 +145,25 @@ export async function ensureEntitySource(input: {
 		manifestPath: input.manifestPath,
 		sourceRoot: input.sourceRoot,
 	})
-	const repoReady = await ensureArtifactRepoReady(input.env, row.repo_id)
-	await insertEntitySource(input.db, row)
-	await ensureArtifactsRepoPushSubscription({
-		env: input.env,
-		userId: row.user_id,
-		sourceId: row.id,
-		repoName: row.repo_id,
-	})
+	const repoReady = await pushServerTiming(
+		input.serverTiming,
+		'artifacts-repo-ready',
+		() => ensureArtifactRepoReady(input.env, row.repo_id),
+	)
+	await pushServerTiming(input.serverTiming, 'entity-source-insert', () =>
+		insertEntitySource(input.db, row),
+	)
+	await pushServerTiming(
+		input.serverTiming,
+		'artifacts-push-subscription',
+		() =>
+			ensureArtifactsRepoPushSubscription({
+				env: input.env,
+				userId: row.user_id,
+				sourceId: row.id,
+				repoName: row.repo_id,
+			}),
+	)
 	return {
 		...row,
 		bootstrapAccess: repoReady.recreated ? repoReady.bootstrapAccess : null,

--- a/packages/worker/src/repo/source-sync.node.test.ts
+++ b/packages/worker/src/repo/source-sync.node.test.ts
@@ -254,3 +254,50 @@ test('syncArtifactSourceSnapshot bootstraps new sources and uses repo sessions f
 		expect.objectContaining({ userId: 'user-1' }),
 	)
 })
+
+test('syncArtifactSourceSnapshot records request-scoped serverTiming phases', async () => {
+	mockModule.getEntitySourceById.mockReset()
+	mockModule.updateEntitySource.mockReset()
+	mockModule.repoSessionRpc.mockReset()
+	mockModule.writePublishedSourceSnapshot.mockReset()
+
+	const bootstrapClient = {
+		bootstrapSource: vi.fn(async () => ({
+			sessionId: 'source-sync-source-1-session',
+			publishedCommit: 'commit-bootstrap-1',
+			message: 'Bootstrapped source source-1 in job-1.',
+			serverTiming: [{ name: 'bootstrap-git-push', durationMs: 12 }],
+		})),
+		openSession: vi.fn(),
+		applyEdits: vi.fn(),
+		publishSession: vi.fn(),
+		discardSession: vi.fn(async () => ({
+			ok: true as const,
+			sessionId: 'source-sync-source-1-session',
+			deleted: false,
+		})),
+	}
+	mockModule.getEntitySourceById.mockResolvedValueOnce(
+		createUnpublishedSourceRow(),
+	)
+	mockModule.repoSessionRpc.mockReturnValueOnce(bootstrapClient as never)
+
+	const serverTiming: Array<{ name: string; durationMs: number }> = []
+	const bootstrapCommit = await syncArtifactSourceSnapshot({
+		...createSyncEnv(),
+		files: jobFiles,
+		serverTiming,
+	})
+
+	expect(bootstrapCommit).toBe('commit-bootstrap-1')
+	expect(serverTiming.map((entry) => entry.name)).toEqual([
+		'bootstrap-git-push',
+		'bootstrap-source',
+		'published-snapshot',
+		'discard-session',
+	])
+	expect(
+		serverTiming.find((entry) => entry.name === 'bootstrap-git-push')
+			?.durationMs,
+	).toBe(12)
+})

--- a/packages/worker/src/repo/source-sync.ts
+++ b/packages/worker/src/repo/source-sync.ts
@@ -17,6 +17,10 @@ import {
 	writePublishedSourceSnapshot,
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { type EntitySourceRow } from './types.ts'
+import {
+	pushServerTiming,
+	type ServerTimingEntry,
+} from '#worker/server-timing.ts'
 
 type SyncArtifactSourceInput = {
 	env: Env
@@ -35,6 +39,8 @@ type SyncArtifactSourceInput = {
 	expectedPackageScope?: string
 	/** Optional git commit message used when publishing an existing source. */
 	commitMessage?: string
+	/** Request-scoped phase timings; omitted when the caller does not collect. */
+	serverTiming?: Array<ServerTimingEntry>
 }
 
 function validateEntitySourceManifest(input: {
@@ -132,73 +138,91 @@ export async function syncArtifactSourceSnapshot(
 				input.bootstrapAccess?.remote &&
 				isLoopbackArtifactsRemote(input.bootstrapAccess.remote)
 			) {
-				// The local-dev mock lane skips the RepoSession applyEdits gate, so
-				// enforce the per-file limit here for dev/prod parity.
-				const oversizedFile = findOversizedRepoSourceFile(
-					Object.entries(input.files),
-				)
-				if (oversizedFile) {
-					throw new Error(buildRepoLargeFileMessage(oversizedFile))
-				}
-				const snapshot = await writeMockArtifactSnapshot({
-					env: input.env,
-					repoId: source.repo_id,
-					files: input.files,
-				})
-				// Plain repos have no manifest requirement (live-at-HEAD).
-				if (source.entity_kind !== 'repo') {
-					const manifestContent = input.files[source.manifest_path]
-					if (typeof manifestContent !== 'string') {
-						throw new Error(
-							`Manifest "${source.manifest_path}" was not found in the repo source.`,
+				return await pushServerTiming(
+					input.serverTiming,
+					'mock-artifact-snapshot',
+					async () => {
+						// The local-dev mock lane skips the RepoSession applyEdits gate, so
+						// enforce the per-file limit here for dev/prod parity.
+						const oversizedFile = findOversizedRepoSourceFile(
+							Object.entries(input.files),
 						)
-					}
-					validateEntitySourceManifest({
-						entityKind: source.entity_kind,
-						content: manifestContent,
-						manifestPath: source.manifest_path,
-					})
-				}
-				await writePublishedSourceSnapshot({
-					env: input.env,
-					source: {
-						...source,
-						published_commit: snapshot.published_commit,
+						if (oversizedFile) {
+							throw new Error(buildRepoLargeFileMessage(oversizedFile))
+						}
+						const snapshot = await writeMockArtifactSnapshot({
+							env: input.env,
+							repoId: source.repo_id,
+							files: input.files,
+						})
+						// Plain repos have no manifest requirement (live-at-HEAD).
+						if (source.entity_kind !== 'repo') {
+							const manifestContent = input.files[source.manifest_path]
+							if (typeof manifestContent !== 'string') {
+								throw new Error(
+									`Manifest "${source.manifest_path}" was not found in the repo source.`,
+								)
+							}
+							validateEntitySourceManifest({
+								entityKind: source.entity_kind,
+								content: manifestContent,
+								manifestPath: source.manifest_path,
+							})
+						}
+						await writePublishedSourceSnapshot({
+							env: input.env,
+							source: {
+								...source,
+								published_commit: snapshot.published_commit,
+							},
+							files: input.files,
+						})
+						try {
+							await updateEntitySource(input.env.APP_DB, {
+								id: source.id,
+								userId: source.user_id,
+								publishedCommit: snapshot.published_commit,
+								manifestPath: source.manifest_path,
+								sourceRoot: source.source_root,
+							})
+						} catch (error) {
+							await input.env.BUNDLE_ARTIFACTS_KV.delete(
+								buildPublishedSourceSnapshotKvKey({
+									sourceId: source.id,
+									publishedCommit: snapshot.published_commit,
+								}),
+							)
+							throw error
+						}
+						return snapshot.published_commit
 					},
-					files: input.files,
-				})
-				try {
-					await updateEntitySource(input.env.APP_DB, {
-						id: source.id,
-						userId: source.user_id,
-						publishedCommit: snapshot.published_commit,
-						manifestPath: source.manifest_path,
-						sourceRoot: source.source_root,
-					})
-				} catch (error) {
-					await input.env.BUNDLE_ARTIFACTS_KV.delete(
-						buildPublishedSourceSnapshotKvKey({
-							sourceId: source.id,
-							publishedCommit: snapshot.published_commit,
-						}),
-					)
-					throw error
-				}
-				return snapshot.published_commit
+				)
 			}
-			const bootstrapResult = await session.bootstrapSource({
-				sessionId,
-				sourceId: source.id,
-				userId: input.userId,
-				edits,
-				bootstrapAccess: input.bootstrapAccess ?? null,
-			})
-			await writePublishedSnapshotWithRevert({
-				env: input.env,
-				source,
-				files: input.files,
-				publishedCommit: bootstrapResult.publishedCommit,
-			})
+			const bootstrapResult = await pushServerTiming(
+				input.serverTiming,
+				'bootstrap-source',
+				async () => {
+					const result = await session.bootstrapSource({
+						sessionId,
+						sourceId: source.id,
+						userId: input.userId,
+						edits,
+						bootstrapAccess: input.bootstrapAccess ?? null,
+					})
+					if (input.serverTiming && result.serverTiming) {
+						input.serverTiming.push(...result.serverTiming)
+					}
+					return result
+				},
+			)
+			await pushServerTiming(input.serverTiming, 'published-snapshot', () =>
+				writePublishedSnapshotWithRevert({
+					env: input.env,
+					source,
+					files: input.files,
+					publishedCommit: bootstrapResult.publishedCommit,
+				}),
+			)
 			return bootstrapResult.publishedCommit
 		}
 		await session.openSession({
@@ -247,10 +271,10 @@ export async function syncArtifactSourceSnapshot(
 		// persistence and rollback.
 		return publishResult.publishedCommit
 	} finally {
-		await session
-			.discardSession({ sessionId, userId: input.userId })
-			.catch(() => {
+		await pushServerTiming(input.serverTiming, 'discard-session', () =>
+			session.discardSession({ sessionId, userId: input.userId }).catch(() => {
 				// Best effort only; publish/apply failures should preserve the root cause.
-			})
+			}),
+		)
 	}
 }

--- a/packages/worker/src/repo/types.ts
+++ b/packages/worker/src/repo/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { type AuthoredPackageJson } from '#worker/package-registry/types.ts'
+import { type ServerTimingEntry } from '#worker/server-timing.ts'
 
 export const entityKindValues = ['job', 'package', 'repo'] as const
 export type EntityKind = (typeof entityKindValues)[number]
@@ -353,6 +354,7 @@ export type RepoSourceBootstrapResult = {
 	sessionId: string
 	publishedCommit: string
 	message: string
+	serverTiming?: Array<ServerTimingEntry>
 }
 
 export type RepoSessionRebaseResult = {

--- a/packages/worker/src/server-timing.node.test.ts
+++ b/packages/worker/src/server-timing.node.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+import { pushServerTiming, type ServerTimingEntry } from './server-timing.ts'
+
+test('pushServerTiming records duration when a collector is provided and skips when omitted', async () => {
+	const timings: Array<ServerTimingEntry> = []
+	const value = await pushServerTiming(timings, 'phase-a', async () => {
+		await Promise.resolve()
+		return 7
+	})
+	expect(value).toBe(7)
+	expect(timings).toEqual([{ name: 'phase-a', durationMs: expect.any(Number) }])
+	expect(timings[0]?.durationMs).toBeGreaterThanOrEqual(0)
+
+	const skipped = await pushServerTiming(undefined, 'phase-b', async () => 'ok')
+	expect(skipped).toBe('ok')
+	expect(timings).toHaveLength(1)
+})

--- a/packages/worker/src/server-timing.ts
+++ b/packages/worker/src/server-timing.ts
@@ -1,0 +1,24 @@
+export type ServerTimingEntry = {
+	name: string
+	durationMs: number
+}
+
+/**
+ * Request-scoped Server-Timing style phase measurement. Same shape as execute
+ * `serverTiming`: `{ name, durationMs }`, returned on the response, not stored.
+ * `Date.now()` in Workers only advances across I/O, which is what we want for
+ * attributing Artifacts/git round trips.
+ */
+export async function pushServerTiming<T>(
+	timings: Array<ServerTimingEntry> | undefined,
+	name: string,
+	run: () => Promise<T>,
+): Promise<T> {
+	if (!timings) return await run()
+	const startedAt = Date.now()
+	try {
+		return await run()
+	} finally {
+		timings.push({ name, durationMs: Date.now() - startedAt })
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Attribute the ~7–8s `community_fork` floor to real Artifacts/git phases before deciding what to cut. Same shape as execute `serverTiming`: `{ name, durationMs }` on the response, not stored.

We should **not** persist these yet. ADR 0002 puts append-only telemetry in Analytics Engine only when we already know we will read it for reporting. We do not know which phases matter, and D1 is the wrong home for per-fork histograms. If a later probe shows a stable bottleneck worth a dashboard, add an AE dataset then — not a D1 table.

## Summary

- Shared `pushServerTiming` helper (request-scoped collector; no-op when omitted).
- `community_fork` returns optional `serverTiming` phases:
  - `prepare` — listing/snapshot/collision preflight
  - `artifacts-repo-ready`, `entity-source-insert`, `artifacts-push-subscription`
  - `bootstrap-source` — RepoSession RPC wall clock, including isolate startup
  - nested `bootstrap-*` from inside the DO (`git-init`, `write-files`, `commit`, `git-push`, `git-note`, …)
  - `published-snapshot`, `discard-session`, `fork-row`
- Cold start ≈ `bootstrap-source` minus the nested `bootstrap-*` durations.
- `Date.now()` in Workers only advances across I/O, which is what we want for Artifacts/git round trips.
- One-click install does **not** collect timings unless a caller passes a collector (`persistPreparedCommunityFork` stays opt-in).
- Existing `community-phase-timing` console logs from #1409 stay.

## Testing

- `vitest run --project node-unit` on `server-timing`, `community-service`, `source-sync`, `source-service`: passed (including persist opt-in)
- `vitest run --project workers-unit` `community-flow.workers.test.ts`: passed
- `nx run worker:typecheck`: passed
- Preview: https://kody-pr-1412.kody-a99.workers.dev

After merge, `community_fork` a tiny listing with a unique `kody_id` and read `serverTiming` to decide what to cut. Clean up any temp fork.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `64118f58` · **Head:** `39ac0042`

**Classification:** extends — additive optional `serverTiming` on `community_fork` and `bootstrapSource`; fork semantics unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `community-listings` | assistant | extends — `community_fork` output includes optional request-scoped `serverTiming` |
| `repo-sessions` | runtime | extends — `bootstrapSource` returns nested phase timings; `ensureEntitySource` / snapshot sync accept a collector |

### System map

Fork MCP collects phase timings through entity-source setup and RepoSession bootstrap, then returns them on the capability result without writing storage.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	communityListings["community-listings<br/>Community package listings"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	communityListings -->|"serverTiming collector on ensure + sync"| repoSessions
	repoSessions -->|"bootstrap-* phases on bootstrapSource"| communityListings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Fork as community_fork
	participant Source as ensureEntitySource
	participant Sync as syncArtifactSourceSnapshot
	participant DO as RepoSession bootstrapSource
	Fork->>Fork: prepare
	Fork->>Source: artifacts-repo-ready / insert / push-subscription
	Fork->>Sync: bootstrap-source RPC
	Sync->>DO: nested bootstrap-* phases
	Sync-->>Fork: published-snapshot, discard-session
	Fork->>Fork: fork-row
	Fork-->>Fork: return serverTiming (not stored)
```

### Before / after

```
community_fork result
  fork_id, source_id, …          →  same fields
                                 + optional serverTiming: [{ name, durationMs }]
```

### Invariants

Fork stays inert until publish. Timings are response-only; no D1 or Analytics Engine writes. One-click install does not collect unless a collector is passed.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community package forks can now return optional, request-scoped server-timing diagnostics.
  * Timing details cover preparation, repository setup, source creation, snapshot synchronization, and fork completion.
  * Diagnostics include named phases and durations in milliseconds and are not persisted.
  * Nested repository bootstrap phases and CPU-only operations are represented where applicable.

* **Documentation**
  * Updated community package documentation to describe the new `serverTiming` response data and available phases.

* **Tests**
  * Added coverage validating timing entries, ordering, and non-negative durations across fork and repository workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->