### PR TITLE
fix(community): keep publish preconditions off Sentry (KODY-CLOUDFLARE-5T)

### DIFF
--- a/packages/worker/src/community/community-service.node.test.ts
+++ b/packages/worker/src/community/community-service.node.test.ts
@@ -910,7 +910,11 @@ test('publishCommunityListing requires MIT license and Intent heading', async ()
 			userId: 'user-1',
 			packageId: 'package-1',
 		}),
-	).rejects.toThrow(/MIT license/)
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityActionError &&
+			/MIT license/.test(error.message),
+	)
 
 	mockModule.loadPackageSourceBySourceId.mockResolvedValue({
 		source: {
@@ -946,7 +950,10 @@ test('publishCommunityListing requires MIT license and Intent heading', async ()
 			userId: 'user-1',
 			packageId: 'package-1',
 		}),
-	).rejects.toThrow(/Intent/)
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityActionError && /Intent/.test(error.message),
+	)
 })
 
 test('publishCommunityListing rejects private packages', async () => {
@@ -988,8 +995,12 @@ test('publishCommunityListing rejects private packages', async () => {
 			userId: 'user-1',
 			packageId: 'package-1',
 		}),
-	).rejects.toThrow(
-		'community listings cannot publish packages with `"private": true`',
+	).rejects.toSatisfy(
+		(error: unknown) =>
+			error instanceof CommunityActionError &&
+			error.message.includes(
+				'community listings cannot publish packages with `"private": true`',
+			),
 	)
 })
 

--- a/packages/worker/src/community/service.ts
+++ b/packages/worker/src/community/service.ts
@@ -27,7 +27,7 @@ import {
 	type ServerTimingEntry,
 } from '#worker/server-timing.ts'
 import { assertPackageNotPrivateForCommunityPublish } from '#worker/package-registry/package-private.ts'
-import { assertKodyDescriptionLength } from '#worker/package-registry/types.ts'
+import { KODY_DESCRIPTION_MAX_LENGTH } from '#worker/package-registry/types.ts'
 import { parseAuthoredPackageJson } from '#worker/package-registry/manifest.ts'
 import { enqueueCommunityActivityDispatch } from './activity-dispatch-queue-producer.ts'
 import { assertNotCommunityBanned } from './assert-not-community-banned.ts'
@@ -321,16 +321,20 @@ function parseRawPackageLicense(packageJsonContent: string) {
 	try {
 		parsed = JSON.parse(packageJsonContent)
 	} catch {
-		throw new Error('Saved package package.json must be valid JSON.')
+		throw new CommunityActionError(
+			'Saved package package.json must be valid JSON.',
+		)
 	}
 	if (typeof parsed !== 'object' || parsed == null || !('license' in parsed)) {
-		throw new Error(
+		// Caller-clearable listing precondition — keep off Sentry
+		// (KODY-CLOUDFLARE-5S).
+		throw new CommunityActionError(
 			'community listings require the MIT license in package.json',
 		)
 	}
 	const license = (parsed as { license?: unknown }).license
 	if (typeof license !== 'string' || license.trim() !== 'MIT') {
-		throw new Error(
+		throw new CommunityActionError(
 			'community listings require the MIT license in package.json',
 		)
 	}
@@ -339,7 +343,7 @@ function parseRawPackageLicense(packageJsonContent: string) {
 
 function assertReadmeIntent(readmeContent: string) {
 	if (!intentHeadingPattern.test(readmeContent)) {
-		throw new Error(
+		throw new CommunityActionError(
 			'Community listings require README.md to include a "## Intent" section.',
 		)
 	}
@@ -502,17 +506,23 @@ export async function publishCommunityListing(input: {
 	})
 	const publishedCommit = loadedSource.source.published_commit
 	if (!publishedCommit) {
-		throw new Error(
+		throw new CommunityActionError(
 			`Saved package "${input.packageId}" does not have a published commit.`,
 		)
 	}
 
 	const packageJsonContent = loadedSource.files['package.json']
 	if (!packageJsonContent) {
-		throw new Error('Saved packages require a root package.json file.')
+		throw new CommunityActionError(
+			'Saved packages require a root package.json file.',
+		)
 	}
 	const description = loadedSource.manifest.kody.description
-	assertKodyDescriptionLength(description)
+	if (description.length > KODY_DESCRIPTION_MAX_LENGTH) {
+		throw new CommunityActionError(
+			'kody.description must be at most 200 characters (short public tagline).',
+		)
+	}
 	const license = parseRawPackageLicense(packageJsonContent)
 	assertPackageNotPrivateForCommunityPublish(packageJsonContent)
 
@@ -521,14 +531,18 @@ export async function publishCommunityListing(input: {
 		maxChars: communityReadmeMaxChars,
 	})
 	if (!readme) {
-		throw new Error('Community listings require a root README file.')
+		throw new CommunityActionError(
+			'Community listings require a root README file.',
+		)
 	}
 	const fullReadme = buildPackageReadmeDetail({
 		files: loadedSource.files,
 		maxChars: Number.MAX_SAFE_INTEGER,
 	})
 	if (!fullReadme) {
-		throw new Error('Community listings require a root README file.')
+		throw new CommunityActionError(
+			'Community listings require a root README file.',
+		)
 	}
 	assertReadmeIntent(fullReadme.content)
 

--- a/packages/worker/src/package-registry/package-private.node.test.ts
+++ b/packages/worker/src/package-registry/package-private.node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { CommunityActionError } from '#worker/community/errors.ts'
 import {
 	assertPackageNotPrivateForCommunityPublish,
 	injectDefaultPrivateField,
@@ -16,6 +17,9 @@ test('package private parsing gates community publish and visibility confirmatio
 		'must be a boolean',
 	)
 
+	expect(() =>
+		assertPackageNotPrivateForCommunityPublish('{"private":true}'),
+	).toThrow(CommunityActionError)
 	expect(() =>
 		assertPackageNotPrivateForCommunityPublish('{"private":true}'),
 	).toThrow('community listings cannot publish packages')

--- a/packages/worker/src/package-registry/package-private.ts
+++ b/packages/worker/src/package-registry/package-private.ts
@@ -1,3 +1,5 @@
+import { CommunityActionError } from '#worker/community/errors.ts'
+
 export type PackagePrivateFieldValue = true | false | undefined
 
 function parsePackageJsonRecord(content: string): Record<string, unknown> {
@@ -57,7 +59,9 @@ export function assertPackageNotPrivateForCommunityPublish(
 	packageJsonContent: string,
 ) {
 	if (isPackagePrivate(packageJsonContent)) {
-		throw new Error(
+		// CommunityActionError so mcp observability keeps this caller-clearable
+		// precondition off Sentry (KODY-CLOUDFLARE-5T).
+		throw new CommunityActionError(
 			'community listings cannot publish packages with `"private": true` in package.json; set `"private": false` or remove `private` after the user explicitly approves public community sharing.',
 		)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop Sentry noise when `community_publish` hits caller-clearable listing preconditions (`private: true`, non-MIT license, missing README/Intent, unpublished commit).

## Summary

- Throw `CommunityActionError` (already filtered from Sentry via mcp observability) instead of plain `Error` for community publish package preconditions.
- Same message text for callers; only the error class changes so failures stay on `mcp-event` lines.
- Unit coverage asserts `CommunityActionError` for private-package and MIT/Intent denials.

## Sentry

- Primary: [KODY-CLOUDFLARE-5T](https://kent-c-dodds-tech-llc.sentry.io/issues/7685278672/) — `community_publish` with `"private": true`
- Sibling: [KODY-CLOUDFLARE-5S](https://kent-c-dodds-tech-llc.sentry.io/issues/7685278623/) — non-MIT `license` on the same path

## Testing

- `vitest run --project node-unit packages/worker/src/community/community-service.node.test.ts packages/worker/src/package-registry/package-private.node.test.ts`

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `ab44449d` · **Head:** `3fff4170`

**Classification:** composes — reuses the existing `CommunityActionError` → mcp-event / Sentry skip path already used by missing-package publish and ratings.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `community-listings` | assistant | composes — publish precondition throws use the established caller-error type |
| `saved-packages` | assistant | composes — private-field assert throws `CommunityActionError` for community publish |

### Change flow

`community_publish` listing preconditions become caller-clearable errors and stay off Sentry.

```mermaid
sequenceDiagram
	actor Caller
	participant mcpServer as mcp-server
	participant communityListings as community-listings
	participant savedPackages as saved-packages
	participant sentryTunnel as sentry-tunnel
	Caller->>mcpServer: community_publish(package_id)
	mcpServer->>communityListings: publishCommunityListing
	communityListings->>savedPackages: assertPackageNotPrivateForCommunityPublish
	savedPackages-->>communityListings: CommunityActionError (private / MIT / README)
	communityListings-->>mcpServer: CommunityActionError
	mcpServer-->>Caller: mcp-event failure (caller-clearable)
	Note over sentryTunnel: isCallerFailure skips Sentry
```

### Before / after

| Case | Before | After |
| ---- | ------ | ----- |
| `"private": true` on publish | plain `Error` → Sentry (5T) | `CommunityActionError` → mcp-event only |
| Non-MIT license | plain `Error` → Sentry (5S) | `CommunityActionError` → mcp-event only |
| Missing README / Intent / unpublished commit | plain `Error` → Sentry risk | `CommunityActionError` → mcp-event only |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4d66c31-ffbc-4af1-b666-ac769a13e7b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4d66c31-ffbc-4af1-b666-ac769a13e7b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved community publishing validation by providing consistent, actionable errors for invalid packages.
  * Added clearer handling for private packages, missing or invalid licenses, README and Intent requirements, unpublished commits, and package metadata.
  * Enforced the 200-character description limit during publishing.
  * Preserved existing validation messages while improving error classification for reliable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->