### PR TITLE
Keep follow controls next to the username

### DIFF
--- a/packages/worker/src/app/community-detail-content.tsx
+++ b/packages/worker/src/app/community-detail-content.tsx
@@ -107,9 +107,14 @@ export function CommunityDetailContent(
 							) : null}
 						</span>
 					) : null}
-					<p mix={css(ownerLineCss)} data-testid="community-detail-owner-line">
-						{/* Separate flex items (not nested flex + trailing space) so
-						    "by" / @username / follow glyph stay on one line with gap. */}
+					{/* A div, not a p: the signed-in follow control is a form, and
+					    browsers close a p before a form, which drops the glyph
+					    onto the next line. Separate flex items (not nested flex +
+					    trailing space) so "by" / @username / follow stay inline. */}
+					<div
+						mix={css(ownerLineCss)}
+						data-testid="community-detail-owner-line"
+					>
 						<span>by</span>
 						{ownerProfilePublic ? (
 							<a
@@ -160,7 +165,7 @@ export function CommunityDetailContent(
 									errorTestId: 'community-detail-owner-follow-error',
 								})
 							: null}
-					</p>
+					</div>
 				</div>
 			</header>
 

--- a/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
+++ b/packages/worker/src/app/handlers/community-detail.frame.node.test.ts
@@ -171,6 +171,12 @@ test('community detail handler returns bare detail frame HTML for target header'
 		url: new URL('https://example.com/community/listing-1'),
 	} as never)
 	const signedInHtml = await signedInResponse.text()
+	expect(signedInHtml).toMatch(
+		/<div[^>]*data-testid="community-detail-owner-line"/,
+	)
+	expect(signedInHtml).not.toMatch(
+		/<p[^>]*data-testid="community-detail-owner-line"/,
+	)
 	expect(signedInHtml).toContain('data-testid="community-detail-owner-follow"')
 	expect(signedInHtml).toContain(
 		'data-testid="community-detail-viewer-install-badge"',

--- a/packages/worker/src/app/profile-content.node.test.ts
+++ b/packages/worker/src/app/profile-content.node.test.ts
@@ -103,7 +103,8 @@ test('profile packages link listings, prefer listing kody ids, and separate publ
 		followError: 'Unable to follow.',
 	})
 
-	expect(followingHtml).toContain('data-testid="profile-username"')
+	expect(followingHtml).toMatch(/<div[^>]*data-testid="profile-username"/)
+	expect(followingHtml).not.toMatch(/<p[^>]*data-testid="profile-username"/)
 	expect(followingHtml).toContain('data-testid="profile-follow"')
 	expect(followingHtml).toContain('data-following="true"')
 	expect(followingHtml).toContain('/profiles/kody/follow.json')

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -114,7 +114,12 @@ export function ProfileContent(handle: Handle<ProfileContentProps>) {
 						<h1 mix={css(pageTitleCss)} data-testid="profile-display-name">
 							{profile.displayName}
 						</h1>
-						<p mix={css(profileUsernameLineCss)} data-testid="profile-username">
+						{/* A div, not a p: the signed-in follow control is a form,
+						    and browsers close a p before a form. */}
+						<div
+							mix={css(profileUsernameLineCss)}
+							data-testid="profile-username"
+						>
 							<span>@{profile.username}</span>
 							{!isSelf
 								? renderProfileFollowControl({
@@ -127,7 +132,7 @@ export function ProfileContent(handle: Handle<ProfileContentProps>) {
 										errorTestId: 'profile-follow-error',
 									})
 								: null}
-						</p>
+						</div>
 					</div>
 				</div>
 				{profile.bio ? (

--- a/packages/worker/src/app/profile-follow-control.tsx
+++ b/packages/worker/src/app/profile-follow-control.tsx
@@ -37,7 +37,7 @@ export function renderProfileFollowControl(input: {
 	}
 
 	return (
-		<span mix={css(followControlCss)}>
+		<div mix={css(followControlCss)}>
 			<form
 				method="post"
 				action={routes.profileFollowApiPost.href({ username: input.username })}
@@ -69,7 +69,7 @@ export function renderProfileFollowControl(input: {
 					{input.followError}
 				</span>
 			) : null}
-		</span>
+		</div>
 	)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the follow checkmark on the same line as the package owner (and profile username) instead of dropping it underneath.

## Summary

- The signed-in follow control is a `<form>`. Browsers close a `<p>` before a form, so the glyph rendered below `@username`.
- Use a `<div>` for the community detail owner line, the profile username line, and the follow-control wrapper so the form stays inline and the markup is valid.
- Tests assert those lines render as `div`, not `p`.

## Testing

- `community-detail.frame.node.test.ts` and `profile-content.node.test.ts`
- Pre-push `test:push` on both commits: Node 1917, Workers 299, Playwright 7

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `5d0eee37` · **Head:** `16da4619`

**Classification:** composes — no primitives added or changed; this PR swaps invalid wrappers so the existing follow control stays on the username line.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — community/profile heading markup only |
| `community-listings` | assistant | composes — frame test coverage only |

### Change flow

Community detail and profile still render the same follow form; the wrappers around the username can legally contain it.

```mermaid
sequenceDiagram
	actor Viewer
	participant appUi as app-ui
	Viewer->>appUi: open community package or profile
	appUi->>appUi: render username line and follow control as divs
	Note over appUi: form stays beside @username instead of breaking out of a p
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed profile and community detail owner lines so follow controls stay on the same line as username or owner information.
  - Improved HTML structure for more consistent rendering.

- **Tests**
  - Added coverage confirming these lines render correctly and maintain their expected layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->