### PR TITLE
Stop cancelled Validate runs and test dispatch-slow warns from failing CI

### DIFF
--- a/.github/actions/setup-validate/action.yml
+++ b/.github/actions/setup-validate/action.yml
@@ -26,6 +26,7 @@ runs:
 
     - name: 🎭 Cache Playwright Browsers
       if: inputs.playwright == 'true'
+      id: playwright-cache
       uses: actions/cache@v5.0.3
       with:
         path: ~/.cache/ms-playwright
@@ -68,7 +69,11 @@ runs:
     - name: 🎭 Install Playwright Browsers
       if: inputs.playwright == 'true'
       shell: bash
-      run: npm run test:e2e:install
+      run: |
+        echo "playwright-cache-hit=${{ steps.playwright-cache.outputs.cache-hit }}"
+        # Cache hit: ensure is a no-op (executable already on disk).
+        # Cache miss: download Chromium only — no apt --with-deps.
+        npm run test:e2e:ensure
 
     - name: 🗄️ Apply D1 Migrations
       if: inputs.migrate-local == 'true'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -250,8 +250,12 @@ jobs:
       - workers
       - mcp
       - e2e
+    # always() so a failed sibling still reports; !cancelled() so a
+    # superseded run (cancel-in-progress) does not paint ✅ Validate red.
+    # A sibling job timeout still fails this job: the workflow is not
+    # cancelled, and that child result is cancelled != success.
     if: >-
-      always() && (github.event_name != 'pull_request' ||
+      always() && !cancelled() && (github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false)
     steps:
       - name: ✅ All checks passed

--- a/docs/contributing/architecture/invocation-overhead-guardrails.md
+++ b/docs/contributing/architecture/invocation-overhead-guardrails.md
@@ -67,6 +67,15 @@ loaders (`resolveSavedPackage`, `loadInvokeManifestBySourceId`); every cache key
 must start with the owning `userId` (per user isolation is inviolable); and new
 caches on invocation paths need an explicit staleness bound documented here.
 
+## Cold first-dispatch sample
+
+The first `kody.*` capability RPC in an isolate logs
+`kody-first-capability-dispatch-slow` when wall time is at least 250ms. That
+probe is for production isolate logs. Workers-unit keeps per-file isolation
+([decision 0011](../decisions/0011-workers-unit-pool-harness.md)), so the same
+threshold is not a test assertion. Vitest skips the warn so CI load cannot fail
+the console spy.
+
 ## Watch the percentiles
 
 Every invocation surface is metered through `recordUsage()` (see

--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -66,7 +66,9 @@ Avoid `page.locator('css')` unless no accessible alternative exists.
   applies local D1 migrations, and starts Wrangler against
   `.wrangler/state/e2e`.
 - `npm run test:e2e:run` ensures Playwright Chromium is installed before the
-  suite starts.
+  suite starts (`tools/ensure-playwright-browser.ts`). The Validate E2E job
+  restores `~/.cache/ms-playwright` from Actions cache and calls the same ensure
+  script, so a matching Playwright revision does not download or run `apt-get`.
 - `npm run test:e2e:ui` and plain `npx playwright test` assume Playwright
   browsers are already installed.
 - Playwright sets `CLOUDFLARE_ENV=test`; Wrangler loads `packages/worker/.env`

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -116,7 +116,10 @@ Quick notes for getting a local kody environment running.
   suite starts, so `npm run validate` and `npm run test:push` self-heal on a
   fresh machine.
 - Use `npm run test:e2e:install` when you want to prefetch Playwright browsers
-  ahead of time instead of waiting for the first E2E run.
+  ahead of time instead of waiting for the first E2E run. CI caches
+  `~/.cache/ms-playwright` and runs `test:e2e:ensure`, so a lockfile-matching
+  cache hit skips the download and never runs `apt-get` (`--with-deps` is
+  local-only; `apt-get update` can hang the E2E job past the 15-minute timeout).
 - `npm run test:e2e:run` runs the Playwright suite through Nx and depends on a
   cached `worker:prepare-e2e-env` target for `.env` bootstrap plus an uncached
   `worker:prepare-playwright` target that checks the local Chromium install.

--- a/packages/worker/src/mcp/first-capability-dispatch.node.test.ts
+++ b/packages/worker/src/mcp/first-capability-dispatch.node.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest'
+import {
+	firstCapabilityDispatchWarnMs,
+	shouldWarnFirstCapabilityDispatch,
+} from './first-capability-dispatch.ts'
+
+test('first capability dispatch warn stays off under Vitest and fires only when the probe is enabled past the budget', () => {
+	expect(shouldWarnFirstCapabilityDispatch(firstCapabilityDispatchWarnMs)).toBe(
+		false,
+	)
+	expect(shouldWarnFirstCapabilityDispatch(10_000)).toBe(false)
+	expect(
+		shouldWarnFirstCapabilityDispatch(firstCapabilityDispatchWarnMs - 1, {
+			probeEnabled: true,
+		}),
+	).toBe(false)
+	expect(
+		shouldWarnFirstCapabilityDispatch(firstCapabilityDispatchWarnMs, {
+			probeEnabled: true,
+		}),
+	).toBe(true)
+})

--- a/packages/worker/src/mcp/first-capability-dispatch.ts
+++ b/packages/worker/src/mcp/first-capability-dispatch.ts
@@ -1,0 +1,19 @@
+export const firstCapabilityDispatchWarnMs = 250
+export const firstCapabilityDispatchWarnTag =
+	'kody-first-capability-dispatch-slow'
+
+function isVitestRuntime() {
+	const runtimeProcess = (
+		globalThis as { process?: { env?: Record<string, unknown> } }
+	).process
+	return Boolean(runtimeProcess?.env?.VITEST)
+}
+
+export function shouldWarnFirstCapabilityDispatch(
+	durationMs: number,
+	options?: { probeEnabled?: boolean; warnMs?: number },
+) {
+	const probeEnabled = options?.probeEnabled ?? !isVitestRuntime()
+	if (!probeEnabled) return false
+	return durationMs >= (options?.warnMs ?? firstCapabilityDispatchWarnMs)
+}

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -95,6 +95,10 @@ import {
 	reportExecutePhaseProgress,
 	type McpReportProgress,
 } from '#mcp/progress.ts'
+import {
+	firstCapabilityDispatchWarnTag,
+	shouldWarnFirstCapabilityDispatch,
+} from './first-capability-dispatch.ts'
 
 type ExecuteServerTimingEntry = {
 	name: string
@@ -140,7 +144,6 @@ export function createAdHocExecuteSourceFiles(code: string) {
 
 /** Once per isolate: sample the first kody.* capability RPC wall time. */
 let firstCapabilityDispatchSampled = false
-const firstCapabilityDispatchWarnMs = 250
 
 function isPackageSecretAvailabilityError(error: unknown) {
 	return (
@@ -326,8 +329,8 @@ async function buildKodyToolContext(
 				} finally {
 					if (shouldSampleFirstDispatch) {
 						const durationMs = Date.now() - dispatchStartedAtMs
-						if (durationMs >= firstCapabilityDispatchWarnMs) {
-							console.warn('kody-first-capability-dispatch-slow', {
+						if (shouldWarnFirstCapabilityDispatch(durationMs)) {
+							console.warn(firstCapabilityDispatchWarnTag, {
 								capabilityName,
 								durationMs,
 							})

--- a/packages/worker/src/test-support/incidental-runtime-warnings.ts
+++ b/packages/worker/src/test-support/incidental-runtime-warnings.ts
@@ -2,9 +2,12 @@ import { silenceExpectedConsoleWarns } from './console-spies.ts'
 
 // The worker bundler warns that it is experimental, and the registry runtime's
 // optional MCP-server, usage, run-record, and activation lookups warn when
-// their tables or bindings are absent from the unit-test schema. Tests that run
-// those paths swallow exactly these messages; any other warning still fails the
-// test so real problems are never silently suppressed.
+// their tables or bindings are absent from the unit-test schema. The first
+// kody.* dispatch probe can also warn under workers-unit isolation; Vitest
+// skips that emit, and this tag stays allowlisted if a workerd isolate still
+// logs it. Tests that run those paths swallow exactly these messages; any
+// other warning still fails the test so real problems are never silently
+// suppressed.
 const incidentalRuntimeWarnings = [
 	/^\[worker-bundler\] /,
 	'mcp-server-refs-load-failed',
@@ -18,6 +21,7 @@ const incidentalRuntimeWarnings = [
 	'activation-milestone-failed',
 	'activation-run-record-failed',
 	'artifacts-push-subscription-ensure-failed',
+	'kody-first-capability-dispatch-slow',
 ]
 
 export function silenceIncidentalRuntimeWarnings(

--- a/tools/ensure-playwright-browser.node.test.ts
+++ b/tools/ensure-playwright-browser.node.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+import { playwrightChromiumInstallArgs } from './ensure-playwright-browser.ts'
+
+test('Playwright Chromium install skips apt deps on GitHub Actions and keeps them locally', () => {
+	expect(playwrightChromiumInstallArgs({ githubActions: true })).toEqual([
+		'install',
+		'chromium',
+	])
+	expect(playwrightChromiumInstallArgs({ githubActions: false })).toEqual([
+		'install',
+		'chromium',
+		'--with-deps',
+	])
+})

--- a/tools/ensure-playwright-browser.ts
+++ b/tools/ensure-playwright-browser.ts
@@ -1,36 +1,55 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { chromium } from '@playwright/test'
+import { isExecutedDirectly, resolveLocalBinary } from './node-runtime.ts'
 
-const browserExecutablePath = chromium.executablePath()
-
-if (existsSync(browserExecutablePath)) {
-	console.log(
-		`Playwright Chromium already installed at ${browserExecutablePath}.`,
-	)
-	process.exit(0)
+export function playwrightChromiumInstallArgs(input: {
+	githubActions: boolean
+}): Array<string> {
+	// GitHub-hosted runners already have the system libraries. `--with-deps`
+	// runs `apt-get update` on every E2E job and can hang past the 15-minute
+	// Validate timeout. Local Linux still needs the dep install.
+	if (input.githubActions) {
+		return ['install', 'chromium']
+	}
+	return ['install', 'chromium', '--with-deps']
 }
 
-console.log('Installing Playwright Chromium for E2E tests...')
+function ensurePlaywrightChromium() {
+	const browserExecutablePath = chromium.executablePath()
+	if (existsSync(browserExecutablePath)) {
+		console.log(
+			`Playwright Chromium already installed at ${browserExecutablePath}.`,
+		)
+		return 0
+	}
 
-const result = spawnSync(
-	'npx',
-	['playwright', 'install', 'chromium', '--with-deps'],
-	{
+	const installArgs = playwrightChromiumInstallArgs({
+		githubActions: process.env.GITHUB_ACTIONS === 'true',
+	})
+	console.log(
+		`Installing Playwright Chromium for E2E tests (${installArgs.join(' ')})...`,
+	)
+
+	const result = spawnSync(resolveLocalBinary('playwright'), installArgs, {
 		stdio: 'inherit',
 		shell: process.platform === 'win32',
-	},
-)
+	})
+	if (result.status !== 0) {
+		return result.status ?? 1
+	}
 
-if (result.status !== 0) {
-	process.exit(result.status ?? 1)
+	if (!existsSync(browserExecutablePath)) {
+		console.error(
+			'Playwright Chromium install completed, but the browser executable is still missing.',
+		)
+		return 1
+	}
+
+	console.log(`Playwright Chromium installed at ${browserExecutablePath}.`)
+	return 0
 }
 
-if (!existsSync(browserExecutablePath)) {
-	console.error(
-		'Playwright Chromium install completed, but the browser executable is still missing.',
-	)
-	process.exit(1)
+if (isExecutedDirectly(import.meta.url)) {
+	process.exit(ensurePlaywrightChromium())
 }
-
-console.log(`Playwright Chromium installed at ${browserExecutablePath}.`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the required ✅ Validate check honest: superseded CI runs should not paint PRs red, workers-unit should not fail because a production cold-isolate latency probe fired under per-file test isolation, and the E2E job should not burn its 15-minute timeout on `apt-get`.

## Summary

- The ✅ Validate aggregator still reports sibling failures, but it no longer runs when the workflow itself is cancelled (`cancel-in-progress`). A sibling job timeout still fails Validate, because that workflow is not cancelled.
- The first `kody.*` capability RPC still logs `kody-first-capability-dispatch-slow` in production when wall time is at least 250ms.
- Vitest skips that warn. Tests that already silence incidental runtime warnings also allowlist the tag, so a workerd isolate cannot trip the console spy.
- CI already cached `~/.cache/ms-playwright`, then always ran `playwright install chromium --with-deps`. That `apt-get update` hung E2E (and other PRs) past the job timeout even on a cache hit. Setup now calls `test:e2e:ensure`: a lockfile-matching cache hit is a no-op, and a miss downloads Chromium without `--with-deps`. Local Linux still installs system deps.
- Documented the production-only probe and the Playwright cache/ensure path.

## Testing

- `first-capability-dispatch.node.test.ts` — warn stays off under Vitest and fires only when the probe is enabled past the budget
- `ensure-playwright-browser.node.test.ts` — GitHub Actions install args omit `--with-deps`
- Pre-push: `test:node` (1858), `test:workers` (296), Playwright E2E (7). Ensure logged `Playwright Chromium already installed`.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `75de52c5` · **Head:** `c5562569`

**Classification:** composes — no primitives added or changed; production first-dispatch logging is unchanged. This PR adjusts the Validate aggregator, the Vitest/console-spy path around an existing probe, and the E2E Playwright install path.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capabilities-execute` | runtime | composes — same 250ms production warn; skip emit under Vitest |
| `mcp-server` | surfaces | composes — helper extracted next to the registry wrapper |

Unmatched: `.github/workflows/validate.yml`, `.github/actions/setup-validate/action.yml`, Playwright ensure script, test-support incidental allowlist, contributing docs.

### Change flow

A cancelled Validate workflow no longer starts the aggregator; a slow first `kody.*` RPC no longer fails workers-unit; E2E setup honors the browser cache and skips apt.

```mermaid
sequenceDiagram
	actor Push as later push
	participant validateWf as validate.yml
	participant validateJob as Validate job
	participant e2eSetup as setup-validate
	participant workers as Workers unit
	participant executeRt as capabilities-execute
	Push->>validateWf: cancel-in-progress prior run
	validateWf->>validateJob: skip when cancelled()
	Note over validateJob: sibling timeout still fails<br/>because the workflow is not cancelled
	e2eSetup->>e2eSetup: restore ~/.cache/ms-playwright
	e2eSetup->>e2eSetup: test:e2e:ensure no-op on cache hit
	workers->>executeRt: first kody.* RPC in isolate
	executeRt-->>workers: skip kody-first-capability-dispatch-slow under Vitest
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f62dfa1-5460-4565-a57e-9951e36853da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f62dfa1-5460-4565-a57e-9951e36853da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented superseded validation runs from being incorrectly reported as failed.
  - Improved Playwright browser setup to avoid redundant downloads and system package installation in CI.

- **Documentation**
  - Clarified end-to-end testing setup, browser caching, and local-versus-CI installation behavior.
  - Documented warnings for slow initial capability dispatches.

- **Tests**
  - Added coverage for dispatch warning thresholds and Playwright installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->