### PR TITLE
Describe token fields and select package exports

### DIFF
--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -11,9 +11,11 @@ category: platform
 # Package invocation token setup guide
 
 Use the hosted **package details** page when an external trusted client needs to
-call one Kody package export through the package invocation HTTP API. The agent
-may construct a prefilled setup URL, but the agent must never see, generate for
-chat, or place the raw bearer token in the URL.
+call one Kody package export through the package invocation HTTP API. The create
+form lists **Any export (`*`)** plus each export from the package manifest.
+Setup query params prefill that selection. The agent may construct a prefilled
+setup URL, but the agent must never see, generate for chat, or place the raw
+bearer token in the URL.
 
 For code that runs inside Kody, never use bearer tokens: statically import the
 target package (`kody:@scope/package/export`) when its name is known when the
@@ -73,12 +75,12 @@ Repeat params or comma-separate values for list fields. The form also accepts
 common snake_case and kebab-case aliases so agents can construct URLs from API
 field names without extra translation.
 
-| Param                               | Required | Description                                                                                         |
-| ----------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
-| `newToken`                          | yes      | Set to `1` to open the create form on this package.                                                 |
-| `name`                              | no       | Human-readable token name.                                                                          |
-| `exportNames` / `exportName`        | no       | Package export names. `dispatch-event` is normalized to `./dispatch-event`; `*` allows all exports. |
-| `export_names`, `export-names`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                |
+| Param                               | Required | Description                                                                                                      |
+| ----------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `newToken`                          | yes      | Set to `1` to open the create form on this package.                                                              |
+| `name`                              | no       | Human-readable token name.                                                                                       |
+| `exportNames` / `exportName`        | no       | Package export names to preselect. `dispatch-event` is normalized to `./dispatch-event`; `*` selects Any export. |
+| `export_names`, `export-names`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                             |
 
 ## Invocation URL format
 
@@ -136,10 +138,11 @@ they speak MCP.
    metadata out of the browser UI unless the capability response is
    insufficient.
 3. Generate an `/account/packages/<packageId>?newToken=1` URL with `name` and
-   export scope.
-4. Ask the user to open the URL, paste their locally generated raw token into
-   the Raw token field, or click **Generate** and copy/deliver the generated
-   value before creating the token.
+   export scope. Those query params prefill the create form: `exportNames`
+   checks the matching export boxes, and `*` checks **Any export**.
+4. Ask the user to open the URL, confirm the export selection, paste their
+   locally generated raw token into the Raw token field, or click **Generate**
+   and copy/deliver the generated value before creating the token.
    - For rotation, ask the user to open the package details page, select the
      token, and paste or generate the new raw token.
    - The external service or secret store must receive the exact raw value that

--- a/docs/guides/account-package-invocation-token-setup.md
+++ b/docs/guides/account-package-invocation-token-setup.md
@@ -75,12 +75,12 @@ Repeat params or comma-separate values for list fields. The form also accepts
 common snake_case and kebab-case aliases so agents can construct URLs from API
 field names without extra translation.
 
-| Param                               | Required | Description                                                                                                      |
-| ----------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `newToken`                          | yes      | Set to `1` to open the create form on this package.                                                              |
-| `name`                              | no       | Human-readable token name.                                                                                       |
-| `exportNames` / `exportName`        | no       | Package export names to preselect. `dispatch-event` is normalized to `./dispatch-event`; `*` selects Any export. |
-| `export_names`, `export-names`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                             |
+| Param                               | Required | Description                                                                                                                                                                      |
+| ----------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `newToken`                          | yes      | Set to `1` to open the create form on this package.                                                                                                                              |
+| `name`                              | no       | Human-readable token name.                                                                                                                                                       |
+| `exportNames` / `exportName`        | no       | Package export names to preselect. `dispatch-event` is normalized to `./dispatch-event`; `*` selects Any export. Omitted means no export is selected until the user chooses one. |
+| `export_names`, `export-names`, etc | no       | Snake_case and kebab-case aliases are accepted for the fields above.                                                                                                             |
 
 ## Invocation URL format
 

--- a/packages/worker/client/routes/account-package-tokens.tsx
+++ b/packages/worker/client/routes/account-package-tokens.tsx
@@ -6,6 +6,14 @@ import {
 	type AccountPackageToken,
 	type AccountPackagesLoaderData,
 } from '#universal/loader-data.ts'
+import {
+	applyPackageTokenExportSelection,
+	formatPackageTokenExportChoiceLabel,
+	isPackageTokenWildcardSelected,
+	listPackageTokenExportChoices,
+	packageTokenWildcardExport,
+	parsePackageTokenExportSelection,
+} from '#universal/package-token-export-selection.ts'
 import { css, type Handle } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
@@ -32,17 +40,23 @@ import {
 } from '#universal/styles/style-primitives.ts'
 import {
 	accountInputCss,
-	accountTextareaCss,
 	TimestampValue,
 } from './account-management-components.tsx'
 
 const accountPackagesApiPath = '/account/packages.json'
-const wildcardScope = '*'
+
+const exportChoiceRowCss = {
+	display: 'flex',
+	alignItems: 'flex-start',
+	gap: spacing.sm,
+	color: colors.text,
+	fontSize: typography.fontSize.sm,
+}
 
 type TokenEditorState = {
 	name: string
 	rawToken: string
-	exportNamesText: string
+	exportNames: Array<string>
 }
 
 export function readPackageTokenQuery(href: string) {
@@ -55,17 +69,21 @@ export function readPackageTokenQuery(href: string) {
 
 export function createTokenEditorStateFromHref(href: string): TokenEditorState {
 	const params = new URL(href, 'http://localhost').searchParams
-	return {
-		name: readTrimmedParam(params, 'name') ?? '',
-		rawToken: '',
-		exportNamesText: readCommaListParams(params, [
+	const exportNames = parsePackageTokenExportSelection(
+		readCommaListParams(params, [
 			'exportName',
 			'exportNames',
 			'export_name',
 			'export_names',
 			'export-name',
 			'export-names',
-		]).join('\n'),
+		]),
+	)
+	return {
+		name: readTrimmedParam(params, 'name') ?? '',
+		rawToken: '',
+		exportNames:
+			exportNames.length > 0 ? exportNames : [packageTokenWildcardExport],
 	}
 }
 
@@ -73,7 +91,7 @@ function createEmptyEditorState(): TokenEditorState {
 	return {
 		name: '',
 		rawToken: '',
-		exportNamesText: '',
+		exportNames: [packageTokenWildcardExport],
 	}
 }
 
@@ -83,7 +101,7 @@ function createEditorStateFromToken(
 	return {
 		name: token.name,
 		rawToken: '',
-		exportNamesText: token.exportNames.join('\n'),
+		exportNames: parsePackageTokenExportSelection(token.exportNames),
 	}
 }
 
@@ -97,16 +115,9 @@ function generatePackageInvocationRawToken() {
 	return `kody_${bytesToBase64Url(bytes)}`
 }
 
-function parseListText(value: string) {
-	return value
-		.split(/[\n,]/)
-		.map((entry) => entry.trim())
-		.filter((entry) => entry.length > 0)
-}
-
 function formatScope(values: Array<string>) {
 	if (values.length === 0) return 'None'
-	if (values.includes(wildcardScope)) return 'Any export'
+	if (isPackageTokenWildcardSelected(values)) return 'Any export'
 	return values.join(', ')
 }
 
@@ -198,6 +209,13 @@ export function AccountPackageTokens(
 		const invocationUrl = username
 			? `${invocationUrlOrigin}/@${username}/api/package-invocations/${packageDetail.kodyId}/<exportName>`
 			: ''
+		const exportChoices = listPackageTokenExportChoices({
+			packageExports: packageDetail.exports,
+			selected: editorState.exportNames,
+		})
+		const wildcardSelected = isPackageTokenWildcardSelected(
+			editorState.exportNames,
+		)
 
 		return (
 			<section
@@ -408,7 +426,7 @@ export function AccountPackageTokens(
 											id: selectedToken?.id,
 											name: editorState.name,
 											rawToken: editorState.rawToken,
-											exportNames: parseListText(editorState.exportNamesText),
+											exportNames: editorState.exportNames,
 										})
 										saveState = 'idle'
 										messageTone = 'info'
@@ -451,6 +469,10 @@ export function AccountPackageTokens(
 						</div>
 						<label mix={css(fieldCss)}>
 							<span mix={css(fieldLabelCss)}>Name</span>
+							<p mix={css(descriptionCss)}>
+								Human-readable label for this token. Shown in the list; not sent
+								to callers.
+							</p>
 							<input
 								value={editorState.name}
 								mix={[
@@ -471,6 +493,11 @@ export function AccountPackageTokens(
 							<span mix={css(fieldLabelCss)}>
 								{query.isCreating ? 'Raw token' : 'New raw token (optional)'}
 							</span>
+							<p mix={css(descriptionCss)}>
+								{query.isCreating
+									? 'Paste a high-entropy secret or click Generate. Kody stores only the hash and will not show this value again after you save.'
+									: 'Leave blank to keep the current secret. Paste or generate a new value to rotate.'}
+							</p>
 							<div
 								mix={css({
 									display: 'grid',
@@ -532,25 +559,68 @@ export function AccountPackageTokens(
 								</button>
 							</div>
 						</label>
-						<label mix={css(fieldCss)}>
+						<div mix={css(fieldCss)}>
 							<span mix={css(fieldLabelCss)}>Exports</span>
-							<textarea
-								value={editorState.exportNamesText}
-								placeholder={'./process-video\n*'}
-								mix={[
-									css(accountTextareaCss),
-									on('input', (event) => {
-										if (event.currentTarget instanceof HTMLTextAreaElement) {
+							<p mix={css(descriptionCss)}>
+								Choose which package exports this token may invoke.
+							</p>
+							{packageDetail.exports === null ? (
+								<p mix={css(descriptionCss)}>
+									Package exports could not be loaded. You can still choose Any
+									export, or keep export names already on this token.
+								</p>
+							) : null}
+							<label mix={css(exportChoiceRowCss)}>
+								<input
+									type="checkbox"
+									checked={wildcardSelected}
+									mix={on('change', (event) => {
+										if (!(event.currentTarget instanceof HTMLInputElement)) {
+											return
+										}
+										editorState = {
+											...editorState,
+											exportNames: applyPackageTokenExportSelection({
+												current: editorState.exportNames,
+												exportName: packageTokenWildcardExport,
+												selected: event.currentTarget.checked,
+											}),
+										}
+										handle.update()
+									})}
+								/>
+								<span>Any export (`*`)</span>
+							</label>
+							<p mix={css(descriptionCss)}>
+								All current and future exports on this package.
+							</p>
+							{exportChoices.map((exportName) => (
+								<label key={exportName} mix={css(exportChoiceRowCss)}>
+									<input
+										type="checkbox"
+										checked={
+											!wildcardSelected &&
+											editorState.exportNames.includes(exportName)
+										}
+										mix={on('change', (event) => {
+											if (!(event.currentTarget instanceof HTMLInputElement)) {
+												return
+											}
 											editorState = {
 												...editorState,
-												exportNamesText: event.currentTarget.value,
+												exportNames: applyPackageTokenExportSelection({
+													current: editorState.exportNames,
+													exportName,
+													selected: event.currentTarget.checked,
+												}),
 											}
 											handle.update()
-										}
-									}),
-								]}
-							/>
-						</label>
+										})}
+									/>
+									<span>{formatPackageTokenExportChoiceLabel(exportName)}</span>
+								</label>
+							))}
+						</div>
 						<div
 							mix={css({ display: 'flex', flexWrap: 'wrap', gap: spacing.sm })}
 						>

--- a/packages/worker/client/routes/account-package-tokens.tsx
+++ b/packages/worker/client/routes/account-package-tokens.tsx
@@ -468,10 +468,10 @@ export function AccountPackageTokens(
 						</div>
 						<label mix={css(fieldCss)}>
 							<span mix={css(fieldLabelCss)}>Name</span>
-							<p mix={css(descriptionCss)}>
+							<span mix={css({ ...descriptionCss, display: 'block' })}>
 								Human-readable label for this token. Shown in the list; not sent
 								to callers.
-							</p>
+							</span>
 							<input
 								value={editorState.name}
 								mix={[
@@ -492,11 +492,11 @@ export function AccountPackageTokens(
 							<span mix={css(fieldLabelCss)}>
 								{query.isCreating ? 'Raw token' : 'New raw token (optional)'}
 							</span>
-							<p mix={css(descriptionCss)}>
+							<span mix={css({ ...descriptionCss, display: 'block' })}>
 								{query.isCreating
 									? 'Paste a high-entropy secret or click Generate. Kody stores only the hash and will not show this value again after you save.'
 									: 'Leave blank to keep the current secret. Paste or generate a new value to rotate.'}
-							</p>
+							</span>
 							<div
 								mix={css({
 									display: 'grid',

--- a/packages/worker/client/routes/account-package-tokens.tsx
+++ b/packages/worker/client/routes/account-package-tokens.tsx
@@ -82,8 +82,7 @@ export function createTokenEditorStateFromHref(href: string): TokenEditorState {
 	return {
 		name: readTrimmedParam(params, 'name') ?? '',
 		rawToken: '',
-		exportNames:
-			exportNames.length > 0 ? exportNames : [packageTokenWildcardExport],
+		exportNames,
 	}
 }
 
@@ -91,7 +90,7 @@ function createEmptyEditorState(): TokenEditorState {
 	return {
 		name: '',
 		rawToken: '',
-		exportNames: [packageTokenWildcardExport],
+		exportNames: [],
 	}
 }
 

--- a/packages/worker/src/app/account-packages-data.ts
+++ b/packages/worker/src/app/account-packages-data.ts
@@ -6,6 +6,7 @@ import {
 	type AccountPackagesLoaderData,
 	type AccountPackagesSort,
 } from '#universal/loader-data.ts'
+import { listPackageManifestExportNames } from '#universal/package-token-export-selection.ts'
 import { type readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
 import {
@@ -17,6 +18,7 @@ import {
 	getSavedPackageById,
 	searchSavedPackagesByUserId,
 } from '#worker/package-registry/repo.ts'
+import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
 import { type SavedPackageRecord } from '#worker/package-registry/types.ts'
 
 type AuthenticatedUser = NonNullable<
@@ -94,19 +96,51 @@ function toToken(token: PackageInvocationTokenRecord): AccountPackageToken {
 	}
 }
 
+async function loadPackageExportNames(input: {
+	env: Env
+	requestUrl: string
+	userId: string
+	sourceId: string
+}): Promise<Array<string> | null> {
+	try {
+		const loaded = await loadPackageManifestBySourceId({
+			env: input.env,
+			baseUrl: getAppBaseUrl({
+				env: input.env,
+				requestUrl: input.requestUrl,
+			}),
+			userId: input.userId,
+			sourceId: input.sourceId,
+		})
+		return listPackageManifestExportNames(loaded.manifest.exports)
+	} catch {
+		return null
+	}
+}
+
 async function toDetail(input: {
-	db: D1Database
+	env: Env
+	requestUrl: string
 	userId: string
 	record: SavedPackageRecord
 }): Promise<AccountPackageDetail> {
-	const tokens = await listPackageInvocationTokensByPackageId({
-		db: input.db,
-		userId: input.userId,
-		packageId: input.record.id,
-	})
+	const [tokens, exports] = await Promise.all([
+		listPackageInvocationTokensByPackageId({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			packageId: input.record.id,
+		}),
+		loadPackageExportNames({
+			env: input.env,
+			requestUrl: input.requestUrl,
+			userId: input.userId,
+			sourceId: input.record.sourceId,
+		}),
+	])
 	return {
 		...toListItem(input.record),
 		searchText: input.record.searchText,
+		exports,
 		tokens: tokens.map(toToken),
 	}
 }
@@ -159,7 +193,8 @@ export async function loadAccountPackagesData(input: {
 		packages: items.map(toListItem),
 		selectedPackage: selectedRecord
 			? await toDetail({
-					db: input.env.APP_DB,
+					env: input.env,
+					requestUrl: input.request.url,
 					userId,
 					record: selectedRecord,
 				})

--- a/packages/worker/src/app/handlers/account-packages.node.test.ts
+++ b/packages/worker/src/app/handlers/account-packages.node.test.ts
@@ -53,6 +53,7 @@ const mockModule = vi.hoisted(() => ({
 	reinstatePackageInvocationToken: vi.fn(async () => true),
 	deletePackageInvocationToken: vi.fn(async () => true),
 	getAppBaseUrl: () => 'https://example.com',
+	loadPackageManifestBySourceId: vi.fn(),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -82,6 +83,11 @@ vi.mock('#worker/package-registry/repo.ts', () => ({
 		mockModule.searchSavedPackagesByUserId(...args),
 	getSavedPackageById: (...args: Array<unknown>) =>
 		mockModule.getSavedPackageById(...args),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: (...args: Array<unknown>) =>
+		mockModule.loadPackageManifestBySourceId(...args),
 }))
 
 vi.mock('#worker/package-invocations/repo.ts', () => ({
@@ -122,6 +128,14 @@ function resetTokenMocks() {
 	mockModule.listPackageInvocationTokensByPackageId.mockResolvedValue([
 		tokenRecord,
 	])
+	mockModule.loadPackageManifestBySourceId.mockReset()
+	mockModule.loadPackageManifestBySourceId.mockResolvedValue({
+		manifest: {
+			exports: {
+				'./dispatch-message-created': { import: './src/index.ts' },
+			},
+		},
+	})
 }
 
 test('packages API lists with filters, ignores invalid values, and rejects unknown actions', async () => {
@@ -182,6 +196,13 @@ test('packages API lists with filters, ignores invalid values, and rejects unkno
 	mockModule.listPackageInvocationTokensByPackageId.mockResolvedValue([
 		tokenRecord,
 	])
+	mockModule.loadPackageManifestBySourceId.mockResolvedValue({
+		manifest: {
+			exports: {
+				'./dispatch-message-created': { import: './src/index.ts' },
+			},
+		},
+	})
 
 	const filtered = await handler.handler({
 		request: new Request(
@@ -223,6 +244,7 @@ test('packages API lists with filters, ignores invalid values, and rejects unkno
 		selectedPackage: {
 			id: 'pkg-1',
 			searchText: 'discord gateway websocket',
+			exports: ['./dispatch-message-created'],
 			tokens: [
 				{
 					id: 'token-1',
@@ -233,6 +255,29 @@ test('packages API lists with filters, ignores invalid values, and rejects unkno
 		},
 	})
 	expect(JSON.stringify(filteredPayload)).not.toContain('stored-hash')
+	expect(mockModule.loadPackageManifestBySourceId).toHaveBeenCalledWith({
+		env,
+		baseUrl: 'https://example.com',
+		userId: 'stable-user-1',
+		sourceId: 'source-1',
+	})
+
+	mockModule.loadPackageManifestBySourceId.mockRejectedValueOnce(
+		new Error('Saved package source bindings are not available.'),
+	)
+	const missingManifest = await handler.handler({
+		request: new Request(
+			'https://example.com/account/packages.json?selected=pkg-1',
+		),
+		params: {},
+	} as never)
+	await expect(missingManifest.json()).resolves.toMatchObject({
+		ok: true,
+		selectedPackage: {
+			id: 'pkg-1',
+			exports: null,
+		},
+	})
 
 	mockModule.searchSavedPackagesByUserId.mockClear()
 	mockModule.getSavedPackageById.mockResolvedValue(null)

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1004,6 +1004,7 @@ export type AccountPackageListItem = {
 
 export type AccountPackageDetail = AccountPackageListItem & {
 	searchText: string | null
+	exports: Array<string> | null
 	tokens: Array<AccountPackageToken>
 }
 

--- a/packages/worker/universal/package-token-export-selection.node.test.ts
+++ b/packages/worker/universal/package-token-export-selection.node.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from 'vitest'
+import {
+	applyPackageTokenExportSelection,
+	formatPackageTokenExportChoiceLabel,
+	isPackageTokenWildcardSelected,
+	listPackageManifestExportNames,
+	listPackageTokenExportChoices,
+	packageTokenWildcardExport,
+	parsePackageTokenExportSelection,
+	tryNormalizePackageTokenExportName,
+} from './package-token-export-selection.ts'
+
+test('package token export selection normalizes names, wildcard exclusivity, and stale choices', () => {
+	expect(tryNormalizePackageTokenExportName('')).toBe(null)
+	expect(tryNormalizePackageTokenExportName('   ')).toBe(null)
+	expect(tryNormalizePackageTokenExportName('*')).toBe(
+		packageTokenWildcardExport,
+	)
+	expect(tryNormalizePackageTokenExportName('dispatch-event')).toBe(
+		'./dispatch-event',
+	)
+	expect(tryNormalizePackageTokenExportName('./dispatch-event')).toBe(
+		'./dispatch-event',
+	)
+	expect(tryNormalizePackageTokenExportName('.')).toBe('.')
+	expect(tryNormalizePackageTokenExportName('./')).toBe('.')
+
+	expect(
+		parsePackageTokenExportSelection([
+			'dispatch-event',
+			'./process-video',
+			'dispatch-event',
+			'',
+		]),
+	).toEqual(['./dispatch-event', './process-video'])
+	expect(
+		parsePackageTokenExportSelection([
+			'dispatch-event',
+			'*',
+			'./process-video',
+		]),
+	).toEqual([packageTokenWildcardExport])
+
+	expect(
+		applyPackageTokenExportSelection({
+			current: ['./dispatch-event'],
+			exportName: '*',
+			selected: true,
+		}),
+	).toEqual([packageTokenWildcardExport])
+	expect(
+		applyPackageTokenExportSelection({
+			current: [packageTokenWildcardExport],
+			exportName: '*',
+			selected: false,
+		}),
+	).toEqual([])
+	expect(
+		applyPackageTokenExportSelection({
+			current: [packageTokenWildcardExport],
+			exportName: 'process-video',
+			selected: true,
+		}),
+	).toEqual(['./process-video'])
+	expect(
+		applyPackageTokenExportSelection({
+			current: ['./dispatch-event', './process-video'],
+			exportName: './dispatch-event',
+			selected: false,
+		}),
+	).toEqual(['./process-video'])
+	expect(
+		applyPackageTokenExportSelection({
+			current: ['./process-video'],
+			exportName: 'dispatch-event',
+			selected: true,
+		}),
+	).toEqual(['./process-video', './dispatch-event'])
+
+	expect(
+		listPackageTokenExportChoices({
+			packageExports: ['./process-video', '.', 'dispatch-event'],
+			selected: ['*', './retired-export', 'process-video'],
+		}),
+	).toEqual(['.', './dispatch-event', './process-video', './retired-export'])
+	expect(
+		listPackageTokenExportChoices({
+			packageExports: null,
+			selected: ['*', './retired-export'],
+		}),
+	).toEqual(['./retired-export'])
+	expect(
+		listPackageManifestExportNames({
+			'.': './src/index.ts',
+			'./dispatch-message-created': './src/dispatch.ts',
+			'*': './src/star.ts',
+		}),
+	).toEqual(['.', './dispatch-message-created'])
+
+	expect(isPackageTokenWildcardSelected(['*'])).toBe(true)
+	expect(isPackageTokenWildcardSelected(['./process-video'])).toBe(false)
+	expect(formatPackageTokenExportChoiceLabel('.')).toBe('. (root export)')
+	expect(formatPackageTokenExportChoiceLabel('./process-video')).toBe(
+		'./process-video',
+	)
+})

--- a/packages/worker/universal/package-token-export-selection.ts
+++ b/packages/worker/universal/package-token-export-selection.ts
@@ -1,0 +1,79 @@
+import { normalizePackageInvocationExportName } from '@kody-internal/shared/public-urls.ts'
+
+export const packageTokenWildcardExport = '*'
+
+export function tryNormalizePackageTokenExportName(
+	exportName: string,
+): string | null {
+	const trimmed = exportName.trim()
+	if (!trimmed) return null
+	if (trimmed === packageTokenWildcardExport) {
+		return packageTokenWildcardExport
+	}
+	try {
+		return normalizePackageInvocationExportName(trimmed)
+	} catch {
+		return null
+	}
+}
+
+export function parsePackageTokenExportSelection(
+	values: Array<string>,
+): Array<string> {
+	const names: Array<string> = []
+	for (const value of values) {
+		const normalized = tryNormalizePackageTokenExportName(value)
+		if (normalized) names.push(normalized)
+	}
+	if (names.includes(packageTokenWildcardExport)) {
+		return [packageTokenWildcardExport]
+	}
+	return Array.from(new Set(names))
+}
+
+export function applyPackageTokenExportSelection(input: {
+	current: Array<string>
+	exportName: string
+	selected: boolean
+}): Array<string> {
+	const normalized = tryNormalizePackageTokenExportName(input.exportName)
+	if (!normalized) return parsePackageTokenExportSelection(input.current)
+	if (normalized === packageTokenWildcardExport) {
+		return input.selected ? [packageTokenWildcardExport] : []
+	}
+	const specific = parsePackageTokenExportSelection(input.current).filter(
+		(name) => name !== packageTokenWildcardExport && name !== normalized,
+	)
+	return input.selected ? [...specific, normalized] : specific
+}
+
+export function listPackageTokenExportChoices(input: {
+	packageExports: Array<string> | null
+	selected: Array<string>
+}): Array<string> {
+	const names = new Set<string>()
+	for (const name of [...(input.packageExports ?? []), ...input.selected]) {
+		const normalized = tryNormalizePackageTokenExportName(name)
+		if (normalized && normalized !== packageTokenWildcardExport) {
+			names.add(normalized)
+		}
+	}
+	return [...names].sort((left, right) => left.localeCompare(right))
+}
+
+export function listPackageManifestExportNames(
+	exports: Record<string, unknown>,
+): Array<string> {
+	return listPackageTokenExportChoices({
+		packageExports: Object.keys(exports),
+		selected: [],
+	})
+}
+
+export function isPackageTokenWildcardSelected(exportNames: Array<string>) {
+	return exportNames.includes(packageTokenWildcardExport)
+}
+
+export function formatPackageTokenExportChoiceLabel(exportName: string) {
+	return exportName === '.' ? '. (root export)' : exportName
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the package invocation token form explain its fields and let the owner pick from the package's real exports instead of typing names into a textarea.

## Summary

- Account package detail now loads manifest export names (`exports: Array<string> | null`; `null` when the manifest cannot be loaded).
- Create/edit token form adds descriptions for **Name**, **Raw token**, and **Exports**.
- **Exports** is a checkbox list: **Any export (`*`)** plus each current package export. Selecting `*` clears specific exports; selecting a specific export clears `*`. Stale names already on a token stay visible so edit does not drop them.
- Setup URL `exportNames` / aliases still prefill the selection. Omitting them leaves no export selected, so the user must choose a scope (including `*` only when they mean it).
- Setup guide describes the checkbox form.

## Testing

- `npx vitest run --project node-unit packages/worker/universal/package-token-export-selection.node.test.ts packages/worker/src/app/handlers/account-packages.node.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format -- --check`

Preview manual test as the seeded user follows after this PR is up (medium risk).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `03f1f54` · **Head:** `99c7edf`

**Classification:** extends — `AccountPackageDetail` now includes package export names, and the token form selects from that list instead of a free-text textarea.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — package detail loader returns `exports`; token form describes fields and uses export checkboxes |

Unmatched: `docs/guides/account-package-invocation-token-setup.md` (usage guide only).

### Change flow

Selected package detail loads manifest export names, then the token form renders those names as checkboxes.

```mermaid
sequenceDiagram
	actor user as User
	participant appUi as app-ui
	participant savedPackages as saved-packages
	user->>appUi: Open package token create or edit form
	appUi->>savedPackages: loadPackageManifestBySourceId for selected sourceId
	alt Manifest loads
		savedPackages-->>appUi: export keys as selectedPackage.exports
	else Manifest missing or bindings unavailable
		savedPackages-->>appUi: catch and set selectedPackage.exports to null
	end
	appUi-->>user: Field descriptions plus Any export (*) and per-export checkboxes
	user->>appUi: POST /account/packages.json create-token or update-token with exportNames
```

### Before / after

```
selectedPackage.exports: (absent)
Exports field: textarea (./process-video / *)
```

```
selectedPackage.exports: Array<string> | null
Exports field: Any export (*) + one checkbox per manifest export
Create form: no export preselected unless the setup URL names one
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6399322-2fa0-4068-a33b-e237406601f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6399322-2fa0-4068-a33b-e237406601f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select package token exports using checkboxes, including individual exports or **Any export (*)**.
  * Package details now display available export names when they can be loaded.
  * New token forms default to allowing any export and provide clearer field guidance.
  * Export selections are validated, normalized, and kept mutually exclusive with the wildcard option.

* **Documentation**
  * Clarified setup URL behavior, export selection options, bearer-token safety, and confirmation steps before token creation.

* **Bug Fixes**
  * Added a fallback message when package exports cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->