### PR TITLE
Export PackageServiceInstance stub so runtime can drop its binding

### DIFF
--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -171,15 +171,18 @@ npm run deploy -- --config packages/worker/wrangler-production.generated.json
 A class that arrived on `kody-runtime` through `transferred_classes` keeps a
 remote binding until a deploy publishes config without that binding. Cloudflare
 rejects a same-deploy `deleted_classes` migration while that binding still
-exists (error 10061). Drop the binding first, then add the `deleted_classes`
-migration and its `tools/ci/do-deletion-allowlist.json` entry on a later deploy.
+exists (error 10061). Existing objects also require the script to keep exporting
+the class until `deleted_classes` runs (error 10064). Export a stub, drop the
+binding, then add the `deleted_classes` migration and its
+`tools/ci/do-deletion-allowlist.json` entry on a later deploy.
 
 `PackageServiceInstance` is in that window on production: the transferred
-binding is still present, so top-level runtime-worker tag `v2` is deferred until
-after the binding-only deploy. Preview keeps `v2` and the matching
-`tools/ci/do-deletion-allowlist.json` entry because a fresh worker applies `v1`
-`new_sqlite_classes` and cannot create an unexported class (error 10070). The
-follow-up reuses that allowlist entry when it restores top-level `v2`.
+objects still exist, so the runtime worker exports a stub and top-level tag `v2`
+is deferred until after the binding-only deploy. Preview keeps `v2` and the
+matching `tools/ci/do-deletion-allowlist.json` entry because a fresh worker
+applies `v1` `new_sqlite_classes` and cannot create an unexported class (error
+10070). The follow-up reuses that allowlist entry when it restores top-level
+`v2` and removes the stub.
 
 ## Rollback
 

--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -176,13 +176,11 @@ the class until `deleted_classes` runs (error 10064). Export a stub, drop the
 binding, then add the `deleted_classes` migration and its
 `tools/ci/do-deletion-allowlist.json` entry on a later deploy.
 
-`PackageServiceInstance` is in that window on production: the transferred
-objects still exist, so the runtime worker exports a stub and top-level tag `v2`
-is deferred until after the binding-only deploy. Preview keeps `v2` and the
-matching `tools/ci/do-deletion-allowlist.json` entry because a fresh worker
-applies `v1` `new_sqlite_classes` and cannot create an unexported class (error
-10070). The follow-up reuses that allowlist entry when it restores top-level
-`v2` and removes the stub.
+`PackageServiceInstance` is in that window: the runtime worker exports a stub
+and omits tag `v2` so production can drop the remote binding. Preview also omits
+`v2` while the stub is exported; `deleted_classes` fails with error 10074 when
+the previous script version did not export the class. The allowlist entry stays
+for the follow-up that restores `v2` and removes the stub.
 
 ## Rollback
 

--- a/docs/contributing/decisions/0025-no-package-services-primitive.md
+++ b/docs/contributing/decisions/0025-no-package-services-primitive.md
@@ -40,8 +40,8 @@ The class arrived through a `transferred_classes` migration, so Cloudflare still
 has a remote binding and existing objects after the source binding is gone. A
 same-deploy `deleted_classes` migration fails with error 10061. Dropping the
 binding without exporting the class fails with error 10064. Export a stub, drop
-the remote binding, then apply top-level runtime-worker tag `v2`
-`deleted_classes` and remove the stub. The `tools/ci/do-deletion-allowlist.json`
-entry for that tag stays for preview `v2` and is the same contract the follow-up
-reuses. Preview keeps `v2` because a fresh worker applies `v1`
-`new_sqlite_classes` and cannot create an unexported class (error 10070).
+the remote binding, then apply runtime-worker tag `v2` `deleted_classes` and
+remove the stub. The `tools/ci/do-deletion-allowlist.json` entry for that tag
+stays for the follow-up. Preview also omits `v2` while the stub is exported:
+`deleted_classes` fails with error 10074 when the previous script version did
+not export the class.

--- a/docs/contributing/decisions/0025-no-package-services-primitive.md
+++ b/docs/contributing/decisions/0025-no-package-services-primitive.md
@@ -37,10 +37,11 @@ discovering those storage ids until that purge succeeds.
 
 Deleting `PackageServiceInstance` on production `kody-runtime` is two deploys.
 The class arrived through a `transferred_classes` migration, so Cloudflare still
-has a remote binding after the source binding is gone. A same-deploy
-`deleted_classes` migration fails with error 10061. Drop the remote binding
-first, then apply top-level runtime-worker tag `v2` `deleted_classes`. The
-`tools/ci/do-deletion-allowlist.json` entry for that tag stays for preview `v2`
-and is the same contract the follow-up reuses. Preview keeps `v2` because a
-fresh worker applies `v1` `new_sqlite_classes` and cannot create an unexported
-class (error 10070).
+has a remote binding and existing objects after the source binding is gone. A
+same-deploy `deleted_classes` migration fails with error 10061. Dropping the
+binding without exporting the class fails with error 10064. Export a stub, drop
+the remote binding, then apply top-level runtime-worker tag `v2`
+`deleted_classes` and remove the stub. The `tools/ci/do-deletion-allowlist.json`
+entry for that tag stays for preview `v2` and is the same contract the follow-up
+reuses. Preview keeps `v2` because a fresh worker applies `v1`
+`new_sqlite_classes` and cannot create an unexported class (error 10070).

--- a/packages/runtime-worker/wrangler.jsonc
+++ b/packages/runtime-worker/wrangler.jsonc
@@ -74,11 +74,13 @@
 				},
 			],
 		},
-		// Production still has the transferred PackageServiceInstance
-		// binding (error 10061). Do not add deleted_classes here until
-		// after this binding-only deploy lands. Preview keeps tag v2
-		// because a fresh worker applies v1 new_sqlite_classes and
-		// cannot create an unexported class (error 10070).
+		// Production still has transferred PackageServiceInstance
+		// objects. deleted_classes while the remote binding exists is
+		// error 10061; dropping the binding without exporting the class
+		// is error 10064. Export the stub, drop the binding here, then
+		// add tag v2 after this deploy. Preview keeps v2 because a
+		// fresh worker applies v1 new_sqlite_classes (error 10070
+		// without the delete).
 	],
 	"observability": {
 		"enabled": true,

--- a/packages/runtime-worker/wrangler.jsonc
+++ b/packages/runtime-worker/wrangler.jsonc
@@ -77,10 +77,10 @@
 		// Production still has transferred PackageServiceInstance
 		// objects. deleted_classes while the remote binding exists is
 		// error 10061; dropping the binding without exporting the class
-		// is error 10064. Export the stub, drop the binding here, then
-		// add tag v2 after this deploy. Preview keeps v2 because a
-		// fresh worker applies v1 new_sqlite_classes (error 10070
-		// without the delete).
+		// is error 10064. Export the stub and omit the binding here.
+		// Add tag v2 after this deploy. Preview also omits v2: a
+		// delete-class on a script whose previous version did not
+		// export the class is error 10074.
 	],
 	"observability": {
 		"enabled": true,
@@ -269,10 +269,6 @@
 						"PackageRealtimeSession",
 						"PackageServiceInstance",
 					],
-				},
-				{
-					"tag": "v2",
-					"deleted_classes": ["PackageServiceInstance"],
 				},
 			],
 			"worker_loaders": [

--- a/packages/worker/src/package-service-instance-stub.ts
+++ b/packages/worker/src/package-service-instance-stub.ts
@@ -1,0 +1,9 @@
+import { DurableObject } from 'cloudflare:workers'
+
+/**
+ * Temporary export so production `kody-runtime` can drop the transferred
+ * `PackageServiceInstance` binding. Existing Durable Objects still require
+ * the class to be exported (Cloudflare error 10064). Remove this module when
+ * top-level runtime-worker tag `v2` `deleted_classes` lands.
+ */
+export class PackageServiceInstance extends DurableObject<Env> {}

--- a/packages/worker/src/runtime-worker.ts
+++ b/packages/worker/src/runtime-worker.ts
@@ -5,6 +5,7 @@ import {
 } from '@kody-internal/shared/runtime-worker.ts'
 import { StorageRunner } from './storage-runner.ts'
 import { RunLog } from './run-records/run-log-do.ts'
+import { PackageServiceInstance } from './package-service-instance-stub.ts'
 import { PackageRealtimeSession } from '#worker/package-runtime/realtime-session.ts'
 import { DynamicCallableWorkflow } from '#worker/package-runtime/package-workflows.ts'
 import { PackageAppRuntimeBridge } from '#worker/package-runtime/package-app.ts'
@@ -41,6 +42,7 @@ export {
 	StorageRunner,
 	RunLog,
 	PackageRealtimeSession,
+	PackageServiceInstance,
 	DynamicCallableWorkflow,
 	PackageAppRuntimeBridge,
 	KodyFetchGateway,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock production `kody-runtime` after #1558. Dropping the transferred `PackageServiceInstance` binding without exporting the class fails with Cloudflare error 10064 because existing Durable Objects still depend on the export.

## Summary

- Export a no-op `PackageServiceInstance` stub from the runtime worker.
- Omit the binding and omit tag `v2` `deleted_classes` on both production and preview.
- Keep the allowlist entry for the follow-up that restores `v2` and removes the stub.

This deploy should drop the production remote binding while satisfying 10064. Preview omits `v2` because `deleted_classes` fails with 10074 when the previous script version did not export the class.

Failed deploys:
- #1552 `deleted_classes` + no binding: [10061](https://github.com/kentcdodds/kody/actions/runs/32241884482)
- #1558 no `deleted_classes` + no export: [10064](https://github.com/kentcdodds/kody/actions/runs/32243829066)
- #1559 first revision stub + preview `v2`: [10074](https://github.com/kentcdodds/kody/actions/runs/32244194880)

## Testing

- `npm run deploy-guardrails:check` — pass
- `npm run runtime:build` dry-run — no `PackageServiceInstance` binding
- format / docs temporal / lint — pass
- Preview success criterion: runtime worker deploy no longer fails with 10074
- Production success criterion: runtime worker deploy no longer fails with 10064

## System changes

Temporary Durable Object stub export only. No user-facing API.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7c384451` · **Head:** `28584451`

**Classification:** extends — this PR changes what the runtime worker exports so Cloudflare will accept a binding-only deploy.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-runtime` | runtime | extends — temporary stub export of retired `PackageServiceInstance` |

Unmatched paths: `packages/runtime-worker/wrangler.jsonc`, docs, `packages/worker/src/package-service-instance-stub.ts`, `packages/worker/src/runtime-worker.ts`.

### Change flow

#1558 dropped top-level `v2` and the binding. Production then failed because existing transferred objects still require the class export. Preview of the stub plus `v2` failed because delete-class requires the previous version to export the class.

```mermaid
sequenceDiagram
	actor Operator
	participant runtimeWorker as kody-runtime
	participant cloudflare as Cloudflare DO registry
	Operator->>runtimeWorker: deploy stub export, no binding, no v2
	runtimeWorker->>cloudflare: keep PackageServiceInstance export
	runtimeWorker->>cloudflare: drop remote binding
	Note over cloudflare: objects remain until follow-up v2 deleted_classes
	cloudflare-->>runtimeWorker: deploy succeeds (no 10064)
```

### Before / after

| | #1552 | #1558 | This PR |
| --- | --- | --- | --- |
| Binding | absent | absent | absent |
| Class export | removed | removed | stub |
| `v2` | present | prod omitted | omitted everywhere |
| Cloudflare | 10061 | 10064 | expect binding drop |

### Invariants

Protected `v1` transfer / preview `new_sqlite_classes` stay unchanged. Do not edit `tools/ci/durable-object-baseline.json`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d38711-e9f1-4574-b52e-335fa9e48713?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d38711-e9f1-4574-b52e-335fa9e48713&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a temporary compatibility stub to preserve existing package service instances during migration.
  * Updated runtime migration guidance for safely removing the package service binding.
* **Documentation**
  * Clarified the required deployment sequence, including retaining the export until cleanup is complete.
  * Documented migration errors and the follow-up cleanup process for production and preview environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->