### PR TITLE
Fix Remix dotted path params 404ing avatars and account URLs

### DIFF
--- a/packages/worker/client/list-detail-route.node.test.ts
+++ b/packages/worker/client/list-detail-route.node.test.ts
@@ -65,6 +65,15 @@ test('list-detail route helper supports the URL-backed list/detail workflow', ()
 	expect(mcpServersRoute.buildDetailHref('server 1', '?q=docs')).toBe(
 		'/account/mcp-servers/server%201?q=docs',
 	)
+	expect(mcpServersRoute.buildDetailHref('google.personal')).toBe(
+		'/account/mcp-servers/google%2Epersonal',
+	)
+	expect(
+		mcpServersRoute.getSelection('/account/mcp-servers/google%2Epersonal'),
+	).toEqual({
+		selectedId: 'google.personal',
+		isCreating: false,
+	})
 
 	expect(nestedRoute.getSelection('/account/secrets/new')).toEqual({
 		selectedId: null,

--- a/packages/worker/client/list-detail-route.ts
+++ b/packages/worker/client/list-detail-route.ts
@@ -1,3 +1,5 @@
+import { createHref } from 'remix/route-pattern/href'
+
 function decodePathSegment(value: string) {
 	try {
 		return decodeURIComponent(value)
@@ -75,7 +77,10 @@ export function createListDetailRoute(
 	}
 
 	function buildDetailHref(id: string, search = '') {
-		return appendSearch(`${basePath}/${encodeURIComponent(id)}`, search)
+		// Remix treats `.` as a route delimiter, so `encodeURIComponent` is not
+		// enough — `createHref` percent-encodes dots (`%2E`) the same way
+		// `routes.*.href()` does for named routes.
+		return appendSearch(createHref(`${basePath}/:id`, { id }), search)
 	}
 
 	return {

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -47,6 +47,7 @@ import {
 	type AccountJobSchedule,
 	type AccountJobsLoaderData,
 } from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
 import {
 	colors,
 	radius,
@@ -179,7 +180,9 @@ function ownershipValue(
 	if (job.packageId && job.packageName) {
 		return (
 			<a
-				href={`/account/packages/${encodeURIComponent(job.packageId)}`}
+				href={routes.accountPackageDetail.href({
+					packageId: job.packageId,
+				})}
 				mix={css(primaryLinkCss)}
 			>
 				{job.packageName}
@@ -1182,7 +1185,9 @@ export function AccountJobsRoute(handle: Handle) {
 																	})}
 																>
 																	<a
-																		href={`/account/activity/${encodeURIComponent(run.id)}`}
+																		href={routes.accountActivityDetail.href({
+																			runId: run.id,
+																		})}
 																		mix={css(primaryLinkCss)}
 																	>
 																		Logs

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -38,6 +38,7 @@ import {
 	type AdminInsightsRunLogCompleteness,
 	type AdminUsageMetric,
 } from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
 import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
@@ -101,7 +102,7 @@ function formatPressurePercent(value: number) {
 }
 
 function adminUserDetailHref(stableUserId: string) {
-	return `/admin/users/${encodeURIComponent(stableUserId)}`
+	return routes.adminUserDetail.href({ stableUserId })
 }
 
 const runtimeDurationMetricLabels: Record<AdminUsageMetric, string> = {

--- a/packages/worker/src/app/handlers/account-mcp-servers.ts
+++ b/packages/worker/src/app/handlers/account-mcp-servers.ts
@@ -9,7 +9,7 @@ import {
 	readTrimmedStringOrEmpty,
 } from '#app/request-body.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
-import { type routes } from '#universal/routes.ts'
+import { routes } from '#universal/routes.ts'
 import { createMcpClientHubClient } from '#worker/mcp-client/hub-client.ts'
 import { enrichMcpOAuthProviderError } from '#worker/mcp-client/oauth-provider-error.ts'
 import {
@@ -173,11 +173,8 @@ export function createAccountMcpServersOauthCallbackHandler(env: Env) {
 			}
 
 			const target = serverId
-				? new URL(
-						`/account/mcp-servers/${encodeURIComponent(serverId)}`,
-						request.url,
-					)
-				: new URL('/account/mcp-servers', request.url)
+				? new URL(routes.accountMcpServerDetail.href({ serverId }), request.url)
+				: new URL(routes.accountMcpServers.href(), request.url)
 			if (authorizationNeeded) {
 				target.searchParams.set('auth', serverId ? 'required' : 'retry')
 			} else if (authSuccess) {

--- a/packages/worker/src/app/handlers/profile-avatar.node.test.ts
+++ b/packages/worker/src/app/handlers/profile-avatar.node.test.ts
@@ -53,7 +53,7 @@ function createEnv() {
 
 async function runHandler(
 	request: Request,
-	params: { username: string; cacheKey: string },
+	params: { username: string; hash: string; ext: string },
 ) {
 	const handler = createProfileAvatarHandler(createEnv())
 	return handler.handler({
@@ -75,7 +75,7 @@ test('profile avatar cache visibility, anon 404, and cacheKey mismatch', async (
 
 	const publicResponse = await runHandler(
 		new Request('https://example.com/profiles/alice/avatar/abcdef.png'),
-		{ username: 'alice', cacheKey: 'abcdef.png' },
+		{ username: 'alice', hash: 'abcdef', ext: 'png' },
 	)
 	expect(publicResponse.status).toBe(200)
 	expect(publicResponse.headers.get('Cache-Control')).toBe(
@@ -100,7 +100,7 @@ test('profile avatar cache visibility, anon 404, and cacheKey mismatch', async (
 	})
 	const privateResponse = await runHandler(
 		new Request('https://example.com/profiles/alice/avatar/abcdef.png'),
-		{ username: 'alice', cacheKey: 'abcdef.png' },
+		{ username: 'alice', hash: 'abcdef', ext: 'png' },
 	)
 	expect(privateResponse.status).toBe(200)
 	expect(privateResponse.headers.get('Cache-Control')).toBe('private, no-store')
@@ -113,7 +113,7 @@ test('profile avatar cache visibility, anon 404, and cacheKey mismatch', async (
 	mocks.getUserAvatarObject.mockClear()
 	const anonPrivate = await runHandler(
 		new Request('https://example.com/profiles/alice/avatar/abcdef.png'),
-		{ username: 'alice', cacheKey: 'abcdef.png' },
+		{ username: 'alice', hash: 'abcdef', ext: 'png' },
 	)
 	expect(anonPrivate.status).toBe(404)
 	expect(mocks.getUserAvatarObject).not.toHaveBeenCalled()
@@ -122,7 +122,7 @@ test('profile avatar cache visibility, anon 404, and cacheKey mismatch', async (
 	mocks.getUserAvatarObject.mockClear()
 	const mismatch = await runHandler(
 		new Request('https://example.com/profiles/alice/avatar/wrong.png'),
-		{ username: 'alice', cacheKey: 'wrong.png' },
+		{ username: 'alice', hash: 'wrong', ext: 'png' },
 	)
 	expect(mismatch.status).toBe(404)
 	expect(mocks.getUserAvatarObject).not.toHaveBeenCalled()

--- a/packages/worker/src/app/handlers/profile-avatar.ts
+++ b/packages/worker/src/app/handlers/profile-avatar.ts
@@ -21,7 +21,7 @@ export function createProfileAvatarHandler(env: Env) {
 			}
 
 			const cacheKey = parseUserAvatarCacheKey(row.avatar_key)
-			if (!cacheKey || cacheKey !== params.cacheKey) {
+			if (!cacheKey || cacheKey !== `${params.hash}.${params.ext}`) {
 				return new Response('Not found', { status: 404 })
 			}
 

--- a/packages/worker/src/app/router-specificity.node.test.ts
+++ b/packages/worker/src/app/router-specificity.node.test.ts
@@ -61,6 +61,14 @@ test('delimiter-bounded params keep companion suffixes, hyphens, and encoded dot
 	)
 	router.get(routePattern(routes.profile), createStubHandler('profile'))
 	router.get(
+		routePattern(routes.profileAvatar),
+		createStubHandler('profile-avatar'),
+	)
+	router.get(
+		routePattern(routes.profileOgImage),
+		createStubHandler('profile-og'),
+	)
+	router.get(
 		routePattern(routes.accountSecretUserDetail),
 		createStubHandler('secret'),
 	)
@@ -87,6 +95,22 @@ test('delimiter-bounded params keep companion suffixes, hyphens, and encoded dot
 	expect(
 		(await router.fetch(new Request('http://localhost/@john.doe'))).status,
 	).toBe(404)
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/profiles/kentcdodds/avatar/00e495130208345dcc438bce0102f73a6e5cef01085a930c9c9ed2651a67b8d9.jpg',
+				),
+			)
+		).text(),
+	).toBe('profile-avatar')
+	expect(
+		await (
+			await router.fetch(
+				new Request('http://localhost/profiles/alice/og.png'),
+			)
+		).text(),
+	).toBe('profile-og')
 	expect(
 		await (
 			await router.fetch(

--- a/packages/worker/src/app/router-specificity.node.test.ts
+++ b/packages/worker/src/app/router-specificity.node.test.ts
@@ -117,3 +117,93 @@ test('delimiter-bounded params keep companion suffixes, hyphens, and encoded dot
 		).text(),
 	).toBe('secret')
 })
+
+test('single-segment params 404 on raw dots and match href-encoded dots', async () => {
+	const router = createRouter()
+	router.get(
+		routePattern(routes.accountIntegrationDetail),
+		createStubHandler('integration'),
+	)
+	router.get(routePattern(routes.integrationLogo), createStubHandler('logo'))
+	router.get(
+		routePattern(routes.adminPlatformIntegrationDetail),
+		createStubHandler('platform-integration'),
+	)
+	router.get(routePattern(routes.accountJobDetail), createStubHandler('job'))
+	router.get(
+		routePattern(routes.accountActivityDetail),
+		createStubHandler('activity'),
+	)
+
+	expect(
+		(
+			await router.fetch(
+				new Request('http://localhost/account/integrations/google.personal'),
+			)
+		).status,
+	).toBe(404)
+	expect(
+		await (
+			await router.fetch(
+				new Request('http://localhost/account/integrations/google%2Epersonal'),
+			)
+		).text(),
+	).toBe('integration')
+
+	expect(
+		(
+			await router.fetch(
+				new Request('http://localhost/integrations/logos/openai.com'),
+			)
+		).status,
+	).toBe(404)
+	expect(
+		await (
+			await router.fetch(
+				new Request('http://localhost/integrations/logos/openai%2Ecom'),
+			)
+		).text(),
+	).toBe('logo')
+
+	expect(
+		(
+			await router.fetch(
+				new Request('http://localhost/admin/platform-integrations/openai.com'),
+			)
+		).status,
+	).toBe(404)
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/admin/platform-integrations/openai%2Ecom',
+				),
+			)
+		).text(),
+	).toBe('platform-integration')
+
+	expect(
+		(
+			await router.fetch(
+				new Request(
+					'http://localhost/account/jobs/package-job:pkg:daily.backup',
+				),
+			)
+		).status,
+	).toBe(404)
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/account/jobs/package-job%3Apkg%3Adaily%2Ebackup',
+				),
+			)
+		).text(),
+	).toBe('job')
+
+	expect(
+		await (
+			await router.fetch(new Request('http://localhost/account/activity/run-1'))
+		).text(),
+	).toBe('activity')
+})

--- a/packages/worker/src/app/router-specificity.node.test.ts
+++ b/packages/worker/src/app/router-specificity.node.test.ts
@@ -106,9 +106,7 @@ test('delimiter-bounded params keep companion suffixes, hyphens, and encoded dot
 	).toBe('profile-avatar')
 	expect(
 		await (
-			await router.fetch(
-				new Request('http://localhost/profiles/alice/og.png'),
-			)
+			await router.fetch(new Request('http://localhost/profiles/alice/og.png'))
 		).text(),
 	).toBe('profile-og')
 	expect(

--- a/packages/worker/src/community/avatar.node.test.ts
+++ b/packages/worker/src/community/avatar.node.test.ts
@@ -1,10 +1,12 @@
 import { expect, test } from 'vitest'
+import { buildUserAvatarUrl } from './public-urls.ts'
 import {
 	buildUserAvatarR2Key,
 	getUserAvatarObject,
 	parseUserAvatarCacheKey,
 	processUserAvatar,
 	saveUserAvatar,
+	splitUserAvatarCacheKey,
 } from './avatar.ts'
 import { AccountDeletionInProgressError } from '#worker/account/deletion-state.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
@@ -190,6 +192,23 @@ test('buildUserAvatarR2Key and parseUserAvatarCacheKey round-trip content hash s
 		'abcdef.webp',
 	)
 	expect(parseUserAvatarCacheKey('community-icon:v1/listing/asset')).toBeNull()
+	expect(splitUserAvatarCacheKey('abcdef.webp')).toEqual({
+		hash: 'abcdef',
+		ext: 'webp',
+	})
+	expect(splitUserAvatarCacheKey('abcdef')).toBeNull()
+	expect(
+		buildUserAvatarUrl({
+			username: 'alice',
+			avatarKey: 'user-avatars/stable-1/abcdef.jpg',
+		}),
+	).toBe('/profiles/alice/avatar/abcdef.jpg')
+	expect(
+		buildUserAvatarUrl({
+			username: 'alice',
+			avatarKey: null,
+		}),
+	).toBeNull()
 })
 
 test('getUserAvatarObject refuses keys outside the user-avatars prefix', async () => {

--- a/packages/worker/src/community/avatar.ts
+++ b/packages/worker/src/community/avatar.ts
@@ -71,6 +71,17 @@ export function parseUserAvatarCacheKey(avatarKey: string): string | null {
 	return match?.[1] ?? null
 }
 
+export function splitUserAvatarCacheKey(
+	cacheKey: string,
+): { hash: string; ext: string } | null {
+	const lastDot = cacheKey.lastIndexOf('.')
+	if (lastDot <= 0 || lastDot === cacheKey.length - 1) return null
+	return {
+		hash: cacheKey.slice(0, lastDot),
+		ext: cacheKey.slice(lastDot + 1),
+	}
+}
+
 function assertUserAvatarSourceSize(bytes: Uint8Array) {
 	if (bytes.byteLength === 0 || bytes.byteLength > maxUserAvatarSourceBytes) {
 		throw new Error(

--- a/packages/worker/src/community/public-urls.ts
+++ b/packages/worker/src/community/public-urls.ts
@@ -1,5 +1,9 @@
-import { parseUserAvatarCacheKey } from '#worker/community/avatar.ts'
+import {
+	parseUserAvatarCacheKey,
+	splitUserAvatarCacheKey,
+} from '#worker/community/avatar.ts'
 import { parseListingOwnerUsername } from '#universal/community-links.ts'
+import { routes } from '#universal/routes.ts'
 
 export function buildUserAvatarUrl(input: {
 	username: string
@@ -8,7 +12,13 @@ export function buildUserAvatarUrl(input: {
 	if (!input.avatarKey) return null
 	const cacheKey = parseUserAvatarCacheKey(input.avatarKey)
 	if (!cacheKey) return null
-	return `/profiles/${input.username}/avatar/${cacheKey}`
+	const parts = splitUserAvatarCacheKey(cacheKey)
+	if (!parts) return null
+	return routes.profileAvatar.href({
+		username: input.username,
+		hash: parts.hash,
+		ext: parts.ext,
+	})
 }
 
 export function getOwnerUsernameFromListingName(name: string) {

--- a/packages/worker/src/integrations/account-identity.node.test.ts
+++ b/packages/worker/src/integrations/account-identity.node.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest'
+import {
+	buildIntegrationAccountUrl,
+	buildIntegrationReconnectUrl,
+} from './account-identity.ts'
+
+test('account integration URLs encode Remix delimiter dots in names', () => {
+	expect(
+		buildIntegrationAccountUrl({
+			baseUrl: 'https://example.com',
+			integrationName: 'google',
+		}),
+	).toBe('https://example.com/account/integrations/google')
+	expect(
+		buildIntegrationAccountUrl({
+			baseUrl: 'https://example.com',
+			integrationName: 'google.personal',
+		}),
+	).toBe('https://example.com/account/integrations/google%2Epersonal')
+
+	expect(
+		buildIntegrationReconnectUrl({
+			baseUrl: 'https://example.com',
+			integrationName: 'google.personal',
+		}),
+	).toBe('https://example.com/connect/oauth?provider=google.personal')
+})

--- a/packages/worker/src/integrations/account-identity.ts
+++ b/packages/worker/src/integrations/account-identity.ts
@@ -1,3 +1,5 @@
+import { routes } from '#universal/routes.ts'
+
 export function isAccountEmailLabel(value: string | null | undefined) {
 	if (!value) return false
 	const email = value.trim()
@@ -8,7 +10,9 @@ export function buildIntegrationAccountUrl(input: {
 	baseUrl: string
 	integrationName: string
 }) {
-	return `${input.baseUrl}/account/integrations/${encodeURIComponent(input.integrationName)}`
+	return `${input.baseUrl}${routes.accountIntegrationDetail.href({
+		integrationName: input.integrationName,
+	})}`
 }
 
 export function buildIntegrationReconnectUrl(input: {

--- a/packages/worker/src/integrations/platform-app-logo.node.test.ts
+++ b/packages/worker/src/integrations/platform-app-logo.node.test.ts
@@ -138,6 +138,15 @@ test('logo lifecycle uploads, clears, and survives app upserts without touching 
 	expect(updated.logoKey).toMatch(/^platform-oauth-app-logos\/github\//)
 })
 
+test('logo paths encode Remix delimiter dots in slugs', () => {
+	expect(
+		buildPlatformOauthAppLogoPath({
+			slug: 'openai.com',
+			logoKey: 'platform-oauth-app-logos/openai.com/0123456789abcdef.png',
+		}),
+	).toBe('/integrations/logos/openai%2Ecom?v=0123456789abcdef')
+})
+
 test('uploads reject unknown formats and unknown apps', async () => {
 	const harness = createHarness()
 	await provisionApp(harness)

--- a/packages/worker/src/integrations/platform-app-logo.ts
+++ b/packages/worker/src/integrations/platform-app-logo.ts
@@ -1,4 +1,5 @@
 import { toHex } from '@kody-internal/shared/hex.ts'
+import { routes } from '#universal/routes.ts'
 import { processCommunityIcon } from '#worker/community/community-icon.ts'
 import {
 	getPlatformOauthAppBySlug,
@@ -29,9 +30,10 @@ export function buildPlatformOauthAppLogoPath(app: {
 }): string | null {
 	if (!app.logoKey) return null
 	const contentTag = /\/([0-9a-f]{16})[^/]*$/.exec(app.logoKey)?.[1]
-	return `/integrations/logos/${encodeURIComponent(app.slug)}${
-		contentTag ? `?v=${contentTag}` : ''
-	}`
+	return routes.integrationLogo.href(
+		{ integrationSlug: app.slug },
+		contentTag ? { searchParams: { v: contentTag } } : undefined,
+	)
 }
 
 /**

--- a/packages/worker/src/mcp-client/package-subscriptions.ts
+++ b/packages/worker/src/mcp-client/package-subscriptions.ts
@@ -1,4 +1,5 @@
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import { routes } from '#universal/routes.ts'
 import { runWithDynamicWorkerEvaluationBudget } from '#mcp/executor.ts'
 import { readPreExecutionPackageInvocationInfrastructureCode } from '#worker/package-invocations/admin-package-subscriptions.ts'
 import { invokePackageSubscription } from '#worker/package-invocations/service.ts'
@@ -40,7 +41,9 @@ export function buildMcpServerAccountUrl(input: {
 	baseUrl: string
 	serverId: string
 }) {
-	return `${input.baseUrl}/account/mcp-servers/${input.serverId}`
+	return `${input.baseUrl}${routes.accountMcpServerDetail.href({
+		serverId: input.serverId,
+	})}`
 }
 
 function buildSubscriptionIdempotencyKey(input: {

--- a/packages/worker/src/run-records/package-subscriptions.ts
+++ b/packages/worker/src/run-records/package-subscriptions.ts
@@ -1,4 +1,5 @@
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import { routes } from '#universal/routes.ts'
 import { runWithDynamicWorkerEvaluationBudget } from '#mcp/executor.ts'
 import { readPreExecutionPackageInvocationInfrastructureCode } from '#worker/package-invocations/admin-package-subscriptions.ts'
 import { invokePackageSubscription } from '#worker/package-invocations/service.ts'
@@ -78,7 +79,9 @@ function buildSubscriptionIdempotencyKey(input: {
 }
 
 function buildActivityUrl(input: { baseUrl: string; runId: string }) {
-	return `${input.baseUrl}/account/activity/${encodeURIComponent(input.runId)}`
+	return `${input.baseUrl}${routes.accountActivityDetail.href({
+		runId: input.runId,
+	})}`
 }
 
 async function loadMatchingRunErrorSubscriptions(input: {

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -153,7 +153,9 @@ export const routes = route({
 	// APIs, keeping the `/@…` namespace to human-shareable page URLs.
 	communityPackageApi: '/profiles/:username/packages/:kodyId.json',
 	profileApi: '/profiles/:username.json',
-	profileAvatar: '/profiles/:username/avatar/:cacheKey',
+	// `.` is a Remix route delimiter, so the filename must be `:hash.:ext`
+	// (not a single `:cacheKey`) or `/avatar/abc.jpg` never matches.
+	profileAvatar: '/profiles/:username/avatar/:hash.:ext',
 	profileOgImage: '/profiles/:username/og.png',
 	profileFollowApiPost: post('/profiles/:username/follow.json'),
 	webhookIngress: post(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Kent's (and anyone else's) uploaded profile photo should actually render. The same Remix `.` delimiter also 404s other account URLs whose ids can contain dots (integration names like `google.personal`, platform slugs like `openai.com`, job names with dots).

## Summary

Remix treats `.` as a route delimiter. `encodeURIComponent` does not encode `.`, so a single `:param` never matches `hash.jpg` or `google.personal`.

- Avatar route is `/profiles/:username/avatar/:hash.:ext` so existing filename URLs match
- Avatar URLs are generated with `routes.profileAvatar.href()`
- List-detail hrefs now use Remix `createHref` (dots become `%2E`)
- Server URL builders for integrations, platform logos, MCP servers, and activity use `routes.*.href()`
- Secrets already used `href()`; webhooks stay path-split before Remix (unchanged)

Public avatar URLs stay the same, they just start matching. Other account links that used to 404 on dotted ids now encode `%2E`.

Production evidence before this change: `https://kody.codes/profiles/kentcdodds/avatar/00e495130208345dcc438bce0102f73a6e5cef01085a930c9c9ed2651a67b8d9.jpg` returns HTML 404.

## Testing

Preview `kody-pr-1538` at merge commit `70046263` (parent `f53fab73`):

- Seed login `me@kentcdodds.com` / `user-me`
- `POST /account/profile/avatar.json` uploaded a 64×64 PNG; `avatarUrl` is `/profiles/user-me/avatar/<hash>.png`
- `GET` that URL returns `image/png` (155 bytes), not the app HTML 404
- `/account` and `/@user-me` render the avatar (red circle)
- `GET /account/integrations/google.personal` → 404
- `GET /account/integrations/google%2Epersonal` → integrations UI (connection not found, not a 404)
- Same 404 vs match for a dotted job id vs the `%2E` form

Node unit coverage: avatar, list-detail, account-identity, platform-app-logo, router-specificity.

CI on `f53fab73` is green. CodeRabbit reported no actionable comments; Bugbot found no issues.

![Account page avatar](https://cursor.com/artifacts/c/art-fafb009b-303d-4f3c-bd55-fa7769f2f7f3)
![Public profile avatar](https://cursor.com/artifacts/c/art-43587eea-7d9e-46ef-ab7f-501e80c31493)
![Raw dotted integration URL 404](https://cursor.com/artifacts/c/art-029cb7d4-4af7-44e9-9c5a-c79685e4a4b1)
![Encoded dotted integration URL](https://cursor.com/artifacts/c/art-de48e1cf-4b2e-4d12-b4a4-1f4daf358da4)
<a href="https://cursor.com/agents/bc-94f3fcff-f10b-42e6-b292-ecfb6643dfe7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_avatar_and_dotted_routes_ui.mp4"><img src="https://cursor.com/artifacts/c/art-172875d3-1a25-40dc-bbc4-2d6206048310" alt="preview_avatar_and_dotted_routes_ui.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `cc8ee9d4` · **Head:** `f53fab73`

**Classification:** extends — Remix path params that can contain `.` now match, either as `:hash.:ext` (avatars) or as `href()`-encoded `%2E` (account list-detail and related URL builders).

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — avatar route pattern; list-detail and account hrefs encode `.` |
| `community-listings` | assistant | composes — `buildUserAvatarUrl` uses `href()` |
| `integrations` | assistant | composes — integration and logo paths use `href()` |
| `mcp-client-servers` | assistant | composes — MCP account URLs use `href()` |
| `run-records` | storage | composes — activity URLs use `href()` |

### Change flow

Browsers request existing `/avatar/<hash>.<ext>` URLs and dotted account ids; the router now matches instead of returning the app 404 page.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	participant integrations as integrations
	User->>appUi: GET /profiles/:username/avatar/:hash.:ext
	appUi->>communityListings: parse avatar_key and load R2 object
	communityListings-->>appUi: image bytes + content type
	appUi-->>User: 200 image (was HTML 404)
	User->>appUi: GET /account/integrations/google%2Epersonal
	appUi->>integrations: load connection by decoded name
	integrations-->>appUi: integration detail
	appUi-->>User: 200 account page (raw google.personal was 404)
```

### Before / after

```text
before: encodeURIComponent(id)  →  /account/integrations/google.personal  →  Remix 404
after:  routes.*.href({ id })   →  /account/integrations/google%2Epersonal →  match
before: /profiles/:username/avatar/:cacheKey  →  hash.jpg never matches
after:  /profiles/:username/avatar/:hash.:ext →  hash.jpg matches
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94f3fcff-f10b-42e6-b292-ecfb6643dfe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94f3fcff-f10b-42e6-b292-ecfb6643dfe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile avatar URLs now support file extensions, such as `.jpg` and `.png`.
  * Avatar links are generated and validated more reliably from separate image hash and extension values.

* **Bug Fixes**
  * Invalid or mismatched avatar URLs continue to return a not-found response.
  * Added coverage for avatar and Open Graph image route matching, including long filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->