### PR TITLE
feat(packages): store kody.dependencies as a name-to-* map

### DIFF
--- a/docs/contributing/decisions/0029-kody-dependencies-wildcard-map.md
+++ b/docs/contributing/decisions/0029-kody-dependencies-wildcard-map.md
@@ -1,0 +1,36 @@
+# 0029: `kody.dependencies` is a name-to-`*` map; still no pins or live resolution
+
+- **Status:** accepted
+- **Date:** 2026-08-20
+
+## Context
+
+`package.json#kody.dependencies` was an array of scoped names. Agents already
+write npm-style maps, and [0001](./0001-no-package-versioning.md) already named
+this field as the future pin surface. Changing the array to a map without
+changing resolution was the remaining question: should `*` mean live latest
+(skip republishing dependents), and should other versions be legal?
+
+Package storage is keyed by immutable `packageId`, not commit. Two pinned
+versions of the same package would share one SQLite bucket. Live `*` would run
+dependency code that publish checks never saw.
+
+## Decision
+
+`kody.dependencies` is a map of `"@scope/package": "*"`. `*` means the
+dependency's latest published commit, captured when **this** package publishes.
+Do not accept ranges, tags, or commit SHAs. Do not resolve static imports live
+when a dependency publishes. Do not auto-republish dependents.
+
+A legacy array of those names still publishes until fleet apply of
+`0005-kody-dependencies-to-wildcard-map` and a follow-up enforcement drop.
+
+## Consequences
+
+The published bundle remains the lock. Execute and `packages.invoke` stay the
+live paths. Freeze by forking under another name (new `packageId`, new bucket),
+not by pinning a version onto shared storage.
+
+Revisit only if a concrete consumer needs a pin that a fork cannot serve, and
+then prefer commit-SHA values in this map (0001) after deciding how those
+commits share `packageStorage()`.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -41,6 +41,7 @@ Add new steering records to the steering list, not a catch-all numbered dump.
 Open these before proposing a new primitive, surface, or storage home.
 
 - [0001 — No user-facing package versioning or import pins](./0001-no-package-versioning.md)
+- [0029 — `kody.dependencies` is a name-to-`*` map; still no pins or live resolution](./0029-kody-dependencies-wildcard-map.md)
 - [0002 — Data placement: D1, per-user Durable Objects, Analytics Engine](./0002-data-placement.md)
 - [0003 — Repos are the base primitive; packages are an explicit extension](./0003-repos-as-base-primitive.md)
 - [0004 — Status page stays a separate worker with its own storage](./0004-status-page-separate-worker.md)

--- a/docs/contributing/package-codemods.md
+++ b/docs/contributing/package-codemods.md
@@ -196,6 +196,20 @@ legacy package-app origin to the canonical hosted-app origin:
 - Emits `needsManual` for every remaining `kodyapps.dev` mention after the
   origin rewrite (bare hostnames, nested labels, lookalikes).
 
+### `0005-kody-dependencies-to-wildcard-map`
+
+This manifest-format codemod rewrites `package.json#kody.dependencies` from the
+legacy array of scoped names to a name-to-`*` map:
+
+- Rewrites `["@scope/pkg"]` to `{ "@scope/pkg": "*" }`, including an empty array
+  to `{}`.
+- Rewrites the agent-common `latest` alias to `*`. Already-migrated `*` maps are
+  left unchanged.
+- Emits `needsManual` for unsupported versions (semver ranges, commit SHAs),
+  unscoped names, and missing or invalid `package.json`.
+- Does **not** change resolution: `*` is latest-at-publish, captured when the
+  dependent republishes. It is not a live pin.
+
 ## Engine
 
 The engine entry point is `runPackageCodemodStep` in

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -22,9 +22,12 @@ Use `package.json` as the canonical source of truth for saved package metadata.
 - `kody.description` — short public tagline for search/detail (max 200)
 - `kody.tags` — search tags
 - `kody.searchText` — optional longer search text beyond the short description
-- `kody.dependencies` — direct static saved package dependencies imported via
-  `kody:@...`. Repo checks reject cycles in this graph at publish time, and fail
-  closed if a reachable saved package manifest cannot be loaded.
+- `kody.dependencies` — map of direct static saved package dependencies imported
+  via `kody:@...`, written as `{ "@scope/package": "*" }`. `*` means the
+  dependency's latest published commit, captured when this package publishes.
+  Repo checks also accept a legacy array of those names. They reject cycles in
+  this graph at publish time, and fail closed if a reachable saved package
+  manifest cannot be loaded.
 - `kody.secretMounts` — optional package-scoped secret mount declarations
 - `kody.app` — optional hosted package app config
 - `kody.subscriptions` — optional package-owned event subscriptions
@@ -119,11 +122,13 @@ A saved package is a repo with the package extension activated. Four concepts:
   and the runtime rewrites the call site to a teaching error.
 - Direct static `kody:@...` imports are a breaking manifest contract: they must
   be listed in `package.json#kody.dependencies` by package name, for example
-  `"dependencies": ["@scope/my-package"]` inside the `kody` object. Repo checks
-  fail when a static import is missing from the list or when the list contains a
-  package that is not statically imported. Type-only imports do not count, and
-  declaration files such as `.d.ts` are treated as type-only. Literal dynamic
-  `import("kody:@...")` expressions are not static dependency declarations.
+  `"dependencies": { "@scope/my-package": "*" }` inside the `kody` object. `*`
+  is the only supported version and means latest-at-publish, not a live pin.
+  Repo checks fail when a static import is missing from the map or when the map
+  contains a package that is not statically imported. Type-only imports do not
+  count, and declaration files such as `.d.ts` are treated as type-only. Literal
+  dynamic `import("kody:@...")` expressions are not static dependency
+  declarations.
 - Computed dynamic Kody package imports are intentionally unsupported. The
   bundler rewrites non-literal `import(...)` expressions with a guard that
   throws clearly when the runtime specifier starts with `kody:@`; do not add

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -75,8 +75,8 @@ Important fields:
   export docs
 - `kody.tags` — package tags
 - `kody.searchText` — optional longer search text beyond the short description
-- `kody.dependencies` — direct saved package names imported through static
-  `kody:@...` imports
+- `kody.dependencies` — map of direct saved package names imported through
+  static `kody:@...` imports (`{ "@scope/package": "*" }`)
 - `kody.secretMounts` — optional package-scoped secret mount declarations
 - `kody.app` — optional hosted package app config
 - `kody.subscriptions` — optional event-topic subscriptions with package-local
@@ -159,9 +159,11 @@ exhaustive.
   [Dynamic package invocation](#dynamic-package-invocation)).
 - Every direct static `kody:@...` import must be declared in
   `package.json#kody.dependencies` using the imported package name, for example
-  `"dependencies": ["@scope/my-package"]` inside the `kody` object. Package
-  checks fail when static imports and declarations differ. Type-only imports do
-  not count, and declaration files such as `.d.ts` are treated as type-only.
+  `"dependencies": { "@scope/my-package": "*" }` inside the `kody` object. `*`
+  means the dependency's latest published commit, captured when this package
+  publishes. Package checks fail when static imports and declarations differ.
+  Type-only imports do not count, and declaration files such as `.d.ts` are
+  treated as type-only.
 - Computed dynamic Kody package imports, including template strings and
   variables such as `import(packageSpecifier)`, are unsupported. When the target
   package is not known until runtime, use `packages.invoke` instead.

--- a/packages/worker/src/community/fork-scan.node.test.ts
+++ b/packages/worker/src/community/fork-scan.node.test.ts
@@ -108,6 +108,28 @@ import 'kody:@owner/a/y'`,
 	})
 
 	expect(sameScopeOnly).toEqual([])
+
+	const mapShaped = scanCrossScopeReferences({
+		files: {
+			'package.json': `{
+	"name": "@jane/pkg",
+	"kody": {
+		"id": "pkg",
+		"description": "Pkg",
+		"dependencies": {
+			"@owner/shared-utils": "*",
+			"@jane/local-lib": "*"
+		}
+	},
+	"exports": { ".": "./src/index.ts" }
+}
+`,
+		},
+		expectedPackageScope: 'jane',
+	})
+	expect(mapShaped).toEqual([
+		{ file: 'package.json', specifier: '@owner/shared-utils' },
+	])
 })
 
 test('scanCrossScopeReferences allows platform scopes to remain in forked packages', () => {

--- a/packages/worker/src/community/fork-scan.ts
+++ b/packages/worker/src/community/fork-scan.ts
@@ -1,3 +1,4 @@
+import { listKodyPackageDependencyNames } from '#worker/package-registry/types.ts'
 import { type CrossScopeReference } from './types.ts'
 
 const kodyImportPattern = /kody:@([a-z0-9][a-z0-9._-]*)\//g
@@ -75,9 +76,11 @@ export function scanCrossScopeReferences(input: {
 		if (file === 'package.json') {
 			try {
 				const parsed = JSON.parse(content) as {
-					kody?: { dependencies?: Array<string> }
+					kody?: { dependencies?: Array<string> | Record<string, string> }
 				}
-				for (const dependency of parsed.kody?.dependencies ?? []) {
+				for (const dependency of listKodyPackageDependencyNames(
+					parsed.kody?.dependencies,
+				)) {
 					const dependencyScope = getScopeFromScopedName(dependency)
 					if (dependencyScope != null && isForeign(dependencyScope)) {
 						addCrossScopeReference(seen, results, {

--- a/packages/worker/src/package-codemods/codemods/0005-kody-dependencies-to-wildcard-map.node.test.ts
+++ b/packages/worker/src/package-codemods/codemods/0005-kody-dependencies-to-wildcard-map.node.test.ts
@@ -1,0 +1,163 @@
+import { expect, test } from 'vitest'
+import { kodyDependenciesToWildcardMapCodemod } from './0005-kody-dependencies-to-wildcard-map.ts'
+
+function manifest(kodyExtra: Record<string, unknown> = {}) {
+	return `${JSON.stringify(
+		{
+			name: '@user/demo',
+			exports: { '.': './index.ts' },
+			kody: {
+				id: 'demo',
+				description: 'Demo package for kody.dependencies map codemod tests.',
+				...kodyExtra,
+			},
+		},
+		null,
+		'\t',
+	)}\n`
+}
+
+test('0005 rewrites array and latest-alias maps to name-to-* and is idempotent', () => {
+	const arrayFiles = {
+		'package.json': manifest({
+			dependencies: ['@user/helper', '@other/lib'],
+		}),
+		'index.ts': 'export const ready = true\n',
+	}
+	const arrayDetect = kodyDependenciesToWildcardMapCodemod.detect(arrayFiles)
+	expect(arrayDetect).toEqual([
+		{
+			path: 'package.json',
+			message: expect.stringContaining('array-shaped'),
+		},
+	])
+	const arrayTransform =
+		kodyDependenciesToWildcardMapCodemod.transform(arrayFiles)
+	expect(arrayTransform.changed).toBe(true)
+	expect(arrayTransform.changedPaths).toEqual(['package.json'])
+	expect(arrayTransform.needsManual).toEqual([])
+	expect(
+		JSON.parse(arrayTransform.files['package.json']!).kody.dependencies,
+	).toEqual({
+		'@other/lib': '*',
+		'@user/helper': '*',
+	})
+	expect(arrayTransform.files['index.ts']).toBe(arrayFiles['index.ts'])
+
+	const secondPass = kodyDependenciesToWildcardMapCodemod.transform(
+		arrayTransform.files,
+	)
+	expect(secondPass.changed).toBe(false)
+	expect(secondPass.files['package.json']).toBe(
+		arrayTransform.files['package.json'],
+	)
+	expect(
+		kodyDependenciesToWildcardMapCodemod.detect(arrayTransform.files),
+	).toEqual([])
+
+	const aliasFiles = {
+		'package.json': manifest({
+			dependencies: {
+				'@user/helper': 'latest',
+				'@other/lib': '*',
+			},
+		}),
+	}
+	const aliasDetect = kodyDependenciesToWildcardMapCodemod.detect(aliasFiles)
+	expect(aliasDetect).toEqual([
+		{
+			path: 'package.json',
+			message: expect.stringContaining('normalizes to "*"'),
+		},
+	])
+	const aliasTransform =
+		kodyDependenciesToWildcardMapCodemod.transform(aliasFiles)
+	expect(aliasTransform.changed).toBe(true)
+	expect(
+		JSON.parse(aliasTransform.files['package.json']!).kody.dependencies,
+	).toEqual({
+		'@other/lib': '*',
+		'@user/helper': '*',
+	})
+
+	const emptyArray = {
+		'package.json': manifest({ dependencies: [] }),
+	}
+	const emptyTransform =
+		kodyDependenciesToWildcardMapCodemod.transform(emptyArray)
+	expect(emptyTransform.changed).toBe(true)
+	expect(
+		JSON.parse(emptyTransform.files['package.json']!).kody.dependencies,
+	).toEqual({})
+
+	const alreadyMigrated = {
+		'package.json': manifest({
+			dependencies: { '@user/helper': '*' },
+		}),
+	}
+	expect(kodyDependenciesToWildcardMapCodemod.detect(alreadyMigrated)).toEqual(
+		[],
+	)
+	expect(
+		kodyDependenciesToWildcardMapCodemod.transform(alreadyMigrated).changed,
+	).toBe(false)
+})
+
+test('0005 leaves unsupported shapes for manual review and skips missing manifests', () => {
+	const semverFiles = {
+		'package.json': manifest({
+			dependencies: { '@user/helper': '^1.2.3' },
+		}),
+	}
+	expect(kodyDependenciesToWildcardMapCodemod.detect(semverFiles)).toEqual([
+		{
+			path: 'package.json',
+			message: expect.stringContaining('review and update manually'),
+		},
+	])
+	const semverTransform =
+		kodyDependenciesToWildcardMapCodemod.transform(semverFiles)
+	expect(semverTransform.changed).toBe(false)
+	expect(semverTransform.files['package.json']).toBe(
+		semverFiles['package.json'],
+	)
+	expect(semverTransform.needsManual).toEqual([
+		{
+			path: 'package.json',
+			message: expect.stringContaining('review and update manually'),
+		},
+	])
+
+	const invalidName = {
+		'package.json': manifest({
+			dependencies: ['helper', '@user/ok'],
+		}),
+	}
+	const invalidNameTransform =
+		kodyDependenciesToWildcardMapCodemod.transform(invalidName)
+	expect(invalidNameTransform.changed).toBe(false)
+	expect(invalidNameTransform.needsManual).toEqual([
+		{
+			path: 'package.json',
+			message: expect.stringContaining('not scoped package names'),
+		},
+	])
+
+	const noManifest = {
+		'index.ts': 'export const ready = true\n',
+	}
+	expect(kodyDependenciesToWildcardMapCodemod.detect(noManifest)).toEqual([
+		{
+			path: 'package.json',
+			message: expect.stringContaining('missing or not valid JSON'),
+		},
+	])
+
+	const noKody = {
+		'package.json': `${JSON.stringify({ name: '@user/demo' }, null, '\t')}\n`,
+	}
+	expect(kodyDependenciesToWildcardMapCodemod.detect(noKody)).toEqual([])
+	expect(kodyDependenciesToWildcardMapCodemod.transform(noKody).changed).toBe(
+		false,
+	)
+})

--- a/packages/worker/src/package-codemods/codemods/0005-kody-dependencies-to-wildcard-map.ts
+++ b/packages/worker/src/package-codemods/codemods/0005-kody-dependencies-to-wildcard-map.ts
@@ -1,0 +1,266 @@
+import {
+	type KodyPackageDependencies,
+	kodyPackageDependencySchema,
+	kodyPackageDependencyWildcard,
+	listKodyPackageDependencyNames,
+} from '#worker/package-registry/types.ts'
+import {
+	type PackageCodemod,
+	type PackageCodemodFinding,
+	type PackageCodemodTransformResult,
+} from '../types.ts'
+
+export const kodyDependenciesToWildcardMapCodemodId =
+	'0005-kody-dependencies-to-wildcard-map'
+
+const packageManifestPath = 'package.json'
+const latestAlias = 'latest'
+
+const arrayRewriteMessage =
+	'Declares array-shaped package.json#kody.dependencies; rewrite to a name-to-"*" map.'
+
+const aliasRewriteMessage =
+	'Declares a kody.dependencies version that normalizes to "*"; rewrite that value to "*".'
+
+const invalidJsonMessage =
+	'package.json is missing or not valid JSON; review kody.dependencies manually.'
+
+const invalidShapeMessage =
+	'package.json#kody.dependencies is not an array or object map; review and update manually.'
+
+const invalidNamesMessage =
+	'package.json#kody.dependencies has entries that are not scoped package names; review and update manually.'
+
+const unsupportedVersionMessage =
+	'Declares a kody.dependencies version that is not "*"; review and update manually. Only "*" is supported (latest published commit, captured when this package publishes).'
+
+type ManifestRecord = Record<string, unknown>
+
+type DependenciesRewrite =
+	| { kind: 'clean' }
+	| { kind: 'rewrite-array'; next: KodyPackageDependencies }
+	| { kind: 'rewrite-alias'; next: KodyPackageDependencies }
+	| { kind: 'manual'; message: string }
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseManifest(source: string): ManifestRecord | null {
+	try {
+		const parsed: unknown = JSON.parse(source)
+		if (!isPlainObject(parsed)) return null
+		return parsed
+	} catch {
+		return null
+	}
+}
+
+function toWildcardMap(names: ReadonlyArray<string>): KodyPackageDependencies {
+	return Object.fromEntries(
+		names.map((name) => [name, kodyPackageDependencyWildcard]),
+	)
+}
+
+function allEntriesAreScopedNames(entries: ReadonlyArray<string>) {
+	return entries.every(
+		(entry) => kodyPackageDependencySchema.safeParse(entry.trim()).success,
+	)
+}
+
+function classifyDependencies(value: unknown): DependenciesRewrite {
+	if (value === undefined) return { kind: 'clean' }
+	if (Array.isArray(value)) {
+		if (!value.every((entry) => typeof entry === 'string')) {
+			return { kind: 'manual', message: invalidNamesMessage }
+		}
+		if (value.length > 0 && !allEntriesAreScopedNames(value)) {
+			return { kind: 'manual', message: invalidNamesMessage }
+		}
+		return {
+			kind: 'rewrite-array',
+			next: toWildcardMap(listKodyPackageDependencyNames(value)),
+		}
+	}
+	if (!isPlainObject(value)) {
+		return { kind: 'manual', message: invalidShapeMessage }
+	}
+	const names = Object.keys(value)
+	if (!allEntriesAreScopedNames(names)) {
+		return { kind: 'manual', message: invalidNamesMessage }
+	}
+	const versions = Object.values(value)
+	if (
+		!versions.every(
+			(version) =>
+				version === kodyPackageDependencyWildcard || version === latestAlias,
+		)
+	) {
+		return { kind: 'manual', message: unsupportedVersionMessage }
+	}
+	if (versions.every((version) => version === kodyPackageDependencyWildcard)) {
+		return { kind: 'clean' }
+	}
+	return {
+		kind: 'rewrite-alias',
+		next: toWildcardMap(
+			listKodyPackageDependencyNames(value as Record<string, string>),
+		),
+	}
+}
+
+function detectJsonIndent(source: string) {
+	const match = source.match(/\n([ \t]+)"/)
+	return match?.[1] ?? '\t'
+}
+
+function formatPackageJson(value: unknown, source: string) {
+	return `${JSON.stringify(value, null, detectJsonIndent(source))}\n`
+}
+
+function classifyPackageJson(files: Record<string, string>): {
+	path: string
+	rewrite: DependenciesRewrite
+	source: string | null
+	parsed: ManifestRecord | null
+} {
+	const source = files[packageManifestPath]
+	if (typeof source !== 'string') {
+		return {
+			path: packageManifestPath,
+			rewrite: { kind: 'manual', message: invalidJsonMessage },
+			source: null,
+			parsed: null,
+		}
+	}
+	const parsed = parseManifest(source)
+	if (!parsed) {
+		return {
+			path: packageManifestPath,
+			rewrite: { kind: 'manual', message: invalidJsonMessage },
+			source,
+			parsed: null,
+		}
+	}
+	const kody = parsed['kody']
+	if (kody === undefined) {
+		return {
+			path: packageManifestPath,
+			rewrite: { kind: 'clean' },
+			source,
+			parsed,
+		}
+	}
+	if (!isPlainObject(kody)) {
+		return {
+			path: packageManifestPath,
+			rewrite: { kind: 'manual', message: invalidShapeMessage },
+			source,
+			parsed,
+		}
+	}
+	return {
+		path: packageManifestPath,
+		rewrite: classifyDependencies(kody['dependencies']),
+		source,
+		parsed,
+	}
+}
+
+function detectKodyDependenciesToWildcardMap(
+	files: Record<string, string>,
+): Array<PackageCodemodFinding> {
+	const { path, rewrite } = classifyPackageJson(files)
+	switch (rewrite.kind) {
+		case 'clean':
+			return []
+		case 'rewrite-array':
+			return [{ path, message: arrayRewriteMessage }]
+		case 'rewrite-alias':
+			return [{ path, message: aliasRewriteMessage }]
+		case 'manual':
+			return [{ path, message: rewrite.message }]
+		default: {
+			const exhaustive: never = rewrite
+			return exhaustive
+		}
+	}
+}
+
+function transformKodyDependenciesToWildcardMap(
+	files: Record<string, string>,
+): PackageCodemodTransformResult {
+	const { path, rewrite, source, parsed } = classifyPackageJson(files)
+	if (rewrite.kind === 'clean') {
+		return {
+			files: { ...files },
+			changed: false,
+			changedPaths: [],
+			needsManual: [],
+		}
+	}
+	if (rewrite.kind === 'manual' || source == null || parsed == null) {
+		return {
+			files: { ...files },
+			changed: false,
+			changedPaths: [],
+			needsManual: [
+				{
+					path,
+					message:
+						rewrite.kind === 'manual' ? rewrite.message : invalidJsonMessage,
+				},
+			],
+		}
+	}
+	if (!isPlainObject(parsed['kody'])) {
+		return {
+			files: { ...files },
+			changed: false,
+			changedPaths: [],
+			needsManual: [{ path, message: invalidJsonMessage }],
+		}
+	}
+	const nextSource = formatPackageJson(
+		{
+			...parsed,
+			kody: {
+				...parsed['kody'],
+				dependencies: rewrite.next,
+			},
+		},
+		source,
+	)
+	if (nextSource === source) {
+		return {
+			files: { ...files },
+			changed: false,
+			changedPaths: [],
+			needsManual: [],
+		}
+	}
+	return {
+		files: {
+			...files,
+			[packageManifestPath]: nextSource,
+		},
+		changed: true,
+		changedPaths: [packageManifestPath],
+		needsManual: [],
+	}
+}
+
+/**
+ * Manifest-format migration: rewrite published `kody.dependencies` from an
+ * array of package names (or a map that uses the `latest` alias) to a
+ * name-to-"*" object. Resolution stays snapshot-at-publish; "*" is not a
+ * live pin. Kept registered while any published package still uses the
+ * array form.
+ */
+export const kodyDependenciesToWildcardMapCodemod = {
+	id: kodyDependenciesToWildcardMapCodemodId,
+	description:
+		'Rewrite package.json#kody.dependencies from an array of names to a name-to-"*" map; flag unsupported versions for manual review.',
+	detect: detectKodyDependenciesToWildcardMap,
+	transform: transformKodyDependenciesToWildcardMap,
+} satisfies PackageCodemod

--- a/packages/worker/src/package-codemods/registry.ts
+++ b/packages/worker/src/package-codemods/registry.ts
@@ -2,6 +2,7 @@ import { ambientStorageToPackageStorageCodemod } from './codemods/0001-ambient-s
 import { staticFirstInvocationCodemod } from './codemods/0002-static-first-invocation.ts'
 import { heykodyDomainsToKodyCodesCodemod } from './codemods/0003-heykody-domains-to-kody-codes.ts'
 import { kodyappsDevToKodyRunCodemod } from './codemods/0004-kodyapps-dev-to-kody-run.ts'
+import { kodyDependenciesToWildcardMapCodemod } from './codemods/0005-kody-dependencies-to-wildcard-map.ts'
 import { type PackageCodemod } from './types.ts'
 
 const packageCodemods: Array<PackageCodemod> = [
@@ -9,6 +10,7 @@ const packageCodemods: Array<PackageCodemod> = [
 	staticFirstInvocationCodemod,
 	heykodyDomainsToKodyCodesCodemod,
 	kodyappsDevToKodyRunCodemod,
+	kodyDependenciesToWildcardMapCodemod,
 ]
 
 const packageCodemodsById = new Map(

--- a/packages/worker/src/package-registry/static-dependency-cycles.ts
+++ b/packages/worker/src/package-registry/static-dependency-cycles.ts
@@ -1,6 +1,7 @@
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import { listSavedPackagesByUserId } from '#worker/package-registry/repo.ts'
 import { loadPackageManifestBySourceId } from '#worker/package-registry/source.ts'
+import { listKodyPackageDependencyNames } from '#worker/package-registry/types.ts'
 
 /**
  * Detect cycles in static `kody:@` / `package.json#kody.dependencies` graphs.
@@ -68,7 +69,9 @@ export async function loadReachableStaticKodyDependencyEdges(input: {
 	rootDependencies: ReadonlyArray<string>
 }): Promise<LoadedStaticKodyDependencyEdges> {
 	const edges = new Map<string, Array<string>>()
-	const rootDependencies = uniqueTrimmedNames(input.rootDependencies)
+	const rootDependencies = listKodyPackageDependencyNames(
+		input.rootDependencies,
+	)
 	edges.set(input.rootPackageName, rootDependencies)
 	const savedPackages = await listSavedPackagesByUserId(input.env.APP_DB, {
 		userId: input.userId,
@@ -92,8 +95,8 @@ export async function loadReachableStaticKodyDependencyEdges(input: {
 				userId: input.userId,
 				sourceId: savedPackage.sourceId,
 			})
-			const dependencies = uniqueTrimmedNames(
-				loaded.manifest.kody.dependencies ?? [],
+			const dependencies = listKodyPackageDependencyNames(
+				loaded.manifest.kody.dependencies,
 			)
 			edges.set(packageName, dependencies)
 			pending.push(...dependencies)
@@ -108,10 +111,4 @@ export async function loadReachableStaticKodyDependencyEdges(input: {
 		}
 	}
 	return { ok: true, edges }
-}
-
-function uniqueTrimmedNames(names: ReadonlyArray<string>) {
-	return Array.from(
-		new Set(names.map((name) => name.trim()).filter((name) => name.length > 0)),
-	)
 }

--- a/packages/worker/src/package-registry/types.node.test.ts
+++ b/packages/worker/src/package-registry/types.node.test.ts
@@ -22,6 +22,9 @@ test('kody.dependencies accepts a name-to-* map and a legacy name array, and lis
 	expect(
 		listKodyPackageDependencyNames(['@scope/b', ' @scope/a ', '@scope/b']),
 	).toEqual(['@scope/a', '@scope/b'])
+	expect(listKodyPackageDependencyNames([1, '@scope/a', null])).toEqual([
+		'@scope/a',
+	])
 	expect(
 		listKodyPackageDependencyNames({
 			'@scope/b': '*',
@@ -69,6 +72,19 @@ test('kody.dependencies accepts a name-to-* map and a legacy name array, and lis
 	expect(() =>
 		parseAuthoredPackageJson({
 			content: manifest(['helper']),
+		}),
+	).toThrow(/scoped package names/)
+
+	// Zod 4 still runs transform after non-fatal superRefine issues. A
+	// non-string array entry must stay a schema failure, not a throw from trim.
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: manifest([1, '@scope/helper']),
+		}),
+	).toThrow(/scoped package names/)
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: manifest([null]),
 		}),
 	).toThrow(/scoped package names/)
 })

--- a/packages/worker/src/package-registry/types.node.test.ts
+++ b/packages/worker/src/package-registry/types.node.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest'
+import { parseAuthoredPackageJson } from './manifest.ts'
+import {
+	kodyPackageDependencyWildcard,
+	listKodyPackageDependencyNames,
+} from './types.ts'
+
+function manifest(dependencies: unknown) {
+	return JSON.stringify({
+		name: '@scope/demo',
+		exports: { '.': './index.ts' },
+		kody: {
+			id: 'demo',
+			description: 'Demo package',
+			dependencies,
+		},
+	})
+}
+
+test('kody.dependencies accepts a name-to-* map and a legacy name array, and lists names from either shape', () => {
+	expect(listKodyPackageDependencyNames(undefined)).toEqual([])
+	expect(
+		listKodyPackageDependencyNames(['@scope/b', ' @scope/a ', '@scope/b']),
+	).toEqual(['@scope/a', '@scope/b'])
+	expect(
+		listKodyPackageDependencyNames({
+			'@scope/b': '*',
+			'@scope/a': 'latest',
+		}),
+	).toEqual(['@scope/a', '@scope/b'])
+
+	const fromArray = parseAuthoredPackageJson({
+		content: manifest(['@scope/helper', '@other/lib']),
+	})
+	expect(fromArray.kody.dependencies).toEqual({
+		'@other/lib': kodyPackageDependencyWildcard,
+		'@scope/helper': kodyPackageDependencyWildcard,
+	})
+
+	const fromMap = parseAuthoredPackageJson({
+		content: manifest({
+			'@scope/helper': '*',
+			'@other/lib': '*',
+		}),
+	})
+	expect(fromMap.kody.dependencies).toEqual({
+		'@other/lib': '*',
+		'@scope/helper': '*',
+	})
+
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: manifest({ '@scope/helper': 'latest' }),
+		}),
+	).toThrow(/must be "\*"/)
+
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: manifest({ '@scope/helper': '^1.2.3' }),
+		}),
+	).toThrow(/must be "\*"/)
+
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: manifest(['@scope/helper', '@scope/helper']),
+		}),
+	).toThrow(/Duplicate static Kody package dependency/)
+
+	expect(() =>
+		parseAuthoredPackageJson({
+			content: manifest(['helper']),
+		}),
+	).toThrow(/scoped package names/)
+})

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -176,14 +176,14 @@ export type KodyPackageDependency = z.infer<typeof kodyPackageDependencySchema>
 export function listKodyPackageDependencyNames(
 	dependencies:
 		| KodyPackageDependencies
-		| ReadonlyArray<string>
+		| ReadonlyArray<unknown>
 		| Record<string, string>
 		| null
 		| undefined,
 ): Array<string> {
 	if (dependencies == null) return []
 	const names = Array.isArray(dependencies)
-		? dependencies
+		? dependencies.filter((name): name is string => typeof name === 'string')
 		: Object.keys(dependencies)
 	return Array.from(
 		new Set(names.map((name) => name.trim()).filter((name) => name.length > 0)),
@@ -208,6 +208,7 @@ const kodyPackageDependenciesSchema = z
 						path: [index],
 						message:
 							'Static Kody package dependencies must be scoped package names like "@scope/package".',
+						fatal: true,
 					})
 					continue
 				}
@@ -254,7 +255,7 @@ const kodyPackageDependenciesSchema = z
 		if (value === undefined) return undefined
 		if (Array.isArray(value)) {
 			return Object.fromEntries(
-				listKodyPackageDependencyNames(value as Array<string>).map((name) => [
+				listKodyPackageDependencyNames(value).map((name) => [
 					name,
 					kodyPackageDependencyWildcard,
 				]),

--- a/packages/worker/src/package-registry/types.ts
+++ b/packages/worker/src/package-registry/types.ts
@@ -162,24 +162,111 @@ export const kodyPackageDependencySchema = z
 			'Static Kody package dependencies must be scoped package names like "@scope/package".',
 	})
 
-const kodyPackageDependenciesSchema = z
-	.array(kodyPackageDependencySchema)
-	.superRefine((dependencies, ctx) => {
-		const seen = new Set<string>()
-		for (const [index, dependency] of dependencies.entries()) {
-			const normalized = dependency.trim()
-			if (seen.has(normalized)) {
-				ctx.addIssue({
-					code: 'custom',
-					path: [index],
-					message: `Duplicate static Kody package dependency "${normalized}".`,
-				})
-			}
-			seen.add(normalized)
-		}
-	})
+export const kodyPackageDependencyWildcard = '*' as const
+
+export type KodyPackageDependencyWildcard = typeof kodyPackageDependencyWildcard
+
+export type KodyPackageDependencies = Record<
+	string,
+	KodyPackageDependencyWildcard
+>
 
 export type KodyPackageDependency = z.infer<typeof kodyPackageDependencySchema>
+
+export function listKodyPackageDependencyNames(
+	dependencies:
+		| KodyPackageDependencies
+		| ReadonlyArray<string>
+		| Record<string, string>
+		| null
+		| undefined,
+): Array<string> {
+	if (dependencies == null) return []
+	const names = Array.isArray(dependencies)
+		? dependencies
+		: Object.keys(dependencies)
+	return Array.from(
+		new Set(names.map((name) => name.trim()).filter((name) => name.length > 0)),
+	).sort((left, right) => left.localeCompare(right))
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+const kodyPackageDependenciesSchema = z
+	.unknown()
+	.superRefine((value, ctx) => {
+		if (value === undefined) return
+		if (Array.isArray(value)) {
+			const seen = new Set<string>()
+			for (const [index, dependency] of value.entries()) {
+				const parsed = kodyPackageDependencySchema.safeParse(dependency)
+				if (!parsed.success) {
+					ctx.addIssue({
+						code: 'custom',
+						path: [index],
+						message:
+							'Static Kody package dependencies must be scoped package names like "@scope/package".',
+					})
+					continue
+				}
+				const normalized = parsed.data.trim()
+				if (seen.has(normalized)) {
+					ctx.addIssue({
+						code: 'custom',
+						path: [index],
+						message: `Duplicate static Kody package dependency "${normalized}".`,
+					})
+				}
+				seen.add(normalized)
+			}
+			return
+		}
+		if (!isPlainObject(value)) {
+			ctx.addIssue({
+				code: 'custom',
+				message:
+					'kody.dependencies must be a map of "@scope/package": "*" (a legacy array of those names is also accepted).',
+			})
+			return
+		}
+		for (const [name, version] of Object.entries(value)) {
+			if (!kodyPackageDependencySchema.safeParse(name).success) {
+				ctx.addIssue({
+					code: 'custom',
+					path: [name],
+					message:
+						'Static Kody package dependencies must be scoped package names like "@scope/package".',
+				})
+			}
+			if (version !== kodyPackageDependencyWildcard) {
+				ctx.addIssue({
+					code: 'custom',
+					path: [name],
+					message:
+						'must be "*" (latest published commit, captured when this package publishes).',
+				})
+			}
+		}
+	})
+	.transform((value): KodyPackageDependencies | undefined => {
+		if (value === undefined) return undefined
+		if (Array.isArray(value)) {
+			return Object.fromEntries(
+				listKodyPackageDependencyNames(value as Array<string>).map((name) => [
+					name,
+					kodyPackageDependencyWildcard,
+				]),
+			)
+		}
+		if (!isPlainObject(value)) return undefined
+		return Object.fromEntries(
+			listKodyPackageDependencyNames(value as Record<string, string>).map(
+				(name) => [name, kodyPackageDependencyWildcard],
+			),
+		)
+	})
 
 /** Soft cap for new/updated `kody.description` taglines on write/publish only. */
 export const KODY_DESCRIPTION_MAX_LENGTH = 200

--- a/packages/worker/src/repo/checks.node.test.ts
+++ b/packages/worker/src/repo/checks.node.test.ts
@@ -120,7 +120,7 @@ function createPackageManifest(input: {
 		{ handler: string; description?: string; filters?: Record<string, unknown> }
 	>
 	emits?: Record<string, { description: string }>
-	kodyDependencies?: Array<string>
+	kodyDependencies?: Array<string> | Record<string, string>
 	retrievers?: Record<
 		string,
 		{
@@ -845,10 +845,10 @@ test('runRepoChecks injects package tsconfig overlays that allow optional .ts im
 	).toBe(repoTsconfig)
 })
 
-test('runRepoChecks returns a failed manifest check for object-shaped kody.dependencies instead of throwing', async () => {
-	// Agents sometimes confuse npm dependencies (object map) with
-	// kody.dependencies (string array). Publish must return checks_failed, not
-	// throw — otherwise MCP observability opens a Sentry platform-bug issue.
+test('runRepoChecks returns a failed manifest check for unsupported kody.dependencies versions instead of throwing', async () => {
+	// Agents sometimes write npm-style ranges in kody.dependencies. Publish
+	// must return checks_failed, not throw — otherwise MCP observability opens
+	// a Sentry platform-bug issue.
 	const result = await runChecksOnWorkspaceFiles(
 		new Map<string, string>([
 			[
@@ -860,9 +860,9 @@ test('runRepoChecks returns a failed manifest check for object-shaped kody.depen
 					},
 					kody: {
 						id: 'object-deps',
-						description: 'Uses object-shaped kody.dependencies by mistake',
+						description: 'Uses a semver range in kody.dependencies',
 						dependencies: {
-							'@kentcdodds/helper': 'latest',
+							'@kentcdodds/helper': '^1.2.3',
 						},
 					},
 				}),
@@ -876,9 +876,7 @@ test('runRepoChecks returns a failed manifest check for object-shaped kody.depen
 		expect.objectContaining({
 			kind: 'manifest',
 			ok: false,
-			message: expect.stringMatching(
-				/expected array, received object[\s\S]*kody\.dependencies/,
-			),
+			message: expect.stringMatching(/must be "\*"/),
 		}),
 	])
 })
@@ -935,6 +933,34 @@ test('runRepoChecks validates static kody package import declarations across mis
 	)
 	expect(declaredImports.ok).toBe(true)
 	expect(declaredImports.results).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				kind: 'dependencies',
+				ok: true,
+			}),
+		]),
+	)
+
+	const declaredMapImports = await runChecksOnWorkspaceFiles(
+		new Map<string, string>([
+			[
+				'package.json',
+				createPackageManifest({
+					packageName: '@kody/declared-static-package-map',
+					kodyId: 'declared-static-package-map',
+					description:
+						'Declares static Kody package imports as a name-to-* map',
+					kodyDependencies: { '@kentcdodds/helper': '*' },
+				}),
+			],
+			[
+				'src/index.ts',
+				'import helper from "kody:@kentcdodds/helper/run"\nexport const ready = helper\n',
+			],
+		]),
+	)
+	expect(declaredMapImports.ok).toBe(true)
+	expect(declaredMapImports.results).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({
 				kind: 'dependencies',

--- a/packages/worker/src/repo/checks.ts
+++ b/packages/worker/src/repo/checks.ts
@@ -13,6 +13,7 @@ import {
 } from '#worker/package-registry/static-dependency-cycles.ts'
 import {
 	assertKodyDescriptionLength,
+	listKodyPackageDependencyNames,
 	type AuthoredPackageJson,
 } from '#worker/package-registry/types.ts'
 import {
@@ -601,11 +602,7 @@ function formatNpmDependencyCheckMessage(input: {
 function getDeclaredStaticKodyPackageDependencies(
 	manifest: AuthoredPackageJson,
 ) {
-	return Array.from(
-		new Set(
-			(manifest.kody.dependencies ?? []).map((dependency) => dependency.trim()),
-		),
-	).sort((left, right) => left.localeCompare(right))
+	return listKodyPackageDependencyNames(manifest.kody.dependencies)
 }
 
 function getImportedStaticKodyPackageDependencies(input: {
@@ -1167,8 +1164,9 @@ export async function runRepoChecks(input: {
 		})
 		assertKodyDescriptionLength(manifest.kody.description)
 	} catch (error) {
-		// Invalid package.json shape (e.g. kody.dependencies as an object) is a
-		// caller fix — keep it on the check result path, not as an exception.
+		// Invalid package.json shape (e.g. kody.dependencies values other than
+		// "*") is a caller fix — keep it on the check result path, not as an
+		// exception.
 		return {
 			ok: false,
 			results: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give `kody.dependencies` an npm-like map so agents stop writing the wrong shape, without opening package versioning. `*` is latest-at-publish, not a live pin.

## Summary

- Authored `package.json#kody.dependencies` is `{ "@scope/pkg": "*" }`. Parse still accepts a legacy array of those names and normalizes it in memory.
- Values other than `*` fail the manifest check (including `latest` and semver ranges). Fleet codemod `0005` rewrites arrays and the `latest` alias to `*`.
- Static import resolution is unchanged: snapshot the dependency's published commit when the dependent publishes. No auto-republish, no SHA/semver pins.
- [ADR 0029](docs/contributing/decisions/0029-kody-dependencies-wildcard-map.md) records the veto. Array acceptance is a soak leftover until fleet apply + enforcement ([#1610](https://github.com/kentcdodds/kody/issues/1610)).
- Invalid legacy array entries (non-strings) stay schema failures. Zod 4 still runs `transform` after non-fatal `superRefine` issues; those names are filtered and the issue is marked fatal so `safeParse` does not throw.

## Testing

- Focused node tests: schema dual-read, non-string array entries, repo checks, cycle walk, fork-scan, and 0005 detect/transform/idempotency.
- `npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run docs:check-temporal` passed locally for the original change. Schema unit test passed for the Bugbot fix.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5bd709ec` · **Head:** `1242e2d7`

**Classification:** extends — saved-package manifest contract and package-codemod registry change; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — `kody.dependencies` is a name-to-`*` map; arrays still parse; invalid array items stay schema errors |
| `package-codemods` | assistant | extends — registers `0005-kody-dependencies-to-wildcard-map` |
| `repo-sessions` | runtime | extends — publish checks accept the map and reject non-`*` values |
| `community-listings` | assistant | composes — fork-scan lists names from either shape |

### Change flow

Publish still snapshots static imports; the new map is the authored declaration, and 0005 rewrites published arrays.

```mermaid
sequenceDiagram
	actor Operator
	participant packageCodemods as package-codemods
	participant savedPackages as saved-packages
	participant repoSessions as repo-sessions
	Operator->>packageCodemods: scan/dry-run/apply 0005
	packageCodemods->>savedPackages: rewrite kody.dependencies array to name-to-* map
	packageCodemods->>repoSessions: runRepoChecks on transformed tree
	Note over repoSessions: arrays still pass; non-* versions fail
	repoSessions-->>packageCodemods: no-new-failures gate
	packageCodemods->>savedPackages: republish published snapshot
```

### Before / after

```json
{ "kody": { "dependencies": ["@scope/pkg"] } }
```

```json
{ "kody": { "dependencies": { "@scope/pkg": "*" } } }
```

### Invariants

Per-user isolation is unchanged. `*` is not live resolution and does not share storage across versions — storage stays keyed by `packageId`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9903f7d9-421c-4d7b-b0f8-a4b00b027e0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9903f7d9-421c-4d7b-b0f8-a4b00b027e0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring package dependencies as package-name-to-`"*"` maps.
  * Added a migration tool to convert supported legacy dependency arrays.
  * Added validation ensuring declarations match static package imports and reject unsupported versions or cycles.

* **Documentation**
  * Documented the new dependency format, migration guidance, and publishing behavior.
  * Added a decision record defining wildcard dependency rules.

* **Bug Fixes**
  * Improved dependency scanning and validation for both legacy arrays and the new map format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->