### PR TITLE
refactor(entitlements): remove retired mirror contracts

### DIFF
--- a/packages/worker/src/app/account-email-data.ts
+++ b/packages/worker/src/app/account-email-data.ts
@@ -242,14 +242,12 @@ async function loadUsage(input: {
 			now,
 		}),
 		readDailyEntitlementResourceUsage({
-			db: input.db,
 			env: input.env,
 			userId: input.userId,
 			resource: 'email_sends_per_day',
 			now,
 		}),
 		readDailyEntitlementResourceUsage({
-			db: input.db,
 			env: input.env,
 			userId: input.userId,
 			resource: 'email_receives_per_day',

--- a/packages/worker/src/email/outbound.ts
+++ b/packages/worker/src/email/outbound.ts
@@ -757,7 +757,6 @@ export async function sendOutboundEmail(
 			}
 		} catch (error) {
 			await refundDailyEntitlement({
-				db: input.env.APP_DB,
 				env: input.env,
 				userId: input.userId,
 				resource: 'email_sends_per_day',

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -20,10 +20,7 @@ import {
 	refundDailyEntitlement,
 } from './service.ts'
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
-import {
-	createInMemoryUserMeterEnv,
-	createWaitUntilDrain,
-} from '#worker/test-support/user-meter.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import { userMeterRpc } from './user-meter-client.ts'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
@@ -406,6 +403,26 @@ test('findCachedUserAccountByStableUserId caches the account reverse-resolution 
 	expect(await findCachedUserAccountByStableUserId(db, '  ')).toBeNull()
 })
 
+test('scheduled job entitlement checks fail closed without a jobsData usage reader', async () => {
+	const userId = await createStableUserIdFromEmail(plannedEmail)
+	const { db, queries } = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: 'free', stable_user_id: userId }],
+		counts: { jobs: 0 },
+	})
+
+	await expect(
+		assertWithinEntitlement({
+			db,
+			userId,
+			email: plannedEmail,
+			resource: 'scheduled_jobs',
+		}),
+	).rejects.toThrow(
+		'scheduled_jobs usage must be read from jobsData (pass getCurrent or use readCurrentEntitlementResourceUsage).',
+	)
+	expect(queries.some((query) => query.sql.includes('FROM jobs'))).toBe(false)
+})
+
 test('assertWithinEntitlement passes under the limit, throws at it, and enforces finite max ordinary limits', async () => {
 	const userId = await createStableUserIdFromEmail(plannedEmail)
 	const freeLimit = planLimits.free.maxScheduledJobs
@@ -420,6 +437,7 @@ test('assertWithinEntitlement passes under the limit, throws at it, and enforces
 		userId,
 		email: plannedEmail,
 		resource: 'scheduled_jobs',
+		getCurrent: async () => maxLimit - 1,
 	})
 
 	const maxAt = createEntitlementsTestDb({
@@ -431,6 +449,7 @@ test('assertWithinEntitlement passes under the limit, throws at it, and enforces
 		userId,
 		email: plannedEmail,
 		resource: 'scheduled_jobs',
+		getCurrent: async () => maxLimit,
 	}).then(
 		() => null,
 		(thrown: unknown) => thrown,
@@ -453,6 +472,7 @@ test('assertWithinEntitlement passes under the limit, throws at it, and enforces
 		userId,
 		email: plannedEmail,
 		resource: 'scheduled_jobs',
+		getCurrent: async () => freeLimit - 1,
 	})
 
 	const at = createEntitlementsTestDb({
@@ -464,6 +484,7 @@ test('assertWithinEntitlement passes under the limit, throws at it, and enforces
 		userId,
 		email: plannedEmail,
 		resource: 'scheduled_jobs',
+		getCurrent: async () => freeLimit,
 	}).then(
 		() => null,
 		(thrown: unknown) => thrown,
@@ -490,27 +511,32 @@ test('assertWithinEntitlement reuses cached plan within TTL while still enforcin
 		users: [{ email: plannedEmail, plan: 'free', stable_user_id: userId }],
 		counts,
 	})
+	let usageReads = 0
+	const getCurrent = async () => {
+		usageReads += 1
+		return counts.jobs
+	}
 	const planQueries = () =>
 		queries.filter((query) =>
 			query.sql.includes('email = ? AND stable_user_id = ?'),
 		)
-	const usageQueries = () =>
-		queries.filter((query) => query.sql.includes('FROM jobs'))
 
 	await assertWithinEntitlement({
 		db,
 		userId,
 		email: plannedEmail,
 		resource: 'scheduled_jobs',
+		getCurrent,
 	})
 	await assertWithinEntitlement({
 		db,
 		userId,
 		email: plannedEmail,
 		resource: 'scheduled_jobs',
+		getCurrent,
 	})
 	expect(planQueries()).toHaveLength(1)
-	expect(usageQueries()).toHaveLength(2)
+	expect(usageReads).toBe(2)
 
 	counts.jobs = freeLimit
 	const denied = await assertWithinEntitlement({
@@ -518,6 +544,7 @@ test('assertWithinEntitlement reuses cached plan within TTL while still enforcin
 		userId,
 		email: plannedEmail,
 		resource: 'scheduled_jobs',
+		getCurrent,
 	}).then(
 		() => null,
 		(thrown: unknown) => thrown,
@@ -531,7 +558,7 @@ test('assertWithinEntitlement reuses cached plan within TTL while still enforcin
 		current: freeLimit,
 	})
 	expect(planQueries()).toHaveLength(1)
-	expect(usageQueries()).toHaveLength(3)
+	expect(usageReads).toBe(3)
 })
 
 test('assertWithinEntitlement enforces concurrent workflow limits for unresolved and max-plan callers', async () => {
@@ -742,7 +769,6 @@ test('refundDailyEntitlement decrements the user/day counter and floors at zero'
 		})
 	}
 	await refundDailyEntitlement({
-		db,
 		env,
 		userId: 'user-1',
 		resource: 'email_receives_per_day',
@@ -766,14 +792,12 @@ test('refundDailyEntitlement decrements the user/day counter and floors at zero'
 	).toBe(3)
 
 	await refundDailyEntitlement({
-		db,
 		env,
 		userId: 'user-1',
 		resource: 'email_receives_per_day',
 		now,
 	})
 	await refundDailyEntitlement({
-		db,
 		env,
 		userId: 'user-1',
 		resource: 'email_receives_per_day',

--- a/packages/worker/src/entitlements/service.ts
+++ b/packages/worker/src/entitlements/service.ts
@@ -239,18 +239,13 @@ async function ensureUserMeterCounterInitializedAtZero(input: {
  * Point-read one daily entitlement counter from UserMeter. Cold meters
  * initialize the `(resource, day)` at zero, then re-read; warm meters return
  * the DO count. Never touches D1 daily counter state.
- *
- * `db` remains on the signature for call-site stability; plan/account lookups
- * on other paths still need APP_DB.
  */
 export async function readDailyEntitlementResourceUsage(input: {
-	db: D1Database
 	env: UserMeterEnv
 	userId: string
 	resource: EntitlementResource
 	now?: Date
 }): Promise<number> {
-	void input.db
 	const resource = assertDailyEntitlementResource(input.resource)
 	const now = input.now ?? new Date()
 	const day = utcDayKey(now)
@@ -707,14 +702,8 @@ export async function readEntitlementResourceUsage(input: {
 				[userId],
 			)
 		case 'scheduled_jobs':
-			// Job rows live in the jobs-worker database (ADR 0016). Production
-			// callers must go through readCurrentEntitlementResourceUsage or pass
-			// getCurrent with a jobsData count; this direct query only works
-			// against test/local fallback databases that still have the table.
-			return await countRows(
-				db,
-				`SELECT COUNT(*) AS count FROM jobs WHERE user_id = ?`,
-				[userId],
+			throw new Error(
+				'scheduled_jobs usage must be read from jobsData (pass getCurrent or use readCurrentEntitlementResourceUsage).',
 			)
 		case 'package_services':
 			// Authoritative running liveness is in UserMeter. Callers must use
@@ -832,7 +821,6 @@ export async function readCurrentEntitlementResourceUsage(input: {
 }): Promise<number> {
 	if (isDailyEntitlementResource(input.resource)) {
 		return await readDailyEntitlementResourceUsage({
-			db: input.db,
 			env: input.env,
 			userId: input.userId,
 			resource: input.resource,
@@ -1068,11 +1056,6 @@ export type ConsumeDailyEntitlementInput = {
 	email: string | null | undefined
 	resource: EntitlementResource
 	now?: Date
-	/**
-	 * Retained for call-site stability. Daily counters no longer schedule D1
-	 * mirror work; unused after mirror retirement.
-	 */
-	waitUntil?: (promise: Promise<unknown>) => void
 }
 
 /**
@@ -1084,7 +1067,6 @@ export type ConsumeDailyEntitlementInput = {
 export async function consumeDailyEntitlement(
 	input: ConsumeDailyEntitlementInput,
 ): Promise<void> {
-	void input.waitUntil
 	const resource = assertDailyEntitlementResource(input.resource)
 	const now = input.now ?? new Date()
 	const day = utcDayKey(now)
@@ -1136,16 +1118,10 @@ export async function consumeDailyEntitlement(
 }
 
 export type RefundDailyEntitlementInput = {
-	db: D1Database
 	env: UserMeterEnv
 	userId: string
 	resource: EntitlementResource
 	now?: Date
-	/**
-	 * Retained for call-site stability. Daily counters no longer schedule D1
-	 * mirror work; unused after mirror retirement.
-	 */
-	waitUntil?: (promise: Promise<unknown>) => void
 }
 
 /**
@@ -1156,8 +1132,6 @@ export type RefundDailyEntitlementInput = {
 export async function refundDailyEntitlement(
 	input: RefundDailyEntitlementInput,
 ): Promise<void> {
-	void input.db
-	void input.waitUntil
 	const resource = assertDailyEntitlementResource(input.resource)
 	const now = input.now ?? new Date()
 	const day = utcDayKey(now)

--- a/packages/worker/src/entitlements/user-meter.workers.test.ts
+++ b/packages/worker/src/entitlements/user-meter.workers.test.ts
@@ -246,7 +246,6 @@ test('warm daily consume/read never prepares entitlement_daily_counters', async 
 	})
 	await expect(
 		readDailyEntitlementResourceUsage({
-			db: env.APP_DB,
 			env,
 			userId: user.userId,
 			resource: 'email_sends_per_day',
@@ -403,7 +402,6 @@ test('UserMeter daily entitlement consume/refund/read/export/purge workflow is p
 	).toMatchObject({ outcome: 'ready', count: sendLimit })
 
 	await refundDailyEntitlement({
-		db: env.APP_DB,
 		env,
 		userId: userA.userId,
 		resource: 'email_sends_per_day',
@@ -418,7 +416,6 @@ test('UserMeter daily entitlement consume/refund/read/export/purge workflow is p
 	).toMatchObject({ outcome: 'ready', count: sendLimit - 1 })
 	for (let index = 0; index < sendLimit; index += 1) {
 		await refundDailyEntitlement({
-			db: env.APP_DB,
 			env,
 			userId: userA.userId,
 			resource: 'email_sends_per_day',

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -1244,7 +1244,6 @@ export async function executeJobOnce(input: {
 						userId: input.job.userId,
 						email: backgroundUser.email,
 						resource: 'job_runs_per_day',
-						waitUntil: input.waitUntil,
 					})
 					const result = await runRepoBackedJob({
 						env: input.env,

--- a/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-usage-get.ts
@@ -54,14 +54,12 @@ export const emailUsageGetCapability = defineDomainCapability(
 					now,
 				}),
 				readDailyEntitlementResourceUsage({
-					db,
 					env: ctx.env,
 					userId: user.userId,
 					resource: 'email_sends_per_day',
 					now,
 				}),
 				readDailyEntitlementResourceUsage({
-					db,
 					env: ctx.env,
 					userId: user.userId,
 					resource: 'email_receives_per_day',

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -135,7 +135,6 @@ export async function executeGatewayFetch(input: {
 				userId: input.props.userId,
 				email,
 				resource: 'outbound_fetches_per_day',
-				waitUntil: input.waitUntil,
 			})
 		}
 		const transformed = await expandSecretPlaceholders({

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -354,7 +354,6 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 						userId: callerContext.user.userId,
 						email: callerContext.user.email,
 						resource: 'execute_calls_per_day',
-						waitUntil: agent.waitUntil?.bind(agent),
 					})
 				}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove post-entitlement-mirror compatibility arguments and prevent scheduled-job enforcement from querying the APP_DB table removed by migration 0010.

## Summary

- Remove unused `db` inputs from daily usage reads and refunds.
- Remove unused `waitUntil` inputs from daily consumption and refunds while retaining `consumeDailyEntitlement.db` for plan lookup.
- Fail closed when generic scheduled-job enforcement lacks a `getCurrent` jobs-data reader; keep authoritative reads on `jobsData`.
- Update callers and entitlement tests for the contracted interfaces.

## Testing

- `npx vitest run --project node-unit packages/worker/src/entitlements/entitlements.node.test.ts` — 24 passed.
- `npx vitest run --project workers-unit packages/worker/src/entitlements/user-meter.workers.test.ts` — 11 passed.
- GitHub [`✅ Validate`](https://github.com/kentcdodds/kody/actions/runs/32010384033) — all Node, Workers, E2E, and MCP jobs passed. Two local full-gate attempts were resource-inconclusive because unrelated mock/test workers exceeded startup budgets under concurrent load.
- Authenticated preview as `me@kentcdodds.com`: `/account/email.json` returned UserMeter-backed free-plan usage and `/account/jobs.json` returned jobs-worker-backed state; both account pages rendered without errors.
- Post-merge [`✅ Validate`](https://github.com/kentcdodds/kody/actions/runs/32012064291) and superseding [production deployment](https://github.com/kentcdodds/kody/actions/runs/32012321842) passed; the deployed main commit includes this merge.

<a href="https://cursor.com/agents/bc-ab11b236-b25c-4489-a243-0b283829ee2b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fentitlement-preview-email-and-jobs.mp4"><img src="https://cursor.com/artifacts/c/art-6e7c755a-9c96-4a2e-b174-bcbd24cc7e4a" alt="entitlement-preview-email-and-jobs.mp4" /></a>

## Conductor report

Track B · STATUS: merged and deployed · PR: https://github.com/kentcdodds/kody/pull/1488 · CI: https://github.com/kentcdodds/kody/actions/runs/32012064291 · Deploy: https://github.com/kentcdodds/kody/actions/runs/32012321842 · Conductor: `bc-b61e649d-b323-465c-a5b9-9bdfe35dcf49`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `39c87a91` · **Head:** `9fa50029`

**Classification:** extends — tightens entitlement service contracts and removes a production-dead APP_DB fallback without adding primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `entitlements` | auth | extends — daily metering signatures are contracted and scheduled-job reads fail closed without jobs data |
| `jobs` | assistant | composes — continues supplying authoritative `getCurrent` counts through `jobsData` |
| `email` | assistant | composes — adopts daily read/refund contracts without discarded inputs |
| `mcp-server` | surfaces | composes — execute and fetch metering omit retired lifecycle arguments |
| `app-ui` | surfaces | composes — account email usage reads omit APP_DB from UserMeter reads |

### System map

Daily quota surfaces call the contracted UserMeter entitlement APIs, while scheduled-job enforcement must receive an authoritative jobs-worker-backed count.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	email["email<br/>Email"]:::touched
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::touched
	jobs["jobs<br/>Scheduled jobs"]:::touched
	jobsWorker["jobs-worker<br/>Jobs worker"]:::untouched
	entitlements["entitlements<br/>Plans & entitlements"]:::extended
	appUi -->|"daily usage read without APP_DB"| entitlements
	email -->|"daily consume/refund without retired inputs"| entitlements
	mcpServer -->|"daily consume without waitUntil"| entitlements
	jobs -->|"scheduled_jobs getCurrent"| entitlements
	jobs -->|"jobsData countJobsForUser"| jobsWorker
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Contract | Before | After |
| --- | --- | --- |
| Daily usage read | accepted unused `db` | UserMeter inputs only |
| Daily consume/refund | accepted unused `waitUntil`; refund accepted unused `db` | only inputs used by each operation |
| `scheduled_jobs` generic usage | queried dropped APP_DB `jobs` table | throws unless caller supplies `getCurrent`; aggregate reads use `jobsData` |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab11b236-b25c-4489-a243-0b283829ee2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab11b236-b25c-4489-a243-0b283829ee2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy and consistency of daily usage tracking across email, gateway, tool, and scheduled-job activity.
  - Daily entitlement checks now fail safely when usage information is unavailable, preventing incorrect allowance or consumption decisions.
  - Updated entitlement refunds and usage calculations to provide more reliable results during failed email deliveries and job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->