### PR TITLE
fix(sentry): retry and filter Artifacts packfile corruption

### DIFF
--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -71,24 +71,24 @@ export async function readFirstArtifactFileAtCommit(input: {
 	const auth = buildArtifactsGitAuth({ token: token.plaintext })
 	// Fresh ephemeral workspace per attempt: a corrupt pack may leave partial
 	// objects that would poison a retry on the same Map store.
-	let workspace: ReturnType<typeof createEphemeralGitWorkspace> | null = null
+	let workspace: ReturnType<typeof createEphemeralGitWorkspace>
 	try {
-		await runArtifactsGitWithRetry(async () => {
-			workspace = createEphemeralGitWorkspace()
+		workspace = await runArtifactsGitWithRetry(async () => {
+			const nextWorkspace = createEphemeralGitWorkspace()
 			await git.init({
-				fs: workspace.fs,
-				dir: workspace.dir,
+				fs: nextWorkspace.fs,
+				dir: nextWorkspace.dir,
 			})
 			await git.addRemote({
-				fs: workspace.fs,
-				dir: workspace.dir,
+				fs: nextWorkspace.fs,
+				dir: nextWorkspace.dir,
 				remote: 'origin',
 				url: remote,
 			})
 			await git.fetch({
-				fs: workspace.fs,
+				fs: nextWorkspace.fs,
 				http,
-				dir: workspace.dir,
+				dir: nextWorkspace.dir,
 				remote: 'origin',
 				ref: input.commit,
 				depth: 1,
@@ -98,6 +98,7 @@ export async function readFirstArtifactFileAtCommit(input: {
 					return auth
 				},
 			})
+			return nextWorkspace
 		})
 	} catch (error) {
 		throw wrapArtifactsGitHttpError({
@@ -105,9 +106,6 @@ export async function readFirstArtifactFileAtCommit(input: {
 			remote: info.remote,
 			error,
 		})
-	}
-	if (!workspace) {
-		throw new Error('Artifacts git fetch completed without a workspace.')
 	}
 
 	for (const filePath of input.filePaths) {

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -69,20 +69,23 @@ export async function readFirstArtifactFileAtCommit(input: {
 		token: token.plaintext,
 	})
 	const auth = buildArtifactsGitAuth({ token: token.plaintext })
-	const workspace = createEphemeralGitWorkspace()
-	await git.init({
-		fs: workspace.fs,
-		dir: workspace.dir,
-	})
-	await git.addRemote({
-		fs: workspace.fs,
-		dir: workspace.dir,
-		remote: 'origin',
-		url: remote,
-	})
+	// Fresh ephemeral workspace per attempt: a corrupt pack may leave partial
+	// objects that would poison a retry on the same Map store.
+	let workspace: ReturnType<typeof createEphemeralGitWorkspace> | null = null
 	try {
-		await runArtifactsGitWithRetry(() =>
-			git.fetch({
+		await runArtifactsGitWithRetry(async () => {
+			workspace = createEphemeralGitWorkspace()
+			await git.init({
+				fs: workspace.fs,
+				dir: workspace.dir,
+			})
+			await git.addRemote({
+				fs: workspace.fs,
+				dir: workspace.dir,
+				remote: 'origin',
+				url: remote,
+			})
+			await git.fetch({
 				fs: workspace.fs,
 				http,
 				dir: workspace.dir,
@@ -94,14 +97,17 @@ export async function readFirstArtifactFileAtCommit(input: {
 				onAuth() {
 					return auth
 				},
-			}),
-		)
+			})
+		})
 	} catch (error) {
 		throw wrapArtifactsGitHttpError({
 			operation: 'git fetch',
 			remote: info.remote,
 			error,
 		})
+	}
+	if (!workspace) {
+		throw new Error('Artifacts git fetch completed without a workspace.')
 	}
 
 	for (const filePath of input.filePaths) {

--- a/packages/worker/src/repo/artifacts-git-retry.node.test.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.node.test.ts
@@ -114,9 +114,9 @@ test('Artifacts git packfile corruption is transient, wrapped for git clone, and
 	const corruption = packfileCorruptionError()
 	expect(isIsomorphicGitPackfileCorruptionError(corruption)).toBe(true)
 	expect(isTransientArtifactsGitError(corruption)).toBe(true)
-	expect(isTransientArtifactsGitError(new Error('unrelated InternalError'))).toBe(
-		false,
-	)
+	expect(
+		isTransientArtifactsGitError(new Error('unrelated InternalError')),
+	).toBe(false)
 
 	const wrapped = wrapArtifactsGitHttpError({
 		operation: 'git clone',
@@ -128,9 +128,9 @@ test('Artifacts git packfile corruption is transient, wrapped for git clone, and
 	expect(wrapped.message).toContain('Packfile payload corrupted')
 	expect(wrapped.message).not.toContain('secret')
 	expect(isArtifactsGitTransientErrorMessage(wrapped.message)).toBe(true)
-	expect(isArtifactsGitPackfileCorruptionSentryMessage(corruption.message)).toBe(
-		true,
-	)
+	expect(
+		isArtifactsGitPackfileCorruptionSentryMessage(corruption.message),
+	).toBe(true)
 	expect(
 		isArtifactsGitTransientHttpErrorMessage(
 			'Artifacts git clone failed for https://example.test: HTTP Error: 500',

--- a/packages/worker/src/repo/artifacts-git-retry.node.test.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.node.test.ts
@@ -1,7 +1,11 @@
 import { expect, test, vi } from 'vitest'
 import {
 	getArtifactsGitHttpStatus,
+	isArtifactsGitPackfileCorruptionSentryMessage,
+	isArtifactsGitTransientErrorMessage,
 	isArtifactsGitTransientHttpErrorMessage,
+	isIsomorphicGitPackfileCorruptionError,
+	isTransientArtifactsGitError,
 	isTransientArtifactsGitHttpError,
 	isTransientArtifactsGitHttpStatus,
 	runArtifactsGitWithRetry,
@@ -22,6 +26,15 @@ function httpError(
 	error.code = 'HttpError'
 	error.name = 'HttpError'
 	error.data = { statusCode, statusMessage, response: '' }
+	return error
+}
+
+function packfileCorruptionError() {
+	const error = new Error(
+		`An internal error caused this command to fail.\n\nIf you're using an application that depends on isomorphic-git, please report this error to that application's developers.\n\nIf you're a developer and you believe this is a bug in isomorphic-git, please file an issue at https://github.com/isomorphic-git/isomorphic-git/issues with a minimal reproduction, version and environment details, and this error message: Packfile payload corrupted: calculated abc but expected def. The packfile may have been tampered with.`,
+	) as Error & { code: string; name: string }
+	error.code = 'InternalError'
+	error.name = 'InternalError'
 	return error
 }
 
@@ -93,6 +106,49 @@ test('Artifacts git HTTP helpers classify transient statuses, wrap messages, and
 	const persistent = vi.fn().mockRejectedValue(httpError(500))
 	await expect(runArtifactsGitWithRetry(persistent, [0, 0])).rejects.toThrow(
 		/HTTP Error: 500/,
+	)
+	expect(persistent).toHaveBeenCalledTimes(3)
+})
+
+test('Artifacts git packfile corruption is transient, wrapped for git clone, and retried', async () => {
+	const corruption = packfileCorruptionError()
+	expect(isIsomorphicGitPackfileCorruptionError(corruption)).toBe(true)
+	expect(isTransientArtifactsGitError(corruption)).toBe(true)
+	expect(isTransientArtifactsGitError(new Error('unrelated InternalError'))).toBe(
+		false,
+	)
+
+	const wrapped = wrapArtifactsGitHttpError({
+		operation: 'git clone',
+		remote:
+			'https://x:secret@acct.artifacts.cloudflare.net/git/production/repo-1.git',
+		error: corruption,
+	})
+	expect(wrapped.message).toMatch(/^Artifacts git clone failed for /)
+	expect(wrapped.message).toContain('Packfile payload corrupted')
+	expect(wrapped.message).not.toContain('secret')
+	expect(isArtifactsGitTransientErrorMessage(wrapped.message)).toBe(true)
+	expect(isArtifactsGitPackfileCorruptionSentryMessage(corruption.message)).toBe(
+		true,
+	)
+	expect(
+		isArtifactsGitTransientHttpErrorMessage(
+			'Artifacts git clone failed for https://example.test: HTTP Error: 500',
+		),
+	).toBe(true)
+
+	const operation = vi
+		.fn()
+		.mockRejectedValueOnce(corruption)
+		.mockResolvedValueOnce({ cloned: true })
+	await expect(runArtifactsGitWithRetry(operation, [0, 0])).resolves.toEqual({
+		cloned: true,
+	})
+	expect(operation).toHaveBeenCalledTimes(2)
+
+	const persistent = vi.fn().mockRejectedValue(corruption)
+	await expect(runArtifactsGitWithRetry(persistent, [0, 0])).rejects.toThrow(
+		/Packfile payload corrupted/,
 	)
 	expect(persistent).toHaveBeenCalledTimes(3)
 })

--- a/packages/worker/src/repo/artifacts-git-retry.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.ts
@@ -8,6 +8,11 @@ import {
  * returns 5xx / 429 after REST createToken + repo info already succeeded
  * (KODY-CLOUDFLARE-4Y / 4Z / 50). Short retries paper over the blip without
  * treating it as an application defect.
+ *
+ * Separately, upload-pack sometimes returns HTTP 200 with a truncated or
+ * corrupt pack body; isomorphic-git then throws InternalError containing
+ * "Packfile payload corrupted" (KODY-CLOUDFLARE-55 / 56). Same retry + wrap
+ * treatment — never an app-logic defect we can fix in-repo.
  */
 export const artifactsGitHttpRetryDelaysMs = [50, 150] as const
 
@@ -51,6 +56,34 @@ export function isTransientArtifactsGitHttpError(error: unknown) {
 }
 
 /**
+ * isomorphic-git integrity failure while unpacking a remote pack. The phrase
+ * is unique to that check; match it anywhere in the cause chain so HTTP-200
+ * corrupt packs and 5xx-interrupted uploads both retry.
+ */
+export function isIsomorphicGitPackfileCorruptionMessage(message: string) {
+	return /Packfile payload corrupted/i.test(message)
+}
+
+export function isIsomorphicGitPackfileCorruptionError(error: unknown) {
+	for (const entry of getErrorCauseChain(error)) {
+		if (
+			entry instanceof Error &&
+			isIsomorphicGitPackfileCorruptionMessage(entry.message)
+		) {
+			return true
+		}
+	}
+	return false
+}
+
+export function isTransientArtifactsGitError(error: unknown) {
+	return (
+		isTransientArtifactsGitHttpError(error) ||
+		isIsomorphicGitPackfileCorruptionError(error)
+	)
+}
+
+/**
  * Stable wrapper phrases used by Artifacts git call sites and the Sentry
  * beforeSend filter. Keep these exact so triage filters stay narrow, and keep
  * the status set aligned with `isTransientArtifactsGitHttpStatus` so we do not
@@ -58,11 +91,28 @@ export function isTransientArtifactsGitHttpError(error: unknown) {
  */
 export function isArtifactsGitTransientHttpErrorMessage(message: string) {
 	const match =
-		/Artifacts (?:listServerRefs|git fetch) failed for .+: HTTP Error: (\d{3})\b/i.exec(
+		/Artifacts (?:listServerRefs|git fetch|git clone) failed for .+: HTTP Error: (\d{3})\b/i.exec(
 			message.trim(),
 		)
 	if (!match?.[1]) return false
 	return isTransientArtifactsGitHttpStatus(Number(match[1]))
+}
+
+/**
+ * Drop Sentry events for Artifacts pack corruption whether or not a call site
+ * wrapped them. The phrase is never produced by application logic — only by
+ * isomorphic-git verifying a remote pack — so bare InternalError events from
+ * `git.clone` paths are safe to filter the same way as wrapped ones.
+ */
+export function isArtifactsGitPackfileCorruptionSentryMessage(message: string) {
+	return isIsomorphicGitPackfileCorruptionMessage(message)
+}
+
+export function isArtifactsGitTransientErrorMessage(message: string) {
+	return (
+		isArtifactsGitTransientHttpErrorMessage(message) ||
+		isArtifactsGitPackfileCorruptionSentryMessage(message)
+	)
 }
 
 function describeArtifactRemote(remote: string) {
@@ -79,7 +129,7 @@ function describeArtifactRemote(remote: string) {
 }
 
 export function wrapArtifactsGitHttpError(input: {
-	operation: 'listServerRefs' | 'git fetch'
+	operation: 'listServerRefs' | 'git fetch' | 'git clone'
 	remote: string
 	error: unknown
 }) {
@@ -105,7 +155,7 @@ export async function runArtifactsGitWithRetry<T>(
 		} catch (error) {
 			lastError = error
 			const canRetry =
-				isTransientArtifactsGitHttpError(error) && attempt < maxAttempts - 1
+				isTransientArtifactsGitError(error) && attempt < maxAttempts - 1
 			if (!canRetry) throw error
 			const delayMs = delaysMs[attempt]
 			if (delayMs !== undefined && delayMs > 0) {

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -1410,6 +1410,67 @@ test('openSession sanitizes repo names, persists namespace metadata, and rejects
 	).rejects.toThrow(/does not match published commit/)
 })
 
+test('openSession wraps packfile corruption but leaves opaque Cloudflare internals bare', async () => {
+	restoreRepoSessionMockBaseline()
+	const { remote } = stubPackageSourceForOpenSession()
+	mockModule.git.clone.mockRejectedValue(
+		new Error(
+			'An internal error caused this command to fail. Packfile payload corrupted: calculated abc but expected def.',
+		),
+	)
+
+	const packfileError = await new RepoSession(
+		createDurableObjectState(),
+		createEnv(),
+	)
+		.openSession({
+			sessionId: 'session-packfile',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			baseUrl: 'https://example.com',
+			sourceRoot: '/',
+		})
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+	expect(packfileError).toBeInstanceOf(Error)
+	expect((packfileError as Error).message).toMatch(
+		new RegExp(
+			`^Artifacts git clone failed for ${remote.replaceAll('.', '\\.')}:`,
+		),
+	)
+	expect((packfileError as Error).message).toContain(
+		'Packfile payload corrupted',
+	)
+	expect(mockModule.git.clone.mock.calls.length).toBeGreaterThanOrEqual(2)
+
+	restoreRepoSessionMockBaseline()
+	stubPackageSourceForOpenSession()
+	mockModule.git.clone.mockClear()
+	mockModule.git.clone.mockRejectedValue(
+		new Error('An internal error occurred.'),
+	)
+	const opaqueError = await new RepoSession(
+		createDurableObjectState(),
+		createEnv(),
+	)
+		.openSession({
+			sessionId: 'session-opaque',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			baseUrl: 'https://example.com',
+			sourceRoot: '/',
+		})
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+	expect(opaqueError).toBeInstanceOf(Error)
+	expect((opaqueError as Error).message).toBe('An internal error occurred.')
+	expect(mockModule.git.clone).toHaveBeenCalledTimes(1)
+})
+
 test('readFile retries D1 reads and falls back to cached sessions when replicas lag', async () => {
 	restoreRepoSessionMockBaseline()
 	const replicaLagSessionRow = {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -102,6 +102,10 @@ import {
 } from './publish-git-notes.ts'
 import { createIsomorphicGitFs } from './isomorphic-git-fs.ts'
 import {
+	runArtifactsGitWithRetry,
+	wrapArtifactsGitHttpError,
+} from './artifacts-git-retry.ts'
+import {
 	buildRepoLargeFileMessage,
 	maxRepoSourceFileBytes,
 	measureRepoSourceFileBytes,
@@ -266,6 +270,52 @@ class RepoSessionBase extends DurableObject<Env> {
 	readonly git = createGit(this.fileSystem, repoSessionWorkspacePrefix)
 
 	private initializedSessionId: string | null = null
+
+	/**
+	 * Clone an Artifacts remote with brief retries for transient HTTP 5xx /
+	 * 429 and isomorphic-git packfile corruption (KODY-CLOUDFLARE-55). Retries
+	 * always reset the DO workspace so a partial unpack cannot poison the next
+	 * attempt. Callers that already expect a clean tree (openSession / publish)
+	 * pass `resetBeforeFirstAttempt`.
+	 */
+	private async cloneArtifactsRepoWithRetry(input: {
+		remote: string
+		token: string
+		branch?: string | null
+		resetBeforeFirstAttempt?: boolean
+	}) {
+		let attempt = 0
+		try {
+			await runArtifactsGitWithRetry(async () => {
+				if (attempt > 0 || input.resetBeforeFirstAttempt) {
+					await this.resetWorkspace()
+				}
+				attempt += 1
+				await this.workspace.mkdir(repoSessionWorkspacePrefix, {
+					recursive: true,
+				})
+				await this.git.clone({
+					dir: repoSessionWorkspacePrefix,
+					...(input.branch
+						? {
+								branch: input.branch,
+								singleBranch: true,
+							}
+						: {}),
+					...buildGitCloneAuth({
+						remote: input.remote,
+						token: input.token,
+					}),
+				})
+			})
+		} catch (error) {
+			throw wrapArtifactsGitHttpError({
+				operation: 'git clone',
+				remote: input.remote,
+				error,
+			})
+		}
+	}
 
 	// In-memory cache for the active DO instance. This serves as the primary
 	// fallback for follow-up RPC calls on the same sessionId so that even the
@@ -751,21 +801,10 @@ class RepoSessionBase extends DurableObject<Env> {
 		}
 		const hasCleanGitDir = await this.workspace.exists(gitConfigPath)
 		if (!hasCleanGitDir) {
-			await this.workspace.mkdir(repoSessionWorkspacePrefix, {
-				recursive: true,
-			})
-			await this.git.clone({
-				dir: repoSessionWorkspacePrefix,
-				...(input.sessionBranch
-					? {
-							branch: input.sessionBranch,
-							singleBranch: true,
-						}
-					: {}),
-				...buildGitCloneAuth({
-					remote: input.repoRemote,
-					token: input.repoToken,
-				}),
+			await this.cloneArtifactsRepoWithRetry({
+				remote: input.repoRemote,
+				token: input.repoToken,
+				branch: input.sessionBranch,
 			})
 		}
 		this.initializedSessionId = input.sessionId
@@ -1128,18 +1167,11 @@ class RepoSessionBase extends DurableObject<Env> {
 				)
 			}
 			const sessionBranch = buildSessionBranchName(input.sessionId)
-			await this.resetWorkspace()
-			await this.workspace.mkdir(repoSessionWorkspacePrefix, {
-				recursive: true,
-			})
-			await this.git.clone({
-				dir: repoSessionWorkspacePrefix,
+			await this.cloneArtifactsRepoWithRetry({
+				remote: sourceAccess.remote,
+				token: sourceAccess.token,
 				branch: sourceBranch,
-				singleBranch: true,
-				...buildGitCloneAuth({
-					remote: sourceAccess.remote,
-					token: sourceAccess.token,
-				}),
+				resetBeforeFirstAttempt: true,
 			})
 			await this.git.checkout({
 				dir: repoSessionWorkspacePrefix,
@@ -2634,19 +2666,12 @@ class RepoSessionBase extends DurableObject<Env> {
 			scope: 'read',
 		})
 		const targetBranch = sourceInfo?.defaultBranch ?? defaultSessionBranch
-		await this.resetWorkspace()
-		await this.workspace.mkdir(repoSessionWorkspacePrefix, {
-			recursive: true,
-		})
 		try {
-			await this.git.clone({
-				dir: repoSessionWorkspacePrefix,
+			await this.cloneArtifactsRepoWithRetry({
+				remote: sourceAccess.remote,
+				token: sourceAccess.token,
 				branch: targetBranch,
-				singleBranch: true,
-				...buildGitCloneAuth({
-					remote: sourceAccess.remote,
-					token: sourceAccess.token,
-				}),
+				resetBeforeFirstAttempt: true,
 			})
 			// Race protection without a second Artifacts REST HEAD resolve: the
 			// single-branch clone tip is the remote default-branch HEAD at clone

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -102,6 +102,7 @@ import {
 } from './publish-git-notes.ts'
 import { createIsomorphicGitFs } from './isomorphic-git-fs.ts'
 import {
+	isTransientArtifactsGitError,
 	runArtifactsGitWithRetry,
 	wrapArtifactsGitHttpError,
 } from './artifacts-git-retry.ts'
@@ -309,11 +310,18 @@ class RepoSessionBase extends DurableObject<Env> {
 				})
 			})
 		} catch (error) {
-			throw wrapArtifactsGitHttpError({
-				operation: 'git clone',
-				remote: input.remote,
-				error,
-			})
+			// Only wrap Artifacts-transient signatures (HTTP 5xx / packfile
+			// corruption). Bare Cloudflare opaque internals must stay unwrapped
+			// so repo_open_session can still match and retry with a fresh
+			// session id (KODY-CLOUDFLARE-4H).
+			if (isTransientArtifactsGitError(error)) {
+				throw wrapArtifactsGitHttpError({
+					operation: 'git clone',
+					remote: input.remote,
+					error,
+				})
+			}
+			throw error
 		}
 	}
 

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -175,9 +175,10 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	}
 	expect(filterSentryEvent(wrappedOpaqueInternal)).toBe(wrappedOpaqueInternal)
 
-	// Artifacts git protocol HTTP 5xx wrappers (KODY-CLOUDFLARE-4Y / 4Z / 50).
-	// Classifier edge cases live in artifacts-git-retry; here we only pin the
-	// Sentry drop vs keep contract for wrapper vs bare messages.
+	// Artifacts git protocol HTTP 5xx wrappers (KODY-CLOUDFLARE-4Y / 4Z / 50)
+	// and packfile corruption (KODY-CLOUDFLARE-55 / 56). Classifier edge cases
+	// live in artifacts-git-retry; here we only pin the Sentry drop vs keep
+	// contract for wrapper vs bare HTTP messages, plus bare packfile drops.
 	expect(
 		filterSentryEvent({
 			exception: {
@@ -197,6 +198,43 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	}
 	expect(filterSentryEvent(bareArtifactsGitHttpError)).toBe(
 		bareArtifactsGitHttpError,
+	)
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'Artifacts git clone failed for https://acct.artifacts.cloudflare.net/git/production/repo-1.git: Packfile payload corrupted: calculated abc but expected def.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'An internal error caused this command to fail.\n\nPackfile payload corrupted: calculated abc but expected def. The packfile may have been tampered with.',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	const bareInternalWithoutPackfile = {
+		exception: {
+			values: [
+				{
+					value:
+						'An internal error caused this command to fail.\n\nUnrelated isomorphic-git InternalError.',
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(bareInternalWithoutPackfile)).toBe(
+		bareInternalWithoutPackfile,
 	)
 
 	// Bare Agents MCP session teardown abort (`ctx.abort("destroyed")`) —

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -5,7 +5,7 @@ import { isRetryableD1LockSentryEvent } from './d1-retry.ts'
 import { isEntitlementLimitError } from './entitlements/errors.ts'
 import { isIntegrationTokenRefreshCallerMessage } from './integrations/token-refresh.ts'
 import { isRemoteConnectorUnavailableMessage } from './remote-connector/status.ts'
-import { isArtifactsGitTransientHttpErrorMessage } from './repo/artifacts-git-retry.ts'
+import { isArtifactsGitTransientErrorMessage } from './repo/artifacts-git-retry.ts'
 import { isUserCodeError } from './user-code-error.ts'
 
 function sentryEventMessages(event: ErrorEvent) {
@@ -347,16 +347,18 @@ export function filterCloudflareOpaqueInternalErrorSentryEvent(
 
 /**
  * Cloudflare Artifacts git protocol HTTP 5xx / 429 after REST auth already
- * succeeded (KODY-CLOUDFLARE-4Y / 4Z / 50). Call sites retry briefly; exhausted
- * failures keep the stable `Artifacts listServerRefs|git fetch failed for …:
- * HTTP Error: NNN` wrapper so this beforeSend gate can drop platform blips
- * without swallowing unrelated HTTP errors.
+ * succeeded (KODY-CLOUDFLARE-4Y / 4Z / 50), and isomorphic-git packfile
+ * corruption when upload-pack returns a bad pack body (KODY-CLOUDFLARE-55 /
+ * 56). Call sites retry briefly; exhausted HTTP failures keep the stable
+ * `Artifacts listServerRefs|git fetch|git clone failed for …: HTTP Error: NNN`
+ * wrapper. Packfile corruption is matched by its unique phrase even when bare
+ * (clone paths historically threw unwrapped InternalError).
  */
 export function isArtifactsGitTransientHttpErrorSentryEvent(event: ErrorEvent) {
 	return sentryEventMessages(event).some(
 		(message) =>
 			typeof message === 'string' &&
-			isArtifactsGitTransientHttpErrorMessage(message),
+			isArtifactsGitTransientErrorMessage(message),
 	)
 }
 
@@ -481,8 +483,9 @@ export function buildSentryOptions(env: Env): CloudflareOptions {
 		// INTERNAL_ERROR wording) with no support reference are dropped the
 		// same way — see filterCloudflareOpaqueInternalErrorSentryEvent.
 		// Artifacts git protocol HTTP 5xx / 429 wrappers (listServerRefs /
-		// git fetch) are dropped the same way after brief call-site retries —
-		// see filterArtifactsGitTransientHttpErrorSentryEvent.
+		// git fetch / git clone) and isomorphic-git "Packfile payload
+		// corrupted" events are dropped the same way after brief call-site
+		// retries — see filterArtifactsGitTransientHttpErrorSentryEvent.
 		// Bare Durable Object abort token `destroyed` from Agents MCP session
 		// teardown (`ctx.abort("destroyed")`) is dropped the same way — see
 		// filterMcpAgentSessionDestroyedAbortSentryEvent.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare Artifacts corrupt/truncated pack payloads from failing `repo_open_session` / `repo_get` and flooding Sentry (KODY-CLOUDFLARE-55, sibling 56).

## Summary

- Extend the existing Artifacts git transient-retry helper (HTTP 5xx / 429 from #1456) to isomorphic-git `Packfile payload corrupted` InternalErrors.
- Retry `git.clone` in repo sessions (fresh workspace on retry) and recreate the ephemeral workspace per shallow `git.fetch` attempt.
- Wrap only transient Artifacts clone failures so bare Cloudflare opaque internals still reach `repo_open_session`'s fresh-session retry (Bugbot).
- Drop packfile-corruption events in `beforeSend` (unique phrase; safe bare or wrapped).
- Siblings: KODY-CLOUDFLARE-56 (`repo_get` → `readArtifactFileAtCommit` same pack corruption).

## Testing

- `npm run typecheck` — passed
- Focused node tests including new wrap/opaque regression — passed
- `npm run preview:manual-test -- --pr 1475` — health/login/account smoke passed
- CI Validate — re-running after Bugbot fix

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends repo-sessions</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d84abf1a` · **Head:** `3a821301`

**Classification:** extends — Artifacts git clone/fetch now retries packfile corruption; Sentry drops that signature after retries.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — retry + wrap corrupt Artifacts packs on clone/fetch; beforeSend filter |

### System map

Artifacts REST auth still succeeds; upload-pack may return a bad pack (HTTP 200 or interrupted 5xx). Clone/fetch retries briefly, then Sentry drops the exhausted packfile signature. Opaque Cloudflare internals stay bare for capability-level retry.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	repoOpen["repo_open_session / repo_get"]:::untouched
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	sentry["sentry beforeSend"]:::touched
	repoOpen -->|"clone / shallow fetch"| repoSessions
	repoSessions -->|"exhausted Packfile payload corrupted"| sentry
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a407d16e-d43f-4d2f-9425-b0906f804703?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a407d16e-d43f-4d2f-9425-b0906f804703&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

