### PR TITLE
Drop the invocation-token source allowlist

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1168,11 +1168,11 @@ on write unless a migration backfills existing rows.
   stores package dependency pointers queried with SQLite JSON functions in
   `packages/worker/src/repo/published-bundle-artifacts-repo.ts`.
 - `package_invocation_tokens.export_names_json`
-  (`0019-drop-invocation-token-sources.sql`) stores per-package
-  invocation-token export-scope projections. Each token row also has a required
-  `package_id`. Request JSON `source` is an optional log label, not a stored
-  allowlist. Keyed invocation replay lives in the RunLog Durable Object ledger
-  (see [Run records](./run-records.md)); the current D1 schema has no
+  (`0019-drop-invocation-token-sources.sql`) stores per-package invocation-token
+  export-scope projections. Each token row also has a required `package_id`.
+  Request JSON `source` is an optional log label, not a stored allowlist. Keyed
+  invocation replay lives in the RunLog Durable Object ledger (see
+  [Run records](./run-records.md)); the current D1 schema has no
   `package_invocations` table.
 - `webhook_endpoints` (`0001-squashed-init.sql`) stores per-user minted URL
   state for `package.json#kody.webhooks`, keyed by

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1167,12 +1167,12 @@ on write unless a migration backfills existing rows.
 - `published_bundle_artifacts.dependencies_json` (`0001-squashed-init.sql`)
   stores package dependency pointers queried with SQLite JSON functions in
   `packages/worker/src/repo/published-bundle-artifacts-repo.ts`.
-- `package_invocation_tokens.export_names_json` and
-  `package_invocation_tokens.sources_json`
-  (`0017-package-owned-invocation-tokens.sql`) store per-package
-  invocation-token scope projections. Each token row also has a required
-  `package_id`. Keyed invocation replay lives in the RunLog Durable Object
-  ledger (see [Run records](./run-records.md)); the current D1 schema has no
+- `package_invocation_tokens.export_names_json`
+  (`0019-drop-invocation-token-sources.sql`) stores per-package
+  invocation-token export-scope projections. Each token row also has a required
+  `package_id`. Request JSON `source` is an optional log label, not a stored
+  allowlist. Keyed invocation replay lives in the RunLog Durable Object ledger
+  (see [Run records](./run-records.md)); the current D1 schema has no
   `package_invocations` table.
 - `webhook_endpoints` (`0001-squashed-init.sql`) stores per-user minted URL
   state for `package.json#kody.webhooks`, keyed by

--- a/docs/contributing/decisions/0026-package-owned-invocation-tokens.md
+++ b/docs/contributing/decisions/0026-package-owned-invocation-tokens.md
@@ -25,9 +25,10 @@ reason to keep a grant table.
 An invocation token belongs to exactly one saved package. Auth resolves the
 owner and package from the URL, then looks up
 `(user_id, package_id, token_hash)`. There is no cross-package grant, no
-account-level token page, and no global hash index. Export and source allowlists
-stay as restrictions _within_ that package. Tokens are created, rotated, and
-revoked from the package details page.
+account-level token page, and no global hash index. Export allowlists stay as
+restrictions _within_ that package. Source allowlists were dropped in
+[0027](./0027-no-invocation-token-source-allowlist.md). Tokens are created,
+rotated, and revoked from the package details page.
 
 Cross-package HTTP clients call one package (an orchestrator or a discovery
 package) and use `packages.invoke` inside Kody, or they speak MCP. They do not

--- a/docs/contributing/decisions/0027-no-invocation-token-source-allowlist.md
+++ b/docs/contributing/decisions/0027-no-invocation-token-source-allowlist.md
@@ -1,0 +1,31 @@
+# 0027: No invocation-token source allowlist
+
+- **Status:** accepted
+- **Date:** 2026-08-19
+
+## Context
+
+[0026](./0026-package-owned-invocation-tokens.md) kept a per-token source
+allowlist after tokens became package-owned. The check was: omit or null
+`source` always passes; a named `source` must be on `sources_json`. Empty lists
+rejected every named label. That is not a client allowlist — a stolen bearer
+that omits `source` still works — and the form field was hard to explain.
+
+Production tokens all stored one caller label (`youtube-websub-proxy`,
+`discord`, `raycast`, and the rest). Callers already send that string on the
+request for logs. The token column added a second, weaker copy of the same
+name.
+
+## Decision
+
+Invocation tokens do not store or enforce a source allowlist. Request JSON
+`source` remains an optional label for logs and idempotency metadata. Export
+allowlists stay. The 0026 package-ownership decision is unchanged.
+
+## Consequences
+
+`0019-drop-invocation-token-sources.sql` drops `sources_json`. Token create and
+edit forms, MCP token metadata, and HTTP auth no longer mention allowed
+sources. Agents may still send `source` on invoke; it is not required and does
+not fail the call. Revisit only if a real caller-identity check is added that
+cannot be omitted.

--- a/docs/contributing/decisions/0027-no-invocation-token-source-allowlist.md
+++ b/docs/contributing/decisions/0027-no-invocation-token-source-allowlist.md
@@ -13,8 +13,7 @@ that omits `source` still works — and the form field was hard to explain.
 
 Production tokens all stored one caller label (`youtube-websub-proxy`,
 `discord`, `raycast`, and the rest). Callers already send that string on the
-request for logs. The token column added a second, weaker copy of the same
-name.
+request for logs. The token column added a second, weaker copy of the same name.
 
 ## Decision
 
@@ -25,7 +24,7 @@ allowlists stay. The 0026 package-ownership decision is unchanged.
 ## Consequences
 
 `0019-drop-invocation-token-sources.sql` drops `sources_json`. Token create and
-edit forms, MCP token metadata, and HTTP auth no longer mention allowed
-sources. Agents may still send `source` on invoke; it is not required and does
-not fail the call. Revisit only if a real caller-identity check is added that
-cannot be omitted.
+edit forms, MCP token metadata, and HTTP auth no longer mention allowed sources.
+Agents may still send `source` on invoke; it is not required and does not fail
+the call. Revisit only if a real caller-identity check is added that cannot be
+omitted.

--- a/docs/contributing/decisions/0027-no-invocation-token-source-allowlist.md
+++ b/docs/contributing/decisions/0027-no-invocation-token-source-allowlist.md
@@ -18,8 +18,8 @@ request for logs. The token column added a second, weaker copy of the same name.
 ## Decision
 
 Invocation tokens do not store or enforce a source allowlist. Request JSON
-`source` remains an optional label for logs and idempotency metadata. Export
-allowlists stay. The 0026 package-ownership decision is unchanged.
+`source` remains an optional label for logs. Export allowlists stay. The 0026
+package-ownership decision is unchanged.
 
 ## Consequences
 

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -47,3 +47,4 @@ behavior (see [documentation principles](../documentation.md)).
 - [0024 — Packages outrank synthesized providers](./0024-packages-outrank-synthesized-providers.md)
 - [0025 — No package services primitive](./0025-no-package-services-primitive.md)
 - [0026 — Package-owned invocation tokens](./0026-package-owned-invocation-tokens.md)
+- [0027 — No invocation-token source allowlist](./0027-no-invocation-token-source-allowlist.md)

--- a/docs/contributing/package-invocation-api.md
+++ b/docs/contributing/package-invocation-api.md
@@ -142,8 +142,8 @@ Fields:
 
 - `params` — JSON object passed as the first argument to the package export
 - `idempotencyKey` — required stable key for replay protection
-- `source` — optional caller label for logs and idempotency metadata. It does
-  not gate authentication.
+- `source` — optional caller label for logs. It does not gate authentication or
+  determine idempotency.
 - `topic` — optional event topic label for downstream logic and logs
 
 ## Idempotency

--- a/docs/contributing/package-invocation-api.md
+++ b/docs/contributing/package-invocation-api.md
@@ -48,7 +48,6 @@ Each token row includes:
 - token id and human-readable name
 - owning `user_id` and `package_id`
 - allowed package exports (`export_names_json`)
-- allowed request sources (`sources_json`)
 - `last_used_at`
 - `revoked_at`
 
@@ -57,7 +56,7 @@ The token is not a global backdoor:
 - the path names the owner and package
 - the bearer proves access to that package only
 - export access requires an explicit allowlist (including per-package `*`)
-- `source` metadata is checked against the allowlist when provided
+- request JSON `source` is an optional log label and does not gate auth
 - tokens can be revoked without deploys
 - execution uses normal package runtime machinery
 - `last_used_at` is a best-effort write and does not gate authentication
@@ -78,8 +77,8 @@ The backing same-origin JSON endpoint is:
 - `POST /account/packages.json` with `action: "create-token"` — create a token
   for one owned package
 - `POST /account/packages.json` with `action: "update-token"` — update token
-  name, allowlists, and optionally replace the stored token hash from a new raw
-  token
+  name, export allowlist, and optionally replace the stored token hash from a
+  new raw token
 - `POST /account/packages.json` with `action: "revoke-token"` — revoke a token
   by id
 - `POST /account/packages.json` with `action: "reinstate-token"` — reinstate a
@@ -95,26 +94,23 @@ Create payload shape:
 	"packageId": "<saved-package-id>",
 	"name": "Trusted external client",
 	"rawToken": "<raw-token>",
-	"exportNames": ["*"],
-	"sources": ["trusted-client"]
+	"exportNames": ["*"]
 }
 ```
 
 Export allowlists support the deliberate wildcard value `*` for every export on
-that package. Source values do not use wildcard matching: if a request includes
-`source`, that exact value must be present in the token's `sources` list.
+that package.
 
 Package details support metadata prefill query parameters for setup flows:
 
 - `newToken=1` opens the create form
 - `name`
 - `exportName` / `exportNames`
-- `allowedSource` / `allowedSources` / `source` / `sources`
 
 Snake case and kebab case aliases are accepted for list fields, such as
-`export_names`, `export-names`, `allowed_sources`, and `allowed-sources`. Repeat
-parameters or comma-separate values. Do not put the raw token in the URL; paste
-it into the form or submit it over the authenticated same-origin JSON API.
+`export_names` and `export-names`. Repeat parameters or comma-separate values.
+Do not put the raw token in the URL; paste it into the form or submit it over
+the authenticated same-origin JSON API.
 
 When editing an existing token in the account UI, the raw token field is
 write-only and optional: leave it blank to preserve the current token hash, or
@@ -146,9 +142,8 @@ Fields:
 
 - `params` — JSON object passed as the first argument to the package export
 - `idempotencyKey` — required stable key for replay protection
-- `source` — optional source label for auditing and token scoping; when present,
-  it must match the token's `sources` list. Omit it or send null when that list
-  is empty.
+- `source` — optional caller label for logs and idempotency metadata. It does
+  not gate authentication.
 - `topic` — optional event topic label for downstream logic and logs
 
 ## Idempotency
@@ -282,16 +277,14 @@ Recommended flow for a trusted external client:
 2. copy the raw token to the clipboard or keep it in the client's local secret
    storage
 3. open Kody at
-   `/account/packages/<packageId>?newToken=1&name=Trusted%20External%20Client&exportNames=*&sources=trusted-client`
+   `/account/packages/<packageId>?newToken=1&name=Trusted%20External%20Client&exportNames=*`
 4. paste the raw token into the form and create the token
-5. send invocation requests with `Authorization: Bearer <raw-token>` and
-   `"source": "trusted-client"`
+5. send invocation requests with `Authorization: Bearer <raw-token>` and an
+   optional JSON `source` label for logs
 
-A token with `exportNames: ["*"]` can call any export on that package. When the
-token lists allowed sources, the request must send one of those labels as JSON
-`source`. An empty source list allows unlabeled requests only; a named `source`
-is rejected. Cross-package callers invoke one package (an orchestrator or
-discovery package) and use `packages.invoke` inside Kody, or they speak MCP.
+A token with `exportNames: ["*"]` can call any export on that package.
+Cross-package callers invoke one package (an orchestrator or discovery package)
+and use `packages.invoke` inside Kody, or they speak MCP.
 
 ## Related
 

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -628,11 +628,11 @@ How to get/set each value:
     sync a different worker secret than production.
 - `KODY_PACKAGE_INVOCATION_TOKEN` (optional)
   - In Kody: open
-    `/account/packages/<weekly-site-perf-package-id>?newToken=1&name=Weekly%20site%20perf&exportNames=.&allowedSources=weekly-site-perf`,
+    `/account/packages/<weekly-site-perf-package-id>?newToken=1&name=Weekly%20site%20perf&exportNames=.`,
     generate a raw token in the browser, and store that value as the repository
     secret `KODY_PACKAGE_INVOCATION_TOKEN`. Scope it to the `weekly-site-perf`
-    package and source `weekly-site-perf`. The weekly workflow uses it only to
-    invoke that package; it is not synced to the Worker.
+    package. The weekly workflow uses it only to invoke that package; it is not
+    synced to the Worker.
 - `SENTRY_DSN` (optional)
   - In Sentry: create a project, copy the DSN, and add it as the repository
     secret `SENTRY_DSN`. Production and preview deploy workflows sync it with

--- a/docs/contributing/weekly-site-perf.md
+++ b/docs/contributing/weekly-site-perf.md
@@ -43,8 +43,8 @@ package. The agent implements an obvious local fix when it can, follows
 leaves the tracking issue open when a human should decide.
 
 Create a scoped invocation token on the `weekly-site-perf` package details page
-(`exportNames=.`, source `weekly-site-perf`) at
-`https://kody.codes/account/packages/<weekly-site-perf-package-id>?newToken=1&name=Weekly%20site%20perf&exportNames=.&allowedSources=weekly-site-perf`
+(`exportNames=.`) at
+`https://kody.codes/account/packages/<weekly-site-perf-package-id>?newToken=1&name=Weekly%20site%20perf&exportNames=.`
 and store the raw value as the repository (or org) secret
 `KODY_PACKAGE_INVOCATION_TOKEN`. Do not put the raw token in the URL. See
 [setup manifest](./setup-manifest.md).

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -110,8 +110,8 @@ curl -X POST \
 	}'
 ```
 
-Request JSON `source` is an optional caller label for logs and idempotency
-metadata. It does not gate authentication. For Kent's YouTube Worker, callers
+Request JSON `source` is an optional caller label for logs. It does not gate
+authentication or determine idempotency. For Kent's YouTube Worker, callers
 typically send `"source": "youtube-websub-proxy"`.
 
 Prefer canonical URL metadata from package discovery over manual string

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -28,8 +28,7 @@ Use it when:
 
 - a non-Kody process must invoke one saved package export
 - the user will store the raw bearer token in that external system
-- export access should be scoped to specific exports and optional source labels
-  on that package
+- export access should be scoped to specific exports on that package
 
 Do **not** ask the user to paste bearer tokens into chat. Do **not** include a
 `rawToken`, `token`, `bearer`, or token hash query parameter.
@@ -42,7 +41,7 @@ existing raw token or token hash.
 Agents can inspect existing token record metadata with
 `package_invocation_token_list` (requires `package_id`),
 `package_invocation_token_get`, and `package_get` (includes `tokens`). These
-capabilities return record ids, names, the owning package, export/source scopes,
+capabilities return record ids, names, the owning package, export scopes,
 timestamps, last-used metadata, and revocation status for the signed-in user's
 own records. They never return raw bearer token values or stored token hashes.
 
@@ -62,11 +61,11 @@ the HTTP API endpoint.
 
 Provide the user a URL like:
 
-`https://<your-kody-origin>/account/packages/<packageId>?newToken=1&name=Webhook%20Dispatcher&exportNames=dispatch-event&allowedSources=webhook-dispatcher`
+`https://<your-kody-origin>/account/packages/<packageId>?newToken=1&name=Webhook%20Dispatcher&exportNames=dispatch-event`
 
 Wildcard export setup for a highly trusted client of one package:
 
-`https://<your-kody-origin>/account/packages/<packageId>?newToken=1&name=Trusted%20External%20Client&exportNames=*&allowedSources=trusted-client`
+`https://<your-kody-origin>/account/packages/<packageId>?newToken=1&name=Trusted%20External%20Client&exportNames=*`
 
 ## Query params
 
@@ -79,8 +78,6 @@ field names without extra translation.
 | `newToken`                          | yes      | Set to `1` to open the create form on this package.                                                 |
 | `name`                              | no       | Human-readable token name.                                                                          |
 | `exportNames` / `exportName`        | no       | Package export names. `dispatch-event` is normalized to `./dispatch-event`; `*` allows all exports. |
-| `allowedSources` / `allowedSource`  | no       | Optional exact source labels the external caller may send in request JSON.                          |
-| `sources` / `source`                | no       | Alias for `allowedSources`.                                                                         |
 | `export_names`, `export-names`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                |
 
 ## Invocation URL format
@@ -113,10 +110,9 @@ curl -X POST \
 	}'
 ```
 
-When a token lists allowed sources, the request JSON `source` must match one of
-those labels exactly. For Kent's YouTube Worker, use
-`"source": "youtube-websub-proxy"`. When the list is empty, omit `source` or
-send null; a named `source` is rejected.
+Request JSON `source` is an optional caller label for logs and idempotency
+metadata. It does not gate authentication. For Kent's YouTube Worker, callers
+typically send `"source": "youtube-websub-proxy"`.
 
 Prefer canonical URL metadata from package discovery over manual string
 construction. `package_get` and package entity search details include canonical
@@ -136,11 +132,10 @@ they speak MCP.
 2. If debugging an existing setup, call `package_invocation_token_list` with
    that `package_id`, `package_invocation_token_get`, or read `tokens` from
    `package_get` first to confirm which token record exists and whether its
-   export and allowed-source scopes match the external caller. Do not ask the
-   user to read token metadata out of the browser UI unless the capability
-   response is insufficient.
-3. Generate an `/account/packages/<packageId>?newToken=1` URL with `name`,
-   export scope, and optional `allowedSources`.
+   export scopes match the external caller. Do not ask the user to read token
+   metadata out of the browser UI unless the capability response is insufficient.
+3. Generate an `/account/packages/<packageId>?newToken=1` URL with `name` and
+   export scope.
 4. Ask the user to open the URL, paste their locally generated raw token into
    the Raw token field, or click **Generate** and copy/deliver the generated
    value before creating the token.
@@ -152,8 +147,7 @@ they speak MCP.
    - `POST` to the canonical owner-scoped invocation URL from package metadata,
      not to an `/account/packages/...` setup URL
    - `Authorization: Bearer <raw-token>`
-   - JSON `source` matching one of the allowed sources when the token lists
-     sources; omit `source` when the list is empty
+   - optional JSON `source` as a caller label for logs; it does not gate auth
 6. Never display, log, store in docs, or send raw token material through chat or
    query params.
 
@@ -177,8 +171,8 @@ For external invocation smoke tests, check failures in this order:
    Rotate the package invocation token or check that the external secret
    contains the exact active raw bearer value scoped to that package.
 
-Package export names and `source` policy are checked only after bearer-token
-authentication succeeds.
+Package export names are checked only after bearer-token authentication
+succeeds. Request `source` is recorded when present and does not fail the call.
 
 ## Related
 

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -133,7 +133,8 @@ they speak MCP.
    that `package_id`, `package_invocation_token_get`, or read `tokens` from
    `package_get` first to confirm which token record exists and whether its
    export scopes match the external caller. Do not ask the user to read token
-   metadata out of the browser UI unless the capability response is insufficient.
+   metadata out of the browser UI unless the capability response is
+   insufficient.
 3. Generate an `/account/packages/<packageId>?newToken=1` URL with `name` and
    export scope.
 4. Ask the user to open the URL, paste their locally generated raw token into

--- a/packages/worker/client/routes/account-package-tokens.tsx
+++ b/packages/worker/client/routes/account-package-tokens.tsx
@@ -43,7 +43,6 @@ type TokenEditorState = {
 	name: string
 	rawToken: string
 	exportNamesText: string
-	sourcesText: string
 }
 
 export function readPackageTokenQuery(href: string) {
@@ -67,16 +66,6 @@ export function createTokenEditorStateFromHref(href: string): TokenEditorState {
 			'export-name',
 			'export-names',
 		]).join('\n'),
-		sourcesText: readCommaListParams(params, [
-			'source',
-			'sources',
-			'allowedSource',
-			'allowedSources',
-			'allowed_source',
-			'allowed_sources',
-			'allowed-source',
-			'allowed-sources',
-		]).join('\n'),
 	}
 }
 
@@ -85,7 +74,6 @@ function createEmptyEditorState(): TokenEditorState {
 		name: '',
 		rawToken: '',
 		exportNamesText: '',
-		sourcesText: '',
 	}
 }
 
@@ -96,7 +84,6 @@ function createEditorStateFromToken(
 		name: token.name,
 		rawToken: '',
 		exportNamesText: token.exportNames.join('\n'),
-		sourcesText: token.sources.join('\n'),
 	}
 }
 
@@ -120,11 +107,6 @@ function parseListText(value: string) {
 function formatScope(values: Array<string>) {
 	if (values.length === 0) return 'None'
 	if (values.includes(wildcardScope)) return 'Any export'
-	return values.join(', ')
-}
-
-function formatSources(values: Array<string>) {
-	if (values.length === 0) return 'Unlabeled only'
 	return values.join(', ')
 }
 
@@ -396,9 +378,6 @@ export function AccountPackageTokens(
 								<p mix={css({ margin: 0, color: colors.textMuted })}>
 									Exports: {formatScope(token.exportNames)}
 								</p>
-								<p mix={css({ margin: 0, color: colors.textMuted })}>
-									Sources: {formatSources(token.sources)}
-								</p>
 								{token.lastUsedAt ? (
 									<p mix={css({ margin: 0, color: colors.textMuted })}>
 										Last used {formatTimestamp(token.lastUsedAt)}
@@ -430,7 +409,6 @@ export function AccountPackageTokens(
 											name: editorState.name,
 											rawToken: editorState.rawToken,
 											exportNames: parseListText(editorState.exportNamesText),
-											sources: parseListText(editorState.sourcesText),
 										})
 										saveState = 'idle'
 										messageTone = 'info'
@@ -566,25 +544,6 @@ export function AccountPackageTokens(
 											editorState = {
 												...editorState,
 												exportNamesText: event.currentTarget.value,
-											}
-											handle.update()
-										}
-									}),
-								]}
-							/>
-						</label>
-						<label mix={css(fieldCss)}>
-							<span mix={css(fieldLabelCss)}>Allowed sources</span>
-							<textarea
-								value={editorState.sourcesText}
-								placeholder="youtube-websub-proxy"
-								mix={[
-									css(accountTextareaCss),
-									on('input', (event) => {
-										if (event.currentTarget instanceof HTMLTextAreaElement) {
-											editorState = {
-												...editorState,
-												sourcesText: event.currentTarget.value,
 											}
 											handle.update()
 										}

--- a/packages/worker/migrations/0019-drop-invocation-token-sources.sql
+++ b/packages/worker/migrations/0019-drop-invocation-token-sources.sql
@@ -1,0 +1,49 @@
+-- Invocation tokens no longer store a source allowlist. Request JSON
+-- `source` stays an optional label for logs and does not gate auth.
+
+CREATE TABLE package_invocation_tokens_next (
+	id TEXT PRIMARY KEY,
+	user_id TEXT NOT NULL,
+	package_id TEXT NOT NULL,
+	name TEXT NOT NULL,
+	token_hash TEXT NOT NULL,
+	export_names_json TEXT NOT NULL DEFAULT '[]',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	last_used_at TEXT,
+	revoked_at TEXT
+);
+
+INSERT INTO package_invocation_tokens_next (
+	id,
+	user_id,
+	package_id,
+	name,
+	token_hash,
+	export_names_json,
+	created_at,
+	updated_at,
+	last_used_at,
+	revoked_at
+)
+SELECT
+	id,
+	user_id,
+	package_id,
+	name,
+	token_hash,
+	export_names_json,
+	created_at,
+	updated_at,
+	last_used_at,
+	revoked_at
+FROM package_invocation_tokens;
+
+DROP TABLE package_invocation_tokens;
+ALTER TABLE package_invocation_tokens_next RENAME TO package_invocation_tokens;
+
+CREATE INDEX idx_package_invocation_tokens_user_package
+ON package_invocation_tokens(user_id, package_id);
+
+CREATE UNIQUE INDEX idx_package_invocation_tokens_user_package_hash
+ON package_invocation_tokens(user_id, package_id, token_hash);

--- a/packages/worker/src/app/account-package-tokens.ts
+++ b/packages/worker/src/app/account-package-tokens.ts
@@ -102,9 +102,6 @@ async function handleCreateToken(input: {
 			400,
 		)
 	}
-	const sources = normalizeScopeList(
-		readStringArray(input.body, ['sources', 'source', 'source_names']),
-	)
 	if (exportNames.length === 0) {
 		return jsonResponse(
 			{ ok: false, error: 'Choose at least one export scope.' },
@@ -123,7 +120,6 @@ async function handleCreateToken(input: {
 				name,
 				tokenHash: await hashPackageInvocationBearerToken(rawToken),
 				exportNames,
-				sources,
 			},
 		})
 	} catch (error) {
@@ -187,9 +183,6 @@ async function handleUpdateToken(input: {
 			400,
 		)
 	}
-	const sources = normalizeScopeList(
-		readStringArray(input.body, ['sources', 'source', 'source_names']),
-	)
 	if (exportNames.length === 0) {
 		return jsonResponse(
 			{ ok: false, error: 'Choose at least one export scope.' },
@@ -209,7 +202,6 @@ async function handleUpdateToken(input: {
 				? await hashPackageInvocationBearerToken(rawToken)
 				: undefined,
 			exportNames,
-			sources,
 		})
 	} catch (error) {
 		const message = error instanceof Error ? error.message : ''
@@ -342,14 +334,6 @@ async function handleDeleteToken(input: {
 			user: input.user,
 			pathPackageId: owned.packageId,
 		}),
-	)
-}
-
-function normalizeScopeList(values: Array<string>) {
-	return Array.from(
-		new Set(
-			values.map((value) => value.trim()).filter((value) => value.length > 0),
-		),
 	)
 }
 

--- a/packages/worker/src/app/account-packages-data.ts
+++ b/packages/worker/src/app/account-packages-data.ts
@@ -87,7 +87,6 @@ function toToken(token: PackageInvocationTokenRecord): AccountPackageToken {
 		id: token.id,
 		name: token.name,
 		exportNames: token.exportNames,
-		sources: token.sources,
 		createdAt: token.created_at,
 		updatedAt: token.updated_at,
 		lastUsedAt: token.last_used_at,

--- a/packages/worker/src/app/handlers/account-packages.node.test.ts
+++ b/packages/worker/src/app/handlers/account-packages.node.test.ts
@@ -21,13 +21,11 @@ const tokenRecord = {
 	token_hash: 'stored-hash',
 	name: 'Personal client',
 	export_names_json: '["*"]',
-	sources_json: '["personal-client"]',
 	created_at: new Date(0).toISOString(),
 	updated_at: new Date(0).toISOString(),
 	last_used_at: null,
 	revoked_at: null,
 	exportNames: ['*'],
-	sources: ['personal-client'],
 }
 
 const mockModule = vi.hoisted(() => ({
@@ -230,7 +228,6 @@ test('packages API lists with filters, ignores invalid values, and rejects unkno
 					id: 'token-1',
 					name: 'Personal client',
 					exportNames: ['*'],
-					sources: ['personal-client'],
 				},
 			],
 		},
@@ -300,7 +297,6 @@ test('packages API creates, updates, revokes, reinstates, and deletes package to
 				name: 'Personal automation',
 				rawToken: 'raw-personal-client-token',
 				exportNames: ['*'],
-				sources: ['personal-client'],
 			}),
 		}),
 		params: {},
@@ -318,7 +314,6 @@ test('packages API creates, updates, revokes, reinstates, and deletes package to
 			name: 'Personal automation',
 			tokenHash: 'hashed-raw-token',
 			exportNames: ['*'],
-			sources: ['personal-client'],
 		}),
 	})
 	const createText = await createResponse.text()
@@ -357,7 +352,6 @@ test('packages API creates, updates, revokes, reinstates, and deletes package to
 				id: 'token-1',
 				name: 'Updated personal client',
 				exportNames: ['dispatch-message-created'],
-				sources: ['updated-client'],
 				tokenHash: 'should-not-be-read',
 			}),
 		}),
@@ -374,7 +368,6 @@ test('packages API creates, updates, revokes, reinstates, and deletes package to
 		name: 'Updated personal client',
 		tokenHash: undefined,
 		exportNames: ['./dispatch-message-created'],
-		sources: ['updated-client'],
 	})
 	const updateText = await updateResponse.text()
 	expect(updateText).not.toContain('should-not-be-read')
@@ -395,7 +388,6 @@ test('packages API creates, updates, revokes, reinstates, and deletes package to
 				name: 'Rotated personal client',
 				rawToken: 'replacement-raw-token',
 				exportNames: ['dispatch-message-created'],
-				sources: ['rotated-client'],
 			}),
 		}),
 		params: {},
@@ -414,7 +406,6 @@ test('packages API creates, updates, revokes, reinstates, and deletes package to
 		name: 'Rotated personal client',
 		tokenHash: 'hashed-raw-token',
 		exportNames: ['./dispatch-message-created'],
-		sources: ['rotated-client'],
 	})
 
 	const revokeResponse = await handler.handler({

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-capabilities.node.test.ts
@@ -34,13 +34,11 @@ const tokenRecord = {
 	token_hash: 'stored-token-hash',
 	name: 'Discord gateway',
 	export_names_json: '["./dispatch-event"]',
-	sources_json: '["discord-fly-proxy"]',
 	created_at: '2026-07-01T00:00:00.000Z',
 	updated_at: '2026-07-02T00:00:00.000Z',
 	last_used_at: '2026-07-03T00:00:00.000Z',
 	revoked_at: null,
 	exportNames: ['./dispatch-event'],
-	sources: ['discord-fly-proxy'],
 }
 
 function createCapabilityContext() {
@@ -101,7 +99,6 @@ test('package invocation token capabilities return package-scoped metadata witho
 				name: 'Discord gateway',
 				package_id: 'package-1',
 				export_names: ['./dispatch-event'],
-				allowed_sources: ['discord-fly-proxy'],
 				created_at: '2026-07-01T00:00:00.000Z',
 				updated_at: '2026-07-02T00:00:00.000Z',
 				last_used_at: '2026-07-03T00:00:00.000Z',
@@ -126,7 +123,6 @@ test('package invocation token capabilities return package-scoped metadata witho
 			name: 'Revoked client',
 			package_id: 'package-1',
 			export_names: ['./dispatch-event'],
-			allowed_sources: ['discord-fly-proxy'],
 			created_at: '2026-07-01T00:00:00.000Z',
 			updated_at: '2026-07-02T00:00:00.000Z',
 			last_used_at: null,

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-get.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-get.ts
@@ -14,7 +14,7 @@ export const packageInvocationTokenGetCapability = defineDomainCapability(
 	{
 		name: 'package_invocation_token_get',
 		description:
-			'Get metadata for one package invocation token record owned by the signed-in user, including the owning package, export/source scopes, timestamps, last-used, and revocation status. Raw bearer token values and stored token hashes are never returned.',
+			'Get metadata for one package invocation token record owned by the signed-in user, including the owning package, export scopes, timestamps, last-used, and revocation status. Raw bearer token values and stored token hashes are never returned.',
 		keywords: [
 			'package invocation token',
 			'invocation token',

--- a/packages/worker/src/mcp/capabilities/packages/package-invocation-token-list.ts
+++ b/packages/worker/src/mcp/capabilities/packages/package-invocation-token-list.ts
@@ -18,7 +18,7 @@ export const packageInvocationTokenListCapability = defineDomainCapability(
 	{
 		name: 'package_invocation_token_list',
 		description:
-			'List invocation token metadata for one saved package owned by the signed-in user, including export/source scopes, timestamps, last-used, and revocation status. Raw bearer token values and stored token hashes are never returned.',
+			'List invocation token metadata for one saved package owned by the signed-in user, including export scopes, timestamps, last-used, and revocation status. Raw bearer token values and stored token hashes are never returned.',
 		keywords: [
 			'package invocation token',
 			'invocation token',

--- a/packages/worker/src/mcp/capabilities/packages/shared.ts
+++ b/packages/worker/src/mcp/capabilities/packages/shared.ts
@@ -217,11 +217,6 @@ export const packageInvocationTokenMetadataSchema = z.object({
 		.describe(
 			'Normalized package export scopes allowed by this token record, including * when all exports on this package are allowed.',
 		),
-	allowed_sources: z
-		.array(z.string())
-		.describe(
-			'Exact source labels this token accepts in request JSON. Empty allows unlabeled requests only; a named source must match the list.',
-		),
 	created_at: z.string(),
 	updated_at: z.string(),
 	last_used_at: z
@@ -249,7 +244,6 @@ export function toPackageInvocationTokenMetadata(token: {
 	name: string
 	package_id: string
 	exportNames: Array<string>
-	sources: Array<string>
 	created_at: string
 	updated_at: string
 	last_used_at: string | null
@@ -260,7 +254,6 @@ export function toPackageInvocationTokenMetadata(token: {
 		name: token.name,
 		package_id: token.package_id,
 		export_names: token.exportNames,
-		allowed_sources: token.sources,
 		created_at: token.created_at,
 		updated_at: token.updated_at,
 		last_used_at: token.last_used_at,

--- a/packages/worker/src/package-invocations/common.ts
+++ b/packages/worker/src/package-invocations/common.ts
@@ -21,7 +21,6 @@ export type PackageInvocationTokenScope = {
 	email?: string
 	packageId: string
 	exportNames?: Array<string>
-	sources?: Array<string>
 }
 
 export type PackageInvocationRequest = {

--- a/packages/worker/src/package-invocations/drop-invocation-token-sources-migration.node.test.ts
+++ b/packages/worker/src/package-invocations/drop-invocation-token-sources-migration.node.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+
+const migrationsDirectory = new URL('../../migrations/', import.meta.url)
+const baselineSql = readFileSync(
+	new URL('0001-squashed-init.sql', migrationsDirectory),
+	'utf8',
+)
+const ownedTokenSql = readFileSync(
+	new URL('0017-package-owned-invocation-tokens.sql', migrationsDirectory),
+	'utf8',
+)
+const dropSourcesSql = readFileSync(
+	new URL('0019-drop-invocation-token-sources.sql', migrationsDirectory),
+	'utf8',
+)
+
+test('0019 drops sources_json and keeps package-owned token rows', () => {
+	const db = new DatabaseSync(':memory:')
+	db.exec(baselineSql)
+	db.exec(ownedTokenSql)
+	db.prepare(
+		`INSERT INTO saved_packages (
+			id, user_id, name, kody_id, description, source_id, created_at, updated_at
+		) VALUES (?, ?, ?, ?, '', ?, '2026-08-19', '2026-08-19')`,
+	).run('pkg-a', 'user-1', '@user/alpha', 'alpha', 'source-pkg-a')
+	db.prepare(
+		`INSERT INTO package_invocation_tokens (
+			id, user_id, package_id, name, token_hash, export_names_json,
+			sources_json, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, '2026-08-19', '2026-08-19')`,
+	).run(
+		'token-1',
+		'user-1',
+		'pkg-a',
+		'Weekly site perf',
+		'hash-1',
+		'["."]',
+		'["weekly-site-perf"]',
+	)
+
+	db.exec(dropSourcesSql)
+
+	const columns = db
+		.prepare(`PRAGMA table_info(package_invocation_tokens)`)
+		.all() as Array<{ name: string }>
+	const columnNames = columns.map((column) => column.name)
+	expect(columnNames).toContain('package_id')
+	expect(columnNames).toContain('export_names_json')
+	expect(columnNames).not.toContain('sources_json')
+
+	const rows = db
+		.prepare(
+			`SELECT id, user_id, package_id, name, token_hash, export_names_json
+			FROM package_invocation_tokens`,
+		)
+		.all() as Array<{
+		id: string
+		user_id: string
+		package_id: string
+		name: string
+		token_hash: string
+		export_names_json: string
+	}>
+	expect(rows).toEqual([
+		{
+			id: 'token-1',
+			user_id: 'user-1',
+			package_id: 'pkg-a',
+			name: 'Weekly site perf',
+			token_hash: 'hash-1',
+			export_names_json: '["."]',
+		},
+	])
+})

--- a/packages/worker/src/package-invocations/http-invoke.ts
+++ b/packages/worker/src/package-invocations/http-invoke.ts
@@ -37,15 +37,6 @@ function tokenAllowsExport(input: {
 	)
 }
 
-function tokenAllowsSource(input: {
-	token: PackageInvocationTokenScope
-	source: string | null
-}) {
-	if (!input.source) return true
-	const sources = input.token.sources ?? []
-	return sources.includes(input.source)
-}
-
 export async function invokePackageExportForExecuteRuntime(input: {
 	env: Env
 	baseUrl: string
@@ -241,14 +232,6 @@ export async function invokePackageExportWithToolFactories(input: {
 	}
 	const source = normalizeNullableString(input.request.source)
 	const topic = normalizeNullableString(input.request.topic)
-	if (!tokenAllowsSource({ token: input.token, source })) {
-		return buildJsonErrorResponse({
-			status: 403,
-			code: 'source_not_allowed',
-			message: 'This token is not allowed to invoke the requested source.',
-			idempotencyKey: idempotencyKey ?? undefined,
-		})
-	}
 	const savedPackage = await resolveSavedPackage({
 		db: input.env.APP_DB,
 		userId: input.token.userId,

--- a/packages/worker/src/package-invocations/http.node.test.ts
+++ b/packages/worker/src/package-invocations/http.node.test.ts
@@ -27,7 +27,6 @@ async function createEnv(
 		tokenRow?: {
 			package_id?: string
 			export_names_json?: string
-			sources_json?: string
 			revoked_at?: string | null
 		}
 		touchChanges?: number
@@ -46,8 +45,6 @@ async function createEnv(
 			export_names_json:
 				options.tokenRow?.export_names_json ??
 				JSON.stringify(['./dispatch-message-created']),
-			sources_json:
-				options.tokenRow?.sources_json ?? JSON.stringify(['discord-gateway']),
 			created_at: '2026-04-27T00:00:00.000Z',
 			updated_at: '2026-04-27T00:00:00.000Z',
 			last_used_at: null,
@@ -392,7 +389,6 @@ test('package invocation API validates requests and invokes exports with scoped 
 			email: 'me@example.com',
 			packageId: 'pkg-discord-gateway',
 			exportNames: ['./dispatch-message-created'],
-			sources: ['discord-gateway'],
 		},
 		request: {
 			packageIdOrKodyId: 'discord-gateway',

--- a/packages/worker/src/package-invocations/http.ts
+++ b/packages/worker/src/package-invocations/http.ts
@@ -156,7 +156,6 @@ async function resolveTokenScope(input: {
 		email: input.email,
 		packageId: record.package_id,
 		exportNames: record.exportNames,
-		sources: record.sources,
 	}
 }
 

--- a/packages/worker/src/package-invocations/public-url.ts
+++ b/packages/worker/src/package-invocations/public-url.ts
@@ -18,7 +18,7 @@ export type ExternalPackageInvocationDescriptor = {
 }
 
 const sourceGuidance =
-	'JSON "source" is an optional caller label for logs and idempotency metadata. It does not gate authentication.'
+	'JSON "source" is an optional caller label for logs. It does not gate authentication or determine idempotency.'
 
 function buildPackageInvocationTokenSetupExportName(exportName: string) {
 	const normalized = normalizePackageInvocationExportName(exportName)

--- a/packages/worker/src/package-invocations/public-url.ts
+++ b/packages/worker/src/package-invocations/public-url.ts
@@ -18,7 +18,7 @@ export type ExternalPackageInvocationDescriptor = {
 }
 
 const sourceGuidance =
-	'If the token lists allowedSources, include JSON "source" with an exact listed label. If the list is empty, omit "source" or send null.'
+	'JSON "source" is an optional caller label for logs and idempotency metadata. It does not gate authentication.'
 
 function buildPackageInvocationTokenSetupExportName(exportName: string) {
 	const normalized = normalizePackageInvocationExportName(exportName)

--- a/packages/worker/src/package-invocations/repo.ts
+++ b/packages/worker/src/package-invocations/repo.ts
@@ -46,7 +46,6 @@ const packageInvocationTokenRowSchema = object({
 	token_hash: string(),
 	name: string(),
 	export_names_json: string(),
-	sources_json: string(),
 	created_at: string(),
 	updated_at: string(),
 	last_used_at: nullable(string()),
@@ -62,7 +61,6 @@ export type PackageInvocationTokenRecord = InferOutput<
 	typeof packageInvocationTokenRowSchema
 > & {
 	exportNames: Array<string>
-	sources: Array<string>
 }
 
 export async function hashPackageInvocationBearerToken(token: string) {
@@ -140,10 +138,6 @@ function mapTokenRow(
 		exportNames: parseStringArrayJson({
 			value: parsed.value.export_names_json,
 			field: 'export_names_json',
-		}),
-		sources: parseStringArrayJson({
-			value: parsed.value.sources_json,
-			field: 'sources_json',
 		}),
 	}
 }
@@ -229,7 +223,6 @@ export async function insertPackageInvocationToken(input: {
 		name: string
 		tokenHash: string
 		exportNames: Array<string>
-		sources: Array<string>
 	}
 }) {
 	const now = new Date().toISOString()
@@ -242,10 +235,9 @@ export async function insertPackageInvocationToken(input: {
 				name,
 				token_hash,
 				export_names_json,
-				sources_json,
 				created_at,
 				updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.bind(
 			input.row.id,
@@ -254,7 +246,6 @@ export async function insertPackageInvocationToken(input: {
 			input.row.name,
 			input.row.tokenHash,
 			JSON.stringify(input.row.exportNames),
-			JSON.stringify(input.row.sources),
 			now,
 			now,
 		)
@@ -269,7 +260,6 @@ export async function updatePackageInvocationToken(input: {
 	name: string
 	tokenHash?: string
 	exportNames: Array<string>
-	sources: Array<string>
 }) {
 	const result = await input.db
 		.prepare(
@@ -277,7 +267,6 @@ export async function updatePackageInvocationToken(input: {
 			SET name = ?,
 				token_hash = COALESCE(?, token_hash),
 				export_names_json = ?,
-				sources_json = ?,
 				updated_at = ?
 			WHERE id = ?
 				AND user_id = ?
@@ -288,7 +277,6 @@ export async function updatePackageInvocationToken(input: {
 			input.name,
 			input.tokenHash ?? null,
 			JSON.stringify(input.exportNames),
-			JSON.stringify(input.sources),
 			new Date().toISOString(),
 			input.id,
 			input.userId,

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -501,7 +501,6 @@ function createToken(
 	overrides: Partial<{
 		packageId: string
 		exportNames: Array<string>
-		sources: Array<string>
 	}> = {},
 ) {
 	return {
@@ -510,7 +509,6 @@ function createToken(
 		email: 'me@example.com',
 		packageId: overrides.packageId ?? 'pkg-1',
 		exportNames: overrides.exportNames ?? ['./dispatch-message-created'],
-		sources: overrides.sources ?? ['discord-gateway'],
 	} as const
 }
 
@@ -2119,13 +2117,13 @@ test('completed keyed invocation reports terminal persistence failure instead of
 	const first = await invokePackageExport({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
-		token: createToken({ sources: ['webhook'] }),
+		token: createToken(),
 		request,
 	})
 	const retry = await invokePackageExport({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
-		token: createToken({ sources: ['webhook'] }),
+		token: createToken(),
 		request,
 	})
 
@@ -2243,42 +2241,19 @@ test('a pre-migration-style key misses cleanly: it executes fresh instead of err
 	).toMatchObject({ status: 'completed' })
 })
 
-test('invokePackageExport enforces source scopes for wildcard tokens', async () => {
+test('invokePackageExport records request source without gating auth', async () => {
 	const db = createDatabase()
 	seedPackageResolution()
-
-	const disallowedSource = await invokePackageExport({
-		env: createEnv(db),
-		baseUrl: 'https://kody.dev',
-		token: createToken(),
-		request: {
-			packageIdOrKodyId: 'discord-gateway',
-			exportName: 'dispatch-message-created',
-			params: { content: 'hi' },
-			idempotencyKey: 'evt-bad-source',
-			source: 'other-gateway',
-		},
-	})
-
-	expect(disallowedSource.status).toBe(403)
-	expect(disallowedSource.body).toMatchObject({
-		ok: false,
-		error: {
-			code: 'source_not_allowed',
-		},
-	})
-
 	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
 		result: { reply: 'hello trusted client' },
 		logs: ['invoked'],
 	})
 
-	const allowed = await invokePackageExport({
+	const namedSource = await invokePackageExport({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
 		token: createToken({
 			exportNames: ['*'],
-			sources: ['personal-client'],
 		}),
 		request: {
 			packageIdOrKodyId: 'discord-gateway',
@@ -2289,20 +2264,19 @@ test('invokePackageExport enforces source scopes for wildcard tokens', async () 
 		},
 	})
 
-	expect(allowed.status).toBe(200)
-	expect(allowed.body).toMatchObject({
+	expect(namedSource.status).toBe(200)
+	expect(namedSource.body).toMatchObject({
 		ok: true,
 		exportName: './dispatch-message-created',
 		source: 'personal-client',
 		result: { reply: 'hello trusted client' },
 	})
 
-	const denied = await invokePackageExport({
+	const otherNamedSource = await invokePackageExport({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
 		token: createToken({
 			exportNames: ['*'],
-			sources: ['personal-client'],
 		}),
 		request: {
 			packageIdOrKodyId: 'discord-gateway',
@@ -2313,21 +2287,38 @@ test('invokePackageExport enforces source scopes for wildcard tokens', async () 
 		},
 	})
 
-	expect(denied.status).toBe(403)
-	expect(denied.body).toMatchObject({
-		ok: false,
-		error: {
-			code: 'source_not_allowed',
+	expect(otherNamedSource.status).toBe(200)
+	expect(otherNamedSource.body).toMatchObject({
+		ok: true,
+		source: 'shortcuts',
+	})
+
+	const unlabeled = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken({
+			exportNames: ['*'],
+		}),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: { content: 'hi' },
+			idempotencyKey: 'evt-unlabeled',
 		},
 	})
-	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(1)
+
+	expect(unlabeled.status).toBe(200)
+	expect(unlabeled.body).toMatchObject({
+		ok: true,
+		result: { reply: 'hello trusted client' },
+	})
+	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(3)
 
 	const scopedDeniedByExport = await invokePackageExport({
 		env: createEnv(db),
 		baseUrl: 'https://kody.dev',
 		token: createToken({
 			exportNames: ['./other-export'],
-			sources: ['discord-gateway'],
 		}),
 		request: {
 			packageIdOrKodyId: 'discord-gateway',
@@ -2352,7 +2343,6 @@ test('invokePackageExport enforces source scopes for wildcard tokens', async () 
 		token: createToken({
 			packageId: 'pkg-other',
 			exportNames: ['*'],
-			sources: ['discord-gateway'],
 		}),
 		request: {
 			packageIdOrKodyId: 'discord-gateway',
@@ -2370,57 +2360,6 @@ test('invokePackageExport enforces source scopes for wildcard tokens', async () 
 			code: 'package_not_allowed',
 		},
 	})
-
-	const emptySourcesNamedDenied = await invokePackageExport({
-		env: createEnv(db),
-		baseUrl: 'https://kody.dev',
-		token: createToken({
-			exportNames: ['*'],
-			sources: [],
-		}),
-		request: {
-			packageIdOrKodyId: 'discord-gateway',
-			exportName: 'dispatch-message-created',
-			params: { content: 'hi' },
-			idempotencyKey: 'evt-empty-sources-named',
-			source: 'personal-client',
-		},
-	})
-
-	expect(emptySourcesNamedDenied.status).toBe(403)
-	expect(emptySourcesNamedDenied.body).toMatchObject({
-		ok: false,
-		error: {
-			code: 'source_not_allowed',
-		},
-	})
-
-	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
-		result: { reply: 'unlabeled' },
-		logs: ['invoked'],
-	})
-
-	const emptySourcesUnlabeled = await invokePackageExport({
-		env: createEnv(db),
-		baseUrl: 'https://kody.dev',
-		token: createToken({
-			exportNames: ['*'],
-			sources: [],
-		}),
-		request: {
-			packageIdOrKodyId: 'discord-gateway',
-			exportName: 'dispatch-message-created',
-			params: { content: 'hi' },
-			idempotencyKey: 'evt-empty-sources-unlabeled',
-		},
-	})
-
-	expect(emptySourcesUnlabeled.status).toBe(200)
-	expect(emptySourcesUnlabeled.body).toMatchObject({
-		ok: true,
-		result: { reply: 'unlabeled' },
-	})
-	expect(repoMockModule.runBundledModuleWithRegistry).toHaveBeenCalledTimes(2)
 })
 
 test('invokePackageExport stores terminal failures for execution errors and missing exports', async () => {

--- a/packages/worker/src/package-invocations/test-schema.ts
+++ b/packages/worker/src/package-invocations/test-schema.ts
@@ -12,7 +12,6 @@ export async function ensurePackageInvocationTokensTestSchema(db: D1Database) {
 				name TEXT NOT NULL,
 				token_hash TEXT NOT NULL,
 				export_names_json TEXT NOT NULL DEFAULT '[]',
-				sources_json TEXT NOT NULL DEFAULT '[]',
 				created_at TEXT NOT NULL,
 				updated_at TEXT NOT NULL,
 				last_used_at TEXT,

--- a/packages/worker/src/package-runtime/package-workflows.ts
+++ b/packages/worker/src/package-runtime/package-workflows.ts
@@ -1497,7 +1497,6 @@ export class DynamicCallableWorkflowBase extends WorkflowEntrypoint<
 					userId: payload.userId,
 					packageId: payload.packageId,
 					exportNames: [payload.exportName],
-					sources: [packageWorkflowInvocationSource],
 				},
 				request: {
 					packageIdOrKodyId: payload.packageId,

--- a/packages/worker/src/webhooks/delivery.ts
+++ b/packages/worker/src/webhooks/delivery.ts
@@ -79,7 +79,6 @@ export async function dispatchWebhookInvocation(input: {
 			userId: input.endpoint.userId,
 			packageId: input.endpoint.packageId,
 			exportNames: [input.exportName],
-			sources: ['webhook'],
 		},
 		request: {
 			packageIdOrKodyId: input.endpoint.packageId,

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -984,7 +984,6 @@ export type AccountPackageToken = {
 	id: string
 	name: string
 	exportNames: Array<string>
-	sources: Array<string>
 	createdAt: string
 	updatedAt: string
 	lastUsedAt: string | null

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -75,6 +75,10 @@
 		{
 			"filename": "0018-drop-retired-service-storage-kind.sql",
 			"sha256": "a7036229d5821900c3a45da2e4841d3439ea7d219f874a208462a10a29de26c5"
+		},
+		{
+			"filename": "0019-drop-invocation-token-sources.sql",
+			"sha256": "de2e5badf20b92e69237cd60ef7a9736adefb45e6d6895c0fcf40859ca86552f"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The token-level source allowlist is not a real client check: omit or null `source` always passed, so a stolen bearer that skipped the label still worked. Drop that column and the form/MCP/auth check. Keep request JSON `source` as an optional log label. Export allowlists and package ownership stay.

## Summary

- Migration `0019` rebuilds `package_invocation_tokens` without `sources_json`.
- HTTP invoke no longer returns `source_not_allowed`. Request `source` is still recorded.
- Create/edit UI, account JSON, and MCP token metadata no longer mention allowed sources.
- Leftover `?allowedSources=` setup-URL params are ignored.
- ADR [0027](docs/contributing/decisions/0027-no-invocation-token-source-allowlist.md). 0026 package ownership stays accepted.

## Testing

- `npx vitest run --project node-unit` on invoke, HTTP, account-packages, MCP token, public-url, and 0017/0019 migration tests (31 passed).
- `npm run typecheck`, `npm run lint`, and `npm run format -- --check` passed.
- Validate on `fa401b0c` was green (Static, Node, Workers, MCP, E2E). Head is now `44aa17a4` (CodeRabbit wording fix: `source` is a log label, not idempotency metadata).
- Bugbot: success, no comments. CodeRabbit: one valid docs nit, addressed.
- Preview `https://kody-pr-1570.kody-a99.workers.dev` as seed `me@kentcdodds.com` / `user-me`:
  - `GET /account/packages.json` → empty list, no `sources` key
  - `POST create-token` without `packageId` → 400 `Package id is required`
  - `POST create-token` with a fake package id and leftover `sources` → 404 `Package not found` (sources ignored)
  - `GET /account/package-invocation-tokens` → 404
  - leftover `?allowedSources=` query loads; page has no Allowed sources copy
  - Deployed `account-area` JS: token form submits `exportNames` only; list shows Exports; no Package tokens nav
  - Seed has no packages and preview community listings are empty, so the create-token happy path could not be exercised on preview. Unit tests cover create/update/invoke.

![Preview packages page with Packages nav and no Package tokens item](https://cursor.com/artifacts/c/art-b1e2db34-d5ca-4d5d-9ce5-4f1d59739c43)
<a href="https://cursor.com/agents/bc-a6399322-2fa0-4068-a33b-e237406601f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_packages_no_source_allowlist.mp4"><img src="https://cursor.com/artifacts/c/art-1ec7f12b-9e32-44ec-8773-2b498627e4f8" alt="preview_packages_no_source_allowlist.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `dc5e6ec6` · **Head:** `44aa17a4`

**Classification:** extends — token schema, HTTP auth, account UI, and MCP metadata drop the source allowlist. Request `source` stays a log label.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `d1-app-db` | storage | extends — `0019` drops `sources_json` |
| `app-ui` | surfaces | extends — token form and `/account/packages.json` no longer read or write sources |
| `saved-packages` | assistant | extends — MCP token metadata drops `allowed_sources` |
| `webhooks` | assistant | composes — synthetic token no longer sets `sources`; request `source` stays `webhook` |
| `workflows` | assistant | composes — synthetic token no longer sets `sources`; request `source` stays `package-workflow` |

Unmatched `packages/worker/src/package-invocations/` is the bearer-token HTTP path: `tokenAllowsSource` and `source_not_allowed` are removed.

### Change flow

External HTTP invoke still resolves owner and package from the URL, then the bearer hash. This PR stops checking a token-level source list.

```mermaid
sequenceDiagram
	actor Caller
	participant appUi as app-ui
	participant d1AppDb as d1-app-db
	participant savedPackages as saved-packages
	Caller->>appUi: POST /account/packages.json create-token (exportNames only)
	appUi->>d1AppDb: insert package_invocation_tokens without sources_json
	Caller->>savedPackages: POST /@:user/api/package-invocations/:kodyId/:export
	savedPackages->>d1AppDb: lookup user_id + package_id + token_hash
	Note over savedPackages: export allowlist still gates; request source is logged only
	savedPackages-->>Caller: invoke result (no source_not_allowed)
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Token row | `sources_json` allowlist | column dropped |
| Named request `source` | 403 unless listed | allowed; recorded |
| Empty `sources_json` + named `source` | 403 | n/a (column gone) |
| MCP token metadata | `allowed_sources` | field removed |
| Setup URL `allowedSources=` | prefills the form | ignored |

### Invariants

Per-user isolation is unchanged: auth still resolves owner + package from the URL, then `(user_id, package_id, token_hash)`. This PR does not add a cross-user or cross-package grant.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6399322-2fa0-4068-a33b-e237406601f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6399322-2fa0-4068-a33b-e237406601f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package invocation tokens now use export scopes exclusively.
  * Request `source` values remain available as optional logging metadata and do not affect authentication or idempotency.
  * Export scope handling is normalized, deduplicated, and supports wildcard access.

* **Bug Fixes**
  * Removed source-based authorization checks while preserving package and export permissions.

* **Documentation**
  * Updated token setup, API guidance, architecture records, and examples to reflect the revised behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->