### PR TITLE
fix(packages): retry artifact rebuild on deploy-time DO resets (KODY-CLOUDFLARE-5A)

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -742,18 +742,13 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([
 		rebuildTarget,
 	])
-	mockModule.publishFromExternalRef
-		.mockResolvedValueOnce({
-			status: 'published',
-			previous_commit: 'commit-old',
-			published_commit: 'commit-new',
-			manifest: {},
-			checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
-		})
-		.mockResolvedValueOnce({
-			status: 'already_published',
-			published_commit: 'commit-new',
-		})
+	mockModule.publishFromExternalRef.mockResolvedValueOnce({
+		status: 'published',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-new',
+		manifest: {},
+		checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+	})
 	mockModule.rebuildPublishedPackageArtifact
 		.mockRejectedValueOnce(
 			new Error('rebuild target failed', {
@@ -774,8 +769,8 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 			createContext(),
 		)
 
-	expect(recoveredAfterRebuildReset.status).toBe('already_published')
-	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(2)
+	expect(recoveredAfterRebuildReset.status).toBe('published')
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(1)
 	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
 
 	// Deploy-time DO resets use "Durable Object reset because…" (no "was").
@@ -787,18 +782,13 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([
 		rebuildTarget,
 	])
-	mockModule.publishFromExternalRef
-		.mockResolvedValueOnce({
-			status: 'published',
-			previous_commit: 'commit-old',
-			published_commit: 'commit-new',
-			manifest: {},
-			checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
-		})
-		.mockResolvedValueOnce({
-			status: 'already_published',
-			published_commit: 'commit-new',
-		})
+	mockModule.publishFromExternalRef.mockResolvedValueOnce({
+		status: 'published',
+		previous_commit: 'commit-old',
+		published_commit: 'commit-new',
+		manifest: {},
+		checks: [{ kind: 'manifest', ok: true, message: 'ok' }],
+	})
 	mockModule.rebuildPublishedPackageArtifact
 		.mockRejectedValueOnce(
 			new Error(
@@ -821,8 +811,8 @@ test('publishExternalPush recovers from transient Durable Object resets', async 
 			{ package_id: 'package-1' },
 			createContext(),
 		)
-	expect(recoveredAfterCodeUpdatedReset.status).toBe('already_published')
-	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(2)
+	expect(recoveredAfterCodeUpdatedReset.status).toBe('published')
+	expect(mockModule.publishFromExternalRef).toHaveBeenCalledTimes(1)
 	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(2)
 	expect(consoleWarn).toHaveBeenCalledTimes(1)
 })

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { publishedPackageArtifactRebuildConcurrency } from './package-artifact-rebuild.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -358,4 +359,127 @@ test('falls back to per-target session rebuild when isolated runner bindings are
 
 	expect(maxInFlight).toBe(2)
 	expect(mockModule.rebuildPublishedPackageArtifact).toHaveBeenCalledTimes(3)
+})
+
+test('recovers from transient Durable Object resets during staging', async () => {
+	consoleWarn.mockImplementation(() => {})
+	resetMocks()
+
+	const run = vi.fn(async () => ({
+		ok: true,
+		message: 'rebuilt',
+	}))
+	const touch = vi.fn(async () => undefined)
+	const discard = vi.fn(async () => undefined)
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		touch,
+		run,
+		discard,
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([
+		sampleTargets[0],
+	])
+	mockModule.stagePublishedPackageArtifactRebuild
+		.mockRejectedValueOnce(
+			new Error('Durable Object reset because its code was updated.'),
+		)
+		.mockResolvedValueOnce({
+			stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-retry',
+		})
+
+	await rebuildPublishedPackageArtifactsViaRepoSession({
+		env: {
+			REPO_SESSION: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as unknown as Env,
+		rpcSessionId: 'session-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
+		2,
+	)
+	expect(run).toHaveBeenCalledTimes(1)
+	expect(discard).toHaveBeenCalledWith(
+		'repo-artifact-rebuild-staging:v1:user-1:stage-retry',
+	)
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
+	expect(String(consoleWarn.mock.calls[0]?.[0])).toContain(
+		'rebuildPublishedPackageArtifactsViaRepoSession transient Durable Object reset',
+	)
+})
+
+test('exhausts transient Durable Object reset retries during staging', async () => {
+	consoleWarn.mockImplementation(() => {})
+	resetMocks()
+
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		touch: vi.fn(),
+		run: vi.fn(),
+		discard: vi.fn(),
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([
+		sampleTargets[0],
+	])
+	mockModule.stagePublishedPackageArtifactRebuild.mockRejectedValue(
+		new Error('Durable Object reset because its code was updated.'),
+	)
+
+	await expect(
+		rebuildPublishedPackageArtifactsViaRepoSession({
+			env: {
+				REPO_SESSION: {},
+				BUNDLE_ARTIFACTS_KV: {},
+			} as unknown as Env,
+			rpcSessionId: 'session-1',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-1',
+			baseUrl: 'https://kody.test',
+		}),
+	).rejects.toThrow(
+		/could not recover after 3 transient Durable Object reset attempts/,
+	)
+
+	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
+		3,
+	)
+	expect(consoleWarn).toHaveBeenCalledTimes(3)
+})
+
+test('does not retry non-transient rebuild failures', async () => {
+	resetMocks()
+
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		touch: vi.fn(),
+		run: vi.fn(),
+		discard: vi.fn(),
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([
+		sampleTargets[0],
+	])
+	mockModule.stagePublishedPackageArtifactRebuild.mockRejectedValue(
+		new Error('staging kv unavailable'),
+	)
+
+	await expect(
+		rebuildPublishedPackageArtifactsViaRepoSession({
+			env: {
+				REPO_SESSION: {},
+				BUNDLE_ARTIFACTS_KV: {},
+			} as unknown as Env,
+			rpcSessionId: 'session-1',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-1',
+			baseUrl: 'https://kody.test',
+		}),
+	).rejects.toThrow(/bundle artifact rebuild failed/i)
+
+	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
+		1,
+	)
 })

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -1,9 +1,14 @@
 import { chunkArray } from '@kody-internal/shared/chunk.ts'
-import { formatErrorCauseChain } from '@kody-internal/shared/error-message.ts'
+import {
+	errorCauseChainIncludes,
+	formatErrorCauseChain,
+	getErrorMessage,
+} from '@kody-internal/shared/error-message.ts'
 import { isPublishedPackageArtifactBuiltForCommit } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/package-artifact-targets.ts'
 import { createIsolatedArtifactRebuildRunner } from '#worker/repo/isolated-artifact-rebuild.ts'
 import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
+import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
 
 /**
  * Same-session rebuild RPCs hit one Durable Object, which serializes
@@ -13,6 +18,42 @@ import { repoSessionRpc } from '#worker/repo/repo-session-do.ts'
  * path uses the same bound so fan-out stays modest.
  */
 export const publishedPackageArtifactRebuildConcurrency = 2
+
+/**
+ * Deploy-time DO code resets (and other platform isolate resets) during
+ * staging or target rebuilds are transient. Rebuilds are idempotent
+ * (already-built targets are skipped), so a short bounded retry recovers
+ * without re-running publish. Matches package_publish_external_push delays.
+ */
+export const publishedPackageArtifactRebuildRetryDelaysMs = [100, 500] as const
+
+function isTransientDurableObjectResetError(error: unknown) {
+	return errorCauseChainIncludes(error, isDurableObjectIsolateResetMessage)
+}
+
+function logArtifactRebuildRetry(input: {
+	sourceId: string
+	publishedCommit: string
+	attempt: number
+	nextDelayMs: number
+	error: unknown
+}) {
+	console.warn(
+		JSON.stringify({
+			message:
+				'rebuildPublishedPackageArtifactsViaRepoSession transient Durable Object reset',
+			sourceId: input.sourceId,
+			publishedCommit: input.publishedCommit,
+			attempt: input.attempt,
+			nextDelayMs: input.nextDelayMs,
+			errorMessage: getErrorMessage(input.error),
+		}),
+	)
+}
+
+async function delay(ms: number) {
+	await new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 function describePackageArtifactTarget(
 	target: PublishedPackageArtifactBuildTarget,
@@ -182,7 +223,7 @@ async function rebuildPublishedPackageArtifactsOnSession(input: {
 	)
 }
 
-export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
+async function rebuildPublishedPackageArtifactsViaRepoSessionOnce(input: {
 	env: Env
 	rpcSessionId: string
 	repoSessionId?: string
@@ -308,5 +349,51 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 			failed,
 		}),
 		{ cause: failed[0]?.error },
+	)
+}
+
+export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
+	env: Env
+	rpcSessionId: string
+	repoSessionId?: string
+	sourceId: string
+	userId: string
+	publishedCommit: string
+	baseUrl: string
+}) {
+	const maxAttempts = publishedPackageArtifactRebuildRetryDelaysMs.length + 1
+	let lastTransientError: unknown = null
+	for (let attemptIndex = 0; attemptIndex < maxAttempts; attemptIndex += 1) {
+		const attempt = attemptIndex + 1
+		try {
+			await rebuildPublishedPackageArtifactsViaRepoSessionOnce(input)
+			return
+		} catch (error) {
+			if (!isTransientDurableObjectResetError(error)) {
+				throw error
+			}
+			lastTransientError = error
+			const willRetry =
+				attemptIndex < publishedPackageArtifactRebuildRetryDelaysMs.length
+			const nextDelayMs = willRetry
+				? (publishedPackageArtifactRebuildRetryDelaysMs[attemptIndex] ?? 0)
+				: 0
+			logArtifactRebuildRetry({
+				sourceId: input.sourceId,
+				publishedCommit: input.publishedCommit,
+				attempt,
+				nextDelayMs,
+				error,
+			})
+			if (!willRetry) {
+				break
+			}
+			await delay(nextDelayMs)
+		}
+	}
+	throw new Error(
+		`rebuildPublishedPackageArtifactsViaRepoSession could not recover after ${maxAttempts} transient Durable Object reset attempts: ${getErrorMessage(
+			lastTransientError,
+		)}`,
 	)
 }

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -548,6 +548,19 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		exhaustedPublishRecovery,
 	)
 
+	const exhaustedArtifactRebuildRecovery = {
+		exception: {
+			values: [
+				{
+					value: `rebuildPublishedPackageArtifactsViaRepoSession could not recover after 3 transient Durable Object reset attempts: Package source publish succeeded, but bundle artifact rebuild failed for source "source-1" at commit "commit-1". Succeeded: none. Failed: ${durableObjectCodeUpdatedResetMessage} Re-run the publish capability to repair artifacts.`,
+				},
+			],
+		},
+	}
+	expect(filterSentryEvent(exhaustedArtifactRebuildRecovery)).toBe(
+		exhaustedArtifactRebuildRecovery,
+	)
+
 	const unreferencedDoStorageReset = {
 		exception: {
 			values: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop production package publishes from failing Sentry-noisy when Cloudflare resets a Durable Object mid–artifact rebuild because a deploy replaced DO code. Source publish already succeeded; rebuild is idempotent and should recover.

Fixes [KODY-CLOUDFLARE-5A](https://kent-c-dodds-tech-llc.sentry.io/issues/7676344101/).

## Summary

- `repo_publish_session` published package source, then `stagePublishedPackageArtifactRebuild` failed with `Durable Object reset because its code was updated.`
- Bare DO resets are already filtered in Sentry; the rebuild wrapper kept this event visible (by design).
- `package_publish_external_push` already retried the full publish path; `repo_publish_session` had no rebuild retry.
- Add the same bounded DO-reset retry (100ms / 500ms, 3 attempts) inside `rebuildPublishedPackageArtifactsViaRepoSession` so both publish paths recover rebuild-only deploy blips without re-publishing.
- Exhausted retries still throw a recovery wrapper (stays Sentry-visible); non-transient failures still fail immediately.

## Testing

- Focused suites green: `package-artifact-rebuild`, `publish-external-push`, `sentry-options`, `repo-workflow`
- CI Validate / Node / Workers / MCP / E2E green on the PR
- Squash-merged as `5ff43acc`; production `/health` returns that commit
- Deploy workflow failed only on post-deploy Vectorize reindex curl timeout (unrelated); workers + healthchecks already succeeded

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `954dc6d1` · **Head:** `61916522` (merged as `5ff43acc`)

**Classification:** composes — wires existing Durable Object isolate-reset detection into the shared published-artifact rebuild path with the same retry delays already used by `package_publish_external_push`.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `capability-registry` | assistant | composes — retry around `rebuildPublishedPackageArtifactsViaRepoSession` used by `repo_publish_session` |
| `saved-packages` | assistant | composes — external publish rebuild recovery now happens inside shared rebuild instead of only via full republish |

### System map

Publish succeeds, then shared rebuild retries on deploy-time DO code resets before surfacing failure.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilityRegistry["capability-registry<br/>Capability registry"]:::touched
	savedPackages["saved-packages<br/>Saved packages"]:::touched
	capabilityRegistry -->|"repo_publish_session rebuild retry"| savedPackages
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Pub as repo_publish_session / external push
	participant Rebuild as rebuildPublishedPackageArtifactsViaRepoSession
	participant DO as RepoSession DO
	Pub->>Rebuild: rebuild after source publish ok
	Rebuild->>DO: stage / rebuild targets
	DO-->>Rebuild: Durable Object reset (code updated)
	Note over Rebuild: warn + delay (100ms / 500ms)
	Rebuild->>DO: retry (idempotent; skip built targets)
	DO-->>Rebuild: ok or exhaust after 3 attempts
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e6d666a-181c-4da5-bbb5-a15d883eec89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e6d666a-181c-4da5-bbb5-a15d883eec89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package artifact rebuild recovery after transient service resets.
  * Automatically retries eligible rebuild failures with bounded delays, while preserving immediate failure for non-transient errors.
  * Ensured successful publish operations are not unnecessarily repeated after recovery.
  * Preserved visibility of final recovery failures in error monitoring.

* **Tests**
  * Added coverage for successful recovery, retry exhaustion, and non-retryable staging failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->