### PR TITLE
Bind packages.invoke in standalone scheduled jobs

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -184,9 +184,10 @@ The agent-facing package-reuse contract is two rules:
    imports from execute always see the current published version; snapshot
    staleness only affects package-to-package static dependencies.
 2. **Name is data, the call needs the target package's own runtime, or the call
-   needs exactly-once → `packages.invoke`.** Package runtime contexts and
-   authenticated ad hoc execute calls expose it from `kody:runtime`. It is the
-   only dynamic primitive and is always contract-checked before invoking.
+   needs exactly-once → `packages.invoke`.** Package runtime contexts,
+   authenticated ad hoc execute calls, and standalone scheduled jobs expose it
+   from `kody:runtime`. It is the only dynamic primitive and is always
+   contract-checked before invoking.
 
 ```ts
 import { packages } from 'kody:runtime'
@@ -238,10 +239,10 @@ Security and loop safeguards:
 
 - Resolution is same-user only; package code cannot invoke another user's saved
   package.
-- `packages.invoke` requires either package runtime context or authenticated
-  execute context. Static `kody:@...` imports remain library imports in the
-  caller's runtime; use keyless `packages.invoke` when execute needs to enter a
-  package runtime.
+- `packages.invoke` requires package runtime context, authenticated execute
+  context, or a standalone scheduled job. Static `kody:@...` imports remain
+  library imports in the caller's runtime; use keyless `packages.invoke` when
+  execute or a standalone job needs to enter a package runtime.
 - Nested dynamic package invocations are depth-limited to prevent runaway
   package-to-package loops.
 

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -28,10 +28,10 @@ invoke it instead of creating another implementation.
   per call, so static imports from execute always see the current published
   version.
 - Use keyless `packages.invoke({ kodyId, exportName, params })` from an
-  authenticated `execute` call or package runtime when the target's name is data
-  or the call must run in the target package's own runtime (package secret
-  mounts, `packageStorage()`, `packageContext`). Pass `idempotencyKey` only when
-  the call needs exactly-once semantics.
+  authenticated `execute` call, a standalone scheduled job, or package runtime
+  when the target's name is data or the call must run in the target package's
+  own runtime (package secret mounts, `packageStorage()`, `packageContext`).
+  Pass `idempotencyKey` only when the call needs exactly-once semantics.
 
 This is the default for an established operation whose behavior should stay
 owned by its existing capability or package.

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -41,7 +41,8 @@ helpers are runtime exports:
 - use **`import { packageContext } from 'kody:runtime'`** inside saved package
   code when you need package metadata; it is **`null`** for ad hoc execute calls
 - use **`import { packages } from 'kody:runtime'`** inside saved package runtime
-  contexts or authenticated execute calls when a package call must be dynamic:
+  contexts, authenticated execute calls, or standalone scheduled jobs when a
+  package call must be dynamic:
   the target's name is data, the call needs the target package's own runtime, or
   you need exactly-once. `packages.invoke({ kodyId, exportName, params })` (plus
   an optional `idempotencyKey` field for exactly-once calls) is the only dynamic
@@ -209,7 +210,7 @@ but `packageContext` remains **`null`** because the imported module has not been
 entered as its own package runtime. This is fine for most reuse — packages
 backed by user-scope secrets (for example `github`) work fully through plain
 static imports because `{{secret:...}}` placeholders resolve at the fetch
-gateway under the calling user. When execute must enter a saved package export
+gateway under the calling user. When execute or a standalone scheduled job must enter a saved package export
 as that package — package-mounted secrets (`kody.secretMounts`),
 `packageContext`, the package's own `packageStorage()` bucket — use keyless
 `packages.invoke` from `kody:runtime`. It resolves the bare `kodyId`, such as

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -42,15 +42,14 @@ helpers are runtime exports:
   code when you need package metadata; it is **`null`** for ad hoc execute calls
 - use **`import { packages } from 'kody:runtime'`** inside saved package runtime
   contexts, authenticated execute calls, or standalone scheduled jobs when a
-  package call must be dynamic:
-  the target's name is data, the call needs the target package's own runtime, or
-  you need exactly-once. `packages.invoke({ kodyId, exportName, params })` (plus
-  an optional `idempotencyKey` field for exactly-once calls) is the only dynamic
-  call and is always contract-checked before invoking. Pass the bare
-  `package.json#kody.id` as `kodyId` (for example, `github`), not the npm-scoped
-  `package.json.name` (for example, `@kentcdodds/github`). When the target
-  package's name is known when the code is written, use a static `kody:@...`
-  import instead (see below)
+  package call must be dynamic: the target's name is data, the call needs the
+  target package's own runtime, or you need exactly-once.
+  `packages.invoke({ kodyId, exportName, params })` (plus an optional
+  `idempotencyKey` field for exactly-once calls) is the only dynamic call and is
+  always contract-checked before invoking. Pass the bare `package.json#kody.id`
+  as `kodyId` (for example, `github`), not the npm-scoped `package.json.name`
+  (for example, `@kentcdodds/github`). When the target package's name is known
+  when the code is written, use a static `kody:@...` import instead (see below)
 - use **`import thing from 'kody:@scope/my-package/export-name'`** or
   **`import { helper } from 'kody:@scope/my-package/export-name'`** to reuse a
   saved package export by npm-scoped package name. This is **the default for
@@ -210,11 +209,11 @@ but `packageContext` remains **`null`** because the imported module has not been
 entered as its own package runtime. This is fine for most reuse — packages
 backed by user-scope secrets (for example `github`) work fully through plain
 static imports because `{{secret:...}}` placeholders resolve at the fetch
-gateway under the calling user. When execute or a standalone scheduled job must enter a saved package export
-as that package — package-mounted secrets (`kody.secretMounts`),
-`packageContext`, the package's own `packageStorage()` bucket — use keyless
-`packages.invoke` from `kody:runtime`. It resolves the bare `kodyId`, such as
-`my-package`, rather than the npm-scoped package name, such as
+gateway under the calling user. When execute or a standalone scheduled job must
+enter a saved package export as that package — package-mounted secrets
+(`kody.secretMounts`), `packageContext`, the package's own `packageStorage()`
+bucket — use keyless `packages.invoke` from `kody:runtime`. It resolves the bare
+`kodyId`, such as `my-package`, rather than the npm-scoped package name, such as
 `@scope/my-package`.
 
 When you need to edit saved source, prefer the repo-backed workflow in

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -243,9 +243,9 @@ is accepted as an alias.
 
 Package runtime contexts, authenticated ad hoc MCP `execute` calls, and
 standalone scheduled jobs can call `packages.invoke`, and resolution is scoped
-to packages owned by the current authenticated user. Package code does not need to mint or pass
-package-invocation bearer tokens. Nested package invocations are depth-limited
-to prevent runaway loops.
+to packages owned by the current authenticated user. Package code does not need
+to mint or pass package-invocation bearer tokens. Nested package invocations are
+depth-limited to prevent runaway loops.
 
 External trusted clients that must call package exports over HTTP use package
 invocation tokens instead. Before sending a user to create one, agents should

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -241,9 +241,9 @@ The primary identifier is the bare `kodyId`; `kody_id`, `packageId`, and
 `package_id` are accepted aliases. `exportName` is required, and `export_name`
 is accepted as an alias.
 
-Package runtime contexts and authenticated ad hoc MCP `execute` calls can call
-`packages.invoke`, and resolution is scoped to packages owned by the current
-authenticated user. Package code does not need to mint or pass
+Package runtime contexts, authenticated ad hoc MCP `execute` calls, and
+standalone scheduled jobs can call `packages.invoke`, and resolution is scoped
+to packages owned by the current authenticated user. Package code does not need to mint or pass
 package-invocation bearer tokens. Nested package invocations are depth-limited
 to prevent runaway loops.
 
@@ -262,9 +262,10 @@ platform (built-in) dependencies receive no `packageStorage()` grant and the
 call fails closed inside live platform code. `{{secret:...}}` placeholders for
 user-scope secrets still resolve at the fetch gateway under the calling user —
 so secret-backed packages such as `github` work fully via plain static import.
-Use keyless `packages.invoke` from execute when you need to enter a saved
-package as that package so it receives `packageContext`, package-owned storage,
-package-mounted secrets (`kody.secretMounts`), and its own `packages` helper.
+Use keyless `packages.invoke` from execute or a standalone scheduled job when
+you need to enter a saved package as that package so it receives
+`packageContext`, package-owned storage, package-mounted secrets
+(`kody.secretMounts`), and its own `packages` helper.
 
 **Unsupported helpers:** `packages.invokeChecked`, `packages.check`, and literal
 dynamic `import("kody:@...")` are not available. Package publish checks reject

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -2677,6 +2677,17 @@ test('executeJobOnce background execution workflow', async () => {
 				},
 				logs: ['storage helper executed'],
 			})
+		const packageInvocations = await import(
+			'#worker/package-invocations/service.ts'
+		)
+		const executeInvokeSpy = vi.spyOn(
+			packageInvocations,
+			'createExecutePackageInvokeTools',
+		)
+		const runtimeInvokeSpy = vi.spyOn(
+			packageInvocations,
+			'createPackageRuntimeInvokeTools',
+		)
 
 		try {
 			const sessionClient = {
@@ -2772,11 +2783,24 @@ test('executeJobOnce background execution workflow', async () => {
 				}),
 				expect.any(Object),
 				expect.any(Object),
-				expect.any(Object),
+				expect.objectContaining({
+					storageTools: {
+						userId: callerContext.user.userId,
+						storageId: `job:${jobView.id}`,
+						writable: true,
+					},
+					packageInvokeTools: expect.objectContaining({
+						invoke: expect.any(Function),
+					}),
+				}),
 			)
+			expect(executeInvokeSpy).toHaveBeenCalledTimes(1)
+			expect(runtimeInvokeSpy).not.toHaveBeenCalled()
 			repoSessionRpcSpy.mockRestore()
 		} finally {
 			executeSpy.mockRestore()
+			executeInvokeSpy.mockRestore()
+			runtimeInvokeSpy.mockRestore()
 		}
 	}
 
@@ -4369,6 +4393,17 @@ test('executeJobOnce repo session bundling and check policy workflow', async () 
 			await import('#mcp/run-kody-registry.ts'),
 			'runBundledModuleWithRegistry',
 		)
+		const packageInvocations = await import(
+			'#worker/package-invocations/service.ts'
+		)
+		const executeInvokeSpy = vi.spyOn(
+			packageInvocations,
+			'createExecutePackageInvokeTools',
+		)
+		const runtimeInvokeSpy = vi.spyOn(
+			packageInvocations,
+			'createPackageRuntimeInvokeTools',
+		)
 		const bundleSpy = vi.spyOn(
 			await import('#worker/package-runtime/module-graph.ts'),
 			'buildKodyModuleBundle',
@@ -4422,10 +4457,17 @@ test('executeJobOnce repo session bundling and check policy workflow', async () 
 					packageId: 'job-repo-module',
 					kodyId: 'repo-module-job',
 				},
+				packageInvokeTools: expect.objectContaining({
+					invoke: expect.any(Function),
+				}),
 			})
+			expect(runtimeInvokeSpy).toHaveBeenCalledTimes(1)
+			expect(executeInvokeSpy).not.toHaveBeenCalled()
 		} finally {
 			repoSessionRpcSpy.mockRestore()
 			executeSpy.mockRestore()
+			executeInvokeSpy.mockRestore()
+			runtimeInvokeSpy.mockRestore()
 			bundleSpy.mockRestore()
 			loadFilesSpy.mockRestore()
 		}

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -2677,9 +2677,8 @@ test('executeJobOnce background execution workflow', async () => {
 				},
 				logs: ['storage helper executed'],
 			})
-		const packageInvocations = await import(
-			'#worker/package-invocations/service.ts'
-		)
+		const packageInvocations =
+			await import('#worker/package-invocations/service.ts')
 		const executeInvokeSpy = vi.spyOn(
 			packageInvocations,
 			'createExecutePackageInvokeTools',
@@ -4393,9 +4392,8 @@ test('executeJobOnce repo session bundling and check policy workflow', async () 
 			await import('#mcp/run-kody-registry.ts'),
 			'runBundledModuleWithRegistry',
 		)
-		const packageInvocations = await import(
-			'#worker/package-invocations/service.ts'
-		)
+		const packageInvocations =
+			await import('#worker/package-invocations/service.ts')
 		const executeInvokeSpy = vi.spyOn(
 			packageInvocations,
 			'createExecutePackageInvokeTools',

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -444,27 +444,37 @@ async function executePublishedJobArtifact(input: {
 				}
 			: {}),
 	}
+	// Avoid a top-level jobs -> package-invocations cycle during capability
+	// registry initialization. Standalone jobs use the execute invoke path
+	// (same as inline workflows without package context); package-owned jobs
+	// keep package-runtime provenance so nested invoke/events stay in-package.
+	const {
+		createExecutePackageInvokeTools,
+		createPackageEventTools,
+		createPackageRuntimeInvokeTools,
+	} = await import('#worker/package-invocations/service.ts')
+	const sharedInvokeInput = {
+		env: input.env,
+		baseUrl: input.callerContext.baseUrl,
+		callerContext,
+		parentRunRecord: runRecord,
+		packageInvokeDepth: 0,
+		waitUntil: input.waitUntil,
+	}
 	const packageRuntimeTools = packageContext
-		? await (async () => {
-				// Avoid a top-level jobs -> package-invocations cycle during capability
-				// registry initialization.
-				const { createPackageEventTools, createPackageRuntimeInvokeTools } =
-					await import('#worker/package-invocations/service.ts')
-				const sharedInput = {
-					env: input.env,
-					baseUrl: input.callerContext.baseUrl,
-					callerContext,
+		? {
+				packageInvokeTools: createPackageRuntimeInvokeTools({
+					...sharedInvokeInput,
 					packageContext,
-					parentRunRecord: runRecord,
-					packageInvokeDepth: 0,
-					waitUntil: input.waitUntil,
-				}
-				return {
-					packageInvokeTools: createPackageRuntimeInvokeTools(sharedInput),
-					packageEventTools: createPackageEventTools(sharedInput),
-				}
-			})()
-		: null
+				}),
+				packageEventTools: createPackageEventTools({
+					...sharedInvokeInput,
+					packageContext,
+				}),
+			}
+		: {
+				packageInvokeTools: createExecutePackageInvokeTools(sharedInvokeInput),
+			}
 	return await runBundledModuleWithRegistry(
 		input.env,
 		callerContext,

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -1539,7 +1539,7 @@ const unboundRuntimeHelperNextSteps: Record<string, string> = {
 	storage:
 		"If this code belongs to a saved package that owns its data, use `packageStorage()` from 'kody:runtime' inside that package's module instead of ambient `storage`: it always reaches the declaring package's own bucket, in the package's own runtime and when statically imported into another context. Otherwise ambient `storage` is only bound when the call provides durable storage: retry the execute call with a `storageId` to bind a caller-owned bucket. To work with another package's data, call that package's export with keyless `packages.invoke({ kodyId, exportName, params })` so it runs in the package's own runtime context. Code that must also run without storage can guard with `if (storage) { ... }`.",
 	packages:
-		'`packages` is bound for authenticated ad hoc execute calls and saved-package runtime contexts; retry the call as an authenticated user, or guard with `if (packages) { ... }` where dynamic package invocation is optional.',
+		'`packages` is bound for authenticated ad hoc execute calls, standalone scheduled jobs, and saved-package runtime contexts; retry the call as an authenticated user or from a scheduled job, or guard with `if (packages) { ... }` where dynamic package invocation is optional.',
 	events:
 		"`events` is only bound in saved-package runtime contexts that can dispatch package events; call the owning package's export with keyless `packages.invoke` so it runs in that context, or guard with `if (events) { ... }`.",
 	packageSecrets:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Standalone scheduled jobs that wrap `packages.invoke` to enter another package's runtime should work the same way authenticated `execute` and inline workflows already do.

## Summary

- Nightly job `Nightly forecast thermostat ranges` failed with `Cannot read properties of null (reading 'invoke')` because standalone jobs left the optional `kody:runtime` `packages` helper unbound.
- Package-owned jobs already bound `packages` via `createPackageRuntimeInvokeTools`. Standalone jobs now bind `createExecutePackageInvokeTools`, matching inline workflows that have no package context.
- Updated usage, lifecycle, and contributing docs plus the unbound-helper next-steps copy so they list standalone jobs as a `packages.invoke` context.
- Follow-up: oxfmt on the three files Static CI flagged.

## Testing

- `npx vitest run --project node-unit packages/worker/src/jobs/service.node.test.ts` — 19/19 passed, including the extended standalone (`createExecutePackageInvokeTools`) and package-owned (`createPackageRuntimeInvokeTools`) assertions.
- Preview `kody-pr-1583` on merge commit of `c093e6e9`: seed login succeeded; `GET /account/jobs.json` returned `jobs: []` with alarm `idle`; `GET /account/activity.json` returned zero open errors. UI pass: Jobs empty state and Activity 7-day empty errors view both loaded. The account JSON API cannot create standalone jobs or packages, so the invoke-binding path is covered by the node-unit spies plus the production fingerprint.
- Production fingerprint: `job:Nightly forecast thermostat ranges:cannot-read-properties-of-null` on run `9730cc5e-2d59-4094-b007-d251ca26d290`.

Preview: https://kody-pr-1583.kody-a99.workers.dev

![Preview jobs empty state](https://cursor.com/artifacts/c/art-f594816c-3ed9-47e9-a732-b4a5b51b6f65)
![Preview activity empty errors](https://cursor.com/artifacts/c/art-e73dfb6d-9a52-4754-b6d1-d661db647cd6)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `67f3d425` · **Head:** `c093e6e9`

**Classification:** extends — standalone job execution now binds `packages.invoke` using the existing execute invoke path.

### Primitives touched

| Primitive    | Group      | Impact                                                                 |
| ------------ | ---------- | ---------------------------------------------------------------------- |
| `jobs`       | assistant  | extends — standalone jobs bind execute-style `packages.invoke`         |
| `mcp-server` | surfaces   | composes — unbound-`packages` next-steps copy names scheduled jobs     |

### Change flow

A standalone job that calls `packages.invoke` now receives the same execute-style helper inline workflows already bind.

```mermaid
sequenceDiagram
	actor Job as standalone job
	participant jobs as jobs
	participant packageInvocations as package-invocations
	participant capabilitiesExecute as capabilities-execute
	Job->>jobs: scheduled run with packages.invoke
	jobs->>packageInvocations: createExecutePackageInvokeTools when packageContext is absent
	packageInvocations->>capabilitiesExecute: bind packages helper on kody:runtime
	Job->>capabilitiesExecute: packages.invoke enters target package runtime
```

### Before / after

```text
before: standalone job → packageInvokeTools omitted → packages === null
after:  standalone job → createExecutePackageInvokeTools → packages.invoke
        package-owned job → createPackageRuntimeInvokeTools (unchanged)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97643339-41fb-47d0-9f4b-87ad110bf8e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97643339-41fb-47d0-9f4b-87ad110bf8e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone scheduled jobs can now invoke saved package exports and use package runtime tools.
  * Package invocation guidance now covers authenticated executions, scheduled jobs, and package runtimes.

* **Documentation**
  * Updated package, execution, lifecycle, and contribution documentation to explain invocation contexts and when to use dynamic package invocation.

* **Tests**
  * Added coverage verifying the appropriate package invocation tools are available in interactive executions and package runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->