### PR TITLE
Retry execute and export on Durable Object code resets

### DIFF
--- a/packages/worker/src/durable-object-reset-retry.node.test.ts
+++ b/packages/worker/src/durable-object-reset-retry.node.test.ts
@@ -93,6 +93,35 @@ test('transient Durable Object reset retry recovers thrown and result errors the
 			error: durableObjectCodeUpdatedResetMessage,
 		})
 		expect(exhausted).toHaveBeenCalledTimes(3)
+
+		const dirtyResult = vi
+			.fn<() => Promise<{ error: string; dirty: boolean }>>()
+			.mockResolvedValue({
+				error: durableObjectCodeUpdatedResetMessage,
+				dirty: true,
+			})
+		await expect(
+			runWithTransientDurableObjectResetRetry({
+				operation: dirtyResult,
+				retryableResultError: (value) => value.error,
+				shouldRetry: ({ result }) => result?.dirty !== true,
+			}),
+		).resolves.toEqual({
+			error: durableObjectCodeUpdatedResetMessage,
+			dirty: true,
+		})
+		expect(dirtyResult).toHaveBeenCalledTimes(1)
+
+		const dirtyThrown = vi
+			.fn<() => Promise<never>>()
+			.mockRejectedValue(new Error(durableObjectCodeUpdatedResetMessage))
+		await expect(
+			runWithTransientDurableObjectResetRetry({
+				operation: dirtyThrown,
+				shouldRetry: () => false,
+			}),
+		).rejects.toThrow(durableObjectCodeUpdatedResetMessage)
+		expect(dirtyThrown).toHaveBeenCalledTimes(1)
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/durable-object-reset-retry.node.test.ts
+++ b/packages/worker/src/durable-object-reset-retry.node.test.ts
@@ -1,0 +1,99 @@
+import { expect, test, vi } from 'vitest'
+import { durableObjectCodeUpdatedResetMessage } from '#worker/sentry-options.ts'
+import {
+	isTransientDurableObjectResetError,
+	runWithTransientDurableObjectResetRetry,
+} from './durable-object-reset-retry.ts'
+
+test('transient Durable Object reset retry recovers thrown and result errors then exhausts', async () => {
+	expect(
+		isTransientDurableObjectResetError(
+			new Error(durableObjectCodeUpdatedResetMessage),
+		),
+	).toBe(true)
+	expect(
+		isTransientDurableObjectResetError(durableObjectCodeUpdatedResetMessage),
+	).toBe(true)
+	expect(
+		isTransientDurableObjectResetError(
+			new Error('wrapped', {
+				cause: new Error(durableObjectCodeUpdatedResetMessage),
+			}),
+		),
+	).toBe(true)
+	expect(
+		isTransientDurableObjectResetError(new Error('user code failed')),
+	).toBe(false)
+
+	vi.useFakeTimers()
+	try {
+		const thrownThenOk = vi
+			.fn<() => Promise<{ ok: boolean }>>()
+			.mockRejectedValueOnce(new Error(durableObjectCodeUpdatedResetMessage))
+			.mockResolvedValueOnce({ ok: true })
+		const retries: Array<{ attempt: number; nextDelayMs: number }> = []
+		const thrownPending = runWithTransientDurableObjectResetRetry({
+			operation: thrownThenOk,
+			onRetry: ({ attempt, nextDelayMs }) => {
+				retries.push({ attempt, nextDelayMs })
+			},
+		})
+		await vi.runAllTimersAsync()
+		await expect(thrownPending).resolves.toEqual({ ok: true })
+		expect(thrownThenOk).toHaveBeenCalledTimes(2)
+		expect(retries).toEqual([{ attempt: 1, nextDelayMs: 100 }])
+
+		const resultThenOk = vi
+			.fn<() => Promise<{ error?: string; result?: string }>>()
+			.mockResolvedValueOnce({
+				error: durableObjectCodeUpdatedResetMessage,
+			})
+			.mockResolvedValueOnce({ result: 'recovered' })
+		const resultPending = runWithTransientDurableObjectResetRetry({
+			operation: resultThenOk,
+			retryableResultError: (value) =>
+				typeof value === 'object' &&
+				value &&
+				'error' in value &&
+				typeof value.error === 'string'
+					? value.error
+					: null,
+		})
+		await vi.runAllTimersAsync()
+		await expect(resultPending).resolves.toEqual({ result: 'recovered' })
+		expect(resultThenOk).toHaveBeenCalledTimes(2)
+
+		const permanent = vi
+			.fn<() => Promise<never>>()
+			.mockRejectedValue(new Error('user code failed'))
+		await expect(
+			runWithTransientDurableObjectResetRetry({
+				operation: permanent,
+			}),
+		).rejects.toThrow('user code failed')
+		expect(permanent).toHaveBeenCalledTimes(1)
+
+		const exhausted = vi
+			.fn<() => Promise<{ error: string }>>()
+			.mockResolvedValue({
+				error: durableObjectCodeUpdatedResetMessage,
+			})
+		const exhaustedPending = runWithTransientDurableObjectResetRetry({
+			operation: exhausted,
+			retryableResultError: (value) =>
+				typeof value === 'object' &&
+				value &&
+				'error' in value &&
+				typeof value.error === 'string'
+					? value.error
+					: null,
+		})
+		await vi.runAllTimersAsync()
+		await expect(exhaustedPending).resolves.toEqual({
+			error: durableObjectCodeUpdatedResetMessage,
+		})
+		expect(exhausted).toHaveBeenCalledTimes(3)
+	} finally {
+		vi.useRealTimers()
+	}
+})

--- a/packages/worker/src/durable-object-reset-retry.node.test.ts
+++ b/packages/worker/src/durable-object-reset-retry.node.test.ts
@@ -122,6 +122,17 @@ test('transient Durable Object reset retry recovers thrown and result errors the
 			}),
 		).rejects.toThrow(durableObjectCodeUpdatedResetMessage)
 		expect(dirtyThrown).toHaveBeenCalledTimes(1)
+
+		const exhaustedUndefined = vi
+			.fn<() => Promise<undefined>>()
+			.mockResolvedValue(undefined)
+		const exhaustedUndefinedPending = runWithTransientDurableObjectResetRetry({
+			operation: exhaustedUndefined,
+			retryableResultError: () => durableObjectCodeUpdatedResetMessage,
+		})
+		await vi.runAllTimersAsync()
+		await expect(exhaustedUndefinedPending).resolves.toBeUndefined()
+		expect(exhaustedUndefined).toHaveBeenCalledTimes(3)
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/durable-object-reset-retry.ts
+++ b/packages/worker/src/durable-object-reset-retry.ts
@@ -1,0 +1,108 @@
+import {
+	errorCauseChainIncludes,
+	getErrorMessage,
+} from '@kody-internal/shared/error-message.ts'
+import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
+
+/**
+ * Same bounded backoff as package_publish_external_push and published
+ * artifact rebuild. Deploy-time isolate resets usually recover on the next
+ * call to a fresh isolate.
+ */
+export const durableObjectResetRetryDelaysMs = [100, 500] as const
+
+export function isTransientDurableObjectResetError(error: unknown) {
+	if (typeof error === 'string') {
+		return isDurableObjectIsolateResetMessage(error)
+	}
+	return errorCauseChainIncludes(error, isDurableObjectIsolateResetMessage)
+}
+
+function assertNotAborted(signal: AbortSignal | undefined) {
+	if (signal?.aborted) {
+		throw new DOMException('The operation was aborted.', 'AbortError')
+	}
+}
+
+async function delay(ms: number, signal?: AbortSignal) {
+	assertNotAborted(signal)
+	if (!signal) {
+		await new Promise((resolve) => setTimeout(resolve, ms))
+		return
+	}
+	await new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			signal.removeEventListener('abort', onAbort)
+			resolve()
+		}, ms)
+		const onAbort = () => {
+			clearTimeout(timer)
+			reject(new DOMException('The operation was aborted.', 'AbortError'))
+		}
+		signal.addEventListener('abort', onAbort, { once: true })
+	})
+}
+
+/**
+ * Retry an operation when Cloudflare resets a Durable Object isolate
+ * (deploy "code was updated", memory/CPU, storage timeout, etc.).
+ *
+ * Thrown resets retry until the delay list is exhausted, then rethrow.
+ * Resolved values can opt in via `retryableResultError` (sandbox execute
+ * returns the platform string on `result.error` instead of throwing).
+ * Exhausted result-errors return the last value so callers can record it.
+ */
+export async function runWithTransientDurableObjectResetRetry<T>(input: {
+	operation: () => Promise<T>
+	retryableResultError?: (result: T) => unknown | null
+	onRetry?: (input: {
+		attempt: number
+		nextDelayMs: number
+		error: unknown
+	}) => void
+	signal?: AbortSignal
+}): Promise<T> {
+	const delays = durableObjectResetRetryDelaysMs
+	const maxAttempts = delays.length + 1
+	let lastResult: T | undefined
+	let lastError: unknown
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		assertNotAborted(input.signal)
+		try {
+			const result = await input.operation()
+			lastResult = result
+			const resultError = input.retryableResultError?.(result) ?? null
+			if (
+				resultError == null ||
+				!isTransientDurableObjectResetError(resultError)
+			) {
+				return result
+			}
+			lastError = resultError
+		} catch (error) {
+			lastError = error
+			if (
+				!isTransientDurableObjectResetError(error) ||
+				attempt === maxAttempts
+			) {
+				throw error
+			}
+		}
+		if (attempt === maxAttempts) {
+			break
+		}
+		const nextDelayMs = delays[attempt - 1] ?? 0
+		input.onRetry?.({
+			attempt,
+			nextDelayMs,
+			error: lastError,
+		})
+		await delay(nextDelayMs, input.signal)
+	}
+	if (lastResult !== undefined) {
+		return lastResult
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error(getErrorMessage(lastError))
+}

--- a/packages/worker/src/durable-object-reset-retry.ts
+++ b/packages/worker/src/durable-object-reset-retry.ts
@@ -55,6 +55,12 @@ async function delay(ms: number, signal?: AbortSignal) {
 export async function runWithTransientDurableObjectResetRetry<T>(input: {
 	operation: () => Promise<T>
 	retryableResultError?: (result: T) => unknown | null
+	/**
+	 * Extra gate after a reset is recognized. Return false to keep the
+	 * result or rethrow instead of retrying (for example, this evaluate
+	 * already started a host-mediated side effect). Omitted means retry.
+	 */
+	shouldRetry?: (input: { error: unknown; result?: T }) => boolean
 	onRetry?: (input: {
 		attempt: number
 		nextDelayMs: number
@@ -74,7 +80,8 @@ export async function runWithTransientDurableObjectResetRetry<T>(input: {
 			const resultError = input.retryableResultError?.(result) ?? null
 			if (
 				resultError == null ||
-				!isTransientDurableObjectResetError(resultError)
+				!isTransientDurableObjectResetError(resultError) ||
+				input.shouldRetry?.({ error: resultError, result }) === false
 			) {
 				return result
 			}
@@ -83,7 +90,8 @@ export async function runWithTransientDurableObjectResetRetry<T>(input: {
 			lastError = error
 			if (
 				!isTransientDurableObjectResetError(error) ||
-				attempt === maxAttempts
+				attempt === maxAttempts ||
+				input.shouldRetry?.({ error }) === false
 			) {
 				throw error
 			}

--- a/packages/worker/src/durable-object-reset-retry.ts
+++ b/packages/worker/src/durable-object-reset-retry.ts
@@ -71,12 +71,14 @@ export async function runWithTransientDurableObjectResetRetry<T>(input: {
 	const delays = durableObjectResetRetryDelaysMs
 	const maxAttempts = delays.length + 1
 	let lastResult: T | undefined
+	let hasLastResult = false
 	let lastError: unknown
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		assertNotAborted(input.signal)
 		try {
 			const result = await input.operation()
 			lastResult = result
+			hasLastResult = true
 			const resultError = input.retryableResultError?.(result) ?? null
 			if (
 				resultError == null ||
@@ -107,8 +109,8 @@ export async function runWithTransientDurableObjectResetRetry<T>(input: {
 		})
 		await delay(nextDelayMs, input.signal)
 	}
-	if (lastResult !== undefined) {
-		return lastResult
+	if (hasLastResult) {
+		return lastResult as T
 	}
 	throw lastError instanceof Error
 		? lastError

--- a/packages/worker/src/mcp/evaluation-side-effects.node.test.ts
+++ b/packages/worker/src/mcp/evaluation-side-effects.node.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest'
+import {
+	createEvaluationSideEffectTracker,
+	createHostSideEffectProvider,
+	evaluationHasHostMediatedSideEffects,
+	hostSideEffectProviderName,
+	isPlatformOnlyHostSideEffectProvider,
+	staticCallMeterRuntimeBridgeProviderName,
+} from './evaluation-side-effects.ts'
+
+test('evaluation side-effect tracker counts attempts and treats a missing snapshot as dirty', () => {
+	expect(evaluationHasHostMediatedSideEffects(undefined)).toBe(true)
+	expect(evaluationHasHostMediatedSideEffects(null)).toBe(true)
+	expect(
+		evaluationHasHostMediatedSideEffects({
+			dispatcherAttempts: 0,
+			fetchAttempts: 0,
+		}),
+	).toBe(false)
+
+	const sideEffects = createEvaluationSideEffectTracker()
+	expect(evaluationHasHostMediatedSideEffects(sideEffects.snapshot())).toBe(
+		false,
+	)
+	sideEffects.recordDispatcherAttempt()
+	expect(sideEffects.snapshot()).toEqual({
+		dispatcherAttempts: 1,
+		fetchAttempts: 0,
+	})
+	expect(evaluationHasHostMediatedSideEffects(sideEffects.snapshot())).toBe(
+		true,
+	)
+
+	const fetchOnly = createEvaluationSideEffectTracker()
+	fetchOnly.recordFetchAttempt()
+	expect(fetchOnly.snapshot()).toEqual({
+		dispatcherAttempts: 0,
+		fetchAttempts: 1,
+	})
+	expect(evaluationHasHostMediatedSideEffects(fetchOnly.snapshot())).toBe(true)
+
+	expect(isPlatformOnlyHostSideEffectProvider(hostSideEffectProviderName)).toBe(
+		true,
+	)
+	expect(
+		isPlatformOnlyHostSideEffectProvider(
+			staticCallMeterRuntimeBridgeProviderName,
+		),
+	).toBe(true)
+	expect(isPlatformOnlyHostSideEffectProvider('kody')).toBe(false)
+
+	const provider = createHostSideEffectProvider(fetchOnly)
+	expect(provider.name).toBe(hostSideEffectProviderName)
+})

--- a/packages/worker/src/mcp/evaluation-side-effects.ts
+++ b/packages/worker/src/mcp/evaluation-side-effects.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-evaluate host counters for Durable Object reset retry.
+ *
+ * LOADER requires a real Fetcher for `globalOutbound`, so we cannot wrap
+ * outbound fetch on the host. Fetch attempts are recorded through this
+ * evaluate's RPC dispatcher *before* the sandbox calls native fetch.
+ * Dispatcher attempts increment before `await` so a reset mid-call still
+ * counts.
+ */
+
+export const hostSideEffectProviderName = '__kodyHostSideEffects'
+
+export const staticCallMeterRuntimeBridgeProviderName =
+	'__kodyStaticCallMeterRuntimeBridge'
+
+const platformOnlyHostSideEffectProviderNames = new Set([
+	hostSideEffectProviderName,
+	staticCallMeterRuntimeBridgeProviderName,
+])
+
+export type EvaluationHostSideEffects = {
+	dispatcherAttempts: number
+	fetchAttempts: number
+}
+
+export type EvaluationSideEffectTracker = {
+	recordDispatcherAttempt: () => void
+	recordFetchAttempt: () => void
+	snapshot: () => EvaluationHostSideEffects
+}
+
+export function isPlatformOnlyHostSideEffectProvider(providerName: string) {
+	return platformOnlyHostSideEffectProviderNames.has(providerName)
+}
+
+export function createEvaluationSideEffectTracker(): EvaluationSideEffectTracker {
+	let dispatcherAttempts = 0
+	let fetchAttempts = 0
+	return {
+		recordDispatcherAttempt() {
+			dispatcherAttempts += 1
+		},
+		recordFetchAttempt() {
+			fetchAttempts += 1
+		},
+		snapshot() {
+			return { dispatcherAttempts, fetchAttempts }
+		},
+	}
+}
+
+export function createHostSideEffectProvider(
+	sideEffects: EvaluationSideEffectTracker,
+) {
+	return {
+		name: hostSideEffectProviderName,
+		fns: {
+			recordFetch: async () => {
+				sideEffects.recordFetchAttempt()
+			},
+		},
+	}
+}
+
+/**
+ * Missing snapshot is treated as dirty: a thrown evaluate that never
+ * attached host counters is "unknown side effects," not a clean retry.
+ */
+export function evaluationHasHostMediatedSideEffects(
+	sideEffects: EvaluationHostSideEffects | null | undefined,
+) {
+	if (sideEffects == null) return true
+	return sideEffects.dispatcherAttempts > 0 || sideEffects.fetchAttempts > 0
+}

--- a/packages/worker/src/mcp/execute-console-capture.workers.test.ts
+++ b/packages/worker/src/mcp/execute-console-capture.workers.test.ts
@@ -9,8 +9,9 @@ import { silenceIncidentalRuntimeWarnings } from '#worker/test-support/incidenta
  * Regression coverage for sandbox console capture: user modules are loaded via
  * `import("./main.js")`, so a lexical `const console` in `evaluate()` cannot
  * shadow the free `console` binding those modules resolve. Capture must assign
- * onto `globalThis` (same pattern as the fetch shim) and restore in `finally`
- * so reused dynamic workers do not write into a previous run's `__logs`.
+ * onto `globalThis` and restore in `finally` so reused dynamic workers do not
+ * write into a previous run's `__logs`. Fetch uses a once-per-isolate patch
+ * plus AsyncLocalStorage instead of restore-in-finally.
  */
 
 const reuseEnv = {

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -28,6 +28,8 @@ import {
 import { executorSandboxTimeoutMessage } from '#worker/sentry-options.ts'
 import { assertGeneratedExecutorSourceIsBundleSafe } from './kody-remote-proxy-source.ts'
 import { createDynamicWorkerCompatibilityOptions } from '#worker/dynamic-worker-compatibility.ts'
+import { createEvaluationSideEffectTracker } from '#mcp/evaluation-side-effects.ts'
+import { durableObjectCodeUpdatedResetMessage } from '#worker/sentry-options.ts'
 
 type FakeWorkerOptions = Record<string, unknown>
 
@@ -289,6 +291,9 @@ test('generated kody provider and executor module sources stay bundle-safe', () 
 		timeoutMs: 1_000,
 	})
 	assertGeneratedExecutorSourceIsBundleSafe(moduleSource)
+	expect(moduleSource).toContain('from "node:async_hooks"')
+	expect(moduleSource).toContain('__kodyEvaluateFetchStorage.run')
+	expect(moduleSource).toContain('.call("recordFetch", "[]")')
 })
 
 test('generated kody provider source wires mcp proxy dispatch', async () => {
@@ -576,6 +581,10 @@ test('createExecuteExecutor drains logs from an evaluation that settles just aft
 		result: undefined,
 		error: timeoutMessage,
 		logs: ['started context lookup'],
+		hostMediatedSideEffects: {
+			dispatcherAttempts: 0,
+			fetchAttempts: 0,
+		},
 	})
 	expect(createNamedExecutionError(result.error).name).toBe('TimeoutError')
 })
@@ -1171,9 +1180,56 @@ test('createExecuteExecutor rejects reserved JavaScript provider names before lo
 		expect(result).toEqual({
 			result: undefined,
 			error: `Provider name "${name}" is a JavaScript reserved word`,
+			hostMediatedSideEffects: {
+				dispatcherAttempts: 0,
+				fetchAttempts: 0,
+			},
 		})
 	}
 	expect(fakeLoader.factoryCallCount).toBe(0)
+})
+
+test('createExecuteExecutor keeps host side-effect counts when evaluate throws a Durable Object reset', async () => {
+	const loader = {
+		get(_id: string, factory: () => FakeWorkerOptions) {
+			factory()
+			return {
+				getEntrypoint() {
+					return {
+						async evaluate(
+							dispatchers: Record<string, { call: typeof ToolDispatcherCall }>,
+						) {
+							await dispatchers.kody?.call('search', '{}')
+							throw new Error(durableObjectCodeUpdatedResetMessage)
+						},
+					}
+				},
+			}
+		},
+	} as unknown as Env['LOADER']
+
+	const result = await createExecuteExecutor({
+		env: createExecutorTestEnv(loader),
+		exports: createExecutorTestExports(),
+		gatewayProps: createGatewayProps('reset-user'),
+	}).execute('async () => "ok"', [
+		{
+			name: 'kody',
+			fns: {
+				search: async () => ({ ok: true }),
+			},
+		},
+	])
+
+	expect(result).toEqual({
+		result: undefined,
+		error: durableObjectCodeUpdatedResetMessage,
+		logs: [],
+		hostMediatedSideEffects: {
+			dispatcherAttempts: 1,
+			fetchAttempts: 0,
+		},
+	})
 })
 
 test('createExecuteExecutor disables dispatchers after execution completes', async () => {
@@ -1195,6 +1251,55 @@ test('createExecuteExecutor disables dispatchers after execution completes', asy
 
 	expect(JSON.parse(result ?? '{}')).toEqual({
 		error: 'Execution has already completed.',
+	})
+})
+
+test('createToolDispatchers counts host-mediated attempts before the awaited call', async () => {
+	const sideEffects = createEvaluationSideEffectTracker()
+	let searchCalls = 0
+	const dispatchers = createToolDispatchers(
+		[
+			{
+				name: 'kody',
+				fns: {
+					search: async () => {
+						searchCalls += 1
+						throw new Error('search failed after starting')
+					},
+				},
+			},
+			{
+				name: '__kodyStaticCallMeterRuntimeBridge',
+				fns: {
+					record: async () => ({ ok: true }),
+				},
+			},
+		],
+		{ active: true },
+		undefined,
+		sideEffects,
+	)
+
+	expect(
+		JSON.parse((await dispatchers.kody.call('search', '{}')) ?? '{}'),
+	).toEqual({ error: 'search failed after starting' })
+	expect(searchCalls).toBe(1)
+	expect(sideEffects.snapshot()).toEqual({
+		dispatcherAttempts: 1,
+		fetchAttempts: 0,
+	})
+
+	expect(
+		JSON.parse(
+			(await dispatchers.__kodyStaticCallMeterRuntimeBridge.call(
+				'record',
+				JSON.stringify([{}]),
+			)) ?? '{}',
+		),
+	).toEqual({ result: { ok: true } })
+	expect(sideEffects.snapshot()).toEqual({
+		dispatcherAttempts: 1,
+		fetchAttempts: 0,
 	})
 })
 

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -54,6 +54,15 @@ import {
 	isExecutorSandboxTimeoutMessage,
 } from '#worker/sentry-options.ts'
 import { parseStorageEstimateReadErrorMessage } from '#worker/storage-estimate-error.ts'
+import { isTransientDurableObjectResetError } from '#worker/durable-object-reset-retry.ts'
+import {
+	createEvaluationSideEffectTracker,
+	createHostSideEffectProvider,
+	hostSideEffectProviderName,
+	isPlatformOnlyHostSideEffectProvider,
+	type EvaluationHostSideEffects,
+	type EvaluationSideEffectTracker,
+} from '#mcp/evaluation-side-effects.ts'
 
 type WorkerLoopbackExports = Exclude<typeof workerExports, undefined>
 
@@ -61,7 +70,7 @@ export const defaultExecutionResponseLimitBytes = 102_400
 const maxSupportedExecutorTimeoutMs = 2_147_483_647
 const dynamicWorkerMainModule = 'executor.js'
 const dynamicWorkerIdPrefix = 'kody-'
-const dynamicWorkerCacheKeyVersion = 3
+const dynamicWorkerCacheKeyVersion = 4
 // Cloudflare caps Worker Loader evaluations at four for one incoming request.
 // Async-local state shares that budget with nested evaluations while keeping
 // unrelated requests out of the same queue.
@@ -71,7 +80,11 @@ const dynamicWorkerCapacityErrorMessages = [
 	'Too many concurrent dynamic workers',
 	'Dynamic worker concurrency limit exceeded: each request may have up to 4 concurrent dynamic worker invocations.',
 ] as const
-const reservedProviderNames = new Set(['__dispatchers', '__logs'])
+const reservedProviderNames = new Set([
+	'__dispatchers',
+	'__logs',
+	hostSideEffectProviderName,
+])
 const validProviderNamePattern = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
 const javascriptReservedWords = new Set([
 	'arguments',
@@ -152,6 +165,20 @@ type DynamicWorkerEntrypoint = {
 		logs?: Array<string>
 		rawFetchHosts?: Array<string>
 	}>
+}
+
+export type ExecuteResultWithHostSideEffects = ExecuteResult & {
+	hostMediatedSideEffects: EvaluationHostSideEffects
+}
+
+function attachHostSideEffects(
+	result: ExecuteResult,
+	sideEffects: EvaluationSideEffectTracker,
+): ExecuteResultWithHostSideEffects {
+	return {
+		...result,
+		hostMediatedSideEffects: sideEffects.snapshot(),
+	}
 }
 
 type DynamicWorkerPermitWaiter = {
@@ -565,13 +592,17 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 		async execute(
 			code: string,
 			providers: Array<ResolvedProvider>,
-		): Promise<ExecuteResult> {
+		): Promise<ExecuteResultWithHostSideEffects> {
+			const sideEffects = createEvaluationSideEffectTracker()
 			const validationError = validateProviders(providers)
 			if (validationError) {
-				return {
-					result: undefined,
-					error: validationError,
-				}
+				return attachHostSideEffects(
+					{
+						result: undefined,
+						error: validationError,
+					},
+					sideEffects,
+				)
 			}
 			const excludedHostname = readBaseUrlHostname(input.gatewayProps.baseUrl)
 			const executorModule = createExecutorModule({
@@ -610,9 +641,10 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 							await withDynamicWorkerEvaluationPermit(async () => {
 								throwIfEvaluationDeadlineAborted(signal)
 								const dispatchers = createToolDispatchers(
-									providers,
+									[...providers, createHostSideEffectProvider(sideEffects)],
 									executionState,
 									signal,
+									sideEffects,
 								)
 								return await entrypoint.evaluate(dispatchers)
 							}, signal),
@@ -629,11 +661,25 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 										| Awaited<ReturnType<DynamicWorkerEntrypoint['evaluate']>>
 										| undefined)
 								: undefined
-						return {
-							result: undefined,
-							error: drainedResponse?.error ?? message,
-							logs: drainedResponse?.logs ?? [],
-						}
+						return attachHostSideEffects(
+							{
+								result: undefined,
+								error: drainedResponse?.error ?? message,
+								logs: drainedResponse?.logs ?? [],
+							},
+							sideEffects,
+						)
+					}
+					if (isTransientDurableObjectResetError(error)) {
+						outcome = 'error'
+						return attachHostSideEffects(
+							{
+								result: undefined,
+								error: message,
+								logs: [],
+							},
+							sideEffects,
+						)
 					}
 					throw error
 				}
@@ -644,18 +690,34 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 				}
 				if (response.error) {
 					outcome = 'error'
-					return {
-						result: undefined,
-						error: response.error,
+					return attachHostSideEffects(
+						{
+							result: undefined,
+							error: response.error,
+							logs: response.logs,
+						},
+						sideEffects,
+					)
+				}
+				return attachHostSideEffects(
+					{
+						result: response.result,
 						logs: response.logs,
-					}
-				}
-				return {
-					result: response.result,
-					logs: response.logs,
-				}
+					},
+					sideEffects,
+				)
 			} catch (error) {
 				outcome = 'error'
+				if (isTransientDurableObjectResetError(error)) {
+					return attachHostSideEffects(
+						{
+							result: undefined,
+							error: getErrorMessage(error),
+							logs: [],
+						},
+						sideEffects,
+					)
+				}
 				throw error
 			} finally {
 				executionState.active = false
@@ -727,14 +789,31 @@ function createExecutorModule(input: {
 		: ['        (', normalized, ')(),']
 	return [
 		'import { WorkerEntrypoint } from "cloudflare:workers";',
+		'import { AsyncLocalStorage } from "node:async_hooks";',
+		'',
+		'const __kodyEvaluateFetchStorageSymbol = Symbol.for("kody.evaluateFetchStorage");',
+		'const __kodyEvaluateFetchPatchedSymbol = Symbol.for("kody.evaluateFetchPatched");',
+		'const __kodyNativeFetchSymbol = Symbol.for("kody.nativeFetch");',
+		'const __kodyEvaluateFetchStorage =',
+		'  globalThis[__kodyEvaluateFetchStorageSymbol] ??',
+		'  (globalThis[__kodyEvaluateFetchStorageSymbol] = new AsyncLocalStorage());',
+		'if (!globalThis[__kodyEvaluateFetchPatchedSymbol]) {',
+		'  globalThis[__kodyNativeFetchSymbol] = globalThis.fetch.bind(globalThis);',
+		'  const __kodyNativeFetch = globalThis[__kodyNativeFetchSymbol];',
+		'  globalThis.fetch = (input, init) => {',
+		'    const ctx = __kodyEvaluateFetchStorage.getStore();',
+		'    if (ctx) return ctx.fetch(input, init);',
+		'    return __kodyNativeFetch(input, init);',
+		'  };',
+		'  globalThis[__kodyEvaluateFetchPatchedSymbol] = true;',
+		'}',
 		'',
 		'export default class CodeExecutor extends WorkerEntrypoint {',
 		'  async evaluate(__dispatchers = {}) {',
 		'    const __logs = [];',
 		'    const __kodyRawFetchHosts = [];',
 		`    const __kodyExcludedFetchHost = ${excludedHostname};`,
-		'    const __kodyNativeFetch = globalThis.fetch.bind(globalThis);',
-		'    globalThis.fetch = (input, init) => {',
+		'    const __kodyRunFetch = (input, init) => {',
 		'      try {',
 		'        let url = "";',
 		'        if (typeof input === "string") url = input;',
@@ -747,8 +826,16 @@ function createExecutorModule(input: {
 		'      } catch {',
 		'        // Ignore unparseable / relative URLs; only literal hosts count.',
 		'      }',
-		'      return __kodyNativeFetch(input, init);',
+		'      return (async () => {',
+		`        if (__dispatchers.${hostSideEffectProviderName}) {`,
+		`          const resJson = await __dispatchers.${hostSideEffectProviderName}.call("recordFetch", "[]");`,
+		'          const data = JSON.parse(resJson);',
+		'          if (data.error) throw new Error(data.error);',
+		'        }',
+		'        return globalThis[__kodyNativeFetchSymbol](input, init);',
+		'      })();',
 		'    };',
+		'    return __kodyEvaluateFetchStorage.run({ fetch: __kodyRunFetch }, async () => {',
 		'    const __kodyNativeConsole = globalThis.console;',
 		'    globalThis.console = {',
 		'      ...__kodyNativeConsole,',
@@ -780,6 +867,7 @@ function createExecutorModule(input: {
 		'      clearTimeout(__timeoutId);',
 		'      globalThis.console = __kodyNativeConsole;',
 		'    }',
+		'    });',
 		'  }',
 		'}',
 	].join('\n')
@@ -814,6 +902,7 @@ export function createToolDispatchers(
 	providers: Array<ResolvedProvider>,
 	executionState: { active: boolean },
 	signal?: AbortSignal,
+	sideEffects?: EvaluationSideEffectTracker,
 ) {
 	const dispatchers: Record<string, ToolDispatcher> = {}
 	for (const provider of providers) {
@@ -841,6 +930,12 @@ export function createToolDispatchers(
 			sanitizedFns[sanitizedName] = async (...args) => {
 				if (!executionState.active) {
 					throw new Error('Execution has already completed.')
+				}
+				if (
+					sideEffects &&
+					!isPlatformOnlyHostSideEffectProvider(provider.name)
+				) {
+					sideEffects.recordDispatcherAttempt()
 				}
 				return abortSignalToolNames.has(name)
 					? await fn(...args, signal)

--- a/packages/worker/src/mcp/raw-fetch-host-nudge.ts
+++ b/packages/worker/src/mcp/raw-fetch-host-nudge.ts
@@ -74,8 +74,9 @@ export function readHostnameFromFetchInput(input: RequestInfo | URL) {
 /**
  * Test/helper wrapper that records literal hostnames from fetch inputs.
  * Do not pass the result to WorkerLoader `globalOutbound` — LOADER requires a
- * real Fetcher binding. Production counting wraps `globalThis.fetch` inside
- * the execute sandbox instead (see `#mcp/executor.ts`).
+ * real Fetcher binding. Production counting routes sandbox `fetch` through
+ * AsyncLocalStorage to this evaluate's host dispatcher before native fetch
+ * (see `#mcp/executor.ts` and `#mcp/evaluation-side-effects.ts`).
  */
 export function wrapOutboundFetcherRecordingHosts(
 	outbound: Fetcher,

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2695,6 +2695,137 @@ test('runBundledModuleWithRegistry finishes execute run records on failure only'
 	}
 })
 
+test('runBundledModuleWithRegistry retries transient Durable Object isolate resets', async () => {
+	silenceIncidentalRuntimeWarnings()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-do-reset',
+			email: 'reset@example.com',
+			displayName: 'Reset User',
+		},
+	})
+	const bundle = {
+		mainModule: 'entry.js',
+		modules: {
+			'entry.js': 'export default async () => "ok"',
+		},
+	}
+	const handle = {
+		id: 'run-do-reset-1',
+		userId: 'user-do-reset',
+		startedAt: '2026-08-18T00:00:00.000Z',
+		persistence: 'on-failure' as const,
+		context: {
+			surface: 'export' as const,
+			name: './scan',
+			metadata: {},
+		},
+	}
+	const runRecords = await import('#worker/run-records/service.ts')
+	const beginSpy = vi
+		.spyOn(runRecords, 'beginRunRecord')
+		.mockReturnValue(handle)
+	const finishSpy = vi
+		.spyOn(runRecords, 'finishRunRecord')
+		.mockResolvedValue(undefined)
+	const execute = vi
+		.fn()
+		.mockResolvedValueOnce({
+			result: undefined,
+			error: 'Durable Object reset because its code was updated.',
+			logs: [],
+		})
+		.mockResolvedValueOnce({
+			result: { scanned: 2 },
+			logs: ['recovered'],
+		})
+	const createExecuteExecutorSpy = vi
+		.spyOn(mcpExecutor, 'createExecuteExecutor')
+		.mockReturnValue({
+			execute,
+		} as never)
+	const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+	try {
+		vi.useFakeTimers()
+		const recoveredPending = runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+				runRecord: {
+					surface: 'export',
+					name: './scan',
+				},
+			},
+		)
+		await vi.runAllTimersAsync()
+		const recovered = await recoveredPending
+		expect(recovered.error).toBeUndefined()
+		expect(recovered.result).toEqual({ scanned: 2 })
+		expect(execute).toHaveBeenCalledTimes(2)
+		expect(finishSpy).toHaveBeenCalledTimes(1)
+		expect(finishSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				handle,
+				status: 'success',
+				result: { scanned: 2 },
+			}),
+		)
+		expect(consoleWarn).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'runBundledModuleWithRegistry transient Durable Object reset',
+			),
+		)
+
+		execute.mockReset()
+		finishSpy.mockClear()
+		consoleWarn.mockClear()
+		execute.mockResolvedValue({
+			result: undefined,
+			error: 'Durable Object reset because its code was updated.',
+			logs: [],
+		})
+		const exhaustedPending = runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+				runRecord: {
+					surface: 'export',
+					name: './scan',
+				},
+			},
+		)
+		await vi.runAllTimersAsync()
+		const exhausted = await exhaustedPending
+		expect(exhausted.error).toBe(
+			'Durable Object reset because its code was updated.',
+		)
+		expect(execute).toHaveBeenCalledTimes(3)
+		expect(finishSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: 'error',
+				error: expect.objectContaining({
+					message: 'Durable Object reset because its code was updated.',
+				}),
+			}),
+		)
+	} finally {
+		vi.useRealTimers()
+		consoleWarn.mockRestore()
+		beginSpy.mockRestore()
+		finishSpy.mockRestore()
+		createExecuteExecutorSpy.mockRestore()
+	}
+})
+
 test('runBundledModuleWithRegistry schedules finish via waitUntil when provided', async () => {
 	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2730,16 +2730,22 @@ test('runBundledModuleWithRegistry retries transient Durable Object isolate rese
 	const finishSpy = vi
 		.spyOn(runRecords, 'finishRunRecord')
 		.mockResolvedValue(undefined)
+	const cleanHostSideEffects = {
+		dispatcherAttempts: 0,
+		fetchAttempts: 0,
+	}
 	const execute = vi
 		.fn()
 		.mockResolvedValueOnce({
 			result: undefined,
 			error: 'Durable Object reset because its code was updated.',
 			logs: [],
+			hostMediatedSideEffects: cleanHostSideEffects,
 		})
 		.mockResolvedValueOnce({
 			result: { scanned: 2 },
 			logs: ['recovered'],
+			hostMediatedSideEffects: cleanHostSideEffects,
 		})
 	const createExecuteExecutorSpy = vi
 		.spyOn(mcpExecutor, 'createExecuteExecutor')
@@ -2789,6 +2795,7 @@ test('runBundledModuleWithRegistry retries transient Durable Object isolate rese
 			result: undefined,
 			error: 'Durable Object reset because its code was updated.',
 			logs: [],
+			hostMediatedSideEffects: cleanHostSideEffects,
 		})
 		const exhaustedPending = runBundledModuleWithRegistry(
 			env,
@@ -2816,6 +2823,41 @@ test('runBundledModuleWithRegistry retries transient Durable Object isolate rese
 					message: 'Durable Object reset because its code was updated.',
 				}),
 			}),
+		)
+
+		execute.mockReset()
+		finishSpy.mockClear()
+		consoleWarn.mockClear()
+		execute.mockResolvedValue({
+			result: undefined,
+			error: 'Durable Object reset because its code was updated.',
+			logs: [],
+			hostMediatedSideEffects: {
+				dispatcherAttempts: 1,
+				fetchAttempts: 0,
+			},
+		})
+		const dirty = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+				runRecord: {
+					surface: 'export',
+					name: './scan',
+				},
+			},
+		)
+		expect(dirty.error).toBe(
+			'Durable Object reset because its code was updated.',
+		)
+		expect(execute).toHaveBeenCalledTimes(1)
+		expect(consoleWarn).not.toHaveBeenCalledWith(
+			expect.stringContaining(
+				'runBundledModuleWithRegistry transient Durable Object reset',
+			),
 		)
 	} finally {
 		vi.useRealTimers()

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -72,6 +72,7 @@ import {
 	createUnboundRuntimeHelperMessage,
 	findUnboundRuntimeHelperAccess,
 } from '#worker/package-runtime/unbound-runtime-helpers.ts'
+import { runWithTransientDurableObjectResetRetry } from '#worker/durable-object-reset-retry.ts'
 import { beginRunRecord, finishRunRecord } from '#worker/run-records/service.ts'
 import {
 	type RunRecordContext,
@@ -1053,7 +1054,22 @@ ${runtimeHelperRuntimePropertySource}
 			const sandboxStartedAtMs = Date.now()
 			let result: ExecuteResult
 			try {
-				result = await executor.execute(wrapped, providers)
+				result = await runWithTransientDurableObjectResetRetry({
+					operation: () => executor.execute(wrapped, providers),
+					retryableResultError: (executeResult) => executeResult.error ?? null,
+					signal: options?.signal,
+					onRetry: ({ attempt, nextDelayMs, error }) => {
+						console.warn(
+							JSON.stringify({
+								message:
+									'runBundledModuleWithRegistry transient Durable Object reset',
+								attempt,
+								nextDelayMs,
+								errorMessage: getErrorMessage(error),
+							}),
+						)
+					},
+				})
 			} finally {
 				const sandboxMs = Date.now() - sandboxStartedAtMs
 				runServerTiming.push({

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -73,6 +73,7 @@ import {
 	findUnboundRuntimeHelperAccess,
 } from '#worker/package-runtime/unbound-runtime-helpers.ts'
 import { runWithTransientDurableObjectResetRetry } from '#worker/durable-object-reset-retry.ts'
+import { evaluationHasHostMediatedSideEffects } from '#mcp/evaluation-side-effects.ts'
 import { beginRunRecord, finishRunRecord } from '#worker/run-records/service.ts'
 import {
 	type RunRecordContext,
@@ -1057,6 +1058,10 @@ ${runtimeHelperRuntimePropertySource}
 				result = await runWithTransientDurableObjectResetRetry({
 					operation: () => executor.execute(wrapped, providers),
 					retryableResultError: (executeResult) => executeResult.error ?? null,
+					shouldRetry: ({ result: executeResult }) =>
+						!evaluationHasHostMediatedSideEffects(
+							executeResult?.hostMediatedSideEffects,
+						),
 					signal: options?.signal,
 					onRetry: ({ attempt, nextDelayMs, error }) => {
 						console.warn(

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -20,6 +20,7 @@ import {
 	type PackageStaticCallMeterInput,
 	type PackageStaticCallMeterTools,
 } from '#worker/usage/package-static-call-usage.ts'
+import { staticCallMeterRuntimeBridgeProviderName } from '#mcp/evaluation-side-effects.ts'
 
 export type AdditionalKodyTools = Record<
 	string,
@@ -246,9 +247,6 @@ const workflows = {
 const packageInvokeRuntimeBridgeProviderName =
 	'__kodyPackageInvokeRuntimeBridge'
 const packageEventRuntimeBridgeProviderName = '__kodyPackageEventRuntimeBridge'
-
-const staticCallMeterRuntimeBridgeProviderName =
-	'__kodyStaticCallMeterRuntimeBridge'
 
 function createPackagesHelperPrelude() {
 	return `

--- a/packages/worker/src/package-invocations/infrastructure-codes.ts
+++ b/packages/worker/src/package-invocations/infrastructure-codes.ts
@@ -4,6 +4,8 @@
  * dispatchers like subscription-dispatch can classify responses without
  * creating an import cycle through admin-package-subscriptions → service.
  */
+export const durableObjectResetInvocationErrorCode = 'durable_object_reset'
+
 const retryablePackageInvocationInfrastructureCodes = new Set([
 	'idempotency_lookup_failed',
 	'idempotency_persistence_failed',
@@ -11,6 +13,7 @@ const retryablePackageInvocationInfrastructureCodes = new Set([
 	'invocation_in_progress',
 	'invocation_failed',
 	'idempotency_response_unavailable',
+	durableObjectResetInvocationErrorCode,
 ])
 
 /** Codes raised before user code ran, so Queue redelivery re-executes. */

--- a/packages/worker/src/package-invocations/responses.ts
+++ b/packages/worker/src/package-invocations/responses.ts
@@ -2,7 +2,9 @@ import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { toJsonSafeValue } from '@kody-internal/shared/json-safe-value.ts'
 import { getExecutionErrorDetails } from '#mcp/executor.ts'
+import { isTransientDurableObjectResetError } from '#worker/durable-object-reset-retry.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
+import { durableObjectResetInvocationErrorCode } from './infrastructure-codes.ts'
 import { type PackageInvocationStoredResponse } from './repo.ts'
 
 export function buildExecutionSuccessResponse(input: {
@@ -63,8 +65,9 @@ export function buildExecutionErrorResponse(input: {
 	logs: Array<string>
 }): PackageInvocationStoredResponse {
 	const message = getErrorMessage(input.error)
+	const durableObjectReset = isTransientDurableObjectResetError(input.error)
 	return {
-		status: 500,
+		status: durableObjectReset ? 503 : 500,
 		body: {
 			ok: false,
 			package: {
@@ -83,7 +86,9 @@ export function buildExecutionErrorResponse(input: {
 					}
 				: {}),
 			error: {
-				code: 'execution_failed',
+				code: durableObjectReset
+					? durableObjectResetInvocationErrorCode
+					: 'execution_failed',
 				message,
 				details: toJsonSafeValue(getExecutionErrorDetails(input.error)),
 			},

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -2388,6 +2388,31 @@ test('invokePackageExport stores terminal failures for execution errors and miss
 		logs: ['before-error'],
 	})
 
+	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
+		error: new Error('Durable Object reset because its code was updated.'),
+		logs: [],
+	})
+	const durableObjectReset = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: { content: 'hi' },
+			idempotencyKey: 'evt-do-reset',
+			source: 'discord-gateway',
+		},
+	})
+	expect(durableObjectReset.status).toBe(503)
+	expect(durableObjectReset.body).toMatchObject({
+		ok: false,
+		error: {
+			code: 'durable_object_reset',
+			message: 'Durable Object reset because its code was updated.',
+		},
+	})
+
 	repoMockModule.runBundledModuleWithRegistry.mockClear()
 	const missingExportFirst = await invokePackageExport({
 		env: createEnv(db),

--- a/packages/worker/src/package-runtime/package-workflows.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows.node.test.ts
@@ -796,6 +796,65 @@ test('inline workflow sandbox failures throw UserCodeError', async () => {
 	)
 })
 
+test('inline workflow Durable Object isolate resets are not UserCodeError', async () => {
+	const { UserCodeError } = await import('#worker/user-code-error.ts')
+	runRecordMocks.resetProjections()
+	runRecordMocks.beginRunRecord.mockClear()
+	runRecordMocks.finishRunRecord.mockClear()
+	const binding = createStatefulWorkflowBinding()
+	const db = createWorkflowRunsDatabase()
+	const env = {
+		APP_DB: db,
+		DYNAMIC_CALLABLE_WORKFLOWS: binding.workflow,
+		APP_BASE_URL: 'https://app.example.com',
+	} as Env
+	const created = await createDynamicCallableWorkflow({
+		env,
+		userId: 'user-1',
+		packageContext: null,
+		body: {
+			code: 'export default async function main(){ return 1 }',
+			runAt: '2026-05-03T12:34:56.000Z',
+			idempotencyKey: 'inline-durable-object-reset',
+		},
+	})
+	const queued = binding.instances.get(created.id)
+	if (!queued?.params) throw new Error('Expected queued workflow payload.')
+	invocationMocks.runModuleWithRegistry.mockReset()
+	invocationMocks.runModuleWithRegistry.mockResolvedValueOnce({
+		result: undefined,
+		error: 'Durable Object reset because its code was updated.',
+		logs: [],
+	})
+	const workflow = new DynamicCallableWorkflowBase(
+		{ waitUntil: vi.fn() } as unknown as ExecutionContext,
+		env,
+	)
+	const stepDo = vi.fn(
+		async (_name: string, _config: unknown, callback: () => unknown) =>
+			await callback(),
+	)
+	await expect(
+		workflow.run(
+			{
+				payload: queued.params as never,
+				timestamp: new Date(),
+				instanceId: created.id,
+			},
+			{ sleepUntil: vi.fn(), do: stepDo } as unknown as WorkflowStep,
+		),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof Error &&
+			!(error instanceof UserCodeError) &&
+			error.message === 'Durable Object reset because its code was updated.',
+	)
+	const finishError =
+		runRecordMocks.finishRunRecord.mock.calls.at(-1)?.[0]?.error
+	expect(finishError).toBeInstanceOf(Error)
+	expect(finishError).not.toBeInstanceOf(UserCodeError)
+})
+
 test('package-created inline workflows retain package secret authorization context', async () => {
 	runRecordMocks.resetProjections()
 	const binding = createStatefulWorkflowBinding()
@@ -1282,6 +1341,20 @@ test('package workflow infrastructure failures are not UserCodeError', async () 
 				},
 			},
 			message: 'Durable Object storage blew up.',
+		},
+		{
+			idempotencyKey: 'package-durable-object-reset-infra',
+			response: {
+				status: 503,
+				body: {
+					ok: false,
+					error: {
+						code: 'durable_object_reset',
+						message: 'Durable Object reset because its code was updated.',
+					},
+				},
+			},
+			message: 'Durable Object reset because its code was updated.',
 		},
 	] as const
 

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -49,6 +49,7 @@ import {
 	isWorkflowBindingName,
 	type WorkflowBindingName,
 } from '#worker/run-records/workflow-projection.ts'
+import { isTransientDurableObjectResetError } from '#worker/durable-object-reset-retry.ts'
 import { UserCodeError } from '#worker/user-code-error.ts'
 import {
 	activeWorkflowStatusValues,
@@ -1611,7 +1612,10 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 			)
 			logs = result.logs
 			if (result.error) {
-				throw new UserCodeError(result.error)
+				if (isTransientDurableObjectResetError(result.error)) {
+					throw new Error(getErrorMessage(result.error))
+				}
+				throw new UserCodeError(getErrorMessage(result.error))
 			}
 			await finishRunRecord({
 				env: this.env,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Cloudflare deploy-time Durable Object isolate resets from failing package exports, ad-hoc execute, and workflows as if the user package crashed — without re-running user code after this evaluate already started a host-mediated side effect.

## Summary

`codemod-runner ./scan` is a thin userland export. A platform deploy reset in-flight isolates and recorded:

- export `960ab2fa-8694-4edd-864d-98273b29ad64` as `Durable Object reset because its code was updated.`
- workflow `./fleet` as `[execution_failed] Durable Object reset…` (`UserCodeError`, so `step.do` did not retry)

Jobs, `package_publish_external_push`, and artifact rebuild already retry this class. Execute/export did not.

- Shared `runWithTransientDurableObjectResetRetry` (100ms / 500ms, same delays as publish/rebuild)
- Each evaluate keeps host dispatcher/fetch attempt counters (increment **before** `await`; fetch via ALS + a recorder RPC because LOADER cannot take a wrapped `Fetcher`)
- In-process re-evaluate runs only when that snapshot is present and both counters are 0
- Thrown `evaluate` resets become a result carrying the live snapshot (missing snapshot = dirty = no retry)
- Remaining failures use HTTP 503 / `durable_object_reset` instead of `execution_failed`
- Workflows treat that as retryable infrastructure, not `UserCodeError`

## Testing

- Node-unit: evaluation-side-effects, durable-object-reset-retry (including exhausted `undefined`), executor, run-kody-registry, package-workflows, package-invocations/service — passed
- Workers-unit: execute-console-capture, execute-dynamic-worker-reuse — passed
- `npx nx run worker:typecheck` — passed
- Preview: https://kody-pr-1520.kody-a99.workers.dev — seed login, created `do-reset-preview`, activity/packages 200. Could not force an isolate reset on preview.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `2538cfd` · **Head:** `3c67311`

**Classification:** extends — in-process sandbox retry is now gated on this evaluate's host-visible side-effect counters; remaining isolate resets stay retryable infrastructure.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `capabilities-execute` | runtime | extends — retries isolate reset only when this evaluate's host dispatcher/fetch attempts are 0 |
| `mcp-server` | surfaces | extends — per-evaluate host counters; ALS-routed fetch records on the host before native fetch |
| `workflows` | assistant | extends — isolate resets are retryable infrastructure, not `UserCodeError` |
| `package-runtime` | runtime | composes — workflow tests only |

Unmatched paths (no primitive `code` root): `packages/worker/src/durable-object-reset-retry.ts` (shared retry helper + `shouldRetry` gate) and `packages/worker/src/package-invocations/{responses,infrastructure-codes}.ts` (export error code `durable_object_reset`).

### System map

A deploy-time isolate reset during sandbox evaluate is retried only when this evaluate started no host-mediated dispatcher or fetch; remaining failures stay classified so workflows can `step.do` again.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	capabilitiesExecute["capabilities-execute<br/>Capabilities execute runtime"]:::extended
	mcpServer["mcp-server<br/>MCP endpoint"]:::extended
	workflows["workflows<br/>Workflows"]:::extended
	packageInvocations["package-invocations<br/>Export HTTP/invoke"]:::extended
	mcpServer -->|"host counters + ALS fetch recorder"| capabilitiesExecute
	capabilitiesExecute -->|"retry evaluate only if both counters are 0"| capabilitiesExecute
	packageInvocations -->|"503 durable_object_reset"| workflows
	workflows -->|"plain Error so step.do retries"| capabilitiesExecute
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Caller
	participant Registry as runBundledModuleWithRegistry
	participant Sandbox as executor.evaluate
	participant Host as host dispatchers / fetch recorder
	Caller->>Registry: execute / export
	Registry->>Sandbox: evaluate
	Sandbox->>Host: increment-before-await on RPC / fetch
	Sandbox-->>Registry: Durable Object reset + snapshot
	alt counters are 0
		Registry->>Sandbox: retry after 100ms/500ms
	else unknown or dirty snapshot
		Registry-->>Caller: classified error, no in-process retry
	end
	Note over Caller: export returns 503 durable_object_reset when exhausted
```

### Before / after

| Path | Before | After |
| ---- | ------ | ----- |
| Sandbox isolate reset | Immediate `execution_failed` | Retry up to 3 times only when this evaluate's host counters are 0 |
| Thrown `evaluate` | Unknown / treated as retryable | Converted to a result with the live host snapshot |
| Package export error code | `execution_failed` (500) | `durable_object_reset` (503) |
| Package/inline workflow | `UserCodeError` (no step retry) | Plain `Error` (Workflows retry) |

### Invariants

In-process re-evaluate does not run after this evaluate started a host-mediated capability RPC or fetch. Missing snapshot is treated as dirty. Jobs/workflows may still re-enter user code at their own retry layer. Remaining failures stay visible in Activity if retries exhaust.

### Plan vs actual

Shipped the return-path and thrown-`evaluate` host counters in this PR instead of deferring fetch counting. LOADER still cannot take a wrapped `Fetcher`; fetch is counted via this evaluate's recorder RPC. Exhausted `undefined` results now return instead of throw. Origin tagging for spoofed reset strings was skipped — same message classifier as jobs/publish/rebuild.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06f69d76-678f-491e-9bd8-62594afe2d6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06f69d76-678f-491e-9bd8-62594afe2d6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retries for transient Durable Object isolate-reset errors.
  * Retries stop when host-side effects have occurred or attempts are exhausted.
  * Execution results now report host-mediated side effects.
  * Durable Object reset failures return HTTP 503 with a dedicated error code.

* **Bug Fixes**
  * Preserved permanent failures and correctly propagated reset errors in workflows and package executions.

* **Tests**
  * Added comprehensive coverage for retry behavior, side-effect tracking, error responses, and workflow failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->