### PR TITLE
fix(mcp): keep package scope denials off Sentry (KODY-CLOUDFLARE-5N)

### DIFF
--- a/packages/worker/src/mcp/observability.node.test.ts
+++ b/packages/worker/src/mcp/observability.node.test.ts
@@ -38,6 +38,8 @@ const { PackageSecretAccessDeniedError } =
 	await import('./secrets/package-access.ts')
 const { CommunityActionError } = await import('#worker/community/errors.ts')
 const { EntitlementLimitError } = await import('#worker/entitlements/errors.ts')
+const { PackageScopeAccessError } =
+	await import('#worker/package-registry/package-owner.ts')
 const { UserCodeError } = await import('#worker/user-code-error.ts')
 
 function captureMcpEvents(run: () => void) {
@@ -173,6 +175,21 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 			errorMessage: 'Fork this community listing before rating it.',
 			cause: new CommunityActionError(
 				'Fork this community listing before rating it.',
+			),
+		})
+
+		// Missing package scope grant (KODY-CLOUDFLARE-5N).
+		logMcpEvent({
+			...callerFailureBase,
+			capabilityName: 'package_list',
+			domain: 'packages',
+			capabilitySource: 'builtin',
+			failurePhase: 'handler',
+			errorName: 'PackageScopeAccessError',
+			errorMessage:
+				'You do not have a package scope grant for "@kody". Omit package_scope to use your personal scope, or ask an admin to grant access to that platform account.',
+			cause: new PackageScopeAccessError(
+				'You do not have a package scope grant for "@kody". Omit package_scope to use your personal scope, or ask an admin to grant access to that platform account.',
 			),
 		})
 
@@ -335,7 +352,7 @@ test('logMcpEvent keeps sandbox and caller failures off Sentry and still reports
 		})
 	})
 
-	expect(payloads).toHaveLength(19)
+	expect(payloads).toHaveLength(20)
 	expect(JSON.parse(payloads[0]!)).toMatchObject({
 		tool: 'execute',
 		outcome: 'failure',

--- a/packages/worker/src/mcp/observability.ts
+++ b/packages/worker/src/mcp/observability.ts
@@ -3,6 +3,7 @@ import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { getErrorCauseChain } from '@kody-internal/shared/error-message.ts'
 import { CommunityActionError } from '#worker/community/errors.ts'
 import { isEntitlementLimitError } from '#worker/entitlements/errors.ts'
+import { PackageScopeAccessError } from '#worker/package-registry/package-owner.ts'
 import { isRepoLargeFileMessage } from '#worker/repo/large-file-policy.ts'
 import {
 	isGitPushNotFastForwardMessage,
@@ -109,6 +110,15 @@ function isCallerFailure(payload: McpObservabilityPayload, cause?: unknown) {
 	if (
 		getErrorCauseChain(cause).some(
 			(entry) => entry instanceof CommunityActionError,
+		)
+	) {
+		return true
+	}
+	// Missing / invalid package_scope (no grant, non-platform target, bad
+	// format) — agents must omit the field or obtain a grant. KODY-CLOUDFLARE-5N.
+	if (
+		getErrorCauseChain(cause).some(
+			(entry) => entry instanceof PackageScopeAccessError,
 		)
 	) {
 		return true

--- a/packages/worker/src/package-registry/package-owner.ts
+++ b/packages/worker/src/package-registry/package-owner.ts
@@ -8,6 +8,19 @@ import {
 import { getMcpUserPackageScope } from './user-scope.ts'
 
 /**
+ * Caller-clearable package scope denial (invalid scope, non-platform target,
+ * or missing grant). Lives in the worker layer so MCP capabilities and shared
+ * resolvers can throw it without importing `#mcp/*`; observability treats it
+ * like `CommunityActionError` and keeps it off Sentry (KODY-CLOUDFLARE-5N).
+ */
+export class PackageScopeAccessError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'PackageScopeAccessError'
+	}
+}
+
+/**
  * The acting-user / owning-account pair for a package operation.
  *
  * `ownerUserId` (a stable MCP user id) is the only id that may be used for
@@ -26,7 +39,7 @@ export type PackageOwnerContext = {
 }
 
 export const packageScopeInputDescription =
-	'Optional package scope (without "@") to act in, for example "kody". Requires an explicit package scope grant on that platform account. Omit to act in your own personal scope.'
+	'Optional platform account scope (without "@") only when you already hold an explicit package scope grant for that account. Omit to act in your own personal scope. Do not guess a platform scope you have not been granted.'
 
 function normalizeRequestedScope(scope: string | undefined) {
 	const normalized = scope?.trim().toLowerCase().replace(/^@/, '') ?? ''
@@ -66,12 +79,14 @@ export async function resolvePackageOwnerContext(
 
 	const formatError = getUsernameFormatValidationError(scope)
 	if (formatError) {
-		throw new Error(`Invalid package scope "@${scope}": ${formatError}`)
+		throw new PackageScopeAccessError(
+			`Invalid package scope "@${scope}": ${formatError}`,
+		)
 	}
 	const platformAccount = await getPlatformAccountByUsername(db, scope)
 	if (!platformAccount) {
-		throw new Error(
-			`Package scope "@${scope}" is not a platform account scope you can act in.`,
+		throw new PackageScopeAccessError(
+			`Package scope "@${scope}" is not a platform account scope you can act in. Omit package_scope to use your personal scope.`,
 		)
 	}
 	const granted = await hasPackageScopeGrant(db, {
@@ -79,7 +94,9 @@ export async function resolvePackageOwnerContext(
 		granteeUserId: user.userId,
 	})
 	if (!granted) {
-		throw new Error(`You do not have a package scope grant for "@${scope}".`)
+		throw new PackageScopeAccessError(
+			`You do not have a package scope grant for "@${scope}". Omit package_scope to use your personal scope, or ask an admin to grant access to that platform account.`,
+		)
 	}
 	await logAuditEvent({
 		db: auditDatabaseFromEnv(env),

--- a/packages/worker/src/package-registry/package-owner.workers.test.ts
+++ b/packages/worker/src/package-registry/package-owner.workers.test.ts
@@ -2,7 +2,10 @@ import { env } from 'cloudflare:workers'
 import { expect, test } from 'vitest'
 import { createPlatformAccount } from '#worker/identity/platform-account-creation.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
-import { resolvePackageOwnerContext } from './package-owner.ts'
+import {
+	PackageScopeAccessError,
+	resolvePackageOwnerContext,
+} from './package-owner.ts'
 import { insertPackageScopeGrant } from './scope-grants.ts'
 import { ensurePackageScopeGrantsTestSchema } from './test-schema.ts'
 
@@ -85,12 +88,21 @@ test('resolvePackageOwnerContext returns caller ownership, grant delegation, and
 
 	await expect(
 		resolvePackageOwnerContext(env, actorUser, otherPerson.username),
+	).rejects.toThrow(PackageScopeAccessError)
+	await expect(
+		resolvePackageOwnerContext(env, actorUser, otherPerson.username),
 	).rejects.toThrow(/not a platform account scope/)
 
 	await expect(
 		resolvePackageOwnerContext(env, actorUser, platform.username),
+	).rejects.toThrow(PackageScopeAccessError)
+	await expect(
+		resolvePackageOwnerContext(env, actorUser, platform.username),
 	).rejects.toThrow(/do not have a package scope grant/)
 
+	await expect(
+		resolvePackageOwnerContext(env, actorUser, 'missing-scope-xyz'),
+	).rejects.toThrow(PackageScopeAccessError)
 	await expect(
 		resolvePackageOwnerContext(env, actorUser, 'missing-scope-xyz'),
 	).rejects.toThrow(/not a platform account scope/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop expected `package_scope` denials (no grant / non-platform / invalid scope) from opening Sentry issues that look like platform bugs ([KODY-CLOUDFLARE-5N](https://kent-c-dodds-tech-llc.sentry.io/issues/7683776147/)).

## Summary

- Introduce `PackageScopeAccessError` in `resolvePackageOwnerContext` for caller-clearable scope denials (worker-layer, same pattern as `CommunityActionError`).
- Teach MCP observability `isCallerFailure` to skip Sentry for that error class while keeping `mcp-event` failure lines.
- Clarify `package_scope` input description (no bait example that nudges agents to guess `"kody"`) and make denial messages tell callers to omit the field or request a grant.

## Testing

- `vitest` node-unit: `observability.node.test.ts`
- `vitest` workers-unit: `package-owner.workers.test.ts`
- Full local `npm run validate` hit unrelated env contention (mcp-e2e / Playwright / Cloudflare mock timeouts); CI is the gate for those suites.

## System changes

See system recap below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `21293004` · **Head:** `f7aa5d1a`

**Classification:** composes — wires the existing MCP caller-failure / Sentry skip path to package scope denials; no new primitives or grant/authz rules.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `mcp-server` | surfaces | composes — `isCallerFailure` recognizes `PackageScopeAccessError` |
| `saved-packages` | assistant | composes — typed denial + clearer `package_scope` copy (same deny outcomes) |

### Change flow

Ungranted `package_scope` stays on `mcp-event` and skips Sentry.

```mermaid
sequenceDiagram
	actor caller as MCP caller
	participant mcpServer as mcp-server
	participant savedPackages as saved-packages
	participant sentry as Sentry
	caller->>mcpServer: package_list(package_scope)
	mcpServer->>savedPackages: resolvePackageOwnerContext
	savedPackages-->>mcpServer: throw PackageScopeAccessError
	mcpServer-->>caller: capability failure message
	Note over mcpServer,sentry: isCallerFailure true — no Sentry issue
```

### Invariants

Per-user isolation and grant-only platform-scope delegation are unchanged: foreign scopes still require a platform account plus an explicit grant row.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af44ce96-f570-421e-9361-59160e1a1eb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af44ce96-f570-421e-9361-59160e1a1eb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

