### PR TITLE
Identify which OAuth account needs reconnect

### DIFF
--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -115,8 +115,12 @@ host-approval gaps, invalid connection config) best-effort dispatch
 `integration.auth.failed` to the owning user's packages that declare the topic.
 Every classified attempt emits; the platform does not coalesce repeats. Provider
 HTTP 5xx and missing connections do not emit. The payload is metadata-first
-(connection name, lane, reason, optional provider error fields, trusted
-`reconnect_url`) and never includes token or secret values. See
+(connection name, lane, account label, description, scopes, connect/refresh
+timestamps, reason, optional provider error fields, trusted `reconnect_url` and
+`account_url`) and never includes token or secret values. When `account_label`
+is an email, `reconnect_url` includes `loginHint` so the provider account
+chooser can preselect it. A successful Google refresh that still has no
+`account_label` persists `userinfo.email` onto the connection. See
 [Package subscriptions](../../guides/package-subscriptions.md).
 
 On 401, `createAuthenticatedFetch` calls `integration_token_refresh` then

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -361,10 +361,11 @@ emit (recursion guard). See
 For reconnectable OAuth refresh failures, `integration.auth.failed` dispatches
 best-effort from host-side `refreshIntegrationTokens`
 (`createAuthenticatedFetch` 401 retry and explicit `integration_token_refresh`).
-The payload is metadata-first (connection name, lane, reason, optional provider
-error fields, and a trusted `reconnect_url`); it omits token and secret values.
-Every classified attempt emits. Provider HTTP 5xx and missing connections do not
-emit. See [Package subscriptions](../guides/package-subscriptions.md) and
+The payload is metadata-first (connection name, account label, scopes,
+timestamps, reason, optional provider error fields, and trusted `reconnect_url`
+/ `account_url`); it omits token and secret values. Every classified attempt
+emits. Provider HTTP 5xx and missing connections do not emit. See
+[Package subscriptions](../guides/package-subscriptions.md) and
 [OAuth integrations](./architecture/integrations.md).
 
 Operator system-inbox mail (`system:email` owner) dispatches the separate

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -105,6 +105,7 @@ with `allowedHosts` when needed.
 | `apiBaseUrl`                | Optional API base URL hint.                                                  |
 | `dashboardUrl`              | Provider settings link.                                                      |
 | `extraAuthorizeParams`      | Provider-specific authorize params.                                          |
+| `loginHint`                 | Merges into authorize `login_hint` without replacing stored extra params.    |
 | `providerSetupInstructions` | Free-form setup hints shown in the wizard.                                   |
 
 ## PKCE and client secrets are orthogonal

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -485,8 +485,12 @@ type IntegrationAuthFailedEvent = {
 		name: string
 		lane: 'user' | 'platform'
 		account_label: string | null
+		description: string | null
 		provider: string | null
 		platform_app_slug: string | null
+		scopes: Array<string>
+		connected_at: string | null
+		token_refreshed_at: string | null
 	}
 	reason:
 		| 'missing_refresh_token'
@@ -500,14 +504,19 @@ type IntegrationAuthFailedEvent = {
 		http_status: number | null
 	}
 	reconnect_url: string
+	account_url: string
 	occurred_at: string
 }
 ```
 
 `reconnect_url` is built from the trusted deployment origin and links to
-`/connect/oauth?provider=<name>`. The event deliberately omits token values,
-secret values, client secrets, and secret names. A short-lived access token that
-refreshes cleanly never emits.
+`/connect/oauth?provider=<name>`. When `account_label` looks like an email it
+also adds `loginHint` so Google/OIDC can preselect that account. `account_url`
+is the connection detail page (`/account/integrations/<name>`). The event
+deliberately omits token values, secret values, client secrets, and secret
+names. A short-lived access token that refreshes cleanly never emits. Successful
+Google refreshes persist `userinfo.email` onto an empty `account_label` so later
+reconnect pings can name the account.
 
 Use this topic for notifier packages that post to Discord, email, or otherwise
 ask the owner to reconnect a dead grant.

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -508,9 +508,10 @@ needed. See [Activity](./activity.md) and the
 
 When host-side OAuth token refresh fails with reconnectable caller state, Kody
 dispatches `integration.auth.failed` to your packages that declare that topic.
-The payload is metadata-first (connection name, lane, reason, optional provider
-error fields, and a trusted `reconnect_url`). Every classified attempt emits;
-notifier packages decide how often to ping. See the
+The payload is metadata-first (connection name, account label, scopes,
+timestamps, reason, optional provider error fields, and trusted `reconnect_url`
+/ `account_url`). Every classified attempt emits; notifier packages decide how
+often to ping. See the
 [package subscriptions guide](../guides/package-subscriptions.md).
 
 Artifacts-backed plain repos, packages, and job sources also emit `repo.pushed`,

--- a/docs/use/synthetic-event-dispatch.md
+++ b/docs/use/synthetic-event-dispatch.md
@@ -120,10 +120,14 @@ Example minimal `integration.auth.failed` fixture:
 		"event_id": "00000000-0000-4000-8000-000000000001",
 		"integration": {
 			"name": "google",
-			"lane": "platform",
-			"account_label": null,
+			"lane": "user",
+			"account_label": "kent.c.dodds@gmail.com",
+			"description": null,
 			"provider": "google",
-			"platform_app_slug": "google"
+			"platform_app_slug": null,
+			"scopes": ["openid", "email", "https://www.googleapis.com/auth/calendar"],
+			"connected_at": "2026-01-01T00:00:00.000Z",
+			"token_refreshed_at": "2026-08-01T00:00:00.000Z"
 		},
 		"reason": "provider_rejected",
 		"provider": {
@@ -131,7 +135,8 @@ Example minimal `integration.auth.failed` fixture:
 			"error_description": "Token has been expired or revoked.",
 			"http_status": 400
 		},
-		"reconnect_url": "https://kody.codes/connect/oauth?provider=google",
+		"reconnect_url": "https://kody.codes/connect/oauth?provider=google&loginHint=kent.c.dodds%40gmail.com",
+		"account_url": "https://kody.codes/account/integrations/google",
 		"occurred_at": "2026-08-18T17:00:00.000Z"
 	}
 }

--- a/packages/worker/client/routes/connect-oauth-config.ts
+++ b/packages/worker/client/routes/connect-oauth-config.ts
@@ -27,6 +27,8 @@ export type ConnectOauthQueryConfig = {
 	providerSetupInstructions: string | null
 	dashboardUrl: string | null
 	allowedHosts: Array<string>
+	/** Prefills Google/OIDC account chooser without replacing stored extra params. */
+	loginHint?: string | null
 }
 
 export type ConnectOauthConfig = {
@@ -391,7 +393,13 @@ export function mergeConnectOauthConfig(input: {
 			: resolveConnectOauthScopes(input).filter((scope) =>
 					platformAllowedScopes.includes(scope),
 				)
-	const extraAuthorizeParams = resolveConnectOauthExtraAuthorizeParams(input)
+	const extraAuthorizeParams = {
+		...resolveConnectOauthExtraAuthorizeParams(input),
+	}
+	const loginHint = input.queryConfig.loginHint?.trim()
+	if (loginHint) {
+		extraAuthorizeParams.login_hint = loginHint
+	}
 	const allowedHosts = normalizeHosts([
 		tokenHost,
 		...input.queryConfig.allowedHosts,

--- a/packages/worker/client/routes/connect-oauth.node.test.ts
+++ b/packages/worker/client/routes/connect-oauth.node.test.ts
@@ -542,6 +542,32 @@ test('shared-app family lookup prefills google-calendar from the google app payl
 		tokenUrl: 'https://oauth2.googleapis.com/token',
 		accessTokenSecretName: 'google-calendarAccessToken',
 	})
+
+	const reconnectWithHint = mergeConnectOauthConfig({
+		queryConfig: {
+			provider: 'google-calendar',
+			providerKey: 'google-calendar',
+			authorizeHost: 'accounts.google.com',
+			authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+			tokenUrl: 'https://oauth2.googleapis.com/token',
+			apiBaseUrl: 'https://www.googleapis.com',
+			scopes: null,
+			flow: null,
+			usePkce: null,
+			tokenExchangeStyle: null,
+			scopeSeparator: null,
+			extraAuthorizeParams: {},
+			providerSetupInstructions: null,
+			dashboardUrl: null,
+			allowedHosts: [],
+			loginHint: 'kent.c.dodds@gmail.com',
+		},
+		storedIntegration: storedFromFamilyLookup,
+	})
+	expect(reconnectWithHint?.extraAuthorizeParams).toEqual({
+		access_type: 'offline',
+		login_hint: 'kent.c.dodds@gmail.com',
+	})
 })
 
 test('abandoned setup still prefills client id from a connectionless app on a fresh session', () => {

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -363,6 +363,7 @@ export function ConnectOauthRoute(handle: Handle) {
 				? null
 				: parseExtraParams(rawExtraAuthorizeParams)
 		const dashboardUrl = parseOptionalUrl(readOptional('dashboardUrl'))
+		const loginHint = readOptional('loginHint')
 		const providerKey = normalizeProviderKey(provider)
 		if (!providerKey) {
 			return { ok: false, error: 'Provider must contain letters or numbers.' }
@@ -392,6 +393,7 @@ export function ConnectOauthRoute(handle: Handle) {
 				providerSetupInstructions,
 				dashboardUrl,
 				allowedHosts,
+				loginHint,
 			},
 		}
 	}

--- a/packages/worker/src/integrations/account-identity.ts
+++ b/packages/worker/src/integrations/account-identity.ts
@@ -1,0 +1,23 @@
+export function isAccountEmailLabel(value: string | null | undefined) {
+	if (!value) return false
+	const email = value.trim()
+	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
+
+export function buildIntegrationAccountUrl(input: {
+	baseUrl: string
+	integrationName: string
+}) {
+	return `${input.baseUrl}/account/integrations/${encodeURIComponent(input.integrationName)}`
+}
+
+export function buildIntegrationReconnectUrl(input: {
+	baseUrl: string
+	integrationName: string
+	accountLabel?: string | null
+}) {
+	const reconnectUrl = `${input.baseUrl}/connect/oauth?provider=${encodeURIComponent(input.integrationName)}`
+	const accountLabel = input.accountLabel?.trim() ?? ''
+	if (!isAccountEmailLabel(accountLabel)) return reconnectUrl
+	return `${reconnectUrl}&loginHint=${encodeURIComponent(accountLabel)}`
+}

--- a/packages/worker/src/integrations/package-subscriptions.node.test.ts
+++ b/packages/worker/src/integrations/package-subscriptions.node.test.ts
@@ -20,9 +20,35 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 }))
 
 const {
+	buildIntegrationAuthFailedReconnectUrl,
 	dispatchIntegrationAuthFailedSubscriptionEvents,
 	integrationAuthFailedTopic,
 } = await import('./package-subscriptions.ts')
+
+test('reconnect URLs add loginHint only when the account label is an email', () => {
+	expect(
+		buildIntegrationAuthFailedReconnectUrl({
+			baseUrl: 'https://example.com',
+			integrationName: 'google',
+		}),
+	).toBe('https://example.com/connect/oauth?provider=google')
+	expect(
+		buildIntegrationAuthFailedReconnectUrl({
+			baseUrl: 'https://example.com',
+			integrationName: 'google-business',
+			accountLabel: 'Work',
+		}),
+	).toBe('https://example.com/connect/oauth?provider=google-business')
+	expect(
+		buildIntegrationAuthFailedReconnectUrl({
+			baseUrl: 'https://example.com',
+			integrationName: 'google',
+			accountLabel: 'kent.c.dodds@gmail.com',
+		}),
+	).toBe(
+		'https://example.com/connect/oauth?provider=google&loginHint=kent.c.dodds%40gmail.com',
+	)
+})
 
 function createEnv() {
 	return {
@@ -79,8 +105,12 @@ test('integration.auth.failed fans out only to owning-user packages with a lean 
 			name: 'google',
 			lane: 'platform',
 			account_label: 'Work',
+			description: 'Personal Gmail',
 			provider: 'google',
 			platform_app_slug: 'google',
+			scopes: ['openid', 'email', 'https://www.googleapis.com/auth/calendar'],
+			connected_at: '2026-01-01T00:00:00.000Z',
+			token_refreshed_at: '2026-08-01T00:00:00.000Z',
 		},
 		reason: 'provider_rejected',
 		provider: {
@@ -107,8 +137,16 @@ test('integration.auth.failed fans out only to owning-user packages with a lean 
 					name: 'google',
 					lane: 'platform',
 					account_label: 'Work',
+					description: 'Personal Gmail',
 					provider: 'google',
 					platform_app_slug: 'google',
+					scopes: [
+						'openid',
+						'email',
+						'https://www.googleapis.com/auth/calendar',
+					],
+					connected_at: '2026-01-01T00:00:00.000Z',
+					token_refreshed_at: '2026-08-01T00:00:00.000Z',
 				},
 				reason: 'provider_rejected',
 				provider: {
@@ -117,6 +155,7 @@ test('integration.auth.failed fans out only to owning-user packages with a lean 
 					http_status: 400,
 				},
 				reconnect_url: 'https://example.com/connect/oauth?provider=google',
+				account_url: 'https://example.com/account/integrations/google',
 				occurred_at: '2026-08-18T17:00:00.000Z',
 			},
 		}),
@@ -149,8 +188,12 @@ test('integration.auth.failed never throws on discovery or handler failures', as
 				name: 'google',
 				lane: 'user',
 				account_label: null,
+				description: null,
 				provider: 'google',
 				platform_app_slug: null,
+				scopes: [],
+				connected_at: null,
+				token_refreshed_at: null,
 			},
 			reason: 'missing_refresh_token',
 			provider: {
@@ -230,8 +273,12 @@ test('integration.auth.failed never throws on discovery or handler failures', as
 				name: 'google',
 				lane: 'platform',
 				account_label: null,
+				description: null,
 				provider: 'google',
 				platform_app_slug: 'google',
+				scopes: [],
+				connected_at: null,
+				token_refreshed_at: null,
 			},
 			reason: 'provider_rejected',
 			provider: {

--- a/packages/worker/src/integrations/package-subscriptions.ts
+++ b/packages/worker/src/integrations/package-subscriptions.ts
@@ -6,6 +6,10 @@ import { listPackageSubscriptions } from '#worker/package-registry/manifest.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import {
+	buildIntegrationAccountUrl,
+	buildIntegrationReconnectUrl,
+} from './account-identity.ts'
 import { type IntegrationAuthFailedReason } from './token-refresh.ts'
 
 export const integrationAuthFailedTopic = 'integration.auth.failed'
@@ -17,8 +21,12 @@ export type IntegrationAuthFailedSubscriptionEnvelope = {
 		name: string
 		lane: 'user' | 'platform'
 		account_label: string | null
+		description: string | null
 		provider: string | null
 		platform_app_slug: string | null
+		scopes: Array<string>
+		connected_at: string | null
+		token_refreshed_at: string | null
 	}
 	reason: IntegrationAuthFailedReason
 	provider: {
@@ -27,6 +35,7 @@ export type IntegrationAuthFailedSubscriptionEnvelope = {
 		http_status: number | null
 	}
 	reconnect_url: string
+	account_url: string
 	occurred_at: string
 }
 
@@ -38,8 +47,13 @@ type LoadedAuthFailedSubscription = {
 export function buildIntegrationAuthFailedReconnectUrl(input: {
 	baseUrl: string
 	integrationName: string
+	accountLabel?: string | null
 }) {
-	return `${input.baseUrl}/connect/oauth?provider=${encodeURIComponent(input.integrationName)}`
+	return buildIntegrationReconnectUrl({
+		baseUrl: input.baseUrl,
+		integrationName: input.integrationName,
+		accountLabel: input.accountLabel,
+	})
 }
 
 function buildSubscriptionIdempotencyKey(input: {
@@ -64,6 +78,11 @@ function buildEventPayload(input: {
 		reason: input.reason,
 		provider: input.provider,
 		reconnect_url: buildIntegrationAuthFailedReconnectUrl({
+			baseUrl: input.baseUrl,
+			integrationName: input.integration.name,
+			accountLabel: input.integration.account_label,
+		}),
+		account_url: buildIntegrationAccountUrl({
 			baseUrl: input.baseUrl,
 			integrationName: input.integration.name,
 		}),

--- a/packages/worker/src/integrations/token-refresh.node.test.ts
+++ b/packages/worker/src/integrations/token-refresh.node.test.ts
@@ -504,6 +504,33 @@ test('successful Google refresh persists userinfo email as account_label when mi
 		})
 		expect(joined?.connection.accountLabel).toBe('kent.c.dodds@gmail.com')
 		expect(fetchMock).toHaveBeenCalledTimes(2)
+
+		await upsertPlatformIntegration({
+			env,
+			userId,
+			platformAppSlug: 'google',
+			scopes: ['openid', 'email'],
+			accessTokenSecretName: 'googleAccessToken',
+			refreshTokenSecretName: 'googleRefreshToken',
+			accountLabel: 'Work',
+		})
+		await refreshIntegrationTokens({
+			env,
+			userId,
+			name: 'google',
+		})
+		const labeled = await getJoinedIntegration({
+			env,
+			userId,
+			name: 'google',
+		})
+		expect(labeled?.connection.accountLabel).toBe('Work')
+		expect(fetchMock).toHaveBeenCalledTimes(3)
+		expect(
+			fetchMock.mock.calls.filter(([url]) =>
+				String(url).includes('openidconnect.googleapis.com'),
+			),
+		).toHaveLength(1)
 	} finally {
 		vi.unstubAllGlobals()
 	}

--- a/packages/worker/src/integrations/token-refresh.node.test.ts
+++ b/packages/worker/src/integrations/token-refresh.node.test.ts
@@ -9,7 +9,11 @@ import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-su
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import { upsertPlatformOauthApp } from './platform-apps.ts'
-import { upsertIntegration, upsertPlatformIntegration } from './service.ts'
+import {
+	getJoinedIntegration,
+	upsertIntegration,
+	upsertPlatformIntegration,
+} from './service.ts'
 
 const mocks = vi.hoisted(() => ({
 	dispatchIntegrationAuthFailedSubscriptionEvents: vi.fn(async () => []),
@@ -436,6 +440,70 @@ test('user-lane refresh resolves the client secret from the user secret store', 
 			storageContext,
 		})
 		expect(access.found && access.value).toBe('fresh-google-token')
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('successful Google refresh persists userinfo email as account_label when missing', async () => {
+	const { env } = createHarness()
+	const userId = 'user-google-label'
+	await upsertPlatformOauthApp({
+		db: env.APP_DB,
+		env,
+		app: {
+			slug: 'google',
+			clientId: 'platform-google-client-id',
+			clientSecret: 'platform-google-client-secret-value',
+			tokenUrl: 'https://oauth2.googleapis.com/token',
+			authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+			apiBaseUrl: 'https://www.googleapis.com',
+			flow: 'confidential',
+			requiredHosts: ['oauth2.googleapis.com', 'openidconnect.googleapis.com'],
+			allowedScopes: ['openid', 'email'],
+			defaultScopes: ['openid', 'email'],
+		},
+	})
+	await upsertPlatformIntegration({
+		env,
+		userId,
+		platformAppSlug: 'google',
+		scopes: ['openid', 'email'],
+		accessTokenSecretName: 'googleAccessToken',
+		refreshTokenSecretName: 'googleRefreshToken',
+	})
+	await seedUserTokens(env, userId, 'google')
+
+	const fetchMock = vi.fn(async (url: string | URL | Request) => {
+		const href = String(url)
+		if (href.includes('openidconnect.googleapis.com')) {
+			return new Response(JSON.stringify({ email: 'kent.c.dodds@gmail.com' }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		}
+		return new Response(
+			JSON.stringify({ access_token: 'fresh-google-token' }),
+			{
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			},
+		)
+	})
+	vi.stubGlobal('fetch', fetchMock)
+	try {
+		await refreshIntegrationTokens({
+			env,
+			userId,
+			name: 'google',
+		})
+		const joined = await getJoinedIntegration({
+			env,
+			userId,
+			name: 'google',
+		})
+		expect(joined?.connection.accountLabel).toBe('kent.c.dodds@gmail.com')
+		expect(fetchMock).toHaveBeenCalledTimes(2)
 	} finally {
 		vi.unstubAllGlobals()
 	}

--- a/packages/worker/src/integrations/token-refresh.ts
+++ b/packages/worker/src/integrations/token-refresh.ts
@@ -139,7 +139,7 @@ async function maybePersistGoogleAccountLabel(input: {
 	requiredHosts: Array<string>
 	accessToken: string
 }) {
-	if (isAccountEmailLabel(input.accountLabel)) return
+	if (input.accountLabel?.trim()) return
 	if (!input.requiredHosts.includes('openidconnect.googleapis.com')) return
 	try {
 		const response = await fetch(

--- a/packages/worker/src/integrations/token-refresh.ts
+++ b/packages/worker/src/integrations/token-refresh.ts
@@ -4,6 +4,7 @@ import {
 	buildOAuthTokenExchangeRequest,
 	resolveTokenExchangeStyle,
 } from './oauth-token-exchange.ts'
+import { isAccountEmailLabel } from './account-identity.ts'
 import { getPlatformOauthAppClientSecret } from './platform-apps.ts'
 import { getJoinedIntegration } from './service.ts'
 import { type JoinedIntegration } from './types.ts'
@@ -32,8 +33,12 @@ export type IntegrationAuthFailedSnapshot = {
 	name: string
 	lane: 'user' | 'platform'
 	accountLabel: string | null
+	description: string | null
 	provider: string | null
 	platformAppSlug: string | null
+	scopes: Array<string>
+	connectedAt: string | null
+	tokenRefreshedAt: string | null
 }
 
 /**
@@ -117,8 +122,50 @@ function snapshotJoinedIntegration(
 		name: joined.connection.name,
 		lane: joined.lane,
 		accountLabel: joined.connection.accountLabel,
+		description: joined.connection.description.trim() || null,
 		provider: joined.app.provider,
 		platformAppSlug: joined.connection.platformAppSlug,
+		scopes: joined.connection.scopes,
+		connectedAt: joined.connection.connectedAt,
+		tokenRefreshedAt: joined.connection.tokenRefreshedAt,
+	}
+}
+
+async function maybePersistGoogleAccountLabel(input: {
+	env: Env
+	userId: string
+	name: string
+	accountLabel: string | null
+	requiredHosts: Array<string>
+	accessToken: string
+}) {
+	if (isAccountEmailLabel(input.accountLabel)) return
+	if (!input.requiredHosts.includes('openidconnect.googleapis.com')) return
+	try {
+		const response = await fetch(
+			'https://openidconnect.googleapis.com/v1/userinfo',
+			{
+				headers: { Authorization: `Bearer ${input.accessToken}` },
+				signal: AbortSignal.timeout(5_000),
+			},
+		)
+		if (!response.ok) return
+		const payload = (await response.json().catch(() => null)) as {
+			email?: unknown
+		} | null
+		const email = typeof payload?.email === 'string' ? payload.email.trim() : ''
+		if (!isAccountEmailLabel(email)) return
+		const now = new Date().toISOString()
+		await input.env.APP_DB.prepare(
+			`UPDATE user_integrations
+			SET account_label = ?, updated_at = ?
+			WHERE user_id = ? AND name = ?
+				AND (account_label IS NULL OR account_label = '')`,
+		)
+			.bind(email, now, input.userId, input.name)
+			.run()
+	} catch {
+		// Identity capture is best-effort and must never fail a successful refresh.
 	}
 }
 
@@ -166,8 +213,12 @@ async function emitIntegrationAuthFailedEvent(input: {
 				name: snapshot.name,
 				lane: snapshot.lane,
 				account_label: snapshot.accountLabel,
+				description: snapshot.description,
 				provider: snapshot.provider,
 				platform_app_slug: snapshot.platformAppSlug,
+				scopes: snapshot.scopes,
+				connected_at: snapshot.connectedAt,
+				token_refreshed_at: snapshot.tokenRefreshedAt,
 			},
 			reason: input.error.reason,
 			provider: {
@@ -473,6 +524,15 @@ async function refreshIntegrationTokensOrThrow(input: {
 	)
 		.bind(refreshedAt, refreshedAt, input.userId, connection.name)
 		.run()
+
+	await maybePersistGoogleAccountLabel({
+		env: input.env,
+		userId: input.userId,
+		name: connection.name,
+		accountLabel: connection.accountLabel,
+		requiredHosts: connection.requiredHosts,
+		accessToken: payload.access_token,
+	})
 
 	return { refreshedAt, refreshTokenRotated }
 }

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
@@ -15,7 +15,10 @@ import {
 	mergeIntegrationConfig,
 } from './integration-shared.ts'
 import { upsertPlatformOauthApp } from '#worker/integrations/platform-apps.ts'
-import { upsertPlatformIntegration } from '#worker/integrations/service.ts'
+import {
+	getJoinedIntegration,
+	upsertPlatformIntegration,
+} from '#worker/integrations/service.ts'
 
 const migrationsDirectory = new URL('../../../../migrations/', import.meta.url)
 
@@ -444,4 +447,22 @@ test('integration_save refuses platform (built-in) connections instead of conver
 		{ env: platformEnv, callerContext: caller('user-123') },
 	)
 	expect(got.integration?.platform).toBe(true)
+})
+
+test('integration_save persists accountLabel on an existing user-lane connection', async () => {
+	const { env } = createEnv()
+	await integrationSaveCapability.handler(spotifyBase, {
+		env,
+		callerContext: caller('user-123'),
+	})
+	await integrationSaveCapability.handler(
+		{ name: 'spotify', accountLabel: 'me@kentcdodds.com' },
+		{ env, callerContext: caller('user-123') },
+	)
+	const joined = await getJoinedIntegration({
+		env,
+		userId: 'user-123',
+		name: 'spotify',
+	})
+	expect(joined?.connection.accountLabel).toBe('me@kentcdodds.com')
 })

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.ts
@@ -65,6 +65,9 @@ export const integrationSaveCapability = defineDomainCapability(
 				env: ctx.env,
 				userId: user.userId,
 				config,
+				...(args.accountLabel !== undefined
+					? { accountLabel: args.accountLabel }
+					: {}),
 			})
 			return { integration }
 		},

--- a/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-shared.ts
@@ -91,6 +91,7 @@ export const integrationSaveSchema = z
 		requiredHosts: z.array(z.string()).optional(),
 		tokenExchangeStyle: z.enum(tokenExchangeStyleValues).nullable().optional(),
 		authorization: integrationAuthorizationSchema.nullable().optional(),
+		accountLabel: z.string().min(1).nullable().optional(),
 	})
 	.strict()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

When an OAuth grant dies, the Discord reconnect ping should name the **Kody connection** and the **provider account** so a Google account picker is not a guessing game.

## Summary

- `integration.auth.failed` now includes `account_label`, `description`, `scopes`, connect/refresh timestamps, and `account_url` (`/account/integrations/<name>`).
- `reconnect_url` adds `loginHint` when `account_label` is an email. `/connect/oauth` merges that into authorize `login_hint` without replacing stored extra params (`access_type`, `prompt`, …).
- A successful Google refresh persists `userinfo.email` onto an empty `account_label`.
- `integration_save` accepts optional `accountLabel` for existing user-lane connections.

The Discord notifier package (`integration-auth-notifier`) is already updated in-account: it looks up scopes / Google userinfo and posts the connection name, email, account page, and a `loginHint` reconnect link.

## Testing

- `npx vitest run` on package-subscriptions, token-refresh, integration-save, and connect-oauth unit tests (24 passed).
- Synthetic dispatch of `integration-auth-notifier` posted Discord `1539349980492337294` with `google` → `[redacted]@gmail.com` and `loginHint`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `b2da6f71` · **Head:** `1f2b9b67`

**Classification:** extends — `integration.auth.failed` payload and reconnect URL change, Google email is persisted on refresh, and `/connect/oauth` gains `loginHint`.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `integrations` | assistant | extends — richer auth-failed envelope, `loginHint` reconnect URL, persist Google `userinfo.email` onto empty `account_label`, `integration_save.accountLabel` |
| `app-ui` | surfaces | extends — `/connect/oauth?loginHint=` merges into authorize `login_hint` |

### System map

Refresh failures fan out a richer reconnect event; connect OAuth uses `loginHint` so the provider chooser can preselect the named account.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	integrations["integrations<br/>OAuth integrations"]:::extended
	appUi["app-ui<br/>Browser app"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::untouched
	integrations -->|"integration.auth.failed + loginHint reconnect_url"| appUi
	mcpServer -->|"integration_save accountLabel"| integrations
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

```ts
// before
reconnect_url: `${origin}/connect/oauth?provider=google`
integration: { name, lane, account_label, provider, platform_app_slug }

// after
reconnect_url: `${origin}/connect/oauth?provider=google&loginHint=[redacted]%40gmail.com`
account_url: `${origin}/account/integrations/google`
integration: { name, lane, account_label, description, provider, platform_app_slug, scopes, connected_at, token_refreshed_at }
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2a52f7f-a051-4a20-8713-67ffff906d3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2a52f7f-a051-4a20-8713-67ffff906d3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

