### PR TITLE
Color status day bars from incidents, not probe blips

### DIFF
--- a/packages/status/day-bars.node.test.ts
+++ b/packages/status/day-bars.node.test.ts
@@ -70,4 +70,19 @@ test('day bars follow opened incidents and keep isolated probe failures green', 
 		),
 	).toBe(720)
 	expect(incidentMinutesForDay('not-a-day', [crossing], now)).toBe(0)
+
+	const underHour = incidentMinutesForDay(
+		'2026-08-12',
+		[
+			{
+				startedAt: midnight,
+				resolvedAt: midnight + 59 * 60_000 + 30_000,
+			},
+		],
+		now,
+	)
+	expect(underHour).toBe(59)
+	expect(dayBarKind(day({ failed: 59, incidentMinutes: underHour }))).toBe(
+		'partial',
+	)
 })

--- a/packages/status/day-bars.node.test.ts
+++ b/packages/status/day-bars.node.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'vitest'
+import {
+	dayBarClassName,
+	dayBarKind,
+	dayBarTitle,
+	incidentMinutesForDay,
+	type IncidentSpan,
+} from './day-bars.ts'
+import { type ComponentDayStat } from './status-types.ts'
+
+function day(overrides: Partial<ComponentDayStat> = {}): ComponentDayStat {
+	return {
+		day: '2026-08-19',
+		total: 1440,
+		failed: 0,
+		incidentMinutes: 0,
+		...overrides,
+	}
+}
+
+test('day bars follow opened incidents and keep isolated probe failures green', () => {
+	expect(dayBarKind(day({ total: 0 }))).toBe('empty')
+	expect(dayBarClassName('empty')).toBe('bar empty')
+	expect(dayBarTitle(day({ total: 0 }))).toBe('2026-08-19: no data')
+
+	expect(dayBarKind(day())).toBe('ok')
+	expect(dayBarTitle(day())).toBe('2026-08-19: 100% up')
+
+	const isolated = day({ failed: 2 })
+	expect(dayBarKind(isolated)).toBe('ok')
+	expect(dayBarClassName('ok')).toBe('bar')
+	expect(dayBarTitle(isolated)).toBe(
+		'2026-08-19: 2 isolated probe failures, no incident',
+	)
+	expect(dayBarTitle(day({ failed: 1 }))).toBe(
+		'2026-08-19: 1 isolated probe failure, no incident',
+	)
+
+	const shortIncident = day({ failed: 6, incidentMinutes: 6 })
+	expect(dayBarKind(shortIncident)).toBe('partial')
+	expect(dayBarClassName('partial')).toBe('bar partial')
+	expect(dayBarTitle(shortIncident)).toBe(
+		'2026-08-19: 6 min incident · 99.58% up',
+	)
+
+	const longIncident = day({ failed: 90, incidentMinutes: 90 })
+	expect(dayBarKind(longIncident)).toBe('bad')
+	expect(dayBarClassName('bad')).toBe('bar bad')
+	expect(dayBarTitle(longIncident)).toBe(
+		'2026-08-19: 90 min incident · 93.75% up',
+	)
+
+	const highFailedRatio = day({ failed: 80, incidentMinutes: 20 })
+	expect(dayBarKind(highFailedRatio)).toBe('bad')
+
+	const midnight = Date.parse('2026-08-12T00:00:00.000Z')
+	const now = Date.parse('2026-08-12T12:00:00.000Z')
+	const crossing: IncidentSpan = {
+		startedAt: Date.parse('2026-08-11T23:58:00.000Z'),
+		resolvedAt: Date.parse('2026-08-12T00:03:00.000Z'),
+	}
+	expect(incidentMinutesForDay('2026-08-11', [crossing], now)).toBe(2)
+	expect(incidentMinutesForDay('2026-08-12', [crossing], now)).toBe(3)
+	expect(incidentMinutesForDay('2026-08-13', [crossing], now)).toBe(0)
+	expect(
+		incidentMinutesForDay(
+			'2026-08-12',
+			[{ startedAt: midnight, resolvedAt: null }],
+			now,
+		),
+	).toBe(720)
+	expect(incidentMinutesForDay('not-a-day', [crossing], now)).toBe(0)
+})

--- a/packages/status/day-bars.ts
+++ b/packages/status/day-bars.ts
@@ -38,7 +38,7 @@ export function incidentMinutesForDay(
 		)
 	}
 	if (overlapMs <= 0) return 0
-	return Math.max(1, Math.round(overlapMs / minuteMs))
+	return Math.max(1, Math.floor(overlapMs / minuteMs))
 }
 
 export function dayBarKind(day: ComponentDayStat): DayBarKind {

--- a/packages/status/day-bars.ts
+++ b/packages/status/day-bars.ts
@@ -1,0 +1,94 @@
+/**
+ * 90-day status bars follow opened incidents, not raw probe failures.
+ * Isolated ticks below the consecutive-failure threshold stay green.
+ */
+
+import { type ComponentDayStat } from './status-types.ts'
+
+export type IncidentSpan = {
+	startedAt: number
+	resolvedAt: number | null
+}
+
+export type DayBarKind = 'empty' | 'ok' | 'partial' | 'bad'
+
+const dayMs = 24 * 60 * 60 * 1000
+const minuteMs = 60_000
+const majorIncidentMinutes = 60
+const majorFailedRatio = 0.05
+
+export function utcDayStartMs(day: string): number {
+	return Date.parse(`${day}T00:00:00.000Z`)
+}
+
+export function incidentMinutesForDay(
+	day: string,
+	spans: ReadonlyArray<IncidentSpan>,
+	now: number,
+): number {
+	const dayStart = utcDayStartMs(day)
+	if (!Number.isFinite(dayStart)) return 0
+	const dayEnd = dayStart + dayMs
+	let overlapMs = 0
+	for (const span of spans) {
+		const end = span.resolvedAt ?? now
+		overlapMs += Math.max(
+			0,
+			Math.min(end, dayEnd) - Math.max(span.startedAt, dayStart),
+		)
+	}
+	if (overlapMs <= 0) return 0
+	return Math.max(1, Math.round(overlapMs / minuteMs))
+}
+
+export function dayBarKind(day: ComponentDayStat): DayBarKind {
+	if (day.total === 0) return 'empty'
+	if (day.incidentMinutes === 0) return 'ok'
+	const failedRatio = day.failed / day.total
+	if (
+		failedRatio >= majorFailedRatio ||
+		day.incidentMinutes >= majorIncidentMinutes
+	) {
+		return 'bad'
+	}
+	return 'partial'
+}
+
+export function dayBarClassName(kind: DayBarKind): string {
+	switch (kind) {
+		case 'ok':
+			return 'bar'
+		case 'empty':
+			return 'bar empty'
+		case 'partial':
+			return 'bar partial'
+		case 'bad':
+			return 'bar bad'
+		default: {
+			kind satisfies never
+			throw new Error(`Unknown day bar kind: ${String(kind)}`)
+		}
+	}
+}
+
+export function dayBarTitle(day: ComponentDayStat): string {
+	const kind = dayBarKind(day)
+	switch (kind) {
+		case 'empty':
+			return `${day.day}: no data`
+		case 'ok': {
+			if (day.failed === 0) return `${day.day}: 100% up`
+			const noun = day.failed === 1 ? 'failure' : 'failures'
+			return `${day.day}: ${day.failed} isolated probe ${noun}, no incident`
+		}
+		case 'partial':
+		case 'bad': {
+			const pct = (((day.total - day.failed) / day.total) * 100).toFixed(2)
+			return `${day.day}: ${day.incidentMinutes} min incident · ${pct}% up`
+		}
+		default: {
+			kind satisfies never
+			throw new Error(`Unknown day bar kind: ${String(kind)}`)
+		}
+	}
+}

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -31,10 +31,9 @@ returns Cloudflare 1016. Component probes never use the status hostname, so a
   resolves it after two consecutive successes.
 - Day bars follow those opened incidents. Isolated probe failures below the
   threshold stay green (the hover names them as isolated) and still count
-  against the 90-day probe uptime percentage. A day turns amber when an
-  incident covered it for under an hour and under 5% of that day's probes
-  failed; red when the incident lasted an hour or more, or at least 5% of
-  probes failed.
+  against the 90-day probe uptime percentage. A day turns amber when an incident
+  covered it for under an hour and under 5% of that day's probes failed; red
+  when the incident lasted an hour or more, or at least 5% of probes failed.
 - Operator alert emails go to `ALERT_EMAIL_TO` through the Cloudflare Email REST
   API: one email when an outage starts, at most one reminder per day while it
   lasts, one all-clear when everything has recovered, all under a daily cap

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -29,6 +29,12 @@ returns Cloudflare 1016. Component probes never use the status hostname, so a
   h), daily uptime rollups (90 days), incidents, and sent notifications.
 - A component opens an incident after two consecutive probe failures and
   resolves it after two consecutive successes.
+- Day bars follow those opened incidents. Isolated probe failures below the
+  threshold stay green (the hover names them as isolated) and still count
+  against the 90-day probe uptime percentage. A day turns amber when an
+  incident covered it for under an hour and under 5% of that day's probes
+  failed; red when the incident lasted an hour or more, or at least 5% of
+  probes failed.
 - Operator alert emails go to `ALERT_EMAIL_TO` through the Cloudflare Email REST
   API: one email when an outage starts, at most one reminder per day while it
   lasts, one all-clear when everything has recovered, all under a daily cap

--- a/packages/status/status-page.node.test.ts
+++ b/packages/status/status-page.node.test.ts
@@ -16,8 +16,10 @@ function componentSnapshot(
 		latencyMs: 42,
 		uptimePct: 99.98,
 		days: [
-			{ day: '2026-08-03', total: 1440, failed: 0 },
-			{ day: '2026-08-04', total: 720, failed: 3 },
+			{ day: '2026-08-03', total: 1440, failed: 0, incidentMinutes: 0 },
+			{ day: '2026-08-04', total: 720, failed: 3, incidentMinutes: 0 },
+			{ day: '2026-08-05', total: 1440, failed: 6, incidentMinutes: 6 },
+			{ day: '2026-08-06', total: 1440, failed: 90, incidentMinutes: 90 },
 		],
 		...overrides,
 	}
@@ -46,6 +48,15 @@ test('status page renders components, incidents, unknown state, and escapes deta
 		expect(healthy).toContain(component.name.replaceAll('&', '&amp;'))
 	}
 	expect(healthy).toContain('99.98% uptime')
+	expect(healthy).toContain(
+		'class="bar" title="2026-08-04: 3 isolated probe failures, no incident"',
+	)
+	expect(healthy).toContain(
+		'class="bar partial" title="2026-08-05: 6 min incident · 99.58% up"',
+	)
+	expect(healthy).toContain(
+		'class="bar bad" title="2026-08-06: 90 min incident · 93.75% up"',
+	)
 	expect(healthy).toContain(
 		'https://github.com/kentcdodds/kody/commit/abc123def4567890abcdef1234567890abcdef12',
 	)

--- a/packages/status/status-page.ts
+++ b/packages/status/status-page.ts
@@ -1,3 +1,4 @@
+import { dayBarClassName, dayBarKind, dayBarTitle } from './day-bars.ts'
 import {
 	cloudflareStatusPageUrl,
 	sanitizeProviderIncidentShortlink,
@@ -156,14 +157,8 @@ function bannerFor(snapshot: StatusSnapshot): { label: string; kind: string } {
 function renderDayBars(component: ComponentSnapshot): string {
 	const bars = component.days
 		.map((day) => {
-			if (day.total === 0) {
-				return `<div class="bar empty" title="${escapeHtml(day.day)}: no data"></div>`
-			}
-			const failedRatio = day.failed / day.total
-			const kind =
-				failedRatio === 0 ? '' : failedRatio < 0.05 ? ' partial' : ' bad'
-			const pct = (((day.total - day.failed) / day.total) * 100).toFixed(2)
-			return `<div class="bar${kind}" title="${escapeHtml(day.day)}: ${pct}% up"></div>`
+			const kind = dayBarKind(day)
+			return `<div class="${dayBarClassName(kind)}" title="${escapeHtml(dayBarTitle(day))}"></div>`
 		})
 		.join('')
 	return `<div class="bars">${bars}</div>`

--- a/packages/status/status-store.ts
+++ b/packages/status/status-store.ts
@@ -1,5 +1,6 @@
 import { DurableObject } from 'cloudflare:workers'
 import { sendAlertEmail } from './alert-email.ts'
+import { incidentMinutesForDay, type IncidentSpan } from './day-bars.ts'
 import {
 	composeStatusEmail,
 	decideStatusEmail,
@@ -509,8 +510,17 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 
 	async getSnapshot(): Promise<StatusSnapshot> {
 		const now = Date.now()
+		const windowStartMs = Date.parse(
+			`${toDay(now - (uptimeWindowDays - 1) * 24 * 60 * 60 * 1000)}T00:00:00.000Z`,
+		)
+		const incidentSpans = this.loadIncidentSpans(windowStartMs, now)
 		const components = statusComponents.map((component) =>
-			this.buildComponentSnapshot(component.id, component.name, now),
+			this.buildComponentSnapshot(
+				component.id,
+				component.name,
+				now,
+				incidentSpans.get(component.id) ?? [],
+			),
 		)
 		const overallStatus: ComponentStatus = components.some(
 			(component) => component.status === 'down',
@@ -532,10 +542,40 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 		}
 	}
 
+	private loadIncidentSpans(
+		windowStartMs: number,
+		now: number,
+	): Map<StatusComponentId, Array<IncidentSpan>> {
+		const rows = this.ctx.storage.sql
+			.exec<{
+				component: string
+				started_at: number
+				resolved_at: number | null
+			}>(
+				`SELECT component, started_at, resolved_at FROM incidents
+				WHERE started_at < ? AND (resolved_at IS NULL OR resolved_at >= ?)`,
+				now,
+				windowStartMs,
+			)
+			.toArray()
+		const byComponent = new Map<StatusComponentId, Array<IncidentSpan>>()
+		for (const row of rows) {
+			if (!isStatusComponentId(row.component)) continue
+			const spans = byComponent.get(row.component) ?? []
+			spans.push({
+				startedAt: row.started_at,
+				resolvedAt: row.resolved_at,
+			})
+			byComponent.set(row.component, spans)
+		}
+		return byComponent
+	}
+
 	private buildComponentSnapshot(
 		id: StatusComponentId,
 		name: string,
 		now: number,
+		spans: ReadonlyArray<IncidentSpan>,
 	): ComponentSnapshot {
 		const stateRows = this.ctx.storage.sql
 			.exec<{ status: string }>(
@@ -573,6 +613,7 @@ export class StatusStore extends DurableObject<StatusWorkerEnv> {
 				day,
 				total: stat?.total ?? 0,
 				failed: stat?.failed ?? 0,
+				incidentMinutes: incidentMinutesForDay(day, spans, now),
 			})
 		}
 		const total = days.reduce((sum, day) => sum + day.total, 0)

--- a/packages/status/status-types.ts
+++ b/packages/status/status-types.ts
@@ -56,6 +56,9 @@ export type ComponentDayStat = {
 	day: string
 	total: number
 	failed: number
+	/** Minutes an opened incident overlapped this UTC day. Isolated probe
+	 * failures below the consecutive-failure threshold stay 0. */
+	incidentMinutes: number
 }
 
 export type ComponentSnapshot = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the public status page from looking like Primary database is flapping when D1 is up. Isolated one-minute probe failures were painting a full day amber even though they never opened an incident.

## Audit (production, 2026-08-19 ~23:42 UTC)

Live `GET https://status.kody.codes/status.json` and `GET https://kody.codes/health/components`:

- Overall: **operational**. No open incidents. No relevant Cloudflare provider incidents.
- App, MCP, KV: **100%** of 21,583 probes (15 days of data). Jobs: **100%** of 8,973 probes (7 days; card is newer).
- **Primary database is not down.** `app_db` is operational at ~103ms (direct health check 43ms). **0 incidents** in the last 90 days.
- Those orange bars were **10 isolated failed probes** out of 21,583 (99.95% probe uptime), spread as 1–2 ticks on 6 days. None were two consecutive failures, so the incident state machine never opened.

| Day | Failed probes | Failed ratio | Opened an incident? | Old bar | New bar |
| --- | ---: | ---: | --- | --- | --- |
| 2026-08-07 | 2 / 1442 | 0.14% | no | amber | green |
| 2026-08-10 | 2 / 1440 | 0.14% | no | amber | green |
| 2026-08-12 | 2 / 1443 | 0.14% | no | amber | green |
| 2026-08-13 | 1 / 1441 | 0.07% | no | amber | green |
| 2026-08-17 | 2 / 1442 | 0.14% | no | amber | green |
| 2026-08-19 | 1 / 1424 | 0.07% | no | amber | green |

The only recorded incident in this window is **Package runtime** on 2026-08-12: HTTP 530 for 6 minutes (6 failed probes). That day stays amber. Asset storage had one isolated failure on 2026-08-14 and no incident — it also goes back to green.

Root cause: bars used `failed / total > 0` (any tick → amber). Incidents already require two consecutive failures. D1 health already retries transient/idle blips three times; leftover ticks are real ~1 minute binding blips, not an outage.

![Live status page Primary database card with orange blip days](https://cursor.com/artifacts/c/art-f83fcfea-90a8-4304-bbe8-8d08ea38d533)

![Before and after Primary database bars plus days-that-change table](https://cursor.com/artifacts/c/art-367c0c6f-4c4c-4f9c-b3ef-709bb1fb690f)

<a href="https://cursor.com/agents/bc-adf4cbaa-c3ed-4dc0-8667-cde56304f189/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstatus_page_primary_db_false_alarms_before_after.mp4"><img src="https://cursor.com/artifacts/c/art-b048e484-8b2b-4ff5-b21b-f5f3feeb17f1" alt="status_page_primary_db_false_alarms_before_after.mp4" /></a>

## Summary

- Color 90-day bars from **opened incident overlap**, not raw failed-probe ratio.
- Isolated failures stay green; hover text names them (`1 isolated probe failure, no incident`).
- Probe uptime percentage is unchanged and still counts every failed tick.
- Amber = incident under an hour and under 5% of that day's probes. Red = hour-plus incident or ≥5% failed.
- Incident minutes use `Math.floor` so a 59m30s overlap stays amber (CodeRabbit).

## Testing

- `npm --prefix packages/status test` — 9 files, 18 tests
- `npm --prefix packages/status run typecheck`
- Production `status.json` + `/health/components` pulled for the numbers above
- Manual walkthrough of live `status.kody.codes` vs rendered before/after from that snapshot
- Preview (`https://kody-pr-1575.kody-a99.workers.dev`, merge commit `86d2e979` of `8a5e7220`): `npm run preview:manual-test` signed in as `user-me`. `GET /health`, `GET /health/components` (app_db/kv/assets/audit_db all ok), `GET /mcp` 401, `/account` 200. Status worker is independently deployed and is not on this preview; probe endpoints the page consumes are healthy.

![Preview signed-in account page as seed user](https://cursor.com/artifacts/c/art-adf3b798-6be4-4f37-89fc-f06b72e84932)

![Preview /health/components JSON all ok](https://cursor.com/artifacts/c/art-62b61860-53d0-4153-aade-f05346daf10a)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `8e97d40e` · **Head:** `8a5e7220`

**Classification:** extends — public status day bars and `status.json` day stats now carry incident overlap so a day is labeled from opened incidents, not raw probe failures.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `status-page` | surfaces | extends — `ComponentDayStat.incidentMinutes`; bars follow incident overlap |

### Change flow

The prober still records every tick and still opens incidents only after two consecutive failures. Snapshot rendering now joins those incidents onto each UTC day before choosing a bar color.

```mermaid
sequenceDiagram
	participant cron as status-page cron
	participant store as StatusStore
	participant page as status-page HTML
	cron->>store: recordOutcome(ok or fail)
	store->>store: applyProbeResult (2-fail open / 2-ok resolve)
	page->>store: getSnapshot()
	store->>store: loadIncidentSpans for 90-day window
	store->>page: days[] with failed + incidentMinutes
	page->>page: green unless incidentMinutes > 0
```

### Before / after

```text
failed > 0 and ratio < 5%  → amber day
failed === 0               → green day
```

```text
incidentMinutes === 0      → green (hover names isolated failures)
incident < 60m and < 5%    → amber
incident ≥ 60m or ≥ 5%     → red
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adf4cbaa-c3ed-4dc0-8667-cde56304f189?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adf4cbaa-c3ed-4dc0-8667-cde56304f189&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uptime bars now reflect incident duration across each affected UTC day.
  * Days are categorized as healthy, partial, degraded, or having no data based on incident impact and uptime.
  * Isolated probe failures remain visually healthy while still appearing in uptime details.
  * Status-bar titles explain incident duration, probe failures, and uptime percentages.
  * Incidents spanning multiple days, including incidents lasting under an hour, are accurately represented.

* **Documentation**
  * Updated guidance for status-bar colors and incident thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->