### PR TITLE
Spill oversized ack webhook bodies past the queue size cap

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1270,6 +1270,11 @@ app-owned keys in it. App-owned `BUNDLE_ARTIFACTS_KV` keys are:
 - `derived-cache:v1:community-icon:v1:{listingId}:...` — derived community
   listing icon cache; registered as a user-owned KV surface and deleted for a
   user's listings during account deletion.
+- `webhook-dispatch-payload:v1:{userId}:{deliveryId}` — ephemeral ack-mode
+  webhook body spill written with KV `expirationTtl` (24 hours) when the
+  serialized queue message would exceed 120 KB. Immediate account-deletion
+  cleanup is not required because KV enforces the TTL; the queue consumer
+  deletes the key after a terminal delivery.
 
 Account deletion derives these keys from D1 rows and package ids before deleting
 D1 projections. New KV prefixes must add corresponding account-deletion coverage

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -48,22 +48,26 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
 8. `ack`: await enqueue to `kody-webhook-dispatch`, then return **202**. The
    queue consumer owns the full invocation and its terminal writes, so work is
    not tied to the post-response `waitUntil` window. A failed enqueue returns
-   **503** so the provider can retry. Ack queue messages have a conservative 120
-   KB serialized ceiling beneath Cloudflare Queues' 128 KB limit; larger
-   authenticated deliveries return **413**. `sync`: await (30s) and return
-   export JSON, **502** on failure.
+   **503** so the provider can retry. Queue messages omit reconstructed
+   `params.request.json` (the consumer parses `body`) and spill `body` to
+   `BUNDLE_ARTIFACTS_KV` under
+   `webhook-dispatch-payload:v1:{userId}:{deliveryId}` when the serialized
+   message would exceed a conservative 120 KB ceiling beneath Cloudflare Queues'
+   128 KB limit. `sync`: await (30s) and return export JSON, **502** on failure.
 9. Authenticated deliveries (and post-auth rejects such as HMAC / size / missing
    declaration) record a `webhook` surface run record (no payload body). See
    [Run records](./run-records.md). URL-secret mismatches and pre-auth rate
    limits still write no delivery history.
 
 Ack messages carry the accepted delivery id, idempotency key, scoped endpoint
-identity, export name, and already-authenticated payload. Queue retries reuse
-that exact idempotency key. Transient ledger lookup/terminal-persistence
-failures and still-in-progress replays are retried; terminal package errors are
-recorded and acknowledged. The package export sandbox retains its normal ~90s
-budget, so genuinely longer package work ends as an explicit timeout rather than
-an unknown interrupted outcome.
+identity, export name, and already-authenticated payload (inline `body`, or a
+user-scoped KV key when the body was spilled). Queue retries reuse that exact
+idempotency key. Transient ledger lookup/terminal-persistence failures and
+still-in-progress replays are retried; terminal package errors are recorded and
+acknowledged. A missing spilled body is a terminal failure
+(`ack_queue_payload_missing`). The package export sandbox retains its normal
+~90s budget, so genuinely longer package work ends as an explicit timeout rather
+than an unknown interrupted outcome.
 
 The Queue consumer batch size is one. Processing is sequential and one export
 can consume the full sandbox budget, so larger batches could exceed the Queue

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -78,9 +78,7 @@ delivery history also appears under [Activity](./activity.md)
 - About **60 requests/minute** per minted webhook → **429**.
 - `ack`: **202** `{ "ok": true }` after Kody durably queues the delivery; the
   export runs in the background. A temporary queue failure returns **503** so
-  the provider can retry without Kody claiming acceptance. Ack deliveries must
-  fit the queue-safe serialized limit (about **120 KB**); larger authenticated
-  payloads return **413**.
+  the provider can retry without Kody claiming acceptance.
 - `sync`: waits for the export JSON result (**502** on failure).
 
 Background delivery retries keep the same idempotency key, so a transient

--- a/packages/worker/src/account/user-owned-surfaces.ts
+++ b/packages/worker/src/account/user-owned-surfaces.ts
@@ -37,6 +37,7 @@ export type UserOwnedKvKeyScheme = {
 		| 'package_retriever_manifest'
 		| 'package_retriever_index_entry'
 		| 'package_retriever_index_prefix'
+		| 'webhook_dispatch_payload'
 	binding: 'BUNDLE_ARTIFACTS_KV'
 	sourceTable?: string
 	sourceColumn?: string
@@ -227,6 +228,15 @@ export const accountUserOwnedKvKeySchemes: ReadonlyArray<UserOwnedKvKeyScheme> =
 			prefixTemplate:
 				'package-retriever-index-entry:v1:{userId}:{scope}:{packageId}:',
 			notes: 'Deleted by deleteAllPackageRetrieverCacheEntriesForUser.',
+		},
+		{
+			id: 'webhook_dispatch_payload',
+			binding: 'BUNDLE_ARTIFACTS_KV',
+			prefixTemplate: 'webhook-dispatch-payload:v1:{userId}:',
+			retention:
+				'Expires through the KV expirationTtl written at store time; retention is 24 hours.',
+			notes:
+				'Short-lived ack-mode webhook body spill so Cloudflare Queue messages stay under 128 KB. Immediate account-deletion cleanup is optional because KV enforces the TTL. The consumer deletes the key after a terminal delivery.',
 		},
 	] as const
 

--- a/packages/worker/src/webhooks/dispatch-payload-store.node.test.ts
+++ b/packages/worker/src/webhooks/dispatch-payload-store.node.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from 'vitest'
+import {
+	createWebhookDispatchQueueMessage,
+	getWebhookDispatchQueueMessageBytes,
+	parseWebhookDispatchQueueMessage,
+	webhookDispatchPayloadKvKey,
+	webhookDispatchQueueMessageMaxBytes,
+	withSpilledWebhookDispatchPayload,
+} from './dispatch-queue-producer.ts'
+import {
+	deleteWebhookDispatchPayload,
+	hydrateWebhookDispatchQueueMessage,
+	storeWebhookDispatchPayload,
+	webhookDispatchPayloadTtlSeconds,
+} from './dispatch-payload-store.ts'
+
+function createKv(initial: Record<string, string> = {}) {
+	const values = new Map(Object.entries(initial))
+	const puts: Array<{ key: string; value: string; expirationTtl?: number }> = []
+	return {
+		values,
+		puts,
+		async get(key: string) {
+			return values.get(key) ?? null
+		},
+		async put(
+			key: string,
+			value: string,
+			options?: { expirationTtl?: number },
+		) {
+			values.set(key, value)
+			puts.push({ key, value, expirationTtl: options?.expirationTtl })
+		},
+		async delete(key: string) {
+			values.delete(key)
+		},
+	}
+}
+
+function createParams(body: string) {
+	return {
+		webhook: {
+			packageKodyId: 'sentry-triage',
+			name: 'sentry',
+			receivedAt: '2026-08-19T21:54:10.904Z',
+		},
+		request: {
+			method: 'POST',
+			contentType: 'application/json',
+			headers: { 'sentry-hook-resource': 'issue' },
+			body,
+			json: { ignored: true },
+		},
+	}
+}
+
+function createInput(body: string) {
+	return {
+		endpoint: {
+			id: 'endpoint-1',
+			userId: 'user-1',
+			packageId: 'package-1',
+			webhookName: 'sentry',
+		},
+		packageKodyId: 'sentry-triage',
+		exportName: './process-sentry-webhook',
+		params: createParams(body),
+		idempotencyKey: 'webhook:endpoint-1:delivery-1',
+		deliveryId: 'delivery-1',
+		payloadBytes: body.length,
+		receivedAt: '2026-08-19T21:54:10.904Z',
+	}
+}
+
+test('ack queue messages drop reconstructed json and spill bodies that miss the 120 KB ceiling', async () => {
+	const compact = createWebhookDispatchQueueMessage(
+		createInput(JSON.stringify({ event: 'error' })),
+	)
+	expect(compact.params.request.json).toBeNull()
+	expect(parseWebhookDispatchQueueMessage(compact)).toEqual(compact)
+	expect(getWebhookDispatchQueueMessageBytes(compact)).toBeLessThan(
+		webhookDispatchQueueMessageMaxBytes,
+	)
+
+	const midSizeBody = JSON.stringify({ payload: 'x'.repeat(70_000) })
+	const midSize = createWebhookDispatchQueueMessage(createInput(midSizeBody))
+	expect(midSize.params.request.json).toBeNull()
+	expect(getWebhookDispatchQueueMessageBytes(midSize)).toBeLessThan(
+		webhookDispatchQueueMessageMaxBytes,
+	)
+
+	const largeBody = JSON.stringify({ payload: 'y'.repeat(143_315) })
+	const large = createWebhookDispatchQueueMessage(createInput(largeBody))
+	expect(getWebhookDispatchQueueMessageBytes(large)).toBeGreaterThan(
+		webhookDispatchQueueMessageMaxBytes,
+	)
+
+	const kv = createKv()
+	const payloadKvKey = await storeWebhookDispatchPayload({
+		kv,
+		userId: 'user-1',
+		deliveryId: 'delivery-1',
+		body: largeBody,
+	})
+	expect(payloadKvKey).toBe(webhookDispatchPayloadKvKey('user-1', 'delivery-1'))
+	expect(kv.puts[0]?.expirationTtl).toBe(webhookDispatchPayloadTtlSeconds)
+
+	const spilled = withSpilledWebhookDispatchPayload(large, payloadKvKey)
+	expect(spilled.params.request.body).toBe('')
+	expect(spilled.payloadKvKey).toBe(payloadKvKey)
+	expect(getWebhookDispatchQueueMessageBytes(spilled)).toBeLessThan(
+		webhookDispatchQueueMessageMaxBytes,
+	)
+	expect(parseWebhookDispatchQueueMessage(spilled)).toEqual(spilled)
+	expect(
+		parseWebhookDispatchQueueMessage({
+			...spilled,
+			payloadKvKey: webhookDispatchPayloadKvKey('user-2', 'delivery-1'),
+		}),
+	).toBeNull()
+
+	const hydrated = await hydrateWebhookDispatchQueueMessage({
+		message: spilled,
+		kv,
+	})
+	expect(hydrated?.params.request.body).toBe(largeBody)
+	expect(hydrated?.params.request.json).toEqual({
+		payload: 'y'.repeat(143_315),
+	})
+
+	await deleteWebhookDispatchPayload({ kv, key: payloadKvKey })
+	await expect(
+		hydrateWebhookDispatchQueueMessage({
+			message: spilled,
+			kv,
+		}),
+	).resolves.toBeNull()
+})

--- a/packages/worker/src/webhooks/dispatch-payload-store.ts
+++ b/packages/worker/src/webhooks/dispatch-payload-store.ts
@@ -1,0 +1,74 @@
+import {
+	type WebhookDispatchQueueMessage,
+	webhookDispatchPayloadKvKey,
+	webhookDispatchPayloadTtlSeconds,
+} from './dispatch-queue-producer.ts'
+import { parseWebhookJsonBody } from './params.ts'
+
+export {
+	webhookDispatchPayloadKvKey,
+	webhookDispatchPayloadKvPrefix,
+	webhookDispatchPayloadTtlSeconds,
+} from './dispatch-queue-producer.ts'
+
+export async function storeWebhookDispatchPayload(input: {
+	kv: Pick<KVNamespace, 'put'>
+	userId: string
+	deliveryId: string
+	body: string
+}) {
+	const key = webhookDispatchPayloadKvKey(input.userId, input.deliveryId)
+	await input.kv.put(key, input.body, {
+		expirationTtl: webhookDispatchPayloadTtlSeconds,
+	})
+	return key
+}
+
+export async function loadWebhookDispatchPayload(input: {
+	kv: Pick<KVNamespace, 'get'>
+	key: string
+	expectedUserId: string
+	expectedDeliveryId: string
+}) {
+	const expected = webhookDispatchPayloadKvKey(
+		input.expectedUserId,
+		input.expectedDeliveryId,
+	)
+	if (input.key !== expected) return null
+	return await input.kv.get(input.key)
+}
+
+export async function deleteWebhookDispatchPayload(input: {
+	kv: Pick<KVNamespace, 'delete'>
+	key: string
+}) {
+	await input.kv.delete(input.key)
+}
+
+export async function hydrateWebhookDispatchQueueMessage(input: {
+	message: WebhookDispatchQueueMessage
+	kv: Pick<KVNamespace, 'get'>
+}): Promise<WebhookDispatchQueueMessage | null> {
+	let body = input.message.params.request.body
+	if (input.message.payloadKvKey) {
+		const stored = await loadWebhookDispatchPayload({
+			kv: input.kv,
+			key: input.message.payloadKvKey,
+			expectedUserId: input.message.endpoint.userId,
+			expectedDeliveryId: input.message.deliveryId,
+		})
+		if (stored == null) return null
+		body = stored
+	}
+	return {
+		...input.message,
+		params: {
+			...input.message.params,
+			request: {
+				...input.message.params.request,
+				body,
+				json: parseWebhookJsonBody(body),
+			},
+		},
+	}
+}

--- a/packages/worker/src/webhooks/dispatch-queue-producer.ts
+++ b/packages/worker/src/webhooks/dispatch-queue-producer.ts
@@ -4,6 +4,11 @@ import { type WebhookExportParams } from './types.ts'
 // enough headroom for transport metadata and structured-clone framing.
 export const webhookDispatchQueueMessageMaxBytes = 120_000
 
+export const webhookDispatchPayloadKvPrefix = 'webhook-dispatch-payload:v1:'
+
+/** Covers queue retries plus sandbox budget, with headroom for backlog. */
+export const webhookDispatchPayloadTtlSeconds = 24 * 60 * 60
+
 export type WebhookDispatchQueueMessage = {
 	endpoint: {
 		id: string
@@ -18,6 +23,60 @@ export type WebhookDispatchQueueMessage = {
 	deliveryId: string
 	payloadBytes: number
 	receivedAt: string
+	payloadKvKey?: string
+}
+
+export function webhookDispatchPayloadKvKey(
+	userId: string,
+	deliveryId: string,
+) {
+	return `${webhookDispatchPayloadKvPrefix}${userId}:${deliveryId}`
+}
+
+export function createWebhookDispatchQueueMessage(input: {
+	endpoint: WebhookDispatchQueueMessage['endpoint']
+	packageKodyId: string
+	exportName: string
+	params: WebhookExportParams
+	idempotencyKey: string
+	deliveryId: string
+	payloadBytes: number
+	receivedAt: string
+}): WebhookDispatchQueueMessage {
+	return {
+		endpoint: input.endpoint,
+		packageKodyId: input.packageKodyId,
+		exportName: input.exportName,
+		params: {
+			webhook: input.params.webhook,
+			request: {
+				...input.params.request,
+				json: null,
+			},
+		},
+		idempotencyKey: input.idempotencyKey,
+		deliveryId: input.deliveryId,
+		payloadBytes: input.payloadBytes,
+		receivedAt: input.receivedAt,
+	}
+}
+
+export function withSpilledWebhookDispatchPayload(
+	message: WebhookDispatchQueueMessage,
+	payloadKvKey: string,
+): WebhookDispatchQueueMessage {
+	return {
+		...message,
+		payloadKvKey,
+		params: {
+			...message.params,
+			request: {
+				...message.params.request,
+				body: '',
+				json: null,
+			},
+		},
+	}
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -68,6 +127,15 @@ export function parseWebhookDispatchQueueMessage(
 	) {
 		return null
 	}
+	const payloadKvKey = message['payloadKvKey']
+	if (payloadKvKey !== undefined) {
+		if (
+			!isNonEmptyString(payloadKvKey) ||
+			payloadKvKey !== webhookDispatchPayloadKvKey(userId, deliveryId)
+		) {
+			return null
+		}
+	}
 	return {
 		endpoint: {
 			id,
@@ -82,6 +150,7 @@ export function parseWebhookDispatchQueueMessage(
 		deliveryId,
 		payloadBytes,
 		receivedAt,
+		...(payloadKvKey ? { payloadKvKey } : {}),
 	}
 }
 

--- a/packages/worker/src/webhooks/dispatch-queue.node.test.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.node.test.ts
@@ -189,7 +189,10 @@ test('queue hydrates spilled payloads, deletes them after terminal work, and ack
 		status: 200,
 		body: { ok: true, result: { handled: true } },
 	})
-	mocks.recordWebhookDelivery.mockResolvedValue(undefined)
+	mocks.recordWebhookDelivery
+		.mockResolvedValueOnce(undefined)
+		.mockResolvedValueOnce(undefined)
+		.mockRejectedValueOnce(new Error('RunLog unavailable'))
 
 	const payloadKvKey = webhookDispatchPayloadKvKey('user-1', 'delivery-1')
 	const values = new Map<string, string>([
@@ -214,13 +217,27 @@ test('queue hydrates spilled payloads, deletes them after terminal work, and ack
 		idempotencyKey: 'webhook:endpoint-1:delivery-missing',
 		payloadKvKey: webhookDispatchPayloadKvKey('user-1', 'delivery-missing'),
 	})
+	const missingRecordFailure = createQueueMessage('missing-record-failure', {
+		...spilled,
+		deliveryId: 'delivery-missing-record',
+		idempotencyKey: 'webhook:endpoint-1:delivery-missing-record',
+		payloadKvKey: webhookDispatchPayloadKvKey(
+			'user-1',
+			'delivery-missing-record',
+		),
+	})
 
-	await handleWebhookDispatchQueue(createBatch([queued, missing]), {
-		BUNDLE_ARTIFACTS_KV: kv,
-	} as unknown as Env)
+	await handleWebhookDispatchQueue(
+		createBatch([queued, missing, missingRecordFailure]),
+		{
+			BUNDLE_ARTIFACTS_KV: kv,
+		} as unknown as Env,
+	)
 
 	expect(queued.ack).toHaveBeenCalledTimes(1)
 	expect(missing.ack).toHaveBeenCalledTimes(1)
+	expect(missingRecordFailure.ack).not.toHaveBeenCalled()
+	expect(missingRecordFailure.retry).toHaveBeenCalledWith({ delaySeconds: 30 })
 	expect(values.has(payloadKvKey)).toBe(false)
 	expect(mocks.dispatchWebhookInvocation).toHaveBeenCalledTimes(1)
 	expect(mocks.dispatchWebhookInvocation).toHaveBeenCalledWith(

--- a/packages/worker/src/webhooks/dispatch-queue.node.test.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.node.test.ts
@@ -7,6 +7,7 @@ import {
 import {
 	getWebhookDispatchQueueMessageBytes,
 	parseWebhookDispatchQueueMessage,
+	webhookDispatchPayloadKvKey,
 	webhookDispatchQueueMessageMaxBytes,
 	type WebhookDispatchQueueMessage,
 } from './dispatch-queue-producer.ts'
@@ -177,5 +178,66 @@ test('webhook queue parser rejects malformed isolation and delivery fields', () 
 	).toBeNull()
 	expect(getWebhookDispatchQueueMessageBytes(message)).toBeLessThan(
 		webhookDispatchQueueMessageMaxBytes,
+	)
+})
+
+test('queue hydrates spilled payloads, deletes them after terminal work, and acks a missing spill', async () => {
+	consoleError.mockImplementation(() => {})
+	mocks.dispatchWebhookInvocation.mockReset()
+	mocks.recordWebhookDelivery.mockReset()
+	mocks.dispatchWebhookInvocation.mockResolvedValue({
+		status: 200,
+		body: { ok: true, result: { handled: true } },
+	})
+	mocks.recordWebhookDelivery.mockResolvedValue(undefined)
+
+	const payloadKvKey = webhookDispatchPayloadKvKey('user-1', 'delivery-1')
+	const values = new Map<string, string>([
+		[payloadKvKey, '{"event":"error","extra":"spill"}'],
+	])
+	const kv = {
+		async get(key: string) {
+			return values.get(key) ?? null
+		},
+		async delete(key: string) {
+			values.delete(key)
+		},
+	}
+	const spilled = createMessage()
+	spilled.params.request.body = ''
+	spilled.params.request.json = null
+	spilled.payloadKvKey = payloadKvKey
+	const queued = createQueueMessage('spilled', spilled)
+	const missing = createQueueMessage('missing', {
+		...spilled,
+		deliveryId: 'delivery-missing',
+		idempotencyKey: 'webhook:endpoint-1:delivery-missing',
+		payloadKvKey: webhookDispatchPayloadKvKey('user-1', 'delivery-missing'),
+	})
+
+	await handleWebhookDispatchQueue(createBatch([queued, missing]), {
+		BUNDLE_ARTIFACTS_KV: kv,
+	} as unknown as Env)
+
+	expect(queued.ack).toHaveBeenCalledTimes(1)
+	expect(missing.ack).toHaveBeenCalledTimes(1)
+	expect(values.has(payloadKvKey)).toBe(false)
+	expect(mocks.dispatchWebhookInvocation).toHaveBeenCalledTimes(1)
+	expect(mocks.dispatchWebhookInvocation).toHaveBeenCalledWith(
+		expect.objectContaining({
+			params: expect.objectContaining({
+				request: expect.objectContaining({
+					body: '{"event":"error","extra":"spill"}',
+					json: { event: 'error', extra: 'spill' },
+				}),
+			}),
+		}),
+	)
+	expect(mocks.recordWebhookDelivery).toHaveBeenCalledWith(
+		expect.objectContaining({
+			outcome: 'failed',
+			error: 'ack_queue_payload_missing',
+			invocationId: 'delivery-missing',
+		}),
 	)
 })

--- a/packages/worker/src/webhooks/dispatch-queue.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.ts
@@ -103,6 +103,10 @@ export async function handleWebhookDispatchQueue(
 						endpointId: message.endpoint.id,
 						error,
 					})
+					queueMessage.retry({
+						delaySeconds: webhookDispatchRetryDelaySeconds,
+					})
+					continue
 				}
 				queueMessage.ack()
 				continue
@@ -111,6 +115,7 @@ export async function handleWebhookDispatchQueue(
 			if (outcome === 'retry') {
 				queueMessage.retry({ delaySeconds: webhookDispatchRetryDelaySeconds })
 			} else {
+				queueMessage.ack()
 				if (message.payloadKvKey) {
 					await deleteWebhookDispatchPayload({
 						kv: env.BUNDLE_ARTIFACTS_KV,
@@ -123,7 +128,6 @@ export async function handleWebhookDispatchQueue(
 						})
 					})
 				}
-				queueMessage.ack()
 			}
 		} catch (error) {
 			console.error('webhook-dispatch-queue-processing-failed', {

--- a/packages/worker/src/webhooks/dispatch-queue.ts
+++ b/packages/worker/src/webhooks/dispatch-queue.ts
@@ -3,6 +3,10 @@ import {
 	readWebhookInvocationResult,
 	recordWebhookDelivery,
 } from './delivery.ts'
+import {
+	deleteWebhookDispatchPayload,
+	hydrateWebhookDispatchQueueMessage,
+} from './dispatch-payload-store.ts'
 import { webhookDispatchQueueName } from './dispatch-queue-names.ts'
 import {
 	parseWebhookDispatchQueueMessage,
@@ -70,10 +74,55 @@ export async function handleWebhookDispatchQueue(
 			continue
 		}
 		try {
-			const outcome = await processWebhookDispatch(message, env)
+			const hydrated = await hydrateWebhookDispatchQueueMessage({
+				message,
+				kv: env.BUNDLE_ARTIFACTS_KV,
+			})
+			if (!hydrated) {
+				console.error('webhook-dispatch-payload-missing', {
+					queueMessageId: queueMessage.id,
+					endpointId: message.endpoint.id,
+					deliveryId: message.deliveryId,
+				})
+				try {
+					await recordWebhookDelivery({
+						env,
+						endpoint: message.endpoint,
+						kodyId: message.packageKodyId,
+						outcome: 'failed',
+						httpStatus: 502,
+						error: 'ack_queue_payload_missing',
+						payloadBytes: message.payloadBytes,
+						invocationId: message.deliveryId,
+						startedAt: message.receivedAt,
+						requirePersistence: true,
+					})
+				} catch (error) {
+					console.error('webhook-dispatch-payload-missing-record-failed', {
+						queueMessageId: queueMessage.id,
+						endpointId: message.endpoint.id,
+						error,
+					})
+				}
+				queueMessage.ack()
+				continue
+			}
+			const outcome = await processWebhookDispatch(hydrated, env)
 			if (outcome === 'retry') {
 				queueMessage.retry({ delaySeconds: webhookDispatchRetryDelaySeconds })
 			} else {
+				if (message.payloadKvKey) {
+					await deleteWebhookDispatchPayload({
+						kv: env.BUNDLE_ARTIFACTS_KV,
+						key: message.payloadKvKey,
+					}).catch((error) => {
+						console.error('webhook-dispatch-payload-delete-failed', {
+							queueMessageId: queueMessage.id,
+							endpointId: message.endpoint.id,
+							error,
+						})
+					})
+				}
 				queueMessage.ack()
 			}
 		} catch (error) {

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -20,15 +20,20 @@ import {
 	recordWebhookDelivery,
 } from './delivery.ts'
 import {
+	createWebhookDispatchQueueMessage,
 	enqueueWebhookDispatch,
 	getWebhookDispatchQueueMessageBytes,
 	webhookDispatchQueueMessageMaxBytes,
-	type WebhookDispatchQueueMessage,
+	withSpilledWebhookDispatchPayload,
 } from './dispatch-queue-producer.ts'
+import {
+	deleteWebhookDispatchPayload,
+	storeWebhookDispatchPayload,
+} from './dispatch-payload-store.ts'
 import { collectSafeWebhookHeaders } from './headers.ts'
+import { buildWebhookExportParams } from './params.ts'
 import { getWebhookEndpointByKey } from './repo.ts'
 import {
-	type WebhookExportParams,
 	webhookMaxPayloadBytes,
 	webhookRateLimitConfig,
 	webhookSyncInvocationTimeoutMs,
@@ -185,40 +190,6 @@ async function readBodyWithCap(
 		}
 	}
 	return { ok: true, bytes: new Uint8Array(buffer) }
-}
-
-function parseJsonBody(text: string): unknown | null {
-	const trimmed = text.trim()
-	if (!trimmed) return null
-	try {
-		return JSON.parse(trimmed) as unknown
-	} catch {
-		return null
-	}
-}
-
-function buildExportParams(input: {
-	packageKodyId: string
-	webhookName: string
-	request: Request
-	bodyText: string
-	receivedAt: string
-	headers: Record<string, string>
-}): WebhookExportParams {
-	return {
-		webhook: {
-			packageKodyId: input.packageKodyId,
-			name: input.webhookName,
-			receivedAt: input.receivedAt,
-		},
-		request: {
-			method: input.request.method,
-			contentType: input.request.headers.get('content-type'),
-			headers: input.headers,
-			body: input.bodyText,
-			json: parseJsonBody(input.bodyText),
-		},
-	}
 }
 
 async function runWithTimeout<T>(
@@ -454,7 +425,7 @@ export async function handleWebhookIngressRequest(
 		request,
 		declared.verification ? [declared.verification.header] : [],
 	)
-	const params = buildExportParams({
+	const params = buildWebhookExportParams({
 		packageKodyId: savedPackage.kodyId,
 		webhookName: route.webhookName,
 		request,
@@ -466,7 +437,7 @@ export async function handleWebhookIngressRequest(
 	const idempotencyKey = `webhook:${endpoint.id}:${deliveryId}`
 
 	if (declared.responseMode === 'ack') {
-		const message: WebhookDispatchQueueMessage = {
+		let message = createWebhookDispatchQueueMessage({
 			endpoint: {
 				id: endpoint.id,
 				userId: endpoint.userId,
@@ -480,11 +451,42 @@ export async function handleWebhookIngressRequest(
 			deliveryId,
 			payloadBytes: bodyBytes.byteLength,
 			receivedAt,
+		})
+		if (
+			getWebhookDispatchQueueMessageBytes(message) >
+			webhookDispatchQueueMessageMaxBytes
+		) {
+			try {
+				const payloadKvKey = await storeWebhookDispatchPayload({
+					kv: env.BUNDLE_ARTIFACTS_KV,
+					userId: endpoint.userId,
+					deliveryId,
+					body: bodyText,
+				})
+				message = withSpilledWebhookDispatchPayload(message, payloadKvKey)
+			} catch (error) {
+				console.error('webhook-dispatch-payload-store-failed', {
+					endpointId: endpoint.id,
+					error,
+				})
+				return dispatchUnavailableResponse()
+			}
 		}
 		if (
 			getWebhookDispatchQueueMessageBytes(message) >
 			webhookDispatchQueueMessageMaxBytes
 		) {
+			if (message.payloadKvKey) {
+				await deleteWebhookDispatchPayload({
+					kv: env.BUNDLE_ARTIFACTS_KV,
+					key: message.payloadKvKey,
+				}).catch((error) => {
+					console.error('webhook-dispatch-payload-delete-failed', {
+						endpointId: endpoint.id,
+						error,
+					})
+				})
+			}
 			await recordWebhookDelivery({
 				env,
 				endpoint,
@@ -505,6 +507,17 @@ export async function handleWebhookIngressRequest(
 				message,
 			})
 		} catch (error) {
+			if (message.payloadKvKey) {
+				await deleteWebhookDispatchPayload({
+					kv: env.BUNDLE_ARTIFACTS_KV,
+					key: message.payloadKvKey,
+				}).catch((error) => {
+					console.error('webhook-dispatch-payload-delete-failed', {
+						endpointId: endpoint.id,
+						error,
+					})
+				})
+			}
 			console.error('webhook-dispatch-enqueue-failed', {
 				endpointId: endpoint.id,
 				error,

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -287,9 +287,10 @@ test('package-centered webhook ingress auth, HMAC, size cap, ack/sync, and isola
 	const enqueueArgs = mocks.enqueueWebhookDispatch.mock.calls[0]?.[0] as {
 		message: {
 			endpoint: { userId: string }
+			payloadKvKey?: string
 			params: {
 				webhook: { packageKodyId: string; name: string }
-				request: { json: unknown }
+				request: { body: string; json: unknown }
 			}
 		}
 	}
@@ -299,17 +300,50 @@ test('package-centered webhook ingress auth, HMAC, size cap, ack/sync, and isola
 		name: 'sentry',
 		receivedAt: expect.any(String),
 	})
-	expect(enqueueArgs.message.params.request.json).toEqual({ event: 'push' })
+	expect(enqueueArgs.message.params.request.json).toBeNull()
+	expect(enqueueArgs.message.params.request.body).toBe(body)
+	expect(enqueueArgs.message.payloadKvKey).toBeUndefined()
 
 	declareWebhook({ name: 'sentry' })
-	const oversizedAck = await postWebhook({
+	const midSizeAck = await postWebhook({
 		packageKodyId: 'sentry-bridge',
 		webhookName: 'sentry',
 		urlSecret,
 		body: JSON.stringify({ payload: 'x'.repeat(70_000) }),
 	})
-	expect(oversizedAck.status).toBe(413)
-	expect(mocks.enqueueWebhookDispatch).toHaveBeenCalledTimes(1)
+	expect(midSizeAck.status).toBe(202)
+	expect(mocks.enqueueWebhookDispatch).toHaveBeenCalledTimes(2)
+	const midSizeArgs = mocks.enqueueWebhookDispatch.mock.calls[1]?.[0] as {
+		message: { payloadKvKey?: string; params: { request: { json: unknown } } }
+	}
+	expect(midSizeArgs.message.payloadKvKey).toBeUndefined()
+	expect(midSizeArgs.message.params.request.json).toBeNull()
+
+	const largeBody = JSON.stringify({ payload: 'y'.repeat(140_000) })
+	const largeAck = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+		urlSecret,
+		body: largeBody,
+	})
+	expect(largeAck.status).toBe(202)
+	expect(mocks.enqueueWebhookDispatch).toHaveBeenCalledTimes(3)
+	const largeArgs = mocks.enqueueWebhookDispatch.mock.calls[2]?.[0] as {
+		message: {
+			payloadKvKey?: string
+			deliveryId: string
+			endpoint: { userId: string }
+			params: { request: { body: string; json: unknown } }
+		}
+	}
+	expect(largeArgs.message.params.request.body).toBe('')
+	expect(largeArgs.message.params.request.json).toBeNull()
+	expect(largeArgs.message.payloadKvKey).toBe(
+		`webhook-dispatch-payload:v1:${largeArgs.message.endpoint.userId}:${largeArgs.message.deliveryId}`,
+	)
+	expect(
+		await env.BUNDLE_ARTIFACTS_KV.get(largeArgs.message.payloadKvKey!),
+	).toBe(largeBody)
 
 	declareWebhook({ name: 'sync-hook', responseMode: 'sync' })
 	mocks.invokePackageExport.mockClear()

--- a/packages/worker/src/webhooks/params.ts
+++ b/packages/worker/src/webhooks/params.ts
@@ -1,0 +1,35 @@
+import { type WebhookExportParams } from './types.ts'
+
+export function parseWebhookJsonBody(text: string): unknown | null {
+	const trimmed = text.trim()
+	if (!trimmed) return null
+	try {
+		return JSON.parse(trimmed) as unknown
+	} catch {
+		return null
+	}
+}
+
+export function buildWebhookExportParams(input: {
+	packageKodyId: string
+	webhookName: string
+	request: Request
+	bodyText: string
+	receivedAt: string
+	headers: Record<string, string>
+}): WebhookExportParams {
+	return {
+		webhook: {
+			packageKodyId: input.packageKodyId,
+			name: input.webhookName,
+			receivedAt: input.receivedAt,
+		},
+		request: {
+			method: input.request.method,
+			contentType: input.request.headers.get('content-type'),
+			headers: input.headers,
+			body: input.bodyText,
+			json: parseWebhookJsonBody(input.bodyText),
+		},
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Ack-mode webhook ingress should accept every payload that already passed the 1 MB cap. A 143 KB Sentry body was rejected with HTTP 413 (`payload_too_large_for_ack_queue`) because the queue message serialized both `request.body` and `request.json` under Cloudflare Queues' 128 KB limit.

## Summary

- Ack queue messages omit reconstructed `params.request.json`; the consumer parses `body`.
- Bodies that would still miss the 120 KB serialized ceiling are stored in `BUNDLE_ARTIFACTS_KV` under `webhook-dispatch-payload:v1:{userId}:{deliveryId}` with a 24-hour TTL.
- The queue consumer hydrates `body` + `json`, invokes the export, and deletes the spill after a terminal delivery.
- Missing spilled bodies stay on the queue until the terminal `ack_queue_payload_missing` record persists; successful deliveries are acknowledged before spill cleanup.
- User docs no longer advertise a second 120 KB ack-only cap.

## Testing

- `vitest run --project node-unit` on webhook queue/store tests — passed (including spill hydrate, missing spill, and persistence-failure retry)
- `vitest run --project workers-unit` on `http.workers.test.ts` — passed (70 KB inline enqueue, ~140 KB KV spill, 1 MB+ still 413)
- GitHub ✅ Validate (Static, Node, Workers, MCP, E2E) passed on `c70d3275` before the review-follow-up commit
- Preview https://kody-pr-1582.kody-a99.workers.dev: seeded login, empty packages/activity, unminted webhook POST of 140 KB returned 404 (not 413). Webhook mint is MCP-only, so the 143 KB enqueue path is covered by workers-unit tests rather than a preview mint.

## System changes

See the system recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ff89855` · **Head:** `9e54c22`

**Classification:** extends — ack-mode webhook dispatch now spills oversized bodies to KV instead of rejecting them at the Cloudflare Queue ceiling.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `webhooks` | assistant | extends — ack enqueue omits reconstructed `json` and spills oversized `body` to `BUNDLE_ARTIFACTS_KV` |

Unmatched paths are the webhook/storage docs and the account KV inventory note for the new TTL prefix.

### Change flow

A 143 KB Sentry POST that already passed the 1 MB cap is queued instead of rejected; the consumer reconstructs export params from the spilled body.

```mermaid
sequenceDiagram
	actor Provider
	participant webhooks as webhooks
	Provider->>webhooks: POST /@user/webhooks/... (body under 1 MB)
	webhooks->>webhooks: omit params.request.json from queue message
	alt serialized message still over 120 KB
		webhooks->>webhooks: put webhook-dispatch-payload:v1:userId:deliveryId in BUNDLE_ARTIFACTS_KV
		webhooks-->>Provider: 202 after enqueue of KV pointer
	else fits inline
		webhooks-->>Provider: 202 after enqueue of body
	end
	webhooks->>webhooks: hydrate body + json, invoke export
	webhooks->>webhooks: ack queue message, then delete spill
```

### Before / after

```text
before: 1 MB body accepted, then 413 if JSON.stringify(message) > 120 KB
        (body + json duplication made ~70 KB JSON fail)
after:  1 MB body accepted; json reconstructed on consume; oversized body
        spilled to KV; consumer hydrates, acks, then deletes the spill
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23335fd3-90a5-4690-853a-3adc4757915f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23335fd3-90a5-4690-853a-3adc4757915f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Webhook acknowledgements now support larger request bodies without rejecting them due to queue size.
  - Oversized payloads are temporarily stored and restored during delivery.
  - Queue failures now return a temporary-unavailable response (`503`).

- **Bug Fixes**
  - Improved handling of missing or invalid stored payloads, including terminal delivery failure recording.
  - Stored payloads are cleaned up after terminal processing.

- **Documentation**
  - Updated webhook usage and architecture documentation to reflect payload handling and response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->