### PR TITLE
ci: align static checks with local validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,6 +82,14 @@ jobs:
         if: ${{ !cancelled() }}
         run: npm run nx-cache:build
 
+      - name: 🗓️ Jobs build
+        if: ${{ !cancelled() }}
+        run: npm run jobs:build
+
+      - name: 🏃 Runtime build
+        if: ${{ !cancelled() }}
+        run: npm run runtime:build
+
       - name: 🗺️ Primitives
         if: ${{ !cancelled() }}
         run: npm run primitives:check
@@ -99,6 +107,10 @@ jobs:
       - name: 🛡️ Deploy guardrails
         if: ${{ !cancelled() }}
         run: npm run deploy-guardrails:check
+
+      - name: 📚 Temporal docs
+        if: ${{ !cancelled() }}
+        run: npm run docs:check-temporal
 
   node:
     runs-on: ubuntu-latest

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -90,14 +90,14 @@ Quick notes for getting a local kody environment running.
 - `npm run validate` is the single authoritative local gate. It is read-only and
   executes `format:check`, `lint`, `typecheck`, `test:node`, `test:workers`,
   Playwright E2E, MCP E2E, `backup:build`, `status:build`, `nx-cache:build`,
-  `primitives:check`, and `migrations:check` in parallel, plus
-  `deploy-guardrails:check` and `docs:check-temporal`, reporting every failure
-  (sibling checks are not aborted on the first failure). The unit-test and
-  Playwright legs set `CI=1` so timeouts, worker limits, and Nx cache hashes
-  match the contended parallel layout used in GitHub Actions. CI runs the same
-  checks as parallel jobs (🧹 Static, 🧪 Node, ☁️ Workers, 🔌 MCP, 🎭 E2E,
-  aggregated by ✅ Validate). If `npm run validate` passes locally, CI will
-  pass. When `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` and
+  `jobs:build`, `runtime:build`, `primitives:check`, `migrations:check`,
+  `deploy-guardrails:check`, and `docs:check-temporal` in parallel, reporting
+  every failure (sibling checks are not aborted on the first failure). The
+  unit-test and Playwright legs set `CI=1` so timeouts, worker limits, and Nx
+  cache hashes match the contended parallel layout used in GitHub Actions. CI
+  runs the same checks as parallel jobs (🧹 Static, 🧪 Node, ☁️ Workers, 🔌 MCP,
+  🎭 E2E, aggregated by ✅ Validate). If `npm run validate` passes locally, CI
+  will pass. When `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` and
   `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` are set, Nx uploads those task
   artifacts to `https://nx-cache.kody.codes` so CI can reuse them (see
   [decision 0019](./decisions/0019-self-hosted-nx-remote-cache.md) and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Close the drift between the authoritative local `npm run validate` gate and GitHub Actions so CI exercises every static build/documentation check developers rely on locally.

## Summary

- add `jobs:build`, `runtime:build`, and `docs:check-temporal` to the Static validation job
- keep sibling static checks running after failures, matching local `concurrently` behavior
- align the contributor setup guide with the complete validation command inventory

## Testing

- CI `✅ Validate`: passed, including Static, Node, Workers, MCP, and E2E jobs
- `npm run jobs:build && npm run runtime:build && npm run docs:check-temporal`: passed
- `npm run validate`: two local attempts reached the unrelated contended-runner timeouts documented in the logs (MCP worker readiness and Workers test timeout); the equivalent CI jobs all passed
- `npm run preview:manual-test -- --pr 1485 ...`: passed health, runtime, login/session, authenticated data creation/readback, and account page checks
- logged-in preview UI: confirmed `ci-parity-track` renders with value `validated`

<a href="https://cursor.com/agents/bc-c7c6f5e2-f89c-4f7b-89e5-ea7cdc8d175d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr-1485-preview-value-verification.mp4"><img src="https://cursor.com/artifacts/c/art-39eb3975-6152-49d6-b2e3-291bef25da6b" alt="pr-1485-preview-value-verification.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends validation coverage</b> (medium operational risk)</summary>

**Mode:** recap · **Base:** `main` @ `39c87a91` · **Head:** `fe612b08`

**Classification:** extends — CI now enforces three existing local validation checks. The primitive classifier matched no application primitives because this change is limited to CI configuration and contributor documentation.

### Primitives touched

No application primitives are added, removed, or behaviorally changed.

### Before / after

| Before | After |
| --- | --- |
| Local `validate` ran jobs/runtime builds and temporal-doc checks, but CI omitted them. | The Static CI job runs all three checks alongside the existing build and repository checks. |

</details>

<!-- system-recap:end -->

## Conductor report

- Track D Legacy Reaper
- Risk: MEDIUM
- Conductor run: `bc-b61e649d-b323-465c-a5b9-9bdfe35dcf49`
- Status: shipped — PR squash-merged as Kent at `45d83650`; main CI and production deployment passed
- CI: https://github.com/kentcdodds/kody/actions/runs/32012223721
- Production deploy: https://github.com/kentcdodds/kody/actions/runs/32012321842
- AI review: CodeRabbit and Cursor Bugbot completed with no actionable feedback
- Scope boundary: app code remains in tracks A–C

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7c6f5e2-f89c-4f7b-89e5-ea7cdc8d175d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7c6f5e2-f89c-4f7b-89e5-ea7cdc8d175d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated validation guidance to include Jobs and Runtime build checks.
  - Clarified that validation checks run in parallel and are mirrored in CI.
  - Added information about Temporal documentation validation.

- **Chores**
  - Expanded automated validation to run additional build and documentation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->