### PR TITLE
Allowlist Cursor Cloud Agent authors on the CLA check

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -3,11 +3,7 @@
 	"document": "docs/legal/individual-cla.md",
 	"allowlist": {
 		"github": ["kentcdodds", "kody-bot", "cursoragent"],
-		"email": [
-			"me@kentcdodds.com",
-			"me+github@kentcdodds.com",
-			"cursoragent@cursor.com"
-		]
+		"email": ["me@kentcdodds.com", "me+github@kentcdodds.com"]
 	},
 	"signers": []
 }

--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -2,8 +2,12 @@
 	"version": 1,
 	"document": "docs/legal/individual-cla.md",
 	"allowlist": {
-		"github": ["kentcdodds", "kody-bot"],
-		"email": ["me@kentcdodds.com", "me+github@kentcdodds.com"]
+		"github": ["kentcdodds", "kody-bot", "cursoragent"],
+		"email": [
+			"me@kentcdodds.com",
+			"me+github@kentcdodds.com",
+			"cursoragent@cursor.com"
+		]
 	},
 	"signers": []
 }

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@v6.0.2
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
       - name: Setup Node

--- a/docs/contributing/decisions/0018-inbound-cla.md
+++ b/docs/contributing/decisions/0018-inbound-cla.md
@@ -51,8 +51,9 @@ How it works:
 - **Scope.** This git repository only. User packages, community listings (MIT),
   and unsubmitted forks are out of scope.
 - **Who signs.** Every GitHub identity that authors a commit on the pull
-  request, unless that identity is `kentcdodds`, `kody-bot`, a `*[bot]` or
-  `app/*` account, or an email listed as Licensor-owned in
+  request, unless that identity is `kentcdodds`, `kody-bot`, `cursoragent`, a
+  `*[bot]` or `app/*` account, or an email listed as Licensor-owned or Cloud
+  Agent-owned in
   [`.github/cla-signers.json`](../../../.github/cla-signers.json).
 - **Which form.** [Individual CLA](../../legal/individual-cla.md) by default.
   [Entity CLA](../../legal/entity-cla.md) when the work is owned by an employer

--- a/docs/contributing/decisions/0018-inbound-cla.md
+++ b/docs/contributing/decisions/0018-inbound-cla.md
@@ -52,8 +52,7 @@ How it works:
   and unsubmitted forks are out of scope.
 - **Who signs.** Every GitHub identity that authors a commit on the pull
   request, unless that identity is `kentcdodds`, `kody-bot`, `cursoragent`, a
-  `*[bot]` or `app/*` account, or an email listed as Licensor-owned or Cloud
-  Agent-owned in
+  `*[bot]` or `app/*` account, or an email listed as Licensor-owned in
   [`.github/cla-signers.json`](../../../.github/cla-signers.json).
 - **Which form.** [Individual CLA](../../legal/individual-cla.md) by default.
   [Entity CLA](../../legal/entity-cla.md) when the work is owned by an employer

--- a/docs/contributing/inbound-contributions.md
+++ b/docs/contributing/inbound-contributions.md
@@ -63,7 +63,7 @@ These identities are allowlisted in `.github/cla-signers.json` and do not sign:
 - `kentcdodds` (Licensor)
 - `kody-bot` and other logins listed in that file
 - `cursoragent` (Cursor Cloud Agent commit author)
-- Licensor-owned and Cloud Agent commit emails listed in that file
+- Licensor-owned commit emails listed in that file
 - GitHub accounts whose login ends in `[bot]` or starts with `app/`
 
 Cursor Cloud Agent pull requests follow the Licensor path even when GitHub

--- a/docs/contributing/inbound-contributions.md
+++ b/docs/contributing/inbound-contributions.md
@@ -62,11 +62,12 @@ These identities are allowlisted in `.github/cla-signers.json` and do not sign:
 
 - `kentcdodds` (Licensor)
 - `kody-bot` and other logins listed in that file
-- Licensor-owned commit emails listed in that file
+- `cursoragent` (Cursor Cloud Agent commit author)
+- Licensor-owned and Cloud Agent commit emails listed in that file
 - GitHub accounts whose login ends in `[bot]` or starts with `app/`
 
-Cursor Cloud Agent pull requests that GitHub authors as `kentcdodds` follow the
-Licensor path.
+Cursor Cloud Agent pull requests follow the Licensor path even when GitHub
+authors the pull request as `kentcdodds` and the commits as `cursoragent`.
 
 ## Maintainer steps
 

--- a/tools/ci/check-cla.node.test.ts
+++ b/tools/ci/check-cla.node.test.ts
@@ -13,8 +13,12 @@ function signersFile(overrides: Partial<ClaSignersFile> = {}): ClaSignersFile {
 		version: 1,
 		document: 'docs/legal/individual-cla.md',
 		allowlist: {
-			github: ['kentcdodds', 'kody-bot'],
-			email: ['me@kentcdodds.com', 'me+github@kentcdodds.com'],
+			github: ['kentcdodds', 'kody-bot', 'cursoragent'],
+			email: [
+				'me@kentcdodds.com',
+				'me+github@kentcdodds.com',
+				'cursoragent@cursor.com',
+			],
 		},
 		signers: [],
 		...overrides,
@@ -36,6 +40,11 @@ test('CLA check allowlists the Licensor, bots, signed humans, and rejects everyo
 		[
 			{ githubLogin: 'kentcdodds', name: 'Kent', email: null },
 			{ githubLogin: 'kody-bot', name: 'Kody', email: null },
+			{
+				githubLogin: 'cursoragent',
+				name: 'Cursor Agent',
+				email: 'cursoragent@cursor.com',
+			},
 			{
 				githubLogin: 'cursor[bot]',
 				name: 'cursor[bot]',
@@ -99,6 +108,28 @@ test('CLA signers file parser rejects the wrong version and accepts the repo fil
 	const parsed = parseClaSignersFile(
 		readFileSync('.github/cla-signers.json', 'utf8'),
 	)
-	expect(parsed.allowlist.github).toEqual(['kentcdodds', 'kody-bot'])
+	expect(parsed.allowlist.github).toEqual([
+		'kentcdodds',
+		'kody-bot',
+		'cursoragent',
+	])
+	expect(parsed.allowlist.email).toContain('cursoragent@cursor.com')
 	expect(parsed.signers).toEqual([])
+	expect(
+		checkClaIdentities(
+			[
+				{
+					githubLogin: 'kentcdodds',
+					name: 'kentcdodds',
+					email: null,
+				},
+				{
+					githubLogin: 'cursoragent',
+					name: 'Cursor Agent',
+					email: 'cursoragent@cursor.com',
+				},
+			],
+			parsed,
+		),
+	).toEqual({ ok: true })
 })

--- a/tools/ci/check-cla.node.test.ts
+++ b/tools/ci/check-cla.node.test.ts
@@ -14,11 +14,7 @@ function signersFile(overrides: Partial<ClaSignersFile> = {}): ClaSignersFile {
 		document: 'docs/legal/individual-cla.md',
 		allowlist: {
 			github: ['kentcdodds', 'kody-bot', 'cursoragent'],
-			email: [
-				'me@kentcdodds.com',
-				'me+github@kentcdodds.com',
-				'cursoragent@cursor.com',
-			],
+			email: ['me@kentcdodds.com', 'me+github@kentcdodds.com'],
 		},
 		signers: [],
 		...overrides,
@@ -113,7 +109,10 @@ test('CLA signers file parser rejects the wrong version and accepts the repo fil
 		'kody-bot',
 		'cursoragent',
 	])
-	expect(parsed.allowlist.email).toContain('cursoragent@cursor.com')
+	expect(parsed.allowlist.email).toEqual([
+		'me@kentcdodds.com',
+		'me+github@kentcdodds.com',
+	])
 	expect(parsed.signers).toEqual([])
 	expect(
 		checkClaIdentities(
@@ -132,4 +131,42 @@ test('CLA signers file parser rejects the wrong version and accepts the repo fil
 			parsed,
 		),
 	).toEqual({ ok: true })
+	expect(
+		checkClaIdentities(
+			[
+				{
+					githubLogin: null,
+					name: 'Cursor Agent',
+					email: 'cursoragent@cursor.com',
+				},
+				{
+					githubLogin: 'mirkosalvato1-ctrl',
+					name: 'Mirko',
+					email: 'cursoragent@cursor.com',
+				},
+			],
+			parsed,
+		),
+	).toEqual({
+		ok: false,
+		missing: [
+			{
+				identity: {
+					githubLogin: null,
+					name: 'Cursor Agent',
+					email: 'cursoragent@cursor.com',
+				},
+				reason:
+					'cursoragent@cursor.com has no GitHub login and is not a Licensor email',
+			},
+			{
+				identity: {
+					githubLogin: 'mirkosalvato1-ctrl',
+					name: 'Mirko',
+					email: 'cursoragent@cursor.com',
+				},
+				reason: '@mirkosalvato1-ctrl has not signed the CLA',
+			},
+		],
+	})
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Cloud Agent pull requests should pass the CLA check. They are Licensor work, not outside contributions.

## Summary

[#1462](https://github.com/kentcdodds/kody/pull/1462) failed CLA because GitHub authors the PR as `kentcdodds` (allowlisted) and the commits as `cursoragent` (not allowlisted). That identity is Cursor Cloud Agent automation, not a human contributor.

- Allowlist the authenticated GitHub login `cursoragent` in `.github/cla-signers.json`
- Do **not** allowlist `cursoragent@cursor.com` by itself (a commit can claim that email without Cursor provenance)
- Document that Cloud Agent PRs follow the Licensor path even when commits are authored as `cursoragent`
- Check out the live base **ref** (`main`) instead of the frozen base SHA so a re-run after this lands sees the updated signers file

**Merge note:** this PR's own `CLA` check stays red until the allowlist is on `main` (the workflow reads signers from the base branch). That is the same miss as #1462, not a new unsigned contributor. Merge this first, then re-run CLA on #1462. A re-run is enough; no new commit is required.

kody-video and kody-exchange will hit the same miss unless they get the same allowlist.

## Testing

- Reproduced #1462 identities against the old allowlist: `@cursoragent has not signed the CLA` (same text as [job 95113396445](https://github.com/kentcdodds/kody/actions/runs/31925939293/job/95113396445))
- Same identities against this branch (login allowlist only): `PASS`
- Email-only or mismatched-login `cursoragent@cursor.com` still fails
- `npx vitest run --project node-unit tools/ci/check-cla.node.test.ts` — 2 passed
- GitHub `✅ Validate` on the first revision was green (Static, Node, Workers, MCP, E2E). The red `CLA` check is the expected chicken-and-egg until merge.

## System changes

CI and contributing docs only. No runtime primitives.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c65a44f9` · **Head:** `b6466768`

**Classification:** composes — no primitives added or changed; this PR only updates the inbound CLA allowlist and the workflow checkout ref.

### Primitives touched

_None._ Classifier matched 0 of 5 paths. The diff is `.github/cla-signers.json`, `.github/workflows/cla.yml`, inbound CLA docs, and `tools/ci/check-cla.node.test.ts`.

### System map

The CLA job still reads signers from `main` and still fails closed. This PR only adds the Cloud Agent GitHub login and points checkout at the live base branch so a re-run sees that file.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	claWorkflow["CLA workflow<br/>.github/workflows/cla.yml"]:::touched
	signersFile["cla-signers.json<br/>allowlist on main"]:::touched
	checkCla["check-cla.ts<br/>identity gate"]:::untouched
	claWorkflow -->|"checkout base.ref instead of base.sha"| signersFile
	claWorkflow -->|"kentcdodds + cursoragent identities"| checkCla
	signersFile -->|"allowlist cursoragent login"| checkCla
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant PR as Cloud Agent PR
	participant GH as GitHub
	participant CLA as CLA job
	PR->>GH: author kentcdodds, commits cursoragent
	GH->>CLA: pull_request synchronize
	CLA->>CLA: checkout main (base.ref)
	CLA->>CLA: allowlist cursoragent login
	CLA-->>GH: pass
```

### Before / after

| Identity on a Cloud Agent PR | Before | After |
| --- | --- | --- |
| `kentcdodds` (PR author) | allowlisted | allowlisted |
| `cursoragent` (commit author login) | unsigned, job fails | allowlisted, job passes |
| `cursoragent@cursor.com` without that login | n/a | still unsigned |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62bdff02-40a1-4661-883a-c1b0f4f417cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62bdff02-40a1-4661-883a-c1b0f4f417cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contribution and CLA guidance for Cloud Agent-authored pull requests and commits.
* **Chores**
  * Updated CLA signer permissions to recognize the Cloud Agent identity and email.
  * Improved CLA workflow branch handling.
* **Tests**
  * Expanded CLA validation coverage for approved Cloud Agent identities and signer records.
  * Confirmed invalid Cloud Agent email-only and unsigned-account scenarios remain rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->