### PR TITLE
fix(mcp): keep package_save name UNIQUE conflicts off Sentry

### DIFF
--- a/packages/worker/src/mcp/capabilities/packages/save-package-entitlements.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package-entitlements.node.test.ts
@@ -151,6 +151,16 @@ function createDatabase(
 										row['user_id'] === params[1],
 								) as T | null
 							}
+							if (
+								query.includes('FROM saved_packages') &&
+								query.includes('WHERE name = ? AND user_id = ?')
+							) {
+								return selectOne(
+									'saved_packages',
+									(row) =>
+										row['name'] === params[0] && row['user_id'] === params[1],
+								) as T | null
+							}
 							throw new Error(`Unsupported first query: ${query}`)
 						},
 						async all<T = Record<string, unknown>>() {

--- a/packages/worker/src/mcp/capabilities/packages/save-package-name-collision.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package-name-collision.node.test.ts
@@ -10,6 +10,7 @@ const mockModule = vi.hoisted(() => ({
 	refreshSavedPackageProjection: vi.fn(),
 	upsertSavedPackageVector: vi.fn(),
 	getEntitySourceByEntity: vi.fn(),
+	deleteEntitySource: vi.fn(),
 	loadPriorPackageManifestContent: vi.fn(),
 }))
 
@@ -36,6 +37,8 @@ vi.mock('#worker/package-registry/vectorize.ts', () => ({
 vi.mock('#worker/repo/entity-sources.ts', () => ({
 	getEntitySourceByEntity: (...args: Array<unknown>) =>
 		mockModule.getEntitySourceByEntity(...args),
+	deleteEntitySource: (...args: Array<unknown>) =>
+		mockModule.deleteEntitySource(...args),
 }))
 
 vi.mock('#worker/repo/source-safety-policy.ts', async (importOriginal) => {
@@ -189,6 +192,7 @@ function setupPersistenceMocks() {
 	mockModule.refreshSavedPackageProjection.mockReset()
 	mockModule.upsertSavedPackageVector.mockReset()
 	mockModule.getEntitySourceByEntity.mockReset()
+	mockModule.deleteEntitySource.mockReset()
 	mockModule.loadPriorPackageManifestContent.mockReset()
 
 	mockModule.ensureEntitySource.mockImplementation(
@@ -229,6 +233,7 @@ function setupPersistenceMocks() {
 	)
 	mockModule.upsertSavedPackageVector.mockResolvedValue(undefined)
 	mockModule.getEntitySourceByEntity.mockResolvedValue(null)
+	mockModule.deleteEntitySource.mockResolvedValue(true)
 	mockModule.loadPriorPackageManifestContent.mockResolvedValue(null)
 }
 
@@ -446,4 +451,12 @@ test('package_save maps insert UNIQUE name races to McpCallerError', async () =>
 		return true
 	})
 	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalled()
+	expect(mockModule.deleteEntitySource).toHaveBeenCalledTimes(1)
+	expect(mockModule.deleteEntitySource).toHaveBeenCalledWith(
+		expect.anything(),
+		{
+			id: expect.stringMatching(/^source-/),
+			userId,
+		},
+	)
 })

--- a/packages/worker/src/mcp/capabilities/packages/save-package-name-collision.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package-name-collision.node.test.ts
@@ -1,0 +1,449 @@
+import { expect, test, vi } from 'vitest'
+import type * as sourceSafetyPolicyModule from '#worker/repo/source-safety-policy.ts'
+import { McpCallerError } from '#mcp/caller-error.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import { createMcpCallerContext } from '#mcp/context.ts'
+
+const mockModule = vi.hoisted(() => ({
+	ensureEntitySource: vi.fn(),
+	syncArtifactSourceSnapshot: vi.fn(),
+	refreshSavedPackageProjection: vi.fn(),
+	upsertSavedPackageVector: vi.fn(),
+	getEntitySourceByEntity: vi.fn(),
+	loadPriorPackageManifestContent: vi.fn(),
+}))
+
+vi.mock('#worker/repo/source-service.ts', () => ({
+	ensureEntitySource: (...args: Array<unknown>) =>
+		mockModule.ensureEntitySource(...args),
+}))
+
+vi.mock('#worker/repo/source-sync.ts', () => ({
+	syncArtifactSourceSnapshot: (...args: Array<unknown>) =>
+		mockModule.syncArtifactSourceSnapshot(...args),
+}))
+
+vi.mock('#worker/package-registry/service.ts', () => ({
+	refreshSavedPackageProjection: (...args: Array<unknown>) =>
+		mockModule.refreshSavedPackageProjection(...args),
+}))
+
+vi.mock('#worker/package-registry/vectorize.ts', () => ({
+	upsertSavedPackageVector: (...args: Array<unknown>) =>
+		mockModule.upsertSavedPackageVector(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	getEntitySourceByEntity: (...args: Array<unknown>) =>
+		mockModule.getEntitySourceByEntity(...args),
+}))
+
+vi.mock('#worker/repo/source-safety-policy.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof sourceSafetyPolicyModule>()
+	return {
+		...actual,
+		loadPriorPackageManifestContent: (...args: Array<unknown>) =>
+			mockModule.loadPriorPackageManifestContent(...args),
+		assertPackageSourceOverwriteAllowed: vi.fn(async () => undefined),
+	}
+})
+
+const {
+	buildSavedPackageIdMismatchMessage,
+	buildSavedPackageNameCollisionMessage,
+	savePackageCapability,
+} = await import('./save-package.ts')
+
+function createDatabase(
+	initialRows: {
+		users?: Array<Record<string, unknown>>
+		saved_packages?: Array<Record<string, unknown>>
+	} = {},
+	options: { failInsertWithUniqueName?: boolean } = {},
+) {
+	const tables = new Map<string, Array<Record<string, unknown>>>([
+		['users', (initialRows.users ?? []).map((row) => ({ ...row }))],
+		[
+			'saved_packages',
+			(initialRows.saved_packages ?? []).map((row) => ({ ...row })),
+		],
+	])
+
+	const clone = <T>(value: T): T => structuredClone(value)
+
+	function getTable(name: string) {
+		const table = tables.get(name)
+		if (!table) throw new Error(`Unknown table ${name}`)
+		return table
+	}
+
+	function selectOne(
+		tableName: string,
+		predicate: (row: Record<string, unknown>) => boolean,
+	) {
+		return clone(getTable(tableName).find(predicate) ?? null)
+	}
+
+	return {
+		prepare(query: string) {
+			return {
+				bind(...params: Array<unknown>) {
+					return {
+						async first<T = Record<string, unknown>>() {
+							if (query.includes('SELECT plan, stripe_plan FROM users')) {
+								return selectOne(
+									'users',
+									(row) =>
+										row['email'] === params[0] &&
+										row['stable_user_id'] === params[1],
+								) as T | null
+							}
+							if (
+								query.includes('SELECT username') &&
+								query.includes('FROM users') &&
+								query.includes('stable_user_id')
+							) {
+								return selectOne(
+									'users',
+									(row) => row['stable_user_id'] === params[0],
+								) as T | null
+							}
+							if (
+								query.includes('SELECT COUNT(*) AS count FROM saved_packages')
+							) {
+								return {
+									count: getTable('saved_packages').filter(
+										(row) => row['user_id'] === params[0],
+									).length,
+								} as T
+							}
+							if (
+								query.includes('FROM saved_packages') &&
+								query.includes('WHERE id = ? AND user_id = ?')
+							) {
+								return selectOne(
+									'saved_packages',
+									(row) =>
+										row['id'] === params[0] && row['user_id'] === params[1],
+								) as T | null
+							}
+							if (
+								query.includes('FROM saved_packages') &&
+								query.includes('WHERE kody_id = ? AND user_id = ?')
+							) {
+								return selectOne(
+									'saved_packages',
+									(row) =>
+										row['kody_id'] === params[0] &&
+										row['user_id'] === params[1],
+								) as T | null
+							}
+							if (
+								query.includes('FROM saved_packages') &&
+								query.includes('WHERE name = ? AND user_id = ?')
+							) {
+								return selectOne(
+									'saved_packages',
+									(row) =>
+										row['name'] === params[0] && row['user_id'] === params[1],
+								) as T | null
+							}
+							throw new Error(`Unsupported first query: ${query}`)
+						},
+						async run() {
+							if (query.includes('INSERT INTO saved_packages')) {
+								if (options.failInsertWithUniqueName) {
+									throw new Error(
+										'D1_ERROR: UNIQUE constraint failed: saved_packages.user_id, saved_packages.name: SQLITE_CONSTRAINT (extended: SQLITE_CONSTRAINT_UNIQUE)',
+									)
+								}
+								getTable('saved_packages').push({
+									id: params[0],
+									user_id: params[1],
+									name: params[2],
+									kody_id: params[3],
+									description: params[4],
+									tags_json: params[5],
+									search_text: params[6],
+									source_id: params[7],
+									has_app: params[8],
+									hidden: params[9],
+									is_private: params[10],
+									created_at: params[11],
+									updated_at: params[12],
+								})
+								return { meta: { changes: 1 } }
+							}
+							throw new Error(`Unsupported run query: ${query}`)
+						},
+					}
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+function setupPersistenceMocks() {
+	mockModule.ensureEntitySource.mockReset()
+	mockModule.syncArtifactSourceSnapshot.mockReset()
+	mockModule.refreshSavedPackageProjection.mockReset()
+	mockModule.upsertSavedPackageVector.mockReset()
+	mockModule.getEntitySourceByEntity.mockReset()
+	mockModule.loadPriorPackageManifestContent.mockReset()
+
+	mockModule.ensureEntitySource.mockImplementation(
+		async ({ entityId, userId }) => ({
+			id: `source-${entityId}`,
+			user_id: userId,
+			entity_kind: 'package',
+			entity_id: entityId,
+			repo_id: `repo-${entityId}`,
+			published_commit: 'published-commit-1',
+			indexed_commit: 'published-commit-1',
+			manifest_path: 'package.json',
+			source_root: '/',
+			created_at: '2026-08-19T00:00:00.000Z',
+			updated_at: '2026-08-19T00:00:00.000Z',
+			bootstrapAccess: null,
+		}),
+	)
+	mockModule.syncArtifactSourceSnapshot.mockResolvedValue('published-commit-1')
+	mockModule.refreshSavedPackageProjection.mockImplementation(
+		async ({ packageId, userId }) => ({
+			record: {
+				id: packageId,
+				userId,
+				name: '@collision/pkg',
+				kodyId: 'pkg',
+				description: 'Package pkg',
+				tags: [],
+				searchText: null,
+				sourceId: `source-${packageId}`,
+				hasApp: false,
+				hidden: false,
+				isPrivate: true,
+				createdAt: '2026-08-19T00:00:00.000Z',
+				updatedAt: '2026-08-19T00:00:00.000Z',
+			},
+		}),
+	)
+	mockModule.upsertSavedPackageVector.mockResolvedValue(undefined)
+	mockModule.getEntitySourceByEntity.mockResolvedValue(null)
+	mockModule.loadPriorPackageManifestContent.mockResolvedValue(null)
+}
+
+function buildPackageFiles(input: { name: string; kodyId: string }) {
+	return [
+		{
+			path: 'package.json',
+			content: JSON.stringify({
+				name: input.name,
+				private: true,
+				exports: { '.': './src/index.ts' },
+				kody: {
+					id: input.kodyId,
+					description: `Package ${input.kodyId}`,
+				},
+			}),
+		},
+		{
+			path: 'src/index.ts',
+			content: 'export default async function main() { return { ok: true } }\n',
+		},
+	]
+}
+
+test('package_save rejects unknown package_id when kody_id already owns a package', async () => {
+	setupPersistenceMocks()
+	const email = 'mismatch@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const existingPackageId = 'existing-package-id'
+	const requestedPackageId = 'fabricated-package-id'
+	const db = createDatabase({
+		users: [
+			{
+				email,
+				plan: 'pro',
+				username: 'collision',
+				stable_user_id: userId,
+			},
+		],
+		saved_packages: [
+			{
+				id: existingPackageId,
+				user_id: userId,
+				name: '@collision/pkg',
+				kody_id: 'pkg',
+				description: 'Existing package',
+				tags_json: '[]',
+				search_text: null,
+				source_id: 'source-existing',
+				has_app: 0,
+				hidden: 0,
+				is_private: 1,
+				created_at: '2026-08-19T00:00:00.000Z',
+				updated_at: '2026-08-19T00:00:00.000Z',
+			},
+		],
+	})
+	const ctx = {
+		env: { APP_DB: db } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId,
+				email,
+				displayName: 'Collision User',
+			},
+		}),
+	}
+
+	await expect(
+		savePackageCapability.handler(
+			{
+				package_id: requestedPackageId,
+				files: buildPackageFiles({
+					name: '@collision/pkg',
+					kodyId: 'pkg',
+				}),
+				confirm_destructive_overwrite: false,
+				confirm_private_visibility_change: false,
+			},
+			ctx as never,
+		),
+	).rejects.toSatisfy((error: unknown) => {
+		expect(error).toBeInstanceOf(McpCallerError)
+		expect((error as Error).message).toBe(
+			buildSavedPackageIdMismatchMessage({
+				requestedPackageId,
+				existingKodyId: 'pkg',
+				existingPackageId,
+			}),
+		)
+		return true
+	})
+	expect(mockModule.ensureEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
+})
+
+test('package_save rejects create when package.json#name collides with a legacy row', async () => {
+	setupPersistenceMocks()
+	const email = 'legacy@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const existingPackageId = 'legacy-package-id'
+	const sharedName = '@collision/new-kody'
+	const db = createDatabase({
+		users: [
+			{
+				email,
+				plan: 'pro',
+				username: 'collision',
+				stable_user_id: userId,
+			},
+		],
+		saved_packages: [
+			{
+				id: existingPackageId,
+				user_id: userId,
+				// Legacy row: name leaf no longer matches kody_id, so kody_id
+				// lookup misses while (user_id, name) still conflicts.
+				name: sharedName,
+				kody_id: 'legacy-other',
+				description: 'Legacy package',
+				tags_json: '[]',
+				search_text: null,
+				source_id: 'source-legacy',
+				has_app: 0,
+				hidden: 0,
+				is_private: 1,
+				created_at: '2026-08-19T00:00:00.000Z',
+				updated_at: '2026-08-19T00:00:00.000Z',
+			},
+		],
+	})
+	const ctx = {
+		env: { APP_DB: db } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId,
+				email,
+				displayName: 'Legacy User',
+			},
+		}),
+	}
+
+	await expect(
+		savePackageCapability.handler(
+			{
+				files: buildPackageFiles({ name: sharedName, kodyId: 'new-kody' }),
+				confirm_destructive_overwrite: false,
+				confirm_private_visibility_change: false,
+			},
+			ctx as never,
+		),
+	).rejects.toSatisfy((error: unknown) => {
+		expect(error).toBeInstanceOf(McpCallerError)
+		expect((error as Error).message).toBe(
+			buildSavedPackageNameCollisionMessage({
+				name: sharedName,
+				existingKodyId: 'legacy-other',
+				existingPackageId,
+			}),
+		)
+		return true
+	})
+	expect(mockModule.ensureEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.syncArtifactSourceSnapshot).not.toHaveBeenCalled()
+})
+
+test('package_save maps insert UNIQUE name races to McpCallerError', async () => {
+	setupPersistenceMocks()
+	const email = 'race@example.com'
+	const userId = await createStableUserIdFromEmail(email)
+	const db = createDatabase(
+		{
+			users: [
+				{
+					email,
+					plan: 'pro',
+					username: 'race',
+					stable_user_id: userId,
+				},
+			],
+		},
+		{ failInsertWithUniqueName: true },
+	)
+	const ctx = {
+		env: { APP_DB: db } as Env,
+		callerContext: createMcpCallerContext({
+			baseUrl: 'https://example.com',
+			user: {
+				userId,
+				email,
+				displayName: 'Race User',
+			},
+		}),
+	}
+
+	await expect(
+		savePackageCapability.handler(
+			{
+				files: buildPackageFiles({
+					name: '@race/pkg',
+					kodyId: 'pkg',
+				}),
+				confirm_destructive_overwrite: false,
+				confirm_private_visibility_change: false,
+			},
+			ctx as never,
+		),
+	).rejects.toSatisfy((error: unknown) => {
+		expect(error).toBeInstanceOf(McpCallerError)
+		expect((error as Error).message).toMatch(
+			/A saved package named "@race\/pkg" already exists/,
+		)
+		return true
+	})
+	expect(mockModule.syncArtifactSourceSnapshot).toHaveBeenCalled()
+})

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -6,7 +6,10 @@ import { capabilityDomainNames } from '#mcp/capabilities/domain-metadata.ts'
 import { requireMcpUser } from '#mcp/capabilities/meta/require-user.ts'
 import { ensureEntitySource } from '#worker/repo/source-service.ts'
 import { syncArtifactSourceSnapshot } from '#worker/repo/source-sync.ts'
-import { getEntitySourceByEntity } from '#worker/repo/entity-sources.ts'
+import {
+	deleteEntitySource,
+	getEntitySourceByEntity,
+} from '#worker/repo/entity-sources.ts'
 import {
 	buildRepoLargeFileMessage,
 	findOversizedRepoSourceFile,
@@ -388,8 +391,13 @@ export const savePackageCapability = defineDomainCapability(
 					const message = getErrorMessage(error)
 					// Pre-check covers the common path; this catches races where
 					// another create won the (user_id, name) or (user_id, kody_id)
-					// unique index between lookup and insert.
+					// unique index between lookup and insert. Drop only the source
+					// this invocation just created so a retry does not orphan it.
 					if (isSavedPackageUniqueConstraintMessage(message)) {
+						await deleteEntitySource(ctx.env, {
+							id: ensuredSource.id,
+							userId: owner.ownerUserId,
+						})
 						throw new McpCallerError(
 							buildSavedPackageUniqueConstraintCallerMessage({
 								name: manifest.name,

--- a/packages/worker/src/mcp/capabilities/packages/save-package.ts
+++ b/packages/worker/src/mcp/capabilities/packages/save-package.ts
@@ -26,6 +26,7 @@ import { injectDefaultPrivateField } from '#worker/package-registry/package-priv
 import {
 	getSavedPackageById,
 	getSavedPackageByKodyId,
+	getSavedPackageByName,
 	insertSavedPackage,
 } from '#worker/package-registry/repo.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
@@ -136,6 +137,47 @@ export function buildPackageSaveNextSteps(input: {
 	return steps.join(' ')
 }
 
+/**
+ * Per-user `saved_packages` uniqueness is on (user_id, name) and
+ * (user_id, kody_id). package_save resolves "existing" by package_id when
+ * provided, otherwise by kody_id. A wrong/new package_id must not skip the
+ * kody_id check and fall into INSERT — that surfaces as a raw D1 UNIQUE on
+ * name (KODY-CLOUDFLARE-5J).
+ */
+export function buildSavedPackageNameCollisionMessage(input: {
+	name: string
+	existingKodyId: string
+	existingPackageId: string
+}) {
+	return `A saved package named "${input.name}" already exists (kody_id "${input.existingKodyId}", package_id "${input.existingPackageId}"). Change package.json#name, or call package_save with package_id "${input.existingPackageId}" to update that package (set confirm_destructive_overwrite: true only after the user explicitly approves overwriting).`
+}
+
+export function buildSavedPackageIdMismatchMessage(input: {
+	requestedPackageId: string
+	existingKodyId: string
+	existingPackageId: string
+}) {
+	return `package_id "${input.requestedPackageId}" was not found. A saved package with kody_id "${input.existingKodyId}" already exists as package_id "${input.existingPackageId}". Omit package_id or pass package_id "${input.existingPackageId}" to update it (set confirm_destructive_overwrite: true only after the user explicitly approves overwriting).`
+}
+
+function isSavedPackageUniqueConstraintMessage(message: string) {
+	return (
+		/UNIQUE constraint failed/i.test(message) &&
+		/saved_packages\.(name|kody_id|user_id)/i.test(message)
+	)
+}
+
+function buildSavedPackageUniqueConstraintCallerMessage(input: {
+	name: string
+	kodyId: string
+	message: string
+}) {
+	if (/saved_packages\.kody_id/i.test(input.message)) {
+		return `A saved package with kody id "${input.kodyId}" already exists. Call package_save with that package's package_id to update it, or change package.json#kody.id.`
+	}
+	return `A saved package named "${input.name}" already exists. Change package.json#name, or call package_save with that package's package_id to update it.`
+}
+
 export const savePackageCapability = defineDomainCapability(
 	capabilityDomainNames.packages,
 	{
@@ -178,7 +220,11 @@ export const savePackageCapability = defineDomainCapability(
 				)
 			}
 			const expectedPackageScope = owner.ownerScope
-			const existing =
+			const lookupManifest = parseSavedPackageManifest({
+				content: packageJsonContent,
+				expectedPackageScope,
+			})
+			let existing =
 				args.package_id !== undefined
 					? await getSavedPackageById(ctx.env.APP_DB, {
 							userId: owner.ownerUserId,
@@ -186,11 +232,23 @@ export const savePackageCapability = defineDomainCapability(
 						})
 					: await getSavedPackageByKodyId(ctx.env.APP_DB, {
 							userId: owner.ownerUserId,
-							kodyId: parseSavedPackageManifest({
-								content: packageJsonContent,
-								expectedPackageScope,
-							}).kody.id,
+							kodyId: lookupManifest.kody.id,
 						})
+			if (!existing && args.package_id !== undefined) {
+				const byKodyId = await getSavedPackageByKodyId(ctx.env.APP_DB, {
+					userId: owner.ownerUserId,
+					kodyId: lookupManifest.kody.id,
+				})
+				if (byKodyId) {
+					throw new McpCallerError(
+						buildSavedPackageIdMismatchMessage({
+							requestedPackageId: args.package_id,
+							existingKodyId: byKodyId.kodyId,
+							existingPackageId: byKodyId.id,
+						}),
+					)
+				}
+			}
 			if (!existing) {
 				await assertWithinEntitlement({
 					db: ctx.env.APP_DB,
@@ -212,6 +270,19 @@ export const savePackageCapability = defineDomainCapability(
 				expectedPackageScope,
 			})
 			const packageId = existing?.id ?? args.package_id ?? crypto.randomUUID()
+			const nameOwner = await getSavedPackageByName(ctx.env.APP_DB, {
+				userId: owner.ownerUserId,
+				name: manifest.name,
+			})
+			if (nameOwner && nameOwner.id !== packageId) {
+				throw new McpCallerError(
+					buildSavedPackageNameCollisionMessage({
+						name: manifest.name,
+						existingKodyId: nameOwner.kodyId,
+						existingPackageId: nameOwner.id,
+					}),
+				)
+			}
 			const canonicalExistingSource =
 				existing == null
 					? null
@@ -297,21 +368,39 @@ export const savePackageCapability = defineDomainCapability(
 			})
 			if (!existing) {
 				const now = new Date().toISOString()
-				await insertSavedPackage(ctx.env.APP_DB, {
-					id: packageId,
-					user_id: owner.ownerUserId,
-					name: manifest.name,
-					kody_id: manifest.kody.id,
-					description: manifest.kody.description,
-					tags_json: JSON.stringify(manifest.kody.tags ?? []),
-					search_text: manifest.kody.searchText ?? null,
-					source_id: ensuredSource.id,
-					has_app: manifest.kody.app ? 1 : 0,
-					hidden: 0,
-					is_private: manifest.private === true ? 1 : 0,
-					created_at: now,
-					updated_at: now,
-				})
+				try {
+					await insertSavedPackage(ctx.env.APP_DB, {
+						id: packageId,
+						user_id: owner.ownerUserId,
+						name: manifest.name,
+						kody_id: manifest.kody.id,
+						description: manifest.kody.description,
+						tags_json: JSON.stringify(manifest.kody.tags ?? []),
+						search_text: manifest.kody.searchText ?? null,
+						source_id: ensuredSource.id,
+						has_app: manifest.kody.app ? 1 : 0,
+						hidden: 0,
+						is_private: manifest.private === true ? 1 : 0,
+						created_at: now,
+						updated_at: now,
+					})
+				} catch (error) {
+					const message = getErrorMessage(error)
+					// Pre-check covers the common path; this catches races where
+					// another create won the (user_id, name) or (user_id, kody_id)
+					// unique index between lookup and insert.
+					if (isSavedPackageUniqueConstraintMessage(message)) {
+						throw new McpCallerError(
+							buildSavedPackageUniqueConstraintCallerMessage({
+								name: manifest.name,
+								kodyId: manifest.kody.id,
+								message,
+							}),
+							{ cause: error },
+						)
+					}
+					throw error
+				}
 			}
 			await reportCapabilityProgress(ctx.reportProgress, {
 				progress: 2,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Sentry issue [KODY-CLOUDFLARE-5J](https://kent-c-dodds-tech-llc.sentry.io/issues/7681659351/) from firing when agents call `package_save` in a way that collides with an existing saved package name — return actionable `McpCallerError` instead of a raw D1 UNIQUE.

## Summary

- When `package_id` is provided but not found, also check `kody_id` and return a clear id-mismatch caller error (this matches the production breadcrumb: id lookup miss → INSERT → UNIQUE on name).
- Pre-check `(user_id, name)` before create/sync so legacy name collisions stay off Sentry.
- Catch insert UNIQUE races, delete only the source created by this invocation, and map to `McpCallerError` (same pattern as `repo_create`).
- Node tests for id mismatch, legacy name collision, and insert race + source cleanup.

No unresolved siblings share this root cause.

## Testing

- [x] `save-package-name-collision.node.test.ts` (3 passed)
- [x] `save-package-entitlements.node.test.ts` / `save-package-private-visibility.node.test.ts`
- [x] `observability.workers.test.ts` package_save cases (passed in isolation)
- [x] CI green on first revision; follow-up commit addresses CodeRabbit orphan-source feedback

## System changes

See system recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `fc40c5c3` · **Head:** `592a422f`

**Classification:** composes — no primitives added or reshaped; package_save maps existing uniqueness constraints to caller errors and cleans up its own create-path source on race.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | composes — clearer create collision errors on package_save |
| `d1-app-db` | storage | composes — delete entity_sources row created by this invocation on UNIQUE race |

### Change flow

Unknown package_id no longer skips kody_id ownership and falls into a raw D1 UNIQUE insert; insert races clean up the just-created source.

```mermaid
sequenceDiagram
	actor Agent
	participant PackageSave as package_save
	participant d1AppDb as d1-app-db
	Agent->>PackageSave: package_save with unknown package_id
	PackageSave->>d1AppDb: getSavedPackageById
	d1AppDb-->>PackageSave: miss
	PackageSave->>d1AppDb: getSavedPackageByKodyId
	alt kody_id already owned
		d1AppDb-->>PackageSave: existing row
		PackageSave-->>Agent: McpCallerError (id mismatch guidance)
	else name owned by another row
		PackageSave->>d1AppDb: getSavedPackageByName
		d1AppDb-->>PackageSave: colliding row
		PackageSave-->>Agent: McpCallerError (name collision guidance)
	else create race on insert
		PackageSave->>d1AppDb: insertSavedPackage
		d1AppDb-->>PackageSave: UNIQUE constraint
		PackageSave->>d1AppDb: deleteEntitySource (this invocation only)
		PackageSave-->>Agent: McpCallerError (mapped UNIQUE)
	end
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e880a3d5-8d2d-4f60-b4f5-5c2521eeeb92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e880a3d5-8d2d-4f60-b4f5-5c2521eeeb92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saved-package validation when package IDs or ownership details do not match.
  * Added clear errors for duplicate package names, including conflicts from simultaneous saves.
  * Prevented unnecessary source synchronization when validation fails.
  * Cleaned up newly created sources after save conflicts to avoid incomplete records.
  * Preserved source synchronization for successful saves.

* **Tests**
  * Added coverage for package ID mismatches, legacy name collisions, and concurrent save conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->