### PR TITLE
Persist refreshAccessToken rotations host-side

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -345,8 +345,10 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   (`community_forks.adopted_at` set via `community_fork_adopt`). Unadopted
   community forks (`community_forks.forked_package_id`, indexed in the squashed
   baseline) still require an explicit `allowed_packages` grant on every package
-  read path. Updating or deleting a user secret from package code always
-  requires that grant, regardless of fork or adoption state.
+  read path. Updating or deleting a user secret from package code (`secret_set`
+  / `secret_delete`) always requires that grant, regardless of fork or adoption
+  state. Official OAuth token rotation persists host-side and does not use that
+  write grant.
 - `user_oauth_apps` (`0001-squashed-init.sql`): per-user OAuth app rows keyed by
   `(user_id, slug)`. Holds shared client id, client-secret secret name, provider
   endpoints, and flow options. See [OAuth integrations](./integrations.md).
@@ -1231,9 +1233,9 @@ on write unless a migration backfills existing rows.
   `forker_user_id`; index in `0001-squashed-init.sql`). Self-authored packages
   and adopted forks (`community_forks.adopted_at` / `adoption_note`) skip that
   grant for read/use only. Mutations from package code (`secret_set` /
-  `secret_delete` / OpenAPI token-refresh writes) always require the grant.
-  Package-scoped secrets are owned exclusively by the package id in their bucket
-  binding.
+  `secret_delete`) always require the grant. Official OAuth token rotation
+  persists host-side and does not use that write grant. Package-scoped secrets
+  are owned exclusively by the package id in their bucket binding.
 - `user_oauth_apps.extra_authorize_params_json`,
   `user_integrations.scopes_json`, and `user_integrations.required_hosts_json`
   (`0001-squashed-init.sql`, `packages/worker/src/integrations/`) store a

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -100,7 +100,9 @@ arbitrary hosts:
 This invariant must hold for any code path that materializes an integration
 token and then attaches it to an outbound request. Host-side refresh via
 `integration_token_refresh` materializes tokens only server-side and returns
-metadata, so no new sandbox-visible token path is introduced.
+metadata. `refreshAccessToken` is the existing residual raw-token helper; it now
+persists through that same host path, then returns the access token for
+user-lane integrations only.
 
 ## Source of truth in code
 

--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -133,8 +133,12 @@ never enter the sandbox heap. Package code that triggers refresh through
 grant — the system persists rotated tokens host-side and the package never sees
 or writes token values. `refreshAccessToken` is the raw-token helper for auth
 patterns that cannot use an Authorization header (WebSockets, SDK constructors,
-query-param tokens); it runs in-sandbox for user-lane integrations and throws
-for platform ones (`integration_get` carries `platform: true`). Token-exchange
+query-param tokens). It also refreshes host-side
+(`integration_refresh_access_token` → `refreshIntegrationTokens`) so token
+rotation does not need an `allowed_packages` write grant, then materializes the
+new access token for user-lane integrations and throws for platform ones
+(`integration_get` carries `platform: true`). Unadopted community forks still
+need a read/use grant before the helper will return a raw token. Token-exchange
 request building is shared:
 `packages/worker/src/integrations/oauth-token-exchange.ts` lives in the
 shared-primitive layer so both the `/connect/oauth` handlers and the MCP refresh
@@ -260,15 +264,16 @@ join.
 Domain: `integrations`
 (`packages/worker/src/mcp/capabilities/integrations/domain.ts`).
 
-| Capability                                             | Role                                                                  |
-| ------------------------------------------------------ | --------------------------------------------------------------------- |
-| `integration_save` / `_get` / `_list` / `_delete`      | Connection CRUD with flat `clientId` output                           |
-| `integration_oauth_app_list`                           | Apps with connection counts and sibling connection names              |
-| `integration_oauth_app_rotate_credentials`             | Rotate shared app `clientId` / client-secret name                     |
-| `integration_platform_app_list`                        | Enabled platform (built-in) apps; public projection, never any secret |
-| `integration_token_refresh`                            | Host-side OAuth refresh; returns metadata only, never token values    |
-| `integration_registry_search` / `integration_discover` | Untrusted integrations.sh research                                    |
-| `openapi_spec_summarize` / `openapi_client_scaffold`   | Spec research helpers (bindings live in the `openapi` domain)         |
+| Capability                                             | Role                                                                           |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `integration_save` / `_get` / `_list` / `_delete`      | Connection CRUD with flat `clientId` output                                    |
+| `integration_oauth_app_list`                           | Apps with connection counts and sibling connection names                       |
+| `integration_oauth_app_rotate_credentials`             | Rotate shared app `clientId` / client-secret name                              |
+| `integration_platform_app_list`                        | Enabled platform (built-in) apps; public projection, never any secret          |
+| `integration_token_refresh`                            | Host-side OAuth refresh; returns metadata only, never token values             |
+| `integration_refresh_access_token`                     | User-lane host refresh plus materialized access token for `refreshAccessToken` |
+| `integration_registry_search` / `integration_discover` | Untrusted integrations.sh research                                             |
+| `openapi_spec_summarize` / `openapi_client_scaffold`   | Spec research helpers (bindings live in the `openapi` domain)                  |
 
 OpenAPI provider bindings (`user_openapi_bindings` /
 `user_openapi_binding_operations`) are a separate primitive; see

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -361,7 +361,8 @@ emit (recursion guard). See
 
 For reconnectable OAuth refresh failures, `integration.auth.failed` dispatches
 best-effort from host-side `refreshIntegrationTokens`
-(`createAuthenticatedFetch` 401 retry and explicit `integration_token_refresh`).
+(`createAuthenticatedFetch` 401 retry, `refreshAccessToken` /
+`integration_refresh_access_token`, and explicit `integration_token_refresh`).
 Successful refreshes and successful `/connect/oauth` token persists dispatch
 `integration.auth.succeeded`. Both payloads are metadata-first (connection name,
 account label, scopes, timestamps, and for failed: reason, optional provider

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -49,9 +49,10 @@ that subscribe; successful refreshes and `/connect/oauth` persists dispatch
 `integration.auth.succeeded` (see
 [package subscriptions](./package-subscriptions.md)). Use `refreshAccessToken`
 only for auth that cannot use an Authorization header (WebSockets, SDK
-constructors, query-param tokens); it still runs in-sandbox for user-owned apps
-and throws for built-ins. The rest of this guide applies to providers without a
-built-in app.
+constructors, query-param tokens). It refreshes host-side like
+`createAuthenticatedFetch` (no `allowed_packages` write grant for token
+rotation), returns the raw access token for user-owned apps, and throws for
+built-ins. The rest of this guide applies to providers without a built-in app.
 
 ## Redirect URI
 

--- a/docs/use/secrets-and-values.md
+++ b/docs/use/secrets-and-values.md
@@ -123,11 +123,12 @@ User-scoped secrets are available automatically for **reading and using**
 themselves, and to adopted community forks (`community_fork_adopt` after a real
 source review). Unadopted community-forked packages need explicit **package**
 approval (`allowed_packages`) before those read/use paths. Updating or deleting
-a user secret from package code (`secret_set`, `secret_delete`, OpenAPI
-token-refresh writes) always needs the grant, including for self-authored and
-adopted packages. Saving a secret, approving a host, or succeeding in an ad hoc
-execute smoke test does not grant package access. Host and capability approvals
-are unchanged.
+a user secret from package code (`secret_set`, `secret_delete`) always needs the
+grant, including for self-authored and adopted packages. Official OAuth token
+rotation (`createAuthenticatedFetch`, `refreshAccessToken`, OpenAPI integration
+401 retry) persists host-side and does not need that write grant. Saving a
+secret, approving a host, or succeeding in an ad hoc execute smoke test does not
+grant package access. Host and capability approvals are unchanged.
 
 When several secrets need the same package approved, Kody can provide a bulk
 approval URL shaped like

--- a/packages/worker/src/integrations/token-refresh.node.test.ts
+++ b/packages/worker/src/integrations/token-refresh.node.test.ts
@@ -30,8 +30,10 @@ vi.mock('./package-subscriptions.ts', () => ({
 }))
 
 const {
+	IntegrationRawTokenRefusedError,
 	IntegrationTokenRefreshCallerError,
 	integrationTokenRefreshCallerMarker,
+	refreshAndMaterializeUserLaneAccessToken,
 	refreshIntegrationTokens,
 } = await import('./token-refresh.ts')
 
@@ -566,4 +568,108 @@ test('successful Google refresh persists userinfo email as account_label when mi
 	} finally {
 		vi.unstubAllGlobals()
 	}
+})
+
+test('user-lane refreshAccessToken host path persists without a package write grant and returns the access token', async () => {
+	const { env } = createHarness()
+	const userId = 'user-lane-materialize'
+	await upsertIntegration({
+		env,
+		userId,
+		config: {
+			name: 'x-kodykoala',
+			tokenUrl: 'https://api.x.com/2/oauth2/token',
+			flow: 'pkce',
+			clientId: 'x-client-id',
+			accessTokenSecretName: 'x-kodykoalaAccessToken',
+			refreshTokenSecretName: 'x-kodykoalaRefreshToken',
+			requiredHosts: ['api.x.com'],
+			authorization: {
+				authorizeUrl: 'https://x.com/i/oauth2/authorize',
+				scopes: ['tweet.read'],
+				scopeSeparator: ' ',
+				extraAuthorizeParams: {},
+			},
+		},
+	})
+	await saveSecret({
+		env,
+		userId,
+		name: 'x-kodykoalaAccessToken',
+		value: 'stale-access-token',
+		scope: 'user',
+		description: '',
+		storageContext,
+	})
+	await saveSecret({
+		env,
+		userId,
+		name: 'x-kodykoalaRefreshToken',
+		value: 'current-refresh-token',
+		scope: 'user',
+		description: '',
+		storageContext,
+	})
+	await approveSecretHosts(env, userId, 'x-kodykoalaRefreshToken', [
+		'api.x.com',
+	])
+
+	const fetchMock = stubTokenEndpoint({
+		access_token: 'fresh-x-access-token',
+		refresh_token: 'rotated-x-refresh-token',
+	})
+	try {
+		const result = await refreshAndMaterializeUserLaneAccessToken({
+			env,
+			userId,
+			name: 'x-kodykoala',
+		})
+		expect(result.accessToken).toBe('fresh-x-access-token')
+		expect(result.refreshTokenRotated).toBe(true)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+
+		const persistedAccess = await resolveSecret({
+			env,
+			userId,
+			name: 'x-kodykoalaAccessToken',
+			scope: 'user',
+			storageContext,
+		})
+		expect(persistedAccess.found && persistedAccess.value).toBe(
+			'fresh-x-access-token',
+		)
+		expect(persistedAccess.found && persistedAccess.allowedPackages).toEqual([])
+	} finally {
+		vi.unstubAllGlobals()
+	}
+
+	await upsertPlatformOauthApp({
+		db: env.APP_DB,
+		env,
+		app: {
+			slug: 'github',
+			clientId: 'platform-github-client-id',
+			clientSecret: 'platform-github-client-secret-value',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+		},
+	})
+	await upsertPlatformIntegration({
+		env,
+		userId,
+		platformAppSlug: 'github',
+		scopes: [],
+		accessTokenSecretName: 'githubAccessToken',
+		refreshTokenSecretName: 'githubRefreshToken',
+	})
+	await seedUserTokens(env, userId, 'github')
+	await expect(
+		refreshAndMaterializeUserLaneAccessToken({
+			env,
+			userId,
+			name: 'github',
+		}),
+	).rejects.toBeInstanceOf(IntegrationRawTokenRefusedError)
 })

--- a/packages/worker/src/integrations/token-refresh.ts
+++ b/packages/worker/src/integrations/token-refresh.ts
@@ -592,3 +592,71 @@ async function refreshIntegrationTokensOrThrow(input: {
 
 	return { refreshedAt, refreshTokenRotated }
 }
+
+export function createPlatformRawTokenRefusedMessage(providerName: string) {
+	return `Integration "${providerName}" is a platform (built-in) integration: raw tokens are never exposed to sandboxed code. Use createAuthenticatedFetch("${providerName}") — it refreshes host-side via integration_token_refresh automatically.`
+}
+
+export class IntegrationRawTokenRefusedError extends Error {
+	constructor(providerName: string) {
+		super(createPlatformRawTokenRefusedMessage(providerName))
+		this.name = 'IntegrationRawTokenRefusedError'
+	}
+}
+
+export type IntegrationRefreshAccessTokenResult =
+	IntegrationTokenRefreshResult & {
+		accessToken: string
+	}
+
+/**
+ * User-lane `refreshAccessToken` host path: rotate tokens through
+ * `refreshIntegrationTokens` (no package `allowed_packages` write grant), then
+ * materialize the new access token for callers that cannot use an
+ * Authorization header. Platform connections are refused — raw tokens never
+ * leave the host for built-in apps.
+ */
+export async function refreshAndMaterializeUserLaneAccessToken(input: {
+	env: Env
+	userId: string
+	userEmail?: string | undefined
+	name: string
+	waitUntil?: (promise: Promise<unknown>) => void
+}): Promise<IntegrationRefreshAccessTokenResult> {
+	const joined = await getJoinedIntegration({
+		env: input.env,
+		userId: input.userId,
+		name: input.name,
+	})
+	if (!joined) {
+		throw callerRefreshError(`Integration "${input.name}" was not found.`, {
+			reason: 'not_found',
+		})
+	}
+	if (joined.lane === 'platform') {
+		throw new IntegrationRawTokenRefusedError(joined.connection.name)
+	}
+
+	const result = await refreshIntegrationTokens(input)
+	const accessTokenSecretName = joined.connection.accessTokenSecretName.trim()
+	const accessTokenSecret = await resolveSecret({
+		env: input.env,
+		userId: input.userId,
+		name: accessTokenSecretName,
+		scope: 'user',
+		storageContext: { sessionId: null, appId: null, packageId: null },
+	})
+	if (!accessTokenSecret.found || !accessTokenSecret.value) {
+		throw callerRefreshError(
+			`Access token secret "${accessTokenSecretName}" was not found after refreshing integration "${joined.connection.name}".`,
+			{
+				reason: 'missing_secret',
+				integration: snapshotJoinedIntegration(joined),
+			},
+		)
+	}
+	return {
+		...result,
+		accessToken: accessTokenSecret.value,
+	}
+}

--- a/packages/worker/src/mcp/capabilities/integrations/domain.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/domain.ts
@@ -9,6 +9,7 @@ import { integrationOauthAppRotateCredentialsCapability } from './integration-oa
 import { integrationPlatformAppListCapability } from './integration-platform-app-list.ts'
 import { integrationRegistrySearchCapability } from './integration-registry-search.ts'
 import { integrationSaveCapability } from './integration-save.ts'
+import { integrationRefreshAccessTokenCapability } from './integration-refresh-access-token.ts'
 import { integrationTokenRefreshCapability } from './integration-token-refresh.ts'
 import { openapiClientScaffoldCapability } from './openapi-client-scaffold.ts'
 import { openapiSpecSummarizeCapability } from './openapi-spec-summarize.ts'
@@ -42,6 +43,7 @@ export const integrationsDomain = defineDomain({
 		integrationOauthAppRotateCredentialsCapability,
 		integrationPlatformAppListCapability,
 		integrationTokenRefreshCapability,
+		integrationRefreshAccessTokenCapability,
 		integrationRegistrySearchCapability,
 		integrationDiscoverCapability,
 		openapiSpecSummarizeCapability,

--- a/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.node.test.ts
@@ -2,8 +2,12 @@ import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
 
 vi.mock('#worker/integrations/package-subscriptions.ts', () => ({
-	dispatchIntegrationAuthFailedSubscriptionEvents: vi.fn(async () => []),
-	dispatchIntegrationAuthSucceededSubscriptionEvents: vi.fn(async () => []),
+	dispatchIntegrationAuthFailedSubscriptionEvents: vi.fn<
+		() => Promise<Array<unknown>>
+	>(async () => []),
+	dispatchIntegrationAuthSucceededSubscriptionEvents: vi.fn<
+		() => Promise<Array<unknown>>
+	>(async () => []),
 	integrationAuthFailedTopic: 'integration.auth.failed',
 	integrationAuthSucceededTopic: 'integration.auth.succeeded',
 }))
@@ -12,7 +16,12 @@ import { createMcpCallerContext } from '#mcp/context.ts'
 import { PackageSecretAccessDeniedError } from '#mcp/secrets/package-access.ts'
 import { saveSecret, setSecretAllowedHosts } from '#mcp/secrets/service.ts'
 import { insertCommunityFork } from '#worker/community/repo.ts'
-import { upsertIntegration } from '#worker/integrations/service.ts'
+import { upsertPlatformOauthApp } from '#worker/integrations/platform-apps.ts'
+import {
+	upsertIntegration,
+	upsertPlatformIntegration,
+} from '#worker/integrations/service.ts'
+import { createPlatformRawTokenRefusedMessage } from '#worker/integrations/token-refresh.ts'
 import { insertSavedPackage } from '#worker/package-registry/repo.ts'
 import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
@@ -110,7 +119,7 @@ test('self-authored packages can materialize a refreshed access token without an
 	await seedUserLaneX(env, userId)
 	await insertPackage(env, userId, packageId)
 
-	const fetchMock = vi.fn(
+	const fetchMock = vi.fn<typeof fetch>(
 		async () =>
 			new Response(
 				JSON.stringify({
@@ -191,6 +200,72 @@ test('self-authored packages can materialize a refreshed access token without an
 			expect(error).toBeInstanceOf(McpCallerError)
 			expect((error as Error).message).toContain(
 				'is not allowed for package "x-fork"',
+			)
+			return true
+		})
+		expect(fetchMock).not.toHaveBeenCalled()
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('platform integrations refuse raw-token materialize before contacting the provider', async () => {
+	const { env } = createHarness()
+	const userId = 'user-platform'
+	const packageId = 'pkg-platform-1'
+	await insertPackage(env, userId, packageId)
+	await upsertPlatformOauthApp({
+		db: env.APP_DB,
+		env,
+		app: {
+			slug: 'github',
+			clientId: 'platform-github-client-id',
+			clientSecret: 'platform-github-client-secret-value',
+			tokenUrl: 'https://github.com/login/oauth/access_token',
+			authorizeUrl: 'https://github.com/login/oauth/authorize',
+			apiBaseUrl: 'https://api.github.com',
+			flow: 'confidential',
+		},
+	})
+	await upsertPlatformIntegration({
+		env,
+		userId,
+		platformAppSlug: 'github',
+		scopes: [],
+		accessTokenSecretName: 'githubAccessToken',
+		refreshTokenSecretName: 'githubRefreshToken',
+	})
+
+	const fetchMock = vi.fn<typeof fetch>(async () => {
+		throw new Error('provider must not be contacted for platform raw tokens')
+	})
+	vi.stubGlobal('fetch', fetchMock)
+	try {
+		await expect(
+			integrationRefreshAccessTokenCapability.handler(
+				{ name: 'github' },
+				{
+					env,
+					callerContext: createMcpCallerContext({
+						baseUrl: 'https://kody.codes',
+						user: {
+							userId,
+							email: 'me@kentcdodds.com',
+							displayName: 'Kent',
+						},
+						storageContext: {
+							sessionId: null,
+							appId: null,
+							packageId,
+							storageId: null,
+						},
+					}),
+				},
+			),
+		).rejects.toSatisfy((error: unknown) => {
+			expect(error).toBeInstanceOf(McpCallerError)
+			expect((error as Error).message).toBe(
+				createPlatformRawTokenRefusedMessage('github'),
 			)
 			return true
 		})

--- a/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.node.test.ts
@@ -1,0 +1,201 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+
+vi.mock('#worker/integrations/package-subscriptions.ts', () => ({
+	dispatchIntegrationAuthFailedSubscriptionEvents: vi.fn(async () => []),
+	dispatchIntegrationAuthSucceededSubscriptionEvents: vi.fn(async () => []),
+	integrationAuthFailedTopic: 'integration.auth.failed',
+	integrationAuthSucceededTopic: 'integration.auth.succeeded',
+}))
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+import { PackageSecretAccessDeniedError } from '#mcp/secrets/package-access.ts'
+import { saveSecret, setSecretAllowedHosts } from '#mcp/secrets/service.ts'
+import { insertCommunityFork } from '#worker/community/repo.ts'
+import { upsertIntegration } from '#worker/integrations/service.ts'
+import { insertSavedPackage } from '#worker/package-registry/repo.ts'
+import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { integrationRefreshAccessTokenCapability } from './integration-refresh-access-token.ts'
+
+const migrationsDirectory = new URL('../../../../migrations/', import.meta.url)
+const storageContext = { sessionId: null, appId: null, packageId: null }
+
+function createHarness() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyRepositoryMigrations(sqlite, migrationsDirectory)
+	const env = {
+		APP_DB: createD1FromSqlite(sqlite),
+		SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+		...createInMemoryUserMeterEnv().env,
+	} as Env
+	return { env }
+}
+
+async function seedUserLaneX(env: Env, userId: string) {
+	await upsertIntegration({
+		env,
+		userId,
+		config: {
+			name: 'x-kodykoala',
+			tokenUrl: 'https://api.x.com/2/oauth2/token',
+			flow: 'pkce',
+			clientId: 'x-client-id',
+			accessTokenSecretName: 'x-kodykoalaAccessToken',
+			refreshTokenSecretName: 'x-kodykoalaRefreshToken',
+			requiredHosts: ['api.x.com'],
+			authorization: {
+				authorizeUrl: 'https://x.com/i/oauth2/authorize',
+				scopes: ['tweet.read'],
+				scopeSeparator: ' ',
+				extraAuthorizeParams: {},
+			},
+		},
+	})
+	await saveSecret({
+		env,
+		userId,
+		name: 'x-kodykoalaAccessToken',
+		value: 'stale-access-token',
+		scope: 'user',
+		description: '',
+		storageContext,
+	})
+	await saveSecret({
+		env,
+		userId,
+		name: 'x-kodykoalaRefreshToken',
+		value: 'current-refresh-token',
+		scope: 'user',
+		description: '',
+		storageContext,
+	})
+	await setSecretAllowedHosts({
+		env,
+		userId,
+		name: 'x-kodykoalaRefreshToken',
+		scope: 'user',
+		allowedHosts: ['api.x.com'],
+		storageContext,
+	})
+}
+
+async function insertPackage(
+	env: Env,
+	userId: string,
+	packageId: string,
+	input: { name: string; kodyId: string } = {
+		name: '@kentcdodds/x',
+		kodyId: 'x',
+	},
+) {
+	await insertSavedPackage(env.APP_DB, {
+		id: packageId,
+		user_id: userId,
+		name: input.name,
+		kody_id: input.kodyId,
+		description: 'X helpers',
+		tags_json: '[]',
+		search_text: null,
+		source_id: `source-${packageId}`,
+		has_app: 0,
+	})
+}
+
+test('self-authored packages can materialize a refreshed access token without an allowed_packages write grant', async () => {
+	const { env } = createHarness()
+	const userId = 'user-x'
+	const packageId = '0f5b1512-1e45-45f9-a08d-0c574055abda'
+	await seedUserLaneX(env, userId)
+	await insertPackage(env, userId, packageId)
+
+	const fetchMock = vi.fn(
+		async () =>
+			new Response(
+				JSON.stringify({
+					access_token: 'fresh-x-access-token',
+					refresh_token: 'rotated-x-refresh-token',
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+	)
+	vi.stubGlobal('fetch', fetchMock)
+	try {
+		const result = await integrationRefreshAccessTokenCapability.handler(
+			{ name: 'x-kodykoala' },
+			{
+				env,
+				callerContext: createMcpCallerContext({
+					baseUrl: 'https://kody.codes',
+					user: {
+						userId,
+						email: 'me@kentcdodds.com',
+						displayName: 'Kent',
+					},
+					storageContext: {
+						sessionId: null,
+						appId: null,
+						packageId,
+						storageId: null,
+					},
+				}),
+			},
+		)
+		expect(result).toMatchObject({
+			accessToken: 'fresh-x-access-token',
+			refreshTokenRotated: true,
+		})
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+
+		const forkPackageId = 'fork-pkg-1'
+		await insertPackage(env, userId, forkPackageId, {
+			name: '@someone/x',
+			kodyId: 'x-fork',
+		})
+		await insertCommunityFork(env.APP_DB, {
+			id: 'fork-1',
+			listing_id: 'listing-1',
+			forker_user_id: userId,
+			origin_commit: 'abc123',
+			forked_package_id: forkPackageId,
+			forked_source_id: `source-${forkPackageId}`,
+			target_kody_id: 'x',
+			listing_name: '@someone/x',
+			listing_kody_id: 'x',
+		})
+		fetchMock.mockClear()
+		await expect(
+			integrationRefreshAccessTokenCapability.handler(
+				{ name: 'x-kodykoala' },
+				{
+					env,
+					callerContext: createMcpCallerContext({
+						baseUrl: 'https://kody.codes',
+						user: {
+							userId,
+							email: 'me@kentcdodds.com',
+							displayName: 'Kent',
+						},
+						storageContext: {
+							sessionId: null,
+							appId: null,
+							packageId: forkPackageId,
+							storageId: null,
+						},
+					}),
+				},
+			),
+		).rejects.toSatisfy((error: unknown) => {
+			expect(error).toBeInstanceOf(PackageSecretAccessDeniedError)
+			expect(error).toBeInstanceOf(McpCallerError)
+			expect((error as Error).message).toContain(
+				'is not allowed for package "x-fork"',
+			)
+			return true
+		})
+		expect(fetchMock).not.toHaveBeenCalled()
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})

--- a/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-refresh-access-token.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { assertPackageCanAccessResolvedSecret } from '#mcp/secrets/package-access.ts'
+import { resolveSecret } from '#mcp/secrets/service.ts'
+import { getJoinedIntegration } from '#worker/integrations/service.ts'
+import {
+	createPlatformRawTokenRefusedMessage,
+	IntegrationRawTokenRefusedError,
+	IntegrationTokenRefreshCallerError,
+	refreshAndMaterializeUserLaneAccessToken,
+} from '#worker/integrations/token-refresh.ts'
+
+const inputSchema = z.object({
+	name: z
+		.string()
+		.min(1)
+		.describe(
+			'User-lane integration (connection) name to refresh. Returns the new access token. Platform (built-in) integrations are refused.',
+		),
+})
+
+const outputSchema = z.object({
+	accessToken: z.string(),
+	refreshedAt: z.string(),
+	refreshTokenRotated: z.boolean(),
+})
+
+async function assertCallerCanUseIntegrationTokenSecrets(input: {
+	env: Env
+	baseUrl: string
+	userId: string
+	storageContext: {
+		sessionId: string | null
+		appId: string | null
+		packageId: string | null
+		storageId: string | null
+	}
+	secretNames: Array<string>
+}) {
+	if (!input.storageContext.packageId) return
+	for (const secretName of input.secretNames) {
+		const resolved = await resolveSecret({
+			env: input.env,
+			userId: input.userId,
+			name: secretName,
+			scope: 'user',
+			storageContext: input.storageContext,
+		})
+		if (!resolved.found) continue
+		await assertPackageCanAccessResolvedSecret({
+			env: input.env,
+			baseUrl: input.baseUrl,
+			userId: input.userId,
+			storageContext: input.storageContext,
+			secretName,
+			resolved,
+			intent: 'use',
+		})
+	}
+}
+
+export const integrationRefreshAccessTokenCapability = defineDomainCapability(
+	capabilityDomainNames.integrations,
+	{
+		name: 'integration_refresh_access_token',
+		description:
+			'Refresh a user-lane OAuth integration host-side and return the new access token. Token rotation persists without an allowed_packages write grant (same path as integration_token_refresh). Platform (built-in) integrations are refused — use createAuthenticatedFetch instead. Prefer createAuthenticatedFetch whenever an Authorization header works.',
+		keywords: [
+			'integration',
+			'oauth',
+			'token',
+			'refresh',
+			'access token',
+			'refreshAccessToken',
+			'raw token',
+		],
+		readOnly: false,
+		idempotent: false,
+		destructive: false,
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			const storageContext = {
+				sessionId: ctx.callerContext.storageContext?.sessionId ?? null,
+				appId: ctx.callerContext.storageContext?.appId ?? null,
+				packageId: ctx.callerContext.storageContext?.packageId ?? null,
+				storageId: ctx.callerContext.storageContext?.storageId ?? null,
+			}
+			const joined = await getJoinedIntegration({
+				env: ctx.env,
+				userId: user.userId,
+				name: args.name,
+			})
+			if (joined?.lane === 'platform') {
+				throw new McpCallerError(
+					createPlatformRawTokenRefusedMessage(joined.connection.name),
+				)
+			}
+			if (joined) {
+				const secretNames = [
+					joined.connection.refreshTokenSecretName,
+					joined.connection.accessTokenSecretName,
+				].filter((name): name is string => Boolean(name?.trim()))
+				await assertCallerCanUseIntegrationTokenSecrets({
+					env: ctx.env,
+					baseUrl: ctx.callerContext.baseUrl,
+					userId: user.userId,
+					storageContext,
+					secretNames,
+				})
+			}
+			try {
+				return await refreshAndMaterializeUserLaneAccessToken({
+					env: ctx.env,
+					userId: user.userId,
+					userEmail: user.email,
+					name: args.name,
+					waitUntil: ctx.waitUntil,
+				})
+			} catch (error) {
+				if (error instanceof IntegrationRawTokenRefusedError) {
+					throw new McpCallerError(error.message, { cause: error })
+				}
+				if (error instanceof IntegrationTokenRefreshCallerError) {
+					throw new McpCallerError(error.message, { cause: error })
+				}
+				throw error
+			}
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/openapi-provider/operation-request.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/openapi-provider/operation-request.node.test.ts
@@ -4,6 +4,7 @@ import { IntegrationHostNotAllowedError } from '#mcp/execute-modules/integration
 import * as secretService from '#mcp/secrets/service.ts'
 import * as communityRepo from '#worker/community/repo.ts'
 import * as integrationsService from '#worker/integrations/service.ts'
+import * as tokenRefresh from '#worker/integrations/token-refresh.ts'
 import * as packageRepo from '#worker/package-registry/repo.ts'
 import * as usageModule from '#worker/usage/record-usage.ts'
 import { type OpenApiBinding } from '#worker/openapi/binding-shared.ts'
@@ -516,51 +517,18 @@ test('integration auth 401 triggers host-side refresh retry', async () => {
 			allowedCapabilities: [],
 			allowedPackages: [],
 		})
-	const setSecretsSpy = vi
-		.spyOn(secretService, 'setSecretsAtomically')
-		.mockResolvedValue([
-			{
-				name: 'spotifyRefreshToken',
-				scope: 'user',
-				description: '',
-				packageId: null,
-				createdAt: '2026-03-29T00:00:00.000Z',
-				updatedAt: '2026-03-29T00:00:00.000Z',
-				ttlMs: null,
-				allowedHosts: [],
-				allowedCapabilities: [],
-				allowedPackages: [],
-			},
-			{
-				name: 'spotifyAccessToken',
-				scope: 'user',
-				description: '',
-				packageId: null,
-				createdAt: '2026-03-29T00:00:00.000Z',
-				updatedAt: '2026-03-29T00:00:00.000Z',
-				ttlMs: null,
-				allowedHosts: [],
-				allowedCapabilities: [],
-				allowedPackages: [],
-			},
-		])
+	const refreshSpy = vi
+		.spyOn(tokenRefresh, 'refreshIntegrationTokens')
+		.mockResolvedValue({
+			refreshedAt: '2026-03-29T00:00:00.000Z',
+			refreshTokenRotated: true,
+		})
 
 	try {
 		let apiCalls = 0
 		let firstUnauthorizedResponse: Response | null = null
 		const fetchStub = vi.fn(async (request: Request) => {
-			if (request.url.includes('/api/token')) {
-				const body = await request.text()
-				expect(body).toContain('grant_type=refresh_token')
-				expect(body).toContain('client_id=client-id-value')
-				return new Response(
-					JSON.stringify({
-						access_token: 'new-access',
-						refresh_token: 'new-refresh',
-					}),
-					{ status: 200, headers: { 'content-type': 'application/json' } },
-				)
-			}
+			expect(request.url.includes('/api/token')).toBe(false)
 			apiCalls += 1
 			if (apiCalls === 1) {
 				const response = new Response(JSON.stringify({ error: 'expired' }), {
@@ -599,23 +567,10 @@ test('integration auth 401 triggers host-side refresh retry', async () => {
 		expect(result.ok).toBe(true)
 		expect(result.body).toEqual({ ok: true })
 		expect(apiCalls).toBe(2)
-		expect(setSecretsSpy).toHaveBeenCalledWith(
+		expect(refreshSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
 				userId: 'user-1',
-				secrets: [
-					{
-						name: 'spotifyRefreshToken',
-						value: 'new-refresh',
-						scope: 'user',
-						description: 'Refresh token for integration spotify',
-					},
-					{
-						name: 'spotifyAccessToken',
-						value: 'new-access',
-						scope: 'user',
-						description: 'Access token for integration spotify',
-					},
-				],
+				name: 'spotify',
 			}),
 		)
 		expect(firstUnauthorizedResponse).not.toBeNull()
@@ -628,7 +583,7 @@ test('integration auth 401 triggers host-side refresh retry', async () => {
 	} finally {
 		getIntegrationSpy.mockRestore()
 		resolveSpy.mockRestore()
-		setSecretsSpy.mockRestore()
+		refreshSpy.mockRestore()
 		usageSpy.mockRestore()
 	}
 })

--- a/packages/worker/src/mcp/capabilities/openapi-provider/operation-request.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/openapi-provider/operation-request.node.test.ts
@@ -588,6 +588,83 @@ test('integration auth 401 triggers host-side refresh retry', async () => {
 	}
 })
 
+test('failed host-side refresh guidance omits provider error details', async () => {
+	const usageSpy = vi
+		.spyOn(usageModule, 'recordUsage')
+		.mockResolvedValue(undefined)
+	const getIntegrationSpy = vi
+		.spyOn(integrationsService, 'getIntegration')
+		.mockResolvedValue(spotifyIntegrationConfig)
+	const resolveSpy = vi
+		.spyOn(secretService, 'resolveSecret')
+		.mockResolvedValue({
+			found: true,
+			value: 'token-value',
+			scope: 'user',
+			allowedHosts: ['api.spotify.com', 'accounts.spotify.com'],
+			allowedCapabilities: [],
+			allowedPackages: [],
+		})
+	const refreshSpy = vi
+		.spyOn(tokenRefresh, 'refreshIntegrationTokens')
+		.mockRejectedValue(
+			new tokenRefresh.IntegrationTokenRefreshCallerError(
+				'Token refresh was rejected for integration "spotify" with HTTP 400 (invalid_grant: refresh_token=REFRESH-TOKEN-VALUE user_id=user-123). Reconnect at /connect/oauth?provider=spotify. (integration_token_refresh caller state)',
+				{
+					reason: 'provider_rejected',
+					providerError: 'invalid_grant',
+					providerErrorDescription:
+						'refresh_token=REFRESH-TOKEN-VALUE user_id=user-123',
+					httpStatus: 400,
+				},
+			),
+		)
+
+	try {
+		const fetchStub = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ error: 'expired' }), {
+					status: 401,
+					headers: { 'content-type': 'application/json' },
+				}),
+		)
+
+		const result = await executeOpenApiOperationRequest({
+			env: createEnv(),
+			userId: 'user-1',
+			baseUrl: 'https://app.example.com',
+			storageContext: null,
+			binding: {
+				...bindingBase,
+				apiBaseUrl: 'https://api.spotify.com/v1',
+				auth: { kind: 'integration', provider: 'spotify' },
+			},
+			operation: {
+				...getWidget,
+				path: '/me',
+				parameters: [],
+			},
+			args: {},
+			globalFetch: fetchStub as unknown as typeof fetch,
+		})
+
+		expect(result.ok).toBe(false)
+		expect(result.status).toBe(401)
+		expect(result.body).toEqual({
+			error: 'expired',
+			kodyGuidance:
+				'OpenAPI request returned HTTP 401; host-side token refresh failed. Reconnect the "spotify" integration at /connect/oauth, or call refreshAccessToken("spotify") from execute, then retry.',
+		})
+		expect(JSON.stringify(result.body)).not.toContain('REFRESH-TOKEN-VALUE')
+		expect(JSON.stringify(result.body)).not.toContain('user-123')
+	} finally {
+		getIntegrationSpy.mockRestore()
+		resolveSpy.mockRestore()
+		refreshSpy.mockRestore()
+		usageSpy.mockRestore()
+	}
+})
+
 test('integration auth enforces binding host pin and integration allowlist before attaching tokens', async () => {
 	const usageSpy = vi
 		.spyOn(usageModule, 'recordUsage')

--- a/packages/worker/src/mcp/capabilities/openapi-provider/operation-request.ts
+++ b/packages/worker/src/mcp/capabilities/openapi-provider/operation-request.ts
@@ -5,13 +5,12 @@ import {
 	buildBasicAuthSecretPlaceholder,
 	buildSecretPlaceholder,
 } from '#mcp/secrets/placeholders.ts'
-import { assertCanSetSecrets } from '#mcp/secrets/package-access.ts'
-import { setSecretsAtomically } from '#mcp/secrets/service.ts'
 import { type StorageContext } from '#mcp/storage.ts'
 import {
 	getIntegration,
 	type IntegrationConfig,
 } from '#worker/integrations/service.ts'
+import { refreshIntegrationTokens } from '#worker/integrations/token-refresh.ts'
 import {
 	normalizeApiBaseUrl,
 	type OpenApiBinding,
@@ -105,11 +104,7 @@ export async function executeOpenApiOperationRequest(input: {
 		const refreshed = await tryRefreshIntegrationAccessToken({
 			env: input.env,
 			userId: input.userId,
-			baseUrl: input.baseUrl,
 			provider: input.binding.auth.provider,
-			integration,
-			storageContext: input.storageContext,
-			globalFetch: input.globalFetch,
 		})
 		if (refreshed.ok) {
 			void response.body?.cancel().catch(() => {})
@@ -342,101 +337,15 @@ function isJsonContentType(contentType: string): boolean {
 async function tryRefreshIntegrationAccessToken(input: {
 	env: Env
 	userId: string
-	baseUrl: string
 	provider: string
-	integration: IntegrationConfig
-	storageContext: StorageContext | null
-	globalFetch?: typeof fetch
 }): Promise<{ ok: boolean; guidance?: string }> {
-	const refreshTokenSecretName =
-		input.integration.refreshTokenSecretName?.trim() ?? ''
-	if (!refreshTokenSecretName) {
-		return {
-			ok: false,
-			guidance: `OpenAPI request returned HTTP 401 and integration "${input.provider}" has no refreshTokenSecretName. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
-		}
-	}
-
-	const clientId = input.integration.clientId.trim()
-	if (!clientId) {
-		return {
-			ok: false,
-			guidance: `OpenAPI request returned HTTP 401; integration "${input.provider}" has no clientId. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
-		}
-	}
-
-	const accessTokenSecretName = input.integration.accessTokenSecretName.trim()
-	if (!accessTokenSecretName) {
-		return {
-			ok: false,
-			guidance: `OpenAPI request returned HTTP 401; integration "${input.provider}" has no accessTokenSecretName. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
-		}
-	}
-
 	try {
-		await assertCanSetSecrets({
+		await refreshIntegrationTokens({
 			env: input.env,
 			userId: input.userId,
-			baseUrl: input.baseUrl,
-			secrets: [
-				{ name: refreshTokenSecretName, scope: 'user' },
-				{ name: accessTokenSecretName, scope: 'user' },
-			],
-			storageContext: input.storageContext,
+			name: input.provider,
 		})
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error)
-		return {
-			ok: false,
-			guidance: `OpenAPI request returned HTTP 401; cannot persist refreshed tokens for integration "${input.provider}": ${message}. Call refreshAccessToken("${input.provider}") from execute after approving the package for those secrets, then retry.`,
-		}
-	}
-
-	const params = new URLSearchParams()
-	params.set('grant_type', 'refresh_token')
-	params.set(
-		'refresh_token',
-		buildSecretPlaceholder({ name: refreshTokenSecretName, scope: 'user' }),
-	)
-	params.set('client_id', clientId)
-	if (input.integration.flow === 'confidential') {
-		const clientSecretSecretName =
-			input.integration.clientSecretSecretName?.trim() ?? ''
-		if (!clientSecretSecretName) {
-			return {
-				ok: false,
-				guidance: `OpenAPI request returned HTTP 401; integration "${input.provider}" uses confidential flow but has no clientSecretSecretName. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
-			}
-		}
-		params.set(
-			'client_secret',
-			buildSecretPlaceholder({
-				name: clientSecretSecretName,
-				scope: 'user',
-			}),
-		)
-	}
-
-	let refreshResponse: Response
-	try {
-		refreshResponse = await executeGatewayFetch({
-			env: input.env,
-			props: {
-				baseUrl: input.baseUrl,
-				userId: input.userId,
-				email: null,
-				storageContext: input.storageContext,
-			},
-			request: new Request(input.integration.tokenUrl, {
-				method: 'POST',
-				headers: {
-					Accept: 'application/json',
-					'Content-Type': 'application/x-www-form-urlencoded',
-				},
-				body: params.toString(),
-			}),
-			globalFetch: input.globalFetch,
-		})
+		return { ok: true }
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
 		return {
@@ -444,63 +353,6 @@ async function tryRefreshIntegrationAccessToken(input: {
 			guidance: `OpenAPI request returned HTTP 401; host-side token refresh failed: ${message}. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
 		}
 	}
-
-	let payload: Record<string, unknown>
-	try {
-		payload = (await refreshResponse.json()) as Record<string, unknown>
-	} catch {
-		return {
-			ok: false,
-			guidance: `OpenAPI request returned HTTP 401; token refresh response was not JSON. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
-		}
-	}
-
-	if (!refreshResponse.ok || typeof payload.access_token !== 'string') {
-		return {
-			ok: false,
-			guidance: `OpenAPI request returned HTTP 401; token refresh failed with HTTP ${refreshResponse.status}. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
-		}
-	}
-
-	const secretsToPersist: Array<{
-		name: string
-		value: string
-		scope: 'user'
-		description: string
-	}> = []
-	if (
-		typeof payload.refresh_token === 'string' &&
-		payload.refresh_token.length > 0
-	) {
-		secretsToPersist.push({
-			name: refreshTokenSecretName,
-			value: payload.refresh_token,
-			scope: 'user',
-			description: `Refresh token for integration ${input.provider}`,
-		})
-	}
-	secretsToPersist.push({
-		name: accessTokenSecretName,
-		value: payload.access_token,
-		scope: 'user',
-		description: `Access token for integration ${input.provider}`,
-	})
-
-	try {
-		await setSecretsAtomically({
-			env: input.env,
-			userId: input.userId,
-			secrets: secretsToPersist,
-			storageContext: input.storageContext,
-		})
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error)
-		return {
-			ok: false,
-			guidance: `OpenAPI request returned HTTP 401; failed to persist refreshed tokens for integration "${input.provider}": ${message}. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
-		}
-	}
-	return { ok: true }
 }
 
 async function readOperationResponse(

--- a/packages/worker/src/mcp/capabilities/openapi-provider/operation-request.ts
+++ b/packages/worker/src/mcp/capabilities/openapi-provider/operation-request.ts
@@ -10,7 +10,10 @@ import {
 	getIntegration,
 	type IntegrationConfig,
 } from '#worker/integrations/service.ts'
-import { refreshIntegrationTokens } from '#worker/integrations/token-refresh.ts'
+import {
+	IntegrationTokenRefreshCallerError,
+	refreshIntegrationTokens,
+} from '#worker/integrations/token-refresh.ts'
 import {
 	normalizeApiBaseUrl,
 	type OpenApiBinding,
@@ -347,10 +350,13 @@ async function tryRefreshIntegrationAccessToken(input: {
 		})
 		return { ok: true }
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error)
+		const reconnectHint =
+			error instanceof IntegrationTokenRefreshCallerError
+				? ` Reconnect the "${input.provider}" integration at /connect/oauth, or call refreshAccessToken("${input.provider}") from execute, then retry.`
+				: ` Call refreshAccessToken("${input.provider}") from execute, then retry.`
 		return {
 			ok: false,
-			guidance: `OpenAPI request returned HTTP 401; host-side token refresh failed: ${message}. Call refreshAccessToken("${input.provider}") from execute, then retry.`,
+			guidance: `OpenAPI request returned HTTP 401; host-side token refresh failed.${reconnectHint}`,
 		}
 	}
 }

--- a/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/authenticated-fetch.node.test.ts
@@ -31,8 +31,15 @@ function createKody(integration = spotifyIntegration) {
 			expect(args.name).toBe('spotify')
 			return { integration }
 		},
-		async secret_set_many() {
-			return { ok: true, assertOnly: false, secrets: [] }
+		async integration_token_refresh() {
+			return {
+				ok: true,
+				refreshedAt: new Date().toISOString(),
+				refreshTokenRotated: false,
+			}
+		},
+		async integration_refresh_access_token() {
+			throw new Error('createAuthenticatedFetch must not materialize tokens')
 		},
 	} satisfies KodyNamespace
 

--- a/packages/worker/src/mcp/execute-modules/kody-runtime-utils.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/kody-runtime-utils.node.test.ts
@@ -13,15 +13,6 @@ import {
 } from './kody-runtime-utils.ts'
 import { createMswNodeServer } from '#worker/test-support/msw-node-server.ts'
 
-type SecretSetManyCall = {
-	secrets: Array<{
-		name: string
-		value?: string
-		scope: string
-	}>
-	assertOnly?: boolean
-}
-
 type SandboxHelpers = {
 	refreshAccessToken: (providerName: string) => Promise<string>
 	createAuthenticatedFetch: (
@@ -65,11 +56,12 @@ const githubConfidentialIntegration = {
 function createKody(
 	integration = spotifyIntegration,
 	options: {
-		onSecretSetMany?: (call: SecretSetManyCall) => void | Promise<void>
+		accessToken?: string
+		onRefreshAccessToken?: (args: CapabilityArgs) => void | Promise<void>
 	} = {},
 ) {
-	const secretSetManyCalls: Array<SecretSetManyCall> = []
 	const tokenRefreshCalls: Array<CapabilityArgs> = []
+	const refreshAccessTokenCalls: Array<CapabilityArgs> = []
 	const storedSecrets = new Map<string, string>()
 	const kody = {
 		async integration_get(args: CapabilityArgs) {
@@ -85,31 +77,25 @@ function createKody(
 				refreshTokenRotated: false,
 			}
 		},
-		async secret_set_many(args: CapabilityArgs) {
-			const call = args as SecretSetManyCall
-			secretSetManyCalls.push(call)
-			await options.onSecretSetMany?.(call)
-			if (!call.assertOnly) {
-				for (const secret of call.secrets) {
-					if (typeof secret.value === 'string') {
-						storedSecrets.set(secret.name, secret.value)
-					}
-				}
-			}
+		async integration_refresh_access_token(args: CapabilityArgs) {
+			refreshAccessTokenCalls.push(args)
+			await options.onRefreshAccessToken?.(args)
+			const accessToken = options.accessToken ?? 'new-access-token'
+			storedSecrets.set(integration.accessTokenSecretName, accessToken)
 			return {
-				ok: true,
-				assertOnly: Boolean(call.assertOnly),
-				secrets: call.assertOnly
-					? []
-					: call.secrets.map((secret) => ({
-							name: secret.name,
-							scope: secret.scope,
-						})),
+				accessToken,
+				refreshedAt: new Date().toISOString(),
+				refreshTokenRotated: false,
 			}
 		},
 	} satisfies KodyNamespace
 
-	return { kody, secretSetManyCalls, tokenRefreshCalls, storedSecrets }
+	return {
+		kody,
+		tokenRefreshCalls,
+		refreshAccessTokenCalls,
+		storedSecrets,
+	}
 }
 
 function createSpotifyHandlers(options: {
@@ -202,17 +188,15 @@ test('kody oauth helpers refresh tokens, retry on missing or expired access toke
 	const rotatedRefreshFetchCalls: Array<Request> = []
 	const {
 		kody: rotatedKody,
-		secretSetManyCalls: rotatedSecretSetManyCalls,
+		refreshAccessTokenCalls,
 		storedSecrets: rotatedStoredSecrets,
-	} = createKody()
-	rotatedStoredSecrets.set('spotifyRefreshToken', 'old-refresh-token')
-	rotatedStoredSecrets.set('spotifyAccessToken', 'old-access-token')
+	} = createKody(spotifyIntegration, { accessToken: 'new-access-token' })
 	{
 		using _server = createMswNodeServer(
 			createSpotifyHandlers({
 				tokenPayload: {
-					access_token: 'new-access-token',
-					refresh_token: 'new-refresh-token',
+					access_token: 'should-not-be-used-in-sandbox',
+					refresh_token: 'should-not-be-used-in-sandbox',
 				},
 				fetchCalls: rotatedRefreshFetchCalls,
 			}),
@@ -220,47 +204,15 @@ test('kody oauth helpers refresh tokens, retry on missing or expired access toke
 		const rotatedAccessToken = await refreshAccessToken(rotatedKody, 'spotify')
 		expect(rotatedAccessToken).toBe('new-access-token')
 	}
-	expect(rotatedSecretSetManyCalls).toEqual([
-		{
-			secrets: [
-				{ name: 'spotifyRefreshToken', scope: 'user' },
-				{ name: 'spotifyAccessToken', scope: 'user' },
-			],
-			assertOnly: true,
-		},
-		{
-			secrets: [
-				{
-					name: 'spotifyRefreshToken',
-					value: 'new-refresh-token',
-					scope: 'user',
-				},
-				{
-					name: 'spotifyAccessToken',
-					value: 'new-access-token',
-					scope: 'user',
-				},
-			],
-		},
-	])
-	expect(rotatedRefreshFetchCalls).toHaveLength(1)
-	expect(rotatedRefreshFetchCalls[0]?.method).toBe('POST')
-	const rotatedRefreshBody = await rotatedRefreshFetchCalls[0]?.text()
-	expect(rotatedRefreshBody).toContain(
-		'refresh_token=%7B%7Bsecret%3AspotifyRefreshToken%7Cscope%3Duser%7D%7D',
-	)
-	expect(rotatedRefreshBody).toContain('client_id=spotify-client-id')
-	expect(rotatedRefreshBody).not.toContain('client_secret=')
+	expect(refreshAccessTokenCalls).toEqual([{ name: 'spotify' }])
+	expect(rotatedRefreshFetchCalls).toEqual([])
 	expect(Object.fromEntries(rotatedStoredSecrets)).toEqual({
-		spotifyRefreshToken: 'new-refresh-token',
 		spotifyAccessToken: 'new-access-token',
 	})
 
 	const storedTokenFetchCalls: Array<Request> = []
-	const {
-		kody: storedTokenKody,
-		secretSetManyCalls: storedSecretSetManyCalls,
-	} = createKody()
+	const { kody: storedTokenKody, tokenRefreshCalls: storedTokenRefreshCalls } =
+		createKody()
 	{
 		using _server = createMswNodeServer(
 			createSpotifyHandlers({
@@ -284,12 +236,11 @@ test('kody oauth helpers refresh tokens, retry on missing or expired access toke
 	expect(storedTokenFetchCalls[0]?.headers.get('authorization')).toBe(
 		'Bearer {{secret:spotifyAccessToken|scope=user}}',
 	)
-	expect(storedSecretSetManyCalls).toEqual([])
+	expect(storedTokenRefreshCalls).toEqual([])
 
 	const missingTokenFetchCalls: Array<Request> = []
 	const {
 		kody: missingTokenKody,
-		secretSetManyCalls: missingSecretSetManyCalls,
 		tokenRefreshCalls: missingTokenRefreshCalls,
 	} = createKody()
 	{
@@ -305,7 +256,6 @@ test('kody oauth helpers refresh tokens, retry on missing or expired access toke
 		const missingTokenResponse = await missingTokenFetch('/me?market=US')
 		expect(await missingTokenResponse.json()).toEqual({ ok: true })
 	}
-	expect(missingSecretSetManyCalls).toEqual([])
 	expect(missingTokenRefreshCalls).toEqual([{ name: 'spotify' }])
 	expect(missingTokenFetchCalls).toHaveLength(2)
 	expect(missingTokenFetchCalls[0]?.headers.get('authorization')).toBe(
@@ -318,7 +268,6 @@ test('kody oauth helpers refresh tokens, retry on missing or expired access toke
 	const expiredTokenFetchCalls: Array<Request> = []
 	const {
 		kody: expiredTokenKody,
-		secretSetManyCalls: expiredSecretSetManyCalls,
 		tokenRefreshCalls: expiredTokenRefreshCalls,
 	} = createKody()
 	{
@@ -337,7 +286,6 @@ test('kody oauth helpers refresh tokens, retry on missing or expired access toke
 		const expiredTokenResponse = await expiredTokenFetch('/me?market=US')
 		expect(await expiredTokenResponse.json()).toEqual({ ok: true })
 	}
-	expect(expiredSecretSetManyCalls).toEqual([])
 	expect(expiredTokenRefreshCalls).toEqual([{ name: 'spotify' }])
 	expect(expiredTokenFetchCalls).toHaveLength(2)
 	expect(expiredTokenFetchCalls[0]?.url).toBe(
@@ -351,17 +299,15 @@ test('kody oauth helpers refresh tokens, retry on missing or expired access toke
 	)
 })
 
-test('token refresh asserts package grants before the provider request and never consumes the token on denial', async () => {
+test('refreshAccessToken forwards host-side use denials and never exchanges tokens in the sandbox', async () => {
 	const fetchCalls: Array<Request> = []
-	const { kody, secretSetManyCalls, storedSecrets } = createKody(
+	const { kody, refreshAccessTokenCalls, storedSecrets } = createKody(
 		spotifyIntegration,
 		{
-			onSecretSetMany(call) {
-				if (call.assertOnly) {
-					throw new Error(
-						'Secret "spotifyRefreshToken" is not allowed for package "@test/spotify".',
-					)
-				}
+			onRefreshAccessToken() {
+				throw new Error(
+					'Secret "spotifyRefreshToken" is not allowed for package "@test/spotify".',
+				)
 			},
 		},
 	)
@@ -380,74 +326,8 @@ test('token refresh asserts package grants before the provider request and never
 		)
 	}
 	expect(fetchCalls).toEqual([])
-	expect(secretSetManyCalls).toEqual([
-		{
-			secrets: [
-				{ name: 'spotifyRefreshToken', scope: 'user' },
-				{ name: 'spotifyAccessToken', scope: 'user' },
-			],
-			assertOnly: true,
-		},
-	])
+	expect(refreshAccessTokenCalls).toEqual([{ name: 'spotify' }])
 	expect(storedSecrets.size).toBe(0)
-})
-
-test('token refresh keeps prior secret state when the atomic persist fails after a rotated provider response', async () => {
-	const fetchCalls: Array<Request> = []
-	const { kody, secretSetManyCalls, storedSecrets } = createKody(
-		spotifyIntegration,
-		{
-			onSecretSetMany(call) {
-				if (call.assertOnly) return
-				throw new Error('simulated second-write failure')
-			},
-		},
-	)
-	storedSecrets.set('spotifyRefreshToken', 'old-refresh-token')
-	storedSecrets.set('spotifyAccessToken', 'old-access-token')
-	{
-		using _server = createMswNodeServer(
-			createSpotifyHandlers({
-				tokenPayload: {
-					access_token: 'new-access-token',
-					refresh_token: 'new-refresh-token',
-				},
-				fetchCalls,
-			}),
-		)
-		await expect(refreshAccessToken(kody, 'spotify')).rejects.toThrow(
-			'simulated second-write failure',
-		)
-	}
-	expect(fetchCalls).toHaveLength(1)
-	expect(secretSetManyCalls).toEqual([
-		{
-			secrets: [
-				{ name: 'spotifyRefreshToken', scope: 'user' },
-				{ name: 'spotifyAccessToken', scope: 'user' },
-			],
-			assertOnly: true,
-		},
-		{
-			secrets: [
-				{
-					name: 'spotifyRefreshToken',
-					value: 'new-refresh-token',
-					scope: 'user',
-				},
-				{
-					name: 'spotifyAccessToken',
-					value: 'new-access-token',
-					scope: 'user',
-				},
-			],
-		},
-	])
-	// Atomic persist failed as one unit: neither rotated secret was committed.
-	expect(Object.fromEntries(storedSecrets)).toEqual({
-		spotifyRefreshToken: 'old-refresh-token',
-		spotifyAccessToken: 'old-access-token',
-	})
 })
 
 test('createExecuteHelperPrelude exposes sandbox oauth and secret helper bindings', async () => {
@@ -523,6 +403,7 @@ const githubPlatformIntegration = {
 
 function createPlatformKody() {
 	const tokenRefreshCalls: Array<CapabilityArgs> = []
+	const refreshAccessTokenCalls: Array<CapabilityArgs> = []
 	const kody = {
 		async integration_get(args: CapabilityArgs) {
 			expect(args.name).toBe(githubPlatformIntegration.name)
@@ -536,21 +417,24 @@ function createPlatformKody() {
 				refreshTokenRotated: false,
 			}
 		},
-		async secret_set_many() {
+		async integration_refresh_access_token(args: CapabilityArgs) {
+			refreshAccessTokenCalls.push(args)
 			throw new Error(
-				'platform refresh must never persist secrets from the sandbox',
+				'platform refresh must never materialize a raw access token',
 			)
 		},
 	} satisfies KodyNamespace
-	return { kody, tokenRefreshCalls }
+	return { kody, tokenRefreshCalls, refreshAccessTokenCalls }
 }
 
 test('refreshAccessToken refuses platform integrations instead of exposing a raw token', async () => {
-	const { kody, tokenRefreshCalls } = createPlatformKody()
+	const { kody, tokenRefreshCalls, refreshAccessTokenCalls } =
+		createPlatformKody()
 	await expect(refreshAccessToken(kody, 'github')).rejects.toThrow(
 		'raw tokens are never exposed to sandboxed code',
 	)
 	expect(tokenRefreshCalls).toEqual([])
+	expect(refreshAccessTokenCalls).toEqual([])
 })
 
 test('createAuthenticatedFetch refreshes platform integrations host-side and retries with a placeholder header', async () => {
@@ -610,45 +494,22 @@ function createGithubPlatformFetchInterceptor(options: {
 	}
 }
 
-test('confidential-flow token refresh includes inline client id and client secret placeholder', async () => {
+test('confidential-flow refreshAccessToken still delegates persist to the host helper', async () => {
 	const fetchCalls: Array<Request> = []
-	const { kody, secretSetManyCalls } = createKody(githubConfidentialIntegration)
+	const { kody, refreshAccessTokenCalls } = createKody(
+		githubConfidentialIntegration,
+		{ accessToken: 'new-github-access' },
+	)
 	{
 		using _server = createMswNodeServer([
 			http.post(githubConfidentialIntegration.tokenUrl, async ({ request }) => {
 				fetchCalls.push(request.clone())
-				return HttpResponse.json({ access_token: 'new-github-access' })
+				return HttpResponse.json({ access_token: 'should-not-be-used' })
 			}),
 		])
 		const accessToken = await refreshAccessToken(kody, 'github')
 		expect(accessToken).toBe('new-github-access')
 	}
-	expect(secretSetManyCalls).toEqual([
-		{
-			secrets: [
-				{ name: 'githubRefreshToken', scope: 'user' },
-				{ name: 'githubAccessToken', scope: 'user' },
-			],
-			assertOnly: true,
-		},
-		{
-			secrets: [
-				{
-					name: 'githubAccessToken',
-					value: 'new-github-access',
-					scope: 'user',
-				},
-			],
-		},
-	])
-	expect(fetchCalls).toHaveLength(1)
-	const body = await fetchCalls[0]?.text()
-	expect(body).toContain('grant_type=refresh_token')
-	expect(body).toContain('client_id=github-client-id')
-	expect(body).toContain(
-		'client_secret=%7B%7Bsecret%3AgithubClientSecret%7Cscope%3Duser%7D%7D',
-	)
-	expect(body).toContain(
-		'refresh_token=%7B%7Bsecret%3AgithubRefreshToken%7Cscope%3Duser%7D%7D',
-	)
+	expect(refreshAccessTokenCalls).toEqual([{ name: 'github' }])
+	expect(fetchCalls).toEqual([])
 })

--- a/packages/worker/src/mcp/execute-modules/kody-runtime-utils.node.test.ts
+++ b/packages/worker/src/mcp/execute-modules/kody-runtime-utils.node.test.ts
@@ -513,3 +513,23 @@ test('confidential-flow refreshAccessToken still delegates persist to the host h
 	expect(refreshAccessTokenCalls).toEqual([{ name: 'github' }])
 	expect(fetchCalls).toEqual([])
 })
+
+test('refreshAccessToken throws when the host helper capability is missing', async () => {
+	const { kody } = createKody(githubConfidentialIntegration)
+	const namespace = {
+		integration_get: kody.integration_get,
+		integration_token_refresh: kody.integration_token_refresh,
+	}
+	await expect(refreshAccessToken(namespace, 'github')).rejects.toThrow(
+		'kody.integration_refresh_access_token is not available in this sandbox.',
+	)
+})
+
+test('refreshAccessToken throws when the host helper returns no access token', async () => {
+	const { kody } = createKody(githubConfidentialIntegration, {
+		accessToken: '',
+	})
+	await expect(refreshAccessToken(kody, 'github')).rejects.toThrow(
+		'Host-side token refresh for integration "github" did not return an access token.',
+	)
+})

--- a/packages/worker/src/mcp/execute-modules/kody-runtime-utils.ts
+++ b/packages/worker/src/mcp/execute-modules/kody-runtime-utils.ts
@@ -80,8 +80,7 @@ export const secretHeaders = {
 export const EXECUTE_HELPER_CAPABILITY_NAMES = [
 	'integration_get',
 	'integration_token_refresh',
-	'secret_set',
-	'secret_set_many',
+	'integration_refresh_access_token',
 ] as const
 
 /**
@@ -93,6 +92,11 @@ export const EXECUTE_HELPER_CAPABILITY_NAMES = [
  * `createAuthenticatedFetch` refreshes host-side via
  * `integration_token_refresh` and never materializes tokens in the sandbox —
  * prefer it everywhere a fetch wrapper works.
+ *
+ * Token rotation persists host-side (`integration_refresh_access_token` →
+ * `integration_token_refresh`) and does not need an `allowed_packages` write
+ * grant. The helper still returns a raw access token for user-lane
+ * integrations and throws for platform ones.
  *
  * **Security boundary**: The returned value is a materialized credential. Once
  * in caller hands, the fetch gateway's host-allowlist check is bypassed because
@@ -110,7 +114,24 @@ export async function refreshAccessToken(
 			`Integration "${providerName}" is a platform (built-in) integration: raw tokens are never exposed to sandboxed code. Use createAuthenticatedFetch("${providerName}") — it refreshes host-side via integration_token_refresh automatically.`,
 		)
 	}
-	return refreshAccessTokenWithIntegration(kody, providerName, integration)
+	const refresh = kody.integration_refresh_access_token
+	if (typeof refresh !== 'function') {
+		throw new Error(
+			'kody.integration_refresh_access_token is not available in this sandbox.',
+		)
+	}
+	const result = (await refresh({ name: providerName })) as {
+		accessToken?: unknown
+	} | null
+	if (
+		typeof result?.accessToken !== 'string' ||
+		result.accessToken.length === 0
+	) {
+		throw new Error(
+			`Host-side token refresh for integration "${providerName}" did not return an access token.`,
+		)
+	}
+	return result.accessToken
 }
 
 async function refreshIntegrationTokensHostSide(
@@ -237,172 +258,6 @@ async function readIntegrationConfig(
 		throw new Error(`Integration "${providerName}" was not found.`)
 	}
 	return integration
-}
-
-async function assertSecretsCanBePersisted(
-	kody: KodyNamespace,
-	providerName: string,
-	secrets: Array<{
-		name: string
-		secretKind: 'access token' | 'refresh token'
-	}>,
-) {
-	const secretSetMany = kody.secret_set_many
-	if (typeof secretSetMany !== 'function') {
-		throw new Error('kody.secret_set_many is not available in this sandbox.')
-	}
-	const entries = secrets.map((secret) => {
-		const normalizedSecretName = secret.name.trim()
-		if (!normalizedSecretName) {
-			throw new Error(
-				`Integration "${providerName}" does not define an ${secret.secretKind} secret name.`,
-			)
-		}
-		return {
-			name: normalizedSecretName,
-			scope: 'user' as const,
-		}
-	})
-	await secretSetMany({
-		secrets: entries,
-		assertOnly: true,
-	})
-}
-
-async function persistSecretsAtomically(
-	kody: KodyNamespace,
-	providerName: string,
-	secrets: Array<{
-		name: string
-		secretKind: 'access token' | 'refresh token'
-		value: string
-	}>,
-) {
-	const secretSetMany = kody.secret_set_many
-	if (typeof secretSetMany !== 'function') {
-		throw new Error('kody.secret_set_many is not available in this sandbox.')
-	}
-	const entries = secrets.map((secret) => {
-		const normalizedSecretName = secret.name.trim()
-		if (!normalizedSecretName) {
-			throw new Error(
-				`Integration "${providerName}" does not define an ${secret.secretKind} secret name.`,
-			)
-		}
-		return {
-			name: normalizedSecretName,
-			value: secret.value,
-			scope: 'user' as const,
-		}
-	})
-	await secretSetMany({
-		secrets: entries,
-	})
-}
-
-async function refreshAccessTokenWithIntegration(
-	kody: KodyNamespace,
-	providerName: string,
-	integration: IntegrationConfig,
-) {
-	const clientId = integration.clientId.trim()
-	if (!clientId) {
-		throw new Error(
-			`Integration "${providerName}" does not define a client id.`,
-		)
-	}
-	const refreshTokenSecretName =
-		integration.refreshTokenSecretName?.trim() ?? ''
-	if (!refreshTokenSecretName) {
-		throw new Error(
-			`Integration "${providerName}" does not define a refresh token secret name.`,
-		)
-	}
-	const accessTokenSecretName = integration.accessTokenSecretName.trim()
-	if (!accessTokenSecretName) {
-		throw new Error(
-			`Integration "${providerName}" does not define an access token secret name.`,
-		)
-	}
-
-	// Fail closed before the provider request: rotating providers invalidate
-	// the old refresh token as soon as they issue a replacement. A later
-	// allowed_packages denial would permanently strand the integration.
-	await assertSecretsCanBePersisted(kody, providerName, [
-		{ name: refreshTokenSecretName, secretKind: 'refresh token' },
-		{ name: accessTokenSecretName, secretKind: 'access token' },
-	])
-
-	const params = new URLSearchParams()
-	params.set('grant_type', 'refresh_token')
-	params.set(
-		'refresh_token',
-		buildSecretPlaceholder(refreshTokenSecretName, 'user'),
-	)
-	params.set('client_id', clientId)
-
-	if (integration.flow === 'confidential') {
-		const clientSecretSecretName =
-			integration.clientSecretSecretName?.trim() ?? ''
-		if (!clientSecretSecretName) {
-			throw new Error(
-				`Integration "${providerName}" uses confidential flow but does not define a client secret secret name.`,
-			)
-		}
-		params.set(
-			'client_secret',
-			buildSecretPlaceholder(clientSecretSecretName, 'user'),
-		)
-	}
-
-	const response = await fetch(integration.tokenUrl, {
-		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-		body: params.toString(),
-	})
-	const payload = (await response.json()) as Record<string, unknown>
-
-	if (!response.ok) {
-		throw new Error(
-			`Token refresh failed for integration "${providerName}" with HTTP ${response.status}.`,
-		)
-	}
-	if (!payload || typeof payload.access_token !== 'string') {
-		throw new Error(
-			`Token refresh for integration "${providerName}" did not return an access_token.`,
-		)
-	}
-
-	// Refresh-token-before-access-token is load-bearing for rotating providers:
-	// if a process dies mid-write, keeping the new refresh token is preferable
-	// to keeping only the new access token. The atomic batch makes partial
-	// commits impossible; order is still preserved inside the batch.
-	const secretsToPersist: Array<{
-		name: string
-		secretKind: 'access token' | 'refresh token'
-		value: string
-	}> = []
-	if (
-		typeof payload.refresh_token === 'string' &&
-		payload.refresh_token.length > 0
-	) {
-		secretsToPersist.push({
-			name: refreshTokenSecretName,
-			secretKind: 'refresh token',
-			value: payload.refresh_token,
-		})
-	}
-	secretsToPersist.push({
-		name: accessTokenSecretName,
-		secretKind: 'access token',
-		value: payload.access_token,
-	})
-	await persistSecretsAtomically(kody, providerName, secretsToPersist)
-
-	return payload.access_token
 }
 
 function buildSecretPlaceholder(name: string, scope: SecretScope) {
@@ -657,56 +512,6 @@ const __kodyReadIntegrationConfig = async (providerName) => {
   }
   return integration;
 };
-const __kodyAssertSecretsCanBePersisted = async (
-  providerName,
-  secrets,
-) => {
-  const secretSetMany = kody.secret_set_many;
-  if (typeof secretSetMany !== 'function') {
-    throw new Error('kody.secret_set_many is not available in this sandbox.');
-  }
-  const entries = secrets.map((secret) => {
-    const normalizedSecretName = secret.name.trim();
-    if (!normalizedSecretName) {
-      throw new Error(
-        \`Integration "\${providerName}" does not define an \${secret.secretKind} secret name.\`,
-      );
-    }
-    return {
-      name: normalizedSecretName,
-      scope: 'user',
-    };
-  });
-  await secretSetMany({
-    secrets: entries,
-    assertOnly: true,
-  });
-};
-const __kodyPersistSecretsAtomically = async (
-  providerName,
-  secrets,
-) => {
-  const secretSetMany = kody.secret_set_many;
-  if (typeof secretSetMany !== 'function') {
-    throw new Error('kody.secret_set_many is not available in this sandbox.');
-  }
-  const entries = secrets.map((secret) => {
-    const normalizedSecretName = secret.name.trim();
-    if (!normalizedSecretName) {
-      throw new Error(
-        \`Integration "\${providerName}" does not define an \${secret.secretKind} secret name.\`,
-      );
-    }
-    return {
-      name: normalizedSecretName,
-      value: secret.value,
-      scope: 'user',
-    };
-  });
-  await secretSetMany({
-    secrets: entries,
-  });
-};
 const __kodyGetNormalizedApiBaseUrl = (integration) => {
   if (!integration.apiBaseUrl) return null;
   return integration.apiBaseUrl.endsWith('/')
@@ -773,84 +578,19 @@ const __kodyRefreshAccessToken = async (providerName) => {
       \`Integration "\${providerName}" is a platform (built-in) integration: raw tokens are never exposed to sandboxed code. Use createAuthenticatedFetch("\${providerName}") — it refreshes host-side via integration_token_refresh automatically.\`,
     );
   }
-  return __kodyRefreshAccessTokenWithIntegration(providerName, integration);
-};
-const __kodyRefreshAccessTokenWithIntegration = async (providerName, integration) => {
-  const clientId = integration.clientId.trim();
-  if (!clientId) {
+  const refresh = kody.integration_refresh_access_token;
+  if (typeof refresh !== 'function') {
     throw new Error(
-      \`Integration "\${providerName}" does not define a client id.\`,
+      'kody.integration_refresh_access_token is not available in this sandbox.',
     );
   }
-  const refreshTokenSecretName = integration.refreshTokenSecretName?.trim() ?? '';
-  if (!refreshTokenSecretName) {
+  const result = await refresh({ name: providerName });
+  if (typeof result?.accessToken !== 'string' || result.accessToken.length === 0) {
     throw new Error(
-      \`Integration "\${providerName}" does not define a refresh token secret name.\`,
+      \`Host-side token refresh for integration "\${providerName}" did not return an access token.\`,
     );
   }
-  const accessTokenSecretName = integration.accessTokenSecretName.trim();
-  if (!accessTokenSecretName) {
-    throw new Error(
-      \`Integration "\${providerName}" does not define an access token secret name.\`,
-    );
-  }
-  await __kodyAssertSecretsCanBePersisted(providerName, [
-    { name: refreshTokenSecretName, secretKind: 'refresh token' },
-    { name: accessTokenSecretName, secretKind: 'access token' },
-  ]);
-  const params = new URLSearchParams();
-  params.set('grant_type', 'refresh_token');
-  params.set(
-    'refresh_token',
-    __kodyBuildSecretPlaceholder(refreshTokenSecretName, 'user'),
-  );
-  params.set('client_id', clientId);
-  if (integration.flow === 'confidential') {
-    const clientSecretSecretName = integration.clientSecretSecretName?.trim() ?? '';
-    if (!clientSecretSecretName) {
-      throw new Error(
-        \`Integration "\${providerName}" uses confidential flow but does not define a client secret secret name.\`,
-      );
-    }
-    params.set(
-      'client_secret',
-      __kodyBuildSecretPlaceholder(clientSecretSecretName, 'user'),
-    );
-  }
-  const response = await fetch(integration.tokenUrl, {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: params.toString(),
-  });
-  const payload = await response.json();
-  if (!response.ok) {
-    throw new Error(
-      \`Token refresh failed for integration "\${providerName}" with HTTP \${response.status}.\`,
-    );
-  }
-  if (!payload || typeof payload.access_token !== 'string') {
-    throw new Error(
-      \`Token refresh for integration "\${providerName}" did not return an access_token.\`,
-    );
-  }
-  const secretsToPersist = [];
-  if (typeof payload.refresh_token === 'string' && payload.refresh_token.length > 0) {
-    secretsToPersist.push({
-      name: refreshTokenSecretName,
-      secretKind: 'refresh token',
-      value: payload.refresh_token,
-    });
-  }
-  secretsToPersist.push({
-    name: accessTokenSecretName,
-    secretKind: 'access token',
-    value: payload.access_token,
-  });
-  await __kodyPersistSecretsAtomically(providerName, secretsToPersist);
-  return payload.access_token;
+  return result.accessToken;
 };
 const __kodyCreateAuthenticatedFetch = async (providerName) => {
   const integration = await __kodyReadIntegrationConfig(providerName);

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2406,9 +2406,8 @@ test('runBundledModuleWithRegistry injects OAuth helper prelude only when execut
 				additionalTools: {
 					integration_get: async () => ({}),
 					integration_token_refresh: async () => ({}),
+					integration_refresh_access_token: async () => ({}),
 					value_get: async () => ({}),
-					secret_set: async () => ({}),
-					secret_set_many: async () => ({}),
 				},
 			}),
 		).resolves.toMatchObject({ result: 'ok' })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop self-authored helpers such as `@kentcdodds/x` from failing token rotation on a newly connected account (`x-kodykoala`) just because `/connect/oauth` did not add an `allowed_packages` write grant.

## Summary

- `refreshAccessToken` now refreshes host-side (`integration_refresh_access_token` → `refreshIntegrationTokens`) and then materializes the access token for user-lane integrations.
- Token rotation no longer goes through sandbox `secret_set_many`, so it does not need an `allowed_packages` write grant.
- Platform (built-in) integrations still refuse to expose a raw token.
- Unadopted community forks still need a read/use grant before a raw token is returned.
- OpenAPI integration 401 retry uses the same host persist path. Failed-refresh `kodyGuidance` is fixed caller-safe text (no provider `error_description`).
- Docs updated so official OAuth rotation is no longer described as a package secret mutation.

## Testing

- `npx vitest run` on the token-refresh, runtime-helper, OpenAPI 401, and capability suites (including the new guidance / refusal / helper-guard cases).
- Preview (`kody-pr-1542`): signed in as the seed user, created `x-previewkoalaAccessToken` / `x-previewkoalaRefreshToken` with empty `allowedPackages`, confirmed both on `/account/secrets` (package column `---`) and on the refresh-token detail ("No packages currently have access"). Re-run after this rebase once the preview worker is on the new head.

Immediate production unblock while this ships: approve both koala token secrets for package `x` at `/account/secrets/approve?package_id=0f5b1512-1e45-45f9-a08d-0c574055abda&package=x&names=x-kodykoalaAccessToken,x-kodykoalaRefreshToken`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `0e7067ab` · **Head:** `8fa6755e`

**Classification:** extends — OAuth token rotation persist for `refreshAccessToken` and OpenAPI 401 retry moves onto the existing host-side `refreshIntegrationTokens` path.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `integrations` | assistant | extends — new `integration_refresh_access_token` capability; user-lane raw-token refresh persists without a write grant |
| `capabilities-execute` | runtime | extends — `refreshAccessToken` no longer exchanges or writes secrets in the sandbox |
| `openapi-bindings` | assistant | extends — integration 401 retry calls `refreshIntegrationTokens` instead of package-context `secret_set`; failed-refresh guidance no longer interpolates provider error text |
| `mcp-server` | surfaces | composes — execute helper prelude binding list |

### Change flow

A package export that calls `refreshAccessToken` after a 401 now rotates tokens on the host, then receives only the new access token.

```mermaid
sequenceDiagram
	actor Package as package export
	participant capabilitiesExecute as capabilities-execute
	participant integrations as integrations
	participant secrets as secrets
	Package->>capabilitiesExecute: refreshAccessToken(x-kodykoala)
	capabilitiesExecute->>integrations: integration_refresh_access_token
	Note over integrations: use-intent check only; no allowed_packages write grant
	integrations->>integrations: refreshIntegrationTokens
	integrations->>secrets: saveSecret packageId null
	integrations-->>capabilitiesExecute: accessToken
	capabilitiesExecute-->>Package: raw access token
```

### Invariants

Per-user isolation is unchanged. Platform integrations still refuse raw-token materialization. Unadopted community forks still need a read/use grant before this helper returns a token.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bcd413c-7fcc-40bd-886d-e0f415a0338c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bcd413c-7fcc-40bd-886d-e0f415a0338c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added host-side OAuth access-token refresh for user-owned integrations.
  - Refreshed tokens are returned securely and persisted without package write approval.
  - Added capability support for refreshing integration access tokens.
  - Platform and built-in integrations remain restricted from exposing raw tokens.

- **Documentation**
  - Updated OAuth, integration, secret-management, and architecture guidance.
  - Clarified secret approval rules and token-refresh failure behavior.

- **Tests**
  - Added coverage for refresh success, persistence, access restrictions, and platform-integration denial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->