### PR TITLE
Improve onboarding connection and package ownership UX

### DIFF
--- a/packages/worker/client/routes/onboarding-example-card.tsx
+++ b/packages/worker/client/routes/onboarding-example-card.tsx
@@ -25,6 +25,7 @@ import {
 type OnboardingExampleCardProps = {
 	listing: OnboardingFeaturedListing
 	loggedIn: boolean
+	username: string | null
 	/** Called when install finishes so the parent can refresh checklist state. */
 	onInstalled?: () => void
 }
@@ -151,10 +152,13 @@ export function OnboardingExampleCard(
 		// visible without an extra click (same UI as after "Try this").
 		const showExpandedPrompt =
 			selected || alreadyReady || phase === 'installing' || phase === 'error'
-		const examplePrompt = buildOnboardingExamplePrompt({
-			listingName: listing.name,
-			kodyId: listing.kodyId,
-		})
+		const examplePrompt = handle.props.username
+			? buildOnboardingExamplePrompt({
+					listingName: listing.name,
+					kodyId: listing.kodyId,
+					username: handle.props.username,
+				})
+			: null
 		const readyStatus =
 			phase === 'error'
 				? null
@@ -183,7 +187,7 @@ export function OnboardingExampleCard(
 						{listing.description}
 					</span>
 				</a>
-				{showExpandedPrompt ? (
+				{showExpandedPrompt && examplePrompt ? (
 					<>
 						<figure mix={css(examplePromptBlockCss)}>
 							<blockquote
@@ -252,6 +256,10 @@ export function OnboardingExampleCard(
 							</a>
 						</p>
 					</>
+				) : showExpandedPrompt ? (
+					<p mix={css(exampleHintCss)}>
+						Log in to copy a prompt scoped to your package.
+					</p>
 				) : (
 					<button
 						type="button"

--- a/packages/worker/client/routes/onboarding-next-confirmation.node.test.ts
+++ b/packages/worker/client/routes/onboarding-next-confirmation.node.test.ts
@@ -1,0 +1,53 @@
+import { expect, test, vi } from 'vitest'
+
+const mockEventMixin = vi.hoisted(() => ({
+	on: vi.fn((type: string, handler: (event: Event) => void) => ({
+		type,
+		handler,
+	})),
+}))
+
+vi.mock('#client/event-mixin.ts', () => ({
+	on: mockEventMixin.on,
+}))
+
+const { createOnboardingNextConfirmation } =
+	await import('./onboarding-next-confirmation.ts')
+
+type RecordedMixin = {
+	type: string
+	handler: (event: Event) => void
+}
+
+test('unconnected onboarding Next warns once before advancing', () => {
+	const handle = { update: vi.fn() }
+	const onNext = vi.fn()
+	const confirmation = createOnboardingNextConfirmation(handle as never)
+	const mix = confirmation.getButtonMix({ confirm: true, onNext })
+	const click = mix[1] as RecordedMixin
+
+	const firstClick = { preventDefault: vi.fn() } as unknown as Event
+	click.handler(firstClick)
+	expect(firstClick.preventDefault).toHaveBeenCalledOnce()
+	expect(confirmation.armed).toBe(true)
+	expect(confirmation.getLabel(true)).toBe(
+		'Not connected — continue anyway?',
+	)
+	expect(onNext).not.toHaveBeenCalled()
+
+	const secondClick = { preventDefault: vi.fn() } as unknown as Event
+	click.handler(secondClick)
+	expect(secondClick.preventDefault).not.toHaveBeenCalled()
+	expect(onNext).toHaveBeenCalledOnce()
+	expect(confirmation.armed).toBe(false)
+
+	const connectedNext = vi.fn()
+	const connectedMix = confirmation.getButtonMix({
+		confirm: false,
+		onNext: connectedNext,
+	})
+	expect(connectedMix).toHaveLength(1)
+	;(connectedMix[0] as RecordedMixin).handler(new Event('click'))
+	expect(connectedNext).toHaveBeenCalledOnce()
+	expect(confirmation.getLabel(false)).toBe('Next')
+})

--- a/packages/worker/client/routes/onboarding-next-confirmation.node.test.ts
+++ b/packages/worker/client/routes/onboarding-next-confirmation.node.test.ts
@@ -30,9 +30,7 @@ test('unconnected onboarding Next warns once before advancing', () => {
 	click.handler(firstClick)
 	expect(firstClick.preventDefault).toHaveBeenCalledOnce()
 	expect(confirmation.armed).toBe(true)
-	expect(confirmation.getLabel(true)).toBe(
-		'Not connected — continue anyway?',
-	)
+	expect(confirmation.getLabel(true)).toBe('Not connected — continue anyway?')
 	expect(onNext).not.toHaveBeenCalled()
 
 	const secondClick = { preventDefault: vi.fn() } as unknown as Event

--- a/packages/worker/client/routes/onboarding-next-confirmation.ts
+++ b/packages/worker/client/routes/onboarding-next-confirmation.ts
@@ -1,0 +1,25 @@
+import { type Handle } from 'remix/ui'
+import { createDoubleCheck } from '#client/double-check.ts'
+import { on } from '#client/event-mixin.ts'
+
+export function createOnboardingNextConfirmation(handle: Handle<unknown>) {
+	const confirmation = createDoubleCheck(handle as unknown as Handle)
+
+	return {
+		get armed() {
+			return confirmation.doubleCheck
+		},
+		getButtonMix(input: { confirm: boolean; onNext: () => void }) {
+			return input.confirm
+				? confirmation.getButtonMix({
+						on: { click: input.onNext },
+					})
+				: [on('click', input.onNext)]
+		},
+		getLabel(confirm: boolean) {
+			return confirm && confirmation.doubleCheck
+				? 'Not connected — continue anyway?'
+				: 'Next'
+		},
+	}
+}

--- a/packages/worker/client/routes/onboarding-package-next-steps.tsx
+++ b/packages/worker/client/routes/onboarding-package-next-steps.tsx
@@ -1,0 +1,159 @@
+import { type Handle, css } from 'remix/ui'
+import { CopyTextButton } from '#client/copy-text-button.tsx'
+import { buildOnboardingPackageAuthoringPrompt } from '#universal/onboarding-examples.ts'
+import {
+	getAccentCalloutCss,
+	hoverMq,
+	primaryLinkCss,
+} from '#universal/styles/style-primitives.ts'
+import {
+	colors,
+	radius,
+	transitions,
+	typography,
+} from '#universal/styles/tokens.ts'
+
+export function OnboardingPackageNextSteps(handle: Handle<{ kodyId: string }>) {
+	return () => {
+		const authoringPrompt = buildOnboardingPackageAuthoringPrompt(
+			handle.props.kodyId,
+		)
+		return (
+			<div mix={css(nextStepsCss)} data-testid="onboarding-package-next-steps">
+				<section mix={css(authoringCardCss)}>
+					<p mix={css(kickerCss)}>This fork is yours</p>
+					<h3>Make it your own — or create a new package</h3>
+					<p>
+						Your agent can edit this package, publish its next version, or help
+						you build a completely new one. Start with the authoring guide, or
+						copy the prompt and let your agent lead.
+					</p>
+					<div mix={css(authoringActionsCss)}>
+						<a
+							href="/guides/package-authoring"
+							target="_blank"
+							rel="noreferrer noopener"
+							mix={css(primaryLinkCss)}
+						>
+							Read the package-authoring guide
+						</a>
+						<CopyTextButton
+							value={authoringPrompt}
+							idleLabel="Copy build prompt"
+							variant="pill"
+						/>
+					</div>
+				</section>
+
+				<a href="/guides/kody-factory" mix={css(factoryCardCss)}>
+					<img
+						src="/images/kody-factory-map.webp"
+						width={627}
+						height={627}
+						loading="lazy"
+						alt="Kody mapping the path from an idea to a reusable software package"
+					/>
+					<span>
+						<em>See the whole factory</em>
+						<strong>Your agent can create packages</strong>
+						<small>
+							Follow an idea through code, storage, triggers, and a reusable
+							tool you own.
+						</small>
+					</span>
+				</a>
+			</div>
+		)
+	}
+}
+
+const nextStepsCss = {
+	display: 'grid',
+	gridTemplateColumns: 'minmax(0, 1.1fr) minmax(15rem, 0.9fr)',
+	gap: '1rem',
+	'@media (max-width: 720px)': {
+		gridTemplateColumns: '1fr',
+	},
+}
+
+const authoringCardCss = {
+	...getAccentCalloutCss(),
+	display: 'grid',
+	alignContent: 'center',
+	gap: '0.75rem',
+	'& h3, & p': { margin: 0 },
+	'& h3': {
+		font: `700 1.2rem/1.2 ${typography.fontFamilyDisplay}`,
+		color: colors.text,
+	},
+	'& > p:not(:first-child)': {
+		color: colors.textMuted,
+		lineHeight: 1.55,
+	},
+}
+
+const kickerCss = {
+	font: `700 0.75rem/1 ${typography.fontFamilyDisplay}`,
+	letterSpacing: '0.09em',
+	textTransform: 'uppercase' as const,
+	color: colors.primaryText,
+}
+
+const authoringActionsCss = {
+	display: 'flex',
+	alignItems: 'center',
+	flexWrap: 'wrap' as const,
+	gap: '0.8rem 1rem',
+}
+
+const factoryCardCss = {
+	display: 'grid',
+	gridTemplateColumns: 'minmax(8rem, 0.8fr) minmax(0, 1.2fr)',
+	alignItems: 'center',
+	gap: '0.7rem',
+	padding: '0.8rem',
+	color: colors.text,
+	textDecoration: 'none',
+	border: `2px solid oklch(from ${colors.primary} l c h / 0.55)`,
+	borderRadius: radius.card,
+	background: `linear-gradient(145deg, oklch(from ${colors.primary} l c h / 0.16), ${colors.surface})`,
+	overflow: 'hidden' as const,
+	transition: `transform 180ms ${transitions.easeOut}, border-color 180ms ${transitions.easeOut}`,
+	'& img': {
+		width: '100%',
+		height: 'auto',
+		rotate: '-2deg',
+	},
+	'& > span': {
+		display: 'grid',
+		gap: '0.35rem',
+	},
+	'& em': {
+		font: `700 0.72rem/1 ${typography.fontFamilyDisplay}`,
+		fontStyle: 'normal',
+		letterSpacing: '0.08em',
+		textTransform: 'uppercase' as const,
+		color: colors.primaryText,
+	},
+	'& strong': {
+		font: `700 1.05rem/1.2 ${typography.fontFamilyDisplay}`,
+	},
+	'& small': {
+		color: colors.textMuted,
+		fontSize: '0.86rem',
+		lineHeight: 1.45,
+	},
+	[hoverMq]: {
+		'&:hover': {
+			transform: 'translateY(-2px)',
+			borderColor: colors.primary,
+		},
+	},
+	'@media (max-width: 420px)': {
+		gridTemplateColumns: '1fr',
+		'& img': {
+			width: 'min(12rem, 70%)',
+			justifySelf: 'center',
+		},
+	},
+}

--- a/packages/worker/client/routes/onboarding-payload.ts
+++ b/packages/worker/client/routes/onboarding-payload.ts
@@ -14,6 +14,7 @@ import { readJson } from '#client/routes/account-approval-shared.ts'
 export type OnboardingPayload = {
 	ok: true
 	loggedIn: boolean
+	username: string | null
 	mcpServerUrl: string
 	setupPrompt: string
 	discoveryPrompt: string

--- a/packages/worker/client/routes/onboarding.tsx
+++ b/packages/worker/client/routes/onboarding.tsx
@@ -37,6 +37,8 @@ import {
 } from '#client/routes/onboarding-checklist.tsx'
 import { OnboardingMcpClientTabs } from '#client/routes/onboarding-mcp-client-tabs.tsx'
 import { OnboardingExampleCard } from '#client/routes/onboarding-example-card.tsx'
+import { createOnboardingNextConfirmation } from '#client/routes/onboarding-next-confirmation.ts'
+import { OnboardingPackageNextSteps } from '#client/routes/onboarding-package-next-steps.tsx'
 import {
 	OnboardingStarterCard,
 	starterCardCss,
@@ -97,6 +99,17 @@ function isOnboardingPath(href: string) {
 	return new URL(href, 'http://localhost').pathname === onboardingPath
 }
 
+function readOwnedExampleKodyId(
+	listings: Array<OnboardingFeaturedListing>,
+): string {
+	const owned = listings.find((listing) => listing.viewerInstall != null)
+	if (!owned?.viewerInstall) return 'my-package'
+	const separatorIndex = owned.viewerInstall.targetName.lastIndexOf('/')
+	return separatorIndex >= 0
+		? owned.viewerInstall.targetName.slice(separatorIndex + 1)
+		: owned.kodyId
+}
+
 function readStepFromHref(href: string): OnboardingStep | null {
 	const hash = new URL(href, 'http://localhost').hash.slice(1)
 	return (
@@ -138,6 +151,7 @@ export function OnboardingRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let message: string | null = null
 	let loggedIn = false
+	let username: string | null = null
 	let mcpServerUrl = ''
 	let setupPrompt = ''
 	let hasMcpClient = false
@@ -169,6 +183,7 @@ export function OnboardingRoute(handle: Handle) {
 	function applyPayload(payload: OnboardingPayload) {
 		const wasConnected = hasMcpClient
 		loggedIn = payload.loggedIn
+		username = payload.username
 		mcpServerUrl = payload.mcpServerUrl
 		setupPrompt = payload.setupPrompt
 		hasMcpClient = payload.hasMcpClient
@@ -540,14 +555,6 @@ export function OnboardingRoute(handle: Handle) {
 										mix={css(panelArtCss)}
 									/>
 								</div>
-								<div mix={css(authNoteCss)} role="note">
-									<strong>One-time authorization required</strong>
-									<span>
-										After you add the server, your client opens a browser window
-										or shows an <strong>Authenticate</strong> button. Approve
-										the request so your agent can use your Kody factory.
-									</span>
-								</div>
 								<div
 									mix={css(connectStatusCss)}
 									role="status"
@@ -561,9 +568,30 @@ export function OnboardingRoute(handle: Handle) {
 									})}
 								</div>
 								<OnboardingMcpClientTabs mcpServerUrl={mcpServerUrl} />
+								<div
+									mix={css(authNoteCss)}
+									role="note"
+									data-testid="onboarding-authenticate-callout"
+								>
+									<strong>Authenticate Kody before you continue</strong>
+									<span>
+										<strong>Cursor:</strong> after Add to Cursor, open the
+										Cursor MCP list and click <strong>Authenticate</strong>.
+									</span>
+									<span>
+										<strong>Claude Code:</strong> after copying and running the
+										command, enter <code>/mcp</code> → Kody →{' '}
+										<strong>Authenticate</strong>.
+									</span>
+									<span>
+										Approve the <strong>kody.codes</strong> OAuth window. This
+										is the step that connects your agent to your factory.
+									</span>
+								</div>
 								<WizardNavigation
 									activeStep={activeStep}
 									onSelectStep={selectStep}
+									confirmUnconnectedNext={!hasMcpClient}
 								/>
 							</section>
 						) : null}
@@ -597,8 +625,10 @@ export function OnboardingRoute(handle: Handle) {
 									/>
 								</div>
 								<p mix={css(panelLedeCss)}>
-									Fork a ready-made package, run it once, and see how Kody turns
-									agent work into something you own. No accounts to connect yet.
+									Get a first win with a package you own: fork one of these
+									three demos, run your copy once, then change it whenever you
+									want. The weather, HN, or capture result is only the starting
+									point.
 								</p>
 								{exampleListings.length > 0 ? (
 									<ul
@@ -610,6 +640,7 @@ export function OnboardingRoute(handle: Handle) {
 												key={listing.id}
 												listing={listing}
 												loggedIn={loggedIn}
+												username={username}
 												onInstalled={() => {
 													void refreshOnboardingAfterInstall()
 												}}
@@ -635,14 +666,19 @@ export function OnboardingRoute(handle: Handle) {
 									</p>
 								)}
 								{hasQuickExample ? (
-									<p
-										mix={css(quickExampleDoneCss)}
-										data-testid="onboarding-quick-example-done"
-									>
-										Done — you have a package in your account. Paste the prompt
-										into your agent if you have not already, then connect real
-										services next.
-									</p>
+									<>
+										<p
+											mix={css(quickExampleDoneCss)}
+											data-testid="onboarding-quick-example-done"
+										>
+											Done — you have a package in your account. Paste the
+											prompt into your agent if you have not already, then make
+											the fork yours.
+										</p>
+										<OnboardingPackageNextSteps
+											kodyId={readOwnedExampleKodyId(exampleListings)}
+										/>
+									</>
 								) : null}
 								<aside
 									aria-label="How it works"
@@ -887,8 +923,10 @@ function WizardNavigation(
 		/** Optional overrides when a step owns custom Back/Next behavior. */
 		onBack?: () => void
 		onNext?: () => void
+		confirmUnconnectedNext?: boolean
 	}>,
 ) {
+	const nextConfirmation = createOnboardingNextConfirmation(handle)
 	return () => {
 		const previousStep =
 			handle.props.activeStep > 1
@@ -899,6 +937,13 @@ function WizardNavigation(
 				? ((handle.props.activeStep + 1) as OnboardingStep)
 				: null
 		const { onBack, onNext } = handle.props
+		const requiresConnectionConfirmation =
+			handle.props.activeStep === 1 &&
+			handle.props.confirmUnconnectedNext === true
+		const advance = () => {
+			if (onNext) return onNext()
+			if (nextStep) handle.props.onSelectStep(nextStep)
+		}
 
 		return (
 			<footer mix={css(wizardNavCss)}>
@@ -920,13 +965,14 @@ function WizardNavigation(
 					disabled={!onNext && nextStep == null}
 					mix={[
 						css(wizardNextButtonCss),
-						on('click', () => {
-							if (onNext) return onNext()
-							if (nextStep) handle.props.onSelectStep(nextStep)
+						...nextConfirmation.getButtonMix({
+							confirm: requiresConnectionConfirmation,
+							onNext: advance,
 						}),
 					]}
+					data-testid="onboarding-wizard-next"
 				>
-					Next
+					{nextConfirmation.getLabel(requiresConnectionConfirmation)}
 				</button>
 			</footer>
 		)
@@ -1240,18 +1286,25 @@ const howItWorksLabelCss = {
 	color: colors.primaryText,
 }
 
-/* One-time authorization callout: the only hard-edged warning on the page. */
+/* One-time authorization callout follows the install controls because this
+   is the action users must take after copying or adding the MCP config. */
 const authNoteCss = {
-	display: 'grid',
-	gap: '0.3rem',
-	padding: '1rem 1.2rem',
-	border: `2px solid oklch(from ${colors.primary} l c h / 0.45)`,
-	borderRadius: radius.card,
-	backgroundColor: `oklch(from ${colors.primary} l c h / 0.06)`,
-	/* Tinted wells forfeit the muted gray: body text keeps ink weight but
-	   leans toward the well's green so the callout reads as one material. */
+	...getAccentCalloutCss({ accentColor: colors.primary }),
+	gap: '0.55rem',
+	padding: '1.2rem 1.35rem',
+	borderLeftWidth: '6px',
+	backgroundColor: `oklch(from ${colors.primary} l c h / 0.14)`,
+	boxShadow: `0 10px 28px oklch(from ${colors.primary} l c h / 0.12)`,
+	'& > strong': {
+		font: `750 1.2rem/1.15 ${typography.fontFamilyDisplay}`,
+		color: colors.primaryText,
+	},
 	'& > span': {
-		color: `oklch(from ${colors.text} l 0.05 145)`,
+		color: colors.text,
+		lineHeight: 1.5,
+	},
+	'& code': {
+		font: '600 0.9em ui-monospace, "SF Mono", Menlo, monospace',
 	},
 }
 

--- a/packages/worker/src/app/handlers/account.ts
+++ b/packages/worker/src/app/handlers/account.ts
@@ -24,6 +24,7 @@ export function createAccountHandler(env: Env) {
 						env,
 						requestUrl: request.url,
 						stableUserId: user.mcpUser.userId,
+						username: user.username,
 						emailVerified: user.emailVerified,
 					}),
 				])

--- a/packages/worker/src/app/handlers/home.ts
+++ b/packages/worker/src/app/handlers/home.ts
@@ -55,6 +55,7 @@ export function createHomeHandler(env: Env) {
 				env,
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
+				username: user.username,
 				emailVerified: user.emailVerified,
 			})
 			return withAgentDiscoveryLinkHeaders(

--- a/packages/worker/src/app/handlers/onboarding.node.test.ts
+++ b/packages/worker/src/app/handlers/onboarding.node.test.ts
@@ -91,6 +91,27 @@ test('onboarding serves public setup content to anonymous visitors', async () =>
 	})
 })
 
+test('onboarding API includes the authenticated package-scope username', async () => {
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		username: 'u-b',
+		emailVerified: false,
+		mcpUser: { userId: 'user-1' },
+	})
+	setAuthSessionSecret(testCookieSecret)
+	const env = { COOKIE_SECRET: testCookieSecret } as Env
+
+	const response = await createOnboardingApiHandler(env).handler(
+		new RequestContext(new Request('https://example.com/onboarding.json')),
+	)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toMatchObject({
+		ok: true,
+		loggedIn: true,
+		username: 'u-b',
+	})
+})
+
 test('the Reply sub-step names the welcome email, not merely the newest outbound', async () => {
 	const env = {} as Env
 

--- a/packages/worker/src/app/handlers/onboarding.ts
+++ b/packages/worker/src/app/handlers/onboarding.ts
@@ -196,6 +196,7 @@ export function createOnboardingHandler(env: Env) {
 				env,
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
+				username: user.username,
 				emailVerified: user.emailVerified,
 				featuredListings: await loadOnboardingFeaturedListings(env, request),
 				builtInProviders: await loadOnboardingBuiltInProviders(
@@ -248,6 +249,7 @@ export function createOnboardingApiHandler(env: Env) {
 				env,
 				requestUrl: request.url,
 				stableUserId: user.mcpUser.userId,
+				username: user.username,
 				emailVerified: user.emailVerified,
 				featuredListings: user.emailVerified
 					? await loadOnboardingFeaturedListings(env, request)

--- a/packages/worker/src/app/onboarding-data.node.test.ts
+++ b/packages/worker/src/app/onboarding-data.node.test.ts
@@ -39,6 +39,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 	).toEqual({
 		ok: true,
 		loggedIn: false,
+		username: null,
 		mcpServerUrl: 'https://heykody.dev/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
 		discoveryPrompt: buildDiscoveryPrompt({
@@ -67,11 +68,13 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		},
 		requestUrl: 'https://heykody.dev/onboarding',
 		stableUserId: 'user-1',
+		username: 'u-b',
 		emailVerified: true,
 	})
 	expect(withoutClient).toEqual({
 		ok: true,
 		loggedIn: true,
+		username: 'u-b',
 		mcpServerUrl: 'https://heykody.dev/mcp',
 		setupPrompt: buildOnboardingSetupPrompt(),
 		discoveryPrompt: buildDiscoveryPrompt({
@@ -102,6 +105,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		},
 		requestUrl: 'http://localhost:3742/onboarding',
 		stableUserId: 'user-1',
+		username: 'u-b',
 		emailVerified: true,
 		welcomeEmail: {
 			subject: 'Welcome to Kody — reply to introduce yourself',
@@ -109,6 +113,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		},
 	})
 	expect(withClient).toMatchObject({
+		username: 'u-b',
 		hasMcpClient: true,
 		emailVerified: true,
 		needsOnboarding: false,
@@ -131,6 +136,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		},
 		requestUrl: 'https://heykody.dev/onboarding',
 		stableUserId: 'user-1',
+		username: 'u-b',
 		emailVerified: false,
 	})
 	expect(unverifiedWithGrant).toMatchObject({
@@ -158,6 +164,7 @@ test('onboarding data builds the MCP URL and derives incomplete setup from verif
 		},
 		requestUrl: 'https://heykody.dev/onboarding',
 		stableUserId: 'user-1',
+		username: 'u-b',
 		emailVerified: true,
 	})
 	expect(whenProviderListingFails.hasMcpClient).toBe(false)

--- a/packages/worker/src/app/onboarding-data.ts
+++ b/packages/worker/src/app/onboarding-data.ts
@@ -55,6 +55,7 @@ export function loadPublicOnboardingData(input: {
 	return {
 		ok: true,
 		loggedIn: false,
+		username: null,
 		mcpServerUrl: buildMcpServerUrl({
 			env: input.env,
 			requestUrl: input.requestUrl,
@@ -83,6 +84,7 @@ export async function loadOnboardingData(input: {
 	env: OnboardingEnv
 	requestUrl: string | URL
 	stableUserId: string
+	username: string
 	emailVerified: boolean
 	/**
 	 * Featured starter packages loaded by the handler (which has the full
@@ -116,6 +118,7 @@ export async function loadOnboardingData(input: {
 	return {
 		ok: true,
 		loggedIn: true,
+		username: input.username,
 		mcpServerUrl,
 		setupPrompt,
 		// The discovery prompt needs no MCP connection or verified email, so it

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -334,6 +334,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(accountProps.loaderData?.onboarding).toEqual({
 		ok: true,
 		loggedIn: true,
+		username: 'account-user',
 		mcpServerUrl: '',
 		setupPrompt: '',
 		discoveryPrompt: expect.stringContaining('what-is-kody'),

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -743,6 +743,8 @@ export type OnboardingWelcomeEmail = {
 export type OnboardingLoaderData = {
 	ok: true
 	loggedIn: boolean
+	/** Signed-in package scope owner; null for public onboarding payloads. */
+	username: string | null
 	mcpServerUrl: string
 	setupPrompt: string
 	/** Pre-connection "is Kody for me?" prompt; usable in any tool-calling agent. */

--- a/packages/worker/universal/onboarding-examples.node.test.ts
+++ b/packages/worker/universal/onboarding-examples.node.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'vitest'
 import {
+	buildOnboardingExamplePrompt,
+	buildOnboardingPackageAuthoringPrompt,
 	isOnboardingExampleListing,
 	onboardingExampleListingIds,
 	selectOnboardingExampleListings,
@@ -54,4 +56,29 @@ test('selects zero-auth examples in the known production order', () => {
 			tags: [],
 		}),
 	).toBe(true)
+})
+
+test('example prompt searches the user-owned scoped package and invokes in user scope', () => {
+	const prompt = buildOnboardingExamplePrompt({
+		listingName: '@kody/hn-pulse',
+		kodyId: 'hn-pulse',
+		username: 'u-b',
+	})
+
+	expect(prompt).toContain('search({ query: "@u-b/hn-pulse" })')
+	expect(prompt).toContain(
+		'packages.invoke({ kodyId: "hn-pulse", exportName: "getTopStories"',
+	)
+	expect(prompt).not.toContain('search for the package by that kody id')
+
+	const authoringPrompt = buildOnboardingPackageAuthoringPrompt('hn-pulse')
+	expect(authoringPrompt).toContain(
+		'coding_guide_get({ guide: "package_authoring" })',
+	)
+	expect(authoringPrompt).toContain(
+		'coding_guide_get({ guide: "package_lifecycle" })',
+	)
+	expect(authoringPrompt).toContain(
+		'package_get_git_remote({ create: true, kody_id: "hn-pulse" })',
+	)
 })

--- a/packages/worker/universal/onboarding-examples.ts
+++ b/packages/worker/universal/onboarding-examples.ts
@@ -53,16 +53,17 @@ export function selectOnboardingServiceStarterListings(
 	)
 }
 
-function exampleInvokeHint(kodyId: string): string {
+function exampleInvokeHint(scopedName: string, kodyId: string): string {
+	const searchHint = `Search with search({ query: ${JSON.stringify(scopedName)} }) and inspect that user-owned package.`
 	switch (kodyId) {
 		case 'local-conditions':
-			return 'Example invoke: packages.invoke({ kodyId: "local-conditions", exportName: "getLocalConditions", params: { place: "Salt Lake City" } }).'
+			return `${searchHint} Example invoke: packages.invoke({ kodyId: "local-conditions", exportName: "getLocalConditions", params: { place: "Salt Lake City" } }).`
 		case 'hn-pulse':
-			return 'Example invoke: packages.invoke({ kodyId: "hn-pulse", exportName: "getTopStories", params: { limit: 5 } }).'
+			return `${searchHint} Example invoke: packages.invoke({ kodyId: "hn-pulse", exportName: "getTopStories", params: { limit: 5 } }).`
 		case 'personal-capture':
-			return 'Example invoke: packages.invoke({ kodyId: "personal-capture", exportName: "capture", params: { text: "Onboarding first build" } }), then packages.invoke({ kodyId: "personal-capture", exportName: "listCaptures", params: { limit: 5 } }).'
+			return `${searchHint} Example invoke: packages.invoke({ kodyId: "personal-capture", exportName: "capture", params: { text: "Onboarding first build" } }), then packages.invoke({ kodyId: "personal-capture", exportName: "listCaptures", params: { limit: 5 } }).`
 		default:
-			return 'Call package_get for the installed package, read its README exports, then packages.invoke once with that kody id.'
+			return `${searchHint} Call package_get for that installed package, read its README exports, then packages.invoke once with its kody id.`
 	}
 }
 
@@ -74,14 +75,25 @@ function exampleInvokeHint(kodyId: string): string {
 export function buildOnboardingExamplePrompt(input: {
 	listingName: string
 	kodyId: string
+	username: string
 }): string {
+	const scopedName = `@${input.username}/${input.kodyId}`
 	return [
 		`I started a one-click install/fork of the onboarding example "${input.listingName}" (kody id: ${input.kodyId}) into my Kody account.`,
-		'Wait until that install is ready: search for the package by that kody id once, and if it is missing, try again once after I say install finished — do not poll in a loop.',
+		`Wait until that install is ready: search for my user-owned package by its scoped name "${scopedName}" once, and if it is missing, try again once after I say install finished — do not poll in a loop.`,
 		`Then invoke MY installed/forked package with packages.invoke using kody id "${input.kodyId}" (not a bare platform @kody/* static import — that fails for packages that need my account's packageStorage until forked).`,
-		exampleInvokeHint(input.kodyId),
+		exampleInvokeHint(scopedName, input.kodyId),
 		'Show the result briefly. Explain that the package is one I own.',
 		'Ask if I want to hang a trigger on it (webhook, Kody app, cron, or skip) — list options without recommending one.',
 		'Keep messages short.',
+	].join(' ')
+}
+
+export function buildOnboardingPackageAuthoringPrompt(kodyId: string): string {
+	return [
+		`Help me change my Kody package "${kodyId}" or create a new package.`,
+		'First load coding_guide_get({ guide: "package_authoring" }) and coding_guide_get({ guide: "package_lifecycle" }).',
+		`Then call package_get_git_remote({ create: true, kody_id: ${JSON.stringify(kodyId)} }) so we can work in the package repository.`,
+		'Ask what I want the package to do, then follow the guides.',
 	].join(' ')
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make first-run onboarding clearly guide users through MCP authentication, a first owned-package win, and the path to authoring their own packages.

## Summary

- Require a two-click confirmation before an unconnected user leaves Step 1, while connected users still advance once.
- Add a prominent post-install Authenticate callout for Cursor and Claude Code.
- Scope Step 2 package search prompts as `@username/kodyId` while retaining user-scoped `packages.invoke({ kodyId })` calls.
- Emphasize the three owned-package demos and add package-authoring and Kody Factory next steps after a successful example.
- Thread the signed-in username through onboarding loader payloads.

## Testing

- [CI is green](https://github.com/kentcdodds/kody/actions/runs/32318291434): Static, Node, Workers, MCP, and E2E all pass; Cursor Bugbot and CodeRabbit pass.
- Focused onboarding + SSR suite: 21 tests passed.
- `npm run format:check` and `npm run typecheck` pass.
- Sequential local Node: 1,843 tests passed; sequential Workers: 297 tests passed. The all-at-once Cloud VM gate hit Wrangler startup-budget timeouts, while clean CI passed every equivalent job.
- Seeded PR preview passed health, login, runtime, authenticated `/onboarding`, and `/onboarding.json`; payload includes `username: "user-me"`.
- Manual preview verified the prominent Authenticate callout, first-click disconnected warning, second-click advance, and owned-package Step 2 lede. The isolated preview has no featured community listings, so it cannot create the HN fork needed to render the scoped prompt/post-success cards; those contracts are covered by focused unit tests.

<a href="https://cursor.com/agents/bc-eaa633bf-edf9-4d69-9fd1-8ff0225402c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_connection_warning_and_first_win.mp4"><img src="https://cursor.com/artifacts/c/art-0b1e69f9-4b6c-45c3-8f65-3194b4b90f62" alt="onboarding_connection_warning_and_first_win.mp4" /></a>

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1dfda4ec` · **Head:** `52eb5fbf`

**Classification:** extends — the onboarding payload and browser wizard behavior gain username-scoped prompts, connection confirmation, and owned-package authoring guidance; no primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — new wizard confirmation, authentication callout, scoped prompts, and post-install cards |
| `app-sessions` | auth | composes — authenticated username is forwarded through the existing onboarding loader |

### Change flow

The onboarding loader supplies package scope and MCP grant state; the wizard uses them to guard Step 1 and produce an unambiguous owned-package prompt in Step 2.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant appSessions as app-sessions
	User->>appUi: open onboarding wizard
	appUi->>appSessions: GET onboarding payload
	appSessions-->>appUi: username + hasMcpClient
	alt MCP client is not connected
		User->>appUi: first Next arms “continue anyway?” warning
		User->>appUi: second Next advances to owned-package examples
	else MCP client is connected
		User->>appUi: Next advances in one click
	end
	appUi-->>User: copy search prompt for @username/kodyId
	appUi-->>User: show package-authoring + Kody Factory cards after install
```

</details>

<!-- system-recap:end -->

## Conductor report

- **Track:** `onboarding-ux`
- **Files:** onboarding route/components, onboarding payload/data handlers and types, scoped prompt builders, SSR expectation, and focused node tests
- **Evidence:** green CI; focused tests 21/21; Node 1,843/1,843; Workers 297/297; seeded preview payload contains `user-me`; recorded Step 1 warning and Step 2 first-win flow; search indexes both `kodyId` and scoped package `name`, while invocation correctly remains bare `kodyId` in user scope
- **Remains:** squash merge and deploy verification. The isolated preview's missing featured listings prevent a live HN install, so scoped prompt/post-success behavior is verified by unit coverage rather than preview interaction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eaa633bf-edf9-4d69-9fd1-8ff0225402c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaa633bf-edf9-4d69-9fd1-8ff0225402c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added personalized onboarding prompts using the signed-in username.
  - Added package-authoring next steps with copyable guidance, documentation links, and a factory example.
  - Added explicit Cursor and Claude Code authentication instructions.
  - Added confirmation before advancing from onboarding when not connected.
  - Added package-specific guidance after installation.

- **Bug Fixes**
  - Improved onboarding behavior for logged-out visitors by displaying an appropriate login hint.

- **Tests**
  - Expanded coverage for personalized onboarding data and confirmation-aware navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->