### PR TITLE
Hide Values from account navigation

### DIFF
--- a/docs/contributing/architecture/values-retirement-runbook.md
+++ b/docs/contributing/architecture/values-retirement-runbook.md
@@ -118,7 +118,9 @@ migrate.
 
 ### Phase 2 — Assisted migration (weeks 2–3)
 
-Goal: remaining rows have an owner and a destination. Reads stay live.
+Goal: remaining rows have an owner and a destination. Reads stay live. The
+account section nav omits Values; `/account/values` stays available for leftover
+rows.
 
 **Platform / Kent packages (can parallelize with outreach):**
 

--- a/docs/guides/values.md
+++ b/docs/guides/values.md
@@ -11,7 +11,8 @@ category: platform
 
 Do not store new named config or state with `value_set`. Existing rows stay
 readable through `value_get` / `value_list` and `/account/values` so you can
-move them. Load this guide before writing or migrating a value.
+move them. The account section nav omits Values; open `/account/values` directly
+during migration. Load this guide before writing or migrating a value.
 
 ## Destination map
 

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -406,7 +406,6 @@ const accountNavItems = [
 	{ href: '/account/jobs', label: 'Jobs' },
 	{ href: '/account/stars', label: 'Stars' },
 	{ href: '/account/secrets', label: 'Secrets' },
-	{ href: '/account/values', label: 'Values' },
 	{ href: '/account/integrations', label: 'Integrations' },
 	{ href: '/account/package-invocation-tokens', label: 'Package tokens' },
 	{ href: '/account/mcp-servers', label: 'MCP servers' },

--- a/packages/worker/client/routes/account-management-metadata.node.test.ts
+++ b/packages/worker/client/routes/account-management-metadata.node.test.ts
@@ -2,6 +2,7 @@ import { jsx } from 'remix/ui/jsx-runtime'
 import { renderToString } from 'remix/ui/server'
 import { expect, test } from 'vitest'
 import {
+	AccountPageHeader,
 	IdValue,
 	MetadataGrid,
 	TimestampValue,
@@ -69,4 +70,20 @@ test('metadata band auto-fits columns and keeps id/timestamp values copyable and
 		jsx(TimestampValue, { value: null, fallback: 'Unknown' }),
 	)
 	expect(missing).toContain('>Unknown</span>')
+})
+
+test('account subnav lists secrets and memories and omits values', async () => {
+	const html = await renderToString(
+		jsx(AccountPageHeader, {
+			title: 'Overview',
+			description: 'Account home',
+			currentHref: '/account',
+		}),
+	)
+
+	expect(html).toContain('aria-label="Account sections"')
+	expect(html).toContain('href="/account/secrets"')
+	expect(html).toContain('href="/account/memories"')
+	expect(html).not.toContain('href="/account/values"')
+	expect(html).not.toContain('>Values</a>')
 })

--- a/packages/worker/client/routes/account-values.tsx
+++ b/packages/worker/client/routes/account-values.tsx
@@ -488,7 +488,7 @@ export function AccountValuesRoute(handle: Handle) {
 			<AccountManagementShell>
 				<AccountPageHeader
 					title="Values"
-					description="Readable non-secret configuration for your account. Values are available to packages and workflows as user-scoped config."
+					description="Leftover readable config while values are retired. This route stays available for migration; it is not listed in account navigation."
 					currentHref={currentHref}
 					actions={
 						<button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep leftover values reachable for migration without presenting Values as a first-class account destination.

## Summary

- Remove the Values item from the account section nav.
- Keep `/account/values`, `/account/values/new`, `/account/values/:valueId`, and `/account/values.json`.
- Update the Values page lede and the values coding guide / retirement runbook so agents open `/account/values` directly.

## Testing

- `npx vitest run --project node-unit packages/worker/client/routes/account-management-metadata.node.test.ts` — 2 passed, including the new assertion that `AccountPageHeader` lists Secrets/Memories and omits `/account/values`.
- `npm run validate` — format, lint, typecheck, primitives, docs temporal, and builds passed. Parallel node/workers/e2e/mcp jobs hit local mock/webServer timeouts; the same node-unit mock files and the workers observability file passed when rerun serially.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `4e5c7450` · **Head:** `eabb99f9`

**Classification:** composes — no primitives added or changed; this PR removes one account-nav wiring entry and leaves the values route in place.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — account section nav omits Values; `/account/values` stays routed |

Unmatched docs: `docs/guides/values.md`, `docs/contributing/architecture/values-retirement-runbook.md` (present-tense note that the nav omits Values).

### Change flow

Signed-in account pages still render `AccountPageHeader`; the Values href is no longer in that list. Direct URL and MCP/account JSON stay available for leftover rows.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open /account/secrets
	appUi-->>User: account section nav without Values
	User->>appUi: open /account/values directly
	appUi-->>User: leftover values list (route kept)
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| Account section nav | Secrets, Values, Integrations, … | Secrets, Integrations, … |
| `/account/values` | Linked from nav | Reachable by URL only |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a18e1a6d-a58a-4c0b-b414-1e7631f38e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a18e1a6d-a58a-4c0b-b414-1e7631f38e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

