### PR TITLE
fix(sentry): retry and filter Artifacts git HTTP 5xx

### DIFF
--- a/packages/worker/src/repo/artifact-file.node.test.ts
+++ b/packages/worker/src/repo/artifact-file.node.test.ts
@@ -83,4 +83,43 @@ test('reads binary artifact files from an exact pinned commit', async () => {
 			filepath: 'community-icon.png',
 		}),
 	)
+
+	const httpError = Object.assign(
+		new Error('HTTP Error: 500 Internal Server Error'),
+		{
+			code: 'HttpError',
+			name: 'HttpError',
+			data: {
+				statusCode: 500,
+				statusMessage: 'Internal Server Error',
+				response: '',
+			},
+		},
+	)
+	mocks.fetch.mockReset()
+	mocks.fetch.mockRejectedValueOnce(httpError).mockResolvedValueOnce(undefined)
+	mocks.readBlob.mockResolvedValue({ blob: bytes })
+	await expect(
+		readArtifactFileAtCommit({
+			env: {} as Env,
+			repoId: 'package-1',
+			commit: 'abc123',
+			filePath: 'community-icon.png',
+		}),
+	).resolves.toEqual(bytes)
+	expect(mocks.fetch).toHaveBeenCalledTimes(2)
+
+	mocks.fetch.mockReset()
+	mocks.fetch.mockRejectedValue(httpError)
+	await expect(
+		readArtifactFileAtCommit({
+			env: {} as Env,
+			repoId: 'package-1',
+			commit: 'abc123',
+			filePath: 'community-icon.png',
+		}),
+	).rejects.toThrow(
+		/Artifacts git fetch failed for https:\/\/artifacts\.example\.test\/package\.git: HTTP Error: 500 Internal Server Error/,
+	)
+	expect(mocks.fetch).toHaveBeenCalledTimes(3)
 })

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -7,6 +7,10 @@ import {
 	readMockArtifactSnapshot,
 	resolveExistingArtifactSourceRepo,
 } from './artifacts.ts'
+import {
+	runArtifactsGitWithRetry,
+	wrapArtifactsGitHttpError,
+} from './artifacts-git-retry.ts'
 import { createEphemeralGitWorkspace } from './ephemeral-git-workspace.ts'
 
 export async function readArtifactFileAtCommit(input: {
@@ -76,19 +80,29 @@ export async function readFirstArtifactFileAtCommit(input: {
 		remote: 'origin',
 		url: remote,
 	})
-	await git.fetch({
-		fs: workspace.fs,
-		http,
-		dir: workspace.dir,
-		remote: 'origin',
-		ref: input.commit,
-		depth: 1,
-		singleBranch: true,
-		tags: false,
-		onAuth() {
-			return auth
-		},
-	})
+	try {
+		await runArtifactsGitWithRetry(() =>
+			git.fetch({
+				fs: workspace.fs,
+				http,
+				dir: workspace.dir,
+				remote: 'origin',
+				ref: input.commit,
+				depth: 1,
+				singleBranch: true,
+				tags: false,
+				onAuth() {
+					return auth
+				},
+			}),
+		)
+	} catch (error) {
+		throw wrapArtifactsGitHttpError({
+			operation: 'git fetch',
+			remote: info.remote,
+			error,
+		})
+	}
 
 	for (const filePath of input.filePaths) {
 		try {

--- a/packages/worker/src/repo/artifacts-git-retry.node.test.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.node.test.ts
@@ -57,6 +57,16 @@ test('Artifacts git HTTP helpers classify transient statuses, wrap messages, and
 	).toBe(true)
 	expect(
 		isArtifactsGitTransientHttpErrorMessage(
+			'Artifacts listServerRefs failed for https://example.test: HTTP Error: 501 Not Implemented',
+		),
+	).toBe(false)
+	expect(
+		isArtifactsGitTransientHttpErrorMessage(
+			'Artifacts listServerRefs failed for https://example.test: HTTP Error: 505 HTTP Version Not Supported',
+		),
+	).toBe(false)
+	expect(
+		isArtifactsGitTransientHttpErrorMessage(
 			'HTTP Error: 500 Internal Server Error',
 		),
 	).toBe(false)
@@ -65,6 +75,18 @@ test('Artifacts git HTTP helpers classify transient statuses, wrap messages, and
 			'Artifacts listServerRefs failed for https://example.test: HTTP Error: 401 Unauthorized',
 		),
 	).toBe(false)
+
+	const wrappedWithQuery = wrapArtifactsGitHttpError({
+		operation: 'git fetch',
+		remote:
+			'https://x:secret@acct.artifacts.cloudflare.net/git/production/repo-1.git?token=should-not-leak#frag',
+		error: fiveHundred,
+	})
+	expect(wrappedWithQuery.message).toBe(
+		'Artifacts git fetch failed for https://acct.artifacts.cloudflare.net/git/production/repo-1.git: HTTP Error: 500 Internal Server Error',
+	)
+	expect(wrappedWithQuery.message).not.toContain('token=')
+	expect(wrappedWithQuery.message).not.toContain('secret')
 
 	const operation = vi
 		.fn()

--- a/packages/worker/src/repo/artifacts-git-retry.node.test.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.node.test.ts
@@ -8,8 +8,13 @@ import {
 	wrapArtifactsGitHttpError,
 } from './artifacts-git-retry.ts'
 
-function httpError(statusCode: number, statusMessage = 'Internal Server Error') {
-	const error = new Error(`HTTP Error: ${statusCode} ${statusMessage}`) as Error & {
+function httpError(
+	statusCode: number,
+	statusMessage = 'Internal Server Error',
+) {
+	const error = new Error(
+		`HTTP Error: ${statusCode} ${statusMessage}`,
+	) as Error & {
 		code: string
 		name: string
 		data: { statusCode: number; statusMessage: string; response: string }
@@ -36,7 +41,8 @@ test('Artifacts git HTTP helpers classify transient statuses, wrap messages, and
 
 	const wrapped = wrapArtifactsGitHttpError({
 		operation: 'listServerRefs',
-		remote: 'https://x:secret@acct.artifacts.cloudflare.net/git/production/repo-1.git',
+		remote:
+			'https://x:secret@acct.artifacts.cloudflare.net/git/production/repo-1.git',
 		error: fiveHundred,
 	})
 	expect(wrapped.message).toBe(

--- a/packages/worker/src/repo/artifacts-git-retry.node.test.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.node.test.ts
@@ -1,0 +1,85 @@
+import { expect, test, vi } from 'vitest'
+import {
+	getArtifactsGitHttpStatus,
+	isArtifactsGitTransientHttpErrorMessage,
+	isTransientArtifactsGitHttpError,
+	isTransientArtifactsGitHttpStatus,
+	runArtifactsGitWithRetry,
+	wrapArtifactsGitHttpError,
+} from './artifacts-git-retry.ts'
+
+function httpError(statusCode: number, statusMessage = 'Internal Server Error') {
+	const error = new Error(`HTTP Error: ${statusCode} ${statusMessage}`) as Error & {
+		code: string
+		name: string
+		data: { statusCode: number; statusMessage: string; response: string }
+	}
+	error.code = 'HttpError'
+	error.name = 'HttpError'
+	error.data = { statusCode, statusMessage, response: '' }
+	return error
+}
+
+test('Artifacts git HTTP helpers classify transient statuses, wrap messages, and retry then succeed', async () => {
+	expect(isTransientArtifactsGitHttpStatus(429)).toBe(true)
+	expect(isTransientArtifactsGitHttpStatus(500)).toBe(true)
+	expect(isTransientArtifactsGitHttpStatus(503)).toBe(true)
+	expect(isTransientArtifactsGitHttpStatus(400)).toBe(false)
+	expect(isTransientArtifactsGitHttpStatus(401)).toBe(false)
+
+	const fiveHundred = httpError(500)
+	expect(getArtifactsGitHttpStatus(fiveHundred)).toBe(500)
+	expect(isTransientArtifactsGitHttpError(fiveHundred)).toBe(true)
+	expect(isTransientArtifactsGitHttpError(httpError(401, 'Unauthorized'))).toBe(
+		false,
+	)
+
+	const wrapped = wrapArtifactsGitHttpError({
+		operation: 'listServerRefs',
+		remote: 'https://x:secret@acct.artifacts.cloudflare.net/git/production/repo-1.git',
+		error: fiveHundred,
+	})
+	expect(wrapped.message).toBe(
+		'Artifacts listServerRefs failed for https://acct.artifacts.cloudflare.net/git/production/repo-1.git: HTTP Error: 500 Internal Server Error',
+	)
+	expect(wrapped.cause).toBe(fiveHundred)
+	expect(isArtifactsGitTransientHttpErrorMessage(wrapped.message)).toBe(true)
+	expect(
+		isArtifactsGitTransientHttpErrorMessage(
+			'Artifacts git fetch failed for https://acct.artifacts.cloudflare.net/git/production/repo-1.git: HTTP Error: 502 Bad Gateway',
+		),
+	).toBe(true)
+	expect(
+		isArtifactsGitTransientHttpErrorMessage(
+			'HTTP Error: 500 Internal Server Error',
+		),
+	).toBe(false)
+	expect(
+		isArtifactsGitTransientHttpErrorMessage(
+			'Artifacts listServerRefs failed for https://example.test: HTTP Error: 401 Unauthorized',
+		),
+	).toBe(false)
+
+	const operation = vi
+		.fn()
+		.mockRejectedValueOnce(httpError(500))
+		.mockRejectedValueOnce(httpError(503))
+		.mockResolvedValueOnce([{ ref: 'refs/heads/main', oid: 'abc' }])
+
+	await expect(runArtifactsGitWithRetry(operation, [0, 0])).resolves.toEqual([
+		{ ref: 'refs/heads/main', oid: 'abc' },
+	])
+	expect(operation).toHaveBeenCalledTimes(3)
+
+	const authFailure = vi.fn().mockRejectedValue(httpError(401, 'Unauthorized'))
+	await expect(runArtifactsGitWithRetry(authFailure, [0, 0])).rejects.toThrow(
+		/HTTP Error: 401/,
+	)
+	expect(authFailure).toHaveBeenCalledTimes(1)
+
+	const persistent = vi.fn().mockRejectedValue(httpError(500))
+	await expect(runArtifactsGitWithRetry(persistent, [0, 0])).rejects.toThrow(
+		/HTTP Error: 500/,
+	)
+	expect(persistent).toHaveBeenCalledTimes(3)
+})

--- a/packages/worker/src/repo/artifacts-git-retry.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.ts
@@ -52,12 +52,17 @@ export function isTransientArtifactsGitHttpError(error: unknown) {
 
 /**
  * Stable wrapper phrases used by Artifacts git call sites and the Sentry
- * beforeSend filter. Keep these exact so triage filters stay narrow.
+ * beforeSend filter. Keep these exact so triage filters stay narrow, and keep
+ * the status set aligned with `isTransientArtifactsGitHttpStatus` so we do not
+ * drop un-retried failures (e.g. HTTP 501) from Sentry.
  */
 export function isArtifactsGitTransientHttpErrorMessage(message: string) {
-	return /Artifacts (?:listServerRefs|git fetch) failed for .+: HTTP Error: (?:429|5\d\d)\b/i.test(
-		message.trim(),
-	)
+	const match =
+		/Artifacts (?:listServerRefs|git fetch) failed for .+: HTTP Error: (\d{3})\b/i.exec(
+			message.trim(),
+		)
+	if (!match?.[1]) return false
+	return isTransientArtifactsGitHttpStatus(Number(match[1]))
 }
 
 function describeArtifactRemote(remote: string) {
@@ -65,6 +70,8 @@ function describeArtifactRemote(remote: string) {
 		const url = new URL(remote)
 		url.username = ''
 		url.password = ''
+		url.search = ''
+		url.hash = ''
 		return url.toString()
 	} catch {
 		return 'unparseable-remote'

--- a/packages/worker/src/repo/artifacts-git-retry.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.ts
@@ -1,0 +1,110 @@
+import {
+	getErrorCauseChain,
+	getErrorMessage,
+} from '@kody-internal/shared/error-message.ts'
+
+/**
+ * Cloudflare Artifacts git protocol (`info/refs`, upload-pack) occasionally
+ * returns 5xx / 429 after REST createToken + repo info already succeeded
+ * (KODY-CLOUDFLARE-4Y / 4Z / 50). Short retries paper over the blip without
+ * treating it as an application defect.
+ */
+export const artifactsGitHttpRetryDelaysMs = [50, 150] as const
+
+export function isTransientArtifactsGitHttpStatus(status: number) {
+	return (
+		status === 429 ||
+		status === 500 ||
+		status === 502 ||
+		status === 503 ||
+		status === 504
+	)
+}
+
+function readHttpStatusFromErrorData(error: unknown): number | null {
+	if (!error || typeof error !== 'object' || !('data' in error)) return null
+	const data = (error as { data?: { statusCode?: unknown } }).data
+	return data && typeof data.statusCode === 'number' ? data.statusCode : null
+}
+
+function readHttpStatusFromMessage(message: string): number | null {
+	const match = /HTTP Error: (\d{3})\b/i.exec(message)
+	if (!match?.[1]) return null
+	return Number(match[1])
+}
+
+export function getArtifactsGitHttpStatus(error: unknown): number | null {
+	for (const entry of getErrorCauseChain(error)) {
+		const fromData = readHttpStatusFromErrorData(entry)
+		if (fromData != null) return fromData
+		if (entry instanceof Error) {
+			const fromMessage = readHttpStatusFromMessage(entry.message)
+			if (fromMessage != null) return fromMessage
+		}
+	}
+	return null
+}
+
+export function isTransientArtifactsGitHttpError(error: unknown) {
+	const status = getArtifactsGitHttpStatus(error)
+	return status != null && isTransientArtifactsGitHttpStatus(status)
+}
+
+/**
+ * Stable wrapper phrases used by Artifacts git call sites and the Sentry
+ * beforeSend filter. Keep these exact so triage filters stay narrow.
+ */
+export function isArtifactsGitTransientHttpErrorMessage(message: string) {
+	return /Artifacts (?:listServerRefs|git fetch) failed for .+: HTTP Error: (?:429|5\d\d)\b/i.test(
+		message.trim(),
+	)
+}
+
+function describeArtifactRemote(remote: string) {
+	try {
+		const url = new URL(remote)
+		url.username = ''
+		url.password = ''
+		return url.toString()
+	} catch {
+		return 'unparseable-remote'
+	}
+}
+
+export function wrapArtifactsGitHttpError(input: {
+	operation: 'listServerRefs' | 'git fetch'
+	remote: string
+	error: unknown
+}) {
+	return new Error(
+		`Artifacts ${input.operation} failed for ${describeArtifactRemote(input.remote)}: ${getErrorMessage(input.error)}`,
+		{ cause: input.error },
+	)
+}
+
+function waitForArtifactsGitRetry(delayMs: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+}
+
+export async function runArtifactsGitWithRetry<T>(
+	operation: () => Promise<T>,
+	delaysMs: ReadonlyArray<number> = artifactsGitHttpRetryDelaysMs,
+): Promise<T> {
+	let lastError: unknown
+	const maxAttempts = delaysMs.length + 1
+	for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+		try {
+			return await operation()
+		} catch (error) {
+			lastError = error
+			const canRetry =
+				isTransientArtifactsGitHttpError(error) && attempt < maxAttempts - 1
+			if (!canRetry) throw error
+			const delayMs = delaysMs[attempt]
+			if (delayMs !== undefined && delayMs > 0) {
+				await waitForArtifactsGitRetry(delayMs)
+			}
+		}
+	}
+	throw lastError ?? new Error('Artifacts git operation failed after retries')
+}

--- a/packages/worker/src/repo/artifacts.node.test.ts
+++ b/packages/worker/src/repo/artifacts.node.test.ts
@@ -529,6 +529,43 @@ test('resolveArtifactDefaultBranchHead reuses a provided token and still works w
 		'Artifacts createToken result is missing plaintext.',
 	)
 	expect(gitMocks.listServerRefs).toHaveBeenCalledTimes(1)
+
+	const httpError = Object.assign(
+		new Error('HTTP Error: 500 Internal Server Error'),
+		{
+			code: 'HttpError',
+			name: 'HttpError',
+			data: {
+				statusCode: 500,
+				statusMessage: 'Internal Server Error',
+				response: '',
+			},
+		},
+	)
+	gitMocks.listServerRefs.mockReset()
+	gitMocks.listServerRefs
+		.mockRejectedValueOnce(httpError)
+		.mockResolvedValueOnce([{ ref: 'refs/heads/main', oid: 'retried-oid' }])
+	createToken.mockReset()
+	createToken.mockResolvedValue({
+		id: 'tok_read',
+		plaintext: 'art_v1_throwaway',
+		scope: 'read',
+		expiresAt: '2026-10-09T08:55:00.000Z',
+	})
+	await expect(resolveArtifactDefaultBranchHead({ repo })).resolves.toEqual({
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/repo-1.git',
+		defaultBranch: 'main',
+		commit: 'retried-oid',
+	})
+	expect(gitMocks.listServerRefs).toHaveBeenCalledTimes(2)
+
+	gitMocks.listServerRefs.mockReset()
+	gitMocks.listServerRefs.mockRejectedValue(httpError)
+	await expect(resolveArtifactDefaultBranchHead({ repo })).rejects.toThrow(
+		/Artifacts listServerRefs failed for https:\/\/acct\.artifacts\.cloudflare\.net\/git\/default\/repo-1\.git: HTTP Error: 500 Internal Server Error/,
+	)
+	expect(gitMocks.listServerRefs).toHaveBeenCalledTimes(3)
 })
 
 test('native createToken maps token when JSRPC omits plaintext', async () => {

--- a/packages/worker/src/repo/artifacts.ts
+++ b/packages/worker/src/repo/artifacts.ts
@@ -5,6 +5,10 @@ import {
 } from '#mcp/cloudflare/cloudflare-rest-client.ts'
 import git from 'isomorphic-git'
 import http from 'isomorphic-git/http/web'
+import {
+	runArtifactsGitWithRetry,
+	wrapArtifactsGitHttpError,
+} from './artifacts-git-retry.ts'
 import { type EntityKind } from './types.ts'
 
 export type ArtifactToken = {
@@ -767,17 +771,6 @@ export function buildAuthenticatedArtifactsRemote(input: {
 	return remoteUrl.toString()
 }
 
-function describeArtifactRemote(remote: string) {
-	try {
-		const url = new URL(remote)
-		url.username = ''
-		url.password = ''
-		return url.toString()
-	} catch {
-		return 'unparseable-remote'
-	}
-}
-
 export async function listArtifactServerRefs(input: {
 	remote: string
 	token: string
@@ -789,12 +782,14 @@ export async function listArtifactServerRefs(input: {
 		remote: input.remote,
 		token: input.token,
 	})
-	return git.listServerRefs({
-		http,
-		url,
-		prefix: input.prefix,
-		symrefs: true,
-	})
+	return runArtifactsGitWithRetry(() =>
+		git.listServerRefs({
+			http,
+			url,
+			prefix: input.prefix,
+			symrefs: true,
+		}),
+	)
 }
 
 export async function resolveArtifactDefaultBranchHead(input: {
@@ -823,10 +818,11 @@ export async function resolveArtifactDefaultBranchHead(input: {
 			prefix: refName,
 		})
 	} catch (error) {
-		throw new Error(
-			`Artifacts listServerRefs failed for ${describeArtifactRemote(info.remote)}: ${getErrorMessage(error)}`,
-			{ cause: error },
-		)
+		throw wrapArtifactsGitHttpError({
+			operation: 'listServerRefs',
+			remote: info.remote,
+			error,
+		})
 	}
 	const branchRef = refs.find((ref) => ref.ref === refName)
 	if (!branchRef?.oid) {

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -173,6 +173,19 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 			},
 		}),
 	).toBeNull()
+	const artifactsGitNotImplemented = {
+		exception: {
+			values: [
+				{
+					value:
+						'Artifacts listServerRefs failed for https://acct.artifacts.cloudflare.net/git/production/repo-1.git: HTTP Error: 501 Not Implemented',
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(artifactsGitNotImplemented)).toBe(
+		artifactsGitNotImplemented,
+	)
 	const bareArtifactsGitHttpError = {
 		exception: {
 			values: [{ value: 'HTTP Error: 500 Internal Server Error' }],

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -147,6 +147,54 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	}
 	expect(filterSentryEvent(wrappedOpaqueInternal)).toBe(wrappedOpaqueInternal)
 
+	// Artifacts git protocol HTTP 5xx / 429 wrappers (KODY-CLOUDFLARE-4Y / 4Z /
+	// 50). Bare isomorphic-git HttpError stays visible; non-5xx wrappers too.
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Artifacts listServerRefs failed for https://acct.artifacts.cloudflare.net/git/production/repo-1.git: HTTP Error: 500 Internal Server Error',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Artifacts git fetch failed for https://acct.artifacts.cloudflare.net/git/production/repo-1.git: HTTP Error: 503 Service Unavailable',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	const bareArtifactsGitHttpError = {
+		exception: {
+			values: [{ value: 'HTTP Error: 500 Internal Server Error' }],
+		},
+	}
+	expect(filterSentryEvent(bareArtifactsGitHttpError)).toBe(
+		bareArtifactsGitHttpError,
+	)
+	const artifactsGitAuthFailure = {
+		exception: {
+			values: [
+				{
+					value:
+						'Artifacts listServerRefs failed for https://acct.artifacts.cloudflare.net/git/production/repo-1.git: HTTP Error: 401 Unauthorized',
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(artifactsGitAuthFailure)).toBe(
+		artifactsGitAuthFailure,
+	)
+
 	// Bare Agents MCP session teardown abort (`ctx.abort("destroyed")`) —
 	// KODY-CLOUDFLARE-4K. Wrapped "stream was destroyed" forms stay visible.
 	expect(

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -1,10 +1,11 @@
 import { type CloudflareOptions } from '@sentry/cloudflare'
 import { type ErrorEvent, type EventHint } from '@sentry/core'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
-import { isEntitlementLimitError } from './entitlements/errors.ts'
 import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
+import { isEntitlementLimitError } from './entitlements/errors.ts'
 import { isIntegrationTokenRefreshCallerMessage } from './integrations/token-refresh.ts'
 import { isRemoteConnectorUnavailableMessage } from './remote-connector/status.ts'
+import { isArtifactsGitTransientHttpErrorMessage } from './repo/artifacts-git-retry.ts'
 import { isUserCodeError } from './user-code-error.ts'
 
 function sentryEventMessages(event: ErrorEvent) {
@@ -345,6 +346,28 @@ export function filterCloudflareOpaqueInternalErrorSentryEvent(
 }
 
 /**
+ * Cloudflare Artifacts git protocol HTTP 5xx / 429 after REST auth already
+ * succeeded (KODY-CLOUDFLARE-4Y / 4Z / 50). Call sites retry briefly; exhausted
+ * failures keep the stable `Artifacts listServerRefs|git fetch failed for …:
+ * HTTP Error: NNN` wrapper so this beforeSend gate can drop platform blips
+ * without swallowing unrelated HTTP errors.
+ */
+export function isArtifactsGitTransientHttpErrorSentryEvent(event: ErrorEvent) {
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isArtifactsGitTransientHttpErrorMessage(message),
+	)
+}
+
+export function filterArtifactsGitTransientHttpErrorSentryEvent(
+	event: ErrorEvent,
+) {
+	if (!isArtifactsGitTransientHttpErrorSentryEvent(event)) return event
+	return null
+}
+
+/**
  * Bare Durable Object abort reason from Cloudflare Agents MCP session
  * teardown (`ctx.abort("destroyed")` inside `Agent.destroy()` /
  * `_cf_scheduleDestroy`). Observed on `/mcp` when a Streamable-HTTP client
@@ -402,6 +425,8 @@ export function filterSentryEvent(event: ErrorEvent, hint?: EventHint) {
 	if (filterDurableObjectIsolateResetSentryEvent(event) === null) return null
 	if (filterCloudflareOpaqueInternalErrorSentryEvent(event) === null)
 		return null
+	if (filterArtifactsGitTransientHttpErrorSentryEvent(event) === null)
+		return null
 	if (filterMcpAgentSessionDestroyedAbortSentryEvent(event) === null)
 		return null
 	return event
@@ -453,6 +478,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// Exact opaque Cloudflare "An internal error occurred." (and Artifacts
 		// INTERNAL_ERROR wording) with no support reference are dropped the
 		// same way — see filterCloudflareOpaqueInternalErrorSentryEvent.
+		// Artifacts git protocol HTTP 5xx / 429 wrappers (listServerRefs /
+		// git fetch) are dropped the same way after brief call-site retries —
+		// see filterArtifactsGitTransientHttpErrorSentryEvent.
 		// Bare Durable Object abort token `destroyed` from Agents MCP session
 		// teardown (`ctx.abort("destroyed")`) is dropped the same way — see
 		// filterMcpAgentSessionDestroyedAbortSentryEvent.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare Artifacts git-protocol HTTP 5xx / 429 blips from failing MCP repo reads and flooding Sentry (KODY-CLOUDFLARE-4Y, 4Z, 50).

## Summary

- Add short retries for transient Artifacts git HTTP statuses (`429` / `5xx`) around `listServerRefs` and shallow `git.fetch`.
- Keep the stable `Artifacts listServerRefs|git fetch failed for …: HTTP Error: NNN` wrappers (credentials + query/hash redacted).
- Drop those wrapper messages in `beforeSend` so exhausted platform blips do not open triage issues; bare / non-retryable HTTP errors stay visible.
- Siblings: KODY-CLOUDFLARE-4Z (same `listServerRefs` 500), KODY-CLOUDFLARE-50 (`git.fetch` 500 via `readFirstArtifactFileAtCommit`).

## Testing

- `npm run test:node -- packages/worker/src/repo/artifacts-git-retry.node.test.ts packages/worker/src/repo/artifacts.node.test.ts packages/worker/src/repo/artifact-file.node.test.ts packages/worker/src/sentry-options.node.test.ts` — passed
- CI on PR head — all required checks green (Static, Node, Workers, MCP, E2E, Validate, Bugbot)
- `npm run preview:manual-test -- --pr 1456 --no-wait` — health/login/session smoke on preview
- Production deploy after squash-merge — success (`a2c08085`)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** merged as `a2c08085`

**Classification:** extends — Artifacts git discovery/fetch now retries transient HTTP 5xx/429; Sentry drops the stable exhausted-wrapper messages.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `artifacts-repos` | storage | extends — brief retry + stable error wrappers on git protocol calls |
| `repo-sessions` | runtime | composes — `artifact-file` fetch path uses the shared retry helper |

### System map

Artifacts REST auth still succeeds; only the git `info/refs` / upload-pack path retries and is filtered when it still fails.

**Legend:** green = composes (wiring only) · amber = extended by this PR · gray = context.

```mermaid
flowchart LR
	repoGet["repo_get / repo_open_session"]:::untouched
	artifactsGit["artifacts-repos<br/>listServerRefs / git fetch"]:::extended
	sentry["sentry beforeSend"]:::touched
	repoGet --> artifactsGit
	artifactsGit -->|"exhausted 5xx wrapper"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Before:** single Artifacts git HTTP 500 → MCP failure + Sentry issue.

**After:** up to 3 attempts with short backoff; exhausted failures still surface to the caller but are dropped from Sentry when they match the Artifacts wrapper signature.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9621c551-dc8f-4221-beab-8e2b0ca598fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9621c551-dc8f-4221-beab-8e2b0ca598fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git-based artifact operations now automatically retry transient HTTP failures, including server errors and rate limits.
  * Authentication and other non-transient failures are reported immediately with clearer repository context.
  * Persistent failures preserve the original error details after retries are exhausted.
  * Transient artifact Git errors are filtered from error monitoring to reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->