### PR TITLE
fix(ui): show connected and already-forked state (#1402, #1173)

### DIFF
--- a/packages/worker/client/routes/community-detail.tsx
+++ b/packages/worker/client/routes/community-detail.tsx
@@ -81,6 +81,7 @@ type CommunityInstallApiPayload = {
 	ok: boolean
 	requiresAcknowledgement?: boolean
 	status?: 'installed' | 'adaptation_required'
+	packageId?: string
 	targetName?: string
 	agentPrompt?: string
 	failedChecks?: Array<{ kind: string; message: string }>
@@ -91,6 +92,7 @@ type CommunityInstallOutcome = {
 	status: 'installed' | 'adaptation_required'
 	targetName: string
 	agentPrompt: string
+	packageId: string | null
 	failedChecks: Array<{ kind: string; message: string }>
 }
 
@@ -631,6 +633,8 @@ export function CommunityDetailRoute(handle: Handle) {
 				status: payload.status,
 				targetName: payload.targetName,
 				agentPrompt: payload.agentPrompt,
+				packageId:
+					payload.status === 'installed' ? (payload.packageId ?? null) : null,
 				failedChecks: payload.failedChecks ?? [],
 			}
 			installState = 'idle'
@@ -774,6 +778,7 @@ export function CommunityDetailRoute(handle: Handle) {
 						status: existingInstall.status,
 						targetName: existingInstall.targetName,
 						agentPrompt: existingInstall.agentPrompt,
+						packageId: existingInstall.packageId,
 						failedChecks: [] as Array<{ kind: string; message: string }>,
 						existing: true,
 					}
@@ -829,10 +834,19 @@ export function CommunityDetailRoute(handle: Handle) {
 										</p>
 										<p>
 											<a
-												href={routes.accountPackages.href()}
+												href={
+													shownInstall.packageId
+														? routes.accountPackageDetail.href({
+																packageId: shownInstall.packageId,
+															})
+														: routes.accountPackages.href()
+												}
 												mix={css(inlineLinkCss)}
+												data-testid="community-install-open-package"
 											>
-												View it in your packages
+												{shownInstall.packageId
+													? 'Open in your packages'
+													: 'View it in your packages'}
 											</a>
 										</p>
 										<p>

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -19,6 +19,7 @@ import {
 	type OnboardingChecklistLoaderData,
 } from '#universal/loader-data.ts'
 import { type OnboardingFeaturedListing } from '#universal/community-public-types.ts'
+import { routes } from '#universal/routes.ts'
 import {
 	selectOnboardingExampleListings,
 	selectOnboardingServiceStarterListings,
@@ -705,38 +706,56 @@ export function OnboardingRoute(handle: Handle) {
 											mix={css(starterGridCss)}
 											data-testid="onboarding-built-in-integrations"
 										>
-											{builtInProviders.map((provider) => (
-												<li key={provider.slug} mix={css(providerCardCss)}>
-													<a
-														href={`/connect/oauth?provider=${encodeURIComponent(provider.slug)}`}
-														mix={css(providerCardLinkCss)}
+											{builtInProviders.map((provider) => {
+												const href =
+													provider.connected && provider.connectionName
+														? routes.accountIntegrationDetail.href({
+																integrationName: provider.connectionName,
+															})
+														: `/connect/oauth?provider=${encodeURIComponent(provider.slug)}`
+												return (
+													<li
+														key={provider.slug}
+														mix={css(providerCardCss)}
+														data-connected={
+															provider.connected ? 'true' : undefined
+														}
+														data-testid={`onboarding-provider-${provider.slug}`}
 													>
-														<span mix={css(providerIconWellCss)}>
-															{provider.logoPath ? (
-																<img
-																	src={provider.logoPath}
-																	alt=""
-																	width={30}
-																	height={30}
-																	loading="lazy"
-																	mix={css(providerLogoCss)}
-																/>
-															) : (
-																<ProviderIcon
-																	providerId={provider.slug}
-																	size="30"
-																/>
-															)}
-														</span>
-														<strong mix={css(providerCardNameCss)}>
-															{provider.label}
-														</strong>
-														<span mix={css(providerConnectPillCss)}>
-															Connect
-														</span>
-													</a>
-												</li>
-											))}
+														<a href={href} mix={css(providerCardLinkCss)}>
+															<span mix={css(providerIconWellCss)}>
+																{provider.logoPath ? (
+																	<img
+																		src={provider.logoPath}
+																		alt=""
+																		width={30}
+																		height={30}
+																		loading="lazy"
+																		mix={css(providerLogoCss)}
+																	/>
+																) : (
+																	<ProviderIcon
+																		providerId={provider.slug}
+																		size="30"
+																	/>
+																)}
+															</span>
+															<strong mix={css(providerCardNameCss)}>
+																{provider.label}
+															</strong>
+															<span
+																mix={css(
+																	provider.connected
+																		? providerConnectedPillCss
+																		: providerConnectPillCss,
+																)}
+															>
+																{provider.connected ? 'Connected' : 'Connect'}
+															</span>
+														</a>
+													</li>
+												)
+											})}
 										</ul>
 										<p mix={css(builtInByoCss)}>
 											Want scopes or rate limits Kody's app does not offer?{' '}
@@ -1352,6 +1371,19 @@ const providerConnectPillCss = {
 	width: '100%',
 	fontSize: '0.95rem',
 	textAlign: 'center' as const,
+}
+
+/** Already-connected providers: solid status pill, not another Connect CTA. */
+const providerConnectedPillCss = {
+	...getGhostButtonCss(),
+	marginTop: 'auto',
+	width: '100%',
+	fontSize: '0.95rem',
+	textAlign: 'center' as const,
+	color: colors.primaryText,
+	borderColor: `oklch(from ${colors.primary} l c h / 0.45)`,
+	backgroundColor: `oklch(from ${colors.primary} l c h / 0.08)`,
+	cursor: 'pointer',
 }
 
 const builtInByoCss = {

--- a/packages/worker/src/app/community-data.node.test.ts
+++ b/packages/worker/src/app/community-data.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { resetDataCacheForTests } from './data-cache.ts'
 import {
+	loadCommunityDetailData,
 	loadCommunityIndexData,
 	loadOnboardingFeaturedListings,
 } from './community-data.ts'
@@ -15,10 +16,14 @@ const mockModule = vi.hoisted(() => ({
 	listCommunityListingsWithAggregates: vi.fn(),
 	searchCommunityListings: vi.fn(),
 	listFeaturedCommunityListingsWithAggregates: vi.fn(),
+	getCommunityListingWithAggregates: vi.fn(),
 	listCommunityForksByListingIdsAndUser: vi.fn(),
 	listSavedPackagesByKodyIds: vi.fn(),
 	listSavedPackagesByIds: vi.fn(),
 	getMcpUserPackageScope: vi.fn(),
+	getCommunityStar: vi.fn(),
+	getUserFollow: vi.fn(),
+	getUserSocialRowByUsername: vi.fn(),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -33,12 +38,22 @@ vi.mock('#worker/community/service.ts', () => ({
 		mockModule.searchCommunityListings(...args),
 	listFeaturedCommunityListingsWithAggregates: (...args: Array<unknown>) =>
 		mockModule.listFeaturedCommunityListingsWithAggregates(...args),
-	getCommunityListingWithAggregates: vi.fn(),
+	getCommunityListingWithAggregates: (...args: Array<unknown>) =>
+		mockModule.getCommunityListingWithAggregates(...args),
 }))
 
 vi.mock('#worker/community/repo.ts', () => ({
 	listCommunityForksByListingIdsAndUser: (...args: Array<unknown>) =>
 		mockModule.listCommunityForksByListingIdsAndUser(...args),
+}))
+
+vi.mock('#worker/community/social-repo.ts', () => ({
+	getCommunityStar: (...args: Array<unknown>) =>
+		mockModule.getCommunityStar(...args),
+	getUserFollow: (...args: Array<unknown>) =>
+		mockModule.getUserFollow(...args),
+	getUserSocialRowByUsername: (...args: Array<unknown>) =>
+		mockModule.getUserSocialRowByUsername(...args),
 }))
 
 vi.mock('#worker/package-registry/repo.ts', () => ({
@@ -118,6 +133,7 @@ test('community index overlays matching kody_id installs for signed-in viewers',
 		status: 'installed',
 		targetName: '@burhan/github',
 		agentPrompt: buildExistingInstallPrompt({ targetName: '@burhan/github' }),
+		packageId: 'pkg-github',
 	})
 	expect(mockModule.listSavedPackagesByKodyIds).toHaveBeenCalledWith(
 		undefined,
@@ -160,7 +176,63 @@ test('onboarding featured listings overlay inert forks as adaptation_required', 
 			targetName: '@burhan/github',
 			sourceId: 'src-inert',
 		}),
+		packageId: null,
 	})
+})
+
+test('community detail overlays viewerInstall for forked listings and omits it when not forked', async () => {
+	resetDataCacheForTests()
+	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
+	mockModule.getUserSocialRowByUsername.mockResolvedValue({
+		profile_visibility: 'public',
+		stable_user_id: 'owner-mcp-id',
+	})
+	mockModule.getCommunityStar.mockResolvedValue(false)
+	mockModule.getUserFollow.mockResolvedValue(false)
+	mockModule.getMcpUserPackageScope.mockResolvedValue('burhan')
+	mockModule.listSavedPackagesByIds.mockResolvedValue([])
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(signedInUser())
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([])
+	const notForked = await loadCommunityDetailData(
+		{} as Env,
+		new Request('https://example.com/community/listing-github'),
+		'listing-github',
+	)
+	expect(notForked?.viewerInstall).toBeNull()
+
+	resetDataCacheForTests()
+	mockModule.getCommunityListingWithAggregates.mockResolvedValue(sampleListing)
+	mockModule.listCommunityForksByListingIdsAndUser.mockResolvedValue([
+		{
+			listingId: 'listing-github',
+			targetKodyId: 'github',
+			forkedPackageId: 'pkg-github',
+			forkedSourceId: 'src-github',
+			createdAt: '2026-08-01T00:00:00.000Z',
+		},
+	])
+	mockModule.listSavedPackagesByKodyIds.mockResolvedValue([
+		{
+			id: 'pkg-github',
+			kodyId: 'github',
+			name: '@burhan/github',
+			sourceId: 'src-github',
+		},
+	])
+	const forked = await loadCommunityDetailData(
+		{} as Env,
+		new Request('https://example.com/community/listing-github-forked'),
+		'listing-github',
+	)
+	expect(forked?.viewerInstall).toEqual({
+		status: 'installed',
+		targetName: '@burhan/github',
+		agentPrompt: buildExistingInstallPrompt({ targetName: '@burhan/github' }),
+		packageId: 'pkg-github',
+	})
+	expect(forked?.listing.viewerInstall).toEqual(forked?.viewerInstall)
 })
 
 test('community index omits viewerInstall for anonymous viewers and auth failures', async () => {

--- a/packages/worker/src/app/community-data.node.test.ts
+++ b/packages/worker/src/app/community-data.node.test.ts
@@ -50,8 +50,7 @@ vi.mock('#worker/community/repo.ts', () => ({
 vi.mock('#worker/community/social-repo.ts', () => ({
 	getCommunityStar: (...args: Array<unknown>) =>
 		mockModule.getCommunityStar(...args),
-	getUserFollow: (...args: Array<unknown>) =>
-		mockModule.getUserFollow(...args),
+	getUserFollow: (...args: Array<unknown>) => mockModule.getUserFollow(...args),
 	getUserSocialRowByUsername: (...args: Array<unknown>) =>
 		mockModule.getUserSocialRowByUsername(...args),
 }))

--- a/packages/worker/src/app/community-public.ts
+++ b/packages/worker/src/app/community-public.ts
@@ -190,6 +190,7 @@ export function toViewerListingInstall(input: {
 	status: 'installed' | 'adaptation_required'
 	targetName: string
 	sourceId: string
+	packageId: string | null
 }): ViewerListingInstall {
 	if (input.status === 'installed') {
 		return {
@@ -198,6 +199,7 @@ export function toViewerListingInstall(input: {
 			agentPrompt: buildExistingInstallPrompt({
 				targetName: input.targetName,
 			}),
+			packageId: input.packageId,
 		}
 	}
 	return {
@@ -207,5 +209,6 @@ export function toViewerListingInstall(input: {
 			targetName: input.targetName,
 			sourceId: input.sourceId,
 		}),
+		packageId: null,
 	}
 }

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -4,6 +4,7 @@ import { setAuthSessionSecret } from '#app/auth-session.ts'
 import {
 	createOnboardingApiHandler,
 	createOnboardingHandler,
+	loadOnboardingBuiltInProviders,
 	loadWelcomeEmail,
 } from '#app/handlers/onboarding.ts'
 import {
@@ -18,6 +19,9 @@ const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
 	listOwnerEmailMessages: vi.fn(),
 	searchOwnerEmailMessages: vi.fn(),
+	listTopPlatformAppsByUse: vi.fn(),
+	listJoinedIntegrations: vi.fn(),
+	buildPlatformOauthAppLogoPath: vi.fn(),
 }))
 
 vi.mock('#app/ssr-render.tsx', () => ({
@@ -38,6 +42,21 @@ vi.mock('#worker/email/owner-email-reader.ts', () => ({
 		mockModule.listOwnerEmailMessages(...args),
 	searchOwnerEmailMessages: (...args: Array<unknown>) =>
 		mockModule.searchOwnerEmailMessages(...args),
+}))
+
+vi.mock('#worker/integrations/platform-apps.ts', () => ({
+	listTopPlatformAppsByUse: (...args: Array<unknown>) =>
+		mockModule.listTopPlatformAppsByUse(...args),
+}))
+
+vi.mock('#worker/integrations/service.ts', () => ({
+	listJoinedIntegrations: (...args: Array<unknown>) =>
+		mockModule.listJoinedIntegrations(...args),
+}))
+
+vi.mock('#worker/integrations/platform-app-logo.ts', () => ({
+	buildPlatformOauthAppLogoPath: (...args: Array<unknown>) =>
+		mockModule.buildPlatformOauthAppLogoPath(...args),
 }))
 
 test('onboarding serves public setup content to anonymous visitors', async () => {
@@ -105,4 +124,98 @@ test('the Reply sub-step names the welcome email, not merely the newest outbound
 		new Error('mailbox unavailable'),
 	)
 	await expect(loadWelcomeEmail(env, 'user-1')).resolves.toBeNull()
+})
+
+test('onboarding built-in providers mark connected vs not from viewer integrations', async () => {
+	const env = {} as Env
+	mockModule.listTopPlatformAppsByUse.mockResolvedValue([
+		{ slug: 'github', label: 'GitHub', logoKey: null },
+		{ slug: 'google', label: 'Google', logoKey: null },
+		{ slug: 'slack', label: null, logoKey: null },
+	])
+	mockModule.buildPlatformOauthAppLogoPath.mockImplementation(
+		(app: { slug: string }) => `/integrations/logos/${app.slug}`,
+	)
+	mockModule.listJoinedIntegrations.mockResolvedValue([
+		{
+			lane: 'platform',
+			app: { slug: 'github' },
+			connection: {
+				name: 'github',
+				platformAppSlug: 'github',
+			},
+		},
+		{
+			lane: 'user',
+			app: { slug: 'custom-slack' },
+			connection: {
+				name: 'my-slack',
+				platformAppSlug: null,
+			},
+		},
+	])
+
+	const anonymous = await loadOnboardingBuiltInProviders(env)
+	expect(anonymous).toEqual([
+		{
+			slug: 'github',
+			label: 'GitHub',
+			logoPath: '/integrations/logos/github',
+			connected: false,
+			connectionName: null,
+		},
+		{
+			slug: 'google',
+			label: 'Google',
+			logoPath: '/integrations/logos/google',
+			connected: false,
+			connectionName: null,
+		},
+		{
+			slug: 'slack',
+			label: 'slack',
+			logoPath: '/integrations/logos/slack',
+			connected: false,
+			connectionName: null,
+		},
+	])
+	expect(mockModule.listJoinedIntegrations).not.toHaveBeenCalled()
+
+	const signedIn = await loadOnboardingBuiltInProviders(env, 'viewer-1')
+	expect(signedIn).toEqual([
+		{
+			slug: 'github',
+			label: 'GitHub',
+			logoPath: '/integrations/logos/github',
+			connected: true,
+			connectionName: 'github',
+		},
+		{
+			slug: 'google',
+			label: 'Google',
+			logoPath: '/integrations/logos/google',
+			connected: false,
+			connectionName: null,
+		},
+		{
+			slug: 'slack',
+			label: 'slack',
+			logoPath: '/integrations/logos/slack',
+			connected: false,
+			connectionName: null,
+		},
+	])
+	expect(mockModule.listJoinedIntegrations).toHaveBeenCalledWith({
+		env,
+		userId: 'viewer-1',
+	})
+
+	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+	mockModule.listJoinedIntegrations.mockRejectedValue(new Error('d1 blip'))
+	const failedLookup = await loadOnboardingBuiltInProviders(env, 'viewer-1')
+	expect(failedLookup.every((provider) => provider.connected === false)).toBe(
+		true,
+	)
+	expect(consoleError).toHaveBeenCalled()
+	consoleError.mockRestore()
 })

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -15,6 +15,7 @@ import {
 } from '#worker/email/owner-email-reader.ts'
 import { buildPlatformOauthAppLogoPath } from '#worker/integrations/platform-app-logo.ts'
 import { listTopPlatformAppsByUse } from '#worker/integrations/platform-apps.ts'
+import { listJoinedIntegrations } from '#worker/integrations/service.ts'
 import {
 	type OnboardingBuiltInProvider,
 	type OnboardingChecklistLoaderData,
@@ -108,22 +109,47 @@ const onboardingBuiltInProviderLimit = 6
 
 /**
  * Top enabled built-in integrations by adoption, offered as one-click
- * connects in the wizard. Fails open to an empty list so a D1 blip (or a
- * deployment with no platform apps) never breaks the onboarding payload.
+ * connects in the wizard. When `userId` is set, overlays whether the viewer
+ * already has a platform connection for each app. Fails open to an empty
+ * list so a D1 blip (or a deployment with no platform apps) never breaks
+ * the onboarding payload; connection lookup failures leave cards disconnected.
  */
 export async function loadOnboardingBuiltInProviders(
 	env: Env,
+	userId?: string | null,
 ): Promise<Array<OnboardingBuiltInProvider>> {
 	try {
 		const apps = await listTopPlatformAppsByUse({
 			db: env.APP_DB,
 			limit: onboardingBuiltInProviderLimit,
 		})
-		return apps.map((app) => ({
-			slug: app.slug,
-			label: app.label ?? app.slug,
-			logoPath: buildPlatformOauthAppLogoPath(app),
-		}))
+		const connectedBySlug = new Map<string, string>()
+		if (userId) {
+			try {
+				const integrations = await listJoinedIntegrations({ env, userId })
+				for (const joined of integrations) {
+					if (joined.lane !== 'platform') continue
+					const slug = joined.connection.platformAppSlug
+					if (!slug || connectedBySlug.has(slug)) continue
+					connectedBySlug.set(slug, joined.connection.name)
+				}
+			} catch (error) {
+				console.error(
+					'Failed to load viewer connections for onboarding providers:',
+					error,
+				)
+			}
+		}
+		return apps.map((app) => {
+			const connectionName = connectedBySlug.get(app.slug) ?? null
+			return {
+				slug: app.slug,
+				label: app.label ?? app.slug,
+				logoPath: buildPlatformOauthAppLogoPath(app),
+				connected: connectionName != null,
+				connectionName,
+			}
+		})
 	} catch {
 		return []
 	}
@@ -172,7 +198,10 @@ export function createOnboardingHandler(env: Env) {
 				stableUserId: user.mcpUser.userId,
 				emailVerified: user.emailVerified,
 				featuredListings: await loadOnboardingFeaturedListings(env, request),
-				builtInProviders: await loadOnboardingBuiltInProviders(env),
+				builtInProviders: await loadOnboardingBuiltInProviders(
+					env,
+					user.mcpUser.userId,
+				),
 			})
 			;[
 				onboarding.checklist,
@@ -224,7 +253,7 @@ export function createOnboardingApiHandler(env: Env) {
 					? await loadOnboardingFeaturedListings(env, request)
 					: [],
 				builtInProviders: user.emailVerified
-					? await loadOnboardingBuiltInProviders(env)
+					? await loadOnboardingBuiltInProviders(env, user.mcpUser.userId)
 					: [],
 			})
 			if (user.emailVerified) {

--- a/packages/worker/src/community/viewer-install.node.test.ts
+++ b/packages/worker/src/community/viewer-install.node.test.ts
@@ -70,21 +70,25 @@ test('resolveViewerListingInstalls prefers matching kody_id, then listing forks'
 		status: 'installed',
 		targetName: '@burhan/github',
 		sourceId: 'src-github',
+		packageId: 'pkg-github',
 	})
 	expect(resolved.get('listing-cloudflare')).toEqual({
 		status: 'adaptation_required',
 		targetName: '@burhan/cloudflare',
 		sourceId: 'src-cf',
+		packageId: null,
 	})
 	expect(resolved.get('listing-notion')).toEqual({
 		status: 'installed',
 		targetName: '@burhan/my-notion',
 		sourceId: 'src-notion',
+		packageId: 'pkg-notion-custom',
 	})
 	expect(resolved.has('listing-slack')).toBe(false)
 	expect(resolved.get('listing-dropbox')).toEqual({
 		status: 'adaptation_required',
 		targetName: '@burhan/my-dropbox',
 		sourceId: 'src-dropbox-new',
+		packageId: null,
 	})
 })

--- a/packages/worker/src/community/viewer-install.ts
+++ b/packages/worker/src/community/viewer-install.ts
@@ -22,6 +22,8 @@ export type ResolvedViewerListingInstall = {
 	status: 'installed' | 'adaptation_required'
 	targetName: string
 	sourceId: string
+	/** Live saved package id when status is `installed`; otherwise null. */
+	packageId: string | null
 }
 
 function compareCreatedAtDesc(left: string, right: string) {
@@ -74,6 +76,7 @@ export function resolveViewerListingInstalls(input: {
 				status: 'installed',
 				targetName: savedByKody.name,
 				sourceId: savedByKody.sourceId,
+				packageId: savedByKody.id,
 			})
 			continue
 		}
@@ -91,6 +94,7 @@ export function resolveViewerListingInstalls(input: {
 				status: 'installed',
 				targetName: forkedSaved.name,
 				sourceId: forkedSaved.sourceId,
+				packageId: forkedSaved.id,
 			})
 			continue
 		}
@@ -98,6 +102,7 @@ export function resolveViewerListingInstalls(input: {
 			status: 'adaptation_required',
 			targetName: scopedPackageName(input.packageScope, fork.targetKodyId),
 			sourceId: fork.forkedSourceId,
+			packageId: null,
 		})
 	}
 	return resolved

--- a/packages/worker/universal/community-public-types.ts
+++ b/packages/worker/universal/community-public-types.ts
@@ -6,6 +6,11 @@ export type ViewerListingInstall = {
 	status: 'installed' | 'adaptation_required'
 	targetName: string
 	agentPrompt: string
+	/**
+	 * Saved package id when the viewer has a live package for this listing.
+	 * Null for inert forks that still need adaptation.
+	 */
+	packageId: string | null
 }
 
 /**

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -701,6 +701,13 @@ export type OnboardingBuiltInProvider = {
 	slug: string
 	label: string
 	logoPath: string | null
+	/** True when the signed-in viewer already has a connection for this app. */
+	connected: boolean
+	/**
+	 * Connection name for `/account/integrations/:name` when `connected`.
+	 * Null when disconnected or anonymous.
+	 */
+	connectionName: string | null
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop onboarding Connect cards and community Install CTAs from looking available when the viewer already has the connection or fork.

## Summary

- **Onboarding built-in providers (#1402):** `loadOnboardingBuiltInProviders` overlays the viewer's platform connections via `listJoinedIntegrations`. Connected cards show **Connected** and link to `/account/integrations/:name` (not Connect / Manage / Reconnect).
- **Community listing install (#1173):** Keep using the existing `viewerInstall` overlay so refresh shows Already installed / Already forked instead of a primary Install that 400s. Expose `packageId` when a live saved package exists and link to that package detail.
- No Manage/Reconnect surfaces, no fork-again / kody_id override UI, no collision-policy changes.

## Testing

- `npx vitest run packages/worker/src/app/handlers/onboarding.node.test.ts packages/worker/src/app/community-data.node.test.ts packages/worker/src/community/viewer-install.node.test.ts` (pass)
- Related frame/onboarding suites pass
- `npm run typecheck` / `npm run lint` pass in validate; local full `validate` hit unrelated Cloud VM flakes (mcp-e2e worker startup timeouts, artifacts-mock DNS)

## System changes

Closes #1402
Closes #1173

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `73ff76fd` · **Head:** `508a5f0e`

**Classification:** extends — onboarding provider and viewerInstall payload shapes gain connection/package identity so the two UIs can render already-done state.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — `OnboardingBuiltInProvider.connected` / `connectionName`; Connected pill + integration link |
| `community-listings` | assistant | extends — `ViewerListingInstall.packageId`; install section links to saved package |

### System map

Onboarding and community listing UIs read existing connection/fork data and stop offering Connect/Install when the viewer already has them.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	communityListings["community-listings<br/>Community package listings"]:::extended
	appUi -->|"listJoinedIntegrations overlay"| appUi
	communityListings -->|"viewerInstall + packageId link"| communityListings
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| Onboarding provider card | Always **Connect** → `/connect/oauth` | **Connected** → integration detail when `platformAppSlug` matches |
| Community install | Session-only success; refresh shows **Install** | Loader `viewerInstall` survives refresh; open link uses `packageId` when present |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-101eaf89-6399-49c9-b6ab-1bd8180c3b13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-101eaf89-6399-49c9-b6ab-1bd8180c3b13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

