### PR TITLE
Say the factory is honest, and Free is the whole product

### DIFF
--- a/docs/guides/what-is-kody.md
+++ b/docs/guides/what-is-kody.md
@@ -47,6 +47,16 @@ and keep running while your computer is off. Kody makes no inference calls of
 its own — your agent supplies the intelligence; Kody supplies memory,
 credentials, saved code, schedules, and execution.
 
+## The agent reasons. Kody keeps it honest.
+
+Your agent does the thinking. Kody holds the result so it does not have to
+think it again.
+
+- **Ask again tomorrow** — a saved export. No model in the loop.
+- **A key in chat or a `.env`** — a secret the agent never sees.
+- **Re-run the agent on a timer** — a job that runs while you are offline.
+- **Context stuck in one host** — memories that follow the account.
+
 ## What you cannot get elsewhere
 
 If you are comparing Kody against something else, or explaining it to someone,

--- a/docs/guides/what-is-kody.md
+++ b/docs/guides/what-is-kody.md
@@ -49,8 +49,8 @@ credentials, saved code, schedules, and execution.
 
 ## The agent reasons. Kody keeps it honest.
 
-Your agent does the thinking. Kody holds the result so it does not have to
-think it again.
+Your agent does the thinking. Kody holds the result so it does not have to think
+it again.
 
 - **Ask again tomorrow** — a saved export. No model in the loop.
 - **A key in chat or a `.env`** — a secret the agent never sees.

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -56,8 +56,8 @@ Read in order for a full tour, or jump to a topic.
   real-surface subscription handler smoke tests
 - [Activity](./activity.md) — failures and recent runs for jobs, apps, webhooks,
   and other runtimes (`/account/activity` and the `runs` MCP capabilities)
-- [Plans and pricing](https://kody.codes/pricing) — Free, Standard, and Pro
-  prices and the finite limits enforced for each plan
+- [Plans and pricing](https://kody.codes/pricing) — every plan is the whole
+  factory; paid plans raise the caps
 - [Mutating actions and confirmations](./mutating-actions.md)
 - [Privacy](./privacy.md) — what Kody stores and what deployment admins can see
   (Terms and Acceptable Use are in-app at [`/terms`](https://kody.codes/terms))

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -59,6 +59,25 @@ const factoryBeats = [
 	},
 ] as const
 
+const honestRows = [
+	{
+		from: 'Ask again tomorrow',
+		to: 'A saved export. No model in the loop.',
+	},
+	{
+		from: 'A key in chat or a .env',
+		to: 'A secret the agent never sees.',
+	},
+	{
+		from: 'Re-run the agent on a timer',
+		to: 'A job that runs while you are offline.',
+	},
+	{
+		from: 'Context stuck in one host',
+		to: 'Memories that follow the account.',
+	},
+] as const
+
 const hostAgents = [
 	{ label: 'Cursor', icon: 'cursor' },
 	{ label: 'Claude Code', icon: 'claudecode' },
@@ -322,6 +341,31 @@ export function HomeRoute(handle: Handle) {
 							See the whole loop
 						</a>
 					</p>
+				</section>
+
+				{/* ============ honest runtime ============ */}
+				<section aria-labelledby="honest-title" class="landing-honest">
+					<h2 id="honest-title" class="landing-section-heading">
+						The agent reasons.
+						<br />
+						Kody keeps it <em>honest</em>.
+					</h2>
+					<p class="landing-honest-lead">
+						Your agent does the thinking. Kody holds the result so it does not
+						have to think it again.
+					</p>
+					<dl class="landing-honest-rows">
+						{honestRows.map((row, index) => (
+							<div
+								key={row.from}
+								class="landing-honest-row"
+								mix={reveal(index * 70)}
+							>
+								<dt>{row.from}</dt>
+								<dd>{row.to}</dd>
+							</div>
+						))}
+					</dl>
 				</section>
 
 				{/* ============ git + npm ecosystem ============ */}

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -95,6 +95,7 @@ export function PricingRoute(handle: Handle) {
 						<br />
 						Pay when Kody <em>earns it</em>.
 					</h1>
+					<p>Every plan is the whole factory. You pay for volume.</p>
 				</header>
 
 				<div mix={css(plansCss)}>
@@ -107,8 +108,7 @@ export function PricingRoute(handle: Handle) {
 						</h2>
 						<p mix={css(planPriceCss)}>$0</p>
 						<p mix={css(planCopyCss)}>
-							Enough to build useful automations and find out whether Kody earns
-							a place in your setup.
+							The whole factory. Tight caps so you can see if it earns a place.
 						</p>
 						<a href="/signup" mix={css(planPillButtonCss)}>
 							Create a free account
@@ -133,8 +133,7 @@ export function PricingRoute(handle: Handle) {
 						</p>
 						<p mix={css(planPriceNoteCss)}>$10/mo billed annually</p>
 						<p mix={css(planCopyCss)}>
-							Higher daily volume and more room for scheduled jobs and
-							workflows.
+							Same factory. More room for jobs, workflows, and daily volume.
 						</p>
 						{renderPaidPlanCta(isSignedIn)}
 					</section>
@@ -151,8 +150,7 @@ export function PricingRoute(handle: Handle) {
 						</p>
 						<p mix={css(planPriceNoteCss)}>$24/mo billed annually</p>
 						<p mix={css(planCopyCss)}>
-							For heavy daily automation — roughly double Standard on every
-							axis.
+							Same factory. Roughly double Standard on every axis.
 						</p>
 						{renderPaidPlanCta(isSignedIn)}
 					</section>

--- a/packages/worker/client/routes/pricing.tsx
+++ b/packages/worker/client/routes/pricing.tsx
@@ -150,7 +150,8 @@ export function PricingRoute(handle: Handle) {
 						</p>
 						<p mix={css(planPriceNoteCss)}>$24/mo billed annually</p>
 						<p mix={css(planCopyCss)}>
-							Same factory. Roughly double Standard on every axis.
+							Same factory. More room for storage, jobs, workflows, and daily
+							volume.
 						</p>
 						{renderPaidPlanCta(isSignedIn)}
 					</section>

--- a/packages/worker/public/styles.css
+++ b/packages/worker/public/styles.css
@@ -652,6 +652,11 @@ html.is-settled {
 	line-height: 1.08;
 }
 
+.landing-section-heading em {
+	font-style: normal;
+	color: var(--color-primary-text);
+}
+
 .landing-inline-link {
 	color: var(--color-primary-text);
 	text-decoration-thickness: 1.5px;
@@ -1092,6 +1097,52 @@ html.is-settled {
 	text-decoration: underline;
 }
 
+.landing-honest {
+	max-width: 44rem;
+	margin-inline: auto;
+	padding: clamp(2.5rem, 6vw, 5rem) clamp(1.25rem, 4vw, 2.5rem);
+	text-align: center;
+}
+
+.landing-honest-lead {
+	margin: 1.1rem auto 0;
+	color: var(--color-text-muted);
+	font-size: 1.08rem;
+	max-width: 42ch;
+	text-wrap: pretty;
+}
+
+.landing-honest-rows {
+	margin: clamp(1.8rem, 4vw, 2.4rem) 0 0;
+	text-align: left;
+}
+
+.landing-honest-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1.15fr);
+	gap: 0.75rem 1.5rem;
+	padding: 0.95rem 0;
+	border-top: 1px solid var(--color-border);
+}
+
+.landing-honest-row:last-child {
+	border-bottom: 1px solid var(--color-border);
+}
+
+.landing-honest-row dt {
+	margin: 0;
+	color: var(--color-text-muted);
+	font-size: 0.98rem;
+	text-wrap: pretty;
+}
+
+.landing-honest-row dd {
+	margin: 0;
+	font-size: 0.98rem;
+	font-weight: 550;
+	text-wrap: pretty;
+}
+
 .landing-ecosystem,
 .landing-byok {
 	max-width: 72rem;
@@ -1388,6 +1439,16 @@ html.is-settled {
 		font-size: 1rem;
 		max-width: 46ch;
 		margin-inline: auto;
+	}
+
+	.landing-honest {
+		padding: 1.75rem 1.25rem;
+	}
+
+	.landing-honest-row {
+		grid-template-columns: 1fr;
+		gap: 0.3rem;
+		text-align: center;
 	}
 
 	.landing-ecosystem,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -560,6 +560,7 @@ test('renderAppPage emits a doctype, meta description, and inlines the styleshee
 	expect(withoutAssetsHtml.startsWith('<!DOCTYPE html>')).toBe(true)
 	expect(withoutAssetsHtml).toContain('href="/styles.css')
 	expect(withoutAssetsHtml).toContain('name="description"')
+	expect(withoutAssetsHtml).toContain('Kody keeps it')
 	expect(withoutAssetsHtml).toContain('href="/images/hero/kody-base-640.webp"')
 	expect(withoutAssetsHtml).toContain('kody-base-960.webp')
 	expect(withoutAssetsHtml).toContain('as="image"')
@@ -1242,6 +1243,7 @@ test('renderAppPage renders the redesigned pricing page', async () => {
 
 	expect(response.status).toBe(200)
 	const html = await readResponseText(response)
+	expect(html).toContain('Every plan is the whole factory. You pay for volume.')
 	expect(html).toContain('Standard')
 	expect(html).toContain('Pro')
 	const count = new Intl.NumberFormat('en-US')

--- a/packages/worker/universal/og-pages.ts
+++ b/packages/worker/universal/og-pages.ts
@@ -67,7 +67,7 @@ export const publicOgPages = {
 		imageSubtitle: 'Every plan is the whole factory. You pay for volume.',
 		ogTitle: 'Pricing — Kody',
 		ogDescription:
-			'Every plan is the whole factory. You pay for volume. Free, Standard, and Pro raise the caps.',
+			'Every plan is the whole factory. You pay for volume. Paid plans raise the caps.',
 		path: '/pricing',
 	},
 	privacy: {

--- a/packages/worker/universal/og-pages.ts
+++ b/packages/worker/universal/og-pages.ts
@@ -64,11 +64,10 @@ export const publicOgPages = {
 	},
 	pricing: {
 		imageTitle: 'Simple Kody pricing',
-		imageSubtitle:
-			'Start free. Standard is $12/month; Pro is $29/month for heavier use.',
+		imageSubtitle: 'Every plan is the whole factory. You pay for volume.',
 		ogTitle: 'Pricing — Kody',
 		ogDescription:
-			'Compare the Free, Standard, and Pro plans and their finite limits.',
+			'Every plan is the whole factory. You pay for volume. Free, Standard, and Pro raise the caps.',
 		path: '/pricing',
 	},
 	privacy: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make two pieces of positioning copy match how Kody already works: the agent does the thinking and Kody holds the result, and every paid plan is volume headroom rather than a feature unlock.

## Summary

- Homepage contrast after the factory loop: four pairs (ask again / saved export, key in chat / secret the agent never sees, re-run the agent / offline job, host-stuck context / account memories).
- Same contrast, as a short list, in `what-is-kody`.
- Pricing header and plan blurbs state that every plan is the whole factory; paid tiers raise the caps. OG copy matches.
- Pro no longer claims it is “roughly double Standard on every axis” (jobs are 3×, storage 5×, email message size is equal). OG now says paid plans raise the caps.

## Testing

- `npx vitest run packages/worker/src/app/ssr-render.node.test.ts packages/worker/src/og/page-image.node.test.ts --project node-unit` — 16 passed, including the new homepage and pricing copy assertions.
- `npx vitest run packages/worker/src/guides/catalog.node.test.ts packages/worker/src/app/ssr-render.node.test.ts --project node-unit` — 15 passed; `what-is-kody` still catalogs.
- Local `npm run format:check` on the touched files after wrapping the `what-is-kody` line that failed Static / Format.
- Local `npm run dev` did not become ready: Wrangler rejected `deleted_classes` for `PackageServiceInstance` (pre-existing local runtime-worker migration issue, not this copy change).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f99c4986` · **Head:** `434a68fa`

**Classification:** composes — marketing copy and landing CSS on existing `app-ui` routes. No primitive contract, storage, or MCP surface changes.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — home contrast, pricing volume line, guide copy |

### Change flow

Anonymous visitors read the new contrast on `/` and the volume line on `/pricing`; agents read the same idea from the what-is-kody guide.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	appUi-->>Visitor: honest contrast after factory loop
	Visitor->>appUi: GET /pricing
	appUi-->>Visitor: every plan is the whole factory
	Visitor->>appUi: GET /guides/what-is-kody
	appUi-->>Visitor: same contrast as a short list
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fb4bec2-dabf-444c-9d80-133468686415?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fb4bec2-dabf-444c-9d80-133468686415&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a landing-page section explaining how durable storage, secrets, scheduled jobs, and account-wide memories support agent workflows.
  * Updated pricing messaging to clarify that every plan includes the full factory, with paid plans increasing usage caps.

* **Documentation**
  * Expanded guidance on the relationship between agent reasoning and Kody’s execution capabilities.

* **Style**
  * Added responsive styling for the new landing-page comparison section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->