### PR TITLE
fix(search): share dynamic-worker budget across retriever waves

### DIFF
--- a/packages/worker/src/mcp/tools/search-execution.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-execution.node.test.ts
@@ -1,0 +1,220 @@
+import { expect, test, vi } from 'vitest'
+import {
+	createExecuteExecutor,
+	runWithDynamicWorkerEvaluationBudget,
+} from '#mcp/executor.ts'
+
+const mockModule = vi.hoisted(() => {
+	function createEmptySearchUnifiedResult() {
+		return {
+			matches: [],
+			offline: false,
+			intent: {
+				normalizedQuery: 'skills',
+				tokens: ['skills'],
+				meaningfulTokens: ['skills'],
+				phrases: [],
+				task: { name: 'discover', confidence: 1 },
+				actions: [],
+				entities: [],
+				constraints: [],
+				confidence: 1,
+			},
+			telemetry: {
+				intent: {
+					task: 'discover',
+					confidence: 1,
+					entityCount: 0,
+					actionCount: 0,
+					constraintCount: 0,
+					topEntities: [],
+				},
+				candidateCounts: {},
+				topResultTypes: [],
+			},
+			phaseTimings: {
+				queryUnderstandingMs: 0,
+				candidateGenerationMs: 0,
+				rerankingMs: 0,
+			},
+		}
+	}
+	return {
+		createEmptySearchUnifiedResult,
+		resolvePublicUsername: vi.fn(async () => 'user'),
+		resolvePackageIdentitySearch: vi.fn(async () => ({ recognized: false })),
+		loadSearchRowsAndRegistry: vi.fn(async () => ({
+			packageRows: [],
+			userSecretRows: [],
+			userValueRows: [],
+			userIntegrationRows: [],
+			warnings: [],
+			registry: { capabilitySpecs: {} },
+		})),
+		loadDownRemoteConnectorStatuses: vi.fn(async () => []),
+		searchUnified: vi.fn(async () => createEmptySearchUnifiedResult()),
+		loadRelevantMemoriesForTool: vi.fn(),
+		runPackageRetrievers: vi.fn(),
+	}
+})
+
+vi.mock('#worker/identity/user-lookup.ts', () => ({
+	resolvePublicUsername: (...args: Array<unknown>) =>
+		mockModule.resolvePublicUsername(...args),
+}))
+
+vi.mock('./package-search-identity.ts', () => ({
+	resolvePackageIdentitySearch: (...args: Array<unknown>) =>
+		mockModule.resolvePackageIdentitySearch(...args),
+}))
+
+vi.mock('./search-loaders.ts', () => ({
+	loadSearchRowsAndRegistry: (...args: Array<unknown>) =>
+		mockModule.loadSearchRowsAndRegistry(...args),
+	loadDownRemoteConnectorStatuses: (...args: Array<unknown>) =>
+		mockModule.loadDownRemoteConnectorStatuses(...args),
+	serializeRemoteConnectorStatus: (status: { connectorId: string }) => status,
+}))
+
+vi.mock('./search-core.ts', () => ({
+	buildExactPackageSearchResult: () =>
+		mockModule.createEmptySearchUnifiedResult(),
+	searchUnified: (...args: Array<unknown>) => mockModule.searchUnified(...args),
+}))
+
+vi.mock('#mcp/tools/memory-tool-context.ts', () => ({
+	loadRelevantMemoriesForTool: (...args: Array<unknown>) =>
+		mockModule.loadRelevantMemoriesForTool(...args),
+	acknowledgeToolMemories: async () => undefined,
+	buildMemoryRetrievalQuery: (memoryContext?: { query?: string }) =>
+		memoryContext?.query?.trim() ?? '',
+}))
+
+vi.mock('#worker/package-retrievers/service.ts', () => ({
+	runPackageRetrievers: (...args: Array<unknown>) =>
+		mockModule.runPackageRetrievers(...args),
+}))
+
+const { executeSearchList } = await import('./search-execution.ts')
+
+type BudgetState = {
+	started: number
+	active: number
+	maxActive: number
+	releases: Array<() => void>
+}
+
+function createBlockingLoader(state: BudgetState) {
+	return {
+		get(_id: string, factory: () => Record<string, unknown>) {
+			factory()
+			return {
+				getEntrypoint() {
+					return {
+						async evaluate() {
+							state.started += 1
+							state.active += 1
+							state.maxActive = Math.max(state.maxActive, state.active)
+							await new Promise<void>((resolve) => {
+								state.releases.push(() => {
+									state.active -= 1
+									resolve()
+								})
+							})
+							return { result: 'done', logs: [] }
+						},
+					}
+				},
+			}
+		},
+	} as unknown as Env['LOADER']
+}
+
+function createExecutorTestExports() {
+	return {
+		KodyFetchGateway: ({ props }: { props: unknown }) => ({ props }),
+	} as never
+}
+
+async function runThreeBlockingEvaluations(env: Env) {
+	return await runWithDynamicWorkerEvaluationBudget(async () => {
+		await Promise.all(
+			Array.from({ length: 3 }, async (_, index) => {
+				return await createExecuteExecutor({
+					env,
+					exports: createExecutorTestExports(),
+					gatewayProps: {
+						baseUrl: 'https://example.com',
+						userId: 'user-1',
+						storageContext: null,
+					},
+				}).execute(`async () => ${index}`, [{ name: 'kody', fns: {} }])
+			}),
+		)
+	})
+}
+
+test('executeSearchList shares one dynamic-worker budget across memory and search retrievers', async () => {
+	const state: BudgetState = {
+		started: 0,
+		active: 0,
+		maxActive: 0,
+		releases: [],
+	}
+	const env = {
+		LOADER: createBlockingLoader(state),
+		APP_COMMIT_SHA: 'commit-for-test',
+	} as Env
+
+	mockModule.loadRelevantMemoriesForTool.mockImplementation(async () => {
+		await runThreeBlockingEvaluations(env)
+		return {
+			memories: [],
+			retrieverResults: [],
+			retrieverWarnings: [],
+			suppressedCount: 0,
+			retrievalQuery: 'skills',
+		}
+	})
+	mockModule.runPackageRetrievers.mockImplementation(async () => {
+		await runThreeBlockingEvaluations(env)
+		return { results: [], warnings: [] }
+	})
+
+	const searchPromise = executeSearchList({
+		env,
+		callerContext: {
+			baseUrl: 'https://example.com',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User',
+				username: 'user',
+			},
+		} as never,
+		conversationId: 'conv-search-budget',
+		query: 'skills',
+		memoryQuery: 'skills',
+		limit: 15,
+		userId: 'user-1',
+		includeHiddenPackages: false,
+	})
+
+	await expect.poll(() => state.started).toBe(4)
+	expect(state.active).toBe(4)
+	expect(state.maxActive).toBe(4)
+	await new Promise((resolve) => setTimeout(resolve, 20))
+	expect(state.started).toBe(4)
+	expect(state.maxActive).toBe(4)
+
+	for (const release of state.releases.splice(0)) release()
+	await expect.poll(() => state.started).toBe(6)
+	for (const release of state.releases.splice(0)) release()
+	await searchPromise
+
+	expect(state.started).toBe(6)
+	expect(state.active).toBe(0)
+	expect(state.maxActive).toBe(4)
+	expect(mockModule.loadRelevantMemoriesForTool).toHaveBeenCalledTimes(1)
+	expect(mockModule.runPackageRetrievers).toHaveBeenCalledTimes(1)
+})

--- a/packages/worker/src/mcp/tools/search-execution.ts
+++ b/packages/worker/src/mcp/tools/search-execution.ts
@@ -1,6 +1,7 @@
+import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
+import { runWithDynamicWorkerEvaluationBudget } from '#mcp/executor.ts'
 import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
 import { resolvePublicUsername } from '#worker/identity/user-lookup.ts'
-import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { runPackageRetrievers } from '#worker/package-retrievers/service.ts'
 import { type RemoteConnectorStatus } from '#worker/remote-connector/status.ts'
 
@@ -35,7 +36,7 @@ export type SearchListExecutionResult = {
 	capabilityGuidance?: string
 }
 
-export async function executeSearchList(input: {
+type ExecuteSearchListInput = {
 	env: Env
 	callerContext: McpCallerContext
 	conversationId: string
@@ -47,7 +48,23 @@ export async function executeSearchList(input: {
 	memoryContext?: SearchToolArgs['memoryContext']
 	/** Optional capability domain id; scopes ranked results to that domain's capabilities. */
 	domain?: string
-}): Promise<SearchListExecutionResult> {
+}
+
+export async function executeSearchList(
+	input: ExecuteSearchListInput,
+): Promise<SearchListExecutionResult> {
+	// Memory enrichment (context-scope retrievers) and search-scope retrievers
+	// each open their own Worker Loader evaluations. Cloudflare caps those at
+	// four per incoming request; a shared budget lets the later wave queue
+	// instead of failing at sandboxMs 0.
+	return await runWithDynamicWorkerEvaluationBudget(
+		async () => await executeSearchListWithinBudget(input),
+	)
+}
+
+async function executeSearchListWithinBudget(
+	input: ExecuteSearchListInput,
+): Promise<SearchListExecutionResult> {
 	const domainFilter = input.domain?.trim() || undefined
 	const username = await resolvePublicUsername({
 		db: input.env.APP_DB,

--- a/packages/worker/src/package-retrievers/service.ts
+++ b/packages/worker/src/package-retrievers/service.ts
@@ -287,7 +287,9 @@ export async function runPackageRetrievers(input: {
 	).slice(0, input.maxProviders ?? (input.scope === 'context' ? 3 : 10))
 	// Soft-fail per retriever: one stalled/buggy package must not fail MCP
 	// `search` or pre-sandbox execute memory/context enrichment. Callers already
-	// surface `warnings` to agents.
+	// surface `warnings` to agents. This wrap creates a request budget only
+	// when the caller has not already opened one — sibling retriever waves in
+	// the same request (search + memory) must share that outer budget.
 	const settled = await runWithDynamicWorkerEvaluationBudget(
 		async () =>
 			await Promise.allSettled(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop MCP `search` from blowing Cloudflare's 4-dynamic-worker cap when memory/context retrievers and search-scope retrievers start in the same request.

## Summary

- `executeSearchList` launched `launchSearchMemoryEnrichment` (context-scope retrievers, up to 3) in parallel with `runPackageRetrievers` (search-scope, up to 10).
- Each wave called `runWithDynamicWorkerEvaluationBudget` independently, so they did not share the request gate. Together they could start more than 4 Worker Loader evaluations and fail immediately (`sandboxMs 0`) with `Dynamic worker concurrency limit exceeded`.
- `@kentcdodds/skills` `./skill-search` is a read-only SQL query; the failures were platform scheduling, not package code.
- Wrap the whole search-list path in one `runWithDynamicWorkerEvaluationBudget` so the later wave queues instead of racing Cloudflare's hard cap.

## Testing

- `npx vitest run --project node-unit packages/worker/src/mcp/tools/search-execution.node.test.ts packages/worker/src/mcp/tools/search-handler.node.test.ts packages/worker/src/mcp/capabilities/meta/search.node.test.ts` — 10 passed
- New regression: 3 memory + 3 search blocking evaluations stay at max 4 concurrent, then drain the queued 2

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `d8b55ac` · **Head:** `379eab9`

**Classification:** composes — no primitives added or changed; search now opens the existing per-request Worker Loader budget before launching sibling retriever waves.

### Primitives touched

| Primitive    | Group    | Impact                                                                 |
| ------------ | -------- | ---------------------------------------------------------------------- |
| `mcp-server` | surfaces | composes — wraps `executeSearchList` in `runWithDynamicWorkerEvaluationBudget` |

Unmatched path: `packages/worker/src/package-retrievers/service.ts` (comment only; the service already inherited an outer budget when one existed).

### System map

MCP `search` now opens one Worker Loader budget for the request, then memory enrichment and search retrievers share that 4-slot gate.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
	mcpServer -->|"shared 4-slot budget around search + memory retrievers"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Search as executeSearchList
	participant Budget as runWithDynamicWorkerEvaluationBudget
	participant Memory as context retrievers
	participant Retrievers as search retrievers
	Search->>Budget: open one request gate
	Budget->>Memory: launch (up to 3)
	Budget->>Retrievers: launch (up to 10)
	Note over Budget: extra evaluations queue<br/>instead of hitting CF's cap of 4
```

### Before / after

```text
before: memory wave budget (4) + search wave budget (4) = up to 8 concurrent evaluates
after:  one request budget (4); later wave waits for a free slot
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fe4c8b1-9ef2-4b31-a863-b19100585d66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fe4c8b1-9ef2-4b31-a863-b19100585d66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search execution concurrency management so memory and package-search operations share a limit of four simultaneous evaluations.
  * Prevented excessive concurrent activity during combined searches while allowing all requested evaluations to complete.

* **Tests**
  * Added coverage verifying shared concurrency limits and successful completion across both search retrievers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->