### PR TITLE
Record publish-gated composition decisions and reject dependency cycles

### DIFF
--- a/docs/contributing/decisions/0021-publish-gated-package-composition.md
+++ b/docs/contributing/decisions/0021-publish-gated-package-composition.md
@@ -1,0 +1,42 @@
+# 0021: Publish-gated packages; no in-process composition runtime
+
+- **Status:** accepted
+- **Date:** 2026-08-18
+
+## Context
+
+A preprint on spatiotemporal composability (Cordis / Koishi) describes
+in-process plugin load/unload, reactive dependent deactivation, and live
+self-modification of an agent harness. Those ideas map onto Kody's packages,
+jobs, services, and community listings, so they needed an explicit decision
+against project intent (personal software, per-user isolation, compact MCP
+surface, Workers isolates). Versioning and auto-republish of dependents are
+already declined in [0001](./0001-no-package-versioning.md). Session-trace
+self-improvement is declined in [0008](./0008-declined-adlc-primitives.md).
+
+## Decision
+
+Keep Kody publish-gated and snapshot-isolated:
+
+- Agents create and publish packages under existing checks and secret/host
+  approval. They do not hot-patch a running harness or skip those gates.
+- Do not adopt an in-process fiber/HMR/context-proxy composition runtime. Worker
+  Loader isolates plus durable surfaces are the composition model.
+- Do not add a package-level disable primitive. Jobs and webhooks already have
+  per-surface enable flags; `hidden` is search visibility; full stop is delete.
+- Do not deactivate or auto-republish dependents when a provider changes or is
+  deleted. Publish already reports stale static snapshots for the agent to
+  decide.
+- Ad hoc `execute` stays ambient. Packages remain the declared-authority unit
+  (`kody.secretMounts`, host approval, integration allowlists,
+  `kody.dependencies`).
+
+## Consequences
+
+- Package delete is the inverse of a package existing. Closing leftover
+  community listings, minted webhooks, and service DO state is cleanup of that
+  inverse, not a new lifecycle.
+- Repo checks may reject `kody.dependencies` cycles at publish time. There is no
+  runtime that leaves cyclic packages "permanently inactive."
+- Revisit only if a concrete user need requires live in-process composition or a
+  package-wide kill switch that is not delete.

--- a/docs/contributing/decisions/0021-publish-gated-package-composition.md
+++ b/docs/contributing/decisions/0021-publish-gated-package-composition.md
@@ -37,9 +37,9 @@ Keep Kody publish-gated and snapshot-isolated:
   community listings, minted webhooks, and service DO state is cleanup of that
   inverse, not a new lifecycle.
 - Repo checks reject `kody.dependencies` cycles at publish time, including
-  reachable cyclic subgraphs the package under check depends on. A saved
-  sibling whose published manifest cannot load fails the dependency check
-  instead of being treated as a leaf. There is no runtime that leaves cyclic
-  packages "permanently inactive."
+  reachable cyclic subgraphs the package under check depends on. A saved sibling
+  whose published manifest cannot load fails the dependency check instead of
+  being treated as a leaf. There is no runtime that leaves cyclic packages
+  "permanently inactive."
 - Revisit only if a concrete user need requires live in-process composition or a
   package-wide kill switch that is not delete.

--- a/docs/contributing/decisions/0021-publish-gated-package-composition.md
+++ b/docs/contributing/decisions/0021-publish-gated-package-composition.md
@@ -36,7 +36,10 @@ Keep Kody publish-gated and snapshot-isolated:
 - Package delete is the inverse of a package existing. Closing leftover
   community listings, minted webhooks, and service DO state is cleanup of that
   inverse, not a new lifecycle.
-- Repo checks may reject `kody.dependencies` cycles at publish time. There is no
-  runtime that leaves cyclic packages "permanently inactive."
+- Repo checks reject `kody.dependencies` cycles at publish time, including
+  reachable cyclic subgraphs the package under check depends on. A saved
+  sibling whose published manifest cannot load fails the dependency check
+  instead of being treated as a leaf. There is no runtime that leaves cyclic
+  packages "permanently inactive."
 - Revisit only if a concrete user need requires live in-process composition or a
   package-wide kill switch that is not delete.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -40,3 +40,4 @@ behavior (see [documentation principles](../documentation.md)).
 - [0018 — Inbound CLA for external contributions to this repository](./0018-inbound-cla.md)
 - [0019 — Self-hosted Nx remote cache (not Nx Cloud)](./0019-self-hosted-nx-remote-cache.md)
 - [0020 — Repo sessions spill Workspace objects to R2; do not adopt `@cloudflare/computer`](./0020-repo-session-workspace-r2-not-computer.md)
+- [0021 — Publish-gated packages; no in-process composition runtime](./0021-publish-gated-package-composition.md)

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -23,7 +23,8 @@ Use `package.json` as the canonical source of truth for saved package metadata.
 - `kody.tags` — search tags
 - `kody.searchText` — optional longer search text beyond the short description
 - `kody.dependencies` — direct static saved package dependencies imported via
-  `kody:@...`. Repo checks reject cycles in this graph at publish time.
+  `kody:@...`. Repo checks reject cycles in this graph at publish time, and
+  fail closed if a reachable saved package manifest cannot be loaded.
 - `kody.secretMounts` — optional package-scoped secret mount declarations
 - `kody.app` — optional hosted package app config
 - `kody.services` — optional package-owned service runtimes

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -23,7 +23,7 @@ Use `package.json` as the canonical source of truth for saved package metadata.
 - `kody.tags` — search tags
 - `kody.searchText` — optional longer search text beyond the short description
 - `kody.dependencies` — direct static saved package dependencies imported via
-  `kody:@...`
+  `kody:@...`. Repo checks reject cycles in this graph at publish time.
 - `kody.secretMounts` — optional package-scoped secret mount declarations
 - `kody.app` — optional hosted package app config
 - `kody.services` — optional package-owned service runtimes

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -23,8 +23,8 @@ Use `package.json` as the canonical source of truth for saved package metadata.
 - `kody.tags` — search tags
 - `kody.searchText` — optional longer search text beyond the short description
 - `kody.dependencies` — direct static saved package dependencies imported via
-  `kody:@...`. Repo checks reject cycles in this graph at publish time, and
-  fail closed if a reachable saved package manifest cannot be loaded.
+  `kody:@...`. Repo checks reject cycles in this graph at publish time, and fail
+  closed if a reachable saved package manifest cannot be loaded.
 - `kody.secretMounts` — optional package-scoped secret mount declarations
 - `kody.app` — optional hosted package app config
 - `kody.services` — optional package-owned service runtimes

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -46,6 +46,13 @@ Keep the module focused and return structured evidence. Do not treat the
 ephemeral module as the durable source for behavior that must be maintained,
 reused, or evolved.
 
+Ad hoc `execute` runs with the signed-in user's ambient authority: it can call
+discovered capabilities through `kody`. A saved package is the
+declared-authority unit. Secret mounts, host approval, integration allowlists,
+and `kody.dependencies` are the request, and agents cannot widen those. Outbound
+emissions (email, paid APIs, third-party writes) are not invertible; use a
+package `dryRun` and fresh user confirmation before a live mutation.
+
 ### Fork a close community package before creating
 
 Community listings are excluded from general `search`. When you need durable

--- a/packages/worker/src/package-registry/static-dependency-cycles.node.test.ts
+++ b/packages/worker/src/package-registry/static-dependency-cycles.node.test.ts
@@ -1,0 +1,109 @@
+import { expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	listSavedPackagesByUserId: vi.fn(),
+	loadPackageManifestBySourceId: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: (...args: Array<unknown>) =>
+		mocks.listSavedPackagesByUserId(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+		mocks.loadPackageManifestBySourceId(...args),
+}))
+
+import {
+	findStaticKodyDependencyCycle,
+	formatStaticKodyDependencyCycleMessage,
+	loadReachableStaticKodyDependencyEdges,
+} from './static-dependency-cycles.ts'
+
+test('findStaticKodyDependencyCycle reports the path through a loop and ignores acyclic or missing roots', () => {
+	expect(
+		findStaticKodyDependencyCycle({
+			rootPackageName: '@scope/a',
+			edges: new Map([
+				['@scope/a', ['@scope/b']],
+				['@scope/b', ['@scope/a']],
+				['@scope/c', ['@scope/d']],
+			]),
+		}),
+	).toEqual(['@scope/a', '@scope/b', '@scope/a'])
+	expect(
+		findStaticKodyDependencyCycle({
+			rootPackageName: '@scope/c',
+			edges: new Map([
+				['@scope/c', ['@scope/d']],
+				['@scope/d', ['@scope/e']],
+				['@scope/e', ['@scope/c']],
+			]),
+		}),
+	).toEqual(['@scope/c', '@scope/d', '@scope/e', '@scope/c'])
+	expect(
+		findStaticKodyDependencyCycle({
+			rootPackageName: '@scope/c',
+			edges: new Map([
+				['@scope/a', ['@scope/b']],
+				['@scope/b', ['@scope/a']],
+				['@scope/c', ['@scope/d']],
+			]),
+		}),
+	).toBeNull()
+	expect(
+		findStaticKodyDependencyCycle({
+			rootPackageName: '@scope/missing',
+			edges: new Map([['@scope/a', ['@scope/b']]]),
+		}),
+	).toBeNull()
+	expect(
+		formatStaticKodyDependencyCycleMessage([
+			'@scope/a',
+			'@scope/b',
+			'@scope/a',
+		]),
+	).toBe(
+		'package.json#kody.dependencies forms a cycle: @scope/a -> @scope/b -> @scope/a.',
+	)
+})
+
+test('loadReachableStaticKodyDependencyEdges walks published sibling manifests and treats missing or unloadable packages as sinks', async () => {
+	mocks.listSavedPackagesByUserId.mockReset()
+	mocks.loadPackageManifestBySourceId.mockReset()
+	mocks.listSavedPackagesByUserId.mockResolvedValue([
+		{ name: '@scope/b', sourceId: 'source-b' },
+		{ name: '@scope/c', sourceId: 'source-c' },
+	])
+	mocks.loadPackageManifestBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => {
+			if (input.sourceId === 'source-b') {
+				return {
+					manifest: { kody: { dependencies: ['@scope/c', '@scope/missing'] } },
+				}
+			}
+			throw new Error('manifest unavailable')
+		},
+	)
+
+	const edges = await loadReachableStaticKodyDependencyEdges({
+		env: { APP_DB: {} } as Env,
+		baseUrl: 'https://example.test',
+		userId: 'user-1',
+		rootPackageName: '@scope/a',
+		rootDependencies: ['@scope/b', ' @scope/b '],
+	})
+
+	expect(edges.get('@scope/a')).toEqual(['@scope/b'])
+	expect(edges.get('@scope/b')).toEqual(['@scope/c', '@scope/missing'])
+	expect(edges.get('@scope/c')).toEqual([])
+	expect(edges.get('@scope/missing')).toEqual([])
+	expect(mocks.loadPackageManifestBySourceId).toHaveBeenCalledTimes(2)
+	expect(
+		findStaticKodyDependencyCycle({
+			rootPackageName: '@scope/a',
+			edges,
+		}),
+	).toBeNull()
+})

--- a/packages/worker/src/package-registry/static-dependency-cycles.node.test.ts
+++ b/packages/worker/src/package-registry/static-dependency-cycles.node.test.ts
@@ -18,10 +18,11 @@ vi.mock('#worker/package-registry/source.ts', () => ({
 import {
 	findStaticKodyDependencyCycle,
 	formatStaticKodyDependencyCycleMessage,
+	formatStaticKodyDependencyLoadFailureMessage,
 	loadReachableStaticKodyDependencyEdges,
 } from './static-dependency-cycles.ts'
 
-test('findStaticKodyDependencyCycle reports the path through a loop and ignores acyclic or missing roots', () => {
+test('findStaticKodyDependencyCycle reports reachable loops and ignores unreachable ones', () => {
 	expect(
 		findStaticKodyDependencyCycle({
 			rootPackageName: '@scope/a',
@@ -42,6 +43,16 @@ test('findStaticKodyDependencyCycle reports the path through a loop and ignores 
 			]),
 		}),
 	).toEqual(['@scope/c', '@scope/d', '@scope/e', '@scope/c'])
+	expect(
+		findStaticKodyDependencyCycle({
+			rootPackageName: '@scope/c',
+			edges: new Map([
+				['@scope/c', ['@scope/a']],
+				['@scope/a', ['@scope/b']],
+				['@scope/b', ['@scope/a']],
+			]),
+		}),
+	).toEqual(['@scope/a', '@scope/b', '@scope/a'])
 	expect(
 		findStaticKodyDependencyCycle({
 			rootPackageName: '@scope/c',
@@ -67,9 +78,17 @@ test('findStaticKodyDependencyCycle reports the path through a loop and ignores 
 	).toBe(
 		'package.json#kody.dependencies forms a cycle: @scope/a -> @scope/b -> @scope/a.',
 	)
+	expect(
+		formatStaticKodyDependencyLoadFailureMessage({
+			packageName: '@scope/c',
+			cause: new Error('manifest unavailable'),
+		}),
+	).toBe(
+		'Could not load the saved package manifest for @scope/c while checking package.json#kody.dependencies: manifest unavailable.',
+	)
 })
 
-test('loadReachableStaticKodyDependencyEdges walks published sibling manifests and treats missing or unloadable packages as sinks', async () => {
+test('loadReachableStaticKodyDependencyEdges walks published sibling manifests and treats missing packages as sinks', async () => {
 	mocks.listSavedPackagesByUserId.mockReset()
 	mocks.loadPackageManifestBySourceId.mockReset()
 	mocks.listSavedPackagesByUserId.mockResolvedValue([
@@ -83,11 +102,11 @@ test('loadReachableStaticKodyDependencyEdges walks published sibling manifests a
 					manifest: { kody: { dependencies: ['@scope/c', '@scope/missing'] } },
 				}
 			}
-			throw new Error('manifest unavailable')
+			return { manifest: { kody: { dependencies: [] } } }
 		},
 	)
 
-	const edges = await loadReachableStaticKodyDependencyEdges({
+	const graph = await loadReachableStaticKodyDependencyEdges({
 		env: { APP_DB: {} } as Env,
 		baseUrl: 'https://example.test',
 		userId: 'user-1',
@@ -95,15 +114,50 @@ test('loadReachableStaticKodyDependencyEdges walks published sibling manifests a
 		rootDependencies: ['@scope/b', ' @scope/b '],
 	})
 
-	expect(edges.get('@scope/a')).toEqual(['@scope/b'])
-	expect(edges.get('@scope/b')).toEqual(['@scope/c', '@scope/missing'])
-	expect(edges.get('@scope/c')).toEqual([])
-	expect(edges.get('@scope/missing')).toEqual([])
+	expect(graph).toMatchObject({ ok: true })
+	if (!graph.ok) throw new Error('expected loaded edges')
+	expect(graph.edges.get('@scope/a')).toEqual(['@scope/b'])
+	expect(graph.edges.get('@scope/b')).toEqual(['@scope/c', '@scope/missing'])
+	expect(graph.edges.get('@scope/c')).toEqual([])
+	expect(graph.edges.get('@scope/missing')).toEqual([])
 	expect(mocks.loadPackageManifestBySourceId).toHaveBeenCalledTimes(2)
 	expect(
 		findStaticKodyDependencyCycle({
 			rootPackageName: '@scope/a',
-			edges,
+			edges: graph.edges,
 		}),
 	).toBeNull()
+})
+
+test('loadReachableStaticKodyDependencyEdges fails closed when a saved package manifest cannot load', async () => {
+	mocks.listSavedPackagesByUserId.mockReset()
+	mocks.loadPackageManifestBySourceId.mockReset()
+	mocks.listSavedPackagesByUserId.mockResolvedValue([
+		{ name: '@scope/b', sourceId: 'source-b' },
+		{ name: '@scope/c', sourceId: 'source-c' },
+	])
+	mocks.loadPackageManifestBySourceId.mockImplementation(
+		async (input: { sourceId: string }) => {
+			if (input.sourceId === 'source-b') {
+				return {
+					manifest: { kody: { dependencies: ['@scope/c'] } },
+				}
+			}
+			throw new Error('manifest unavailable')
+		},
+	)
+
+	await expect(
+		loadReachableStaticKodyDependencyEdges({
+			env: { APP_DB: {} } as Env,
+			baseUrl: 'https://example.test',
+			userId: 'user-1',
+			rootPackageName: '@scope/a',
+			rootDependencies: ['@scope/b'],
+		}),
+	).resolves.toEqual({
+		ok: false,
+		message:
+			'Could not load the saved package manifest for @scope/c while checking package.json#kody.dependencies: manifest unavailable.',
+	})
 })

--- a/packages/worker/src/package-registry/static-dependency-cycles.ts
+++ b/packages/worker/src/package-registry/static-dependency-cycles.ts
@@ -1,0 +1,98 @@
+import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+
+/**
+ * Detect cycles in static `kody:@` / `package.json#kody.dependencies` graphs.
+ * Edges are package names (`@scope/leaf`). Missing nodes have no outgoing
+ * edges (an unpublished or platform-live dependency cannot close a user-local
+ * cycle).
+ */
+export function findStaticKodyDependencyCycle(input: {
+	rootPackageName: string
+	edges: ReadonlyMap<string, ReadonlyArray<string>>
+}): Array<string> | null {
+	const root = input.rootPackageName.trim()
+	if (!root) return null
+	const visiting = new Set<string>()
+	const visited = new Set<string>()
+	const path: Array<string> = []
+
+	function walk(packageName: string): Array<string> | null {
+		if (visiting.has(packageName)) {
+			const cycleStart = path.indexOf(packageName)
+			if (cycleStart === -1) return null
+			return [...path.slice(cycleStart), packageName]
+		}
+		if (visited.has(packageName)) return null
+		visiting.add(packageName)
+		path.push(packageName)
+		for (const dependency of input.edges.get(packageName) ?? []) {
+			const next = dependency.trim()
+			if (!next) continue
+			const cycle = walk(next)
+			if (cycle) return cycle
+		}
+		path.pop()
+		visiting.delete(packageName)
+		visited.add(packageName)
+		return null
+	}
+
+	return walk(root)
+}
+
+export function formatStaticKodyDependencyCycleMessage(
+	cycle: ReadonlyArray<string>,
+) {
+	return `package.json#kody.dependencies forms a cycle: ${cycle.join(' -> ')}.`
+}
+
+export async function loadReachableStaticKodyDependencyEdges(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	rootPackageName: string
+	rootDependencies: ReadonlyArray<string>
+}): Promise<Map<string, Array<string>>> {
+	const edges = new Map<string, Array<string>>()
+	const rootDependencies = uniqueTrimmedNames(input.rootDependencies)
+	edges.set(input.rootPackageName, rootDependencies)
+	const savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
+		userId: input.userId,
+	})
+	const savedByName = new Map(
+		savedPackages.map((savedPackage) => [savedPackage.name, savedPackage]),
+	)
+	const pending = [...rootDependencies]
+	while (pending.length > 0) {
+		const packageName = pending.pop()
+		if (!packageName || edges.has(packageName)) continue
+		const savedPackage = savedByName.get(packageName)
+		if (!savedPackage) {
+			edges.set(packageName, [])
+			continue
+		}
+		try {
+			const loaded = await loadPackageManifestBySourceId({
+				env: input.env,
+				baseUrl: input.baseUrl,
+				userId: input.userId,
+				sourceId: savedPackage.sourceId,
+			})
+			const dependencies = uniqueTrimmedNames(
+				loaded.manifest.kody.dependencies ?? [],
+			)
+			edges.set(packageName, dependencies)
+			pending.push(...dependencies)
+		} catch {
+			edges.set(packageName, [])
+		}
+	}
+	return edges
+}
+
+function uniqueTrimmedNames(names: ReadonlyArray<string>) {
+	return Array.from(
+		new Set(names.map((name) => name.trim()).filter((name) => name.length > 0)),
+	)
+}

--- a/packages/worker/src/package-registry/static-dependency-cycles.ts
+++ b/packages/worker/src/package-registry/static-dependency-cycles.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 
@@ -5,8 +6,13 @@ import { loadPackageManifestBySourceId } from '#worker/package-registry/source.t
  * Detect cycles in static `kody:@` / `package.json#kody.dependencies` graphs.
  * Edges are package names (`@scope/leaf`). Missing nodes have no outgoing
  * edges (an unpublished or platform-live dependency cannot close a user-local
- * cycle).
+ * cycle). A saved package whose published manifest cannot load fails the
+ * graph walk instead of pretending it has no dependencies.
  */
+
+export type LoadedStaticKodyDependencyEdges =
+	| { ok: true; edges: Map<string, Array<string>> }
+	| { ok: false; message: string }
 export function findStaticKodyDependencyCycle(input: {
 	rootPackageName: string
 	edges: ReadonlyMap<string, ReadonlyArray<string>>
@@ -47,13 +53,20 @@ export function formatStaticKodyDependencyCycleMessage(
 	return `package.json#kody.dependencies forms a cycle: ${cycle.join(' -> ')}.`
 }
 
+export function formatStaticKodyDependencyLoadFailureMessage(input: {
+	packageName: string
+	cause: unknown
+}) {
+	return `Could not load the saved package manifest for ${input.packageName} while checking package.json#kody.dependencies: ${getErrorMessage(input.cause)}.`
+}
+
 export async function loadReachableStaticKodyDependencyEdges(input: {
 	env: Env
 	baseUrl: string
 	userId: string
 	rootPackageName: string
 	rootDependencies: ReadonlyArray<string>
-}): Promise<Map<string, Array<string>>> {
+}): Promise<LoadedStaticKodyDependencyEdges> {
 	const edges = new Map<string, Array<string>>()
 	const rootDependencies = uniqueTrimmedNames(input.rootDependencies)
 	edges.set(input.rootPackageName, rootDependencies)
@@ -84,11 +97,17 @@ export async function loadReachableStaticKodyDependencyEdges(input: {
 			)
 			edges.set(packageName, dependencies)
 			pending.push(...dependencies)
-		} catch {
-			edges.set(packageName, [])
+		} catch (cause) {
+			return {
+				ok: false,
+				message: formatStaticKodyDependencyLoadFailureMessage({
+					packageName,
+					cause,
+				}),
+			}
 		}
 	}
-	return edges
+	return { ok: true, edges }
 }
 
 function uniqueTrimmedNames(names: ReadonlyArray<string>) {

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -1293,21 +1293,26 @@ export async function runRepoChecks(input: {
 		input.userId &&
 		getDeclaredStaticKodyPackageDependencies(manifest).length > 0
 	) {
-		const edges = await loadReachableStaticKodyDependencyEdges({
+		const graph = await loadReachableStaticKodyDependencyEdges({
 			env: input.env,
 			baseUrl: input.baseUrl ?? input.sourceRoot,
 			userId: input.userId,
 			rootPackageName: manifest.name,
 			rootDependencies: getDeclaredStaticKodyPackageDependencies(manifest),
 		})
-		const cycle = findStaticKodyDependencyCycle({
-			rootPackageName: manifest.name,
-			edges,
-		})
-		if (cycle) {
+		if (!graph.ok) {
 			staticKodyDependencyOk = false
-			staticKodyDependencyMessage =
-				formatStaticKodyDependencyCycleMessage(cycle)
+			staticKodyDependencyMessage = graph.message
+		} else {
+			const cycle = findStaticKodyDependencyCycle({
+				rootPackageName: manifest.name,
+				edges: graph.edges,
+			})
+			if (cycle) {
+				staticKodyDependencyOk = false
+				staticKodyDependencyMessage =
+					formatStaticKodyDependencyCycleMessage(cycle)
+			}
 		}
 	}
 	results.push({

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -8,6 +8,11 @@ import {
 	resolvePackageExportPath,
 } from '#worker/package-registry/manifest.ts'
 import {
+	findStaticKodyDependencyCycle,
+	formatStaticKodyDependencyCycleMessage,
+	loadReachableStaticKodyDependencyEdges,
+} from '#worker/package-registry/static-dependency-cycles.ts'
+import {
 	assertKodyDescriptionLength,
 	type AuthoredPackageJson,
 } from '#worker/package-registry/types.ts'
@@ -1280,15 +1285,40 @@ export async function runRepoChecks(input: {
 			manifest,
 			sourceFiles,
 		})
+	let staticKodyDependencyMessage = staticKodyDependencyCheck.message
+	let staticKodyDependencyOk = staticKodyDependencyCheck.ok
+	if (
+		staticKodyDependencyOk &&
+		input.env &&
+		input.userId &&
+		getDeclaredStaticKodyPackageDependencies(manifest).length > 0
+	) {
+		const edges = await loadReachableStaticKodyDependencyEdges({
+			env: input.env,
+			baseUrl: input.baseUrl ?? input.sourceRoot,
+			userId: input.userId,
+			rootPackageName: manifest.name,
+			rootDependencies: getDeclaredStaticKodyPackageDependencies(manifest),
+		})
+		const cycle = findStaticKodyDependencyCycle({
+			rootPackageName: manifest.name,
+			edges,
+		})
+		if (cycle) {
+			staticKodyDependencyOk = false
+			staticKodyDependencyMessage =
+				formatStaticKodyDependencyCycleMessage(cycle)
+		}
+	}
 	results.push({
 		kind: 'dependencies',
-		ok: staticKodyDependencyCheck.ok,
+		ok: staticKodyDependencyOk,
 		message: [
 			formatNpmDependencyCheckMessage({
 				packageJsonMissing: packageJson == null,
 				dependencies: declaredNpmDependencies,
 			}),
-			staticKodyDependencyCheck.message,
+			staticKodyDependencyMessage,
 		].join(' '),
 	})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Record the composition model we are keeping (publish-gated packages, no in-process plugin runtime) and make `kody.dependencies` cycles fail at publish time.

## Summary

- Add [ADR 0021](docs/contributing/decisions/0021-publish-gated-package-composition.md): no Cordis-style fibers/HMR, no package-level disable, snapshot dependents, ambient `execute` vs declared package authority.
- Note authority and non-invertible emissions in the package lifecycle guide.
- Repo checks walk the reachable static Kody package graph and fail when that graph contains a cycle, including a cyclic subgraph the package under check depends on.
- Fail closed if a reachable saved package's published manifest cannot load, so a transient load error cannot hide a cycle.

This does **not** change `package_delete`. The remaining delete inverse gaps (community listings, minted webhooks, service purge, dependents notice, published bundle artifacts) stay a follow-up.

## Testing

- `npx vitest run packages/worker/src/package-registry/static-dependency-cycles.node.test.ts packages/worker/src/repo/checks.node.test.ts` (19 passed)
- Preview [kody-pr-1523](https://kody-pr-1523.kody-a99.workers.dev): seed login, empty packages list, value `composition-preview-marker` = `cycle-check-adr-0021`. Cycle rejection is publish-time only; `/account/packages.json` cannot create packages.

## Review notes

- CodeRabbit: fail closed on unloadable sibling manifests — **fixed**.
- Bugbot: fail only when the package under check is itself on the cycle — **wontfix**. Depending on a reachable cyclic subgraph is still a publish failure (now covered by test).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/package-composition-decisions-2e6c`

**Classification:** extends — repo checks gain a cycle walk over static package dependencies; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — cycle detection over `kody.dependencies`; fail closed on unloadable sibling manifests |
| `repo-sessions` | runtime | extends — `runRepoChecks` fails cyclic or unloadable static graphs |

### System map

Repo checks load reachable sibling manifests and fail publish when the reachable `kody.dependencies` graph is cyclic or a saved sibling manifest cannot load.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	repoSessions["repo-sessions<br/>Repo sessions"]:::extended
	savedPackages["saved-packages<br/>Saved packages"]:::extended
	repoSessions -->|"runRepoChecks cycle walk"| savedPackages
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Invariants

Per-user isolation is unchanged: the cycle walk only reads the signed-in user's saved packages.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e3d95db-8fc5-48b5-a538-2617ff952e6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e3d95db-8fc5-48b5-a538-2617ff952e6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation for publish-gated package composition, package authority rules, and safeguards for irreversible actions.
  * Added publish-time detection and reporting of circular package dependencies.
  * Publishing now fails closed when a reachable saved package manifest cannot be loaded.

* **Bug Fixes**
  * Repository checks reject dependency cycles across reachable packages.

* **Tests**
  * Added coverage for cyclic, acyclic, missing, duplicate, and unavailable dependency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->