### PR TITLE
Autofocus the secret value on prefilled /new links

### DIFF
--- a/docs/guides/account-secret-setup.md
+++ b/docs/guides/account-secret-setup.md
@@ -35,6 +35,9 @@ Provide the user a URL like:
 
 `https://<your-kody-origin>/account/secrets/new?name=exampleApiKey&description=Example%20API%20key&allowedHosts=api.example.com&scope=user&allowedCapabilities=example_capability&allowedPackages=pkg_123`
 
+When `name` is present, the page focuses and scrolls to the secret value input
+so the user can paste immediately.
+
 ## Query params
 
 | Param                 | Required | Description                                                                                                                |

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -50,6 +50,10 @@ import {
 	getPillButtonCss,
 	getSelectCss,
 } from '#universal/styles/style-primitives.ts'
+import {
+	getNewSecretQueryKey,
+	getNewSecretValueAutofocusKey,
+} from './new-secret-query.ts'
 import { SecretEditorFields } from './secret-editor-fields.tsx'
 import {
 	normalizeAllowedCapabilities,
@@ -179,27 +183,6 @@ function createEditorStateFromNewSecretQuery(
 				? allowedPackages
 				: state.allowedPackages,
 	}
-}
-
-function getNewSecretQueryKey(href: string) {
-	const url = new URL(href, 'http://localhost')
-	if (url.pathname !== `${secretsBasePath}/new`) return ''
-	const keys = [
-		'name',
-		'description',
-		'scope',
-		'packageId',
-		'allowedHosts',
-		'allowed-host',
-		'allowedCapabilities',
-		'capability',
-		'allowedPackages',
-		'package_id',
-		'package',
-	]
-	return keys
-		.map((key) => `${key}=${url.searchParams.getAll(key).join('\u0000')}`)
-		.join('&')
 }
 
 function coerceStringRows(list: Array<unknown>): Array<string> {
@@ -1015,6 +998,7 @@ export function AccountSecretsRoute(handle: Handle) {
 		const isMutating = saveState !== 'idle' || submittingApprovalAction != null
 		const canCreatePackageSecrets = packageOptions.length > 0
 		const showEditor = selection.isCreating || selectedSecret != null
+		const secretValueAutofocusKey = getNewSecretValueAutofocusKey(currentHref)
 		const alreadyAddedNotice = getAlreadyAddedNotice({
 			href: currentHref,
 			selectedSecret,
@@ -1507,6 +1491,7 @@ export function AccountSecretsRoute(handle: Handle) {
 								) : null}
 
 								<SecretEditorFields
+									autoFocusKey={secretValueAutofocusKey}
 									description={editorState.description}
 									onDescriptionChange={(description) => {
 										editorState = {

--- a/packages/worker/client/routes/new-secret-query.node.test.ts
+++ b/packages/worker/client/routes/new-secret-query.node.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest'
+import {
+	getNewSecretQueryKey,
+	getNewSecretValueAutofocusKey,
+} from './new-secret-query.ts'
+
+test('prefilled /new?name=... keys autofocus on the secret value', () => {
+	expect(getNewSecretValueAutofocusKey('/account/secrets')).toBe('')
+	expect(getNewSecretValueAutofocusKey('/account/secrets/new')).toBe('')
+	expect(getNewSecretValueAutofocusKey('/account/secrets/new?name=%20')).toBe(
+		'',
+	)
+	expect(
+		getNewSecretValueAutofocusKey(
+			'/account/secrets/new?description=Bot%20token&allowedHosts=discord.com',
+		),
+	).toBe('')
+
+	const prefilled =
+		'/account/secrets/new?name=discordBotTokenKodyOfficial&description=Discord%20bot%20token&allowedHosts=discord.com&scope=user'
+	expect(getNewSecretValueAutofocusKey(prefilled)).toBe(
+		getNewSecretQueryKey(prefilled),
+	)
+	expect(getNewSecretValueAutofocusKey(prefilled).length).toBeGreaterThan(0)
+	expect(getNewSecretValueAutofocusKey(`${prefilled}&q=unrelated-filter`)).toBe(
+		getNewSecretQueryKey(prefilled),
+	)
+})

--- a/packages/worker/client/routes/new-secret-query.ts
+++ b/packages/worker/client/routes/new-secret-query.ts
@@ -1,0 +1,35 @@
+import { readTrimmedParam } from '#client/url-params.ts'
+
+const newSecretPath = '/account/secrets/new'
+
+const newSecretQueryKeys = [
+	'name',
+	'description',
+	'scope',
+	'packageId',
+	'allowedHosts',
+	'allowed-host',
+	'allowedCapabilities',
+	'capability',
+	'allowedPackages',
+	'package_id',
+	'package',
+]
+
+export function getNewSecretQueryKey(href: string) {
+	const url = new URL(href, 'http://localhost')
+	if (url.pathname !== newSecretPath) return ''
+	return newSecretQueryKeys
+		.map((key) => `${key}=${url.searchParams.getAll(key).join('\u0000')}`)
+		.join('&')
+}
+
+export function getNewSecretValueAutofocusKey(href: string) {
+	const queryKey = getNewSecretQueryKey(href)
+	if (!queryKey) return ''
+	const name = readTrimmedParam(
+		new URL(href, 'http://localhost').searchParams,
+		'name',
+	)
+	return name ? queryKey : ''
+}

--- a/packages/worker/client/routes/secret-editor-fields.tsx
+++ b/packages/worker/client/routes/secret-editor-fields.tsx
@@ -1,4 +1,4 @@
-import { type Handle, css } from 'remix/ui'
+import { type Handle, css, ref } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
@@ -12,6 +12,7 @@ import {
 } from '#universal/styles/style-primitives.ts'
 
 type SecretEditorFieldsProps = {
+	autoFocusKey?: string
 	description: string
 	onDescriptionChange: (value: string) => void
 	value: string
@@ -31,9 +32,33 @@ type SecretEditorFieldsProps = {
 	allowedCapabilitiesListName?: string
 }
 
+function focusSecretValueInput(root: Element) {
+	const input = root.querySelector('input[data-field="secret-value"]')
+	if (!(input instanceof HTMLInputElement)) return false
+	input.focus({ preventScroll: true })
+	input.scrollIntoView({ block: 'center', inline: 'nearest' })
+	return true
+}
+
 export function SecretEditorFields(handle: Handle<SecretEditorFieldsProps>) {
+	let valueField: HTMLElement | null = null
+	let focusedForKey: string | null = null
+
 	return () => {
 		const props = handle.props
+		const autoFocusKey = props.autoFocusKey ?? ''
+		if (!autoFocusKey) {
+			focusedForKey = null
+		} else if (focusedForKey !== autoFocusKey) {
+			handle.queueTask((signal) => {
+				if (signal.aborted || focusedForKey === autoFocusKey || !valueField) {
+					return
+				}
+				if (focusSecretValueInput(valueField)) {
+					focusedForKey = autoFocusKey
+				}
+			})
+		}
 		return (
 			<>
 				<label mix={css(fieldCss)}>
@@ -59,16 +84,33 @@ export function SecretEditorFields(handle: Handle<SecretEditorFieldsProps>) {
 				<label mix={css(fieldCss)}>
 					<span mix={css(fieldLabelCss)}>Secret value</span>
 					<div
-						mix={css({
-							position: 'relative',
-							display: 'flex',
-							alignItems: 'center',
-						})}
+						mix={[
+							css({
+								position: 'relative',
+								display: 'flex',
+								alignItems: 'center',
+							}),
+							ref((node, signal) => {
+								valueField = node as HTMLElement
+								signal.addEventListener('abort', () => {
+									if (valueField === node) valueField = null
+								})
+								if (
+									autoFocusKey &&
+									focusedForKey !== autoFocusKey &&
+									focusSecretValueInput(node)
+								) {
+									focusedForKey = autoFocusKey
+								}
+							}),
+						]}
 					>
 						{props.showSecretValue ? (
 							<input
 								type="text"
 								required
+								autoFocus={Boolean(autoFocusKey)}
+								data-field="secret-value"
 								{...passwordManagerIgnoreProps}
 								value={props.value}
 								placeholder={props.valuePlaceholder ?? 'Enter the secret value'}
@@ -91,6 +133,8 @@ export function SecretEditorFields(handle: Handle<SecretEditorFieldsProps>) {
 							<input
 								type="password"
 								required
+								autoFocus={Boolean(autoFocusKey)}
+								data-field="secret-value"
 								{...passwordManagerIgnoreProps}
 								value={props.value}
 								placeholder={props.valuePlaceholder ?? 'Enter the secret value'}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Opening a prefilled `/account/secrets/new?name=…` link should put the cursor on the secret value so the user can paste immediately, instead of landing on Name (already filled) or nowhere in particular.

## Summary

- When `/account/secrets/new` includes a non-empty `name` query param, the secret value input is focused and scrolled into view (`block: center`).
- Blank `/new` is unchanged so the Name field stays first.
- List filters (`q`, etc.) do not retarget focus.
- Account secret setup guide notes that a `name` param focuses the value field.

## Testing

- `vitest` `new-secret-query.node.test.ts`
- Pre-push: node-unit, workers-unit, Playwright e2e
- Typecheck on commit

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `b825e42c` · **Head:** `7bf7517a`

**Classification:** composes — no primitives added or changed; the new-secret form focuses an existing input when the URL already has a name.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

A prefilled `/account/secrets/new?name=…` link focuses and scrolls to the secret value input.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: open /account/secrets/new?name=…
	appUi->>appUi: prefill name and metadata from query
	appUi->>User: focus and scroll to secret value input
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secret creation links with a prefilled name now automatically focus and scroll to the secret value field.
  * Autofocus behavior works consistently for both text and password secret inputs.
  * Navigating between different secret creation links updates the focused field appropriately.

* **Documentation**
  * Updated the account secret setup guide to explain the `name` URL parameter and its focus-and-scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->