### PR TITLE
Drain unused leftover repo sessions from the index catalog

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -926,7 +926,11 @@ via `durableObjectNameFromParts`); domain helpers such as
   per-user session catalog: rows, active counts, conversation resume, export,
   and deletion inventory. Each index self-alarms; D1 keeps only the thin
   `repo_session_due_owners` hint (one row per user with any session) plus the
-  platform-owned storage-bucket inventory cursor.
+  platform-owned storage-bucket inventory cursor. Unused (never-checkpointed)
+  due sessions leave the catalog in one SQL pass so entitlement counts drop
+  immediately; workspace Durable Objects then purge in bounded alarm batches
+  without waiting on remote branch deletes. Edited and expired sessions still
+  take the per-session cleanup path.
 - `RepoSession` — `repoSessionDurableObjectName(sessionId)` keyed by session id
   only (not user-prefixed). Every RPC validates the catalog row's `user_id`
   before touching the workspace. Account deletion enumerates the user's session

--- a/packages/worker/src/repo/repo-session-due.ts
+++ b/packages/worker/src/repo/repo-session-due.ts
@@ -61,6 +61,38 @@ export function nextOwnerDueAt(
 	return dues.reduce((earliest, due) => (due < earliest ? due : earliest))
 }
 
+/**
+ * Same earliest-due rule as {@link nextOwnerDueAt}, from catalog MIN() bounds
+ * plus an optional pending workspace-purge queue. Avoids loading every row.
+ */
+export function nextOwnerDueAtFromBounds(input: {
+	unusedMinUpdatedAt: string | null
+	editedMinUpdatedAt: string | null
+	minExpiresAt: string | null
+	hasRows: boolean
+	pendingPurge: boolean
+	now?: Date
+}): string | null {
+	if (!input.hasRows && !input.pendingPurge) return null
+	const dues: Array<string> = []
+	if (input.unusedMinUpdatedAt != null) {
+		dues.push(
+			addMs(input.unusedMinUpdatedAt, unusedAbandonedSessionRetentionMs),
+		)
+	}
+	if (input.editedMinUpdatedAt != null) {
+		dues.push(
+			addMs(input.editedMinUpdatedAt, editedAbandonedSessionRetentionMs),
+		)
+	}
+	if (input.minExpiresAt != null) dues.push(input.minExpiresAt)
+	if (input.pendingPurge) {
+		dues.push((input.now ?? new Date()).toISOString())
+	}
+	if (dues.length === 0) return repoSessionFarFutureDueAt
+	return dues.reduce((earliest, due) => (due < earliest ? due : earliest))
+}
+
 export function isRepoSessionDue(
 	row: RepoSessionDueFields,
 	now: Date,

--- a/packages/worker/src/repo/repo-session-index-do.ts
+++ b/packages/worker/src/repo/repo-session-index-do.ts
@@ -6,7 +6,7 @@ import { buildSentryOptions } from '#worker/sentry-options.ts'
 import { replaceRepoSessionDueOwner } from './repo-session-due-owners.ts'
 import {
 	editedActiveDueBefore,
-	nextOwnerDueAt,
+	nextOwnerDueAtFromBounds,
 	repoSessionCleanupReason,
 	unusedActiveDueBefore,
 } from './repo-session-due.ts'
@@ -14,9 +14,9 @@ import { repoSessionRpc } from './repo-session-rpc.ts'
 import { repoSessionRowSchema, type RepoSessionRow } from './types.ts'
 
 const schemaVersionKey = 'schema_version'
-const hydratedFromD1Key = 'hydrated_from_d1'
-const repoSessionIndexSchemaVersion = 1
+const repoSessionIndexSchemaVersion = 2
 const defaultCleanupBatchSize = 100
+const unusedWorkspacePurgeBatchSize = 200
 const defaultExportPageSize = 100
 const maxExportPageSize = 500
 
@@ -156,6 +156,9 @@ class RepoSessionIndexBase extends DurableObject<Env> {
 				ON repo_sessions(status, last_checkpoint_at, updated_at, expires_at);
 			CREATE INDEX IF NOT EXISTS idx_repo_sessions_status
 				ON repo_sessions(status);
+			CREATE TABLE IF NOT EXISTS repo_session_pending_purge (
+				session_id TEXT PRIMARY KEY NOT NULL
+			);
 		`)
 		this.writeMeta(schemaVersionKey, String(repoSessionIndexSchemaVersion))
 	}
@@ -212,14 +215,6 @@ class RepoSessionIndexBase extends DurableObject<Env> {
 			)
 		}
 		return id
-	}
-
-	private isHydrated(): boolean {
-		return this.readMeta(hydratedFromD1Key) === '1'
-	}
-
-	private markHydrated(): void {
-		this.writeMeta(hydratedFromD1Key, '1')
 	}
 
 	private insertStoredRow(row: StoredRepoSessionRow): void {
@@ -296,8 +291,108 @@ class RepoSessionIndexBase extends DurableObject<Env> {
 			.map(mapStoredRow)
 	}
 
-	private async scheduleNextDue(ownerId: string): Promise<void> {
-		const dueAt = nextOwnerDueAt(this.listStoredRows())
+	private readMinText(query: string): string | null {
+		const row = this.sql.exec<{ value: string | null }>(query).toArray()[0]
+		return row?.value == null ? null : String(row.value)
+	}
+
+	private hasPendingPurge(): boolean {
+		const row = this.sql
+			.exec<{ present: number }>(
+				`SELECT 1 AS present FROM repo_session_pending_purge LIMIT 1`,
+			)
+			.toArray()[0]
+		return row?.present === 1
+	}
+
+	private nextStoredDueAt(now: Date): string | null {
+		return nextOwnerDueAtFromBounds({
+			unusedMinUpdatedAt: this.readMinText(
+				`SELECT MIN(updated_at) AS value FROM repo_sessions
+				WHERE status = 'active' AND last_checkpoint_at IS NULL`,
+			),
+			editedMinUpdatedAt: this.readMinText(
+				`SELECT MIN(updated_at) AS value FROM repo_sessions
+				WHERE status = 'active' AND last_checkpoint_at IS NOT NULL`,
+			),
+			minExpiresAt: this.readMinText(
+				`SELECT MIN(expires_at) AS value FROM repo_sessions
+				WHERE status IN ('published', 'discarded') AND expires_at IS NOT NULL`,
+			),
+			hasRows: this.countStoredRows() > 0,
+			pendingPurge: this.hasPendingPurge(),
+			now,
+		})
+	}
+
+	private enqueueUnusedDueForPurge(now: Date): number {
+		const cutoff = unusedActiveDueBefore(now)
+		const queued = this.sql
+			.exec<{ count: number }>(
+				`SELECT COUNT(*) AS count FROM repo_sessions
+				WHERE status = 'active' AND last_checkpoint_at IS NULL AND updated_at <= ?`,
+				cutoff,
+			)
+			.toArray()[0]
+		this.sql.exec(
+			`INSERT OR IGNORE INTO repo_session_pending_purge (session_id)
+			SELECT id FROM repo_sessions
+			WHERE status = 'active' AND last_checkpoint_at IS NULL AND updated_at <= ?`,
+			cutoff,
+		)
+		this.sql.exec(
+			`DELETE FROM repo_sessions
+			WHERE status = 'active' AND last_checkpoint_at IS NULL AND updated_at <= ?`,
+			cutoff,
+		)
+		return Number(queued?.count ?? 0)
+	}
+
+	private async purgePendingWorkspaces(
+		ownerId: string,
+		limit: number,
+	): Promise<{ deleted: number; errors: number }> {
+		const pending = this.sql
+			.exec<{ session_id: string }>(
+				`SELECT session_id FROM repo_session_pending_purge
+				ORDER BY session_id ASC
+				LIMIT ?`,
+				limit,
+			)
+			.toArray()
+		let deleted = 0
+		let errors = 0
+		for (const row of pending) {
+			try {
+				await repoSessionRpc(this.env, row.session_id).cleanupSessionBranch({
+					sessionId: row.session_id,
+					userId: ownerId,
+					reason: 'abandoned',
+				})
+				this.sql.exec(
+					`DELETE FROM repo_session_pending_purge WHERE session_id = ?`,
+					row.session_id,
+				)
+				deleted += 1
+			} catch (error) {
+				errors += 1
+				console.warn(
+					JSON.stringify({
+						message: 'repo session pending workspace purge failed',
+						sessionId: row.session_id,
+						error: getErrorMessage(error),
+					}),
+				)
+			}
+		}
+		return { deleted, errors }
+	}
+
+	private async scheduleNextDue(
+		ownerId: string,
+		now = new Date(),
+	): Promise<void> {
+		const dueAt = this.nextStoredDueAt(now)
 		try {
 			await replaceRepoSessionDueOwner({
 				db: this.env.APP_DB,
@@ -322,9 +417,7 @@ class RepoSessionIndexBase extends DurableObject<Env> {
 	}
 
 	private async ensureReady(ownerId: string): Promise<string> {
-		const id = this.assertOwner(ownerId)
-		if (!this.isHydrated()) this.markHydrated()
-		return id
+		return this.assertOwner(ownerId)
 	}
 
 	async alarm(): Promise<void> {
@@ -521,12 +614,19 @@ class RepoSessionIndexBase extends DurableObject<Env> {
 	}): Promise<RepoSessionIndexCleanupResult> {
 		const ownerId = await this.ensureReady(input.ownerId)
 		const now = input.now ? new Date(input.now) : new Date()
-		const due = this.listDueStoredRows(
-			now,
-			input.limit ?? defaultCleanupBatchSize,
+		const limit = input.limit ?? defaultCleanupBatchSize
+		const queuedUnused = this.enqueueUnusedDueForPurge(now)
+		const unusedPurge = await this.purgePendingWorkspaces(
+			ownerId,
+			Math.min(limit, unusedWorkspacePurgeBatchSize),
 		)
-		let deleted = 0
-		let errors = 0
+		const remaining = Math.max(
+			limit - unusedPurge.deleted - unusedPurge.errors,
+			0,
+		)
+		const due = remaining > 0 ? this.listDueStoredRows(now, remaining) : []
+		let deleted = unusedPurge.deleted
+		let errors = unusedPurge.errors
 		for (const row of due) {
 			try {
 				await repoSessionRpc(this.env, row.id).cleanupSessionBranch({
@@ -546,9 +646,9 @@ class RepoSessionIndexBase extends DurableObject<Env> {
 				)
 			}
 		}
-		await this.scheduleNextDue(ownerId)
+		await this.scheduleNextDue(ownerId, now)
 		return {
-			checked: due.length,
+			checked: queuedUnused + due.length,
 			deleted,
 			errors,
 		}
@@ -599,7 +699,6 @@ class RepoSessionIndexBase extends DurableObject<Env> {
 			await this.ctx.storage.deleteAll()
 			this.initializeSchema()
 			this.assertOwner(ownerId)
-			this.markHydrated()
 		})
 		await replaceRepoSessionDueOwner({
 			db: this.env.APP_DB,

--- a/packages/worker/src/repo/repo-session-index.workers.test.ts
+++ b/packages/worker/src/repo/repo-session-index.workers.test.ts
@@ -1,5 +1,6 @@
 import { env, runInDurableObject } from 'cloudflare:test'
 import { expect, test } from 'vitest'
+import { ensureUserStorageBucketsTestSchema } from '#worker/storage-buckets/test-schema.ts'
 import { repoSessionIndexDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
 import { RepoSessionIndex } from './repo-session-index-do.ts'
 import { type RepoSessionRow } from './types.ts'
@@ -93,4 +94,80 @@ test('RepoSessionIndex is the catalog authority for one user', async () => {
 		await instance.purge({ ownerId: userId })
 		expect(await instance.listByUser({ ownerId: userId })).toEqual([])
 	})
+})
+
+test('RepoSessionIndex drops unused due catalog rows in one cleanup pass', async () => {
+	await ensureUserStorageBucketsTestSchema(env.APP_DB)
+	await env.APP_DB.prepare(
+		`CREATE TABLE IF NOT EXISTS repo_session_due_owners (
+			user_id TEXT PRIMARY KEY NOT NULL,
+			due_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)`,
+	).run()
+	const userId = `index-drain-${crypto.randomUUID()}`
+	const stub = env.REPO_SESSION_INDEX.get(
+		env.REPO_SESSION_INDEX.idFromName(
+			repoSessionIndexDurableObjectName(userId),
+		),
+	)
+	const now = '2026-08-16T06:00:00.000Z'
+	await runInDurableObject(stub, async (instance: RepoSessionIndex) => {
+		await instance.insertSession({
+			ownerId: userId,
+			row: sessionRow({
+				id: 'unused-due-1',
+				user_id: userId,
+				updated_at: '2026-08-16T05:00:00.000Z',
+			}),
+		})
+		await instance.insertSession({
+			ownerId: userId,
+			row: sessionRow({
+				id: 'unused-due-2',
+				user_id: userId,
+				source_id: 'source-2',
+				updated_at: '2026-08-16T04:00:00.000Z',
+			}),
+		})
+		await instance.insertSession({
+			ownerId: userId,
+			row: sessionRow({
+				id: 'unused-recent',
+				user_id: userId,
+				source_id: 'source-3',
+				updated_at: '2026-08-16T05:50:00.000Z',
+			}),
+		})
+		await instance.insertSession({
+			ownerId: userId,
+			row: sessionRow({
+				id: 'edited-keep',
+				user_id: userId,
+				source_id: 'source-4',
+				last_checkpoint_at: '2026-08-15T12:00:00.000Z',
+				last_checkpoint_commit: 'edited',
+				updated_at: '2026-08-15T12:00:00.000Z',
+			}),
+		})
+		expect(await instance.countActive({ ownerId: userId })).toBe(4)
+		const result = await instance.runDueCleanup({
+			ownerId: userId,
+			now,
+			limit: 10,
+		})
+		expect(result.checked).toBeGreaterThanOrEqual(2)
+		expect(result.errors).toBe(0)
+		const remaining = (await instance.listByUser({ ownerId: userId })).map(
+			(row) => row.id,
+		)
+		expect(remaining.sort()).toEqual(['edited-keep', 'unused-recent'])
+		expect(await instance.countActive({ ownerId: userId })).toBe(2)
+	})
+	const due = await env.APP_DB.prepare(
+		`SELECT due_at FROM repo_session_due_owners WHERE user_id = ?`,
+	)
+		.bind(userId)
+		.first<{ due_at: string }>()
+	expect(due?.due_at).toBe('2026-08-16T06:20:00.000Z')
 })

--- a/packages/worker/src/repo/repo-sessions.node.test.ts
+++ b/packages/worker/src/repo/repo-sessions.node.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from 'vitest'
 import {
 	isRepoSessionDue,
 	nextOwnerDueAt,
+	nextOwnerDueAtFromBounds,
 	nextRepoSessionDueAt,
+	repoSessionFarFutureDueAt,
 } from './repo-session-due.ts'
 
 test('due helpers treat unused leftovers sooner than edited sessions', () => {
@@ -97,4 +99,41 @@ test('due helpers treat unused leftovers sooner than edited sessions', () => {
 			},
 		]),
 	).toBe('2026-06-24T12:00:00.000Z')
+	expect(
+		nextOwnerDueAtFromBounds({
+			unusedMinUpdatedAt: '2026-06-24T19:00:00.000Z',
+			editedMinUpdatedAt: null,
+			minExpiresAt: '2026-06-24T12:00:00.000Z',
+			hasRows: true,
+			pendingPurge: false,
+		}),
+	).toBe('2026-06-24T12:00:00.000Z')
+	expect(
+		nextOwnerDueAtFromBounds({
+			unusedMinUpdatedAt: null,
+			editedMinUpdatedAt: null,
+			minExpiresAt: null,
+			hasRows: false,
+			pendingPurge: false,
+		}),
+	).toBeNull()
+	expect(
+		nextOwnerDueAtFromBounds({
+			unusedMinUpdatedAt: null,
+			editedMinUpdatedAt: null,
+			minExpiresAt: null,
+			hasRows: true,
+			pendingPurge: false,
+		}),
+	).toBe(repoSessionFarFutureDueAt)
+	expect(
+		nextOwnerDueAtFromBounds({
+			unusedMinUpdatedAt: null,
+			editedMinUpdatedAt: null,
+			minExpiresAt: null,
+			hasRows: false,
+			pendingPurge: true,
+			now: new Date('2026-08-16T06:00:00.000Z'),
+		}),
+	).toBe('2026-08-16T06:00:00.000Z')
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Kent is at ~19.9k / 20k active repo sessions after the D1 catalog cutover. Leftover unused rows were hydrated into `RepoSessionIndex` and still count against entitlements. The sweeper was due but only processed ~100 git-heavy workspace cleanups per tick, so the pile never drained. This PR drops unused due catalog rows immediately and finishes leftover hydrate-flag cleanup. Follow-up: #1465.

## Summary

- Unused (never-checkpointed) due sessions leave the catalog in one SQL pass so `countActive` / entitlements drop immediately
- Workspace Durable Objects then purge in bounded alarm batches; unused cleanup no longer waits on remote branch deletes
- Next-due scheduling uses `MIN()` bounds instead of loading every catalog row
- Removes the leftover `hydrated_from_d1` flag
- Edited sessions (`last_checkpoint_at` set) keep the 7-day idle window

Not in this PR (see #1465): retiring the no-op `repo_session_index_backfill` lane name, sweeping leftover Artifacts session branches, and resume-by-source to stop unused-session leaks.

## Testing

- `npx vitest run` on `repo-sessions.node.test.ts`, `repo-session-index.workers.test.ts`, `repo-session-cleanup.node.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** extends — unused due catalog rows drop in one SQL pass; workspace purge is batched; next-due no longer loads the full catalog.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — unused due rows leave `RepoSessionIndex` immediately; workspace DOs purge in alarm batches without remote git |

### System map

Unused leftover sessions leave the per-user catalog first so entitlement counts drop; workspace purge continues on the index alarm.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	repoSessions -->|"due_owners hint after unused catalog drop"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```text
before: runDueCleanup loads due rows (limit 100) and git-deletes each workspace before the catalog row can drop
after:  unused due rows DELETE from the catalog in one statement; pending workspace purge is batched; next due is MIN(updated_at)/MIN(expires_at)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c29dcb8e-9283-4cd6-9673-2be3a74a4bc7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c29dcb8e-9283-4cd6-9673-2be3a74a4bc7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

