### PR TITLE
Track leftover migration cleanup in a skill and GitHub issues

### DIFF
--- a/.agents/skills/cleanup-after-migrations/SKILL.md
+++ b/.agents/skills/cleanup-after-migrations/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: cleanup-after-migrations
+description: >
+  Clean up leftover code, schema, shims, dual-writes, compatibility aliases,
+  feature flags, and docs after a migration or similar change. Use when you
+  introduce transitional leftovers, leave a deprecated path, need a soak or
+  follow-up migration before dropping something, or are finishing a migration
+  runbook. Remove the leftover in the same change when it is safe; otherwise
+  open a GitHub issue so it is not forgotten.
+---
+
+# Cleanup after migrations
+
+Read
+[`docs/contributing/cleanup-after-migrations.md`](../../../docs/contributing/cleanup-after-migrations.md).
+Do not leave untracked cruft.
+
+## Decision
+
+1. **Do it now** when the leftover is safe to drop with this change.
+2. **Open a GitHub issue** when it must wait on a later migration, a second
+   deploy, a soak or metrics gate, a fleet apply, or another cutover.
+
+A runbook or `TODO` is not the tracker. The issue is.
+
+Search open `Cleanup:` issues first. Title:
+`Cleanup: <what to remove> after <gate>`. Label: `improvement`. Link the issue
+from the introducing PR.
+
+```markdown
+## Leftover
+
+What to delete or stop serving.
+
+## Why it waits
+
+The gate.
+
+## Ready when
+
+A falsifiable criterion (not a calendar date alone).
+
+## How to verify
+
+Commands, queries, or deploy evidence.
+
+## Introduced by
+
+PR that added the leftover.
+```
+
+```bash
+gh issue create --title "Cleanup: … after …" --label improvement --body-file -
+```
+
+Or `kody:@kentcdodds/github/request` `POST /repos/kentcdodds/kody/issues`.
+
+Soak or calendar gates also get a scheduled wake (`job_schedule` + `createRun`)
+per [ship-pr](../ship-pr/SKILL.md). Close the issue when the cleanup lands.

--- a/.agents/skills/conduct/SKILL.md
+++ b/.agents/skills/conduct/SKILL.md
@@ -34,8 +34,10 @@ Do not spawn a one-agent "fleet."
   steps. Production / irreversible: say so and raise the bar.
 - **Expand owns contract.** No `STATUS: done` after expand-only — same kickoff
   or a scheduled wake with an owner.
-- **Stop when the goal is met.** Cleanup/drop is a later ask unless the user
-  says finish it now.
+- **Stop when the goal is met.** Do not expand a fleet into dropping the old
+  system unless that is the assigned work. Leftovers **this** change adds still
+  follow [cleanup-after-migrations](../cleanup-after-migrations/SKILL.md):
+  remove them now when safe, otherwise open a GitHub issue.
 - **Ship autonomously** under the user's shipping policy; hand `ship-pr` when
   agents may merge. High-risk park only when the user requires it — then ask
   once, list PRs, schedule a self-wake (don't sleep-poll).

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -35,7 +35,9 @@ Self-assess; user policy overrides.
 
 Blocked on soak / parity CHECK / calendar gate → **end the run** and schedule a
 wake (Kody `job_schedule` + `createRun`). Don't sleep-poll or code-thrash an
-intentional time window.
+intentional time window. Leftovers that wait on that gate need a GitHub issue
+(`Cleanup:` title); see
+[cleanup-after-migrations](../cleanup-after-migrations/SKILL.md).
 
 Batch related expand steps into fewer PRs when risk posture allows.
 

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -54,6 +54,8 @@ to become.
 - [Values retirement runbook](./values-retirement-runbook.md): absorb values
   into memories, package storage, repos, secrets, and integrations
   ([ADR 0022](../decisions/0022-retire-values-primitive.md)).
+- [Cleanup after migrations](../cleanup-after-migrations.md): drop leftovers in
+  the same change when safe; otherwise open a GitHub issue.
 - [Primitives map](./primitives.yaml): stable taxonomy of system primitives and
   invariants for the visual-recap skill
   (`.agents/skills/visual-recap/SKILL.md`). It is not a living feature changelog

--- a/docs/contributing/architecture/jobs-worker-migration-runbook.md
+++ b/docs/contributing/architecture/jobs-worker-migration-runbook.md
@@ -164,3 +164,6 @@ D1 migration step).
 - After step 6: roll forward. The old `APP_DB` tables still hold the pre-pause
   rows as a cold copy until step 8, so data loss is bounded to the cutover
   window in the worst case.
+
+Leftovers that wait on a later drop follow
+[Cleanup after migrations](../cleanup-after-migrations.md).

--- a/docs/contributing/architecture/runtime-worker-migration-runbook.md
+++ b/docs/contributing/architecture/runtime-worker-migration-runbook.md
@@ -192,3 +192,6 @@ applies `v1` `new_sqlite_classes` then `v2` `deleted_classes` on first deploy.
   edits).
 - The main worker can always be rolled back independently as long as its config
   keeps the cross-script bindings.
+
+Leftovers that wait on a later tag or deploy follow
+[Cleanup after migrations](../cleanup-after-migrations.md).

--- a/docs/contributing/architecture/values-retirement-runbook.md
+++ b/docs/contributing/architecture/values-retirement-runbook.md
@@ -216,3 +216,5 @@ day 30 because the calendar said so.
 - [0003 — Repos as the base primitive](../decisions/0003-repos-as-base-primitive.md)
 - [0005 — Metrics-driven lane retirement](../decisions/0005-mcp-dual-lane-stateless-migration.md)
 - [Package state model](../../use/packages.md#package-state-model)
+- [Cleanup after migrations](../cleanup-after-migrations.md) (GitHub issue for
+  leftovers that wait on a soak or later drop)

--- a/docs/contributing/cleanup-after-migrations.md
+++ b/docs/contributing/cleanup-after-migrations.md
@@ -1,0 +1,96 @@
+# Cleanup after migrations
+
+Agents clean up leftover cruft from the change they are making. Untracked
+leftovers linger; tracked leftovers get finished.
+
+This page is the policy. Load the skill at
+[`.agents/skills/cleanup-after-migrations/SKILL.md`](../../.agents/skills/cleanup-after-migrations/SKILL.md)
+when the work introduces a transitional leftover, a deprecated path, a soak, or
+a follow-up migration.
+
+## Decision
+
+1. **Remove it in this change** when the leftover is safe to drop with the
+   landing code: unused helpers, dead call sites, docs that describe the old
+   path, tests that only exist to keep a shim green, feature-flag branches whose
+   gate already passed, columns the app no longer reads or writes.
+2. **Open a GitHub issue** when the leftover cannot go in this change. Typical
+   gates: a later schema drop, a second deploy (Cloudflare Durable Object class
+   deletion), a metrics or soak window, a fleet codemod, or another team's
+   cutover. A runbook can describe the steps; the issue is the tracker so the
+   leftover is not forgotten.
+
+Do not leave a "we can clean this up later" comment, a TODO, or a runbook
+paragraph as the only record.
+
+## What counts as leftover
+
+Anything this change keeps around only because something else has not finished:
+
+- Unused D1 columns, tables, or indexes after a backfill
+- Dual-write or dual-read paths
+- Compatibility shims, deprecated aliases, and dual-lane serving
+- Feature flags whose rollout is complete
+- Durable Object classes that a later `deleted_classes` migration must drop
+- Codemod deprecation shims after fleet apply and publish-time enforcement
+- One-off guard scripts that only apply to old local or preview state
+- Docs, MCP instructions, and tests that exist only to explain the old path
+
+A leftover you did not introduce is still worth removing when it is in your
+diff's way and safe. Do not expand a multi-track program into dropping an old
+system unless that is the assigned work; still file an issue for leftovers
+**this** change adds.
+
+## Issue
+
+Search open issues first (`Cleanup:` title prefix) and comment on a match
+instead of opening a duplicate.
+
+Title: `Cleanup: <what to remove> after <gate>`.
+
+Label: `improvement`.
+
+Body:
+
+```markdown
+## Leftover
+
+What to delete or stop serving (paths, tables, flags, shims, classes).
+
+## Why it waits
+
+The gate: soak metric, subsequent migration, deploy order, fleet apply, or other
+cutover.
+
+## Ready when
+
+A falsifiable criterion. Not a calendar date alone.
+
+## How to verify
+
+Commands, queries, or deploy evidence that prove the drop is safe.
+
+## Introduced by
+
+PR that added the leftover.
+```
+
+Link the issue from the introducing PR description. If a runbook exists, link
+both ways. When the cleanup later lands, close the issue.
+
+Create with `gh issue create` from a repo checkout, or
+`kody:@kentcdodds/github/request` `POST /repos/kentcdodds/kody/issues`.
+
+When the gate is a soak or calendar window, also schedule a wake
+(`job_schedule` + `createRun`) as in the
+[ship-pr skill](../../.agents/skills/ship-pr/SKILL.md). The issue remains the
+durable tracker after the session ends.
+
+## Related
+
+- [Authoring D1 migrations](./setup.md#authoring-d1-migrations)
+- [Package codemod rollout](./package-codemods.md#rollout-doctrine)
+- [Harness engineering](./harness-engineering.md)
+- [Values retirement runbook](./architecture/values-retirement-runbook.md)
+- [Runtime worker migration runbook](./architecture/runtime-worker-migration-runbook.md)
+- [Jobs worker migration runbook](./architecture/jobs-worker-migration-runbook.md)

--- a/docs/contributing/harness-engineering.md
+++ b/docs/contributing/harness-engineering.md
@@ -65,7 +65,10 @@ Use a lightweight "doc and quality gardening" pass to prevent drift:
 - Remove stale guidance from `docs/contributing`.
 - Tighten unclear instructions and add cross-links.
 - Identify recurring defects and propose one new mechanical guardrail.
-- Record follow-up tech debt as explicit, trackable work.
+- Record follow-up tech debt as explicit, trackable work. Leftovers from a
+  migration or similar change follow
+  [Cleanup after migrations](./cleanup-after-migrations.md): remove them in the
+  same change when safe, otherwise open a GitHub issue.
 
 Continuous small cleanups are cheaper than periodic large rewrites.
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -19,6 +19,8 @@ style, tests, MCP capabilities, and runtime architecture.
   shared by agents and CI)
 - [Harness engineering](./harness-engineering.md) (agent-first loop, promoting
   lessons into enforcement)
+- [Cleanup after migrations](./cleanup-after-migrations.md) (drop leftovers in
+  the same change, or open a GitHub issue)
 
 ## Code and tooling
 

--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -350,7 +350,10 @@ sequence (formalizing existing practice):
    publishes cannot use the deprecated pattern.
 
 Skipping dry-run or canary apply risks mass check failures; skipping step 6
-allows new packages to reintroduce debt.
+allows new packages to reintroduce debt. After enforcement lands, drop the
+deprecation shims when no remaining packages need them — or open a GitHub issue
+if that drop must wait. See
+[Cleanup after migrations](./cleanup-after-migrations.md).
 
 ## Revert
 

--- a/docs/contributing/remix.md
+++ b/docs/contributing/remix.md
@@ -11,6 +11,9 @@ Load that skill before changing Remix routes, controllers, middleware, data
 access, validation, auth, sessions, file uploads, server setup, UI components,
 hydration, navigation, frames, or tests.
 
+Kody D1 leftovers (unused columns, dual-write, a later drop) follow
+[Cleanup after migrations](./cleanup-after-migrations.md), not the Remix skill.
+
 For `<Frame>` partial reloads, see [frames](./frames.md).
 
 `npx remix@next new <app>` copies this skill from the Remix CLI bootstrap

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -165,6 +165,10 @@ Quick notes for getting a local kody environment running.
   exactly before touching anything, and no-ops on fresh or already-squashed
   databases. The guard runs only for local applies against pre-squash developer
   state dirs; delete it once those have died out.
+- Leftovers this migration cannot drop yet (old columns, dual-write, a later
+  `deleted_classes` tag, a soak) follow
+  [Cleanup after migrations](./cleanup-after-migrations.md): remove them in this
+  change when safe, otherwise open a GitHub issue.
 
 ## Documentation maintenance
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Agents should not leave untracked cruft after a migration or similar change. If leftover code, schema, shims, or flags cannot be dropped in the same change, the leftover needs a GitHub issue so it is not forgotten. The policy is progressively disclosed (skill + contributing page), not added to `AGENTS.md`.

## Summary

- Add `docs/contributing/cleanup-after-migrations.md` as the policy: drop leftovers in this change when safe; otherwise open a `Cleanup:` GitHub issue with a falsifiable gate.
- Add `.agents/skills/cleanup-after-migrations/SKILL.md` so agents load the rule when they introduce transitional leftovers, deprecated paths, soaks, or follow-up migrations.
- Point at the policy from the contributing index, D1 migration setup, harness engineering, package-codemod rollout, Remix contributor notes, architecture runbooks, `ship-pr`, and `conduct`.
- `AGENTS.md` is unchanged.

## Testing

- `npx oxfmt` on the edited markdown
- `npm run docs:check-temporal`
- `npm run validate` (running after this PR exists)

## System changes

No runtime primitives change. Docs and agent skills only.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>no primitives changed</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `3cd38054` · **Head:** `fbdd3cbe`

**Classification:** no primitive change — contributing docs and agent skills only. `classify-primitives.mjs` matched no `code` roots.

### Primitives touched

None. Unmatched paths are `.agents/skills/*` and `docs/contributing/*`.

### Change flow

An agent that introduces a transitional leftover either drops it in the same change or opens a tracked GitHub issue.

```mermaid
flowchart TB
	leftover["Transitional leftover"] --> safe{"Safe to drop in this change?"}
	safe -->|"yes: unused helpers, dead paths, passed flags"| drop["Remove in this PR"]
	safe -->|"no: soak, later migration, second deploy"| issue["Open Cleanup GitHub issue"]
	issue --> wake["Schedule a wake when the gate is a time window"]
```

### Invariants

`AGENTS.md` stays a map. Cleanup policy is disclosed from the skill description and from migration-related contributing pages.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e028f39a-8718-4a12-8313-134cf584aeef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e028f39a-8718-4a12-8313-134cf584aeef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

