### PR TITLE
fix(packages): populate package_get export contracts from source files (#1401)

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageWithCommunityProvenanceById: vi.fn(),
-	loadPackageManifestBySourceId: vi.fn(),
+	loadPackageSourceBySourceId: vi.fn(),
 	resolvePackageOwnerContext: vi.fn(),
 }))
 
@@ -12,8 +12,8 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 }))
 
 vi.mock('#worker/package-registry/source.ts', () => ({
-	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
-		mockModule.loadPackageManifestBySourceId(...args),
+	loadPackageSourceBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageSourceBySourceId(...args),
 }))
 
 vi.mock('#worker/package-registry/package-owner.ts', () => ({
@@ -68,28 +68,39 @@ function createCallerContext(input?: {
 	}
 }
 
-test('getPackageCapability returns export metadata for owner and delegated package scopes', async () => {
-	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
-	mockModule.loadPackageManifestBySourceId.mockReset()
+function stubSavedPackage(input?: {
+	userId?: string
+	name?: string
+	hasApp?: boolean
+	sourceListingId?: string | null
+	listingCurrent?: boolean | null
+	listingKodyId?: string | null
+}) {
 	mockModule.getSavedPackageWithCommunityProvenanceById.mockResolvedValue({
 		id: 'package-1',
-		userId: 'user-1',
-		name: '@kentcdodds/discord-gateway',
+		userId: input?.userId ?? 'user-1',
+		name: input?.name ?? '@kentcdodds/discord-gateway',
 		kodyId: 'discord-gateway',
 		description: 'Discord helpers',
 		tags: ['discord'],
 		searchText: null,
 		sourceId: 'source-1',
-		hasApp: true,
+		hasApp: input?.hasApp ?? true,
 		hidden: false,
 		isPrivate: false,
-		sourceListingId: 'listing-1',
-		listingCurrent: true,
-		listingKodyId: 'upstream-discord-gateway',
+		sourceListingId: input?.sourceListingId ?? 'listing-1',
+		listingCurrent: input?.listingCurrent ?? true,
+		listingKodyId: input?.listingKodyId ?? 'upstream-discord-gateway',
 		createdAt: '2026-04-25T00:00:00.000Z',
 		updatedAt: '2026-04-26T00:00:00.000Z',
 	})
-	mockModule.loadPackageManifestBySourceId.mockResolvedValue({
+}
+
+test('getPackageCapability returns export metadata for owner and delegated package scopes', async () => {
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockReset()
+	stubSavedPackage()
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
 		source: { id: 'source-1' },
 		manifest: {
 			name: '@kentcdodds/discord-gateway',
@@ -109,6 +120,7 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 				},
 			},
 		},
+		files: {},
 	})
 
 	const withUsername = await getPackageCapability.handler(
@@ -173,7 +185,7 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 		expect.anything(),
 		expect.objectContaining({ userId: 'user-1', packageId: 'package-1' }),
 	)
-	expect(mockModule.loadPackageManifestBySourceId).toHaveBeenCalledWith({
+	expect(mockModule.loadPackageSourceBySourceId).toHaveBeenCalledWith({
 		env: expect.objectContaining({ APP_DB: expect.anything() }),
 		baseUrl: 'https://heykody.dev',
 		userId: 'user-1',
@@ -182,27 +194,17 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 
 	// Delegated package_scope loads and builds invocation URLs for the owner.
 	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
-	mockModule.loadPackageManifestBySourceId.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockReset()
 	mockModule.resolvePackageOwnerContext.mockClear()
-	mockModule.getSavedPackageWithCommunityProvenanceById.mockResolvedValue({
-		id: 'package-1',
+	stubSavedPackage({
 		userId: 'platform-owner',
 		name: '@kody/discord-gateway',
-		kodyId: 'discord-gateway',
-		description: 'Discord helpers',
-		tags: ['discord'],
-		searchText: null,
-		sourceId: 'source-1',
 		hasApp: false,
-		hidden: false,
-		isPrivate: false,
 		sourceListingId: null,
 		listingCurrent: null,
 		listingKodyId: null,
-		createdAt: '2026-04-25T00:00:00.000Z',
-		updatedAt: '2026-04-26T00:00:00.000Z',
 	})
-	mockModule.loadPackageManifestBySourceId.mockResolvedValue({
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
 		source: { id: 'source-1' },
 		manifest: {
 			name: '@kody/discord-gateway',
@@ -214,6 +216,7 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 				description: 'Discord helpers',
 			},
 		},
+		files: {},
 	})
 
 	const delegated = await getPackageCapability.handler(
@@ -240,11 +243,194 @@ test('getPackageCapability returns export metadata for owner and delegated packa
 			packageId: 'package-1',
 		}),
 	)
-	expect(mockModule.loadPackageManifestBySourceId).toHaveBeenCalledWith(
+	expect(mockModule.loadPackageSourceBySourceId).toHaveBeenCalledWith(
 		expect.objectContaining({ userId: 'platform-owner' }),
 	)
 	expect(delegated.exports[0]?.external_invocation).toMatchObject({
 		owner_username: 'kody',
 		url: 'https://heykody.dev/@kody/api/package-invocations/discord-gateway/post-message',
 	})
+})
+
+test('getPackageCapability projects type_definition and description when source files are loaded', async () => {
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockReset()
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockResolvedValue({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/calendar',
+		kodyId: 'calendar',
+		description: 'Calendar helpers',
+		tags: ['calendar'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		sourceListingId: null,
+		listingCurrent: null,
+		listingKodyId: null,
+		createdAt: '2026-04-25T00:00:00.000Z',
+		updatedAt: '2026-04-26T00:00:00.000Z',
+	})
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/calendar',
+			exports: {
+				'./list-events': {
+					import: './src/list-events.ts',
+					types: './src/list-events.d.ts',
+				},
+			},
+			kody: {
+				id: 'calendar',
+				description: 'Calendar helpers',
+				tags: ['calendar'],
+			},
+		},
+		files: {
+			'src/list-events.ts':
+				'export const ignored = "types file should be preferred"',
+			'src/list-events.d.ts': `/**
+ * List upcoming calendar events.
+ */
+export declare function listEvents(calendarId: string): Promise<string[]>
+`,
+		},
+	})
+
+	const result = await getPackageCapability.handler(
+		{ package_id: 'package-1' },
+		createCallerContext(),
+	)
+
+	expect(result.exports).toEqual([
+		expect.objectContaining({
+			subpath: './list-events',
+			import_specifier: 'kody:@kentcdodds/calendar/list-events',
+			runtime_target: 'src/list-events.ts',
+			types_path: 'src/list-events.d.ts',
+			description: 'List upcoming calendar events.',
+			type_definition:
+				'export declare function listEvents(calendarId: string): Promise<string[]>',
+		}),
+	])
+	expect(mockModule.loadPackageSourceBySourceId).toHaveBeenCalledWith(
+		expect.objectContaining({
+			sourceId: 'source-1',
+			userId: 'user-1',
+		}),
+	)
+})
+
+test('getPackageCapability leaves export contracts empty when source files are missing', async () => {
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockReset()
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockResolvedValue({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/calendar',
+		kodyId: 'calendar',
+		description: 'Calendar helpers',
+		tags: ['calendar'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		sourceListingId: null,
+		listingCurrent: null,
+		listingKodyId: null,
+		createdAt: '2026-04-25T00:00:00.000Z',
+		updatedAt: '2026-04-26T00:00:00.000Z',
+	})
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/calendar',
+			exports: {
+				'./list-events': {
+					import: './src/list-events.ts',
+					types: './src/list-events.d.ts',
+				},
+			},
+			kody: {
+				id: 'calendar',
+				description: 'Calendar helpers',
+			},
+		},
+		// Same path search hydration avoids: projection without file text
+		// cannot derive callable contracts even when the manifest lists types.
+		files: undefined,
+	})
+
+	const result = await getPackageCapability.handler(
+		{ package_id: 'package-1' },
+		createCallerContext(),
+	)
+
+	expect(result.exports).toEqual([
+		expect.objectContaining({
+			subpath: './list-events',
+			runtime_target: 'src/list-events.ts',
+			types_path: 'src/list-events.d.ts',
+			description: null,
+			type_definition: null,
+		}),
+	])
+})
+
+test('getPackageCapability leaves export contracts empty for untyped sources', async () => {
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockReset()
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockResolvedValue({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/untyped-helpers',
+		kodyId: 'untyped-helpers',
+		description: 'Untyped helpers',
+		tags: [],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		sourceListingId: null,
+		listingCurrent: null,
+		listingKodyId: null,
+		createdAt: '2026-04-25T00:00:00.000Z',
+		updatedAt: '2026-04-26T00:00:00.000Z',
+	})
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/untyped-helpers',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'untyped-helpers',
+				description: 'Untyped helpers',
+			},
+		},
+		files: {
+			// Non-function exports are intentionally ignored by the projector.
+			'src/index.ts': "export const VERSION = '1.0.0'\n",
+		},
+	})
+
+	const result = await getPackageCapability.handler(
+		{ package_id: 'package-1' },
+		createCallerContext(),
+	)
+
+	expect(result.exports).toEqual([
+		expect.objectContaining({
+			subpath: '.',
+			runtime_target: 'src/index.ts',
+			description: null,
+			type_definition: null,
+		}),
+	])
 })

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -16,7 +16,7 @@ import {
 	buildPlainRepoPromotionErrorMessage,
 	findPlainRepoPromotionHint,
 } from '#worker/repo/user-repos.ts'
-import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 import { packageDetailSchema } from './shared.ts'
 
 export const getPackageCapability = defineDomainCapability(
@@ -78,13 +78,16 @@ export const getPackageCapability = defineDomainCapability(
 				username: owner.ownerScope,
 				email: owner.ownerEmail,
 			})
-			const loaded = await loadPackageManifestBySourceId({
+			const loaded = await loadPackageSourceBySourceId({
 				env: ctx.env,
 				baseUrl: ctx.callerContext.baseUrl,
 				userId: owner.ownerUserId,
 				sourceId: saved.sourceId,
 			})
-			const projection = buildPackageSearchProjection(loaded.manifest)
+			const projection = buildPackageSearchProjection(
+				loaded.manifest,
+				loaded.files,
+			)
 			return {
 				package_id: saved.id,
 				kody_id: saved.kodyId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1401. `package_get` was building its export projection from the package manifest alone, so every export returned `type_definition: null` and `description: null` even when search already hydrated callable contracts for the same packages.

This wires `package_get` to the same commit-keyed source load search uses (`loadPackageSourceBySourceId`) and passes `loaded.files` into `buildPackageSearchProjection`. No projection API redesign, no new export fields, and the multi-function `type_definition` nulling rule is unchanged.

## Changes

- `get-package.ts`: load full source (manifest + files) instead of manifest-only
- Tests cover typed files wired through, missing files, and genuinely untyped sources

## Test plan

- [x] `npm run test:node -- packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts`
- [ ] Confirm CI green
- [ ] Optional smoke: `package_get` on a typed package (e.g. `@kentcdodds/google`) returns non-null `type_definition` / `description` for single-function exports that search already shows

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `73ff76fd` · **Head:** `35b2b1ff`

**Classification:** composes — no primitives added or changed; this PR wires `package_get` to the existing source-load + export-projection path search already uses.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `saved-packages` | assistant | composes — `package_get` loads source files for export contracts |

### System map

`package_get` now reuses the commit-cached package source load so export contracts match search hydration.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	sourceLoad["loadPackageSourceBySourceId<br/>commit-keyed source cache"]:::untouched
	projection["buildPackageSearchProjection<br/>export contracts"]:::untouched
	savedPackages -->|"package_get loads source + files"| sourceLoad
	sourceLoad -->|"manifest + files"| projection
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** `loadPackageManifestBySourceId` → `buildPackageSearchProjection(manifest)` → export `type_definition` / `description` always null.

**After:** `loadPackageSourceBySourceId` → `buildPackageSearchProjection(manifest, files)` → contracts match search when source carries typed signatures / JSDoc.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a81f73fe-de6a-46d0-83f0-0db23769c248?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a81f73fe-de6a-46d0-83f0-0db23769c248&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package searches now include richer information derived from package source files.
  * Package descriptions and type definitions are displayed when available.
  * Packages without applicable source files gracefully show no export contract.

* **Bug Fixes**
  * Improved package ownership and delegated-access handling during package retrieval.
  * Preserved package listing and app metadata in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->