### PR TITLE
Stop stacking timed-out storage estimate RPCs; retry the job occurrence

### DIFF
--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -570,9 +570,15 @@ Rules:
      (bounded staleness, same trade-off as peers). Each live estimate read waits
      at most ~2s via `Promise.race` and is retried with backoff
      (`storageEstimateReadRetryDelaysMs`; a single 150ms retry lost to transient
-     per-bucket DO read failures in production) before failing closed for the
-     caller; the underlying DO RPC is not cancelled if the runtime keeps it
-     running. A cron lane (`storage_bucket_estimate_backfill`,
+     per-bucket DO read _rejections_ in production) before failing closed for
+     the caller. The underlying DO RPC is not cancelled if the runtime keeps it
+     running, so a timeout does **not** open a second stub call to the same
+     `storageId` — retries keep waiting on the in-flight promise. Fast rejects
+     still start a new RPC after backoff. A scheduled job that still fails
+     closed treats this as a transient occurrence error: the claimed run stays
+     `running` so the scheduler can abandon it and retry the same `scheduledFor`
+     instead of finishing a terminal error that idempotency would replay. A cron
+     lane (`storage_bucket_estimate_backfill`,
      `packages/worker/src/storage-buckets/estimate-backfill.ts`) sweeps
      inventory rows without a stored estimate in bounded batches (failed probes
      stay unmeasured and are retried on later sweeps) so freshly migrated

--- a/packages/worker/src/jobs/execution-safety.node.test.ts
+++ b/packages/worker/src/jobs/execution-safety.node.test.ts
@@ -185,6 +185,13 @@ test('transient platform failures back off the same occurrence while permanent o
 			),
 		),
 	).toBe(true)
+	expect(
+		isTransientJobExecutionError(
+			new Error(
+				'Unable to verify the storage byte entitlement because the bucket estimate for storageId "package:1" could not be read after 4 attempts.',
+			),
+		),
+	).toBe(true)
 	expect(isTransientJobExecutionError(new Error('user code failed'))).toBe(
 		false,
 	)

--- a/packages/worker/src/jobs/execution-safety.ts
+++ b/packages/worker/src/jobs/execution-safety.ts
@@ -1,6 +1,7 @@
 import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
 import { isRetryableD1LockError } from '#worker/d1-retry.ts'
 import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
+import { isStorageEstimateReadError } from '#worker/storage-estimate-error.ts'
 import {
 	type RunRecord,
 	type RunRecordHandle,
@@ -28,7 +29,8 @@ export function isTransientJobExecutionError(error: unknown) {
 	return (
 		error instanceof TransientJobExecutionError ||
 		isRetryableD1LockError(error) ||
-		errorCauseChainIncludes(error, isDurableObjectIsolateResetMessage)
+		errorCauseChainIncludes(error, isDurableObjectIsolateResetMessage) ||
+		isStorageEstimateReadError(error)
 	)
 }
 

--- a/packages/worker/src/jobs/service.node.test.ts
+++ b/packages/worker/src/jobs/service.node.test.ts
@@ -38,6 +38,7 @@ import {
 	type PersistedJobCallerContext,
 } from './types.ts'
 import { TransientJobExecutionError } from './execution-safety.ts'
+import { createStorageEstimateReadError } from '#worker/storage-estimate-error.ts'
 
 const repoMockModule = vi.hoisted(() => ({
 	ensureEntitySource: vi.fn(),
@@ -4734,6 +4735,111 @@ test('executeJobOnce failure modes workflow', async () => {
 		} finally {
 			executeSpy.mockRestore()
 		}
+	}
+})
+
+test('executeJobOnce retries a claimed storage-estimate failure and surfaces it on run-now', async () => {
+	silenceIncidentalRuntimeWarnings()
+	const db = createDatabase()
+	const env = createJobServiceTestEnv({
+		APP_DB: db,
+		CLOUDFLARE_ACCOUNT_ID: 'acct-test',
+		CLOUDFLARE_API_TOKEN: 'token-test',
+		BUNDLE_ARTIFACTS_KV: createBundleArtifactsKv(),
+		LOADER: {} as WorkerLoader,
+		REPO_SESSION: {} as DurableObjectNamespace,
+		STORAGE_RUNNER: createStorageRunnerBinding(),
+	})
+	mockRepoPersistence()
+	const callerContext = createBaseCallerContext()
+	const jobView = await createJob({
+		env,
+		callerContext,
+		body: {
+			name: 'Estimate retry job',
+			code: 'export default async () => ({ ok: true })',
+			schedule: {
+				type: 'interval',
+				every: '15m',
+			},
+		},
+	})
+	await insertPublishedEntitySource({
+		db,
+		env,
+		userId: callerContext.user.userId,
+		sourceId: jobView.sourceId,
+		entityKind: 'job',
+		entityId: jobView.id,
+		publishedCommit: 'published-commit-estimate',
+		manifestPath: 'kody.json',
+		files: {
+			'kody.json': JSON.stringify({
+				version: 1,
+				kind: 'job',
+				title: 'Estimate retry job',
+				description: 'Retries storage estimate misses',
+				sourceRoot: '/',
+				entrypoint: 'src/job.ts',
+			}),
+			'src/job.ts': 'export default async () => ({ ok: true })',
+		},
+	})
+	const estimateError = createStorageEstimateReadError({
+		storageId: 'package:estimate-target',
+		attempts: 4,
+		cause: new Error('Storage estimate read timed out after 2000ms.'),
+	})
+	const executeSpy = vi
+		.spyOn(
+			await import('#mcp/run-kody-registry.ts'),
+			'runBundledModuleWithRegistry',
+		)
+		.mockResolvedValue({
+			result: undefined,
+			error: estimateError.message,
+			logs: [],
+		})
+	const row = await (
+		await import('@kody-internal/shared/jobs/repo.ts')
+	).getJobRowById(db, callerContext.user.userId, jobView.id)
+	if (!row) {
+		throw new Error('Expected created job row.')
+	}
+
+	try {
+		const runNow = await executeJobOnce({
+			env,
+			job: row.record,
+			callerContext,
+		})
+		expect(runNow.execution).toEqual({
+			ok: false,
+			error: estimateError.message,
+			logs: [],
+		})
+
+		await expect(
+			executeJobOnce({
+				env,
+				job: row.record,
+				callerContext,
+				runRecordHandle: {
+					id: 'run-estimate-claimed',
+					userId: callerContext.user.userId,
+					startedAt: '2026-08-21T14:40:00.000Z',
+					persistence: 'eager',
+					context: {
+						surface: 'job',
+						name: row.record.name,
+						jobId: row.record.id,
+						storageId: row.record.storageId,
+					},
+				},
+			}),
+		).rejects.toBeInstanceOf(TransientJobExecutionError)
+	} finally {
+		executeSpy.mockRestore()
 	}
 })
 

--- a/packages/worker/src/jobs/service.ts
+++ b/packages/worker/src/jobs/service.ts
@@ -47,6 +47,7 @@ import {
 } from './types.ts'
 import { createJobStorageId, storageRunnerRpc } from '#worker/storage-runner.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
+import { isStorageEstimateReadError } from '#worker/storage-estimate-error.ts'
 import {
 	assertWithinEntitlement,
 	consumeDailyEntitlement,
@@ -1304,6 +1305,18 @@ export async function executeJobOnce(input: {
 						idempotencyKey: input.idempotencyKey,
 					})
 					if (result.error) {
+						const errorMessage =
+							typeof result.error === 'string'
+								? result.error
+								: formatJobError(result.error)
+						if (
+							input.runRecordHandle &&
+							isStorageEstimateReadError(result.error)
+						) {
+							throw new TransientJobExecutionError(errorMessage, {
+								cause: result.error,
+							})
+						}
 						outcome = 'error'
 					}
 					execution = result.error
@@ -1325,6 +1338,11 @@ export async function executeJobOnce(input: {
 			} catch (error) {
 				if (error instanceof TransientJobExecutionError) {
 					throw error
+				}
+				if (input.runRecordHandle && isStorageEstimateReadError(error)) {
+					throw new TransientJobExecutionError(formatJobError(error), {
+						cause: error,
+					})
 				}
 				outcome = 'error'
 				execution = {

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2651,6 +2651,82 @@ test('runBundledModuleWithRegistry finishes execute run records on failure only'
 	}
 })
 
+test('runBundledModuleWithRegistry leaves claimed job storage-estimate failures running', async () => {
+	silenceIncidentalRuntimeWarnings()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://heykody.dev',
+		user: {
+			userId: 'user-job-estimate',
+			email: 'job-estimate@example.com',
+			displayName: 'Job Estimate',
+		},
+	})
+	const bundle = {
+		mainModule: 'entry.js',
+		modules: {
+			'entry.js': 'export default async () => "ok"',
+		},
+	}
+	const handle = {
+		id: 'run-job-estimate-1',
+		userId: 'user-job-estimate',
+		startedAt: '2026-08-21T14:40:00.000Z',
+		persistence: 'eager' as const,
+		context: {
+			surface: 'job' as const,
+			name: 'sweep',
+			jobId: 'package-job:estimate:sweep',
+			metadata: {},
+		},
+	}
+	const runRecords = await import('#worker/run-records/service.ts')
+	const finishSpy = vi
+		.spyOn(runRecords, 'finishRunRecord')
+		.mockResolvedValue(true)
+	const { createStorageEstimateReadError } =
+		await import('#worker/storage-estimate-error.ts')
+	const estimateError = createStorageEstimateReadError({
+		storageId: 'package:estimate-target',
+		attempts: 4,
+		cause: new Error('Storage estimate read timed out after 2000ms.'),
+	})
+	const createExecuteExecutorSpy = vi
+		.spyOn(await import('#mcp/executor.ts'), 'createExecuteExecutor')
+		.mockReturnValue({
+			async execute() {
+				return {
+					result: undefined,
+					error: estimateError.message,
+					logs: [],
+				}
+			},
+		} as never)
+
+	try {
+		const claimed = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+				runRecord: {
+					surface: 'job',
+					name: 'sweep',
+					jobId: 'package-job:estimate:sweep',
+				},
+				runRecordHandle: handle,
+			},
+		)
+		expect(claimed.error).toBe(estimateError.message)
+		expect(finishSpy).not.toHaveBeenCalled()
+	} finally {
+		finishSpy.mockRestore()
+		createExecuteExecutorSpy.mockRestore()
+	}
+})
+
 test('runBundledModuleWithRegistry retries transient Durable Object isolate resets', async () => {
 	silenceIncidentalRuntimeWarnings()
 	const env = {} as Env

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -74,6 +74,7 @@ import {
 import { runWithTransientDurableObjectResetRetry } from '#worker/durable-object-reset-retry.ts'
 import { evaluationHasHostMediatedSideEffects } from '#mcp/evaluation-side-effects.ts'
 import { beginRunRecord, finishRunRecord } from '#worker/run-records/service.ts'
+import { isStorageEstimateReadError } from '#worker/storage-estimate-error.ts'
 import {
 	type RunRecordContext,
 	type RunRecordHandle,
@@ -1109,6 +1110,19 @@ ${runtimeHelperRuntimePropertySource}
 						error: secretRedactor.redactErrorMessage(rewrittenMessage),
 					}
 				: sanitizedResult
+			const callerOwnsScheduledJobRun =
+				options?.runRecordHandle != null &&
+				(options.runRecord?.surface === 'job' ||
+					options.runRecordHandle.context.surface === 'job')
+			if (
+				callerOwnsScheduledJobRun &&
+				isStorageEstimateReadError(finalResult.error)
+			) {
+				// Leave the claimed run `running` so the job scheduler can
+				// abandon it and retry the same scheduledFor. Finishing as
+				// error would make the idempotency replay permanent.
+				return withRunId(finalResult)
+			}
 			await finishObservedRun({
 				status: 'error',
 				logs: finalResult.logs ?? [],

--- a/packages/worker/src/storage-estimate-error.ts
+++ b/packages/worker/src/storage-estimate-error.ts
@@ -1,3 +1,5 @@
+import { errorCauseChainIncludes } from '@kody-internal/shared/error-message.ts'
+
 // Deliberately unanchored: transport layers can prefix/wrap this sentence, and
 // execute error taxonomy must still recover the storage id and attempt count.
 const storageEstimateReadErrorPattern =
@@ -41,4 +43,11 @@ export function parseStorageEstimateReadErrorMessage(
 	} catch {
 		return null
 	}
+}
+
+export function isStorageEstimateReadError(error: unknown) {
+	return errorCauseChainIncludes(
+		error,
+		(message) => parseStorageEstimateReadErrorMessage(message) != null,
+	)
 }

--- a/packages/worker/src/storage-runner.entitlement.node.test.ts
+++ b/packages/worker/src/storage-runner.entitlement.node.test.ts
@@ -1,7 +1,10 @@
 import { expect, test, vi } from 'vitest'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
 import { planLimits } from '#universal/plans.ts'
-import { storageEstimateReadRetryDelaysMs } from '#worker/storage-runner.ts'
+import {
+	storageEstimateReadRetryDelaysMs,
+	storageEstimateReadTimeoutMs,
+} from '#worker/storage-runner.ts'
 import type * as EntitlementsService from '#worker/entitlements/service.ts'
 
 const totalRetryDelayMs = storageEstimateReadRetryDelaysMs.reduce(
@@ -198,6 +201,68 @@ test('assertStorageRunnerWriteWithinEntitlement retries estimate reads with back
 	expect(callCounts.get('fast-fail')).toBe(2)
 	expect(callCounts.get('slow-ok')).toBe(1)
 	expect(maxInFlight).toBe(chunkStorageIds.length)
+
+	// A late success after the per-attempt timeout must reuse the in-flight
+	// RPC. Opening a second stub call queues behind the abandoned one on the
+	// single-threaded DO and is how a 2.5s wake becomes four stacked timeouts.
+	mockModule.listUserStorageBucketEstimates.mockResolvedValue([
+		{ storageId: 'slow-wake', kind: 'unknown', estimatedBytes: null },
+	])
+	let slowWakeCalls = 0
+	const slowWake = () => {
+		slowWakeCalls += 1
+		return new Promise<{ estimatedBytes: number }>((resolve) => {
+			setTimeout(() => {
+				resolve({ estimatedBytes: 48 })
+			}, storageEstimateReadTimeoutMs + 500)
+		})
+	}
+	vi.useFakeTimers()
+	try {
+		const assertion = assertStorageRunnerWriteWithinEntitlement({
+			env: createEstimateEnv(() => slowWake()),
+			userId: 'user-1',
+			email: null,
+			storageId: 'slow-wake',
+			requested: 1,
+		})
+		await vi.advanceTimersByTimeAsync(
+			storageEstimateReadTimeoutMs + storageEstimateReadRetryDelaysMs[0] + 500,
+		)
+		await expect(assertion).resolves.toBeUndefined()
+		expect(slowWakeCalls).toBe(1)
+	} finally {
+		vi.useRealTimers()
+	}
+
+	const hungRead = () => new Promise<{ estimatedBytes: number }>(() => {})
+	let hungCalls = 0
+	vi.useFakeTimers()
+	try {
+		const assertion = assertStorageRunnerWriteWithinEntitlement({
+			env: createEstimateEnv(() => {
+				hungCalls += 1
+				return hungRead()
+			}),
+			userId: 'user-1',
+			email: null,
+			storageId: 'slow-wake',
+			requested: 1,
+		})
+		// Attach before advancing timers so the rejection is not unhandled.
+		// oxlint-disable-next-line vitest/valid-expect
+		const expectation = expect(assertion).rejects.toThrow(
+			`Unable to verify the storage byte entitlement because the bucket estimate for storageId "slow-wake" could not be read after ${maxEstimateReadAttempts} attempts.`,
+		)
+		await vi.advanceTimersByTimeAsync(
+			totalRetryDelayMs +
+				storageEstimateReadTimeoutMs * maxEstimateReadAttempts,
+		)
+		await expectation
+		expect(hungCalls).toBe(1)
+	} finally {
+		vi.useRealTimers()
+	}
 })
 
 // Regression for the 2026-07-30 production incidents: a tiny first write of a

--- a/packages/worker/src/storage-runner.entitlement.node.test.ts
+++ b/packages/worker/src/storage-runner.entitlement.node.test.ts
@@ -205,6 +205,9 @@ test('assertStorageRunnerWriteWithinEntitlement retries estimate reads with back
 	// A late success after the per-attempt timeout must reuse the in-flight
 	// RPC. Opening a second stub call queues behind the abandoned one on the
 	// single-threaded DO and is how a 2.5s wake becomes four stacked timeouts.
+	// Fulfill during the first backoff (timeout + 50ms < 150ms) is the
+	// CodeRabbit case: dropping a fulfilled promise from the map would start
+	// a second RPC.
 	mockModule.listUserStorageBucketEstimates.mockResolvedValue([
 		{ storageId: 'slow-wake', kind: 'unknown', estimatedBytes: null },
 	])
@@ -214,7 +217,7 @@ test('assertStorageRunnerWriteWithinEntitlement retries estimate reads with back
 		return new Promise<{ estimatedBytes: number }>((resolve) => {
 			setTimeout(() => {
 				resolve({ estimatedBytes: 48 })
-			}, storageEstimateReadTimeoutMs + 500)
+			}, storageEstimateReadTimeoutMs + 50)
 		})
 	}
 	vi.useFakeTimers()
@@ -227,7 +230,7 @@ test('assertStorageRunnerWriteWithinEntitlement retries estimate reads with back
 			requested: 1,
 		})
 		await vi.advanceTimersByTimeAsync(
-			storageEstimateReadTimeoutMs + storageEstimateReadRetryDelaysMs[0] + 500,
+			storageEstimateReadTimeoutMs + storageEstimateReadRetryDelaysMs[0],
 		)
 		await expect(assertion).resolves.toBeUndefined()
 		expect(slowWakeCalls).toBe(1)

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -761,12 +761,17 @@ async function readStorageEstimateChunkWithRetry(input: {
 					)
 				}
 			}
-		})().finally(() => {
+		})()
+		// Keep a fulfilled read in the map until this baseline returns so a
+		// timeout-then-success during backoff is reused instead of opening a
+		// second stub call. Only rejected RPCs are dropped so the next
+		// attempt can start a new one.
+		inflightReads.set(bucket.storageId, rpc)
+		void rpc.catch(() => {
 			if (inflightReads.get(bucket.storageId) === rpc) {
 				inflightReads.delete(bucket.storageId)
 			}
 		})
-		inflightReads.set(bucket.storageId, rpc)
 		return rpc
 	}
 	const readOne = (bucket: { storageId: string; kind: StorageBucketKind }) =>

--- a/packages/worker/src/storage-runner.ts
+++ b/packages/worker/src/storage-runner.ts
@@ -29,13 +29,19 @@ const maxConcurrentStorageEstimateReads = 16
  * Entitlement baselines only probe the write-target bucket plus any bucket
  * that has never been measured, so the probe set is small enough to afford
  * several attempts: production showed a single 150ms retry was not enough to
- * ride out transient per-bucket DO estimate-read failures, which used to
- * block tiny writes outright.
+ * ride out transient per-bucket DO estimate-read *rejections*.
+ *
+ * A timeout does not start a second RPC to the same storageId. The underlying
+ * stub call is not cancelled; a new call would queue behind it on the
+ * single-threaded DO and turn a slow wake into four stacked timeouts.
+ * Timed-out attempts keep waiting on the in-flight promise. Fast rejects
+ * still open a new RPC after backoff.
  */
 export const storageEstimateReadRetryDelaysMs = [150, 600, 2400] as const
 /**
- * Bound each StorageRunner `getEstimatedBytes` RPC so one hung DO cannot own
- * the whole sandbox deadline (~90s). Fail closed after this budget.
+ * Bound each StorageRunner `getEstimatedBytes` wait so one hung DO cannot own
+ * the whole sandbox deadline (~90s). Fail closed after this budget per
+ * attempt; retries of a timed-out storageId reuse the same RPC.
  */
 export const storageEstimateReadTimeoutMs = 2_000
 /**
@@ -725,8 +731,14 @@ async function readStorageEstimateChunkWithRetry(input: {
 }): Promise<Array<StorageEstimateResult>> {
 	const retryDelaysMs = input.retryDelaysMs ?? storageEstimateReadRetryDelaysMs
 	const maxAttempts = retryDelaysMs.length + 1
-	const readOne = (bucket: { storageId: string; kind: StorageBucketKind }) =>
-		withStorageEstimateReadTimeout(() => {
+	const inflightReads = new Map<string, Promise<StorageEstimateResult>>()
+	const startOrReuseRead = (bucket: {
+		storageId: string
+		kind: StorageBucketKind
+	}) => {
+		const existing = inflightReads.get(bucket.storageId)
+		if (existing) return existing
+		const rpc = (() => {
 			switch (bucket.kind) {
 				case 'repo_session':
 					return repoSessionRpc(
@@ -749,7 +761,19 @@ async function readStorageEstimateChunkWithRetry(input: {
 					)
 				}
 			}
-		}, bucket.storageId)
+		})().finally(() => {
+			if (inflightReads.get(bucket.storageId) === rpc) {
+				inflightReads.delete(bucket.storageId)
+			}
+		})
+		inflightReads.set(bucket.storageId, rpc)
+		return rpc
+	}
+	const readOne = (bucket: { storageId: string; kind: StorageBucketKind }) =>
+		withStorageEstimateReadTimeout(
+			() => startOrReuseRead(bucket),
+			bucket.storageId,
+		)
 
 	const values: Array<StorageEstimateResult | undefined> = Array.from({
 		length: input.buckets.length,
@@ -794,9 +818,20 @@ async function readStorageEstimateChunkWithRetry(input: {
 			})
 		}
 		pendingIndexes = failedIndexes
-		await new Promise<void>((resolve) => {
-			setTimeout(resolve, retryDelaysMs[attempt - 1] ?? 0)
-		})
+		const pendingReads = failedIndexes
+			.map((index) => {
+				const storageId = input.buckets[index]?.storageId
+				return storageId ? inflightReads.get(storageId) : undefined
+			})
+			.filter((value): value is Promise<StorageEstimateResult> => value != null)
+		await Promise.race([
+			new Promise<void>((resolve) => {
+				setTimeout(resolve, retryDelaysMs[attempt - 1] ?? 0)
+			}),
+			pendingReads.length > 0
+				? Promise.allSettled(pendingReads).then(() => undefined)
+				: new Promise<void>(() => {}),
+		])
 	}
 	return values.map((value, index) => {
 		if (value === undefined) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

A 15m `status-incident-triage` sweep failed closed after four `getEstimatedBytes` timeouts on a healthy 40KB package bucket (664MB of 100GB used). The measurement itself is a local SQLite `databaseSize` read. The unreliability is the Worker→StorageRunner RPC, and the retry policy made a miss worse by opening new stub calls behind abandoned ones. This change makes the probe reuse the in-flight RPC, then retries the scheduled occurrence if it still fails — no stale-estimate fallback.

## Summary

- Timed-out estimate reads keep waiting on the same Durable Object stub call. Fast rejects still open a new RPC after backoff. Fulfilled reads stay reusable if they land during backoff.
- Claimed scheduled-job runs that hit `storage_estimate_unavailable` stay `running` so the scheduler can abandon and retry the same `scheduledFor`. Manual run-now still surfaces the error.
- Execute / unclaimed paths still finish the run as an error (unchanged user-visible retry hint).

## Testing

- `npx vitest run` on `storage-runner.entitlement.node.test.ts`, `execution-safety.node.test.ts`, `jobs/service.node.test.ts`, and `run-kody-registry.node.test.ts`, including:
  - a fulfill 50ms after the 2s timeout (inside the first backoff) uses one RPC
  - a hung RPC uses one RPC and still fails closed
  - claimed job storage-estimate failures do not call `finishRunRecord`
  - `executeJobOnce` throws `TransientJobExecutionError` when a handle is present and returns the error on run-now
- Preview (seeded `user-me` on https://kody-pr-1627.kody-a99.workers.dev): usage `storage_bytes` 0/16MiB, empty jobs, empty activity

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `21293004` · **Head:** `527d1efa`

**Classification:** extends — Durable Object estimate reads no longer stack timed-out RPCs; scheduled jobs treat a remaining miss as a retryable occurrence.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `durable-storage` | assistant | extends — one in-flight `getEstimatedBytes` per `storageId`; fulfilled reads stay reusable across timeout retries |
| `jobs` | assistant | extends — claimed storage-estimate failures abandon and retry `scheduledFor` |
| `capabilities-execute` | runtime | extends — claimed job runs skip `finishRunRecord` on this error so idempotency cannot replay a terminal failure |
| `mcp-server` | surfaces | composes — registry test only |

### Change flow

A mutating `packageStorage().sql()` still live-probes the write-target bucket. A timeout now waits on the same RPC (including a fulfill during backoff); if the probe still fails, a scheduled job retries the occurrence instead of advancing the interval.

```mermaid
sequenceDiagram
	actor Sweep as scheduled job
	participant capabilitiesExecute as capabilities-execute
	participant durableStorage as durable-storage
	participant jobs as jobs
	Sweep->>capabilitiesExecute: first mutating packageStorage().sql()
	capabilitiesExecute->>durableStorage: getEstimatedBytes (write-target)
	Note over durableStorage: timeout waits on the same in-flight RPC
	alt probe succeeds
		durableStorage-->>capabilitiesExecute: estimatedBytes
		capabilitiesExecute-->>Sweep: write proceeds
	else still unreadable after retries
		capabilitiesExecute-->>jobs: return error, run stays running
		jobs->>jobs: abandon claimed run and retry scheduledFor
	end
```

### Invariants

Per-user isolation is unchanged: estimate RPCs still use `storageRunnerDurableObjectName(userId, storageId)`. Fail-closed remains when no in-flight read produces a value. Stored D1 estimates are not used as a fallback.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11b1a4f8-37ad-4097-aac3-d34136b2bee6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11b1a4f8-37ad-4097-aac3-d34136b2bee6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage usage checks to avoid duplicate requests when an earlier check is still in progress.
  - Fast failures now retry promptly, while slow or unavailable checks time out safely.
  - Scheduled jobs affected by temporary storage-check failures remain retryable instead of being marked as permanently failed.
  - Improved handling of storage verification errors so transient issues do not incorrectly finalize job runs.
- **Documentation**
  - Clarified storage quota checks, retry behavior, timeouts, and scheduled-job recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->