### PR TITLE
Keep account packages search focused after the first keystroke

### DIFF
--- a/packages/worker/client/routes/record-table-search-sync.ts
+++ b/packages/worker/client/routes/record-table-search-sync.ts
@@ -1,0 +1,52 @@
+export type RecordTableSearchSync = {
+	lastExternalValue: string
+	pendingExternalValue: string | null
+}
+
+/**
+ * The reader just typed this string, so the coming URL update is theirs.
+ * Record it as the last applied value and drop any deferred external string
+ * so blur cannot write stale text back into the field.
+ */
+export function acknowledgeRecordTableSearchInput(
+	value: string,
+): RecordTableSearchSync {
+	return { lastExternalValue: value, pendingExternalValue: null }
+}
+
+/**
+ * Reconcile an incoming `value` prop (URL / back-button) with the last
+ * applied or typed string. Focused changes wait for blur; a return to the
+ * last applied value clears a stale pending string instead of keeping it.
+ */
+export function reconcileRecordTableSearchExternalValue(
+	state: RecordTableSearchSync,
+	nextValue: string,
+	focused: boolean,
+): { state: RecordTableSearchSync; applyValue: string | null } {
+	if (nextValue === state.lastExternalValue) {
+		return {
+			state: {
+				lastExternalValue: state.lastExternalValue,
+				pendingExternalValue: null,
+			},
+			applyValue: null,
+		}
+	}
+	if (focused) {
+		return {
+			state: {
+				lastExternalValue: state.lastExternalValue,
+				pendingExternalValue: nextValue,
+			},
+			applyValue: null,
+		}
+	}
+	return {
+		state: {
+			lastExternalValue: nextValue,
+			pendingExternalValue: null,
+		},
+		applyValue: nextValue,
+	}
+}

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -6,6 +6,10 @@ import {
 	RecordTableSearch,
 	type RecordTableColumn,
 } from '#client/routes/record-table.tsx'
+import {
+	acknowledgeRecordTableSearchInput,
+	reconcileRecordTableSearchExternalValue,
+} from '#client/routes/record-table-search-sync.ts'
 
 const columns: Array<RecordTableColumn> = [
 	{ key: 'name', label: 'Name', primary: true },
@@ -152,6 +156,55 @@ test('record table search stays uncontrolled so the first keystroke cannot remou
 	// WebKit cancel-button rules that otherwise appear on the first character.
 	expect(html).toContain('::-webkit-search-cancel-button')
 	expect(html).toContain('display: none')
+})
+
+test('record table search defers focused URL updates and drops a stale pending string', () => {
+	const empty = { lastExternalValue: '', pendingExternalValue: null }
+
+	// A keystroke is user-driven: the coming URL update must not become
+	// pending, or blur would overwrite whatever the reader typed next.
+	const typed = acknowledgeRecordTableSearchInput('ab')
+	expect(
+		reconcileRecordTableSearchExternalValue(typed, 'ab', true),
+	).toEqual({
+		state: { lastExternalValue: 'ab', pendingExternalValue: null },
+		applyValue: null,
+	})
+
+	// Clearing the field returns `q` to the last applied empty string.
+	// Without acknowledging the keystroke, pending would stay "ab" and
+	// blur would write that stale text back.
+	const cleared = acknowledgeRecordTableSearchInput('')
+	expect(
+		reconcileRecordTableSearchExternalValue(cleared, '', true),
+	).toEqual({
+		state: empty,
+		applyValue: null,
+	})
+	expect(
+		reconcileRecordTableSearchExternalValue(
+			{ lastExternalValue: '', pendingExternalValue: 'ab' },
+			'',
+			true,
+		),
+	).toEqual({
+		state: empty,
+		applyValue: null,
+	})
+
+	// Back-button while focused defers until blur; unfocused applies now.
+	expect(
+		reconcileRecordTableSearchExternalValue(typed, '', true),
+	).toEqual({
+		state: { lastExternalValue: 'ab', pendingExternalValue: '' },
+		applyValue: null,
+	})
+	expect(
+		reconcileRecordTableSearchExternalValue(typed, '', false),
+	).toEqual({
+		state: empty,
+		applyValue: '',
+	})
 })
 
 test('record table empty and busy states keep toolbar layout stable', async () => {

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -164,9 +164,7 @@ test('record table search defers focused URL updates and drops a stale pending s
 	// A keystroke is user-driven: the coming URL update must not become
 	// pending, or blur would overwrite whatever the reader typed next.
 	const typed = acknowledgeRecordTableSearchInput('ab')
-	expect(
-		reconcileRecordTableSearchExternalValue(typed, 'ab', true),
-	).toEqual({
+	expect(reconcileRecordTableSearchExternalValue(typed, 'ab', true)).toEqual({
 		state: { lastExternalValue: 'ab', pendingExternalValue: null },
 		applyValue: null,
 	})
@@ -175,9 +173,7 @@ test('record table search defers focused URL updates and drops a stale pending s
 	// Without acknowledging the keystroke, pending would stay "ab" and
 	// blur would write that stale text back.
 	const cleared = acknowledgeRecordTableSearchInput('')
-	expect(
-		reconcileRecordTableSearchExternalValue(cleared, '', true),
-	).toEqual({
+	expect(reconcileRecordTableSearchExternalValue(cleared, '', true)).toEqual({
 		state: empty,
 		applyValue: null,
 	})
@@ -193,15 +189,11 @@ test('record table search defers focused URL updates and drops a stale pending s
 	})
 
 	// Back-button while focused defers until blur; unfocused applies now.
-	expect(
-		reconcileRecordTableSearchExternalValue(typed, '', true),
-	).toEqual({
+	expect(reconcileRecordTableSearchExternalValue(typed, '', true)).toEqual({
 		state: { lastExternalValue: 'ab', pendingExternalValue: '' },
 		applyValue: null,
 	})
-	expect(
-		reconcileRecordTableSearchExternalValue(typed, '', false),
-	).toEqual({
+	expect(reconcileRecordTableSearchExternalValue(typed, '', false)).toEqual({
 		state: empty,
 		applyValue: '',
 	})

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -3,6 +3,7 @@ import { renderToString } from 'remix/ui/server'
 import { expect, test } from 'vitest'
 import {
 	RecordTable,
+	RecordTableSearch,
 	type RecordTableColumn,
 } from '#client/routes/record-table.tsx'
 
@@ -131,6 +132,26 @@ test('record table keeps container drops, row links, and expand/pane selection c
 	)
 	expect(overflowHtml).toContain('overflow-x: auto')
 	expect(overflowHtml).toContain('overflow: clip')
+})
+
+test('record table search stays uncontrolled so the first keystroke cannot remount it', async () => {
+	const html = await renderToString(
+		jsx(RecordTableSearch, {
+			label: 'Search packages',
+			placeholder: 'Search by name, id, description, or tag',
+			value: '',
+			onInput() {},
+		}),
+	)
+
+	expect(html).toContain('type="search"')
+	expect(html).toContain('aria-label="Search packages"')
+	// Passing `value` makes Remix restore the previous query on `input` and
+	// drop focus. `defaultValue` serializes as the HTML value attribute, so
+	// the client contract is "no controlled value prop" — pinned here by the
+	// WebKit cancel-button rules that otherwise appear on the first character.
+	expect(html).toContain('::-webkit-search-cancel-button')
+	expect(html).toContain('display: none')
 })
 
 test('record table empty and busy states keep toolbar layout stable', async () => {

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -14,6 +14,11 @@ import {
 	getSurfaceCardCss,
 	hoverMq,
 } from '#universal/styles/style-primitives.ts'
+import {
+	acknowledgeRecordTableSearchInput,
+	reconcileRecordTableSearchExternalValue,
+	type RecordTableSearchSync,
+} from './record-table-search-sync.ts'
 
 /*
  * The account and admin list/detail screens, as one table.
@@ -321,7 +326,10 @@ const footerCss = {
  * previous (empty) query, and WebKit's search cancel control appears on that
  * same keystroke — either one drops focus and the reader has to click back in.
  * The field stays uncontrolled. URL/back-button updates apply immediately
- * when it is not focused, and on blur if they arrived while it was.
+ * when it is not focused, and on blur if they arrived while it was. A
+ * keystroke records the typed string as the last applied value so a later
+ * render that returns `q` to that value (clear, or back to the same query)
+ * cannot leave a stale pending string for blur to write back.
  */
 const searchCancelHiddenCss = {
 	'&::-webkit-search-decoration': {
@@ -353,24 +361,26 @@ export function RecordTableSearch(
 ) {
 	let input: HTMLInputElement | null = null
 	const initialValue = handle.props.value
-	let lastExternalValue = initialValue
-	let pendingExternalValue: string | null = null
+	let sync: RecordTableSearchSync = {
+		lastExternalValue: initialValue,
+		pendingExternalValue: null,
+	}
 
 	function applyExternalValue(nextValue: string) {
 		if (input) input.value = nextValue
-		lastExternalValue = nextValue
-		pendingExternalValue = null
+		sync = acknowledgeRecordTableSearchInput(nextValue)
 	}
 
 	return () => {
 		const nextValue = handle.props.value
-		if (nextValue !== lastExternalValue) {
-			if (input && document.activeElement === input) {
-				pendingExternalValue = nextValue
-			} else {
-				applyExternalValue(nextValue)
-			}
-		}
+		const focused = Boolean(input && document.activeElement === input)
+		const reconciled = reconcileRecordTableSearchExternalValue(
+			sync,
+			nextValue,
+			focused,
+		)
+		sync = reconciled.state
+		if (reconciled.applyValue !== null) applyExternalValue(reconciled.applyValue)
 		return (
 			<input
 				type="search"
@@ -385,14 +395,14 @@ export function RecordTableSearch(
 							if (input === node) input = null
 						})
 					}),
-					on('input', (event) =>
-						handle.props.onInput(
-							(event.currentTarget as HTMLInputElement).value,
-						),
-					),
+					on('input', (event) => {
+						const value = (event.currentTarget as HTMLInputElement).value
+						sync = acknowledgeRecordTableSearchInput(value)
+						handle.props.onInput(value)
+					}),
 					on('blur', () => {
-						if (pendingExternalValue !== null) {
-							applyExternalValue(pendingExternalValue)
+						if (sync.pendingExternalValue !== null) {
+							applyExternalValue(sync.pendingExternalValue)
 						}
 					}),
 					css({

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -380,7 +380,8 @@ export function RecordTableSearch(
 			focused,
 		)
 		sync = reconciled.state
-		if (reconciled.applyValue !== null) applyExternalValue(reconciled.applyValue)
+		if (reconciled.applyValue !== null)
+			applyExternalValue(reconciled.applyValue)
 		return (
 			<input
 				type="search"

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -320,8 +320,8 @@ const footerCss = {
  * Remix-controlled `value` lets the first character schedule a restore of the
  * previous (empty) query, and WebKit's search cancel control appears on that
  * same keystroke — either one drops focus and the reader has to click back in.
- * The field stays uncontrolled; URL/back-button updates land only while it is
- * not focused.
+ * The field stays uncontrolled. URL/back-button updates apply immediately
+ * when it is not focused, and on blur if they arrived while it was.
  */
 const searchCancelHiddenCss = {
 	'&::-webkit-search-decoration': {
@@ -354,13 +354,21 @@ export function RecordTableSearch(
 	let input: HTMLInputElement | null = null
 	const initialValue = handle.props.value
 	let lastExternalValue = initialValue
+	let pendingExternalValue: string | null = null
+
+	function applyExternalValue(nextValue: string) {
+		if (input) input.value = nextValue
+		lastExternalValue = nextValue
+		pendingExternalValue = null
+	}
 
 	return () => {
 		const nextValue = handle.props.value
 		if (nextValue !== lastExternalValue) {
-			lastExternalValue = nextValue
-			if (input && document.activeElement !== input) {
-				input.value = nextValue
+			if (input && document.activeElement === input) {
+				pendingExternalValue = nextValue
+			} else {
+				applyExternalValue(nextValue)
 			}
 		}
 		return (
@@ -382,6 +390,11 @@ export function RecordTableSearch(
 							(event.currentTarget as HTMLInputElement).value,
 						),
 					),
+					on('blur', () => {
+						if (pendingExternalValue !== null) {
+							applyExternalValue(pendingExternalValue)
+						}
+					}),
 					css({
 						...getAuthInputCss(),
 						flex: '1 1 12rem',

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -1,4 +1,4 @@
-import { css, type Handle } from 'remix/ui'
+import { css, ref, type Handle } from 'remix/ui'
 import { shouldRouterHandleClick } from '#client/client-router.tsx'
 import { on } from '#client/event-mixin.ts'
 import {
@@ -315,6 +315,34 @@ const footerCss = {
  * they cost 48px, so the label becomes the control's accessible name.
  */
 
+/**
+ * Live filter fields write the query into the URL on every keystroke. A
+ * Remix-controlled `value` lets the first character schedule a restore of the
+ * previous (empty) query, and WebKit's search cancel control appears on that
+ * same keystroke — either one drops focus and the reader has to click back in.
+ * The field stays uncontrolled; URL/back-button updates land only while it is
+ * not focused.
+ */
+const searchCancelHiddenCss = {
+	'&::-webkit-search-decoration': {
+		WebkitAppearance: 'none',
+		appearance: 'none',
+	},
+	'&::-webkit-search-cancel-button': {
+		WebkitAppearance: 'none',
+		appearance: 'none',
+		display: 'none',
+	},
+	'&::-webkit-search-results-button': {
+		WebkitAppearance: 'none',
+		appearance: 'none',
+	},
+	'&::-webkit-search-results-decoration': {
+		WebkitAppearance: 'none',
+		appearance: 'none',
+	},
+} as const
+
 export function RecordTableSearch(
 	handle: Handle<{
 		label: string
@@ -323,26 +351,48 @@ export function RecordTableSearch(
 		onInput: (value: string) => void
 	}>,
 ) {
-	return () => (
-		<input
-			type="search"
-			data-field-ring
-			value={handle.props.value}
-			placeholder={handle.props.placeholder}
-			aria-label={handle.props.label}
-			mix={[
-				on('input', (event) =>
-					handle.props.onInput((event.currentTarget as HTMLInputElement).value),
-				),
-				css({
-					...getAuthInputCss(),
-					flex: '1 1 12rem',
-					minWidth: '7rem',
-					width: 'auto',
-				}),
-			]}
-		/>
-	)
+	let input: HTMLInputElement | null = null
+	const initialValue = handle.props.value
+	let lastExternalValue = initialValue
+
+	return () => {
+		const nextValue = handle.props.value
+		if (nextValue !== lastExternalValue) {
+			lastExternalValue = nextValue
+			if (input && document.activeElement !== input) {
+				input.value = nextValue
+			}
+		}
+		return (
+			<input
+				type="search"
+				data-field-ring
+				defaultValue={initialValue}
+				placeholder={handle.props.placeholder}
+				aria-label={handle.props.label}
+				mix={[
+					ref((node, signal) => {
+						input = node as HTMLInputElement
+						signal.addEventListener('abort', () => {
+							if (input === node) input = null
+						})
+					}),
+					on('input', (event) =>
+						handle.props.onInput(
+							(event.currentTarget as HTMLInputElement).value,
+						),
+					),
+					css({
+						...getAuthInputCss(),
+						flex: '1 1 12rem',
+						minWidth: '7rem',
+						width: 'auto',
+						...searchCancelHiddenCss,
+					}),
+				]}
+			/>
+		)
+	}
 }
 
 export function RecordTableSelect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Typing in `/account/packages` search should keep the caret in the field. The first character was dropping focus, so you had to click back in before continuing.

## Summary

- `RecordTableSearch` is no longer a Remix-controlled `value` field. The first keystroke used to write `?q=` into the URL, restore the previous empty query, and reveal WebKit's search cancel control — any of those dropped focus.
- The input stays uncontrolled (`defaultValue` plus a ref). URL / back-button updates apply immediately when the field is not focused, and on blur if they arrived while it was.
- A keystroke records the typed string as the last applied value so clearing the field or backing to the same `q` cannot leave a stale pending string for blur to write back.
- WebKit search-cancel chrome is hidden so the first character does not recreate the inner field.
- Shared by every account/admin `RecordTable` search, including packages.

## Testing

- `npx vitest run packages/worker/client/routes/record-table.node.test.ts --project node-unit`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `17b0fbf4` · **Head:** `1929e1a5`

**Classification:** composes — no primitives added or changed; this PR keeps the existing URL-backed table search and fixes how the shared search field holds focus and syncs after blur.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — `RecordTableSearch` stays the same control; only its focus/value wiring changes |

### Change flow

The packages (and other table) search field writes `q` into the URL on input without remounting, defers a different URL value until blur, and drops a stale pending string when `q` returns to the last typed value.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: type in RecordTableSearch
	appUi->>appUi: acknowledge typed value as last applied
	appUi->>appUi: replaceLocation ?q=
	Note over appUi: uncontrolled input; no WebKit cancel chrome
	User->>appUi: back or clear returns q to last applied
	appUi->>appUi: drop stale pending string
	User->>appUi: blur after a different URL q
	appUi->>appUi: apply deferred external value
	appUi-->>User: caret stays; field matches URL after blur
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55cde936-db09-45fe-83c0-855c79d91587?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55cde936-db09-45fe-83c0-855c79d91587&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved record-table search synchronization when navigating or receiving URL-provided updates.
  - Preserved in-progress search text while the field is focused, applying external changes after the field loses focus.
  - Ensured newly entered search text takes precedence over stale pending updates.
  - Removed browser-provided search decorations and cancel controls for a more consistent interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->