### PR TITLE
Add Actions dispatch for production secret re-encrypt

### DIFF
--- a/.github/workflows/reencrypt-secrets.yml
+++ b/.github/workflows/reencrypt-secrets.yml
@@ -1,0 +1,63 @@
+name: 🔐 Re-encrypt pre-AAD secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Decrypt-verify without writes
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reencrypt-secrets
+  cancel-in-progress: false
+
+jobs:
+  reencrypt:
+    runs-on: ubuntu-latest
+    name: 🔐 Re-encrypt pre-AAD secrets
+    timeout-minutes: 10
+    steps:
+      - name: 🔐 POST /__maintenance/reencrypt-secrets
+        shell: bash
+        env:
+          CAPABILITY_REINDEX_SECRET: ${{ secrets.CAPABILITY_REINDEX_SECRET }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CAPABILITY_REINDEX_SECRET:-}" ]; then
+            echo "CAPABILITY_REINDEX_SECRET is not set." >&2
+            exit 1
+          fi
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            body='{"dryRun":true}'
+          else
+            body='{}'
+          fi
+
+          echo "POST https://kody.codes/__maintenance/reencrypt-secrets"
+          echo "dryRun=${DRY_RUN}"
+
+          status="$(curl --silent --show-error --location --max-time 180 \
+            -X POST \
+            -H "Authorization: Bearer ${CAPABILITY_REINDEX_SECRET}" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            --data "${body}" \
+            --output reencrypt.json \
+            --write-out "%{http_code}" \
+            "https://kody.codes/__maintenance/reencrypt-secrets")"
+
+          STATUS="${status}" node -e '
+            const fs = require("node:fs");
+            const status = Number(process.env.STATUS);
+            const json = JSON.parse(fs.readFileSync("reencrypt.json", "utf8"));
+            console.log(JSON.stringify({ status, ...json }, null, 2));
+            if (status < 200 || status >= 300 || json.ok !== true) {
+              process.exit(1);
+            }
+          '

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -74,10 +74,10 @@ dual-reads both shapes; user-facing reads never rewrite. The operator pass
 upgrades remaining 2-part rows in place without rotating `SECRET_STORE_KEY`.
 
 `POST /__maintenance/reencrypt-secrets` (bearer `CAPABILITY_REINDEX_SECRET`).
-Operators with Actions access dispatch
-`.github/workflows/reencrypt-secrets.yml` (`dry_run` defaults to true) so the
-bearer never leaves GitHub Actions. Direct curl against `https://kody.codes`
-is equivalent when the secret is already on the operator machine.
+Operators with Actions access dispatch `.github/workflows/reencrypt-secrets.yml`
+(`dry_run` defaults to true) so the bearer never leaves GitHub Actions. Direct
+curl against `https://kody.codes` is equivalent when the secret is already on
+the operator machine.
 
 The pass:
 

--- a/docs/contributing/secret-rotation.md
+++ b/docs/contributing/secret-rotation.md
@@ -73,7 +73,13 @@ Rows that still store `<iv>.<ciphertext>` have no AAD. `decryptWithKey`
 dual-reads both shapes; user-facing reads never rewrite. The operator pass
 upgrades remaining 2-part rows in place without rotating `SECRET_STORE_KEY`.
 
-`POST /__maintenance/reencrypt-secrets` (bearer `CAPABILITY_REINDEX_SECRET`):
+`POST /__maintenance/reencrypt-secrets` (bearer `CAPABILITY_REINDEX_SECRET`).
+Operators with Actions access dispatch
+`.github/workflows/reencrypt-secrets.yml` (`dry_run` defaults to true) so the
+bearer never leaves GitHub Actions. Direct curl against `https://kody.codes`
+is equivalent when the secret is already on the operator machine.
+
+The pass:
 
 1. Keyset-pages `secret_entries.encrypted_value`,
    `remote_connector_settings.encrypted_shared_secret`, and


### PR DESCRIPTION
## Intent

Give operators a way to run the production pre-AAD secret re-encrypt pass without copying `CAPABILITY_REINDEX_SECRET` onto a laptop. Kent authorized the pass; this workflow is the vehicle so the bearer stays in GitHub Actions.

Related: #1489. Does not rotate `SECRET_STORE_KEY`, does not delete dual-read, and does not change worker behavior.

## Summary

- Add `.github/workflows/reencrypt-secrets.yml` (`workflow_dispatch`, `dry_run` defaults **true**).
- POST `https://kody.codes/__maintenance/reencrypt-secrets` with the existing repo secret as bearer.
- Concurrency group `reencrypt-secrets` with `cancel-in-progress: false` so a write is not cancelled by a later dispatch.
- Document the dispatch path in `docs/contributing/secret-rotation.md`.

## Testing

- Workflow YAML is operator-only; no worker code change.
- After merge: dispatch **dry_run=true**, confirm counts (~173 scanned, no writes), then dispatch **dry_run=false**.
- Re-inventory APP_DB with `LIKE 'v2.%'` counts only (never ciphertext).

## System changes

Low risk: GitHub Actions + docs only. Classifier unmatched (no primitive code roots). Recap block follows in a PATCH.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `3d9f7107` · **Head:** `bb041f51`

**Classification:** composes — no primitives added or changed; this PR wires GitHub Actions to the existing maintenance route.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none — unmatched)_ | — | `.github/workflows/reencrypt-secrets.yml`, `docs/contributing/secret-rotation.md` |
| `secrets` | assistant | untouched context — existing `/__maintenance/reencrypt-secrets` decrypt/re-encrypt path |
| `d1-app-db` | storage | untouched context — existing pass writes ciphertext columns in APP_DB |

### System map

Operators dispatch the new workflow; Actions POSTs the already-shipped maintenance route, which dual-reads then re-encrypts APP_DB rows in place.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	secrets["secrets<br/>Secret references"]:::untouched
	d1AppDb["d1-app-db<br/>D1 app database"]:::untouched
	secrets -->|"existing POST /__maintenance/reencrypt-secrets"| d1AppDb
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Op as Operator
	participant GHA as reencrypt-secrets.yml
	participant Prod as kody.codes
	Op->>GHA: workflow_dispatch dry_run=true then false
	GHA->>Prod: POST /__maintenance/reencrypt-secrets
	Note over GHA: bearer stays in Actions secrets
	Prod-->>GHA: counts only (no ciphertext)
```

### Invariants

Per-user secret isolation is unchanged. Dual-read stays until the scheduled soak follow-up. `SECRET_STORE_KEY` is not rotated.

</details>

<!-- system-recap:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub Actions and docs only; no worker changes. A `dry_run=false` dispatch triggers the existing production ciphertext upgrade path, which was already available via curl.
> 
> **Overview**
> Adds a **manual GitHub Actions workflow** so operators can run the existing pre-AAD secret re-encrypt pass on production without putting `CAPABILITY_REINDEX_SECRET` on a laptop.
> 
> **`reencrypt-secrets.yml`** is `workflow_dispatch` with **`dry_run` defaulting to true** (sends `{"dryRun":true}`). A false dispatch POSTs `{}` to `https://kody.codes/__maintenance/reencrypt-secrets` with the repo secret as bearer, prints the JSON response, and fails unless HTTP 2xx and `ok: true`. Concurrency group **`reencrypt-secrets`** with **`cancel-in-progress: false`** avoids cancelling an in-flight write.
> 
> **`secret-rotation.md`** documents dispatching this workflow as the preferred operator path, with direct curl noted as equivalent when the bearer is already local.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb041f5147cc0f2a89c9a0980265c67135202237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->