### PR TITLE
fix(privacy): name MCP servers instead of remote connectors

### DIFF
--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -40,7 +40,7 @@ export function PrivacyRoute(_handle: Handle) {
 					Each signed-in user gets a fully isolated assistant. Kody stores
 					account profile information (email and username), secrets, values,
 					memories, packages and their source, jobs, email inboxes and messages,
-					durable storage, remote connector configuration, OAuth grants, package
+					durable storage, MCP server configuration, OAuth grants, package
 					invocation tokens, and any platform feedback you approve for
 					submission. All of this remains scoped to your account except for the
 					narrow admin review of approved platform feedback and the community
@@ -120,7 +120,7 @@ export function PrivacyRoute(_handle: Handle) {
 					<li>Jobs</li>
 					<li>Email inboxes and messages</li>
 					<li>Durable storage contents</li>
-					<li>Remote connector configuration</li>
+					<li>MCP server configuration</li>
 					<li>OAuth grants</li>
 				</ul>
 				<p mix={css(descriptionCss)}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the public privacy page aligned with the product after remote connectors were removed.

## Summary

- Replace leftover "remote connector configuration" copy on `/privacy` with "MCP server configuration"
- Matches the wording already in `docs/use/privacy.md`

## Testing

- Copy-only change in `packages/worker/client/routes/privacy.tsx`
- Preview https://kody-pr-1522.kody-a99.workers.dev/privacy renders **MCP server configuration** in both stored-per-account copy and the admin-never-sees list; old remote-connector wording is gone
- CI: Static, Node, Workers, MCP, and smoke-related E2E passed on `35b3557a`
- First E2E run flaked: `social-login` hung on the mock Google callback, then wrangler died (`Network connection lost`); `two-factor` failed because the server was already down. Unrelated to this copy change. Reran failed jobs.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `2538cfd4` · **Head:** `35b3557a`

**Classification:** composes — no primitives added or changed; this PR updates public privacy copy on an existing Remix route.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### System map

The public `/privacy` route is Remix UI. This PR only changes two strings so stored-account and admin-never-sees copy names MCP servers instead of the removed remote-connector product.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app (Remix 3)"]:::touched
	appUi -->|"/privacy stored-data and admin-never-sees copy"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

| Location | Before | After |
| -------- | ------ | ----- |
| Stored per account | remote connector configuration | MCP server configuration |
| Admin never sees | Remote connector configuration | MCP server configuration |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5f8a45c-0a01-4ff8-99fe-7240a5ddcbd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5f8a45c-0a01-4ff8-99fe-7240a5ddcbd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated privacy disclosures to clarify that MCP server configuration is stored with account data.
  - Clarified that MCP server configuration is excluded from administrator-visible data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->