### PR TITLE
Point the MCP Registry entry at kody.codes (v1.0.2)

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,8 +3,8 @@
 	"name": "io.github.kentcdodds/kody",
 	"title": "Kody",
 	"description": "Personal assistant MCP server with search, execute, packages, jobs, secrets, and integrations.",
-	"version": "1.0.1",
-	"websiteUrl": "https://heykody.app",
+	"version": "1.0.2",
+	"websiteUrl": "https://kody.codes",
 	"repository": {
 		"url": "https://github.com/kentcdodds/kody",
 		"source": "github"
@@ -12,7 +12,7 @@
 	"remotes": [
 		{
 			"type": "streamable-http",
-			"url": "https://heykody.app/mcp"
+			"url": "https://kody.codes/mcp"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Companion to #1418, per the #1417 flip sequence: merging this republishes `server.json` to the MCP Registry, so it merges **only after** kody.codes is attached, serving, and verified canonical. Version bumps to 1.0.2 because the registry rejects duplicate versions (learned in #1293).

Existing clients on `https://heykody.app/mcp` and `https://heykody.dev/mcp` keep working (`/mcp` is never redirected) until those hosts retire per #1300.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `77db258a` · **Head:** `bd8fa143`

**Classification:** composes — registry metadata only; no code paths touched.

### Primitives touched

| Primitive    | Group    | Impact                                                  |
| ------------ | -------- | ------------------------------------------------------- |
| `mcp-server` | surfaces | composes — registry entry v1.0.2 → https://kody.codes/mcp |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01e21ce8-0ad4-4f1d-aac4-2a50dcefa108?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01e21ce8-0ad4-4f1d-aac4-2a50dcefa108&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

