### PR TITLE
fix(package-apps): advertise connected MCP servers on kody.mcp

### DIFF
--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -39,7 +39,9 @@ async function extractCreateKodyProxySource() {
 		new URL('./package-app.ts', import.meta.url),
 		'utf8',
 	)
-	const start = sourceText.indexOf('function createKodyProxy(runtimeBridge) {')
+	const start = sourceText.indexOf(
+		'function createKodyProxy(runtimeBridge, mcpServerNames) {',
+	)
 	const end = sourceText.indexOf('\nfunction createRealtimeProxy', start)
 	if (start < 0 || end < 0) {
 		throw new Error('createKodyProxy source was not found.')
@@ -49,13 +51,24 @@ async function extractCreateKodyProxySource() {
 		.replaceAll('\\\\', '\\')
 		.replaceAll('\\`', '`')
 		.replaceAll('\\${', '${')
-	return `${proxySource}; return createKodyProxy(runtimeBridge);`
+	return `${proxySource}; return createKodyProxy(runtimeBridge, mcpServerNames);`
 }
 
-async function createKodyProxyForTest(runtimeBridge: unknown) {
-	return new Function('runtimeBridge', await extractCreateKodyProxySource())(
-		runtimeBridge,
-	) as Record<string, unknown>
+async function createKodyProxyForTest(
+	runtimeBridge: unknown,
+	mcpServerNames: Array<string> = [],
+) {
+	return new Function(
+		'runtimeBridge',
+		'mcpServerNames',
+		await extractCreateKodyProxySource(),
+	)(runtimeBridge, mcpServerNames) as Record<string, unknown>
+}
+
+/** Workerd-style: [[OwnPropertyKeys]] then GOPD.value (not plain Get). */
+function getViaOwnKeysThenGopd(target: object, name: string): unknown {
+	if (!Reflect.ownKeys(target).includes(name)) return undefined
+	return Reflect.getOwnPropertyDescriptor(target, name)?.value
 }
 
 async function createWorkflowsProxyForTest(runtimeBridge: unknown) {
@@ -216,6 +229,49 @@ test('package app kody proxy supports mcp namespace calls', async () => {
 		Record<string, (args: unknown) => Promise<unknown>>
 	>
 	await expect(home.set_pin({ pin: '9' })).resolves.toEqual({ ok: true })
+})
+
+test('package app kody.mcp advertises connected server names for Workerd destructuring', async () => {
+	const calls: Array<{ name: string; args: unknown }> = []
+	const runtimeBridge = {
+		callCapability: async (input: { name: string; args: unknown }) => {
+			calls.push(input)
+			return { ok: true }
+		},
+	}
+
+	const withoutNames = await createKodyProxyForTest(runtimeBridge)
+	expect(Reflect.ownKeys(withoutNames.mcp as object)).toEqual([])
+	expect(getViaOwnKeysThenGopd(withoutNames.mcp as object, 'home')).toBe(
+		undefined,
+	)
+	// Get stays open even when ownKeys is empty (Node destructure uses Get).
+	await expect(
+		(
+			(
+				withoutNames.mcp as Record<
+					string,
+					Record<string, (args: unknown) => Promise<unknown>>
+				>
+			)['home'] as Record<string, (args: unknown) => Promise<unknown>>
+		).set_pin({ pin: '1' }),
+	).resolves.toEqual({ ok: true })
+
+	const withNames = await createKodyProxyForTest(runtimeBridge, [
+		'home',
+		'mediarss',
+	])
+	expect(Reflect.ownKeys(withNames.mcp as object)).toEqual(['home', 'mediarss'])
+	const home = getViaOwnKeysThenGopd(withNames.mcp as object, 'home') as Record<
+		string,
+		(args: unknown) => Promise<unknown>
+	>
+	expect(home).toBeTypeOf('object')
+	await expect(home.set_pin({ pin: '2' })).resolves.toEqual({ ok: true })
+	expect(calls).toEqual([
+		{ name: 'mcp:home:set_pin', args: { pin: '1' } },
+		{ name: 'mcp:home:set_pin', args: { pin: '2' } },
+	])
 })
 
 test('package app workflows proxy validates input and forwards to the runtime bridge', async () => {

--- a/packages/worker/src/package-runtime/package-app.node.test.ts
+++ b/packages/worker/src/package-runtime/package-app.node.test.ts
@@ -274,6 +274,22 @@ test('package app kody.mcp advertises connected server names for Workerd destruc
 	])
 })
 
+test('package app kody.mcp ownKeys dedupes duplicate server names', async () => {
+	const kody = await createKodyProxyForTest(
+		{
+			callCapability: async () => ({ ok: true }),
+		},
+		['home', 'home', 'mediarss'],
+	)
+	expect(Reflect.ownKeys(kody.mcp as object)).toEqual(['home', 'mediarss'])
+	const home = getViaOwnKeysThenGopd(kody.mcp as object, 'home') as Record<
+		string,
+		(args: unknown) => Promise<unknown>
+	>
+	expect(home).toBeTypeOf('object')
+	await expect(home.set_pin({ pin: '3' })).resolves.toEqual({ ok: true })
+})
+
 test('package app workflows proxy validates input and forwards to the runtime bridge', async () => {
 	const workflows = await createWorkflowsProxyForTest({
 		workflowCreate: async (input: unknown) => input,

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -13,6 +13,7 @@ import {
 	type PackageInvokeTools,
 } from '#mcp/run-kody-registry.ts'
 import { getCapabilityRegistryForContext } from '#mcp/capabilities/registry.ts'
+import { listEnabledMcpServerRefsCached } from '#worker/mcp-client/settings-service.ts'
 import {
 	createAuthenticatedFetch,
 	refreshAccessToken,
@@ -120,7 +121,7 @@ function buildFacetClassExportName(rawFacetName) {
 		: \`App_\${sanitizedFacetName}_\${hashSuffix}\`;
 }
 
-function createKodyProxy(runtimeBridge) {
+function createKodyProxy(runtimeBridge, mcpServerNames) {
 	const isProxyLookupKey = (name) =>
 		typeof name !== 'string' || name === 'then';
 	const createOpenNamespaceProxy = (getValue) =>
@@ -142,7 +143,43 @@ function createKodyProxy(runtimeBridge) {
 				};
 			},
 		});
-	const mcp = createOpenNamespaceProxy((serverName) =>
+	// Workerd destructures \`const { home } = kody.mcp\` via ownKeys then
+	// GOPD. Advertise connected server names so home is not undefined.
+	// Empty/missing names stay open (GOPD still returns getValue) so a
+	// listing failure does not hide Get. Only a non-empty list restricts
+	// has/GOPD. Tool namespaces stay fully open.
+	const knownServerNames = Array.isArray(mcpServerNames)
+		? mcpServerNames.filter((name) => typeof name === 'string')
+		: [];
+	const restrictServerKeys = knownServerNames.length > 0;
+	const createMcpServerNamespaceProxy = (getValue) =>
+		new Proxy({}, {
+			get(_target, name) {
+				if (isProxyLookupKey(name)) return undefined;
+				return getValue(name);
+			},
+			has(_target, name) {
+				if (isProxyLookupKey(name)) return false;
+				if (!restrictServerKeys) return true;
+				return knownServerNames.includes(name);
+			},
+			ownKeys() {
+				return [...knownServerNames];
+			},
+			getOwnPropertyDescriptor(_target, name) {
+				if (isProxyLookupKey(name)) return undefined;
+				if (restrictServerKeys && !knownServerNames.includes(name)) {
+					return undefined;
+				}
+				return {
+					configurable: true,
+					enumerable: true,
+					writable: true,
+					value: getValue(name),
+				};
+			},
+		});
+	const mcp = createMcpServerNamespaceProxy((serverName) =>
 		createOpenNamespaceProxy((toolName) => async (args = {}) =>
 			await runtimeBridge.callCapability({
 				name: \`mcp:\${serverName}:\${toolName}\`,
@@ -453,7 +490,7 @@ function createPackageAppEnv(env, userModule) {
 	return runtimeEnv;
 }
 
-function createRuntime(runtimeBridge, packageContext) {
+function createRuntime(runtimeBridge, packageContext, mcpServerNames) {
 	const packageId = packageContext?.packageId ?? '';
 	const packageSecrets =
 		packageId.length > 0
@@ -471,7 +508,7 @@ function createRuntime(runtimeBridge, packageContext) {
 					},
 				}
 	return {
-		kody: createKodyProxy(runtimeBridge),
+		kody: createKodyProxy(runtimeBridge, mcpServerNames),
 		storage: undefined,
 		__kodyPackageStorage: (storagePackageId) => ({
 			id: 'package:' + encodeURIComponent(storagePackageId),
@@ -656,9 +693,11 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 			},
 		});
 		const consoleCapture = createConsoleLogCapture();
+		const mcpServerNames = await runtimeBridge.listMcpServerNames().catch(() => []);
 		const runtime = createRuntime(
 			runtimeBridge,
 			this.env.__kodyPackageContext ?? null,
+			mcpServerNames,
 		);
 		try {
 			consoleCapture.install();
@@ -711,9 +750,11 @@ export class ${packageAppEntrypointName} extends WorkerEntrypoint {
 			},
 		});
 		const consoleCapture = createConsoleLogCapture();
+		const mcpServerNames = await runtimeBridge.listMcpServerNames().catch(() => []);
 		const runtime = createRuntime(
 			runtimeBridge,
 			this.env.__kodyPackageContext ?? null,
+			mcpServerNames,
 		);
 		try {
 			consoleCapture.install();
@@ -962,6 +1003,18 @@ export class PackageAppRuntimeBridge extends WorkerEntrypoint<
 		})
 		this.ctx.waitUntil(finishPromise)
 		return { ok: true }
+	}
+
+	async listMcpServerNames(): Promise<Array<string>> {
+		try {
+			const refs = await listEnabledMcpServerRefsCached({
+				env: this.env,
+				userId: this.ctx.props.userId,
+			})
+			return refs.map((ref) => ref.name)
+		} catch {
+			return []
+		}
 	}
 
 	async callCapability(input: { name: string; args?: unknown }) {

--- a/packages/worker/src/package-runtime/package-app.ts
+++ b/packages/worker/src/package-runtime/package-app.ts
@@ -149,7 +149,7 @@ function createKodyProxy(runtimeBridge, mcpServerNames) {
 	// listing failure does not hide Get. Only a non-empty list restricts
 	// has/GOPD. Tool namespaces stay fully open.
 	const knownServerNames = Array.isArray(mcpServerNames)
-		? mcpServerNames.filter((name) => typeof name === 'string')
+		? [...new Set(mcpServerNames.filter((name) => typeof name === 'string' && name.length > 0))]
 		: [];
 	const restrictServerKeys = knownServerNames.length > 0;
 	const createMcpServerNamespaceProxy = (getValue) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop package apps from seeing `kody.mcp.home` as missing when Workerd rewrites tool access into `const { home } = kody.mcp`. Execute and static import already worked; package-app `createKodyProxy` did not advertise connected server names via `ownKeys`/`GOPD`.

## Summary

- `createKodyProxy(runtimeBridge, mcpServerNames)` keeps open `[[Get]]` for tools and servers; when names are non-empty, the MCP server namespace advertises them via `ownKeys` / `has` / `GOPD`.
- Empty/missing names stay open so a listing failure does not hide `[[Get]]` (documents the prior Workerd hole).
- Duplicate and empty server names are Set-deduped before `ownKeys` so `Reflect.ownKeys` cannot throw TypeError.
- `PackageAppWorker` fetch and `handleRealtimeEvent` load names via `runtimeBridge.listMcpServerNames()` (from `listEnabledMcpServerRefsCached`) and pass them into `createRuntime`.
- No shade-automation / home-controls / packages.invoke fallback; execute/package-export proxies unchanged.

## Testing

- `npx vitest run packages/worker/src/package-runtime/package-app.node.test.ts --project node-unit` — 16 tests passed (Workerd-style ownKeys+GOPD coverage, including duplicate-name dedupe).
- `npm run typecheck` — passed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `17b0fbf4` · **Head:** `58765c55`

**Classification:** extends — package-app `kody.mcp` now advertises connected MCP server names so Workerd destructuring binds real server proxies instead of `undefined`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `package-apps` | assistant | extends — `createKodyProxy`/`createRuntime` take `mcpServerNames`; fetch/realtime list names before building runtime; ownKeys dedupes names |
| `package-runtime` | runtime | extends — `PackageAppRuntimeBridge.listMcpServerNames()` |
| `mcp-server` | surfaces | composes — reads enabled server names via `listEnabledMcpServerRefsCached` |

### Change flow

Package-app fetch loads enabled MCP server names, then builds a `kody.mcp` proxy that Workerd can destructure.

```mermaid
sequenceDiagram
	actor PackageApp as package app
	participant packageApps as package-apps
	participant packageRuntime as package-runtime
	participant mcpServer as mcp-server
	PackageApp->>packageApps: fetch / handleRealtimeEvent
	packageApps->>packageRuntime: listMcpServerNames()
	packageRuntime->>mcpServer: listEnabledMcpServerRefsCached
	mcpServer-->>packageRuntime: enabled server names
	packageRuntime-->>packageApps: mcpServerNames
	packageApps->>packageApps: createKodyProxy(..., mcpServerNames)
	Note over packageApps: ownKeys/has/GOPD advertise deduped names
	PackageApp->>packageApps: const { home } = kody.mcp
	packageApps-->>PackageApp: home proxy (not undefined)
	PackageApp->>packageRuntime: home.bond_shade_set_position(...)
	packageRuntime->>mcpServer: callCapability mcp:home:...
```

### Before / after

**Before:** `createKodyProxy` used an open get-only `kody.mcp` with no `ownKeys`. Workerd `const { home } = kody.mcp` bound `undefined` → `Cannot read properties of undefined (reading 'bond_shade_set_position')`.

**After:** Non-empty enabled server names are advertised on `kody.mcp` (deduped), so Workerd GOPD returns the server namespace proxy. Empty listing keeps open Get (Node-style) without pretending servers exist on `ownKeys`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1ecea29-1747-4e84-adb9-3b361f00bd70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1ecea29-1747-4e84-adb9-3b361f00bd70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP namespaces now display connected server names for easier discovery.
  * MCP server calls continue to support dynamic access and are routed through the runtime bridge.

* **Bug Fixes**
  * Improved MCP server name retrieval, including graceful handling when discovery is unavailable or fails.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->