### PR TITLE
Treat native ArtifactsError NOT_FOUND without instanceof Error

### DIFF
--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -675,7 +675,32 @@ test('getArtifactsBinding prefers the native ARTIFACTS binding for the env names
 		readOnly: false,
 	})
 
-	nativeGet.mockClear()
+	nativeGet.mockReset()
+	nativeGet.mockImplementation(async () => {
+		throw {
+			name: 'ArtifactsError',
+			message: 'Repository not found: repo-native-message-only',
+		}
+	})
+	await expect(binding.get('repo-native-message-only')).resolves.toEqual({
+		status: 'not_found',
+	})
+	nativeGet.mockReset()
+	nativeGet.mockImplementation(async () => {
+		throw new Error('git: repository not found on the remote')
+	})
+	await expect(binding.get('repo-unrelated-not-found')).rejects.toThrow(
+		/git: repository not found/,
+	)
+
+	nativeGet.mockReset()
+	nativeGet.mockImplementation(async () => {
+		throw {
+			name: 'ArtifactsError',
+			code: 'NOT_FOUND',
+			message: 'Repository not found: repo-native-no-exp',
+		}
+	})
 	nativeCreate.mockImplementation(async () => ({
 		id: 'repo_native_no_exp',
 		name: 'repo-native-no-exp',

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -694,6 +694,52 @@ test('getArtifactsBinding prefers the native ARTIFACTS binding for the env names
 			expiresAt: '2025-10-09T08:53:20.000Z',
 		},
 	})
+
+	const readyHandle = {
+		id: 'repo_exists',
+		name: 'repo-native-exists',
+		description: null,
+		defaultBranch: 'main',
+		createdAt: '2026-08-13T00:00:00.000Z',
+		updatedAt: '2026-08-13T00:00:00.000Z',
+		lastPushAt: null,
+		source: null,
+		readOnly: false,
+		remote:
+			'https://acct.artifacts.cloudflare.net/git/production/repo-native-exists.git',
+		createToken: vi.fn(),
+		listTokens: vi.fn(),
+		revokeToken: vi.fn(),
+	}
+	let existsGets = 0
+	nativeGet.mockReset()
+	nativeGet.mockImplementation(async () => {
+		existsGets += 1
+		if (existsGets === 1) {
+			throw {
+				name: 'ArtifactsError',
+				code: 'NOT_FOUND',
+				message: 'Repository not found: repo-native-exists',
+			}
+		}
+		return readyHandle
+	})
+	nativeCreate.mockReset()
+	nativeCreate.mockImplementation(async () => {
+		throw {
+			name: 'ArtifactsError',
+			code: 'ALREADY_EXISTS',
+			message: 'Repository already exists: repo-native-exists',
+		}
+	})
+	await expect(
+		ensureArtifactRepoReady(env, 'repo-native-exists', binding),
+	).resolves.toMatchObject({
+		recreated: false,
+		repo: expect.any(Object),
+	})
+	expect(nativeCreate).toHaveBeenCalledTimes(1)
+	expect(existsGets).toBeGreaterThan(1)
 })
 
 test('artifacts REST logs redact plaintext tokens on revoke', async () => {

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -640,6 +640,41 @@ test('getArtifactsBinding prefers the native ARTIFACTS binding for the env names
 	expect(nativeCreate).toHaveBeenCalledWith('repo-native', { readOnly: false })
 	expect(nativeGet).toHaveBeenCalledTimes(2)
 
+	const duckTypedNotFound = {
+		name: 'ArtifactsError',
+		code: 'NOT_FOUND',
+		message: 'Repository not found: repo-native-duck',
+	}
+	nativeGet.mockReset()
+	nativeGet.mockImplementation(async () => {
+		throw duckTypedNotFound
+	})
+	nativeCreate.mockClear()
+	nativeCreate.mockImplementation(async () => ({
+		id: 'repo_native_duck',
+		name: 'repo-native-duck',
+		description: null,
+		defaultBranch: 'main',
+		remote:
+			'https://acct.artifacts.cloudflare.net/git/production/repo-native-duck.git',
+		token: 'art_v2_native?expires=1760000000',
+	}))
+	await expect(binding.get('repo-native-duck')).resolves.toEqual({
+		status: 'not_found',
+	})
+	await expect(
+		ensureArtifactRepoReady(env, 'repo-native-duck', binding),
+	).resolves.toMatchObject({
+		recreated: true,
+		bootstrapAccess: {
+			token: 'art_v2_native?expires=1760000000',
+			expiresAt: '2025-10-09T08:53:20.000Z',
+		},
+	})
+	expect(nativeCreate).toHaveBeenCalledWith('repo-native-duck', {
+		readOnly: false,
+	})
+
 	nativeGet.mockClear()
 	nativeCreate.mockImplementation(async () => ({
 		id: 'repo_native_no_exp',

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -191,12 +191,32 @@ type ArtifactRestStoredToken = {
 }
 
 function isArtifactsBindingError(error: unknown): error is ArtifactsError {
+	// Binding errors may not pass `instanceof Error` across the JSRPC
+	// boundary. Match the documented `{ name, code }` shape only.
+	if (error === null || typeof error !== 'object') return false
+	const candidate = error as { name?: unknown; code?: unknown }
 	return (
-		error instanceof Error &&
-		error.name === 'ArtifactsError' &&
-		'code' in error &&
-		typeof error.code === 'string'
+		candidate.name === 'ArtifactsError' && typeof candidate.code === 'string'
 	)
+}
+
+function artifactsBindingErrorCode(error: unknown) {
+	if (isArtifactsBindingError(error)) return error.code
+	const message =
+		error instanceof Error
+			? error.message
+			: typeof error === 'object' &&
+				  error !== null &&
+				  'message' in error &&
+				  typeof error.message === 'string'
+				? error.message
+				: ''
+	if (/repository not found/i.test(message)) return 'NOT_FOUND'
+	if (/already[\s_-]*exists/i.test(message)) return 'ALREADY_EXISTS'
+	if (/import[\s_-]*in[\s_-]*progress/i.test(message)) {
+		return 'IMPORT_IN_PROGRESS'
+	}
+	return null
 }
 
 function adaptNativeRepoHandle(repo: ArtifactsRepo): ArtifactRepoHandle {
@@ -288,13 +308,11 @@ function adaptNativeArtifactsBinding(
 					repo: adaptNativeRepoHandle(handle),
 				}
 			} catch (error) {
-				if (isArtifactsBindingError(error) && error.code === 'NOT_FOUND') {
+				const code = artifactsBindingErrorCode(error)
+				if (code === 'NOT_FOUND') {
 					return { status: 'not_found' as const }
 				}
-				if (
-					isArtifactsBindingError(error) &&
-					error.code === 'IMPORT_IN_PROGRESS'
-				) {
+				if (code === 'IMPORT_IN_PROGRESS') {
 					return { status: 'importing' as const, retryAfter: 5 }
 				}
 				throw error
@@ -788,7 +806,7 @@ function isArtifactRepoAlreadyExistsError(error: unknown) {
 			: null
 	return (
 		causeCode === 10201 ||
-		(isArtifactsBindingError(error) && error.code === 'ALREADY_EXISTS') ||
+		artifactsBindingErrorCode(error) === 'ALREADY_EXISTS' ||
 		/already[\s_-]*exists|already_exists/i.test(`${text} ${causeMessage}`)
 	)
 }

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -791,6 +791,9 @@ export async function readMockArtifactSnapshot(input: {
 }
 
 function isArtifactRepoAlreadyExistsError(error: unknown) {
+	if (artifactsBindingErrorCode(error) === 'ALREADY_EXISTS') {
+		return true
+	}
 	if (!(error instanceof Error)) {
 		return false
 	}
@@ -806,7 +809,6 @@ function isArtifactRepoAlreadyExistsError(error: unknown) {
 			: null
 	return (
 		causeCode === 10201 ||
-		artifactsBindingErrorCode(error) === 'ALREADY_EXISTS' ||
 		/already[\s_-]*exists|already_exists/i.test(`${text} ${causeMessage}`)
 	)
 }

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -202,18 +202,23 @@ function isArtifactsBindingError(error: unknown): error is ArtifactsError {
 
 function artifactsBindingErrorCode(error: unknown) {
 	if (isArtifactsBindingError(error)) return error.code
-	const message =
-		error instanceof Error
-			? error.message
-			: typeof error === 'object' &&
-				  error !== null &&
-				  'message' in error &&
-				  typeof error.message === 'string'
-				? error.message
-				: ''
-	if (/repository not found/i.test(message)) return 'NOT_FOUND'
-	if (/already[\s_-]*exists/i.test(message)) return 'ALREADY_EXISTS'
-	if (/import[\s_-]*in[\s_-]*progress/i.test(message)) {
+	if (error === null || typeof error !== 'object') return null
+	const candidate = error as { name?: unknown; message?: unknown }
+	// Message fallback only for ArtifactsError with known prefixes so a
+	// generic git/HTTP "not found" cannot look like a create-safe miss.
+	if (
+		candidate.name !== 'ArtifactsError' ||
+		typeof candidate.message !== 'string'
+	) {
+		return null
+	}
+	if (/^Repository not found(?::|\b)/.test(candidate.message)) {
+		return 'NOT_FOUND'
+	}
+	if (/^Repository already exists(?::|\b)/.test(candidate.message)) {
+		return 'ALREADY_EXISTS'
+	}
+	if (/^Import in progress(?::|\b)/i.test(candidate.message)) {
 		return 'IMPORT_IN_PROGRESS'
 	}
 	return null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock `community_fork` on production after #1437. Native `ARTIFACTS.get` throws `ArtifactsError: Repository not found` for a repo we are about to create; the adapter required `instanceof Error`, which JSRPC binding errors may not satisfy, so `NOT_FOUND` escaped before `create`.

## Summary

- Match `{ name: 'ArtifactsError', code }` without `instanceof Error`.
- Message fallback only for `ArtifactsError` messages that start with `Repository not found`, `Repository already exists`, or `Import in progress`. A generic git "repository not found" does not map.
- Recognize duck-typed `ALREADY_EXISTS` **before** the `instanceof Error` guard so create conflicts wait instead of rethrowing.

## Testing

- Duck-typed `{ name, code, message }` (not an `Error` instance) is `not_found`, then create proceeds.
- `ArtifactsError` message-only `Repository not found: …` maps; `Error('git: repository not found…')` does not.
- Duck-typed `ALREADY_EXISTS` on create waits and returns the existing repo.
- Production: `community_fork` of `@kody/personal-capture` on `74eda525` threw `ArtifactsError: Repository not found: package-<new-uuid>`. Re-probe after this deploy.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `74eda525` · **Head:** `a27fe0dd`

**Classification:** extends — Artifacts binding error matching; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `artifacts-repos` | storage | extends — recognize JSRPC `ArtifactsError` without `instanceof Error` |
| `repo-sessions` | runtime | composes — test only |

### System map

Native `get` miss for a new repo name must become `not_found` so `create` can run. Duck-typed `ALREADY_EXISTS` must take the wait-ready path.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	artifactsRepos -->|"get NOT_FOUND then create"| repoSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of artifact repository errors across runtime boundaries.
  - Missing repositories are now correctly detected and recreated when appropriate.
  - Repository creation conflicts and in-progress imports are handled more reliably.
  - Expiration times are correctly derived from returned access tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->