### PR TITLE
Expand list/detail records inside the table

### DIFF
--- a/docs/contributing/decisions/0010-account-record-table.md
+++ b/docs/contributing/decisions/0010-account-record-table.md
@@ -1,6 +1,6 @@
 # 0010: One RecordTable for account and admin list/detail screens
 
-- **Status:** accepted
+- **Status:** superseded by [0028](./0028-list-detail-expand.md)
 - **Date:** 2026-08-07
 
 ## Context

--- a/docs/contributing/decisions/0028-list-detail-expand.md
+++ b/docs/contributing/decisions/0028-list-detail-expand.md
@@ -1,0 +1,38 @@
+# 0028: List/detail records expand inside the table
+
+- **Status:** accepted
+- **Date:** 2026-08-20
+- **Supersedes:** [0010](./0010-account-record-table.md) mode assignment
+  (`expand` for read-only records, `pane` for editors)
+
+## Context
+
+[0010](./0010-account-record-table.md) put editors in a pane below `RecordTable`
+so a long form would not push the list apart. In use, that made secrets,
+integrations, MCP servers, memories, jobs, and the other list/detail screens
+feel unlike packages: the record lived outside the row that selected it. Create
+flows (`/new`) also had no row to attach to — `selectedId` is `null` — so a
+naive `mode="expand"` hid the editor.
+
+Admin platform integrations already kept its form in the expanded row. That is
+the shape readers expect for every list/detail screen.
+
+## Decision
+
+List/detail screens use `RecordTable` `mode="expand"`, including editors. `pane`
+stays only as the off-window fallback: a loaded record whose row is not in the
+current list (deep link, filter, paging, or a not-found selection) still renders
+below the table rather than disappearing.
+
+Create flows share one `createRow` prop. It prepends a selected placeholder row
+and unfolds the editor under it, including when the collection is empty so the
+table is not replaced by the empty-state copy.
+
+## Consequences
+
+The list is not height-capped while a record is expanded (already required by
+0010). A large editor still grows the table; that is the accepted trade. Screens
+no longer assemble a one-off `__new__` row and selected id.
+
+Revisit if a record outgrows one column badly enough to need a dedicated route —
+the option 0010 left open — rather than adding a fourth table mode.

--- a/docs/contributing/decisions/0028-list-detail-expand.md
+++ b/docs/contributing/decisions/0028-list-detail-expand.md
@@ -21,8 +21,8 @@ the shape readers expect for every list/detail screen.
 
 List/detail screens use `RecordTable` `mode="expand"`, including editors. `pane`
 stays only as the off-window fallback: a loaded record whose row is not in the
-current list (deep link, filter, paging, or a not-found selection) still renders
-below the table rather than disappearing.
+current list (deep link, filter, or paging) still renders below the table. A
+not-found state also renders below the table, even when no row is selected.
 
 Create flows share one `createRow` prop. It prepends a selected placeholder row
 and unfolds the editor under it, including when the collection is empty so the

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -29,7 +29,8 @@ behavior (see [documentation principles](../documentation.md)).
 - [0008 — Declined ADLC primitives (traces, previews, browser runs, session mining)](./0008-declined-adlc-primitives.md)
 - [0009 — Shiki for in-app syntax highlighting](./0009-shiki-syntax-highlighting.md)
 - [0010 — One RecordTable for account and admin list/detail screens](./0010-account-record-table.md)
-  ([supporting material](./0010-account-record-table/index.md))
+  ([supporting material](./0010-account-record-table/index.md); superseded by
+  [0028](./0028-list-detail-expand.md) for mode assignment)
 - [0011 — Workers-unit keeps per-file isolation; budget cold DO load in timeouts](./0011-workers-unit-pool-harness.md)
 - [0012 — Client-safe shared code lives in `#universal/*`](./0012-universal-layer.md)
 - [0013 — Synthetic package requests for post-publish verification](./0013-synthetic-package-requests.md)
@@ -48,3 +49,4 @@ behavior (see [documentation principles](../documentation.md)).
 - [0025 — No package services primitive](./0025-no-package-services-primitive.md)
 - [0026 — Package-owned invocation tokens](./0026-package-owned-invocation-tokens.md)
 - [0027 — No invocation-token source allowlist](./0027-no-invocation-token-source-allowlist.md)
+- [0028 — List/detail records expand inside the table](./0028-list-detail-expand.md)

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -172,11 +172,11 @@ connected, and `integration_platform_app_list` before building a BYO connect
 URL.
 
 Manage integrations from `/account/integrations`. The list is one row per
-service; the pane shows the connections on that integration. Built-in
+service; opening a row unfolds its connections in the table. Built-in
 integrations are marked “Provided by Kody.” User-registered integrations also
 resolve at `/account/integrations/apps/<app-slug>`. Disconnect a connected
-account or delete a user-registered integration from that pane — both ask for a
-second click, then offer Undo for a few seconds. App metadata and the
+account or delete a user-registered integration from that expanded row — both
+ask for a second click, then offer Undo for a few seconds. App metadata and the
 client-secret rotation form live under Advanced details, with an explicit
 confirmation step. Agents can call `integration_oauth_app_list`,
 `integration_oauth_app_delete`, and `integration_oauth_app_rotate_credentials`

--- a/packages/worker/client/routes/account-integrations.tsx
+++ b/packages/worker/client/routes/account-integrations.tsx
@@ -1075,7 +1075,7 @@ export function AccountIntegrationsRoute(handle: Handle) {
 				{status === 'ready' ? (
 					<>
 						<RecordTable
-							mode="pane"
+							mode="expand"
 							ariaLabel="Integrations"
 							selectedId={selectedApp ? integrationListId(selectedApp) : null}
 							countLabel={`${filteredApps.length} of ${apps.length} integrations`}

--- a/packages/worker/client/routes/account-jobs.tsx
+++ b/packages/worker/client/routes/account-jobs.tsx
@@ -657,7 +657,7 @@ export function AccountJobsRoute(handle: Handle) {
 
 				{status === 'ready' ? (
 					<RecordTable
-						mode="pane"
+						mode="expand"
 						ariaLabel="Scheduled jobs"
 						selectedId={selection.selectedId}
 						onNavigate={() => {
@@ -737,8 +737,8 @@ export function AccountJobsRoute(handle: Handle) {
 						]}
 						rows={filteredJobs.map((item) => ({
 							id: item.id,
-							// A save, toggle, or delete is in flight; the editor below
-							// owns the selection until it settles.
+							// A save, toggle, or delete is in flight; the expanded
+							// editor owns the selection until it settles.
 							href: isMutating
 								? undefined
 								: jobsRoute.buildDetailHref(item.id, getCurrentSearch()),

--- a/packages/worker/client/routes/account-mcp-servers.tsx
+++ b/packages/worker/client/routes/account-mcp-servers.tsx
@@ -550,7 +550,7 @@ export function AccountMcpServersRoute(handle: Handle) {
 
 				{status === 'ready' ? (
 					<RecordTable
-						mode="pane"
+						mode="expand"
 						ariaLabel="Connected MCP servers"
 						selectedId={selection.selectedId}
 						onNavigate={() => {
@@ -580,10 +580,20 @@ export function AccountMcpServersRoute(handle: Handle) {
 							{ key: 'url', label: 'URL', drop: 1 },
 							{ key: 'tools', label: 'Tools', align: 'end', drop: 2 },
 						]}
+						createRow={
+							selection.isCreating
+								? {
+										href: isMutating
+											? undefined
+											: mcpServersRoute.buildNewHref(getCurrentSearch()),
+										label: 'New server',
+									}
+								: undefined
+						}
 						rows={filteredServers.map((item) => ({
 							id: item.id,
-							// An add, toggle, or removal is in flight; the editor below
-							// owns the selection until it settles.
+							// An add, toggle, or removal is in flight; the expanded
+							// editor owns the selection until it settles.
 							href: isMutating
 								? undefined
 								: mcpServersRoute.buildDetailHref(item.id, getCurrentSearch()),

--- a/packages/worker/client/routes/account-memories.tsx
+++ b/packages/worker/client/routes/account-memories.tsx
@@ -367,7 +367,7 @@ export function AccountMemoriesRoute(handle: Handle) {
 							through verify and upsert.
 						</p>
 						<RecordTable
-							mode="pane"
+							mode="expand"
 							ariaLabel="Saved memories"
 							selectedId={selection.selectedId}
 							onNavigate={() => {

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -1279,7 +1279,7 @@ export function AccountSecretsRoute(handle: Handle) {
 				) : null}
 
 				<RecordTable
-					mode="pane"
+					mode="expand"
 					ariaLabel="Saved secrets"
 					selectedId={activeSecretId}
 					countLabel={
@@ -1352,10 +1352,20 @@ export function AccountSecretsRoute(handle: Handle) {
 						{ key: 'description', label: 'Description', drop: 1 },
 						{ key: 'ttl', label: 'Expires' },
 					]}
+					createRow={
+						selection.isCreating
+							? {
+									href: isMutating
+										? undefined
+										: buildNewSecretHref(getCurrentSearch()),
+									label: 'New secret',
+								}
+							: undefined
+					}
 					rows={filteredSecrets.map((secret) => ({
 						id: secret.id,
-						// A save or delete is in flight; the editor below owns the
-						// selection until it settles.
+						// A save or delete is in flight; the expanded editor owns
+						// the selection until it settles.
 						href: isMutating
 							? undefined
 							: buildSecretHref(secret, getCurrentSearch()),

--- a/packages/worker/client/routes/account-values.tsx
+++ b/packages/worker/client/routes/account-values.tsx
@@ -518,7 +518,7 @@ export function AccountValuesRoute(handle: Handle) {
 
 				{status === 'ready' ? (
 					<RecordTable
-						mode="pane"
+						mode="expand"
 						ariaLabel="Saved values"
 						selectedId={selection.selectedId}
 						onNavigate={resetSelectionState}
@@ -544,10 +544,20 @@ export function AccountValuesRoute(handle: Handle) {
 							{ key: 'preview', label: 'Value', drop: 2 },
 							{ key: 'updated', label: 'Updated' },
 						]}
+						createRow={
+							selection.isCreating
+								? {
+										href: isMutating
+											? undefined
+											: valuesRoute.buildNewHref(getCurrentSearch()),
+										label: 'New value',
+									}
+								: undefined
+						}
 						rows={filteredValues.map((entry) => ({
 							id: entry.id,
-							// A save or delete is in flight; the editor below owns the
-							// selection until it settles.
+							// A save or delete is in flight; the expanded editor owns
+							// the selection until it settles.
 							href: isMutating
 								? undefined
 								: valuesRoute.buildDetailHref(entry.id, getCurrentSearch()),

--- a/packages/worker/client/routes/admin-codemods.tsx
+++ b/packages/worker/client/routes/admin-codemods.tsx
@@ -24,6 +24,7 @@ import {
 } from './account-management-components.tsx'
 import {
 	RecordTable,
+	recordBodyCss,
 	recordCellClamp,
 	recordStampCss,
 	type RecordTableColumn,
@@ -905,183 +906,191 @@ export function AdminCodemodsRoute(handle: Handle) {
 								No runs recorded yet.
 							</p>
 						) : (
-							<div mix={css({ display: 'grid', gap: spacing.md })}>
-								<RecordTable
-									mode="pane"
-									ariaLabel="Codemod run history"
-									selectedId={selectedHistoryRunId}
-									scrollHeight="28rem"
-									columns={[
-										{ key: 'run', label: 'Run', primary: true },
-										{ key: 'created', label: 'Created' },
-										{ key: 'codemod', label: 'Codemod', drop: 1 },
-										{ key: 'mode', label: 'Mode' },
-										{ key: 'status', label: 'Status' },
-										{ key: 'scope', label: 'Scope', drop: 2 },
-										{ key: 'initiatedBy', label: 'Initiated by', drop: 3 },
-										{ key: 'actions', label: 'Actions' },
-									]}
-									rows={runs.map((run) => {
-										const revertConfirmActive =
-											pendingConfirmKey ===
-											getConfirmKey('revert-history', run.id)
-										// Abandoned and failed apply runs can hold applied items
-										// too; only an actively-paging run is off limits for revert.
-										const canRevert =
-											run.mode === 'apply' && run.status !== 'running'
-										return {
-											id: run.id,
-											cells: {
-												run: (
-													<code
-														title={run.id}
-														mix={css({ fontSize: typography.fontSize.sm })}
+							<RecordTable
+								mode="expand"
+								ariaLabel="Codemod run history"
+								selectedId={selectedHistoryRunId}
+								columns={[
+									{ key: 'run', label: 'Run', primary: true },
+									{ key: 'created', label: 'Created' },
+									{ key: 'codemod', label: 'Codemod', drop: 1 },
+									{ key: 'mode', label: 'Mode' },
+									{ key: 'status', label: 'Status' },
+									{ key: 'scope', label: 'Scope', drop: 2 },
+									{ key: 'initiatedBy', label: 'Initiated by', drop: 3 },
+									{ key: 'actions', label: 'Actions' },
+								]}
+								rows={runs.map((run) => {
+									const revertConfirmActive =
+										pendingConfirmKey ===
+										getConfirmKey('revert-history', run.id)
+									// Abandoned and failed apply runs can hold applied items
+									// too; only an actively-paging run is off limits for revert.
+									const canRevert =
+										run.mode === 'apply' && run.status !== 'running'
+									return {
+										id: run.id,
+										cells: {
+											run: (
+												<code
+													title={run.id}
+													mix={css({ fontSize: typography.fontSize.sm })}
+												>
+													{run.id.slice(0, 8)}
+												</code>
+											),
+											created: (
+												<span mix={css(recordStampCss)}>
+													{formatNullableTimestamp(run.createdAt)}
+												</span>
+											),
+											codemod: (
+												<code mix={css({ fontSize: typography.fontSize.sm })}>
+													{run.codemodId}
+												</code>
+											),
+											mode: run.mode,
+											status: run.status,
+											scope: (
+												<span mix={clampedCellCss}>
+													{run.scopeUserId ?? 'fleet'}
+												</span>
+											),
+											initiatedBy: (
+												<span mix={clampedCellCss}>
+													{run.initiatedByUserId}
+												</span>
+											),
+											actions: (
+												<span
+													mix={css({
+														display: 'flex',
+														gap: spacing.xs,
+														flexWrap: 'wrap',
+													})}
+												>
+													<button
+														type="button"
+														disabled={historyLoading}
+														mix={[
+															on('click', () => {
+																void loadHistoryRun(run.id)
+															}),
+															css(secondaryButtonCss),
+														]}
 													>
-														{run.id.slice(0, 8)}
-													</code>
-												),
-												created: (
-													<span mix={css(recordStampCss)}>
-														{formatNullableTimestamp(run.createdAt)}
-													</span>
-												),
-												codemod: (
-													<code mix={css({ fontSize: typography.fontSize.sm })}>
-														{run.codemodId}
-													</code>
-												),
-												mode: run.mode,
-												status: run.status,
-												scope: (
-													<span mix={clampedCellCss}>
-														{run.scopeUserId ?? 'fleet'}
-													</span>
-												),
-												initiatedBy: (
-													<span mix={clampedCellCss}>
-														{run.initiatedByUserId}
-													</span>
-												),
-												actions: (
-													<span
-														mix={css({
-															display: 'flex',
-															gap: spacing.xs,
-															flexWrap: 'wrap',
-														})}
-													>
+														{selectedHistoryRunId === run.id && historyLoading
+															? 'Loading…'
+															: 'Details'}
+													</button>
+													{canRevert ? (
 														<button
 															type="button"
-															disabled={historyLoading}
+															disabled={!canMutate}
 															mix={[
-																on('click', () => {
-																	void loadHistoryRun(run.id)
-																}),
-																css(secondaryButtonCss),
+																...getDestructiveButtonMix(
+																	'revert-history',
+																	run.id,
+																	() => {
+																		selectedCodemodId = run.codemodId
+																		selectedMode = 'revert'
+																		revertOfRunId = run.id
+																		void runPagedCodemod({
+																			mode: 'revert',
+																			codemodId: run.codemodId,
+																			revertOfRunId: run.id,
+																		})
+																	},
+																),
+																css(dangerButtonCss),
 															]}
 														>
-															{selectedHistoryRunId === run.id && historyLoading
-																? 'Loading…'
-																: 'Details'}
+															{revertConfirmActive
+																? 'Confirm revert'
+																: 'Revert'}
 														</button>
-														{canRevert ? (
-															<button
-																type="button"
-																disabled={!canMutate}
-																mix={[
-																	...getDestructiveButtonMix(
-																		'revert-history',
-																		run.id,
-																		() => {
-																			selectedCodemodId = run.codemodId
-																			selectedMode = 'revert'
-																			revertOfRunId = run.id
-																			void runPagedCodemod({
-																				mode: 'revert',
-																				codemodId: run.codemodId,
-																				revertOfRunId: run.id,
-																			})
-																		},
-																	),
-																	css(dangerButtonCss),
-																]}
-															>
-																{revertConfirmActive
-																	? 'Confirm revert'
-																	: 'Revert'}
-															</button>
-														) : null}
-													</span>
-												),
-											},
-										}
-									})}
-								/>
-
-								{selectedHistoryRunId ? (
-									<div mix={css({ display: 'grid', gap: spacing.sm })}>
-										<p mix={css(descriptionCss)}>
-											Details for <code>{selectedHistoryRunId}</code>
-											{historyRun
-												? ` · ${historyRun.mode} · ${historyRun.status}`
-												: ''}
-										</p>
-										{historyLoading && historyItems.length === 0 ? (
-											<p mix={css({ margin: 0, color: colors.textMuted })}>
-												Loading items…
+													) : null}
+												</span>
+											),
+										},
+									}
+								})}
+								record={
+									selectedHistoryRunId ? (
+										<div mix={css(recordBodyCss)}>
+											<p mix={css(descriptionCss)}>
+												Details for <code>{selectedHistoryRunId}</code>
+												{historyRun
+													? ` · ${historyRun.mode} · ${historyRun.status}`
+													: ''}
 											</p>
-										) : null}
-										{historyItems.length > 0 ? (
-											<RecordTable
-												mode="none"
-												ariaLabel="Run items"
-												scrollHeight="28rem"
-												columns={codemodItemColumns}
-												rows={historyItems.map((item) => ({
-													id: item.id,
-													cells: {
-														kodyId: item.kodyId,
-														userId: (
-															<span mix={clampedCellCss}>{item.userId}</span>
-														),
-														status: item.status,
-														changedPaths: (
-															<span mix={clampedCellCss}>
-																{item.changedPaths.join(', ') || '—'}
-															</span>
-														),
-														findings: formatFindings(item.findings),
-														error: (
-															<span mix={clampedCellCss}>
-																{item.error ?? '—'}
-															</span>
-														),
-													},
-												}))}
-											/>
-										) : !historyLoading ? (
-											<p mix={css({ margin: 0, color: colors.textMuted })}>
-												No items for this run.
-											</p>
-										) : null}
-										{historyNextAfterId ? (
-											<button
-												type="button"
-												disabled={historyLoading}
-												mix={[
-													on('click', () => {
-														if (!selectedHistoryRunId) return
-														void loadHistoryRun(selectedHistoryRunId, true)
-													}),
-													css(secondaryButtonCss),
-												]}
-											>
-												{historyLoading ? 'Loading…' : 'Load more'}
-											</button>
-										) : null}
-									</div>
-								) : null}
-							</div>
+											{historyLoading && historyItems.length === 0 ? (
+												<p
+													mix={css({
+														margin: 0,
+														color: colors.textMuted,
+													})}
+												>
+													Loading items…
+												</p>
+											) : null}
+											{historyItems.length > 0 ? (
+												<RecordTable
+													mode="none"
+													ariaLabel="Run items"
+													scrollHeight="28rem"
+													columns={codemodItemColumns}
+													rows={historyItems.map((item) => ({
+														id: item.id,
+														cells: {
+															kodyId: item.kodyId,
+															userId: (
+																<span mix={clampedCellCss}>{item.userId}</span>
+															),
+															status: item.status,
+															changedPaths: (
+																<span mix={clampedCellCss}>
+																	{item.changedPaths.join(', ') || '—'}
+																</span>
+															),
+															findings: formatFindings(item.findings),
+															error: (
+																<span mix={clampedCellCss}>
+																	{item.error ?? '—'}
+																</span>
+															),
+														},
+													}))}
+												/>
+											) : !historyLoading ? (
+												<p
+													mix={css({
+														margin: 0,
+														color: colors.textMuted,
+													})}
+												>
+													No items for this run.
+												</p>
+											) : null}
+											{historyNextAfterId ? (
+												<button
+													type="button"
+													disabled={historyLoading}
+													mix={[
+														on('click', () => {
+															if (!selectedHistoryRunId) return
+															void loadHistoryRun(selectedHistoryRunId, true)
+														}),
+														css(secondaryButtonCss),
+													]}
+												>
+													{historyLoading ? 'Loading…' : 'Load more'}
+												</button>
+											) : null}
+										</div>
+									) : null
+								}
+							/>
 						)}
 					</AccountManagementPanel>
 				</div>

--- a/packages/worker/client/routes/admin-platform-integrations.tsx
+++ b/packages/worker/client/routes/admin-platform-integrations.tsx
@@ -53,8 +53,6 @@ const adminPlatformIntegrationsApiPath = '/admin/platform-integrations.json'
 const platformIntegrationsRoute = createListDetailRoute(
 	'/admin/platform-integrations',
 )
-const createRecordId = '__new__'
-
 type PageStatus = 'loading' | 'ready' | 'error'
 type ActionState = 'idle' | 'saving-form' | 'toggling-enabled' | 'deleting'
 type TokenExchangeStyleOption = 'default' | 'form' | 'basic-json' | 'basic-form'
@@ -965,10 +963,6 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 			!selection.isCreating &&
 			editingApp == null &&
 			status === 'ready'
-		const tableSelectedId = selection.isCreating
-			? createRecordId
-			: selection.selectedId
-
 		return (
 			<AccountManagementShell>
 				<AdminPageHeader
@@ -991,7 +985,19 @@ export function AdminPlatformIntegrationsRoute(handle: Handle) {
 						mode="expand"
 						busy={status === 'loading'}
 						ariaLabel="Platform integrations"
-						selectedId={tableSelectedId}
+						selectedId={selection.selectedId}
+						createRow={
+							selection.isCreating
+								? {
+										href: isMutating
+											? undefined
+											: platformIntegrationsRoute.buildNewHref(
+													getCurrentSearch(currentHref),
+												),
+										label: 'New integration',
+									}
+								: undefined
+						}
 						onNavigate={() => {
 							resetSelectionState()
 						}}

--- a/packages/worker/client/routes/admin-system-email.tsx
+++ b/packages/worker/client/routes/admin-system-email.tsx
@@ -7,7 +7,12 @@ import { readRouterSearch } from '#client/router-location.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
-import { colors, radius, typography } from '#universal/styles/tokens.ts'
+import {
+	colors,
+	radius,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
 import { cardCss } from '#universal/styles/style-primitives.ts'
 import {
 	AccountManagementMessage,
@@ -19,6 +24,7 @@ import {
 } from './account-management-components.tsx'
 import {
 	RecordTable,
+	recordBodyCss,
 	recordCellClamp,
 	recordStampCss,
 } from './record-table.tsx'
@@ -216,16 +222,12 @@ export function AdminSystemEmailRoute(handle: Handle) {
 								)}. Retention keeps ${data.limits.retentionDays} days and at most ${data.limits.maxStoredMessages} stored messages.`}
 						>
 							<RecordTable
-								mode="pane"
+								mode="expand"
 								busy={status === 'loading'}
 								ariaLabel="System inbox messages"
 								selectedId={selectedMessage?.id ?? null}
 								countLabel={`${data.total} stored`}
 								emptyLabel="No system mail has been stored."
-								// The message opens in its own panel below rather than in
-								// this table's record slot, so the two panels keep the
-								// titles and audit-log framing they already carry.
-								scrollHeight="32rem"
 								columns={[
 									{ key: 'subject', label: 'Subject', primary: true },
 									{ key: 'inbox', label: 'Inbox' },
@@ -281,112 +283,132 @@ export function AdminSystemEmailRoute(handle: Handle) {
 										</p>
 									) : null
 								}
+								record={
+									selectedMessage ? (
+										<div mix={css(recordBodyCss)}>
+											<div mix={css({ display: 'grid', gap: spacing.xs })}>
+												<h2
+													mix={css({
+														margin: 0,
+														fontSize: typography.fontSize.lg,
+														fontWeight: typography.fontWeight.semibold,
+														color: colors.text,
+													})}
+												>
+													{selectedMessage.subject || '(no subject)'}
+												</h2>
+												<p
+													mix={css({
+														margin: 0,
+														color: colors.textMuted,
+													})}
+												>
+													Admin reads of message content are audit logged.
+												</p>
+											</div>
+											<MetadataGrid
+												items={[
+													{
+														label: 'Inbox',
+														value: selectedMessage.inbox_local_part,
+													},
+													{
+														label: 'From',
+														value:
+															selectedMessage.from_address ??
+															selectedMessage.envelope_from ??
+															'Unknown',
+													},
+													{
+														label: 'Received',
+														value: (
+															<TimestampValue
+																value={
+																	selectedMessage.received_at ??
+																	selectedMessage.created_at
+																}
+																fallback="Unknown"
+															/>
+														),
+													},
+													{
+														label: 'To',
+														value:
+															selectedMessage.to_addresses.join(', ') || 'None',
+													},
+													{
+														label: 'Reply-To',
+														value:
+															selectedMessage.reply_to_addresses.join(', ') ||
+															'None',
+													},
+													{
+														label: 'Attachments',
+														value: String(selectedMessage.attachments.length),
+													},
+												]}
+											/>
+											<section mix={css(cardCss)}>
+												<h3
+													mix={css({
+														margin: 0,
+														fontSize: typography.fontSize.base,
+													})}
+												>
+													Message body
+												</h3>
+												<Tabs defaultActiveTab="html">
+													<TabList aria-label="Email body">
+														<Tab name="html">HTML</Tab>
+														<Tab name="text">Text</Tab>
+														<Tab name="source">HTML Source</Tab>
+													</TabList>
+													<TabPanel name="html">
+														{selectedMessage.html_body ? (
+															<iframe
+																title="Email HTML preview"
+																sandbox=""
+																referrerPolicy="no-referrer"
+																srcdoc={buildAdminEmailHtmlPreviewDocument(
+																	selectedMessage.html_body,
+																)}
+																mix={emailHtmlPreviewIframeCss}
+															/>
+														) : (
+															<p mix={emailBodyEmptyCss}>
+																No HTML body exists for this message.
+															</p>
+														)}
+													</TabPanel>
+													<TabPanel name="text">
+														{selectedMessage.text_body ? (
+															<pre mix={emailBodyPreCss}>
+																{selectedMessage.text_body}
+															</pre>
+														) : (
+															<p mix={emailBodyEmptyCss}>
+																No text exists in this tab content.
+															</p>
+														)}
+													</TabPanel>
+													<TabPanel name="source">
+														{selectedMessage.html_body ? (
+															<pre mix={emailBodyPreCss}>
+																{selectedMessage.html_body}
+															</pre>
+														) : (
+															<p mix={emailBodyEmptyCss}>
+																No HTML body exists for this message.
+															</p>
+														)}
+													</TabPanel>
+												</Tabs>
+											</section>
+										</div>
+									) : null
+								}
 							/>
 						</AccountManagementPanel>
-
-						{selectedMessage ? (
-							<AccountManagementPanel
-								title={`Message: ${selectedMessage.subject || '(no subject)'}`}
-								description="Admin reads of message content are audit logged."
-							>
-								<MetadataGrid
-									items={[
-										{
-											label: 'Inbox',
-											value: selectedMessage.inbox_local_part,
-										},
-										{
-											label: 'From',
-											value:
-												selectedMessage.from_address ??
-												selectedMessage.envelope_from ??
-												'Unknown',
-										},
-										{
-											label: 'Received',
-											value: (
-												<TimestampValue
-													value={
-														selectedMessage.received_at ??
-														selectedMessage.created_at
-													}
-													fallback="Unknown"
-												/>
-											),
-										},
-										{
-											label: 'To',
-											value: selectedMessage.to_addresses.join(', ') || 'None',
-										},
-										{
-											label: 'Reply-To',
-											value:
-												selectedMessage.reply_to_addresses.join(', ') || 'None',
-										},
-										{
-											label: 'Attachments',
-											value: String(selectedMessage.attachments.length),
-										},
-									]}
-								/>
-								<section mix={css(cardCss)}>
-									<h3
-										mix={css({
-											margin: 0,
-											fontSize: typography.fontSize.base,
-										})}
-									>
-										Message body
-									</h3>
-									<Tabs defaultActiveTab="html">
-										<TabList aria-label="Email body">
-											<Tab name="html">HTML</Tab>
-											<Tab name="text">Text</Tab>
-											<Tab name="source">HTML Source</Tab>
-										</TabList>
-										<TabPanel name="html">
-											{selectedMessage.html_body ? (
-												<iframe
-													title="Email HTML preview"
-													sandbox=""
-													referrerPolicy="no-referrer"
-													srcdoc={buildAdminEmailHtmlPreviewDocument(
-														selectedMessage.html_body,
-													)}
-													mix={emailHtmlPreviewIframeCss}
-												/>
-											) : (
-												<p mix={emailBodyEmptyCss}>
-													No HTML body exists for this message.
-												</p>
-											)}
-										</TabPanel>
-										<TabPanel name="text">
-											{selectedMessage.text_body ? (
-												<pre mix={emailBodyPreCss}>
-													{selectedMessage.text_body}
-												</pre>
-											) : (
-												<p mix={emailBodyEmptyCss}>
-													No text exists in this tab content.
-												</p>
-											)}
-										</TabPanel>
-										<TabPanel name="source">
-											{selectedMessage.html_body ? (
-												<pre mix={emailBodyPreCss}>
-													{selectedMessage.html_body}
-												</pre>
-											) : (
-												<p mix={emailBodyEmptyCss}>
-													No HTML body exists for this message.
-												</p>
-											)}
-										</TabPanel>
-									</Tabs>
-								</section>
-							</AccountManagementPanel>
-						) : null}
 					</>
 				) : null}
 			</AccountManagementShell>

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -4,6 +4,8 @@ import { expect, test } from 'vitest'
 import {
 	RecordTable,
 	RecordTableSearch,
+	recordTableCreateId,
+	resolveRecordTableSelection,
 	type RecordTableColumn,
 } from '#client/routes/record-table.tsx'
 import {
@@ -123,6 +125,63 @@ test('record table keeps container drops, row links, and expand/pane selection c
 	expect(orphanHtml).not.toContain('data-record-row="true"')
 	expect(orphanHtml.indexOf('Orphan record')).toBeGreaterThan(
 		orphanHtml.indexOf('</table>'),
+	)
+
+	// A not-found record has no selected row. It must still render, not vanish.
+	const missingHtml = await renderToString(
+		jsx(RecordTable, {
+			mode: 'expand',
+			ariaLabel: 'Integrations',
+			columns,
+			rows,
+			selectedId: null,
+			record: jsx('p', { children: 'Connection not found' }),
+		}),
+	)
+	expect(missingHtml).toContain('Connection not found')
+	expect(missingHtml).not.toContain('data-record-row="true"')
+	expect(missingHtml.indexOf('Connection not found')).toBeGreaterThan(
+		missingHtml.indexOf('</table>'),
+	)
+
+	// `/new` has no entity id. The create row is the row the editor unfolds
+	// under, including when the collection is empty (no empty-state copy).
+	const createOnEmpty = resolveRecordTableSelection({
+		columns,
+		rows: [],
+		selectedId: null,
+		createRow: { href: '/account/secrets/new', label: 'New secret' },
+	})
+	expect(createOnEmpty.selectedId).toBe(recordTableCreateId)
+	expect(createOnEmpty.rows).toEqual([
+		{
+			id: recordTableCreateId,
+			href: '/account/secrets/new',
+			cells: { name: 'New secret' },
+		},
+	])
+
+	const createHtml = await renderToString(
+		jsx(RecordTable, {
+			mode: 'expand',
+			ariaLabel: 'Secrets',
+			columns,
+			rows: [],
+			createRow: { href: '/account/secrets/new', label: 'New secret' },
+			record: jsx('p', { children: 'Create editor' }),
+			emptyLabel: 'No secrets yet.',
+		}),
+	)
+	expect(createHtml).toContain('<table')
+	expect(createHtml).not.toContain('No secrets yet.')
+	expect(createHtml).toContain('New secret')
+	expect(createHtml).toContain('Create editor')
+	expect(createHtml).toContain('data-record-row="true"')
+	expect(createHtml.indexOf('Create editor')).toBeGreaterThan(
+		createHtml.indexOf('New secret'),
+	)
+	expect(createHtml.indexOf('Create editor')).toBeLessThan(
+		createHtml.indexOf('</table>'),
 	)
 
 	// Wide rows stay reachable via horizontal overflow.

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -69,6 +69,9 @@ export const recordTableCreateId = '__new__'
 /**
  * A create flow (`/new`) has no real row to expand under. Screens pass this
  * instead of building a one-off placeholder row and selected id.
+ *
+ * When `createRow` is set it always wins over `selectedId`: the synthetic
+ * create row is the selection. Callers pass `createRow` only on `/new`.
  */
 export type RecordTableCreateRow = {
 	href?: string

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -63,12 +63,55 @@ export type RecordTableRow = {
 	cells: Record<string, Slot>
 }
 
+/** Synthetic row id for a `/new` create flow unfolded inside the table. */
+export const recordTableCreateId = '__new__'
+
+/**
+ * A create flow (`/new`) has no real row to expand under. Screens pass this
+ * instead of building a one-off placeholder row and selected id.
+ */
+export type RecordTableCreateRow = {
+	href?: string
+	label: string
+}
+
+export function resolveRecordTableSelection({
+	columns,
+	rows,
+	selectedId,
+	createRow,
+}: {
+	columns: Array<RecordTableColumn>
+	rows: Array<RecordTableRow>
+	selectedId?: string | null
+	createRow?: RecordTableCreateRow
+}): {
+	rows: Array<RecordTableRow>
+	selectedId?: string | null
+} {
+	if (!createRow) {
+		return { rows, selectedId }
+	}
+	const primary = columns.find((column) => column.primary) ?? columns[0]
+	return {
+		rows: [
+			{
+				id: recordTableCreateId,
+				href: createRow.href,
+				cells: primary ? { [primary.key]: createRow.label } : {},
+			},
+			...rows,
+		],
+		selectedId: recordTableCreateId,
+	}
+}
+
 type RecordTableProps = {
 	/**
 	 * `expand` unfolds the record inside the table under its own row,
 	 * `pane` renders it below the table, `none` is a table with no selection.
-	 * Prefer `pane` for large editors (decision 0010); `expand` may still host
-	 * an editor when the screen deliberately keeps the form under its row.
+	 * List/detail screens use `expand`, including editors (decision 0028).
+	 * `pane` remains for the off-window selection fallback.
 	 */
 	mode: 'expand' | 'pane' | 'none'
 	/**
@@ -81,6 +124,12 @@ type RecordTableProps = {
 	columns: Array<RecordTableColumn>
 	rows: Array<RecordTableRow>
 	selectedId?: string | null
+	/**
+	 * When set, prepends a selected create row and unfolds `record` under it.
+	 * `/new` has no entity id, so without this the editor has nowhere to go
+	 * in `expand` (and an empty collection would hide the table entirely).
+	 */
+	createRow?: RecordTableCreateRow
 	/**
 	 * The already-built record for `selectedId`. It is a prop rather than a
 	 * `renderRecord(row)` callback because every one of these screens loads
@@ -576,7 +625,13 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 	}
 
 	return () => {
-		const { mode, columns, rows, selectedId, onNavigate } = handle.props
+		const { mode, columns, onNavigate } = handle.props
+		const { rows, selectedId } = resolveRecordTableSelection({
+			columns,
+			rows: handle.props.rows,
+			selectedId: handle.props.selectedId,
+			createRow: handle.props.createRow,
+		})
 		const selectable = mode !== 'none'
 		// `expand` must not cap the list: the record renders inside the
 		// scroller, so a max-height traps it in a nested scroll you have to
@@ -584,14 +639,17 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 		// the record below reachable without a long scroll first.
 		const capped = mode !== 'expand'
 		// `expand` puts the record inside the row it belongs to, which only works
-		// while that row is on screen. A deep link, a filter change, or paging
-		// past the selection leaves a loaded record with no row to unfold under —
-		// so it falls back to a pane below the table rather than disappearing.
-		const orphanedRecord = Boolean(
+		// while that row is on screen. A deep link, a filter, paging, or a
+		// not-found selection leaves a loaded record with no row to unfold under
+		// — so it falls back to a pane below the table rather than disappearing.
+		const expandedInTable = Boolean(
 			mode === 'expand' &&
 			handle.props.record &&
 			selectedId != null &&
-			!rows.some((row) => row.id === selectedId),
+			rows.some((row) => row.id === selectedId),
+		)
+		const orphanedRecord = Boolean(
+			mode === 'expand' && handle.props.record && !expandedInTable,
 		)
 
 		const table = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Secrets, integrations, MCP servers, memories, jobs, values, and the remaining admin list/detail screens now unfold the selected record under its own row — the same accordion as packages.

`RecordTable` already had `mode="expand"`. This PR makes that the list/detail default (ADR 0028) and adds a shared `createRow` so `/new` still has a row to expand under. Without that, `selectedId` is `null` and the editor would disappear.

## What changed

- **`RecordTable`:** `createRow` prepends a selected placeholder row (including on an empty collection). A record that cannot unfold in-table (off-window, filter, or not-found) still falls back to a pane so it does not vanish.
- **Account:** secrets, integrations, MCP servers, memories, jobs, values.
- **Admin:** platform integrations create flow, system email message detail, codemod run history.
- **Docs:** ADR 0028 supersedes 0010’s pane-for-editors rule; OAuth guide copy matches the expanded row. CodeRabbit follow-up: `createRow` wins over `selectedId`; not-found is documented separately from an orphan loaded record.

## Test notes

- `record-table.node.test.ts` covers expand, pane, orphan, empty-collection `/new`, and not-found fallback.
- `ssr-render.node.test.ts` still asserts integration connection/not-found markup.
- Preview (seeded user `me@kentcdodds.com`): created `previewExpandSecret`, then confirmed HTML for `/account/secrets/user/previewExpandSecret`, `/account/secrets/new`, and `/account/mcp-servers/new` includes `data-record-row` and `aria-expanded="true"`. Also 200s on integrations, memories, jobs, and packages.

Preview: https://kody-pr-1594.kody-a99.workers.dev

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `32be999e` · **Head:** `5f8da6e7`

**Classification:** extends — `RecordTable` gains a shared create-row contract and list/detail screens switch from pane to in-row expand.

### Primitives touched

| Primitive | Group    | Impact                                                               |
| --------- | -------- | -------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — `createRow`, expand-as-default, orphan fallback for no row |

### Change flow

Opening a list/detail record now unfolds under its row; `/new` gets a shared placeholder row so the editor stays in the table.

```mermaid
sequenceDiagram
	actor user as User
	participant appUi as app-ui
	user->>appUi: open /account/secrets/:id
	appUi->>appUi: RecordTable expand under selected row
	user->>appUi: open /account/secrets/new
	appUi->>appUi: createRow prepends New secret
	appUi->>appUi: unfold editor under that row
	user->>appUi: open missing integration id
	appUi->>appUi: orphan pane below table
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Record details and editors now expand directly within list rows across account and administration pages.
  * Create flows display selectable “New” rows, including when collections are empty.
  * Run history details, message content, metadata, pagination, and revert actions are available within expanded records.
  * Expanded editors retain selection during save, deletion, and other in-progress actions.
  * Records that are unavailable or outside the current list continue to open in a separate pane.

* **Documentation**
  * Updated integration guidance and architectural decisions to describe the expanded-row experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->