### PR TITLE
Fade the account rail when leaving shell pages

### DIFF
--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -353,8 +353,11 @@ export function AccountManagementLinkNav(
 				// The nav fills the shell's absolute left track (full height,
 				// so the sticky inner column has the whole page to stick
 				// through); below 860px it returns to flow as a wrapping row.
-				// Named so a view transition lifts it out of `<main>` / `page`
-				// and the rail stays still even if a transition still runs.
+				// Named so a view transition lifts it out of `<main>` / `page`.
+				// Intra-shell tab clicks skip VT. Leaving/entering the shell
+				// fades this name (styles.css) so the old rail is not pinned
+				// as a ghost on the destination. The group stays still so
+				// account↔admin (rail on both sides) does not morph.
 				position: 'absolute',
 				left: pageGutter,
 				top: 0,

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -474,8 +474,13 @@ html.is-settled {
 	   DOM swap in startViewTransition (client/client-router.tsx). Motion
 	   lives on `page` (`<main>`), not `root` — otherwise the account rail
 	   (inside main, no name of its own until lifted) fades and slides with
-	   the content. Named chrome is pinned static. Browsers without the API
-	   never match these pseudos — the swap is simply instant. */
+	   the content. Always-present chrome is pinned static. The rail is
+	   named so it lifts out of `page`, but it is *not* always on screen:
+	   leaving `/account` or `/admin` has an old snapshot and no new one.
+	   Pinning old/new (`animation: none`) froze that leftover rail on top
+	   of the destination. Old/new fade; only the group stays still so
+	   account↔admin (rail on both sides) does not morph/squash. Browsers
+	   without the API never match these pseudos — the swap is instant. */
 	::view-transition-old(root),
 	::view-transition-new(root) {
 		animation: none;
@@ -498,10 +503,16 @@ html.is-settled {
 	::view-transition-old(nav-progress),
 	::view-transition-new(nav-progress),
 	::view-transition-group(nav-progress),
-	::view-transition-old(account-nav),
-	::view-transition-new(account-nav),
 	::view-transition-group(account-nav) {
 		animation: none;
+	}
+
+	::view-transition-old(account-nav) {
+		animation: vt-page-out 120ms var(--ease-out) both;
+	}
+
+	::view-transition-new(account-nav) {
+		animation: vt-account-nav-in 220ms var(--ease-out) both;
 	}
 
 	@keyframes vt-page-out {
@@ -514,6 +525,12 @@ html.is-settled {
 		from {
 			opacity: 0;
 			transform: translateY(8px);
+		}
+	}
+
+	@keyframes vt-account-nav-in {
+		from {
+			opacity: 0;
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Leaving `/account` or `/admin` still runs a view transition, but the named `account-nav` snapshot was pinned with `animation: none`, so the old sidebar sat on top of the destination until the transition finished.
- Fade unpaired `account-nav` old/new snapshots with the page timing. Keep the group pinned so `/account` ↔ `/admin` (rail on both sides) does not morph or squash.

## Test plan

- [ ] From `/account` (or any `/account/*` page), click the Kody logo. The sidebar should fade out with the account content, not hang over the home hero.
- [ ] From `/` or `/pricing`, open `/account`. The rail should fade in rather than pop in frozen.
- [ ] Click between `/account` tabs (Overview → Billing). Still instant, no view transition.
- [ ] If you have admin: `/account` → `/admin` should keep the rail still (crossfade contents, no height squash).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `def750f1` · **Head:** `1fd6ffd2`

**Classification:** extends — changes how `app-ui` animates the named account rail during SPA view transitions.

### Primitives touched

| Primitive | Group    | Impact |
| --------- | -------- | ------ |
| `app-ui`  | surfaces | extends — `account-nav` old/new snapshots fade instead of staying pinned; group remains static |

`packages/worker/public/styles.css` is unmatched by the classifier (not under an `app-ui` code root) but is the behavior change for this named transition.

### System map

SPA navigations off a shell page capture the named rail separately from `<main>`; this PR fades that unpaired snapshot instead of pinning it.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	appUi["app-ui<br/>Browser app"]:::extended
	appUi -->|"startViewTransition + account-nav fade"| appUi
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
flowchart LR
	leaveShell["Leave /account or /admin"] --> vt["startViewTransition"]
	vt --> oldRail["::view-transition-old(account-nav)"]
	oldRail --> fadeOut["opacity fade 120ms"]
	vt --> pageSwap["::view-transition-*(page)"]
	pageSwap --> pageFade["existing page in/out"]
```

### Before / after

```
before: ::view-transition-old/new/group(account-nav) { animation: none }
after:  group pinned; old fades out; new fades in (no 8px slide)
```

</details>

<!-- system-recap:end -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved transitions within account navigation for a smoother experience when switching tabs.
  - Added fade effects when entering or leaving account and admin areas.
  - Kept the account navigation group visually stable during route changes.
  - Added an entrance animation for account navigation when it appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->