### PR TITLE
Emit mcp.server.disconnected after a lightweight hub retry

### DIFF
--- a/docs/contributing/architecture/mcp-client-servers.md
+++ b/docs/contributing/architecture/mcp-client-servers.md
@@ -114,6 +114,13 @@ fetch `{canonical-app-origin}/oauth/client-metadata.json`; that document's
   synthesis. Account deletion purges the hub DO storage
   (`purgeForAccountDeletion`) and deletes `mcp_server_settings` rows; account
   export includes the settings rows.
+- Connection episodes live in hub DO storage (`mcp-connection-episode/<id>`).
+  After a server has been `ready`, a later `disconnected` / `failed` state gets
+  two lightweight reconnects (`connectToServer` + discover, no OAuth restart)
+  before `mcp.server.disconnected` fans out to the owning user's packages.
+  Recovery emits `mcp.server.reconnected`. `mcp_server_reconnect` remains the
+  explicit authorization restart. See
+  [Package subscriptions](../../guides/package-subscriptions.md).
 
 ## Related docs
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -367,6 +367,15 @@ Every classified attempt emits. Provider HTTP 5xx and missing connections do not
 emit. See [Package subscriptions](../guides/package-subscriptions.md) and
 [OAuth integrations](./architecture/integrations.md).
 
+For saved outbound MCP servers, `mcp.server.disconnected` and
+`mcp.server.reconnected` dispatch best-effort from the per-user MCP client hub
+after a previously-ready server stays down through two lightweight reconnects
+(or recovers). The payload is metadata-first (server id/name/state, episode id,
+and a trusted `account_url`); it omits URLs, tokens, and tool lists. Never-ready
+and disabled servers do not emit. See
+[Package subscriptions](../guides/package-subscriptions.md) and
+[MCP client servers](./architecture/mcp-client-servers.md).
+
 Operator system-inbox mail (`system:email` owner) dispatches the separate
 `email.system-message.received` topic to packages saved by users who hold the
 admin role at dispatch time, only when the message is accepted. Quarantined

--- a/docs/guides/package-subscriptions.md
+++ b/docs/guides/package-subscriptions.md
@@ -5,9 +5,11 @@ summary:
   Use package.json#kody.subscriptions for package-owned event handlers; discover
   subscribers with package_subscriptions_list; smoke-test handlers with
   package_subscription_dispatch; follow metadata-first email, run.error.recorded
-  activity notifiers, integration.auth.failed reconnect notifiers, consent-gated
-  admin-only platform.feedback.submitted notification guidance, and admin-only
-  status.incident.opened / status.incident.resolved operator telemetry.
+  activity notifiers, integration.auth.failed reconnect notifiers,
+  mcp.server.disconnected / mcp.server.reconnected connection episodes,
+  consent-gated admin-only platform.feedback.submitted notification guidance,
+  and admin-only status.incident.opened / status.incident.resolved operator
+  telemetry.
 category: platform
 ---
 
@@ -511,6 +513,56 @@ refreshes cleanly never emits.
 
 Use this topic for notifier packages that post to Discord, email, or otherwise
 ask the owner to reconnect a dead grant.
+
+## `mcp.server.disconnected` / `mcp.server.reconnected`
+
+When a saved, enabled outbound MCP server that was previously `ready` stays
+unavailable after the hub's lightweight reconnect (two `connectToServer` +
+discover attempts, no OAuth restart), Kody dispatches `mcp.server.disconnected`
+to packages saved by that same user that declare the topic. When that down
+episode later observes `ready` again, Kody dispatches `mcp.server.reconnected`
+with the same `server.episode_id`.
+
+Never-ready servers (still `authenticating` after add), disabled servers, and
+in-flight `connecting` / `connected` / `discovering` states do not emit. Token
+loss that parks in `authenticating` after a prior `ready` emits disconnected
+without the lightweight retry — the user must reopen `/account/mcp-servers`.
+`mcp_server_reconnect` remains the explicit OAuth restart; listener packages
+should not call it on every event.
+
+Delivery is best-effort after the hub observes the transition — there is no
+Queue / DLQ for these topics in v1. Failures during subscriber discovery or
+package-invocation infrastructure are logged and do not fail the MCP tool call
+or snapshot that noticed the change.
+
+Handlers receive a metadata-first payload:
+
+```ts
+type McpServerConnectionEvent = {
+	event: 'mcp.server.disconnected' | 'mcp.server.reconnected'
+	event_id: string
+	server: {
+		id: string
+		name: string
+		state: string
+		previous_state: string
+		episode_id: string
+	}
+	observed_at: string
+	account_url: string
+}
+```
+
+`account_url` is built from the trusted deployment origin and links to
+`/account/mcp-servers/<id>`. The event omits server URLs, OAuth tokens, bearer
+headers, auth URLs, and discovered tool lists. Fetch live status with
+`mcp_server_list` when needed. Idempotency keys include the topic, episode id,
+and subscriber package id, so one disconnected and one reconnected invoke per
+episode.
+
+Use these topics for notifier packages that post to Discord or otherwise tell
+the owner an MCP server (for example `home`) dropped or came back. Do not scrape
+run-error strings for connection health.
 
 ## `repo.pushed`
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -485,8 +485,8 @@ Use the built-in `package_subscriptions_list` capability to discover the
 signed-in user's saved package subscriptions, optionally filtered by exact
 topic. This is the generic discovery step before building fan-out, debugging why
 an event did or did not dispatch, or checking which packages subscribe to
-`email.message.received`, `run.error.recorded`, `integration.auth.failed`, or
-`mcp.server.disconnected`.
+`email.message.received`, `run.error.recorded`, `integration.auth.failed`,
+`mcp.server.disconnected`, or `mcp.server.reconnected`.
 
 For accepted stored inbound email, the topic is `email.message.received`.
 Quarantined inbound email dispatches `email.message.quarantined` instead. Both

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -485,7 +485,8 @@ Use the built-in `package_subscriptions_list` capability to discover the
 signed-in user's saved package subscriptions, optionally filtered by exact
 topic. This is the generic discovery step before building fan-out, debugging why
 an event did or did not dispatch, or checking which packages subscribe to
-`email.message.received`, `run.error.recorded`, or `integration.auth.failed`.
+`email.message.received`, `run.error.recorded`, `integration.auth.failed`, or
+`mcp.server.disconnected`.
 
 For accepted stored inbound email, the topic is `email.message.received`.
 Quarantined inbound email dispatches `email.message.quarantined` instead. Both
@@ -511,6 +512,12 @@ dispatches `integration.auth.failed` to your packages that declare that topic.
 The payload is metadata-first (connection name, lane, reason, optional provider
 error fields, and a trusted `reconnect_url`). Every classified attempt emits;
 notifier packages decide how often to ping. See the
+[package subscriptions guide](../guides/package-subscriptions.md).
+
+When a saved MCP server that was previously ready stays down after a lightweight
+hub retry, Kody dispatches `mcp.server.disconnected`. Recovery to ready
+dispatches `mcp.server.reconnected` with the same episode id. The payload is
+metadata-first (server id/name/state, `account_url`). See the
 [package subscriptions guide](../guides/package-subscriptions.md).
 
 Artifacts-backed plain repos, packages, and job sources also emit `repo.pushed`,

--- a/docs/use/synthetic-event-dispatch.md
+++ b/docs/use/synthetic-event-dispatch.md
@@ -137,6 +137,28 @@ Example minimal `integration.auth.failed` fixture:
 }
 ```
 
+Example minimal `mcp.server.disconnected` fixture:
+
+```json
+{
+	"kody_id": "home-watch",
+	"topic": "mcp.server.disconnected",
+	"params": {
+		"event": "mcp.server.disconnected",
+		"event_id": "00000000-0000-4000-8000-000000000001",
+		"server": {
+			"id": "00000000-0000-4000-8000-000000000002",
+			"name": "home",
+			"state": "disconnected",
+			"previous_state": "ready",
+			"episode_id": "00000000-0000-4000-8000-000000000003"
+		},
+		"observed_at": "2026-08-18T17:54:07.000Z",
+		"account_url": "https://kody.codes/account/mcp-servers/00000000-0000-4000-8000-000000000002"
+	}
+}
+```
+
 ### Stored-mail replay (`email_message_id`)
 
 For email topics, pass a stored message id instead of hand-building metadata:

--- a/packages/worker/src/mcp-client/connection-episodes.node.test.ts
+++ b/packages/worker/src/mcp-client/connection-episodes.node.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from 'vitest'
+import {
+	createInitialMcpConnectionEpisode,
+	mcpServerDisconnectedTopic,
+	mcpServerReconnectedTopic,
+	observeMcpConnectionState,
+} from './connection-episodes.ts'
+
+function observe(input: {
+	previous?: ReturnType<typeof createInitialMcpConnectionEpisode>
+	currentState: Parameters<typeof observeMcpConnectionState>[0]['currentState']
+	retryCompleted?: boolean
+	episodeId?: string
+}) {
+	return observeMcpConnectionState({
+		previous: input.previous ?? createInitialMcpConnectionEpisode(),
+		currentState: input.currentState,
+		retryCompleted: input.retryCompleted ?? false,
+		createEpisodeId: () => input.episodeId ?? 'episode-1',
+	})
+}
+
+test('MCP connection episodes retry then emit once per down period', () => {
+	const firstReady = observe({ currentState: 'ready' })
+	expect(firstReady).toEqual({
+		next: {
+			lastObservedState: 'ready',
+			wasReady: true,
+			episodeId: null,
+			disconnectedEmitted: false,
+		},
+		shouldRetry: false,
+		event: null,
+	})
+
+	const neverReady = observe({ currentState: 'disconnected' })
+	expect(neverReady.shouldRetry).toBe(false)
+	expect(neverReady.event).toBeNull()
+
+	const downFromReady = observe({
+		previous: firstReady.next,
+		currentState: 'disconnected',
+	})
+	expect(downFromReady.shouldRetry).toBe(true)
+	expect(downFromReady.event).toBeNull()
+
+	const recoveredDuringRetry = observe({
+		previous: downFromReady.next,
+		currentState: 'ready',
+		retryCompleted: true,
+	})
+	expect(recoveredDuringRetry.event).toBeNull()
+	expect(recoveredDuringRetry.next.wasReady).toBe(true)
+	expect(recoveredDuringRetry.next.episodeId).toBeNull()
+
+	const stillDownAfterRetry = observe({
+		previous: downFromReady.next,
+		currentState: 'failed',
+		retryCompleted: true,
+		episodeId: 'episode-home',
+	})
+	expect(stillDownAfterRetry.shouldRetry).toBe(false)
+	expect(stillDownAfterRetry.event).toEqual({
+		topic: mcpServerDisconnectedTopic,
+		episodeId: 'episode-home',
+		previousState: 'ready',
+	})
+	expect(stillDownAfterRetry.next.disconnectedEmitted).toBe(true)
+
+	const repeatWhileDown = observe({
+		previous: stillDownAfterRetry.next,
+		currentState: 'disconnected',
+	})
+	expect(repeatWhileDown.shouldRetry).toBe(false)
+	expect(repeatWhileDown.event).toBeNull()
+
+	const authenticatingAfterReady = observe({
+		previous: firstReady.next,
+		currentState: 'authenticating',
+	})
+	expect(authenticatingAfterReady.shouldRetry).toBe(false)
+	expect(authenticatingAfterReady.event?.topic).toBe(mcpServerDisconnectedTopic)
+
+	const inFlight = observe({
+		previous: firstReady.next,
+		currentState: 'connecting',
+	})
+	expect(inFlight.event).toBeNull()
+	expect(inFlight.shouldRetry).toBe(false)
+	expect(inFlight.next.wasReady).toBe(true)
+
+	const reconnected = observe({
+		previous: stillDownAfterRetry.next,
+		currentState: 'ready',
+	})
+	expect(reconnected.event).toEqual({
+		topic: mcpServerReconnectedTopic,
+		episodeId: 'episode-home',
+		previousState: 'failed',
+	})
+	expect(reconnected.next.episodeId).toBeNull()
+	expect(reconnected.next.disconnectedEmitted).toBe(false)
+})

--- a/packages/worker/src/mcp-client/connection-episodes.ts
+++ b/packages/worker/src/mcp-client/connection-episodes.ts
@@ -1,0 +1,182 @@
+import { type McpServerConnectionState } from './types.ts'
+
+export const mcpServerDisconnectedTopic = 'mcp.server.disconnected'
+export const mcpServerReconnectedTopic = 'mcp.server.reconnected'
+
+export const mcpLightweightReconnectAttempts = 2
+export const mcpLightweightReconnectBackoffMs = [250] as const
+export const mcpLightweightReconnectDiscoverTimeoutMs = 5_000
+
+export const mcpConnectionEpisodeStoragePrefix = 'mcp-connection-episode/'
+export const mcpConnectionEventsPendingStorageKey =
+	'mcp-connection-events-pending'
+
+export type McpServerConnectionEventTopic =
+	| typeof mcpServerDisconnectedTopic
+	| typeof mcpServerReconnectedTopic
+
+export type McpConnectionEpisodeRecord = {
+	lastObservedState: McpServerConnectionState | 'unknown'
+	wasReady: boolean
+	episodeId: string | null
+	disconnectedEmitted: boolean
+}
+
+export type McpServerConnectionEvent = {
+	topic: McpServerConnectionEventTopic
+	eventId: string
+	episodeId: string
+	serverId: string
+	serverName: string
+	state: McpServerConnectionState
+	previousState: McpServerConnectionState | 'unknown'
+	observedAt: string
+}
+
+export type McpConnectionObserveDecision = {
+	next: McpConnectionEpisodeRecord
+	shouldRetry: boolean
+	event: {
+		topic: McpServerConnectionEventTopic
+		episodeId: string
+		previousState: McpServerConnectionState | 'unknown'
+	} | null
+}
+
+export function mcpConnectionEpisodeStorageKey(serverId: string) {
+	return `${mcpConnectionEpisodeStoragePrefix}${serverId}`
+}
+
+export function createInitialMcpConnectionEpisode(): McpConnectionEpisodeRecord {
+	return {
+		lastObservedState: 'unknown',
+		wasReady: false,
+		episodeId: null,
+		disconnectedEmitted: false,
+	}
+}
+
+export function isMcpServerUnavailableState(
+	state: McpServerConnectionState,
+): boolean {
+	return (
+		state === 'disconnected' || state === 'failed' || state === 'authenticating'
+	)
+}
+
+export function isMcpServerInFlightState(
+	state: McpServerConnectionState,
+): boolean {
+	return (
+		state === 'connecting' || state === 'connected' || state === 'discovering'
+	)
+}
+
+/**
+ * Classify one observed hub state against the persisted episode.
+ *
+ * Ready is recorded the first time we see it. A later unavailable state
+ * retries (except `authenticating`, which needs the user) and then emits
+ * `mcp.server.disconnected` once per episode. Recovery to ready emits
+ * `mcp.server.reconnected` for that same episode.
+ */
+export function observeMcpConnectionState(input: {
+	previous: McpConnectionEpisodeRecord
+	currentState: McpServerConnectionState
+	retryCompleted: boolean
+	createEpisodeId: () => string
+}): McpConnectionObserveDecision {
+	const previousState = input.previous.lastObservedState
+
+	if (input.currentState === 'ready') {
+		if (
+			input.previous.wasReady &&
+			input.previous.episodeId &&
+			input.previous.disconnectedEmitted
+		) {
+			return {
+				next: {
+					lastObservedState: 'ready',
+					wasReady: true,
+					episodeId: null,
+					disconnectedEmitted: false,
+				},
+				shouldRetry: false,
+				event: {
+					topic: mcpServerReconnectedTopic,
+					episodeId: input.previous.episodeId,
+					previousState,
+				},
+			}
+		}
+		return {
+			next: {
+				lastObservedState: 'ready',
+				wasReady: true,
+				episodeId: null,
+				disconnectedEmitted: false,
+			},
+			shouldRetry: false,
+			event: null,
+		}
+	}
+
+	if (isMcpServerInFlightState(input.currentState)) {
+		return {
+			next: {
+				...input.previous,
+				lastObservedState: input.currentState,
+			},
+			shouldRetry: false,
+			event: null,
+		}
+	}
+
+	if (!input.previous.wasReady) {
+		return {
+			next: {
+				...input.previous,
+				lastObservedState: input.currentState,
+			},
+			shouldRetry: false,
+			event: null,
+		}
+	}
+
+	if (input.previous.disconnectedEmitted && input.previous.episodeId) {
+		return {
+			next: {
+				...input.previous,
+				lastObservedState: input.currentState,
+			},
+			shouldRetry: false,
+			event: null,
+		}
+	}
+
+	const skipRetry =
+		input.retryCompleted || input.currentState === 'authenticating'
+	if (!skipRetry) {
+		return {
+			next: input.previous,
+			shouldRetry: true,
+			event: null,
+		}
+	}
+
+	const episodeId = input.previous.episodeId ?? input.createEpisodeId()
+	return {
+		next: {
+			lastObservedState: input.currentState,
+			wasReady: true,
+			episodeId,
+			disconnectedEmitted: true,
+		},
+		shouldRetry: false,
+		event: {
+			topic: mcpServerDisconnectedTopic,
+			episodeId,
+			previousState,
+		},
+	}
+}

--- a/packages/worker/src/mcp-client/hub-client.ts
+++ b/packages/worker/src/mcp-client/hub-client.ts
@@ -1,6 +1,7 @@
 import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { PromiseLruCache } from '#worker/package-registry/published-package-cache.ts'
 import { mcpClientHubDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
+import { type McpServerConnectionEvent } from './connection-episodes.ts'
 import {
 	type McpClientHubSnapshot,
 	type McpServerConnectResult,
@@ -10,6 +11,12 @@ import {
 export const mcpClientHubSnapshotCacheTtlMs = 30_000
 export const mcpClientHubSnapshotCacheLimit = 100
 
+type McpClientHubClientInput = {
+	env: Env
+	userId: string
+	waitUntil?: (promise: Promise<unknown>) => void
+}
+
 /** Cache/DO key alias for {@link mcpClientHubDurableObjectName}. */
 export function mcpClientHubKey(userId: string) {
 	return mcpClientHubDurableObjectName(userId)
@@ -18,6 +25,18 @@ export function mcpClientHubKey(userId: string) {
 function getMcpClientHubStub(input: { env: Env; userId: string }) {
 	const key = mcpClientHubDurableObjectName(input.userId)
 	return input.env.MCP_CLIENT_HUB.get(input.env.MCP_CLIENT_HUB.idFromName(key))
+}
+
+async function emitMcpServerConnectionEvents(input: {
+	env: Env
+	userId: string
+	events: Array<McpServerConnectionEvent>
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	if (input.events.length === 0) return
+	const { emitMcpServerConnectionEventsIfNeeded } =
+		await import('./package-subscriptions.ts')
+	await emitMcpServerConnectionEventsIfNeeded(input)
 }
 
 export type McpClientHubClient = {
@@ -46,23 +65,28 @@ export type McpClientHubClient = {
 	}): Promise<CallToolResult>
 }
 
-export function createMcpClientHubClient(input: {
-	env: Env
-	userId: string
-}): McpClientHubClient {
+export function createMcpClientHubClient(
+	input: McpClientHubClientInput,
+): McpClientHubClient {
 	const stub = getMcpClientHubStub(input)
 	return {
 		async addServer(addInput) {
 			invalidateMcpClientHubSnapshotCache(input)
-			return await stub.addServer(addInput)
+			const result = await stub.addServer(addInput)
+			await emitTakenConnectionEvents(input, stub)
+			return result
 		},
 		async reconnectServer(reconnectInput) {
 			invalidateMcpClientHubSnapshotCache(input)
-			return await stub.reconnectServer(reconnectInput)
+			const result = await stub.reconnectServer(reconnectInput)
+			await emitTakenConnectionEvents(input, stub)
+			return result
 		},
 		async refreshServer(refreshInput) {
 			invalidateMcpClientHubSnapshotCache(input)
-			return await stub.refreshServer(refreshInput)
+			const result = await stub.refreshServer(refreshInput)
+			await emitTakenConnectionEvents(input, stub)
+			return result
 		},
 		async removeServer(removeInput) {
 			invalidateMcpClientHubSnapshotCache(input)
@@ -70,20 +94,39 @@ export function createMcpClientHubClient(input: {
 		},
 		async handleOAuthCallback(callbackInput) {
 			invalidateMcpClientHubSnapshotCache(input)
-			return await stub.handleOAuthCallback(callbackInput)
+			const result = await stub.handleOAuthCallback(callbackInput)
+			await emitTakenConnectionEvents(input, stub)
+			return result
 		},
 		async getSnapshot() {
 			return getCachedMcpClientHubSnapshot(input)
 		},
 		async callTool(callInput) {
 			try {
-				return (await stub.callTool(callInput)) as CallToolResult
+				const result = (await stub.callTool(callInput)) as CallToolResult
+				await emitTakenConnectionEvents(input, stub)
+				return result
 			} catch (error) {
 				invalidateMcpClientHubSnapshotCache(input)
+				await emitTakenConnectionEvents(input, stub)
 				throw error
 			}
 		},
 	}
+}
+
+async function emitTakenConnectionEvents(
+	input: McpClientHubClientInput,
+	stub: ReturnType<typeof getMcpClientHubStub>,
+) {
+	const events =
+		(await stub.takeConnectionEvents()) as Array<McpServerConnectionEvent>
+	await emitMcpServerConnectionEvents({
+		env: input.env,
+		userId: input.userId,
+		events,
+		waitUntil: input.waitUntil,
+	})
 }
 
 function createMcpClientHubSnapshotCache() {
@@ -95,16 +138,22 @@ function createMcpClientHubSnapshotCache() {
 
 let mcpClientHubSnapshotCache = createMcpClientHubSnapshotCache()
 
-export function getCachedMcpClientHubSnapshot(input: {
-	env: Env
-	userId: string
-}): Promise<McpClientHubSnapshot> {
+export function getCachedMcpClientHubSnapshot(
+	input: McpClientHubClientInput,
+): Promise<McpClientHubSnapshot> {
 	const cacheKey = mcpClientHubKey(input.userId)
 	return mcpClientHubSnapshotCache.getOrCreate({
 		cacheKey,
 		create: async () => {
 			const stub = getMcpClientHubStub(input)
-			return await stub.getSnapshot()
+			const snapshot = await stub.getSnapshot()
+			await emitMcpServerConnectionEvents({
+				env: input.env,
+				userId: input.userId,
+				events: snapshot.connectionEvents ?? [],
+				waitUntil: input.waitUntil,
+			})
+			return { servers: snapshot.servers }
 		},
 	})
 }

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -35,6 +35,7 @@ type FakeManager = {
 	rows: Array<FakeServerRow>
 	mcpConnections: Record<string, FakeConnection>
 	connectCount: number
+	connectBehavior: 'oauth' | 'ready' | 'disconnected'
 	registerFailuresRemaining: number
 	callbackMatches: boolean
 	callbackResult: {
@@ -90,6 +91,7 @@ vi.mock('agents/mcp/client', () => ({
 		rows: Array<FakeServerRow> = []
 		mcpConnections: Record<string, FakeConnection> = {}
 		connectCount = 0
+		connectBehavior: 'oauth' | 'ready' | 'disconnected' = 'oauth'
 		registerFailuresRemaining = 0
 		callbackMatches = true
 		callbackResult = {
@@ -157,6 +159,16 @@ vi.mock('agents/mcp/client', () => ({
 			const connection = this.mcpConnections[serverId]
 			if (!connection) throw new Error('Missing fake connection.')
 			const provider = connection.options.transport.authProvider
+			if (this.connectBehavior === 'ready') {
+				connection.connectionState = 'ready'
+				connection.connectionError = null
+				return { state: 'connected' }
+			}
+			if (this.connectBehavior === 'disconnected') {
+				connection.connectionState = 'disconnected'
+				connection.connectionError = 'upstream closed'
+				return { state: 'disconnected' }
+			}
 			provider.clientId ??= `client-${this.connectCount}`
 			provider.authUrl = `https://auth.example/authorize?state=fresh-${this.connectCount}.${serverId}&redirect_uri=${encodeURIComponent(provider.redirectUrl)}`
 			connection.connectionState = 'authenticating'
@@ -297,7 +309,9 @@ test('reconnect repairs stale callbacks and always replaces pending OAuth state'
 	expect(manager.mcpConnections['server-1']?.options.transport.headers).toEqual(
 		{ 'X-Test': 'preserved' },
 	)
-	expect(values.size).toBe(0)
+	expect([...values.keys()].filter((key) => key.startsWith('/Kody/'))).toEqual(
+		[],
+	)
 
 	values.set('/Kody/server-1/client-1/client_info/', {
 		client_id: 'client-1',
@@ -430,4 +444,74 @@ test('used and missing callback states recover without exposing an internal stat
 	expect(missingState.serverId).toBe('server-1')
 	expect(missingState.authError).not.toContain('state')
 	expect(manager.rows[0]?.auth_url).toContain('state=fresh-2.server-1')
+})
+
+test('snapshot retries a previously ready server before emitting disconnect', async () => {
+	const { state, values } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const callbackUrl = 'https://kody.codes/account/mcp-servers/oauth/callback'
+	seedServer({
+		manager,
+		callbackUrl,
+		clientId: 'client-1',
+		authUrl: 'https://auth.example/authorize?state=ok.server-1',
+	})
+	const connection = manager.mcpConnections['server-1']
+	if (!connection) throw new Error('Fake connection was not seeded.')
+	connection.connectionState = 'ready'
+	manager.rows[0]!.name = 'home'
+
+	const readySnapshot = await hub.getSnapshot()
+	expect(readySnapshot.connectionEvents).toEqual([])
+	expect(values.get('mcp-connection-episode/server-1')).toEqual({
+		lastObservedState: 'ready',
+		wasReady: true,
+		episodeId: null,
+		disconnectedEmitted: false,
+	})
+
+	connection.connectionState = 'disconnected'
+	manager.connectBehavior = 'ready'
+	const recovered = await hub.getSnapshot()
+	expect(manager.connectCount).toBe(1)
+	expect(recovered.servers[0]?.state).toBe('ready')
+	expect(recovered.connectionEvents).toEqual([])
+
+	connection.connectionState = 'disconnected'
+	manager.connectBehavior = 'disconnected'
+	const down = await hub.getSnapshot()
+	expect(manager.connectCount).toBe(3)
+	expect(down.servers[0]?.state).toBe('disconnected')
+	expect(down.connectionEvents).toEqual([
+		expect.objectContaining({
+			topic: 'mcp.server.disconnected',
+			serverId: 'server-1',
+			serverName: 'home',
+			state: 'disconnected',
+			previousState: 'ready',
+		}),
+	])
+	const episode = values.get('mcp-connection-episode/server-1') as {
+		episodeId: string
+		disconnectedEmitted: boolean
+	}
+	expect(episode.disconnectedEmitted).toBe(true)
+	expect(episode.episodeId).toBeTruthy()
+
+	const stillDown = await hub.getSnapshot()
+	expect(manager.connectCount).toBe(3)
+	expect(stillDown.connectionEvents).toEqual([])
+
+	connection.connectionState = 'ready'
+	const back = await hub.getSnapshot()
+	expect(back.connectionEvents).toEqual([
+		expect.objectContaining({
+			topic: 'mcp.server.reconnected',
+			serverId: 'server-1',
+			episodeId: episode.episodeId,
+			state: 'ready',
+		}),
+	])
 })

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -36,6 +36,7 @@ type FakeManager = {
 	mcpConnections: Record<string, FakeConnection>
 	connectCount: number
 	connectBehavior: 'oauth' | 'ready' | 'disconnected'
+	connectBehaviors: Array<'oauth' | 'ready' | 'disconnected'>
 	registerFailuresRemaining: number
 	callbackMatches: boolean
 	callbackResult: {
@@ -92,6 +93,7 @@ vi.mock('agents/mcp/client', () => ({
 		mcpConnections: Record<string, FakeConnection> = {}
 		connectCount = 0
 		connectBehavior: 'oauth' | 'ready' | 'disconnected' = 'oauth'
+		connectBehaviors: Array<'oauth' | 'ready' | 'disconnected'> = []
 		registerFailuresRemaining = 0
 		callbackMatches = true
 		callbackResult = {
@@ -154,17 +156,21 @@ vi.mock('agents/mcp/client', () => ({
 			}
 		}
 
+		async establishConnection() {}
+
 		async connectToServer(serverId: string) {
 			this.connectCount += 1
 			const connection = this.mcpConnections[serverId]
 			if (!connection) throw new Error('Missing fake connection.')
 			const provider = connection.options.transport.authProvider
-			if (this.connectBehavior === 'ready') {
+			const connectBehavior =
+				this.connectBehaviors.shift() ?? this.connectBehavior
+			if (connectBehavior === 'ready') {
 				connection.connectionState = 'ready'
 				connection.connectionError = null
 				return { state: 'connected' }
 			}
-			if (this.connectBehavior === 'disconnected') {
+			if (connectBehavior === 'disconnected') {
 				connection.connectionState = 'disconnected'
 				connection.connectionError = 'upstream closed'
 				return { state: 'disconnected' }
@@ -273,6 +279,25 @@ function seedServer(input: {
 			},
 		},
 	}
+}
+
+async function seedReadyHomeServer(input: {
+	hub: InstanceType<typeof McpClientHub>
+	manager: FakeManager
+}) {
+	const callbackUrl = 'https://kody.codes/account/mcp-servers/oauth/callback'
+	seedServer({
+		manager: input.manager,
+		callbackUrl,
+		clientId: 'client-1',
+		authUrl: 'https://auth.example/authorize?state=ok.server-1',
+	})
+	const connection = input.manager.mcpConnections['server-1']
+	if (!connection) throw new Error('Fake connection was not seeded.')
+	connection.connectionState = 'ready'
+	input.manager.rows[0]!.name = 'home'
+	await input.hub.getSnapshot()
+	return { callbackUrl, connection }
 }
 
 test('reconnect repairs stale callbacks and always replaces pending OAuth state', async () => {
@@ -514,4 +539,84 @@ test('snapshot retries a previously ready server before emitting disconnect', as
 			state: 'ready',
 		}),
 	])
+
+	const batchWrites = (
+		state.storage.put as ReturnType<typeof vi.fn>
+	).mock.calls.filter(
+		(call): call is [Record<string, unknown>] =>
+			typeof call[0] === 'object' &&
+			call[0] !== null &&
+			'mcp-connection-events-pending' in call[0],
+	)
+	expect(batchWrites.length).toBeGreaterThan(0)
+	for (const [entries] of batchWrites) {
+		expect(
+			Object.keys(entries).some((key) =>
+				key.startsWith('mcp-connection-episode/'),
+			),
+		).toBe(true)
+	}
+})
+
+test('refreshServer returns the recovered ready connection after a lightweight retry', async () => {
+	const { state } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const { connection } = await seedReadyHomeServer({ hub, manager })
+	connection.connectionState = 'disconnected'
+	manager.connectBehavior = 'ready'
+	const result = await hub.refreshServer({ serverId: 'server-1' })
+	expect(result.state).toBe('ready')
+})
+
+test('reconnectServer returns the recovered ready connection after a lightweight retry', async () => {
+	const { state } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const { callbackUrl } = await seedReadyHomeServer({ hub, manager })
+	manager.connectBehaviors = ['disconnected', 'ready']
+	const result = await hub.reconnectServer({
+		serverId: 'server-1',
+		callbackUrl,
+	})
+	expect(result.state).toBe('ready')
+})
+
+test('addServer returns the recovered ready connection after a lightweight retry', async () => {
+	const { state } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const { callbackUrl } = await seedReadyHomeServer({ hub, manager })
+	manager.connectBehaviors = ['disconnected', 'ready']
+	const result = await hub.addServer({
+		serverId: 'server-1',
+		name: 'home',
+		url: 'https://kody-home.doddsfamily.us/mcp',
+		callbackUrl,
+	})
+	expect(result.state).toBe('ready')
+})
+
+test('handleOAuthCallback reports success after observe recovers a previously ready server', async () => {
+	const { state } = createDurableObjectState()
+	const hub = new McpClientHub(state, {} as Env)
+	const manager = mockModule.manager
+	if (!manager) throw new Error('Fake manager was not constructed.')
+	const { callbackUrl, connection } = await seedReadyHomeServer({
+		hub,
+		manager,
+	})
+	connection.connectionState = 'disconnected'
+	manager.connectBehavior = 'ready'
+	manager.callbackMatches = true
+	manager.callbackResult = { serverId: 'server-1', authSuccess: true }
+	const result = await hub.handleOAuthCallback({
+		url: `${callbackUrl}?code=abc&state=ok.server-1`,
+		callbackUrl,
+	})
+	expect(result.authSuccess).toBe(true)
+	expect(result.authorizationNeeded).toBe(false)
 })

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -12,6 +12,17 @@ import {
 	resolveMcpOAuthCallbackOutcome,
 } from './oauth-callback-outcome.ts'
 import {
+	createInitialMcpConnectionEpisode,
+	mcpConnectionEpisodeStorageKey,
+	mcpConnectionEventsPendingStorageKey,
+	mcpLightweightReconnectAttempts,
+	mcpLightweightReconnectBackoffMs,
+	mcpLightweightReconnectDiscoverTimeoutMs,
+	observeMcpConnectionState,
+	type McpConnectionEpisodeRecord,
+	type McpServerConnectionEvent,
+} from './connection-episodes.ts'
+import {
 	type McpClientHubSnapshot,
 	type McpServerConnectResult,
 	type McpServerConnectionState,
@@ -194,13 +205,18 @@ class McpClientHubBase extends DurableObject<Env> {
 				...(input.headers ? { headers: input.headers } : {}),
 			},
 		})
-		const result = await this.manager.connectToServer(input.serverId)
-		if (result.state === 'connected') {
+		const connected = await this.manager.connectToServer(input.serverId)
+		if (connected.state === 'connected') {
 			await this.manager.discoverIfConnected(input.serverId, {
 				timeoutMs: discoverTimeoutMs,
 			})
 		}
-		return this.buildConnectResult(input.serverId)
+		const result = this.buildConnectResult(input.serverId)
+		await this.observeServer({
+			serverId: input.serverId,
+			serverName: input.name,
+		})
+		return result
 	}
 
 	/**
@@ -219,7 +235,17 @@ class McpClientHubBase extends DurableObject<Env> {
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
 		})
-		return await this.restartServerAuthorization(input)
+		const result = await this.restartServerAuthorization(input)
+		const row = this.manager
+			.listServers()
+			.find((server) => server.id === input.serverId)
+		if (row) {
+			await this.observeServer({
+				serverId: row.id,
+				serverName: row.name,
+			})
+		}
+		return result
 	}
 
 	/** Re-discover tools for a connected server. */
@@ -233,12 +259,25 @@ class McpClientHubBase extends DurableObject<Env> {
 		await this.manager.discoverIfConnected(input.serverId, {
 			timeoutMs: discoverTimeoutMs,
 		})
-		return this.buildConnectResult(input.serverId)
+		const result = this.buildConnectResult(input.serverId)
+		const row = this.manager
+			.listServers()
+			.find((server) => server.id === input.serverId)
+		if (row) {
+			await this.observeServer({
+				serverId: row.id,
+				serverName: row.name,
+			})
+		}
+		return result
 	}
 
 	async removeServer(input: { serverId: string }): Promise<void> {
 		await this.ensureRestored()
 		await this.manager.removeServer(input.serverId)
+		await this.ctx.storage.delete(
+			mcpConnectionEpisodeStorageKey(input.serverId),
+		)
 	}
 
 	/**
@@ -311,6 +350,12 @@ class McpClientHubBase extends DurableObject<Env> {
 			let connection = this.buildConnectResult(serverId)
 			if (isStuckMcpAuthenticatingWithoutAuthUrl(connection)) {
 				connection = await this.recoverStuckAuthenticating(serverId)
+			}
+			if (serverName) {
+				await this.observeServer({
+					serverId,
+					serverName,
+				})
 			}
 			return resolveMcpOAuthCallbackOutcome({
 				sdkAuthSuccess: true,
@@ -519,10 +564,17 @@ class McpClientHubBase extends DurableObject<Env> {
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
 		})
+		for (const row of this.manager.listServers()) {
+			await this.observeServer({
+				serverId: row.id,
+				serverName: row.name,
+			})
+		}
 		return {
 			servers: this.manager
 				.listServers()
 				.map((row) => this.buildServerSnapshot(row)),
+			connectionEvents: await this.takeConnectionEvents(),
 		}
 	}
 
@@ -535,6 +587,15 @@ class McpClientHubBase extends DurableObject<Env> {
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
 		})
+		const row = this.manager
+			.listServers()
+			.find((server) => server.id === input.serverId)
+		if (row) {
+			await this.observeServer({
+				serverId: row.id,
+				serverName: row.name,
+			})
+		}
 		const state = this.connectionStateFor(input.serverId)
 		if (state !== 'ready') {
 			throw new Error(
@@ -546,6 +607,114 @@ class McpClientHubBase extends DurableObject<Env> {
 			name: input.toolName,
 			arguments: input.args,
 		})) as CallToolResult
+	}
+
+	async takeConnectionEvents(): Promise<Array<McpServerConnectionEvent>> {
+		const events =
+			(await this.ctx.storage.get<Array<McpServerConnectionEvent>>(
+				mcpConnectionEventsPendingStorageKey,
+			)) ?? []
+		if (events.length > 0) {
+			await this.ctx.storage.delete(mcpConnectionEventsPendingStorageKey)
+		}
+		return events
+	}
+
+	private async readEpisode(
+		serverId: string,
+	): Promise<McpConnectionEpisodeRecord> {
+		return (
+			(await this.ctx.storage.get<McpConnectionEpisodeRecord>(
+				mcpConnectionEpisodeStorageKey(serverId),
+			)) ?? createInitialMcpConnectionEpisode()
+		)
+	}
+
+	private async writeEpisode(
+		serverId: string,
+		episode: McpConnectionEpisodeRecord,
+	) {
+		await this.ctx.storage.put(
+			mcpConnectionEpisodeStorageKey(serverId),
+			episode,
+		)
+	}
+
+	private async appendConnectionEvent(event: McpServerConnectionEvent) {
+		const existing =
+			(await this.ctx.storage.get<Array<McpServerConnectionEvent>>(
+				mcpConnectionEventsPendingStorageKey,
+			)) ?? []
+		await this.ctx.storage.put(mcpConnectionEventsPendingStorageKey, [
+			...existing,
+			event,
+		])
+	}
+
+	private async lightweightReconnectServer(serverId: string) {
+		const connected = await this.manager.connectToServer(serverId)
+		if (connected.state === 'connected') {
+			await this.manager.discoverIfConnected(serverId, {
+				timeoutMs: mcpLightweightReconnectDiscoverTimeoutMs,
+			})
+		}
+		return this.buildConnectResult(serverId)
+	}
+
+	private async recoverUnavailableServer(serverId: string) {
+		for (
+			let attempt = 0;
+			attempt < mcpLightweightReconnectAttempts;
+			attempt++
+		) {
+			if (attempt > 0) {
+				const backoffMs = mcpLightweightReconnectBackoffMs[attempt - 1] ?? 0
+				if (backoffMs > 0) {
+					await new Promise((resolve) => setTimeout(resolve, backoffMs))
+				}
+			}
+			try {
+				const result = await this.lightweightReconnectServer(serverId)
+				if (result.state === 'ready' || result.state === 'authenticating') {
+					return
+				}
+			} catch {
+				// The next attempt (or the observe pass) records the still-down state.
+			}
+		}
+	}
+
+	private async observeServer(input: { serverId: string; serverName: string }) {
+		const previous = await this.readEpisode(input.serverId)
+		const first = observeMcpConnectionState({
+			previous,
+			currentState: this.connectionStateFor(input.serverId),
+			retryCompleted: false,
+			createEpisodeId: () => crypto.randomUUID(),
+		})
+		let decision = first
+		if (first.shouldRetry) {
+			await this.writeEpisode(input.serverId, first.next)
+			await this.recoverUnavailableServer(input.serverId)
+			decision = observeMcpConnectionState({
+				previous: first.next,
+				currentState: this.connectionStateFor(input.serverId),
+				retryCompleted: true,
+				createEpisodeId: () => crypto.randomUUID(),
+			})
+		}
+		await this.writeEpisode(input.serverId, decision.next)
+		if (!decision.event) return
+		await this.appendConnectionEvent({
+			topic: decision.event.topic,
+			eventId: crypto.randomUUID(),
+			episodeId: decision.event.episodeId,
+			serverId: input.serverId,
+			serverName: input.serverName,
+			state: this.connectionStateFor(input.serverId),
+			previousState: decision.event.previousState,
+			observedAt: new Date().toISOString(),
+		})
 	}
 
 	/** Close all connections and wipe stored servers, tokens, and OAuth state. */

--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -211,12 +211,11 @@ class McpClientHubBase extends DurableObject<Env> {
 				timeoutMs: discoverTimeoutMs,
 			})
 		}
-		const result = this.buildConnectResult(input.serverId)
 		await this.observeServer({
 			serverId: input.serverId,
 			serverName: input.name,
 		})
-		return result
+		return this.buildConnectResult(input.serverId)
 	}
 
 	/**
@@ -235,7 +234,7 @@ class McpClientHubBase extends DurableObject<Env> {
 		await this.manager.waitForConnections({
 			timeout: connectionSettleTimeoutMs,
 		})
-		const result = await this.restartServerAuthorization(input)
+		await this.restartServerAuthorization(input)
 		const row = this.manager
 			.listServers()
 			.find((server) => server.id === input.serverId)
@@ -245,7 +244,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				serverName: row.name,
 			})
 		}
-		return result
+		return this.buildConnectResult(input.serverId)
 	}
 
 	/** Re-discover tools for a connected server. */
@@ -259,7 +258,6 @@ class McpClientHubBase extends DurableObject<Env> {
 		await this.manager.discoverIfConnected(input.serverId, {
 			timeoutMs: discoverTimeoutMs,
 		})
-		const result = this.buildConnectResult(input.serverId)
 		const row = this.manager
 			.listServers()
 			.find((server) => server.id === input.serverId)
@@ -269,7 +267,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				serverName: row.name,
 			})
 		}
-		return result
+		return this.buildConnectResult(input.serverId)
 	}
 
 	async removeServer(input: { serverId: string }): Promise<void> {
@@ -362,7 +360,7 @@ class McpClientHubBase extends DurableObject<Env> {
 				sdkAuthError: result.authError ?? null,
 				serverId,
 				serverName,
-				connection,
+				connection: this.buildConnectResult(serverId),
 			})
 		}
 		return resolveMcpOAuthCallbackOutcome({
@@ -633,22 +631,19 @@ class McpClientHubBase extends DurableObject<Env> {
 	private async writeEpisode(
 		serverId: string,
 		episode: McpConnectionEpisodeRecord,
+		event?: McpServerConnectionEvent,
 	) {
-		await this.ctx.storage.put(
-			mcpConnectionEpisodeStorageKey(serverId),
-			episode,
-		)
-	}
-
-	private async appendConnectionEvent(event: McpServerConnectionEvent) {
-		const existing =
-			(await this.ctx.storage.get<Array<McpServerConnectionEvent>>(
-				mcpConnectionEventsPendingStorageKey,
-			)) ?? []
-		await this.ctx.storage.put(mcpConnectionEventsPendingStorageKey, [
-			...existing,
-			event,
-		])
+		const entries: Record<string, unknown> = {
+			[mcpConnectionEpisodeStorageKey(serverId)]: episode,
+		}
+		if (event) {
+			const existing =
+				(await this.ctx.storage.get<Array<McpServerConnectionEvent>>(
+					mcpConnectionEventsPendingStorageKey,
+				)) ?? []
+			entries[mcpConnectionEventsPendingStorageKey] = [...existing, event]
+		}
+		await this.ctx.storage.put(entries)
 	}
 
 	private async lightweightReconnectServer(serverId: string) {
@@ -703,18 +698,22 @@ class McpClientHubBase extends DurableObject<Env> {
 				createEpisodeId: () => crypto.randomUUID(),
 			})
 		}
-		await this.writeEpisode(input.serverId, decision.next)
-		if (!decision.event) return
-		await this.appendConnectionEvent({
-			topic: decision.event.topic,
-			eventId: crypto.randomUUID(),
-			episodeId: decision.event.episodeId,
-			serverId: input.serverId,
-			serverName: input.serverName,
-			state: this.connectionStateFor(input.serverId),
-			previousState: decision.event.previousState,
-			observedAt: new Date().toISOString(),
-		})
+		await this.writeEpisode(
+			input.serverId,
+			decision.next,
+			decision.event
+				? {
+						topic: decision.event.topic,
+						eventId: crypto.randomUUID(),
+						episodeId: decision.event.episodeId,
+						serverId: input.serverId,
+						serverName: input.serverName,
+						state: this.connectionStateFor(input.serverId),
+						previousState: decision.event.previousState,
+						observedAt: new Date().toISOString(),
+					}
+				: undefined,
+		)
 	}
 
 	/** Close all connections and wipe stored servers, tokens, and OAuth state. */

--- a/packages/worker/src/mcp-client/package-subscriptions.node.test.ts
+++ b/packages/worker/src/mcp-client/package-subscriptions.node.test.ts
@@ -1,0 +1,198 @@
+import { expect, test, vi } from 'vitest'
+import { consoleWarn } from '#worker/test-support/console-spies.ts'
+import {
+	mcpServerDisconnectedTopic,
+	mcpServerReconnectedTopic,
+	type McpServerConnectionEvent,
+} from './connection-episodes.ts'
+
+const mocks = vi.hoisted(() => ({
+	invokePackageSubscription: vi.fn(async () => ({ status: 200, body: {} })),
+	listSavedPackagesByUserId: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
+	listEnabledMcpServerSettingRows: vi.fn(),
+}))
+
+vi.mock('#worker/package-invocations/service.ts', () => ({
+	invokePackageSubscription: mocks.invokePackageSubscription,
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: mocks.listSavedPackagesByUserId,
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: mocks.loadPackageManifestBySourceId,
+}))
+
+vi.mock('./settings-repo.ts', () => ({
+	listEnabledMcpServerSettingRows: mocks.listEnabledMcpServerSettingRows,
+}))
+
+const {
+	dispatchMcpServerConnectionSubscriptionEvents,
+	emitMcpServerConnectionEventsIfNeeded,
+} = await import('./package-subscriptions.ts')
+
+function createEnv() {
+	return {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {},
+		APP_BASE_URL: 'https://example.com',
+	} as Env
+}
+
+function disconnectedEvent(): McpServerConnectionEvent {
+	return {
+		topic: mcpServerDisconnectedTopic,
+		eventId: 'event-1',
+		episodeId: 'episode-1',
+		serverId: 'server-home',
+		serverName: 'home',
+		state: 'disconnected',
+		previousState: 'ready',
+		observedAt: '2026-08-18T17:54:07.000Z',
+	}
+}
+
+function subscribedManifest(input: { topic: string }) {
+	return {
+		manifest: {
+			name: '@user/home-watch',
+			kody: {
+				id: 'home-watch',
+				description: 'Home MCP notifier',
+				subscriptions: {
+					[input.topic]: {
+						handler: './src/on-mcp-server.ts',
+					},
+				},
+			},
+		},
+	}
+}
+
+test('mcp.server.disconnected fans out a lean same-user payload', async () => {
+	const savedPackage = {
+		id: 'package-1',
+		userId: 'user-1',
+		sourceId: 'source-1',
+		kodyId: 'home-watch',
+		name: '@user/home-watch',
+	}
+	mocks.listSavedPackagesByUserId.mockResolvedValueOnce([savedPackage])
+	mocks.loadPackageManifestBySourceId.mockResolvedValueOnce(
+		subscribedManifest({ topic: mcpServerDisconnectedTopic }),
+	)
+	const env = createEnv()
+	const event = disconnectedEvent()
+
+	const results = await dispatchMcpServerConnectionSubscriptionEvents({
+		env,
+		userId: 'user-1',
+		event,
+	})
+
+	expect(results).toHaveLength(1)
+	expect(mocks.invokePackageSubscription).toHaveBeenCalledWith(
+		expect.objectContaining({
+			savedPackage,
+			topic: mcpServerDisconnectedTopic,
+			idempotencyKey: `mcp-server:${mcpServerDisconnectedTopic}:episode-1:package-1`,
+			source: 'mcp-client',
+			params: {
+				event: mcpServerDisconnectedTopic,
+				event_id: 'event-1',
+				server: {
+					id: 'server-home',
+					name: 'home',
+					state: 'disconnected',
+					previous_state: 'ready',
+					episode_id: 'episode-1',
+				},
+				observed_at: '2026-08-18T17:54:07.000Z',
+				account_url: 'https://example.com/account/mcp-servers/server-home',
+			},
+		}),
+	)
+	const params = mocks.invokePackageSubscription.mock.calls[0]?.[0]?.params as
+		| Record<string, unknown>
+		| undefined
+	expect(params).not.toHaveProperty('url')
+	expect(params).not.toHaveProperty('authUrl')
+	expect(params).not.toHaveProperty('access_token')
+	expect(JSON.stringify(params)).not.toContain('Bearer')
+})
+
+test('mcp.server connection events skip disabled servers and never throw', async () => {
+	consoleWarn.mockImplementation(() => {})
+	mocks.invokePackageSubscription.mockReset()
+	mocks.listSavedPackagesByUserId.mockReset()
+	mocks.loadPackageManifestBySourceId.mockReset()
+	mocks.listEnabledMcpServerSettingRows.mockReset()
+	const env = createEnv()
+	const event = disconnectedEvent()
+
+	mocks.listEnabledMcpServerSettingRows.mockResolvedValueOnce([])
+	await emitMcpServerConnectionEventsIfNeeded({
+		env,
+		userId: 'user-1',
+		events: [event],
+	})
+	expect(mocks.invokePackageSubscription).not.toHaveBeenCalled()
+
+	mocks.listEnabledMcpServerSettingRows.mockResolvedValueOnce([
+		{ id: 'server-home' },
+	])
+	mocks.listSavedPackagesByUserId.mockRejectedValueOnce(
+		new Error('D1 unavailable'),
+	)
+	await expect(
+		emitMcpServerConnectionEventsIfNeeded({
+			env,
+			userId: 'user-1',
+			events: [event],
+		}),
+	).resolves.toBeUndefined()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'mcp.server connection package subscription discovery incomplete',
+		expect.objectContaining({
+			eventId: 'event-1',
+			topic: mcpServerDisconnectedTopic,
+			serverName: 'home',
+		}),
+	)
+
+	mocks.listEnabledMcpServerSettingRows.mockResolvedValueOnce([
+		{ id: 'server-home' },
+	])
+	mocks.listSavedPackagesByUserId.mockResolvedValueOnce([
+		{
+			id: 'package-1',
+			userId: 'user-1',
+			sourceId: 'source-1',
+			kodyId: 'home-watch',
+			name: '@user/home-watch',
+		},
+	])
+	mocks.loadPackageManifestBySourceId.mockResolvedValueOnce(
+		subscribedManifest({ topic: mcpServerReconnectedTopic }),
+	)
+	await emitMcpServerConnectionEventsIfNeeded({
+		env,
+		userId: 'user-1',
+		events: [
+			{
+				...event,
+				topic: mcpServerReconnectedTopic,
+				state: 'ready',
+				previousState: 'disconnected',
+			},
+		],
+	})
+	expect(mocks.invokePackageSubscription).toHaveBeenCalledWith(
+		expect.objectContaining({
+			topic: mcpServerReconnectedTopic,
+		}),
+	)
+})

--- a/packages/worker/src/mcp-client/package-subscriptions.ts
+++ b/packages/worker/src/mcp-client/package-subscriptions.ts
@@ -1,0 +1,255 @@
+import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import { runWithDynamicWorkerEvaluationBudget } from '#mcp/executor.ts'
+import { readPreExecutionPackageInvocationInfrastructureCode } from '#worker/package-invocations/admin-package-subscriptions.ts'
+import { invokePackageSubscription } from '#worker/package-invocations/service.ts'
+import { listPackageSubscriptions } from '#worker/package-registry/manifest.ts'
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import {
+	mcpServerDisconnectedTopic,
+	mcpServerReconnectedTopic,
+	type McpServerConnectionEvent,
+	type McpServerConnectionEventTopic,
+} from './connection-episodes.ts'
+import { listEnabledMcpServerSettingRows } from './settings-repo.ts'
+import { type McpServerConnectionState } from './types.ts'
+
+export { mcpServerDisconnectedTopic, mcpServerReconnectedTopic }
+
+export type McpServerConnectionSubscriptionEnvelope = {
+	event: McpServerConnectionEventTopic
+	event_id: string
+	server: {
+		id: string
+		name: string
+		state: McpServerConnectionState
+		previous_state: McpServerConnectionState | 'unknown'
+		episode_id: string
+	}
+	observed_at: string
+	account_url: string
+}
+
+type LoadedMcpServerSubscription = {
+	savedPackage: SavedPackageRecord
+	subscription: ReturnType<typeof listPackageSubscriptions>[number]
+}
+
+export function buildMcpServerAccountUrl(input: {
+	baseUrl: string
+	serverId: string
+}) {
+	return `${input.baseUrl}/account/mcp-servers/${input.serverId}`
+}
+
+function buildSubscriptionIdempotencyKey(input: {
+	topic: McpServerConnectionEventTopic
+	episodeId: string
+	packageId: string
+}) {
+	return `mcp-server:${input.topic}:${input.episodeId}:${input.packageId}`
+}
+
+function buildEventPayload(input: {
+	baseUrl: string
+	event: McpServerConnectionEvent
+}): McpServerConnectionSubscriptionEnvelope {
+	return {
+		event: input.event.topic,
+		event_id: input.event.eventId,
+		server: {
+			id: input.event.serverId,
+			name: input.event.serverName,
+			state: input.event.state,
+			previous_state: input.event.previousState,
+			episode_id: input.event.episodeId,
+		},
+		observed_at: input.event.observedAt,
+		account_url: buildMcpServerAccountUrl({
+			baseUrl: input.baseUrl,
+			serverId: input.event.serverId,
+		}),
+	}
+}
+
+async function loadMatchingMcpServerSubscriptions(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV'>
+	baseUrl: string
+	userId: string
+	topic: McpServerConnectionEventTopic
+}) {
+	let savedPackages: Array<SavedPackageRecord>
+	try {
+		savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
+			userId: input.userId,
+		})
+	} catch (error) {
+		const missingTable =
+			error instanceof Error &&
+			error.message.includes('no such table: saved_packages')
+		return {
+			subscriptions: [] as Array<LoadedMcpServerSubscription>,
+			discoveryErrors: missingTable ? [] : [error],
+		}
+	}
+	const settled = await Promise.allSettled(
+		savedPackages.map(async (savedPackage) => {
+			const loaded = await loadPackageManifestBySourceId({
+				env: input.env as Env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: savedPackage.sourceId,
+			})
+			const subscription = listPackageSubscriptions(loaded.manifest).find(
+				(candidate) => candidate.topic === input.topic,
+			)
+			if (!subscription) return null
+			return {
+				savedPackage,
+				subscription,
+			} satisfies LoadedMcpServerSubscription
+		}),
+	)
+	const subscriptions: Array<LoadedMcpServerSubscription> = []
+	const discoveryErrors: Array<unknown> = []
+	for (const [index, result] of settled.entries()) {
+		if (result.status === 'fulfilled') {
+			if (result.value) subscriptions.push(result.value)
+			continue
+		}
+		const savedPackage = savedPackages[index]
+		console.warn(
+			'Failed to load package manifest for MCP server connection subscription',
+			{
+				sourceId: savedPackage?.sourceId,
+				packageId: savedPackage?.id,
+				topic: input.topic,
+				error: result.reason,
+			},
+		)
+		discoveryErrors.push(result.reason)
+	}
+	return { subscriptions, discoveryErrors }
+}
+
+/**
+ * Fan an MCP server connection episode out to the owning user's packages that
+ * declare the topic. Best-effort: discovery and invocation infrastructure
+ * failures are logged, never thrown. Sibling handler terminal failures are
+ * isolated via `Promise.allSettled`.
+ *
+ * One emit per topic per episode. Packages decide how to notify.
+ */
+export async function dispatchMcpServerConnectionSubscriptionEvents(input: {
+	env: Pick<Env, 'APP_DB' | 'BUNDLE_ARTIFACTS_KV' | 'APP_BASE_URL'>
+	userId: string
+	event: McpServerConnectionEvent
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	const baseUrl = getAppBaseUrl({ env: input.env })
+	const { subscriptions, discoveryErrors } =
+		await loadMatchingMcpServerSubscriptions({
+			env: input.env,
+			baseUrl,
+			userId: input.userId,
+			topic: input.event.topic,
+		})
+	const eventPayload = buildEventPayload({
+		baseUrl,
+		event: input.event,
+	})
+	const settled = await runWithDynamicWorkerEvaluationBudget(
+		async () =>
+			await Promise.allSettled(
+				subscriptions.map(async ({ savedPackage }) => {
+					const response = await invokePackageSubscription({
+						env: input.env as Env,
+						baseUrl,
+						savedPackage,
+						topic: input.event.topic,
+						params: eventPayload as Record<string, unknown>,
+						idempotencyKey: buildSubscriptionIdempotencyKey({
+							topic: input.event.topic,
+							episodeId: input.event.episodeId,
+							packageId: savedPackage.id,
+						}),
+						source: 'mcp-client',
+						waitUntil: input.waitUntil,
+					})
+					const retryableCode =
+						readPreExecutionPackageInvocationInfrastructureCode(response)
+					if (retryableCode) {
+						throw new Error(
+							`Retryable package invocation infrastructure response: ${retryableCode}.`,
+						)
+					}
+					return response
+				}),
+			),
+	)
+	for (const result of settled) {
+		if (result.status === 'rejected') {
+			console.warn('mcp.server connection package subscription invoke failed', {
+				eventId: input.event.eventId,
+				topic: input.event.topic,
+				serverName: input.event.serverName,
+				error: result.reason,
+			})
+		}
+	}
+	if (discoveryErrors.length > 0) {
+		console.warn(
+			'mcp.server connection package subscription discovery incomplete',
+			{
+				eventId: input.event.eventId,
+				topic: input.event.topic,
+				serverName: input.event.serverName,
+				errorCount: discoveryErrors.length,
+				error: discoveryErrors[0],
+			},
+		)
+	}
+	return settled.map((result) =>
+		result.status === 'fulfilled' ? result.value : null,
+	)
+}
+
+export async function emitMcpServerConnectionEventsIfNeeded(input: {
+	env: Env
+	userId: string
+	events: Array<McpServerConnectionEvent>
+	waitUntil?: (promise: Promise<unknown>) => void
+}) {
+	if (input.events.length === 0) return
+	let enabledIds: Set<string>
+	try {
+		const rows = await listEnabledMcpServerSettingRows({
+			db: input.env.APP_DB,
+			userId: input.userId,
+		})
+		enabledIds = new Set(rows.map((row) => row.id))
+	} catch (error) {
+		console.warn('mcp.server connection event enabled-server lookup failed', {
+			error,
+		})
+		return
+	}
+	const pending = input.events
+		.filter((event) => enabledIds.has(event.serverId))
+		.map((event) =>
+			dispatchMcpServerConnectionSubscriptionEvents({
+				env: input.env,
+				userId: input.userId,
+				event,
+				waitUntil: input.waitUntil,
+			}),
+		)
+	if (pending.length === 0) return
+	const all = Promise.all(pending).then(() => undefined)
+	if (input.waitUntil) {
+		input.waitUntil(all)
+		return
+	}
+	await all
+}

--- a/packages/worker/src/mcp-client/types.ts
+++ b/packages/worker/src/mcp-client/types.ts
@@ -1,5 +1,6 @@
 import { type JsonSchemaToolDescriptor } from '@cloudflare/codemode'
 import { type Tool } from '@modelcontextprotocol/sdk/types.js'
+import { type McpServerConnectionEvent } from './connection-episodes.ts'
 
 export type McpServerConnectionState =
 	| 'authenticating'
@@ -40,6 +41,7 @@ export type McpServerSnapshot = {
 
 export type McpClientHubSnapshot = {
 	servers: Array<McpServerSnapshot>
+	connectionEvents?: Array<McpServerConnectionEvent>
 }
 
 export type McpServerConnectResult = {

--- a/packages/worker/src/mcp/capabilities/mcp-server/index.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-server/index.ts
@@ -96,6 +96,7 @@ function createCapabilityFromTool(input: {
 			const hub = createMcpClientHubClient({
 				env: ctx.env,
 				userId,
+				waitUntil: ctx.waitUntil,
 			})
 			let result: Awaited<ReturnType<typeof hub.callTool>>
 			try {

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-list.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-list.ts
@@ -51,7 +51,11 @@ export const mcpServerListCapability = defineDomainCapability(
 			})
 			const [settings, hubSnapshot] = await Promise.all([
 				listMcpServerSettings({ env: ctx.env, userId: user.userId }),
-				loadMcpClientHubSnapshotOrNull({ env: ctx.env, userId: user.userId }),
+				loadMcpClientHubSnapshotOrNull({
+					env: ctx.env,
+					userId: user.userId,
+					waitUntil: ctx.waitUntil,
+				}),
 			])
 			return {
 				oauthClientOrigin: oauth.clientOrigin,

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-reconnect.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-reconnect.ts
@@ -48,6 +48,7 @@ export const mcpServerReconnectCapability = defineDomainCapability(
 			const hub = createMcpClientHubClient({
 				env: ctx.env,
 				userId: user.userId,
+				waitUntil: ctx.waitUntil,
 			})
 			const result = await hub.reconnectServer({
 				serverId: setting.id,

--- a/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-refresh.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/mcp-server-refresh.ts
@@ -38,6 +38,7 @@ export const mcpServerRefreshCapability = defineDomainCapability(
 			const hub = createMcpClientHubClient({
 				env: ctx.env,
 				userId: user.userId,
+				waitUntil: ctx.waitUntil,
 			})
 			const result = await hub.refreshServer({ serverId: setting.id })
 			return {

--- a/packages/worker/src/mcp/capabilities/mcp-servers/shared.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-servers/shared.ts
@@ -64,6 +64,7 @@ export function buildMcpServerStatusView(input: {
 export async function loadMcpClientHubSnapshotOrNull(input: {
 	env: Env
 	userId: string
+	waitUntil?: (promise: Promise<unknown>) => void
 }) {
 	try {
 		return await getCachedMcpClientHubSnapshot(input)

--- a/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
+++ b/packages/worker/src/mcp/capabilities/packages/list-package-subscriptions.ts
@@ -20,7 +20,7 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 	{
 		name: 'package_subscriptions_list',
 		description:
-			'List package.json#kody.subscriptions entries for the signed-in user, optionally filtered by exact event topic. Use this to discover package event handlers such as email receipt, delivery-update, repo.pushed / repo.created / repo.deleted Artifacts lifecycle notifiers, run.error.recorded activity notifiers, admin platform-feedback, admin community-activity, or admin status-incident notification subscribers before debugging dispatch or building fan-out. Admin-only topics carry only their documented narrow metadata, and declaring one does not grant delivery; dispatch checks the package owner role fresh at delivery time.',
+			'List package.json#kody.subscriptions entries for the signed-in user, optionally filtered by exact event topic. Use this to discover package event handlers such as email receipt, delivery-update, repo.pushed / repo.created / repo.deleted Artifacts lifecycle notifiers, run.error.recorded activity notifiers, integration.auth.failed reconnect notifiers, mcp.server.disconnected / mcp.server.reconnected connection episodes, admin platform-feedback, admin community-activity, or admin status-incident notification subscribers before debugging dispatch or building fan-out. Admin-only topics carry only their documented narrow metadata, and declaring one does not grant delivery; dispatch checks the package owner role fresh at delivery time.',
 		keywords: [
 			'package',
 			'package.json#kody.subscriptions',
@@ -51,6 +51,10 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 			'status incident opened',
 			'status.incident.resolved',
 			'status incident resolved',
+			'integration.auth.failed',
+			'mcp.server.disconnected',
+			'mcp.server.reconnected',
+			'mcp server disconnected',
 			'inbound email',
 			'list',
 			'discover',
@@ -65,7 +69,7 @@ export const listPackageSubscriptionsCapability = defineDomainCapability(
 				.min(1)
 				.optional()
 				.describe(
-					'Optional exact event topic filter such as "email.message.received", "repo.pushed", "run.error.recorded", "platform.feedback.submitted", "community.activity.recorded", or "status.incident.opened".',
+					'Optional exact event topic filter such as "email.message.received", "repo.pushed", "run.error.recorded", "integration.auth.failed", "mcp.server.disconnected", "platform.feedback.submitted", "community.activity.recorded", or "status.incident.opened".',
 				),
 		}),
 		outputSchema: z.object({

--- a/packages/worker/src/mcp/capabilities/packages/package-subscription-dispatch.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-subscription-dispatch.ts
@@ -116,6 +116,8 @@ export const packageSubscriptionDispatchCapability = defineDomainCapability(
 			'replay',
 			'email.message.received',
 			'integration.auth.failed',
+			'mcp.server.disconnected',
+			'mcp.server.reconnected',
 			'test',
 			'smoke',
 			'simulate',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give packages a first-class way to learn when a saved outbound MCP server drops or comes back, so shade-automation and others can stop scraping leftover “connector not connected” run-error strings. After #1511, home is a normal `kody.mcp["home"]` server; this event observes only the MCP client hub.

## Summary

- Persist per-server connection episodes on the MCP client hub DO.
- After a server has been `ready`, a later `disconnected` / `failed` state gets two lightweight `connectToServer` + discover attempts (no OAuth restart).
- If it is still down, fan out `mcp.server.disconnected` to the owning user’s packages. Recovery emits `mcp.server.reconnected` with the same episode id.
- `authenticating` after a prior `ready` emits without retry (user must reopen `/account/mcp-servers`). Never-ready and disabled servers do not emit.
- `mcp_server_reconnect` stays the explicit OAuth restart. Listener packages should not call it on every event.
- Payload is metadata-first: server id/name/state, episode id, trusted `account_url`. No URLs, tokens, or tool lists.
- Review follow-up: mutation/OAuth results are built after observe so callers see `ready` when the lightweight retry recovers; episode latch and pending event persist in one storage write.

## Testing

- `npx vitest run` on `mcp-client` connection-episode, package-subscription, and hub OAuth recovery suites (node-unit) — 12 passed after review fixes
- Broader node-unit: `mcp-client`, `mcp-server`, `mcp-servers`, `account-mcp-servers`
- `npm run typecheck`
- `npm run validate:fix` (format + lint)
- Hub assertions: `refreshServer` / `reconnectServer` / `addServer` / `handleOAuthCallback` return `ready` after lightweight recovery; episode + pending event share one `storage.put`
- CI on `f8798a81`: Validate (Node / Workers / Static / MCP / E2E), CLA, Preview, CodeRabbit, and Bugbot all passed
- Preview (`https://kody-pr-1518.kody-a99.workers.dev`) as seed user `me@kentcdodds.com` on the review-fix deploy:
  - `GET /account/mcp-servers.json` → 200, empty list, then `POST add` created `preview-home` (`https://example.com/mcp`) in `failed` (never-ready, so no disconnect event — expected)
  - `POST refresh` and `POST reconnect` returned 200 and left the never-ready server `failed`
  - UI: list shows `preview-home` / Connection failed; add form has name, URL, optional bearer token

![Preview MCP servers list with failed preview-home](https://cursor.com/artifacts/c/art-0ad17db3-84f8-4ede-905e-6fb42112de76)
![Preview add MCP server form](https://cursor.com/artifacts/c/art-aa010a8e-49d1-463e-b9f1-190441b493fe)
<a href="https://cursor.com/agents/bc-72a96088-8b16-4943-9570-db1b90322a8f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_mcp_servers_list_and_add_form.mp4"><img src="https://cursor.com/artifacts/c/art-17b20569-f332-4548-afef-6d8dd8901118" alt="preview_mcp_servers_list_and_add_form.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends mcp-client-servers</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** extends — the MCP client hub now retries and emits package subscription topics; no primitive was added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | extends — episode latch, lightweight reconnect, `mcp.server.disconnected` / `.reconnected` |
| `saved-packages` | assistant | composes — discovery/dispatch keywords for the new topics |

### System map

The hub observes ready-to-down transitions, retries without clearing OAuth, then the worker fans out to the owning user’s packages.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	mcpClient["mcp-client-servers<br/>MCP client servers"]:::extended
	savedPkgs["saved-packages<br/>Saved packages"]:::touched
	mcpClient -->|"episode emit after lightweight retry"| savedPkgs
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Caller
	participant Hub as McpClientHub
	participant Worker as hub-client
	participant Pkgs as owning-user packages
	Caller->>Hub: getSnapshot / callTool / add / refresh / reconnect
	Hub->>Hub: waitForConnections
	alt previously ready and now down
		Hub->>Hub: connectToServer x2
	end
	Hub-->>Caller: post-observe connection result
	Hub-->>Worker: connectionEvents
	Worker-->>Pkgs: mcp.server.disconnected or reconnected
```

### Invariants

Per-user isolation: fan-out is the MCP server owner only. Payload has no tokens, bearer headers, or tool schemas. Episode latch and pending event share one Durable Object storage write.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72a96088-8b16-4943-9570-db1b90322a8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72a96088-8b16-4943-9570-db1b90322a8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery attempts for MCP server connection failures.
  * Added `mcp.server.disconnected` and `mcp.server.reconnected` subscription events.
  * Events include redacted connection metadata and avoid duplicate notifications.
  * Recovered servers now emit a reconnection notification after returning to a ready state.

* **Documentation**
  * Documented connection recovery, event delivery, payloads, exclusions, and subscription behavior.
  * Added a synthetic disconnected-event example.

* **Tests**
  * Added coverage for retries, recovery, event suppression, disabled servers, and subscription delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->