### PR TITLE
Reposition the homepage as a personal software factory

### DIFF
--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -19,7 +19,7 @@ const publicRoutes: RouteScenario[] = [
 		ready: async (page) => {
 			await expect(
 				page.getByRole('heading', {
-					name: /Your AI agent,\s*finally useful\./i,
+					name: /When your agent figures it out,\s*Kody makes it permanent\./i,
 				}),
 			).toBeVisible()
 		},

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -17,7 +17,9 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 		}),
 	).toBeVisible()
 	await expect(
-		page.getByRole('heading', { name: /Your AI agent,\s*finally useful\./i }),
+		page.getByRole('heading', {
+			name: /When your agent figures it out,\s*Kody makes it permanent\./i,
+		}),
 	).toBeVisible()
 
 	await page.goto('/account')

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -150,7 +150,7 @@ export function App(handle: Handle<AppProps>) {
 		const loginHref = buildAuthLink('/login', oauthRedirectTo)
 		// Redesigned pages own their own layout (gutters, measures, max-width
 		// container), so `<main>` must not add its generic padding on top. The
-		// landing page also owns its own waitlist close (the "Equip your agent"
+		// landing page also owns its own waitlist close (the "Make it permanent"
 		// section), so the compact strip would double up there.
 		const isRedesignedMarketingPath =
 			currentPathname === '/' ||

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -181,9 +181,9 @@ export function HomeRoute(handle: Handle) {
 						Kody makes it <em>permanent</em>.
 					</h1>
 					<p data-rise style={{ '--rise': '1' }} mix={css(heroSubCss)}>
-						A personal software factory for the agent you already use. Packages
-						you own, run with no model in the loop, from Cursor, Claude,
-						ChatGPT, or your phone.
+						A personal <strong>software factory</strong> for the agent you
+						already use. Packages you own, run with no model in the loop, from
+						Cursor, Claude, ChatGPT, or your phone.
 					</p>
 					<div data-rise style={{ '--rise': '2' }} mix={css(heroActionsCss)}>
 						{isSignedIn ? (
@@ -755,6 +755,10 @@ const heroSubCss = {
 	color: colors.textMuted,
 	maxWidth: '56ch',
 	textWrap: 'pretty' as const,
+	'& strong': {
+		fontWeight: 700,
+		color: colors.text,
+	},
 }
 
 const heroActionsCss = {

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -36,31 +36,47 @@ import {
 } from '#universal/styles/style-primitives.ts'
 
 /**
- * heykody.dev landing page, ported from the redesign prototype
+ * heykody.app landing page, ported from the redesign prototype
  * (`landing/landing.html`). Flat neutral canvas, one vibrant green accent,
  * centered single-column flow, mascot illustrations doing the explanatory
  * work. Motion is enhance-only (`html.js`) and fully off under
  * `prefers-reduced-motion`.
+ *
+ * Positioning: permanence / personal software factory — not "equip your
+ * agent." Factory-loop art reuses the existing 3D set; do not generate a
+ * new koala.
  */
 
-const capabilityItems = [
+const factoryBeats = [
 	{
-		src: '/images/kody-slack-catchup.webp',
-		alt: 'Kody carrying a neat stack of Slack messages while a reminder bell rings overhead',
-		prompt: '“Catch me up on Slack”',
-		copy: 'Your agent reads the right channels and hands you the three things that actually need you. Kody supplies the Slack access.',
+		trigger: 'Cron',
+		title: 'Nightly release notes',
+		copy: 'The nightly-release job. The agent wrote the changelog once; a cron publishes it and skips quiet days.',
 	},
 	{
-		src: '/images/kody-plan-week.webp',
-		alt: 'Kody arranging a fan of calendar pages, emails, and a clock into an orderly arc',
-		prompt: '“Plan my week”',
-		copy: 'Calendar, email, and open issues in one pass: your agent drafts the schedule and books the focus time. Kody holds the keys to all three.',
+		trigger: 'Webhook',
+		title: 'A Sentry issue lands',
+		copy: 'sentry-triage starts a cloud agent. Nobody opened chat.',
 	},
 	{
-		src: '/images/kody-github-triage.webp',
-		alt: 'Kody sorting GitHub issues into labeled trays, holding one card up for review',
-		prompt: '“Triage my GitHub issues”',
-		copy: 'Labels, duplicates, and a morning brief on what changed while you slept. Your agent set it up once; a Kody job runs it every day.',
+		trigger: 'Cron',
+		title: 'Morning briefing',
+		copy: '7am Denver. It runs every morning.',
+	},
+] as const
+
+const permanenceClaims = [
+	{
+		title: 'No model in the loop',
+		copy: 'Saved packages run on cron, webhook, or invoke. No tokens, no prompt drift, nothing waiting on a model.',
+	},
+	{
+		title: 'Keys the agent never sees',
+		copy: "Secrets stay server-side and never enter the prompt or your agent's context.",
+	},
+	{
+		title: 'Every install is a fork you own',
+		copy: 'Community packages land in your git, on your credentials, that you can open, change, and republish.',
 	},
 ] as const
 
@@ -160,14 +176,14 @@ export function HomeRoute(handle: Handle) {
 				{/* ============ hero ============ */}
 				<section data-parallax-scope mix={css(heroCss)}>
 					<h1 data-rise style={{ '--rise': '0' }} mix={css(heroTitleCss)}>
-						Your AI agent,
+						When your agent figures it out,
 						<br />
-						finally <em>useful</em>.
+						Kody makes it <em>permanent</em>.
 					</h1>
 					<p data-rise style={{ '--rise': '1' }} mix={css(heroSubCss)}>
-						Not another agent. Kody equips the one you already use with secure
-						access to your services and jobs that run while your laptop is
-						closed.
+						A personal software factory for the agent you already use. Packages
+						you own, run with no model in the loop, from Cursor, Claude,
+						ChatGPT, or your phone.
 					</p>
 					<div data-rise style={{ '--rise': '2' }} mix={css(heroActionsCss)}>
 						{isSignedIn ? (
@@ -197,19 +213,8 @@ export function HomeRoute(handle: Handle) {
 						)}
 					</div>
 					<p data-rise style={{ '--rise': '3' }} mix={css(heroHintCss)}>
-						Not sure what you&apos;d use it for?{' '}
-						<a href="/guides/what-is-kody" mix={css(inlineLinkCss)}>
-							Read what Kody can do
-						</a>
-						{discoveryPrompt ? (
-							<>
-								{' '}
-								— or copy one prompt and let your agent tell you. No account
-								needed.
-							</>
-						) : (
-							<> — no account needed.</>
-						)}
+						Not sure yet? Ask the agent you already use whether Kody would help.
+						No account.
 					</p>
 					{discoveryPrompt ? (
 						<div data-rise style={{ '--rise': '3.2' }} mix={css(heroHintCss)}>
@@ -269,53 +274,84 @@ export function HomeRoute(handle: Handle) {
 					</div>
 				</section>
 
-				{/* ============ capabilities ============ */}
-				<section aria-labelledby="ask-title" mix={css(askCss)}>
-					<h2 id="ask-title" mix={css(visuallyHiddenCss)}>
-						What you can ask
+				{/* ============ factory loop ============ */}
+				<section aria-labelledby="factory-title" mix={css(factoryCss)}>
+					<h2 id="factory-title" mix={css(sectionHeadingCss)}>
+						Three jobs. Same loop.
 					</h2>
-					<div mix={css(askGridCss)}>
-						{capabilityItems.map((item, index) => (
-							<article
-								key={item.prompt}
-								mix={[css(askItemCss), reveal(index * 90)]}
-							>
-								<img
-									src={item.src}
-									width={627}
-									height={627}
-									loading="lazy"
-									alt={item.alt}
-								/>
-								<h3>{item.prompt}</h3>
-								<p>{item.copy}</p>
-							</article>
-						))}
-					</div>
-				</section>
-
-				{/* ============ reliability ============ */}
-				<section aria-labelledby="reliable-title" mix={css(reliableCss)}>
-					<div>
-						<h2 id="reliable-title" mix={css(sectionHeadingCss)}>
-							Solve it once.
-							<br />
-							Run it forever.
-						</h2>
-						<p mix={css(splitCopyCss)}>
-							Ask a typical agent for a weekly report and it re-does every step
-							from scratch, with more chances to go wrong each time. With Kody,
-							your agent writes the code once, tests it, and saves it as a
-							package. Every run after is the same: fast, cheap, predictable.
-						</p>
-					</div>
+					<p mix={css(factoryLeadCss)}>
+						Ask once, save a package, then a cron, webhook, or invoke runs it
+						with no model in the loop.
+					</p>
 					<img
 						src="/images/kody-compounding-capabilities.webp"
 						width={480}
 						height={480}
 						loading="lazy"
-						alt="Kody saving a solved task as a glowing green seed pod on a branch that keeps producing results"
-						mix={[css(reliableArtCss), reveal()]}
+						alt="Kody tending glowing package pods on a small plant"
+						mix={[css(factoryArtCss), reveal()]}
+					/>
+					<div mix={css(factoryBeatsCss)}>
+						{factoryBeats.map((beat, index) => (
+							<article
+								key={beat.title}
+								mix={[css(factoryBeatCss), reveal(index * 90)]}
+							>
+								<p mix={css(factoryBeatTriggerCss)}>{beat.trigger}</p>
+								<h3>{beat.title}</h3>
+								<p>{beat.copy}</p>
+							</article>
+						))}
+					</div>
+				</section>
+
+				{/* ============ ask once / run forever ============ */}
+				<section aria-labelledby="reliable-title" mix={css(reliableCss)}>
+					<h2 id="reliable-title" mix={css(sectionHeadingCss)}>
+						Ask once.
+						<br />
+						Run it forever.
+					</h2>
+					<p mix={css(reliableLeadCss)}>
+						Ask a typical agent for a weekly report and it re-does every step
+						from scratch, with more chances to go wrong each time. With Kody,
+						your agent writes the code once, tests it, and saves it as a
+						package. Every run after is the same: fast, cheap, predictable. No
+						model in the loop.
+					</p>
+					<ul aria-label="What you cannot get elsewhere" mix={css(claimsCss)}>
+						{permanenceClaims.map((claim, index) => (
+							<li
+								key={claim.title}
+								mix={[css(claimItemCss), reveal(index * 90)]}
+							>
+								<h3>{claim.title}</h3>
+								<p>{claim.copy}</p>
+							</li>
+						))}
+					</ul>
+				</section>
+
+				{/* ============ git + npm ecosystem ============ */}
+				<section aria-labelledby="ecosystem-title" mix={css(ecosystemCss)}>
+					<div>
+						<h2 id="ecosystem-title" mix={css(sectionHeadingCss)}>
+							Your own git and npm.
+						</h2>
+						<p mix={css(splitCopyCss)}>
+							Fork community packages, version them, hang a webhook, a tiny app,
+							or a cron on them. Every install is a fork you own — code in your
+							account, on your credentials, that you can open, change, and
+							republish.
+						</p>
+					</div>
+					<img
+						src="/images/kody-community-packages.webp"
+						width={480}
+						height={480}
+						loading="lazy"
+						alt="Kody handing a wrapped package across a counter of neatly sorted parcels"
+						mix={[css(ecosystemArtCss), reveal()]}
 					/>
 				</section>
 
@@ -334,10 +370,10 @@ export function HomeRoute(handle: Handle) {
 							Bring your own keys
 						</h2>
 						<p mix={css(splitCopyCss)}>
-							Kody never asks a company for access on your behalf. You create
-							the connection yourself, with your agent walking you through it:
-							your app, your scopes, revocable anytime. No shared app sits
-							between you and your accounts.
+							Keys the agent never sees. You create the connection yourself,
+							with your agent walking you through it: your app, your scopes,
+							revocable anytime. Secrets never enter the prompt. No shared app
+							sits between you and your accounts.
 						</p>
 						<p mix={css(splitCopyCss)}>
 							And there&apos;s no fixed list. If the integration doesn&apos;t
@@ -407,8 +443,8 @@ export function HomeRoute(handle: Handle) {
 					</p>
 				</section>
 
-				{/* ============ equip / invite ============ */}
-				<section id="invite" aria-labelledby="equip-title" mix={css(equipCss)}>
+				{/* ============ closing invite ============ */}
+				<section id="invite" aria-labelledby="invite-title" mix={css(equipCss)}>
 					<img
 						src="/images/kody-greeting.webp"
 						width={480}
@@ -417,14 +453,14 @@ export function HomeRoute(handle: Handle) {
 						alt="Kody waving hello with an open hand"
 						mix={css(equipArtCss)}
 					/>
-					<h2 id="equip-title" mix={css(equipTitleCss)}>
-						Equip your agent
+					<h2 id="invite-title" mix={css(equipTitleCss)}>
+						Make it permanent
 					</h2>
 					{isSignedIn ? (
 						<div>
 							<p mix={css(equipLeadCss)}>
-								You&apos;re in. Add Kody to the agent you already use and ask
-								for anything.
+								You&apos;re in. Connect the agent you already use and start
+								saving packages.
 							</p>
 							<p mix={css({ margin: '1.8rem auto 0' })}>
 								<a href={onboardingPath} mix={css(pillButtonCss)}>
@@ -717,7 +753,7 @@ const heroSubCss = {
 	margin: '1.5rem auto 0',
 	fontSize: 'clamp(1.05rem, 1.6vw, 1.2rem)',
 	color: colors.textMuted,
-	maxWidth: '44ch',
+	maxWidth: '56ch',
 	textWrap: 'pretty' as const,
 }
 
@@ -846,67 +882,146 @@ const hostsMoreChipCss = {
 	padding: '0.4rem 0.95rem',
 }
 
-/* ---------- capabilities ---------- */
+/* ---------- factory loop ---------- */
 
-const askCss = {
+const factoryCss = {
 	maxWidth: layoutMaxWidths.extended,
 	marginInline: 'auto',
 	padding: `clamp(2rem, 4vw, 3.5rem) ${sectionGutter}`,
+	textAlign: 'center' as const,
 	'@media (max-width: 800px)': {
 		padding: '1.75rem 1.25rem',
 	},
 }
 
-const askGridCss = {
-	display: 'grid',
-	gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
-	gap: 'clamp(2.5rem, 5vw, 3.5rem) clamp(1.5rem, 3vw, 2.5rem)',
+const factoryLeadCss = {
+	margin: '1.1rem auto 0',
+	color: colors.textMuted,
+	fontSize: '1.08rem',
+	maxWidth: '48ch',
+	textWrap: 'pretty' as const,
 }
 
-const askItemCss = {
-	textAlign: 'center' as const,
-	'& img': {
-		width: 'min(92%, 340px)',
-		maxWidth: '100%',
-		height: 'auto',
-		display: 'block',
-		marginInline: 'auto',
-		transition: `transform 200ms ${transitions.easeOut}`,
+const factoryArtCss = {
+	width: 'min(70%, 400px)',
+	maxWidth: '100%',
+	height: 'auto',
+	display: 'block',
+	marginInline: 'auto',
+	marginTop: 'clamp(1.5rem, 3vw, 2.5rem)',
+	'@media (max-width: 800px)': {
+		width: 'min(60%, 300px)',
 	},
-	// Gated: touch taps would otherwise leave the mascot stuck mid-lift.
-	[hoverMq]: {
-		'&:hover img': {
-			transform: 'translateY(-6px) rotate(-0.5deg)',
-		},
+}
+
+const factoryBeatsCss = {
+	display: 'grid',
+	gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+	gap: 'clamp(1.75rem, 4vw, 2.5rem) clamp(1.5rem, 3vw, 2.5rem)',
+	marginTop: 'clamp(2rem, 4vw, 3rem)',
+	textAlign: 'left' as const,
+	'@media (max-width: 800px)': {
+		textAlign: 'center' as const,
 	},
+}
+
+const factoryBeatTriggerCss = {
+	margin: 0,
+	fontSize: '0.78rem',
+	fontWeight: 600,
+	letterSpacing: '0.12em',
+	textTransform: 'uppercase' as const,
+	color: colors.primaryText,
+}
+
+const factoryBeatCss = {
 	'& h3': {
-		margin: '1.4rem 0 0',
-		fontSize: '1.45rem',
+		margin: '0.45rem 0 0',
+		fontSize: '1.35rem',
 		fontWeight: 700,
 		letterSpacing: '-0.015em',
 	},
-	'& p': {
-		margin: '0.8rem auto 0',
+	'& p:last-child': {
+		margin: '0.7rem 0 0',
 		color: colors.textMuted,
 		fontSize: '0.98rem',
 		maxWidth: '38ch',
 		textWrap: 'pretty' as const,
 	},
-	'@media (prefers-reduced-motion: reduce)': {
-		'& img': { transition: 'none' },
-		'&:hover img': { transform: 'none' },
-	},
 	'@media (max-width: 800px)': {
-		'& p': { fontSize: '1rem', maxWidth: '46ch' },
+		'& p:last-child': {
+			fontSize: '1rem',
+			maxWidth: '46ch',
+			marginInline: 'auto',
+		},
 	},
 }
 
-/* ---------- reliability + byok splits ---------- */
+/* ---------- ask once + claims ---------- */
 
 const reliableCss = {
 	maxWidth: layoutMaxWidths.extended,
 	marginInline: 'auto',
 	padding: `clamp(3.5rem, 8vw, 6.5rem) ${sectionGutter} clamp(2rem, 5vw, 4rem)`,
+	textAlign: 'center' as const,
+	'@media (max-width: 800px)': {
+		padding: '3.25rem 1.25rem 1.75rem',
+	},
+}
+
+const reliableLeadCss = {
+	margin: '1.1rem auto 0',
+	color: colors.textMuted,
+	maxWidth: '54ch',
+	textWrap: 'pretty' as const,
+	'@media (max-width: 800px)': {
+		fontSize: '1rem',
+		maxWidth: '46ch',
+	},
+}
+
+const claimsCss = {
+	listStyle: 'none',
+	margin: 'clamp(2rem, 4vw, 3rem) 0 0',
+	padding: 0,
+	display: 'grid',
+	gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+	gap: 'clamp(1.5rem, 3vw, 2.25rem)',
+	textAlign: 'left' as const,
+	'@media (max-width: 800px)': {
+		textAlign: 'center' as const,
+	},
+}
+
+const claimItemCss = {
+	'& h3': {
+		margin: 0,
+		fontSize: '1.12rem',
+		fontWeight: 700,
+		letterSpacing: '-0.015em',
+	},
+	'& p': {
+		margin: '0.65rem 0 0',
+		color: colors.textMuted,
+		fontSize: '0.98rem',
+		maxWidth: '36ch',
+		textWrap: 'pretty' as const,
+	},
+	'@media (max-width: 800px)': {
+		'& p': {
+			fontSize: '1rem',
+			maxWidth: '46ch',
+			marginInline: 'auto',
+		},
+	},
+}
+
+/* ---------- git + npm + byok splits ---------- */
+
+const ecosystemCss = {
+	maxWidth: layoutMaxWidths.extended,
+	marginInline: 'auto',
+	padding: `clamp(2rem, 5vw, 4rem) ${sectionGutter}`,
 	display: 'grid',
 	gridTemplateColumns: 'minmax(0, 3fr) minmax(0, 2fr)',
 	gap: 'clamp(2rem, 5vw, 4.5rem)',
@@ -914,11 +1029,11 @@ const reliableCss = {
 	'@media (max-width: 800px)': {
 		gridTemplateColumns: '1fr',
 		textAlign: 'center' as const,
-		padding: '3.25rem 1.25rem 1.75rem',
+		padding: '1.75rem 1.25rem',
 	},
 }
 
-const reliableArtCss = {
+const ecosystemArtCss = {
 	width: 'min(100%, 400px)',
 	maxWidth: '100%',
 	height: 'auto',
@@ -1030,7 +1145,7 @@ const equipCss = {
 	position: 'relative' as const,
 	/* See `pageHeadCss`: the fabric is a backdrop, so it paints under the copy. */
 	isolation: 'isolate' as const,
-	/* Same fabric behind the closing invite: equipping your agent, literally. */
+	/* Same fabric behind the closing invite: make the work permanent. */
 	'&::before': {
 		content: '""',
 		position: 'absolute' as const,

--- a/packages/worker/client/site-footer.tsx
+++ b/packages/worker/client/site-footer.tsx
@@ -26,7 +26,7 @@ export function SiteFooter(handle: Handle<SiteFooterProps>) {
 					/>
 					<span>Kody</span>
 				</a>
-				<p mix={css(taglineCss)}>At your agent&apos;s service.</p>
+				<p mix={css(taglineCss)}>Make it permanent.</p>
 				<div mix={css(footerEndCss)}>
 					<nav aria-label="Footer" mix={css(footerNavCss)}>
 						<a href="/community">Community</a>

--- a/packages/worker/universal/og-pages.ts
+++ b/packages/worker/universal/og-pages.ts
@@ -21,14 +21,14 @@ export type PublicOgPage = {
 
 export const publicOgPages = {
 	home: {
-		imageTitle: "Your assistant's home",
+		imageTitle: 'Make it permanent',
 		// Complements the title rather than restating it: the card shows both at
 		// once, so repeating the headline wastes the only supporting line.
 		imageSubtitle:
-			'Memory, keys, code, and automations — portable across every MCP host.',
-		ogTitle: "Kody — your assistant's home",
+			'A personal software factory for the agent you already use. Packages you own, no model in the loop.',
+		ogTitle: 'Kody — make it permanent',
 		ogDescription:
-			"Your assistant's home — memory, keys, code, and automations, portable across every MCP host.",
+			'A personal software factory for the agent you already use. Packages you own, run with no model in the loop, from Cursor, Claude, ChatGPT, or your phone.',
 		path: '/',
 	},
 	community: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Repositions [heykody.app](https://heykody.app) around **permanence / personal software factory**, not “equip your agent.” Copy and layout only. Existing 3D art is reused; no new koala.

## Positioning

- **Hero:** “When your agent figures it out, Kody makes it permanent.” Sub: personal software factory, packages you own, no model in the loop, from Cursor / Claude / ChatGPT / phone.
- **Primary CTA** stays Join the waiting list; secondary stays I have a code.
- **Discovery prompt** is labeled as a helper (“Not sure yet? … No account.”), not a peer try-it CTA. No “try a quick example” button.
- **Factory loop** replaces the Slack / plan-my-week / GitHub-triage cards. One image (`kody-compounding-capabilities.webp`) plus three copy beats of the same loop (Kent’s real jobs: nightly-release, sentry-triage, morning briefing at 7am Denver). No carousel, no unverified run-count stat.
- **Ask once. Run it forever.** kept as its own section, with the three claims from `/guides/what-is-kody` pulled up (no model in the loop; keys the agent never sees; every install is a fork you own).
- **Your own git and npm.** new ecosystem block; art is existing `kody-community-packages.webp`.
- **BYOK** stays as trust proof (“keys the agent never sees” / secrets never enter the prompt).
- **Nothing new to learn** / MCP hosts unchanged.
- Closing CTA + footer tagline: “Make it permanent” instead of “Equip your agent” / “At your agent’s service.” Waitlist + I have a code remain.

## Out of scope

- No DNS / `kody.codes` cutover.
- No onboarding rewrite (that’s #1411).
- No waitlist or product behavior changes.
- README / `package.json` product tagline left as-is (homepage + OG + footer only).

## Art

Hero keeps `kody-base.webp` + floating props. Factory loop uses `kody-compounding-capabilities.webp`. Git+npm reuses `kody-community-packages.webp`. BYOK keeps `kody-keys.webp`. Close keeps `kody-greeting.webp`. Slack / week / GitHub scenes are no longer on the homepage.

## Desktop screenshots

Captured locally at 1440px width, light theme, reduced motion. Review these instead of waiting on a preview deploy.

**Nav + hero**

![Homepage nav and hero](https://cursor.com/artifacts/c/art-2777f4f0-bad4-4efe-a34a-306df4273586)

**Nothing new to learn**

![Nothing new to learn section](https://cursor.com/artifacts/c/art-154a1e15-b723-4ad7-bc5a-2587b1201044)

**Factory loop**

![Factory loop with compounding-capabilities art and three job beats](https://cursor.com/artifacts/c/art-944ce09f-46ca-49b9-be9a-d9f01e085bf1)

**Ask once. Run it forever.**

![Ask once run forever with three claims](https://cursor.com/artifacts/c/art-2c02b2ff-9d18-4632-b38e-8ccb5985d05c)

**Your own git and npm**

![Git and npm ecosystem section](https://cursor.com/artifacts/c/art-6f82f869-f2f8-4fcb-8a85-050edb79f0e6)

**Bring your own keys**

![Bring your own keys section](https://cursor.com/artifacts/c/art-9cb5ec54-e947-4b3a-ab33-ebb375ed9f44)

**It already speaks your stack**

![Community stack brand cloud](https://cursor.com/artifacts/c/art-b017dccb-c15d-4869-b8c5-8ec807807e6c)

**Trust / open source**

![Trust and open source receipts](https://cursor.com/artifacts/c/art-bcd56960-3817-4436-8274-c3470dd503ff)

**Final CTA + footer**

![Make it permanent waitlist close and footer](https://cursor.com/artifacts/c/art-c96e0b5b-8e96-46a3-9bd8-433878654580)

**Full page**

![Full homepage at desktop width](https://cursor.com/artifacts/c/art-0c57c1b1-ec1b-4515-90d3-f41f376051b1)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `77db258a` · **Head:** `69165a14`

**Classification:** composes — marketing copy, layout, and OG text on the existing browser app. No primitive behavior, contract, or storage change.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — homepage, footer tagline, home OG card, e2e heading locators |

### System map

Anonymous visitors hit the existing home route; this PR only changes the Remix marketing copy and the home OG descriptor that the document head already reads.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	appUi -->|"GET / homepage + footer tagline"| appUi
	appUi -->|"home entry in publicOgPages"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart LR
	visitor["Anonymous visitor"] --> home["GET /"]
	home --> hero["Hero + waitlist CTAs"]
	home --> loop["Factory loop beats"]
	home --> claims["Ask once + three claims"]
	home --> invite["Make it permanent + footer"]
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7be7b7f9-0f4a-4e9e-bd33-47150c28f64c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7be7b7f9-0f4a-4e9e-bd33-47150c28f64c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

