### PR TITLE
fix(package-apps): align pkg session cookie with parent remaining TTL

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -408,12 +408,19 @@ the owner's subdomain sets `__Host-kody_pkg_session` on secure requests (plain
 `kody_pkg_session` on insecure local HTTP only):
 
 - `httpOnly: true`, `sameSite: 'Lax'`, `path: '/'`, `secure` per request
-- 12 hour max age
+- max age is the **remaining** lifetime of the `kody_session` that minted the
+  handoff (7 days, or 30 days with remember-me), snapshotted into the token as
+  `sessExp` and into the cookie as `expiresAt`. Browser `Max-Age` and a
+  server-side `expiresAt` check both use that instant, so the package-app cookie
+  cannot outlive the parent session. Remember-me renewal on the app origin does
+  not extend an already-issued package-app cookie; a later handoff mints a new
+  snapshot. Tokens minted before `sessExp` existed fall back to a 12 hour
+  lifetime for the rolling-deploy overlap
 - signed with a **derived** secret,
   `sha256Base64Url('kody-package-app-session:v2:' + COOKIE_SECRET)`, so a value
   signed for this cookie can never verify as a `kody_session`
-- payload is `{ v, stableUserId, pkgUsername, issuedAt }` — a shape the app
-  session schema rejects, so the two cannot be confused even by name
+- payload is `{ v, stableUserId, pkgUsername, issuedAt, expiresAt }` — a shape
+  the app session schema rejects, so the two cannot be confused even by name
   substitution
 - the `__Host-` prefix on secure requests forbids a `Domain` attribute, so
   sibling subdomains cannot plant a shadow cookie under this name

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -414,8 +414,8 @@ the owner's subdomain sets `__Host-kody_pkg_session` on secure requests (plain
   server-side `expiresAt` check both use that instant, so the package-app cookie
   cannot outlive the parent session. Remember-me renewal on the app origin does
   not extend an already-issued package-app cookie; a later handoff mints a new
-  snapshot. Tokens minted before `sessExp` existed fall back to a 12 hour
-  lifetime for the rolling-deploy overlap
+  snapshot. Tokens minted before `sessExp` existed, and cookies minted before
+  `expiresAt` existed, fall back to a 12 hour lifetime from mint/`issuedAt`
 - signed with a **derived** secret,
   `sha256Base64Url('kody-package-app-session:v2:' + COOKIE_SECRET)`, so a value
   signed for this cookie can never verify as a `kody_session`

--- a/packages/worker/src/app/auth-session.node.test.ts
+++ b/packages/worker/src/app/auth-session.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import { createCookie } from 'remix/cookie'
 import {
 	createAuthCookie,
+	getAuthSessionExpiresAtMs,
 	isAuthSessionInvalidatedByPasswordChange,
 	readParsedAuthSession,
 	setAuthSessionSecret,
@@ -28,6 +29,20 @@ test('createAuthCookie stamps issuedAt for password-change invalidation', async 
 	const parsed = await readParsedAuthSession(request, now)
 	expect(parsed?.issuedAt).toBe(now)
 	expect(parsed?.session.rememberMe).toBe(false)
+	expect(
+		getAuthSessionExpiresAtMs({
+			rememberMe: false,
+			issuedAt: parsed?.issuedAt,
+			now,
+		}),
+	).toBe(now + 7 * 24 * 60 * 60 * 1000)
+	expect(
+		getAuthSessionExpiresAtMs({
+			rememberMe: true,
+			issuedAt: now - 24 * 60 * 60 * 1000,
+			now,
+		}),
+	).toBe(now + 29 * 24 * 60 * 60 * 1000)
 })
 
 test('legacy numeric-id session cookies fail closed', async () => {

--- a/packages/worker/src/app/auth-session.ts
+++ b/packages/worker/src/app/auth-session.ts
@@ -83,6 +83,23 @@ function getSessionMaxAgeSeconds(session: Pick<AuthSession, 'rememberMe'>) {
 		: defaultSessionMaxAgeSeconds
 }
 
+/**
+ * Absolute expiry of a `kody_session`. Missing `issuedAt` (legacy cookies)
+ * is treated as issued now, so remaining time is a full TTL rather than
+ * failing closed and stranding a still-valid browser session.
+ */
+export function getAuthSessionExpiresAtMs(input: {
+	rememberMe: boolean
+	issuedAt: number | undefined
+	now?: number
+}) {
+	const now = input.now ?? Date.now()
+	const issuedAt = input.issuedAt ?? now
+	return (
+		issuedAt + getSessionMaxAgeSeconds({ rememberMe: input.rememberMe }) * 1000
+	)
+}
+
 function createStoredAuthSession(
 	session: AuthSession,
 	now: number,

--- a/packages/worker/src/app/package-app-handoff.node.test.ts
+++ b/packages/worker/src/app/package-app-handoff.node.test.ts
@@ -43,15 +43,29 @@ const claims = {
 }
 
 const expected = { username: claims.username, kodyId: claims.kodyId }
+const sessionExpiresAt = 1_800_000_000_000
+const consumed = { ...claims, sessionExpiresAt }
+
+function mintToken(
+	env: Env,
+	input: { now?: number; sessionExpiresAt?: number } = {},
+) {
+	return createPackageAppHandoffToken({
+		env,
+		claims,
+		sessionExpiresAt: input.sessionExpiresAt ?? sessionExpiresAt,
+		now: input.now,
+	})
+}
 
 test('handoff tokens are single use, short lived, and bound to one user and package', async () => {
 	silenceExpectedConsoleWarns(['Package app handoff rejected.'])
 	const env = createTestEnv()
 
-	const token = await createPackageAppHandoffToken({ env, claims })
+	const token = await mintToken(env)
 	await expect(
 		consumePackageAppHandoffToken({ env, token, expected }),
-	).resolves.toStrictEqual(claims)
+	).resolves.toStrictEqual(consumed)
 
 	// Burned on first use, so a token captured from browser history or a referrer
 	// cannot be replayed.
@@ -63,18 +77,14 @@ test('handoff tokens are single use, short lived, and bound to one user and pack
 	})
 
 	// Expired tokens fail closed, even unused ones.
-	const staleToken = await createPackageAppHandoffToken({
-		env,
-		claims,
-		now: Date.now() - 61_000,
-	})
+	const staleToken = await mintToken(env, { now: Date.now() - 61_000 })
 	await expect(
 		consumePackageAppHandoffToken({ env, token: staleToken, expected }),
 	).resolves.toBeNull()
 
 	// Tampering with the payload (for example to point at another user's package)
 	// invalidates the signature.
-	const freshToken = await createPackageAppHandoffToken({ env, claims })
+	const freshToken = await mintToken(env)
 	const [payload, signature] = freshToken.split('.')
 	expect(payload).toBeTruthy()
 	expect(signature).toBeTruthy()
@@ -103,10 +113,7 @@ test('handoff tokens are single use, short lived, and bound to one user and pack
 	const otherEnv = createTestEnv({
 		cookieSecret: 'ANOTHER_TEST_COOKIE_SECRET_32_CHARS_MINIMUM_OK',
 	})
-	const foreignToken = await createPackageAppHandoffToken({
-		env: otherEnv,
-		claims,
-	})
+	const foreignToken = await mintToken(otherEnv)
 	await expect(
 		consumePackageAppHandoffToken({ env, token: foreignToken, expected }),
 	).resolves.toBeNull()
@@ -114,7 +121,7 @@ test('handoff tokens are single use, short lived, and bound to one user and pack
 	// A token aimed at another package (or another user) is refused *without*
 	// being burned: it was never meant for this request, so a mistyped URL must
 	// not cost the owner the handoff they still hold.
-	const boundToken = await createPackageAppHandoffToken({ env, claims })
+	const boundToken = await mintToken(env)
 	for (const wrongTarget of [
 		{ username: 'someone-else', kodyId: claims.kodyId },
 		{ username: claims.username, kodyId: 'other-package' },
@@ -129,31 +136,37 @@ test('handoff tokens are single use, short lived, and bound to one user and pack
 	}
 	await expect(
 		consumePackageAppHandoffToken({ env, token: boundToken, expected }),
-	).resolves.toStrictEqual(claims)
+	).resolves.toStrictEqual(consumed)
 
 	// Replay protection needs KV; signature and expiry checks do not.
 	const envWithoutKv = createTestEnv({ kv: false })
-	const tokenWithoutKv = await createPackageAppHandoffToken({
-		env: envWithoutKv,
-		claims,
-	})
+	const tokenWithoutKv = await mintToken(envWithoutKv)
 	await expect(
 		consumePackageAppHandoffToken({
 			env: envWithoutKv,
 			token: tokenWithoutKv,
 			expected,
 		}),
-	).resolves.toStrictEqual(claims)
+	).resolves.toStrictEqual(consumed)
 
 	// Missing COOKIE_SECRET must throw rather than look like an invalid token,
 	// otherwise the visitor stays on the 403 page with `__kody_handoff` in the URL.
 	await expect(
 		consumePackageAppHandoffToken({
 			env: createTestEnv({ cookieSecret: '' }),
-			token: await createPackageAppHandoffToken({ env, claims }),
+			token: await mintToken(env),
 			expected,
 		}),
 	).rejects.toThrow(/COOKIE_SECRET/)
+
+	// A token whose parent session has already expired is refused even if the
+	// one-minute handoff window is still open.
+	const expiredParent = await mintToken(env, {
+		sessionExpiresAt: Date.now() - 1,
+	})
+	await expect(
+		consumePackageAppHandoffToken({ env, token: expiredParent, expected }),
+	).resolves.toBeNull()
 })
 
 test('the package-app session cookie is not interchangeable with the app session cookie', async () => {
@@ -164,17 +177,32 @@ test('the package-app session cookie is not interchangeable with the app session
 	// Secure requests get the `__Host-` prefixed name, which browsers only
 	// accept host-only (`Secure`, no `Domain`, `Path=/`): a sibling package-app
 	// subdomain cannot toss a `Domain`-wide cookie under this name.
+	const now = 1_700_000_000_000
+	const threeHoursMs = 3 * 60 * 60 * 1000
+	const expiresAt = now + threeHoursMs
 	const setCookie = await createPackageAppSessionCookie({
 		env,
 		session: { stableUserId: ownerStableUserId, username: 'owner' },
 		secure: true,
+		now,
+		expiresAt,
 	})
 	expect(setCookie).toContain('__Host-kody_pkg_session=')
 	expect(setCookie).toContain('HttpOnly')
 	expect(setCookie).toContain('SameSite=Lax')
 	expect(setCookie).toContain('Secure')
 	expect(setCookie).toContain('Path=/')
+	expect(setCookie).toContain('Max-Age=10800')
 	expect(setCookie).not.toContain('Domain=')
+
+	const rememberMeSetCookie = await createPackageAppSessionCookie({
+		env,
+		session: { stableUserId: ownerStableUserId, username: 'owner' },
+		secure: true,
+		now,
+		expiresAt: now + 30 * 24 * 60 * 60 * 1000,
+	})
+	expect(rememberMeSetCookie).toContain('Max-Age=2592000')
 
 	// Plain-HTTP local development falls back to an unprefixed name because
 	// browsers refuse `__Host-` cookies on insecure origins.
@@ -182,6 +210,8 @@ test('the package-app session cookie is not interchangeable with the app session
 		env,
 		session: { stableUserId: ownerStableUserId, username: 'owner' },
 		secure: false,
+		now,
+		expiresAt,
 	})
 	expect(insecureSetCookie).toContain('kody_pkg_session=')
 	expect(insecureSetCookie).not.toContain('__Host-')
@@ -191,6 +221,7 @@ test('the package-app session cookie is not interchangeable with the app session
 				headers: { Cookie: insecureSetCookie.split(';')[0] ?? '' },
 			}),
 			env,
+			now,
 		}),
 	).resolves.toMatchObject({
 		session: { stableUserId: ownerStableUserId, username: 'owner' },
@@ -206,10 +237,32 @@ test('the package-app session cookie is not interchangeable with the app session
 				headers: { Cookie: cookiePair },
 			}),
 			env,
+			now,
+		}),
+	).resolves.toMatchObject({
+		session: { stableUserId: ownerStableUserId, username: 'owner' },
+		expiresAt,
+	})
+	await expect(
+		readPackageAppSession({
+			request: new Request('https://owner.kodyapps.dev/packages/x', {
+				headers: { Cookie: cookiePair },
+			}),
+			env,
+			now: expiresAt - 1,
 		}),
 	).resolves.toMatchObject({
 		session: { stableUserId: ownerStableUserId, username: 'owner' },
 	})
+	await expect(
+		readPackageAppSession({
+			request: new Request('https://owner.kodyapps.dev/packages/x', {
+				headers: { Cookie: cookiePair },
+			}),
+			env,
+			now: expiresAt,
+		}),
+	).resolves.toBeNull()
 
 	// Same secret material, different derived signing key: replaying the
 	// package-app cookie value under the app session name does not authenticate.

--- a/packages/worker/src/app/package-app-handoff.node.test.ts
+++ b/packages/worker/src/app/package-app-handoff.node.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from 'vitest'
+import { createCookie } from 'remix/cookie'
+import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
 import {
 	createAuthCookie,
 	readParsedAuthSession,
@@ -167,6 +169,21 @@ test('handoff tokens are single use, short lived, and bound to one user and pack
 	await expect(
 		consumePackageAppHandoffToken({ env, token: expiredParent, expected }),
 	).resolves.toBeNull()
+
+	// Less than one second of parent TTL cannot become a cookie Max-Age, so
+	// consume refuses before burning the token.
+	const now = Date.now()
+	const subSecondParent = await mintToken(env, {
+		sessionExpiresAt: now + 500,
+	})
+	await expect(
+		consumePackageAppHandoffToken({
+			env,
+			token: subSecondParent,
+			expected,
+			now,
+		}),
+	).resolves.toBeNull()
 })
 
 test('the package-app session cookie is not interchangeable with the app session cookie', async () => {
@@ -291,6 +308,49 @@ test('the package-app session cookie is not interchangeable with the app session
 				headers: { Cookie: `kody_pkg_session=${appCookieValue}` },
 			}),
 			env,
+		}),
+	).resolves.toBeNull()
+
+	// Cookies minted before expiresAt existed keep the old 12 hour bound from
+	// issuedAt, so a copied value cannot be replayed after that window.
+	const legacyIssuedAt = now
+	const legacyExpiresAt = legacyIssuedAt + 12 * 60 * 60 * 1000
+	const legacyCookie = createCookie('kody_pkg_session', {
+		httpOnly: true,
+		sameSite: 'Lax',
+		path: '/',
+		secrets: [
+			await sha256Base64Url(`kody-package-app-session:v2:${cookieSecret}`),
+		],
+	})
+	const legacySetCookie = await legacyCookie.serialize(
+		JSON.stringify({
+			v: 2,
+			stableUserId: ownerStableUserId,
+			pkgUsername: 'owner',
+			issuedAt: legacyIssuedAt,
+		}),
+	)
+	const legacyPair = legacySetCookie.split(';')[0] ?? ''
+	await expect(
+		readPackageAppSession({
+			request: new Request('http://owner.packages.localhost/packages/x', {
+				headers: { Cookie: legacyPair },
+			}),
+			env,
+			now: legacyExpiresAt - 1,
+		}),
+	).resolves.toMatchObject({
+		session: { stableUserId: ownerStableUserId, username: 'owner' },
+		expiresAt: legacyExpiresAt,
+	})
+	await expect(
+		readPackageAppSession({
+			request: new Request('http://owner.packages.localhost/packages/x', {
+				headers: { Cookie: legacyPair },
+			}),
+			env,
+			now: legacyExpiresAt,
 		}),
 	).resolves.toBeNull()
 })

--- a/packages/worker/src/app/package-app-handoff.ts
+++ b/packages/worker/src/app/package-app-handoff.ts
@@ -3,6 +3,7 @@ import {
 	bytesToBase64Url,
 	utf8ToBase64Url,
 } from '@kody-internal/shared/base64.ts'
+import { remainingCookieMaxAgeSeconds } from '#app/package-app-session.ts'
 import { isStableUserId } from '#worker/user-id.ts'
 
 /**
@@ -182,7 +183,10 @@ export async function consumePackageAppHandoffToken(input: {
 	}
 	const sessionExpiresAt =
 		parsed.sessExp ?? now + missingSessionExpiryFallbackMs
-	if (sessionExpiresAt <= now) {
+	// Cookie Max-Age is whole seconds. Reject before the burn when the parent
+	// session has less than one second left, so a still-usable token is not
+	// consumed without a Set-Cookie.
+	if (remainingCookieMaxAgeSeconds(sessionExpiresAt, now) == null) {
 		console.warn('Package app handoff rejected.', { reason: 'expired' })
 		return null
 	}

--- a/packages/worker/src/app/package-app-handoff.ts
+++ b/packages/worker/src/app/package-app-handoff.ts
@@ -28,11 +28,18 @@ const handoffReplayKeyPrefix = 'package-app-handoff:'
 // Cloudflare KV enforces a 60 second minimum expiration TTL, which matches the
 // token lifetime.
 const handoffReplayTtlSeconds = 60
+// Tokens minted before `sessExp` existed fall back to the previous 12 hour
+// package-app cookie lifetime for the rolling-deploy overlap.
+const missingSessionExpiryFallbackMs = 60 * 60 * 12 * 1000
 
 export type PackageAppHandoffClaims = {
 	stableUserId: string
 	username: string
 	kodyId: string
+}
+
+export type ConsumedPackageAppHandoff = PackageAppHandoffClaims & {
+	sessionExpiresAt: number
 }
 
 type StoredHandoffPayload = {
@@ -42,6 +49,7 @@ type StoredHandoffPayload = {
 	pkg: string
 	exp: number
 	jti: string
+	sessExp?: number
 }
 
 function isStoredHandoffPayload(value: unknown): value is StoredHandoffPayload {
@@ -57,7 +65,11 @@ function isStoredHandoffPayload(value: unknown): value is StoredHandoffPayload {
 		typeof record.exp === 'number' &&
 		Number.isFinite(record.exp) &&
 		typeof record.jti === 'string' &&
-		record.jti.length > 0
+		record.jti.length > 0 &&
+		(record.sessExp === undefined ||
+			(typeof record.sessExp === 'number' &&
+				Number.isFinite(record.sessExp) &&
+				record.sessExp > 0))
 	)
 }
 
@@ -82,6 +94,7 @@ function signedMessage(payload: string) {
 export async function createPackageAppHandoffToken(input: {
 	env: Env
 	claims: PackageAppHandoffClaims
+	sessionExpiresAt: number
 	now?: number
 }) {
 	const now = input.now ?? Date.now()
@@ -93,6 +106,7 @@ export async function createPackageAppHandoffToken(input: {
 			pkg: input.claims.kodyId,
 			exp: now + handoffTokenTtlMs,
 			jti: crypto.randomUUID(),
+			sessExp: input.sessionExpiresAt,
 		} satisfies StoredHandoffPayload),
 	)
 	const signature = await crypto.subtle.sign(
@@ -121,7 +135,7 @@ export async function consumePackageAppHandoffToken(input: {
 	token: string
 	expected: Pick<PackageAppHandoffClaims, 'username' | 'kodyId'>
 	now?: number
-}): Promise<PackageAppHandoffClaims | null> {
+}): Promise<ConsumedPackageAppHandoff | null> {
 	const now = input.now ?? Date.now()
 	const [payload, signature, ...rest] = input.token.split('.')
 	if (!payload || !signature || rest.length > 0) {
@@ -166,6 +180,12 @@ export async function consumePackageAppHandoffToken(input: {
 		console.warn('Package app handoff rejected.', { reason: 'expired' })
 		return null
 	}
+	const sessionExpiresAt =
+		parsed.sessExp ?? now + missingSessionExpiryFallbackMs
+	if (sessionExpiresAt <= now) {
+		console.warn('Package app handoff rejected.', { reason: 'expired' })
+		return null
+	}
 	if (
 		parsed.usr !== input.expected.username ||
 		parsed.pkg !== input.expected.kodyId
@@ -194,5 +214,6 @@ export async function consumePackageAppHandoffToken(input: {
 		stableUserId: parsed.stableUserId,
 		username: parsed.usr,
 		kodyId: parsed.pkg,
+		sessionExpiresAt,
 	}
 }

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -27,7 +27,6 @@ import { resolvePackageAppOwnerByStableUserId } from '#app/package-app-owner.ts'
 import {
 	createPackageAppSessionCookie,
 	readPackageAppSession,
-	remainingCookieMaxAgeSeconds,
 } from '#app/package-app-session.ts'
 import {
 	type PackageAppPath,
@@ -357,6 +356,7 @@ async function handleUserSubdomainRequest(input: {
 
 	const handoffToken = url.searchParams.get(packageAppHandoffQueryParam)
 	if (handoffToken) {
+		const now = Date.now()
 		const claims = await consumePackageAppHandoffToken({
 			env,
 			token: handoffToken,
@@ -364,8 +364,9 @@ async function handleUserSubdomainRequest(input: {
 				username: packagePath.username,
 				kodyId: packagePath.kodyId,
 			},
+			now,
 		})
-		if (claims && remainingCookieMaxAgeSeconds(claims.sessionExpiresAt)) {
+		if (claims) {
 			return redirectResponse({
 				location: withoutHandoffToken(url).toString(),
 				status: 302,
@@ -377,6 +378,7 @@ async function handleUserSubdomainRequest(input: {
 					},
 					secure: isSecureRequest(request),
 					expiresAt: claims.sessionExpiresAt,
+					now,
 				}),
 			})
 		}

--- a/packages/worker/src/app/package-app-origin.ts
+++ b/packages/worker/src/app/package-app-origin.ts
@@ -13,7 +13,11 @@ import {
 } from '#worker/app-base-url.ts'
 import { redirectToLoginWhenUnauthenticated } from '#app/auth-redirect.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
-import { isSecureRequest } from '#app/auth-session.ts'
+import {
+	getAuthSessionExpiresAtMs,
+	isSecureRequest,
+	readParsedAuthSession,
+} from '#app/auth-session.ts'
 import {
 	consumePackageAppHandoffToken,
 	createPackageAppHandoffToken,
@@ -23,6 +27,7 @@ import { resolvePackageAppOwnerByStableUserId } from '#app/package-app-owner.ts'
 import {
 	createPackageAppSessionCookie,
 	readPackageAppSession,
+	remainingCookieMaxAgeSeconds,
 } from '#app/package-app-session.ts'
 import {
 	type PackageAppPath,
@@ -250,6 +255,11 @@ async function redirectAppOriginToPackageAppOrigin(input: {
 		return new Response('Saved package app not found.', { status: 404 })
 	}
 
+	const parsedSession = await readParsedAuthSession(request)
+	if (!parsedSession) {
+		return await redirectToLoginWhenUnauthenticated(request, env)
+	}
+
 	target.searchParams.set(
 		packageAppHandoffQueryParam,
 		await createPackageAppHandoffToken({
@@ -259,6 +269,10 @@ async function redirectAppOriginToPackageAppOrigin(input: {
 				username: user.username,
 				kodyId: packagePath.kodyId,
 			},
+			sessionExpiresAt: getAuthSessionExpiresAtMs({
+				rememberMe: parsedSession.session.rememberMe,
+				issuedAt: parsedSession.issuedAt,
+			}),
 		}),
 	)
 	return redirectResponse({ location: target.toString(), status: 302 })
@@ -351,7 +365,7 @@ async function handleUserSubdomainRequest(input: {
 				kodyId: packagePath.kodyId,
 			},
 		})
-		if (claims) {
+		if (claims && remainingCookieMaxAgeSeconds(claims.sessionExpiresAt)) {
 			return redirectResponse({
 				location: withoutHandoffToken(url).toString(),
 				status: 302,
@@ -362,6 +376,7 @@ async function handleUserSubdomainRequest(input: {
 						username: claims.username,
 					},
 					secure: isSecureRequest(request),
+					expiresAt: claims.sessionExpiresAt,
 				}),
 			})
 		}

--- a/packages/worker/src/app/package-app-origin.workers.test.ts
+++ b/packages/worker/src/app/package-app-origin.workers.test.ts
@@ -148,6 +148,13 @@ test('hosted package apps move to the owner subdomain behind a single-use handof
 	expect(packageSessionCookieHeader).toContain('Secure')
 	expect(packageSessionCookieHeader).toContain('Path=/')
 	expect(packageSessionCookieHeader).not.toContain('Domain=')
+	const packageSessionMaxAge = Number(
+		/Max-Age=(\d+)/.exec(packageSessionCookieHeader)?.[1],
+	)
+	// Fresh non-remember-me `kody_session` is 7 days; the exchanged cookie
+	// inherits that remaining time rather than a fixed 12-hour cap.
+	expect(packageSessionMaxAge).toBeGreaterThan(7 * 24 * 60 * 60 - 30)
+	expect(packageSessionMaxAge).toBeLessThanOrEqual(7 * 24 * 60 * 60)
 	const cleanLocation = new URL(handoffResponse.headers.get('Location') ?? '')
 	expect(cleanLocation.origin).toBe(ownerPackageAppOrigin)
 	expect(cleanLocation.searchParams.has(packageAppHandoffQueryParam)).toBe(

--- a/packages/worker/src/app/package-app-session.ts
+++ b/packages/worker/src/app/package-app-session.ts
@@ -24,12 +24,14 @@ import { isStableUserId } from '#worker/user-id.ts'
  *
  * It authorizes hosted package-app access for one user on that user's
  * package-app subdomain and nothing else; serving additionally requires the
- * session's username to match the subdomain being requested.
+ * session's username to match the subdomain being requested. Lifetime matches
+ * the remaining `kody_session` that minted the handoff, not a fixed cap.
  */
 
 const securePackageAppSessionCookieName = '__Host-kody_pkg_session'
 const insecurePackageAppSessionCookieName = 'kody_pkg_session'
-const packageAppSessionMaxAgeSeconds = 60 * 60 * 12
+/** Fallback Max-Age for handoff tokens minted before `sessExp` existed. */
+const legacyPackageAppSessionMaxAgeSeconds = 60 * 60 * 12
 const packageAppSessionSecretPurpose = 'kody-package-app-session:v2'
 
 export type PackageAppSession = {
@@ -42,11 +44,21 @@ type StoredPackageAppSession = {
 	stableUserId: string
 	pkgUsername: string
 	issuedAt: number
+	expiresAt?: number
 }
 
 export type ParsedPackageAppSession = {
 	session: PackageAppSession
 	issuedAt: number
+	expiresAt?: number
+}
+
+export function remainingCookieMaxAgeSeconds(
+	expiresAt: number,
+	now = Date.now(),
+) {
+	const remaining = Math.floor((expiresAt - now) / 1000)
+	return remaining > 0 ? remaining : null
 }
 
 let cachedCookies: {
@@ -69,7 +81,7 @@ async function getPackageAppSessionCookies(env: Env) {
 		httpOnly: true,
 		sameSite: 'Lax' as const,
 		path: '/',
-		maxAge: packageAppSessionMaxAgeSeconds,
+		maxAge: legacyPackageAppSessionMaxAgeSeconds,
 		secrets: [derivedSecret],
 	}
 	cachedCookies = {
@@ -107,7 +119,11 @@ function isStoredPackageAppSession(
 		record.pkgUsername.length > 0 &&
 		typeof record.issuedAt === 'number' &&
 		Number.isFinite(record.issuedAt) &&
-		record.issuedAt > 0
+		record.issuedAt > 0 &&
+		(record.expiresAt === undefined ||
+			(typeof record.expiresAt === 'number' &&
+				Number.isFinite(record.expiresAt) &&
+				record.expiresAt > 0))
 	)
 }
 
@@ -115,17 +131,24 @@ export async function createPackageAppSessionCookie(input: {
 	env: Env
 	session: PackageAppSession
 	secure: boolean
+	expiresAt: number
 	now?: number
 }) {
+	const now = input.now ?? Date.now()
+	const maxAge = remainingCookieMaxAgeSeconds(input.expiresAt, now)
+	if (maxAge == null) {
+		throw new Error('Package app session expiresAt is not in the future.')
+	}
 	const cookie = await getPackageAppSessionCookie(input.env, input.secure)
 	return await cookie.serialize(
 		JSON.stringify({
 			v: 2,
 			stableUserId: input.session.stableUserId,
 			pkgUsername: input.session.username,
-			issuedAt: input.now ?? Date.now(),
+			issuedAt: now,
+			expiresAt: input.expiresAt,
 		} satisfies StoredPackageAppSession),
-		{ secure: input.secure },
+		{ secure: input.secure, maxAge },
 	)
 }
 
@@ -143,17 +166,22 @@ export async function destroyPackageAppSessionCookie(input: {
 
 function parseStoredPackageAppSession(
 	stored: unknown,
+	now: number,
 ): ParsedPackageAppSession | null {
 	if (!stored || typeof stored !== 'string') return null
 	try {
 		const parsed: unknown = JSON.parse(stored)
 		if (!isStoredPackageAppSession(parsed)) return null
+		if (typeof parsed.expiresAt === 'number' && parsed.expiresAt <= now) {
+			return null
+		}
 		return {
 			session: {
 				stableUserId: parsed.stableUserId,
 				username: parsed.pkgUsername,
 			},
 			issuedAt: parsed.issuedAt,
+			expiresAt: parsed.expiresAt,
 		}
 	} catch {
 		return null
@@ -163,16 +191,20 @@ function parseStoredPackageAppSession(
 export async function readPackageAppSession(input: {
 	request: Request
 	env: Env
+	now?: number
 }): Promise<ParsedPackageAppSession | null> {
 	const cookieHeader = input.request.headers.get('Cookie')
 	if (!cookieHeader) return null
 
+	const now = input.now ?? Date.now()
 	const cookies = await getPackageAppSessionCookies(input.env)
 	const secureSession = parseStoredPackageAppSession(
 		await cookies.secureCookie.parse(cookieHeader),
+		now,
 	)
 	if (secureSession) return secureSession
 	return parseStoredPackageAppSession(
 		await cookies.insecureCookie.parse(cookieHeader),
+		now,
 	)
 }

--- a/packages/worker/src/app/package-app-session.ts
+++ b/packages/worker/src/app/package-app-session.ts
@@ -172,7 +172,10 @@ function parseStoredPackageAppSession(
 	try {
 		const parsed: unknown = JSON.parse(stored)
 		if (!isStoredPackageAppSession(parsed)) return null
-		if (typeof parsed.expiresAt === 'number' && parsed.expiresAt <= now) {
+		const expiresAt =
+			parsed.expiresAt ??
+			parsed.issuedAt + legacyPackageAppSessionMaxAgeSeconds * 1000
+		if (expiresAt <= now) {
 			return null
 		}
 		return {
@@ -181,7 +184,7 @@ function parseStoredPackageAppSession(
 				username: parsed.pkgUsername,
 			},
 			issuedAt: parsed.issuedAt,
-			expiresAt: parsed.expiresAt,
+			expiresAt,
 		}
 	} catch {
 		return null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Hosted package-app cookies should not invent their own lifetime. After a successful `__kody_handoff` exchange, `__Host-kody_pkg_session` should last only as long as the remaining `kody_session` that minted it.

## Why this is a tradeoff (and why it is still fine)

The previous **12-hour cap** was blast-radius control on a less-trusted origin (`{username}.kody.run` runs author-supplied JS; sibling subdomains are still same-site until PSL; logout on `kody.codes` cannot clear that host's cookies).

Matching parent remaining time means:

- a just-signed-in session can last **7 days**, or **30 days** with remember-me
- a nearly expired parent no longer gets a fresh 12-hour cookie that **outlives** `kody_session`

That longer remember-me window is the real cost. It is acceptable here because the cookie stays `httpOnly` + `__Host-` + derived secret, mutating requests still require a matching `Origin`, and every request still re-resolves the account (suspension / password-change revoke). Browser `Max-Age` alone is not a security control, so the snapshot is also stored as `expiresAt` and enforced on read.

This is a snapshot, not live sync: remember-me renewal on the app origin does not extend an already-issued package-app cookie. A later handoff mints a new snapshot.

## Summary

- Handoff tokens carry `sessExp` from the parent `kody_session` (`issuedAt` + 7d / 30d).
- The exchanged cookie's `Max-Age` is that remaining time.
- The cookie payload stores `expiresAt`; reads after that instant fail closed.
- Tokens minted before `sessExp` existed, and cookies minted before `expiresAt` existed, fall back to 12 hours from mint/`issuedAt`.
- Consume refuses (before the burn) when remaining parent time is under one second, so a token is not consumed without a `Set-Cookie`.

## Testing

- `npx vitest run` on `package-app-handoff.node.test.ts`, `auth-session.node.test.ts`, and `package-app-origin.workers.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `3d9f7107` · **Head:** `c7c54b2b`

**Classification:** extends — package-app session lifetime and handoff token payload change; `kody_session` itself is unchanged.

### Primitives touched

| Primitive      | Group    | Impact                                                                 |
| -------------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`       | surfaces | extends — handoff token carries `sessExp`; pkg cookie `Max-Age` + `expiresAt` follow parent remaining TTL |
| `app-sessions` | auth     | composes — reads `issuedAt` / `rememberMe` to compute parent expiry    |

### System map

A signed-in owner hitting the app-origin package path mints a handoff bound to the remaining `kody_session`; the package-app subdomain exchanges it for a host-scoped cookie that expires at the same instant.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appSessions["app-sessions<br/>Browser sessions"]:::touched
	appUi["app-ui<br/>Browser app"]:::extended
	appSessions -->|"remaining TTL into handoff sessExp"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant App as App origin
	participant Token as Handoff token
	participant Pkg as Package-app host
	App->>App: read kody_session remaining TTL
	App->>Token: mint with sessExp
	Token->>Pkg: consume __kody_handoff
	Pkg->>Pkg: Set-Cookie Max-Age + expiresAt
	Pkg->>Pkg: later reads fail after expiresAt
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Package-app cookie `Max-Age` | Fixed 12 hours | Remaining parent session (7d / 30d remember-me) |
| Server-side expiry | Browser `Max-Age` only | `expiresAt` in payload (legacy cookies: `issuedAt` + 12h), rejected on read |
| Handoff payload | `{ v, user, pkg, exp, jti }` | plus optional `sessExp` |

### Invariants

Per-user isolation is unchanged: the cookie is still `__Host-` / host-only, serving still requires username == subdomain == path owner, and every request still re-resolves the account (suspension / password-change revoke).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-484e44eb-3777-44ab-992b-390c65a3744e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-484e44eb-3777-44ab-992b-390c65a3744e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Package-app sessions now expire in line with the parent authentication session.
  * Expired handoff tokens and package-app sessions are rejected automatically.
  * Session cookies now apply accurate remaining lifetimes, including support for remember-me sessions.
  * Legacy handoff tokens continue to work with a 12-hour fallback expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->