### PR TITLE
feat(oauth): serve official CLI Client ID Metadata Document

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -533,6 +533,11 @@ routed from `packages/worker/src/index.ts`.
   sets `clientMetadataUrl` to the canonical HTTPS document URL so the SDK
   prefers CIMD and falls back to DCR. Local `http` origins omit
   `clientMetadataUrl`.
+- The official CLI (`@kodycodes/cli`) hosts its CIMD at
+  `/oauth/cli-client-metadata.json`. The document is origin-exact: `client_id`
+  matches the fetch URL, and `redirect_uris` lists the fixed loopback
+  `http://127.0.0.1:43742/callback` so the CLI can use SEP-991 instead of
+  deprecated DCR.
 - Supported scopes: `profile`, `email`
 - On `/oauth/authorize`, unauthenticated users can log in inline or via top-nav
   auth links; those links preserve the full authorize URL in `redirectTo` so

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -49,6 +49,9 @@ Requests are handled in this order:
    - Client ID Metadata Document: `/oauth/client-metadata.json` (`GET` / `HEAD`
      / `OPTIONS`) — Kody-as-client CIMD. Served from the request origin so
      `client_id` matches the fetch URL.
+   - Official CLI CIMD: `/oauth/cli-client-metadata.json` (`GET` / `HEAD` /
+     `OPTIONS`) — `@kodycodes/cli` presents this URL as `client_id`. Loopback
+     redirect is `http://127.0.0.1:43742/callback`.
 2. OAuth authorization endpoints:
    - `/oauth/authorize`
    - `/oauth/authorize-info`

--- a/packages/worker/src/cli-client-metadata.node.test.ts
+++ b/packages/worker/src/cli-client-metadata.node.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest'
+import {
+	buildCliClientIdMetadataDocument,
+	cliClientIdMetadataPath,
+	cliClientName,
+	cliOAuthCallbackUrl,
+	handleCliClientIdMetadataRequest,
+} from './cli-client-metadata.ts'
+
+test('CLI CIMD is origin-bound with a fixed loopback redirect', async () => {
+	const origin = 'https://kody.codes'
+	const documentUrl = `${origin}${cliClientIdMetadataPath}`
+	const document = buildCliClientIdMetadataDocument(`${origin}/ignored`)
+	expect(document.client_id).toBe(documentUrl)
+	expect(document.client_name).toBe(cliClientName)
+	expect(document.redirect_uris).toEqual([cliOAuthCallbackUrl])
+	expect(document.token_endpoint_auth_method).toBe('none')
+	expect(document.application_type).toBe('native')
+
+	const getResponse = handleCliClientIdMetadataRequest(new Request(documentUrl))
+	expect(getResponse?.status).toBe(200)
+	expect(getResponse?.headers.get('Content-Type')).toBe('application/json')
+	const body = (await getResponse?.json()) as {
+		client_id: string
+		redirect_uris: Array<string>
+	}
+	expect(body.client_id).toBe(documentUrl)
+	expect(body.redirect_uris).toEqual([cliOAuthCallbackUrl])
+
+	const headResponse = handleCliClientIdMetadataRequest(
+		new Request(documentUrl, { method: 'HEAD' }),
+	)
+	expect(headResponse?.status).toBe(200)
+	expect(await headResponse?.text()).toBe('')
+	expect(
+		handleCliClientIdMetadataRequest(
+			new Request(documentUrl, { method: 'OPTIONS' }),
+		)?.status,
+	).toBe(204)
+	expect(
+		handleCliClientIdMetadataRequest(
+			new Request(`${origin}/oauth/client-metadata.json`),
+		),
+	).toBeNull()
+	expect(
+		handleCliClientIdMetadataRequest(
+			new Request(documentUrl, { method: 'POST' }),
+		),
+	).toBeNull()
+})

--- a/packages/worker/src/cli-client-metadata.ts
+++ b/packages/worker/src/cli-client-metadata.ts
@@ -1,0 +1,52 @@
+export const cliClientIdMetadataPath = '/oauth/cli-client-metadata.json'
+export const cliOAuthCallbackUrl = 'http://127.0.0.1:43742/callback'
+export const cliClientName = '@kodycodes/cli'
+export const cliClientUri = 'https://github.com/kody-bot/cli'
+
+/**
+ * Official CLI Client ID Metadata Document (SEP-991).
+ *
+ * The CLI presents this HTTPS URL as `client_id`. Loopback redirect is fixed
+ * so the document can list it; ephemeral ports would force deprecated DCR.
+ */
+export function buildCliClientIdMetadataDocument(origin: string) {
+	const clientOrigin = new URL(origin).origin
+	const clientId = `${clientOrigin}${cliClientIdMetadataPath}`
+	return {
+		client_id: clientId,
+		client_name: cliClientName,
+		client_uri: cliClientUri,
+		redirect_uris: [cliOAuthCallbackUrl],
+		grant_types: ['authorization_code', 'refresh_token'],
+		response_types: ['code'],
+		token_endpoint_auth_method: 'none',
+		application_type: 'native',
+		scope: 'profile email',
+	}
+}
+
+export function isCliClientIdMetadataRequest(pathname: string) {
+	return pathname === cliClientIdMetadataPath
+}
+
+export function handleCliClientIdMetadataRequest(request: Request) {
+	const url = new URL(request.url)
+	if (!isCliClientIdMetadataRequest(url.pathname)) return null
+	if (request.method === 'OPTIONS') {
+		return new Response(null, {
+			status: 204,
+			headers: { 'Content-Length': '0' },
+		})
+	}
+	if (request.method !== 'GET' && request.method !== 'HEAD') return null
+
+	const body = JSON.stringify(buildCliClientIdMetadataDocument(url.origin))
+	const headers = {
+		'Content-Type': 'application/json',
+		'Cache-Control': 'public, max-age=3600',
+	}
+	if (request.method === 'HEAD') {
+		return new Response(null, { status: 200, headers })
+	}
+	return new Response(body, { headers })
+}

--- a/packages/worker/src/cli-client-metadata.workers.test.ts
+++ b/packages/worker/src/cli-client-metadata.workers.test.ts
@@ -1,0 +1,35 @@
+import { env, exports } from 'cloudflare:workers'
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { expect, test } from 'vitest'
+import {
+	cliClientIdMetadataPath,
+	cliOAuthCallbackUrl,
+} from './cli-client-metadata.ts'
+
+async function workerFetch(request: Request) {
+	const ctx = createExecutionContext()
+	const response = await exports.default.fetch(request, env, ctx)
+	await waitOnExecutionContext(ctx)
+	return response
+}
+
+test('worker serves CLI CIMD before the OAuth wrapper and reflects Origin for CORS', async () => {
+	const documentUrl = `https://kody.codes${cliClientIdMetadataPath}`
+	const response = await workerFetch(new Request(documentUrl))
+	expect(response.status).toBe(200)
+	expect(response.headers.get('Content-Type')).toBe('application/json')
+	const body = (await response.json()) as {
+		client_id: string
+		redirect_uris: Array<string>
+	}
+	expect(body.client_id).toBe(documentUrl)
+	expect(body.redirect_uris).toEqual([cliOAuthCallbackUrl])
+
+	const first = await workerFetch(
+		new Request(documentUrl, { headers: { Origin: 'https://as.example' } }),
+	)
+	expect(first.headers.get('Access-Control-Allow-Origin')).toBe(
+		'https://as.example',
+	)
+	expect(first.headers.get('Vary')?.split(/\s*,\s*/)).toContain('Origin')
+})

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -31,6 +31,7 @@ import {
 	protectedResourceMetadataPath,
 } from './mcp-auth.ts'
 import { handleMcpClientIdMetadataRequest } from './mcp-client/client-id-metadata.ts'
+import { handleCliClientIdMetadataRequest } from './cli-client-metadata.ts'
 import {
 	handlePackageInvocationApiRequest,
 	isPackageInvocationApiRequest,
@@ -541,7 +542,9 @@ const workerHandler = {
 		// MCP clients must use `<origin>/mcp` as the resource (RFC 8707) to match our
 		// token audience; otherwise authorize stores origin but the token request sends
 		// `/mcp` → invalid_target. Serve the same document as the `/mcp` metadata path.
-		const clientIdMetadataResponse = handleMcpClientIdMetadataRequest(request)
+		const clientIdMetadataResponse =
+			handleMcpClientIdMetadataRequest(request) ??
+			handleCliClientIdMetadataRequest(request)
 		if (clientIdMetadataResponse) {
 			return addOAuthDiscoveryCorsHeaders(clientIdMetadataResponse, request)
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Let `@kodycodes/cli` log in with MCP `2026-07-28` Client ID Metadata Documents instead of deprecated dynamic client registration.

## Summary

- Serve origin-exact CIMD at `/oauth/cli-client-metadata.json` (`GET` / `HEAD` / `OPTIONS`).
- Document `client_id` matches the fetch URL.
- Fixed loopback redirect: `http://127.0.0.1:43742/callback`.
- Existing Kody-as-client CIMD at `/oauth/client-metadata.json` is unchanged.
- Pairs with [kody-bot/cli#1](https://github.com/kody-bot/cli/pull/1): `@modelcontextprotocol/client` 2.0.0 `auth()`, this URL as `client_id`, no DCR fallback.

## Testing

- `npx vitest run --project node-unit packages/worker/src/cli-client-metadata.node.test.ts`
- `npx vitest run --project workers-unit packages/worker/src/cli-client-metadata.workers.test.ts`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `625cbb49` · **Head:** `c39a4249`

**Classification:** composes — new public CIMD JSON for the official CLI; same fetch-and-CORS path as the existing Kody-as-client document.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-oauth` | auth | composes — serves `/oauth/cli-client-metadata.json` before the OAuth wrapper |

`packages/worker/src/index.ts` also sits under the `scheduled-cron` ownership root; this PR does not change the scheduled handler.

### Change flow

The official CLI presents the HTTPS document URL as `client_id`. Kody fetches that document instead of `/oauth/register`.

```mermaid
sequenceDiagram
	actor CLI
	participant mcpOauth as mcp-oauth
	CLI->>mcpOauth: GET /oauth/cli-client-metadata.json
	mcpOauth-->>CLI: 200 origin-exact CIMD
	CLI->>mcpOauth: GET /.well-known/oauth-authorization-server
	mcpOauth-->>CLI: client_id_metadata_document_supported
	CLI->>mcpOauth: GET /oauth/authorize client_id is CIMD URL
	mcpOauth-->>CLI: 302 to 127.0.0.1:43742/callback
	CLI->>mcpOauth: POST /oauth/token
	mcpOauth-->>CLI: access + refresh tokens
```

### Before / after

| Request | Before | After |
| --- | --- | --- |
| `GET /oauth/cli-client-metadata.json` | Unrelated app route / 404 | Origin-exact CIMD JSON |
| `GET /oauth/client-metadata.json` | Kody-as-client CIMD | Unchanged |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e1105d3-e986-4e3a-9378-6c7adf4c3bb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e1105d3-e986-4e3a-9378-6c7adf4c3bb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an official OAuth client metadata endpoint for CLI authentication.
  * Supports `GET`, `HEAD`, and `OPTIONS` requests with JSON metadata, fixed loopback redirect details, and origin-aware CORS headers.

* **Documentation**
  * Documented the CLI metadata endpoint, supported methods, and OAuth callback behavior.

* **Tests**
  * Added coverage for valid responses, metadata fields, CORS behavior, and invalid paths or methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->