### PR TITLE
Rebuild the package files explorer on GitHub's shape

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -48,6 +48,24 @@ file style first, then run the formatter.
   `packages/worker/universal/styles/style-primitives.ts` instead of hand-rolling
   the pattern.
 
+## Page containers
+
+- A page-level container uses the same box as the site header:
+  `maxWidth: layoutMaxWidths.extended`, `marginInline: 'auto'`, and `pageGutter`
+  for its horizontal padding — all from
+  `packages/worker/universal/styles/style-primitives.ts`.
+- Do not pick horizontal padding from the spacing tokens (`spacing.lg` and
+  friends) for a page container. Those are fixed, `pageGutter` is
+  `clamp(1.25rem, 4vw, 2.5rem)`, and on a wide viewport the fixed value is the
+  smaller one — so the page's content renders _wider_ than the nav above it and
+  the left edges no longer line up. This is the most common layout mistake in
+  this repo.
+- Do not hand-copy the values either (`'72rem'`,
+  `'clamp(1.25rem, 4vw, 2.5rem)'`). Import the tokens so a change to the measure
+  moves every container at once.
+- Nested panels and cards inside the container keep using the spacing tokens for
+  their own padding; the gutter rule is about the outermost box only.
+
 ## Article breakout
 
 - Articles and guides sit on `articleMeasure` (43rem). To let a block use more

--- a/packages/worker/client/app.tsx
+++ b/packages/worker/client/app.tsx
@@ -29,6 +29,7 @@ import { visuallyHiddenUntilFocusedCss } from '#universal/styles/style-primitive
 import { SiteFooter } from './site-footer.tsx'
 import { SiteHeader } from './site-header.tsx'
 import { type AppLoaderData } from '#universal/loader-data.ts'
+import { isPackageFilesPathname } from '#universal/package-files.ts'
 import { userHasRole } from '#universal/permissions.ts'
 import { buildAuthLink } from './auth-links.ts'
 import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
@@ -169,6 +170,13 @@ export function App(handle: Handle<AppProps>) {
 		// header/footer stand down entirely there.
 		const isAuthShellPath =
 			currentPathname === '/login' || currentPathname === '/signup'
+		// The files explorer owns its gutters too (it hangs off a listing page
+		// that already does), so `<main>` must not pad it — the generic padding
+		// stacks on the route's own and pushes it in past the site header. Kept
+		// separate from the marketing predicate: only the padding changes, the
+		// waitlist banner still belongs on these pages.
+		const routeOwnsItsGutters =
+			isRedesignedMarketingPath || isPackageFilesPathname(currentPathname)
 		const hideWaitlistBanner =
 			!showAuthLinks ||
 			isRedesignedMarketingPath ||
@@ -245,7 +253,7 @@ export function App(handle: Handle<AppProps>) {
 											// The auth canvas stretches to fill the shell column.
 											display: 'grid',
 										}
-									: isRedesignedMarketingPath
+									: routeOwnsItsGutters
 										? {
 												width: '100%',
 												boxSizing: 'border-box',

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -2,11 +2,14 @@
 // component so Remix can mount it from the shared /files route.
 import { type Handle, type RemixNode, css } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
+import { on } from '#client/event-mixin.ts'
 import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { renderHighlightedCode } from '#client/syntax-highlight.tsx'
 import {
+	buildPackageFilesAncestors,
 	joinPackageFilesPath,
 	listPackageFilesChildren,
+	packageFileLanguageLabel,
 } from '#universal/package-files.ts'
 import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
 import {
@@ -14,40 +17,147 @@ import {
 	mq,
 	radius,
 	spacing,
+	transitions,
 	typography,
 } from '#universal/styles/tokens.ts'
-import { proseCss } from '#universal/styles/style-primitives.ts'
+import {
+	layoutMaxWidths,
+	pageGutter,
+	proseCss,
+} from '#universal/styles/style-primitives.ts'
+
+// The one mono stack in the codebase (`style-primitives`' inline-code rule).
+// Code used to inherit the browser's `monospace` default at body size here.
+const monoFont = "ui-monospace, 'SF Mono', Menlo, monospace"
+
+/** Directories on the way to `path`, which open so the file is in view. */
+function ancestorDirectories(path: string) {
+	return buildPackageFilesAncestors(path)
+		.map((ancestor) => ancestor.path)
+		.filter((candidate) => candidate !== path)
+}
+
+function formatBytes(value: string) {
+	const bytes = new TextEncoder().encode(value).length
+	if (bytes < 1024) return `${bytes} B`
+	return `${(bytes / 1024).toFixed(1)} KB`
+}
+
+function countLines(value: string) {
+	return value.replace(/\n$/, '').split('\n').length
+}
 
 export function PackageFilesExplorer(
-	handle: Handle<{ data: PackageFilesLoaderData }>,
+	handle: Handle<{ data: PackageFilesLoaderData; busy?: boolean }>,
 ) {
+	// Directory open/closed state is the visitor's, so it survives navigation
+	// between files; each newly selected path opens its own ancestors on top of
+	// whatever they already opened.
+	const expanded = new Set<string>()
+	let openedFor: string | null = null
+	let query = ''
+
+	// Opening a directory opens it in the tree too, the way GitHub's sidebar
+	// does — the row navigates *and* unfolds, rather than only doing one.
+	function syncExpanded(selectedPath: string, selectionIsDirectory: boolean) {
+		if (openedFor === selectedPath) return
+		openedFor = selectedPath
+		for (const directory of ancestorDirectories(selectedPath)) {
+			expanded.add(directory)
+		}
+		if (selectionIsDirectory && selectedPath) expanded.add(selectedPath)
+	}
+
+	function toggleDirectory(path: string) {
+		if (expanded.has(path)) expanded.delete(path)
+		else expanded.add(path)
+		handle.update()
+	}
+
+	function collapseAll() {
+		expanded.clear()
+		handle.update()
+	}
+
+	function setQuery(value: string) {
+		if (value === query) return
+		query = value
+		handle.update()
+	}
+
 	return () => {
 		const { data } = handle.props
+		syncExpanded(data.selectedPath, data.kind === 'directory')
+		const trimmedQuery = query.trim().toLowerCase()
+
 		return (
-			<article mix={css(articleCss)} data-testid="package-files">
+			<article
+				mix={css(articleCss)}
+				data-testid="package-files"
+				// The previous file stays on screen while the next one loads, so
+				// assistive tech is told the region is mid-update.
+				aria-busy={handle.props.busy ? 'true' : undefined}
+			>
 				<a href={data.backHref} mix={css(backLinkCss)}>
-					← {data.backLabel}
+					{arrowLeftIcon()} {data.backLabel}
 				</a>
 				<header mix={css(headCss)}>
 					<h1 mix={css(titleCss)}>{data.title}</h1>
-					<nav aria-label="Path" mix={css(breadcrumbCss)}>
-						<a href={data.filesBasePath}>files</a>
-						{data.ancestors.map((ancestor) => (
-							<span key={ancestor.path}>
-								<span mix={css(crumbSepCss)}>/</span>
-								<a
-									href={joinPackageFilesPath(data.filesBasePath, ancestor.path)}
-								>
-									{ancestor.name}
-								</a>
-							</span>
-						))}
-					</nav>
 				</header>
 				<div mix={css(layoutCss)}>
 					<nav aria-label="Files" mix={css(treeCss)}>
-						<h2 mix={css(treeHeadingCss)}>Files</h2>
-						{renderTree(data.paths, '', data.selectedPath, data.filesBasePath)}
+						<div mix={css(treeHeadCss)}>
+							<h2 mix={css(treeHeadingCss)}>Files</h2>
+							{/* Always rendered so the row keeps its height — appearing and
+							    disappearing shifted the filter and tree below it. */}
+							<button
+								type="button"
+								disabled={expanded.size === 0}
+								mix={[
+									css(
+										expanded.size > 0
+											? collapseButtonCss
+											: collapseButtonHiddenCss,
+									),
+									on('click', collapseAll),
+								]}
+							>
+								Collapse all
+							</button>
+						</div>
+						<div mix={css(filterWrapCss)}>
+							<div mix={css(filterFieldCss)}>
+								<span mix={css(filterIconCss)}>{searchIcon()}</span>
+								<input
+									type="search"
+									value={query}
+									placeholder="Go to file"
+									aria-label="Filter files"
+									mix={[
+										css(filterInputCss),
+										on('input', (event) => {
+											const target = event.target
+											if (target instanceof HTMLInputElement) {
+												setQuery(target.value)
+											}
+										}),
+									]}
+								/>
+							</div>
+						</div>
+						<div mix={css(treeScrollCss)}>
+							{trimmedQuery
+								? renderMatches(data, trimmedQuery)
+								: renderTree(
+										data.paths,
+										'',
+										data.selectedPath,
+										data.filesBasePath,
+										expanded,
+										toggleDirectory,
+										0,
+									)}
+						</div>
 					</nav>
 					<section mix={css(contentCss)} aria-label="Selected file">
 						{renderContent(data)}
@@ -58,11 +168,47 @@ export function PackageFilesExplorer(
 	}
 }
 
+function renderMatches(data: PackageFilesLoaderData, query: string): RemixNode {
+	const matches = data.paths.filter((path) =>
+		path.toLowerCase().includes(query),
+	)
+	if (matches.length === 0) {
+		return <p mix={css(emptyCss)}>No file matches that filter.</p>
+	}
+	return (
+		<ul mix={css(treeListCss)}>
+			{matches.map((path) => {
+				const slash = path.lastIndexOf('/')
+				const name = slash === -1 ? path : path.slice(slash + 1)
+				const directory = slash === -1 ? '' : path.slice(0, slash)
+				return (
+					<li key={path}>
+						<a
+							href={joinPackageFilesPath(data.filesBasePath, path)}
+							aria-current={data.selectedPath === path ? 'page' : undefined}
+							mix={css(data.selectedPath === path ? rowCurrentCss : rowCss)}
+						>
+							<span mix={css(rowIconCss)}>{fileIcon()}</span>
+							<span mix={css(rowNameCss)}>{name}</span>
+							{directory ? (
+								<span mix={css(rowMetaCss)}>{directory}</span>
+							) : null}
+						</a>
+					</li>
+				)
+			})}
+		</ul>
+	)
+}
+
 function renderTree(
 	paths: Array<string>,
 	directoryPath: string,
 	selectedPath: string,
 	filesBasePath: string,
+	expanded: Set<string>,
+	toggleDirectory: (path: string) => void,
+	depth: number,
 ): RemixNode {
 	const children = listPackageFilesChildren(paths, directoryPath)
 	if (children.length === 0 && directoryPath === '') {
@@ -73,18 +219,49 @@ function renderTree(
 			{children.map((child) => {
 				const href = joinPackageFilesPath(filesBasePath, child.path)
 				const current = selectedPath === child.path
+				const isDirectory = child.kind === 'directory'
+				const isOpen = isDirectory && expanded.has(child.path)
 				return (
 					<li key={child.path}>
-						<a
-							href={href}
-							aria-current={current ? 'page' : undefined}
-							mix={css(current ? treeLinkCurrentCss : treeLinkCss)}
-						>
-							{child.name}
-							{child.kind === 'directory' ? '/' : ''}
-						</a>
-						{child.kind === 'directory'
-							? renderTree(paths, child.path, selectedPath, filesBasePath)
+						<div mix={css(rowShellCss)} style={`padding-left: ${depth * 14}px`}>
+							{isDirectory ? (
+								<button
+									type="button"
+									aria-expanded={isOpen ? 'true' : 'false'}
+									aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${child.name}`}
+									mix={[
+										css(chevronButtonCss),
+										on('click', () => toggleDirectory(child.path)),
+									]}
+								>
+									<span mix={css(isOpen ? chevronOpenCss : chevronCss)}>
+										{chevronIcon()}
+									</span>
+								</button>
+							) : (
+								<span mix={css(chevronSpacerCss)} aria-hidden="true" />
+							)}
+							<a
+								href={href}
+								aria-current={current ? 'page' : undefined}
+								mix={css(current ? rowCurrentCss : rowCss)}
+							>
+								<span mix={css(isDirectory ? rowDirIconCss : rowIconCss)}>
+									{isDirectory ? directoryIcon() : fileIcon()}
+								</span>
+								<span mix={css(rowNameCss)}>{child.name}</span>
+							</a>
+						</div>
+						{isOpen
+							? renderTree(
+									paths,
+									child.path,
+									selectedPath,
+									filesBasePath,
+									expanded,
+									toggleDirectory,
+									depth + 1,
+								)
 							: null}
 					</li>
 				)
@@ -97,9 +274,14 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 	if (data.kind === 'directory' && !data.content) {
 		return (
 			<div>
-				<h2 mix={css(contentHeadingCss)}>
-					{data.selectedPath ? data.selectedPath : 'Package root'}
-				</h2>
+				<div mix={css(contentToolbarCss)}>
+					<div mix={css(contentHeadingWrapCss)}>
+						<span mix={css(headingIconCss)}>{directoryIcon()}</span>
+						<h2 mix={css(contentHeadingCss)}>
+							{data.selectedPath ? data.selectedPath : 'Package root'}
+						</h2>
+					</div>
+				</div>
 				{data.children.length === 0 ? (
 					<p mix={css(emptyCss)}>This folder is empty.</p>
 				) : (
@@ -110,8 +292,14 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 									href={joinPackageFilesPath(data.filesBasePath, child.path)}
 									mix={css(dirLinkCss)}
 								>
-									{child.name}
-									{child.kind === 'directory' ? '/' : ''}
+									<span
+										mix={css(
+											child.kind === 'directory' ? rowDirIconCss : rowIconCss,
+										)}
+									>
+										{child.kind === 'directory' ? directoryIcon() : fileIcon()}
+									</span>
+									<span mix={css(rowNameCss)}>{child.name}</span>
 								</a>
 							</li>
 						))}
@@ -126,7 +314,18 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 	return (
 		<div>
 			<div mix={css(contentToolbarCss)}>
-				<h2 mix={css(contentHeadingCss)}>{heading}</h2>
+				<div mix={css(contentHeadingWrapCss)}>
+					<span mix={css(headingIconCss)}>{fileIcon()}</span>
+					<h2 mix={css(contentHeadingCss)}>{heading}</h2>
+					{body ? (
+						<span mix={css(contentMetaCss)}>
+							{countLines(body)} lines · {formatBytes(body)}
+							{packageFileLanguageLabel(data.language)
+								? ` · ${packageFileLanguageLabel(data.language)}`
+								: ''}
+						</span>
+					) : null}
+				</div>
 				{body ? (
 					<CopyTextButton
 						value={body}
@@ -138,11 +337,11 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 				) : null}
 			</div>
 			{data.contentKind === 'markdown' ? (
-				<div mix={css(proseCss)} data-testid="package-files-markdown">
+				<div mix={css(markdownCss)} data-testid="package-files-markdown">
 					{renderMarkdownNodes(body)}
 				</div>
 			) : (
-				<div data-testid="package-files-code">
+				<div mix={css(codeCss)} data-testid="package-files-code">
 					{renderHighlightedCode(body, data.language ?? 'plaintext')}
 				</div>
 			)}
@@ -150,14 +349,123 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 	)
 }
 
+/* ---------- icons ---------- */
+
+function arrowLeftIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="14"
+			height="14"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M19 12H5" />
+			<path d="m12 19-7-7 7-7" />
+		</svg>
+	)
+}
+
+function chevronIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="12"
+			height="12"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2.5"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="m9 18 6-6-6-6" />
+		</svg>
+	)
+}
+
+function directoryIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="15"
+			height="15"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.8"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M4 20V6a1 1 0 0 1 1-1h4.6a1 1 0 0 1 .8.4l1.2 1.6H19a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1Z" />
+		</svg>
+	)
+}
+
+function fileIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="15"
+			height="15"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.8"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M14 3v5h5" />
+			<path d="M15 3H7a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V6Z" />
+		</svg>
+	)
+}
+
+function searchIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			width="14"
+			height="14"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<circle cx="11" cy="11" r="7" />
+			<path d="m21 21-4.3-4.3" />
+		</svg>
+	)
+}
+
+/* ---------- styles ---------- */
+
+// Same box as the site header (`navCss`): `layoutMaxWidths.extended` centered,
+// inset by `pageGutter`. A container that picks its own padding renders wider
+// than the nav above it.
+// This route owns its gutters — the shell leaves it unpadded (`app.tsx`), so
+// the same box as the site header lines the two up at every width.
 const articleCss = {
-	width: 'min(72rem, 100%)',
-	margin: '0 auto',
-	padding: `${spacing.xl} ${spacing.lg} ${spacing['2xl']}`,
+	maxWidth: layoutMaxWidths.extended,
+	marginInline: 'auto',
+	padding: `${spacing.lg} ${pageGutter} ${spacing['2xl']}`,
+	[mq.tablet]: {
+		padding: `${spacing.md} ${pageGutter} ${spacing.xl}`,
+	},
 }
 
 const backLinkCss = {
+	// Pinned out of the `page` transition with the rest of the explorer chrome.
+	viewTransitionName: 'files-back',
 	display: 'inline-flex',
+	alignItems: 'center',
+	gap: spacing.xs,
 	fontSize: typography.fontSize.sm,
 	fontWeight: typography.fontWeight.medium,
 	color: colors.primaryText,
@@ -166,7 +474,11 @@ const backLinkCss = {
 }
 
 const headCss = {
-	marginTop: spacing.lg,
+	// Lifted out of the `page` view transition (see `public/styles.css`) so the
+	// title does not slide on every in-explorer file switch.
+	viewTransitionName: 'files-head',
+	// The back link reads as part of this head, so it sits tight to the title.
+	marginTop: spacing.sm,
 	marginBottom: spacing.lg,
 	display: 'grid',
 	gap: spacing.xs,
@@ -179,107 +491,380 @@ const titleCss = {
 	overflowWrap: 'anywhere' as const,
 }
 
-const breadcrumbCss = {
-	fontSize: typography.fontSize.sm,
-	color: colors.textMuted,
-	overflowWrap: 'anywhere' as const,
-	'& a': {
-		color: colors.primaryText,
-		textDecoration: 'none',
-	},
-}
-
-const crumbSepCss = {
-	margin: `0 ${spacing.xs}`,
-	color: colors.textMuted,
-}
-
+// Two columns need room for both: below the tablet breakpoint the blob is too
+// narrow to read code in, so the tree moves above it and runs full width.
 const layoutCss = {
 	display: 'grid',
-	gridTemplateColumns: '18rem minmax(0, 1fr)',
+	gridTemplateColumns: '18.75rem minmax(0, 1fr)',
 	gap: spacing.lg,
 	alignItems: 'start',
-	[mq.mobile]: {
-		gridTemplateColumns: '1fr',
+	[mq.tablet]: {
+		gridTemplateColumns: 'minmax(0, 1fr)',
+		gap: spacing.md,
 	},
 }
 
 const treeCss = {
 	border: `1px solid ${colors.border}`,
 	borderRadius: radius.md,
-	padding: spacing.md,
-	backgroundColor: colors.background,
+	backgroundColor: colors.surface,
 	minWidth: 0,
+	viewTransitionName: 'files-tree',
+	// 5rem clears the sticky site header, as on the timeline and account nav.
+	position: 'sticky' as const,
+	top: '5rem',
+	[mq.tablet]: {
+		position: 'static' as const,
+	},
+}
+
+const treeHeadCss = {
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'space-between',
+	gap: spacing.sm,
+	padding: `${spacing.md} ${spacing.md} ${spacing.sm}`,
 }
 
 const treeHeadingCss = {
-	margin: `0 0 ${spacing.sm}`,
-	fontSize: typography.fontSize.sm,
+	margin: 0,
+	fontSize: typography.fontSize.xs,
 	fontWeight: typography.fontWeight.semibold,
+	letterSpacing: '0.02em',
+	textTransform: 'uppercase' as const,
+	color: colors.textMuted,
+}
+
+const collapseButtonCss = {
+	padding: spacing.xs,
+	border: 'none',
+	background: 'transparent',
+	color: colors.textMuted,
+	fontFamily: typography.fontFamily,
+	fontSize: typography.fontSize.xs,
+	fontWeight: typography.fontWeight.medium,
+	cursor: 'pointer',
+	'&:hover': { color: colors.text },
+}
+
+// Holds its space in the layout; `visibility` also drops it from the
+// accessibility tree and out of tab order.
+const collapseButtonHiddenCss = {
+	...collapseButtonCss,
+	visibility: 'hidden' as const,
+}
+
+const filterWrapCss = {
+	padding: `0 ${spacing.md} ${spacing.sm}`,
+}
+
+// The icon is positioned against the input, not the padded wrapper around it —
+// anchoring it to the wrapper puts it outside the field by the padding.
+const filterFieldCss = {
+	position: 'relative' as const,
+	display: 'flex',
+	alignItems: 'center',
+}
+
+const filterIconCss = {
+	position: 'absolute' as const,
+	left: '0.625rem',
+	top: '50%',
+	translate: '0 -50%',
+	display: 'inline-flex',
+	color: colors.textMuted,
+	pointerEvents: 'none' as const,
+}
+
+const filterInputCss = {
+	width: '100%',
+	minWidth: 0,
+	height: '2rem',
+	padding: `0 ${spacing.sm} 0 1.875rem`,
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.sm,
+	backgroundColor: colors.background,
+	color: colors.text,
+	fontFamily: typography.fontFamily,
+	fontSize: typography.fontSize.sm,
+	boxSizing: 'border-box' as const,
+	'&:focus-visible': {
+		outline: `2px solid ${colors.primary}`,
+		outlineOffset: '-1px',
+		borderColor: 'transparent',
+	},
+}
+
+const treeScrollCss = {
+	maxHeight: '38rem',
+	overflowY: 'auto' as const,
+	padding: `0 ${spacing.sm} ${spacing.sm}`,
+	// Stacked above the file, the tree must not push the content off-screen.
+	[mq.tablet]: {
+		maxHeight: '18rem',
+	},
 }
 
 const treeListCss = {
 	margin: 0,
-	paddingLeft: spacing.md,
+	padding: 0,
 	listStyle: 'none',
-	fontSize: typography.fontSize.sm,
 	'& ul': {
 		margin: 0,
-		paddingLeft: spacing.md,
+		padding: 0,
 		listStyle: 'none',
 	},
 }
 
-const treeLinkCss = {
-	color: colors.text,
-	textDecoration: 'none',
-	overflowWrap: 'anywhere' as const,
-	'&:hover': { color: colors.primaryText },
+const rowShellCss = {
+	display: 'flex',
+	alignItems: 'center',
+	minWidth: 0,
 }
 
-const treeLinkCurrentCss = {
-	...treeLinkCss,
+const chevronButtonCss = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	flex: 'none',
+	width: '1.25rem',
+	height: '2rem',
+	padding: 0,
+	border: 'none',
+	background: 'transparent',
+	color: colors.textMuted,
+	cursor: 'pointer',
+	'&:hover': { color: colors.text },
+}
+
+const chevronSpacerCss = {
+	flex: 'none',
+	width: '1.25rem',
+}
+
+const chevronCss = {
+	display: 'inline-flex',
+	transition: `rotate ${transitions.fast}`,
+	rotate: '0deg',
+}
+
+const chevronOpenCss = {
+	...chevronCss,
+	rotate: '90deg',
+}
+
+const rowCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.sm,
+	flex: 1,
+	minWidth: 0,
+	height: '2rem',
+	padding: `0 ${spacing.sm}`,
+	borderRadius: radius.sm,
+	color: colors.text,
+	fontSize: typography.fontSize.sm,
+	fontWeight: typography.fontWeight.medium,
+	textDecoration: 'none',
+	'&:hover': {
+		backgroundColor: colors.primarySoftest,
+		color: colors.primaryText,
+	},
+}
+
+const rowCurrentCss = {
+	...rowCss,
+	backgroundColor: colors.primarySoft,
+	color: colors.primaryText,
 	fontWeight: typography.fontWeight.semibold,
+}
+
+const rowIconCss = {
+	display: 'inline-flex',
+	flex: 'none',
+	color: colors.textMuted,
+}
+
+const rowDirIconCss = {
+	display: 'inline-flex',
+	flex: 'none',
 	color: colors.primaryText,
 }
 
+const rowNameCss = {
+	flex: 1,
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap' as const,
+}
+
+const rowMetaCss = {
+	flex: 'none',
+	fontSize: typography.fontSize.xs,
+	fontWeight: typography.fontWeight.normal,
+	color: colors.textMuted,
+}
+
 const contentCss = {
+	// Named so the file pane cross-fades in place instead of sliding up with
+	// the page; its group is pinned so the box does not morph between the
+	// old and new file's heights.
+	viewTransitionName: 'files-blob',
 	minWidth: 0,
 	border: `1px solid ${colors.border}`,
 	borderRadius: radius.md,
-	padding: spacing.lg,
-	backgroundColor: colors.background,
-	'& pre': {
-		overflowX: 'auto' as const,
-	},
+	backgroundColor: colors.surface,
+	overflow: 'hidden',
 }
 
 const contentToolbarCss = {
 	display: 'flex',
 	alignItems: 'center',
 	justifyContent: 'space-between',
-	gap: spacing.md,
-	marginBottom: spacing.md,
+	flexWrap: 'wrap' as const,
+	gap: spacing.sm,
+	padding: `${spacing.sm} ${spacing.md}`,
+	borderBottom: `1px solid ${colors.border}`,
 }
 
+const contentHeadingWrapCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.sm,
+	minWidth: 0,
+	color: colors.textMuted,
+}
+
+const headingIconCss = {
+	display: 'inline-flex',
+	flex: 'none',
+}
+
+// `overflow-wrap: anywhere` broke the path one character per line as soon as
+// the toolbar squeezed it; a path truncates from the front instead, and the
+// breadcrumb above still carries the full location.
 const contentHeadingCss = {
 	margin: 0,
-	fontSize: typography.fontSize.base,
+	minWidth: 0,
+	fontFamily: monoFont,
+	fontSize: typography.fontSize.sm,
 	fontWeight: typography.fontWeight.semibold,
-	overflowWrap: 'anywhere' as const,
+	color: colors.text,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap' as const,
+}
+
+const contentMetaCss = {
+	flex: 'none',
+	fontSize: typography.fontSize.xs,
+	color: colors.textMuted,
+	[mq.mobile]: {
+		display: 'none',
+	},
+}
+
+// Rendered markdown is prose, so it gets the reading inset the code view gets
+// from its own gutter and `pre` padding.
+const markdownCss = {
+	...proseCss,
+	padding: spacing.lg,
+	// The panel supplies the inset, so the prose block adds none of its own and
+	// the first block — a heading here, which `proseCss` only zeroes for a
+	// leading paragraph — starts flush with the padding.
+	marginTop: 0,
+	'& > :first-child': {
+		marginTop: 0,
+	},
+	// `proseCss` styles no tables. A README table sized to the column would
+	// wrap every cell to a few characters, so it sizes to its content
+	// (`max-content`) and scrolls inside its own box instead — the block
+	// display is what lets a table overflow at all.
+	'& table': {
+		display: 'block',
+		width: 'max-content',
+		maxWidth: '100%',
+		overflowX: 'auto',
+		margin: '1.15rem 0 0',
+		borderCollapse: 'collapse',
+		fontSize: typography.fontSize.sm,
+	},
+	'& th, & td': {
+		padding: `${spacing.sm} ${spacing.md}`,
+		border: `1px solid ${colors.border}`,
+		textAlign: 'left' as const,
+		verticalAlign: 'top' as const,
+	},
+	'& th': {
+		fontWeight: typography.fontWeight.semibold,
+		backgroundColor: colors.background,
+		whiteSpace: 'nowrap' as const,
+	},
+	'& td code': {
+		whiteSpace: 'nowrap' as const,
+	},
+}
+
+// Line numbers ride Shiki's own `.line` spans as a CSS counter, so the
+// highlighter keeps emitting one flat token tree.
+const codeCss = {
+	'& pre': {
+		margin: 0,
+		padding: `${spacing.md} 0`,
+		overflowX: 'auto' as const,
+		fontFamily: monoFont,
+		fontSize: '0.8125rem',
+		lineHeight: 1.55,
+	},
+	'& code': {
+		counterReset: 'package-file-line',
+	},
+	'& .line': {
+		display: 'block',
+		counterIncrement: 'package-file-line',
+		paddingRight: spacing.md,
+	},
+	'& .line:hover': {
+		backgroundColor: colors.primarySoftest,
+	},
+	'& .line::before': {
+		content: 'counter(package-file-line)',
+		display: 'inline-block',
+		width: '2.5rem',
+		marginRight: spacing.md,
+		textAlign: 'right' as const,
+		color: colors.textMuted,
+		opacity: 0.65,
+		userSelect: 'none' as const,
+	},
 }
 
 const emptyCss = {
-	margin: 0,
+	margin: `${spacing.sm} ${spacing.sm}`,
 	color: colors.textMuted,
+	fontSize: typography.fontSize.sm,
 }
 
 const dirListCss = {
 	margin: 0,
-	paddingLeft: spacing.lg,
+	padding: 0,
+	listStyle: 'none',
 }
 
 const dirLinkCss = {
-	color: colors.primaryText,
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.sm,
+	padding: `0 ${spacing.md}`,
+	height: '2.75rem',
+	borderBottom: `1px solid ${colors.border}`,
+	color: colors.text,
+	fontSize: typography.fontSize.sm,
+	fontWeight: typography.fontWeight.medium,
 	textDecoration: 'none',
+	'&:hover': {
+		backgroundColor: colors.primarySoftest,
+		color: colors.primaryText,
+	},
 }

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -3,6 +3,7 @@
 import { type Handle, type RemixNode, css } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
+import { matchesSearchQuery } from '#client/search-filter.ts'
 import { renderMarkdownNodes } from '#client/markdown-view.tsx'
 import { renderHighlightedCode } from '#client/syntax-highlight.tsx'
 import {
@@ -26,10 +27,6 @@ import {
 	proseCss,
 } from '#universal/styles/style-primitives.ts'
 
-// The one mono stack in the codebase (`style-primitives`' inline-code rule).
-// Code used to inherit the browser's `monospace` default at body size here.
-const monoFont = "ui-monospace, 'SF Mono', Menlo, monospace"
-
 /** Directories on the way to `path`, which open so the file is in view. */
 function ancestorDirectories(path: string) {
 	return buildPackageFilesAncestors(path)
@@ -40,7 +37,8 @@ function ancestorDirectories(path: string) {
 function formatBytes(value: string) {
 	const bytes = new TextEncoder().encode(value).length
 	if (bytes < 1024) return `${bytes} B`
-	return `${(bytes / 1024).toFixed(1)} KB`
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 function countLines(value: string) {
@@ -62,6 +60,7 @@ export function PackageFilesExplorer(
 	function syncExpanded(selectedPath: string, selectionIsDirectory: boolean) {
 		if (openedFor === selectedPath) return
 		openedFor = selectedPath
+		query = ''
 		for (const directory of ancestorDirectories(selectedPath)) {
 			expanded.add(directory)
 		}
@@ -85,10 +84,21 @@ export function PackageFilesExplorer(
 		handle.update()
 	}
 
+	// Filter keystrokes and chevron toggles re-run this whole closure; the
+	// blob is untouched by either, and re-highlighting a large file with
+	// Shiki on every keystroke janks the input. Selection is the only thing
+	// that changes the blob.
+	let contentNode: RemixNode = null
+	let contentFor: string | null = null
+
 	return () => {
 		const { data } = handle.props
 		syncExpanded(data.selectedPath, data.kind === 'directory')
-		const trimmedQuery = query.trim().toLowerCase()
+		const contentKey = `${data.selectedPath}\n${data.contentPath ?? ''}`
+		if (contentFor !== contentKey) {
+			contentFor = contentKey
+			contentNode = renderContent(data)
+		}
 
 		return (
 			<article
@@ -146,8 +156,8 @@ export function PackageFilesExplorer(
 							</div>
 						</div>
 						<div mix={css(treeScrollCss)}>
-							{trimmedQuery
-								? renderMatches(data, trimmedQuery)
+							{query.trim()
+								? renderMatches(data, query)
 								: renderTree(
 										data.paths,
 										'',
@@ -160,7 +170,7 @@ export function PackageFilesExplorer(
 						</div>
 					</nav>
 					<section mix={css(contentCss)} aria-label="Selected file">
-						{renderContent(data)}
+						{contentNode}
 					</section>
 				</div>
 			</article>
@@ -168,16 +178,17 @@ export function PackageFilesExplorer(
 	}
 }
 
+const maxFilterMatches = 100
+
 function renderMatches(data: PackageFilesLoaderData, query: string): RemixNode {
-	const matches = data.paths.filter((path) =>
-		path.toLowerCase().includes(query),
-	)
+	const matches = data.paths.filter((path) => matchesSearchQuery(query, [path]))
 	if (matches.length === 0) {
 		return <p mix={css(emptyCss)}>No file matches that filter.</p>
 	}
+	const overflow = matches.length - maxFilterMatches
 	return (
 		<ul mix={css(treeListCss)}>
-			{matches.map((path) => {
+			{matches.slice(0, maxFilterMatches).map((path) => {
 				const slash = path.lastIndexOf('/')
 				const name = slash === -1 ? path : path.slice(slash + 1)
 				const directory = slash === -1 ? '' : path.slice(0, slash)
@@ -197,6 +208,13 @@ function renderMatches(data: PackageFilesLoaderData, query: string): RemixNode {
 					</li>
 				)
 			})}
+			{overflow > 0 ? (
+				<li>
+					<p mix={css(emptyCss)}>
+						…and {overflow} more. Keep typing to narrow.
+					</p>
+				</li>
+			) : null}
 		</ul>
 	)
 }
@@ -316,7 +334,9 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 			<div mix={css(contentToolbarCss)}>
 				<div mix={css(contentHeadingWrapCss)}>
 					<span mix={css(headingIconCss)}>{fileIcon()}</span>
-					<h2 mix={css(contentHeadingCss)}>{heading}</h2>
+					<h2 mix={css(contentHeadingCss)} title={heading}>
+						{heading}
+					</h2>
 					{body ? (
 						<span mix={css(contentMetaCss)}>
 							{countLines(body)} lines · {formatBytes(body)}
@@ -742,12 +762,12 @@ const headingIconCss = {
 }
 
 // `overflow-wrap: anywhere` broke the path one character per line as soon as
-// the toolbar squeezed it; a path truncates from the front instead, and the
-// breadcrumb above still carries the full location.
+// the toolbar squeezed it; the path truncates instead, with the full location
+// in the title tooltip and the tree alongside.
 const contentHeadingCss = {
 	margin: 0,
 	minWidth: 0,
-	fontFamily: monoFont,
+	fontFamily: typography.fontFamilyMono,
 	fontSize: typography.fontSize.sm,
 	fontWeight: typography.fontWeight.semibold,
 	color: colors.text,
@@ -813,17 +833,21 @@ const codeCss = {
 		margin: 0,
 		padding: `${spacing.md} 0`,
 		overflowX: 'auto' as const,
-		fontFamily: monoFont,
+		fontFamily: typography.fontFamilyMono,
 		fontSize: '0.8125rem',
 		lineHeight: 1.55,
 	},
+	// Padding lives on `code`, not the .line spans, so the fallback output
+	// (plaintext before the Shiki chunk resolves, or an oversized file) gets
+	// the same gutters as highlighted lines.
 	'& code': {
+		display: 'block',
+		paddingInline: spacing.md,
 		counterReset: 'package-file-line',
 	},
 	'& .line': {
 		display: 'block',
 		counterIncrement: 'package-file-line',
-		paddingRight: spacing.md,
 	},
 	'& .line:hover': {
 		backgroundColor: colors.primarySoftest,

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -320,8 +320,8 @@ function renderContent(data: PackageFilesLoaderData): RemixNode {
 					{body ? (
 						<span mix={css(contentMetaCss)}>
 							{countLines(body)} lines · {formatBytes(body)}
-							{packageFileLanguageLabel(data.language)
-								? ` · ${packageFileLanguageLabel(data.language)}`
+							{packageFileLanguageLabel(data.contentPath)
+								? ` · ${packageFileLanguageLabel(data.contentPath)}`
 								: ''}
 						</span>
 					) : null}

--- a/packages/worker/client/routes/package-files.tsx
+++ b/packages/worker/client/routes/package-files.tsx
@@ -269,6 +269,23 @@ export function PackageFilesRoute(handle: Handle) {
 			)
 		}
 
+		// A commit without preloaded data (e.g. the router's loader-failure
+		// path) can land here holding another package's explorer; showing it
+		// under the new URL would render the wrong tree with the wrong links.
+		const currentPathname = new URL(currentHref, 'http://localhost').pathname
+		if (
+			data &&
+			currentPathname !== data.filesBasePath &&
+			!currentPathname.startsWith(`${data.filesBasePath}/`)
+		) {
+			data = null
+			return (
+				<article mix={css(messageCss)}>
+					<p>Loading files…</p>
+				</article>
+			)
+		}
+
 		// Switching files keeps the current one on screen until the next
 		// arrives. Tearing the explorer down to a loading line for the ~6ms
 		// between renders blinked the whole tree out and back, and made the

--- a/packages/worker/client/routes/package-files.tsx
+++ b/packages/worker/client/routes/package-files.tsx
@@ -20,6 +20,10 @@ import {
 import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
 import { routes } from '#universal/routes.ts'
 import { colors, spacing } from '#universal/styles/tokens.ts'
+import {
+	layoutMaxWidths,
+	pageGutter,
+} from '#universal/styles/style-primitives.ts'
 
 const communityPackageFilesMatcher = createMatcher(
 	routes.communityPackageFiles.pattern,
@@ -136,6 +140,13 @@ export async function packageFilesRouteLoader(
 	return { packageFiles: payload }
 }
 
+const messageCss = {
+	maxWidth: layoutMaxWidths.extended,
+	marginInline: 'auto',
+	padding: `${spacing.xl} ${pageGutter}`,
+	color: colors.textMuted,
+}
+
 export function PackageFilesRoute(handle: Handle) {
 	let status: 'loading' | 'ready' | 'error' | 'not-found' = 'loading'
 	let data: PackageFilesLoaderData | null = null
@@ -234,25 +245,39 @@ export function PackageFilesRoute(handle: Handle) {
 			})
 		}
 
-		if (status !== 'ready' || loadedHref !== currentHref || !data) {
+		// A miss or a failure replaces the explorer — there is nothing to keep
+		// showing, and the visitor has to be told.
+		if (status === 'not-found' || status === 'error') {
 			return (
-				<article
-					mix={css({
-						padding: spacing.xl,
-						color: colors.textMuted,
-					})}
-				>
+				<article mix={css(messageCss)}>
 					<p>
 						{status === 'not-found'
 							? 'Those files were not found.'
-							: status === 'error'
-								? 'Unable to load package files.'
-								: 'Loading files…'}
+							: 'Unable to load package files.'}
 					</p>
 				</article>
 			)
 		}
 
-		return <PackageFilesExplorer data={data} />
+		// Only the very first load has nothing to show; a server-rendered visit
+		// arrives with data already applied, so this is the SPA cold path.
+		if (!data) {
+			return (
+				<article mix={css(messageCss)}>
+					<p>Loading files…</p>
+				</article>
+			)
+		}
+
+		// Switching files keeps the current one on screen until the next
+		// arrives. Tearing the explorer down to a loading line for the ~6ms
+		// between renders blinked the whole tree out and back, and made the
+		// page transition run twice per click.
+		return (
+			<PackageFilesExplorer
+				data={data}
+				busy={status === 'loading' || loadedHref !== currentHref}
+			/>
+		)
 	}
 }

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -125,6 +125,7 @@
 	--font-display: 'Bricolage Grotesque', system-ui, sans-serif;
 	--font-body: 'Wix Madefor Text', system-ui, sans-serif;
 	--font-family: var(--font-body);
+	--font-mono: ui-monospace, 'SF Mono', Menlo, monospace;
 	--font-size-xs: 0.75rem;
 	--font-size-sm: 0.875rem;
 	--font-size-base: 1rem;

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -503,15 +503,34 @@ html.is-settled {
 	::view-transition-old(nav-progress),
 	::view-transition-new(nav-progress),
 	::view-transition-group(nav-progress),
-	::view-transition-group(account-nav) {
+	::view-transition-group(account-nav),
+	::view-transition-group(files-back),
+	::view-transition-group(files-head),
+	::view-transition-group(files-tree),
+	::view-transition-group(files-blob) {
 		animation: none;
 	}
 
-	::view-transition-old(account-nav) {
+	/* Same treatment for the whole package files explorer: switching files is
+	   an in-place content swap, so nothing there may lift and slide the way a
+	   route change does. Every part is named (lifted out of `page`) with its
+	   group pinned — the file pane's height changes per file, and an unpinned
+	   group would squash between the two sizes. Old/new cross-fade rather
+	   than being pinned outright: none of these are on screen outside
+	   `/files`, and pinning old/new strands the leftover snapshot. */
+	::view-transition-old(account-nav),
+	::view-transition-old(files-back),
+	::view-transition-old(files-head),
+	::view-transition-old(files-tree),
+	::view-transition-old(files-blob) {
 		animation: vt-page-out 120ms var(--ease-out) both;
 	}
 
-	::view-transition-new(account-nav) {
+	::view-transition-new(account-nav),
+	::view-transition-new(files-back),
+	::view-transition-new(files-head),
+	::view-transition-new(files-tree),
+	::view-transition-new(files-blob) {
 		animation: vt-account-nav-in 220ms var(--ease-out) both;
 	}
 

--- a/packages/worker/src/app/handlers/package-files.node.test.ts
+++ b/packages/worker/src/app/handlers/package-files.node.test.ts
@@ -59,7 +59,6 @@ const filesPayload = {
 	kind: 'file',
 	paths: ['src/index.ts'],
 	children: [],
-	ancestors: [{ name: 'src', path: 'src' }],
 	content: 'export const answer = 42\n',
 	contentPath: 'src/index.ts',
 	contentKind: 'code',

--- a/packages/worker/src/app/package-files-data.ts
+++ b/packages/worker/src/app/package-files-data.ts
@@ -37,7 +37,6 @@ function toLoaderData(input: {
 		kind: input.view.kind,
 		paths: input.view.paths,
 		children: input.view.children,
-		ancestors: input.view.ancestors,
 		content: input.view.content,
 		contentPath: input.view.contentPath,
 		contentKind: input.view.contentKind,

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -110,7 +110,6 @@ export type PackageFilesLoaderData = {
 	kind: 'file' | 'directory'
 	paths: Array<string>
 	children: Array<PackageFilesChildLoaderData>
-	ancestors: Array<{ name: string; path: string }>
 	content: string | null
 	contentPath: string | null
 	contentKind: 'markdown' | 'code' | 'text' | null

--- a/packages/worker/universal/package-files.node.test.ts
+++ b/packages/worker/universal/package-files.node.test.ts
@@ -65,10 +65,6 @@ test('package files views normalize paths and distinguish root, directories, fil
 		contentKind: 'code',
 		language: 'ts',
 	})
-	expect(file?.ancestors.map((entry) => entry.path)).toEqual([
-		'src',
-		'src/index.ts',
-	])
 
 	expect(buildPackageFilesView({ files, selectedPath: 'missing' })).toBeNull()
 	expect(buildPackageFilesView({ files: {}, selectedPath: '' })?.kind).toBe(

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -38,7 +38,6 @@ export type PackageFilesView = {
 	contentKind: PackageFilesContentKind | null
 	language: string | null
 	children: Array<PackageFilesChild>
-	ancestors: Array<PackageFilesAncestor>
 }
 
 const readmeFileNamePattern = /^readme(?:\.[a-z0-9._-]+)?$/i
@@ -311,7 +310,6 @@ export function buildPackageFilesView(input: {
 			contentKind: contentKindFromLanguage(language),
 			language,
 			children: [],
-			ancestors: buildPackageFilesAncestors(selectedPath),
 		}
 	}
 
@@ -327,7 +325,6 @@ export function buildPackageFilesView(input: {
 		contentKind: language ? contentKindFromLanguage(language) : null,
 		language,
 		children: listPackageFilesChildren(paths, selectedPath),
-		ancestors: buildPackageFilesAncestors(selectedPath),
 	}
 }
 

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -1,3 +1,4 @@
+import { createMultiMatcher } from 'remix/route-pattern/match'
 import { routes } from '#universal/routes.ts'
 
 /**
@@ -82,6 +83,56 @@ const extensionLanguages: Record<string, string> = {
 	ini: 'ini',
 	diff: 'diff',
 	patch: 'diff',
+}
+
+// Shiki grammar ids are what the highlighter needs; these are what a reader
+// should see next to a file's line count.
+const languageLabels: Record<string, string> = {
+	ts: 'TypeScript',
+	tsx: 'TypeScript',
+	json: 'JSON',
+	markdown: 'Markdown',
+	yaml: 'YAML',
+	toml: 'TOML',
+	html: 'HTML',
+	css: 'CSS',
+	shellscript: 'Shell',
+	python: 'Python',
+	go: 'Go',
+	rust: 'Rust',
+	sql: 'SQL',
+	graphql: 'GraphQL',
+	xml: 'XML',
+	dockerfile: 'Dockerfile',
+	dotenv: 'dotenv',
+	ini: 'INI',
+	diff: 'Diff',
+	plaintext: 'Plain text',
+}
+
+export function packageFileLanguageLabel(language: string | null | undefined) {
+	if (!language) return ''
+	return languageLabels[language] ?? language
+}
+
+/**
+ * The `/files` explorer routes, in every public shape. The app shell asks
+ * this so it can leave the page unpadded: the explorer owns its gutters (like
+ * the package listing it hangs off), and the shell's generic `main` padding
+ * would stack on top and push the content in past the site header.
+ */
+const packageFilesPathMatcher = (() => {
+	const matcher = createMultiMatcher<true>()
+	matcher.add(routes.communityPackageFiles.pattern, true)
+	matcher.add(routes.communityDetailFiles.pattern, true)
+	matcher.add(routes.accountPackageFiles.pattern, true)
+	return matcher
+})()
+
+export function isPackageFilesPathname(pathname: string) {
+	return (
+		packageFilesPathMatcher.match(new URL(pathname, 'http://localhost')) != null
+	)
 }
 
 export function isReservedPackageFilesKodyId(kodyId: string) {

--- a/packages/worker/universal/package-files.ts
+++ b/packages/worker/universal/package-files.ts
@@ -104,14 +104,24 @@ const languageLabels: Record<string, string> = {
 	graphql: 'GraphQL',
 	xml: 'XML',
 	dockerfile: 'Dockerfile',
-	dotenv: 'dotenv',
+	dotenv: 'Dotenv',
 	ini: 'INI',
 	diff: 'Diff',
 	plaintext: 'Plain text',
 }
 
-export function packageFileLanguageLabel(language: string | null | undefined) {
-	if (!language) return ''
+// The grammar map aliases the js family to the TypeScript grammar so the
+// client bundles one grammar for both; the label must not leak that, so it
+// derives from the file's own extension instead of the grammar id.
+const javascriptExtensions = new Set(['js', 'jsx', 'mjs', 'cjs'])
+
+export function packageFileLanguageLabel(path: string | null | undefined) {
+	if (!path) return ''
+	const name = path.split('/').pop() ?? ''
+	const separator = name.lastIndexOf('.')
+	const extension = separator > 0 ? name.slice(separator + 1).toLowerCase() : ''
+	if (javascriptExtensions.has(extension)) return 'JavaScript'
+	const language = languageFromFilePath(path)
 	return languageLabels[language] ?? language
 }
 

--- a/packages/worker/universal/styles/tokens.ts
+++ b/packages/worker/universal/styles/tokens.ts
@@ -34,6 +34,7 @@ export const typography = {
 	fontFamily: 'var(--font-family)',
 	fontFamilyDisplay: 'var(--font-display)',
 	fontFamilyBody: 'var(--font-body)',
+	fontFamilyMono: 'var(--font-mono)',
 	fontSize: {
 		xs: 'var(--font-size-xs)',
 		sm: 'var(--font-size-sm)',


### PR DESCRIPTION
## Intent

`/@owner/pkg/files` was the weakest surface in the community area: a bare
nested `<ul>` beside an unstyled code block. You could not collapse a
directory, could not find a file without reading the whole tree, and the code
rendered in the browser's default `monospace` at body line-height with no line
numbers. This rebuilds it on the shape people already know from GitHub, using
the app's existing tokens and components rather than a new vocabulary.

<img width="1142" height="1201" alt="image" src="https://github.com/user-attachments/assets/07c17214-cff8-4d20-8d2d-8258a27b4e66" />
<img width="1144" height="1209" alt="image" src="https://github.com/user-attachments/assets/bcf7f066-768c-44ce-b55e-fa88689358a0" />


## Summary

**Explorer**

- Collapsible tree: chevrons, file/directory icons, indent. Directory rows
  stay real links so the tree works without JS, and the chevron is a separate
  `aria-expanded` button. Opening a directory also unfolds it in the tree
  (checked against github.com — their sidebar rows both navigate and expand).
- "Go to file" filter, switching the tree to a flat match list with each hit
  labelled by its directory.
- Blob header with the path, line count, size and language.
  `packageFileLanguageLabel()` turns the Shiki grammar id into a readable name
  — the meta strip was showing `ts`.
- Line numbers ride Shiki's own `.line` spans as a CSS counter, so
  `renderHighlightedCode` keeps emitting one flat token tree. Code now uses
  the mono stack `style-primitives` already declares for inline code.
- Rendered markdown gets the reading inset the code view gets from its gutter,
  and tables size to their content and scroll horizontally instead of wrapping
  every cell to a few characters. Scoped to this route on purpose: `proseCss`
  styles no tables at all, so fixing it there would change guides and blog too
  — happy to lift it if wanted.
- The breadcrumb under the title is gone; the blob header already states the
  path.

**Two fixes the explorer needed from outside itself**

- *Gutters.* The container used `spacing.lg` for horizontal padding while the
  site header uses `pageGutter`. Above ~1216px the shell's own `main` padding
  is absorbed by centering so the edges happened to line up; below it, content
  sat wider than the nav and phones lost ~36px to a double gutter. This route
  now owns its gutters like the listing page it hangs off (`app.tsx`), and
  uses the header's exact box. Verified aligned to the nav at 570 / 844 / 968
  / 1144 / 1624px, single column below `mq.tablet`.
- *Navigation feel.* Switching files replaced the whole explorer with a
  loading line for one render (~6ms), which blinked the tree out and back and
  ran the page view transition twice per click. The current file now stays on
  screen until the next arrives (`aria-busy` while swapping), and the
  explorer's four regions are named and pinned so they cross-fade in place
  instead of sliding with the page — the same treatment `account-nav` already
  gets in `styles.css`.

Also documents the container rule in `docs/contributing/code-style.md`; it
previously lived only as a comment on `pageGutter`.

## Testing

- `npm run typecheck`, `oxlint`, `oxfmt --check` clean; full pre-push suite
  (1864 node tests + workers + e2e) green.
- Verified in a browser against a locally seeded copy of `@kentcdodds/skills`
  (12 real files) at five viewport widths, in both themes: nav/tree left edges
  measured equal at every width, no page-level horizontal scroll, filename on
  one line, markdown table scrolling inside its panel.
- Interaction verified live: collapse-all and chevrons toggle, filter narrows
  to matches, directory click navigates *and* expands, and across 116 samples
  during a file switch the tree is never torn down.
- Not covered by automated tests — this route has no e2e spec, and I did not
  add one in this PR.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `1310ff9f` · **Head:** `package-files-explorer`

**Classification:** composes — no primitives added or changed. One client
surface is rebuilt and one shell predicate is extended; no storage, auth, MCP
or capability boundary is touched.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — files explorer rebuilt; `main` no longer pads `/files` paths |

### Change flow

A file click inside the explorer, before and after: the route used to drop to a
loading line between renders, which tore the tree down and ran the page
transition twice.

```mermaid
sequenceDiagram
	participant visitor as visitor
	participant appUi as app-ui
	participant filesApi as app-ui (/files.json)
	visitor->>appUi: click a file row (SPA nav)
	appUi->>appUi: keep current file rendered, set aria-busy
	appUi->>filesApi: GET files.json?path=… (unchanged)
	filesApi-->>appUi: PackageFilesLoaderData
	appUi->>appUi: swap blob only (files-blob cross-fade, chrome pinned)
```

### Before / after

Page container, which is what moved the content off the header's edge:

```diff
- padding: `${spacing.xl} ${spacing.lg} ${spacing['2xl']}`   // fixed 1.5rem
+ padding: `${spacing.lg} ${pageGutter} ${spacing['2xl']}`   // clamp(1.25rem, 4vw, 2.5rem)
+ // and app.tsx leaves /files unpadded, as it already does for the listing page
```

### Invariants

Per-user isolation is untouched: the explorer reads the same loader data as
before, and both the community and account routes keep their existing auth
paths (`requireAuthenticatedPageUser` on the account side).

</details>

<!-- system-recap:end -->
