### PR TITLE
Load attached remotes in package apps, services, and subscriptions

### DIFF
--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -92,8 +92,14 @@ that connector:
   defines the set of remote connectors for that session.
 
 Regular authenticated MCP and chat sessions load this array from the user's
-saved remote connector settings. Operators can manage those settings at
-`/account/remote-connectors`:
+saved remote connector settings. Background package runtimes do the same:
+package apps (when the runtime bridge builds caller context for capabilities or
+nested `packages.invoke`), package services, subscription handlers, jobs,
+workflows, HTTP invocation tokens, and webhook delivery. Hosted app serve
+(`servePackageAppRequest`) does not load remotes on the warm path; the runtime
+bridge loads them when user code needs capabilities.
+
+Operators can manage those settings at `/account/remote-connectors`:
 
 - **`instanceId`** is the user-chosen connector name. Names are unique per user
   and key `kody.remote[name]`.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -406,6 +406,8 @@ Treat package apps like Worker-style modules:
 - the entry module is declared by `kody.app.entry`
 - durable package data uses `packageStorage()` — the same shared package bucket
   as exports, jobs, and services
+- attached remote connectors from `/account/remote-connectors` are available as
+  `kody.remote["name"]`, the same as execute
 - internal Durable Objects or facets are app-only realtime/coordination details
   layered under the package namespace, not the persistence mechanism and not
   separate saved primitives

--- a/packages/worker/src/mcp-auth-user-context.node.test.ts
+++ b/packages/worker/src/mcp-auth-user-context.node.test.ts
@@ -10,8 +10,10 @@ vi.mock('#worker/identity/permissions-db.ts', () => ({
 		mockModule.getUserRolesAndPermissions(...args),
 }))
 
-const { buildMcpUserContextFromGrantProps } =
-	await import('./mcp-auth-user-context.ts')
+const {
+	buildMcpUserContextFromGrantProps,
+	listAttachedRemoteConnectorRefsCached,
+} = await import('./mcp-auth-user-context.ts')
 
 type GrantUserRow = {
 	id: number
@@ -278,6 +280,12 @@ test('MCP auth reads account gates once, loads roles and connectors in parallel,
 	await buildMcpUserContextFromGrantProps({ APP_DB: account.db } as Env, {
 		userId: 'verified-id',
 	})
+	await expect(
+		listAttachedRemoteConnectorRefsCached({
+			env: { APP_DB: account.db } as Env,
+			userId: 'verified-id',
+		}),
+	).resolves.toEqual([{ instanceId: 'home' }])
 	expect(
 		account.queries.filter(({ sql }) =>
 			sql.toLowerCase().includes('remote_connector_settings'),

--- a/packages/worker/src/mcp-auth-user-context.ts
+++ b/packages/worker/src/mcp-auth-user-context.ts
@@ -40,7 +40,12 @@ const attachedRemoteConnectorRefsCaches = new WeakMap<
 	PromiseLruCache<ReadonlyArray<RemoteConnectorRef>>
 >()
 
-function listAttachedRemoteConnectorRefsCached(input: {
+/**
+ * Resolve attached remote connector refs for MCP auth and background package
+ * runtimes. Cached 30s per user per D1 binding so app/service/subscription
+ * caller-context builds do not each pay a settings read.
+ */
+export function listAttachedRemoteConnectorRefsCached(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string
 }) {

--- a/packages/worker/src/package-invocations/subscription-dispatch.node.test.ts
+++ b/packages/worker/src/package-invocations/subscription-dispatch.node.test.ts
@@ -6,11 +6,24 @@ const mocks = vi.hoisted(() => ({
 		status: 200,
 		body: {},
 	})),
+	listAttachedRemoteConnectorRefsCached: vi.fn(async () => [
+		{ instanceId: 'home' },
+	]),
 }))
 
 vi.mock('./idempotent-module-invocation.ts', () => ({
 	invokeSavedPackageModule: mocks.invokeSavedPackageModule,
 }))
+
+vi.mock('#worker/mcp-auth-user-context.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#worker/mcp-auth-user-context.ts')>()
+	return {
+		...actual,
+		listAttachedRemoteConnectorRefsCached: (...args: Array<unknown>) =>
+			mocks.listAttachedRemoteConnectorRefsCached(...args),
+	}
+})
 
 const { invokePackageSubscriptionWithToolFactories } =
 	await import('./subscription-dispatch.ts')
@@ -54,8 +67,16 @@ test('invokePackageSubscriptionWithToolFactories strips forged synthetic markers
 				event: 'email.message.received',
 			},
 			source: 'email',
+			actor: expect.objectContaining({
+				userId: 'user-1',
+				remoteConnectors: [{ instanceId: 'home' }],
+			}),
 		}),
 	)
+	expect(mocks.listAttachedRemoteConnectorRefsCached).toHaveBeenCalledWith({
+		env: {},
+		userId: 'user-1',
+	})
 })
 
 test('invokePackageSubscriptionWithToolFactories preserves synthetic markers only with the trusted dispatch token', async () => {

--- a/packages/worker/src/package-invocations/subscription-dispatch.ts
+++ b/packages/worker/src/package-invocations/subscription-dispatch.ts
@@ -3,6 +3,7 @@ import { listJsonSchemaSubsetValueErrors } from '@kody-internal/shared/json-sche
 import { toHex } from '@kody-internal/shared/hex.ts'
 import { runWithDynamicWorkerEvaluationBudget } from '#mcp/executor.ts'
 import { type createMcpCallerContext } from '#mcp/context.ts'
+import { listAttachedRemoteConnectorRefsCached } from '#worker/mcp-auth-user-context.ts'
 import {
 	type PackageEventDispatchInput,
 	type PackageEventTools,
@@ -459,12 +460,19 @@ export async function invokePackageSubscriptionWithToolFactories(input: {
 	const params = synthetic
 		? input.params
 		: stripUntrustedSubscriptionEnvelopeFields(input.params)
+	const remoteConnectors = [
+		...(await listAttachedRemoteConnectorRefsCached({
+			env: input.env,
+			userId: input.savedPackage.userId,
+		})),
+	]
 	return await invokeSavedPackageModule({
 		env: input.env,
 		baseUrl: input.baseUrl,
 		actor: {
 			tokenId: input.actorTokenId ?? internalEmailSubscriptionTokenId,
 			userId: input.savedPackage.userId,
+			remoteConnectors,
 		},
 		savedPackage: input.savedPackage,
 		invocationName: buildPackageSubscriptionArtifactName(topic),

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -322,6 +322,18 @@ const packageAppRuntimeMock = vi.hoisted(() => ({
 	resolvePackageMountedSecret: vi.fn(),
 	beginRunRecord: vi.fn(),
 	finishRunRecord: vi.fn(async () => {}),
+	listAttachedRemoteConnectorRefsCached: vi.fn(
+		async () => [] as Array<{ instanceId: string }>,
+	),
+	getCapabilityRegistryForContext: vi.fn(async () => ({
+		capabilityMap: {},
+	})),
+	createPackageRuntimeInvokeTools: vi.fn(async () => ({
+		invoke: vi.fn(async () => ({})),
+	})),
+	createPackageEventTools: vi.fn(async () => ({
+		dispatch: vi.fn(async () => ({})),
+	})),
 }))
 
 vi.mock('cloudflare:workers', async (importOriginal) => {
@@ -378,6 +390,28 @@ vi.mock('#mcp/secrets/package-access.ts', () => ({
 		error instanceof Error && error.message === 'secret-unavailable',
 	resolvePackageMountedSecret: (...args: Array<unknown>) =>
 		packageAppRuntimeMock.resolvePackageMountedSecret(...args),
+}))
+
+vi.mock('#worker/mcp-auth-user-context.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#worker/mcp-auth-user-context.ts')>()
+	return {
+		...actual,
+		listAttachedRemoteConnectorRefsCached: (...args: Array<unknown>) =>
+			packageAppRuntimeMock.listAttachedRemoteConnectorRefsCached(...args),
+	}
+})
+
+vi.mock('#mcp/capabilities/registry.ts', () => ({
+	getCapabilityRegistryForContext: (...args: Array<unknown>) =>
+		packageAppRuntimeMock.getCapabilityRegistryForContext(...args),
+}))
+
+vi.mock('#worker/package-invocations/service.ts', () => ({
+	createPackageRuntimeInvokeTools: (...args: Array<unknown>) =>
+		packageAppRuntimeMock.createPackageRuntimeInvokeTools(...args),
+	createPackageEventTools: (...args: Array<unknown>) =>
+		packageAppRuntimeMock.createPackageEventTools(...args),
 }))
 
 vi.mock('#worker/run-records/service.ts', async (importOriginal) => {
@@ -452,8 +486,24 @@ function resetPackageAppRuntimeMocks() {
 	packageAppRuntimeMock.resolvePackageMountedSecret.mockReset()
 	packageAppRuntimeMock.beginRunRecord.mockReset()
 	packageAppRuntimeMock.finishRunRecord.mockReset()
+	packageAppRuntimeMock.listAttachedRemoteConnectorRefsCached.mockReset()
+	packageAppRuntimeMock.getCapabilityRegistryForContext.mockReset()
+	packageAppRuntimeMock.createPackageRuntimeInvokeTools.mockReset()
+	packageAppRuntimeMock.createPackageEventTools.mockReset()
 	packageAppRuntimeMock.packageAppRuntimeBridge.mockClear()
 	packageAppRuntimeMock.finishRunRecord.mockResolvedValue(undefined)
+	packageAppRuntimeMock.listAttachedRemoteConnectorRefsCached.mockResolvedValue(
+		[],
+	)
+	packageAppRuntimeMock.getCapabilityRegistryForContext.mockResolvedValue({
+		capabilityMap: {},
+	})
+	packageAppRuntimeMock.createPackageRuntimeInvokeTools.mockResolvedValue({
+		invoke: vi.fn(async () => ({})),
+	})
+	packageAppRuntimeMock.createPackageEventTools.mockResolvedValue({
+		dispatch: vi.fn(async () => ({})),
+	})
 	packageAppRuntimeMock.hydrateKodyRuntimeModules.mockImplementation(
 		async ({ modules }: { modules: Record<string, string> }) => ({
 			modules,
@@ -1327,4 +1377,99 @@ test('buildPackageAppWorker passes packageStorage grant ids from root, static, a
 		props: { packageStorageGrantIds: Array<string> }
 	}
 	expect(bridgeProps.props.packageStorageGrantIds).toHaveLength(3)
+})
+
+test('package app caller context includes attached remotes for capabilities and nested invoke', async () => {
+	resetPackageAppRuntimeMocks()
+	packageAppRuntimeMock.getCapabilityRegistryForContext.mockImplementation(
+		async ({
+			callerContext,
+		}: {
+			callerContext: {
+				remoteConnectors?: Array<{ instanceId: string }> | null
+			}
+		}) => {
+			const hasHome = (callerContext.remoteConnectors ?? []).some(
+				(ref) => ref.instanceId === 'home',
+			)
+			return {
+				capabilityMap: hasHome
+					? {
+							'remote:home:bond_shade_set_position': {
+								handler: async (
+									args: Record<string, unknown>,
+									context: {
+										callerContext: {
+											remoteConnectors?: Array<{ instanceId: string }> | null
+										}
+									},
+								) => ({
+									ok: true,
+									args,
+									remoteConnectors: context.callerContext.remoteConnectors,
+								}),
+							},
+						}
+					: {},
+			}
+		},
+	)
+
+	const emptyBridge = createPackageAppRuntimeBridgeForTest().bridge
+	await expect(
+		emptyBridge.callCapability({
+			name: 'remote:home:bond_shade_set_position',
+			args: { position: 50 },
+		}),
+	).rejects.toThrow(
+		'Package app capability "remote:home:bond_shade_set_position" is not available.',
+	)
+	expect(
+		packageAppRuntimeMock.getCapabilityRegistryForContext,
+	).toHaveBeenCalledWith(
+		expect.objectContaining({
+			callerContext: expect.objectContaining({
+				remoteConnectors: [],
+			}),
+		}),
+	)
+
+	packageAppRuntimeMock.listAttachedRemoteConnectorRefsCached.mockResolvedValue(
+		[{ instanceId: 'home' }],
+	)
+	const homeBridge = createPackageAppRuntimeBridgeForTest().bridge
+	await expect(
+		homeBridge.callCapability({
+			name: 'remote:home:bond_shade_set_position',
+			args: { position: 50 },
+		}),
+	).resolves.toEqual({
+		ok: true,
+		args: { position: 50 },
+		remoteConnectors: [{ instanceId: 'home' }],
+	})
+
+	const invoke = vi.fn(async () => ({ invoked: true }))
+	packageAppRuntimeMock.createPackageRuntimeInvokeTools.mockResolvedValue({
+		invoke,
+	})
+	await expect(
+		homeBridge.packageInvoke({
+			packageIdOrKodyId: 'shade-automation',
+			exportName: 'control',
+		}),
+	).resolves.toEqual({ invoked: true })
+	expect(
+		packageAppRuntimeMock.createPackageRuntimeInvokeTools,
+	).toHaveBeenCalledWith(
+		expect.objectContaining({
+			callerContext: expect.objectContaining({
+				remoteConnectors: [{ instanceId: 'home' }],
+			}),
+		}),
+	)
+	expect(invoke).toHaveBeenCalledWith({
+		packageIdOrKodyId: 'shade-automation',
+		exportName: 'control',
+	})
 })

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -1,5 +1,6 @@
 import { WorkerEntrypoint, exports as workerExports } from 'cloudflare:workers'
 import { createMcpCallerContext } from '#mcp/context.ts'
+import { listAttachedRemoteConnectorRefsCached } from '#worker/mcp-auth-user-context.ts'
 import {
 	getPackageAppEntryPath,
 	parseAuthoredPackageJson,
@@ -833,7 +834,13 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	private readonly secretRedactor: ExecutionSecretRedactor =
 		createExecutionSecretRedactor()
 
-	private createCallerContext(storageId: string | null) {
+	private async createCallerContext(storageId: string | null) {
+		const remoteConnectors = [
+			...(await listAttachedRemoteConnectorRefsCached({
+				env: this.env,
+				userId: this.ctx.props.userId,
+			})),
+		]
 		return createMcpCallerContext({
 			baseUrl: this.ctx.props.baseUrl,
 			executionOrigin: 'background',
@@ -843,6 +850,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 				username: undefined,
 				displayName: this.ctx.props.displayName,
 			},
+			remoteConnectors,
 			storageContext: {
 				sessionId: null,
 				appId: this.ctx.props.packageId,
@@ -1002,9 +1010,10 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 
 	async callCapability(input: { name: string; args?: unknown }) {
 		const name = input.name.trim()
+		const callerContext = await this.createCallerContext(null)
 		const { capabilityMap } = await getCapabilityRegistryForContext({
 			env: this.env,
-			callerContext: this.createCallerContext(null),
+			callerContext,
 		})
 		const capability = capabilityMap[name]
 		if (!capability) {
@@ -1014,7 +1023,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 			(input.args ?? {}) as Record<string, unknown>,
 			{
 				env: this.env,
-				callerContext: this.createCallerContext(null),
+				callerContext,
 			},
 		)
 	}
@@ -1204,7 +1213,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	async refreshAccessToken(providerName: string) {
 		const kody = await buildKodyFns(
 			this.env,
-			this.createCallerContext(this.ctx.props.packageId),
+			await this.createCallerContext(this.ctx.props.packageId),
 		)
 		return await refreshAccessToken(kody, providerName)
 	}
@@ -1220,7 +1229,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	}) {
 		const kody = await buildKodyFns(
 			this.env,
-			this.createCallerContext(this.ctx.props.packageId),
+			await this.createCallerContext(this.ctx.props.packageId),
 		)
 		const authenticatedFetch = await createAuthenticatedFetch(
 			kody,
@@ -1234,7 +1243,9 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	}
 
 	async packageSecretGet(input: { alias: string }) {
-		const callerContext = this.createCallerContext(this.ctx.props.packageId)
+		const callerContext = await this.createCallerContext(
+			this.ctx.props.packageId,
+		)
 		const resolved = await resolvePackageMountedSecret({
 			env: this.env,
 			callerContext,
@@ -1248,7 +1259,9 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 	}
 
 	async packageSecretHas(input: { alias: string }) {
-		const callerContext = this.createCallerContext(this.ctx.props.packageId)
+		const callerContext = await this.createCallerContext(
+			this.ctx.props.packageId,
+		)
 		try {
 			await resolvePackageMountedSecret({
 				env: this.env,
@@ -1366,7 +1379,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		// startup; apps only need this helper when package code calls it.
 		this.packageRuntimeInvokeTools =
 			import('#worker/package-invocations/service.ts').then(
-				({ createPackageRuntimeInvokeTools }) => {
+				async ({ createPackageRuntimeInvokeTools }) => {
 					const packageContext = {
 						packageId: this.ctx.props.packageId,
 						kodyId: this.ctx.props.kodyId,
@@ -1375,7 +1388,9 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 					return createPackageRuntimeInvokeTools({
 						env: this.env,
 						baseUrl: this.ctx.props.baseUrl,
-						callerContext: this.createCallerContext(this.ctx.props.packageId),
+						callerContext: await this.createCallerContext(
+							this.ctx.props.packageId,
+						),
 						packageContext,
 						parentRunRecord: null,
 						packageInvokeDepth: 0,
@@ -1392,7 +1407,7 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		// startup; apps only need this helper when package code calls it.
 		this.packageEventTools =
 			import('#worker/package-invocations/service.ts').then(
-				({ createPackageEventTools }) => {
+				async ({ createPackageEventTools }) => {
 					const packageContext = {
 						packageId: this.ctx.props.packageId,
 						kodyId: this.ctx.props.kodyId,
@@ -1401,7 +1416,9 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 					return createPackageEventTools({
 						env: this.env,
 						baseUrl: this.ctx.props.baseUrl,
-						callerContext: this.createCallerContext(this.ctx.props.packageId),
+						callerContext: await this.createCallerContext(
+							this.ctx.props.packageId,
+						),
 						packageContext,
 						parentRunRecord: null,
 						packageInvokeDepth: 0,

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -12,6 +12,7 @@ const mockModule = vi.hoisted(() => ({
 	runBundledModuleWithRegistry: vi.fn(),
 	createPackageEventTools: vi.fn(() => ({})),
 	createPackageRuntimeInvokeTools: vi.fn(() => ({})),
+	listAttachedRemoteConnectorRefsCached: vi.fn(async () => []),
 }))
 
 vi.mock('@sentry/cloudflare', () => ({
@@ -72,6 +73,16 @@ vi.mock('#worker/identity/background-mcp-user.ts', () => ({
 		displayName: userId,
 	}),
 }))
+
+vi.mock('#worker/mcp-auth-user-context.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#worker/mcp-auth-user-context.ts')>()
+	return {
+		...actual,
+		listAttachedRemoteConnectorRefsCached: (...args: Array<unknown>) =>
+			mockModule.listAttachedRemoteConnectorRefsCached(...args),
+	}
+})
 
 const usageModule = await import('#worker/usage/record-usage.ts')
 const recordUsageSpy = vi.spyOn(usageModule, 'recordUsage')
@@ -225,6 +236,8 @@ function resetMocks() {
 	mockModule.runBundledModuleWithRegistry.mockReset()
 	mockModule.createPackageEventTools.mockReset()
 	mockModule.createPackageRuntimeInvokeTools.mockReset()
+	mockModule.listAttachedRemoteConnectorRefsCached.mockReset()
+	mockModule.listAttachedRemoteConnectorRefsCached.mockResolvedValue([])
 	// The global `mockReset: true` config restores the spy's real
 	// implementation before every test; re-stub so recordUsage does not run
 	// against the stub env and log `usage-rollup-failed`.
@@ -342,6 +355,9 @@ test('package service start and stop project liveness into package_service_state
 
 	try {
 		setupSavedPackage('bounded')
+		mockModule.listAttachedRemoteConnectorRefsCached.mockResolvedValue([
+			{ instanceId: 'home' },
+		])
 		mockModule.runBundledModuleWithRegistry.mockImplementation(async () => {
 			vi.setSystemTime(new Date('2026-07-05T12:00:05.000Z'))
 			return { result: { ok: true }, error: null }
@@ -369,6 +385,11 @@ test('package service start and stop project liveness into package_service_state
 		expect(created.getAlarmAt()).toBe(Date.parse('2026-07-05T13:00:00.000Z'))
 
 		await flushWaitUntilTasks(created.waitUntilTasks)
+		expect(mockModule.runBundledModuleWithRegistry.mock.calls[0]?.[1]).toEqual(
+			expect.objectContaining({
+				remoteConnectors: [{ instanceId: 'home' }],
+			}),
+		)
 		expect(upserts.at(-1)).toEqual([
 			'user-123',
 			'package-1',

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -4,6 +4,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { z } from 'zod'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
+import { listAttachedRemoteConnectorRefsCached } from '#worker/mcp-auth-user-context.ts'
 import {
 	userMeterNamespace,
 	userMeterRpc,
@@ -948,10 +949,18 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 					rootPackageId: runtime.packageContext.packageId,
 				})
 			})())
+		const [user, remoteConnectors] = await Promise.all([
+			resolveBackgroundMcpUser(this.env.APP_DB, binding.userId),
+			listAttachedRemoteConnectorRefsCached({
+				env: this.env,
+				userId: binding.userId,
+			}),
+		])
 		const callerContext = createMcpCallerContext({
 			baseUrl: binding.baseUrl,
 			executionOrigin: 'background',
-			user: await resolveBackgroundMcpUser(this.env.APP_DB, binding.userId),
+			user,
+			remoteConnectors: [...remoteConnectors],
 			storageContext: {
 				sessionId: null,
 				appId: binding.packageId,

--- a/packages/worker/src/test-support/workers-seed.ts
+++ b/packages/worker/src/test-support/workers-seed.ts
@@ -79,6 +79,16 @@ export async function ensurePackageSubscriptionTestSchema(db: D1Database) {
 		)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_published_bundle_artifacts_identity
 		ON published_bundle_artifacts(user_id, source_id, artifact_kind, COALESCE(artifact_name, ''), entry_point)`,
+		`CREATE TABLE IF NOT EXISTS remote_connector_settings (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			instance_id TEXT NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			attached INTEGER NOT NULL DEFAULT 1,
+			encrypted_shared_secret TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
 	]
 	for (const statement of statements) {
 		await db.prepare(statement).run()


### PR DESCRIPTION
## Intent

Close the implementation gap that left package apps (and the same omitted-remotes path in package services and subscription handlers) unable to call `kody.remote["home"]` the way MCP execute already can. Attached connectors in `/account/remote-connectors` are already the grant — this PR only wires that list into those background caller contexts.

## Summary

- Export the existing 30s `listAttachedRemoteConnectorRefsCached` helper from `mcp-auth-user-context.ts` for background package runtimes.
- Make `PackageAppRuntimeBridge.createCallerContext` async and pass `remoteConnectors` into `createMcpCallerContext`, so `callCapability` synthesizes `remote:*` tools and nested `packages.invoke` inherits those refs as `actor.remoteConnectors`.
- Load the same attached list in `package-service.ts` and subscription dispatch (same omitted-remotes bug).
- Do **not** load remotes in `servePackageAppRequest` (warm-path zero D1-before-dispatch budget stays intact).
- Do **not** add a `kody.app.remotes` manifest grant.
- Docs: architecture + usage note that attached remotes are available as `kody.remote["name"]` from package apps.
- Workers-unit subscription schema now includes `remote_connector_settings` so dispatch can load an empty attached list.

## Testing

- `package-app.node.test.ts`: empty attached list still throws `Package app capability "remote:home:…" is not available.`; `[{ instanceId: "home" }]` includes the capability and `packageInvoke` receives those refs on caller context.
- `package-service.node.test.ts`: service start passes `remoteConnectors: [{ instanceId: "home" }]` into `runBundledModuleWithRegistry`.
- `subscription-dispatch.node.test.ts`: actor includes attached remotes.
- `package-app-serve.node.test.ts`: warm serve still performs zero D1/KV loads before dispatch.
- `mcp-auth-user-context.node.test.ts`: exported helper shares the 30s cache.
- Workers-unit subscription suites (platform-feedback, system email, user mailbox flow) pass after adding the settings table to the shared test schema.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `9149ce30` · **Head:** `4ab37480`

**Classification:** extends — package apps, package services, and subscription dispatch now attach the user's saved remote connectors to caller context. No new primitive and no new manifest grant.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `package-apps` | assistant | extends — runtime bridge caller context includes attached remotes |
| `package-services` | assistant | extends — service isolate caller context includes attached remotes |
| `package-events-dispatch-queue` | storage | extends — subscription actor carries `remoteConnectors` |
| `package-runtime` | runtime | composes — tests for the same caller-context wiring |
| `remote-connectors` | assistant | composes — reuse attached-refs cache; no protocol/settings change |

### System map

Background package runtimes load the user's attached remote connectors through the shared 30s cache, then pass that list into MCP caller context so the capability registry can synthesize `remote:*` tools.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	packageApps["package-apps<br/>Package apps"]:::extended
	packageServices["package-services<br/>Package services"]:::extended
	subscriptionDispatch["package-events-dispatch-queue<br/>Package events dispatch queue"]:::extended
	remoteConnectors["remote-connectors<br/>Remote connectors"]:::touched
	packageApps -->|"listAttachedRemoteConnectorRefsCached"| remoteConnectors
	packageServices -->|"listAttachedRemoteConnectorRefsCached"| remoteConnectors
	subscriptionDispatch -->|"actor.remoteConnectors"| remoteConnectors
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant App as Package app isolate
	participant Bridge as PackageAppRuntimeBridge
	participant Cache as attached remotes cache
	participant Registry as capability registry
	App->>Bridge: kody.remote["home"].tool(input)
	Bridge->>Cache: listAttachedRemoteConnectorRefsCached
	Cache-->>Bridge: [{ instanceId: "home" }]
	Bridge->>Registry: getCapabilityRegistryForContext(remoteConnectors)
	Registry-->>Bridge: remote:home:tool
	Bridge-->>App: capability result
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Package app `callCapability` | `remoteConnectors` omitted (`null`) | attached list (including empty) |
| Nested `packages.invoke` from an app | `Available remote connectors: none` | inherits the same attached refs |
| Package service / subscription | remotes omitted | same attached list |
| `servePackageAppRequest` | no remotes load | unchanged (warm path) |

### Invariants

Per-user isolation is unchanged: remotes are loaded with the runtime owner's `userId`. Empty attached list still means none, not "load all." Attached connectors in `/account/remote-connectors` remain the grant.

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends capability exposure to background package surfaces using existing per-user attached-connector grants and cache; no new manifest grant, but mis-attached connectors could now affect apps/services/subscriptions.
> 
> **Overview**
> Background package runtimes now load the package owner’s **attached** remote connectors from `/account/remote-connectors` (same grant as MCP/chat) and pass them as `remoteConnectors` on MCP caller context, so `kody.remote["name"]` and synthesized `remote:*` capabilities work outside interactive execute.
> 
> **`listAttachedRemoteConnectorRefsCached`** is exported from `mcp-auth-user-context.ts` (30s per-user D1 cache). **`PackageAppRuntimeBridge`** makes `createCallerContext` async and includes attached refs for `callCapability`, secrets/OAuth helpers, and nested **`packages.invoke`** / event tools. **Package services** and **subscription dispatch** set `actor.remoteConnectors` the same way when invoking handlers.
> 
> Hosted app **warm serve** is unchanged—remotes load only when the runtime bridge builds context on demand. Docs note package apps can use `kody.remote["name"]` like execute. Workers-unit seed adds **`remote_connector_settings`** for subscription tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab37480709cd215558cc9d652261b97af849fdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Package apps and background executions now use configured remote connectors when capabilities or tools require them.
  - Remote connectors attached to a package user are available through `kody.remote["name"]`, including subscription-triggered executions.
  - Hosted apps load connector settings when needed, improving capability access without unnecessary loading.

- **Documentation**
  - Clarified the remote connector settings location: `/account/remote-connectors`.
  - Updated guidance on connector availability across package runtimes and hosted apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->