### PR TITLE
Make MCP search discovery progressively disclosed

### DIFF
--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -663,6 +663,23 @@ invariants:
     docs:
       - docs/contributing/project-intent.md
 
+  - id: discovery-progressive-disclosure
+    summary: Default discovery is a bounded index; expensive detail is explicit.
+    docs:
+      - docs/use/search.md
+      - docs/contributing/decisions/0022-progressive-search-disclosure.md
+
+  - id: package-over-synthesized-provider
+    summary: Rank wrapping packages before matching synthesized provider ops.
+    docs:
+      - docs/use/search.md
+      - docs/contributing/decisions/0023-packages-outrank-synthesized-providers.md
+
+  - id: bounded-always-on-mcp-text
+    summary: Keep always-on MCP instructions bounded to durable essentials.
+    docs:
+      - docs/contributing/project-intent.md
+
   - id: community-listing-isolation
     summary:
       Public community reads are deliberate; forks stay inert until publish.

--- a/docs/contributing/decisions/0022-progressive-search-disclosure.md
+++ b/docs/contributing/decisions/0022-progressive-search-disclosure.md
@@ -24,9 +24,9 @@ count rather than expanding up to 20 siblings.
 Empty discovery, over-broad search, and `meta_list_capabilities()` without a
 domain return a domain index: id, capability count, one-line description, and
 two or three samples. `meta_list_capabilities({ domain })` still lists that
-domain. Task-specific zero-hit results may suggest the closest domains.
-Repeated detail calls with the same `conversationId` may omit boilerplate
-already taught earlier in the conversation.
+domain. Task-specific zero-hit results may suggest the closest domains. Repeated
+detail calls with the same `conversationId` may omit boilerplate already taught
+earlier in the conversation.
 
 ## Consequences
 

--- a/docs/contributing/decisions/0022-progressive-search-disclosure.md
+++ b/docs/contributing/decisions/0022-progressive-search-disclosure.md
@@ -1,0 +1,36 @@
+# 0022: Progressive search disclosure
+
+- **Status:** accepted
+- **Date:** 2026-08-19
+
+## Context
+
+Search discovery must teach every user what exists without spending most of the
+context window on registry internals. Package and synthesized-provider detail
+previously expanded types, URLs, README content, and sibling operations before
+the caller knew which part it needed. Empty or broad discovery could also push
+callers toward an unbounded registry listing or force them to guess a domain.
+
+## Decision
+
+Search uses progressive disclosure. A package entity defaults to an index:
+summary, an export table of subpath plus one-line purpose, job and retriever
+names, and the README `Intent` section. Structured content has the same slim
+shape. Types, token URLs, and the full README require a follow-up. OpenAPI
+capability titles use `METHOD path`; the stable operation slug remains in the
+entity reference. Synthesized capability detail reports a related-operation
+count rather than expanding up to 20 siblings.
+
+Empty discovery, over-broad search, and `meta_list_capabilities()` without a
+domain return a domain index: id, capability count, one-line description, and
+two or three samples. `meta_list_capabilities({ domain })` still lists that
+domain. Task-specific zero-hit results may suggest the closest domains.
+Repeated detail calls with the same `conversationId` may omit boilerplate
+already taught earlier in the conversation.
+
+## Consequences
+
+Discovery stays bounded and callers use explicit follow-ups for expensive
+detail. Clients must treat entity references, not display titles, as stable
+identifiers. We reject returning the full SDK for every entity, an unbounded
+`meta_list_capabilities`, and guessing a domain on the caller's behalf.

--- a/docs/contributing/decisions/0023-packages-outrank-synthesized-providers.md
+++ b/docs/contributing/decisions/0023-packages-outrank-synthesized-providers.md
@@ -7,13 +7,13 @@
 
 OpenAPI bindings and connected MCP servers can synthesize dozens of operations
 for one provider. A provider-name query therefore favored repetitive raw
-operations even when the user had saved a package that wrapped the provider
-with safer workflows, storage, jobs, or an app.
+operations even when the user had saved a package that wrapped the provider with
+safer workflows, storage, jobs, or an app.
 
 ## Decision
 
-When a saved package's Kody id, package name, tags, or README identity matches an
-OpenAPI or MCP provider, ranked discovery places the package and a compact
+When a saved package's Kody id, package name, tags, or README identity matches
+an OpenAPI or MCP provider, ranked discovery places the package and a compact
 provider card above raw operations. The provider card reports the operation
 count, runtime call pattern, and matching wrapping package. General
 provider-name search does not expand dozens of operations; exact tool or
@@ -21,9 +21,9 @@ operation names and `search({ domain })` continue to resolve operations.
 
 ## Consequences
 
-Users discover maintained, higher-level behavior before low-level bindings
-while retaining direct access to every generated operation. Provider/package
-matching remains explainable identity matching and may need additional aliases
-as naming conventions evolve. We reject automatically deleting provider
-bindings and a per-user ranking toggle because both would make capability
-availability or discovery semantics inconsistent.
+Users discover maintained, higher-level behavior before low-level bindings while
+retaining direct access to every generated operation. Provider/package matching
+remains explainable identity matching and may need additional aliases as naming
+conventions evolve. We reject automatically deleting provider bindings and a
+per-user ranking toggle because both would make capability availability or
+discovery semantics inconsistent.

--- a/docs/contributing/decisions/0023-packages-outrank-synthesized-providers.md
+++ b/docs/contributing/decisions/0023-packages-outrank-synthesized-providers.md
@@ -1,0 +1,29 @@
+# 0023: Packages outrank synthesized providers
+
+- **Status:** accepted
+- **Date:** 2026-08-19
+
+## Context
+
+OpenAPI bindings and connected MCP servers can synthesize dozens of operations
+for one provider. A provider-name query therefore favored repetitive raw
+operations even when the user had saved a package that wrapped the provider
+with safer workflows, storage, jobs, or an app.
+
+## Decision
+
+When a saved package's Kody id, package name, tags, or README identity matches an
+OpenAPI or MCP provider, ranked discovery places the package and a compact
+provider card above raw operations. The provider card reports the operation
+count, runtime call pattern, and matching wrapping package. General
+provider-name search does not expand dozens of operations; exact tool or
+operation names and `search({ domain })` continue to resolve operations.
+
+## Consequences
+
+Users discover maintained, higher-level behavior before low-level bindings
+while retaining direct access to every generated operation. Provider/package
+matching remains explainable identity matching and may need additional aliases
+as naming conventions evolve. We reject automatically deleting provider
+bindings and a per-user ranking toggle because both would make capability
+availability or discovery semantics inconsistent.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -43,3 +43,5 @@ behavior (see [documentation principles](../documentation.md)).
 - [0021 — Publish-gated packages; no in-process composition runtime](./0021-publish-gated-package-composition.md)
 - [0022 — Retire the values primitive](./0022-retire-values-primitive.md)
   ([runbook](../architecture/values-retirement-runbook.md))
+- [0022 — Progressive search disclosure](./0022-progressive-search-disclosure.md)
+- [0023 — Packages outrank synthesized providers](./0023-packages-outrank-synthesized-providers.md)

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -30,14 +30,23 @@ whitespace-collapsed input type, truncated when long) so you can often call from
 
 ### Broad queries return domain overviews
 
-When a query is broad or exploratory rather than task-specific — "what can you
-do with email", "what can kody do", or a bare domain name like `jobs` — search
-returns a compact **domain overview** instead of ranked individual hits: one
-line per matched domain with its id, description, capability count, and a few
-sample capability names. This keeps browse-style discovery cheap; drill in with
-a scoped follow-up (`search({ query, domain })`) or a domain listing
-(`search({ domain })`). Task-specific queries ("send an email to Kent") keep
-returning ranked capability, package, value, integration, and secret hits.
+An empty search or a broad, exploratory query — "what can you do with email",
+"what can kody do", or a bare built-in domain name like `jobs` — returns a
+compact **domain index** instead of ranked individual hits. Each row has the
+domain id, one-line description, capability count, and two or three sample
+names. Drill in with `search({ query, domain })` or `search({ domain })`.
+Task-specific queries ("send an email to Kent") keep returning ranked results.
+`meta_list_capabilities()` returns the same domain index;
+`meta_list_capabilities({ domain })` lists that domain.
+
+### Packages before synthesized providers
+
+When a saved package's id, name, tags, or README matches an OpenAPI or connected
+MCP provider, the package ranks before the provider's raw operations. General
+provider discovery returns one provider card with its operation count, runtime
+call pattern, and matching wrapper package instead of flooding the result with
+operations. Search an exact operation/tool name or pass the provider's `domain`
+to resolve raw operations directly.
 
 ### Domain scoping
 
@@ -57,7 +66,9 @@ available domains. The `search` meta capability (usable inside **execute**)
 accepts the same `domain` argument alongside `query`.
 
 An entire saved-package UUID or `kody.id` is treated as an exact package
-identity when it resolves for the signed-in user. Kody also recognizes
+identity when it resolves for the signed-in user, except when that identity also
+names a synthesized provider; that query participates in ranking so the package
+and provider card can appear together. Kody also recognizes
 current-origin `/account/packages/:packageId` URLs, owner-matching
 `/@username/packages/:kodyId` URLs, and per-user package-app subdomain URLs
 (`https://{username}.<package-app host>/packages/:kodyId`) — so a URL copied
@@ -66,9 +77,11 @@ semantic capability results. Hidden exact query matches still require
 `includeHiddenPackages: true`; exact `entity` lookup by UUID or `kody.id`
 ignores the hidden discovery preference.
 
-When a tool call also includes **`memoryContext`**, Kody may include relevant
-long-term memory metadata in structured content, but broad query markdown stays
-focused on the ranked matches.
+Ranked `search({ query })` calls may include relevant long-term memory metadata
+in structured content. Entity lookups, domain listings, empty/broad discovery,
+and `search({ domain })` do not attach memories. **execute** retrieves memories
+only when its caller opts in with **`memoryContext`**. Archived or very weak
+memory matches are not surfaced automatically.
 
 Search responses also return top-level **`timing`** metadata with
 **`startedAt`**, **`endedAt`**, and **`durationMs`** so hosts can reason about
@@ -78,13 +91,14 @@ Optional **`limit`** caps how many ranked hits return. Optional
 **`maxResponseSize`** trims low-ranked matches against the compact list when the
 response must stay small.
 
-## Entity detail
+## Entity indexes and detail
 
-To get **full markdown detail for one hit**, call **search** again with
+To inspect one hit, call **search** again with
 **`entity`** set to `"{id}:{type}"` where **`type`** is `capability`, `value`,
 `integration`, `package`, or `secret`. Capability entities additionally include
 a ready-to-run **execute** snippet plus `inputTypeDefinition` /
-`outputTypeDefinition`.
+`outputTypeDefinition`. OpenAPI capability titles use `METHOD path`; the
+operation slug stays in the entity ref.
 
 Pass an **array of 1–10 entity refs** when you need several related details at
 once (for example a create/poll OpenAPI pair). Each ref resolves independently:
@@ -109,20 +123,20 @@ Top-level ranked result cards include an explicit entity ref for each hit when
 applicable, using that same `"{id}:{type}"` format, so you can immediately copy
 the ref into a follow-up `entity` lookup when needed.
 
-For synthesized provider capabilities (OpenAPI bindings, connected MCP servers,
-), capability detail also lists **related operations from the same provider** so
-create/poll pairs and sibling tools are visible without a second lookup.
-Built-in capabilities skip that section to keep common lookups lean.
+For synthesized provider capabilities (OpenAPI bindings and connected MCP
+servers), capability detail reports the **related operation count**. Use
+`search({ domain })` to list siblings.
 
 Integration entity detail may include a small set of **related package
 suggestions** for the same provider (the user's packages first; otherwise
 trusted-first community listings, capped). Ranked query results stay lean and do
 not run community lookup or expand those suggestions.
 
-Package detail includes a short **Maintain** pointer: the git lane
-(`package_get_git_remote` → clone/edit/push → `package_publish_external_push`)
-and the tool-only alternative (`package_save` / repo sessions, with
-`coding_guide_get({ guide: "package_authoring" })` for the full guide).
+Package entity detail is a slim index: summary, export subpaths with one-line
+purposes, job and retriever names, and the README `Intent` section. Structured
+content mirrors that index and does not contain a full export tree. Follow the
+returned `package_get` / `package_authoring` pointer when you need types,
+external token URLs, the full README, source, or maintenance steps.
 
 Capability detail shows the exact runtime pattern for **execute**:
 
@@ -144,11 +158,11 @@ no required fields.
 
 ## When results look thin
 
-If ranked search misses what you need, **rephrase the query** or use
-**`meta_list_capabilities`** to read the live capability registry (including
-dynamic entries from MCP servers). **`entity`** does not help when a **`query`**
-returned no matches — **`entity`** looks up a known id, not a fix for an empty
-ranked list.
+If ranked search misses what you need, **rephrase the query** or call
+**`meta_list_capabilities()`** for the domain index, then
+**`meta_list_capabilities({ domain })`** for one live domain (including dynamic
+MCP/OpenAPI entries). **`entity`** looks up a known id; it does not improve an
+empty ranked list.
 
 ## Authentication
 
@@ -156,8 +170,8 @@ Saved **packages** require a signed-in MCP user. Capabilities and built-in
 behavior work without user-scoped data.
 
 Package and integration query hits stay summary-only. Exact package detail
-(`entity: "my-package:package"`) includes package app, export, job, retriever,
-and README metadata. Exact integration detail (`entity: "github:integration"`)
+(`entity: "my-package:package"`) returns the package index described above.
+Exact integration detail (`entity: "github:integration"`)
 includes operational details such as token URL, API base URL, client id,
 required hosts, and related secret names.
 

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -68,8 +68,8 @@ accepts the same `domain` argument alongside `query`.
 An entire saved-package UUID or `kody.id` is treated as an exact package
 identity when it resolves for the signed-in user, except when that identity also
 names a synthesized provider; that query participates in ranking so the package
-and provider card can appear together. Kody also recognizes
-current-origin `/account/packages/:packageId` URLs, owner-matching
+and provider card can appear together. Kody also recognizes current-origin
+`/account/packages/:packageId` URLs, owner-matching
 `/@username/packages/:kodyId` URLs, and per-user package-app subdomain URLs
 (`https://{username}.<package-app host>/packages/:kodyId`) — so a URL copied
 from an open app resolves too. Exact package identities never compete with
@@ -93,12 +93,11 @@ response must stay small.
 
 ## Entity indexes and detail
 
-To inspect one hit, call **search** again with
-**`entity`** set to `"{id}:{type}"` where **`type`** is `capability`, `value`,
-`integration`, `package`, or `secret`. Capability entities additionally include
-a ready-to-run **execute** snippet plus `inputTypeDefinition` /
-`outputTypeDefinition`. OpenAPI capability titles use `METHOD path`; the
-operation slug stays in the entity ref.
+To inspect one hit, call **search** again with **`entity`** set to
+`"{id}:{type}"` where **`type`** is `capability`, `value`, `integration`,
+`package`, or `secret`. Capability entities additionally include a ready-to-run
+**execute** snippet plus `inputTypeDefinition` / `outputTypeDefinition`. OpenAPI
+capability titles use `METHOD path`; the operation slug stays in the entity ref.
 
 Pass an **array of 1–10 entity refs** when you need several related details at
 once (for example a create/poll OpenAPI pair). Each ref resolves independently:
@@ -171,9 +170,9 @@ behavior work without user-scoped data.
 
 Package and integration query hits stay summary-only. Exact package detail
 (`entity: "my-package:package"`) returns the package index described above.
-Exact integration detail (`entity: "github:integration"`)
-includes operational details such as token URL, API base URL, client id,
-required hosts, and related secret names.
+Exact integration detail (`entity: "github:integration"`) includes operational
+details such as token URL, API base URL, client id, required hosts, and related
+secret names.
 
 Long-term memory retrieval also requires a signed-in MCP user.
 

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.node.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { metaListCapabilitiesCapability } from './meta-list-capabilities.ts'
 
-test('meta_list_capabilities lists builtin capabilities and filters by domain', async () => {
+test('meta_list_capabilities indexes domains and lists one requested domain', async () => {
 	const allResult = await metaListCapabilitiesCapability.handler(
 		{
 			detail: true,
@@ -20,12 +20,15 @@ test('meta_list_capabilities lists builtin capabilities and filters by domain', 
 		},
 	)
 
-	expect(allResult.capabilities.length).toBeGreaterThan(0)
-	expect(
-		allResult.capabilities.some(
-			(capability) => capability.name === 'meta_list_capabilities',
-		),
-	).toBe(true)
+	expect(allResult.capabilities).toBeUndefined()
+	expect(allResult.domains?.length).toBeGreaterThan(0)
+	expect(allResult.domains).toContainEqual(
+		expect.objectContaining({
+			id: 'meta',
+			capabilityCount: expect.any(Number),
+			sampleCapabilities: expect.any(Array),
+		}),
+	)
 
 	const metaOnly = await metaListCapabilitiesCapability.handler(
 		{
@@ -41,10 +44,10 @@ test('meta_list_capabilities lists builtin capabilities and filters by domain', 
 
 	expect(metaOnly.total).toBeGreaterThan(0)
 	expect(
-		metaOnly.capabilities.every((capability) => capability.domain === 'meta'),
+		metaOnly.capabilities?.every((capability) => capability.domain === 'meta'),
 	).toBe(true)
 	expect(
-		metaOnly.capabilities.some(
+		metaOnly.capabilities?.some(
 			(capability) => capability.name === 'meta_list_capabilities',
 		),
 	).toBe(true)
@@ -63,7 +66,7 @@ test('meta_list_capabilities lists builtin capabilities and filters by domain', 
 
 	expect(packagesOnly.total).toBeGreaterThan(0)
 	expect(
-		packagesOnly.capabilities.every(
+		packagesOnly.capabilities?.every(
 			(capability) => capability.domain === 'packages',
 		),
 	).toBe(true)
@@ -80,7 +83,7 @@ test('meta_list_capabilities lists builtin capabilities and filters by domain', 
 			}),
 		},
 	)
-	const listSessionsCapability = repoOnly.capabilities.find(
+	const listSessionsCapability = repoOnly.capabilities?.find(
 		(capability) => capability.name === 'repo_list_sessions',
 	)
 	expect(listSessionsCapability).toMatchObject({

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { buildDomainIndexMatches } from '#mcp/tools/search-domain-overview.ts'
 
 const capabilitySummarySchema = z.object({
 	name: z.string(),
@@ -44,9 +45,19 @@ const capabilityDetailSchema = capabilitySummarySchema.extend({
 
 const outputSchema = z.object({
 	total: z.number().int().nonnegative(),
-	capabilities: z.array(
-		z.union([capabilityDetailSchema, capabilitySummarySchema]),
-	),
+	domains: z
+		.array(
+			z.object({
+				id: z.string(),
+				description: z.string(),
+				capabilityCount: z.number().int().nonnegative(),
+				sampleCapabilities: z.array(z.string()),
+			}),
+		)
+		.optional(),
+	capabilities: z
+		.array(z.union([capabilityDetailSchema, capabilitySummarySchema]))
+		.optional(),
 })
 
 type CapabilitySummary = z.infer<typeof capabilitySummarySchema>
@@ -75,7 +86,7 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 	{
 		name: 'meta_list_capabilities',
 		description:
-			'List the current runtime capability registry, including dynamic capabilities from connected MCP servers and OpenAPI bindings. Use this when search seems incomplete and you need exact capability names and TypeScript call shapes.',
+			'Browse the current runtime capability registry, including dynamic capabilities from connected MCP servers and OpenAPI bindings. Without a domain, returns a compact domain index. Pass a domain for exact capability names and optional TypeScript call shapes.',
 		keywords: [
 			'capabilities',
 			'list',
@@ -114,6 +125,26 @@ export const metaListCapabilitiesCapability = defineDomainCapability(
 				env: ctx.env,
 				callerContext: ctx.callerContext,
 			})
+			if (!args.domain) {
+				const domains = buildDomainIndexMatches({
+					capabilityDomains: registry.capabilityDomains ?? [],
+					capabilitySpecs: registry.capabilitySpecs,
+				}).map((domain) => {
+					if (domain.type !== 'domain') {
+						throw new Error('Domain index contained a non-domain match.')
+					}
+					return {
+						id: domain.name,
+						description: domain.description,
+						capabilityCount: domain.capabilityCount,
+						sampleCapabilities: domain.sampleCapabilities,
+					}
+				})
+				return {
+					total: domains.length,
+					domains,
+				}
+			}
 			const allCapabilities = Object.values(registry.capabilitySpecs)
 				.map((spec) =>
 					args.detail

--- a/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
+++ b/packages/worker/src/mcp/capabilities/meta/meta-list-capabilities.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
-import { buildDomainIndexMatches } from '#mcp/tools/search-domain-overview.ts'
+import { buildDomainIndexMatches } from '#mcp/tools/search-domain-index.ts'
 
 const capabilitySummarySchema = z.object({
 	name: z.string(),

--- a/packages/worker/src/mcp/capabilities/meta/search.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/meta/search.node.test.ts
@@ -2,6 +2,12 @@ import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
 	getCapabilityRegistryForContext: vi.fn(async () => ({
+		capabilityDomains: [
+			{
+				name: 'meta',
+				description: 'Search and registry metadata.',
+			},
+		],
 		capabilitySpecs: {
 			search_docs: {
 				name: 'search_docs',
@@ -237,7 +243,7 @@ test('meta search wires exact package identity, hidden gating, and natural-langu
 	)
 })
 
-test('meta search supports domain-only browsing and requires query or domain', async () => {
+test('meta search supports domain browsing and empty discovery', async () => {
 	const context = createContext({ userId: 'user-1', username: 'user' })
 
 	const browse = await searchCapability.handler(
@@ -252,7 +258,20 @@ test('meta search supports domain-only browsing and requires query or domain', a
 		}),
 	])
 
-	await expect(
-		searchCapability.handler({ conversationId: 'meta-missing-args' }, context),
-	).rejects.toThrow('Provide "query" or "domain".')
+	const memoryCallsBeforeEmpty =
+		mockModule.loadRelevantMemoriesForTool.mock.calls.length
+	const empty = await searchCapability.handler(
+		{ conversationId: 'meta-empty-index' },
+		context,
+	)
+	expect(empty.matches).toEqual([
+		expect.objectContaining({
+			type: 'domain',
+			id: 'meta',
+			capabilityCount: 1,
+		}),
+	])
+	expect(mockModule.loadRelevantMemoriesForTool).toHaveBeenCalledTimes(
+		memoryCallsBeforeEmpty,
+	)
 })

--- a/packages/worker/src/mcp/capabilities/meta/search.ts
+++ b/packages/worker/src/mcp/capabilities/meta/search.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { McpCallerError } from '#mcp/caller-error.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
 import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { type CapabilityContext } from '#mcp/capabilities/types.ts'
@@ -49,7 +48,7 @@ export const searchCapability = defineDomainCapability(
 	{
 		name: 'search',
 		description:
-			'Search Kody capabilities, saved packages, values, integrations, and secret references using natural language or exact user-scoped package identity. Pass "domain" to rank only one capability domain. Use this inside package and execute runtimes when reusable code needs the same discovery surface as the public MCP search tool.',
+			'Search Kody capabilities, saved packages, values, integrations, and secret references using natural language or exact user-scoped package identity. An empty call returns the domain index. Pass "domain" to rank or list one capability domain. Use this inside package and execute runtimes when reusable code needs the same discovery surface as the public MCP search tool.',
 		keywords: [
 			'search',
 			'discover',
@@ -107,9 +106,6 @@ export const searchCapability = defineDomainCapability(
 		) {
 			const query = args.query?.trim() ?? ''
 			const domainFilter = args.domain?.trim() || undefined
-			if (!query && !domainFilter) {
-				throw new McpCallerError('Provide "query" or "domain".')
-			}
 			const conversationId = resolveConversationId(args.conversationId)
 			const userId = ctx.callerContext.user?.userId ?? null
 			const includeHiddenPackages = !!args.includeHiddenPackages

--- a/packages/worker/src/mcp/tools/memory-tool-context.node.test.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.node.test.ts
@@ -1,13 +1,16 @@
 import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
-	surfaceRelevantMemories: vi.fn(),
+	searchMemoryRecords: vi.fn(),
+	acknowledgeSurfacedMemories: vi.fn(),
 	runPackageRetrievers: vi.fn(),
 }))
 
 vi.mock('#mcp/memory/service.ts', () => ({
-	surfaceRelevantMemories: (...args: Array<unknown>) =>
-		mockModule.surfaceRelevantMemories(...args),
+	searchMemoryRecords: (...args: Array<unknown>) =>
+		mockModule.searchMemoryRecords(...args),
+	acknowledgeSurfacedMemories: (...args: Array<unknown>) =>
+		mockModule.acknowledgeSurfacedMemories(...args),
 }))
 
 vi.mock('#worker/package-retrievers/service.ts', () => ({
@@ -20,13 +23,15 @@ const { formatSurfacedMemoriesMarkdown } =
 	await import('./memory-tool-context.ts')
 
 function setupMemoryContextMocks() {
-	mockModule.surfaceRelevantMemories.mockReset()
+	mockModule.searchMemoryRecords.mockReset()
+	mockModule.acknowledgeSurfacedMemories.mockReset()
 	mockModule.runPackageRetrievers.mockReset()
-	mockModule.surfaceRelevantMemories.mockResolvedValue({
-		memories: [],
+	mockModule.searchMemoryRecords.mockResolvedValue({
+		matches: [],
 		suppressedCount: 0,
-		retrievalQuery: 'sprinkler instructions',
+		query: 'sprinkler instructions',
 	})
+	mockModule.acknowledgeSurfacedMemories.mockResolvedValue(undefined)
 	mockModule.runPackageRetrievers.mockResolvedValue({
 		results: [
 			{
@@ -95,8 +100,8 @@ test('memory tool context surfaces retriever results, fails on retriever errors,
 	expect(retrieverOnlyContent?.text?.length).toBeGreaterThan(0)
 
 	setupMemoryContextMocks()
-	mockModule.surfaceRelevantMemories.mockResolvedValue({
-		memories: [
+	mockModule.searchMemoryRecords.mockResolvedValue({
+		matches: [
 			{
 				id: 'memory-1',
 				category: 'workflow',
@@ -106,11 +111,16 @@ test('memory tool context surfaces retriever results, fails on retriever errors,
 				details: '',
 				tags: ['sprinkler'],
 				sourceUris: [],
+				dedupeKey: null,
+				createdAt: '2026-04-28T00:00:00.000Z',
 				updatedAt: '2026-04-28T00:00:00.000Z',
+				lastAccessedAt: null,
+				deletedAt: null,
+				score: 0.03,
 			},
 		],
 		suppressedCount: 0,
-		retrievalQuery: 'sprinkler instructions',
+		query: 'sprinkler instructions',
 	})
 	mockModule.runPackageRetrievers.mockRejectedValue(
 		new Error('retriever unavailable'),
@@ -119,4 +129,69 @@ test('memory tool context surfaces retriever results, fails on retriever errors,
 	await expect(loadRelevantMemoriesForTool(request)).rejects.toThrow(
 		'retriever unavailable',
 	)
+})
+
+test('automatic memory context drops archived and low-score matches', async () => {
+	setupMemoryContextMocks()
+	const baseMemory = {
+		category: 'workflow',
+		subject: 'Search workflow',
+		summary: 'Use ranked search.',
+		details: '',
+		tags: ['search'],
+		sourceUris: [],
+		dedupeKey: null,
+		createdAt: '2026-04-28T00:00:00.000Z',
+		updatedAt: '2026-04-28T00:00:00.000Z',
+		lastAccessedAt: null,
+		deletedAt: null,
+	}
+	mockModule.searchMemoryRecords.mockResolvedValue({
+		matches: [
+			{
+				...baseMemory,
+				id: 'active-strong',
+				status: 'active',
+				score: 0.03,
+			},
+			{
+				...baseMemory,
+				id: 'active-noise',
+				status: 'active',
+				score: 0.0164,
+			},
+			{
+				...baseMemory,
+				id: 'archived-strong',
+				status: 'archived',
+				score: 0.04,
+			},
+		],
+		suppressedCount: 0,
+		query: 'ranked search',
+	})
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
+
+	const result = await loadRelevantMemoriesForTool({
+		env: { APP_DB: {} } as Env,
+		callerContext: {
+			baseUrl: 'https://heykody.dev',
+			user: {
+				userId: 'user-1',
+				email: 'user@example.com',
+				displayName: 'User',
+			},
+			storageContext: null,
+			repoContext: null,
+		},
+		conversationId: 'conversation-quality',
+		memoryContext: { query: 'ranked search' },
+		acknowledgeSurfaced: false,
+	})
+
+	expect(result?.memories.map((memory) => memory.id)).toEqual(['active-strong'])
+	expect(mockModule.acknowledgeSurfacedMemories).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/tools/memory-tool-context.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.ts
@@ -2,7 +2,7 @@ import { type ContentBlock } from '@modelcontextprotocol/sdk/types.js'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import {
 	acknowledgeSurfacedMemories,
-	surfaceRelevantMemories,
+	searchMemoryRecords,
 } from '#mcp/memory/service.ts'
 import { type MemoryRecord } from '#mcp/memory/types.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
@@ -27,6 +27,48 @@ export type MemoryToolSummary = {
 	retrieverWarnings: Array<string>
 	suppressedCount: number
 	retrievalQuery: string
+}
+
+/** Automatic context drops one-list RRF noise (~0.016 at k=60). */
+const automaticMemoryScoreFloor = 0.02
+
+async function loadAutomaticMemories(input: {
+	env: Pick<Env, 'APP_DB'> & Partial<Pick<Env, 'CAPABILITY_VECTOR_INDEX'>>
+	callerContext: McpCallerContext
+	userId: string
+	query: string
+	conversationId: string
+	limit?: number
+	acknowledgeSurfaced?: boolean
+}) {
+	const result = await searchMemoryRecords({
+		env: input.env,
+		userId: input.userId,
+		storageContext: {
+			sessionId: input.callerContext.storageContext?.sessionId ?? null,
+			appId: input.callerContext.storageContext?.appId ?? null,
+		},
+		query: input.query,
+		conversationId: input.conversationId,
+		limit: input.limit,
+	})
+	const memories = result.matches.filter(
+		(match) =>
+			match.status === 'active' && match.score >= automaticMemoryScoreFloor,
+	)
+	if (input.acknowledgeSurfaced !== false && memories.length > 0) {
+		await acknowledgeSurfacedMemories({
+			env: input.env,
+			userId: input.userId,
+			conversationId: input.conversationId,
+			memoryIds: memories.map((memory) => memory.id),
+		})
+	}
+	return {
+		memories,
+		suppressedCount: result.suppressedCount,
+		retrievalQuery: result.query,
+	}
 }
 
 async function runContextPackageRetrievers(input: {
@@ -74,13 +116,10 @@ export async function loadRelevantMemoriesForTool(input: {
 	const retrievalQuery = buildMemoryRetrievalQuery(input.memoryContext)
 	if (!retrievalQuery) return null
 	const [result, retrieverResult] = await Promise.all([
-		surfaceRelevantMemories({
+		loadAutomaticMemories({
 			env: input.env,
+			callerContext: input.callerContext,
 			userId,
-			storageContext: {
-				sessionId: input.callerContext.storageContext?.sessionId ?? null,
-				appId: input.callerContext.storageContext?.appId ?? null,
-			},
 			query: retrievalQuery,
 			conversationId: input.conversationId,
 			limit: input.limit,
@@ -141,13 +180,10 @@ export async function surfaceToolMemories(input: {
 	const retrievalQuery = input.retrievalQuery.trim()
 	if (!retrievalQuery) return null
 	const [result, retrieverResult] = await Promise.all([
-		surfaceRelevantMemories({
+		loadAutomaticMemories({
 			env: input.env,
+			callerContext: input.callerContext,
 			userId,
-			storageContext: {
-				sessionId: input.callerContext.storageContext?.sessionId ?? null,
-				appId: input.callerContext.storageContext?.appId ?? null,
-			},
 			query: retrievalQuery,
 			conversationId: input.conversationId,
 			limit: input.limit,

--- a/packages/worker/src/mcp/tools/search-core.ts
+++ b/packages/worker/src/mcp/tools/search-core.ts
@@ -11,7 +11,10 @@ import {
 	buildRecommendedNextStep,
 	buildSearchableEntityDescriptors,
 } from './search-descriptors.ts'
-import { buildDomainOverviewMatches } from './search-domain-overview.ts'
+import {
+	buildDomainIndexMatches,
+	buildDomainOverviewMatches,
+} from './search-domain-overview.ts'
 import { searchEntityPlugins } from './search-entity-registry.ts'
 import { toCapabilitySearchMatch } from './search-entity-plugins/capability.ts'
 import { hydrateTopPackageMatches } from './search-entity-plugins/package.ts'
@@ -22,6 +25,7 @@ import {
 	buildCandidateTelemetry,
 	rerankCandidates,
 } from './search-scoring.ts'
+import { collapseSynthesizedProviderMatches } from './search-provider-overview.ts'
 import { elapsedMs } from './search-timing.ts'
 import {
 	type OptionalSearchRowsResult,
@@ -211,14 +215,18 @@ export async function searchUnified(input: {
 			entities: [],
 		})
 		const queryUnderstandingMs = elapsedMs(queryUnderstandingStart)
+		const matches = buildDomainIndexMatches({
+			capabilityDomains: input.registry.capabilityDomains ?? [],
+			capabilitySpecs: input.registry.capabilitySpecs,
+		})
 		return {
-			matches: [],
+			matches,
 			offline,
 			intent: emptyIntent,
 			telemetry: buildCandidateTelemetry({
 				intent: emptyIntent,
 				candidates: [],
-				matches: [],
+				matches,
 			}),
 			phaseTimings: {
 				queryUnderstandingMs,
@@ -334,7 +342,13 @@ export async function searchUnified(input: {
 		intent,
 		limit,
 	})
-	const matches = reranked.map((candidate) => candidate.match)
+	const matches = domainFilter
+		? reranked.map((candidate) => candidate.match)
+		: collapseSynthesizedProviderMatches({
+				query,
+				candidates: reranked,
+				registry,
+			})
 	attachTopCapabilityCallShapes({
 		matches,
 		registry,

--- a/packages/worker/src/mcp/tools/search-detail.ts
+++ b/packages/worker/src/mcp/tools/search-detail.ts
@@ -21,7 +21,7 @@ import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
 
 import { collectIntegrationPackageSuggestions } from './integration-package-suggestions.ts'
 import { parseEntityRef } from './search-format.ts'
-import { collectRelatedCapabilityOperations } from './search-related-capabilities.ts'
+import { countRelatedCapabilityOperations } from './search-related-capabilities.ts'
 import { type SearchRowsAndRegistry } from './search-types.ts'
 
 export async function resolveEntityDetail(input: {
@@ -38,17 +38,19 @@ export async function resolveEntityDetail(input: {
 		if (!spec) {
 			throw new McpCallerError('Capability not found.')
 		}
-		const relatedOperations = collectRelatedCapabilityOperations({
+		const relatedOperationCount = countRelatedCapabilityOperations({
 			spec,
 			registry: input.searchRows.registry,
 		})
 		return {
 			type: 'capability' as const,
 			id: ref.id,
-			title: spec.name,
+			title: spec.openApi
+				? `${spec.openApi.method.toUpperCase()} ${spec.openApi.path}`
+				: spec.name,
 			description: spec.description,
 			spec,
-			...(relatedOperations.length > 0 ? { relatedOperations } : {}),
+			...(relatedOperationCount > 0 ? { relatedOperationCount } : {}),
 		}
 	}
 

--- a/packages/worker/src/mcp/tools/search-domain-index.ts
+++ b/packages/worker/src/mcp/tools/search-domain-index.ts
@@ -1,0 +1,41 @@
+import {
+	type CapabilityDomainMetadata,
+	type CapabilitySpec,
+} from '#mcp/capabilities/types.ts'
+
+import { type SearchMatch } from './search-format-types.ts'
+
+const sampleCapabilityCount = 3
+
+function buildDomainMatch(
+	domain: CapabilityDomainMetadata,
+	specs: ReadonlyArray<CapabilitySpec>,
+): SearchMatch {
+	return {
+		type: 'domain',
+		name: domain.name,
+		title: domain.name,
+		description: domain.description,
+		capabilityCount: specs.length,
+		sampleCapabilities: specs
+			.slice(0, sampleCapabilityCount)
+			.map((spec) => spec.name),
+	}
+}
+
+export function buildDomainIndexMatches(input: {
+	capabilityDomains: ReadonlyArray<CapabilityDomainMetadata>
+	capabilitySpecs: Record<string, CapabilitySpec>
+}): Array<SearchMatch> {
+	const specsByDomain = new Map<string, Array<CapabilitySpec>>()
+	for (const spec of Object.values(input.capabilitySpecs)) {
+		const group = specsByDomain.get(spec.domain) ?? []
+		group.push(spec)
+		specsByDomain.set(spec.domain, group)
+	}
+	return input.capabilityDomains
+		.filter((domain) => (specsByDomain.get(domain.name)?.length ?? 0) > 0)
+		.map((domain) =>
+			buildDomainMatch(domain, specsByDomain.get(domain.name) ?? []),
+		)
+}

--- a/packages/worker/src/mcp/tools/search-domain-overview.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-domain-overview.node.test.ts
@@ -53,8 +53,16 @@ test('domain overviews cover named, plural, exploratory, and non-collapse cases'
 			capabilitySpecs: registry.capabilitySpecs,
 		}),
 	).toEqual([
-		expect.objectContaining({ type: 'domain', name: 'email', capabilityCount: 4 }),
-		expect.objectContaining({ type: 'domain', name: 'jobs', capabilityCount: 1 }),
+		expect.objectContaining({
+			type: 'domain',
+			name: 'email',
+			capabilityCount: 4,
+		}),
+		expect.objectContaining({
+			type: 'domain',
+			name: 'jobs',
+			capabilityCount: 1,
+		}),
 	])
 	expect(overviewFor('what can you do with email')).toEqual([
 		{

--- a/packages/worker/src/mcp/tools/search-domain-overview.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-domain-overview.node.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'vitest'
 import { buildCapabilityRegistry } from '#mcp/capabilities/build-capability-registry.ts'
-import { buildDomainOverviewMatches } from './search-domain-overview.ts'
+import {
+	buildDomainIndexMatches,
+	buildDomainOverviewMatches,
+} from './search-domain-overview.ts'
 import { understandSearchQuery } from './understand-search-query.ts'
 
 function capability(name: string, domain: string, description: string) {
@@ -44,6 +47,15 @@ function overviewFor(query: string) {
 }
 
 test('domain overviews cover named, plural, exploratory, and non-collapse cases', () => {
+	expect(
+		buildDomainIndexMatches({
+			capabilityDomains: registry.capabilityDomains,
+			capabilitySpecs: registry.capabilitySpecs,
+		}),
+	).toEqual([
+		expect.objectContaining({ type: 'domain', name: 'email', capabilityCount: 4 }),
+		expect.objectContaining({ type: 'domain', name: 'jobs', capabilityCount: 1 }),
+	])
 	expect(overviewFor('what can you do with email')).toEqual([
 		{
 			type: 'domain',

--- a/packages/worker/src/mcp/tools/search-domain-overview.ts
+++ b/packages/worker/src/mcp/tools/search-domain-overview.ts
@@ -4,12 +4,11 @@ import {
 } from '#mcp/capabilities/types.ts'
 
 import { type SearchMatch } from './search-format-types.ts'
+import { buildDomainIndexMatches } from './search-domain-index.ts'
 import {
 	type SearchIntent,
 	extractSearchTokens,
 } from './understand-search-query.ts'
-
-const sampleCapabilityCount = 3
 
 /**
  * Generic discovery/browse words. A query qualifies for a domain overview only
@@ -85,39 +84,6 @@ function singularizeToken(token: string): string {
 	return token
 }
 
-function buildDomainMatch(
-	domain: CapabilityDomainMetadata,
-	specs: ReadonlyArray<CapabilitySpec>,
-): SearchMatch {
-	return {
-		type: 'domain',
-		name: domain.name,
-		title: domain.name,
-		description: domain.description,
-		capabilityCount: specs.length,
-		sampleCapabilities: specs
-			.slice(0, sampleCapabilityCount)
-			.map((spec) => spec.name),
-	}
-}
-
-export function buildDomainIndexMatches(input: {
-	capabilityDomains: ReadonlyArray<CapabilityDomainMetadata>
-	capabilitySpecs: Record<string, CapabilitySpec>
-}): Array<SearchMatch> {
-	const specsByDomain = new Map<string, Array<CapabilitySpec>>()
-	for (const spec of Object.values(input.capabilitySpecs)) {
-		const group = specsByDomain.get(spec.domain) ?? []
-		group.push(spec)
-		specsByDomain.set(spec.domain, group)
-	}
-	return input.capabilityDomains
-		.filter((domain) => (specsByDomain.get(domain.name)?.length ?? 0) > 0)
-		.map((domain) =>
-			buildDomainMatch(domain, specsByDomain.get(domain.name) ?? []),
-		)
-}
-
 /**
  * Broad/exploratory queries ("what can you do with email", "what can kody
  * do") return compact domain summaries instead of ranked individual hits, so
@@ -142,7 +108,9 @@ export function buildDomainOverviewMatches(input: {
 		specsByDomain.set(spec.domain, group)
 	}
 	const visibleDomains = input.capabilityDomains.filter((domain) =>
-		domainIndex.some((match) => match.type === 'domain' && match.name === domain.name),
+		domainIndex.some(
+			(match) => match.type === 'domain' && match.name === domain.name,
+		),
 	)
 	if (visibleDomains.length === 0) return null
 
@@ -190,7 +158,10 @@ export function buildDomainOverviewMatches(input: {
 		if (!hasExplorationToken) return null
 	}
 
-	return overviewDomains.map((domain) =>
-		buildDomainMatch(domain, specsByDomain.get(domain.name) ?? []),
-	)
+	return buildDomainIndexMatches({
+		capabilityDomains: overviewDomains,
+		capabilitySpecs: input.capabilitySpecs,
+	})
 }
+
+export { buildDomainIndexMatches }

--- a/packages/worker/src/mcp/tools/search-domain-overview.ts
+++ b/packages/worker/src/mcp/tools/search-domain-overview.ts
@@ -101,6 +101,23 @@ function buildDomainMatch(
 	}
 }
 
+export function buildDomainIndexMatches(input: {
+	capabilityDomains: ReadonlyArray<CapabilityDomainMetadata>
+	capabilitySpecs: Record<string, CapabilitySpec>
+}): Array<SearchMatch> {
+	const specsByDomain = new Map<string, Array<CapabilitySpec>>()
+	for (const spec of Object.values(input.capabilitySpecs)) {
+		const group = specsByDomain.get(spec.domain) ?? []
+		group.push(spec)
+		specsByDomain.set(spec.domain, group)
+	}
+	return input.capabilityDomains
+		.filter((domain) => (specsByDomain.get(domain.name)?.length ?? 0) > 0)
+		.map((domain) =>
+			buildDomainMatch(domain, specsByDomain.get(domain.name) ?? []),
+		)
+}
+
 /**
  * Broad/exploratory queries ("what can you do with email", "what can kody
  * do") return compact domain summaries instead of ranked individual hits, so
@@ -117,14 +134,15 @@ export function buildDomainOverviewMatches(input: {
 	if (meaningfulTokens.length === 0) return null
 	if (input.capabilityDomains.length === 0) return null
 
+	const domainIndex = buildDomainIndexMatches(input)
 	const specsByDomain = new Map<string, Array<CapabilitySpec>>()
 	for (const spec of Object.values(input.capabilitySpecs)) {
 		const group = specsByDomain.get(spec.domain) ?? []
 		group.push(spec)
 		specsByDomain.set(spec.domain, group)
 	}
-	const visibleDomains = input.capabilityDomains.filter(
-		(domain) => (specsByDomain.get(domain.name)?.length ?? 0) > 0,
+	const visibleDomains = input.capabilityDomains.filter((domain) =>
+		domainIndex.some((match) => match.type === 'domain' && match.name === domain.name),
 	)
 	if (visibleDomains.length === 0) return null
 
@@ -134,6 +152,14 @@ export function buildDomainOverviewMatches(input: {
 	const matchedDomains: Array<CapabilityDomainMetadata> = []
 	const domainMatchedTokens = new Set<string>()
 	for (const domain of visibleDomains) {
+		const synthesizedDomain = domain.name.includes(':')
+		if (
+			synthesizedDomain &&
+			input.intent.normalizedQuery !==
+				extractSearchTokens(domain.name).join(' ')
+		) {
+			continue
+		}
 		const nameConcepts = new Set(
 			extractSearchTokens(domain.name).map(singularizeToken),
 		)

--- a/packages/worker/src/mcp/tools/search-entity-plugin.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugin.ts
@@ -74,5 +74,6 @@ export type SearchEntityPlugin<Type extends SearchMatch['type']> = {
 	) => SlimSearchMatch
 	formatEntityDetail?: (
 		detail: Extract<SearchEntityDetail, { type: Type }>,
+		options?: { includeBoilerplate?: boolean },
 	) => SearchEntityDetailFormatResult
 }

--- a/packages/worker/src/mcp/tools/search-entity-plugins/capability.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/capability.ts
@@ -1,16 +1,12 @@
 import { searchCapabilities } from '#mcp/capabilities/capability-search.ts'
 import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
 
-import {
-	escapeMarkdownText,
-	formatMarkdownInlineCode,
-} from '../markdown-safety.ts'
+import { formatMarkdownInlineCode } from '../markdown-safety.ts'
 import {
 	buildCapabilityExecuteExample,
 	buildCapabilityUsage,
 	buildEntityRef,
 	formatList,
-	formatOneLineSentence,
 } from '../search-format-helpers.ts'
 import { type SearchEntityPlugin } from '../search-entity-plugin.ts'
 import { type SearchMatch } from '../search-format-types.ts'
@@ -65,6 +61,9 @@ export function toCapabilitySearchMatch(
 	return {
 		type: 'capability',
 		name: spec.name,
+		title: spec.openApi
+			? `${spec.openApi.method.toUpperCase()} ${spec.openApi.path}`
+			: spec.name,
 		description: spec.description,
 		domain: spec.domain,
 		source: spec.source,
@@ -158,7 +157,7 @@ export const capabilitySearchEntityPlugin = {
 			type: 'capability',
 			id: match.name,
 			entityRef: buildEntityRef(match.name, 'capability'),
-			title: match.name,
+			title: match.title ?? match.name,
 			description:
 				'description' in match && typeof match.description === 'string'
 					? match.description
@@ -176,10 +175,10 @@ export const capabilitySearchEntityPlugin = {
 				: {}),
 		}
 	},
-	formatEntityDetail(detail) {
-		const relatedOperations = detail.relatedOperations ?? []
+	formatEntityDetail(detail, options) {
+		const relatedOperationCount = detail.relatedOperationCount ?? 0
 		const lines = [
-			`# Capability — \`${detail.spec.name}\``,
+			`# Capability — \`${detail.title}\``,
 			'',
 			detail.spec.description,
 			'',
@@ -195,13 +194,21 @@ export const capabilitySearchEntityPlugin = {
 			'',
 			'## Execute from `execute`',
 			'',
-			'Built-in capabilities returned by `search` are available inside `execute` as methods on the imported `kody` object.',
-			'',
+			...(options?.includeBoilerplate ?? true
+				? [
+						'Capabilities returned by `search` are available inside `execute` on the imported `kody` object.',
+						'',
+					]
+				: []),
 			'```ts',
 			buildCapabilityExecuteExample(detail.spec),
 			'```',
-			'',
-			'Pass concrete arguments that satisfy the input type below; use `{}` when there are no required fields.',
+			...(options?.includeBoilerplate ?? true
+				? [
+						'',
+						'Pass concrete arguments that satisfy the input type below; use `{}` when there are no required fields.',
+					]
+				: []),
 			'',
 			'## Type definitions',
 			'',
@@ -212,17 +219,11 @@ export const capabilitySearchEntityPlugin = {
 				: []),
 			'```',
 		]
-		if (relatedOperations.length > 0) {
-			lines.push('', '## Related operations (same provider)', '')
-			for (const related of relatedOperations) {
-				const openApiSuffix =
-					related.method && related.path
-						? ` — ${formatMarkdownInlineCode(`${related.method.toUpperCase()} ${related.path}`)}`
-						: ''
-				lines.push(
-					`- ${formatMarkdownInlineCode(related.name)}${openApiSuffix} — ${escapeMarkdownText(formatOneLineSentence(related.description))} Entity: ${formatMarkdownInlineCode(related.entityRef)}`,
-				)
-			}
+		if (relatedOperationCount > 0) {
+			lines.push(
+				'',
+				`- Related operations from this provider: ${String(relatedOperationCount)}. Use ${formatMarkdownInlineCode(`search({ domain: ${JSON.stringify(detail.spec.domain)} })`)} to list them.`,
+			)
 		}
 		return {
 			markdown: lines.join('\n'),
@@ -246,7 +247,7 @@ export const capabilitySearchEntityPlugin = {
 				...(detail.spec.outputTypeDefinition
 					? { outputTypeDefinition: detail.spec.outputTypeDefinition }
 					: {}),
-				...(relatedOperations.length > 0 ? { relatedOperations } : {}),
+				...(relatedOperationCount > 0 ? { relatedOperationCount } : {}),
 			},
 		}
 	},

--- a/packages/worker/src/mcp/tools/search-entity-plugins/capability.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/capability.ts
@@ -194,7 +194,7 @@ export const capabilitySearchEntityPlugin = {
 			'',
 			'## Execute from `execute`',
 			'',
-			...(options?.includeBoilerplate ?? true
+			...((options?.includeBoilerplate ?? true)
 				? [
 						'Capabilities returned by `search` are available inside `execute` on the imported `kody` object.',
 						'',
@@ -203,7 +203,7 @@ export const capabilitySearchEntityPlugin = {
 			'```ts',
 			buildCapabilityExecuteExample(detail.spec),
 			'```',
-			...(options?.includeBoilerplate ?? true
+			...((options?.includeBoilerplate ?? true)
 				? [
 						'',
 						'Pass concrete arguments that satisfy the input type below; use `{}` when there are no required fields.',

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -528,7 +528,7 @@ export const packageSearchEntityPlugin = {
 		})
 		const maintain = buildPackageMaintainSnippets(detail.record.kodyId)
 		const rootImportUsage = buildPackageRootImportUsage(detail.record.name)
-		const followUp = `Use package_get({ kody_id: ${JSON.stringify(detail.record.kodyId)} }) for the full README and source, or coding_guide_get({ guide: "package_authoring" }) for types, external invocation, and maintenance workflows.`
+		const followUp = `Use package_get({ package_id: ${JSON.stringify(detail.record.id)} }) for the full README and source, or coding_guide_get({ guide: "package_authoring" }) for types, external invocation, and maintenance workflows.`
 		const lines = [
 			`# Package — \`${detail.record.kodyId}\``,
 			'',

--- a/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/package.ts
@@ -11,16 +11,14 @@ import {
 	sortIdsByScore,
 } from '#worker/vectorize/scoring.ts'
 import { userVectorNamespace } from '#worker/vectorize/vector-namespaces.ts'
-import { buildExternalPackageInvocationDescriptor } from '#worker/package-invocations/public-url.ts'
 import {
 	buildPackageSearchDocument,
 	buildPackageSearchProjection,
 	type PackageSearchProjection,
 } from '#worker/package-registry/manifest.ts'
 import { buildPackageImportSpecifier } from '#worker/package-registry/package-import-specifier.ts'
-import { buildPackageReadmeDetail } from '#worker/package-registry/package-readme.ts'
+import { buildPackageReadmeIntent } from '#worker/package-registry/package-readme.ts'
 import { savedPackageVectorId } from '#worker/package-registry/repo.ts'
-import { buildPackageTestHints } from '#worker/package-registry/package-test-hints.ts'
 
 import { maxFusedPackageCandidates } from '../search-constants.ts'
 import { type SearchEntityPlugin } from '../search-entity-plugin.ts'
@@ -34,8 +32,6 @@ import {
 	buildPackageHostedUrl,
 	buildPackageMaintainSnippets,
 	buildPackageRootImportUsage,
-	formatInlineTypeDefinition,
-	formatPackageSchedule,
 	getPrimaryPackageActionFunction,
 } from '../search-format-helpers.ts'
 import { type SearchMatch } from '../search-format-types.ts'
@@ -336,6 +332,12 @@ export const packageSearchEntityPlugin = {
 					type: 'package' as const,
 					id: entry.record.kodyId,
 					title: entry.record.name,
+					packageIdentityFields: [
+						entry.record.kodyId,
+						entry.record.name,
+						...entry.record.tags,
+						readmeSnippet,
+					],
 					searchFields: [
 						entry.record.kodyId,
 						entry.record.name,
@@ -499,172 +501,88 @@ export const packageSearchEntityPlugin = {
 			nextStep,
 		}
 	},
-	formatEntityDetail(detail) {
+	formatEntityDetail(detail, options) {
 		const exportProjection = buildPackageSearchProjection(
 			detail.manifest,
 			detail.files,
 		)
 		const exportDetails = exportProjection.exports.map((exportDetail) => ({
-			...exportDetail,
-			importSpecifier: buildPackageImportSpecifier(
-				detail.record.name,
-				exportDetail.subpath,
-			),
-			externalInvocation: detail.ownerUsername
-				? buildExternalPackageInvocationDescriptor({
-						baseUrl: detail.baseUrl,
-						ownerUsername: detail.ownerUsername,
-						kodyId: detail.record.kodyId,
-						exportName: exportDetail.subpath,
-					})
-				: null,
+			subpath: exportDetail.subpath,
+			description:
+				exportDetail.description ??
+				exportDetail.functions.find((fn) => fn.description)?.description ??
+				null,
 		}))
-		const jobs = Object.entries(detail.manifest.kody.jobs ?? {}).map(
-			([jobName, job]) => ({
-				name: jobName,
-				entry: job.entry,
-				scheduleSummary: formatPackageSchedule(job.schedule, job.timezone),
-				enabled: job.enabled ?? true,
-			}),
-		)
+		const jobs = Object.keys(detail.manifest.kody.jobs ?? {}).map((name) => ({
+			name,
+		}))
 		const retrievers = Object.entries(
 			detail.manifest.kody.retrievers ?? {},
 		).map(([key, retriever]) => ({
 			key,
-			exportName: retriever.export,
 			name: retriever.name,
-			description: retriever.description,
-			scopes: retriever.scopes,
-			timeoutMs: retriever.timeoutMs ?? null,
-			maxResults: retriever.maxResults ?? null,
 		}))
 		const appEntry = detail.manifest.kody.app?.entry ?? null
-		const readme = buildPackageReadmeDetail({
+		const readmeIntent = buildPackageReadmeIntent({
 			files: detail.files,
 		})
 		const maintain = buildPackageMaintainSnippets(detail.record.kodyId)
-		const testHints = buildPackageTestHints({
-			kodyId: detail.record.kodyId,
-			hasApp: Boolean(appEntry),
-			subscriptionTopics: exportProjection.subscriptions.map(
-				(subscription) => subscription.topic,
-			),
-		})
-		const invokeUsage = `packages.invoke({ kodyId: ${JSON.stringify(detail.record.kodyId)}, exportName, params })`
 		const rootImportUsage = buildPackageRootImportUsage(detail.record.name)
+		const followUp = `Use package_get({ kody_id: ${JSON.stringify(detail.record.kodyId)} }) for the full README and source, or coding_guide_get({ guide: "package_authoring" }) for types, external invocation, and maintenance workflows.`
 		const lines = [
 			`# Package — \`${detail.record.kodyId}\``,
 			'',
 			detail.description,
 			'',
-			'## Summary',
+			'## Index',
 			'',
 			`- Entity: \`${buildEntityRef(detail.record.kodyId, 'package')}\``,
-			`- Package id: \`${detail.record.id}\``,
 			`- Package name: \`${detail.record.name}\``,
-			`- Kody id: \`${detail.record.kodyId}\``,
 			`- Tags: ${detail.record.tags.length > 0 ? detail.record.tags.map((tag) => `\`${tag}\``).join(', ') : 'none'}`,
 			`- Has app: ${detail.record.hasApp ? 'yes' : 'no'}`,
 			`- Hidden: ${detail.record.hidden ? 'yes' : 'no'}`,
 			...(detail.hostedUrl ? [`- Hosted URL: \`${detail.hostedUrl}\``] : []),
-			'',
-			'## Maintain',
-			'',
-			`- Git lane: \`${maintain.gitLane}\` → clone → edit → push → \`${maintain.publish}\``,
-			'- Tool-only: `package_save` / repo sessions; full guide: `coding_guide_get({ guide: "package_authoring" })`',
-			...(testHints
-				? [
-						'',
-						'## Test',
-						'',
-						...(testHints.app ? [`- App probe: \`${testHints.app}\``] : []),
-						...(testHints.subscriptions ?? []).map(
-							(subscription) =>
-								`- Subscription \`${subscription.topic}\`: \`${subscription.snippet}\``,
-						),
-					]
-				: []),
-			'',
-			'## Import vs invoke',
-			'',
-			`- Default — package name known when the code is written: ${formatMarkdownInlineCode(rootImportUsage)}. Static \`kody:\` imports use the npm-scoped package name (${formatMarkdownInlineCode(detail.record.name)}); typed, publish-verified, zero per-call platform cost.`,
-			`- Dynamic — name is data, the call needs this package's own runtime (secret mounts, \`packageStorage()\`), or exactly-once: ${formatMarkdownInlineCode(invokeUsage)}. Always contract-checked; keyless is lean/ephemeral, pass \`idempotencyKey\` only for exactly-once. The \`kodyId\` is the bare Kody id (${formatMarkdownInlineCode(detail.record.kodyId)}), not the npm-scoped package name.`,
 		]
-		if (appEntry) {
-			lines.push(
-				'',
-				'## App',
-				'',
-				`- Entry: \`${appEntry}\``,
-				...(detail.hostedUrl ? [`- Open: \`${detail.hostedUrl}\``] : []),
-			)
-		}
 		if (exportDetails.length > 0) {
-			lines.push('', '## Exports', '')
+			lines.push('', '## Exports', '', '| Subpath | Purpose |', '| --- | --- |')
 			for (const exportDetail of exportDetails) {
 				lines.push(
-					`- \`${exportDetail.subpath}\` -> \`${exportDetail.importSpecifier}\`${exportDetail.runtimeTarget ? ` (runtime target: \`${exportDetail.runtimeTarget}\`)` : ''}${exportDetail.typesPath ? ` (types: \`${exportDetail.typesPath}\`)` : ''}`,
+					`| ${formatMarkdownInlineCode(exportDetail.subpath)} | ${escapeMarkdownText(exportDetail.description ?? 'Package export.')} |`,
 				)
-				if (exportDetail.externalInvocation) {
-					lines.push(
-						`  - External invocation: \`${exportDetail.externalInvocation.method} ${exportDetail.externalInvocation.url}\``,
-						`  - Route export name: \`${exportDetail.externalInvocation.routeExportName}\`; normalized export name for token scope checks: \`${exportDetail.externalInvocation.normalizedExportName}\``,
-						`  - Token setup URL: \`${exportDetail.externalInvocation.tokenSetupUrl}\` (setup only; not an invocation URL)`,
-						`  - Source: ${escapeMarkdownText(exportDetail.externalInvocation.sourceGuidance)}`,
-					)
-				}
-				for (const exportedFunction of exportDetail.functions) {
-					if (exportedFunction.description) {
-						lines.push(
-							`  - ${escapeMarkdownText(exportedFunction.description)}`,
-						)
-					}
-					if (exportedFunction.typeDefinition) {
-						lines.push(
-							`  - \`${formatInlineTypeDefinition(exportedFunction.typeDefinition)}\``,
-						)
-					}
-				}
-				if (exportDetail.referencedTypes.length > 0) {
-					lines.push('  - Referenced types:', '    ```ts')
-					exportDetail.referencedTypes.forEach((referencedType, index) => {
-						if (index > 0) lines.push('    ')
-						lines.push(
-							...referencedType.definition
-								.split('\n')
-								.map((line) => `    ${line}`),
-						)
-					})
-					lines.push('    ```')
-				}
 			}
 		}
 		if (jobs.length > 0) {
-			lines.push('', '## Jobs', '')
-			for (const job of jobs) {
-				lines.push(
-					`- \`${job.name}\` -> \`${job.entry}\` — ${job.scheduleSummary}${job.enabled ? '' : ' (disabled)'}`,
-				)
-			}
-		}
-		if (retrievers.length > 0) {
-			lines.push('', '## Retrievers', '')
-			for (const retriever of retrievers) {
-				lines.push(
-					`- ${formatMarkdownInlineCode(retriever.key)} -> ${formatMarkdownInlineCode(retriever.exportName)} — ${escapeMarkdownText(retriever.description)} (scopes: ${retriever.scopes.map((scope) => formatMarkdownInlineCode(scope)).join(', ')})`,
-				)
-			}
-		}
-		if (readme) {
 			lines.push(
 				'',
-				`## README (\`${readme.path}\`)`,
+				'## Jobs',
 				'',
-				readme.content,
-				...(readme.truncated
-					? ['', '> README content was truncated for this detail response.']
+				...jobs.map((job) => `- ${formatMarkdownInlineCode(job.name)}`),
+			)
+		}
+		if (retrievers.length > 0) {
+			lines.push(
+				'',
+				'## Retrievers',
+				'',
+				...retrievers.map(
+					(retriever) =>
+						`- ${formatMarkdownInlineCode(retriever.name)} (${formatMarkdownInlineCode(retriever.key)})`,
+				),
+			)
+		}
+		if (readmeIntent) {
+			lines.push(
+				'',
+				`## README Intent (${formatMarkdownInlineCode(readmeIntent.path)})`,
+				'',
+				readmeIntent.content,
+				...(readmeIntent.truncated
+					? ['', '> README Intent was truncated for this index.']
 					: []),
 			)
+		}
+		if (options?.includeBoilerplate ?? true) {
+			lines.push('', '## Follow up', '', followUp)
 		}
 		return {
 			markdown: lines.join('\n'),
@@ -686,11 +604,11 @@ export const packageSearchEntityPlugin = {
 				hostedUrl: detail.hostedUrl,
 				appEntry,
 				maintain,
-				...(testHints ? { test: testHints } : {}),
 				exports: exportDetails,
 				jobs,
 				retrievers,
-				readme,
+				readmeIntent,
+				followUp,
 			},
 		}
 	},

--- a/packages/worker/src/mcp/tools/search-entity-plugins/provider.ts
+++ b/packages/worker/src/mcp/tools/search-entity-plugins/provider.ts
@@ -1,0 +1,23 @@
+import { type SearchEntityPlugin } from '../search-entity-plugin.ts'
+
+/**
+ * Result-only summary for a synthesized MCP/OpenAPI provider. Provider cards
+ * keep general discovery bounded while exact operations remain entity-backed.
+ */
+export const providerSearchEntityPlugin = {
+	type: 'provider',
+	formatSlimMatch({ match }) {
+		return {
+			type: 'provider',
+			id: match.id,
+			title: match.title,
+			description: match.description,
+			domain: match.domain,
+			source: match.source,
+			capabilityCount: match.capabilityCount,
+			sampleCapabilities: match.sampleCapabilities,
+			usage: match.usage,
+			wrappingPackage: match.wrappingPackage,
+		}
+	},
+} satisfies SearchEntityPlugin<'provider'>

--- a/packages/worker/src/mcp/tools/search-entity-registry.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-entity-registry.node.test.ts
@@ -106,6 +106,7 @@ test('descriptor seam follows registry order and preserves value-backed affinity
 		'secret',
 		'retriever_result',
 		'domain',
+		'provider',
 	])
 
 	const descriptors = buildSearchableEntityDescriptors({

--- a/packages/worker/src/mcp/tools/search-entity-registry.ts
+++ b/packages/worker/src/mcp/tools/search-entity-registry.ts
@@ -2,6 +2,7 @@ import { capabilitySearchEntityPlugin } from './search-entity-plugins/capability
 import { domainSearchEntityPlugin } from './search-entity-plugins/domain.ts'
 import { integrationSearchEntityPlugin } from './search-entity-plugins/integration.ts'
 import { packageSearchEntityPlugin } from './search-entity-plugins/package.ts'
+import { providerSearchEntityPlugin } from './search-entity-plugins/provider.ts'
 import { retrieverResultSearchEntityPlugin } from './search-entity-plugins/retriever-result.ts'
 import { secretSearchEntityPlugin } from './search-entity-plugins/secret.ts'
 import { valueSearchEntityPlugin } from './search-entity-plugins/value.ts'
@@ -18,6 +19,7 @@ export const searchEntityPlugins = [
 	secretSearchEntityPlugin,
 	retrieverResultSearchEntityPlugin,
 	domainSearchEntityPlugin,
+	providerSearchEntityPlugin,
 ] as const
 
 type RegisteredSearchEntityPlugin = (typeof searchEntityPlugins)[number]

--- a/packages/worker/src/mcp/tools/search-execution.ts
+++ b/packages/worker/src/mcp/tools/search-execution.ts
@@ -84,7 +84,12 @@ async function executeSearchListWithinBudget(
 		ReturnType<typeof loadSearchRowsAndRegistry>
 	> | null = null
 	let identityMatchesProvider = false
-	if (identityResolution.recognized) {
+	if (
+		identityResolution.recognized &&
+		identityResolution.match &&
+		input.query.trim().toLowerCase() ===
+			identityResolution.match.kodyId.toLowerCase()
+	) {
 		preloadedSearchRows = await loadSearchRowsAndRegistry({
 			env: input.env,
 			callerContext: input.callerContext,

--- a/packages/worker/src/mcp/tools/search-execution.ts
+++ b/packages/worker/src/mcp/tools/search-execution.ts
@@ -19,6 +19,7 @@ import {
 	type SearchUnifiedResult,
 } from './search-types.ts'
 import { type SearchToolArgs } from './search-tool-definition.ts'
+import { queryMatchesSynthesizedProvider } from './search-provider-overview.ts'
 
 export type SearchListExecutionResult = {
 	result: SearchUnifiedResult
@@ -64,15 +65,6 @@ async function executeSearchListWithinBudget(
 		username: input.callerContext.user?.username ?? null,
 		email: input.callerContext.user?.email ?? null,
 	})
-	const memoryLaunch = launchSearchMemoryEnrichment({
-		env: input.env,
-		callerContext: input.callerContext,
-		conversationId: input.conversationId,
-		query: input.memoryQuery,
-		memoryContext: input.memoryContext,
-	})
-	const memoryEnrichmentPromise = memoryLaunch?.promise ?? Promise.resolve(null)
-	const memoryEnrichmentLaunchedAtMs = memoryLaunch?.launchedAtMs
 	// Domain-scoped searches rank capabilities only; exact package identity
 	// resolution does not apply.
 	const identityResolution =
@@ -88,26 +80,53 @@ async function executeSearchListWithinBudget(
 					includeHiddenPackages: input.includeHiddenPackages,
 				})
 			: { recognized: false as const }
+	let preloadedSearchRows: Awaited<
+		ReturnType<typeof loadSearchRowsAndRegistry>
+	> | null = null
+	let identityMatchesProvider = false
+	if (identityResolution.recognized) {
+		preloadedSearchRows = await loadSearchRowsAndRegistry({
+			env: input.env,
+			callerContext: input.callerContext,
+			userId: input.userId,
+			includeHiddenPackages: input.includeHiddenPackages,
+		})
+		identityMatchesProvider = queryMatchesSynthesizedProvider({
+			query: input.query,
+			registry: preloadedSearchRows.registry,
+		})
+	}
+	const rankedQuery =
+		Boolean(input.query) &&
+		!domainFilter &&
+		(!identityResolution.recognized || identityMatchesProvider)
+	const memoryLaunch = rankedQuery
+		? launchSearchMemoryEnrichment({
+				env: input.env,
+				callerContext: input.callerContext,
+				conversationId: input.conversationId,
+				query: input.memoryQuery,
+				memoryContext: input.memoryContext,
+			})
+		: null
+	const memoryEnrichmentPromise = memoryLaunch?.promise ?? Promise.resolve(null)
+	const memoryEnrichmentLaunchedAtMs = memoryLaunch?.launchedAtMs
 	const phaseTimings: Partial<SearchPhaseTimings> = {}
 	let warnings: Array<string> = []
 	let result: SearchUnifiedResult
 	let capabilityGuidance: string | undefined
 
-	if (identityResolution.recognized) {
+	if (identityResolution.recognized && !identityMatchesProvider) {
 		result = buildExactPackageSearchResult({
 			env: input.env,
 			query: input.query,
 			match: identityResolution.match,
 		})
-		const memorySettlement = await settleSearchMemoryEnrichment({
-			env: input.env,
-			callerContext: input.callerContext,
-			conversationId: input.conversationId,
-			promise: memoryEnrichmentPromise,
-			launchedAtMs: memoryEnrichmentLaunchedAtMs,
-		})
-		Object.assign(phaseTimings, memorySettlement.phaseTimings)
-		warnings.push(...memorySettlement.warnings)
+		const memorySettlement: SearchMemoryEnrichmentSettlement = {
+			warnings: [],
+			phaseTimings: {},
+		}
+		warnings.push(...(preloadedSearchRows?.warnings ?? []))
 		return {
 			result,
 			username,
@@ -118,12 +137,16 @@ async function executeSearchListWithinBudget(
 	}
 
 	const rowAndRegistryLoadStart = performance.now()
-	const rowsPromise = loadSearchRowsAndRegistry({
-		env: input.env,
-		callerContext: input.callerContext,
-		userId: input.userId,
-		includeHiddenPackages: input.includeHiddenPackages,
-	}).then((rows) => {
+	const rowsPromise = (
+		preloadedSearchRows
+			? Promise.resolve(preloadedSearchRows)
+			: loadSearchRowsAndRegistry({
+					env: input.env,
+					callerContext: input.callerContext,
+					userId: input.userId,
+					includeHiddenPackages: input.includeHiddenPackages,
+				})
+	).then((rows) => {
 		phaseTimings.rowAndRegistryLoadMs = elapsedMs(rowAndRegistryLoadStart)
 		return rows
 	})
@@ -165,13 +188,22 @@ async function executeSearchListWithinBudget(
 		...(domainFilter ? { domain: domainFilter } : {}),
 	})
 	capabilityGuidance = result.guidance
-	const memorySettlement = await settleSearchMemoryEnrichment({
-		env: input.env,
-		callerContext: input.callerContext,
-		conversationId: input.conversationId,
-		promise: memoryEnrichmentPromise,
-		launchedAtMs: memoryEnrichmentLaunchedAtMs,
-	})
+	const returnsDomainIndex =
+		result.matches.length > 0 &&
+		result.matches.every((match) => match.type === 'domain')
+	const memorySettlement =
+		rankedQuery && !returnsDomainIndex
+			? await settleSearchMemoryEnrichment({
+					env: input.env,
+					callerContext: input.callerContext,
+					conversationId: input.conversationId,
+					promise: memoryEnrichmentPromise,
+					launchedAtMs: memoryEnrichmentLaunchedAtMs,
+				})
+			: ({
+					warnings: [],
+					phaseTimings: {},
+				} satisfies SearchMemoryEnrichmentSettlement)
 	Object.assign(phaseTimings, memorySettlement.phaseTimings)
 	warnings.push(...memorySettlement.warnings)
 

--- a/packages/worker/src/mcp/tools/search-format-detail.ts
+++ b/packages/worker/src/mcp/tools/search-format-detail.ts
@@ -1,10 +1,13 @@
 import { getSearchEntityPluginForDetail } from './search-entity-registry.ts'
 import { type SearchEntityDetail } from './search-format-types.ts'
 
-export function formatEntityDetailMarkdown(detail: SearchEntityDetail) {
+export function formatEntityDetailMarkdown(
+	detail: SearchEntityDetail,
+	options?: { includeBoilerplate?: boolean },
+) {
 	const plugin = getSearchEntityPluginForDetail(detail)
 	if (!plugin?.formatEntityDetail) {
 		throw new Error(`No detail formatter registered for ${detail.type}.`)
 	}
-	return plugin.formatEntityDetail(detail as never)
+	return plugin.formatEntityDetail(detail as never, options)
 }

--- a/packages/worker/src/mcp/tools/search-format-list.ts
+++ b/packages/worker/src/mcp/tools/search-format-list.ts
@@ -72,9 +72,15 @@ function formatMatchListItem(match: SearchMatch, index: number) {
 				: ''
 		return `${String(index + 1)}. **domain** ${formatMarkdownInlineCode(match.name)} (${String(match.capabilityCount)} ${match.capabilityCount === 1 ? 'capability' : 'capabilities'}) — ${escapeMarkdownText(formatOneLineSentence(match.description, domainOverviewDescriptionMaxLength))}${sample}`
 	}
+	if (match.type === 'provider') {
+		const packageSuffix = match.wrappingPackage
+			? ` Wrapping package: ${formatMarkdownInlineCode(match.wrappingPackage.name)} (Entity: ${formatMarkdownInlineCode(match.wrappingPackage.entityRef)}).`
+			: ''
+		return `${String(index + 1)}. **provider** ${escapeMarkdownText(match.title)} (${formatMarkdownInlineCode(match.domain)}, ${String(match.capabilityCount)} operations) — ${escapeMarkdownText(formatOneLineSentence(match.description))} Call via ${formatMarkdownInlineCode(match.usage)}.${packageSuffix}`
+	}
 	if (match.type === 'capability') {
 		const entityRef = buildEntityRef(match.name, 'capability')
-		const mainLine = `${String(index + 1)}. **capability** ${formatMarkdownInlineCode(match.name)} (${formatMarkdownInlineCode(match.domain)}) — ${escapeMarkdownText(formatOneLineSentence(match.description))} Entity: ${formatMarkdownInlineCode(entityRef)}`
+		const mainLine = `${String(index + 1)}. **capability** ${formatMarkdownInlineCode(match.title ?? match.name)} (${formatMarkdownInlineCode(match.domain)}) — ${escapeMarkdownText(formatOneLineSentence(match.description))} Entity: ${formatMarkdownInlineCode(entityRef)}`
 		if (!match.inputTypeDefinition) {
 			return mainLine
 		}

--- a/packages/worker/src/mcp/tools/search-format-types.ts
+++ b/packages/worker/src/mcp/tools/search-format-types.ts
@@ -2,7 +2,6 @@ import { type IntegrationConfig } from '#mcp/capabilities/integrations/integrati
 import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
 import { type SecretSearchRow } from '#mcp/secrets/types.ts'
 import { type ValueMetadata } from '#mcp/values/types.ts'
-import { type PackageReferencedTypeProjection } from '#worker/package-registry/manifest.ts'
 import { type PackageRetrieverSurfaceResult } from '#worker/package-retrievers/types.ts'
 import {
 	type AuthoredPackageJson,
@@ -24,6 +23,7 @@ type SearchMatchType =
 	| 'secret'
 	| 'retriever_result'
 	| 'domain'
+	| 'provider'
 
 export type PackageActionMatch = {
 	subpath: string
@@ -133,6 +133,22 @@ export type SlimSearchMatch =
 			capabilityCount: number
 			sampleCapabilities: Array<string>
 			usage: string
+	  }
+	| {
+			type: 'provider'
+			id: string
+			title: string
+			description: string
+			domain: string
+			source: 'mcp-server' | 'openapi'
+			capabilityCount: number
+			sampleCapabilities: Array<string>
+			usage: string
+			wrappingPackage: {
+				kodyId: string
+				name: string
+				entityRef: string
+			} | null
 	  }
 	| {
 			type: 'capability'
@@ -258,6 +274,7 @@ export type SearchEntityDetailStructured =
 			inputTypeDefinition: string
 			outputTypeDefinition?: string
 			relatedOperations?: Array<RelatedCapabilityOperation>
+			relatedOperationCount?: number
 	  }
 	| {
 			kind: 'entity'
@@ -283,50 +300,21 @@ export type SearchEntityDetailStructured =
 			}
 			exports: Array<{
 				subpath: string
-				importSpecifier: string
-				runtimeTarget: string | null
-				typesPath: string | null
 				description: string | null
-				typeDefinition: string | null
-				functions: Array<{
-					name: string
-					description: string | null
-					typeDefinition: string | null
-					referencedTypes: Array<PackageReferencedTypeProjection>
-				}>
-				referencedTypes: Array<PackageReferencedTypeProjection>
-				externalInvocation: {
-					method: 'POST'
-					url: string
-					path: string
-					ownerUsername: string
-					kodyId: string
-					routeExportName: string
-					normalizedExportName: string
-					tokenSetupUrl: string
-					sourceGuidance: string
-				} | null
 			}>
 			jobs: Array<{
 				name: string
-				entry: string
-				scheduleSummary: string
-				enabled: boolean
 			}>
 			retrievers: Array<{
 				key: string
-				exportName: string
 				name: string
-				description: string
-				scopes: Array<string>
-				timeoutMs: number | null
-				maxResults: number | null
 			}>
-			readme: {
+			readmeIntent: {
 				path: string
 				content: string
 				truncated: boolean
 			} | null
+			followUp: string
 	  }
 	| {
 			kind: 'entity'
@@ -381,6 +369,7 @@ export type SearchEntityDetail =
 			description: string
 			spec: CapabilitySpec
 			relatedOperations?: Array<RelatedCapabilityOperation>
+			relatedOperationCount?: number
 	  }
 	| {
 			type: 'package'
@@ -429,8 +418,25 @@ export type SearchMatch =
 			sampleCapabilities: Array<string>
 	  }
 	| {
+			type: 'provider'
+			id: string
+			title: string
+			description: string
+			domain: string
+			source: 'mcp-server' | 'openapi'
+			capabilityCount: number
+			sampleCapabilities: Array<string>
+			usage: string
+			wrappingPackage: {
+				kodyId: string
+				name: string
+				entityRef: string
+			} | null
+	  }
+	| {
 			type: 'capability'
 			name: string
+			title?: string
 			description: string
 			domain: string
 			source?: CapabilitySpec['source']

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -680,7 +680,7 @@ export declare function fetch(request: Request): Promise<Response>
 	})
 	expect(observedPackageDetail.markdown).toContain('## Follow up')
 	expect(observedPackageDetail.markdown).toContain(
-		'package_get({ kody_id: "observed-package" })',
+		'package_get({ package_id: "package-123" })',
 	)
 	expect(observedPackageDetail.markdown).not.toContain('src/app.d.ts')
 	expect(observedPackageDetail.markdown).not.toContain('Token setup URL')

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -583,7 +583,7 @@ test('capability formatting keeps execute contracts for identifier and bracket i
 	})
 })
 
-test('package entity detail includes exports, jobs, and referenced local types', () => {
+test('package entity detail is a slim index with explicit follow-up', () => {
 	const observedPackageDetail = formatEntityDetailMarkdown({
 		type: 'package',
 		id: 'observed-package',
@@ -638,6 +638,8 @@ test('package entity detail includes exports, jobs, and referenced local types',
 			'package.json': '{}',
 			'README.md': `# Observed package
 
+## Intent
+
 Use this package to inspect observed UI state.
 
 ## Usage
@@ -660,58 +662,31 @@ export declare function fetch(request: Request): Promise<Response>
 		hostedUrl: 'http://localhost/@test-user/packages/observed-package',
 		appEntry: './src/app.ts',
 		exports: [
-			expect.objectContaining({
+			{
 				subpath: '.',
-				importSpecifier: 'kody:@kody/observed-package',
-			}),
-			expect.objectContaining({
+				description: null,
+			},
+			{
 				subpath: './app',
-				externalInvocation: expect.objectContaining({
-					method: 'POST',
-					url: 'http://localhost/@test-user/api/package-invocations/observed-package/app',
-					path: '/@test-user/api/package-invocations/observed-package/app',
-					routeExportName: 'app',
-					normalizedExportName: './app',
-					tokenSetupUrl:
-						'http://localhost/account/package-invocation-tokens/new?packageKodyIds=observed-package&exportNames=app',
-				}),
-				referencedTypes: [],
-				functions: [
-					expect.objectContaining({
-						name: 'fetch',
-					}),
-				],
-			}),
+				description: 'Render the observed app.',
+			},
 		],
-		jobs: [
-			expect.objectContaining({
-				name: 'nightly',
-				entry: './src/jobs/nightly.ts',
-				enabled: true,
-			}),
-		],
-		readme: {
+		jobs: [{ name: 'nightly' }],
+		readmeIntent: {
 			path: 'README.md',
+			content: 'Use this package to inspect observed UI state.',
 			truncated: false,
 		},
 	})
-	expect(observedPackageDetail.markdown).toContain('## Import vs invoke')
+	expect(observedPackageDetail.markdown).toContain('## Follow up')
 	expect(observedPackageDetail.markdown).toContain(
-		'`packages.invoke({ kodyId: "observed-package", exportName, params })`',
+		'package_get({ kody_id: "observed-package" })',
 	)
-	expect(observedPackageDetail.markdown).not.toContain('invokeChecked')
-	expect(observedPackageDetail.markdown).toContain(
-		'The `kodyId` is the bare Kody id (`observed-package`), not the npm-scoped package name.',
+	expect(observedPackageDetail.markdown).not.toContain('src/app.d.ts')
+	expect(observedPackageDetail.markdown).not.toContain('Token setup URL')
+	expect(JSON.stringify(observedPackageDetail.structured)).not.toContain(
+		'typeDefinition',
 	)
-	expect(observedPackageDetail.markdown).toContain(
-		'`import entry from "kody:@kody/observed-package"`',
-	)
-	// Static import is the default and must lead the section.
-	expect(
-		observedPackageDetail.markdown.indexOf(
-			'`import entry from "kody:@kody/observed-package"`',
-		),
-	).toBeLessThan(observedPackageDetail.markdown.indexOf('packages.invoke({'))
 })
 
 test('package search formatting keeps runnable actions and hosted URLs in structured output', () => {
@@ -1206,7 +1181,9 @@ test('search formatting inlines top capability call shapes, related ops, and pac
 		},
 		relatedOperationCount: 2,
 	})
-	expect(openApiDetail.markdown).toContain('Related operations from this provider: 2')
+	expect(openApiDetail.markdown).toContain(
+		'Related operations from this provider: 2',
+	)
 	expect(openApiDetail.markdown).not.toContain(
 		'openapi:widgets:listwidgets:capability',
 	)

--- a/packages/worker/src/mcp/tools/search-format.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-format.node.test.ts
@@ -1075,6 +1075,7 @@ test('search formatting inlines top capability call shapes, related ops, and pac
 			{
 				type: 'capability',
 				name: 'openapi:widgets:createwidget',
+				title: 'POST /widgets',
 				description: 'Create a widget.',
 				domain: 'openapi:widgets',
 				source: 'openapi',
@@ -1090,6 +1091,7 @@ test('search formatting inlines top capability call shapes, related ops, and pac
 			{
 				type: 'capability',
 				name: 'openapi:widgets:listwidgets',
+				title: 'GET /widgets',
 				description: 'List widgets.',
 				domain: 'openapi:widgets',
 				source: 'openapi',
@@ -1113,6 +1115,7 @@ test('search formatting inlines top capability call shapes, related ops, and pac
 		],
 		includePreamble: false,
 	})
+	expect(listMarkdown).toContain('POST /widgets')
 	expect(listMarkdown).toContain('kody.openapi["widgets"].createwidget(args)')
 	expect(listMarkdown).toContain('type CreateWidgetInput = { name: string }')
 	expect(listMarkdown).toContain(compact.definition)
@@ -1201,40 +1204,17 @@ test('search formatting inlines top capability call shapes, related ops, and pac
 			},
 			inputTypeDefinition: 'type CreateWidgetInput = { name: string }',
 		},
-		relatedOperations: [
-			{
-				name: 'openapi:widgets:listwidgets',
-				entityRef: 'openapi:widgets:listwidgets:capability',
-				description: 'List widgets',
-				method: 'get',
-				path: '/widgets',
-			},
-			{
-				name: 'openapi:widgets:getwidget',
-				entityRef: 'openapi:widgets:getwidget:capability',
-				description: 'Get one widget.',
-				method: 'get',
-				path: '/widgets/{id}',
-			},
-		],
+		relatedOperationCount: 2,
 	})
-	expect(openApiDetail.markdown).toContain('GET /widgets')
-	expect(openApiDetail.markdown).toContain(
+	expect(openApiDetail.markdown).toContain('Related operations from this provider: 2')
+	expect(openApiDetail.markdown).not.toContain(
 		'openapi:widgets:listwidgets:capability',
 	)
 	expect(openApiDetail.structured).toMatchObject({
 		type: 'capability',
-		relatedOperations: [
-			expect.objectContaining({
-				name: 'openapi:widgets:listwidgets',
-				method: 'get',
-				path: '/widgets',
-			}),
-			expect.objectContaining({
-				name: 'openapi:widgets:getwidget',
-			}),
-		],
+		relatedOperationCount: 2,
 	})
+	expect(openApiDetail.structured).not.toHaveProperty('relatedOperations')
 
 	const builtinDetail = formatEntityDetailMarkdown({
 		type: 'capability',
@@ -1301,34 +1281,36 @@ test('search formatting inlines top capability call shapes, related ops, and pac
 		},
 		files: {
 			'package.json': '{}',
-			'index.ts': 'export default function main() {}',
+			'README.md':
+				'# Notes helper\n\n## Intent\n\nKeep notes workflows safe and reusable.\n\n## Usage\n\nFull usage details.',
+			'index.ts':
+				'/** Save a note. */\nexport default function main(input: { text: string }) { return input.text }',
 			'on-repo-pushed.ts': 'export default function handler() {}',
 		},
 	})
+	expect(packageDetail.markdown).toContain('## Index')
+	expect(packageDetail.markdown).toContain('| Subpath | Purpose |')
+	expect(packageDetail.markdown).toContain('## README Intent')
 	expect(packageDetail.markdown).toContain(
-		'package_get_git_remote({ kody_id: "notes-helper" })',
+		'Keep notes workflows safe and reusable.',
 	)
-	expect(packageDetail.markdown).toContain(
-		'package_publish_external_push({ kody_id: "notes-helper" })',
-	)
-	expect(packageDetail.markdown).toContain('## Test')
-	expect(packageDetail.markdown).toContain(
-		'package_subscription_dispatch({ kody_id: "notes-helper", topic: "repo.pushed", params: {} })',
+	expect(packageDetail.markdown).not.toContain('Full usage details.')
+	expect(packageDetail.markdown).not.toContain('typeDefinition')
+	expect(JSON.stringify(packageDetail.structured)).not.toContain(
+		'referencedTypes',
 	)
 	expect(packageDetail.structured).toMatchObject({
 		type: 'package',
-		maintain: {
-			gitLane: 'package_get_git_remote({ kody_id: "notes-helper" })',
-			publish: 'package_publish_external_push({ kody_id: "notes-helper" })',
-		},
-		test: {
-			subscriptions: [
-				{
-					topic: 'repo.pushed',
-					snippet:
-						'package_subscription_dispatch({ kody_id: "notes-helper", topic: "repo.pushed", params: {} })',
-				},
-			],
+		exports: [
+			{
+				subpath: '.',
+				description: 'Save a note.',
+			},
+		],
+		readmeIntent: {
+			path: 'README.md',
+			content: 'Keep notes workflows safe and reusable.',
+			truncated: false,
 		},
 	})
 })

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -120,6 +120,12 @@ type SearchHandler = (input: {
 	limit?: number
 	maxResponseSize?: number
 	conversationId?: string
+	memoryContext?: {
+		task?: string
+		query?: string
+		entities?: Array<string>
+		constraints?: Array<string>
+	}
 	includeHiddenPackages?: boolean
 }) => Promise<{
 	content: Array<{
@@ -148,6 +154,11 @@ async function getSearchRegistration(input?: {
 	} | null
 }) {
 	const registerTool = vi.fn()
+	const state: {
+		searchConversationIdsWithPreamble?: Array<string>
+		onboardingNoticeConversationIds?: Array<string>
+		onboardingNoticeLastShownAtMs?: number
+	} = {}
 
 	await registerSearchTool({
 		server: {
@@ -158,6 +169,10 @@ async function getSearchRegistration(input?: {
 			baseUrl: 'https://example.com',
 			user: input?.user === undefined ? null : input.user,
 		})),
+		state,
+		setState: vi.fn((nextState: typeof state) => {
+			Object.assign(state, nextState)
+		}),
 	} as never)
 
 	expect(registerTool).toHaveBeenCalledTimes(1)
@@ -606,23 +621,13 @@ test('search tool batches entity detail with per-ref isolation and preserves sin
 			kind: 'entity',
 			type: 'capability',
 			id: 'openapi:widgets:createwidget',
-			relatedOperations: [
-				expect.objectContaining({
-					name: 'openapi:widgets:getwidget',
-					method: 'get',
-					path: '/widgets/{id}',
-				}),
-			],
+			relatedOperationCount: 1,
 		}),
 		expect.objectContaining({
 			kind: 'entity',
 			type: 'capability',
 			id: 'openapi:widgets:getwidget',
-			relatedOperations: [
-				expect.objectContaining({
-					name: 'openapi:widgets:createwidget',
-				}),
-			],
+			relatedOperationCount: 1,
 		}),
 	])
 	mockPerformanceNow.mockReturnValueOnce(300).mockReturnValueOnce(310)
@@ -1269,4 +1274,196 @@ test('search tool domain param: browse, reject unknown, and scope ranked results
 		expect(match).toMatchObject({ type: 'capability', domain: 'meta' })
 	}
 	expect(mockModule.runPackageRetrievers).not.toHaveBeenCalled()
+})
+
+test('empty discovery returns a counted domain index without memory enrichment', async () => {
+	vi.clearAllMocks()
+	mockModule.getCapabilityRegistryForContext.mockResolvedValueOnce({
+		capabilityDomains: [
+			{
+				name: 'meta',
+				description: 'Search and registry metadata.',
+			},
+		],
+		capabilitySpecs: {
+			search_docs: {
+				name: 'search_docs',
+				description: 'Search docs capability',
+				domain: 'meta',
+				keywords: [],
+				inputFields: [],
+				requiredInputFields: [],
+				outputFields: [],
+				readOnly: true,
+				idempotent: true,
+				destructive: false,
+				source: 'builtin',
+				inputSchema: { type: 'object', properties: {} },
+				inputTypeDefinition: 'type Input = {}',
+			},
+		},
+	})
+	const { handler } = await getSearchRegistration({
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'User',
+		},
+	})
+
+	const response = await handler({ conversationId: 'conv-empty-index' })
+	expect(response.isError).toBeUndefined()
+	expect(response.structuredContent.result).toMatchObject({
+		matches: [
+			{
+				type: 'domain',
+				id: 'meta',
+				capabilityCount: 1,
+				sampleCapabilities: ['search_docs'],
+			},
+		],
+	})
+	expect(mockModule.loadRelevantMemoriesForTool).not.toHaveBeenCalled()
+	expect(mockModule.runPackageRetrievers).not.toHaveBeenCalled()
+})
+
+test('provider-name search ranks a wrapping package and provider card without an operation flood', async () => {
+	vi.clearAllMocks()
+	const openApiSpec = (
+		name: string,
+		operationSlug: string,
+		method: string,
+		path: string,
+	) => ({
+		name,
+		description: `${method.toUpperCase()} ${path}`,
+		domain: 'openapi:github',
+		keywords: ['github'],
+		inputFields: [],
+		requiredInputFields: [],
+		outputFields: [],
+		readOnly: true,
+		idempotent: true,
+		destructive: false,
+		source: 'openapi' as const,
+		openApi: {
+			bindingName: 'github',
+			kodyName: 'github',
+			operationSlug,
+			method,
+			path,
+		},
+		inputSchema: { type: 'object' as const, properties: {} },
+		inputTypeDefinition: 'type Input = {}',
+	})
+	mockModule.getCapabilityRegistryForContext.mockResolvedValue({
+		capabilityDomains: [
+			{
+				name: 'openapi:github',
+				description: 'GitHub OpenAPI operations.',
+			},
+		],
+		capabilitySpecs: {
+			'openapi:github:listrepositories': openApiSpec(
+				'openapi:github:listrepositories',
+				'listrepositories',
+				'get',
+				'/user/repos',
+			),
+			'openapi:github:createrepository': openApiSpec(
+				'openapi:github:createrepository',
+				'createrepository',
+				'post',
+				'/user/repos',
+			),
+		},
+	})
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([
+		{
+			id: 'pkg-github-wrapper',
+			userId: 'user-1',
+			name: '@user/github',
+			kodyId: 'github',
+			description: 'Safer GitHub workflows',
+			tags: ['github'],
+			searchText: 'github provider wrapper',
+			sourceId: 'source-github-wrapper',
+			hasApp: false,
+			hidden: false,
+			isPrivate: false,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		},
+	])
+	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
+		manifest: {
+			name: '@user/github',
+			exports: { '.': './index.ts' },
+			kody: {
+				id: 'github',
+				description: 'Safer GitHub workflows',
+			},
+		},
+		files: {
+			'package.json': '{}',
+			'README.md':
+				'# GitHub workflows\n\n## Intent\n\nWrap GitHub operations safely.',
+			'index.ts': 'export default function run() {}',
+		},
+	})
+	const { handler } = await getSearchRegistration({
+		user: {
+			userId: 'user-1',
+			email: 'user@example.com',
+			displayName: 'User',
+			username: 'user',
+		},
+	})
+
+	const response = await handler({
+		query: 'github',
+		conversationId: 'conv-provider',
+	})
+	const result = response.structuredContent.result as {
+		matches: Array<{
+			type: string
+			wrappingPackage?: { kodyId: string } | null
+		}>
+	}
+	expect(result.matches.map((match) => match.type)).toEqual([
+		'package',
+		'provider',
+	])
+	expect(result.matches[1]).toMatchObject({
+		type: 'provider',
+		wrappingPackage: { kodyId: 'github' },
+	})
+	expect(
+		result.matches.filter((match) => match.type === 'capability'),
+	).toHaveLength(0)
+})
+
+test('later entity detail in one conversation omits already-taught boilerplate', async () => {
+	vi.clearAllMocks()
+	const { handler } = await getSearchRegistration()
+
+	await handler({
+		query: 'search docs',
+		conversationId: 'conv-detail-preamble',
+	})
+	const laterDetail = await handler({
+		entity: 'search_docs:capability',
+		conversationId: 'conv-detail-preamble',
+	})
+	expect(laterDetail.content[1]?.text).not.toContain(
+		'Capabilities returned by `search` are available inside `execute`',
+	)
+
+	const firstDetail = await handler({
+		entity: 'search_docs:capability',
+		conversationId: 'conv-first-detail',
+	})
+	expect(firstDetail.content[1]?.text).toContain(
+		'Capabilities returned by `search` are available inside `execute`',
+	)
 })

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -331,18 +331,20 @@ test('search tool returns compact query markdown while preserving structured aux
 	)
 
 	mockPerformanceNow.mockReturnValueOnce(5).mockReturnValueOnce(9)
-	const validationErrorResponse = await handler({
+	const emptyDiscoveryResponse = await handler({
 		conversationId: 'conv-search-error',
 	})
-	expect(validationErrorResponse.isError).toBe(true)
-	expect(validationErrorResponse.structuredContent).toMatchObject({
+	expect(emptyDiscoveryResponse.isError).toBeUndefined()
+	expect(emptyDiscoveryResponse.structuredContent).toMatchObject({
 		conversationId: 'conv-search-error',
 		timing: {
 			startedAt: expect.any(String),
 			endedAt: expect.any(String),
 			durationMs: expect.any(Number),
 		},
-		error: expect.stringMatching(/query.*entity/i),
+		result: {
+			matches: [],
+		},
 	})
 
 	mockModule.getCapabilityRegistryForContext.mockRejectedValueOnce(
@@ -1050,7 +1052,7 @@ test('search tool memory enrichment: timeout, rejection, and ack failure stay of
 		user,
 	})
 	const structuredContextResult = await structuredContextHandler({
-		query: ' ',
+		query: 'search docs',
 		conversationId: 'conv-structured-memory',
 		memoryContext: { task: 'search docs' },
 	})
@@ -1303,16 +1305,13 @@ test('empty discovery returns a counted domain index without memory enrichment',
 			},
 		},
 	})
-	const { handler } = await getSearchRegistration({
-		user: {
-			userId: 'user-1',
-			email: 'user@example.com',
-			displayName: 'User',
-		},
-	})
+	const { handler } = await getSearchRegistration({ user: null })
 
 	const response = await handler({ conversationId: 'conv-empty-index' })
-	expect(response.isError).toBeUndefined()
+	expect(
+		response.isError,
+		JSON.stringify(response.structuredContent),
+	).toBeUndefined()
 	expect(response.structuredContent.result).toMatchObject({
 		matches: [
 			{

--- a/packages/worker/src/mcp/tools/search-provider-overview.ts
+++ b/packages/worker/src/mcp/tools/search-provider-overview.ts
@@ -54,10 +54,7 @@ function getProviderIdentity(spec: CapabilitySpec): SynthesizedProvider | null {
 			title: spec.mcpServer.serverName,
 			domain: spec.domain,
 			source: 'mcp-server',
-			identityFields: [
-				spec.mcpServer.serverName,
-				spec.mcpServer.kodyName,
-			],
+			identityFields: [spec.mcpServer.serverName, spec.mcpServer.kodyName],
 			operationIdentityFields: [
 				spec.name,
 				spec.mcpServer.mcpToolName,
@@ -126,7 +123,10 @@ function isExactOperationQuery(query: string, provider: SynthesizedProvider) {
 	)
 }
 
-function shouldKeepTaskOperations(query: string, provider: SynthesizedProvider) {
+function shouldKeepTaskOperations(
+	query: string,
+	provider: SynthesizedProvider,
+) {
 	const providerTokens = new Set(
 		provider.identityFields.flatMap(extractSearchTokens),
 	)

--- a/packages/worker/src/mcp/tools/search-provider-overview.ts
+++ b/packages/worker/src/mcp/tools/search-provider-overview.ts
@@ -1,0 +1,225 @@
+import { type getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
+import { type CapabilitySpec } from '#mcp/capabilities/types.ts'
+
+import { type SearchMatch } from './search-format-types.ts'
+import { type SearchCandidate } from './search-types.ts'
+import {
+	extractSearchTokens,
+	normalizeSearchText,
+} from './understand-search-query.ts'
+
+const providerOnlyQueryTokens = new Set([
+	'api',
+	'binding',
+	'integration',
+	'mcp',
+	'openapi',
+	'operation',
+	'operations',
+	'provider',
+	'server',
+	'tool',
+	'tools',
+])
+const maxTaskSpecificProviderOperations = 2
+const providerSampleCount = 3
+
+type SynthesizedProvider = {
+	key: string
+	title: string
+	domain: string
+	source: 'mcp-server' | 'openapi'
+	identityFields: Array<string>
+	operationIdentityFields: Array<string>
+	specs: Array<CapabilitySpec>
+	usage: string
+}
+
+function getProviderIdentity(spec: CapabilitySpec): SynthesizedProvider | null {
+	if (spec.openApi) {
+		return {
+			key: `openapi:${spec.openApi.bindingName}`,
+			title: spec.openApi.bindingName,
+			domain: spec.domain,
+			source: 'openapi',
+			identityFields: [spec.openApi.bindingName, spec.openApi.kodyName],
+			operationIdentityFields: [spec.name, spec.openApi.operationSlug],
+			specs: [spec],
+			usage: `kody.openapi[${JSON.stringify(spec.openApi.kodyName)}].operation_slug(args)`,
+		}
+	}
+	if (spec.mcpServer) {
+		return {
+			key: `mcp-server:${spec.mcpServer.serverId}`,
+			title: spec.mcpServer.serverName,
+			domain: spec.domain,
+			source: 'mcp-server',
+			identityFields: [
+				spec.mcpServer.serverName,
+				spec.mcpServer.kodyName,
+			],
+			operationIdentityFields: [
+				spec.name,
+				spec.mcpServer.mcpToolName,
+				spec.mcpServer.toolName,
+			],
+			specs: [spec],
+			usage: `kody.mcp[${JSON.stringify(spec.mcpServer.kodyName)}].tool_name(args)`,
+		}
+	}
+	return null
+}
+
+function buildProviders(
+	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>,
+) {
+	const providers = new Map<string, SynthesizedProvider>()
+	for (const spec of Object.values(registry.capabilitySpecs)) {
+		const identity = getProviderIdentity(spec)
+		if (!identity) continue
+		const existing = providers.get(identity.key)
+		if (!existing) {
+			providers.set(identity.key, identity)
+			continue
+		}
+		existing.specs.push(spec)
+		existing.operationIdentityFields.push(...identity.operationIdentityFields)
+	}
+	return providers
+}
+
+export function queryMatchesSynthesizedProvider(input: {
+	query: string
+	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
+}) {
+	return [...buildProviders(input.registry).values()].some((provider) =>
+		queryTargetsProvider(input.query, provider),
+	)
+}
+
+function packageWrapsProvider(
+	candidate: SearchCandidate,
+	provider: SynthesizedProvider,
+) {
+	if (candidate.type !== 'package' || !candidate.packageIdentityFields) {
+		return false
+	}
+	const packageTokens = new Set(
+		candidate.packageIdentityFields.flatMap(extractSearchTokens),
+	)
+	return provider.identityFields
+		.flatMap(extractSearchTokens)
+		.some((token) => packageTokens.has(token))
+}
+
+function queryTargetsProvider(query: string, provider: SynthesizedProvider) {
+	const queryTokens = new Set(extractSearchTokens(query))
+	return provider.identityFields
+		.flatMap(extractSearchTokens)
+		.some((token) => queryTokens.has(token))
+}
+
+function isExactOperationQuery(query: string, provider: SynthesizedProvider) {
+	const normalizedQuery = normalizeSearchText(query).trim()
+	return provider.operationIdentityFields.some(
+		(identity) => normalizeSearchText(identity).trim() === normalizedQuery,
+	)
+}
+
+function shouldKeepTaskOperations(query: string, provider: SynthesizedProvider) {
+	const providerTokens = new Set(
+		provider.identityFields.flatMap(extractSearchTokens),
+	)
+	return extractSearchTokens(query).some(
+		(token) =>
+			!providerTokens.has(token) && !providerOnlyQueryTokens.has(token),
+	)
+}
+
+function buildProviderCard(input: {
+	provider: SynthesizedProvider
+	candidates: ReadonlyArray<SearchCandidate>
+}): Extract<SearchMatch, { type: 'provider' }> {
+	const wrappingCandidate = input.candidates.find((candidate) =>
+		packageWrapsProvider(candidate, input.provider),
+	)
+	const wrappingPackage =
+		wrappingCandidate?.match.type === 'package'
+			? {
+					kodyId: wrappingCandidate.match.kodyId,
+					name: wrappingCandidate.match.name,
+					entityRef: `${wrappingCandidate.match.kodyId}:package`,
+				}
+			: null
+	const capabilityCount = input.provider.specs.length
+	return {
+		type: 'provider',
+		id: input.provider.key,
+		title: input.provider.title,
+		description: `${input.provider.source === 'openapi' ? 'OpenAPI' : 'MCP'} provider with ${String(capabilityCount)} ${capabilityCount === 1 ? 'operation' : 'operations'}.`,
+		domain: input.provider.domain,
+		source: input.provider.source,
+		capabilityCount,
+		sampleCapabilities: input.provider.specs
+			.slice(0, providerSampleCount)
+			.map((spec) => spec.name),
+		usage: input.provider.usage,
+		wrappingPackage,
+	}
+}
+
+/**
+ * Replaces provider-name floods with one provider card. A task-specific query
+ * may retain two top operations; exact operation names remain untouched.
+ */
+export function collapseSynthesizedProviderMatches(input: {
+	query: string
+	candidates: Array<SearchCandidate>
+	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
+}): Array<SearchMatch> {
+	const providers = buildProviders(input.registry)
+	const representedProviderKeys = new Set(
+		input.candidates.flatMap((candidate) =>
+			candidate.type === 'capability' && candidate.synthesizedProviderKey
+				? [candidate.synthesizedProviderKey]
+				: [],
+		),
+	)
+	const collapsedProviders = new Map(
+		[...providers].filter(
+			([key, provider]) =>
+				representedProviderKeys.has(key) &&
+				queryTargetsProvider(input.query, provider) &&
+				!isExactOperationQuery(input.query, provider),
+		),
+	)
+	if (collapsedProviders.size === 0) {
+		return input.candidates.map((candidate) => candidate.match)
+	}
+
+	const emittedCards = new Set<string>()
+	const retainedOperationsByProvider = new Map<string, number>()
+	const matches: Array<SearchMatch> = []
+	for (const candidate of input.candidates) {
+		const providerKey = candidate.synthesizedProviderKey
+		const provider = providerKey
+			? collapsedProviders.get(providerKey)
+			: undefined
+		if (!provider || candidate.type !== 'capability') {
+			matches.push(candidate.match)
+			continue
+		}
+		if (!emittedCards.has(provider.key)) {
+			matches.push(
+				buildProviderCard({ provider, candidates: input.candidates }),
+			)
+			emittedCards.add(provider.key)
+		}
+		if (!shouldKeepTaskOperations(input.query, provider)) continue
+		const retained = retainedOperationsByProvider.get(provider.key) ?? 0
+		if (retained >= maxTaskSpecificProviderOperations) continue
+		matches.push(candidate.match)
+		retainedOperationsByProvider.set(provider.key, retained + 1)
+	}
+	return matches
+}

--- a/packages/worker/src/mcp/tools/search-related-capabilities.ts
+++ b/packages/worker/src/mcp/tools/search-related-capabilities.ts
@@ -78,3 +78,19 @@ export function collectRelatedCapabilityOperations(input: {
 				: {}),
 		}))
 }
+
+export function countRelatedCapabilityOperations(input: {
+	spec: Awaited<
+		ReturnType<typeof getCapabilityRegistryForContext>
+	>['capabilitySpecs'][string]
+	registry: Awaited<ReturnType<typeof getCapabilityRegistryForContext>>
+}): number {
+	if (input.spec.source !== 'openapi' && input.spec.source !== 'mcp-server') {
+		return 0
+	}
+	return Object.values(input.registry.capabilitySpecs).filter(
+		(other) =>
+			other.name !== input.spec.name &&
+			sameSynthesizedProvider(input.spec, other),
+	).length
+}

--- a/packages/worker/src/mcp/tools/search-scoring.ts
+++ b/packages/worker/src/mcp/tools/search-scoring.ts
@@ -508,6 +508,54 @@ function findStrongSynthesizedIdentityTerms(input: {
 }
 
 const maxSynthesizedProviderEntityAffinity = 1.1
+const maxPackageProviderEntityAffinity = 1.15
+
+function findPackageProviderAffinity(input: {
+	candidate: SearchCandidate
+	candidates: ReadonlyArray<SearchCandidate>
+	strongIdentityTermsByProvider: ReadonlyMap<string, ReadonlySet<string>>
+}): number {
+	if (
+		input.candidate.type !== 'package' ||
+		!input.candidate.packageIdentityFields?.length
+	) {
+		return 0
+	}
+	let affinity = 0
+	for (const [providerKey, strongTerms] of input.strongIdentityTermsByProvider) {
+		const providerIdentityFields = input.candidates.flatMap((candidate) =>
+			candidate.synthesizedProviderKey === providerKey
+				? (candidate.providerIdentityFields ?? [])
+				: [],
+		)
+		const providerTerms = Array.from(
+			new Set(providerIdentityFields.flatMap(extractSearchTokens)),
+		)
+		if (
+			scoreSemanticMatchedTerms(
+				input.candidate.packageIdentityFields,
+				providerTerms,
+			) <= 0 ||
+			scoreSemanticMatchedTerms(
+				input.candidate.packageIdentityFields,
+				[...strongTerms],
+			) <= 0
+		) {
+			continue
+		}
+		affinity = Math.max(
+			affinity,
+			Math.min(
+				maxPackageProviderEntityAffinity,
+				scoreSemanticMatchedTerms(
+					input.candidate.packageIdentityFields,
+					providerTerms,
+				) * maxPackageProviderEntityAffinity,
+			),
+		)
+	}
+	return affinity
+}
 
 function hasExactNonProviderEntityTarget(input: {
 	candidates: ReadonlyArray<SearchCandidate>
@@ -556,7 +604,7 @@ export function rerankCandidates(input: {
 				],
 				[...strongIdentityTerms],
 			) > 0
-		const providerEntityAffinity =
+		const synthesizedProviderAffinity =
 			matchesStrongSynthesizedIdentity && !exactNonProviderEntityTarget
 				? Math.min(
 						maxSynthesizedProviderEntityAffinity,
@@ -569,6 +617,15 @@ export function rerankCandidates(input: {
 						) * maxSynthesizedProviderEntityAffinity,
 					)
 				: 0
+		const packageProviderAffinity = findPackageProviderAffinity({
+			candidate,
+			candidates: input.candidates,
+			strongIdentityTermsByProvider,
+		})
+		const providerEntityAffinity = Math.max(
+			synthesizedProviderAffinity,
+			packageProviderAffinity,
+		)
 		const taskSignals = scoreTaskAffinity(candidate, input.intent)
 		const final =
 			candidate.scoreComponents.base +

--- a/packages/worker/src/mcp/tools/search-scoring.ts
+++ b/packages/worker/src/mcp/tools/search-scoring.ts
@@ -522,7 +522,10 @@ function findPackageProviderAffinity(input: {
 		return 0
 	}
 	let affinity = 0
-	for (const [providerKey, strongTerms] of input.strongIdentityTermsByProvider) {
+	for (const [
+		providerKey,
+		strongTerms,
+	] of input.strongIdentityTermsByProvider) {
 		const providerIdentityFields = input.candidates.flatMap((candidate) =>
 			candidate.synthesizedProviderKey === providerKey
 				? (candidate.providerIdentityFields ?? [])
@@ -536,10 +539,9 @@ function findPackageProviderAffinity(input: {
 				input.candidate.packageIdentityFields,
 				providerTerms,
 			) <= 0 ||
-			scoreSemanticMatchedTerms(
-				input.candidate.packageIdentityFields,
-				[...strongTerms],
-			) <= 0
+			scoreSemanticMatchedTerms(input.candidate.packageIdentityFields, [
+				...strongTerms,
+			]) <= 0
 		) {
 			continue
 		}

--- a/packages/worker/src/mcp/tools/search-tool-definition.ts
+++ b/packages/worker/src/mcp/tools/search-tool-definition.ts
@@ -17,10 +17,10 @@ before \`execute\`.
 
 **query** — compact ranked markdown + structured matches (order matters). Query
 markdown is summary-only: type, title/name, one-line description, and entity ref.
-Broad/exploratory queries ("what can you do with email") return compact
-**domain summaries** instead of individual hits; drill in with \`domain\`.
-If nothing useful returns, rephrase or call \`meta_list_capabilities\`; \`entity\`
-does not fix an empty ranked list.
+An empty call and broad/exploratory queries ("what can you do with email")
+return a compact **domain index** instead of individual hits; drill in with
+\`domain\`. General provider-name discovery returns one provider card and ranks
+a matching saved wrapper package above raw OpenAPI/MCP operations.
 
 **domain** — optional capability domain id (e.g. \`email\`, \`jobs\`,
 \`mcp:linear\`). With \`query\`, ranks only that domain's
@@ -34,21 +34,24 @@ without competing semantic matches. Hidden exact queries require
 
 **entity: "{id}:{type}"** — detail for one hit (\`capability\` | \`value\`
 | \`integration\` | \`package\` | \`secret\`), or an array of 1–10 refs to batch
-related lookups in one call. Capability detail includes an exact \`execute\`
-module snippet plus TypeScript call-shape definitions by default. Synthesized
-provider capabilities (OpenAPI, MCP server) also list related
-operations from the same provider. Integration detail may include a small set of
+related lookups in one call. Package detail defaults to a slim index (export
+subpaths, job/retriever names, README Intent). Capability detail includes an
+exact \`execute\` module snippet plus TypeScript call-shape definitions.
+Synthesized provider detail reports its related-operation count. Integration
+detail may include a small set of
 same-provider package suggestions (user packages first, else trusted-first
 community listings). Package ids may be UUIDs or kody ids, and hidden packages
 resolve here regardless of \`includeHiddenPackages\`.
 
 Secret results expose metadata only; credential values never appear.
 
-If results look incomplete: \`meta_list_capabilities\` (full registry).
+If results look incomplete: \`meta_list_capabilities()\` for a domain index,
+then \`meta_list_capabilities({ domain })\` for one domain.
 
 Optional **limit** (default 15) and **maxResponseSize** trim low-ranked results.
 Example arguments:
 - \`{ "query": "saved github automation package", "limit": 10 }\`
+- \`{}\`
 - \`{ "query": "send a message", "domain": "email" }\`
 - \`{ "domain": "jobs" }\`
 - \`{ "entity": "coding_guide_get:capability" }\`

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -77,39 +77,6 @@ export async function runSearchTool(input: {
 	// Whitespace-only queries stay valid (memory enrichment may still run) but
 	// count as "no query" for the domain-browse limit default.
 	const trimmedQuery = args.query?.trim() ?? ''
-	if (!args.query && !args.entity && !domainFilter) {
-		const timing = finishToolTiming(timingStart)
-		logMcpEvent({
-			category: 'mcp',
-			tool: 'search',
-			toolName: 'search',
-			outcome: 'failure',
-			durationMs: timing.durationMs,
-			...mcpCallerFields,
-			sandboxError: false,
-			callerError: true,
-			errorName: 'ValidationError',
-			errorMessage: 'Provide "query", "entity", or "domain".',
-			message: 'Search request missing query, entity, and domain.',
-			context: {
-				failurePhase: 'validation_error',
-			},
-		})
-		return {
-			content: prependToolMetadataContent(conversationId, [
-				{
-					type: 'text',
-					text: 'Error: Provide "query", "entity", or "domain".',
-				},
-			]),
-			structuredContent: {
-				conversationId,
-				timing,
-				error: 'Provide "query", "entity", or "domain".',
-			},
-			isError: true,
-		}
-	}
 	// Domain browsing (domain without query) deliberately lists the whole
 	// domain by default instead of cutting at the ranked default.
 	const limit =
@@ -121,6 +88,36 @@ export async function runSearchTool(input: {
 	let warnings: Array<string> = []
 	let username: string | null = null
 	const endToEndPhaseTimings: Partial<SearchPhaseTimings> = {}
+	const statefulAgent = agent as McpRegistrationAgent & {
+		state?: {
+			searchConversationIdsWithPreamble?: Array<string>
+			onboardingNoticeConversationIds?: Array<string>
+			onboardingNoticeLastShownAtMs?: number
+		}
+		setState?: (state: {
+			searchConversationIdsWithPreamble?: Array<string>
+			onboardingNoticeConversationIds?: Array<string>
+			onboardingNoticeLastShownAtMs?: number
+		}) => void
+	}
+	const searchConversationIdsWithPreamble = Array.isArray(
+		statefulAgent.state?.searchConversationIdsWithPreamble,
+	)
+		? (statefulAgent.state?.searchConversationIdsWithPreamble ?? [])
+		: []
+	const includePreamble =
+		!args.conversationId ||
+		!searchConversationIdsWithPreamble.includes(conversationId)
+	function rememberConversationPreamble() {
+		if (!includePreamble || typeof statefulAgent.setState !== 'function') return
+		statefulAgent.setState({
+			...statefulAgent.state,
+			searchConversationIdsWithPreamble: [
+				...searchConversationIdsWithPreamble,
+				conversationId,
+			].slice(-maxOnboardingNoticeConversationIds),
+		})
+	}
 
 	const searchSpan = async () => {
 		const query = trimmedQuery
@@ -249,7 +246,10 @@ export async function runSearchTool(input: {
 		)
 
 		if (outcome.mode === 'entity') {
-			const entityResult = formatEntityDetailMarkdown(outcome.detail)
+			const entityResult = formatEntityDetailMarkdown(outcome.detail, {
+				includeBoilerplate: includePreamble,
+			})
+			rememberConversationPreamble()
 			const timing = finishToolTiming(timingStart)
 			logMcpEvent({
 				category: 'mcp',
@@ -292,7 +292,9 @@ export async function runSearchTool(input: {
 					)
 					continue
 				}
-				const entityResult = formatEntityDetailMarkdown(entry.detail)
+				const entityResult = formatEntityDetailMarkdown(entry.detail, {
+					includeBoilerplate: includePreamble,
+				})
 				const candidateStructured = [
 					...structuredResults,
 					entityResult.structured,
@@ -320,6 +322,7 @@ export async function runSearchTool(input: {
 				markdownParts.push(entityResult.markdown)
 			}
 			const allFailed = successCount === 0
+			if (!allFailed) rememberConversationPreamble()
 			const failedEntries = outcome.results.filter((entry) => !entry.ok)
 			const allFailuresAreCallerErrors =
 				allFailed && failedEntries.every((entry) => entry.callerError)
@@ -391,35 +394,7 @@ export async function runSearchTool(input: {
 			matches: execution.result.matches,
 			offline: execution.result.offline,
 		}
-		const statefulAgent = agent as McpRegistrationAgent & {
-			state?: {
-				searchConversationIdsWithPreamble?: Array<string>
-				onboardingNoticeConversationIds?: Array<string>
-				onboardingNoticeLastShownAtMs?: number
-			}
-			setState?: (state: {
-				searchConversationIdsWithPreamble?: Array<string>
-				onboardingNoticeConversationIds?: Array<string>
-				onboardingNoticeLastShownAtMs?: number
-			}) => void
-		}
-		const searchConversationIdsWithPreamble = Array.isArray(
-			statefulAgent.state?.searchConversationIdsWithPreamble,
-		)
-			? (statefulAgent.state?.searchConversationIdsWithPreamble ?? [])
-			: []
-		const includePreamble =
-			!args.conversationId ||
-			!searchConversationIdsWithPreamble.includes(conversationId)
-		if (includePreamble && typeof statefulAgent.setState === 'function') {
-			statefulAgent.setState({
-				...statefulAgent.state,
-				searchConversationIdsWithPreamble: [
-					...searchConversationIdsWithPreamble,
-					conversationId,
-				],
-			})
-		}
+		rememberConversationPreamble()
 		// Onboarding reminder: at most once per conversation, only while the
 		// user's derived checklist is incomplete and undismissed. A session
 		// cooldown backstops hosts that never send a conversationId (each of

--- a/packages/worker/src/mcp/tools/search-types.ts
+++ b/packages/worker/src/mcp/tools/search-types.ts
@@ -62,6 +62,8 @@ export type SearchCandidate = {
 	searchFields: Array<string>
 	identityFields?: Array<string>
 	providerIdentityFields?: Array<string>
+	/** Saved-package identity used to recognize wrappers for synthesized providers. */
+	packageIdentityFields?: Array<string>
 	synthesizedProviderKey?: string
 	scoreComponents: SearchScoreComponents
 }

--- a/packages/worker/src/package-registry/package-readme.ts
+++ b/packages/worker/src/package-registry/package-readme.ts
@@ -19,6 +19,8 @@ export type PackageReadmeDetail = {
 	truncated: boolean
 }
 
+export type PackageReadmeIntent = PackageReadmeDetail
+
 function normalizeReadmeContent(content: string) {
 	return content.replace(/\r\n/g, '\n').trim()
 }
@@ -128,6 +130,39 @@ export function buildPackageReadmeDetail(input: {
 		return null
 	}
 	const trimmed = trimWithEllipsis(readme.content, input.maxChars ?? 6_000)
+	return {
+		path: readme.path,
+		content: trimmed.text,
+		truncated: trimmed.truncated,
+	}
+}
+
+export function buildPackageReadmeIntent(input: {
+	files: Record<string, string>
+	maxChars?: number
+}): PackageReadmeIntent | null {
+	const readme = findRootReadmeFile(input.files)
+	if (!readme) return null
+	const lines = readme.content.split('\n')
+	const headingIndex = lines.findIndex((line) =>
+		/^#{1,6}\s+intent\s*$/i.test(line.trim()),
+	)
+	if (headingIndex === -1) return null
+	const headingLevel = lines[headingIndex]?.match(/^#+/)?.[0].length ?? 6
+	let endIndex = lines.length
+	for (let index = headingIndex + 1; index < lines.length; index += 1) {
+		const nextHeading = lines[index]?.trim().match(/^(#{1,6})\s+/)
+		if (nextHeading && nextHeading[1]!.length <= headingLevel) {
+			endIndex = index
+			break
+		}
+	}
+	const content = lines
+		.slice(headingIndex + 1, endIndex)
+		.join('\n')
+		.trim()
+	if (!content) return null
+	const trimmed = trimWithEllipsis(content, input.maxChars ?? 1_200)
 	return {
 		path: readme.path,
 		content: trimmed.text,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make search and capability discovery context-efficient for every user while preferring reusable package wrappers over raw synthesized provider operations.

## Summary

- return counted domain indexes for empty/broad discovery and unscoped `meta_list_capabilities`
- rank matching saved packages above compact OpenAPI/MCP provider cards
- make package entity detail a slim index and bound related-operation disclosure
- tighten automatic memory/retriever enrichment to ranked task queries
- record ADRs 0022/0023 and the three discovery invariants

## Testing

- post-rebase focused suite — 7 files / 27 tests passed
- Bugbot follow-up — `search-format.node.test.ts`, 9 tests passed
- `npm run typecheck` — passed
- `npm run primitives:check` — passed (53 primitives, 12 invariants)
- local Node — 568 files / 1,840 tests passed
- local Workers — 86 files / 296 tests passed
- [real Validate run 32220843750](https://github.com/kentcdodds/kody/actions/runs/32220843750) — all jobs passed, including Static, Node, Workers, MCP, and E2E
- Bugbot passed after its valid `package_get({ package_id })` finding was fixed
- [production deploy 32224695387](https://github.com/kentcdodds/kody/actions/runs/32224695387) — passed on the subsequent `main` head containing this squash commit

No logged-in UI was added, so preview manual testing was not applicable.

## Conductor report

Status: SHIPPED. Squash-merged as `a8e79941781b2d5fb427e8353e148d5117df0e60`; real Validate and production deploy are green. Bugbot's valid finding was fixed and resolved. CodeRabbit was rate-limited and the user explicitly made that review non-blocking. Discord completion report sent to channel `1491568683737157683`. The conductor wake returned Cursor API 409, so Discord is the final report-back.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4e5c7450` · **Head:** `2ee15b62`

**Classification:** extends — this PR changes MCP search contracts, package discovery projection, and automatic memory enrichment without adding a runtime primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — bounded domain/provider/entity discovery |
| `capability-registry` | assistant | extends — provider cards and domain indexes |
| `saved-packages` | assistant | extends — wrapper affinity and slim package index |
| `memories` | assistant | extends — ranked-query-only automatic enrichment |

### Change flow

Search now resolves broad discovery to indexes, provider discovery to package-first cards, and memory enrichment only to ranked task queries.

```mermaid
sequenceDiagram
	actor Caller
	participant mcpServer as mcp-server
	participant registry as capability-registry
	participant savedPackages as saved-packages
	participant memories as memories
	Caller->>mcpServer: search query, domain, or entity ref
	mcpServer->>registry: build counted domain index or provider card
	mcpServer->>savedPackages: rank matching wrapper and project slim package index
	opt ranked task query only
		mcpServer->>memories: retrieve active matches above score floor
	end
	mcpServer-->>Caller: bounded cards with explicit follow-ups
```

### Before / after

| Before | After |
| --- | --- |
| empty discovery errored or registry listing expanded | empty/broad discovery returns counted domain index |
| provider-name hits repeated raw operations | wrapper package + one provider card rank first |
| package entity returned full export/type/README tree | package entity returns index + follow-up pointer |

### Invariants

- `compact-mcp-surface` remains in force.
- `discovery-progressive-disclosure` makes expensive detail explicit.
- `package-over-synthesized-provider` prefers maintained wrappers.
- `bounded-always-on-mcp-text` records the cross-track instruction bound.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffac55df-3dd2-4a8e-a935-7fb93d6d28fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffac55df-3dd2-4a8e-a935-7fb93d6d28fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

