### PR TITLE
Join Discord and connect in one action

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -480,10 +480,11 @@ Kody can act as an OAuth 2.0 client of GitHub, Google, X, and Discord for
 browser sign-in. Provider identities live in the `oauth_connections` table;
 handlers live in `packages/worker/src/app/handlers/auth-provider.ts` with the
 provider definitions in `packages/worker/src/app/oauth-providers.ts`. Discord
-connections also best-effort assign or remove operator-configured guild roles in
-the official Kody Discord (`packages/worker/src/discord/guild-role.ts`) without
-persisting the login token. The member role is assigned on connect; Standard and
-Pro roles follow `users.stripe_plan`.
+connections also best-effort join the official Kody Discord (`guilds.join` plus
+the operator bot) and assign or remove configured guild roles
+(`packages/worker/src/discord/guild-role.ts`) without persisting the login
+token. The member role is assigned on connect; Standard and Pro roles follow
+`users.stripe_plan`.
 
 - `POST /auth/:provider` starts the flow (CSRF state + PKCE verifier + optional
   invite code in the signed `kody_oauth_login` cookie);
@@ -496,8 +497,8 @@ Pro roles follow `users.stripe_plan`.
 - A signed-in user hitting the callback links the provider identity to their
   account, managed from the `/account` "Connected accounts" card backed by
   `/account/connections.json` (disconnect is refused when the connection is the
-  only sign-in method). `/discord` is the public page for joining the official
-  server and connecting Discord when the account is not linked yet
+  only sign-in method). `/discord` is the public **Connect Discord** page (one
+  action joins the official server and links the account)
 - A provider-verified email matching an existing account auto-links and signs
   in; otherwise account creation follows the signup posture
   (`SIGNUP_MODE !== 'open'` requires a valid invite code carried from the invite

--- a/docs/contributing/decisions/0029-discord-social-login-and-guild-role.md
+++ b/docs/contributing/decisions/0029-discord-social-login-and-guild-role.md
@@ -1,6 +1,7 @@
 # 0029: Discord social login and official guild role
 
-- **Status:** accepted
+- **Status:** superseded by
+  [0030](./0030-discord-guilds-join-on-social-login.md)
 - **Date:** 2026-08-20
 
 ## Context

--- a/docs/contributing/decisions/0030-discord-guilds-join-on-social-login.md
+++ b/docs/contributing/decisions/0030-discord-guilds-join-on-social-login.md
@@ -1,0 +1,27 @@
+# 0030: Join the official Discord during social login
+
+- **Status:** accepted
+- **Date:** 2026-08-20
+
+## Context
+
+[0029](./0029-discord-social-login-and-guild-role.md) added Discord social login
+with `identify email` only. Guild membership stayed on a public invite; login
+only wrote roles from the stored snowflake. `/discord` then had two CTAs (join
+invite + connect). People expected **Connect Discord** to both link the account
+and put them in the official server.
+
+## Decision
+
+Request `guilds.join` on Discord social login. On every successful Discord
+callback, best-effort **Add Guild Member** with the operator bot plus the
+ephemeral user access token, then discard the token. Still do not persist
+provider tokens, and still do not reuse `/connect/oauth` Discord apps for
+sign-in.
+
+## Consequences
+
+The bot needs **Create Instant Invite** in addition to **Manage Roles**. Join
+failures are logged and never fail login; mock OAuth has no user token so join
+skips. `/discord` is one **Connect Discord** action. Revisit if Discord login
+needs assistant scopes, or if join must become a hard login failure.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -82,3 +82,7 @@ Do not treat this list as homework. History stays; it is not silently deleted.
 - [0028 — List/detail records expand inside the table](./0028-list-detail-expand.md)
   — UI mode assignment (supersedes 0010)
 - [0029 — Discord social login and official guild role](./0029-discord-social-login-and-guild-role.md)
+  — superseded by 0030; invite-only membership is no longer the product path
+- [0030 — Join the official Discord during social login](./0030-discord-guilds-join-on-social-login.md)
+  — `guilds.join` on Discord social login; token still discarded after the
+  callback

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -177,8 +177,10 @@ Optional Worker secrets (see `packages/worker/src/app/oauth-providers.ts` and
 - `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET`
 - `DISCORD_BOT_TOKEN` / `DISCORD_GUILD_ID` / `DISCORD_MEMBER_ROLE_ID` /
   `DISCORD_STANDARD_ROLE_ID` / `DISCORD_PRO_ROLE_ID` (optional; official Kody
-  Discord guild-role sync. Bot token + guild id plus at least one role id.
-  Standard/Pro follow `users.stripe_plan`.)
+  Discord guild join and role sync. Bot token + guild id enable Add Guild Member
+  during Discord social login; at least one role id enables role writes. The bot
+  needs Create Instant Invite and Manage Roles. Standard/Pro follow
+  `users.stripe_plan`.)
 
 A provider's login button only renders when both of its values are set. A
 `MOCK_`-prefixed client id activates the in-worker mock provider flow on

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -447,9 +447,10 @@ automatically:
   `docs/contributing/social-login.md`.)
 - `DISCORD_BOT_TOKEN` / `DISCORD_GUILD_ID` / `DISCORD_MEMBER_ROLE_ID` /
   `DISCORD_STANDARD_ROLE_ID` / `DISCORD_PRO_ROLE_ID` (optional Worker secrets;
-  when bot token, guild id, and at least one role id are set, Discord social
-  login and Stripe plan refresh assign official Kody Discord roles. See
-  `docs/contributing/social-login.md`.)
+  when bot token and guild id are set, Discord social login best-effort joins
+  the official guild. At least one role id enables member/plan role writes on
+  login and Stripe plan refresh. The bot needs Create Instant Invite and Manage
+  Roles. See `docs/contributing/social-login.md`.)
 - `STRIPE_SECRET_KEY` (optional Worker secret; enables Stripe checkout linking,
   billing portal, and `users.stripe_plan` refresh. When unset, billing degrades
   to manual plans.)
@@ -534,7 +535,8 @@ Configure these GitHub Actions secrets and variables for workflows:
   `docs/contributing/social-login.md` for provider app setup.)
 - `DISCORD_BOT_TOKEN` / `DISCORD_GUILD_ID` / `DISCORD_MEMBER_ROLE_ID` /
   `DISCORD_STANDARD_ROLE_ID` / `DISCORD_PRO_ROLE_ID` (optional; official Kody
-  Discord guild-role sync. Synced to the Worker under the same names.)
+  Discord guild join and role sync. Synced to the Worker under the same names.
+  The bot needs Create Instant Invite and Manage Roles.)
 - `KIT_API_KEY` (optional GitHub / Worker secret; Kit / kit.com API key for
   `/waiting-list` signup and best-effort `signed_up::kody` tagging on account
   signup when the email already exists in Kit. Production deploy syncs it when

--- a/docs/contributing/social-login.md
+++ b/docs/contributing/social-login.md
@@ -23,9 +23,9 @@ Routes (see `packages/worker/src/app/handlers/auth-provider.ts` and
   production social signup). With `Accept: application/json` it returns
   `{ authorizeUrl }` for client-side navigation; otherwise it 302s.
 - `GET /auth/:provider/callback` — completes the flow
-- `GET /discord` / `GET /discord.json` — public Discord page (join invite plus
-  Connect to Discord; signed-in visitors see whether `oauth_connections` already
-  has Discord)
+- `GET /discord` / `GET /discord.json` — public Discord page (**Connect
+  Discord** joins the official server and links the account; signed-in visitors
+  see whether `oauth_connections` already has Discord)
 - `GET/POST /account/connections.json` — signed-in connection management (list,
   disconnect)
 
@@ -126,10 +126,11 @@ the token endpoint uses HTTP Basic client authentication). Note that X meters
 3. Copy the **Client ID** and reset/reveal the **Client Secret**.
 4. Save them as `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET`.
 
-Scopes requested: `identify email`. Discord's `verified` field on
+Scopes requested: `identify email guilds.join`. Discord's `verified` field on
 `GET /users/@me` gates email-based account matching, the same way Google's
 `email_verified` does. Unverified Discord emails can only be linked from
-`/account` while already signed in.
+`/account` while already signed in. The `guilds.join` token is used once on the
+callback to add the member to the official guild, then discarded.
 
 Do not add `/connect/oauth` to this application. User-owned Discord integrations
 for the assistant stay on a separate app and the `/connect/oauth` flow (see
@@ -150,18 +151,21 @@ official Kody Discord:
   role.
 
 Disconnect and account deletion best-effort remove every configured role. Login
-and billing still succeed when the bot is unset, the member is not in the guild
-yet (HTTP 404), or Discord errors.
+and billing still succeed when the bot is unset, join or role writes fail, or
+Discord errors.
 
-The bot must already be in the guild with **Manage Roles**, and its highest role
-must sit above every role it assigns. Users join through the existing invite
-(`https://kcd.im/kody-discord`); login does not request `guilds.join`.
-`/discord` is the shareable page for that invite plus a **Connect to Discord**
-button. `/account` still shows a Join the Kody Discord link on a connected
-Discord row, plus **Sync Discord roles** when bot config is present.
+The bot must already be in the guild with **Create Instant Invite** (needed to
+add a member via `guilds.join`) and **Manage Roles**, and its highest role must
+sit above every role it assigns. Every successful Discord social-login callback
+best-effort adds the user to the official guild
+(`PUT /guilds/{id}/members/{user}`) with the operator bot plus the ephemeral
+user token, then assigns roles. `/discord` is the shareable **Connect Discord**
+page. `/account` still shows a Join the Kody Discord link on a connected Discord
+row, plus **Sync Discord roles** when bot config is present.
 
-Social-login tokens are still discarded after the profile fetch. Role writes use
-the operator bot token and the stored Discord snowflake only.
+Social-login tokens are discarded after the profile fetch and the one guild-join
+call. Role writes use the operator bot token and the stored Discord snowflake
+only. Mock OAuth (`MOCK_*` client ids) has no user token, so join skips.
 
 ## Environment variables
 
@@ -175,7 +179,8 @@ renders when both of its values are set (see
 - `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET`
 - `DISCORD_BOT_TOKEN` / `DISCORD_GUILD_ID` / `DISCORD_MEMBER_ROLE_ID` /
   `DISCORD_STANDARD_ROLE_ID` / `DISCORD_PRO_ROLE_ID` (optional; bot token +
-  guild id plus at least one role id enable official Discord guild-role sync)
+  guild id enable official Discord guild join; at least one role id enables role
+  sync. The bot needs Create Instant Invite and Manage Roles.)
 
 For production deploys, store the social-login client credentials as GitHub
 Actions repository secrets named `OAUTH_GITHUB_CLIENT_ID`,

--- a/packages/worker/client/routes/discord.tsx
+++ b/packages/worker/client/routes/discord.tsx
@@ -257,7 +257,8 @@ export function DiscordRoute(handle: Handle) {
 		}
 
 		const showConnect =
-			Boolean(page?.discordProviderAvailable) &&
+			page != null &&
+			page.discordProviderAvailable &&
 			(!page.signedIn || !page.discordConnected)
 
 		return (

--- a/packages/worker/client/routes/discord.tsx
+++ b/packages/worker/client/routes/discord.tsx
@@ -4,7 +4,6 @@ import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
-import { ProviderIcon } from '#client/provider-icons.tsx'
 import { startSocialSignIn } from '#client/social-sign-in.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
@@ -15,7 +14,6 @@ import {
 	resetTurnstileWidgets,
 	turnstileWidgetClassName,
 } from '#client/public-form-protection.ts'
-import { kodyDiscordInviteUrl } from '#universal/community-links.ts'
 import { getOauthLoginErrorMessage } from '#universal/oauth-login-errors.ts'
 import {
 	type AccountConnectionsLoaderData,
@@ -25,10 +23,9 @@ import { routes } from '#universal/routes.ts'
 import { colors, spacing } from '#universal/styles/tokens.ts'
 import {
 	cardCss,
-	cardTitleCss,
 	descriptionCss,
 	getGhostButtonCss,
-	getPillButtonCss,
+	getPrimaryButtonCss,
 	mutedLinkCss,
 	pageDescriptionCss,
 	pageHeaderCss,
@@ -50,7 +47,7 @@ function readCallbackMessage(href: string) {
 	const linkedProvider = searchParams.get('oauthLinked')
 	if (linkedProvider === 'discord') {
 		return {
-			text: 'Discord connected to your Kody account.',
+			text: 'Discord connected.',
 			tone: 'info' as const,
 		}
 	}
@@ -66,7 +63,7 @@ function discordMemberRoleMessage(status: string) {
 		case 'assigned':
 			return 'Kody Discord roles updated.'
 		case 'not-in-guild':
-			return 'Join the Kody Discord first, then sync your roles.'
+			return 'You are not in the Kody Discord yet.'
 		case 'not-configured':
 		case 'skipped':
 			return 'Discord role sync is not configured.'
@@ -208,7 +205,7 @@ export function DiscordRoute(handle: Handle) {
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
 		if (!isDiscordPagePath(currentHref)) {
-			return <section mix={css(stackedPageCss)} />
+			return <section mix={css(pageCss)} />
 		}
 
 		const routeData = tryConsumeRouteLoaderData(handle, 'discord', currentHref)
@@ -249,7 +246,6 @@ export function DiscordRoute(handle: Handle) {
 
 		const callbackMessage = readCallbackMessage(currentHref)
 		const message = actionMessage ?? callbackMessage
-		const inviteUrl = page?.inviteUrl ?? kodyDiscordInviteUrl
 		const turnstileSiteKey = page?.turnstileSiteKey ?? null
 		if (
 			typeof document !== 'undefined' &&
@@ -260,15 +256,17 @@ export function DiscordRoute(handle: Handle) {
 			handle.queueTask(() => renderTurnstileWidgets(turnstileSiteKey))
 		}
 
+		const showConnect =
+			Boolean(page?.discordProviderAvailable) &&
+			(!page.signedIn || !page.discordConnected)
+
 		return (
-			<section mix={css(stackedPageCss)}>
+			<section mix={css(pageCss)}>
 				<header mix={css(pageHeaderCss)}>
 					<h1 mix={css(pageTitleCss)}>Discord</h1>
 					<p mix={css(pageDescriptionCss)}>
-						The official Kody Discord is where people get help, share what they
-						are building, and hear about new capabilities. Connecting your Kody
-						account lets us assign the member role — and Standard or Pro if you
-						subscribe.
+						Connect Discord to join the official Kody server and get the member
+						role — plus Standard or Pro if you subscribe.
 					</p>
 				</header>
 
@@ -292,24 +290,6 @@ export function DiscordRoute(handle: Handle) {
 				) : null}
 
 				<section mix={css(cardCss)}>
-					<h2 mix={css(cardTitleCss)}>Join the server</h2>
-					<p mix={css(descriptionCss)}>
-						Anyone can join with the invite. Connecting your account afterward
-						is what unlocks the Kody member and plan roles.
-					</p>
-					<a
-						href={inviteUrl}
-						target="_blank"
-						rel="noreferrer"
-						mix={css(getGhostButtonCss())}
-					>
-						<ProviderIcon providerId="discord" size="1.1em" />
-						Join the Kody Discord
-					</a>
-				</section>
-
-				<section mix={css(cardCss)}>
-					<h2 mix={css(cardTitleCss)}>Connect your Kody account</h2>
 					{status === 'loading' && !page ? (
 						<p mix={css(descriptionCss)}>Checking your connection…</p>
 					) : null}
@@ -330,97 +310,93 @@ export function DiscordRoute(handle: Handle) {
 								<button
 									type="button"
 									disabled={busy}
-									mix={[css(getGhostButtonCss()), on('click', handleSyncRoles)]}
+									mix={[
+										css({
+											...getGhostButtonCss(),
+											justifySelf: 'start',
+										}),
+										on('click', handleSyncRoles),
+									]}
 								>
 									Sync Discord roles
 								</button>
 							) : null}
 						</>
 					) : null}
-					{page?.signedIn && !page.discordConnected ? (
-						<>
-							<p mix={css(descriptionCss)}>
-								Your Kody account is not connected to Discord yet. Connect it so
-								we can match this Discord user to your assistant.
-							</p>
-							{page.discordProviderAvailable ? (
-								<button
-									type="button"
-									disabled={busy}
-									mix={[
-										css(getPillButtonCss()),
-										on('click', handleConnectDiscord),
-									]}
-								>
-									<ProviderIcon providerId="discord" size="1.1em" />
-									Connect to Discord
-								</button>
-							) : (
-								<p mix={css(descriptionCss)}>
-									Discord login is not configured on this deployment yet.
-								</p>
-							)}
-						</>
+					{page?.signedIn &&
+					!page.discordConnected &&
+					page.discordProviderAvailable ? (
+						<p mix={css(descriptionCss)}>
+							Connect Discord to join the official server and link it to this
+							Kody account.
+						</p>
 					) : null}
-					{page && !page.signedIn ? (
-						<>
-							<p mix={css(descriptionCss)}>
-								Sign in with Discord to create or match your Kody account, or
-								log in another way and then connect Discord from here.
-							</p>
-							<form
-								data-discord-connect-form
-								mix={[
-									css({
-										display: 'flex',
-										flexWrap: 'wrap',
-										gap: spacing.sm,
-										alignItems: 'center',
-									}),
-									on('submit', (event) => {
-										event.preventDefault()
-									}),
-								]}
-							>
-								<input
-									type="text"
-									name={honeypotFieldName}
-									tabIndex={-1}
-									autoComplete="off"
-									aria-hidden="true"
-									mix={css(visuallyHiddenCss)}
-								/>
-								{turnstileSiteKey ? (
-									<div class={turnstileWidgetClassName}></div>
-								) : null}
-								{page.discordProviderAvailable ? (
-									<button
-										type="button"
-										disabled={busy}
-										mix={[
-											css(getPillButtonCss()),
-											on('click', handleConnectDiscord),
-										]}
-									>
-										<ProviderIcon providerId="discord" size="1.1em" />
-										Connect to Discord
-									</button>
-								) : null}
-								<a
-									href={buildAuthLink(routes.login.href(), discordPath)}
-									mix={css(
-										page.discordProviderAvailable
-											? getGhostButtonCss()
-											: getPillButtonCss(),
-									)}
-								>
-									Sign in
-								</a>
-							</form>
-						</>
+					{page && !page.signedIn && page.discordProviderAvailable ? (
+						<p mix={css(descriptionCss)}>
+							Connect Discord to create or match your Kody account and join the
+							official server in one step.
+						</p>
+					) : null}
+					{page && !page.discordProviderAvailable ? (
+						<p mix={css(descriptionCss)}>
+							Discord login is not configured on this deployment yet.
+						</p>
+					) : null}
+					{showConnect && page && !page.signedIn ? (
+						<form
+							data-discord-connect-form
+							mix={[
+								css(connectFormCss),
+								on('submit', (event) => {
+									event.preventDefault()
+									void handleConnectDiscord()
+								}),
+							]}
+						>
+							<input
+								type="text"
+								name={honeypotFieldName}
+								tabIndex={-1}
+								autoComplete="off"
+								aria-hidden="true"
+								mix={css(visuallyHiddenCss)}
+							/>
+							{turnstileSiteKey ? (
+								<div class={turnstileWidgetClassName}></div>
+							) : null}
+							<button type="submit" disabled={busy} mix={css(connectButtonCss)}>
+								Connect Discord
+							</button>
+						</form>
+					) : null}
+					{showConnect && page?.signedIn ? (
+						<button
+							type="button"
+							disabled={busy}
+							mix={[css(connectButtonCss), on('click', handleConnectDiscord)]}
+						>
+							Connect Discord
+						</button>
 					) : null}
 				</section>
 			</section>
 		)
 	}
+}
+
+const pageCss = {
+	...stackedPageCss,
+	maxWidth: '28rem',
+	margin: '0 auto',
+}
+
+const connectButtonCss = {
+	...getPrimaryButtonCss({ size: 'lg', weight: 'semibold' }),
+	justifySelf: 'start' as const,
+}
+
+const connectFormCss = {
+	display: 'grid',
+	gap: spacing.sm,
+	justifyItems: 'start' as const,
 }

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -446,6 +446,9 @@ test('discord sign-in creates a verified account and assigns the guild role', as
 	})
 	const rolePuts: Array<string> = []
 	const roleDeletes: Array<string> = []
+	const guildJoins: Array<{ authorization: string; accessToken: string }> = []
+	const guildMemberUrl =
+		'https://discord.com/api/v10/guilds/111111111111111111/members/333333333333333333'
 	const guildRoleUrl =
 		'https://discord.com/api/v10/guilds/111111111111111111/members/333333333333333333/roles/:roleId'
 
@@ -470,6 +473,14 @@ test('discord sign-in creates a verified account and assigns the guild role', as
 				verified: true,
 			})
 		}),
+		http.put(guildMemberUrl, async ({ request }) => {
+			const body = (await request.json()) as { access_token?: string }
+			guildJoins.push({
+				authorization: request.headers.get('Authorization') ?? '',
+				accessToken: body.access_token ?? '',
+			})
+			return new HttpResponse(null, { status: 201 })
+		}),
 		http.put(guildRoleUrl, ({ request, params }) => {
 			expect(request.headers.get('Authorization')).toBe('Bot bot-token-test')
 			rolePuts.push(String(params.roleId))
@@ -489,7 +500,7 @@ test('discord sign-in creates a verified account and assigns the guild role', as
 	)
 	expect(start.location).toContain('https://discord.com/oauth2/authorize')
 	expect(start.location).toContain('code_challenge_method=S256')
-	expect(start.location).toContain('scope=identify+email')
+	expect(start.location).toContain('scope=identify+email+guilds.join')
 
 	const callbackResponse = await runHandler(
 		createAuthProviderCallbackHandler(env),
@@ -513,6 +524,12 @@ test('discord sign-in creates a verified account and assigns the guild role', as
 		)
 		.get() as Record<string, unknown>
 	expect(connection.user_id).toBe(user.id)
+	expect(guildJoins).toEqual([
+		{
+			authorization: 'Bot bot-token-test',
+			accessToken: 'discord-access-token',
+		},
+	])
 	expect(rolePuts).toEqual(['222222222222222222'])
 	expect(roleDeletes.sort()).toEqual([
 		'444444444444444444',

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -67,7 +67,10 @@ import { defaultPostVerificationRedirect } from '#universal/safe-redirect.ts'
 import { getSignupMode } from '#universal/signup-mode.ts'
 import { followDefaultWelcomeAccounts } from '#worker/community/welcome-follow.ts'
 import { parseLegacyHosts } from '#worker/app-legacy-redirect.ts'
-import { maybeSyncDiscordGuildRolesForUser } from '#worker/discord/guild-role.ts'
+import {
+	maybeJoinOfficialDiscordGuild,
+	maybeSyncDiscordGuildRolesForUser,
+} from '#worker/discord/guild-role.ts'
 
 /**
  * Accounts created through social login have no usable password until the
@@ -287,12 +290,18 @@ export function createAuthProviderCallbackHandler(env: Env) {
 		})
 	}
 
-	async function syncDiscordGuildRoles(input: {
+	async function completeDiscordGuildLogin(input: {
 		provider: OauthProviderId
 		userId: number
 		discordUserId: string
+		accessToken: string | null
 	}) {
 		if (input.provider !== 'discord') return
+		await maybeJoinOfficialDiscordGuild({
+			env,
+			discordUserId: input.discordUserId,
+			accessToken: input.accessToken,
+		})
 		await maybeSyncDiscordGuildRolesForUser({
 			env,
 			userId: input.userId,
@@ -358,14 +367,15 @@ export function createAuthProviderCallbackHandler(env: Env) {
 			}
 
 			let profile: OauthProfile
+			let accessToken: string | null = null
 			try {
-				profile = await resolveOauthProfile({
+				;({ profile, accessToken } = await resolveOauthProfile({
 					env,
 					provider,
 					code,
 					codeVerifier: loginState.codeVerifier,
 					redirectUri: getCallbackRedirectUri(env, url, provider),
-				})
+				}))
 			} catch (error) {
 				console.error('OAuth login provider exchange failed:', error)
 				return fail('provider-error', 'provider_exchange_failed')
@@ -452,10 +462,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				}
 				if (connection) {
 					if (connection.user_id === currentUser.id) {
-						await syncDiscordGuildRoles({
+						await completeDiscordGuildLogin({
 							provider,
 							userId: currentUser.id,
 							discordUserId: profile.providerUserId,
+							accessToken,
 						})
 						return redirect(
 							signedInOauthReturnLocation(redirectTo, 'oauthLinked', provider),
@@ -476,10 +487,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 					}
 					throw error
 				}
-				await syncDiscordGuildRoles({
+				await completeDiscordGuildLogin({
 					provider,
 					userId: currentUser.id,
 					discordUserId: profile.providerUserId,
+					accessToken,
 				})
 				void logAuditEvent({
 					category: 'auth',
@@ -504,10 +516,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				if (!user) {
 					return fail('account-error', 'connection_user_missing')
 				}
-				await syncDiscordGuildRoles({
+				await completeDiscordGuildLogin({
 					provider,
 					userId: user.id,
 					discordUserId: profile.providerUserId,
+					accessToken,
 				})
 				return issueLogin(user)
 			}
@@ -542,10 +555,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 						email_verified_at: new Date().toISOString(),
 					})
 				}
-				await syncDiscordGuildRoles({
+				await completeDiscordGuildLogin({
 					provider,
 					userId: existingUser.id,
 					discordUserId: profile.providerUserId,
+					accessToken,
 				})
 				return issueLogin(existingUser)
 			}
@@ -652,10 +666,11 @@ export function createAuthProviderCallbackHandler(env: Env) {
 				await rollbackNewUser(newUser.id)
 				return fail('account-error', 'connection_create_failed')
 			}
-			await syncDiscordGuildRoles({
+			await completeDiscordGuildLogin({
 				provider,
 				userId: newUser.id,
 				discordUserId: profile.providerUserId,
+				accessToken,
 			})
 
 			// Best-effort, mirroring password signup: the automatic

--- a/packages/worker/src/app/oauth-providers.ts
+++ b/packages/worker/src/app/oauth-providers.ts
@@ -87,7 +87,8 @@ export const oauthProviderDefinitions: Record<
 		label: 'Discord',
 		authorizationEndpoint: 'https://discord.com/oauth2/authorize',
 		tokenEndpoint: 'https://discord.com/api/oauth2/token',
-		scope: 'identify email',
+		// guilds.join is used once on the callback to add the member, then discarded.
+		scope: 'identify email guilds.join',
 		usesPkce: true,
 		tokenAuthStyle: 'body',
 	},
@@ -484,22 +485,22 @@ export async function resolveOauthProfile(input: {
 	code: string
 	codeVerifier: string
 	redirectUri: string
-}): Promise<OauthProfile> {
+}): Promise<{ profile: OauthProfile; accessToken: string | null }> {
 	const { env, provider } = input
 	if (isMockOauthProvider(env, provider)) {
-		return getMockOauthProfile(provider)
+		return { profile: getMockOauthProfile(provider), accessToken: null }
 	}
 
 	const accessToken = await exchangeCodeForAccessToken(input)
 	switch (provider) {
 		case 'github':
-			return fetchGithubProfile(accessToken)
+			return { profile: await fetchGithubProfile(accessToken), accessToken }
 		case 'google':
-			return fetchGoogleProfile(accessToken)
+			return { profile: await fetchGoogleProfile(accessToken), accessToken }
 		case 'x':
-			return fetchXProfile(accessToken)
+			return { profile: await fetchXProfile(accessToken), accessToken }
 		case 'discord':
-			return fetchDiscordProfile(accessToken)
+			return { profile: await fetchDiscordProfile(accessToken), accessToken }
 		default: {
 			const exhaustiveCheck: never = provider
 			throw new Error(`Unhandled OAuth provider: ${String(exhaustiveCheck)}`)

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1275,6 +1275,10 @@ test('renderAppPage renders the public Discord connect page', async () => {
 	expect(html).not.toContain('Join the Kody Discord')
 	expect(html).not.toContain('Connect to Discord')
 	expect(html).toContain('<title>Discord</title>')
+	expect(html).toContain('max-width: 28rem')
+	expect(
+		html.match(/<button\b[^>]*>\s*Connect Discord\s*<\/button>/g),
+	).toHaveLength(1)
 })
 
 test('renderAppPage renders the redesigned blog index', async () => {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1271,9 +1271,9 @@ test('renderAppPage renders the public Discord connect page', async () => {
 
 	expect(response.status).toBe(200)
 	const html = await readResponseText(response)
-	expect(html).toContain('Connect to Discord')
-	expect(html).toContain('Join the Kody Discord')
-	expect(html).toContain('Sign in')
+	expect(html).toContain('Connect Discord')
+	expect(html).not.toContain('Join the Kody Discord')
+	expect(html).not.toContain('Connect to Discord')
 	expect(html).toContain('<title>Discord</title>')
 })
 

--- a/packages/worker/src/discord/guild-role.node.test.ts
+++ b/packages/worker/src/discord/guild-role.node.test.ts
@@ -10,6 +10,7 @@ import {
 	isDiscordPlanRoleSyncConfigured,
 	isDiscordSnowflake,
 	maybeAssignDiscordMemberRole,
+	maybeJoinOfficialDiscordGuild,
 	maybeRemoveDiscordGuildRoles,
 	maybeRemoveDiscordMemberRole,
 	maybeSyncDiscordGuildRolesForUser,
@@ -40,6 +41,10 @@ function roleUrl(roleId: string) {
 	return `https://discord.com/api/v10/guilds/${configuredEnv.DISCORD_GUILD_ID}/members/${discordUserId}/roles/${roleId}`
 }
 
+function memberUrl() {
+	return `https://discord.com/api/v10/guilds/${configuredEnv.DISCORD_GUILD_ID}/members/${discordUserId}`
+}
+
 test('role sync stays off until bot token, guild id, and at least one role id are set', () => {
 	expect(isDiscordSnowflake('12345')).toBe(true)
 	expect(isDiscordSnowflake('mock-discord-user-1')).toBe(false)
@@ -65,6 +70,107 @@ test('role sync stays off until bot token, guild id, and at least one role id ar
 			DISCORD_PRO_ROLE_ID: configuredEnv.DISCORD_PRO_ROLE_ID,
 		}),
 	).toBe(true)
+})
+
+test('guild join uses the ephemeral access token once and classifies outcomes', async () => {
+	consoleWarn.mockImplementation(() => {})
+	const calls: Array<{
+		url: string
+		method: string
+		authorization: string
+		body: unknown
+	}> = []
+
+	async function fetchImpl(input: RequestInfo | URL, init?: RequestInit) {
+		const url = String(input)
+		calls.push({
+			url,
+			method: init?.method ?? 'GET',
+			authorization: new Headers(init?.headers).get('Authorization') ?? '',
+			body: init?.body ? JSON.parse(String(init.body)) : null,
+		})
+		if (url === memberUrl() && init?.method === 'PUT') {
+			return new Response(null, { status: 201 })
+		}
+		return jsonResponse(500)
+	}
+
+	expect(
+		await maybeJoinOfficialDiscordGuild({
+			env: configuredEnv,
+			discordUserId,
+			accessToken: '  discord-access-token  ',
+			fetchImpl,
+		}),
+	).toEqual({ status: 'joined' })
+	expect(calls).toEqual([
+		{
+			url: memberUrl(),
+			method: 'PUT',
+			authorization: 'Bot bot-token-test',
+			body: { access_token: 'discord-access-token' },
+		},
+	])
+
+	expect(
+		await maybeJoinOfficialDiscordGuild({
+			env: configuredEnv,
+			discordUserId,
+			accessToken: '   ',
+			fetchImpl,
+		}),
+	).toEqual({ status: 'skipped', reason: 'missing-access-token' })
+	expect(
+		await maybeJoinOfficialDiscordGuild({
+			env: configuredEnv,
+			discordUserId,
+			accessToken: null,
+			fetchImpl,
+		}),
+	).toEqual({ status: 'skipped', reason: 'missing-access-token' })
+	expect(
+		await maybeJoinOfficialDiscordGuild({
+			env: {},
+			discordUserId,
+			accessToken: 'discord-access-token',
+			fetchImpl,
+		}),
+	).toEqual({ status: 'skipped', reason: 'not-configured' })
+	expect(
+		await maybeJoinOfficialDiscordGuild({
+			env: configuredEnv,
+			discordUserId: 'mock-discord-user-1',
+			accessToken: 'discord-access-token',
+			fetchImpl,
+		}),
+	).toEqual({ status: 'skipped', reason: 'invalid-user-id' })
+	expect(
+		await maybeJoinOfficialDiscordGuild({
+			env: configuredEnv,
+			discordUserId,
+			accessToken: 'discord-access-token',
+			fetchImpl: async () => new Response(null, { status: 204 }),
+		}),
+	).toEqual({ status: 'already-member' })
+	expect(
+		await maybeJoinOfficialDiscordGuild({
+			env: configuredEnv,
+			discordUserId,
+			accessToken: 'discord-access-token',
+			fetchImpl: async () => jsonResponse(403),
+		}),
+	).toEqual({ status: 'forbidden' })
+	expect(
+		await maybeJoinOfficialDiscordGuild({
+			env: configuredEnv,
+			discordUserId,
+			accessToken: 'discord-access-token',
+			fetchImpl: async () => jsonResponse(500),
+		}),
+	).toEqual({
+		status: 'error',
+		message: 'Discord guild join failed (500).',
+	})
 })
 
 test('assign and remove call the Discord member-role routes and classify outcomes', async () => {

--- a/packages/worker/src/discord/guild-role.ts
+++ b/packages/worker/src/discord/guild-role.ts
@@ -2,9 +2,11 @@
  * Best-effort Kody Discord guild-role sync.
  *
  * Social login stores the Discord snowflake on `oauth_connections` and then
- * discards the user token. Guild role writes use an operator bot token, so
- * they stay off the login token path and skip entirely when bot config is
- * unset (local, preview, tests).
+ * discards the user token. During that same callback the ephemeral token
+ * (scope `guilds.join`) is used once to add the member, then thrown away.
+ * Guild role writes use an operator bot token, so they stay off the login
+ * token path and skip entirely when bot config is unset (local, preview,
+ * tests).
  *
  * The member role is assigned whenever Discord is connected. Standard and Pro
  * roles follow `users.stripe_plan` (the paid subscription), not the effective
@@ -30,6 +32,18 @@ export type DiscordGuildRoleEnv = {
 export type DiscordMemberRoleEnv = DiscordGuildRoleEnv
 
 export type DiscordMemberRoleSkipReason = 'not-configured' | 'invalid-user-id'
+
+export type DiscordGuildJoinSkipReason =
+	| 'not-configured'
+	| 'invalid-user-id'
+	| 'missing-access-token'
+
+export type DiscordGuildJoinResult =
+	| { status: 'skipped'; reason: DiscordGuildJoinSkipReason }
+	| { status: 'joined' }
+	| { status: 'already-member' }
+	| { status: 'forbidden' }
+	| { status: 'error'; message: string }
 
 export type DiscordMemberRoleSyncResult =
 	| { status: 'skipped'; reason: DiscordMemberRoleSkipReason }
@@ -128,6 +142,72 @@ function desiredDiscordPlanRole(
 
 function memberRoleUrl(guildId: string, discordUserId: string, roleId: string) {
 	return `${discordApiBaseUrl}/guilds/${guildId}/members/${discordUserId}/roles/${roleId}`
+}
+
+function guildMemberUrl(guildId: string, discordUserId: string) {
+	return `${discordApiBaseUrl}/guilds/${guildId}/members/${discordUserId}`
+}
+
+/**
+ * Add the Discord user to the official guild with the operator bot plus the
+ * ephemeral `guilds.join` access token from social login. The token is never
+ * stored. Failures are logged and never thrown.
+ */
+export async function maybeJoinOfficialDiscordGuild(input: {
+	env: DiscordGuildRoleEnv
+	discordUserId: string
+	accessToken: string | null | undefined
+	fetchImpl?: typeof fetch
+	timeoutMs?: number
+}): Promise<DiscordGuildJoinResult> {
+	const accessToken = input.accessToken?.trim()
+	if (!accessToken) {
+		return { status: 'skipped', reason: 'missing-access-token' }
+	}
+	if (!isDiscordSnowflake(input.discordUserId)) {
+		return { status: 'skipped', reason: 'invalid-user-id' }
+	}
+	const config = getDiscordGuildBotConfig(input.env)
+	if (!config) {
+		return { status: 'skipped', reason: 'not-configured' }
+	}
+
+	const fetchImpl = input.fetchImpl ?? fetch
+	const timeoutMs = input.timeoutMs ?? DISCORD_MEMBER_ROLE_REQUEST_TIMEOUT_MS
+	try {
+		const response = await fetchImpl(
+			guildMemberUrl(config.guildId, input.discordUserId),
+			{
+				method: 'PUT',
+				headers: {
+					Authorization: `Bot ${config.botToken}`,
+					'Content-Type': 'application/json',
+					'User-Agent': 'kody',
+				},
+				body: JSON.stringify({ access_token: accessToken }),
+				signal: AbortSignal.timeout(timeoutMs),
+			},
+		)
+		if (response.status === 201) {
+			return { status: 'joined' }
+		}
+		if (response.ok || response.status === 204) {
+			return { status: 'already-member' }
+		}
+		if (response.status === 403) {
+			console.warn(
+				'Failed to join official Kody Discord: bot is forbidden (needs Create Instant Invite).',
+			)
+			return { status: 'forbidden' }
+		}
+		const message = `Discord guild join failed (${response.status}).`
+		console.warn(message)
+		return { status: 'error', message }
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn('Failed to join official Kody Discord:', message)
+		return { status: 'error', message }
+	}
 }
 
 function rollupDiscordRoleResults(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

`/discord` should be a simple, reasonably sized page with one action: **Connect Discord** links the account and joins the official server.

## Summary

- Discord social login requests `identify email guilds.join`.
- On every successful Discord callback, best-effort Add Guild Member with the operator bot plus the ephemeral user token, then discard the token and sync roles.
- `/discord` is a `28rem` card with one **Connect Discord** button (no purple Discord icon, no invite/Sign in pair).
- ADR 0029 is superseded by 0030 so agents do not re-apply invite-only membership.

## Testing

- `npx vitest run --project node-unit` on `ssr-render.node.test.ts`, `auth-provider.node.test.ts`, and `guild-role.node.test.ts` — 33 passed
- `npx tsc -b packages/worker/tsconfig-client.json packages/worker/tsconfig-worker-typecheck.json --noEmit` — clean
- SSR HTML for `/discord` is a single card with one `Connect Discord` submit button and `max-width: 28rem`
- Local `npm run dev` did not come up in this Cloud Agent VM (`PackageServiceInstance` deleted-class migration against leftover Wrangler state), so the page was verified via SSR rather than a live browser

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `625cbb49` · **Head:** `07513f67`

**Classification:** extends — Discord social login now joins the official guild during the callback, and `/discord` is a single connect action.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-sessions` | auth | extends — Discord scope is `identify email guilds.join`; callback joins then discards the token |
| `app-ui` | surfaces | extends — `/discord` is one narrow card and one **Connect Discord** button |

### Change flow

Connect Discord authorizes `guilds.join`, adds the member with the bot plus the ephemeral user token, then syncs roles.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant appSessions as app-sessions
	actor Discord
	User->>appUi: click Connect Discord
	appUi->>appSessions: POST /auth/discord
	appSessions->>Discord: authorize identify email guilds.join
	Discord-->>appSessions: ephemeral access token
	appSessions->>Discord: PUT /guilds/{id}/members/{user}
	appSessions->>Discord: PUT member and plan roles
	Note over appSessions: discard user token after join
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Discord scopes | `identify email` | `identify email guilds.join` |
| `/discord` | Invite + Connect (icons, full width) | One **Connect Discord** button on a `28rem` page |
| Guild membership | Public invite only | Add Guild Member on the social-login callback |

### Invariants

Per-user isolation is unchanged: the Discord snowflake stays on `oauth_connections` for that `user_id`. Social-login tokens are still not persisted.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8617b04-2244-4103-9f13-c5b44a0587f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8617b04-2244-4103-9f13-c5b44a0587f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord social login now best-effort joins the official Discord server.
  * The Discord connection page provides a streamlined “Connect Discord” flow.
  * Connected members can receive synchronized Discord roles based on their plan.

* **Documentation**
  * Updated setup, configuration, authentication, and social-login guidance.
  * Documented required permissions, token handling, and join behavior.

* **Bug Fixes**
  * Discord joining and role synchronization failures no longer block sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->