### PR TITLE
fix: bind RepoSessionIndex on the runtime worker

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -990,6 +990,9 @@ and are bound cross-script from main — see
   [Mailbox](#durable-objects-mailbox))
 - `STORAGE_RUNNER` (Durable Objects; class hosted on the runtime worker)
 - `REPO_SESSION` (Durable Objects)
+- `REPO_SESSION_INDEX` (Durable Objects; per-user repo session catalog. The
+  runtime worker binds this class cross-script from `kody` so package and
+  workflow capability calls can open, list, and publish repo sessions.)
 - `PACKAGE_REALTIME_SESSION` (Durable Objects; class hosted on the runtime
   worker)
 - `PACKAGE_SERVICE_INSTANCE` (Durable Objects; class hosted on the runtime

--- a/packages/runtime-worker/wrangler.jsonc
+++ b/packages/runtime-worker/wrangler.jsonc
@@ -158,6 +158,14 @@
 						"name": "REPO_SESSION",
 						"script_name": "kody",
 					},
+					// Catalog authority for repo_* capabilities. Package and
+					// workflow execution on this worker open/list/publish
+					// sessions through the main Worker's per-user index.
+					{
+						"class_name": "RepoSessionIndex",
+						"name": "REPO_SESSION_INDEX",
+						"script_name": "kody",
+					},
 				],
 			},
 			// Jobs worker service binding (ADR 0016): package save/delete paths
@@ -327,6 +335,14 @@
 					{
 						"class_name": "RepoSession",
 						"name": "REPO_SESSION",
+						"script_name": "kody",
+					},
+					// Catalog authority for repo_* capabilities. Package and
+					// workflow execution on this worker open/list/publish
+					// sessions through the main Worker's per-user index.
+					{
+						"class_name": "RepoSessionIndex",
+						"name": "REPO_SESSION_INDEX",
 						"script_name": "kody",
 					},
 				],

--- a/tools/ci/durable-object-baseline.json
+++ b/tools/ci/durable-object-baseline.json
@@ -506,6 +506,11 @@
 							"name": "REPO_SESSION",
 							"class_name": "RepoSession",
 							"script_name": "kody"
+						},
+						{
+							"name": "REPO_SESSION_INDEX",
+							"class_name": "RepoSessionIndex",
+							"script_name": "kody"
 						}
 					]
 				},
@@ -556,6 +561,11 @@
 						{
 							"name": "REPO_SESSION",
 							"class_name": "RepoSession",
+							"script_name": "kody"
+						},
+						{
+							"name": "REPO_SESSION_INDEX",
+							"class_name": "RepoSessionIndex",
 							"script_name": "kody"
 						}
 					]

--- a/tools/ci/runtime-worker-config.node.test.ts
+++ b/tools/ci/runtime-worker-config.node.test.ts
@@ -18,7 +18,9 @@ test('runtime worker binds RepoSessionIndex cross-script next to RepoSession', a
 	}>(await readFile(runtimeBaseConfigPath, 'utf8'))
 	for (const envName of ['production', 'preview']) {
 		const bindings = config.env?.[envName]?.durable_objects?.bindings ?? []
-		const repoSession = bindings.find((binding) => binding.name === 'REPO_SESSION')
+		const repoSession = bindings.find(
+			(binding) => binding.name === 'REPO_SESSION',
+		)
 		const repoSessionIndex = bindings.find(
 			(binding) => binding.name === 'REPO_SESSION_INDEX',
 		)

--- a/tools/ci/runtime-worker-config.node.test.ts
+++ b/tools/ci/runtime-worker-config.node.test.ts
@@ -9,6 +9,30 @@ import { parseJsonc } from './resource-utils.ts'
 
 const runtimeBaseConfigPath = 'packages/runtime-worker/wrangler.jsonc'
 
+test('runtime worker binds RepoSessionIndex cross-script next to RepoSession', async () => {
+	const config = parseJsonc<{
+		env?: Record<
+			string,
+			{ durable_objects?: { bindings?: Array<Record<string, unknown>> } }
+		>
+	}>(await readFile(runtimeBaseConfigPath, 'utf8'))
+	for (const envName of ['production', 'preview']) {
+		const bindings = config.env?.[envName]?.durable_objects?.bindings ?? []
+		const repoSession = bindings.find((binding) => binding.name === 'REPO_SESSION')
+		const repoSessionIndex = bindings.find(
+			(binding) => binding.name === 'REPO_SESSION_INDEX',
+		)
+		expect(repoSession).toMatchObject({
+			class_name: 'RepoSession',
+			script_name: 'kody',
+		})
+		expect(repoSessionIndex).toMatchObject({
+			class_name: 'RepoSessionIndex',
+			script_name: 'kody',
+		})
+	}
+})
+
 function buildMainGeneratedConfig(envName: string) {
 	const env = {
 		durable_objects: {
@@ -162,6 +186,13 @@ test('generate rewrites worker names, copies resource ids, and writes a bootstra
 			(binding) => binding.name === 'USER_METER',
 		)
 		expect(userMeter?.script_name).toBe('kody-pr-7')
+		const repoSessionIndex = previewEnv?.durable_objects?.bindings?.find(
+			(binding) => binding.name === 'REPO_SESSION_INDEX',
+		)
+		expect(repoSessionIndex).toMatchObject({
+			class_name: 'RepoSessionIndex',
+			script_name: 'kody-pr-7',
+		})
 		// Resource identifiers are copied from the provisioned main config.
 		expect(previewEnv?.d1_databases?.[0]).toMatchObject({
 			binding: 'APP_DB',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Nightly `@kentcdodds/release` write workflows for kody.codes, kody.video, and kody.exchange failed after the RepoSessionIndex cutover because package/workflow capability calls run on `kody-runtime`, which never received the catalog Durable Object binding.

## Summary

- Bind `REPO_SESSION_INDEX` cross-script from `kody` on the runtime worker (production and preview), next to the existing `REPO_SESSION` binding.
- Update the Durable Object deploy-guardrail baseline so the new binding is reviewed, not accidental.
- Pin the committed config and the preview config generator so a later catalog DO cannot ship on main without the runtime worker.
- Document the binding in the data-storage configuration reference.

## Testing

- `npx vitest run tools/ci/runtime-worker-config.node.test.ts tools/check-deploy-guardrails.node.test.ts --project node-unit` — 10 passed
- `npm run deploy-guardrails:check` — ok
- `npm run docs:check-temporal` — passed
- `oxfmt --check` on the changed files — passed after format commit
- Production evidence: unused skills leftovers are gone (`0` listed for source `5efdbfa3-3ec5-4507-b90b-b6389593d4b3`; usage `1 / 20,000`). The three failed runs were `nightly-release-write-kody`, `nightly-release-write-kody-video`, and `nightly-release-write-kody-exchange` at `2026-08-16T10:00Z` with `UserCodeError: REPO_SESSION_INDEX Durable Object binding is not configured.`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f32c92e4` · **Head:** `bed73fd0`

**Classification:** composes — no primitives added or changed; this PR wires the existing per-user repo session catalog into the package runtime worker.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | composes — existing `RepoSessionIndex` class, now reachable from runtime-worker env |
| `package-runtime` | runtime | composes — runtime worker gains the catalog binding package/workflow `repo_*` calls need |

Unmatched paths (`packages/runtime-worker/wrangler.jsonc`, `tools/ci/*`, data-storage docs) are the wiring and the reviewed baseline, not new surfaces.

### System map

Package and workflow `repo_*` calls run on `kody-runtime` and must reach the main worker's per-user catalog the same way they already reach `RepoSession`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	packageRuntime["package-runtime<br/>Package runtime"]:::touched
	repoSessions["repo-sessions<br/>Repo sessions"]:::touched
	packageRuntime -->|"REPO_SESSION_INDEX cross-script binding"| repoSessions
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Release as @kentcdodds/release workflow
	participant Runtime as kody-runtime
	participant Index as RepoSessionIndex on kody
	Release->>Runtime: kody.repo_open_session / publish
	Runtime->>Index: catalog RPC via REPO_SESSION_INDEX
	Index-->>Runtime: session row
	Runtime-->>Release: session id
```

### Before / after

**Before:** runtime worker bound `REPO_SESSION` but not `REPO_SESSION_INDEX`. Workflow `repo_*` calls threw `REPO_SESSION_INDEX Durable Object binding is not configured.`

**After:** both production and preview runtime envs bind `REPO_SESSION_INDEX` with `script_name: kody`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c29dcb8e-9283-4cd6-9673-2be3a74a4bc7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c29dcb8e-9283-4cd6-9673-2be3a74a4bc7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration reference documentation to describe repository session indexing and its runtime integration.

- **Improvements**
  - Added repository session index configuration for production and preview environments, supporting more consistent repository session handling across runtime capabilities.

- **Quality**
  - Added configuration checks to verify the session index is correctly connected in both deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->