### PR TITLE
fix(client): stop route-load handle.update() infinite loops (KODY-CLOUDFLARE-4V)

### DIFF
--- a/packages/worker/client/route-load-latch.node.test.ts
+++ b/packages/worker/client/route-load-latch.node.test.ts
@@ -15,6 +15,28 @@ test('loads once and stays idle for the same href after success', () => {
 	expect(latch.isLoadedFor('/a')).toBe(true)
 })
 
+test('a pending load does not re-queue on later renders for the same href', () => {
+	const latch = createRouteLoadLatch()
+	// First decision latches pending so a queueTask that aborts itself via
+	// handle.update() cannot cascade into the Remix infinite-loop guard.
+	expect(
+		latch.needsLoad({ ...baseInput, currentHref: '/a', isLoading: true }),
+	).toBe(true)
+	expect(
+		latch.needsLoad({ ...baseInput, currentHref: '/a', isLoading: true }),
+	).toBe(false)
+	latch.markLoaded('/a')
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(false)
+})
+
+test('isLoading alone does not force a load when the href is already loaded', () => {
+	const latch = createRouteLoadLatch()
+	latch.markLoaded('/a')
+	expect(
+		latch.needsLoad({ ...baseInput, currentHref: '/a', isLoading: true }),
+	).toBe(false)
+})
+
 test('a failed load does not re-queue in a loop but retries after navigation', () => {
 	const latch = createRouteLoadLatch()
 	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(true)
@@ -46,6 +68,19 @@ test('a stale refresh overrides a prior failure for the same href', () => {
 	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(false)
 	// A same-path reload whose loader failed signals staleness once; that
 	// user-driven refresh must not be blocked by the failure latch.
+	expect(
+		latch.needsLoad({
+			...baseInput,
+			currentHref: '/a',
+			needsStaleRefresh: true,
+		}),
+	).toBe(true)
+})
+
+test('a stale refresh clears an abandoned pending latch for the same href', () => {
+	const latch = createRouteLoadLatch()
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(true)
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(false)
 	expect(
 		latch.needsLoad({
 			...baseInput,

--- a/packages/worker/client/route-load-latch.node.test.ts
+++ b/packages/worker/client/route-load-latch.node.test.ts
@@ -37,6 +37,19 @@ test('isLoading alone does not force a load when the href is already loaded', ()
 	).toBe(false)
 })
 
+test('a stale completion for a previous href does not clear the active pending latch', () => {
+	const latch = createRouteLoadLatch()
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(true)
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/b' })).toBe(true)
+	// Late success for /a must not clear /b's pending or steal lastLoaded.
+	latch.markLoaded('/a')
+	expect(latch.isLoadedFor('/a')).toBe(false)
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/b' })).toBe(false)
+	latch.markLoaded('/b')
+	expect(latch.isLoadedFor('/b')).toBe(true)
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/b' })).toBe(false)
+})
+
 test('a failed load does not re-queue in a loop but retries after navigation', () => {
 	const latch = createRouteLoadLatch()
 	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(true)

--- a/packages/worker/client/route-load-latch.ts
+++ b/packages/worker/client/route-load-latch.ts
@@ -33,15 +33,24 @@ export function createRouteLoadLatch() {
 	return {
 		/** Record a successful load (or applied preloaded data) for `href`. */
 		markLoaded(href: string) {
-			lastLoadedHref = toLatchKey(href)
+			const key = toLatchKey(href)
+			// Ignore late completions after navigating away so they cannot
+			// clobber the active location's loaded/pending markers.
+			if (key !== lastSeenHref) return
+			lastLoadedHref = key
 			lastFailedHref = null
-			lastPendingHref = null
+			if (lastPendingHref === key) {
+				lastPendingHref = null
+			}
 		},
 		/** Record a failed load so renders stop re-queuing for this `href`. */
 		markFailed(href: string) {
 			const key = toLatchKey(href)
+			if (key !== lastSeenHref) return
 			lastFailedHref = key
-			lastPendingHref = null
+			if (lastPendingHref === key) {
+				lastPendingHref = null
+			}
 			// A failure supersedes any earlier success for the same location;
 			// otherwise a failed refresh would leave the route latched as
 			// loaded and never refetch after navigating away and back.

--- a/packages/worker/client/route-load-latch.ts
+++ b/packages/worker/client/route-load-latch.ts
@@ -7,18 +7,27 @@ function toLatchKey(href: string) {
 
 /**
  * Href latch for client routes that fetch their own data. Tracks which
- * location the data was last loaded for, and which location last failed so a
+ * location the data was last loaded for, which location last failed so a
  * failed load does not re-queue in a tight render loop but does retry after
- * navigating away and back (previously a failure latched these routes into a
- * permanent error state because the loaded-href marker was set before the
- * fetch resolved).
+ * navigating away and back, and which location is already pending so an
+ * in-flight `queueTask` is not re-queued on every re-render.
  *
  * Keys are pathname+search only. In-page hashes (`/#invite`, onboarding step
  * hashes) are scroll/UI state, not a new data location.
+ *
+ * Why pending matters: Remix aborts a `queueTask` signal when the component
+ * re-renders. A load that calls `handle.update()` before its first `await`
+ * aborts itself, `needsLoad` stays true, and the next render queues another
+ * load — cascading microtask flushes until the scheduler throws
+ * `handle.update() infinite loop detected`. Marking pending on the first
+ * `needsLoad` decision stops that re-queue. Callers must still avoid
+ * premature `handle.update()` inside the queued load (set loading UI in the
+ * render that decides to load instead).
  */
 export function createRouteLoadLatch() {
 	let lastLoadedHref = ''
 	let lastFailedHref: string | null = null
+	let lastPendingHref: string | null = null
 	let lastSeenHref = ''
 
 	return {
@@ -26,11 +35,13 @@ export function createRouteLoadLatch() {
 		markLoaded(href: string) {
 			lastLoadedHref = toLatchKey(href)
 			lastFailedHref = null
+			lastPendingHref = null
 		},
 		/** Record a failed load so renders stop re-queuing for this `href`. */
 		markFailed(href: string) {
 			const key = toLatchKey(href)
 			lastFailedHref = key
+			lastPendingHref = null
 			// A failure supersedes any earlier success for the same location;
 			// otherwise a failed refresh would leave the route latched as
 			// loaded and never refetch after navigating away and back.
@@ -44,7 +55,13 @@ export function createRouteLoadLatch() {
 		},
 		/**
 		 * Whether the route must queue a data load this render pass. Call once
-		 * per render with the current router href.
+		 * per render with the current router href. A `true` result latches the
+		 * href as pending until `markLoaded` / `markFailed` (or a navigation /
+		 * stale-refresh clears it).
+		 *
+		 * `isLoading` is accepted for call-site compatibility but ignored: the
+		 * pending latch is the in-flight guard. Using `isLoading` as a reason
+		 * *to* load re-queued every render while status stayed `'loading'`.
 		 */
 		needsLoad(input: {
 			currentHref: string
@@ -52,26 +69,34 @@ export function createRouteLoadLatch() {
 			appliedRouteData: boolean
 			needsStaleRefresh: boolean
 		}) {
-			// The failure latch only guards retry loops for the location that
-			// failed; leaving it (or coming back) must allow a fresh attempt.
+			void input.isLoading
+			// The failure/pending latches only guard the location they were set
+			// for; leaving it (or coming back) must allow a fresh attempt.
 			const currentHref = toLatchKey(input.currentHref)
 			if (currentHref !== lastSeenHref) {
 				lastSeenHref = currentHref
 				lastFailedHref = null
+				lastPendingHref = null
 			}
 			// A stale-refresh signal is one-shot (the caller consumes it from
 			// navigation state), so it represents a fresh user-driven reload and
-			// must win over a previous failure for the same location.
+			// must win over a previous failure or abandoned pending for the same
+			// location.
 			if (input.needsStaleRefresh) {
 				lastFailedHref = null
+				lastPendingHref = null
 			}
-			return (
-				!input.appliedRouteData &&
-				(input.isLoading ||
-					currentHref !== lastLoadedHref ||
-					input.needsStaleRefresh) &&
-				currentHref !== lastFailedHref
-			)
+			if (input.appliedRouteData) {
+				return false
+			}
+			const shouldLoad =
+				(currentHref !== lastLoadedHref || input.needsStaleRefresh) &&
+				currentHref !== lastFailedHref &&
+				currentHref !== lastPendingHref
+			if (shouldLoad) {
+				lastPendingHref = currentHref
+			}
+			return shouldLoad
 		},
 	}
 }

--- a/packages/worker/client/route-load-latch.ts
+++ b/packages/worker/client/route-load-latch.ts
@@ -35,8 +35,10 @@ export function createRouteLoadLatch() {
 		markLoaded(href: string) {
 			const key = toLatchKey(href)
 			// Ignore late completions after navigating away so they cannot
-			// clobber the active location's loaded/pending markers.
-			if (key !== lastSeenHref) return
+			// clobber the active location's loaded/pending markers. Allow
+			// markLoaded before the first needsLoad (applied route data is
+			// often recorded in the same render pass before needsLoad runs).
+			if (lastSeenHref !== '' && key !== lastSeenHref) return
 			lastLoadedHref = key
 			lastFailedHref = null
 			if (lastPendingHref === key) {
@@ -46,7 +48,7 @@ export function createRouteLoadLatch() {
 		/** Record a failed load so renders stop re-queuing for this `href`. */
 		markFailed(href: string) {
 			const key = toLatchKey(href)
-			if (key !== lastSeenHref) return
+			if (lastSeenHref !== '' && key !== lastSeenHref) return
 			lastFailedHref = key
 			if (lastPendingHref === key) {
 				lastPendingHref = null

--- a/packages/worker/client/routes/account-stars.tsx
+++ b/packages/worker/client/routes/account-stars.tsx
@@ -62,8 +62,7 @@ export function AccountStarsRoute(handle: Handle) {
 
 	async function loadStars() {
 		const href = readCurrentRouterHref(handle)
-		status = 'loading'
-		handle.update()
+		// Do not call handle.update() before the first await — see blog.tsx.
 		try {
 			const response = await fetch(accountStarsApiPath, {
 				headers: { Accept: 'application/json' },
@@ -153,6 +152,7 @@ export function AccountStarsRoute(handle: Handle) {
 			needsStaleRefresh,
 		})
 		if (needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
 			handle.queueTask(async () => {
 				try {
 					await loadStars()

--- a/packages/worker/client/routes/blog-post.tsx
+++ b/packages/worker/client/routes/blog-post.tsx
@@ -115,8 +115,7 @@ export function BlogPostRoute(handle: Handle) {
 	}
 
 	async function loadPost(slug: string, signal: AbortSignal) {
-		status = 'loading'
-		handle.update()
+		// Do not call handle.update() before the first await — see blog.tsx.
 		try {
 			const response = await fetch(routes.blogPostApi.href({ slug }), {
 				headers: { Accept: 'application/json' },
@@ -171,6 +170,7 @@ export function BlogPostRoute(handle: Handle) {
 			needsStaleRefresh,
 		})
 		if (needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
 			handle.queueTask(async (signal) => {
 				try {
 					await loadPost(slug, signal)

--- a/packages/worker/client/routes/blog.tsx
+++ b/packages/worker/client/routes/blog.tsx
@@ -53,8 +53,9 @@ export function BlogRoute(handle: Handle) {
 	const loadLatch = createRouteLoadLatch()
 
 	async function loadBlog(signal: AbortSignal) {
-		status = 'loading'
-		handle.update()
+		// Do not call handle.update() before the first await. Remix aborts this
+		// queueTask on re-render; an early update aborts the fetch, needsLoad
+		// re-queues, and the scheduler hits "infinite loop detected".
 		try {
 			const response = await fetch(blogApiPath, {
 				headers: { Accept: 'application/json' },
@@ -97,6 +98,7 @@ export function BlogRoute(handle: Handle) {
 			needsStaleRefresh,
 		})
 		if (needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
 			handle.queueTask(async (signal) => {
 				try {
 					await loadBlog(signal)

--- a/packages/worker/client/routes/guide-detail.tsx
+++ b/packages/worker/client/routes/guide-detail.tsx
@@ -121,8 +121,7 @@ export function GuideDetailRoute(handle: Handle) {
 	}
 
 	async function loadGuide(slug: string, signal: AbortSignal) {
-		status = 'loading'
-		handle.update()
+		// Do not call handle.update() before the first await — see blog.tsx.
 		try {
 			const response = await fetch(routes.guideDetailApi.href({ slug }), {
 				headers: { Accept: 'application/json' },
@@ -181,6 +180,7 @@ export function GuideDetailRoute(handle: Handle) {
 			needsStaleRefresh,
 		})
 		if (needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
 			handle.queueTask(async (signal) => {
 				try {
 					await loadGuide(slug, signal)

--- a/packages/worker/client/routes/guides.tsx
+++ b/packages/worker/client/routes/guides.tsx
@@ -69,8 +69,7 @@ export function GuidesRoute(handle: Handle) {
 	const loadLatch = createRouteLoadLatch()
 
 	async function loadGuides(signal: AbortSignal) {
-		status = 'loading'
-		handle.update()
+		// Do not call handle.update() before the first await — see blog.tsx.
 		try {
 			const response = await fetch(guidesApiPath, {
 				headers: { Accept: 'application/json' },
@@ -113,6 +112,7 @@ export function GuidesRoute(handle: Handle) {
 			needsStaleRefresh,
 		})
 		if (needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
 			handle.queueTask(async (signal) => {
 				try {
 					await loadGuides(signal)

--- a/packages/worker/client/routes/timeline.tsx
+++ b/packages/worker/client/routes/timeline.tsx
@@ -84,8 +84,7 @@ export function TimelineRoute(handle: Handle) {
 	const loadLatch = createRouteLoadLatch()
 
 	async function loadTimeline() {
-		status = 'loading'
-		handle.update()
+		// Do not call handle.update() before the first await — see blog.tsx.
 		try {
 			const response = await fetch(timelineApiPath, {
 				headers: { Accept: 'application/json' },
@@ -140,6 +139,7 @@ export function TimelineRoute(handle: Handle) {
 			needsStaleRefresh,
 		})
 		if (needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
 			handle.queueTask(async () => {
 				await runLoad(currentHref)
 			})

--- a/packages/worker/client/routes/timeline.tsx
+++ b/packages/worker/client/routes/timeline.tsx
@@ -181,6 +181,11 @@ export function TimelineRoute(handle: Handle) {
 								mix={[
 									css(getPillButtonCss()),
 									on('click', () => {
+										// Click-driven retry may call handle.update() —
+										// unlike queueTask loads, this is not aborted by
+										// the same render cycle.
+										status = 'loading'
+										handle.update()
 										void runLoad(currentHref)
 									}),
 								]}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop production `handle.update() infinite loop detected` when SPA navigations fall back to client route fetches (Sentry [KODY-CLOUDFLARE-4V](https://kent-c-dodds-tech-llc.sentry.io/issues/7671935996/)).

## Summary

- **Root cause:** Remix aborts a `queueTask` signal when the component re-renders. Blog (and sibling) fallback loads called `handle.update()` before the first `await`, which aborted the fetch; `needsLoad` stayed true (and treated `isLoading` as a reason to load), so the next render re-queued — cascading microtask flushes until the scheduler's 50-update guard threw.
- **Evidence:** Production event on `/blog` after `/guides/what-is-kody` → `/blog` with a failed/aborted `/blog.json` preload (fallback path). Culprit: `@remix-run/ui` scheduler `flush`.
- **Fix:** Latch the href as pending on the first `needsLoad` decision; set `status = 'loading'` in the render that queues the load; remove premature `handle.update()` from blog, blog-post, guides, guide-detail, timeline, and account-stars loaders. Completions ignore stale hrefs so a late `/a` finish cannot clear `/b`'s pending latch.
- **Siblings:** KODY-CLOUDFLARE-4W/4X (`scheduleUpdate not implemented` on Mobile Safari) look like Navigation API / hydration fallout (see #998), not this cascade — left alone.

## Testing

- `npx vitest run packages/worker/client/route-load-latch.node.test.ts --project node-unit` (pending, isLoading, and /a→/b interleaving)
- Local `npm run validate`: typecheck/lint/format green; node/mcp/e2e flaked on mock-cloudflare readiness (unrelated; re-ran flaky node mocks green). CI Validate is the gate.
- Preview: `npm run preview:manual-test` against `/blog`, `/guides`, guide detail (in progress / results below)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk — clear root cause + latch tests; no auth/isolation/billing)</summary>

**Mode:** recap · **Base:** `main` @ `db8f3cf9` · **Head:** `8f98a2fa`

**Classification:** extends — `route-load-latch` gains an in-flight pending guard and attempt-safe completions; six public routes stop calling `handle.update()` before their first await.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — client route-load latch + fallback fetch update sequencing |

### System map

SPA navigations that miss preloaded loader data queue a client fetch once; the latch and render-time loading state prevent update cascades into Remix's scheduler.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	remixUi["remix-ui<br/>Remix client runtime"]:::untouched
	appUi -->|"needsLoad marks pending; queueTask fetch without early update()"| remixUi
	remixUi -->|"flush no longer cascades past MAX_CASCADING_UPDATES"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| Fallback client load (e.g. `/blog` after failed preload) | `handle.update()` in `queueTask` → abort → re-queue → infinite loop error | Pending latch + no early update; one fetch completes |
| Same href while status is `'loading'` | `isLoading` forced `needsLoad` true every render | Pending latch blocks re-queue until markLoaded/Failed |
| Late `/a` completion after navigate to `/b` | Could clear `/b` pending | Ignored; `/b` pending stays |

### Invariants

No change to per-user isolation, auth, billing, or storage.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf748f25-a940-436d-b6c8-4b6149ac58da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf748f25-a940-436d-b6c8-4b6149ac58da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate route-loading requests while navigation data is still being fetched.
  - Improved recovery when a previous or stale route load is interrupted.
  - Avoided unnecessary reloads when route data is already available.
  - Improved loading-state updates across account stars, blog, guide, and timeline pages, providing more consistent feedback during navigation.
  - Ensured outdated route responses do not override the current page’s loading state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->