### PR TITLE
Wait for Remix hydration before two-factor e2e clicks

### DIFF
--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -103,6 +103,10 @@ handled by the static asset fetcher in `packages/worker/src/index.ts`.
 - For async actions, wait on the UI result, not arbitrary timeouts.
 - Assert important intermediate states as part of the same journey that causes
   them instead of creating isolated loading-state or transition-state tests.
+- After `page.goto`, wait for client hydration before clicking JS-only
+  controls (`waitForClientHydration` in `e2e/playwright-utils.ts`). Boot
+  preloads the route chunk before Remix `run()`, so SSR headings are visible
+  while `on('click')` handlers are still unbound.
 - For client-router regressions, you may set a `window` marker before clicking a
   link and assert it survives navigation to prove there was no full document
   reload.

--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -103,10 +103,10 @@ handled by the static asset fetcher in `packages/worker/src/index.ts`.
 - For async actions, wait on the UI result, not arbitrary timeouts.
 - Assert important intermediate states as part of the same journey that causes
   them instead of creating isolated loading-state or transition-state tests.
-- After `page.goto`, wait for client hydration before clicking JS-only
-  controls (`waitForClientHydration` in `e2e/playwright-utils.ts`). Boot
-  preloads the route chunk before Remix `run()`, so SSR headings are visible
-  while `on('click')` handlers are still unbound.
+- After `page.goto`, wait for client hydration before clicking JS-only controls
+  (`waitForClientHydration` in `e2e/playwright-utils.ts`). Boot preloads the
+  route chunk before Remix `run()`, so SSR headings are visible while
+  `on('click')` handlers are still unbound.
 - For client-router regressions, you may set a `window` marker before clicking a
   link and assert it survives navigation to prove there was no full document
   reload.

--- a/e2e/playwright-utils.ts
+++ b/e2e/playwright-utils.ts
@@ -1,4 +1,9 @@
-import { test as base, type APIRequestContext } from '@playwright/test'
+import {
+	expect,
+	test as base,
+	type APIRequestContext,
+	type Page,
+} from '@playwright/test'
 import * as setCookieParser from 'set-cookie-parser'
 import {
 	assignRoleInE2eDatabase,
@@ -13,6 +18,17 @@ import {
 } from './web-server-liveness.ts'
 
 export * from '@playwright/test'
+
+/**
+ * Wait until Remix client hydration has bound event handlers.
+ *
+ * `entry.tsx` preloads the route chunk before `run()`, so SSR headings and
+ * buttons are visible while `on('click')` / `on('submit')` mixins are still
+ * unbound. Clicking a `type="button"` control in that gap is a silent no-op.
+ */
+export async function waitForClientHydration(page: Page) {
+	await expect(page.locator('html')).toHaveAttribute('data-hydrated', 'true')
+}
 
 const authRetryBudgetMs = 15_000
 const authRetryPauseMs = 250

--- a/e2e/two-factor.spec.ts
+++ b/e2e/two-factor.spec.ts
@@ -1,5 +1,5 @@
 import { generateTOTP } from '@epic-web/totp'
-import { expect, test } from './playwright-utils.ts'
+import { expect, test, waitForClientHydration } from './playwright-utils.ts'
 import { clearAuthRateLimitsInE2eDatabase } from './d1-utils.ts'
 
 async function currentCodeFor(secret: string) {
@@ -21,6 +21,7 @@ test('two-factor lifecycle: enable, login with code, disable', async ({
 	await login({ email: user.email, password: user.password, mode: 'login' })
 
 	await page.goto('/account/two-factor')
+	await waitForClientHydration(page)
 	await expect(
 		page.getByRole('heading', {
 			name: 'Two-factor authentication is disabled',
@@ -43,10 +44,12 @@ test('two-factor lifecycle: enable, login with code, disable', async ({
 	await page.context().clearCookies()
 	clearAuthRateLimitsInE2eDatabase()
 	await page.goto('/login')
+	await waitForClientHydration(page)
 	await page.getByLabel('Email').fill(user.email)
 	await page.getByLabel('Password').fill(user.password)
 	await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 	await expect(page).toHaveURL(/\/verify$/)
+	await waitForClientHydration(page)
 
 	clearAuthRateLimitsInE2eDatabase()
 	await page.getByLabel('Verification code').fill(await currentCodeFor(secret))
@@ -55,6 +58,7 @@ test('two-factor lifecycle: enable, login with code, disable', async ({
 	await expect(page.getByText(`Email: ${user.email}`)).toBeVisible()
 
 	await page.goto('/account/two-factor')
+	await waitForClientHydration(page)
 	await expect(
 		page.getByRole('heading', {
 			name: 'Two-factor authentication is enabled',
@@ -69,6 +73,7 @@ test('two-factor lifecycle: enable, login with code, disable', async ({
 	await page.context().clearCookies()
 	clearAuthRateLimitsInE2eDatabase()
 	await page.goto('/login')
+	await waitForClientHydration(page)
 	await page.getByLabel('Email').fill(user.email)
 	await page.getByLabel('Password').fill(user.password)
 	await page.getByRole('button', { name: 'Sign in', exact: true }).click()

--- a/packages/worker/client/entry.tsx
+++ b/packages/worker/client/entry.tsx
@@ -90,6 +90,10 @@ async function boot() {
 	})
 
 	await app.ready()
+	// Boot preloads the route chunk before `run()`, so SSR headings and
+	// buttons are visible while click handlers are still unbound. Tests wait
+	// on this marker instead of racing that gap.
+	document.documentElement.dataset.hydrated = 'true'
 }
 
 void boot().catch((error: unknown) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the daily two-factor Playwright flake: SSR headings and buttons were visible while Remix boot still preloaded the route chunk, so Enable 2FA (`type="button"`) was a silent no-op and Disable 2FA could native-submit before handlers bound.

## Summary

Clustered two Validate 🎭 E2E signals from the last 24h:

- [Validate #32431990561](https://github.com/kentcdodds/kody/actions/runs/32431990561) (`user-lifecycle-events`): deterministic `/account` light-theme axe contrast on **Delete account** (already fixed before #1620 merge by darkening `--color-danger`), plus a flaky two-factor journey.
- [Validate #32423652546](https://github.com/kentcdodds/kody/actions/runs/32423652546) (`honest-factory-copy`): attempt 1 died after a Discord OAuth callback hang + wrangler `Connection reset by peer`; attempt 2 passed with the same two-factor test marked flaky.

This PR only fixes the **shared two-factor flake** (QR heading / “disabled.” toast missing after a full `page.goto`):

- Set `html[data-hydrated="true"]` after `app.ready()` in client boot.
- Wait on that marker in `e2e/two-factor.spec.ts` before JS-only clicks.
- Document the convention in the e2e contributing notes.

Left alone (not obvious / already shipped):

- Delete-account contrast — already on `main`.
- Social-login Discord callback hang + mid-suite wrangler crash — infrastructure, no competing PR.

## Testing

- Focused Playwright: `npx playwright test e2e/two-factor.spec.ts` (local wrangler in this VM never became healthy; CI 🎭 E2E on the first commit passed).
- `oxfmt` wrap on the docs note after Static CI failed line-length only.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `21293004` · **Head:** `359039bd`

**Classification:** composes — adds a hydration-complete marker after existing Remix `app.ready()` and waits on it in the two-factor e2e journey. No primitive contract or user-facing behavior change.

### Primitives touched

| Primitive | Group    | Impact                                      |
| --------- | -------- | ------------------------------------------- |
| `app-ui`  | surfaces | composes — `data-hydrated` after `app.ready()` |

Unmatched (harness/docs only): `e2e/playwright-utils.ts`, `e2e/two-factor.spec.ts`, `docs/contributing/end-to-end-testing.md`.

### Change flow

Full document loads show SSR two-factor UI before Remix binds click/submit handlers; tests now wait for the boot marker.

```mermaid
sequenceDiagram
	actor Test as Playwright
	participant appUi as app-ui
	Test->>appUi: page.goto /account/two-factor
	Note over appUi: SSR headings visible during chunk preload
	appUi->>appUi: preloadClientRouteModules then run and app.ready
	appUi->>appUi: set html data-hydrated true
	Test->>appUi: waitForClientHydration
	Test->>appUi: click Enable 2FA or Disable 2FA
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37ed8a2d-e5d3-4a79-ade9-291633c27168?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37ed8a2d-e5d3-4a79-ade9-291633c27168&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

