### PR TITLE
fix(sentry): drop D1 overloaded queue blips (KODY-CLOUDFLARE-51)

### DIFF
--- a/packages/shared/src/d1-retry.ts
+++ b/packages/shared/src/d1-retry.ts
@@ -27,6 +27,17 @@ export const d1LongRunningExportMessage =
 export const d1NetworkConnectionLostMessage = 'Network connection lost'
 
 /**
+ * Cloudflare D1 capacity blip
+ * (`D1_ERROR: D1 DB is overloaded. Requests queued for too long.`).
+ * Not an application defect — D1's request queue timed out under platform
+ * load. Same retry / Sentry-drop class as SQLITE_BUSY and binding transport
+ * blips. Match only the exact D1 forms (optional `Error:` / `D1_ERROR:`
+ * prefixes) so unrelated "… overloaded …" messages stay out.
+ */
+export const d1DbOverloadedMessage =
+	'D1 DB is overloaded. Requests queued for too long'
+
+/**
  * Cloudflare D1 opaque platform failures with a support reference, e.g.
  * `D1_ERROR: internal error; reference = <id>` and
  * `D1_ERROR: Internal error in D1 DB storage caused object to be reset; reference = <id>`.
@@ -46,12 +57,17 @@ function stripD1ErrorPrefixes(message: string) {
 		.replace(/^D1_ERROR:\s*/i, '')
 }
 
-function isD1NetworkConnectionLostMessage(message: string) {
+function isExactD1PlatformMessage(message: string, expected: string) {
 	const normalized = stripD1ErrorPrefixes(message)
-	return (
-		normalized === d1NetworkConnectionLostMessage ||
-		normalized === `${d1NetworkConnectionLostMessage}.`
-	)
+	return normalized === expected || normalized === `${expected}.`
+}
+
+function isD1NetworkConnectionLostMessage(message: string) {
+	return isExactD1PlatformMessage(message, d1NetworkConnectionLostMessage)
+}
+
+function isD1DbOverloadedMessage(message: string) {
+	return isExactD1PlatformMessage(message, d1DbOverloadedMessage)
 }
 
 function isD1InternalErrorMessage(message: string) {
@@ -64,6 +80,7 @@ export function isRetryableD1LockMessage(message: string) {
 		message.includes('database is locked') ||
 		message.includes(d1LongRunningExportMessage) ||
 		isD1NetworkConnectionLostMessage(message) ||
+		isD1DbOverloadedMessage(message) ||
 		isD1InternalErrorMessage(message)
 	)
 }
@@ -76,11 +93,13 @@ export function isRetryableD1LockError(error: unknown) {
  * Retries transient D1 unavailability: SQLITE_BUSY lock contention,
  * Cloudflare's "Currently processing a long-running export" (DR / REST
  * exports block other requests), binding "Network connection lost"
- * transport blips, and opaque D1 "internal error …; reference = …" platform
+ * transport blips, "D1 DB is overloaded. Requests queued for too long"
+ * capacity blips, and opaque D1 "internal error …; reference = …" platform
  * faults (including storage object-reset). D1 does not automatically retry
  * write queries, so cron lanes and long-running retention batches need
  * application-level backoff when they overlap with concurrent writers, an
- * in-flight export, a brief D1 session drop, or a D1 backend blip.
+ * in-flight export, a brief D1 session drop, a D1 capacity spike, or a D1
+ * backend blip.
  */
 export async function runD1WithRetry<T>(
 	operation: () => Promise<T>,

--- a/packages/worker/src/app/handlers/health-components.ts
+++ b/packages/worker/src/app/handlers/health-components.ts
@@ -15,8 +15,9 @@ const componentCheckTimeoutMs = 3_000
 const resultCacheTtlMs = 10_000
 
 /**
- * Transient D1 blips (SQLITE_BUSY, "Network connection lost", opaque
- * "internal error; reference = …") are tolerated with retries on every
+ * Transient D1 blips (SQLITE_BUSY, "Network connection lost", "D1 DB is
+ * overloaded…", opaque "internal error; reference = …") are tolerated with
+ * retries on every
  * production D1 path, so a single blip must not register as component
  * downtime on the public status page — the mostly idle audit database was
  * losing uptime to exactly these. Three attempts with the standard backoff

--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -22,6 +22,18 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 	expect(
 		isRetryableD1LockError(
 			new Error(
+				'D1_ERROR: D1 DB is overloaded. Requests queued for too long.',
+			),
+		),
+	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error('D1 DB is overloaded. Requests queued for too long'),
+		),
+	).toBe(true)
+	expect(
+		isRetryableD1LockError(
+			new Error(
 				'D1_ERROR: internal error; reference = 0u3odos5iotccpol68ppc0eg',
 			),
 		),
@@ -36,6 +48,11 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 	expect(
 		isRetryableD1LockError(
 			new Error('Network connection lost while uploading...'),
+		),
+	).toBe(false)
+	expect(
+		isRetryableD1LockError(
+			new Error('queue is overloaded while uploading...'),
 		),
 	).toBe(false)
 	expect(isRetryableD1LockError(new Error('internal error'))).toBe(false)

--- a/packages/worker/src/d1-retry.node.test.ts
+++ b/packages/worker/src/d1-retry.node.test.ts
@@ -21,9 +21,7 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 	)
 	expect(
 		isRetryableD1LockError(
-			new Error(
-				'D1_ERROR: D1 DB is overloaded. Requests queued for too long.',
-			),
+			new Error('D1_ERROR: D1 DB is overloaded. Requests queued for too long.'),
 		),
 	).toBe(true)
 	expect(
@@ -51,9 +49,7 @@ test('runD1WithRetry matches lock errors, retries them, and rethrows other failu
 		),
 	).toBe(false)
 	expect(
-		isRetryableD1LockError(
-			new Error('queue is overloaded while uploading...'),
-		),
+		isRetryableD1LockError(new Error('queue is overloaded while uploading...')),
 	).toBe(false)
 	expect(isRetryableD1LockError(new Error('internal error'))).toBe(false)
 	expect(

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -78,6 +78,27 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 				values: [
 					{
 						value:
+							'D1_ERROR: D1 DB is overloaded. Requests queued for too long.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{ value: 'D1 DB is overloaded. Requests queued for too long' },
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
 							'D1_ERROR: internal error; reference = 0u3odos5iotccpol68ppc0eg',
 					},
 				],
@@ -103,6 +124,13 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		},
 	}
 	expect(filterSentryEvent(unrelatedNetworkLoss)).toBe(unrelatedNetworkLoss)
+
+	const unrelatedOverload = {
+		exception: {
+			values: [{ value: 'queue is overloaded while uploading...' }],
+		},
+	}
+	expect(filterSentryEvent(unrelatedOverload)).toBe(unrelatedOverload)
 
 	const bareInternalError = {
 		exception: { values: [{ value: 'internal error' }] },

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -453,11 +453,13 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// application capture paths (for example scheduled_lane_failed) still
 		// forwarded them. The same applies to "Currently processing a
 		// long-running export" while the nightly DR D1 export holds the DB,
-		// "Network connection lost" when the D1 binding drops mid-query, and
-		// opaque D1 "internal error …; reference = …" platform faults
-		// (including storage object-reset). These are transient platform
-		// unavailability errors retried in app code and should not open or
-		// regress Sentry issues.
+		// "Network connection lost" when the D1 binding drops mid-query,
+		// "D1 DB is overloaded. Requests queued for too long" when D1's
+		// request queue times out under platform load, and opaque D1
+		// "internal error …; reference = …" platform faults (including
+		// storage object-reset). These are transient platform unavailability
+		// errors retried in app code and should not open or regress Sentry
+		// issues.
 		//
 		// User-authored failures are dropped primarily via `UserCodeError`
 		// (`filterUserCodeErrorSentryEvent`). Plan-limit denials


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare D1 capacity spikes (`D1 DB is overloaded. Requests queued for too long`) from opening Sentry triage noise, and retry them like other known D1 platform blips.

## Summary

- Treat the exact D1 overload message as retryable in `@kody-internal/shared/d1-retry` (same class as SQLITE_BUSY / network-loss / export-busy / internal-error-with-reference).
- Existing `beforeSend` (`filterRetryableD1LockSentryEvent`) therefore drops these events.
- Cover positive and negative cases in worker D1 retry + Sentry filter tests.
- Siblings from the same ~1s production spike: KODY-CLOUDFLARE-52, 53, 54.

## Testing

- `npx vitest run packages/worker/src/d1-retry.node.test.ts packages/worker/src/sentry-options.node.test.ts` (pass)
- Local full `npm run validate` hit unrelated concurrent Cloudflare-mock / e2e flakes; CI is the merge gate.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fecd413c` · **Head:** `1bfaeab8`

**Classification:** composes — wires one known Cloudflare D1 platform string into the existing retry + Sentry-drop path; no schema, auth, or API contract changes.

### Primitives touched

| Primitive   | Group   | Impact                                                                 |
| ----------- | ------- | ---------------------------------------------------------------------- |
| `d1-app-db` | storage | composes — recognize D1 overload queue timeout as retryable platform blip |

### System map

D1 overload errors flow through the shared retry matcher into Worker `beforeSend`, so brief platform capacity spikes stop opening Sentry issues while call sites using `runD1WithRetry` back off.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	d1Retry["shared d1-retry<br/>retry matcher"]:::touched
	sentryFilter["sentry-options<br/>beforeSend"]:::touched
	d1AppDb -->|"overloaded queue timeout"| d1Retry
	d1Retry -->|"isRetryableD1LockMessage"| sentryFilter
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bce7d447-c399-4282-82f1-912b447fcd07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bce7d447-c399-4282-82f1-912b447fcd07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transient D1 database overload errors, including common prefixed and trailing-period variants.
  * Retry logic now recognizes overload conditions alongside network and queued-request failures.
  * Unrelated overload errors continue to be reported normally.

* **Documentation**
  * Updated health and error-monitoring documentation to describe transient D1 capacity and connectivity failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->