### PR TITLE
fix(remote-connector): keep last-known tools after list refresh failures

### DIFF
--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -420,7 +420,15 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 			connectorId: 'home',
 			connectedAt: '2026-04-26T05:00:00.000Z',
 		},
-		tools: [],
+		tools: [{ name: 'bond_shade_set_position' }],
+	})
+	// Same in-memory snapshot the host gate reads after a tools/list
+	// timeout while the websocket is still up.
+	const stillConnected = [{} as WebSocket]
+	softFail.state.getWebSockets.mockReturnValue(stillConnected)
+	await expect(softFail.session.getSnapshot()).resolves.toMatchObject({
+		connectorId: 'home',
+		tools: [{ name: 'bond_shade_set_position' }],
 	})
 
 	captureMessageMock.mockClear()

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -609,7 +609,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		try {
 			await this.refreshToolsSnapshot()
 		} catch (error) {
-			await this.handleToolsSnapshotRefreshFailure({
+			this.handleToolsSnapshotRefreshFailure({
 				phase: 'after websocket hello',
 				error,
 			})
@@ -637,7 +637,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			try {
 				await this.refreshToolsSnapshot()
 			} catch (error) {
-				await this.handleToolsSnapshotRefreshFailure({
+				this.handleToolsSnapshotRefreshFailure({
 					phase: 'on tools/list_changed',
 					error,
 				})
@@ -645,7 +645,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		}
 	}
 
-	private async handleToolsSnapshotRefreshFailure(input: {
+	private handleToolsSnapshotRefreshFailure(input: {
 		phase: 'after websocket hello' | 'on tools/list_changed'
 		error: unknown
 	}) {
@@ -657,20 +657,14 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		}
 		// Timeouts, disconnects mid-RPC, and "not connected" are expected
 		// remote-connector lifecycle noise (same class as websocket closes).
-		// Soft-fail by clearing tools; keep an ops log line and do not open
-		// Sentry issues. Restore the in-memory cache if persistence fails so
-		// later reads are not left empty while Sentry captures the storage bug.
-		const previousTools = this.stateSnapshot.tools
-		this.stateSnapshot.tools = []
+		// Keep last-known-good tools: wiping them while the websocket is
+		// still up makes kody.remote[name] fail the host gate with
+		// "connected, but it has not exposed any tools yet" even though
+		// tools/call would still work. Real disconnects already clear tools
+		// in handleDisconnect. Keep an ops log line and do not open Sentry.
 		console.warn(
 			`Remote connector tools snapshot refresh failed ${input.phase}. connectorId=${this.stateSnapshot.persisted.connectorId ?? 'null'} error=${getErrorMessage(input.error)}`,
 		)
-		try {
-			await this.persistState()
-		} catch (persistError) {
-			this.stateSnapshot.tools = previousTools
-			throw persistError
-		}
 	}
 
 	private async refreshToolsSnapshot() {

--- a/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
+++ b/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
@@ -76,20 +76,16 @@ test('getCachedRemoteConnectorSnapshot reuses DO snapshots within TTL', async ()
 	expect(getSnapshotCalls()).toBe(1)
 })
 
-test('getCachedRemoteConnectorSnapshot does not retain disconnected snapshots', async () => {
+test('getCachedRemoteConnectorSnapshot does not retain disconnected or empty-tool snapshots', async () => {
 	clearRemoteConnectorSnapshotCacheForTests()
-	let connected = false
-	const { env, getSnapshotCalls } = buildEnv(async () =>
-		connected
-			? {
-					connectorKind: 'roku',
-					connectorId: 'home',
-					connectedAt: '2026-03-25T00:00:00.000Z',
-					lastSeenAt: '2026-03-25T00:00:01.000Z',
-					tools: runtimeTools,
-				}
-			: null,
-	)
+	let snapshot: {
+		connectorKind: string
+		connectorId: string
+		connectedAt: string
+		lastSeenAt: string
+		tools: typeof runtimeTools | []
+	} | null = null
+	const { env, getSnapshotCalls } = buildEnv(async () => snapshot)
 	const request = {
 		env,
 		userId: 'user-1',
@@ -97,11 +93,24 @@ test('getCachedRemoteConnectorSnapshot does not retain disconnected snapshots', 
 	}
 
 	await expect(getCachedRemoteConnectorSnapshot(request)).resolves.toBeNull()
-	connected = true
-	await expect(
-		getCachedRemoteConnectorSnapshot(request),
-	).resolves.not.toBeNull()
-	expect(getSnapshotCalls()).toBe(2)
+	snapshot = {
+		connectorKind: 'roku',
+		connectorId: 'home',
+		connectedAt: '2026-03-25T00:00:00.000Z',
+		lastSeenAt: '2026-03-25T00:00:01.000Z',
+		tools: [],
+	}
+	await expect(getCachedRemoteConnectorSnapshot(request)).resolves.toEqual(
+		snapshot,
+	)
+	snapshot = {
+		...snapshot,
+		tools: runtimeTools,
+	}
+	await expect(getCachedRemoteConnectorSnapshot(request)).resolves.toEqual(
+		snapshot,
+	)
+	expect(getSnapshotCalls()).toBe(3)
 })
 
 test('a failed connector RPC evicts the cached snapshot', async () => {

--- a/packages/worker/src/remote-connector/snapshot-cache.ts
+++ b/packages/worker/src/remote-connector/snapshot-cache.ts
@@ -70,9 +70,12 @@ export function getCachedRemoteConnectorSnapshot(input: {
 				instanceId: input.instanceId,
 				getSnapshot: () => stub.getSnapshot(),
 			})
-			if (snapshot == null) {
-				// Do not retain disconnected results: a connector that comes online
-				// should be visible on the next lookup instead of after the TTL.
+			if (snapshot == null || snapshot.tools.length === 0) {
+				// Do not retain disconnected or empty-tool results: a connector
+				// that comes online or finishes exposing tools should be visible
+				// on the next lookup instead of after the TTL. Empty-tool
+				// connected snapshots are the host-gate failure mode for
+				// kody.remote[name] ("has not exposed any tools yet").
 				remoteConnectorSnapshotCache.delete(cacheKey)
 			}
 			return snapshot


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop a still-connected remote connector from becoming unusable after a transient `tools/list` timeout. shade-automation's `home` connector stays connected and heartbeats, but a failed snapshot refresh was wiping the tool list so `kody.remote["home"].bond_shade_set_position` failed at the host gate.

## Summary

- On expected `tools/list` refresh failures (timeout, disconnect mid-RPC, not connected), keep the last-known-good tool snapshot instead of persisting `tools: []`.
- Real websocket disconnects still clear tools via `handleDisconnect`.
- Do not cache connected-but-empty snapshots for the 30s TTL, so a later successful list is visible on the next lookup.
- Existing `home` sessions that already persisted an empty list still need a connector reconnect after deploy.

## Testing

- `npx vitest run --project node-unit packages/worker/src/remote-connector/session.node.test.ts packages/worker/src/remote-connector/snapshot-cache.node.test.ts` — 9 passed.
- Live production check before the fix: `home` connected since `2026-08-17T22:08:38Z`, `last_seen_at` current, `tool_count` 0, and a live `kody.remote["home"].bond_shade_set_position` execute failed with "has not exposed any tools yet".

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c8c801fe` · **Head:** `71269795`

**Classification:** extends — remote connector session and snapshot-cache behavior change; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | ---------------------------------------- |
| `remote-connectors` | assistant | extends — keep last-known tools after a failed `tools/list` refresh |
| `connector-ingress` | surfaces | extends — same session DO snapshot path |

### System map

A failed `tools/list` refresh no longer empties the session snapshot that the host gate uses to decide whether `kody.remote[name]` is callable.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	connectorIngress["connector-ingress<br/>Remote connector ingress"]:::extended
	remoteConnectors["remote-connectors<br/>Remote connectors"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	connectorIngress -->|"keep last-known tools on tools/list timeout"| remoteConnectors
	remoteConnectors -->|"skip 30s cache for empty-tool snapshots"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Connector
	participant Session as RemoteConnectorSession
	participant Cache as Snapshot cache
	participant Gate as kody.remote host gate
	Connector->>Session: notifications/tools/list_changed
	Session->>Connector: tools/list
	Connector--xSession: timeout / mid-RPC drop
	Note over Session: keep last-known tools (do not persist [])
	Gate->>Cache: getSnapshot
	Cache->>Session: connected + previous tools
	Gate->>Connector: tools/call still allowed
```

### Before / after

```
before: tools/list timeout → persist tools: [] → connected + toolCount 0 → host gate blocks
after:  tools/list timeout → keep last tools → connected + toolCount N → host gate allows tools/call
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-167ed7ae-c4be-4b34-849a-cc06b91cce51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-167ed7ae-c4be-4b34-849a-cc06b91cce51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the last known set of tools when a remote refresh times out while the connection remains active.
  - Prevented temporary refresh failures from clearing previously available tools.
  - Improved snapshot handling by removing disconnected or empty tool snapshots from the cache.
  - Ensured newly populated tool snapshots are cached correctly for subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->