### PR TITLE
Map flattened ArtifactsError and enable enhanced_error_serialization

### DIFF
--- a/packages/mock-servers/cloudflare/wrangler.jsonc
+++ b/packages/mock-servers/cloudflare/wrangler.jsonc
@@ -2,7 +2,11 @@
 	"$schema": "../../../node_modules/wrangler/config-schema.json",
 	"name": "kody-mock-cloudflare",
 	"compatibility_date": "2026-04-16",
-	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+	"compatibility_flags": [
+		"nodejs_compat",
+		"global_fetch_strictly_public",
+		"enhanced_error_serialization",
+	],
 	"main": "./src/worker.ts",
 	"preview_urls": true,
 	"observability": { "enabled": true },

--- a/packages/worker/src/dynamic-worker-compatibility.node.test.ts
+++ b/packages/worker/src/dynamic-worker-compatibility.node.test.ts
@@ -7,6 +7,9 @@ import {
 
 test('dynamic and mock Cloudflare worker compatibility match the main wrangler config', () => {
 	const mainWorker = readMainWorkerWranglerCompatibility()
+	expect(mainWorker.compatibilityFlags).toContain(
+		'enhanced_error_serialization',
+	)
 	expect(createDynamicWorkerCompatibilityOptions()).toEqual({
 		compatibilityDate: mainWorker.compatibilityDate,
 		compatibilityFlags: mainWorker.compatibilityFlags,

--- a/packages/worker/src/dynamic-worker-compatibility.ts
+++ b/packages/worker/src/dynamic-worker-compatibility.ts
@@ -7,6 +7,7 @@ export const dynamicWorkerCompatibilityDate = '2026-04-16'
 export const dynamicWorkerCompatibilityFlags = [
 	'nodejs_compat',
 	'global_fetch_strictly_public',
+	'enhanced_error_serialization',
 ] as const
 
 export type DynamicWorkerCompatibilityOptions = {

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -692,6 +692,15 @@ test('getArtifactsBinding prefers the native ARTIFACTS binding for the env names
 	await expect(binding.get('repo-unrelated-not-found')).rejects.toThrow(
 		/git: repository not found/,
 	)
+	nativeGet.mockReset()
+	nativeGet.mockImplementation(async () => {
+		throw new Error(
+			'ArtifactsError: Repository not found: repo-native-prefixed',
+		)
+	})
+	await expect(binding.get('repo-native-prefixed')).resolves.toEqual({
+		status: 'not_found',
+	})
 
 	nativeGet.mockReset()
 	nativeGet.mockImplementation(async () => {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -200,28 +200,51 @@ function isArtifactsBindingError(error: unknown): error is ArtifactsError {
 	)
 }
 
+function readArtifactsErrorMessage(error: unknown) {
+	if (typeof error === 'string') return error
+	if (error instanceof Error) return error.message
+	if (
+		error !== null &&
+		typeof error === 'object' &&
+		'message' in error &&
+		typeof error.message === 'string'
+	) {
+		return error.message
+	}
+	return ''
+}
+
 function artifactsBindingErrorCode(error: unknown) {
 	if (isArtifactsBindingError(error)) return error.code
-	if (error === null || typeof error !== 'object') return null
-	const candidate = error as { name?: unknown; message?: unknown }
-	// Message fallback only for ArtifactsError with known prefixes so a
-	// generic git/HTTP "not found" cannot look like a create-safe miss.
-	if (
-		candidate.name !== 'ArtifactsError' ||
-		typeof candidate.message !== 'string'
-	) {
-		return null
-	}
-	if (/^Repository not found(?::|\b)/.test(candidate.message)) {
-		return 'NOT_FOUND'
-	}
-	if (/^Repository already exists(?::|\b)/.test(candidate.message)) {
+	// JSRPC may flatten the class so `name` is Error and the message is
+	// `ArtifactsError: Repository not found: <repo>`. Strip that prefix,
+	// then require the known create-safe starts.
+	const message = readArtifactsErrorMessage(error).replace(
+		/^ArtifactsError:\s*/,
+		'',
+	)
+	if (/^Repository not found(?::|\b)/.test(message)) return 'NOT_FOUND'
+	if (/^Repository already exists(?::|\b)/.test(message)) {
 		return 'ALREADY_EXISTS'
 	}
-	if (/^Import in progress(?::|\b)/i.test(candidate.message)) {
+	if (/^Import in progress(?::|\b)/i.test(message)) {
 		return 'IMPORT_IN_PROGRESS'
 	}
 	return null
+}
+
+async function getNativeRepoOrThrow(native: Artifacts, name: string) {
+	try {
+		return await native.get(name)
+	} catch (error) {
+		const code = artifactsBindingErrorCode(error)
+		if (code === 'NOT_FOUND') {
+			throw new Error(`Artifacts repo "${name}" was not found.`, {
+				cause: error,
+			})
+		}
+		throw error
+	}
 }
 
 function adaptNativeRepoHandle(repo: ArtifactsRepo): ArtifactRepoHandle {
@@ -267,19 +290,19 @@ function adaptNativeArtifactsBinding(
 ): ArtifactNamespaceBinding & Record<string, unknown> {
 	const repo = (name: string): ArtifactRepoHandle => ({
 		info: async () => {
-			const handle = await native.get(name)
+			const handle = await getNativeRepoOrThrow(native, name)
 			return adaptNativeRepoHandle(handle).info()
 		},
 		createToken: async (scope = 'write', ttl = 3600) => {
-			const handle = await native.get(name)
+			const handle = await getNativeRepoOrThrow(native, name)
 			return adaptNativeRepoHandle(handle).createToken(scope, ttl)
 		},
 		listTokens: async () => {
-			const handle = await native.get(name)
+			const handle = await getNativeRepoOrThrow(native, name)
 			return adaptNativeRepoHandle(handle).listTokens?.() ?? []
 		},
 		revokeToken: async (idOrPlaintext) => {
-			const handle = await native.get(name)
+			const handle = await getNativeRepoOrThrow(native, name)
 			await adaptNativeRepoHandle(handle).revokeToken?.(idOrPlaintext)
 		},
 	})

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -2,7 +2,17 @@
 	"$schema": "../../node_modules/wrangler/config-schema.json",
 	"name": "kody",
 	"compatibility_date": "2026-04-16",
-	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+	// `enhanced_error_serialization` is date-default on 2026-04-21. Opt in
+	// explicitly so JSRPC from the Artifacts binding preserves `name`/`code`
+	// instead of flattening to `Error` + `ArtifactsError: …` message. Keep
+	// the structural matcher in `src/repo/artifacts.ts`; this flag does not
+	// restore custom prototype identity. Do not advance the date just to
+	// pick this up — 2026-04-21 also defaults `enable_python_external_sdk`.
+	"compatibility_flags": [
+		"nodejs_compat",
+		"global_fetch_strictly_public",
+		"enhanced_error_serialization",
+	],
 	// Paid default is 10_000 subrequests/invocation. The MCP Agent Durable
 	// Object keeps a long-lived session and each mutating storage_query pays
 	// several D1 + StorageRunner RPCs (entitlement baseline, sqlQuery,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`community_fork` is still broken on production after #1438 (`53ae3918`). The same probe threw `ArtifactsError: Repository not found: package-<new-uuid>`. #1438 required `name === 'ArtifactsError'` for the message fallback. Without `enhanced_error_serialization` (date-default 2026-04-21; Kody is dated 2026-04-16), JSRPC can flatten that into a plain `Error` whose **message** is `ArtifactsError: Repository not found: …`, so `get` still rethrew before `create`.

## Summary

- Strip a leading `ArtifactsError: ` from the error message, then match the same known prefixes (`Repository not found`, `Repository already exists`, `Import in progress`).
- A generic `git: repository not found` still does not map.
- Lazy native `repo()` gets go through the same matcher.
- Opt in `enhanced_error_serialization` on the main worker (and aligned dynamic/mock copies). Do not advance `compatibility_date` — 2026-04-21 also defaults `enable_python_external_sdk`. Keep the structural matcher; the flag does not restore custom prototype identity.

## Testing

- `new Error('ArtifactsError: Repository not found: repo-native-prefixed')` → `not_found`.
- Prior duck-typed `{ name, code }` and message-only `ArtifactsError` cases still pass.
- Dynamic/mock compatibility flags stay aligned with the main wrangler config and include `enhanced_error_serialization`.
- Preview smoke: health + seed login + `/account` on `kody-pr-1439`.
- Re-probe `community_fork` of `@kody/personal-capture` after deploy.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `53ae3918` · **Head:** `a7a405d2`

**Classification:** extends — Artifacts binding error matching plus consumer JSRPC serialization.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `artifacts-repos` | storage | extends — map flattened `ArtifactsError: Repository not found` and opt in `enhanced_error_serialization` |
| `repo-sessions` | runtime | composes — test only |

### System map

Native `get` miss must become `not_found` whether JSRPC preserves `{ name, code }` or flattens to a prefixed `Error.message`. The compatibility flag asks the consumer runtime to keep structured fields; the matcher stays as defense.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	artifactsRepos -->|"flattened or structured NOT_FOUND then create"| repoSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of native artifact repository lookup errors.
  * Repository-not-found errors now provide clearer, more descriptive feedback.
  * Other repository errors are preserved correctly instead of being misclassified.
  * Improved consistency across native repository handle operations.
  * Enhanced error details are now preserved for artifact-related errors.

* **Tests**
  * Added coverage for repository-not-found errors reported through native error messages.
  * Added verification for enhanced error serialization compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->