### PR TITLE
fix(package-apps): __kody_handoff stays on the 403 page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -575,7 +575,7 @@ jobs:
             if curl --fail --silent --show-error --location --max-time 10 \
               --header "Accept: application/json" \
               "$HEALTHCHECK_URL" > runtime-health.json && \
-              node -e "const fs = require('node:fs'); const json = JSON.parse(fs.readFileSync('runtime-health.json','utf8')); const expected = process.env.EXPECTED_COMMIT_SHA; if (json?.status !== 'ok') { console.error('runtime-healthcheck-unexpected-response', json); process.exit(1); } if (json?.commitSha !== expected) { console.error('runtime-healthcheck-unexpected-commit-sha', { expected, actual: json?.commitSha }); process.exit(1); } console.log('runtime-healthcheck-ok', json);"; then
+              node -e "const fs = require('node:fs'); const json = JSON.parse(fs.readFileSync('runtime-health.json','utf8')); const expected = process.env.EXPECTED_COMMIT_SHA; if (json?.status !== 'ok') { console.error('runtime-healthcheck-unexpected-response', json); process.exit(1); } if (json?.commitSha !== expected) { console.error('runtime-healthcheck-unexpected-commit-sha', { expected, actual: json?.commitSha }); process.exit(1); } if (json?.cookieSecretConfigured !== true) { console.error('runtime-healthcheck-missing-cookie-secret', json); process.exit(1); } console.log('runtime-healthcheck-ok', json);"; then
               exit 0
             fi
             sleep "$delay_seconds"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -513,7 +513,7 @@ jobs:
             if curl --fail --silent --show-error --location --max-time 10 \
               --header "Accept: application/json" \
               "$HEALTHCHECK_URL" > runtime-health.json && \
-              node -e "const fs = require('node:fs'); const json = JSON.parse(fs.readFileSync('runtime-health.json','utf8')); const expected = process.env.EXPECTED_COMMIT_SHA; if (json?.status !== 'ok') { console.error('runtime-healthcheck-unexpected-response', json); process.exit(1); } if (json?.commitSha !== expected) { console.error('runtime-healthcheck-unexpected-commit-sha', { expected, actual: json?.commitSha }); process.exit(1); } console.log('runtime-healthcheck-ok', json);"; then
+              node -e "const fs = require('node:fs'); const json = JSON.parse(fs.readFileSync('runtime-health.json','utf8')); const expected = process.env.EXPECTED_COMMIT_SHA; if (json?.status !== 'ok') { console.error('runtime-healthcheck-unexpected-response', json); process.exit(1); } if (json?.commitSha !== expected) { console.error('runtime-healthcheck-unexpected-commit-sha', { expected, actual: json?.commitSha }); process.exit(1); } if (json?.cookieSecretConfigured !== true) { console.error('runtime-healthcheck-missing-cookie-secret', json); process.exit(1); } console.log('runtime-healthcheck-ok', json);"; then
               exit 0
             fi
             sleep "$delay_seconds"

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -389,6 +389,17 @@ that exposure but cannot eliminate it. The 60-second expiry and the single-use
 burn are what bound the damage when a token does leak. A request that still
 carries the parameter is rewritten without it before package code sees it.
 
+Mint and consume must share `COOKIE_SECRET`. In production the app-origin mint
+(`/@{username}/packages/...`) is forwarded to `kody-runtime`, and the subdomain
+exchange is served by that same script's zone routes. If a leftover main-worker
+route still receives `{username}.kodyapps.dev`, the main Worker must forward it
+too (`isRuntimeWorkerOwnedRequest` matches every package-app host, not only the
+apex). A `COOKIE_SECRET` mismatch, or a missing secret swallowed as "invalid
+token", leaves the visitor on the 403 page with `__kody_handoff` still in the
+URL and no `Set-Cookie`. Missing `COOKIE_SECRET` on consume fails closed with
+500; signature / expiry / path / replay rejects log a reason without the token
+and set `X-Kody-Handoff: rejected`.
+
 **Package-app session cookie**
 (`packages/worker/src/app/package-app-session.ts`). Exchanging a valid token on
 the owner's subdomain sets `__Host-kody_pkg_session` on secure requests (plain

--- a/packages/shared/src/runtime-worker.node.test.ts
+++ b/packages/shared/src/runtime-worker.node.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest'
+import { buildRuntimeWorkerHealth } from './runtime-worker.ts'
+
+test('runtime health reports whether COOKIE_SECRET is configured', () => {
+	expect(
+		buildRuntimeWorkerHealth({
+			commitSha: '  abc  ',
+			cookieSecretConfigured: true,
+		}),
+	).toEqual({
+		status: 'ok',
+		commitSha: 'abc',
+		cookieSecretConfigured: true,
+	})
+	expect(
+		buildRuntimeWorkerHealth({
+			commitSha: undefined,
+			cookieSecretConfigured: false,
+		}),
+	).toEqual({
+		status: 'ok',
+		commitSha: null,
+		cookieSecretConfigured: false,
+	})
+})

--- a/packages/shared/src/runtime-worker.ts
+++ b/packages/shared/src/runtime-worker.ts
@@ -4,11 +4,12 @@
  *
  * The main Worker reaches the runtime Worker over a plain HTTP service
  * binding (`RUNTIME_WORKER`). The contract is deliberately coarse-grained:
- * whole runtime-owned requests (package-app origin, inline package apps,
- * package invocation API) are forwarded wholesale, and the only structured
- * endpoint is the deploy healthcheck below. Durable Object access in either
- * direction (RunLog reads from the main Worker, UserMeter writes from the
- * runtime Worker) uses cross-script Durable Object bindings, not RPC.
+ * whole runtime-owned requests (package-app origin including per-user
+ * subdomains, inline package apps, package invocation API) are forwarded
+ * wholesale, and the only structured endpoint is the deploy healthcheck below.
+ * Durable Object access in either direction (RunLog reads from the main Worker,
+ * UserMeter writes from the runtime Worker) uses cross-script Durable Object
+ * bindings, not RPC.
  */
 
 /** Healthcheck endpoint served by the runtime Worker. */
@@ -17,11 +18,17 @@ export const runtimeWorkerHealthPath = '/__runtime/health'
 export type RuntimeWorkerHealth = {
 	status: 'ok'
 	commitSha: string | null
+	cookieSecretConfigured: boolean
 }
 
-export function buildRuntimeWorkerHealth(
-	commitSha: string | undefined,
-): RuntimeWorkerHealth {
-	const trimmed = commitSha?.trim()
-	return { status: 'ok', commitSha: trimmed ? trimmed : null }
+export function buildRuntimeWorkerHealth(input: {
+	commitSha: string | undefined
+	cookieSecretConfigured: boolean
+}): RuntimeWorkerHealth {
+	const trimmed = input.commitSha?.trim()
+	return {
+		status: 'ok',
+		commitSha: trimmed ? trimmed : null,
+		cookieSecretConfigured: input.cookieSecretConfigured,
+	}
 }

--- a/packages/worker/src/app/package-app-handoff.node.test.ts
+++ b/packages/worker/src/app/package-app-handoff.node.test.ts
@@ -14,6 +14,10 @@ import {
 	readPackageAppSession,
 	resetPackageAppSessionCookieForTests,
 } from '#app/package-app-session.ts'
+import {
+	consoleWarn,
+	silenceExpectedConsoleWarns,
+} from '#worker/test-support/console-spies.ts'
 
 const cookieSecret = 'PACKAGE_APP_TEST_COOKIE_SECRET_32_CHARS_MINIMUM'
 const ownerStableUserId = '1'.repeat(64)
@@ -41,6 +45,7 @@ const claims = {
 const expected = { username: claims.username, kodyId: claims.kodyId }
 
 test('handoff tokens are single use, short lived, and bound to one user and package', async () => {
+	silenceExpectedConsoleWarns(['Package app handoff rejected.'])
 	const env = createTestEnv()
 
 	const token = await createPackageAppHandoffToken({ env, claims })
@@ -53,6 +58,9 @@ test('handoff tokens are single use, short lived, and bound to one user and pack
 	await expect(
 		consumePackageAppHandoffToken({ env, token, expected }),
 	).resolves.toBeNull()
+	expect(consoleWarn).toHaveBeenCalledWith('Package app handoff rejected.', {
+		reason: 'replay',
+	})
 
 	// Expired tokens fail closed, even unused ones.
 	const staleToken = await createPackageAppHandoffToken({
@@ -136,6 +144,16 @@ test('handoff tokens are single use, short lived, and bound to one user and pack
 			expected,
 		}),
 	).resolves.toStrictEqual(claims)
+
+	// Missing COOKIE_SECRET must throw rather than look like an invalid token,
+	// otherwise the visitor stays on the 403 page with `__kody_handoff` in the URL.
+	await expect(
+		consumePackageAppHandoffToken({
+			env: createTestEnv({ cookieSecret: '' }),
+			token: await createPackageAppHandoffToken({ env, claims }),
+			expected,
+		}),
+	).rejects.toThrow(/COOKIE_SECRET/)
 })
 
 test('the package-app session cookie is not interchangeable with the app session cookie', async () => {

--- a/packages/worker/src/app/package-app-handoff.ts
+++ b/packages/worker/src/app/package-app-handoff.ts
@@ -124,33 +124,53 @@ export async function consumePackageAppHandoffToken(input: {
 }): Promise<PackageAppHandoffClaims | null> {
 	const now = input.now ?? Date.now()
 	const [payload, signature, ...rest] = input.token.split('.')
-	if (!payload || !signature || rest.length > 0) return null
+	if (!payload || !signature || rest.length > 0) {
+		console.warn('Package app handoff rejected.', { reason: 'malformed' })
+		return null
+	}
 
+	// Missing COOKIE_SECRET must fail loudly (500), not look like an invalid
+	// token. Mint and consume run on the runtime Worker in production; if this
+	// isolate cannot import the signing key, the visitor otherwise lands on the
+	// 403 handoff page with `__kody_handoff` still in the URL.
+	const signingKey = await getHandoffSigningKey(input.env)
 	let signatureValid: boolean
 	try {
 		signatureValid = await crypto.subtle.verify(
 			'HMAC',
-			await getHandoffSigningKey(input.env),
+			signingKey,
 			base64UrlToBytes(signature),
 			signedMessage(payload),
 		)
 	} catch {
+		console.warn('Package app handoff rejected.', { reason: 'signature' })
 		return null
 	}
-	if (!signatureValid) return null
+	if (!signatureValid) {
+		console.warn('Package app handoff rejected.', { reason: 'signature' })
+		return null
+	}
 
 	let parsed: unknown
 	try {
 		parsed = JSON.parse(new TextDecoder().decode(base64UrlToBytes(payload)))
 	} catch {
+		console.warn('Package app handoff rejected.', { reason: 'payload' })
 		return null
 	}
-	if (!isStoredHandoffPayload(parsed)) return null
-	if (parsed.exp <= now) return null
+	if (!isStoredHandoffPayload(parsed)) {
+		console.warn('Package app handoff rejected.', { reason: 'payload' })
+		return null
+	}
+	if (parsed.exp <= now) {
+		console.warn('Package app handoff rejected.', { reason: 'expired' })
+		return null
+	}
 	if (
 		parsed.usr !== input.expected.username ||
 		parsed.pkg !== input.expected.kodyId
 	) {
+		console.warn('Package app handoff rejected.', { reason: 'path' })
 		return null
 	}
 
@@ -158,7 +178,10 @@ export async function consumePackageAppHandoffToken(input: {
 	if (replayStore) {
 		const replayKey = `${handoffReplayKeyPrefix}${parsed.jti}`
 		try {
-			if (await replayStore.get(replayKey)) return null
+			if (await replayStore.get(replayKey)) {
+				console.warn('Package app handoff rejected.', { reason: 'replay' })
+				return null
+			}
 			await replayStore.put(replayKey, '1', {
 				expirationTtl: handoffReplayTtlSeconds,
 			})

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -159,19 +159,29 @@ function buildAppOriginEntryUrl(input: {
 function createPackageAppSessionRequiredResponse(input: {
 	request: Request
 	appOriginUrl: URL
+	handoffPresented: boolean
 }) {
 	const openUrl = input.appOriginUrl.toString()
+	const headers = {
+		'Cache-Control': 'no-store',
+		'X-Kody-Handoff': input.handoffPresented ? 'rejected' : 'required',
+	}
+	const message = input.handoffPresented
+		? 'Kody could not complete the session handoff. The link may have expired or already been used.'
+		: 'Hosted package apps run on their own domain and need a Kody handoff before they can load.'
 	if (wantsJson(input.request)) {
 		return Response.json(
 			{
 				error: 'Package app session required',
-				message:
-					'Hosted package apps run on their own domain and need a Kody handoff before they can load.',
+				message,
 				next_step: `Open the app from Kody at ${openUrl}.`,
 			},
-			{ status: 403, headers: { 'Cache-Control': 'no-store' } },
+			{ status: 403, headers },
 		)
 	}
+	const troubleshooting = input.handoffPresented
+		? 'If Continue keeps bringing you back here with the handoff parameter still in the address bar, the package-app domain did not accept the token. That is not a cookie setting — try once more, and if it still fails this is a server-side handoff problem.'
+		: "If you keep landing here, your browser is refusing this site's cookie. Allow cookies for this domain and try again."
 	return createHtmlResponse(
 		html`<!doctype html>
 			<html lang="en">
@@ -201,14 +211,11 @@ function createPackageAppSessionRequiredResponse(input: {
 							off your signed-in session before this app can load.
 						</p>
 						<p><a href="${openUrl}">Continue to this app</a></p>
-						<p>
-							If you keep landing here, your browser is refusing this site's
-							cookie. Allow cookies for this domain and try again.
-						</p>
+						<p>${troubleshooting}</p>
 					</main>
 				</body>
 			</html>`,
-		{ status: 403, headers: { 'Cache-Control': 'no-store' } },
+		{ status: 403, headers },
 	)
 }
 
@@ -372,6 +379,7 @@ async function handleUserSubdomainRequest(input: {
 		return createPackageAppSessionRequiredResponse({
 			request,
 			appOriginUrl: buildAppOriginEntryUrl({ appBaseUrl, packagePath, url }),
+			handoffPresented: Boolean(handoffToken),
 		})
 	}
 

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -11,6 +11,7 @@ import {
 	buildPackageAppNotFoundMessage,
 	buildUnmatchedPackageAppOriginPathMessage,
 } from '#worker/package-runtime/package-app-synthetic.ts'
+import { silenceExpectedConsoleWarns } from '#worker/test-support/console-spies.ts'
 import {
 	ensurePackageSubscriptionTestSchema,
 	ensureRbacTestSchema,
@@ -107,6 +108,7 @@ function cookieValue(setCookieHeader: string) {
 }
 
 test('hosted package apps move to the owner subdomain behind a single-use handoff', async () => {
+	silenceExpectedConsoleWarns(['Package app handoff rejected.'])
 	configureOrigins({
 		packageAppBaseUrl: packageAppOrigin,
 		runtime: 'production',
@@ -202,15 +204,26 @@ test('hosted package apps move to the owner subdomain behind a single-use handof
 	// package-app session. Both terminate here (never a redirect back to the app
 	// origin) so a browser that drops the cookie cannot ping-pong between hosts.
 	// The terminal page links to the app-origin entry path that restarts the
-	// handoff.
-	for (const request of [handoffLocation, cleanLocation]) {
-		const rejected = await workerFetch(request)
-		expect(rejected.status).toBe(403)
-		expect(rejected.headers.get('Location')).toBeNull()
-		await expect(rejected.text()).resolves.toContain(
-			`${appOrigin}/@${ownerUsername}/packages/demo/report`,
-		)
-	}
+	// handoff. A presented-but-rejected token is not a cookie problem.
+	const replayed = await workerFetch(handoffLocation)
+	expect(replayed.status).toBe(403)
+	expect(replayed.headers.get('Location')).toBeNull()
+	expect(replayed.headers.get('X-Kody-Handoff')).toBe('rejected')
+	const replayedBody = await replayed.text()
+	expect(replayedBody).toContain(
+		`${appOrigin}/@${ownerUsername}/packages/demo/report`,
+	)
+	expect(replayedBody).toContain(
+		'the package-app domain did not accept the token',
+	)
+	const missingSession = await workerFetch(cleanLocation)
+	expect(missingSession.status).toBe(403)
+	expect(missingSession.headers.get('X-Kody-Handoff')).toBe('required')
+	const missingSessionBody = await missingSession.text()
+	expect(missingSessionBody).toContain(
+		`${appOrigin}/@${ownerUsername}/packages/demo/report`,
+	)
+	expect(missingSessionBody).toContain('your browser is refusing this site')
 	const rejectedJson = await workerFetch(cleanLocation, {
 		headers: { Accept: 'application/json' },
 	})

--- a/packages/worker/src/runtime-worker-routing.node.test.ts
+++ b/packages/worker/src/runtime-worker-routing.node.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'vitest'
+import { isRuntimeWorkerOwnedRequest } from '#worker/runtime-worker-routing.ts'
+
+const packageAppOrigin = 'https://kodyapps.dev'
+
+function request(url: string) {
+	return new Request(url)
+}
+
+function env(input: { packageAppBaseUrl?: string } = {}) {
+	return {
+		PACKAGE_APP_BASE_URL: input.packageAppBaseUrl,
+	} as Env
+}
+
+test('runtime-owned requests include package-app apex, user subdomains, and app-origin package paths', () => {
+	const production = env({ packageAppBaseUrl: packageAppOrigin })
+
+	expect(
+		isRuntimeWorkerOwnedRequest(request(`${packageAppOrigin}/`), production),
+	).toBe(true)
+	expect(
+		isRuntimeWorkerOwnedRequest(
+			request('https://kentcdodds.kodyapps.dev/packages/hn-pulse'),
+			production,
+		),
+	).toBe(true)
+	expect(
+		isRuntimeWorkerOwnedRequest(
+			request(
+				'https://kentcdodds.kodyapps.dev/packages/hn-pulse?__kody_handoff=token',
+			),
+			production,
+		),
+	).toBe(true)
+	// Wildcard DNS still delivers nested/invalid labels; runtime owns the 404.
+	expect(
+		isRuntimeWorkerOwnedRequest(
+			request('https://a.b.kodyapps.dev/packages/hn-pulse'),
+			production,
+		),
+	).toBe(true)
+	expect(
+		isRuntimeWorkerOwnedRequest(
+			request('https://heykody.app/@kentcdodds/packages/hn-pulse'),
+			production,
+		),
+	).toBe(true)
+	expect(
+		isRuntimeWorkerOwnedRequest(
+			request(
+				'https://heykody.app/@kentcdodds/api/package-invocations/demo/run',
+			),
+			production,
+		),
+	).toBe(true)
+
+	expect(
+		isRuntimeWorkerOwnedRequest(
+			request('https://heykody.app/account'),
+			production,
+		),
+	).toBe(false)
+	expect(
+		isRuntimeWorkerOwnedRequest(
+			request('https://heykody.app/login'),
+			production,
+		),
+	).toBe(false)
+})

--- a/packages/worker/src/runtime-worker-routing.ts
+++ b/packages/worker/src/runtime-worker-routing.ts
@@ -1,18 +1,26 @@
-import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
+import { parsePackageAppRequestHost } from '#worker/app-base-url.ts'
 import { isPackageInvocationApiRequest } from '#worker/package-invocations/http.ts'
 import { isPackageAppRequestPath } from '#worker/package-runtime/package-app-serve.ts'
 
 /**
  * Requests owned by the package runtime Worker (`kody-runtime`): everything on
- * the package-app origin, inline package-app paths on the app origin, and the
- * package invocation API. When the main Worker has a `RUNTIME_WORKER` service
- * binding it forwards these wholesale; without the binding (tests, single
- * Worker local dev) the main Worker keeps serving them in-process.
+ * the package-app origin (apex, per-user subdomains, and unrecognized labels
+ * the wildcard still delivers), inline package-app paths on the app origin, and
+ * the package invocation API. When the main Worker has a `RUNTIME_WORKER`
+ * service binding it forwards these wholesale; without the binding (tests,
+ * single Worker local dev) the main Worker keeps serving them in-process.
+ *
+ * Matching the apex origin alone is not enough. Production serves each owner's
+ * apps on `{username}.<package-app host>`, and the handoff token is exchanged
+ * there. If that request ever lands on the main Worker (leftover zone route,
+ * workers.dev probe, mis-attached custom domain), it must still reach the same
+ * script that minted the token — otherwise HMAC verification uses a different
+ * `COOKIE_SECRET` and the visitor is stuck on the 403 handoff page with
+ * `__kody_handoff` still in the URL.
  */
 export function isRuntimeWorkerOwnedRequest(request: Request, env: Env) {
 	const url = new URL(request.url)
-	const packageAppOrigin = getPackageAppBaseUrl({ env })
-	if (packageAppOrigin && url.origin === packageAppOrigin) return true
+	if (parsePackageAppRequestHost({ env, url })) return true
 	return (
 		isPackageInvocationApiRequest(url.pathname) ||
 		isPackageAppRequestPath(url.pathname)

--- a/packages/worker/src/runtime-worker.ts
+++ b/packages/worker/src/runtime-worker.ts
@@ -54,9 +54,10 @@ const runtimeWorkerHandler = {
 
 		if (url.pathname === runtimeWorkerHealthPath) {
 			return Response.json(
-				buildRuntimeWorkerHealth(
-					(env as { APP_COMMIT_SHA?: string }).APP_COMMIT_SHA,
-				),
+				buildRuntimeWorkerHealth({
+					commitSha: (env as { APP_COMMIT_SHA?: string }).APP_COMMIT_SHA,
+					cookieSecretConfigured: Boolean(env.COOKIE_SECRET?.trim()),
+				}),
 			)
 		}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Investigation

A HAR from production (`heykody.app` → `kentcdodds.kodyapps.dev/packages/hn-pulse?__kody_handoff=…`) shows the handoff mint succeeding and the exchange failing:

1. `GET https://heykody.app/@kentcdodds/packages/hn-pulse` → **302** with a well-formed v2 token (`usr=kentcdodds`, `pkg=hn-pulse`, `exp` ~60s out).
2. `GET https://kentcdodds.kodyapps.dev/packages/hn-pulse?__kody_handoff=…` → **403** HTML (“Open this package app from Kody”), **no `Set-Cookie`**, token still in the URL.

That combination is conclusive: `consumePackageAppHandoffToken` returned `null`. The cookie was never offered. The 403 copy that blamed the browser for refusing cookies was the wrong diagnosis.

Decoded token (valid at the time of the request):

- `v: 2`, `usr: kentcdodds`, `pkg: hn-pulse`
- path and expiry match the request
- mint ran on `heykody.app` (SLC); consume ran on `kodyapps.dev` (LAX)

After ADR 0016 those are different ingresses of `kody-runtime` (service-binding forward vs zone routes). HMAC verification only works if they share `COOKIE_SECRET`. A leftover main-worker route on `{username}.kodyapps.dev` made that worse: `isRuntimeWorkerOwnedRequest` only treated the **apex** origin as runtime-owned, so a subdomain request that landed on `kody` would consume with the main worker’s secret after the mint had already been forwarded to `kody-runtime`.

## Recommendation

**Production check (do this even after this PR):** confirm `kodyapps.dev/*` and `*.kodyapps.dev/*` are attached to the same script the main worker’s `RUNTIME_WORKER` binding targets (`kody-runtime`, not `kody-runtime-production` or leftover `kody`), and that `COOKIE_SECRET` on that script matches production. After deploy, a rejected token logs `Package app handoff rejected. { reason: "signature" | "replay" | … }` (never the token) and the 403 sets `X-Kody-Handoff: rejected`.

## Code changes

- Forward every package-app host (apex, per-user subdomain, unrecognized wildcard labels) to `kody-runtime`, not just the apex origin.
- Missing `COOKIE_SECRET` on consume throws (500) instead of looking like an invalid token (403 with `__kody_handoff` still in the URL).
- 403 copy distinguishes “token presented and rejected” from “no session / cookie refused”.
- Runtime `/__runtime/health` reports `cookieSecretConfigured`; production and preview healthchecks fail closed if it is not `true`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6e812b16` · **Head:** `e0e7f4e1`

**Classification:** extends — handoff consume, 403 contract, and runtime-worker forwarding change behavior of the existing package-app session exchange.

### Primitives touched

| Primitive | Group    | Impact                                                                                          |
| --------- | -------- | ----------------------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — handoff consume no longer swallows a missing signing key; 403 distinguishes rejection |

### System map

Package-app session handoff is minted on the app origin, forwarded to the runtime worker, and exchanged on the per-user package-app subdomain.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appUi -->|"forward every package-app host"| appUi
	appUi -->|"consume logs reason; 403 X-Kody-Handoff"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Browser
	participant Heykody as heykody.app (kody)
	participant Runtime as kody-runtime
	Browser->>Heykody: GET /@user/packages/id
	Heykody->>Runtime: RUNTIME_WORKER.fetch (package path)
	Runtime-->>Browser: 302 Location ?__kody_handoff=
	Browser->>Runtime: GET username.kodyapps.dev/packages/id?__kody_handoff=
	Note over Runtime: HMAC + path + replay
	alt valid
		Runtime-->>Browser: 302 Set-Cookie __Host-kody_pkg_session
	else rejected
		Runtime-->>Browser: 403 X-Kody-Handoff: rejected
	end
```

### Before / after

| Case                         | Before                                      | After                                              |
| ---------------------------- | ------------------------------------------- | -------------------------------------------------- |
| `{user}.kodyapps.dev` on `kody` | Not forwarded (apex-only origin match)    | Forwarded to `kody-runtime`                        |
| Missing `COOKIE_SECRET`      | Swallowed as invalid token → 403            | Throws → 500                                       |
| Token in URL, consume fails  | “browser is refusing this site's cookie”    | Token-rejected copy + `X-Kody-Handoff: rejected`   |
| Runtime health               | `{ status, commitSha }`                     | also `cookieSecretConfigured` (healthcheck gated)  |

### Invariants

Per-user isolation of hosted package apps is unchanged: tokens stay bound to one `username`/`kodyId`, and the package-app session cookie stays host-scoped.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-484e44eb-3777-44ab-992b-390c65a3744e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-484e44eb-3777-44ab-992b-390c65a3744e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

