### PR TITLE
refactor(client): remove ignored route latch loading input

### DIFF
--- a/packages/worker/client/route-load-latch.node.test.ts
+++ b/packages/worker/client/route-load-latch.node.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from 'vitest'
 import { createRouteLoadLatch } from './route-load-latch.ts'
 
 const baseInput = {
-	isLoading: false,
 	appliedRouteData: false,
 	needsStaleRefresh: false,
 }
@@ -11,12 +10,8 @@ test('pending latch stops re-queue; abort clearPending is attempt-scoped', () =>
 	const latch = createRouteLoadLatch()
 	// First decision latches pending so a queueTask that aborts itself via
 	// handle.update() cannot cascade into the Remix infinite-loop guard.
-	expect(
-		latch.needsLoad({ ...baseInput, currentHref: '/a', isLoading: true }),
-	).toBe(true)
-	expect(
-		latch.needsLoad({ ...baseInput, currentHref: '/a', isLoading: true }),
-	).toBe(false)
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(true)
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(false)
 	const firstAttempt = latch.getPendingAttempt()
 	latch.clearPending('/a', firstAttempt)
 	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(true)
@@ -35,9 +30,7 @@ test('load, fail, navigate, and stale-refresh workflows share one latch', () => 
 	latch.markLoaded('/a')
 	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(false)
 	expect(latch.isLoadedFor('/a')).toBe(true)
-	expect(
-		latch.needsLoad({ ...baseInput, currentHref: '/a', isLoading: true }),
-	).toBe(false)
+	expect(latch.needsLoad({ ...baseInput, currentHref: '/a' })).toBe(false)
 
 	expect(latch.needsLoad({ ...baseInput, currentHref: '/b' })).toBe(true)
 	latch.markLoaded('/b')

--- a/packages/worker/client/route-load-latch.ts
+++ b/packages/worker/client/route-load-latch.ts
@@ -96,18 +96,12 @@ export function createRouteLoadLatch() {
 		 * href as pending until `markLoaded` / `markFailed` / `clearPending`
 		 * (or a navigation / stale-refresh clears it). Read `getPendingAttempt()`
 		 * immediately after a `true` result for abort-safe clearing.
-		 *
-		 * `isLoading` is accepted for call-site compatibility but ignored: the
-		 * pending latch is the in-flight guard. Using `isLoading` as a reason
-		 * *to* load re-queued every render while status stayed `'loading'`.
 		 */
 		needsLoad(input: {
 			currentHref: string
-			isLoading: boolean
 			appliedRouteData: boolean
 			needsStaleRefresh: boolean
 		}) {
-			void input.isLoading
 			// The failure/pending latches only guard the location they were set
 			// for; leaving it (or coming back) must allow a fresh attempt.
 			const currentHref = toLatchKey(input.currentHref)

--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -421,7 +421,6 @@ export function AccountActivityRoute(handle: Handle) {
 		const latchKey = getDataLatchKey(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref: latchKey,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -346,7 +346,6 @@ export function AccountBillingRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -397,7 +397,6 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		const latchKey = getDataLatchKey(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref: latchKey,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -454,7 +454,6 @@ export function AccountJobsRoute(handle: Handle) {
 		const latchKey = getDataLatchKey(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref: latchKey,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -415,7 +415,6 @@ export function AccountMcpServersRoute(handle: Handle) {
 		const latchKey = getDataLatchKey(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref: latchKey,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-memories.tsx
+++ b/packages/worker/client/routes/account-memories.tsx
@@ -306,7 +306,6 @@ export function AccountMemoriesRoute(handle: Handle) {
 		const latchKey = getDataLatchKey(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref: latchKey,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-package-invocation-tokens.tsx
+++ b/packages/worker/client/routes/account-package-invocation-tokens.tsx
@@ -970,7 +970,6 @@ export function AccountPackageInvocationTokensRoute(handle: Handle) {
 			status !== 'loading' && !loadLatch.isLoadedFor(latchKey)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref: latchKey,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-passkeys.tsx
+++ b/packages/worker/client/routes/account-passkeys.tsx
@@ -328,7 +328,6 @@ export function AccountPasskeysRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-remote-connectors.tsx
+++ b/packages/worker/client/routes/account-remote-connectors.tsx
@@ -738,7 +738,6 @@ export function AccountRemoteConnectorsRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref: dataKey,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-stars.tsx
+++ b/packages/worker/client/routes/account-stars.tsx
@@ -147,7 +147,6 @@ export function AccountStarsRoute(handle: Handle) {
 		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-two-factor.tsx
+++ b/packages/worker/client/routes/account-two-factor.tsx
@@ -308,7 +308,6 @@ export function AccountTwoFactorRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-usage.tsx
+++ b/packages/worker/client/routes/account-usage.tsx
@@ -226,7 +226,6 @@ export function AccountUsageRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account-values.tsx
+++ b/packages/worker/client/routes/account-values.tsx
@@ -447,7 +447,6 @@ export function AccountValuesRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref: latchKey,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -607,7 +607,6 @@ export function AccountRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/blog-post.tsx
+++ b/packages/worker/client/routes/blog-post.tsx
@@ -165,7 +165,6 @@ export function BlogPostRoute(handle: Handle) {
 		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/blog.tsx
+++ b/packages/worker/client/routes/blog.tsx
@@ -93,7 +93,6 @@ export function BlogRoute(handle: Handle) {
 		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/guide-detail.tsx
+++ b/packages/worker/client/routes/guide-detail.tsx
@@ -176,7 +176,6 @@ export function GuideDetailRoute(handle: Handle) {
 		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/guides.tsx
+++ b/packages/worker/client/routes/guides.tsx
@@ -107,7 +107,6 @@ export function GuidesRoute(handle: Handle) {
 		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -155,7 +155,6 @@ export function HomeRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: onboardingStatus === 'loading' || onboardingStatus === 'idle',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -419,7 +419,6 @@ export function OnboardingRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/pending-verification.tsx
+++ b/packages/worker/client/routes/pending-verification.tsx
@@ -177,7 +177,6 @@ export function PendingVerificationRoute(handle: Handle) {
 			consumeStaleNavigationData(currentHref) && !appliedRouteData
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})

--- a/packages/worker/client/routes/timeline.tsx
+++ b/packages/worker/client/routes/timeline.tsx
@@ -134,7 +134,6 @@ export function TimelineRoute(handle: Handle) {
 		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
 		const needsLoad = loadLatch.needsLoad({
 			currentHref,
-			isLoading: status === 'loading',
 			appliedRouteData,
 			needsStaleRefresh,
 		})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove the legacy `isLoading` route-load-latch input now that the pending latch is the sole in-flight guard.

## Summary

- Remove the ignored field from `needsLoad`.
- Update all client route callers and focused Node tests.

## Testing

- ✅ Focused Node suite: 3/3 passed.
- ✅ [PR CI](https://github.com/kentcdodds/kody/actions/runs/32011860689): all 20 checks passed.
- ✅ [Post-merge validation](https://github.com/kentcdodds/kody/actions/runs/32012498033) passed.
- ✅ [Production deployment](https://github.com/kentcdodds/kody/actions/runs/32012994179) and health/smoke checks passed.

## Conductor report

- **Track:** C — Legacy Reaper
- **Status:** shipped to production
- **Risk:** low
- **Conductor run:** `bc-b61e649d-b323-465c-a5b9-9bdfe35dcf49`
- **PR:** squash-merged as `d56d0613465e6d01086f89066ad3b4dd5251142c`
- **Out of scope:** server, CI, entitlements, and MCP

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `39c87a91` · **Head:** `6d5000d2`

**Classification:** composes — no primitive behavior changes; this removes an ignored internal input and updates existing callers.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — routes use the same pending latch without the obsolete argument |

### System map

Client routes continue to gate loads through the same route-load latch.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Before | After |
| --- | --- |
| Callers passed ignored `isLoading` | Inputs contain only decision values |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ec601cb-7a25-4b52-9b9b-8062a01b13d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ec601cb-7a25-4b52-9b9b-8062a01b13d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

