### PR TITLE
Add a Discord invite on the README and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
   <p>
     <a href="https://github.com/kentcdodds/kody/actions/workflows/deploy.yml"><img src="https://img.shields.io/github/actions/workflow/status/kentcdodds/kody/deploy.yml?branch=main&style=flat-square&logo=github&label=CI" alt="Build Status" /></a>
+    <a href="https://kcd.im/kody-discord"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Join the Discord" /></a>
     <img src="https://img.shields.io/badge/TypeScript-6.0-blue?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
     <img src="https://img.shields.io/badge/Node-26-5FA04E?style=flat-square&logo=node.js&logoColor=white" alt="Node 26" />
     <img src="https://img.shields.io/badge/Cloudflare-Workers-F38020?style=flat-square&logo=cloudflare&logoColor=white" alt="Cloudflare Workers" />

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -9,7 +9,8 @@ it run durable Worker-native automations while your computer is offline.
 These docs are for people who connect their assistant to Kody over MCP. Setup
 and repository development live elsewhere
 ([contributing docs](../contributing/index.md)). The in-app Get started page
-(`/onboarding`) walks through connecting a host for the first time.
+(`/onboarding`) walks through connecting a host for the first time. People with
+a Kody account can also [join the Discord](https://kcd.im/kody-discord).
 
 Read in order for a full tour, or jump to a topic.
 

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -21,6 +21,7 @@ import {
 import { type OnboardingFeaturedListing } from '#universal/community-public-types.ts'
 import { landingArtAttrs } from '#universal/landing-images.ts'
 import { routes } from '#universal/routes.ts'
+import { kodyDiscordInviteUrl } from '#universal/community-links.ts'
 import {
 	selectOnboardingExampleListings,
 	selectOnboardingServiceStarterListings,
@@ -459,6 +460,22 @@ export function OnboardingRoute(handle: Handle) {
 							Read what Kody can do
 						</a>{' '}
 						first.
+					</p>
+					<p
+						data-rise
+						style={{ '--rise': '2' }}
+						mix={css(discordInviteWrapCss)}
+					>
+						<a
+							href={kodyDiscordInviteUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+							mix={css(discordInviteLinkCss)}
+							data-testid="onboarding-join-discord"
+						>
+							<ProviderIcon providerId="discord" size="1.1em" />
+							Join the Discord
+						</a>
 					</p>
 				</header>
 
@@ -1209,6 +1226,18 @@ const headerGuideLinkCss = {
 	color: colors.primaryText,
 	textDecorationThickness: '1.5px',
 	textUnderlineOffset: '3px',
+}
+
+const discordInviteWrapCss = {
+	margin: '1rem 0 0',
+}
+
+const discordInviteLinkCss = {
+	...getGhostButtonCss({ size: 'sm' }),
+	width: 'fit-content',
+	gap: '0.4rem',
+	padding: '0.4rem 0.85rem 0.4rem 0.65rem',
+	font: `600 0.92rem/1 ${typography.fontFamilyBody}`,
 }
 
 const quickExampleDoneCss = {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -423,6 +423,13 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		new Request('https://example.com/onboarding'),
 	)
 	expect(anonymousOnboardingResponse.status).toBe(200)
+	const anonymousOnboardingHtml = await readResponseText(
+		anonymousOnboardingResponse,
+	)
+	expect(anonymousOnboardingHtml).toContain(
+		'data-testid="onboarding-join-discord"',
+	)
+	expect(anonymousOnboardingHtml).toContain('https://kcd.im/kody-discord')
 
 	const anonymousAccountResponse = await runHtmlHandler(
 		createAccountHandler(env),

--- a/packages/worker/universal/community-links.ts
+++ b/packages/worker/universal/community-links.ts
@@ -1,5 +1,8 @@
 import { routes } from '#universal/routes.ts'
 
+/** Public invite for the Kody community Discord. */
+export const kodyDiscordInviteUrl = 'https://kcd.im/kody-discord'
+
 const scopedPackageNamePattern = /^@([a-z0-9][a-z0-9._-]*)\//
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give people a clear, low-friction way to find the new Kody Discord from the two places they already look first: the repo README and Get started.

## Summary

- Adds a Discord badge to the README badge row (`https://kcd.im/kody-discord`).
- Adds a compact "Join the Discord" link with the Discord icon under the onboarding header so it stays visible on every step without becoming a fourth wizard step.
- Shares the invite URL from `kodyDiscordInviteUrl` in `community-links.ts`.
- Mentions the Discord on the usage docs index.
- Asserts anonymous onboarding SSR HTML includes the invite URL and test id.

## Testing

- `npx vitest run packages/worker/universal/community-links.node.test.ts` — 1 passed.
- `npx vitest run packages/worker/src/app/ssr-render.node.test.ts -t 'SSR HTML routes render page content'` — 1 passed. Anonymous `/onboarding` HTML includes `data-testid="onboarding-join-discord"` and `https://kcd.im/kody-discord`.
- Local `npm run dev` did not become ready in this environment (`Cannot apply deleted_classes migration to non-existent class PackageServiceInstance`). That is existing local Wrangler DO state, not this diff.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `1dfda4e` · **Head:** `c801009`

**Classification:** composes — no primitives added or changed; this PR wires an existing public invite URL into the browser app and docs.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Onboarding and the README point people at the Kody Discord invite.

```mermaid
sequenceDiagram
	actor Person
	participant appUi as app-ui
	Person->>appUi: open /onboarding or the README
	appUi-->>Person: Join the Discord (kcd.im/kody-discord)
	appUi->>appUi: SSR test asserts invite URL on Get started
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9d593c7-9cc8-4091-addd-1190f26f053a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9d593c7-9cc8-4091-addd-1190f26f053a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

