### PR TITLE
fix(packages): rebuild artifacts after external publish

### DIFF
--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -152,6 +152,8 @@ const mockModule = vi.hoisted(() => {
 			},
 		})),
 		writePublishedSourceSnapshot: vi.fn(async () => 'snapshot-key'),
+		loadPublishedSourceSnapshot: vi.fn(async () => null),
+		loadPublishedSourceManifestSnapshot: vi.fn(async () => null),
 		validatePackageBundles: vi.fn(async () => ({
 			ok: true,
 			message: 'Bundled 2 package target(s) successfully.',
@@ -269,6 +271,8 @@ function restoreRepoSessionMockBaseline() {
 		},
 	})
 	mockModule.writePublishedSourceSnapshot.mockResolvedValue('snapshot-key')
+	mockModule.loadPublishedSourceSnapshot.mockResolvedValue(null)
+	mockModule.loadPublishedSourceManifestSnapshot.mockResolvedValue(null)
 	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(false)
 	mockModule.persistPublishedPackageArtifactTarget.mockResolvedValue(
 		'kv:artifact',
@@ -497,6 +501,10 @@ vi.mock('#worker/package-runtime/published-runtime-artifacts.ts', async () => {
 		...actual,
 		writePublishedSourceSnapshot: (...args: Array<unknown>) =>
 			mockModule.writePublishedSourceSnapshot(...args),
+		loadPublishedSourceSnapshot: (...args: Array<unknown>) =>
+			mockModule.loadPublishedSourceSnapshot(...args),
+		loadPublishedSourceManifestSnapshot: (...args: Array<unknown>) =>
+			mockModule.loadPublishedSourceManifestSnapshot(...args),
 	}
 })
 
@@ -2228,4 +2236,116 @@ test('stagePublishedPackageArtifactRebuild collects workspace files once and sta
 		'index.ts': 'export const ready = true\n',
 	})
 	expect(mockModule.workspaceGlob).toHaveBeenCalledTimes(1)
+})
+
+test('listPublishedPackageArtifactTargets falls back to the published snapshot when the session workspace is empty', async () => {
+	restoreRepoSessionMockBaseline()
+	mockModule.workspaceReadFile.mockResolvedValue(null)
+	const packageJson =
+		'{"name":"@kody/demo","exports":{".":"./index.ts"},"kody":{"id":"demo","description":"Demo"}}'
+	mockModule.loadPublishedSourceManifestSnapshot.mockResolvedValue({
+		version: 1,
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		manifestPath: 'package.json',
+		manifestContent: packageJson,
+		createdAt: '2026-08-17T20:00:00.000Z',
+	})
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-1',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		external_check_until: null,
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	})
+
+	const session = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+	} as unknown as Env)
+	const targets = await session.listPublishedPackageArtifactTargets({
+		sourceId: 'source-1',
+		userId: 'user-1',
+	})
+	expect(targets).toEqual([
+		{
+			kind: 'module',
+			artifactName: '.',
+			entryPoint: 'index.ts',
+			bundleKind: 'module',
+		},
+		{
+			kind: 'importable-module',
+			artifactName: '.',
+			entryPoint: 'index.ts',
+			bundleKind: 'importable-module',
+		},
+	])
+	expect(mockModule.loadPublishedSourceManifestSnapshot).toHaveBeenCalledTimes(
+		1,
+	)
+})
+
+test('stagePublishedPackageArtifactRebuild falls back to the published snapshot when the session workspace is empty', async () => {
+	restoreRepoSessionMockBaseline()
+	mockModule.workspaceGlob.mockResolvedValue([])
+	mockModule.workspaceReadFile.mockResolvedValue(null)
+	const packageJson =
+		'{"name":"@kody/demo","exports":{".":"./index.ts"},"kody":{"id":"demo","description":"Demo"}}'
+	const snapshotFiles = {
+		'package.json': packageJson,
+		'index.ts': 'export const ready = true\n',
+	}
+	mockModule.loadPublishedSourceSnapshot.mockResolvedValue({
+		version: 1,
+		sourceId: 'source-1',
+		repoId: 'package-package-1',
+		entityKind: 'package',
+		entityId: 'package-1',
+		publishedCommit: 'commit-1',
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		files: snapshotFiles,
+		createdAt: '2026-08-17T20:00:00.000Z',
+	})
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-1',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		external_check_until: null,
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	})
+
+	const put = vi.fn(async () => undefined)
+	const session = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: { put },
+	} as unknown as Env)
+	const staged = await session.stagePublishedPackageArtifactRebuild({
+		sourceId: 'source-1',
+		userId: 'user-1',
+	})
+	const payload = JSON.parse(put.mock.calls[0]?.[1] as string) as {
+		sourceFiles: Record<string, string>
+	}
+	expect(payload.sourceFiles).toEqual(snapshotFiles)
+	expect(mockModule.loadPublishedSourceSnapshot).toHaveBeenCalledTimes(1)
+	expect(
+		staged.stagingKey.startsWith('repo-artifact-rebuild-staging:v1:user-1:'),
+	).toBe(true)
 })

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -39,6 +39,10 @@ import {
 	persistPublishedPackageArtifactTarget,
 	type PublishedPackageArtifactBuildTarget,
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
+import {
+	loadPublishedSourceManifestSnapshot,
+	loadPublishedSourceSnapshot,
+} from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { searchRepoWorkspace } from './repo-session-search.ts'
 import { repoSessionRpc as createRepoSessionRpc } from './repo-session-rpc.ts'
 import {
@@ -794,13 +798,75 @@ class RepoSessionBase extends DurableObject<Env> {
 
 	private async listPackageArtifactTargetsForSource(source: EntitySourceRow) {
 		if (source.entity_kind !== 'package') return []
-		const manifest = await this.readManifestFromWorkspace(
-			source.manifest_path,
-			source.entity_kind,
-		)
+		const manifest = await this.readPackageManifestForPublishedArtifacts(source)
 		return collectPublishedPackageArtifactTargets(
 			manifest as Parameters<typeof collectPublishedPackageArtifactTargets>[0],
 		)
+	}
+
+	/**
+	 * External publish (KODY-CLOUDFLARE-57) clones into ephemeral FS and never
+	 * populates the session Durable Object workspace. Artifact rebuild then
+	 * runs against that empty session, so listing and staging must fall back
+	 * to the published source snapshot written during finalize.
+	 */
+	private async readPackageManifestForPublishedArtifacts(
+		source: EntitySourceRow,
+	) {
+		const workspaceContent = await this.workspace.readFile(
+			resolveRepoWorkspacePath(
+				source.manifest_path,
+				repoSessionWorkspacePrefix,
+			),
+		)
+		if (typeof workspaceContent === 'string') {
+			return parseAuthoredPackageJson({
+				content: workspaceContent,
+				manifestPath: source.manifest_path,
+			})
+		}
+		const manifestSnapshot = await loadPublishedSourceManifestSnapshot({
+			env: this.env,
+			userId: source.user_id,
+			source,
+		})
+		if (typeof manifestSnapshot?.manifestContent === 'string') {
+			return parseAuthoredPackageJson({
+				content: manifestSnapshot.manifestContent,
+				manifestPath: source.manifest_path,
+			})
+		}
+		const snapshot = await loadPublishedSourceSnapshot({
+			env: this.env,
+			userId: source.user_id,
+			source,
+		})
+		const snapshotContent = snapshot?.files[source.manifest_path]
+		if (typeof snapshotContent === 'string') {
+			return parseAuthoredPackageJson({
+				content: snapshotContent,
+				manifestPath: source.manifest_path,
+			})
+		}
+		throw new Error(`Manifest "${source.manifest_path}" was not found.`)
+	}
+
+	private async collectSourceFilesForPublishedArtifactRebuild(
+		source: EntitySourceRow,
+	) {
+		const workspaceFiles = await this.collectWorkspaceFiles()
+		if (typeof workspaceFiles[source.manifest_path] === 'string') {
+			return workspaceFiles
+		}
+		const snapshot = await loadPublishedSourceSnapshot({
+			env: this.env,
+			userId: source.user_id,
+			source,
+		})
+		if (snapshot && typeof snapshot.files[source.manifest_path] === 'string') {
+			return snapshot.files
+		}
+		throw new Error(`Manifest "${source.manifest_path}" was not found.`)
 	}
 
 	async initialize(input: {
@@ -2191,7 +2257,8 @@ class RepoSessionBase extends DurableObject<Env> {
 				'BUNDLE_ARTIFACTS_KV binding is required to stage published package artifact rebuilds.',
 			)
 		}
-		const sourceFiles = await this.collectWorkspaceFiles()
+		const sourceFiles =
+			await this.collectSourceFilesForPublishedArtifactRebuild(source)
 		const stagingKey = isolatedArtifactRebuildStagingKeyForUser(input.userId)
 		await stagingKv.put(stagingKey, JSON.stringify({ sourceFiles }), {
 			expirationTtl: isolatedArtifactRebuildStagingTtlSeconds,
@@ -2324,7 +2391,8 @@ class RepoSessionBase extends DurableObject<Env> {
 		if (!savedPackage) {
 			throw new Error(`Saved package "${source.entity_id}" was not found.`)
 		}
-		const sourceFiles = await this.collectWorkspaceFiles()
+		const sourceFiles =
+			await this.collectSourceFilesForPublishedArtifactRebuild(source)
 		const kvKey = await this.persistPublishedPackageArtifactTargetFromFiles({
 			source,
 			savedPackage,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`package_publish_external_push` promotes Artifacts HEAD, then rebuilds published bundle artifacts so `packages.invoke` hits the new source. That rebuild was reading the empty session Durable Object workspace (external publish clones into ephemeral FS and never populates the session), so it failed with `Manifest "package.json" was not found` after a successful source publish. This change makes listing and staging fall back to the published source snapshot written during finalize.

This unblocks git-lane republish of packages such as `@kentcdodds/origin`.

## Summary

- After external publish, artifact target listing reads the published manifest snapshot when the session workspace has no `package.json`.
- Staging and same-session rebuild collect source files from the published snapshot in that same empty-workspace case.
- Session workspaces that already contain the manifest keep the existing path.

## Testing

- `npx vitest run --project node-unit packages/worker/src/repo/repo-session-do.node.test.ts` — 25 passed, including empty-workspace list and stage fallbacks.
- CI Validate on this branch is green (Static, Node, Workers, MCP, E2E).
- Preview https://kody-pr-1505.kody-a99.workers.dev: `npm run preview:manual-test` signed in as the seed user, saved `preview-origin-rebuild=snapshot-fallback`, listed packages (`total: 0`), and served `/account/packages` + `/account/values`. UI pass confirmed the empty Packages state and the saved value. The actual snapshot-fallback path is MCP/git-lane only and is covered by the node tests, not cookie HTTP.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends repo-sessions</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `d8b55acb` · **Head:** `77229dc4`

**Classification:** extends — repo-session artifact rebuild now reads the published source snapshot when the session workspace is empty.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `repo-sessions` | runtime | extends — empty-workspace rebuild falls back to the published snapshot |

### System map

External publish writes a source snapshot, then artifact rebuild lists and stages from that snapshot when the session workspace has no manifest.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	packageRuntime["package-runtime<br/>Package runtime"]:::untouched
	repoSessions -->|"loadPublishedSourceSnapshot when workspace lacks package.json"| packageRuntime
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Push as package_publish_external_push
	participant Clone as ephemeral clone
	participant Snap as published source snapshot
	participant Rebuild as artifact rebuild
	Push->>Clone: clone Artifacts HEAD
	Push->>Snap: write snapshot during finalize
	Push->>Rebuild: list and stage on empty session DO
	Rebuild->>Snap: read manifest and files
	Rebuild-->>Push: published bundles
```

### Before / after

| Path | Before | After |
| ---- | ------ | ----- |
| External publish + rebuild | Source publish succeeds; rebuild throws missing `package.json` | Rebuild lists/stages from the published snapshot |
| Session publish with workspace files | Workspace files | Unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-309b70b4-4a93-4133-9be0-c7c69495f553?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-309b70b4-4a93-4133-9be0-c7c69495f553&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

