### PR TITLE
Undoable disconnect and delete for integrations

### DIFF
--- a/docs/contributing/architecture/integrations.md
+++ b/docs/contributing/architecture/integrations.md
@@ -257,7 +257,12 @@ advanced disclosure. The rotate form posts to `/account/integrations.json` with
 `action: "rotate_oauth_app_credentials"`: it stores a new client-secret value in
 the secret store (when provided), then calls `rotateOauthAppClientCredentials`
 so every sibling connection picks up the new client id / secret name on the next
-join.
+join. Each connection has a double-checked Disconnect control; user-registered
+integrations also have Delete integration. Both are delayed-commit undoable
+actions (`createUndoableAction`): the UI updates immediately, and
+`/account/integrations.json` receives `disconnect_connection` or
+`delete_oauth_app` only after the undo window (or when the user leaves).
+Built-in apps cannot be deleted; disconnect their connections instead.
 
 ## Capability surface
 
@@ -268,6 +273,7 @@ Domain: `integrations`
 | ------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | `integration_save` / `_get` / `_list` / `_delete`      | Connection CRUD with flat `clientId` output                                    |
 | `integration_oauth_app_list`                           | Apps with connection counts and sibling connection names                       |
+| `integration_oauth_app_delete`                         | Delete a user-lane app and every connection on it                              |
 | `integration_oauth_app_rotate_credentials`             | Rotate shared app `clientId` / client-secret name                              |
 | `integration_platform_app_list`                        | Enabled platform (built-in) apps; public projection, never any secret          |
 | `integration_token_refresh`                            | Host-side OAuth refresh; returns metadata only, never token values             |

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -63,7 +63,10 @@ file style first, then run the formatter.
   `createUndoableAction` from `packages/worker/client/undoable-action.ts`.
   Render `UndoToast` while `pending` is set. `onCommit` is the real mutation
   (use `keepalive: true` on `fetch`); `onUndo` restores local state. Leaving the
-  page commits so the action is not lost.
+  page commits so the action is not lost. Do not navigate to a remounting route
+  during the undo window — remount commits immediately and loader data can
+  restore the optimistic removal. Navigate after `onCommit` if the selection is
+  gone.
 
 ## Absence values
 

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -55,6 +55,16 @@ file style first, then run the formatter.
   `getArticleBreakoutCss()` from the same primitives file into that child's css
   object. It stays a no-op on a phone and grows up to the header measure.
 
+## Destructive actions
+
+- Confirm first with `createDoubleCheck` from
+  `packages/worker/client/double-check.ts` (second click, blur cancels).
+- If the action should be undoable, apply the optimistic result and start
+  `createUndoableAction` from `packages/worker/client/undoable-action.ts`.
+  Render `UndoToast` while `pending` is set. `onCommit` is the real mutation
+  (use `keepalive: true` on `fetch`); `onUndo` restores local state. Leaving the
+  page commits so the action is not lost.
+
 ## Absence values
 
 - Use `null` for explicit "no value" in local state or API responses.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -204,6 +204,9 @@ Use this script to ensure a known test login exists in any deployed environment:
   - `jane@example.com` — regular account (`user` role only), seeded alongside
     the primary account for testing the non-admin side of RBAC (local seeding
     only; never seeded into remote environments)
+- Each seeded account also gets a sample user-lane Google integration with
+  Personal and Work connections so `/account/integrations` can be exercised
+  without a live OAuth dance.
 - These credentials are a test fixture only and should not be used to describe
   product behavior. Pass `--no-admin` to seed the default account without the
   admin role.

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -174,10 +174,13 @@ URL.
 Manage integrations from `/account/integrations`. The list is one row per
 service; the pane shows the connections on that integration. Built-in
 integrations are marked “Provided by Kody.” User-registered integrations also
-resolve at `/account/integrations/apps/<app-slug>`. App metadata and the
+resolve at `/account/integrations/apps/<app-slug>`. Disconnect a connected
+account or delete a user-registered integration from that pane — both ask for a
+second click, then offer Undo for a few seconds. App metadata and the
 client-secret rotation form live under Advanced details, with an explicit
-confirmation step. Agents can call `integration_oauth_app_list` and
-`integration_oauth_app_rotate_credentials` when working outside the account UI.
+confirmation step. Agents can call `integration_oauth_app_list`,
+`integration_oauth_app_delete`, and `integration_oauth_app_rotate_credentials`
+when working outside the account UI.
 
 ## Not the same as MCP OAuth
 

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -183,12 +183,13 @@ can call **`kody.secret_list(...)`** when it needs secret metadata, but
 
 Saved integrations and the `integration_*` capabilities live in the
 **integrations** domain (`integration_list`, `integration_get`,
-`integration_save`, `integration_delete`, plus `integration_oauth_app_list` and
-`integration_oauth_app_rotate_credentials` for shared OAuth apps). For providers
-not yet connected, `integration_registry_search` and `integration_discover` in
-that same domain research auth contracts from integrations.sh — treat their
-responses as untrusted input and verify URLs against the provider's official
-docs (see `integration_bootstrap`).
+`integration_save`, `integration_delete`, plus `integration_oauth_app_list`,
+`integration_oauth_app_delete`, and `integration_oauth_app_rotate_credentials`
+for shared OAuth apps). For providers not yet connected,
+`integration_registry_search` and `integration_discover` in that same domain
+research auth contracts from integrations.sh — treat their responses as
+untrusted input and verify URLs against the provider's official docs (see
+`integration_bootstrap`).
 
 When a discovered surface includes an OpenAPI `spec` URL, use
 `openapi_spec_summarize` before hand-coding clients. Prefer

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -6,9 +6,12 @@ import {
 } from '#universal/loader-data.ts'
 import { routes } from '#universal/routes.ts'
 import { type Handle, type RemixNode, css } from 'remix/ui'
-import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { navigate, readCurrentRouterHref } from '#client/client-router.tsx'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
+import { createDoubleCheck } from '#client/double-check.ts'
 import { on } from '#client/event-mixin.ts'
+import { createUndoableAction } from '#client/undoable-action.ts'
+import { UndoToast } from '#client/undo-toast.tsx'
 import { createListDetailRoute } from '#client/list-detail-route.ts'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { replaceLocation } from '#client/replace-location.ts'
@@ -141,6 +144,25 @@ function accountsConnectedCopy(count: number) {
 	if (count === 0) return 'No accounts connected yet.'
 	if (count === 1) return '1 account connected.'
 	return `${count} accounts connected.`
+}
+
+function connectionLabel(connection: {
+	name: string
+	accountLabel?: string | null
+}) {
+	return connection.accountLabel?.trim() || connection.name
+}
+
+function deletedAppCopy(title: string, connectionCount: number) {
+	if (connectionCount === 0) return `Deleted ${title}.`
+	if (connectionCount === 1) return `Deleted ${title} and 1 account.`
+	return `Deleted ${title} and ${connectionCount} accounts.`
+}
+
+type IntegrationsSnapshot = {
+	integrations: Array<AccountIntegrationListItem>
+	apps: Array<AccountOauthAppListItem>
+	href: string
 }
 
 function resolveIntegrationsSelection(input: {
@@ -637,6 +659,157 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	let rotateMessageTone: 'error' | 'info' = 'info'
 	let lastRotateAppSlug: string | null = null
 	const loadLatch = createRouteLoadLatch()
+	const disconnectChecks = new Map<
+		string,
+		ReturnType<typeof createDoubleCheck>
+	>()
+	const deleteAppCheck = createDoubleCheck(handle)
+	const undoable = createUndoableAction(handle)
+
+	function getDisconnectCheck(name: string) {
+		const existing = disconnectChecks.get(name)
+		if (existing) return existing
+		const created = createDoubleCheck(handle)
+		disconnectChecks.set(name, created)
+		return created
+	}
+
+	function snapshotList(): IntegrationsSnapshot {
+		return {
+			integrations,
+			apps,
+			href: getCurrentHref(),
+		}
+	}
+
+	function restoreSnapshot(snapshot: IntegrationsSnapshot) {
+		integrations = snapshot.integrations
+		apps = snapshot.apps
+		message = null
+		handle.update()
+		if (getCurrentHref() !== snapshot.href) {
+			navigate(snapshot.href)
+		}
+	}
+
+	function listHref() {
+		return `${routes.accountIntegrations.href()}${getCurrentSearch()}`
+	}
+
+	function removeConnectionLocally(name: string) {
+		integrations = integrations.filter((entry) => entry.name !== name)
+		apps = apps.flatMap((app) => {
+			const connections = app.connections.filter(
+				(connection) => connection.name !== name,
+			)
+			if (connections.length === app.connections.length) return [app]
+			if (connections.length === 0 && !isBuiltInApp(app)) return []
+			return [
+				{
+					...app,
+					connections,
+					connectionCount: connections.length,
+				},
+			]
+		})
+	}
+
+	function removeAppLocally(app: AccountOauthAppListItem) {
+		const names = new Set(app.connections.map((connection) => connection.name))
+		integrations = integrations.filter((entry) => !names.has(entry.name))
+		apps = apps.filter(
+			(entry) => integrationListId(entry) !== integrationListId(app),
+		)
+	}
+
+	async function postIntegrationsMutation(body: Record<string, unknown>) {
+		const response = await fetch(accountIntegrationsApiPath, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			credentials: 'include',
+			keepalive: true,
+			body: JSON.stringify(body),
+		})
+		if (response.status === 401) {
+			window.location.assign('/login')
+			return
+		}
+		const payload = await readJson<{ ok?: boolean; error?: string }>(response)
+		if (!response.ok || !payload?.ok) {
+			throw new Error(payload?.error || 'Unable to complete that action.')
+		}
+	}
+
+	async function startDisconnect(connection: {
+		name: string
+		accountLabel?: string | null
+	}) {
+		const snapshot = snapshotList()
+		removeConnectionLocally(connection.name)
+		getDisconnectCheck(connection.name).reset()
+		const stillSelected = resolveIntegrationsSelection({
+			href: getCurrentHref(),
+			apps,
+			integrations,
+		}).selectedApp
+		if (!stillSelected) {
+			navigate(listHref())
+		}
+		await undoable.start({
+			message: `Disconnected ${connectionLabel(connection)}.`,
+			onCommit: async () => {
+				try {
+					await postIntegrationsMutation({
+						action: 'disconnect_connection',
+						name: connection.name,
+					})
+				} catch (error) {
+					restoreSnapshot(snapshot)
+					message =
+						error instanceof Error
+							? error.message
+							: 'Unable to disconnect that account.'
+					handle.update()
+				}
+			},
+			onUndo: () => {
+				restoreSnapshot(snapshot)
+			},
+		})
+	}
+
+	async function startDeleteApp(app: AccountOauthAppListItem) {
+		const snapshot = snapshotList()
+		const title = oauthAppTitle(app)
+		const connectionCount = app.connections.length
+		removeAppLocally(app)
+		deleteAppCheck.reset()
+		navigate(listHref())
+		await undoable.start({
+			message: deletedAppCopy(title, connectionCount),
+			onCommit: async () => {
+				try {
+					await postIntegrationsMutation({
+						action: 'delete_oauth_app',
+						appSlug: app.slug,
+					})
+				} catch (error) {
+					restoreSnapshot(snapshot)
+					message =
+						error instanceof Error
+							? error.message
+							: 'Unable to delete that integration.'
+					handle.update()
+				}
+			},
+			onUndo: () => {
+				restoreSnapshot(snapshot)
+			},
+		})
+	}
 
 	function getCurrentHref() {
 		return readCurrentRouterHref(handle)
@@ -942,6 +1115,36 @@ export function AccountIntegrationsRoute(handle: Handle) {
 														selectedApp.connections.length,
 													)}
 												</p>
+												{isBuiltInApp(selectedApp) ? null : (
+													<button
+														type="button"
+														data-testid="delete-integration"
+														aria-label={
+															deleteAppCheck.doubleCheck
+																? `Confirm delete integration "${oauthAppTitle(selectedApp)}"`
+																: `Delete integration "${oauthAppTitle(selectedApp)}"`
+														}
+														title={
+															deleteAppCheck.doubleCheck
+																? `Click again to delete "${oauthAppTitle(selectedApp)}" and every connected account`
+																: `Delete "${oauthAppTitle(selectedApp)}" and every connected account`
+														}
+														mix={[
+															...deleteAppCheck.getButtonMix({
+																on: {
+																	click: () => {
+																		void startDeleteApp(selectedApp)
+																	},
+																},
+															}),
+															css(dangerButtonCss),
+														]}
+													>
+														{deleteAppCheck.doubleCheck
+															? 'Confirm delete'
+															: 'Delete integration'}
+													</button>
+												)}
 											</div>
 										</header>
 
@@ -996,6 +1199,14 @@ export function AccountIntegrationsRoute(handle: Handle) {
 																isBuiltInApp(selectedApp),
 															appSlug: connection?.appSlug ?? selectedApp.slug,
 														})
+														const disconnectCheck = getDisconnectCheck(
+															connectionRef.name,
+														)
+														const confirmingDisconnect =
+															disconnectCheck.doubleCheck
+														const disconnectLabel = connectionLabel(
+															connection ?? connectionRef,
+														)
 														return (
 															<article
 																key={connectionRef.name}
@@ -1039,7 +1250,13 @@ export function AccountIntegrationsRoute(handle: Handle) {
 																		{status}
 																	</p>
 																</div>
-																<div>
+																<div
+																	mix={css({
+																		display: 'flex',
+																		flexWrap: 'wrap',
+																		gap: spacing.xs,
+																	})}
+																>
 																	<a
 																		href={connectHref}
 																		mix={css({
@@ -1052,6 +1269,36 @@ export function AccountIntegrationsRoute(handle: Handle) {
 																	>
 																		{connectActionLabel(status)}
 																	</a>
+																	<button
+																		type="button"
+																		data-testid="disconnect-connection"
+																		aria-label={
+																			confirmingDisconnect
+																				? `Confirm disconnect ${disconnectLabel}`
+																				: `Disconnect ${disconnectLabel}`
+																		}
+																		title={
+																			confirmingDisconnect
+																				? `Click again to disconnect ${disconnectLabel}`
+																				: `Disconnect ${disconnectLabel}`
+																		}
+																		mix={[
+																			...disconnectCheck.getButtonMix({
+																				on: {
+																					click: () => {
+																						void startDisconnect(
+																							connection ?? connectionRef,
+																						)
+																					},
+																				},
+																			}),
+																			css(dangerButtonCss),
+																		]}
+																	>
+																		{confirmingDisconnect
+																			? 'Confirm disconnect'
+																			: 'Disconnect'}
+																	</button>
 																</div>
 															</article>
 														)
@@ -1448,6 +1695,15 @@ export function AccountIntegrationsRoute(handle: Handle) {
 						Back to account
 					</a>
 				</p>
+				{undoable.pending ? (
+					<UndoToast
+						message={undoable.pending.message}
+						undoLabel={undoable.pending.undoLabel}
+						onUndo={() => {
+							void undoable.undo()
+						}}
+					/>
+				) : null}
 			</AccountManagementShell>
 		)
 	}

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -715,9 +715,13 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		)
 	}
 
-	function navigateIfSelectionGone() {
+	function finishOptimisticRemoval() {
 		holdingOptimisticRemoval = false
-		if (currentSelectionMissing()) navigate(listHref())
+		if (currentSelectionMissing()) {
+			navigate(listHref())
+			return
+		}
+		handle.update()
 	}
 
 	function removeConnectionLocally(name: string) {
@@ -774,7 +778,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		const snapshot = snapshotList()
 		removeConnectionLocally(connection.name)
 		getDisconnectCheck(connection.name).reset()
-		holdingOptimisticRemoval = currentSelectionMissing()
+		holdingOptimisticRemoval = true
 		// Stay on this route element until commit. List/detail are separate
 		// Remix routes, so navigating away remounts, commits immediately, and
 		// loader data restores the row that was just hidden.
@@ -786,7 +790,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 						action: 'disconnect_connection',
 						name: connection.name,
 					})
-					navigateIfSelectionGone()
+					finishOptimisticRemoval()
 				} catch (error) {
 					holdingOptimisticRemoval = false
 					restoreSnapshot(snapshot)
@@ -810,7 +814,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		const connectionCount = app.connections.length
 		removeAppLocally(app)
 		deleteAppCheck.reset()
-		holdingOptimisticRemoval = currentSelectionMissing()
+		holdingOptimisticRemoval = true
 		await undoable.start({
 			message: deletedAppCopy(title, connectionCount),
 			onCommit: async () => {
@@ -819,7 +823,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 						action: 'delete_oauth_app',
 						appSlug: app.slug,
 					})
-					navigateIfSelectionGone()
+					finishOptimisticRemoval()
 				} catch (error) {
 					holdingOptimisticRemoval = false
 					restoreSnapshot(snapshot)

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -665,6 +665,11 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	>()
 	const deleteAppCheck = createDoubleCheck(handle)
 	const undoable = createUndoableAction(handle)
+	let holdingOptimisticRemoval = false
+
+	function isHoldingOptimisticRemoval() {
+		return Boolean(undoable.pending) || holdingOptimisticRemoval
+	}
 
 	function getDisconnectCheck(name: string) {
 		const existing = disconnectChecks.get(name)
@@ -711,6 +716,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	}
 
 	function navigateIfSelectionGone() {
+		holdingOptimisticRemoval = false
 		if (currentSelectionMissing()) navigate(listHref())
 	}
 
@@ -768,6 +774,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		const snapshot = snapshotList()
 		removeConnectionLocally(connection.name)
 		getDisconnectCheck(connection.name).reset()
+		holdingOptimisticRemoval = currentSelectionMissing()
 		// Stay on this route element until commit. List/detail are separate
 		// Remix routes, so navigating away remounts, commits immediately, and
 		// loader data restores the row that was just hidden.
@@ -781,6 +788,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 					})
 					navigateIfSelectionGone()
 				} catch (error) {
+					holdingOptimisticRemoval = false
 					restoreSnapshot(snapshot)
 					message =
 						error instanceof Error
@@ -790,6 +798,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 				}
 			},
 			onUndo: () => {
+				holdingOptimisticRemoval = false
 				restoreSnapshot(snapshot)
 			},
 		})
@@ -801,6 +810,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		const connectionCount = app.connections.length
 		removeAppLocally(app)
 		deleteAppCheck.reset()
+		holdingOptimisticRemoval = currentSelectionMissing()
 		await undoable.start({
 			message: deletedAppCopy(title, connectionCount),
 			onCommit: async () => {
@@ -811,6 +821,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 					})
 					navigateIfSelectionGone()
 				} catch (error) {
+					holdingOptimisticRemoval = false
 					restoreSnapshot(snapshot)
 					message =
 						error instanceof Error
@@ -820,6 +831,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 				}
 			},
 			onUndo: () => {
+				holdingOptimisticRemoval = false
 				restoreSnapshot(snapshot)
 			},
 		})
@@ -886,7 +898,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	}
 
 	function applyRouteLoaderData(href: string) {
-		if (undoable.pending) return false
+		if (isHoldingOptimisticRemoval()) return false
 		if (!integrationsRoute.isRoutePath(href)) return false
 		const routeData = tryConsumeRouteLoaderData(
 			handle,
@@ -991,12 +1003,12 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		// stale-refresh or latch a load — both would clobber the removal or
 		// block the next fetch after undo.
 		const needsStaleRefresh =
-			!undoable.pending &&
+			!isHoldingOptimisticRemoval() &&
 			consumeStaleNavigationData(currentHref) &&
 			!appliedRouteData
 		const latchKey = getDataLatchKey(currentHref)
 		const needsLoad =
-			!undoable.pending &&
+			!isHoldingOptimisticRemoval() &&
 			loadLatch.needsLoad({
 				currentHref: latchKey,
 				appliedRouteData,
@@ -1022,9 +1034,13 @@ export function AccountIntegrationsRoute(handle: Handle) {
 			resetRotateForm(selectedApp)
 		}
 		const showIntegrationNotFound =
-			missingKind === 'integration' && status === 'ready' && !undoable.pending
+			missingKind === 'integration' &&
+			status === 'ready' &&
+			!isHoldingOptimisticRemoval()
 		const showConnectionNotFound =
-			missingKind === 'connection' && status === 'ready' && !undoable.pending
+			missingKind === 'connection' &&
+			status === 'ready' &&
+			!isHoldingOptimisticRemoval()
 		const highlightedConnection = highlightedConnectionName
 			? (integrations.find(
 					(connection) => connection.name === highlightedConnectionName,

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -696,6 +696,20 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		return `${routes.accountIntegrations.href()}${getCurrentSearch()}`
 	}
 
+	function currentSelectionMissing() {
+		return Boolean(
+			resolveIntegrationsSelection({
+				href: getCurrentHref(),
+				apps,
+				integrations,
+			}).missingKind,
+		)
+	}
+
+	function navigateIfSelectionGone() {
+		if (currentSelectionMissing()) navigate(listHref())
+	}
+
 	function removeConnectionLocally(name: string) {
 		integrations = integrations.filter((entry) => entry.name !== name)
 		apps = apps.flatMap((app) => {
@@ -750,14 +764,9 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		const snapshot = snapshotList()
 		removeConnectionLocally(connection.name)
 		getDisconnectCheck(connection.name).reset()
-		const stillSelected = resolveIntegrationsSelection({
-			href: getCurrentHref(),
-			apps,
-			integrations,
-		}).selectedApp
-		if (!stillSelected) {
-			navigate(listHref())
-		}
+		// Stay on this route element until commit. List/detail are separate
+		// Remix routes, so navigating away remounts, commits immediately, and
+		// loader data restores the row that was just hidden.
 		await undoable.start({
 			message: `Disconnected ${connectionLabel(connection)}.`,
 			onCommit: async () => {
@@ -766,6 +775,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 						action: 'disconnect_connection',
 						name: connection.name,
 					})
+					navigateIfSelectionGone()
 				} catch (error) {
 					restoreSnapshot(snapshot)
 					message =
@@ -787,7 +797,6 @@ export function AccountIntegrationsRoute(handle: Handle) {
 		const connectionCount = app.connections.length
 		removeAppLocally(app)
 		deleteAppCheck.reset()
-		navigate(listHref())
 		await undoable.start({
 			message: deletedAppCopy(title, connectionCount),
 			onCommit: async () => {
@@ -796,6 +805,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 						action: 'delete_oauth_app',
 						appSlug: app.slug,
 					})
+					navigateIfSelectionGone()
 				} catch (error) {
 					restoreSnapshot(snapshot)
 					message =
@@ -872,6 +882,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	}
 
 	function applyRouteLoaderData(href: string) {
+		if (undoable.pending) return false
 		if (!integrationsRoute.isRoutePath(href)) return false
 		const routeData = tryConsumeRouteLoaderData(
 			handle,
@@ -972,16 +983,21 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	return () => {
 		const currentHref = getCurrentHref()
 		const appliedRouteData = applyRouteLoaderData(currentHref)
-		// A same-path refresh whose loader failed leaves no preload and no
-		// href change; the stale marker forces the fallback refetch.
+		// Hold optimistic list state for the undo window. Do not consume a
+		// stale-refresh or latch a load — both would clobber the removal or
+		// block the next fetch after undo.
 		const needsStaleRefresh =
-			consumeStaleNavigationData(currentHref) && !appliedRouteData
+			!undoable.pending &&
+			consumeStaleNavigationData(currentHref) &&
+			!appliedRouteData
 		const latchKey = getDataLatchKey(currentHref)
-		const needsLoad = loadLatch.needsLoad({
-			currentHref: latchKey,
-			appliedRouteData,
-			needsStaleRefresh,
-		})
+		const needsLoad =
+			!undoable.pending &&
+			loadLatch.needsLoad({
+				currentHref: latchKey,
+				appliedRouteData,
+				needsStaleRefresh,
+			})
 		if (needsLoad && typeof document !== 'undefined') {
 			handle.queueTask(loadIntegrations)
 		}
@@ -1002,9 +1018,9 @@ export function AccountIntegrationsRoute(handle: Handle) {
 			resetRotateForm(selectedApp)
 		}
 		const showIntegrationNotFound =
-			missingKind === 'integration' && status === 'ready'
+			missingKind === 'integration' && status === 'ready' && !undoable.pending
 		const showConnectionNotFound =
-			missingKind === 'connection' && status === 'ready'
+			missingKind === 'connection' && status === 'ready' && !undoable.pending
 		const highlightedConnection = highlightedConnectionName
 			? (integrations.find(
 					(connection) => connection.name === highlightedConnectionName,

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -683,11 +683,15 @@ export function AccountIntegrationsRoute(handle: Handle) {
 	}
 
 	function restoreSnapshot(snapshot: IntegrationsSnapshot) {
+		if (handle.signal.aborted) return
 		integrations = snapshot.integrations
 		apps = snapshot.apps
 		message = null
 		handle.update()
-		if (getCurrentHref() !== snapshot.href) {
+		if (
+			integrationsRoute.isRoutePath(getCurrentHref()) &&
+			getCurrentHref() !== snapshot.href
+		) {
 			navigate(snapshot.href)
 		}
 	}

--- a/packages/worker/client/undo-toast.tsx
+++ b/packages/worker/client/undo-toast.tsx
@@ -1,0 +1,65 @@
+import { type Handle, css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import {
+	colors,
+	radius,
+	shadows,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+import { getPillButtonCss } from '#universal/styles/style-primitives.ts'
+
+type UndoToastProps = {
+	message: string
+	undoLabel?: string
+	onUndo: () => void
+}
+
+export function UndoToast(handle: Handle<UndoToastProps>) {
+	return () => (
+		<div
+			role="status"
+			aria-live="polite"
+			data-testid="undo-toast"
+			mix={css({
+				position: 'fixed',
+				left: '50%',
+				bottom: spacing.xl,
+				transform: 'translateX(-50%)',
+				zIndex: 1000,
+				display: 'flex',
+				alignItems: 'center',
+				gap: spacing.md,
+				padding: `${spacing.sm} ${spacing.md}`,
+				backgroundColor: colors.surface,
+				color: colors.text,
+				boxShadow: shadows.md,
+				borderRadius: radius.lg,
+				border: `1px solid ${colors.border}`,
+				maxWidth: 'min(36rem, calc(100vw - 2rem))',
+			})}
+		>
+			<p
+				mix={css({
+					margin: 0,
+					fontSize: typography.fontSize.sm,
+					minWidth: 0,
+				})}
+			>
+				{handle.props.message}
+			</p>
+			<button
+				type="button"
+				data-testid="undo-toast-undo"
+				mix={[
+					on('click', () => {
+						handle.props.onUndo()
+					}),
+					css(getPillButtonCss({ size: 'sm' })),
+				]}
+			>
+				{handle.props.undoLabel ?? 'Undo'}
+			</button>
+		</div>
+	)
+}

--- a/packages/worker/client/undoable-action.node.test.ts
+++ b/packages/worker/client/undoable-action.node.test.ts
@@ -73,6 +73,28 @@ test('undoable action commits after the timeout, undoes before it, and commits a
 		await vi.advanceTimersByTimeAsync(0)
 		expect(abortCommit).toHaveBeenCalledTimes(1)
 		expect(abortable.pending).toBeNull()
+
+		let releaseFirst: () => void = () => {}
+		const firstInFlight = new Promise<void>((resolve) => {
+			releaseFirst = resolve
+		})
+		const inFlightCommit = vi.fn(() => firstInFlight)
+		const nextUndo = vi.fn()
+		await undoable.start({
+			message: 'Disconnected first in-flight.',
+			onCommit: inFlightCommit,
+		})
+		void undoable.commit()
+		await Promise.resolve()
+		expect(inFlightCommit).toHaveBeenCalledTimes(1)
+		await undoable.start({
+			message: 'Disconnected next.',
+			onCommit: vi.fn(),
+			onUndo: nextUndo,
+		})
+		await undoable.undo()
+		expect(nextUndo).toHaveBeenCalledTimes(1)
+		releaseFirst()
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/client/undoable-action.node.test.ts
+++ b/packages/worker/client/undoable-action.node.test.ts
@@ -1,0 +1,79 @@
+import { expect, test, vi } from 'vitest'
+
+const { createUndoableAction } = await import('./undoable-action.ts')
+
+function createHandle() {
+	const abort = new AbortController()
+	return {
+		update: vi.fn(),
+		signal: abort.signal,
+		abort: () => abort.abort(),
+	}
+}
+
+test('undoable action commits after the timeout, undoes before it, and commits a replaced or aborted pending action', async () => {
+	vi.useFakeTimers()
+	try {
+		const handle = createHandle()
+		const undoable = createUndoableAction(handle as never, { timeoutMs: 1_000 })
+		const firstCommit = vi.fn()
+		const firstUndo = vi.fn()
+
+		await undoable.start({
+			message: 'Disconnected Personal.',
+			onCommit: firstCommit,
+			onUndo: firstUndo,
+		})
+		expect(undoable.pending).toEqual({
+			message: 'Disconnected Personal.',
+			undoLabel: 'Undo',
+		})
+		expect(handle.update).toHaveBeenCalled()
+
+		await undoable.undo()
+		expect(firstUndo).toHaveBeenCalledTimes(1)
+		expect(firstCommit).not.toHaveBeenCalled()
+		expect(undoable.pending).toBeNull()
+
+		const timedCommit = vi.fn()
+		await undoable.start({
+			message: 'Disconnected Work.',
+			undoLabel: 'Restore',
+			onCommit: timedCommit,
+		})
+		expect(undoable.pending?.undoLabel).toBe('Restore')
+		await vi.advanceTimersByTimeAsync(1_000)
+		expect(timedCommit).toHaveBeenCalledTimes(1)
+		expect(undoable.pending).toBeNull()
+
+		const replacedCommit = vi.fn()
+		const nextCommit = vi.fn()
+		await undoable.start({
+			message: 'Disconnected first.',
+			onCommit: replacedCommit,
+		})
+		await undoable.start({
+			message: 'Deleted Google.',
+			onCommit: nextCommit,
+		})
+		expect(replacedCommit).toHaveBeenCalledTimes(1)
+		expect(nextCommit).not.toHaveBeenCalled()
+		expect(undoable.pending?.message).toBe('Deleted Google.')
+
+		const abortHandle = createHandle()
+		const abortable = createUndoableAction(abortHandle as never, {
+			timeoutMs: 5_000,
+		})
+		const abortCommit = vi.fn()
+		await abortable.start({
+			message: 'Disconnected abort.',
+			onCommit: abortCommit,
+		})
+		abortHandle.abort()
+		await vi.advanceTimersByTimeAsync(0)
+		expect(abortCommit).toHaveBeenCalledTimes(1)
+		expect(abortable.pending).toBeNull()
+	} finally {
+		vi.useRealTimers()
+	}
+})

--- a/packages/worker/client/undoable-action.ts
+++ b/packages/worker/client/undoable-action.ts
@@ -1,0 +1,111 @@
+import { type Handle } from 'remix/ui'
+
+const defaultUndoTimeoutMs = 8_000
+
+export type UndoableActionPending = {
+	message: string
+	undoLabel: string
+}
+
+export type UndoableActionStartInput = {
+	message: string
+	undoLabel?: string
+	onCommit: () => void | Promise<void>
+	onUndo?: () => void | Promise<void>
+}
+
+/**
+ * Delayed-commit undo for destructive UI actions.
+ *
+ * After the caller confirms (typically via `createDoubleCheck`), apply the
+ * optimistic result and call `start({ message, onCommit, onUndo })`. Undo
+ * before `timeoutMs` runs `onUndo` and never `onCommit`. Otherwise `onCommit`
+ * is the real mutation. Unmount and `pagehide` also commit so the action is
+ * not lost if the user leaves. A second `start` commits the first pending
+ * action first.
+ *
+ * `onCommit` should use `keepalive: true` on `fetch` when the mutation must
+ * finish after navigation.
+ */
+export function createUndoableAction(
+	handle: Handle,
+	options?: { timeoutMs?: number },
+) {
+	const timeoutMs = options?.timeoutMs ?? defaultUndoTimeoutMs
+	let pending: UndoableActionPending | null = null
+	let timer: ReturnType<typeof setTimeout> | null = null
+	let commitFn: (() => void | Promise<void>) | null = null
+	let undoFn: (() => void | Promise<void>) | null = null
+	let committing = false
+
+	function clearTimer() {
+		if (timer === null) return
+		clearTimeout(timer)
+		timer = null
+	}
+
+	function clearPending() {
+		pending = null
+		commitFn = null
+		undoFn = null
+	}
+
+	async function commit(options?: { silent?: boolean }) {
+		if (!pending || committing) return
+		committing = true
+		clearTimer()
+		const fn = commitFn
+		clearPending()
+		if (!options?.silent) handle.update()
+		try {
+			await fn?.()
+		} finally {
+			committing = false
+		}
+	}
+
+	async function undo() {
+		if (!pending || committing) return
+		clearTimer()
+		const fn = undoFn
+		clearPending()
+		handle.update()
+		await fn?.()
+	}
+
+	async function start(input: UndoableActionStartInput) {
+		if (pending) await commit()
+		pending = {
+			message: input.message,
+			undoLabel: input.undoLabel ?? 'Undo',
+		}
+		commitFn = input.onCommit
+		undoFn = input.onUndo ?? null
+		timer = setTimeout(() => {
+			void commit()
+		}, timeoutMs)
+		handle.update()
+	}
+
+	const onPageHide = () => {
+		void commit({ silent: true })
+	}
+	if (typeof document !== 'undefined') {
+		window.addEventListener('pagehide', onPageHide)
+	}
+	handle.signal.addEventListener('abort', () => {
+		if (typeof document !== 'undefined') {
+			window.removeEventListener('pagehide', onPageHide)
+		}
+		void commit({ silent: true })
+	})
+
+	return {
+		get pending() {
+			return pending
+		},
+		start,
+		undo,
+		commit,
+	}
+}

--- a/packages/worker/client/undoable-action.ts
+++ b/packages/worker/client/undoable-action.ts
@@ -25,7 +25,8 @@ export type UndoableActionStartInput = {
  * action first.
  *
  * `onCommit` should use `keepalive: true` on `fetch` when the mutation must
- * finish after navigation.
+ * finish after navigation. Do not navigate to a remounting route during the
+ * undo window; remount commits immediately and can restore optimistic UI.
  */
 export function createUndoableAction(
 	handle: Handle,

--- a/packages/worker/client/undoable-action.ts
+++ b/packages/worker/client/undoable-action.ts
@@ -37,7 +37,6 @@ export function createUndoableAction(
 	let timer: ReturnType<typeof setTimeout> | null = null
 	let commitFn: (() => void | Promise<void>) | null = null
 	let undoFn: (() => void | Promise<void>) | null = null
-	let committing = false
 
 	function clearTimer() {
 		if (timer === null) return
@@ -52,21 +51,16 @@ export function createUndoableAction(
 	}
 
 	async function commit(options?: { silent?: boolean }) {
-		if (!pending || committing) return
-		committing = true
+		if (!pending) return
 		clearTimer()
 		const fn = commitFn
 		clearPending()
 		if (!options?.silent) handle.update()
-		try {
-			await fn?.()
-		} finally {
-			committing = false
-		}
+		await fn?.()
 	}
 
 	async function undo() {
-		if (!pending || committing) return
+		if (!pending) return
 		clearTimer()
 		const fn = undoFn
 		clearPending()

--- a/packages/worker/src/app/handlers/account-integrations.node.test.ts
+++ b/packages/worker/src/app/handlers/account-integrations.node.test.ts
@@ -259,6 +259,11 @@ const mockModule = vi.hoisted(() => ({
 		updatedAt: '1970-01-01T00:00:00.002Z',
 	})),
 	setSecretAllowedHosts: vi.fn(async () => undefined),
+	deleteIntegration: vi.fn(async () => true),
+	deleteOauthAppWithConnections: vi.fn(async () => ({
+		deleted: true,
+		connectionNames: ['google', 'google-calendar'],
+	})),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
@@ -301,6 +306,10 @@ vi.mock('#worker/integrations/service.ts', async (importOriginal) => {
 		getOauthApp: (...args: Array<unknown>) => mockModule.getOauthApp(...args),
 		rotateOauthAppClientCredentials: (...args: Array<unknown>) =>
 			mockModule.rotateOauthAppClientCredentials(...args),
+		deleteIntegration: (...args: Array<unknown>) =>
+			mockModule.deleteIntegration(...args),
+		deleteOauthAppWithConnections: (...args: Array<unknown>) =>
+			mockModule.deleteOauthAppWithConnections(...args),
 		getAvailablePlatformApp: (...args: Array<unknown>) =>
 			mockModule.getAvailablePlatformApp(...args),
 	}
@@ -879,4 +888,85 @@ test('integrations API scopes rotate actions to the authenticated user', async (
 			userId: 'stable-user-other',
 		}),
 	)
+})
+
+test('integrations API disconnects a connection and deletes a user-lane OAuth app', async () => {
+	const handler = createAccountIntegrationsApiHandler(createEnv())
+	const disconnectResponse = await handler.handler({
+		request: new Request('https://example.com/account/integrations.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'disconnect_connection',
+				name: 'google-calendar',
+			}),
+		}),
+		params: {},
+	} as never)
+	expect(disconnectResponse.status).toBe(200)
+	await expect(disconnectResponse.json()).resolves.toEqual({
+		ok: true,
+		deleted: true,
+	})
+	expect(mockModule.deleteIntegration).toHaveBeenCalledWith({
+		env: expect.any(Object),
+		userId: 'stable-user-1',
+		name: 'google-calendar',
+	})
+
+	mockModule.deleteIntegration.mockResolvedValueOnce(false)
+	const missingDisconnect = await handler.handler({
+		request: new Request('https://example.com/account/integrations.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'disconnect_connection',
+				name: 'missing',
+			}),
+		}),
+		params: {},
+	} as never)
+	expect(missingDisconnect.status).toBe(404)
+
+	const deleteAppResponse = await handler.handler({
+		request: new Request('https://example.com/account/integrations.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'delete_oauth_app',
+				appSlug: 'google',
+			}),
+		}),
+		params: {},
+	} as never)
+	expect(deleteAppResponse.status).toBe(200)
+	await expect(deleteAppResponse.json()).resolves.toEqual({
+		ok: true,
+		deleted: true,
+		connectionNames: ['google', 'google-calendar'],
+	})
+	expect(mockModule.getOauthApp).toHaveBeenCalledWith({
+		env: expect.any(Object),
+		userId: 'stable-user-1',
+		slug: 'google',
+	})
+	expect(mockModule.deleteOauthAppWithConnections).toHaveBeenCalledWith({
+		env: expect.any(Object),
+		userId: 'stable-user-1',
+		slug: 'google',
+	})
+
+	mockModule.getOauthApp.mockResolvedValueOnce(null)
+	const missingApp = await handler.handler({
+		request: new Request('https://example.com/account/integrations.json', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				action: 'delete_oauth_app',
+				appSlug: 'missing',
+			}),
+		}),
+		params: {},
+	} as never)
+	expect(missingApp.status).toBe(404)
 })

--- a/packages/worker/src/app/handlers/account-integrations.ts
+++ b/packages/worker/src/app/handlers/account-integrations.ts
@@ -23,6 +23,8 @@ import {
 	setSecretAllowedHosts,
 } from '#mcp/secrets/service.ts'
 import {
+	deleteIntegration,
+	deleteOauthAppWithConnections,
 	getOauthApp,
 	listJoinedIntegrations,
 	rotateOauthAppClientCredentials,
@@ -41,6 +43,30 @@ const rotateOauthAppCredentialsSchema = z
 	.refine((value) => Boolean(value.clientId || value.clientSecret), {
 		message: 'Provide a new client id and/or client secret.',
 	})
+
+const disconnectConnectionSchema = z
+	.object({
+		action: z.literal('disconnect_connection'),
+		name: z.string().min(1),
+	})
+	.strict()
+
+const deleteOauthAppSchema = z
+	.object({
+		action: z.literal('delete_oauth_app'),
+		appSlug: z.string().min(1),
+	})
+	.strict()
+
+const accountIntegrationsActionSchema = z
+	.object({
+		action: z.enum([
+			'rotate_oauth_app_credentials',
+			'disconnect_connection',
+			'delete_oauth_app',
+		]),
+	})
+	.passthrough()
 
 export function createAccountIntegrationsHandler(env: Env) {
 	return {
@@ -122,21 +148,109 @@ export function createAccountIntegrationsApiHandler(env: Env) {
 			}
 
 			const body = await request.json().catch(() => null)
-			const parsed = rotateOauthAppCredentialsSchema.safeParse(body)
-			if (!parsed.success) {
+			const actionParsed = accountIntegrationsActionSchema.safeParse(body)
+			if (!actionParsed.success) {
 				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
 			}
 
-			return handleRotateOauthAppCredentials({
-				env,
-				user,
-				body: parsed.data,
-			})
+			switch (actionParsed.data.action) {
+				case 'rotate_oauth_app_credentials': {
+					const parsed = rotateOauthAppCredentialsSchema.safeParse(body)
+					if (!parsed.success) {
+						return jsonResponse(
+							{ ok: false, error: 'Invalid request body.' },
+							400,
+						)
+					}
+					return handleRotateOauthAppCredentials({
+						env,
+						user,
+						body: parsed.data,
+					})
+				}
+				case 'disconnect_connection': {
+					const parsed = disconnectConnectionSchema.safeParse(body)
+					if (!parsed.success) {
+						return jsonResponse(
+							{ ok: false, error: 'Invalid request body.' },
+							400,
+						)
+					}
+					return handleDisconnectConnection({
+						env,
+						user,
+						name: parsed.data.name,
+					})
+				}
+				case 'delete_oauth_app': {
+					const parsed = deleteOauthAppSchema.safeParse(body)
+					if (!parsed.success) {
+						return jsonResponse(
+							{ ok: false, error: 'Invalid request body.' },
+							400,
+						)
+					}
+					return handleDeleteOauthApp({
+						env,
+						user,
+						appSlug: parsed.data.appSlug,
+					})
+				}
+				default: {
+					const _exhaustive: never = actionParsed.data.action
+					return _exhaustive
+				}
+			}
 		},
 	} satisfies Action<
 		| typeof routes.accountIntegrationsApi
 		| typeof routes.accountIntegrationsApiPost
 	>
+}
+
+async function handleDisconnectConnection(input: {
+	env: Env
+	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
+	name: string
+}) {
+	const deleted = await deleteIntegration({
+		env: input.env,
+		userId: input.user.mcpUser.userId,
+		name: input.name,
+	})
+	if (!deleted) {
+		return jsonResponse({ ok: false, error: 'Connection not found.' }, 404)
+	}
+	return jsonResponse({ ok: true, deleted: true })
+}
+
+async function handleDeleteOauthApp(input: {
+	env: Env
+	user: NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>
+	appSlug: string
+}) {
+	const userId = input.user.mcpUser.userId
+	const existing = await getOauthApp({
+		env: input.env,
+		userId,
+		slug: input.appSlug,
+	})
+	if (!existing) {
+		return jsonResponse({ ok: false, error: 'OAuth app not found.' }, 404)
+	}
+	const result = await deleteOauthAppWithConnections({
+		env: input.env,
+		userId,
+		slug: existing.slug,
+	})
+	if (!result.deleted) {
+		return jsonResponse({ ok: false, error: 'OAuth app not found.' }, 404)
+	}
+	return jsonResponse({
+		ok: true,
+		deleted: true,
+		connectionNames: result.connectionNames,
+	})
 }
 
 async function handleRotateOauthAppCredentials(input: {

--- a/packages/worker/src/integrations/service.node.test.ts
+++ b/packages/worker/src/integrations/service.node.test.ts
@@ -6,6 +6,7 @@ import { upsertPlatformOauthApp } from './platform-apps.ts'
 import {
 	deleteIntegration,
 	deleteOauthAppIfUnused,
+	deleteOauthAppWithConnections,
 	findOauthAppForProviderSetup,
 	getAvailablePlatformApp,
 	getIntegration,
@@ -205,6 +206,26 @@ test('rotateOauthAppClientCredentials updates sibling joins, blocks delete while
 
 	const stillThere = await getIntegration({ env, userId, name: 'google' })
 	expect(stillThere?.name).toBe('google')
+
+	expect(
+		await deleteOauthAppWithConnections({
+			env,
+			userId,
+			slug: 'GOOGLE',
+		}),
+	).toEqual({
+		deleted: true,
+		connectionNames: ['google', 'google-mail'],
+	})
+	expect(await listIntegrations({ env, userId })).toEqual([])
+	expect(await getOauthApp({ env, userId, slug: 'google' })).toBeNull()
+	expect(
+		await deleteOauthAppWithConnections({
+			env,
+			userId,
+			slug: 'google',
+		}),
+	).toEqual({ deleted: false, connectionNames: [] })
 })
 
 test('upsertIntegration reuses a confidential app that stored usePkce false as NULL', async () => {

--- a/packages/worker/src/integrations/service.ts
+++ b/packages/worker/src/integrations/service.ts
@@ -766,6 +766,43 @@ export async function rotateOauthAppClientCredentials(input: {
 	return app
 }
 
+export async function deleteOauthAppWithConnections(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	slug: string
+}): Promise<{ deleted: boolean; connectionNames: Array<string> }> {
+	const slug = canonicalizeOauthAppSlug(input.slug)
+	if (!slug) return { deleted: false, connectionNames: [] }
+	const existing = await getOauthAppBySlug({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		slug,
+	})
+	if (!existing) return { deleted: false, connectionNames: [] }
+
+	const joined = await listJoinedIntegrationsForUser({
+		db: input.env.APP_DB,
+		userId: input.userId,
+	})
+	const connectionNames: Array<string> = []
+	for (const entry of joined) {
+		if (entry.lane !== 'user' || entry.app.slug !== existing.slug) continue
+		const deleted = await deleteIntegrationConnection({
+			db: input.env.APP_DB,
+			userId: input.userId,
+			name: entry.connection.name,
+		})
+		if (deleted) connectionNames.push(entry.connection.name)
+	}
+
+	const deleted = await deleteOauthApp({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		slug: existing.slug,
+	})
+	return { deleted, connectionNames }
+}
+
 export async function deleteOauthAppIfUnused(input: {
 	env: Pick<Env, 'APP_DB'>
 	userId: string

--- a/packages/worker/src/mcp/capabilities/integrations/domain.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/domain.ts
@@ -4,6 +4,7 @@ import { integrationDeleteCapability } from './integration-delete.ts'
 import { integrationDiscoverCapability } from './integration-discover.ts'
 import { integrationGetCapability } from './integration-get.ts'
 import { integrationListCapability } from './integration-list.ts'
+import { integrationOauthAppDeleteCapability } from './integration-oauth-app-delete.ts'
 import { integrationOauthAppListCapability } from './integration-oauth-app-list.ts'
 import { integrationOauthAppRotateCredentialsCapability } from './integration-oauth-app-rotate-credentials.ts'
 import { integrationPlatformAppListCapability } from './integration-platform-app-list.ts'
@@ -40,6 +41,7 @@ export const integrationsDomain = defineDomain({
 		integrationListCapability,
 		integrationDeleteCapability,
 		integrationOauthAppListCapability,
+		integrationOauthAppDeleteCapability,
 		integrationOauthAppRotateCredentialsCapability,
 		integrationPlatformAppListCapability,
 		integrationTokenRefreshCapability,

--- a/packages/worker/src/mcp/capabilities/integrations/integration-oauth-app-delete.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-oauth-app-delete.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod'
+import { defineDomainCapability } from '#mcp/capabilities/define-domain-capability.ts'
+import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
+import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
+import { type CapabilityContext } from '#mcp/capabilities/types.ts'
+import { deleteOauthAppWithConnections } from '#worker/integrations/service.ts'
+
+const inputSchema = z.object({
+	slug: z
+		.string()
+		.min(1)
+		.describe(
+			'User-lane OAuth app slug to delete, including every connection.',
+		),
+})
+
+const outputSchema = z.object({
+	deleted: z.boolean(),
+	connectionNames: z.array(z.string()),
+})
+
+export const integrationOauthAppDeleteCapability = defineDomainCapability(
+	capabilityDomainNames.integrations,
+	{
+		name: 'integration_oauth_app_delete',
+		description:
+			'Delete a user-registered OAuth app and every connection on it. Built-in (platform) apps cannot be deleted this way — disconnect their connections with integration_delete instead.',
+		keywords: ['integration', 'oauth', 'app', 'delete', 'remove', 'connection'],
+		readOnly: false,
+		idempotent: false,
+		destructive: true,
+		inputSchema,
+		outputSchema,
+		async handler(args, ctx: CapabilityContext) {
+			const user = requireMcpUser(ctx.callerContext)
+			return deleteOauthAppWithConnections({
+				env: ctx.env,
+				userId: user.userId,
+				slug: args.slug,
+			})
+		},
+	},
+)

--- a/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/integrations/integration-save.node.test.ts
@@ -7,6 +7,7 @@ import { applyAllMigrations as applyRepositoryMigrations } from '#worker/test-su
 import { integrationDeleteCapability } from './integration-delete.ts'
 import { integrationGetCapability } from './integration-get.ts'
 import { integrationListCapability } from './integration-list.ts'
+import { integrationOauthAppDeleteCapability } from './integration-oauth-app-delete.ts'
 import { integrationOauthAppListCapability } from './integration-oauth-app-list.ts'
 import { integrationOauthAppRotateCredentialsCapability } from './integration-oauth-app-rotate-credentials.ts'
 import { integrationSaveCapability } from './integration-save.ts'
@@ -361,6 +362,34 @@ test('integration_delete and credential rotation return the expected MCP respons
 		{ env, callerContext: caller(userId) },
 	)
 	expect(emptyApps.apps).toEqual([])
+
+	await integrationSaveCapability.handler(googleBase, {
+		env,
+		callerContext: caller(userId),
+	})
+	await integrationSaveCapability.handler(
+		{
+			...googleBase,
+			name: 'google-mail',
+			accessTokenSecretName: 'googleMailAccessToken',
+			refreshTokenSecretName: 'googleMailRefreshToken',
+		},
+		{ env, callerContext: caller(userId) },
+	)
+	const deletedApp = await integrationOauthAppDeleteCapability.handler(
+		{ slug: 'google' },
+		{ env, callerContext: caller(userId) },
+	)
+	expect(deletedApp).toEqual({
+		deleted: true,
+		connectionNames: ['google', 'google-mail'],
+	})
+	expect(
+		await integrationOauthAppListCapability.handler(
+			{},
+			{ env, callerContext: caller(userId) },
+		),
+	).toEqual({ apps: [] })
 })
 
 test('integration capabilities deny cross-user reads and require authentication', async () => {

--- a/tools/seed-sql.ts
+++ b/tools/seed-sql.ts
@@ -50,3 +50,46 @@ ON CONFLICT(email) DO UPDATE SET
   updated_at = CURRENT_TIMESTAMP;
 ${roleSql}`.trim()
 }
+
+/**
+ * A user-lane Google app with two connected accounts so /account/integrations
+ * can exercise Disconnect and Delete integration without a live OAuth dance.
+ */
+export function buildSeedIntegrationSql(email: string) {
+	const userId = quoteSqlString(stableUserIdFromEmail(email))
+	return `
+INSERT INTO user_oauth_apps (
+	user_id, slug, provider, label, client_id, client_secret_secret_name,
+	token_url, authorize_url, api_base_url, flow, extra_authorize_params_json
+) VALUES (
+	${userId}, 'google', 'google', 'Google', 'seed-google-client',
+	'googleClientSecret',
+	'https://oauth2.googleapis.com/token',
+	'https://accounts.google.com/o/oauth2/v2/auth',
+	'https://www.googleapis.com',
+	'pkce', '{}'
+)
+ON CONFLICT(user_id, slug) DO UPDATE SET
+	label = excluded.label,
+	client_id = excluded.client_id,
+	updated_at = CURRENT_TIMESTAMP;
+INSERT INTO user_integrations (
+	user_id, name, app_slug, platform_app_slug, account_label, description,
+	scopes_json, required_hosts_json, access_token_secret_name,
+	refresh_token_secret_name, connected_at
+) VALUES
+	(
+		${userId}, 'google', 'google', NULL, 'Personal', '',
+		'["openid","email"]', '["www.googleapis.com"]',
+		'googleAccessToken', 'googleRefreshToken', CURRENT_TIMESTAMP
+	),
+	(
+		${userId}, 'google-work', 'google', NULL, 'Work', '',
+		'["openid","email"]', '["www.googleapis.com"]',
+		'googleWorkAccessToken', 'googleWorkRefreshToken', CURRENT_TIMESTAMP
+	)
+ON CONFLICT(user_id, name) DO UPDATE SET
+	account_label = excluded.account_label,
+	app_slug = excluded.app_slug,
+	updated_at = CURRENT_TIMESTAMP;`.trim()
+}

--- a/tools/seed-test-data.node.test.ts
+++ b/tools/seed-test-data.node.test.ts
@@ -84,6 +84,9 @@ test('buildSeedSql seeds each account with its roles', () => {
 	expect(sql).toContain(
 		`WHERE u.email = 'kody@example.com' AND r.name = 'admin'`,
 	)
+	expect(sql).toContain(`'google-work'`)
+	expect(sql).toContain(stableUserIdFromEmail('kody@example.com'))
+	expect(sql).toContain(stableUserIdFromEmail('jane@example.com'))
 })
 
 test('seeded users carry the same stable id the signup path derives', async () => {

--- a/tools/seed-test-data.ts
+++ b/tools/seed-test-data.ts
@@ -3,7 +3,7 @@ import { basename } from 'node:path'
 import { fail, runWrangler } from './ci/resource-utils.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 import { isExecutedDirectly } from './node-runtime.ts'
-import { buildSeedUserSql } from './seed-sql.ts'
+import { buildSeedIntegrationSql, buildSeedUserSql } from './seed-sql.ts'
 import { usernameFromEmail } from '../packages/worker/src/identity/username.ts'
 import {
 	getDefaultWranglerConfigPath,
@@ -180,7 +180,12 @@ type SeedAccount = {
 }
 
 export function buildSeedSql(accounts: Array<SeedAccount>) {
-	return accounts.map(buildSeedUserSql).join('\n')
+	return accounts
+		.flatMap((account) => [
+			buildSeedUserSql(account),
+			buildSeedIntegrationSql(account.email),
+		])
+		.join('\n')
 }
 
 /**


### PR DESCRIPTION
## Summary

- Account integrations can now **disconnect a connected account** or **delete a user-registered OAuth app** (and every account on it). Built-in apps stay operator-owned; you only disconnect their accounts.
- Both actions use the existing double-check, then a new delayed-commit **undo** primitive (`createUndoableAction` + `UndoToast`) so the mutation waits a few seconds (or until you leave the page).
- Agents get the same app-level delete as `integration_oauth_app_delete`.

## Test plan

- [ ] Open `/account/integrations` on a user-registered integration with at least one account
- [ ] Click **Disconnect** once — button should read **Confirm disconnect**
- [ ] Click again — the account disappears and an **Undo** toast appears
- [ ] Click **Undo** — the account comes back and nothing is deleted
- [ ] Disconnect again and wait ~8s (or navigate away) — the connection is gone after reload
- [ ] On a user-registered integration, click **Delete integration** twice — the app leaves the list with Undo; built-in integrations must not show this button
- [ ] `integration_oauth_app_delete` removes the user-lane app and its connections; platform apps are unaffected

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8e97d40e` · **Head:** `6f8ae621`

**Classification:** extends — account integrations gain disconnect/delete mutations and a reusable delayed-commit undo helper; no new system primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — `createUndoableAction` / `UndoToast`, double-checked Disconnect and Delete integration; stay mounted until commit |
| `integrations` | assistant | extends — `deleteOauthAppWithConnections`, `disconnect_connection` / `delete_oauth_app` API actions, `integration_oauth_app_delete` |

### Change flow

Disconnect and delete stay optimistic on the current route until the undo window ends; then the account API commits and the list URL updates only if the selection is gone.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant integrations as integrations
	User->>appUi: second click on Disconnect or Delete integration
	appUi->>appUi: hide row and show UndoToast
	Note over appUi: stay on current route element
	alt Undo before timeout
		User->>appUi: click Undo
		appUi->>appUi: restore snapshot (no server write)
	else timeout or leave page
		appUi->>integrations: POST disconnect_connection or delete_oauth_app
		integrations->>integrations: delete connection and unused or whole user-lane app
		appUi->>appUi: navigate to list only if selection is gone
	end
```

### Invariants

Per-user isolation is unchanged: deletes are keyed by the signed-in `userId`. Platform (built-in) app rows are never deleted from this UI.

</details>

<!-- system-recap:end -->

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to disconnect integrations with an Undo option.
  * Added deletion of user-registered OAuth apps and their associated connections.
  * Added confirmation prompts, optimistic updates, rollback on failure, and navigation-safe action handling.
  * Added an accessible Undo notification for destructive actions.
  * Exposed OAuth app deletion through agent capabilities.

* **Documentation**
  * Documented integration deletion, delayed commits, undo behavior, and destructive-action guidelines.

* **Tests**
  * Added coverage for undo flows, integration disconnection, OAuth app deletion, and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


