### PR TITLE
docs: record completed PackageServiceInstance delete sequence

### DIFF
--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -174,11 +174,14 @@ rejects a same-deploy `deleted_classes` migration while that binding still
 exists (error 10061). Existing objects also require the script to keep exporting
 the class until `deleted_classes` runs (error 10064). Export a stub, drop the
 binding, then add the `deleted_classes` migration and its
-`tools/ci/do-deletion-allowlist.json` entry on a later deploy.
+`tools/ci/do-deletion-allowlist.json` entry on a later deploy. Preview
+`deleted_classes` requires a previous script version that exported the class
+(error 10074). A first preview deploy can apply the create and delete tags
+together so they elide.
 
-`PackageServiceInstance` uses that sequence: production `kody-runtime` applies
-tag `v2` after a stub-export deploy dropped the transferred binding. Preview
-applies `v1` `new_sqlite_classes` then `v2` `deleted_classes` on first deploy.
+`PackageServiceInstance` is gone from production `kody-runtime` (tag `v2`; no
+stub export). Preview applies `v1` `new_sqlite_classes` then `v2`
+`deleted_classes` on first deploy so create and delete elide.
 
 ## Rollback
 

--- a/docs/contributing/decisions/0025-no-package-services-primitive.md
+++ b/docs/contributing/decisions/0025-no-package-services-primitive.md
@@ -33,15 +33,17 @@ deployment and communicate with Kody through supported integration surfaces.
 Leftover `kind = 'service'` `user_storage_buckets` rows stay until the
 `storage_bucket_estimate_backfill` lane clears the matching StorageRunner
 Durable Objects and then deletes the inventory. Account export and deletion keep
-discovering those storage ids until that purge succeeds.
+discovering those storage ids until that purge succeeds. Confirm the production
+count is zero, then remove the purge lane, in #1565.
 
-Deleting `PackageServiceInstance` on production `kody-runtime` is two deploys.
-The class arrived through a `transferred_classes` migration, so Cloudflare still
-has a remote binding and existing objects after the source binding is gone. A
-same-deploy `deleted_classes` migration fails with error 10061. Dropping the
-binding without exporting the class fails with error 10064. Export a stub, drop
-the remote binding, then apply runtime-worker tag `v2` `deleted_classes` and
-remove the stub. #1559 completed the stub-and-drop-binding deploy. The
-`tools/ci/do-deletion-allowlist.json` entry for tag `v2` is the contract for the
-class-delete follow-up. Preview `deleted_classes` requires a previous script
-version that exported the class (error 10074).
+Deleting `PackageServiceInstance` on production `kody-runtime` required two
+deploys after #1552. The class arrived through a `transferred_classes`
+migration, so Cloudflare still had a remote binding and existing objects after
+the source binding was gone. A same-deploy `deleted_classes` migration failed
+with error 10061 (#1552 deploy). Dropping the binding without exporting the
+class failed with error 10064 (#1558). #1559 exported a stub and dropped the
+remote binding. #1560 applied runtime-worker tag `v2` `deleted_classes` and
+removed the stub. Preview `deleted_classes` requires a previous script version
+that exported the class (error 10074); a first preview deploy applies `v1`
+`new_sqlite_classes` and `v2` `deleted_classes` together so create and delete
+elide.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep contributing docs aligned with the finished `PackageServiceInstance` delete, and point leftover `kind='service'` storage inventory purge at a tracked issue so it is not forgotten.

## Summary

- Garden the runtime-worker runbook: keep the Cloudflare 10061 / 10064 / 10074 transferred-class delete procedure, and describe `PackageServiceInstance` as already deleted on production (`v2`; no stub).
- Update ADR 0025 consequences to record the completed #1558 / #1559 / #1560 sequence instead of a live follow-up.
- Track remaining operational work in #1565 (confirm leftover `kind='service'` inventory is gone, then remove the purge lane).

## Testing

Docs-only. Relevant local checks passed:

- `npm run docs:check-temporal`
- `npm run format:check`
- `npm run primitives:check`
- `npm run migrations:check`
- `npm run deploy-guardrails:check`

Full `npm run validate` was started; the docs-adjacent jobs above passed. Parallel e2e / mock-API timeouts on this Cloud Agent VM are unrelated to the two markdown files.

## System changes

Docs only. Wrangler history, deletion allowlist, durable-object baseline, and the leftover-service purge lane are unchanged.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `3cd38054` · **Head:** `0465d9fa`

**Classification:** composes — no primitives added or changed; this PR gardens two contributing docs.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_ | — | docs-only; classifier matched no `code` roots |

Unmatched paths: `docs/contributing/architecture/runtime-worker-migration-runbook.md`, `docs/contributing/decisions/0025-no-package-services-primitive.md`.

### Change flow

Contributors reading the runtime-worker runbook see the completed class-delete state; ADR 0025 points leftover inventory purge at #1565.

```mermaid
sequenceDiagram
	actor Contributor
	participant runbook as runtime-worker-migration-runbook
	participant adr as adr-0025
	Contributor->>runbook: read Deleting a transferred class
	Note over runbook: PackageServiceInstance gone on production (v2; no stub)
	Contributor->>adr: read 0025 consequences
	Note over adr: leftover kind=service purge tracked in #1565
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d38711-e9f1-4574-b52e-335fa9e48713?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d38711-e9f1-4574-b52e-335fa9e48713&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

