### PR TITLE
docs: persist the Nx cache token on Cloud Agent environments

### DIFF
--- a/docs/contributing/cloud-agents.md
+++ b/docs/contributing/cloud-agents.md
@@ -41,8 +41,15 @@ manually with native `unzip`:
 ## Nx remote cache
 
 Validate and `test:push` write Nx task artifacts. Those stay local unless the
-self-hosted cache is configured. To share hits with GitHub Actions, set both in
-this VM (same values as the GitHub Actions secret / Worker secret):
+self-hosted cache is configured. GitHub Actions already enables
+`https://nx-cache.kody.codes` after `GET /health` succeeds. Agents only populate
+that cache when the same token lives on the Cursor Cloud **environment** (not
+just one shell). A one-off `export` does not persist to later runs, and Cloud
+Agents cannot read the GitHub Actions secret back.
+
+Set the server URL as an environment variable and the token as an environment
+secret (same value as repository secret
+`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`):
 
 ```bash
 export NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.kody.codes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Agents can populate the self-hosted Nx remote cache that GitHub Actions already hits, instead of only documenting a one-off `export` that dies with the VM.

## Summary

- Spell out that `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` belongs on the Cursor Cloud **environment** (same value as the GitHub Actions secret).
- A shell `export` in one agent run does not persist, and Cloud Agents cannot read the Actions secret back.
- Also set `NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.kody.codes` as an environment variable.

## Testing

- `npm run docs:check-temporal -- docs/contributing/cloud-agents.md`
- Process review evidence (2026-08-19): main validate `32246141579` and PR validate `32245675714` show `[remote cache]` hits (Workers/Static/MCP 100%; E2E 75%). This Cloud Agent VM has neither env var set.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `09f8faa` · **Head:** `15a8855`

**Classification:** composes — contributor docs only; no product primitives.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_ | — | Classifier matched no `primitives.yaml` roots. |

### System map

Docs tell operators to store the Nx cache token on the Cloud environment so agent runs can PUT the same artifacts CI already GETs.

**Legend:** green = composes (wiring only) · amber = extended by this PR · red = new primitive · gray = context (unchanged, included only when an edge crosses it).

```mermaid
flowchart LR
	agent["Cloud Agent validate"]:::touched
	gha["GitHub Actions validate"]:::touched
	nxCache["nx-cache.kody.codes"]:::untouched
	agent -->|"PUT when env token is set"| nxCache
	gha -->|"GET after /health"| nxCache
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c093569-b79d-4898-8907-76e37a3a853f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c093569-b79d-4898-8907-76e37a3a853f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

