### PR TITLE
Remove unused jobs helper and document JOB_REINDEX_SECRET

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -277,6 +277,12 @@ Worker secrets:
   built-in capability, memory, job, and saved-package vectors with per-user
   `userId` metadata on user-owned rows. Local dev uses offline search while
   `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
+- **`JOB_REINDEX_SECRET`** — optional Worker secret; bearer token for
+  `POST /__maintenance/reindex-jobs` when you want a jobs-only Vectorize rebuild
+  (without the full capability/memory/package reindex that
+  `CAPABILITY_REINDEX_SECRET` drives). When unset, the jobs-only endpoint returns
+  not-configured; production deploys rely on the capability reindex path for job
+  vectors and do not require this secret.
 
 ## Cloudflare API (Worker + Email)
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -280,9 +280,9 @@ Worker secrets:
 - **`JOB_REINDEX_SECRET`** — optional Worker secret; bearer token for
   `POST /__maintenance/reindex-jobs` when you want a jobs-only Vectorize rebuild
   (without the full capability/memory/package reindex that
-  `CAPABILITY_REINDEX_SECRET` drives). When unset, the jobs-only endpoint returns
-  not-configured; production deploys rely on the capability reindex path for job
-  vectors and do not require this secret.
+  `CAPABILITY_REINDEX_SECRET` drives). When unset, the jobs-only endpoint
+  returns not-configured; production deploys rely on the capability reindex path
+  for job vectors and do not require this secret.
 
 ## Cloudflare API (Worker + Email)
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -397,6 +397,11 @@ automatically:
   to refresh all capability-search vectors in Vectorize: built-in capabilities,
   memories, jobs, and saved packages. Saved package projections also refresh
   when packages are saved or published.)
+- `JOB_REINDEX_SECRET` (optional Worker secret; bearer auth for
+  `POST /__maintenance/reindex-jobs` for a jobs-only Vectorize rebuild. Not
+  required for production deploys — the capability reindex path already refreshes
+  job vectors. Omit locally and for previews unless you need the jobs-only
+  endpoint.)
 - `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`, `GOOGLE_CLIENT_ID` /
   `GOOGLE_CLIENT_SECRET`, `X_CLIENT_ID` / `X_CLIENT_SECRET` (optional Worker
   secrets; enable the "Sign in with GitHub / Google / X" login buttons. A
@@ -457,6 +462,9 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `CAPABILITY_REINDEX_SECRET` (strongly recommended for production; optional
   locally and for previews; authenticates post-deploy maintenance calls such as
   capability reindex — CI skips those calls when it is unset)
+- `JOB_REINDEX_SECRET` (optional; authenticates `POST /__maintenance/reindex-jobs`
+  for a jobs-only Vectorize rebuild. Production deploys do not require it —
+  capability reindex already refreshes job vectors.)
 - `DR_BACKUP_ACCOUNT_ID` / `DR_BACKUP_BUCKET_NAME` / `DR_BACKUP_ACCESS_KEY_ID` /
   `DR_BACKUP_SECRET_ACCESS_KEY` (production DR staging into the DR bucket; also
   used by `.github/workflows/dr-escrow.yml`. `DR_BACKUP_ACCOUNT_ID` is also the
@@ -604,6 +612,11 @@ How to get/set each value:
     Vectorize index dimensions so existing rows are rebuilt with compatible
     vectors. Local and preview environments can omit it; CI skips reindex and
     execute-smoke when the secret is unset.
+- `JOB_REINDEX_SECRET` (optional; jobs-only reindex)
+  - Bearer token for `POST /__maintenance/reindex-jobs`. Generate and sync the
+    same way as `CAPABILITY_REINDEX_SECRET` only if you want the jobs-only
+    maintenance endpoint. Production deploys do not require it; the capability
+    reindex path already refreshes job vectors. Local and preview can omit it.
 
 Preview deploys for pull requests create an app Worker per PR named
 `<app-name>-pr-<number>` (for kody: `kody-pr-123`), sibling runtime and jobs

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -399,9 +399,9 @@ automatically:
   when packages are saved or published.)
 - `JOB_REINDEX_SECRET` (optional Worker secret; bearer auth for
   `POST /__maintenance/reindex-jobs` for a jobs-only Vectorize rebuild. Not
-  required for production deploys — the capability reindex path already refreshes
-  job vectors. Omit locally and for previews unless you need the jobs-only
-  endpoint.)
+  required for production deploys — the capability reindex path already
+  refreshes job vectors. Omit locally and for previews unless you need the
+  jobs-only endpoint.)
 - `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`, `GOOGLE_CLIENT_ID` /
   `GOOGLE_CLIENT_SECRET`, `X_CLIENT_ID` / `X_CLIENT_SECRET` (optional Worker
   secrets; enable the "Sign in with GitHub / Google / X" login buttons. A
@@ -462,9 +462,10 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `CAPABILITY_REINDEX_SECRET` (strongly recommended for production; optional
   locally and for previews; authenticates post-deploy maintenance calls such as
   capability reindex — CI skips those calls when it is unset)
-- `JOB_REINDEX_SECRET` (optional; authenticates `POST /__maintenance/reindex-jobs`
-  for a jobs-only Vectorize rebuild. Production deploys do not require it —
-  capability reindex already refreshes job vectors.)
+- `JOB_REINDEX_SECRET` (optional; authenticates
+  `POST /__maintenance/reindex-jobs` for a jobs-only Vectorize rebuild.
+  Production deploys do not require it — capability reindex already refreshes
+  job vectors.)
 - `DR_BACKUP_ACCOUNT_ID` / `DR_BACKUP_BUCKET_NAME` / `DR_BACKUP_ACCESS_KEY_ID` /
   `DR_BACKUP_SECRET_ACCESS_KEY` (production DR staging into the DR bucket; also
   used by `.github/workflows/dr-escrow.yml`. `DR_BACKUP_ACCOUNT_ID` is also the

--- a/packages/worker/.env.example
+++ b/packages/worker/.env.example
@@ -79,6 +79,13 @@ X_CLIENT_SECRET=MOCK_X_CLIENT_SECRET
 # deploy workflow.
 # CAPABILITY_REINDEX_SECRET=
 
+# Jobs-only Vectorize reindex (optional Worker secret).
+# POST /__maintenance/reindex-jobs with Authorization: Bearer <this value>
+# rebuilds job vectors without the full capability/memory/package reindex.
+# Production deploys do not require this — capability reindex already refreshes
+# job vectors.
+# JOB_REINDEX_SECRET=
+
 # Kit (kit.com) waiting-list signup (optional Worker secret + tag/sequence ids).
 # Production /waiting-list posts create/upsert a subscriber, tag waitlist::kody,
 # and enroll them in the Kody Waitlist Welcome sequence (hello@kentcdodds.com).

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -834,31 +834,6 @@ export async function syncPackageJobsForPackage(input: {
 	})
 }
 
-export async function deletePackageJobsForSourceId(input: {
-	env: Env
-	userId: string
-	sourceId: string
-}) {
-	return await withAccountWriteLease({
-		db: input.env.APP_DB,
-		stableUserId: input.userId,
-		env: input.env,
-		async write() {
-			const existingRows = await jobsData(input.env).listJobsForUser({
-				userId: input.userId,
-			})
-			for (const row of existingRows) {
-				if (row.source_id !== input.sourceId) continue
-				await jobsData(input.env).deleteJob({
-					userId: input.userId,
-					jobId: row.id,
-				})
-				await deleteJobVector(input.env, row.id)
-			}
-		},
-	})
-}
-
 function resolveCreateShape(input: JobCreateInput) {
 	return {
 		moduleSource: normalizeJobCode(input.code),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes leftover #543 cruft (not large-file extractions) and the #1092 item-6 docs gap.

## What changed

- **Deleted unused `deletePackageJobsForSourceId`** from `packages/worker/src/jobs/service.ts`. Introduced in #221 and never imported or called; package delete already inlines its own D1 job-row cleanup. Pure dead export removal — no runtime call sites.
- **Documented `JOB_REINDEX_SECRET`** next to `CAPABILITY_REINDEX_SECRET` in `environment-variables.md`, `setup-manifest.md` (all three secret lists), and `.env.example`. Bearer for `POST /__maintenance/reindex-jobs`; optional because capability reindex already refreshes job vectors.

## What this deliberately does *not* do

Per owner guidance on #543: no extractions/splits of `index.ts`, `jobs/service.ts`, or `account-secrets.tsx` for size alone; no repo-wide `getErrorMessage` codemod (remaining ternaries match the shared helper — no behavioral inconsistency found).

## Audit summary (full punch list on #543)

| Item | Status |
| --- | --- |
| `kody-widget-runtime.ts` / mcp-apps | Already gone (#667) |
| connect-oauth helpers + secret-normalization parity | Shipped (#1019) |
| Unused `deletePackageJobsForSourceId` | Deleted here |
| Large-module “please extract” notes | Not worth tracking — closed #543 |
| Error-formatting codemod | Not worth tracking — same behavior as `getErrorMessage` |

## Verification

- Focused node unit tests: `package-registry/service.node.test.ts` + `jobs/service.node.test.ts` — 35 passed
- `rg deletePackageJobsForSourceId` — zero hits after delete
- `oxfmt` on touched docs/service file

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `73ff76fd` · **Head:** `2f2628ca`

**Classification:** composes — deletes an unused jobs helper export and documents an existing optional Worker secret; no primitive behavior, shape, or contract changes.

### Primitives touched

| Primitive | Group     | Impact                                                                 |
| --------- | --------- | ---------------------------------------------------------------------- |
| `jobs`    | assistant | composes — remove never-called `deletePackageJobsForSourceId` export |

### System map

Docs and `.env.example` record the existing jobs-only reindex secret; the jobs service drops a dead export with no callers.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	jobs["jobs<br/>Scheduled jobs"]:::touched
	docs["docs / .env.example<br/>operator docs"]:::untouched
	jobs -->|"delete unused deletePackageJobsForSourceId"| jobs
	docs -->|"document JOB_REINDEX_SECRET beside CAPABILITY_REINDEX_SECRET"| docs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user isolation untouched: no user-scoped read/write paths changed — only an unused export and documentation.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf9516c8-7ec6-436e-818e-bfe796289857?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf9516c8-7ec6-436e-818e-bfe796289857&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the optional jobs-only reindex secret and endpoint.
  * Clarified setup requirements across local development, previews, GitHub Actions, and maintenance workflows.
  * Explained how jobs-only reindexing differs from full capability reindexing.

* **Chores**
  * Removed obsolete job cleanup functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->