### PR TITLE
Resume persistent services after Cloudflare platform faults

### DIFF
--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -114,9 +114,12 @@ Saved packages may also declare long-lived package services under
   Background `waitUntil` work does not keep the Durable Object alive by itself;
   without that wake, Cloudflare evicts the isolate and orphans the sandbox,
   including any outbound WebSocket.
-- `mode: 'persistent'` means stay up until stopped. Eviction is treated as a
-  platform interrupt: the host immediately reschedules the same service, even
-  when `autoStart` is false. Persist resume cursors (`session_id`, sequence) in
+- `mode: 'persistent'` means stay up until stopped. Eviction and opaque
+  Cloudflare platform faults (`internal error; reference = …`, Durable Object
+  isolate resets, retryable D1 blips) are treated as platform interrupts: the
+  host immediately reschedules the same service, even when `autoStart` is false.
+  Package-thrown errors still require `autoStart` or `service.setAlarm` to
+  reconnect. Persist resume cursors (`session_id`, sequence) in
   `packageStorage()` so the next run can continue.
 
 ## Workflow runtime

--- a/docs/guides/package-service-pattern.md
+++ b/docs/guides/package-service-pattern.md
@@ -197,8 +197,11 @@ short incoming alarm; still treat disconnect and eviction as normal:
 
 Use `mode: 'persistent'` for daemon-like supervisors (Discord Gateway, other
 outbound sockets). Persistent services resume immediately after Durable Object
-eviction even when `autoStart` is false. Bounded services still use crash-loop
-backoff when `autoStart` is true.
+eviction and after opaque Cloudflare platform faults (sandbox
+`internal error; reference = …`, isolate resets, retryable D1 blips) even when
+`autoStart` is false. Package-thrown errors still need `autoStart` or
+`service.setAlarm`. Bounded services still use crash-loop backoff when
+`autoStart` is true.
 
 Use `timeoutMs` to give a bounded service enough room to run, but do not rely on
 indefinite execution as the only lifecycle mechanism.

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -89,6 +89,7 @@ const {
 	buildPackageServiceStorageId,
 	buildServiceRuntimeUsageEvent,
 	computePackageServiceRetryDelayMs,
+	isTransientPackageServicePlatformError,
 	packageServiceKeepaliveMs,
 	packageServiceStateHeartbeatMs,
 } = await import('./package-service.ts')
@@ -668,6 +669,150 @@ test('durable object restore immediately resumes an evicted persistent service',
 	}
 })
 
+test('persistent service resumes after a platform internal error but stays down after a package crash', async () => {
+	resetMocks()
+	const usageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockResolvedValue(undefined)
+	vi.useFakeTimers()
+	try {
+		const startedAt = new Date('2026-08-19T03:42:18.000Z')
+		vi.setSystemTime(startedAt)
+		setupSavedPackage('persistent')
+		mockModule.runBundledModuleWithRegistry.mockResolvedValue({
+			result: null,
+			error: 'internal error; reference = 197apho8c3i03ul6hjbbi2b9',
+		})
+
+		const created = await createPackageServiceInstance({
+			APP_DB: {},
+		} as Env)
+		const start = await created.instance.fetch(
+			new Request('https://package-service.invalid/service/start', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ binding: serviceBinding }),
+			}),
+		)
+		expect(start.status).toBe(200)
+		await flushWaitUntilTasks(created.waitUntilTasks)
+
+		const afterPlatformError = created.persistedEntries.get(
+			'package-service-state',
+		) as {
+			status: string
+			lastError: string | null
+			consecutiveFailureCount: number
+			nextAlarmSource: string | null
+			currentRunId: string | null
+		}
+		expect(afterPlatformError).toMatchObject({
+			status: 'error',
+			lastError: 'internal error; reference = 197apho8c3i03ul6hjbbi2b9',
+			consecutiveFailureCount: 0,
+			nextAlarmSource: 'auto-start',
+			currentRunId: null,
+		})
+		expect(created.getAlarmAt()).toBe(startedAt.valueOf())
+
+		mockModule.runBundledModuleWithRegistry.mockResolvedValue({
+			result: { resumed: true },
+			error: null,
+		})
+		await created.instance.alarm()
+		await flushWaitUntilTasks(created.waitUntilTasks)
+		expect(mockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(2)
+		const afterResume = created.persistedEntries.get(
+			'package-service-state',
+		) as { status: string; lastError: string | null }
+		expect(afterResume).toMatchObject({
+			status: 'stopped',
+			lastError: null,
+		})
+
+		mockModule.runBundledModuleWithRegistry.mockResolvedValue({
+			result: null,
+			error: 'service crashed',
+		})
+		const packageCrashAt = new Date('2026-08-19T03:46:35.000Z')
+		vi.setSystemTime(packageCrashAt)
+		const crashStart = await created.instance.fetch(
+			new Request('https://package-service.invalid/service/start', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ binding: serviceBinding }),
+			}),
+		)
+		expect(crashStart.status).toBe(200)
+		await flushWaitUntilTasks(created.waitUntilTasks)
+
+		const afterPackageCrash = created.persistedEntries.get(
+			'package-service-state',
+		) as {
+			status: string
+			lastError: string | null
+			consecutiveFailureCount: number
+			nextAlarmSource: string | null
+		}
+		expect(afterPackageCrash).toMatchObject({
+			status: 'error',
+			lastError: 'service crashed',
+			consecutiveFailureCount: 1,
+		})
+		expect(afterPackageCrash.nextAlarmSource).not.toBe('auto-start')
+
+		mockModule.runBundledModuleWithRegistry.mockClear()
+		await created.instance.alarm()
+		await drainSettledWaitUntilTasks(created.waitUntilTasks)
+		expect(mockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
+	} finally {
+		usageSpy.mockRestore()
+		vi.useRealTimers()
+	}
+})
+
+test('bounded service without autoStart stays down after a platform internal error', async () => {
+	resetMocks()
+	const usageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockResolvedValue(undefined)
+	vi.useFakeTimers()
+	try {
+		vi.setSystemTime(new Date('2026-08-19T03:42:18.000Z'))
+		setupSavedPackage('bounded')
+		mockModule.runBundledModuleWithRegistry.mockResolvedValue({
+			result: null,
+			error: 'internal error; reference = 197apho8c3i03ul6hjbbi2b9',
+		})
+		const created = await createPackageServiceInstance({
+			APP_DB: {},
+		} as Env)
+		const start = await created.instance.fetch(
+			new Request('https://package-service.invalid/service/start', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ binding: serviceBinding }),
+			}),
+		)
+		expect(start.status).toBe(200)
+		await flushWaitUntilTasks(created.waitUntilTasks)
+		const persisted = created.persistedEntries.get('package-service-state') as {
+			status: string
+			nextAlarmSource: string | null
+		}
+		expect(persisted.status).toBe('error')
+		expect(persisted.nextAlarmSource).not.toBe('auto-start')
+
+		mockModule.runBundledModuleWithRegistry.mockClear()
+		await created.instance.alarm()
+		await drainSettledWaitUntilTasks(created.waitUntilTasks)
+		expect(mockModule.runBundledModuleWithRegistry).not.toHaveBeenCalled()
+	} finally {
+		usageSpy.mockRestore()
+		vi.useRealTimers()
+	}
+})
+
 test('running keepalive alarms do not start a second service run', async () => {
 	resetMocks()
 	vi.useFakeTimers()
@@ -708,6 +853,32 @@ test('running keepalive alarms do not start a second service run', async () => {
 	} finally {
 		vi.useRealTimers()
 	}
+})
+
+test('isTransientPackageServicePlatformError matches opaque Cloudflare faults and not package crashes', () => {
+	expect(
+		isTransientPackageServicePlatformError(
+			new Error('internal error; reference = 197apho8c3i03ul6hjbbi2b9'),
+		),
+	).toBe(true)
+	expect(
+		isTransientPackageServicePlatformError(
+			new Error(
+				'D1_ERROR: Internal error in D1 DB storage caused object to be reset; reference = abc123',
+			),
+		),
+	).toBe(true)
+	expect(
+		isTransientPackageServicePlatformError(
+			new Error('Durable Object exceeded its CPU time limit and was reset.'),
+		),
+	).toBe(true)
+	expect(
+		isTransientPackageServicePlatformError(new Error('service crashed')),
+	).toBe(false)
+	expect(
+		isTransientPackageServicePlatformError(new Error('internal error')),
+	).toBe(false)
 })
 
 test('computePackageServiceRetryDelayMs doubles from the base delay to a 15-minute cap with jitter', () => {

--- a/packages/worker/src/package-runtime/package-service.ts
+++ b/packages/worker/src/package-runtime/package-service.ts
@@ -3,11 +3,13 @@ import * as Sentry from '@sentry/cloudflare'
 import { DurableObject } from 'cloudflare:workers'
 import { z } from 'zod'
 import { createMcpCallerContext } from '#mcp/context.ts'
-import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
+import { isRetryableD1LockError } from '#worker/d1-retry.ts'
+import { isTransientDurableObjectResetError } from '#worker/durable-object-reset-retry.ts'
 import {
 	userMeterNamespace,
 	userMeterRpc,
 } from '#worker/entitlements/user-meter-client.ts'
+import { resolveBackgroundMcpUser } from '#worker/identity/background-mcp-user.ts'
 import {
 	getPackageServiceEntryPath,
 	listPackageServices,
@@ -362,6 +364,45 @@ export function computePackageServiceRetryDelayMs(input: {
 function buildPackageServiceRetryTime(consecutiveFailureCount: number) {
 	return new Date(
 		Date.now() + computePackageServiceRetryDelayMs({ consecutiveFailureCount }),
+	)
+}
+
+/**
+ * Opaque Cloudflare faults that kill a service sandbox without giving package
+ * code a chance to `setAlarm`. Same class as Durable Object eviction: a
+ * platform interrupt, not a package crash-loop.
+ */
+export function isTransientPackageServicePlatformError(error: unknown) {
+	return (
+		isRetryableD1LockError(error) || isTransientDurableObjectResetError(error)
+	)
+}
+
+function shouldResumePersistentServiceAfterError(input: {
+	autoStart: boolean
+	mode: PackageServiceState['mode']
+	nextStatus: PackageServiceState['status']
+	platformInterrupt: boolean
+	nextAlarmAt: string | null
+	nextAlarmSource: PackageServiceState['nextAlarmSource']
+}) {
+	if (
+		input.nextAlarmAt &&
+		input.nextAlarmSource !== 'heartbeat' &&
+		input.nextAlarmSource !== 'keepalive'
+	) {
+		return false
+	}
+	if (
+		input.autoStart &&
+		(input.mode !== 'persistent' || input.nextStatus === 'error')
+	) {
+		return true
+	}
+	return (
+		input.mode === 'persistent' &&
+		input.nextStatus === 'error' &&
+		input.platformInterrupt
 	)
 }
 
@@ -791,12 +832,14 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		nextStatus: PackageServiceState['status']
 		lastResult?: unknown
 		lastError?: string | null
+		platformInterrupt?: boolean
 	}) {
 		if (this.stateSnapshot.currentRunId !== input.runId) return
 		const binding = this.stateSnapshot.binding
 		const startedAt = this.stateSnapshot.lastStartedAt
 		const finishedAtMs = Date.now()
 		const stopRequested = this.stateSnapshot.stopRequested
+		const platformInterrupt = input.platformInterrupt === true && !stopRequested
 		this.stateSnapshot.status = input.nextStatus
 		this.stateSnapshot.currentRunId = null
 		this.stateSnapshot.stopRequested = false
@@ -806,10 +849,11 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		if ('lastError' in input) {
 			this.stateSnapshot.lastError = input.lastError ?? null
 		}
-		this.stateSnapshot.consecutiveFailureCount =
-			input.lastError == null
-				? 0
-				: this.stateSnapshot.consecutiveFailureCount + 1
+		if (input.lastError == null) {
+			this.stateSnapshot.consecutiveFailureCount = 0
+		} else if (!platformInterrupt) {
+			this.stateSnapshot.consecutiveFailureCount += 1
+		}
 		this.stateSnapshot.lastRunFinishedAt = new Date(finishedAtMs).toISOString()
 		this.stateSnapshot.lastStoppedAt = this.stateSnapshot.lastRunFinishedAt
 		await this.persistState()
@@ -817,17 +861,22 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 		if (stopRequested) {
 			await this.clearAlarm()
 		} else if (
-			this.stateSnapshot.autoStart &&
-			(this.stateSnapshot.mode !== 'persistent' ||
-				input.nextStatus === 'error') &&
-			(!this.stateSnapshot.nextAlarmAt ||
-				this.stateSnapshot.nextAlarmSource === 'heartbeat' ||
-				this.stateSnapshot.nextAlarmSource === 'keepalive')
+			shouldResumePersistentServiceAfterError({
+				autoStart: this.stateSnapshot.autoStart,
+				mode: this.stateSnapshot.mode,
+				nextStatus: input.nextStatus,
+				platformInterrupt,
+				nextAlarmAt: this.stateSnapshot.nextAlarmAt,
+				nextAlarmSource: this.stateSnapshot.nextAlarmSource,
+			})
 		) {
 			await this.scheduleAlarm({
-				runAt: buildPackageServiceRetryTime(
-					this.stateSnapshot.consecutiveFailureCount,
-				),
+				runAt:
+					platformInterrupt && this.stateSnapshot.mode === 'persistent'
+						? new Date()
+						: buildPackageServiceRetryTime(
+								this.stateSnapshot.consecutiveFailureCount,
+							),
 				source: 'auto-start',
 			})
 		}
@@ -906,6 +955,7 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 				runId: input.runId,
 				nextStatus: this.stateSnapshot.stopRequested ? 'stopped' : 'error',
 				lastError: errorMessage,
+				platformInterrupt: isTransientPackageServicePlatformError(error),
 			})
 		} finally {
 			if (this.activeRunPromise) {
@@ -1375,9 +1425,11 @@ class PackageServiceInstanceBase extends DurableObject<Env> {
 			await this.persistState()
 			await this.projectServiceStateToD1()
 			if (
-				this.stateSnapshot.autoStart &&
 				!this.stateSnapshot.stopRequested &&
-				!this.stateSnapshot.nextAlarmAt
+				!this.stateSnapshot.nextAlarmAt &&
+				(this.stateSnapshot.autoStart ||
+					(this.stateSnapshot.mode === 'persistent' &&
+						isTransientPackageServicePlatformError(error)))
 			) {
 				await this.scheduleAlarm({
 					runAt: buildPackageServiceRetryTime(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Persistent package services (Discord Gateway and other outbound-socket supervisors) should stay up until the user stops them. After #1530 they already resume from Durable Object eviction. They still died for good when Cloudflare killed the sandbox with an opaque `internal error; reference = …` — the package `catch`/`setAlarm` path never ran, and the host left `status=error` with no alarm.

## Summary

- Classify opaque Cloudflare faults (`internal error; reference = …`, Durable Object isolate resets, retryable D1 blips) as **platform interrupts**, not package crash-loops.
- On a persistent service, those faults now reschedule immediately even when `autoStart` is false, matching eviction resume.
- Package-thrown errors still stay down unless `autoStart` or `service.setAlarm` is set.
- Docs in the service pattern guide and request-lifecycle note the new interrupt class.

This is the host-side fix for fingerprint `service:discord:internal-error` (run `90f617ce-70ba-4138-893c-d74d88aa6755`): six successful Discord heartbeats, then a zero-log sandbox death at the next heartbeat interval that stuck `gateway` in `status=error`.

## Testing

- `npx vitest run --project node-unit packages/worker/src/package-runtime/package-service.node.test.ts packages/worker/src/d1-retry.node.test.ts packages/worker/src/durable-object-reset-retry.node.test.ts` — 26 passed
- `npx tsc -b packages/worker/tsconfig-client.json packages/worker/tsconfig-worker-typecheck.json --noEmit` — clean

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends package-services</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `df8165ab` · **Head:** `d029ec53`

**Classification:** extends — persistent service finalization now resumes after host/sandbox platform faults, not only Durable Object eviction.

### Primitives touched

| Primitive          | Group     | Impact                                                                 |
| ------------------ | --------- | ---------------------------------------------------------------------- |
| `package-services` | assistant | extends — resume after opaque Cloudflare faults when `autoStart` is false |
| `package-runtime`  | runtime   | composes — node-unit coverage for the service host                     |

### Change flow

A healthy persistent run that dies inside the sandbox on an opaque Cloudflare fault is finalized as `error` (run record + `lastError` stay) and immediately rescheduled, the same way eviction already resumed.

```mermaid
sequenceDiagram
	participant sandbox as package-runtime
	participant packageServices as package-services
	participant alarm as package-services
	sandbox->>packageServices: sandbox throws internal error; reference = …
	Note over packageServices: lastError kept; consecutiveFailureCount unchanged
	packageServices->>alarm: schedule auto-start now (even if autoStart is false)
	alarm->>sandbox: start a new persistent run
```

### Before / after

**Before:** persistent + `autoStart: false` + sandbox platform fault → `status=error`, `next_alarm_at=null`, stuck until a human `service_start`.

**After:** same fault → `status=error` briefly, immediate `auto-start` alarm, next run can resume from `packageStorage()`.

### Invariants

Per-user service isolation is unchanged. Package-authored throws still do not auto-resume without `autoStart` or `service.setAlarm`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf8b7e0e-5efa-4630-9c96-94514c2ba876?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf8b7e0e-5efa-4630-9c96-94514c2ba876&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

