### PR TITLE
Stop community report filters from overlaying the admin nav

### DIFF
--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -400,6 +400,39 @@ export function AccountManagementLinkNav(
 	)
 }
 
+/**
+ * In-flow pill row for filters and other secondary link sets. Do not use
+ * `AccountManagementLinkNav` for this — that component is the unique
+ * `[data-account-nav]` rail the shell absolutely positions, so a second
+ * instance stacks on top of the admin/account sections.
+ */
+export function AccountManagementInlineLinkNav(
+	handle: Handle<AccountManagementLinkNavProps>,
+) {
+	return () => (
+		<nav
+			aria-label={handle.props.label}
+			mix={css({
+				display: 'flex',
+				flexWrap: 'wrap',
+				alignItems: 'center',
+				gap: '0.3rem',
+			})}
+		>
+			{handle.props.items.map((item) => (
+				<a
+					key={item.href}
+					href={item.href}
+					aria-current={item.active ? 'page' : undefined}
+					mix={css(accountNavLinkCss)}
+				>
+					{item.label}
+				</a>
+			))}
+		</nav>
+	)
+}
+
 const accountNavItems = [
 	{ href: '/account', label: 'Overview' },
 	{ href: '/account/billing', label: 'Billing' },

--- a/packages/worker/client/routes/account-management-metadata.node.test.ts
+++ b/packages/worker/client/routes/account-management-metadata.node.test.ts
@@ -1,7 +1,12 @@
 import { jsx } from 'remix/ui/jsx-runtime'
 import { renderToString } from 'remix/ui/server'
 import { expect, test } from 'vitest'
+import { AppLoaderDataProvider } from '#client/loader-data-context.tsx'
+import { RouterLocationProvider } from '#client/router-location.tsx'
+import { AdminCommunityReportsRoute } from '#client/routes/admin-community-reports.tsx'
 import {
+	AccountManagementInlineLinkNav,
+	AccountManagementLinkNav,
 	AccountPageHeader,
 	IdValue,
 	MetadataGrid,
@@ -86,4 +91,52 @@ test('account subnav lists secrets and memories and omits values', async () => {
 	expect(html).toContain('href="/account/memories"')
 	expect(html).not.toContain('href="/account/values"')
 	expect(html).not.toContain('>Values</a>')
+})
+
+test('inline link nav stays in flow and is not a second account rail', async () => {
+	const items = [
+		{ href: '/admin/community-reports', label: 'Open', active: true },
+		{
+			href: '/admin/community-reports?status=resolved',
+			label: 'Resolved',
+			active: false,
+		},
+	]
+
+	const railHtml = await renderToString(
+		jsx(AccountManagementLinkNav, {
+			label: 'Admin sections',
+			items,
+		}),
+	)
+	expect(railHtml).toContain('data-account-nav')
+	expect(readRulesFor(railHtml, 'nav')).toContain('position: absolute')
+
+	const inlineHtml = await renderToString(
+		jsx(AccountManagementInlineLinkNav, {
+			label: 'Report status',
+			items,
+		}),
+	)
+	expect(inlineHtml).toContain('aria-label="Report status"')
+	expect(inlineHtml).toContain('>Open</a>')
+	expect(inlineHtml).not.toContain('data-account-nav')
+	expect(readRulesFor(inlineHtml, 'nav')).not.toContain('position: absolute')
+})
+
+test('community reports page keeps one admin rail and an in-flow status filter', async () => {
+	const html = await renderToString(
+		jsx(RouterLocationProvider, {
+			url: '/admin/community-reports',
+			children: jsx(AppLoaderDataProvider, {
+				children: jsx(AdminCommunityReportsRoute, {}),
+			}),
+		}),
+	)
+
+	// The shell CSS mentions `[data-account-nav]`; count the live attribute.
+	expect((html.match(/(?<!\[)data-account-nav/g) ?? []).length).toBe(1)
+	expect(html).toContain('aria-label="Admin sections"')
+	expect(html).toContain('aria-label="Report status"')
+	expect(html).toContain('href="/admin/community-reports?status=resolved"')
 })

--- a/packages/worker/client/routes/admin-community-reports.tsx
+++ b/packages/worker/client/routes/admin-community-reports.tsx
@@ -16,7 +16,7 @@ import {
 	getGhostButtonCss,
 } from '#universal/styles/style-primitives.ts'
 import {
-	AccountManagementLinkNav,
+	AccountManagementInlineLinkNav,
 	AccountManagementMessage,
 	AccountManagementShell,
 	AdminPageHeader,
@@ -297,7 +297,7 @@ export function AdminCommunityReportsRoute(handle: Handle) {
 					currentHref={currentHref}
 				/>
 
-				<AccountManagementLinkNav
+				<AccountManagementInlineLinkNav
 					label="Report status"
 					items={statusOptions.map((option) => ({
 						href: buildReportsHref(handle, option.value),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

On `/admin/community-reports`, the report-status pills (Open / Resolved / Dismissed / All) sat on top of the left admin sections rail. That is a layout bug: the status filter reused the unique account/admin rail component.

## Summary

- Added `AccountManagementInlineLinkNav` for in-flow filter pills that do **not** carry `data-account-nav`.
- Community reports now uses that inline nav for status filters; the admin sections rail stays the only absolutely positioned `[data-account-nav]`.
- Added render tests so a second rail cannot silently come back.
- Rebased onto latest `main` (`0e7067ab`).

## Testing

- `vitest run --project node-unit packages/worker/client/routes/account-management-metadata.node.test.ts`
- Husky `test:push` on push: node-unit, workers-unit, and Playwright e2e all passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `0e7067ab` · **Head:** `5f9606d1`

**Classification:** composes — no primitives added or changed; this PR rewires the community-reports status filter onto an in-flow nav instead of a second account rail.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — community reports status pills leave the `[data-account-nav]` rail |

### Change flow

`/admin/community-reports` still loads through the admin route; only the status filter's host element changes so the shell positions one rail.

```mermaid
sequenceDiagram
	actor Admin
	participant appUi as app-ui
	Admin->>appUi: GET /admin/community-reports
	appUi->>appUi: AdminPageHeader renders one [data-account-nav] rail
	appUi->>appUi: status filter uses AccountManagementInlineLinkNav in content flow
	Note over appUi: no second absolutely positioned rail
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-347c7dc6-aaf9-4b7c-84d8-7499582319e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-347c7dc6-aaf9-4b7c-84d8-7499582319e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inline navigation for secondary account-management links, allowing links to wrap naturally within page content.
  - Preserved consistent active-link styling across navigation layouts.

- **Bug Fixes**
  - Updated community reports status filters to display in-flow instead of as an additional navigation rail.
  - Ensured the community reports page displays only one account navigation rail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->