### PR TITLE
fix(runtime): treat Durable Object instance-inactive closes as platform resets

### DIFF
--- a/packages/worker/src/durable-object-reset-retry.node.test.ts
+++ b/packages/worker/src/durable-object-reset-retry.node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test, vi } from 'vitest'
-import { durableObjectCodeUpdatedResetMessage } from '#worker/sentry-options.ts'
+import {
+	durableObjectCodeUpdatedResetMessage,
+	durableObjectInstanceInactiveCloseMessage,
+} from '#worker/sentry-options.ts'
 import {
 	isTransientDurableObjectResetError,
 	runWithTransientDurableObjectResetRetry,
@@ -19,6 +22,16 @@ test('transient Durable Object reset retry recovers thrown and result errors the
 			new Error('wrapped', {
 				cause: new Error(durableObjectCodeUpdatedResetMessage),
 			}),
+		),
+	).toBe(true)
+	expect(
+		isTransientDurableObjectResetError(
+			durableObjectInstanceInactiveCloseMessage,
+		),
+	).toBe(true)
+	expect(
+		isTransientDurableObjectResetError(
+			new Error(durableObjectInstanceInactiveCloseMessage),
 		),
 	).toBe(true)
 	expect(

--- a/packages/worker/src/jobs/execution-safety.node.test.ts
+++ b/packages/worker/src/jobs/execution-safety.node.test.ts
@@ -185,6 +185,13 @@ test('transient platform failures back off the same occurrence while permanent o
 			),
 		),
 	).toBe(true)
+	expect(
+		isTransientJobExecutionError(
+			new Error(
+				'Connection closed: this Durable Object instance is no longer active. Reconnect or retry the request.',
+			),
+		),
+	).toBe(true)
 	expect(isTransientJobExecutionError(new Error('user code failed'))).toBe(
 		false,
 	)

--- a/packages/worker/src/package-invocations/service.node.test.ts
+++ b/packages/worker/src/package-invocations/service.node.test.ts
@@ -2418,6 +2418,33 @@ test('invokePackageExport stores terminal failures for execution errors and miss
 		},
 	})
 
+	repoMockModule.runBundledModuleWithRegistry.mockResolvedValue({
+		error:
+			'Connection closed: this Durable Object instance is no longer active. Reconnect or retry the request.',
+		logs: [],
+	})
+	const durableObjectInactiveClose = await invokePackageExport({
+		env: createEnv(db),
+		baseUrl: 'https://kody.dev',
+		token: createToken(),
+		request: {
+			packageIdOrKodyId: 'discord-gateway',
+			exportName: 'dispatch-message-created',
+			params: { content: 'hi' },
+			idempotencyKey: 'evt-do-inactive-close',
+			source: 'discord-gateway',
+		},
+	})
+	expect(durableObjectInactiveClose.status).toBe(503)
+	expect(durableObjectInactiveClose.body).toMatchObject({
+		ok: false,
+		error: {
+			code: 'durable_object_reset',
+			message:
+				'Connection closed: this Durable Object instance is no longer active. Reconnect or retry the request.',
+		},
+	})
+
 	repoMockModule.runBundledModuleWithRegistry.mockClear()
 	const missingExportFirst = await invokePackageExport({
 		env: createEnv(db),

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -6,6 +6,7 @@ import {
 	cloudflareOpaqueInternalErrorMessage,
 	durableObjectBlockConcurrencyWhileTimeoutResetMessage,
 	durableObjectCodeUpdatedResetMessage,
+	durableObjectInstanceInactiveCloseMessage,
 	durableObjectIsolateCpuResetMessage,
 	durableObjectIsolateMemoryResetMessage,
 	durableObjectStorageOperationTimeoutResetMessage,
@@ -40,6 +41,11 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 	expect(
 		isDurableObjectIsolateResourceLimitResetMessage(
 			durableObjectBlockConcurrencyWhileTimeoutResetMessage,
+		),
+	).toBe(false)
+	expect(
+		isDurableObjectIsolateResourceLimitResetMessage(
+			durableObjectInstanceInactiveCloseMessage,
 		),
 	).toBe(false)
 
@@ -462,9 +468,10 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 
 	// Bare Cloudflare DO platform resets (memory / CPU / deploy-time code
 	// update / blockConcurrencyWhile timeout / storage-op timeout / storage
-	// object-reset) are transient — one representative form per family, plus
-	// an `Error:`-prefixed variant and a missing trailing period. Wrapped
-	// recovery failures and unreferenced storage resets must stay visible.
+	// object-reset / instance-inactive RPC close) are transient — one
+	// representative form per family, plus an `Error:`-prefixed variant and
+	// a missing trailing period. Wrapped recovery failures and unreferenced
+	// storage resets must stay visible.
 	expect(
 		filterSentryEvent({
 			exception: {
@@ -504,6 +511,20 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 					{
 						value:
 							'Internal error in Durable Object storage caused object to be reset; reference = 849rqmf61lg3qbmtb3j6moc4',
+					},
+				],
+			},
+		}),
+	).toBeNull()
+	expect(
+		filterSentryEvent({
+			exception: {
+				values: [
+					{
+						value: durableObjectInstanceInactiveCloseMessage.replace(
+							/\.$/,
+							'',
+						),
 					},
 				],
 			},

--- a/packages/worker/src/sentry-options.node.test.ts
+++ b/packages/worker/src/sentry-options.node.test.ts
@@ -521,10 +521,7 @@ test('filterSentryEvent drops expected platform and caller noise and keeps real 
 			exception: {
 				values: [
 					{
-						value: durableObjectInstanceInactiveCloseMessage.replace(
-							/\.$/,
-							'',
-						),
+						value: durableObjectInstanceInactiveCloseMessage.replace(/\.$/, ''),
 					},
 				],
 			},

--- a/packages/worker/src/sentry-options.ts
+++ b/packages/worker/src/sentry-options.ts
@@ -177,14 +177,16 @@ export function filterIntegrationTokenRefreshCallerSentryEvent(
  * when `blockConcurrencyWhile` exceeds its ~30s deadlock timeout (for
  * example PartyServer awaiting MCP Agent `onStart` via `getServerByName` →
  * `setName`), when a DO SQLite storage operation exceeds the platform timeout
- * and resets the object, or when DO SQLite storage hits an opaque internal
- * fault and resets the object, the platform surfaces one of these errors to
- * the caller. The next call gets a fresh isolate / storage handle; app-level
- * retry of non-idempotent work is still unsafe, and moving heavy Agent/MCP
- * startup out of `onStart` is an architectural change outside a triage fix.
- * Match only the bare platform strings (plus the storage form that requires
- * a support `reference =` token) so wrapped failures such as exhausted
- * `package_publish_external_push` recovery messages stay visible.
+ * and resets the object, when DO SQLite storage hits an opaque internal
+ * fault and resets the object, or when an in-flight RPC's target instance is
+ * evicted or replaced ("no longer active"), the platform surfaces one of
+ * these errors to the caller. The next call gets a fresh isolate / storage
+ * handle; app-level retry of non-idempotent work is still unsafe, and moving
+ * heavy Agent/MCP startup out of `onStart` is an architectural change
+ * outside a triage fix. Match only the bare platform strings (plus the
+ * storage form that requires a support `reference =` token) so wrapped
+ * failures such as exhausted `package_publish_external_push` recovery
+ * messages stay visible.
  */
 export const durableObjectIsolateMemoryResetMessage =
 	"Durable Object's isolate exceeded its memory limit and was reset."
@@ -205,6 +207,17 @@ export const durableObjectBlockConcurrencyWhileTimeoutResetMessage =
  */
 export const durableObjectStorageOperationTimeoutResetMessage =
 	'Durable Object storage operation exceeded timeout which caused object to be reset.'
+
+/**
+ * Cloudflare closes an in-flight Durable Object RPC when that instance is
+ * evicted, replaced, or otherwise no longer current. The platform string
+ * itself says to reconnect or retry; the next stub call lands on a fresh
+ * instance. Same class as deploy-time "code was updated" resets — not an
+ * application defect. Observed on package workflows as a misclassified
+ * `UserCodeError` (`execution_failed`) when this string was unrecognized.
+ */
+export const durableObjectInstanceInactiveCloseMessage =
+	'Connection closed: this Durable Object instance is no longer active. Reconnect or retry the request.'
 
 /**
  * Cloudflare Durable Object SQLite storage opaque platform fault with a
@@ -253,6 +266,7 @@ export function isDurableObjectIsolateResetMessage(message: string) {
 		normalized === durableObjectCodeUpdatedResetMessage ||
 		normalized === durableObjectBlockConcurrencyWhileTimeoutResetMessage ||
 		normalized === durableObjectStorageOperationTimeoutResetMessage ||
+		normalized === durableObjectInstanceInactiveCloseMessage ||
 		isDurableObjectStorageObjectResetMessage(message)
 	)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop blaming package authors when Cloudflare closes an in-flight Durable Object RPC because that instance was evicted or replaced. Retry and filter those closes the same way we already handle other DO isolate resets.

## Summary

- Production `sentry-triage` workflow `./process-sentry-webhook` (`621917c5-eec6-4f45-9367-09fa1de2cc91`) failed after 8771ms as `UserCodeError` with `Connection closed: this Durable Object instance is no longer active. Reconnect or retry the request.`
- That Cloudflare string was missing from `isDurableObjectIsolateResetMessage`, so package invoke classified it as `execution_failed` (500) instead of `durable_object_reset` (503).
- Adding the exact platform string to the shared detector makes invoke return `durable_object_reset`, workflows throw a plain `Error` (not `UserCodeError`), `runBundledModuleWithRegistry` retries, jobs treat it as transient, and Sentry drops the bare event.
- Rebased onto current `main` (kept both transient-error assertions after #1627) and oxfmt'd the Sentry filter test.

## Testing

- `npx vitest run --project node-unit` on `sentry-options`, `durable-object-reset-retry`, `jobs/execution-safety`, `package-invocations/service` — 27 tests passed after the merge.
- Preview: health/login plus a logged-in account check on the isolated preview (no way to seed a real Cloudflare DO eviction).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `31f1ba6c` · **Head:** `f494d9d7`

**Classification:** extends — the shared Durable Object isolate-reset detector now recognizes Cloudflare instance-inactive RPC closes. No primitives added.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `jobs` | assistant | extends — `isTransientJobExecutionError` now matches the instance-inactive close (test-locked) |

Unmatched path `packages/worker/src/sentry-options.ts` is the shared detector. Workflows, package invoke, and execute-runtime retries consume it without a file touch in this diff.

### Change flow

A package workflow that hits a Cloudflare instance-inactive close is classified as a platform reset instead of user code.

```mermaid
sequenceDiagram
	actor CF as Cloudflare DO RPC
	participant workflows as workflows
	participant jobs as jobs
	CF->>workflows: instance-inactive close during package export
	Note over workflows: new string matches isolate-reset detector
	workflows->>workflows: invoke returns 503 durable_object_reset not UserCodeError
	CF->>jobs: same message on scheduled work
	jobs->>jobs: mark transient and back off
```

### Invariants

Per-user isolation is unchanged. This only widens the existing exact-string platform-reset matcher.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2db5e7e-d79b-4d0e-b12b-aca0eae86d49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2db5e7e-d79b-4d0e-b12b-aca0eae86d49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Durable Object connection closures when an instance is evicted, replaced, or no longer active.
  * These transient errors are now correctly recognized for retry and reset handling.
  * Package export requests return HTTP 503 with the appropriate reset error while preserving retry guidance.
  * Prevented expected platform reset events from being reported as isolate resource-limit errors or unnecessary monitoring alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->