### PR TITLE
Give community search misses a package-creation path

### DIFF
--- a/packages/worker/src/app/community-listings-content.node.test.ts
+++ b/packages/worker/src/app/community-listings-content.node.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+import { renderCommunityListingsContentHtml } from '#app/community-listings-content.tsx'
+
+test('community empty state distinguishes a search miss from an empty catalog', async () => {
+	const searchMissHtml = await renderCommunityListingsContentHtml({
+		listings: [],
+		query: 'obsidian',
+	})
+
+	expect(searchMissHtml).toContain('Nothing matched that search.')
+	expect(searchMissHtml).toContain('Ask your agent to create this package')
+	expect(searchMissHtml).toContain('data-testid="community-create-prompt"')
+	expect(searchMissHtml).toContain('obsidian')
+	expect(searchMissHtml).toContain(
+		'coding_guide_get({ guide: "package_authoring" })',
+	)
+	expect(searchMissHtml).toContain(
+		'coding_guide_get({ guide: "package_lifecycle" })',
+	)
+	expect(searchMissHtml).toContain(
+		'package_get_git_remote({ kody_id, create: true })',
+	)
+	expect(searchMissHtml).toContain('href="/guides/package-authoring"')
+	expect(searchMissHtml).toContain('href="/community"')
+
+	const emptyCatalogHtml = await renderCommunityListingsContentHtml({
+		listings: [],
+		query: null,
+	})
+
+	expect(emptyCatalogHtml).toContain('The shelf is <em>waiting</em>.')
+	expect(emptyCatalogHtml).toContain('Connect your agent')
+	expect(emptyCatalogHtml).not.toContain(
+		'Ask your agent to create this package',
+	)
+	expect(emptyCatalogHtml).not.toContain(
+		'data-testid="community-create-prompt"',
+	)
+})

--- a/packages/worker/universal/community-empty-state.tsx
+++ b/packages/worker/universal/community-empty-state.tsx
@@ -3,7 +3,14 @@
 import { css } from 'remix/ui'
 import { routes } from '#universal/routes.ts'
 import { colors } from '#universal/styles/tokens.ts'
-import { getPillButtonCss } from '#universal/styles/style-primitives.ts'
+import {
+	getGhostButtonCss,
+	getPillButtonCss,
+} from '#universal/styles/style-primitives.ts'
+
+function buildCreatePackagePrompt(query: string) {
+	return `I searched Kody Community for "${query}" and found no published package. Create this package for me. First load coding_guide_get({ guide: "package_authoring" }) and coding_guide_get({ guide: "package_lifecycle" }). Then choose a suitable lower-kebab-case kody_id and call package_get_git_remote({ kody_id, create: true }) to create its repository. Build, test, and publish a useful package that matches my search.`
+}
 
 /**
  * Catalog and search-miss empty state for the community listings frame.
@@ -11,33 +18,56 @@ import { getPillButtonCss } from '#universal/styles/style-primitives.ts'
  * a loading placeholder, so first paint never flashes "no results."
  */
 export function renderCommunityEmptyState(query: string | null) {
-	const isSearch = Boolean(query)
+	if (query) {
+		const createPackagePrompt = buildCreatePackagePrompt(query)
+		return (
+			<div mix={css(emptyCss)} data-testid="community-listings-empty">
+				<h2 mix={css(emptyTitleCss)}>Nothing matched that search.</h2>
+				<p mix={css(emptyTextCss)}>
+					No published community package matches <strong>{query}</strong> yet.
+					You can ask your agent to create it.
+				</p>
+				<details mix={css(createPackageCss)}>
+					<summary mix={css(getPillButtonCss())}>
+						Ask your agent to create this package
+					</summary>
+					<div mix={css(promptPanelCss)}>
+						<p mix={css(promptIntroCss)}>
+							Copy this prompt into your MCP-capable agent:
+						</p>
+						<pre mix={css(promptCss)} data-testid="community-create-prompt">
+							<code>{createPackagePrompt}</code>
+						</pre>
+					</div>
+				</details>
+				<p mix={css(secondaryCtaCss)}>
+					<a
+						href={routes.guideDetail.href({ slug: 'package-authoring' })}
+						mix={css(getGhostButtonCss())}
+					>
+						Read the package authoring guide
+					</a>
+					<a href={routes.community.href()} mix={css(secondaryLinkCss)}>
+						Clear search
+					</a>
+				</p>
+			</div>
+		)
+	}
+
 	return (
 		<div mix={css(emptyCss)} data-testid="community-listings-empty">
 			<h2 mix={css(emptyTitleCss)}>
-				{isSearch ? (
-					'Nothing matched that search.'
-				) : (
-					<>
-						The shelf is <em>waiting</em>.
-					</>
-				)}
+				The shelf is <em>waiting</em>.
 			</h2>
 			<p mix={css(emptyTextCss)}>
-				{isSearch
-					? 'No packages matched that name, description, or tag. Try a different search, or clear it and browse everything.'
-					: 'Nobody has published a community package yet. Ask your agent to share something useful — forks keep their own history.'}
+				Nobody has published a community package yet. Ask your agent to share
+				something useful — forks keep their own history.
 			</p>
 			<p mix={css(emptyCtaCss)}>
-				{isSearch ? (
-					<a href={routes.community.href()} mix={css(getPillButtonCss())}>
-						Clear search
-					</a>
-				) : (
-					<a href={routes.onboarding.href()} mix={css(getPillButtonCss())}>
-						Connect your agent
-					</a>
-				)}
+				<a href={routes.onboarding.href()} mix={css(getPillButtonCss())}>
+					Connect your agent
+				</a>
 			</p>
 		</div>
 	)
@@ -69,4 +99,56 @@ const emptyTextCss = {
 
 const emptyCtaCss = {
 	margin: '1.5rem 0 0',
+}
+
+const createPackageCss = {
+	marginTop: '1.5rem',
+	'&[open] > summary': {
+		marginBottom: '0.9rem',
+	},
+	'& > summary': {
+		cursor: 'pointer',
+		listStyle: 'none',
+		width: 'fit-content',
+	},
+	'& > summary::-webkit-details-marker': {
+		display: 'none',
+	},
+}
+
+const promptPanelCss = {
+	padding: '1rem',
+	backgroundColor: colors.surface,
+	border: `1px solid ${colors.border}`,
+	borderRadius: '0.8rem',
+}
+
+const promptIntroCss = {
+	margin: '0 0 0.65rem',
+	color: colors.textMuted,
+	fontSize: '0.9rem',
+}
+
+const promptCss = {
+	margin: 0,
+	whiteSpace: 'pre-wrap' as const,
+	overflowWrap: 'anywhere' as const,
+	fontFamily: 'inherit',
+	fontSize: '0.95rem',
+	lineHeight: 1.55,
+	userSelect: 'text' as const,
+}
+
+const secondaryCtaCss = {
+	margin: '1rem 0 0',
+	display: 'flex',
+	alignItems: 'center',
+	flexWrap: 'wrap' as const,
+	gap: '0.9rem',
+}
+
+const secondaryLinkCss = {
+	color: colors.primaryText,
+	fontWeight: 650,
+	textUnderlineOffset: '0.18em',
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Turn a Community search miss into a useful package-authoring path instead of a dead end.

## Summary

- Keep a clear no-match result and explain that no published package matches yet.
- Add a primary expandable CTA with a selectable, query-specific agent prompt that loads the package authoring and lifecycle guides before creating a git-backed package.
- Add package-authoring guide and clear-search secondary actions while preserving the empty-catalog state.
- Cover search-miss and empty-catalog rendering in a focused unit test.

## Testing

- `npx vitest run --project node-unit packages/worker/src/app/community-listings-content.node.test.ts`
- Focused `oxfmt --check` and `oxlint`
- Local `npm run validate` completed its relevant static/type/unit checks; unrelated mock-worker suites contended when all local jobs ran concurrently. The same split CI checks are all green: [Validate run](https://github.com/kentcdodds/kody/actions/runs/32317594008).
- Seeded preview: `npm run preview:manual-test -- --pr 1576 --request 'GET /community?q=obsidian' --check '/community?q=obsidian' --json`
- Logged-in UI pass verified the query-specific prompt, both guide loads, `package_get_git_remote({ kody_id, create: true })`, authoring guide link, and clear-search action.

<a href="https://cursor.com/agents/bc-755d89ca-e483-4bfa-bdde-15d271538222/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcommunity_search_miss_create_package.mp4"><img src="https://cursor.com/artifacts/c/art-054253dc-06b0-4b3e-bbdc-312b6d87eadd" alt="community_search_miss_create_package.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1dfda4ec` · **Head:** `5d1f8f81`

**Classification:** extends — this PR changes the Community search-miss behavior in the browser app without adding a system primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — search misses expose a package-authoring path |

### Change flow

A Community search miss leads the user from an empty result to a query-specific package-creation prompt.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	actor Agent
	User->>appUi: GET /community?q=obsidian
	appUi-->>User: render no-match explanation and create-package CTA
	User->>appUi: expand selectable query-specific prompt
	User->>Agent: paste prompt with guide loads and package_get_git_remote create
```

</details>

<!-- system-recap:end -->

## Conductor report

- **Track:** `community-empty`
- **Files:** `packages/worker/universal/community-empty-state.tsx`; `packages/worker/src/app/community-listings-content.node.test.ts`
- **Evidence:** focused node-unit test; formatter/linter; all CI checks; seeded authenticated preview request; recorded `/community?q=obsidian` UI walkthrough
- **Remains:** squash-merge and production deploy verification

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-755d89ca-e483-4bfa-bdde-15d271538222?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-755d89ca-e483-4bfa-bdde-15d271538222&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

