### PR TITLE
Record individual CLA signatures from the signing comment

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -5,5 +5,11 @@
 		"github": ["kentcdodds", "kody-bot", "cursoragent"],
 		"email": ["me@kentcdodds.com", "me+github@kentcdodds.com"]
 	},
-	"signers": []
+	"signers": [
+		{
+			"github": "vojtaholik",
+			"signedAt": "2026-08-16",
+			"cla": "individual"
+		}
+	]
 }

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -137,7 +137,7 @@ jobs:
     if: >
       github.event_name == 'issue_comment' && github.event.issue.pull_request &&
       github.event.comment.user.type == 'User' &&
-      contains(github.event.comment.body, 'I have read the CLA and I hereby sign the CLA')
+      contains(github.event.comment.body, 'I hereby sign the CLA')
     runs-on: ubuntu-latest
     name: 📝 Record CLA
     timeout-minutes: 5

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-name: CLA
+name: ✍️ CLA
 
 on:
   pull_request:
@@ -22,24 +22,24 @@ jobs:
   cla:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    name: CLA
+    name: ✍️ CLA
     timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout base
+      - name: 📦 Checkout base
         uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
-      - name: Setup Node
+      - name: 🟢 Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 26
 
-      - name: Collect identities
+      - name: 🧾 Collect identities
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -72,7 +72,7 @@ jobs:
               `${JSON.stringify(identities, null, '\t')}\n`,
             )
 
-      - name: Check CLA
+      - name: ✍️ Check CLA
         id: check
         run: |
           if [ ! -f tools/ci/check-cla.ts ] || [ ! -f .github/cla-signers.json ]; then
@@ -89,7 +89,7 @@ jobs:
             exit "$code"
           fi
 
-      - name: Comment when unsigned
+      - name: 💬 Comment when unsigned
         if: steps.check.outputs.exit_code == '1'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -131,7 +131,7 @@ jobs:
               })
             }
 
-      - name: Fail when unsigned
+      - name: ❌ Fail when unsigned
         if: steps.check.outputs.exit_code == '1'
         run: exit 1
 
@@ -140,7 +140,7 @@ jobs:
       github.event_name == 'issue_comment' && github.event.issue.pull_request &&
       github.event.comment.user.type == 'User'
     runs-on: ubuntu-latest
-    name: Record CLA
+    name: 📝 Record CLA
     timeout-minutes: 5
     concurrency:
       group: cla-signers-main
@@ -150,17 +150,17 @@ jobs:
       pull-requests: write
       actions: write
     steps:
-      - name: Checkout main
+      - name: 📦 Checkout main
         uses: actions/checkout@v6.0.2
         with:
           ref: main
 
-      - name: Setup Node
+      - name: 🟢 Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 26
 
-      - name: Record signer
+      - name: 📝 Record signer
         id: record
         env:
           CLA_COMMENT: ${{ github.event.comment.body }}
@@ -179,7 +179,7 @@ jobs:
             --signed-at "${CLA_SIGNED_AT%%T*}" \
             --comment-file cla-comment.txt | tee -a "$GITHUB_OUTPUT"
 
-      - name: Commit signer on main
+      - name: 💾 Commit signer on main
         if: steps.record.outputs.added == 'true'
         run: |
           git config user.name 'github-actions[bot]'
@@ -189,7 +189,7 @@ jobs:
           git pull --rebase origin main
           git push origin HEAD:main
 
-      - name: Comment and re-run CLA
+      - name: 💬 Comment and re-run CLA
         if: steps.record.outputs.skipped == 'false'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,8 +15,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  actions: write
 
 jobs:
   cla:
@@ -138,7 +136,8 @@ jobs:
   record:
     if: >
       github.event_name == 'issue_comment' && github.event.issue.pull_request &&
-      github.event.comment.user.type == 'User'
+      github.event.comment.user.type == 'User' &&
+      contains(github.event.comment.body, 'I have read the CLA and I hereby sign the CLA')
     runs-on: ubuntu-latest
     name: 📝 Record CLA
     timeout-minutes: 5
@@ -177,15 +176,19 @@ jobs:
             --signers .github/cla-signers.json \
             --record-signer "$CLA_LOGIN" \
             --signed-at "${CLA_SIGNED_AT%%T*}" \
-            --comment-file cla-comment.txt | tee -a "$GITHUB_OUTPUT"
+            --comment-file cla-comment.txt > cla-record-output.txt
+          cat cla-record-output.txt
+          grep -E '^(skipped|added|github)=' cla-record-output.txt >> "$GITHUB_OUTPUT"
 
       - name: 💾 Commit signer on main
         if: steps.record.outputs.added == 'true'
+        env:
+          CLA_GITHUB: ${{ steps.record.outputs.github }}
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add .github/cla-signers.json
-          git commit -m "Record @${{ steps.record.outputs.github }} as an individual CLA signer"
+          git commit -m "Record @${CLA_GITHUB} as an individual CLA signer"
           git pull --rebase origin main
           git push origin HEAD:main
 
@@ -200,16 +203,63 @@ jobs:
             const login = process.env.CLA_GITHUB
             const added = process.env.CLA_ADDED === 'true'
             const marker = '<!-- kody-cla-recorded -->'
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const pull = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: context.payload.issue.number,
+            })
+            const headSha = pull.data.head.sha
+
+            async function latestClaRun() {
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: 'cla.yml',
+                event: 'pull_request',
+                head_sha: headSha,
+                per_page: 5,
+              })
+              return runs.data.workflow_runs[0] ?? null
+            }
+
+            const deadline = Date.now() + 180_000
+            let latest = await latestClaRun()
+            while (latest && latest.status !== 'completed' && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 10_000))
+              latest = await latestClaRun()
+            }
+
+            let reran = false
+            if (latest?.status === 'completed') {
+              try {
+                await github.rest.actions.reRunWorkflow({
+                  owner,
+                  repo,
+                  run_id: latest.id,
+                })
+                reran = true
+              } catch (error) {
+                core.warning(
+                  `Could not re-run CLA: ${error instanceof Error ? error.message : String(error)}`,
+                )
+              }
+            }
+
+            const followUp = reran
+              ? 'The CLA check will re-run.'
+              : 'The next CLA check will read the updated signers file.'
             const body = added
               ? `${marker}
-            Recorded @${login} as an individual CLA signer on \`main\`. The CLA check will re-run.`
+            Recorded @${login} as an individual CLA signer on \`main\`. ${followUp}`
               : `${marker}
-            @${login} is already recorded as an individual CLA signer. The CLA check will re-run.`
+            @${login} is already recorded as an individual CLA signer. ${followUp}`
             const comments = await github.paginate(
               github.rest.issues.listComments,
               {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: context.payload.issue.number,
                 per_page: 100,
               },
@@ -219,38 +269,16 @@ jobs:
             )
             if (existing) {
               await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 comment_id: existing.id,
                 body,
               })
             } else {
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: context.payload.issue.number,
                 body,
-              })
-            }
-
-            const pull = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.issue.number,
-            })
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'cla.yml',
-              event: 'pull_request',
-              head_sha: pull.data.head.sha,
-              per_page: 5,
-            })
-            const latest = runs.data.workflow_runs[0]
-            if (latest?.status === 'completed') {
-              await github.rest.actions.reRunWorkflow({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: latest.id,
               })
             }

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,16 +8,25 @@ on:
       - opened
       - reopened
       - synchronize
+  issue_comment:
+    types:
+      - created
+      - edited
 
 permissions:
   contents: read
   pull-requests: write
+  actions: write
 
 jobs:
   cla:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     name: CLA
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout base
         uses: actions/checkout@v6.0.2
@@ -91,7 +100,7 @@ jobs:
 
             1. Read the [Individual CLA](https://github.com/${{ github.repository }}/blob/main/docs/legal/individual-cla.md) (or the [Entity CLA](https://github.com/${{ github.repository }}/blob/main/docs/legal/entity-cla.md) if an organization owns the work).
             2. Comment exactly: \`I have read the CLA and I hereby sign the CLA\`
-            3. A maintainer records your GitHub username on \`main\`. See [Inbound contributions](https://github.com/${{ github.repository }}/blob/main/docs/contributing/inbound-contributions.md).
+            3. The CLA workflow records your GitHub username on \`main\` and re-runs this check. See [Inbound contributions](https://github.com/${{ github.repository }}/blob/main/docs/contributing/inbound-contributions.md).
 
             Adding your own username on this branch does not pass the check.`
             const comments = await github.paginate(
@@ -125,3 +134,123 @@ jobs:
       - name: Fail when unsigned
         if: steps.check.outputs.exit_code == '1'
         run: exit 1
+
+  record:
+    if: >
+      github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User'
+    runs-on: ubuntu-latest
+    name: Record CLA
+    timeout-minutes: 5
+    concurrency:
+      group: cla-signers-main
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: Record signer
+        id: record
+        env:
+          CLA_COMMENT: ${{ github.event.comment.body }}
+          CLA_LOGIN: ${{ github.event.comment.user.login }}
+          CLA_SIGNED_AT: ${{ github.event.comment.created_at }}
+        run: |
+          if [ ! -f tools/ci/check-cla.ts ] || [ ! -f .github/cla-signers.json ]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "added=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s' "$CLA_COMMENT" > cla-comment.txt
+          node tools/ci/check-cla.ts \
+            --signers .github/cla-signers.json \
+            --record-signer "$CLA_LOGIN" \
+            --signed-at "${CLA_SIGNED_AT%%T*}" \
+            --comment-file cla-comment.txt | tee -a "$GITHUB_OUTPUT"
+
+      - name: Commit signer on main
+        if: steps.record.outputs.added == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/cla-signers.json
+          git commit -m "Record @${{ steps.record.outputs.github }} as an individual CLA signer"
+          git pull --rebase origin main
+          git push origin HEAD:main
+
+      - name: Comment and re-run CLA
+        if: steps.record.outputs.skipped == 'false'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          CLA_ADDED: ${{ steps.record.outputs.added }}
+          CLA_GITHUB: ${{ steps.record.outputs.github }}
+        with:
+          script: |
+            const login = process.env.CLA_GITHUB
+            const added = process.env.CLA_ADDED === 'true'
+            const marker = '<!-- kody-cla-recorded -->'
+            const body = added
+              ? `${marker}
+            Recorded @${login} as an individual CLA signer on \`main\`. The CLA check will re-run.`
+              : `${marker}
+            @${login} is already recorded as an individual CLA signer. The CLA check will re-run.`
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                per_page: 100,
+              },
+            )
+            const existing = comments.find((comment) =>
+              comment.body?.includes(marker),
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body,
+              })
+            }
+
+            const pull = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            })
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'cla.yml',
+              event: 'pull_request',
+              head_sha: pull.data.head.sha,
+              per_page: 5,
+            })
+            const latest = runs.data.workflow_runs[0]
+            if (latest?.status === 'completed') {
+              await github.rest.actions.reRunWorkflow({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: latest.id,
+              })
+            }

--- a/docs/contributing/decisions/0018-inbound-cla.md
+++ b/docs/contributing/decisions/0018-inbound-cla.md
@@ -58,12 +58,15 @@ How it works:
   [Entity CLA](../../legal/entity-cla.md) when the work is owned by an employer
   or the contributor is signing for an organization.
 - **How they sign.** Read the CLA, then comment on the pull request:
-  `I have read the CLA and I hereby sign the CLA`. A maintainer records the
-  GitHub username in `.github/cla-signers.json` on `main`. Signing covers past,
-  present, and future contributions from that identity.
+  `I have read the CLA and I hereby sign the CLA`. The `CLA` workflow, running
+  from `main` on that comment, records the commenter's GitHub username in
+  `.github/cla-signers.json` on `main` and re-runs the check. Signing covers
+  past, present, and future contributions from that identity. Entity CLA
+  recording stays a maintainer step.
 - **Enforcement.** The `CLA` workflow reads signers from `main` (never from the
   pull request head), fails closed on unsigned identities, and comments with the
-  signing steps. Maintainers do not merge a red `CLA` check. There is no
+  signing steps. It never checks out or runs pull request code to record a
+  signature. Maintainers do not merge a red `CLA` check. There is no
   trivial-contribution exception.
 - **Existing commits.** History is not rewritten. People who already contributed
   are asked to sign before the next merge; the CLA text covers prior
@@ -73,10 +76,9 @@ How it works:
 
 - The Licensor stays one party for FSL, the Apache conversion, relicensing, and
   enforcement.
-- Outside pull requests take one extra maintainer step (record the signer on
-  `main`). That matches current volume. If volume grows, replace the manual
-  record with a hosted CLA Assistant gist pointed at the same documents; do not
-  adopt an unmaintained `pull_request_target` signing bot.
+- Individual signatures do not need a maintainer to edit the signers file. The
+  recorder is a first-party `issue_comment` job that writes `main` only. Do not
+  replace it with an unmaintained `pull_request_target` signing bot.
 - Community package authors keep their own MIT copyright; they never sign this
   CLA unless they also patch this repository.
 - Revisit if the Licensor becomes a company (assign the inbound grants to that

--- a/docs/contributing/inbound-contributions.md
+++ b/docs/contributing/inbound-contributions.md
@@ -75,7 +75,8 @@ Do not merge a pull request while the `CLA` check is red.
 
 Individual signatures are recorded automatically from the signing comment. After
 an accepted Entity CLA, add each authorized username to
-`.github/cla-signers.json` on `main` with `cla` of `entity`.
+`.github/cla-signers.json` on `main` with `signedAt` as an ISO date
+(`YYYY-MM-DD`) and `cla` of `entity`.
 
 Make the `CLA` check required for `main` in GitHub branch protection so a green
 review cannot skip it.

--- a/docs/contributing/inbound-contributions.md
+++ b/docs/contributing/inbound-contributions.md
@@ -32,15 +32,15 @@ There is no exception for docs-only or one-line patches.
    I have read the CLA and I hereby sign the CLA
    ```
 
-4. Wait for a maintainer to record your GitHub username in
-   [`.github/cla-signers.json`](../../.github/cla-signers.json) on `main`.
-5. Re-run the `CLA` check, or push another commit.
+4. The `CLA` workflow records your GitHub username in
+   [`.github/cla-signers.json`](../../.github/cla-signers.json) on `main` and
+   re-runs the check.
 
 Signing once covers past, present, and future contributions from that GitHub
 identity. People who contributed before this process sign the same way before
-their next merge. The `CLA` workflow reads signers from `main`, not from the
-pull request branch, so adding your own username on the branch does not pass the
-check.
+their next merge. The workflow reads signers from `main`, not from the pull
+request branch, so adding your own username on the branch does not pass the
+check. Only the commenter is recorded, and only from the exact phrase.
 
 ## How to sign (entity)
 
@@ -73,10 +73,9 @@ authors the pull request as `kentcdodds` and the commits as `cursoragent`.
 
 Do not merge a pull request while the `CLA` check is red.
 
-After a valid individual signing comment, add a `signers` entry on `main`
-(GitHub login, `signedAt` as an ISO date, `cla` of `individual`) and re-run the
-check. After an accepted Entity CLA, add each authorized username with `cla` of
-`entity`.
+Individual signatures are recorded automatically from the signing comment. After
+an accepted Entity CLA, add each authorized username to
+`.github/cla-signers.json` on `main` with `cla` of `entity`.
 
 Make the `CLA` check required for `main` in GitHub branch protection so a green
 review cannot skip it.

--- a/tools/ci/check-cla.node.test.ts
+++ b/tools/ci/check-cla.node.test.ts
@@ -159,7 +159,21 @@ test('CLA signing comment records the commenter once and ignores everything else
 		status: 'already_signed',
 		github: 'examplesigner',
 	})
-	expect(serializeClaSignersFile(recorded.file)).toContain('"ExampleSigner"')
+	const serialized = serializeClaSignersFile(recorded.file)
+	expect(serialized).toContain('"ExampleSigner"')
+	expect(serialized).toContain(
+		'"github": ["kentcdodds", "kody-bot", "cursoragent"]',
+	)
+	expect(serialized.endsWith('\n')).toBe(true)
+	expect(parseClaSignersFile(serialized)).toEqual(recorded.file)
+	expect(
+		applyIndividualClaSigningComment({
+			file: empty,
+			github: '   ',
+			signedAt: '2026-08-16',
+			comment: individualClaSigningPhrase,
+		}),
+	).toEqual({ file: empty, status: 'ignored', reason: 'missing_login' })
 })
 
 test('CLA signers file parser rejects the wrong version and accepts a valid repo file', () => {

--- a/tools/ci/check-cla.node.test.ts
+++ b/tools/ci/check-cla.node.test.ts
@@ -113,7 +113,13 @@ test('CLA signers file parser rejects the wrong version and accepts the repo fil
 		'me@kentcdodds.com',
 		'me+github@kentcdodds.com',
 	])
-	expect(parsed.signers).toEqual([])
+	expect(parsed.signers).toEqual([
+		{
+			github: 'vojtaholik',
+			signedAt: '2026-08-16',
+			cla: 'individual',
+		},
+	])
 	expect(
 		checkClaIdentities(
 			[
@@ -126,6 +132,11 @@ test('CLA signers file parser rejects the wrong version and accepts the repo fil
 					githubLogin: 'cursoragent',
 					name: 'Cursor Agent',
 					email: 'cursoragent@cursor.com',
+				},
+				{
+					githubLogin: 'vojtaholik',
+					name: 'Vojta Holik',
+					email: 'vojta@egghead.io',
 				},
 			],
 			parsed,

--- a/tools/ci/check-cla.node.test.ts
+++ b/tools/ci/check-cla.node.test.ts
@@ -2,9 +2,13 @@ import { readFileSync } from 'node:fs'
 import { expect, test } from 'vitest'
 
 import {
+	applyIndividualClaSigningComment,
 	checkClaIdentities,
 	formatClaFailure,
+	individualClaSigningPhrase,
+	isIndividualClaSigningComment,
 	parseClaSignersFile,
+	serializeClaSignersFile,
 	type ClaSignersFile,
 } from './check-cla.ts'
 
@@ -25,7 +29,7 @@ test('CLA check allowlists the Licensor, bots, signed humans, and rejects everyo
 	const file = signersFile({
 		signers: [
 			{
-				github: 'VojtaHolik',
+				github: 'ExampleSigner',
 				signedAt: '2026-08-16',
 				cla: 'individual',
 			},
@@ -57,9 +61,9 @@ test('CLA check allowlists the Licensor, bots, signed humans, and rejects everyo
 				email: 'me+github@kentcdodds.com',
 			},
 			{
-				githubLogin: 'vojtaholik',
-				name: 'Vojta Holik',
-				email: 'vojta@egghead.io',
+				githubLogin: 'examplesigner',
+				name: 'Example Signer',
+				email: 'signer@example.com',
 			},
 		],
 		file,
@@ -94,90 +98,78 @@ test('CLA check allowlists the Licensor, bots, signed humans, and rejects everyo
 		'@mirkosalvato1-ctrl has not signed the CLA',
 		'someone@example.com has no GitHub login and is not a Licensor email',
 	])
+	expect(formatClaFailure(failing)).toContain(individualClaSigningPhrase)
 	expect(formatClaFailure(failing)).toContain(
-		'I have read the CLA and I hereby sign the CLA',
+		'The CLA workflow records that GitHub username on main',
 	)
 })
 
-test('CLA signers file parser rejects the wrong version and accepts the repo file', () => {
-	expect(() => parseClaSignersFile('{"version":2}')).toThrow(/version 1/)
-	const parsed = parseClaSignersFile(
-		readFileSync('.github/cla-signers.json', 'utf8'),
-	)
-	expect(parsed.allowlist.github).toEqual([
-		'kentcdodds',
-		'kody-bot',
-		'cursoragent',
-	])
-	expect(parsed.allowlist.email).toEqual([
-		'me@kentcdodds.com',
-		'me+github@kentcdodds.com',
-	])
-	expect(parsed.signers).toEqual([
+test('CLA signing comment records the commenter once and ignores everything else', () => {
+	const empty = signersFile()
+	expect(
+		isIndividualClaSigningComment(`  ${individualClaSigningPhrase}  `),
+	).toBe(true)
+	expect(isIndividualClaSigningComment('I agree')).toBe(false)
+
+	const ignored = applyIndividualClaSigningComment({
+		file: empty,
+		github: 'ExampleSigner',
+		signedAt: '2026-08-16',
+		comment: 'I agree',
+	})
+	expect(ignored).toEqual({
+		file: empty,
+		status: 'ignored',
+		reason: 'not_signing_comment',
+	})
+
+	const recorded = applyIndividualClaSigningComment({
+		file: empty,
+		github: 'ExampleSigner',
+		signedAt: '2026-08-16',
+		comment: individualClaSigningPhrase,
+	})
+	expect(recorded.status).toBe('recorded')
+	if (recorded.status !== 'recorded') {
+		throw new Error('expected a new signature')
+	}
+	expect(recorded.github).toBe('ExampleSigner')
+	expect(recorded.file.signers).toEqual([
 		{
-			github: 'vojtaholik',
+			github: 'ExampleSigner',
 			signedAt: '2026-08-16',
 			cla: 'individual',
 		},
 	])
 	expect(
 		checkClaIdentities(
-			[
-				{
-					githubLogin: 'kentcdodds',
-					name: 'kentcdodds',
-					email: null,
-				},
-				{
-					githubLogin: 'cursoragent',
-					name: 'Cursor Agent',
-					email: 'cursoragent@cursor.com',
-				},
-				{
-					githubLogin: 'vojtaholik',
-					name: 'Vojta Holik',
-					email: 'vojta@egghead.io',
-				},
-			],
-			parsed,
+			[{ githubLogin: 'examplesigner', name: 'Example', email: null }],
+			recorded.file,
 		),
 	).toEqual({ ok: true })
-	expect(
-		checkClaIdentities(
-			[
-				{
-					githubLogin: null,
-					name: 'Cursor Agent',
-					email: 'cursoragent@cursor.com',
-				},
-				{
-					githubLogin: 'mirkosalvato1-ctrl',
-					name: 'Mirko',
-					email: 'cursoragent@cursor.com',
-				},
-			],
-			parsed,
-		),
-	).toEqual({
-		ok: false,
-		missing: [
-			{
-				identity: {
-					githubLogin: null,
-					name: 'Cursor Agent',
-					email: 'cursoragent@cursor.com',
-				},
-				reason:
-					'cursoragent@cursor.com has no GitHub login and is not a Licensor email',
-			},
-			{
-				identity: {
-					githubLogin: 'mirkosalvato1-ctrl',
-					name: 'Mirko',
-					email: 'cursoragent@cursor.com',
-				},
-				reason: '@mirkosalvato1-ctrl has not signed the CLA',
-			},
-		],
+
+	const again = applyIndividualClaSigningComment({
+		file: recorded.file,
+		github: 'examplesigner',
+		signedAt: '2026-08-17',
+		comment: individualClaSigningPhrase,
 	})
+	expect(again).toEqual({
+		file: recorded.file,
+		status: 'already_signed',
+		github: 'examplesigner',
+	})
+	expect(serializeClaSignersFile(recorded.file)).toContain('"ExampleSigner"')
+})
+
+test('CLA signers file parser rejects the wrong version and accepts a valid repo file', () => {
+	expect(() => parseClaSignersFile('{"version":2}')).toThrow(/version 1/)
+	const parsed = parseClaSignersFile(
+		readFileSync('.github/cla-signers.json', 'utf8'),
+	)
+	expect(parsed.version).toBe(1)
+	expect(parsed.document.length).toBeGreaterThan(0)
+	expect(Array.isArray(parsed.allowlist.github)).toBe(true)
+	expect(Array.isArray(parsed.allowlist.email)).toBe(true)
+	expect(Array.isArray(parsed.signers)).toBe(true)
 })

--- a/tools/ci/check-cla.ts
+++ b/tools/ci/check-cla.ts
@@ -88,14 +88,23 @@ export function parseClaSignersFile(raw: string): ClaSignersFile {
 export function serializeClaSignersFile(file: ClaSignersFile) {
 	const compactStringArray = (values: ReadonlyArray<string>) =>
 		`[${values.map((value) => JSON.stringify(value)).join(', ')}]`
-	const indented = JSON.stringify(file, null, '\t')
+	const placeholderGithub = '__CLA_ALLOWLIST_GITHUB__'
+	const placeholderEmail = '__CLA_ALLOWLIST_EMAIL__'
+	const indented = JSON.stringify(
+		{
+			...file,
+			allowlist: { github: placeholderGithub, email: placeholderEmail },
+		},
+		null,
+		'\t',
+	)
 		.replace(
-			/"github": \[[\s\S]*?\]/,
-			`"github": ${compactStringArray(file.allowlist.github)}`,
+			JSON.stringify(placeholderGithub),
+			compactStringArray(file.allowlist.github),
 		)
 		.replace(
-			/"email": \[[\s\S]*?\]/,
-			`"email": ${compactStringArray(file.allowlist.email)}`,
+			JSON.stringify(placeholderEmail),
+			compactStringArray(file.allowlist.email),
 		)
 	return `${indented}\n`
 }
@@ -236,7 +245,14 @@ export function formatClaFailure(
 
 function readFlag(args: Array<string>, flag: string) {
 	const index = args.indexOf(flag)
-	return index === -1 ? null : (args[index + 1] ?? null)
+	if (index === -1) {
+		return null
+	}
+	const value = args[index + 1]
+	if (!value || value.startsWith('--')) {
+		return null
+	}
+	return value
 }
 
 async function runRecordCli(args: Array<string>) {

--- a/tools/ci/check-cla.ts
+++ b/tools/ci/check-cla.ts
@@ -85,9 +85,11 @@ export function parseClaSignersFile(raw: string): ClaSignersFile {
 	return file
 }
 
+function compactStringArray(values: ReadonlyArray<string>) {
+	return `[${values.map((value) => JSON.stringify(value)).join(', ')}]`
+}
+
 export function serializeClaSignersFile(file: ClaSignersFile) {
-	const compactStringArray = (values: ReadonlyArray<string>) =>
-		`[${values.map((value) => JSON.stringify(value)).join(', ')}]`
 	const placeholderGithub = '__CLA_ALLOWLIST_GITHUB__'
 	const placeholderEmail = '__CLA_ALLOWLIST_EMAIL__'
 	const indented = JSON.stringify(

--- a/tools/ci/check-cla.ts
+++ b/tools/ci/check-cla.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { isExecutedDirectly } from '../node-runtime.ts'
 
 export type ClaIdentity = {
@@ -32,7 +32,15 @@ export type ClaCheckResult =
 	| { ok: true }
 	| { ok: false; missing: Array<ClaMissingIdentity> }
 
+export const individualClaSigningPhrase =
+	'I have read the CLA and I hereby sign the CLA'
+
 const githubBotLoginPattern = /\[bot\]$/i
+
+export type ClaRecordResult =
+	| { status: 'recorded'; github: string }
+	| { status: 'already_signed'; github: string }
+	| { status: 'ignored'; reason: 'not_signing_comment' | 'missing_login' }
 
 function normalize(value: string) {
 	return value.trim().toLowerCase()
@@ -75,6 +83,69 @@ export function parseClaSignersFile(raw: string): ClaSignersFile {
 	}
 
 	return file
+}
+
+export function serializeClaSignersFile(file: ClaSignersFile) {
+	const compactStringArray = (values: ReadonlyArray<string>) =>
+		`[${values.map((value) => JSON.stringify(value)).join(', ')}]`
+	const indented = JSON.stringify(file, null, '\t')
+		.replace(
+			/"github": \[[\s\S]*?\]/,
+			`"github": ${compactStringArray(file.allowlist.github)}`,
+		)
+		.replace(
+			/"email": \[[\s\S]*?\]/,
+			`"email": ${compactStringArray(file.allowlist.email)}`,
+		)
+	return `${indented}\n`
+}
+
+export function isIndividualClaSigningComment(body: string) {
+	return body.trim() === individualClaSigningPhrase
+}
+
+export function applyIndividualClaSigningComment(input: {
+	file: ClaSignersFile
+	github: string
+	signedAt: string
+	comment: string
+}): { file: ClaSignersFile } & ClaRecordResult {
+	if (!isIndividualClaSigningComment(input.comment)) {
+		return {
+			file: input.file,
+			status: 'ignored',
+			reason: 'not_signing_comment',
+		}
+	}
+
+	const login = input.github.trim()
+	if (!login) {
+		return { file: input.file, status: 'ignored', reason: 'missing_login' }
+	}
+
+	if (
+		input.file.signers.some(
+			(signer) => normalize(signer.github) === normalize(login),
+		)
+	) {
+		return { file: input.file, status: 'already_signed', github: login }
+	}
+
+	return {
+		file: {
+			...input.file,
+			signers: [
+				...input.file.signers,
+				{
+					github: login,
+					signedAt: input.signedAt,
+					cla: 'individual',
+				},
+			],
+		},
+		status: 'recorded',
+		github: login,
+	}
 }
 
 export function isAllowlistedIdentity(
@@ -155,7 +226,7 @@ export function formatClaFailure(
 		'Unsigned contributions cannot merge.',
 		'Read docs/legal/individual-cla.md (or the Entity CLA if an organization owns the work).',
 		'Comment on the pull request: I have read the CLA and I hereby sign the CLA',
-		'A maintainer then records your GitHub username on main. See docs/contributing/inbound-contributions.md.',
+		'The CLA workflow records that GitHub username on main. See docs/contributing/inbound-contributions.md.',
 		'',
 		'Missing signatures:',
 		...result.missing.map((entry) => `- ${entry.reason}`),
@@ -163,11 +234,63 @@ export function formatClaFailure(
 	return lines.join('\n')
 }
 
-async function runCli(args: Array<string>) {
-	const signersFlag = args.indexOf('--signers')
-	const identitiesFlag = args.indexOf('--identities-json')
-	const signersPath = signersFlag === -1 ? null : args[signersFlag + 1]
-	const identitiesPath = identitiesFlag === -1 ? null : args[identitiesFlag + 1]
+function readFlag(args: Array<string>, flag: string) {
+	const index = args.indexOf(flag)
+	return index === -1 ? null : (args[index + 1] ?? null)
+}
+
+async function runRecordCli(args: Array<string>) {
+	const signersPath = readFlag(args, '--signers')
+	const github = readFlag(args, '--record-signer')
+	const signedAt = readFlag(args, '--signed-at')
+	const commentPath = readFlag(args, '--comment-file')
+
+	if (!signersPath || !github || !signedAt || !commentPath) {
+		throw new Error(
+			'Usage: node tools/ci/check-cla.ts --signers <file> --record-signer <login> --signed-at <YYYY-MM-DD> --comment-file <file>',
+		)
+	}
+
+	const current = parseClaSignersFile(await readFile(signersPath, 'utf8'))
+	const recorded = applyIndividualClaSigningComment({
+		file: current,
+		github,
+		signedAt,
+		comment: await readFile(commentPath, 'utf8'),
+	})
+
+	switch (recorded.status) {
+		case 'ignored':
+			console.log('skipped=true')
+			console.log('added=false')
+			break
+		case 'already_signed':
+			console.log('skipped=false')
+			console.log('added=false')
+			console.log(`github=${recorded.github}`)
+			break
+		case 'recorded':
+			await writeFile(
+				signersPath,
+				serializeClaSignersFile(recorded.file),
+				'utf8',
+			)
+			console.log('skipped=false')
+			console.log('added=true')
+			console.log(`github=${recorded.github}`)
+			break
+		default: {
+			const exhaustive: never = recorded
+			throw new Error(
+				`Unhandled CLA record status: ${JSON.stringify(exhaustive)}`,
+			)
+		}
+	}
+}
+
+async function runCheckCli(args: Array<string>) {
+	const signersPath = readFlag(args, '--signers')
+	const identitiesPath = readFlag(args, '--identities-json')
 
 	if (!signersPath || !identitiesPath) {
 		throw new Error(
@@ -191,6 +314,15 @@ async function runCli(args: Array<string>) {
 		console.error(formatClaFailure(result))
 		process.exitCode = 1
 	}
+}
+
+async function runCli(args: Array<string>) {
+	if (args.includes('--record-signer')) {
+		await runRecordCli(args)
+		return
+	}
+
+	await runCheckCli(args)
 }
 
 if (isExecutedDirectly(import.meta.url)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop making a maintainer edit `.github/cla-signers.json` after a valid individual signing comment. Record the commenter on `main` automatically, and stop tests from pinning the live allowlist or signer roster.

## Summary

Vojta's comment on [#1233](https://github.com/kentcdodds/kody/pull/1233#issuecomment-5306105485) was the exact phrase. That part worked. Nothing recorded him because the workflow only ran on pull request events, and the designed next step was a manual edit on `main`.

- `issue_comment` job checks out `main` only (never the PR head), records the commenter's login when the body is exactly `I have read the CLA and I hereby sign the CLA`, commits to `main`, and re-runs the CLA check
- Only the commenter is recorded; bots are ignored; Entity CLA stays a maintainer step
- Jobs use glanceable emoji (`✍️ CLA`, `📝 Record CLA`) to match Validate/Preview
- After recording, wait for an in-flight CLA run on that head SHA before re-running it, so a check that started against the old signers file does not stay red
- Backfill `vojtaholik` from that already-posted comment
- Tests use fixtures for check/record behavior and only assert that the repo signers file is valid version-1 JSON

Same process on the product repos: [kody-video#172](https://github.com/kentcdodds/kody-video/pull/172) and [kody-exchange#28](https://github.com/kentcdodds/kody-exchange/pull/28).

## Testing

- `npx vitest run --project node-unit tools/ci/check-cla.node.test.ts`
- `npm run format:check`

## System changes

CI and contributing docs only. No runtime primitives.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `cbea8ec3` · **Head:** `e680e724`

**Classification:** composes — no primitives added or changed; this PR automates the inbound CLA signer record and names the jobs with glanceable emoji.

### Primitives touched

_None._ The diff is CI, the CLA checker, tests, and contributing docs.

### System map

The CLA job still reads signers from `main` and still fails closed. A comment job writes only that file on `main`, then waits for an in-flight check before re-running it.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	prComment["PR comment<br/>exact signing phrase"]:::touched
	recordJob["CLA record job<br/>issue_comment on main"]:::extended
	signersFile["cla-signers.json<br/>signers on main"]:::extended
	checkCla["CLA check job<br/>pull_request"]:::touched
	prComment -->|"commenter login only"| recordJob
	recordJob -->|"commit signer on main"| signersFile
	recordJob -->|"wait then re-run"| checkCla
	checkCla -->|"checkout base.ref"| signersFile
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62bdff02-40a1-4661-883a-c1b0f4f417cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62bdff02-40a1-4661-883a-c1b0f4f417cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contributors can sign the individual agreement directly by commenting on a pull request with the required signing phrase.
  * Valid signatures are recorded automatically, duplicate signatures are handled, and the agreement check is rerun with updated status messaging.

* **Documentation**
  * Updated contributor guidance to explain the automated signing process and clarify maintainer responsibilities for entity agreements.

* **Tests**
  * Expanded validation coverage for signing comments, identity checks, duplicate signatures, and recorded results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->