### PR TITLE
Simplify the OAuth connect page

### DIFF
--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -218,11 +218,14 @@ When the user has no matching user-lane app, `?provider=<slug>` prefills from an
 enabled platform app (`loadAccountIntegrationByName` in
 `packages/worker/src/app/account-integrations-data.ts`). The client then skips
 the client-credentials setup step entirely — no client ID/secret inputs and no
-redirect-URI card. The `oauth_exchange` / `connect_oauth` JSON actions accept
-`platformAppSlug`; for the platform lane every exchange input (token URL, flow,
-exchange style, client id, client secret) comes from the operator-provisioned
-row, never the request body, so a caller cannot point the decrypted shared
-secret at an arbitrary token URL.
+redirect-URI card. The hosted page leads with the provider mark, credentials or
+a connect button, and a terms note. Endpoints, host allowlists, stored config,
+and the built-in-alternative pitch stay behind an advanced disclosure. The
+`oauth_exchange` / `connect_oauth` JSON actions accept `platformAppSlug`; for
+the platform lane every exchange input (token URL, flow, exchange style, client
+id, client secret) comes from the operator-provisioned row, never the request
+body, so a caller cannot point the decrypted shared secret at an arbitrary token
+URL.
 
 `createAuthenticatedFetch(providerName)` (execute runtime helper) loads the
 named connection joined to its app, refreshes the access token when needed, and

--- a/packages/worker/client/provider-icons.node.test.ts
+++ b/packages/worker/client/provider-icons.node.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest'
+import { resolveProviderIconId } from './provider-icons.tsx'
+
+test('resolveProviderIconId matches exact keys, families, and authorize hosts', () => {
+	expect(resolveProviderIconId({ providerKey: 'GitHub' })).toBe('github')
+	expect(resolveProviderIconId({ providerKey: 'google-youtube-brand' })).toBe(
+		'google',
+	)
+	expect(resolveProviderIconId({ providerKey: 'work-slack' })).toBe('slack')
+	expect(resolveProviderIconId({ providerKey: 'x-kodykoala' })).toBe('x')
+	expect(resolveProviderIconId({ providerKey: 'twitter' })).toBe('x')
+	expect(resolveProviderIconId({ providerKey: 'example' })).toBeNull()
+	expect(resolveProviderIconId({ host: 'accounts.google.com' })).toBe('google')
+	expect(resolveProviderIconId({ host: 'www.googleapis.com' })).toBe('google')
+	expect(resolveProviderIconId({ host: 'github.com' })).toBe('github')
+	expect(
+		resolveProviderIconId({
+			providerKey: 'custom-crm',
+			host: 'login.unknown.test',
+		}),
+	).toBeNull()
+})

--- a/packages/worker/client/provider-icons.tsx
+++ b/packages/worker/client/provider-icons.tsx
@@ -1,4 +1,5 @@
-import { type Handle } from 'remix/ui'
+import { type Handle, css } from 'remix/ui'
+import { getLogoWellCss } from '#universal/styles/style-primitives.ts'
 
 /**
  * Inline brand marks for the social login providers and integration provider
@@ -123,7 +124,22 @@ function renderDiscordIcon(size: string) {
 	)
 }
 
-const providerIconRenderers: Record<string, (size: string) => JSX.Element> = {
+const knownProviderIconIds = [
+	'discord',
+	'github',
+	'google',
+	'notion',
+	'slack',
+	'spotify',
+	'x',
+] as const
+
+export type ProviderIconId = (typeof knownProviderIconIds)[number]
+
+const providerIconRenderers: Record<
+	ProviderIconId,
+	(size: string) => JSX.Element
+> = {
 	github: renderGitHubIcon,
 	google: renderGoogleIcon,
 	x: renderXIcon,
@@ -131,6 +147,55 @@ const providerIconRenderers: Record<string, (size: string) => JSX.Element> = {
 	spotify: renderSpotifyIcon,
 	notion: renderNotionIcon,
 	discord: renderDiscordIcon,
+}
+
+const providerIconHosts: Record<string, ProviderIconId> = {
+	'accounts.google.com': 'google',
+	'accounts.spotify.com': 'spotify',
+	'api.github.com': 'github',
+	'api.notion.com': 'notion',
+	'api.spotify.com': 'spotify',
+	'discord.com': 'discord',
+	'discordapp.com': 'discord',
+	'github.com': 'github',
+	'googleapis.com': 'google',
+	'notion.so': 'notion',
+	'oauth2.googleapis.com': 'google',
+	'slack.com': 'slack',
+	'spotify.com': 'spotify',
+	'twitter.com': 'x',
+	'x.com': 'x',
+}
+
+function isProviderIconId(value: string): value is ProviderIconId {
+	return (knownProviderIconIds as ReadonlyArray<string>).includes(value)
+}
+
+/**
+ * Maps a connect-page provider key (`google-youtube-brand`) or authorize
+ * host (`accounts.google.com`) onto an inline brand mark. `x` only matches
+ * exact / `x-…` / twitter names so short keys like `example` stay unmatched.
+ */
+export function resolveProviderIconId(input: {
+	providerKey?: string | null
+	host?: string | null
+}): ProviderIconId | null {
+	const key = input.providerKey?.trim().toLowerCase() ?? ''
+	if (isProviderIconId(key)) return key
+	if (key === 'twitter' || key.startsWith('x-')) return 'x'
+	if (key) {
+		for (const id of knownProviderIconIds) {
+			if (id === 'x') continue
+			if (key.startsWith(`${id}-`) || key.endsWith(`-${id}`)) return id
+		}
+	}
+	const host = input.host?.trim().toLowerCase() ?? ''
+	if (!host) return null
+	if (providerIconHosts[host]) return providerIconHosts[host]
+	for (const [known, id] of Object.entries(providerIconHosts)) {
+		if (host === known || host.endsWith(`.${known}`)) return id
+	}
+	return null
 }
 
 export function ProviderIcon(
@@ -141,7 +206,60 @@ export function ProviderIcon(
 	}>,
 ) {
 	return () =>
-		providerIconRenderers[handle.props.providerId]?.(
+		providerIconRenderers[handle.props.providerId as ProviderIconId]?.(
 			handle.props.size ?? defaultIconSize,
 		) ?? null
+}
+
+/**
+ * Provider identity for connect / integration headers: uploaded logo, known
+ * brand SVG, or a letter fallback. Always sits on the white logo well so
+ * dark marks stay readable in dark mode.
+ */
+export function ProviderMark(
+	handle: Handle<{
+		providerKey: string
+		label: string
+		logoPath?: string | null
+		host?: string | null
+		size?: string
+	}>,
+) {
+	return () => {
+		const { providerKey, label, logoPath, host } = handle.props
+		const wellSize = handle.props.size ?? '3rem'
+		const iconId = resolveProviderIconId({ providerKey, host })
+		const letter = label.trim().charAt(0).toUpperCase() || '?'
+		return (
+			<span
+				aria-hidden="true"
+				data-testid="provider-mark"
+				mix={css({
+					...getLogoWellCss({ size: wellSize, radius: '12px' }),
+					fontWeight: 700,
+					fontSize: '1.15rem',
+					lineHeight: 1,
+				})}
+			>
+				{logoPath ? (
+					<img
+						src={logoPath}
+						alt=""
+						width={40}
+						height={40}
+						mix={css({
+							display: 'block',
+							width: '70%',
+							height: '70%',
+							objectFit: 'contain' as const,
+						})}
+					/>
+				) : iconId ? (
+					<ProviderIcon providerId={iconId} size="1.65rem" />
+				) : (
+					letter
+				)}
+			</span>
+		)
+	}
 }

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -28,6 +28,8 @@ import {
 	spacing,
 	typography,
 } from '#universal/styles/tokens.ts'
+import { ProviderMark } from '#client/provider-icons.tsx'
+import { routes } from '#universal/routes.ts'
 import {
 	cardCss,
 	cardTitleCss,
@@ -38,6 +40,7 @@ import {
 	detailValueCss,
 	fieldCss,
 	fieldLabelCss,
+	getAccentCalloutCss,
 	getPrimaryButtonCss,
 	getSecondaryButtonCss,
 	insetCardCss,
@@ -51,6 +54,7 @@ import {
 	stackedPageCss,
 	inputCss,
 } from '#universal/styles/style-primitives.ts'
+import { accountDisclosureCss } from './account-management-components.tsx'
 import {
 	type ConnectOauthConfig,
 	type ConnectOauthHostApprovalLink,
@@ -562,11 +566,7 @@ export function ConnectOauthRoute(handle: Handle) {
 			platform: Boolean(nextConfig.platformAppSlug),
 		})
 		if (setupStatus.isReady) {
-			statusMessage = nextConfig.platformAppSlug
-				? 'Built-in integration — no OAuth app setup needed. Ready to connect.'
-				: existingIntegrationConfig
-					? 'Loaded your existing integration config and client credentials. Ready to connect.'
-					: 'Loaded your existing OAuth client configuration. Ready to connect.'
+			statusMessage = 'Ready to connect.'
 			statusTone = 'info'
 			currentStep = 'connect'
 			return
@@ -1025,18 +1025,19 @@ export function ConnectOauthRoute(handle: Handle) {
 		if (config?.platformAppSlug) return null
 		const redirectUri = getRedirectUri()
 		if (!redirectUri) return null
+		const providerName = config?.provider ?? 'your provider'
 		return (
 			<section mix={css(redirectUriCardCss)}>
-				<h2 mix={css(cardTitleCss)}>Redirect URI</h2>
+				<h2 mix={css(cardTitleCss)}>Redirect URL</h2>
 				<p mix={css({ margin: 0, color: colors.text })}>
-					Register this exact URL as the redirect (callback) URI in your
-					provider&apos;s OAuth app settings.
+					Paste this exact URL into {providerName}&apos;s OAuth app settings as
+					the redirect (callback) URL.
 				</p>
 				<pre mix={css(redirectUriValueCss)}>{redirectUri}</pre>
 				<div>
 					<CopyTextButton
 						value={redirectUri}
-						idleLabel="Copy redirect URI"
+						idleLabel="Copy redirect URL"
 						variant="primary"
 					/>
 				</div>
@@ -1068,6 +1069,16 @@ export function ConnectOauthRoute(handle: Handle) {
 						{instructions}
 					</p>
 				) : null}
+				{config.dashboardUrl && isSafeExternalUrl(config.dashboardUrl) ? (
+					<a
+						href={config.dashboardUrl}
+						target="_blank"
+						rel="noreferrer noopener"
+						mix={css(primaryLinkCss)}
+					>
+						Open {config.provider} developer settings
+					</a>
+				) : null}
 			</>
 		)
 	}
@@ -1078,14 +1089,49 @@ export function ConnectOauthRoute(handle: Handle) {
 			<section mix={css(insetCardCss)}>
 				<h3 mix={css(sectionTitleCss)}>Allowed hosts</h3>
 				<p mix={css(descriptionCss)}>
-					These hosts will be approved for the saved secrets. Host approvals are
-					never automatic.
+					Kody only sends this connection&apos;s tokens to these API hosts.
+					Approvals are never automatic.
 				</p>
 				<ul mix={css(listCss)}>
 					{config.allowedHosts.map((host) => (
 						<li key={host}>{host}</li>
 					))}
 				</ul>
+			</section>
+		)
+	}
+
+	const renderProviderDetails = () => {
+		if (!config) return null
+		return (
+			<section mix={css(insetCardCss)}>
+				<h3 mix={css(sectionTitleCss)}>Provider details</h3>
+				<div mix={css(detailGridCss)}>
+					<div mix={css(detailItemCss)}>
+						<span mix={css(detailLabelCss)}>Authorize URL</span>
+						<code mix={css(detailValueCss)}>{config.authorizeUrl}</code>
+					</div>
+					<div mix={css(detailItemCss)}>
+						<span mix={css(detailLabelCss)}>Token URL</span>
+						<code mix={css(detailValueCss)}>{config.tokenUrl}</code>
+					</div>
+					<div mix={css(detailItemCss)}>
+						<span mix={css(detailLabelCss)}>Flow</span>
+						<span mix={css(detailValueCss)}>{config.flow}</span>
+					</div>
+					<div mix={css(detailItemCss)}>
+						<span mix={css(detailLabelCss)}>PKCE</span>
+						<span mix={css(detailValueCss)}>
+							{config.usePkce ? 'S256' : 'off'}
+						</span>
+					</div>
+					<div mix={css(detailItemCss)}>
+						<span mix={css(detailLabelCss)}>Scopes</span>
+						<span mix={css(detailValueCss)}>
+							{config.scopes.length ? config.scopes.join(' ') : 'None'}
+						</span>
+					</div>
+				</div>
 			</section>
 		)
 	}
@@ -1180,6 +1226,63 @@ export function ConnectOauthRoute(handle: Handle) {
 				</div>
 			</section>
 		)
+	}
+
+	const renderAdvancedDetails = () => {
+		if (!config) return null
+		return (
+			<details
+				mix={css(advancedDetailsCss)}
+				data-testid="connect-oauth-advanced"
+			>
+				<summary>Advanced details</summary>
+				<div mix={css({ display: 'grid', gap: spacing.md })}>
+					{renderBuiltInAlternative()}
+					{renderProviderDetails()}
+					{renderAllowedHosts()}
+					{renderExistingIntegrationConfig()}
+				</div>
+			</details>
+		)
+	}
+
+	const renderStatusCallout = () => {
+		if (statusTone === 'error') {
+			return (
+				<div
+					role="alert"
+					mix={css(
+						getAccentCalloutCss({
+							accentColor: colors.error,
+						}),
+					)}
+				>
+					<p mix={css({ margin: 0, color: colors.error })}>{statusMessage}</p>
+				</div>
+			)
+		}
+		if (currentStep === 'callback') {
+			return <p mix={css(pageDescriptionCss)}>{statusMessage}</p>
+		}
+		return null
+	}
+
+	const headerTitle = () =>
+		config ? `Connect ${config.provider}` : 'Connect an account'
+
+	const headerDescription = () => {
+		if (!config) return statusMessage
+		if (statusTone === 'error') return null
+		if (currentStep === 'callback') return null
+		if (currentStep === 'success') return "You're connected."
+		if (config.platformDescription) return config.platformDescription
+		if (config.platformAppSlug) {
+			return `Continue to ${config.provider} to approve access.`
+		}
+		if (currentStep === 'setup') {
+			return `Create an OAuth app on ${config.provider}, register the redirect URL, and paste the credentials below.`
+		}
+		return `Continue to ${config.provider} to approve access.`
 	}
 
 	/**
@@ -1357,110 +1460,41 @@ export function ConnectOauthRoute(handle: Handle) {
 			return (
 				<section mix={css(pageCss)}>
 					<header mix={css(headerCss)}>
-						<span mix={css(eyebrowCss)}>Kody secure connection</span>
-						<h1 mix={css(pageTitleCss)}>Connect OAuth</h1>
+						<span mix={css(eyebrowCss)}>Connect an account</span>
+						<h1 mix={css(pageTitleCss)}>{headerTitle()}</h1>
 						<p mix={css(pageDescriptionCss)}>{statusMessage}</p>
 					</header>
+					{renderStatusCallout()}
 					{renderRedirectUriCard()}
 				</section>
 			)
 		}
+		const description = headerDescription()
 		return (
 			<section mix={css(pageCss)}>
 				<header mix={css(headerCss)}>
-					<span mix={css(eyebrowCss)}>Kody secure connection</span>
-					<h1
-						mix={css({
-							...pageTitleCss,
-							display: 'flex',
-							alignItems: 'center',
-							gap: spacing.sm,
-						})}
-					>
-						{config.platformLogoPath ? (
-							<img
-								src={config.platformLogoPath}
-								alt=""
-								width={36}
-								height={36}
-								mix={css({ borderRadius: radius.sm })}
-							/>
-						) : null}
-						Connect {config.provider}
-					</h1>
-					{config.platformDescription ? (
-						<p mix={css(pageDescriptionCss)}>{config.platformDescription}</p>
-					) : (
-						<p mix={css(pageDescriptionCss)}>
-							Follow the steps below to connect your account using OAuth.
-						</p>
-					)}
-				</header>
-				<section mix={css(getStatusCardCss(statusTone))}>
-					<div
-						mix={css({
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'space-between',
-							gap: spacing.sm,
-							flexWrap: 'wrap',
-						})}
-					>
-						<strong mix={css(sectionTitleCss)}>Status</strong>
-						<span mix={css(getStatusBadgeCss(statusTone))}>{currentStep}</span>
-					</div>
-					<p mix={css(getStatusMessageCss(statusTone))}>{statusMessage}</p>
-				</section>
-				{renderRedirectUriCard()}
-				<section mix={css(cardCss)}>
-					<h2 mix={css(cardTitleCss)}>Provider details</h2>
-					<div mix={css(detailGridCss)}>
-						<div mix={css(detailItemCss)}>
-							<span mix={css(detailLabelCss)}>Authorize URL</span>
-							<code mix={css(detailValueCss)}>{config.authorizeUrl}</code>
-						</div>
-						<div mix={css(detailItemCss)}>
-							<span mix={css(detailLabelCss)}>Token URL</span>
-							<code mix={css(detailValueCss)}>{config.tokenUrl}</code>
-						</div>
-						<div mix={css(detailItemCss)}>
-							<span mix={css(detailLabelCss)}>Flow</span>
-							<span mix={css(detailValueCss)}>{config.flow}</span>
-						</div>
-						<div mix={css(detailItemCss)}>
-							<span mix={css(detailLabelCss)}>PKCE</span>
-							<span mix={css(detailValueCss)}>
-								{config.usePkce ? 'S256' : 'off'}
-							</span>
-						</div>
-						<div mix={css(detailItemCss)}>
-							<span mix={css(detailLabelCss)}>Scopes</span>
-							<span mix={css(detailValueCss)}>
-								{config.scopes.length ? config.scopes.join(' ') : 'None'}
-							</span>
-						</div>
-					</div>
-					{config.dashboardUrl && isSafeExternalUrl(config.dashboardUrl) ? (
-						<a
-							href={config.dashboardUrl}
-							target="_blank"
-							rel="noreferrer noopener"
-							mix={css(primaryLinkCss)}
-						>
-							Open provider dashboard
-						</a>
+					<ProviderMark
+						providerKey={config.providerKey}
+						label={config.provider}
+						logoPath={config.platformLogoPath}
+						host={config.authorizeHost}
+					/>
+					<span mix={css(eyebrowCss)}>Connect an account</span>
+					<h1 mix={css(pageTitleCss)}>{headerTitle()}</h1>
+					{description ? (
+						<p mix={css(pageDescriptionCss)}>{description}</p>
 					) : null}
-				</section>
-				{renderExistingIntegrationConfig()}
+				</header>
+				{renderStatusCallout()}
+				{currentStep === 'setup' ? renderRedirectUriCard() : null}
 				{currentStep === 'setup' ? (
 					<section mix={css(cardCss)}>
 						<h2 mix={css(cardTitleCss)}>
-							1. {existingIntegrationConfig ? 'Review' : 'Save'} OAuth client
-							configuration
+							{existingIntegrationConfig
+								? 'Confirm your app credentials'
+								: 'Enter your app credentials'}
 						</h2>
-						{renderBuiltInAlternative()}
 						{renderProviderInstructions()}
-						{renderAllowedHosts()}
 						<form
 							{...passwordManagerIgnoreProps}
 							mix={[
@@ -1554,32 +1588,18 @@ export function ConnectOauthRoute(handle: Handle) {
 								disabled={submitting}
 								mix={css(primaryButtonCss)}
 							>
-								Save configuration
+								Save and continue
 							</button>
 						</form>
 					</section>
 				) : null}
 				{currentStep === 'connect' ? (
 					<section mix={css(cardCss)}>
-						<h2 mix={css(cardTitleCss)}>2. Connect</h2>
-						<p mix={css({ margin: 0, color: colors.text })}>
-							Start the OAuth flow. You will be redirected to the provider.
-						</p>
 						{renderReplaceConfirmation()}
-						{renderBuiltInAlternative()}
-						{existingIntegrationConfig && hasStoredClientId ? (
-							<p mix={css(descriptionCss)}>
-								Using stored client ID
-								{config.flow === 'confidential' && hasStoredClientSecret
-									? ` and stored client secret ${config.clientSecretSecretName ?? ''}.`
-									: '.'}
-							</p>
-						) : null}
-						<p mix={css(descriptionCss)}>
+						<p mix={css({ margin: 0, color: colors.text })}>
 							Connecting authorizes your agent — and any code you run or install
-							— to act as you on {config.provider} with the scopes you grant.
-							Kody does not control or supervise what your agent does with this
-							access; that responsibility is yours. See the{' '}
+							— to act as you on {config.provider} with the access you grant.
+							See the{' '}
 							<a href="/terms" target="_blank" rel="noreferrer noopener">
 								Terms
 							</a>
@@ -1596,31 +1616,34 @@ export function ConnectOauthRoute(handle: Handle) {
 									css(primaryButtonCss),
 								]}
 							>
-								Connect {config.provider}
+								Continue to {config.provider}
 							</button>
 						)}
 					</section>
 				) : null}
 				{currentStep === 'success' ? (
 					<section mix={css(cardCss)}>
-						<h2 mix={css(cardTitleCss)}>4. Success</h2>
-						<div mix={css(detailGridCss)}>
-							<div mix={css(detailItemCss)}>
-								<span mix={css(detailLabelCss)}>Access token saved</span>
-								<strong mix={css(detailValueCss)}>
-									{accessTokenSaved ? 'Yes' : 'No'}
-								</strong>
+						{hostApprovalLinks.length > 0 ? (
+							<div mix={css({ display: 'grid', gap: spacing.md })}>
+								<p mix={css({ margin: 0, color: colors.text })}>
+									One more step: allow this connection to call {config.provider}
+									.
+								</p>
+								<button
+									type="button"
+									disabled={approvingAllHosts}
+									mix={[
+										on('click', () => void approveAllHostApprovals()),
+										css(primaryButtonCss),
+									]}
+								>
+									{approvingAllHosts ? 'Allowing access…' : 'Allow access'}
+								</button>
 							</div>
-							<div mix={css(detailItemCss)}>
-								<span mix={css(detailLabelCss)}>Refresh token saved</span>
-								<strong mix={css(detailValueCss)}>
-									{refreshTokenSaved ? 'Yes' : 'No'}
-								</strong>
-							</div>
-						</div>
+						) : null}
 						{nextSteps ? (
 							<div mix={css(insetCardCss)}>
-								<h3 mix={css(sectionTitleCss)}>Next: helpers package</h3>
+								<h2 mix={css(cardTitleCss)}>What to do next</h2>
 								<p mix={css(descriptionCss)}>{nextSteps.guidance}</p>
 								{nextSteps.suggestions.length > 0 ? (
 									<ul mix={css(listCss)}>
@@ -1673,31 +1696,39 @@ export function ConnectOauthRoute(handle: Handle) {
 								</div>
 							</div>
 						) : null}
-						<h3 mix={css(sectionTitleCss)}>Host approvals</h3>
-						<p mix={css({ margin: 0, color: colors.text })}>
-							Hosts are never auto-approved. Review these allowed hosts in your
-							account secrets.
-						</p>
-						<ul mix={css(listCss)}>
-							{config.allowedHosts.map((host) => (
-								<li key={host}>{host}</li>
-							))}
-						</ul>
-						{hostApprovalLinks.length > 0 ? (
-							<div mix={css(insetCardCss)}>
-								<p mix={css(descriptionCss)}>
-									Approve each token host directly:
-								</p>
-								<button
-									type="button"
-									disabled={approvingAllHosts}
-									mix={[
-										on('click', () => void approveAllHostApprovals()),
-										css(primaryButtonCss),
-									]}
-								>
-									{approvingAllHosts ? 'Approving hosts…' : 'Approve all hosts'}
-								</button>
+						<a
+							href={routes.accountIntegrationDetail.href({
+								integrationName: config.providerKey,
+							})}
+							mix={css(primaryLinkCss)}
+						>
+							View this connection
+						</a>
+					</section>
+				) : null}
+				{currentStep === 'success' ? (
+					<details
+						mix={css(advancedDetailsCss)}
+						data-testid="connect-oauth-advanced"
+					>
+						<summary>Advanced details</summary>
+						<div mix={css({ display: 'grid', gap: spacing.md })}>
+							<div mix={css(detailGridCss)}>
+								<div mix={css(detailItemCss)}>
+									<span mix={css(detailLabelCss)}>Access token saved</span>
+									<strong mix={css(detailValueCss)}>
+										{accessTokenSaved ? 'Yes' : 'No'}
+									</strong>
+								</div>
+								<div mix={css(detailItemCss)}>
+									<span mix={css(detailLabelCss)}>Refresh token saved</span>
+									<strong mix={css(detailValueCss)}>
+										{refreshTokenSaved ? 'Yes' : 'No'}
+									</strong>
+								</div>
+							</div>
+							{renderAllowedHosts()}
+							{hostApprovalLinks.length > 0 ? (
 								<ul mix={css(listCss)}>
 									{hostApprovalLinks.map((link) => (
 										<li key={`${link.secretName}:${link.host}`}>
@@ -1713,18 +1744,20 @@ export function ConnectOauthRoute(handle: Handle) {
 										</li>
 									))}
 								</ul>
-							</div>
-						) : null}
-						<a
-							href="/account/secrets"
-							target="_blank"
-							rel="noreferrer"
-							mix={css(primaryLinkCss)}
-						>
-							Open account secrets
-						</a>
-					</section>
-				) : null}
+							) : null}
+							<a
+								href="/account/secrets"
+								target="_blank"
+								rel="noreferrer"
+								mix={css(primaryLinkCss)}
+							>
+								Open account secrets
+							</a>
+						</div>
+					</details>
+				) : (
+					renderAdvancedDetails()
+				)}
 			</section>
 		)
 	}
@@ -1732,12 +1765,21 @@ export function ConnectOauthRoute(handle: Handle) {
 
 const pageCss = {
 	...stackedPageCss,
-	maxWidth: '56rem',
+	maxWidth: '32rem',
 	margin: '0 auto',
 }
 
-const headerCss = pageHeaderCss
+const headerCss = {
+	...pageHeaderCss,
+	justifyItems: 'center',
+	textAlign: 'center' as const,
+}
 const eyebrowCss = pageEyebrowCss
+const advancedDetailsCss = {
+	...accountDisclosureCss,
+	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
+}
 
 const redirectUriCardCss = {
 	...cardCss,
@@ -1784,41 +1826,4 @@ const trustedBadgeCss = {
 	color: colors.primaryText,
 	fontSize: typography.fontSize.xs,
 	fontWeight: typography.fontWeight.semibold,
-}
-
-function getStatusCardCss(tone: 'info' | 'warn' | 'error') {
-	return {
-		...cardCss,
-		border: `1px solid ${tone === 'error' ? colors.error : colors.primary}`,
-		backgroundColor:
-			tone === 'error'
-				? 'color-mix(in srgb, var(--color-danger) 8%, var(--color-surface))'
-				: colors.primarySoftest,
-	}
-}
-
-function getStatusBadgeCss(tone: 'info' | 'warn' | 'error') {
-	return {
-		display: 'inline-flex',
-		alignItems: 'center',
-		justifyContent: 'center',
-		padding: `0.25rem ${spacing.sm}`,
-		borderRadius: radius.full,
-		backgroundColor:
-			tone === 'error'
-				? 'color-mix(in srgb, var(--color-danger) 14%, transparent)'
-				: colors.surface,
-		color: tone === 'error' ? colors.error : colors.primaryText,
-		fontSize: typography.fontSize.xs,
-		fontWeight: typography.fontWeight.semibold,
-		letterSpacing: '0.08em',
-		textTransform: 'uppercase' as const,
-	}
-}
-
-function getStatusMessageCss(tone: 'info' | 'warn' | 'error') {
-	return {
-		margin: 0,
-		color: tone === 'error' ? colors.error : colors.text,
-	}
 }

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -1271,9 +1271,9 @@ export function ConnectOauthRoute(handle: Handle) {
 		config ? `Connect ${config.provider}` : 'Connect an account'
 
 	const headerDescription = () => {
-		if (!config) return statusMessage
 		if (statusTone === 'error') return null
 		if (currentStep === 'callback') return null
+		if (!config) return statusMessage
 		if (currentStep === 'success') return "You're connected."
 		if (config.platformDescription) return config.platformDescription
 		if (config.platformAppSlug) {
@@ -1457,12 +1457,15 @@ export function ConnectOauthRoute(handle: Handle) {
 			handle.queueTask(initializeVisit)
 		}
 		if (!config) {
+			const description = headerDescription()
 			return (
 				<section mix={css(pageCss)}>
 					<header mix={css(headerCss)}>
 						<span mix={css(eyebrowCss)}>Connect an account</span>
 						<h1 mix={css(pageTitleCss)}>{headerTitle()}</h1>
-						<p mix={css(pageDescriptionCss)}>{statusMessage}</p>
+						{description ? (
+							<p mix={css(pageDescriptionCss)}>{description}</p>
+						) : null}
 					</header>
 					{renderStatusCallout()}
 					{renderRedirectUriCard()}

--- a/packages/worker/src/app/handlers/connect-oauth.ts
+++ b/packages/worker/src/app/handlers/connect-oauth.ts
@@ -107,7 +107,6 @@ export function createConnectOauthHandler(env: Env) {
 			return renderAppPage({
 				request,
 				env,
-				title: 'Connect OAuth',
 				loaderData: { connectOauth },
 			})
 		},

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -838,6 +838,32 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 	expect(setupHtml).toContain('Save and continue')
 	expect(setupHtml).toContain('data-testid="connect-oauth-advanced"')
 	expect(setupHtml).toContain('https://github.com/login/oauth/authorize')
+
+	// Provider without stored or query endpoints: the missing-config error
+	// is a single alert, not also repeated as the header description.
+	const missingResponse = await renderAppPage({
+		request: new Request(
+			'https://example.com/connect/oauth?provider=unknown-provider',
+		),
+		env,
+		loaderData: {
+			connectOauth: {
+				ok: true,
+				provider: 'unknown-provider',
+				integration: null,
+				builtInAvailable: false,
+				hasStoredClientSecret: false,
+				redirectUri: 'https://example.com/connect/oauth',
+			},
+		},
+	})
+	expect(missingResponse.status).toBe(200)
+	const missingHtml = await readResponseText(missingResponse)
+	expect(missingHtml).toContain('role="alert"')
+	expect(
+		missingHtml.split('Missing required OAuth configuration parameters.')
+			.length - 1,
+	).toBe(1)
 })
 
 test('renderAppPage renders the redesigned pricing page', async () => {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -753,12 +753,16 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 
 	expect(response.status).toBe(200)
 	const html = await readResponseText(response)
-	expect(html).toContain('https://example.com/connect/oauth')
+	expect(html).toContain('Connect google')
+	expect(html).toContain('data-testid="provider-mark"')
+	expect(html).toContain('data-testid="connect-oauth-advanced"')
+	expect(html).toContain('Continue to google')
 	expect(html).toContain('https://accounts.google.com/o/oauth2/v2/auth')
+	expect(html).not.toContain('>Status<')
 
 	// A built-in connect that would replace a user-lane connection under the
 	// same name server-renders the replace confirmation and withholds the
-	// plain Connect button (the client also skips auto-start in this state).
+	// Continue button (the client also skips auto-start in this state).
 	const replaceResponse = await renderAppPage({
 		request: new Request(
 			'https://example.com/connect/oauth?provider=google&platform=1',
@@ -805,7 +809,35 @@ test('renderAppPage server-renders connect-oauth provider visits without a loadi
 	expect(replaceResponse.status).toBe(200)
 	const replaceHtml = await readResponseText(replaceResponse)
 	expect(replaceHtml).toContain('data-testid="connect-replace-confirm"')
-	expect(replaceHtml).not.toContain('>Connect google</button>')
+	expect(replaceHtml).toContain('data-testid="provider-mark"')
+	expect(replaceHtml).not.toContain('>Continue to google</button>')
+
+	// First-time bring-your-own setup: credentials form and redirect URL are
+	// visible; endpoints and allowed hosts stay behind the disclosure.
+	const setupResponse = await renderAppPage({
+		request: new Request(
+			'https://example.com/connect/oauth?provider=github&authorizeUrl=https%3A%2F%2Fgithub.com%2Flogin%2Foauth%2Fauthorize&tokenUrl=https%3A%2F%2Fgithub.com%2Flogin%2Foauth%2Faccess_token',
+		),
+		env,
+		loaderData: {
+			connectOauth: {
+				ok: true,
+				provider: 'github',
+				integration: null,
+				builtInAvailable: false,
+				hasStoredClientSecret: false,
+				redirectUri: 'https://example.com/connect/oauth',
+			},
+		},
+	})
+	expect(setupResponse.status).toBe(200)
+	const setupHtml = await readResponseText(setupResponse)
+	expect(setupHtml).toContain('Connect github')
+	expect(setupHtml).toContain('Redirect URL')
+	expect(setupHtml).toContain('https://example.com/connect/oauth')
+	expect(setupHtml).toContain('Save and continue')
+	expect(setupHtml).toContain('data-testid="connect-oauth-advanced"')
+	expect(setupHtml).toContain('https://github.com/login/oauth/authorize')
 })
 
 test('renderAppPage renders the redesigned pricing page', async () => {

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -293,7 +293,10 @@ const routeDocumentHeads = {
 		const verification = loaderData?.emailVerification
 		return titleOnly(verification?.ok ? 'Email changed' : 'Verify email change')
 	},
-	[routePattern(routes.connectOauth)]: titleOnly('Connect OAuth'),
+	[routePattern(routes.connectOauth)]: ({ loaderData }) => {
+		const provider = loaderData?.connectOauth?.provider?.trim()
+		return titleOnly(provider ? `Connect ${provider}` : 'Connect an account')
+	},
 	[oauthPaths.authorize]: titleOnly('Authorize access'),
 	[oauthPaths.callback]: titleOnly('OAuth callback'),
 } as const satisfies Record<string, DocumentHeadResolver>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `/connect/oauth` readable for a person who just wants to connect an account. Most visitors do not need host allowlists, endpoint dumps, or a pitch for the built-in integration.

## Summary

- Default path is now provider mark + short explanation + the one action that matters (credentials, continue, or allow access).
- Provider identity uses the uploaded platform logo when present, a known brand SVG (including family keys like `google-youtube-brand`), or a letter fallback.
- Endpoints, allowed hosts, stored-config internals, token-saved flags, and the built-in alternative move behind **Advanced details**.
- Happy-path status card / step badge is gone; errors still surface as a callout.
- Success leads with “Allow access” when a host approval is still required, then a link to the connection instead of account secrets.
- Document title becomes `Connect {provider}` when the loader knows the name.
- Empty-config errors render once (alert only), matching the configured path.

## Screenshots

First-time bring-your-own setup (GitHub):

![Connect GitHub setup page](https://cursor.com/artifacts/c/art-9b21b9a5-5b2c-4584-a533-6abd27686825)

Ready reconnect (Google):

![Connect Google ready page](https://cursor.com/artifacts/c/art-82611280-4bb6-4e69-8daf-c93175f8beb9)

Replace an existing connection (Google built-in):

![Connect Google replace confirmation](https://cursor.com/artifacts/c/art-35d1e188-67f2-4b66-87dc-694ab9dae856)

Advanced details opened on setup:

![Connect GitHub advanced details](https://cursor.com/artifacts/c/art-50037769-117a-4b19-8867-938379e919d3)

## Preview manual test

Signed in as the preview seed (`me@kentcdodds.com` / `user-me`) on https://kody-pr-1527.kody-a99.workers.dev (`221926d8`).

- `GET /connect/oauth` GitHub BYO setup: provider mark, redirect URL, credentials, collapsed Advanced details, no Status card.
- Advanced details: authorize/token URLs, PKCE, allowed hosts (`github.com`).
- Unknown provider: a single `Missing required OAuth configuration parameters.` alert (not repeated in the header).
- Preview has no built-in Google platform config (`builtInAvailable: false`); `?provider=google` showing the same missing-config error is expected there, not a regression.
- Seed integrations list was empty: `{"integrations":[],"apps":[]}`.

![Preview GitHub setup default path](https://cursor.com/artifacts/c/art-61bec5ef-1a6b-41cc-b3a2-daac101a9e98)
![Preview GitHub advanced details open](https://cursor.com/artifacts/c/art-6dd44a0b-6501-4055-8881-1f915481ac69)
![Preview unknown-provider single error](https://cursor.com/artifacts/c/art-06ab19a0-91a0-4584-a2da-89b88126107e)
<a href="https://cursor.com/agents/bc-c0d0f646-7b54-4da4-b515-f1f0103012e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_connect_oauth_signed_in_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-91aea3df-b6e7-4e63-af24-df50a27d26f8" alt="preview_connect_oauth_signed_in_walkthrough.mp4" /></a>

## Testing

- `npx vitest run --project node-unit` on connect-oauth, provider-icons, document-head, connect-oauth handler, and SSR render suites (including a missing-config alert count).
- Screenshots captured from the same SSR HTML those tests render.
- Preview: `npm run preview:manual-test -- --pr 1527` plus the signed-in UI pass above. Validate CI is green on `221926d8`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `c629b06f` · **Head:** `221926d8`

**Classification:** extends — `/connect/oauth` presentation and document title change; OAuth persist / exchange contracts are unchanged.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — simplified connect page, provider mark, advanced disclosure |

### System map

The hosted connect page still reads the existing integration loader payload; only the Remix UI and document title change.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	integrations["integrations<br/>OAuth integrations"]:::untouched
	appUi -->|"loader prefill + platform logo path"| integrations
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Before / after

**Default connect page**

```text
Before: status card, redirect URI, provider details,
        existing-config dump, allowed hosts, built-in pitch,
        credentials / connect, host list on success

After:  provider mark + title, redirect URL (setup only),
        credentials or continue, terms,
        advanced disclosure for the rest
```

### Invariants

Unchanged: per-user isolation, host allowlists still enforced on save/exchange, built-in auto-start and replace confirmation still run.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0d0f646-7b54-4da4-b515-f1f0103012e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0d0f646-7b54-4da4-b515-f1f0103012e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned OAuth connection pages with provider branding, clearer setup instructions, and improved connection actions.
  * Added provider icons with support for recognized provider names, aliases, and hosts.
  * Added expandable advanced details for endpoints, host approvals, stored settings, and alternatives.
  * OAuth page titles now reflect the selected provider when available.

* **Documentation**
  * Updated OAuth integration documentation to describe the hosted connection experience.

* **Bug Fixes**
  * Improved redirect URL guidance and provider dashboard access during OAuth setup.
  * Improved handling and messaging for missing OAuth configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->