### PR TITLE
docs: allow altering the Community Project mark

### DIFF
--- a/docs/use/community-project-mark.md
+++ b/docs/use/community-project-mark.md
@@ -33,10 +33,12 @@ that suggest your project is official. Use the Community Project mark instead.
 
 ## How to use the mark
 
-1. **Use the mark as-is** for app icons, README badges, store listings, and
+1. **Use the mark** for app icons, README badges, store listings, and
    marketing where space allows.
-2. **Keep it readable.** Do not stretch, recolor, or edit the character or ring
-   text. Cropping to a circle is fine when the platform requires a square icon.
+2. **Alter the mark if you need to.** Recolor, restyle, crop, or otherwise
+   adapt it, as long as the community label stays intact and readable. That
+   label — the ring text that names this a community project, or an equally
+   clear community label — is what tells users the project is unofficial.
 3. **Name your project clearly.** Prefer names like “Kody Bridge for iOS” or
    “Acme’s Kody Toolkit” rather than plain “Kody.”
 4. **Include attribution** wherever you show the mark or describe the

--- a/docs/use/community-project-mark.md
+++ b/docs/use/community-project-mark.md
@@ -33,12 +33,12 @@ that suggest your project is official. Use the Community Project mark instead.
 
 ## How to use the mark
 
-1. **Use the mark** for app icons, README badges, store listings, and
-   marketing where space allows.
-2. **Alter the mark if you need to.** Recolor, restyle, crop, or otherwise
-   adapt it, as long as the community label stays intact and readable. That
-   label — the ring text that names this a community project, or an equally
-   clear community label — is what tells users the project is unofficial.
+1. **Use the mark** for app icons, README badges, store listings, and marketing
+   where space allows.
+2. **Alter the mark if you need to.** Recolor, restyle, crop, or otherwise adapt
+   it, as long as the community label stays intact and readable. That label —
+   the ring text that names this a community project, or an equally clear
+   community label — is what tells users the project is unofficial.
 3. **Name your project clearly.** Prefer names like “Kody Bridge for iOS” or
    “Acme’s Kody Toolkit” rather than plain “Kody.”
 4. **Include attribution** wherever you show the mark or describe the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Community builders should be able to adapt the Community Project mark (recolor, restyle, crop) without implying official Kody branding, as long as the community label stays intact.

## Summary

- Update [Community Project mark](https://github.com/kentcdodds/kody/blob/cursor/community-logo-guidelines-9283/docs/use/community-project-mark.md) usage rules.
- Drop the “use as-is / do not recolor or edit” restriction.
- Require that the community label (ring text, or an equally clear community label) stay intact and readable.

## Testing

- `npm run docs:check-temporal` passed.
- `oxfmt` wrap applied after Static CI failed on line length.
- Docs-only change; no code, UI, or primitive behavior to exercise.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fecd413c` · **Head:** `15863f9e`

**Classification:** composes — no primitives added or changed; this PR updates usage docs only.

### Primitives touched

None. The classifier matched no primitive `code` roots. The only path is `docs/use/community-project-mark.md`.

### System map

Usage docs describe how third-party projects may display the Community Project mark. This PR does not cross any runtime primitive boundary.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	docs["usage docs<br/>Community Project mark"]:::touched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dcaee77-1fa7-4f41-98bf-cfbe31a29283?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dcaee77-1fa7-4f41-98bf-cfbe31a29283&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated community project mark guidance to allow recoloring, restyling, cropping, and other adaptations.
  * Clarified that the community designation must remain intact and readable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->