### PR TITLE
fix: bind packages.invoke in inline workflow sandboxes

### DIFF
--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -24,6 +24,8 @@ import {
 const invocationMocks = vi.hoisted(() => ({
 	invokePackageExport: vi.fn(),
 	runModuleWithRegistry: vi.fn(),
+	createExecutePackageInvokeTools: vi.fn(() => ({ invoke: vi.fn() })),
+	createPackageRuntimeInvokeTools: vi.fn(() => ({ invoke: vi.fn() })),
 }))
 
 const remoteConnectorMocks = vi.hoisted(() => ({
@@ -280,6 +282,10 @@ const runRecordMocks = vi.hoisted(() => {
 vi.mock('#worker/package-invocations/service.ts', () => ({
 	invokePackageExport: (...args: Array<unknown>) =>
 		invocationMocks.invokePackageExport(...args),
+	createExecutePackageInvokeTools: (...args: Array<unknown>) =>
+		invocationMocks.createExecutePackageInvokeTools(...args),
+	createPackageRuntimeInvokeTools: (...args: Array<unknown>) =>
+		invocationMocks.createPackageRuntimeInvokeTools(...args),
 }))
 
 vi.mock('#worker/remote-connector/settings-service.ts', () => ({
@@ -649,6 +655,12 @@ test('DynamicCallableWorkflowBase executes queued inline code and records comple
 			result: { ok: true, p: { greeting: 'hello' } },
 			logs: [],
 		})
+		const packageInvokeTools = { invoke: vi.fn() }
+		invocationMocks.createExecutePackageInvokeTools.mockReset()
+		invocationMocks.createExecutePackageInvokeTools.mockReturnValueOnce(
+			packageInvokeTools,
+		)
+		invocationMocks.createPackageRuntimeInvokeTools.mockReset()
 		vi.setSystemTime(new Date('2026-05-03T12:35:00.000Z'))
 		const workflow = new DynamicCallableWorkflowBase(
 			{ waitUntil: vi.fn() } as unknown as ExecutionContext,
@@ -668,6 +680,20 @@ test('DynamicCallableWorkflowBase executes queued inline code and records comple
 				{ sleepUntil: vi.fn(), do: stepDo } as unknown as WorkflowStep,
 			),
 		).resolves.toEqual({ ok: true, p: { greeting: 'hello' } })
+		expect(invocationMocks.createExecutePackageInvokeTools).toHaveBeenCalledWith(
+			{
+				env: expect.objectContaining({
+					APP_BASE_URL: 'https://app.example.com',
+				}),
+				baseUrl: 'https://app.example.com',
+				callerContext: expect.objectContaining({
+					executionOrigin: 'background',
+					user: expect.objectContaining({ userId: 'user-1' }),
+				}),
+				waitUntil: expect.any(Function),
+			},
+		)
+		expect(invocationMocks.createPackageRuntimeInvokeTools).not.toHaveBeenCalled()
 		expect(invocationMocks.runModuleWithRegistry).toHaveBeenCalledWith(
 			expect.objectContaining({ APP_BASE_URL: 'https://app.example.com' }),
 			expect.objectContaining({
@@ -678,6 +704,7 @@ test('DynamicCallableWorkflowBase executes queued inline code and records comple
 			{ greeting: 'hello' },
 			{
 				packageContext: null,
+				packageInvokeTools,
 				executorTimeoutMs: workflowExecutorTimeoutMs,
 			},
 		)
@@ -806,6 +833,12 @@ test('package-created inline workflows retain package secret authorization conte
 		result: { ok: true },
 		logs: [],
 	})
+	const packageInvokeTools = { invoke: vi.fn() }
+	invocationMocks.createPackageRuntimeInvokeTools.mockReset()
+	invocationMocks.createPackageRuntimeInvokeTools.mockReturnValueOnce(
+		packageInvokeTools,
+	)
+	invocationMocks.createExecutePackageInvokeTools.mockReset()
 	const stepDo = vi.fn(
 		async (_name: string, _config: unknown, callback: () => unknown) =>
 			await callback(),
@@ -834,6 +867,21 @@ test('package-created inline workflows retain package secret authorization conte
 		{ sleepUntil: vi.fn(), do: stepDo } as unknown as WorkflowStep,
 	)
 
+	expect(invocationMocks.createPackageRuntimeInvokeTools).toHaveBeenCalledWith({
+		env: expect.any(Object),
+		baseUrl: 'https://app.example.com',
+		callerContext: expect.objectContaining({
+			storageContext: {
+				sessionId: null,
+				appId: 'package-1',
+				packageId: 'package-1',
+				storageId: null,
+			},
+		}),
+		packageContext,
+		waitUntil: expect.any(Function),
+	})
+	expect(invocationMocks.createExecutePackageInvokeTools).not.toHaveBeenCalled()
 	expect(invocationMocks.runModuleWithRegistry).toHaveBeenCalledWith(
 		expect.any(Object),
 		expect.objectContaining({
@@ -848,6 +896,7 @@ test('package-created inline workflows retain package secret authorization conte
 		undefined,
 		{
 			packageContext,
+			packageInvokeTools,
 			executorTimeoutMs: workflowExecutorTimeoutMs,
 		},
 	)
@@ -909,6 +958,7 @@ test('DynamicCallableWorkflowBase restores attached remote connectors for inline
 		undefined,
 		{
 			packageContext: null,
+			packageInvokeTools: expect.objectContaining({ invoke: expect.any(Function) }),
 			executorTimeoutMs: workflowExecutorTimeoutMs,
 		},
 	)

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -680,20 +680,22 @@ test('DynamicCallableWorkflowBase executes queued inline code and records comple
 				{ sleepUntil: vi.fn(), do: stepDo } as unknown as WorkflowStep,
 			),
 		).resolves.toEqual({ ok: true, p: { greeting: 'hello' } })
-		expect(invocationMocks.createExecutePackageInvokeTools).toHaveBeenCalledWith(
-			{
-				env: expect.objectContaining({
-					APP_BASE_URL: 'https://app.example.com',
-				}),
-				baseUrl: 'https://app.example.com',
-				callerContext: expect.objectContaining({
-					executionOrigin: 'background',
-					user: expect.objectContaining({ userId: 'user-1' }),
-				}),
-				waitUntil: expect.any(Function),
-			},
-		)
-		expect(invocationMocks.createPackageRuntimeInvokeTools).not.toHaveBeenCalled()
+		expect(
+			invocationMocks.createExecutePackageInvokeTools,
+		).toHaveBeenCalledWith({
+			env: expect.objectContaining({
+				APP_BASE_URL: 'https://app.example.com',
+			}),
+			baseUrl: 'https://app.example.com',
+			callerContext: expect.objectContaining({
+				executionOrigin: 'background',
+				user: expect.objectContaining({ userId: 'user-1' }),
+			}),
+			waitUntil: expect.any(Function),
+		})
+		expect(
+			invocationMocks.createPackageRuntimeInvokeTools,
+		).not.toHaveBeenCalled()
 		expect(invocationMocks.runModuleWithRegistry).toHaveBeenCalledWith(
 			expect.objectContaining({ APP_BASE_URL: 'https://app.example.com' }),
 			expect.objectContaining({
@@ -958,7 +960,9 @@ test('DynamicCallableWorkflowBase restores attached remote connectors for inline
 		undefined,
 		{
 			packageContext: null,
-			packageInvokeTools: expect.objectContaining({ invoke: expect.any(Function) }),
+			packageInvokeTools: expect.objectContaining({
+				invoke: expect.any(Function),
+			}),
 			executorTimeoutMs: workflowExecutorTimeoutMs,
 		},
 	)

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -18,7 +18,11 @@ import {
 	readPreExecutionPackageInvocationInfrastructureCode,
 	readRetryablePackageInvocationInfrastructureCode,
 } from '#worker/package-invocations/admin-package-subscriptions.ts'
-import { invokePackageExport } from '#worker/package-invocations/service.ts'
+import {
+	createExecutePackageInvokeTools,
+	createPackageRuntimeInvokeTools,
+	invokePackageExport,
+} from '#worker/package-invocations/service.ts'
 import { packageWorkflowInvocationSource } from './package-invocation-sources.ts'
 import {
 	getSavedPackageById,
@@ -1552,6 +1556,42 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 			env: this.env,
 			userId: payload.userId,
 		})
+		const waitUntil = (promise: Promise<unknown>) => {
+			this.ctx.waitUntil(promise)
+		}
+		const callerContext = createMcpCallerContext({
+			baseUrl: getAppBaseUrl({
+				env: this.env,
+			}),
+			executionOrigin: 'background',
+			user: await resolveBackgroundMcpUser(this.env.APP_DB, payload.userId),
+			storageContext: payload.packageContext
+				? {
+						sessionId: null,
+						appId: payload.packageContext.packageId,
+						packageId: payload.packageContext.packageId,
+						storageId: null,
+					}
+				: null,
+			remoteConnectors,
+		})
+		// Inline workflow sandboxes use the same execute module loader, including
+		// packages.invoke. Package-created inline code keeps package-runtime
+		// provenance; execute-created inline code uses the execute invoke path.
+		const packageInvokeTools = payload.packageContext
+			? createPackageRuntimeInvokeTools({
+					env: this.env,
+					baseUrl: callerContext.baseUrl,
+					callerContext,
+					packageContext: payload.packageContext,
+					waitUntil,
+				})
+			: createExecutePackageInvokeTools({
+					env: this.env,
+					baseUrl: callerContext.baseUrl,
+					callerContext,
+					waitUntil,
+				})
 		const runHandle = beginRunRecord({
 			env: this.env,
 			userId: payload.userId,
@@ -1565,34 +1605,18 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 					sourceType: 'inline',
 				},
 			},
-			waitUntil: (promise) => {
-				this.ctx.waitUntil(promise)
-			},
+			waitUntil,
 		})
 		let logs: Array<string> | undefined
 		try {
 			const result = await runModuleWithRegistry(
 				this.env,
-				createMcpCallerContext({
-					baseUrl: getAppBaseUrl({
-						env: this.env,
-					}),
-					executionOrigin: 'background',
-					user: await resolveBackgroundMcpUser(this.env.APP_DB, payload.userId),
-					storageContext: payload.packageContext
-						? {
-								sessionId: null,
-								appId: payload.packageContext.packageId,
-								packageId: payload.packageContext.packageId,
-								storageId: null,
-							}
-						: null,
-					remoteConnectors,
-				}),
+				callerContext,
 				payload.code,
 				payload.params,
 				{
 					packageContext: payload.packageContext,
+					packageInvokeTools,
 					executorTimeoutMs: workflowExecutorTimeoutMs,
 				},
 			)


### PR DESCRIPTION
## Intent

Inline workflow code is documented as using the same execute module loader, including `packages.invoke`. Those sandboxes never received `packageInvokeTools`, so `kody:runtime` left `packages` as `null` and `packages.invoke` threw.

## Summary

- Bind `createExecutePackageInvokeTools` when an inline workflow was created from execute (`packageContext` is null).
- Bind `createPackageRuntimeInvokeTools` when the workflow was created from a package, so invoke keeps package-runtime provenance.
- Cover both bindings in the existing inline workflow node tests.

Fingerprint: `workflow:inline-code:cannot-read-properties-of-null-reading-invoke-the-optional-kody-runtime-exp`

Sample activity: https://kody.codes/account/activity/b93a4171-6923-4d95-a87e-cc4bb73dace5

## Testing

- `npx vitest run --project node-unit packages/worker/src/package-runtime/package-workflows.node.test.ts` — 22 passed
- `npx tsc -b packages/worker/tsconfig-worker-typecheck.json` — passed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cd515e76` · **Head:** `33b2ecff`

**Classification:** extends — inline workflow sandboxes now bind the existing `packages.invoke` helper instead of leaving `kody:runtime` `packages` as `null`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `workflows` | assistant | extends — inline sandbox now receives `packageInvokeTools` |
| `package-runtime` | runtime | composes — node tests for the workflow binding |
| `capabilities-execute` | runtime | composes — same `runModuleWithRegistry` loader, now with invoke tools |

### System map

Inline workflow steps now construct the same package-invoke helpers execute and package jobs already use, then pass them into the execute module loader.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	workflows["workflows<br/>Workflows"]:::extended
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::touched
	packageRuntime["package-runtime<br/>Package runtime"]:::touched
	workflows -->|"createExecutePackageInvokeTools / createPackageRuntimeInvokeTools"| packageRuntime
	workflows -->|"runModuleWithRegistry + packageInvokeTools"| capabilitiesExecute
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Inline as Inline workflow step
	participant Tools as package-invocations helpers
	participant Loader as runModuleWithRegistry
	participant Runtime as kody:runtime packages
	Inline->>Tools: createExecute or createPackageRuntime invoke tools
	Inline->>Loader: run module with packageInvokeTools
	Loader->>Runtime: bind packages.invoke
	Runtime-->>Inline: packages.invoke no longer null
```

### Before / after

**Before:** `invokeInlineWorkflowCode` called `runModuleWithRegistry` with only `packageContext` and `executorTimeoutMs`. `packages` stayed `null`.

**After:** the same call also passes `packageInvokeTools` from the execute helper (ad hoc inline) or the package-runtime helper (package-created inline).

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches background workflow execution and package invoke provenance (execute vs package-runtime), but reuses existing helpers already used elsewhere; scope is limited to inline workflow code paths with added test coverage.
> 
> **Overview**
> **Inline workflow sandboxes** now pass **`packageInvokeTools`** into `runModuleWithRegistry`, fixing `packages.invoke` failures where `kody:runtime` left `packages` as `null`.
> 
> When inline code runs with **no** `packageContext` (execute-created workflows), the worker builds **`createExecutePackageInvokeTools`**. When **`packageContext`** is present (package-created inline workflows), it uses **`createPackageRuntimeInvokeTools`** so invokes keep package-runtime provenance and storage context.
> 
> Node tests assert each path calls the right helper and forwards the tools into the module loader options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b2ecff3bef60e037116ecb5217c81377743813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow execution by selecting the appropriate invocation tools for inline and package-based workflows.
  * Enhanced background task handling during workflow runs.
  * Ensured remote connector executions receive the correct invocation tools and execution context.

* **Tests**
  * Added coverage verifying tool selection, context propagation, and background task wiring across workflow execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->