### PR TITLE
Put the Discord logo next to the /discord title

### DIFF
--- a/packages/worker/client/routes/discord.tsx
+++ b/packages/worker/client/routes/discord.tsx
@@ -4,6 +4,7 @@ import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { createRouteLoadLatch } from '#client/route-load-latch.ts'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { consumeStaleNavigationData } from '#client/navigation-data.ts'
+import { ProviderIcon } from '#client/provider-icons.tsx'
 import { startSocialSignIn } from '#client/social-sign-in.ts'
 import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
@@ -264,7 +265,10 @@ export function DiscordRoute(handle: Handle) {
 		return (
 			<section mix={css(pageCss)}>
 				<header mix={css(pageHeaderCss)}>
-					<h1 mix={css(pageTitleCss)}>Discord</h1>
+					<h1 mix={css(titleCss)}>
+						<ProviderIcon providerId="discord" size="1em" />
+						Discord
+					</h1>
 					<p mix={css(pageDescriptionCss)}>
 						Connect Discord to join the official Kody server and get the member
 						role — plus Standard or Pro if you subscribe.
@@ -389,6 +393,13 @@ const pageCss = {
 	...stackedPageCss,
 	maxWidth: '28rem',
 	margin: '0 auto',
+}
+
+const titleCss = {
+	...pageTitleCss,
+	display: 'flex',
+	alignItems: 'center',
+	gap: '0.35em',
 }
 
 const connectButtonCss = {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1276,9 +1276,15 @@ test('renderAppPage renders the public Discord connect page', async () => {
 	expect(html).not.toContain('Connect to Discord')
 	expect(html).toContain('<title>Discord</title>')
 	expect(html).toContain('max-width: 28rem')
-	expect(
-		html.match(/<button\b[^>]*>\s*Connect Discord\s*<\/button>/g),
-	).toHaveLength(1)
+	const heading = html.match(/<h1\b[^>]*>[\s\S]*?<\/h1>/)?.[0]
+	expect(heading).toContain('fill="#5865F2"')
+	expect(heading).toContain('width="1em"')
+	expect(heading).toContain('Discord')
+	const connectButtons = (
+		html.match(/<button\b[^>]*>[\s\S]*?<\/button>/g) ?? []
+	).filter((button) => button.includes('Connect Discord'))
+	expect(connectButtons).toHaveLength(1)
+	expect(connectButtons[0]).not.toContain('<svg')
 })
 
 test('renderAppPage renders the redesigned blog index', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

The Discord brand mark belongs next to the page title, not on the green Connect Discord button.

## Summary

- `/discord` heading is the existing Discord logo at `1em` plus **Discord**
- The connect button stays text-only

## Testing

- `npx vitest run --project node-unit packages/worker/src/app/ssr-render.node.test.ts -t "public Discord connect page"` — passed
- `npx tsc -b packages/worker/tsconfig-client.json --noEmit` — clean

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `de296c04` · **Head:** `f0442993`

**Classification:** composes — existing `ProviderIcon` next to the page title; no auth or join-path change.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | composes — `/discord` heading uses the existing Discord mark |

### Change flow

The Discord page heading renders the brand mark inline with the title; the connect button stays text-only.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: GET /discord
	appUi-->>User: h1 with ProviderIcon 1em plus Discord
	Note over appUi: Connect Discord button has no icon
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8617b04-2244-4103-9f13-c5b44a0587f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8617b04-2244-4103-9f13-c5b44a0587f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Discord icon to the page heading for clearer visual identification.
  * Improved heading layout with consistent icon and title alignment.

* **Bug Fixes**
  * Updated Discord page rendering to ensure the correct icon and a single “Connect Discord” button are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->