### PR TITLE
Host a CIMD for Kody-as-MCP-client

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -519,6 +519,13 @@ routed from `packages/worker/src/index.ts`.
   `global_fetch_strictly_public` compatibility flag in
   `packages/worker/wrangler.jsonc` for SSRF safety; the provider only advertises
   `client_id_metadata_document_supported` when both are set.
+- Kody-as-client (user-added remote MCP servers) hosts its own CIMD at
+  `/oauth/client-metadata.json`. The document is origin-exact: `client_id`
+  matches the fetch URL, and `redirect_uris` lists
+  `{origin}/account/mcp-servers/oauth/callback`. The MCP client OAuth provider
+  sets `clientMetadataUrl` to the canonical HTTPS document URL so the SDK
+  prefers CIMD and falls back to DCR. Local `http` origins omit
+  `clientMetadataUrl`.
 - Supported scopes: `profile`, `email`
 - On `/oauth/authorize`, unauthenticated users can log in inline or via top-nav
   auth links; those links preserve the full authorize URL in `redirectTo` so

--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -38,8 +38,12 @@ the `/mcp` endpoint (where Kody is the server) and complements remote connectors
    `APP_BASE_URL`, not the request host) and starts connecting. Optional static
    Authorization headers from `bearerToken` are registered on the transport at
    the same time.
-2. If the server requires OAuth, the SDK performs dynamic client registration
-   and the connection parks in state `authenticating` with an `authUrl`.
+2. If the server requires OAuth, the MCP SDK uses Client ID Metadata Documents
+   when the authorization server advertises
+   `client_id_metadata_document_supported` and the callback origin is HTTPS:
+   Kody presents `{canonical-app-origin}/oauth/client-metadata.json` as
+   `client_id`. Otherwise it falls back to Dynamic Client Registration. The
+   connection parks in state `authenticating` with an `authUrl`.
 3. The user opens `authUrl` in the browser (surfaced in the account UI and by
    the `mcp_server_add` / `mcp_server_list` capabilities). The authorize link
    uses `rel="noopener noreferrer"` so browser Referer does not send Kody's
@@ -70,7 +74,9 @@ always looked up in the hub belonging to the signed-in user — cross-user
 callback replay finds no matching state.
 
 Providers that allowlist client origins or redirect URIs must permit the
-canonical app origin and the callback path above. See
+canonical app origin and the callback path above. CIMD-capable servers also
+fetch `{canonical-app-origin}/oauth/client-metadata.json`; that document's
+`client_id` matches its URL and lists the same redirect URI. See
 [Connect remote MCP servers](../../use/mcp-client-servers.md).
 
 ## Capability synthesis and invocation

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -43,10 +43,12 @@ Requests are handled in this order:
      package code never executes inline.
    - In confirmed local, preview, and test runtimes, an unset package-app origin
      is a no-op and package apps are served inline at step 9 below.
-1. Protected resource metadata (base path only, before `OAuthProvider`):
-   - `/.well-known/oauth-protected-resource` (`GET` / `HEAD` / `OPTIONS`)
-   - `/oauth/client-metadata.json` (`GET` / `HEAD` / `OPTIONS`) — Kody-as-client
-     CIMD. Served from the request origin so `client_id` matches the fetch URL.
+1. Public OAuth metadata (before `OAuthProvider`):
+   - Protected resource metadata (base path only):
+     `/.well-known/oauth-protected-resource` (`GET` / `HEAD` / `OPTIONS`)
+   - Client ID Metadata Document: `/oauth/client-metadata.json` (`GET` / `HEAD`
+     / `OPTIONS`) — Kody-as-client CIMD. Served from the request origin so
+     `client_id` matches the fetch URL.
 2. OAuth authorization endpoints:
    - `/oauth/authorize`
    - `/oauth/authorize-info`

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -45,6 +45,8 @@ Requests are handled in this order:
      is a no-op and package apps are served inline at step 9 below.
 1. Protected resource metadata (base path only, before `OAuthProvider`):
    - `/.well-known/oauth-protected-resource` (`GET` / `HEAD` / `OPTIONS`)
+   - `/oauth/client-metadata.json` (`GET` / `HEAD` / `OPTIONS`) — Kody-as-client
+     CIMD. Served from the request origin so `client_id` matches the fetch URL.
 2. OAuth authorization endpoints:
    - `/oauth/authorize`
    - `/oauth/authorize-info`

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -24,11 +24,18 @@ This is the inverse of [connecting your agent to Kody](./connect-your-agent.md)
 
 ## OAuth allowlists (common failure)
 
-When Kody connects, it registers as an OAuth client using:
+When Kody connects, it identifies itself as an OAuth client using:
 
 - **Client origin:** the deployment's canonical app origin (for hosted Kody,
   `https://kody.codes`)
 - **Redirect URI:** `{origin}/account/mcp-servers/oauth/callback`
+- **Client ID Metadata Document (HTTPS only):**
+  `{origin}/oauth/client-metadata.json`
+
+On HTTPS deployments, Kody presents that CIMD URL as `client_id` when the remote
+authorization server advertises `client_id_metadata_document_supported`.
+Otherwise it falls back to Dynamic Client Registration. Local `http` origins
+skip CIMD and use DCR only.
 
 Many authorization servers (including FusionAuth "authorized origins" / redirect
 URI settings, and other providers with similar allowlists) reject the authorize

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -18,10 +18,11 @@ OAuth request after verifying in another tab, then reconnect or approve again.
 ## Adding a remote MCP server fails with `Invalid origin uri` or redirect URI errors
 
 That message comes from the **remote** authorization server, not from Kody being
-unreachable. Kody registers as an OAuth client from the deployment origin and
-redirects to `{origin}/account/mcp-servers/oauth/callback`. Allow those values
-in the MCP server's identity provider (authorized origins / redirect URIs), then
-remove and re-add the server. See
+unreachable. Kody identifies as an OAuth client from the deployment origin,
+redirects to `{origin}/account/mcp-servers/oauth/callback`, and on HTTPS
+presents `{origin}/oauth/client-metadata.json` as its CIMD `client_id`. Allow
+those values in the MCP server's identity provider (authorized origins /
+redirect URIs / client metadata URL), then remove and re-add the server. See
 [Connect remote MCP servers](./mcp-client-servers.md).
 
 ## Search returns no good matches

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -18,11 +18,13 @@ OAuth request after verifying in another tab, then reconnect or approve again.
 ## Adding a remote MCP server fails with `Invalid origin uri` or redirect URI errors
 
 That message comes from the **remote** authorization server, not from Kody being
-unreachable. Kody identifies as an OAuth client from the deployment origin,
-redirects to `{origin}/account/mcp-servers/oauth/callback`, and on HTTPS
-presents `{origin}/oauth/client-metadata.json` as its CIMD `client_id`. Allow
-those values in the MCP server's identity provider (authorized origins /
-redirect URIs / client metadata URL), then remove and re-add the server. See
+unreachable. Kody identifies as an OAuth client from the deployment origin and
+redirects to `{origin}/account/mcp-servers/oauth/callback`. Allow those values
+in the MCP server's identity provider (authorized origins / redirect URIs). When
+the authorization server advertises `client_id_metadata_document_supported` and
+the callback origin is HTTPS, Kody also presents
+`{origin}/oauth/client-metadata.json` as its CIMD `client_id` — allowlist that
+URL only for CIMD-capable providers. Then remove and re-add the server. See
 [Connect remote MCP servers](./mcp-client-servers.md).
 
 ## Search returns no good matches

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -71,6 +71,7 @@ type AccountMcpServersPayload = {
 	username: string
 	oauthClientOrigin: string
 	oauthCallbackUrl: string
+	oauthClientMetadataUrl: string | null
 	servers: Array<McpServerListItem>
 	selectedServerId?: string
 }
@@ -203,6 +204,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 	let servers: Array<McpServerListItem> = []
 	let oauthClientOrigin = ''
 	let oauthCallbackUrl = ''
+	let oauthClientMetadataUrl: string | null = null
 	let addName = ''
 	let addUrl = ''
 	let addBearerToken = ''
@@ -248,6 +250,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 		servers = payload.servers
 		oauthClientOrigin = payload.oauthClientOrigin
 		oauthCallbackUrl = payload.oauthCallbackUrl
+		oauthClientMetadataUrl = payload.oauthClientMetadataUrl
 		deleteServerCheck.reset()
 	}
 
@@ -473,6 +476,9 @@ export function AccountMcpServersRoute(handle: Handle) {
 								client origins or redirect URIs (for example FusionAuth), add
 								{oauthClientOrigin ? ` ${oauthClientOrigin} and` : ''} this
 								exact callback before authorizing.
+								{oauthClientMetadataUrl
+									? " Servers that support Client ID Metadata Documents use the CIMD URL as Kody's client_id."
+									: ''}
 							</p>
 						</div>
 						<code
@@ -497,6 +503,33 @@ export function AccountMcpServersRoute(handle: Handle) {
 								size="sm"
 							/>
 						</div>
+						{oauthClientMetadataUrl ? (
+							<>
+								<span mix={css(fieldLabelCss)}>OAuth client metadata URL</span>
+								<code
+									mix={css({
+										padding: spacing.sm,
+										borderRadius: radius.md,
+										border: `1px solid ${colors.border}`,
+										backgroundColor: colors.background,
+										color: colors.text,
+										fontFamily: 'monospace',
+										fontSize: typography.fontSize.sm,
+										overflowWrap: 'anywhere',
+									})}
+								>
+									{oauthClientMetadataUrl}
+								</code>
+								<div>
+									<CopyTextButton
+										value={oauthClientMetadataUrl}
+										idleLabel="Copy CIMD URL"
+										variant="secondary"
+										size="sm"
+									/>
+								</div>
+							</>
+						) : null}
 					</section>
 				) : null}
 

--- a/packages/worker/src/app/account-mcp-servers-data.ts
+++ b/packages/worker/src/app/account-mcp-servers-data.ts
@@ -34,6 +34,7 @@ export async function loadAccountMcpServersData(input: {
 		username: input.user.username,
 		oauthClientOrigin: oauth.clientOrigin,
 		oauthCallbackUrl: oauth.callbackUrl,
+		oauthClientMetadataUrl: oauth.clientMetadataUrl,
 		servers: settings.map((setting) =>
 			buildMcpServerStatusView({
 				setting,

--- a/packages/worker/src/app/account-mcp-servers-data.ts
+++ b/packages/worker/src/app/account-mcp-servers-data.ts
@@ -43,6 +43,7 @@ export async function loadAccountMcpServersData(input: {
 					null,
 				oauthCallbackUrl: oauth.callbackUrl,
 				oauthClientOrigin: oauth.clientOrigin,
+				oauthClientMetadataUrl: oauth.clientMetadataUrl,
 			}),
 		),
 	}

--- a/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
@@ -352,7 +352,9 @@ test('MCP servers OAuth callback redirects with the auth outcome', async () => {
 		originFailureResponse.headers.get('Location') ?? '',
 	)
 	expect(originFailureLocation.searchParams.get('auth')).toBe('error')
-	expect(originFailureLocation.searchParams.get('reason')).toBeTruthy()
+	expect(originFailureLocation.searchParams.get('reason')).toContain(
+		'https://example.com/oauth/client-metadata.json',
+	)
 
 	mockModule.handleOAuthCallback.mockResolvedValueOnce({
 		serverId: 'server-1',

--- a/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.node.test.ts
@@ -136,6 +136,9 @@ vi.mock('#worker/mcp-client/settings-service.ts', () => ({
 		return {
 			clientOrigin,
 			callbackUrl: `${clientOrigin}/account/mcp-servers/oauth/callback`,
+			clientMetadataUrl: clientOrigin.startsWith('https:')
+				? `${clientOrigin}/oauth/client-metadata.json`
+				: null,
 		}
 	},
 }))
@@ -178,6 +181,7 @@ test('MCP servers API lists servers with live hub status', async () => {
 		username: 'test-user',
 		oauthClientOrigin: 'https://example.com',
 		oauthCallbackUrl: 'https://example.com/account/mcp-servers/oauth/callback',
+		oauthClientMetadataUrl: 'https://example.com/oauth/client-metadata.json',
 		servers: [
 			{
 				id: 'server-1',

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -470,6 +470,8 @@ function addOAuthDiscoveryCorsHeaders(
 	}
 	const headers = new Headers(response.headers)
 	headers.set('Access-Control-Allow-Origin', origin)
+	const vary = headers.get('Vary')
+	headers.set('Vary', vary ? `${vary}, Origin` : 'Origin')
 	headers.set('Access-Control-Allow-Methods', '*')
 	headers.set('Access-Control-Allow-Headers', 'Authorization, *')
 	headers.set('Access-Control-Max-Age', '86400')

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -32,6 +32,7 @@ import {
 	mcpResourcePath,
 	protectedResourceMetadataPath,
 } from './mcp-auth.ts'
+import { handleMcpClientIdMetadataRequest } from './mcp-client/client-id-metadata.ts'
 import {
 	handlePackageInvocationApiRequest,
 	isPackageInvocationApiRequest,
@@ -583,6 +584,11 @@ const workerHandler = {
 		// MCP clients must use `<origin>/mcp` as the resource (RFC 8707) to match our
 		// token audience; otherwise authorize stores origin but the token request sends
 		// `/mcp` → invalid_target. Serve the same document as the `/mcp` metadata path.
+		const clientIdMetadataResponse = handleMcpClientIdMetadataRequest(request)
+		if (clientIdMetadataResponse) {
+			return addOAuthDiscoveryCorsHeaders(clientIdMetadataResponse, request)
+		}
+
 		if (url.pathname === protectedResourceMetadataPath) {
 			if (request.method === 'OPTIONS') {
 				return addOAuthDiscoveryCorsHeaders(

--- a/packages/worker/src/mcp-client/client-id-metadata.node.test.ts
+++ b/packages/worker/src/mcp-client/client-id-metadata.node.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from 'vitest'
+import {
+	buildMcpClientIdMetadataDocument,
+	createMcpClientOAuthProvider,
+	handleMcpClientIdMetadataRequest,
+	mcpClientIdMetadataPath,
+	mcpClientName,
+	resolveMcpClientMetadataUrl,
+} from './client-id-metadata.ts'
+
+test('CIMD document is self-describing for the request origin', () => {
+	const origin = 'https://kody.codes'
+	const document = buildMcpClientIdMetadataDocument(`${origin}/ignored`)
+	expect(document).toEqual({
+		client_id: `${origin}${mcpClientIdMetadataPath}`,
+		client_name: mcpClientName,
+		client_uri: origin,
+		logo_uri: `${origin}/logo.png`,
+		redirect_uris: [`${origin}/account/mcp-servers/oauth/callback`],
+		grant_types: ['authorization_code', 'refresh_token'],
+		response_types: ['code'],
+		token_endpoint_auth_method: 'none',
+		application_type: 'web',
+	})
+	expect(document.client_id).toBe(
+		`${document.client_uri}${mcpClientIdMetadataPath}`,
+	)
+})
+
+test('CIMD URL is HTTPS-only so local http falls back to DCR', () => {
+	expect(
+		resolveMcpClientMetadataUrl(
+			'https://kody.codes/account/mcp-servers/oauth/callback',
+		),
+	).toBe('https://kody.codes/oauth/client-metadata.json')
+	expect(
+		resolveMcpClientMetadataUrl(
+			'http://localhost:8787/account/mcp-servers/oauth/callback',
+		),
+	).toBeUndefined()
+	expect(resolveMcpClientMetadataUrl('not-a-url')).toBeUndefined()
+})
+
+test('CIMD route serves JSON, HEAD, and OPTIONS for the request origin', async () => {
+	const documentUrl = `https://preview.example${mcpClientIdMetadataPath}`
+	const getResponse = handleMcpClientIdMetadataRequest(new Request(documentUrl))
+	expect(getResponse?.status).toBe(200)
+	expect(getResponse?.headers.get('Content-Type')).toBe('application/json')
+	const body = (await getResponse?.json()) as {
+		client_id: string
+		redirect_uris: Array<string>
+	}
+	expect(body.client_id).toBe(documentUrl)
+	expect(body.redirect_uris).toEqual([
+		'https://preview.example/account/mcp-servers/oauth/callback',
+	])
+
+	const headResponse = handleMcpClientIdMetadataRequest(
+		new Request(documentUrl, { method: 'HEAD' }),
+	)
+	expect(headResponse?.status).toBe(200)
+	expect(headResponse?.headers.get('Content-Type')).toBe('application/json')
+	expect(await headResponse?.text()).toBe('')
+
+	const optionsResponse = handleMcpClientIdMetadataRequest(
+		new Request(documentUrl, { method: 'OPTIONS' }),
+	)
+	expect(optionsResponse?.status).toBe(204)
+
+	expect(
+		handleMcpClientIdMetadataRequest(
+			new Request('https://preview.example/oauth/authorize'),
+		),
+	).toBeNull()
+	expect(
+		handleMcpClientIdMetadataRequest(
+			new Request(documentUrl, { method: 'POST' }),
+		),
+	).toBeNull()
+})
+
+test('OAuth provider presents CIMD on https callbacks and omits it on http', () => {
+	const storage = {} as DurableObjectStorage
+	const httpsProvider = createMcpClientOAuthProvider(
+		storage,
+		'https://kody.codes/account/mcp-servers/oauth/callback',
+	)
+	expect(httpsProvider.clientMetadataUrl).toBe(
+		'https://kody.codes/oauth/client-metadata.json',
+	)
+	expect(httpsProvider.clientMetadata.client_name).toBe(mcpClientName)
+	expect(httpsProvider.clientMetadata.redirect_uris).toEqual([
+		'https://kody.codes/account/mcp-servers/oauth/callback',
+	])
+
+	const httpProvider = createMcpClientOAuthProvider(
+		storage,
+		'http://127.0.0.1:8787/account/mcp-servers/oauth/callback',
+	)
+	expect(httpProvider.clientMetadataUrl).toBeUndefined()
+})

--- a/packages/worker/src/mcp-client/client-id-metadata.ts
+++ b/packages/worker/src/mcp-client/client-id-metadata.ts
@@ -1,0 +1,83 @@
+import { DurableObjectOAuthClientProvider } from 'agents/mcp/do-oauth-client-provider'
+
+export const mcpClientIdMetadataPath = '/oauth/client-metadata.json'
+export const mcpServerOAuthCallbackPath = '/account/mcp-servers/oauth/callback'
+export const mcpClientName = 'Kody'
+
+/**
+ * MCP clients MUST host CIMD at an HTTPS URL with a path. Local http
+ * origins stay on DCR: the SDK only uses `clientMetadataUrl` when the
+ * authorization server advertises CIMD support *and* this URL is HTTPS.
+ */
+export function resolveMcpClientMetadataUrl(callbackUrl: string) {
+	try {
+		const url = new URL(mcpClientIdMetadataPath, callbackUrl)
+		if (url.protocol !== 'https:') return undefined
+		return url.href
+	} catch {
+		return undefined
+	}
+}
+
+export function buildMcpClientIdMetadataDocument(origin: string) {
+	const clientOrigin = new URL(origin).origin
+	const clientId = `${clientOrigin}${mcpClientIdMetadataPath}`
+	return {
+		client_id: clientId,
+		client_name: mcpClientName,
+		client_uri: clientOrigin,
+		logo_uri: `${clientOrigin}/logo.png`,
+		redirect_uris: [`${clientOrigin}${mcpServerOAuthCallbackPath}`],
+		grant_types: ['authorization_code', 'refresh_token'],
+		response_types: ['code'],
+		token_endpoint_auth_method: 'none',
+		application_type: 'web',
+	}
+}
+
+export function isMcpClientIdMetadataRequest(pathname: string) {
+	return pathname === mcpClientIdMetadataPath
+}
+
+export function handleMcpClientIdMetadataRequest(request: Request) {
+	const url = new URL(request.url)
+	if (!isMcpClientIdMetadataRequest(url.pathname)) return null
+	if (request.method === 'OPTIONS') {
+		return new Response(null, {
+			status: 204,
+			headers: { 'Content-Length': '0' },
+		})
+	}
+	if (request.method !== 'GET' && request.method !== 'HEAD') return null
+
+	const body = JSON.stringify(buildMcpClientIdMetadataDocument(url.origin))
+	const headers = {
+		'Content-Type': 'application/json',
+		'Cache-Control': 'public, max-age=3600',
+	}
+	if (request.method === 'HEAD') {
+		return new Response(null, { status: 200, headers })
+	}
+	return new Response(body, { headers })
+}
+
+/**
+ * Agents SDK storage/PKCE provider plus the MCP SDK `clientMetadataUrl`
+ * hook. HTTPS callbacks present CIMD; http (local dev) omits it so auth
+ * falls back to DCR.
+ */
+export function createMcpClientOAuthProvider(
+	storage: DurableObjectStorage,
+	callbackUrl: string,
+) {
+	const provider = new DurableObjectOAuthClientProvider(
+		storage,
+		mcpClientName,
+		callbackUrl,
+	) as DurableObjectOAuthClientProvider & { clientMetadataUrl?: string }
+	const clientMetadataUrl = resolveMcpClientMetadataUrl(callbackUrl)
+	if (clientMetadataUrl) {
+		provider.clientMetadataUrl = clientMetadataUrl
+	}
+	return provider
+}

--- a/packages/worker/src/mcp-client/client-id-metadata.workers.test.ts
+++ b/packages/worker/src/mcp-client/client-id-metadata.workers.test.ts
@@ -23,3 +23,23 @@ test('worker serves Kody CIMD before the OAuth provider wrapper', async () => {
 		buildMcpClientIdMetadataDocument(origin),
 	)
 })
+
+test('CIMD CORS reflects Origin and varies the cache key', async () => {
+	const documentUrl = `https://kody.codes${mcpClientIdMetadataPath}`
+	const first = await workerFetch(
+		new Request(documentUrl, { headers: { Origin: 'https://as.example' } }),
+	)
+	const second = await workerFetch(
+		new Request(documentUrl, {
+			headers: { Origin: 'https://other-as.example' },
+		}),
+	)
+	expect(first.headers.get('Access-Control-Allow-Origin')).toBe(
+		'https://as.example',
+	)
+	expect(second.headers.get('Access-Control-Allow-Origin')).toBe(
+		'https://other-as.example',
+	)
+	expect(first.headers.get('Vary')?.split(/\s*,\s*/)).toContain('Origin')
+	expect(second.headers.get('Vary')?.split(/\s*,\s*/)).toContain('Origin')
+})

--- a/packages/worker/src/mcp-client/client-id-metadata.workers.test.ts
+++ b/packages/worker/src/mcp-client/client-id-metadata.workers.test.ts
@@ -1,0 +1,25 @@
+import { env, exports } from 'cloudflare:workers'
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { expect, test } from 'vitest'
+import {
+	buildMcpClientIdMetadataDocument,
+	mcpClientIdMetadataPath,
+} from './client-id-metadata.ts'
+
+async function workerFetch(request: Request) {
+	const ctx = createExecutionContext()
+	const response = await exports.default.fetch(request, env, ctx)
+	await waitOnExecutionContext(ctx)
+	return response
+}
+
+test('worker serves Kody CIMD before the OAuth provider wrapper', async () => {
+	const origin = 'https://kody.codes'
+	const documentUrl = `${origin}${mcpClientIdMetadataPath}`
+	const response = await workerFetch(new Request(documentUrl))
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Content-Type')).toBe('application/json')
+	await expect(response.json()).resolves.toEqual(
+		buildMcpClientIdMetadataDocument(origin),
+	)
+})

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -1,9 +1,12 @@
 import * as Sentry from '@sentry/cloudflare'
 import { DurableObject } from 'cloudflare:workers'
 import { MCPClientManager } from 'agents/mcp/client'
-import { DurableObjectOAuthClientProvider } from 'agents/mcp/do-oauth-client-provider'
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { buildSentryOptions } from '#worker/sentry-options.ts'
+import {
+	createMcpClientOAuthProvider,
+	mcpClientName,
+} from './client-id-metadata.ts'
 import {
 	isStuckMcpAuthenticatingWithoutAuthUrl,
 	resolveMcpOAuthCallbackOutcome,
@@ -17,7 +20,6 @@ import {
 	type McpServerToolDescriptor,
 } from './types.ts'
 
-const mcpClientName = 'Kody'
 const mcpClientVersion = '1.0.0'
 const connectionSettleTimeoutMs = 8_000
 const discoverTimeoutMs = 15_000
@@ -75,11 +77,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		this.manager = new MCPClientManager(mcpClientName, mcpClientVersion, {
 			storage: state.storage,
 			createAuthProvider: (callbackUrl) =>
-				new DurableObjectOAuthClientProvider(
-					state.storage,
-					mcpClientName,
-					callbackUrl,
-				),
+				createMcpClientOAuthProvider(state.storage, callbackUrl),
 		})
 	}
 
@@ -181,9 +179,8 @@ class McpClientHubBase extends DurableObject<Env> {
 		// DO-storage-backed provider here or OAuth servers can never surface an
 		// authorization URL. The clientName must match the one passed to
 		// `restoreConnectionsFromStorage` so storage keys line up after restarts.
-		const authProvider = new DurableObjectOAuthClientProvider(
+		const authProvider = createMcpClientOAuthProvider(
 			this.ctx.storage,
-			mcpClientName,
 			input.callbackUrl,
 		)
 		authProvider.serverId = input.serverId
@@ -412,9 +409,8 @@ class McpClientHubBase extends DurableObject<Env> {
 				clearClientRegistration: callbackChanged,
 			})
 
-			const authProvider = new DurableObjectOAuthClientProvider(
+			const authProvider = createMcpClientOAuthProvider(
 				this.ctx.storage,
-				mcpClientName,
 				input.callbackUrl,
 			)
 			authProvider.serverId = input.serverId
@@ -440,9 +436,8 @@ class McpClientHubBase extends DurableObject<Env> {
 					.catch(() => {})
 			}
 
-			const originalAuthProvider = new DurableObjectOAuthClientProvider(
+			const originalAuthProvider = createMcpClientOAuthProvider(
 				this.ctx.storage,
-				mcpClientName,
 				row.callback_url,
 			)
 			originalAuthProvider.serverId = input.serverId

--- a/packages/worker/src/mcp-client/oauth-provider-error.node.test.ts
+++ b/packages/worker/src/mcp-client/oauth-provider-error.node.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+import { enrichMcpOAuthProviderError } from './oauth-provider-error.ts'
+
+const oauth = {
+	clientOrigin: 'https://kody.codes',
+	callbackUrl: 'https://kody.codes/account/mcp-servers/oauth/callback',
+	clientMetadataUrl: 'https://kody.codes/oauth/client-metadata.json',
+}
+
+test('origin rejections include CIMD when Kody presents one', () => {
+	const message = enrichMcpOAuthProviderError(
+		'Invalid origin uri https://kody.codes',
+		oauth,
+	)
+	expect(message).toContain('Invalid origin uri https://kody.codes')
+	expect(message).toContain(oauth.clientOrigin)
+	expect(message).toContain(oauth.callbackUrl)
+	expect(message).toContain(oauth.clientMetadataUrl)
+})
+
+test('origin rejections omit CIMD when Kody is on DCR only', () => {
+	const message = enrichMcpOAuthProviderError(
+		'Invalid origin uri http://localhost:8787',
+		{
+			clientOrigin: 'http://localhost:8787',
+			callbackUrl: 'http://localhost:8787/account/mcp-servers/oauth/callback',
+			clientMetadataUrl: null,
+		},
+	)
+	expect(message).toContain('http://localhost:8787')
+	expect(message).not.toContain('CIMD')
+	expect(message).not.toContain('client-metadata.json')
+})
+
+test('unrelated OAuth errors stay unchanged', () => {
+	expect(enrichMcpOAuthProviderError('Invalid state.', oauth)).toBe(
+		'Invalid state.',
+	)
+})

--- a/packages/worker/src/mcp-client/oauth-provider-error.ts
+++ b/packages/worker/src/mcp-client/oauth-provider-error.ts
@@ -10,7 +10,11 @@
  */
 export function enrichMcpOAuthProviderError(
 	message: string,
-	input: { callbackUrl: string; clientOrigin: string },
+	input: {
+		callbackUrl: string
+		clientOrigin: string
+		clientMetadataUrl?: string | null
+	},
 ): string {
 	const trimmed = message.trim()
 	if (!trimmed) return trimmed
@@ -30,10 +34,13 @@ export function enrichMcpOAuthProviderError(
 		return trimmed
 	}
 
+	const allowlist = input.clientMetadataUrl
+		? `If you operate this MCP server (or its identity provider), allow that origin, register this exact redirect URI: ${input.callbackUrl}, and allowlist this CIMD client_id: ${input.clientMetadataUrl}.`
+		: `If you operate this MCP server (or its identity provider), allow that origin and register this exact redirect URI: ${input.callbackUrl}.`
 	const parts = [
 		trimmed,
 		`Kody authorizes as an OAuth client from ${input.clientOrigin}.`,
-		`If you operate this MCP server (or its identity provider), allow that origin and register this exact redirect URI: ${input.callbackUrl}.`,
+		allowlist,
 		'Then reconnect the server in Kody so authorization uses the allowlisted values.',
 	]
 	return parts.join(' ')

--- a/packages/worker/src/mcp-client/settings-service.node.test.ts
+++ b/packages/worker/src/mcp-client/settings-service.node.test.ts
@@ -112,6 +112,7 @@ test('resolveMcpServerOAuthClientUrls prefers APP_BASE_URL over the request host
 	).toEqual({
 		clientOrigin: 'https://heykody.app',
 		callbackUrl: 'https://heykody.app/account/mcp-servers/oauth/callback',
+		clientMetadataUrl: 'https://heykody.app/oauth/client-metadata.json',
 	})
 
 	expect(
@@ -122,6 +123,18 @@ test('resolveMcpServerOAuthClientUrls prefers APP_BASE_URL over the request host
 	).toEqual({
 		clientOrigin: 'https://preview.example',
 		callbackUrl: 'https://preview.example/account/mcp-servers/oauth/callback',
+		clientMetadataUrl: 'https://preview.example/oauth/client-metadata.json',
+	})
+
+	expect(
+		resolveMcpServerOAuthClientUrls({
+			env: {},
+			requestUrl: 'http://localhost:8787/account/mcp-servers',
+		}),
+	).toEqual({
+		clientOrigin: 'http://localhost:8787',
+		callbackUrl: 'http://localhost:8787/account/mcp-servers/oauth/callback',
+		clientMetadataUrl: null,
 	})
 })
 

--- a/packages/worker/src/mcp-client/settings-service.ts
+++ b/packages/worker/src/mcp-client/settings-service.ts
@@ -9,6 +9,10 @@ import {
 } from '@kody-internal/shared/mcp-servers.ts'
 import { getCanonicalAppBaseUrl } from '#worker/app-base-url.ts'
 import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
+import {
+	mcpServerOAuthCallbackPath,
+	resolveMcpClientMetadataUrl,
+} from './client-id-metadata.ts'
 import { createMcpClientHubClient } from './hub-client.ts'
 import {
 	deleteMcpServerSettingRow,
@@ -25,7 +29,7 @@ import {
 } from './settings-types.ts'
 import { type McpServerConnectResult } from './types.ts'
 
-export const mcpServerOAuthCallbackPath = '/account/mcp-servers/oauth/callback'
+export { mcpServerOAuthCallbackPath } from './client-id-metadata.ts'
 
 export function buildMcpServerOAuthCallbackUrl(baseUrl: string) {
 	const origin = baseUrl.trim().replace(/\/+$/, '')
@@ -36,8 +40,9 @@ export function buildMcpServerOAuthCallbackUrl(baseUrl: string) {
  * Stable OAuth client origin + callback for user-added MCP servers.
  *
  * Prefer the configured canonical `APP_BASE_URL` (not the request host) so
- * dynamic client registration always advertises one allowlistable redirect URI
- * during dual-host domain migrations.
+ * CIMD and DCR always advertise one allowlistable redirect URI during
+ * dual-host domain migrations. `clientMetadataUrl` is set only for HTTPS
+ * origins (MCP CIMD requires https).
  */
 export function resolveMcpServerOAuthClientUrls(input: {
 	env: { APP_BASE_URL?: string | null; PACKAGE_APP_BASE_URL?: string | null }
@@ -47,9 +52,11 @@ export function resolveMcpServerOAuthClientUrls(input: {
 		env: input.env,
 		requestUrl: input.requestUrl,
 	})
+	const callbackUrl = buildMcpServerOAuthCallbackUrl(clientOrigin)
 	return {
 		clientOrigin,
-		callbackUrl: buildMcpServerOAuthCallbackUrl(clientOrigin),
+		callbackUrl,
+		clientMetadataUrl: resolveMcpClientMetadataUrl(callbackUrl) ?? null,
 	}
 }
 

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-add.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-add.ts
@@ -19,6 +19,7 @@ const outputSchema = z.object({
 	error: z.string().nullable(),
 	oauthClientOrigin: z.string(),
 	oauthCallbackUrl: z.string(),
+	oauthClientMetadataUrl: z.string().nullable(),
 	nextStep: z.string(),
 })
 
@@ -27,7 +28,7 @@ export const mcpServerAddCapability = defineDomainCapability(
 	{
 		name: 'mcp_server_add',
 		description:
-			'Add a remote MCP server for the signed-in user and connect to it. Servers that require OAuth return an authUrl the user must open to authorize Kody; other servers connect immediately. Pass bearerToken for servers that authenticate with a static Authorization header instead of (or in addition to) OAuth. Connected server tools become kody.mcp["server-name"].tool_name(...) capabilities. When OAuth fails with origin or redirect URI errors, the remote authorization server must allow Kody\'s oauthClientOrigin and oauthCallbackUrl.',
+			'Add a remote MCP server for the signed-in user and connect to it. Servers that require OAuth return an authUrl the user must open to authorize Kody; other servers connect immediately. Pass bearerToken for servers that authenticate with a static Authorization header instead of (or in addition to) OAuth. Connected server tools become kody.mcp["server-name"].tool_name(...) capabilities. When OAuth fails with origin or redirect URI errors, the remote authorization server must allow Kody\'s oauthClientOrigin, oauthCallbackUrl, and oauthClientMetadataUrl (CIMD client_id) when present.',
 		keywords: [
 			'mcp',
 			'server',
@@ -89,7 +90,7 @@ export const mcpServerAddCapability = defineDomainCapability(
 				: null
 			const nextStep =
 				connection.state === 'authenticating' && connection.authUrl
-					? `The server requires OAuth authorization. Ask the user to open ${connection.authUrl} (also available from ${oauth.clientOrigin}/account/mcp-servers) to authorize Kody. If the provider rejects Kody's origin or redirect URI, they must allow ${oauth.clientOrigin} and ${oauth.callbackUrl}, then reconnect the server. After authorizing, check mcp_server_list.`
+					? `The server requires OAuth authorization. Ask the user to open ${connection.authUrl} (also available from ${oauth.clientOrigin}/account/mcp-servers) to authorize Kody. If the provider rejects Kody's origin, redirect URI, or CIMD client_id, they must allow ${oauth.clientOrigin}, ${oauth.callbackUrl}${oauth.clientMetadataUrl ? `, and ${oauth.clientMetadataUrl}` : ''}, then reconnect the server. After authorizing, check mcp_server_list.`
 					: connection.state === 'ready'
 						? `Connected with ${connection.toolCount} tool(s). Use search or meta_list_capabilities to discover kody.mcp["${setting.name}"] capabilities.`
 						: error
@@ -105,6 +106,7 @@ export const mcpServerAddCapability = defineDomainCapability(
 				error,
 				oauthClientOrigin: oauth.clientOrigin,
 				oauthCallbackUrl: oauth.callbackUrl,
+				oauthClientMetadataUrl: oauth.clientMetadataUrl,
 				nextStep,
 			}
 		},

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-list.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-list.ts
@@ -19,6 +19,7 @@ import {
 const outputSchema = z.object({
 	oauthClientOrigin: z.string(),
 	oauthCallbackUrl: z.string(),
+	oauthClientMetadataUrl: z.string().nullable(),
 	servers: z.array(mcpServerStatusSchema),
 })
 
@@ -55,6 +56,7 @@ export const mcpServerListCapability = defineDomainCapability(
 			return {
 				oauthClientOrigin: oauth.clientOrigin,
 				oauthCallbackUrl: oauth.callbackUrl,
+				oauthClientMetadataUrl: oauth.clientMetadataUrl,
 				servers: settings.map((setting) =>
 					buildMcpServerStatusView({
 						setting,

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-list.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-list.ts
@@ -66,6 +66,7 @@ export const mcpServerListCapability = defineDomainCapability(
 							) ?? null,
 						oauthCallbackUrl: oauth.callbackUrl,
 						oauthClientOrigin: oauth.clientOrigin,
+						oauthClientMetadataUrl: oauth.clientMetadataUrl,
 					}),
 				),
 			}

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-reconnect.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-reconnect.ts
@@ -17,6 +17,7 @@ const outputSchema = z.object({
 	error: z.string().nullable(),
 	oauthClientOrigin: z.string(),
 	oauthCallbackUrl: z.string(),
+	oauthClientMetadataUrl: z.string().nullable(),
 })
 
 export const mcpServerReconnectCapability = defineDomainCapability(
@@ -63,6 +64,7 @@ export const mcpServerReconnectCapability = defineDomainCapability(
 					: null,
 				oauthClientOrigin: oauth.clientOrigin,
 				oauthCallbackUrl: oauth.callbackUrl,
+				oauthClientMetadataUrl: oauth.clientMetadataUrl,
 			}
 		},
 	},

--- a/packages/worker/src/mcp/capabilities/mcp-servers/shared.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/shared.ts
@@ -32,6 +32,7 @@ export function buildMcpServerStatusView(input: {
 	snapshot: McpServerSnapshot | null
 	oauthCallbackUrl?: string
 	oauthClientOrigin?: string
+	oauthClientMetadataUrl?: string | null
 }): McpServerStatusView {
 	const { setting, snapshot } = input
 	const connected = snapshot?.state === 'ready'
@@ -41,6 +42,7 @@ export function buildMcpServerStatusView(input: {
 			? enrichMcpOAuthProviderError(rawError, {
 					callbackUrl: input.oauthCallbackUrl,
 					clientOrigin: input.oauthClientOrigin,
+					clientMetadataUrl: input.oauthClientMetadataUrl,
 				})
 			: rawError
 	return {

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -948,6 +948,8 @@ export type AccountMcpServersLoaderData = {
 	oauthClientOrigin: string
 	/** Exact redirect URI remote authorization servers must allow. */
 	oauthCallbackUrl: string
+	/** HTTPS CIMD URL Kody presents as client_id, or null on http origins. */
+	oauthClientMetadataUrl: string | null
 	servers: Array<AccountMcpServerListItem>
 }
 


### PR DESCRIPTION
## Summary
- Serve an origin-exact Client ID Metadata Document at `/oauth/client-metadata.json` so Kody can present a stable HTTPS `client_id` when connecting to remote MCP servers.
- Wire the Agents/MCP OAuth provider `clientMetadataUrl` on HTTPS callbacks (CIMD first, DCR fallback; local `http` stays on DCR).
- Surface the CIMD URL on `/account/mcp-servers` and in `mcp_server_list` / `mcp_server_add` / `mcp_server_reconnect`.

## Test plan
- [ ] `GET https://<origin>/oauth/client-metadata.json` returns JSON whose `client_id` matches the fetch URL and lists `{origin}/account/mcp-servers/oauth/callback`
- [ ] Account MCP servers page shows the CIMD URL on HTTPS
- [ ] Local `http` origins omit `clientMetadataUrl` / CIMD and still use DCR
- [ ] Existing DCR-registered remote servers keep working until re-added


Made with [Cursor](https://cursor.com)
<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `82e5d247` · **Head:** `94ac58e8`

**Classification:** extends — Kody-as-client now hosts a CIMD and presents that URL as `client_id` when the remote authorization server supports it.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | extends — HTTPS OAuth uses CIMD (`clientMetadataUrl`); DCR remains the fallback |
| `app-ui` | surfaces | composes — account MCP servers page shows the CIMD URL |
| `scheduled-cron` | surfaces | composes — worker `fetch` serves `/oauth/client-metadata.json` before `OAuthProvider` (`index.ts` is this primitive's root) |

### System map

Kody hosts a self-describing CIMD, presents that URL when connecting to a remote MCP server, and shows the same URL in the account UI.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	scheduledCron["scheduled-cron<br/>Scheduled handler"]:::touched
	mcpClientServers["mcp-client-servers<br/>MCP client servers"]:::extended
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	scheduledCron -->|"GET /oauth/client-metadata.json"| mcpClientServers
	mcpClientServers -->|"clientMetadataUrl on HTTPS callback"| mcpClientServers
	appUi -->|"oauthClientMetadataUrl on /account/mcp-servers"| mcpClientServers
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Hub as MCP client hub
	participant AS as Remote authorization server
	participant CIMD as /oauth/client-metadata.json
	Hub->>AS: discover metadata
	alt AS advertises CIMD and callback is HTTPS
		Hub->>AS: authorize with client_id = CIMD URL
		AS->>CIMD: GET metadata
		CIMD-->>AS: client_id + redirect_uris
	else otherwise
		Hub->>AS: RFC 7591 DCR
	end
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Client `client_id` | DCR-issued string | HTTPS CIMD URL when supported |
| Public document | none | `{origin}/oauth/client-metadata.json` |
| Local `http` | DCR | DCR (`clientMetadataUrl` omitted) |

</details>

<!-- system-recap:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OAuth Client ID Metadata Document support for remote MCP server connections on HTTPS deployments.
  - Displayed the client metadata URL in MCP server settings with a copy option.
  - Included the metadata URL in MCP server add, list, and reconnect responses.
  - Added a metadata endpoint supporting standard discovery requests.
  - Local HTTP deployments continue using Dynamic Client Registration without a metadata URL.
  - Improved OAuth error guidance when metadata URL allowlisting is required.

- **Documentation**
  - Updated setup, architecture, and troubleshooting guidance for metadata URLs, callback URLs, and OAuth allowlists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->