### PR TITLE
fix(repo): accept native Artifacts createToken.token as plaintext

### DIFF
--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -517,6 +517,80 @@ test('resolveArtifactDefaultBranchHead reuses a provided token and still works w
 	expect(createToken).not.toHaveBeenCalled()
 	expect(info).toHaveBeenCalledTimes(1)
 	expect(gitMocks.listServerRefs).toHaveBeenCalledTimes(1)
+
+	createToken.mockReset()
+	createToken.mockResolvedValue({
+		id: 'tok_empty',
+		plaintext: undefined,
+		scope: 'read',
+		expiresAt: '2026-10-09T08:55:00.000Z',
+	})
+	await expect(resolveArtifactDefaultBranchHead({ repo })).rejects.toThrow(
+		'Artifacts createToken result is missing plaintext.',
+	)
+	expect(gitMocks.listServerRefs).toHaveBeenCalledTimes(1)
+})
+
+test('native createToken maps token when JSRPC omits plaintext', async () => {
+	const nativeCreateToken = vi.fn(async () => ({
+		id: 'tok_native',
+		token: 'art_v2_read?expires=1760000100',
+		scope: 'read' as const,
+	}))
+	const env = {
+		ARTIFACTS_NAMESPACE: 'production',
+		ARTIFACTS: {
+			create: vi.fn(),
+			get: vi.fn(async () => ({
+				id: 'repo_1',
+				name: 'repo-1',
+				description: null,
+				defaultBranch: 'main',
+				createdAt: '2026-04-17T00:00:00.000Z',
+				updatedAt: '2026-04-17T00:00:00.000Z',
+				lastPushAt: null,
+				source: null,
+				readOnly: false,
+				remote:
+					'https://acct.artifacts.cloudflare.net/git/production/repo-1.git',
+				createToken: nativeCreateToken,
+				listTokens: vi.fn(async () => ({ tokens: [], total: 0 })),
+				revokeToken: vi.fn(),
+			})),
+			delete: vi.fn(),
+			list: vi.fn(async () => ({ repos: [], total: 0 })),
+		},
+	} as unknown as Env
+
+	const result = await getArtifactsBinding(env).get('repo-1')
+	expect(result.status).toBe('ready')
+	if (result.status !== 'ready') {
+		throw new Error('expected native repo to be ready')
+	}
+	await expect(result.repo.createToken('read', 120)).resolves.toEqual({
+		id: 'tok_native',
+		plaintext: 'art_v2_read?expires=1760000100',
+		scope: 'read',
+		expiresAt: '2025-10-09T08:55:00.000Z',
+	})
+	expect(nativeCreateToken).toHaveBeenCalledWith('read', 120)
+	expect(parseArtifactTokenSecret('art_v2_read?expires=1760000100')).toBe(
+		'art_v2_read',
+	)
+	expect(() =>
+		parseArtifactTokenSecret(undefined as unknown as string),
+	).toThrow('Artifacts token plaintext is missing.')
+	expect(() => parseArtifactTokenSecret('')).toThrow(
+		'Artifacts token plaintext is missing.',
+	)
+
+	nativeCreateToken.mockResolvedValueOnce({
+		id: 'tok_empty',
+		scope: 'read' as const,
+	})
+	await expect(result.repo.createToken('read', 120)).rejects.toThrow(
+		'Artifacts createToken result is missing plaintext.',
+	)
 })
 
 test('ensureArtifactRepoReady uses the create result without a follow-up GET', async () => {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -263,11 +263,16 @@ function adaptNativeRepoHandle(repo: ArtifactsRepo): ArtifactRepoHandle {
 		}),
 		createToken: async (scope = 'write', ttl = 3600) => {
 			const token = await repo.createToken(scope, ttl)
+			const plaintext = readArtifactTokenPlaintext(token)
 			return {
 				id: token.id,
-				plaintext: token.plaintext,
+				plaintext,
 				scope: token.scope,
-				expiresAt: token.expiresAt,
+				expiresAt: resolveCreatedTokenExpiry({
+					token: plaintext,
+					tokenExpiresAt:
+						typeof token.expiresAt === 'string' ? token.expiresAt : null,
+				}),
 			}
 		},
 		listTokens: async () => {
@@ -394,9 +399,10 @@ function createArtifactsRestBinding(env: Env, namespace: string) {
 					},
 				},
 			)
+			const plaintext = readArtifactTokenPlaintext(result)
 			return {
 				id: result.id,
-				plaintext: result.plaintext,
+				plaintext,
 				scope: result.scope,
 				expiresAt: result.expires_at,
 			}
@@ -637,6 +643,23 @@ function tryParseArtifactTokenExpiry(token: string) {
 	return null
 }
 
+function readArtifactTokenPlaintext(token: {
+	plaintext?: unknown
+	token?: unknown
+}) {
+	if (typeof token.plaintext === 'string' && token.plaintext.length > 0) {
+		return token.plaintext
+	}
+	// Native create() uses `token`; createToken is typed as `plaintext`.
+	// JSRPC can drop one or the other the same way it dropped
+	// `tokenExpiresAt`. Accept either so git remotes do not call
+	// `undefined.split`.
+	if (typeof token.token === 'string' && token.token.length > 0) {
+		return token.token
+	}
+	throw new Error('Artifacts createToken result is missing plaintext.')
+}
+
 function resolveCreatedTokenExpiry(input: {
 	token: string
 	tokenExpiresAt?: string | null
@@ -681,6 +704,9 @@ export function buildSessionRepoId(input: {
 }
 
 export function parseArtifactTokenSecret(token: string) {
+	if (typeof token !== 'string' || token.length === 0) {
+		throw new Error('Artifacts token plaintext is missing.')
+	}
 	return token.split('?expires=')[0] ?? token
 }
 
@@ -739,6 +765,9 @@ export async function resolveArtifactDefaultBranchHead(input: {
 	])
 	if (!info?.remote) {
 		throw new Error('Artifact repo remote URL is unavailable.')
+	}
+	if (typeof tokenPlaintext !== 'string' || tokenPlaintext.length === 0) {
+		throw new Error('Artifacts createToken result is missing plaintext.')
 	}
 	const refName = `refs/heads/${info.defaultBranch || 'main'}`
 	const refs = await listArtifactServerRefs({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

#1437 started preferring the native `ARTIFACTS` binding. Community fork create still works because `create()` returns `token`. Package edit / `package_get_git_remote` / `repo_open_session` mint a later token via `createToken()`, which is typed as `plaintext`. When JSRPC omits that field, `parseArtifactTokenSecret` calls `.split` on `undefined` and source-safety wraps it as a backup-snapshot failure.

## Summary

- Native `createToken` now accepts `plaintext` or `token`, then parses `?expires=` when `expiresAt` is missing.
- REST `createToken` uses the same reader so an empty plaintext fails clearly.
- `parseArtifactTokenSecret` and `resolveArtifactDefaultBranchHead` reject missing plaintext instead of throwing `Cannot read properties of undefined (reading 'split')`.

## Testing

- Focused: `npm run test:node -- packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/repo/artifacts-mock-cloudflare.node.test.ts` — 10 passed (includes native `{ token }` without `plaintext`, and the mock REST workflow in isolation).
- Full `npm run validate` on this VM: format/lint/primitives/migrations/docs/deploy-guardrails passed. Typecheck and several unit/e2e/mcp failures match Remix #1440 (`6f7fdaeb` on `main`) plus workerd `SQLITE_BUSY` under parallel load. The artifacts-mock timeout reproduced only inside that parallel run; isolation re-run passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6f7fdaeb` · **Head:** `25c5e644`

**Classification:** extends — native Artifacts `createToken` now maps `token` onto the existing `plaintext` contract used by git remotes and source-safety.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `artifacts-repos` | storage | extends — accept `token` or `plaintext` from native `createToken`; fail closed on a missing secret |
| `repo-sessions` | runtime | composes — regression tests only; session open still calls the same source-safety HEAD check |

### System map

Native `createToken` now yields a usable plaintext for package git remotes and source-safety HEAD checks.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	mcpServer -->|"package_get_git_remote createToken"| artifactsRepos
	repoSessions -->|"repo_open_session HEAD check"| artifactsRepos
	artifactsRepos -->|"plaintext or token"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cap as package_get_git_remote
	participant Safety as source-safety HEAD
	participant Native as ARTIFACTS.createToken
	Cap->>Safety: mint read/write token
	Safety->>Native: createToken(scope, ttl)
	Native-->>Safety: token (plaintext may be omitted)
	Safety-->>Cap: ArtifactToken.plaintext
	Cap->>Cap: parseArtifactTokenSecret
```

### Before / after

```text
before: native createToken.plaintext === undefined
        → token.split('?expires=') throws
        → "could not verify a restorable backup snapshot"

after:  read plaintext or token
        → missing both throws "createToken result is missing plaintext"
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token creation compatibility across supported response formats.
  * Added validation to reject incomplete token responses before authentication or branch lookup.
  * Improved expiration handling when token metadata is provided separately or encoded in the token.
  * Git authentication and default-branch resolution now fail clearly when token plaintext is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->