### PR TITLE
Add "What is a …?" explainers to entity pages

### DIFF
--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -16,6 +16,7 @@ import {
 	layoutMaxWidths,
 	pageGutter,
 } from '#universal/styles/style-primitives.ts'
+import { EntityExplainer, resolveEntityExplainer } from './entity-explainer.tsx'
 
 /*
  * Account-area visual language, ported from the redesign prototype
@@ -470,6 +471,7 @@ export function AccountPageHeader(handle: Handle<AccountPageHeaderProps>) {
 	return () => {
 		const currentPath = new URL(handle.props.currentHref, 'http://localhost')
 			.pathname
+		const explainer = resolveEntityExplainer(currentPath)
 
 		return (
 			<>
@@ -478,6 +480,7 @@ export function AccountPageHeader(handle: Handle<AccountPageHeaderProps>) {
 					description={handle.props.description}
 					actions={handle.props.actions}
 				/>
+				{explainer ? <EntityExplainer copy={explainer} /> : null}
 				<AccountManagementLinkNav
 					label="Account sections"
 					items={accountNavItems.map((item) => ({

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -16,6 +16,10 @@ import {
 	visuallyHiddenCss,
 } from '#universal/styles/style-primitives.ts'
 import { readCommunitySearchQueryFromHref } from '#client/routes/community-search.ts'
+import {
+	EntityExplainer,
+	resolveEntityExplainer,
+} from '#client/routes/entity-explainer.tsx'
 
 /**
  * Community index, ported from the redesign prototype
@@ -73,6 +77,10 @@ export function CommunityRoute(handle: Handle) {
 		const searchQuery = readCommunitySearchQueryFromHref(currentHref)
 		const frameSrc = buildCommunityListingsFrameSrc(currentHref)
 
+		const explainer = resolveEntityExplainer(
+			new URL(currentHref, 'http://localhost').pathname,
+		)
+
 		return (
 			<section mix={css(communityPageCss)}>
 				<header mix={css(communityHeadCss)}>
@@ -86,6 +94,9 @@ export function CommunityRoute(handle: Handle) {
 							Browse packages shared by Kody users. Fork with your agent, adapt
 							them to your goals, and rate your experience.
 						</p>
+						{explainer ? (
+							<EntityExplainer copy={explainer} marginTop="1.15rem" />
+						) : null}
 						<form
 							data-rise
 							data-focus-container

--- a/packages/worker/client/routes/entity-explainer.node.test.ts
+++ b/packages/worker/client/routes/entity-explainer.node.test.ts
@@ -1,0 +1,111 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { AccountPageHeader } from '#client/routes/account-management-components.tsx'
+import {
+	EntityExplainer,
+	resolveEntityExplainer,
+} from '#client/routes/entity-explainer.tsx'
+import { routes } from '#universal/routes.ts'
+
+test('resolves an explainer for entity pages and skips settings-only routes', () => {
+	expect(resolveEntityExplainer(routes.accountPackages.href())?.question).toBe(
+		'What is a package?',
+	)
+	expect(
+		resolveEntityExplainer(
+			routes.accountPackageDetail.href({ packageId: 'pkg_123' }),
+		)?.id,
+	).toBe('packages')
+	expect(resolveEntityExplainer(routes.accountEmail.href())?.question).toBe(
+		'What is email?',
+	)
+	expect(resolveEntityExplainer(routes.accountJobs.href())?.question).toBe(
+		'What is a job?',
+	)
+	expect(resolveEntityExplainer(routes.accountSecrets.href())?.question).toBe(
+		'What is a secret?',
+	)
+	expect(
+		resolveEntityExplainer(routes.accountIntegrations.href())?.question,
+	).toBe('What is an integration?')
+	expect(
+		resolveEntityExplainer(routes.accountPackageInvocationTokens.href())
+			?.question,
+	).toBe('What is a package token?')
+	expect(
+		resolveEntityExplainer(routes.accountMcpServers.href())?.question,
+	).toBe('What is an MCP server?')
+	expect(resolveEntityExplainer(routes.accountMemories.href())?.question).toBe(
+		'What is a memory?',
+	)
+	expect(resolveEntityExplainer(routes.accountActivity.href())?.question).toBe(
+		'What is activity?',
+	)
+	expect(resolveEntityExplainer(routes.accountStars.href())?.question).toBe(
+		'What is a star?',
+	)
+	expect(resolveEntityExplainer(routes.accountValues.href())?.question).toBe(
+		'What is a value?',
+	)
+	expect(resolveEntityExplainer(routes.accountUsage.href())?.question).toBe(
+		'What is usage?',
+	)
+	expect(resolveEntityExplainer(routes.community.href())?.question).toBe(
+		'What is community?',
+	)
+	expect(resolveEntityExplainer(routes.timeline.href())?.question).toBe(
+		'What is the timeline?',
+	)
+
+	expect(resolveEntityExplainer(routes.account.href())).toBeNull()
+	expect(resolveEntityExplainer(routes.accountBilling.href())).toBeNull()
+	expect(resolveEntityExplainer(routes.accountPasskeys.href())).toBeNull()
+	expect(resolveEntityExplainer(routes.accountTwoFactor.href())).toBeNull()
+	expect(resolveEntityExplainer(routes.login.href())).toBeNull()
+	expect(resolveEntityExplainer(routes.pricing.href())).toBeNull()
+	expect(resolveEntityExplainer(routes.admin.href())).toBeNull()
+	expect(
+		resolveEntityExplainer(
+			routes.communityDetail.href({ listingId: 'listing_1' }),
+		),
+	).toBeNull()
+})
+
+test('entity explainer renders a collapsed details with a learn-more link', async () => {
+	const copy = resolveEntityExplainer(routes.accountPackages.href())
+	expect(copy).not.toBeNull()
+	if (!copy) throw new Error('expected packages explainer')
+
+	const html = await renderToString(jsx(EntityExplainer, { copy }))
+
+	expect(html).toContain('data-entity-explainer="packages"')
+	expect(html).toContain('<summary>What is a package?</summary>')
+	expect(html).toContain(`href="${copy.learnMore?.href}"`)
+	expect(html).toContain('Package lifecycle guide')
+	expect(html).toMatch(
+		/<details(?![^>]*\bopen\b)[^>]*data-entity-explainer="packages"/,
+	)
+})
+
+test('account page header inserts the matching explainer under the title', async () => {
+	const packagesHtml = await renderToString(
+		jsx(AccountPageHeader, {
+			title: 'Packages',
+			description: 'Saved packages',
+			currentHref: routes.accountPackages.href(),
+		}),
+	)
+	expect(packagesHtml).toContain('data-entity-explainer="packages"')
+	expect(packagesHtml).toContain('What is a package?')
+
+	const overviewHtml = await renderToString(
+		jsx(AccountPageHeader, {
+			title: 'Overview',
+			description: 'Account home',
+			currentHref: routes.account.href(),
+		}),
+	)
+	expect(overviewHtml).not.toContain('data-entity-explainer')
+	expect(overviewHtml).not.toContain('What is a package?')
+})

--- a/packages/worker/client/routes/entity-explainer.tsx
+++ b/packages/worker/client/routes/entity-explainer.tsx
@@ -1,0 +1,280 @@
+import { css, type Handle } from 'remix/ui'
+import { routes } from '#universal/routes.ts'
+import { colors, transitions, typography } from '#universal/styles/tokens.ts'
+import { hoverMq } from '#universal/styles/style-primitives.ts'
+
+export type EntityExplainerCopy = {
+	id: string
+	question: string
+	paragraphs: Array<string>
+	learnMore?: {
+		href: string
+		label: string
+	}
+}
+
+type EntityExplainerDefinition = EntityExplainerCopy & {
+	match: (pathname: string) => boolean
+}
+
+function accountSection(href: string) {
+	return (pathname: string) =>
+		pathname === href || pathname.startsWith(`${href}/`)
+}
+
+const entityExplainerDefinitions: Array<EntityExplainerDefinition> = [
+	{
+		id: 'packages',
+		question: 'What is a package?',
+		match: accountSection(routes.accountPackages.href()),
+		paragraphs: [
+			'A package is reusable saved code your agent writes and improves over time. Unlike a one-off execute, it lives in a repo with a package.json and can expose exports, scheduled jobs, inbound webhooks, and even a small web app.',
+			'Use a package when work should stay invokable after the conversation ends — a daily digest, a GitHub helper, or a UI your agent hosts for you. Browse metadata here; create and edit packages through your connected agent.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({ slug: 'package-lifecycle' }),
+			label: 'Package lifecycle guide',
+		},
+	},
+	{
+		id: 'email',
+		question: 'What is email?',
+		match: accountSection(routes.accountEmail.href()),
+		paragraphs: [
+			"Every Kody account gets a personal inbox at your username on this deployment's email domain. Inbound mail is stored so automations can react to it, and your agent can send you notify-self messages or reply to stored threads.",
+			'Use the inbox as an automation trigger — invoices to a +tag address, alerts from a job, or a daily digest that stays quiet until something actually happened. Compose and reply through your agent; this page is for browsing, classifying, and inspecting messages.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({ slug: 'how-kody-works' }),
+			label: 'How Kody works',
+		},
+	},
+	{
+		id: 'jobs',
+		question: 'What is a job?',
+		match: accountSection(routes.accountJobs.href()),
+		paragraphs: [
+			'A job is scheduled work that runs in the cloud on Cloudflare Workers, whether or not your computer is on. Ad-hoc jobs are one-off or recurring schedules that are not tied to a package; package-owned jobs live with the saved package that declares them.',
+			'Use a job for anything that should happen later or on a cadence — a morning briefing, a weekly cleanup, or a catch-up run. From here you can inspect schedules, run a job now, and toggle kill switch or Preserve.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({ slug: 'how-kody-works' }),
+			label: 'How Kody works',
+		},
+	},
+	{
+		id: 'secrets',
+		question: 'What is a secret?',
+		match: accountSection(routes.accountSecrets.href()),
+		paragraphs: [
+			'A secret is a credential Kody stores for you — an API key, personal access token, or OAuth token. Your agent references secrets by name; Kody substitutes them at the network boundary and never returns the raw value to chat.',
+			'Use secrets so your agent can call the services you already use without pasting keys into the conversation. Add API keys here; connect OAuth apps from Integrations.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({ slug: 'account-secret-setup' }),
+			label: 'Secret setup guide',
+		},
+	},
+	{
+		id: 'integrations',
+		question: 'What is an integration?',
+		match: accountSection(routes.accountIntegrations.href()),
+		paragraphs: [
+			"An integration is a connected service — usually OAuth — so Kody can act as you on that provider. Built-in integrations use Kody's registered app; you can also bring your own OAuth client.",
+			'Use an integration when a provider needs a signed-in connection rather than a static API key. Tokens land as your secrets. Scope connections deliberately and revoke unused ones.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({ slug: 'integration-bootstrap' }),
+			label: 'Integration bootstrap guide',
+		},
+	},
+	{
+		id: 'package-tokens',
+		question: 'What is a package token?',
+		match: accountSection(routes.accountPackageInvocationTokens.href()),
+		paragraphs: [
+			'A package invocation token is a bearer credential for trusted clients outside Kody — a CLI, gateway, or other process that cannot use MCP. The raw token is shown once and stored only as a hash.',
+			'Use a token when a non-Kody process must call a package export over HTTP. Code that already runs inside Kody should import the package or use packages.invoke instead.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({
+				slug: 'account-package-invocation-token-setup',
+			}),
+			label: 'Package token setup guide',
+		},
+	},
+	{
+		id: 'mcp-servers',
+		question: 'What is an MCP server?',
+		match: accountSection(routes.accountMcpServers.href()),
+		paragraphs: [
+			'Kody can act as an MCP client: you add a remote MCP server, and its tools become callable as kody.mcp["server-name"].tool_name(...). This is the inverse of connecting your agent to Kody.',
+			'Use this when another product already exposes MCP tools you want your Kody-connected agent to reach. Add a URL plus a bearer token, or complete OAuth when the server requires it.',
+		],
+	},
+	{
+		id: 'memories',
+		question: 'What is a memory?',
+		match: accountSection(routes.accountMemories.href()),
+		paragraphs: [
+			'A memory is a durable fact or preference Kody keeps about you across conversations — things like a preferred language or how you like to be notified. Agents retrieve a few relevant memories per task and must verify before writing.',
+			'Browse, filter, and delete memories here. Ask your agent to remember something important; do not store secrets or credentials as memories.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({ slug: 'what-is-kody' }),
+			label: 'What is Kody?',
+		},
+	},
+	{
+		id: 'activity',
+		question: 'What is activity?',
+		match: accountSection(routes.accountActivity.href()),
+		paragraphs: [
+			'Activity is a short execution history for jobs, package apps, webhooks, and other runtimes. When something fails, the run, logs, and a triage state (open, ignored, or resolved) show up here.',
+			'Use this page to see what broke and whether to ignore, resolve, or fix it. Your agent can review open errors through the runs capabilities. A later successful run for the same job automatically resolves earlier open errors.',
+		],
+	},
+	{
+		id: 'stars',
+		question: 'What is a star?',
+		match: accountSection(routes.accountStars.href()),
+		paragraphs: [
+			'A star is your bookmark for a community package listing. It is separate from the 1–5 rating you can leave on a listing.',
+			'Star packages you want to find again, fork later, or keep an eye on. Stars are public on listings; this page is your personal list.',
+		],
+	},
+	{
+		id: 'values',
+		question: 'What is a value?',
+		match: accountSection(routes.accountValues.href()),
+		paragraphs: [
+			'Values were named readable config rows. New values are not created; existing rows stay here so you can migrate them to memories, package storage, repos, secrets, or integrations, then delete them.',
+			'Open this page only during migration. Prefer memories for durable facts, package storage for package state, and secrets for credentials.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({ slug: 'values' }),
+			label: 'Values migration guide',
+		},
+	},
+	{
+		id: 'usage',
+		question: 'What is usage?',
+		match: accountSection(routes.accountUsage.href()),
+		paragraphs: [
+			'Usage is how much of your plan you have consumed — stored email, job slots, workflow concurrency, and other finite entitlements.',
+			'Check this page when something is quota-gated or you are deciding whether to upgrade. Limits are per signed-in user.',
+		],
+		learnMore: {
+			href: routes.pricing.href(),
+			label: 'Plans and pricing',
+		},
+	},
+	{
+		id: 'community',
+		question: 'What is community?',
+		match: (pathname) => pathname === routes.community.href(),
+		paragraphs: [
+			"Community is the public catalog of published packages on this deployment. A listing is a pinned snapshot of someone else's package, not a live link to their private copy.",
+			'Browse and search without an account. Installing creates a fork you own — you can change it, schedule it, and publish your own version. Prefer a close community package before creating one from scratch.',
+		],
+		learnMore: {
+			href: routes.guideDetail.href({ slug: 'what-is-kody' }),
+			label: 'What is Kody?',
+		},
+	},
+	{
+		id: 'timeline',
+		question: 'What is the timeline?',
+		match: (pathname) => pathname === routes.timeline.href(),
+		paragraphs: [
+			'The timeline is a feed of public community activity from accounts you follow: publishes, republishes, forks, and stars. Private package edits never appear.',
+			'Follow public profiles to see what they ship. Your own public activity shows up on your profile; this page is the follow-graph view of the same events.',
+		],
+	},
+]
+
+export function resolveEntityExplainer(
+	pathname: string,
+): EntityExplainerCopy | null {
+	const entry = entityExplainerDefinitions.find((item) => item.match(pathname))
+	if (!entry) return null
+	return {
+		id: entry.id,
+		question: entry.question,
+		paragraphs: entry.paragraphs,
+		...(entry.learnMore ? { learnMore: entry.learnMore } : {}),
+	}
+}
+
+const entityExplainerCss = {
+	margin: 0,
+	maxWidth: '60ch',
+	'& > summary': {
+		cursor: 'pointer',
+		fontWeight: 600,
+		color: colors.primaryText,
+		width: 'fit-content',
+		transition: `color ${transitions.fast}`,
+	},
+	[hoverMq]: {
+		'& > summary:hover': { color: colors.text },
+	},
+	'&[open] > summary': { marginBottom: '0.4rem' },
+	'& > :not(summary)': {
+		display: 'grid',
+		gap: '0.7rem',
+		color: colors.textMuted,
+		fontSize: '0.98rem',
+		lineHeight: 1.5,
+		'@media (prefers-reduced-motion: no-preference)': {
+			transition: `opacity 200ms ${transitions.easeOut}, translate 200ms ${transitions.easeOut}`,
+		},
+		'@starting-style': {
+			opacity: 0,
+			translate: '0 4px',
+		},
+	},
+	'& p': {
+		margin: 0,
+		textWrap: 'pretty' as const,
+	},
+	'& a': {
+		color: colors.primaryText,
+		fontWeight: 600,
+		width: 'fit-content',
+		fontSize: typography.fontSize.sm,
+	},
+}
+
+type EntityExplainerProps = {
+	copy: EntityExplainerCopy
+	marginTop?: string
+}
+
+export function EntityExplainer(handle: Handle<EntityExplainerProps>) {
+	return () => (
+		<details
+			data-entity-explainer={handle.props.copy.id}
+			mix={css({
+				...entityExplainerCss,
+				...(handle.props.marginTop
+					? { marginTop: handle.props.marginTop }
+					: {}),
+			})}
+		>
+			<summary>{handle.props.copy.question}</summary>
+			<div>
+				{handle.props.copy.paragraphs.map((paragraph) => (
+					<p key={paragraph}>{paragraph}</p>
+				))}
+				{handle.props.copy.learnMore ? (
+					<p>
+						<a href={handle.props.copy.learnMore.href}>
+							{handle.props.copy.learnMore.label}
+						</a>
+					</p>
+				) : null}
+			</div>
+		</details>
+	)
+}

--- a/packages/worker/client/routes/timeline.tsx
+++ b/packages/worker/client/routes/timeline.tsx
@@ -26,6 +26,10 @@ import {
 } from '#client/route-loader.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import {
+	EntityExplainer,
+	resolveEntityExplainer,
+} from '#client/routes/entity-explainer.tsx'
+import {
 	colors,
 	radius,
 	transitions,
@@ -146,6 +150,10 @@ export function TimelineRoute(handle: Handle) {
 
 		const days = status === 'ready' ? groupTimelineItems(items) : []
 
+		const explainer = resolveEntityExplainer(
+			new URL(currentHref, 'http://localhost').pathname,
+		)
+
 		return (
 			<section mix={css(pageCss)} data-testid="timeline-page">
 				<header mix={css(headCss)}>
@@ -155,6 +163,9 @@ export function TimelineRoute(handle: Handle) {
 					<p data-rise style={{ '--rise': '1' }}>
 						Public activity from the accounts you follow.
 					</p>
+					{explainer ? (
+						<EntityExplainer copy={explainer} marginTop="1.15rem" />
+					) : null}
 				</header>
 
 				{status === 'loading' ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Help people who land on Packages, Email, and the other entity pages understand what those things are and how they might use them — without making the page louder for people who already know.

## Summary

- Add a shared collapsed `<details>` explainer (`What is a package?`, `What is email?`, and the rest) at the top of relevant entity pages.
- Account entity pages pick up the matching explainer from `AccountPageHeader` automatically.
- Community and Timeline render the same component under their page heads.
- Settings-only routes (overview, billing, passkeys, 2FA) stay explainer-free.
- Learn-more links point at the existing in-app guides where one exists.

## Testing

- `vitest run --project node-unit` on `entity-explainer.node.test.ts` and `account-management-metadata.node.test.ts`
- Full `npm run validate` after this PR opens

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `75de52c` · **Head:** `c0518a9`

**Classification:** composes — no primitives added or changed; this PR wires existing primitives together.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — collapsed entity explainer on account and timeline pages |
| `community-listings` | assistant | composes — same explainer on the community index |

### Change flow

Signed-in (and public community) page renders resolve a pathname to optional explainer copy and output a native details element.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant communityListings as community-listings
	User->>appUi: open /account/packages or /account/email
	appUi->>appUi: resolveEntityExplainer(pathname)
	appUi-->>User: collapsed What is a package? / What is email? details
	User->>communityListings: open /community
	communityListings->>appUi: render EntityExplainer
	appUi-->>User: collapsed What is community? details
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9b2d13a-408f-4ec1-8cda-6f9f9c2f0fa6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9b2d13a-408f-4ec1-8cda-6f9f9c2f0fa6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual explainers to account, community, and timeline pages.
  * Explainers provide concise guidance and may include links to relevant learning resources.
  * Added collapsible “learn more” sections for a cleaner page experience.

* **Tests**
  * Added coverage to verify explainers appear only on applicable routes and render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->