### PR TITLE
Add interactive Google OAuth guide (Lane B Gmail walkthrough)

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,6 +17,7 @@ content:
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | [what-is-kody.md](./what-is-kody.md)                                                     | Pre-account capability tour and discovery-interview notes; needs no account or MCP connection                                  |
 | [how-kody-works.md](./how-kody-works.md)                                                 | Factory loop as a conversation: ask what your favorite bot shipped, save an export, daily email only when something shipped    |
+| [google-oauth.md](./google-oauth.md)                                                     | Interactive transcript: agent walks a naive user through Lane B Google OAuth for Gmail inbox reading                           |
 | [quick-example.md](./quick-example.md)                                                   | **Start here** after a host authorizes: fork a zero-auth example, invoke the owned package, offer optional triggers            |
 | [first-win.md](./first-win.md)                                                           | Optional email → reply → memories loop (not the onboarding Step 2 climax)                                                      |
 | [package-authoring.md](./package-authoring.md)                                           | General package-authoring guidance, including the README Intent section                                                        |

--- a/docs/guides/google-oauth.md
+++ b/docs/guides/google-oauth.md
@@ -53,11 +53,11 @@ This page is the playbook. The same story is an interactive transcript at
 
 ## The loop
 
-1. **Ask for inbox access.** The user wants Kody to read Gmail for invoices
-   (for example from Acme) and does not know the steps.
+1. **Ask for inbox access.** The user wants Kody to read Gmail for invoices (for
+   example from Acme) and does not know the steps.
 2. **Look up the guides.** Search for Google / Gmail / OAuth, open
-   `coding_guide_get` entity detail, then load `integration_bootstrap`,
-   `oauth`, and `provider_google`.
+   `coding_guide_get` entity detail, then load `integration_bootstrap`, `oauth`,
+   and `provider_google`.
 3. **Choose Lane B.** Built-in Google does not cover inbox reading. Walk Google
    Cloud and Google Auth Platform one step at a time: project, enable Gmail API,
    branding and External audience, Web client with redirect

--- a/docs/guides/google-oauth.md
+++ b/docs/guides/google-oauth.md
@@ -1,0 +1,81 @@
+---
+id: google_oauth
+title: Google OAuth interactive guide
+summary:
+  Interactive transcript of a coding agent walking a naive user through
+  Lane B Google OAuth for Gmail inbox reading: official guides first,
+  one console step at a time, prefilled /connect/oauth, refuse secrets
+  in chat, then a Gmail profile smoke test.
+category: platform
+---
+
+# Google OAuth interactive guide
+
+<!--
+Agent notes — for AI agents explaining or recreating this loop:
+
+- The web page at /guides/google-oauth is an interactive transcript of the
+  same story. This markdown is the playbook.
+- Do not invent Google console UI, URLs, or scopes. Load provider_google,
+  oauth, and integration_bootstrap via coding_guide_get and follow those.
+- Honest Lane B reason: inbox reading (gmail.readonly) is outside the
+  built-in Google scope menu. Do not pretend Calendar-only needs a BYO
+  client, and do not start already knowing "Lane B" or the 7-day trap —
+  discover those from the guides.
+- Walk the user one console step at a time. Wait for "done" between:
+  Cloud project → enable Gmail API → Google Auth Platform Get started →
+  Web client with redirect https://kody.codes/connect/oauth → Data Access
+  gmail.readonly → Audience test user → Publish to Production (7-day
+  Testing refresh-token trap / invalid_grant).
+- Send a prefilled /connect/oauth URL from provider_google with
+  gmail.readonly, gmail.googleapis.com in allowedHosts, confidential
+  flow, access_type=offline, and prompt=consent. Client ID and secret
+  go on that Kody form only — never accept them in chat.
+- After authorize, smoke-test with createAuthenticatedFetch('google')
+  against the Gmail profile URL from provider_google. Do not create a
+  package in this story; the payoff is a working integration.
+- Tool names exposed to the agent are only search or execute. Nested
+  calls (coding_guide_get, createAuthenticatedFetch) live inside execute
+  code. Every tool needs a note. Search markdown starts with
+  "# Search results"; entity detail with "# Capability —"; execute text
+  with "conversationId: ".
+- search and execute can take a short memoryContext (task plus a couple
+  of entities). This story needs no memory writes and may have zero
+  memories.
+-->
+
+Kody can connect Google two ways. The built-in path covers Calendar and other
+allowed scopes without a Cloud project. Inbox reading needs a bring-your-own
+OAuth client (Lane B) because `gmail.readonly` is outside that menu.
+
+This page is the playbook. The same story is an interactive transcript at
+`/guides/google-oauth` on the origin you fetched this guide from.
+
+## The loop
+
+1. **Ask for inbox access.** The user wants Kody to read Gmail for invoices
+   (for example from Acme) and does not know the steps.
+2. **Look up the guides.** Search for Google / Gmail / OAuth, open
+   `coding_guide_get` entity detail, then load `integration_bootstrap`,
+   `oauth`, and `provider_google`.
+3. **Choose Lane B.** Built-in Google does not cover inbox reading. Walk Google
+   Cloud and Google Auth Platform one step at a time: project, enable Gmail API,
+   branding and External audience, Web client with redirect
+   `https://kody.codes/connect/oauth`, Data Access scope
+   `https://www.googleapis.com/auth/gmail.readonly`, test user while Testing,
+   then Publish to Production so refresh tokens are not limited to seven days.
+4. **Connect on Kody.** Send a prefilled `/connect/oauth` URL (confidential,
+   `gmail.readonly`, `gmail.googleapis.com`, `access_type=offline`,
+   `prompt=consent`). Paste client ID and secret only on that form. Refuse any
+   secret pasted in chat.
+5. **Smoke-test.** After authorize, call `createAuthenticatedFetch('google')`
+   against `https://gmail.googleapis.com/gmail/v1/users/me/profile`. Later
+   reconnects can use `/connect/oauth?provider=google` alone.
+
+## When to load this guide
+
+Load `google_oauth` when someone wants a teaching walkthrough of Google OAuth
+for Gmail inbox reading, or when an agent should see how to coach a user through
+Lane B without inventing console steps. For the authoritative console checklist,
+load `provider_google`. For the generic OAuth path, load `oauth`. For ordering
+before packages, load `integration_bootstrap`.

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -17,6 +17,10 @@ similar providers).
 This guide covers the standard hosted OAuth path. Use it before building a
 package or package app that depends on the resulting integration or tokens.
 
+For a teaching walkthrough of Google Lane B (bring-your-own client for Gmail
+inbox reading) as an interactive agent transcript, see
+[google-oauth.md](./google-oauth.md).
+
 ## Default path: `/connect/oauth`
 
 Send the signed-in user to `https://kody.codes/connect/oauth` with query

--- a/docs/guides/providers/google.md
+++ b/docs/guides/providers/google.md
@@ -18,6 +18,9 @@ Prefer the **built-in** Google integration when its scope menu covers the task
 and related allowed scopes). Bring your own Google OAuth client when you need
 access outside that menu — especially inbox reading or Drive-wide access.
 
+For a teaching walkthrough of Lane B (Gmail inbox reading) as an interactive
+agent transcript, see [google-oauth.md](../google-oauth.md).
+
 ## What you get
 
 Once connected, you can ask Kody things like:

--- a/packages/worker/client/routes/google-oauth-transcript.node.test.ts
+++ b/packages/worker/client/routes/google-oauth-transcript.node.test.ts
@@ -1,0 +1,210 @@
+import { expect, test } from 'vitest'
+import { googleOauthTranscriptActs } from './google-oauth-transcript.ts'
+
+test('google oauth transcript covers Lane B, console beats, connect, and smoke test', () => {
+	expect(googleOauthTranscriptActs.map((act) => act.id)).toEqual([
+		'discover',
+		'console',
+		'connect',
+	])
+
+	const tools = googleOauthTranscriptActs.flatMap((act) =>
+		act.lines.flatMap((line) => (line.role === 'tools' ? line.tools : [])),
+	)
+	expect(tools.some((tool) => tool.name === 'search')).toBe(true)
+	expect(tools.some((tool) => tool.name === 'execute')).toBe(true)
+	expect(
+		tools.every((tool) => tool.name === 'search' || tool.name === 'execute'),
+	).toBe(true)
+	expect(tools.every((tool) => tool.note.trim().length > 0)).toBe(true)
+	expect(tools.every((tool) => tool.result.trim().length > 0)).toBe(true)
+	expect(
+		tools.every((tool) =>
+			tool.inputs.every((input) => input.value.trim().length > 0),
+		),
+	).toBe(true)
+	expect(tools.some((tool) => tool.name.startsWith('meta_memory_'))).toBe(false)
+	expect(
+		tools
+			.filter((tool) => tool.name === 'execute')
+			.every((tool) => tool.inputs.some((input) => input.name === 'code')),
+	).toBe(true)
+	expect(
+		tools
+			.filter((tool) => tool.name === 'execute')
+			.every((tool) =>
+				tool.inputs.some((input) => input.name === 'memoryContext'),
+			),
+	).toBe(true)
+	expect(
+		tools
+			.filter((tool) => tool.name === 'execute')
+			.every((tool) => tool.result.startsWith('conversationId: ')),
+	).toBe(true)
+	expect(
+		tools
+			.filter((tool) => tool.name === 'search')
+			.every((tool) => {
+				const isEntityDetail = tool.inputs.some(
+					(input) => input.name === 'entity',
+				)
+				return isEntityDetail
+					? tool.result.includes('# Capability —')
+					: tool.result.includes('# Search results')
+			}),
+	).toBe(true)
+	expect(
+		tools.every((tool) => !tool.result.includes('"matches"')),
+	).toBe(true)
+	expect(
+		tools.every(
+			(tool) =>
+				!tool.result.includes('{{secret:') &&
+				!tool.note.includes('{{secret:'),
+		),
+	).toBe(true)
+
+	const agentLines = googleOauthTranscriptActs.flatMap((act) =>
+		act.lines.flatMap((line) => (line.role === 'agent' ? [line.text] : [])),
+	)
+	expect(
+		agentLines.every(
+			(text) =>
+				!text.includes('{{secret:') && !/GOCSPX-|ya29\.|Bearer [A-Za-z0-9_-]{20}/.test(text),
+		),
+	).toBe(true)
+
+	const discoverLines = googleOauthTranscriptActs.find(
+		(act) => act.id === 'discover',
+	)?.lines
+	const firstUser = discoverLines?.find((line) => line.role === 'user')
+	expect(firstUser && 'text' in firstUser ? firstUser.text : '').toMatch(
+		/Gmail|inbox|invoice/i,
+	)
+	const firstReasoning = discoverLines?.find(
+		(line) => line.role === 'agent' && line.tone === 'reasoning',
+	)
+	expect(
+		firstReasoning && 'text' in firstReasoning ? firstReasoning.text : '',
+	).not.toMatch(/Lane B|7-day|invalid_grant/i)
+
+	const discoverTools = discoverLines?.flatMap((line) =>
+		line.role === 'tools' ? line.tools : [],
+	)
+	expect(
+		discoverTools?.some((tool) =>
+			tool.inputs.some(
+				(input) =>
+					input.name === 'query' &&
+					/google|gmail|oauth/i.test(input.value),
+			),
+		),
+	).toBe(true)
+	expect(
+		discoverTools?.some((tool) =>
+			tool.inputs.some(
+				(input) =>
+					input.name === 'memoryContext' &&
+					input.value.includes('Gmail'),
+			),
+		),
+	).toBe(true)
+	expect(
+		discoverTools?.some((tool) =>
+			tool.inputs.some(
+				(input) =>
+					input.name === 'entity' &&
+					input.value.includes('coding_guide_get:capability'),
+			),
+		),
+	).toBe(true)
+	expect(
+		discoverTools?.some((tool) =>
+			tool.inputs.some(
+				(input) =>
+					input.name === 'code' &&
+					input.value.includes('integration_bootstrap') &&
+					input.value.includes('oauth') &&
+					input.value.includes('provider_google'),
+			),
+		),
+	).toBe(true)
+	expect(
+		discoverTools?.every(
+			(tool) => !tool.result.includes('## Relevant memories'),
+		),
+	).toBe(true)
+
+	expect(
+		agentLines.some((text) => /gmail\.readonly|Lane B|bring-your-own/i.test(text)),
+	).toBe(true)
+	expect(
+		agentLines.some((text) =>
+			text.includes('https://kody.codes/connect/oauth'),
+		),
+	).toBe(true)
+	expect(agentLines.some((text) => /7-day|seven days|invalid_grant/i.test(text))).toBe(
+		true,
+	)
+	expect(
+		agentLines.some((text) => /never paste|do not paste|client secret/i.test(text)),
+	).toBe(true)
+	expect(
+		agentLines.some((text) =>
+			/redirect URI/i.test(text) &&
+			text.includes('https://kody.codes/connect/oauth'),
+		),
+	).toBe(true)
+
+	const userLines = googleOauthTranscriptActs.flatMap((act) =>
+		act.lines.flatMap((line) => (line.role === 'user' ? [line.text] : [])),
+	)
+	expect(userLines.some((text) => /done|what.?s next|what is next/i.test(text))).toBe(
+		true,
+	)
+	expect(userLines.some((text) => /created a project/i.test(text))).toBe(true)
+	expect(userLines.some((text) => /redirect URI/i.test(text))).toBe(true)
+	expect(userLines.some((text) => /paste|client secret/i.test(text))).toBe(true)
+	expect(userLines.some((text) => /Testing|works in Testing/i.test(text))).toBe(
+		true,
+	)
+	expect(userLines.some((text) => /authorized/i.test(text))).toBe(true)
+
+	const connectUrlAgent = agentLines.find((text) =>
+		text.includes('/connect/oauth?provider=google'),
+	)
+	expect(connectUrlAgent).toBeTruthy()
+	expect(connectUrlAgent).toContain('gmail.readonly')
+	expect(connectUrlAgent).toContain('gmail.googleapis.com')
+	expect(connectUrlAgent).toContain('confidential')
+	expect(connectUrlAgent).toMatch(/access_type|offline/)
+	expect(connectUrlAgent).toMatch(/prompt|consent/)
+
+	expect(
+		tools.some((tool) =>
+			tool.inputs.some(
+				(input) =>
+					input.name === 'code' &&
+					input.value.includes("createAuthenticatedFetch('google')") &&
+					input.value.includes(
+						'https://gmail.googleapis.com/gmail/v1/users/me/profile',
+					),
+			),
+		),
+	).toBe(true)
+	expect(
+		tools.every((tool) =>
+			tool.inputs.every(
+				(input) =>
+					!input.value.includes('package_save') &&
+					!input.value.includes('community_fork') &&
+					!input.value.includes('packages.invoke'),
+			),
+		),
+	).toBe(true)
+	expect(
+		googleOauthTranscriptActs.every((act) =>
+			act.lines.every((line) => line.role !== 'files'),
+		),
+	).toBe(true)
+})

--- a/packages/worker/client/routes/google-oauth-transcript.node.test.ts
+++ b/packages/worker/client/routes/google-oauth-transcript.node.test.ts
@@ -171,7 +171,7 @@ test('google oauth transcript covers Lane B, console beats, connect, and smoke t
 	expect(userLines.some((text) => /authorized/i.test(text))).toBe(true)
 
 	const connectUrlAgent = agentLines.find((text) =>
-		text.includes('/connect/oauth?provider=google'),
+		text.includes('authorizeUrl=') && text.includes('/connect/oauth?provider=google'),
 	)
 	expect(connectUrlAgent).toBeTruthy()
 	expect(connectUrlAgent).toContain('gmail.readonly')

--- a/packages/worker/client/routes/google-oauth-transcript.node.test.ts
+++ b/packages/worker/client/routes/google-oauth-transcript.node.test.ts
@@ -53,14 +53,11 @@ test('google oauth transcript covers Lane B, console beats, connect, and smoke t
 					: tool.result.includes('# Search results')
 			}),
 	).toBe(true)
-	expect(
-		tools.every((tool) => !tool.result.includes('"matches"')),
-	).toBe(true)
+	expect(tools.every((tool) => !tool.result.includes('"matches"'))).toBe(true)
 	expect(
 		tools.every(
 			(tool) =>
-				!tool.result.includes('{{secret:') &&
-				!tool.note.includes('{{secret:'),
+				!tool.result.includes('{{secret:') && !tool.note.includes('{{secret:'),
 		),
 	).toBe(true)
 
@@ -70,7 +67,8 @@ test('google oauth transcript covers Lane B, console beats, connect, and smoke t
 	expect(
 		agentLines.every(
 			(text) =>
-				!text.includes('{{secret:') && !/GOCSPX-|ya29\.|Bearer [A-Za-z0-9_-]{20}/.test(text),
+				!text.includes('{{secret:') &&
+				!/GOCSPX-|ya29\.|Bearer [A-Za-z0-9_-]{20}/.test(text),
 		),
 	).toBe(true)
 
@@ -95,8 +93,7 @@ test('google oauth transcript covers Lane B, console beats, connect, and smoke t
 		discoverTools?.some((tool) =>
 			tool.inputs.some(
 				(input) =>
-					input.name === 'query' &&
-					/google|gmail|oauth/i.test(input.value),
+					input.name === 'query' && /google|gmail|oauth/i.test(input.value),
 			),
 		),
 	).toBe(true)
@@ -104,8 +101,7 @@ test('google oauth transcript covers Lane B, console beats, connect, and smoke t
 		discoverTools?.some((tool) =>
 			tool.inputs.some(
 				(input) =>
-					input.name === 'memoryContext' &&
-					input.value.includes('Gmail'),
+					input.name === 'memoryContext' && input.value.includes('Gmail'),
 			),
 		),
 	).toBe(true)
@@ -136,32 +132,37 @@ test('google oauth transcript covers Lane B, console beats, connect, and smoke t
 	).toBe(true)
 
 	expect(
-		agentLines.some((text) => /gmail\.readonly|Lane B|bring-your-own/i.test(text)),
+		agentLines.some((text) =>
+			/gmail\.readonly|Lane B|bring-your-own/i.test(text),
+		),
 	).toBe(true)
 	expect(
 		agentLines.some((text) =>
 			text.includes('https://kody.codes/connect/oauth'),
 		),
 	).toBe(true)
-	expect(agentLines.some((text) => /7-day|seven days|invalid_grant/i.test(text))).toBe(
-		true,
-	)
 	expect(
-		agentLines.some((text) => /never paste|do not paste|client secret/i.test(text)),
+		agentLines.some((text) => /7-day|seven days|invalid_grant/i.test(text)),
 	).toBe(true)
 	expect(
 		agentLines.some((text) =>
-			/redirect URI/i.test(text) &&
-			text.includes('https://kody.codes/connect/oauth'),
+			/never paste|do not paste|client secret/i.test(text),
+		),
+	).toBe(true)
+	expect(
+		agentLines.some(
+			(text) =>
+				/redirect URI/i.test(text) &&
+				text.includes('https://kody.codes/connect/oauth'),
 		),
 	).toBe(true)
 
 	const userLines = googleOauthTranscriptActs.flatMap((act) =>
 		act.lines.flatMap((line) => (line.role === 'user' ? [line.text] : [])),
 	)
-	expect(userLines.some((text) => /done|what.?s next|what is next/i.test(text))).toBe(
-		true,
-	)
+	expect(
+		userLines.some((text) => /done|what.?s next|what is next/i.test(text)),
+	).toBe(true)
 	expect(userLines.some((text) => /created a project/i.test(text))).toBe(true)
 	expect(userLines.some((text) => /redirect URI/i.test(text))).toBe(true)
 	expect(userLines.some((text) => /paste|client secret/i.test(text))).toBe(true)
@@ -170,8 +171,10 @@ test('google oauth transcript covers Lane B, console beats, connect, and smoke t
 	)
 	expect(userLines.some((text) => /authorized/i.test(text))).toBe(true)
 
-	const connectUrlAgent = agentLines.find((text) =>
-		text.includes('authorizeUrl=') && text.includes('/connect/oauth?provider=google'),
+	const connectUrlAgent = agentLines.find(
+		(text) =>
+			text.includes('authorizeUrl=') &&
+			text.includes('/connect/oauth?provider=google'),
 	)
 	expect(connectUrlAgent).toBeTruthy()
 	expect(connectUrlAgent).toContain('gmail.readonly')

--- a/packages/worker/client/routes/google-oauth-transcript.ts
+++ b/packages/worker/client/routes/google-oauth-transcript.ts
@@ -87,10 +87,10 @@ const codingGuideSearchMarkdown = `# Search results
 
 For full detail on entity-backed hits, call \`search\` with \`entity: "{id}:{type}"\`.
 
-1. `capability` \`coding_guide_get\` (\`coding\`) — Load an official Kody guide (markdown, bundled from the kody repository). Prefer this capability plus \`search\` results over local repo spelunking when Kody auth or integration behavior is already documented. Entity: \`coding_guide_get:capability\`
+1. **capability** \`coding_guide_get\` (\`coding\`) — Load an official Kody guide (markdown, bundled from the kody repository). Prefer this capability plus \`search\` results over local repo spelunking when Kody auth or integration behavior is already documented. Entity: \`coding_guide_get:capability\`
    \`kody.coding_guide_get(args)\` — \`type CodingGuideGetInput = { guide: "integration_bootstrap" | "oauth" | "provider_google" | ... }\`; use entity detail for the full definition
-2. `guide` Connect Google (Gmail, Calendar, Drive) — Built-in Calendar scopes vs bring-your-own OAuth for inbox reading. Entity: \`provider_google:guide\`
-3. `guide` OAuth guide (standard path) — Hosted \`/connect/oauth\`, redirect URI, PKCE vs confidential. Entity: \`oauth:guide\``
+2. **guide** Connect Google (Gmail, Calendar, Drive) — Built-in Calendar scopes vs bring-your-own OAuth for inbox reading. Entity: \`provider_google:guide\`
+3. **guide** OAuth guide (standard path) — Hosted \`/connect/oauth\`, redirect URI, PKCE vs confidential. Entity: \`oauth:guide\``
 
 const codingGuideDetailMarkdown = `# Capability — \`coding_guide_get\`
 
@@ -261,7 +261,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: `On the `Data Access` tab, add this scope: \`${gmailReadonlyScope}\`. That is the inbox-read scope this invoice task needs.`,
+				text: `On the \`Data Access\` tab, add this scope: \`${gmailReadonlyScope}\`. That is the inbox-read scope this invoice task needs.`,
 			},
 			{
 				role: 'user',

--- a/packages/worker/client/routes/google-oauth-transcript.ts
+++ b/packages/worker/client/routes/google-oauth-transcript.ts
@@ -87,10 +87,10 @@ const codingGuideSearchMarkdown = `# Search results
 
 For full detail on entity-backed hits, call \`search\` with \`entity: "{id}:{type}"\`.
 
-1. **capability** \`coding_guide_get\` (\`coding\`) — Load an official Kody guide (markdown, bundled from the kody repository). Prefer this capability plus \`search\` results over local repo spelunking when Kody auth or integration behavior is already documented. Entity: \`coding_guide_get:capability\`
+1. `capability` \`coding_guide_get\` (\`coding\`) — Load an official Kody guide (markdown, bundled from the kody repository). Prefer this capability plus \`search\` results over local repo spelunking when Kody auth or integration behavior is already documented. Entity: \`coding_guide_get:capability\`
    \`kody.coding_guide_get(args)\` — \`type CodingGuideGetInput = { guide: "integration_bootstrap" | "oauth" | "provider_google" | ... }\`; use entity detail for the full definition
-2. **guide** Connect Google (Gmail, Calendar, Drive) — Built-in Calendar scopes vs bring-your-own OAuth for inbox reading. Entity: \`provider_google:guide\`
-3. **guide** OAuth guide (standard path) — Hosted \`/connect/oauth\`, redirect URI, PKCE vs confidential. Entity: \`oauth:guide\``
+2. `guide` Connect Google (Gmail, Calendar, Drive) — Built-in Calendar scopes vs bring-your-own OAuth for inbox reading. Entity: \`provider_google:guide\`
+3. `guide` OAuth guide (standard path) — Hosted \`/connect/oauth\`, redirect URI, PKCE vs confidential. Entity: \`oauth:guide\``
 
 const codingGuideDetailMarkdown = `# Capability — \`coding_guide_get\`
 
@@ -192,7 +192,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 							value: {
 								bootstrap: {
 									title: 'Integration bootstrap guide',
-									body: '# Integration bootstrap guide\n\n**Read this guide first** when a user wants a package, package app, or workflow that depends on a third-party integration.\n\n## Core rule\n\nDo **not** save or present an auth-dependent package as complete until a minimal authenticated smoke test succeeds.\n\n…',
+									body: '# Integration bootstrap guide\n\nRead this guide first when a user wants a package, package app, or workflow that depends on a third-party integration.\n\n## Core rule\n\nDo not save or present an auth-dependent package as complete until a minimal authenticated smoke test succeeds.\n\n…',
 								},
 								oauth: {
 									title: 'OAuth guide (standard path)',
@@ -200,7 +200,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 								},
 								google: {
 									title: 'Connect Google (Gmail, Calendar, Drive)',
-									body: '# Connect Google (Gmail, Calendar, Drive)\n\nPrefer the **built-in** Google integration when its scope menu covers the task. Bring your own Google OAuth client when you need access outside that menu — especially inbox reading.\n\n## Lane A: built-in Google (default)\n\n…\n\n## Lane B: bring-your-own OAuth client\n\n…',
+									body: '# Connect Google (Gmail, Calendar, Drive)\n\nPrefer the built-in Google integration when its scope menu covers the task. Bring your own Google OAuth client when you need access outside that menu — especially inbox reading.\n\n## Lane A: built-in Google (default)\n\n…\n\n## Lane B: bring-your-own OAuth client\n\n…',
 								},
 							},
 						}),
@@ -214,7 +214,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: 'Reading your Gmail inbox needs a Google Cloud OAuth client you own — the built-in Google connect only covers scopes like Calendar and send-only Gmail, not inbox reading. I will walk you through the console one step at a time. Open [console.cloud.google.com](https://console.cloud.google.com) and create a new project (or select one you already use). Reply when that is done.',
+				text: 'Reading your Gmail inbox needs a Google Cloud OAuth client you own — the built-in Google connect only covers scopes like Calendar and send-only Gmail, not inbox reading. I will walk you through the console one step at a time. Open https://console.cloud.google.com and create a new project (or select one you already use). Reply when that is done.',
 			},
 		],
 	},
@@ -229,7 +229,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: 'In **APIs & Services → Library**, enable **Gmail API** for that project. Skip Calendar and Drive unless you need them for this task. Reply when Gmail API shows as enabled.',
+				text: 'In `APIs & Services → Library`, enable `Gmail API` for that project. Skip Calendar and Drive unless you need them for this task. Reply when Gmail API shows as enabled.',
 			},
 			{
 				role: 'user',
@@ -237,7 +237,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: 'Open **APIs & Services → Google Auth Platform** and click **Get started**. Fill in **Branding** (app name and support email), set **Audience** to **External**, and add your contact email. Reply when the wizard finishes.',
+				text: 'Open `APIs & Services → Google Auth Platform` and click `Get started`. Fill in `Branding` (app name and support email), set `Audience` to `External`, and add your contact email. Reply when the wizard finishes.',
 			},
 			{
 				role: 'user',
@@ -245,7 +245,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: 'On the **Clients** tab, click **Create Client**, choose application type **Web application**, and add this redirect URI exactly: `https://kody.codes/connect/oauth`. Copy the client ID and client secret when Google shows them — you will paste those into Kody later, not here.',
+				text: 'On the `Clients` tab, click `Create Client`, choose application type `Web application`, and add this redirect URI exactly: `https://kody.codes/connect/oauth`. Copy the client ID and client secret when Google shows them — you will paste those into Kody later, not here.',
 			},
 			{
 				role: 'user',
@@ -261,7 +261,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: `On the **Data Access** tab, add this scope: \`${gmailReadonlyScope}\`. That is the inbox-read scope this invoice task needs.`,
+				text: `On the `Data Access` tab, add this scope: \`${gmailReadonlyScope}\`. That is the inbox-read scope this invoice task needs.`,
 			},
 			{
 				role: 'user',
@@ -269,7 +269,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: 'While publishing status is **Testing**, open the **Audience** tab and add your own Google account as a test user. Reply when you are listed.',
+				text: 'While publishing status is `Testing`, open the `Audience` tab and add your own Google account as a test user. Reply when you are listed.',
 			},
 			{
 				role: 'user',
@@ -277,7 +277,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'agent',
-				text: 'Almost — but stay on **Testing** and refresh tokens expire after seven days. Everything looks fine during setup, then the integration dies a week later with `invalid_grant` on refresh. On the **Audience** page, click **Publish app** to move to **Production**. Google shows an “unverified app” warning on consent; for a personal app that is expected — click Advanced, then continue to your app when you authorize. Reply when status is Production.',
+				text: 'Almost — but stay on `Testing` and refresh tokens expire after seven days. Everything looks fine during setup, then the integration dies a week later with `invalid_grant` on refresh. On the `Audience` page, click `Publish app` to move to `Production`. Google shows an “unverified app” warning on consent; for a personal app that is expected — click Advanced, then continue to your app when you authorize. Reply when status is Production.',
 			},
 			{
 				role: 'user',

--- a/packages/worker/client/routes/google-oauth-transcript.ts
+++ b/packages/worker/client/routes/google-oauth-transcript.ts
@@ -1,0 +1,375 @@
+import {
+	conversationIdInput,
+	executeTextReturn,
+	jsonInput,
+	memoryContextInput,
+	searchTextReturn,
+	type TranscriptAct,
+} from './interactive-guide-transcript.ts'
+
+export type {
+	TranscriptAct,
+	TranscriptFile,
+	TranscriptInput,
+	TranscriptLine,
+	TranscriptTool,
+} from './interactive-guide-transcript.ts'
+
+const conversationId = '8g4q1n6m2s9t'
+
+const askMemoryContext = {
+	task: 'Connect Google so Kody can read my Gmail inbox for Acme invoices',
+	entities: ['Google', 'Gmail', 'Acme invoices'],
+}
+
+const loadGuidesCode = `import { kody } from 'kody:runtime'
+
+export default async function main() {
+	const bootstrap = await kody.coding_guide_get({
+		guide: 'integration_bootstrap',
+	})
+	const oauth = await kody.coding_guide_get({ guide: 'oauth' })
+	const google = await kody.coding_guide_get({ guide: 'provider_google' })
+	return { bootstrap, oauth, google }
+}`
+
+const gmailProfileSmokeCode = `import { createAuthenticatedFetch } from 'kody:runtime'
+
+export default async function main() {
+	const googleFetch = await createAuthenticatedFetch('google')
+	const response = await googleFetch(
+		'https://gmail.googleapis.com/gmail/v1/users/me/profile',
+	)
+	if (!response.ok) {
+		throw new Error(
+			\`Gmail smoke test failed: \${response.status} \${await response.text()}\`,
+		)
+	}
+	return await response.json()
+}`
+
+const recentSubjectsCode = `import { createAuthenticatedFetch } from 'kody:runtime'
+
+export default async function main() {
+	const googleFetch = await createAuthenticatedFetch('google')
+	const listResponse = await googleFetch(
+		'https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=2',
+	)
+	if (!listResponse.ok) {
+		throw new Error(\`Gmail list failed: \${listResponse.status}\`)
+	}
+	const list = (await listResponse.json()) as {
+		messages?: Array<{ id: string }>
+	}
+	const subjects: Array<string> = []
+	for (const message of list.messages ?? []) {
+		const detailResponse = await googleFetch(
+			\`https://gmail.googleapis.com/gmail/v1/users/me/messages/\${message.id}?format=metadata&metadataHeaders=Subject\`,
+		)
+		if (!detailResponse.ok) continue
+		const detail = (await detailResponse.json()) as {
+			payload?: { headers?: Array<{ name: string; value: string }> }
+		}
+		const subject = detail.payload?.headers?.find(
+			(header) => header.name.toLowerCase() === 'subject',
+		)?.value
+		if (subject) subjects.push(subject)
+	}
+	return { subjects }
+}`
+
+const gmailReadonlyScope = 'https://www.googleapis.com/auth/gmail.readonly'
+
+const connectOauthUrl =
+	'https://kody.codes/connect/oauth?provider=google&authorizeUrl=https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fv2%2Fauth&tokenUrl=https%3A%2F%2Foauth2.googleapis.com%2Ftoken&flow=confidential&scopes=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly&allowedHosts=gmail.googleapis.com&extraAuthorizeParams=%7B%22access_type%22%3A%22offline%22%2C%22prompt%22%3A%22consent%22%7D'
+
+const codingGuideSearchMarkdown = `# Search results
+
+For full detail on entity-backed hits, call \`search\` with \`entity: "{id}:{type}"\`.
+
+1. **capability** \`coding_guide_get\` (\`coding\`) — Load an official Kody guide (markdown, bundled from the kody repository). Prefer this capability plus \`search\` results over local repo spelunking when Kody auth or integration behavior is already documented. Entity: \`coding_guide_get:capability\`
+   \`kody.coding_guide_get(args)\` — \`type CodingGuideGetInput = { guide: "integration_bootstrap" | "oauth" | "provider_google" | ... }\`; use entity detail for the full definition
+2. **guide** Connect Google (Gmail, Calendar, Drive) — Built-in Calendar scopes vs bring-your-own OAuth for inbox reading. Entity: \`provider_google:guide\`
+3. **guide** OAuth guide (standard path) — Hosted \`/connect/oauth\`, redirect URI, PKCE vs confidential. Entity: \`oauth:guide\``
+
+const codingGuideDetailMarkdown = `# Capability — \`coding_guide_get\`
+
+Load an official Kody guide (markdown, bundled from the kody repository).
+Use \`guide: "integration_bootstrap"\` before building anything that depends on third-party auth.
+Use \`guide: "oauth"\` for the hosted \`/connect/oauth\` path and redirect URI.
+Use \`guide: "provider_google"\` for Google console steps, built-in vs BYO lanes, and the Testing-status refresh-token trap.
+
+## Summary
+
+- Entity: \`coding_guide_get:capability\`
+- Domain: \`coding\`
+- Required input fields: \`guide\`
+
+## Execute from \`execute\`
+
+\`\`\`ts
+import { kody } from 'kody:runtime'
+
+export default async function main(input = {}) {
+	return await kody.coding_guide_get(input)
+}
+\`\`\`
+`
+
+export const googleOauthTranscriptActs: Array<TranscriptAct> = [
+	{
+		id: 'discover',
+		kicker: 'Example of a conversation you might have with your agent.',
+		title: 'Find the path',
+		lines: [
+			{
+				role: 'user',
+				text: 'I want Kody to read my Gmail inbox for invoices from Acme. I have no idea how to connect Google — can you walk me through it?',
+			},
+			{
+				role: 'agent',
+				tone: 'reasoning',
+				text: 'I do not already know the Google connect steps. I will search for official Kody guides on Google, Gmail, and OAuth.',
+			},
+			{
+				role: 'tools',
+				tools: [
+					{
+						name: 'search',
+						summary: 'Find official guides for Google Gmail OAuth',
+						note: 'Search ranks `coding_guide_get` and the Google / OAuth guides. No matching memory is required for this story. The `conversationId` is minted here so later calls in this chat stay cheap.',
+						inputs: [
+							{
+								name: 'query',
+								kind: 'query',
+								lang: 'json',
+								value: jsonInput('google gmail inbox oauth'),
+							},
+							memoryContextInput(askMemoryContext),
+						],
+						resultLang: 'md',
+						result: searchTextReturn({
+							conversationId,
+							body: codingGuideSearchMarkdown,
+						}),
+					},
+					{
+						name: 'search',
+						summary: 'Open coding_guide_get for the guide ids',
+						note: 'Entity detail is the full card. It names `integration_bootstrap`, `oauth`, and `provider_google` — the three guides this connect needs.',
+						inputs: [
+							{
+								name: 'entity',
+								kind: 'query',
+								lang: 'json',
+								value: jsonInput('coding_guide_get:capability'),
+							},
+							conversationIdInput(conversationId),
+						],
+						resultLang: 'md',
+						result: searchTextReturn({
+							conversationId,
+							body: codingGuideDetailMarkdown,
+						}),
+					},
+					{
+						name: 'execute',
+						summary: 'Load bootstrap, OAuth, and Google provider guides',
+						note: 'Guides are bundled markdown from the Kody repo. The real `coding_guide_get` return is the full guide (a couple hundred lines each). This walkthrough shows the opening only.',
+						inputs: [
+							{
+								name: 'code',
+								kind: 'code',
+								lang: 'ts',
+								value: loadGuidesCode,
+							},
+							conversationIdInput(conversationId),
+							memoryContextInput(askMemoryContext),
+						],
+						resultLang: 'md',
+						result: executeTextReturn({
+							conversationId,
+							value: {
+								bootstrap: {
+									title: 'Integration bootstrap guide',
+									body: '# Integration bootstrap guide\n\n**Read this guide first** when a user wants a package, package app, or workflow that depends on a third-party integration.\n\n## Core rule\n\nDo **not** save or present an auth-dependent package as complete until a minimal authenticated smoke test succeeds.\n\n…',
+								},
+								oauth: {
+									title: 'OAuth guide (standard path)',
+									body: '# OAuth guide\n\nSend the signed-in user to `https://kody.codes/connect/oauth` with query parameters that describe the provider.\n\n## Redirect URI\n\nThe redirect URI is `https://kody.codes/connect/oauth`.\n\n…',
+								},
+								google: {
+									title: 'Connect Google (Gmail, Calendar, Drive)',
+									body: '# Connect Google (Gmail, Calendar, Drive)\n\nPrefer the **built-in** Google integration when its scope menu covers the task. Bring your own Google OAuth client when you need access outside that menu — especially inbox reading.\n\n## Lane A: built-in Google (default)\n\n…\n\n## Lane B: bring-your-own OAuth client\n\n…',
+								},
+							},
+						}),
+					},
+				],
+			},
+			{
+				role: 'agent',
+				tone: 'reasoning',
+				text: 'Inbox reading (`gmail.readonly`) is outside the built-in Google scope menu. That means Lane B: bring-your-own OAuth client in Google Cloud, not the one-click `/connect/oauth?provider=google` path.',
+			},
+			{
+				role: 'agent',
+				text: 'Reading your Gmail inbox needs a Google Cloud OAuth client you own — the built-in Google connect only covers scopes like Calendar and send-only Gmail, not inbox reading. I will walk you through the console one step at a time. Open [console.cloud.google.com](https://console.cloud.google.com) and create a new project (or select one you already use). Reply when that is done.',
+			},
+		],
+	},
+	{
+		id: 'console',
+		kicker: 'Same conversation — one console step at a time',
+		title: 'Build the OAuth client',
+		lines: [
+			{
+				role: 'user',
+				text: 'I created a project. What is next?',
+			},
+			{
+				role: 'agent',
+				text: 'In **APIs & Services → Library**, enable **Gmail API** for that project. Skip Calendar and Drive unless you need them for this task. Reply when Gmail API shows as enabled.',
+			},
+			{
+				role: 'user',
+				text: 'Done, what is next?',
+			},
+			{
+				role: 'agent',
+				text: 'Open **APIs & Services → Google Auth Platform** and click **Get started**. Fill in **Branding** (app name and support email), set **Audience** to **External**, and add your contact email. Reply when the wizard finishes.',
+			},
+			{
+				role: 'user',
+				text: 'Done.',
+			},
+			{
+				role: 'agent',
+				text: 'On the **Clients** tab, click **Create Client**, choose application type **Web application**, and add this redirect URI exactly: `https://kody.codes/connect/oauth`. Copy the client ID and client secret when Google shows them — you will paste those into Kody later, not here.',
+			},
+			{
+				role: 'user',
+				text: "What is a redirect URI? And is it okay if I paste the client secret here so you can save it?",
+			},
+			{
+				role: 'agent',
+				text: 'A redirect URI is the URL the provider sends the browser back to after you approve access. For Kody it is always `https://kody.codes/connect/oauth` — register it exactly, no trailing slash. Do not paste the client secret in chat. When we get to the connect form, paste the client ID and client secret only on that Kody page.',
+			},
+			{
+				role: 'user',
+				text: 'Okay, client is created. Next?',
+			},
+			{
+				role: 'agent',
+				text: `On the **Data Access** tab, add this scope: \`${gmailReadonlyScope}\`. That is the inbox-read scope this invoice task needs.`,
+			},
+			{
+				role: 'user',
+				text: 'Added. Done, what is next?',
+			},
+			{
+				role: 'agent',
+				text: 'While publishing status is **Testing**, open the **Audience** tab and add your own Google account as a test user. Reply when you are listed.',
+			},
+			{
+				role: 'user',
+				text: 'I am a test user. Can we connect now? It already works in Testing.',
+			},
+			{
+				role: 'agent',
+				text: 'Almost — but stay on **Testing** and refresh tokens expire after seven days. Everything looks fine during setup, then the integration dies a week later with `invalid_grant` on refresh. On the **Audience** page, click **Publish app** to move to **Production**. Google shows an “unverified app” warning on consent; for a personal app that is expected — click Advanced, then continue to your app when you authorize. Reply when status is Production.',
+			},
+			{
+				role: 'user',
+				text: 'Published. Ready for the Kody side.',
+			},
+		],
+	},
+	{
+		id: 'connect',
+		kicker: 'Same conversation — connect on Kody, then prove it',
+		title: 'Connect and verify',
+		lines: [
+			{
+				role: 'agent',
+				text: `Open this prefilled connect link while signed in to Kody:\n\n${connectOauthUrl}\n\nPaste the client ID and client secret into that form (confidential flow). Authorize Google when prompted. The link already requests \`gmail.readonly\`, allows \`gmail.googleapis.com\`, and sets \`access_type=offline\` with \`prompt=consent\` so you get a refresh token.`,
+			},
+			{
+				role: 'user',
+				text: 'Here is my client secret — can I paste it here so you finish setup?',
+			},
+			{
+				role: 'agent',
+				text: 'No — never paste a client secret into chat. Delete that message if you can. Paste the client ID and client secret only on the Kody `/connect/oauth` form I linked, then authorize in the browser.',
+			},
+			{
+				role: 'user',
+				text: 'I authorized. What is next?',
+			},
+			{
+				role: 'agent',
+				tone: 'reasoning',
+				text: 'I will smoke-test the Gmail profile endpoint with the saved Google integration before we call this done.',
+			},
+			{
+				role: 'tools',
+				tools: [
+					{
+						name: 'execute',
+						summary: 'Smoke-test Gmail with the saved Google integration',
+						note: '`createAuthenticatedFetch` refreshes tokens host-side. The module never sees a raw access token. Profile URL comes from the Google provider guide.',
+						inputs: [
+							{
+								name: 'code',
+								kind: 'code',
+								lang: 'ts',
+								value: gmailProfileSmokeCode,
+							},
+							conversationIdInput(conversationId),
+							memoryContextInput(askMemoryContext),
+						],
+						resultLang: 'md',
+						result: executeTextReturn({
+							conversationId,
+							value: {
+								emailAddress: 'you@example.com',
+								messagesTotal: 1842,
+								threadsTotal: 921,
+								historyId: '123456',
+							},
+						}),
+					},
+					{
+						name: 'execute',
+						summary: 'List a couple of recent message subjects',
+						note: 'Optional second check after profile succeeds. Still no package — the payoff is a working integration.',
+						inputs: [
+							{
+								name: 'code',
+								kind: 'code',
+								lang: 'ts',
+								value: recentSubjectsCode,
+							},
+							conversationIdInput(conversationId),
+							memoryContextInput(askMemoryContext),
+						],
+						resultLang: 'md',
+						result: executeTextReturn({
+							conversationId,
+							value: {
+								subjects: [
+									'Acme Invoice #4412',
+									'Your weekly digest',
+								],
+							},
+						}),
+					},
+				],
+			},
+			{
+				role: 'agent',
+				text: 'Connected. Your Gmail profile loads, and recent mail includes an Acme invoice subject. Later reconnects can use `/connect/oauth?provider=google` alone — Kody already has the endpoints from this setup.',
+			},
+		],
+	},
+]

--- a/packages/worker/client/routes/google-oauth-transcript.ts
+++ b/packages/worker/client/routes/google-oauth-transcript.ts
@@ -249,7 +249,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 			},
 			{
 				role: 'user',
-				text: "What is a redirect URI? And is it okay if I paste the client secret here so you can save it?",
+				text: 'What is a redirect URI? And is it okay if I paste the client secret here so you can save it?',
 			},
 			{
 				role: 'agent',
@@ -357,10 +357,7 @@ export const googleOauthTranscriptActs: Array<TranscriptAct> = [
 						result: executeTextReturn({
 							conversationId,
 							value: {
-								subjects: [
-									'Acme Invoice #4412',
-									'Your weekly digest',
-								],
+								subjects: ['Acme Invoice #4412', 'Your weekly digest'],
 							},
 						}),
 					},

--- a/packages/worker/client/routes/google-oauth-walkthrough.tsx
+++ b/packages/worker/client/routes/google-oauth-walkthrough.tsx
@@ -1,0 +1,13 @@
+import { googleOauthTranscriptActs } from './google-oauth-transcript.ts'
+import { renderInteractiveGuideWalkthrough } from './interactive-guide-walkthrough.tsx'
+
+/**
+ * Interactive Google OAuth transcript for /guides/google-oauth.
+ * Shared line/tool rendering lives in interactive-guide-walkthrough.tsx.
+ */
+export function renderGoogleOauthWalkthrough() {
+	return renderInteractiveGuideWalkthrough({
+		lead: 'A coding agent looks up the official Kody guides, then walks a naive user through Lane B Google OAuth — bring-your-own client for Gmail inbox reading — one console step at a time.',
+		acts: googleOauthTranscriptActs,
+	})
+}

--- a/packages/worker/client/routes/guide-detail.tsx
+++ b/packages/worker/client/routes/guide-detail.tsx
@@ -14,6 +14,7 @@ import { readRouterPathname } from '#client/router-location.tsx'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { formatLastVerified } from '#client/routes/guides.tsx'
 import { renderHowKodyWorksWalkthrough } from '#client/routes/how-kody-works-walkthrough.tsx'
+import { renderGoogleOauthWalkthrough } from '#client/routes/google-oauth-walkthrough.tsx'
 import { colors } from '#universal/styles/tokens.ts'
 import {
 	articleMeasure,
@@ -22,15 +23,20 @@ import {
 	proseCss,
 } from '#universal/styles/style-primitives.ts'
 
-const interactiveGuideSlug = 'how-kody-works'
+const interactiveGuideRenderers: Readonly<
+	Record<string, () => ReturnType<typeof renderHowKodyWorksWalkthrough>>
+> = {
+	'how-kody-works': renderHowKodyWorksWalkthrough,
+	'google-oauth': renderGoogleOauthWalkthrough,
+}
 
 /**
  * Guide detail: back link → guide head (title, verified month) → `.prose`
  * body rendered from the server's bundled markdown catalog with the
  * first-party link policy (guides link into `/connect/oauth` and
- * `/account/secrets/new`) and copyable code blocks. `/guides/how-kody-works`
- * swaps the prose body for the interactive factory-loop transcript. A quiet
- * foot links the raw markdown twin for agents.
+ * `/account/secrets/new`) and copyable code blocks. Interactive slugs
+ * (how-kody-works, google-oauth) swap the prose body for a transcript
+ * walkthrough. A quiet foot links the raw markdown twin for agents.
  */
 
 export function getGuideSlugFromPathname(pathname: string) {
@@ -248,11 +254,14 @@ export function GuideDetailRoute(handle: Handle) {
 							</p>
 						</header>
 
-						{guide.slug === interactiveGuideSlug ? (
-							renderHowKodyWorksWalkthrough()
-						) : (
-							<div mix={css(proseCss)}>{renderGuideBody(guide.body)}</div>
-						)}
+						{(() => {
+							const renderInteractive = interactiveGuideRenderers[guide.slug]
+							return renderInteractive ? (
+								renderInteractive()
+							) : (
+								<div mix={css(proseCss)}>{renderGuideBody(guide.body)}</div>
+							)
+						})()}
 
 						<footer mix={css(guideFootCss)}>
 							<p>

--- a/packages/worker/client/routes/guide-detail.tsx
+++ b/packages/worker/client/routes/guide-detail.tsx
@@ -254,14 +254,9 @@ export function GuideDetailRoute(handle: Handle) {
 							</p>
 						</header>
 
-						{(() => {
-							const renderInteractive = interactiveGuideRenderers[guide.slug]
-							return renderInteractive ? (
-								renderInteractive()
-							) : (
-								<div mix={css(proseCss)}>{renderGuideBody(guide.body)}</div>
-							)
-						})()}
+						{interactiveGuideRenderers[guide.slug]?.() ?? (
+							<div mix={css(proseCss)}>{renderGuideBody(guide.body)}</div>
+						)}
 
 						<footer mix={css(guideFootCss)}>
 							<p>

--- a/packages/worker/client/routes/how-kody-works-transcript.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.ts
@@ -1,43 +1,19 @@
-export type TranscriptInput = {
-	name: string
-	kind: 'query' | 'code' | 'memory'
-	lang?: string
-	value: string
-}
+import {
+	conversationIdInput,
+	executeTextReturn,
+	jsonInput,
+	memoryContextInput,
+	searchTextReturn,
+	type TranscriptAct,
+} from './interactive-guide-transcript.ts'
 
-export type TranscriptTool = {
-	name: string
-	summary: string
-	note: string
-	inputs: Array<TranscriptInput>
-	resultLang?: string
-	result: string
-}
-
-export type TranscriptFile = {
-	path: string
-	summary: string
-	lang?: string
-	content: string
-}
-
-export type TranscriptLine =
-	| { role: 'user'; text: string }
-	| { role: 'agent'; text: string; tone?: 'reasoning' }
-	| { role: 'tools'; tools: Array<TranscriptTool> }
-	| {
-			role: 'files'
-			summary: string
-			note: string
-			files: Array<TranscriptFile>
-	  }
-
-export type TranscriptAct = {
-	id: string
-	kicker: string
-	title: string
-	lines: Array<TranscriptLine>
-}
+export type {
+	TranscriptAct,
+	TranscriptFile,
+	TranscriptInput,
+	TranscriptLine,
+	TranscriptTool,
+} from './interactive-guide-transcript.ts'
 
 const whatShippedSource = `import { packageStorage } from 'kody:runtime'
 
@@ -323,9 +299,6 @@ function publishReturn(input: {
 	}
 }
 
-function jsonInput(value: unknown) {
-	return JSON.stringify(value, null, 2)
-}
 
 const askMemoryContext = {
 	task: 'What did my favorite bot ship recently on GitHub?',
@@ -348,16 +321,6 @@ const watchLoginMemory = {
 		"kody-bot is my favorite bot. I'm really interested in what it ships on github",
 }
 
-function memoryContextInput(
-	context: { task: string; entities: Array<string> } = askMemoryContext,
-) {
-	return {
-		name: 'memoryContext',
-		kind: 'memory' as const,
-		lang: 'json',
-		value: jsonInput(context),
-	}
-}
 
 const askConversationId = '3k7n2p9q4r8w'
 const phoneConversationId = '5h8m2q7t1v4x'
@@ -474,59 +437,10 @@ function repoSessionPublishReturn(publishedCommit: string) {
 	}
 }
 
-function conversationIdInput(conversationId: string) {
-	return {
-		name: 'conversationId',
-		kind: 'query' as const,
-		lang: 'json',
-		value: jsonInput(conversationId),
-	}
-}
 
-const conversationIdReturnNote =
-	'Tool conversation id; pass it back on subsequent search/execute calls.'
 
-function conversationIdReturn(conversationId: string) {
-	return `conversationId: ${conversationId}\n${conversationIdReturnNote}`
-}
 
-function relevantMemoriesMarkdown(
-	memories: Array<{ subject: string; summary: string }>,
-) {
-	return [
-		'## Relevant memories',
-		'',
-		...memories.map((memory) => `- **${memory.subject}** — ${memory.summary}`),
-	].join('\n')
-}
 
-function searchTextReturn(input: {
-	conversationId: string
-	body: string
-	memories?: Array<{ subject: string; summary: string }>
-}) {
-	const parts = [conversationIdReturn(input.conversationId), '', input.body]
-	if (input.memories && input.memories.length > 0) {
-		parts.push('', relevantMemoriesMarkdown(input.memories))
-	}
-	return parts.join('\n')
-}
-
-function executeTextReturn(input: {
-	conversationId: string
-	value: unknown
-	memories?: Array<{ subject: string; summary: string }>
-}) {
-	const parts = [
-		conversationIdReturn(input.conversationId),
-		'',
-		jsonInput(input.value),
-	]
-	if (input.memories && input.memories.length > 0) {
-		parts.push('', relevantMemoriesMarkdown(input.memories))
-	}
-	return parts.join('\n')
-}
 
 const githubSearchMarkdown = `# Search results
 
@@ -607,7 +521,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 								lang: 'json',
 								value: jsonInput('github user activity'),
 							},
-							memoryContextInput(),
+							memoryContextInput(askMemoryContext),
 						],
 						resultLang: 'md',
 						result: searchTextReturn({
@@ -639,7 +553,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 								value: fetchShipsCode,
 							},
 							conversationIdInput(askConversationId),
-							memoryContextInput(),
+							memoryContextInput(askMemoryContext),
 						],
 						resultLang: 'md',
 						result: executeTextReturn({
@@ -732,7 +646,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 								value: loadGuidesCode,
 							},
 							conversationIdInput(askConversationId),
-							memoryContextInput(),
+							memoryContextInput(askMemoryContext),
 						],
 						resultLang: 'md',
 						result: executeTextReturn({
@@ -771,7 +685,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 								value: getGitRemoteCreateCode,
 							},
 							conversationIdInput(askConversationId),
-							memoryContextInput(),
+							memoryContextInput(askMemoryContext),
 						],
 						resultLang: 'md',
 						result: executeTextReturn({
@@ -821,7 +735,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 								value: publishExternalPushCode,
 							},
 							conversationIdInput(askConversationId),
-							memoryContextInput(),
+							memoryContextInput(askMemoryContext),
 						],
 						resultLang: 'md',
 						result: executeTextReturn({

--- a/packages/worker/client/routes/how-kody-works-transcript.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.ts
@@ -299,7 +299,6 @@ function publishReturn(input: {
 	}
 }
 
-
 const askMemoryContext = {
 	task: 'What did my favorite bot ship recently on GitHub?',
 	entities: ['favorite bot'],
@@ -320,7 +319,6 @@ const watchLoginMemory = {
 	summary:
 		"kody-bot is my favorite bot. I'm really interested in what it ships on github",
 }
-
 
 const askConversationId = '3k7n2p9q4r8w'
 const phoneConversationId = '5h8m2q7t1v4x'
@@ -436,11 +434,6 @@ function repoSessionPublishReturn(publishedCommit: string) {
 		},
 	}
 }
-
-
-
-
-
 
 const githubSearchMarkdown = `# Search results
 

--- a/packages/worker/client/routes/how-kody-works-walkthrough.tsx
+++ b/packages/worker/client/routes/how-kody-works-walkthrough.tsx
@@ -3,59 +3,31 @@ import { CopyCodeBlock } from '#client/copy-code-block.tsx'
 import {
 	howKodyWorksPackageFiles,
 	howKodyWorksTranscriptActs,
-	type TranscriptFile,
-	type TranscriptInput,
-	type TranscriptLine,
-	type TranscriptTool,
 } from './how-kody-works-transcript.ts'
 import {
-	getAccentCalloutCss,
-	getArticleBreakoutCss,
-} from '#universal/styles/style-primitives.ts'
-import {
-	colors,
-	radius,
-	spacing,
-	typography,
-} from '#universal/styles/tokens.ts'
+	interactiveGuideActCss,
+	interactiveGuideKickerCss,
+	interactiveGuideMutedLeadCss,
+	interactiveGuideToolBodyCss,
+	interactiveGuideToolCss,
+	interactiveGuideToolNameCss,
+	interactiveGuideToolSummaryCss,
+	renderInteractiveGuideWalkthrough,
+} from './interactive-guide-walkthrough.tsx'
 
 /**
  * Interactive factory-loop transcript for /guides/how-kody-works.
- * Tool calls are native <details> so they work without JavaScript.
- * This is a render helper, not a Remix component — only CopyCodeBlock
- * needs a handle.
+ * Shared line/tool rendering lives in interactive-guide-walkthrough.tsx.
  */
 export function renderHowKodyWorksWalkthrough() {
-	return (
-		<div mix={css(walkthroughCss)}>
-			<p mix={css(leadCss)}>
-				A question you would ask again becomes an export you can invoke from any
-				agent, then a daily email that stays quiet until something actually
-				shipped.
-			</p>
-
-			{howKodyWorksTranscriptActs.map((act) => (
-				<section
-					key={act.id}
-					mix={css(actCss)}
-					aria-labelledby={`${act.id}-title`}
-				>
-					<p mix={css(act.id === 'ask' ? exampleKickerCss : kickerCss)}>
-						{act.kicker}
-					</p>
-					<h2 id={`${act.id}-title`}>{act.title}</h2>
-					<ol mix={css(threadCss)}>
-						{act.lines.map((line, index) => (
-							<li key={`${act.id}-${index}`}>{renderLine(line)}</li>
-						))}
-					</ol>
-				</section>
-			))}
-
-			<section mix={css(actCss)} aria-labelledby="package-files-title">
-				<p mix={css(kickerCss)}>The package</p>
+	return renderInteractiveGuideWalkthrough({
+		lead: 'A question you would ask again becomes an export you can invoke from any agent, then a daily email that stays quiet until something actually shipped.',
+		acts: howKodyWorksTranscriptActs,
+		afterActs: (
+			<section mix={css(interactiveGuideActCss)} aria-labelledby="package-files-title">
+				<p mix={css(interactiveGuideKickerCss)}>The package</p>
 				<h2 id="package-files-title">What the agent wrote</h2>
-				<p mix={css(packageLeadCss)}>
+				<p mix={css(interactiveGuideMutedLeadCss)}>
 					Same implementation for “ask again” and the morning job. The job calls{' '}
 					<code>email_send</code> only when the list is not empty.
 				</p>
@@ -64,12 +36,14 @@ export function renderHowKodyWorksWalkthrough() {
 						[keyof typeof howKodyWorksPackageFiles, string]
 					>
 				).map(([path, code]) => (
-					<details key={path} mix={css(toolCss)}>
+					<details key={path} mix={css(interactiveGuideToolCss)}>
 						<summary>
-							<span mix={css(toolNameCss)}>{path}</span>
-							<span mix={css(toolSummaryCss)}>{packageFileSummary(path)}</span>
+							<span mix={css(interactiveGuideToolNameCss)}>{path}</span>
+							<span mix={css(interactiveGuideToolSummaryCss)}>
+								{packageFileSummary(path)}
+							</span>
 						</summary>
-						<div mix={css(toolBodyCss)}>
+						<div mix={css(interactiveGuideToolBodyCss)}>
 							<CopyCodeBlock
 								copy={false}
 								code={code}
@@ -85,8 +59,8 @@ export function renderHowKodyWorksWalkthrough() {
 					</details>
 				))}
 			</section>
-		</div>
-	)
+		),
+	})
 }
 
 function packageFileSummary(path: keyof typeof howKodyWorksPackageFiles) {
@@ -104,494 +78,4 @@ function packageFileSummary(path: keyof typeof howKodyWorksPackageFiles) {
 			return exhaustive
 		}
 	}
-}
-
-function renderLine(line: TranscriptLine) {
-	switch (line.role) {
-		case 'user':
-			return (
-				<figure mix={css(youCss)}>
-					<figcaption>
-						You
-						{renderUserIcon()}
-					</figcaption>
-					<blockquote>
-						<p>{line.text}</p>
-					</blockquote>
-				</figure>
-			)
-		case 'agent': {
-			const reasoning = line.tone === 'reasoning'
-			return (
-				<figure mix={css(reasoning ? agentReasoningCss : agentCss)}>
-					<figcaption>
-						{renderAgentIcon()}
-						{reasoning ? 'Reasoning' : 'Agent'}
-					</figcaption>
-					<blockquote>
-						<p>{line.text}</p>
-					</blockquote>
-				</figure>
-			)
-		}
-		case 'tools':
-			return (
-				<div mix={css(toolsCss)}>
-					{line.tools.map((tool) => renderToolCall(tool))}
-				</div>
-			)
-		case 'files':
-			return renderFiles(line)
-		default: {
-			const exhaustive: never = line
-			return exhaustive
-		}
-	}
-}
-
-const leadingInputNames = ['conversationId', 'memoryContext'] as const
-
-function sortToolInputs(inputs: Array<TranscriptInput>) {
-	return [...inputs].sort((left, right) => {
-		if (left.name === 'code' || right.name === 'code') {
-			if (left.name === 'code' && right.name !== 'code') return 1
-			if (right.name === 'code' && left.name !== 'code') return -1
-		}
-		const leftLead = leadingInputNames.indexOf(
-			left.name as (typeof leadingInputNames)[number],
-		)
-		const rightLead = leadingInputNames.indexOf(
-			right.name as (typeof leadingInputNames)[number],
-		)
-		const leftRank = leftLead === -1 ? leadingInputNames.length : leftLead
-		const rightRank = rightLead === -1 ? leadingInputNames.length : rightLead
-		return leftRank - rightRank
-	})
-}
-
-function renderFiles(line: Extract<TranscriptLine, { role: 'files' }>) {
-	return (
-		<div mix={css(toolsCss)}>
-			<details mix={css(toolCss)}>
-				<summary>
-					<span mix={css(toolNameCss)}>files</span>
-					<span mix={css(toolSummaryCss)}>{line.summary}</span>
-				</summary>
-				<div mix={css(toolBodyCss)}>
-					<aside mix={css(toolNoteCss)} role="note">
-						{renderInfoIcon()}
-						<p>{renderNotedText(line.note)}</p>
-					</aside>
-					{line.files.map((file) => renderCloneFile(file))}
-				</div>
-			</details>
-		</div>
-	)
-}
-
-function renderCloneFile(file: TranscriptFile) {
-	return (
-		<details key={file.path} mix={css(toolCss)}>
-			<summary>
-				<span mix={css(toolNameCss)}>{file.path}</span>
-				<span mix={css(toolSummaryCss)}>{file.summary}</span>
-			</summary>
-			<div mix={css(toolBodyCss)}>
-				<CopyCodeBlock
-					copy={false}
-					code={file.content}
-					lang={file.lang ?? fileLangFromPath(file.path)}
-				/>
-			</div>
-		</details>
-	)
-}
-
-function fileLangFromPath(path: string) {
-	if (path.endsWith('.ts')) return 'ts'
-	if (path.endsWith('.json')) return 'json'
-	if (path.endsWith('.md')) return 'md'
-	return 'txt'
-}
-
-function renderToolCall(tool: TranscriptTool) {
-	return (
-		<details key={`${tool.name}-${tool.summary}`} mix={css(toolCss)}>
-			<summary>
-				<span mix={css(toolNameCss)}>
-					{isKodyToolName(tool.name) ? renderKodyMark() : null}
-					{tool.name}
-				</span>
-				<span mix={css(toolSummaryCss)}>{tool.summary}</span>
-			</summary>
-			<div mix={css(toolBodyCss)}>
-				<aside mix={css(toolNoteCss)} role="note">
-					{renderInfoIcon()}
-					<p>{renderNotedText(tool.note)}</p>
-				</aside>
-				{sortToolInputs(tool.inputs).map((input) => renderInput(input))}
-				<hr mix={css(ioRuleCss)} />
-				<div mix={css(paneCss)}>
-					<span mix={css(paneLabelCss)}>Returns</span>
-					<CopyCodeBlock
-						copy={false}
-						code={tool.result}
-						lang={tool.resultLang ?? 'json'}
-					/>
-				</div>
-			</div>
-		</details>
-	)
-}
-
-function isKodyToolName(name: string) {
-	return name === 'search' || name === 'execute'
-}
-
-function renderUserIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<circle cx="12" cy="8" r="3.5" />
-			<path d="M5 19.5c.7-3.2 3.4-5 7-5s6.3 1.8 7 5" />
-		</svg>
-	)
-}
-
-function renderAgentIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<rect x="5" y="8" width="14" height="11" rx="2.5" />
-			<path d="M12 8V5" />
-			<circle cx="12" cy="4.5" r="1" fill="currentColor" />
-			<circle cx="9" cy="13.5" r="1" fill="currentColor" />
-			<circle cx="15" cy="13.5" r="1" fill="currentColor" />
-		</svg>
-	)
-}
-
-function renderNotedText(note: string) {
-	return note.split(/(`[^`]+`)/).map((part, index) => {
-		if (part.startsWith('`') && part.endsWith('`') && part.length > 2) {
-			return <code key={index}>{part.slice(1, -1)}</code>
-		}
-		return part
-	})
-}
-
-function renderInfoIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<circle cx="12" cy="12" r="9" />
-			<path d="M12 11v5" />
-			<circle cx="12" cy="8" r="0.75" fill="currentColor" />
-		</svg>
-	)
-}
-
-function renderKodyMark() {
-	return (
-		<img
-			src="/images/kody-mark.png"
-			alt=""
-			width={12}
-			height={12}
-			mix={css(inlineMarkCss)}
-		/>
-	)
-}
-
-function renderInput(input: TranscriptInput) {
-	return (
-		<div mix={css(paneCss)} data-kind={input.kind}>
-			<span mix={css(paneLabelCss)}>{input.name}</span>
-			<CopyCodeBlock
-				copy={false}
-				code={input.value}
-				lang={input.lang ?? 'json'}
-			/>
-		</div>
-	)
-}
-
-const walkthroughCss = {
-	marginTop: 'clamp(1.8rem, 4vw, 2.5rem)',
-	minWidth: 0,
-	maxWidth: '100%',
-}
-
-const leadCss = {
-	margin: '0 0 clamp(2rem, 5vw, 2.8rem)',
-	color: colors.textMuted,
-	fontSize: '1.05rem',
-	textWrap: 'pretty' as const,
-}
-
-const actCss = {
-	...getArticleBreakoutCss(),
-	marginTop: 'clamp(2.4rem, 6vw, 3.4rem)',
-	minWidth: 0,
-	'& h2': {
-		margin: '0.2rem 0 0',
-		fontSize: '1.55rem',
-		fontWeight: 720,
-		letterSpacing: '-0.02em',
-	},
-}
-
-const kickerCss = {
-	margin: 0,
-	fontSize: '0.78rem',
-	fontWeight: 600,
-	letterSpacing: '0.12em',
-	textTransform: 'uppercase' as const,
-	color: colors.primaryText,
-}
-
-const exampleKickerCss = {
-	margin: 0,
-	fontSize: '0.95rem',
-	fontWeight: 600,
-	color: colors.primaryText,
-	textWrap: 'pretty' as const,
-}
-
-const threadCss = {
-	listStyle: 'none',
-	margin: '1.25rem 0 0',
-	padding: 0,
-	display: 'grid',
-	gap: '0.9rem',
-	minWidth: 0,
-	'& > *': { minWidth: 0 },
-}
-
-const captionIconGap = '0.35em'
-
-const bubbleCss = {
-	margin: 0,
-	'& figcaption': {
-		display: 'flex',
-		alignItems: 'center',
-		gap: captionIconGap,
-		margin: 0,
-		fontSize: '0.75rem',
-		fontWeight: 650,
-		letterSpacing: '0.06em',
-		textTransform: 'uppercase' as const,
-		color: colors.textMuted,
-	},
-	'& blockquote': {
-		margin: '0.35rem 0 0',
-		padding: `${spacing.sm} ${spacing.md}`,
-		borderRadius: radius.lg,
-		border: `1px solid ${colors.border}`,
-	},
-	'& p': {
-		margin: 0,
-		textWrap: 'pretty' as const,
-	},
-}
-
-const youCss = {
-	...bubbleCss,
-	'& figcaption': {
-		...bubbleCss['& figcaption'],
-		justifyContent: 'flex-end',
-		textAlign: 'right' as const,
-	},
-	'& blockquote': {
-		...bubbleCss['& blockquote'],
-		marginInlineStart: 'auto',
-		maxWidth: 'min(36rem, 100%)',
-		backgroundColor: colors.primarySoftest,
-		borderColor: colors.primarySoft,
-	},
-}
-
-const agentCss = {
-	...bubbleCss,
-	'& blockquote': {
-		...bubbleCss['& blockquote'],
-		backgroundColor: colors.surface,
-	},
-}
-
-const agentReasoningCss = {
-	...bubbleCss,
-	'& blockquote': {
-		margin: '0.25rem 0 0',
-		padding: 0,
-		border: 'none',
-		backgroundColor: 'transparent',
-	},
-	'& p': {
-		margin: 0,
-		fontSize: '0.92rem',
-		fontStyle: 'italic' as const,
-		color: colors.textMuted,
-		textWrap: 'pretty' as const,
-	},
-}
-
-const toolsCss = {
-	display: 'grid',
-	gap: '0.55rem',
-	minWidth: 0,
-}
-
-const toolCss = {
-	minWidth: 0,
-	border: `1px solid ${colors.border}`,
-	borderRadius: radius.lg,
-	backgroundColor: colors.surface,
-	'& summary': {
-		display: 'grid',
-		gridTemplateColumns: 'auto auto 1fr',
-		columnGap: spacing.sm,
-		rowGap: '0.15rem',
-		alignItems: 'center',
-		padding: `${spacing.sm} ${spacing.md}`,
-		cursor: 'pointer',
-		listStyle: 'none',
-		'&::-webkit-details-marker': { display: 'none' },
-		'&::before': {
-			content: '""',
-			width: '0.38em',
-			height: '0.38em',
-			marginInlineEnd: `calc(${spacing.sm} * 0.5)`,
-			borderRight: `2px solid ${colors.textMuted}`,
-			borderBottom: `2px solid ${colors.textMuted}`,
-			transform: 'rotate(-45deg)',
-			transition: 'transform 140ms ease',
-		},
-	},
-	'&[open] summary': {
-		borderBottom: `1px solid ${colors.border}`,
-		'&::before': {
-			transform: 'rotate(45deg)',
-		},
-	},
-}
-
-const toolNameCss = {
-	display: 'inline-flex',
-	alignItems: 'center',
-	gap: captionIconGap,
-	fontFamily: typography.fontFamily,
-	fontSize: '0.82rem',
-	fontWeight: 700,
-	color: colors.primaryText,
-}
-
-const inlineMarkCss = {
-	width: '1em',
-	height: '1em',
-	display: 'block',
-}
-
-const toolSummaryCss = {
-	fontSize: '0.92rem',
-	color: colors.textMuted,
-}
-
-const toolNoteCss = {
-	...getAccentCalloutCss(),
-	gridTemplateColumns: 'auto 1fr',
-	alignItems: 'start',
-	columnGap: '0.65rem',
-	padding: `${spacing.sm} ${spacing.md}`,
-	color: colors.text,
-	'& svg': {
-		width: '1.15em',
-		height: '1.15em',
-		marginTop: '0.15em',
-		color: colors.primaryText,
-	},
-	'& p': {
-		margin: 0,
-		fontSize: '0.95rem',
-		textWrap: 'pretty' as const,
-	},
-	'& code': {
-		font: '500 0.9em/1.2 ui-monospace, "SF Mono", Menlo, monospace',
-		backgroundColor: colors.primarySoftest,
-		border: `1px solid ${colors.primarySoft}`,
-		borderRadius: '5px',
-		padding: '0.1em 0.35em',
-	},
-}
-
-const toolBodyCss = {
-	padding: spacing.md,
-	display: 'grid',
-	gap: spacing.sm,
-	minWidth: 0,
-	'& > *': { minWidth: 0 },
-}
-
-const ioRuleCss = {
-	margin: `${spacing.xs} 0`,
-	border: 'none',
-	borderTop: `1px solid ${colors.border}`,
-}
-
-const paneCss = {
-	display: 'grid',
-	gap: spacing.xs,
-	minWidth: 0,
-	'&[data-kind="memory"] > span': {
-		backgroundColor: colors.primarySoft,
-		color: colors.primaryText,
-	},
-}
-
-const paneLabelCss = {
-	padding: '0.1rem 0.45rem',
-	justifySelf: 'start' as const,
-	borderRadius: radius.full,
-	backgroundColor: colors.primarySoftest,
-	color: colors.textMuted,
-	fontSize: '0.72rem',
-	fontWeight: 700,
-	letterSpacing: '0.04em',
-	textTransform: 'uppercase' as const,
-}
-
-const packageLeadCss = {
-	margin: '0.7rem 0 1rem',
-	color: colors.textMuted,
-	textWrap: 'pretty' as const,
-	'& code': {
-		fontSize: '0.9em',
-	},
 }

--- a/packages/worker/client/routes/how-kody-works-walkthrough.tsx
+++ b/packages/worker/client/routes/how-kody-works-walkthrough.tsx
@@ -24,7 +24,10 @@ export function renderHowKodyWorksWalkthrough() {
 		lead: 'A question you would ask again becomes an export you can invoke from any agent, then a daily email that stays quiet until something actually shipped.',
 		acts: howKodyWorksTranscriptActs,
 		afterActs: (
-			<section mix={css(interactiveGuideActCss)} aria-labelledby="package-files-title">
+			<section
+				mix={css(interactiveGuideActCss)}
+				aria-labelledby="package-files-title"
+			>
 				<p mix={css(interactiveGuideKickerCss)}>The package</p>
 				<h2 id="package-files-title">What the agent wrote</h2>
 				<p mix={css(interactiveGuideMutedLeadCss)}>

--- a/packages/worker/client/routes/interactive-guide-transcript.ts
+++ b/packages/worker/client/routes/interactive-guide-transcript.ts
@@ -1,0 +1,110 @@
+export type TranscriptInput = {
+	name: string
+	kind: 'query' | 'code' | 'memory'
+	lang?: string
+	value: string
+}
+
+export type TranscriptTool = {
+	name: string
+	summary: string
+	note: string
+	inputs: Array<TranscriptInput>
+	resultLang?: string
+	result: string
+}
+
+export type TranscriptFile = {
+	path: string
+	summary: string
+	lang?: string
+	content: string
+}
+
+export type TranscriptLine =
+	| { role: 'user'; text: string }
+	| { role: 'agent'; text: string; tone?: 'reasoning' }
+	| { role: 'tools'; tools: Array<TranscriptTool> }
+	| {
+			role: 'files'
+			summary: string
+			note: string
+			files: Array<TranscriptFile>
+	  }
+
+export type TranscriptAct = {
+	id: string
+	kicker: string
+	title: string
+	lines: Array<TranscriptLine>
+}
+
+export function jsonInput(value: unknown) {
+	return JSON.stringify(value, null, 2)
+}
+
+export function memoryContextInput(context: {
+	task: string
+	entities: Array<string>
+}) {
+	return {
+		name: 'memoryContext',
+		kind: 'memory' as const,
+		lang: 'json',
+		value: jsonInput(context),
+	}
+}
+
+export function conversationIdInput(conversationId: string) {
+	return {
+		name: 'conversationId',
+		kind: 'query' as const,
+		lang: 'json',
+		value: jsonInput(conversationId),
+	}
+}
+
+const conversationIdReturnNote =
+	'Tool conversation id; pass it back on subsequent search/execute calls.'
+
+export function conversationIdReturn(conversationId: string) {
+	return `conversationId: ${conversationId}\n${conversationIdReturnNote}`
+}
+
+function relevantMemoriesMarkdown(
+	memories: Array<{ subject: string; summary: string }>,
+) {
+	return [
+		'## Relevant memories',
+		'',
+		...memories.map((memory) => `- **${memory.subject}** — ${memory.summary}`),
+	].join('\n')
+}
+
+export function searchTextReturn(input: {
+	conversationId: string
+	body: string
+	memories?: Array<{ subject: string; summary: string }>
+}) {
+	const parts = [conversationIdReturn(input.conversationId), '', input.body]
+	if (input.memories && input.memories.length > 0) {
+		parts.push('', relevantMemoriesMarkdown(input.memories))
+	}
+	return parts.join('\n')
+}
+
+export function executeTextReturn(input: {
+	conversationId: string
+	value: unknown
+	memories?: Array<{ subject: string; summary: string }>
+}) {
+	const parts = [
+		conversationIdReturn(input.conversationId),
+		'',
+		jsonInput(input.value),
+	]
+	if (input.memories && input.memories.length > 0) {
+		parts.push('', relevantMemoriesMarkdown(input.memories))
+	}
+	return parts.join('\n')
+}

--- a/packages/worker/client/routes/interactive-guide-walkthrough.tsx
+++ b/packages/worker/client/routes/interactive-guide-walkthrough.tsx
@@ -39,7 +39,11 @@ export function renderInteractiveGuideWalkthrough(input: {
 					mix={css(actCss)}
 					aria-labelledby={`${act.id}-title`}
 				>
-					<p mix={css(act.id === input.acts[0]?.id ? exampleKickerCss : kickerCss)}>
+					<p
+						mix={css(
+							act.id === input.acts[0]?.id ? exampleKickerCss : kickerCss,
+						)}
+					>
 						{act.kicker}
 					</p>
 					<h2 id={`${act.id}-title`}>{act.title}</h2>

--- a/packages/worker/client/routes/interactive-guide-walkthrough.tsx
+++ b/packages/worker/client/routes/interactive-guide-walkthrough.tsx
@@ -1,0 +1,559 @@
+import { type RemixNode, css } from 'remix/ui'
+import { CopyCodeBlock } from '#client/copy-code-block.tsx'
+import {
+	type TranscriptAct,
+	type TranscriptFile,
+	type TranscriptInput,
+	type TranscriptLine,
+	type TranscriptTool,
+} from './interactive-guide-transcript.ts'
+import {
+	getAccentCalloutCss,
+	getArticleBreakoutCss,
+} from '#universal/styles/style-primitives.ts'
+import {
+	colors,
+	radius,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+
+/**
+ * Shared interactive-guide transcript renderer (How Kody works, Google OAuth,
+ * and later siblings). Tool calls are native <details> so they work without
+ * JavaScript. This is a render helper, not a Remix component — only
+ * CopyCodeBlock needs a handle.
+ */
+export function renderInteractiveGuideWalkthrough(input: {
+	lead: string
+	acts: Array<TranscriptAct>
+	afterActs?: RemixNode
+}) {
+	return (
+		<div mix={css(walkthroughCss)}>
+			<p mix={css(leadCss)}>{input.lead}</p>
+
+			{input.acts.map((act) => (
+				<section
+					key={act.id}
+					mix={css(actCss)}
+					aria-labelledby={`${act.id}-title`}
+				>
+					<p mix={css(act.id === input.acts[0]?.id ? exampleKickerCss : kickerCss)}>
+						{act.kicker}
+					</p>
+					<h2 id={`${act.id}-title`}>{act.title}</h2>
+					<ol mix={css(threadCss)}>
+						{act.lines.map((line, index) => (
+							<li key={`${act.id}-${index}`}>{renderLine(line)}</li>
+						))}
+					</ol>
+				</section>
+			))}
+
+			{input.afterActs}
+		</div>
+	)
+}
+
+function renderLine(line: TranscriptLine) {
+	switch (line.role) {
+		case 'user':
+			return (
+				<figure mix={css(youCss)}>
+					<figcaption>
+						You
+						{renderUserIcon()}
+					</figcaption>
+					<blockquote>
+						<p>{line.text}</p>
+					</blockquote>
+				</figure>
+			)
+		case 'agent': {
+			const reasoning = line.tone === 'reasoning'
+			return (
+				<figure mix={css(reasoning ? agentReasoningCss : agentCss)}>
+					<figcaption>
+						{renderAgentIcon()}
+						{reasoning ? 'Reasoning' : 'Agent'}
+					</figcaption>
+					<blockquote>
+						<p>{line.text}</p>
+					</blockquote>
+				</figure>
+			)
+		}
+		case 'tools':
+			return (
+				<div mix={css(toolsCss)}>
+					{line.tools.map((tool) => renderToolCall(tool))}
+				</div>
+			)
+		case 'files':
+			return renderFiles(line)
+		default: {
+			const exhaustive: never = line
+			return exhaustive
+		}
+	}
+}
+
+const leadingInputNames = ['conversationId', 'memoryContext'] as const
+
+function sortToolInputs(inputs: Array<TranscriptInput>) {
+	return [...inputs].sort((left, right) => {
+		if (left.name === 'code' || right.name === 'code') {
+			if (left.name === 'code' && right.name !== 'code') return 1
+			if (right.name === 'code' && left.name !== 'code') return -1
+		}
+		const leftLead = leadingInputNames.indexOf(
+			left.name as (typeof leadingInputNames)[number],
+		)
+		const rightLead = leadingInputNames.indexOf(
+			right.name as (typeof leadingInputNames)[number],
+		)
+		const leftRank = leftLead === -1 ? leadingInputNames.length : leftLead
+		const rightRank = rightLead === -1 ? leadingInputNames.length : rightLead
+		return leftRank - rightRank
+	})
+}
+
+function renderFiles(line: Extract<TranscriptLine, { role: 'files' }>) {
+	return (
+		<div mix={css(toolsCss)}>
+			<details mix={css(toolCss)}>
+				<summary>
+					<span mix={css(toolNameCss)}>files</span>
+					<span mix={css(toolSummaryCss)}>{line.summary}</span>
+				</summary>
+				<div mix={css(toolBodyCss)}>
+					<aside mix={css(toolNoteCss)} role="note">
+						{renderInfoIcon()}
+						<p>{renderNotedText(line.note)}</p>
+					</aside>
+					{line.files.map((file) => renderCloneFile(file))}
+				</div>
+			</details>
+		</div>
+	)
+}
+
+function renderCloneFile(file: TranscriptFile) {
+	return (
+		<details key={file.path} mix={css(toolCss)}>
+			<summary>
+				<span mix={css(toolNameCss)}>{file.path}</span>
+				<span mix={css(toolSummaryCss)}>{file.summary}</span>
+			</summary>
+			<div mix={css(toolBodyCss)}>
+				<CopyCodeBlock
+					copy={false}
+					code={file.content}
+					lang={file.lang ?? fileLangFromPath(file.path)}
+				/>
+			</div>
+		</details>
+	)
+}
+
+function fileLangFromPath(path: string) {
+	if (path.endsWith('.ts')) return 'ts'
+	if (path.endsWith('.json')) return 'json'
+	if (path.endsWith('.md')) return 'md'
+	return 'txt'
+}
+
+function renderToolCall(tool: TranscriptTool) {
+	return (
+		<details key={`${tool.name}-${tool.summary}`} mix={css(toolCss)}>
+			<summary>
+				<span mix={css(toolNameCss)}>
+					{isKodyToolName(tool.name) ? renderKodyMark() : null}
+					{tool.name}
+				</span>
+				<span mix={css(toolSummaryCss)}>{tool.summary}</span>
+			</summary>
+			<div mix={css(toolBodyCss)}>
+				<aside mix={css(toolNoteCss)} role="note">
+					{renderInfoIcon()}
+					<p>{renderNotedText(tool.note)}</p>
+				</aside>
+				{sortToolInputs(tool.inputs).map((input) => renderInput(input))}
+				<hr mix={css(ioRuleCss)} />
+				<div mix={css(paneCss)}>
+					<span mix={css(paneLabelCss)}>Returns</span>
+					<CopyCodeBlock
+						copy={false}
+						code={tool.result}
+						lang={tool.resultLang ?? 'json'}
+					/>
+				</div>
+			</div>
+		</details>
+	)
+}
+
+function isKodyToolName(name: string) {
+	return name === 'search' || name === 'execute'
+}
+
+function renderUserIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<circle cx="12" cy="8" r="3.5" />
+			<path d="M5 19.5c.7-3.2 3.4-5 7-5s6.3 1.8 7 5" />
+		</svg>
+	)
+}
+
+function renderAgentIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<rect x="5" y="8" width="14" height="11" rx="2.5" />
+			<path d="M12 8V5" />
+			<circle cx="12" cy="4.5" r="1" fill="currentColor" />
+			<circle cx="9" cy="13.5" r="1" fill="currentColor" />
+			<circle cx="15" cy="13.5" r="1" fill="currentColor" />
+		</svg>
+	)
+}
+
+function renderNotedText(note: string) {
+	return note.split(/(`[^`]+`)/).map((part, index) => {
+		if (part.startsWith('`') && part.endsWith('`') && part.length > 2) {
+			return <code key={index}>{part.slice(1, -1)}</code>
+		}
+		return part
+	})
+}
+
+function renderInfoIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="1em"
+			height="1em"
+			aria-hidden="true"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<circle cx="12" cy="12" r="9" />
+			<path d="M12 11v5" />
+			<circle cx="12" cy="8" r="0.75" fill="currentColor" />
+		</svg>
+	)
+}
+
+function renderKodyMark() {
+	return (
+		<img
+			src="/images/kody-mark.png"
+			alt=""
+			width={12}
+			height={12}
+			mix={css(inlineMarkCss)}
+		/>
+	)
+}
+
+function renderInput(input: TranscriptInput) {
+	return (
+		<div mix={css(paneCss)} data-kind={input.kind}>
+			<span mix={css(paneLabelCss)}>{input.name}</span>
+			<CopyCodeBlock
+				copy={false}
+				code={input.value}
+				lang={input.lang ?? 'json'}
+			/>
+		</div>
+	)
+}
+
+const walkthroughCss = {
+	marginTop: 'clamp(1.8rem, 4vw, 2.5rem)',
+	minWidth: 0,
+	maxWidth: '100%',
+}
+
+const leadCss = {
+	margin: '0 0 clamp(2rem, 5vw, 2.8rem)',
+	color: colors.textMuted,
+	fontSize: '1.05rem',
+	textWrap: 'pretty' as const,
+}
+
+export const interactiveGuideActCss = {
+	...getArticleBreakoutCss(),
+	marginTop: 'clamp(2.4rem, 6vw, 3.4rem)',
+	minWidth: 0,
+	'& h2': {
+		margin: '0.2rem 0 0',
+		fontSize: '1.55rem',
+		fontWeight: 720,
+		letterSpacing: '-0.02em',
+	},
+}
+
+const actCss = interactiveGuideActCss
+
+export const interactiveGuideKickerCss = {
+	margin: 0,
+	fontSize: '0.78rem',
+	fontWeight: 600,
+	letterSpacing: '0.12em',
+	textTransform: 'uppercase' as const,
+	color: colors.primaryText,
+}
+
+const kickerCss = interactiveGuideKickerCss
+
+const exampleKickerCss = {
+	margin: 0,
+	fontSize: '0.95rem',
+	fontWeight: 600,
+	color: colors.primaryText,
+	textWrap: 'pretty' as const,
+}
+
+const threadCss = {
+	listStyle: 'none',
+	margin: '1.25rem 0 0',
+	padding: 0,
+	display: 'grid',
+	gap: '0.9rem',
+	minWidth: 0,
+	'& > *': { minWidth: 0 },
+}
+
+const captionIconGap = '0.35em'
+
+const bubbleCss = {
+	margin: 0,
+	'& figcaption': {
+		display: 'flex',
+		alignItems: 'center',
+		gap: captionIconGap,
+		margin: 0,
+		fontSize: '0.75rem',
+		fontWeight: 650,
+		letterSpacing: '0.06em',
+		textTransform: 'uppercase' as const,
+		color: colors.textMuted,
+	},
+	'& blockquote': {
+		margin: '0.35rem 0 0',
+		padding: `${spacing.sm} ${spacing.md}`,
+		borderRadius: radius.lg,
+		border: `1px solid ${colors.border}`,
+	},
+	'& p': {
+		margin: 0,
+		textWrap: 'pretty' as const,
+	},
+}
+
+const youCss = {
+	...bubbleCss,
+	'& figcaption': {
+		...bubbleCss['& figcaption'],
+		justifyContent: 'flex-end',
+		textAlign: 'right' as const,
+	},
+	'& blockquote': {
+		...bubbleCss['& blockquote'],
+		marginInlineStart: 'auto',
+		maxWidth: 'min(36rem, 100%)',
+		backgroundColor: colors.primarySoftest,
+		borderColor: colors.primarySoft,
+	},
+}
+
+const agentCss = {
+	...bubbleCss,
+	'& blockquote': {
+		...bubbleCss['& blockquote'],
+		backgroundColor: colors.surface,
+	},
+}
+
+const agentReasoningCss = {
+	...bubbleCss,
+	'& blockquote': {
+		margin: '0.25rem 0 0',
+		padding: 0,
+		border: 'none',
+		backgroundColor: 'transparent',
+	},
+	'& p': {
+		margin: 0,
+		fontSize: '0.92rem',
+		fontStyle: 'italic' as const,
+		color: colors.textMuted,
+		textWrap: 'pretty' as const,
+	},
+}
+
+const toolsCss = {
+	display: 'grid',
+	gap: '0.55rem',
+	minWidth: 0,
+}
+
+export const interactiveGuideToolCss = {
+	minWidth: 0,
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.lg,
+	backgroundColor: colors.surface,
+	'& summary': {
+		display: 'grid',
+		gridTemplateColumns: 'auto auto 1fr',
+		columnGap: spacing.sm,
+		rowGap: '0.15rem',
+		alignItems: 'center',
+		padding: `${spacing.sm} ${spacing.md}`,
+		cursor: 'pointer',
+		listStyle: 'none',
+		'&::-webkit-details-marker': { display: 'none' },
+		'&::before': {
+			content: '""',
+			width: '0.38em',
+			height: '0.38em',
+			marginInlineEnd: `calc(${spacing.sm} * 0.5)`,
+			borderRight: `2px solid ${colors.textMuted}`,
+			borderBottom: `2px solid ${colors.textMuted}`,
+			transform: 'rotate(-45deg)',
+			transition: 'transform 140ms ease',
+		},
+	},
+	'&[open] summary': {
+		borderBottom: `1px solid ${colors.border}`,
+		'&::before': {
+			transform: 'rotate(45deg)',
+		},
+	},
+}
+
+const toolCss = interactiveGuideToolCss
+
+export const interactiveGuideToolNameCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: captionIconGap,
+	fontFamily: typography.fontFamily,
+	fontSize: '0.82rem',
+	fontWeight: 700,
+	color: colors.primaryText,
+}
+
+const toolNameCss = interactiveGuideToolNameCss
+
+const inlineMarkCss = {
+	width: '1em',
+	height: '1em',
+	display: 'block',
+}
+
+export const interactiveGuideToolSummaryCss = {
+	fontSize: '0.92rem',
+	color: colors.textMuted,
+}
+
+const toolSummaryCss = interactiveGuideToolSummaryCss
+
+const toolNoteCss = {
+	...getAccentCalloutCss(),
+	gridTemplateColumns: 'auto 1fr',
+	alignItems: 'start',
+	columnGap: '0.65rem',
+	padding: `${spacing.sm} ${spacing.md}`,
+	color: colors.text,
+	'& svg': {
+		width: '1.15em',
+		height: '1.15em',
+		marginTop: '0.15em',
+		color: colors.primaryText,
+	},
+	'& p': {
+		margin: 0,
+		fontSize: '0.95rem',
+		textWrap: 'pretty' as const,
+	},
+	'& code': {
+		font: '500 0.9em/1.2 ui-monospace, "SF Mono", Menlo, monospace',
+		backgroundColor: colors.primarySoftest,
+		border: `1px solid ${colors.primarySoft}`,
+		borderRadius: '5px',
+		padding: '0.1em 0.35em',
+	},
+}
+
+export const interactiveGuideToolBodyCss = {
+	padding: spacing.md,
+	display: 'grid',
+	gap: spacing.sm,
+	minWidth: 0,
+	'& > *': { minWidth: 0 },
+}
+
+const toolBodyCss = interactiveGuideToolBodyCss
+
+const ioRuleCss = {
+	margin: `${spacing.xs} 0`,
+	border: 'none',
+	borderTop: `1px solid ${colors.border}`,
+}
+
+const paneCss = {
+	display: 'grid',
+	gap: spacing.xs,
+	minWidth: 0,
+	'&[data-kind="memory"] > span': {
+		backgroundColor: colors.primarySoft,
+		color: colors.primaryText,
+	},
+}
+
+const paneLabelCss = {
+	padding: '0.1rem 0.45rem',
+	justifySelf: 'start' as const,
+	borderRadius: radius.full,
+	backgroundColor: colors.primarySoftest,
+	color: colors.textMuted,
+	fontSize: '0.72rem',
+	fontWeight: 700,
+	letterSpacing: '0.04em',
+	textTransform: 'uppercase' as const,
+}
+
+export const interactiveGuideMutedLeadCss = {
+	margin: '0.7rem 0 1rem',
+	color: colors.textMuted,
+	textWrap: 'pretty' as const,
+	'& code': {
+		fontSize: '0.9em',
+	},
+}

--- a/packages/worker/src/app/handlers/guides.node.test.ts
+++ b/packages/worker/src/app/handlers/guides.node.test.ts
@@ -66,6 +66,38 @@ test('guides API, markdown index, and markdown detail serve the bundled catalog'
 	expect(detailBody.startsWith('#')).toBe(true)
 	expect(detailBody).not.toContain('\nid: oauth\n')
 
+	const googleOauthMd = await callHandler(
+		createGuideDetailMarkdownHandler(env) as never,
+		{
+			request: new Request('https://kody.example/guides/google-oauth.md'),
+			params: { slug: 'google-oauth' },
+		},
+	)
+	expect(googleOauthMd.status).toBe(200)
+	const googleOauthBody = await googleOauthMd.text()
+	expect(googleOauthBody).toContain('# Google OAuth interactive guide')
+	expect(googleOauthBody).toContain('gmail.readonly')
+
+	const googleOauthApi = await callHandler(
+		createGuideDetailApiHandler(env) as never,
+		{
+			request: new Request('https://kody.example/guides/google-oauth.json'),
+			params: { slug: 'google-oauth' },
+		},
+	)
+	expect(googleOauthApi.status).toBe(200)
+	const googleOauthPayload = (await googleOauthApi.json()) as {
+		ok: boolean
+		slug: string
+		id: string
+		title: string
+	}
+	expect(googleOauthPayload).toMatchObject({
+		ok: true,
+		slug: 'google-oauth',
+		id: 'google_oauth',
+	})
+
 	const missing = await callHandler(
 		createGuideDetailMarkdownHandler(env) as never,
 		{

--- a/packages/worker/src/guides/catalog.node.test.ts
+++ b/packages/worker/src/guides/catalog.node.test.ts
@@ -29,6 +29,8 @@ test('guide catalog parses every guide with unique ids and slugs', () => {
 	expect(getGuideById('connect_secret')?.slug).toBe('account-secret-setup')
 	expect(getGuideBySlug('how-kody-works')?.id).toBe('how_kody_works')
 	expect(getGuideById('how_kody_works')?.slug).toBe('how-kody-works')
+	expect(getGuideBySlug('google-oauth')?.id).toBe('google_oauth')
+	expect(getGuideById('google_oauth')?.slug).toBe('google-oauth')
 
 	// Web ordering: platform guides first, then provider guides sorted by
 	// provider name.

--- a/packages/worker/src/guides/catalog.ts
+++ b/packages/worker/src/guides/catalog.ts
@@ -7,6 +7,7 @@ import accountPackageInvocationTokenSetup from '../../../../docs/guides/account-
 import accountSecretSetup from '../../../../docs/guides/account-secret-setup.md'
 import firstWin from '../../../../docs/guides/first-win.md'
 import howKodyWorks from '../../../../docs/guides/how-kody-works.md'
+import googleOauth from '../../../../docs/guides/google-oauth.md'
 import quickExample from '../../../../docs/guides/quick-example.md'
 import integrationBackedAppHappyPath from '../../../../docs/guides/integration-backed-app-happy-path.md'
 import integrationBootstrap from '../../../../docs/guides/integration-bootstrap.md'
@@ -37,6 +38,7 @@ import whatIsKody from '../../../../docs/guides/what-is-kody.md'
 const guideSources: Array<{ slug: string; raw: string }> = [
 	{ slug: 'what-is-kody', raw: whatIsKody },
 	{ slug: 'how-kody-works', raw: howKodyWorks },
+	{ slug: 'google-oauth', raw: googleOauth },
 	{ slug: 'quick-example', raw: quickExample },
 	{ slug: 'first-win', raw: firstWin },
 	{ slug: 'package-authoring', raw: packageAuthoring },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give coding agents and humans a How-Kody-works-style interactive transcript for connecting Google when inbox reading requires bring-your-own OAuth (Lane B), without inventing console steps.

## Summary

- New official guide `google_oauth` / `/guides/google-oauth`: agent looks up guides, walks a naive user through Google Auth Platform one step at a time, refuses secrets in chat, sends a prefilled `/connect/oauth` URL, smoke-tests Gmail profile.
- Extracted shared transcript types + walkthrough renderer from How Kody works so both interactive guides share one UI language.
- Wired interactive slug map in `guide-detail.tsx`, catalog registration, README + pointers from `oauth` and `providers/google`.
- Focused transcript + catalog + guides-handler tests for tool constraints, Lane B / 7-day trap / connect URL / smoke test / user “done” beats, and markdown/API twin serving.

## Testing

- Focused vitest: `google-oauth-transcript.node.test.ts`, `how-kody-works-transcript.node.test.ts`, `catalog.node.test.ts`, `guides.node.test.ts` (google-oauth.md + .json), `kody-official-guide.node.test.ts` (covers `coding_guide_get` for every catalog id including `google_oauth`) — pass
- `npm run typecheck` — pass
- `npm run format:check` on touched files — pass
- Full local `npm run validate` hit unrelated cloud-VM timeouts (mcp-e2e / Playwright webServer / cloudflare mock) after typecheck/lint/docs/primitives passed; local `npm run dev` entered a wrangler reload loop so browser walkthrough was not captured here — rely on CI + focused suite

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `817ddaec` · **Head:** `77361c94`

**Classification:** composes — no primitives added or changed; this PR wires a new interactive guide through the existing guide catalog and shared transcript UI.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — shared interactive-guide renderer; `/guides/google-oauth` transcript; multi-slug swap in `guide-detail` |

Unmatched paths (docs + `guides/catalog.ts`) register the markdown twin for `coding_guide_get` / `/guides` without changing the capability contract.

### System map

Guide detail swaps interactive slugs for the shared transcript renderer; the catalog bundles the new markdown twin for MCP and raw `.md` serving.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::touched
	guideCatalog["guides catalog<br/>bundled markdown"]:::untouched
	codingGuides["capability-registry<br/>Capability registry"]:::untouched
	appUi -->|"interactive slug → shared walkthrough"| guideCatalog
	guideCatalog -->|"google_oauth entry"| codingGuides
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant GuideDetail as guide-detail
	participant Walkthrough as interactive walkthrough
	participant Catalog as guides catalog
	User->>GuideDetail: GET /guides/google-oauth
	GuideDetail->>Catalog: load slug google-oauth
	GuideDetail->>Walkthrough: renderGoogleOauthWalkthrough()
	Walkthrough-->>User: transcript search/execute beats
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfddf267-be6d-4e6a-b434-a982cb29a779?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfddf267-be6d-4e6a-b434-a982cb29a779&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive Google OAuth walkthrough for connecting Gmail and verifying inbox access.
  - Added guidance for Google Cloud setup, required permissions, redirect configuration, credential security, and post-authorization testing.
  - Added Google OAuth to the platform guide catalog with links from related OAuth and provider documentation.
  - Improved interactive guide presentation with shared transcript rendering, tool details, file previews, responsive styling, and copyable code blocks.

- **Tests**
  - Added coverage validating the walkthrough flow, guide availability, catalog mapping, and expected authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->