### PR TITLE
Add a read-only /files explorer for published packages

### DIFF
--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -125,7 +125,9 @@ Pinned file trees live in `BUNDLE_ARTIFACTS_KV` under:
 (`version`, `listingId`, `pinnedCommit`, `files`, optional `communityIconPath`,
 `createdAt`). Publish and re-publish overwrite the snapshot; unpublish and hard
 delete remove it. Binary icon bytes are omitted from the text-backed `files`
-map; the path metadata lets the icon route retrieve bytes from Artifacts.
+map; the path metadata lets the icon route retrieve bytes from Artifacts. The
+public `/@owner/kody-id/files` explorer reads this snapshot (not a live git
+checkout).
 
 ### Community icon cache
 

--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -81,11 +81,12 @@ Anyone can browse `/community` and open a package at `/@username/kody-id` — fo
 example `/@kentcdodds/devin`. `/community/:listingId` redirects to that
 canonical URL; username and `kody.id` redirect tables resolve renamed owners and
 package ids the same way. Detail pages show metadata, aggregate ratings, **star
-count** (stargazers — distinct from 1–5 ratings), fork count, the README (not
-the full source tree), and a dynamically generated Open Graph image (1200×630).
-When the owner keeps a [public profile](./community-profiles.md), the listing
-links to `/@username` and shows a follow control next to the username. Private
-owners show as `@username` with a lock that explains the profile is private.
+count** (stargazers — distinct from 1–5 ratings), fork count, the README, a
+**Browse files** link to the published snapshot at `/@username/kody-id/files`,
+and a dynamically generated Open Graph image (1200×630). When the owner keeps a
+[public profile](./community-profiles.md), the listing links to `/@username` and
+shows a follow control next to the username. Private owners show as `@username`
+with a lock that explains the profile is private.
 
 Each detail page includes a **copyable prompt** you can hand to your agent to
 start a fork. You can also ask your agent to use `community_search` or

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -23,7 +23,8 @@ Think in terms of:
 - package-owned webhooks
 
 Packages are the saved-entity unit across search, execute, repo editing, and UI
-hosting.
+hosting. `/account/packages/:packageId/files` browses the published text
+snapshot of a saved package.
 
 ## Package state model
 

--- a/packages/worker/client/document-head.node.test.ts
+++ b/packages/worker/client/document-head.node.test.ts
@@ -14,10 +14,11 @@ import {
 
 function concretePathForPattern(pattern: string) {
 	return pattern
+		.replaceAll('(', '')
+		.replaceAll(')', '')
 		.split('/')
 		.map((segment) => {
-			if (segment.startsWith(':')) return 'sample'
-			if (segment === '*') return 'sample'
+			if (segment.startsWith(':') || segment.startsWith('*')) return 'sample'
 			return segment
 		})
 		.join('/')

--- a/packages/worker/client/lazy-route.node.test.ts
+++ b/packages/worker/client/lazy-route.node.test.ts
@@ -20,10 +20,11 @@ const eagerPatterns = new Set([routePattern(routes.home), oauthPaths.callback])
 
 function concretePathForPattern(pattern: string) {
 	return pattern
+		.replaceAll('(', '')
+		.replaceAll(')', '')
 		.split('/')
 		.map((segment) => {
-			if (segment.startsWith(':')) return 'sample'
-			if (segment === '*') return 'sample'
+			if (segment.startsWith(':') || segment.startsWith('*')) return 'sample'
 			return segment
 		})
 		.join('/')
@@ -35,6 +36,7 @@ test('syntax highlight areas stay a subset of registered lazy areas', () => {
 		'blog-area',
 		'community-area',
 		'onboarding-area',
+		'package-files-area',
 	])
 })
 

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -14,6 +14,7 @@ import type * as blogAreaExports from './routes/blog-area.ts'
 import type * as communityAreaExports from './routes/community-area.ts'
 import type * as marketingAreaExports from './routes/marketing-area.ts'
 import type * as onboardingAreaExports from './routes/onboarding-area.ts'
+import type * as packageFilesAreaExports from './routes/package-files-area.ts'
 
 export type LazyRouteArea<TModule> = {
 	load: () => Promise<TModule>
@@ -60,6 +61,7 @@ export type CommunityAreaModule = typeof communityAreaExports
 export type BlogAreaModule = typeof blogAreaExports
 export type MarketingAreaModule = typeof marketingAreaExports
 export type OnboardingAreaModule = typeof onboardingAreaExports
+export type PackageFilesAreaModule = typeof packageFilesAreaExports
 
 export const accountArea = createLazyRouteArea<AccountAreaModule>(
 	() =>
@@ -108,6 +110,13 @@ export const marketingArea = createLazyRouteArea<MarketingAreaModule>(
 		// Dynamic import is intentional for route-level code splitting
 		// (sanctioned exception to the no-inline-imports rule).
 		import('./routes/marketing-area.ts'),
+)
+
+export const packageFilesArea = createLazyRouteArea<PackageFilesAreaModule>(
+	() =>
+		// Dynamic import is intentional for route-level code splitting
+		// (sanctioned exception to the no-inline-imports rule).
+		import('./routes/package-files-area.ts'),
 )
 
 type LazyRouteRenderProps<TModule> = {
@@ -201,6 +210,8 @@ export const LazyAuthRoute: LazyRouteComponent<AuthAreaModule> =
 	createLazyRoute(authArea)
 export const LazyMarketingRoute: LazyRouteComponent<MarketingAreaModule> =
 	createLazyRoute(marketingArea)
+export const LazyPackageFilesRoute: LazyRouteComponent<PackageFilesAreaModule> =
+	createLazyRoute(packageFilesArea)
 
 export function lazyRouteLoader<TModule>(
 	area: LazyRouteArea<TModule>,
@@ -360,6 +371,19 @@ registerPreloadPatterns(
 	},
 )
 
+registerPreloadPatterns(
+	[
+		routePattern(routes.accountPackageFiles),
+		routePattern(routes.communityDetailFiles),
+		routePattern(routes.communityPackageFiles),
+	],
+	{
+		name: 'package-files-area',
+		load: packageFilesArea.load,
+		getCached: packageFilesArea.getCached,
+	},
+)
+
 export function isClientRouteModuleCached(pathnameWithSearch: string) {
 	const url = new URL(pathnameWithSearch, clientRouteOrigin)
 	const match = preloadMatcher.match(url)
@@ -388,6 +412,7 @@ export const syntaxHighlightAreaNames = [
 	'blog-area',
 	'community-area',
 	'onboarding-area',
+	'package-files-area',
 ] as const
 
 const syntaxHighlightAreaNameSet = new Set<string>(syntaxHighlightAreaNames)

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -1,0 +1,285 @@
+// remix-skill: Handle-based files explorer (tree + blob). Must be a Handle
+// component so Remix can mount it from the shared /files route.
+import { type Handle, type RemixNode, css } from 'remix/ui'
+import { CopyTextButton } from '#client/copy-text-button.tsx'
+import { renderMarkdownNodes } from '#client/markdown-view.tsx'
+import { renderHighlightedCode } from '#client/syntax-highlight.tsx'
+import {
+	joinPackageFilesPath,
+	listPackageFilesChildren,
+} from '#universal/package-files.ts'
+import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
+import {
+	colors,
+	mq,
+	radius,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+import { proseCss } from '#universal/styles/style-primitives.ts'
+
+export function PackageFilesExplorer(
+	handle: Handle<{ data: PackageFilesLoaderData }>,
+) {
+	return () => {
+		const { data } = handle.props
+		return (
+			<article mix={css(articleCss)} data-testid="package-files">
+				<a href={data.backHref} mix={css(backLinkCss)}>
+					← {data.backLabel}
+				</a>
+				<header mix={css(headCss)}>
+					<h1 mix={css(titleCss)}>{data.title}</h1>
+					<nav aria-label="Path" mix={css(breadcrumbCss)}>
+						<a href={data.filesBasePath}>files</a>
+						{data.ancestors.map((ancestor) => (
+							<span key={ancestor.path}>
+								<span mix={css(crumbSepCss)}>/</span>
+								<a
+									href={joinPackageFilesPath(data.filesBasePath, ancestor.path)}
+								>
+									{ancestor.name}
+								</a>
+							</span>
+						))}
+					</nav>
+				</header>
+				<div mix={css(layoutCss)}>
+					<nav aria-label="Files" mix={css(treeCss)}>
+						<h2 mix={css(treeHeadingCss)}>Files</h2>
+						{renderTree(data.paths, '', data.selectedPath, data.filesBasePath)}
+					</nav>
+					<section mix={css(contentCss)} aria-label="Selected file">
+						{renderContent(data)}
+					</section>
+				</div>
+			</article>
+		)
+	}
+}
+
+function renderTree(
+	paths: Array<string>,
+	directoryPath: string,
+	selectedPath: string,
+	filesBasePath: string,
+): RemixNode {
+	const children = listPackageFilesChildren(paths, directoryPath)
+	if (children.length === 0 && directoryPath === '') {
+		return <p mix={css(emptyCss)}>No published files.</p>
+	}
+	return (
+		<ul mix={css(treeListCss)}>
+			{children.map((child) => {
+				const href = joinPackageFilesPath(filesBasePath, child.path)
+				const current = selectedPath === child.path
+				return (
+					<li key={child.path}>
+						<a
+							href={href}
+							aria-current={current ? 'page' : undefined}
+							mix={css(current ? treeLinkCurrentCss : treeLinkCss)}
+						>
+							{child.name}
+							{child.kind === 'directory' ? '/' : ''}
+						</a>
+						{child.kind === 'directory'
+							? renderTree(paths, child.path, selectedPath, filesBasePath)
+							: null}
+					</li>
+				)
+			})}
+		</ul>
+	)
+}
+
+function renderContent(data: PackageFilesLoaderData): RemixNode {
+	if (data.kind === 'directory' && !data.content) {
+		return (
+			<div>
+				<h2 mix={css(contentHeadingCss)}>
+					{data.selectedPath ? data.selectedPath : 'Package root'}
+				</h2>
+				{data.children.length === 0 ? (
+					<p mix={css(emptyCss)}>This folder is empty.</p>
+				) : (
+					<ul mix={css(dirListCss)}>
+						{data.children.map((child) => (
+							<li key={child.path}>
+								<a
+									href={joinPackageFilesPath(data.filesBasePath, child.path)}
+									mix={css(dirLinkCss)}
+								>
+									{child.name}
+									{child.kind === 'directory' ? '/' : ''}
+								</a>
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		)
+	}
+
+	const heading = data.contentPath ?? data.selectedPath
+	const body = data.content ?? ''
+	return (
+		<div>
+			<div mix={css(contentToolbarCss)}>
+				<h2 mix={css(contentHeadingCss)}>{heading}</h2>
+				{body ? (
+					<CopyTextButton
+						value={body}
+						idleLabel="Copy"
+						variant="ghost"
+						size="sm"
+						ariaLabel={`Copy ${heading}`}
+					/>
+				) : null}
+			</div>
+			{data.contentKind === 'markdown' ? (
+				<div mix={css(proseCss)} data-testid="package-files-markdown">
+					{renderMarkdownNodes(body)}
+				</div>
+			) : (
+				<div data-testid="package-files-code">
+					{renderHighlightedCode(body, data.language ?? 'plaintext')}
+				</div>
+			)}
+		</div>
+	)
+}
+
+const articleCss = {
+	width: 'min(72rem, 100%)',
+	margin: '0 auto',
+	padding: `${spacing.xl} ${spacing.lg} ${spacing['2xl']}`,
+}
+
+const backLinkCss = {
+	display: 'inline-flex',
+	fontSize: typography.fontSize.sm,
+	fontWeight: typography.fontWeight.medium,
+	color: colors.primaryText,
+	textDecoration: 'none',
+	'&:hover': { color: colors.text },
+}
+
+const headCss = {
+	marginTop: spacing.lg,
+	marginBottom: spacing.lg,
+	display: 'grid',
+	gap: spacing.xs,
+}
+
+const titleCss = {
+	margin: 0,
+	fontSize: typography.fontSize['2xl'],
+	fontWeight: typography.fontWeight.semibold,
+	overflowWrap: 'anywhere' as const,
+}
+
+const breadcrumbCss = {
+	fontSize: typography.fontSize.sm,
+	color: colors.textMuted,
+	overflowWrap: 'anywhere' as const,
+	'& a': {
+		color: colors.primaryText,
+		textDecoration: 'none',
+	},
+}
+
+const crumbSepCss = {
+	margin: `0 ${spacing.xs}`,
+	color: colors.textMuted,
+}
+
+const layoutCss = {
+	display: 'grid',
+	gridTemplateColumns: '18rem minmax(0, 1fr)',
+	gap: spacing.lg,
+	alignItems: 'start',
+	[mq.mobile]: {
+		gridTemplateColumns: '1fr',
+	},
+}
+
+const treeCss = {
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.md,
+	padding: spacing.md,
+	backgroundColor: colors.background,
+	minWidth: 0,
+}
+
+const treeHeadingCss = {
+	margin: `0 0 ${spacing.sm}`,
+	fontSize: typography.fontSize.sm,
+	fontWeight: typography.fontWeight.semibold,
+}
+
+const treeListCss = {
+	margin: 0,
+	paddingLeft: spacing.md,
+	listStyle: 'none',
+	fontSize: typography.fontSize.sm,
+	'& ul': {
+		margin: 0,
+		paddingLeft: spacing.md,
+		listStyle: 'none',
+	},
+}
+
+const treeLinkCss = {
+	color: colors.text,
+	textDecoration: 'none',
+	overflowWrap: 'anywhere' as const,
+	'&:hover': { color: colors.primaryText },
+}
+
+const treeLinkCurrentCss = {
+	...treeLinkCss,
+	fontWeight: typography.fontWeight.semibold,
+	color: colors.primaryText,
+}
+
+const contentCss = {
+	minWidth: 0,
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.md,
+	padding: spacing.lg,
+	backgroundColor: colors.background,
+	'& pre': {
+		overflowX: 'auto' as const,
+	},
+}
+
+const contentToolbarCss = {
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'space-between',
+	gap: spacing.md,
+	marginBottom: spacing.md,
+}
+
+const contentHeadingCss = {
+	margin: 0,
+	fontSize: typography.fontSize.base,
+	fontWeight: typography.fontWeight.semibold,
+	overflowWrap: 'anywhere' as const,
+}
+
+const emptyCss = {
+	margin: 0,
+	color: colors.textMuted,
+}
+
+const dirListCss = {
+	margin: 0,
+	paddingLeft: spacing.lg,
+}
+
+const dirLinkCss = {
+	color: colors.primaryText,
+	textDecoration: 'none',
+}

--- a/packages/worker/client/routes/account-packages.tsx
+++ b/packages/worker/client/routes/account-packages.tsx
@@ -38,6 +38,7 @@ import {
 	recordCellClamp,
 	recordStampCss,
 } from './record-table.tsx'
+import { getAccountPackageFilesHref } from '#universal/package-files.ts'
 import {
 	type AccountPackageDetail,
 	type AccountPackageListItem,
@@ -538,6 +539,18 @@ export function AccountPackagesRoute(handle: Handle) {
 										},
 									]}
 								/>
+								<a
+									href={getAccountPackageFilesHref({
+										packageId: selectedPackage.id,
+									})}
+									data-testid="account-browse-files"
+									mix={css({
+										...getGhostButtonCss({ size: 'sm' }),
+										width: 'fit-content',
+									})}
+								>
+									Browse files
+								</a>
 								{selectedPackage.searchText ? (
 									// The search index is a wall of concatenated text with no
 									// reading order. Left in flow it set the height of the whole

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -12,8 +12,10 @@ import {
 	LazyCommunityRoute,
 	LazyMarketingRoute,
 	LazyOnboardingRoute,
+	LazyPackageFilesRoute,
 	lazyRouteLoader,
 	onboardingArea,
+	packageFilesArea,
 } from '#client/lazy-route.tsx'
 import { oauthPaths } from '#universal/oauth-paths.ts'
 import { routePattern } from '#universal/route-pattern.ts'
@@ -78,6 +80,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 	[routePattern(routes.accountPackageDetail)]: lazyRouteLoader(
 		accountArea,
 		(m) => m.accountPackagesRouteLoader,
+	),
+	[routePattern(routes.accountPackageFiles)]: lazyRouteLoader(
+		packageFilesArea,
+		(m) => m.packageFilesRouteLoader,
 	),
 	[routePattern(routes.accountStars)]: lazyRouteLoader(
 		accountArea,
@@ -243,6 +249,14 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		communityArea,
 		(m) => m.communityDetailRouteLoader,
 	),
+	[routePattern(routes.communityDetailFiles)]: lazyRouteLoader(
+		packageFilesArea,
+		(m) => m.packageFilesRouteLoader,
+	),
+	[routePattern(routes.communityPackageFiles)]: lazyRouteLoader(
+		packageFilesArea,
+		(m) => m.packageFilesRouteLoader,
+	),
 	[routePattern(routes.profile)]: lazyRouteLoader(
 		communityArea,
 		(m) => m.profileRouteLoader,
@@ -326,6 +340,9 @@ export const clientRoutes = {
 	),
 	[routePattern(routes.accountPackageDetail)]: (
 		<LazyAccountRoute render={(m) => <m.AccountPackagesRoute />} />
+	),
+	[routePattern(routes.accountPackageFiles)]: (
+		<LazyPackageFilesRoute render={(m) => <m.PackageFilesRoute />} />
 	),
 	[routePattern(routes.accountStars)]: (
 		<LazyAccountRoute render={(m) => <m.AccountStarsRoute />} />
@@ -449,6 +466,12 @@ export const clientRoutes = {
 	),
 	[routePattern(routes.communityPackage)]: (
 		<LazyCommunityRoute render={(m) => <m.CommunityDetailRoute />} />
+	),
+	[routePattern(routes.communityDetailFiles)]: (
+		<LazyPackageFilesRoute render={(m) => <m.PackageFilesRoute />} />
+	),
+	[routePattern(routes.communityPackageFiles)]: (
+		<LazyPackageFilesRoute render={(m) => <m.PackageFilesRoute />} />
 	),
 	[routePattern(routes.profile)]: (
 		<LazyCommunityRoute render={(m) => <m.ProfileRoute />} />

--- a/packages/worker/client/routes/package-files-area.ts
+++ b/packages/worker/client/routes/package-files-area.ts
@@ -1,0 +1,1 @@
+export { PackageFilesRoute, packageFilesRouteLoader } from './package-files.tsx'

--- a/packages/worker/client/routes/package-files.tsx
+++ b/packages/worker/client/routes/package-files.tsx
@@ -1,0 +1,258 @@
+// remix-skill: shared /files explorer route (community + account) with a
+// Handle-based explorer component and a dedicated lazy area so listing chunks
+// do not pull Shiki.
+import { type Handle, css } from 'remix/ui'
+import { createMatcher } from 'remix/route-pattern/match'
+import { PackageFilesExplorer } from '#client/package-files-explorer.tsx'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
+import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { createRouteLoadLatch } from '#client/route-load-latch.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import {
+	buildPackageFilesApiHref,
+	normalizePackageFilesPath,
+} from '#universal/package-files.ts'
+import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
+import { colors, spacing } from '#universal/styles/tokens.ts'
+
+const communityPackageFilesMatcher = createMatcher(
+	routes.communityPackageFiles.pattern,
+)
+const communityDetailFilesMatcher = createMatcher(
+	routes.communityDetailFiles.pattern,
+)
+const accountPackageFilesMatcher = createMatcher(
+	routes.accountPackageFiles.pattern,
+)
+
+type FilesLocation =
+	| {
+			kind: 'community-package'
+			apiHref: string
+	  }
+	| {
+			kind: 'community-detail'
+			apiHref: string
+	  }
+	| {
+			kind: 'account'
+			apiHref: string
+	  }
+
+function readFilesLocation(url: URL): FilesLocation | null {
+	const communityPackage = communityPackageFilesMatcher.match(url)
+	if (communityPackage) {
+		const selectedPath = normalizePackageFilesPath(
+			communityPackage.params.relativePath ?? '',
+		)
+		if (selectedPath == null) return null
+		return {
+			kind: 'community-package',
+			apiHref: buildPackageFilesApiHref(
+				routes.communityPackageFilesApi.href({
+					username: communityPackage.params.username,
+					kodyId: communityPackage.params.kodyId,
+				}),
+				selectedPath,
+			),
+		}
+	}
+
+	const communityDetail = communityDetailFilesMatcher.match(url)
+	if (communityDetail) {
+		const selectedPath = normalizePackageFilesPath(
+			communityDetail.params.relativePath ?? '',
+		)
+		if (selectedPath == null) return null
+		return {
+			kind: 'community-detail',
+			apiHref: buildPackageFilesApiHref(
+				routes.communityDetailFilesApi.href({
+					listingId: communityDetail.params.listingId,
+				}),
+				selectedPath,
+			),
+		}
+	}
+
+	const account = accountPackageFilesMatcher.match(url)
+	if (account) {
+		const selectedPath = normalizePackageFilesPath(
+			account.params.relativePath ?? '',
+		)
+		if (selectedPath == null) return null
+		return {
+			kind: 'account',
+			apiHref: buildPackageFilesApiHref(
+				routes.accountPackageFilesApi.href({
+					packageId: account.params.packageId,
+				}),
+				selectedPath,
+			),
+		}
+	}
+
+	return null
+}
+
+type MovedPayload = {
+	ok: false
+	redirectTo?: string
+}
+
+export async function packageFilesRouteLoader(
+	url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const location = readFilesLocation(url)
+	if (!location) {
+		return routeLoaderRedirect(`${url.pathname}${url.search}`)
+	}
+	const response = await fetch(location.apiHref, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) {
+		return routeLoaderRedirect('/login')
+	}
+	if (response.status === 404) {
+		const moved = await readJson<MovedPayload>(response)
+		if (moved?.redirectTo) {
+			return routeLoaderRedirect(moved.redirectTo)
+		}
+		throw new Error('Package files not found.')
+	}
+	const payload = await readJson<PackageFilesLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load package files.')
+	}
+	return { packageFiles: payload }
+}
+
+export function PackageFilesRoute(handle: Handle) {
+	let status: 'loading' | 'ready' | 'error' | 'not-found' = 'loading'
+	let data: PackageFilesLoaderData | null = null
+	let loadedHref = ''
+	const loadLatch = createRouteLoadLatch()
+
+	async function loadFiles(apiHref: string, href: string, signal: AbortSignal) {
+		try {
+			const response = await fetch(apiHref, {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (signal.aborted) return
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			if (response.status === 404) {
+				const moved = await readJson<MovedPayload>(response)
+				if (moved?.redirectTo) {
+					window.location.assign(moved.redirectTo)
+					return
+				}
+				data = null
+				status = 'not-found'
+				loadedHref = href
+				handle.update()
+				return
+			}
+			const payload = await readJson<PackageFilesLoaderData>(response)
+			if (signal.aborted) return
+			if (!response.ok || !payload?.ok) {
+				throw new Error('Unable to load package files.')
+			}
+			data = payload
+			status = 'ready'
+			loadedHref = href
+			handle.update()
+		} catch {
+			if (signal.aborted) return
+			status = 'error'
+			loadedHref = href
+			handle.update()
+		}
+	}
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const location = readFilesLocation(new URL(currentHref, 'http://localhost'))
+		if (!location) {
+			return <article />
+		}
+
+		const routeData = tryConsumeRouteLoaderData(
+			handle,
+			'packageFiles',
+			currentHref,
+		)
+		const appliedRouteData = Boolean(routeData?.ok)
+		if (routeData?.ok) {
+			data = routeData
+			status = 'ready'
+			loadedHref = currentHref
+			loadLatch.markLoaded(currentHref)
+		}
+
+		const needsStaleRefresh = consumeStaleNavigationData(currentHref)
+		const needsLoad = loadLatch.needsLoad({
+			currentHref,
+			appliedRouteData,
+			needsStaleRefresh,
+		})
+		if (needsLoad && typeof document !== 'undefined') {
+			status = 'loading'
+			const loadAttempt = loadLatch.getPendingAttempt()
+			handle.queueTask(async (signal) => {
+				try {
+					await loadFiles(location.apiHref, currentHref, signal)
+					if (signal.aborted) {
+						loadLatch.clearPending(currentHref, loadAttempt)
+						return
+					}
+					if (status === 'ready' || status === 'not-found') {
+						loadLatch.markLoaded(currentHref)
+					} else {
+						loadLatch.markFailed(currentHref)
+					}
+				} catch {
+					if (signal.aborted) {
+						loadLatch.clearPending(currentHref, loadAttempt)
+						return
+					}
+					loadLatch.markFailed(currentHref)
+				}
+			})
+		}
+
+		if (status !== 'ready' || loadedHref !== currentHref || !data) {
+			return (
+				<article
+					mix={css({
+						padding: spacing.xl,
+						color: colors.textMuted,
+					})}
+				>
+					<p>
+						{status === 'not-found'
+							? 'Those files were not found.'
+							: status === 'error'
+								? 'Unable to load package files.'
+								: 'Loading files…'}
+					</p>
+				</article>
+			)
+		}
+
+		return <PackageFilesExplorer data={data} />
+	}
+}

--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -17,6 +17,7 @@ import {
 	communityTagPillCss,
 } from '#app/community-listings-content.tsx'
 import { renderProfileFollowControl } from '#app/profile-follow-control.tsx'
+import { getCommunityPackageFilesHref } from '#universal/package-files.ts'
 import { routes } from '#universal/routes.ts'
 import { visuallyHiddenCss } from '#universal/styles/style-primitives.ts'
 import { colors } from '#universal/styles/tokens.ts'
@@ -165,6 +166,19 @@ export function CommunityDetailContent(
 
 			<p data-rise style={{ '--rise': '2' }} mix={css(detailSubCss)}>
 				{listing.description}
+			</p>
+			<p data-rise style={{ '--rise': '2' }} mix={css(filesLinkRowCss)}>
+				<a
+					href={getCommunityPackageFilesHref({
+						listingId: listing.id,
+						ownerUsername: listing.ownerUsername,
+						kodyId: listing.kodyId,
+					})}
+					data-testid="community-browse-files"
+					mix={css(filesLinkCss)}
+				>
+					Browse files
+				</a>
 			</p>
 
 			{listing.tags.length > 0 ? (
@@ -319,6 +333,19 @@ const detailSubCss = {
 	color: colors.textMuted,
 	fontSize: '1.05rem',
 	maxWidth: '58ch',
+}
+
+const filesLinkRowCss = {
+	margin: '0.7rem 0 0',
+}
+
+const filesLinkCss = {
+	color: colors.primaryText,
+	fontWeight: 550,
+	textDecoration: 'none',
+	'&:hover': {
+		color: colors.text,
+	},
 }
 
 const detailTagListCss = {

--- a/packages/worker/src/app/community-package-route.ts
+++ b/packages/worker/src/app/community-package-route.ts
@@ -3,6 +3,10 @@ import {
 	getCommunityPackageHref,
 	resolveCommunityPackageUrl,
 } from '#worker/community/package-url.ts'
+import {
+	getCommunityPackageFilesHref,
+	normalizePackageFilesPath,
+} from '#universal/package-files.ts'
 import { routes } from '#universal/routes.ts'
 
 const communityDetailMatcher = createMatcher(routes.communityDetail.pattern)
@@ -61,4 +65,86 @@ export async function resolveCanonicalListingPath(input: {
 	})
 	if (target?.listingId !== input.listingId) return null
 	return getCommunityPackageHref(target)
+}
+
+const communityDetailFilesMatcher = createMatcher(
+	routes.communityDetailFiles.pattern,
+)
+const communityPackageFilesMatcher = createMatcher(
+	routes.communityPackageFiles.pattern,
+)
+
+export type CommunityFilesRouteTarget =
+	| { kind: 'listing'; listingId: string; selectedPath: string }
+	| { kind: 'redirect'; to: string }
+	| { kind: 'invalid-path' }
+
+function selectedPathFromParams(relativePath: string | undefined) {
+	return normalizePackageFilesPath(relativePath ?? '')
+}
+
+export async function resolveCommunityFilesRoute(input: {
+	env: Env
+	url: URL
+}): Promise<CommunityFilesRouteTarget | null> {
+	const detailMatch = communityDetailFilesMatcher.match(input.url)
+	if (detailMatch) {
+		const selectedPath = selectedPathFromParams(detailMatch.params.relativePath)
+		if (selectedPath == null) return { kind: 'invalid-path' }
+		return {
+			kind: 'listing',
+			listingId: detailMatch.params.listingId,
+			selectedPath,
+		}
+	}
+
+	const packageMatch = communityPackageFilesMatcher.match(input.url)
+	if (!packageMatch) return null
+
+	const selectedPath = selectedPathFromParams(packageMatch.params.relativePath)
+	if (selectedPath == null) return { kind: 'invalid-path' }
+
+	const target = await resolveCommunityPackageUrl({
+		db: input.env.APP_DB,
+		username: packageMatch.params.username,
+		kodyId: packageMatch.params.kodyId,
+	})
+	if (!target) return null
+	if (target.kind === 'redirect') {
+		return {
+			kind: 'redirect',
+			to: getCommunityPackageFilesHref({
+				listingId: target.listingId,
+				ownerUsername: target.username,
+				kodyId: target.kodyId,
+				relativePath: selectedPath,
+			}),
+		}
+	}
+	return {
+		kind: 'listing',
+		listingId: target.listingId,
+		selectedPath,
+	}
+}
+
+export async function resolveCanonicalFilesPath(input: {
+	env: Env
+	listingId: string
+	ownerUsername: string
+	kodyId: string
+	selectedPath: string
+}): Promise<string | null> {
+	const target = await resolveCommunityPackageUrl({
+		db: input.env.APP_DB,
+		username: input.ownerUsername,
+		kodyId: input.kodyId,
+	})
+	if (target?.listingId !== input.listingId) return null
+	return getCommunityPackageFilesHref({
+		listingId: input.listingId,
+		ownerUsername: target.username,
+		kodyId: target.kodyId,
+		relativePath: input.selectedPath,
+	})
 }

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -121,6 +121,8 @@ test('community detail handler returns bare detail frame HTML for target header'
 		'data-testid="community-detail-owner-private"',
 	)
 	expect(publicHtml).toContain('data-testid="community-detail-forks"')
+	expect(publicHtml).toContain('data-testid="community-browse-files"')
+	expect(publicHtml).toContain('href="/@kentcdodds/github-triage/files"')
 	expect(publicHtml).not.toContain('<html')
 
 	mockModule.getUserSocialRowByUsername.mockResolvedValue({

--- a/packages/worker/src/app/handlers/package-files.node.test.ts
+++ b/packages/worker/src/app/handlers/package-files.node.test.ts
@@ -1,0 +1,152 @@
+import { expect, test, vi } from 'vitest'
+
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn<() => Promise<unknown>>(),
+	requireAuthenticatedPageUser: vi.fn<() => Promise<unknown>>(),
+	loadCommunityPackageFilesData: vi.fn<() => Promise<unknown>>(),
+	loadAccountPackageFilesData: vi.fn<() => Promise<unknown>>(),
+	resolveCommunityPackageUrl: vi.fn<() => Promise<unknown>>(),
+	renderAppPage: vi.fn<(input: unknown) => Promise<Response>>(
+		async () => new Response('ok'),
+	),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#app/page-auth.ts', () => ({
+	requireAuthenticatedPageUser: (...args: Array<unknown>) =>
+		mockModule.requireAuthenticatedPageUser(...args),
+}))
+
+vi.mock('#app/package-files-data.ts', () => ({
+	loadCommunityPackageFilesData: (...args: Array<unknown>) =>
+		mockModule.loadCommunityPackageFilesData(...args),
+	loadAccountPackageFilesData: (...args: Array<unknown>) =>
+		mockModule.loadAccountPackageFilesData(...args),
+	readPackageFilesSelectedPath: (requestUrl: string) => {
+		const url = new URL(requestUrl, 'http://localhost')
+		const raw = url.searchParams.get('path')
+		if (raw == null) return ''
+		if (raw.includes('..')) return null
+		return raw
+	},
+}))
+
+vi.mock('#worker/community/package-url.ts', () => ({
+	resolveCommunityPackageUrl: (...args: Array<unknown>) =>
+		mockModule.resolveCommunityPackageUrl(...args),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: (...args: Array<unknown>) => mockModule.renderAppPage(...args),
+}))
+
+const {
+	createAccountPackageFilesApiHandler,
+	createCommunityPackageFilesApiHandler,
+} = await import('./package-files.ts')
+
+const filesPayload = {
+	ok: true,
+	title: '@owner/demo',
+	backHref: '/@owner/demo',
+	backLabel: 'Package listing',
+	filesBasePath: '/@owner/demo/files',
+	selectedPath: 'src/index.ts',
+	kind: 'file',
+	paths: ['src/index.ts'],
+	children: [],
+	ancestors: [{ name: 'src', path: 'src' }],
+	content: 'export const answer = 42\n',
+	contentPath: 'src/index.ts',
+	contentKind: 'code',
+	language: 'ts',
+}
+
+test('community files API resolves the listing, rejects traversal, and 404s misses', async () => {
+	const handler = createCommunityPackageFilesApiHandler({} as Env)
+	mockModule.resolveCommunityPackageUrl.mockResolvedValue({
+		kind: 'listing',
+		listingId: 'listing-1',
+		username: 'owner',
+		kodyId: 'demo',
+	})
+	mockModule.loadCommunityPackageFilesData.mockResolvedValue(filesPayload)
+
+	const success = await handler.handler({
+		request: new Request(
+			'https://example.com/profiles/owner/packages/demo/files.json?path=src/index.ts',
+		),
+		params: { username: 'owner', kodyId: 'demo' },
+		url: new URL(
+			'https://example.com/profiles/owner/packages/demo/files.json?path=src/index.ts',
+		),
+	} as never)
+	expect(success.status).toBe(200)
+	expect(await success.json()).toEqual(filesPayload)
+	expect(mockModule.loadCommunityPackageFilesData).toHaveBeenCalledWith({
+		env: {},
+		listingId: 'listing-1',
+		selectedPath: 'src/index.ts',
+	})
+
+	const invalid = await handler.handler({
+		request: new Request(
+			'https://example.com/profiles/owner/packages/demo/files.json?path=../secret',
+		),
+		params: { username: 'owner', kodyId: 'demo' },
+		url: new URL(
+			'https://example.com/profiles/owner/packages/demo/files.json?path=../secret',
+		),
+	} as never)
+	expect(invalid.status).toBe(400)
+
+	mockModule.loadCommunityPackageFilesData.mockResolvedValue(null)
+	const missing = await handler.handler({
+		request: new Request(
+			'https://example.com/profiles/owner/packages/demo/files.json',
+		),
+		params: { username: 'owner', kodyId: 'demo' },
+		url: new URL('https://example.com/profiles/owner/packages/demo/files.json'),
+	} as never)
+	expect(missing.status).toBe(404)
+})
+
+test('account files API requires the owner session and does not leak other users', async () => {
+	const handler = createAccountPackageFilesApiHandler({} as Env)
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	const unauthorized = await handler.handler({
+		request: new Request(
+			'https://example.com/account/packages/pkg-1/files.json',
+		),
+		params: { packageId: 'pkg-1' },
+		url: new URL('https://example.com/account/packages/pkg-1/files.json'),
+	} as never)
+	expect(unauthorized.status).toBe(401)
+	expect(mockModule.loadAccountPackageFilesData).not.toHaveBeenCalled()
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		mcpUser: { userId: 'stable-user-1' },
+	})
+	mockModule.loadAccountPackageFilesData.mockResolvedValue(filesPayload)
+	const success = await handler.handler({
+		request: new Request(
+			'https://example.com/account/packages/pkg-1/files.json?path=src/index.ts',
+		),
+		params: { packageId: 'pkg-1' },
+		url: new URL(
+			'https://example.com/account/packages/pkg-1/files.json?path=src/index.ts',
+		),
+	} as never)
+	expect(success.status).toBe(200)
+	expect(mockModule.loadAccountPackageFilesData).toHaveBeenCalledWith({
+		env: {},
+		request: expect.any(Request),
+		userId: 'stable-user-1',
+		packageId: 'pkg-1',
+		selectedPath: 'src/index.ts',
+	})
+})

--- a/packages/worker/src/app/handlers/package-files.ts
+++ b/packages/worker/src/app/handlers/package-files.ts
@@ -1,0 +1,300 @@
+// remix-skill: HTML + JSON /files controllers for community and account
+// snapshots. Pages SSR the explorer; JSON companions use `?path=`.
+import { jsonResponse } from '#worker/json-response.ts'
+import { type Action } from 'remix/router'
+import { getOwnerUsernameFromListingName } from '#worker/community/public-urls.ts'
+import { getCommunityListingById } from '#worker/community/repo.ts'
+import { resolveCommunityPackageUrl } from '#worker/community/package-url.ts'
+import {
+	resolveCanonicalFilesPath,
+	resolveCommunityFilesRoute,
+} from '#app/community-package-route.ts'
+import {
+	loadAccountPackageFilesData,
+	loadCommunityPackageFilesData,
+	readPackageFilesSelectedPath,
+} from '#app/package-files-data.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import {
+	getCommunityPackageFilesHref,
+	normalizePackageFilesPath,
+} from '#universal/package-files.ts'
+import { type routes } from '#universal/routes.ts'
+
+function redirectToCanonicalPath(input: { path: string; url: URL }) {
+	const destination = new URL(input.path, input.url)
+	destination.search = input.url.search
+	return new Response(null, {
+		status: 301,
+		headers: {
+			location: destination.toString(),
+			'cache-control': 'public, max-age=3600',
+		},
+	})
+}
+
+async function renderCommunityFilesPage(input: {
+	request: Request
+	env: Env
+	listingId: string | null
+	selectedPath: string
+}) {
+	const data = input.listingId
+		? await loadCommunityPackageFilesData({
+				env: input.env,
+				listingId: input.listingId,
+				selectedPath: input.selectedPath,
+			})
+		: null
+	if (!data) {
+		return renderAppPage({
+			request: input.request,
+			env: input.env,
+			title: 'Package files not found',
+			notFound: true,
+			status: 404,
+		})
+	}
+	return renderAppPage({
+		request: input.request,
+		env: input.env,
+		title: `${data.title} files`,
+		loaderData: { packageFiles: data },
+	})
+}
+
+export function createCommunityPackageFilesHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const url = new URL(request.url)
+			const target = await resolveCommunityFilesRoute({ env, url })
+			if (target?.kind === 'invalid-path') {
+				return renderCommunityFilesPage({
+					request,
+					env,
+					listingId: null,
+					selectedPath: '',
+				})
+			}
+			if (target?.kind === 'redirect') {
+				return redirectToCanonicalPath({ path: target.to, url })
+			}
+			return renderCommunityFilesPage({
+				request,
+				env,
+				listingId: target?.listingId ?? null,
+				selectedPath: target?.selectedPath ?? '',
+			})
+		},
+	} satisfies Action<typeof routes.communityPackageFiles>
+}
+
+export function createCommunityDetailFilesHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const url = new URL(request.url)
+			const target = await resolveCommunityFilesRoute({ env, url })
+			if (target?.kind === 'invalid-path' || !target) {
+				return renderCommunityFilesPage({
+					request,
+					env,
+					listingId: null,
+					selectedPath: '',
+				})
+			}
+			if (target.kind === 'redirect') {
+				return redirectToCanonicalPath({ path: target.to, url })
+			}
+
+			const listing = await getCommunityListingById(env.APP_DB, {
+				listingId: target.listingId,
+				includeDelisted: false,
+			})
+			const ownerUsername = listing
+				? getOwnerUsernameFromListingName(listing.name)
+				: null
+			const canonicalPath =
+				listing && ownerUsername
+					? await resolveCanonicalFilesPath({
+							env,
+							listingId: listing.id,
+							ownerUsername,
+							kodyId: listing.kodyId,
+							selectedPath: target.selectedPath,
+						})
+					: null
+			if (canonicalPath && canonicalPath !== url.pathname) {
+				return redirectToCanonicalPath({ path: canonicalPath, url })
+			}
+
+			return renderCommunityFilesPage({
+				request,
+				env,
+				listingId: target.listingId,
+				selectedPath: target.selectedPath,
+			})
+		},
+	} satisfies Action<typeof routes.communityDetailFiles>
+}
+
+export function createCommunityPackageFilesApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			const selectedPath = readPackageFilesSelectedPath(request.url)
+			if (selectedPath == null) {
+				return jsonResponse(
+					{ ok: false, error: 'Package file path was invalid.' },
+					400,
+				)
+			}
+			const target = await resolveCommunityPackageUrl({
+				db: env.APP_DB,
+				username: params.username,
+				kodyId: params.kodyId,
+			})
+			if (target?.kind === 'redirect') {
+				return jsonResponse(
+					{
+						ok: false,
+						error: 'Community package moved.',
+						redirectTo: getCommunityPackageFilesHref({
+							listingId: target.listingId,
+							ownerUsername: target.username,
+							kodyId: target.kodyId,
+							relativePath: selectedPath,
+						}),
+					},
+					404,
+				)
+			}
+			const data = target
+				? await loadCommunityPackageFilesData({
+						env,
+						listingId: target.listingId,
+						selectedPath,
+					})
+				: null
+			if (!data) {
+				return jsonResponse(
+					{ ok: false, error: 'Community package files not found.' },
+					404,
+				)
+			}
+			return jsonResponse(data)
+		},
+	} satisfies Action<typeof routes.communityPackageFilesApi>
+}
+
+export function createCommunityDetailFilesApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			const selectedPath = readPackageFilesSelectedPath(request.url)
+			if (selectedPath == null) {
+				return jsonResponse(
+					{ ok: false, error: 'Package file path was invalid.' },
+					400,
+				)
+			}
+			const data = await loadCommunityPackageFilesData({
+				env,
+				listingId: params.listingId,
+				selectedPath,
+			})
+			if (!data) {
+				return jsonResponse(
+					{ ok: false, error: 'Community package files not found.' },
+					404,
+				)
+			}
+			return jsonResponse(data)
+		},
+	} satisfies Action<typeof routes.communityDetailFilesApi>
+}
+
+export function createAccountPackageFilesHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) return user
+
+			const selectedPath = normalizePackageFilesPath(
+				typeof params.relativePath === 'string' ? params.relativePath : '',
+			)
+			if (selectedPath == null) {
+				return renderAppPage({
+					request,
+					env,
+					title: 'Package files not found',
+					notFound: true,
+					status: 404,
+				})
+			}
+
+			const data = await loadAccountPackageFilesData({
+				env,
+				request,
+				userId: user.mcpUser.userId,
+				packageId: params.packageId,
+				selectedPath,
+			})
+			if (!data) {
+				return renderAppPage({
+					request,
+					env,
+					title: 'Package files not found',
+					notFound: true,
+					status: 404,
+				})
+			}
+			return renderAppPage({
+				request,
+				env,
+				title: `${data.title} files`,
+				loaderData: { packageFiles: data },
+			})
+		},
+	} satisfies Action<typeof routes.accountPackageFiles>
+}
+
+export function createAccountPackageFilesApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, params }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+			if (request.method !== 'GET') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+			const selectedPath = readPackageFilesSelectedPath(request.url)
+			if (selectedPath == null) {
+				return jsonResponse(
+					{ ok: false, error: 'Package file path was invalid.' },
+					400,
+				)
+			}
+			const data = await loadAccountPackageFilesData({
+				env,
+				request,
+				userId: user.mcpUser.userId,
+				packageId: params.packageId,
+				selectedPath,
+			})
+			if (!data) {
+				return jsonResponse(
+					{ ok: false, error: 'Package files not found.' },
+					404,
+				)
+			}
+			return jsonResponse(data)
+		},
+	} satisfies Action<typeof routes.accountPackageFilesApi>
+}

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -1,0 +1,126 @@
+import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import { getOwnerUsernameFromListingName } from '#worker/community/public-urls.ts'
+import { getCommunityListingById } from '#worker/community/repo.ts'
+import { readCommunitySnapshot } from '#worker/community/snapshot.ts'
+import { getSavedPackageById } from '#worker/package-registry/repo.ts'
+import { loadPackageSourceBySourceId } from '#worker/package-registry/source.ts'
+import { getCommunityListingHref } from '#universal/community-links.ts'
+import {
+	buildPackageFilesView,
+	getAccountPackageFilesHref,
+	getCommunityPackageFilesHref,
+	normalizePackageFilesPath,
+	type PackageFilesView,
+} from '#universal/package-files.ts'
+import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
+
+export function readPackageFilesSelectedPath(requestUrl: string) {
+	const url = new URL(requestUrl, 'http://localhost')
+	return normalizePackageFilesPath(url.searchParams.get('path'))
+}
+
+function toLoaderData(input: {
+	title: string
+	backHref: string
+	backLabel: string
+	filesBasePath: string
+	view: PackageFilesView
+}): PackageFilesLoaderData {
+	return {
+		ok: true,
+		title: input.title,
+		backHref: input.backHref,
+		backLabel: input.backLabel,
+		filesBasePath: input.filesBasePath,
+		selectedPath: input.view.selectedPath,
+		kind: input.view.kind,
+		paths: input.view.paths,
+		children: input.view.children,
+		ancestors: input.view.ancestors,
+		content: input.view.content,
+		contentPath: input.view.contentPath,
+		contentKind: input.view.contentKind,
+		language: input.view.language,
+	}
+}
+
+export async function loadCommunityPackageFilesData(input: {
+	env: Env
+	listingId: string
+	selectedPath: string
+}): Promise<PackageFilesLoaderData | null> {
+	const listing = await getCommunityListingById(input.env.APP_DB, {
+		listingId: input.listingId,
+		includeDelisted: false,
+	})
+	if (!listing) return null
+
+	const ownerUsername = getOwnerUsernameFromListingName(listing.name)
+	const filesBasePath = getCommunityPackageFilesHref({
+		listingId: listing.id,
+		ownerUsername,
+		kodyId: listing.kodyId,
+	})
+	const snapshot = input.env.BUNDLE_ARTIFACTS_KV
+		? await readCommunitySnapshot(input.env.BUNDLE_ARTIFACTS_KV, listing.id)
+		: null
+	const view = buildPackageFilesView({
+		files: snapshot?.files ?? {},
+		selectedPath: input.selectedPath,
+	})
+	if (!view) return null
+
+	return toLoaderData({
+		title: listing.name,
+		backHref: getCommunityListingHref({
+			listingId: listing.id,
+			ownerUsername,
+			kodyId: listing.kodyId,
+		}),
+		backLabel: 'Package listing',
+		filesBasePath,
+		view,
+	})
+}
+
+export async function loadAccountPackageFilesData(input: {
+	env: Env
+	request: Request
+	userId: string
+	packageId: string
+	selectedPath: string
+}): Promise<PackageFilesLoaderData | null> {
+	const record = await getSavedPackageById(input.env.APP_DB, {
+		userId: input.userId,
+		packageId: input.packageId,
+	})
+	if (!record) return null
+
+	let files: Record<string, string> = {}
+	try {
+		const loaded = await loadPackageSourceBySourceId({
+			env: input.env,
+			baseUrl: getAppBaseUrl({ env: input.env, requestUrl: input.request.url }),
+			userId: input.userId,
+			sourceId: record.sourceId,
+		})
+		files = loaded.files
+	} catch {
+		files = {}
+	}
+
+	const view = buildPackageFilesView({
+		files,
+		selectedPath: input.selectedPath,
+	})
+	if (!view) return null
+
+	return toLoaderData({
+		title: record.name,
+		backHref: routes.accountPackageDetail.href({ packageId: record.id }),
+		backLabel: 'Package',
+		filesBasePath: getAccountPackageFilesHref({ packageId: record.id }),
+		view,
+	})
+}

--- a/packages/worker/src/app/router-specificity.node.test.ts
+++ b/packages/worker/src/app/router-specificity.node.test.ts
@@ -118,6 +118,75 @@ test('delimiter-bounded params keep companion suffixes, hyphens, and encoded dot
 	).toBe('secret')
 })
 
+test('package files routes win over listing and package detail siblings', async () => {
+	const router = createRouter()
+	router.get(
+		routePattern(routes.communityPackage),
+		createStubHandler('listing'),
+	)
+	router.get(
+		routePattern(routes.communityPackageFiles),
+		createStubHandler('community-files'),
+	)
+	router.get(
+		routePattern(routes.accountPackageDetail),
+		createStubHandler('package-detail'),
+	)
+	router.get(
+		routePattern(routes.accountPackageFiles),
+		createStubHandler('account-files'),
+	)
+	router.get(
+		routePattern(routes.communityDetail),
+		createStubHandler('listing-uuid'),
+	)
+	router.get(
+		routePattern(routes.communityDetailFiles),
+		createStubHandler('listing-uuid-files'),
+	)
+
+	expect(
+		await (
+			await router.fetch(new Request('http://localhost/@kentcdodds/devin'))
+		).text(),
+	).toBe('listing')
+	expect(
+		await (
+			await router.fetch(
+				new Request('http://localhost/@kentcdodds/devin/files'),
+			)
+		).text(),
+	).toBe('community-files')
+	expect(
+		await (
+			await router.fetch(
+				new Request('http://localhost/@kentcdodds/devin/files/src/index.ts'),
+			)
+		).text(),
+	).toBe('community-files')
+	expect(
+		await (
+			await router.fetch(new Request('http://localhost/account/packages/pkg-1'))
+		).text(),
+	).toBe('package-detail')
+	expect(
+		await (
+			await router.fetch(
+				new Request('http://localhost/account/packages/pkg-1/files/README.md'),
+			)
+		).text(),
+	).toBe('account-files')
+	expect(
+		await (
+			await router.fetch(
+				new Request(
+					'http://localhost/community/550e8400-e29b-41d4-a716-446655440000/files/src/lib.ts',
+				),
+			)
+		).text(),
+	).toBe('listing-uuid-files')
+})
+
 test('single-segment params 404 on raw dots and match href-encoded dots', async () => {
 	const router = createRouter()
 	router.get(

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -81,6 +81,14 @@ import {
 	createAccountPackagesHandler,
 } from '#app/handlers/account-packages.ts'
 import {
+	createAccountPackageFilesApiHandler,
+	createAccountPackageFilesHandler,
+	createCommunityDetailFilesApiHandler,
+	createCommunityDetailFilesHandler,
+	createCommunityPackageFilesApiHandler,
+	createCommunityPackageFilesHandler,
+} from '#app/handlers/package-files.ts'
+import {
 	createAccountPasskeysApiHandler,
 	createAccountPasskeysHandler,
 } from '#app/handlers/account-passkeys.ts'
@@ -307,6 +315,8 @@ export function createAppRouter(env: Env) {
 				createAccountPackageInvocationTokensApiHandler(env),
 			accountPackages: createAccountPackagesHandler(env),
 			accountPackageDetail: createAccountPackagesHandler(env),
+			accountPackageFiles: createAccountPackageFilesHandler(env),
+			accountPackageFilesApi: createAccountPackageFilesApiHandler(env),
 			accountPackagesApi: createAccountPackagesApiHandler(env),
 			accountConnectionsApi: createAccountConnectionsApiHandler(env),
 			accountConnectionsApiPost: createAccountConnectionsApiHandler(env),
@@ -396,8 +406,12 @@ export function createAppRouter(env: Env) {
 			communityApi: createCommunityApiHandler(env),
 			communityDetail: createCommunityDetailHandler(env),
 			communityDetailApi: createCommunityDetailApiHandler(env),
+			communityDetailFiles: createCommunityDetailFilesHandler(env),
+			communityDetailFilesApi: createCommunityDetailFilesApiHandler(env),
 			communityPackage: createCommunityPackageHandler(env),
 			communityPackageApi: createCommunityPackageApiHandler(env),
+			communityPackageFiles: createCommunityPackageFilesHandler(env),
+			communityPackageFilesApi: createCommunityPackageFilesApiHandler(env),
 			communityDetailIcon: createCommunityIconHandler(env),
 			integrationLogo: createIntegrationLogoHandler(env),
 			communityDetailOgImage: createCommunityDetailOgImageHandler(env),

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -152,6 +152,10 @@ const routeDocumentHeads = {
 	),
 	[routePattern(routes.accountPackages)]: titleOnly('Packages'),
 	[routePattern(routes.accountPackageDetail)]: titleOnly('Packages'),
+	[routePattern(routes.accountPackageFiles)]: ({ loaderData }) => {
+		const files = loaderData?.packageFiles
+		return titleOnly(files?.ok ? `${files.title} files` : 'Package files')
+	},
 	[routePattern(routes.accountStars)]: titleOnly('Starred packages'),
 	[routePattern(routes.accountPasskeys)]: titleOnly('Passkeys'),
 	[routePattern(routes.accountSecrets)]: titleOnly('Secrets'),
@@ -236,6 +240,22 @@ const routeDocumentHeads = {
 	),
 	[routePattern(routes.communityDetail)]: communityListingHead,
 	[routePattern(routes.communityPackage)]: communityListingHead,
+	[routePattern(routes.communityDetailFiles)]: ({ loaderData, pathname }) => {
+		const files = loaderData?.packageFiles
+		if (!files?.ok) return titleOnly('Package files')
+		return {
+			title: `${files.title} files`,
+			canonicalPath: pathname,
+		}
+	},
+	[routePattern(routes.communityPackageFiles)]: ({ loaderData, pathname }) => {
+		const files = loaderData?.packageFiles
+		if (!files?.ok) return titleOnly('Package files')
+		return {
+			title: `${files.title} files`,
+			canonicalPath: pathname,
+		}
+	},
 	[routePattern(routes.profile)]: ({ loaderData, params, pathname }) => {
 		const shell = loaderData?.profileShell
 		if (shell && !shell.ok) {

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -91,6 +91,29 @@ export type CommunityDetailLoaderData = {
 	viewerInstall: ViewerListingInstall | null
 }
 
+export type PackageFilesChildLoaderData = {
+	name: string
+	path: string
+	kind: 'file' | 'directory'
+}
+
+export type PackageFilesLoaderData = {
+	ok: true
+	title: string
+	backHref: string
+	backLabel: string
+	filesBasePath: string
+	selectedPath: string
+	kind: 'file' | 'directory'
+	paths: Array<string>
+	children: Array<PackageFilesChildLoaderData>
+	ancestors: Array<{ name: string; path: string }>
+	content: string | null
+	contentPath: string | null
+	contentKind: 'markdown' | 'code' | 'text' | null
+	language: string | null
+}
+
 /** SSR-embedded shell data for client-only regions on the detail page. */
 export type CommunityDetailShellLoaderData = {
 	ok: true
@@ -1438,6 +1461,7 @@ export type AppLoaderData = {
 	guides?: GuidesLoaderData
 	guideDetail?: GuideDetailLoaderData
 	communityDetailShell?: CommunityDetailShellLoaderData
+	packageFiles?: PackageFilesLoaderData
 	profileShell?: ProfileShellLoaderData | ProfileUnavailableLoaderData
 	timeline?: TimelineLoaderData
 	accountStars?: AccountStarsLoaderData

--- a/packages/worker/universal/package-files.node.test.ts
+++ b/packages/worker/universal/package-files.node.test.ts
@@ -77,6 +77,18 @@ test('buildPackageFilesView distinguishes root, directories, files, and misses',
 	expect(buildPackageFilesView({ files: {}, selectedPath: '' })?.kind).toBe(
 		'directory',
 	)
+	expect(buildPackageFilesView({ files, selectedPath: 'constructor' })).toBeNull()
+	expect(buildPackageFilesView({ files, selectedPath: 'toString' })).toBeNull()
+	expect(buildPackageFilesView({ files, selectedPath: '__proto__' })).toBeNull()
+	expect(
+		buildPackageFilesView({
+			files: { constructor: 'export {}\n' },
+			selectedPath: 'constructor',
+		}),
+	).toMatchObject({
+		kind: 'file',
+		content: 'export {}\n',
+	})
 })
 
 test('language and readme helpers cover common package files', () => {

--- a/packages/worker/universal/package-files.node.test.ts
+++ b/packages/worker/universal/package-files.node.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from 'vitest'
+import {
+	buildPackageFilesAncestors,
+	buildPackageFilesApiHref,
+	buildPackageFilesView,
+	findDirectoryReadmePath,
+	getAccountPackageFilesHref,
+	getCommunityPackageFilesHref,
+	isReservedPackageFilesKodyId,
+	joinPackageFilesPath,
+	languageFromFilePath,
+	listPackageFilesChildren,
+	normalizePackageFilesPath,
+} from './package-files.ts'
+
+const files = {
+	'README.md': '# Hello\n\n## Intent\n\nDo a thing.',
+	'package.json': '{"name":"@owner/demo"}',
+	'src/index.ts': 'export const answer = 42\n',
+	'src/lib/util.ts':
+		'export function add(a: number, b: number) { return a + b }\n',
+	'docs/guide.md': '# Guide\n',
+}
+
+test('normalizePackageFilesPath rejects traversal and decodes URI segments', () => {
+	expect(normalizePackageFilesPath(null)).toBe('')
+	expect(normalizePackageFilesPath('')).toBe('')
+	expect(normalizePackageFilesPath('/')).toBe('')
+	expect(normalizePackageFilesPath('src/index.ts')).toBe('src/index.ts')
+	expect(normalizePackageFilesPath('/src/lib/util.ts/')).toBe('src/lib/util.ts')
+	expect(normalizePackageFilesPath('src/%2E%2E/secrets')).toBe(null)
+	expect(normalizePackageFilesPath('../package.json')).toBe(null)
+	expect(normalizePackageFilesPath('src\\index.ts')).toBe(null)
+	expect(normalizePackageFilesPath('src/%2Findex.ts')).toBe('src/index.ts')
+})
+
+test('buildPackageFilesView distinguishes root, directories, files, and misses', () => {
+	const root = buildPackageFilesView({ files, selectedPath: '' })
+	expect(root).toMatchObject({
+		kind: 'directory',
+		selectedPath: '',
+		contentPath: 'README.md',
+		contentKind: 'markdown',
+	})
+	expect(root?.children.map((child) => child.name)).toEqual([
+		'docs',
+		'src',
+		'package.json',
+		'README.md',
+	])
+
+	const src = buildPackageFilesView({ files, selectedPath: 'src' })
+	expect(src).toMatchObject({
+		kind: 'directory',
+		contentPath: null,
+		content: null,
+	})
+	expect(src?.children).toEqual([
+		{ name: 'lib', path: 'src/lib', kind: 'directory' },
+		{ name: 'index.ts', path: 'src/index.ts', kind: 'file' },
+	])
+
+	const file = buildPackageFilesView({ files, selectedPath: 'src/index.ts' })
+	expect(file).toMatchObject({
+		kind: 'file',
+		content: 'export const answer = 42\n',
+		contentPath: 'src/index.ts',
+		contentKind: 'code',
+		language: 'ts',
+	})
+	expect(file?.ancestors.map((entry) => entry.path)).toEqual([
+		'src',
+		'src/index.ts',
+	])
+
+	expect(buildPackageFilesView({ files, selectedPath: 'missing' })).toBeNull()
+	expect(buildPackageFilesView({ files: {}, selectedPath: '' })?.kind).toBe(
+		'directory',
+	)
+})
+
+test('language and readme helpers cover common package files', () => {
+	expect(languageFromFilePath('src/app.tsx')).toBe('tsx')
+	expect(languageFromFilePath('notes.md')).toBe('markdown')
+	expect(languageFromFilePath('.env.local')).toBe('dotenv')
+	expect(languageFromFilePath('Dockerfile')).toBe('dockerfile')
+	expect(languageFromFilePath('unknown.bin')).toBe('plaintext')
+	expect(findDirectoryReadmePath(files, '')).toBe('README.md')
+	expect(findDirectoryReadmePath(files, 'docs')).toBeNull()
+	expect(findDirectoryReadmePath(files, 'src')).toBeNull()
+	expect(listPackageFilesChildren(Object.keys(files), 'docs')).toEqual([
+		{ name: 'guide.md', path: 'docs/guide.md', kind: 'file' },
+	])
+	expect(
+		buildPackageFilesAncestors('src/lib/util.ts').map((entry) => entry.name),
+	).toEqual(['src', 'lib', 'util.ts'])
+})
+
+test('files hrefs use /files paths and avoid reserved kody ids', () => {
+	expect(isReservedPackageFilesKodyId('packages')).toBe(true)
+	expect(isReservedPackageFilesKodyId('devin')).toBe(false)
+	expect(
+		getCommunityPackageFilesHref({
+			listingId: 'listing-1',
+			ownerUsername: 'kentcdodds',
+			kodyId: 'devin',
+			relativePath: 'src/index.ts',
+		}),
+	).toBe('/@kentcdodds/devin/files/src/index.ts')
+	expect(
+		getCommunityPackageFilesHref({
+			listingId: 'listing-1',
+			ownerUsername: 'kentcdodds',
+			kodyId: 'packages',
+			relativePath: 'src/index.ts',
+		}),
+	).toBe('/community/listing-1/files/src/index.ts')
+	expect(getAccountPackageFilesHref({ packageId: 'pkg-1' })).toBe(
+		'/account/packages/pkg-1/files',
+	)
+	expect(joinPackageFilesPath('/@kentcdodds/devin/files', 'src/index.ts')).toBe(
+		'/@kentcdodds/devin/files/src/index.ts',
+	)
+	expect(
+		buildPackageFilesApiHref(
+			'/profiles/kentcdodds/packages/devin/files.json',
+			'src/index.ts',
+		),
+	).toBe('/profiles/kentcdodds/packages/devin/files.json?path=src%2Findex.ts')
+})

--- a/packages/worker/universal/package-files.node.test.ts
+++ b/packages/worker/universal/package-files.node.test.ts
@@ -77,7 +77,9 @@ test('buildPackageFilesView distinguishes root, directories, files, and misses',
 	expect(buildPackageFilesView({ files: {}, selectedPath: '' })?.kind).toBe(
 		'directory',
 	)
-	expect(buildPackageFilesView({ files, selectedPath: 'constructor' })).toBeNull()
+	expect(
+		buildPackageFilesView({ files, selectedPath: 'constructor' }),
+	).toBeNull()
 	expect(buildPackageFilesView({ files, selectedPath: 'toString' })).toBeNull()
 	expect(buildPackageFilesView({ files, selectedPath: '__proto__' })).toBeNull()
 	expect(

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -1,0 +1,325 @@
+import { routes } from '#universal/routes.ts'
+
+/**
+ * Second-segment `/@username/…` namespaces claimed before the app router.
+ * A package whose `kody.id` is one of these cannot use
+ * `/@owner/:kodyId/files/…` because `/@owner/packages/files/…` is a hosted
+ * package-app path. Fall back to `/community/:listingId/files/…`.
+ */
+export const reservedPackageFilesKodyIds = [
+	'packages',
+	'api',
+	'webhooks',
+	'connectors',
+] as const
+
+export type PackageFilesKind = 'file' | 'directory'
+
+export type PackageFilesContentKind = 'markdown' | 'code' | 'text'
+
+export type PackageFilesChild = {
+	name: string
+	path: string
+	kind: PackageFilesKind
+}
+
+export type PackageFilesAncestor = {
+	name: string
+	path: string
+}
+
+export type PackageFilesView = {
+	paths: Array<string>
+	selectedPath: string
+	kind: PackageFilesKind
+	content: string | null
+	contentPath: string | null
+	contentKind: PackageFilesContentKind | null
+	language: string | null
+	children: Array<PackageFilesChild>
+	ancestors: Array<PackageFilesAncestor>
+}
+
+const readmeFileNamePattern = /^readme(?:\.[a-z0-9._-]+)?$/i
+const preferredReadmeNames = [
+	'readme.md',
+	'readme.mdx',
+	'readme.markdown',
+	'readme.txt',
+	'readme',
+] as const
+
+const extensionLanguages: Record<string, string> = {
+	ts: 'ts',
+	tsx: 'tsx',
+	js: 'ts',
+	jsx: 'tsx',
+	mjs: 'ts',
+	cjs: 'ts',
+	json: 'json',
+	md: 'markdown',
+	markdown: 'markdown',
+	mdx: 'markdown',
+	yml: 'yaml',
+	yaml: 'yaml',
+	toml: 'toml',
+	html: 'html',
+	htm: 'html',
+	css: 'css',
+	sh: 'shellscript',
+	bash: 'shellscript',
+	zsh: 'shellscript',
+	py: 'python',
+	go: 'go',
+	rs: 'rust',
+	sql: 'sql',
+	graphql: 'graphql',
+	gql: 'graphql',
+	xml: 'xml',
+	svg: 'xml',
+	dockerfile: 'dockerfile',
+	env: 'dotenv',
+	ini: 'ini',
+	diff: 'diff',
+	patch: 'diff',
+}
+
+export function isReservedPackageFilesKodyId(kodyId: string) {
+	return (reservedPackageFilesKodyIds as ReadonlyArray<string>).includes(
+		kodyId.trim().toLowerCase(),
+	)
+}
+
+/**
+ * Normalize a URL path segment or query value to a repo-relative file path.
+ * Empty string is the package root. Returns null for traversal or junk.
+ */
+export function normalizePackageFilesPath(
+	raw: string | null | undefined,
+): string | null {
+	if (raw == null) return ''
+	const trimmed = raw.trim()
+	if (trimmed === '' || trimmed === '/') return ''
+	if (trimmed.includes('\\') || trimmed.includes('\0')) return null
+	let decoded = trimmed
+	try {
+		decoded = decodeURIComponent(trimmed)
+	} catch {
+		return null
+	}
+	if (decoded.includes('\\') || decoded.includes('\0')) return null
+	const parts = decoded.split('/').filter((part) => part !== '' && part !== '.')
+	if (parts.some((part) => part === '..')) return null
+	return parts.join('/')
+}
+
+export function languageFromFilePath(path: string) {
+	const name = path.split('/').pop() ?? ''
+	if (name === 'Dockerfile' || name === 'dockerfile') return 'dockerfile'
+	if (name === '.env' || name.startsWith('.env.')) return 'dotenv'
+	const separator = name.lastIndexOf('.')
+	if (separator <= 0) return 'plaintext'
+	const ext = name.slice(separator + 1).toLowerCase()
+	return extensionLanguages[ext] ?? 'plaintext'
+}
+
+export function contentKindFromLanguage(
+	language: string,
+): PackageFilesContentKind {
+	if (language === 'markdown') return 'markdown'
+	if (language === 'plaintext') return 'text'
+	return 'code'
+}
+
+export function joinPackageFilesPath(basePath: string, relativePath: string) {
+	if (!relativePath) return basePath
+	return `${basePath}/${relativePath.split('/').map(encodeURIComponent).join('/')}`
+}
+
+export function buildPackageFilesAncestors(selectedPath: string) {
+	if (!selectedPath) return []
+	const parts = selectedPath.split('/')
+	const ancestors: Array<PackageFilesAncestor> = []
+	for (let index = 0; index < parts.length; index += 1) {
+		const name = parts[index]
+		if (!name) continue
+		ancestors.push({
+			name,
+			path: parts.slice(0, index + 1).join('/'),
+		})
+	}
+	return ancestors
+}
+
+function sortReadmeCandidates(paths: Array<string>) {
+	return [...paths].sort((left, right) => {
+		const normalizedLeft = left.split('/').pop()?.toLowerCase() ?? ''
+		const normalizedRight = right.split('/').pop()?.toLowerCase() ?? ''
+		const leftIndex = preferredReadmeNames.indexOf(
+			normalizedLeft as (typeof preferredReadmeNames)[number],
+		)
+		const rightIndex = preferredReadmeNames.indexOf(
+			normalizedRight as (typeof preferredReadmeNames)[number],
+		)
+		const leftRank = leftIndex === -1 ? preferredReadmeNames.length : leftIndex
+		const rightRank =
+			rightIndex === -1 ? preferredReadmeNames.length : rightIndex
+		if (leftRank !== rightRank) return leftRank - rightRank
+		return normalizedLeft.localeCompare(normalizedRight)
+	})
+}
+
+export function findDirectoryReadmePath(
+	files: Record<string, string>,
+	directoryPath: string,
+) {
+	const prefix = directoryPath === '' ? '' : `${directoryPath}/`
+	const matches = Object.keys(files).filter((path) => {
+		if (!path.startsWith(prefix)) return false
+		const rest = path.slice(prefix.length)
+		return !rest.includes('/') && readmeFileNamePattern.test(rest)
+	})
+	const [firstMatch] = sortReadmeCandidates(matches)
+	return firstMatch ?? null
+}
+
+export function listPackageFilesChildren(
+	paths: Array<string>,
+	directoryPath: string,
+) {
+	const prefix = directoryPath === '' ? '' : `${directoryPath}/`
+	const children = new Map<string, PackageFilesKind>()
+	for (const path of paths) {
+		if (prefix && !path.startsWith(prefix)) continue
+		const rest = prefix ? path.slice(prefix.length) : path
+		if (!rest) continue
+		const [name, ...nested] = rest.split('/')
+		if (!name) continue
+		const kind: PackageFilesKind = nested.length > 0 ? 'directory' : 'file'
+		const existing = children.get(name)
+		children.set(
+			name,
+			existing === 'directory' || kind === 'directory' ? 'directory' : 'file',
+		)
+	}
+	return [...children.entries()]
+		.sort(([leftName, leftKind], [rightName, rightKind]) => {
+			if (leftKind !== rightKind) return leftKind === 'directory' ? -1 : 1
+			return leftName.localeCompare(rightName, undefined, {
+				sensitivity: 'base',
+			})
+		})
+		.map(([name, kind]) => ({
+			name,
+			path: prefix ? `${prefix}${name}` : name,
+			kind,
+		}))
+}
+
+function directoryExists(paths: Array<string>, directoryPath: string) {
+	if (directoryPath === '') return true
+	const prefix = `${directoryPath}/`
+	return paths.some((path) => path.startsWith(prefix))
+}
+
+/**
+ * Build the explorer view for one selected path inside a published file map.
+ * Returns null when the path is neither a file nor a directory in that map.
+ * The package root (`''`) is always a directory, including an empty map.
+ */
+export function buildPackageFilesView(input: {
+	files: Record<string, string>
+	selectedPath: string
+}): PackageFilesView | null {
+	const paths = Object.keys(input.files).sort((left, right) =>
+		left.localeCompare(right),
+	)
+	const selectedPath = input.selectedPath
+	const isFile = selectedPath !== '' && selectedPath in input.files
+	if (!isFile && !directoryExists(paths, selectedPath)) return null
+
+	if (isFile) {
+		const content = input.files[selectedPath] ?? ''
+		const language = languageFromFilePath(selectedPath)
+		return {
+			paths,
+			selectedPath,
+			kind: 'file',
+			content,
+			contentPath: selectedPath,
+			contentKind: contentKindFromLanguage(language),
+			language,
+			children: [],
+			ancestors: buildPackageFilesAncestors(selectedPath),
+		}
+	}
+
+	const contentPath = findDirectoryReadmePath(input.files, selectedPath)
+	const content = contentPath ? (input.files[contentPath] ?? '') : null
+	const language = contentPath ? languageFromFilePath(contentPath) : null
+	return {
+		paths,
+		selectedPath,
+		kind: 'directory',
+		content,
+		contentPath,
+		contentKind: language ? contentKindFromLanguage(language) : null,
+		language,
+		children: listPackageFilesChildren(paths, selectedPath),
+		ancestors: buildPackageFilesAncestors(selectedPath),
+	}
+}
+
+export function getCommunityPackageFilesHref(input: {
+	listingId: string
+	ownerUsername?: string | null
+	kodyId?: string | null
+	relativePath?: string
+}) {
+	const relativePath = input.relativePath?.trim() || undefined
+	if (
+		input.ownerUsername &&
+		input.kodyId &&
+		!isReservedPackageFilesKodyId(input.kodyId)
+	) {
+		return relativePath
+			? routes.communityPackageFiles.href({
+					username: input.ownerUsername,
+					kodyId: input.kodyId,
+					relativePath,
+				})
+			: routes.communityPackageFiles.href({
+					username: input.ownerUsername,
+					kodyId: input.kodyId,
+				})
+	}
+	return relativePath
+		? routes.communityDetailFiles.href({
+				listingId: input.listingId,
+				relativePath,
+			})
+		: routes.communityDetailFiles.href({ listingId: input.listingId })
+}
+
+export function getAccountPackageFilesHref(input: {
+	packageId: string
+	relativePath?: string
+}) {
+	const relativePath = input.relativePath?.trim() || undefined
+	return relativePath
+		? routes.accountPackageFiles.href({
+				packageId: input.packageId,
+				relativePath,
+			})
+		: routes.accountPackageFiles.href({ packageId: input.packageId })
+}
+
+export function buildPackageFilesApiHref(
+	apiPath: string,
+	relativePath: string,
+) {
+	if (!relativePath) return apiPath
+	const url = new URL(apiPath, 'http://localhost')
+	url.searchParams.set('path', relativePath)
+	return `${url.pathname}${url.search}`
+}

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -235,8 +235,7 @@ export function buildPackageFilesView(input: {
 		left.localeCompare(right),
 	)
 	const selectedPath = input.selectedPath
-	const isFile =
-		selectedPath !== '' && Object.hasOwn(input.files, selectedPath)
+	const isFile = selectedPath !== '' && Object.hasOwn(input.files, selectedPath)
 	if (!isFile && !directoryExists(paths, selectedPath)) return null
 
 	if (isFile) {

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -235,7 +235,8 @@ export function buildPackageFilesView(input: {
 		left.localeCompare(right),
 	)
 	const selectedPath = input.selectedPath
-	const isFile = selectedPath !== '' && selectedPath in input.files
+	const isFile =
+		selectedPath !== '' && Object.hasOwn(input.files, selectedPath)
 	if (!isFile && !directoryExists(paths, selectedPath)) return null
 
 	if (isFile) {

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -36,6 +36,8 @@ export const routes = route({
 	),
 	accountPackages: '/account/packages',
 	accountPackageDetail: '/account/packages/:packageId',
+	accountPackageFiles: '/account/packages/:packageId/files(/*relativePath)',
+	accountPackageFilesApi: '/account/packages/:packageId/files.json',
 	accountPackagesApi: '/account/packages.json',
 	accountSecrets: '/account/secrets',
 	accountSecretNew: '/account/secrets/new',
@@ -134,6 +136,8 @@ export const routes = route({
 	communityApi: '/community.json',
 	communityDetail: '/community/:listingId',
 	communityDetailApi: '/community/:listingId.json',
+	communityDetailFiles: '/community/:listingId/files(/*relativePath)',
+	communityDetailFilesApi: '/community/:listingId/files.json',
 	communityDetailIcon: '/community/:listingId/icon/:iconCommit',
 	communityDetailOgImage: '/community/:listingId/og.png',
 	communityReportApiPost: post('/community/:listingId/report.json'),
@@ -144,14 +148,15 @@ export const routes = route({
 	communityStargazersApi: '/community/:listingId/stargazers.json',
 	profile: '/@:username',
 	// Canonical public URL for a published package, keyed by its owner and
-	// `kody.id` (`/@kentcdodds/devin`) rather than the listing uuid. Kept a leaf
-	// route: the `/@:username/…` namespaces handled before this router
-	// (`packages`, `connectors`, `webhooks`, `api`) all match on the second
-	// segment, so any deeper package route would sit at their depth.
+	// `kody.id` (`/@kentcdodds/devin`) rather than the listing uuid. Deeper
+	// package routes use a third-segment noun (`/files`) so they do not collide
+	// with `/@:username/{packages,connectors,webhooks,api}` ingress.
 	communityPackage: '/@:username/:kodyId',
+	communityPackageFiles: '/@:username/:kodyId/files(/*relativePath)',
 	// JSON companion lives under `/profiles/…` with the other username-keyed
 	// APIs, keeping the `/@…` namespace to human-shareable page URLs.
 	communityPackageApi: '/profiles/:username/packages/:kodyId.json',
+	communityPackageFilesApi: '/profiles/:username/packages/:kodyId/files.json',
 	profileApi: '/profiles/:username.json',
 	// `.` is a Remix route delimiter, so the filename must be `:hash.:ext`
 	// (not a single `:cacheKey`) or `/avatar/abc.jpg` never matches.

--- a/tools/build-client-manifest.node.test.ts
+++ b/tools/build-client-manifest.node.test.ts
@@ -16,6 +16,7 @@ test('lazy area names match the client router contract', () => {
 		'community-area',
 		'marketing-area',
 		'onboarding-area',
+		'package-files-area',
 	])
 	// Keep in sync with `syntaxHighlightAreaNames` in lazy-route.tsx.
 	expect([...highlightAreaNames].sort()).toEqual([
@@ -23,6 +24,7 @@ test('lazy area names match the client router contract', () => {
 		'blog-area',
 		'community-area',
 		'onboarding-area',
+		'package-files-area',
 	])
 })
 
@@ -61,6 +63,7 @@ test('manifest contains the entry static closure and per-area unique chunks', ()
 			[chunk('onboarding-area-H6.js')]: output([]),
 			[chunk('auth-area-H8.js')]: output([]),
 			[chunk('marketing-area-H9.js')]: output([]),
+			[chunk('package-files-area-H10.js')]: output([]),
 			[chunk('syntax-highlight-core-H7.js')]: output([
 				staticImport('shiki-lang.js'),
 			]),
@@ -117,6 +120,7 @@ test('manifest builder rejects a metafile missing the highlight chunk', () => {
 			[chunk('onboarding-area-H6.js')]: output([]),
 			[chunk('auth-area-H8.js')]: output([]),
 			[chunk('marketing-area-H9.js')]: output([]),
+			[chunk('package-files-area-H10.js')]: output([]),
 		},
 	}
 	expect(() => buildClientPreloadManifest(metafile)).toThrow(
@@ -138,6 +142,7 @@ test('manifest builder rejects a highlight chunk that leaked into the entry', ()
 			[chunk('onboarding-area-H6.js')]: output([]),
 			[chunk('auth-area-H8.js')]: output([]),
 			[chunk('marketing-area-H9.js')]: output([]),
+			[chunk('package-files-area-H10.js')]: output([]),
 		},
 	}
 	expect(() => buildClientPreloadManifest(metafile)).toThrow(

--- a/tools/build-client-manifest.ts
+++ b/tools/build-client-manifest.ts
@@ -43,6 +43,7 @@ export const lazyAreaNames = [
 	'community-area',
 	'marketing-area',
 	'onboarding-area',
+	'package-files-area',
 ]
 
 /**
@@ -57,6 +58,7 @@ export const highlightAreaNames = [
 	'blog-area',
 	'community-area',
 	'onboarding-area',
+	'package-files-area',
 ] as const
 
 const highlightAreaNameSet = new Set<string>(highlightAreaNames)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give humans a GitHub-like way to browse the published text snapshot of a community listing or their own saved package, without turning the listing page into a file browser and without opening git sessions.

## Summary

- Dedicated `/files` pages:
  - `/@:username/:kodyId/files(/*relativePath)`
  - `/community/:listingId/files(/*relativePath)` fallback (also used when `kody.id` is a reserved second-segment namespace)
  - `/account/packages/:packageId/files(/*relativePath)`
- JSON companions use `?path=` (`/profiles/…/files.json`, `/community/:id/files.json`, `/account/packages/:id/files.json`).
- Listing and account package pages keep README/install/fork and add a **Browse files** link.
- SSR the tree + selected file from the published text snapshot only (community KV snapshot, account published source). Unknown paths 404; empty snapshot + root shows an empty directory.
- Explorer lives in its own `package-files-area` lazy chunk so listing/profile/account list chunks do not pull Shiki.
- Own-key check for snapshot membership (`Object.hasOwn`) so inherited names like `constructor` / `toString` 404.

## Testing

- Focused: `package-files` unit/handler tests, including inherited-key 404s; router specificity, lazy-route, document-head, client-manifest, community-detail frame.
- `npx nx run worker:typecheck` passed locally.
- Preview logged-in session on `kody-pr-1545` (merge of `a492d70a`): empty account packages, community 404 `/files` HTML + JSON, missing account package `/files` 404, login smoke.
- UI pass on the same preview as the seed user (`user-me`). Preview D1 has no saved packages or community listings, so this exercises the explorer 404 / empty-catalog paths (packages are created via MCP, not `/account/*.json`).
- `oxfmt` follow-up for Static `format:check` on the inherited-key files.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `def750f1` · **Head:** `be6ce16b`

**Classification:** extends — `app-ui` gains public and account `/files` routes, a dedicated explorer page, and a `packageFiles` loader contract. Community listings and saved packages are read as-is.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — `/files` HTML + JSON routes, explorer UI, lazy `package-files-area` |
| `community-listings` | assistant | composes — public listing + KV snapshot reads |
| `saved-packages` | assistant | composes — owner-scoped published source for account files |
| `bundle-artifacts-kv` | storage | composes — community snapshot files |

### Change flow

A Browse files click SSRs the published snapshot tree and selected file; client navigations refetch the JSON companion.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	participant bundleArtifactsKv as bundle-artifacts-kv
	participant savedPackages as saved-packages
	participant appSessions as app-sessions
	User->>appUi: GET /@:user/:kodyId/files/src/index.ts
	appUi->>communityListings: resolve listing by owner + kody.id
	communityListings->>bundleArtifactsKv: readCommunitySnapshot(listingId)
	appUi-->>User: SSR tree + selected file
	User->>appUi: GET /account/packages/:id/files
	appUi->>appSessions: require authenticated page user
	appUi->>savedPackages: getSavedPackageById(userId) + load source
	appUi-->>User: SSR owner snapshot tree
```

### Before / after

| Surface | Before | After |
| ------- | ------ | ----- |
| Community listing | README / install / fork only | same, plus **Browse files** → `/files` |
| Account package | package detail only | same, plus **Browse files** → `/account/packages/:id/files` |
| Published tree | MCP `repo_tree` counts | human-readable text snapshot explorer |

### Invariants

- `per-user-isolation`: account files load `getSavedPackageById` / `loadPackageSourceBySourceId` with the signed-in `userId`.
- `community-listing-isolation`: community files read the public pinned snapshot only; fork rewrite files are never shown.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f9892be-8dbf-4489-8eac-5fac91472899?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f9892be-8dbf-4489-8eac-5fac91472899&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

