### PR TITLE
fix(packages): extract default-export bindings and one-hop imported types

### DIFF
--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -799,3 +799,308 @@ export function run(huge: HugeInput, small: SmallInput): string {
 		},
 	])
 })
+
+test('buildPackageSearchProjection follows local default-export bindings and one-hop imported types', () => {
+	const spotifyManifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/spotify-like-tools',
+			exports: {
+				'./search': './src/search.ts',
+			},
+			kody: {
+				id: 'spotify-like-tools',
+				description: 'Spotify-like thin-export package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+
+	const spotifyProjection = buildPackageSearchProjection(spotifyManifest, {
+		'src/search.ts': `import type { SearchParams } from '../lib/export-types.ts'
+import { searchCatalog } from '../lib/search-catalog.ts'
+
+/**
+ * Search the Spotify catalog.
+ */
+async function spotifySearch(params: SearchParams = {}) {
+	return await searchCatalog(params)
+}
+
+export default spotifySearch
+`,
+		'lib/export-types.ts': `import type { PagingParams } from './paging.ts'
+
+export type SearchParams = {
+	q?: string
+	types?: Array<'album' | 'artist' | 'track'>
+	limit?: number
+	paging?: PagingParams
+}
+
+export type UnrelatedExportType = {
+	ignored: boolean
+}
+`,
+		'lib/paging.ts': `export type PagingParams = {
+	offset?: number
+}
+`,
+		'lib/search-catalog.ts': `export async function searchCatalog(params: { q?: string }) {
+	return params
+}
+`,
+	})
+
+	const [spotifyExport] = spotifyProjection.exports
+	expect(spotifyExport).toMatchObject({
+		subpath: './search',
+		runtimeTarget: 'src/search.ts',
+		description: 'Search the Spotify catalog.',
+		typeDefinition:
+			'export default async function spotifySearch(params: SearchParams = {})',
+	})
+	expect(spotifyExport?.functions).toEqual([
+		expect.objectContaining({
+			name: 'default',
+			description: 'Search the Spotify catalog.',
+			typeDefinition:
+				'export default async function spotifySearch(params: SearchParams = {})',
+		}),
+	])
+	expect(spotifyExport?.referencedTypes.map((type) => type.name)).toEqual([
+		'SearchParams',
+	])
+	expect(spotifyExport?.referencedTypes[0]?.kind).toBe('type')
+	expect(spotifyExport?.referencedTypes[0]?.definition).toContain('q?: string')
+	expect(spotifyExport?.referencedTypes.map((type) => type.name)).not.toContain(
+		'PagingParams',
+	)
+	expect(spotifyExport?.referencedTypes.map((type) => type.name)).not.toContain(
+		'UnrelatedExportType',
+	)
+
+	const inlineDefaultManifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/inline-default-tools',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'inline-default-tools',
+				description: 'Inline default export package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	const inlineDefaultProjection = buildPackageSearchProjection(
+		inlineDefaultManifest,
+		{
+			'src/index.ts': `/**
+ * Look up a city forecast.
+ */
+export default async function forecast(city: string): Promise<string> {
+	return city
+}
+`,
+		},
+	)
+	expect(inlineDefaultProjection.exports[0]).toMatchObject({
+		description: 'Look up a city forecast.',
+		typeDefinition:
+			'export default async function forecast(city: string): Promise<string>',
+		functions: [
+			expect.objectContaining({
+				name: 'default',
+				description: 'Look up a city forecast.',
+			}),
+		],
+	})
+
+	const namedAndLocalTypeManifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/named-local-type-tools',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'named-local-type-tools',
+				description: 'Named export with a same-file type',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	const namedAndLocalTypeProjection = buildPackageSearchProjection(
+		namedAndLocalTypeManifest,
+		{
+			'src/index.ts': `export type ForecastInput = {
+	city: string
+}
+
+/**
+ * Look up a city forecast.
+ */
+export async function forecast(input: ForecastInput): Promise<string> {
+	return input.city
+}
+`,
+		},
+	)
+	expect(namedAndLocalTypeProjection.exports[0]?.functions[0]).toMatchObject({
+		name: 'forecast',
+		description: 'Look up a city forecast.',
+		typeDefinition:
+			'export async function forecast(input: ForecastInput): Promise<string>',
+	})
+	expect(
+		namedAndLocalTypeProjection.exports[0]?.referencedTypes.map(
+			(type) => type.name,
+		),
+	).toEqual(['ForecastInput'])
+
+	const specifierImportManifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/imported-type-variants',
+			exports: {
+				'./inline-type': './src/inline-type.ts',
+				'./value-type': './src/value-type.ts',
+				'./arrow-default': './src/arrow-default.ts',
+			},
+			kody: {
+				id: 'imported-type-variants',
+				description: 'Imported type specifier variants',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	const specifierImportProjection = buildPackageSearchProjection(
+		specifierImportManifest,
+		{
+			'src/inline-type.ts': `import { type SearchParams } from '../lib/export-types.ts'
+
+/**
+ * Search with an inline type import.
+ */
+export default async function search(params: SearchParams = {}) {
+	return params
+}
+`,
+			'src/value-type.ts': `import { SearchParams } from '../lib/export-types'
+
+/**
+ * Search with a value import used only as a type.
+ */
+export async function search(params: SearchParams = {}): Promise<SearchParams> {
+	return params
+}
+`,
+			'src/arrow-default.ts': `import type { SearchParams } from '../lib/export-types.ts'
+
+/**
+ * Search with a local arrow binding.
+ */
+const search = async (params: SearchParams = {}) => params
+
+export default search
+`,
+			'lib/export-types.ts': `export type SearchParams = {
+	q?: string
+}
+`,
+		},
+	)
+	const bySubpath = Object.fromEntries(
+		specifierImportProjection.exports.map((exportDetail) => [
+			exportDetail.subpath,
+			exportDetail,
+		]),
+	)
+	expect(bySubpath['./inline-type']?.description).toBe(
+		'Search with an inline type import.',
+	)
+	expect(
+		bySubpath['./inline-type']?.referencedTypes.map((type) => type.name),
+	).toEqual(['SearchParams'])
+	expect(bySubpath['./value-type']?.functions[0]).toMatchObject({
+		name: 'search',
+		description: 'Search with a value import used only as a type.',
+	})
+	expect(
+		bySubpath['./value-type']?.referencedTypes.map((type) => type.name),
+	).toEqual(['SearchParams'])
+	expect(bySubpath['./arrow-default']).toMatchObject({
+		description: 'Search with a local arrow binding.',
+		typeDefinition:
+			'export default async function search(params: SearchParams = {}): unknown',
+	})
+	expect(
+		bySubpath['./arrow-default']?.referencedTypes.map((type) => type.name),
+	).toEqual(['SearchParams'])
+
+	const jsDocFallbackManifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/jsdoc-fallback-tools',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'jsdoc-fallback-tools',
+				description: 'JSDoc fallback on export default',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	const jsDocFallbackProjection = buildPackageSearchProjection(
+		jsDocFallbackManifest,
+		{
+			'src/index.ts': `async function search(query: string) {
+	return query
+}
+
+/**
+ * Docs live on the export default line.
+ */
+export default search
+`,
+		},
+	)
+	expect(jsDocFallbackProjection.exports[0]).toMatchObject({
+		description: 'Docs live on the export default line.',
+		typeDefinition: 'export default async function search(query: string)',
+	})
+
+	const reexportManifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/reexport-tools',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'reexport-tools',
+				description: 'Imported value re-export package',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	const reexportProjection = buildPackageSearchProjection(reexportManifest, {
+		'src/index.ts': `import foo from './other.ts'
+
+/**
+ * Should not be attributed to an imported re-export.
+ */
+export default foo
+`,
+		'src/other.ts': `/**
+ * Implemented in another module.
+ */
+export default async function foo(params: { q: string }) {
+	return params
+}
+`,
+	})
+	expect(reexportProjection.exports[0]).toMatchObject({
+		description: null,
+		typeDefinition: null,
+		functions: [],
+		referencedTypes: [],
+	})
+})

--- a/packages/worker/src/package-registry/manifest.node.test.ts
+++ b/packages/worker/src/package-registry/manifest.node.test.ts
@@ -1103,4 +1103,44 @@ export default async function foo(params: { q: string }) {
 		functions: [],
 		referencedTypes: [],
 	})
+
+	const namedPlusDefaultManifest = parseAuthoredPackageJson({
+		content: JSON.stringify({
+			name: '@kentcdodds/named-plus-default-tools',
+			exports: {
+				'.': './src/index.ts',
+			},
+			kody: {
+				id: 'named-plus-default-tools',
+				description: 'Named export also re-exported as default',
+			},
+		}),
+		manifestPath: 'package.json',
+	})
+	const namedPlusDefaultProjection = buildPackageSearchProjection(
+		namedPlusDefaultManifest,
+		{
+			'src/index.ts': `/**
+ * Look up a city forecast.
+ */
+export async function forecast(city: string): Promise<string> {
+	return city
+}
+
+export default forecast
+`,
+		},
+	)
+	expect(namedPlusDefaultProjection.exports[0]).toMatchObject({
+		description: 'Look up a city forecast.',
+		typeDefinition:
+			'export async function forecast(city: string): Promise<string>',
+		functions: [
+			expect.objectContaining({
+				name: 'forecast',
+				description: 'Look up a city forecast.',
+			}),
+		],
+	})
+	expect(namedPlusDefaultProjection.exports[0]?.functions).toHaveLength(1)
 })

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -965,7 +965,10 @@ function collectLocalFunctionBindings(body: Array<ModuleAstNode>) {
 		}
 	}
 	for (const statement of body) {
-		if (isFunctionDeclaration(statement)) {
+		if (
+			getNodeType(statement) === 'FunctionDeclaration' ||
+			getNodeType(statement) === 'TSDeclareFunction'
+		) {
 			addFunctionDeclaration(statement, getNodeStart(statement))
 			continue
 		}
@@ -973,7 +976,7 @@ function collectLocalFunctionBindings(body: Array<ModuleAstNode>) {
 			addVariableDeclaration(statement, getNodeStart(statement))
 			continue
 		}
-		if (statement.type !== 'ExportNamedDeclaration') continue
+		if (getNodeType(statement) !== 'ExportNamedDeclaration') continue
 		const declaration = (statement as { declaration?: unknown }).declaration as
 			| ModuleAstNode
 			| undefined
@@ -1196,7 +1199,7 @@ function collectExportedFunctionsFromSource(input: {
 							)
 						: [],
 				})
-			} else if (getNodeType(declaration) === 'Identifier') {
+			} else if (declaration && getNodeType(declaration) === 'Identifier') {
 				const projected = projectDefaultExportIdentifier({
 					source,
 					statement,

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -634,6 +634,27 @@ function collectTypeReferenceNamesFromNodes(nodes: Array<unknown>) {
 	return names
 }
 
+function getParamTypeAnnotationNodes(param: unknown): Array<unknown> {
+	if (!param || typeof param !== 'object') return []
+	const nodes: Array<unknown> = []
+	const typeAnnotation = (param as { typeAnnotation?: unknown }).typeAnnotation
+	if (typeAnnotation) nodes.push(typeAnnotation)
+	const type = getNodeType(param)
+	if (type === 'AssignmentPattern') {
+		nodes.push(
+			...getParamTypeAnnotationNodes((param as { left?: unknown }).left),
+		)
+	}
+	if (type === 'RestElement') {
+		nodes.push(
+			...getParamTypeAnnotationNodes(
+				(param as { argument?: unknown }).argument,
+			),
+		)
+	}
+	return nodes
+}
+
 function getFunctionReferenceNodes(
 	node: unknown,
 	options: { includeTypeParameters?: boolean } = {},
@@ -648,9 +669,7 @@ function getFunctionReferenceNodes(
 		...((options.includeTypeParameters ?? true)
 			? [functionNode.typeParameters]
 			: []),
-		...params.map(
-			(param) => (param as { typeAnnotation?: unknown }).typeAnnotation,
-		),
+		...params.flatMap(getParamTypeAnnotationNodes),
 		functionNode.returnType,
 	]
 }
@@ -786,7 +805,7 @@ function getReturnType(source: string, node: unknown) {
 function getVariableFunctionSignature(input: {
 	source: string
 	declarator: ModuleAstNode
-	exportKind: 'export' | 'export declare'
+	exportKind: 'export' | 'export declare' | 'export default'
 }) {
 	const id = (input.declarator as { id?: unknown }).id
 	const name = readIdentifierName(id)
@@ -795,7 +814,9 @@ function getVariableFunctionSignature(input: {
 	const typeStart = getNodeStart(typeAnnotation)
 	const typeEnd = getNodeEnd(typeAnnotation)
 	if (typeStart != null && typeEnd != null) {
-		return `${input.exportKind} const ${name}${input.source.slice(typeStart, typeEnd)}`
+		return input.exportKind === 'export default'
+			? `${input.exportKind} ${name}${input.source.slice(typeStart, typeEnd)}`
+			: `${input.exportKind} const ${name}${input.source.slice(typeStart, typeEnd)}`
 	}
 	const init = (input.declarator as { init?: unknown }).init as
 		| ModuleAstNode
@@ -844,7 +865,285 @@ function getVariableDeclarationExportKind(
 		: 'export'
 }
 
-function collectExportedFunctionsFromSource(source: string) {
+type LocalFunctionBinding = {
+	kind: 'function' | 'variable'
+	node: ModuleAstNode
+	jsDocStart: number | null
+}
+
+type ImportedTypeSpecifier = {
+	localName: string
+	importedName: string
+	moduleSpecifier: string
+}
+
+function dirnamePackagePath(filePath: string) {
+	const normalized = normalizePackageWorkspacePath(filePath)
+	const separator = normalized.lastIndexOf('/')
+	return separator === -1 ? '' : normalized.slice(0, separator)
+}
+
+function normalizeRelativePackagePath(path: string) {
+	const parts: Array<string> = []
+	for (const segment of path.replace(/\\/g, '/').split('/')) {
+		if (!segment || segment === '.') continue
+		if (segment === '..') {
+			parts.pop()
+			continue
+		}
+		parts.push(segment)
+	}
+	return parts.join('/')
+}
+
+function resolveSamePackageTypeImportPath(input: {
+	files: Record<string, string>
+	fromPath: string
+	specifier: string
+}) {
+	if (!input.specifier.startsWith('./') && !input.specifier.startsWith('../')) {
+		return null
+	}
+	const fromDir = dirnamePackagePath(input.fromPath)
+	const resolved = normalizeRelativePackagePath(
+		fromDir ? `${fromDir}/${input.specifier}` : input.specifier,
+	)
+	const candidates = [resolved]
+	if (!resolved.endsWith('.ts')) {
+		candidates.push(`${resolved}.ts`)
+	}
+	return candidates.find((candidate) => input.files[candidate] != null) ?? null
+}
+
+function collectImportedBindingNames(body: Array<ModuleAstNode>) {
+	const names = new Set<string>()
+	for (const statement of body) {
+		if (statement.type !== 'ImportDeclaration') continue
+		const specifiers = (statement as { specifiers?: unknown }).specifiers
+		if (!Array.isArray(specifiers)) continue
+		for (const specifier of specifiers) {
+			const localName = readIdentifierName(
+				(specifier as { local?: unknown }).local,
+			)
+			if (localName) names.add(localName)
+		}
+	}
+	return names
+}
+
+function collectLocalFunctionBindings(body: Array<ModuleAstNode>) {
+	const bindings = new Map<string, LocalFunctionBinding>()
+	function addFunctionDeclaration(
+		declaration: ModuleAstNode,
+		jsDocStart: number | null,
+	) {
+		const name = readIdentifierName((declaration as { id?: unknown }).id)
+		if (!name || bindings.has(name)) return
+		bindings.set(name, {
+			kind: 'function',
+			node: declaration,
+			jsDocStart,
+		})
+	}
+	function addVariableDeclaration(
+		declaration: ModuleAstNode,
+		jsDocStart: number | null,
+	) {
+		const declarations = (declaration as { declarations?: unknown })
+			.declarations
+		if (!Array.isArray(declarations)) return
+		for (const declarator of (declarations as Array<ModuleAstNode>).filter(
+			isFunctionDeclarator,
+		)) {
+			const name = readIdentifierName((declarator as { id?: unknown }).id)
+			if (!name || bindings.has(name)) continue
+			bindings.set(name, {
+				kind: 'variable',
+				node: declarator,
+				jsDocStart,
+			})
+		}
+	}
+	for (const statement of body) {
+		if (isFunctionDeclaration(statement)) {
+			addFunctionDeclaration(statement, getNodeStart(statement))
+			continue
+		}
+		if (getNodeType(statement) === 'VariableDeclaration') {
+			addVariableDeclaration(statement, getNodeStart(statement))
+			continue
+		}
+		if (statement.type !== 'ExportNamedDeclaration') continue
+		const declaration = (statement as { declaration?: unknown }).declaration as
+			| ModuleAstNode
+			| undefined
+		if (isFunctionDeclaration(declaration)) {
+			addFunctionDeclaration(
+				declaration,
+				getNodeStart(declaration) ?? getNodeStart(statement),
+			)
+			continue
+		}
+		if (declaration && getNodeType(declaration) === 'VariableDeclaration') {
+			addVariableDeclaration(
+				declaration,
+				getNodeStart(declaration) ?? getNodeStart(statement),
+			)
+		}
+	}
+	return bindings
+}
+
+function readImportSourceSpecifier(node: ModuleAstNode) {
+	const value = (node as { source?: { value?: unknown } }).source?.value
+	return typeof value === 'string' && value.trim() ? value : null
+}
+
+function collectImportedTypeSpecifiers(body: Array<ModuleAstNode>) {
+	const specifiers: Array<ImportedTypeSpecifier> = []
+	for (const statement of body) {
+		if (statement.type !== 'ImportDeclaration') continue
+		const moduleSpecifier = readImportSourceSpecifier(statement)
+		if (
+			!moduleSpecifier ||
+			(!moduleSpecifier.startsWith('./') && !moduleSpecifier.startsWith('../'))
+		) {
+			continue
+		}
+		const rawSpecifiers = (statement as { specifiers?: unknown }).specifiers
+		if (!Array.isArray(rawSpecifiers)) continue
+		for (const specifier of rawSpecifiers) {
+			if (getNodeType(specifier) !== 'ImportSpecifier') continue
+			const localName = readIdentifierName(
+				(specifier as { local?: unknown }).local,
+			)
+			if (!localName) continue
+			const importedName =
+				readIdentifierName((specifier as { imported?: unknown }).imported) ??
+				localName
+			specifiers.push({
+				localName,
+				importedName,
+				moduleSpecifier,
+			})
+		}
+	}
+	return specifiers
+}
+
+function remapAliasedImportedType(input: {
+	localTypes: Map<string, LocalTypeDeclaration>
+	specifier: ImportedTypeSpecifier
+}) {
+	if (input.specifier.importedName === input.specifier.localName) return
+	if (input.localTypes.has(input.specifier.localName)) return
+	const declaration = input.localTypes.get(input.specifier.importedName)
+	if (!declaration) return
+	input.localTypes.set(input.specifier.localName, {
+		...declaration,
+		name: input.specifier.localName,
+	})
+}
+
+function createImportedTypeMerger(input: {
+	sourcePath: string | null
+	files?: Record<string, string>
+	body: Array<ModuleAstNode>
+	localTypes: Map<string, LocalTypeDeclaration>
+}) {
+	const importedSpecifiers = collectImportedTypeSpecifiers(input.body)
+	const resolvedModules = new Set<string>()
+	return (typeNames: Array<string>) => {
+		if (!input.sourcePath || !input.files || typeNames.length === 0) return
+		for (const specifier of importedSpecifiers) {
+			if (!typeNames.includes(specifier.localName)) continue
+			if (!resolvedModules.has(specifier.moduleSpecifier)) {
+				const resolvedPath = resolveSamePackageTypeImportPath({
+					files: input.files,
+					fromPath: input.sourcePath,
+					specifier: specifier.moduleSpecifier,
+				})
+				if (!resolvedPath) continue
+				const importedSource = input.files[resolvedPath]
+				if (importedSource == null) continue
+				let importedBody: Array<ModuleAstNode>
+				try {
+					importedBody = getProgramBody(parseModuleSource(importedSource))
+				} catch {
+					continue
+				}
+				resolvedModules.add(specifier.moduleSpecifier)
+				for (const [name, declaration] of collectLocalTypeDeclarations(
+					importedSource,
+					importedBody,
+				)) {
+					if (!input.localTypes.has(name)) {
+						input.localTypes.set(name, declaration)
+					}
+				}
+			}
+			remapAliasedImportedType({
+				localTypes: input.localTypes,
+				specifier,
+			})
+		}
+	}
+}
+
+function projectDefaultExportIdentifier(input: {
+	source: string
+	statement: ModuleAstNode
+	declaration: ModuleAstNode
+	localFunctions: Map<string, LocalFunctionBinding>
+	importedBindings: Set<string>
+	referencedTypesFor: (
+		typeNames: Array<string>,
+	) => Array<PackageReferencedTypeProjection>
+}): PackageExportFunctionProjection | null {
+	const name = readIdentifierName(input.declaration)
+	if (!name || input.importedBindings.has(name)) return null
+	const binding = input.localFunctions.get(name)
+	if (!binding) return null
+	const typeDefinition =
+		binding.kind === 'function'
+			? getFunctionSignature({
+					source: input.source,
+					node: binding.node,
+					exportKeyword: 'export default',
+				})
+			: getVariableFunctionSignature({
+					source: input.source,
+					declarator: binding.node,
+					exportKind: 'export default',
+				})
+	const typeNames = typeDefinition
+		? collectTypeReferenceNamesFromNodes(
+				binding.kind === 'function'
+					? getFunctionReferenceNodes(binding.node)
+					: getVariableFunctionReferenceNodes(binding.node),
+			)
+		: []
+	const bindingJsDoc =
+		binding.jsDocStart == null
+			? null
+			: readLeadingJsDoc(input.source, binding.jsDocStart)
+	const exportStart = getNodeStart(input.statement)
+	const exportJsDoc =
+		exportStart == null ? null : readLeadingJsDoc(input.source, exportStart)
+	return {
+		name: 'default',
+		description: bindingJsDoc ?? exportJsDoc,
+		typeDefinition,
+		referencedTypes: typeDefinition ? input.referencedTypesFor(typeNames) : [],
+	}
+}
+
+function collectExportedFunctionsFromSource(input: {
+	source: string
+	files?: Record<string, string>
+	sourcePath?: string | null
+}) {
+	const { source } = input
 	let body: Array<ModuleAstNode>
 	try {
 		body = getProgramBody(parseModuleSource(source))
@@ -852,6 +1151,21 @@ function collectExportedFunctionsFromSource(source: string) {
 		return []
 	}
 	const localTypes = collectLocalTypeDeclarations(source, body)
+	const localFunctions = collectLocalFunctionBindings(body)
+	const importedBindings = collectImportedBindingNames(body)
+	const mergeImportedTypes = createImportedTypeMerger({
+		sourcePath: input.sourcePath ?? null,
+		files: input.files,
+		body,
+		localTypes,
+	})
+	function referencedTypesFor(typeNames: Array<string>) {
+		mergeImportedTypes(typeNames)
+		return collectReferencedTypes({
+			typeNames,
+			localTypes,
+		})
+	}
 	const functions: Array<PackageExportFunctionProjection> = []
 	for (const statement of body) {
 		if (statement.type === 'ExportDefaultDeclaration') {
@@ -875,14 +1189,23 @@ function collectExportedFunctionsFromSource(source: string) {
 							: readLeadingJsDoc(source, getNodeStart(statement) ?? 0)),
 					typeDefinition,
 					referencedTypes: typeDefinition
-						? collectReferencedTypes({
-								typeNames: collectTypeReferenceNamesFromNodes(
+						? referencedTypesFor(
+								collectTypeReferenceNamesFromNodes(
 									getFunctionReferenceNodes(declaration),
 								),
-								localTypes,
-							})
+							)
 						: [],
 				})
+			} else if (getNodeType(declaration) === 'Identifier') {
+				const projected = projectDefaultExportIdentifier({
+					source,
+					statement,
+					declaration,
+					localFunctions,
+					importedBindings,
+					referencedTypesFor,
+				})
+				if (projected) functions.push(projected)
 			}
 			continue
 		}
@@ -906,12 +1229,11 @@ function collectExportedFunctionsFromSource(source: string) {
 				description,
 				typeDefinition,
 				referencedTypes: typeDefinition
-					? collectReferencedTypes({
-							typeNames: collectTypeReferenceNamesFromNodes(
+					? referencedTypesFor(
+							collectTypeReferenceNamesFromNodes(
 								getFunctionReferenceNodes(declaration),
 							),
-							localTypes,
-						})
+						)
 					: [],
 			})
 			continue
@@ -938,12 +1260,11 @@ function collectExportedFunctionsFromSource(source: string) {
 				description,
 				typeDefinition,
 				referencedTypes: typeDefinition
-					? collectReferencedTypes({
-							typeNames: collectTypeReferenceNamesFromNodes(
+					? referencedTypesFor(
+							collectTypeReferenceNamesFromNodes(
 								getVariableFunctionReferenceNodes(declarator),
 							),
-							localTypes,
-						})
+						)
 					: [],
 			})
 		}
@@ -964,9 +1285,19 @@ function summarizePackageExport(input: {
 	const typesSource = typesPath
 		? (input.files?.[normalizePackageWorkspacePath(typesPath)] ?? null)
 		: null
-	const functions = collectExportedFunctionsFromSource(
-		typesSource ?? runtimeSource ?? '',
-	)
+	const source = typesSource ?? runtimeSource ?? ''
+	const sourcePath = typesSource
+		? typesPath
+			? normalizePackageWorkspacePath(typesPath)
+			: null
+		: runtimeTarget
+			? normalizePackageWorkspacePath(runtimeTarget)
+			: null
+	const functions = collectExportedFunctionsFromSource({
+		source,
+		files: input.files,
+		sourcePath,
+	})
 	const [firstFunction] = functions
 	return {
 		subpath: normalizePackageExportKey(input.exportName),

--- a/packages/worker/src/package-registry/manifest.ts
+++ b/packages/worker/src/package-registry/manifest.ts
@@ -915,6 +915,35 @@ function resolveSamePackageTypeImportPath(input: {
 	return candidates.find((candidate) => input.files[candidate] != null) ?? null
 }
 
+function hasNamedExportedFunction(body: Array<ModuleAstNode>, name: string) {
+	for (const statement of body) {
+		if (getNodeType(statement) !== 'ExportNamedDeclaration') continue
+		const declaration = (statement as { declaration?: unknown }).declaration as
+			| ModuleAstNode
+			| undefined
+		if (isFunctionDeclaration(declaration)) {
+			if (readIdentifierName((declaration as { id?: unknown }).id) === name) {
+				return true
+			}
+			continue
+		}
+		if (!declaration || getNodeType(declaration) !== 'VariableDeclaration') {
+			continue
+		}
+		const declarations = (declaration as { declarations?: unknown })
+			.declarations
+		if (!Array.isArray(declarations)) continue
+		for (const declarator of (declarations as Array<ModuleAstNode>).filter(
+			isFunctionDeclarator,
+		)) {
+			if (readIdentifierName((declarator as { id?: unknown }).id) === name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 function collectImportedBindingNames(body: Array<ModuleAstNode>) {
 	const names = new Set<string>()
 	for (const statement of body) {
@@ -1200,6 +1229,10 @@ function collectExportedFunctionsFromSource(input: {
 						: [],
 				})
 			} else if (declaration && getNodeType(declaration) === 'Identifier') {
+				const bindingName = readIdentifierName(declaration)
+				if (bindingName && hasNamedExportedFunction(body, bindingName)) {
+					continue
+				}
 				const projected = projectDefaultExportIdentifier({
 					source,
 					statement,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close the **platform** half of #1403: after #1401 / #1430, `package_get` still projected null description / `type_definition` for thin-export packages like `@kentcdodds/spotify`. Those packages write `export default foo` with JSDoc and types on a same-file function, and import param types from a sibling file.

This does **not** close #1403. Remaining package-side work (strict unknown-key rejection, host-side auth refresh) stays there. `@kentcdodds/spotify` is not in this tree and is not rewritten here.

## Summary

- Follow `export default foo` when `foo` is a same-file `FunctionDeclaration` or `const foo = async (…) =>` / function expression.
- Use that function's signature as `typeDefinition` (`export default …`).
- Prefer JSDoc immediately above the local function; fall back to JSDoc above `export default`.
- Do **not** invent a contract for `import foo from './other'; export default foo`.
- Skip `export default foo` when `foo` is already a named export, so `package_get` keeps a single `type_definition` (Bugbot).
- One-hop relative `import type` / `import { type X }` / `import { X }` used as a type: resolve `.ts` / specifier-as-written / with extension against the current export file, parse that one file, and merge its local type/interface/enum declarations into `localTypes` for `collectReferencedTypes`.
- Also read type annotations on default parameters (`params: SearchParams = {}`), which the Spotify pattern uses.
- Existing caps unchanged (`maxReferencedTypesPerExport = 8`, char/depth limits). No module-graph walk. No runtime function import following.

## Testing

- `npx vitest run packages/worker/src/package-registry/manifest.node.test.ts` — 6 passed.
- Worker typecheck passed.
- New cases: Spotify-style default-export binding + imported `SearchParams`; `import { type X }` / `import { X }` / extensionless specifier; inline `export default async function`; named export + same-file `export type`; imported value re-export still has a null contract; named+default keeps the named contract.

CodeRabbit nits (`.js`/index candidates, `: unknown` suffix alignment, rest-param fixture, sourcePath tidy) left as-is — out of the requested scope.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `47fde327` · **Head:** `d770ceea`

**Classification:** extends — the saved-package search projection now follows local default-export bindings and one-hop imported types; `package_get` / search documents pick that up with no API shape change.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `saved-packages` | assistant | extends — `buildPackageSearchProjection` extracts `export default foo` contracts and one-hop imported type definitions |

The classifier also matches `webhooks` because it owns `packages/worker/src/package-registry/`; this diff does not change webhook listing or dispatch.

### System map

`package_get` and package search still read `buildPackageSearchProjection`; this PR only deepens what that projection can extract from package source.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	savedPackages -->|"description / typeDefinition / referencedTypes"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	source["Export file: async function foo; export default foo"] --> bind["Resolve local function + JSDoc"]
	source --> types["Type names on the signature"]
	types --> hop["One-hop relative import type file"]
	bind --> projection["PackageExportProjection"]
	hop --> projection
```

### Before / after

**Before** (`export default spotifySearch` + `import type { SearchParams }`):

- `description`: `null`
- `typeDefinition`: `null`
- `referencedTypes`: `[]`

**After:**

- `description`: JSDoc from the local function
- `typeDefinition`: `export default async function spotifySearch(params: SearchParams = {})`
- `referencedTypes`: `SearchParams` with its sibling-file definition

Named `export function foo` plus `export default foo` still projects only the named contract.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cd38dcb-06fd-49e6-972b-40d87c365627?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cd38dcb-06fd-49e6-972b-40d87c365627&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Package search results now provide more complete information for default, named, and variable exports.
  - Export signatures better include types referenced in parameters, including rest and default parameters.
  - Cross-file, aliased, imported, and re-exported type references are resolved more accurately.
  - Search projections can include function signatures, documentation descriptions, and related type information.

- **Tests**
  - Added comprehensive coverage for export analysis, documentation metadata, and type-resolution scenarios across local and imported definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->