### PR TITLE
Leave the SPA for blog RSS and shorten timeline copy

### DIFF
--- a/packages/worker/client/client-router.node.test.ts
+++ b/packages/worker/client/client-router.node.test.ts
@@ -233,9 +233,11 @@ test('guide and blog markdown twins leave the SPA instead of rendering a 404', (
 	expect(matchRoute('/guides/oauth.md', pageRoutes)).toBeNull()
 	expect(matchRoute('/guides/oauth.json', pageRoutes)).toBeNull()
 	expect(matchRoute('/blog/your-assistants-home.md', pageRoutes)).toBeNull()
+	expect(matchRoute(routes.blogRss.href(), pageRoutes)).toBeNull()
 	expect(routes.guideDetailMarkdown.href({ slug: 'oauth' })).toBe(
 		'/guides/oauth.md',
 	)
+	expect(routes.blogRss.href()).toBe('/blog/rss.xml')
 
 	registerClientRoutes(pageRoutes)
 	const previousWindow = globalThis.window
@@ -258,6 +260,7 @@ test('guide and blog markdown twins leave the SPA instead of rendering a 404', (
 		expect(shouldLeaveDocumentForPath('/auth.md')).toBe(true)
 		expect(shouldLeaveDocumentForPath('/robots.txt')).toBe(true)
 		expect(shouldLeaveDocumentForPath('/missing-page')).toBe(true)
+		expect(shouldLeaveDocumentForPath(routes.blogRss.href())).toBe(true)
 
 		const click = {
 			defaultPrevented: false,
@@ -283,6 +286,14 @@ test('guide and blog markdown twins leave the SPA instead of rendering a 404', (
 		} as unknown as HTMLAnchorElement
 		expect(shouldRouterHandleClick(click, documentAnchor)).toBe(false)
 
+		const rssAnchor = {
+			target: '',
+			hasAttribute: (name: string) => name === 'rmx-document',
+			getAttribute: (name: string) =>
+				name === 'href' ? routes.blogRss.href() : null,
+		} as unknown as HTMLAnchorElement
+		expect(shouldRouterHandleClick(click, rssAnchor)).toBe(false)
+
 		const pageAnchor = {
 			target: '',
 			hasAttribute: () => false,
@@ -293,6 +304,8 @@ test('guide and blog markdown twins leave the SPA instead of rendering a 404', (
 
 		navigate('/guides/how-kody-works.md')
 		expect(assign).toHaveBeenCalledWith('/guides/how-kody-works.md')
+		navigate(routes.blogRss.href())
+		expect(assign).toHaveBeenCalledWith(routes.blogRss.href())
 	} finally {
 		registerClientRoutes({})
 		globalThis.window = previousWindow

--- a/packages/worker/client/routes/blog.tsx
+++ b/packages/worker/client/routes/blog.tsx
@@ -24,6 +24,8 @@ import { hoverMq, pageHeadCss } from '#universal/styles/style-primitives.ts'
  * server orders by date desc, then `order` frontmatter) is featured with
  * mascot art; the rest is a flat hairline-divided list. All post content
  * comes from the server's markdown catalog — nothing is hardcoded here.
+ * "Subscribe via RSS" uses `rmx-document` so the SPA does not intercept
+ * `/blog/rss.xml` (the worker serves that as a raw feed).
  */
 
 const blogApiPath = routes.blogApi.href()
@@ -134,6 +136,7 @@ export function BlogRoute(handle: Handle) {
 						data-rise
 						style={{ '--rise': '2' }}
 						href={routes.blogRss.href()}
+						rmx-document
 						mix={css(rssLinkCss)}
 					>
 						Subscribe via RSS

--- a/packages/worker/client/routes/timeline.tsx
+++ b/packages/worker/client/routes/timeline.tsx
@@ -153,10 +153,7 @@ export function TimelineRoute(handle: Handle) {
 						What the people you follow <em>shipped</em>.
 					</h1>
 					<p data-rise style={{ '--rise': '1' }}>
-						Public activity from every account you follow: community publishes
-						and republishes, forks, and stars. Package edits that were never
-						republished do not show up. The {timelineEventLimit} most recent,
-						newest first.
+						Public activity from the accounts you follow.
 					</p>
 				</header>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the blog RSS subscribe link from starting a client-app transition, and shorten the timeline intro to a single sentence.

## Summary

- Mark **Subscribe via RSS** with `rmx-document` so the client router leaves `/blog/rss.xml` to a full document load (the worker serves the raw feed).
- Change the timeline header copy to **Public activity from the accounts you follow.**
- Extend the existing companion-document router test to cover `/blog/rss.xml`.

## Testing

- `vitest run --project node-unit packages/worker/client/client-router.node.test.ts`
- Husky pre-commit typecheck + `migrations:check`
- Husky pre-push: `test:node`, `test:workers`, `test:e2e:run` (all green)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `1d27a510` · **Head:** `ea7830af`

**Classification:** composes — no primitives added or changed; this PR wires the existing `rmx-document` full-document navigation path onto the blog RSS link and updates timeline copy.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — existing Remix `rmx-document` attribute on the RSS anchor; timeline intro text only |

### Change flow

A blog-index RSS click skips the SPA and loads the worker feed as a document.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant workerApp as app-ui
	User->>appUi: click Subscribe via RSS
	appUi->>appUi: rmx-document skips client-router intercept
	appUi->>workerApp: full document GET /blog/rss.xml
	Note over workerApp: worker already serves application/rss+xml
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c33cd973-d408-442c-92c5-61fe30977d6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c33cd973-d408-442c-92c5-61fe30977d6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RSS subscription support that opens the feed directly instead of treating it as an in-app navigation.
* **Bug Fixes**
  * Improved handling of RSS links so the feed loads correctly.
* **Style**
  * Simplified the timeline subtitle to clearly describe the activity shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->