### PR TITLE
Move persistent services off Standard; Pro keeps two

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -557,8 +557,9 @@ Rules:
   across a UTC-day boundary. The retained claim is the idempotency boundary;
   production inbound handling does not call `refundDailyEntitlement`.
 
-- **Boolean allowances** (persistent package services) are modeled as limit `0`
-  (not allowed) vs `1` (allowed) so the numeric contract stays uniform.
+- **Persistent package services** use the same numeric concurrency contract as
+  other counters. Free and Standard are `0` (not allowed). Pro and `max` allow a
+  small number of concurrent persistent runs.
 - **Per-unit size limits** (`email_message_bytes`) compare one candidate value
   against the limit instead of an accumulating count: the enforcement point
   passes the candidate size via `getCurrent` with `requested: 0`. There is no

--- a/packages/worker/client/routes/account-billing.tsx
+++ b/packages/worker/client/routes/account-billing.tsx
@@ -70,7 +70,7 @@ const planTiers: Array<{
 		name: 'Standard',
 		price: '$12/month',
 		annualPrice: '$10/mo billed annually',
-		description: 'Higher daily volume, more services, and persistent ones.',
+		description: 'Higher daily volume and more running services.',
 	},
 	{
 		id: 'pro',
@@ -78,7 +78,7 @@ const planTiers: Array<{
 		price: '$29/month',
 		annualPrice: '$24/mo billed annually',
 		description:
-			'For heavy daily automation — roughly double Standard on every axis.',
+			'For heavy daily automation — roughly double Standard, plus persistent package services.',
 	},
 ]
 

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -145,8 +145,7 @@ export function PricingRoute(handle: Handle) {
 						</p>
 						<p mix={css(planPriceNoteCss)}>$10/mo billed annually</p>
 						<p mix={css(planCopyCss)}>
-							Higher daily volume, more running services, and persistent package
-							services.
+							Higher daily volume and more running services.
 						</p>
 						{renderPaidPlanCta(isSignedIn)}
 					</section>
@@ -163,8 +162,8 @@ export function PricingRoute(handle: Handle) {
 						</p>
 						<p mix={css(planPriceNoteCss)}>$24/mo billed annually</p>
 						<p mix={css(planCopyCss)}>
-							For heavy daily automation — roughly double Standard on every
-							axis.
+							For heavy daily automation — roughly double Standard, plus
+							persistent package services.
 						</p>
 						{renderPaidPlanCta(isSignedIn)}
 					</section>

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -619,7 +619,7 @@ test('assertWithinEntitlement enforces concurrent workflow limits for unresolved
 	})
 })
 
-test('persistent package services deny free and allow standard', async () => {
+test('persistent package services deny free and standard and allow pro', async () => {
 	const userId = await createStableUserIdFromEmail(plannedEmail)
 	const { db } = createEntitlementsTestDb({
 		users: [{ email: plannedEmail, plan: 'free', stable_user_id: userId }],
@@ -645,8 +645,30 @@ test('persistent package services deny free and allow standard', async () => {
 	const standardDb = createEntitlementsTestDb({
 		users: [{ email: plannedEmail, plan: 'standard', stable_user_id: userId }],
 	})
-	await assertWithinEntitlement({
+	const standardDenied = await assertWithinEntitlement({
 		db: standardDb.db,
+		userId,
+		email: plannedEmail,
+		resource: 'persistent_package_services',
+		getCurrent: async () => 0,
+	}).then(
+		() => null,
+		(thrown: unknown) => thrown,
+	)
+	if (!(standardDenied instanceof EntitlementLimitError)) {
+		throw new Error('Expected an EntitlementLimitError for standard.')
+	}
+	expect(standardDenied.details).toMatchObject({
+		resource: 'persistent_package_services',
+		plan: 'standard',
+		limit: 0,
+	})
+
+	const proDb = createEntitlementsTestDb({
+		users: [{ email: plannedEmail, plan: 'pro', stable_user_id: userId }],
+	})
+	await assertWithinEntitlement({
+		db: proDb.db,
 		userId,
 		email: plannedEmail,
 		resource: 'persistent_package_services',

--- a/packages/worker/src/mcp/capabilities/services/service-start.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/services/service-start.node.test.ts
@@ -272,13 +272,43 @@ test('service_start entitlement gating covers plan limits, running skips, and st
 		current: 0,
 	})
 
-	const standardPersistentLimit =
-		planLimits.standard.maxPersistentPackageServices
+	const { env: standardMeterEnv } = createInMemoryUserMeterEnv()
+	const standardError = await serviceStartCapability
+		.handler(
+			{ service_name: 'realtime-supervisor' },
+			{
+				env: {
+					APP_DB: createEntitlementsTestDb({
+						users: [{ email, plan: 'standard' }],
+					}),
+					...standardMeterEnv,
+				} as Env,
+				callerContext,
+			},
+		)
+		.then(
+			() => null,
+			(thrown: unknown) => thrown,
+		)
+	if (!isEntitlementLimitError(standardError)) {
+		throw new Error(
+			'Expected an EntitlementLimitError for standard persistent services.',
+		)
+	}
+	expect(standardError.details).toMatchObject({
+		code: 'entitlement_limit_exceeded',
+		resource: 'persistent_package_services',
+		plan: 'standard',
+		limit: 0,
+		current: 0,
+	})
+
+	const proPersistentLimit = planLimits.pro.maxPersistentPackageServices
 	const { env: persistentMeterEnv } = createInMemoryUserMeterEnv()
 	await seedRunningServicesInMeter(
 		persistentMeterEnv,
 		userId,
-		buildRunningServices(standardPersistentLimit).map((service) => ({
+		buildRunningServices(proPersistentLimit).map((service) => ({
 			...service,
 			mode: 'persistent',
 		})),
@@ -289,7 +319,7 @@ test('service_start entitlement gating covers plan limits, running skips, and st
 			{
 				env: {
 					APP_DB: createEntitlementsTestDb({
-						users: [{ email, plan: 'standard' }],
+						users: [{ email, plan: 'pro' }],
 					}),
 					...persistentMeterEnv,
 				} as Env,
@@ -308,9 +338,9 @@ test('service_start entitlement gating covers plan limits, running skips, and st
 	expect(persistentError.details).toMatchObject({
 		code: 'entitlement_limit_exceeded',
 		resource: 'persistent_package_services',
-		plan: 'standard',
-		limit: standardPersistentLimit,
-		current: standardPersistentLimit,
+		plan: 'pro',
+		limit: proPersistentLimit,
+		current: proPersistentLimit,
 	})
 
 	const { env: boundedMeterEnv } = createInMemoryUserMeterEnv()

--- a/packages/worker/universal/plans.ts
+++ b/packages/worker/universal/plans.ts
@@ -262,7 +262,8 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxSavedPackages: 100,
 		maxScheduledJobs: 50,
 		maxPackageServices: 10,
-		maxPersistentPackageServices: 1,
+		// Always-on DO duration is too expensive for this tier.
+		maxPersistentPackageServices: 0,
 		maxRepoSessions: 200,
 		maxEmailSendsPerDay: 200,
 		maxEmailReceivesPerDay: 1_000,
@@ -280,7 +281,7 @@ export const planLimits: Record<PlanName, PlanLimits> = {
 		maxSavedPackages: 200,
 		maxScheduledJobs: 150,
 		maxPackageServices: 20,
-		maxPersistentPackageServices: 3,
+		maxPersistentPackageServices: 2,
 		maxRepoSessions: 400,
 		maxEmailSendsPerDay: 500,
 		maxEmailReceivesPerDay: 2_000,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop giving Standard a persistent-service slot. One always-on Durable Object is about a third of the $12 plan, so persistent services become a Pro feature (two concurrent slots). Add-ons can come later.

## Summary

- Standard `maxPersistentPackageServices`: `1` → `0`
- Pro `maxPersistentPackageServices`: `3` → `2`
- Free stays `0`; `max` stays `10`
- Pricing and billing copy no longer promise persistent services on Standard
- Entitlement and `service_start` tests follow the new gates

Already-running Standard persistent services are not force-stopped. Eviction/platform resume does not re-check `service_start`, so an existing run can stay up until someone stops it. A new start is denied.

## Testing

- `npx vitest run --project node-unit packages/worker/src/entitlements/entitlements.node.test.ts packages/worker/src/mcp/capabilities/services/service-start.node.test.ts packages/worker/src/app/ssr-render.node.test.ts` — 38 passed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends entitlements</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4e5c7450` · **Head:** `4f733787`

**Classification:** extends — persistent-service concurrency limits change on Standard and Pro.

### Primitives touched

| Primitive              | Group     | Impact                                                                 |
| ---------------------- | --------- | ---------------------------------------------------------------------- |
| `entitlements`         | auth      | extends — Standard persistent cap is 0; Pro cap is 2                   |
| `app-ui`               | surfaces  | composes — pricing and billing copy match the new caps                 |
| `capability-registry`  | assistant | composes — `service_start` tests cover the new Standard/Pro gates      |

### Change flow

`service_start` for a `mode: persistent` service still goes through `assertWithinEntitlement` on `persistent_package_services`; Standard now fails at 0 and Pro fails at 2.

```mermaid
sequenceDiagram
	actor User
	participant mcpServer as mcp-server
	participant entitlements as entitlements
	participant packageServices as package-services
	User->>mcpServer: service_start (persistent)
	mcpServer->>entitlements: assert persistent_package_services
	Note over entitlements: Standard limit 0 · Pro limit 2
	alt Standard or at Pro cap
		entitlements-->>mcpServer: EntitlementLimitError
	else Pro with a free slot
		entitlements-->>mcpServer: ok
		mcpServer->>packageServices: start run
	end
```

### Before / after

| Plan     | Before | After         |
| -------- | ------ | ------------- |
| Free     | 0      | 0 (unchanged) |
| Standard | 1      | **0**         |
| Pro      | 3      | **2**         |
| max      | 10     | 10 (unchanged)|

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e06ee6bf-c3a7-430b-94ee-e93235e3471f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e06ee6bf-c3a7-430b-94ee-e93235e3471f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

