### PR TITLE
fix(mcp): keep missing feedback/email ids off Sentry (KODY-CLOUDFLARE-58)

### DIFF
--- a/packages/worker/src/mcp/capabilities/admin/admin-platform-feedback-update.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-platform-feedback-update.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
@@ -66,8 +67,10 @@ export const adminPlatformFeedbackUpdateCapability = defineDomainCapability(
 							content_warning: platformFeedbackContentWarning,
 						}
 					} catch (error) {
+						// Missing ids, invalid transitions, concurrent updates, and
+						// submission limits are caller-clearable; keep them off Sentry.
 						if (isPlatformFeedbackDomainError(error)) {
-							throw new Error(error.message)
+							throw new McpCallerError(error.message, { cause: error })
 						}
 						throw error
 					}

--- a/packages/worker/src/mcp/capabilities/email/email-message-classify.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-classify.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 
 const mocks = vi.hoisted(() => ({
@@ -83,5 +84,9 @@ test('email_message_classify updates classification and reports not-found', asyn
 			{ message_id: 'missing', classification: 'quarantined' },
 			context,
 		),
-	).rejects.toThrow('Email message not found: missing')
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message === 'Email message not found: missing',
+	)
 })

--- a/packages/worker/src/mcp/capabilities/email/email-message-classify.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-classify.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { setEmailMessageClassification } from '#worker/email/service.ts'
@@ -43,7 +44,7 @@ export const emailMessageClassifyCapability = defineDomainCapability(
 				classificationReason,
 			})
 			if (!updated) {
-				throw new Error(`Email message not found: ${args.message_id}`)
+				throw new McpCallerError(`Email message not found: ${args.message_id}`)
 			}
 			return {
 				message_id: args.message_id,

--- a/packages/worker/src/mcp/capabilities/email/email-message-get.ts
+++ b/packages/worker/src/mcp/capabilities/email/email-message-get.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import {
@@ -30,7 +31,7 @@ export const emailMessageGetCapability = defineDomainCapability(
 				messageId: args.message_id,
 			})
 			if (!message) {
-				throw new Error(`Email message not found: ${args.message_id}`)
+				throw new McpCallerError(`Email message not found: ${args.message_id}`)
 			}
 			const attachments = await listOwnerEmailAttachmentsForMessage({
 				env: ctx.env,

--- a/packages/worker/src/mcp/capabilities/platform-feedback-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/platform-feedback-capabilities.node.test.ts
@@ -1,7 +1,11 @@
 import type * as PlatformFeedbackService from '#worker/platform-feedback/service.ts'
 import { expect, test, vi } from 'vitest'
+import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
-import { PlatformFeedbackInvalidTransitionError } from '#worker/platform-feedback/errors.ts'
+import {
+	PlatformFeedbackInvalidTransitionError,
+	PlatformFeedbackNotFoundError,
+} from '#worker/platform-feedback/errors.ts'
 import {
 	auditEventSummaries,
 	logAuditEventSpy,
@@ -349,14 +353,37 @@ test('admin platform feedback capabilities enforce role access, redact lists, pa
 			{ id: 'feedback-1', action: 'dismiss' },
 			adminContext,
 		),
-	).rejects.toThrow(
-		'Cannot dismiss platform feedback "feedback-1" from status "resolved".',
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message.includes(
+				'Cannot dismiss platform feedback "feedback-1" from status "resolved".',
+			) &&
+			error.cause instanceof PlatformFeedbackInvalidTransitionError,
+	)
+	mockModule.updatePlatformFeedbackForAdmin.mockRejectedValueOnce(
+		new PlatformFeedbackNotFoundError('missing-feedback'),
+	)
+	await expect(
+		adminPlatformFeedbackUpdateCapability.handler(
+			{
+				id: 'missing-feedback',
+				action: 'triage',
+			},
+			adminContext,
+		),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof McpCallerError &&
+			error.message === 'Platform feedback "missing-feedback" was not found.' &&
+			error.cause instanceof PlatformFeedbackNotFoundError,
 	)
 	expect(auditEventSummaries()).toEqual([
 		'mcp_capability_denied:failure',
 		'admin_platform_feedback_list:success',
 		'admin_platform_feedback_get:success',
 		'admin_platform_feedback_update:success',
+		'admin_platform_feedback_update:failure',
 		'admin_platform_feedback_update:failure',
 	])
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-CLOUDFLARE-58](https://kent-c-dodds-tech-llc.sentry.io/issues/7675426753/) reported `Platform feedback "…" was not found` from `admin_platform_feedback_update`. The handler rethrew `PlatformFeedbackDomainError` as a plain `Error`, so MCP observability treated a caller-clearable miss as a platform bug.

Sibling [KODY-CLOUDFLARE-59](https://kent-c-dodds-tech-llc.sentry.io/issues/7675434013/) (`Email message not found: …`) had the same pattern in `email_message_get` / `email_message_classify`.

## Fix

Wrap those domain/not-found failures as `McpCallerError` (same idiom as mailbox maintenance / OAuth admin caps) so they stay on `mcp-event` logs and out of Sentry. Callers still see the same messages.

## Test plan

- [x] Unit tests assert `McpCallerError` (+ cause) for feedback not-found / invalid transition and email classify not-found
- [x] CI `✅ Validate` green on `ec17f3e1`
- [ ] Preview deploy (prior run failed on transient Cloudflare workers subdomain 503; empty commit retrigger)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/sentry-triage-kody-cloudflare-kody-cloudflare-58-80ab`

**Classification:** composes — wires existing `McpCallerError` into two capability handlers; no primitive contracts or storage shape changes.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `platform-feedback` | assistant | composes — domain errors rethrown as `McpCallerError` |
| `email` | assistant | composes — message not-found rethrown as `McpCallerError` |
| `capability-registry` | assistant | composes — test coverage only |

### System map

Caller-supplied missing ids flow through MCP capabilities into observability; this PR only changes the error class so Sentry reporting skips them.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	platformFeedback["platform-feedback<br/>Platform feedback"]:::touched
	emailCap["email<br/>Email"]:::touched
	mcpCallerError["McpCallerError<br/>caller-failure carve-out"]:::untouched
	platformFeedback -->|"not-found / invalid transition"| mcpCallerError
	emailCap -->|"message not found"| mcpCallerError
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Cap as admin_platform_feedback_update
	participant Svc as updatePlatformFeedbackForAdmin
	participant Obs as logMcpEvent / Sentry
	Cap->>Svc: update(id)
	Svc-->>Cap: PlatformFeedbackNotFoundError
	Cap-->>Obs: McpCallerError(cause)
	Note over Obs: isCallerFailure → no Sentry issue
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5930eb7e-7656-4caf-8795-4dbf49161471?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5930eb7e-7656-4caf-8795-4dbf49161471&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

