### PR TITLE
docs: steer agents with a short ADR veto list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   - [docs/contributing/index.md](./docs/contributing/index.md)
 - Project intent and scope:
   [docs/contributing/project-intent.md](./docs/contributing/project-intent.md)
-- Decision records (check before proposing something already decided against):
+- Decision records (steering veto list — open before proposing a new primitive
+  or surface):
   [docs/contributing/decisions/index.md](./docs/contributing/decisions/index.md)
 - Setup, checks, docs maintenance, preview deploys, and seeding:
   - [docs/contributing/setup.md](./docs/contributing/setup.md)

--- a/docs/contributing/decisions/0000-template.md
+++ b/docs/contributing/decisions/0000-template.md
@@ -1,19 +1,23 @@
-# NNNN: Short decision title
+# NNNN: Short decision title (the no)
 
 - **Status:** accepted <!-- accepted | superseded by [NNNN](./NNNN-slug.md) -->
 - **Date:** YYYY-MM-DD
 
 ## Context
 
-What question or situation forced the decision. A few sentences on the relevant
-system state and constraints, with links to code or docs.
+What proposal or situation forced the decision. A few sentences on the system
+state and constraints, with links to code or docs. Write this **after** the
+decision is made — not as a design brief for a PR.
 
 ## Decision
 
-What was decided, in one or two sentences. Decisions **not** to build something
-count and should be recorded.
+What was decided, in one or two sentences. The usual record is a product-shaped
+**no** (we will not build X). Name the existing primitive that covers the need.
 
 ## Consequences
 
-What follows: what stays simple, what gets harder, and what would trigger
-revisiting. When a preferred future shape is known, name it.
+What stays simple, what gets harder, and the **revisit-if** — the concrete
+condition that would reopen this. Half a page is enough.
+
+Do not use this template for a layout or UI tweak, a library pick the code
+already encodes, or because a PR shipped.

--- a/docs/contributing/decisions/0010-account-record-table.md
+++ b/docs/contributing/decisions/0010-account-record-table.md
@@ -20,7 +20,8 @@ of broken hex. There are 17 `MetadataGrid` call sites, nine of them at
 `accountManagementTableCss`.
 
 Measurements and the rejected alternatives are in
-[the supporting material](./0010-account-record-table/index.md).
+[historical working notes](./historical/0010-account-record-table/index.md) (not
+current layout law; not part of the steering list).
 
 ## Decision
 

--- a/docs/contributing/decisions/historical/0010-account-record-table/index.md
+++ b/docs/contributing/decisions/historical/0010-account-record-table/index.md
@@ -1,9 +1,11 @@
 # 0010 supporting material — account RecordTable
 
-Working material behind [decision 0010](../0010-account-record-table.md): the
-measurements that forced it, the alternatives that were rejected, the settled
-component API, and the screen-by-screen inventory. Point-in-time by design, like
-the record it supports.
+Historical working notes behind
+[decision 0010](../../0010-account-record-table.md). Measurements, rejected
+alternatives, and a screen inventory from the week the first RecordTable landed.
+**Not current layout law** and not part of the
+[steering veto list](../../index.md). 0010 is superseded by
+[0028](../../0028-list-detail-expand.md).
 
 - [Screen inventory](./page-inventory.md) — every affected screen, its mode, and
   its `MetadataGrid` call site

--- a/docs/contributing/decisions/historical/0010-account-record-table/page-inventory.md
+++ b/docs/contributing/decisions/historical/0010-account-record-table/page-inventory.md
@@ -1,7 +1,8 @@
 # Screen inventory
 
-Supporting material for [decision 0010](../0010-account-record-table.md). Counts
-taken on `main` at `9a4f3fcc`; line numbers drift, the shapes do not.
+Historical screen inventory for
+[decision 0010](../../0010-account-record-table.md). Counts taken on `main` at
+`9a4f3fcc`; line numbers drift. Not current layout law.
 
 Two independent axes: which screens compose `AccountManagementLayout` (so they
 get a `RecordTable` mode), and which render a `MetadataGrid` (so they get the

--- a/docs/contributing/decisions/historical/readme.md
+++ b/docs/contributing/decisions/historical/readme.md
@@ -1,0 +1,4 @@
+# Historical decision notes
+
+Working notes that are **not** part of the [steering veto list](../index.md). Do
+not treat anything here as current product law.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -1,52 +1,83 @@
 # Decision records
 
-Short architecture decision records (ADRs) for choices that shape the platform,
-including decisions **not** to build something. Check here before proposing a
-change that may already have been decided.
+A **steering veto list**. Open the list below before proposing a new primitive,
+surface, or storage home. Architecture docs and code describe how the system
+works today; this folder records product-shaped decisions **already made**,
+usually a no with a revisit-if.
+
+Linked from [AGENTS.md](../../../AGENTS.md) for that check — not as homework and
+not as a museum.
+
+A good record is half a page: context, the decision, consequences. See
+[0025](./0025-no-package-services-primitive.md) for the shape that actually
+steers (write the no before the next agent re-proposes the primitive).
 
 Decision records are point-in-time documents, so they are exempt from
 `npm run docs:check-temporal`; everything else in `docs/` describes current
 behavior (see [documentation principles](../documentation.md)).
 
-## Adding a record
+## When to add a record
 
-1. Copy [`0000-template.md`](./0000-template.md) to the next number with a short
-   kebab-case slug (for example `0002-some-decision.md`).
-2. Keep it to roughly half a page: context, decision, consequences.
-3. When a later record changes a decision, mark the old one `superseded by NNNN`
-   rather than editing or deleting it.
-4. Add the record to the list below.
+Write one after you have already decided **not** to build something the next
+agent will otherwise re-propose. Copy [`0000-template.md`](./0000-template.md)
+to the next unused number (read this index on `main` first) with a kebab-case
+slug. Keep it to roughly half a page.
 
-## Records
+Do **not** write an ADR on every PR. Number collisions (two 0022s, then two
+0028s the same day) are the failure mode of that habit. If a number collides,
+renumber the later record; do not leave duplicates.
+
+Do **not** record layout or UI tweaks, mode assignments, or "we use library X"
+unless that pick is a no that will otherwise be re-litigated.
+
+When a later record changes a decision, mark the old one `superseded by NNNN`
+rather than editing or deleting it, and list it under
+[Historical / UI / implementation](#historical--ui--implementation).
+
+Add new steering records to the steering list, not a catch-all numbered dump.
+
+## Steering list
+
+Open these before proposing a new primitive, surface, or storage home.
 
 - [0001 — No user-facing package versioning or import pins](./0001-no-package-versioning.md)
 - [0002 — Data placement: D1, per-user Durable Objects, Analytics Engine](./0002-data-placement.md)
 - [0003 — Repos are the base primitive; packages are an explicit extension](./0003-repos-as-base-primitive.md)
-- [0004 — Status page as a separate worker with its own storage](./0004-status-page-separate-worker.md)
-- [0005 — MCP dual-lane serving with metrics-driven legacy retirement](./0005-mcp-dual-lane-stateless-migration.md)
-- [0006 — No repo/package CI primitive for now](./0006-no-repo-ci-primitive.md)
-- [0007 — Keep in-house feature flags; revisit Flagship at GA](./0007-keep-in-house-feature-flags.md)
-- [0008 — Declined ADLC primitives (traces, previews, browser runs, session mining)](./0008-declined-adlc-primitives.md)
-- [0009 — Shiki for in-app syntax highlighting](./0009-shiki-syntax-highlighting.md)
-- [0010 — One RecordTable for account and admin list/detail screens](./0010-account-record-table.md)
-  ([supporting material](./0010-account-record-table/index.md); superseded by
-  [0028](./0028-list-detail-expand.md) for mode assignment)
-- [0011 — Workers-unit keeps per-file isolation; budget cold DO load in timeouts](./0011-workers-unit-pool-harness.md)
-- [0012 — Client-safe shared code lives in `#universal/*`](./0012-universal-layer.md)
-- [0013 — Synthetic package requests for post-publish verification](./0013-synthetic-package-requests.md)
-- [0014 — Platform scopes resolve live in package imports](./0014-platform-live-packages.md)
-- [0015 — Wait on Skills over MCP (SEP-2640); serve skill content via packages](./0015-skills-over-mcp-wait.md)
-- [0016 — Extract the package runtime and jobs lanes into separate workers](./0016-mono-worker-extraction.md)
-- [0017 — Per-user subdomains for hosted package apps](./0017-per-user-package-app-subdomains.md)
-- [0018 — Inbound CLA for external contributions to this repository](./0018-inbound-cla.md)
-- [0019 — Self-hosted Nx remote cache (not Nx Cloud)](./0019-self-hosted-nx-remote-cache.md)
+- [0004 — Status page stays a separate worker with its own storage](./0004-status-page-separate-worker.md)
+- [0005 — Keep the MCP legacy lane until metrics retire it; no Tasks yet](./0005-mcp-dual-lane-stateless-migration.md)
+- [0006 — No repo/package CI primitive](./0006-no-repo-ci-primitive.md)
+- [0007 — Keep in-house feature flags; no package flag primitive](./0007-keep-in-house-feature-flags.md)
+- [0008 — No traces, previews, browser-run, gradual deploys, or session mining](./0008-declined-adlc-primitives.md)
+- [0011 — Keep workers-unit per-file isolation; do not warm DOs to "fix" slowness](./0011-workers-unit-pool-harness.md)
+- [0013 — Post-publish checks stay on MCP; no signed app URLs or inbox injection](./0013-synthetic-package-requests.md)
+- [0014 — Platform scopes resolve live; person-account imports stay caller-owned](./0014-platform-live-packages.md)
+- [0015 — Wait on Skills over MCP; serve skill content via packages](./0015-skills-over-mcp-wait.md)
+- [0017 — Hosted package apps use per-user subdomains; same-owner isolation deferred](./0017-per-user-package-app-subdomains.md)
 - [0020 — Repo sessions spill Workspace objects to R2; do not adopt `@cloudflare/computer`](./0020-repo-session-workspace-r2-not-computer.md)
 - [0021 — Publish-gated packages; no in-process composition runtime](./0021-publish-gated-package-composition.md)
-- [0022 — Retire the values primitive](./0022-retire-values-primitive.md)
-  ([runbook](../architecture/values-retirement-runbook.md))
-- [0023 — Progressive search disclosure](./0023-progressive-search-disclosure.md)
-- [0024 — Packages outrank synthesized providers](./0024-packages-outrank-synthesized-providers.md)
+- [0022 — Retire the values primitive; do not add a thinner settings twin](./0022-retire-values-primitive.md)
+- [0023 — Progressive search disclosure; no full-SDK dumps or unbounded listings](./0023-progressive-search-disclosure.md)
+- [0024 — Packages outrank synthesized providers; no auto-delete or ranking toggle](./0024-packages-outrank-synthesized-providers.md)
 - [0025 — No package services primitive](./0025-no-package-services-primitive.md)
-- [0026 — Package-owned invocation tokens](./0026-package-owned-invocation-tokens.md)
+- [0026 — Invocation tokens belong to one package; no account-level wildcard bearer](./0026-package-owned-invocation-tokens.md)
 - [0027 — No invocation-token source allowlist](./0027-no-invocation-token-source-allowlist.md)
+
+## Historical / UI / implementation
+
+Accepted or superseded records that do **not** change the next product proposal.
+Do not treat this list as homework. History stays; it is not silently deleted.
+
+- [0009 — Shiki for in-app syntax highlighting](./0009-shiki-syntax-highlighting.md)
+  — library pick; the highlighter is already in the app
+- [0010 — One RecordTable for account and admin list/detail screens](./0010-account-record-table.md)
+  — superseded by 0028; UI diary (working notes are not steering)
+- [0012 — Client-safe shared code lives in `#universal/*`](./0012-universal-layer.md)
+  — encoded by [import boundaries](../import-boundaries.md) and lint
+- [0016 — Extract the package runtime and jobs lanes into separate workers](./0016-mono-worker-extraction.md)
+  — landed; see the architecture runbooks
+- [0018 — Inbound CLA for external contributions to this repository](./0018-inbound-cla.md)
+  — legal/process; see [CONTRIBUTING.md](../../../CONTRIBUTING.md)
+- [0019 — Self-hosted Nx remote cache (not Nx Cloud)](./0019-self-hosted-nx-remote-cache.md)
+  — contributor infra, not a product primitive
 - [0028 — List/detail records expand inside the table](./0028-list-detail-expand.md)
+  — UI mode assignment (supersedes 0010)

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -23,11 +23,11 @@ notes.
 
 **Exceptions.** Migration and rotation guides (for example
 [`secret-rotation.md`](./secret-rotation.md)) may use ordered steps across
-deploy phases, and [decision records](./decisions/index.md) are point-in-time
-documents by design. Outside those procedures, still describe the current design
-in plain language. Quoted validation errors and runtime messages should match
-what the product returns, even when the wording contrasts with older manifest
-shapes.
+deploy phases, and [decision records](./decisions/index.md) are a point-in-time
+steering veto list by design. Outside those procedures, still describe the
+current design in plain language. Quoted validation errors and runtime messages
+should match what the product returns, even when the wording contrasts with
+older manifest shapes.
 
 **Stay lightweight but valuable.** Prefer small, accurate pages over large stale
 ones. **Garden** docs when behavior changes: update or delete sections in the

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -6,8 +6,8 @@ style, tests, MCP capabilities, and runtime architecture.
 ## Setup and workflow
 
 - [Getting started](./getting-started.md), [project intent](./project-intent.md)
-- [Decision records](./decisions/index.md) (ADRs, including decisions **not** to
-  build something)
+- [Decision records](./decisions/index.md) (steering veto list: product-shaped
+  nos and durable constraints — not an ADR-per-PR log)
 - [Inbound contributions](./inbound-contributions.md) (CLA for patches to this
   repository)
 - [Setup](./setup.md), [environment variables](./environment-variables.md),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make Kody ADRs a short veto list that changes what the next coding agent proposes — not a museum, UI diary, or ADR-per-PR habit.

## Summary

Classification test for every record: **Would this change what the next coding agent proposes?**

**Kept** on the steering list (product-shaped nos and durable platform constraints). Accepted nos were not rewritten.

- Proven agent-steering nos: [0001](docs/contributing/decisions/0001-no-package-versioning.md) (no package versioning), [0006](docs/contributing/decisions/0006-no-repo-ci-primitive.md) (no repo CI), [0008](docs/contributing/decisions/0008-declined-adlc-primitives.md) (no traces/previews/browser-run/session mining), [0015](docs/contributing/decisions/0015-skills-over-mcp-wait.md) (wait on Skills over MCP), [0021](docs/contributing/decisions/0021-publish-gated-package-composition.md) (publish-gated; no in-process composition), [0025](docs/contributing/decisions/0025-no-package-services-primitive.md) (no package services — the example good no)
- Other accepted primitive/scope nos: 0002 data placement, 0003 repos as the base primitive, 0004 status stays a separate worker, 0005 keep the MCP legacy lane until metrics, 0007 in-house flags / no package flags, 0011 workers-unit isolation, 0013 no signed app URLs or inbox injection, 0014 platform live imports, 0017 per-user package-app subdomains, 0020 no `@cloudflare/computer`, 0022 retire values, 0023/0024 search disclosure and ranking, 0026/0027 package-owned tokens / no source allowlist

**Demoted** to a labeled historical / UI / implementation list (not deleted):

- 0009 Shiki — library pick the app already encodes
- 0010 RecordTable — superseded UI diary (13 days later)
- 0012 `#universal/*` — already enforced by import boundaries and lint
- 0016 worker split — landed; architecture runbooks remain
- 0018 inbound CLA — legal/process, not a product primitive
- 0019 Nx remote cache — contributor infra
- 0028 list/detail expand — UI mode assignment that superseded 0010

**Refiled**

- `0010-account-record-table/` → `historical/0010-account-record-table/` so a file and directory no longer share the same name
- Supporting measurements stay as history and are not on the agent-facing index

**Process inverted**

- Template and "When to add a record" now default to: record a declined product decision you already made; half a page; revisit-if
- Do **not** write an ADR on every PR (that habit produced two 0022s, then two 0028s the same day)
- Do **not** record layout/UI tweaks or "we use library X" unless it is a no that will otherwise be re-litigated
- [AGENTS.md](AGENTS.md) now points at the steering veto list, not a museum

No application code. No new product decisions. No ADR CI / ADR-per-PR check.

## Testing

- Read every file under `docs/contributing/decisions/` and classified with the veto-list test
- Coverage check: 21 steering + 7 historical = all 28 numbered ADRs; none unlisted or duplicated
- 0010 file/directory collision gone; notes live under `historical/0010-account-record-table/`
- Template and index now forbid layout/library/PR-diary ADRs and ADR-per-PR
- `npm run docs:check-temporal` passed
- `npm run format:check` passed on the touched docs
- `npm run primitives:check` passed (no map edits)

## System changes

Docs-only contributor guidance. No primitives added or changed.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `779b982d` · **Head:** `0c9162c3`

**Classification:** composes — no primitives added or changed; this PR only reorganizes contributor decision docs.

### Primitives touched

_None._ Classifier matched 0 of 9 paths. Unmatched paths are `AGENTS.md` and `docs/contributing/**` (decision index, template, 0010 notes move).

### Change flow

An agent with a new primitive or surface idea hits the steering list first; historical UI and implementation records stay in the repo but are no longer the homework.

```mermaid
flowchart TD
	agent["Coding agent proposes a new primitive or surface"] --> agentsMd["AGENTS.md points at the veto list"]
	agentsMd --> steering["Open the steering list in decisions/index.md"]
	steering -->|"matches a product-shaped no"| stop["Keep the existing primitive"]
	steering -->|"no matching no"| proceed["Propose against current architecture docs"]
	steering -.->|"do not treat as homework"| historical["Historical / UI / implementation list"]
```

### Before / after

| Before | After |
| ------ | ----- |
| Flat numbered dump of ~28 ADRs plus a colliding `0010-account-record-table` file and directory | Steering list first; demoted records in a second list; 0010 notes under `historical/` |
| "Adding a record" = copy template, add to the dump | Write a declined product decision already made; do not ADR every PR |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8da0b8c3-e5c4-40e5-b4ff-e492570b090f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8da0b8c3-e5c4-40e5-b4ff-e492570b090f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to consult and create decision records before proposing new product primitives or surfaces.
  * Reframed decision records as a steering veto list focused on durable constraints and product-shaped “no” decisions.
  * Updated the decision-record template with clearer guidance on context, consequences, and when records are appropriate.
  * Improved historical-record documentation, including superseded decisions, supporting notes, and their non-authoritative status.
  * Corrected links and refreshed descriptions throughout the contribution documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->