### PR TITLE
feat(packages): surface functions and referenced types on package_get

### DIFF
--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -185,8 +185,9 @@ exhaustive.
   can use any named exports that the module provides.
 - Packages may also export non-callable helper modules and values for reuse.
 - Add JSDoc to exported functions and, when helpful, point the export at a
-  `types` file. Package search detail surfaces package descriptions, export
-  descriptions, function signatures, JSDoc, and type definitions.
+  `types` file. Package search detail and `package_get` surface package
+  descriptions, export descriptions, function signatures, JSDoc, and type
+  definitions.
 
 ### Dynamic package invocation
 

--- a/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts
@@ -314,6 +314,15 @@ export declare function listEvents(calendarId: string): Promise<string[]>
 			description: 'List upcoming calendar events.',
 			type_definition:
 				'export declare function listEvents(calendarId: string): Promise<string[]>',
+			functions: [
+				{
+					name: 'listEvents',
+					description: 'List upcoming calendar events.',
+					type_definition:
+						'export declare function listEvents(calendarId: string): Promise<string[]>',
+				},
+			],
+			referenced_types: [],
 		}),
 	])
 	expect(mockModule.loadPackageSourceBySourceId).toHaveBeenCalledWith(
@@ -376,6 +385,8 @@ test('getPackageCapability leaves export contracts empty without projectable sou
 			types_path: 'src/list-events.d.ts',
 			description: null,
 			type_definition: null,
+			functions: [],
+			referenced_types: [],
 		}),
 	])
 
@@ -425,6 +436,105 @@ test('getPackageCapability leaves export contracts empty without projectable sou
 			runtime_target: 'src/index.ts',
 			description: null,
 			type_definition: null,
+			functions: [],
+			referenced_types: [],
 		}),
 	])
+})
+
+test('getPackageCapability projects functions and referenced_types for multi-function namespace exports', async () => {
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockReset()
+	mockModule.loadPackageSourceBySourceId.mockReset()
+	mockModule.getSavedPackageWithCommunityProvenanceById.mockResolvedValue({
+		id: 'package-1',
+		userId: 'user-1',
+		name: '@kentcdodds/google',
+		kodyId: 'google',
+		description: 'Google helpers',
+		tags: ['google', 'calendar'],
+		searchText: null,
+		sourceId: 'source-1',
+		hasApp: false,
+		hidden: false,
+		isPrivate: false,
+		sourceListingId: null,
+		listingCurrent: null,
+		listingKodyId: null,
+		createdAt: '2026-04-25T00:00:00.000Z',
+		updatedAt: '2026-04-26T00:00:00.000Z',
+	})
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		source: { id: 'source-1' },
+		manifest: {
+			name: '@kentcdodds/google',
+			exports: {
+				'./calendar': './src/calendar.ts',
+			},
+			kody: {
+				id: 'google',
+				description: 'Google helpers',
+				tags: ['google', 'calendar'],
+			},
+		},
+		files: {
+			'src/calendar.ts': `export type CalendarEventsParams = { account: string; calendarId?: string }
+export type CalendarEventsAcrossCalendarsParams = CalendarEventsParams & { calendarMaxResults?: number }
+
+export async function listEvents(params: CalendarEventsParams): Promise<{ items: Array<unknown> }> {
+	return { items: [] }
+}
+
+export async function listEventsAcrossCalendars(
+	params: CalendarEventsAcrossCalendarsParams,
+): Promise<{ items: Array<unknown>; calendars: Array<unknown>; failures: Array<string> }> {
+	return { items: [], calendars: [], failures: [] }
+}
+
+/**
+ * Return the Google Calendar helper namespace.
+ */
+export default function calendar() {
+	return { listEvents, listEventsAcrossCalendars }
+}
+`,
+		},
+	})
+
+	const result = await getPackageCapability.handler(
+		{ package_id: 'package-1' },
+		createCallerContext(),
+	)
+
+	const [calendarExport] = result.exports
+	expect(calendarExport).toMatchObject({
+		subpath: './calendar',
+		import_specifier: 'kody:@kentcdodds/google/calendar',
+		runtime_target: 'src/calendar.ts',
+		description: null,
+		type_definition: null,
+	})
+	expect(calendarExport?.functions.map((fn) => fn.name)).toEqual([
+		'listEvents',
+		'listEventsAcrossCalendars',
+		'default',
+	])
+	expect(calendarExport?.functions[0]?.type_definition).toContain(
+		'CalendarEventsParams',
+	)
+	expect(calendarExport?.functions[1]?.type_definition).toContain(
+		'CalendarEventsAcrossCalendarsParams',
+	)
+	expect(calendarExport?.functions[2]).toMatchObject({
+		name: 'default',
+		description: 'Return the Google Calendar helper namespace.',
+		type_definition: 'export default function calendar()',
+	})
+	expect(calendarExport?.referenced_types.map((type) => type.name)).toEqual([
+		'CalendarEventsParams',
+		'CalendarEventsAcrossCalendarsParams',
+	])
+	expect(calendarExport?.referenced_types[0]?.kind).toBe('type')
+	expect(calendarExport?.referenced_types[0]?.definition).toContain(
+		'account: string',
+	)
 })

--- a/packages/worker/src/mcp/capabilities/packages/get-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-package.ts
@@ -24,7 +24,7 @@ export const getPackageCapability = defineDomainCapability(
 	{
 		name: 'package_get',
 		description:
-			'Load one saved package metadata record for the signed-in user, including community-fork source listing provenance, ready-to-import export specifiers, and canonical owner-scoped external invocation URLs for each export.',
+			'Load one saved package metadata record for the signed-in user, including community-fork source listing provenance, ready-to-import export specifiers, callable export contracts, and canonical owner-scoped external invocation URLs for each export.',
 		keywords: [
 			'package',
 			'get',
@@ -112,6 +112,18 @@ export const getPackageCapability = defineDomainCapability(
 					types_path: exportDetail.typesPath,
 					description: exportDetail.description,
 					type_definition: exportDetail.typeDefinition,
+					functions: (exportDetail.functions ?? []).map((exportedFunction) => ({
+						name: exportedFunction.name,
+						description: exportedFunction.description,
+						type_definition: exportedFunction.typeDefinition,
+					})),
+					referenced_types: (exportDetail.referencedTypes ?? []).map(
+						(referencedType) => ({
+							name: referencedType.name,
+							kind: referencedType.kind,
+							definition: referencedType.definition,
+						}),
+					),
 					external_invocation: username
 						? (() => {
 								const descriptor = buildExternalPackageInvocationDescriptor({

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -147,7 +147,9 @@ export const packageExportSurfaceSchema = z.object({
 				type_definition: z
 					.string()
 					.nullable()
-					.describe('Function type signature parsed from source when available.'),
+					.describe(
+						'Function type signature parsed from source when available.',
+					),
 			}),
 		)
 		.describe(
@@ -164,7 +166,7 @@ export const packageExportSurfaceSchema = z.object({
 			}),
 		)
 		.describe(
-			'Type, interface, and enum definitions referenced by this export\'s callable functions.',
+			"Type, interface, and enum definitions referenced by this export's callable functions.",
 		),
 	external_invocation: z
 		.object({

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -130,7 +130,41 @@ export const packageExportSurfaceSchema = z.object({
 		.string()
 		.nullable()
 		.describe(
-			'Primary export type signature parsed from source when available.',
+			'Primary export type signature parsed from source when available. Null when the export has more than one callable function; use `functions` in that case.',
+		),
+	functions: z
+		.array(
+			z.object({
+				name: z
+					.string()
+					.describe(
+						'Exported function name. Default exports use the name "default".',
+					),
+				description: z
+					.string()
+					.nullable()
+					.describe('Function JSDoc description when available.'),
+				type_definition: z
+					.string()
+					.nullable()
+					.describe('Function type signature parsed from source when available.'),
+			}),
+		)
+		.describe(
+			'Callable functions extracted from this export. Namespace modules that export several helpers list each one here.',
+		),
+	referenced_types: z
+		.array(
+			z.object({
+				name: z.string(),
+				kind: z.enum(['type', 'interface', 'enum']),
+				definition: z
+					.string()
+					.describe('Source text of the referenced type, interface, or enum.'),
+			}),
+		)
+		.describe(
+			'Type, interface, and enum definitions referenced by this export\'s callable functions.',
 		),
 	external_invocation: z
 		.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Agents that inspect a saved package with `package_get` should see the same callable contracts search already extracts — including multi-function namespace exports such as `@kentcdodds/google/calendar`.

## Summary

- `package_get` now returns `functions` and `referenced_types` on each export, mapped from the existing search projection.
- Top-level `type_definition` stays null when an export has more than one callable function; helpers are listed on `functions` instead.
- Usage docs mention that `package_get` surfaces the same export contracts as package search detail.

This is the leftover from #1401 that #1430 deferred (no new export fields at the time). Spotify single-function exports were already typed after #1434; Calendar-style namespace modules were not.

## Testing

- `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/packages/get-package.node.test.ts` — 4 passed, including a Google Calendar-style namespace fixture.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `82e5d247` · **Head:** `8ba4f6ba`

**Classification:** extends — `package_get` adds `functions` and `referenced_types` to the saved-package inspect contract.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `saved-packages` | assistant | extends — `package_get` export surface now includes extracted functions and referenced types |

### System map

`package_get` maps the existing search projection onto its MCP output so inspect and search agree on multi-function exports.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint (/mcp)"]:::untouched
	savedPackages -->|"package_get functions + referenced_types"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart TD
	source["Export source + manifest"] --> projection["buildPackageSearchProjection"]
	projection --> inspect["package_get export surface"]
	inspect --> functions["functions[]"]
	inspect --> types["referenced_types[]"]
	inspect --> primary["type_definition when exactly one function"]
```

### Before / after

**Before** (`package_get` on `@kentcdodds/google` `./calendar`):

- `type_definition`: `null`
- `description`: `null`
- no per-helper list

**After:**

- `type_definition`: still `null` (more than one function)
- `functions`: `listEvents`, `listEventsAcrossCalendars`, `default`, …
- `referenced_types`: `CalendarEventsParams`, `CalendarEventsAcrossCalendarsParams`, …

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc90dc46-e671-41dc-a679-e54f77cb0c2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc90dc46-e671-41dc-a679-e54f77cb0c2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package details and search results now include callable export contracts with function names, descriptions, and type signatures.
  * Export information now includes referenced type, interface, and enum definitions.
  * Multiple functions within a single export are supported.

* **Documentation**
  * Updated package export documentation to describe the additional function and type information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->