### PR TITLE
fix(client): polyfill crypto.randomUUID for Twitter/X iOS WebViews

### DIFF
--- a/packages/worker/client/ensure-crypto-random-uuid.node.test.ts
+++ b/packages/worker/client/ensure-crypto-random-uuid.node.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest'
+import { ensureCryptoRandomUUID } from './ensure-crypto-random-uuid.ts'
+
+const uuidPattern =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+test('ensureCryptoRandomUUID polyfills missing randomUUID from getRandomValues and leaves an existing implementation alone', () => {
+	const bytes = new Uint8Array(16).fill(0xab)
+	const getRandomValues = (target: Uint8Array) => {
+		target.set(bytes.subarray(0, target.length))
+		return target
+	}
+	const cryptoWithoutUuid = {
+		getRandomValues,
+	} as Crypto
+
+	ensureCryptoRandomUUID(cryptoWithoutUuid)
+
+	expect(typeof cryptoWithoutUuid.randomUUID).toBe('function')
+	const first = cryptoWithoutUuid.randomUUID()
+	expect(first).toMatch(uuidPattern)
+	expect(first[14]).toBe('4')
+	expect(['8', '9', 'a', 'b']).toContain(first[19]!.toLowerCase())
+
+	const existing = () => 'already-present-uuid'
+	const cryptoWithUuid = {
+		getRandomValues,
+		randomUUID: existing,
+	} as Crypto
+
+	ensureCryptoRandomUUID(cryptoWithUuid)
+	expect(cryptoWithUuid.randomUUID).toBe(existing)
+	expect(cryptoWithUuid.randomUUID()).toBe('already-present-uuid')
+
+	const empty = {} as Crypto
+	ensureCryptoRandomUUID(empty)
+	expect(empty.randomUUID).toBeUndefined()
+
+	ensureCryptoRandomUUID(undefined)
+})

--- a/packages/worker/client/ensure-crypto-random-uuid.ts
+++ b/packages/worker/client/ensure-crypto-random-uuid.ts
@@ -1,0 +1,41 @@
+/**
+ * Remix's reconcile runtime calls `crypto.randomUUID()` for frame ids.
+ * Some in-app browsers (e.g. Twitter/X on iOS) expose `crypto` /
+ * `getRandomValues` but not `randomUUID`, which aborts client hydration.
+ * Install a RFC 4122 v4 polyfill before `run()` when needed.
+ */
+export function ensureCryptoRandomUUID(
+	cryptoApi: Crypto | undefined = globalThis.crypto,
+): void {
+	if (!cryptoApi) return
+	if (typeof cryptoApi.randomUUID === 'function') return
+	if (typeof cryptoApi.getRandomValues !== 'function') return
+
+	const polyfill = function randomUUID(this: Crypto): string {
+		const bytes = new Uint8Array(16)
+		this.getRandomValues(bytes)
+		// Version 4 + RFC 4122 variant bits.
+		bytes[6] = (bytes[6]! & 0x0f) | 0x40
+		bytes[8] = (bytes[8]! & 0x3f) | 0x80
+		const hex = Array.from(bytes, (byte) =>
+			byte.toString(16).padStart(2, '0'),
+		).join('')
+		return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+	}
+
+	try {
+		Object.defineProperty(cryptoApi, 'randomUUID', {
+			configurable: true,
+			enumerable: false,
+			writable: true,
+			value: polyfill,
+		})
+	} catch {
+		try {
+			;(cryptoApi as Crypto & { randomUUID: typeof polyfill }).randomUUID =
+				polyfill
+		} catch {
+			// Leave crypto unchanged; Remix will still throw if it calls randomUUID.
+		}
+	}
+}

--- a/packages/worker/client/ensure-crypto-random-uuid.ts
+++ b/packages/worker/client/ensure-crypto-random-uuid.ts
@@ -11,7 +11,9 @@ export function ensureCryptoRandomUUID(
 	if (typeof cryptoApi.randomUUID === 'function') return
 	if (typeof cryptoApi.getRandomValues !== 'function') return
 
-	const polyfill = function randomUUID(this: Crypto): string {
+const polyfill = function randomUUID(
+		this: Crypto,
+	): `${string}-${string}-${string}-${string}-${string}` {
 		const bytes = new Uint8Array(16)
 		this.getRandomValues(bytes)
 		// Version 4 + RFC 4122 variant bits.
@@ -20,7 +22,7 @@ export function ensureCryptoRandomUUID(
 		const hex = Array.from(bytes, (byte) =>
 			byte.toString(16).padStart(2, '0'),
 		).join('')
-		return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+		return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as `${string}-${string}-${string}-${string}-${string}`
 	}
 
 	try {
@@ -32,8 +34,7 @@ export function ensureCryptoRandomUUID(
 		})
 	} catch {
 		try {
-			;(cryptoApi as Crypto & { randomUUID: typeof polyfill }).randomUUID =
-				polyfill
+			cryptoApi.randomUUID = polyfill
 		} catch {
 			// Leave crypto unchanged; Remix will still throw if it calls randomUUID.
 		}

--- a/packages/worker/client/ensure-crypto-random-uuid.ts
+++ b/packages/worker/client/ensure-crypto-random-uuid.ts
@@ -11,7 +11,7 @@ export function ensureCryptoRandomUUID(
 	if (typeof cryptoApi.randomUUID === 'function') return
 	if (typeof cryptoApi.getRandomValues !== 'function') return
 
-const polyfill = function randomUUID(
+	const polyfill = function randomUUID(
 		this: Crypto,
 	): `${string}-${string}-${string}-${string}-${string}` {
 		const bytes = new Uint8Array(16)

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -7,7 +7,10 @@ import {
 	initSentryClient,
 } from '#client/sentry-client.ts'
 import { AppRoot, APP_ROOT_ENTRY_ID } from './app-root.tsx'
+import { ensureCryptoRandomUUID } from './ensure-crypto-random-uuid.ts'
 
+// Remix frame ids call crypto.randomUUID(); some in-app browsers omit it.
+ensureCryptoRandomUUID()
 initSentryClient(document)
 
 const clientRegistry: Record<string, typeof AppRoot> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-CLOUDFLARE-4P](https://kent-c-dodds-tech-llc.sentry.io/issues/7669749308/): Remix `@remix-run/ui` `randomFrameId` calls `crypto.randomUUID()`, which is missing in some in-app browsers (reproduced in Sentry as Twitter 12.15 on iPhone). That aborts client hydration on routes like `/community`.

Install a `getRandomValues`-based RFC 4122 v4 polyfill at the top of `client/entry.tsx` before `run()` / Sentry init. Leaves an existing `randomUUID` alone.

## Test plan

- [x] Unit test covers polyfill install, v4 shape, no-op when present, and no-op without `getRandomValues`
- [x] `npm run typecheck` / `format:check`
- [ ] CI `validate` after format fix (prior Static fail was indentation; MCP fail was flaky signup email send)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `4d104cb1` · **Head:** `568d47d5`

**Classification:** composes — adds a client boot shim so Remix's existing `crypto.randomUUID()` usage works in incomplete WebCrypto environments; no primitive contracts change.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### System map

_Client entry polyfills missing `crypto.randomUUID` before Remix hydration so frame reconcile can run in restricted in-app browsers._

```mermaid
flowchart LR
  entry["client/entry.tsx"] --> polyfill["ensureCryptoRandomUUID"]
  polyfill --> crypto["globalThis.crypto"]
  entry --> remix["remix/ui run()"]
  remix --> frameId["randomFrameId → crypto.randomUUID()"]
  style entry fill:#bbf4bb,stroke:#1a7f37,color:#000
  style polyfill fill:#bbf4bb,stroke:#1a7f37,color:#000
  style crypto fill:#e0e0e0,stroke:#666,color:#000
  style remix fill:#e0e0e0,stroke:#666,color:#000
  style frameId fill:#e0e0e0,stroke:#666,color:#000
```

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context

### Risk

Overall **low**. No auth, isolation, billing, migrations, or DR surface. Isolated client compatibility shim with unit coverage.

### Docs

No doc updates required for this compatibility shim.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10d87c93-e3ed-4ff7-869c-99c1ccf1d60d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10d87c93-e3ed-4ff7-869c-99c1ccf1d60d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility in environments where `crypto.randomUUID()` is unavailable.
  - Added secure UUID generation using available cryptographic randomness.
  - Preserved existing implementations and safely handles environments without sufficient crypto support.
  - Ensured UUID generation is available before the application starts.
- **Tests**
  - Added coverage for fallback generation, existing implementations, unsupported crypto APIs, and undefined crypto environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->