### PR TITLE
fix: stop guide markdown twin links from 404ing in the SPA

### DIFF
--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -8,6 +8,7 @@ import {
 	listenToRouterNavigation,
 	listenToRouterNavigationEnd,
 	navigate,
+	registerClientRoutes,
 	registerRouteLoaders,
 	Router,
 } from './client-router.tsx'
@@ -34,6 +35,7 @@ import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
 import { WaitlistBanner } from './waitlist-banner.tsx'
 
 registerRouteLoaders(clientRouteLoaders)
+registerClientRoutes(clientRoutes)
 
 type AppProps = {
 	embeddedSession?: SessionInfo | null

--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -7,13 +7,17 @@ import {
 	navigate,
 	navigationTimeoutMs,
 	persistentShellNavSelector,
+	registerClientRoutes,
 	registerRouteLoaders,
 	Router,
+	shouldLeaveDocumentForPath,
 	shouldRouterHandleClick,
 	shouldUseViewTransition,
 	type RouteLoader,
 } from './client-router.tsx'
 import { communityArea } from './lazy-route.tsx'
+import { routePattern } from '#universal/route-pattern.ts'
+import { routes } from '#universal/routes.ts'
 
 test('client route and loader matching prefer specific static routes over dynamic parents', () => {
 	const tokenDetailRoute = 'token-detail-route' as unknown as JSX.Element
@@ -233,6 +237,84 @@ test('same-origin hash links are intercepted so scroll restoration can reach the
 		} as unknown as HTMLAnchorElement
 		expect(shouldRouterHandleClick(click, remixFrameAnchor)).toBe(false)
 	} finally {
+		globalThis.window = previousWindow
+	}
+})
+
+test('guide and blog markdown twins leave the SPA instead of rendering a 404', () => {
+	const guidePage = 'guide-page' as unknown as JSX.Element
+	const blogPage = 'blog-page' as unknown as JSX.Element
+	const pageRoutes = {
+		[routePattern(routes.guideDetail)]: guidePage,
+		[routePattern(routes.blogPost)]: blogPage,
+		[routePattern(routes.guides)]: guidePage,
+		[routePattern(routes.home)]: guidePage,
+	}
+
+	expect(matchRoute('/guides/oauth', pageRoutes)).toBe(guidePage)
+	expect(matchRoute('/guides/oauth.md', pageRoutes)).toBeNull()
+	expect(matchRoute('/guides/oauth.json', pageRoutes)).toBeNull()
+	expect(matchRoute('/blog/your-assistants-home.md', pageRoutes)).toBeNull()
+	expect(routes.guideDetailMarkdown.href({ slug: 'oauth' })).toBe(
+		'/guides/oauth.md',
+	)
+
+	registerClientRoutes(pageRoutes)
+	const previousWindow = globalThis.window
+	const assign = vi.fn<() => void>()
+	globalThis.window = {
+		location: {
+			href: 'https://kody.local/guides/oauth',
+			origin: 'https://kody.local',
+			pathname: '/guides/oauth',
+			search: '',
+			hash: '',
+			assign,
+		},
+	} as unknown as Window & typeof globalThis
+
+	try {
+		expect(shouldLeaveDocumentForPath('/guides/oauth')).toBe(false)
+		expect(shouldLeaveDocumentForPath('/guides/oauth.md')).toBe(true)
+		expect(shouldLeaveDocumentForPath('/guides.md')).toBe(true)
+		expect(shouldLeaveDocumentForPath('/missing-page')).toBe(true)
+
+		const click = {
+			defaultPrevented: false,
+			button: 0,
+			metaKey: false,
+			altKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+		} as MouseEvent
+		const markdownAnchor = {
+			target: '',
+			hasAttribute: () => false,
+			getAttribute: (name: string) =>
+				name === 'href' ? '/guides/oauth.md' : null,
+		} as unknown as HTMLAnchorElement
+		expect(shouldRouterHandleClick(click, markdownAnchor)).toBe(false)
+
+		const documentAnchor = {
+			target: '',
+			hasAttribute: (name: string) => name === 'rmx-document',
+			getAttribute: (name: string) =>
+				name === 'href' ? '/guides/oauth.md' : null,
+		} as unknown as HTMLAnchorElement
+		expect(shouldRouterHandleClick(click, documentAnchor)).toBe(false)
+
+		const pageAnchor = {
+			target: '',
+			hasAttribute: () => false,
+			getAttribute: (name: string) =>
+				name === 'href' ? '/guides/oauth' : null,
+		} as unknown as HTMLAnchorElement
+		expect(shouldRouterHandleClick(click, pageAnchor)).toBe(true)
+
+		navigate('/guides/how-kody-works.md')
+		expect(assign).toHaveBeenCalledWith('/guides/how-kody-works.md')
+	} finally {
+		registerClientRoutes({})
 		globalThis.window = previousWindow
 	}
 })

--- a/packages/worker/client/client-router.tsx
+++ b/packages/worker/client/client-router.tsx
@@ -290,6 +290,31 @@ export function registerRouteLoaders(loaders: Record<string, RouteLoader>) {
 	loaderMatchers.delete(loaders)
 }
 
+let registeredClientRoutes: Record<string, JSX.Element> = {}
+let clientRoutesRegistered = false
+
+/**
+ * Page-route registry used to decide whether a same-origin click should stay
+ * in the SPA. Companion documents (`/guides/:slug.md`, `/blog/rss.xml`) are
+ * not registered here — the worker serves those as raw responses.
+ */
+export function registerClientRoutes(routes: Record<string, JSX.Element>) {
+	registeredClientRoutes = routes
+	clientRoutesRegistered = Object.keys(routes).length > 0
+	routeMatchers.delete(routes)
+}
+
+/**
+ * True when this pathname is not a client-rendered page, so the browser
+ * should leave the SPA (markdown twins, JSON companions, RSS, 404s the
+ * worker owns). With no registry yet, assume every path is in-app so unit
+ * tests that never register routes keep the historical intercept behavior.
+ */
+export function shouldLeaveDocumentForPath(pathname: string) {
+	if (!clientRoutesRegistered) return false
+	return matchRoute(pathname, registeredClientRoutes) === null
+}
+
 export function matchRouteLoader(
 	path: string | URL,
 	loaders: Record<string, RouteLoader> = registeredRouteLoaders,
@@ -345,6 +370,7 @@ export function shouldRouterHandleClick(
 
 	const destination = new URL(href, window.location.href)
 	if (destination.origin !== window.location.origin) return false
+	if (shouldLeaveDocumentForPath(destination.pathname)) return false
 	return true
 }
 
@@ -381,6 +407,7 @@ function getPrefetchableLink(
 
 	const destination = new URL(href, window.location.href)
 	if (destination.origin !== window.location.origin) return null
+	if (shouldLeaveDocumentForPath(destination.pathname)) return null
 	if (
 		`${destination.pathname}${destination.search}` ===
 		`${window.location.pathname}${window.location.search}`
@@ -996,6 +1023,10 @@ async function navigateInternal(to: string, options?: NavigationRunOptions) {
 	const destination = new URL(to, window.location.href)
 	if (destination.origin !== window.location.origin) {
 		window.location.assign(destination.toString())
+		return
+	}
+	if (shouldLeaveDocumentForPath(destination.pathname)) {
+		window.location.assign(getPathWithSearchAndHashFromUrl(destination))
 		return
 	}
 

--- a/packages/worker/client/routes/guide-detail.tsx
+++ b/packages/worker/client/routes/guide-detail.tsx
@@ -36,7 +36,8 @@ const interactiveGuideRenderers: Readonly<
  * first-party link policy (guides link into `/connect/oauth` and
  * `/account/secrets/new`) and copyable code blocks. Interactive slugs
  * (how-kody-works, google-oauth) swap the prose body for a transcript
- * walkthrough. A quiet foot links the raw markdown twin for agents.
+ * walkthrough. A quiet foot links the raw markdown twin for agents
+ * (`rmx-document` so the SPA does not intercept `/guides/:slug.md`).
  */
 
 export function getGuideSlugFromPathname(pathname: string) {
@@ -268,7 +269,10 @@ export function GuideDetailRoute(handle: Handle) {
 						<footer mix={css(guideFootCss)}>
 							<p>
 								Working with an agent? This guide is also plain markdown at{' '}
-								<a href={routes.guideDetailMarkdown.href({ slug: guide.slug })}>
+								<a
+									href={routes.guideDetailMarkdown.href({ slug: guide.slug })}
+									rmx-document
+								>
 									/guides/{guide.slug}.md
 								</a>
 								, or load it over MCP with{' '}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Clicking the “plain markdown” footer on a guide (`/guides/<slug>.md`) should serve the worker’s raw markdown twin, not the in-app 404 page.

## Summary

- The guide footer already pointed at the correct worker route. The SPA intercepted that same-origin click, failed to match `/guides/:slug` (dots are delimiters), and rendered the 404 fallback.
- Register client page routes and skip SPA intercept, prefetch, and `navigate()` when the destination is not a rendered page. The browser then loads the markdown (or the worker’s real 404).
- Mark the footer link with `rmx-document` so Remix treats it as a document navigation even before the registry is consulted.

## Testing

- `npx vitest run --project node-unit` on `client-router.node.test.ts`, `client-router-recovery.node.test.ts`, `guides.node.test.ts`, and `router-specificity.node.test.ts`: **11 passed**.
- `npx tsc -b packages/worker/tsconfig-client.json --noEmit`: **clean**.
- Preview `https://kody-pr-1459.kody-a99.workers.dev` (signed in as `me@kentcdodds.com`):
  - `GET /guides/oauth`, `/guides/oauth.md`, `/guides/how-kody-works` all 200
  - UI: from `/guides/oauth`, click `/guides/oauth.md` → raw markdown (`# OAuth guide`), not the in-app 404
  - Same for `/guides/how-kody-works.md`

![Guide footer markdown link before click](https://cursor.com/artifacts/c/art-4dad6d81-7360-4a7c-b805-d67307838d28)
![Raw markdown after clicking the footer link](https://cursor.com/artifacts/c/art-69d91b7a-86e9-4685-8a1a-818413c52b00)
<a href="https://cursor.com/agents/bc-805065fb-62b4-47dc-80e9-be71217153a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fguide_markdown_footer_click.mp4"><img src="https://cursor.com/artifacts/c/art-8187a6c5-9eb0-4e30-b12b-ea49cacc8f3f" alt="guide_markdown_footer_click.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ebb6040b` · **Head:** `2105b949`

**Classification:** extends — client-router intercept contract now leaves the document for paths that are not registered page routes.

### Primitives touched

| Primitive | Group    | Impact                                                             |
| --------- | -------- | ------------------------------------------------------------------ |
| `app-ui`  | surfaces | extends — SPA clicks/navigations to worker documents no longer 404 |

### System map

Guide markdown twins are worker documents. The SPA must not claim those URLs.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appUi -->|"click /guides/:slug.md leaves SPA"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant SPA as Client router
	participant Worker as Guide markdown handler
	User->>SPA: click /guides/oauth.md
	SPA-->>User: no page route (skip intercept)
	User->>Worker: full document GET
	Worker-->>User: 200 text/markdown
```

### Before / after

```
Before: click /guides/oauth.md → SPA 404 fallback
After:  click /guides/oauth.md → worker markdown twin
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-805065fb-62b4-47dc-80e9-be71217153a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-805065fb-62b4-47dc-80e9-be71217153a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation handling for documentation and blog Markdown links, ensuring they open with full-page navigation.
  * Regular application pages continue to use fast in-app routing.
  * Updated raw Markdown links to bypass SPA navigation when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->