### PR TITLE
fix(repo): authenticate Artifacts listServerRefs on the first request

### DIFF
--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -492,7 +492,7 @@ test('resolveArtifactDefaultBranchHead reuses a provided token and still works w
 	expect(createToken).toHaveBeenCalledWith('read', 300)
 	expect(gitMocks.listServerRefs).toHaveBeenCalledWith(
 		expect.objectContaining({
-			url: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+			url: 'https://x:art_v1_throwaway@acct.artifacts.cloudflare.net/git/default/repo-1.git',
 			prefix: 'refs/heads/main',
 		}),
 	)

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -250,27 +250,33 @@ async function getNativeRepoOrThrow(native: Artifacts, name: string) {
 
 function adaptNativeRepoHandle(
 	repo: ArtifactsRepo,
-	restCreateToken?: ArtifactRepoHandle['createToken'],
+	restRepo?: ArtifactRepoHandle,
 ): ArtifactRepoHandle {
 	return {
-		info: async () => ({
-			id: repo.id,
-			name: repo.name,
-			description: repo.description,
-			defaultBranch: repo.defaultBranch,
-			createdAt: repo.createdAt,
-			updatedAt: repo.updatedAt,
-			lastPushAt: repo.lastPushAt,
-			source: repo.source,
-			readOnly: repo.readOnly,
-			remote: repo.remote,
-		}),
+		info: async () => {
+			if (restRepo) {
+				const info = await restRepo.info()
+				if (info?.remote) return info
+			}
+			return {
+				id: repo.id,
+				name: repo.name,
+				description: repo.description,
+				defaultBranch: repo.defaultBranch,
+				createdAt: repo.createdAt,
+				updatedAt: repo.updatedAt,
+				lastPushAt: repo.lastPushAt,
+				source: repo.source,
+				readOnly: repo.readOnly,
+				remote: repo.remote,
+			}
+		},
 		createToken: async (scope = 'write', ttl = 3600) => {
 			// Native createToken still throws `undefined.split` across JSRPC
 			// after mapping plaintext/token. Mint via REST when credentials
 			// exist — that path worked before #1437 preferred the binding.
-			if (restCreateToken) {
-				return restCreateToken(scope, ttl)
+			if (restRepo) {
+				return restRepo.createToken(scope, ttl)
 			}
 			try {
 				const token = await repo.createToken(scope, ttl)
@@ -312,15 +318,10 @@ function adaptNativeArtifactsBinding(
 	env: Env,
 ): ArtifactNamespaceBinding & Record<string, unknown> {
 	const rest = createArtifactsRestBinding(env, getArtifactsNamespace(env))
-	const restCreateToken = rest
-		? (name: string): ArtifactRepoHandle['createToken'] =>
-				(scope, ttl) =>
-					rest.repo(name).createToken(scope, ttl)
-		: null
 	const repo = (name: string): ArtifactRepoHandle => ({
 		info: async () => {
 			const handle = await getNativeRepoOrThrow(native, name)
-			return adaptNativeRepoHandle(handle, restCreateToken?.(name)).info()
+			return adaptNativeRepoHandle(handle, rest?.repo(name)).info()
 		},
 		createToken: async (scope = 'write', ttl = 3600) => {
 			if (rest) {
@@ -332,16 +333,14 @@ function adaptNativeArtifactsBinding(
 		listTokens: async () => {
 			const handle = await getNativeRepoOrThrow(native, name)
 			return (
-				adaptNativeRepoHandle(handle, restCreateToken?.(name)).listTokens?.() ??
-				[]
+				adaptNativeRepoHandle(handle, rest?.repo(name)).listTokens?.() ?? []
 			)
 		},
 		revokeToken: async (idOrPlaintext) => {
 			const handle = await getNativeRepoOrThrow(native, name)
-			await adaptNativeRepoHandle(
-				handle,
-				restCreateToken?.(name),
-			).revokeToken?.(idOrPlaintext)
+			await adaptNativeRepoHandle(handle, rest?.repo(name)).revokeToken?.(
+				idOrPlaintext,
+			)
 		},
 	})
 	return {
@@ -371,7 +370,7 @@ function adaptNativeArtifactsBinding(
 				const handle = await native.get(name)
 				return {
 					status: 'ready' as const,
-					repo: adaptNativeRepoHandle(handle, restCreateToken?.(name)),
+					repo: adaptNativeRepoHandle(handle, rest?.repo(name)),
 				}
 			} catch (error) {
 				const code = artifactsBindingErrorCode(error)
@@ -768,20 +767,33 @@ export function buildAuthenticatedArtifactsRemote(input: {
 	return remoteUrl.toString()
 }
 
+function describeArtifactRemote(remote: string) {
+	try {
+		const url = new URL(remote)
+		url.username = ''
+		url.password = ''
+		return url.toString()
+	} catch {
+		return 'unparseable-remote'
+	}
+}
+
 export async function listArtifactServerRefs(input: {
 	remote: string
 	token: string
 	prefix?: string
 }) {
-	const auth = buildArtifactsGitAuth({ token: input.token })
+	// Embed credentials in the URL so the first info/refs request is
+	// authenticated. onAuth only runs after 401; Artifacts can fail earlier.
+	const url = buildAuthenticatedArtifactsRemote({
+		remote: input.remote,
+		token: input.token,
+	})
 	return git.listServerRefs({
 		http,
-		url: input.remote,
+		url,
 		prefix: input.prefix,
 		symrefs: true,
-		onAuth() {
-			return auth
-		},
 	})
 }
 
@@ -812,7 +824,7 @@ export async function resolveArtifactDefaultBranchHead(input: {
 		})
 	} catch (error) {
 		throw new Error(
-			`Artifacts listServerRefs failed: ${getErrorMessage(error)}`,
+			`Artifacts listServerRefs failed for ${describeArtifactRemote(info.remote)}: ${getErrorMessage(error)}`,
 			{ cause: error },
 		)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

#1442 made REST `createToken` succeed. Production `package_get_git_remote` on `@kentcdodds/gist-agent-mailbox` then failed at `Artifacts listServerRefs failed: Cannot read properties of undefined (reading 'split')`. Clone/push already embed the token in the git URL; `listServerRefs` only sent auth after a 401.

## Summary

- Embed the token in the `listServerRefs` URL (same as `buildAuthenticatedArtifactsRemote`).
- Prefer REST `info()` for the remote URL when Cloudflare credentials exist.
- Include the redacted remote in `listServerRefs` errors.

## Testing

- `npm run test:node -- packages/worker/src/repo/artifacts.node.test.ts` — 9 passed
- Production after #1442: write `package_get_git_remote` failed in `listServerRefs` (createToken no longer the failure)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e2990b46` · **Head:** `44c3a0e1`

**Classification:** extends — Artifacts git ref discovery now authenticates on the first request.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `artifacts-repos` | storage | extends — listServerRefs embeds token; REST info preferred for remotes |
| `repo-sessions` | runtime | composes — tests only |

### System map

Source-safety HEAD checks authenticate git info/refs on the first request.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	artifactsRepos["artifacts-repos<br/>Artifacts repos"]:::extended
	mcpServer -->|"package_get_git_remote HEAD check"| artifactsRepos
	artifactsRepos -->|"authenticated listServerRefs"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-543ba2df-a5c6-4b7e-af89-9a0bfbdbc3b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

