### PR TITLE
docs: garden squashed migration references

### DIFF
--- a/docs/contributing/account-write-lease-repair.md
+++ b/docs/contributing/account-write-lease-repair.md
@@ -5,9 +5,9 @@ account deletion until an administrator verifies that the process is gone and
 releases its exact token with an audit reason.
 
 Active leases live in the UserMeter DO. All callers supply `env` (including
-email paths), so every lease is a UserMeter-authoritative row. Migration `0141`
-dropped D1 `account_write_leases`; `account_write_lease_repairs` remains the D1
-audit log for all repairs.
+email paths), so every lease is a UserMeter-authoritative row. D1 has no
+`account_write_leases` table; `account_write_lease_repairs` remains the audit
+log for all repairs in `packages/worker/migrations/0001-squashed-init.sql`.
 
 First inspect active leases:
 

--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -344,8 +344,10 @@ connector-style credential setup capabilities that store write-only values.
 ## Directory layout
 
 Organize capabilities by domain. Each domain folder should include a
-**`domain.ts`** that calls `defineDomain`, an optional **`index.ts`** barrel,
-and one or more capability modules.
+**`domain.ts`** that calls `defineDomain` and one or more capability modules.
+The domain module imports each capability from its defining file; consumers
+import the domain from `domain.ts` and individual capabilities from their own
+modules.
 
 ```text
 packages/worker/src/mcp/capabilities/
@@ -360,7 +362,6 @@ packages/worker/src/mcp/capabilities/
   coding/
     domain.ts
     kody-official-guide.ts
-    index.ts
   values/
     domain.ts
     value-get.ts
@@ -377,7 +378,7 @@ domain when you introduce a new system boundary or ownership area (e.g.
    extends the `BuiltinCapabilityDomain` union; `CapabilityDomain` itself is a
    plain `string` so runtime remote-connector domains stay valid).
 2. Add `packages/worker/src/mcp/capabilities/<name>/domain.ts`, capability
-   files, and `index.ts` if you want a barrel.
+   files, and direct imports from those files in `domain.ts`.
 3. Append the new domain to the `builtinDomains` array in `builtin-domains.ts`.
 
 You do not edit `registry.ts` for routine additions—only `builtin-domains` and
@@ -391,8 +392,9 @@ the domain modules.
 3. Add helpful `tags`/`keywords` when they improve search.
 4. Include the capability in that domain’s **`domain.ts`**:
    `capabilities: [..., yourCapability]`.
-5. If the domain uses `index.ts`, ensure it exports `domain` /
-   `codingCapabilities`-style aliases as needed for local imports.
+5. Import the domain directly from **`<domain>/domain.ts`** in
+   `builtin-domains.ts`; import individual capabilities from their defining
+   files wherever they are used.
 6. Add or update focused `*.node.test.ts` or `*.workers.test.ts` coverage beside
    the implementation for most MCP-visible behavior. Touch
    `packages/worker/src/mcp/*.mcp-e2e.test.ts` only when the behavior truly

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -111,15 +111,13 @@ The `invites` table stores operator-created invite codes:
   deletion does not strand invites)
 - `note`, `max_uses`, `use_count`, `expires_at`, `revoked_at`, and `created_at`
   describe current invite state
-- `plan` (NOT NULL; DDL DEFAULT `'free'` after `0083-plan-default-free.sql`;
-  added by `0065-invite-plans.sql`; stored `'unlimited'` renamed to `'max'` by
-  `0082-rename-unlimited-plan-to-max.sql`; migration-window residual
-  `'unlimited'` reconciled to `'max'` by `0083-plan-default-free.sql`) is an
-  optional signup plan name; password and social signup read the consumed
-  invite's stored plan with `parseStoredPlanName` and copy it onto `users.plan`
-  via `resolvePlanWrite`. Omitted invite plans are written as `free`. Admin
-  invite creation validates plan names with strict `parsePlanName`. See
-  [Entitlements](./entitlements.md).
+- `plan` is a NOT NULL signup plan name with a DDL default of `'free'` and a
+  CHECK constraint for `free`, `standard`, `pro`, or `max` (the squashed
+  baseline plus `0002-restructure-plan-tiers.sql`). Password and social signup
+  read the consumed invite's stored plan with `parseStoredPlanName` and copy it
+  onto `users.plan` via `resolvePlanWrite`. Omitted invite plans are written as
+  `free`. Admin invite creation validates plan names with strict
+  `parsePlanName`. See [Entitlements](./entitlements.md).
 
 When invite gating is on, signup atomically consumes an invite with a single
 conditional `UPDATE ... WHERE use_count < max_uses AND revoked_at IS NULL ...`;

--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -50,9 +50,8 @@ of truth for valid permission strings. Call sites pass literal
 
 ### Baseline roles
 
-The squashed baseline
-(`packages/worker/migrations/0001-squashed-init.sql`) defines the RBAC tables
-and seeds two roles:
+The squashed baseline (`packages/worker/migrations/0001-squashed-init.sql`)
+defines the RBAC tables and seeds two roles:
 
 - **`user`** — default role assigned at signup. Permissions:
   `create|read|update|delete:{entity}:own` for every entity in the registry.
@@ -298,8 +297,8 @@ consumer-time fan-out is the authorization boundary rather than a handler role
 check. This remains a narrow exception only for feedback shown to and explicitly
 approved by the user; it does not grant package runtime general admin roles.
 Username and email are stored submission-time snapshots. Package events never
-resolve mutable live profile data, and persisted feedback rows always carry
-both snapshots.
+resolve mutable live profile data, and persisted feedback rows always carry both
+snapshots.
 
 Submission awaits only Queue enqueue after persistence. An enqueue failure is
 logged without changing the successful response, preventing duplicate feedback

--- a/docs/contributing/architecture/authorization.md
+++ b/docs/contributing/architecture/authorization.md
@@ -50,8 +50,9 @@ of truth for valid permission strings. Call sites pass literal
 
 ### Baseline roles
 
-Migration `packages/worker/migrations/0043-rbac.sql` seeds two roles with
-`INSERT OR IGNORE`:
+The squashed baseline
+(`packages/worker/migrations/0001-squashed-init.sql`) defines the RBAC tables
+and seeds two roles:
 
 - **`user`** — default role assigned at signup. Permissions:
   `create|read|update|delete:{entity}:own` for every entity in the registry.
@@ -59,10 +60,6 @@ Migration `packages/worker/migrations/0043-rbac.sql` seeds two roles with
   `create|read|update|delete:{entity}:any` for every entity in the registry.
 
 Role names are typed: `roleNames = ['user', 'admin']` in `permissions.ts`.
-
-Migration `packages/worker/migrations/0044-rbac-backfill-user-role.sql`
-backfills the `user` role onto accounts that lack a role assignment, so every
-account has the default role.
 
 There is no runtime path that grants `admin`. The first admin is bootstrapped
 with SQL (see [First admin bootstrap](#first-admin-bootstrap) below).
@@ -301,9 +298,8 @@ consumer-time fan-out is the authorization boundary rather than a handler role
 check. This remains a narrow exception only for feedback shown to and explicitly
 approved by the user; it does not grant package runtime general admin roles.
 Username and email are stored submission-time snapshots. Package events never
-resolve mutable live profile data. Migration 0114 backfills pre-snapshot rows
-from the matching user and removes rows that cannot satisfy this attribution
-contract, so persisted snapshots are always present.
+resolve mutable live profile data, and persisted feedback rows always carry
+both snapshots.
 
 Submission awaits only Queue enqueue after persistence. An enqueue failure is
 logged without changing the successful response, preventing duplicate feedback
@@ -433,9 +429,7 @@ assignment happens through the admin UI.
 - `packages/worker/universal/permissions.ts` — typed registry
 - `packages/worker/src/identity/permissions-db.ts` — D1 queries
 - `packages/worker/src/app/permissions-server.ts` — request guards
-- `packages/worker/migrations/0043-rbac.sql` — schema and seed data
-- `packages/worker/migrations/0044-rbac-backfill-user-role.sql` — role backfill
-  for pre-RBAC accounts
+- `packages/worker/migrations/0001-squashed-init.sql` — schema and seed data
 - `packages/worker/src/app/handlers/admin-users.ts` — users admin API
 - `packages/worker/src/app/handlers/admin-roles.ts` — roles admin API
 - `packages/worker/src/mcp-auth-user-context.ts` — MCP role loading

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -281,12 +281,12 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   `profile_visibility` (default `public`). `account_type` (`'person'` default or
   `'platform'`) distinguishes normal signups from operator-provisioned platform
   accounts that own official package scopes (see
-  [Platform accounts](./platform-accounts.md)). The
-  `d1_storage_reconciliation` lane sweeps users by `stable_user_id` keyset from
-  the platform-owned `d1_storage_reconcile_cursor` singleton. UserMeter
-  `storage_bytes_state` (schema v4) drives storage-byte enforcement; UserMeter
-  `package_service_states` (schema v5) is the authoritative running-count
-  source for `package_services` / `service_start` — see
+  [Platform accounts](./platform-accounts.md)). The `d1_storage_reconciliation`
+  lane sweeps users by `stable_user_id` keyset from the platform-owned
+  `d1_storage_reconcile_cursor` singleton. UserMeter `storage_bytes_state`
+  (schema v4) drives storage-byte enforcement; UserMeter
+  `package_service_states` (schema v5) is the authoritative running-count source
+  for `package_services` / `service_start` — see
   [Entitlements](./entitlements.md#usermeter). Inbound email routing does not
   reverse-resolve stable ids — it uses the indexed username lookup
   (`findPublicUserIdentityByUsername`). Contextless paths resolve stable ids
@@ -312,13 +312,13 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   The catalog lives in the per-user `RepoSessionIndex` Durable Object. D1 keeps
   only the thin `repo_session_due_owners` hint and the platform-owned
   `repo_session_storage_bucket_cursor`.
-- `package_service_states` (`0001-squashed-init.sql`): per-service
-  liveness projection (`running` / `idle` / `stopped` / `error`) for discovery,
-  account export/deletion inventory, and disaster recovery. Upserted and
-  heartbeaten (1h) by the `PackageServiceInstance` Durable Object. Running-count
-  enforcement and `service_start` read the per-user `UserMeter` copy (schema v5;
-  24h staleness on DO `source_updated_at`). D1 remains only the enumeration
-  index — see [Entitlements](./entitlements.md#package-service-liveness).
+- `package_service_states` (`0001-squashed-init.sql`): per-service liveness
+  projection (`running` / `idle` / `stopped` / `error`) for discovery, account
+  export/deletion inventory, and disaster recovery. Upserted and heartbeaten
+  (1h) by the `PackageServiceInstance` Durable Object. Running-count enforcement
+  and `service_start` read the per-user `UserMeter` copy (schema v5; 24h
+  staleness on DO `source_updated_at`). D1 remains only the enumeration index —
+  see [Entitlements](./entitlements.md#package-service-liveness).
 - `entity_sources`: durable mapping from user-facing entities (`job`, `package`,
   or `repo`) to Artifacts repos and their latest published commit (packages
   only; plain repos are live-at-HEAD without a publish pointer)
@@ -352,8 +352,7 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   requires that grant, regardless of fork or adoption state.
 - `user_oauth_apps` (`0001-squashed-init.sql`): per-user OAuth app rows keyed by
   `(user_id, slug)`. Holds shared client id, client-secret secret name, provider
-  endpoints, and flow options. See
-  [OAuth integrations](./integrations.md).
+  endpoints, and flow options. See [OAuth integrations](./integrations.md).
 - `platform_oauth_apps` (`0004-platform-oauth-apps.sql`): operator-provisioned
   built-in OAuth apps users connect to without registering their own provider
   app. Global operator config with **no `user_id`** (like feature flags, not
@@ -379,14 +378,13 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   `required_hosts_json`, and access/refresh token secret names. Secret
   credential values stay in `secret_entries` in both lanes; the non-secret
   `client_id` is stored inline on the owning app row.
-- `user_openapi_bindings` (`0001-squashed-init.sql`): per-user OpenAPI
-  provider binding rows keyed by `(user_id, name)`. Holds `spec_url`,
-  `api_base_url`, `auth_json`, `selection_json`, `include_destructive`, and
-  optional description / spec metadata. See
-  [OpenAPI provider bindings](./openapi-bindings.md).
-- `user_openapi_binding_operations` (`0001-squashed-init.sql`):
-  per-operation child rows keyed by `(user_id, binding_name, slug)`, with
-  composite FK `(user_id, binding_name) → user_openapi_bindings(user_id, name)`
+- `user_openapi_bindings` (`0001-squashed-init.sql`): per-user OpenAPI provider
+  binding rows keyed by `(user_id, name)`. Holds `spec_url`, `api_base_url`,
+  `auth_json`, `selection_json`, `include_destructive`, and optional description
+  / spec metadata. See [OpenAPI provider bindings](./openapi-bindings.md).
+- `user_openapi_binding_operations` (`0001-squashed-init.sql`): per-operation
+  child rows keyed by `(user_id, binding_name, slug)`, with composite FK
+  `(user_id, binding_name) → user_openapi_bindings(user_id, name)`
   (`ON DELETE CASCADE`). Holds `operation_json` for each curated operation
   snapshot entry. Account deletion lists operations before bindings so cleanup
   does not rely on CASCADE.
@@ -1214,9 +1212,8 @@ on write unless a migration backfills existing rows.
 - `saved_packages.tags_json` and `community_listings.tags_json`
   (`packages/worker/migrations/0001-squashed-init.sql`) are `string[]`
   projections.
-- `published_bundle_artifacts.dependencies_json`
-  (`0001-squashed-init.sql`) stores package dependency pointers queried with
-  SQLite JSON functions in
+- `published_bundle_artifacts.dependencies_json` (`0001-squashed-init.sql`)
+  stores package dependency pointers queried with SQLite JSON functions in
   `packages/worker/src/repo/published-bundle-artifacts-repo.ts`.
 - `package_invocation_tokens.package_ids_json`,
   `package_invocation_tokens.package_kody_ids_json`,
@@ -1232,38 +1229,37 @@ on write unless a migration backfills existing rows.
   time). Delivery history is recorded as `webhook` surface run records (see
   [Run records](./run-records.md) and [Inbound webhooks](./webhooks.md)), not as
   D1 rows.
-- `system_email_daily_counters` (`0001-squashed-init.sql`) stores
-  fixed per-local daily receive counters for operator-owned system inboxes.
-  These counters are not user entitlements and are pruned by the system-email
+- `system_email_daily_counters` (`0001-squashed-init.sql`) stores fixed
+  per-local daily receive counters for operator-owned system inboxes. These
+  counters are not user entitlements and are pruned by the system-email
   retention job.
 - `mcp_memories.tags_json` and `mcp_memories.source_uris_json`
   (`0001-squashed-init.sql`) back memory search and provenance.
 - `secret_entries.allowed_hosts`, `secret_entries.allowed_capabilities`, and
   `secret_entries.allowed_packages` are JSON string lists used as security
   policy inputs (`0001-squashed-init.sql`). Tightening parse-error behavior
-  requires explicit compatibility review.
-  `allowed_packages` applies only to user-scoped secrets. Unadopted
-  community-forked packages need it for every package read/use path (provenance
-  via `community_forks.forked_package_id` + `forker_user_id`; index in
-  `0001-squashed-init.sql`). Self-authored packages and adopted forks
-  (`community_forks.adopted_at` / `adoption_note`) skip that grant for read/use
-  only.
-  Mutations from package code (`secret_set` / `secret_delete` / OpenAPI
-  token-refresh writes) always require the grant. Package-scoped secrets are
-  owned exclusively by the package id in their bucket binding.
+  requires explicit compatibility review. `allowed_packages` applies only to
+  user-scoped secrets. Unadopted community-forked packages need it for every
+  package read/use path (provenance via `community_forks.forked_package_id` +
+  `forker_user_id`; index in `0001-squashed-init.sql`). Self-authored packages
+  and adopted forks (`community_forks.adopted_at` / `adoption_note`) skip that
+  grant for read/use only. Mutations from package code (`secret_set` /
+  `secret_delete` / OpenAPI token-refresh writes) always require the grant.
+  Package-scoped secrets are owned exclusively by the package id in their bucket
+  binding.
 - `user_oauth_apps.extra_authorize_params_json`,
   `user_integrations.scopes_json`, and `user_integrations.required_hosts_json`
   (`0001-squashed-init.sql`, `packages/worker/src/integrations/`) store a
-  string→string object, a scope string list, and a host string list respectively.
-  Parsers in the integrations data-access layer own the shapes; credential
-  values are never stored in these columns (only secret names and the inline
-  non-secret `client_id`).
+  string→string object, a scope string list, and a host string list
+  respectively. Parsers in the integrations data-access layer own the shapes;
+  credential values are never stored in these columns (only secret names and the
+  inline non-secret `client_id`).
 - `user_openapi_bindings.auth_json`, `user_openapi_bindings.selection_json`, and
-  `user_openapi_binding_operations.operation_json`
-  (`0001-squashed-init.sql`, `packages/worker/src/openapi/`) store the auth
-  discriminant, selection object, and per-operation snapshot object. Parsers in
-  the OpenAPI binding service own the shapes; credential values are never stored
-  (only secret / integration name references inside `auth_json`).
+  `user_openapi_binding_operations.operation_json` (`0001-squashed-init.sql`,
+  `packages/worker/src/openapi/`) store the auth discriminant, selection object,
+  and per-operation snapshot object. Parsers in the OpenAPI binding service own
+  the shapes; credential values are never stored (only secret / integration name
+  references inside `auth_json`).
 
 ### Durable Object id contracts
 

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -274,19 +274,19 @@ Relational app data lives in D1.
 The schema is defined by migrations in `packages/worker/migrations/`:
 
 - `users`: login identity and password hash, plus the persisted stable MCP
-  `userId` (`stable_user_id`, NOT NULL unique index from migrations 0052 + 0075;
-  initially SHA-256 of the normalized email at signup via
-  `createStableUserIdFromEmail`, then preserved across email changes). Optional
-  community profile fields (`display_name`, `bio`, `profile_visibility` with
-  default `public`) come from migration 0068. `account_type` (`'person'` default
-  or `'platform'`, migration 0072) distinguishes normal signups from
-  operator-provisioned platform accounts that own official package scopes (see
-  [Platform accounts](./platform-accounts.md)). The `d1_storage_reconciliation`
-  lane sweeps users by `stable_user_id` keyset from the platform-owned
-  `d1_storage_reconcile_cursor` singleton. UserMeter `storage_bytes_state`
-  (schema v4) drives storage-byte enforcement; UserMeter
-  `package_service_states` (schema v5) is the authoritative running-count source
-  for `package_services` / `service_start` — see
+  `userId` (`stable_user_id`, with a NOT NULL unique index in
+  `0001-squashed-init.sql`; initially SHA-256 of the normalized email at signup
+  via `createStableUserIdFromEmail`, then preserved across email changes).
+  Optional community profile fields are `display_name`, `bio`, and
+  `profile_visibility` (default `public`). `account_type` (`'person'` default or
+  `'platform'`) distinguishes normal signups from operator-provisioned platform
+  accounts that own official package scopes (see
+  [Platform accounts](./platform-accounts.md)). The
+  `d1_storage_reconciliation` lane sweeps users by `stable_user_id` keyset from
+  the platform-owned `d1_storage_reconcile_cursor` singleton. UserMeter
+  `storage_bytes_state` (schema v4) drives storage-byte enforcement; UserMeter
+  `package_service_states` (schema v5) is the authoritative running-count
+  source for `package_services` / `service_start` — see
   [Entitlements](./entitlements.md#usermeter). Inbound email routing does not
   reverse-resolve stable ids — it uses the indexed username lookup
   (`findPublicUserIdentityByUsername`). Contextless paths resolve stable ids
@@ -300,8 +300,8 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   removes any remaining rows.
 - `package_scope_grants`: explicit rows granting a person account permission to
   act inside a platform account's package scope (`scope_owner_user_id`,
-  `grantee_user_id`, `created_by_user_id`, `created_at`; migration 0072). Grants
-  are only representable when the scope owner is a platform account.
+  `grantee_user_id`, `created_by_user_id`, `created_at`; squashed baseline).
+  Grants are only representable when the scope owner is a platform account.
 - `password_resets`: hashed reset tokens with expiry and foreign key to users
 - Workflow, activation, and package-success state lives in dedicated RunLog
   tables; D1 has no corresponding projection tables (see
@@ -312,7 +312,7 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   The catalog lives in the per-user `RepoSessionIndex` Durable Object. D1 keeps
   only the thin `repo_session_due_owners` hint and the platform-owned
   `repo_session_storage_bucket_cursor`.
-- `package_service_states` (`0095-package-service-states.sql`): per-service
+- `package_service_states` (`0001-squashed-init.sql`): per-service
   liveness projection (`running` / `idle` / `stopped` / `error`) for discovery,
   account export/deletion inventory, and disaster recovery. Upserted and
   heartbeaten (1h) by the `PackageServiceInstance` Durable Object. Running-count
@@ -328,8 +328,8 @@ The schema is defined by migrations in `packages/worker/migrations/`:
 - `saved_packages`: package metadata/search projection derived from published
   `package.json` source, plus a user-scoped `hidden` flag (0/1) that excludes
   the package from default ranked search while leaving list/get/execute paths
-  intact, and `is_private` (0/1, migration 0068) projecting
-  `package.json#private` for public-profile and timeline filters
+  intact, and `is_private` (0/1) projecting `package.json#private` for
+  public-profile and timeline filters
 - `community_listings`, `community_forks`, `community_ratings`,
   `community_reports`, `community_bans`: public community package listings and
   moderation (see [Community packages](../community-packages.md))
@@ -345,16 +345,14 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   package runtimes may use their own package secrets. User secrets are
   auto-granted for read/use to self-authored packages (no `community_forks` row
   for that `saved_packages.id` + `userId`) and to adopted forks
-  (`community_forks.adopted_at` set via `community_fork_adopt`; columns in
-  `0074-community-fork-adoption.sql`). Unadopted community forks
-  (`community_forks.forked_package_id`, indexed in
-  `0073-community-forks-forked-package-index.sql`) still require an explicit
-  `allowed_packages` grant on every package read path. Updating or deleting a
-  user secret from package code always requires that grant, regardless of fork
-  or adoption state.
-- `user_oauth_apps` (`0101-user-oauth-apps-and-integrations.sql`): per-user
-  OAuth app rows keyed by `(user_id, slug)`. Holds shared client id, client-
-  secret secret name, provider endpoints, and flow options. See
+  (`community_forks.adopted_at` set via `community_fork_adopt`). Unadopted
+  community forks (`community_forks.forked_package_id`, indexed in the squashed
+  baseline) still require an explicit `allowed_packages` grant on every package
+  read path. Updating or deleting a user secret from package code always
+  requires that grant, regardless of fork or adoption state.
+- `user_oauth_apps` (`0001-squashed-init.sql`): per-user OAuth app rows keyed by
+  `(user_id, slug)`. Holds shared client id, client-secret secret name, provider
+  endpoints, and flow options. See
   [OAuth integrations](./integrations.md).
 - `platform_oauth_apps` (`0004-platform-oauth-apps.sql`): operator-provisioned
   built-in OAuth apps users connect to without registering their own provider
@@ -372,7 +370,7 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   `platform-oauth-app-logos/{slug}/` keys; SVG uploads are rasterized to PNG
   before storage). See
   [OAuth integrations](./integrations.md#platform-built-in-oauth-apps).
-- `user_integrations` (`0101-user-oauth-apps-and-integrations.sql`, rebuilt by
+- `user_integrations` (squashed baseline, rebuilt by
   `0004-platform-oauth-apps.sql`): per-user OAuth connections keyed by
   `(user_id, name)`. Exactly one of nullable `app_slug` (composite FK
   `(user_id, app_slug) → user_oauth_apps(user_id, slug)`) or nullable
@@ -381,12 +379,12 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   `required_hosts_json`, and access/refresh token secret names. Secret
   credential values stay in `secret_entries` in both lanes; the non-secret
   `client_id` is stored inline on the owning app row.
-- `user_openapi_bindings` (`0102-user-openapi-bindings.sql`): per-user OpenAPI
+- `user_openapi_bindings` (`0001-squashed-init.sql`): per-user OpenAPI
   provider binding rows keyed by `(user_id, name)`. Holds `spec_url`,
   `api_base_url`, `auth_json`, `selection_json`, `include_destructive`, and
   optional description / spec metadata. See
   [OpenAPI provider bindings](./openapi-bindings.md).
-- `user_openapi_binding_operations` (`0102-user-openapi-bindings.sql`):
+- `user_openapi_binding_operations` (`0001-squashed-init.sql`):
   per-operation child rows keyed by `(user_id, binding_name, slug)`, with
   composite FK `(user_id, binding_name) → user_openapi_bindings(user_id, name)`
   (`ON DELETE CASCADE`). Holds `operation_json` for each curated operation
@@ -1214,60 +1212,58 @@ on write unless a migration backfills existing rows.
   compatibility. Package jobs persist both `storageContext.appId` for value
   scope and `storageContext.packageId` for package-owned secret scope.
 - `saved_packages.tags_json` and `community_listings.tags_json`
-  (`0027-saved-packages.sql`, `0045-community-listings.sql`) are `string[]`
+  (`packages/worker/migrations/0001-squashed-init.sql`) are `string[]`
   projections.
 - `published_bundle_artifacts.dependencies_json`
-  (`0028-published-bundle-artifacts-and-archived-jobs.sql`) stores package
-  dependency pointers queried with SQLite JSON functions in
+  (`0001-squashed-init.sql`) stores package dependency pointers queried with
+  SQLite JSON functions in
   `packages/worker/src/repo/published-bundle-artifacts-repo.ts`.
 - `package_invocation_tokens.package_ids_json`,
   `package_invocation_tokens.package_kody_ids_json`,
   `package_invocation_tokens.export_names_json`, and
-  `package_invocation_tokens.sources_json` (`0029-package-invocations.sql`)
-  store invocation-token scope projections. Keyed invocation replay lives in the
-  RunLog Durable Object ledger (see [Run records](./run-records.md)); there is
-  no D1 `package_invocations` table (`0112-drop-package-invocations.sql`).
-- `webhook_endpoints` (`0090-webhook-endpoints.sql`) stores per-user minted URL
+  `package_invocation_tokens.sources_json` (`0001-squashed-init.sql`) store
+  invocation-token scope projections. Keyed invocation replay lives in the
+  RunLog Durable Object ledger (see [Run records](./run-records.md)); the
+  current D1 schema has no `package_invocations` table.
+- `webhook_endpoints` (`0001-squashed-init.sql`) stores per-user minted URL
   state for `package.json#kody.webhooks`, keyed by
   `(user_id, package_id, webhook_name)`. URL secrets are SHA-256 hashed;
   verification secrets stay in the secrets primitive (`secretName` at delivery
   time). Delivery history is recorded as `webhook` surface run records (see
   [Run records](./run-records.md) and [Inbound webhooks](./webhooks.md)), not as
   D1 rows.
-- `system_email_daily_counters` (`0051-system-email-daily-counters.sql`) stores
+- `system_email_daily_counters` (`0001-squashed-init.sql`) stores
   fixed per-local daily receive counters for operator-owned system inboxes.
   These counters are not user entitlements and are pruned by the system-email
   retention job.
 - `mcp_memories.tags_json` and `mcp_memories.source_uris_json`
-  (`0016-mcp-memories.sql`, `0018-mcp-memory-source-uris.sql`) back memory
-  search and provenance.
+  (`0001-squashed-init.sql`) back memory search and provenance.
 - `secret_entries.allowed_hosts`, `secret_entries.allowed_capabilities`, and
   `secret_entries.allowed_packages` are JSON string lists used as security
-  policy inputs (`0009-secret-allowed-hosts.sql`,
-  `0010-secret-allowed-capabilities.sql`, `0023-secret-allowed-packages.sql`).
-  Tightening parse-error behavior requires explicit compatibility review.
+  policy inputs (`0001-squashed-init.sql`). Tightening parse-error behavior
+  requires explicit compatibility review.
   `allowed_packages` applies only to user-scoped secrets. Unadopted
   community-forked packages need it for every package read/use path (provenance
-  via `community_forks.forked_package_id` + `forker_user_id`; index
-  `0073-community-forks-forked-package-index.sql`). Self-authored packages and
-  adopted forks (`community_forks.adopted_at` / `adoption_note` from
-  `0074-community-fork-adoption.sql`) skip that grant for read/use only.
+  via `community_forks.forked_package_id` + `forker_user_id`; index in
+  `0001-squashed-init.sql`). Self-authored packages and adopted forks
+  (`community_forks.adopted_at` / `adoption_note`) skip that grant for read/use
+  only.
   Mutations from package code (`secret_set` / `secret_delete` / OpenAPI
   token-refresh writes) always require the grant. Package-scoped secrets are
   owned exclusively by the package id in their bucket binding.
 - `user_oauth_apps.extra_authorize_params_json`,
   `user_integrations.scopes_json`, and `user_integrations.required_hosts_json`
-  (`0101-user-oauth-apps-and-integrations.sql`,
-  `packages/worker/src/integrations/`) store a string→string object, a scope
-  string list, and a host string list respectively. Parsers in the integrations
-  data-access layer own the shapes; credential values are never stored in these
-  columns (only secret names and the inline non-secret `client_id`).
+  (`0001-squashed-init.sql`, `packages/worker/src/integrations/`) store a
+  string→string object, a scope string list, and a host string list respectively.
+  Parsers in the integrations data-access layer own the shapes; credential
+  values are never stored in these columns (only secret names and the inline
+  non-secret `client_id`).
 - `user_openapi_bindings.auth_json`, `user_openapi_bindings.selection_json`, and
   `user_openapi_binding_operations.operation_json`
-  (`0102-user-openapi-bindings.sql`, `packages/worker/src/openapi/`) store the
-  auth discriminant, selection object, and per-operation snapshot object.
-  Parsers in the OpenAPI binding service own the shapes; credential values are
-  never stored (only secret / integration name references inside `auth_json`).
+  (`0001-squashed-init.sql`, `packages/worker/src/openapi/`) store the auth
+  discriminant, selection object, and per-operation snapshot object. Parsers in
+  the OpenAPI binding service own the shapes; credential values are never stored
+  (only secret / integration name references inside `auth_json`).
 
 ### Durable Object id contracts
 
@@ -1510,9 +1506,9 @@ Current retention policies:
   by `processed_at`. They are not user-owned and remain independent of account
   deletion/export.
 
-Migration `0055-retention-indexes.sql` adds the global time-column indexes these
-prunes order by (`created_at` / `day` / `month` / `started_at` across users);
-per-user composite indexes cannot serve those ordered scans.
+The squashed baseline defines the global time-column indexes these prunes order
+by (`created_at` / `day` / `month` / `started_at` across users); per-user
+composite indexes cannot serve those ordered scans.
 
 Documented exemptions: `archived_job_artifacts` is exempt because job artifact
 cleanup is driven by each row's `retain_until` value, `jobs` are cleaned by the

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -758,7 +758,8 @@ Handled event types:
   `subscriptionStatus` such as `past_due` for UX; does not email users)
 - Unknown event types — acknowledge `200` after process+record
 
-Idempotency uses migration `0093-stripe-webhook-events.sql`
+Idempotency uses the `stripe_webhook_events` table from
+`packages/worker/migrations/0001-squashed-init.sql`
 (`stripe_webhook_events.event_id` unique). Events are processed first (handlers
 are idempotent), then recorded. A UNIQUE conflict after a successful process is
 treated as duplicate success (`200`). Process failures return `500` without

--- a/docs/contributing/architecture/feature-flags.md
+++ b/docs/contributing/architecture/feature-flags.md
@@ -25,8 +25,8 @@ mutations).
 
 ## The registry-owns-existence invariant
 
-The database stores **state**, never **existence**. Migration
-`0064-feature-flags.sql` adds two tables:
+The database stores **state**, never **existence**. The squashed baseline
+(`packages/worker/migrations/0001-squashed-init.sql`) defines two tables:
 
 - `feature_flags` — at most one global row per key: `enabled`, `rollout_percent`
   (nullable), `note`, `updated_by`, `updated_at`. No row means "use the registry
@@ -101,7 +101,8 @@ week, so measured flags record **exposures** at the two evaluation chokepoints
 `(stable user id, flag key, on/off, assignment source, timestamp)`. The write
 path mirrors usage metering — the `FLAG_EXPOSURES` Analytics Engine dataset in
 production/preview, the D1 `feature_flag_exposure_rollups` table (migration
-`0117`, 90-day retention) in local dev and tests — and never throws.
+`0001-squashed-init.sql`, 90-day retention) in local dev and tests — and never
+throws.
 
 The assignment source (`default` / `global` / `rollout` / `override`) is what
 keeps the readout honest: `override` users are hand-picked and excluded from

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -17,10 +17,9 @@ the `/mcp` endpoint (where Kody is the server) and complements remote connectors
   `handleOAuthCallback`, `getSnapshot`, `callTool`, and
   `purgeForAccountDeletion`.
 - **D1 `mcp_server_settings` table**
-  (`packages/worker/migrations/0053-mcp-server-settings.sql`) — user-scoped
-  metadata (id, name, url, enabled). D1 answers "which servers does this user
-  have enabled" without waking the DO; the DO owns live connection state and
-  tokens.
+  (`packages/worker/migrations/0001-squashed-init.sql`) — user-scoped metadata
+  (id, name, url, enabled). D1 answers "which servers does this user have
+  enabled" without waking the DO; the DO owns live connection state and tokens.
 - **Hub client with snapshot cache**
   (`packages/worker/src/mcp-client/hub-client.ts`) — worker-side facade over the
   DO stub. Snapshots are cached per user for 30 seconds and invalidated on every

--- a/docs/contributing/architecture/platform-accounts.md
+++ b/docs/contributing/architecture/platform-accounts.md
@@ -12,7 +12,8 @@ See [Data storage](./data-storage.md) for table inventory and
 
 ## Data model
 
-Migration `packages/worker/migrations/0072-package-scope-grants.sql`:
+The squashed baseline
+(`packages/worker/migrations/0001-squashed-init.sql`) defines:
 
 - **`users.account_type`** — `'person'` (default) or `'platform'`. Platform
   accounts are created by operators, not through signup.
@@ -123,5 +124,5 @@ the mechanism.
   platform account lookup
 - `packages/worker/src/package-registry/package-owner.ts` — scope resolution and
   audit
-- `packages/worker/migrations/0072-package-scope-grants.sql` — schema
+- `packages/worker/migrations/0001-squashed-init.sql` — schema
 - `packages/worker/src/identity/reserved-usernames.ts` — username denylist

--- a/docs/contributing/architecture/platform-accounts.md
+++ b/docs/contributing/architecture/platform-accounts.md
@@ -12,8 +12,8 @@ See [Data storage](./data-storage.md) for table inventory and
 
 ## Data model
 
-The squashed baseline
-(`packages/worker/migrations/0001-squashed-init.sql`) defines:
+The squashed baseline (`packages/worker/migrations/0001-squashed-init.sql`)
+defines:
 
 - **`users.account_type`** — `'person'` (default) or `'platform'`. Platform
   accounts are created by operators, not through signup.

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -237,9 +237,10 @@ of replaying.
   passes and alarm as run rows; `in_progress` rows are never pruned. There is no
   D1 ledger or D1 sweep for this state.
 - **The DO is the only store**: the keyed path performs no D1 ledger reads or
-  writes (there is no D1 `package_invocations` table; see migration
-  `0112-drop-package-invocations.sql`). Only keys claimed in this DO ledger can
-  replay; a redelivery for an unknown key executes fresh.
+  writes; the current schema in
+  `packages/worker/migrations/0001-squashed-init.sql` has no D1
+  `package_invocations` table. Only keys claimed in this DO ledger can replay; a
+  redelivery for an unknown key executes fresh.
 - Account export pages ledger rows through the same `run_records` section cursor
   (runs first, then ledger rows, then dedicated unpruned state); account
   deletion purges them with `clearAll` (every DO table, then schema

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -183,9 +183,9 @@ each chokepoint records exactly one event per metered unit, so sums are safe.
 
 ## Agent package popularity (MCP instructions hint)
 
-Separate from `usage_rollups`, D1 table `agent_package_conversation_uses`
-(also defined in `0001-squashed-init.sql`) tracks **distinct conversations** in
-which a signed-in user’s agents used a saved package via MCP `execute`
+Separate from `usage_rollups`, D1 table `agent_package_conversation_uses` (also
+defined in `0001-squashed-init.sql`) tracks **distinct conversations** in which
+a signed-in user’s agents used a saved package via MCP `execute`
 (`packages.invoke*` with execute provenance, plus static/dynamic `kody:@…` deps
 attributed to that execute call’s `conversationId`).
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -154,8 +154,8 @@ each chokepoint records exactly one event per metered unit, so sums are safe.
    Analytics Engine is the analysis store (sampling-tolerant, high cardinality).
    Do not build enforcement on it.
 
-2. **D1 `usage_rollups` is a derived aggregate** (migration
-   `packages/worker/migrations/0047-usage-rollups.sql`): per-user, per-metric,
+2. **D1 `usage_rollups` is a derived aggregate** (defined in
+   `packages/worker/migrations/0001-squashed-init.sql`): per-user, per-metric,
    per-month counters:
    - key: `(user_id, metric, month)` where `metric` is the `eventType` and
      `month` is the UTC `YYYY-MM` prefix of the event timestamp
@@ -184,10 +184,10 @@ each chokepoint records exactly one event per metered unit, so sums are safe.
 ## Agent package popularity (MCP instructions hint)
 
 Separate from `usage_rollups`, D1 table `agent_package_conversation_uses`
-(migration `0073-agent-package-conversation-uses.sql`) tracks **distinct
-conversations** in which a signed-in user’s agents used a saved package via MCP
-`execute` (`packages.invoke*` with execute provenance, plus static/dynamic
-`kody:@…` deps attributed to that execute call’s `conversationId`).
+(also defined in `0001-squashed-init.sql`) tracks **distinct conversations** in
+which a signed-in user’s agents used a saved package via MCP `execute`
+(`packages.invoke*` with execute provenance, plus static/dynamic `kody:@…` deps
+attributed to that execute call’s `conversationId`).
 
 - Key: `(user_id, package_id, conversation_id)` — upsert updates `last_used_at`;
   the same package in the same conversation counts once. Stored

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -83,6 +83,7 @@ consumer's 15-minute wall-clock limit before later messages are acknowledged.
 
 ## Storage
 
-Minted endpoint state is in migration `0090-webhook-endpoints.sql`. Delivery
-history is in the per-user `RunLog` Durable Object (`webhook` surface), not in
-D1. See [Data storage](./data-storage.md) and [Run records](./run-records.md).
+Minted endpoint state lives in the D1 `webhook_endpoints` table defined by
+`packages/worker/migrations/0001-squashed-init.sql`. Delivery history is in the
+per-user `RunLog` Durable Object (`webhook` surface), not in D1. See
+[Data storage](./data-storage.md) and [Run records](./run-records.md).

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -35,9 +35,8 @@ package vector indexes.
 
 ### D1 tables
 
-The squashed baseline
-(`packages/worker/migrations/0001-squashed-init.sql`) defines the community
-tables and social columns.
+The squashed baseline (`packages/worker/migrations/0001-squashed-init.sql`)
+defines the community tables and social columns.
 
 | Table                | Purpose                                                            |
 | -------------------- | ------------------------------------------------------------------ |
@@ -78,12 +77,12 @@ owner unpublish. **Hard delete** (admin report action) removes the listing row,
 KV snapshot, and ratings.
 
 Admin **trust** marks live in `trusted_commit` / `trusted_by_user_id` /
-`trusted_at`. A listing is
-effectively trusted only while `trusted_commit = pinned_commit`, so an owner
-republish (which moves the pinned commit) drops the effective mark without an
-explicit revoke. `setCommunityListingTrusted` in `service.ts` sets or clears the
-mark; delisted listings cannot be trusted. Surfaces: the `Trusted` badge on
-`/community` cards and detail pages, the admin-only toggle on the detail page
+`trusted_at`. A listing is effectively trusted only while
+`trusted_commit = pinned_commit`, so an owner republish (which moves the pinned
+commit) drops the effective mark without an explicit revoke.
+`setCommunityListingTrusted` in `service.ts` sets or clears the mark; delisted
+listings cannot be trusted. Surfaces: the `Trusted` badge on `/community` cards
+and detail pages, the admin-only toggle on the detail page
 (`POST /community/:listingId/trust.json`, audited), and the admin-only
 `community_set_trusted` capability. `community_search` and `community_get`
 expose the effective `trusted` flag.
@@ -200,11 +199,10 @@ stable user ids, and package source. Rating rows use `updated_at`, so the feed
 shows the latest value for each user/listing rating. Since one-click install and
 agent fork both persist through `community_forks`, historical data cannot
 distinguish them and reports both as `fork`. Fork writes snapshot the public
-listing name and kody id, preserving readable fork provenance after a later
-hard delete. Rows without recoverable listing identity use explicit
-deleted/unknown placeholders. Actor usernames resolve through the unique
-`users.stable_user_id` index; neither email nor stable user id enters the feed
-or event.
+listing name and kody id, preserving readable fork provenance after a later hard
+delete. Rows without recoverable listing identity use explicit deleted/unknown
+placeholders. Actor usernames resolve through the unique `users.stable_user_id`
+index; neither email nor stable user id enters the feed or event.
 
 `installCommunityListing` (one-click install) composes `forkCommunityListing`
 with `runRepoChecks` over the fork's rewritten snapshot files and, when checks

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -35,7 +35,9 @@ package vector indexes.
 
 ### D1 tables
 
-Migration: `packages/worker/migrations/0045-community-listings.sql`
+The squashed baseline
+(`packages/worker/migrations/0001-squashed-init.sql`) defines the community
+tables and social columns.
 
 | Table                | Purpose                                                            |
 | -------------------- | ------------------------------------------------------------------ |
@@ -44,9 +46,6 @@ Migration: `packages/worker/migrations/0045-community-listings.sql`
 | `community_ratings`  | Per-user ratings (upsert on `listing_id` + `user_id`)              |
 | `community_reports`  | Reports with denormalized `listing_name` / `listing_owner_user_id` |
 | `community_bans`     | Community-wide bans (publish, fork, rate, report)                  |
-
-Social / profiles migration:
-`packages/worker/migrations/0068-community-social.sql`
 
 | Table / column                    | Purpose                                                           |
 | --------------------------------- | ----------------------------------------------------------------- |
@@ -61,9 +60,8 @@ Follow, star, and activity actor columns store the MCP **stable user id**
 (`users.stable_user_id`), matching other community ownership columns such as
 `community_listings.owner_user_id`.
 
-`saved_packages.is_private` defaulted to `1` when migration 0068 added it.
-Package save and publish paths keep the column in sync with
-`package.json#private`.
+`saved_packages.is_private` defaults to `1`. Package save and publish paths keep
+the column in sync with `package.json#private`.
 
 ### Derived timeline events
 
@@ -80,7 +78,7 @@ owner unpublish. **Hard delete** (admin report action) removes the listing row,
 KV snapshot, and ratings.
 
 Admin **trust** marks live in `trusted_commit` / `trusted_by_user_id` /
-`trusted_at` (migration `0059-community-trusted-listings.sql`). A listing is
+`trusted_at`. A listing is
 effectively trusted only while `trusted_commit = pinned_commit`, so an owner
 republish (which moves the pinned commit) drops the effective mark without an
 explicit revoke. `setCommunityListingTrusted` in `service.ts` sets or clears the
@@ -90,8 +88,7 @@ mark; delisted listings cannot be trusted. Surfaces: the `Trusted` badge on
 `community_set_trusted` capability. `community_search` and `community_get`
 expose the effective `trusted` flag.
 
-Admin **featured** marks live in `featured_at` (migration
-`0060-community-featured-listings.sql`) and highlight onboarding starter
+Admin **featured** marks live in `featured_at` and highlight onboarding starter
 packages. Operators publish official starters under a platform scope (for
 example `@kody`) by passing `package_scope` to `community_publish` while holding
 a package scope grant; see
@@ -202,10 +199,9 @@ timestamp, and rating scores; they omit rating notes, forked source/package ids,
 stable user ids, and package source. Rating rows use `updated_at`, so the feed
 shows the latest value for each user/listing rating. Since one-click install and
 agent fork both persist through `community_forks`, historical data cannot
-distinguish them and reports both as `fork`. New fork rows snapshot the public
-listing name and kody id; migration `0070-community-fork-listing-snapshots.sql`
-backfills existing rows while their listings still exist, preserving readable
-fork provenance after a later hard delete. Pre-snapshot orphan rows use explicit
+distinguish them and reports both as `fork`. Fork writes snapshot the public
+listing name and kody id, preserving readable fork provenance after a later
+hard delete. Rows without recoverable listing identity use explicit
 deleted/unknown placeholders. Actor usernames resolve through the unique
 `users.stable_user_id` index; neither email nor stable user id enters the feed
 or event.

--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -271,9 +271,9 @@ Each per-package row in a run records one of:
 
 ## Ledger
 
-Every run and per-package item is stored in D1 (migration
-`0111-package-codemod-ledger.sql`). Pagination cursors live on step responses,
-not in the ledger tables.
+Every run and per-package item is stored in D1 (tables defined in
+`packages/worker/migrations/0001-squashed-init.sql`). Pagination cursors live on
+step responses, not in the ledger tables.
 
 **`package_codemod_runs`:** `id`, `codemod_id`, `mode`, `scope_user_id` (`NULL`
 for fleet runs), `initiated_by_user_id`, `filters_json`, `status` (`running` |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep contributor guidance aligned with the current capability-domain import pattern and squashed worker migration layout.

## Summary

- document direct `domain.ts` and capability-file imports instead of deleted domain barrels
- replace deleted pre-squash migration citations with current table names and checked-in migration sources
- preserve point-in-time decision records unchanged and use present-tense system descriptions

## Testing

- `npm run docs:check-temporal` — passed
- `npx oxfmt --check <changed docs>` — passed
- PR CI — green: [Validate](https://github.com/kentcdodds/kody/actions/runs/32030396481/job/95389106155), [Static](https://github.com/kentcdodds/kody/actions/runs/32030396481/job/95388876810), [Node](https://github.com/kentcdodds/kody/actions/runs/32030396481/job/95388876613), [Workers](https://github.com/kentcdodds/kody/actions/runs/32030396481/job/95388876787), [MCP](https://github.com/kentcdodds/kody/actions/runs/32030396481/job/95388876657), [E2E](https://github.com/kentcdodds/kody/actions/runs/32030396481/job/95388876687)
- Post-merge [validation](https://github.com/kentcdodds/kody/actions/runs/32030731233) and [production deploy](https://github.com/kentcdodds/kody/actions/runs/32030816964) — passed
- `npm run validate` — static/docs phases passed locally; two runs later hit broad runtime-test resource contention. The equivalent CI lanes all passed.

## System changes

Documentation-only; no runtime primitive, schema, migration, or application behavior changes.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `4560d004` · **Head:** `1e7111f2`

**Classification:** composes — documentation describes existing domain imports and D1 schema without changing any primitive.

### Primitives touched

None. The classifier matched no runtime ownership roots; all 14 changed paths are under `docs/contributing/`.

### System map

The docs point capability authors to direct domain modules and schema readers to the checked-in squashed baseline.

```mermaid
flowchart LR
	docs["contributing docs<br/>Author guidance"]:::touched
	domains["capability-registry<br/>Capability registry"]:::untouched
	d1["d1-app-db<br/>D1 app database"]:::untouched
	docs -.->|"direct domain.ts imports"| domains
	docs -.->|"0001/current migration citations"| d1
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

## Conductor report

Conductor run: `bc-49a227fd-6578-4c66-a365-a31f6b1deea3`

Status: shipped. PR squash-merged as `9d9508aef95c165b6bdf3ddb71e85857dff2a47c`. Evidence: [PR CI](https://github.com/kentcdodds/kody/actions/runs/32030396481), [post-merge validation](https://github.com/kentcdodds/kody/actions/runs/32030731233), [production deploy](https://github.com/kentcdodds/kody/actions/runs/32030816964).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b7adf59-9ae9-4531-a2ed-15cd4c813d2a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b7adf59-9ae9-4531-a2ed-15cd4c813d2a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and contributor guidance to reflect the current consolidated data baseline.
  * Clarified authentication, authorization, entitlements, usage metering, webhooks, account leases, and package codemods.
  * Documented capability organization and direct import conventions.
  * Clarified community package privacy, fork provenance, secret access, and synchronization behavior.
  * Updated guidance for run records, MCP servers, feature flags, platform accounts, storage schemas, and invitation plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->