### PR TITLE
fix(packages): refresh stale artifacts when publish is already_published

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
+++ b/packages/worker/src/mcp/capabilities/packages/publish-external-push.ts
@@ -549,6 +549,7 @@ async function runExternalPublishAttempt(input: {
 					userId: input.ownerUserId,
 					publishedCommit: result.published_commit,
 					baseUrl: input.baseUrl,
+					force: true,
 				})
 				const testHints = await getPublishedPackageTestHints({
 					env: input.env,

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -218,6 +218,52 @@ test('isolated rebuild skips already-built targets and does not stage when all a
 	expect(discard).not.toHaveBeenCalled()
 })
 
+test('force rebuilds already-built targets so already_published can repair stale same-commit artifacts', async () => {
+	resetMocks()
+	const run = vi.fn(async () => ({ ok: true, message: 'rebuilt' }))
+	const discard = vi.fn(async () => undefined)
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		touch: vi.fn(),
+		run,
+		discard,
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue(
+		sampleTargets,
+	)
+	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-1',
+	})
+	mockModule.isPublishedPackageArtifactBuiltForCommit.mockResolvedValue(true)
+
+	await rebuildPublishedPackageArtifactsViaRepoSession({
+		env: {
+			REPO_SESSION: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as unknown as Env,
+		rpcSessionId: 'session-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		baseUrl: 'https://kody.test',
+		force: true,
+	})
+
+	expect(
+		mockModule.isPublishedPackageArtifactBuiltForCommit,
+	).not.toHaveBeenCalled()
+	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
+		1,
+	)
+	expect(run).toHaveBeenCalledTimes(3)
+	expect(run).toHaveBeenCalledWith(
+		expect.objectContaining({
+			force: true,
+			target: sampleTargets[0],
+		}),
+	)
+	expect(discard).toHaveBeenCalledTimes(1)
+})
+
 test('rebuild failure stops later chunks and reports succeeded versus failed for isolated and fallback paths', async () => {
 	const targets = [
 		...sampleTargets,

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -106,7 +106,14 @@ async function filterTargetsNeedingRebuild(input: {
 	sourceId: string
 	publishedCommit: string
 	targets: ReadonlyArray<PublishedPackageArtifactBuildTarget>
+	force?: boolean
 }) {
+	if (input.force) {
+		return {
+			remaining: [...input.targets],
+			alreadyBuilt: [],
+		}
+	}
 	const remaining: Array<PublishedPackageArtifactBuildTarget> = []
 	const alreadyBuilt: Array<PublishedPackageArtifactBuildTarget> = []
 	for (const target of input.targets) {
@@ -162,6 +169,7 @@ async function rebuildPublishedPackageArtifactsOnSession(input: {
 	publishedCommit: string
 	baseUrl: string
 	targets: ReadonlyArray<PublishedPackageArtifactBuildTarget>
+	force?: boolean
 }) {
 	const session = repoSessionRpc(input.env, input.rpcSessionId)
 	const succeeded: Array<PublishedPackageArtifactBuildTarget> = []
@@ -171,6 +179,7 @@ async function rebuildPublishedPackageArtifactsOnSession(input: {
 		sourceId: input.sourceId,
 		publishedCommit: input.publishedCommit,
 		targets: input.targets,
+		force: input.force,
 	})
 	succeeded.push(...alreadyBuilt)
 
@@ -231,6 +240,7 @@ async function rebuildPublishedPackageArtifactsViaRepoSessionOnce(input: {
 	userId: string
 	publishedCommit: string
 	baseUrl: string
+	force?: boolean
 }) {
 	const session = repoSessionRpc(input.env, input.rpcSessionId)
 	const isolatedRunner = createIsolatedArtifactRebuildRunner(input.env)
@@ -266,6 +276,7 @@ async function rebuildPublishedPackageArtifactsViaRepoSessionOnce(input: {
 		sourceId: input.sourceId,
 		publishedCommit: input.publishedCommit,
 		targets,
+		force: input.force,
 	})
 	const succeeded: Array<PublishedPackageArtifactBuildTarget> = [
 		...alreadyBuilt,
@@ -317,6 +328,7 @@ async function rebuildPublishedPackageArtifactsViaRepoSessionOnce(input: {
 						publishedCommit: input.publishedCommit,
 						target,
 						baseUrl: input.baseUrl,
+						force: input.force,
 					})
 					if (!outcome.ok) {
 						throw new Error(outcome.message)
@@ -360,6 +372,7 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 	userId: string
 	publishedCommit: string
 	baseUrl: string
+	force?: boolean
 }) {
 	const maxAttempts = publishedPackageArtifactRebuildRetryDelaysMs.length + 1
 	let lastTransientError: unknown = null

--- a/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
@@ -460,6 +460,57 @@ test('an artifact rebuild resolves its entry point from the fresh source, not th
 	expect(rebuilt.entryPoint).toBe('src/probe-v2.ts')
 })
 
+test('ensureModuleArtifact rebuilds when the identity artifact is for a different commit', async () => {
+	const fixture = createFixture({
+		userId: 'user-stale-artifact',
+		publishedCommit: 'commit-new',
+		suffix: 'stale-artifact',
+	})
+	mockModule.getEntitySourceById.mockResolvedValue(fixture.source)
+	mockModule.loadPublishedEntityManifest.mockResolvedValue({
+		source: fixture.source,
+		content: fixture.manifestContent,
+	})
+	mockModule.loadPublishedEntitySource.mockResolvedValue({
+		source: fixture.source,
+		files: {
+			'package.json': fixture.manifestContent,
+			'src/get-issue-state.ts':
+				'export default async function main() { return "new" }',
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity
+		.mockResolvedValueOnce({
+			row: { publishedCommit: 'commit-old' },
+			artifact: { ...fixture.artifact, publishedCommit: 'commit-old' },
+		})
+		.mockResolvedValueOnce({
+			row: { publishedCommit: 'commit-new' },
+			artifact: fixture.artifact,
+		})
+	mockModule.typecheckPackageEntrypointsFromSourceFiles.mockResolvedValue({
+		ok: true,
+	})
+	mockModule.buildKodyModuleBundle.mockResolvedValue({
+		mainModule: 'main.js',
+		modules: { 'main.js': 'export default async () => ({ ok: true })' },
+		dependencies: [],
+		dynamicDependencies: [],
+	})
+	mockModule.persistPublishedBundleArtifact.mockResolvedValue('kv-key')
+
+	const rebuilt = await ensureModuleArtifact({
+		env: createEnv(),
+		baseUrl: 'https://kody.dev',
+		savedPackage: fixture.savedPackage,
+		selector: { kind: 'export', exportName: 'get-issue-state' },
+		userId: fixture.savedPackage.userId,
+	})
+
+	expect(mockModule.persistPublishedBundleArtifact).toHaveBeenCalledTimes(1)
+	expect(rebuilt.artifact.publishedCommit).toBe('commit-new')
+})
+
 test('an artifact from a different commit is served but never retained', async () => {
 	const load = vi.fn(async () => ({
 		artifact: { publishedCommit: 'commit-old' } as never,

--- a/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
+++ b/packages/worker/src/package-invocations/invoke-contract-cache.node.test.ts
@@ -193,7 +193,13 @@ function seedFixtures(fixturesByUserId: Record<string, Fixture>) {
 				(candidate) => candidate.source.id === input.sourceId,
 			)
 			if (!fixture) return null
-			return { row: { kvKey: 'kv-key' }, artifact: fixture.artifact }
+			return {
+				row: {
+					kvKey: 'kv-key',
+					publishedCommit: fixture.artifact.publishedCommit,
+				},
+				artifact: fixture.artifact,
+			}
 		},
 	)
 }
@@ -497,6 +503,58 @@ test('ensureModuleArtifact rebuilds when the identity artifact is for a differen
 		dependencies: [],
 		dynamicDependencies: [],
 	})
+	mockModule.persistPublishedBundleArtifact.mockResolvedValue('kv-key')
+
+	const rebuilt = await ensureModuleArtifact({
+		env: createEnv(),
+		baseUrl: 'https://kody.dev',
+		savedPackage: fixture.savedPackage,
+		selector: { kind: 'export', exportName: 'get-issue-state' },
+		userId: fixture.savedPackage.userId,
+	})
+
+	expect(mockModule.persistPublishedBundleArtifact).toHaveBeenCalledTimes(1)
+	expect(rebuilt.artifact.publishedCommit).toBe('commit-new')
+})
+
+test('ensureModuleArtifact rebuilds when the identity row is missing a published commit', async () => {
+	const fixture = createFixture({
+		userId: 'user-null-row',
+		publishedCommit: 'commit-new',
+		suffix: 'null-row',
+	})
+	mockModule.getEntitySourceById.mockResolvedValue(fixture.source)
+	mockModule.loadPublishedEntityManifest.mockResolvedValue({
+		source: fixture.source,
+		content: fixture.manifestContent,
+	})
+	mockModule.loadPublishedEntitySource.mockResolvedValue({
+		source: fixture.source,
+		files: {
+			'package.json': fixture.manifestContent,
+			'src/get-issue-state.ts':
+				'export default async function main() { return "new" }',
+		},
+	})
+	mockModule.loadPublishedBundleArtifactByIdentity
+		.mockResolvedValueOnce({
+			row: { publishedCommit: null },
+			artifact: fixture.artifact,
+		})
+		.mockResolvedValueOnce({
+			row: { publishedCommit: 'commit-new' },
+			artifact: fixture.artifact,
+		})
+	mockModule.typecheckPackageEntrypointsFromSourceFiles.mockResolvedValue({
+		ok: true,
+	})
+	mockModule.buildKodyModuleBundle.mockResolvedValue({
+		mainModule: 'main.js',
+		modules: { 'main.js': 'export default async () => ({ ok: true })' },
+		dependencies: [],
+		dynamicDependencies: [],
+	})
+	mockModule.persistPublishedBundleArtifact.mockReset()
 	mockModule.persistPublishedBundleArtifact.mockResolvedValue('kv-key')
 
 	const rebuilt = await ensureModuleArtifact({

--- a/packages/worker/src/package-invocations/module-artifacts.ts
+++ b/packages/worker/src/package-invocations/module-artifacts.ts
@@ -151,8 +151,7 @@ async function ensureModuleArtifactUncached(input: {
 	if (
 		loaded?.artifact &&
 		loaded.artifact.publishedCommit === currentPublishedCommit &&
-		(loaded.row.publishedCommit == null ||
-			loaded.row.publishedCommit === currentPublishedCommit)
+		loaded.row.publishedCommit === currentPublishedCommit
 	) {
 		return {
 			artifact: loaded.artifact,

--- a/packages/worker/src/package-invocations/module-artifacts.ts
+++ b/packages/worker/src/package-invocations/module-artifacts.ts
@@ -147,7 +147,13 @@ async function ensureModuleArtifactUncached(input: {
 		artifactName: resolution.artifactName,
 		entryPoint: resolution.entryPoint,
 	})
-	if (loaded?.artifact) {
+	const currentPublishedCommit = packageManifest.source.published_commit
+	if (
+		loaded?.artifact &&
+		loaded.artifact.publishedCommit === currentPublishedCommit &&
+		(loaded.row.publishedCommit == null ||
+			loaded.row.publishedCommit === currentPublishedCommit)
+	) {
 		return {
 			artifact: loaded.artifact,
 			source: packageManifest.source,

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -623,6 +623,7 @@ function seedPackageResolution() {
 	repoMockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue({
 		row: {
 			id: 'artifact-1',
+			publishedCommit: 'commit-1',
 		},
 		artifact: {
 			version: 1,
@@ -739,6 +740,7 @@ function createModuleArtifact(input: {
 	return {
 		row: {
 			id: `artifact-${input.packageContext.packageId}`,
+			publishedCommit: input.publishedCommit,
 		},
 		artifact: {
 			version: 1,
@@ -2594,6 +2596,7 @@ test('invokePackageSubscription uses the normal capability registry with package
 	repoMockModule.loadPublishedBundleArtifactByIdentity.mockResolvedValue({
 		row: {
 			id: 'artifact-subscription-1',
+			publishedCommit: 'commit-1',
 		},
 		artifact: {
 			version: 1,

--- a/packages/worker/src/repo/external-publish-clone.node.test.ts
+++ b/packages/worker/src/repo/external-publish-clone.node.test.ts
@@ -88,9 +88,17 @@ test('cloneExternalPublishWorkspace clones into ephemeral FS and exposes publish
 	).resolves.toBe(true)
 
 	await cloned.filesystem.writeFile('/repo/package.json', '{"name":"@kody/x"}')
+	await cloned.filesystem.writeFile(
+		'/repo/src/index.ts',
+		'export const ok = true\n',
+	)
 	await expect(cloned.workspace.readFile('/repo/package.json')).resolves.toBe(
 		'{"name":"@kody/x"}',
 	)
+	await expect(cloned.collectFiles()).resolves.toEqual({
+		'package.json': '{"name":"@kody/x"}',
+		'src/index.ts': 'export const ok = true\n',
+	})
 	const globbed = await cloned.workspace.glob('**/*')
 	expect(globbed).toEqual([
 		{ path: '/repo/package.json', type: 'file' },

--- a/packages/worker/src/repo/external-publish-clone.ts
+++ b/packages/worker/src/repo/external-publish-clone.ts
@@ -32,12 +32,34 @@ export type ExternalPublishCloneResult = {
 	}) => Promise<boolean>
 	filesystem: PublishGitNoteFileSystem
 	dir: string
+	collectFiles(): Promise<Record<string, string>>
 }
 
 function normalizePublishPath(path: string) {
 	const trimmed = path.trim()
 	if (trimmed === '' || trimmed === '/') return '/'
 	return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+async function collectPublishWorkspaceFiles(input: {
+	workspace: RepoPublishWorkspace
+	dir: string
+	listFiles: () => Promise<Array<string>>
+}) {
+	const dirPrefix = input.dir.endsWith('/') ? input.dir.slice(0, -1) : input.dir
+	const files: Record<string, string> = {}
+	for (const relative of await input.listFiles()) {
+		if (relative.split('/').includes('.git')) continue
+		const absolute = `${dirPrefix}/${relative}`.replace(/\/+/g, '/')
+		const content = await input.workspace.readFile(absolute)
+		if (content == null) {
+			throw new Error(
+				`Failed to read published clone file "${absolute}" while refreshing the source snapshot.`,
+			)
+		}
+		files[relative] = content
+	}
+	return files
 }
 
 function buildPublishWorkspaceFromCheckout(input: {
@@ -169,14 +191,15 @@ export async function cloneExternalPublishWorkspace(input: {
 		)
 	}
 
+	const listFiles = async () =>
+		await git.listFiles({
+			fs: workspace.fs,
+			dir,
+		})
 	const publishWorkspace = buildPublishWorkspaceFromCheckout({
 		dir,
 		filesystem: workspace.filesystem,
-		listFiles: async () =>
-			await git.listFiles({
-				fs: workspace.fs,
-				dir,
-			}),
+		listFiles,
 	})
 
 	return {
@@ -184,6 +207,12 @@ export async function cloneExternalPublishWorkspace(input: {
 		headCommit,
 		dir,
 		filesystem: workspace.filesystem,
+		collectFiles: async () =>
+			await collectPublishWorkspaceFiles({
+				workspace: publishWorkspace,
+				dir,
+				listFiles,
+			}),
 		isAncestorCommit: async ({ ancestor, descendant }) => {
 			if (ancestor === descendant) return true
 			const commits = await git.log({

--- a/packages/worker/src/repo/isolated-artifact-rebuild.ts
+++ b/packages/worker/src/repo/isolated-artifact-rebuild.ts
@@ -35,6 +35,12 @@ export type IsolatedArtifactRebuildRequest = {
 	publishedCommit: string
 	target: PublishedPackageArtifactBuildTarget
 	baseUrl?: string
+	/**
+	 * Rebuild even when a same-commit artifact already exists. Used by
+	 * `already_published` so a leftover workspace-built bundle cannot keep
+	 * serving after D1 already points at HEAD.
+	 */
+	force?: boolean
 }
 
 /**

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -2526,3 +2526,72 @@ test('already_published external publish refreshes the snapshot from the in-memo
 		}),
 	)
 })
+
+test('already_published external publish fails when snapshot refresh fails', async () => {
+	restoreRepoSessionMockBaseline()
+	setCommonSessionFixtures()
+	consoleWarn.mockImplementation(() => {})
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		repo_id: 'source-repo',
+		published_commit: 'commit-new',
+		manifest_path: 'package.json',
+		source_root: '/',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+	})
+	mockModule.cloneExternalPublishWorkspace.mockResolvedValueOnce({
+		workspace: {
+			readFile: vi.fn(async () => null),
+			glob: vi.fn(async () => []),
+		},
+		headCommit: 'commit-new',
+		dir: '/repo',
+		filesystem: {
+			readFile: vi.fn(async () => ''),
+			readFileBytes: vi.fn(async () => new Uint8Array()),
+			writeFile: vi.fn(async () => undefined),
+			writeFileBytes: vi.fn(async () => undefined),
+			rm: vi.fn(async () => undefined),
+			mkdir: vi.fn(async () => undefined),
+			readdir: vi.fn(async () => []),
+			stat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			lstat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			readlink: vi.fn(async () => ''),
+			symlink: vi.fn(async () => undefined),
+		},
+		isAncestorCommit: vi.fn(async () => true),
+		collectFiles: vi.fn(async () => {
+			throw new Error('clone files unreadable')
+		}),
+	})
+
+	const repoSession = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {} as KVNamespace,
+	} as Env)
+	await expect(
+		repoSession.publishFromExternalRef({
+			sessionId: 'external-publish-source-1',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			newCommit: 'commit-new',
+		}),
+	).rejects.toThrow('clone files unreadable')
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+	expect(consoleWarn).toHaveBeenCalledWith(
+		'already_published snapshot refresh failed',
+		expect.objectContaining({
+			scope: 'repo.publishFromExternalRef.refresh-already-published-snapshot',
+		}),
+	)
+})

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -2150,9 +2150,9 @@ test('runIsolatedArtifactRebuild loads staged files, skips built targets, and re
 		kvKey: 'kv:artifact',
 		target,
 	})
-	expect(mockModule.persistPublishedPackageArtifactTarget).toHaveBeenCalledTimes(
-		1,
-	)
+	expect(
+		mockModule.persistPublishedPackageArtifactTarget,
+	).toHaveBeenCalledTimes(1)
 
 	const rebuilt = await session.runIsolatedArtifactRebuild({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:abc',
@@ -2385,7 +2385,8 @@ test('published artifact rebuild prefers the published snapshot over a leftover 
 		if (path === '/session/package.json') {
 			return '{"name":"@kody/stale","exports":{".":"./index.ts"},"kody":{"id":"stale","description":"Stale"}}'
 		}
-		if (path === '/session/index.ts') return 'export const fromWorkspace = true\n'
+		if (path === '/session/index.ts')
+			return 'export const fromWorkspace = true\n'
 		return null
 	})
 	mockModule.loadPublishedSourceManifestSnapshot.mockResolvedValue({

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -115,6 +115,7 @@ const mockModule = vi.hoisted(() => {
 				symlink: vi.fn(async () => undefined),
 			},
 			isAncestorCommit: vi.fn(async () => true),
+			collectFiles: vi.fn(async () => ({})),
 		})),
 		storageGet: vi.fn(async () => ({
 			runId: 'run-1',
@@ -219,6 +220,7 @@ function restoreRepoSessionMockBaseline() {
 			symlink: vi.fn(async () => undefined),
 		},
 		isAncestorCommit: vi.fn(async () => true),
+		collectFiles: vi.fn(async () => ({})),
 	}))
 	mockModule.storageGet.mockResolvedValue({
 		runId: 'run-1',
@@ -2134,6 +2136,24 @@ test('runIsolatedArtifactRebuild loads staged files, skips built targets, and re
 		mockModule.persistPublishedPackageArtifactTarget,
 	).not.toHaveBeenCalled()
 
+	const forced = await session.runIsolatedArtifactRebuild({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:abc',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		target,
+		baseUrl: 'https://kody.test',
+		force: true,
+	})
+	expect(forced).toMatchObject({
+		ok: true,
+		kvKey: 'kv:artifact',
+		target,
+	})
+	expect(mockModule.persistPublishedPackageArtifactTarget).toHaveBeenCalledTimes(
+		1,
+	)
+
 	const rebuilt = await session.runIsolatedArtifactRebuild({
 		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:abc',
 		sourceId: 'source-1',
@@ -2333,4 +2353,175 @@ test('published artifact rebuild falls back to the published snapshot when the s
 	expect(
 		staged.stagingKey.startsWith('repo-artifact-rebuild-staging:v1:user-1:'),
 	).toBe(true)
+})
+
+test('published artifact rebuild prefers the published snapshot over a leftover session workspace', async () => {
+	restoreRepoSessionMockBaseline()
+	const snapshotFiles = {
+		'package.json':
+			'{"name":"@kody/demo","exports":{".":"./index.ts"},"kody":{"id":"demo","description":"Demo"}}',
+		'index.ts': 'export const fromSnapshot = true\n',
+	}
+	const packageSource = {
+		id: 'source-1',
+		user_id: 'user-1',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+		repo_id: 'package-package-1',
+		published_commit: 'commit-1',
+		indexed_commit: null,
+		manifest_path: 'package.json',
+		source_root: '/',
+		last_external_check_at: null,
+		external_check_until: null,
+		created_at: '2026-04-18T00:00:00.000Z',
+		updated_at: '2026-04-18T00:00:00.000Z',
+	}
+	mockModule.workspaceGlob.mockResolvedValue([
+		{ type: 'file', path: '/session/package.json' },
+		{ type: 'file', path: '/session/index.ts' },
+	] as unknown as Array<{ type: 'file'; path: string }>)
+	mockModule.workspaceReadFile.mockImplementation(async (path: string) => {
+		if (path === '/session/package.json') {
+			return '{"name":"@kody/stale","exports":{".":"./index.ts"},"kody":{"id":"stale","description":"Stale"}}'
+		}
+		if (path === '/session/index.ts') return 'export const fromWorkspace = true\n'
+		return null
+	})
+	mockModule.loadPublishedSourceManifestSnapshot.mockResolvedValue({
+		version: 1,
+		sourceId: 'source-1',
+		publishedCommit: 'commit-1',
+		manifestPath: 'package.json',
+		manifestContent: snapshotFiles['package.json'],
+		createdAt: '2026-08-19T15:00:00.000Z',
+	})
+	mockModule.loadPublishedSourceSnapshot.mockResolvedValue({
+		version: 1,
+		sourceId: 'source-1',
+		repoId: 'package-package-1',
+		entityKind: 'package',
+		entityId: 'package-1',
+		publishedCommit: 'commit-1',
+		manifestPath: 'package.json',
+		sourceRoot: '/',
+		files: snapshotFiles,
+		createdAt: '2026-08-19T15:00:00.000Z',
+	})
+	mockModule.getEntitySourceById.mockResolvedValue(packageSource)
+
+	const listSession = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+	} as unknown as Env)
+	await expect(
+		listSession.listPublishedPackageArtifactTargets({
+			sourceId: 'source-1',
+			userId: 'user-1',
+		}),
+	).resolves.toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				kind: 'module',
+				artifactName: '.',
+				entryPoint: 'index.ts',
+			}),
+		]),
+	)
+	expect(mockModule.loadPublishedSourceManifestSnapshot).toHaveBeenCalledTimes(
+		1,
+	)
+	expect(mockModule.workspaceReadFile).not.toHaveBeenCalled()
+
+	const put = vi.fn(async () => undefined)
+	const stageSession = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: { put },
+	} as unknown as Env)
+	await stageSession.stagePublishedPackageArtifactRebuild({
+		sourceId: 'source-1',
+		userId: 'user-1',
+	})
+	const payload = JSON.parse(put.mock.calls[0]?.[1] as string) as {
+		sourceFiles: Record<string, string>
+	}
+	expect(payload.sourceFiles).toEqual(snapshotFiles)
+	expect(mockModule.workspaceGlob).not.toHaveBeenCalled()
+})
+
+test('already_published external publish refreshes the snapshot from the in-memory clone', async () => {
+	restoreRepoSessionMockBaseline()
+	setCommonSessionFixtures()
+	mockModule.getEntitySourceById.mockResolvedValue({
+		id: 'source-1',
+		user_id: 'user-1',
+		repo_id: 'source-repo',
+		published_commit: 'commit-new',
+		manifest_path: 'package.json',
+		source_root: '/',
+		entity_kind: 'package',
+		entity_id: 'package-1',
+	})
+	const cloneFiles = {
+		'package.json':
+			'{"name":"@kody/demo","exports":{".":"./index.ts"},"kody":{"id":"demo","description":"Demo"}}',
+		'index.ts': 'export const fromClone = true\n',
+	}
+	const collectFiles = vi.fn(async () => cloneFiles)
+	mockModule.cloneExternalPublishWorkspace.mockResolvedValueOnce({
+		workspace: {
+			readFile: vi.fn(async () => null),
+			glob: vi.fn(async () => []),
+		},
+		headCommit: 'commit-new',
+		dir: '/repo',
+		filesystem: {
+			readFile: vi.fn(async () => ''),
+			readFileBytes: vi.fn(async () => new Uint8Array()),
+			writeFile: vi.fn(async () => undefined),
+			writeFileBytes: vi.fn(async () => undefined),
+			rm: vi.fn(async () => undefined),
+			mkdir: vi.fn(async () => undefined),
+			readdir: vi.fn(async () => []),
+			stat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			lstat: vi.fn(async () => ({
+				type: 'file' as const,
+				size: 0,
+				mtime: new Date(),
+			})),
+			readlink: vi.fn(async () => ''),
+			symlink: vi.fn(async () => undefined),
+		},
+		isAncestorCommit: vi.fn(async () => true),
+		collectFiles,
+	})
+	mockModule.writePublishedSourceSnapshot.mockClear()
+
+	const repoSession = new RepoSession(createDurableObjectState(), {
+		APP_DB: {},
+		BUNDLE_ARTIFACTS_KV: {} as KVNamespace,
+	} as Env)
+	const result = await repoSession.publishFromExternalRef({
+		sessionId: 'external-publish-source-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		newCommit: 'commit-new',
+	})
+
+	expect(result).toEqual({
+		status: 'already_published',
+		published_commit: 'commit-new',
+	})
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.runRepoChecks).not.toHaveBeenCalled()
+	expect(collectFiles).toHaveBeenCalledTimes(1)
+	expect(mockModule.writePublishedSourceSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({
+			source: expect.objectContaining({ published_commit: 'commit-new' }),
+			files: cloneFiles,
+		}),
+	)
 })

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -40,8 +40,10 @@ import {
 	type PublishedPackageArtifactBuildTarget,
 } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import {
+	hasPublishedRuntimeArtifacts,
 	loadPublishedSourceManifestSnapshot,
 	loadPublishedSourceSnapshot,
+	writePublishedSourceSnapshot,
 } from '#worker/package-runtime/published-runtime-artifacts.ts'
 import { searchRepoWorkspace } from './repo-session-search.ts'
 import { repoSessionRpc as createRepoSessionRpc } from './repo-session-rpc.ts'
@@ -806,25 +808,14 @@ class RepoSessionBase extends DurableObject<Env> {
 
 	/**
 	 * External publish (KODY-CLOUDFLARE-57) clones into ephemeral FS and never
-	 * populates the session Durable Object workspace. Artifact rebuild then
-	 * runs against that empty session, so listing and staging must fall back
-	 * to the published source snapshot written during finalize.
+	 * populates the session Durable Object workspace. The long-lived
+	 * `external-publish-${sourceId}` DO can still hold a leftover workspace
+	 * from an older clone or initialize(), so listing and staging must prefer
+	 * the published source snapshot written from that in-memory clone.
 	 */
 	private async readPackageManifestForPublishedArtifacts(
 		source: EntitySourceRow,
 	) {
-		const workspaceContent = await this.workspace.readFile(
-			resolveRepoWorkspacePath(
-				source.manifest_path,
-				repoSessionWorkspacePrefix,
-			),
-		)
-		if (typeof workspaceContent === 'string') {
-			return parseAuthoredPackageJson({
-				content: workspaceContent,
-				manifestPath: source.manifest_path,
-			})
-		}
 		const manifestSnapshot = await loadPublishedSourceManifestSnapshot({
 			env: this.env,
 			userId: source.user_id,
@@ -848,16 +839,24 @@ class RepoSessionBase extends DurableObject<Env> {
 				manifestPath: source.manifest_path,
 			})
 		}
+		const workspaceContent = await this.workspace.readFile(
+			resolveRepoWorkspacePath(
+				source.manifest_path,
+				repoSessionWorkspacePrefix,
+			),
+		)
+		if (typeof workspaceContent === 'string') {
+			return parseAuthoredPackageJson({
+				content: workspaceContent,
+				manifestPath: source.manifest_path,
+			})
+		}
 		throw new Error(`Manifest "${source.manifest_path}" was not found.`)
 	}
 
 	private async collectSourceFilesForPublishedArtifactRebuild(
 		source: EntitySourceRow,
 	) {
-		const workspaceFiles = await this.collectWorkspaceFiles()
-		if (typeof workspaceFiles[source.manifest_path] === 'string') {
-			return workspaceFiles
-		}
 		const snapshot = await loadPublishedSourceSnapshot({
 			env: this.env,
 			userId: source.user_id,
@@ -865,6 +864,10 @@ class RepoSessionBase extends DurableObject<Env> {
 		})
 		if (snapshot && typeof snapshot.files[source.manifest_path] === 'string') {
 			return snapshot.files
+		}
+		const workspaceFiles = await this.collectWorkspaceFiles()
+		if (typeof workspaceFiles[source.manifest_path] === 'string') {
+			return workspaceFiles
 		}
 		throw new Error(`Manifest "${source.manifest_path}" was not found.`)
 	}
@@ -2290,13 +2293,15 @@ class RepoSessionBase extends DurableObject<Env> {
 				target: input.target,
 			}
 		}
-		const alreadyBuilt = await isPublishedPackageArtifactBuiltForCommit({
-			env: this.env,
-			userId: input.userId,
-			sourceId: input.sourceId,
-			publishedCommit: input.publishedCommit,
-			target: input.target,
-		})
+		const alreadyBuilt =
+			!input.force &&
+			(await isPublishedPackageArtifactBuiltForCommit({
+				env: this.env,
+				userId: input.userId,
+				sourceId: input.sourceId,
+				publishedCommit: input.publishedCommit,
+				target: input.target,
+			}))
 		if (alreadyBuilt) {
 			return {
 				ok: true,
@@ -2821,7 +2826,47 @@ class RepoSessionBase extends DurableObject<Env> {
 			rebuildPackageArtifacts: input.rebuildPackageArtifacts ?? true,
 			expectedPackageScope: input.expectedPackageScope,
 		})
-		if (publishResult.status === 'published') {
+		if (publishResult.status === 'already_published') {
+			// D1 stays a no-op (overlapping inline + durable escalation). Still
+			// rewrite the KV snapshot from the just-cloned HEAD so a prior
+			// finalize that tagged the current commit with stale files cannot
+			// keep winning artifact rebuilds.
+			try {
+				if (
+					publishResult.published_commit &&
+					hasPublishedRuntimeArtifacts(this.env)
+				) {
+					const files = await publishClone.collectFiles()
+					if (typeof files[source.manifest_path] === 'string') {
+						await writePublishedSourceSnapshot({
+							env: this.env,
+							source: {
+								...source,
+								published_commit: publishResult.published_commit,
+							},
+							files,
+						})
+					}
+				}
+			} catch (error) {
+				Sentry.captureException(error, {
+					tags: {
+						scope: 'repo.publishFromExternalRef.refresh-already-published-snapshot',
+					},
+					extra: {
+						sourceId: source.id,
+						commit: input.newCommit,
+					},
+				})
+				console.warn('already_published snapshot refresh failed', {
+					scope:
+						'repo.publishFromExternalRef.refresh-already-published-snapshot',
+					sourceId: source.id,
+					commit: input.newCommit,
+					error: getErrorMessage(error),
+				})
+			}
+		} else if (publishResult.status === 'published') {
 			try {
 				const sourceWriteAccess = await ensureArtifactRepoRemote({
 					repo: sourceRepo,

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -2866,6 +2866,7 @@ class RepoSessionBase extends DurableObject<Env> {
 					commit: input.newCommit,
 					error: getErrorMessage(error),
 				})
+				throw error
 			}
 		} else if (publishResult.status === 'published') {
 			try {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -2851,7 +2851,8 @@ class RepoSessionBase extends DurableObject<Env> {
 			} catch (error) {
 				Sentry.captureException(error, {
 					tags: {
-						scope: 'repo.publishFromExternalRef.refresh-already-published-snapshot',
+						scope:
+							'repo.publishFromExternalRef.refresh-already-published-snapshot',
 					},
 					extra: {
 						sourceId: source.id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop package jobs and `packages.invoke` from executing an old published bundle after `package_publish_external_push` reports `already_published` and D1 already points at HEAD.

Morning-briefing's `daily-morning-briefing` job and `run-morning-briefing` export kept throwing `Missing morningBriefingDiscordChannelId value` (commit `5fd5d3b`) while `published_commit` was `a78fc5e` (and earlier `430c732`). `job_get includeCode` already showed the new entrypoint; the identity-row bundle did not.

## Summary

- `already_published` still leaves D1 alone (overlapping inline + durable publish stays safe).
- It now rewrites the published source snapshot from the in-memory Artifacts clone.
- Artifact rebuild prefers that snapshot over a leftover `external-publish-${sourceId}` RepoSession workspace.
- `already_published` force-rebuilds same-commit bundles instead of skipping them as fresh.
- Snapshot refresh failure now fails the publish (no leftover-workspace force rebuild).
- `packages.invoke` rebuilds unless both the identity-row and artifact commits match the source row.

After this deploys, one `package_publish_external_push` on `morning-briefing` is enough to repair the live artifacts.

## Testing

- `vitest` on `external-publish-clone`, `repo-session-do`, `package-artifact-rebuild`, `publish-external-push`, `invoke-contract-cache`, and `package-invocations/service`.
- Added coverage for null identity-row `publishedCommit` (must rebuild) and `already_published` snapshot-refresh failure (must throw).
- Invoke service fixtures now include matching identity-row `publishedCommit` so reuse stays on the mocked happy path.
- Production evidence before the fix: job `package-job:630292e1-…:daily-morning-briefing` at `a78fc5e` still threw the `5fd5d3b` string; snapshot entrypoint did not contain it.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `4cd83b61` · **Head:** `ab64a881`

**Classification:** extends — `already_published` publish repair and invoke artifact freshness change behavior of existing package publish / repo-session primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — `already_published` force-rebuilds artifacts |
| `repo-sessions` | runtime | extends — snapshot-first rebuild files; clone snapshot refresh; refresh failure fails the publish |
| `capability-registry` | assistant | extends — rebuild orchestrator honors `force` |
| unmatched `package-invocations/` | runtime | extends — invoke requires identity-row `publishedCommit` to equal the source row |

### Change flow

`already_published` now refreshes the KV snapshot from the in-memory clone and force-rebuilds bundles from that snapshot. A failed snapshot refresh no longer continues into a leftover-workspace rebuild.

```mermaid
sequenceDiagram
	actor caller as agent
	participant savedPackages as saved-packages
	participant repoSessions as repo-sessions
	participant kv as bundle-artifacts-kv
	caller->>savedPackages: package_publish_external_push
	savedPackages->>repoSessions: clone HEAD (in-memory)
	alt D1 published_commit already equals HEAD
		repoSessions->>kv: rewrite source snapshot from clone
		alt snapshot refresh fails
			repoSessions-->>savedPackages: throw after Sentry/warn
		else snapshot rewritten
			savedPackages->>repoSessions: force rebuild artifacts from snapshot
			repoSessions->>kv: overwrite same-commit job/export bundles
		end
	else new commit
		repoSessions->>kv: finalize snapshot then rebuild
	end
	Note over savedPackages: invoke rebuilds unless identity row and artifact commits both equal the source row
```

### Invariants

Per-user isolation is unchanged. `already_published` still does not double-apply D1 `published_commit` writes.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1931eace-96f3-4a37-ba3e-3e3da258fdf4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1931eace-96f3-4a37-ba3e-3e3da258fdf4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Published packages now rebuild artifacts when existing artifacts are stale or require a forced refresh.
  * Artifact reuse validates commit information to prevent outdated artifacts from being served.
  * Published source snapshots take precedence over outdated workspace files.
  * Already-published external packages refresh source snapshots from the latest cloned content, with refresh failures reported without altering the source record.

* **Tests**
  * Added coverage for forced rebuilds, stale artifact replacement, snapshot precedence, external workspace file collection, and refresh failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->