### PR TITLE
Add a dispatchable Nx cache worker redeploy

### DIFF
--- a/.github/actions/setup-validate/action.yml
+++ b/.github/actions/setup-validate/action.yml
@@ -48,14 +48,29 @@ runs:
       if: env.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN != ''
       shell: bash
       run: |
+        set -euo pipefail
         server='https://nx-cache.kody.codes'
-        if curl -fsS --max-time 5 "$server/health" >/dev/null; then
-          echo "NX_SELF_HOSTED_REMOTE_CACHE_SERVER=$server" >> "$GITHUB_ENV"
-          echo "Nx remote cache enabled ($server)"
-        else
+        if ! curl -fsS --max-time 5 "$server/health" >/dev/null; then
           echo "Nx remote cache skipped: $server/health is unreachable."
           echo "Validate will use local .nx + actions/cache until the worker is deployed."
+          exit 0
         fi
+        # Nx treats a configured-but-unauthorized cache as fatal. Probe a
+        # missing hash so a rotated GitHub secret that has not been synced
+        # to the worker falls back to local cache instead of failing validate.
+        probe_status="$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+          --header "Authorization: Bearer ${NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN}" \
+          "$server/v1/cache/0000000000000000" || true)"
+        case "$probe_status" in
+          200|404)
+            echo "NX_SELF_HOSTED_REMOTE_CACHE_SERVER=$server" >> "$GITHUB_ENV"
+            echo "Nx remote cache enabled ($server)"
+            ;;
+          *)
+            echo "Nx remote cache skipped: $server rejected cache auth (HTTP ${probe_status:-curl-error})."
+            echo "Validate will use local .nx + actions/cache until the worker secret matches."
+            ;;
+        esac
 
     - name: 📥 Install Dependencies
       shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,7 @@ jobs:
           fi
 
           if git diff --name-only "${DEPLOY_SHA}^" "${DEPLOY_SHA}" | grep -E \
-            '^(\.github/workflows/deploy\.yml|tools/ci/nx-cache-resources|packages/nx-cache/)'; then
+            '^(\.github/workflows/deploy\.yml|\.github/workflows/nx-cache-deploy\.yml|tools/ci/nx-cache-resources|packages/nx-cache/)'; then
             echo "deploy_nx_cache_worker=true" >> "$GITHUB_OUTPUT"
             echo "Nx cache worker deploy: path filter matched."
           else
@@ -893,121 +893,11 @@ jobs:
           done
 
   deploy-nx-cache-worker:
-    runs-on: ubuntu-latest
-    name: 🧊 Deploy Nx cache worker
-    timeout-minutes: 8
     needs: sha-guard
     if: >-
       needs.sha-guard.outputs.should_deploy == 'true' &&
       needs.sha-guard.outputs.deploy_nx_cache_worker == 'true'
-    environment:
-      name: production
-      url: https://nx-cache.kody.codes
-    steps:
-      - name: 📦 Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          ref: ${{ needs.sha-guard.outputs.deploy_sha }}
-          fetch-depth: 0
-
-      - name: 🟢 Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 26
-          cache: npm
-
-      - name: 📥 Install Dependencies
-        run: npm ci
-
-      - name: 🧱 Ensure Nx cache R2 bucket and lifecycle
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-        run: node tools/ci/nx-cache-resources.ts
-
-      - name: ☁️ Deploy Nx cache worker
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          DEPLOY_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
-          CACHE_ACCESS_TOKEN:
-            ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${CACHE_ACCESS_TOKEN:-}" ]; then
-            echo "Skipping Nx cache worker deploy: repository secret" >&2
-            echo "NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN is not set." >&2
-            echo "Generate one with: openssl rand -hex 32" >&2
-            exit 0
-          fi
-
-          deploy_attempts=3
-          deploy_delay_seconds=10
-          for attempt in $(seq 1 "$deploy_attempts"); do
-            echo "Nx cache worker deploy attempt $attempt/$deploy_attempts"
-            set +e
-            npm run nx-cache:deploy -- \
-              --var "BUILD_COMMIT:${DEPLOY_COMMIT_SHA}" 2>&1 | tee nx-cache-deploy.log
-            deploy_status="${PIPESTATUS[0]}"
-            set -e
-            if [ "$deploy_status" -eq 0 ]; then
-              break
-            fi
-            if [ "$attempt" -eq "$deploy_attempts" ]; then
-              echo "Nx cache worker deploy failed after $deploy_attempts attempts." >&2
-              exit "$deploy_status"
-            fi
-            echo "Retrying in ${deploy_delay_seconds}s."
-            sleep "$deploy_delay_seconds"
-            deploy_delay_seconds=$((deploy_delay_seconds * 2))
-          done
-
-      - name: 🔐 Sync Nx cache access token
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          CACHE_ACCESS_TOKEN:
-            ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${CACHE_ACCESS_TOKEN:-}" ]; then
-            echo "Skipping Nx cache secret sync: token is not set."
-            exit 0
-          fi
-          node tools/ci/sync-worker-secrets.ts --env "" --config \
-            packages/nx-cache/wrangler.jsonc --name kody-nx-cache \
-            --set-from-env CACHE_ACCESS_TOKEN
-
-      - name: 🩺 Healthcheck (Nx cache worker)
-        shell: bash
-        env:
-          EXPECTED_COMMIT_SHA: ${{ needs.sha-guard.outputs.deploy_sha }}
-          CACHE_ACCESS_TOKEN:
-            ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${CACHE_ACCESS_TOKEN:-}" ]; then
-            echo "Skipping Nx cache healthcheck: token is not set."
-            exit 0
-          fi
-          HEALTHCHECK_URL="https://nx-cache.kody.codes/health"
-          attempts=20
-          delay_seconds=3
-          for i in $(seq 1 "$attempts"); do
-            echo "Attempt $i/$attempts"
-            echo "Healthcheck URL: $HEALTHCHECK_URL"
-            if curl --fail --silent --show-error --max-time 10 \
-              --header "Accept: application/json" \
-              "$HEALTHCHECK_URL" > nx-cache-health.json && \
-              node -e "const fs = require('node:fs'); const json = JSON.parse(fs.readFileSync('nx-cache-health.json','utf8')); const expected = process.env.EXPECTED_COMMIT_SHA; if (json?.ok !== true) { console.error('nx-cache-healthcheck-unexpected-response', json); process.exit(1); } if (json?.commit !== expected) { console.error('nx-cache-healthcheck-unexpected-commit', { expected, actual: json?.commit }); process.exit(1); } console.log('nx-cache-healthcheck-ok', json);"; then
-              exit 0
-            fi
-            sleep "$delay_seconds"
-          done
-
-          echo "Nx cache worker healthcheck failed after ${attempts} attempts." >&2
-          if [ -f nx-cache-health.json ]; then
-            echo "Last response body:" >&2
-            cat nx-cache-health.json >&2
-          fi
-          exit 1
+    uses: ./.github/workflows/nx-cache-deploy.yml
+    secrets: inherit
+    with:
+      sha: ${{ needs.sha-guard.outputs.deploy_sha }}

--- a/.github/workflows/nx-cache-deploy.yml
+++ b/.github/workflows/nx-cache-deploy.yml
@@ -24,9 +24,10 @@ concurrency:
 
 jobs:
   deploy-nx-cache-worker:
-    if: >-
-      github.event_name == 'workflow_call' || (github.event_name ==
-      'workflow_dispatch' && github.ref_name == 'main')
+    # github is the caller context: event_name stays workflow_run /
+    # workflow_dispatch, never workflow_call. Manual runs are main-only;
+    # production deploy already gates the workflow_call.
+    if: github.event_name != 'workflow_dispatch' || github.ref_name == 'main'
     runs-on: ubuntu-latest
     name: 🧊 Deploy Nx cache worker
     timeout-minutes: 8
@@ -37,9 +38,7 @@ jobs:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
         with:
-          ref:
-            ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha
-            }}
+          ref: ${{ inputs.sha || github.sha }}
           fetch-depth: 0
 
       - name: 🟢 Setup Node
@@ -61,9 +60,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          DEPLOY_COMMIT_SHA:
-            ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha
-            }}
+          DEPLOY_COMMIT_SHA: ${{ inputs.sha || github.sha }}
           DISPATCH_REASON: ${{ inputs.reason }}
           CACHE_ACCESS_TOKEN:
             ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
@@ -119,9 +116,7 @@ jobs:
       - name: 🩺 Healthcheck (Nx cache worker)
         shell: bash
         env:
-          EXPECTED_COMMIT_SHA:
-            ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha
-            }}
+          EXPECTED_COMMIT_SHA: ${{ inputs.sha || github.sha }}
           CACHE_ACCESS_TOKEN:
             ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
         run: |

--- a/.github/workflows/nx-cache-deploy.yml
+++ b/.github/workflows/nx-cache-deploy.yml
@@ -25,8 +25,8 @@ concurrency:
 jobs:
   deploy-nx-cache-worker:
     if: >-
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'workflow_dispatch' && github.ref_name == 'main')
+      github.event_name == 'workflow_call' || (github.event_name ==
+      'workflow_dispatch' && github.ref_name == 'main')
     runs-on: ubuntu-latest
     name: 🧊 Deploy Nx cache worker
     timeout-minutes: 8
@@ -37,7 +37,9 @@ jobs:
       - name: 📦 Checkout
         uses: actions/checkout@v6.0.2
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha }}
+          ref:
+            ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha
+            }}
           fetch-depth: 0
 
       - name: 🟢 Setup Node
@@ -59,7 +61,9 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          DEPLOY_COMMIT_SHA: ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha }}
+          DEPLOY_COMMIT_SHA:
+            ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha
+            }}
           DISPATCH_REASON: ${{ inputs.reason }}
           CACHE_ACCESS_TOKEN:
             ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
@@ -115,7 +119,9 @@ jobs:
       - name: 🩺 Healthcheck (Nx cache worker)
         shell: bash
         env:
-          EXPECTED_COMMIT_SHA: ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha }}
+          EXPECTED_COMMIT_SHA:
+            ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha
+            }}
           CACHE_ACCESS_TOKEN:
             ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
         run: |

--- a/.github/workflows/nx-cache-deploy.yml
+++ b/.github/workflows/nx-cache-deploy.yml
@@ -1,0 +1,147 @@
+name: 🧊 Nx cache worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Why this redeploy (token rotation, healthcheck, etc.)
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      sha:
+        description: Commit SHA to deploy
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: deploy-nx-cache
+  cancel-in-progress: false
+
+jobs:
+  deploy-nx-cache-worker:
+    if: >-
+      github.event_name == 'workflow_call' ||
+      (github.event_name == 'workflow_dispatch' && github.ref_name == 'main')
+    runs-on: ubuntu-latest
+    name: 🧊 Deploy Nx cache worker
+    timeout-minutes: 8
+    environment:
+      name: production
+      url: https://nx-cache.kody.codes
+    steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: 🟢 Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: 📥 Install Dependencies
+        run: npm ci
+
+      - name: 🧱 Ensure Nx cache R2 bucket and lifecycle
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: node tools/ci/nx-cache-resources.ts
+
+      - name: ☁️ Deploy Nx cache worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOY_COMMIT_SHA: ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha }}
+          DISPATCH_REASON: ${{ inputs.reason }}
+          CACHE_ACCESS_TOKEN:
+            ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DISPATCH_REASON:-}" ]; then
+            echo "Nx cache worker redeploy reason: ${DISPATCH_REASON}"
+          fi
+          if [ -z "${CACHE_ACCESS_TOKEN:-}" ]; then
+            echo "Skipping Nx cache worker deploy: repository secret" >&2
+            echo "NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN is not set." >&2
+            echo "Generate one with: openssl rand -hex 32" >&2
+            exit 0
+          fi
+
+          deploy_attempts=3
+          deploy_delay_seconds=10
+          for attempt in $(seq 1 "$deploy_attempts"); do
+            echo "Nx cache worker deploy attempt $attempt/$deploy_attempts"
+            set +e
+            npm run nx-cache:deploy -- \
+              --var "BUILD_COMMIT:${DEPLOY_COMMIT_SHA}" 2>&1 | tee nx-cache-deploy.log
+            deploy_status="${PIPESTATUS[0]}"
+            set -e
+            if [ "$deploy_status" -eq 0 ]; then
+              break
+            fi
+            if [ "$attempt" -eq "$deploy_attempts" ]; then
+              echo "Nx cache worker deploy failed after $deploy_attempts attempts." >&2
+              exit "$deploy_status"
+            fi
+            echo "Retrying in ${deploy_delay_seconds}s."
+            sleep "$deploy_delay_seconds"
+            deploy_delay_seconds=$((deploy_delay_seconds * 2))
+          done
+
+      - name: 🔐 Sync Nx cache access token
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CACHE_ACCESS_TOKEN:
+            ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CACHE_ACCESS_TOKEN:-}" ]; then
+            echo "Skipping Nx cache secret sync: token is not set."
+            exit 0
+          fi
+          node tools/ci/sync-worker-secrets.ts --env "" --config \
+            packages/nx-cache/wrangler.jsonc --name kody-nx-cache \
+            --set-from-env CACHE_ACCESS_TOKEN
+
+      - name: 🩺 Healthcheck (Nx cache worker)
+        shell: bash
+        env:
+          EXPECTED_COMMIT_SHA: ${{ github.event_name == 'workflow_call' && inputs.sha || github.sha }}
+          CACHE_ACCESS_TOKEN:
+            ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CACHE_ACCESS_TOKEN:-}" ]; then
+            echo "Skipping Nx cache healthcheck: token is not set."
+            exit 0
+          fi
+          HEALTHCHECK_URL="https://nx-cache.kody.codes/health"
+          attempts=20
+          delay_seconds=3
+          for i in $(seq 1 "$attempts"); do
+            echo "Attempt $i/$attempts"
+            echo "Healthcheck URL: $HEALTHCHECK_URL"
+            if curl --fail --silent --show-error --max-time 10 \
+              --header "Accept: application/json" \
+              "$HEALTHCHECK_URL" > nx-cache-health.json && \
+              node -e "const fs = require('node:fs'); const json = JSON.parse(fs.readFileSync('nx-cache-health.json','utf8')); const expected = process.env.EXPECTED_COMMIT_SHA; if (json?.ok !== true) { console.error('nx-cache-healthcheck-unexpected-response', json); process.exit(1); } if (json?.commit !== expected) { console.error('nx-cache-healthcheck-unexpected-commit', { expected, actual: json?.commit }); process.exit(1); } console.log('nx-cache-healthcheck-ok', json);"; then
+              exit 0
+            fi
+            sleep "$delay_seconds"
+          done
+
+          echo "Nx cache worker healthcheck failed after ${attempts} attempts." >&2
+          if [ -f nx-cache-health.json ]; then
+            echo "Last response body:" >&2
+            cat nx-cache-health.json >&2
+          fi
+          exit 1

--- a/docs/contributing/decisions/0019-self-hosted-nx-remote-cache.md
+++ b/docs/contributing/decisions/0019-self-hosted-nx-remote-cache.md
@@ -26,10 +26,11 @@ spec and stores artifacts in R2. Clients set
 
 Remote hits require the access token in GitHub Actions and in Cursor Cloud Agent
 environments; without it, tasks run locally as before. Validate jobs probe
-`GET /health` before setting the server URL because Nx treats an unreachable
-self-hosted cache as a fatal error. First PUT wins (`409` on overwrite) so a
-poisoned key cannot replace a stored artifact. R2 expires `v1/` objects 14 days
-after write (Age, not last access — GET does not refresh mtime) and aborts
-incomplete multipart uploads after 1 day. The cache worker is contributor infra,
-not a product primitive, and holds no user data. Revisit only if Nx Cloud
-becomes mandatory for a feature we need, or if the HTTP spec changes.
+`GET /health` and an authorized `GET /v1/cache/{hash}` before setting the server
+URL because Nx treats an unreachable or unauthorized self-hosted cache as a
+fatal error. First PUT wins (`409` on overwrite) so a poisoned key cannot
+replace a stored artifact. R2 expires `v1/` objects 14 days after write (Age,
+not last access — GET does not refresh mtime) and aborts incomplete multipart
+uploads after 1 day. The cache worker is contributor infra, not a product
+primitive, and holds no user data. Revisit only if Nx Cloud becomes mandatory
+for a feature we need, or if the HTTP spec changes.

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -12,7 +12,10 @@ This project uses the following resources:
   - `bucket_name`: `kody-nx-cache`
   - Worker: `kody-nx-cache` at `nx-cache.kody.codes` (`packages/nx-cache`)
   - Production deploy ensures the bucket and a 14-day `v1/` lifecycle (1-day
-    incomplete multipart abort) when the cache worker path changes
+    incomplete multipart abort) when the cache worker path changes or that
+    workflow is dispatched on `main`. The dedicated
+    `.github/workflows/nx-cache-deploy.yml` workflow does the same on its own
+    `workflow_dispatch` without a full production deploy.
 - KV namespace for OAuth/session storage
   - `binding`: `OAUTH_KV`
   - `title`: `<app-name>-oauth`
@@ -541,10 +544,11 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` (optional GitHub **secret**; bearer
   token for the Nx HTTP cache worker at `https://nx-cache.kody.codes`. Generate
   with `openssl rand -hex 32`. Validate jobs enable remote cache when this is
-  set; production deploy syncs it to the worker as `CACHE_ACCESS_TOKEN` and
-  creates the `kody-nx-cache` R2 bucket with a 14-day object lifecycle. Use the
-  same value in Cursor Cloud Agent environments so agent `validate` /
-  `test:push` can populate CI hits. Validate jobs probe `/health` before setting
+  set; production deploy and the dedicated `🧊 Nx cache worker` workflow sync
+  it to the worker as `CACHE_ACCESS_TOKEN` and create the `kody-nx-cache` R2
+  bucket with a 14-day object lifecycle. Use the same value in Cursor Cloud
+  Agent environments so agent `validate` / `test:push` can populate CI hits.
+  Validate jobs probe `/health` before setting
   the server URL so an undeployed worker does not fail Nx. Leave unset to run CI
   with local `.nx` + `actions/cache` only.)
 - **Repository variables** `SENTRY_ORG` and `SENTRY_PROJECT` (optional; Sentry
@@ -641,8 +645,10 @@ How to get/set each value:
   - Generate locally: `openssl rand -hex 32`
   - Store the exact value as the repository secret
     `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`, and use the same value in Cursor
-    Cloud Agent environments. Production deploy syncs it to the `kody-nx-cache`
-    Worker as `CACHE_ACCESS_TOKEN`.
+    Cloud Agent environments. Production deploy and the dedicated
+    `🧊 Nx cache worker` workflow sync it to the `kody-nx-cache` Worker as
+    `CACHE_ACCESS_TOKEN`. After rotating the GitHub secret, run that workflow
+    on `main` so the worker secret matches.
 - `SENTRY_ORG` / `SENTRY_PROJECT` (optional)
   - In GitHub: **Settings → Secrets and variables → Actions → Variables**, add
     `SENTRY_ORG` and `SENTRY_PROJECT` with your Sentry slugs (for example from

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -548,9 +548,9 @@ Configure these GitHub Actions secrets and variables for workflows:
   to the worker as `CACHE_ACCESS_TOKEN` and create the `kody-nx-cache` R2 bucket
   with a 14-day object lifecycle. Use the same value in Cursor Cloud Agent
   environments so agent `validate` / `test:push` can populate CI hits. Validate
-  jobs probe `/health` before setting the server URL so an undeployed worker
-  does not fail Nx. Leave unset to run CI with local `.nx` + `actions/cache`
-  only.)
+  jobs probe `/health` and an authorized cache GET before setting the server URL
+  so an undeployed worker or unsynced token does not fail Nx. Leave unset to run
+  CI with local `.nx` + `actions/cache` only.)
 - **Repository variables** `SENTRY_ORG` and `SENTRY_PROJECT` (optional; Sentry
   organization and project **slugs** for source map upload — same values as in
   the Sentry wizard’s `--org` / `--project` flags)

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -544,13 +544,13 @@ Configure these GitHub Actions secrets and variables for workflows:
 - `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` (optional GitHub **secret**; bearer
   token for the Nx HTTP cache worker at `https://nx-cache.kody.codes`. Generate
   with `openssl rand -hex 32`. Validate jobs enable remote cache when this is
-  set; production deploy and the dedicated `🧊 Nx cache worker` workflow sync
-  it to the worker as `CACHE_ACCESS_TOKEN` and create the `kody-nx-cache` R2
-  bucket with a 14-day object lifecycle. Use the same value in Cursor Cloud
-  Agent environments so agent `validate` / `test:push` can populate CI hits.
-  Validate jobs probe `/health` before setting
-  the server URL so an undeployed worker does not fail Nx. Leave unset to run CI
-  with local `.nx` + `actions/cache` only.)
+  set; production deploy and the dedicated `🧊 Nx cache worker` workflow sync it
+  to the worker as `CACHE_ACCESS_TOKEN` and create the `kody-nx-cache` R2 bucket
+  with a 14-day object lifecycle. Use the same value in Cursor Cloud Agent
+  environments so agent `validate` / `test:push` can populate CI hits. Validate
+  jobs probe `/health` before setting the server URL so an undeployed worker
+  does not fail Nx. Leave unset to run CI with local `.nx` + `actions/cache`
+  only.)
 - **Repository variables** `SENTRY_ORG` and `SENTRY_PROJECT` (optional; Sentry
   organization and project **slugs** for source map upload — same values as in
   the Sentry wizard’s `--org` / `--project` flags)
@@ -647,8 +647,8 @@ How to get/set each value:
     `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`, and use the same value in Cursor
     Cloud Agent environments. Production deploy and the dedicated
     `🧊 Nx cache worker` workflow sync it to the `kody-nx-cache` Worker as
-    `CACHE_ACCESS_TOKEN`. After rotating the GitHub secret, run that workflow
-    on `main` so the worker secret matches.
+    `CACHE_ACCESS_TOKEN`. After rotating the GitHub secret, run that workflow on
+    `main` so the worker secret matches.
 - `SENTRY_ORG` / `SENTRY_PROJECT` (optional)
   - In GitHub: **Settings → Secrets and variables → Actions → Variables**, add
     `SENTRY_ORG` and `SENTRY_PROJECT` with your Sentry slugs (for example from

--- a/packages/nx-cache/readme.md
+++ b/packages/nx-cache/readme.md
@@ -22,9 +22,11 @@ export NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN="$NX_CACHE_TOKEN"
 
 Leave them unset to run with the local `.nx` cache only. Validate and
 `test:push` use `CI=1` so cache hashes match GitHub Actions (`CI=true` would
-miss). GitHub Actions only sets the server URL after `GET /health` succeeds — Nx
-fails the job if the host is configured but unreachable, so the first merge can
-still validate before the worker exists.
+miss). GitHub Actions only sets the server URL after `GET /health` succeeds and
+an authorized `GET /v1/cache/{hash}` returns 200 or 404 — Nx fails the job if
+the host is configured but unreachable or unauthorized, so validate can still
+pass before the worker exists or after a token rotation that has not been synced
+yet.
 
 `npm run nx-cache:smoke` (also part of `test:node`) starts a local HTTP cache,
 runs `nx-cache:smoke-probe` twice with an isolated local cache wiped in between,

--- a/packages/nx-cache/readme.md
+++ b/packages/nx-cache/readme.md
@@ -40,7 +40,14 @@ the window after which a poisoned hash can be replaced.
 
 ## Deploy
 
-Production deploy creates the `kody-nx-cache` R2 bucket, applies the 14-day
-lifecycle, uploads the worker, and syncs `CACHE_ACCESS_TOKEN` from the
-`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` GitHub Actions secret. The job no-ops
-when that secret is missing so a first merge does not block production.
+Production deploy (`.github/workflows/deploy.yml`) creates the `kody-nx-cache`
+R2 bucket, applies the 14-day lifecycle, uploads the worker, and syncs
+`CACHE_ACCESS_TOKEN` from the `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` GitHub
+Actions secret when cache-related paths change or when that workflow is
+dispatched on `main`. The job no-ops when that secret is missing so a first
+merge does not block production.
+
+To redeploy only the cache worker (for example after rotating
+`NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`), run **Actions → 🧊 Nx cache worker
+→ Run workflow** on `main` (`.github/workflows/nx-cache-deploy.yml`). That
+reuses the same job and does not cancel an in-progress production deploy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make it possible to redeploy only the Nx cache worker (and resync `CACHE_ACCESS_TOKEN`) after a token rotation, without a full production deploy. Validate should keep passing while that sync is outstanding.

## Summary

- Extract the production `🧊 Deploy Nx cache worker` job into `.github/workflows/nx-cache-deploy.yml`
- The new workflow is `workflow_dispatch` on `main` and `workflow_call` from `deploy.yml`
- Own concurrency group (`deploy-nx-cache`) so a cache-only redeploy does not cancel production
- Path filter also matches the new workflow file
- Reusable workflow uses `inputs.sha` (caller `github.event_name` is never `workflow_call`)
- Setup-validate probes `/health` and an authorized cache GET before setting the server URL, so a 401 token mismatch falls back to local `.nx` instead of failing Nx

## Testing

- Local `docs:check-temporal` and `format:check`
- After merge: dispatch **Actions → 🧊 Nx cache worker** on `main` to sync the rotated token, then verify from a fresh Cloud Agent

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `4cd83b61` · **Head:** `af101ead`

**Classification:** composes — no primitives added or changed; this PR extracts an existing deploy job into a reusable workflow and tightens the CI cache gate.

### Primitives touched

None. Classifier unmatched paths are GitHub Actions workflows, the validate setup action, and contributing docs.

### Change flow

Operators can redeploy only `kody-nx-cache` via the extracted workflow. Validate enables the remote cache only after health and token probes succeed.

```mermaid
sequenceDiagram
	actor Operator
	participant setupValidate as setup-validate
	participant nxCacheDeploy as nx-cache-deploy.yml
	participant deployYml as deploy.yml
	setupValidate->>setupValidate: GET /health then authorized GET /v1/cache
	alt health or auth fails
		setupValidate->>setupValidate: leave server URL unset
	else 200 or 404
		setupValidate->>setupValidate: set NX_SELF_HOSTED_REMOTE_CACHE_SERVER
	end
	Operator->>nxCacheDeploy: workflow_dispatch on main
	nxCacheDeploy->>nxCacheDeploy: ensure R2 + deploy worker + sync CACHE_ACCESS_TOKEN
	deployYml->>nxCacheDeploy: workflow_call with deploy SHA
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c093569-b79d-4898-8907-76e37a3a853f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c093569-b79d-4898-8907-76e37a3a853f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

