### PR TITLE
Require an inbound CLA for external contributions

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -2,7 +2,7 @@
 	"version": 1,
 	"document": "docs/legal/individual-cla.md",
 	"allowlist": {
-		"github": ["kentcdodds"],
+		"github": ["kentcdodds", "kody-bot"],
 		"email": ["me@kentcdodds.com", "me+github@kentcdodds.com"]
 	},
 	"signers": []

--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -1,0 +1,9 @@
+{
+	"version": 1,
+	"document": "docs/legal/individual-cla.md",
+	"allowlist": {
+		"github": ["kentcdodds"],
+		"email": ["me@kentcdodds.com", "me+github@kentcdodds.com"]
+	},
+	"signers": []
+}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,127 @@
+name: CLA
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    name: CLA
+    timeout-minutes: 5
+    steps:
+      - name: Checkout base
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: Collect identities
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const identities = [
+              {
+                githubLogin: context.payload.pull_request.user.login,
+                name: context.payload.pull_request.user.login,
+                email: null,
+              },
+            ]
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              },
+            )
+            for (const commit of commits) {
+              identities.push({
+                githubLogin: commit.author?.login ?? null,
+                name: commit.commit.author?.name ?? null,
+                email: commit.commit.author?.email ?? null,
+              })
+            }
+            const fs = await import('node:fs/promises')
+            await fs.writeFile(
+              'cla-identities.json',
+              `${JSON.stringify(identities, null, '\t')}\n`,
+            )
+
+      - name: Check CLA
+        id: check
+        run: |
+          if [ ! -f tools/ci/check-cla.ts ] || [ ! -f .github/cla-signers.json ]; then
+            echo "CLA checker is not on the base branch yet."
+            exit 0
+          fi
+          set +e
+          node tools/ci/check-cla.ts \
+            --signers .github/cla-signers.json \
+            --identities-json cla-identities.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          if [ "$code" -ne 0 ] && [ "$code" -ne 1 ]; then
+            exit "$code"
+          fi
+
+      - name: Comment when unsigned
+        if: steps.check.outputs.exit_code == '1'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const marker = '<!-- kody-cla-check -->'
+            const body = `${marker}
+            Unsigned contributions cannot merge.
+
+            1. Read the [Individual CLA](https://github.com/${{ github.repository }}/blob/main/docs/legal/individual-cla.md) (or the [Entity CLA](https://github.com/${{ github.repository }}/blob/main/docs/legal/entity-cla.md) if an organization owns the work).
+            2. Comment exactly: \`I have read the CLA and I hereby sign the CLA\`
+            3. A maintainer records your GitHub username on \`main\`. See [Inbound contributions](https://github.com/${{ github.repository }}/blob/main/docs/contributing/inbound-contributions.md).
+
+            Adding your own username on this branch does not pass the check.`
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                per_page: 100,
+              },
+            )
+            const existing = comments.find((comment) =>
+              comment.body?.includes(marker),
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              })
+            }
+
+      - name: Fail when unsigned
+        if: steps.check.outputs.exit_code == '1'
+        run: exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+This repository is Fair Source ([FSL-1.1-ALv2](./LICENSE)). Outside pull
+requests need a signed inbound Contributor License Agreement. You keep
+copyright; the CLA is the license grant that keeps Kody a single-licensor tree.
+
+- [Inbound contributions](./docs/contributing/inbound-contributions.md) — who
+  signs, how to sign, and maintainer steps
+- [Individual CLA](./docs/legal/individual-cla.md)
+- [Entity CLA](./docs/legal/entity-cla.md)
+- [0018 — Inbound CLA](./docs/contributing/decisions/0018-inbound-cla.md)
+
+Reusable behavior for Kody users belongs in a
+[community package](./docs/use/community-packages.md) (MIT). Publishing or
+forking a listing does not use this CLA.
+
+Setup, tests, and architecture for people developing the repo:
+
+- [Contributing index](./docs/contributing/index.md)
+- [Getting started](./docs/contributing/getting-started.md)
+- [Project intent](./docs/contributing/project-intent.md)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Request → packages/worker/src/index.ts
 | [`docs/use/index.md`](./docs/use/index.md)                                                   | Using Kody over MCP                  |
 | [`docs/contributing/setup.md`](./docs/contributing/setup.md)                                 | Local development and verification   |
 
+## Contributing
+
+Outside pull requests to this repository need a signed inbound
+[Contributor License Agreement](./docs/contributing/inbound-contributions.md).
+Community packages stay MIT and do not use that CLA.
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and
+[`docs/contributing/index.md`](./docs/contributing/index.md).
+
 ## License
 
 Kody is licensed under the

--- a/docs/contributing/decisions/0018-inbound-cla.md
+++ b/docs/contributing/decisions/0018-inbound-cla.md
@@ -51,8 +51,8 @@ How it works:
 - **Scope.** This git repository only. User packages, community listings (MIT),
   and unsubmitted forks are out of scope.
 - **Who signs.** Every GitHub identity that authors a commit on the pull
-  request, unless that identity is `kentcdodds`, a `*[bot]` account, or an email
-  listed as Licensor-owned in
+  request, unless that identity is `kentcdodds`, `kody-bot`, a `*[bot]` or
+  `app/*` account, or an email listed as Licensor-owned in
   [`.github/cla-signers.json`](../../../.github/cla-signers.json).
 - **Which form.** [Individual CLA](../../legal/individual-cla.md) by default.
   [Entity CLA](../../legal/entity-cla.md) when the work is owned by an employer

--- a/docs/contributing/decisions/0018-inbound-cla.md
+++ b/docs/contributing/decisions/0018-inbound-cla.md
@@ -1,0 +1,84 @@
+# 0018: Inbound CLA for external contributions to this repository
+
+- **Status:** accepted
+- **Date:** 2026-08-16
+
+## Context
+
+This repository is Fair Source under [FSL-1.1-ALv2](../../../LICENSE). Copyright
+is held by Kent C. Dodds as the sole Licensor. FSL's competing-use restriction,
+two-year Apache 2.0 conversion, and any later relicensing or commercial license
+only work cleanly when one party can speak as "We" for the whole tree.
+
+GitHub's inbound-same-license rule is not enough here. It licenses a patch under
+FSL, but it does not grant relicensing rights, a contributor patent license, or
+a warranty that the contributor (or their employer) actually owns the patch. A
+Developer Certificate of Origin records provenance only; it does not move those
+rights.
+
+The repo is public and has already merged outside human commits, including
+substantial UI work. Almost all other history is Kent C. Dodds and allowlisted
+automation (Cursor, Kody, Devin, Sentry, Dependabot). Community packages are a
+separate MIT surface and are not this question.
+
+Alternatives considered:
+
+- **Rely on GitHub TOS / implicit FSL inbound.** Fine for same-license use;
+  insufficient for relicensing, enforcement, patents, or employer IP.
+- **DCO only.** Right tool for Apache/MIT projects; wrong tool for a
+  single-licensor Fair Source tree.
+- **Copyright assignment.** Heavier than needed; inbound license is enough.
+- **Close the repo to outside pull requests.** Legally simplest, but the repo is
+  already public and has taken outside patches. Issues and community packages
+  remain the preferred place for most work; they do not replace a rule for the
+  patches that do land here.
+
+## Decision
+
+Require a signed **inbound Contributor License Agreement** (not assignment)
+before merging a pull request that includes commits from anyone other than the
+Licensor or an allowlisted bot.
+
+The contributor keeps copyright. They grant Kent C. Dodds a perpetual,
+worldwide, irrevocable, sublicensable copyright and patent license, including
+the right to relicense the contribution under FSL-1.1-ALv2, Apache 2.0, and any
+commercial or other terms the Licensor offers. They represent that they have the
+right to grant that license (and employer permission when the work is not theirs
+alone).
+
+How it works:
+
+- **Scope.** This git repository only. User packages, community listings (MIT),
+  and unsubmitted forks are out of scope.
+- **Who signs.** Every GitHub identity that authors a commit on the pull
+  request, unless that identity is `kentcdodds`, a `*[bot]` account, or an email
+  listed as Licensor-owned in
+  [`.github/cla-signers.json`](../../../.github/cla-signers.json).
+- **Which form.** [Individual CLA](../../legal/individual-cla.md) by default.
+  [Entity CLA](../../legal/entity-cla.md) when the work is owned by an employer
+  or the contributor is signing for an organization.
+- **How they sign.** Read the CLA, then comment on the pull request:
+  `I have read the CLA and I hereby sign the CLA`. A maintainer records the
+  GitHub username in `.github/cla-signers.json` on `main`. Signing covers past,
+  present, and future contributions from that identity.
+- **Enforcement.** The `CLA` workflow reads signers from `main` (never from the
+  pull request head), fails closed on unsigned identities, and comments with the
+  signing steps. Maintainers do not merge a red `CLA` check. There is no
+  trivial-contribution exception.
+- **Existing commits.** History is not rewritten. People who already contributed
+  are asked to sign before the next merge; the CLA text covers prior
+  contributions once signed.
+
+## Consequences
+
+- The Licensor stays one party for FSL, the Apache conversion, relicensing, and
+  enforcement.
+- Outside pull requests take one extra maintainer step (record the signer on
+  `main`). That matches current volume. If volume grows, replace the manual
+  record with a hosted CLA Assistant gist pointed at the same documents; do not
+  adopt an unmaintained `pull_request_target` signing bot.
+- Community package authors keep their own MIT copyright; they never sign this
+  CLA unless they also patch this repository.
+- Revisit if the Licensor becomes a company (assign the inbound grants to that
+  successor), if counsel revises the CLA text, or if contribution volume
+  justifies hosted click-to-sign.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -37,3 +37,4 @@ behavior (see [documentation principles](../documentation.md)).
 - [0015 — Wait on Skills over MCP (SEP-2640); serve skill content via packages](./0015-skills-over-mcp-wait.md)
 - [0016 — Extract the package runtime and jobs lanes into separate workers](./0016-mono-worker-extraction.md)
 - [0017 — Per-user subdomains for hosted package apps](./0017-per-user-package-app-subdomains.md)
+- [0018 — Inbound CLA for external contributions to this repository](./0018-inbound-cla.md)

--- a/docs/contributing/inbound-contributions.md
+++ b/docs/contributing/inbound-contributions.md
@@ -61,8 +61,9 @@ Licensor records those usernames after accepting the agreement.
 These identities are allowlisted in `.github/cla-signers.json` and do not sign:
 
 - `kentcdodds` (Licensor)
+- `kody-bot` and other logins listed in that file
 - Licensor-owned commit emails listed in that file
-- GitHub accounts whose login ends in `[bot]`
+- GitHub accounts whose login ends in `[bot]` or starts with `app/`
 
 Cursor Cloud Agent pull requests that GitHub authors as `kentcdodds` follow the
 Licensor path.

--- a/docs/contributing/inbound-contributions.md
+++ b/docs/contributing/inbound-contributions.md
@@ -1,0 +1,86 @@
+# Inbound contributions
+
+How outside patches enter [this repository](https://github.com/kentcdodds/kody).
+The decision and the why live in
+[0018 — Inbound CLA](./decisions/0018-inbound-cla.md).
+
+This page is the platform-repo contribution path. Most reusable behavior belongs
+in a [community package](../use/community-packages.md) (MIT, your copyright).
+You do not sign a CLA to publish or fork a community listing.
+
+## What needs a CLA
+
+A pull request needs a signed Contributor License Agreement when any commit on
+it is authored by someone other than Kent C. Dodds or an allowlisted bot.
+
+The contributor keeps copyright. The CLA is an inbound license so the repository
+can stay a single-licensor Fair Source tree under [FSL-1.1-ALv2](../../LICENSE).
+
+Sign the [Individual CLA](../legal/individual-cla.md) unless an employer owns
+the work. If an organization owns the work, an authorized representative
+completes the [Entity CLA](../legal/entity-cla.md) instead.
+
+There is no exception for docs-only or one-line patches.
+
+## How to sign (individual)
+
+1. Open the pull request.
+2. Read the [Individual CLA](../legal/individual-cla.md).
+3. Comment exactly:
+
+   ```
+   I have read the CLA and I hereby sign the CLA
+   ```
+
+4. Wait for a maintainer to record your GitHub username in
+   [`.github/cla-signers.json`](../../.github/cla-signers.json) on `main`.
+5. Re-run the `CLA` check, or push another commit.
+
+Signing once covers past, present, and future contributions from that GitHub
+identity. People who contributed before this process sign the same way before
+their next merge. The `CLA` workflow reads signers from `main`, not from the
+pull request branch, so adding your own username on the branch does not pass the
+check.
+
+## How to sign (entity)
+
+An authorized representative emails
+[me@kentcdodds.com](mailto:me@kentcdodds.com) with:
+
+- subject `Kody Entity CLA`
+- legal name and address of the organization
+- representative name and title
+- GitHub usernames authorized to submit on the organization's behalf
+- a statement that the organization accepts the
+  [Entity CLA](../legal/entity-cla.md)
+
+Licensor records those usernames after accepting the agreement.
+
+## Who does not sign
+
+These identities are allowlisted in `.github/cla-signers.json` and do not sign:
+
+- `kentcdodds` (Licensor)
+- Licensor-owned commit emails listed in that file
+- GitHub accounts whose login ends in `[bot]`
+
+Cursor Cloud Agent pull requests that GitHub authors as `kentcdodds` follow the
+Licensor path.
+
+## Maintainer steps
+
+Do not merge a pull request while the `CLA` check is red.
+
+After a valid individual signing comment, add a `signers` entry on `main`
+(GitHub login, `signedAt` as an ISO date, `cla` of `individual`) and re-run the
+check. After an accepted Entity CLA, add each authorized username with `cla` of
+`entity`.
+
+Make the `CLA` check required for `main` in GitHub branch protection so a green
+review cannot skip it.
+
+## Out of scope
+
+- Publishing or forking community packages
+- Issues, discussions, and security reports that do not include a patch
+- Private vulnerability reports ([Security policy](../../SECURITY.md))

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -8,6 +8,8 @@ style, tests, MCP capabilities, and runtime architecture.
 - [Getting started](./getting-started.md), [project intent](./project-intent.md)
 - [Decision records](./decisions/index.md) (ADRs, including decisions **not** to
   build something)
+- [Inbound contributions](./inbound-contributions.md) (CLA for patches to this
+  repository)
 - [Setup](./setup.md), [environment variables](./environment-variables.md),
   [setup manifest](./setup-manifest.md)
 - [Manual PR preview testing](./preview-manual-testing.md)

--- a/docs/legal/entity-cla.md
+++ b/docs/legal/entity-cla.md
@@ -1,0 +1,93 @@
+# Kody Entity Contributor License Agreement
+
+Thank you for your interest in Kody ("the Project"), a project of Kent C. Dodds
+("Licensor").
+
+This Entity Contributor License Agreement ("Agreement") is for an organization
+that owns work being submitted to the Project. Individuals who own their own
+work should sign the [Individual CLA](./individual-cla.md) instead.
+
+The organization keeps copyright in its contributions. This Agreement is a
+license grant, not an assignment of copyright.
+
+To accept this Agreement, an authorized representative emails
+[me@kentcdodds.com](mailto:me@kentcdodds.com) with the subject
+`Kody Entity CLA`, the legal name and address of the organization, the
+representative's name and title, and the GitHub usernames authorized to Submit
+on the organization's behalf. Licensor records those usernames after accepting
+the Agreement.
+
+## 1. Definitions
+
+**"You"** means the organization identified in the acceptance email.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that a person acting on Your
+behalf Submits to the Project in any form (including pull requests, patches,
+issues that include code or documentation, and git commits).
+
+**"Submit"** means any form of electronic, verbal, or written communication sent
+to the Project or Licensor, excluding communication conspicuously marked as "Not
+a Contribution."
+
+## 2. Copyright license
+
+You grant Licensor a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable, sublicensable copyright license to reproduce, prepare
+derivative works of, publicly display, publicly perform, sublicense, and
+distribute Your Contributions and such derivative works.
+
+You also grant Licensor the right to relicense Your Contributions under any
+license terms, including the Functional Source License, Version 1.1, ALv2 Future
+License (FSL-1.1-ALv2), the Apache License 2.0, and any commercial or other
+license terms Licensor offers.
+
+## 3. Patent license
+
+You grant Licensor a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Project, where such license applies only to those patent claims licensable by
+You that are necessarily infringed by Your Contribution(s) alone or by
+combination of Your Contribution(s) with the Project to which such
+Contribution(s) were submitted.
+
+If You institute patent litigation against any entity (including a cross-claim
+or counterclaim in a lawsuit) alleging that the Project or a Contribution
+incorporated within the Project constitutes direct or contributory patent
+infringement, then any patent licenses granted to You under this Agreement for
+that Project terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. Each Contribution is Your original creation, or You have sufficient rights to
+   grant the licenses in this Agreement for material You Submit that You did not
+   create.
+3. Each person who Submits a Contribution on Your behalf is authorized to do so,
+   and You will keep Licensor's recorded GitHub username list current.
+
+## 5. Disclaimer
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied, including, without limitation, any warranties or
+conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+## 6. Notice of inaccuracy
+
+You agree to notify Licensor of any facts or circumstances of which You become
+aware that would make Your representations in this Agreement inaccurate in any
+respect.
+
+## 7. Successor
+
+Licensor may assign this Agreement to a successor that continues the Project.
+This Agreement does not grant You any trademark rights.
+
+## How to sign
+
+See [Inbound contributions](../contributing/inbound-contributions.md).

--- a/docs/legal/individual-cla.md
+++ b/docs/legal/individual-cla.md
@@ -1,0 +1,94 @@
+# Kody Individual Contributor License Agreement
+
+Thank you for your interest in Kody ("the Project"), a project of Kent C. Dodds
+("Licensor").
+
+This Contributor License Agreement ("Agreement") records the rights you grant so
+the Project can remain a single-licensor Fair Source work. You keep copyright in
+your contributions. You are not assigning copyright to Licensor.
+
+You accept this Agreement for your past, present, and future Contributions by
+commenting `I have read the CLA and I hereby sign the CLA` on a Project pull
+request, or by otherwise accepting these terms in a form Licensor records.
+
+## 1. Definitions
+
+**"You"** means the individual who accepts this Agreement.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that You submit to the Project
+in any form (including pull requests, patches, issues that include code or
+documentation, and git commits).
+
+**"Submit"** means any form of electronic, verbal, or written communication sent
+to the Project or Licensor, excluding communication conspicuously marked by You
+as "Not a Contribution."
+
+## 2. Copyright license
+
+You grant Licensor a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable, sublicensable copyright license to reproduce, prepare
+derivative works of, publicly display, publicly perform, sublicense, and
+distribute Your Contributions and such derivative works.
+
+You also grant Licensor the right to relicense Your Contributions under any
+license terms, including the Functional Source License, Version 1.1, ALv2 Future
+License (FSL-1.1-ALv2), the Apache License 2.0, and any commercial or other
+license terms Licensor offers.
+
+## 3. Patent license
+
+You grant Licensor a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Project, where such license applies only to those patent claims licensable by
+You that are necessarily infringed by Your Contribution(s) alone or by
+combination of Your Contribution(s) with the Project to which such
+Contribution(s) were submitted.
+
+If You institute patent litigation against any entity (including a cross-claim
+or counterclaim in a lawsuit) alleging that the Project or a Contribution
+incorporated within the Project constitutes direct or contributory patent
+infringement, then any patent licenses granted to You under this Agreement for
+that Project terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. If your employer has rights to intellectual property that You create, You
+   have received permission to make Contributions on behalf of that employer,
+   that your employer has waived such rights for Your Contributions to the
+   Project, or that You will not Submit that work until an
+   [Entity CLA](./entity-cla.md) is on file.
+3. Each of Your Contributions is Your original creation, or You have sufficient
+   rights to grant the licenses in this Agreement for material You Submit that
+   You did not create.
+4. You will complete an Entity CLA instead of this Agreement when You are
+   signing for an organization rather than as an individual.
+
+## 5. Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You want to provide support. You may provide support for free, for a fee,
+or not at all. Unless required by applicable law or agreed to in writing, You
+provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+FOR A PARTICULAR PURPOSE.
+
+## 6. Notice of inaccuracy
+
+You agree to notify Licensor of any facts or circumstances of which You become
+aware that would make Your representations in this Agreement inaccurate in any
+respect.
+
+## 7. Successor
+
+Licensor may assign this Agreement to a successor that continues the Project.
+This Agreement does not grant You any trademark rights.
+
+## How to sign
+
+See [Inbound contributions](../contributing/inbound-contributions.md).

--- a/tools/ci/check-cla.node.test.ts
+++ b/tools/ci/check-cla.node.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs'
+import { expect, test } from 'vitest'
+
+import {
+	checkClaIdentities,
+	formatClaFailure,
+	parseClaSignersFile,
+	type ClaSignersFile,
+} from './check-cla.ts'
+
+function signersFile(overrides: Partial<ClaSignersFile> = {}): ClaSignersFile {
+	return {
+		version: 1,
+		document: 'docs/legal/individual-cla.md',
+		allowlist: {
+			github: ['kentcdodds'],
+			email: ['me@kentcdodds.com', 'me+github@kentcdodds.com'],
+		},
+		signers: [],
+		...overrides,
+	}
+}
+
+test('CLA check allowlists the Licensor, bots, signed humans, and rejects everyone else', () => {
+	const file = signersFile({
+		signers: [
+			{
+				github: 'VojtaHolik',
+				signedAt: '2026-08-16',
+				cla: 'individual',
+			},
+		],
+	})
+
+	const passing = checkClaIdentities(
+		[
+			{ githubLogin: 'kentcdodds', name: 'Kent', email: null },
+			{
+				githubLogin: 'cursor[bot]',
+				name: 'cursor[bot]',
+				email: null,
+			},
+			{
+				githubLogin: null,
+				name: 'Kent C. Dodds',
+				email: 'me+github@kentcdodds.com',
+			},
+			{
+				githubLogin: 'vojtaholik',
+				name: 'Vojta Holik',
+				email: 'vojta@egghead.io',
+			},
+		],
+		file,
+	)
+	expect(passing).toEqual({ ok: true })
+
+	const failing = checkClaIdentities(
+		[
+			{
+				githubLogin: 'kentcdodds',
+				name: 'Kent',
+				email: null,
+			},
+			{
+				githubLogin: 'mirkosalvato1-ctrl',
+				name: 'Mirko',
+				email: 'mirkosalvato1@gmail.com',
+			},
+			{
+				githubLogin: null,
+				name: 'Someone',
+				email: 'someone@example.com',
+			},
+		],
+		file,
+	)
+	expect(failing.ok).toBe(false)
+	if (failing.ok) {
+		throw new Error('expected missing signatures')
+	}
+	expect(failing.missing.map((entry) => entry.reason)).toEqual([
+		'@mirkosalvato1-ctrl has not signed the CLA',
+		'someone@example.com has no GitHub login and is not a Licensor email',
+	])
+	expect(formatClaFailure(failing)).toContain(
+		'I have read the CLA and I hereby sign the CLA',
+	)
+})
+
+test('CLA signers file parser rejects the wrong version and accepts the repo file', () => {
+	expect(() => parseClaSignersFile('{"version":2}')).toThrow(/version 1/)
+	const parsed = parseClaSignersFile(
+		readFileSync('.github/cla-signers.json', 'utf8'),
+	)
+	expect(parsed.allowlist.github).toEqual(['kentcdodds'])
+	expect(parsed.signers).toEqual([])
+})

--- a/tools/ci/check-cla.node.test.ts
+++ b/tools/ci/check-cla.node.test.ts
@@ -13,7 +13,7 @@ function signersFile(overrides: Partial<ClaSignersFile> = {}): ClaSignersFile {
 		version: 1,
 		document: 'docs/legal/individual-cla.md',
 		allowlist: {
-			github: ['kentcdodds'],
+			github: ['kentcdodds', 'kody-bot'],
 			email: ['me@kentcdodds.com', 'me+github@kentcdodds.com'],
 		},
 		signers: [],
@@ -35,9 +35,15 @@ test('CLA check allowlists the Licensor, bots, signed humans, and rejects everyo
 	const passing = checkClaIdentities(
 		[
 			{ githubLogin: 'kentcdodds', name: 'Kent', email: null },
+			{ githubLogin: 'kody-bot', name: 'Kody', email: null },
 			{
 				githubLogin: 'cursor[bot]',
 				name: 'cursor[bot]',
+				email: null,
+			},
+			{
+				githubLogin: 'app/imgbot',
+				name: 'ImgBot',
 				email: null,
 			},
 			{
@@ -93,6 +99,6 @@ test('CLA signers file parser rejects the wrong version and accepts the repo fil
 	const parsed = parseClaSignersFile(
 		readFileSync('.github/cla-signers.json', 'utf8'),
 	)
-	expect(parsed.allowlist.github).toEqual(['kentcdodds'])
+	expect(parsed.allowlist.github).toEqual(['kentcdodds', 'kody-bot'])
 	expect(parsed.signers).toEqual([])
 })

--- a/tools/ci/check-cla.ts
+++ b/tools/ci/check-cla.ts
@@ -1,0 +1,195 @@
+import { readFile } from 'node:fs/promises'
+import { isExecutedDirectly } from '../node-runtime.ts'
+
+export type ClaIdentity = {
+	githubLogin: string | null
+	name: string | null
+	email: string | null
+}
+
+export type ClaSigner = {
+	github: string
+	signedAt: string
+	cla: 'individual' | 'entity'
+}
+
+export type ClaSignersFile = {
+	version: 1
+	document: string
+	allowlist: {
+		github: Array<string>
+		email: Array<string>
+	}
+	signers: Array<ClaSigner>
+}
+
+export type ClaMissingIdentity = {
+	identity: ClaIdentity
+	reason: string
+}
+
+export type ClaCheckResult =
+	| { ok: true }
+	| { ok: false; missing: Array<ClaMissingIdentity> }
+
+const githubBotLoginPattern = /\[bot\]$/i
+
+function normalize(value: string) {
+	return value.trim().toLowerCase()
+}
+
+function identityLabel(identity: ClaIdentity) {
+	if (identity.githubLogin) {
+		return `@${identity.githubLogin}`
+	}
+	if (identity.email) {
+		return identity.email
+	}
+	if (identity.name) {
+		return identity.name
+	}
+	return 'unknown identity'
+}
+
+export function parseClaSignersFile(raw: string): ClaSignersFile {
+	const parsed: unknown = JSON.parse(raw)
+	if (
+		typeof parsed !== 'object' ||
+		parsed === null ||
+		!('version' in parsed) ||
+		parsed.version !== 1
+	) {
+		throw new Error('CLA signers file must be version 1 JSON')
+	}
+
+	const file = parsed as ClaSignersFile
+	if (
+		typeof file.document !== 'string' ||
+		typeof file.allowlist !== 'object' ||
+		file.allowlist === null ||
+		!Array.isArray(file.allowlist.github) ||
+		!Array.isArray(file.allowlist.email) ||
+		!Array.isArray(file.signers)
+	) {
+		throw new Error('CLA signers file is missing allowlist or signers')
+	}
+
+	return file
+}
+
+export function isAllowlistedIdentity(
+	identity: ClaIdentity,
+	signersFile: ClaSignersFile,
+) {
+	const login = identity.githubLogin ? normalize(identity.githubLogin) : null
+	if (login && githubBotLoginPattern.test(login)) {
+		return true
+	}
+	if (
+		login &&
+		signersFile.allowlist.github.some((entry) => normalize(entry) === login)
+	) {
+		return true
+	}
+
+	const email = identity.email ? normalize(identity.email) : null
+	return Boolean(
+		email &&
+		signersFile.allowlist.email.some((entry) => normalize(entry) === email),
+	)
+}
+
+export function hasSignedCla(
+	identity: ClaIdentity,
+	signersFile: ClaSignersFile,
+) {
+	const login = identity.githubLogin ? normalize(identity.githubLogin) : null
+	if (!login) {
+		return false
+	}
+
+	return signersFile.signers.some(
+		(signer) => normalize(signer.github) === login,
+	)
+}
+
+export function checkClaIdentities(
+	identities: ReadonlyArray<ClaIdentity>,
+	signersFile: ClaSignersFile,
+): ClaCheckResult {
+	const missing: Array<ClaMissingIdentity> = []
+	const seen = new Set<string>()
+
+	for (const identity of identities) {
+		const key = [identity.githubLogin, identity.email, identity.name]
+			.map((part) => (part ? normalize(part) : ''))
+			.join('|')
+		if (seen.has(key)) {
+			continue
+		}
+		seen.add(key)
+
+		if (isAllowlistedIdentity(identity, signersFile)) {
+			continue
+		}
+		if (hasSignedCla(identity, signersFile)) {
+			continue
+		}
+
+		const reason = identity.githubLogin
+			? `${identityLabel(identity)} has not signed the CLA`
+			: `${identityLabel(identity)} has no GitHub login and is not a Licensor email`
+		missing.push({ identity, reason })
+	}
+
+	return missing.length === 0 ? { ok: true } : { ok: false, missing }
+}
+
+export function formatClaFailure(
+	result: Extract<ClaCheckResult, { ok: false }>,
+) {
+	const lines = [
+		'Unsigned contributions cannot merge.',
+		'Read docs/legal/individual-cla.md (or the Entity CLA if an organization owns the work).',
+		'Comment on the pull request: I have read the CLA and I hereby sign the CLA',
+		'A maintainer then records your GitHub username on main. See docs/contributing/inbound-contributions.md.',
+		'',
+		'Missing signatures:',
+		...result.missing.map((entry) => `- ${entry.reason}`),
+	]
+	return lines.join('\n')
+}
+
+async function runCli(args: Array<string>) {
+	const signersFlag = args.indexOf('--signers')
+	const identitiesFlag = args.indexOf('--identities-json')
+	const signersPath = signersFlag === -1 ? null : args[signersFlag + 1]
+	const identitiesPath = identitiesFlag === -1 ? null : args[identitiesFlag + 1]
+
+	if (!signersPath || !identitiesPath) {
+		throw new Error(
+			'Usage: node tools/ci/check-cla.ts --signers <file> --identities-json <file>',
+		)
+	}
+
+	const signersFile = parseClaSignersFile(await readFile(signersPath, 'utf8'))
+	const identitiesRaw: unknown = JSON.parse(
+		await readFile(identitiesPath, 'utf8'),
+	)
+	if (!Array.isArray(identitiesRaw)) {
+		throw new Error('Identities JSON must be an array')
+	}
+
+	const result = checkClaIdentities(
+		identitiesRaw as Array<ClaIdentity>,
+		signersFile,
+	)
+	if (!result.ok) {
+		console.error(formatClaFailure(result))
+		process.exitCode = 1
+	}
+}
+
+if (isExecutedDirectly(import.meta.url)) {
+	await runCli(process.argv.slice(2))
+}

--- a/tools/ci/check-cla.ts
+++ b/tools/ci/check-cla.ts
@@ -82,7 +82,10 @@ export function isAllowlistedIdentity(
 	signersFile: ClaSignersFile,
 ) {
 	const login = identity.githubLogin ? normalize(identity.githubLogin) : null
-	if (login && githubBotLoginPattern.test(login)) {
+	if (
+		login &&
+		(githubBotLoginPattern.test(login) || login.startsWith('app/'))
+	) {
 		return true
 	}
 	if (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep Kody a single-licensor Fair Source tree when outside patches land in this repository.

## Summary

- **Yes, we need a CLA** if this repo accepts external pull requests. GitHub's inbound-same-license rule and a DCO are not enough for FSL: they do not grant relicensing rights, a contributor patent license, or an employer-IP warranty.
- **How it works:** inbound license (not assignment). The contributor keeps copyright and grants Kent C. Dodds the right to use, sublicense, and relicense under FSL-1.1-ALv2, Apache 2.0, and any commercial terms. Individual CLA by default; Entity CLA when an organization owns the work.
- Recorded as [decision 0018](docs/contributing/decisions/0018-inbound-cla.md). Process: [Inbound contributions](docs/contributing/inbound-contributions.md).
- The `CLA` workflow reads signers from `main` (never from the PR head) and fails closed. Signing is a PR comment; a maintainer records the GitHub username on `main`. Bots and `kentcdodds` are allowlisted. Community packages stay MIT and are out of scope.
- No trivial-contribution exception. History is not rewritten; prior contributors sign before their next merge.

## Testing

- `npx vitest run --project node-unit tools/ci/check-cla.node.test.ts` — 2 passed
- CLI smoke: Licensor + bot identities exit 0; an unsigned human exits 1
- `npm run docs:check-temporal` passed
- GitHub `CLA / CLA` on this PR passed via the bootstrap skip (`CLA checker is not on the base branch yet`). After merge, the same job reads signers from `main`.

[cla_process_local_checks.log](https://cursor.com/artifacts/c/art-ed7ac625-1652-44f5-b9ad-5a0664b49922)

## System changes

No runtime primitives. GitHub contribution gate only.

## Maintainer follow-up after merge

- Make the `CLA` check required for `main` in branch protection.
- Ask prior outside contributors to sign before their next merge (the CLA covers past contributions once signed).
- Counsel review of the CLA text is the revisit trigger before relying on it in a dispute.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ebb6040b` · **Head:** `54f3f111`

**Classification:** composes — no primitives added or changed; this PR adds a GitHub inbound-CLA gate and contributing docs.

### Primitives touched

None. Classifier matched 0 of 12 paths (`primitives.yaml` has no ownership roots for `.github/`, `docs/`, or `tools/ci/`).

### System map

The CLA check runs in GitHub Actions against `.github/cla-signers.json` on `main` before merge. It does not call into any Kody runtime primitive.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	claWorkflow["CLA workflow<br/>GitHub Actions"]:::touched
	signersFile["cla-signers.json<br/>on main"]:::touched
	claWorkflow -->|"read allowlist and signers"| signersFile
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Contributor
	participant PR as Pull request
	participant CLA as CLA workflow
	participant Maintainer
	participant Main as main signers file
	Contributor->>PR: open PR with commits
	CLA->>Main: read signers (base SHA)
	CLA-->>PR: fail if unsigned
	Contributor->>PR: comment CLA acceptance
	Maintainer->>Main: record GitHub username
	CLA->>Main: re-read signers
	CLA-->>PR: pass
```

### Invariants

Single-licensor FSL: outside commits do not merge without an inbound license grant recorded on `main`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62bdff02-40a1-4661-883a-c1b0f4f417cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62bdff02-40a1-4661-883a-c1b0f4f417cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Contributor License Agreement (CLA) checks for contributions targeting the main branch.
  * Added support for individual and entity CLA signing, identity allowlists, and signer tracking.
* **Documentation**
  * Added contribution guidance explaining licensing, CLA requirements, signing procedures, and contribution scope.
  * Added individual and entity CLA documents and a decision record documenting the policy.
* **Tests**
  * Added coverage for signer validation, identity matching, allowlists, parsing, and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->