### PR TITLE
fix(repo): keep non-fast-forward publish pushes off Sentry (KODY-CLOUDFLARE-5M)

### DIFF
--- a/packages/worker/client/routes/account-package-tokens.tsx
+++ b/packages/worker/client/routes/account-package-tokens.tsx
@@ -114,8 +114,8 @@ function generatePackageInvocationRawToken() {
 	return `kody_${bytesToBase64Url(bytes)}`
 }
 
-function formatScope(values: Array<string>) {
-	if (values.length === 0) return 'None'
+function formatScope(values: Array<string> | null | undefined) {
+	if (!values || values.length === 0) return 'None'
 	if (isPackageTokenWildcardSelected(values)) return 'Any export'
 	return values.join(', ')
 }

--- a/packages/worker/client/sentry-browser-filters.node.test.ts
+++ b/packages/worker/client/sentry-browser-filters.node.test.ts
@@ -446,3 +446,40 @@ test('browser Sentry filters drop AbortError and Firefox Xray noise and keep rea
 		}),
 	).not.toBeNull()
 })
+
+test('browser Sentry filters drop WorkerGlobalScope blob importScripts NetworkError (KODY-CLOUDFLARE-5G)', () => {
+	const blobImportScriptsMessage =
+		"Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'blob:https://kody.codes/746a7af2-37c5-4c0d-953f-661052a239a3' failed to load."
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: blobImportScriptsMessage,
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'blob:https://kody.codes/da30da39-78fc-444b-abb1-01ebd8bfc126',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterBrowserSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'NetworkError',
+						value: 'Failed to fetch',
+					},
+				],
+			},
+		}),
+	).not.toBeNull()
+})

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -725,9 +725,7 @@ export function isBrowserBlobImportScriptsNetworkSentryEvent(
 export function filterBrowserBlobImportScriptsNetworkSentryEvent<
 	T extends SentryErrorEventLike,
 >(event: T, originalException?: unknown): T | null {
-	if (
-		isBrowserBlobImportScriptsNetworkSentryEvent(event, originalException)
-	) {
+	if (isBrowserBlobImportScriptsNetworkSentryEvent(event, originalException)) {
 		return null
 	}
 	return event

--- a/packages/worker/client/sentry-browser-filters.ts
+++ b/packages/worker/client/sentry-browser-filters.ts
@@ -688,6 +688,51 @@ export function filterOgTypeMetaQuerySelectorContentSentryEvent<
 	return event
 }
 
+/**
+ * Web Worker `importScripts` failing to load a `blob:` URL. Observed when a
+ * page navigates away (or HeadlessChrome tears down) while an editor/worker
+ * blob is still booting — KODY-CLOUDFLARE-5G on `/@…/files`. Not an app defect;
+ * match only this WorkerGlobalScope + blob: signature.
+ */
+const browserBlobImportScriptsNetworkErrorMessage =
+	/Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'blob:[^']+' failed to load\.?/i
+
+export function isBrowserBlobImportScriptsNetworkErrorMessage(message: string) {
+	return browserBlobImportScriptsNetworkErrorMessage.test(message.trim())
+}
+
+export function isBrowserBlobImportScriptsNetworkError(error: unknown) {
+	if (typeof error === 'string') {
+		return isBrowserBlobImportScriptsNetworkErrorMessage(error)
+	}
+	if (typeof error !== 'object' || error === null) return false
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isBrowserBlobImportScriptsNetworkErrorMessage(error.message)
+}
+
+export function isBrowserBlobImportScriptsNetworkSentryEvent(
+	event: SentryErrorEventLike,
+	originalException?: unknown,
+) {
+	if (isBrowserBlobImportScriptsNetworkError(originalException)) return true
+	return sentryEventMessages(event).some(
+		(message) =>
+			typeof message === 'string' &&
+			isBrowserBlobImportScriptsNetworkErrorMessage(message),
+	)
+}
+
+export function filterBrowserBlobImportScriptsNetworkSentryEvent<
+	T extends SentryErrorEventLike,
+>(event: T, originalException?: unknown): T | null {
+	if (
+		isBrowserBlobImportScriptsNetworkSentryEvent(event, originalException)
+	) {
+		return null
+	}
+	return event
+}
+
 /** Combined browser beforeSend / capture gate used by the client SDK. */
 export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	event: T,
@@ -752,6 +797,14 @@ export function filterBrowserSentryEvent<T extends SentryErrorEventLike>(
 	}
 	if (
 		filterOgTypeMetaQuerySelectorContentSentryEvent(
+			event,
+			originalException,
+		) === null
+	) {
+		return null
+	}
+	if (
+		filterBrowserBlobImportScriptsNetworkSentryEvent(
 			event,
 			originalException,
 		) === null

--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -273,6 +273,21 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			),
 		})
 
+		// Non-fast-forward publish push (KODY-CLOUDFLARE-5M). Plain Error from DO.
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'repo_publish_session',
+			domain: 'repo',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'PushRejectedError',
+			errorMessage:
+				'Push rejected because it was not a simple fast-forward. Use "force: true" to override.',
+			cause: new Error(
+				'Push rejected because it was not a simple fast-forward. Use "force: true" to override.',
+			),
+		})
+
 		// package_save destructive overwrite confirmation (issue 7661329778).
 		// Plain Error from shared source-safety-policy helpers.
 		logMcpEvent({
@@ -320,7 +335,7 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 		})
 	})
 
-	expect(payloads).toHaveLength(18)
+	expect(payloads).toHaveLength(19)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -157,8 +157,7 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	if (
 		getErrorCauseChain(cause).some(
 			(entry) =>
-				entry instanceof Error &&
-				isGitPushNotFastForwardMessage(entry.message),
+				entry instanceof Error && isGitPushNotFastForwardMessage(entry.message),
 		)
 	) {
 		return true

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -5,6 +5,7 @@ import { CommunityActionError } from '#worker/community/errors.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { isRepoLargeFileMessage } from '#worker/repo/large-file-policy.ts'
 import {
+	isGitPushNotFastForwardMessage,
 	isRepoSearchInvalidRegexMessage,
 	isRepoSessionInactiveMessage,
 } from '#worker/repo/repo-session-caller-error.ts'
@@ -146,6 +147,18 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 				entry instanceof Error &&
 				(isRepoSessionInactiveMessage(entry.message) ||
 					isRepoSearchInvalidRegexMessage(entry.message)),
+		)
+	) {
+		return true
+	}
+	// Non-fast-forward publish pushes (isomorphic-git PushRejectedError). The
+	// DO maps these to base_moved; this phrase match covers any plain Error
+	// that still escapes RPC — KODY-CLOUDFLARE-5M.
+	if (
+		getErrorCauseChain(cause).some(
+			(entry) =>
+				entry instanceof Error &&
+				isGitPushNotFastForwardMessage(entry.message),
 		)
 	) {
 		return true

--- a/packages/worker/src/repo/repo-session-caller-error.node.test.ts
+++ b/packages/worker/src/repo/repo-session-caller-error.node.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest'
+import {
+	isGitPushNotFastForwardError,
+	isGitPushNotFastForwardMessage,
+} from './repo-session-caller-error.ts'
+
+test('isGitPushNotFastForwardError matches isomorphic-git PushRejected non-FF only', () => {
+	expect(
+		isGitPushNotFastForwardMessage(
+			'Push rejected because it was not a simple fast-forward. Use "force: true" to override.',
+		),
+	).toBe(true)
+	expect(
+		isGitPushNotFastForwardMessage('Push rejected because tag-exists'),
+	).toBe(false)
+
+	const nonFastForward = Object.assign(
+		new Error(
+			'Push rejected because it was not a simple fast-forward. Use "force: true" to override.',
+		),
+		{ name: 'PushRejectedError', code: 'PushRejectedError' },
+	)
+	expect(isGitPushNotFastForwardError(nonFastForward)).toBe(true)
+
+	const tagExists = Object.assign(
+		new Error('Push rejected because tag-exists'),
+		{ name: 'PushRejectedError', code: 'PushRejectedError' },
+	)
+	expect(isGitPushNotFastForwardError(tagExists)).toBe(false)
+
+	expect(isGitPushNotFastForwardError(new Error('D1 write failed.'))).toBe(
+		false,
+	)
+})

--- a/packages/worker/src/repo/repo-session-caller-error.ts
+++ b/packages/worker/src/repo/repo-session-caller-error.ts
@@ -20,8 +20,7 @@ export function isRepoSessionInactiveMessage(message: string) {
  * RPC (subclass identity lost), MCP observability matches this phrase.
  * KODY-CLOUDFLARE-5M.
  */
-export const gitPushNotFastForwardMessagePhrase =
-	'not a simple fast-forward'
+export const gitPushNotFastForwardMessagePhrase = 'not a simple fast-forward'
 
 export function isGitPushNotFastForwardMessage(message: string) {
 	return message.includes(gitPushNotFastForwardMessagePhrase)
@@ -39,9 +38,7 @@ export function isGitPushNotFastForwardError(error: unknown) {
 				? error.message
 				: ''
 		// tag-exists uses the same error class; only treat non-FF as recoverable.
-		return (
-			message.length === 0 || isGitPushNotFastForwardMessage(message)
-		)
+		return message.length === 0 || isGitPushNotFastForwardMessage(message)
 	}
 	if (!('message' in error) || typeof error.message !== 'string') return false
 	return isGitPushNotFastForwardMessage(error.message)

--- a/packages/worker/src/repo/repo-session-caller-error.ts
+++ b/packages/worker/src/repo/repo-session-caller-error.ts
@@ -15,6 +15,39 @@ export function isRepoSessionInactiveMessage(message: string) {
 }
 
 /**
+ * isomorphic-git `PushRejectedError` for non-fast-forward pushes. Publish maps
+ * these to `base_moved` so agents rebase; when a plain Error still escapes DO
+ * RPC (subclass identity lost), MCP observability matches this phrase.
+ * KODY-CLOUDFLARE-5M.
+ */
+export const gitPushNotFastForwardMessagePhrase =
+	'not a simple fast-forward'
+
+export function isGitPushNotFastForwardMessage(message: string) {
+	return message.includes(gitPushNotFastForwardMessagePhrase)
+}
+
+export function isGitPushNotFastForwardError(error: unknown) {
+	if (typeof error !== 'object' || error === null) return false
+	const name =
+		'name' in error && typeof error.name === 'string' ? error.name : null
+	const code =
+		'code' in error && typeof error.code === 'string' ? error.code : null
+	if (name === 'PushRejectedError' || code === 'PushRejectedError') {
+		const message =
+			'message' in error && typeof error.message === 'string'
+				? error.message
+				: ''
+		// tag-exists uses the same error class; only treat non-FF as recoverable.
+		return (
+			message.length === 0 || isGitPushNotFastForwardMessage(message)
+		)
+	}
+	if (!('message' in error) || typeof error.message !== 'string') return false
+	return isGitPushNotFastForwardMessage(error.message)
+}
+
+/**
  * Stable prefix for invalid `mode=regex` patterns from repo session search.
  * Agents often pass Python/PCRE inline flags (`(?s)`, `(?i)`) that JavaScript
  * RegExp rejects; treat those as caller-correctable input, not platform bugs.

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -138,6 +138,10 @@ const mockModule = vi.hoisted(() => {
 			remote:
 				'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
 		})),
+		resolveArtifactSourceHead: vi.fn(async () => ({
+			branch: 'main',
+			commit: 'commit-published-new',
+		})),
 		parseRepoManifest: vi.fn(() => ({ sourceRoot: '/' })),
 		runRepoChecks: vi.fn(async () => ({
 			ok: true,
@@ -257,6 +261,10 @@ function restoreRepoSessionMockBaseline() {
 		defaultBranch: 'main',
 		commit: 'commit-published-new',
 		remote: 'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
+	})
+	mockModule.resolveArtifactSourceHead.mockResolvedValue({
+		branch: 'main',
+		commit: 'commit-published-new',
 	})
 	mockModule.parseRepoManifest.mockReturnValue({ sourceRoot: '/' })
 	mockModule.runRepoChecks.mockResolvedValue({
@@ -467,6 +475,8 @@ vi.mock('./artifacts.ts', async () => {
 			mockModule.resolveExistingArtifactSourceRepo(...args),
 		resolveArtifactDefaultBranchHead: (...args: Array<unknown>) =>
 			mockModule.resolveArtifactDefaultBranchHead(...args),
+		resolveArtifactSourceHead: (...args: Array<unknown>) =>
+			mockModule.resolveArtifactSourceHead(...args),
 	}
 })
 
@@ -2631,11 +2641,12 @@ test('publishSession maps non-fast-forward PushRejectedError to base_moved witho
 		sessionId: 'session-1',
 		publishedCommit: null,
 		sessionBaseCommit: 'commit-base',
-		currentPublishedCommit: 'commit-base',
+		currentPublishedCommit: 'commit-published-new',
 		repairHint: 'repo_rebase_session',
 		message:
 			'The source repo rejected a non-fast-forward publish. Rebase the session before publishing.',
 	})
+	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalled()
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 	expect(mockModule.git.push).toHaveBeenCalledWith(
 		expect.objectContaining({

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -134,13 +134,13 @@ const mockModule = vi.hoisted(() => {
 		resolveExistingArtifactSourceRepo: vi.fn(),
 		resolveArtifactDefaultBranchHead: vi.fn(async () => ({
 			defaultBranch: 'main',
-			commit: 'commit-published-new',
+			commit: 'commit-base',
 			remote:
 				'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
 		})),
 		resolveArtifactSourceHead: vi.fn(async () => ({
 			branch: 'main',
-			commit: 'commit-published-new',
+			commit: 'commit-base',
 		})),
 		parseRepoManifest: vi.fn(() => ({ sourceRoot: '/' })),
 		runRepoChecks: vi.fn(async () => ({
@@ -259,12 +259,12 @@ function restoreRepoSessionMockBaseline() {
 	})
 	mockModule.resolveArtifactDefaultBranchHead.mockResolvedValue({
 		defaultBranch: 'main',
-		commit: 'commit-published-new',
+		commit: 'commit-base',
 		remote: 'https://acct.artifacts.cloudflare.net/git/default/source-repo.git',
 	})
 	mockModule.resolveArtifactSourceHead.mockResolvedValue({
 		branch: 'main',
-		commit: 'commit-published-new',
+		commit: 'commit-base',
 	})
 	mockModule.parseRepoManifest.mockReturnValue({ sourceRoot: '/' })
 	mockModule.runRepoChecks.mockResolvedValue({
@@ -2632,6 +2632,18 @@ test('publishSession maps non-fast-forward PushRejectedError to base_moved witho
 	})
 	const repoSession = new RepoSession(state, createEnv())
 
+	// Pre-push live tip matches session base; post-rejection tip has moved.
+	mockModule.resolveArtifactSourceHead.mockClear()
+	mockModule.resolveArtifactSourceHead
+		.mockResolvedValueOnce({
+			branch: 'main',
+			commit: 'commit-base',
+		})
+		.mockResolvedValueOnce({
+			branch: 'main',
+			commit: 'commit-published-new',
+		})
+
 	const result = await repoSession.publishSession({
 		sessionId: 'session-1',
 		userId: 'user-1',
@@ -2646,7 +2658,12 @@ test('publishSession maps non-fast-forward PushRejectedError to base_moved witho
 		message:
 			'The source repo rejected a non-fast-forward publish. Rebase the session before publishing.',
 	})
-	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalled()
+	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalledTimes(2)
+	expect(mockModule.resolveArtifactSourceHead).toHaveBeenNthCalledWith(
+		2,
+		expect.anything(),
+		'source-repo',
+	)
 	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
 	expect(mockModule.git.push).toHaveBeenCalledWith(
 		expect.objectContaining({

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -806,6 +806,7 @@ test('rebaseSession and publishSession use Artifacts username/password auth with
 		expect.objectContaining({
 			remote: 'origin',
 			ref: 'sessions/session1',
+			force: true,
 			username: 'x',
 			password: 'art_source_secret',
 		}),
@@ -827,6 +828,7 @@ test('rebaseSession and publishSession use Artifacts username/password auth with
 		expect.objectContaining({
 			remote: 'origin',
 			ref: 'sessions/session1',
+			force: true,
 			username: 'x',
 			password: 'art_source_secret',
 		}),
@@ -842,6 +844,7 @@ test('rebaseSession and publishSession use Artifacts username/password auth with
 			remote: 'origin',
 			ref: 'sessions/session1',
 			remoteRef: 'main',
+			force: true,
 		}),
 	)
 	for (const call of mockModule.git.push.mock.calls) {
@@ -2593,5 +2596,54 @@ test('already_published external publish fails when snapshot refresh fails', asy
 		expect.objectContaining({
 			scope: 'repo.publishFromExternalRef.refresh-already-published-snapshot',
 		}),
+	)
+})
+
+test('publishSession maps non-fast-forward PushRejectedError to base_moved without force', async () => {
+	consoleWarn.mockImplementation(() => {})
+	setCommonSessionFixtures()
+	mockModule.rawPush.mockRejectedValueOnce(
+		Object.assign(
+			new Error(
+				'Push rejected because it was not a simple fast-forward. Use "force: true" to override.',
+			),
+			{ name: 'PushRejectedError', code: 'PushRejectedError' },
+		),
+	)
+	const state = createDurableObjectState()
+	// Empty workspace → SHA-256 of '' so checks are not stale without force.
+	await state.storage.put('repo-session:last-check-status', {
+		runId: 'run-1',
+		treeHash:
+			'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+		checkedAt: '2026-04-18T00:00:00.000Z',
+		ok: true,
+		results: [],
+	})
+	const repoSession = new RepoSession(state, createEnv())
+
+	const result = await repoSession.publishSession({
+		sessionId: 'session-1',
+		userId: 'user-1',
+	})
+	expect(result).toEqual({
+		status: 'base_moved',
+		sessionId: 'session-1',
+		publishedCommit: null,
+		sessionBaseCommit: 'commit-base',
+		currentPublishedCommit: 'commit-base',
+		repairHint: 'repo_rebase_session',
+		message:
+			'The source repo rejected a non-fast-forward publish. Rebase the session before publishing.',
+	})
+	expect(mockModule.updateEntitySource).not.toHaveBeenCalled()
+	expect(mockModule.git.push).toHaveBeenCalledWith(
+		expect.objectContaining({
+			ref: 'sessions/session1',
+			force: true,
+		}),
+	)
+	expect(mockModule.rawPush).toHaveBeenCalledWith(
+		expect.not.objectContaining({ force: true }),
 	)
 })

--- a/packages/worker/src/repo/repo-session-do.node.test.ts
+++ b/packages/worker/src/repo/repo-session-do.node.test.ts
@@ -2632,17 +2632,12 @@ test('publishSession maps non-fast-forward PushRejectedError to base_moved witho
 	})
 	const repoSession = new RepoSession(state, createEnv())
 
-	// Pre-push live tip matches session base; post-rejection tip has moved.
+	// Post-rejection tip refresh (precheck uses D1 published_commit only).
 	mockModule.resolveArtifactSourceHead.mockClear()
-	mockModule.resolveArtifactSourceHead
-		.mockResolvedValueOnce({
-			branch: 'main',
-			commit: 'commit-base',
-		})
-		.mockResolvedValueOnce({
-			branch: 'main',
-			commit: 'commit-published-new',
-		})
+	mockModule.resolveArtifactSourceHead.mockResolvedValueOnce({
+		branch: 'main',
+		commit: 'commit-published-new',
+	})
 
 	const result = await repoSession.publishSession({
 		sessionId: 'session-1',
@@ -2658,9 +2653,8 @@ test('publishSession maps non-fast-forward PushRejectedError to base_moved witho
 		message:
 			'The source repo rejected a non-fast-forward publish. Rebase the session before publishing.',
 	})
-	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalledTimes(2)
-	expect(mockModule.resolveArtifactSourceHead).toHaveBeenNthCalledWith(
-		2,
+	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalledTimes(1)
+	expect(mockModule.resolveArtifactSourceHead).toHaveBeenCalledWith(
 		expect.anything(),
 		'source-repo',
 	)

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -2594,10 +2594,14 @@ class RepoSessionBase extends DurableObject<Env> {
 			})
 		} catch (error) {
 			if (isGitPushNotFastForwardError(error)) {
+				const refreshedHead = await resolveLiveSourceHeadCommit(
+					this.env,
+					input.source,
+				)
 				return this.buildPublishBaseMovedResult({
 					sessionId: input.sessionRow.id,
 					sessionBaseCommit: input.sessionRow.base_commit,
-					currentPublishedCommit: liveHead,
+					currentPublishedCommit: refreshedHead ?? liveHead,
 				})
 			}
 			throw error
@@ -2752,10 +2756,14 @@ class RepoSessionBase extends DurableObject<Env> {
 			})
 		} catch (error) {
 			if (!forceSourcePush && isGitPushNotFastForwardError(error)) {
+				const refreshedHead = await resolveLiveSourceHeadCommit(
+					this.env,
+					source,
+				)
 				return this.buildPublishBaseMovedResult({
 					sessionId: input.sessionId,
 					sessionBaseCommit: sessionRow.base_commit,
-					currentPublishedCommit: source.published_commit,
+					currentPublishedCommit: refreshedHead ?? source.published_commit,
 				})
 			}
 			throw error

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -105,6 +105,7 @@ import {
 	measureRepoSessionWorkspaceBlobBytes,
 	purgeRepoSessionWorkspaceBlobs,
 } from './repo-session-blobs.ts'
+import { isGitPushNotFastForwardError } from './repo-session-caller-error.ts'
 import {
 	assertPackagePrivateVisibilityChangeAllowed,
 	assertPackageSourceOverwriteAllowed,
@@ -621,6 +622,7 @@ class RepoSessionBase extends DurableObject<Env> {
 		branch: string
 		remoteRef: string
 		token: string
+		force?: boolean
 	}) {
 		const auth = buildArtifactsGitAuth({ token: input.token })
 		return rawGit.push({
@@ -630,10 +632,28 @@ class RepoSessionBase extends DurableObject<Env> {
 			remote: 'origin',
 			ref: input.branch,
 			remoteRef: input.remoteRef,
+			...(input.force === true ? { force: true } : {}),
 			onAuth() {
 				return auth
 			},
 		})
+	}
+
+	private buildPublishBaseMovedResult(input: {
+		sessionId: string
+		sessionBaseCommit: string
+		currentPublishedCommit: string | null
+	}): Extract<RepoSessionPublishResult, { status: 'base_moved' }> {
+		return {
+			status: 'base_moved',
+			sessionId: input.sessionId,
+			publishedCommit: null,
+			sessionBaseCommit: input.sessionBaseCommit,
+			currentPublishedCommit: input.currentPublishedCommit,
+			repairHint: 'repo_rebase_session',
+			message:
+				'The source repo rejected a non-fast-forward publish. Rebase the session before publishing.',
+		}
 	}
 
 	private async deleteRemoteBranch(input: { branch: string; token: string }) {
@@ -2486,10 +2506,13 @@ class RepoSessionBase extends DurableObject<Env> {
 			...buildArtifactsGitAuth({ token: sessionAccess.token }),
 		})
 		const headCommit = await this.getHeadCommit()
+		// Session branches are ephemeral workspace state; pull/merge can rewrite
+		// history, so force-push the session ref (never the source branch).
 		await this.git.push({
 			dir: repoSessionWorkspacePrefix,
 			remote: 'origin',
 			ref: sessionBranch,
+			force: true,
 			...buildArtifactsGitAuth({ token: sessionAccess.token }),
 		})
 		// Resolve the live head exactly once so the persisted base_commit and
@@ -2560,13 +2583,25 @@ class RepoSessionBase extends DurableObject<Env> {
 			dir: repoSessionWorkspacePrefix,
 			remote: 'origin',
 			ref: sessionBranch,
+			force: true,
 			...buildArtifactsGitAuth({ token: input.sessionAccess.token }),
 		})
-		await this.pushBranchToRemoteRef({
-			branch: sessionBranch,
-			remoteRef: input.sessionRow.source_branch,
-			token: input.sessionAccess.token,
-		})
+		try {
+			await this.pushBranchToRemoteRef({
+				branch: sessionBranch,
+				remoteRef: input.sessionRow.source_branch,
+				token: input.sessionAccess.token,
+			})
+		} catch (error) {
+			if (isGitPushNotFastForwardError(error)) {
+				return this.buildPublishBaseMovedResult({
+					sessionId: input.sessionRow.id,
+					sessionBaseCommit: input.sessionRow.base_commit,
+					currentPublishedCommit: liveHead,
+				})
+			}
+			throw error
+		}
 		const publishedCommit = sessionHeadCommit ?? input.sessionRow.base_commit
 		await this.attachSourcePublishGitNote({
 			source: input.source,
@@ -2590,6 +2625,18 @@ class RepoSessionBase extends DurableObject<Env> {
 			lastCheckpointCommit: publishedCommit,
 			lastCheckpointAt: nowIso(),
 			expiresAt: buildPublishedSessionExpiresAt(),
+		})
+		await this.writeCachedSessionState({
+			sessionRow: {
+				...input.sessionRow,
+				status: 'published',
+				base_commit: publishedCommit,
+				last_checkpoint_commit: publishedCommit,
+			},
+			source: {
+				...input.source,
+				published_commit: publishedCommit,
+			},
 		})
 		this.refreshStoredEstimate(input.sessionRow.id, input.sessionRow.user_id)
 		return {
@@ -2692,13 +2739,27 @@ class RepoSessionBase extends DurableObject<Env> {
 			dir: repoSessionWorkspacePrefix,
 			remote: 'origin',
 			ref: sessionBranch,
+			force: true,
 			...buildArtifactsGitAuth({ token: sessionAccess.token }),
 		})
-		await this.pushBranchToRemoteRef({
-			branch: sessionBranch,
-			remoteRef: sessionRow.source_branch,
-			token: sessionAccess.token,
-		})
+		const forceSourcePush = input.force === true
+		try {
+			await this.pushBranchToRemoteRef({
+				branch: sessionBranch,
+				remoteRef: sessionRow.source_branch,
+				token: sessionAccess.token,
+				...(forceSourcePush ? { force: true } : {}),
+			})
+		} catch (error) {
+			if (!forceSourcePush && isGitPushNotFastForwardError(error)) {
+				return this.buildPublishBaseMovedResult({
+					sessionId: input.sessionId,
+					sessionBaseCommit: sessionRow.base_commit,
+					currentPublishedCommit: source.published_commit,
+				})
+			}
+			throw error
+		}
 		const snapshotFiles = await this.collectWorkspaceFiles()
 		await finalizePublishedEntitySource({
 			env: this.env,
@@ -2731,6 +2792,18 @@ class RepoSessionBase extends DurableObject<Env> {
 			lastCheckpointCommit: sessionHeadCommit,
 			lastCheckpointAt: nowIso(),
 			expiresAt: buildPublishedSessionExpiresAt(),
+		})
+		await this.writeCachedSessionState({
+			sessionRow: {
+				...sessionRow,
+				status: 'published',
+				base_commit: publishedCommit,
+				last_checkpoint_commit: sessionHeadCommit,
+			},
+			source: {
+				...source,
+				published_commit: publishedCommit,
+			},
 		})
 		this.refreshStoredEstimate(sessionRow.id, sessionRow.user_id)
 		return {

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -2517,10 +2517,12 @@ class RepoSessionBase extends DurableObject<Env> {
 		})
 		// Resolve the live head exactly once so the persisted base_commit and
 		// the returned baseCommit cannot diverge when a push lands in between.
+		// Packages use the Artifacts tip too (not only D1 published_commit) so a
+		// non-fast-forward publish's repair path rebases onto the same tip the
+		// push rejected against.
 		const rebasedBaseCommit =
-			source.entity_kind === 'repo'
-				? ((await resolveLiveSourceHeadCommit(this.env, source)) ?? '')
-				: (source.published_commit ?? '')
+			(await resolveLiveSourceHeadCommit(this.env, source)) ??
+			(source.published_commit ?? '')
 		await updateRepoSession(this.env, {
 			id: sessionRow.id,
 			userId: sessionRow.user_id,
@@ -2689,13 +2691,16 @@ class RepoSessionBase extends DurableObject<Env> {
 					'Run repo_run_checks on the current session state before publishing.',
 			}
 		}
-		if ((source.published_commit ?? '') !== sessionRow.base_commit) {
+		const livePublishedCommit =
+			(await resolveLiveSourceHeadCommit(this.env, source)) ??
+			source.published_commit
+		if ((livePublishedCommit ?? '') !== sessionRow.base_commit) {
 			return {
 				status: 'base_moved',
 				sessionId: input.sessionId,
 				publishedCommit: null,
 				sessionBaseCommit: sessionRow.base_commit,
-				currentPublishedCommit: source.published_commit,
+				currentPublishedCommit: livePublishedCommit,
 				repairHint: 'repo_rebase_session',
 				message:
 					'The source repo has moved since this session opened. Rebase the session before publishing.',
@@ -2763,7 +2768,8 @@ class RepoSessionBase extends DurableObject<Env> {
 				return this.buildPublishBaseMovedResult({
 					sessionId: input.sessionId,
 					sessionBaseCommit: sessionRow.base_commit,
-					currentPublishedCommit: refreshedHead ?? source.published_commit,
+					currentPublishedCommit:
+						refreshedHead ?? livePublishedCommit ?? source.published_commit,
 				})
 			}
 			throw error

--- a/packages/worker/src/repo/repo-session-do.ts
+++ b/packages/worker/src/repo/repo-session-do.ts
@@ -2517,12 +2517,12 @@ class RepoSessionBase extends DurableObject<Env> {
 		})
 		// Resolve the live head exactly once so the persisted base_commit and
 		// the returned baseCommit cannot diverge when a push lands in between.
-		// Packages use the Artifacts tip too (not only D1 published_commit) so a
-		// non-fast-forward publish's repair path rebases onto the same tip the
-		// push rejected against.
+		// Packages stay on D1 published_commit: Artifacts HEAD can include
+		// unpublished git-lane pushes that must not become the session base.
 		const rebasedBaseCommit =
-			(await resolveLiveSourceHeadCommit(this.env, source)) ??
-			(source.published_commit ?? '')
+			source.entity_kind === 'repo'
+				? ((await resolveLiveSourceHeadCommit(this.env, source)) ?? '')
+				: (source.published_commit ?? '')
 		await updateRepoSession(this.env, {
 			id: sessionRow.id,
 			userId: sessionRow.user_id,
@@ -2691,16 +2691,13 @@ class RepoSessionBase extends DurableObject<Env> {
 					'Run repo_run_checks on the current session state before publishing.',
 			}
 		}
-		const livePublishedCommit =
-			(await resolveLiveSourceHeadCommit(this.env, source)) ??
-			source.published_commit
-		if ((livePublishedCommit ?? '') !== sessionRow.base_commit) {
+		if ((source.published_commit ?? '') !== sessionRow.base_commit) {
 			return {
 				status: 'base_moved',
 				sessionId: input.sessionId,
 				publishedCommit: null,
 				sessionBaseCommit: sessionRow.base_commit,
-				currentPublishedCommit: livePublishedCommit,
+				currentPublishedCommit: source.published_commit,
 				repairHint: 'repo_rebase_session',
 				message:
 					'The source repo has moved since this session opened. Rebase the session before publishing.',
@@ -2768,8 +2765,7 @@ class RepoSessionBase extends DurableObject<Env> {
 				return this.buildPublishBaseMovedResult({
 					sessionId: input.sessionId,
 					sessionBaseCommit: sessionRow.base_commit,
-					currentPublishedCommit:
-						refreshedHead ?? livePublishedCommit ?? source.published_commit,
+					currentPublishedCommit: refreshedHead ?? source.published_commit,
 				})
 			}
 			throw error


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry triage for **KODY-CLOUDFLARE-5M** (`PushRejectedError` from `repo_publish_session`) plus backfill siblings **5H** / **5G** (unrelated root causes; handled in the same PR).

### KODY-CLOUDFLARE-5M — PushRejectedError on publish

After rebase/publish, isomorphic-git can reject a non-fast-forward push. That error escaped the RepoSession DO as a platform Sentry issue instead of the existing `base_moved` recovery path.

- Force-push **ephemeral session branches** after rebase and during publish (history may be rewritten by pull/merge).
- On source-branch push rejection without `force`, return `base_moved` with `repo_rebase_session` repair hint, after refreshing the live Artifacts source tip for `currentPublishedCommit`.
- When `force: true` (already gated by overwrite confirmation), force-push the source ref too.
- Update the DO session cache after successful publish so status/`published_commit` stay coherent.
- Observability phrase-match keeps any escaped PushRejected non-FF off Sentry.

### KODY-CLOUDFLARE-5H — formatSources `.length` TypeError

Already fixed on main by #1570 (dropped invocation-token source allowlist / `formatSources`). Resolved in Sentry against `03f1f547`. This PR also hardens `formatScope` against missing `exportNames`.

### KODY-CLOUDFLARE-5G — blob `importScripts` NetworkError

Narrow browser `beforeSend` filter for `WorkerGlobalScope` blob `importScripts` load failures (HeadlessChrome / navigation tear-down noise on `/@…/files`).

## Test plan

- [x] Unit: `publishSession` maps PushRejected → `base_moved` (refreshed live tip)
- [x] Unit: observability drops PushRejected non-FF caller failures
- [x] Unit: browser filter drops blob importScripts NetworkError
- [x] Preview: login + `/account/packages` smoke on `kody-pr-1603`
- [ ] CI green on PR

## Preview

![Preview account packages empty state](https://cursor.com/artifacts/c/art-ee1567b9-4522-4dc6-b4e9-6ed0589f7954)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `493ac5c2` · **Head:** `b0afc12c`

**Classification:** extends — changes repo-session publish/rebase push behavior and MCP/browser Sentry caller-failure matching; no new primitives.

### Primitives touched

| Primitive       | Group    | Impact                                                                  |
| --------------- | -------- | ----------------------------------------------------------------------- |
| `repo-sessions` | runtime  | extends — session-branch force push; NFF source push → `base_moved`     |
| `mcp-server`    | surfaces | composes — observability phrase match for PushRejected                  |
| `app-ui`        | surfaces | composes — browser filter + defensive `formatScope`                     |

### Change flow

Non-fast-forward source publishes recover via `base_moved` instead of Sentry.

```mermaid
sequenceDiagram
	actor agent as agent
	participant mcpServer as mcp-server
	participant repoSessions as repo-sessions
	participant artifactsGit as artifacts-git
	agent->>mcpServer: repo_publish_session
	mcpServer->>repoSessions: publishSession
	repoSessions->>artifactsGit: force-push session branch
	repoSessions->>artifactsGit: push session → source branch
	alt source rejects non-fast-forward
		artifactsGit-->>repoSessions: PushRejectedError
		repoSessions->>artifactsGit: refresh live source tip
		repoSessions-->>mcpServer: status base_moved + repair_hint
		mcpServer-->>agent: rebase then retry
	else fast-forward ok
		artifactsGit-->>repoSessions: ok
		repoSessions-->>mcpServer: status ok
	end
```

### Invariants

Per-user isolation unchanged. Source-branch force push still requires the existing destructive-overwrite confirmation gate (`force: true` path only).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-139b8c8d-57cc-42f0-841b-c884300dce4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-139b8c8d-57cc-42f0-841b-c884300dce4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved repository publishing for temporary session branches with safer forced updates.
  * Added clearer guidance when a source branch has moved and publishing cannot proceed.
  * Publishing state and commit information now update correctly after successful operations.

* **Bug Fixes**
  * Prevented expected Git push conflicts from being reported as application errors.
  * Suppressed known browser worker loading errors while continuing to report unrelated network failures.
  * Account token scopes now display “None” when no exports are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->