### PR TITLE
Prefer sequence diagrams in visual-recap skill

### DIFF
--- a/.agents/skills/visual-recap/SKILL.md
+++ b/.agents/skills/visual-recap/SKILL.md
@@ -81,8 +81,8 @@ to a topology flowchart.
   diagram when topology is the story.
 - **Other mermaid types** when they fit better: `erDiagram` for schema,
   `stateDiagram-v2` for lifecycle, `flowchart TB` for a decision tree. Use them
-  instead of (or alongside) a sequence diagram — do not force a sequence
-  diagram that hides the real change.
+  instead of (or alongside) a sequence diagram — do not force a sequence diagram
+  that hides the real change.
 
 Every diagram is PR-scoped: only the path this diff changes, not the full
 architecture. Open with one sentence naming what the graph shows. **Label every
@@ -133,8 +133,8 @@ sequenceDiagram
 
 ### System map
 
-_Optional: a topology flowchart when a sequence diagram is not enough, or when
-a second view of crossings helps._
+_Optional: a topology flowchart when a sequence diagram is not enough, or when a
+second view of crossings helps._
 
 ### Before / after
 
@@ -166,14 +166,14 @@ Format rules:
   - Open with one sentence naming the main flow (e.g. "Social login flows from
     the login UI through session auth into D1.").
   - Participants are primitives: use the `id` as the alias (e.g.
-    `participant appSessions as app-sessions`). Add an `actor` only when a
-    human or external caller is part of the change.
+    `participant appSessions as app-sessions`). Add an `actor` only when a human
+    or external caller is part of the change.
   - **Label every message** with what this PR does on that hop. Unlabeled
     messages are the sequence-diagram form of unlabeled flowchart arrows.
-  - Include only participants on the changed path — not all ~25 primitives.
-    Add a neighbor only when this PR actually calls through them.
-  - Use `Note over` / `Note right of` for new or changed data, guards, or
-    status — not as a substitute for a labeled message.
+  - Include only participants on the changed path — not all ~25 primitives. Add
+    a neighbor only when this PR actually calls through them.
+  - Use `Note over` / `Note right of` for new or changed data, guards, or status
+    — not as a substitute for a labeled message.
   - Keep the happy path first. Use `alt` / `opt` only for a branch this PR
     introduces or changes.
 - **System map** (optional): a PR-scoped **topology** view — how touched
@@ -195,8 +195,8 @@ Format rules:
   - Skip this section when the sequence diagram already covers the path,
     including storage or cross-cutting hops (DB, RBAC, export).
 - Other mermaid types follow the same labeling and PR-scope rules. Put an
-  `erDiagram` or `stateDiagram-v2` in **Change flow** (or **Before / after**
-  for a compact schema snippet) when that graph is the clearest.
+  `erDiagram` or `stateDiagram-v2` in **Change flow** (or **Before / after** for
+  a compact schema snippet) when that graph is the clearest.
 - Keep the whole block scannable: prefer tables and diagrams over prose, and
   keep it well under ~120 lines.
 
@@ -279,8 +279,8 @@ sequenceDiagram
 	Note over d1AppDb: new table is an export + deletion target
 ```
 
-A topology flowchart is still useful when the change is structural rather than
-a single timed path (several owners, fan-out, or crossings a sequence would
+A topology flowchart is still useful when the change is structural rather than a
+single timed path (several owners, fan-out, or crossings a sequence would
 flatten). Same labeling bar: every edge names what this PR does.
 
 **Weak** (unlabeled topology):

--- a/.agents/skills/visual-recap/SKILL.md
+++ b/.agents/skills/visual-recap/SKILL.md
@@ -3,9 +3,11 @@ name: visual-recap
 description:
   Generate and maintain the system recap block in a PR description - a
   GitHub-rendered visual summary of which system primitives a change touches,
-  how risky it is, and what changed. Use when planning a non-trivial change
-  (plan mode), when creating or updating a pull request (recap mode), or when
-  the user asks for a visual recap, visual plan, system review, or PR recap.
+  how risky it is, and what changed. Prefer mermaid sequence diagrams for the
+  change; pick another graph type when it explains the diff better. Use when
+  planning a non-trivial change (plan mode), when creating or updating a pull
+  request (recap mode), or when the user asks for a visual recap, visual plan,
+  system review, or PR recap.
 ---
 
 # System recap (visual plan / visual recap)
@@ -67,6 +69,30 @@ The classifier reports which primitives' `code` roots the diff touches; you
 still decide `composes` vs `extends` from the diff (and `adds` when you create a
 new map entry).
 
+## Choosing a diagram
+
+Pick the mermaid graph that best explains **this PR's** change. Do not default
+to a topology flowchart.
+
+- **Sequence diagram (preferred):** request or job timing, who calls whom, and
+  what this PR adds or changes on each hop. This is the usual choice.
+- **Flowchart / system map:** many-to-many wiring, fan-out, or a crossing that
+  is awkward as a single timed path. Useful **in addition** to a sequence
+  diagram when topology is the story.
+- **Other mermaid types** when they fit better: `erDiagram` for schema,
+  `stateDiagram-v2` for lifecycle, `flowchart TB` for a decision tree. Use them
+  instead of (or alongside) a sequence diagram — do not force a sequence
+  diagram that hides the real change.
+
+Every diagram is PR-scoped: only the path this diff changes, not the full
+architecture. Open with one sentence naming what the graph shows. **Label every
+arrow or message** with what this PR does across that boundary (route, handler,
+table/column, guard, capability, env var). Unlabeled arrows are forbidden.
+
+Include at least one diagram. Add a second only when it shows something the
+first cannot (for example a sequence for timing plus a small ER snippet for a
+new table). Do not restate the same path in two graphs.
+
 ## Block format
 
 The block lives in the PR description between HTML comment markers, wrapped in
@@ -92,30 +118,23 @@ existing primitives together.
 | `mcp-server` | surfaces | composes                                |
 | `d1-app-db`  | storage  | extends — new `jobs.retry_count` column |
 
-### System map
-
-_One sentence: what this diagram shows and the main path through the change._
-
-**Legend:** green = composes (wiring only) · amber = extended by this PR · red =
-new primitive · gray = context (unchanged, included only when an edge crosses
-it).
-
-```mermaid
-flowchart LR
-	mcpServer["mcp-server<br/>MCP endpoint"]:::touched
-	capabilityRegistry["capability-registry<br/>Capability registry"]:::untouched
-	d1AppDb["d1-app-db<br/>D1 app database"]:::extended
-	mcpServer -->|"search/execute"| capabilityRegistry
-	capabilityRegistry -->|"jobs.retry_count column"| d1AppDb
-	classDef touched fill:#1a7f37,color:#fff
-	classDef extended fill:#9a6700,color:#fff
-	classDef added fill:#cf222e,color:#fff
-	classDef untouched fill:#57606a,color:#fff
-```
-
 ### Change flow
 
-_Optional: a mermaid flowchart or sequence diagram of the specific change._
+Search/execute records a retry count on the job row.
+
+```mermaid
+sequenceDiagram
+	participant mcpServer as mcp-server
+	participant registry as capability-registry
+	participant d1AppDb as d1-app-db
+	mcpServer->>registry: search/execute
+	registry->>d1AppDb: write jobs.retry_count
+```
+
+### System map
+
+_Optional: a topology flowchart when a sequence diagram is not enough, or when
+a second view of crossings helps._
 
 ### Before / after
 
@@ -142,30 +161,42 @@ Format rules:
   bold so reviewers see it without expanding.
 - Blank line after `<summary>` and around every fenced block, or GitHub will not
   render the markdown/mermaid inside `<details>`.
-- **System map**: a PR-scoped **change map** — how touched primitives interact
-  _because of this diff_, not the full architecture. Rules:
+- **Change flow** (preferred visual): usually a mermaid **sequence diagram** of
+  the changed path. Rules:
   - Open with one sentence naming the main flow (e.g. "Social login flows from
     the login UI through session auth into D1.").
-  - Include the **legend** line (colors and what they mean) directly above the
-    diagram, using the fixed wording from the template.
-  - Include only primitives the diff touches plus neighbors needed to show a
-    crossing edge — not all ~25 nodes, and no gray context nodes unless this PR
-    actually calls through them.
-  - **Label every edge** with what this PR does across that boundary: route,
-    handler, table/column, guard, capability, env var, etc. Unlabeled arrows are
-    forbidden; they read as meaningless topology and are the main failure mode
-    reviewers report.
+  - Participants are primitives: use the `id` as the alias (e.g.
+    `participant appSessions as app-sessions`). Add an `actor` only when a
+    human or external caller is part of the change.
+  - **Label every message** with what this PR does on that hop. Unlabeled
+    messages are the sequence-diagram form of unlabeled flowchart arrows.
+  - Include only participants on the changed path — not all ~25 primitives.
+    Add a neighbor only when this PR actually calls through them.
+  - Use `Note over` / `Note right of` for new or changed data, guards, or
+    status — not as a substitute for a labeled message.
+  - Keep the happy path first. Use `alt` / `opt` only for a branch this PR
+    introduces or changes.
+- **System map** (optional): a PR-scoped **topology** view — how touched
+  primitives connect because of this diff. Use when a sequence diagram cannot
+  show fan-out, ownership, or several crossings at once. Rules when you include
+  one:
+  - Include the **legend** line directly above the flowchart, using this fixed
+    wording: green = composes (wiring only) · amber = extended by this PR · red
+    = new primitive · gray = context (unchanged, included only when an edge
+    crosses it).
   - Node labels: primitive `id` plus the `name` from `primitives.yaml` on a
     second line via `<br/>` (e.g.
     `appSessions["app-sessions<br/>Browser sessions"]`).
   - Color nodes with the four `classDef` styles (`touched` = composes,
     `extended`, `added`, `untouched` for context-only nodes).
-  - Prefer fewer, labeled edges over chaining unlabeled `A --> B --> C` hops.
-    Split long chains only when each hop has its own label.
+  - **Label every edge.** Prefer fewer, labeled edges over chaining unlabeled
+    `A --> B --> C` hops.
   - Quote node labels containing spaces or special characters.
-  - When a sequence diagram already in **Change flow** covers the same path, the
-    system map may omit duplicate edges — but still include storage or
-    cross-cutting hops (DB, RBAC, export) that the sequence diagram skips.
+  - Skip this section when the sequence diagram already covers the path,
+    including storage or cross-cutting hops (DB, RBAC, export).
+- Other mermaid types follow the same labeling and PR-scope rules. Put an
+  `erDiagram` or `stateDiagram-v2` in **Change flow** (or **Before / after**
+  for a compact schema snippet) when that graph is the clearest.
 - Keep the whole block scannable: prefer tables and diagrams over prose, and
   keep it well under ~120 lines.
 
@@ -183,9 +214,10 @@ Format rules:
 3. Read the full diff for anything you did not author this session; decide
    composes/extends/adds per matched primitive (and note important unmatched
    paths if they introduce a new surface).
-4. Author the block following the format above. Use map `name` for diagram
-   labels; pull behavioral detail from architecture docs / the diff, not by
-   rewriting map summaries.
+4. Author the block following the format above. Use map `name` for participant
+   and node labels; pull behavioral detail from architecture docs / the diff,
+   not by rewriting map summaries. Choose the graph type using **Choosing a
+   diagram**.
 5. Upsert it into the PR description:
 
    ```bash
@@ -212,12 +244,46 @@ requires **no** change to any primitive — that is the lowest-risk outcome and
 worth stating explicitly. When implementation later diverges from the plan, the
 recap's "Plan vs actual" section records the drift.
 
-## System map example (weak vs strong)
+## Diagram examples (weak vs strong)
 
 The diagram must explain **this PR's** crossings, not restate static
-architecture. Compare:
+architecture. A sequence diagram is the usual strong choice:
 
-**Weak** (unlabeled topology — reviewers cannot tell what the arrows mean):
+**Weak** (unlabeled hops — reviewers cannot tell what changed):
+
+```mermaid
+sequenceDiagram
+	participant appUi as app-ui
+	participant appSessions as app-sessions
+	participant d1AppDb as d1-app-db
+	appUi->>appSessions: request
+	appSessions->>d1AppDb: write
+```
+
+**Strong** (intro sentence, primitive participants, messages from the diff):
+
+Social login flows from the login UI through session auth into D1; the new
+`oauth_connections` row is what account export later reads.
+
+```mermaid
+sequenceDiagram
+	actor User
+	participant appUi as app-ui
+	participant appSessions as app-sessions
+	participant rbac as rbac
+	participant d1AppDb as d1-app-db
+	User->>appUi: click provider button
+	appUi->>appSessions: POST /auth/:provider
+	appSessions->>rbac: 2FA gate on sign-in
+	appSessions->>d1AppDb: insert oauth_connections
+	Note over d1AppDb: new table is an export + deletion target
+```
+
+A topology flowchart is still useful when the change is structural rather than
+a single timed path (several owners, fan-out, or crossings a sequence would
+flatten). Same labeling bar: every edge names what this PR does.
+
+**Weak** (unlabeled topology):
 
 ```mermaid
 flowchart LR
@@ -229,8 +295,7 @@ flowchart LR
 
 **Strong** (intro, legend, human names, labeled edges):
 
-Social login flows from the login UI through session auth into D1; account
-export picks up the new table.
+Account export and session auth both gain the new `oauth_connections` table.
 
 **Legend:** green = composes · amber = extended by this PR · red = new primitive
 · gray = context.
@@ -252,6 +317,7 @@ flowchart LR
 	classDef untouched fill:#57606a,color:#fff
 ```
 
-Derive edge labels from the diff (routes, migrations, guards, capabilities). The
-**Change flow** sequence diagram can stay for request timing; the system map
-answers "which primitives does this PR connect, and how?"
+Derive message and edge labels from the diff (routes, migrations, guards,
+capabilities). Prefer the sequence diagram for "what happens in what order?";
+add a system map only when reviewers also need "which primitives does this PR
+connect?"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let agents show system changes with the graph that explains the diff, leaning toward mermaid sequence diagrams instead of treating a topology flowchart as the required recap visual.

## Summary

- Rewrites the repo `visual-recap` skill so **Change flow** is the primary visual and a sequence diagram is the usual choice.
- Keeps flowchart system maps, ER diagrams, and other mermaid types available when they explain the change better — and as an optional second view, not a mandatory default.
- Adds the same skill to the Kody skills registry (`visual-recap`). It was not present there before; `skill_list` now includes it.

## Testing

- `npx vitest run .agents/skills/visual-recap/scripts/primitives-map.node.test.ts` — 3 passed.
- Classifier against this diff: no primitives matched (only `.agents/skills/visual-recap/SKILL.md`).
- Kody `skill_get({ id: "visual-recap" })` returns the sequence-first document; `skill_list` includes `visual-recap` after index sync.
- Static CI failed on `oxfmt --check`; formatted the skill and pushed.

## System changes

No runtime primitives change. Recap guidance only.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>no primitives touched</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `c629b06` · **Head:** `93ac0d3a`

**Classification:** no primitives added or changed — this PR only updates recap guidance. That is the lowest-risk outcome.

### Primitives touched

_None. The classifier matched no `primitives.yaml` roots; the unmatched path is `.agents/skills/visual-recap/SKILL.md`._

### Change flow

Agents load visual-recap, pick a graph for the diff (sequence by default), and upsert that block into the PR description. The same document is what Kody `skill_get` returns.

```mermaid
sequenceDiagram
	actor Agent
	participant RecapSkill as visual-recap
	participant Classifier as classify-primitives
	participant PR as PR description
	Agent->>RecapSkill: load skill for plan or recap
	Agent->>Classifier: classify diff paths
	Classifier-->>Agent: matched primitives (none on this PR)
	RecapSkill-->>Agent: prefer sequence diagram
	Agent->>PR: upsert labeled mermaid change flow
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a5d13a6-9681-4ffc-98ae-0cd7c88dd317?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a5d13a6-9681-4ffc-98ae-0cd7c88dd317&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted visual recap guidance to improve readability and consistency.
  * No changes were made to the documented behavior, requirements, examples, or supported workflows.
  * Existing instructions remain functionally unchanged while being easier to scan and follow during visual recap creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->