### PR TITLE
Skip Artifacts ready GET, prefer native binding, take account-level repo.pushed

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -330,12 +330,13 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
   same inboxes; outbound always sends from the canonical domains. Production
   commits `inbox.heykody.app,inbox.heykody.dev` / `heykody.app,heykody.dev`.
   Empty the lists when retiring the old domains' email DNS.
-- `ARTIFACTS_NAMESPACE` — Cloudflare Artifacts namespace for repo REST calls.
-  Defaults to `default` when unset (local dev and tests). Wrangler sets
-  `production` and `preview` per environment in
-  `packages/worker/wrangler.jsonc`. New repo sessions persist this value in D1
-  as `session_repo_namespace` so follow-up lookups resolve the correct namespace
-  even after env changes.
+- `ARTIFACTS_NAMESPACE` — Cloudflare Artifacts namespace for repo REST calls
+  and for choosing the env-scoped `ARTIFACTS` binding. Defaults to `default`
+  when unset (local dev and tests). Wrangler sets `production` and `preview`
+  per environment in `packages/worker/wrangler.jsonc`. Production/preview also
+  bind `ARTIFACTS` (JSRPC); create/get prefer that binding and fall back to
+  REST. New repo sessions persist this value in D1 as `session_repo_namespace`
+  so follow-up lookups resolve the correct namespace even after env changes.
 
 ## Disaster recovery (production Worker)
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -330,13 +330,13 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
   same inboxes; outbound always sends from the canonical domains. Production
   commits `inbox.heykody.app,inbox.heykody.dev` / `heykody.app,heykody.dev`.
   Empty the lists when retiring the old domains' email DNS.
-- `ARTIFACTS_NAMESPACE` — Cloudflare Artifacts namespace for repo REST calls
-  and for choosing the env-scoped `ARTIFACTS` binding. Defaults to `default`
-  when unset (local dev and tests). Wrangler sets `production` and `preview`
-  per environment in `packages/worker/wrangler.jsonc`. Production/preview also
-  bind `ARTIFACTS` (JSRPC); create/get prefer that binding and fall back to
-  REST. New repo sessions persist this value in D1 as `session_repo_namespace`
-  so follow-up lookups resolve the correct namespace even after env changes.
+- `ARTIFACTS_NAMESPACE` — Cloudflare Artifacts namespace for repo REST calls and
+  for choosing the env-scoped `ARTIFACTS` binding. Defaults to `default` when
+  unset (local dev and tests). Wrangler sets `production` and `preview` per
+  environment in `packages/worker/wrangler.jsonc`. Production/preview also bind
+  `ARTIFACTS` (JSRPC); create/get prefer that binding and fall back to REST. New
+  repo sessions persist this value in D1 as `session_repo_namespace` so
+  follow-up lookups resolve the correct namespace even after env changes.
 
 ## Disaster recovery (production Worker)
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -34,8 +34,8 @@ This project uses the following resources:
     subscriptions; leftover per-repo rows are still deleted during artifact
     cleanup. Uses `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN`.
   - Production and preview Workers bind `ARTIFACTS` (wrangler `artifacts`,
-    namespaces `production` / `preview`). Create/get prefer that JSRPC
-    binding and fall back to REST when the binding is absent (local/tests).
+    namespaces `production` / `preview`). Create/get prefer that JSRPC binding
+    and fall back to REST when the binding is absent (local/tests).
   - The production consumer batches at most 10 messages for 5 seconds, retries
     three times, and routes exhausted messages to the dedicated dead-letter
     queue. Consumers filter by `ARTIFACTS_NAMESPACE` and ignore session fork

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -29,15 +29,13 @@ This project uses the following resources:
   - Queue: `kody-artifacts-repo-events`
   - Dead-letter queue: `kody-artifacts-repo-events-dlq`
   - Production CI ensures both queues and reconciles an account-level
-    `artifacts` event subscription for `repo.created` / `repo.deleted`.
-  - Per-repo `artifacts.repo` push subscriptions (`pushed`) are scheduled via
-    `waitUntil` when durable `entity_sources` rows are ensured, and also from
-    the account-level `repo.created` queue consumer. Source creation does not
-    await that REST setup. The Worker looks up the destination queue
-    (`kody-artifacts-repo-events`) by name and caches the queue id for the
-    isolate lifetime. Subscription ids are stored in
-    `entity_source_artifacts_push_subscriptions` and deleted during artifact
+    `artifacts` event subscription for `repo.created` / `repo.deleted` /
+    `repo.pushed`. New repos do not create per-repo `artifacts.repo` push
+    subscriptions; leftover per-repo rows are still deleted during artifact
     cleanup. Uses `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN`.
+  - Production and preview Workers bind `ARTIFACTS` (wrangler `artifacts`,
+    namespaces `production` / `preview`). Create/get prefer that JSRPC
+    binding and fall back to REST when the binding is absent (local/tests).
   - The production consumer batches at most 10 messages for 5 seconds, retries
     three times, and routes exhausted messages to the dedicated dead-letter
     queue. Consumers filter by `ARTIFACTS_NAMESPACE` and ignore session fork

--- a/docs/use/repos.md
+++ b/docs/use/repos.md
@@ -72,6 +72,10 @@ subscriptions for the owning user:
 | `repo.created` | `cf.artifacts.repo.created` | A managed Artifacts repo is created      |
 | `repo.deleted` | `cf.artifacts.repo.deleted` | A managed Artifacts repo is deleted      |
 
+Account-level Artifacts subscriptions deliver `repo.pushed` as
+`cf.artifacts.repo.pushed` with `source.type === "artifacts"`. Repo-scoped
+wrappers use the same event type with `source.type === "artifacts.repo"`.
+
 Declare handlers under `package.json#kody.subscriptions`. Delivery is same-user
 only: packages saved by the entity owner that declare the topic receive the
 event. Session fork Artifacts repos never fan out.

--- a/packages/worker/src/env-schema.ts
+++ b/packages/worker/src/env-schema.ts
@@ -45,6 +45,13 @@ const optionalAiSchema = createSchema<unknown, Ai | undefined>(
 	},
 )
 
+const optionalArtifactsSchema = createSchema<unknown, Artifacts | undefined>(
+	(value, _context) => {
+		if (value === undefined) return { value: undefined }
+		return { value: value as Artifacts }
+	},
+)
+
 // Service binding to the package runtime Worker (`kody-runtime`). Present in
 // production/preview and multi-worker local dev; absent in tests and
 // single-worker dev, where the main Worker serves the runtime lane itself.
@@ -275,6 +282,9 @@ export const EnvSchema = object({
 	CLOUDFLARE_API_TOKEN: optionalNonEmptyStringSchema,
 	CLOUDFLARE_API_BASE_URL: optionalUrlStringSchema,
 	ARTIFACTS_NAMESPACE: optionalNonEmptyStringSchema,
+	// Worker-to-Worker Artifacts binding. Present in production/preview when
+	// wrangler `artifacts` is configured; local/tests fall back to REST.
+	ARTIFACTS: optionalArtifactsSchema,
 	AI: optionalAiSchema,
 	AI_GATEWAY_ID: optionalNonEmptyStringSchema,
 	CAPABILITY_REINDEX_SECRET: optionalNonEmptyStringSchema,

--- a/packages/worker/src/mcp/cloudflare/cloudflare-rest-client.node.test.ts
+++ b/packages/worker/src/mcp/cloudflare/cloudflare-rest-client.node.test.ts
@@ -16,10 +16,13 @@ test('Cloudflare REST clients read mock responses, enforce API paths, and send J
 	using _server = createMswNodeServer([
 		http.get(`${baseUrl}/client/v4/accounts`, ({ request }) => {
 			accountsRequest = request.clone()
-			return HttpResponse.json({
-				success: true,
-				result: [{ id: 'cf_account_mock_123' }],
-			})
+			return HttpResponse.json(
+				{
+					success: true,
+					result: [{ id: 'cf_account_mock_123' }],
+				},
+				{ headers: { 'cf-ray': 'accounts-ray-1' } },
+			)
 		}),
 		http.get(`${baseUrl}/client/v4/user/tokens/verify`, ({ request }) => {
 			verifyRequest = request.clone()
@@ -46,6 +49,7 @@ test('Cloudflare REST clients read mock responses, enforce API paths, and send J
 		path: '/client/v4/accounts',
 	})
 	expect(accountsResponse.status).toBe(200)
+	expect(accountsResponse.cfRay).toBe('accounts-ray-1')
 	const accountsBody = accountsResponse.body as {
 		success?: boolean
 		result?: Array<{ id?: string }>

--- a/packages/worker/src/mcp/cloudflare/cloudflare-rest-client.ts
+++ b/packages/worker/src/mcp/cloudflare/cloudflare-rest-client.ts
@@ -64,7 +64,11 @@ export class CloudflareRestClient {
 		path: string
 		query?: Record<string, string>
 		body?: unknown
-	}): Promise<{ status: number; body: unknown | null }> {
+	}): Promise<{
+		status: number
+		body: unknown | null
+		cfRay: string | null
+	}> {
 		assertSafeCloudflareApiV4Path(input.path)
 		const pathPart = input.path.startsWith('/') ? input.path : `/${input.path}`
 		const url = new URL(`${this.baseUrl}${pathPart}`)
@@ -98,13 +102,18 @@ export class CloudflareRestClient {
 
 		const response = await fetch(url.toString(), init)
 		const text = await response.text()
+		const cfRay = response.headers.get('cf-ray')
 
 		if (response.status === 204 || !text.trim()) {
-			return { status: response.status, body: null }
+			return { status: response.status, body: null, cfRay }
 		}
 
 		try {
-			return { status: response.status, body: JSON.parse(text) as unknown }
+			return {
+				status: response.status,
+				body: JSON.parse(text) as unknown,
+				cfRay,
+			}
 		} catch {
 			throw new CloudflareApiError(
 				`Cloudflare API returned non-JSON (${response.status}).`,

--- a/packages/worker/src/repo/artifacts-events.node.test.ts
+++ b/packages/worker/src/repo/artifacts-events.node.test.ts
@@ -44,7 +44,28 @@ test('artifacts event helpers parse envelopes, reject unknowns, and detect sessi
 		metadata,
 	})
 	expect(pushed?.type).toBe('cf.artifacts.repo.pushed')
+	expect(pushed?.source.type).toBe('artifacts.repo')
 	expect(topicForArtifactsRepoEvent(pushed!)).toBe(repoPushedTopic)
+
+	const accountPushed = parseCloudflareArtifactsRepoEvent({
+		type: 'cf.artifacts.repo.pushed',
+		source: {
+			type: 'artifacts',
+			namespace: 'production',
+			repoName: 'repo-abc',
+		},
+		payload: {
+			ref: 'refs/heads/main',
+			before: 'abc123def456abc123def456abc123def456abc1',
+			after: 'def789ghi012def789ghi012def789ghi012def7',
+			commits: [],
+			totalCommitsCount: 0,
+			commitsTruncated: false,
+		},
+		metadata,
+	})
+	expect(accountPushed?.source.type).toBe('artifacts')
+	expect(topicForArtifactsRepoEvent(accountPushed!)).toBe(repoPushedTopic)
 
 	const created = parseCloudflareArtifactsRepoEvent({
 		type: 'cf.artifacts.repo.created',

--- a/packages/worker/src/repo/artifacts-events.ts
+++ b/packages/worker/src/repo/artifacts-events.ts
@@ -34,16 +34,25 @@ const artifactsEventMetadataSchema = z.object({
 	eventTimestamp: z.iso.datetime(),
 })
 
+const artifactsEventUserSchema = z
+	.object({
+		id: z.string(),
+		email: z.string(),
+	})
+	.optional()
+
 const artifactsAccountSourceSchema = z.object({
 	type: z.literal('artifacts'),
 	namespace: z.string().min(1),
 	repoName: z.string().min(1),
+	user: artifactsEventUserSchema,
 })
 
 const artifactsRepoSourceSchema = z.object({
 	type: z.literal('artifacts.repo'),
 	namespace: z.string().min(1),
 	repoName: z.string().min(1),
+	user: artifactsEventUserSchema,
 })
 
 const artifactsRepoLifecyclePayloadSchema = z.object({
@@ -72,7 +81,7 @@ const cloudflareArtifactsRepoDeletedEventSchema = z.object({
 
 const cloudflareArtifactsRepoPushedEventSchema = z.object({
 	type: z.literal('cf.artifacts.repo.pushed'),
-	source: artifactsRepoSourceSchema,
+	source: z.union([artifactsAccountSourceSchema, artifactsRepoSourceSchema]),
 	payload: z.object({
 		ref: z.string().min(1),
 		before: z.string().min(1),

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -639,6 +639,26 @@ test('getArtifactsBinding prefers the native ARTIFACTS binding for the env names
 	})
 	expect(nativeCreate).toHaveBeenCalledWith('repo-native', { readOnly: false })
 	expect(nativeGet).toHaveBeenCalledTimes(2)
+
+	nativeGet.mockClear()
+	nativeCreate.mockImplementation(async () => ({
+		id: 'repo_native_no_exp',
+		name: 'repo-native-no-exp',
+		description: null,
+		defaultBranch: 'main',
+		remote:
+			'https://acct.artifacts.cloudflare.net/git/production/repo-native-no-exp.git',
+		token: 'art_v2_native?expires=1760000000',
+	}))
+	await expect(
+		ensureArtifactRepoReady(env, 'repo-native-no-exp', binding),
+	).resolves.toMatchObject({
+		recreated: true,
+		bootstrapAccess: {
+			token: 'art_v2_native?expires=1760000000',
+			expiresAt: '2025-10-09T08:53:20.000Z',
+		},
+	})
 })
 
 test('artifacts REST logs redact plaintext tokens on revoke', async () => {

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -640,3 +640,51 @@ test('getArtifactsBinding prefers the native ARTIFACTS binding for the env names
 	expect(nativeCreate).toHaveBeenCalledWith('repo-native', { readOnly: false })
 	expect(nativeGet).toHaveBeenCalledTimes(2)
 })
+
+test('artifacts REST logs redact plaintext tokens on revoke', async () => {
+	const plaintext = 'art_v1_secret?expires=1760000100'
+	const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			expect(method).toBe('DELETE')
+			expect(url.pathname).toContain(`/tokens/${encodeURIComponent(plaintext)}`)
+			return new Response(
+				JSON.stringify({
+					success: true,
+					result: null,
+					errors: [],
+					messages: [],
+				}),
+				{
+					status: 200,
+					headers: {
+						'content-type': 'application/json',
+						'cf-ray': 'revoke-ray-1',
+					},
+				},
+			)
+		})
+
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+	await getArtifactsBinding(env).repo('repo-1').revokeToken?.(plaintext)
+
+	const logged = info.mock.calls.filter((call) => call[0] === 'artifacts-rest')
+	expect(logged).toHaveLength(1)
+	expect(logged[0]?.[1]).toEqual({
+		method: 'DELETE',
+		path: '/client/v4/accounts/acct/artifacts/namespaces/default/tokens/:token',
+		status: 200,
+		cfRay: 'revoke-ray-1',
+	})
+	expect(JSON.stringify(logged)).not.toContain(plaintext)
+	expect(JSON.stringify(logged)).not.toContain(encodeURIComponent(plaintext))
+	info.mockRestore()
+	fetchMock.mockRestore()
+})

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -518,3 +518,121 @@ test('resolveArtifactDefaultBranchHead reuses a provided token and still works w
 	expect(info).toHaveBeenCalledTimes(1)
 	expect(gitMocks.listServerRefs).toHaveBeenCalledTimes(1)
 })
+
+test('ensureArtifactRepoReady uses the create result without a follow-up GET', async () => {
+	const env = {
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as Env
+	const fetchMock = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'GET' && url.pathname.endsWith('/repos/repo-new')) {
+				return new Response(
+					JSON.stringify({
+						success: false,
+						result: null,
+						errors: [{ code: 1000, message: 'Repo not found' }],
+						messages: [],
+					}),
+					{
+						status: 404,
+						headers: {
+							'content-type': 'application/json',
+							'cf-ray': 'create-miss-ray',
+						},
+					},
+				)
+			}
+			if (method === 'POST' && url.pathname.endsWith('/repos')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'repo_new',
+							name: 'repo-new',
+							description: null,
+							default_branch: 'main',
+							remote:
+								'https://acct.artifacts.cloudflare.net/git/default/repo-new.git',
+							token: 'art_v1_create?expires=1760000000',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 201,
+						headers: {
+							'content-type': 'application/json',
+							'cf-ray': 'create-post-ray',
+						},
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		})
+
+	await expect(ensureArtifactRepoReady(env, 'repo-new')).resolves.toMatchObject({
+		recreated: true,
+		bootstrapAccess: {
+			defaultBranch: 'main',
+			remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-new.git',
+			token: 'art_v1_create?expires=1760000000',
+		},
+		repo: expect.any(Object),
+	})
+	expect(fetchMock).toHaveBeenCalledTimes(2)
+	fetchMock.mockRestore()
+})
+
+test('getArtifactsBinding prefers the native ARTIFACTS binding for the env namespace', async () => {
+	const created = {
+		id: 'repo_native',
+		name: 'repo-native',
+		description: null,
+		defaultBranch: 'main',
+		remote: 'https://acct.artifacts.cloudflare.net/git/production/repo-native.git',
+		token: 'art_v2_native',
+		tokenExpiresAt: '2026-10-09T08:53:20.000Z',
+	}
+	const nativeGet = vi.fn(async () => {
+		const error = new Error('not found') as Error & {
+			name: string
+			code: string
+		}
+		error.name = 'ArtifactsError'
+		error.code = 'NOT_FOUND'
+		throw error
+	})
+	const nativeCreate = vi.fn(async () => created)
+	const env = {
+		ARTIFACTS_NAMESPACE: 'production',
+		ARTIFACTS: {
+			create: nativeCreate,
+			get: nativeGet,
+			delete: vi.fn(async () => true),
+			list: vi.fn(async () => ({ repos: [], total: 0 })),
+		},
+	} as unknown as Env
+
+	const binding = getArtifactsBinding(env)
+	await expect(binding.get('repo-native')).resolves.toEqual({
+		status: 'not_found',
+	})
+	await expect(
+		ensureArtifactRepoReady(env, 'repo-native', binding),
+	).resolves.toMatchObject({
+		recreated: true,
+		bootstrapAccess: {
+			defaultBranch: 'main',
+			remote: created.remote,
+			token: created.token,
+			expiresAt: created.tokenExpiresAt,
+		},
+	})
+	expect(nativeCreate).toHaveBeenCalledWith('repo-native', { readOnly: false })
+	expect(nativeGet).toHaveBeenCalledTimes(2)
+})

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -575,15 +575,18 @@ test('ensureArtifactRepoReady uses the create result without a follow-up GET', a
 			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
 		})
 
-	await expect(ensureArtifactRepoReady(env, 'repo-new')).resolves.toMatchObject({
-		recreated: true,
-		bootstrapAccess: {
-			defaultBranch: 'main',
-			remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-new.git',
-			token: 'art_v1_create?expires=1760000000',
+	await expect(ensureArtifactRepoReady(env, 'repo-new')).resolves.toMatchObject(
+		{
+			recreated: true,
+			bootstrapAccess: {
+				defaultBranch: 'main',
+				remote:
+					'https://acct.artifacts.cloudflare.net/git/default/repo-new.git',
+				token: 'art_v1_create?expires=1760000000',
+			},
+			repo: expect.any(Object),
 		},
-		repo: expect.any(Object),
-	})
+	)
 	expect(fetchMock).toHaveBeenCalledTimes(2)
 	fetchMock.mockRestore()
 })
@@ -594,7 +597,8 @@ test('getArtifactsBinding prefers the native ARTIFACTS binding for the env names
 		name: 'repo-native',
 		description: null,
 		defaultBranch: 'main',
-		remote: 'https://acct.artifacts.cloudflare.net/git/production/repo-native.git',
+		remote:
+			'https://acct.artifacts.cloudflare.net/git/production/repo-native.git',
 		token: 'art_v2_native',
 		tokenExpiresAt: '2026-10-09T08:53:20.000Z',
 	}

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -190,9 +190,7 @@ type ArtifactRestStoredToken = {
 	created_at?: string | null
 }
 
-function isArtifactsBindingError(
-	error: unknown,
-): error is ArtifactsError {
+function isArtifactsBindingError(error: unknown): error is ArtifactsError {
 	return (
 		error instanceof Error &&
 		error.name === 'ArtifactsError' &&

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -465,6 +465,10 @@ function createArtifactsRestBinding(env: Env, namespace: string) {
 	} satisfies ArtifactNamespaceBinding & Record<string, unknown>
 }
 
+function redactArtifactsRestPath(path: string) {
+	return path.replace(/\/tokens\/[^/?#]+/g, '/tokens/:token')
+}
+
 async function requestArtifactsApi<T>(
 	client: ReturnType<typeof createCloudflareRestClient>,
 	input: {
@@ -502,7 +506,7 @@ async function requestArtifactsEnvelope<T>(
 		if (response.cfRay) {
 			console.info('artifacts-rest', {
 				method: input.method,
-				path: input.path,
+				path: redactArtifactsRestPath(input.path),
 				status: response.status,
 				cfRay: response.cfRay,
 			})

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -89,6 +89,8 @@ export type ArtifactNamespaceBinding = {
 		total: number
 		cursor?: string
 	}>
+	/** Local handle for `name`. Does not fetch; `info` / tokens hit the API later. */
+	repo(name: string): ArtifactRepoHandle
 }
 
 export function resolveArtifactsNamespace(env: Env, namespace?: string | null) {
@@ -96,17 +98,25 @@ export function resolveArtifactsNamespace(env: Env, namespace?: string | null) {
 	return trimmed && trimmed.length > 0 ? trimmed : getArtifactsNamespace(env)
 }
 
+function readNativeArtifactsBinding(env: Env): Artifacts | null {
+	const binding = env.ARTIFACTS
+	if (!binding || typeof binding.create !== 'function') return null
+	return binding
+}
+
 export function getArtifactsBinding(
 	env: Env,
 	namespace?: string | null,
 ): ArtifactNamespaceBinding & Record<string, unknown> {
-	const restBinding = createArtifactsRestBinding(
-		env,
-		resolveArtifactsNamespace(env, namespace),
-	)
+	const requestedNamespace = resolveArtifactsNamespace(env, namespace)
+	const native = readNativeArtifactsBinding(env)
+	if (native && requestedNamespace === getArtifactsNamespace(env)) {
+		return adaptNativeArtifactsBinding(native)
+	}
+	const restBinding = createArtifactsRestBinding(env, requestedNamespace)
 	if (!restBinding) {
 		throw new Error(
-			'Cloudflare Artifacts REST access requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
+			'Cloudflare Artifacts access requires the ARTIFACTS binding or CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
 		)
 	}
 	return restBinding
@@ -178,6 +188,121 @@ type ArtifactRestStoredToken = {
 	scope: string
 	expires_at: string
 	created_at?: string | null
+}
+
+function isArtifactsBindingError(
+	error: unknown,
+): error is ArtifactsError {
+	return (
+		error instanceof Error &&
+		error.name === 'ArtifactsError' &&
+		'code' in error &&
+		typeof error.code === 'string'
+	)
+}
+
+function adaptNativeRepoHandle(repo: ArtifactsRepo): ArtifactRepoHandle {
+	return {
+		info: async () => ({
+			id: repo.id,
+			name: repo.name,
+			description: repo.description,
+			defaultBranch: repo.defaultBranch,
+			createdAt: repo.createdAt,
+			updatedAt: repo.updatedAt,
+			lastPushAt: repo.lastPushAt,
+			source: repo.source,
+			readOnly: repo.readOnly,
+			remote: repo.remote,
+		}),
+		createToken: async (scope = 'write', ttl = 3600) => {
+			const token = await repo.createToken(scope, ttl)
+			return {
+				id: token.id,
+				plaintext: token.plaintext,
+				scope: token.scope,
+				expiresAt: token.expiresAt,
+			}
+		},
+		listTokens: async () => {
+			const listed = await repo.listTokens()
+			return listed.tokens.map((token) => ({
+				id: token.id,
+				scope: token.scope,
+				expiresAt: token.expiresAt,
+				createdAt: token.createdAt,
+			}))
+		},
+		revokeToken: async (idOrPlaintext) => {
+			await repo.revokeToken(idOrPlaintext)
+		},
+	}
+}
+
+function adaptNativeArtifactsBinding(
+	native: Artifacts,
+): ArtifactNamespaceBinding & Record<string, unknown> {
+	const repo = (name: string): ArtifactRepoHandle => ({
+		info: async () => {
+			const handle = await native.get(name)
+			return adaptNativeRepoHandle(handle).info()
+		},
+		createToken: async (scope = 'write', ttl = 3600) => {
+			const handle = await native.get(name)
+			return adaptNativeRepoHandle(handle).createToken(scope, ttl)
+		},
+		listTokens: async () => {
+			const handle = await native.get(name)
+			return adaptNativeRepoHandle(handle).listTokens?.() ?? []
+		},
+		revokeToken: async (idOrPlaintext) => {
+			const handle = await native.get(name)
+			await adaptNativeRepoHandle(handle).revokeToken?.(idOrPlaintext)
+		},
+	})
+	return {
+		create: async (name, opts) => {
+			const created = await native.create(name, opts)
+			return {
+				id: created.id,
+				name: created.name,
+				description: created.description,
+				defaultBranch: created.defaultBranch,
+				remote: created.remote,
+				token: created.token,
+				expiresAt: created.tokenExpiresAt,
+			}
+		},
+		get: async (name) => {
+			try {
+				const handle = await native.get(name)
+				return {
+					status: 'ready' as const,
+					repo: adaptNativeRepoHandle(handle),
+				}
+			} catch (error) {
+				if (isArtifactsBindingError(error) && error.code === 'NOT_FOUND') {
+					return { status: 'not_found' as const }
+				}
+				if (
+					isArtifactsBindingError(error) &&
+					error.code === 'IMPORT_IN_PROGRESS'
+				) {
+					return { status: 'importing' as const, retryAfter: 5 }
+				}
+				throw error
+			}
+		},
+		delete: async (name) => {
+			const deleted = await native.delete(name)
+			return {
+				id: null,
+				alreadyDeleted: !deleted,
+			}
+		},
+		list: async (opts) => await native.list(opts),
+		repo,
+	}
 }
 
 function createArtifactsRestBinding(env: Env, namespace: string) {
@@ -338,6 +463,7 @@ function createArtifactsRestBinding(env: Env, namespace: string) {
 				cursor: envelope.result_info?.cursor,
 			}
 		},
+		repo: (name) => repoHandle(name),
 	} satisfies ArtifactNamespaceBinding & Record<string, unknown>
 }
 
@@ -375,6 +501,14 @@ async function requestArtifactsEnvelope<T>(
 			query: input.query,
 			body: input.body,
 		})
+		if (response.cfRay) {
+			console.info('artifacts-rest', {
+				method: input.method,
+				path: input.path,
+				status: response.status,
+				cfRay: response.cfRay,
+			})
+		}
 		const envelope = response.body as ArtifactApiEnvelope<T> | null
 		if (!envelope?.success) {
 			const primaryError = envelope?.errors?.[0]
@@ -628,6 +762,7 @@ function isArtifactRepoAlreadyExistsError(error: unknown) {
 			: null
 	return (
 		causeCode === 10201 ||
+		(isArtifactsBindingError(error) && error.code === 'ALREADY_EXISTS') ||
 		/already[\s_-]*exists|already_exists/i.test(`${text} ${causeMessage}`)
 	)
 }
@@ -691,12 +826,6 @@ export async function ensureArtifactRepoReady(
 		}
 		throw error
 	}
-	const getResult = await binding.get(created.name)
-	if (getResult.status !== 'ready') {
-		throw new Error(
-			`Artifacts repo "${created.name}" is ${getResult.status} after create.`,
-		)
-	}
 	const bootstrapAccess = {
 		defaultBranch: created.defaultBranch,
 		remote: created.remote,
@@ -706,7 +835,7 @@ export async function ensureArtifactRepoReady(
 	return {
 		recreated: true,
 		bootstrapAccess,
-		repo: getResult.repo,
+		repo: binding.repo(created.name),
 	}
 }
 

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -268,7 +268,16 @@ function adaptNativeArtifactsBinding(
 				defaultBranch: created.defaultBranch,
 				remote: created.remote,
 				token: created.token,
-				expiresAt: created.tokenExpiresAt,
+				// Provider create currently omits tokenExpiresAt despite the
+				// generated binding type. Prefer the field when present; else
+				// parse `?expires=` from the token; else leave empty.
+				expiresAt: resolveCreatedTokenExpiry({
+					token: created.token,
+					tokenExpiresAt:
+						typeof created.tokenExpiresAt === 'string'
+							? created.tokenExpiresAt
+							: null,
+				}),
 			}
 		},
 		get: async (name) => {
@@ -566,6 +575,12 @@ function normalizeArtifactRepoInfo(
 }
 
 function parseArtifactTokenExpiry(token: string) {
+	const expiresAt = tryParseArtifactTokenExpiry(token)
+	if (expiresAt) return expiresAt
+	throw new Error('Artifacts token is missing a parseable expires timestamp.')
+}
+
+function tryParseArtifactTokenExpiry(token: string) {
 	const expiresAtSeconds = Number.parseInt(
 		token.split('?expires=')[1] ?? '',
 		10,
@@ -573,7 +588,16 @@ function parseArtifactTokenExpiry(token: string) {
 	if (Number.isFinite(expiresAtSeconds)) {
 		return new Date(expiresAtSeconds * 1000).toISOString()
 	}
-	throw new Error('Artifacts token is missing a parseable expires timestamp.')
+	return null
+}
+
+function resolveCreatedTokenExpiry(input: {
+	token: string
+	tokenExpiresAt?: string | null
+}) {
+	const fromBinding = input.tokenExpiresAt?.trim()
+	if (fromBinding) return fromBinding
+	return tryParseArtifactTokenExpiry(input.token) ?? ''
 }
 
 function normalizeRepoNamePart(value: string) {

--- a/packages/worker/src/repo/package-subscriptions.ts
+++ b/packages/worker/src/repo/package-subscriptions.ts
@@ -20,7 +20,6 @@ import {
 	repoPushedTopic,
 	topicForArtifactsRepoEvent,
 } from './artifacts-events.ts'
-import { ensureArtifactsRepoPushSubscription } from './artifacts-push-subscriptions.ts'
 import { getEntitySourceByRepoId } from './entity-sources.ts'
 import { type EntitySourceRow } from './types.ts'
 import { getUserRepoById } from './user-repos.ts'
@@ -408,15 +407,6 @@ export async function processCloudflareArtifactsRepoEvent(input: {
 	)
 	if (!source) {
 		return { outcome: 'unmatched', providerEvent }
-	}
-
-	if (providerEvent.type === 'cf.artifacts.repo.created') {
-		await ensureArtifactsRepoPushSubscription({
-			env: input.env,
-			userId: source.user_id,
-			sourceId: source.id,
-			repoName: source.repo_id,
-		})
 	}
 
 	await dispatchRepoSubscriptionEvents({

--- a/packages/worker/src/repo/package-subscriptions.ts
+++ b/packages/worker/src/repo/package-subscriptions.ts
@@ -185,6 +185,8 @@ function buildSubscriptionIdempotencyKey(input: {
 			if (input.event.type !== 'cf.artifacts.repo.pushed') {
 				throw new Error('repo.pushed idempotency requires a pushed event')
 			}
+			// Omit source.type so account-level and leftover repo-scoped
+			// publications of the same push collapse to one invocation.
 			return `repo-push:${input.repoId}:${input.event.payload.after}:${input.event.payload.ref}:${input.packageId}`
 		}
 		case repoCreatedTopic:

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -181,18 +181,6 @@ test('ensureEntitySource workflow: fail-closed, bootstrap, recreate missing repo
 		getRepoCountRef: newJobGetRepoCount,
 	})
 
-	let releasePushSubscription!: (value: {
-		subscriptionId: string | null
-		skipped: boolean
-	}) => void
-	mocks.ensureArtifactsRepoPushSubscription.mockImplementation(
-		() =>
-			new Promise((resolve) => {
-				releasePushSubscription = resolve
-			}),
-	)
-	mocks.waitUntil.mockImplementation(() => {})
-
 	try {
 		const serverTiming: Array<{ name: string; durationMs: number }> = []
 		const newSource = await ensureEntitySource({
@@ -210,7 +198,7 @@ test('ensureEntitySource workflow: fail-closed, bootstrap, recreate missing repo
 			serverTiming,
 		})
 
-		expect(newJobFetchMock).toHaveBeenCalledTimes(3)
+		expect(newJobFetchMock).toHaveBeenCalledTimes(2)
 		expect(newSource.repo_id).toBe('job-job-1')
 		expect(newSource.bootstrapAccess).toEqual({
 			defaultBranch: 'main',
@@ -222,9 +210,7 @@ test('ensureEntitySource workflow: fail-closed, bootstrap, recreate missing repo
 			'artifacts-repo-ready',
 			'entity-source-insert',
 		])
-		expect(mocks.waitUntil).toHaveBeenCalledTimes(1)
-		releasePushSubscription({ subscriptionId: null, skipped: true })
-		await mocks.waitUntil.mock.calls[0]?.[0]
+		expect(mocks.waitUntil).toHaveBeenCalledTimes(0)
 	} finally {
 		newJobFetchMock.mockRestore()
 		// Restore settled defaults before later phases so hanging push-subscription
@@ -281,7 +267,7 @@ test('ensureEntitySource workflow: fail-closed, bootstrap, recreate missing repo
 			sourceRoot: '/',
 		})
 
-		expect(recreateFetchMock).toHaveBeenCalledTimes(3)
+		expect(recreateFetchMock).toHaveBeenCalledTimes(2)
 		expect(recreateRunMock).toHaveBeenCalledTimes(1)
 		expect(recreatedSource).toMatchObject({
 			...existingRow,
@@ -375,7 +361,7 @@ test('ensureEntitySource workflow: fail-closed, bootstrap, recreate missing repo
 		expect(reuseRunMock).not.toHaveBeenCalled()
 		expect(reusedSource).toEqual(existingRow)
 		expect(reusedSource.bootstrapAccess).toBeUndefined()
-		expect(mocks.waitUntil).toHaveBeenCalledTimes(1)
+		expect(mocks.waitUntil).toHaveBeenCalledTimes(0)
 	} finally {
 		reuseFetchMock.mockRestore()
 	}

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -160,7 +160,9 @@ function missingPersistenceRequirements(input: {
 		missing.push('APP_DB')
 	}
 	if (!input.hasArtifactsAccess) {
-		missing.push('ARTIFACTS binding or CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN')
+		missing.push(
+			'ARTIFACTS binding or CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN',
+		)
 	}
 	return missing
 }

--- a/packages/worker/src/repo/source-service.ts
+++ b/packages/worker/src/repo/source-service.ts
@@ -1,11 +1,9 @@
-import { waitUntil } from 'cloudflare:workers'
 import {
 	buildEntityRepoId,
 	hasArtifactsAccess,
 	ensureArtifactRepoReady,
 	type ArtifactBootstrapAccess,
 } from './artifacts.ts'
-import { ensureArtifactsRepoPushSubscription } from './artifacts-push-subscriptions.ts'
 import {
 	getEntitySourceByEntity,
 	insertEntitySource,
@@ -124,12 +122,6 @@ export async function ensureEntitySource(input: {
 				indexedCommit: null,
 			})
 		}
-		scheduleArtifactsRepoPushSubscription({
-			env: input.env,
-			userId: existing.user_id,
-			sourceId: existing.id,
-			repoName: existing.repo_id,
-		})
 		return source
 	}
 	const row = buildEntitySourceRow({
@@ -149,27 +141,10 @@ export async function ensureEntitySource(input: {
 	await pushServerTiming(input.serverTiming, 'entity-source-insert', () =>
 		insertEntitySource(input.db, row),
 	)
-	scheduleArtifactsRepoPushSubscription({
-		env: input.env,
-		userId: row.user_id,
-		sourceId: row.id,
-		repoName: row.repo_id,
-	})
 	return {
 		...row,
 		bootstrapAccess: repoReady.recreated ? repoReady.bootstrapAccess : null,
 	}
-}
-
-function scheduleArtifactsRepoPushSubscription(input: {
-	env: Env
-	userId: string
-	sourceId: string
-	repoName: string
-}) {
-	// Best-effort; also runs from the repo.created consumer. Do not await —
-	// listing queues/subscriptions is not on the source-creation hot path.
-	waitUntil(ensureArtifactsRepoPushSubscription(input))
 }
 
 function hasAppDbBinding(db: D1Database | null | undefined) {
@@ -185,7 +160,7 @@ function missingPersistenceRequirements(input: {
 		missing.push('APP_DB')
 	}
 	if (!input.hasArtifactsAccess) {
-		missing.push('CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN')
+		missing.push('ARTIFACTS binding or CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN')
 	}
 	return missing
 }

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -427,6 +427,12 @@
 			"ai": {
 				"binding": "AI",
 			},
+			"artifacts": [
+				{
+					"binding": "ARTIFACTS",
+					"namespace": "production",
+				},
+			],
 			"vars": {
 				"SENTRY_ENVIRONMENT": "production",
 				"SIGNUP_MODE": "invite",
@@ -784,6 +790,12 @@
 			"ai": {
 				"binding": "AI",
 			},
+			"artifacts": [
+				{
+					"binding": "ARTIFACTS",
+					"namespace": "preview",
+				},
+			],
 			"vars": {
 				"SENTRY_ENVIRONMENT": "preview",
 				"SIGNUP_MODE": "invite",

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -863,7 +863,7 @@ test('ensureArtifactsAccountEventSubscription creates account-level lifecycle su
 					type: 'queues.queue',
 					queue_id: 'queue-artifacts',
 				},
-				events: ['repo.created', 'repo.deleted'],
+				events: ['repo.created', 'repo.deleted', 'repo.pushed'],
 			}),
 		}),
 	)

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -85,6 +85,7 @@ export const emailSendingEventTypes = [
 export const artifactsAccountEventTypes = [
 	'repo.created',
 	'repo.deleted',
+	'repo.pushed',
 ] as const
 
 export function fail(message: string): never {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Cut remaining `community_fork` wait on Artifacts create/ready and per-repo push-subscription POSTs, using Dillon’s confirmed Event Hub and binding facts. Empty `POST /repos` is already a ready empty git repo; account-level `repo.pushed` covers package repos so we do not need a per-repo subscription on the source-create path.

## Summary

- After a successful Artifacts create, skip the confirm-ready GET and use `binding.repo(name)` (local handle).
- Prefer the Worker `ARTIFACTS` binding when the requested namespace matches `ARTIFACTS_NAMESPACE`; REST remains the fallback. Native adapter maps `tokenExpiresAt`, `NOT_FOUND` / `IMPORT_IN_PROGRESS`, and `ALREADY_EXISTS`. Create does not catch a binding failure and retry REST.
- Native create `expiresAt` tolerates the current provider dropping `tokenExpiresAt`: prefer the field, else parse `?expires=` from the token, else empty.
- Add wrangler `artifacts` bindings for production (`namespace: "production"`) and preview (`namespace: "preview"`).
- Accept account-level `source.type === "artifacts"` on `cf.artifacts.repo.pushed` (repo-scoped `artifacts.repo` still works). Add `repo.pushed` to the account Event Hub subscription types so deploy PATCHes the existing account subscription.
- Stop scheduling per-repo `artifacts.repo` POSTs from `ensureEntitySource` and from `repo.created`. Leftover D1 rows stay until a later cleanup. `repo.pushed` invoke keys omit `source.type` so account + leftover repo-scoped publications of the same push collapse.
- Log Artifacts REST `{ method, path, status, cfRay }` with `/tokens/:token` redacted so revoke never writes a plaintext token.

Out of scope: custom receive-pack (keep two isomorphic-git pushes), persisted fork timings, snapshot-first / lazy-git, bulk delete of historical per-repo subscriptions (follow-up after this deploy).

## Testing

- Focused Node tests: `artifacts` (8), `artifacts-events`, `source-service`, `cloudflare-rest-client`, `resource-utils`, `package-subscriptions`.
- CodeRabbit: accepted token-path redaction + revoke log test. Kept account-level `repo.pushed` — first-party Event Hub fact.
- Dillon review (gist): no catch-and-REST (already true); tolerate missing `tokenExpiresAt` (this SHA); leftover per-repo overlap is idempotent, cleanup is a follow-up.

## System changes

See the system recap below. Medium risk: native binding plus a live account-subscription PATCH on deploy.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ec24819d` · **Head:** `b81a0a99`

**Classification:** extends — Artifacts create/ready contract and repo-session push-event wiring change; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `artifacts-repos` | storage | extends — skip post-create GET; prefer native `ARTIFACTS` binding; tolerate missing `tokenExpiresAt`; REST logs CF-Ray with token paths redacted |
| `repo-sessions` | runtime | extends — accept account-level `repo.pushed`; drop per-repo push-sub schedule |
| `mcp-server` | surfaces | extends — Cloudflare REST client returns `cfRay` |

### System map

Fork/install create now returns a local repo handle from the native binding (or REST), and push events arrive on the account Event Hub instead of a per-repo subscription POST.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	artifactsRepos -->|"native create + local repo handle"| repoSessions
	repoSessions -->|"account repo.pushed / no per-repo POST"| artifactsRepos
	mcpServer -->|"REST fallback + redacted cfRay log"| artifactsRepos
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Fork as community_fork
	participant Src as ensureEntitySource
	participant Art as Artifacts create
	participant Hub as account Event Hub
	Fork->>Src: ensure source
	Src->>Art: create empty repo
	Art-->>Src: 201 ready (remote + token)
	Note over Src: no confirm GET, no per-repo sub POST
	Src-->>Fork: bootstrapAccess
	Hub-->>Src: cf.artifacts.repo.pushed (source.type artifacts)
```

### Before / after

| Path | Before | After |
| ---- | ------ | ----- |
| Create ready | `POST /repos` then `GET` until ready | `POST` 201 is ready; `binding.repo(name)` |
| Binding | REST only (`api.cloudflare.com`) | Native `env.ARTIFACTS` when namespace matches; REST fallback |
| Push events | Per-repo `artifacts.repo` subscription POST | Account `repo.pushed` + existing `repo.created` / `repo.deleted` |
| REST observability | status only | `{ method, path, status, cfRay }` with `/tokens/:token` redacted |

### Invariants

Per-user isolation is unchanged: Artifacts repo names and Event Hub delivery stay user-scoped. Tokens are not logged.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Artifacts repository access with REST fallback.
  * Added support for account-level `repo.pushed` events alongside repository-scoped events.
  * Repository creation can return ready-to-use metadata without an additional lookup.
  * Added optional Artifacts bindings for production and preview environments.

* **Bug Fixes**
  * Improved handling of missing, importing, and duplicate repositories.
  * Cloudflare Ray identifiers are now available for request diagnostics.

* **Documentation**
  * Updated setup, environment variable, repository event, and binding configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->