### PR TITLE
Disclose connected-account and Google user data on /privacy

### DIFF
--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -59,8 +59,9 @@ Read in order for a full tour, or jump to a topic.
 - [Plans and pricing](https://kody.codes/pricing) — Free, Standard, and Pro
   prices and the finite limits enforced for each plan
 - [Mutating actions and confirmations](./mutating-actions.md)
-- [Privacy](./privacy.md) — what Kody stores and what deployment admins can see
-  (Terms and Acceptable Use are in-app at [`/terms`](https://kody.codes/terms))
+- [Privacy](./privacy.md) — what Kody stores, how connected accounts work, and
+  what deployment admins can see (Terms and Acceptable Use are in-app at
+  [`/terms`](https://kody.codes/terms))
 - [Troubleshooting](./troubleshooting.md)
 - [Memory and conversation context](./memory.md)
 - [Community Project mark](./community-project-mark.md) — logo for unofficial

--- a/docs/use/privacy.md
+++ b/docs/use/privacy.md
@@ -1,6 +1,7 @@
 # Privacy
 
-How Kody stores your data and what a deployment admin can see.
+How Kody stores your data, how connected accounts work, and what a deployment
+admin can see.
 
 ## What Kody stores per account
 
@@ -28,6 +29,44 @@ authored). The browser download is a bounded metadata manifest; use its
 `account_export_section` instructions to retrieve every D1, Durable Object, and
 R2 page for a complete portable export. Account deletion removes those same
 user-owned rows and objects.
+
+## Connected accounts
+
+When you connect a third-party service — a built-in integration Kody hosts, or
+an OAuth app or API key you register yourself — Kody stores that connection in
+your account only: tokens, the scopes you granted, and host allowlists. Those
+credentials stay in the encrypted secret store. Your agent and package code
+refer to them by name; Kody substitutes them at the network boundary and never
+returns the raw value to chat, search, or capability output.
+
+Kody fetches data from a connected service only to fulfill a request you, or a
+job you saved, just made. Content a package or job persists (for example a saved
+summary) stays in your account under the same isolation rules. Kody does not
+sell that data, use it for advertising, share it with other Kody users, or use
+it to train a Kody model. Kody makes no inference calls of its own.
+
+**Share, transfer, and disclose.** Provider data leaves your isolated account
+only to Cloudflare, which hosts the application, database, object storage, and
+network; the MCP host you connected (for example ChatGPT, Claude, or Cursor),
+when that host asks Kody to act and receives the result; the provider itself,
+when Kody calls its API with your token; and disclosure required by law. Kody
+does not hand connected-account data to other customers or advertisers.
+
+**Protection.** Tokens and OAuth grants are encrypted at rest, isolated per
+user, and sent only to hosts you approved. The admin role cannot read secret
+values, secret metadata, or OAuth grants. You can disconnect a connection in
+Kody and revoke it at the provider.
+
+### Google user data
+
+When you connect Google, the rules above apply to Google user data — Calendar,
+Docs, Sheets, Gmail send, Contacts, Tasks, YouTube, and any other Google scopes
+you grant. Kody uses Google user data only to fulfill your request or saved job.
+Kody stores Google OAuth tokens in your encrypted secret store and does not use
+Google user data for advertising. Kody shares, transfers, or discloses Google
+user data only with Cloudflare (hosting), the MCP host you connected when it
+asks Kody to act, Google when Kody calls Google APIs on your behalf, and when
+required by law.
 
 ## What a deployment admin can see
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -77,6 +77,12 @@ test('smoke test covers shell, auth redirect, and login', async ({ page }) => {
 	await page.goto('/privacy')
 	await expect(page.getByRole('heading', { name: 'Privacy' })).toBeVisible()
 	await expect(
+		page.getByRole('heading', { name: 'Connected accounts' }),
+	).toBeVisible()
+	await expect(
+		page.getByRole('heading', { name: 'Google user data' }),
+	).toBeVisible()
+	await expect(
 		page.getByRole('heading', { name: 'What a deployment admin can see' }),
 	).toBeVisible()
 	await expect(

--- a/packages/worker/client/routes/privacy.tsx
+++ b/packages/worker/client/routes/privacy.tsx
@@ -8,6 +8,7 @@ import {
 	pageDescriptionCss,
 	pageHeaderCss,
 	pageTitleCss,
+	sectionTitleCss,
 	stackedPageCss,
 } from '#universal/styles/style-primitives.ts'
 
@@ -45,6 +46,55 @@ export function PrivacyRoute(_handle: Handle) {
 					submission. All of this remains scoped to your account except for the
 					narrow admin review of approved platform feedback and the community
 					activity metadata described below.
+				</p>
+			</section>
+
+			<section mix={css(cardCss)}>
+				<h2 mix={css(cardTitleCss)}>Connected accounts</h2>
+				<p mix={css(descriptionCss)}>
+					When you connect a third-party service — a built-in integration Kody
+					hosts, or an OAuth app or API key you register yourself — Kody stores
+					that connection in your account only: tokens, the scopes you granted,
+					and host allowlists. Those credentials stay in the encrypted secret
+					store. Your agent and package code refer to them by name; Kody
+					substitutes them at the network boundary and never returns the raw
+					value to chat, search, or capability output.
+				</p>
+				<p mix={css(descriptionCss)}>
+					Kody fetches data from a connected service only to fulfill a request
+					you, or a job you saved, just made. Content a package or job persists
+					(for example a saved summary) stays in your account under the same
+					isolation rules. Kody does not sell that data, use it for advertising,
+					share it with other Kody users, or use it to train a Kody model. Kody
+					makes no inference calls of its own.
+				</p>
+				<p mix={css(descriptionCss)}>
+					<strong>Share, transfer, and disclose.</strong> Provider data leaves
+					your isolated account only to Cloudflare, which hosts the application,
+					database, object storage, and network; the MCP host you connected (for
+					example ChatGPT, Claude, or Cursor), when that host asks Kody to act
+					and receives the result; the provider itself, when Kody calls its API
+					with your token; and disclosure required by law. Kody does not hand
+					connected-account data to other customers or advertisers.
+				</p>
+				<p mix={css(descriptionCss)}>
+					<strong>Protection.</strong> Tokens and OAuth grants are encrypted at
+					rest, isolated per user, and sent only to hosts you approved. The
+					admin role cannot read secret values, secret metadata, or OAuth
+					grants. You can disconnect a connection in Kody and revoke it at the
+					provider.
+				</p>
+				<h3 mix={css(subsectionTitleCss)}>Google user data</h3>
+				<p mix={css(descriptionCss)}>
+					When you connect Google, the rules above apply to Google user data —
+					Calendar, Docs, Sheets, Gmail send, Contacts, Tasks, YouTube, and any
+					other Google scopes you grant. Kody uses Google user data only to
+					fulfill your request or saved job. Kody stores Google OAuth tokens in
+					your encrypted secret store and does not use Google user data for
+					advertising. Kody shares, transfers, or discloses Google user data
+					only with Cloudflare (hosting), the MCP host you connected when it
+					asks Kody to act, Google when Kody calls Google APIs on your behalf,
+					and when required by law.
 				</p>
 			</section>
 
@@ -278,4 +328,9 @@ const listCss = {
 	gap: spacing.xs,
 	fontSize: typography.fontSize.sm,
 	lineHeight: 1.6,
+}
+
+const subsectionTitleCss = {
+	...sectionTitleCss,
+	marginTop: spacing.md,
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Google OAuth verification rejected the current privacy policy for missing two disclosures: who Google user data is shared with, and how sensitive data is protected. The page also never named Google user data. This change adds those disclosures without turning `/privacy` into a per-provider catalog.

## Summary

- Add a durable **Connected accounts** section that covers every integration (built-in or BYO): what is stored, when provider data is fetched, who it is shared with, and how tokens are protected.
- Add a short **Google user data** heading so reviewers can find the required phrases without a new card per future provider.
- Mirror the same section in `docs/use/privacy.md`.
- Assert the new headings on the existing `/privacy` smoke path.

## Testing

- `oxfmt` on the touched files
- Smoke heading assertions added for `Connected accounts` and `Google user data`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f99c4986` · **Head:** `f5ee4e07`

**Classification:** composes — public privacy copy and matching usage docs; no primitive behavior, storage, or auth contract changes.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — new Connected accounts / Google user data copy on `/privacy` |

Unmatched paths: `docs/use/privacy.md`, `docs/use/index.md`, `e2e/smoke.spec.ts`.

### Change flow

A visitor opens `/privacy` and reads the new connected-account disclosure, including the Google user data heading required for OAuth verification.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /privacy
	appUi-->>Visitor: Connected accounts plus Google user data heading
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce4ca3e0-e144-4903-9ff9-1495748240fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce4ca3e0-e144-4903-9ff9-1495748240fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Privacy guide to explain connected accounts, credential handling, access boundaries, provider data use, disclosures, revocation, and Google-specific data practices.
  * Updated the documentation index to highlight connected account information.

* **User Experience**
  * Added a “Connected accounts” section to the privacy page with clearer subsections and guidance.

* **Tests**
  * Added coverage confirming the privacy page displays the new connected account and Google user data sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->