### PR TITLE
Clear oxlint warning annotations from CI

### DIFF
--- a/packages/worker/client/routes/account-activity.tsx
+++ b/packages/worker/client/routes/account-activity.tsx
@@ -54,7 +54,6 @@ import {
 	fieldCss,
 	fieldLabelCss,
 	getGhostButtonCss,
-	getSelectCss,
 } from '#universal/styles/style-primitives.ts'
 
 const clampedCellCss = css(recordCellClamp(30))

--- a/packages/worker/client/routes/admin-platform-feedback.tsx
+++ b/packages/worker/client/routes/admin-platform-feedback.tsx
@@ -13,10 +13,7 @@ import { readJson } from '#client/routes/account-approval-shared.ts'
 import { colors, spacing, typography } from '#universal/styles/tokens.ts'
 import {
 	cardCss,
-	fieldCss,
-	fieldLabelCss,
 	getGhostButtonCss,
-	getSelectCss,
 } from '#universal/styles/style-primitives.ts'
 import {
 	type AdminPlatformFeedbackLoaderData,

--- a/packages/worker/client/routes/blog.tsx
+++ b/packages/worker/client/routes/blog.tsx
@@ -168,6 +168,7 @@ export function BlogRoute(handle: Handle) {
 function renderFeaturedPostItem(post: BlogPostSummaryLoaderData) {
 	return (
 		<li key={post.slug} mix={[css(featuredItemCss), revealCard()]}>
+			{/* oxlint-disable-next-line jsx-a11y/control-has-associated-label -- link name comes from the date, title, and description children */}
 			<a
 				href={routes.blogPost.href({ slug: post.slug })}
 				mix={css(featuredLinkCss)}

--- a/packages/worker/client/routes/secret-normalization.node.test.ts
+++ b/packages/worker/client/routes/secret-normalization.node.test.ts
@@ -9,7 +9,7 @@ import {
 } from './secret-normalization.ts'
 
 test('client secret allowlist normalizers match server and collapse empties/duplicates', () => {
-	expect(() => new URL('https://exa mple.com/path')).toThrow()
+	expect(() => new URL('https://exa mple.com/path')).toThrow(TypeError)
 
 	const hostFixtures = [
 		'api.example.com',

--- a/packages/worker/src/account/deletion-state.node.test.ts
+++ b/packages/worker/src/account/deletion-state.node.test.ts
@@ -402,7 +402,7 @@ test('sequential sibling leases each acquire after the previous released', async
 })
 
 test('nested/detached parity for DO-authority leases', async () => {
-	const { sqlite, db } = createLeaseTestDb()
+	const { db } = createLeaseTestDb()
 	const meter = createInMemoryUserMeterEnv()
 	const meterA = userMeterRpc({ env: meter.env, userId: 'user-a' })
 

--- a/packages/worker/src/app-base-url.node.test.ts
+++ b/packages/worker/src/app-base-url.node.test.ts
@@ -175,7 +175,7 @@ test('parsePackageAppRequestHost classifies apex, user subdomains, and rejects e
 		'https://kodyapps.dev./',
 		'https://kentcdodds.kodyapps.dev./',
 	]) {
-		expect(parse(url), url).toEqual({
+		expect(parse(url)).toEqual({
 			kind: 'unrecognized-subdomain',
 			role: 'canonical',
 		})
@@ -188,7 +188,7 @@ test('parsePackageAppRequestHost classifies apex, user subdomains, and rejects e
 		// Same hostname on another scheme/port is another local service.
 		'http://kodyapps.dev/',
 	]) {
-		expect(parse(url), url).toBeNull()
+		expect(parse(url)).toBeNull()
 	}
 	// No configured package-app origin: nothing classifies.
 	expect(

--- a/packages/worker/src/app/handlers/account-secrets.node.test.ts
+++ b/packages/worker/src/app/handlers/account-secrets.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import type * as AllowedCapabilities from '#mcp/secrets/allowed-capabilities.ts'
+import type * as AllowedHosts from '#mcp/secrets/allowed-hosts.ts'
+import type * as IntegrationsService from '#worker/integrations/service.ts'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(async () => ({
@@ -119,8 +121,7 @@ vi.mock('#worker/app-base-url.ts', () => ({
 }))
 
 vi.mock('#mcp/secrets/allowed-hosts.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#mcp/secrets/allowed-hosts.ts')>()
+	const actual = await importOriginal<typeof AllowedHosts>()
 	return {
 		normalizeAllowedHosts: actual.normalizeAllowedHosts,
 		normalizeHost: actual.normalizeHost,
@@ -161,8 +162,7 @@ vi.mock('#mcp/values/service.ts', () => ({
 }))
 
 vi.mock('#worker/integrations/service.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/integrations/service.ts')>()
+	const actual = await importOriginal<typeof IntegrationsService>()
 	return {
 		upsertIntegration: (...args: Array<unknown>) =>
 			mockModule.upsertIntegration(...args),

--- a/packages/worker/src/app/handlers/admin-feature-flags.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-feature-flags.node.test.ts
@@ -275,6 +275,8 @@ function createFeatureFlagsTestEnv(
 				) {
 					const flagKey = String(params[0])
 					let changes = 0
+					// Snapshot keys so deletes during this loop do not skip entries.
+					// oxlint-disable-next-line unicorn/no-useless-spread
 					for (const mapKey of [...overrides.keys()]) {
 						if (mapKey.startsWith(`${flagKey}:`)) {
 							overrides.delete(mapKey)

--- a/packages/worker/src/app/handlers/community-install.node.test.ts
+++ b/packages/worker/src/app/handlers/community-install.node.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import { createCommunityInstallApiPostHandler } from './community-install.ts'
+import type * as CloudflareWorkers from 'cloudflare:workers'
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
@@ -11,7 +12,7 @@ const mockModule = vi.hoisted(() => ({
 }))
 
 vi.mock('cloudflare:workers', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('cloudflare:workers')>()
+	const actual = await importOriginal<typeof CloudflareWorkers>()
 	return {
 		...actual,
 		waitUntil: (...args: Array<unknown>) => mockModule.waitUntil(...args),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -28,6 +28,7 @@ import { firstPartySecurityHeaders } from '#app/security-headers.ts'
 import { testStableUserIdFromEmail } from '#worker/test-support/stable-user-id.ts'
 import { planLimits } from '#universal/plans.ts'
 import { getScrollRestorationInlineScript } from '#universal/router-scroll-restoration.ts'
+import type * as CommunitySocialRepo from '#worker/community/social-repo.ts'
 
 const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
 
@@ -62,8 +63,7 @@ vi.mock('#app/community-package-route.ts', () => ({
 }))
 
 vi.mock('#worker/community/social-repo.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/community/social-repo.ts')>()
+	const actual = await importOriginal<typeof CommunitySocialRepo>()
 	return {
 		...actual,
 		getCommunityStar: vi.fn().mockResolvedValue(false),

--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -1046,7 +1046,9 @@ test('forkCommunityListing rejects repeat fork without a new kody_id', async () 
 			expectedPackageScope: 'jane',
 			listingId: 'listing-1',
 		}),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'You already forked this listing with kody id "discord-gateway". Resume the existing fork with source_id "fork-source-1" (package_id "package-fork-1") via repo_open_session, or pass a different kody_id to fork again.',
+	)
 
 	expect(mockModule.ensureEntitySource).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/community/og-image.node.test.ts
+++ b/packages/worker/src/community/og-image.node.test.ts
@@ -18,6 +18,7 @@ async function sampleIconDataUri(name: string) {
 }
 
 test('renderCommunityOgImage returns valid PNG bytes with and without ratings', async () => {
+	expect.hasAssertions()
 	const withRatings = await renderCommunityOgImage({
 		name: '@kody/github-triage',
 		description:

--- a/packages/worker/src/community/profile-og-image.node.test.ts
+++ b/packages/worker/src/community/profile-og-image.node.test.ts
@@ -18,6 +18,7 @@ async function sampleAvatarDataUri(name: string) {
 }
 
 test('renderProfileOgImage returns valid PNG bytes with and without avatar', async () => {
+	expect.hasAssertions()
 	const withAvatar = await renderProfileOgImage({
 		displayName: 'Jane Doe',
 		username: 'jane',

--- a/packages/worker/src/dr/dr-export-maintenance.node.test.ts
+++ b/packages/worker/src/dr/dr-export-maintenance.node.test.ts
@@ -115,7 +115,7 @@ function createR2() {
 	} as unknown as R2Bucket
 }
 
-function createEnv(client: DrBackupS3Client) {
+function createEnv(_client: DrBackupS3Client) {
 	return {
 		DR_EXPORT_ENABLED: 'true',
 		DR_BACKUP_ACCOUNT_ID: 'acct',

--- a/packages/worker/src/email/outbound-provider-index.workers.test.ts
+++ b/packages/worker/src/email/outbound-provider-index.workers.test.ts
@@ -66,5 +66,5 @@ test('provider index rejects the dedicated system owner', async () => {
 			inboxId: null,
 			now: new Date().toISOString(),
 		}),
-	).rejects.toThrow()
+	).rejects.toThrow(/CHECK constraint failed/)
 })

--- a/packages/worker/src/email/system-email-authority.workers.test.ts
+++ b/packages/worker/src/email/system-email-authority.workers.test.ts
@@ -38,7 +38,9 @@ test('dedicated system graph enforces config ownership and reports health', asyn
 			id: 'cross-owner-thread',
 			inboxId: 'foreign-inbox',
 		}),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'System email thread insert rejected an invalid operator-owned inbox reference.',
+	)
 	await expect(
 		insertSystemEmailMessage({
 			db: env.APP_DB,
@@ -49,7 +51,9 @@ test('dedicated system graph enforces config ownership and reports health', asyn
 				processingStatus: 'stored',
 			},
 		}),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'System email message insert rejected an invalid dedicated reference.',
+	)
 	await expect(
 		insertSystemEmailAttachments({
 			db: env.APP_DB,

--- a/packages/worker/src/entitlements/entitlements.node.test.ts
+++ b/packages/worker/src/entitlements/entitlements.node.test.ts
@@ -22,7 +22,6 @@ import {
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
 import { userMeterRpc } from './user-meter-client.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
 
 function createEntitlementsTestDb(
 	input: {

--- a/packages/worker/src/entitlements/user-meter.workers.test.ts
+++ b/packages/worker/src/entitlements/user-meter.workers.test.ts
@@ -2,7 +2,6 @@ import { runInDurableObject } from 'cloudflare:test'
 import { env } from 'cloudflare:workers'
 import { expect, test, vi } from 'vitest'
 import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { seedAccount } from '#worker/test-support/workers-seed.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
 import { userMeterDurableObjectName } from '#worker/user-scoped-durable-object-name.ts'
@@ -17,10 +16,7 @@ import {
 import { ensureEntitlementTestSchema } from './test-schema.ts'
 import { userMeterRpc } from './user-meter-client.ts'
 import { UserMeter, userMeterMirrorUpdatedAtToken } from './user-meter-do.ts'
-import {
-	createWaitUntilDrain,
-	withPatchedDbPrepare,
-} from '#worker/test-support/user-meter.ts'
+import { withPatchedDbPrepare } from '#worker/test-support/user-meter.ts'
 
 async function seedFreeUser(emailPrefix: string) {
 	await ensureEntitlementTestSchema(env.APP_DB)

--- a/packages/worker/src/feature-flags/service.node.test.ts
+++ b/packages/worker/src/feature-flags/service.node.test.ts
@@ -217,6 +217,8 @@ function createFeatureFlagsTestDb(
 				) {
 					const flagKey = String(params[0])
 					let changes = 0
+					// Snapshot keys so deletes during this loop do not skip entries.
+					// oxlint-disable-next-line unicorn/no-useless-spread
 					for (const mapKey of [...overrides.keys()]) {
 						if (mapKey.startsWith(`${flagKey}:`)) {
 							overrides.delete(mapKey)

--- a/packages/worker/src/integrations/platform-apps.node.test.ts
+++ b/packages/worker/src/integrations/platform-apps.node.test.ts
@@ -95,7 +95,7 @@ test('upsert lifecycle encrypts secrets, omits retain fields, null clears, and p
 		await getPlatformOauthAppClientSecret({ db, env, slug: 'github' }),
 	).toBe('platform-github-client-secret-value')
 
-	const clearedSecret = await upsertPlatformOauthApp({
+	await upsertPlatformOauthApp({
 		db,
 		env,
 		app: {

--- a/packages/worker/src/jobs/job-reindex.node.test.ts
+++ b/packages/worker/src/jobs/job-reindex.node.test.ts
@@ -171,6 +171,8 @@ test('job reindex retries transient D1 export page errors then surfaces exhausti
 	vi.useFakeTimers()
 	try {
 		const exhaustedPromise = reindexJobVectors({ APP_DB: {} } as Env)
+		// Attach before advancing timers so the rejection is not unhandled.
+		// oxlint-disable-next-line vitest/valid-expect
 		const expectation = expect(exhaustedPromise).rejects.toThrow(
 			'Currently processing a long-running export',
 		)

--- a/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
+++ b/packages/worker/src/jobs/reconcile-artifacts-pushes.node.test.ts
@@ -7,7 +7,7 @@ test('reconcileArtifactsPushes skips plain repo entity_sources', async () => {
 		APP_DB: {
 			prepare(query: string) {
 				return {
-					bind(...params: Array<unknown>) {
+					bind(..._params: Array<unknown>) {
 						return {
 							async all<T>() {
 								if (query.includes('FROM entity_sources')) {

--- a/packages/worker/src/jobs/run-due-jobs-claim-fence.node.test.ts
+++ b/packages/worker/src/jobs/run-due-jobs-claim-fence.node.test.ts
@@ -2,6 +2,10 @@ import { expect, test, vi } from 'vitest'
 import { consoleInfo } from '#worker/test-support/console-spies.ts'
 import { type JobRecord } from './types.ts'
 import { TransientJobExecutionError } from './execution-safety.ts'
+import type * as JobsRepo from '@kody-internal/shared/jobs/repo.ts'
+import type * as RunRecordsServiceModule from '#worker/run-records/service.ts'
+import type * as EntitySources from '#worker/repo/entity-sources.ts'
+import type * as PackageRegistryRepo from '#worker/package-registry/repo.ts'
 
 const withAccountWriteLease = vi.fn(
 	async (input: { write: () => Promise<unknown> }) => input.write(),
@@ -22,8 +26,7 @@ vi.mock('#worker/account/deletion-state.ts', () => ({
 }))
 
 vi.mock('@kody-internal/shared/jobs/repo.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('@kody-internal/shared/jobs/repo.ts')>()
+	const actual = await importOriginal<typeof JobsRepo>()
 	return {
 		...actual,
 		disableExpiredJobRowsForUser: (...args: Array<unknown>) =>
@@ -39,8 +42,7 @@ vi.mock('@kody-internal/shared/jobs/repo.ts', async (importOriginal) => {
 })
 
 vi.mock('#worker/run-records/service.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/run-records/service.ts')>()
+	const actual = await importOriginal<typeof RunRecordsServiceModule>()
 	return {
 		...actual,
 		claimRunRecord: (...args: Array<unknown>) =>
@@ -52,8 +54,7 @@ vi.mock('#worker/run-records/service.ts', async (importOriginal) => {
 })
 
 vi.mock('#worker/repo/entity-sources.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/repo/entity-sources.ts')>()
+	const actual = await importOriginal<typeof EntitySources>()
 	return {
 		...actual,
 		getEntitySourceByIdForUser: (...args: Array<unknown>) =>
@@ -62,8 +63,7 @@ vi.mock('#worker/repo/entity-sources.ts', async (importOriginal) => {
 })
 
 vi.mock('#worker/package-registry/repo.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/package-registry/repo.ts')>()
+	const actual = await importOriginal<typeof PackageRegistryRepo>()
 	return {
 		...actual,
 		getSavedPackageById: (...args: Array<unknown>) =>

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -981,7 +981,7 @@ test('admin_user_update rejects unknown users and unknown plan names', async () 
 			{ id: 1, plan: 'enterprise' } as never,
 			ctx,
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "admin_user_update"')
 })
 
 test('admin user lookup does not fall through from an invalid stable id', async () => {

--- a/packages/worker/src/mcp/capabilities/admin/admin-mailbox-maintenance.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-mailbox-maintenance.node.test.ts
@@ -233,7 +233,7 @@ test('admin_mailbox_maintenance routes final status, retention, and delete with 
 			{ action: 'reconcile', batch_size: 101 },
 			ctx,
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "admin_mailbox_maintenance"')
 	await expect(
 		adminMailboxMaintenanceCapability.handler(
 			{
@@ -242,10 +242,10 @@ test('admin_mailbox_maintenance routes final status, retention, and delete with 
 			},
 			ctx,
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "admin_mailbox_maintenance"')
 	await expect(
 		adminMailboxMaintenanceCapability.handler({ action: 'seed' }, ctx),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "admin_mailbox_maintenance"')
 	await expect(
 		adminMailboxMaintenanceCapability.handler(
 			{
@@ -255,7 +255,7 @@ test('admin_mailbox_maintenance routes final status, retention, and delete with 
 			},
 			ctx,
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "admin_mailbox_maintenance"')
 
 	const notFound = new AdminMailboxMessageNotFoundError({
 		stableUserId,

--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-send.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-send.node.test.ts
@@ -80,7 +80,7 @@ test('admin_system_email_send is admin-gated, validates input, and audits a reda
 			},
 			ctx,
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "admin_system_email_send"')
 	expect(mockModule.sendSystemEmail).not.toHaveBeenCalled()
 
 	mockModule.sendSystemEmail.mockResolvedValue({

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-meter-storage-reconcile.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-meter-storage-reconcile.node.test.ts
@@ -105,9 +105,13 @@ test('admin_user_meter_storage_reconcile routes batch size, audits, and rejects 
 	mockModule.reconcileD1StorageBytes.mockClear()
 	await expect(
 		adminUserMeterStorageReconcileCapability.handler({ batch_size: 0 }, ctx),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'Invalid input for capability "admin_user_meter_storage_reconcile"',
+	)
 	await expect(
 		adminUserMeterStorageReconcileCapability.handler({ batch_size: 9 }, ctx),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'Invalid input for capability "admin_user_meter_storage_reconcile"',
+	)
 	expect(mockModule.reconcileD1StorageBytes).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/capabilities/community/adopt.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/community/adopt.node.test.ts
@@ -109,6 +109,6 @@ test('community_fork_adopt adopts by package_id or kody_id and rejects invalid r
 			},
 			createContext(),
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "community_fork_adopt"')
 	expect(mocks.adoptCommunityFork).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/durable-escalation.node.test.ts
@@ -11,6 +11,8 @@ import {
 	type WorkflowProjectionRecord,
 	type WorkflowProjectionUpsertInput,
 } from '#worker/run-records/service.ts'
+import type * as PackageWorkflows from '#worker/package-runtime/package-workflows.ts'
+import type * as RunRecordsServiceModule from '#worker/run-records/service.ts'
 
 const mockModule = vi.hoisted(() => ({
 	createDynamicCallableWorkflow: vi.fn(),
@@ -118,10 +120,7 @@ const runRecordMocks = vi.hoisted(() => {
 vi.mock(
 	'#worker/package-runtime/package-workflows.ts',
 	async (importOriginal) => {
-		const actual =
-			await importOriginal<
-				typeof import('#worker/package-runtime/package-workflows.ts')
-			>()
+		const actual = await importOriginal<typeof PackageWorkflows>()
 		return {
 			...actual,
 			createDynamicCallableWorkflow: (...args: Array<unknown>) =>
@@ -131,8 +130,7 @@ vi.mock(
 )
 
 vi.mock('#worker/run-records/service.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/run-records/service.ts')>()
+	const actual = await importOriginal<typeof RunRecordsServiceModule>()
 	return {
 		...actual,
 		upsertWorkflowProjection: (...args: Array<unknown>) =>

--- a/packages/worker/src/mcp/capabilities/mcp-server/mcp-server-caller-error.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/mcp-server/mcp-server-caller-error.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { McpCallerError } from '#mcp/caller-error.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { type McpServerSnapshot } from '#worker/mcp-client/types.ts'
+import type * as McpClientStatus from '#worker/mcp-client/status.ts'
 
 const mocks = vi.hoisted(() => ({
 	callTool: vi.fn(),
@@ -15,9 +16,9 @@ vi.mock('#worker/mcp-client/hub-client.ts', () => ({
 }))
 
 vi.mock('#worker/mcp-client/status.ts', async () => {
-	const actual = await vi.importActual<
-		typeof import('#worker/mcp-client/status.ts')
-	>('#worker/mcp-client/status.ts')
+	const actual = await vi.importActual<typeof McpClientStatus>(
+		'#worker/mcp-client/status.ts',
+	)
 	return {
 		...actual,
 		getMcpServerStatus: (...args: Array<unknown>) =>

--- a/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/get-git-remote.node.test.ts
@@ -275,13 +275,13 @@ test('get_git_remote returns scoped artifact remotes and rejects invalid input',
 			{ package_id: 'package-1', ttl_seconds: 59 },
 			createContext(),
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "package_get_git_remote"')
 	await expect(
 		getGitRemoteCapability.handler(
 			{ package_id: 'package-1', ttl_seconds: 86_401 },
 			createContext(),
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "package_get_git_remote"')
 })
 
 test('get_git_remote write scope blocks when no restorable backup snapshot exists', async () => {

--- a/packages/worker/src/mcp/capabilities/packages/package-update.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-update.node.test.ts
@@ -124,7 +124,7 @@ test('package_update rejects invalid changes and cross-user or unauthenticated a
 			{ package_id: 'pkg-1', changes: {} },
 			createCtx(),
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Provide at least one supported package change.')
 	await expect(
 		packageUpdateCapability.handler(
 			{
@@ -133,7 +133,7 @@ test('package_update rejects invalid changes and cross-user or unauthenticated a
 			},
 			createCtx(),
 		),
-	).rejects.toThrow()
+	).rejects.toThrow('Invalid input for capability "package_update"')
 	expect(mockModule.updateSavedPackage).not.toHaveBeenCalled()
 
 	mockModule.updateSavedPackage.mockResolvedValueOnce(false)

--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts
@@ -121,7 +121,7 @@ function createContext(
 	return {
 		env: {
 			APP_DB: {
-				prepare(query: string) {
+				prepare(_query: string) {
 					return {
 						bind() {
 							return {

--- a/packages/worker/src/mcp/capabilities/platform-feedback-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/platform-feedback-capabilities.node.test.ts
@@ -123,13 +123,17 @@ test('meta platform feedback submission gates consent and isolates post-persiste
 			{ ...input, user_confirmed: false } as never,
 			createCapabilityContext({ userId: 'user-1' }),
 		),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'Invalid input for capability "meta_platform_feedback_submit"',
+	)
 	await expect(
 		metaPlatformFeedbackSubmitCapability.handler(
 			{ ...input, metadata: { conversation: 'private' } } as never,
 			createCapabilityContext({ userId: 'user-1' }),
 		),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'Invalid input for capability "meta_platform_feedback_submit"',
+	)
 	expect(mockModule.submitPlatformFeedback).not.toHaveBeenCalled()
 	await expect(
 		metaPlatformFeedbackSubmitCapability.handler(

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -203,9 +203,7 @@ test('repo open session workflow and conversation conflict guard', async () => {
 			},
 			createCapabilityContext(),
 		),
-	).rejects.toThrow(
-		'Active repo session does not match the requested source. Discard the current session before opening a new source.',
-	)
+	).rejects.toThrow(Error)
 })
 
 test('repo edit → commit → checks → publish session workflow', async () => {

--- a/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/repo-workflow.node.test.ts
@@ -203,7 +203,9 @@ test('repo open session workflow and conversation conflict guard', async () => {
 			},
 			createCapabilityContext(),
 		),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'Active repo session does not match the requested source. Discard the current session before opening a new source.',
+	)
 })
 
 test('repo edit → commit → checks → publish session workflow', async () => {

--- a/packages/worker/src/mcp/capabilities/schema-compression.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/schema-compression.node.test.ts
@@ -102,6 +102,7 @@ test('compressSchemaForLlm strips redundant metadata across object, array, and c
 				},
 			},
 		},
+		// oxlint-disable-next-line unicorn/no-thenable -- JSON Schema if/then/else keyword, not a thenable
 		then: {
 			type: 'object',
 			properties: {
@@ -210,6 +211,7 @@ test('compressSchemaForLlm strips redundant metadata across object, array, and c
 				},
 			},
 		},
+		// oxlint-disable-next-line unicorn/no-thenable -- JSON Schema if/then/else keyword, not a thenable
 		then: {
 			type: 'object',
 			properties: {

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -25,11 +25,13 @@ import {
 	limitExecutionResultValue,
 	runWithDynamicWorkerEvaluationBudget,
 } from './executor.ts'
-import { executorSandboxTimeoutMessage } from '#worker/sentry-options.ts'
+import {
+	durableObjectCodeUpdatedResetMessage,
+	executorSandboxTimeoutMessage,
+} from '#worker/sentry-options.ts'
 import { assertGeneratedExecutorSourceIsBundleSafe } from './kody-remote-proxy-source.ts'
 import { createDynamicWorkerCompatibilityOptions } from '#worker/dynamic-worker-compatibility.ts'
 import { createEvaluationSideEffectTracker } from '#mcp/evaluation-side-effects.ts'
-import { durableObjectCodeUpdatedResetMessage } from '#worker/sentry-options.ts'
 
 type FakeWorkerOptions = Record<string, unknown>
 

--- a/packages/worker/src/mcp/index.ts
+++ b/packages/worker/src/mcp/index.ts
@@ -83,6 +83,7 @@ class MCPBase extends McpAgent<Env, State, Props> {
 	 * (search preamble dedup, raw-fetch host nudges) on this lane.
 	 */
 	getRegistrationAgent() {
+		// oxlint-disable-next-line typescript/no-this-alias -- object literal methods must close over the McpAgent instance
 		const self = this
 		const agent: McpRegistrationAgent & {
 			state?: State

--- a/packages/worker/src/mcp/memory/memory-reindex.node.test.ts
+++ b/packages/worker/src/mcp/memory/memory-reindex.node.test.ts
@@ -140,6 +140,8 @@ test('memory reindex retries transient D1 export page errors then surfaces exhau
 	vi.useFakeTimers()
 	try {
 		const exhaustedPromise = reindexMemoryVectors({ APP_DB: {} } as Env)
+		// Attach before advancing timers so the rejection is not unhandled.
+		// oxlint-disable-next-line vitest/valid-expect
 		const expectation = expect(exhaustedPromise).rejects.toThrow(
 			'Currently processing a long-running export',
 		)

--- a/packages/worker/src/mcp/observability.workers.test.ts
+++ b/packages/worker/src/mcp/observability.workers.test.ts
@@ -207,7 +207,7 @@ test('package_save logs parse failures, rejects invalid manifests, and logs succ
 					}),
 				},
 			),
-		).rejects.toThrow()
+		).rejects.toThrow('Invalid input for capability "package_save"')
 	} finally {
 		console.info = originalInfo
 	}

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -18,14 +18,11 @@ import {
 } from '#worker/run-records/service.ts'
 import {
 	buildKodyFns,
-	buildKodyProvider,
 	createWorkflowTools,
 	runBundledModuleWithRegistry,
 	runModuleWithRegistry,
 } from './run-kody-registry.ts'
 import * as mcpExecutor from '#mcp/executor.ts'
-import { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
-import { type KodyResolvedProvider } from '#mcp/kody-remote-types.ts'
 import { PackageSecretMountError } from '#mcp/secrets/package-access.ts'
 import * as packageAccess from '#mcp/secrets/package-access.ts'
 import * as secretService from '#mcp/secrets/service.ts'

--- a/packages/worker/src/mcp/tools/package-search-identity.node.test.ts
+++ b/packages/worker/src/mcp/tools/package-search-identity.node.test.ts
@@ -157,7 +157,7 @@ test('package identity parser accepts exact ids and current-origin URLs and reje
 		// Wrong scheme for the configured package-app origin.
 		'http://user.kodyapps.dev/packages/daily-notes',
 	]) {
-		expect(parsePackageSearchIdentity({ ...hosted, query }), query).toEqual({
+		expect(parsePackageSearchIdentity({ ...hosted, query })).toEqual({
 			kind: 'invalid-package-identity',
 		})
 	}
@@ -185,7 +185,7 @@ test('package identity parser accepts exact ids and current-origin URLs and reje
 		'https://kodyapps.dev.attacker.example/@user/packages/daily-notes',
 		'https://user:password@kodyapps.dev/@user/packages/daily-notes',
 	]) {
-		expect(parsePackageSearchIdentity({ ...hosted, query }), query).toEqual({
+		expect(parsePackageSearchIdentity({ ...hosted, query })).toEqual({
 			kind: 'invalid-package-identity',
 		})
 	}
@@ -214,7 +214,7 @@ test('package identity parser accepts exact ids and current-origin URLs and reje
 		'/@INVALID/packages/daily-notes',
 		'https://user:password@heykody.dev/account/packages/' + packageId,
 	]) {
-		expect(parsePackageSearchIdentity({ ...common, query }), query).toEqual({
+		expect(parsePackageSearchIdentity({ ...common, query })).toEqual({
 			kind: 'invalid-package-identity',
 		})
 	}

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -1308,10 +1308,8 @@ test('empty discovery returns a counted domain index without memory enrichment',
 	const { handler } = await getSearchRegistration({ user: null })
 
 	const response = await handler({ conversationId: 'conv-empty-index' })
-	expect(
-		response.isError,
-		JSON.stringify(response.structuredContent),
-	).toBeUndefined()
+	// structuredContent is asserted next; this only checks the success flag.
+	expect(response.isError).toBeUndefined()
 	expect(response.structuredContent.result).toMatchObject({
 		matches: [
 			{

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -159,7 +159,7 @@ export async function runSearchTool(input: {
 			)
 			return rows
 		})
-		const [searchRows] = await Promise.all([rowsPromise])
+		const searchRows = await rowsPromise
 		warnings = searchRows.warnings
 
 		if (Array.isArray(args.entity)) {

--- a/packages/worker/src/mcp/tools/search.node.test.ts
+++ b/packages/worker/src/mcp/tools/search.node.test.ts
@@ -8,12 +8,8 @@ import {
 } from '#worker/vectorize/embedding.ts'
 import { filterCapabilityRegistryForCaller } from '#mcp/capabilities/access-control.ts'
 import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
-import { synthesizeMcpServerToolDomain } from '#mcp/capabilities/mcp-server/index.ts'
-import { synthesizeOpenApiProviderDomain } from '#mcp/capabilities/openapi-provider/index.ts'
-import { repoGetCheckStatusCapability } from '#mcp/capabilities/repo/repo-get-check-status.ts'
 import { createMcpCallerContext } from '#mcp/context.ts'
 import { type JoinedIntegration } from '#worker/integrations/types.ts'
-import { type OpenApiBinding } from '#worker/openapi/binding-shared.ts'
 import type * as PackageRegistrySource from '#worker/package-registry/source.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import {

--- a/packages/worker/src/mcp/values/service.node.test.ts
+++ b/packages/worker/src/mcp/values/service.node.test.ts
@@ -7,10 +7,8 @@ import {
 } from '#mcp/storage-bindings.ts'
 import { deleteAllAppScopedValues } from '#worker/package-config-cleanup.ts'
 import { userMeterRpc } from '#worker/entitlements/user-meter-client.ts'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import {
 	createInMemoryUserMeterEnv,
-	createWaitUntilDrain,
 	withPatchedDbPrepare,
 } from '#worker/test-support/user-meter.ts'
 import { deleteValue, getValue, listValues, saveValue } from './service.ts'

--- a/packages/worker/src/og/page-image.node.test.ts
+++ b/packages/worker/src/og/page-image.node.test.ts
@@ -12,6 +12,7 @@ function expectPngBytes(png: Uint8Array) {
 }
 
 test('renderPageOgImage returns valid PNG bytes for home and community', async () => {
+	expect.hasAssertions()
 	const home = await renderPageOgImage({ page: publicOgPages.home })
 	expectPngBytes(home)
 

--- a/packages/worker/src/package-invocations/background-identity.workers.test.ts
+++ b/packages/worker/src/package-invocations/background-identity.workers.test.ts
@@ -4,6 +4,8 @@ import { metaGetCurrentUserCapability } from '#mcp/capabilities/meta/meta-get-cu
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { ensureUsersTestSchema } from '#worker/users-test-schema.ts'
 import { runSavedPackageModuleOnce } from './module-execution.ts'
+import type * as ModuleArtifacts from './module-artifacts.ts'
+import type * as RunKodyRegistry from '#mcp/run-kody-registry.ts'
 
 const mocks = vi.hoisted(() => ({
 	ensureModuleArtifact: vi.fn(),
@@ -11,12 +13,12 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./module-artifacts.ts', async (importOriginal) => ({
-	...(await importOriginal<typeof import('./module-artifacts.ts')>()),
+	...(await importOriginal<typeof ModuleArtifacts>()),
 	ensureModuleArtifact: mocks.ensureModuleArtifact,
 }))
 
 vi.mock('#mcp/run-kody-registry.ts', async (importOriginal) => ({
-	...(await importOriginal<typeof import('#mcp/run-kody-registry.ts')>()),
+	...(await importOriginal<typeof RunKodyRegistry>()),
 	runBundledModuleWithRegistry: mocks.runBundledModuleWithRegistry,
 }))
 

--- a/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex-d1-retry.node.test.ts
@@ -170,7 +170,12 @@ test('saved package reindex retries transient D1 export errors then reports exha
 		const exhaustedPromise = reindexSavedPackageVectors(env, {
 			baseUrl: 'https://kody.example.com',
 		})
-		const expectation = expect(exhaustedPromise).resolves.toEqual({
+		for (let attempt = 1; attempt < d1LockRetryMaxAttempts; attempt++) {
+			await vi.advanceTimersByTimeAsync(
+				d1LockRetryBaseDelayMs * 2 ** (attempt - 1),
+			)
+		}
+		await expect(exhaustedPromise).resolves.toEqual({
 			upserted: 0,
 			failed: 1,
 			failures: [
@@ -183,12 +188,6 @@ test('saved package reindex retries transient D1 export errors then reports exha
 			failedIds: ['package_pkg-1'],
 			error: '1 saved package vector(s) failed to reindex',
 		})
-		for (let attempt = 1; attempt < d1LockRetryMaxAttempts; attempt++) {
-			await vi.advanceTimersByTimeAsync(
-				d1LockRetryBaseDelayMs * 2 ** (attempt - 1),
-			)
-		}
-		await expectation
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/package-registry/package-reindex.node.test.ts
+++ b/packages/worker/src/package-registry/package-reindex.node.test.ts
@@ -318,6 +318,8 @@ test('saved package reindex surfaces page listing failures after the retry budge
 		const resultPromise = reindexSavedPackageVectors({ APP_DB: {} } as Env, {
 			baseUrl: 'https://kody.example.com',
 		})
+		// Attach before advancing timers so the rejection is not unhandled.
+		// oxlint-disable-next-line vitest/valid-expect
 		const expectation = expect(resultPromise).rejects.toThrow(
 			'Currently processing a long-running export',
 		)

--- a/packages/worker/src/package-runtime/module-graph.node.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.node.test.ts
@@ -3,7 +3,6 @@ import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { expect, test, vi } from 'vitest'
-import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { type WorkerLoaderModules } from '#worker/worker-loader-types.ts'
 import type * as PublishedBundleArtifactsModule from './published-bundle-artifacts.ts'
 

--- a/packages/worker/src/package-runtime/package-app-serve.ts
+++ b/packages/worker/src/package-runtime/package-app-serve.ts
@@ -120,6 +120,8 @@ export function createPackageCodeRequest(
 	for (const headerName of strippedPackageRequestHeaders) {
 		packageCodeRequest.headers.delete(headerName)
 	}
+	// Snapshot names so deletes during this loop do not skip headers.
+	// oxlint-disable-next-line unicorn/no-useless-spread
 	for (const headerName of [...packageCodeRequest.headers.keys()]) {
 		const normalized = headerName.toLowerCase()
 		if (

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -8,6 +8,8 @@ import {
 import type * as CloudflareWorkers from 'cloudflare:workers'
 import type * as ModuleGraph from './module-graph.ts'
 import type * as PublishedBundleArtifacts from './published-bundle-artifacts.ts'
+import type * as McpAuthUserContext from '#worker/mcp-auth-user-context.ts'
+import type * as RunRecordsServiceModule from '#worker/run-records/service.ts'
 
 async function extractCreatePackageAppWorkerSource() {
 	const sourceText = await readFile(
@@ -205,7 +207,9 @@ test('package app kody proxy supports mcp namespace calls', async () => {
 			args: { pin: '1234' },
 		},
 	])
-	expect(() => kody['mcp:home:set_pin']).toThrow()
+	expect(() => kody['mcp:home:set_pin']).toThrow(
+		'MCP server tool "mcp:home:set_pin" is not available as a flat kody function.',
+	)
 	expect('mcp' in kody).toBe(true)
 	const { home } = kody.mcp as Record<
 		string,
@@ -396,8 +400,7 @@ vi.mock('#mcp/secrets/package-access.ts', () => ({
 }))
 
 vi.mock('#worker/mcp-auth-user-context.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/mcp-auth-user-context.ts')>()
+	const actual = await importOriginal<typeof McpAuthUserContext>()
 	return {
 		...actual,
 	}
@@ -416,8 +419,7 @@ vi.mock('#worker/package-invocations/service.ts', () => ({
 }))
 
 vi.mock('#worker/run-records/service.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/run-records/service.ts')>()
+	const actual = await importOriginal<typeof RunRecordsServiceModule>()
 	return {
 		...actual,
 		beginRunRecord: (...args: Array<unknown>) =>

--- a/packages/worker/src/package-runtime/package-service.node.test.ts
+++ b/packages/worker/src/package-runtime/package-service.node.test.ts
@@ -4,6 +4,7 @@ import {
 	silenceExpectedConsoleWarns,
 } from '#worker/test-support/console-spies.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import type * as McpAuthUserContext from '#worker/mcp-auth-user-context.ts'
 
 const mockModule = vi.hoisted(() => ({
 	getSavedPackageById: vi.fn(),
@@ -74,8 +75,7 @@ vi.mock('#worker/identity/background-mcp-user.ts', () => ({
 }))
 
 vi.mock('#worker/mcp-auth-user-context.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/mcp-auth-user-context.ts')>()
+	const actual = await importOriginal<typeof McpAuthUserContext>()
 	return {
 		...actual,
 	}

--- a/packages/worker/src/package-runtime/package-workflows-cancel.node.test.ts
+++ b/packages/worker/src/package-runtime/package-workflows-cancel.node.test.ts
@@ -11,6 +11,7 @@ import {
 	dynamicCallableWorkflowsBindingName,
 	listWorkflowRunsForUser,
 } from './package-workflows.ts'
+import type * as RunRecordsServiceModule from '#worker/run-records/service.ts'
 
 const runRecordMocks = vi.hoisted(() => {
 	const projectionsByUser = new Map<
@@ -252,8 +253,7 @@ const runRecordMocks = vi.hoisted(() => {
 })
 
 vi.mock('#worker/run-records/service.ts', async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import('#worker/run-records/service.ts')>()
+	const actual = await importOriginal<typeof RunRecordsServiceModule>()
 	return {
 		...actual,
 		beginRunRecord: (...args: Array<unknown>) =>

--- a/packages/worker/src/repo/ephemeral-git-workspace.ts
+++ b/packages/worker/src/repo/ephemeral-git-workspace.ts
@@ -105,6 +105,8 @@ export function createEphemeralGitWorkspace() {
 		rm: async (path, options) => {
 			const normalized = normalizeFsPath(path)
 			if (options?.recursive) {
+				// Snapshot keys so deletes during this loop do not skip entries.
+				// oxlint-disable-next-line unicorn/no-useless-spread
 				for (const key of [...store.keys()]) {
 					if (key === normalized || key.startsWith(`${normalized}/`)) {
 						store.delete(key)

--- a/packages/worker/src/repo/isomorphic-git-fs.node.test.ts
+++ b/packages/worker/src/repo/isomorphic-git-fs.node.test.ts
@@ -72,6 +72,8 @@ test('workspace filesystem adapter supports raw isomorphic-git operations', asyn
 	await workspaceFileSystem.mkdir('/remove-me')
 	await fs.promises.unlink('/remove-me.txt')
 	await fs.promises.rmdir('/remove-me')
-	await expect(workspaceFileSystem.stat('/remove-me.txt')).rejects.toThrow()
-	await expect(workspaceFileSystem.stat('/remove-me')).rejects.toThrow()
+	await expect(workspaceFileSystem.stat('/remove-me.txt')).rejects.toThrow(
+		Error,
+	)
+	await expect(workspaceFileSystem.stat('/remove-me')).rejects.toThrow(Error)
 })

--- a/packages/worker/src/repo/source-service.node.test.ts
+++ b/packages/worker/src/repo/source-service.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import type * as CloudflareWorkers from 'cloudflare:workers'
 
 const mocks = vi.hoisted(() => ({
 	waitUntil: vi.fn((promise: Promise<unknown>) => {
@@ -11,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('cloudflare:workers', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('cloudflare:workers')>()
+	const actual = await importOriginal<typeof CloudflareWorkers>()
 	return {
 		...actual,
 		waitUntil: (...args: Array<unknown>) => mocks.waitUntil(...args),
@@ -148,7 +149,9 @@ test('ensureEntitySource workflow: fail-closed, bootstrap, recreate missing repo
 			sourceRoot: '/',
 			requirePersistence: true,
 		}),
-	).rejects.toThrow()
+	).rejects.toThrow(
+		'Repo-backed source persistence requires ARTIFACTS binding or CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
+	)
 
 	const newJobDb = {
 		prepare(query: string) {

--- a/packages/worker/src/storage-runner.entitlement.node.test.ts
+++ b/packages/worker/src/storage-runner.entitlement.node.test.ts
@@ -115,6 +115,8 @@ test('assertStorageRunnerWriteWithinEntitlement retries estimate reads with back
 			storageId: 'bucket-a',
 			requested: 1,
 		})
+		// Attach before advancing timers so the rejection is not unhandled.
+		// oxlint-disable-next-line vitest/valid-expect
 		const expectation = expect(assertion).rejects.toThrow(
 			`Unable to verify the storage byte entitlement because the bucket estimate for storageId "bucket-a" could not be read after ${maxEstimateReadAttempts} attempts.`,
 		)

--- a/packages/worker/src/storage-runner.read-sql-entitlement.node.test.ts
+++ b/packages/worker/src/storage-runner.read-sql-entitlement.node.test.ts
@@ -277,6 +277,8 @@ test('entitlement run cache drops a rejected baseline so later writes retry', as
 			requested: 1,
 			cache,
 		})
+		// Attach before advancing timers so the rejection is not unhandled.
+		// oxlint-disable-next-line vitest/valid-expect
 		const expectation =
 			expect(firstAssertion).rejects.toThrow(/could not be read/)
 		await vi.advanceTimersByTimeAsync(

--- a/tools/ci/production-resources.ts
+++ b/tools/ci/production-resources.ts
@@ -686,7 +686,7 @@ async function ensureProductionResources(options: CliOptions) {
 		bindings.packageAppHostname,
 		...bindings.packageAppLegacyHostnames,
 	].filter((hostname): hostname is string => Boolean(hostname))
-	for (const packageAppHostname of [...new Set(packageAppHostnames)]) {
+	for (const packageAppHostname of new Set(packageAppHostnames)) {
 		await ensurePackageAppDnsRecords({
 			accountId: accountId ?? 'dry-run-account',
 			apiToken: apiToken ?? 'dry-run-token',

--- a/tools/ci/resource-utils.node.test.ts
+++ b/tools/ci/resource-utils.node.test.ts
@@ -143,7 +143,7 @@ test('writeGeneratedWranglerConfig preserves migrations and copies environment a
 		const packageAppBaseUrl =
 			productionConfig.env?.production?.vars?.PACKAGE_APP_BASE_URL
 		expect(typeof packageAppBaseUrl).toBe('string')
-		const packageAppHostname = new URL(String(packageAppBaseUrl)).hostname
+		const _packageAppHostname = new URL(String(packageAppBaseUrl)).hostname
 		expect(productionConfig.env?.production?.routes).toEqual([
 			{ pattern: 'heykody.dev', custom_domain: true },
 		])

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -1755,7 +1755,7 @@ export async function writeGeneratedWranglerConfig({
 	}
 
 	const resolvedVars = {
-		...((existingVars as Record<string, unknown> | undefined) ?? {}),
+		...(existingVars as Record<string, unknown> | undefined),
 	}
 	for (const [key, value] of Object.entries(workerVars ?? {})) {
 		if (typeof value === 'string' && value.length > 0) {

--- a/tools/disaster-recovery/restore-cli-and-staging.node.test.ts
+++ b/tools/disaster-recovery/restore-cli-and-staging.node.test.ts
@@ -110,7 +110,7 @@ test('staged SQL remains immutable when the operator path is replaced before Wra
 				expect(result.commands[1]?.args).not.toContain(source)
 			},
 		)
-		await expect(stat(stagedPath)).rejects.toThrow()
+		await expect(stat(stagedPath)).rejects.toThrow(/ENOENT/)
 	} finally {
 		await rm(directory, { recursive: true, force: true })
 	}

--- a/tools/oxlint/oxlint-rules.json
+++ b/tools/oxlint/oxlint-rules.json
@@ -34,6 +34,24 @@
 		"kody-custom/enforce-import-boundaries": "error",
 		"kody-custom/no-example-identifier": "error",
 		"kody-custom/no-literal-frame-src": "error",
-		"kody-custom/prefer-loader-data-types": "error"
-	}
+		"kody-custom/prefer-loader-data-types": "error",
+		"vitest/require-mock-type-parameters": "off",
+		"vitest/no-conditional-expect": "off",
+		"epic-web/prefer-dispose-in-tests": "off",
+		"epic-web/no-manual-dispose": "off"
+	},
+	"overrides": [
+		{
+			"files": [
+				"**/tests/**",
+				"**/#tests/**",
+				"**/__tests__/**/*",
+				"**/*.test.*",
+				"**/*.spec.*"
+			],
+			"rules": {
+				"epic-web/prefer-dispose-in-tests": "off"
+			}
+		}
+	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Static Validate was posting GitHub warning annotations on every green run. Oxlint reported ~1,900 warnings (mostly default-warn Vitest rules this repo never adopted). This PR fixes the real ones and turns off the unenforced defaults so CI stays clean.

## What changed

- **Fixed** unused vars/imports, empty `toThrow()`, `typeof import()` type annotations, two-arg `expect()`, and a few unicorn/import nits.
- **Left snapshots in place** where `[...map.keys()]` / `[...headers.keys()]` exists so deletes during iteration cannot skip entries; those lines keep an oxlint disable.
- **Turned off** `vitest/require-mock-type-parameters` (~1,770 dummy `vi.fn` types), `vitest/no-conditional-expect` (TypeScript narrowing), and `epic-web/prefer-dispose-in-tests` / `no-manual-dispose` (not a migration we want).
- **No intended runtime behavior change.** `Promise.all([onePromise])` is a direct await; object spread of `undefined` is still a no-op.

**Risk:** Low — lint/test cleanup. Local `oxlint` is 0 warnings; node-unit + workers + e2e ran on push.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `cursor/fix-ci-lint-warnings-46b8`

**Classification:** composes — oxlint config and call-site cleanup only; no primitive contracts change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — unused imports, a11y disable on featured blog link |
| `mcp-server` | surfaces | composes — `this` alias disable, single-promise await |
| `package-runtime` | runtime | composes — keep header-key snapshot during deletes |
| `repo-sessions` | runtime | composes — keep map-key snapshot during deletes |
| `capability-registry` | assistant | composes — test assertion messages |
| `saved-packages` | assistant | composes — test assertion messages |
| `rbac` | auth | composes — test assertion messages |

### Change flow

Oxlint on CI was emitting warning annotations; this PR makes that job silent.

```mermaid
sequenceDiagram
	participant staticJob as Static Validate
	participant oxlint as oxlint
	participant gh as GitHub annotations
	staticJob->>oxlint: npm run lint
	oxlint-->>gh: warning annotations (before)
	Note over oxlint: fix real warnings; turn off unenforced defaults
	oxlint-->>gh: no warning annotations (after)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75093e98-91e1-46f1-983e-c69e794446b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75093e98-91e1-46f1-983e-c69e794446b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recursive file removal to reliably delete all entries.
  * Streamlined search processing without changing results or error handling.
  * Strengthened error handling and validation for invalid inputs and unavailable operations.

* **Tests**
  * Expanded coverage for precise validation, file-system, retry, rendering, and authorization errors.
  * Improved reliability of asynchronous and timer-based test scenarios.

* **Chores**
  * Cleaned up unused code and refined linting and accessibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->