### PR TITLE
Retry D1 blips during published package artifact rebuild

### DIFF
--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts
@@ -454,7 +454,7 @@ test('recovers from transient Durable Object resets during staging', async () =>
 	)
 	expect(consoleWarn).toHaveBeenCalledTimes(1)
 	expect(String(consoleWarn.mock.calls[0]?.[0])).toContain(
-		'rebuildPublishedPackageArtifactsViaRepoSession transient Durable Object reset',
+		'rebuildPublishedPackageArtifactsViaRepoSession transient platform error',
 	)
 })
 
@@ -487,13 +487,66 @@ test('exhausts transient Durable Object reset retries during staging', async () 
 			baseUrl: 'https://kody.test',
 		}),
 	).rejects.toThrow(
-		/could not recover after 3 transient Durable Object reset attempts/,
+		/could not recover after 3 transient platform error attempts/,
 	)
 
 	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
 		3,
 	)
 	expect(consoleWarn).toHaveBeenCalledTimes(3)
+})
+
+test('recovers from retryable D1 internal errors during isolated target rebuild', async () => {
+	consoleWarn.mockImplementation(() => {})
+	resetMocks()
+
+	const run = vi
+		.fn()
+		.mockResolvedValueOnce({
+			ok: false,
+			message: 'internal error; reference = s46pgsm6st3fg81p6qumom80',
+		})
+		.mockResolvedValueOnce({
+			ok: true,
+			message: 'rebuilt',
+		})
+	const discard = vi.fn(async () => undefined)
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		touch: vi.fn(),
+		run,
+		discard,
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([
+		sampleTargets[0],
+	])
+	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-d1',
+	})
+
+	await rebuildPublishedPackageArtifactsViaRepoSession({
+		env: {
+			REPO_SESSION: {},
+			BUNDLE_ARTIFACTS_KV: {},
+		} as unknown as Env,
+		rpcSessionId: 'session-1',
+		sourceId: 'source-1',
+		userId: 'user-1',
+		publishedCommit: 'commit-1',
+		baseUrl: 'https://kody.test',
+	})
+
+	expect(run).toHaveBeenCalledTimes(2)
+	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
+		2,
+	)
+	expect(discard).toHaveBeenCalledTimes(2)
+	expect(consoleWarn).toHaveBeenCalledTimes(1)
+	expect(String(consoleWarn.mock.calls[0]?.[0])).toContain(
+		'rebuildPublishedPackageArtifactsViaRepoSession transient platform error',
+	)
+	expect(String(consoleWarn.mock.calls[0]?.[0])).toContain(
+		'internal error; reference = s46pgsm6st3fg81p6qumom80',
+	)
 })
 
 test('does not retry non-transient rebuild failures', async () => {
@@ -525,6 +578,42 @@ test('does not retry non-transient rebuild failures', async () => {
 		}),
 	).rejects.toThrow(/bundle artifact rebuild failed/i)
 
+	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
+		1,
+	)
+
+	resetMocks()
+	const run = vi.fn().mockResolvedValue({
+		ok: false,
+		message: 'No matching default export for import "default"',
+	})
+	mockModule.createIsolatedArtifactRebuildRunner.mockReturnValue({
+		touch: vi.fn(),
+		run,
+		discard: vi.fn(),
+	})
+	mockModule.listPublishedPackageArtifactTargets.mockResolvedValue([
+		sampleTargets[0],
+	])
+	mockModule.stagePublishedPackageArtifactRebuild.mockResolvedValue({
+		stagingKey: 'repo-artifact-rebuild-staging:v1:user-1:stage-compile',
+	})
+
+	await expect(
+		rebuildPublishedPackageArtifactsViaRepoSession({
+			env: {
+				REPO_SESSION: {},
+				BUNDLE_ARTIFACTS_KV: {},
+			} as unknown as Env,
+			rpcSessionId: 'session-1',
+			sourceId: 'source-1',
+			userId: 'user-1',
+			publishedCommit: 'commit-1',
+			baseUrl: 'https://kody.test',
+		}),
+	).rejects.toThrow(/bundle artifact rebuild failed/i)
+
+	expect(run).toHaveBeenCalledTimes(1)
 	expect(mockModule.stagePublishedPackageArtifactRebuild).toHaveBeenCalledTimes(
 		1,
 	)

--- a/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
+++ b/packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.ts
@@ -4,6 +4,7 @@ import {
 	formatErrorCauseChain,
 	getErrorMessage,
 } from '@kody-internal/shared/error-message.ts'
+import { isRetryableD1LockError } from '#worker/d1-retry.ts'
 import { isPublishedPackageArtifactBuiltForCommit } from '#worker/package-runtime/published-bundle-artifacts.ts'
 import { type PublishedPackageArtifactBuildTarget } from '#worker/package-runtime/package-artifact-targets.ts'
 import { createIsolatedArtifactRebuildRunner } from '#worker/repo/isolated-artifact-rebuild.ts'
@@ -20,15 +21,22 @@ import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
 export const publishedPackageArtifactRebuildConcurrency = 2
 
 /**
- * Deploy-time DO code resets (and other platform isolate resets) during
- * staging or target rebuilds are transient. Rebuilds are idempotent
- * (already-built targets are skipped), so a short bounded retry recovers
- * without re-running publish. Matches package_publish_external_push delays.
+ * Deploy-time DO code resets, other platform isolate resets, and D1
+ * `internal error; reference = …` blips during staging or target rebuilds
+ * are transient. Rebuilds are idempotent (already-built targets are skipped),
+ * so a short bounded retry recovers without re-running publish. Matches
+ * package_publish_external_push delays.
  */
 export const publishedPackageArtifactRebuildRetryDelaysMs = [100, 500] as const
 
 function isTransientDurableObjectResetError(error: unknown) {
 	return errorCauseChainIncludes(error, isDurableObjectIsolateResetMessage)
+}
+
+function isTransientArtifactRebuildError(error: unknown) {
+	return (
+		isTransientDurableObjectResetError(error) || isRetryableD1LockError(error)
+	)
 }
 
 function logArtifactRebuildRetry(input: {
@@ -41,7 +49,7 @@ function logArtifactRebuildRetry(input: {
 	console.warn(
 		JSON.stringify({
 			message:
-				'rebuildPublishedPackageArtifactsViaRepoSession transient Durable Object reset',
+				'rebuildPublishedPackageArtifactsViaRepoSession transient platform error',
 			sourceId: input.sourceId,
 			publishedCommit: input.publishedCommit,
 			attempt: input.attempt,
@@ -382,7 +390,7 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 			await rebuildPublishedPackageArtifactsViaRepoSessionOnce(input)
 			return
 		} catch (error) {
-			if (!isTransientDurableObjectResetError(error)) {
+			if (!isTransientArtifactRebuildError(error)) {
 				throw error
 			}
 			lastTransientError = error
@@ -405,7 +413,7 @@ export async function rebuildPublishedPackageArtifactsViaRepoSession(input: {
 		}
 	}
 	throw new Error(
-		`rebuildPublishedPackageArtifactsViaRepoSession could not recover after ${maxAttempts} transient Durable Object reset attempts: ${getErrorMessage(
+		`rebuildPublishedPackageArtifactsViaRepoSession could not recover after ${maxAttempts} transient platform error attempts: ${getErrorMessage(
 			lastTransientError,
 		)}`,
 	)

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -527,7 +527,7 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 		exception: {
 			values: [
 				{
-					value: `rebuildPublishedPackageArtifactsViaRepoSession could not recover after 3 transient Durable Object reset attempts: Package source publish succeeded, but bundle artifact rebuild failed for source "source-1" at commit "commit-1". Succeeded: none. Failed: ${durableObjectCodeUpdatedResetMessage} Re-run the publish capability to repair artifacts.`,
+					value: `rebuildPublishedPackageArtifactsViaRepoSession could not recover after 3 transient platform error attempts: Package source publish succeeded, but bundle artifact rebuild failed for source "source-1" at commit "commit-1". Succeeded: none. Failed: ${durableObjectCodeUpdatedResetMessage} Re-run the publish capability to repair artifacts.`,
 				},
 			],
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop leaving a saved package in a split state when source publish succeeds and one bundle artifact rebuild dies on a transient D1 platform fault.

## Summary

- `package_publish_external_push` publishes the Artifacts HEAD first, then rebuilds bundle artifacts. Rebuild already retried Durable Object isolate resets; it treated D1 `internal error; reference = …` as fatal.
- Production evidence: `@kentcdodds/kody-discord` source commit `20f50cc4d3b1fac6154b289162b21c4ba2404dca` published, then the `importable-module` rebuild for `src/list-channels.ts` failed with `internal error; reference = s46pgsm6st3fg81p6qumom80` while the same entry's `module` bundle succeeded.
- Treat that known retryable D1 class like isolate resets. Rebuilds are idempotent (already-built targets are skipped), so a short bounded retry finishes the missing artifact without re-running publish.
- Compile / package errors are still not retried.

## Testing

- Node unit passed: `package-artifact-rebuild.node.test.ts`, `sentry-options.node.test.ts`, `publish-external-push.node.test.ts` (17 tests), plus `d1-retry.node.test.ts` and `isolated-artifact-rebuild.node.test.ts` (5 tests).
- New coverage: isolated rebuild returns `internal error; reference = …`, then succeeds on the next attempt; compile errors still fail immediately.
- Preview UI pass skipped: no user-visible surface; the failure is a Cloudflare D1 blip during isolated rebuild.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f99c498` · **Head:** `e892359`

**Classification:** extends — published artifact rebuild now retries the existing D1 `internal error; reference = …` class; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capability-registry` | assistant | extends — `rebuildPublishedPackageArtifactsViaRepoSession` retries retryable D1 faults the same way it already retries Durable Object isolate resets |

### Change flow

External publish still promotes source first; a D1 blip on one isolated rebuild target now retries the idempotent rebuild instead of failing the workflow.

```mermaid
sequenceDiagram
	participant mcpServer as mcp-server
	participant capabilityRegistry as capability-registry
	participant repoSessions as repo-sessions
	participant d1AppDb as d1-app-db
	mcpServer->>capabilityRegistry: package_publish_external_push
	capabilityRegistry->>repoSessions: publishFromExternalRef (source commit)
	capabilityRegistry->>repoSessions: isolated artifact rebuild per target
	repoSessions->>d1AppDb: persist published_bundle_artifacts
	alt retryable D1 internal error
		capabilityRegistry->>repoSessions: bounded rebuild retry (skip already-built)
	end
```

### Invariants

Per-user isolation is unchanged: rebuild still scopes staging keys and D1 rows by `userId`.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75a44c6f-fab0-4ad3-9ac5-e7caf27cf813?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75a44c6f-fab0-4ad3-9ac5-e7caf27cf813&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

