### PR TITLE
Keep package services alive through Durable Object eviction

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -110,6 +110,14 @@ Saved packages may also declare long-lived package services under
 - Package services share package identity with apps/jobs and can publish into
   package app realtime sessions, but they own their own durable storage bucket
   and lifecycle.
+- A running service is kept resident with a short incoming alarm (about 15s).
+  Background `waitUntil` work does not keep the Durable Object alive by itself;
+  without that wake, Cloudflare evicts the isolate and orphans the sandbox,
+  including any outbound WebSocket.
+- `mode: 'persistent'` means stay up until stopped. Eviction is treated as a
+  platform interrupt: the host immediately reschedules the same service, even
+  when `autoStart` is false. Persist resume cursors (`session_id`, sequence)
+  in `packageStorage()` so the next run can continue.
 
 ## Workflow runtime
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -116,8 +116,8 @@ Saved packages may also declare long-lived package services under
   including any outbound WebSocket.
 - `mode: 'persistent'` means stay up until stopped. Eviction is treated as a
   platform interrupt: the host immediately reschedules the same service, even
-  when `autoStart` is false. Persist resume cursors (`session_id`, sequence)
-  in `packageStorage()` so the next run can continue.
+  when `autoStart` is false. Persist resume cursors (`session_id`, sequence) in
+  `packageStorage()` so the next run can continue.
 
 ## Workflow runtime
 

--- a/docs/guides/package-service-pattern.md
+++ b/docs/guides/package-service-pattern.md
@@ -187,15 +187,21 @@ service status through the existing package runtime bridge.
 ## Prefer bounded reconnect loops over one immortal run
 
 Cloudflare Durable Objects can open outbound WebSockets, but outgoing WebSockets
-do **not** hibernate. Favor a design where the service can:
+do **not** hibernate. The host keeps a running service isolate awake with a
+short incoming alarm; still treat disconnect and eviction as normal:
 
 - reconnect intentionally
 - reschedule itself with alarms
-- persist resumable state early
+- persist resumable state early (`session_id`, sequence, cursor)
 - stop cooperatively
 
-Use `timeoutMs` to give the service enough room to run, but do not rely on
-indefinite execution as the only lifecycle mechanism.
+Use `mode: 'persistent'` for daemon-like supervisors (Discord Gateway, other
+outbound sockets). Persistent services resume immediately after Durable Object
+eviction even when `autoStart` is false. Bounded services still use crash-loop
+backoff when `autoStart` is true.
+
+Use `timeoutMs` to give a bounded service enough room to run, but do not rely
+on indefinite execution as the only lifecycle mechanism.
 
 ## What to persist
 

--- a/docs/guides/package-service-pattern.md
+++ b/docs/guides/package-service-pattern.md
@@ -200,8 +200,8 @@ outbound sockets). Persistent services resume immediately after Durable Object
 eviction even when `autoStart` is false. Bounded services still use crash-loop
 backoff when `autoStart` is true.
 
-Use `timeoutMs` to give a bounded service enough room to run, but do not rely
-on indefinite execution as the only lifecycle mechanism.
+Use `timeoutMs` to give a bounded service enough room to run, but do not rely on
+indefinite execution as the only lifecycle mechanism.
 
 ## What to persist
 

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -433,8 +433,8 @@ Use the package service model when the package needs:
 - package-owned daemon-like logic
 - package state that is separate from browser sessions
 - a service that should publish updates into a package app
-- an outbound WebSocket or reconnect loop (`mode: 'persistent'`, persist
-  resume cursors in `packageStorage()`; the host keeps the isolate awake and
+- an outbound WebSocket or reconnect loop (`mode: 'persistent'`, persist resume
+  cursors in `packageStorage()`; the host keeps the isolate awake and
   immediately resumes after eviction)
 
 Treat package services like package-owned runtime modules:

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -433,6 +433,9 @@ Use the package service model when the package needs:
 - package-owned daemon-like logic
 - package state that is separate from browser sessions
 - a service that should publish updates into a package app
+- an outbound WebSocket or reconnect loop (`mode: 'persistent'`, persist
+  resume cursors in `packageStorage()`; the host keeps the isolate awake and
+  immediately resumes after eviction)
 
 Treat package services like package-owned runtime modules:
 

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -89,6 +89,8 @@ const {
 	buildPackageServiceStorageId,
 	buildServiceRuntimeUsageEvent,
 	computePackageServiceRetryDelayMs,
+	packageServiceKeepaliveMs,
+	packageServiceStateHeartbeatMs,
 } = await import('./package-service.ts')
 
 const serviceBinding = {
@@ -374,7 +376,9 @@ test('package service start and stop project liveness into package_service_state
 			'2026-07-05T12:00:00.000Z',
 			'2026-07-05T12:00:00.000Z',
 		])
-		expect(created.getAlarmAt()).toBe(Date.parse('2026-07-05T13:00:00.000Z'))
+		expect(created.getAlarmAt()).toBe(
+			Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs,
+		)
 
 		await flushWaitUntilTasks(created.waitUntilTasks)
 		expect(mockModule.runBundledModuleWithRegistry.mock.calls[0]?.[1]).toEqual(
@@ -605,6 +609,102 @@ test('durable object restore meters an eviction-orphaned in-flight run without a
 		expect(restoreUsageSpy).not.toHaveBeenCalled()
 	} finally {
 		restoreUsageSpy.mockRestore()
+	}
+})
+
+test('durable object restore immediately resumes an evicted persistent service', async () => {
+	resetMocks()
+	const usageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockResolvedValue(undefined)
+	vi.useFakeTimers()
+	try {
+		const restoredAt = new Date('2026-07-05T13:00:00.000Z')
+		vi.setSystemTime(restoredAt)
+		setupSavedPackage('persistent')
+		mockModule.runBundledModuleWithRegistry.mockResolvedValue({
+			result: { resumed: true },
+			error: null,
+		})
+		const restored = createPackageServiceState()
+		restored.persistedEntries.set('package-service-state', {
+			binding: serviceBinding,
+			autoStart: false,
+			mode: 'persistent',
+			timeoutMs: null,
+			stopRequested: false,
+			currentRunId: 'run-evicted',
+			nextAlarmAt: null,
+			nextAlarmSource: null,
+			lastStartedAt: '2026-07-05T12:55:00.000Z',
+			lastStoppedAt: null,
+			status: 'running',
+			lastError: null,
+			lastResult: null,
+			lastRunFinishedAt: null,
+			consecutiveFailureCount: 0,
+		})
+		const meter = createInMemoryUserMeterEnv()
+		const instance = new PackageServiceInstance(restored.state, {
+			APP_DB: {},
+			USER_METER: meter.env.USER_METER,
+		} as Env)
+		await waitForRestoreState(restored.state)
+		await flushWaitUntilTasks(restored.waitUntilTasks)
+
+		expect(restored.getAlarmAt()).toBe(restoredAt.valueOf())
+		const persisted = restored.persistedEntries.get(
+			'package-service-state',
+		) as { status: string; currentRunId: string | null }
+		expect(persisted.status).toBe('stopped')
+		expect(persisted.currentRunId).toBeNull()
+
+		await instance.alarm()
+		await flushWaitUntilTasks(restored.waitUntilTasks)
+		expect(mockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+	} finally {
+		usageSpy.mockRestore()
+		vi.useRealTimers()
+	}
+})
+
+test('running keepalive alarms do not start a second service run', async () => {
+	resetMocks()
+	vi.useFakeTimers()
+	vi.setSystemTime(new Date('2026-07-05T12:00:00.000Z'))
+	try {
+		setupSavedPackage('persistent')
+		mockModule.runBundledModuleWithRegistry.mockImplementation(
+			() => new Promise(() => {}),
+		)
+		const created = await createPackageServiceInstance({
+			APP_DB: {},
+		} as Env)
+		const start = await created.instance.fetch(
+			new Request('https://package-service.invalid/service/start', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ binding: serviceBinding }),
+			}),
+		)
+		expect(start.status).toBe(200)
+		await drainSettledWaitUntilTasks(created.waitUntilTasks)
+		expect(mockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+		expect(created.getAlarmAt()).toBe(
+			Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs,
+		)
+
+		vi.setSystemTime(
+			new Date(Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs),
+		)
+		await created.instance.alarm()
+		await drainSettledWaitUntilTasks(created.waitUntilTasks)
+		expect(mockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+		expect(created.getAlarmAt()).toBe(
+			Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs * 2,
+		)
+	} finally {
+		vi.useRealTimers()
 	}
 })
 
@@ -951,9 +1051,40 @@ test('package service start/heartbeat/stop/purge shadow UserMeter transitions', 
 			sourceUpdatedAt: '2026-07-05T12:00:00.000Z',
 			revision: 1,
 		})
-		expect(created.getAlarmAt()).toBe(Date.parse('2026-07-05T13:00:00.000Z'))
+		expect(created.getAlarmAt()).toBe(
+			Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs,
+		)
 
-		vi.setSystemTime(new Date('2026-07-05T13:00:00.000Z'))
+		vi.setSystemTime(
+			new Date(Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs),
+		)
+		const afterKeepaliveWaitUntilCount = created.waitUntilTasks.length
+		await created.instance.alarm()
+		await drainSettledWaitUntilTasks(
+			created.waitUntilTasks,
+			afterKeepaliveWaitUntilCount,
+		)
+		expect(
+			packageServiceShadowRow(
+				meter,
+				'user-123',
+				'package-1',
+				'realtime-supervisor',
+			),
+		).toMatchObject({
+			status: 'running',
+			sourceUpdatedAt: '2026-07-05T12:00:00.000Z',
+			revision: 1,
+		})
+		expect(created.getAlarmAt()).toBe(
+			Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs * 2,
+		)
+
+		vi.setSystemTime(
+			new Date(
+				Date.parse('2026-07-05T12:00:00.000Z') + packageServiceStateHeartbeatMs,
+			),
+		)
 		const afterStartWaitUntilCount = created.waitUntilTasks.length
 		await created.instance.alarm()
 		await drainSettledWaitUntilTasks(
@@ -972,7 +1103,9 @@ test('package service start/heartbeat/stop/purge shadow UserMeter transitions', 
 			sourceUpdatedAt: '2026-07-05T13:00:00.000Z',
 			revision: 2,
 		})
-		expect(created.getAlarmAt()).toBe(Date.parse('2026-07-05T14:00:00.000Z'))
+		expect(created.getAlarmAt()).toBe(
+			Date.parse('2026-07-05T13:00:00.000Z') + packageServiceKeepaliveMs,
+		)
 
 		const afterHeartbeatWaitUntilCount = created.waitUntilTasks.length
 		await postPackageService(created.instance, 'stop')

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -695,7 +695,9 @@ test('running keepalive alarms do not start a second service run', async () => {
 		)
 
 		vi.setSystemTime(
-			new Date(Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs),
+			new Date(
+				Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs,
+			),
 		)
 		await created.instance.alarm()
 		await drainSettledWaitUntilTasks(created.waitUntilTasks)
@@ -1056,7 +1058,9 @@ test('package service start/heartbeat/stop/purge shadow UserMeter transitions', 
 		)
 
 		vi.setSystemTime(
-			new Date(Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs),
+			new Date(
+				Date.parse('2026-07-05T12:00:00.000Z') + packageServiceKeepaliveMs,
+			),
 		)
 		const afterKeepaliveWaitUntilCount = created.waitUntilTasks.length
 		await created.instance.alarm()

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -32,7 +32,14 @@ const requiredPackageServiceProjectionAttempts = 3
  * Must stay well below `packageServiceStateStaleMs` in entitlements so live
  * services are never dropped from the concurrency count.
  */
-const packageServiceStateHeartbeatMs = 60 * 60 * 1000
+export const packageServiceStateHeartbeatMs = 60 * 60 * 1000
+/**
+ * Incoming Durable Object alarm while a run is in-flight. Background
+ * `waitUntil` execution does not keep the isolate resident; without a frequent
+ * wake, Cloudflare evicts the object and orphans the sandbox (including any
+ * outbound WebSocket). Keep this well under a minute.
+ */
+export const packageServiceKeepaliveMs = 15_000
 
 export type PackageServiceBindingState = {
 	userId: string
@@ -53,9 +60,10 @@ type PackageServiceState = {
 	stopRequested: boolean
 	currentRunId: string | null
 	nextAlarmAt: string | null
-	nextAlarmSource: 'service' | 'auto-start' | 'heartbeat' | null
+	nextAlarmSource: 'service' | 'auto-start' | 'heartbeat' | 'keepalive' | null
 	lastStartedAt: string | null
 	lastStoppedAt: string | null
+	lastProjectedAt: string | null
 	status: 'idle' | 'running' | 'stopping' | 'stopped' | 'error'
 	lastError: string | null
 	lastResult: unknown
@@ -120,6 +128,7 @@ function createInitialPackageServiceState(): PackageServiceState {
 		nextAlarmSource: null,
 		lastStartedAt: null,
 		lastStoppedAt: null,
+		lastProjectedAt: null,
 		status: 'idle',
 		lastError: null,
 		lastResult: null,
@@ -415,17 +424,22 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			if (orphanedRunUsageEvent) {
 				this.ctx.waitUntil(recordUsage(this.env, orphanedRunUsageEvent))
 			}
-			if (
-				this.stateSnapshot.autoStart &&
-				!this.stateSnapshot.stopRequested &&
-				this.stateSnapshot.binding
-			) {
-				await this.scheduleAlarm({
-					runAt: buildPackageServiceRetryTime(
-						this.stateSnapshot.consecutiveFailureCount,
-					),
-					source: 'auto-start',
-				})
+			if (!this.stateSnapshot.stopRequested && this.stateSnapshot.binding) {
+				if (this.stateSnapshot.mode === 'persistent') {
+					// Persistent means "stay up until stopped". Eviction is a
+					// platform interrupt, not a user stop or a crash-loop.
+					await this.scheduleAlarm({
+						runAt: new Date(),
+						source: 'auto-start',
+					})
+				} else if (this.stateSnapshot.autoStart) {
+					await this.scheduleAlarm({
+						runAt: buildPackageServiceRetryTime(
+							this.stateSnapshot.consecutiveFailureCount,
+						),
+						source: 'auto-start',
+					})
+				}
 			}
 		} else if (this.stateSnapshot.binding) {
 			// Warm-start after upgrades that introduced package_service_states:
@@ -466,6 +480,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				startedAt,
 				updatedAt,
 			})
+			this.stateSnapshot.lastProjectedAt = updatedAt
 		} catch {
 			// Best-effort: D1 outages must not take down package services.
 		}
@@ -639,20 +654,28 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		this.schedulePackageServiceShadowDelete(binding)
 	}
 
-	private async ensureRunningHeartbeat() {
+	private shouldProjectRunningHeartbeat() {
+		const lastProjectedAtMs = Date.parse(
+			this.stateSnapshot.lastProjectedAt ?? '',
+		)
+		if (Number.isNaN(lastProjectedAtMs)) return true
+		return Date.now() - lastProjectedAtMs >= packageServiceStateHeartbeatMs
+	}
+
+	private async ensureRunningKeepalive() {
 		if (!this.stateSnapshot.currentRunId) return
 		if (this.stateSnapshot.nextAlarmAt) {
 			const nextAtMs = Date.parse(this.stateSnapshot.nextAlarmAt)
 			if (
 				!Number.isNaN(nextAtMs) &&
-				nextAtMs - Date.now() <= packageServiceStateHeartbeatMs
+				nextAtMs - Date.now() <= packageServiceKeepaliveMs
 			) {
 				return
 			}
 		}
 		await this.scheduleAlarm({
-			runAt: new Date(Date.now() + packageServiceStateHeartbeatMs),
-			source: 'heartbeat',
+			runAt: new Date(Date.now() + packageServiceKeepaliveMs),
+			source: 'keepalive',
 		})
 	}
 
@@ -694,7 +717,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 
 	private async scheduleAlarm(input: {
 		runAt: Date | string
-		source?: 'service' | 'auto-start' | 'heartbeat'
+		source?: 'service' | 'auto-start' | 'heartbeat' | 'keepalive'
 	}) {
 		const runAtDate =
 			typeof input.runAt === 'string' ? new Date(input.runAt) : input.runAt
@@ -798,7 +821,8 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			(this.stateSnapshot.mode !== 'persistent' ||
 				input.nextStatus === 'error') &&
 			(!this.stateSnapshot.nextAlarmAt ||
-				this.stateSnapshot.nextAlarmSource === 'heartbeat')
+				this.stateSnapshot.nextAlarmSource === 'heartbeat' ||
+				this.stateSnapshot.nextAlarmSource === 'keepalive')
 		) {
 			await this.scheduleAlarm({
 				runAt: buildPackageServiceRetryTime(
@@ -1078,7 +1102,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			const runId = pendingAtEntry.runId
 			await pendingAtEntry.promise
 			this.assertPendingStartIsCurrent(runId)
-			await this.ensureRunningHeartbeat()
+			await this.ensureRunningKeepalive()
 			this.assertPendingStartIsCurrent(runId)
 			return Response.json({
 				ok: true,
@@ -1099,7 +1123,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				await pending.promise
 			}
 			this.assertPendingStartIsCurrent(runId)
-			await this.ensureRunningHeartbeat()
+			await this.ensureRunningKeepalive()
 			this.assertPendingStartIsCurrent(runId)
 			return Response.json({
 				ok: true,
@@ -1122,7 +1146,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		try {
 			await pending.promise
 			this.assertPendingStartIsCurrent(runId)
-			await this.ensureRunningHeartbeat()
+			await this.ensureRunningKeepalive()
 			this.assertPendingStartIsCurrent(runId)
 		} catch (error) {
 			await this.failPendingStart(runId, error)
@@ -1279,11 +1303,13 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		this.stateSnapshot.nextAlarmSource = null
 		await this.persistState()
 		if (this.stateSnapshot.currentRunId) {
-			await this.projectServiceStateToD1()
-			await this.ensureRunningHeartbeat()
+			if (this.shouldProjectRunningHeartbeat()) {
+				await this.projectServiceStateToD1()
+			}
+			await this.ensureRunningKeepalive()
 			return
 		}
-		if (alarmSource === 'heartbeat') {
+		if (alarmSource === 'heartbeat' || alarmSource === 'keepalive') {
 			return
 		}
 		try {
@@ -1299,7 +1325,9 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			await this.persistState()
 			if (
 				!this.stateSnapshot.stopRequested &&
-				(alarmSource === 'service' || this.stateSnapshot.autoStart)
+				(alarmSource === 'service' ||
+					alarmSource === 'auto-start' ||
+					this.stateSnapshot.autoStart)
 			) {
 				const startedAt = new Date().toISOString()
 				const runId = crypto.randomUUID()
@@ -1312,7 +1340,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				const pending = this.getOrCreateRequiredStartProjection(runId)
 				await pending.promise
 				this.assertPendingStartIsCurrent(runId)
-				await this.ensureRunningHeartbeat()
+				await this.ensureRunningKeepalive()
 				this.assertPendingStartIsCurrent(runId)
 				if (this.pendingStartProjection === pending) {
 					this.pendingStartProjection = null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make package services actually usable for daemon-like outbound sockets (Discord Gateway) so the Fly proxy is not required.

Kent's `@kentcdodds/discord-gateway-cf-experiment` already proved a Discord Gateway WebSocket can identify, heartbeat, and receive `MESSAGE_CREATE` inside a persistent package service. It then died after ~4.5 minutes with no error: the sandbox run lived in `waitUntil`, the host only woke the Durable Object hourly, and eviction silently marked the service `stopped`. `autoStart` was false, so nothing came back.

## Summary

- Wake a running service isolate every 15 seconds (`keepalive` alarm). D1 / UserMeter liveness projection stays hourly.
- `mode: 'persistent'` now means stay up until stopped: eviction immediately reschedules the same service, even when `autoStart` is false. Bounded + `autoStart` still uses crash-loop backoff.
- Document the Discord-shaped contract: persist resume cursors in `packageStorage()`, use `mode: 'persistent'`.

## Testing

- `npx vitest run packages/worker/src/package-runtime/package-service.node.test.ts --project node-unit` — 20 passed, including new cases for persistent eviction resume and keepalive-does-not-start-a-second-run.
- Did not start the production Discord experiment from this agent: a second Gateway identify on the same bot token would fight the live Fly proxy.

After this deploys, start `@kentcdodds/discord-gateway-cf-experiment` `gateway` again and watch `./status` for heartbeats past the old ~4 minute cliff. Persist `session_id` / sequence is already in that package; this host change is what was missing.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends package-services</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `295abe6a` · **Head:** `25ff17a4`

**Classification:** extends — persistent service lifecycle now resumes after Durable Object eviction and keeps the isolate awake with a short incoming alarm.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-services` | assistant | extends — 15s keepalive while running; persistent eviction immediately reschedules |
| `package-runtime` | runtime | composes — unit coverage for the new lifecycle |

### Change flow

A running package service no longer depends on hourly heartbeats or `autoStart` to survive isolate eviction.

```mermaid
sequenceDiagram
	actor User as user
	participant packageServices as package-services
	participant packageRuntime as package-runtime
	User->>packageServices: service_start (persistent)
	packageServices->>packageRuntime: waitUntil(sandbox run)
	packageServices->>packageServices: schedule keepalive alarm (15s)
	Note over packageServices: D1/UserMeter projection still hourly
	alt isolate stays resident
		packageServices->>packageRuntime: keepalive wake, no second run
	else Durable Object evicted
		packageServices->>packageServices: restore orphans in-flight run
		packageServices->>packageRuntime: immediate auto-start (no backoff)
	end
```

### Invariants

Per-user isolation is unchanged: service Durable Object ids stay user-scoped. Persistent resume is same-user, same package, same service name.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d38711-e9f1-4574-b52e-335fa9e48713?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d38711-e9f1-4574-b52e-335fa9e48713&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how persistent and bounded package services behave during disconnects, eviction, and restarts.
  * Added guidance for outbound WebSocket reconnection and resumable state.
  * Documented keepalive behavior and continuation from saved resume cursors.

* **Bug Fixes**
  * Improved reliability when persistent services are evicted or disconnected.
  * Prevented duplicate active runs and maintained service liveness with frequent keepalive scheduling.
  * Improved service resumption and alarm handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->