### PR TITLE
chore: remove legacy dead code

### DIFF
--- a/docs/contributing/cloudflare-agents-sdk.md
+++ b/docs/contributing/cloudflare-agents-sdk.md
@@ -9,8 +9,7 @@ Primary docs:
 
 - https://developers.cloudflare.com/agents/
 
-Installed in this repo as `agents` in `packages/worker/package.json` (currently
-pinned to `0.20.1`).
+The installed version is pinned in `packages/worker/package.json`.
 
 ## Quick pointers for this repo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11114,7 +11114,6 @@
         "@simplewebauthn/server": "^13.3.2",
         "agents": "0.20.1",
         "aws4fetch": "^1.0.20",
-        "croner": "^10.0.1",
         "diff": "^9.0.0",
         "isomorphic-git": "^1.40.0",
         "marked": "^18.0.7",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -25,7 +25,6 @@
     "@simplewebauthn/server": "^13.3.2",
     "agents": "0.20.1",
     "aws4fetch": "^1.0.20",
-    "croner": "^10.0.1",
     "diff": "^9.0.0",
     "isomorphic-git": "^1.40.0",
     "marked": "^18.0.7",

--- a/packages/worker/src/email/mailbox-inbound-ledger-shared.ts
+++ b/packages/worker/src/email/mailbox-inbound-ledger-shared.ts
@@ -24,7 +24,7 @@ export const mailboxEffectRetryMs = 15 * 60 * 1000
 export const mailboxMaxSubscriptionEffectAttempts = 3
 export const mailboxInboundDueWorkDefaultLimit = 20
 
-/** Inbound delivery identity + CAS fields (D1 `InboundDelivery` parity). */
+/** Inbound delivery identity and Mailbox CAS fields. */
 export type MailboxInboundDeliverySnapshot = {
 	fingerprint: string
 	deliveryId: string

--- a/packages/worker/src/email/mailbox-inbound-ledger.ts
+++ b/packages/worker/src/email/mailbox-inbound-ledger.ts
@@ -2,10 +2,9 @@
  * Mailbox USER inbound ledger authority CAS primitives.
  *
  * Owner-bound SQLite helpers implementing authoritative USER transitions.
- * The legacy D1 implementation is system-only. Effect lease CAS lives in
+ * D1 remains authoritative only for `system:email`. Effect lease CAS lives in
  * `mailbox-inbound-effect-ledger.ts`. No external usage/subscription side
- * effects. D1 receives synchronous compatibility snapshots after CAS;
- * `system:email` stays on D1.
+ * effects.
  */
 
 import { emailRawMimeKey } from './blob-keys.ts'
@@ -482,7 +481,7 @@ export function claimMailboxInboundDeliveryStorage(
 	const usageStartedAt = current.usageStartedAt ?? input.usageStartedAt ?? null
 	/**
 	 * Storage reclaim invalidates prior finalization + in-flight effect leases.
-	 * D1 `json_set` only patches storage fields (stale lease keys can linger in
+	 * SQLite `json_set` only patches storage fields (stale lease keys can linger in
 	 * `detail_json`); promoted Mailbox columns must clear explicitly so a stale
 	 * effect worker cannot complete against a later re-finalization.
 	 */

--- a/packages/worker/src/email/mailbox-inbound-ledger.workers.test.ts
+++ b/packages/worker/src/email/mailbox-inbound-ledger.workers.test.ts
@@ -219,7 +219,7 @@ test('Mailbox inbound ledger CAS covers USER authority transition matrix', async
 		reason: 'too-late',
 		now: takeoverNow,
 	})
-	// No message row → lease-lost (D1 would throw); with message would be already-received.
+	// No message row yields lease-lost; attaching the message would yield already-received.
 	expect(rejectAfterReceived.status).toBe('lease-lost')
 
 	// Rejected path on a separate delivery.
@@ -472,7 +472,7 @@ test('Mailbox inbound ledger CAS covers USER authority transition matrix', async
 		).toISOString(),
 	)
 
-	// Mirror upsert compatibility still works alongside ledger rows.
+	// Generic delivery-event upserts still work alongside authoritative inbound rows.
 	const mirror = await mailboxA.upsertDeliveryEvent({
 		ownerId: ownerA,
 		event: {

--- a/packages/worker/src/email/parser.ts
+++ b/packages/worker/src/email/parser.ts
@@ -47,7 +47,6 @@ function normalizeReferences(value: string | undefined) {
 }
 
 function headersToRecord(
-	_headers: Headers,
 	parsedHeaders: Array<{ name: string; value: string }>,
 ) {
 	const record: Record<string, Array<string>> = {}
@@ -179,7 +178,7 @@ export async function parseForwardableEmailRawMime(
 		messageId: messageIdHeader ?? null,
 		inReplyTo: inReplyToHeader ?? null,
 		references: normalizeReferences(parsed.references),
-		headers: headersToRecord(message.headers, parsedHeaders),
+		headers: headersToRecord(parsedHeaders),
 		authResults:
 			getHeader(message.headers, 'Authentication-Results') ??
 			getHeader(message.headers, 'ARC-Authentication-Results'),

--- a/packages/worker/src/mcp/capabilities/admin/index.ts
+++ b/packages/worker/src/mcp/capabilities/admin/index.ts
@@ -1,1 +1,0 @@
-export { adminDomain } from './domain.ts'

--- a/packages/worker/src/mcp/capabilities/coding/index.ts
+++ b/packages/worker/src/mcp/capabilities/coding/index.ts
@@ -1,5 +1,0 @@
-import { codingDomain } from './domain.ts'
-
-export { codingDomain } from './domain.ts'
-
-export const codingCapabilities = codingDomain.capabilities

--- a/packages/worker/src/mcp/capabilities/openapi/index.ts
+++ b/packages/worker/src/mcp/capabilities/openapi/index.ts
@@ -1,6 +1,0 @@
-export { openapiDomain } from './domain.ts'
-export { openapiBindingSaveCapability } from './openapi-binding-save.ts'
-export { openapiBindingListCapability } from './openapi-binding-list.ts'
-export { openapiBindingGetCapability } from './openapi-binding-get.ts'
-export { openapiBindingDeleteCapability } from './openapi-binding-delete.ts'
-export { openapiBindingRefreshCapability } from './openapi-binding-refresh.ts'

--- a/packages/worker/src/package-codemods/codemods/0001-ambient-storage-to-package-storage.ts
+++ b/packages/worker/src/package-codemods/codemods/0001-ambient-storage-to-package-storage.ts
@@ -251,10 +251,7 @@ function hasExportReexportOfStorage(body: Array<AstNode>) {
 	return false
 }
 
-function hasStorageBindingSite(
-	parsed: AstNode,
-	storageImportStarts: Set<number>,
-) {
+function hasStorageBindingSite(parsed: AstNode) {
 	let found = false
 	walkAst(parsed, null, (node, parent) => {
 		if (found) return
@@ -285,7 +282,6 @@ function hasStorageBindingSite(
 			found = true
 		}
 	})
-	void storageImportStarts
 	return found
 }
 
@@ -518,12 +514,7 @@ function transformSourceFile(source: string): {
 			needsManual: manualUnusualMessage,
 		}
 	}
-	const importStarts = new Set<number>(
-		typeof target.declaration.start === 'number'
-			? [target.declaration.start]
-			: [],
-	)
-	if (hasStorageBindingSite(parsed, importStarts)) {
+	if (hasStorageBindingSite(parsed)) {
 		return {
 			content: source,
 			changed: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove a set of verified dead compatibility scaffolding and stale contributor guidance without changing runtime behavior.

## Summary

- delete unused admin, coding, and OpenAPI capability barrels while keeping each `domain.ts`
- remove the worker's redundant direct `croner` dependency; the shared workspace dependency remains
- remove unused email parser and package-codemod parameters/locals
- correct stale Mailbox inbound-ledger comments and make the Agents SDK guide defer to `packages/worker/package.json` for its pinned version

## Testing

- `npx vitest run --project node-unit packages/worker/src/email/parser.node.test.ts packages/worker/src/package-codemods/codemods/0001-ambient-storage-to-package-storage.node.test.ts` — 3 passed
- `npx vitest run --project workers-unit packages/worker/src/email/mailbox-inbound-ledger.workers.test.ts` — 4 passed
- `CI=1 npm run test:workers` — 295 passed
- `npm run build` — passed
- [PR validation](https://github.com/kentcdodds/kody/actions/runs/32012975977) — green
- [production validation](https://github.com/kentcdodds/kody/actions/runs/32014252691) — green on main including this merge
- [production deploy](https://github.com/kentcdodds/kody/actions/runs/32014379764) — green

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `39c87a91` · **Head:** `38e02004`

**Classification:** composes — dead entry points, redundant metadata, unused parameters, and stale comments are removed without changing primitive behavior or contracts.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | composes — unused coding barrel removed; direct domain registration remains |
| `rbac` | auth | composes — unused admin barrel removed |
| `openapi-bindings` | assistant | composes — unused OpenAPI barrel removed |
| `email` | assistant | composes — unused parser parameter removed |
| `mailbox` | storage | composes — comments aligned with current Mailbox authority |
| `package-codemods` | assistant | composes — unused local and parameter removed |

### System map

Dead compatibility surfaces are removed while the direct capability-domain and inbound-email paths remain unchanged.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	rbac["rbac<br/>Role-based access control"]:::touched
	openapiBindings["openapi-bindings<br/>OpenAPI provider bindings"]:::touched
	email["email<br/>Email"]:::touched
	mailbox["mailbox<br/>Mailbox"]:::touched
	packageCodemods["package-codemods<br/>Package codemods"]:::touched
	capabilityRegistry -->|"direct admin domain import remains"| rbac
	capabilityRegistry -->|"direct OpenAPI domain import remains"| openapiBindings
	email -->|"parsed inbound message shape unchanged"| mailbox
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user Mailbox isolation and authoritative inbound state transitions are unchanged; only stale explanatory comments in that path changed.

</details>

<!-- system-recap:end -->

## Conductor report

**STATUS: SHIPPED.** Track A was squash-merged as `eeb83457e25c601a4f3f598673d1b6c2485f4a84`. [PR #1487](https://github.com/kentcdodds/kody/pull/1487) and its [validation](https://github.com/kentcdodds/kody/actions/runs/32012975977) are green. A later main commit containing Track A passed [production validation](https://github.com/kentcdodds/kody/actions/runs/32014252691) and [production deployment](https://github.com/kentcdodds/kody/actions/runs/32014379764). Scope stayed within the requested legacy cleanup; sibling Tracks B, C, and D were merged separately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-624d429a-3db0-40f3-ac43-02bf13f831b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-624d429a-3db0-40f3-ac43-02bf13f831b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

