### PR TITLE
fix(client): filter Chrome extension Client destroyed Sentry noise (KODY-CLOUDFLARE-5K)

### DIFF
--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -258,6 +258,72 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 			exception: {
 				values: [
 					{
+						type: 'WrappedError',
+						value: 'Client has been destroyed',
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'chrome-extension://iohjgamcilhbgmhbnllfolmkmmekfmci/injected-scripts/host-additional-hooks.js',
+								},
+								{
+									function: 'a6.send',
+									abs_path:
+										'chrome-extension://iohjgamcilhbgmhbnllfolmkmmekfmci/injected-scripts/host-additional-hooks.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'WrappedError',
+						value: 'Client has been destroyed',
+						stacktrace: {
+							frames: [
+								{
+									filename: 'https://kody.codes/assets/entry.js',
+									function: 'boot',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Client has been destroyed during hydrate',
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'chrome-extension://iohjgamcilhbgmhbnllfolmkmmekfmci/injected-scripts/host-additional-hooks.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
 						type: 'ReferenceError',
 						value: 'CONFIG is not defined',
 						stacktrace: {

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -443,6 +443,76 @@ export function filterMetaMaskExtensionSentryEvent<
 }
 
 /**
+ * Chrome extension page hooks reject with "Client has been destroyed" when
+ * their background/service-worker client is gone (reload, update, or tab
+ * teardown). The rejected promise surfaces on the host page via
+ * `onunhandledrejection` with a stack that is exclusively chrome-extension
+ * frames — never Kody bundles. Signature from production issue 7682968915 /
+ * KODY-CLOUDFLARE-5K (`WrappedError: Client has been destroyed` from
+ * `chrome-extension://…/injected-scripts/host-additional-hooks.js`).
+ *
+ * Match is intentionally narrow: this exact wording (optional
+ * `WrappedError:` / `Error:` preface) AND every reported stack frame URL is
+ * `chrome-extension:`. Never blanket-drop "destroyed" wording from app code
+ * or mixed stacks that include first-party frames.
+ */
+const chromeExtensionClientDestroyedMessage =
+	/^(?:(?:WrappedError|Error):\s*)?Client has been destroyed\.?$/i
+
+export function isChromeExtensionClientDestroyedMessage(message: string) {
+	return chromeExtensionClientDestroyedMessage.test(message.trim())
+}
+
+export function isChromeExtensionStackFrameUrl(url: string) {
+	try {
+		return (
+			new URL(url, 'https://sentry.invalid').protocol === 'chrome-extension:'
+		)
+	} catch {
+		return false
+	}
+}
+
+export function isChromeExtensionClientDestroyedError(error: unknown) {
+	if (typeof error === 'string') {
+		return isChromeExtensionClientDestroyedMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isChromeExtensionClientDestroyedMessage(error.message)
+}
+
+export function isChromeExtensionClientDestroyedSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	const hasClientDestroyedMessage =
+		isChromeExtensionClientDestroyedError(originalException) ||
+		sentryEventMessages(event).some(
+			(message) =>
+				typeof message === 'string' &&
+				isChromeExtensionClientDestroyedMessage(message),
+		)
+	if (!hasClientDestroyedMessage) return false
+	const frameUrls = sentryEventStackFrameUrls(event)
+	return (
+		frameUrls.length > 0 &&
+		frameUrls.every(isChromeExtensionStackFrameUrl)
+	)
+}
+
+export function filterChromeExtensionClientDestroyedSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (
+		isChromeExtensionClientDestroyedSentryEvent(event, originalException)
+	) {
+		return null
+	}
+	return event
+}
+
+/**
  * Twitter/X iOS in-app browser chrome (`updateFooterPositions` /
  * `updateGapFiller`) references a host-page `CONFIG` global that Kody never
  * defines. WebKit reports it as an unhandled `ReferenceError` attributed to
@@ -661,6 +731,14 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 		return null
 	}
 	if (filterMetaMaskExtensionSentryEvent(event, originalException) === null) {
+		return null
+	}
+	if (
+		filterChromeExtensionClientDestroyedSentryEvent(
+			event,
+			originalException,
+		) === null
+	) {
 		return null
 	}
 	if (

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -495,18 +495,13 @@ export function isChromeExtensionClientDestroyedSentryEvent(
 		)
 	if (!hasClientDestroyedMessage) return false
 	const frameUrls = sentryEventStackFrameUrls(event)
-	return (
-		frameUrls.length > 0 &&
-		frameUrls.every(isChromeExtensionStackFrameUrl)
-	)
+	return frameUrls.length > 0 && frameUrls.every(isChromeExtensionStackFrameUrl)
 }
 
 export function filterChromeExtensionClientDestroyedSentryEvent<
 	T extends SentryErrorEventLike,
 >(event: T, originalException?: unknown): T | null {
-	if (
-		isChromeExtensionClientDestroyedSentryEvent(event, originalException)
-	) {
+	if (isChromeExtensionClientDestroyedSentryEvent(event, originalException)) {
 		return null
 	}
 	return event

--- a/packages/worker/client/sentry-init.ts
+++ b/packages/worker/client/sentry-init.ts
@@ -33,16 +33,18 @@ export function initBrowserSentry(config: SentryClientConfig) {
 		// injected wallet/`__firefox__` globals, Fathom beacon
 		// removeChild-on-null, Chrome extension IPC "Object Not Found
 		// Matching Id…", Chrome/Firefox extension "Receiving end does not
-		// exist", MetaMask inpage connect failures, Twitter/X in-app browser
-		// chrome `CONFIG` ReferenceErrors / `sendScrollEvent`→
-		// `window.webkit.messageHandlers` TypeErrors, and injected unguarded
-		// `meta[property='og:type']` probes from `global code`) — see
-		// filterBrowserSentryEvent / KODY-CLOUDFLARE-23 /
-		// KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S / KODY-CLOUDFLARE-3X /
-		// KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 / KODY-CLOUDFLARE-4F /
-		// KODY-CLOUDFLARE-5C / issues 7639685398, 7648833360, 7648833403,
-		// 7653117289, 7655189301, 7658961865, 7659616372, 7660258027,
-		// 7662064169, 7677729361.
+		// exist", MetaMask inpage connect failures, Chrome extension
+		// "Client has been destroyed" with exclusively chrome-extension
+		// frames, Twitter/X in-app browser chrome `CONFIG` ReferenceErrors /
+		// `sendScrollEvent`→ `window.webkit.messageHandlers` TypeErrors, and
+		// injected unguarded `meta[property='og:type']` probes from
+		// `global code`) — see filterBrowserSentryEvent /
+		// KODY-CLOUDFLARE-23 / KODY-CLOUDFLARE-3Q / KODY-CLOUDFLARE-3S /
+		// KODY-CLOUDFLARE-3X / KODY-CLOUDFLARE-43 / KODY-CLOUDFLARE-46 /
+		// KODY-CLOUDFLARE-4F / KODY-CLOUDFLARE-5C / KODY-CLOUDFLARE-5K /
+		// issues 7639685398, 7648833360, 7648833403, 7653117289, 7655189301,
+		// 7658961865, 7659616372, 7660258027, 7662064169, 7677729361,
+		// 7682968915.
 		beforeSend(event, hint) {
 			return filterBrowserSentryEvent(event, hint.originalException)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Chrome extension teardown noise from opening Sentry issues on production kody.codes pages.

## Summary

- Browser `beforeSend` now drops `Client has been destroyed` / `WrappedError: Client has been destroyed` when **every** stack frame URL is `chrome-extension:` (KODY-CLOUDFLARE-5K).
- Keeps the same message when any first-party frame is present, or when wording is only a partial match.
- Unit coverage added in `sentry-browser-filters.node.test.ts`; `sentry-init` comment documents the new family.

## Testing

- `npx vitest run packages/worker/client/sentry-browser-filters.node.test.ts`
- Local `npm run validate` hit unrelated worker/mock Cloudflare timeouts; CI is the authoritative gate for this PR.

## Sentry

- Issue: [KODY-CLOUDFLARE-5K](https://kent-c-dodds-tech-llc.sentry.io/issues/7682968915/)
- Root cause: third-party extension `host-additional-hooks.js` rejects after its client is destroyed; surfaces via `onunhandledrejection` with no Kody frames.
- Outcome after merge: mark issue **ignored** (filter prevents recurrence).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `8d2ca427` · **Head:** `4a747482`

**Classification:** composes — narrow browser Sentry `beforeSend` predicate only; no new primitives, contracts, or auth/isolation surface.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — extends existing browser noise filters in client Sentry init |

### What changed

```mermaid
sequenceDiagram
  participant Ext as Chrome extension page hook
  participant Page as kody.codes document
  participant Sentry as Browser Sentry SDK
  participant Filter as filterBrowserSentryEvent
  Ext->>Page: unhandledrejection Client has been destroyed
  Page->>Sentry: beforeSend(event)
  Sentry->>Filter: message + chrome-extension-only frames
  Filter-->>Sentry: null (drop)
  Note over Filter: App-frame or mixed stacks still pass through
```

### Risk

Low — filter-only; match requires exact wording and exclusively `chrome-extension:` frames.

### Invariants

No per-user isolation, auth, billing, or migration changes.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c912c62-a519-4751-a9fa-b7ba960d5085?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c912c62-a519-4751-a9fa-b7ba960d5085&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reports caused by Chrome extensions when the browser client has been destroyed.
  * Preserved reporting for equivalent application errors and relevant hydration-related errors.

* **Documentation**
  * Updated error-filtering documentation to clarify handling of browser, extension, in-app browser, and injected-script errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->