### PR TITLE
Preserve enabled package jobs when a package is republished

### DIFF
--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -296,6 +296,10 @@ Jobs belong to packages.
 - Each job run binds a job-scoped scratch bucket; shared durable data uses
   `packageStorage()`
 - Package config stays keyed by the saved package id
+- Manifest `enabled` is the create-time default and can turn an existing job
+  on. Republishing with `"enabled": false` does not disable a job that is
+  already running; use `job_update` (or a package pause/resume export) to turn
+  one off.
 
 Jobs are not their own top-level saved primitive.
 

--- a/docs/contributing/packages-and-manifests.md
+++ b/docs/contributing/packages-and-manifests.md
@@ -296,10 +296,9 @@ Jobs belong to packages.
 - Each job run binds a job-scoped scratch bucket; shared durable data uses
   `packageStorage()`
 - Package config stays keyed by the saved package id
-- Manifest `enabled` is the create-time default and can turn an existing job
-  on. Republishing with `"enabled": false` does not disable a job that is
-  already running; use `job_update` (or a package pause/resume export) to turn
-  one off.
+- Manifest `enabled` is the create-time default and can turn an existing job on.
+  Republishing with `"enabled": false` does not disable a job that is already
+  running; use `job_update` (or a package pause/resume export) to turn one off.
 
 Jobs are not their own top-level saved primitive.
 

--- a/docs/guides/package-lifecycle.md
+++ b/docs/guides/package-lifecycle.md
@@ -175,6 +175,12 @@ After package checks and publishing succeed:
 5. Only then change the job to `"enabled": true`, publish again, and verify the
    package/job detail reflects the enabled schedule.
 
+   Republishing a package whose job still says `"enabled": false` does not
+   disable a job that is already running. Manifest `enabled` is the create-time
+   default and can turn a job on; use `job_update` (or a package pause/resume
+   export) to turn one off. This keeps fleet-wide package publishes from
+   silently stopping a sweeper that an operator already enabled.
+
 Example test call:
 
 ```ts

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -1440,6 +1440,78 @@ test('package job sync reports scheduler changes for add, update, and remove onl
 	expect(await listJobRowsByUserId(env.APP_DB, input.userId)).toEqual([])
 })
 
+test('package job sync preserves a runtime-enabled job when the manifest still says disabled', async () => {
+	const env = createJobServiceTestEnv({
+		APP_DB: createDatabase(),
+	})
+	const input = {
+		env,
+		userId: 'user-1',
+		baseUrl: 'https://heykody.dev',
+		packageId: 'package-1',
+		sourceId: 'source-1',
+	}
+	const createManifest = (enabled: boolean) =>
+		parseAuthoredPackageJson({
+			content: JSON.stringify({
+				name: '@kentcdodds/cloudflare',
+				exports: {
+					'.': './index.ts',
+				},
+				kody: {
+					id: 'cloudflare',
+					description: 'Cloudflare package',
+					jobs: {
+						sweep: {
+							entry: './src/jobs/sweep.ts',
+							schedule: { type: 'interval', every: '15m' },
+							timezone: 'UTC',
+							enabled,
+						},
+					},
+				},
+			}),
+		})
+	await insertPublishedEntitySource({
+		db: env.APP_DB as ReturnType<typeof createDatabase>,
+		userId: input.userId,
+		sourceId: input.sourceId,
+		entityKind: 'package',
+		entityId: input.packageId,
+		publishedCommit: 'package-published-commit',
+		manifestPath: 'package.json',
+	})
+
+	expect(
+		await syncPackageJobsForPackage({
+			...input,
+			manifest: createManifest(false),
+		}),
+	).toBe(true)
+	const created = (await listJobRowsByUserId(env.APP_DB, input.userId))[0]
+	expect(created?.record.enabled).toBe(false)
+
+	expect(
+		await syncPackageJobsForPackage({
+			...input,
+			manifest: createManifest(true),
+		}),
+	).toBe(true)
+	const turnedOn = (await listJobRowsByUserId(env.APP_DB, input.userId))[0]
+	expect(turnedOn?.record.enabled).toBe(true)
+	const nextRunAtAfterEnable = turnedOn?.record.nextRunAt
+
+	expect(
+		await syncPackageJobsForPackage({
+			...input,
+			manifest: createManifest(false),
+		}),
+	).toBe(false)
+	const preserved = (await listJobRowsByUserId(env.APP_DB, input.userId))[0]
+	expect(preserved?.record.enabled).toBe(true)
+	expect(preserved?.record.nextRunAt).toBe(nextRunAtAfterEnable)
+})
+
 test('package job sync preflights the full addition set without partial inserts', async () => {
 	const email = 'package-sync-free@example.com'
 	const userId = await createStableUserIdFromEmail(email)

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -738,7 +738,10 @@ export async function syncPackageJobsForPackage(input: {
 				const existing = existingByName.get(jobName)
 				const schedule = normalizeJobSchedule(definition.schedule)
 				const timezone = normalizeJobTimezone(definition.timezone)
-				const enabled = definition.enabled ?? true
+				const enabled = resolvePackageJobEnabled({
+					existingEnabled: existing?.record.enabled,
+					manifestEnabled: definition.enabled,
+				})
 				if (existing) {
 					const schedulerStateMatches =
 						JSON.stringify(existing.record.schedule) ===
@@ -832,6 +835,20 @@ export async function syncPackageJobsForPackage(input: {
 			return schedulerStateChanged
 		},
 	})
+}
+
+function resolvePackageJobEnabled(input: {
+	existingEnabled?: boolean
+	manifestEnabled?: boolean
+}) {
+	const manifestEnabled = input.manifestEnabled ?? true
+	if (input.existingEnabled === undefined) return manifestEnabled
+	// Manifest `enabled` is the create-time default and can still turn a job
+	// on. Republishing with `enabled: false` must not stop a job that is
+	// already running — fleet-wide package publishes (codemods) otherwise
+	// silently disable production sweepers that were enabled via job_update
+	// or a package resume export.
+	return input.existingEnabled || manifestEnabled
 }
 
 function resolveCreateShape(input: JobCreateInput) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop package republishes from silently disabling production sweepers that operators already turned on. That is what kept recent platform feedback from getting a Cursor triage agent.

## Summary

- `syncPackageJobsForPackage` treated manifest `enabled` as the live switch on every publish.
- Fleet-wide package republishes (including the 2026-08-20 `kody.dependencies` codemod) therefore set `@kentcdodds/platform-feedback-triage` `sweep` back to `enabled: false`, even though `./resume` had already enabled it and the package kill switch was still on.
- The subscription handler still queued fingerprints. The 15m spawn path did not run.
- Manifest `enabled` remains the create-time default and can still turn a job on. Republishing with `"enabled": false` no longer disables a running job. Use `job_update` or a package pause/resume export to turn one off.

## Production recovery (already done)

- Republished `@kentcdodds/platform-feedback-triage` with `sweep` `enabled: true` (commit `f53f850`).
- Confirmed the package-owned job is enabled again.
- Manually invoked `./sweep` for the latest feedback (`18ac1748`). Spawned agent `bc-c3a61362-ef6c-4b6e-b7dd-51bbf7e1d638`.

## Testing

- `npx vitest run packages/worker/src/jobs/service.node.test.ts -t "package job sync"` — 3 passed, including the new preserve-enabled workflow.
- `npm run format:check` after wrapping the packages-and-manifests bullet.
- Preview (`kody-pr-1622`): signed in as `me@kentcdodds.com` / `user-me`. `GET /account/jobs.json` and `GET /account/packages.json` returned empty lists (seed starts empty). `/admin` 403. UI pass: Jobs shows "No scheduled jobs yet."; Packages shows "No saved packages yet." Seed account cannot publish a package through `/account/*.json`, so the sync preserve path is covered by the unit test, not by creating a preview package.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends scheduled jobs</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `61de6e73` · **Head:** `c4f5b49f`

**Classification:** extends — package job sync no longer treats leftover manifest `enabled: false` as a disable on republish.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `jobs` | assistant | extends — existing package jobs keep a runtime-enabled schedule across publish |

### Change flow

Package publish still syncs job identity, schedule, and timezone from the manifest. An already-enabled job stays enabled when the authored default is still `false`.

```mermaid
sequenceDiagram
	actor Operator
	participant packageRegistry as package-registry
	participant jobs as jobs
	participant jobsWorker as jobs-worker
	Operator->>jobs: job_update or package resume enables sweep
	Note over jobs: D1 jobs.enabled = true
	Operator->>packageRegistry: publish package (codemod / source edit)
	packageRegistry->>jobs: syncPackageJobsForPackage
	jobs-->>jobs: keep enabled when existing job is already on
	jobs-->>jobsWorker: scheduler state unchanged
```

### Before / after

```text
before: existing.enabled=true + manifest.enabled=false → job disabled
after:  existing.enabled=true + manifest.enabled=false → job stays enabled
after:  existing.enabled=false + manifest.enabled=true  → job turns on
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-874f30bb-f863-4298-9019-e24814487d4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-874f30bb-f863-4298-9019-e24814487d4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Existing package jobs that are already enabled remain enabled when a package is republished with `enabled: false`.
  - New jobs continue to use the manifest’s `enabled` setting, defaulting to enabled when unspecified.
  - Preserved scheduled run times during package job synchronization.

- **Documentation**
  - Clarified how job enablement behaves during package publishing and republishing.
  - Documented supported ways to disable an active job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->