### PR TITLE
Move onboarding checklist dismissal onto users

### DIFF
--- a/docs/contributing/architecture/values-retirement-runbook.md
+++ b/docs/contributing/architecture/values-retirement-runbook.md
@@ -85,10 +85,9 @@ smell leaves the readable store.
 
 1. **Move onboarding dismiss off values.** Add
    `users.onboarding_checklist_dismissed_at` (nullable ISO timestamp). Migration
-   `0015` backfills from `onboardingChecklistDismissed` and deletes those
-   rows. Reads copy any leftover value onto the column; writes go to the
-   column only. The operator account plus six others drop off values without
-   a user action.
+   `0015` backfills from `onboardingChecklistDismissed` and deletes those rows.
+   Reads copy any leftover value onto the column; writes go to the column only.
+   The operator account plus six others drop off values without a user action.
 2. **Move bearer-token-like rows to a secret** (operator). Values entity detail
    prints the stored string; bearer tokens must not live there.
 3. **Tell agents in server instructions.** Keep a `retiringPrimitiveNotices`

--- a/docs/contributing/architecture/values-retirement-runbook.md
+++ b/docs/contributing/architecture/values-retirement-runbook.md
@@ -84,10 +84,11 @@ Goal: the platform stops _creating_ reasons to use values, and the one security
 smell leaves the readable store.
 
 1. **Move onboarding dismiss off values.** Add
-   `users.onboarding_checklist_dismissed_at` (nullable ISO timestamp). Backfill
-   from `onboardingChecklistDismissed`, then stop reading/writing that value
-   name. The operator account plus six others drop off values without a user
-   action.
+   `users.onboarding_checklist_dismissed_at` (nullable ISO timestamp). Migration
+   `0015` backfills from `onboardingChecklistDismissed` and deletes those
+   rows. Reads copy any leftover value onto the column; writes go to the
+   column only. The operator account plus six others drop off values without
+   a user action.
 2. **Move bearer-token-like rows to a secret** (operator). Values entity detail
    prints the stored string; bearer tokens must not live there.
 3. **Tell agents in server instructions.** Keep a `retiringPrimitiveNotices`

--- a/packages/worker/migrations/0015-users-onboarding-checklist-dismissed-at.sql
+++ b/packages/worker/migrations/0015-users-onboarding-checklist-dismissed-at.sql
@@ -1,0 +1,28 @@
+-- Move onboarding checklist dismissal off leftover user values.
+-- Backfill from onboardingChecklistDismissed, then delete those rows.
+-- The stored value is an ISO timestamp; fall back to the row's updated_at.
+
+ALTER TABLE users ADD COLUMN onboarding_checklist_dismissed_at TEXT;
+
+UPDATE users
+SET onboarding_checklist_dismissed_at = (
+	SELECT COALESCE(NULLIF(TRIM(ve.value), ''), ve.updated_at)
+	FROM value_buckets vb
+	INNER JOIN value_entries ve ON ve.bucket_id = vb.id
+	WHERE vb.user_id = users.stable_user_id
+		AND vb.scope = 'user'
+		AND ve.name = 'onboardingChecklistDismissed'
+	LIMIT 1
+)
+WHERE onboarding_checklist_dismissed_at IS NULL
+	AND EXISTS (
+		SELECT 1
+		FROM value_buckets vb
+		INNER JOIN value_entries ve ON ve.bucket_id = vb.id
+		WHERE vb.user_id = users.stable_user_id
+			AND vb.scope = 'user'
+			AND ve.name = 'onboardingChecklistDismissed'
+	);
+
+DELETE FROM value_entries
+WHERE name = 'onboardingChecklistDismissed';

--- a/packages/worker/migrations/0015-users-onboarding-checklist-dismissed-at.sql
+++ b/packages/worker/migrations/0015-users-onboarding-checklist-dismissed-at.sql
@@ -1,6 +1,7 @@
 -- Move onboarding checklist dismissal off leftover user values.
--- Backfill from onboardingChecklistDismissed, then delete those rows.
--- The stored value is an ISO timestamp; fall back to the row's updated_at.
+-- Backfill from onboardingChecklistDismissed, then delete those user-scope rows.
+-- Session/app leftover rows stay intact. The stored value is an ISO timestamp;
+-- fall back to the row's updated_at.
 
 ALTER TABLE users ADD COLUMN onboarding_checklist_dismissed_at TEXT;
 
@@ -25,4 +26,9 @@ WHERE onboarding_checklist_dismissed_at IS NULL
 	);
 
 DELETE FROM value_entries
-WHERE name = 'onboardingChecklistDismissed';
+WHERE name = 'onboardingChecklistDismissed'
+	AND bucket_id IN (
+		SELECT id
+		FROM value_buckets
+		WHERE scope = 'user'
+	);

--- a/packages/worker/src/mcp/onboarding-checklist-migration.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist-migration.node.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+const migrationFileName = '0015-users-onboarding-checklist-dismissed-at.sql'
+const userId = 'a'.repeat(64)
+
+function applyMigrationsBeforeOnboardingColumn(db: DatabaseSync) {
+	for (const fileName of readdirSync(migrationsDirectory)
+		.filter(
+			(fileName) => fileName.endsWith('.sql') && fileName < migrationFileName,
+		)
+		.sort()) {
+		db.exec(readFileSync(new URL(fileName, migrationsDirectory), 'utf8'))
+	}
+}
+
+function applyOnboardingColumnMigration(db: DatabaseSync) {
+	db.exec(readFileSync(new URL(migrationFileName, migrationsDirectory), 'utf8'))
+}
+
+test('0015 backfills user dismissals and leaves non-user leftover rows intact', () => {
+	const db = new DatabaseSync(':memory:')
+	applyMigrationsBeforeOnboardingColumn(db)
+
+	db.prepare(
+		`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
+		 VALUES (?, ?, ?, ?, ?)`,
+	).run(
+		'user-onboarding',
+		'user-onboarding@example.test',
+		'test-password-hash',
+		'2026-08-01T00:00:00.000Z',
+		userId,
+	)
+	db.prepare(
+		`INSERT INTO value_buckets (id, user_id, scope, binding_key, created_at, updated_at)
+		 VALUES (?, ?, ?, '', ?, ?)`,
+	).run(
+		'vb-user',
+		userId,
+		'user',
+		'2026-08-01T00:00:00.000Z',
+		'2026-08-01T00:00:00.000Z',
+	)
+	db.prepare(
+		`INSERT INTO value_buckets (id, user_id, scope, binding_key, created_at, updated_at)
+		 VALUES (?, ?, ?, '', ?, ?)`,
+	).run(
+		'vb-session',
+		userId,
+		'session',
+		'2026-08-01T00:00:00.000Z',
+		'2026-08-01T00:00:00.000Z',
+	)
+	db.prepare(
+		`INSERT INTO value_entries (bucket_id, name, description, value, created_at, updated_at)
+		 VALUES (?, 'onboardingChecklistDismissed', '', ?, ?, ?)`,
+	).run(
+		'vb-user',
+		'2026-08-01T12:00:00.000Z',
+		'2026-08-01T12:00:00.000Z',
+		'2026-08-01T12:00:00.000Z',
+	)
+	db.prepare(
+		`INSERT INTO value_entries (bucket_id, name, description, value, created_at, updated_at)
+		 VALUES (?, 'onboardingChecklistDismissed', '', ?, ?, ?)`,
+	).run(
+		'vb-session',
+		'keep-session',
+		'2026-08-01T12:00:00.000Z',
+		'2026-08-01T12:00:00.000Z',
+	)
+
+	applyOnboardingColumnMigration(db)
+
+	const dismissedAt = db
+		.prepare(
+			`SELECT onboarding_checklist_dismissed_at
+			 FROM users
+			 WHERE stable_user_id = ?`,
+		)
+		.get(userId) as { onboarding_checklist_dismissed_at: string | null }
+	expect(dismissedAt.onboarding_checklist_dismissed_at).toBe(
+		'2026-08-01T12:00:00.000Z',
+	)
+
+	const leftover = db
+		.prepare(
+			`SELECT ve.bucket_id, ve.value, vb.scope
+			 FROM value_entries ve
+			 INNER JOIN value_buckets vb ON vb.id = ve.bucket_id
+			 WHERE ve.name = 'onboardingChecklistDismissed'
+			 ORDER BY vb.scope`,
+		)
+		.all() as Array<{ bucket_id: string; value: string; scope: string }>
+	expect(leftover).toEqual([
+		{ bucket_id: 'vb-session', value: 'keep-session', scope: 'session' },
+	])
+})

--- a/packages/worker/src/mcp/onboarding-checklist.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.node.test.ts
@@ -1,208 +1,208 @@
-import { DatabaseSync } from "node:sqlite";
-import { expect, test } from "vitest";
-import { utcDayKey } from "@kody-internal/shared/date-keys.ts";
-import { applyAllMigrations as applyRepositoryMigrations } from "#worker/test-support/apply-all-migrations.ts";
-import { createD1FromSqlite } from "#worker/test-support/create-d1-from-sqlite.ts";
-import { createInMemoryUserMeterEnv } from "#worker/test-support/user-meter.ts";
-import { upsertIntegration } from "#worker/integrations/service.ts";
-import { insertMemory } from "#mcp/memory/repo.ts";
-import { buildOnboardingSearchNotice } from "#mcp/tools/search-onboarding-notice.ts";
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { upsertIntegration } from '#worker/integrations/service.ts'
+import { insertMemory } from '#mcp/memory/repo.ts'
+import { buildOnboardingSearchNotice } from '#mcp/tools/search-onboarding-notice.ts'
 import {
-  deriveOnboardingChecklist,
-  dismissOnboardingChecklist,
-  readOnboardingChecklistDismissed,
-  userHasSentWelcomeEmail,
-} from "./onboarding-checklist.ts";
+	deriveOnboardingChecklist,
+	dismissOnboardingChecklist,
+	readOnboardingChecklistDismissed,
+	userHasSentWelcomeEmail,
+} from './onboarding-checklist.ts'
 
-const migrationsDirectory = new URL("../../migrations/", import.meta.url);
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
 
 function createEnv() {
-  const sqlite = new DatabaseSync(":memory:");
-  applyRepositoryMigrations(sqlite, migrationsDirectory);
-  const { env: meterEnv, seed } = createInMemoryUserMeterEnv();
-  // MAILBOX is deliberately absent: the mailbox probe must fail open.
-  return {
-    env: { APP_DB: createD1FromSqlite(sqlite), ...meterEnv } as Env,
-    seed,
-  };
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const { env: meterEnv, seed } = createInMemoryUserMeterEnv()
+	// MAILBOX is deliberately absent: the mailbox probe must fail open.
+	return {
+		env: { APP_DB: createD1FromSqlite(sqlite), ...meterEnv } as Env,
+		seed,
+	}
 }
 
-const userId = "a".repeat(64);
+const userId = 'a'.repeat(64)
 
 async function seedUser(db: D1Database, stableUserId = userId) {
-  await db
-    .prepare(
-      `INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
+	await db
+		.prepare(
+			`INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
 			 VALUES (?, ?, ?, ?, ?)`,
-    )
-    .bind(
-      `user-${stableUserId.slice(0, 8)}`,
-      `${stableUserId.slice(0, 8)}@example.test`,
-      "test-password-hash",
-      new Date().toISOString(),
-      stableUserId,
-    )
-    .run();
+		)
+		.bind(
+			`user-${stableUserId.slice(0, 8)}`,
+			`${stableUserId.slice(0, 8)}@example.test`,
+			'test-password-hash',
+			new Date().toISOString(),
+			stableUserId,
+		)
+		.run()
 }
 
 async function readDismissedAt(db: D1Database, stableUserId = userId) {
-  const row = await db
-    .prepare(
-      `SELECT onboarding_checklist_dismissed_at
+	const row = await db
+		.prepare(
+			`SELECT onboarding_checklist_dismissed_at
 			 FROM users
 			 WHERE stable_user_id = ?`,
-    )
-    .bind(stableUserId)
-    .first<{ onboarding_checklist_dismissed_at: string | null }>();
-  return row?.onboarding_checklist_dismissed_at ?? null;
+		)
+		.bind(stableUserId)
+		.first<{ onboarding_checklist_dismissed_at: string | null }>()
+	return row?.onboarding_checklist_dismissed_at ?? null
 }
 
-test("checklist derives from stored signals, fails open on missing bindings, and dismissal round-trips", async () => {
-  const { env } = createEnv();
-  await seedUser(env.APP_DB);
+test('checklist derives from stored signals, fails open on missing bindings, and dismissal round-trips', async () => {
+	const { env } = createEnv()
+	await seedUser(env.APP_DB)
 
-  const fresh = await deriveOnboardingChecklist({
-    env,
-    userId,
-    emailVerified: true,
-    hasMcpClient: true,
-  });
-  expect(fresh.complete).toBe(false);
-  expect(Object.fromEntries(fresh.items.map((i) => [i.id, i.done]))).toEqual({
-    "verify-email": true,
-    "connect-agent": true,
-    // No MAILBOX binding in this env: the probe fails open to "not done".
-    "first-hello": false,
-    "save-memory": false,
-    "connect-integration": false,
-    "install-starter": false,
-  });
+	const fresh = await deriveOnboardingChecklist({
+		env,
+		userId,
+		emailVerified: true,
+		hasMcpClient: true,
+	})
+	expect(fresh.complete).toBe(false)
+	expect(Object.fromEntries(fresh.items.map((i) => [i.id, i.done]))).toEqual({
+		'verify-email': true,
+		'connect-agent': true,
+		// No MAILBOX binding in this env: the probe fails open to "not done".
+		'first-hello': false,
+		'save-memory': false,
+		'connect-integration': false,
+		'install-starter': false,
+	})
 
-  await insertMemory(env.APP_DB, {
-    id: "memory-1",
-    user_id: userId,
-    category: "workflow",
-    status: "active",
-    subject: "Kody user",
-    summary: "Prefers concise answers.",
-    details: "Prefers concise answers.",
-    tags_json: "[]",
-    source_uris_json: "[]",
-    dedupe_key: null,
-    last_accessed_at: null,
-    deleted_at: null,
-  });
-  await upsertIntegration({
-    env,
-    userId,
-    config: {
-      name: "github",
-      tokenUrl: "https://github.com/login/oauth/access_token",
-      flow: "confidential",
-      clientId: "client-id",
-      clientSecretSecretName: "githubClientSecret",
-      accessTokenSecretName: "githubAccessToken",
-      refreshTokenSecretName: "githubRefreshToken",
-      requiredHosts: ["api.github.com"],
-      authorization: {
-        authorizeUrl: "https://github.com/login/oauth/authorize",
-        scopes: ["read:user"],
-        scopeSeparator: null,
-        extraAuthorizeParams: {},
-      },
-    },
-  });
+	await insertMemory(env.APP_DB, {
+		id: 'memory-1',
+		user_id: userId,
+		category: 'workflow',
+		status: 'active',
+		subject: 'Kody user',
+		summary: 'Prefers concise answers.',
+		details: 'Prefers concise answers.',
+		tags_json: '[]',
+		source_uris_json: '[]',
+		dedupe_key: null,
+		last_accessed_at: null,
+		deleted_at: null,
+	})
+	await upsertIntegration({
+		env,
+		userId,
+		config: {
+			name: 'github',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			flow: 'confidential',
+			clientId: 'client-id',
+			clientSecretSecretName: 'githubClientSecret',
+			accessTokenSecretName: 'githubAccessToken',
+			refreshTokenSecretName: 'githubRefreshToken',
+			requiredHosts: ['api.github.com'],
+			authorization: {
+				authorizeUrl: 'https://github.com/login/oauth/authorize',
+				scopes: ['read:user'],
+				scopeSeparator: null,
+				extraAuthorizeParams: {},
+			},
+		},
+	})
 
-  const progressed = await deriveOnboardingChecklist({
-    env,
-    userId,
-    emailVerified: true,
-    hasMcpClient: true,
-  });
-  const doneById = Object.fromEntries(
-    progressed.items.map((i) => [i.id, i.done]),
-  );
-  expect(doneById["save-memory"]).toBe(true);
-  expect(doneById["connect-integration"]).toBe(true);
-  expect(progressed.complete).toBe(false);
+	const progressed = await deriveOnboardingChecklist({
+		env,
+		userId,
+		emailVerified: true,
+		hasMcpClient: true,
+	})
+	const doneById = Object.fromEntries(
+		progressed.items.map((i) => [i.id, i.done]),
+	)
+	expect(doneById['save-memory']).toBe(true)
+	expect(doneById['connect-integration']).toBe(true)
+	expect(progressed.complete).toBe(false)
 
-  // Dismissal writes the users column and round-trips without a leftover value.
-  expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(false);
-  await dismissOnboardingChecklist({ env, userId });
-  expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true);
-  expect(await readDismissedAt(env.APP_DB)).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-});
+	// Dismissal writes the users column and round-trips without a leftover value.
+	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(false)
+	await dismissOnboardingChecklist({ env, userId })
+	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true)
+	expect(await readDismissedAt(env.APP_DB)).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+})
 
-test("search onboarding notice points at /onboarding and goes quiet after dismissal", async () => {
-  const { env } = createEnv();
-  await seedUser(env.APP_DB);
+test('search onboarding notice points at /onboarding and goes quiet after dismissal', async () => {
+	const { env } = createEnv()
+	await seedUser(env.APP_DB)
 
-  const notice = await buildOnboardingSearchNotice({
-    env,
-    userId,
-    baseUrl: "https://kody.example",
-  });
-  expect(notice).toContain("https://kody.example/onboarding");
-  expect(typeof notice).toBe("string");
-  expect(notice!.length).toBeGreaterThan(0);
+	const notice = await buildOnboardingSearchNotice({
+		env,
+		userId,
+		baseUrl: 'https://kody.example',
+	})
+	expect(notice).toContain('https://kody.example/onboarding')
+	expect(typeof notice).toBe('string')
+	expect(notice!.length).toBeGreaterThan(0)
 
-  await dismissOnboardingChecklist({ env, userId });
-  expect(
-    await buildOnboardingSearchNotice({
-      env,
-      userId,
-      baseUrl: "https://kody.example",
-    }),
-  ).toBe(null);
-});
+	await dismissOnboardingChecklist({ env, userId })
+	expect(
+		await buildOnboardingSearchNotice({
+			env,
+			userId,
+			baseUrl: 'https://kody.example',
+		}),
+	).toBe(null)
+})
 
-test("first-win Send is done when email_send meter counts even without mailbox", async () => {
-  const now = new Date("2026-08-08T15:00:00.000Z");
-  const fresh = createEnv();
-  expect(await userHasSentWelcomeEmail({ env: fresh.env, userId, now })).toBe(
-    false,
-  );
+test('first-win Send is done when email_send meter counts even without mailbox', async () => {
+	const now = new Date('2026-08-08T15:00:00.000Z')
+	const fresh = createEnv()
+	expect(await userHasSentWelcomeEmail({ env: fresh.env, userId, now })).toBe(
+		false,
+	)
 
-  const { env, seed } = createEnv();
-  await seed({
-    userId,
-    resource: "email_sends_per_day",
-    day: utcDayKey(now),
-    count: 1,
-  });
-  expect(await userHasSentWelcomeEmail({ env, userId, now })).toBe(true);
-  expect(
-    await userHasSentWelcomeEmail({ env, userId: "b".repeat(64), now }),
-  ).toBe(false);
-});
+	const { env, seed } = createEnv()
+	await seed({
+		userId,
+		resource: 'email_sends_per_day',
+		day: utcDayKey(now),
+		count: 1,
+	})
+	expect(await userHasSentWelcomeEmail({ env, userId, now })).toBe(true)
+	expect(
+		await userHasSentWelcomeEmail({ env, userId: 'b'.repeat(64), now }),
+	).toBe(false)
+})
 
-test("leftover onboardingChecklistDismissed value copies onto the users column", async () => {
-  const { env } = createEnv();
-  await seedUser(env.APP_DB);
-  await env.APP_DB.prepare(
-    `INSERT INTO value_buckets (id, user_id, scope, binding_key, created_at, updated_at)
+test('leftover onboardingChecklistDismissed value copies onto the users column', async () => {
+	const { env } = createEnv()
+	await seedUser(env.APP_DB)
+	await env.APP_DB.prepare(
+		`INSERT INTO value_buckets (id, user_id, scope, binding_key, created_at, updated_at)
 		 VALUES (?, ?, 'user', '', ?, ?)`,
-  )
-    .bind(
-      "vb-onboarding",
-      userId,
-      "2026-08-01T00:00:00.000Z",
-      "2026-08-01T00:00:00.000Z",
-    )
-    .run();
-  await env.APP_DB.prepare(
-    `INSERT INTO value_entries (bucket_id, name, description, value, created_at, updated_at)
+	)
+		.bind(
+			'vb-onboarding',
+			userId,
+			'2026-08-01T00:00:00.000Z',
+			'2026-08-01T00:00:00.000Z',
+		)
+		.run()
+	await env.APP_DB.prepare(
+		`INSERT INTO value_entries (bucket_id, name, description, value, created_at, updated_at)
 		 VALUES (?, 'onboardingChecklistDismissed', '', ?, ?, ?)`,
-  )
-    .bind(
-      "vb-onboarding",
-      "2026-08-01T12:00:00.000Z",
-      "2026-08-01T12:00:00.000Z",
-      "2026-08-01T12:00:00.000Z",
-    )
-    .run();
+	)
+		.bind(
+			'vb-onboarding',
+			'2026-08-01T12:00:00.000Z',
+			'2026-08-01T12:00:00.000Z',
+			'2026-08-01T12:00:00.000Z',
+		)
+		.run()
 
-  expect(await readDismissedAt(env.APP_DB)).toBe(null);
-  expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true);
-  expect(await readDismissedAt(env.APP_DB)).toBe("2026-08-01T12:00:00.000Z");
-});
+	expect(await readDismissedAt(env.APP_DB)).toBe(null)
+	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true)
+	expect(await readDismissedAt(env.APP_DB)).toBe('2026-08-01T12:00:00.000Z')
+})

--- a/packages/worker/src/mcp/onboarding-checklist.node.test.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.node.test.ts
@@ -1,146 +1,208 @@
-import { DatabaseSync } from 'node:sqlite'
-import { expect, test } from 'vitest'
-import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
-import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
-import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
-import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
-import { upsertIntegration } from '#worker/integrations/service.ts'
-import { insertMemory } from '#mcp/memory/repo.ts'
-import { buildOnboardingSearchNotice } from '#mcp/tools/search-onboarding-notice.ts'
+import { DatabaseSync } from "node:sqlite";
+import { expect, test } from "vitest";
+import { utcDayKey } from "@kody-internal/shared/date-keys.ts";
+import { applyAllMigrations as applyRepositoryMigrations } from "#worker/test-support/apply-all-migrations.ts";
+import { createD1FromSqlite } from "#worker/test-support/create-d1-from-sqlite.ts";
+import { createInMemoryUserMeterEnv } from "#worker/test-support/user-meter.ts";
+import { upsertIntegration } from "#worker/integrations/service.ts";
+import { insertMemory } from "#mcp/memory/repo.ts";
+import { buildOnboardingSearchNotice } from "#mcp/tools/search-onboarding-notice.ts";
 import {
-	deriveOnboardingChecklist,
-	dismissOnboardingChecklist,
-	readOnboardingChecklistDismissed,
-	userHasSentWelcomeEmail,
-} from './onboarding-checklist.ts'
+  deriveOnboardingChecklist,
+  dismissOnboardingChecklist,
+  readOnboardingChecklistDismissed,
+  userHasSentWelcomeEmail,
+} from "./onboarding-checklist.ts";
 
-const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+const migrationsDirectory = new URL("../../migrations/", import.meta.url);
 
 function createEnv() {
-	const sqlite = new DatabaseSync(':memory:')
-	applyRepositoryMigrations(sqlite, migrationsDirectory)
-	const { env: meterEnv, seed } = createInMemoryUserMeterEnv()
-	// MAILBOX is deliberately absent: the mailbox probe must fail open.
-	return {
-		env: { APP_DB: createD1FromSqlite(sqlite), ...meterEnv } as Env,
-		seed,
-	}
+  const sqlite = new DatabaseSync(":memory:");
+  applyRepositoryMigrations(sqlite, migrationsDirectory);
+  const { env: meterEnv, seed } = createInMemoryUserMeterEnv();
+  // MAILBOX is deliberately absent: the mailbox probe must fail open.
+  return {
+    env: { APP_DB: createD1FromSqlite(sqlite), ...meterEnv } as Env,
+    seed,
+  };
 }
 
-const userId = 'a'.repeat(64)
+const userId = "a".repeat(64);
 
-test('checklist derives from stored signals, fails open on missing bindings, and dismissal round-trips', async () => {
-	const { env } = createEnv()
+async function seedUser(db: D1Database, stableUserId = userId) {
+  await db
+    .prepare(
+      `INSERT INTO users (username, email, password_hash, email_verified_at, stable_user_id)
+			 VALUES (?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      `user-${stableUserId.slice(0, 8)}`,
+      `${stableUserId.slice(0, 8)}@example.test`,
+      "test-password-hash",
+      new Date().toISOString(),
+      stableUserId,
+    )
+    .run();
+}
 
-	const fresh = await deriveOnboardingChecklist({
-		env,
-		userId,
-		emailVerified: true,
-		hasMcpClient: true,
-	})
-	expect(fresh.complete).toBe(false)
-	expect(Object.fromEntries(fresh.items.map((i) => [i.id, i.done]))).toEqual({
-		'verify-email': true,
-		'connect-agent': true,
-		// No MAILBOX binding in this env: the probe fails open to "not done".
-		'first-hello': false,
-		'save-memory': false,
-		'connect-integration': false,
-		'install-starter': false,
-	})
+async function readDismissedAt(db: D1Database, stableUserId = userId) {
+  const row = await db
+    .prepare(
+      `SELECT onboarding_checklist_dismissed_at
+			 FROM users
+			 WHERE stable_user_id = ?`,
+    )
+    .bind(stableUserId)
+    .first<{ onboarding_checklist_dismissed_at: string | null }>();
+  return row?.onboarding_checklist_dismissed_at ?? null;
+}
 
-	await insertMemory(env.APP_DB, {
-		id: 'memory-1',
-		user_id: userId,
-		category: 'workflow',
-		status: 'active',
-		subject: 'Kody user',
-		summary: 'Prefers concise answers.',
-		details: 'Prefers concise answers.',
-		tags_json: '[]',
-		source_uris_json: '[]',
-		dedupe_key: null,
-		last_accessed_at: null,
-		deleted_at: null,
-	})
-	await upsertIntegration({
-		env,
-		userId,
-		config: {
-			name: 'github',
-			tokenUrl: 'https://github.com/login/oauth/access_token',
-			flow: 'confidential',
-			clientId: 'client-id',
-			clientSecretSecretName: 'githubClientSecret',
-			accessTokenSecretName: 'githubAccessToken',
-			refreshTokenSecretName: 'githubRefreshToken',
-			requiredHosts: ['api.github.com'],
-			authorization: {
-				authorizeUrl: 'https://github.com/login/oauth/authorize',
-				scopes: ['read:user'],
-				scopeSeparator: null,
-				extraAuthorizeParams: {},
-			},
-		},
-	})
+test("checklist derives from stored signals, fails open on missing bindings, and dismissal round-trips", async () => {
+  const { env } = createEnv();
+  await seedUser(env.APP_DB);
 
-	const progressed = await deriveOnboardingChecklist({
-		env,
-		userId,
-		emailVerified: true,
-		hasMcpClient: true,
-	})
-	const doneById = Object.fromEntries(
-		progressed.items.map((i) => [i.id, i.done]),
-	)
-	expect(doneById['save-memory']).toBe(true)
-	expect(doneById['connect-integration']).toBe(true)
-	expect(progressed.complete).toBe(false)
+  const fresh = await deriveOnboardingChecklist({
+    env,
+    userId,
+    emailVerified: true,
+    hasMcpClient: true,
+  });
+  expect(fresh.complete).toBe(false);
+  expect(Object.fromEntries(fresh.items.map((i) => [i.id, i.done]))).toEqual({
+    "verify-email": true,
+    "connect-agent": true,
+    // No MAILBOX binding in this env: the probe fails open to "not done".
+    "first-hello": false,
+    "save-memory": false,
+    "connect-integration": false,
+    "install-starter": false,
+  });
 
-	// Dismissal is a user-scoped value that round-trips.
-	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(false)
-	await dismissOnboardingChecklist({ env, userId })
-	expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true)
-})
+  await insertMemory(env.APP_DB, {
+    id: "memory-1",
+    user_id: userId,
+    category: "workflow",
+    status: "active",
+    subject: "Kody user",
+    summary: "Prefers concise answers.",
+    details: "Prefers concise answers.",
+    tags_json: "[]",
+    source_uris_json: "[]",
+    dedupe_key: null,
+    last_accessed_at: null,
+    deleted_at: null,
+  });
+  await upsertIntegration({
+    env,
+    userId,
+    config: {
+      name: "github",
+      tokenUrl: "https://github.com/login/oauth/access_token",
+      flow: "confidential",
+      clientId: "client-id",
+      clientSecretSecretName: "githubClientSecret",
+      accessTokenSecretName: "githubAccessToken",
+      refreshTokenSecretName: "githubRefreshToken",
+      requiredHosts: ["api.github.com"],
+      authorization: {
+        authorizeUrl: "https://github.com/login/oauth/authorize",
+        scopes: ["read:user"],
+        scopeSeparator: null,
+        extraAuthorizeParams: {},
+      },
+    },
+  });
 
-test('search onboarding notice points at /onboarding and goes quiet after dismissal', async () => {
-	const { env } = createEnv()
+  const progressed = await deriveOnboardingChecklist({
+    env,
+    userId,
+    emailVerified: true,
+    hasMcpClient: true,
+  });
+  const doneById = Object.fromEntries(
+    progressed.items.map((i) => [i.id, i.done]),
+  );
+  expect(doneById["save-memory"]).toBe(true);
+  expect(doneById["connect-integration"]).toBe(true);
+  expect(progressed.complete).toBe(false);
 
-	const notice = await buildOnboardingSearchNotice({
-		env,
-		userId,
-		baseUrl: 'https://kody.example',
-	})
-	expect(notice).toContain('https://kody.example/onboarding')
-	expect(typeof notice).toBe('string')
-	expect(notice!.length).toBeGreaterThan(0)
+  // Dismissal writes the users column and round-trips without a leftover value.
+  expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(false);
+  await dismissOnboardingChecklist({ env, userId });
+  expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true);
+  expect(await readDismissedAt(env.APP_DB)).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+});
 
-	await dismissOnboardingChecklist({ env, userId })
-	expect(
-		await buildOnboardingSearchNotice({
-			env,
-			userId,
-			baseUrl: 'https://kody.example',
-		}),
-	).toBe(null)
-})
+test("search onboarding notice points at /onboarding and goes quiet after dismissal", async () => {
+  const { env } = createEnv();
+  await seedUser(env.APP_DB);
 
-test('first-win Send is done when email_send meter counts even without mailbox', async () => {
-	const now = new Date('2026-08-08T15:00:00.000Z')
-	const fresh = createEnv()
-	expect(await userHasSentWelcomeEmail({ env: fresh.env, userId, now })).toBe(
-		false,
-	)
+  const notice = await buildOnboardingSearchNotice({
+    env,
+    userId,
+    baseUrl: "https://kody.example",
+  });
+  expect(notice).toContain("https://kody.example/onboarding");
+  expect(typeof notice).toBe("string");
+  expect(notice!.length).toBeGreaterThan(0);
 
-	const { env, seed } = createEnv()
-	await seed({
-		userId,
-		resource: 'email_sends_per_day',
-		day: utcDayKey(now),
-		count: 1,
-	})
-	expect(await userHasSentWelcomeEmail({ env, userId, now })).toBe(true)
-	expect(
-		await userHasSentWelcomeEmail({ env, userId: 'b'.repeat(64), now }),
-	).toBe(false)
-})
+  await dismissOnboardingChecklist({ env, userId });
+  expect(
+    await buildOnboardingSearchNotice({
+      env,
+      userId,
+      baseUrl: "https://kody.example",
+    }),
+  ).toBe(null);
+});
+
+test("first-win Send is done when email_send meter counts even without mailbox", async () => {
+  const now = new Date("2026-08-08T15:00:00.000Z");
+  const fresh = createEnv();
+  expect(await userHasSentWelcomeEmail({ env: fresh.env, userId, now })).toBe(
+    false,
+  );
+
+  const { env, seed } = createEnv();
+  await seed({
+    userId,
+    resource: "email_sends_per_day",
+    day: utcDayKey(now),
+    count: 1,
+  });
+  expect(await userHasSentWelcomeEmail({ env, userId, now })).toBe(true);
+  expect(
+    await userHasSentWelcomeEmail({ env, userId: "b".repeat(64), now }),
+  ).toBe(false);
+});
+
+test("leftover onboardingChecklistDismissed value copies onto the users column", async () => {
+  const { env } = createEnv();
+  await seedUser(env.APP_DB);
+  await env.APP_DB.prepare(
+    `INSERT INTO value_buckets (id, user_id, scope, binding_key, created_at, updated_at)
+		 VALUES (?, ?, 'user', '', ?, ?)`,
+  )
+    .bind(
+      "vb-onboarding",
+      userId,
+      "2026-08-01T00:00:00.000Z",
+      "2026-08-01T00:00:00.000Z",
+    )
+    .run();
+  await env.APP_DB.prepare(
+    `INSERT INTO value_entries (bucket_id, name, description, value, created_at, updated_at)
+		 VALUES (?, 'onboardingChecklistDismissed', '', ?, ?, ?)`,
+  )
+    .bind(
+      "vb-onboarding",
+      "2026-08-01T12:00:00.000Z",
+      "2026-08-01T12:00:00.000Z",
+      "2026-08-01T12:00:00.000Z",
+    )
+    .run();
+
+  expect(await readDismissedAt(env.APP_DB)).toBe(null);
+  expect(await readOnboardingChecklistDismissed({ env, userId })).toBe(true);
+  expect(await readDismissedAt(env.APP_DB)).toBe("2026-08-01T12:00:00.000Z");
+});

--- a/packages/worker/src/mcp/onboarding-checklist.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.ts
@@ -1,37 +1,38 @@
-import { countInternalUserEmailMessages } from '#worker/email/mailbox-internal-read.ts'
+import { countInternalUserEmailMessages } from "#worker/email/mailbox-internal-read.ts";
 import {
-	readCurrentEntitlementResourceUsage,
-	type EntitlementUsageEnv,
-} from '#worker/entitlements/service.ts'
-import { listIntegrations } from '#worker/integrations/service.ts'
-import { listMemoriesByUserId } from '#mcp/memory/repo.ts'
-import { getValue, saveValue } from '#mcp/values/service.ts'
+  readCurrentEntitlementResourceUsage,
+  type EntitlementUsageEnv,
+} from "#worker/entitlements/service.ts";
+import { listIntegrations } from "#worker/integrations/service.ts";
+import { listMemoriesByUserId } from "#mcp/memory/repo.ts";
+import { getValue } from "#mcp/values/service.ts";
 import {
-	type OnboardingChecklistItem,
-	type OnboardingChecklistItemId,
-} from '#universal/onboarding-checklist-types.ts'
+  type OnboardingChecklistItem,
+  type OnboardingChecklistItemId,
+} from "#universal/onboarding-checklist-types.ts";
 
 /**
  * Derived onboarding progress. Every item is computed from data the platform
- * already stores — the only persisted state is the dismissal, kept as a
- * user-scoped value so it survives across devices and agents.
+ * already stores. Dismissal lives on `users.onboarding_checklist_dismissed_at`.
+ * Leftover `onboardingChecklistDismissed` values are copied on read until
+ * migration 0015 deletes those rows.
  */
 
-export type { OnboardingChecklistItem, OnboardingChecklistItemId }
+export type { OnboardingChecklistItem, OnboardingChecklistItemId };
 
 export type OnboardingChecklist = {
-	items: Array<OnboardingChecklistItem>
-	complete: boolean
-}
+  items: Array<OnboardingChecklistItem>;
+  complete: boolean;
+};
 
 export const onboardingChecklistDismissedValueName =
-	'onboardingChecklistDismissed'
+  "onboardingChecklistDismissed";
 
 /** User-scope value lookups bind with no session or app. */
-const userScopedStorageContext = { sessionId: null, appId: null }
+const userScopedStorageContext = { sessionId: null, appId: null };
 
-export type OnboardingChecklistEnv = Pick<Env, 'APP_DB'> &
-	EntitlementUsageEnv & { MAILBOX: Env['MAILBOX'] }
+export type OnboardingChecklistEnv = Pick<Env, "APP_DB"> &
+  EntitlementUsageEnv & { MAILBOX: Env["MAILBOX"] };
 
 /**
  * First-win Send sub-step: a successful `email_send` (UserMeter daily count)
@@ -43,26 +44,26 @@ export type OnboardingChecklistEnv = Pick<Env, 'APP_DB'> &
  * blip never marks Send done.
  */
 export async function userHasSentWelcomeEmail(input: {
-	env: OnboardingChecklistEnv
-	userId: string
-	now?: Date
+  env: OnboardingChecklistEnv;
+  userId: string;
+  now?: Date;
 }): Promise<boolean> {
-	const now = input.now ?? new Date()
-	const [outboundMail, emailSendsToday] = await Promise.all([
-		countInternalUserEmailMessages({
-			env: input.env,
-			ownerId: input.userId,
-			filters: { direction: 'outbound' },
-		}).catch(() => 0),
-		readCurrentEntitlementResourceUsage({
-			db: input.env.APP_DB,
-			env: input.env,
-			userId: input.userId,
-			resource: 'email_sends_per_day',
-			now,
-		}).catch(() => 0),
-	])
-	return outboundMail > 0 || emailSendsToday > 0
+  const now = input.now ?? new Date();
+  const [outboundMail, emailSendsToday] = await Promise.all([
+    countInternalUserEmailMessages({
+      env: input.env,
+      ownerId: input.userId,
+      filters: { direction: "outbound" },
+    }).catch(() => 0),
+    readCurrentEntitlementResourceUsage({
+      db: input.env.APP_DB,
+      env: input.env,
+      userId: input.userId,
+      resource: "email_sends_per_day",
+      now,
+    }).catch(() => 0),
+  ]);
+  return outboundMail > 0 || emailSendsToday > 0;
 }
 
 /**
@@ -74,79 +75,112 @@ export async function userHasSentWelcomeEmail(input: {
  * onboarding surfaces.
  */
 export async function deriveOnboardingChecklist(input: {
-	env: OnboardingChecklistEnv
-	userId: string
-	emailVerified: boolean
-	hasMcpClient: boolean
-	now?: Date
+  env: OnboardingChecklistEnv;
+  userId: string;
+  emailVerified: boolean;
+  hasMcpClient: boolean;
+  now?: Date;
 }): Promise<OnboardingChecklist> {
-	const { env, userId } = input
-	const now = input.now ?? new Date()
-	const [inboundMail, memories, integrations, savedPackages] =
-		await Promise.all([
-			countInternalUserEmailMessages({
-				env,
-				ownerId: userId,
-				filters: { direction: 'inbound' },
-			}).catch(() => 0),
-			listMemoriesByUserId(env.APP_DB, userId, {
-				limit: 1,
-				statuses: ['active'],
-			}).catch(() => []),
-			listIntegrations({ env, userId }).catch(() => [] as Array<unknown>),
-			readCurrentEntitlementResourceUsage({
-				db: env.APP_DB,
-				env,
-				userId,
-				resource: 'saved_packages',
-				now,
-			}).catch(() => 0),
-		])
+  const { env, userId } = input;
+  const now = input.now ?? new Date();
+  const [inboundMail, memories, integrations, savedPackages] =
+    await Promise.all([
+      countInternalUserEmailMessages({
+        env,
+        ownerId: userId,
+        filters: { direction: "inbound" },
+      }).catch(() => 0),
+      listMemoriesByUserId(env.APP_DB, userId, {
+        limit: 1,
+        statuses: ["active"],
+      }).catch(() => []),
+      listIntegrations({ env, userId }).catch(() => [] as Array<unknown>),
+      readCurrentEntitlementResourceUsage({
+        db: env.APP_DB,
+        env,
+        userId,
+        resource: "saved_packages",
+        now,
+      }).catch(() => 0),
+    ]);
 
-	const items: Array<OnboardingChecklistItem> = [
-		{ id: 'verify-email', done: input.emailVerified },
-		{ id: 'connect-agent', done: input.hasMcpClient },
-		{ id: 'first-hello', done: inboundMail > 0 },
-		{ id: 'save-memory', done: memories.length > 0 },
-		{ id: 'connect-integration', done: integrations.length > 0 },
-		{ id: 'install-starter', done: savedPackages > 0 },
-	]
-	return {
-		items,
-		complete: items.every((item) => item.done),
-	}
+  const items: Array<OnboardingChecklistItem> = [
+    { id: "verify-email", done: input.emailVerified },
+    { id: "connect-agent", done: input.hasMcpClient },
+    { id: "first-hello", done: inboundMail > 0 },
+    { id: "save-memory", done: memories.length > 0 },
+    { id: "connect-integration", done: integrations.length > 0 },
+    { id: "install-starter", done: savedPackages > 0 },
+  ];
+  return {
+    items,
+    complete: items.every((item) => item.done),
+  };
 }
 
 export async function readOnboardingChecklistDismissed(input: {
-	env: Pick<Env, 'APP_DB'>
-	userId: string
+  env: Pick<Env, "APP_DB">;
+  userId: string;
 }): Promise<boolean> {
-	try {
-		const value = await getValue({
-			env: input.env,
-			userId: input.userId,
-			storageContext: userScopedStorageContext,
-			scope: 'user',
-			name: onboardingChecklistDismissedValueName,
-		})
-		return value !== null
-	} catch {
-		return false
-	}
+  try {
+    const column = await readDismissedAtColumn(input.env.APP_DB, input.userId);
+    if (column) return true;
+
+    const leftover = await getValue({
+      env: input.env,
+      userId: input.userId,
+      storageContext: userScopedStorageContext,
+      scope: "user",
+      name: onboardingChecklistDismissedValueName,
+    });
+    if (!leftover) return false;
+
+    const dismissedAt =
+      leftover.value.trim() || leftover.updatedAt || new Date().toISOString();
+    await writeDismissedAtColumn(input.env.APP_DB, input.userId, dismissedAt);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function dismissOnboardingChecklist(input: {
-	env: Pick<Env, 'APP_DB'> & Parameters<typeof saveValue>[0]['env']
-	userId: string
+  env: Pick<Env, "APP_DB">;
+  userId: string;
 }): Promise<void> {
-	await saveValue({
-		env: input.env,
-		userId: input.userId,
-		storageContext: userScopedStorageContext,
-		scope: 'user',
-		name: onboardingChecklistDismissedValueName,
-		value: new Date().toISOString(),
-		description:
-			'Set when the onboarding checklist is dismissed; delete this value to bring the checklist back.',
-	})
+  await writeDismissedAtColumn(
+    input.env.APP_DB,
+    input.userId,
+    new Date().toISOString(),
+  );
+}
+
+async function readDismissedAtColumn(db: D1Database, userId: string) {
+  const row = await db
+    .prepare(
+      `SELECT onboarding_checklist_dismissed_at
+			 FROM users
+			 WHERE stable_user_id = ?
+			 LIMIT 1`,
+    )
+    .bind(userId)
+    .first<{ onboarding_checklist_dismissed_at: string | null }>();
+  const dismissedAt = row?.onboarding_checklist_dismissed_at?.trim();
+  return dismissedAt ? dismissedAt : null;
+}
+
+async function writeDismissedAtColumn(
+  db: D1Database,
+  userId: string,
+  dismissedAt: string,
+) {
+  await db
+    .prepare(
+      `UPDATE users
+			 SET onboarding_checklist_dismissed_at = ?,
+			     updated_at = CURRENT_TIMESTAMP
+			 WHERE stable_user_id = ?`,
+    )
+    .bind(dismissedAt, userId)
+    .run();
 }

--- a/packages/worker/src/mcp/onboarding-checklist.ts
+++ b/packages/worker/src/mcp/onboarding-checklist.ts
@@ -1,15 +1,15 @@
-import { countInternalUserEmailMessages } from "#worker/email/mailbox-internal-read.ts";
+import { countInternalUserEmailMessages } from '#worker/email/mailbox-internal-read.ts'
 import {
-  readCurrentEntitlementResourceUsage,
-  type EntitlementUsageEnv,
-} from "#worker/entitlements/service.ts";
-import { listIntegrations } from "#worker/integrations/service.ts";
-import { listMemoriesByUserId } from "#mcp/memory/repo.ts";
-import { getValue } from "#mcp/values/service.ts";
+	readCurrentEntitlementResourceUsage,
+	type EntitlementUsageEnv,
+} from '#worker/entitlements/service.ts'
+import { listIntegrations } from '#worker/integrations/service.ts'
+import { listMemoriesByUserId } from '#mcp/memory/repo.ts'
+import { getValue } from '#mcp/values/service.ts'
 import {
-  type OnboardingChecklistItem,
-  type OnboardingChecklistItemId,
-} from "#universal/onboarding-checklist-types.ts";
+	type OnboardingChecklistItem,
+	type OnboardingChecklistItemId,
+} from '#universal/onboarding-checklist-types.ts'
 
 /**
  * Derived onboarding progress. Every item is computed from data the platform
@@ -18,21 +18,21 @@ import {
  * migration 0015 deletes those rows.
  */
 
-export type { OnboardingChecklistItem, OnboardingChecklistItemId };
+export type { OnboardingChecklistItem, OnboardingChecklistItemId }
 
 export type OnboardingChecklist = {
-  items: Array<OnboardingChecklistItem>;
-  complete: boolean;
-};
+	items: Array<OnboardingChecklistItem>
+	complete: boolean
+}
 
 export const onboardingChecklistDismissedValueName =
-  "onboardingChecklistDismissed";
+	'onboardingChecklistDismissed'
 
 /** User-scope value lookups bind with no session or app. */
-const userScopedStorageContext = { sessionId: null, appId: null };
+const userScopedStorageContext = { sessionId: null, appId: null }
 
-export type OnboardingChecklistEnv = Pick<Env, "APP_DB"> &
-  EntitlementUsageEnv & { MAILBOX: Env["MAILBOX"] };
+export type OnboardingChecklistEnv = Pick<Env, 'APP_DB'> &
+	EntitlementUsageEnv & { MAILBOX: Env['MAILBOX'] }
 
 /**
  * First-win Send sub-step: a successful `email_send` (UserMeter daily count)
@@ -44,26 +44,26 @@ export type OnboardingChecklistEnv = Pick<Env, "APP_DB"> &
  * blip never marks Send done.
  */
 export async function userHasSentWelcomeEmail(input: {
-  env: OnboardingChecklistEnv;
-  userId: string;
-  now?: Date;
+	env: OnboardingChecklistEnv
+	userId: string
+	now?: Date
 }): Promise<boolean> {
-  const now = input.now ?? new Date();
-  const [outboundMail, emailSendsToday] = await Promise.all([
-    countInternalUserEmailMessages({
-      env: input.env,
-      ownerId: input.userId,
-      filters: { direction: "outbound" },
-    }).catch(() => 0),
-    readCurrentEntitlementResourceUsage({
-      db: input.env.APP_DB,
-      env: input.env,
-      userId: input.userId,
-      resource: "email_sends_per_day",
-      now,
-    }).catch(() => 0),
-  ]);
-  return outboundMail > 0 || emailSendsToday > 0;
+	const now = input.now ?? new Date()
+	const [outboundMail, emailSendsToday] = await Promise.all([
+		countInternalUserEmailMessages({
+			env: input.env,
+			ownerId: input.userId,
+			filters: { direction: 'outbound' },
+		}).catch(() => 0),
+		readCurrentEntitlementResourceUsage({
+			db: input.env.APP_DB,
+			env: input.env,
+			userId: input.userId,
+			resource: 'email_sends_per_day',
+			now,
+		}).catch(() => 0),
+	])
+	return outboundMail > 0 || emailSendsToday > 0
 }
 
 /**
@@ -75,112 +75,112 @@ export async function userHasSentWelcomeEmail(input: {
  * onboarding surfaces.
  */
 export async function deriveOnboardingChecklist(input: {
-  env: OnboardingChecklistEnv;
-  userId: string;
-  emailVerified: boolean;
-  hasMcpClient: boolean;
-  now?: Date;
+	env: OnboardingChecklistEnv
+	userId: string
+	emailVerified: boolean
+	hasMcpClient: boolean
+	now?: Date
 }): Promise<OnboardingChecklist> {
-  const { env, userId } = input;
-  const now = input.now ?? new Date();
-  const [inboundMail, memories, integrations, savedPackages] =
-    await Promise.all([
-      countInternalUserEmailMessages({
-        env,
-        ownerId: userId,
-        filters: { direction: "inbound" },
-      }).catch(() => 0),
-      listMemoriesByUserId(env.APP_DB, userId, {
-        limit: 1,
-        statuses: ["active"],
-      }).catch(() => []),
-      listIntegrations({ env, userId }).catch(() => [] as Array<unknown>),
-      readCurrentEntitlementResourceUsage({
-        db: env.APP_DB,
-        env,
-        userId,
-        resource: "saved_packages",
-        now,
-      }).catch(() => 0),
-    ]);
+	const { env, userId } = input
+	const now = input.now ?? new Date()
+	const [inboundMail, memories, integrations, savedPackages] =
+		await Promise.all([
+			countInternalUserEmailMessages({
+				env,
+				ownerId: userId,
+				filters: { direction: 'inbound' },
+			}).catch(() => 0),
+			listMemoriesByUserId(env.APP_DB, userId, {
+				limit: 1,
+				statuses: ['active'],
+			}).catch(() => []),
+			listIntegrations({ env, userId }).catch(() => [] as Array<unknown>),
+			readCurrentEntitlementResourceUsage({
+				db: env.APP_DB,
+				env,
+				userId,
+				resource: 'saved_packages',
+				now,
+			}).catch(() => 0),
+		])
 
-  const items: Array<OnboardingChecklistItem> = [
-    { id: "verify-email", done: input.emailVerified },
-    { id: "connect-agent", done: input.hasMcpClient },
-    { id: "first-hello", done: inboundMail > 0 },
-    { id: "save-memory", done: memories.length > 0 },
-    { id: "connect-integration", done: integrations.length > 0 },
-    { id: "install-starter", done: savedPackages > 0 },
-  ];
-  return {
-    items,
-    complete: items.every((item) => item.done),
-  };
+	const items: Array<OnboardingChecklistItem> = [
+		{ id: 'verify-email', done: input.emailVerified },
+		{ id: 'connect-agent', done: input.hasMcpClient },
+		{ id: 'first-hello', done: inboundMail > 0 },
+		{ id: 'save-memory', done: memories.length > 0 },
+		{ id: 'connect-integration', done: integrations.length > 0 },
+		{ id: 'install-starter', done: savedPackages > 0 },
+	]
+	return {
+		items,
+		complete: items.every((item) => item.done),
+	}
 }
 
 export async function readOnboardingChecklistDismissed(input: {
-  env: Pick<Env, "APP_DB">;
-  userId: string;
+	env: Pick<Env, 'APP_DB'>
+	userId: string
 }): Promise<boolean> {
-  try {
-    const column = await readDismissedAtColumn(input.env.APP_DB, input.userId);
-    if (column) return true;
+	try {
+		const column = await readDismissedAtColumn(input.env.APP_DB, input.userId)
+		if (column) return true
 
-    const leftover = await getValue({
-      env: input.env,
-      userId: input.userId,
-      storageContext: userScopedStorageContext,
-      scope: "user",
-      name: onboardingChecklistDismissedValueName,
-    });
-    if (!leftover) return false;
+		const leftover = await getValue({
+			env: input.env,
+			userId: input.userId,
+			storageContext: userScopedStorageContext,
+			scope: 'user',
+			name: onboardingChecklistDismissedValueName,
+		})
+		if (!leftover) return false
 
-    const dismissedAt =
-      leftover.value.trim() || leftover.updatedAt || new Date().toISOString();
-    await writeDismissedAtColumn(input.env.APP_DB, input.userId, dismissedAt);
-    return true;
-  } catch {
-    return false;
-  }
+		const dismissedAt =
+			leftover.value.trim() || leftover.updatedAt || new Date().toISOString()
+		await writeDismissedAtColumn(input.env.APP_DB, input.userId, dismissedAt)
+		return true
+	} catch {
+		return false
+	}
 }
 
 export async function dismissOnboardingChecklist(input: {
-  env: Pick<Env, "APP_DB">;
-  userId: string;
+	env: Pick<Env, 'APP_DB'>
+	userId: string
 }): Promise<void> {
-  await writeDismissedAtColumn(
-    input.env.APP_DB,
-    input.userId,
-    new Date().toISOString(),
-  );
+	await writeDismissedAtColumn(
+		input.env.APP_DB,
+		input.userId,
+		new Date().toISOString(),
+	)
 }
 
 async function readDismissedAtColumn(db: D1Database, userId: string) {
-  const row = await db
-    .prepare(
-      `SELECT onboarding_checklist_dismissed_at
+	const row = await db
+		.prepare(
+			`SELECT onboarding_checklist_dismissed_at
 			 FROM users
 			 WHERE stable_user_id = ?
 			 LIMIT 1`,
-    )
-    .bind(userId)
-    .first<{ onboarding_checklist_dismissed_at: string | null }>();
-  const dismissedAt = row?.onboarding_checklist_dismissed_at?.trim();
-  return dismissedAt ? dismissedAt : null;
+		)
+		.bind(userId)
+		.first<{ onboarding_checklist_dismissed_at: string | null }>()
+	const dismissedAt = row?.onboarding_checklist_dismissed_at?.trim()
+	return dismissedAt ? dismissedAt : null
 }
 
 async function writeDismissedAtColumn(
-  db: D1Database,
-  userId: string,
-  dismissedAt: string,
+	db: D1Database,
+	userId: string,
+	dismissedAt: string,
 ) {
-  await db
-    .prepare(
-      `UPDATE users
+	await db
+		.prepare(
+			`UPDATE users
 			 SET onboarding_checklist_dismissed_at = ?,
 			     updated_at = CURRENT_TIMESTAMP
 			 WHERE stable_user_id = ?`,
-    )
-    .bind(dismissedAt, userId)
-    .run();
+		)
+		.bind(dismissedAt, userId)
+		.run()
 }

--- a/packages/worker/src/mcp/tools/search-onboarding-notice.ts
+++ b/packages/worker/src/mcp/tools/search-onboarding-notice.ts
@@ -1,9 +1,9 @@
 import {
-  deriveOnboardingChecklist,
-  dismissOnboardingChecklist,
-  readOnboardingChecklistDismissed,
-  type OnboardingChecklistItemId,
-} from "#mcp/onboarding-checklist.ts";
+	deriveOnboardingChecklist,
+	dismissOnboardingChecklist,
+	readOnboardingChecklistDismissed,
+	type OnboardingChecklistItemId,
+} from '#mcp/onboarding-checklist.ts'
 
 /**
  * One-line onboarding reminder appended to `search` notices, at most once per
@@ -14,51 +14,51 @@ import {
  */
 
 const itemLabels: Record<OnboardingChecklistItemId, string> = {
-  "verify-email": "verify your email",
-  "connect-agent": "connect your agent",
-  "first-hello": "exchange a first email with Kody",
-  "save-memory": "save a memory",
-  "connect-integration": "connect an integration",
-  "install-starter": "install a starter package",
-};
+	'verify-email': 'verify your email',
+	'connect-agent': 'connect your agent',
+	'first-hello': 'exchange a first email with Kody',
+	'save-memory': 'save a memory',
+	'connect-integration': 'connect an integration',
+	'install-starter': 'install a starter package',
+}
 
 export async function buildOnboardingSearchNotice(input: {
-  env: Env;
-  userId: string;
-  /** Deployment origin for the details link, e.g. https://kody.codes */
-  baseUrl: string;
-  waitUntil?: (promise: Promise<unknown>) => void;
+	env: Env
+	userId: string
+	/** Deployment origin for the details link, e.g. https://kody.codes */
+	baseUrl: string
+	waitUntil?: (promise: Promise<unknown>) => void
 }): Promise<string | null> {
-  try {
-    const dismissed = await readOnboardingChecklistDismissed({
-      env: input.env,
-      userId: input.userId,
-    });
-    if (dismissed) return null;
+	try {
+		const dismissed = await readOnboardingChecklistDismissed({
+			env: input.env,
+			userId: input.userId,
+		})
+		if (dismissed) return null
 
-    // An MCP search call implies a verified account and a connected agent.
-    const checklist = await deriveOnboardingChecklist({
-      env: input.env,
-      userId: input.userId,
-      emailVerified: true,
-      hasMcpClient: true,
-    });
-    if (checklist.complete) {
-      const retire = dismissOnboardingChecklist({
-        env: input.env,
-        userId: input.userId,
-      }).catch(() => {});
-      if (input.waitUntil) input.waitUntil(retire);
-      else await retire;
-      return null;
-    }
+		// An MCP search call implies a verified account and a connected agent.
+		const checklist = await deriveOnboardingChecklist({
+			env: input.env,
+			userId: input.userId,
+			emailVerified: true,
+			hasMcpClient: true,
+		})
+		if (checklist.complete) {
+			const retire = dismissOnboardingChecklist({
+				env: input.env,
+				userId: input.userId,
+			}).catch(() => {})
+			if (input.waitUntil) input.waitUntil(retire)
+			else await retire
+			return null
+		}
 
-    const remaining = checklist.items
-      .filter((item) => !item.done)
-      .map((item) => itemLabels[item.id]);
-    return `Onboarding: ${remaining.length} step${remaining.length === 1 ? "" : "s"} left — ${remaining.join(", ")}. Details and dismissal: ${input.baseUrl}/onboarding`;
-  } catch {
-    // The reminder is a courtesy; never let it break search.
-    return null;
-  }
+		const remaining = checklist.items
+			.filter((item) => !item.done)
+			.map((item) => itemLabels[item.id])
+		return `Onboarding: ${remaining.length} step${remaining.length === 1 ? '' : 's'} left — ${remaining.join(', ')}. Details and dismissal: ${input.baseUrl}/onboarding`
+	} catch {
+		// The reminder is a courtesy; never let it break search.
+		return null
+	}
 }

--- a/packages/worker/src/mcp/tools/search-onboarding-notice.ts
+++ b/packages/worker/src/mcp/tools/search-onboarding-notice.ts
@@ -1,64 +1,64 @@
 import {
-	deriveOnboardingChecklist,
-	dismissOnboardingChecklist,
-	readOnboardingChecklistDismissed,
-	type OnboardingChecklistItemId,
-} from '#mcp/onboarding-checklist.ts'
+  deriveOnboardingChecklist,
+  dismissOnboardingChecklist,
+  readOnboardingChecklistDismissed,
+  type OnboardingChecklistItemId,
+} from "#mcp/onboarding-checklist.ts";
 
 /**
  * One-line onboarding reminder appended to `search` notices, at most once per
  * conversation (the runner tracks shown conversations in agent state) and
  * only while the derived checklist is incomplete and undismissed. When the
- * checklist completes, the dismissal value is written automatically so
+ * checklist completes, the dismissal column is written automatically so
  * established accounts stop paying the derivation on new conversations.
  */
 
 const itemLabels: Record<OnboardingChecklistItemId, string> = {
-	'verify-email': 'verify your email',
-	'connect-agent': 'connect your agent',
-	'first-hello': 'exchange a first email with Kody',
-	'save-memory': 'save a memory',
-	'connect-integration': 'connect an integration',
-	'install-starter': 'install a starter package',
-}
+  "verify-email": "verify your email",
+  "connect-agent": "connect your agent",
+  "first-hello": "exchange a first email with Kody",
+  "save-memory": "save a memory",
+  "connect-integration": "connect an integration",
+  "install-starter": "install a starter package",
+};
 
 export async function buildOnboardingSearchNotice(input: {
-	env: Env
-	userId: string
-	/** Deployment origin for the details link, e.g. https://kody.codes */
-	baseUrl: string
-	waitUntil?: (promise: Promise<unknown>) => void
+  env: Env;
+  userId: string;
+  /** Deployment origin for the details link, e.g. https://kody.codes */
+  baseUrl: string;
+  waitUntil?: (promise: Promise<unknown>) => void;
 }): Promise<string | null> {
-	try {
-		const dismissed = await readOnboardingChecklistDismissed({
-			env: input.env,
-			userId: input.userId,
-		})
-		if (dismissed) return null
+  try {
+    const dismissed = await readOnboardingChecklistDismissed({
+      env: input.env,
+      userId: input.userId,
+    });
+    if (dismissed) return null;
 
-		// An MCP search call implies a verified account and a connected agent.
-		const checklist = await deriveOnboardingChecklist({
-			env: input.env,
-			userId: input.userId,
-			emailVerified: true,
-			hasMcpClient: true,
-		})
-		if (checklist.complete) {
-			const retire = dismissOnboardingChecklist({
-				env: input.env,
-				userId: input.userId,
-			}).catch(() => {})
-			if (input.waitUntil) input.waitUntil(retire)
-			else await retire
-			return null
-		}
+    // An MCP search call implies a verified account and a connected agent.
+    const checklist = await deriveOnboardingChecklist({
+      env: input.env,
+      userId: input.userId,
+      emailVerified: true,
+      hasMcpClient: true,
+    });
+    if (checklist.complete) {
+      const retire = dismissOnboardingChecklist({
+        env: input.env,
+        userId: input.userId,
+      }).catch(() => {});
+      if (input.waitUntil) input.waitUntil(retire);
+      else await retire;
+      return null;
+    }
 
-		const remaining = checklist.items
-			.filter((item) => !item.done)
-			.map((item) => itemLabels[item.id])
-		return `Onboarding: ${remaining.length} step${remaining.length === 1 ? '' : 's'} left — ${remaining.join(', ')}. Details and dismissal: ${input.baseUrl}/onboarding`
-	} catch {
-		// The reminder is a courtesy; never let it break search.
-		return null
-	}
+    const remaining = checklist.items
+      .filter((item) => !item.done)
+      .map((item) => itemLabels[item.id]);
+    return `Onboarding: ${remaining.length} step${remaining.length === 1 ? "" : "s"} left — ${remaining.join(", ")}. Details and dismissal: ${input.baseUrl}/onboarding`;
+  } catch {
+    // The reminder is a courtesy; never let it break search.
+    return null;
+  }
 }

--- a/packages/worker/src/users-test-schema.ts
+++ b/packages/worker/src/users-test-schema.ts
@@ -15,26 +15,27 @@
  * migrations each suite depends on.
  */
 export type UsersTestSchemaColumn =
-	| 'email_verified_at'
-	| 'account_type'
-	| 'stripe_customer_id'
-	| 'stripe_plan'
-	| 'stripe_plan_refreshed_at'
-	| 'bio'
-	| 'avatar_key'
-	| 'profile_visibility'
+  | "email_verified_at"
+  | "account_type"
+  | "stripe_customer_id"
+  | "stripe_plan"
+  | "stripe_plan_refreshed_at"
+  | "bio"
+  | "avatar_key"
+  | "profile_visibility"
+  | "onboarding_checklist_dismissed_at";
 
 type UsersColumnDefinition = {
-	/** Definition used by the fresh `CREATE TABLE users`. */
-	create: string
-	/**
-	 * Definition used by `ALTER TABLE users ADD COLUMN` when a preexisting
-	 * shared table needs the column. SQLite cannot add `NOT NULL` without a
-	 * constant default, so some alter forms are weaker than the create form.
-	 * Omit to reuse `create`.
-	 */
-	alter?: string
-}
+  /** Definition used by the fresh `CREATE TABLE users`. */
+  create: string;
+  /**
+   * Definition used by `ALTER TABLE users ADD COLUMN` when a preexisting
+   * shared table needs the column. SQLite cannot add `NOT NULL` without a
+   * constant default, so some alter forms are weaker than the create form.
+   * Omit to reuse `create`.
+   */
+  alter?: string;
+};
 
 /**
  * Present in every suite. `id`, `username`, `email`, `password_hash`,
@@ -43,16 +44,16 @@ type UsersColumnDefinition = {
  * ever come from the fresh `CREATE TABLE`.
  */
 const nonAdditiveCoreColumns = [
-	'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL',
-	'username TEXT NOT NULL UNIQUE',
-	'email TEXT NOT NULL UNIQUE',
-	'password_hash TEXT NOT NULL',
-] as const
+  "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL",
+  "username TEXT NOT NULL UNIQUE",
+  "email TEXT NOT NULL UNIQUE",
+  "password_hash TEXT NOT NULL",
+] as const;
 
 const timestampColumns = [
-	'created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)',
-	'updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)',
-] as const
+  "created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)",
+  "updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)",
+] as const;
 
 /**
  * Mirrors migrations 0052 + 0075 (`stable_user_id` NOT NULL + unique index),
@@ -62,84 +63,86 @@ const timestampColumns = [
  * when plan matters.
  */
 const alwaysAdditiveColumns: Record<string, UsersColumnDefinition> = {
-	// Preexisting shared tables: ALTER ADD COLUMN cannot express NOT NULL
-	// without a default; nullable TEXT matches migration 0052's add step.
-	stable_user_id: { create: 'TEXT NOT NULL', alter: 'TEXT' },
-	plan: { create: `TEXT NOT NULL DEFAULT 'free'` },
-	deleting_at: { create: 'TEXT' },
-	suspended_at: { create: 'TEXT' },
-	email_outbound_paused_at: { create: 'TEXT' },
-	active_write_count: { create: 'INTEGER NOT NULL DEFAULT 0' },
-	active_write_expires_at: { create: 'TEXT' },
-	display_name: { create: 'TEXT' },
-}
+  // Preexisting shared tables: ALTER ADD COLUMN cannot express NOT NULL
+  // without a default; nullable TEXT matches migration 0052's add step.
+  stable_user_id: { create: "TEXT NOT NULL", alter: "TEXT" },
+  plan: { create: `TEXT NOT NULL DEFAULT 'free'` },
+  deleting_at: { create: "TEXT" },
+  suspended_at: { create: "TEXT" },
+  email_outbound_paused_at: { create: "TEXT" },
+  active_write_count: { create: "INTEGER NOT NULL DEFAULT 0" },
+  active_write_expires_at: { create: "TEXT" },
+  display_name: { create: "TEXT" },
+};
 
 /**
  * Opt-in columns. `account_type` mirrors migration 0072, the Stripe columns
- * mirror 0066, `email_verified_at` mirrors 0046, and the profile columns mirror
- * the community social migration. `CHECK` constraints are dropped from the
- * alter forms to match what the migrations do for preexisting tables.
+ * mirror 0066, `email_verified_at` mirrors 0046, the profile columns mirror
+ * the community social migration, and `onboarding_checklist_dismissed_at`
+ * mirrors 0015. `CHECK` constraints are dropped from the alter forms to match
+ * what the migrations do for preexisting tables.
  */
 const optionalColumns: Record<UsersTestSchemaColumn, UsersColumnDefinition> = {
-	email_verified_at: { create: 'TEXT' },
-	account_type: {
-		create: `TEXT NOT NULL DEFAULT 'person' CHECK (account_type IN ('person', 'platform'))`,
-		alter: `TEXT NOT NULL DEFAULT 'person'`,
-	},
-	stripe_customer_id: { create: 'TEXT' },
-	stripe_plan: { create: 'TEXT' },
-	stripe_plan_refreshed_at: { create: 'TEXT' },
-	bio: { create: 'TEXT' },
-	avatar_key: { create: 'TEXT' },
-	profile_visibility: {
-		create: `TEXT NOT NULL DEFAULT 'public' CHECK (profile_visibility IN ('public', 'private'))`,
-		alter: `TEXT NOT NULL DEFAULT 'public'`,
-	},
-}
+  email_verified_at: { create: "TEXT" },
+  account_type: {
+    create: `TEXT NOT NULL DEFAULT 'person' CHECK (account_type IN ('person', 'platform'))`,
+    alter: `TEXT NOT NULL DEFAULT 'person'`,
+  },
+  stripe_customer_id: { create: "TEXT" },
+  stripe_plan: { create: "TEXT" },
+  stripe_plan_refreshed_at: { create: "TEXT" },
+  bio: { create: "TEXT" },
+  avatar_key: { create: "TEXT" },
+  profile_visibility: {
+    create: `TEXT NOT NULL DEFAULT 'public' CHECK (profile_visibility IN ('public', 'private'))`,
+    alter: `TEXT NOT NULL DEFAULT 'public'`,
+  },
+  onboarding_checklist_dismissed_at: { create: "TEXT" },
+};
 
 export async function ensureUsersTestSchema(input: {
-	db: D1Database
-	columns?: ReadonlyArray<UsersTestSchemaColumn>
+  db: D1Database;
+  columns?: ReadonlyArray<UsersTestSchemaColumn>;
 }) {
-	const additive: Array<readonly [string, UsersColumnDefinition]> = [
-		...Object.entries(alwaysAdditiveColumns),
-		...(input.columns ?? []).map(
-			(column) => [column, optionalColumns[column]] as const,
-		),
-	]
+  const additive: Array<readonly [string, UsersColumnDefinition]> = [
+    ...Object.entries(alwaysAdditiveColumns),
+    ...(input.columns ?? []).map(
+      (column) => [column, optionalColumns[column]] as const,
+    ),
+  ];
 
-	const createColumns = [
-		...nonAdditiveCoreColumns,
-		...additive.map(([name, definition]) => `${name} ${definition.create}`),
-		...timestampColumns,
-	]
-	await input.db
-		.prepare(
-			`CREATE TABLE IF NOT EXISTS users (\n\t${createColumns.join(',\n\t')}\n)`,
-		)
-		.run()
+  const createColumns = [
+    ...nonAdditiveCoreColumns,
+    ...additive.map(([name, definition]) => `${name} ${definition.create}`),
+    ...timestampColumns,
+  ];
+  await input.db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS users (\n\t${createColumns.join(",\n\t")}\n)`,
+    )
+    .run();
 
-	for (const [name, definition] of additive) {
-		try {
-			await input.db
-				.prepare(
-					`ALTER TABLE users ADD COLUMN ${name} ${definition.alter ?? definition.create}`,
-				)
-				.run()
-		} catch {
-			// The column already exists (fresh CREATE above, or a prior suite).
-		}
-	}
+  for (const [name, definition] of additive) {
+    try {
+      await input.db
+        .prepare(
+          `ALTER TABLE users ADD COLUMN ${name} ${definition.alter ?? definition.create}`,
+        )
+        .run();
+    } catch {
+      // The column already exists (fresh CREATE above, or a prior suite).
+    }
+  }
 
-	try {
-		await input.db
-			.prepare(
-				`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stable_user_id
+  try {
+    await input.db
+      .prepare(
+        `CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stable_user_id
 				 ON users(stable_user_id)`,
-			)
-			.run()
-	} catch {
-		// Index already exists, or a partial legacy index remains from an
-		// earlier suite sharing this database.
-	}
+      )
+      .run();
+  } catch {
+    // Index already exists, or a partial legacy index remains from an
+    // earlier suite sharing this database.
+  }
 }

--- a/packages/worker/src/users-test-schema.ts
+++ b/packages/worker/src/users-test-schema.ts
@@ -15,27 +15,27 @@
  * migrations each suite depends on.
  */
 export type UsersTestSchemaColumn =
-  | "email_verified_at"
-  | "account_type"
-  | "stripe_customer_id"
-  | "stripe_plan"
-  | "stripe_plan_refreshed_at"
-  | "bio"
-  | "avatar_key"
-  | "profile_visibility"
-  | "onboarding_checklist_dismissed_at";
+	| 'email_verified_at'
+	| 'account_type'
+	| 'stripe_customer_id'
+	| 'stripe_plan'
+	| 'stripe_plan_refreshed_at'
+	| 'bio'
+	| 'avatar_key'
+	| 'profile_visibility'
+	| 'onboarding_checklist_dismissed_at'
 
 type UsersColumnDefinition = {
-  /** Definition used by the fresh `CREATE TABLE users`. */
-  create: string;
-  /**
-   * Definition used by `ALTER TABLE users ADD COLUMN` when a preexisting
-   * shared table needs the column. SQLite cannot add `NOT NULL` without a
-   * constant default, so some alter forms are weaker than the create form.
-   * Omit to reuse `create`.
-   */
-  alter?: string;
-};
+	/** Definition used by the fresh `CREATE TABLE users`. */
+	create: string
+	/**
+	 * Definition used by `ALTER TABLE users ADD COLUMN` when a preexisting
+	 * shared table needs the column. SQLite cannot add `NOT NULL` without a
+	 * constant default, so some alter forms are weaker than the create form.
+	 * Omit to reuse `create`.
+	 */
+	alter?: string
+}
 
 /**
  * Present in every suite. `id`, `username`, `email`, `password_hash`,
@@ -44,16 +44,16 @@ type UsersColumnDefinition = {
  * ever come from the fresh `CREATE TABLE`.
  */
 const nonAdditiveCoreColumns = [
-  "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL",
-  "username TEXT NOT NULL UNIQUE",
-  "email TEXT NOT NULL UNIQUE",
-  "password_hash TEXT NOT NULL",
-] as const;
+	'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL',
+	'username TEXT NOT NULL UNIQUE',
+	'email TEXT NOT NULL UNIQUE',
+	'password_hash TEXT NOT NULL',
+] as const
 
 const timestampColumns = [
-  "created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)",
-  "updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)",
-] as const;
+	'created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)',
+	'updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)',
+] as const
 
 /**
  * Mirrors migrations 0052 + 0075 (`stable_user_id` NOT NULL + unique index),
@@ -63,17 +63,17 @@ const timestampColumns = [
  * when plan matters.
  */
 const alwaysAdditiveColumns: Record<string, UsersColumnDefinition> = {
-  // Preexisting shared tables: ALTER ADD COLUMN cannot express NOT NULL
-  // without a default; nullable TEXT matches migration 0052's add step.
-  stable_user_id: { create: "TEXT NOT NULL", alter: "TEXT" },
-  plan: { create: `TEXT NOT NULL DEFAULT 'free'` },
-  deleting_at: { create: "TEXT" },
-  suspended_at: { create: "TEXT" },
-  email_outbound_paused_at: { create: "TEXT" },
-  active_write_count: { create: "INTEGER NOT NULL DEFAULT 0" },
-  active_write_expires_at: { create: "TEXT" },
-  display_name: { create: "TEXT" },
-};
+	// Preexisting shared tables: ALTER ADD COLUMN cannot express NOT NULL
+	// without a default; nullable TEXT matches migration 0052's add step.
+	stable_user_id: { create: 'TEXT NOT NULL', alter: 'TEXT' },
+	plan: { create: `TEXT NOT NULL DEFAULT 'free'` },
+	deleting_at: { create: 'TEXT' },
+	suspended_at: { create: 'TEXT' },
+	email_outbound_paused_at: { create: 'TEXT' },
+	active_write_count: { create: 'INTEGER NOT NULL DEFAULT 0' },
+	active_write_expires_at: { create: 'TEXT' },
+	display_name: { create: 'TEXT' },
+}
 
 /**
  * Opt-in columns. `account_type` mirrors migration 0072, the Stripe columns
@@ -83,66 +83,66 @@ const alwaysAdditiveColumns: Record<string, UsersColumnDefinition> = {
  * what the migrations do for preexisting tables.
  */
 const optionalColumns: Record<UsersTestSchemaColumn, UsersColumnDefinition> = {
-  email_verified_at: { create: "TEXT" },
-  account_type: {
-    create: `TEXT NOT NULL DEFAULT 'person' CHECK (account_type IN ('person', 'platform'))`,
-    alter: `TEXT NOT NULL DEFAULT 'person'`,
-  },
-  stripe_customer_id: { create: "TEXT" },
-  stripe_plan: { create: "TEXT" },
-  stripe_plan_refreshed_at: { create: "TEXT" },
-  bio: { create: "TEXT" },
-  avatar_key: { create: "TEXT" },
-  profile_visibility: {
-    create: `TEXT NOT NULL DEFAULT 'public' CHECK (profile_visibility IN ('public', 'private'))`,
-    alter: `TEXT NOT NULL DEFAULT 'public'`,
-  },
-  onboarding_checklist_dismissed_at: { create: "TEXT" },
-};
+	email_verified_at: { create: 'TEXT' },
+	account_type: {
+		create: `TEXT NOT NULL DEFAULT 'person' CHECK (account_type IN ('person', 'platform'))`,
+		alter: `TEXT NOT NULL DEFAULT 'person'`,
+	},
+	stripe_customer_id: { create: 'TEXT' },
+	stripe_plan: { create: 'TEXT' },
+	stripe_plan_refreshed_at: { create: 'TEXT' },
+	bio: { create: 'TEXT' },
+	avatar_key: { create: 'TEXT' },
+	profile_visibility: {
+		create: `TEXT NOT NULL DEFAULT 'public' CHECK (profile_visibility IN ('public', 'private'))`,
+		alter: `TEXT NOT NULL DEFAULT 'public'`,
+	},
+	onboarding_checklist_dismissed_at: { create: 'TEXT' },
+}
 
 export async function ensureUsersTestSchema(input: {
-  db: D1Database;
-  columns?: ReadonlyArray<UsersTestSchemaColumn>;
+	db: D1Database
+	columns?: ReadonlyArray<UsersTestSchemaColumn>
 }) {
-  const additive: Array<readonly [string, UsersColumnDefinition]> = [
-    ...Object.entries(alwaysAdditiveColumns),
-    ...(input.columns ?? []).map(
-      (column) => [column, optionalColumns[column]] as const,
-    ),
-  ];
+	const additive: Array<readonly [string, UsersColumnDefinition]> = [
+		...Object.entries(alwaysAdditiveColumns),
+		...(input.columns ?? []).map(
+			(column) => [column, optionalColumns[column]] as const,
+		),
+	]
 
-  const createColumns = [
-    ...nonAdditiveCoreColumns,
-    ...additive.map(([name, definition]) => `${name} ${definition.create}`),
-    ...timestampColumns,
-  ];
-  await input.db
-    .prepare(
-      `CREATE TABLE IF NOT EXISTS users (\n\t${createColumns.join(",\n\t")}\n)`,
-    )
-    .run();
+	const createColumns = [
+		...nonAdditiveCoreColumns,
+		...additive.map(([name, definition]) => `${name} ${definition.create}`),
+		...timestampColumns,
+	]
+	await input.db
+		.prepare(
+			`CREATE TABLE IF NOT EXISTS users (\n\t${createColumns.join(',\n\t')}\n)`,
+		)
+		.run()
 
-  for (const [name, definition] of additive) {
-    try {
-      await input.db
-        .prepare(
-          `ALTER TABLE users ADD COLUMN ${name} ${definition.alter ?? definition.create}`,
-        )
-        .run();
-    } catch {
-      // The column already exists (fresh CREATE above, or a prior suite).
-    }
-  }
+	for (const [name, definition] of additive) {
+		try {
+			await input.db
+				.prepare(
+					`ALTER TABLE users ADD COLUMN ${name} ${definition.alter ?? definition.create}`,
+				)
+				.run()
+		} catch {
+			// The column already exists (fresh CREATE above, or a prior suite).
+		}
+	}
 
-  try {
-    await input.db
-      .prepare(
-        `CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stable_user_id
+	try {
+		await input.db
+			.prepare(
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stable_user_id
 				 ON users(stable_user_id)`,
-      )
-      .run();
-  } catch {
-    // Index already exists, or a partial legacy index remains from an
-    // earlier suite sharing this database.
-  }
+			)
+			.run()
+	} catch {
+		// Index already exists, or a partial legacy index remains from an
+		// earlier suite sharing this database.
+	}
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -59,6 +59,10 @@
 		{
 			"filename": "0014-drop-remote-connector-settings.sql",
 			"sha256": "5a170f05dffc793f94b01bffdbfb62eb11359ed54db768f5a121715317fa5536"
+		},
+		{
+			"filename": "0015-users-onboarding-checklist-dismissed-at.sql",
+			"sha256": "c2863d11723635386525eb4bc90f42743db39f6f5e5e68e5a30bc7fa3385430e"
 		}
 	]
 }

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -62,7 +62,7 @@
 		},
 		{
 			"filename": "0015-users-onboarding-checklist-dismissed-at.sql",
-			"sha256": "c2863d11723635386525eb4bc90f42743db39f6f5e5e68e5a30bc7fa3385430e"
+			"sha256": "b3e5b3c168bdebe0f900d30e3d781f874b4850b975bf5ea0d2278114cd6d58ca"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Retire `onboardingChecklistDismissed` as a user value. Dismissal is a platform UI flag and belongs on `users`, so leftover values (operator plus several other accounts) can drop without a user action.

## Summary

- Add nullable `users.onboarding_checklist_dismissed_at`.
- Migration `0015` backfills from leftover **user-scope** `onboardingChecklistDismissed` rows and deletes only those entries (session/app leftovers stay put).
- Onboarding reads the column first, copies any leftover value onto the column, and writes the column only.
- Update the users test schema and onboarding node tests, including leftover-value copy and a migration regression for non-user leftovers.

## Testing

- `npx vitest run --project node-unit packages/worker/src/mcp/onboarding-checklist.node.test.ts packages/worker/src/mcp/onboarding-checklist-migration.node.test.ts` (5 passed).
- `npm run migrations:check` (ok).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `313e1de2` · **Head:** `e0fb8f7e`

**Classification:** extends — dismissal persistence moves from leftover values onto a new `users` column, and MCP onboarding read/write follow that contract.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `d1-app-db` | storage | extends — new `users.onboarding_checklist_dismissed_at`, user-scope backfill, delete leftover user-scope value rows |
| `mcp-server` | surfaces | extends — onboarding dismiss reads/writes the column; leftover values copy on read |

### Change flow

Onboarding dismiss now lands on `users` instead of a leftover value row.

```mermaid
sequenceDiagram
	actor user as Signed-in user
	participant mcpServer as mcp-server
	participant d1AppDb as d1-app-db
	user->>mcpServer: dismiss onboarding checklist
	mcpServer->>d1AppDb: UPDATE users.onboarding_checklist_dismissed_at
	mcpServer->>mcpServer: skip value_set
	mcpServer->>d1AppDb: read column first
	opt leftover user-scope onboardingChecklistDismissed row
		mcpServer->>d1AppDb: copy leftover onto column
	end
	Note over d1AppDb: 0015 backfills user-scope rows then deletes only those leftovers
```

### Before / after

```text
before: getValue/saveValue name=onboardingChecklistDismissed
after:  users.onboarding_checklist_dismissed_at (nullable ISO timestamp)
delete: user-scope leftover rows only (session/app leftovers stay)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a18e1a6d-a58a-4c0b-b414-1e7631f38e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a18e1a6d-a58a-4c0b-b414-1e7631f38e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Onboarding checklist dismissal status is now stored with a timestamp.
  - Completing the checklist automatically records its dismissal.
  - Existing dismissal information is preserved during migration.

- **Bug Fixes**
  - Improved compatibility with previously stored dismissal data.
  - Onboarding notices remain reliable when legacy information is encountered.

- **Documentation**
  - Updated onboarding and migration guidance to explain the new dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->