### PR TITLE
Delete PackageServiceInstance on kody-runtime

### DIFF
--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -176,11 +176,9 @@ the class until `deleted_classes` runs (error 10064). Export a stub, drop the
 binding, then add the `deleted_classes` migration and its
 `tools/ci/do-deletion-allowlist.json` entry on a later deploy.
 
-`PackageServiceInstance` is in that window: the runtime worker exports a stub
-and omits tag `v2` so production can drop the remote binding. Preview also omits
-`v2` while the stub is exported; `deleted_classes` fails with error 10074 when
-the previous script version did not export the class. The allowlist entry stays
-for the follow-up that restores `v2` and removes the stub.
+`PackageServiceInstance` uses that sequence: production `kody-runtime` applies
+tag `v2` after a stub-export deploy dropped the transferred binding. Preview
+applies `v1` `new_sqlite_classes` then `v2` `deleted_classes` on first deploy.
 
 ## Rollback
 

--- a/docs/contributing/decisions/0025-no-package-services-primitive.md
+++ b/docs/contributing/decisions/0025-no-package-services-primitive.md
@@ -41,7 +41,7 @@ has a remote binding and existing objects after the source binding is gone. A
 same-deploy `deleted_classes` migration fails with error 10061. Dropping the
 binding without exporting the class fails with error 10064. Export a stub, drop
 the remote binding, then apply runtime-worker tag `v2` `deleted_classes` and
-remove the stub. The `tools/ci/do-deletion-allowlist.json` entry for that tag
-stays for the follow-up. Preview also omits `v2` while the stub is exported:
-`deleted_classes` fails with error 10074 when the previous script version did
-not export the class.
+remove the stub. #1559 completed the stub-and-drop-binding deploy. The
+`tools/ci/do-deletion-allowlist.json` entry for tag `v2` is the contract for the
+class-delete follow-up. Preview `deleted_classes` requires a previous script
+version that exported the class (error 10074).

--- a/packages/runtime-worker/wrangler.jsonc
+++ b/packages/runtime-worker/wrangler.jsonc
@@ -74,13 +74,10 @@
 				},
 			],
 		},
-		// Production still has transferred PackageServiceInstance
-		// objects. deleted_classes while the remote binding exists is
-		// error 10061; dropping the binding without exporting the class
-		// is error 10064. Export the stub and omit the binding here.
-		// Add tag v2 after this deploy. Preview also omits v2: a
-		// delete-class on a script whose previous version did not
-		// export the class is error 10074.
+		{
+			"tag": "v2",
+			"deleted_classes": ["PackageServiceInstance"],
+		},
 	],
 	"observability": {
 		"enabled": true,
@@ -269,6 +266,10 @@
 						"PackageRealtimeSession",
 						"PackageServiceInstance",
 					],
+				},
+				{
+					"tag": "v2",
+					"deleted_classes": ["PackageServiceInstance"],
 				},
 			],
 			"worker_loaders": [

--- a/packages/worker/src/package-service-instance-stub.ts
+++ b/packages/worker/src/package-service-instance-stub.ts
@@ -1,9 +1,0 @@
-import { DurableObject } from 'cloudflare:workers'
-
-/**
- * Temporary export so production `kody-runtime` can drop the transferred
- * `PackageServiceInstance` binding. Existing Durable Objects still require
- * the class to be exported (Cloudflare error 10064). Remove this module when
- * top-level runtime-worker tag `v2` `deleted_classes` lands.
- */
-export class PackageServiceInstance extends DurableObject<Env> {}

--- a/packages/worker/src/runtime-worker.ts
+++ b/packages/worker/src/runtime-worker.ts
@@ -5,7 +5,6 @@ import {
 } from '@kody-internal/shared/runtime-worker.ts'
 import { StorageRunner } from './storage-runner.ts'
 import { RunLog } from './run-records/run-log-do.ts'
-import { PackageServiceInstance } from './package-service-instance-stub.ts'
 import { PackageRealtimeSession } from '#worker/package-runtime/realtime-session.ts'
 import { DynamicCallableWorkflow } from '#worker/package-runtime/package-workflows.ts'
 import { PackageAppRuntimeBridge } from '#worker/package-runtime/package-app.ts'
@@ -42,7 +41,6 @@ export {
 	StorageRunner,
 	RunLog,
 	PackageRealtimeSession,
-	PackageServiceInstance,
 	DynamicCallableWorkflow,
 	PackageAppRuntimeBridge,
 	KodyFetchGateway,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Finish the Durable Object cleanup after #1559. Production `kody-runtime` no longer has the transferred `PackageServiceInstance` binding, so tag `v2` `deleted_classes` can apply.

## Summary

- Restore runtime-worker tag `v2` `deleted_classes` (top-level and preview).
- Remove the temporary stub export from #1559.
- Keep the existing `tools/ci/do-deletion-allowlist.json` entry.

Depends on successful production deploy of #1559: https://github.com/kentcdodds/kody/actions/runs/32245113886

## Testing

- `npm run deploy-guardrails:check` — pass
- format / docs temporal / lint — pass
- Preview success criterion: runtime worker first deploy applies `v1` then `v2` without 10070/10074
- Production success criterion: runtime worker deploy applies `v2` without 10061/10064

## System changes

Destructive Durable Object class deletion. No user-facing API.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `7928ec6f` · **Head:** `2194f6c1`

**Classification:** extends — this PR deletes the retired runtime Durable Object class after the binding-only deploy.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-runtime` | runtime | extends — delete `PackageServiceInstance` and remove the stub export |

### Change flow

#1559 left the class exported as a stub with no binding. This PR deletes the class.

```mermaid
sequenceDiagram
	actor Operator
	participant runtimeWorker as kody-runtime
	participant cloudflare as Cloudflare DO registry
	Operator->>runtimeWorker: merge this PR
	runtimeWorker->>cloudflare: apply v2 deleted_classes
	runtimeWorker->>cloudflare: stop exporting PackageServiceInstance
	Note over cloudflare: binding already gone after #1559
	cloudflare-->>runtimeWorker: class deleted
```

### Before / after

| | #1559 production | This PR |
| --- | --- | --- |
| Binding | absent | absent |
| Class export | stub | removed |
| Tag `v2` | omitted | `deleted_classes` |

### Invariants

Protected `v1` transfer / preview `new_sqlite_classes` stay unchanged. Do not edit `tools/ci/durable-object-baseline.json`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d38711-e9f1-4574-b52e-335fa9e48713?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d38711-e9f1-4574-b52e-335fa9e48713&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed cleanup of the retired package service during deployments.
  * Improved production and preview migration handling to safely remove obsolete runtime state.
  * Clarified deployment errors and migration requirements for preview environments.

* **Documentation**
  * Updated architecture and deployment guidance to reflect the revised package service deletion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->