### PR TITLE
fix(app-ui): tolerate blocked sessionStorage in scroll restoration

### DIFF
--- a/packages/worker/client/scroll-restoration.tsx
+++ b/packages/worker/client/scroll-restoration.tsx
@@ -15,6 +15,10 @@ import {
 	type ScrollPosition,
 	type ScrollRestorationTarget,
 } from './router-scroll-state.ts'
+import {
+	getSessionStorageItem,
+	setSessionStorageItem,
+} from './session-storage-access.ts'
 
 const savedScrollPositions = new Map<string, ScrollPosition>()
 let positionsLoaded = false
@@ -22,35 +26,27 @@ let restoreScrollRequestId = 0
 let restoreInProgress = false
 
 function loadSavedScrollPositions() {
-	if (positionsLoaded || typeof sessionStorage === 'undefined') return
+	if (positionsLoaded) return
 	positionsLoaded = true
-	try {
-		const positions = parseSavedScrollPositions(
-			sessionStorage.getItem(scrollRestorationStorageKey),
-		)
-		for (const [key, y] of Object.entries(positions)) {
-			savedScrollPositions.set(key, { x: 0, y })
-		}
-	} catch {
-		// Session storage may be unavailable in private modes; scroll still works
-		// for the current in-memory session.
+	// Firefox can throw SecurityError on sessionStorage *access* (not only
+	// getItem) when storage is blocked — keep the probe inside the helper.
+	const positions = parseSavedScrollPositions(
+		getSessionStorageItem(scrollRestorationStorageKey),
+	)
+	for (const [key, y] of Object.entries(positions)) {
+		savedScrollPositions.set(key, { x: 0, y })
 	}
 }
 
 function persistSavedScrollPositions() {
-	if (typeof sessionStorage === 'undefined') return
-	try {
-		const positions: Record<string, number> = {}
-		for (const [key, position] of savedScrollPositions) {
-			positions[key] = position.y
-		}
-		sessionStorage.setItem(
-			scrollRestorationStorageKey,
-			serializeSavedScrollPositions(positions),
-		)
-	} catch {
-		// Ignore quota and privacy-mode storage failures.
+	const positions: Record<string, number> = {}
+	for (const [key, position] of savedScrollPositions) {
+		positions[key] = position.y
 	}
+	setSessionStorageItem(
+		scrollRestorationStorageKey,
+		serializeSavedScrollPositions(positions),
+	)
 }
 
 function saveWindowScrollPosition() {

--- a/packages/worker/client/session-storage-access.node.test.ts
+++ b/packages/worker/client/session-storage-access.node.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test } from 'vitest'
+import {
+	getSessionStorageItem,
+	setSessionStorageItem,
+} from './session-storage-access.ts'
+
+const originalDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'sessionStorage',
+)
+
+afterEach(() => {
+	if (originalDescriptor) {
+		Object.defineProperty(globalThis, 'sessionStorage', originalDescriptor)
+	} else {
+		Reflect.deleteProperty(globalThis, 'sessionStorage')
+	}
+})
+
+function installThrowingSessionStorage() {
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		configurable: true,
+		enumerable: true,
+		get() {
+			throw new DOMException('The operation is insecure.', 'SecurityError')
+		},
+	})
+}
+
+test('getSessionStorageItem returns null when sessionStorage access throws SecurityError', () => {
+	installThrowingSessionStorage()
+	expect(getSessionStorageItem('kody:router-scroll-positions')).toBeNull()
+})
+
+test('setSessionStorageItem returns false when sessionStorage access throws SecurityError', () => {
+	installThrowingSessionStorage()
+	expect(setSessionStorageItem('kody:router-scroll-positions', '{}')).toBe(
+		false,
+	)
+})
+
+test('getSessionStorageItem and setSessionStorageItem round-trip when storage works', () => {
+	const store = new Map<string, string>()
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		configurable: true,
+		enumerable: true,
+		value: {
+			getItem(key: string) {
+				return store.get(key) ?? null
+			},
+			setItem(key: string, value: string) {
+				store.set(key, value)
+			},
+		},
+	})
+
+	expect(setSessionStorageItem('kody:test', '{"a":1}')).toBe(true)
+	expect(getSessionStorageItem('kody:test')).toBe('{"a":1}')
+})

--- a/packages/worker/client/session-storage-access.ts
+++ b/packages/worker/client/session-storage-access.ts
@@ -1,0 +1,26 @@
+/**
+ * Safe sessionStorage accessors.
+ *
+ * Firefox throws `SecurityError: The operation is insecure.` when storage is
+ * blocked (tracking protection / cookie policy) — including for
+ * `typeof sessionStorage` and property access, not only getItem/setItem.
+ * Callers must never probe sessionStorage outside a try; these helpers keep
+ * that guard in one place (KODY-CLOUDFLARE-5Q).
+ */
+
+export function getSessionStorageItem(key: string): string | null {
+	try {
+		return sessionStorage.getItem(key)
+	} catch {
+		return null
+	}
+}
+
+export function setSessionStorageItem(key: string, value: string): boolean {
+	try {
+		sessionStorage.setItem(key, value)
+		return true
+	} catch {
+		return false
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Firefox `SecurityError: The operation is insecure.` from aborting scroll-restoration mount when sessionStorage is blocked (KODY-CLOUDFLARE-5Q).

## Summary

- Root cause: `loadSavedScrollPositions` probed `typeof sessionStorage` **outside** its try/catch. Firefox throws `SecurityError` on storage *access* under tracking protection / blocked cookies, so Remix component mount failed during hydrate on `https://kody.codes/`.
- Fix: route all scroll-position reads/writes through `getSessionStorageItem` / `setSessionStorageItem`, which catch access failures and fall back to in-memory-only restoration.
- Unit tests simulate a throwing `sessionStorage` getter matching the production signature.

## Testing

- `npx vitest run --project node-unit packages/worker/client/session-storage-access.node.test.ts` — 3/3 pass
- Local `npm run validate`: format/lint/typecheck green; unrelated MCP/workers timeout flakes (mock Cloudflare / worker ready) — relying on CI Validate for the full gate

## Sentry

- Issue: [KODY-CLOUDFLARE-5Q](https://kent-c-dodds-tech-llc.sentry.io/issues/7684350100/) (1 event, Firefox 154, handled `SecurityError` from `ScrollRestoration` → `loadSavedScrollPositions`)
- No sibling issues share this root cause (Navigation API / scheduleUpdate / OAuth siblings are unrelated)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk — isolated client bugfix)</summary>

**Mode:** recap · **Base:** `main` · **Head:** `04a472e9`

**Classification:** composes — no new primitives; scroll restoration uses a small safe-storage helper so blocked sessionStorage cannot throw during mount.

### Primitives touched

| Primitive | Group    | Impact                                                                 |
| --------- | -------- | ---------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — client scroll restoration probes sessionStorage via helpers |

### Change path

```mermaid
sequenceDiagram
	participant Browser as Firefox (storage blocked)
	participant Scroll as ScrollRestoration
	participant Storage as session-storage-access
	participant Map as in-memory positions
	Browser->>Scroll: hydrate / mount
	Scroll->>Storage: getSessionStorageItem(key)
	Storage--xBrowser: SecurityError on sessionStorage access
	Storage-->>Scroll: null (caught)
	Scroll->>Map: start empty; restore still works in-session
	Note over Scroll,Map: persist uses setSessionStorageItem (same catch)
```

### Before / after

| Case | Before | After |
| --- | --- | --- |
| Normal browsers | load/persist via sessionStorage | unchanged |
| Firefox with blocked storage | SecurityError during mount (Sentry) | null/false from helpers; in-memory scroll only |

### Invariants

No change to per-user isolation, auth, or storage backends — browser sessionStorage only.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5730f21a-8d9e-4c16-993c-aac3f3c1b3cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5730f21a-8d9e-4c16-993c-aac3f3c1b3cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scroll position restoration when browser session storage is unavailable or access is restricted.
  - Prevented storage-related errors from disrupting normal page behavior.
  - Preserved in-memory scroll positions during session storage failures.

- **Tests**
  - Added coverage for successful storage access, denied access, and storage state cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->