### PR TITLE
docs: Salesforce connect guide and what-is-kody webhook example

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -40,13 +40,13 @@ content:
 Per-provider connect walkthroughs (`category: provider`). Load by MCP id or web
 slug.
 
-| File                                                 | MCP id                | Web slug      |
-| ---------------------------------------------------- | --------------------- | ------------- |
-| [providers/discord.md](./providers/discord.md)       | `provider_discord`    | `discord`     |
-| [providers/github.md](./providers/github.md)         | `provider_github`     | `github`      |
-| [providers/google.md](./providers/google.md)         | `provider_google`     | `google`      |
-| [providers/notion.md](./providers/notion.md)         | `provider_notion`     | `notion`      |
-| [providers/origin.md](./providers/origin.md)         | `provider_origin`     | `origin`      |
-| [providers/salesforce.md](./providers/salesforce.md) | `provider_salesforce` | `salesforce`  |
-| [providers/slack.md](./providers/slack.md)           | `provider_slack`      | `slack`       |
-| [providers/spotify.md](./providers/spotify.md)       | `provider_spotify`    | `spotify`     |
+| File                                                 | MCP id                | Web slug     |
+| ---------------------------------------------------- | --------------------- | ------------ |
+| [providers/discord.md](./providers/discord.md)       | `provider_discord`    | `discord`    |
+| [providers/github.md](./providers/github.md)         | `provider_github`     | `github`     |
+| [providers/google.md](./providers/google.md)         | `provider_google`     | `google`     |
+| [providers/notion.md](./providers/notion.md)         | `provider_notion`     | `notion`     |
+| [providers/origin.md](./providers/origin.md)         | `provider_origin`     | `origin`     |
+| [providers/salesforce.md](./providers/salesforce.md) | `provider_salesforce` | `salesforce` |
+| [providers/slack.md](./providers/slack.md)           | `provider_slack`      | `slack`      |
+| [providers/spotify.md](./providers/spotify.md)       | `provider_spotify`    | `spotify`    |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -40,12 +40,13 @@ content:
 Per-provider connect walkthroughs (`category: provider`). Load by MCP id or web
 slug.
 
-| File                                           | MCP id             | Web slug  |
-| ---------------------------------------------- | ------------------ | --------- |
-| [providers/discord.md](./providers/discord.md) | `provider_discord` | `discord` |
-| [providers/github.md](./providers/github.md)   | `provider_github`  | `github`  |
-| [providers/google.md](./providers/google.md)   | `provider_google`  | `google`  |
-| [providers/notion.md](./providers/notion.md)   | `provider_notion`  | `notion`  |
-| [providers/origin.md](./providers/origin.md)   | `provider_origin`  | `origin`  |
-| [providers/slack.md](./providers/slack.md)     | `provider_slack`   | `slack`   |
-| [providers/spotify.md](./providers/spotify.md) | `provider_spotify` | `spotify` |
+| File                                                 | MCP id                | Web slug      |
+| ---------------------------------------------------- | --------------------- | ------------- |
+| [providers/discord.md](./providers/discord.md)       | `provider_discord`    | `discord`     |
+| [providers/github.md](./providers/github.md)         | `provider_github`     | `github`      |
+| [providers/google.md](./providers/google.md)         | `provider_google`     | `google`      |
+| [providers/notion.md](./providers/notion.md)         | `provider_notion`     | `notion`      |
+| [providers/origin.md](./providers/origin.md)         | `provider_origin`     | `origin`      |
+| [providers/salesforce.md](./providers/salesforce.md) | `provider_salesforce` | `salesforce`  |
+| [providers/slack.md](./providers/slack.md)           | `provider_slack`      | `slack`       |
+| [providers/spotify.md](./providers/spotify.md)       | `provider_spotify`    | `spotify`     |

--- a/docs/guides/providers/salesforce.md
+++ b/docs/guides/providers/salesforce.md
@@ -34,8 +34,8 @@ permissions in that org.
 - There is one OAuth app per Salesforce org you want to call. Production and
   sandbox are different login hosts and different connections.
 - The official helpers package is
-  [@kody/salesforce](https://kody.codes/@kody/salesforce). A saved integration is
-  credentials only; that package is the agent-facing surface.
+  [@kody/salesforce](https://kody.codes/@kody/salesforce). A saved integration
+  is credentials only; that package is the agent-facing surface.
 
 See the [OAuth guide](../oauth.md) for query parameters, confidential exchange,
 and reconnect behavior.
@@ -70,9 +70,8 @@ prefilled connect link, with the production callback and connect page on
 https://kody.codes/connect/oauth?provider=salesforce&authorizeUrl=https%3A%2F%2Flogin.salesforce.com%2Fservices%2Foauth2%2Fauthorize&tokenUrl=https%3A%2F%2Flogin.salesforce.com%2Fservices%2Foauth2%2Ftoken&apiBaseUrl=https%3A%2F%2Flogin.salesforce.com&scopes=api%20refresh_token%20offline_access&flow=confidential&allowedHosts=login.salesforce.com%2C*.salesforce.com%2C*.force.com%2C*.my.salesforce.com
 ```
 
-Decoded: authorize URL
-`https://login.salesforce.com/services/oauth2/authorize`, token URL
-`https://login.salesforce.com/services/oauth2/token`, `apiBaseUrl`
+Decoded: authorize URL `https://login.salesforce.com/services/oauth2/authorize`,
+token URL `https://login.salesforce.com/services/oauth2/token`, `apiBaseUrl`
 `https://login.salesforce.com`, `flow=confidential`, scopes
 `api refresh_token offline_access`, and `allowedHosts` covering the login host
 plus `*.salesforce.com`, `*.force.com`, and `*.my.salesforce.com` so REST calls
@@ -126,8 +125,8 @@ refresh.
 ## Troubleshooting
 
 - Redirect URI mismatch: the Connected App / External Client App callback must
-  be exactly `https://kody.codes/connect/oauth`. Do not register
-  `heykody.dev` — production callback and connect URLs are on `kody.codes`.
+  be exactly `https://kody.codes/connect/oauth`. Do not register `heykody.dev` —
+  production callback and connect URLs are on `kody.codes`.
 - Sandbox authorize or token errors: the connect URL still points at
   `login.salesforce.com`. Rebuild it with `test.salesforce.com` and a distinct
   integration name.

--- a/docs/guides/providers/salesforce.md
+++ b/docs/guides/providers/salesforce.md
@@ -1,0 +1,149 @@
+---
+id: provider_salesforce
+title: Connect Salesforce
+summary:
+  Verified connect walkthrough for Salesforce: bring-your-own Connected App
+  or External Client App, the exact /connect/oauth callback, production vs
+  sandbox login hosts, scopes, prefilled connect links, and a smoke test.
+category: provider
+provider: Salesforce
+lastVerified: 2026-08
+---
+
+# Connect Salesforce
+
+Salesforce has no built-in Kody platform app. Every connection is
+bring-your-own: you create a Connected App or External Client App in the org,
+register Kody's redirect URI, then finish OAuth on `/connect/oauth`.
+
+## What you get
+
+Once connected, you can ask Kody things like:
+
+- "Run this SOQL query and summarize the results."
+- "Describe the Contact sObject and list its custom fields."
+- "Show the Opportunity records that closed this month."
+
+Exact access depends on the Connected App scopes and the Salesforce user's
+permissions in that org.
+
+## Before you start
+
+- You need permission in the org to create a Connected App or External Client
+  App (typically a system administrator).
+- There is one OAuth app per Salesforce org you want to call. Production and
+  sandbox are different login hosts and different connections.
+- The official helpers package is
+  [@kody/salesforce](https://kody.codes/@kody/salesforce). A saved integration is
+  credentials only; that package is the agent-facing surface.
+
+See the [OAuth guide](../oauth.md) for query parameters, confidential exchange,
+and reconnect behavior.
+
+## Create a Connected App or External Client App
+
+Salesforce Setup offers both **Connected Apps** and **External Client Apps**.
+Either works. Enable OAuth and treat the consumer key / consumer secret as a
+confidential web app.
+
+1. In Salesforce Setup, open **App Manager** (Connected App) or **External
+   Client App Manager** and create a new app with OAuth enabled.
+2. Set the callback / redirect URI to exactly `https://kody.codes/connect/oauth`
+   (a self-hosted deployment registers its own origin plus `/connect/oauth`).
+   Matching is exact — a trailing slash or `heykody.dev` host fails.
+3. Select OAuth scopes that include `api`, `refresh_token`, and
+   `offline_access`. Add more only when a workflow needs them.
+4. Copy the consumer key (client ID) and consumer secret (client secret). Paste
+   those into Kody's `/connect/oauth` setup form, not into chat.
+
+Production orgs authorize at `login.salesforce.com`. Sandboxes authorize at
+`test.salesforce.com`. Using the wrong host looks like a broken client, not a
+wrong org.
+
+## Connect to Kody
+
+Open this URL while signed in to Kody. It matches the official package's
+prefilled connect link, with the production callback and connect page on
+`https://kody.codes/connect/oauth`:
+
+```text
+https://kody.codes/connect/oauth?provider=salesforce&authorizeUrl=https%3A%2F%2Flogin.salesforce.com%2Fservices%2Foauth2%2Fauthorize&tokenUrl=https%3A%2F%2Flogin.salesforce.com%2Fservices%2Foauth2%2Ftoken&apiBaseUrl=https%3A%2F%2Flogin.salesforce.com&scopes=api%20refresh_token%20offline_access&flow=confidential&allowedHosts=login.salesforce.com%2C*.salesforce.com%2C*.force.com%2C*.my.salesforce.com
+```
+
+Decoded: authorize URL
+`https://login.salesforce.com/services/oauth2/authorize`, token URL
+`https://login.salesforce.com/services/oauth2/token`, `apiBaseUrl`
+`https://login.salesforce.com`, `flow=confidential`, scopes
+`api refresh_token offline_access`, and `allowedHosts` covering the login host
+plus `*.salesforce.com`, `*.force.com`, and `*.my.salesforce.com` so REST calls
+can follow the org's instance URL.
+
+For a sandbox, replace every `login.salesforce.com` with `test.salesforce.com`
+in `authorizeUrl`, `tokenUrl`, `apiBaseUrl`, and `allowedHosts`. Use a distinct
+`provider` name such as `salesforce-sandbox` so it does not overwrite the
+production connection.
+
+Paste the consumer key and secret into the setup form, then authorize as a user
+who can see the data the workflow needs.
+
+## More than one org
+
+Each org is its own Kody integration. Give production, sandbox, and extra orgs
+different `provider` values (`salesforce`, `salesforce-sandbox`,
+`salesforce-eu`). Official package helpers take `integrationName` so a call
+targets that connection instead of the default `salesforce` name.
+
+## Verify
+
+After connecting, run the official smoke test from `execute` (pass
+`integrationName` when the connection is not named `salesforce`):
+
+```ts
+import smokeTest from 'kody:@kody/salesforce/smoke-test'
+
+export default async function main() {
+	return smokeTest()
+}
+```
+
+A successful response confirms OAuth without returning profile PII. Once that
+passes, day-to-day calls go through package helpers such as `./query`,
+`./describe-sobject`, `./request`, and `./triage-error`.
+
+## Scopes
+
+Space-delimited. The official connect link requests:
+
+- `api` — REST and SOAP API access for the authorized user
+- `refresh_token` and `offline_access` — a refresh token so Kody can keep
+  calling after the access token expires
+
+Widen only when a later workflow needs extra Salesforce OAuth scopes, then
+reconnect with the new `scopes` value. Missing `refresh_token` /
+`offline_access` is the usual reason a connection works once and then cannot
+refresh.
+
+## Troubleshooting
+
+- Redirect URI mismatch: the Connected App / External Client App callback must
+  be exactly `https://kody.codes/connect/oauth`. Do not register
+  `heykody.dev` — production callback and connect URLs are on `kody.codes`.
+- Sandbox authorize or token errors: the connect URL still points at
+  `login.salesforce.com`. Rebuild it with `test.salesforce.com` and a distinct
+  integration name.
+- No refresh token after a successful connect: the app is missing
+  `refresh_token` and `offline_access`, or the user previously authorized a
+  narrower grant. Add the scopes, revoke the old grant in Salesforce if needed,
+  and reconnect.
+- API calls fail against `login.salesforce.com` or `test.salesforce.com` after
+  connect: those are login hosts, not the org instance. Salesforce returns an
+  instance URL (for example `*.my.salesforce.com`) from userinfo; the official
+  package follows that URL. Keep the wildcard hosts from the connect link so
+  `createAuthenticatedFetch` can reach the instance.
+- `invalid_client` / secret errors: confirm the consumer secret is current and
+  that `flow=confidential` is set. Rotate the secret in Salesforce and reconnect
+  if it was regenerated.
+
+After you are connected, use the official
+[@kody/salesforce](https://kody.codes/@kody/salesforce) package for identity,
+SOQL, sObject metadata, and confirmed record changes.

--- a/docs/guides/what-is-kody.md
+++ b/docs/guides/what-is-kody.md
@@ -121,6 +121,8 @@ Concrete examples that combine the blocks:
   keys.
 - A personal API: a package export you can hit from shortcuts or webhooks to log
   a habit, save a link, or kick off a run.
+- An inbound webhook that fingerprints repeated failures and emails one
+  investigation instead of a flood.
 - Home automation routines through a local-network connector — scenes,
   thermostats, speakers — driven by schedule or by asking your agent.
 - Forking a community package (say, a YouTube video manager or an RSS digest)

--- a/packages/worker/src/guides/catalog.node.test.ts
+++ b/packages/worker/src/guides/catalog.node.test.ts
@@ -41,6 +41,9 @@ test('guide catalog parses every guide with unique ids and slugs', () => {
 	expect(getGuideById('local_mcp_tunnels')?.imageAlt?.length).toBeGreaterThan(0)
 	expect(getGuideBySlug('google-oauth')?.id).toBe('google_oauth')
 	expect(getGuideById('google_oauth')?.slug).toBe('google-oauth')
+	expect(getGuideBySlug('salesforce')?.id).toBe('provider_salesforce')
+	expect(getGuideById('provider_salesforce')?.slug).toBe('salesforce')
+	expect(getGuideById('provider_salesforce')?.provider).toBe('Salesforce')
 
 	// Web ordering: platform guides first, then provider guides sorted by
 	// provider name.

--- a/packages/worker/src/guides/catalog.ts
+++ b/packages/worker/src/guides/catalog.ts
@@ -24,6 +24,7 @@ import providerGithub from '../../../../docs/guides/providers/github.md'
 import providerGoogle from '../../../../docs/guides/providers/google.md'
 import providerNotion from '../../../../docs/guides/providers/notion.md'
 import providerOrigin from '../../../../docs/guides/providers/origin.md'
+import providerSalesforce from '../../../../docs/guides/providers/salesforce.md'
 import providerSlack from '../../../../docs/guides/providers/slack.md'
 import providerSpotify from '../../../../docs/guides/providers/spotify.md'
 import secretBackedIntegration from '../../../../docs/guides/secret-backed-integration.md'
@@ -68,6 +69,7 @@ const guideSources: Array<{ slug: string; raw: string }> = [
 	{ slug: 'github', raw: providerGithub },
 	{ slug: 'notion', raw: providerNotion },
 	{ slug: 'origin', raw: providerOrigin },
+	{ slug: 'salesforce', raw: providerSalesforce },
 	{ slug: 'slack', raw: providerSlack },
 	{ slug: 'spotify', raw: providerSpotify },
 	{ slug: 'discord', raw: providerDiscord },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give agents a verified Salesforce connect walkthrough and one more concrete "what people use it for" example, without changing onboarding or inventing a triage starter package.

## Summary

- Add `docs/guides/providers/salesforce.md` (`provider_salesforce`) for BYO Connected App / External Client App OAuth: exact `https://kody.codes/connect/oauth` callback, prod vs sandbox hosts, scopes, official-package connect URL, `smoke-test`, multi-org `integrationName`, and connect troubleshooting.
- Register the guide in `packages/worker/src/guides/catalog.ts` (slug `salesforce`) and list it in `docs/guides/README.md`.
- Add one webhook → saved code → one-email example to `docs/guides/what-is-kody.md`.

## Testing

- `npx vitest run --project node-unit` on the guide catalog, official-guide, and guides handler suites
- `npm run docs:check-temporal`
- Format fix: `oxfmt` on the Salesforce guide and provider index (Static CI failure)

## System changes

Docs and catalog wiring only. Low risk. No runtime behavior change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `0b4748da` · **Head:** `81ee8fc5`

**Classification:** composes — no primitives added or changed; this PR wires a new provider guide into the existing catalog that `coding_guide_get` and `/guides` already serve.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| *(none matched)* | — | catalog + markdown live outside primitive `code` roots; serving surfaces (`mcp-server`, `app-ui`) are unchanged |

Unmatched paths: `docs/guides/providers/salesforce.md`, `docs/guides/README.md`, `docs/guides/what-is-kody.md`, `packages/worker/src/guides/catalog.ts`, `packages/worker/src/guides/catalog.node.test.ts`.

### Change flow

A new Salesforce provider guide and a what-is-kody example are bundled into the existing guide catalog; MCP and the web guides index serve the same deployed markdown.

```mermaid
sequenceDiagram
	actor Author
	participant catalog as guide catalog
	participant mcpServer as mcp-server
	participant appUi as app-ui
	Author->>catalog: add salesforce.md + guideSources slug salesforce
	Author->>catalog: add what-is-kody webhook investigation bullet
	mcpServer->>catalog: coding_guide_get provider_salesforce
	appUi->>catalog: GET /guides/salesforce
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24be128e-a375-4872-9931-d046e64ae196?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24be128e-a375-4872-9931-d046e64ae196&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive Salesforce connection guide covering OAuth setup, permissions, environments, multi-organization support, testing, and troubleshooting.
  - Added Salesforce to the provider guide catalog.
  - Added an inbound webhook example that consolidates repeated failures into a single email investigation.

- **Documentation**
  - Improved provider guide table formatting for readability.

- **Tests**
  - Added coverage for Salesforce guide lookup and provider metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->