### PR TITLE
fix(ci): put COOKIE_SECRET on kody-runtime, not kody-runtime-production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -360,8 +360,8 @@ jobs:
           AI_GATEWAY_ID: ${{ secrets.AI_GATEWAY_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: >
-          node tools/ci/sync-worker-secrets.ts --env "" --name
-          kody-runtime --config "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET
+          node tools/ci/sync-worker-secrets.ts --env "" --name kody-runtime
+          --config "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET
           --set-from-env-optional SECRET_STORE_KEY --set-from-env-optional
           AI_GATEWAY_ID --set-from-env-optional SENTRY_DSN
           --set-from-env-optional CLOUDFLARE_API_TOKEN

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,7 +168,10 @@ jobs:
             echo "SENTRY_DSN is not configured; skipping jobs worker secret sync."
             exit 0
           fi
-          node tools/ci/sync-worker-secrets.ts --env production --config \
+          # --env "" with --name: wrangler secret bulk still suffixes
+          # -<env> even when --name is set, so --env production would write
+          # to kody-jobs-production while deploy uploads kody-jobs.
+          node tools/ci/sync-worker-secrets.ts --env "" --config \
             "$WRANGLER_CONFIG" --name kody-jobs --set-from-env-optional SENTRY_DSN
 
       - name: ☁️ Deploy jobs worker
@@ -343,6 +346,10 @@ jobs:
       # (Cloudflare REST capabilities). Billing (Stripe), waiting-list (Kit),
       # OAuth client credentials, and maintenance secrets stay main-only so a
       # runtime-Worker compromise cannot reach them.
+      # --env "" with --name: wrangler secret bulk still suffixes -<env>
+      # even when --name is set, so --env production would write
+      # COOKIE_SECRET to kody-runtime-production while deploy uploads
+      # kody-runtime. Preview uses the same empty-env pin.
       - name: 🔐 Sync Cloudflare Secrets to runtime worker (bulk)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -353,7 +360,7 @@ jobs:
           AI_GATEWAY_ID: ${{ secrets.AI_GATEWAY_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: >
-          node tools/ci/sync-worker-secrets.ts --env production --name
+          node tools/ci/sync-worker-secrets.ts --env "" --name
           kody-runtime --config "$WRANGLER_CONFIG" --set-from-env COOKIE_SECRET
           --set-from-env-optional SECRET_STORE_KEY --set-from-env-optional
           AI_GATEWAY_ID --set-from-env-optional SENTRY_DSN

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -392,17 +392,16 @@ carries the parameter is rewritten without it before package code sees it.
 Mint and consume must share `COOKIE_SECRET`. In production the app-origin mint
 (`/@{username}/packages/...`) is forwarded to `kody-runtime`, and the subdomain
 exchange is served by that same script's zone routes. Production CI therefore
-syncs `COOKIE_SECRET` onto the unsuffixed `kody-runtime` script (`--env ""`
-plus `--name`); `wrangler secret bulk --env production --name kody-runtime`
-still writes `kody-runtime-production`, which the runtime deploy does not
-serve. If a leftover main-worker route still receives
-`{username}.kodyapps.dev`, the main Worker must forward it too
-(`isRuntimeWorkerOwnedRequest` matches every package-app host, not only the
-apex). A `COOKIE_SECRET` mismatch, or a missing secret swallowed as "invalid
-token", leaves the visitor on the 403 page with `__kody_handoff` still in the
-URL and no `Set-Cookie`. Missing `COOKIE_SECRET` on consume fails closed with
-500; signature / expiry / path / replay rejects log a reason without the token
-and set `X-Kody-Handoff: rejected`.
+syncs `COOKIE_SECRET` onto the unsuffixed `kody-runtime` script (`--env ""` plus
+`--name`); `wrangler secret bulk --env production --name kody-runtime` still
+writes `kody-runtime-production`, which the runtime deploy does not serve. If a
+leftover main-worker route still receives `{username}.kodyapps.dev`, the main
+Worker must forward it too (`isRuntimeWorkerOwnedRequest` matches every
+package-app host, not only the apex). A `COOKIE_SECRET` mismatch, or a missing
+secret swallowed as "invalid token", leaves the visitor on the 403 page with
+`__kody_handoff` still in the URL and no `Set-Cookie`. Missing `COOKIE_SECRET`
+on consume fails closed with 500; signature / expiry / path / replay rejects log
+a reason without the token and set `X-Kody-Handoff: rejected`.
 
 **Package-app session cookie**
 (`packages/worker/src/app/package-app-session.ts`). Exchanging a valid token on

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -391,9 +391,13 @@ carries the parameter is rewritten without it before package code sees it.
 
 Mint and consume must share `COOKIE_SECRET`. In production the app-origin mint
 (`/@{username}/packages/...`) is forwarded to `kody-runtime`, and the subdomain
-exchange is served by that same script's zone routes. If a leftover main-worker
-route still receives `{username}.kodyapps.dev`, the main Worker must forward it
-too (`isRuntimeWorkerOwnedRequest` matches every package-app host, not only the
+exchange is served by that same script's zone routes. Production CI therefore
+syncs `COOKIE_SECRET` onto the unsuffixed `kody-runtime` script (`--env ""`
+plus `--name`); `wrangler secret bulk --env production --name kody-runtime`
+still writes `kody-runtime-production`, which the runtime deploy does not
+serve. If a leftover main-worker route still receives
+`{username}.kodyapps.dev`, the main Worker must forward it too
+(`isRuntimeWorkerOwnedRequest` matches every package-app host, not only the
 apex). A `COOKIE_SECRET` mismatch, or a missing secret swallowed as "invalid
 token", leaves the visitor on the 403 page with `__kody_handoff` still in the
 URL and no `Set-Cookie`. Missing `COOKIE_SECRET` on consume fails closed with

--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -141,11 +141,15 @@ node tools/ci/runtime-worker-config.ts generate \
   --out-config packages/runtime-worker/wrangler-production.generated.json
 
 # Sync secrets to both workers (full secret set to main; runtime-lane
-# allowlist to kody-runtime — see deploy.yml for the current lists):
+# allowlist to kody-runtime — see deploy.yml for the current lists).
+# Runtime uses --env "" --name so wrangler does not write
+# kody-runtime-production (secret bulk still suffixes -<env> even with
+# --name; deploy uses --name to override).
 node tools/ci/sync-worker-secrets.ts --env production \
   --config packages/worker/wrangler-production.generated.json \
   --set-from-env COOKIE_SECRET ... # copy the main-worker flag list from deploy.yml
-node tools/ci/sync-worker-secrets.ts --env production \
+node tools/ci/sync-worker-secrets.ts --env "" \
+  --name kody-runtime \
   --config packages/runtime-worker/wrangler-production.generated.json \
   --set-from-env COOKIE_SECRET \
   --set-from-env-optional SECRET_STORE_KEY \

--- a/tools/ci/runtime-worker-config.node.test.ts
+++ b/tools/ci/runtime-worker-config.node.test.ts
@@ -143,6 +143,7 @@ test('generate rewrites worker names, copies resource ids, and writes a bootstra
 			name?: string
 			env?: {
 				preview?: {
+					name?: string
 					durable_objects?: { bindings?: Array<Record<string, unknown>> }
 					d1_databases?: Array<Record<string, unknown>>
 					queues?: { producers?: Array<Record<string, unknown>> }
@@ -154,6 +155,7 @@ test('generate rewrites worker names, copies resource ids, and writes a bootstra
 		}>(await readFile(outConfigPath, 'utf8'))
 
 		expect(runtimeConfig.name).toBe('kody-pr-7-runtime')
+		expect(runtimeConfig.env?.preview?.name).toBe('kody-pr-7-runtime')
 		const previewEnv = runtimeConfig.env?.preview
 		// Cross-script references point at the resolved main worker name.
 		const userMeter = previewEnv?.durable_objects?.bindings?.find(
@@ -246,6 +248,7 @@ test('generate publishes the package-app custom domain for production', async ()
 		const runtimeConfig = parseJsonc<{
 			env?: {
 				production?: {
+					name?: string
 					routes?: Array<{
 						pattern: string
 						custom_domain?: boolean
@@ -265,6 +268,7 @@ test('generate publishes the package-app custom domain for production', async ()
 			{ pattern: 'kodyapps.dev/*', zone_name: 'kodyapps.dev' },
 			{ pattern: '*.kodyapps.dev/*', zone_name: 'kodyapps.dev' },
 		])
+		expect(runtimeConfig.env?.production?.name).toBe('kody-runtime')
 		expect(runtimeConfig.env?.production?.workers_dev).toBe(true)
 		// The storage transfer migration survives generation untouched.
 		expect(runtimeConfig.migrations?.[0]?.tag).toBe('v1')

--- a/tools/ci/runtime-worker-config.ts
+++ b/tools/ci/runtime-worker-config.ts
@@ -367,6 +367,10 @@ export async function generate(options: CliOptions) {
 	)
 
 	runtimeConfig.name = options.runtimeWorkerName
+	// Pin the selected env's name too. Wrangler otherwise deploys and
+	// secret-bulks `--env production` as `<name>-production`, which would not
+	// match the main worker's cross-script bindings (`kody-runtime`).
+	runtimeEnv.name = options.runtimeWorkerName
 	delete runtimeConfig.$schema
 	copyResourceIdentifiers({
 		runtimeEnv,

--- a/tools/ci/sync-worker-secrets.node.test.ts
+++ b/tools/ci/sync-worker-secrets.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest'
-import { buildSpawnEnv } from './sync-worker-secrets'
+import {
+	buildSpawnEnv,
+	buildWranglerSecretBulkFlags,
+} from './sync-worker-secrets'
 
 const baseOptions = {
 	env: undefined,
@@ -42,4 +45,46 @@ test('buildSpawnEnv preserves optional vars only when they have values', () => {
 	expect(spawnEnvWithOptionalValues.SENTRY_DSN).toBe(
 		'https://examplePublicKey@o0.ingest.sentry.io/0',
 	)
+})
+
+test('secret bulk omits empty --env so --name pins the unsuffixed script', () => {
+	const secretsFile = '/tmp/wrangler-secrets.env'
+	expect(
+		buildWranglerSecretBulkFlags(
+			{
+				...baseOptions,
+				env: '',
+				name: 'kody-runtime',
+				config: 'packages/runtime-worker/wrangler-production.generated.json',
+			},
+			secretsFile,
+		),
+	).toEqual([
+		'secret',
+		'bulk',
+		secretsFile,
+		'--name',
+		'kody-runtime',
+		'--config',
+		'packages/runtime-worker/wrangler-production.generated.json',
+	])
+
+	expect(
+		buildWranglerSecretBulkFlags(
+			{
+				...baseOptions,
+				env: 'production',
+				config: 'packages/worker/wrangler-production.generated.json',
+			},
+			secretsFile,
+		),
+	).toEqual([
+		'secret',
+		'bulk',
+		secretsFile,
+		'--env',
+		'production',
+		'--config',
+		'packages/worker/wrangler-production.generated.json',
+	])
 })

--- a/tools/ci/sync-worker-secrets.node.test.ts
+++ b/tools/ci/sync-worker-secrets.node.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
+import { consoleError } from '#worker/test-support/console-spies.ts'
 import {
 	buildSpawnEnv,
 	buildWranglerSecretBulkFlags,
@@ -87,4 +88,28 @@ test('secret bulk omits empty --env so --name pins the unsuffixed script', () =>
 		'--config',
 		'packages/worker/wrangler-production.generated.json',
 	])
+})
+
+test('secret bulk rejects --env with --name so it cannot target name-env', () => {
+	const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+		throw new Error('process.exit called')
+	}) as never)
+	consoleError.mockImplementation(() => {})
+	try {
+		expect(() =>
+			buildWranglerSecretBulkFlags(
+				{
+					...baseOptions,
+					env: 'production',
+					name: 'kody-runtime',
+				},
+				'/tmp/wrangler-secrets.env',
+			),
+		).toThrow('process.exit called')
+		expect(consoleError).toHaveBeenCalledWith(
+			expect.stringContaining('kody-runtime-production'),
+		)
+	} finally {
+		exitSpy.mockRestore()
+	}
 })

--- a/tools/ci/sync-worker-secrets.ts
+++ b/tools/ci/sync-worker-secrets.ts
@@ -230,9 +230,35 @@ function toDotenv(secrets: ReadonlyMap<string, string>) {
 	return `${lines.join('\n')}\n`
 }
 
+/**
+ * `wrangler secret bulk --env <env> --name <script>` still targets
+ * `<script>-<env>` (unlike `wrangler deploy --name`, which overrides the
+ * suffix). Callers that pin a script with `--name` must omit `--env`.
+ */
+export function buildWranglerSecretBulkFlags(
+	options: CliOptions,
+	secretsFilePath: string,
+): Array<string> {
+	if (options.name && options.env && options.env.length > 0) {
+		fail(
+			`wrangler secret bulk appends -<env> even when --name is set, so "${options.name}" with --env ${options.env} would target "${options.name}-${options.env}". Pass --env "" with --name to pin the unsuffixed script.`,
+		)
+	}
+	const args = ['secret', 'bulk', secretsFilePath]
+	if (options.env !== undefined && options.env.length > 0) {
+		args.push('--env', options.env)
+	}
+	if (options.name) {
+		args.push('--name', options.name)
+	}
+	if (options.config) {
+		args.push('--config', options.config)
+	}
+	return args
+}
+
 async function runWranglerSecretBulk(options: CliOptions, dotenvText: string) {
 	const wranglerBin = resolveLocalBinary('wrangler')
-	const args = [wranglerBin, 'secret', 'bulk']
 	const spawnEnv = buildSpawnEnv(options)
 	const secretsFilePath = join(
 		tmpdir(),
@@ -242,16 +268,10 @@ async function runWranglerSecretBulk(options: CliOptions, dotenvText: string) {
 		encoding: 'utf8',
 		mode: 0o600,
 	})
-	args.push(secretsFilePath)
-	if (options.env !== undefined) {
-		args.push('--env', options.env)
-	}
-	if (options.name) {
-		args.push('--name', options.name)
-	}
-	if (options.config) {
-		args.push('--config', options.config)
-	}
+	const args = [
+		wranglerBin,
+		...buildWranglerSecretBulkFlags(options, secretsFilePath),
+	]
 
 	try {
 		const [command, ...commandArgs] = args

--- a/tools/ci/sync-worker-secrets.ts
+++ b/tools/ci/sync-worker-secrets.ts
@@ -264,14 +264,14 @@ async function runWranglerSecretBulk(options: CliOptions, dotenvText: string) {
 		tmpdir(),
 		`wrangler-secrets-${Date.now()}-${randomBytes(6).toString('hex')}.env`,
 	)
-	await writeFile(secretsFilePath, dotenvText, {
-		encoding: 'utf8',
-		mode: 0o600,
-	})
 	const args = [
 		wranglerBin,
 		...buildWranglerSecretBulkFlags(options, secretsFilePath),
 	]
+	await writeFile(secretsFilePath, dotenvText, {
+		encoding: 'utf8',
+		mode: 0o600,
+	})
 
 	try {
 		const [command, ...commandArgs] = args


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock production deploy of the package-app handoff fix (#1416) by putting `COOKIE_SECRET` on the same Cloudflare Worker script that serves package-app hosts.

## Summary

Production deploy of #1416 failed the runtime healthcheck with `cookieSecretConfigured: false` on `kody-runtime`. The healthcheck is correct: `wrangler secret bulk --env production --name kody-runtime` still wrote secrets to **`kody-runtime-production`**, while `wrangler deploy --name kody-runtime` uploaded **`kody-runtime`**.

Preview already avoided this by passing `--env ""` with `--name`. This PR:

- Uses `--env "" --name kody-runtime` (and the same for `kody-jobs`) in production secret sync
- Rejects the combined `--env <name> --name <script>` flags in `sync-worker-secrets.ts`, because Wrangler still suffixes `-<env>`
- Pins `env.<env>.name` on the generated runtime Wrangler config so `--env production` without `--name` also targets the unsuffixed script

Evidence: [failed production deploy](https://github.com/kentcdodds/kody/actions/runs/31670859014) — `🌀 Processing the secrets for the Worker "kody-runtime-production"` then health `{"cookieSecretConfigured":false}` on `kody-runtime`.

Leftover: CI created a `kody-runtime-production` script that now holds a copy of the secrets. Safe to delete after this deploy lands; it is not the script the main worker binds.

## Testing

- `npx vitest run tools/ci/sync-worker-secrets.node.test.ts tools/ci/runtime-worker-config.node.test.ts --project node-unit` (4 passed)
- `npm run docs:check-temporal`
- Production proof is the next deploy: runtime `/__runtime/health` must report `cookieSecretConfigured: true` on the unsuffixed `kody-runtime` workers.dev URL

## System changes

CI/docs only — no primitive code roots matched. The change is how production delivers `COOKIE_SECRET` to the runtime Worker that already consumes it for package-app handoff.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `77db258a` · **Head:** `3381c059`

**Classification:** composes — no primitives added or changed; this PR retargets production secret sync so the existing runtime Worker receives `COOKIE_SECRET`.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none matched)_ | — | CI + docs only (`deploy.yml`, `tools/ci/*`, authentication/runbook) |

Unmatched paths are deploy CI and contributing docs. `app-sessions` / package-app handoff already require `COOKIE_SECRET` on `kody-runtime`; this PR does not change that contract.

### System map

Production secret bulk must hit the same script name that runtime deploy uploads; Wrangler still suffixes `-<env>` on `secret bulk` even when `--name` is set.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	deployCi["deploy.yml secret bulk<br/>CI secret sync"]:::touched
	appSessions["app-sessions<br/>Browser sessions"]:::untouched
	deployCi -->|"COOKIE_SECRET onto unsuffixed kody-runtime"| appSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant CI as Production deploy.yml
	participant Bulk as wrangler secret bulk
	participant Runtime as kody-runtime
	CI->>Bulk: --env "" --name kody-runtime
	Bulk->>Runtime: COOKIE_SECRET
	Runtime-->>CI: GET /__runtime/health cookieSecretConfigured true
```

### Before / after

| Step | Before | After |
| ---- | ------ | ----- |
| Runtime secret sync | `--env production --name kody-runtime` → `kody-runtime-production` | `--env "" --name kody-runtime` → `kody-runtime` |
| Generated runtime env | top-level `name` only | `env.production.name` pinned to `kody-runtime` |
| Combined flags | silently suffixes | `sync-worker-secrets` fails closed |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-484e44eb-3777-44ab-992b-390c65a3744e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-484e44eb-3777-44ab-992b-390c65a3744e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected runtime worker and secret synchronization naming to prevent deployment secrets from targeting incorrectly suffixed workers.
  - Ensured preview and production configurations generate the intended worker names.
  - Prevented invalid combinations of worker names and environments during secret synchronization.

- **Documentation**
  - Clarified production secret synchronization, worker routing behavior, and migration runbook instructions.

- **Tests**
  - Added coverage for worker naming and secret synchronization argument generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->