### PR TITLE
fix(runtime): scale outbound fetch timeout to the sandbox budget

### DIFF
--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -132,10 +132,12 @@ several capabilities or package exports, branch on results, and return the final
 structured result. Split into multiple **execute** calls only when you need new
 user input, confirmation, or a result that changes the plan.
 
-Plain **execute** has a hard timeout (~90s by default). For multi-step or
-long-running work (>~60s, batch sweeps, migrations, polling loops), use one
-**execute** call to submit `workflows.create({ code, params })`, then inspect
-progress with `workflow_run_list` instead of chaining many MCP tool calls.
+Plain **execute** has a hard timeout (~90s by default). Sandbox outbound
+`fetch` is capped at 60s (30s under that budget) unless the caller passes a
+tighter `AbortSignal`. For multi-step or long-running work (>~60s, batch
+sweeps, migrations, polling loops), use one **execute** call to submit
+`workflows.create({ code, params })`, then inspect progress with
+`workflow_run_list` instead of chaining many MCP tool calls.
 Sandbox timeout errors state the enforced budget (for example
 `Execution timed out after 90s: …`) and carry a structured next step pointing at
 workflows.

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -132,13 +132,13 @@ several capabilities or package exports, branch on results, and return the final
 structured result. Split into multiple **execute** calls only when you need new
 user input, confirmation, or a result that changes the plan.
 
-Plain **execute** has a hard timeout (~90s by default). Sandbox outbound
-`fetch` is capped at 60s (30s under that budget) unless the caller passes a
-tighter `AbortSignal`. For multi-step or long-running work (>~60s, batch
-sweeps, migrations, polling loops), use one **execute** call to submit
+Plain **execute** has a hard timeout (~90s by default). Sandbox outbound `fetch`
+is capped at 60s (30s under that budget) unless the caller passes a tighter
+`AbortSignal`. For multi-step or long-running work (>~60s, batch sweeps,
+migrations, polling loops), use one **execute** call to submit
 `workflows.create({ code, params })`, then inspect progress with
-`workflow_run_list` instead of chaining many MCP tool calls.
-Sandbox timeout errors state the enforced budget (for example
+`workflow_run_list` instead of chaining many MCP tool calls. Sandbox timeout
+errors state the enforced budget (for example
 `Execution timed out after 90s: …`) and carry a structured next step pointing at
 workflows.
 

--- a/docs/use/workflows.md
+++ b/docs/use/workflows.md
@@ -9,9 +9,11 @@ polling loops, retryable steps, or work that may run longer than execute's
 timeout (~90s). Workflow-invoked package exports and inline workflow code get a
 longer sandbox budget (~4.5 minutes, under the Cloudflare Workflow step timeout)
 and run without the package-invocation idempotency ledger, so a step retry
-re-executes instead of replaying a cached timeout. The initial `execute` call
-should submit one `workflows.create`; inspect that workflow later with
-`workflow_run_list`, or cancel it with `workflow_run_cancel`.
+re-executes instead of replaying a cached timeout. Outbound `fetch` in that
+sandbox is capped ~30s under the same budget (~4 minutes), so a single slow
+upstream can finish without the execute-oriented 60s fetch deadline. The initial
+`execute` call should submit one `workflows.create`; inspect that workflow later
+with `workflow_run_list`, or cancel it with `workflow_run_cancel`.
 
 ```ts
 import { workflows } from 'kody:runtime'

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -412,6 +412,31 @@ test('createExecuteExecutor aligns dynamic worker compatibility with shared opti
 	expect(workerOptions).toMatchObject(createDynamicWorkerCompatibilityOptions())
 })
 
+test('createExecuteExecutor gives the fetch gateway a deadline under the sandbox budget', async () => {
+	const readGatewayProps = async (timeoutMs?: number | null) => {
+		const fakeLoader = createFakeWorkerLoader()
+		await createExecuteExecutor({
+			env: createExecutorTestEnv(fakeLoader.loader),
+			exports: createExecutorTestExports(),
+			gatewayProps: createGatewayProps('user-1'),
+			timeoutMs,
+		}).execute('async () => "ok"', [{ name: 'kody', fns: {} }])
+		const workerOptions = fakeLoader.createdOptions.get(fakeLoader.ids[0]!)
+		return (workerOptions?.globalOutbound as { props?: unknown } | undefined)
+			?.props
+	}
+
+	await expect(readGatewayProps()).resolves.toMatchObject({
+		outboundFetchTimeoutMs: 60_000,
+	})
+	await expect(readGatewayProps(270_000)).resolves.toMatchObject({
+		outboundFetchTimeoutMs: 240_000,
+	})
+	await expect(readGatewayProps(null)).resolves.toMatchObject({
+		outboundFetchTimeoutMs: 240_000,
+	})
+})
+
 test('explicit request budgets cap independent roots at four without blocking separate requests', async () => {
 	type BudgetState = {
 		active: number

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -14,7 +14,10 @@ import { sha256Base64Url } from '@kody-internal/shared/sha256.ts'
 import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { exports as workerExports } from 'cloudflare:workers'
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { type FetchGatewayProps } from '#mcp/fetch-gateway.ts'
+import {
+	outboundFetchTimeoutMsForExecutor,
+	type FetchGatewayProps,
+} from '#mcp/fetch-gateway.ts'
 import {
 	readBaseUrlHostname,
 	type RawFetchHostSink,
@@ -537,15 +540,19 @@ export function createExecuteExecutor(input: {
 		input.timeoutMs === null
 			? maxSupportedExecutorTimeoutMs
 			: (input.timeoutMs ?? 90_000)
+	const gatewayProps = {
+		...input.gatewayProps,
+		outboundFetchTimeoutMs: outboundFetchTimeoutMsForExecutor(timeout),
+	}
 	return createStableDynamicWorkerExecutor({
 		loader: input.env.LOADER,
 		timeout,
 		signal: input.signal,
 		globalOutbound: loopbackExports.KodyFetchGateway({
-			props: input.gatewayProps,
+			props: gatewayProps,
 		}),
 		modules: input.modules,
-		gatewayProps: input.gatewayProps,
+		gatewayProps,
 		appCommitSha: input.env.APP_COMMIT_SHA ?? null,
 		usageEnv: input.env,
 		rawFetchHostSink: input.rawFetchHostSink,

--- a/packages/worker/src/mcp/fetch-gateway.node.test.ts
+++ b/packages/worker/src/mcp/fetch-gateway.node.test.ts
@@ -1,9 +1,13 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { expect, test, vi } from 'vitest'
 import {
+	defaultOutboundFetchTimeoutMs,
 	executeGatewayFetch,
 	expandSecretPlaceholders,
+	outboundFetchTimeoutHeadroomMs,
+	outboundFetchTimeoutMsForExecutor,
 	secretResolutionHeaderName,
+	unboundedOutboundFetchTimeoutMs,
 } from '#mcp/fetch-gateway.ts'
 import {
 	parseHostApprovalRequiredBatchMessage,
@@ -863,6 +867,21 @@ test('gateway fetch metering never derives a hostname from expanded secret place
 	}
 })
 
+test('outbound fetch deadline stays 30s under the executor sandbox budget', () => {
+	expect(outboundFetchTimeoutMsForExecutor(90_000)).toBe(
+		defaultOutboundFetchTimeoutMs,
+	)
+	expect(outboundFetchTimeoutMsForExecutor(90_000)).toBe(
+		90_000 - outboundFetchTimeoutHeadroomMs,
+	)
+	expect(outboundFetchTimeoutMsForExecutor(270_000)).toBe(240_000)
+	expect(outboundFetchTimeoutMsForExecutor(300_000)).toBe(270_000)
+	expect(outboundFetchTimeoutMsForExecutor(2_147_483_647)).toBe(
+		unboundedOutboundFetchTimeoutMs,
+	)
+	expect(outboundFetchTimeoutMsForExecutor(10_000)).toBe(10_000)
+})
+
 test('fetch gateway aborts hung outbound fetches at the default deadline', async () => {
 	const fetchStub = vi.fn((_request: Request) => {
 		return new Promise<Response>((_resolve, reject) => {
@@ -898,4 +917,39 @@ test('fetch gateway aborts hung outbound fetches at the default deadline', async
 	expect(fetchStub).toHaveBeenCalledTimes(1)
 	const outbound = fetchStub.mock.calls[0]?.[0]
 	expect(outbound?.signal.aborted).toBe(true)
+})
+
+test('fetch gateway honors outboundFetchTimeoutMs from gateway props', async () => {
+	const fetchStub = vi.fn((_request: Request) => {
+		return new Promise<Response>((_resolve, reject) => {
+			_request.signal.addEventListener(
+				'abort',
+				() => {
+					reject(
+						_request.signal.reason ??
+							new DOMException('The operation was aborted.', 'AbortError'),
+					)
+				},
+				{ once: true },
+			)
+		})
+	})
+	const startedAtMs = Date.now()
+	await expect(
+		executeGatewayFetch({
+			env,
+			props: { ...props, outboundFetchTimeoutMs: 40 },
+			request: new Request('https://example.com/slow'),
+			globalFetch: fetchStub as unknown as typeof fetch,
+		}),
+	).rejects.toSatisfy((error: unknown) => {
+		const name =
+			error && typeof error === 'object' && 'name' in error
+				? String(error.name)
+				: ''
+		return name === 'TimeoutError' || name === 'AbortError'
+	})
+	expect(Date.now() - startedAtMs).toBeLessThan(500)
+	expect(fetchStub).toHaveBeenCalledTimes(1)
+	expect(fetchStub.mock.calls[0]?.[0]?.signal.aborted).toBe(true)
 })

--- a/packages/worker/src/mcp/fetch-gateway.ts
+++ b/packages/worker/src/mcp/fetch-gateway.ts
@@ -39,6 +39,13 @@ type FetchGatewayProps = {
 	 */
 	email: string | null
 	storageContext: StorageContext | null
+	/**
+	 * Per-sandbox outbound fetch deadline. Execute keeps the 60s default
+	 * (30s under the 90s sandbox). Long-lived surfaces such as workflows
+	 * raise this so a single slow upstream can finish under their larger
+	 * budget. `null` disables the gateway timeout (caller signal only).
+	 */
+	outboundFetchTimeoutMs?: number | null
 }
 export type { FetchGatewayProps }
 
@@ -57,10 +64,49 @@ export const secretResolutionHeaderName = 'x-kody-secret-resolution'
 
 /**
  * Default deadline for sandbox outbound `fetch` when the caller did not pass
- * a tighter `AbortSignal`. Kept under the execute sandbox budget (90s) so a
- * hung upstream cannot strand the whole evaluation past the host deadline.
+ * a tighter `AbortSignal`. Kept 30s under the default execute sandbox budget
+ * (90s) so a hung upstream cannot strand the whole evaluation past the host
+ * deadline.
  */
 export const defaultOutboundFetchTimeoutMs = 60_000
+
+/**
+ * Headroom between the executor sandbox budget and the outbound fetch
+ * deadline. Matches the default execute pair (90s sandbox / 60s fetch).
+ */
+export const outboundFetchTimeoutHeadroomMs = 30_000
+
+/**
+ * Hung-fetch cap when the sandbox itself is unbounded (persistent
+ * services). Matches the workflow sandbox (270s) minus
+ * {@link outboundFetchTimeoutHeadroomMs}.
+ */
+export const unboundedOutboundFetchTimeoutMs = 240_000
+
+const unboundedExecutorTimeoutMs = 2_147_483_647
+
+/**
+ * Outbound fetch deadline for a sandbox whose executor budget is
+ * `executorTimeoutMs`. Short execute budgets keep the historic 60s cap;
+ * workflow / service budgets raise it by the same 30s headroom so one slow
+ * HTTP call (for example Cursor `createAgent`) can finish.
+ */
+export function outboundFetchTimeoutMsForExecutor(executorTimeoutMs: number) {
+	if (
+		!Number.isFinite(executorTimeoutMs) ||
+		executorTimeoutMs >= unboundedExecutorTimeoutMs
+	) {
+		return unboundedOutboundFetchTimeoutMs
+	}
+	if (executorTimeoutMs <= 0) {
+		return defaultOutboundFetchTimeoutMs
+	}
+	const derived = executorTimeoutMs - outboundFetchTimeoutHeadroomMs
+	if (derived <= 0) {
+		return Math.min(executorTimeoutMs, defaultOutboundFetchTimeoutMs)
+	}
+	return Math.max(defaultOutboundFetchTimeoutMs, derived)
+}
 
 export class KodyFetchGateway extends WorkerEntrypoint<Env, FetchGatewayProps> {
 	async fetch(request: Request) {
@@ -69,8 +115,20 @@ export class KodyFetchGateway extends WorkerEntrypoint<Env, FetchGatewayProps> {
 			props: this.ctx.props,
 			request,
 			waitUntil: (promise) => this.ctx.waitUntil(promise),
+			timeoutMs: this.ctx.props.outboundFetchTimeoutMs,
 		})
 	}
+}
+
+function resolveOutboundFetchTimeoutMs(input: {
+	timeoutMs?: number | null
+	propsTimeoutMs?: number | null
+}): number | null {
+	if (input.timeoutMs === null) return null
+	if (input.timeoutMs !== undefined) return input.timeoutMs
+	if (input.propsTimeoutMs === null) return null
+	if (input.propsTimeoutMs !== undefined) return input.propsTimeoutMs
+	return defaultOutboundFetchTimeoutMs
 }
 
 function applyOutboundFetchTimeout(
@@ -103,10 +161,10 @@ export async function executeGatewayFetch(input: {
 	let outcome: 'success' | 'error' = 'success'
 	let response: Response | undefined
 	let meteredEntityId = readMeteredRequestHostname(input.request.url, null)
-	const timeoutMs =
-		input.timeoutMs === null
-			? null
-			: (input.timeoutMs ?? defaultOutboundFetchTimeoutMs)
+	const timeoutMs = resolveOutboundFetchTimeoutMs({
+		timeoutMs: input.timeoutMs,
+		propsTimeoutMs: input.props.outboundFetchTimeoutMs,
+	})
 
 	try {
 		// Daily outbound-fetch quota: every sandbox fetch leaves through


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the host from aborting legitimate long sandbox `fetch` calls in workflows. `sentry-triage` `./process-sentry-webhook` wraps Cursor `createAgent` (POST `/v1/agents`). That SDK has no `AbortSignal`, and sample workflow run `9ca19b2d` lasted 65734ms then failed with `The operation was aborted due to timeout` — the fetch gateway's execute-oriented 60s cap, not a Cursor or package abort.

## Summary

- Derive the fetch-gateway deadline from the executor sandbox budget, keeping the same 30s headroom as execute (90s sandbox / 60s fetch).
- Workflow sandboxes (270s) now get a 240s outbound fetch deadline so a single slow upstream can finish.
- Unbounded persistent-service sandboxes keep a 240s hung-fetch cap.
- Execute behavior is unchanged (60s).
- Usage docs state the execute 60s fetch cap and the workflow ~4 minute fetch budget.

## Testing

- `npx vitest run --project node-unit packages/worker/src/mcp/fetch-gateway.node.test.ts packages/worker/src/mcp/executor.node.test.ts` — 35 passed (budget math, props-honored abort, executor wiring for default / 270s / unbounded).
- CI Static failed on `oxfmt` wrapping in `docs/use/execute.md`; fixed in `0cf28aac`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `448ca94a` · **Head:** `0cf28aac`

**Classification:** extends — the fetch gateway's outbound deadline is no longer a fixed 60s; it scales with the executor sandbox budget.

### Primitives touched

| Primitive    | Group    | Impact                                                                 |
| ------------ | -------- | ---------------------------------------------------------------------- |
| `mcp-server` | surfaces | extends — `KodyFetchGateway` deadline follows the executor timeout     |

### System map

Workflow (and other long-budget) sandboxes pass their executor timeout into the fetch gateway so one slow outbound `fetch` can use that budget minus 30s headroom.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	workflows["workflows<br/>Workflows"]:::untouched
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	workflows -->|"workflowExecutorTimeoutMs 270s"| mcpServer
	mcpServer -->|"outboundFetchTimeoutMs 240s on sandbox fetch"| workflows
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Surface   | Sandbox budget | Outbound fetch deadline |
| --------- | -------------- | ----------------------- |
| execute   | 90s            | 60s (unchanged)         |
| workflow  | 270s           | 60s → 240s              |
| unbounded | none           | 60s → 240s hung-fetch cap |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f79af95-d16c-4fc2-b2a6-2462f2ff79cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f79af95-d16c-4fc2-b2a6-2462f2ff79cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

