### PR TITLE
fix(remote-connector): send tools/list on the live reconnect socket

### DIFF
--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -36,7 +36,9 @@ All messages are **JSON objects** with a **`type`** field.
 
 2. **`connector.heartbeat`**
    - **`type`:** `"connector.heartbeat"`
-   - Keeps `lastSeenAt` fresh in the session DO.
+   - Keeps `lastSeenAt` fresh in the session DO. If the session is still
+     connected with an empty tool snapshot and no RPC is in flight, the Worker
+     retries `tools/list` on that same heartbeat socket.
 
 3. **`connector.jsonrpc`**
    - **`type`:** `"connector.jsonrpc"`

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -520,6 +520,130 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 	})
 })
 
+function parseToolsListRequest(sent: Array<string>) {
+	for (const payload of sent) {
+		const parsed = JSON.parse(payload) as {
+			type: string
+			message?: { id: string; method: string }
+		}
+		if (
+			parsed.type === 'connector.jsonrpc' &&
+			parsed.message?.method === 'tools/list'
+		) {
+			return parsed.message
+		}
+	}
+	return null
+}
+
+test('hello and empty-tools heartbeat send tools/list on the live socket, not a stale sibling', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const staleSent: Array<string> = []
+	const liveSent: Array<string> = []
+	const staleCloses: Array<{ code: number; reason: string }> = []
+	const liveCloses: Array<{ code: number; reason: string }> = []
+	const staleSocket = createHelloSocket({
+		sent: staleSent,
+		closes: staleCloses,
+	})
+	const liveSocket = createHelloSocket({ sent: liveSent, closes: liveCloses })
+	const { session } = await createRemoteConnectorSession({
+		storedState: {
+			persisted: {
+				connectorId: 'home',
+				connectedAt: '2026-04-26T05:00:00.000Z',
+				lastSeenAt: '2026-04-26T05:01:00.000Z',
+			},
+			tools: [],
+		},
+		webSockets: [staleSocket, liveSocket],
+	})
+	remoteConnectorSharedSecretMatchesMock.mockResolvedValue(true)
+
+	const hello = session.webSocketMessage(
+		liveSocket,
+		JSON.stringify({
+			type: 'connector.hello',
+			connectorId: 'home',
+			sharedSecret: 'home-secret',
+		}),
+	)
+	await vi.waitFor(() => {
+		expect(parseToolsListRequest(liveSent)).not.toBeNull()
+	})
+	expect(parseToolsListRequest(staleSent)).toBeNull()
+	expect(staleCloses).toEqual([{ code: 1000, reason: 'replaced' }])
+	expect(liveCloses).toEqual([])
+	expect(JSON.parse(liveSent[0]!)).toMatchObject({
+		type: 'server.ack',
+		connectorId: 'home',
+	})
+
+	const helloList = parseToolsListRequest(liveSent)!
+	await session.webSocketMessage(
+		liveSocket,
+		JSON.stringify({
+			type: 'connector.jsonrpc',
+			message: {
+				jsonrpc: '2.0',
+				id: helloList.id,
+				result: { tools: [{ name: 'bond_shade_set_position' }] },
+			},
+		}),
+	)
+	await hello
+	await expect(session.getSnapshot()).resolves.toMatchObject({
+		connectorId: 'home',
+		tools: [{ name: 'bond_shade_set_position' }],
+	})
+
+	const heartbeatSent: Array<string> = []
+	const heartbeatSocket = {
+		send: (payload: string) => {
+			heartbeatSent.push(payload)
+		},
+		deserializeAttachment: () => ({
+			ingressSessionKey: '',
+			ingressUserId: 'user-home-1',
+		}),
+	} as unknown as WebSocket
+	const empty = await createRemoteConnectorSession({
+		storedState: {
+			persisted: {
+				connectorId: 'home',
+				connectedAt: '2026-04-26T05:00:00.000Z',
+				lastSeenAt: '2026-04-26T05:01:00.000Z',
+			},
+			tools: [],
+		},
+		webSockets: [heartbeatSocket],
+	})
+	const heartbeat = empty.session.webSocketMessage(
+		heartbeatSocket,
+		JSON.stringify({ type: 'connector.heartbeat' }),
+	)
+	await vi.waitFor(() => {
+		expect(parseToolsListRequest(heartbeatSent)).not.toBeNull()
+	})
+	const retryList = parseToolsListRequest(heartbeatSent)!
+	await empty.session.webSocketMessage(
+		heartbeatSocket,
+		JSON.stringify({
+			type: 'connector.jsonrpc',
+			message: {
+				jsonrpc: '2.0',
+				id: retryList.id,
+				result: { tools: [{ name: 'lutron_get_inventory' }] },
+			},
+		}),
+	)
+	await heartbeat
+	await expect(empty.session.getSnapshot()).resolves.toMatchObject({
+		connectorId: 'home',
+		tools: [{ name: 'lutron_get_inventory' }],
+	})
+})
+
 test('remote connector hello shared-secret outcomes cover invalid, transient, and hard failures', async () => {
 	{
 		const sent: Array<string> = []

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -401,10 +401,10 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 					await this.handleHello(ws, parsed)
 					return
 				case 'connector.heartbeat':
-					await this.handleHeartbeat()
+					await this.handleHeartbeat(ws)
 					return
 				case 'connector.jsonrpc':
-					await this.handleJsonRpcMessage(parsed.message)
+					await this.handleJsonRpcMessage(ws, parsed.message)
 					return
 			}
 		} catch (error) {
@@ -599,6 +599,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			connectedAt: this.stateSnapshot.persisted.connectedAt ?? now,
 			lastSeenAt: now,
 		}
+		this.closeOtherSockets(ws)
 		await this.persistState()
 		ws.send(
 			stringifyRemoteConnectorMessage({
@@ -607,7 +608,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			}),
 		)
 		try {
-			await this.refreshToolsSnapshot()
+			await this.refreshToolsSnapshot(ws)
 		} catch (error) {
 			this.handleToolsSnapshotRefreshFailure({
 				phase: 'after websocket hello',
@@ -616,12 +617,27 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		}
 	}
 
-	private async handleHeartbeat() {
+	private async handleHeartbeat(ws: WebSocket) {
 		this.stateSnapshot.persisted.lastSeenAt = new Date().toISOString()
 		await this.persistState()
+		if (this.stateSnapshot.tools.length > 0 || this.pendingRequests.size > 0) {
+			return
+		}
+		// A hello that never delivered tools/list to this socket leaves the
+		// session connected with an empty snapshot. Keeping last-known tools
+		// after a timeout does not help a session that never listed
+		// successfully. Retry on the heartbeat socket until it does.
+		try {
+			await this.refreshToolsSnapshot(ws)
+		} catch (error) {
+			this.handleToolsSnapshotRefreshFailure({
+				phase: 'on heartbeat',
+				error,
+			})
+		}
 	}
 
-	private async handleJsonRpcMessage(message: JSONRPCMessage) {
+	private async handleJsonRpcMessage(ws: WebSocket, message: JSONRPCMessage) {
 		if ('result' in message || 'error' in message) {
 			const pending = this.pendingRequests.get(String(message.id))
 			if (!pending) return
@@ -635,7 +651,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			message.method === 'notifications/tools/list_changed'
 		) {
 			try {
-				await this.refreshToolsSnapshot()
+				await this.refreshToolsSnapshot(ws)
 			} catch (error) {
 				this.handleToolsSnapshotRefreshFailure({
 					phase: 'on tools/list_changed',
@@ -646,7 +662,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 	}
 
 	private handleToolsSnapshotRefreshFailure(input: {
-		phase: 'after websocket hello' | 'on tools/list_changed'
+		phase: 'after websocket hello' | 'on tools/list_changed' | 'on heartbeat'
 		error: unknown
 	}) {
 		if (!isExpectedToolsSnapshotRefreshFailure(input.error)) {
@@ -667,8 +683,12 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		)
 	}
 
-	private async refreshToolsSnapshot() {
-		const response = await this.sendRpcRequest('tools/list', {})
+	private async refreshToolsSnapshot(preferredSocket?: WebSocket) {
+		const response = await this.sendRpcRequest(
+			'tools/list',
+			{},
+			preferredSocket,
+		)
 		if ('error' in response) {
 			const error = new Error(response.error.message)
 			error.name = remoteConnectorToolsListRpcErrorName
@@ -693,11 +713,34 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		await this.persistState()
 	}
 
+	private closeOtherSockets(keep: WebSocket) {
+		for (const socket of this.ctx.getWebSockets(connectorTag)) {
+			if (socket === keep) continue
+			try {
+				socket.close(1000, 'replaced')
+			} catch {
+				// Ignore sockets that are already closing.
+			}
+		}
+	}
+
+	private resolveRpcSocket(preferredSocket?: WebSocket) {
+		const sockets = this.ctx.getWebSockets(connectorTag)
+		if (preferredSocket && sockets.includes(preferredSocket)) {
+			return preferredSocket
+		}
+		return sockets[0]
+	}
+
 	private async sendRpcRequest(
 		method: string,
 		params: Record<string, unknown>,
+		preferredSocket?: WebSocket,
 	): Promise<RemoteConnectorJsonRpcResponse> {
-		const socket = this.ctx.getWebSockets(connectorTag)[0]
+		// Prefer the socket that just hellod or heartbeated. getWebSockets()[0]
+		// can still be a stale sibling during reconnect, so tools/list never
+		// reaches the live connector and the snapshot stays empty.
+		const socket = this.resolveRpcSocket(preferredSocket)
 		if (!socket) {
 			throw new Error('No remote connector is connected.')
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop a still-connected `home` connector from sitting at `toolCount: 0` after reconnect. shade-automation was calling the documented `kody.remote["home"].bond_shade_set_position` accessor and failing the host gate with "connected, but it has not exposed any tools yet" even though the connector had 142 tools locally.

#1508 already keeps last-known tools after a `tools/list` timeout. That does not help a session that never listed successfully: home-connector logs showed Kody acking hello, then never requesting `tools/list` on the live socket (`worker.tools.remote_list_missing`).

## Summary

- Send `tools/list` on the websocket that just hellod, heartbeated, or notified `tools/list_changed`, instead of `getWebSockets()[0]` (a stale sibling during reconnect).
- Close other sockets on a successful hello so later `tools/call` RPCs also hit the live connection.
- If the snapshot is still empty and no RPC is in flight, retry `tools/list` on heartbeat.
- Document the heartbeat retry in `docs/contributing/architecture/remote-connectors.md`.

## Testing

- `npx vitest run --project node-unit packages/worker/src/remote-connector/session.node.test.ts` — 4 passed, including a new workflow that hello's on the live socket next to a stale sibling and recovers an empty snapshot from heartbeat.
- Live production evidence before this PR: `home` acked hello with `localToolCount=142`, then logged `worker.tools.remote_list_missing` / `remote_list_still_missing` (no `tools/list` on that socket). After a later reconnect at `2026-08-18T03:39:44Z`, the same connector exposed 142 tools and shade calls succeeded.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4a39ed0a` · **Head:** `dcb77743`

**Classification:** extends — remote connector session socket targeting and empty-snapshot retry; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | ---------------------------------------- |
| `remote-connectors` | assistant | extends — send `tools/list` on the inbound socket and retry while empty |
| `connector-ingress` | surfaces | extends — same session DO websocket path |

### System map

A reconnect hello now lists tools on the live socket; an empty snapshot retries on heartbeat instead of staying gated at `toolCount: 0`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	connectorIngress["connector-ingress<br/>Remote connector ingress"]:::extended
	remoteConnectors["remote-connectors<br/>Remote connectors"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	connectorIngress -->|"tools/list on hello/heartbeat socket"| remoteConnectors
	remoteConnectors -->|"host gate sees toolCount greater than 0"| mcpServer
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Connector
	participant Session as RemoteConnectorSession
	participant Gate as kody.remote host gate
	Connector->>Session: connector.hello on new websocket
	Session->>Session: close stale sibling sockets
	Session->>Connector: server.ack
	Session->>Connector: tools/list on the hello socket
	Note over Session: if list never arrives, snapshot stays empty
	Connector->>Session: connector.heartbeat
	Session->>Connector: tools/list retry on heartbeat socket
	Connector->>Session: tools/list result
	Gate->>Connector: tools/call allowed
```

### Before / after

```
before: hello/tools/list → getWebSockets()[0] (stale) → connected + toolCount 0 → host gate blocks
after:  hello/tools/list → inbound socket + heartbeat retry → connected + toolCount N → host gate allows tools/call
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9faebfbe-2170-487d-bc3a-ee386d5cdae1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9faebfbe-2170-487d-bc3a-ee386d5cdae1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote connector reliability when multiple connections are present.
  - Tool lists now refresh automatically when a connected session reports no available tools.
  - Requests are routed through the active connection, reducing stale or missed responses.
  - Connector acknowledgements and tool updates are handled more consistently during reconnects and heartbeat activity.

- **Documentation**
  - Clarified the connector heartbeat behavior and automatic tool-list retry process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->