### PR TITLE
Derive signup email links from the sending domain

### DIFF
--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -331,7 +331,8 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
   `kody@<domain>` transactional sender and operator system inboxes). Defaults to
   the `APP_BASE_URL` hostname. Production commits
   `SYSTEM_EMAIL_DOMAIN=kody.codes`. Signup, email-change, and password-reset
-  messages also put this host on their action and asset links.
+  messages also put this host on their action and asset links. Local
+  `npm run dev` keeps those links on the request origin so they stay clickable.
 - `LEGACY_USER_EMAIL_DOMAINS` / `LEGACY_SYSTEM_EMAIL_DOMAINS` — optional
   comma-separated additional email domains that inbound mail is accepted on
   alongside the canonical domains (see

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -330,7 +330,8 @@ Optional Worker secrets/vars (see `packages/worker/src/env-schema.ts` and
 - `SYSTEM_EMAIL_DOMAIN` — optional override for the system email domain (the
   `kody@<domain>` transactional sender and operator system inboxes). Defaults to
   the `APP_BASE_URL` hostname. Production commits
-  `SYSTEM_EMAIL_DOMAIN=kody.codes`.
+  `SYSTEM_EMAIL_DOMAIN=kody.codes`. Signup, email-change, and password-reset
+  messages also put this host on their action and asset links.
 - `LEGACY_USER_EMAIL_DOMAINS` / `LEGACY_SYSTEM_EMAIL_DOMAINS` — optional
   comma-separated additional email domains that inbound mail is accepted on
   alongside the canonical domains (see

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -45,15 +45,14 @@ Quick notes for getting a local kody environment running.
   covers only the REST control plane; repo-session git clone/pull/push flows
   need a real Git-capable Artifacts remote and are not fully simulated by the
   local mock. Password reset and email-verification messages send through the
-  same Cloudflare Email API helper. Both send from
-  `kody@<SYSTEM_EMAIL_DOMAIN>` (falling back to the `APP_BASE_URL` hostname)
-  and put that same sending domain on action and asset links, so a legacy
-  `APP_BASE_URL` cannot pin `heykody.dev` into the message. Local `npm run
-  dev` keeps verification links on the request origin so signup stays
-  clickable. Set
-  `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock entirely. The main
-  worker streams logs live; the client bundle and background mock workers buffer
-  logs and only print them if that child process exits with an error.
+  same Cloudflare Email API helper. Both send from `kody@<SYSTEM_EMAIL_DOMAIN>`
+  (falling back to the `APP_BASE_URL` hostname) and put that same sending domain
+  on action and asset links, so a legacy `APP_BASE_URL` cannot pin `heykody.dev`
+  into the message. Local `npm run dev` keeps verification links on the request
+  origin so signup stays clickable. Set `SKIP_CLOUDFLARE_MOCK=1` to skip the
+  local Cloudflare mock entirely. The main worker streams logs live; the client
+  bundle and background mock workers buffer logs and only print them if that
+  child process exits with an error.
 - MCP **`search`** uses a deterministic offline ranker in tests and when
   `WRANGLER_IS_LOCAL_DEV` is set (no Vectorize / Workers AI embedding calls
   required for `npm run test` or unauthenticated local runs). Production uses

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -45,9 +45,12 @@ Quick notes for getting a local kody environment running.
   covers only the REST control plane; repo-session git clone/pull/push flows
   need a real Git-capable Artifacts remote and are not fully simulated by the
   local mock. Password reset and email-verification messages send through the
-  same Cloudflare Email API helper; password reset uses
-  `kody@<APP_BASE_URL hostname>` when `APP_BASE_URL` is set, and verification
-  can fall back to the request origin for local/E2E signup flows. Set
+  same Cloudflare Email API helper. Both send from
+  `kody@<SYSTEM_EMAIL_DOMAIN>` (falling back to the `APP_BASE_URL` hostname)
+  and put that same sending domain on action and asset links, so a legacy
+  `APP_BASE_URL` cannot pin `heykody.dev` into the message. Local `npm run
+  dev` keeps verification links on the request origin so signup stays
+  clickable. Set
   `SKIP_CLOUDFLARE_MOCK=1` to skip the local Cloudflare mock entirely. The main
   worker streams logs live; the client bundle and background mock workers buffer
   logs and only print them if that child process exits with an error.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -48,11 +48,11 @@ Quick notes for getting a local kody environment running.
   same Cloudflare Email API helper. Both send from `kody@<SYSTEM_EMAIL_DOMAIN>`
   (falling back to the `APP_BASE_URL` hostname) and put that same sending domain
   on action and asset links, so a legacy `APP_BASE_URL` cannot pin `heykody.dev`
-  into the message. Local `npm run dev` keeps verification links on the request
-  origin so signup stays clickable. Set `SKIP_CLOUDFLARE_MOCK=1` to skip the
-  local Cloudflare mock entirely. The main worker streams logs live; the client
-  bundle and background mock workers buffer logs and only print them if that
-  child process exits with an error.
+  into the message. Local `npm run dev` keeps those action and asset links on
+  the request origin so they stay clickable. Set `SKIP_CLOUDFLARE_MOCK=1` to
+  skip the local Cloudflare mock entirely. The main worker streams logs live;
+  the client bundle and background mock workers buffer logs and only print them
+  if that child process exits with an error.
 - MCP **`search`** uses a deterministic offline ranker in tests and when
   `WRANGLER_IS_LOCAL_DEV` is set (no Vectorize / Workers AI embedding calls
   required for `npm run test` or unauthenticated local runs). Production uses

--- a/packages/worker/src/app/email-change.ts
+++ b/packages/worker/src/app/email-change.ts
@@ -4,6 +4,7 @@ import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { hashVerificationToken } from '#app/email-verification.ts'
 import { normalizeEmail } from '#worker/identity/normalize-email.ts'
 import { buildEmailChangeEmail } from '#app/email/messages.ts'
+import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
 import { createDb, pendingEmailChangesTable } from '#worker/db.ts'
 import { resolveUserStableId } from '#worker/user-id.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
@@ -17,13 +18,20 @@ function generateEmailChangeToken() {
 }
 
 function getEmailChangeConfig(input: {
-	env: Pick<Env, 'APP_BASE_URL'>
+	env: Pick<Env, 'APP_BASE_URL' | 'SYSTEM_EMAIL_DOMAIN'> & {
+		WRANGLER_IS_LOCAL_DEV?: string
+	}
 	requestUrl: string | URL
 }) {
-	const configuredBaseUrl = input.env.APP_BASE_URL?.trim()
-	const appBaseUrl = new URL(configuredBaseUrl || input.requestUrl).origin
-	const fromEmail = `kody@${new URL(appBaseUrl).hostname}`
-	return { appBaseUrl, fromEmail }
+	return (
+		resolveTransactionalEmailConfig({
+			env: input.env,
+			requestUrl: input.requestUrl,
+		}) ?? {
+			appBaseUrl: new URL(input.requestUrl).origin,
+			fromEmail: `kody@${new URL(input.requestUrl).hostname}`,
+		}
+	)
 }
 
 export async function createEmailChangeVerification(input: {

--- a/packages/worker/src/app/email-verification.ts
+++ b/packages/worker/src/app/email-verification.ts
@@ -1,6 +1,7 @@
 import { isNonProductionRuntime } from '#app/deployment-env.ts'
 import { sendCloudflareEmail } from '#app/email/cloudflare-email.ts'
 import { buildVerificationEmail } from '#app/email/messages.ts'
+import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
 import { normalizeRedirectTo } from '#universal/safe-redirect.ts'
 import { createDb, emailVerificationsTable } from '#worker/db.ts'
 import { toHex } from '@kody-internal/shared/hex.ts'
@@ -33,13 +34,20 @@ export async function hashVerificationToken(token: string) {
 }
 
 function getVerificationEmailConfig(input: {
-	env: Pick<Env, 'APP_BASE_URL'>
+	env: Pick<Env, 'APP_BASE_URL' | 'SYSTEM_EMAIL_DOMAIN'> & {
+		WRANGLER_IS_LOCAL_DEV?: string
+	}
 	requestUrl: string | URL
 }) {
-	const configuredBaseUrl = input.env.APP_BASE_URL?.trim()
-	const appBaseUrl = new URL(configuredBaseUrl || input.requestUrl).origin
-	const fromEmail = `kody@${new URL(appBaseUrl).hostname}`
-	return { appBaseUrl, fromEmail }
+	return (
+		resolveTransactionalEmailConfig({
+			env: input.env,
+			requestUrl: input.requestUrl,
+		}) ?? {
+			appBaseUrl: new URL(input.requestUrl).origin,
+			fromEmail: `kody@${new URL(input.requestUrl).hostname}`,
+		}
+	)
 }
 
 /** Builds `/verify-email` with token and an optional safe post-verify resume target. */

--- a/packages/worker/src/app/email/messages.ts
+++ b/packages/worker/src/app/email/messages.ts
@@ -22,6 +22,12 @@ export function buildVerificationEmail(input: {
 		],
 		action: { label: 'Verify email address', url: input.verificationUrl },
 		afterAction: ['This link expires in 24 hours.'],
+		illustration: {
+			src: '/images/kody-lantern.webp',
+			alt: '',
+			width: 96,
+			height: 96,
+		},
 		footnote:
 			'If you did not create a Kody account, you can safely ignore this email.',
 	})

--- a/packages/worker/src/app/email/sender-config.node.test.ts
+++ b/packages/worker/src/app/email/sender-config.node.test.ts
@@ -51,6 +51,20 @@ test('resolveTransactionalEmailConfig derives link hosts from the sending domain
 
 	expect(
 		resolveTransactionalEmailConfig({
+			env: {
+				WRANGLER_IS_LOCAL_DEV: 'true',
+				APP_BASE_URL: 'https://kody.codes',
+				SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+			},
+			requestUrl: 'http://localhost:3742/signup',
+		}),
+	).toEqual({
+		appBaseUrl: 'http://localhost:3742',
+		fromEmail: 'kody@kody.codes',
+	})
+
+	expect(
+		resolveTransactionalEmailConfig({
 			env: { APP_BASE_URL: 'http://localhost:3742' },
 		}),
 	).toEqual({

--- a/packages/worker/src/app/email/sender-config.node.test.ts
+++ b/packages/worker/src/app/email/sender-config.node.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from 'vitest'
+import { resolveTransactionalEmailConfig } from './sender-config.ts'
+
+test('resolveTransactionalEmailConfig derives link hosts from the sending domain', () => {
+	expect(
+		resolveTransactionalEmailConfig({
+			env: {
+				APP_BASE_URL: 'https://heykody.dev',
+				SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+			},
+			requestUrl: 'https://heykody.dev/signup',
+		}),
+	).toEqual({
+		appBaseUrl: 'https://kody.codes',
+		fromEmail: 'kody@kody.codes',
+	})
+
+	expect(
+		resolveTransactionalEmailConfig({
+			env: { APP_BASE_URL: 'https://app.example.com/path' },
+		}),
+	).toEqual({
+		appBaseUrl: 'https://app.example.com',
+		fromEmail: 'kody@app.example.com',
+	})
+
+	expect(
+		resolveTransactionalEmailConfig({
+			env: {
+				APP_BASE_URL: 'https://kody.codes',
+				SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+			},
+		}),
+	).toEqual({
+		appBaseUrl: 'https://kody.codes',
+		fromEmail: 'kody@kody.codes',
+	})
+
+	expect(
+		resolveTransactionalEmailConfig({
+			env: {
+				WRANGLER_IS_LOCAL_DEV: 'true',
+				SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+			},
+			requestUrl: 'http://localhost:3742/signup',
+		}),
+	).toEqual({
+		appBaseUrl: 'http://localhost:3742',
+		fromEmail: 'kody@kody.codes',
+	})
+
+	expect(
+		resolveTransactionalEmailConfig({
+			env: { APP_BASE_URL: 'http://localhost:3742' },
+		}),
+	).toEqual({
+		appBaseUrl: 'http://localhost:3742',
+		fromEmail: 'kody@localhost',
+	})
+
+	expect(resolveTransactionalEmailConfig({ env: {} })).toBeNull()
+})

--- a/packages/worker/src/app/email/sender-config.ts
+++ b/packages/worker/src/app/email/sender-config.ts
@@ -1,0 +1,57 @@
+import { getSystemEmailDomain } from '#worker/email/platform-address.ts'
+
+export type TransactionalEmailEnv = {
+	APP_BASE_URL?: string | null
+	SYSTEM_EMAIL_DOMAIN?: string | null
+	WRANGLER_IS_LOCAL_DEV?: string
+}
+
+export type TransactionalEmailConfig = {
+	/** Absolute origin used for action links and email assets. */
+	appBaseUrl: string
+	/** Platform transactional sender: `kody@<sending domain>`. */
+	fromEmail: string
+}
+
+function tryOrigin(value: string | URL | null | undefined) {
+	if (value == null || value === '') return null
+	try {
+		return new URL(value).origin
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Resolve the From address and link origin for signup, email-change, and
+ * password-reset mail.
+ *
+ * From always follows the sending domain (`SYSTEM_EMAIL_DOMAIN`, else the
+ * `APP_BASE_URL` hostname). Link hosts follow that same domain so a legacy
+ * `APP_BASE_URL` or dual-served host cannot pin `heykody.dev` into the
+ * message. Local `npm run dev` keeps clickable links on the request origin
+ * so signup still works against localhost.
+ */
+export function resolveTransactionalEmailConfig(input: {
+	env: TransactionalEmailEnv
+	requestUrl?: string | URL | null
+}): TransactionalEmailConfig | null {
+	const systemDomain = getSystemEmailDomain(input.env)
+	const fallbackOrigin =
+		tryOrigin(input.env.APP_BASE_URL?.trim()) ?? tryOrigin(input.requestUrl)
+	const fromHost =
+		systemDomain ?? (fallbackOrigin ? new URL(fallbackOrigin).hostname : null)
+	if (!fromHost) return null
+
+	const fromEmail = `kody@${fromHost}`
+	if (input.env.WRANGLER_IS_LOCAL_DEV === 'true' && fallbackOrigin) {
+		return { appBaseUrl: fallbackOrigin, fromEmail }
+	}
+	if (fallbackOrigin && new URL(fallbackOrigin).hostname === fromHost) {
+		return { appBaseUrl: fallbackOrigin, fromEmail }
+	}
+	if (systemDomain) {
+		return { appBaseUrl: `https://${systemDomain}`, fromEmail }
+	}
+	return fallbackOrigin ? { appBaseUrl: fallbackOrigin, fromEmail } : null
+}

--- a/packages/worker/src/app/email/sender-config.ts
+++ b/packages/worker/src/app/email/sender-config.ts
@@ -37,15 +37,17 @@ export function resolveTransactionalEmailConfig(input: {
 	requestUrl?: string | URL | null
 }): TransactionalEmailConfig | null {
 	const systemDomain = getSystemEmailDomain(input.env)
-	const fallbackOrigin =
-		tryOrigin(input.env.APP_BASE_URL?.trim()) ?? tryOrigin(input.requestUrl)
+	const requestOrigin = tryOrigin(input.requestUrl)
+	const configuredOrigin = tryOrigin(input.env.APP_BASE_URL?.trim())
+	const fallbackOrigin = configuredOrigin ?? requestOrigin
 	const fromHost =
 		systemDomain ?? (fallbackOrigin ? new URL(fallbackOrigin).hostname : null)
 	if (!fromHost) return null
 
 	const fromEmail = `kody@${fromHost}`
-	if (input.env.WRANGLER_IS_LOCAL_DEV === 'true' && fallbackOrigin) {
-		return { appBaseUrl: fallbackOrigin, fromEmail }
+	if (input.env.WRANGLER_IS_LOCAL_DEV === 'true') {
+		const localOrigin = requestOrigin ?? configuredOrigin
+		if (localOrigin) return { appBaseUrl: localOrigin, fromEmail }
 	}
 	if (fallbackOrigin && new URL(fallbackOrigin).hostname === fromHost) {
 		return { appBaseUrl: fallbackOrigin, fromEmail }

--- a/packages/worker/src/app/email/template.node.test.ts
+++ b/packages/worker/src/app/email/template.node.test.ts
@@ -4,14 +4,14 @@ import { renderTransactionalEmail } from './template.ts'
 
 test('renderTransactionalEmail escapes untrusted content and mirrors the action in the text part', () => {
 	const email = renderTransactionalEmail({
-		appBaseUrl: 'https://heykody.dev',
+		appBaseUrl: 'https://kody.codes',
 		subject: 'Subject <script>',
 		preheader: 'Preheader "quoted"',
 		heading: 'Heading & more',
 		body: ['Body <b>text</b>'],
 		action: {
 			label: 'Do the thing',
-			url: 'https://kody.app/verify-email?token=a&redirectTo=/x',
+			url: 'https://kody.codes/verify-email?token=a&redirectTo=/x',
 		},
 		afterAction: ['Expires soon.'],
 		footnote: 'Ignore if unexpected.',
@@ -21,25 +21,35 @@ test('renderTransactionalEmail escapes untrusted content and mirrors the action 
 	expect(email.html).toContain('Heading &amp; more')
 	expect(email.html).toContain('Body &lt;b&gt;text&lt;/b&gt;')
 	expect(email.html).toContain(
-		'https://kody.app/verify-email?token=a&amp;redirectTo=/x',
+		'https://kody.codes/verify-email?token=a&amp;redirectTo=/x',
 	)
 	expect(email.text).toContain(
-		'Do the thing: https://kody.app/verify-email?token=a&redirectTo=/x',
+		'Do the thing: https://kody.codes/verify-email?token=a&redirectTo=/x',
 	)
 	expect(email.text).toContain('Expires soon.')
 	expect(email.text).toContain('Ignore if unexpected.')
+	expect(email.html).not.toContain('kody-lantern')
 })
 
 test('buildVerificationEmail links to the verification url in both parts', () => {
-	const verificationUrl = 'https://kody.app/verify-email?token=abc123'
+	const verificationUrl = 'https://kody.codes/verify-email?token=abc123'
 	const email = buildVerificationEmail({
-		appBaseUrl: 'https://heykody.dev',
+		appBaseUrl: 'https://kody.codes',
 		verificationUrl,
 	})
 
 	expect(email.subject).toMatch(/verify your email/i)
 	expect(email.html).toContain(verificationUrl)
 	expect(email.text).toContain(verificationUrl)
-	expect(email.html).toContain('https://heykody.dev/images/kody-mark.png')
+	expect(email.html).toContain('https://kody.codes/images/kody-mark.png')
 	expect(email.html).toContain('alt="Kody"')
+	expect(email.html).toContain('https://kody.codes/images/kody-lantern.webp')
+	expect(email.html).toMatch(
+		/<td align="center">\s*<img src="https:\/\/kody\.codes\/images\/kody-lantern\.webp"/,
+	)
+	expect(email.html).toContain('width="96"')
+	expect(email.html).toContain('This link expires in 24 hours.')
+	expect(email.html.indexOf('This link expires in 24 hours.')).toBeLessThan(
+		email.html.indexOf('kody-lantern.webp'),
+	)
 })

--- a/packages/worker/src/app/email/template.ts
+++ b/packages/worker/src/app/email/template.ts
@@ -12,6 +12,14 @@ type EmailAction = {
 	url: string
 }
 
+type EmailIllustration = {
+	/** Site-relative path resolved against `appBaseUrl`. */
+	src: string
+	alt: string
+	width: number
+	height: number
+}
+
 export type TransactionalEmailContent = {
 	/** Absolute origin used to load the Kody mark; keeps the image reachable from mail clients. */
 	appBaseUrl: string
@@ -27,6 +35,8 @@ export type TransactionalEmailContent = {
 	action?: EmailAction
 	/** Paragraphs shown below the action button, above the footer. */
 	afterAction?: Array<string>
+	/** Optional decorative image centered at the bottom of the card. */
+	illustration?: EmailIllustration
 	/** Small muted line at the very bottom of the card. */
 	footnote?: string
 }
@@ -82,6 +92,17 @@ export function renderTransactionalEmail(
             </table>
             <p class="kody-muted" style="${mutedStyle}">Button not working? Paste this link into your browser:<br /><a href="${escapeHtml(action.url)}" class="kody-link" style="color: ${colors.accent}; word-break: break-all;">${escapeHtml(action.url)}</a></p>`
 		: ''
+	const illustration = content.illustration
+	const illustrationBlock = illustration
+		? `
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 8px 0 0;">
+              <tr>
+                <td align="center">
+                  <img src="${escapeHtml(new URL(illustration.src, content.appBaseUrl).toString())}" alt="${escapeHtml(illustration.alt)}" width="${illustration.width}" height="${illustration.height}" style="display: block; margin: 0 auto; width: ${illustration.width}px; height: ${illustration.height}px; border: 0;" />
+                </td>
+              </tr>
+            </table>`
+		: ''
 
 	const html = `<!doctype html>
 <html lang="en">
@@ -126,7 +147,7 @@ export function renderTransactionalEmail(
               <td class="kody-card" style="background-color: ${colors.card}; border: 1px solid ${colors.border}; border-radius: 14px; padding: 32px;">
                 <h1 class="kody-text" style="margin: 0 0 16px; font-family: ${displayFontStack}; font-size: 24px; line-height: 1.25; font-weight: 700; letter-spacing: -0.02em; color: ${colors.text};">${escapeHtml(content.heading)}</h1>
                 ${paragraphs(content.body, 'kody-text', bodyStyle)}${actionBlock}
-                ${content.afterAction?.length ? paragraphs(content.afterAction, 'kody-muted', mutedStyle) : ''}
+                ${content.afterAction?.length ? paragraphs(content.afterAction, 'kody-muted', mutedStyle) : ''}${illustrationBlock}
               </td>
             </tr>
             ${

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -87,6 +87,40 @@ function createResetRequest() {
 
 const hexTokenPattern = /[0-9a-f]{64}/i
 
+test('password reset sends from the sending domain when SYSTEM_EMAIL_DOMAIN overrides a legacy APP_BASE_URL', async () => {
+	vi.clearAllMocks()
+	const handler = createPasswordResetRequestHandler(
+		createEnv({
+			APP_BASE_URL: 'https://heykody.dev',
+			SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+		}),
+	)
+
+	const response = await handler.handler({
+		request: createResetRequest(),
+		url: new URL('https://heykody.dev/password-reset'),
+		params: {},
+	})
+
+	expect(response.status).toBe(200)
+	expect(mockModule.sendCloudflareEmail).toHaveBeenCalledWith(
+		{
+			accountId: 'account-id',
+			apiBaseUrl: 'https://api.cloudflare.test',
+			apiToken: 'api-token',
+		},
+		expect.objectContaining({
+			from: 'kody@kody.codes',
+			to: 'user@example.com',
+		}),
+	)
+	const [, message] = mockModule.sendCloudflareEmail.mock.calls[0]!
+	expect((message as { text: string }).text).toContain(
+		'https://kody.codes/reset-password?token=',
+	)
+	expect((message as { html: string }).html).not.toContain('heykody.dev')
+})
+
 test('password reset sends from the APP_BASE_URL hostname without logging the token', async () => {
 	vi.clearAllMocks()
 	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/packages/worker/src/app/handlers/password-reset.node.test.ts
+++ b/packages/worker/src/app/handlers/password-reset.node.test.ts
@@ -87,6 +87,30 @@ function createResetRequest() {
 
 const hexTokenPattern = /[0-9a-f]{64}/i
 
+test('password reset keeps local action links on the request origin', async () => {
+	vi.clearAllMocks()
+	const handler = createPasswordResetRequestHandler(
+		createEnv({
+			APP_BASE_URL: 'https://kody.codes',
+			SYSTEM_EMAIL_DOMAIN: 'kody.codes',
+			WRANGLER_IS_LOCAL_DEV: 'true',
+		}),
+	)
+
+	const response = await handler.handler({
+		request: createResetRequest(),
+		url: new URL('http://localhost:3742/password-reset'),
+		params: {},
+	})
+
+	expect(response.status).toBe(200)
+	const [, message] = mockModule.sendCloudflareEmail.mock.calls[0]!
+	expect((message as { from: string }).from).toBe('kody@kody.codes')
+	expect((message as { text: string }).text).toContain(
+		'http://localhost:3742/reset-password?token=',
+	)
+})
+
 test('password reset sends from the sending domain when SYSTEM_EMAIL_DOMAIN overrides a legacy APP_BASE_URL', async () => {
 	vi.clearAllMocks()
 	const handler = createPasswordResetRequestHandler(

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -44,8 +44,12 @@ function getPasswordResetEmailConfig(
 	env: Pick<Env, 'APP_BASE_URL' | 'SYSTEM_EMAIL_DOMAIN'> & {
 		WRANGLER_IS_LOCAL_DEV?: string
 	},
+	requestUrl?: string | URL,
 ) {
-	return resolveTransactionalEmailConfig({ env })
+	return resolveTransactionalEmailConfig({
+		env,
+		requestUrl: env.WRANGLER_IS_LOCAL_DEV === 'true' ? requestUrl : undefined,
+	})
 }
 
 export function createPasswordResetRequestHandler(env: Env) {
@@ -94,7 +98,9 @@ export function createPasswordResetRequestHandler(env: Env) {
 			const userRecord = await db.findOne(usersTable, {
 				where: { email: normalizedEmail },
 			})
-			const emailConfig = userRecord ? getPasswordResetEmailConfig(env) : null
+			const emailConfig = userRecord
+				? getPasswordResetEmailConfig(env, url)
+				: null
 
 			const expiresAt = Date.now() + passwordResetTokenExpiryMs
 			const resetToken = userRecord

--- a/packages/worker/src/app/handlers/password-reset.ts
+++ b/packages/worker/src/app/handlers/password-reset.ts
@@ -19,6 +19,7 @@ import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 import { getPasswordPolicyError } from '@kody-internal/shared/password-policy.ts'
 import { verifyPublicFormProtection } from '#app/public-form-protection.ts'
 import { buildPasswordResetEmail } from '#app/email/messages.ts'
+import { resolveTransactionalEmailConfig } from '#app/email/sender-config.ts'
 
 const resetRequestSchema = object({
 	email: string(),
@@ -39,13 +40,12 @@ function logMissingEmailConfig(payload: { to: string; subject: string }) {
 	)
 }
 
-function getPasswordResetEmailConfig(env: Pick<Env, 'APP_BASE_URL'>) {
-	const configuredBaseUrl = env.APP_BASE_URL?.trim()
-	if (!configuredBaseUrl) return null
-
-	const appBaseUrl = new URL(configuredBaseUrl).origin
-	const fromEmail = `kody@${new URL(configuredBaseUrl).hostname}`
-	return { appBaseUrl, fromEmail }
+function getPasswordResetEmailConfig(
+	env: Pick<Env, 'APP_BASE_URL' | 'SYSTEM_EMAIL_DOMAIN'> & {
+		WRANGLER_IS_LOCAL_DEV?: string
+	},
+) {
+	return resolveTransactionalEmailConfig({ env })
 }
 
 export function createPasswordResetRequestHandler(env: Env) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The first email people see at signup should point at the live Kody host (`kody.codes`), not the legacy `heykody.dev` origin, and it should feel a little more like Kody — a small lantern under the expiry line.

## Summary

- Signup, email-change, and password-reset messages send from `kody@<SYSTEM_EMAIL_DOMAIN>` and put that same sending domain on action and asset links.
- A leftover `APP_BASE_URL` of `https://heykody.dev` can no longer leak into the verify / reset URLs or the Kody mark.
- Local `npm run dev` prefers the inbound request origin for those links, even when `APP_BASE_URL` points at production, so signup and password-reset stay clickable on localhost.
- The welcome card now includes a small, centered `kody-lantern` image under “This link expires in 24 hours.”

## Testing

- `npx vitest run` on `sender-config`, `template`, `password-reset`, and `email-verification` node tests.
- `npx nx run worker:typecheck` passed.
- Rendered the welcome HTML with `appBaseUrl=https://kody.codes`: every link/asset host is `kody.codes`, no `heykody.dev`, lantern sits centered under the expiry line.
- Preview smoke on https://kody-pr-1606.kody-a99.workers.dev: health, login as `me@kentcdodds.com`, `POST /password-reset` returned 200.

![Welcome email with kody.codes verify link and centered lantern](https://cursor.com/artifacts/c/art-5f51cf2e-8e63-43b1-8fe3-3ce61dae6a9e)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `779b982d` · **Head:** `11234716`

**Classification:** extends — auth-mail link hosts now follow `SYSTEM_EMAIL_DOMAIN` instead of `APP_BASE_URL` / the request host; the welcome template gains a footer illustration.

### Primitives touched

| Primitive | Group | Impact |
| ------------ | -------- | --------------------------------------- |
| `app-sessions` | auth | extends — verification links resolve from the sending domain |
| `app-ui` | surfaces | extends — welcome card illustration; password-reset / email-change senders share the same host rule |

### Change flow

Signup verification mail now takes its From address and clickable hosts from the system sending domain, not a leftover `heykody.dev` app origin.

```mermaid
sequenceDiagram
	actor User
	participant appSessions as app-sessions
	participant appUi as app-ui
	User->>appSessions: POST /signup
	appSessions->>appSessions: resolveTransactionalEmailConfig from SYSTEM_EMAIL_DOMAIN
	appSessions->>appUi: buildVerificationEmail with kody.codes links
	Note over appUi: centered kody-lantern under expiry line
	appUi->>User: From kody@kody.codes, verify URL on kody.codes
```

### Before / after

```diff
- from: kody@heykody.dev
- https://heykody.dev/verify-email?token=…
+ from: kody@kody.codes
+ https://kody.codes/verify-email?token=…
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07b8268c-b7e7-4444-ad12-ed04e99899a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07b8268c-b7e7-4444-ad12-ed04e99899a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transactional emails now use the configured system email domain for sender addresses and links.
  * Local development emails preserve request-origin links when appropriate.
  * Verification emails now include a lantern illustration.

* **Bug Fixes**
  * Password-reset links no longer use an outdated application URL when a system email domain is configured.

* **Documentation**
  * Updated setup and environment-variable guidance for transactional email behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->