### PR TITLE
Sweep unused repo sessions after 30 minutes idle

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -512,7 +512,10 @@ Rules:
 
 - **Row-count limits** (saved packages, scheduled jobs, repo sessions, secrets,
   running package services) are counted via built-in counters in `service.ts`.
-  Most are counted directly from their source D1 tables. **Running package
+  Most are counted directly from their source D1 tables. **Repo sessions** count
+  `status = 'active'` rows. Unused (never-checkpointed) leftovers are swept
+  after 30 minutes idle; edited sessions after 7 days idle
+  (`repo_session_cleanup` lane, 100 rows per 5-minute tick). **Running package
   services** are counted from the **per-user UserMeter DO**:
   `countRunningPackageServices` counts `status = 'running'` rows with the 24h
   staleness window from DO `source_updated_at`. D1 `package_service_states`

--- a/docs/use/repo-sessions.md
+++ b/docs/use/repo-sessions.md
@@ -117,7 +117,11 @@ Use the other repo capabilities when you need more control over the session:
 - repair drift with `repo_rebase_session`
 
 If you find an active session you no longer need, pass its `id` as `session_id`
-to `repo_discard_session` to close it.
+to `repo_discard_session` to close it. One-shot package helpers that open a
+session to read or write should discard in a `finally` so leftovers do not
+accumulate against the `repo_sessions` entitlement. Unused (never-edited)
+sessions are swept after 30 minutes idle; sessions with unpublished edits are
+swept after 7 days idle.
 
 ### `repo_write_file` vs patches
 

--- a/packages/worker/src/entitlements/resource-visibility.ts
+++ b/packages/worker/src/entitlements/resource-visibility.ts
@@ -71,7 +71,7 @@ export const entitlementResourceVisibility: Record<
 		kind: 'counter',
 		whatCounts: 'Active editing sessions opened by agents against your repos.',
 		howToReduce:
-			'Discard finished sessions with repo_discard_session; idle sessions are cleaned up automatically after 7 days.',
+			'Discard finished sessions with repo_discard_session. Unused (never-edited) sessions are swept after 30 minutes idle; sessions with unpublished edits are swept after 7 days idle.',
 	},
 	email_sends_per_day: {
 		group: 'daily',

--- a/packages/worker/src/repo/repo-session-cleanup.node.test.ts
+++ b/packages/worker/src/repo/repo-session-cleanup.node.test.ts
@@ -35,7 +35,8 @@ test('repo session branch cleanup deletes expired and abandoned session branches
 		expect.anything(),
 		{
 			now: '2026-06-24T20:00:00.000Z',
-			abandonedBefore: '2026-06-17T20:00:00.000Z',
+			unusedAbandonedBefore: '2026-06-24T19:30:00.000Z',
+			editedAbandonedBefore: '2026-06-17T20:00:00.000Z',
 			limit: 10,
 		},
 	)

--- a/packages/worker/src/repo/repo-session-cleanup.ts
+++ b/packages/worker/src/repo/repo-session-cleanup.ts
@@ -2,15 +2,16 @@ import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { listRepoSessionsForBranchCleanup } from './repo-sessions.ts'
 import { repoSessionRpc } from './repo-session-do.ts'
 
-const defaultCleanupBatchSize = 50
+const defaultCleanupBatchSize = 100
 /**
- * Active sessions untouched for this long are considered abandoned and hard
- * deleted (branch + D1 row + DO workspace). Every session operation bumps
- * `updated_at`, so this is idle time, not age — but unpublished work in a
- * swept session is unrecoverable, so the window stays generous relative to
- * a working session's natural cadence.
+ * Read-only leftovers (never checkpointed) are cheap to lose — there is no
+ * unpublished work — so they sweep after a short idle window. Edited sessions
+ * keep the generous window because unpublished work in a swept session is
+ * unrecoverable. Every session operation bumps `updated_at`, so both windows
+ * are idle time, not age.
  */
-const abandonedSessionRetentionMs = 7 * 24 * 60 * 60 * 1000
+const unusedAbandonedSessionRetentionMs = 30 * 60 * 1000
+const editedAbandonedSessionRetentionMs = 7 * 24 * 60 * 60 * 1000
 
 export type RepoSessionBranchCleanupResult = {
 	checked: number
@@ -18,8 +19,8 @@ export type RepoSessionBranchCleanupResult = {
 	errors: number
 }
 
-function abandonedBeforeIso(now: Date) {
-	return new Date(now.valueOf() - abandonedSessionRetentionMs).toISOString()
+function abandonedBeforeIso(now: Date, retentionMs: number) {
+	return new Date(now.valueOf() - retentionMs).toISOString()
 }
 
 export async function cleanupRepoSessionBranches(input: {
@@ -30,7 +31,14 @@ export async function cleanupRepoSessionBranches(input: {
 	const now = input.now ?? new Date()
 	const sessions = await listRepoSessionsForBranchCleanup(input.env.APP_DB, {
 		now: now.toISOString(),
-		abandonedBefore: abandonedBeforeIso(now),
+		unusedAbandonedBefore: abandonedBeforeIso(
+			now,
+			unusedAbandonedSessionRetentionMs,
+		),
+		editedAbandonedBefore: abandonedBeforeIso(
+			now,
+			editedAbandonedSessionRetentionMs,
+		),
 		limit: input.batchSize ?? defaultCleanupBatchSize,
 	})
 	let deleted = 0

--- a/packages/worker/src/repo/repo-sessions.node.test.ts
+++ b/packages/worker/src/repo/repo-sessions.node.test.ts
@@ -1,0 +1,112 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { listRepoSessionsForBranchCleanup } from './repo-sessions.ts'
+
+function insertSession(
+	sqlite: DatabaseSync,
+	row: {
+		id: string
+		status: 'active' | 'published' | 'discarded'
+		updatedAt: string
+		lastCheckpointAt?: string | null
+		expiresAt?: string | null
+	},
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO repo_sessions (
+				id, user_id, source_id, source_repo_id, session_branch, source_branch,
+				base_commit, source_root, conversation_id, status, expires_at,
+				last_checkpoint_at, last_checkpoint_commit, last_check_run_id,
+				last_check_tree_hash, created_at, updated_at
+			) VALUES (?, 'user-1', 'source-1', 'repo-1', ?, 'main', 'commit', '/',
+				NULL, ?, ?, ?, NULL, NULL, NULL, ?, ?)`,
+		)
+		.run(
+			row.id,
+			`sessions/${row.id}`,
+			row.status,
+			row.expiresAt ?? null,
+			row.lastCheckpointAt ?? null,
+			row.updatedAt,
+			row.updatedAt,
+		)
+}
+
+test('branch cleanup selects unused leftovers sooner than edited sessions', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE repo_sessions (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			source_repo_id TEXT NOT NULL,
+			session_branch TEXT NOT NULL,
+			source_branch TEXT NOT NULL,
+			base_commit TEXT NOT NULL,
+			source_root TEXT NOT NULL DEFAULT '/',
+			conversation_id TEXT,
+			status TEXT NOT NULL DEFAULT 'active',
+			expires_at TEXT,
+			last_checkpoint_at TEXT,
+			last_checkpoint_commit TEXT,
+			last_check_run_id TEXT,
+			last_check_tree_hash TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+	`)
+	insertSession(sqlite, {
+		id: 'unused-stale',
+		status: 'active',
+		updatedAt: '2026-06-24T19:00:00.000Z',
+	})
+	insertSession(sqlite, {
+		id: 'unused-fresh',
+		status: 'active',
+		updatedAt: '2026-06-24T19:45:00.000Z',
+	})
+	insertSession(sqlite, {
+		id: 'edited-recent',
+		status: 'active',
+		updatedAt: '2026-06-20T20:00:00.000Z',
+		lastCheckpointAt: '2026-06-20T20:00:00.000Z',
+	})
+	insertSession(sqlite, {
+		id: 'edited-stale',
+		status: 'active',
+		updatedAt: '2026-06-16T20:00:00.000Z',
+		lastCheckpointAt: '2026-06-16T20:00:00.000Z',
+	})
+	insertSession(sqlite, {
+		id: 'published-expired',
+		status: 'published',
+		updatedAt: '2026-06-24T10:00:00.000Z',
+		lastCheckpointAt: '2026-06-24T10:00:00.000Z',
+		expiresAt: '2026-06-24T12:00:00.000Z',
+	})
+	insertSession(sqlite, {
+		id: 'published-live',
+		status: 'published',
+		updatedAt: '2026-06-24T10:00:00.000Z',
+		lastCheckpointAt: '2026-06-24T10:00:00.000Z',
+		expiresAt: '2026-06-25T12:00:00.000Z',
+	})
+
+	const selected = await listRepoSessionsForBranchCleanup(
+		createD1FromSqlite(sqlite),
+		{
+			now: '2026-06-24T20:00:00.000Z',
+			unusedAbandonedBefore: '2026-06-24T19:30:00.000Z',
+			editedAbandonedBefore: '2026-06-17T20:00:00.000Z',
+			limit: 10,
+		},
+	)
+
+	expect(selected.map((session) => session.id)).toEqual([
+		'edited-stale',
+		'published-expired',
+		'unused-stale',
+	])
+})

--- a/packages/worker/src/repo/repo-sessions.ts
+++ b/packages/worker/src/repo/repo-sessions.ts
@@ -175,7 +175,8 @@ export async function listRepoSessionsForBranchCleanup(
 	db: D1Database,
 	input: {
 		now: string
-		abandonedBefore: string
+		unusedAbandonedBefore: string
+		editedAbandonedBefore: string
 		limit: number
 	},
 ): Promise<Array<RepoSessionRow>> {
@@ -183,11 +184,17 @@ export async function listRepoSessionsForBranchCleanup(
 		.prepare(
 			`SELECT * FROM repo_sessions
 			WHERE (status IN ('published', 'discarded') AND expires_at IS NOT NULL AND expires_at <= ?)
-				OR (status = 'active' AND updated_at <= ?)
+				OR (status = 'active' AND last_checkpoint_at IS NULL AND updated_at <= ?)
+				OR (status = 'active' AND last_checkpoint_at IS NOT NULL AND updated_at <= ?)
 			ORDER BY updated_at ASC
 			LIMIT ?`,
 		)
-		.bind(input.now, input.abandonedBefore, input.limit)
+		.bind(
+			input.now,
+			input.unusedAbandonedBefore,
+			input.editedAbandonedBefore,
+			input.limit,
+		)
 		.all<Record<string, unknown>>()
 	return (results ?? []).map(mapRepoSessionRow)
 }

--- a/packages/worker/universal/plans.ts
+++ b/packages/worker/universal/plans.ts
@@ -237,8 +237,10 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxPackageServices: 1,
 		maxPersistentPackageServices: 0,
 		// Sessions are cheap (D1 row + dormant DO workspace + Artifacts
-		// branch) and the 7-day abandoned-session sweep keeps idle ones from
-		// accumulating; sized for a few agent conversations, not dozens.
+		// branch). Unused (never-checkpointed) leftovers sweep after 30
+		// minutes idle; edited sessions keep the 7-day window so unpublished
+		// work is not lost mid-conversation. Sized for a few agent
+		// conversations, not dozens.
 		maxRepoSessions: 15,
 		// notify-self and reply-to-stored only, so the outreach-abuse surface
 		// is small; a daily digest plus a few alerts should not hit the wall.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The 81% session-entitlement alert was leftover **active repo sessions**, not a too-low `max` plan. This change makes unused (never-edited) leftovers eligible for cleanup in 30 minutes instead of 7 days so one-shot readers cannot pin the `repo_sessions` counter for a week.

## Summary

- Confirmed the signed-in account is already on `max` (`repo_sessions` limit 20,000). Usage was ~16,500 active sessions (~82%), almost all against the plain `skills` repo.
- Root leak: `@kentcdodds/skills` opened a new session on every `skill_get` (and other one-shot helpers) and never discarded. That package is already published with `withSkillsRepoSession` discard-in-`finally`.
- Platform backstop: unused sessions (`last_checkpoint_at IS NULL`) now sweep after **30 minutes idle**; sessions with unpublished edits keep the **7-day** window. Cleanup batch size is 100 per 5-minute tick.
- Docs and account-usage copy describe the two windows.

## Testing

- `npm run test:node -- packages/worker/src/repo/repo-session-cleanup.node.test.ts packages/worker/src/repo/repo-sessions.node.test.ts` — pass
- `npm run docs:check-temporal` — pass
- Production: `usage_get` showed `plan: max`, `repo_sessions` 16485/20000 (82%). After publishing `@kentcdodds/skills`, `skill_get` discarded its session (~1.5s after open). Started an inline drain workflow for stale leftovers.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `dbaaeead` · **Head:** `37f3a7ac`

**Classification:** extends — unused active repo sessions become eligible for the existing cleanup lane after 30 minutes idle instead of 7 days.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — unused vs edited idle windows |
| `scheduled-cron` | surfaces | extends — cleanup query + batch 100 |
| `entitlements` | auth | composes — usage copy for `repo_sessions` |

### System map

The `repo_session_cleanup` cron lane selects abandoned `repo_sessions` rows from D1 and deletes their session branches. This PR splits that select into unused (30 minutes) and edited (7 days) idle windows.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::extended
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	entitlements["entitlements<br/>Plans and entitlements"]:::touched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	scheduledCron -->|"unused 30m / edited 7d select"| repoSessions
	repoSessions -->|"status=active count"| entitlements
	repoSessions -->|"repo_sessions rows"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Unused active session idle TTL | 7 days | 30 minutes |
| Edited active session idle TTL | 7 days | 7 days |
| Cleanup batch | 50 / 5 min | 100 / 5 min |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-364fb239-b80c-435f-aa7c-920a64be84d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-364fb239-b80c-435f-aa7c-920a64be84d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repo sessions now follow separate cleanup windows: 30 minutes for unused sessions and 7 days for sessions with unpublished edits.
  * Added guidance to explicitly discard one-shot sessions, including when cleanup is needed after failures.

* **Bug Fixes**
  * Improved cleanup selection to correctly identify expired unused and edited sessions.
  * Added coverage verifying cleanup behavior across session states and timestamps.

* **Documentation**
  * Updated session lifecycle, entitlement, and plan guidance to reflect the new retention rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->