### PR TITLE
fix(community): keep missing-package publish/adopt off Sentry (KODY-CLOUDFLARE-5B)

### DIFF
--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -488,6 +488,45 @@ test('unpublishCommunityListing treats missing or unowned listings as CommunityA
 	expect(mockModule.deleteCommunityListing).not.toHaveBeenCalled()
 })
 
+test('publishCommunityListing treats missing packages as CommunityActionError', async () => {
+	mockModule.getCommunityBan.mockResolvedValue(null)
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+
+	await expect(
+		publishCommunityListing({
+			env: createEnv(),
+			baseUrl: 'https://heykody.dev',
+			userId: 'owner-1',
+			packageId: 'missing-package',
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityActionError &&
+			error.message.includes('Saved package "missing-package" was not found'),
+	)
+
+	expect(mockModule.loadPackageSourceBySourceId).not.toHaveBeenCalled()
+})
+
+test('adoptCommunityFork treats missing packages as CommunityActionError', async () => {
+	mockModule.getSavedPackageById.mockResolvedValue(null)
+
+	await expect(
+		adoptCommunityFork({
+			env: createEnv(),
+			userId: 'owner-1',
+			packageId: 'missing-package',
+			reviewSummary: 'Reviewed the fork source and trust the upstream listing.',
+		}),
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityActionError &&
+			error.message.includes('Saved package "missing-package" was not found'),
+	)
+
+	expect(mockModule.getCommunityForkByForkedPackageId).not.toHaveBeenCalled()
+})
+
 test('unpublishCommunityListing deletes active listings and cascades cleanup', async () => {
 	mockModule.getCommunityListingById.mockResolvedValue(sampleListing())
 	mockModule.deleteCommunityListing.mockResolvedValue(true)

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -441,7 +441,12 @@ export async function publishCommunityListing(input: {
 		packageId: input.packageId,
 	})
 	if (!savedPackage) {
-		throw new Error(`Saved package "${input.packageId}" was not found.`)
+		// Missing / wrong-owner package_id (including delegated package_scope
+		// mismatches) is caller-clearable. CommunityActionError keeps these on
+		// mcp-event lines and out of Sentry (KODY-CLOUDFLARE-5B).
+		throw new CommunityActionError(
+			`Saved package "${input.packageId}" was not found for this package owner. Confirm package_id with search({ domain: "packages" }) and that package_scope matches the account that owns it.`,
+		)
 	}
 
 	const loadedSource = await loadPackageSourceBySourceId({
@@ -1285,7 +1290,11 @@ export async function adoptCommunityFork(input: {
 				})
 	if (!savedPackage) {
 		const missingId = input.packageId ?? input.kodyId
-		throw new Error(`Saved package "${missingId}" was not found.`)
+		// Missing / mistyped package_id or kody_id is caller-clearable.
+		// CommunityActionError keeps these on mcp-event lines and out of Sentry.
+		throw new CommunityActionError(
+			`Saved package "${missingId}" was not found. Confirm the id with search({ domain: "packages" }).`,
+		)
 	}
 
 	const fork = await getCommunityForkByForkedPackageId(input.env.APP_DB, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Sentry noise when `community_publish` / adopt is called with a package id that does not exist for the resolved package owner (including `package_scope` mismatches).

## Summary

- Throw `CommunityActionError` (already filtered from Sentry via mcp observability) instead of plain `Error` when the saved package lookup misses in `publishCommunityListing` and `adoptCommunityFork`.
- Message now points callers at `search({ domain: "packages" })` and matching `package_scope`.
- Unit coverage mirrors the existing unpublish missing-listing caller-error test.

## Sentry

- Primary: [KODY-CLOUDFLARE-5B](https://kent-c-dodds-tech-llc.sentry.io/issues/7676978902/) — `community_publish` with a non-owned / missing `package_id` under delegated `@kody` scope.
- Sibling [KODY-CLOUDFLARE-5E](https://kent-c-dodds-tech-llc.sentry.io/issues/7680229361/) is unrelated (RSS SPA hydration) and was already fixed in #1551.

## Testing

- `vitest run --project node-unit packages/worker/src/community/community-service.node.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` · **Head:** this branch

**Classification:** composes — reuses the existing `CommunityActionError` → mcp-event / Sentry skip path already used by community unpublish and ratings.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `community-listings` | assistant | composes — missing-package publish/adopt throws use the established caller-error type |

### Change flow

```mermaid
sequenceDiagram
	actor Caller
	participant mcp as mcp-server
	participant community as community-listings
	participant sentry as sentry-tunnel
	Caller->>mcp: community_publish(package_id, package_scope?)
	mcp->>community: publishCommunityListing
	community-->>mcp: CommunityActionError (package not found)
	mcp-->>Caller: mcp-event failure (caller-clearable)
	Note over sentry: beforeSend / isCallerFailure skips Sentry
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1c938f2-5560-44cc-ab4f-071b45f78173?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1c938f2-5560-44cc-ab4f-071b45f78173&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

