### PR TITLE
fix(mcp): self-heal remote OAuth authorization

### DIFF
--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -150,7 +150,7 @@ function stateColor(server: Pick<McpServerListItem, 'state' | 'enabled'>) {
 		case 'failed':
 			return colors.error
 		case 'authenticating':
-			return colors.error
+			return colors.textMuted
 		default:
 			return colors.textMuted
 	}
@@ -168,6 +168,13 @@ function readOAuthResultFromHref(href: string): {
 			message: server
 				? `Authorized MCP server "${server}".`
 				: 'Authorized MCP server.',
+			tone: 'info',
+		}
+	}
+	if (auth === 'required') {
+		return {
+			message:
+				'Authorization needed. Open the new authorization link and approve access once more.',
 			tone: 'info',
 		}
 	}
@@ -734,10 +741,10 @@ export function AccountMcpServersRoute(handle: Handle) {
 									) : null}
 
 									{server.state === 'authenticating' && !server.authUrl ? (
-										<AccountManagementMessage tone="error">
-											Authorization is incomplete and no authorization link is
-											available. Click Reconnect to restart OAuth, or remove and
-											add the server again.
+										<AccountManagementMessage tone="info">
+											Authorization needed. Click Reconnect to create a new
+											authorization link. You may need to approve access once
+											more.
 										</AccountManagementMessage>
 									) : null}
 
@@ -753,8 +760,8 @@ export function AccountMcpServersRoute(handle: Handle) {
 											})}
 										>
 											<span mix={css({ color: colors.text })}>
-												This server requires OAuth authorization before its
-												tools become available.
+												Authorization needed. Approve access before this
+												server&apos;s tools become available.
 											</span>
 											<div>
 												<a
@@ -814,7 +821,14 @@ export function AccountMcpServersRoute(handle: Handle) {
 												on('click', () =>
 													postAction({
 														body: { action: 'reconnect', id: server.id },
-														successMessage: () => 'Reconnect requested.',
+														successMessage: (payload) => {
+															const reconnected = payload.servers.find(
+																(item) => item.id === server.id,
+															)
+															return reconnected?.authUrl
+																? 'Authorization needed. Open the new authorization link and approve access once more.'
+																: 'Reconnected MCP server.'
+														},
 														failureMessage: 'Unable to reconnect MCP server.',
 													}),
 												),

--- a/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
@@ -85,6 +85,14 @@ const mockModule = vi.hoisted(() => ({
 		authSuccess: true,
 		authError: null,
 		serverName: 'linear',
+		authorizationNeeded: false,
+	})),
+	reconnectServer: vi.fn(async () => ({
+		serverId: 'server-1',
+		state: 'authenticating',
+		authUrl: 'https://auth.example.com/authorize?state=fresh.server-1',
+		error: null,
+		toolCount: 0,
 	})),
 }))
 
@@ -138,6 +146,8 @@ vi.mock('#worker/mcp-client/hub-client.ts', () => ({
 	createMcpClientHubClient: () => ({
 		handleOAuthCallback: (...args: Array<unknown>) =>
 			mockModule.handleOAuthCallback(...args),
+		reconnectServer: (...args: Array<unknown>) =>
+			mockModule.reconnectServer(...args),
 	}),
 }))
 
@@ -222,6 +232,25 @@ test('MCP servers API add action uses the canonical OAuth callback origin', asyn
 	expect(payload.selectedServerId).toBe('server-2')
 })
 
+test('MCP servers API reconnect uses the current callback and starts fresh authorization', async () => {
+	const handler = createAccountMcpServersApiHandler(createEnv())
+
+	const reconnectResponse = await handler.handler({
+		request: new Request('https://example.com/account/mcp-servers.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action: 'reconnect', id: 'server-1' }),
+		}),
+		params: {},
+	} as never)
+
+	expect(reconnectResponse.status).toBe(200)
+	expect(mockModule.reconnectServer).toHaveBeenCalledWith({
+		serverId: 'server-1',
+		callbackUrl: 'https://example.com/account/mcp-servers/oauth/callback',
+	})
+})
+
 test('MCP servers API set-enabled and delete actions are user-scoped', async () => {
 	const handler = createAccountMcpServersApiHandler(createEnv())
 
@@ -277,12 +306,17 @@ test('MCP servers OAuth callback redirects with the auth outcome', async () => {
 	expect(successLocation.pathname).toBe('/account/mcp-servers/server-1')
 	expect(successLocation.searchParams.get('auth')).toBe('success')
 	expect(successLocation.searchParams.get('server')).toBe('linear')
+	expect(mockModule.handleOAuthCallback).toHaveBeenCalledWith({
+		url: 'https://example.com/account/mcp-servers/oauth/callback?code=abc&state=xyz',
+		callbackUrl: 'https://example.com/account/mcp-servers/oauth/callback',
+	})
 
 	mockModule.handleOAuthCallback.mockResolvedValueOnce({
 		serverId: null,
 		authSuccess: false,
 		authError: 'Invalid state.',
 		serverName: null,
+		authorizationNeeded: false,
 	})
 	const failureResponse = await handler.handler({
 		request: new Request(
@@ -301,6 +335,7 @@ test('MCP servers OAuth callback redirects with the auth outcome', async () => {
 		authSuccess: false,
 		authError: 'Invalid origin uri https://example.com',
 		serverName: 'linear',
+		authorizationNeeded: false,
 	})
 	const originFailureResponse = await handler.handler({
 		request: new Request(
@@ -325,6 +360,7 @@ test('MCP servers OAuth callback redirects with the auth outcome', async () => {
 		authSuccess: false,
 		authError: 'Authorization completed, but no authorization link.',
 		serverName: 'linear',
+		authorizationNeeded: false,
 	})
 	const incompleteResponse = await handler.handler({
 		request: new Request(
@@ -341,4 +377,26 @@ test('MCP servers OAuth callback redirects with the auth outcome', async () => {
 	expect(incompleteLocation.searchParams.get('reason')).toContain(
 		'no authorization link',
 	)
+
+	mockModule.handleOAuthCallback.mockResolvedValueOnce({
+		serverId: 'server-1',
+		authSuccess: false,
+		authError:
+			'Authorization needed. Reconnect the MCP server and approve access once more.',
+		serverName: 'linear',
+		authorizationNeeded: true,
+	})
+	const recoveryResponse = await handler.handler({
+		request: new Request(
+			'https://example.com/account/mcp-servers/oauth/callback?code=abc&state=used.server-1',
+		),
+		params: {},
+	} as never)
+	expect(recoveryResponse.status).toBe(303)
+	const recoveryLocation = new URL(
+		recoveryResponse.headers.get('Location') ?? '',
+	)
+	expect(recoveryLocation.pathname).toBe('/account/mcp-servers/server-1')
+	expect(recoveryLocation.searchParams.get('auth')).toBe('required')
+	expect(recoveryLocation.searchParams.has('reason')).toBe(false)
 })

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -149,20 +149,25 @@ export function createAccountMcpServersOauthCallbackHandler(env: Env) {
 			let authError: string | null = null
 			let serverName: string | null = null
 			let serverId: string | null = null
-			try {
-				const outcome = await hub.handleOAuthCallback({ url: request.url })
-				authSuccess = outcome.authSuccess
-				authError = outcome.authError
-				serverName = outcome.serverName
-				serverId = outcome.serverId
-			} catch (error) {
-				authError = getErrorMessage(error)
-			}
-
+			let authorizationNeeded = false
 			const oauth = resolveMcpServerOAuthClientUrls({
 				env,
 				requestUrl: request.url,
 			})
+			try {
+				const outcome = await hub.handleOAuthCallback({
+					url: request.url,
+					callbackUrl: oauth.callbackUrl,
+				})
+				authSuccess = outcome.authSuccess
+				authError = outcome.authError
+				serverName = outcome.serverName
+				serverId = outcome.serverId
+				authorizationNeeded = outcome.authorizationNeeded
+			} catch (error) {
+				authError = getErrorMessage(error)
+			}
+
 			if (authError) {
 				authError = enrichMcpOAuthProviderError(authError, oauth)
 			}
@@ -173,7 +178,9 @@ export function createAccountMcpServersOauthCallbackHandler(env: Env) {
 						request.url,
 					)
 				: new URL('/account/mcp-servers', request.url)
-			if (authSuccess) {
+			if (authorizationNeeded) {
+				target.searchParams.set('auth', 'required')
+			} else if (authSuccess) {
 				target.searchParams.set('auth', 'success')
 				if (serverName) {
 					target.searchParams.set('server', serverName)
@@ -229,7 +236,14 @@ async function handleConnectionAction(input: {
 		userId: input.user.mcpUser.userId,
 	})
 	if (input.kind === 'reconnect') {
-		await hub.reconnectServer({ serverId: setting.id })
+		const oauth = resolveMcpServerOAuthClientUrls({
+			env: input.env,
+			requestUrl: input.request.url,
+		})
+		await hub.reconnectServer({
+			serverId: setting.id,
+			callbackUrl: oauth.callbackUrl,
+		})
 	} else {
 		await hub.refreshServer({ serverId: setting.id })
 	}

--- a/packages/worker/src/mcp-client/hub-client.ts
+++ b/packages/worker/src/mcp-client/hub-client.ts
@@ -28,11 +28,15 @@ export type McpClientHubClient = {
 		callbackUrl: string
 		headers?: Record<string, string>
 	}): Promise<McpServerConnectResult>
-	reconnectServer(input: { serverId: string }): Promise<McpServerConnectResult>
+	reconnectServer(input: {
+		serverId: string
+		callbackUrl: string
+	}): Promise<McpServerConnectResult>
 	refreshServer(input: { serverId: string }): Promise<McpServerConnectResult>
 	removeServer(input: { serverId: string }): Promise<void>
 	handleOAuthCallback(input: {
 		url: string
+		callbackUrl: string
 	}): Promise<McpServerOAuthCallbackOutcome>
 	getSnapshot(): Promise<McpClientHubSnapshot>
 	callTool(input: {

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -334,7 +334,9 @@ test('used and missing callback states recover without exposing an internal stat
 		callbackUrl,
 	})
 	expect(missingState.authorizationNeeded).toBe(true)
+	expect(missingState.serverId).toBe('server-1')
 	expect(missingState.authError).not.toContain('state')
+	expect(manager.rows[0]?.auth_url).toContain('state=fresh-2.server-1')
 })
 
 test('OAuth state recovery recognizes only unusable state failures', () => {

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -35,6 +35,7 @@ type FakeManager = {
 	rows: Array<FakeServerRow>
 	mcpConnections: Record<string, FakeConnection>
 	connectCount: number
+	registerFailuresRemaining: number
 	callbackMatches: boolean
 	callbackResult: {
 		serverId?: string
@@ -89,6 +90,7 @@ vi.mock('agents/mcp/client', () => ({
 		rows: Array<FakeServerRow> = []
 		mcpConnections: Record<string, FakeConnection> = {}
 		connectCount = 0
+		registerFailuresRemaining = 0
 		callbackMatches = true
 		callbackResult = {
 			serverId: 'server-1',
@@ -120,17 +122,22 @@ vi.mock('agents/mcp/client', () => ({
 				name: string
 				callbackUrl: string
 				clientId?: string
+				authUrl?: string
 				client?: Record<string, unknown>
 				transport: FakeConnection['options']['transport']
 			},
 		) {
+			if (this.registerFailuresRemaining > 0) {
+				this.registerFailuresRemaining -= 1
+				throw new Error('Replacement registration failed.')
+			}
 			this.rows.push({
 				id: serverId,
 				name: options.name,
 				server_url: options.url,
 				callback_url: options.callbackUrl,
 				client_id: options.clientId ?? null,
-				auth_url: null,
+				auth_url: options.authUrl ?? null,
 				server_options: null,
 			})
 			this.mcpConnections[serverId] = {
@@ -188,9 +195,20 @@ function createDurableObjectState() {
 		state: {
 			storage: {
 				sql: { exec: vi.fn(() => []) },
-				put: vi.fn(async (key: string, value: unknown) => {
-					values.set(key, value)
-				}),
+				put: vi.fn(
+					async (
+						keyOrEntries: string | Record<string, unknown>,
+						value?: unknown,
+					) => {
+						if (typeof keyOrEntries === 'string') {
+							values.set(keyOrEntries, value)
+							return
+						}
+						for (const [key, entryValue] of Object.entries(keyOrEntries)) {
+							values.set(key, entryValue)
+						}
+					},
+				),
 				get: vi.fn(async (key: string) => values.get(key)),
 				list: vi.fn(async ({ prefix }: { prefix: string }) => {
 					return new Map(
@@ -299,6 +317,50 @@ test('reconnect repairs stale callbacks and always replaces pending OAuth state'
 	expect(manager.rows[0]?.client_id).toBe('client-1')
 	expect(values.has('/Kody/server-1/client-1/client_info/')).toBe(true)
 	expect(values.has('/Kody/server-1/state/fresh-1')).toBe(false)
+})
+
+test('failed replacement registration restores the saved server and OAuth state', async () => {
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+
+	const oldCallback = 'https://heykody.app/account/mcp-servers/oauth/callback'
+	const currentCallback =
+		'https://kody.codes/account/mcp-servers/oauth/callback'
+	const oldAuthUrl = 'https://auth.example/authorize?state=stale.server-1'
+	seedServer({
+		manager,
+		callbackUrl: oldCallback,
+		clientId: 'stale-client',
+		authUrl: oldAuthUrl,
+	})
+	const clientInfoKey = '/Kody/server-1/stale-client/client_info/'
+	const stateKey = '/Kody/server-1/state/stale'
+	values.set(clientInfoKey, { client_id: 'stale-client' })
+	values.set(stateKey, { serverId: 'server-1' })
+	manager.registerFailuresRemaining = 1
+
+	await expect(
+		hub.reconnectServer({
+			serverId: 'server-1',
+			callbackUrl: currentCallback,
+		}),
+	).rejects.toThrow('Replacement registration failed.')
+
+	expect(manager.rows).toEqual([
+		expect.objectContaining({
+			id: 'server-1',
+			callback_url: oldCallback,
+			client_id: 'stale-client',
+			auth_url: oldAuthUrl,
+		}),
+	])
+	expect(manager.mcpConnections['server-1']?.options.transport.headers).toEqual(
+		{ 'X-Test': 'preserved' },
+	)
+	expect(values.get(clientInfoKey)).toEqual({ client_id: 'stale-client' })
+	expect(values.get(stateKey)).toEqual({ serverId: 'server-1' })
 })
 
 test('used and missing callback states recover without exposing an internal state error', async () => {

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import type * as CloudflareWorkers from 'cloudflare:workers'
 
 type FakeServerRow = {
 	id: string
@@ -53,17 +54,21 @@ vi.mock('@sentry/cloudflare', () => ({
 	) => durableObjectClass,
 }))
 
-vi.mock('cloudflare:workers', () => ({
-	DurableObject: class {
-		protected readonly ctx: DurableObjectState
-		protected readonly env: Env
+vi.mock('cloudflare:workers', async (importOriginal) => {
+	const actual = await importOriginal<CloudflareWorkers>()
+	return {
+		...actual,
+		DurableObject: class {
+			protected readonly ctx: DurableObjectState
+			protected readonly env: Env
 
-		constructor(ctx: DurableObjectState, env: Env) {
-			this.ctx = ctx
-			this.env = env
-		}
-	},
-}))
+			constructor(ctx: DurableObjectState, env: Env) {
+				this.ctx = ctx
+				this.env = env
+			}
+		},
+	}
+})
 
 vi.mock('agents/mcp/do-oauth-client-provider', () => ({
 	DurableObjectOAuthClientProvider: class {
@@ -250,8 +255,7 @@ test('reconnect repairs stale callbacks and always replaces pending OAuth state'
 	const manager = mockModule.manager
 	if (!manager) throw new Error('Fake manager was not constructed.')
 
-	const oldCallback =
-		'https://heykody.app/account/mcp-servers/oauth/callback'
+	const oldCallback = 'https://heykody.app/account/mcp-servers/oauth/callback'
 	const currentCallback =
 		'https://kody.codes/account/mcp-servers/oauth/callback'
 	seedServer({
@@ -276,9 +280,9 @@ test('reconnect repairs stale callbacks and always replaces pending OAuth state'
 	expect(repairedRow?.callback_url).toBe(currentCallback)
 	expect(repairedRow?.client_id).toBe('client-1')
 	expect(repairedRow?.client_id).not.toBe('stale-client')
-	expect(
-		manager.mcpConnections['server-1']?.options.transport.headers,
-	).toEqual({ 'X-Test': 'preserved' })
+	expect(manager.mcpConnections['server-1']?.options.transport.headers).toEqual(
+		{ 'X-Test': 'preserved' },
+	)
 	expect(values.size).toBe(0)
 
 	values.set('/Kody/server-1/client-1/client_info/', {
@@ -302,8 +306,7 @@ test('used and missing callback states recover without exposing an internal stat
 	const hub = new McpClientHub(state, {} as Env)
 	const manager = mockModule.manager
 	if (!manager) throw new Error('Fake manager was not constructed.')
-	const callbackUrl =
-		'https://kody.codes/account/mcp-servers/oauth/callback'
+	const callbackUrl = 'https://kody.codes/account/mcp-servers/oauth/callback'
 	seedServer({
 		manager,
 		callbackUrl,

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -1,0 +1,344 @@
+import { expect, test, vi } from 'vitest'
+
+type FakeServerRow = {
+	id: string
+	name: string
+	server_url: string
+	callback_url: string
+	client_id: string | null
+	auth_url: string | null
+	server_options: string | null
+}
+
+type FakeConnection = {
+	connectionState: string
+	connectionError: string | null
+	instructions: string | null
+	tools: Array<never>
+	options: {
+		client: Record<string, unknown>
+		transport: {
+			type: string
+			headers?: Record<string, string>
+			authProvider: {
+				serverId: string
+				clientId?: string
+				authUrl?: string
+				redirectUrl: string
+			}
+		}
+	}
+}
+
+type FakeManager = {
+	rows: Array<FakeServerRow>
+	mcpConnections: Record<string, FakeConnection>
+	connectCount: number
+	callbackMatches: boolean
+	callbackResult: {
+		serverId?: string
+		authSuccess: boolean
+		authError?: string
+	}
+}
+
+const mockModule = vi.hoisted(() => ({
+	manager: null as FakeManager | null,
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+	instrumentDurableObjectWithSentry: (
+		_factory: unknown,
+		durableObjectClass: new (...args: Array<never>) => unknown,
+	) => durableObjectClass,
+}))
+
+vi.mock('cloudflare:workers', () => ({
+	DurableObject: class {
+		protected readonly ctx: DurableObjectState
+		protected readonly env: Env
+
+		constructor(ctx: DurableObjectState, env: Env) {
+			this.ctx = ctx
+			this.env = env
+		}
+	},
+}))
+
+vi.mock('agents/mcp/do-oauth-client-provider', () => ({
+	DurableObjectOAuthClientProvider: class {
+		serverId = ''
+		clientId: string | undefined
+		authUrl: string | undefined
+
+		constructor(
+			_storage: DurableObjectStorage,
+			_clientName: string,
+			readonly redirectUrl: string,
+		) {}
+	},
+}))
+
+vi.mock('agents/mcp/client', () => ({
+	MCPClientManager: class {
+		rows: Array<FakeServerRow> = []
+		mcpConnections: Record<string, FakeConnection> = {}
+		connectCount = 0
+		callbackMatches = true
+		callbackResult = {
+			serverId: 'server-1',
+			authSuccess: false,
+			authError: 'State not found or already used',
+		}
+
+		constructor() {
+			mockModule.manager = this
+		}
+
+		async restoreConnectionsFromStorage() {}
+
+		async waitForConnections() {}
+
+		listServers() {
+			return this.rows
+		}
+
+		async removeServer(serverId: string) {
+			this.rows = this.rows.filter((row) => row.id !== serverId)
+			delete this.mcpConnections[serverId]
+		}
+
+		async registerServer(
+			serverId: string,
+			options: {
+				url: string
+				name: string
+				callbackUrl: string
+				clientId?: string
+				client?: Record<string, unknown>
+				transport: FakeConnection['options']['transport']
+			},
+		) {
+			this.rows.push({
+				id: serverId,
+				name: options.name,
+				server_url: options.url,
+				callback_url: options.callbackUrl,
+				client_id: options.clientId ?? null,
+				auth_url: null,
+				server_options: null,
+			})
+			this.mcpConnections[serverId] = {
+				connectionState: 'disconnected',
+				connectionError: null,
+				instructions: null,
+				tools: [],
+				options: {
+					client: options.client ?? {},
+					transport: options.transport,
+				},
+			}
+		}
+
+		async connectToServer(serverId: string) {
+			this.connectCount += 1
+			const connection = this.mcpConnections[serverId]
+			if (!connection) throw new Error('Missing fake connection.')
+			const provider = connection.options.transport.authProvider
+			provider.clientId ??= `client-${this.connectCount}`
+			provider.authUrl = `https://auth.example/authorize?state=fresh-${this.connectCount}.${serverId}&redirect_uri=${encodeURIComponent(provider.redirectUrl)}`
+			connection.connectionState = 'authenticating'
+			const row = this.rows.find((item) => item.id === serverId)
+			if (!row) throw new Error('Missing fake server row.')
+			row.client_id = provider.clientId
+			row.auth_url = provider.authUrl
+			return {
+				state: 'authenticating',
+				authUrl: provider.authUrl,
+				clientId: provider.clientId,
+			}
+		}
+
+		async discoverIfConnected() {}
+
+		isCallbackRequest() {
+			return this.callbackMatches
+		}
+
+		async handleCallbackRequest() {
+			return this.callbackResult
+		}
+	},
+}))
+
+const {
+	McpClientHub,
+	extractMcpServerIdFromOAuthState,
+	isRecoverableMcpOAuthStateError,
+} = await import('./hub.ts')
+
+function createDurableObjectState() {
+	const values = new Map<string, unknown>()
+	return {
+		state: {
+			storage: {
+				sql: { exec: vi.fn(() => []) },
+				put: vi.fn(async (key: string, value: unknown) => {
+					values.set(key, value)
+				}),
+				get: vi.fn(async (key: string) => values.get(key)),
+				list: vi.fn(async ({ prefix }: { prefix: string }) => {
+					return new Map(
+						[...values.entries()].filter(([key]) => key.startsWith(prefix)),
+					)
+				}),
+				delete: vi.fn(async (keys: string | Array<string>) => {
+					for (const key of Array.isArray(keys) ? keys : [keys]) {
+						values.delete(key)
+					}
+				}),
+			},
+		} as unknown as DurableObjectState,
+		values,
+	}
+}
+
+function seedServer(input: {
+	manager: FakeManager
+	callbackUrl: string
+	clientId: string
+	authUrl: string
+}) {
+	const provider = {
+		serverId: 'server-1',
+		clientId: input.clientId,
+		authUrl: input.authUrl,
+		redirectUrl: input.callbackUrl,
+	}
+	input.manager.rows = [
+		{
+			id: 'server-1',
+			name: 'mediarss',
+			server_url: 'https://mediarss.example/mcp',
+			callback_url: input.callbackUrl,
+			client_id: input.clientId,
+			auth_url: input.authUrl,
+			server_options: null,
+		},
+	]
+	input.manager.mcpConnections = {
+		'server-1': {
+			connectionState: 'authenticating',
+			connectionError: null,
+			instructions: null,
+			tools: [],
+			options: {
+				client: {},
+				transport: {
+					type: 'auto',
+					headers: { 'X-Test': 'preserved' },
+					authProvider: provider,
+				},
+			},
+		},
+	}
+}
+
+test('reconnect repairs stale callbacks and always replaces pending OAuth state', async () => {
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+
+	const oldCallback =
+		'https://heykody.app/account/mcp-servers/oauth/callback'
+	const currentCallback =
+		'https://kody.codes/account/mcp-servers/oauth/callback'
+	seedServer({
+		manager,
+		callbackUrl: oldCallback,
+		clientId: 'stale-client',
+		authUrl: 'https://auth.example/authorize?state=stale.server-1',
+	})
+	values.set('/Kody/server-1/stale-client/client_info/', {
+		client_id: 'stale-client',
+	})
+	values.set('/Kody/server-1/state/stale', { serverId: 'server-1' })
+
+	const repaired = await hub.reconnectServer({
+		serverId: 'server-1',
+		callbackUrl: currentCallback,
+	})
+	const repairedRow = manager.rows[0]
+	expect(repaired.state).toBe('authenticating')
+	expect(repaired.authUrl).toContain('state=fresh-1.server-1')
+	expect(repaired.authUrl).toContain(encodeURIComponent(currentCallback))
+	expect(repairedRow?.callback_url).toBe(currentCallback)
+	expect(repairedRow?.client_id).toBe('client-1')
+	expect(repairedRow?.client_id).not.toBe('stale-client')
+	expect(
+		manager.mcpConnections['server-1']?.options.transport.headers,
+	).toEqual({ 'X-Test': 'preserved' })
+	expect(values.size).toBe(0)
+
+	values.set('/Kody/server-1/client-1/client_info/', {
+		client_id: 'client-1',
+	})
+	values.set('/Kody/server-1/state/fresh-1', { serverId: 'server-1' })
+	const firstAuthUrl = repaired.authUrl
+	const restarted = await hub.reconnectServer({
+		serverId: 'server-1',
+		callbackUrl: currentCallback,
+	})
+	expect(restarted.authUrl).toContain('state=fresh-2.server-1')
+	expect(restarted.authUrl).not.toBe(firstAuthUrl)
+	expect(manager.rows[0]?.client_id).toBe('client-1')
+	expect(values.has('/Kody/server-1/client-1/client_info/')).toBe(true)
+	expect(values.has('/Kody/server-1/state/fresh-1')).toBe(false)
+})
+
+test('used and missing callback states recover without exposing an internal state error', async () => {
+	const { state } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const callbackUrl =
+		'https://kody.codes/account/mcp-servers/oauth/callback'
+	seedServer({
+		manager,
+		callbackUrl,
+		clientId: 'client-1',
+		authUrl: 'https://auth.example/authorize?state=used.server-1',
+	})
+
+	const usedState = await hub.handleOAuthCallback({
+		url: `${callbackUrl}?code=abc&state=used.server-1`,
+		callbackUrl,
+	})
+	expect(usedState).toEqual({
+		serverId: 'server-1',
+		authSuccess: false,
+		authError:
+			'Authorization needed. Reconnect the MCP server and approve access once more.',
+		serverName: 'mediarss',
+		authorizationNeeded: true,
+	})
+	expect(manager.rows[0]?.auth_url).toContain('state=fresh-1.server-1')
+
+	manager.callbackMatches = false
+	const missingState = await hub.handleOAuthCallback({
+		url: `${callbackUrl}?error=access_denied`,
+		callbackUrl,
+	})
+	expect(missingState.authorizationNeeded).toBe(true)
+	expect(missingState.authError).not.toContain('state')
+})
+
+test('OAuth state recovery recognizes only unusable state failures', () => {
+	expect(extractMcpServerIdFromOAuthState('nonce.server-1')).toBe('server-1')
+	expect(extractMcpServerIdFromOAuthState('missing-server')).toBeNull()
+	expect(
+		isRecoverableMcpOAuthStateError('State not found or already used'),
+	).toBe(true)
+	expect(isRecoverableMcpOAuthStateError('access_denied')).toBe(false)
+})

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -273,6 +273,15 @@ class McpClientHubBase extends DurableObject<Env> {
 					callbackUrl: input.callbackUrl,
 				})
 			}
+			const pendingServers = this.manager
+				.listServers()
+				.filter((server) => Boolean(server.auth_url))
+			if (pendingServers.length === 1 && pendingServers[0]) {
+				return await this.restartAfterUnusableCallback({
+					serverId: pendingServers[0].id,
+					callbackUrl: input.callbackUrl,
+				})
+			}
 			return {
 				serverId: null,
 				authSuccess: false,

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -377,33 +377,72 @@ class McpClientHubBase extends DurableObject<Env> {
 		const existingOptions = existingConnection?.options
 		const callbackChanged = row.callback_url !== input.callbackUrl
 		const clientId = callbackChanged ? null : row.client_id
-
-		await this.manager.removeServer(input.serverId)
-		await this.clearOAuthAuthorizationStorage({
-			serverId: input.serverId,
-			clearClientRegistration: callbackChanged,
+		const oauthStoragePrefix = `/${mcpClientName}/${input.serverId}/`
+		const oauthStorageSnapshot = await this.ctx.storage.list({
+			prefix: oauthStoragePrefix,
 		})
 
-		const authProvider = new DurableObjectOAuthClientProvider(
-			this.ctx.storage,
-			mcpClientName,
-			input.callbackUrl,
-		)
-		authProvider.serverId = input.serverId
-		if (clientId) authProvider.clientId = clientId
+		try {
+			await this.manager.removeServer(input.serverId)
+			await this.clearOAuthAuthorizationStorage({
+				serverId: input.serverId,
+				clearClientRegistration: callbackChanged,
+			})
 
-		await this.manager.registerServer(input.serverId, {
-			url: row.server_url,
-			name: row.name,
-			callbackUrl: input.callbackUrl,
-			...(clientId ? { clientId } : {}),
-			...(existingOptions?.client ? { client: existingOptions.client } : {}),
-			transport: {
-				...existingOptions?.transport,
-				type: existingOptions?.transport.type ?? 'auto',
-				authProvider,
-			},
-		})
+			const authProvider = new DurableObjectOAuthClientProvider(
+				this.ctx.storage,
+				mcpClientName,
+				input.callbackUrl,
+			)
+			authProvider.serverId = input.serverId
+			if (clientId) authProvider.clientId = clientId
+
+			await this.manager.registerServer(input.serverId, {
+				url: row.server_url,
+				name: row.name,
+				callbackUrl: input.callbackUrl,
+				...(clientId ? { clientId } : {}),
+				...(existingOptions?.client ? { client: existingOptions.client } : {}),
+				transport: {
+					...existingOptions?.transport,
+					type: existingOptions?.transport.type ?? 'auto',
+					authProvider,
+				},
+			})
+		} catch (error) {
+			await this.manager.removeServer(input.serverId).catch(() => {})
+			if (oauthStorageSnapshot.size > 0) {
+				await this.ctx.storage
+					.put(Object.fromEntries(oauthStorageSnapshot))
+					.catch(() => {})
+			}
+
+			const originalAuthProvider = new DurableObjectOAuthClientProvider(
+				this.ctx.storage,
+				mcpClientName,
+				row.callback_url,
+			)
+			originalAuthProvider.serverId = input.serverId
+			if (row.client_id) originalAuthProvider.clientId = row.client_id
+			await this.manager
+				.registerServer(input.serverId, {
+					url: row.server_url,
+					name: row.name,
+					callbackUrl: row.callback_url,
+					...(row.client_id ? { clientId: row.client_id } : {}),
+					...(row.auth_url ? { authUrl: row.auth_url } : {}),
+					...(existingOptions?.client
+						? { client: existingOptions.client }
+						: {}),
+					transport: {
+						...existingOptions?.transport,
+						type: existingOptions?.transport.type ?? 'auto',
+						authProvider: originalAuthProvider,
+					},
+				})
+				.catch(() => {})
+			throw error
+		}
 		const result = await this.manager.connectToServer(input.serverId)
 		if (result.state === 'connected') {
 			await this.manager.discoverIfConnected(input.serverId, {

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -266,9 +266,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		if (!this.manager.isCallbackRequest(request)) {
 			if (
 				stateServerId &&
-				this.manager
-					.listServers()
-					.some((server) => server.id === stateServerId)
+				this.manager.listServers().some((server) => server.id === stateServerId)
 			) {
 				return await this.restartAfterUnusableCallback({
 					serverId: stateServerId,
@@ -330,9 +328,8 @@ class McpClientHubBase extends DurableObject<Env> {
 		callbackUrl: string
 	}): Promise<McpServerOAuthCallbackOutcome> {
 		const serverName =
-			this.manager
-				.listServers()
-				.find((server) => server.id === input.serverId)?.name ?? null
+			this.manager.listServers().find((server) => server.id === input.serverId)
+				?.name ?? null
 		try {
 			const connection = await this.restartServerAuthorization(input)
 			if (connection.state === 'ready') {

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -21,6 +21,27 @@ const mcpClientName = 'Kody'
 const mcpClientVersion = '1.0.0'
 const connectionSettleTimeoutMs = 8_000
 const discoverTimeoutMs = 15_000
+const oauthRecoveryMessage =
+	'Authorization needed. Reconnect the MCP server and approve access once more.'
+
+export function extractMcpServerIdFromOAuthState(state: string | null) {
+	if (!state) return null
+	const parts = state.split('.')
+	if (parts.length !== 2) return null
+	return parts[1] || null
+}
+
+export function isRecoverableMcpOAuthStateError(error: string | null) {
+	if (!error) return false
+	const normalized = error.toLowerCase()
+	return (
+		normalized.includes('state not found') ||
+		normalized.includes('already used') ||
+		normalized.includes('state expired') ||
+		normalized.includes('invalid state') ||
+		normalized.includes('no state provided')
+	)
+}
 
 /**
  * Per-user Durable Object that owns the Agents SDK `MCPClientManager` for all
@@ -185,31 +206,23 @@ class McpClientHubBase extends DurableObject<Env> {
 		return this.buildConnectResult(input.serverId)
 	}
 
-	/** Retry connecting to an already registered server. */
+	/**
+	 * Restart a saved server with the deployment's current OAuth callback.
+	 *
+	 * Re-registering the local connection clears pending state and PKCE values,
+	 * so every reconnect gets a fresh authorization URL. A callback change also
+	 * drops the stored dynamic client registration, forcing DCR to advertise the
+	 * current redirect URI while preserving the saved server row in D1.
+	 */
 	async reconnectServer(input: {
 		serverId: string
+		callbackUrl: string
 	}): Promise<McpServerConnectResult> {
 		await this.ensureRestored()
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
 		})
-		const state = this.connectionStateFor(input.serverId)
-		if (state === 'disconnected') {
-			throw new Error(`MCP server "${input.serverId}" is not registered.`)
-		}
-		if (state !== 'ready' && state !== 'discovering') {
-			const result = await this.manager.connectToServer(input.serverId)
-			if (result.state === 'connected') {
-				await this.manager.discoverIfConnected(input.serverId, {
-					timeoutMs: discoverTimeoutMs,
-				})
-			}
-		}
-		const connected = this.buildConnectResult(input.serverId)
-		if (isStuckMcpAuthenticatingWithoutAuthUrl(connected)) {
-			return await this.recoverStuckAuthenticating(input.serverId)
-		}
-		return connected
+		return await this.restartServerAuthorization(input)
 	}
 
 	/** Re-discover tools for a connected server. */
@@ -243,15 +256,31 @@ class McpClientHubBase extends DurableObject<Env> {
 	 */
 	async handleOAuthCallback(input: {
 		url: string
+		callbackUrl: string
 	}): Promise<McpServerOAuthCallbackOutcome> {
 		await this.ensureRestored()
 		const request = new Request(input.url, { method: 'GET' })
+		const stateServerId = extractMcpServerIdFromOAuthState(
+			new URL(request.url).searchParams.get('state'),
+		)
 		if (!this.manager.isCallbackRequest(request)) {
+			if (
+				stateServerId &&
+				this.manager
+					.listServers()
+					.some((server) => server.id === stateServerId)
+			) {
+				return await this.restartAfterUnusableCallback({
+					serverId: stateServerId,
+					callbackUrl: input.callbackUrl,
+				})
+			}
 			return {
 				serverId: null,
 				authSuccess: false,
-				authError: 'This URL is not a pending MCP OAuth callback.',
+				authError: oauthRecoveryMessage,
 				serverName: null,
+				authorizationNeeded: true,
 			}
 		}
 		const result = await this.manager.handleCallbackRequest(request)
@@ -260,6 +289,16 @@ class McpClientHubBase extends DurableObject<Env> {
 			? (this.manager.listServers().find((server) => server.id === serverId)
 					?.name ?? null)
 			: null
+		if (
+			serverId &&
+			!result.authSuccess &&
+			isRecoverableMcpOAuthStateError(result.authError ?? null)
+		) {
+			return await this.restartAfterUnusableCallback({
+				serverId,
+				callbackUrl: input.callbackUrl,
+			})
+		}
 		if (result.authSuccess && serverId) {
 			await this.manager.establishConnection(serverId)
 			await this.manager.waitForConnections({
@@ -284,6 +323,103 @@ class McpClientHubBase extends DurableObject<Env> {
 			serverName,
 			connection: serverId ? this.buildConnectResult(serverId) : null,
 		})
+	}
+
+	private async restartAfterUnusableCallback(input: {
+		serverId: string
+		callbackUrl: string
+	}): Promise<McpServerOAuthCallbackOutcome> {
+		const serverName =
+			this.manager
+				.listServers()
+				.find((server) => server.id === input.serverId)?.name ?? null
+		try {
+			const connection = await this.restartServerAuthorization(input)
+			if (connection.state === 'ready') {
+				return {
+					serverId: input.serverId,
+					authSuccess: true,
+					authError: null,
+					serverName,
+					authorizationNeeded: false,
+				}
+			}
+		} catch {
+			// The account page still offers Reconnect if automatic recovery fails.
+		}
+		return {
+			serverId: input.serverId,
+			authSuccess: false,
+			authError: oauthRecoveryMessage,
+			serverName,
+			authorizationNeeded: true,
+		}
+	}
+
+	private async restartServerAuthorization(input: {
+		serverId: string
+		callbackUrl: string
+	}): Promise<McpServerConnectResult> {
+		const row = this.manager
+			.listServers()
+			.find((server) => server.id === input.serverId)
+		if (!row) {
+			throw new Error(`MCP server "${input.serverId}" is not registered.`)
+		}
+
+		const existingConnection = this.manager.mcpConnections[input.serverId]
+		const existingOptions = existingConnection?.options
+		const callbackChanged = row.callback_url !== input.callbackUrl
+		const clientId = callbackChanged ? null : row.client_id
+
+		await this.manager.removeServer(input.serverId)
+		await this.clearOAuthAuthorizationStorage({
+			serverId: input.serverId,
+			clearClientRegistration: callbackChanged,
+		})
+
+		const authProvider = new DurableObjectOAuthClientProvider(
+			this.ctx.storage,
+			mcpClientName,
+			input.callbackUrl,
+		)
+		authProvider.serverId = input.serverId
+		if (clientId) authProvider.clientId = clientId
+
+		await this.manager.registerServer(input.serverId, {
+			url: row.server_url,
+			name: row.name,
+			callbackUrl: input.callbackUrl,
+			...(clientId ? { clientId } : {}),
+			...(existingOptions?.client ? { client: existingOptions.client } : {}),
+			transport: {
+				...existingOptions?.transport,
+				type: existingOptions?.transport.type ?? 'auto',
+				authProvider,
+			},
+		})
+		const result = await this.manager.connectToServer(input.serverId)
+		if (result.state === 'connected') {
+			await this.manager.discoverIfConnected(input.serverId, {
+				timeoutMs: discoverTimeoutMs,
+			})
+		}
+		return this.buildConnectResult(input.serverId)
+	}
+
+	private async clearOAuthAuthorizationStorage(input: {
+		serverId: string
+		clearClientRegistration: boolean
+	}) {
+		const prefix = `/${mcpClientName}/${input.serverId}/`
+		const entries = await this.ctx.storage.list({ prefix })
+		const keys = [...entries.keys()].filter((key) => {
+			if (input.clearClientRegistration) return true
+			return !key.endsWith('/client_info/') && !key.endsWith('/oauth_discovery')
+		})
+		if (keys.length > 0) {
+			await this.ctx.storage.delete(keys)
+		}
 	}
 
 	/**

--- a/packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts
@@ -23,6 +23,7 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 		authSuccess: true,
 		authError: null,
 		serverName: 'recipe-keeper',
+		authorizationNeeded: false,
 	})
 
 	const stuckAuthenticating = resolveMcpOAuthCallbackOutcome({
@@ -68,6 +69,7 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 		authSuccess: false,
 		authError: 'Token exchange failed.',
 		serverName: 'recipe-keeper',
+		authorizationNeeded: false,
 	})
 
 	expect(
@@ -87,6 +89,7 @@ test('OAuth callback outcome requires a ready connection after SDK success', () 
 		authSuccess: false,
 		authError: 'Invalid state',
 		serverName: 'recipe-keeper',
+		authorizationNeeded: false,
 	})
 
 	const waitingForAuth = describeIncompleteMcpOAuthConnection({

--- a/packages/worker/src/mcp-client/oauth-callback-outcome.ts
+++ b/packages/worker/src/mcp-client/oauth-callback-outcome.ts
@@ -32,6 +32,7 @@ export function resolveMcpOAuthCallbackOutcome(input: {
 			authSuccess: false,
 			authError: input.sdkAuthError ?? 'Authorization failed.',
 			serverName,
+			authorizationNeeded: false,
 		}
 	}
 
@@ -42,6 +43,7 @@ export function resolveMcpOAuthCallbackOutcome(input: {
 			authError:
 				'Authorization completed, but Kody lost the MCP server connection. Try reconnecting from /account/mcp-servers.',
 			serverName,
+			authorizationNeeded: false,
 		}
 	}
 
@@ -51,6 +53,7 @@ export function resolveMcpOAuthCallbackOutcome(input: {
 			authSuccess: true,
 			authError: null,
 			serverName,
+			authorizationNeeded: false,
 		}
 	}
 
@@ -61,6 +64,7 @@ export function resolveMcpOAuthCallbackOutcome(input: {
 			input.connection.error ??
 			describeIncompleteMcpOAuthConnection(input.connection),
 		serverName,
+		authorizationNeeded: false,
 	}
 }
 
@@ -72,7 +76,7 @@ export function describeIncompleteMcpOAuthConnection(connection: {
 		return 'Authorization completed at the identity provider, but the MCP server still requires authorization. Open the authorization link again from /account/mcp-servers.'
 	}
 	if (connection.state === 'authenticating') {
-		return 'Authorization completed at the identity provider, but Kody could not finish connecting and has no authorization link to offer. Reconnect the server from /account/mcp-servers, or remove and add it again.'
+		return 'Authorization completed, but Kody could not finish connecting. Reconnect the server from /account/mcp-servers and approve access once more.'
 	}
 	return `Authorization completed at the identity provider, but the MCP server is still "${connection.state}". Reconnect it from /account/mcp-servers.`
 }

--- a/packages/worker/src/mcp-client/oauth-provider-error.ts
+++ b/packages/worker/src/mcp-client/oauth-provider-error.ts
@@ -34,7 +34,7 @@ export function enrichMcpOAuthProviderError(
 		trimmed,
 		`Kody authorizes as an OAuth client from ${input.clientOrigin}.`,
 		`If you operate this MCP server (or its identity provider), allow that origin and register this exact redirect URI: ${input.callbackUrl}.`,
-		'Then remove and re-add the server in Kody (or reconnect) so registration uses the allowlisted values.',
+		'Then reconnect the server in Kody so authorization uses the allowlisted values.',
 	]
 	return parts.join(' ')
 }

--- a/packages/worker/src/mcp-client/types.ts
+++ b/packages/worker/src/mcp-client/types.ts
@@ -55,4 +55,5 @@ export type McpServerOAuthCallbackOutcome = {
 	authSuccess: boolean
 	authError: string | null
 	serverName: string | null
+	authorizationNeeded: boolean
 }

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-add.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-add.ts
@@ -89,7 +89,7 @@ export const mcpServerAddCapability = defineDomainCapability(
 				: null
 			const nextStep =
 				connection.state === 'authenticating' && connection.authUrl
-					? `The server requires OAuth authorization. Ask the user to open ${connection.authUrl} (also available from ${oauth.clientOrigin}/account/mcp-servers) to authorize Kody. If the provider rejects Kody's origin or redirect URI, they must allow ${oauth.clientOrigin} and ${oauth.callbackUrl}, then remove and re-add the server. After authorizing, check mcp_server_list.`
+					? `The server requires OAuth authorization. Ask the user to open ${connection.authUrl} (also available from ${oauth.clientOrigin}/account/mcp-servers) to authorize Kody. If the provider rejects Kody's origin or redirect URI, they must allow ${oauth.clientOrigin} and ${oauth.callbackUrl}, then reconnect the server. After authorizing, check mcp_server_list.`
 					: connection.state === 'ready'
 						? `Connected with ${connection.toolCount} tool(s). Use search or meta_list_capabilities to discover kody.mcp["${setting.name}"] capabilities.`
 						: error

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-reconnect.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-reconnect.ts
@@ -48,7 +48,10 @@ export const mcpServerReconnectCapability = defineDomainCapability(
 				env: ctx.env,
 				userId: user.userId,
 			})
-			const result = await hub.reconnectServer({ serverId: setting.id })
+			const result = await hub.reconnectServer({
+				serverId: setting.id,
+				callbackUrl: oauth.callbackUrl,
+			})
 			return {
 				id: setting.id,
 				name: setting.name,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let signed-in users recover remote MCP OAuth connections after a public-domain cutover or an unusable authorization attempt without admin support or removing the saved server.

## Summary

- Rebuild reconnect attempts with the deployment's canonical callback URL and a fresh OAuth state/PKCE pair.
- Drop stale local Dynamic Client Registration data only when the callback changed, while preserving the user's MCP server metadata, enabled flag, and connection options.
- Compensate failed registration replacement by restoring the prior server row, transport options, and OAuth storage snapshot.
- Turn missing, expired, or already-used callback state into a plain “Authorization needed” recovery flow; when one pending server can be identified, mint its replacement authorization URL automatically.
- Remove account UI guidance that asks users to remove and re-add a server.
- Add regression coverage for callback migration repair, fresh reconnect state, callback recovery, and replacement rollback.

Migration safety: this is a heal-on-reconnect/callback path, not a bulk migration. Registrations whose callback still matches are retained; only transient authorization credentials are refreshed. A callback mismatch causes Kody to discard the obsolete local client registration and perform DCR again against the remote authorization server. If replacement setup fails, Kody restores the previous registration state so Reconnect remains available.

## Testing

- `npx vitest run --project node-unit packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts packages/worker/src/mcp-client/oauth-callback-outcome.node.test.ts packages/worker/src/app/handlers/account-mcp-servers.node.test.ts` (10 passed)
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- GitHub Validate: Static, Node, Workers, MCP, and E2E all passed on `bc4dfffd`.
- Preview `kody-pr-1462`: signed in as the non-admin seed user, added the preview itself as an OAuth-protected remote MCP server, reconnected it twice through `/account/mcp-servers.json`, and confirmed the saved server remained manageable with a fresh authorization-required state.
- UI pass: Reconnect produced “Authorization needed. Open the new authorization link and approve access once more,” kept the authorization action available, and showed no internal state error or remove/re-add guidance.

<a href="https://cursor.com/agents/bc-59cb3b14-958f-4788-b511-354ce575fefc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_oauth_reconnect_self_heal.mp4"><img src="https://cursor.com/artifacts/c/art-25fa025a-4d9d-42fe-b547-5ce8b4a1ed8f" alt="mcp_oauth_reconnect_self_heal.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1ae55121` · **Head:** `bc4dfffd`

**Classification:** extends — changes remote MCP client OAuth recovery behavior and its account UI; no new primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | extends — canonical callback repair, fresh state issuance, callback recovery, and failure compensation |
| `app-ui` | surfaces | extends — non-scary authorization-needed messaging and self-serve actions |

### System map

Remote MCP authorization flows from the account UI through the per-user MCP client hub, which repairs stale client registration state before sending the user back to the remote authorization server.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::extended
	mcpClient["mcp-client-servers<br/>MCP client servers"]:::extended
	remoteAs["Remote authorization server"]:::untouched
	appUi -->|"Reconnect / callback recovery with canonical callback"| mcpClient
	mcpClient -->|"Fresh state + PKCE; DCR again only after callback mismatch"| remoteAs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant User
	participant UI as Account MCP servers UI
	participant Hub as Per-user MCP client hub
	participant AS as Remote authorization server
	User->>UI: Reconnect or return with unusable callback state
	UI->>Hub: Restart using canonical callback URL
	Hub->>Hub: Snapshot prior registration and OAuth storage
	Hub->>Hub: Clear pending state and PKCE
	alt callback changed
		Hub->>Hub: Drop obsolete local client registration
		Hub->>AS: Dynamic Client Registration with current redirect URI
	end
	alt replacement setup fails
		Hub->>Hub: Restore prior registration, options, and OAuth storage
	else replacement succeeds
		Hub->>AS: Create fresh authorization request
	end
	Hub-->>UI: Authorization needed + new auth URL
	UI-->>User: Ask to approve access once more
```

### Invariants

- Per-user isolation is preserved: repair occurs only inside the signed-in user's existing MCP client hub and saved server row.
- Saved server URL, name, enabled flag, and non-OAuth transport options survive repair.
- Replacement failures restore the prior manageable registration rather than stranding the D1 setting.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59cb3b14-958f-4788-b511-354ce575fefc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59cb3b14-958f-4788-b511-354ce575fefc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved MCP server OAuth recovery for expired, invalid, or missing authorization sessions.
  - Reconnection now preserves connection settings and determines whether additional authorization is required.
  - Added clearer status messages for successful reconnections and pending authorization.

- **Bug Fixes**
  - Replaced misleading OAuth errors with actionable reconnect guidance.
  - Improved handling of servers requiring authorization without a direct authorization link.
  - Reconnection now uses the current authorization callback to restore access more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->