### PR TITLE
Polish owner line, onboarding installed prompt, and quick-example copy

### DIFF
--- a/docs/guides/quick-example.md
+++ b/docs/guides/quick-example.md
@@ -76,9 +76,8 @@ lesson for onboarding — not a practice run.
 ## Step 4 — Offer triggers (optional)
 
 Ask whether they want to hang a trigger on it: webhook, Kody app, cron, or skip
-for now. List the options; do **not** recommend one. If they skip, point them at
-`/onboarding` Step 3 to connect real services (GitHub, Google, Slack, Notion,
-and more).
+for now. List the options. If they skip, point them at `/onboarding` Step 3 to
+connect real services (GitHub, Google, Slack, Notion, and more).
 
 ## Troubleshooting
 

--- a/packages/worker/client/routes/onboarding-example-card.tsx
+++ b/packages/worker/client/routes/onboarding-example-card.tsx
@@ -147,8 +147,10 @@ export function OnboardingExampleCard(
 		})
 		const existingInstall = listing.viewerInstall ?? null
 		const alreadyReady = existingInstall != null
+		// Already-installed packages expand on land so the agent prompt is
+		// visible without an extra click (same UI as after "Try this").
 		const showExpandedPrompt =
-			selected || phase === 'installing' || phase === 'error'
+			selected || alreadyReady || phase === 'installing' || phase === 'error'
 		const examplePrompt = buildOnboardingExamplePrompt({
 			listingName: listing.name,
 			kodyId: listing.kodyId,
@@ -250,31 +252,6 @@ export function OnboardingExampleCard(
 							</a>
 						</p>
 					</>
-				) : alreadyReady ? (
-					<button
-						type="button"
-						aria-describedby={`onboarding-example-prompt-tip-${listing.id}`}
-						mix={[
-							css(exampleCopyButtonCss),
-							on('click', () => {
-								selected = true
-								void copyPrompt(examplePrompt)
-							}),
-						]}
-						data-testid={`onboarding-example-copy-${listing.id}`}
-					>
-						{copyState === 'copied'
-							? 'Copied'
-							: copyState === 'error'
-								? 'Copy failed'
-								: 'Copy prompt'}
-						<span
-							id={`onboarding-example-prompt-tip-${listing.id}`}
-							role="tooltip"
-						>
-							{copyPromptTooltip}
-						</span>
-					</button>
 				) : (
 					<button
 						type="button"
@@ -287,15 +264,6 @@ export function OnboardingExampleCard(
 						Try this
 					</button>
 				)}
-				{!showExpandedPrompt && readyStatus ? (
-					<p
-						mix={css(exampleStatusCss)}
-						role="status"
-						data-testid={`onboarding-example-status-${listing.id}`}
-					>
-						{readyStatus}
-					</p>
-				) : null}
 				{errorMessage ? (
 					<p
 						mix={css(exampleErrorCss)}

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -106,48 +106,48 @@ export function CommunityDetailContent(
 							) : null}
 						</span>
 					) : null}
-					<p mix={css(ownerLineCss)}>
-						<span mix={css(ownerUsernameCss)}>
-							by{' '}
-							{ownerProfilePublic ? (
-								<a
-									href={routes.profile.href({
-										username: listing.ownerUsername,
-									})}
-									mix={css(ownerLinkCss)}
+					<p mix={css(ownerLineCss)} data-testid="community-detail-owner-line">
+						{/* Separate flex items (not nested flex + trailing space) so
+						    "by" / @username / follow glyph stay on one line with gap. */}
+						<span>by</span>
+						{ownerProfilePublic ? (
+							<a
+								href={routes.profile.href({
+									username: listing.ownerUsername,
+								})}
+								mix={css(ownerLinkCss)}
+							>
+								@{listing.ownerUsername}
+							</a>
+						) : (
+							<span mix={css(ownerPrivateNameCss)}>
+								@{listing.ownerUsername}
+								<span
+									data-testid="community-detail-owner-private"
+									title="This profile is private"
+									mix={css(ownerPrivateLockCss)}
 								>
-									@{listing.ownerUsername}
-								</a>
-							) : (
-								<>
-									@{listing.ownerUsername}
-									<span
-										data-testid="community-detail-owner-private"
-										title="This profile is private"
-										mix={css(ownerPrivateLockCss)}
+									<svg
+										viewBox="0 0 16 16"
+										width="0.9em"
+										height="0.9em"
+										aria-hidden="true"
+										focusable={false}
+										fill="none"
+										stroke="currentColor"
+										strokeWidth="1.5"
+										strokeLinecap="round"
+										strokeLinejoin="round"
 									>
-										<svg
-											viewBox="0 0 16 16"
-											width="0.9em"
-											height="0.9em"
-											aria-hidden="true"
-											focusable={false}
-											fill="none"
-											stroke="currentColor"
-											strokeWidth="1.5"
-											strokeLinecap="round"
-											strokeLinejoin="round"
-										>
-											<rect x="3.5" y="7.2" width="9" height="6.3" rx="1.4" />
-											<path d="M5.4 7.2V5.4a2.6 2.6 0 0 1 5.2 0v1.8" />
-										</svg>
-										<span mix={css(visuallyHiddenCss)}>
-											This profile is private
-										</span>
+										<rect x="3.5" y="7.2" width="9" height="6.3" rx="1.4" />
+										<path d="M5.4 7.2V5.4a2.6 2.6 0 0 1 5.2 0v1.8" />
+									</svg>
+									<span mix={css(visuallyHiddenCss)}>
+										This profile is private
 									</span>
-								</>
-							)}
-						</span>
+								</span>
+							</span>
+						)}
 						{ownerProfilePublic && !viewerIsOwner
 							? renderProfileFollowControl({
 									username: listing.ownerUsername,
@@ -278,17 +278,12 @@ const ownerLineCss = {
 	display: 'inline-flex',
 	alignItems: 'center',
 	flexWrap: 'nowrap' as const,
-	gap: '0.45rem',
+	gap: '0.35rem',
 	margin: 0,
 	color: colors.textMuted,
 	fontSize: '0.95rem',
-}
-
-const ownerUsernameCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	flexWrap: 'nowrap' as const,
-	minWidth: 0,
+	width: 'max-content',
+	maxWidth: '100%',
 }
 
 const ownerLinkCss = {
@@ -300,12 +295,17 @@ const ownerLinkCss = {
 	},
 }
 
+const ownerPrivateNameCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.25rem',
+	minWidth: 0,
+}
+
 const ownerPrivateLockCss = {
 	display: 'inline-flex',
 	alignItems: 'center',
-	marginLeft: '0.35rem',
 	color: colors.textMuted,
-	verticalAlign: 'middle',
 	cursor: 'help',
 	flexShrink: 0,
 }

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -110,6 +110,8 @@ test('community detail handler returns bare detail frame HTML for target header'
 	expect(publicHtml).toContain('data-testid="community-detail-frame"')
 	expect(publicHtml).toContain('data-testid="community-listing-icon-detail"')
 	expect(publicHtml).toContain('/community/listing-1/icon/abc1234567890')
+	expect(publicHtml).toContain('data-testid="community-detail-owner-line"')
+	expect(publicHtml).toContain('>by</')
 	expect(publicHtml).toContain('href="/@kentcdodds"')
 	expect(publicHtml).toContain('>@kentcdodds</a>')
 	expect(publicHtml).toContain('data-testid="community-detail-owner-follow"')
@@ -133,7 +135,8 @@ test('community detail handler returns bare detail frame HTML for target header'
 		url: new URL('https://example.com/community/listing-1'),
 	} as never)
 	const privateHtml = await privateResponse.text()
-	expect(privateHtml).toContain('by @kentcdodds')
+	expect(privateHtml).toContain('>by</')
+	expect(privateHtml).toContain('@kentcdodds')
 	expect(privateHtml).toContain('data-testid="community-detail-owner-private"')
 	expect(privateHtml).toContain('title="This profile is private"')
 	expect(privateHtml).not.toContain('href="/@kentcdodds"')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three small UX polish items:

1. **`/guides/quick-example`** — drop the unnecessary “do not recommend one” instruction when listing trigger options.
2. **Package details owner line** — keep `by`, `@owner`, and the follow glyph on one inline row with gap spacing (nested flex was collapsing the space after “by” and letting the glyph wrap).
3. **Onboarding Step 2** — if an example package is already installed, expand the card and show the agent prompt on land (same UI as after “Try this”).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `6e812b1` · **Head:** `19235063`

**Classification:** composes — docs/copy and app-ui layout wiring only.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — owner-line layout + onboarding example card expand |
| _(docs)_ | — | quick-example guide copy |

### System map

Guide markdown, community detail frame HTML, and onboarding example cards are presentation-only tweaks.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>App UI"]:::touched
	appUi -->|"owner line + onboarding prompt expand"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87b86af0-268c-44bd-b09a-13f4bbb47faa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87b86af0-268c-44bd-b09a-13f4bbb47faa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Already-installed onboarding packages now open directly to their prompt details, including ready status.
  * Improved community owner display for clearer separation of labels, usernames, and private-profile indicators.

* **Documentation**
  * Clarified optional-trigger setup instructions.
  * Explained that skipping triggers sends real-service connections to Step 3 of onboarding.
  * Removed the explicit prohibition against recommending a specific trigger option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->