### PR TITLE
fix(repo): retry packfile corruption on readBlob after fetch (KODY-CLOUDFLARE-56)

### DIFF
--- a/packages/worker/src/repo/artifact-file.node.test.ts
+++ b/packages/worker/src/repo/artifact-file.node.test.ts
@@ -164,10 +164,13 @@ test('does not retry missing artifact files as packfile corruption', async () =>
 	mocks.fetch.mockReset()
 	mocks.fetch.mockResolvedValue(undefined)
 	mocks.init.mockClear()
-	const missing = Object.assign(new Error('Could not find community-icon.png'), {
-		code: 'NotFoundError',
-		name: 'NotFoundError',
-	})
+	const missing = Object.assign(
+		new Error('Could not find community-icon.png'),
+		{
+			code: 'NotFoundError',
+			name: 'NotFoundError',
+		},
+	)
 	mocks.readBlob.mockReset()
 	mocks.readBlob.mockRejectedValue(missing)
 

--- a/packages/worker/src/repo/artifact-file.node.test.ts
+++ b/packages/worker/src/repo/artifact-file.node.test.ts
@@ -109,3 +109,77 @@ test('reads binary artifact files from an exact pinned commit', async () => {
 	).resolves.toEqual(bytes)
 	expect(mocks.fetch).toHaveBeenCalledTimes(2)
 })
+
+test('retries when packfile corruption surfaces on readBlob after fetch (KODY-CLOUDFLARE-56)', async () => {
+	const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
+	mocks.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			remote: 'https://artifacts.example.test/package.git',
+			defaultBranch: 'main',
+		})),
+		createToken: vi.fn(async () => ({
+			plaintext: 'token',
+		})),
+	})
+	mocks.fetch.mockReset()
+	mocks.fetch.mockResolvedValue(undefined)
+	mocks.init.mockClear()
+	mocks.addRemote.mockClear()
+
+	const packCorruption = Object.assign(
+		new Error(
+			`An internal error caused this command to fail.\n\nIf you're using an application that depends on isomorphic-git, please report this error to that application's developers.\n\nIf you're a developer and you believe this is a bug in isomorphic-git, please file an issue at https://github.com/isomorphic-git/isomorphic-git/issues with a minimal reproduction, version and environment details, and this error message: Packfile payload corrupted: calculated abc but expected def. The packfile may have been tampered with.`,
+		),
+		{ code: 'InternalError', name: 'InternalError' },
+	)
+	mocks.readBlob
+		.mockRejectedValueOnce(packCorruption)
+		.mockResolvedValueOnce({ blob: bytes })
+
+	await expect(
+		readArtifactFileAtCommit({
+			env: {} as Env,
+			repoId: 'package-1',
+			commit: 'abc123',
+			filePath: 'community-icon.png',
+		}),
+	).resolves.toEqual(bytes)
+
+	// Fresh workspace + fetch on each attempt (corruption on read must re-fetch).
+	expect(mocks.fetch).toHaveBeenCalledTimes(2)
+	expect(mocks.init).toHaveBeenCalledTimes(2)
+	expect(mocks.readBlob).toHaveBeenCalledTimes(2)
+})
+
+test('does not retry missing artifact files as packfile corruption', async () => {
+	mocks.resolveExistingArtifactSourceRepo.mockResolvedValue({
+		info: vi.fn(async () => ({
+			remote: 'https://artifacts.example.test/package.git',
+			defaultBranch: 'main',
+		})),
+		createToken: vi.fn(async () => ({
+			plaintext: 'token',
+		})),
+	})
+	mocks.fetch.mockReset()
+	mocks.fetch.mockResolvedValue(undefined)
+	mocks.init.mockClear()
+	const missing = Object.assign(new Error('Could not find community-icon.png'), {
+		code: 'NotFoundError',
+		name: 'NotFoundError',
+	})
+	mocks.readBlob.mockReset()
+	mocks.readBlob.mockRejectedValue(missing)
+
+	await expect(
+		readArtifactFileAtCommit({
+			env: {} as Env,
+			repoId: 'package-1',
+			commit: 'abc123',
+			filePath: 'community-icon.png',
+		}),
+	).resolves.toBeNull()
+
+	expect(mocks.fetch).toHaveBeenCalledTimes(1)
+	expect(mocks.readBlob).toHaveBeenCalledTimes(1)
+})

--- a/packages/worker/src/repo/artifact-file.ts
+++ b/packages/worker/src/repo/artifact-file.ts
@@ -8,6 +8,7 @@ import {
 	resolveExistingArtifactSourceRepo,
 } from './artifacts.ts'
 import {
+	isIsomorphicGitPackfileCorruptionError,
 	runArtifactsGitWithRetry,
 	wrapArtifactsGitHttpError,
 } from './artifacts-git-retry.ts'
@@ -69,26 +70,28 @@ export async function readFirstArtifactFileAtCommit(input: {
 		token: token.plaintext,
 	})
 	const auth = buildArtifactsGitAuth({ token: token.plaintext })
+	// isomorphic-git verifies pack checksums on first readObjectPacked (during
+	// readBlob), not during fetch — so fetch+read must share one retry scope.
 	// Fresh ephemeral workspace per attempt: a corrupt pack may leave partial
 	// objects that would poison a retry on the same Map store.
-	let workspace: ReturnType<typeof createEphemeralGitWorkspace>
+	// (KODY-CLOUDFLARE-56: #1475 retried fetch only; corruption still escaped.)
 	try {
-		workspace = await runArtifactsGitWithRetry(async () => {
-			const nextWorkspace = createEphemeralGitWorkspace()
+		return await runArtifactsGitWithRetry(async () => {
+			const workspace = createEphemeralGitWorkspace()
 			await git.init({
-				fs: nextWorkspace.fs,
-				dir: nextWorkspace.dir,
+				fs: workspace.fs,
+				dir: workspace.dir,
 			})
 			await git.addRemote({
-				fs: nextWorkspace.fs,
-				dir: nextWorkspace.dir,
+				fs: workspace.fs,
+				dir: workspace.dir,
 				remote: 'origin',
 				url: remote,
 			})
 			await git.fetch({
-				fs: nextWorkspace.fs,
+				fs: workspace.fs,
 				http,
-				dir: nextWorkspace.dir,
+				dir: workspace.dir,
 				remote: 'origin',
 				ref: input.commit,
 				depth: 1,
@@ -98,7 +101,23 @@ export async function readFirstArtifactFileAtCommit(input: {
 					return auth
 				},
 			})
-			return nextWorkspace
+
+			for (const filePath of input.filePaths) {
+				try {
+					const result = await git.readBlob({
+						fs: workspace.fs,
+						dir: workspace.dir,
+						oid: input.commit,
+						filepath: filePath,
+					})
+					return { path: filePath, bytes: result.blob }
+				} catch (error) {
+					// Pack corruption → bubble so runArtifactsGitWithRetry re-fetches.
+					if (isIsomorphicGitPackfileCorruptionError(error)) throw error
+					if (!isMissingArtifactFileError(error)) throw error
+				}
+			}
+			return null
 		})
 	} catch (error) {
 		throw wrapArtifactsGitHttpError({
@@ -107,21 +126,6 @@ export async function readFirstArtifactFileAtCommit(input: {
 			error,
 		})
 	}
-
-	for (const filePath of input.filePaths) {
-		try {
-			const result = await git.readBlob({
-				fs: workspace.fs,
-				dir: workspace.dir,
-				oid: input.commit,
-				filepath: filePath,
-			})
-			return { path: filePath, bytes: result.blob }
-		} catch (error) {
-			if (!isMissingArtifactFileError(error)) throw error
-		}
-	}
-	return null
 }
 
 function isMissingArtifactFileError(error: unknown) {

--- a/packages/worker/src/repo/artifacts-git-retry.ts
+++ b/packages/worker/src/repo/artifacts-git-retry.ts
@@ -11,8 +11,11 @@ import {
  *
  * Separately, upload-pack sometimes returns HTTP 200 with a truncated or
  * corrupt pack body; isomorphic-git then throws InternalError containing
- * "Packfile payload corrupted" (KODY-CLOUDFLARE-55 / 56). Same retry + wrap
- * treatment — never an app-logic defect we can fix in-repo.
+ * "Packfile payload corrupted" when verifying the pack on first
+ * readObjectPacked / readBlob (not during fetch itself)
+ * (KODY-CLOUDFLARE-55 / 56). Same retry + wrap treatment — never an
+ * app-logic defect we can fix in-repo. Call sites that fetch then read
+ * must keep both steps inside `runArtifactsGitWithRetry`.
  */
 export const artifactsGitHttpRetryDelaysMs = [50, 150] as const
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close the gap left by #1475 for KODY-CLOUDFLARE-56: isomorphic-git verifies pack checksums on first `readObjectPacked` (during `readBlob`), not during `git.fetch`, so fetch-only retries still let corrupt Artifacts packs fail `repo_get`.

## Summary

- Move shallow `git.fetch` + candidate `readBlob` into one `runArtifactsGitWithRetry` scope with a fresh ephemeral workspace per attempt.
- Re-throw packfile corruption from `readBlob` so the retry re-fetches; keep missing-file errors non-retrying.
- Document the isomorphic-git verify-on-read behavior next to the transient Artifacts helpers.

## Testing

- Focused vitest: `artifact-file.node.test.ts`, `artifacts-git-retry.node.test.ts` — passed
- CI Validate — green
- `npm run preview:manual-test -- --pr 1480` — health/login/account + values smoke passed
- Preview UI: signed in and confirmed `preview-locale=en-US` on `/account/values`
- Squash-merged and production deploy succeeded

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends repo-sessions</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d7e8f055` · **Head:** `3119f7f3`

**Classification:** extends — shallow Artifacts file reads now retry packfile corruption detected on `readBlob`, not only on `git.fetch`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `repo-sessions` | runtime | extends — `readFirstArtifactFileAtCommit` retries pack corruption on first object read |

### System map

`repo_get` still shallow-fetches an Artifacts commit, but pack integrity failures that isomorphic-git surfaces on `readBlob` now re-enter the same transient retry as fetch failures.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	repoGet["repo_get capability"]:::untouched
	artifactFile["repo-sessions<br/>Repo sessions"]:::extended
	artifacts["Cloudflare Artifacts upload-pack"]:::untouched
	repoGet -->|"readFirstArtifactFileAtCommit"| artifactFile
	artifactFile -->|"fetch + readBlob in one retry"| artifacts
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bac942b-9d18-40a9-853e-f468498d8102?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bac942b-9d18-40a9-853e-f468498d8102&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved artifact retrieval recovery when packfile corruption occurs by automatically refreshing repository data and retrying the read.
  - Preserved expected behavior for missing files, including continuing to check alternate paths without unnecessary retries.
  - Other read errors continue to fail immediately.

- **Tests**
  - Added coverage for packfile-corruption retries and missing-file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->