### PR TITLE
Block community listings until they resolve

### DIFF
--- a/docs/contributing/frames.md
+++ b/docs/contributing/frames.md
@@ -71,6 +71,10 @@ Example (`client/routes/community.tsx`):
 <Frame name={COMMUNITY_LISTINGS_TARGET} src={frameSrc} />
 ```
 
+Leave `fallback` off for this frame so SSR and client navigation wait for
+listings before first paint. A loading fallback that reused the empty-state copy
+flashed "no results" while the query finished.
+
 `COMMUNITY_LISTINGS_TARGET` lives in `community-frame-constants.ts` alongside
 the server-side `registerFrame` call in `frames/community-listings.ts`.
 

--- a/packages/worker/client/routes/community.tsx
+++ b/packages/worker/client/routes/community.tsx
@@ -2,7 +2,6 @@ import { Frame, type Handle, css } from 'remix/ui'
 import { landingArtAttrs } from '#universal/landing-images.ts'
 import { routes } from '#universal/routes.ts'
 import { COMMUNITY_LISTINGS_TARGET } from '#universal/community-frame-constants.ts'
-import { renderCommunityEmptyState } from '#universal/community-empty-state.tsx'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import {
 	listenToRouterNavigation,
@@ -22,9 +21,11 @@ import { readCommunitySearchQueryFromHref } from '#client/routes/community-searc
  * Community index, ported from the redesign prototype
  * (`landing/community.html`). The browse chrome (split head, search pill,
  * publish-back close) renders here; the listings stay server-rendered in the
- * `community-listings` frame exactly as before — this file only restyles the
- * shell around that architecture. Listing card styles live with the frame
- * content in `src/app/community-listings-content.tsx`.
+ * `community-listings` frame. That Frame is blocking (no `fallback`) so SSR
+ * and client navigation wait for listings before painting the page — the
+ * empty-state copy is only for a real empty catalog, not a loading flash.
+ * Listing card styles live with the frame content in
+ * `src/app/community-listings-content.tsx`.
  */
 
 function isCommunityIndexPath(href: string) {
@@ -124,13 +125,7 @@ export function CommunityRoute(handle: Handle) {
 					/>
 				</header>
 
-				<Frame
-					name={COMMUNITY_LISTINGS_TARGET}
-					src={frameSrc}
-					fallback={
-						<div role="status">{renderCommunityEmptyState(searchQuery)}</div>
-					}
-				/>
+				<Frame name={COMMUNITY_LISTINGS_TARGET} src={frameSrc} />
 
 				<div mix={css(communityCloseCss)}>
 					<p>

--- a/packages/worker/src/app/community-data.node.test.ts
+++ b/packages/worker/src/app/community-data.node.test.ts
@@ -230,6 +230,25 @@ test('community detail overlays viewerInstall for forked listings and omits it w
 	expect(forked?.listing.viewerInstall?.status).toBe('installed')
 })
 
+test('community index load is memoized per request', async () => {
+	resetDataCacheForTests()
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	mockModule.listCommunityListingsWithAggregates.mockReset()
+	mockModule.listCommunityListingsWithAggregates.mockResolvedValue([
+		sampleListing,
+	])
+
+	const request = new Request('https://example.com/community')
+	const first = loadCommunityIndexData({} as Env, request)
+	const second = loadCommunityIndexData({} as Env, request)
+	expect(second).toBe(first)
+	expect((await first).listings).toHaveLength(1)
+	expect(await second).toBe(await first)
+	expect(mockModule.listCommunityListingsWithAggregates).toHaveBeenCalledTimes(
+		1,
+	)
+})
+
 test('community index omits viewerInstall for anonymous viewers and auth failures', async () => {
 	resetDataCacheForTests()
 	mockModule.listSavedPackagesByKodyIds.mockReset()

--- a/packages/worker/src/app/community-data.ts
+++ b/packages/worker/src/app/community-data.ts
@@ -65,7 +65,28 @@ async function loadWithCommunityCache<T>(
 	return value
 }
 
-export async function loadCommunityIndexData(
+// One SSR request starts the index load in the page handler so it overlaps
+// session/asset work, then the blocking `community-listings` Frame reads the
+// same data during render. Memoize per Request so the second call reuses
+// the first load.
+const requestIndexDataStore = new WeakMap<
+	Request,
+	Promise<CommunityIndexLoaderData>
+>()
+
+export function loadCommunityIndexData(
+	env: Env,
+	request: Request,
+): Promise<CommunityIndexLoaderData> {
+	let pending = requestIndexDataStore.get(request)
+	if (!pending) {
+		pending = loadCommunityIndexDataUncached(env, request)
+		requestIndexDataStore.set(request, pending)
+	}
+	return pending
+}
+
+async function loadCommunityIndexDataUncached(
 	env: Env,
 	request: Request,
 ): Promise<CommunityIndexLoaderData> {

--- a/packages/worker/src/app/handlers/community.tsx
+++ b/packages/worker/src/app/handlers/community.tsx
@@ -1,4 +1,5 @@
 import { type Action } from 'remix/router'
+import { loadCommunityIndexData } from '#app/community-data.ts'
 import { handleFrameRequest } from '#app/frame-registry.ts'
 import '#app/frame-registrations.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
@@ -15,6 +16,10 @@ export function createCommunityHandler(env: Env) {
 			)
 			if (frameResponse) return frameResponse
 
+			// Start listing load so the blocking Frame overlaps session/asset
+			// work instead of waiting on D1 after streaming setup. resolveFrame
+			// reuses this promise via the per-request memo.
+			void loadCommunityIndexData(env, request)
 			return renderAppPage({
 				request,
 				env,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -262,6 +262,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		]),
 	)
 
+	communityMockModule.listCommunityListingsWithAggregates.mockReset()
 	communityMockModule.listCommunityListingsWithAggregates.mockResolvedValue([
 		sampleListing,
 	])
@@ -274,11 +275,16 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(communityResponse.headers.get('Content-Type')).toContain('text/html')
 	const communityHtml = await readResponseText(communityResponse)
 	expect(communityHtml).toContain('data-testid="community-listings-frame"')
+	expect(communityHtml).toContain('@kentcdodds/github-triage')
+	expect(communityHtml).not.toContain('data-testid="community-listings-empty"')
 	expect(communityHtml).toContain('rmx-target="community-listings"')
 	expect(communityHtml).toContain('rmx-history="push"')
 	expect(communityHtml).toContain('<!-- rmx:h:')
 	const communityProps = readAppRootProps(communityHtml)
 	expect(communityProps.loaderData?.community).toBeUndefined()
+	expect(
+		communityMockModule.listCommunityListingsWithAggregates,
+	).toHaveBeenCalledTimes(1)
 
 	const communityFrameResponse = await runHtmlHandler(
 		createCommunityHandler(env),

--- a/packages/worker/universal/community-empty-state.tsx
+++ b/packages/worker/universal/community-empty-state.tsx
@@ -7,8 +7,8 @@ import { getPillButtonCss } from '#universal/styles/style-primitives.ts'
 
 /**
  * Catalog and search-miss empty state for the community listings frame.
- * Shared by the server-rendered frame HTML and the client Frame fallback so
- * first paint and the resolved frame match.
+ * Rendered only when the resolved listings query is actually empty — not as
+ * a loading placeholder, so first paint never flashes "no results."
  */
 export function renderCommunityEmptyState(query: string | null) {
 	const isSearch = Boolean(query)


### PR DESCRIPTION
## Summary
- `/community` already SSRs listings through the `community-listings` frame; the empty-state `fallback` made that frame non-blocking, so first paint flashed “no results” until the query finished.
- The listings Frame is now blocking (same as profiles and listing detail). Document and SPA navigation both wait for listings before paint. The handler starts the query during SSR setup so the wait overlaps session/asset work, and the per-request memo keeps that load from running twice.

## Test plan
- [ ] Hard-refresh `/community` and confirm listing cards are in the first paint (no empty-shelf flash).
- [ ] From another page, click Community in the nav and confirm listings are present when the page appears.
- [ ] Search for a real package and a miss; empty state should appear only for a real miss.
- [ ] Confirm anonymous `/community` still responds quickly (isolate cache + 60s anonymous HTML cache).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f53cb226` · **Head:** `41816f28`

**Classification:** composes — no primitives added or changed; this PR uses the existing blocking Frame path and the existing community index load.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — blocking Frame, per-request memo, SSR overlap |
| `community-listings` | assistant | composes — browse page waits for the existing index query |

### Change flow

Document load and SPA navigation both wait for the community index before first paint; the handler starts that query so it overlaps other SSR setup.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	participant communityListings as community-listings
	Visitor->>appUi: GET /community or SPA navigate
	appUi->>communityListings: start loadCommunityIndexData during SSR setup
	appUi->>communityListings: blocking Frame reuses the memoized promise
	communityListings-->>appUi: listings HTML or a real empty catalog
	appUi-->>Visitor: first paint includes results
```

</details>

<!-- system-recap:end -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Community listings now wait for data before rendering, preventing a misleading empty-state message during loading.
  * Empty-state content appears only when the catalog has no listings.

* **Performance**
  * Repeated community data requests now share the same in-progress result, reducing duplicate loading operations.

* **Tests**
  * Added coverage confirming request memoization and ensuring listings render correctly with a single data request.

* **Documentation**
  * Updated community frame and empty-state guidance to reflect the revised loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->