### PR TITLE
Make PR preview manual testing easy for agents

### DIFF
--- a/.agents/skills/preview-manual-test/SKILL.md
+++ b/.agents/skills/preview-manual-test/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: preview-manual-test
+description: >
+  Discover, wait for, smoke-check, and manually exercise a PR preview deploy.
+  Use on medium or high risk PRs, after pushing a ready-for-review PR, or when
+  the user asks to test the preview URL.
+---
+
+# Manual preview testing
+
+Read
+[`docs/contributing/preview-manual-testing.md`](../../../docs/contributing/preview-manual-testing.md)
+and run the script. Do not improvise `gh` comment scraping or local E2E against
+the preview URL.
+
+## Command
+
+```bash
+npm run preview:manual-test
+```
+
+Useful flags: `--pr <n>`, `--url <preview-url>`, `--no-wait`, `--json`,
+`--check /path`, `--skip-login`. `--help` prints the rest.
+
+## When
+
+Run this after the PR is **ready for review** (drafts and forks have no preview)
+and you have pushed the commits you want to exercise. Typical triggers:
+visual-recap risk is **medium** (`extends`) or **high** (`adds`); auth, workers,
+or deploy-path behavior changed; the user asked to try the preview.
+
+This does not replace `npm run validate`.
+
+## After the briefing
+
+1. Open the printed URL. On Cloud Agents, use the `computerUse` subagent.
+2. Sign in at `/login`: `me@kentcdodds.com` / `ilikecode` (non-admin; username
+   `user-me`). Button label is **Sign in**.
+3. Exercise the flows this PR changes. Stay on the preview origin.
+4. Record what you saw on the PR.
+
+`GET /mcp` is 401 without OAuth; do not treat that as a regression. `/admin` is
+403 on preview because the seed account is not an admin.

--- a/.agents/skills/preview-manual-test/SKILL.md
+++ b/.agents/skills/preview-manual-test/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: preview-manual-test
 description: >
-  Discover, wait for, smoke-check, and manually exercise a PR preview deploy.
-  Use on medium or high risk PRs, after pushing a ready-for-review PR, or when
-  the user asks to test the preview URL.
+  Discover, wait for, sign in, create specific user data, and assert a PR
+  preview deploy. Use on medium or high risk PRs, after pushing a
+  ready-for-review PR, or when the user asks to test the preview URL.
 ---
 
 # Manual preview testing
 
 Read
-[`docs/contributing/preview-manual-testing.md`](../../../docs/contributing/preview-manual-testing.md)
-and run the script. Do not improvise `gh` comment scraping or local E2E against
-the preview URL.
+[`docs/contributing/preview-manual-testing.md`](../../../docs/contributing/preview-manual-testing.md).
+Do not improvise `gh` comment scraping, local E2E against the preview URL, or
+raw D1 seeding of preview resources.
 
 ## Command
 
@@ -19,25 +19,41 @@ the preview URL.
 npm run preview:manual-test
 ```
 
-Useful flags: `--pr <n>`, `--url <preview-url>`, `--no-wait`, `--json`,
-`--check /path`, `--skip-login`. `--help` prints the rest.
+On **medium or high risk**, do not stop at the default health/login smoke. The
+seed user (`me@kentcdodds.com` / `ilikecode`, username `user-me`) has **no**
+secrets, values, packages, or jobs until you create them. Script that data and
+the assertions as the same logged-in user:
+
+```bash
+npm run preview:manual-test -- \
+  --request 'POST /account/values.json {"action":"save","name":"preview-locale","value":"en-US"}' \
+  --request 'GET /account/values.json' \
+  --check /account/values
+```
+
+`--request` spec: `METHOD /path [status] [json-body]` (default success: 2xx).
+Use the JSON APIs the UI uses (`/account/*.json` in
+`packages/worker/universal/routes.ts`). `--json` includes
+`session.cookieHeader`; `--cookie-file` writes it for follow-up `curl`.
+
+`--pr`, `--url`, `--no-wait`, `--skip-login`, `--help` as documented.
 
 ## When
 
-Run this after the PR is **ready for review** (drafts and forks have no preview)
-and you have pushed the commits you want to exercise. Typical triggers:
-visual-recap risk is **medium** (`extends`) or **high** (`adds`); auth, workers,
-or deploy-path behavior changed; the user asked to try the preview.
+After the PR is **ready for review** (drafts and forks have no preview) and you
+have pushed the commits you want to exercise. Typical triggers: visual-recap
+risk is **medium** (`extends`) or **high** (`adds`); auth, workers, or
+deploy-path behavior changed; the user asked to try the preview.
 
 This does not replace `npm run validate`.
 
-## After the briefing
+## After the scripted session
 
 1. Open the printed URL. On Cloud Agents, use the `computerUse` subagent.
-2. Sign in at `/login`: `me@kentcdodds.com` / `ilikecode` (non-admin; username
-   `user-me`). Button label is **Sign in**.
-3. Exercise the flows this PR changes. Stay on the preview origin.
+2. Sign in at `/login` with the seed credentials. Button label is **Sign in**.
+3. Confirm the data you created and exercise the UI this PR changes. Stay on the
+   preview origin.
 4. Record what you saw on the PR.
 
-`GET /mcp` is 401 without OAuth; do not treat that as a regression. `/admin` is
-403 on preview because the seed account is not an admin.
+`GET /mcp` is 401 without OAuth; `/admin` is 403 (seed account is not admin).
+Neither is a regression.

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -25,8 +25,9 @@ Self-assess; user policy overrides.
 2. Wait for CI — `gh pr checks` (or compose `loop-on-ci` / `fix-ci`).
 3. Fix failures; for **medium+**, wait on AI reviewer(s) and address valid
    feedback. Rebase only when actually unmergeable. For **medium+**, also run
-   `npm run preview:manual-test` and exercise the preview
-   ([preview-manual-test skill](../preview-manual-test/SKILL.md)).
+   `npm run preview:manual-test` as the seeded user **with data for this
+   change** (`--request` / session cookie; see
+   [preview-manual-test skill](../preview-manual-test/SKILL.md)).
 4. Green + (medium+: valid feedback cleared) → break.
 5. Push → repeat.
 

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -24,7 +24,9 @@ Self-assess; user policy overrides.
    `{ prUrl, status: 'ready' }` (or owner/repo/prNumber).
 2. Wait for CI — `gh pr checks` (or compose `loop-on-ci` / `fix-ci`).
 3. Fix failures; for **medium+**, wait on AI reviewer(s) and address valid
-   feedback. Rebase only when actually unmergeable.
+   feedback. Rebase only when actually unmergeable. For **medium+**, also run
+   `npm run preview:manual-test` and exercise the preview
+   ([preview-manual-test skill](../preview-manual-test/SKILL.md)).
 4. Green + (medium+: valid feedback cleared) → break.
 5. Push → repeat.
 

--- a/.agents/skills/visual-recap/SKILL.md
+++ b/.agents/skills/visual-recap/SKILL.md
@@ -197,6 +197,10 @@ Format rules:
 
 6. Re-run steps 2-5 after pushing significant new commits to the PR.
 
+When the recap is **medium** (`extends`) or **high** (`adds`), also load
+[`.agents/skills/preview-manual-test/SKILL.md`](../preview-manual-test/SKILL.md)
+and exercise the PR preview after it deploys.
+
 ### Plan mode
 
 Same steps, except: `**Mode:** plan`, no Base/Head commits required, "Primitives

--- a/.agents/skills/visual-recap/SKILL.md
+++ b/.agents/skills/visual-recap/SKILL.md
@@ -199,7 +199,9 @@ Format rules:
 
 When the recap is **medium** (`extends`) or **high** (`adds`), also load
 [`.agents/skills/preview-manual-test/SKILL.md`](../preview-manual-test/SKILL.md)
-and exercise the PR preview after it deploys.
+and exercise the PR preview **as the seeded logged-in user with data for this
+change** (`--request` / `--cookie-file`, then a UI pass). A health/login smoke
+alone is not enough.
 
 ### Plan mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   [docs/contributing/decisions/index.md](./docs/contributing/decisions/index.md)
 - Setup, checks, docs maintenance, preview deploys, and seeding:
   - [docs/contributing/setup.md](./docs/contributing/setup.md)
-- Manual PR preview testing (medium/high risk):
+- Manual PR preview testing (medium/high risk, logged-in user + data):
   - [docs/contributing/preview-manual-testing.md](./docs/contributing/preview-manual-testing.md)
     and the
     [preview-manual-test skill](./.agents/skills/preview-manual-test/SKILL.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   [docs/contributing/decisions/index.md](./docs/contributing/decisions/index.md)
 - Setup, checks, docs maintenance, preview deploys, and seeding:
   - [docs/contributing/setup.md](./docs/contributing/setup.md)
+- Manual PR preview testing (medium/high risk):
+  - [docs/contributing/preview-manual-testing.md](./docs/contributing/preview-manual-testing.md)
+    and the
+    [preview-manual-test skill](./.agents/skills/preview-manual-test/SKILL.md)
 - Documentation principles (usage vs contributing, MCP text, gardening):
   - [docs/contributing/documentation.md](./docs/contributing/documentation.md)
 - Code style conventions:

--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -47,6 +47,7 @@ manually with native `unzip`:
 | Migrate local D1   | `npm run migrate:local`                                         |
 | Seed test login    | `node tools/seed-test-data.ts --local` (see seeding note below) |
 | Full validate gate | `npm run validate` (CI runs the same checks as parallel jobs)   |
+| Manual PR preview  | `npm run preview:manual-test` (see preview-manual-testing.md)   |
 
 ## Dev server
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -10,6 +10,7 @@ style, tests, MCP capabilities, and runtime architecture.
   build something)
 - [Setup](./setup.md), [environment variables](./environment-variables.md),
   [setup manifest](./setup-manifest.md)
+- [Manual PR preview testing](./preview-manual-testing.md)
 - [Optional Cloudflare offerings](./cloudflare-offerings.md)
 - [Cursor Cloud Agent notes](./cloud-agents.md)
 - [Harness engineering](./harness-engineering.md) (agent-first loop, promoting

--- a/docs/contributing/preview-manual-testing.md
+++ b/docs/contributing/preview-manual-testing.md
@@ -1,0 +1,107 @@
+# Manual preview testing
+
+Use a PR preview when local `npm run validate` is not enough: medium or high
+risk recaps (`extends` / `adds` in
+[`.agents/skills/visual-recap/SKILL.md`](../../.agents/skills/visual-recap/SKILL.md)),
+auth or deploy-path changes, or anything that needs the real isolated preview
+workers, mocks, and seeded login.
+
+This is a manual check. It does not replace `npm run validate`.
+
+## One command
+
+From the repo root, on a pushed PR branch, with `gh` authenticated:
+
+```bash
+npm run preview:manual-test
+```
+
+Same thing:
+
+```bash
+node tools/preview-manual-test.ts
+```
+
+The script:
+
+1. Resolves the current PR (`gh pr view`, or pass `--pr <n>`).
+2. Reads the `<!-- kody-preview-url -->` comment posted by
+   `.github/workflows/preview.yml`.
+3. Waits until `GET /health` returns `{ ok: true, commitSha }` matching the
+   GitHub preview deployment SHA.
+4. Smokes the preview without a browser: `/health`, `/login`, `/mcp` (401),
+   runtime `/__runtime/health` when the URL is known, then `POST /auth`,
+   `/session`, and `/account`.
+5. Prints a briefing: URL, seed login, worker names, smoke results, and UI next
+   steps.
+
+Pass `--json` when a caller needs the structured result. Pass `--no-wait` to
+fail immediately if the preview is not up yet. Pass `--url <preview-url>` to
+skip GitHub discovery (useful once the comment already exists).
+
+`--check /account/secrets` (repeatable) adds authenticated GET checks after
+login.
+
+## When a preview exists
+
+Ready-for-review PRs on this repository (not forks, not drafts) get a per-PR
+Cloudflare worker (`kody-pr-<n>`), isolated D1/KV, mock workers, and a seeded
+login. The workflow comments the URL on the PR. Details of resource names and
+cleanup live in [`setup.md`](./setup.md#pr-preview-deployments).
+
+`/health` `commitSha` is GitHub's `github.sha` for that workflow run. On
+`pull_request` events that is the merge commit, not the branch tip, so it can
+differ from `HEAD` / `headRefOid`. The script compares against the GitHub
+deployment SHA for `preview-<pr-number>` rather than local `HEAD`.
+
+## Seed login
+
+Preview seeding uses a **non-admin** account (the local `jane` companion is not
+seeded remotely):
+
+- Email: `me@kentcdodds.com`
+- Password: `ilikecode`
+- Username: `user-me`
+
+Sign in at `/login` with Email + Password and the **Sign in** button. `/admin`
+is expected to 403. Turnstile is off on preview (partial or missing keys stay
+disabled), so password login works from a script or a browser.
+
+`/mcp` stays OAuth-protected; an unauthenticated GET is 401 by design. Manual
+preview testing is the browser app and HTTP smoke, not a full MCP OAuth dance.
+
+## Manual UI pass
+
+After the script succeeds:
+
+1. Open the printed URL in a browser. On Cursor Cloud Agents, drive that with
+   the `computerUse` subagent.
+2. Log in with the seed credentials above.
+3. Exercise the user-visible flows **this PR changes**. Stay on the preview
+   origin (do not follow package-app handoff into production).
+4. Note what you saw in the PR (pass, bug, screenshot). Keep the recap honest: a
+   green smoke is not evidence that an untested flow works.
+
+Do not point Playwright at the preview. Local E2E (`npm run test:e2e:run`) boots
+its own worker against `.wrangler/state/e2e`.
+
+## If the script cannot find a preview
+
+- **Draft PR** — preview jobs skip drafts. Mark the PR ready for review, wait
+  for 🔎 Preview, then re-run.
+- **Fork PR** — the workflow skips forks.
+- **Workflow still running** — default mode waits (15 minutes). Watch the run
+  URL the script prints.
+- **Workflow failed** — open the run, fix the deploy, push, re-run the script.
+- **Stale URL after a push** — wait; a new deploy updates the same PR comment
+  and `/health` `commitSha`.
+
+Do not `gh workflow run preview.yml` with `target=pr` to "force" a PR preview.
+That dispatch checks out the workflow's ref (usually `main`), not the PR head.
+Pushing to the PR (or marking it ready) is the deploy trigger.
+
+## Resource reset
+
+Full preview resource delete/recreate remains the operator path in
+[`setup.md`](./setup.md#reset-re-migrate-then-seed). The manual-test script does
+not create or destroy Cloudflare resources.

--- a/docs/contributing/preview-manual-testing.md
+++ b/docs/contributing/preview-manual-testing.md
@@ -60,8 +60,10 @@ cleanup live in [`setup.md`](./setup.md#pr-preview-deployments).
 
 `/health` `commitSha` is GitHub's `github.sha` for that workflow run. On
 `pull_request` events that is the merge commit, not the branch tip, so it can
-differ from `HEAD` / `headRefOid`. The script compares against the GitHub
-deployment SHA for `preview-<pr-number>` rather than local `HEAD`.
+differ from `HEAD` / `headRefOid`. GitHub environment deployments record the PR
+head SHA, not that merge commit. The script treats `/health` as ready when
+`commitSha` equals the PR head **or** is a merge commit that has the PR head as
+a parent. Pass `--sha` to override the expected commit.
 
 ## Seed login
 

--- a/docs/contributing/preview-manual-testing.md
+++ b/docs/contributing/preview-manual-testing.md
@@ -4,9 +4,10 @@ Use a PR preview when local `npm run validate` is not enough: medium or high
 risk recaps (`extends` / `adds` in
 [`.agents/skills/visual-recap/SKILL.md`](../../.agents/skills/visual-recap/SKILL.md)),
 auth or deploy-path changes, or anything that needs the real isolated preview
-workers, mocks, and seeded login.
+workers, mocks, and a **logged-in user with the data the change cares about**.
 
-This is a manual check. It does not replace `npm run validate`.
+This does not replace `npm run validate`. A green health/login smoke is not
+evidence that an untested flow works.
 
 ## One command
 
@@ -16,31 +17,39 @@ From the repo root, on a pushed PR branch, with `gh` authenticated:
 npm run preview:manual-test
 ```
 
-Same thing:
+Same thing: `node tools/preview-manual-test.ts`.
+
+The script signs in as the preview seed user and keeps that session. The seed
+account starts **empty** except the user row — there are no secrets, values,
+packages, or jobs until you create them. Create that data and assert the change
+as the same user:
 
 ```bash
-node tools/preview-manual-test.ts
+npm run preview:manual-test -- \
+  --request 'POST /account/values.json {"action":"save","name":"preview-locale","value":"en-US"}' \
+  --request 'GET /account/values.json' \
+  --check /account/values
 ```
 
-The script:
+`--request` is authenticated HTTP as the seed user. Spec:
+`METHOD /path [expected-status] [json-body]`. Default success is any 2xx.
+Example negative check: `--request 'GET /admin 403'`.
 
-1. Resolves the current PR (`gh pr view`, or pass `--pr <n>`).
-2. Reads the `<!-- kody-preview-url -->` comment posted by
-   `.github/workflows/preview.yml`.
-3. Waits until `GET /health` returns `{ ok: true, commitSha }` matching the
-   GitHub preview deployment SHA.
-4. Smokes the preview without a browser: `/health`, `/login`, `/mcp` (401),
-   runtime `/__runtime/health` when the URL is known, then `POST /auth`,
-   `/session`, and `/account`.
-5. Prints a briefing: URL, seed login, worker names, smoke results, and UI next
-   steps.
+`--json` prints `session.cookieHeader` so follow-up `curl` can reuse the
+session. `--cookie-file .tmp/preview-cookie` writes that header value:
 
-Pass `--json` when a caller needs the structured result. Pass `--no-wait` to
-fail immediately if the preview is not up yet. Pass `--url <preview-url>` to
-skip GitHub discovery (useful once the comment already exists).
+```bash
+COOKIE=$(cat .tmp/preview-cookie)
+curl -sS -H "Cookie: $COOKIE" -H 'Accept: application/json' \
+  "$PREVIEW_URL/account/values.json"
+```
 
-`--check /account/secrets` (repeatable) adds authenticated GET checks after
-login.
+`--no-wait` fails immediately if the preview is not up. `--url` skips GitHub
+discovery. `--help` lists the rest.
+
+On medium or high risk, running only the default smoke (health + empty login) is
+not enough. Add `--request` / `--check` for the flows this PR changes, or reuse
+the session cookie and drive those APIs yourself. Then do a UI pass.
 
 ## When a preview exists
 
@@ -63,24 +72,29 @@ seeded remotely):
 - Password: `ilikecode`
 - Username: `user-me`
 
-Sign in at `/login` with Email + Password and the **Sign in** button. `/admin`
-is expected to 403. Turnstile is off on preview (partial or missing keys stay
-disabled), so password login works from a script or a browser.
+The script signs in through `POST /auth` (Turnstile is off on preview). Sign in
+in a browser at `/login` with Email + Password and the **Sign in** button.
+`/admin` is expected to 403.
 
-`/mcp` stays OAuth-protected; an unauthenticated GET is 401 by design. Manual
-preview testing is the browser app and HTTP smoke, not a full MCP OAuth dance.
+Do not seed preview D1 from the agent VM with `tools/ci/preview-resources.ts`
+unless you are an operator with Cloudflare credentials. Create user data through
+the product JSON APIs instead (`/account/*.json` in
+`packages/worker/universal/routes.ts`). Those are the same endpoints the UI
+posts to.
 
-## Manual UI pass
+`/mcp` stays OAuth-protected; an unauthenticated GET is 401 by design. Logged-in
+preview testing is the browser app and cookie-backed HTTP, not a full MCP OAuth
+dance.
 
-After the script succeeds:
+## Logged-in data and UI pass
 
-1. Open the printed URL in a browser. On Cursor Cloud Agents, drive that with
-   the `computerUse` subagent.
-2. Log in with the seed credentials above.
-3. Exercise the user-visible flows **this PR changes**. Stay on the preview
-   origin (do not follow package-app handoff into production).
-4. Note what you saw in the PR (pass, bug, screenshot). Keep the recap honest: a
-   green smoke is not evidence that an untested flow works.
+1. Run the script with `--request` (and `--check` for HTML) covering the change.
+2. If you need a longer session, take `session.cookieHeader` from `--json` or
+   `--cookie-file` and `curl` more endpoints.
+3. Open the preview URL (computerUse on Cloud Agents), sign in with the seed
+   credentials, and confirm the same data in the UI. Stay on the preview origin
+   (do not follow package-app handoff into production).
+4. Record what you saw in the PR.
 
 Do not point Playwright at the preview. Local E2E (`npm run test:e2e:run`) boots
 its own worker against `.wrangler/state/e2e`.

--- a/docs/contributing/preview-manual-testing.md
+++ b/docs/contributing/preview-manual-testing.md
@@ -107,8 +107,11 @@ its own worker against `.wrangler/state/e2e`.
 - **Workflow still running** — default mode waits (15 minutes). Watch the run
   URL the script prints.
 - **Workflow failed** — open the run, fix the deploy, push, re-run the script.
-- **Stale URL after a push** — wait; a new deploy updates the same PR comment
-  and `/health` `commitSha`.
+- **Stale URL after a push** — `/health` can still match the previous deployment
+  SHA until GitHub records a new preview deployment. The script waits until the
+  🔎 Preview workflow run for this PR head is `completed`/`success` (unless you
+  pass `--url` without `--pr`) and `/health` matches the expected SHA. Do not
+  treat a healthy worker as the new commit until that happens.
 
 Do not `gh workflow run preview.yml` with `target=pr` to "force" a PR preview.
 That dispatch checks out the workflow's ref (usually `main`), not the PR head.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -269,8 +269,8 @@ If you ever need to do the same operations manually, use:
 - `node tools/ci/preview-resources.ts cleanup --worker-name <name>`
 - `node tools/ci/production-resources.ts ensure --out-config <path>`
 
-To **manually test** a PR preview (find the URL, wait until `/health` matches
-the deployed commit, smoke login, print a briefing), see
+To **manually test** a PR preview (find the URL, sign in as the seeded user,
+create specific data with `--request`, assert the change), see
 [Manual preview testing](./preview-manual-testing.md) and run
 `npm run preview:manual-test`.
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -269,6 +269,11 @@ If you ever need to do the same operations manually, use:
 - `node tools/ci/preview-resources.ts cleanup --worker-name <name>`
 - `node tools/ci/production-resources.ts ensure --out-config <path>`
 
+To **manually test** a PR preview (find the URL, wait until `/health` matches
+the deployed commit, smoke login, print a briefing), see
+[Manual preview testing](./preview-manual-testing.md) and run
+`npm run preview:manual-test`.
+
 ## Dependency auditing
 
 - `npm run audit:prod` checks production dependencies for known vulnerabilities

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "migrate:e2e": "node tools/apply-local-app-migrations.ts --persist-to .wrangler/state/e2e && node --env-file=packages/worker/.env ./wrangler-env.ts d1 migrations apply AUDIT_DB --local --persist-to .wrangler/state/e2e && node --env-file=packages/worker/.env ./wrangler-env.ts d1 migrations apply JOBS_DB --local --config packages/jobs-worker/wrangler.jsonc --persist-to .wrangler/state/e2e",
     "preview": "nx run worker:build-client && npm run migrate:local && node --env-file=packages/worker/.env ./wrangler-env.ts dev --local",
     "preview:e2e": "node --env-file=packages/worker/.env tools/prepare-e2e-env.ts && nx run worker:build-client && npm run migrate:e2e && node --env-file=packages/worker/.env ./wrangler-env.ts dev --local --persist-to .wrangler/state/e2e",
+    "preview:manual-test": "node tools/preview-manual-test.ts",
     "generate-types": "node --env-file=packages/worker/.env ./wrangler-env.ts types ./packages/worker/worker-configuration.d.ts",
     "typecheck": "nx run worker:typecheck && tsc --noEmit -p packages/backup-control-plane/tsconfig.json && tsc --noEmit -p packages/status/tsconfig.json && tsc --noEmit -p packages/jobs-worker/tsconfig.json",
     "test": "nx run worker:test",

--- a/tools/preview-manual-test.node.test.ts
+++ b/tools/preview-manual-test.node.test.ts
@@ -152,6 +152,16 @@ test('preview manual test parses flags, PR comments, worker URLs, and health pay
 		false,
 	)
 	expect(
+		evaluateAppHealth({ ok: true, commitSha: 'mergesha' }, 'headsha', [
+			'basesha',
+			'headsha',
+		]),
+	).toEqual({
+		ok: true,
+		commitSha: 'mergesha',
+		detail: 'ok, commitSha mergesha (merge of headsha)',
+	})
+	expect(
 		evaluateRuntimeHealth(
 			{ status: 'ok', commitSha: 'abc', cookieSecretConfigured: true },
 			null,
@@ -370,6 +380,33 @@ test('preview manual test waits for the head SHA workflow even when /health alre
 	).toBe(true)
 })
 
+test('preview manual test treats merge-commit /health as ready when it contains the PR head', async () => {
+	await using server = await createPreviewFixtureServer('mergesha')
+	const logs: Array<string> = []
+	const { exitCode, result } = await runPreviewManualTest(
+		['--pr', '42', '--skip-login'],
+		createSilentDeps({
+			logs,
+			execGh: async (args) =>
+				fakeGh(args, {
+					commentBody: sampleCommentWithUrl(server.origin),
+					headSha: 'headsha',
+					deploymentSha: 'headsha',
+					runStatus: 'completed',
+					runConclusion: 'success',
+					commitParents: ['basesha', 'headsha'],
+				}),
+		}),
+	)
+
+	expect(exitCode).toBe(0)
+	expect(result?.ok).toBe(true)
+	expect(result?.smoke?.commitSha).toBe('mergesha')
+	expect(
+		result?.smoke?.checks.find((check) => check.name === 'GET /health')?.detail,
+	).toContain('merge of headsha')
+})
+
 test('preview manual test records fetch failures as checks instead of aborting the briefing', async () => {
 	const logs: Array<string> = []
 	const { exitCode, result } = await runPreviewManualTest(
@@ -524,6 +561,7 @@ function fakeGh(
 		runStatus?: string
 		runConclusion?: string | null
 		runUrl?: string
+		commitParents?: Array<string>
 	},
 ): GhResult {
 	const joined = args.join(' ')
@@ -572,6 +610,12 @@ function fakeGh(
 				: [],
 		)
 	}
+	if (joined.includes('/commits/')) {
+		return jsonGh({
+			sha: joined.split('/commits/')[1] ?? '',
+			parents: (input.commitParents ?? []).map((sha) => ({ sha })),
+		})
+	}
 	return { status: 1, stdout: '', stderr: `unexpected gh ${joined}` }
 }
 
@@ -579,8 +623,7 @@ function jsonGh(value: unknown): GhResult {
 	return { status: 0, stdout: `${JSON.stringify(value)}\n`, stderr: '' }
 }
 
-async function createPreviewFixtureServer() {
-	const commitSha = 'deployedsha'
+async function createPreviewFixtureServer(commitSha = 'deployedsha') {
 	const server = createServer(
 		(request: IncomingMessage, response: ServerResponse) => {
 			const url = new URL(request.url ?? '/', 'http://127.0.0.1')

--- a/tools/preview-manual-test.node.test.ts
+++ b/tools/preview-manual-test.node.test.ts
@@ -1,0 +1,458 @@
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from 'node:http'
+import { expect, test } from 'vitest'
+import {
+	cookieHeaderFromSetCookie,
+	deriveSiblingWorkerUrl,
+	evaluateAppHealth,
+	evaluateRuntimeHealth,
+	formatBriefing,
+	parseArgs,
+	parsePreviewComment,
+	previewCommentMarker,
+	previewSeedEmail,
+	previewSeedPassword,
+	runPreviewManualTest,
+	workerNameFromPreviewUrl,
+	type GhResult,
+	type PreviewManualTestDeps,
+	type PreviewManualTestResult,
+} from './preview-manual-test.ts'
+
+const sampleComment = [
+	previewCommentMarker,
+	'🔎 Preview deployed: https://kody-pr-42.kody.workers.dev',
+	'',
+	'Worker: `kody-pr-42`',
+	'Runtime worker: `kody-pr-42-runtime` (https://kody-pr-42-runtime.kody.workers.dev)',
+	'D1: `kody-pr-42-db`',
+	'KV: `kody-pr-42-oauth-kv`',
+	'',
+	'Mocks:',
+	'- cloudflare: [https://kody-pr-42-mock-cloudflare.kody.workers.dev/__mocks](https://kody-pr-42-mock-cloudflare.kody.workers.dev/__mocks?token=abc) (`kody-pr-42-mock-cloudflare`)',
+].join('\n')
+
+test('preview manual test parses flags, PR comments, worker URLs, and health payloads', () => {
+	const options = parseArgs([
+		'--pr',
+		'42',
+		'--no-wait',
+		'--skip-login',
+		'--timeout-ms',
+		'1000',
+		'--poll-ms',
+		'50',
+		'--sha',
+		'abc123',
+		'--json',
+	])
+	expect(options.prNumber).toBe(42)
+	expect(options.wait).toBe(false)
+	expect(options.skipLogin).toBe(true)
+	expect(options.timeoutMs).toBe(1000)
+	expect(options.pollIntervalMs).toBe(50)
+	expect(options.expectedSha).toBe('abc123')
+	expect(options.json).toBe(true)
+
+	expect(() => parseArgs(['--nope'])).toThrow(/Unknown flag/)
+	expect(() => parseArgs(['--check', '/account', '--skip-login'])).toThrow(
+		/--check requires a session cookie/,
+	)
+
+	expect(parsePreviewComment('no marker here')).toBeNull()
+	expect(parsePreviewComment(sampleComment)).toEqual({
+		previewUrl: 'https://kody-pr-42.kody.workers.dev',
+		workerName: 'kody-pr-42',
+		runtimeWorkerName: 'kody-pr-42-runtime',
+		runtimeUrl: 'https://kody-pr-42-runtime.kody.workers.dev',
+		d1DatabaseName: 'kody-pr-42-db',
+		oauthKvTitle: 'kody-pr-42-oauth-kv',
+		mocks: [
+			'cloudflare: [https://kody-pr-42-mock-cloudflare.kody.workers.dev/__mocks](https://kody-pr-42-mock-cloudflare.kody.workers.dev/__mocks?token=abc) (`kody-pr-42-mock-cloudflare`)',
+		],
+	})
+	expect(
+		parsePreviewComment(sampleCommentWithUrl('http://127.0.0.1:9')),
+	).toEqual({
+		previewUrl: 'http://127.0.0.1:9',
+		workerName: 'kody-pr-42',
+		runtimeWorkerName: null,
+		runtimeUrl: null,
+		d1DatabaseName: null,
+		oauthKvTitle: null,
+		mocks: [],
+	})
+
+	expect(workerNameFromPreviewUrl('https://kody-pr-42.kody.workers.dev')).toBe(
+		'kody-pr-42',
+	)
+	expect(workerNameFromPreviewUrl('http://127.0.0.1:3742')).toBeNull()
+	expect(
+		deriveSiblingWorkerUrl(
+			'https://kody-pr-42.kody.workers.dev',
+			'kody-pr-42',
+			'kody-pr-42-runtime',
+		),
+	).toBe('https://kody-pr-42-runtime.kody.workers.dev')
+
+	expect(
+		cookieHeaderFromSetCookie(['kody_session=abc; Path=/; HttpOnly']),
+	).toBe('kody_session=abc')
+
+	expect(evaluateAppHealth({ ok: true, commitSha: 'abc' }, 'abc')).toEqual({
+		ok: true,
+		commitSha: 'abc',
+		detail: 'ok, commitSha abc',
+	})
+	expect(evaluateAppHealth({ ok: true, commitSha: 'old' }, 'new').ok).toBe(
+		false,
+	)
+	expect(
+		evaluateRuntimeHealth(
+			{ status: 'ok', commitSha: 'abc', cookieSecretConfigured: true },
+			null,
+		).ok,
+	).toBe(true)
+	expect(
+		evaluateRuntimeHealth(
+			{ status: 'ok', commitSha: 'abc', cookieSecretConfigured: false },
+			null,
+		).ok,
+	).toBe(false)
+
+	const briefing = formatBriefing({
+		ok: true,
+		message: 'ready',
+		options,
+		snapshot: {
+			prNumber: 42,
+			prUrl: 'https://github.com/kentcdodds/kody/pull/42',
+			isDraft: false,
+			headSha: 'headsha',
+			previewUrl: 'https://kody-pr-42.kody.workers.dev',
+			workerName: 'kody-pr-42',
+			runtimeWorkerName: 'kody-pr-42-runtime',
+			runtimeUrl: 'https://kody-pr-42-runtime.kody.workers.dev',
+			d1DatabaseName: 'kody-pr-42-db',
+			oauthKvTitle: 'kody-pr-42-oauth-kv',
+			mocks: [],
+			expectedSha: 'mergesha',
+			workflowUrl: 'https://github.com/kentcdodds/kody/actions/runs/1',
+			workflowStatus: 'completed',
+			workflowConclusion: 'success',
+			deploymentSha: 'mergesha',
+		},
+		smoke: {
+			ok: true,
+			checks: [
+				{ name: 'GET /health', ok: true, detail: 'ok, commitSha mergesha' },
+			],
+			sessionEmail: previewSeedEmail,
+			commitSha: 'mergesha',
+			runtimeCommitSha: 'mergesha',
+		},
+		login: {
+			email: previewSeedEmail,
+			password: previewSeedPassword,
+			username: 'user-me',
+			admin: false,
+		},
+		briefing: '',
+	} satisfies PreviewManualTestResult)
+	expect(briefing).toContain('Preview is ready for manual testing.')
+	expect(briefing).toContain(`${previewSeedEmail} / ${previewSeedPassword}`)
+	expect(briefing).toContain('user-me')
+	expect(briefing).toContain('merge commit')
+	expect(briefing).toContain('computerUse')
+})
+
+test('preview manual test smokes a local preview: health, login page, auth, session, account, mcp', async () => {
+	await using server = await createPreviewFixtureServer()
+	const logs: Array<string> = []
+	const { exitCode, result } = await runPreviewManualTest(
+		['--url', server.origin, '--no-wait', '--check', '/account/secrets'],
+		createSilentDeps({ logs }),
+	)
+
+	expect(exitCode).toBe(0)
+	expect(result?.ok).toBe(true)
+	expect(result?.smoke?.ok).toBe(true)
+	expect(result?.smoke?.sessionEmail).toBe(previewSeedEmail)
+	expect(result?.smoke?.checks.map((check) => check.name)).toEqual([
+		'GET /health',
+		'GET /login',
+		'GET /mcp',
+		'POST /auth',
+		'GET /session',
+		'GET /account',
+		'GET /account/secrets',
+	])
+	expect(result?.briefing).toContain(server.origin)
+	expect(logs.join('\n')).toContain('Preview is ready for manual testing.')
+})
+
+test('preview manual test waits for the GitHub preview comment, then smokes the URL', async () => {
+	await using server = await createPreviewFixtureServer()
+	let now = 0
+	let prViews = 0
+	const logs: Array<string> = []
+	const deps = createSilentDeps({
+		logs,
+		now: () => now,
+		sleep: async (ms) => {
+			now += ms
+		},
+		execGh: async (args) => {
+			if (args.join(' ').startsWith('pr view')) prViews += 1
+			return fakeGh(args, {
+				commentBody: prViews >= 2 ? sampleCommentWithUrl(server.origin) : null,
+				headSha: 'headsha',
+				deploymentSha: 'deployedsha',
+				runStatus: prViews >= 2 ? 'completed' : 'in_progress',
+				runConclusion: prViews >= 2 ? 'success' : null,
+			})
+		},
+	})
+
+	const { exitCode, result } = await runPreviewManualTest(
+		[
+			'--pr',
+			'42',
+			'--timeout-ms',
+			'30000',
+			'--poll-ms',
+			'1000',
+			'--skip-login',
+		],
+		deps,
+	)
+
+	expect(exitCode).toBe(0)
+	expect(result?.ok).toBe(true)
+	expect(result?.snapshot.previewUrl).toBe(server.origin)
+	expect(
+		result?.smoke?.checks.some((check) => check.name === 'POST /auth'),
+	).toBe(false)
+	expect(logs.some((line) => line.includes('Waiting'))).toBe(true)
+})
+
+test('preview manual test refuses draft PRs and failed preview workflows', async () => {
+	const logs: Array<string> = []
+	const draft = await runPreviewManualTest(['--pr', '9', '--no-wait'], {
+		...createSilentDeps({ logs }),
+		execGh: async (args) =>
+			fakeGh(args, {
+				isDraft: true,
+				commentBody: null,
+			}),
+	})
+	expect(draft.exitCode).toBe(1)
+	expect(draft.result).toBeNull()
+	expect(logs.join('\n')).toMatch(/draft/i)
+
+	logs.length = 0
+	const failed = await runPreviewManualTest(
+		['--pr', '9', '--timeout-ms', '1000', '--poll-ms', '10'],
+		{
+			...createSilentDeps({
+				logs,
+				now: () => 0,
+				sleep: async () => {
+					// The failed conclusion should abort before a sleep.
+				},
+			}),
+			execGh: async (args) =>
+				fakeGh(args, {
+					commentBody: null,
+					runStatus: 'completed',
+					runConclusion: 'failure',
+					runUrl: 'https://github.com/kentcdodds/kody/actions/runs/99',
+				}),
+		},
+	)
+	expect(failed.exitCode).toBe(1)
+	expect(logs.join('\n')).toMatch(/Preview workflow failure/)
+})
+
+function sampleCommentWithUrl(previewUrl: string) {
+	return [
+		previewCommentMarker,
+		`🔎 Preview deployed: ${previewUrl}`,
+		'',
+		'Worker: `kody-pr-42`',
+	].join('\n')
+}
+
+function createSilentDeps(
+	overrides: Partial<PreviewManualTestDeps> & { logs: Array<string> },
+): PreviewManualTestDeps {
+	const { logs, ...rest } = overrides
+	return {
+		execGh: async () => ({ status: 1, stdout: '', stderr: 'unused' }),
+		fetch,
+		sleep: async () => {
+			// Tests that wait inject their own clock.
+		},
+		now: () => Date.now(),
+		log: (message) => {
+			logs.push(message)
+		},
+		error: (message) => {
+			logs.push(message)
+		},
+		print: (message) => {
+			logs.push(message)
+		},
+		...rest,
+	}
+}
+
+function fakeGh(
+	args: ReadonlyArray<string>,
+	input: {
+		isDraft?: boolean
+		commentBody?: string | null
+		headSha?: string
+		deploymentSha?: string | null
+		runStatus?: string
+		runConclusion?: string | null
+		runUrl?: string
+	},
+): GhResult {
+	const joined = args.join(' ')
+	if (joined.startsWith('pr view')) {
+		return jsonGh({
+			number: 42,
+			url: 'https://github.com/kentcdodds/kody/pull/42',
+			isDraft: input.isDraft === true,
+			headRefOid: input.headSha ?? 'headsha',
+		})
+	}
+	if (joined.startsWith('repo view')) {
+		return jsonGh({ nameWithOwner: 'kentcdodds/kody' })
+	}
+	if (joined.includes('/issues/') && joined.includes('/comments')) {
+		return jsonGh(input.commentBody ? [{ body: input.commentBody }] : [])
+	}
+	if (joined.startsWith('run list')) {
+		return jsonGh([
+			{
+				databaseId: 1,
+				status: input.runStatus ?? 'in_progress',
+				conclusion: input.runConclusion ?? null,
+				headSha: input.headSha ?? 'headsha',
+				event: 'pull_request',
+				url:
+					input.runUrl ?? 'https://github.com/kentcdodds/kody/actions/runs/1',
+				displayTitle: 'Preview #42',
+			},
+		])
+	}
+	if (joined.includes('/deployments?')) {
+		return jsonGh(
+			input.deploymentSha
+				? [
+						{
+							id: 1,
+							sha: input.deploymentSha,
+							environment: 'preview-42',
+						},
+					]
+				: [],
+		)
+	}
+	return { status: 1, stdout: '', stderr: `unexpected gh ${joined}` }
+}
+
+function jsonGh(value: unknown): GhResult {
+	return { status: 0, stdout: `${JSON.stringify(value)}\n`, stderr: '' }
+}
+
+async function createPreviewFixtureServer() {
+	const commitSha = 'deployedsha'
+	const server = createServer(
+		(request: IncomingMessage, response: ServerResponse) => {
+			const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+			if (request.method === 'GET' && url.pathname === '/health') {
+				json(response, 200, { ok: true, commitSha })
+				return
+			}
+			if (request.method === 'GET' && url.pathname === '/login') {
+				response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+				response.end(
+					'<h1>Welcome back</h1><label>Email</label><label>Password</label>',
+				)
+				return
+			}
+			if (request.method === 'GET' && url.pathname === '/mcp') {
+				response.writeHead(401, { 'WWW-Authenticate': 'Bearer' })
+				response.end('unauthorized')
+				return
+			}
+			if (request.method === 'POST' && url.pathname === '/auth') {
+				response.writeHead(200, {
+					'Content-Type': 'application/json',
+					'Set-Cookie': 'kody_session=test-cookie; Path=/; HttpOnly',
+				})
+				response.end(JSON.stringify({ ok: true }))
+				return
+			}
+			if (request.method === 'GET' && url.pathname === '/session') {
+				if (!hasSessionCookie(request)) {
+					json(response, 200, { ok: false })
+					return
+				}
+				json(response, 200, {
+					ok: true,
+					session: { email: previewSeedEmail, username: 'user-me' },
+				})
+				return
+			}
+			if (
+				request.method === 'GET' &&
+				(url.pathname === '/account' || url.pathname === '/account/secrets')
+			) {
+				if (!hasSessionCookie(request)) {
+					response.writeHead(302, { Location: '/login' })
+					response.end()
+					return
+				}
+				response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+				response.end('<h1>Account</h1>')
+				return
+			}
+			response.writeHead(404)
+			response.end('not found')
+		},
+	)
+
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+	const address = server.address()
+	if (!address || typeof address === 'string') {
+		throw new Error('Failed to resolve fixture server port')
+	}
+
+	return {
+		origin: `http://127.0.0.1:${address.port}`,
+		async [Symbol.asyncDispose]() {
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => {
+					if (error) reject(error)
+					else resolve()
+				})
+			})
+		},
+	}
+}
+
+function json(response: ServerResponse, status: number, body: unknown) {
+	response.writeHead(status, { 'Content-Type': 'application/json' })
+	response.end(JSON.stringify(body))
+}
+
+function hasSessionCookie(request: IncomingMessage) {
+	return (request.headers.cookie ?? '').includes('kody_session=test-cookie')
+}

--- a/tools/preview-manual-test.node.test.ts
+++ b/tools/preview-manual-test.node.test.ts
@@ -12,6 +12,7 @@ import {
 	formatBriefing,
 	parseArgs,
 	parsePreviewComment,
+	parseSessionRequest,
 	previewCommentMarker,
 	previewSeedEmail,
 	previewSeedPassword,
@@ -61,6 +62,44 @@ test('preview manual test parses flags, PR comments, worker URLs, and health pay
 	expect(() => parseArgs(['--check', '/account', '--skip-login'])).toThrow(
 		/--check requires a session cookie/,
 	)
+	expect(() =>
+		parseArgs(['--request', 'GET /account/values.json', '--skip-login']),
+	).toThrow(/--request requires a session cookie/)
+	expect(
+		parseArgs([
+			'--request',
+			'POST /account/values.json {"action":"save","name":"locale","value":"en-US"}',
+			'--request',
+			'GET /admin 403',
+			'--cookie-file',
+			'.tmp/preview-cookie',
+		]),
+	).toEqual(
+		expect.objectContaining({
+			cookieFile: '.tmp/preview-cookie',
+			sessionRequests: [
+				{
+					method: 'POST',
+					path: '/account/values.json',
+					expectedStatus: null,
+					body: { action: 'save', name: 'locale', value: 'en-US' },
+				},
+				{
+					method: 'GET',
+					path: '/admin',
+					expectedStatus: 403,
+					body: null,
+				},
+			],
+		}),
+	)
+	expect(parseSessionRequest('GET /account/values.json')).toEqual({
+		method: 'GET',
+		path: '/account/values.json',
+		expectedStatus: null,
+		body: null,
+	})
+	expect(() => parseSessionRequest('FETCH /nope')).toThrow(/Invalid --request/)
 
 	expect(parsePreviewComment('no marker here')).toBeNull()
 	expect(parsePreviewComment(sampleComment)).toEqual({
@@ -153,6 +192,12 @@ test('preview manual test parses flags, PR comments, worker URLs, and health pay
 			sessionEmail: previewSeedEmail,
 			commitSha: 'mergesha',
 			runtimeCommitSha: 'mergesha',
+			cookieHeader: 'kody_session=abc',
+		},
+		session: {
+			cookieHeader: 'kody_session=abc',
+			origin: 'https://kody-pr-42.kody.workers.dev',
+			cookieFile: null,
 		},
 		login: {
 			email: previewSeedEmail,
@@ -167,20 +212,39 @@ test('preview manual test parses flags, PR comments, worker URLs, and health pay
 	expect(briefing).toContain('user-me')
 	expect(briefing).toContain('merge commit')
 	expect(briefing).toContain('computerUse')
+	expect(briefing).toContain('--request')
+	expect(briefing).toContain('session.cookieHeader')
 })
 
 test('preview manual test smokes a local preview: health, login page, auth, session, account, mcp', async () => {
 	await using server = await createPreviewFixtureServer()
 	const logs: Array<string> = []
+	const files = new Map<string, string>()
 	const { exitCode, result } = await runPreviewManualTest(
-		['--url', server.origin, '--no-wait', '--check', '/account/secrets'],
-		createSilentDeps({ logs }),
+		[
+			'--url',
+			server.origin,
+			'--no-wait',
+			'--cookie-file',
+			'.tmp/preview-cookie',
+			'--request',
+			'POST /account/values.json {"action":"save","name":"preview-locale","value":"en-US"}',
+			'--request',
+			'GET /account/values.json',
+			'--request',
+			'GET /admin 403',
+			'--check',
+			'/account/secrets',
+		],
+		createSilentDeps({ logs, files }),
 	)
 
 	expect(exitCode).toBe(0)
 	expect(result?.ok).toBe(true)
 	expect(result?.smoke?.ok).toBe(true)
 	expect(result?.smoke?.sessionEmail).toBe(previewSeedEmail)
+	expect(result?.session.cookieHeader).toBe('kody_session=test-cookie')
+	expect(files.get('.tmp/preview-cookie')).toBe('kody_session=test-cookie\n')
 	expect(result?.smoke?.checks.map((check) => check.name)).toEqual([
 		'GET /health',
 		'GET /login',
@@ -188,6 +252,10 @@ test('preview manual test smokes a local preview: health, login page, auth, sess
 		'POST /auth',
 		'GET /session',
 		'GET /account',
+		'cookie-file',
+		'POST /account/values.json (2xx)',
+		'GET /account/values.json (2xx)',
+		'GET /admin (403)',
 		'GET /account/secrets',
 	])
 	expect(result?.briefing).toContain(server.origin)
@@ -287,9 +355,12 @@ function sampleCommentWithUrl(previewUrl: string) {
 }
 
 function createSilentDeps(
-	overrides: Partial<PreviewManualTestDeps> & { logs: Array<string> },
+	overrides: Partial<PreviewManualTestDeps> & {
+		logs: Array<string>
+		files?: Map<string, string>
+	},
 ): PreviewManualTestDeps {
-	const { logs, ...rest } = overrides
+	const { logs, files = new Map<string, string>(), ...rest } = overrides
 	return {
 		execGh: async () => ({ status: 1, stdout: '', stderr: 'unused' }),
 		fetch,
@@ -305,6 +376,9 @@ function createSilentDeps(
 		},
 		print: (message) => {
 			logs.push(message)
+		},
+		writeFile: async (path, contents) => {
+			files.set(path, contents)
 		},
 		...rest,
 	}
@@ -408,6 +482,33 @@ async function createPreviewFixtureServer() {
 				json(response, 200, {
 					ok: true,
 					session: { email: previewSeedEmail, username: 'user-me' },
+				})
+				return
+			}
+			if (request.method === 'GET' && url.pathname === '/admin') {
+				response.writeHead(403, { 'Content-Type': 'text/html; charset=utf-8' })
+				response.end('forbidden')
+				return
+			}
+			if (
+				request.method === 'POST' &&
+				url.pathname === '/account/values.json'
+			) {
+				if (!hasSessionCookie(request)) {
+					json(response, 401, { ok: false, error: 'Unauthorized.' })
+					return
+				}
+				json(response, 200, { ok: true, selectedValueId: 'preview-locale' })
+				return
+			}
+			if (request.method === 'GET' && url.pathname === '/account/values.json') {
+				if (!hasSessionCookie(request)) {
+					json(response, 401, { ok: false, error: 'Unauthorized.' })
+					return
+				}
+				json(response, 200, {
+					ok: true,
+					values: [{ id: 'preview-locale', value: 'en-US' }],
 				})
 				return
 			}

--- a/tools/preview-manual-test.node.test.ts
+++ b/tools/preview-manual-test.node.test.ts
@@ -383,19 +383,22 @@ test('preview manual test waits for the head SHA workflow even when /health alre
 test('preview manual test treats merge-commit /health as ready when it contains the PR head', async () => {
 	await using server = await createPreviewFixtureServer('mergesha')
 	const logs: Array<string> = []
+	const runListCalls: Array<ReadonlyArray<string>> = []
 	const { exitCode, result } = await runPreviewManualTest(
 		['--pr', '42', '--skip-login'],
 		createSilentDeps({
 			logs,
-			execGh: async (args) =>
-				fakeGh(args, {
+			execGh: async (args) => {
+				if (args[0] === 'run' && args[1] === 'list') runListCalls.push(args)
+				return fakeGh(args, {
 					commentBody: sampleCommentWithUrl(server.origin),
 					headSha: 'headsha',
 					deploymentSha: 'headsha',
 					runStatus: 'completed',
 					runConclusion: 'success',
 					commitParents: ['basesha', 'headsha'],
-				}),
+				})
+			},
 		}),
 	)
 
@@ -405,6 +408,15 @@ test('preview manual test treats merge-commit /health as ready when it contains 
 	expect(
 		result?.smoke?.checks.find((check) => check.name === 'GET /health')?.detail,
 	).toContain('merge of headsha')
+	expect(runListCalls.length).toBeGreaterThan(0)
+	expect(runListCalls[0]).toEqual(
+		expect.arrayContaining([
+			'--commit',
+			'headsha',
+			'--workflow',
+			'preview.yml',
+		]),
+	)
 })
 
 test('preview manual test records fetch failures as checks instead of aborting the briefing', async () => {

--- a/tools/preview-manual-test.node.test.ts
+++ b/tools/preview-manual-test.node.test.ts
@@ -7,8 +7,10 @@ import { expect, test } from 'vitest'
 import {
 	cookieHeaderFromSetCookie,
 	deriveSiblingWorkerUrl,
+	displayTitleMentionsPr,
 	evaluateAppHealth,
 	evaluateRuntimeHealth,
+	flattenGhJsonPages,
 	formatBriefing,
 	parseArgs,
 	parsePreviewComment,
@@ -162,6 +164,21 @@ test('preview manual test parses flags, PR comments, worker URLs, and health pay
 		).ok,
 	).toBe(false)
 
+	expect(displayTitleMentionsPr('Preview #42', 42)).toBe(true)
+	expect(displayTitleMentionsPr('Preview #42', 4)).toBe(false)
+	expect(displayTitleMentionsPr('Preview #4', 4)).toBe(true)
+	expect(displayTitleMentionsPr('Preview #4 from main', 4)).toBe(true)
+	expect(displayTitleMentionsPr(undefined, 4)).toBe(false)
+
+	expect(flattenGhJsonPages([{ body: 'a' }, { body: 'b' }])).toEqual([
+		{ body: 'a' },
+		{ body: 'b' },
+	])
+	expect(
+		flattenGhJsonPages([[{ body: 'a' }], [{ body: 'b' }, { body: 'c' }]]),
+	).toEqual([{ body: 'a' }, { body: 'b' }, { body: 'c' }])
+	expect(flattenGhJsonPages({ not: 'an array' })).toEqual([])
+
 	const briefing = formatBriefing({
 		ok: true,
 		message: 'ready',
@@ -182,6 +199,7 @@ test('preview manual test parses flags, PR comments, worker URLs, and health pay
 			workflowUrl: 'https://github.com/kentcdodds/kody/actions/runs/1',
 			workflowStatus: 'completed',
 			workflowConclusion: 'success',
+			workflowHeadSha: 'headsha',
 			deploymentSha: 'mergesha',
 		},
 		smoke: {
@@ -307,6 +325,118 @@ test('preview manual test waits for the GitHub preview comment, then smokes the 
 	expect(logs.some((line) => line.includes('Waiting'))).toBe(true)
 })
 
+test('preview manual test waits for the head SHA workflow even when /health already matches', async () => {
+	await using server = await createPreviewFixtureServer()
+	let now = 0
+	let prViews = 0
+	const logs: Array<string> = []
+	const deps = createSilentDeps({
+		logs,
+		now: () => now,
+		sleep: async (ms) => {
+			now += ms
+		},
+		execGh: async (args) => {
+			if (args.join(' ').startsWith('pr view')) prViews += 1
+			return fakeGh(args, {
+				commentBody: sampleCommentWithUrl(server.origin),
+				headSha: 'headsha',
+				deploymentSha: 'deployedsha',
+				runStatus: prViews >= 2 ? 'completed' : 'in_progress',
+				runConclusion: prViews >= 2 ? 'success' : null,
+			})
+		},
+	})
+
+	const { exitCode, result } = await runPreviewManualTest(
+		[
+			'--pr',
+			'42',
+			'--timeout-ms',
+			'30000',
+			'--poll-ms',
+			'1000',
+			'--skip-login',
+		],
+		deps,
+	)
+
+	expect(exitCode).toBe(0)
+	expect(prViews).toBeGreaterThanOrEqual(2)
+	expect(result?.snapshot.workflowStatus).toBe('completed')
+	expect(result?.snapshot.workflowConclusion).toBe('success')
+	expect(
+		logs.some((line) => line.includes('Waiting for preview workflow')),
+	).toBe(true)
+})
+
+test('preview manual test records fetch failures as checks instead of aborting the briefing', async () => {
+	const logs: Array<string> = []
+	const { exitCode, result } = await runPreviewManualTest(
+		[
+			'--url',
+			'https://kody-pr-42.example.invalid',
+			'--no-wait',
+			'--skip-login',
+		],
+		{
+			...createSilentDeps({ logs }),
+			fetch: async () => {
+				throw new Error('The operation was aborted due to timeout')
+			},
+		},
+	)
+
+	expect(exitCode).toBe(1)
+	expect(result).not.toBeNull()
+	expect(result?.briefing).toContain('GET /health')
+	expect(
+		result?.smoke?.checks.some(
+			(check) =>
+				check.name === 'GET /health' &&
+				!check.ok &&
+				check.detail.includes('aborted due to timeout'),
+		),
+	).toBe(true)
+	expect(
+		result?.smoke?.checks.some((check) => check.name === 'GET /login'),
+	).toBe(true)
+})
+
+test('preview manual test records cookie-file write failures as checks', async () => {
+	await using server = await createPreviewFixtureServer()
+	const logs: Array<string> = []
+	const { exitCode, result } = await runPreviewManualTest(
+		[
+			'--url',
+			server.origin,
+			'--no-wait',
+			'--cookie-file',
+			'.tmp/preview-cookie',
+		],
+		{
+			...createSilentDeps({ logs }),
+			writeFile: async () => {
+				throw new Error(
+					"ENOENT: no such file or directory, open '.tmp/preview-cookie'",
+				)
+			},
+		},
+	)
+
+	expect(exitCode).toBe(1)
+	expect(result).not.toBeNull()
+	expect(result?.session.cookieHeader).toBe('kody_session=test-cookie')
+	expect(
+		result?.smoke?.checks.find((check) => check.name === 'cookie-file'),
+	).toEqual({
+		name: 'cookie-file',
+		ok: false,
+		detail: "ENOENT: no such file or directory, open '.tmp/preview-cookie'",
+	})
+	expect(result?.briefing).toContain('POST /auth')
+})
+
 test('preview manual test refuses draft PRs and failed preview workflows', async () => {
 	const logs: Array<string> = []
 	const draft = await runPreviewManualTest(['--pr', '9', '--no-wait'], {
@@ -409,7 +539,11 @@ function fakeGh(
 		return jsonGh({ nameWithOwner: 'kentcdodds/kody' })
 	}
 	if (joined.includes('/issues/') && joined.includes('/comments')) {
-		return jsonGh(input.commentBody ? [{ body: input.commentBody }] : [])
+		const comments = input.commentBody ? [{ body: input.commentBody }] : []
+		if (args.includes('--slurp')) {
+			return jsonGh([comments])
+		}
+		return jsonGh(comments)
 	}
 	if (joined.startsWith('run list')) {
 		return jsonGh([

--- a/tools/preview-manual-test.ts
+++ b/tools/preview-manual-test.ts
@@ -449,9 +449,20 @@ export function flattenGhJsonPages(parsed: unknown): Array<unknown> {
 	return parsed
 }
 
+export function commitShaMatchesExpected(
+	commitSha: string | null,
+	expectedSha: string | null,
+	commitParents: ReadonlyArray<string> = [],
+) {
+	if (!expectedSha) return true
+	if (!commitSha) return false
+	return commitSha === expectedSha || commitParents.includes(expectedSha)
+}
+
 export function evaluateAppHealth(
 	body: unknown,
 	expectedSha: string | null,
+	commitParents: ReadonlyArray<string> = [],
 ): { ok: boolean; commitSha: string | null; detail: string } {
 	if (!body || typeof body !== 'object') {
 		return {
@@ -472,7 +483,7 @@ export function evaluateAppHealth(
 			detail: `health ok is not true (${JSON.stringify(body)})`,
 		}
 	}
-	if (expectedSha && commitSha !== expectedSha) {
+	if (!commitShaMatchesExpected(commitSha, expectedSha, commitParents)) {
 		return {
 			ok: false,
 			commitSha,
@@ -482,13 +493,14 @@ export function evaluateAppHealth(
 	return {
 		ok: true,
 		commitSha,
-		detail: commitSha ? `ok, commitSha ${commitSha}` : 'ok',
+		detail: healthMatchDetail(commitSha, expectedSha, commitParents),
 	}
 }
 
 export function evaluateRuntimeHealth(
 	body: unknown,
 	expectedSha: string | null,
+	commitParents: ReadonlyArray<string> = [],
 ): { ok: boolean; commitSha: string | null; detail: string } {
 	if (!body || typeof body !== 'object') {
 		return {
@@ -516,7 +528,7 @@ export function evaluateRuntimeHealth(
 			detail: 'runtime cookieSecretConfigured is not true',
 		}
 	}
-	if (expectedSha && commitSha !== expectedSha) {
+	if (!commitShaMatchesExpected(commitSha, expectedSha, commitParents)) {
 		return {
 			ok: false,
 			commitSha,
@@ -526,8 +538,24 @@ export function evaluateRuntimeHealth(
 	return {
 		ok: true,
 		commitSha,
-		detail: commitSha ? `ok, commitSha ${commitSha}` : 'ok',
+		detail: healthMatchDetail(commitSha, expectedSha, commitParents),
 	}
+}
+
+function healthMatchDetail(
+	commitSha: string | null,
+	expectedSha: string | null,
+	commitParents: ReadonlyArray<string>,
+) {
+	if (!commitSha) return 'ok'
+	if (
+		expectedSha &&
+		commitSha !== expectedSha &&
+		commitParents.includes(expectedSha)
+	) {
+		return `ok, commitSha ${commitSha} (merge of ${expectedSha})`
+	}
+	return `ok, commitSha ${commitSha}`
 }
 
 export function formatBriefing(result: PreviewManualTestResult): string {
@@ -889,7 +917,7 @@ async function loadSnapshot(
 		d1DatabaseName: parsed?.d1DatabaseName ?? null,
 		oauthKvTitle: parsed?.oauthKvTitle ?? null,
 		mocks: parsed?.mocks ?? [],
-		expectedSha: options.expectedSha ?? deploymentSha,
+		expectedSha: options.expectedSha ?? deploymentSha ?? pr.headRefOid,
 		workflowUrl: workflow?.url ?? null,
 		workflowStatus: workflow?.status ?? null,
 		workflowConclusion: workflow?.conclusion ?? null,
@@ -985,9 +1013,55 @@ async function previewHealthReady(
 			deps,
 			`${snapshot.previewUrl.replace(/\/$/, '')}/health`,
 		)
-		return evaluateAppHealth(response.body, snapshot.expectedSha).ok
+		const healthEval = await evaluateFetchedHealth(
+			deps,
+			evaluateAppHealth,
+			response.body,
+			snapshot.expectedSha,
+		)
+		return healthEval.ok
 	} catch {
 		return false
+	}
+}
+
+async function evaluateFetchedHealth(
+	deps: PreviewManualTestDeps,
+	evaluate: (
+		body: unknown,
+		expectedSha: string | null,
+		commitParents?: ReadonlyArray<string>,
+	) => { ok: boolean; commitSha: string | null; detail: string },
+	body: unknown,
+	expectedSha: string | null,
+) {
+	const first = evaluate(body, expectedSha)
+	if (first.ok || !first.commitSha || !expectedSha) return first
+	const parents = await loadCommitParents(deps, first.commitSha)
+	if (!parents) return first
+	return evaluate(body, expectedSha, parents)
+}
+
+async function loadCommitParents(
+	deps: PreviewManualTestDeps,
+	sha: string,
+): Promise<Array<string> | null> {
+	try {
+		const repo = await ghJson<{ nameWithOwner: string }>(deps, [
+			'repo',
+			'view',
+			'--json',
+			'nameWithOwner',
+		])
+		const commit = await ghJson<{ parents?: Array<{ sha?: string }> }>(deps, [
+			'api',
+			`repos/${repo.nameWithOwner}/commits/${sha}`,
+		])
+		return (commit.parents ?? [])
+			.map((parent) => parent.sha)
+			.filter((parentSha): parentSha is string => Boolean(parentSha))
+	} catch {
+		return null
 	}
 }
 
@@ -1028,7 +1102,12 @@ async function runSmokeChecks(
 			detail: health.error,
 		})
 	} else {
-		const healthEval = evaluateAppHealth(health.body, snapshot.expectedSha)
+		const healthEval = await evaluateFetchedHealth(
+			deps,
+			evaluateAppHealth,
+			health.body,
+			snapshot.expectedSha,
+		)
 		commitSha = healthEval.commitSha
 		checks.push({
 			name: 'GET /health',
@@ -1094,7 +1173,9 @@ async function runSmokeChecks(
 				detail: runtimeHealth.error,
 			})
 		} else {
-			const runtimeEval = evaluateRuntimeHealth(
+			const runtimeEval = await evaluateFetchedHealth(
+				deps,
+				evaluateRuntimeHealth,
 				runtimeHealth.body,
 				snapshot.expectedSha,
 			)
@@ -1328,7 +1409,9 @@ function waitStatusMessage(
 		return `Waiting for preview workflow (${snapshot.workflowStatus ?? 'unknown'}${snapshot.workflowConclusion ? `/${snapshot.workflowConclusion}` : ''})${snapshot.workflowUrl ? `: ${snapshot.workflowUrl}` : ''}`
 	}
 	if (snapshot.previewUrl) {
-		return `Waiting for /health to match${snapshot.expectedSha ? ` ${snapshot.expectedSha}` : ''} at ${snapshot.previewUrl}`
+		return snapshot.expectedSha
+			? `Waiting for /health to serve ${snapshot.expectedSha} (exact or merge commit) at ${snapshot.previewUrl}`
+			: `Waiting for a healthy /health at ${snapshot.previewUrl}`
 	}
 	if (snapshot.workflowUrl) {
 		return `Waiting for preview workflow (${snapshot.workflowStatus ?? 'unknown'}): ${snapshot.workflowUrl}`

--- a/tools/preview-manual-test.ts
+++ b/tools/preview-manual-test.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process'
-import { writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
 import { promisify } from 'node:util'
 import { usernameFromEmail } from '../packages/worker/src/identity/username.ts'
 import { runtimeWorkerHealthPath } from '../packages/shared/src/runtime-worker.ts'
@@ -94,6 +95,7 @@ export type PreviewSnapshot = {
 	workflowUrl: string | null
 	workflowStatus: string | null
 	workflowConclusion: string | null
+	workflowHeadSha: string | null
 	deploymentSha: string | null
 }
 
@@ -151,6 +153,11 @@ export type PreviewManualTestDeps = {
 	writeFile: (path: string, contents: string) => Promise<void>
 }
 
+async function writeFileCreatingParents(path: string, contents: string) {
+	await mkdir(dirname(path), { recursive: true })
+	await writeFile(path, contents)
+}
+
 const defaultDeps: PreviewManualTestDeps = {
 	execGh,
 	fetch,
@@ -165,7 +172,7 @@ const defaultDeps: PreviewManualTestDeps = {
 	print: (message) => {
 		console.log(message)
 	},
-	writeFile,
+	writeFile: writeFileCreatingParents,
 }
 
 export function previewSeedUsername() {
@@ -426,6 +433,22 @@ export function cookieHeaderFromSetCookie(
 		.join('; ')
 }
 
+export function displayTitleMentionsPr(
+	displayTitle: string | undefined,
+	prNumber: number,
+) {
+	if (!displayTitle) return false
+	return new RegExp(`(?:^|\\D)#${prNumber}(?:\\D|$)`).test(displayTitle)
+}
+
+export function flattenGhJsonPages(parsed: unknown): Array<unknown> {
+	if (!Array.isArray(parsed)) return []
+	if (parsed.length > 0 && Array.isArray(parsed[0])) {
+		return parsed.flat()
+	}
+	return parsed
+}
+
 export function evaluateAppHealth(
 	body: unknown,
 	expectedSha: string | null,
@@ -527,7 +550,9 @@ export function formatBriefing(result: PreviewManualTestResult): string {
 			? `Deployed commit: ${result.smoke.commitSha}`
 			: result.snapshot.expectedSha
 				? `Expected commit: ${result.snapshot.expectedSha}`
-				: null,
+				: result.snapshot.previewUrl
+					? 'Warning: no expected /health commitSha (no GitHub preview deployment SHA and no --sha). Any healthy worker is accepted.'
+					: null,
 		result.snapshot.headSha &&
 		result.smoke?.commitSha &&
 		result.snapshot.headSha !== result.smoke.commitSha
@@ -745,6 +770,7 @@ async function resolveAndWait(
 
 	while (true) {
 		if (
+			snapshot.workflowHeadSha === snapshot.headSha &&
 			snapshot.workflowConclusion &&
 			isFailedConclusion(snapshot.workflowConclusion)
 		) {
@@ -752,7 +778,11 @@ async function resolveAndWait(
 				`Preview workflow ${snapshot.workflowConclusion}${snapshot.workflowUrl ? `: ${snapshot.workflowUrl}` : ''}`,
 			)
 		}
-		if (snapshot.previewUrl && (await previewHealthReady(snapshot, deps))) {
+		const healthReady =
+			Boolean(snapshot.previewUrl) && (await previewHealthReady(snapshot, deps))
+		const workflowReady = previewWorkflowReady(snapshot, options)
+		if (healthReady && workflowReady) {
+			warnIfMissingExpectedSha(snapshot, deps)
 			return snapshot
 		}
 		if (deps.now() >= deadline) {
@@ -760,9 +790,38 @@ async function resolveAndWait(
 				`Timed out after ${options.timeoutMs}ms. ${notReadyMessage(snapshot)}`,
 			)
 		}
-		deps.log(waitStatusMessage(snapshot))
+		deps.log(waitStatusMessage(snapshot, healthReady, workflowReady))
 		await deps.sleep(options.pollIntervalMs)
 		snapshot = await loadSnapshot(options, deps)
+	}
+}
+
+function skipPreviewWorkflowGate(options: PreviewManualTestOptions) {
+	return Boolean(options.previewUrl) && options.prNumber === null
+}
+
+function previewWorkflowReady(
+	snapshot: PreviewSnapshot,
+	options: PreviewManualTestOptions,
+) {
+	if (skipPreviewWorkflowGate(options)) return true
+	if (!snapshot.headSha || snapshot.workflowHeadSha !== snapshot.headSha) {
+		return false
+	}
+	return (
+		snapshot.workflowStatus === 'completed' &&
+		snapshot.workflowConclusion === 'success'
+	)
+}
+
+function warnIfMissingExpectedSha(
+	snapshot: PreviewSnapshot,
+	deps: PreviewManualTestDeps,
+) {
+	if (snapshot.previewUrl && !snapshot.expectedSha) {
+		deps.log(
+			'Warning: no expected /health commitSha (no GitHub preview deployment SHA and no --sha). Any healthy worker is accepted.',
+		)
 	}
 }
 
@@ -796,6 +855,7 @@ async function loadSnapshot(
 			workflowUrl: null,
 			workflowStatus: null,
 			workflowConclusion: null,
+			workflowHeadSha: null,
 			deploymentSha: null,
 		}
 	}
@@ -833,6 +893,7 @@ async function loadSnapshot(
 		workflowUrl: workflow?.url ?? null,
 		workflowStatus: workflow?.status ?? null,
 		workflowConclusion: workflow?.conclusion ?? null,
+		workflowHeadSha: workflow?.headSha ?? null,
 		deploymentSha,
 	}
 }
@@ -858,10 +919,14 @@ async function loadPreviewComment(
 		'--json',
 		'nameWithOwner',
 	])
-	const comments = await ghJson<Array<IssueComment>>(deps, [
-		'api',
-		`repos/${repo.nameWithOwner}/issues/${prNumber}/comments?per_page=100`,
-	])
+	const comments = flattenGhJsonPages(
+		await ghJson<unknown>(deps, [
+			'api',
+			'--paginate',
+			'--slurp',
+			`repos/${repo.nameWithOwner}/issues/${prNumber}/comments?per_page=100`,
+		]),
+	) as Array<IssueComment>
 	const match = comments.find((comment) =>
 		comment.body?.includes(previewCommentMarker),
 	)
@@ -882,12 +947,11 @@ async function loadPreviewWorkflow(
 		'--limit',
 		'30',
 	])
-	const matching = runs.filter(
-		(run) =>
-			run.headSha === pr.headRefOid ||
-			run.displayTitle.includes(`#${pr.number}`),
+	return (
+		runs.find((run) => run.headSha === pr.headRefOid) ??
+		runs.find((run) => displayTitleMentionsPr(run.displayTitle, pr.number)) ??
+		null
 	)
-	return matching[0] ?? null
 }
 
 async function loadDeploymentSha(
@@ -957,61 +1021,93 @@ async function runSmokeChecks(
 	let cookieHeader = ''
 
 	const health = await fetchJson(deps, `${origin}/health`)
-	const healthEval = evaluateAppHealth(health.body, snapshot.expectedSha)
-	commitSha = healthEval.commitSha
-	checks.push({
-		name: 'GET /health',
-		ok: health.status === 200 && healthEval.ok,
-		detail:
-			health.status === 200
-				? healthEval.detail
-				: `HTTP ${health.status}: ${healthEval.detail}`,
-	})
+	if (health.error) {
+		checks.push({
+			name: 'GET /health',
+			ok: false,
+			detail: health.error,
+		})
+	} else {
+		const healthEval = evaluateAppHealth(health.body, snapshot.expectedSha)
+		commitSha = healthEval.commitSha
+		checks.push({
+			name: 'GET /health',
+			ok: health.status === 200 && healthEval.ok,
+			detail:
+				health.status === 200
+					? healthEval.detail
+					: `HTTP ${health.status}: ${healthEval.detail}`,
+		})
+	}
 
 	const loginPage = await fetchText(deps, `${origin}/login`)
-	const loginPageOk =
-		loginPage.status === 200 &&
-		loginPage.body.includes('Welcome back') &&
-		/email/i.test(loginPage.body) &&
-		/password/i.test(loginPage.body)
-	checks.push({
-		name: 'GET /login',
-		ok: loginPageOk,
-		detail: loginPageOk
-			? 'login form rendered'
-			: `HTTP ${loginPage.status}; expected "Welcome back" plus email/password fields`,
-	})
+	if (loginPage.error) {
+		checks.push({
+			name: 'GET /login',
+			ok: false,
+			detail: loginPage.error,
+		})
+	} else {
+		const loginPageOk =
+			loginPage.status === 200 &&
+			loginPage.body.includes('Welcome back') &&
+			/email/i.test(loginPage.body) &&
+			/password/i.test(loginPage.body)
+		checks.push({
+			name: 'GET /login',
+			ok: loginPageOk,
+			detail: loginPageOk
+				? 'login form rendered'
+				: `HTTP ${loginPage.status}; expected "Welcome back" plus email/password fields`,
+		})
+	}
 
 	const mcp = await fetchText(deps, `${origin}/mcp`, {
 		headers: { Accept: 'application/json, text/event-stream' },
 	})
-	checks.push({
-		name: 'GET /mcp',
-		ok: mcp.status === 401,
-		detail:
-			mcp.status === 401
-				? '401 without OAuth, as expected'
-				: `expected 401, got HTTP ${mcp.status}`,
-	})
+	if (mcp.error) {
+		checks.push({
+			name: 'GET /mcp',
+			ok: false,
+			detail: mcp.error,
+		})
+	} else {
+		checks.push({
+			name: 'GET /mcp',
+			ok: mcp.status === 401,
+			detail:
+				mcp.status === 401
+					? '401 without OAuth, as expected'
+					: `expected 401, got HTTP ${mcp.status}`,
+		})
+	}
 
 	if (snapshot.runtimeUrl) {
 		const runtimeHealth = await fetchJson(
 			deps,
 			`${snapshot.runtimeUrl.replace(/\/$/, '')}${runtimeWorkerHealthPath}`,
 		)
-		const runtimeEval = evaluateRuntimeHealth(
-			runtimeHealth.body,
-			snapshot.expectedSha,
-		)
-		runtimeCommitSha = runtimeEval.commitSha
-		checks.push({
-			name: `GET ${runtimeWorkerHealthPath}`,
-			ok: runtimeHealth.status === 200 && runtimeEval.ok,
-			detail:
-				runtimeHealth.status === 200
-					? runtimeEval.detail
-					: `HTTP ${runtimeHealth.status}: ${runtimeEval.detail}`,
-		})
+		if (runtimeHealth.error) {
+			checks.push({
+				name: `GET ${runtimeWorkerHealthPath}`,
+				ok: false,
+				detail: runtimeHealth.error,
+			})
+		} else {
+			const runtimeEval = evaluateRuntimeHealth(
+				runtimeHealth.body,
+				snapshot.expectedSha,
+			)
+			runtimeCommitSha = runtimeEval.commitSha
+			checks.push({
+				name: `GET ${runtimeWorkerHealthPath}`,
+				ok: runtimeHealth.status === 200 && runtimeEval.ok,
+				detail:
+					runtimeHealth.status === 200
+						? runtimeEval.detail
+						: `HTTP ${runtimeHealth.status}: ${runtimeEval.detail}`,
+			})
+		}
 	}
 
 	if (!options.skipLogin) {
@@ -1024,66 +1120,101 @@ async function runSmokeChecks(
 				mode: 'login',
 			}),
 		})
-		cookieHeader = cookieHeaderFromSetCookie(auth.setCookie)
-		const authOk =
-			auth.status === 200 &&
-			Boolean(cookieHeader) &&
-			(auth.body as { ok?: unknown } | null)?.ok !== false
-		checks.push({
-			name: 'POST /auth',
-			ok: authOk,
-			detail: authOk
-				? `signed in as ${previewSeedEmail}`
-				: `HTTP ${auth.status} ${JSON.stringify(auth.body)}; Set-Cookie ${auth.setCookie.length > 0 ? 'present' : 'missing'}`,
-		})
+		if (auth.error) {
+			checks.push({
+				name: 'POST /auth',
+				ok: false,
+				detail: auth.error,
+			})
+		} else {
+			cookieHeader = cookieHeaderFromSetCookie(auth.setCookie)
+			const authOk =
+				auth.status === 200 &&
+				Boolean(cookieHeader) &&
+				(auth.body as { ok?: unknown } | null)?.ok !== false
+			checks.push({
+				name: 'POST /auth',
+				ok: authOk,
+				detail: authOk
+					? `signed in as ${previewSeedEmail}`
+					: `HTTP ${auth.status} ${JSON.stringify(auth.body)}; Set-Cookie ${auth.setCookie.length > 0 ? 'present' : 'missing'}`,
+			})
+		}
 
 		if (cookieHeader) {
 			const session = await fetchJson(deps, `${origin}/session`, {
 				headers: { Cookie: cookieHeader, Accept: 'application/json' },
 			})
-			const sessionRecord =
-				session.body && typeof session.body === 'object'
-					? (session.body as {
-							ok?: unknown
-							session?: { email?: unknown }
-						})
-					: null
-			sessionEmail =
-				typeof sessionRecord?.session?.email === 'string'
-					? sessionRecord.session.email
-					: null
-			const sessionOk =
-				session.status === 200 &&
-				sessionRecord?.ok === true &&
-				sessionEmail?.toLowerCase() === previewSeedEmail
-			checks.push({
-				name: 'GET /session',
-				ok: sessionOk,
-				detail: sessionOk
-					? `session email ${sessionEmail}`
-					: `HTTP ${session.status} ${JSON.stringify(session.body)}`,
-			})
+			if (session.error) {
+				checks.push({
+					name: 'GET /session',
+					ok: false,
+					detail: session.error,
+				})
+			} else {
+				const sessionRecord =
+					session.body && typeof session.body === 'object'
+						? (session.body as {
+								ok?: unknown
+								session?: { email?: unknown }
+							})
+						: null
+				sessionEmail =
+					typeof sessionRecord?.session?.email === 'string'
+						? sessionRecord.session.email
+						: null
+				const sessionOk =
+					session.status === 200 &&
+					sessionRecord?.ok === true &&
+					sessionEmail?.toLowerCase() === previewSeedEmail
+				checks.push({
+					name: 'GET /session',
+					ok: sessionOk,
+					detail: sessionOk
+						? `session email ${sessionEmail}`
+						: `HTTP ${session.status} ${JSON.stringify(session.body)}`,
+				})
+			}
 
 			const account = await fetchText(deps, `${origin}/account`, {
 				headers: { Cookie: cookieHeader },
 				redirect: 'manual',
 			})
-			const accountOk = account.status === 200
-			checks.push({
-				name: 'GET /account',
-				ok: accountOk,
-				detail: accountOk
-					? 'authenticated account page'
-					: `expected HTTP 200, got ${account.status}`,
-			})
+			if (account.error) {
+				checks.push({
+					name: 'GET /account',
+					ok: false,
+					detail: account.error,
+				})
+			} else {
+				const accountOk = account.status === 200
+				checks.push({
+					name: 'GET /account',
+					ok: accountOk,
+					detail: accountOk
+						? 'authenticated account page'
+						: `expected HTTP 200, got ${account.status}`,
+				})
+			}
 
 			if (options.cookieFile) {
-				await deps.writeFile(options.cookieFile, `${cookieHeader}\n`)
-				checks.push({
-					name: 'cookie-file',
-					ok: true,
-					detail: options.cookieFile,
-				})
+				try {
+					await deps.writeFile(options.cookieFile, `${cookieHeader}\n`)
+					checks.push({
+						name: 'cookie-file',
+						ok: true,
+						detail: options.cookieFile,
+					})
+				} catch (error) {
+					checks.push({
+						name: 'cookie-file',
+						ok: false,
+						detail:
+							error instanceof Error
+								? error.message
+								: `failed to write ${options.cookieFile}`,
+					})
+				}
 			}
 
 			for (const spec of options.sessionRequests) {
@@ -1104,8 +1235,12 @@ async function runSmokeChecks(
 				})
 				checks.push({
 					name: `GET ${normalized}`,
-					ok: extra.status === 200,
-					detail: extra.status === 200 ? '200' : `HTTP ${extra.status}`,
+					ok: extra.error ? false : extra.status === 200,
+					detail: extra.error
+						? extra.error
+						: extra.status === 200
+							? '200'
+							: `HTTP ${extra.status}`,
 				})
 			}
 		}
@@ -1177,7 +1312,21 @@ function notReadyMessage(snapshot: PreviewSnapshot) {
 		.join(' ')
 }
 
-function waitStatusMessage(snapshot: PreviewSnapshot) {
+function waitStatusMessage(
+	snapshot: PreviewSnapshot,
+	healthReady: boolean,
+	workflowReady: boolean,
+) {
+	if (snapshot.previewUrl && healthReady && !workflowReady) {
+		if (
+			snapshot.headSha &&
+			snapshot.workflowHeadSha &&
+			snapshot.workflowHeadSha !== snapshot.headSha
+		) {
+			return `Waiting for a preview workflow run for ${snapshot.headSha}`
+		}
+		return `Waiting for preview workflow (${snapshot.workflowStatus ?? 'unknown'}${snapshot.workflowConclusion ? `/${snapshot.workflowConclusion}` : ''})${snapshot.workflowUrl ? `: ${snapshot.workflowUrl}` : ''}`
+	}
 	if (snapshot.previewUrl) {
 		return `Waiting for /health to match${snapshot.expectedSha ? ` ${snapshot.expectedSha}` : ''} at ${snapshot.previewUrl}`
 	}
@@ -1219,6 +1368,13 @@ async function runAuthenticatedSessionRequest(
 	const response = spec.path.includes('.json')
 		? await fetchJson(deps, `${origin}${spec.path}`, init)
 		: await fetchText(deps, `${origin}${spec.path}`, init)
+	if (response.error) {
+		return {
+			name: sessionRequestName(spec),
+			ok: false,
+			detail: response.error,
+		}
+	}
 	const ok = evaluateSessionRequestStatus(response.status, spec.expectedStatus)
 	const expected =
 		spec.expectedStatus === null ? '2xx' : String(spec.expectedStatus)
@@ -1243,12 +1399,14 @@ type FetchedJson = {
 	status: number
 	body: unknown
 	setCookie: Array<string>
+	error?: string
 }
 
 type FetchedText = {
 	status: number
 	body: string
 	setCookie: Array<string>
+	error?: string
 }
 
 async function fetchJson(
@@ -1256,15 +1414,24 @@ async function fetchJson(
 	url: string,
 	init: RequestInit = {},
 ): Promise<FetchedJson> {
-	const response = await deps.fetch(url, {
-		...init,
-		signal: init.signal ?? AbortSignal.timeout(defaultRequestTimeoutMs),
-	})
-	const body = await response.json().catch(() => null)
-	return {
-		status: response.status,
-		body,
-		setCookie: readSetCookie(response),
+	try {
+		const response = await deps.fetch(url, {
+			...init,
+			signal: init.signal ?? AbortSignal.timeout(defaultRequestTimeoutMs),
+		})
+		const body = await response.json().catch(() => null)
+		return {
+			status: response.status,
+			body,
+			setCookie: readSetCookie(response),
+		}
+	} catch (error) {
+		return {
+			status: 0,
+			body: null,
+			setCookie: [],
+			error: error instanceof Error ? error.message : String(error),
+		}
 	}
 }
 
@@ -1273,14 +1440,23 @@ async function fetchText(
 	url: string,
 	init: RequestInit = {},
 ): Promise<FetchedText> {
-	const response = await deps.fetch(url, {
-		...init,
-		signal: init.signal ?? AbortSignal.timeout(defaultRequestTimeoutMs),
-	})
-	return {
-		status: response.status,
-		body: await response.text().catch(() => ''),
-		setCookie: readSetCookie(response),
+	try {
+		const response = await deps.fetch(url, {
+			...init,
+			signal: init.signal ?? AbortSignal.timeout(defaultRequestTimeoutMs),
+		})
+		return {
+			status: response.status,
+			body: await response.text().catch(() => ''),
+			setCookie: readSetCookie(response),
+		}
+	} catch (error) {
+		return {
+			status: 0,
+			body: '',
+			setCookie: [],
+			error: error instanceof Error ? error.message : String(error),
+		}
 	}
 }
 

--- a/tools/preview-manual-test.ts
+++ b/tools/preview-manual-test.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import { writeFile } from 'node:fs/promises'
 import { promisify } from 'node:util'
 import { usernameFromEmail } from '../packages/worker/src/identity/username.ts'
 import { runtimeWorkerHealthPath } from '../packages/shared/src/runtime-worker.ts'
@@ -17,8 +18,9 @@ const usageLines = [
 	'Usage: node tools/preview-manual-test.ts [options]',
 	'',
 	"Discover this PR's Cloudflare preview, wait until it is serving the",
-	'deployed commit, run a no-browser smoke, and print a briefing for',
-	'manual UI testing. Use on medium-to-high risk PRs after pushing.',
+	'deployed commit, sign in as the seeded user, then run authenticated',
+	'requests so you can create specific data and assert the change.',
+	'Use on medium-to-high risk PRs after pushing.',
 	'',
 	'Options:',
 	'  --pr <n>            PR number (default: gh pr view)',
@@ -29,8 +31,14 @@ const usageLines = [
 	'  --timeout-ms <n>    Wait budget in milliseconds (default: 900000)',
 	'  --poll-ms <n>       Poll interval in milliseconds (default: 8000)',
 	'  --skip-login        Skip POST /auth and cookie-backed checks',
+	'  --request <spec>    Authenticated HTTP as the seed user (repeatable).',
+	'                      Spec: METHOD /path [status] [json-body]',
+	'                      Default success is any 2xx. Example:',
+	'                      POST /account/values.json {"action":"save",...}',
 	'  --check <path>      Extra authenticated GET after login (repeatable)',
-	'  --json              Machine-readable output on stdout',
+	'  --cookie-file <p>   Write the session Cookie header value to a file',
+	'  --json              Machine-readable output on stdout (includes',
+	'                      session.cookieHeader for follow-up curl)',
 	'  --help              Print this help',
 	'',
 	'Docs: docs/contributing/preview-manual-testing.md',
@@ -45,8 +53,19 @@ export type PreviewManualTestOptions = {
 	pollIntervalMs: number
 	skipLogin: boolean
 	checkPaths: Array<string>
+	sessionRequests: Array<SessionRequestSpec>
+	cookieFile: string | null
 	json: boolean
 	help: boolean
+}
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+export type SessionRequestSpec = {
+	method: HttpMethod
+	path: string
+	expectedStatus: number | null
+	body: unknown | null
 }
 
 export type ParsedPreviewComment = {
@@ -90,6 +109,13 @@ export type SmokeReport = {
 	sessionEmail: string | null
 	commitSha: string | null
 	runtimeCommitSha: string | null
+	cookieHeader: string | null
+}
+
+export type PreviewSession = {
+	cookieHeader: string | null
+	origin: string | null
+	cookieFile: string | null
 }
 
 export type PreviewManualTestResult = {
@@ -98,6 +124,7 @@ export type PreviewManualTestResult = {
 	options: PreviewManualTestOptions
 	snapshot: PreviewSnapshot
 	smoke: SmokeReport | null
+	session: PreviewSession
 	login: {
 		email: string
 		password: string
@@ -121,6 +148,7 @@ export type PreviewManualTestDeps = {
 	log: (message: string) => void
 	error: (message: string) => void
 	print: (message: string) => void
+	writeFile: (path: string, contents: string) => Promise<void>
 }
 
 const defaultDeps: PreviewManualTestDeps = {
@@ -137,6 +165,7 @@ const defaultDeps: PreviewManualTestDeps = {
 	print: (message) => {
 		console.log(message)
 	},
+	writeFile,
 }
 
 export function previewSeedUsername() {
@@ -153,6 +182,8 @@ export function parseArgs(argv: Array<string>): PreviewManualTestOptions {
 		pollIntervalMs: defaultPollIntervalMs,
 		skipLogin: false,
 		checkPaths: [],
+		sessionRequests: [],
+		cookieFile: null,
 		json: false,
 		help: false,
 	}
@@ -208,6 +239,18 @@ export function parseArgs(argv: Array<string>): PreviewManualTestOptions {
 				index += 1
 				break
 			}
+			case '--request': {
+				options.sessionRequests.push(
+					parseSessionRequest(requireValue(argv[index + 1], '--request')),
+				)
+				index += 1
+				break
+			}
+			case '--cookie-file': {
+				options.cookieFile = requireValue(argv[index + 1], '--cookie-file')
+				index += 1
+				break
+			}
 			default: {
 				if (arg.startsWith('-')) {
 					throw new PreviewManualTestError(
@@ -221,13 +264,93 @@ export function parseArgs(argv: Array<string>): PreviewManualTestOptions {
 		}
 	}
 
-	if (options.checkPaths.length > 0 && options.skipLogin) {
-		throw new PreviewManualTestError(
-			'--check requires a session cookie; omit --skip-login.',
-		)
+	if (options.skipLogin) {
+		if (options.checkPaths.length > 0) {
+			throw new PreviewManualTestError(
+				'--check requires a session cookie; omit --skip-login.',
+			)
+		}
+		if (options.sessionRequests.length > 0) {
+			throw new PreviewManualTestError(
+				'--request requires a session cookie; omit --skip-login.',
+			)
+		}
+		if (options.cookieFile) {
+			throw new PreviewManualTestError(
+				'--cookie-file requires a session cookie; omit --skip-login.',
+			)
+		}
 	}
 
 	return options
+}
+
+const httpMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const
+
+function isHttpMethod(value: string): value is HttpMethod {
+	return (httpMethods as ReadonlyArray<string>).includes(value)
+}
+
+export function parseSessionRequest(spec: string): SessionRequestSpec {
+	const trimmed = spec.trim()
+	const match =
+		/^(GET|POST|PUT|PATCH|DELETE)\s+(\S+)(?:\s+(\d{3}))?(?:\s+([\s\S]+))?$/i.exec(
+			trimmed,
+		)
+	if (!match?.[1] || !match[2]) {
+		throw new PreviewManualTestError(
+			`Invalid --request spec: ${spec}\nExpected: METHOD /path [status] [json-body]`,
+		)
+	}
+	const methodName = match[1].toUpperCase()
+	if (!isHttpMethod(methodName)) {
+		throw new PreviewManualTestError(`Unsupported HTTP method: ${methodName}`)
+	}
+	const path = match[2]
+	if (!path.startsWith('/')) {
+		throw new PreviewManualTestError(
+			`--request path must start with /: ${path}`,
+		)
+	}
+	const expectedStatus = match[3] ? Number.parseInt(match[3], 10) : null
+	const rawBody = match[4]?.trim() ?? ''
+	let body: unknown | null = null
+	if (rawBody.length > 0) {
+		if (methodName === 'GET') {
+			throw new PreviewManualTestError(
+				'GET --request cannot include a JSON body.',
+			)
+		}
+		try {
+			body = JSON.parse(rawBody) as unknown
+		} catch {
+			throw new PreviewManualTestError(
+				`--request body is not valid JSON: ${rawBody}`,
+			)
+		}
+	}
+	return {
+		method: methodName,
+		path,
+		expectedStatus,
+		body,
+	}
+}
+
+export function sessionRequestName(spec: SessionRequestSpec) {
+	const status =
+		spec.expectedStatus === null ? '2xx' : String(spec.expectedStatus)
+	return `${spec.method} ${spec.path} (${status})`
+}
+
+export function evaluateSessionRequestStatus(
+	actualStatus: number,
+	expectedStatus: number | null,
+) {
+	if (expectedStatus === null) {
+		return actualStatus >= 200 && actualStatus < 300
+	}
+	return actualStatus === expectedStatus
 }
 
 export function parsePreviewComment(body: string): ParsedPreviewComment | null {
@@ -422,6 +545,9 @@ export function formatBriefing(result: PreviewManualTestResult): string {
 		`Login (preview seed, non-admin): ${result.login.email} / ${result.login.password}`,
 		`Username: ${result.login.username}`,
 		'`/admin` is expected to 403 — preview does not seed an admin account.',
+		result.session.cookieHeader
+			? 'Session cookie: `--json` field `session.cookieHeader`, or `--cookie-file`.'
+			: null,
 	].filter((line): line is string => line !== null)
 
 	if (result.snapshot.mocks.length > 0) {
@@ -440,12 +566,17 @@ export function formatBriefing(result: PreviewManualTestResult): string {
 
 	lines.push(
 		'',
-		'Manual UI next steps:',
-		'1. Open the preview URL in a browser (computerUse on Cloud Agents).',
-		'2. Sign in at `/login` with Email + Password, then the "Sign in" button.',
-		'3. Exercise the user-visible flows this PR changes. Stay on the preview origin.',
-		'4. `/mcp` needs OAuth; unauthenticated GET `/mcp` is 401 by design.',
-		'5. Record what you saw in the PR. This does not replace `npm run validate`.',
+		'Logged-in testing (required for medium/high risk):',
+		'The seed account starts empty except the user row. Create the data this',
+		'PR needs through the same JSON APIs the UI uses, then assert them:',
+		'  npm run preview:manual-test -- --request \'POST /account/values.json {"action":"save","name":"preview-locale","value":"en-US"}\' --request \'GET /account/values.json\'',
+		'Follow-up curl with the session cookie:',
+		`  curl -sS -H "Cookie: $COOKIE" -H 'Accept: application/json' ${result.session.origin ?? '<preview-url>'}/account/values.json`,
+		'Stay on the preview origin. `/mcp` is 401 without OAuth by design.',
+		'',
+		'UI pass after data exists: open the preview URL (computerUse on Cloud',
+		'Agents), sign in with the credentials above, and exercise the changed flows.',
+		'Record what you saw in the PR. This does not replace `npm run validate`.',
 		'',
 		'Docs: docs/contributing/preview-manual-testing.md',
 	)
@@ -814,6 +945,7 @@ async function runSmokeChecks(
 			sessionEmail: null,
 			commitSha: null,
 			runtimeCommitSha: null,
+			cookieHeader: null,
 		}
 	}
 
@@ -945,6 +1077,25 @@ async function runSmokeChecks(
 					: `expected HTTP 200, got ${account.status}`,
 			})
 
+			if (options.cookieFile) {
+				await deps.writeFile(options.cookieFile, `${cookieHeader}\n`)
+				checks.push({
+					name: 'cookie-file',
+					ok: true,
+					detail: options.cookieFile,
+				})
+			}
+
+			for (const spec of options.sessionRequests) {
+				const requestCheck = await runAuthenticatedSessionRequest(
+					deps,
+					origin,
+					cookieHeader,
+					spec,
+				)
+				checks.push(requestCheck)
+			}
+
 			for (const path of options.checkPaths) {
 				const normalized = path.startsWith('/') ? path : `/${path}`
 				const extra = await fetchText(deps, `${origin}${normalized}`, {
@@ -966,6 +1117,7 @@ async function runSmokeChecks(
 		sessionEmail,
 		commitSha,
 		runtimeCommitSha,
+		cookieHeader: cookieHeader || null,
 	}
 }
 
@@ -995,6 +1147,13 @@ function buildResult(
 		options,
 		snapshot,
 		smoke,
+		session: {
+			cookieHeader: smoke?.cookieHeader ?? null,
+			origin: snapshot.previewUrl
+				? snapshot.previewUrl.replace(/\/$/, '')
+				: null,
+			cookieFile: options.cookieFile,
+		},
 		login,
 		briefing: '',
 	}
@@ -1036,6 +1195,48 @@ function isFailedConclusion(conclusion: string) {
 		conclusion === 'timed_out' ||
 		conclusion === 'startup_failure'
 	)
+}
+
+async function runAuthenticatedSessionRequest(
+	deps: PreviewManualTestDeps,
+	origin: string,
+	cookieHeader: string,
+	spec: SessionRequestSpec,
+): Promise<SmokeCheck> {
+	const headers: Record<string, string> = {
+		Cookie: cookieHeader,
+		Accept: spec.path.includes('.json') ? 'application/json' : '*/*',
+	}
+	const init: RequestInit = {
+		method: spec.method,
+		headers,
+		redirect: 'manual',
+	}
+	if (spec.body !== null) {
+		headers['Content-Type'] = 'application/json'
+		init.body = JSON.stringify(spec.body)
+	}
+	const response = spec.path.includes('.json')
+		? await fetchJson(deps, `${origin}${spec.path}`, init)
+		: await fetchText(deps, `${origin}${spec.path}`, init)
+	const ok = evaluateSessionRequestStatus(response.status, spec.expectedStatus)
+	const expected =
+		spec.expectedStatus === null ? '2xx' : String(spec.expectedStatus)
+	return {
+		name: sessionRequestName(spec),
+		ok,
+		detail: ok
+			? `HTTP ${response.status} ${truncateDetail(response.body)}`
+			: `expected ${expected}, got HTTP ${response.status} ${truncateDetail(response.body)}`,
+	}
+}
+
+function truncateDetail(body: unknown, maxLength = 400) {
+	const text =
+		typeof body === 'string' ? body : body === null ? '' : JSON.stringify(body)
+	const compact = text.replace(/\s+/g, ' ').trim()
+	if (compact.length <= maxLength) return compact
+	return `${compact.slice(0, maxLength)}…`
 }
 
 type FetchedJson = {

--- a/tools/preview-manual-test.ts
+++ b/tools/preview-manual-test.ts
@@ -970,10 +970,12 @@ async function loadPreviewWorkflow(
 		'list',
 		'--workflow',
 		'preview.yml',
+		'--commit',
+		pr.headRefOid,
 		'--json',
 		'databaseId,status,conclusion,headSha,event,url,displayTitle',
 		'--limit',
-		'30',
+		'10',
 	])
 	return (
 		runs.find((run) => run.headSha === pr.headRefOid) ??

--- a/tools/preview-manual-test.ts
+++ b/tools/preview-manual-test.ts
@@ -1,0 +1,1097 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { usernameFromEmail } from '../packages/worker/src/identity/username.ts'
+import { runtimeWorkerHealthPath } from '../packages/shared/src/runtime-worker.ts'
+import { isExecutedDirectly } from './node-runtime.ts'
+
+const execFileAsync = promisify(execFile)
+
+export const previewCommentMarker = '<!-- kody-preview-url -->'
+export const previewSeedEmail = 'me@kentcdodds.com'
+export const previewSeedPassword = 'ilikecode'
+export const defaultWaitTimeoutMs = 15 * 60 * 1000
+export const defaultPollIntervalMs = 8_000
+export const defaultRequestTimeoutMs = 10_000
+
+const usageLines = [
+	'Usage: node tools/preview-manual-test.ts [options]',
+	'',
+	"Discover this PR's Cloudflare preview, wait until it is serving the",
+	'deployed commit, run a no-browser smoke, and print a briefing for',
+	'manual UI testing. Use on medium-to-high risk PRs after pushing.',
+	'',
+	'Options:',
+	'  --pr <n>            PR number (default: gh pr view)',
+	'  --url <url>         Skip GitHub discovery; smoke this preview URL',
+	'  --sha <sha>         Expected /health commitSha (default: GitHub',
+	'                      preview deployment SHA, not local HEAD — see docs)',
+	'  --no-wait           Fail immediately if the preview is not ready',
+	'  --timeout-ms <n>    Wait budget in milliseconds (default: 900000)',
+	'  --poll-ms <n>       Poll interval in milliseconds (default: 8000)',
+	'  --skip-login        Skip POST /auth and cookie-backed checks',
+	'  --check <path>      Extra authenticated GET after login (repeatable)',
+	'  --json              Machine-readable output on stdout',
+	'  --help              Print this help',
+	'',
+	'Docs: docs/contributing/preview-manual-testing.md',
+]
+
+export type PreviewManualTestOptions = {
+	prNumber: number | null
+	previewUrl: string | null
+	expectedSha: string | null
+	wait: boolean
+	timeoutMs: number
+	pollIntervalMs: number
+	skipLogin: boolean
+	checkPaths: Array<string>
+	json: boolean
+	help: boolean
+}
+
+export type ParsedPreviewComment = {
+	previewUrl: string | null
+	workerName: string | null
+	runtimeWorkerName: string | null
+	runtimeUrl: string | null
+	d1DatabaseName: string | null
+	oauthKvTitle: string | null
+	mocks: Array<string>
+}
+
+export type PreviewSnapshot = {
+	prNumber: number | null
+	prUrl: string | null
+	isDraft: boolean
+	headSha: string | null
+	previewUrl: string | null
+	workerName: string | null
+	runtimeWorkerName: string | null
+	runtimeUrl: string | null
+	d1DatabaseName: string | null
+	oauthKvTitle: string | null
+	mocks: Array<string>
+	expectedSha: string | null
+	workflowUrl: string | null
+	workflowStatus: string | null
+	workflowConclusion: string | null
+	deploymentSha: string | null
+}
+
+export type SmokeCheck = {
+	name: string
+	ok: boolean
+	detail: string
+}
+
+export type SmokeReport = {
+	ok: boolean
+	checks: Array<SmokeCheck>
+	sessionEmail: string | null
+	commitSha: string | null
+	runtimeCommitSha: string | null
+}
+
+export type PreviewManualTestResult = {
+	ok: boolean
+	message: string
+	options: PreviewManualTestOptions
+	snapshot: PreviewSnapshot
+	smoke: SmokeReport | null
+	login: {
+		email: string
+		password: string
+		username: string
+		admin: false
+	}
+	briefing: string
+}
+
+export type GhResult = {
+	status: number
+	stdout: string
+	stderr: string
+}
+
+export type PreviewManualTestDeps = {
+	execGh: (args: ReadonlyArray<string>) => Promise<GhResult>
+	fetch: typeof fetch
+	sleep: (ms: number) => Promise<void>
+	now: () => number
+	log: (message: string) => void
+	error: (message: string) => void
+	print: (message: string) => void
+}
+
+const defaultDeps: PreviewManualTestDeps = {
+	execGh,
+	fetch,
+	sleep,
+	now: () => Date.now(),
+	log: (message) => {
+		console.error(message)
+	},
+	error: (message) => {
+		console.error(message)
+	},
+	print: (message) => {
+		console.log(message)
+	},
+}
+
+export function previewSeedUsername() {
+	return usernameFromEmail(previewSeedEmail)
+}
+
+export function parseArgs(argv: Array<string>): PreviewManualTestOptions {
+	const options: PreviewManualTestOptions = {
+		prNumber: null,
+		previewUrl: null,
+		expectedSha: null,
+		wait: true,
+		timeoutMs: defaultWaitTimeoutMs,
+		pollIntervalMs: defaultPollIntervalMs,
+		skipLogin: false,
+		checkPaths: [],
+		json: false,
+		help: false,
+	}
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index]
+		if (!arg) continue
+		switch (arg) {
+			case '--help':
+			case '-h': {
+				options.help = true
+				break
+			}
+			case '--json': {
+				options.json = true
+				break
+			}
+			case '--no-wait': {
+				options.wait = false
+				break
+			}
+			case '--skip-login': {
+				options.skipLogin = true
+				break
+			}
+			case '--pr': {
+				options.prNumber = parsePositiveInt(argv[index + 1], '--pr')
+				index += 1
+				break
+			}
+			case '--url': {
+				options.previewUrl = requireValue(argv[index + 1], '--url')
+				index += 1
+				break
+			}
+			case '--sha': {
+				options.expectedSha = requireValue(argv[index + 1], '--sha')
+				index += 1
+				break
+			}
+			case '--timeout-ms': {
+				options.timeoutMs = parsePositiveInt(argv[index + 1], '--timeout-ms')
+				index += 1
+				break
+			}
+			case '--poll-ms': {
+				options.pollIntervalMs = parsePositiveInt(argv[index + 1], '--poll-ms')
+				index += 1
+				break
+			}
+			case '--check': {
+				options.checkPaths.push(requireValue(argv[index + 1], '--check'))
+				index += 1
+				break
+			}
+			default: {
+				if (arg.startsWith('-')) {
+					throw new PreviewManualTestError(
+						`Unknown flag: ${arg}\n\n${usageLines.join('\n')}`,
+					)
+				}
+				throw new PreviewManualTestError(
+					`Unexpected argument: ${arg}\n\n${usageLines.join('\n')}`,
+				)
+			}
+		}
+	}
+
+	if (options.checkPaths.length > 0 && options.skipLogin) {
+		throw new PreviewManualTestError(
+			'--check requires a session cookie; omit --skip-login.',
+		)
+	}
+
+	return options
+}
+
+export function parsePreviewComment(body: string): ParsedPreviewComment | null {
+	if (!body.includes(previewCommentMarker)) return null
+
+	const previewUrl = matchFirst(
+		body,
+		/🔎 Preview deployed:\s*(https?:\/\/\S+)/i,
+	)
+	const workerName = matchFirst(body, /Worker:\s*`([^`]+)`/)
+	const runtimeLine = body.match(
+		/Runtime worker:\s*`([^`]+)`\s*(?:\((https?:\/\/[^)\s]+)\))?/i,
+	)
+	const d1DatabaseName = matchFirst(body, /D1:\s*`([^`]+)`/)
+	const oauthKvTitle = matchFirst(body, /KV:\s*`([^`]+)`/)
+	const mocks: Array<string> = []
+	const mocksSection = body.split(/\nMocks:\s*\n/i)[1]
+	if (mocksSection) {
+		for (const line of mocksSection.split('\n')) {
+			const trimmed = line.trim()
+			if (trimmed.startsWith('- ')) mocks.push(trimmed.slice(2).trim())
+		}
+	}
+
+	return {
+		previewUrl,
+		workerName,
+		runtimeWorkerName: runtimeLine?.[1] ?? null,
+		runtimeUrl: runtimeLine?.[2] ?? null,
+		d1DatabaseName,
+		oauthKvTitle,
+		mocks,
+	}
+}
+
+export function workerNameFromPreviewUrl(previewUrl: string): string | null {
+	try {
+		const hostname = new URL(previewUrl).hostname
+		if (!hostname.endsWith('.workers.dev')) return null
+		const label = hostname.split('.')[0]
+		return label || null
+	} catch {
+		return null
+	}
+}
+
+export function deriveSiblingWorkerUrl(
+	previewUrl: string,
+	workerName: string,
+	siblingWorkerName: string,
+): string | null {
+	try {
+		const url = new URL(previewUrl)
+		const labels = url.hostname.split('.')
+		if (labels[0] !== workerName) return null
+		labels[0] = siblingWorkerName
+		url.hostname = labels.join('.')
+		url.pathname = '/'
+		url.search = ''
+		url.hash = ''
+		return url.origin
+	} catch {
+		return null
+	}
+}
+
+export function cookieHeaderFromSetCookie(
+	setCookieValues: ReadonlyArray<string>,
+): string {
+	return setCookieValues
+		.map((value) => value.split(';')[0]?.trim() ?? '')
+		.filter(Boolean)
+		.join('; ')
+}
+
+export function evaluateAppHealth(
+	body: unknown,
+	expectedSha: string | null,
+): { ok: boolean; commitSha: string | null; detail: string } {
+	if (!body || typeof body !== 'object') {
+		return {
+			ok: false,
+			commitSha: null,
+			detail: 'health response was not JSON',
+		}
+	}
+	const record = body as Record<string, unknown>
+	const commitSha =
+		typeof record.commitSha === 'string' && record.commitSha.length > 0
+			? record.commitSha
+			: null
+	if (record.ok !== true) {
+		return {
+			ok: false,
+			commitSha,
+			detail: `health ok is not true (${JSON.stringify(body)})`,
+		}
+	}
+	if (expectedSha && commitSha !== expectedSha) {
+		return {
+			ok: false,
+			commitSha,
+			detail: `health commitSha ${commitSha ?? '(missing)'} does not match expected ${expectedSha}`,
+		}
+	}
+	return {
+		ok: true,
+		commitSha,
+		detail: commitSha ? `ok, commitSha ${commitSha}` : 'ok',
+	}
+}
+
+export function evaluateRuntimeHealth(
+	body: unknown,
+	expectedSha: string | null,
+): { ok: boolean; commitSha: string | null; detail: string } {
+	if (!body || typeof body !== 'object') {
+		return {
+			ok: false,
+			commitSha: null,
+			detail: 'runtime health response was not JSON',
+		}
+	}
+	const record = body as Record<string, unknown>
+	const commitSha =
+		typeof record.commitSha === 'string' && record.commitSha.length > 0
+			? record.commitSha
+			: null
+	if (record.status !== 'ok') {
+		return {
+			ok: false,
+			commitSha,
+			detail: `runtime status is not ok (${JSON.stringify(body)})`,
+		}
+	}
+	if (record.cookieSecretConfigured !== true) {
+		return {
+			ok: false,
+			commitSha,
+			detail: 'runtime cookieSecretConfigured is not true',
+		}
+	}
+	if (expectedSha && commitSha !== expectedSha) {
+		return {
+			ok: false,
+			commitSha,
+			detail: `runtime commitSha ${commitSha ?? '(missing)'} does not match expected ${expectedSha}`,
+		}
+	}
+	return {
+		ok: true,
+		commitSha,
+		detail: commitSha ? `ok, commitSha ${commitSha}` : 'ok',
+	}
+}
+
+export function formatBriefing(result: PreviewManualTestResult): string {
+	const lines = [
+		result.ok
+			? 'Preview is ready for manual testing.'
+			: `Preview is not ready: ${result.message}`,
+		'',
+		result.snapshot.previewUrl
+			? `URL: ${result.snapshot.previewUrl}`
+			: 'URL: (not found)',
+		result.snapshot.prUrl ? `PR: ${result.snapshot.prUrl}` : null,
+		result.snapshot.workerName
+			? `Worker: \`${result.snapshot.workerName}\``
+			: null,
+		result.snapshot.runtimeUrl
+			? `Runtime: ${result.snapshot.runtimeUrl}${result.snapshot.runtimeWorkerName ? ` (\`${result.snapshot.runtimeWorkerName}\`)` : ''}`
+			: null,
+		result.smoke?.commitSha
+			? `Deployed commit: ${result.smoke.commitSha}`
+			: result.snapshot.expectedSha
+				? `Expected commit: ${result.snapshot.expectedSha}`
+				: null,
+		result.snapshot.headSha &&
+		result.smoke?.commitSha &&
+		result.snapshot.headSha !== result.smoke.commitSha
+			? `PR head SHA: ${result.snapshot.headSha} (preview deploys GitHub's merge commit, so /health commitSha can differ from the branch tip)`
+			: result.snapshot.headSha
+				? `PR head SHA: ${result.snapshot.headSha}`
+				: null,
+		result.snapshot.d1DatabaseName
+			? `D1: \`${result.snapshot.d1DatabaseName}\``
+			: null,
+		result.snapshot.oauthKvTitle
+			? `KV: \`${result.snapshot.oauthKvTitle}\``
+			: null,
+		'',
+		`Login (preview seed, non-admin): ${result.login.email} / ${result.login.password}`,
+		`Username: ${result.login.username}`,
+		'`/admin` is expected to 403 — preview does not seed an admin account.',
+	].filter((line): line is string => line !== null)
+
+	if (result.snapshot.mocks.length > 0) {
+		lines.push('', 'Mocks:')
+		for (const mock of result.snapshot.mocks) {
+			lines.push(`- ${mock}`)
+		}
+	}
+
+	if (result.smoke) {
+		lines.push('', 'Smoke:')
+		for (const check of result.smoke.checks) {
+			lines.push(`- ${check.ok ? 'ok' : 'FAIL'} ${check.name}: ${check.detail}`)
+		}
+	}
+
+	lines.push(
+		'',
+		'Manual UI next steps:',
+		'1. Open the preview URL in a browser (computerUse on Cloud Agents).',
+		'2. Sign in at `/login` with Email + Password, then the "Sign in" button.',
+		'3. Exercise the user-visible flows this PR changes. Stay on the preview origin.',
+		'4. `/mcp` needs OAuth; unauthenticated GET `/mcp` is 401 by design.',
+		'5. Record what you saw in the PR. This does not replace `npm run validate`.',
+		'',
+		'Docs: docs/contributing/preview-manual-testing.md',
+	)
+
+	if (result.snapshot.workflowUrl) {
+		lines.push(`Preview workflow: ${result.snapshot.workflowUrl}`)
+	}
+
+	return lines.join('\n')
+}
+
+export async function runPreviewManualTest(
+	argv: Array<string>,
+	deps: PreviewManualTestDeps = defaultDeps,
+): Promise<{ exitCode: number; result: PreviewManualTestResult | null }> {
+	let options: PreviewManualTestOptions
+	try {
+		options = parseArgs(argv)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		deps.error(message)
+		return { exitCode: 1, result: null }
+	}
+
+	if (options.help) {
+		deps.print(usageLines.join('\n'))
+		return { exitCode: 0, result: null }
+	}
+
+	try {
+		const snapshot = await resolveAndWait(options, deps)
+		const smoke =
+			snapshot.previewUrl === null
+				? null
+				: await runSmokeChecks(snapshot, options, deps)
+		const result = buildResult(options, snapshot, smoke)
+		if (options.json) {
+			deps.print(JSON.stringify(result, null, 2))
+		} else {
+			deps.print(result.briefing)
+		}
+		if (!result.ok) deps.error(result.message)
+		return { exitCode: result.ok ? 0 : 1, result }
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		deps.error(message)
+		return { exitCode: 1, result: null }
+	}
+}
+
+export class PreviewManualTestError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'PreviewManualTestError'
+	}
+}
+
+function requireValue(value: string | undefined, flag: string) {
+	if (!value || value.startsWith('-')) {
+		throw new PreviewManualTestError(`Missing value for ${flag}`)
+	}
+	return value
+}
+
+function parsePositiveInt(value: string | undefined, flag: string) {
+	const parsed = Number.parseInt(requireValue(value, flag), 10)
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new PreviewManualTestError(`${flag} must be a positive integer`)
+	}
+	return parsed
+}
+
+function matchFirst(body: string, pattern: RegExp) {
+	return body.match(pattern)?.[1] ?? null
+}
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+async function execGh(args: ReadonlyArray<string>): Promise<GhResult> {
+	try {
+		const result = await execFileAsync('gh', [...args], {
+			encoding: 'utf8',
+			maxBuffer: 10 * 1024 * 1024,
+		})
+		return { status: 0, stdout: result.stdout, stderr: result.stderr }
+	} catch (error) {
+		const failure = error as {
+			status?: number | null
+			stdout?: string
+			stderr?: string
+			message?: string
+		}
+		return {
+			status: failure.status ?? 1,
+			stdout: failure.stdout ?? '',
+			stderr: failure.stderr ?? failure.message ?? '',
+		}
+	}
+}
+
+async function ghJson<T>(
+	deps: PreviewManualTestDeps,
+	args: ReadonlyArray<string>,
+): Promise<T> {
+	const result = await deps.execGh(args)
+	if (result.status !== 0) {
+		throw new PreviewManualTestError(
+			`gh ${args.join(' ')} failed:\n${(result.stderr || result.stdout).trim()}`,
+		)
+	}
+	try {
+		return JSON.parse(result.stdout) as T
+	} catch {
+		throw new PreviewManualTestError(
+			`gh ${args.join(' ')} returned invalid JSON`,
+		)
+	}
+}
+
+type PrView = {
+	number: number
+	url: string
+	isDraft: boolean
+	headRefOid: string
+}
+
+type IssueComment = { body?: string }
+
+type WorkflowRun = {
+	databaseId: number
+	status: string
+	conclusion: string | null
+	headSha: string
+	event: string
+	url: string
+	displayTitle: string
+}
+
+type Deployment = {
+	id: number
+	sha: string
+	environment: string
+}
+
+async function resolveAndWait(
+	options: PreviewManualTestOptions,
+	deps: PreviewManualTestDeps,
+): Promise<PreviewSnapshot> {
+	const deadline = deps.now() + options.timeoutMs
+	let snapshot = await loadSnapshot(options, deps)
+
+	if (snapshot.isDraft && !options.previewUrl) {
+		throw new PreviewManualTestError(
+			`PR #${snapshot.prNumber} is a draft. Preview deploys skip drafts. Mark the PR ready for review, wait for the 🔎 Preview workflow, then re-run.`,
+		)
+	}
+
+	if (!options.wait) {
+		if (!snapshot.previewUrl) {
+			throw new PreviewManualTestError(notReadyMessage(snapshot))
+		}
+		return snapshot
+	}
+
+	while (true) {
+		if (
+			snapshot.workflowConclusion &&
+			isFailedConclusion(snapshot.workflowConclusion)
+		) {
+			throw new PreviewManualTestError(
+				`Preview workflow ${snapshot.workflowConclusion}${snapshot.workflowUrl ? `: ${snapshot.workflowUrl}` : ''}`,
+			)
+		}
+		if (snapshot.previewUrl && (await previewHealthReady(snapshot, deps))) {
+			return snapshot
+		}
+		if (deps.now() >= deadline) {
+			throw new PreviewManualTestError(
+				`Timed out after ${options.timeoutMs}ms. ${notReadyMessage(snapshot)}`,
+			)
+		}
+		deps.log(waitStatusMessage(snapshot))
+		await deps.sleep(options.pollIntervalMs)
+		snapshot = await loadSnapshot(options, deps)
+	}
+}
+
+async function loadSnapshot(
+	options: PreviewManualTestOptions,
+	deps: PreviewManualTestDeps,
+): Promise<PreviewSnapshot> {
+	if (options.previewUrl && options.prNumber === null) {
+		const workerName = workerNameFromPreviewUrl(options.previewUrl)
+		const runtimeWorkerName = workerName ? `${workerName}-runtime` : null
+		return {
+			prNumber: null,
+			prUrl: null,
+			isDraft: false,
+			headSha: null,
+			previewUrl: options.previewUrl,
+			workerName,
+			runtimeWorkerName,
+			runtimeUrl:
+				workerName && runtimeWorkerName
+					? deriveSiblingWorkerUrl(
+							options.previewUrl,
+							workerName,
+							runtimeWorkerName,
+						)
+					: null,
+			d1DatabaseName: null,
+			oauthKvTitle: null,
+			mocks: [],
+			expectedSha: options.expectedSha,
+			workflowUrl: null,
+			workflowStatus: null,
+			workflowConclusion: null,
+			deploymentSha: null,
+		}
+	}
+
+	const pr = await loadPullRequest(options, deps)
+	const comment = await loadPreviewComment(pr.number, deps)
+	const parsed = comment ? parsePreviewComment(comment) : null
+	const workflow = await loadPreviewWorkflow(pr, deps)
+	const deploymentSha = await loadDeploymentSha(pr.number, deps)
+	const previewUrl = options.previewUrl ?? parsed?.previewUrl ?? null
+	const workerName =
+		parsed?.workerName ??
+		(previewUrl ? workerNameFromPreviewUrl(previewUrl) : null)
+	const runtimeWorkerName =
+		parsed?.runtimeWorkerName ?? (workerName ? `${workerName}-runtime` : null)
+	const runtimeUrl =
+		parsed?.runtimeUrl ??
+		(previewUrl && workerName && runtimeWorkerName
+			? deriveSiblingWorkerUrl(previewUrl, workerName, runtimeWorkerName)
+			: null)
+
+	return {
+		prNumber: pr.number,
+		prUrl: pr.url,
+		isDraft: pr.isDraft,
+		headSha: pr.headRefOid,
+		previewUrl,
+		workerName,
+		runtimeWorkerName,
+		runtimeUrl,
+		d1DatabaseName: parsed?.d1DatabaseName ?? null,
+		oauthKvTitle: parsed?.oauthKvTitle ?? null,
+		mocks: parsed?.mocks ?? [],
+		expectedSha: options.expectedSha ?? deploymentSha,
+		workflowUrl: workflow?.url ?? null,
+		workflowStatus: workflow?.status ?? null,
+		workflowConclusion: workflow?.conclusion ?? null,
+		deploymentSha,
+	}
+}
+
+async function loadPullRequest(
+	options: PreviewManualTestOptions,
+	deps: PreviewManualTestDeps,
+): Promise<PrView> {
+	const args = ['pr', 'view', '--json', 'number,url,isDraft,headRefOid']
+	if (options.prNumber !== null) {
+		args.splice(2, 0, String(options.prNumber))
+	}
+	return ghJson<PrView>(deps, args)
+}
+
+async function loadPreviewComment(
+	prNumber: number,
+	deps: PreviewManualTestDeps,
+): Promise<string | null> {
+	const repo = await ghJson<{ nameWithOwner: string }>(deps, [
+		'repo',
+		'view',
+		'--json',
+		'nameWithOwner',
+	])
+	const comments = await ghJson<Array<IssueComment>>(deps, [
+		'api',
+		`repos/${repo.nameWithOwner}/issues/${prNumber}/comments?per_page=100`,
+	])
+	const match = comments.find((comment) =>
+		comment.body?.includes(previewCommentMarker),
+	)
+	return match?.body ?? null
+}
+
+async function loadPreviewWorkflow(
+	pr: PrView,
+	deps: PreviewManualTestDeps,
+): Promise<WorkflowRun | null> {
+	const runs = await ghJson<Array<WorkflowRun>>(deps, [
+		'run',
+		'list',
+		'--workflow',
+		'preview.yml',
+		'--json',
+		'databaseId,status,conclusion,headSha,event,url,displayTitle',
+		'--limit',
+		'30',
+	])
+	const matching = runs.filter(
+		(run) =>
+			run.headSha === pr.headRefOid ||
+			run.displayTitle.includes(`#${pr.number}`),
+	)
+	return matching[0] ?? null
+}
+
+async function loadDeploymentSha(
+	prNumber: number,
+	deps: PreviewManualTestDeps,
+): Promise<string | null> {
+	try {
+		const repo = await ghJson<{ nameWithOwner: string }>(deps, [
+			'repo',
+			'view',
+			'--json',
+			'nameWithOwner',
+		])
+		const deployments = await ghJson<Array<Deployment>>(deps, [
+			'api',
+			`repos/${repo.nameWithOwner}/deployments?environment=preview-${prNumber}&per_page=5`,
+		])
+		return deployments[0]?.sha ?? null
+	} catch {
+		return null
+	}
+}
+
+async function previewHealthReady(
+	snapshot: PreviewSnapshot,
+	deps: PreviewManualTestDeps,
+): Promise<boolean> {
+	if (!snapshot.previewUrl) return false
+	try {
+		const response = await fetchJson(
+			deps,
+			`${snapshot.previewUrl.replace(/\/$/, '')}/health`,
+		)
+		return evaluateAppHealth(response.body, snapshot.expectedSha).ok
+	} catch {
+		return false
+	}
+}
+
+async function runSmokeChecks(
+	snapshot: PreviewSnapshot,
+	options: PreviewManualTestOptions,
+	deps: PreviewManualTestDeps,
+): Promise<SmokeReport> {
+	if (!snapshot.previewUrl) {
+		return {
+			ok: false,
+			checks: [
+				{
+					name: 'preview-url',
+					ok: false,
+					detail: 'no preview URL',
+				},
+			],
+			sessionEmail: null,
+			commitSha: null,
+			runtimeCommitSha: null,
+		}
+	}
+
+	const origin = snapshot.previewUrl.replace(/\/$/, '')
+	const checks: Array<SmokeCheck> = []
+	let sessionEmail: string | null = null
+	let commitSha: string | null = null
+	let runtimeCommitSha: string | null = null
+	let cookieHeader = ''
+
+	const health = await fetchJson(deps, `${origin}/health`)
+	const healthEval = evaluateAppHealth(health.body, snapshot.expectedSha)
+	commitSha = healthEval.commitSha
+	checks.push({
+		name: 'GET /health',
+		ok: health.status === 200 && healthEval.ok,
+		detail:
+			health.status === 200
+				? healthEval.detail
+				: `HTTP ${health.status}: ${healthEval.detail}`,
+	})
+
+	const loginPage = await fetchText(deps, `${origin}/login`)
+	const loginPageOk =
+		loginPage.status === 200 &&
+		loginPage.body.includes('Welcome back') &&
+		/email/i.test(loginPage.body) &&
+		/password/i.test(loginPage.body)
+	checks.push({
+		name: 'GET /login',
+		ok: loginPageOk,
+		detail: loginPageOk
+			? 'login form rendered'
+			: `HTTP ${loginPage.status}; expected "Welcome back" plus email/password fields`,
+	})
+
+	const mcp = await fetchText(deps, `${origin}/mcp`, {
+		headers: { Accept: 'application/json, text/event-stream' },
+	})
+	checks.push({
+		name: 'GET /mcp',
+		ok: mcp.status === 401,
+		detail:
+			mcp.status === 401
+				? '401 without OAuth, as expected'
+				: `expected 401, got HTTP ${mcp.status}`,
+	})
+
+	if (snapshot.runtimeUrl) {
+		const runtimeHealth = await fetchJson(
+			deps,
+			`${snapshot.runtimeUrl.replace(/\/$/, '')}${runtimeWorkerHealthPath}`,
+		)
+		const runtimeEval = evaluateRuntimeHealth(
+			runtimeHealth.body,
+			snapshot.expectedSha,
+		)
+		runtimeCommitSha = runtimeEval.commitSha
+		checks.push({
+			name: `GET ${runtimeWorkerHealthPath}`,
+			ok: runtimeHealth.status === 200 && runtimeEval.ok,
+			detail:
+				runtimeHealth.status === 200
+					? runtimeEval.detail
+					: `HTTP ${runtimeHealth.status}: ${runtimeEval.detail}`,
+		})
+	}
+
+	if (!options.skipLogin) {
+		const auth = await fetchJson(deps, `${origin}/auth`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				email: previewSeedEmail,
+				password: previewSeedPassword,
+				mode: 'login',
+			}),
+		})
+		cookieHeader = cookieHeaderFromSetCookie(auth.setCookie)
+		const authOk =
+			auth.status === 200 &&
+			Boolean(cookieHeader) &&
+			(auth.body as { ok?: unknown } | null)?.ok !== false
+		checks.push({
+			name: 'POST /auth',
+			ok: authOk,
+			detail: authOk
+				? `signed in as ${previewSeedEmail}`
+				: `HTTP ${auth.status} ${JSON.stringify(auth.body)}; Set-Cookie ${auth.setCookie.length > 0 ? 'present' : 'missing'}`,
+		})
+
+		if (cookieHeader) {
+			const session = await fetchJson(deps, `${origin}/session`, {
+				headers: { Cookie: cookieHeader, Accept: 'application/json' },
+			})
+			const sessionRecord =
+				session.body && typeof session.body === 'object'
+					? (session.body as {
+							ok?: unknown
+							session?: { email?: unknown }
+						})
+					: null
+			sessionEmail =
+				typeof sessionRecord?.session?.email === 'string'
+					? sessionRecord.session.email
+					: null
+			const sessionOk =
+				session.status === 200 &&
+				sessionRecord?.ok === true &&
+				sessionEmail?.toLowerCase() === previewSeedEmail
+			checks.push({
+				name: 'GET /session',
+				ok: sessionOk,
+				detail: sessionOk
+					? `session email ${sessionEmail}`
+					: `HTTP ${session.status} ${JSON.stringify(session.body)}`,
+			})
+
+			const account = await fetchText(deps, `${origin}/account`, {
+				headers: { Cookie: cookieHeader },
+				redirect: 'manual',
+			})
+			const accountOk = account.status === 200
+			checks.push({
+				name: 'GET /account',
+				ok: accountOk,
+				detail: accountOk
+					? 'authenticated account page'
+					: `expected HTTP 200, got ${account.status}`,
+			})
+
+			for (const path of options.checkPaths) {
+				const normalized = path.startsWith('/') ? path : `/${path}`
+				const extra = await fetchText(deps, `${origin}${normalized}`, {
+					headers: { Cookie: cookieHeader },
+					redirect: 'manual',
+				})
+				checks.push({
+					name: `GET ${normalized}`,
+					ok: extra.status === 200,
+					detail: extra.status === 200 ? '200' : `HTTP ${extra.status}`,
+				})
+			}
+		}
+	}
+
+	return {
+		ok: checks.every((check) => check.ok),
+		checks,
+		sessionEmail,
+		commitSha,
+		runtimeCommitSha,
+	}
+}
+
+function buildResult(
+	options: PreviewManualTestOptions,
+	snapshot: PreviewSnapshot,
+	smoke: SmokeReport | null,
+): PreviewManualTestResult {
+	const login = {
+		email: previewSeedEmail,
+		password: previewSeedPassword,
+		username: previewSeedUsername(),
+		admin: false as const,
+	}
+	let message = 'ready'
+	let ok = true
+	if (!snapshot.previewUrl) {
+		ok = false
+		message = notReadyMessage(snapshot)
+	} else if (smoke && !smoke.ok) {
+		ok = false
+		message = 'preview smoke checks failed'
+	}
+	const result: PreviewManualTestResult = {
+		ok,
+		message,
+		options,
+		snapshot,
+		smoke,
+		login,
+		briefing: '',
+	}
+	result.briefing = formatBriefing(result)
+	return result
+}
+
+function notReadyMessage(snapshot: PreviewSnapshot) {
+	if (snapshot.isDraft) {
+		return 'PR is a draft, so no preview deploy ran.'
+	}
+	if (snapshot.workflowUrl && snapshot.workflowStatus) {
+		return `No healthy preview URL yet (workflow ${snapshot.workflowStatus}${snapshot.workflowConclusion ? `/${snapshot.workflowConclusion}` : ''}: ${snapshot.workflowUrl}).`
+	}
+	return [
+		'No preview URL found on the PR.',
+		'Previews skip drafts and fork PRs. Push to a ready-for-review PR on this repo, wait for 🔎 Preview, then re-run.',
+		snapshot.prUrl ? `PR: ${snapshot.prUrl}` : null,
+	]
+		.filter(Boolean)
+		.join(' ')
+}
+
+function waitStatusMessage(snapshot: PreviewSnapshot) {
+	if (snapshot.previewUrl) {
+		return `Waiting for /health to match${snapshot.expectedSha ? ` ${snapshot.expectedSha}` : ''} at ${snapshot.previewUrl}`
+	}
+	if (snapshot.workflowUrl) {
+		return `Waiting for preview workflow (${snapshot.workflowStatus ?? 'unknown'}): ${snapshot.workflowUrl}`
+	}
+	return 'Waiting for the 🔎 Preview workflow to comment the preview URL'
+}
+
+function isFailedConclusion(conclusion: string) {
+	// `cancelled` is not terminal: preview.yml uses cancel-in-progress, so a
+	// newer run for the same PR is expected to replace a cancelled one.
+	return (
+		conclusion === 'failure' ||
+		conclusion === 'timed_out' ||
+		conclusion === 'startup_failure'
+	)
+}
+
+type FetchedJson = {
+	status: number
+	body: unknown
+	setCookie: Array<string>
+}
+
+type FetchedText = {
+	status: number
+	body: string
+	setCookie: Array<string>
+}
+
+async function fetchJson(
+	deps: PreviewManualTestDeps,
+	url: string,
+	init: RequestInit = {},
+): Promise<FetchedJson> {
+	const response = await deps.fetch(url, {
+		...init,
+		signal: init.signal ?? AbortSignal.timeout(defaultRequestTimeoutMs),
+	})
+	const body = await response.json().catch(() => null)
+	return {
+		status: response.status,
+		body,
+		setCookie: readSetCookie(response),
+	}
+}
+
+async function fetchText(
+	deps: PreviewManualTestDeps,
+	url: string,
+	init: RequestInit = {},
+): Promise<FetchedText> {
+	const response = await deps.fetch(url, {
+		...init,
+		signal: init.signal ?? AbortSignal.timeout(defaultRequestTimeoutMs),
+	})
+	return {
+		status: response.status,
+		body: await response.text().catch(() => ''),
+		setCookie: readSetCookie(response),
+	}
+}
+
+function readSetCookie(response: Response) {
+	if (typeof response.headers.getSetCookie === 'function') {
+		return response.headers.getSetCookie()
+	}
+	const single = response.headers.get('set-cookie')
+	return single ? [single] : []
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	const { exitCode } = await runPreviewManualTest(process.argv.slice(2))
+	process.exit(exitCode)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Medium-to-high risk PRs already get isolated Cloudflare preview deploys. Agents can now **sign in as the seeded user, create the specific data the change needs, and assert it** — not just hit `/health`.

## What to run

```bash
npm run preview:manual-test -- \
  --request 'POST /account/values.json {"action":"save","name":"preview-locale","value":"en-US"}' \
  --request 'GET /account/values.json' \
  --check /account/values
```

The seed account (`me@kentcdodds.com` / `ilikecode`) starts empty except the user row. `--request` is authenticated HTTP as that user (`METHOD /path [status] [json-body]`). `--json` includes `session.cookieHeader`; `--cookie-file` writes it for follow-up `curl`. Then a UI pass (computerUse) against the same data.

Docs: [`docs/contributing/preview-manual-testing.md`](docs/contributing/preview-manual-testing.md). Skill: [`.agents/skills/preview-manual-test/SKILL.md`](.agents/skills/preview-manual-test/SKILL.md). Visual-recap and ship-pr require this on medium/high risk; a health/login smoke alone is not enough.

This does not replace `npm run validate`. Do not Playwright the preview or seed preview D1 from the agent VM.

## Review follow-up

Addressed Bugbot and CodeRabbit findings, then a live wait-loop bug found while dogfooding:

- Wait until the `preview.yml` run for this PR **head SHA** is `completed`/`success` before treating `/health` as the new deploy (`--url` without `--pr` still skips that gate).
- List those runs with `gh run list --commit <head>` so a busy repo’s last 30 preview runs cannot hide this PR.
- Match workflow titles on digit boundaries so `#42` does not match PR `#4`.
- Create parent dirs for `--cookie-file` and record write/fetch failures as checks so the briefing still prints.
- Treat `/health` `commitSha` as ready when it equals the PR head **or** is a merge commit that has the PR head as a parent (GitHub environment deployments record the branch tip; preview workers serve `github.sha`).

## Verification

- `npx vitest run --project node-unit tools/preview-manual-test.node.test.ts`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `77db258a` · **Head:** `b04b283f`

**Classification:** composes — no primitives added or changed; this PR is contributor tooling and docs only.

### Primitives touched

None. The classifier matched 0 paths against runtime ownership roots. The CLI lives under `tools/` plus contributing docs and agent skills.

### System map

Agents wait for a PR preview, sign in as the seeded user, create change-specific data through existing `/account/*.json` APIs, and optionally drive the UI. No runtime primitive is modified.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	previewScript["preview:manual-test<br/>CLI + docs"]:::touched
	previewWorkflow["🔎 Preview workflow<br/>existing GH Actions"]:::untouched
	previewWorkers["kody-pr-N workers<br/>existing preview deploy"]:::untouched
	previewScript -->|"reads PR comment + head workflow + merge-commit health"| previewWorkflow
	previewScript -->|"POST /auth + --request /account/*.json"| previewWorkers
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Agent
	participant Script as preview:manual-test
	participant GH as GitHub
	participant Preview as Preview workers
	Agent->>Script: npm run preview:manual-test -- --request ...
	Script->>GH: pr view + preview.yml --commit head + preview comment
	loop until workflow success and /health serves head or merge of head
		Script->>Preview: GET /health
		Preview-->>Script: ok + commitSha
		Script->>GH: commit parents when SHA is a merge commit
	end
	Script->>Preview: POST /auth as seed user
	Preview-->>Script: session cookie
	Script->>Preview: authenticated --request (create data, assert)
	Preview-->>Script: JSON / HTML results
	Script-->>Agent: briefing + session.cookieHeader
	Agent->>Preview: computerUse UI pass on the same data
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c51389ac-6255-4f8d-9654-43b75f235cac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c51389ac-6255-4f8d-9654-43b75f235cac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to run comprehensive manual tests against pull request previews.
  * Added checks for preview readiness, application and runtime health, authentication, authorization, and key smoke-test flows.
  * Added human-readable and JSON test results, with support for additional authenticated paths.

* **Documentation**
  * Added setup guidance, troubleshooting steps, workflow instructions, and contributor documentation for manual preview testing.

* **Tests**
  * Added extensive automated coverage for preview discovery, health checks, authentication, error handling, and test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->