### PR TITLE
Stop refresh scroll restoration from drifting on the homepage

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -204,7 +204,11 @@ The app shell also mounts **scroll restoration**. Each history entry's
 `window.scrollY` is stored in `sessionStorage` keyed by `history.state.key` (the
 same `{ [key]: y }` map React Router uses). A blocking inline script in the SSR
 document body restores that Y before first paint on a full document load, so a
-refresh does not flash the top of the page. `history.scrollRestoration` is
+refresh does not flash the top of the page. After hydration the restorer keeps
+applying the same saved Y until the document is tall enough to reach it (images,
+fonts, and async route content). A persist of the current `scrollY` does not
+replace a taller saved Y while that Y is still unreachable, so a clamped early
+`scrollTo` cannot overwrite the intended position. `history.scrollRestoration` is
 `manual` so the browser does not fight the restorer. SPA back/forward still
 restores the saved position, hash targets scroll into view, and new navigations
 go to the top after the destination route commits. Same-document hash links (for

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -205,18 +205,19 @@ The app shell also mounts **scroll restoration**. Each history entry's
 same `{ [key]: y }` map React Router uses). A blocking inline script in the SSR
 document body restores that Y before first paint on a full document load, so a
 refresh does not flash the top of the page. After hydration the restorer keeps
-applying the same saved Y until the document is tall enough to reach it (images,
-fonts, and async route content). A persist of the current `scrollY` does not
-replace a taller saved Y while that Y is still unreachable, so a clamped early
-`scrollTo` cannot overwrite the intended position. `history.scrollRestoration` is
-`manual` so the browser does not fight the restorer. SPA back/forward still
-restores the saved position, hash targets scroll into view, and new navigations
-go to the top after the destination route commits. Same-document hash links (for
-example the landing page's `#invite` waitlist CTA) are intercepted like other
-same-origin links so restoration can scroll to the target. Preserve the current
-scroll for a specific intercepted link or form with `data-prevent-scroll-reset`,
-or for programmatic navigation with
-`navigate(to, { preventScrollReset: true })`.
+applying the same saved Y until the document is tall enough to reach it, then
+keeps pinning that Y through a short settle window so late layout (images,
+fonts, scroll anchoring) cannot persist a drifted position. User input ends the
+pin early. A persist of the current `scrollY` does not replace a taller saved Y
+while that Y is still unreachable, so a clamped early `scrollTo` cannot
+overwrite the intended position. `history.scrollRestoration` is `manual` so the
+browser does not fight the restorer. SPA back/forward still restores the saved
+position, hash targets scroll into view, and new navigations go to the top after
+the destination route commits. Same-document hash links (for example the landing
+page's `#invite` waitlist CTA) are intercepted like other same-origin links so
+restoration can scroll to the target. Preserve the current scroll for a specific
+intercepted link or form with `data-prevent-scroll-reset`, or for programmatic
+navigation with `navigate(to, { preventScrollReset: true })`.
 
 Full page navigations occur for:
 

--- a/packages/worker/client/router-scroll-state.node.test.ts
+++ b/packages/worker/client/router-scroll-state.node.test.ts
@@ -3,9 +3,10 @@ import {
 	createScrollRestorationHistoryState,
 	getScrollRestorationKey,
 	getScrollRestorationTarget,
+	nextSavedScrollPosition,
 } from './router-scroll-state.ts'
 
-test('scroll restoration history state and navigation targets follow push, pop, hash, and preserve rules', () => {
+test('scroll restoration history state and navigation targets follow push, pop, hash, preserve, and load rules', () => {
 	const state = createScrollRestorationHistoryState(
 		{ userState: 'kept' },
 		'scroll-key-1',
@@ -49,4 +50,50 @@ test('scroll restoration history state and navigation targets follow push, pop, 
 			location: '/community',
 		}),
 	).toEqual({ type: 'top' })
+	expect(
+		getScrollRestorationTarget({
+			historyAction: 'load',
+			location: '/',
+			savedPosition: { x: 0, y: 2000 },
+		}),
+	).toEqual({ type: 'position', position: { x: 0, y: 2000 } })
+	expect(
+		getScrollRestorationTarget({
+			historyAction: 'load',
+			location: '/',
+		}),
+	).toEqual({ type: 'preserve' })
+	expect(
+		getScrollRestorationTarget({
+			historyAction: 'load',
+			location: '/#invite',
+		}),
+	).toEqual({ type: 'hash', id: 'invite' })
+})
+
+test('a clamped scroll does not replace a saved Y the document cannot reach yet', () => {
+	const saved = { x: 0, y: 3400 }
+
+	expect(
+		nextSavedScrollPosition(saved, { x: 0, y: 1200 }, { x: 0, y: 1200 }),
+	).toEqual(saved)
+	expect(
+		nextSavedScrollPosition(saved, { x: 0, y: 0 }, { x: 0, y: 0 }),
+	).toEqual(saved)
+	expect(
+		nextSavedScrollPosition(saved, { x: 0, y: 1199.4 }, { x: 0, y: 1200 }),
+	).toEqual(saved)
+
+	expect(
+		nextSavedScrollPosition(saved, { x: 0, y: 800 }, { x: 0, y: 1200 }),
+	).toEqual({ x: 0, y: 800 })
+	expect(
+		nextSavedScrollPosition(saved, { x: 0, y: 100 }, { x: 0, y: 5000 }),
+	).toEqual({ x: 0, y: 100 })
+	expect(
+		nextSavedScrollPosition(saved, { x: 0, y: 3400 }, { x: 0, y: 5000 }),
+	).toEqual({ x: 0, y: 3400 })
+	expect(
+		nextSavedScrollPosition(undefined, { x: 0, y: 1200 }, { x: 0, y: 1200 }),
+	).toEqual({ x: 0, y: 1200 })
 })

--- a/packages/worker/client/router-scroll-state.ts
+++ b/packages/worker/client/router-scroll-state.ts
@@ -3,6 +3,9 @@ import { historyStateScrollKey } from '#universal/router-scroll-restoration.ts'
 
 export type RouterHistoryAction = 'push' | 'pop' | 'replace'
 
+/** Router actions plus document load. `'load'` is never emitted on `routerEvents`. */
+export type ScrollHistoryAction = RouterHistoryAction | 'load'
+
 export type RouterNavigateOptions = {
 	preventScrollReset?: boolean
 }
@@ -77,18 +80,39 @@ export function getScrollRestorationHash(location: string) {
 }
 
 export function getScrollRestorationTarget(input: {
-	historyAction: RouterHistoryAction
+	historyAction: ScrollHistoryAction
 	location: string
 	preventScrollReset?: boolean
 	savedPosition?: ScrollPosition | null
 }): ScrollRestorationTarget {
-	if (input.historyAction === 'pop' && input.savedPosition) {
+	if (
+		(input.historyAction === 'pop' || input.historyAction === 'load') &&
+		input.savedPosition
+	) {
 		return { type: 'position', position: input.savedPosition }
 	}
 
 	const hash = getScrollRestorationHash(input.location)
 	if (hash) return { type: 'hash', id: hash }
 
-	if (input.preventScrollReset) return { type: 'preserve' }
+	if (input.preventScrollReset || input.historyAction === 'load') {
+		return { type: 'preserve' }
+	}
 	return { type: 'top' }
+}
+
+/**
+ * Keep a taller saved Y while the document is still too short to reach it.
+ * A pre-paint `scrollTo` clamps to `maxScroll`; persisting that clamp is what
+ * makes refresh drift down the page.
+ */
+export function nextSavedScrollPosition(
+	saved: ScrollPosition | undefined,
+	current: ScrollPosition,
+	maxScroll: ScrollPosition,
+): ScrollPosition {
+	if (saved && saved.y > maxScroll.y && current.y >= maxScroll.y - 1) {
+		return saved
+	}
+	return current
 }

--- a/packages/worker/client/scroll-restoration.tsx
+++ b/packages/worker/client/scroll-restoration.tsx
@@ -9,7 +9,9 @@ import {
 	ensureCurrentScrollRestorationKey,
 	getCurrentScrollRestorationKey,
 	getScrollRestorationTarget,
+	nextSavedScrollPosition,
 	type RouterNavigationEventDetail,
+	type ScrollHistoryAction,
 	type ScrollPosition,
 	type ScrollRestorationTarget,
 } from './router-scroll-state.ts'
@@ -17,6 +19,7 @@ import {
 const savedScrollPositions = new Map<string, ScrollPosition>()
 let positionsLoaded = false
 let restoreScrollRequestId = 0
+let restoreInProgress = false
 
 function loadSavedScrollPositions() {
 	if (positionsLoaded || typeof sessionStorage === 'undefined') return
@@ -53,14 +56,24 @@ function persistSavedScrollPositions() {
 function saveWindowScrollPosition() {
 	const key = ensureCurrentScrollRestorationKey()
 	if (!key) return
-	savedScrollPositions.set(key, {
+	const current = {
 		x: window.scrollX,
 		y: window.scrollY,
-	})
+	}
+	savedScrollPositions.set(
+		key,
+		nextSavedScrollPosition(
+			savedScrollPositions.get(key),
+			current,
+			maxWindowScrollPosition(),
+		),
+	)
 }
 
 function persistWindowScrollPosition() {
-	saveWindowScrollPosition()
+	if (!restoreInProgress) {
+		saveWindowScrollPosition()
+	}
 	persistSavedScrollPositions()
 }
 
@@ -104,8 +117,14 @@ function maxWindowScrollPosition(): ScrollPosition {
 	}
 }
 
+type ScrollRestoreRequest = {
+	location: string
+	historyAction: ScrollHistoryAction
+	preventScrollReset: boolean
+}
+
 function applyWindowScroll(
-	detail: RouterNavigationEventDetail,
+	detail: ScrollRestoreRequest,
 	target: ScrollRestorationTarget,
 	isFinalAttempt: boolean,
 ): boolean {
@@ -146,10 +165,7 @@ function applyWindowScroll(
 	}
 }
 
-function restoreWindowScroll(
-	detail: RouterNavigationEventDetail,
-	signal: AbortSignal,
-) {
+function restoreWindowScroll(detail: ScrollRestoreRequest, signal: AbortSignal) {
 	const key = getCurrentScrollRestorationKey()
 	const target = getScrollRestorationTarget({
 		historyAction: detail.historyAction,
@@ -158,7 +174,13 @@ function restoreWindowScroll(
 		savedPosition: key ? savedScrollPositions.get(key) : null,
 	})
 	const requestId = ++restoreScrollRequestId
+	restoreInProgress = true
 	const startedAt = Date.now()
+	// Document-load restore keeps applying the saved Y after it is reachable so
+	// late layout (images, fonts, scroll anchoring) cannot persist a drifted
+	// position before the page settles.
+	const pinUntilDeadline =
+		target.type === 'position' && detail.historyAction === 'load'
 	// Restoration must never fight manual scrolling, but layout-driven shifts
 	// (scroll anchoring, async content replacing nodes above the viewport) can
 	// move the position between attempts without any user involvement. Watch
@@ -170,7 +192,10 @@ function restoreWindowScroll(
 	for (const eventName of userScrollInputEvents) {
 		window.addEventListener(eventName, markUserInteraction, { passive: true })
 	}
-	const stopListening = () => {
+	const finish = () => {
+		if (requestId === restoreScrollRequestId) {
+			restoreInProgress = false
+		}
 		for (const eventName of userScrollInputEvents) {
 			window.removeEventListener(eventName, markUserInteraction)
 		}
@@ -188,12 +213,13 @@ function restoreWindowScroll(
 			requestId !== restoreScrollRequestId ||
 			userInteracted
 		) {
-			stopListening()
+			finish()
 			return
 		}
 		const isFinalAttempt = Date.now() - startedAt >= scrollRestorationDeadlineMs
-		if (applyWindowScroll(detail, target, isFinalAttempt) || isFinalAttempt) {
-			stopListening()
+		const reached = applyWindowScroll(detail, target, isFinalAttempt)
+		if (isFinalAttempt || (reached && !pinUntilDeadline)) {
+			finish()
 			return
 		}
 		schedule(attempt)
@@ -227,6 +253,14 @@ export function ScrollRestoration(handle: Handle) {
 				restoreWindowScroll(event.detail, handle.signal)
 			},
 		})
+		restoreWindowScroll(
+			{
+				location: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+				historyAction: 'load',
+				preventScrollReset: false,
+			},
+			handle.signal,
+		)
 		addEventListeners(window, handle.signal, {
 			scroll: persistWindowScrollPosition,
 			pagehide: persistWindowScrollPosition,

--- a/packages/worker/client/scroll-restoration.tsx
+++ b/packages/worker/client/scroll-restoration.tsx
@@ -165,7 +165,10 @@ function applyWindowScroll(
 	}
 }
 
-function restoreWindowScroll(detail: ScrollRestoreRequest, signal: AbortSignal) {
+function restoreWindowScroll(
+	detail: ScrollRestoreRequest,
+	signal: AbortSignal,
+) {
 	const key = getCurrentScrollRestorationKey()
 	const target = getScrollRestorationTarget({
 		historyAction: detail.historyAction,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Refreshing a scrolled homepage should land on the **same** `scrollY` every time. After #1435, restore happens, but repeated refresh moves around the page because a clamped early `scrollTo` overwrites the saved position.

## Repro

On the marketing homepage:

1. Scroll to a mid-page section (for example `scrollY ≈ 2000` or `≈ 3400`).
2. Refresh. Scroll restores, but not quite to the same spot.
3. Refresh again. The position drifts, inconsistently, depending on how tall the document is when the restore runs.

## Cause

The pre-paint SSR script calls `window.scrollTo(0, savedY)` before CSS, fonts, and images finish. The browser clamps that to the current max scroll. The restorer then persisted that clamped Y (scroll / pagehide), so the next refresh restored a worse value.

## Summary

- Keep a taller saved Y while the document is still too short to reach it (`nextSavedScrollPosition`).
- After hydration, re-apply the same saved Y (`historyAction: 'load'`) until the document can reach it, and keep pinning that Y until the settle window ends or the user scrolls.
- Do not write `window.scrollY` into the saved map while a restore is in progress.
- SPA back/forward, new-nav-to-top, `preventScrollReset`, and hash targets are unchanged.
- `history.scrollRestoration` stays `'manual'`. The inline script and CSP hash are unchanged.

## Testing

- `packages/worker/client/router-scroll-state.node.test.ts`: document-load targets restore a saved position (or preserve / hash when none is saved), and `nextSavedScrollPosition` keeps a taller saved Y while `maxScroll` is still short. A reachable page, or a user scroll away from the clamp, still saves the current Y.
- Static CI failed on oxfmt; the restorer signature and request-lifecycle wrap are formatted.
- Preview: `https://kody-pr-1444.kody-a99.workers.dev`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `817ddaec` · **Head:** `34b4a96d`

**Classification:** extends — the browser-app scroll restorer no longer persists a clamped refresh Y, and re-applies the original saved Y after hydration until the document can reach it.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — keep saved Y while `maxScroll` is short; load restore retries that Y |

### System map

Refresh restore still starts in the SSR body script; the client restorer then protects and re-applies that saved Y so a short first layout cannot drift storage.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appUi -->|"nextSavedScrollPosition keeps unreachable Y"| appUi
	appUi -->|"load restore retries saved Y"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Script as SSR inline script
	participant Page as Document
	participant Restorer as ScrollRestoration
	participant Storage as sessionStorage
	Script->>Page: scrollTo(0, savedY) before paint
	Note over Page: layout still short; browser clamps
	Restorer->>Page: re-apply saved Y after hydration
	Page-->>Restorer: maxScroll still below savedY
	Restorer->>Page: retry until reachable or user scrolls
	Restorer->>Storage: persist current Y only if saved Y is reachable
```

### Before / after

```
before: pre-paint scrollTo clamps; persist writes the clamp; next refresh drifts
after:  clamped Y does not replace a taller saved Y; hydration retries that Y
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e907e517-b985-44a9-b106-e5141c9cd1f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e907e517-b985-44a9-b106-e5141c9cd1f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll restoration during page loading and hydration.
  * Preserved saved positions until the document can reach them.
  * Prevented clamped positions from overwriting saved positions.
  * Reduced scroll drift during late layout changes.
  * Improved handling of navigation, preserved positions, and hash links.
  * Stopped restoration when users begin interacting.

* **Documentation**
  * Clarified scroll restoration behavior, opt-outs, and browser history handling.

* **Tests**
  * Added coverage for saved, reachable, clamped, preserved, hash, and missing positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->