### PR TITLE
Stop account rail from bouncing on tab clicks

### DIFF
--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -239,15 +239,22 @@ export function App(handle: Handle<AppProps>) {
 											width: '100%',
 											boxSizing: 'border-box',
 											flex: 1,
+											viewTransitionName: 'page',
 											// The auth canvas stretches to fill the shell column.
 											display: 'grid',
 										}
 									: isRedesignedMarketingPath
-										? { width: '100%', boxSizing: 'border-box', flex: 1 }
+										? {
+												width: '100%',
+												boxSizing: 'border-box',
+												flex: 1,
+												viewTransitionName: 'page',
+											}
 										: {
 												width: '100%',
 												boxSizing: 'border-box',
 												flex: 1,
+												viewTransitionName: 'page',
 												padding: `${spacing.lg} ${spacing.xl} ${spacing.sm}`,
 												[mq.tablet]: {
 													padding: `${spacing.sm} ${spacing.sm} 0`,

--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -1,13 +1,16 @@
 import { expect, test, vi } from 'vitest'
 import {
+	documentHasPersistentShell,
 	isSameShellAreaNavigation,
 	matchRoute,
 	matchRouteLoader,
 	navigate,
 	navigationTimeoutMs,
+	persistentShellNavSelector,
 	registerRouteLoaders,
 	Router,
 	shouldRouterHandleClick,
+	shouldUseViewTransition,
 	type RouteLoader,
 } from './client-router.tsx'
 import { communityArea } from './lazy-route.tsx'
@@ -100,6 +103,87 @@ test('view transitions are skipped only when a navigation stays inside one shell
 
 	// A path that merely starts with the area's characters is a different area.
 	expect(isSameShellAreaNavigation('/account', '/accounts-payable')).toBe(false)
+})
+
+test('view transitions stay off for shell tab switches even when from-path was never recorded', () => {
+	const animate = (input: {
+		from: string | null
+		to: string
+		hasPersistentShell?: boolean
+	}) =>
+		shouldUseViewTransition({
+			from: input.from,
+			to: input.to,
+			canStart: true,
+			prefersReducedMotion: false,
+			hasPersistentShell: input.hasPersistentShell,
+		})
+
+	// The production bug: first click after a full load had from=null, so the
+	// path-only skip missed and the whole account shell faded + slid 8px.
+	expect(
+		animate({
+			from: null,
+			to: '/account/activity',
+			hasPersistentShell: true,
+		}),
+	).toBe(false)
+	expect(
+		animate({
+			from: '/account/usage',
+			to: '/account/activity',
+			hasPersistentShell: true,
+		}),
+	).toBe(false)
+	expect(animate({ from: '/account/usage', to: '/account/activity' })).toBe(
+		false,
+	)
+
+	// Leaving, entering, or crossing shells is still a real page change.
+	expect(
+		animate({
+			from: '/account/usage',
+			to: '/pricing',
+			hasPersistentShell: true,
+		}),
+	).toBe(true)
+	expect(
+		animate({
+			from: '/account/usage',
+			to: '/admin/users',
+			hasPersistentShell: true,
+		}),
+	).toBe(true)
+	expect(animate({ from: '/pricing', to: '/account/usage' })).toBe(true)
+	expect(animate({ from: null, to: '/account/usage' })).toBe(true)
+
+	// Same pathname+search (hash-only / same-URL refresh) never animates.
+	expect(animate({ from: '/account/usage', to: '/account/usage' })).toBe(false)
+	expect(
+		shouldUseViewTransition({
+			from: '/pricing',
+			to: '/community',
+			canStart: false,
+			prefersReducedMotion: false,
+		}),
+	).toBe(false)
+	expect(
+		shouldUseViewTransition({
+			from: '/pricing',
+			to: '/community',
+			canStart: true,
+			prefersReducedMotion: true,
+		}),
+	).toBe(false)
+
+	const withRail = {
+		querySelector: (selector: string) =>
+			selector === persistentShellNavSelector ? ({} as Element) : null,
+	}
+	const withoutRail = { querySelector: () => null }
+	expect(documentHasPersistentShell(withRail)).toBe(true)
+	expect(documentHasPersistentShell(withoutRail)).toBe(false)
+	expect(documentHasPersistentShell(null)).toBe(false)
 })
 
 test('same-origin hash links are intercepted so scroll restoration can reach them', () => {

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -79,7 +79,10 @@ let activeNavigationPath: string | null = null
 // The pathname+search (no hash) the app last rendered. Popstate compares
 // against this to detect hash-only history moves, since `window.location`
 // has already changed by the time the event fires.
-let lastNotifiedDocumentPath: string | null = null
+let lastNotifiedDocumentPath: string | null =
+	typeof window === 'undefined'
+		? null
+		: `${window.location.pathname}${window.location.search}`
 
 function getCurrentDocumentPath() {
 	return `${window.location.pathname}${window.location.search}`
@@ -95,19 +98,67 @@ function getCurrentDocumentPath() {
  */
 const shellAreas = ['/account', '/admin']
 
+/** Live account/admin rail. Present only while a shell page is on screen. */
+export const persistentShellNavSelector = '[data-account-nav]'
+
 function isWithinArea(pathname: string, area: string) {
 	return pathname === area || pathname.startsWith(`${area}/`)
+}
+
+function pathnameOf(path: string) {
+	return path.split('?')[0] ?? ''
+}
+
+function isShellAreaPath(path: string) {
+	const pathname = pathnameOf(path)
+	return shellAreas.some((area) => isWithinArea(pathname, area))
 }
 
 /** Both paths may carry a search string; only the pathname decides the area. */
 export function isSameShellAreaNavigation(from: string | null, to: string) {
 	if (!from) return false
-	const fromPathname = from.split('?')[0] ?? ''
-	const toPathname = to.split('?')[0] ?? ''
 	return shellAreas.some(
 		(area) =>
-			isWithinArea(fromPathname, area) && isWithinArea(toPathname, area),
+			isWithinArea(pathnameOf(from), area) &&
+			isWithinArea(pathnameOf(to), area),
 	)
+}
+
+export function documentHasPersistentShell(
+	root: {
+		querySelector: (selector: string) => Element | null
+	} | null = typeof document === 'undefined' ? null : document,
+) {
+	return Boolean(root?.querySelector(persistentShellNavSelector))
+}
+
+/**
+ * View transitions are for real page changes. Tab switches inside a
+ * persistent shell stay instant — even when `from` was never recorded
+ * (first click after a full document load used to animate because
+ * `lastNotifiedDocumentPath` was still null).
+ */
+export function shouldUseViewTransition(input: {
+	from: string | null
+	to: string
+	canStart: boolean
+	prefersReducedMotion: boolean
+	hasPersistentShell?: boolean
+}) {
+	if (!input.canStart) return false
+	if (input.prefersReducedMotion) return false
+	if (input.from === input.to) return false
+	if (isSameShellAreaNavigation(input.from, input.to)) return false
+	// Full document load never recorded `from`. If the rail is already on
+	// screen and the destination is still a shell page, this is a tab click.
+	if (
+		input.from === null &&
+		input.hasPersistentShell &&
+		isShellAreaPath(input.to)
+	) {
+		return false
+	}
+	return true
 }
 
 function swapDom(onSwapped?: () => void) {
@@ -148,17 +199,16 @@ const viewTransitionScheduler = createViewTransitionScheduler(
 )
 
 function notify(onSwapped?: () => void) {
+	const to = getCurrentDocumentPath()
 	if (
-		!resolveViewTransitionStarter() ||
-		matchMedia('(prefers-reduced-motion: reduce)').matches ||
-		isSameShellAreaNavigation(
-			lastNotifiedDocumentPath,
-			getCurrentDocumentPath(),
-		) ||
-		// Hash-only moves stay on the same document. A view transition would
-		// snapshot the page and fight scroll restoration (the landing waitlist
-		// CTA is `#invite`).
-		getCurrentDocumentPath() === lastNotifiedDocumentPath
+		!shouldUseViewTransition({
+			from: lastNotifiedDocumentPath,
+			to,
+			canStart: Boolean(resolveViewTransitionStarter()),
+			prefersReducedMotion: matchMedia('(prefers-reduced-motion: reduce)')
+				.matches,
+			hasPersistentShell: documentHasPersistentShell(),
+		})
 	) {
 		// Instant path: drop any in-flight/queued VT so a superseded chain
 		// step cannot restart a transition after this swap.

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -353,11 +353,14 @@ export function AccountManagementLinkNav(
 				// The nav fills the shell's absolute left track (full height,
 				// so the sticky inner column has the whole page to stick
 				// through); below 860px it returns to flow as a wrapping row.
+				// Named so a view transition lifts it out of `<main>` / `page`
+				// and the rail stays still even if a transition still runs.
 				position: 'absolute',
 				left: pageGutter,
 				top: 0,
 				bottom: 0,
 				width: '200px',
+				viewTransitionName: 'account-nav',
 				[accountNavMq]: {
 					position: 'static',
 					width: 'auto',

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -468,24 +468,36 @@ html.is-settled {
 	}
 
 	/* SPA route transitions (View Transitions API). The router wraps the
-	   DOM swap in startViewTransition (client/client-router.tsx); chrome
-	   that persists across routes is lifted out of the root snapshot by
-	   view-transition-name and pinned static here. Browsers without the
-	   API never match these pseudos — the swap is simply instant. */
-	::view-transition-old(root) {
+	   DOM swap in startViewTransition (client/client-router.tsx). Motion
+	   lives on `page` (`<main>`), not `root` — otherwise the account rail
+	   (inside main, no name of its own until lifted) fades and slides with
+	   the content. Named chrome is pinned static. Browsers without the API
+	   never match these pseudos — the swap is simply instant. */
+	::view-transition-old(root),
+	::view-transition-new(root) {
+		animation: none;
+	}
+
+	::view-transition-old(page) {
 		animation: vt-page-out 120ms var(--ease-out) both;
 	}
 
-	::view-transition-new(root) {
+	::view-transition-new(page) {
 		animation: vt-page-in 220ms var(--ease-out) both;
 	}
 
 	::view-transition-old(site-header),
 	::view-transition-new(site-header),
+	::view-transition-group(site-header),
 	::view-transition-old(site-footer),
 	::view-transition-new(site-footer),
+	::view-transition-group(site-footer),
 	::view-transition-old(nav-progress),
-	::view-transition-new(nav-progress) {
+	::view-transition-new(nav-progress),
+	::view-transition-group(nav-progress),
+	::view-transition-old(account-nav),
+	::view-transition-new(account-nav),
+	::view-transition-group(account-nav) {
 		animation: none;
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Account tab clicks should swap instantly. Burhan recorded the whole shell fading and sliding ~8px on every `/account/*` click after the `kody.codes` move — the persistent rail bounced with the page.

## Summary

- Skip view transitions for shell tab switches even when `from` was never recorded (full document load left `lastNotifiedDocumentPath` null, so the path-only skip missed).
- If the account/admin rail is already on screen and the destination is still a shell page, treat it as a tab click.
- Move SPA motion off `root` onto `<main>` (`view-transition-name: page`).
- Pin the account rail (`account-nav`) and header/footer groups so chrome stays still if a transition still runs.
- Cover the unrecorded-`from` case in `client-router.node.test.ts`.

## Testing

- `npx vitest run packages/worker/client/client-router.node.test.ts`
- `npm run typecheck`
- Preview `https://kody-pr-1454.kody-a99.workers.dev`: signed in as seed user; `/account`, `/account/usage`, `/account/activity`, `/account/billing`, `/account/packages` all 200.
- UI pass on that preview: Usage → Activity → Billing → Usage → Packages → Jobs. Header and left rail stayed still; only main content swapped.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5817077a` · **Head:** `aed85e09`

**Classification:** extends — SPA view-transition skip and chrome pinning change how the browser app animates account/admin navigations.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — shell tab switches stay instant; page motion moves off `root` onto `<main>` |

### System map

Account rail clicks go through the client router. If the persistent shell is already on screen, the swap is instant; otherwise the page group animates and named chrome stays pinned.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	appUi -->|"shouldUseViewTransition skip"| appUi
	appUi -->|"view-transition-name page + account-nav"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Click as Account rail click
	participant Router as client-router
	participant DOM as Persistent rail
	Click->>Router: notify(from, to)
	Router->>DOM: query [data-account-nav]
	alt from is null and rail is on screen
		Router->>Router: instant swap (no startViewTransition)
	else same /account or /admin area
		Router->>Router: instant swap
	else real page change
		Router->>Router: startViewTransition on page group
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1df1977-85d2-4b56-9dc1-e247908a6375?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1df1977-85d2-4b56-9dc1-e247908a6375&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved page transitions during navigation with smoother content animations.
  * Kept persistent site and account navigation areas stable while pages change.
  * Avoided unnecessary transitions for same-page navigation and reduced-motion preferences.
  * Preserved account navigation positioning during transitions.

* **Bug Fixes**
  * Improved transition behavior when navigating within persistent account shells and across shell boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->