### PR TITLE
Fix admin system inbox showing each email three times

### DIFF
--- a/packages/worker/client/routes/admin-system-email.tsx
+++ b/packages/worker/client/routes/admin-system-email.tsx
@@ -229,6 +229,7 @@ export function AdminSystemEmailRoute(handle: Handle) {
 								columns={[
 									{ key: 'subject', label: 'Subject', primary: true },
 									{ key: 'inbox', label: 'Inbox' },
+									{ key: 'to', label: 'To', drop: 1 },
 									{ key: 'from', label: 'From', drop: 1 },
 									{ key: 'bytes', label: 'Bytes', align: 'end', drop: 2 },
 									{ key: 'received', label: 'Received' },
@@ -243,6 +244,11 @@ export function AdminSystemEmailRoute(handle: Handle) {
 											</span>
 										),
 										inbox: systemMessage.inbox_local_part,
+										to: (
+											<span mix={clampedCellCss}>
+												{systemMessage.to_addresses.join(', ') || 'None'}
+											</span>
+										),
 										from: (
 											<span mix={clampedCellCss}>
 												{systemMessage.from_address ??

--- a/packages/worker/src/admin/system-email-data.ts
+++ b/packages/worker/src/admin/system-email-data.ts
@@ -27,6 +27,7 @@ export const adminSystemEmailListItemFieldNames = [
 	'raw_size',
 	'received_at',
 	'created_at',
+	'to_addresses',
 ] as const
 
 type AdminSystemEmailListItemFieldName =
@@ -45,10 +46,10 @@ export type AdminSystemEmailListItem = Record<
 	raw_size: number
 	received_at: string | null
 	created_at: string
+	to_addresses: Array<string>
 }
 
 export type AdminSystemEmailDetail = AdminSystemEmailListItem & {
-	to_addresses: Array<string>
 	cc_addresses: Array<string>
 	reply_to_addresses: Array<string>
 	headers: Record<string, Array<string>>
@@ -97,6 +98,11 @@ function toListItem(row: Record<string, unknown>): AdminSystemEmailListItem {
 		raw_size: Number(row['raw_size'] ?? 0),
 		received_at: row['received_at'] == null ? null : String(row['received_at']),
 		created_at: String(row['created_at']),
+		to_addresses: parseJsonStringArray(
+			row['to_addresses_json'] == null
+				? null
+				: String(row['to_addresses_json']),
+		),
 	}
 }
 

--- a/packages/worker/src/email/system-email-admin-list.workers.test.ts
+++ b/packages/worker/src/email/system-email-admin-list.workers.test.ts
@@ -42,6 +42,7 @@ test('admin system email list stays one row when an inbox has several domain add
 			id: messageId,
 			inboxId,
 			fromAddress: 'no-reply@accounts.google.com',
+			toAddresses: ['kody@kody.codes'],
 			subject: 'Security alert',
 			rawSize: 13746,
 			processingStatus: 'stored',
@@ -61,6 +62,7 @@ test('admin system email list stays one row when an inbox has several domain add
 		inbox_local_part: 'kody',
 		subject: 'Security alert',
 		raw_size: 13746,
+		to_addresses_json: '["kody@kody.codes"]',
 	})
 
 	const detail = await getSystemEmailAdminMessageRow({

--- a/packages/worker/src/email/system-email-admin-list.workers.test.ts
+++ b/packages/worker/src/email/system-email-admin-list.workers.test.ts
@@ -1,0 +1,75 @@
+import { env } from 'cloudflare:workers'
+import { expect, test } from 'vitest'
+import { systemEmailOwnerId } from './email-owner.ts'
+import {
+	getSystemEmailAdminMessageRow,
+	insertSystemEmailMessage,
+	listSystemEmailAdminMessages,
+} from './system-email-graph-store.ts'
+import { ensureEmailTestSchema } from './test-schema.ts'
+
+test('admin system email list stays one row when an inbox has several domain addresses', async () => {
+	await ensureEmailTestSchema(env.APP_DB)
+	const inboxId = `kody-inbox-${crypto.randomUUID()}`
+	const messageId = `kody-message-${crypto.randomUUID()}`
+	const now = '2026-08-19T00:00:00.000Z'
+	await env.APP_DB.batch([
+		env.APP_DB.prepare(
+			`INSERT INTO email_inboxes (
+				id, user_id, name, enabled, created_at, updated_at
+			) VALUES (?, ?, 'kody', 1, ?, ?)`,
+		).bind(inboxId, systemEmailOwnerId, now, now),
+		...['kody.codes', 'heykody.app', 'heykody.dev'].map((domain) =>
+			env.APP_DB.prepare(
+				`INSERT INTO email_inbox_addresses (
+					id, inbox_id, user_id, address, local_part, domain,
+					enabled, created_at, updated_at
+				) VALUES (?, ?, ?, ?, 'kody', ?, 1, ?, ?)`,
+			).bind(
+				crypto.randomUUID(),
+				inboxId,
+				systemEmailOwnerId,
+				`kody@${domain}`,
+				domain,
+				now,
+				now,
+			),
+		),
+	])
+	await insertSystemEmailMessage({
+		db: env.APP_DB,
+		message: {
+			id: messageId,
+			inboxId,
+			fromAddress: 'no-reply@accounts.google.com',
+			subject: 'Security alert',
+			rawSize: 13746,
+			processingStatus: 'stored',
+			receivedAt: now,
+		},
+	})
+
+	const list = await listSystemEmailAdminMessages({
+		db: env.APP_DB,
+		pageSize: 25,
+		offset: 0,
+	})
+	expect(list.total).toBe(1)
+	expect(list.rows).toHaveLength(1)
+	expect(list.rows[0]).toMatchObject({
+		id: messageId,
+		inbox_local_part: 'kody',
+		subject: 'Security alert',
+		raw_size: 13746,
+	})
+
+	const detail = await getSystemEmailAdminMessageRow({
+		db: env.APP_DB,
+		messageId,
+	})
+	expect(detail).toMatchObject({
+		id: messageId,
+		inbox_local_part: 'kody',
+		subject: 'Security alert',
+	})
+})

--- a/packages/worker/src/email/system-email-graph-store.ts
+++ b/packages/worker/src/email/system-email-graph-store.ts
@@ -687,7 +687,7 @@ export async function listSystemEmailAdminMessages(input: {
 				`SELECT message.id, inbox.name AS inbox_local_part,
 					message.from_address, message.envelope_from, message.subject,
 					message.processing_status, message.raw_size, message.received_at,
-					message.created_at
+					message.created_at, message.to_addresses_json
 				FROM system_email_messages AS message
 				${adminSystemInboxJoin}
 				WHERE message.direction = 'inbound'

--- a/packages/worker/src/email/system-email-graph-store.ts
+++ b/packages/worker/src/email/system-email-graph-store.ts
@@ -656,6 +656,18 @@ export async function deleteSystemEmailMessageById(input: {
 
 export type SystemEmailAdminListRow = Record<string, unknown>
 
+/**
+ * Resolve the admin "Inbox" label from `email_inboxes.name`.
+ *
+ * Do not join `email_inbox_addresses` here. One operator inbox can have
+ * several address rows — one per accepted system domain (canonical plus
+ * `LEGACY_SYSTEM_EMAIL_DOMAINS`) — all with the same local part. That join
+ * fans the list out (three identical rows per message in production).
+ */
+const adminSystemInboxJoin = `LEFT JOIN email_inboxes AS inbox
+	ON inbox.id = message.inbox_id
+	AND inbox.user_id = ?`
+
 export async function listSystemEmailAdminMessages(input: {
 	db: D1Database
 	pageSize: number
@@ -672,14 +684,12 @@ export async function listSystemEmailAdminMessages(input: {
 			.first<{ total: number }>(),
 		input.db
 			.prepare(
-				`SELECT message.id, address.local_part AS inbox_local_part,
+				`SELECT message.id, inbox.name AS inbox_local_part,
 					message.from_address, message.envelope_from, message.subject,
 					message.processing_status, message.raw_size, message.received_at,
 					message.created_at
 				FROM system_email_messages AS message
-				LEFT JOIN email_inbox_addresses AS address
-					ON address.inbox_id = message.inbox_id
-					AND address.user_id = ?
+				${adminSystemInboxJoin}
 				WHERE message.direction = 'inbound'
 				ORDER BY message.created_at DESC, message.id DESC
 				LIMIT ? OFFSET ?`,
@@ -700,11 +710,9 @@ export async function getSystemEmailAdminMessageRow(input: {
 	await assertSystemEmailGraphAuthority(input.db)
 	return await input.db
 		.prepare(
-			`SELECT message.*, address.local_part AS inbox_local_part
+			`SELECT message.*, inbox.name AS inbox_local_part
 			FROM system_email_messages AS message
-			LEFT JOIN email_inbox_addresses AS address
-				ON address.inbox_id = message.inbox_id
-				AND address.user_id = ?
+			${adminSystemInboxJoin}
 			WHERE message.id = ?
 			LIMIT 1`,
 		)

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -784,6 +784,7 @@ test('admin system email capabilities read only system-owned mail and audit read
 			id: 'system-message-1',
 			inbox_local_part: 'abuse',
 			subject: 'Abuse report',
+			to_addresses: ['abuse@example.com'],
 		}),
 	])
 

--- a/packages/worker/src/mcp/capabilities/admin/admin-system-email-list.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-system-email-list.ts
@@ -35,6 +35,7 @@ export const adminSystemEmailListItemSchema = z.object({
 	raw_size: z.number().int().nonnegative(),
 	received_at: z.string().nullable(),
 	created_at: z.string(),
+	to_addresses: z.array(z.string()),
 })
 
 const outputSchema = z.object({

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -609,10 +609,10 @@ export type AdminSystemEmailListItem = {
 	raw_size: number
 	received_at: string | null
 	created_at: string
+	to_addresses: Array<string>
 }
 
 export type AdminSystemEmailDetail = AdminSystemEmailListItem & {
-	to_addresses: Array<string>
 	cc_addresses: Array<string>
 	reply_to_addresses: Array<string>
 	headers: Record<string, Array<string>>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The admin system inbox was showing every stored message three times. That is a list-query fan-out, not three delivered copies: production keeps one address row per accepted system domain on the same operator inbox, and the admin list joined those address rows. Operators also need to see which apex a message actually arrived on.

## Summary

- `listSystemEmailAdminMessages` / `getSystemEmailAdminMessageRow` resolve the Inbox label from `email_inboxes.name` (1:1 on `inbox_id`) instead of `email_inbox_addresses`.
- The list now includes `to_addresses` from the stored message so the admin table can show **To** (actual recipient) next to **Inbox** (operator local).
- Workers test seeds the production shape (one `kody` inbox, addresses on `kody.codes` / `heykody.app` / `heykody.dev`) and asserts one list row, plus the stored To address.

## Testing

- Workers: `npx vitest run --project workers-unit packages/worker/src/email/system-email-admin-list.workers.test.ts` — 1 passed.
- Node: `npx vitest run --project node-unit packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts` — 8 passed.
- CI: Static, Node, Workers, E2E, MCP, Validate, Preview — green.
- Preview (`https://kody-pr-1573.kody-a99.workers.dev`): seed user `me@kentcdodds.com` signed in; `GET /admin/system-email.json` and `/admin/system-email` are 403 (seed is not admin). Query behavior is covered by the workers test.
- CodeRabbit asked to filter `message.user_id`. Not applied: `system_email_messages` has no `user_id`; the operator graph owner is implicit.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8e97d40e` · **Head:** `4316f107`

**Classification:** extends — the email admin list query no longer fans out one stored message per accepted system-domain address, and the list now projects stored To recipients.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `email` | assistant | extends — admin inbox list/detail join `email_inboxes` (1:1) instead of `email_inbox_addresses` (1:N); list SELECT adds `to_addresses_json` |
| `app-ui` | surfaces | extends — admin system-email table gains a To column from stored recipients |
| `rbac` | auth | composes — `admin_system_email_list` output schema adds `to_addresses` |

Unmatched path: `packages/worker/src/admin/system-email-data.ts` maps the new list field.

### Change flow

Admin system-inbox list/detail labels a message from its operator inbox row and shows the stored To address so leftover domain addresses cannot multiply the result.

```mermaid
sequenceDiagram
	actor Admin
	participant appUi as app-ui
	participant email as email
	Admin->>appUi: GET /admin/system-email.json
	appUi->>email: listSystemEmailAdminMessages
	Note over email: JOIN email_inboxes.name; SELECT to_addresses_json
	email-->>appUi: one inbound row plus stored To
	appUi-->>Admin: Inbox local + To recipient
```

### Before / after

```sql
-- before
LEFT JOIN email_inbox_addresses AS address
  ON address.inbox_id = message.inbox_id AND address.user_id = ?

-- after
LEFT JOIN email_inboxes AS inbox
  ON inbox.id = message.inbox_id AND inbox.user_id = ?
-- plus message.to_addresses_json on the list projection
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d7e18e0-0e4d-41a4-abf0-234331bc12ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d7e18e0-0e4d-41a4-abf0-234331bc12ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “To” column to the system email list, showing recipient addresses or “None.”
  - System email list results now include recipient addresses for each message.
  - Improved inbox labeling and prevented duplicate message rows when inboxes have multiple addresses.

- **Bug Fixes**
  - Corrected system email list and detail results for inboxes with multiple domain addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->