### PR TITLE
Point the public status page at status.kody.codes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -686,7 +686,7 @@ jobs:
       needs.sha-guard.outputs.deploy_status_worker == 'true'
     environment:
       name: production
-      url: https://status.heykody.dev
+      url: https://status.kody.codes
     steps:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
@@ -749,19 +749,26 @@ jobs:
           EXPECTED_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
         run: |
           set -euo pipefail
-          HEALTHCHECK_URL="https://status.heykody.dev/health"
-          echo "Healthcheck URL: $HEALTHCHECK_URL"
+          # Canonical host first. Fall back to the legacy host so a 1016 on
+          # status.kody.codes (DNS not attached yet) does not fail the
+          # deploy. /health is sticky on .dev and is not 308'd. Other
+          # component probes never use these hostnames.
+          CANONICAL_HEALTH="https://status.kody.codes/health"
+          LEGACY_HEALTH="https://status.heykody.dev/health"
 
           attempts=20
           delay_seconds=3
           for i in $(seq 1 "$attempts"); do
             echo "Attempt $i/$attempts"
-            if curl --fail --silent --show-error --location --max-time 10 \
-              --header "Accept: application/json" \
-              "$HEALTHCHECK_URL" > status-health.json && \
-              node -e "const fs = require('node:fs'); const json = JSON.parse(fs.readFileSync('status-health.json','utf8')); const expected = process.env.EXPECTED_COMMIT_SHA; if (json?.ok !== true) { console.error('status-healthcheck-unexpected-response', json); process.exit(1); } if (json?.commit !== expected) { console.error('status-healthcheck-unexpected-commit', { expected, actual: json?.commit }); process.exit(1); } console.log('status-healthcheck-ok', json);"; then
-              exit 0
-            fi
+            for HEALTHCHECK_URL in "$CANONICAL_HEALTH" "$LEGACY_HEALTH"; do
+              echo "Healthcheck URL: $HEALTHCHECK_URL"
+              if curl --fail --silent --show-error --max-time 10 \
+                --header "Accept: application/json" \
+                "$HEALTHCHECK_URL" > status-health.json && \
+                node -e "const fs = require('node:fs'); const json = JSON.parse(fs.readFileSync('status-health.json','utf8')); const expected = process.env.EXPECTED_COMMIT_SHA; if (json?.ok !== true) { console.error('status-healthcheck-unexpected-response', json); process.exit(1); } if (json?.commit !== expected) { console.error('status-healthcheck-unexpected-commit', { expected, actual: json?.commit }); process.exit(1); } console.log('status-healthcheck-ok', json);"; then
+                exit 0
+              fi
+            done
             sleep "$delay_seconds"
           done
 

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -68,7 +68,7 @@ primitives:
     group: surfaces
     name: Public status page
     summary:
-      Independently deployed status worker (status.heykody.dev) probing public
+      Independently deployed status worker (status.kody.codes) probing public
       endpoints every minute, storing history in its own Durable Object, and
       emailing operator alerts under a capped policy.
     code:

--- a/docs/contributing/decisions/0004-status-page-separate-worker.md
+++ b/docs/contributing/decisions/0004-status-page-separate-worker.md
@@ -16,9 +16,10 @@ self-contained need; the repo already had a second-worker precedent in
 ## Decision
 
 The status page is an independently deployed worker (`packages/status/`,
-`status.heykody.dev`) that observes the product strictly from the outside via
-public endpoints, and stores probe history, incidents, and notification state in
-its own Durable Object — never in `APP_DB`. The main worker exposes
+`status.kody.codes`) that observes the product strictly from the outside via
+public endpoints (and a jobs-worker service binding, not a public jobs
+hostname), and stores probe history, incidents, and notification state in its
+own Durable Object — never in `APP_DB`. The main worker exposes
 `GET /health/components` (cheap per-binding checks) so the prober can report
 storage subsystems individually. Operator alert email goes through the
 Cloudflare Email REST API under a strict policy: one email per outage episode,
@@ -38,4 +39,6 @@ top; do not move the status page into the main worker. The status worker
 duplicates a small amount of email-sending code rather than importing from
 `packages/worker` (import boundaries keep it dependency-free). Incident records
 are probe-derived only; manually posted incident narratives are a possible later
-addition, not built now.
+addition, not built now. `status.heykody.dev` stays a worker custom domain for
+legacy links and 308s to `status.kody.codes` except `/health`, which remains
+reachable on the legacy host if the canonical hostname is not attached yet.

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -289,12 +289,18 @@ production-identity, and restore-baseline registries.
 
 ### Status page worker
 
-The public status page (`packages/status/`, served at `status.heykody.dev` via a
-wrangler custom domain on the production zone) is an independently deployed
+The public status page (`packages/status/`, served at `status.kody.codes` via a
+wrangler custom domain on the `kody.codes` zone) is an independently deployed
 Worker with a cron trigger and one `StatusStore` Durable Object (SQLite). It
-probes public endpoints on the main worker and `kody.run` every minute and never
-touches `APP_DB` (see decision record
-[0004](./decisions/0004-status-page-separate-worker.md)).
+probes public endpoints on the main worker and package-runtime liveness on
+`kody.run`, and probes the jobs worker over a service binding — never through
+the main app and never via a public jobs hostname. It never touches `APP_DB`
+(see decision record [0004](./decisions/0004-status-page-separate-worker.md)).
+`status.heykody.dev` remains attached as a legacy custom domain: GET/HEAD other
+than `/health` 308 to `status.kody.codes`. `/health` stays sticky on the legacy
+host so deploys can still probe the worker if the canonical hostname returns
+Cloudflare 1016 until DNS exists. Component probes do not use the status
+hostname.
 
 Code deploys are automated by the production deploy workflow
 (`.github/workflows/deploy.yml` job `deploy-status-worker`) when a `main` push

--- a/packages/jobs-worker/src/health.node.test.ts
+++ b/packages/jobs-worker/src/health.node.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	collectJobsHealthComponents,
+	handleJobsHealthRequest,
+} from './health.ts'
+
+function healthyDb() {
+	return {
+		prepare: () => ({ first: async () => ({ 1: 1 }) }),
+	} as unknown as D1Database
+}
+
+test('jobs health reports liveness and treats JOBS_DB failure as components-down', async () => {
+	const liveness = await handleJobsHealthRequest(
+		new Request('https://kody-jobs.example/health'),
+		{ APP_COMMIT_SHA: 'abc123def456' },
+	)
+	expect(liveness?.status).toBe(200)
+	await expect(liveness?.json()).resolves.toEqual({
+		ok: true,
+		commit: 'abc123def456',
+	})
+
+	const healthy = await collectJobsHealthComponents({
+		APP_COMMIT_SHA: 'abc123def456',
+		JOBS_DB: healthyDb(),
+	})
+	expect(healthy.ok).toBe(true)
+	expect(healthy.commit).toBe('abc123def456')
+	expect(healthy.components).toEqual([
+		expect.objectContaining({ id: 'jobs_db', ok: true }),
+	])
+
+	const healthyResponse = await handleJobsHealthRequest(
+		new Request('https://kody-jobs.example/health/components'),
+		{ APP_COMMIT_SHA: 'abc123def456', JOBS_DB: healthyDb() },
+	)
+	expect(healthyResponse?.status).toBe(200)
+	await expect(healthyResponse?.json()).resolves.toMatchObject({
+		ok: true,
+		commit: 'abc123def456',
+		components: [expect.objectContaining({ id: 'jobs_db', ok: true })],
+	})
+
+	consoleWarn.mockImplementation(() => {})
+	const failedResponse = await handleJobsHealthRequest(
+		new Request('https://kody-jobs.example/health/components'),
+		{
+			APP_COMMIT_SHA: 'abc123def456',
+			JOBS_DB: {
+				prepare: () => ({
+					first: async () => {
+						throw new Error('database is unavailable')
+					},
+				}),
+			} as unknown as D1Database,
+		},
+	)
+	expect(failedResponse?.status).toBe(503)
+	await expect(failedResponse?.json()).resolves.toMatchObject({
+		ok: false,
+		components: [
+			expect.objectContaining({ id: 'jobs_db', ok: false, error: 'error' }),
+		],
+	})
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'jobs-health-component-failed',
+		expect.any(String),
+	)
+
+	const missing = await collectJobsHealthComponents({
+		APP_COMMIT_SHA: undefined,
+	})
+	expect(missing.ok).toBe(false)
+	expect(missing.commit).toBeNull()
+	expect(missing.components[0]).toMatchObject({
+		id: 'jobs_db',
+		ok: false,
+		error: 'unavailable',
+	})
+
+	expect(
+		await handleJobsHealthRequest(
+			new Request('https://kody-jobs.example/other'),
+			{ JOBS_DB: healthyDb() },
+		),
+	).toBeNull()
+})

--- a/packages/jobs-worker/src/health.ts
+++ b/packages/jobs-worker/src/health.ts
@@ -1,0 +1,111 @@
+import { runD1WithRetry } from '@kody-internal/shared/d1-retry.ts'
+
+/**
+ * Liveness and JOBS_DB checks for the jobs worker. The public status page
+ * probes these over a service binding (no public jobs hostname). JOBS_DB
+ * rides on the same Jobs component — there is no separate storage card.
+ */
+
+const componentCheckTimeoutMs = 3_000
+const d1CheckRetryOptions = { maxAttempts: 3 } as const
+const noStoreHeaders = { 'Cache-Control': 'no-store' } as const
+
+export type JobsHealthComponentId = 'jobs_db'
+
+export type JobsHealthComponentResult = {
+	id: JobsHealthComponentId
+	ok: boolean
+	latencyMs: number
+	error?: 'timeout' | 'unavailable' | 'error'
+}
+
+export type JobsHealthComponentsReport = {
+	ok: boolean
+	commit: string | null
+	checkedAt: string
+	components: Array<JobsHealthComponentResult>
+}
+
+type JobsHealthEnv = {
+	JOBS_DB?: D1Database
+	APP_COMMIT_SHA?: string
+}
+
+async function checkJobsDb(
+	db: D1Database | undefined,
+): Promise<JobsHealthComponentResult> {
+	const startedAt = Date.now()
+	if (!db) {
+		return { id: 'jobs_db', ok: false, latencyMs: 0, error: 'unavailable' }
+	}
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+	const timeout = new Promise<'timeout'>((resolve) => {
+		timeoutHandle = setTimeout(
+			() => resolve('timeout'),
+			componentCheckTimeoutMs,
+		)
+	})
+	try {
+		const outcome = await Promise.race([
+			runD1WithRetry(
+				() => db.prepare('SELECT 1').first(),
+				d1CheckRetryOptions,
+			).then(() => 'ok' as const),
+			timeout,
+		])
+		const latencyMs = Date.now() - startedAt
+		if (outcome === 'timeout') {
+			console.warn(
+				'jobs-health-component-timeout',
+				JSON.stringify({ id: 'jobs_db' }),
+			)
+			return { id: 'jobs_db', ok: false, latencyMs, error: 'timeout' }
+		}
+		return { id: 'jobs_db', ok: true, latencyMs }
+	} catch (error) {
+		const latencyMs = Date.now() - startedAt
+		console.warn(
+			'jobs-health-component-failed',
+			JSON.stringify({
+				id: 'jobs_db',
+				message: error instanceof Error ? error.message : String(error),
+			}),
+		)
+		return { id: 'jobs_db', ok: false, latencyMs, error: 'error' }
+	} finally {
+		clearTimeout(timeoutHandle)
+	}
+}
+
+export async function collectJobsHealthComponents(
+	env: JobsHealthEnv,
+): Promise<JobsHealthComponentsReport> {
+	const jobsDb = await checkJobsDb(env.JOBS_DB)
+	return {
+		ok: jobsDb.ok,
+		commit: env.APP_COMMIT_SHA ?? null,
+		checkedAt: new Date().toISOString(),
+		components: [jobsDb],
+	}
+}
+
+export async function handleJobsHealthRequest(
+	request: Request,
+	env: JobsHealthEnv,
+): Promise<Response | null> {
+	const url = new URL(request.url)
+	if (url.pathname === '/health') {
+		return Response.json(
+			{ ok: true, commit: env.APP_COMMIT_SHA ?? null },
+			{ headers: noStoreHeaders },
+		)
+	}
+	if (url.pathname === '/health/components') {
+		const report = await collectJobsHealthComponents(env)
+		return Response.json(report, {
+			status: report.ok ? 200 : 503,
+			headers: noStoreHeaders,
+		})
+	}
+	return null
+}

--- a/packages/jobs-worker/src/index.ts
+++ b/packages/jobs-worker/src/index.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/cloudflare'
 import { type JobsWorkerEnv } from './env.ts'
+import { handleJobsHealthRequest } from './health.ts'
 import { JobManager } from './manager-do.ts'
 import {
 	dispatchScheduledLanes,
@@ -12,13 +13,8 @@ export { JobManager, JobsService }
 
 const handler = {
 	async fetch(request: Request, env: JobsWorkerEnv) {
-		const url = new URL(request.url)
-		if (url.pathname === '/health') {
-			return Response.json(
-				{ ok: true, commit: env.APP_COMMIT_SHA ?? null },
-				{ headers: { 'Cache-Control': 'no-store' } },
-			)
-		}
+		const healthResponse = await handleJobsHealthRequest(request, env)
+		if (healthResponse) return healthResponse
 		return new Response('Not found', { status: 404 })
 	},
 	async scheduled(

--- a/packages/status/email-policy.node.test.ts
+++ b/packages/status/email-policy.node.test.ts
@@ -97,18 +97,18 @@ test('composed emails carry component names, status page link, and escape html',
 		const content = composeStatusEmail({
 			kind,
 			openIncidents: [incident],
-			statusPageUrl: 'https://status.heykody.dev',
+			statusPageUrl: 'https://status.kody.codes',
 			now: baseNow,
 		})
 		expect(content.subject).toContain('[kody status]')
-		expect(content.text).toContain('https://status.heykody.dev')
-		expect(content.html).toContain('https://status.heykody.dev')
+		expect(content.text).toContain('https://status.kody.codes')
+		expect(content.html).toContain('https://status.kody.codes')
 		expect(content.html).not.toContain('<script>')
 	}
 	const opened = composeStatusEmail({
 		kind: 'incident_opened',
 		openIncidents: [incident],
-		statusPageUrl: 'https://status.heykody.dev',
+		statusPageUrl: 'https://status.kody.codes',
 		now: baseNow,
 	})
 	expect(opened.subject).toContain('App & API')
@@ -129,7 +129,7 @@ test('outage emails annotate active relevant Cloudflare incidents', () => {
 	const opened = composeStatusEmail({
 		kind: 'incident_opened',
 		openIncidents: [openIncident()],
-		statusPageUrl: 'https://status.heykody.dev',
+		statusPageUrl: 'https://status.kody.codes',
 		now: baseNow,
 		providerIncidents,
 	})
@@ -141,7 +141,7 @@ test('outage emails annotate active relevant Cloudflare incidents', () => {
 	const reminder = composeStatusEmail({
 		kind: 'daily_reminder',
 		openIncidents: [openIncident()],
-		statusPageUrl: 'https://status.heykody.dev',
+		statusPageUrl: 'https://status.kody.codes',
 		now: baseNow,
 		providerIncidents,
 	})
@@ -152,7 +152,7 @@ test('outage emails annotate active relevant Cloudflare incidents', () => {
 	const allClear = composeStatusEmail({
 		kind: 'all_clear',
 		openIncidents: [],
-		statusPageUrl: 'https://status.heykody.dev',
+		statusPageUrl: 'https://status.kody.codes',
 		now: baseNow,
 		providerIncidents,
 	})

--- a/packages/status/legacy-redirect.node.test.ts
+++ b/packages/status/legacy-redirect.node.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest'
+import {
+	canonicalStatusOrigin,
+	getLegacyStatusRedirectResponse,
+	legacyStatusHost,
+} from './legacy-redirect.ts'
+
+test('legacy status host 308s page traffic to status.kody.codes and keeps /health sticky', () => {
+	const page = getLegacyStatusRedirectResponse(
+		new Request(`https://${legacyStatusHost}/?utm=x`),
+	)
+	expect(page?.status).toBe(308)
+	expect(page?.headers.get('location')).toBe(`${canonicalStatusOrigin}/?utm=x`)
+
+	const json = getLegacyStatusRedirectResponse(
+		new Request(`https://${legacyStatusHost}/status.json`),
+	)
+	expect(json?.status).toBe(308)
+	expect(json?.headers.get('location')).toBe(
+		`${canonicalStatusOrigin}/status.json`,
+	)
+
+	const head = getLegacyStatusRedirectResponse(
+		new Request(`https://${legacyStatusHost}/`, { method: 'HEAD' }),
+	)
+	expect(head?.status).toBe(308)
+	expect(head?.headers.get('location')).toBe(`${canonicalStatusOrigin}/`)
+
+	expect(
+		getLegacyStatusRedirectResponse(
+			new Request(`https://${legacyStatusHost}/health`),
+		),
+	).toBeNull()
+	expect(
+		getLegacyStatusRedirectResponse(
+			new Request(`https://${legacyStatusHost}/health/extra`),
+		),
+	).toBeNull()
+
+	expect(
+		getLegacyStatusRedirectResponse(new Request('https://status.kody.codes/')),
+	).toBeNull()
+	expect(
+		getLegacyStatusRedirectResponse(
+			new Request(`https://${legacyStatusHost}/`, { method: 'POST' }),
+		),
+	).toBeNull()
+})

--- a/packages/status/legacy-redirect.ts
+++ b/packages/status/legacy-redirect.ts
@@ -1,0 +1,46 @@
+/**
+ * Legacy status hostname handling. The canonical public place for status is
+ * status.kody.codes. status.heykody.dev stays attached as a worker custom
+ * domain so `/health` still works if the canonical host is 1016 until DNS
+ * exists; other GET/HEAD requests 308 to the canonical origin.
+ */
+
+export const canonicalStatusHost = 'status.kody.codes'
+export const canonicalStatusOrigin = `https://${canonicalStatusHost}`
+export const legacyStatusHost = 'status.heykody.dev'
+
+const stickyPathPrefixes = ['/health'] as const
+
+function isStickyPath(pathname: string) {
+	return stickyPathPrefixes.some(
+		(prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+	)
+}
+
+/**
+ * Redirect safe GET/HEAD navigation from the legacy status host to
+ * status.kody.codes. `/health` stays sticky so deploy healthchecks can probe
+ * the worker on .dev when the canonical hostname is not attached yet.
+ *
+ * Returns `null` when the request should be served normally.
+ */
+export function getLegacyStatusRedirectResponse(
+	request: Request,
+): Response | null {
+	const method = request.method
+	if (method !== 'GET' && method !== 'HEAD') return null
+
+	let url: URL
+	try {
+		url = new URL(request.url)
+	} catch {
+		return null
+	}
+	if (url.hostname.toLowerCase() !== legacyStatusHost) return null
+	if (isStickyPath(url.pathname)) return null
+
+	return Response.redirect(
+		`${canonicalStatusOrigin}${url.pathname}${url.search}`,
+		308,
+	)
+}

--- a/packages/status/probes.node.test.ts
+++ b/packages/status/probes.node.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { runAllProbes } from './probes.ts'
+import { jobsProbeOrigin, runAllProbes } from './probes.ts'
 import { statusComponentIds } from './status-types.ts'
 
 type FakeRoute = {
@@ -22,8 +22,11 @@ function fakeFetcher(routes: Record<string, FakeRoute>): typeof fetch {
 	}) as typeof fetch
 }
 
-const primaryOrigin = 'https://heykody.dev'
-const packageAppOrigin = 'https://kodyapps.dev'
+const primaryOrigin = 'https://kody.codes'
+const packageAppOrigin = 'https://kody.run'
+const runtimeHealth = `${packageAppOrigin}/__runtime/health`
+const jobsHealth = `${jobsProbeOrigin}/health`
+const jobsComponents = `${jobsProbeOrigin}/health/components`
 
 function healthyRoutes(): Record<string, FakeRoute> {
 	return {
@@ -34,7 +37,23 @@ function healthyRoutes(): Record<string, FakeRoute> {
 			status: 401,
 			headers: { 'WWW-Authenticate': 'Bearer resource_metadata="..."' },
 		},
-		[`${packageAppOrigin}/`]: { status: 302, headers: { Location: '/x' } },
+		[runtimeHealth]: {
+			body: {
+				status: 'ok',
+				commitSha: 'def4567890abcdef1234567890abcdef12345678',
+				cookieSecretConfigured: true,
+			},
+		},
+		[jobsHealth]: {
+			body: { ok: true, commit: '7890abcdef1234567890abcdef1234567890abcd' },
+		},
+		[jobsComponents]: {
+			body: {
+				ok: true,
+				commit: '7890abcdef1234567890abcdef1234567890abcd',
+				components: [{ id: 'jobs_db', ok: true, latencyMs: 3 }],
+			},
+		},
 		[`${primaryOrigin}/health/components`]: {
 			body: {
 				ok: true,
@@ -75,6 +94,82 @@ test('a fully healthy pass reports every component ok', async () => {
 	expect(outcome(result, 'app_db')?.latencyMs).toBe(4)
 	expect(result.productionCommitSha).toBe(
 		'abc123def4567890abcdef1234567890abcdef12',
+	)
+	expect(result.runtimeCommitSha).toBe(
+		'def4567890abcdef1234567890abcdef12345678',
+	)
+	expect(result.jobsCommitSha).toBe('7890abcdef1234567890abcdef1234567890abcd')
+})
+
+test('apex 302 is not package-runtime up; jobs probe failure is not app-down', async () => {
+	const requested: Array<string> = []
+	const apexRedirect = healthyRoutes()
+	apexRedirect[`${packageAppOrigin}/`] = {
+		status: 302,
+		headers: { Location: 'https://kody.codes/' },
+	}
+	const apexFetcher = fakeFetcher(apexRedirect)
+	const trackingFetcher: typeof fetch = (async (input, init) => {
+		requested.push(typeof input === 'string' ? input : input.toString())
+		return apexFetcher(input, init)
+	}) as typeof fetch
+	const apexResult = await runAllProbes({
+		primaryOrigin,
+		packageAppOrigin,
+		fetcher: trackingFetcher,
+	})
+	expect(requested).not.toContain(`${packageAppOrigin}/`)
+	expect(requested).toContain(runtimeHealth)
+	expect(outcome(apexResult, 'package_apps')?.ok).toBe(true)
+
+	const runtimeRedirect = healthyRoutes()
+	runtimeRedirect[runtimeHealth] = {
+		status: 302,
+		headers: { Location: 'https://kody.codes/' },
+	}
+	const runtimeRedirectOutcomes = await probe(runtimeRedirect)
+	expect(outcome(runtimeRedirectOutcomes, 'package_apps')).toMatchObject({
+		ok: false,
+		detail: 'HTTP 302',
+	})
+	expect(runtimeRedirectOutcomes.runtimeCommitSha).toBeNull()
+	expect(outcome(runtimeRedirectOutcomes, 'app')?.ok).toBe(true)
+
+	const runtimeHtml = healthyRoutes()
+	runtimeHtml[runtimeHealth] = { status: 200, body: { ok: true } }
+	expect(outcome(await probe(runtimeHtml), 'package_apps')).toMatchObject({
+		ok: false,
+		detail: 'HTTP 200',
+	})
+
+	const jobsDown = healthyRoutes()
+	jobsDown[jobsHealth] = { error: 'jobs worker unreachable' }
+	jobsDown[jobsComponents] = { error: 'jobs worker unreachable' }
+	const jobsDownOutcomes = await probe(jobsDown)
+	expect(outcome(jobsDownOutcomes, 'jobs')).toMatchObject({
+		ok: false,
+		detail: 'jobs worker unreachable',
+	})
+	expect(outcome(jobsDownOutcomes, 'app')?.ok).toBe(true)
+	expect(outcome(jobsDownOutcomes, 'mcp')?.ok).toBe(true)
+	expect(outcome(jobsDownOutcomes, 'package_apps')?.ok).toBe(true)
+
+	const jobsDbDown = healthyRoutes()
+	jobsDbDown[jobsComponents] = {
+		status: 503,
+		body: {
+			ok: false,
+			components: [{ id: 'jobs_db', ok: false, error: 'timeout' }],
+		},
+	}
+	const jobsDbOutcomes = await probe(jobsDbDown)
+	expect(outcome(jobsDbOutcomes, 'jobs')).toMatchObject({
+		ok: false,
+		detail: 'timeout',
+	})
+	expect(outcome(jobsDbOutcomes, 'app')?.ok).toBe(true)
+	expect(jobsDbOutcomes.jobsCommitSha).toBe(
+		'7890abcdef1234567890abcdef1234567890abcd',
 	)
 })
 
@@ -131,11 +226,12 @@ test('probe failures isolate to the affected component and map error details', a
 		ok: false,
 		detail: 'unreachable',
 	})
+	expect(outcome(unreachableOutcomes, 'jobs')?.ok).toBe(true)
 
 	for (const status of [521, 404]) {
-		const packageApps = healthyRoutes()
-		packageApps[`${packageAppOrigin}/`] = { status }
-		expect(outcome(await probe(packageApps), 'package_apps')).toMatchObject({
+		const packageRuntime = healthyRoutes()
+		packageRuntime[runtimeHealth] = { status }
+		expect(outcome(await probe(packageRuntime), 'package_apps')).toMatchObject({
 			ok: false,
 			detail: `HTTP ${String(status)}`,
 		})

--- a/packages/status/probes.ts
+++ b/packages/status/probes.ts
@@ -5,21 +5,31 @@ import {
 } from './status-types.ts'
 
 /**
- * Active probes the status worker runs against public endpoints every
- * scheduled tick. Direct probes cover the worker surfaces (app, MCP, package
- * apps); the `/health/components` endpoint on the main worker reports the
- * storage bindings (D1, KV, R2) it depends on.
+ * Active probes the status worker runs every scheduled tick. Direct probes
+ * cover the worker surfaces (app, MCP, package runtime, jobs); the
+ * `/health/components` endpoint on the main worker reports the storage
+ * bindings (D1, KV, R2) it depends on. Jobs is reached over a service
+ * binding (or an optional non-public origin fallback), never through the
+ * main app and never via a user-facing jobs hostname.
  */
 
 const probeTimeoutMs = 10_000
 
+/** Synthetic origin used with the JOBS service binding. Not a public URL. */
+export const jobsProbeOrigin = 'https://kody-jobs.internal'
+
 type ProbeConfig = {
 	primaryOrigin: string
 	packageAppOrigin: string
+	/** Origin used for jobs `/health` and `/health/components`. */
+	jobsOrigin?: string
 	fetcher?: typeof fetch
+	/** When set, used only for jobs probes (service binding). */
+	jobsFetcher?: typeof fetch
 }
 
 type HealthComponentsBody = {
+	ok?: boolean
 	components?: Array<{
 		id?: string
 		ok?: boolean
@@ -65,15 +75,25 @@ async function timedFetch(
 	}
 }
 
-type AppHealthBody = {
+type CommitBody = {
 	ok?: boolean
+	status?: string
 	commitSha?: string
+	commit?: string
 }
 
-function readProductionCommitSha(body: AppHealthBody | null): string | null {
-	const commitSha = body?.commitSha?.trim()
+function readCommitSha(value: string | null | undefined): string | null {
+	const commitSha = value?.trim()
 	if (!commitSha || !/^[0-9a-f]{7,40}$/i.test(commitSha)) return null
 	return commitSha.toLowerCase()
+}
+
+async function readJsonBody<T>(response: Response): Promise<T | null> {
+	try {
+		return (await response.json()) as T
+	} catch {
+		return null
+	}
 }
 
 async function probeApp(
@@ -92,15 +112,8 @@ async function probeApp(
 			productionCommitSha: null,
 		}
 	}
-	let body: AppHealthBody | null = null
-	let bodyOk = false
-	try {
-		body = (await result.response.json()) as AppHealthBody
-		bodyOk = body.ok === true
-	} catch {
-		body = null
-		bodyOk = false
-	}
+	const body = await readJsonBody<CommitBody>(result.response)
+	const bodyOk = body?.ok === true
 	const ok = result.response.ok && bodyOk
 	return {
 		outcome: {
@@ -109,7 +122,7 @@ async function probeApp(
 			latencyMs: result.latencyMs,
 			detail: ok ? null : `HTTP ${result.response.status}`,
 		},
-		productionCommitSha: readProductionCommitSha(body),
+		productionCommitSha: readCommitSha(body?.commitSha),
 	}
 }
 
@@ -139,25 +152,117 @@ async function probeMcp(
 	}
 }
 
-async function probePackageApps(
+async function probePackageRuntime(
 	fetcher: typeof fetch,
 	packageAppOrigin: string,
-): Promise<ProbeOutcome> {
-	const result = await timedFetch(fetcher, `${packageAppOrigin}/`)
+): Promise<{ outcome: ProbeOutcome; runtimeCommitSha: string | null }> {
+	const result = await timedFetch(
+		fetcher,
+		`${packageAppOrigin}/__runtime/health`,
+	)
 	if (!result.response) {
 		return {
-			component: 'package_apps',
-			ok: false,
-			latencyMs: result.latencyMs,
-			detail: result.error,
+			outcome: {
+				component: 'package_apps',
+				ok: false,
+				latencyMs: result.latencyMs,
+				detail: result.error,
+			},
+			runtimeCommitSha: null,
 		}
 	}
-	const ok = result.response.status >= 200 && result.response.status < 400
+	const body = await readJsonBody<CommitBody>(result.response)
+	const ok = result.response.ok && body?.status === 'ok'
 	return {
-		component: 'package_apps',
-		ok,
-		latencyMs: result.latencyMs,
-		detail: ok ? null : `HTTP ${result.response.status}`,
+		outcome: {
+			component: 'package_apps',
+			ok,
+			latencyMs: result.latencyMs,
+			detail: ok ? null : `HTTP ${result.response.status}`,
+		},
+		runtimeCommitSha: readCommitSha(body?.commitSha),
+	}
+}
+
+async function probeJobs(
+	fetcher: typeof fetch,
+	jobsOrigin: string,
+): Promise<{ outcome: ProbeOutcome; jobsCommitSha: string | null }> {
+	const [health, components] = await Promise.all([
+		timedFetch(fetcher, `${jobsOrigin}/health`),
+		timedFetch(fetcher, `${jobsOrigin}/health/components`),
+	])
+	if (!health.response) {
+		return {
+			outcome: {
+				component: 'jobs',
+				ok: false,
+				latencyMs: health.latencyMs,
+				detail: health.error,
+			},
+			jobsCommitSha: null,
+		}
+	}
+	const healthBody = await readJsonBody<CommitBody>(health.response)
+	const healthOk = health.response.ok && healthBody?.ok === true
+	const jobsCommitSha = readCommitSha(healthBody?.commit)
+	if (!healthOk) {
+		return {
+			outcome: {
+				component: 'jobs',
+				ok: false,
+				latencyMs: health.latencyMs,
+				detail: `HTTP ${health.response.status}`,
+			},
+			jobsCommitSha,
+		}
+	}
+	if (!components.response) {
+		return {
+			outcome: {
+				component: 'jobs',
+				ok: false,
+				latencyMs: components.latencyMs,
+				detail: components.error,
+			},
+			jobsCommitSha,
+		}
+	}
+	const componentsBody = await readJsonBody<HealthComponentsBody>(
+		components.response,
+	)
+	const jobsDb = componentsBody?.components?.find(
+		(entry) => entry.id === 'jobs_db',
+	)
+	const componentsOk =
+		components.response.ok &&
+		(componentsBody?.ok === true || jobsDb?.ok === true)
+	if (!componentsOk) {
+		const detail =
+			jobsDb?.ok === false
+				? (jobsDb.error ?? 'error')
+				: `HTTP ${components.response.status}`
+		return {
+			outcome: {
+				component: 'jobs',
+				ok: false,
+				latencyMs:
+					typeof jobsDb?.latencyMs === 'number'
+						? jobsDb.latencyMs
+						: components.latencyMs,
+				detail,
+			},
+			jobsCommitSha,
+		}
+	}
+	return {
+		outcome: {
+			component: 'jobs',
+			ok: true,
+			latencyMs: health.latencyMs,
+			detail: null,
+		},
+		jobsCommitSha,
 	}
 }
 
@@ -174,12 +279,7 @@ async function probeStorageComponents(
 			detail: 'unreachable',
 		}))
 	}
-	let body: HealthComponentsBody | null = null
-	try {
-		body = (await result.response.json()) as HealthComponentsBody
-	} catch {
-		body = null
-	}
+	const body = await readJsonBody<HealthComponentsBody>(result.response)
 	if (!body || !Array.isArray(body.components)) {
 		return componentEndpointIds.map((component) => ({
 			component,
@@ -206,19 +306,30 @@ async function probeStorageComponents(
 export type ProbeRunResult = {
 	outcomes: Array<ProbeOutcome>
 	productionCommitSha: string | null
+	runtimeCommitSha: string | null
+	jobsCommitSha: string | null
 }
 
 export async function runAllProbes(
 	config: ProbeConfig,
 ): Promise<ProbeRunResult> {
 	const fetcher = config.fetcher ?? fetch
-	const [app, mcp, packageApps, storage] = await Promise.all([
+	const jobsFetcher = config.jobsFetcher ?? fetcher
+	const jobsOrigin = config.jobsOrigin ?? jobsProbeOrigin
+	const [app, mcp, packageRuntime, jobs, storage] = await Promise.all([
 		probeApp(fetcher, config.primaryOrigin),
 		probeMcp(fetcher, config.primaryOrigin),
-		probePackageApps(fetcher, config.packageAppOrigin),
+		probePackageRuntime(fetcher, config.packageAppOrigin),
+		probeJobs(jobsFetcher, jobsOrigin),
 		probeStorageComponents(fetcher, config.primaryOrigin),
 	])
-	const outcomes = [app.outcome, mcp, packageApps, ...storage]
+	const outcomes = [
+		app.outcome,
+		mcp,
+		packageRuntime.outcome,
+		jobs.outcome,
+		...storage,
+	]
 	const covered = new Set(outcomes.map((outcome) => outcome.component))
 	for (const component of statusComponentIds) {
 		if (!covered.has(component)) {
@@ -230,5 +341,10 @@ export async function runAllProbes(
 			})
 		}
 	}
-	return { outcomes, productionCommitSha: app.productionCommitSha }
+	return {
+		outcomes,
+		productionCommitSha: app.productionCommitSha,
+		runtimeCommitSha: packageRuntime.runtimeCommitSha,
+		jobsCommitSha: jobs.jobsCommitSha,
+	}
 }

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -1,16 +1,27 @@
 # kody status worker
 
 The public status page for kody, served at
-[status.heykody.dev](https://status.heykody.dev). It is deliberately a separate
+[status.kody.codes](https://status.kody.codes). It is deliberately a separate
 Cloudflare Worker with its own storage so it stays up when the main worker's
 deploys, code, or database are broken (see decision record 0004).
 
+`status.heykody.dev` remains a worker custom domain for legacy links. The worker
+308s GET/HEAD from that host to `status.kody.codes`, except `/health`, which
+stays sticky so deploys can still probe the worker if the canonical hostname
+returns Cloudflare 1016 until DNS exists. Component probes never use the status
+hostname, so a 1016 on `status.kody.codes` does not turn App, MCP, runtime, or
+Jobs red.
+
 ## How it works
 
-- A cron trigger runs one probe pass per minute against public endpoints:
-  `GET /health` and `GET /health/components` on the primary origin, the
-  unauthenticated OAuth challenge on `/mcp`, and the package-app apex
-  (`kody.run`).
+- A cron trigger runs one probe pass per minute:
+  - `GET /health` and `GET /health/components` on the primary origin
+    (`kody.codes`)
+  - the unauthenticated OAuth challenge on `/mcp`
+  - package-runtime liveness `GET /__runtime/health` on `kody.run` (JSON
+    `status: "ok"`; an apex 302 is not up)
+  - jobs-worker `GET /health` and `GET /health/components` over a service
+    binding (no public jobs hostname; JOBS_DB rides on the Jobs component)
 - A single `StatusStore` Durable Object (SQLite) stores per-minute samples (24
   h), daily uptime rollups (90 days), incidents, and sent notifications.
 - A component opens an incident after two consecutive probe failures and
@@ -18,7 +29,8 @@ deploys, code, or database are broken (see decision record 0004).
 - Operator alert emails go to `ALERT_EMAIL_TO` through the Cloudflare Email REST
   API: one email when an outage starts, at most one reminder per day while it
   lasts, one all-clear when everything has recovered, all under a daily cap
-  (`STATUS_ALERT_DAILY_LIMIT`).
+  (`STATUS_ALERT_DAILY_LIMIT`). Alert links use `STATUS_PAGE_URL`
+  (`https://status.kody.codes`).
 
 ## Provider incidents (Cloudflare)
 
@@ -52,3 +64,10 @@ Deployed by `.github/workflows/deploy.yml` (path-filtered job, like the backup
 control plane) with `npm run status:deploy`. The `CLOUDFLARE_API_TOKEN` Worker
 secret (Email Sending permission) is synced at deploy time; without it, alert
 emails are skipped and logged.
+
+Wrangler attaches both `status.kody.codes` and `status.heykody.dev` as custom
+domains. If `status.kody.codes` still returns Cloudflare 1016 after deploy, the
+`kody.codes` zone still needs a `status` DNS record so that custom domain can
+attach. The deploy healthcheck tries the canonical `/health` first and falls
+back to `status.heykody.dev/health`; other component probes do not depend on
+either hostname.

--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -34,6 +34,8 @@ function snapshot(overrides: Partial<StatusSnapshot> = {}): StatusSnapshot {
 		recentIncidents: [],
 		providerIncidents: null,
 		productionCommit: 'abc123def4567890abcdef1234567890abcdef12',
+		runtimeCommit: 'def4567890abcdef1234567890abcdef12345678',
+		jobsCommit: '7890abcdef1234567890abcdef1234567890abcd',
 		...overrides,
 	}
 }
@@ -43,12 +45,24 @@ test('status page renders components, incidents, unknown state, and escapes deta
 	for (const component of statusComponents) {
 		expect(healthy).toContain(component.name.replaceAll('&', '&amp;'))
 	}
+	expect(healthy).toContain('Package runtime')
+	expect(healthy).toContain('Jobs')
 	expect(healthy).toContain('99.98% uptime')
-	expect(healthy).toContain('Production commit')
+	expect(healthy).toContain('Production app')
+	expect(healthy).toContain('runtime')
+	expect(healthy).toContain('jobs')
 	expect(healthy).toContain(
 		'https://github.com/kentcdodds/kody/commit/abc123def4567890abcdef1234567890abcdef12',
 	)
+	expect(healthy).toContain(
+		'https://github.com/kentcdodds/kody/commit/def4567890abcdef1234567890abcdef12345678',
+	)
+	expect(healthy).toContain(
+		'https://github.com/kentcdodds/kody/commit/7890abcdef1234567890abcdef1234567890abcd',
+	)
 	expect(healthy).toContain('>abc123d<')
+	expect(healthy).toContain('>def4567<')
+	expect(healthy).toContain('>7890abc<')
 	expect(healthy).toContain('http-equiv="refresh"')
 	expect(healthy).toMatch(/operational|All systems/i)
 
@@ -132,8 +146,14 @@ test('status page renders provider incidents separately and omits them when abse
 	expect(withProvider).toContain('R2 Availability Issues')
 	expect(withProvider).toContain('https://stspg.io/r2')
 
-	const withoutCommit = renderStatusPage(snapshot({ productionCommit: null }))
-	expect(withoutCommit).not.toContain('Production commit')
+	const withoutCommit = renderStatusPage(
+		snapshot({
+			productionCommit: null,
+			runtimeCommit: null,
+			jobsCommit: null,
+		}),
+	)
+	expect(withoutCommit).not.toContain('Production app')
 
 	const unsafeLink = renderStatusPage(
 		snapshot({

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -230,9 +230,19 @@ function productionCommitLink(commitSha: string): string {
 	return `<a href="${href}">${escapeHtml(shortSha)}</a>`
 }
 
-function renderProductionCommit(commitSha: string | null): string {
-	if (!commitSha) return ''
-	return `Production commit ${productionCommitLink(commitSha)} · `
+function renderProductionCommits(snapshot: StatusSnapshot): string {
+	const parts: Array<string> = []
+	if (snapshot.productionCommit) {
+		parts.push(`app ${productionCommitLink(snapshot.productionCommit)}`)
+	}
+	if (snapshot.runtimeCommit) {
+		parts.push(`runtime ${productionCommitLink(snapshot.runtimeCommit)}`)
+	}
+	if (snapshot.jobsCommit) {
+		parts.push(`jobs ${productionCommitLink(snapshot.jobsCommit)}`)
+	}
+	if (parts.length === 0) return ''
+	return `Production ${parts.join(' · ')} · `
 }
 
 function renderProviderIncidentsSection(
@@ -281,7 +291,7 @@ export function renderStatusPage(snapshot: StatusSnapshot): string {
 	${providerIncidents}
 	${recentIncidents}
 	<footer>
-		${renderProductionCommit(snapshot.productionCommit)}Probes run every minute from an independently deployed worker.
+		${renderProductionCommits(snapshot)}Probes run every minute from an independently deployed worker.
 		<a href="https://kody.codes">kody.codes</a> ·
 		<a href="/status.json">JSON</a>
 	</footer>

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -11,7 +11,7 @@ import {
 	initialComponentProbeState,
 	type ComponentProbeState,
 } from './incidents.ts'
-import { runAllProbes } from './probes.ts'
+import { jobsProbeOrigin, runAllProbes } from './probes.ts'
 import {
 	fetchRelevantProviderIncidents,
 	parseProviderIncidentCache,
@@ -32,9 +32,14 @@ import {
 
 const providerIncidentsMetaKey = 'provider_incidents_cache'
 const productionCommitMetaKey = 'production_commit_sha'
+const runtimeCommitMetaKey = 'runtime_commit_sha'
+const jobsCommitMetaKey = 'jobs_commit_sha'
 
 export type StatusWorkerEnv = {
 	STATUS_STORE: DurableObjectNamespace<StatusStore>
+	JOBS?: Fetcher
+	/** Non-public fallback origin for jobs probes when JOBS is unset. */
+	JOBS_ORIGIN?: string
 	PRIMARY_ORIGIN: string
 	PACKAGE_APP_ORIGIN: string
 	STATUS_PAGE_URL: string
@@ -386,13 +391,25 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 	}
 
 	async runProbes(): Promise<void> {
-		const { outcomes, productionCommitSha } = await runAllProbes({
-			primaryOrigin: this.env.PRIMARY_ORIGIN,
-			packageAppOrigin: this.env.PACKAGE_APP_ORIGIN,
-		})
+		const jobsFetcher = this.env.JOBS
+			? (this.env.JOBS.fetch.bind(this.env.JOBS) as typeof fetch)
+			: undefined
+		const { outcomes, productionCommitSha, runtimeCommitSha, jobsCommitSha } =
+			await runAllProbes({
+				primaryOrigin: this.env.PRIMARY_ORIGIN,
+				packageAppOrigin: this.env.PACKAGE_APP_ORIGIN,
+				jobsOrigin: this.env.JOBS_ORIGIN ?? jobsProbeOrigin,
+				jobsFetcher,
+			})
 		const now = Date.now()
 		if (productionCommitSha) {
 			this.setMeta(productionCommitMetaKey, productionCommitSha)
+		}
+		if (runtimeCommitSha) {
+			this.setMeta(runtimeCommitMetaKey, runtimeCommitSha)
+		}
+		if (jobsCommitSha) {
+			this.setMeta(jobsCommitMetaKey, jobsCommitSha)
 		}
 		for (const outcome of outcomes) {
 			this.recordOutcome(outcome, now)
@@ -422,6 +439,8 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 			recentIncidents: this.listIncidents('resolved'),
 			providerIncidents: this.readProviderIncidents(now),
 			productionCommit: this.getMeta(productionCommitMetaKey),
+			runtimeCommit: this.getMeta(runtimeCommitMetaKey),
+			jobsCommit: this.getMeta(jobsCommitMetaKey),
 		}
 	}
 

--- a/packages/status/status-types.ts
+++ b/packages/status/status-types.ts
@@ -10,7 +10,8 @@ export type { ProviderIncident }
 export const statusComponents = [
 	{ id: 'app', name: 'App & API' },
 	{ id: 'mcp', name: 'MCP endpoint' },
-	{ id: 'package_apps', name: 'Package apps' },
+	{ id: 'package_apps', name: 'Package runtime' },
+	{ id: 'jobs', name: 'Jobs' },
 	{ id: 'app_db', name: 'Primary database' },
 	{ id: 'audit_db', name: 'Audit database' },
 	{ id: 'kv', name: 'Key-value storage' },
@@ -75,4 +76,8 @@ export type StatusSnapshot = {
 	providerIncidents: Array<ProviderIncident> | null
 	/** Latest `commitSha` reported by production `GET /health` (main worker). */
 	productionCommit: string | null
+	/** Latest `commitSha` from `GET /__runtime/health` on the package origin. */
+	runtimeCommit: string | null
+	/** Latest `commit` from jobs-worker `GET /health`. */
+	jobsCommit: string | null
 }

--- a/packages/status/worker.ts
+++ b/packages/status/worker.ts
@@ -1,3 +1,4 @@
+import { getLegacyStatusRedirectResponse } from './legacy-redirect.ts'
 import { renderStatusPage } from './status-page.ts'
 import { StatusStore, type StatusWorkerEnv } from './status-store.ts'
 
@@ -19,6 +20,8 @@ export default {
 				{ headers: { 'Cache-Control': 'no-store' } },
 			)
 		}
+		const legacyRedirect = getLegacyStatusRedirectResponse(request)
+		if (legacyRedirect) return legacyRedirect
 		if (url.pathname === '/' || url.pathname === '/status.json') {
 			// The page must degrade gracefully even when its own Durable Object
 			// is unavailable; a controlled 503 beats an uncaught error page.

--- a/packages/status/wrangler.jsonc
+++ b/packages/status/wrangler.jsonc
@@ -16,8 +16,22 @@
 	// has its own domain and its own Durable Object storage.
 	"routes": [
 		{
+			"pattern": "status.kody.codes",
+			"custom_domain": true,
+		},
+		{
+			// Legacy host: stays attached so /health still works if
+			// status.kody.codes is 1016 until DNS exists. The worker 308s
+			// other GET/HEAD from this host to status.kody.codes.
 			"pattern": "status.heykody.dev",
 			"custom_domain": true,
+		},
+	],
+	"services": [
+		{
+			// Worker-to-worker only. Not a public jobs hostname.
+			"binding": "JOBS",
+			"service": "kody-jobs",
 		},
 	],
 	"durable_objects": {
@@ -37,7 +51,7 @@
 	"vars": {
 		"PRIMARY_ORIGIN": "https://kody.codes",
 		"PACKAGE_APP_ORIGIN": "https://kody.run",
-		"STATUS_PAGE_URL": "https://status.heykody.dev",
+		"STATUS_PAGE_URL": "https://status.kody.codes",
 		"ALERT_EMAIL_TO": "me@kentcdodds.com",
 		"ALERT_EMAIL_FROM": "kody@kody.codes",
 		"STATUS_ALERT_DAILY_LIMIT": "6",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

One public place for status: **status.kody.codes**. Accurate runtime liveness (not the `kody.run` apex redirect), and a Jobs component that can fail without taking App/MCP with it.

## Summary

- Canonical hostname is `status.kody.codes` (wrangler custom domain + `STATUS_PAGE_URL` + alert links + deploy environment URL). `status.heykody.dev` stays attached and **308s** to the canonical host except `/health`, which stays sticky so the worker still serves on `.dev` if the canonical host is 1016 until DNS exists.
- Package runtime probe is `GET https://kody.run/__runtime/health`. Success is JSON `{ status: "ok" }`, not a 302. Card renamed to **Package runtime**. The apex redirect is no longer treated as up.
- **Jobs** component probes `kody-jobs` over a **service binding** (`GET /health` + `GET /health/components` which checks `JOBS_DB`). No public jobs hostname. Jobs DB rides on this card — no extra storage card.
- Footer shows app, runtime, and jobs commit SHAs next to each other.
- Deploy healthcheck tries `status.kody.codes/health` first, then `status.heykody.dev/health`. Other component probes never use the status hostname, so a 1016 on `status.kody.codes` does not turn App/MCP/runtime/Jobs red.

If `status.kody.codes` still returns Cloudflare 1016 after deploy, the `kody.codes` zone still needs a `status` DNS record so the worker custom domain can attach. Wrangler `custom_domain: true` creates that record when the zone is in this Cloudflare account.

Not added: extra public domains, extra storage cards, Vectorize/queues/DO/email-inbound/MCP-split/backup-control-plane.

## Testing

- `npx vitest run --project node-unit packages/status packages/jobs-worker/src/health.node.test.ts`
- `npx tsc --noEmit -p packages/status/tsconfig.json` and jobs-worker
- `npm run status:build` / `npm run jobs:build` (wrangler dry-run; JOBS binding resolves to `kody-jobs`)
- `npm run primitives:check` / `npm run docs:check-temporal`

Covered explicitly: apex 302 is not package-runtime up; jobs probe failure is Jobs-down, not App-down. Two-consecutive-failure incidents and alert email policy are unchanged.

Status worker is not on PR preview deploys (separate production worker), so there is no logged-in preview UI for this change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a3e36e34` · **Head:** `4367c73d`

**Classification:** extends — status-page probe contract, canonical hostname, and jobs-worker health surface change; no new primitives.

### Primitives touched

| Primitive      | Group    | Impact                                                                 |
| -------------- | -------- | ---------------------------------------------------------------------- |
| `status-page`  | surfaces | extends — canonical URL, runtime JSON probe, Jobs card, commit SHAs    |
| `jobs-worker`  | surfaces | extends — `GET /health/components` checks JOBS_DB for the status probe |

Unmatched paths: `.github/workflows/deploy.yml` (status healthcheck fallback), contributing docs / ADR 0004 hostname, `primitives.yaml` summary hostname.

### System map

The status worker observes package-runtime liveness and jobs-worker health independently of the main app, and serves the page at `status.kody.codes`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	statusPage["status-page<br/>Public status page"]:::extended
	jobsWorker["jobs-worker<br/>Jobs worker"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::untouched
	statusPage -->|"GET kody.run/__runtime/health JSON status=ok"| packageRuntime
	statusPage -->|"JOBS service binding /health and /health/components"| jobsWorker
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| Public URL | `status.heykody.dev` | `status.kody.codes` (`.dev` 308s, `/health` sticky) |
| Runtime card | `GET kody.run/` 2xx/3xx (apex 302 = up) | `GET kody.run/__runtime/health` JSON liveness |
| Jobs | not on the page | Jobs card via service binding; JOBS_DB included |
| Commits | main worker SHA | app · runtime · jobs SHAs |

### Invariants

Per-user isolation is not implicated: the status worker still holds no user state and no `APP_DB` access (ADR 0004). Jobs is probed without going through the main app, so a jobs outage is not hidden behind App/MCP.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c94ad652-872c-476f-afee-1c0879771511?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c94ad652-872c-476f-afee-1c0879771511&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `status.kody.codes` as the canonical status-page address.
  * Added automatic redirects from the legacy status address while preserving health-check access.
  * Expanded status monitoring to include runtime and jobs-worker health, database checks, and commit details.
  * Status pages now display separate application, runtime, and jobs-worker version information.

* **Bug Fixes**
  * Improved health-check fallback behavior and failure reporting.

* **Tests**
  * Added coverage for redirects, health checks, service failures, and database errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->