### PR TITLE
fix(repo): avoid SQLITE_TOOBIG on package_publish_external_push (KODY-CLOUDFLARE-57)

### DIFF
--- a/packages/worker/src/repo/ephemeral-git-workspace.ts
+++ b/packages/worker/src/repo/ephemeral-git-workspace.ts
@@ -164,6 +164,7 @@ export function createEphemeralGitWorkspace() {
 	}
 	return {
 		fs: createIsomorphicGitFs(filesystem),
+		filesystem,
 		dir: '/repo',
 	}
 }

--- a/packages/worker/src/repo/external-publish-clone.node.test.ts
+++ b/packages/worker/src/repo/external-publish-clone.node.test.ts
@@ -38,15 +38,12 @@ vi.mock('./artifacts-git-retry.ts', () => ({
 	isTransientArtifactsGitError: () => false,
 }))
 
-const { cloneExternalPublishWorkspace } = await import(
-	'./external-publish-clone.ts'
-)
+const { cloneExternalPublishWorkspace } =
+	await import('./external-publish-clone.ts')
 
 test('isWorkspaceSqliteTooBigMessage matches DO SQL row-limit wording', () => {
 	expect(
-		isWorkspaceSqliteTooBigMessage(
-			'string or blob too big: SQLITE_TOOBIG',
-		),
+		isWorkspaceSqliteTooBigMessage('string or blob too big: SQLITE_TOOBIG'),
 	).toBe(true)
 	expect(
 		isWorkspaceSqliteTooBigMessage(
@@ -69,8 +66,7 @@ test('cloneExternalPublishWorkspace clones into ephemeral FS and exposes publish
 		.mockResolvedValueOnce([{ oid: 'commit-new' }, { oid: 'commit-old' }])
 
 	const cloned = await cloneExternalPublishWorkspace({
-		remote:
-			'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
+		remote: 'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
 		token: 'art_token',
 		branch: 'main',
 		checkoutCommit: 'commit-new',

--- a/packages/worker/src/repo/external-publish-clone.node.test.ts
+++ b/packages/worker/src/repo/external-publish-clone.node.test.ts
@@ -1,0 +1,111 @@
+import { expect, test, vi } from 'vitest'
+import {
+	buildWorkspaceSqliteTooBigCallerMessage,
+	isWorkspaceSqliteTooBigMessage,
+} from './external-publish-clone.ts'
+
+const gitMocks = vi.hoisted(() => ({
+	clone: vi.fn(async () => undefined),
+	log: vi.fn(async () => [{ oid: 'commit-head' }]),
+	checkout: vi.fn(async () => undefined),
+	listFiles: vi.fn(async () => ['package.json', 'src/index.ts']),
+}))
+
+vi.mock('isomorphic-git', () => ({
+	default: {
+		clone: (...args: Array<unknown>) => gitMocks.clone(...args),
+		log: (...args: Array<unknown>) => gitMocks.log(...args),
+		checkout: (...args: Array<unknown>) => gitMocks.checkout(...args),
+		listFiles: (...args: Array<unknown>) => gitMocks.listFiles(...args),
+	},
+}))
+
+vi.mock('isomorphic-git/http/web', () => ({
+	default: {},
+}))
+
+vi.mock('./artifacts-git-retry.ts', () => ({
+	runArtifactsGitWithRetry: async <T>(operation: () => Promise<T>) =>
+		await operation(),
+	wrapArtifactsGitHttpError: (input: {
+		operation: string
+		remote: string
+		error: unknown
+	}) =>
+		new Error(
+			`Artifacts ${input.operation} failed for ${input.remote}: ${String(input.error)}`,
+		),
+	isTransientArtifactsGitError: () => false,
+}))
+
+const { cloneExternalPublishWorkspace } = await import(
+	'./external-publish-clone.ts'
+)
+
+test('isWorkspaceSqliteTooBigMessage matches DO SQL row-limit wording', () => {
+	expect(
+		isWorkspaceSqliteTooBigMessage(
+			'string or blob too big: SQLITE_TOOBIG',
+		),
+	).toBe(true)
+	expect(
+		isWorkspaceSqliteTooBigMessage(
+			'source clone or commit checkout failed: string or blob too big: SQLITE_TOOBIG',
+		),
+	).toBe(true)
+	expect(isWorkspaceSqliteTooBigMessage('D1 DB is overloaded')).toBe(false)
+	expect(
+		buildWorkspaceSqliteTooBigCallerMessage('Repo session clone'),
+	).toContain('2 MiB row limit')
+})
+
+test('cloneExternalPublishWorkspace clones into ephemeral FS and exposes publish helpers', async () => {
+	gitMocks.clone.mockClear()
+	gitMocks.log.mockClear()
+	gitMocks.checkout.mockClear()
+	gitMocks.listFiles.mockClear()
+	gitMocks.log
+		.mockResolvedValueOnce([{ oid: 'commit-head' }])
+		.mockResolvedValueOnce([{ oid: 'commit-new' }, { oid: 'commit-old' }])
+
+	const cloned = await cloneExternalPublishWorkspace({
+		remote:
+			'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
+		token: 'art_token',
+		branch: 'main',
+		checkoutCommit: 'commit-new',
+	})
+
+	expect(gitMocks.clone).toHaveBeenCalledWith(
+		expect.objectContaining({
+			dir: '/repo',
+			ref: 'main',
+			singleBranch: true,
+		}),
+	)
+	expect(gitMocks.checkout).toHaveBeenCalledWith(
+		expect.objectContaining({
+			dir: '/repo',
+			ref: 'commit-new',
+			force: true,
+		}),
+	)
+	expect(cloned.headCommit).toBe('commit-head')
+	expect(cloned.dir).toBe('/repo')
+	await expect(
+		cloned.isAncestorCommit({
+			ancestor: 'commit-old',
+			descendant: 'commit-new',
+		}),
+	).resolves.toBe(true)
+
+	await cloned.filesystem.writeFile('/repo/package.json', '{"name":"@kody/x"}')
+	await expect(cloned.workspace.readFile('/repo/package.json')).resolves.toBe(
+		'{"name":"@kody/x"}',
+	)
+	const globbed = await cloned.workspace.glob('**/*')
+	expect(globbed).toEqual([
+		{ path: '/repo/package.json', type: 'file' },
+		{ path: '/repo/src/index.ts', type: 'file' },
+	])
+})

--- a/packages/worker/src/repo/external-publish-clone.node.test.ts
+++ b/packages/worker/src/repo/external-publish-clone.node.test.ts
@@ -108,4 +108,12 @@ test('cloneExternalPublishWorkspace clones into ephemeral FS and exposes publish
 		{ path: '/repo/package.json', type: 'file' },
 		{ path: '/repo/src/index.ts', type: 'file' },
 	])
+	// runRepoChecks passes normalizeRepoWorkspacePath('/repo') + '/**/*' → 'repo/**/*'
+	await expect(cloned.workspace.glob('repo/**/*')).resolves.toEqual([
+		{ path: '/repo/package.json', type: 'file' },
+		{ path: '/repo/src/index.ts', type: 'file' },
+	])
+	await expect(cloned.workspace.glob('repo/src/**/*')).resolves.toEqual([
+		{ path: '/repo/src/index.ts', type: 'file' },
+	])
 })

--- a/packages/worker/src/repo/external-publish-clone.ts
+++ b/packages/worker/src/repo/external-publish-clone.ts
@@ -204,8 +204,7 @@ export async function cloneExternalPublishWorkspace(input: {
  */
 export function isWorkspaceSqliteTooBigMessage(message: string) {
 	return (
-		message.includes('SQLITE_TOOBIG') ||
-		/string or blob too big/i.test(message)
+		message.includes('SQLITE_TOOBIG') || /string or blob too big/i.test(message)
 	)
 }
 

--- a/packages/worker/src/repo/external-publish-clone.ts
+++ b/packages/worker/src/repo/external-publish-clone.ts
@@ -1,0 +1,207 @@
+import git from 'isomorphic-git'
+import http from 'isomorphic-git/http/web'
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
+import {
+	buildArtifactsGitAuth,
+	buildAuthenticatedArtifactsRemote,
+} from './artifacts.ts'
+import {
+	runArtifactsGitWithRetry,
+	wrapArtifactsGitHttpError,
+} from './artifacts-git-retry.ts'
+import { createEphemeralGitWorkspace } from './ephemeral-git-workspace.ts'
+import { type RepoPublishWorkspace } from './external-publish.ts'
+import { type PublishGitNoteFileSystem } from './publish-git-notes.ts'
+
+/**
+ * Clone / checkout for `package_publish_external_push` must not use the
+ * RepoSession Durable Object SQL workspace. isomorphic-git writes the whole
+ * packfile as one blob; without an R2 spill `@cloudflare/shell` Workspace
+ * stores that inline and hits Cloudflare DO SQLite's 2 MiB row limit
+ * (`string or blob too big: SQLITE_TOOBIG`). Ephemeral in-memory FS has no
+ * such row ceiling (Artifacts packs are already capped ~32 MiB).
+ */
+export const externalPublishWorkspaceDir = '/repo'
+
+export type ExternalPublishCloneResult = {
+	workspace: RepoPublishWorkspace
+	headCommit: string | null
+	isAncestorCommit: (input: {
+		ancestor: string
+		descendant: string
+	}) => Promise<boolean>
+	filesystem: PublishGitNoteFileSystem
+	dir: string
+}
+
+function normalizePublishPath(path: string) {
+	const trimmed = path.trim()
+	if (trimmed === '' || trimmed === '/') return '/'
+	return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+function buildPublishWorkspaceFromCheckout(input: {
+	filesystem: PublishGitNoteFileSystem
+	listFiles: () => Promise<Array<string>>
+	dir: string
+}): RepoPublishWorkspace {
+	const dirPrefix = input.dir.endsWith('/') ? input.dir.slice(0, -1) : input.dir
+	return {
+		async readFile(path) {
+			const absolute = normalizePublishPath(path)
+			try {
+				return await input.filesystem.readFile(absolute)
+			} catch {
+				return null
+			}
+		},
+		async glob(pattern) {
+			const files = await input.listFiles()
+			const normalizedPattern = pattern.replace(/^\.\//, '')
+			const matchAll =
+				normalizedPattern === '**/*' ||
+				normalizedPattern === '*' ||
+				normalizedPattern.endsWith('/**/*')
+			const rootPrefix = matchAll
+				? normalizedPattern === '**/*' || normalizedPattern === '*'
+					? ''
+					: normalizedPattern.slice(0, -'/**/*'.length).replace(/^\/+/, '')
+				: null
+			const entries: Array<{ path: string; type: string }> = []
+			for (const relative of files) {
+				if (relative.split('/').includes('.git')) continue
+				if (rootPrefix != null && rootPrefix !== '') {
+					if (
+						relative !== rootPrefix &&
+						!relative.startsWith(`${rootPrefix}/`)
+					) {
+						continue
+					}
+				}
+				entries.push({
+					path: `${dirPrefix}/${relative}`.replace(/\/+/g, '/'),
+					type: 'file',
+				})
+			}
+			return entries
+		},
+	}
+}
+
+export async function cloneExternalPublishWorkspace(input: {
+	remote: string
+	token: string
+	branch: string
+	checkoutCommit: string
+}): Promise<ExternalPublishCloneResult> {
+	const auth = buildArtifactsGitAuth({ token: input.token })
+	const authenticatedRemote = buildAuthenticatedArtifactsRemote({
+		remote: input.remote,
+		token: input.token,
+	})
+	const dir = externalPublishWorkspaceDir
+
+	let workspace: ReturnType<typeof createEphemeralGitWorkspace>
+	try {
+		workspace = await runArtifactsGitWithRetry(async () => {
+			const next = createEphemeralGitWorkspace()
+			await git.clone({
+				fs: next.fs,
+				http,
+				dir,
+				url: authenticatedRemote,
+				ref: input.branch,
+				singleBranch: true,
+				onAuth() {
+					return auth
+				},
+			})
+			return next
+		})
+	} catch (error) {
+		throw wrapArtifactsGitHttpError({
+			operation: 'git clone',
+			remote: input.remote,
+			error,
+		})
+	}
+
+	let headCommit: string | null = null
+	try {
+		const log = await git.log({
+			fs: workspace.fs,
+			dir,
+			depth: 1,
+		})
+		headCommit = log[0]?.oid ?? null
+	} catch (error) {
+		throw new Error(
+			`Failed to resolve cloned HEAD after Artifacts clone: ${getErrorMessage(error)}`,
+			{ cause: error },
+		)
+	}
+
+	try {
+		await git.checkout({
+			fs: workspace.fs,
+			dir,
+			ref: input.checkoutCommit,
+			force: true,
+		})
+	} catch (error) {
+		throw new Error(
+			`source clone or commit checkout failed: ${getErrorMessage(error)}`,
+			{ cause: error },
+		)
+	}
+
+	const publishWorkspace = buildPublishWorkspaceFromCheckout({
+		dir,
+		filesystem: workspace.filesystem,
+		listFiles: async () =>
+			await git.listFiles({
+				fs: workspace.fs,
+				dir,
+			}),
+	})
+
+	return {
+		workspace: publishWorkspace,
+		headCommit,
+		dir,
+		filesystem: workspace.filesystem,
+		isAncestorCommit: async ({ ancestor, descendant }) => {
+			if (ancestor === descendant) return true
+			const commits = await git.log({
+				fs: workspace.fs,
+				dir,
+				ref: descendant,
+				depth: Number.POSITIVE_INFINITY,
+			})
+			return commits.some((commit) => commit.oid === ancestor)
+		},
+	}
+}
+
+/**
+ * Stable phrase for DO SQL Workspace writes that exceed Cloudflare's 2 MiB
+ * string/BLOB row limit. Used when interactive repo sessions still clone into
+ * the SQL-backed Workspace (no R2 spill yet).
+ */
+export function isWorkspaceSqliteTooBigMessage(message: string) {
+	return (
+		message.includes('SQLITE_TOOBIG') ||
+		/string or blob too big/i.test(message)
+	)
+}
+
+export function buildWorkspaceSqliteTooBigCallerMessage(operation: string) {
+	return (
+		`${operation} failed because a git object exceeded the Durable Object ` +
+		`SQLite 2 MiB row limit while materializing the repo session workspace ` +
+		`(string or blob too big: SQLITE_TOOBIG). Shrink large files or pack ` +
+		`content (host bulky assets externally and commit a pointer), then retry. ` +
+		`package_publish_external_push uses an in-memory clone and is not limited ` +
+		`by this row ceiling.`
+	)
+}

--- a/packages/worker/src/repo/external-publish-clone.ts
+++ b/packages/worker/src/repo/external-publish-clone.ts
@@ -46,6 +46,7 @@ function buildPublishWorkspaceFromCheckout(input: {
 	dir: string
 }): RepoPublishWorkspace {
 	const dirPrefix = input.dir.endsWith('/') ? input.dir.slice(0, -1) : input.dir
+	const dirName = dirPrefix.replace(/^\/+/, '')
 	return {
 		async readFile(path) {
 			const absolute = normalizePublishPath(path)
@@ -57,26 +58,39 @@ function buildPublishWorkspaceFromCheckout(input: {
 		},
 		async glob(pattern) {
 			const files = await input.listFiles()
+			// runRepoChecks builds patterns from normalizeRepoWorkspacePath(sourceRoot),
+			// so `/repo` (or `/repo/subdir`) becomes `repo/**/*` / `repo/subdir/**/*`.
+			// git.listFiles paths are relative to the worktree root — strip the
+			// workspace dir segment before filtering or every file is dropped.
 			const normalizedPattern = pattern.replace(/^\.\//, '')
-			const matchAll =
+			let relativeRoot = ''
+			if (
 				normalizedPattern === '**/*' ||
 				normalizedPattern === '*' ||
-				normalizedPattern.endsWith('/**/*')
-			const rootPrefix = matchAll
-				? normalizedPattern === '**/*' || normalizedPattern === '*'
-					? ''
-					: normalizedPattern.slice(0, -'/**/*'.length).replace(/^\/+/, '')
-				: null
+				normalizedPattern === ''
+			) {
+				relativeRoot = ''
+			} else if (normalizedPattern.endsWith('/**/*')) {
+				relativeRoot = normalizedPattern
+					.slice(0, -'/**/*'.length)
+					.replace(/^\/+/, '')
+			} else {
+				relativeRoot = normalizedPattern.replace(/^\/+/, '').replace(/\/+$/, '')
+			}
+			if (relativeRoot === dirName) {
+				relativeRoot = ''
+			} else if (relativeRoot.startsWith(`${dirName}/`)) {
+				relativeRoot = relativeRoot.slice(dirName.length + 1)
+			}
 			const entries: Array<{ path: string; type: string }> = []
 			for (const relative of files) {
 				if (relative.split('/').includes('.git')) continue
-				if (rootPrefix != null && rootPrefix !== '') {
-					if (
-						relative !== rootPrefix &&
-						!relative.startsWith(`${rootPrefix}/`)
-					) {
-						continue
-					}
+				if (
+					relativeRoot !== '' &&
+					relative !== relativeRoot &&
+					!relative.startsWith(`${relativeRoot}/`)
+				) {
+					continue
 				}
 				entries.push({
 					path: `${dirPrefix}/${relative}`.replace(/\/+/g, '/'),

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -86,6 +86,36 @@ const mockModule = vi.hoisted(() => {
 		workspaceMkdir: vi.fn(async () => undefined),
 		workspaceRm: vi.fn(async () => undefined),
 		workspaceGlob: vi.fn(async () => []),
+		cloneExternalPublishWorkspace: vi.fn(async () => ({
+			workspace: {
+				readFile: vi.fn(async () => null),
+				glob: vi.fn(async () => []),
+			},
+			headCommit: 'commit-head',
+			dir: '/repo',
+			filesystem: {
+				readFile: vi.fn(async () => ''),
+				readFileBytes: vi.fn(async () => new Uint8Array()),
+				writeFile: vi.fn(async () => undefined),
+				writeFileBytes: vi.fn(async () => undefined),
+				rm: vi.fn(async () => undefined),
+				mkdir: vi.fn(async () => undefined),
+				readdir: vi.fn(async () => []),
+				stat: vi.fn(async () => ({
+					type: 'file' as const,
+					size: 0,
+					mtime: new Date(),
+				})),
+				lstat: vi.fn(async () => ({
+					type: 'file' as const,
+					size: 0,
+					mtime: new Date(),
+				})),
+				readlink: vi.fn(async () => ''),
+				symlink: vi.fn(async () => undefined),
+			},
+			isAncestorCommit: vi.fn(async () => true),
+		})),
 		storageGet: vi.fn(async () => ({
 			runId: 'run-1',
 			treeHash: '',
@@ -158,6 +188,36 @@ function restoreRepoSessionMockBaseline() {
 	mockModule.workspaceMkdir.mockResolvedValue(undefined)
 	mockModule.workspaceRm.mockResolvedValue(undefined)
 	mockModule.workspaceGlob.mockResolvedValue([])
+	mockModule.cloneExternalPublishWorkspace.mockImplementation(async () => ({
+		workspace: {
+			readFile: vi.fn(async () => null),
+			glob: vi.fn(async () => []),
+		},
+		headCommit: gitState.headCommit,
+		dir: '/repo',
+		filesystem: {
+			readFile: vi.fn(async () => ''),
+			readFileBytes: vi.fn(async () => new Uint8Array()),
+			writeFile: vi.fn(async () => undefined),
+			writeFileBytes: vi.fn(async () => undefined),
+			rm: vi.fn(async () => undefined),
+			mkdir: vi.fn(async () => undefined),
+			readdir: vi.fn(async () => []),
+			stat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			lstat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			readlink: vi.fn(async () => ''),
+			symlink: vi.fn(async () => undefined),
+		},
+		isAncestorCommit: vi.fn(async () => true),
+	}))
 	mockModule.storageGet.mockResolvedValue({
 		runId: 'run-1',
 		treeHash: '',
@@ -416,6 +476,17 @@ vi.mock('./checks.ts', () => ({
 		mockModule.validatePackageBundles(...args),
 	runPackageTypecheckLanguageService: (...args: Array<unknown>) =>
 		mockModule.runPackageTypecheckLanguageService(...args),
+}))
+
+vi.mock('./external-publish-clone.ts', () => ({
+	externalPublishWorkspaceDir: '/repo',
+	isWorkspaceSqliteTooBigMessage: (message: string) =>
+		message.includes('SQLITE_TOOBIG') ||
+		/string or blob too big/i.test(message),
+	buildWorkspaceSqliteTooBigCallerMessage: (operation: string) =>
+		`${operation} failed because a git object exceeded the Durable Object SQLite 2 MiB row limit`,
+	cloneExternalPublishWorkspace: (...args: Array<unknown>) =>
+		mockModule.cloneExternalPublishWorkspace(...args),
 }))
 
 vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', async () => {
@@ -1671,9 +1742,38 @@ test('readFile retries D1 reads and falls back to cached sessions when replicas 
 
 test('publishFromExternalRef rejects stale expected HEAD values', async () => {
 	setCommonSessionFixtures()
-	// Clone tip (git.log depth 1) is the remote default-branch HEAD at clone
-	// time; a mismatch with expectedHead means the Artifacts tip moved.
-	mockModule.gitState.headCommit = 'commit-new'
+	// Clone tip is the remote default-branch HEAD at clone time; a mismatch
+	// with expectedHead means the Artifacts tip moved.
+	mockModule.cloneExternalPublishWorkspace.mockResolvedValueOnce({
+		workspace: {
+			readFile: vi.fn(async () => null),
+			glob: vi.fn(async () => []),
+		},
+		headCommit: 'commit-new',
+		dir: '/repo',
+		filesystem: {
+			readFile: vi.fn(async () => ''),
+			readFileBytes: vi.fn(async () => new Uint8Array()),
+			writeFile: vi.fn(async () => undefined),
+			writeFileBytes: vi.fn(async () => undefined),
+			rm: vi.fn(async () => undefined),
+			mkdir: vi.fn(async () => undefined),
+			readdir: vi.fn(async () => []),
+			stat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			lstat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			readlink: vi.fn(async () => ''),
+			symlink: vi.fn(async () => undefined),
+		},
+		isAncestorCommit: vi.fn(async () => true),
+	})
 
 	const repoSession = new RepoSession(createDurableObjectState(), createEnv())
 
@@ -1691,7 +1791,7 @@ test('publishFromExternalRef rejects stale expected HEAD values', async () => {
 	expect(mockModule.resolveArtifactDefaultBranchHead).not.toHaveBeenCalled()
 })
 
-test('publishFromExternalRef checks fast-forward ancestry through shell git adapter', async () => {
+test('publishFromExternalRef checks fast-forward ancestry through ephemeral clone', async () => {
 	// Best-effort publish git-note setup logs an incidental warning.
 	consoleWarn.mockImplementation(() => {})
 	setCommonSessionFixtures()
@@ -1705,10 +1805,39 @@ test('publishFromExternalRef checks fast-forward ancestry through shell git adap
 		entity_kind: 'job',
 		entity_id: 'job-1',
 	})
-	mockModule.git.log.mockResolvedValueOnce([
-		{ oid: 'commit-new' },
-		{ oid: 'commit-old' },
-	])
+	const isAncestorCommit = vi.fn(async ({ ancestor, descendant }) => {
+		return ancestor === 'commit-old' && descendant === 'commit-new'
+	})
+	mockModule.cloneExternalPublishWorkspace.mockResolvedValueOnce({
+		workspace: {
+			readFile: vi.fn(async () => null),
+			glob: vi.fn(async () => []),
+		},
+		headCommit: 'commit-new',
+		dir: '/repo',
+		filesystem: {
+			readFile: vi.fn(async () => ''),
+			readFileBytes: vi.fn(async () => new Uint8Array()),
+			writeFile: vi.fn(async () => undefined),
+			writeFileBytes: vi.fn(async () => undefined),
+			rm: vi.fn(async () => undefined),
+			mkdir: vi.fn(async () => undefined),
+			readdir: vi.fn(async () => []),
+			stat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			lstat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			readlink: vi.fn(async () => ''),
+			symlink: vi.fn(async () => undefined),
+		},
+		isAncestorCommit,
+	})
 	mockModule.writePublishedSourceSnapshot.mockClear()
 
 	const repoSession = new RepoSession(createDurableObjectState(), {
@@ -1725,10 +1854,9 @@ test('publishFromExternalRef checks fast-forward ancestry through shell git adap
 
 	expect(result.status).toBe('published')
 	expect(mockModule.workspaceGlob).not.toHaveBeenCalled()
-	expect(mockModule.git.log).toHaveBeenCalledWith({
-		dir: '/session',
-		ref: 'commit-new',
-		depth: Number.POSITIVE_INFINITY,
+	expect(isAncestorCommit).toHaveBeenCalledWith({
+		ancestor: 'commit-old',
+		descendant: 'commit-new',
 	})
 	expect(mockModule.updateEntitySource).toHaveBeenCalledWith(
 		expect.anything(),

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -89,6 +89,12 @@ import {
 	publishFromExternalRef as publishExternalRefSource,
 } from './external-publish.ts'
 import {
+	buildWorkspaceSqliteTooBigCallerMessage,
+	cloneExternalPublishWorkspace,
+	externalPublishWorkspaceDir,
+	isWorkspaceSqliteTooBigMessage,
+} from './external-publish-clone.ts'
+import {
 	assertPackagePrivateVisibilityChangeAllowed,
 	assertPackageSourceOverwriteAllowed,
 	assertPublishedPackageSourceRepoHead,
@@ -320,6 +326,13 @@ class RepoSessionBase extends DurableObject<Env> {
 					remote: input.remote,
 					error,
 				})
+			}
+			const message = getErrorMessage(error)
+			if (isWorkspaceSqliteTooBigMessage(message)) {
+				throw new Error(
+					buildWorkspaceSqliteTooBigCallerMessage('Repo session clone'),
+					{ cause: error },
+				)
 			}
 			throw error
 		}
@@ -2674,29 +2687,27 @@ class RepoSessionBase extends DurableObject<Env> {
 			scope: 'read',
 		})
 		const targetBranch = sourceInfo?.defaultBranch ?? defaultSessionBranch
+		let publishClone: Awaited<ReturnType<typeof cloneExternalPublishWorkspace>>
 		try {
-			await this.cloneArtifactsRepoWithRetry({
+			// In-memory clone: avoids DO SQL SQLITE_TOOBIG on packfiles
+			// (KODY-CLOUDFLARE-57). Do not route this through the SQL Workspace.
+			publishClone = await cloneExternalPublishWorkspace({
 				remote: sourceAccess.remote,
 				token: sourceAccess.token,
 				branch: targetBranch,
-				resetBeforeFirstAttempt: true,
+				checkoutCommit: input.newCommit,
 			})
 			// Race protection without a second Artifacts REST HEAD resolve: the
 			// single-branch clone tip is the remote default-branch HEAD at clone
-			// time. Compare it to the worker-resolved expectedHead before checkout.
+			// time. Compare it to the worker-resolved expectedHead before publish.
 			if (input.expectedHead) {
-				const clonedHead = await this.getHeadCommit()
+				const clonedHead = publishClone.headCommit
 				if (clonedHead !== input.expectedHead) {
 					throw new Error(
 						`Artifacts HEAD changed from "${input.expectedHead}" to "${clonedHead ?? 'unknown'}" before publish.`,
 					)
 				}
 			}
-			await this.git.checkout({
-				dir: repoSessionWorkspacePrefix,
-				ref: input.newCommit,
-				force: true,
-			})
 		} catch (error) {
 			const message = getErrorMessage(error)
 			if (message.includes('Artifacts HEAD changed from')) {
@@ -2706,12 +2717,15 @@ class RepoSessionBase extends DurableObject<Env> {
 				buildSourceRecoveryProblemMessage({
 					source,
 					operation: 'package_publish_external_push',
-					reason: `source clone or commit checkout failed: ${message}`,
+					reason: message.includes('source clone or commit checkout failed:')
+						? message
+						: `source clone or commit checkout failed: ${message}`,
 				}),
 				{ cause: error },
 			)
 		}
 		const runId = crypto.randomUUID()
+		const publishDir = publishClone.dir || externalPublishWorkspaceDir
 		const publishResult = await publishExternalRefSource({
 			env: this.env,
 			sourceId: source.id,
@@ -2719,21 +2733,18 @@ class RepoSessionBase extends DurableObject<Env> {
 			newCommit: input.newCommit,
 			runId,
 			isFastForward: async ({ previousCommit }) =>
-				await this.isAncestorCommit({
+				await publishClone.isAncestorCommit({
 					ancestor: previousCommit,
 					descendant: input.newCommit,
 				}),
 			allowForce: input.allowForce,
 			destructiveOverwriteConfirmed: input.destructiveOverwriteConfirmed,
-			workspace: this.workspace,
+			workspace: publishClone.workspace,
 			baseUrl: input.baseUrl ?? source.source_root,
-			manifestPath: resolveRepoWorkspacePath(
-				source.manifest_path,
-				repoSessionWorkspacePrefix,
-			),
+			manifestPath: resolveRepoWorkspacePath(source.manifest_path, publishDir),
 			sourceRoot: resolveRepoWorkspacePath(
-				source.source_root || repoSessionWorkspacePrefix,
-				repoSessionWorkspacePrefix,
+				source.source_root || publishDir,
+				publishDir,
 			),
 			rebuildPackageArtifacts: input.rebuildPackageArtifacts ?? true,
 			expectedPackageScope: input.expectedPackageScope,
@@ -2748,26 +2759,31 @@ class RepoSessionBase extends DurableObject<Env> {
 						source,
 					),
 				})
-				await this.attachSourcePublishGitNote({
-					source,
+				await attachPublishGitNoteBestEffort({
+					filesystem: publishClone.filesystem,
+					dir: publishDir,
 					commitOid: input.newCommit,
 					remote: sourceWriteAccess.remote,
 					token: sourceWriteAccess.token,
 					remoteName: 'origin',
-					publishedBy: 'external_push',
-					sessionId: input.sessionId,
-					previousPublishedCommit: publishResult.previous_commit,
-					checks: {
-						runId,
-						treeHash: null,
-						checkedAt: new Date().toISOString(),
-						ok: true,
-						results: publishResult.checks.map((entry) => ({
-							kind: entry.kind,
-							ok: entry.ok,
-							message: entry.message,
-						})),
-					},
+					note: buildPublishGitNote({
+						publishedBy: 'external_push',
+						source,
+						commit: input.newCommit,
+						sessionId: input.sessionId,
+						previousPublishedCommit: publishResult.previous_commit,
+						checks: {
+							runId,
+							treeHash: null,
+							checkedAt: new Date().toISOString(),
+							ok: true,
+							results: publishResult.checks.map((entry) => ({
+								kind: entry.kind,
+								ok: entry.ok,
+								message: entry.message,
+							})),
+						},
+					}),
 					scope: 'repo.publishFromExternalRef.publish-git-note',
 				})
 			} catch (error) {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -680,23 +680,6 @@ class RepoSessionBase extends DurableObject<Env> {
 			.join('')
 	}
 
-	private async isAncestorCommit(input: {
-		ancestor: string
-		descendant: string
-	}) {
-		if (input.ancestor === input.descendant) {
-			return true
-		}
-		// Repo command parsing rejects negative depths; use a positive infinite
-		// depth here to request the complete ancestry chain from the git adapter.
-		const commits = await this.git.log({
-			dir: repoSessionWorkspacePrefix,
-			ref: input.descendant,
-			depth: Number.POSITIVE_INFINITY,
-		})
-		return commits.some((commit) => commit.oid === input.ancestor)
-	}
-
 	private async writeCheckStatus(status: RepoSessionCheckStatus) {
 		await this.ctx.storage.put(lastCheckStatusStorageKey, status)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop `package_publish_external_push` from failing (and opening Sentry) when isomorphic-git’s packfile exceeds Cloudflare Durable Object SQLite’s 2 MiB row limit during clone into the RepoSession SQL workspace.

## Summary

- Root cause (KODY-CLOUDFLARE-57): external publish cloned into the DO SQL-backed `@cloudflare/shell` Workspace. isomorphic-git writes the whole pack as one blob; without R2 spill that hits `string or blob too big: SQLITE_TOOBIG`, wrapped as a source-safety recovery error.
- Fix: clone/checkout for `publishFromExternalRef` in an ephemeral in-memory git workspace (same pattern as artifact file reads), then run publish checks and git-notes against that tree.
- Bugbot follow-up: publish `glob` now strips the workspace dir (`repo/`) before matching `git.listFiles` relative paths so `runRepoChecks` patterns like `repo/**/*` return source files.
- Interactive `repo_open_session` clones still use the SQL Workspace; those paths now get a clearer SQLITE_TOOBIG message. Follow-up: [#1477](https://github.com/kentcdodds/kody/issues/1477) to wire R2 spill so the 10 MiB per-file policy works for editing sessions.
- Backfill siblings KODY-CLOUDFLARE-53 / 54 (`D1 DB is overloaded`) are already covered by #1473 on `main` and were already ignored in Sentry — not part of this code change.

## Testing

- `npx vitest run packages/worker/src/repo/external-publish-clone.node.test.ts packages/worker/src/repo/repo-session-do.node.test.ts` (pass, includes `repo/**/*` glob regression)
- `npm run typecheck` (pass)
- Format check on changed files (pass)
- Local full `npm run validate` hit unrelated concurrent worker/mock timeouts; CI is the merge gate.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `a5ea4706` · **Head:** `4f03829b`

**Classification:** extends — changes how `package_publish_external_push` materializes source for publish (in-memory clone instead of DO SQL Workspace); no new primitives, auth, or schema.

### Primitives touched

| Primitive       | Group   | Impact                                                                 |
| --------------- | ------- | ---------------------------------------------------------------------- |
| `repo-sessions` | runtime | extends — external publish clone uses ephemeral FS; clearer SQL TOOBIG |

### System map

External publish no longer writes Artifacts packfiles into DO SQLite rows; one-shot publish uses an in-memory clone while interactive sessions still use the SQL Workspace until R2 spill lands.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	publishCap["package_publish_external_push"]:::untouched
	repoSessions["repo-sessions<br/>RepoSession DO"]:::extended
	ephemeralFs["ephemeral git FS<br/>in-memory"]:::touched
	sqlWs["DO SQL Workspace"]:::untouched
	artifacts["artifacts-repos"]:::untouched
	publishCap -->|"publishFromExternalRef"| repoSessions
	repoSessions -->|"clone / checkout"| ephemeralFs
	ephemeralFs -->|"fetch pack"| artifacts
	repoSessions -.->|"openSession still"| sqlWs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfc14205-5436-4927-a409-cdecc89a7b09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfc14205-5436-4927-a409-cdecc89a7b09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-memory Git workspace cloning for external publishing.
  * Added commit checkout, ancestry validation, workspace file access, and glob support.
  * Added clearer messaging for workspace storage-limit errors.

* **Bug Fixes**
  * Improved handling of stale remote heads and clone or checkout failures.
  * Preserved head-race errors while providing more useful recovery messages.

* **Tests**
  * Expanded coverage for cloning, filesystem operations, commit ancestry, error handling, and stale-head detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->