### PR TITLE
fix(community): missing unpublish listing is a caller error (KODY-CLOUDFLARE-4N)

### DIFF
--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -451,11 +451,41 @@ test('unpublishCommunityListing refuses delisted listings without deleting anyth
 			userId: 'owner-1',
 			listingId: 'listing-1',
 		}),
-	).rejects.toThrow()
+	).rejects.toBeInstanceOf(CommunityActionError)
 
 	expect(mockModule.deleteCommunityListing).not.toHaveBeenCalled()
 	expect(mockModule.deleteCommunityRatingsByListingId).not.toHaveBeenCalled()
 	expect(mockModule.deleteCommunitySnapshot).not.toHaveBeenCalled()
+})
+
+test('unpublishCommunityListing treats missing or unowned listings as CommunityActionError', async () => {
+	mockModule.getCommunityListingById.mockResolvedValue(null)
+
+	await expect(
+		unpublishCommunityListing({
+			env: createEnv(),
+			userId: 'owner-1',
+			listingId: 'missing-listing',
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityActionError &&
+			error.message === 'Community listing "missing-listing" was not found.',
+	)
+
+	mockModule.getCommunityListingById.mockResolvedValue(
+		sampleListing({ ownerUserId: 'other-owner' }),
+	)
+
+	await expect(
+		unpublishCommunityListing({
+			env: createEnv(),
+			userId: 'owner-1',
+			listingId: 'listing-1',
+		}),
+	).rejects.toBeInstanceOf(CommunityActionError)
+
+	expect(mockModule.deleteCommunityListing).not.toHaveBeenCalled()
 })
 
 test('unpublishCommunityListing deletes active listings and cascades cleanup', async () => {

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -670,7 +670,12 @@ export async function unpublishCommunityListing(input: {
 		includeDelisted: true,
 	})
 	if (!listing || listing.ownerUserId !== input.userId) {
-		throw new Error(`Community listing "${input.listingId}" was not found.`)
+		// Missing / not-owned ids are caller-clearable (stale listing_id, typo,
+		// or another owner's listing). CommunityActionError keeps them on
+		// mcp-event lines and out of Sentry (KODY-CLOUDFLARE-4N).
+		throw new CommunityActionError(
+			`Community listing "${input.listingId}" was not found.`,
+		)
 	}
 	if (listing.status === 'delisted') {
 		throw new CommunityActionError(
@@ -683,7 +688,9 @@ export async function unpublishCommunityListing(input: {
 		ownerUserId: input.userId,
 	})
 	if (!deleted) {
-		throw new Error(`Community listing "${input.listingId}" was not found.`)
+		throw new CommunityActionError(
+			`Community listing "${input.listingId}" was not found.`,
+		)
 	}
 
 	await deleteCommunityIconAssetsBestEffort({
@@ -1047,7 +1054,9 @@ export async function prepareCommunityFork(
 		readCommunitySnapshot(input.env.BUNDLE_ARTIFACTS_KV, input.listingId),
 	])
 	if (!listing) {
-		throw new Error(`Community listing "${input.listingId}" was not found.`)
+		throw new CommunityActionError(
+			`Community listing "${input.listingId}" was not found.`,
+		)
 	}
 	if (!snapshot) {
 		throw new Error(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry

- Issue: [KODY-CLOUDFLARE-4N](https://kent-c-dodds-tech-llc.sentry.io/issues/7668787101/)
- Signature: `Error: Community listing "<id>" was not found.`
- Culprit: `unpublishCommunityListing` via `community_unpublish`
- Tags: `mcp.capability=community_unpublish`, `mcp.failure_phase=handler`

## Root cause

`unpublishCommunityListing` threw a plain `Error` when the listing id was missing or owned by someone else. MCP observability only suppresses `CommunityActionError` / `McpCallerError` for caller-clearable failures, so a stale or mistyped `listing_id` opened a Sentry issue that looked like a platform bug.

Delisted listings already used `CommunityActionError`; missing/unowned did not — an inconsistency with star/rate/trust paths in the same module.

## Fix

Throw `CommunityActionError` for missing/unowned (and post-delete race) cases in `unpublishCommunityListing`, and for missing listings in `prepareCommunityFork` (same message class). Callers still get the same actionable message; Sentry no longer receives these events.

## Verification

- Unit: `unpublishCommunityListing treats missing or unowned listings as CommunityActionError`
- Existing observability coverage already asserts `CommunityActionError` is not reported to Sentry

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d2a56885` · **Head:** `948a6ba3`

**Classification:** composes — isolated bug fix; aligns missing-listing throws with the existing `CommunityActionError` caller-failure path already filtered by MCP observability.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | composes — same public message; error class matches sibling community actions |

### System map

Missing or unowned `listing_id` on unpublish becomes a caller-clearable `CommunityActionError`, so MCP logs the failure without opening a Sentry issue.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpCap["mcp-server<br/>community_unpublish"]:::untouched
	listings["community-listings<br/>unpublishCommunityListing"]:::touched
	obs["mcp observability<br/>isCallerFailure"]:::untouched
	sentry["Sentry"]:::untouched
	mcpCap -->|"listing_id missing / unowned"| listings
	listings -->|"CommunityActionError"| obs
	obs -->|"suppress"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Case | Before | After |
| --- | --- | --- |
| Missing / unowned listing on `community_unpublish` | plain `Error` → Sentry issue | `CommunityActionError` → mcp-event only |
| Delisted listing | already `CommunityActionError` | unchanged |

### Invariants

No change to ownership checks or per-user isolation; not-found still hides other owners' listings.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c70cbbcf-6432-43d6-99b7-9de870cd996c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c70cbbcf-6432-43d6-99b7-9de870cd996c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized errors shown when attempting to unpublish missing, delisted, or unowned community listings.
  * Prevented deletion attempts when a listing cannot be found or is not owned.
  * Improved consistency when preparing community forks for unavailable listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->