### PR TITLE
Stop advertising autoCreatePR as optional on cloud-agent spawns

### DIFF
--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -46,8 +46,10 @@ Do not spawn a one-agent "fleet."
 
 **PR ownership.** Every code-changing agent pushes and creates/updates its own
 PR via Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before its final
-response. Never have Kody/workflows/GitHub create the initial PR. State this in
-every kickoff.
+response. `@kentcdodds/cursor` `createAgent` always enables those tools — do not
+pass `autoCreatePR: false`. That Cursor flag is a capability gate, not “Kody
+opens the PR”; `false` strips ManagePullRequest. Never have Kody/workflows/GitHub
+create the initial PR as a substitute. State this in every kickoff.
 
 **Report-back (wake-ups, not polling).** End of every run — done, partial, or
 blocked — the agent wakes the conductor:
@@ -115,7 +117,6 @@ export default async function main() {
 		model: 'gpt-5.6-sol',
 		repository: 'https://github.com/owner/repo',
 		ref: 'main',
-		autoCreatePR: true,
 		name: 'track-short-name',
 		prompt: '…self-contained kickoff with report-back + your conductor id…',
 	})

--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -46,10 +46,9 @@ Do not spawn a one-agent "fleet."
 
 **PR ownership.** Every code-changing agent pushes and creates/updates its own
 PR via Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before its final
-response. `@kentcdodds/cursor` `createAgent` always enables those tools — do not
-pass `autoCreatePR: false`. That Cursor flag is a capability gate, not “Kody
-opens the PR”; `false` strips ManagePullRequest. Never have Kody/workflows/GitHub
-create the initial PR as a substitute. State this in every kickoff.
+response. `@kentcdodds/cursor` `createAgent` always enables those tools. Never
+have Kody/workflows/GitHub create the initial PR as a substitute. State this in
+every kickoff.
 
 **Report-back (wake-ups, not polling).** End of every run — done, partial, or
 blocked — the agent wakes the conductor:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Cloud agents spawned through Kody should keep ManagePullRequest. `createAgent` always enables those tools; callers do not choose.

## Summary

- `@kentcdodds/cursor` `createAgent` always sends `autoCreatePR: true`. Docs state that as a fact, not as an opt-out warning.
- MCP overlay: the child opens the PR with ManagePullRequest; `createAgent` always enables those tools; do not have Kody open the PR as a substitute.
- `conduct` (this repo and the skills registry) says the same: always-on tools, child opens the PR.
- Spawner packages that used to pass `false` had that line removed (`email-received-subscriber`, `kody-issue-triage` live; `platform-feedback-triage` and `status-incident-triage` source published, live bundle rebuild still needs a retry).

## Testing

- Cursor package session checks passed.
- Overlay read-back no longer says “do not pass false.”
- Live `createAgent` JSDoc: “Always enables the agent's ManagePullRequest tools.”

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `4560d004` · **Head:** `1b6a4a73`

**Classification:** composes — skill wording only; no primitive code or contract change in this repo.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none in this repo)_ | — | unmatched path `.agents/skills/conduct/SKILL.md` |

The behavior change lives in the published `@kentcdodds/cursor` package and the MCP overlay, not in Worker/MCP code.

### System map

Conductors spawn Cursor Cloud agents through the cursor package. This PR updates in-repo spawn instructions to match always-on ManagePullRequest.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	conductSkill["conduct skill<br/>spawn kickoff"]:::touched
	cursorPkg["@kentcdodds/cursor<br/>createAgent"]:::untouched
	cloudAgent["Cursor Cloud agent<br/>ManagePullRequest"]:::untouched
	conductSkill -->|"createAgent always enables PR tools"| cursorPkg
	cursorPkg -->|"autoCreatePR true"| cloudAgent
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0155440-938b-418d-8927-a59f666866c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0155440-938b-418d-8927-a59f666866c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

