### PR TITLE
fix(remote-connector): stop tools/list refresh from hanging workflow shade calls

### DIFF
--- a/docs/contributing/architecture/remote-connectors.md
+++ b/docs/contributing/architecture/remote-connectors.md
@@ -64,8 +64,12 @@ The Worker sends MCP-style requests over the WebSocket wrapped in
   pass through to the upstream MCP client; see
   [Raw MCP content blocks](../../use/raw-content-blocks.md).
 
-If the Worker forwards **`notifications/tools/list_changed`**, the connector
-should re-list tools when it supports dynamic registration.
+When the connector sends **`notifications/tools/list_changed`**, the Worker
+requests **`tools/list`** again and updates the session snapshot. The
+hibernatable WebSocket handler must return before awaiting that round-trip:
+the `tools/list` response is the next websocket message, and blocking the
+handler queues later **`tools/call`** RPCs until the caller sandbox observe
+timeout.
 
 ## Internal access (DO RPC, not HTTP)
 

--- a/packages/worker/src/remote-connector/client.ts
+++ b/packages/worker/src/remote-connector/client.ts
@@ -5,6 +5,10 @@ import {
 	invalidateRemoteConnectorSnapshotCache,
 } from '#worker/remote-connector/snapshot-cache.ts'
 import {
+	remoteConnectorRpcTimeoutMessage,
+	remoteConnectorRpcTimeoutMs,
+} from './rpc-timeout.ts'
+import {
 	type RemoteConnectorSnapshot,
 	type RemoteConnectorToolDescriptor,
 } from './types.ts'
@@ -18,6 +22,27 @@ export type RemoteConnectorMcpClient = {
 		args?: Record<string, unknown>,
 	): Promise<CallToolResult>
 	getSnapshot(): Promise<RemoteConnectorSnapshot | null>
+}
+
+async function withRemoteConnectorRpcTimeout<T>(
+	operation: () => Promise<T>,
+	method: string,
+): Promise<T> {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			operation(),
+			new Promise<never>((_resolve, reject) => {
+				timeoutId = setTimeout(() => {
+					reject(new Error(remoteConnectorRpcTimeoutMessage(method)))
+				}, remoteConnectorRpcTimeoutMs)
+			}),
+		])
+	} finally {
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId)
+		}
+	}
 }
 
 function getSessionStub(input: {
@@ -52,14 +77,20 @@ export function createRemoteConnectorMcpClient(input: {
 	return {
 		async listTools() {
 			try {
-				return await stub.rpcListTools()
+				return await withRemoteConnectorRpcTimeout(
+					() => stub.rpcListTools(),
+					'tools/list',
+				)
 			} catch (error) {
 				invalidateSnapshotOnFailure(error)
 			}
 		},
 		async callTool(name, args) {
 			try {
-				return (await stub.rpcCallTool(name, args ?? {})) as CallToolResult
+				return (await withRemoteConnectorRpcTimeout(
+					() => stub.rpcCallTool(name, args ?? {}),
+					'tools/call',
+				)) as CallToolResult
 			} catch (error) {
 				invalidateSnapshotOnFailure(error)
 			}

--- a/packages/worker/src/remote-connector/rpc-timeout.ts
+++ b/packages/worker/src/remote-connector/rpc-timeout.ts
@@ -1,0 +1,11 @@
+/**
+ * Deadline for one remote-connector JSON-RPC round trip (`tools/list` or
+ * `tools/call`). Enforced inside the session Durable Object and again at
+ * the Worker caller so a stuck hibernatable WebSocket handler cannot hold
+ * `rpcCallTool` until a 270s workflow sandbox observe timeout.
+ */
+export const remoteConnectorRpcTimeoutMs = 15_000
+
+export function remoteConnectorRpcTimeoutMessage(method: string) {
+	return `Timed out waiting for remote connector response to ${method}.`
+}

--- a/packages/worker/src/remote-connector/session.node.test.ts
+++ b/packages/worker/src/remote-connector/session.node.test.ts
@@ -102,6 +102,7 @@ function createState(
 			},
 			getWebSockets: vi.fn(() => webSockets),
 			acceptWebSocket: vi.fn(),
+			waitUntil: vi.fn(),
 			blockConcurrencyWhile: vi.fn((callback: () => Promise<void>) =>
 				callback(),
 			),
@@ -128,6 +129,7 @@ async function createRemoteConnectorSession(
 			storage: state.storage,
 			getWebSockets: state.getWebSockets,
 			acceptWebSocket: state.acceptWebSocket,
+			waitUntil: state.waitUntil,
 			blockConcurrencyWhile: state.blockConcurrencyWhile,
 		} as unknown as DurableObjectState,
 		{} as Env,
@@ -493,10 +495,11 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 		}),
 	)
 	await refresh
-
-	expect(captureMessageMock).toHaveBeenCalledWith(
-		'Remote connector session message handler threw.',
-	)
+	await vi.waitFor(() => {
+		expect(captureMessageMock).toHaveBeenCalledWith(
+			'Remote connector session message handler threw.',
+		)
+	})
 	expect(setLevelMock).toHaveBeenCalledWith('error')
 	expect(setTagMock).toHaveBeenCalledWith(
 		'worker_component',
@@ -518,6 +521,84 @@ test('tools/list_changed soft-fails disconnects and reports malformed snapshots'
 	).toMatchObject({
 		tools: [{ name: 'bond_shade_set_position' }],
 	})
+
+	const staleSent: Array<string> = []
+	const liveSent: Array<string> = []
+	const staleSocket = {
+		send: (payload: string) => {
+			staleSent.push(payload)
+		},
+	} as unknown as WebSocket
+	const liveSocket = {
+		send: (payload: string) => {
+			liveSent.push(payload)
+		},
+	} as unknown as WebSocket
+	const concurrent = await createRemoteConnectorSession({
+		storedState: {
+			persisted: {
+				connectorId: 'home',
+				connectedAt: '2026-04-26T05:00:00.000Z',
+				lastSeenAt: '2026-04-26T05:01:00.000Z',
+			},
+			tools: [{ name: 'bond_shade_set_position' }],
+		},
+		webSockets: [staleSocket, liveSocket],
+	})
+
+	const listChanged = concurrent.session.webSocketMessage(
+		liveSocket,
+		JSON.stringify({
+			type: 'connector.jsonrpc',
+			message: {
+				jsonrpc: '2.0',
+				method: 'notifications/tools/list_changed',
+			},
+		}),
+	)
+	await expect(listChanged).resolves.toBeUndefined()
+	await vi.waitFor(() => {
+		expect(staleSent.length).toBeGreaterThan(0)
+		expect(liveSent.length).toBeGreaterThan(0)
+	})
+	const listRequest = JSON.parse(liveSent[0]!) as {
+		message: { id: string; method: string }
+	}
+	expect(listRequest.message.method).toBe('tools/list')
+	expect(JSON.parse(staleSent[0]!)).toMatchObject({
+		message: { method: 'tools/list', id: listRequest.message.id },
+	})
+
+	const callPromise = concurrent.session.rpcCallTool(
+		'bond_shade_set_position',
+		{ deviceId: 'shade-1', position: 20 },
+	)
+	await vi.waitFor(() => {
+		expect(liveSent.length).toBe(2)
+	})
+	const callRequest = JSON.parse(liveSent[1]!) as {
+		message: { id: string; method: string }
+	}
+	expect(callRequest.message.method).toBe('tools/call')
+	expect(JSON.parse(staleSent[1]!)).toMatchObject({
+		message: { method: 'tools/call', id: callRequest.message.id },
+	})
+
+	await concurrent.session.webSocketMessage(
+		liveSocket,
+		JSON.stringify({
+			type: 'connector.jsonrpc',
+			message: {
+				jsonrpc: '2.0',
+				id: callRequest.message.id,
+				result: { content: [{ type: 'text', text: 'ok' }] },
+			},
+		}),
+	)
+	await expect(callPromise).resolves.toEqual({
+		content: [{ type: 'text', text: 'ok' }],
+	})
+	expect(JSON.parse(liveSent[0]!).message.id).toBe(listRequest.message.id)
 })
 
 test('remote connector hello shared-secret outcomes cover invalid, transient, and hard failures', async () => {

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -407,7 +407,10 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 					await this.handleHeartbeat()
 					return
 				case 'connector.jsonrpc':
-					await this.handleJsonRpcMessage(parsed.message)
+					await this.handleJsonRpcMessage(
+						parsed.message,
+						this.loadIngressUserId(ws),
+					)
 					return
 			}
 		} catch (error) {
@@ -613,7 +616,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		// tools/list's response is the next websocket message. Blocking here
 		// deadlocks the refresh and queues later tools/call RPCs until the
 		// caller sandbox observe timeout (270s on workflows).
-		this.scheduleToolsSnapshotRefresh('after websocket hello')
+		this.scheduleToolsSnapshotRefresh('after websocket hello', ingressUserId)
 	}
 
 	private async handleHeartbeat() {
@@ -621,7 +624,10 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		await this.persistState()
 	}
 
-	private async handleJsonRpcMessage(message: JSONRPCMessage) {
+	private async handleJsonRpcMessage(
+		message: JSONRPCMessage,
+		userId: string | null,
+	) {
 		if ('result' in message || 'error' in message) {
 			const pending = this.pendingRequests.get(String(message.id))
 			if (!pending) return
@@ -634,12 +640,13 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			'method' in message &&
 			message.method === 'notifications/tools/list_changed'
 		) {
-			this.scheduleToolsSnapshotRefresh('on tools/list_changed')
+			this.scheduleToolsSnapshotRefresh('on tools/list_changed', userId)
 		}
 	}
 
 	private scheduleToolsSnapshotRefresh(
 		phase: 'after websocket hello' | 'on tools/list_changed',
+		userId: string | null,
 	) {
 		const refresh = this.refreshToolsSnapshot().catch((error: unknown) => {
 			try {
@@ -652,6 +659,7 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 					'Remote connector session message handler threw.',
 					{
 						level: 'error',
+						userId,
 						extra: {
 							connectorId: this.stateSnapshot.persisted.connectorId,
 							messageType: 'connector.jsonrpc',

--- a/packages/worker/src/remote-connector/session.ts
+++ b/packages/worker/src/remote-connector/session.ts
@@ -23,10 +23,13 @@ import {
 	hasRemoteConnectorSharedSecret,
 	remoteConnectorSharedSecretMatches,
 } from './resolve-remote-connector-secret.ts'
+import {
+	remoteConnectorRpcTimeoutMessage,
+	remoteConnectorRpcTimeoutMs,
+} from './rpc-timeout.ts'
 
 const connectorTag = 'connector'
 const stateStorageKey = 'remote-connector-session-state'
-const rpcTimeoutMs = 15_000
 
 const remoteConnectorToolsListRpcErrorName = 'RemoteConnectorToolsListRpcError'
 
@@ -606,14 +609,11 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 				connectorId: canonicalInstanceId,
 			}),
 		)
-		try {
-			await this.refreshToolsSnapshot()
-		} catch (error) {
-			this.handleToolsSnapshotRefreshFailure({
-				phase: 'after websocket hello',
-				error,
-			})
-		}
+		// Do not await: hibernatable WebSocket handlers are serialized, and
+		// tools/list's response is the next websocket message. Blocking here
+		// deadlocks the refresh and queues later tools/call RPCs until the
+		// caller sandbox observe timeout (270s on workflows).
+		this.scheduleToolsSnapshotRefresh('after websocket hello')
 	}
 
 	private async handleHeartbeat() {
@@ -634,15 +634,35 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 			'method' in message &&
 			message.method === 'notifications/tools/list_changed'
 		) {
+			this.scheduleToolsSnapshotRefresh('on tools/list_changed')
+		}
+	}
+
+	private scheduleToolsSnapshotRefresh(
+		phase: 'after websocket hello' | 'on tools/list_changed',
+	) {
+		const refresh = this.refreshToolsSnapshot().catch((error: unknown) => {
 			try {
-				await this.refreshToolsSnapshot()
-			} catch (error) {
 				this.handleToolsSnapshotRefreshFailure({
-					phase: 'on tools/list_changed',
+					phase,
 					error,
 				})
+			} catch (unexpected) {
+				this.captureSessionMessage(
+					'Remote connector session message handler threw.',
+					{
+						level: 'error',
+						extra: {
+							connectorId: this.stateSnapshot.persisted.connectorId,
+							messageType: 'connector.jsonrpc',
+							error: getErrorMessage(unexpected),
+							phase,
+						},
+					},
+				)
 			}
-		}
+		})
+		this.ctx.waitUntil(refresh)
 	}
 
 	private handleToolsSnapshotRefreshFailure(input: {
@@ -697,35 +717,35 @@ class RemoteConnectorSessionBase extends DurableObject<Env> {
 		method: string,
 		params: Record<string, unknown>,
 	): Promise<RemoteConnectorJsonRpcResponse> {
-		const socket = this.ctx.getWebSockets(connectorTag)[0]
-		if (!socket) {
+		const sockets = this.ctx.getWebSockets(connectorTag)
+		if (sockets.length === 0) {
 			throw new Error('No remote connector is connected.')
 		}
 
 		const id = crypto.randomUUID()
 		const request = createJsonRpcRequest(id, method, params)
+		const envelope = stringifyRemoteConnectorMessage({
+			type: 'connector.jsonrpc',
+			message: request,
+		})
 
 		const response = await new Promise<RemoteConnectorJsonRpcResponse>(
 			(resolve, reject) => {
 				const timeout = setTimeout(() => {
 					this.pendingRequests.delete(id)
-					reject(
-						new Error(
-							`Timed out waiting for remote connector response to ${method}.`,
-						),
-					)
-				}, rpcTimeoutMs)
+					reject(new Error(remoteConnectorRpcTimeoutMessage(method)))
+				}, remoteConnectorRpcTimeoutMs)
 				this.pendingRequests.set(id, {
 					resolve,
 					reject,
 					timeout,
 				})
-				socket.send(
-					stringifyRemoteConnectorMessage({
-						type: 'connector.jsonrpc',
-						message: request,
-					}),
-				)
+				// Hibernation / reconnect can leave a stale socket first in the
+				// list. Fan the request to every accepted socket so the live
+				// connector session actually sees tools/list and tools/call.
+				for (const socket of sockets) {
+					socket.send(envelope)
+				}
 			},
 		)
 

--- a/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
+++ b/packages/worker/src/remote-connector/snapshot-cache.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { createRemoteConnectorMcpClient } from '#worker/remote-connector/client.ts'
+import { remoteConnectorRpcTimeoutMs } from '#worker/remote-connector/rpc-timeout.ts'
 import { getRemoteConnectorStatus } from '#worker/remote-connector/status.ts'
 import {
 	clearRemoteConnectorSnapshotCacheForTests,
@@ -242,6 +243,40 @@ test('remote connector status reports a stalled snapshot as an error', async () 
 			toolCount: 0,
 			error: expect.stringContaining('snapshot timed out'),
 		})
+	} finally {
+		clearRemoteConnectorSnapshotCacheForTests()
+		vi.useRealTimers()
+	}
+})
+
+test('remote connector client bounds a hung tools/call so the sandbox does not wait out the workflow observe timeout', async () => {
+	vi.useFakeTimers()
+	clearRemoteConnectorSnapshotCacheForTests()
+	const { env } = buildEnv(
+		async () => ({
+			connectorKind: 'home',
+			connectorId: 'home',
+			connectedAt: '2026-03-25T00:00:00.000Z',
+			lastSeenAt: '2026-03-25T00:00:01.000Z',
+			tools: runtimeTools,
+		}),
+		() => new Promise(() => undefined),
+	)
+
+	try {
+		const callPromise = createRemoteConnectorMcpClient({
+			env,
+			userId: 'user-1',
+			instanceId: 'home',
+		}).callTool('bond_shade_set_position', {
+			deviceId: 'shade-1',
+			position: 20,
+		})
+		const expectedRejection = expect(callPromise).rejects.toThrow(
+			'Timed out waiting for remote connector response to tools/call.',
+		)
+		await vi.advanceTimersByTimeAsync(remoteConnectorRpcTimeoutMs)
+		await expectedRejection
 	} finally {
 		clearRemoteConnectorSnapshotCacheForTests()
 		vi.useRealTimers()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop shade-automation (and any other) workflow from burning the full 270s sandbox observe timeout when the home connector sends `notifications/tools/list_changed` and Kody's session Durable Object never completes the follow-up `tools/list` / `tools/call` round trip.

## Summary

- Production: `north-east-open` (`pkgwf-jdigSOJxXbfrP9mX9B-mgzfU5TLJu41DGlGSgw-S_8c`) hit 270s three times (ef5e0bb9, 3690f905, ac38cdd0). Home connector metadata still showed `toolInventoryStatus: remote_list_missing` — last `tools/list` at 12:29:48, `tools/list_changed` at 12:52:40, and Bond never saw the three hung attempts. The fourth retry succeeded in 21s once `tools/call` reached the bridge.
- Root cause: hibernatable WebSocket handlers are serialized. Awaiting `tools/list` inside the hello / `list_changed` handler deadlocks the response and queues later `tools/call` RPCs until the workflow observe timeout. #1508 kept last-known tools so the host gate now lets those calls through instead of failing fast.
- Fix: schedule snapshot refresh without blocking the handler, fan JSON-RPC to every accepted socket (stale `[0]` after hibernation/reconnect), and bound the Worker-side DO `rpcCallTool` / `rpcListTools` at 15s so a stuck session cannot hold a workflow for 270s.

## Testing

- Focused node-unit passed: `npx vitest run --project node-unit packages/worker/src/remote-connector/session.node.test.ts packages/worker/src/remote-connector/snapshot-cache.node.test.ts` (10 tests).
- Production evidence from `run_get`, `home_connector_get_metadata`, and `bond_get_reliability_status` on the failing workflow.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `954dc6d1` · **Head:** `732ec26a`

**Classification:** extends — remote connector session and caller RPC timeout behavior change; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `connector-ingress` | surfaces | extends — WS handler no longer awaits `tools/list`; RPC fans out to every accepted socket |
| `remote-connectors` | assistant | extends — Worker-side 15s bound around session DO `rpcCallTool` / `rpcListTools` |
| `workflows` | assistant | composes — workflow `rpcCallTool` no longer sits behind a stuck list refresh |

### System map

A `tools/list_changed` notification must release the hibernatable WebSocket handler before the session Durable Object can accept the `tools/list` response or a later workflow `tools/call`.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	connectorIngress["connector-ingress<br/>Remote connector ingress"]:::extended
	remoteConnectors["remote-connectors<br/>Remote connectors"]:::extended
	workflows["workflows<br/>Workflows"]:::touched
	connectorIngress -->|"schedule tools/list without blocking WS handler"| remoteConnectors
	workflows -->|"15s caller bound on rpcCallTool"| remoteConnectors
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Connector
	participant Session as Session DO
	participant Workflow
	Connector->>Session: notifications/tools/list_changed
	Session-->>Connector: tools/list (handler already returned)
	Workflow->>Session: rpcCallTool (not queued behind refresh)
	Session-->>Connector: tools/call on every accepted socket
	Connector-->>Session: tools/call result
	Session-->>Workflow: result or 15s caller timeout
```

### Invariants

Per-user remote connector isolation is unchanged (same session key / DO name). This PR only changes how an already-attached session handles list refresh and RPC timeouts.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39509663-5f54-42de-a7e8-045f586b7f80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39509663-5f54-42de-a7e8-045f586b7f80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

