### PR TITLE
fix(repo): mint Artifacts tokens over REST when native binding is used

### DIFF
--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -589,8 +589,56 @@ test('native createToken maps token when JSRPC omits plaintext', async () => {
 		scope: 'read' as const,
 	})
 	await expect(result.repo.createToken('read', 120)).rejects.toThrow(
-		'Artifacts createToken result is missing plaintext.',
+		'Artifacts native createToken failed: Artifacts createToken result is missing plaintext.',
 	)
+
+	const restFetch = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = new URL(String(input))
+			const method = init?.method ?? 'GET'
+			if (method === 'POST' && url.pathname.endsWith('/tokens')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						result: {
+							id: 'tok_rest',
+							plaintext: 'art_v1_rest?expires=1760000100',
+							scope: 'read',
+							expires_at: '2026-10-09T08:55:00.000Z',
+						},
+						errors: [],
+						messages: [],
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					},
+				)
+			}
+			throw new Error(`Unexpected fetch: ${method} ${url.pathname}`)
+		})
+	const hybridEnv = {
+		...env,
+		CLOUDFLARE_ACCOUNT_ID: 'acct',
+		CLOUDFLARE_API_TOKEN: 'token-123',
+		CLOUDFLARE_API_BASE_URL: 'https://api.example.com',
+	} as unknown as Env
+	nativeCreateToken.mockClear()
+	const hybrid = await getArtifactsBinding(hybridEnv).get('repo-1')
+	expect(hybrid.status).toBe('ready')
+	if (hybrid.status !== 'ready') {
+		throw new Error('expected hybrid native repo to be ready')
+	}
+	await expect(hybrid.repo.createToken('read', 120)).resolves.toEqual({
+		id: 'tok_rest',
+		plaintext: 'art_v1_rest?expires=1760000100',
+		scope: 'read',
+		expiresAt: '2026-10-09T08:55:00.000Z',
+	})
+	expect(nativeCreateToken).not.toHaveBeenCalled()
+	expect(restFetch).toHaveBeenCalledTimes(1)
+	restFetch.mockRestore()
 })
 
 test('ensureArtifactRepoReady uses the create result without a follow-up GET', async () => {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
 	CloudflareApiError,
 	createCloudflareRestClient,
@@ -111,7 +112,7 @@ export function getArtifactsBinding(
 	const requestedNamespace = resolveArtifactsNamespace(env, namespace)
 	const native = readNativeArtifactsBinding(env)
 	if (native && requestedNamespace === getArtifactsNamespace(env)) {
-		return adaptNativeArtifactsBinding(native)
+		return adaptNativeArtifactsBinding(native, env)
 	}
 	const restBinding = createArtifactsRestBinding(env, requestedNamespace)
 	if (!restBinding) {
@@ -247,7 +248,10 @@ async function getNativeRepoOrThrow(native: Artifacts, name: string) {
 	}
 }
 
-function adaptNativeRepoHandle(repo: ArtifactsRepo): ArtifactRepoHandle {
+function adaptNativeRepoHandle(
+	repo: ArtifactsRepo,
+	restCreateToken?: ArtifactRepoHandle['createToken'],
+): ArtifactRepoHandle {
 	return {
 		info: async () => ({
 			id: repo.id,
@@ -262,17 +266,30 @@ function adaptNativeRepoHandle(repo: ArtifactsRepo): ArtifactRepoHandle {
 			remote: repo.remote,
 		}),
 		createToken: async (scope = 'write', ttl = 3600) => {
-			const token = await repo.createToken(scope, ttl)
-			const plaintext = readArtifactTokenPlaintext(token)
-			return {
-				id: token.id,
-				plaintext,
-				scope: token.scope,
-				expiresAt: resolveCreatedTokenExpiry({
-					token: plaintext,
-					tokenExpiresAt:
-						typeof token.expiresAt === 'string' ? token.expiresAt : null,
-				}),
+			// Native createToken still throws `undefined.split` across JSRPC
+			// after mapping plaintext/token. Mint via REST when credentials
+			// exist — that path worked before #1437 preferred the binding.
+			if (restCreateToken) {
+				return restCreateToken(scope, ttl)
+			}
+			try {
+				const token = await repo.createToken(scope, ttl)
+				const plaintext = readArtifactTokenPlaintext(token)
+				return {
+					id: token.id,
+					plaintext,
+					scope: token.scope,
+					expiresAt: resolveCreatedTokenExpiry({
+						token: plaintext,
+						tokenExpiresAt:
+							typeof token.expiresAt === 'string' ? token.expiresAt : null,
+					}),
+				}
+			} catch (error) {
+				throw new Error(
+					`Artifacts native createToken failed: ${getErrorMessage(error)}`,
+					{ cause: error },
+				)
 			}
 		},
 		listTokens: async () => {
@@ -292,23 +309,39 @@ function adaptNativeRepoHandle(repo: ArtifactsRepo): ArtifactRepoHandle {
 
 function adaptNativeArtifactsBinding(
 	native: Artifacts,
+	env: Env,
 ): ArtifactNamespaceBinding & Record<string, unknown> {
+	const rest = createArtifactsRestBinding(env, getArtifactsNamespace(env))
+	const restCreateToken = rest
+		? (name: string): ArtifactRepoHandle['createToken'] =>
+				(scope, ttl) =>
+					rest.repo(name).createToken(scope, ttl)
+		: null
 	const repo = (name: string): ArtifactRepoHandle => ({
 		info: async () => {
 			const handle = await getNativeRepoOrThrow(native, name)
-			return adaptNativeRepoHandle(handle).info()
+			return adaptNativeRepoHandle(handle, restCreateToken?.(name)).info()
 		},
 		createToken: async (scope = 'write', ttl = 3600) => {
+			if (rest) {
+				return rest.repo(name).createToken(scope, ttl)
+			}
 			const handle = await getNativeRepoOrThrow(native, name)
 			return adaptNativeRepoHandle(handle).createToken(scope, ttl)
 		},
 		listTokens: async () => {
 			const handle = await getNativeRepoOrThrow(native, name)
-			return adaptNativeRepoHandle(handle).listTokens?.() ?? []
+			return (
+				adaptNativeRepoHandle(handle, restCreateToken?.(name)).listTokens?.() ??
+				[]
+			)
 		},
 		revokeToken: async (idOrPlaintext) => {
 			const handle = await getNativeRepoOrThrow(native, name)
-			await adaptNativeRepoHandle(handle).revokeToken?.(idOrPlaintext)
+			await adaptNativeRepoHandle(
+				handle,
+				restCreateToken?.(name),
+			).revokeToken?.(idOrPlaintext)
 		},
 	})
 	return {
@@ -338,7 +371,7 @@ function adaptNativeArtifactsBinding(
 				const handle = await native.get(name)
 				return {
 					status: 'ready' as const,
-					repo: adaptNativeRepoHandle(handle),
+					repo: adaptNativeRepoHandle(handle, restCreateToken?.(name)),
 				}
 			} catch (error) {
 				const code = artifactsBindingErrorCode(error)
@@ -770,11 +803,19 @@ export async function resolveArtifactDefaultBranchHead(input: {
 		throw new Error('Artifacts createToken result is missing plaintext.')
 	}
 	const refName = `refs/heads/${info.defaultBranch || 'main'}`
-	const refs = await listArtifactServerRefs({
-		remote: info.remote,
-		token: tokenPlaintext,
-		prefix: refName,
-	})
+	let refs: Awaited<ReturnType<typeof listArtifactServerRefs>>
+	try {
+		refs = await listArtifactServerRefs({
+			remote: info.remote,
+			token: tokenPlaintext,
+			prefix: refName,
+		})
+	} catch (error) {
+		throw new Error(
+			`Artifacts listServerRefs failed: ${getErrorMessage(error)}`,
+			{ cause: error },
+		)
+	}
 	const branchRef = refs.find((ref) => ref.ref === refName)
 	if (!branchRef?.oid) {
 		return null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

#1441 mapped native `createToken.token` onto `plaintext`. Production still fails `package_get_git_remote` on `@kentcdodds/gist-agent-mailbox` with `undefined.split` after deploy `1e35de53` — not our missing-plaintext guard. Native `createToken` is throwing inside the binding. Token minting worked on REST before #1437.

## Summary

- Prefer REST `createToken` when `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` exist, even if `get`/`create` use the native binding.
- Keep the native `plaintext`/`token` mapper when REST credentials are absent.
- Prefix native createToken failures and `listServerRefs` failures so the next production miss names the step.

## Testing

- `npm run test:node -- packages/worker/src/repo/artifacts.node.test.ts` — 9 passed (native `{ token }` mapping, REST mint when both bindings exist, missing-plaintext wrap)
- Production baseline after #1441: read-scope `package_get_git_remote` still `undefined.split` in 307ms

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1e35de53` · **Head:** `cfd3570a`

**Classification:** extends — native Artifacts handles mint tokens over REST when account credentials exist.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `artifacts-repos` | storage | extends — native get/create stay on the binding; createToken uses REST when credentials exist |
| `repo-sessions` | runtime | composes — tests only |

### System map

Package git remotes mint tokens over REST while repo get/create stay on the native binding.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::extended
	mcpServer -->|"package_get_git_remote"| artifactsRepos
	artifactsRepos -->|"native get/create"| artifactsRepos
	artifactsRepos -->|"REST createToken"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
before: native createToken throws undefined.split
        → source-safety wraps as backup-snapshot failure

after:  REST POST /tokens when CF credentials exist
        → ArtifactToken.plaintext from REST plaintext
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact token creation in hybrid environments by using the REST endpoint when native credentials are unavailable.
  * Added clearer context to errors from native token creation and default-branch reference lookups.
  * Improved consistency of error reporting across artifact repository operations.
* **Tests**
  * Expanded coverage for native token errors and REST fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->