### PR TITLE
Replace doddsfamily.us examples with home.example.com

### DIFF
--- a/docs/guides/local-mcp-tunnels.md
+++ b/docs/guides/local-mcp-tunnels.md
@@ -81,10 +81,10 @@ context, the MCP server authenticates Kody, and Access protects the browser
 approval step. Do not copy route names from another server without checking your
 implementation's OAuth metadata and endpoint paths.
 
-The reference `mcp:home` connector uses `https://kody-home.doddsfamily.us/mcp`
+The reference `mcp:home` connector uses `https://home.example.com/mcp`
 as its resource server. Its protected resource metadata lives at
 `/.well-known/oauth-protected-resource/mcp` and identifies
-`https://kody-home.doddsfamily.us` as the authorization server. That server's
+`https://home.example.com` as the authorization server. That server's
 `/.well-known/oauth-authorization-server` document advertises `/authorize`,
 `/token`, and `/revoke`. Access protects the browser-facing `/authorize` route;
 the metadata routes, `/mcp`, `/token`, and `/revoke` reach the MCP server, which

--- a/docs/guides/local-mcp-tunnels.md
+++ b/docs/guides/local-mcp-tunnels.md
@@ -81,8 +81,8 @@ context, the MCP server authenticates Kody, and Access protects the browser
 approval step. Do not copy route names from another server without checking your
 implementation's OAuth metadata and endpoint paths.
 
-The reference `mcp:home` connector uses `https://home.example.com/mcp`
-as its resource server. Its protected resource metadata lives at
+The reference `mcp:home` connector uses `https://home.example.com/mcp` as its
+resource server. Its protected resource metadata lives at
 `/.well-known/oauth-protected-resource/mcp` and identifies
 `https://home.example.com` as the authorization server. That server's
 `/.well-known/oauth-authorization-server` document advertises `/authorize`,

--- a/docs/use/mcp-client-servers.md
+++ b/docs/use/mcp-client-servers.md
@@ -62,11 +62,11 @@ enough for the remote server.
 ## Home automation
 
 Household LAN tools (lights, TVs, thermostats, and the rest of the home process)
-are a normal outbound MCP server at `https://kody-home.doddsfamily.us/mcp`
-(Dodds Vault Cloudflare tunnel; Access bypasses `/mcp` and the OAuth machine
-paths). Add it as `home`, pass Cloudflare Access on `/authorize`, and approve.
-The LAN origin is trusted and has no extra login. Then call
-`kody.mcp["home"].tool_name(...)`.
+are a normal outbound MCP server at a tunneled HTTPS URL such as
+`https://home.example.com/mcp` (Cloudflare tunnel; Access bypasses `/mcp` and
+the OAuth machine paths). Add it as `home`, pass Cloudflare Access on
+`/authorize`, and approve. The LAN origin is trusted and has no extra login.
+Then call `kody.mcp["home"].tool_name(...)`.
 
 ## Related
 

--- a/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
+++ b/packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts
@@ -594,7 +594,7 @@ test('addServer returns the recovered ready connection after a lightweight retry
 	const result = await hub.addServer({
 		serverId: 'server-1',
 		name: 'home',
-		url: 'https://kody-home.doddsfamily.us/mcp',
+		url: 'https://home.example.com/mcp',
 		callbackUrl,
 	})
 	expect(result.state).toBe('ready')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop using the personal `doddsfamily.us` hostname in repository examples so docs and tests do not point at a private family domain.

## Summary

- Usage and local MCP tunnel docs now use `https://home.example.com/mcp` (the same generic hostname the tunnel guide already used earlier).
- The hub OAuth recovery fixture uses that same example URL.
- A repo-wide search finds no remaining `doddsfamily.us` references.

## Testing

- `npx vitest run --project node-unit packages/worker/src/mcp-client/hub-oauth-recovery.node.test.ts` — 9/9 passed.
- `npm run format:check` — clean after wrapping the tunnel-guide paragraph that failed Static.
- Repo-wide `doddsfamily` / `doddsfamily.us` search is empty.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `17b0fbf4` · **Head:** `06209500`

**Classification:** composes — no primitives added or changed; this PR only swaps example hostnames in docs and a fixture.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-client-servers` | assistant | composes — fixture URL only |

Unmatched paths are usage/guide docs for the same MCP client flow.

### Change flow

Home-automation examples and the recovery fixture now cite `home.example.com` instead of the personal hostname.

```mermaid
sequenceDiagram
	actor Reader
	participant usageDocs as usage docs
	participant tunnelGuide as tunnel guide
	participant mcpClientServers as mcp-client-servers
	Reader->>usageDocs: read home automation example
	usageDocs->>tunnelGuide: cite https://home.example.com/mcp
	Reader->>mcpClientServers: addServer uses the same example URL
	Note over usageDocs,mcpClientServers: doddsfamily.us removed
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Usage + tunnel docs, recovery fixture | `https://kody-home.doddsfamily.us/mcp` | `https://home.example.com/mcp` |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af50086b-7c18-4cc1-8d8d-11f8d25261b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af50086b-7c18-4cc1-8d8d-11f8d25261b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP OAuth and Home automation examples to use generic HTTPS URLs.
  * Preserved existing Cloudflare Access, OAuth approval, trusted network, and tool invocation guidance.

* **Tests**
  * Updated the MCP server recovery test fixture to use the generic example URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->