### PR TITLE
Extend execute sandbox reset retry budget

### DIFF
--- a/packages/worker/src/durable-object-reset-retry.node.test.ts
+++ b/packages/worker/src/durable-object-reset-retry.node.test.ts
@@ -4,11 +4,13 @@ import {
 	durableObjectInstanceInactiveCloseMessage,
 } from '#worker/sentry-options.ts'
 import {
+	durableObjectResetRetryDelaysMs,
 	isTransientDurableObjectResetError,
 	runWithTransientDurableObjectResetRetry,
 } from './durable-object-reset-retry.ts'
 
 test('transient Durable Object reset retry recovers thrown and result errors then exhausts', async () => {
+	expect(durableObjectResetRetryDelaysMs).toEqual([100, 500, 1_500])
 	expect(
 		isTransientDurableObjectResetError(
 			new Error(durableObjectCodeUpdatedResetMessage),
@@ -105,7 +107,7 @@ test('transient Durable Object reset retry recovers thrown and result errors the
 		await expect(exhaustedPending).resolves.toEqual({
 			error: durableObjectCodeUpdatedResetMessage,
 		})
-		expect(exhausted).toHaveBeenCalledTimes(3)
+		expect(exhausted).toHaveBeenCalledTimes(4)
 
 		const dirtyResult = vi
 			.fn<() => Promise<{ error: string; dirty: boolean }>>()
@@ -145,7 +147,7 @@ test('transient Durable Object reset retry recovers thrown and result errors the
 		})
 		await vi.runAllTimersAsync()
 		await expect(exhaustedUndefinedPending).resolves.toBeUndefined()
-		expect(exhaustedUndefined).toHaveBeenCalledTimes(3)
+		expect(exhaustedUndefined).toHaveBeenCalledTimes(4)
 	} finally {
 		vi.useRealTimers()
 	}

--- a/packages/worker/src/durable-object-reset-retry.ts
+++ b/packages/worker/src/durable-object-reset-retry.ts
@@ -5,11 +5,10 @@ import {
 import { isDurableObjectIsolateResetMessage } from '#worker/sentry-options.ts'
 
 /**
- * Same bounded backoff as package_publish_external_push and published
- * artifact rebuild. Deploy-time isolate resets usually recover on the next
- * call to a fresh isolate.
+ * Bounded backoff for sandbox execution. The final delay gives deploy drains
+ * time to finish before the last attempt reaches a fresh isolate.
  */
-export const durableObjectResetRetryDelaysMs = [100, 500] as const
+export const durableObjectResetRetryDelaysMs = [100, 500, 1_500] as const
 
 export function isTransientDurableObjectResetError(error: unknown) {
 	if (typeof error === 'string') {

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -2847,7 +2847,7 @@ test('runBundledModuleWithRegistry retries transient Durable Object isolate rese
 		expect(exhausted.error).toBe(
 			'Durable Object reset because its code was updated.',
 		)
-		expect(execute).toHaveBeenCalledTimes(3)
+		expect(execute).toHaveBeenCalledTimes(4)
 		expect(finishSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
 				status: 'error',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give deploy-time execute-sandbox Durable Object resets enough time to drain before the bounded retry budget is exhausted.

## Summary

- extend sandbox reset delays from `100ms, 500ms` to `100ms, 500ms, 1500ms`
- preserve the existing host-mediated side-effect retry gate
- update exhaustion coverage from three to four attempts

## Testing

- `npx vitest run --project node-unit packages/worker/src/durable-object-reset-retry.node.test.ts packages/worker/src/mcp/run-kody-registry.node.test.ts packages/worker/src/mcp/capabilities/packages/publish-external-push.node.test.ts packages/worker/src/mcp/capabilities/repo/package-artifact-rebuild.node.test.ts` — 34 tests passed
- PR CI — Node, Workers, Static, MCP, E2E, Bugbot, and CodeRabbit passed; no actionable AI feedback
- preview manual testing intentionally skipped: no logged-in UI surface changed

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `313ba6d1` · **Head:** `a81864bc`

**Classification:** extends — changes the bounded reset-retry timing used by sandbox execution without changing the side-effect safety contract.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — execute sandbox gets one additional delayed reset retry |

### Change flow

Execute retries recognized Durable Object resets once more after a 1500ms drain delay, while host-mediated side effects still stop retries.

```mermaid
sequenceDiagram
	participant mcpServer as mcp-server
	participant sandbox as execute-sandbox Durable Object
	mcpServer->>sandbox: execute bundled module
	alt transient reset and no host-mediated side effects
		sandbox-->>mcpServer: reset error
		mcpServer->>sandbox: retry after 100ms, 500ms, then 1500ms
	else host-mediated side effect occurred
		sandbox-->>mcpServer: reset result retained without retry
	end
```

### Invariants

- Retry attempts remain bounded at four total calls.
- The existing `shouldRetry` side-effect gate remains unchanged.

</details>

<!-- system-recap:end -->

## Conductor report

- Status: shipped — [PR #1638](https://github.com/kentcdodds/kody/pull/1638) squash-merged as `4ca2a6cd` at 23:42 UTC.
- Evidence: focused tests 34/34; all PR checks green after one infrastructure-timeout rerun; Bugbot and CodeRabbit reported no actionable issues.
- Deploy: [production run 32539156096](https://github.com/kentcdodds/kody/actions/runs/32539156096) succeeded at 00:09 UTC on `d2c29eef`, a verified descendant of the merge commit; healthchecks and execute smoke check passed.
- Remains: none.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f35c993-b882-46f4-9ce5-97fc8a43a40d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f35c993-b882-46f4-9ce5-97fc8a43a40d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Extended retry handling for Durable Object resets with an additional retry attempt.
  - Added a 1.5-second delay before the final retry.
  - Improved resilience when reset operations temporarily fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->