### PR TITLE
Fix reload/refresh scroll restoration on the marketing homepage

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -457,7 +457,7 @@ This is an intentional design decision, not an oversight. The exfiltration
 concern (XSS or a stolen session reading the owner's secrets) is mitigated by:
 
 - the strict first-party `Content-Security-Policy` (`script-src 'self'`, no
-  inline scripts) plus `HttpOnly` + `SameSite=Lax` session cookies (see
+  `'unsafe-inline'`) plus `HttpOnly` + `SameSite=Lax` session cookies (see
   `docs/contributing/security.md`), which make script-injection theft hard
 - decryption at rest and per-user scoping on every read
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -200,15 +200,18 @@ A thin top-of-viewport **navigation progress bar** listens for `navigationstart`
 / `navigationend` on `routerEvents` and appears only when a navigation is still
 pending after a short delay.
 
-The app shell also mounts **scroll restoration** for SPA navigations. The router
-saves each history entry's window scroll position, restores it on back/forward,
-scrolls to hash targets when present, and otherwise scrolls new navigations to
-the top after the destination route commits. Same-document hash links (for
+The app shell also mounts **scroll restoration**. Each history entry's
+`window.scrollY` is stored in `sessionStorage` keyed by `history.state.key` (the
+same `{ [key]: y }` map React Router uses). A blocking inline script in the SSR
+document body restores that Y before first paint on a full document load, so a
+refresh does not flash the top of the page. `history.scrollRestoration` is
+`manual` so the browser does not fight the restorer. SPA back/forward still
+restores the saved position, hash targets scroll into view, and new navigations
+go to the top after the destination route commits. Same-document hash links (for
 example the landing page's `#invite` waitlist CTA) are intercepted like other
-same-origin links so restoration can scroll to the target — native fragment
-scrolling is disabled while history scroll restoration is `manual`. Preserve the
-current scroll for a specific intercepted link or form with
-`data-prevent-scroll-reset`, or for programmatic navigation with
+same-origin links so restoration can scroll to the target. Preserve the current
+scroll for a specific intercepted link or form with `data-prevent-scroll-reset`,
+or for programmatic navigation with
 `navigate(to, { preventScrollReset: true })`.
 
 Full page navigations occur for:

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -19,7 +19,8 @@ package-app surfaces:
 1. **First-party HTML keeps its security headers.** All trusted account/auth
    pages must go through `render()` (`packages/worker/src/app/render.ts`), which
    applies `packages/worker/src/app/security-headers.ts`. Never add
-   `'unsafe-inline'` to the CSP `script-src`.
+   `'unsafe-inline'` to the CSP `script-src`. The scroll-restoration restore
+   script is allowed only by its sha256 hash, not by relaxing `script-src`.
 2. **Untrusted surfaces stay off the strict CSP.** Hosted package apps
    (`https://{username}.<package-app host>/packages/*` in production, or
    `/@username/packages/*` when served inline) execute author-supplied HTML/JS
@@ -79,14 +80,15 @@ package-app surfaces:
 (login, signup, account pages, the OAuth consent screen, and the SPA shell):
 
 - `Content-Security-Policy` with `script-src 'self' https://cdn.usefathom.com`
-  (no inline scripts; the Fathom Analytics tracker is the only allowed external
-  script and its image beacon is also allowed in `img-src`),
-  `frame-ancestors 'none'`, `base-uri 'self'`, `object-src 'none'`,
-  `form-action 'self'`, `worker-src 'self' blob:` (for Sentry Session Replay),
-  and same-origin `connect-src`. The client bundle loads as an external module,
-  so this does not require inline scripts. `style-src` allows `'unsafe-inline'`
-  because SSR-streamed styles arrive as inline `<style>` tags; style injection
-  is far lower risk than script injection.
+  (no `'unsafe-inline'`; the Fathom Analytics tracker is the only allowed
+  external script and its image beacon is also allowed in `img-src`; the
+  scroll-restoration restore script is an inline classic script allowed only by
+  its sha256 hash), `frame-ancestors 'none'`, `base-uri 'self'`,
+  `object-src 'none'`, `form-action 'self'`, `worker-src 'self' blob:` (for
+  Sentry Session Replay), and same-origin `connect-src`. The client bundle loads
+  as an external module. `style-src` allows `'unsafe-inline'` because
+  SSR-streamed styles arrive as inline `<style>` tags; style injection is far
+  lower risk than script injection.
 - `X-Frame-Options: DENY` plus `frame-ancestors 'none'` — stops clickjacking of
   the OAuth consent screen and account pages.
 - `X-Content-Type-Options: nosniff`.

--- a/packages/worker/client/router-scroll-state.node.test.ts
+++ b/packages/worker/client/router-scroll-state.node.test.ts
@@ -11,7 +11,7 @@ test('scroll restoration history state and navigation targets follow push, pop, 
 		'scroll-key-1',
 	)
 	expect(state).toEqual({
-		kodyScrollRestorationKey: 'scroll-key-1',
+		key: 'scroll-key-1',
 		userState: 'kept',
 	})
 	expect(getScrollRestorationKey(state)).toBe('scroll-key-1')

--- a/packages/worker/client/router-scroll-state.ts
+++ b/packages/worker/client/router-scroll-state.ts
@@ -1,4 +1,5 @@
 import { isRecord } from '@kody-internal/shared/is-record.ts'
+import { historyStateScrollKey } from '#universal/router-scroll-restoration.ts'
 
 export type RouterHistoryAction = 'push' | 'pop' | 'replace'
 
@@ -23,7 +24,6 @@ export type ScrollRestorationTarget =
 	| { type: 'preserve' }
 	| { type: 'top' }
 
-const historyStateScrollKey = 'kodyScrollRestorationKey'
 let scrollRestorationKeyCount = 0
 
 export function createScrollRestorationKey() {

--- a/packages/worker/client/scroll-restoration.tsx
+++ b/packages/worker/client/scroll-restoration.tsx
@@ -1,4 +1,9 @@
 import { addEventListeners, type Handle } from 'remix/ui'
+import {
+	parseSavedScrollPositions,
+	scrollRestorationStorageKey,
+	serializeSavedScrollPositions,
+} from '#universal/router-scroll-restoration.ts'
 import { routerEvents } from './client-router.tsx'
 import {
 	ensureCurrentScrollRestorationKey,
@@ -9,36 +14,19 @@ import {
 	type ScrollRestorationTarget,
 } from './router-scroll-state.ts'
 
-const scrollPositionsSessionKey = 'kody:router-scroll-positions'
 const savedScrollPositions = new Map<string, ScrollPosition>()
 let positionsLoaded = false
 let restoreScrollRequestId = 0
-
-function isScrollPosition(value: unknown): value is ScrollPosition {
-	return (
-		typeof value === 'object' &&
-		value !== null &&
-		'x' in value &&
-		'y' in value &&
-		typeof value.x === 'number' &&
-		typeof value.y === 'number'
-	)
-}
 
 function loadSavedScrollPositions() {
 	if (positionsLoaded || typeof sessionStorage === 'undefined') return
 	positionsLoaded = true
 	try {
-		const rawPositions = sessionStorage.getItem(scrollPositionsSessionKey)
-		if (!rawPositions) return
-		const entries = JSON.parse(rawPositions) as unknown
-		if (!Array.isArray(entries)) return
-		for (const entry of entries) {
-			if (!Array.isArray(entry) || entry.length !== 2) continue
-			const [key, position] = entry
-			if (typeof key === 'string' && isScrollPosition(position)) {
-				savedScrollPositions.set(key, position)
-			}
+		const positions = parseSavedScrollPositions(
+			sessionStorage.getItem(scrollRestorationStorageKey),
+		)
+		for (const [key, y] of Object.entries(positions)) {
+			savedScrollPositions.set(key, { x: 0, y })
 		}
 	} catch {
 		// Session storage may be unavailable in private modes; scroll still works
@@ -49,9 +37,13 @@ function loadSavedScrollPositions() {
 function persistSavedScrollPositions() {
 	if (typeof sessionStorage === 'undefined') return
 	try {
+		const positions: Record<string, number> = {}
+		for (const [key, position] of savedScrollPositions) {
+			positions[key] = position.y
+		}
 		sessionStorage.setItem(
-			scrollPositionsSessionKey,
-			JSON.stringify(Array.from(savedScrollPositions.entries())),
+			scrollRestorationStorageKey,
+			serializeSavedScrollPositions(positions),
 		)
 	} catch {
 		// Ignore quota and privacy-mode storage failures.
@@ -65,6 +57,11 @@ function saveWindowScrollPosition() {
 		x: window.scrollX,
 		y: window.scrollY,
 	})
+}
+
+function persistWindowScrollPosition() {
+	saveWindowScrollPosition()
+	persistSavedScrollPositions()
 }
 
 function getHashTarget(id: string) {
@@ -231,11 +228,9 @@ export function ScrollRestoration(handle: Handle) {
 			},
 		})
 		addEventListeners(window, handle.signal, {
-			scroll: saveWindowScrollPosition,
-			pagehide() {
-				saveWindowScrollPosition()
-				persistSavedScrollPositions()
-			},
+			scroll: persistWindowScrollPosition,
+			pagehide: persistWindowScrollPosition,
+			beforeunload: persistWindowScrollPosition,
 		})
 		handle.signal.addEventListener('abort', () => {
 			persistSavedScrollPositions()

--- a/packages/worker/src/app/security-headers.ts
+++ b/packages/worker/src/app/security-headers.ts
@@ -1,3 +1,5 @@
+import { scrollRestorationInlineScriptCspHash } from '#universal/router-scroll-restoration.ts'
+
 /**
  * First-party HTTP security headers.
  *
@@ -11,7 +13,10 @@
  * - `script-src 'self'` (no `'unsafe-inline'`) is the important protection: the
  *   client bundle is loaded as an external module from the same origin, so an
  *   injected inline `<script>` cannot execute. Do NOT add `'unsafe-inline'` to
- *   `script-src`.
+ *   `script-src`. The one first-party exception is the scroll-restoration
+ *   restore script in the SSR body, allowed only by its sha256 hash (React
+ *   Router's `<ScrollRestoration />` pattern) so a refresh can restore
+ *   `scrollY` before paint.
  * - `style-src` allows `'unsafe-inline'` because SSR streamed styles arrive as
  *   inline `<style>` tags; style injection is far lower risk than script
  *   injection. Client-side styles use constructable stylesheets, which CSP does
@@ -48,7 +53,7 @@ const contentSecurityPolicy = [
 	"img-src 'self' data: blob: https://cdn.usefathom.com",
 	"font-src 'self' data:",
 	"style-src 'self' 'unsafe-inline'",
-	"script-src 'self' https://cdn.usefathom.com https://static.cloudflareinsights.com https://challenges.cloudflare.com",
+	`script-src 'self' ${scrollRestorationInlineScriptCspHash} https://cdn.usefathom.com https://static.cloudflareinsights.com https://challenges.cloudflare.com`,
 	"connect-src 'self' https://cloudflareinsights.com https://challenges.cloudflare.com",
 	'frame-src https://challenges.cloudflare.com',
 	"worker-src 'self' blob:",

--- a/packages/worker/src/app/ssr-document.tsx
+++ b/packages/worker/src/app/ssr-document.tsx
@@ -11,6 +11,7 @@ import {
 	DOCUMENT_HEAD_ATTR,
 	type ResolvedDocumentHead,
 } from '#universal/document-head.ts'
+import { getScrollRestorationInlineScript } from '#universal/router-scroll-restoration.ts'
 import {
 	SENTRY_CONFIG_META_NAME,
 	type SentryClientConfig,
@@ -155,6 +156,7 @@ export function SsrDocument(handle: Handle<SsrDocumentProps>) {
 		handle.props.clientEntryHref ?? buildClientEntryHref('dev')
 	const stylesheetHref =
 		handle.props.stylesheetHref ?? buildStylesheetHref('dev')
+	const scrollRestorationInlineScript = getScrollRestorationInlineScript()
 
 	return () => (
 		<html lang="en">
@@ -262,6 +264,11 @@ export function SsrDocument(handle: Handle<SsrDocumentProps>) {
 						notFound={handle.props.notFound}
 					/>
 				</div>
+				{/* Blocking classic script (not type=module): restores the
+				    saved window.scrollY from sessionStorage before first paint
+				    and before hydration. CSP allows this exact script via its
+				    sha256 hash — do not add `'unsafe-inline'`. */}
+				<script innerHTML={scrollRestorationInlineScript}></script>
 				<script type="module" src={clientEntryHref}></script>
 			</body>
 		</html>

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -24,8 +24,10 @@ import {
 	toBlogPostSummary,
 } from '#worker/blog/catalog.ts'
 import { resetDataCacheForTests } from '#app/data-cache.ts'
+import { firstPartySecurityHeaders } from '#app/security-headers.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 import { planLimits } from '#universal/plans.ts'
+import { getScrollRestorationInlineScript } from '#universal/router-scroll-restoration.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -486,11 +488,36 @@ test('renderAppPage embeds the Fathom tracker only when FATHOM_SITE_ID is set', 
 	expect(withFathomHtml).toContain('data-site="WKKSDJGN"')
 	expect(withFathomHtml).toContain('data-spa="auto"')
 	const csp = withFathom.headers.get('Content-Security-Policy')
+	expect(csp).toContain("script-src 'self' 'sha256-")
 	expect(csp).toContain(
-		"script-src 'self' https://cdn.usefathom.com https://static.cloudflareinsights.com",
+		'https://cdn.usefathom.com https://static.cloudflareinsights.com',
 	)
 	expect(csp).toContain("img-src 'self' data: blob: https://cdn.usefathom.com")
 	expect(csp).toContain("connect-src 'self' https://cloudflareinsights.com")
+})
+
+test('renderAppPage emits a pre-hydration scroll restoration script in the document body', async () => {
+	resetDataCacheForTests()
+	setAuthSessionSecret(testCookieSecret)
+	const env = createTestEnv(createUserTestDb([]))
+	const restoreScript = getScrollRestorationInlineScript()
+
+	const response = await renderAppPage({
+		request: new Request('https://example.com/'),
+		env,
+	})
+	expect(response.status).toBe(200)
+	const html = await readResponseText(response)
+	const restoreScriptIndex = html.indexOf(restoreScript)
+	const clientEntryIndex = html.indexOf('type="module" src="')
+	expect(restoreScriptIndex).toBeGreaterThan(html.indexOf('<div id="root">'))
+	expect(restoreScriptIndex).toBeGreaterThan(0)
+	expect(clientEntryIndex).toBeGreaterThan(restoreScriptIndex)
+	expect(html).toContain(`<script>${restoreScript}</script>`)
+	expect(response.headers.get('Content-Security-Policy')).toBe(
+		firstPartySecurityHeaders['Content-Security-Policy'],
+	)
+	expect(response.headers.get('Content-Security-Policy')).toContain("'sha256-")
 })
 
 test('renderAppPage emits a doctype, meta description, and inlines the stylesheet when assets provide it', async () => {

--- a/packages/worker/universal/router-scroll-restoration.node.test.ts
+++ b/packages/worker/universal/router-scroll-restoration.node.test.ts
@@ -1,0 +1,40 @@
+import { createHash } from 'node:crypto'
+import { expect, test } from 'vitest'
+import {
+	getScrollRestorationInlineScript,
+	getStoredScrollY,
+	parseSavedScrollPositions,
+	scrollRestorationInlineScriptCspHash,
+	scrollRestorationStorageKey,
+	serializeSavedScrollPositions,
+} from './router-scroll-restoration.ts'
+
+test('sessionStorage scroll positions restore the saved Y for the current history key', () => {
+	const stored = serializeSavedScrollPositions({
+		'scroll-key-1': 2000,
+		'scroll-key-2': 3400,
+	})
+	expect(JSON.parse(stored)).toEqual({
+		'scroll-key-1': 2000,
+		'scroll-key-2': 3400,
+	})
+
+	const positions = parseSavedScrollPositions(stored)
+	expect(getStoredScrollY(positions, 'scroll-key-1')).toBe(2000)
+	expect(getStoredScrollY(positions, 'scroll-key-2')).toBe(3400)
+	expect(getStoredScrollY(positions, 'missing-key')).toBeNull()
+	expect(getStoredScrollY(positions, null)).toBeNull()
+	expect(parseSavedScrollPositions(null)).toEqual({})
+	expect(parseSavedScrollPositions('[{"not":"rr-format"}]')).toEqual({})
+
+	const restoreScript = getScrollRestorationInlineScript()
+	expect(restoreScript).toContain(JSON.stringify(scrollRestorationStorageKey))
+	expect(restoreScript).toContain('sessionStorage.getItem')
+	expect(restoreScript).toContain('window.history.state.key')
+	expect(restoreScript).toContain('window.scrollTo(0,storedY)')
+	expect(restoreScript).toContain('scrollRestoration')
+	expect(restoreScript).toContain('"manual"')
+	expect(scrollRestorationInlineScriptCspHash).toBe(
+		`'sha256-${createHash('sha256').update(restoreScript, 'utf8').digest('base64')}'`,
+	)
+})

--- a/packages/worker/universal/router-scroll-restoration.node.test.ts
+++ b/packages/worker/universal/router-scroll-restoration.node.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
-import { expect, test } from 'vitest'
+import { runInNewContext } from 'node:vm'
+import { expect, test, vi } from 'vitest'
 import {
 	getScrollRestorationInlineScript,
 	getStoredScrollY,
@@ -37,4 +38,23 @@ test('sessionStorage scroll positions restore the saved Y for the current histor
 	expect(scrollRestorationInlineScriptCspHash).toBe(
 		`'sha256-${createHash('sha256').update(restoreScript, 'utf8').digest('base64')}'`,
 	)
+
+	const scrollTo = vi.fn()
+	const history = {
+		scrollRestoration: 'auto',
+		state: { key: 'scroll-key-1' },
+		replaceState: vi.fn(),
+	}
+	runInNewContext(restoreScript, {
+		window: { history, scrollTo },
+		sessionStorage: {
+			getItem: () => stored,
+			removeItem: vi.fn(),
+		},
+		console,
+		Math,
+	})
+	expect(history.scrollRestoration).toBe('manual')
+	expect(scrollTo).toHaveBeenCalledWith(0, 2000)
+	expect(history.replaceState).not.toHaveBeenCalled()
 })

--- a/packages/worker/universal/router-scroll-restoration.ts
+++ b/packages/worker/universal/router-scroll-restoration.ts
@@ -1,0 +1,78 @@
+/**
+ * Scroll restoration storage and the pre-hydration restore script.
+ *
+ * Mirrors React Router's `<ScrollRestoration />`: positions are a
+ * `{ [historyKey]: y }` map in sessionStorage, and an inline script in the
+ * SSR body applies `window.scrollTo` before paint so a refresh does not flash
+ * the top of the page.
+ */
+
+export const scrollRestorationStorageKey = 'kody:router-scroll-positions'
+
+/** History state field React Router uses (`window.history.state.key`). */
+export const historyStateScrollKey = 'key'
+
+export type SavedScrollPositions = Record<string, number>
+
+export function parseSavedScrollPositions(
+	raw: string | null,
+): SavedScrollPositions {
+	if (!raw) return {}
+	try {
+		const parsed: unknown = JSON.parse(raw)
+		if (
+			typeof parsed !== 'object' ||
+			parsed === null ||
+			Array.isArray(parsed)
+		) {
+			return {}
+		}
+		const positions: SavedScrollPositions = {}
+		for (const [key, value] of Object.entries(parsed)) {
+			if (typeof value === 'number') {
+				positions[key] = value
+			}
+		}
+		return positions
+	} catch {
+		return {}
+	}
+}
+
+export function serializeSavedScrollPositions(
+	positions: SavedScrollPositions,
+): string {
+	return JSON.stringify(positions)
+}
+
+export function getStoredScrollY(
+	positions: SavedScrollPositions,
+	historyKey: string | null | undefined,
+): number | null {
+	if (!historyKey) return null
+	const storedY = positions[historyKey]
+	return typeof storedY === 'number' ? storedY : null
+}
+
+/**
+ * Blocking classic script inlined in the SSR body. Keep this a string (not a
+ * function that references `window`) so `#universal` stays DOM-free. The body
+ * matches React Router's restore IIFE, plus `manual` scroll restoration so
+ * the browser does not undo the pre-paint scroll.
+ *
+ * CSP allows this exact source via `scrollRestorationInlineScriptCspHash`.
+ * Update the hash in the same change if you edit the script (the node test
+ * fails when they drift).
+ */
+export const scrollRestorationInlineScript = `(function(storageKey,restoreKey){if("scrollRestoration"in window.history){window.history.scrollRestoration="manual"}if(!window.history.state||!window.history.state.key){var key=Math.random().toString(32).slice(2);window.history.replaceState({key:key},"")}try{var positions=JSON.parse(sessionStorage.getItem(storageKey)||"{}");var storedY=positions[restoreKey||window.history.state.key];if(typeof storedY==="number"){window.scrollTo(0,storedY)}}catch(error){console.error(error);sessionStorage.removeItem(storageKey)}})(${JSON.stringify(scrollRestorationStorageKey)},null)`
+
+export function getScrollRestorationInlineScript() {
+	return scrollRestorationInlineScript
+}
+
+/**
+ * `script-src` hash for `scrollRestorationInlineScript`. The node test
+ * recomputes this so the CSP entry cannot drift from the inlined source.
+ */
+export const scrollRestorationInlineScriptCspHash =
+	"'sha256-MdxEgAksnpE4HJeHgjidW/x9g+OeXkea+EM+60WWso0='"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Refreshing a scrolled kody.codes homepage (and any other first-party route) should restore the previous `scrollY` instead of jumping back to the hero.

This is the React Router `<ScrollRestoration />` pattern: persist positions in `sessionStorage`, keep `history.scrollRestoration = 'manual'` for SPA nav, and restore with a blocking inline script in the SSR body **before paint / before hydration**. A JS-after-mount restore still flashes the top of the page.

## Repro (production, 2026-08-13)

On https://kody.codes (`history.scrollRestoration` is `"manual"`):

1. Scroll to `scrollY ≈ 2000` (FOR EXAMPLE cards) or `≈ 3400` ("It already speaks your stack").
2. Refresh / `location.reload()`.
3. Observed: `scrollY = 0`, hero fully back in view. Nothing restored the saved position after the new document load.

## Summary

- Persist scroll as React Router does: `sessionStorage` map `{ [history.state.key]: y }` (`kody:router-scroll-positions`).
- Emit a blocking classic `<script>` in the SSR `<body>` (after `#root`, before the module entry) that reads that map and calls `window.scrollTo(0, storedY)` before first paint.
- Set `history.scrollRestoration = 'manual'` in that script so the browser does not undo the restore.
- Keep the existing SPA restorer: back/forward restores the saved position, new navigations go to top, `preventScrollReset` and hash targets are unchanged.
- CSP still has no `'unsafe-inline'`. The restore script is allowed only by its sha256 hash (the node test recomputes the hash so it cannot drift).

## Testing

- `packages/worker/universal/router-scroll-restoration.node.test.ts`: saved Y lookup by history key, RR storage format, inline script contents, CSP hash matches the inlined source, and executing the script against a fake `window` calls `scrollTo(0, 2000)` for the current history key.
- `packages/worker/src/app/ssr-render.node.test.ts`: homepage HTML includes the restore script in the body before the client entry, and the CSP header carries the hash.
- Existing SPA target tests still cover push/pop/hash/preserve.
- `packages/worker/src/security/security-hardening.workers.test.ts` still matches first-party security headers.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `64d1b9a7` · **Head:** `e0f49eca`

**Classification:** extends — the browser-app scroll restorer now persists React Router-shaped sessionStorage positions and restores them from an SSR inline script on full document load.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — reload restore via SSR inline script + sessionStorage `{ [historyKey]: y }`; CSP hash for that script only |

### System map

Full document loads restore `scrollY` from sessionStorage in the SSR HTML body before hydration; SPA navigations still go through the client restorer.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appUi -->|"SSR body script + sessionStorage map"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Browser
	participant SSR as SsrDocument
	participant Storage as sessionStorage
	Browser->>Storage: save Y on scroll / pagehide / beforeunload
	Browser->>SSR: refresh (new document)
	SSR->>Browser: inline script before client-entry.js
	Browser->>Storage: read positions[history.state.key]
	Browser->>Browser: scrollTo(0, storedY) before paint
```

### Before / after

```
before: history.scrollRestoration = "manual"; reload → scrollY = 0
after:  same manual mode; SSR script restores sessionStorage Y before paint
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e907e517-b985-44a9-b106-e5141c9cd1f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e907e517-b985-44a9-b106-e5141c9cd1f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scroll restoration across full-page loads and browser history navigation.
  * Restores saved scroll positions before the page’s first paint to reduce visual jumps.
  * Added secure support for the restoration script through Content Security Policy.

* **Documentation**
  * Updated architecture and security documentation to describe scroll persistence, restoration behavior, and CSP requirements.

* **Tests**
  * Expanded coverage for scroll restoration, server-rendered output, and security headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->