### PR TITLE
Defer runtime PackageServiceInstance class deletion (Cloudflare 10061)

### DIFF
--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -172,8 +172,7 @@ A class that arrived on `kody-runtime` through `transferred_classes` keeps a
 remote binding until a deploy publishes config without that binding. Cloudflare
 rejects a same-deploy `deleted_classes` migration while that binding still
 exists (error 10061). Drop the binding first, then add the `deleted_classes`
-migration and its `tools/ci/do-deletion-allowlist.json` entry on a later
-deploy.
+migration and its `tools/ci/do-deletion-allowlist.json` entry on a later deploy.
 
 `PackageServiceInstance` is in that window: production still has the transferred
 binding, so runtime-worker tag `v2` is deferred until after the binding-only

--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -174,9 +174,10 @@ rejects a same-deploy `deleted_classes` migration while that binding still
 exists (error 10061). Drop the binding first, then add the `deleted_classes`
 migration and its `tools/ci/do-deletion-allowlist.json` entry on a later deploy.
 
-`PackageServiceInstance` is in that window: production still has the transferred
-binding, so runtime-worker tag `v2` is deferred until after the binding-only
-deploy.
+`PackageServiceInstance` is in that window on production: the transferred
+binding is still present, so top-level runtime-worker tag `v2` is deferred until
+after the binding-only deploy. Preview keeps `v2` because a fresh worker applies
+`v1` `new_sqlite_classes` and cannot create an unexported class (error 10070).
 
 ## Rollback
 

--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -176,8 +176,10 @@ migration and its `tools/ci/do-deletion-allowlist.json` entry on a later deploy.
 
 `PackageServiceInstance` is in that window on production: the transferred
 binding is still present, so top-level runtime-worker tag `v2` is deferred until
-after the binding-only deploy. Preview keeps `v2` because a fresh worker applies
-`v1` `new_sqlite_classes` and cannot create an unexported class (error 10070).
+after the binding-only deploy. Preview keeps `v2` and the matching
+`tools/ci/do-deletion-allowlist.json` entry because a fresh worker applies `v1`
+`new_sqlite_classes` and cannot create an unexported class (error 10070). The
+follow-up reuses that allowlist entry when it restores top-level `v2`.
 
 ## Rollback
 

--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -166,6 +166,19 @@ npm run deploy -- --config packages/runtime-worker/wrangler-production.generated
 npm run deploy -- --config packages/worker/wrangler-production.generated.json
 ```
 
+## Deleting a transferred class
+
+A class that arrived on `kody-runtime` through `transferred_classes` keeps a
+remote binding until a deploy publishes config without that binding. Cloudflare
+rejects a same-deploy `deleted_classes` migration while that binding still
+exists (error 10061). Drop the binding first, then add the `deleted_classes`
+migration and its `tools/ci/do-deletion-allowlist.json` entry on a later
+deploy.
+
+`PackageServiceInstance` is in that window: production still has the transferred
+binding, so runtime-worker tag `v2` is deferred until after the binding-only
+deploy.
+
 ## Rollback
 
 - **Runtime deploy failed before the migration applied:** nothing moved; the old

--- a/docs/contributing/decisions/0025-no-package-services-primitive.md
+++ b/docs/contributing/decisions/0025-no-package-services-primitive.md
@@ -34,3 +34,9 @@ Leftover `kind = 'service'` `user_storage_buckets` rows stay until the
 `storage_bucket_estimate_backfill` lane clears the matching StorageRunner
 Durable Objects and then deletes the inventory. Account export and deletion keep
 discovering those storage ids until that purge succeeds.
+
+Deleting `PackageServiceInstance` on `kody-runtime` is two production deploys.
+The class arrived through a `transferred_classes` migration, so Cloudflare still
+has a remote binding after the source binding is gone. A same-deploy
+`deleted_classes` migration fails with error 10061. Drop the remote binding
+first, then apply runtime-worker tag `v2` `deleted_classes`.

--- a/docs/contributing/decisions/0025-no-package-services-primitive.md
+++ b/docs/contributing/decisions/0025-no-package-services-primitive.md
@@ -35,8 +35,10 @@ Leftover `kind = 'service'` `user_storage_buckets` rows stay until the
 Durable Objects and then deletes the inventory. Account export and deletion keep
 discovering those storage ids until that purge succeeds.
 
-Deleting `PackageServiceInstance` on `kody-runtime` is two production deploys.
+Deleting `PackageServiceInstance` on production `kody-runtime` is two deploys.
 The class arrived through a `transferred_classes` migration, so Cloudflare still
 has a remote binding after the source binding is gone. A same-deploy
 `deleted_classes` migration fails with error 10061. Drop the remote binding
-first, then apply runtime-worker tag `v2` `deleted_classes`.
+first, then apply top-level runtime-worker tag `v2` `deleted_classes`. Preview
+keeps `v2` because a fresh worker applies `v1` `new_sqlite_classes` and cannot
+create an unexported class (error 10070).

--- a/docs/contributing/decisions/0025-no-package-services-primitive.md
+++ b/docs/contributing/decisions/0025-no-package-services-primitive.md
@@ -39,6 +39,8 @@ Deleting `PackageServiceInstance` on production `kody-runtime` is two deploys.
 The class arrived through a `transferred_classes` migration, so Cloudflare still
 has a remote binding after the source binding is gone. A same-deploy
 `deleted_classes` migration fails with error 10061. Drop the remote binding
-first, then apply top-level runtime-worker tag `v2` `deleted_classes`. Preview
-keeps `v2` because a fresh worker applies `v1` `new_sqlite_classes` and cannot
-create an unexported class (error 10070).
+first, then apply top-level runtime-worker tag `v2` `deleted_classes`. The
+`tools/ci/do-deletion-allowlist.json` entry for that tag stays for preview `v2`
+and is the same contract the follow-up reuses. Preview keeps `v2` because a
+fresh worker applies `v1` `new_sqlite_classes` and cannot create an unexported
+class (error 10070).

--- a/packages/runtime-worker/wrangler.jsonc
+++ b/packages/runtime-worker/wrangler.jsonc
@@ -74,10 +74,11 @@
 				},
 			],
 		},
-		// Do not add deleted_classes for PackageServiceInstance in the same
-		// deploy that drops its remote binding. Production still has the
-		// transferred binding (error 10061). Re-add tag v2 after this
-		// binding-only deploy lands.
+		// Production still has the transferred PackageServiceInstance
+		// binding (error 10061). Do not add deleted_classes here until
+		// after this binding-only deploy lands. Preview keeps tag v2
+		// because a fresh worker applies v1 new_sqlite_classes and
+		// cannot create an unexported class (error 10070).
 	],
 	"observability": {
 		"enabled": true,
@@ -267,8 +268,10 @@
 						"PackageServiceInstance",
 					],
 				},
-				// Keep preview in lockstep with production: no v2
-				// deleted_classes until the production binding is gone.
+				{
+					"tag": "v2",
+					"deleted_classes": ["PackageServiceInstance"],
+				},
 			],
 			"worker_loaders": [
 				{

--- a/packages/runtime-worker/wrangler.jsonc
+++ b/packages/runtime-worker/wrangler.jsonc
@@ -74,10 +74,10 @@
 				},
 			],
 		},
-		{
-			"tag": "v2",
-			"deleted_classes": ["PackageServiceInstance"],
-		},
+		// Do not add deleted_classes for PackageServiceInstance in the same
+		// deploy that drops its remote binding. Production still has the
+		// transferred binding (error 10061). Re-add tag v2 after this
+		// binding-only deploy lands.
 	],
 	"observability": {
 		"enabled": true,
@@ -267,10 +267,8 @@
 						"PackageServiceInstance",
 					],
 				},
-				{
-					"tag": "v2",
-					"deleted_classes": ["PackageServiceInstance"],
-				},
+				// Keep preview in lockstep with production: no v2
+				// deleted_classes until the production binding is gone.
 			],
 			"worker_loaders": [
 				{

--- a/tools/ci/do-deletion-allowlist.json
+++ b/tools/ci/do-deletion-allowlist.json
@@ -25,11 +25,6 @@
 			"config": "packages/worker/wrangler.jsonc",
 			"tag": "v26",
 			"classes": ["PackageServiceInstance"]
-		},
-		{
-			"config": "packages/runtime-worker/wrangler.jsonc",
-			"tag": "v2",
-			"classes": ["PackageServiceInstance"]
 		}
 	]
 }

--- a/tools/ci/do-deletion-allowlist.json
+++ b/tools/ci/do-deletion-allowlist.json
@@ -25,6 +25,11 @@
 			"config": "packages/worker/wrangler.jsonc",
 			"tag": "v26",
 			"classes": ["PackageServiceInstance"]
+		},
+		{
+			"config": "packages/runtime-worker/wrangler.jsonc",
+			"tag": "v2",
+			"classes": ["PackageServiceInstance"]
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock the production deploy of #1552. `kody-runtime` still has the transferred `PackageServiceInstance` binding, so a same-deploy `deleted_classes` migration fails with Cloudflare error 10061.

## Summary

- Remove **top-level** runtime-worker tag `v2` `deleted_classes` so production can drop the remote binding without deleting the class.
- Keep **preview** tag `v2` `deleted_classes` and the allowlist entry. Fresh preview workers apply `v1` `new_sqlite_classes` including `PackageServiceInstance`; without `v2` that create fails with error 10070 because the class is not exported.
- Leave protected `v1` `transferred_classes` / preview `new_sqlite_classes` unchanged.
- Main-worker `v26` `deleted_classes` stays.

This production deploy only drops the remote binding. A follow-up PR must re-add **top-level** runtime-worker `v2` after this lands (the allowlist entry is already present for preview `v2`).

Failed production deploy: https://github.com/kentcdodds/kody/actions/runs/32241884482
Preview 10070 on the first hotfix revision: https://github.com/kentcdodds/kody/actions/runs/32242880620
Merged services removal: https://github.com/kentcdodds/kody/pull/1552 (`8b9e6f73`)

## Testing

- `npm run deploy-guardrails:check` — pass
- `tools/check-deploy-guardrails.node.test.ts` — 6/6
- `npm run runtime:build` (wrangler dry-run) — no `PackageServiceInstance` binding
- format / docs temporal — pass
- Preview success criterion: runtime worker deploy no longer fails with 10070
- Production success criterion: runtime worker deploy no longer fails with 10061

## System changes

Config-only Durable Object migration sequencing. No user-facing API change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8b9e6f73` · **Head:** `ffbfa8d8`

**Classification:** extends — this PR changes the runtime-worker Durable Object deletion contract so production can drop a transferred binding before the class is deleted, while preview still deletes the class on first deploy.

### Primitives touched

Classifier reported no `code` root matches. The unmatched paths are the change:

| Path | Impact |
| --- | --- |
| `packages/runtime-worker/wrangler.jsonc` | extends — remove top-level `v2` `deleted_classes`; keep preview `v2` |
| `tools/ci/do-deletion-allowlist.json` | keep the runtime-worker `v2` allowlist row for preview |
| `docs/contributing/architecture/runtime-worker-migration-runbook.md` | documents the two-deploy production delete and preview 10070 |
| `docs/contributing/decisions/0025-no-package-services-primitive.md` | records the Cloudflare 10061 / 10070 constraints |

Neighbor primitive for reviewers: `package-runtime` (unchanged code; this is the worker that hosts its Durable Objects).

### Change flow

Production deploy of #1552 failed because Cloudflare still has the transferred binding when top-level tag `v2` tries to delete the class. Preview of the first hotfix revision failed because a fresh worker still creates `PackageServiceInstance` via `v1` `new_sqlite_classes` and the class is not exported.

```mermaid
sequenceDiagram
	actor Operator
	participant preview as preview kody-runtime
	participant production as production kody-runtime
	participant cloudflare as Cloudflare DO registry
	Operator->>preview: first deploy
	preview->>cloudflare: v1 new_sqlite_classes then v2 deleted_classes
	Note over cloudflare: 10070 if v2 is omitted on a fresh worker
	Operator->>production: merge this PR
	production->>cloudflare: drop remote binding only
	Note over cloudflare: production class remains until follow-up top-level v2
	cloudflare-->>production: deploy succeeds (no 10061)
```

### Before / after

| | #1552 production | First hotfix (bb4db100) | This revision |
| --- | --- | --- | --- |
| Production migrations | `v1` transfer + `v2` delete | `v1` transfer only | `v1` transfer only |
| Preview migrations | `v1` create + `v2` delete | `v1` create only | `v1` create + `v2` delete |
| Cloudflare result | prod 10061 | preview 10070 | prod drops binding; preview deletes class |

### Invariants

Protected `v1` transfer and preview `new_sqlite_classes` entries stay byte-for-byte. Do not edit `tools/ci/durable-object-baseline.json` in this PR.

### Plan vs actual

Two-phase production delete: this PR is phase 1 (drop binding). Phase 2 re-adds top-level runtime-worker `v2` after this production deploy succeeds and reuses the existing allowlist entry. Preview stays on the create-then-delete first-deploy path.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d38711-e9f1-4574-b52e-335fa9e48713?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d38711-e9f1-4574-b52e-335fa9e48713&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the staged procedure for removing transferred runtime services in production.
  * Documented differences between production and preview deployment behavior, including migration sequencing and allowlist reuse.

* **Bug Fixes**
  * Preview deployments now correctly remove the obsolete `PackageServiceInstance` runtime service while preserving compatibility with fresh workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->