### PR TITLE
Notify status-incident-triage when a public incident opens

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -766,8 +766,24 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${STATUS_INCIDENT_WEBHOOK_URL:-}" ]; then
-            echo "STATUS_INCIDENT_WEBHOOK_URL unset; status incident ingest stays poll-only."
-            exit 0
+            echo "STATUS_INCIDENT_WEBHOOK_URL unset; removing Worker secret if present."
+            set +e
+            delete_log="$(
+              CI=true npx wrangler secret delete STATUS_INCIDENT_WEBHOOK_URL \
+                --config packages/status/wrangler.jsonc 2>&1
+            )"
+            delete_status=$?
+            set -e
+            printf '%s\n' "$delete_log"
+            if [ "$delete_status" -eq 0 ]; then
+              exit 0
+            fi
+            if printf '%s' "$delete_log" | grep -qiE 'not found|does not exist|10056'; then
+              echo "Worker secret already absent; status incident ingest stays poll-only."
+              exit 0
+            fi
+            echo "Failed to delete STATUS_INCIDENT_WEBHOOK_URL." >&2
+            exit "$delete_status"
           fi
           printf '%s' "$STATUS_INCIDENT_WEBHOOK_URL" | npx wrangler secret put \
             STATUS_INCIDENT_WEBHOOK_URL --config packages/status/wrangler.jsonc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -757,6 +757,21 @@ jobs:
           printf '%s' "$CLOUDFLARE_API_TOKEN" | npx wrangler secret put \
             CLOUDFLARE_API_TOKEN --config packages/status/wrangler.jsonc
 
+      - name: 🔐 Sync status incident triage webhook secret
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          STATUS_INCIDENT_WEBHOOK_URL:
+            ${{ secrets.STATUS_INCIDENT_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${STATUS_INCIDENT_WEBHOOK_URL:-}" ]; then
+            echo "STATUS_INCIDENT_WEBHOOK_URL unset; status incident ingest stays poll-only."
+            exit 0
+          fi
+          printf '%s' "$STATUS_INCIDENT_WEBHOOK_URL" | npx wrangler secret put \
+            STATUS_INCIDENT_WEBHOOK_URL --config packages/status/wrangler.jsonc
+
       - name: 🩺 Healthcheck (status worker)
         shell: bash
         env:

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -321,8 +321,10 @@ Without that secret, alert sends are skipped and logged.
 An optional Worker secret `STATUS_INCIDENT_WEBHOOK_URL` (synced from the
 same-named GitHub Actions secret when present) POSTs to a minted Kody webhook on
 incident open so `@kentcdodds/status-incident-triage` can enqueue a component
-fingerprint. The URL is a credential; do not commit it. When unset, the package
-still reconciles from the public `/status.json` snapshot.
+fingerprint. The URL is a credential; do not commit it. When the GitHub secret
+is unset, deploy deletes the Worker secret if it exists so a stale URL cannot
+keep firing; the package still reconciles from the public `/status.json`
+snapshot.
 
 ## Optional Cloudflare offerings
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -318,6 +318,12 @@ through the Cloudflare Email REST API (from `ALERT_EMAIL_FROM` to
 `ALERT_EMAIL_TO`, both non-secret vars in `packages/status/wrangler.jsonc`).
 Without that secret, alert sends are skipped and logged.
 
+An optional Worker secret `STATUS_INCIDENT_WEBHOOK_URL` (synced from the
+same-named GitHub Actions secret when present) POSTs to a minted Kody webhook on
+incident open so `@kentcdodds/status-incident-triage` can enqueue a component
+fingerprint. The URL is a credential; do not commit it. When unset, the package
+still reconciles from the public `/status.json` snapshot.
+
 ## Optional Cloudflare offerings
 
 The default footprint stays intentionally small. If you want to add additional

--- a/packages/status/incident-webhook.node.test.ts
+++ b/packages/status/incident-webhook.node.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest'
+import {
+	notifyStatusIncidentOpened,
+	type StatusIncidentOpenedPayload,
+} from './incident-webhook.ts'
+
+const payload: StatusIncidentOpenedPayload = {
+	event: 'incident.opened',
+	component: 'audit_db',
+	detail: 'timeout',
+	startedAt: 1_755_400_000_000,
+	statusUrl: 'https://status.kody.codes',
+}
+
+test('skips when the webhook URL is unset', async () => {
+	const result = await notifyStatusIncidentOpened({
+		webhookUrl: '  ',
+		payload,
+		fetchImpl: async () => {
+			throw new Error('fetch should not run')
+		},
+	})
+	expect(result).toEqual({ ok: true, skipped: 'unset' })
+})
+
+test('rejects non-https webhook URLs', async () => {
+	const result = await notifyStatusIncidentOpened({
+		webhookUrl: 'http://example.com/hook',
+		payload,
+		fetchImpl: async () => {
+			throw new Error('fetch should not run')
+		},
+	})
+	expect(result).toEqual({ ok: false, error: 'insecure-url' })
+})
+
+test('POSTs the incident payload and returns the status', async () => {
+	const calls: Array<{ url: string; init: RequestInit }> = []
+	const result = await notifyStatusIncidentOpened({
+		webhookUrl:
+			'https://kody.codes/@kentcdodds/webhooks/status-incident-triage/incident/secret',
+		payload,
+		fetchImpl: async (input, init) => {
+			calls.push({ url: String(input), init: init ?? {} })
+			return new Response(null, { status: 202 })
+		},
+	})
+	expect(result).toEqual({ ok: true, status: 202 })
+	expect(calls).toHaveLength(1)
+	expect(calls[0]?.init.method).toBe('POST')
+	expect(calls[0]?.init.body).toBe(JSON.stringify(payload))
+})
+
+test('maps non-OK HTTP responses without throwing', async () => {
+	const result = await notifyStatusIncidentOpened({
+		webhookUrl: 'https://kody.codes/hook',
+		payload,
+		fetchImpl: async () => new Response('nope', { status: 503 }),
+	})
+	expect(result).toEqual({ ok: false, error: 'http-503' })
+})

--- a/packages/status/incident-webhook.ts
+++ b/packages/status/incident-webhook.ts
@@ -1,0 +1,57 @@
+/**
+ * Optional outbound notify when the status worker opens an incident.
+ *
+ * The status worker stays dependency-free (ADR 0004): this is a plain HTTPS
+ * POST to a minted Kody webhook URL. Probe recording must not fail if the
+ * webhook is unset, slow, or down.
+ */
+
+export const statusIncidentWebhookTimeoutMs = 3000
+
+export type StatusIncidentOpenedPayload = {
+	event: 'incident.opened'
+	component: string
+	detail: string | null
+	startedAt: number
+	statusUrl: string
+}
+
+export type StatusIncidentWebhookResult =
+	| { ok: true; skipped: 'unset' }
+	| { ok: true; status: number }
+	| { ok: false; error: string }
+
+export async function notifyStatusIncidentOpened(input: {
+	webhookUrl: string | null | undefined
+	payload: StatusIncidentOpenedPayload
+	fetchImpl?: typeof fetch
+}): Promise<StatusIncidentWebhookResult> {
+	const webhookUrl = input.webhookUrl?.trim()
+	if (!webhookUrl) return { ok: true, skipped: 'unset' }
+
+	let url: URL
+	try {
+		url = new URL(webhookUrl)
+	} catch {
+		return { ok: false, error: 'invalid-url' }
+	}
+	if (url.protocol !== 'https:') return { ok: false, error: 'insecure-url' }
+
+	try {
+		const response = await (input.fetchImpl ?? fetch)(url, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(input.payload),
+			signal: AbortSignal.timeout(statusIncidentWebhookTimeoutMs),
+		})
+		if (!response.ok) {
+			return { ok: false, error: `http-${response.status}` }
+		}
+		return { ok: true, status: response.status }
+	} catch (error) {
+		return {
+			ok: false,
+			error: error instanceof Error ? error.message : String(error),
+		}
+	}
+}

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -31,6 +31,13 @@ returns Cloudflare 1016. Component probes never use the status hostname, so a
   (`STATUS_ALERT_DAILY_LIMIT`). Alert links use `STATUS_PAGE_URL`
   (`https://status.kody.codes`).
 
+When an incident opens, the worker also POSTs a small JSON payload to
+`STATUS_INCIDENT_WEBHOOK_URL` when that Worker secret is set (a minted Kody
+webhook for `@kentcdodds/status-incident-triage`). The notify is fire-and-forget
+with a short timeout so a down or missing webhook cannot stall probes or email.
+Until the secret exists, the triage package still enqueues from
+`GET /status.json` on its 15m sweep.
+
 ## Provider incidents (Cloudflare)
 
 Each cron tick also fetches Cloudflare's public Statuspage feed

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -36,7 +36,8 @@ When an incident opens, the worker also POSTs a small JSON payload to
 webhook for `@kentcdodds/status-incident-triage`). The notify is fire-and-forget
 with a short timeout so a down or missing webhook cannot stall probes or email.
 Until the secret exists, the triage package still enqueues from
-`GET /status.json` on its 15m sweep.
+`GET /status.json` on its 15m sweep. Unsetting the GitHub secret on a later
+deploy deletes the Worker secret so a stale URL cannot keep firing.
 
 ## Provider incidents (Cloudflare)
 

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -11,6 +11,7 @@ import {
 	initialComponentProbeState,
 	type ComponentProbeState,
 } from './incidents.ts'
+import { notifyStatusIncidentOpened } from './incident-webhook.ts'
 import { jobsProbeOrigin, runAllProbes } from './probes.ts'
 import {
 	fetchRelevantProviderIncidents,
@@ -51,6 +52,11 @@ export type StatusWorkerEnv = {
 	CLOUDFLARE_API_BASE_URL?: string
 	/** Worker secret: Cloudflare API token with Email Sending permission. */
 	CLOUDFLARE_API_TOKEN?: string
+	/**
+	 * Optional minted Kody webhook URL for status-incident-triage ingest.
+	 * Treat as a credential. When unset, sweep polling is the only ingest path.
+	 */
+	STATUS_INCIDENT_WEBHOOK_URL?: string
 }
 
 const sampleRetentionMs = 25 * 60 * 60 * 1000
@@ -223,6 +229,28 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 				JSON.stringify({
 					component: outcome.component,
 					detail: outcome.detail,
+				}),
+			)
+			this.ctx.waitUntil(
+				notifyStatusIncidentOpened({
+					webhookUrl: this.env.STATUS_INCIDENT_WEBHOOK_URL,
+					payload: {
+						event: 'incident.opened',
+						component: outcome.component,
+						detail: outcome.detail,
+						startedAt: now,
+						statusUrl: this.env.STATUS_PAGE_URL,
+					},
+				}).then((result) => {
+					if (!result.ok) {
+						console.warn(
+							'status-incident-webhook-failed',
+							JSON.stringify({
+								component: outcome.component,
+								error: result.error,
+							}),
+						)
+					}
 				}),
 			)
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

When the public status page opens an incident, automatically enqueue loop-safe Cursor cloud-agent triage — the same wallet guards as `@kentcdodds/kody-issue-triage` — instead of relying on email alone.

## Summary

- Status worker POSTs a small `incident.opened` JSON payload to optional Worker secret `STATUS_INCIDENT_WEBHOOK_URL` (minted Kody webhook for `@kentcdodds/status-incident-triage`).
- Notify is fire-and-forget with a 3s timeout and HTTPS-only URL check so a missing or down webhook cannot stall probes or alert email.
- Deploy syncs the GitHub Actions secret of the same name when present. When that GitHub secret is unset, deploy deletes the Worker secret so a stale URL cannot keep firing. The package still reconciles from `GET /status.json` on its 15m sweep.
- Fingerprint is `status:<component_id>` (one agent per flapping component, not per incident row), with hourly caps, an anomaly breaker, a global lease, and `./pause` / `./resume`.

The triage package itself is already published in the Kody account (`status-incident-triage`). Its sweep job starts **disabled** until a dry-run smoke is accepted and `./resume` is invoked.

## Testing

- `npm --prefix packages/status test` (19 tests, including new webhook helper cases)
- `npm --prefix packages/status run typecheck`
- Keyless `packages.invoke` dry-run on `.`, `./on-incident`, `./sweep`, `./status`, and `./get-issue-state`: sweep reconciled today’s `audit_db` flaps as one queued fingerprint and returned `wouldSpawn: true` without creating an agent

## Operator follow-up (not in this diff)

1. Mint the package `incident` webhook (`webhook_url_mint` / Kody webhooks UI). Treat the URL as a credential.
2. Store it as GitHub Actions secret `STATUS_INCIDENT_WEBHOOK_URL` so deploy can sync it to the status worker.
3. After reviewing the dry-run, invoke `./resume` to enable the 15m sweep. A `status:audit_db` fingerprint is already queued from today’s flaps.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `475a6c54` · **Head:** `3900803a`

**Classification:** extends — status-page now optionally notifies an external Kody webhook when a probe-derived incident opens. No new primitives.

### Primitives touched

| Primitive     | Group    | Impact                                                                 |
| ------------- | -------- | ---------------------------------------------------------------------- |
| `status-page` | surfaces | extends — fire-and-forget HTTPS POST on incident open                  |

Unmatched paths: `.github/workflows/deploy.yml` (optional secret sync + delete-when-unset), `docs/contributing/setup-manifest.md` (operator docs).

### System map

Incident open still writes Durable Object history and may email; this PR adds a non-blocking outbound POST so account-side triage can enqueue by component.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	statusPage["status-page<br/>Public status page"]:::extended
	statusPage -->|"optional POST STATUS_INCIDENT_WEBHOOK_URL"| triagePkg["status-incident-triage<br/>Kody package"]:::untouched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cron
	participant Store as StatusStore
	participant Hook as incident webhook
	Cron->>Store: runProbes()
	Store->>Store: recordOutcome opened
	Store-->>Hook: waitUntil POST (3s, HTTPS)
	Note over Store: email path unchanged
```

### Before / after

**Before:** incident open → SQLite row + log + capped email.

**After:** same, plus optional credentialed POST `{ event, component, detail, startedAt, statusUrl }`. Unsetting the GitHub secret deletes the Worker secret on the next deploy.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91c7d770-453a-48a9-8743-890623cc8d27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91c7d770-453a-48a9-8743-890623cc8d27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional webhook notifications when status incidents are opened.
  * Notifications include incident details and use secure HTTPS delivery with a short timeout.
  * Incident processing continues normally if notifications fail or the webhook is not configured.
  * Deployment configuration now synchronizes or removes the optional webhook secret as needed.

* **Documentation**
  * Added setup guidance for configuring incident webhooks and polling fallback behavior.

* **Tests**
  * Added coverage for configuration, validation, successful delivery, timeouts, and HTTP errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->