### PR TITLE
Classify stale running rows as platform interrupts

### DIFF
--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -203,11 +203,21 @@ cleaned in the same pass. Caps are applied in small batches per finish so a
 single RPC stays bounded.
 
 Stranded `running` rows (isolate reset, lost `waitUntil` finish, hung Worker
-Loader `evaluate`) are reconciled to `status=error` with `errorName=Interrupted`
-(Interrupted means the execution outcome is unknown) using the surface-aware
-TTLs above. Reconciliation runs on the DO alarm, on retention passes, and **on
-read** (`getRun`, keyed lookup, `listRuns`, `summarize`) so Activity and
-keyed-execute recovery do not wait for an alarm.
+Loader `evaluate`) are reconciled to `status=error` with the stable
+`errorName=platform_interrupted`. This name means platform weather ended the
+host execution and its outcome is unknown; Activity, `run_list`, and triage
+automation must not classify it as a user-authored package failure.
+Reconciliation uses the surface-aware TTLs above and runs on the DO alarm, on
+retention passes, and **on read** (`getRun`, keyed lookup, `listRuns`,
+`summarize`) so Activity and keyed-execute recovery do not wait for an alarm.
+
+Interrupted scheduled-job occurrences (`idempotency_key` beginning
+`scheduled-job:`) and keyed subscription deliveries are retained with
+`error_triage=ignored` because their scheduler or delivery queue retries the
+same idempotent unit. Manual jobs, keyed execute calls, and other surfaces stay
+open: their caller may need to recover or act on the unknown outcome. A later
+terminal finish still replaces the reconciled row when the outcome becomes
+known.
 
 ## Keyed package-invocation idempotency ledger
 

--- a/packages/worker/src/run-records/invocation-ledger.workers.test.ts
+++ b/packages/worker/src/run-records/invocation-ledger.workers.test.ts
@@ -15,7 +15,9 @@ import {
 } from './service.ts'
 import {
 	packageInvocationLedgerRetentionDays,
+	runRecordPlatformInterruptedErrorName,
 	runRecordRetentionEveryNFinishes,
+	runRecordStaleRunningTtlMsShortLived,
 	type RunRecordContext,
 } from './types.ts'
 
@@ -181,6 +183,77 @@ test('claim + finish journey: one call each, replay record, run row lifecycle', 
 		metadata: expect.objectContaining({ result: { sent: true } }),
 	})
 	expect(terminalRun?.logs.map((log) => log.message)).toEqual(['sent'])
+})
+
+test('late failed subscription finish reopens a system-ignored platform interrupt', async () => {
+	const userId = uniqueUserId('late-subscription-failure')
+	const idempotencyKey = 'delivery-late-failure'
+	const claimed = await claimPackageInvocationRecord({
+		env,
+		userId,
+		context: exportContext({
+			surface: 'subscription',
+			name: 'email.message.received',
+			idempotencyKey,
+		}),
+		invocation: claimInput({ idempotencyKey }),
+		staleBefore: freshStaleBefore(),
+	})
+	if (claimed.outcome !== 'claimed' || !claimed.handle) {
+		throw new Error('Expected a fresh subscription claim.')
+	}
+
+	const staleStartedAt = new Date(
+		Date.now() - runRecordStaleRunningTtlMsShortLived - 1_000,
+	).toISOString()
+	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
+	await runInDurableObject(stub, async (instance: RunLog, state) => {
+		expect(instance).toBeInstanceOf(RunLog)
+		state.storage.sql.exec(
+			`UPDATE runs SET started_at = ?, created_at = ?, updated_at = ?
+			WHERE id = ?`,
+			staleStartedAt,
+			staleStartedAt,
+			staleStartedAt,
+			claimed.handle.id,
+		)
+	})
+
+	expect(
+		(await getRunRecord({ env, userId, runId: claimed.handle.id }))?.run,
+	).toMatchObject({
+		status: 'error',
+		errorName: runRecordPlatformInterruptedErrorName,
+		errorTriage: 'ignored',
+		triagedBy: 'system:platform-interrupt',
+	})
+
+	const finished = await finishPackageInvocationRecord({
+		env,
+		userId,
+		handle: { ...claimed.handle, startedAt: staleStartedAt },
+		invocationId: claimed.invocationId,
+		claimUpdatedAt: claimed.claimUpdatedAt,
+		ledgerStatus: 'failed',
+		responseJson: JSON.stringify({
+			status: 500,
+			body: { error: 'known package failure' },
+		}),
+		status: 'error',
+		error: new Error('known package failure'),
+	})
+	expect(finished.ledgerUpdated).toBe(true)
+	expect(
+		(await getRunRecord({ env, userId, runId: claimed.handle.id }))?.run,
+	).toMatchObject({
+		status: 'error',
+		errorName: 'Error',
+		errorMessage: 'known package failure',
+		errorTriage: null,
+		triageNote: null,
+		triagedAt: null,
+		triagedBy: null,
+	})
 })
 
 test('stale in-progress claims are reclaimed atomically; mismatched hashes are not', async () => {

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -2108,6 +2108,7 @@ class RunLogBase extends DurableObject<Env> {
 			if (input.run) {
 				const previousStatus = this.getRunStatus(input.run.id)
 				const existed = previousStatus != null
+				this.clearSystemPlatformInterruptTriageBeforeErrorFinish(input.run)
 				this.upsertRun(input.run, 'replace')
 				this.replaceLogs(input.run.id, input.logs)
 				if (!existed) {

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -1021,6 +1021,25 @@ class RunLogBase extends DurableObject<Env> {
 		)
 	}
 
+	private clearSystemPlatformInterruptTriageBeforeErrorFinish(
+		run: Pick<RunLogRowInput, 'id' | 'status'>,
+	) {
+		if (run.status !== 'error') return
+		this.ctx.storage.sql.exec(
+			`UPDATE runs
+			SET error_triage = NULL,
+				triage_note = NULL,
+				triaged_at = NULL,
+				triaged_by = NULL
+			WHERE id = ?
+				AND error_name = ?
+				AND triaged_by = ?`,
+			run.id,
+			runRecordPlatformInterruptedErrorName,
+			platformInterruptTriagedBy,
+		)
+	}
+
 	private replaceLogs(runId: string, logs: Array<RunLogEntryInput>) {
 		this.ctx.storage.sql.exec(`DELETE FROM run_logs WHERE run_id = ?`, runId)
 		const kept = logs.slice(-runRecordMaxLogEntriesPerRun)
@@ -1911,6 +1930,7 @@ class RunLogBase extends DurableObject<Env> {
 		// so a mid-unit SQL failure cannot leave a terminal run that suppresses
 		// missing derived side effects. Alarm / async retention stay outside.
 		this.transactionSyncWithMetaCache(() => {
+			this.clearSystemPlatformInterruptTriageBeforeErrorFinish(input.run)
 			this.upsertRun(input.run, 'replace')
 			this.replaceLogs(input.run.id, input.logs)
 			if (!existed) {

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -47,12 +47,15 @@ import {
 	packageInvocationLedgerRetentionDays,
 	runErrorTriageMaxNoteLength,
 	runErrorTriageValues,
+	runErrorTriageForPlatformInterrupt,
 	runRecordMaxJsonBytes,
 	runRecordMaxLogEntriesPerRun,
 	runRecordMaxRunsPerUser,
 	runRecordMaxTextBytes,
 	runRecordDefaultPageSize,
 	runRecordMaxPageSize,
+	runRecordPlatformInterruptedErrorMessage,
+	runRecordPlatformInterruptedErrorName,
 	runRecordRetentionAlarmMs,
 	runRecordRetentionDays,
 	runRecordRetentionEveryNFinishes,
@@ -86,9 +89,9 @@ const exportJobRunObservabilityCursorPrefix = 'job-run-observability:'
 const exportPackageRunSuccessesCursorPrefix = 'package-run-successes:'
 const exportActivationMilestonesCursorPrefix = 'activation-milestones:'
 
-const staleRunningErrorName = 'Interrupted'
-const staleRunningErrorMessage =
-	'Run did not finish; outcome unknown (reconciled after stale running TTL).'
+const platformInterruptTriageNote =
+	'auto-ignored: idempotent scheduler or delivery queue will retry'
+const platformInterruptTriagedBy = 'system:platform-interrupt'
 
 const retentionMs = runRecordRetentionDays * 24 * 60 * 60 * 1000
 const ledgerRetentionMs =
@@ -1061,6 +1064,8 @@ class RunLogBase extends DurableObject<Env> {
 
 	private markRunningInterrupted(input: {
 		id: string
+		surface: RunSurface
+		idempotencyKey: string | null
 		startedAt: string
 		finishedAt?: string
 	}) {
@@ -1071,6 +1076,10 @@ class RunLogBase extends DurableObject<Env> {
 			Number.isFinite(startedMs) && Number.isFinite(finishedMs)
 				? Math.max(0, finishedMs - startedMs)
 				: null
+		const errorTriage = runErrorTriageForPlatformInterrupt({
+			surface: input.surface,
+			idempotencyKey: input.idempotencyKey,
+		})
 		this.ctx.storage.sql.exec(
 			`UPDATE runs
 			SET status = 'error',
@@ -1078,12 +1087,20 @@ class RunLogBase extends DurableObject<Env> {
 				duration_ms = ?,
 				error_name = ?,
 				error_message = ?,
+				error_triage = ?,
+				triage_note = ?,
+				triaged_at = ?,
+				triaged_by = ?,
 				updated_at = ?
 			WHERE id = ? AND status = 'running'`,
 			finishedAt,
 			durationMs,
-			staleRunningErrorName,
-			staleRunningErrorMessage,
+			runRecordPlatformInterruptedErrorName,
+			runRecordPlatformInterruptedErrorMessage,
+			errorTriage,
+			errorTriage ? platformInterruptTriageNote : null,
+			errorTriage ? finishedAt : null,
+			errorTriage ? platformInterruptTriagedBy : null,
 			finishedAt,
 			input.id,
 		)
@@ -1094,9 +1111,11 @@ class RunLogBase extends DurableObject<Env> {
 
 	/**
 	 * Prefer marking stranded `running` rows terminal over deleting them: an
-	 * interrupted attempt is useful history. `error` + Interrupted is used
-	 * because the public status union has no dedicated unknown-outcome value;
-	 * live "is it running?" state must not be read from these rows anyway.
+	 * interrupted attempt is useful history. `error` +
+	 * `platform_interrupted` is used because the public status union has no
+	 * dedicated unknown-outcome value; live "is it running?" state must not be
+	 * read from these rows anyway. Idempotent scheduler/queue attempts are
+	 * retained as ignored history because their owners will retry.
 	 *
 	 * TTL is surface-aware: sandbox-backed surfaces (execute/export/…) heal in
 	 * minutes; workflow rows keep the day-scale TTL.
@@ -1116,8 +1135,13 @@ class RunLogBase extends DurableObject<Env> {
 			nowMs - runRecordStaleRunningTtlMsForSurface('workflow'),
 		).toISOString()
 		const candidates = this.ctx.storage.sql
-			.exec<{ id: string; started_at: string; surface: string }>(
-				`SELECT id, started_at, surface FROM runs
+			.exec<{
+				id: string
+				started_at: string
+				surface: RunSurface
+				idempotency_key: string | null
+			}>(
+				`SELECT id, started_at, surface, idempotency_key FROM runs
 				WHERE status = 'running' AND (
 					(surface IN ('execute', 'export', 'retriever', 'webhook', 'subscription', 'app_fetch', 'app_realtime')
 						AND started_at < ?)
@@ -1145,6 +1169,8 @@ class RunLogBase extends DurableObject<Env> {
 			}
 			this.markRunningInterrupted({
 				id: row.id,
+				surface: row.surface,
+				idempotencyKey: row.idempotency_key,
 				startedAt: row.started_at,
 				finishedAt,
 			})
@@ -1170,6 +1196,8 @@ class RunLogBase extends DurableObject<Env> {
 		}
 		this.markRunningInterrupted({
 			id: run.id,
+			surface: run.surface,
+			idempotencyKey: run.idempotencyKey,
 			startedAt: run.startedAt,
 		})
 		const healed = this.ctx.storage.sql
@@ -1542,8 +1570,8 @@ class RunLogBase extends DurableObject<Env> {
 			if (existing) {
 				// Heal stranded `running` owners before refusing the claim so a
 				// keyed retry after an isolate death is not stuck on inProgress
-				// forever. Terminal rows (including reconciled Interrupted)
-				// still own the key for replay.
+				// forever. Terminal rows (including reconciled platform
+				// interrupts) still own the key for replay.
 				return {
 					claimed: false,
 					run: this.healStaleRunningRecord(existing),

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -1013,6 +1013,48 @@ test('cap and stale retention journey', async () => {
 				triagedBy: 'system:platform-interrupt',
 			})
 		}
+
+		await finishRunRecord({
+			env,
+			handle: {
+				id: 'stale-scheduled-job',
+				userId,
+				startedAt: staleJobStartedAt,
+				persistence: 'eager',
+				context: baseContext({
+					surface: 'job',
+					idempotencyKey: 'scheduled-job:job-1:2026-08-21T00:00:00.000Z',
+				}),
+			},
+			status: 'error',
+			error: new Error('package failed after the delayed finish arrived'),
+		})
+		const lateError = await getRunRecord({
+			env,
+			userId,
+			runId: 'stale-scheduled-job',
+		})
+		expect(lateError?.run).toMatchObject({
+			status: 'error',
+			errorName: 'Error',
+			errorMessage: 'package failed after the delayed finish arrived',
+			errorTriage: null,
+			triageNote: null,
+			triagedAt: null,
+			triagedBy: null,
+		})
+		expect(
+			(
+				await getRunRecord({
+					env,
+					userId,
+					runId: 'stale-subscription-delivery',
+				})
+			)?.run,
+		).toMatchObject({
+			errorName: runRecordPlatformInterruptedErrorName,
+			errorTriage: 'ignored',
+		})
 	}
 
 	// --- a real late finish replaces reconciled platform interrupt ---

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -28,6 +28,7 @@ import {
 	runRecordMaxLogEntriesPerRun,
 	runRecordMaxResultSnapshotBytes,
 	runRecordMaxRunsPerUser,
+	runRecordPlatformInterruptedErrorName,
 	runRecordRetentionDays,
 	runRecordRetentionEveryNFinishes,
 	runRecordStaleRunningTtlMsJob,
@@ -78,6 +79,7 @@ function insertRunRow(
 		errorName?: string | null
 		errorMessage?: string | null
 		errorTriage?: 'ignored' | 'resolved' | null
+		idempotencyKey?: string | null
 	},
 ) {
 	const finishedAt = input.finishedAt ?? null
@@ -89,11 +91,12 @@ function insertRunRow(
 			duration_ms, error_name, error_message, metadata_json, created_at,
 			updated_at
 		) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, NULL,
-			NULL, NULL, NULL, NULL, NULL, ?, ?, ?, NULL, NULL, '{}', ?, ?)`,
+			NULL, NULL, NULL, ?, NULL, ?, ?, ?, NULL, NULL, '{}', ?, ?)`,
 		input.id,
 		input.surface ?? 'job',
 		input.status,
 		input.name ?? null,
+		input.idempotencyKey ?? null,
 		input.startedAt,
 		finishedAt,
 		finishedAt == null ? null : 1,
@@ -920,8 +923,11 @@ test('cap and stale retention journey', async () => {
 		})
 		const stale = await getRunRecord({ env, userId, runId: 'stale-running' })
 		expect(stale?.run.status).toBe('error')
-		expect(stale?.run.errorName).toBe('Interrupted')
-		expect(stale?.run.errorMessage).toMatch(/outcome unknown/i)
+		expect(stale?.run.errorName).toBe(runRecordPlatformInterruptedErrorName)
+		expect(stale?.run.errorMessage).toBe(
+			'The platform interrupted this run before completion; outcome unknown.',
+		)
+		expect(stale?.run.errorTriage).toBeNull()
 		expect(stale?.run.finishedAt).toBeTruthy()
 		const fresh = await getRunRecord({ env, userId, runId: 'fresh-running' })
 		expect(fresh?.run.status).toBe('running')
@@ -951,11 +957,65 @@ test('cap and stale retention journey', async () => {
 			runId: 'stale-execute',
 		})
 		expect(healed?.run.status).toBe('error')
-		expect(healed?.run.errorName).toBe('Interrupted')
+		expect(healed?.run.errorName).toBe(runRecordPlatformInterruptedErrorName)
 		expect(healed?.run.surface).toBe('execute')
 	}
 
-	// --- a real late finish replaces reconciled Interrupted (outcome is known) ---
+	// --- idempotent scheduled/queued runs retain auto-ignored interrupt history ---
+	{
+		const userId = uniqueUserId('idempotent-platform-interrupt')
+		const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
+		const staleJobStartedAt = new Date(
+			Date.now() - runRecordStaleRunningTtlMsJob - 1_000,
+		).toISOString()
+		const staleSubscriptionStartedAt = new Date(
+			Date.now() - runRecordStaleRunningTtlMsShortLived - 1_000,
+		).toISOString()
+		await runInDurableObject(stub, async (instance: RunLog, state) => {
+			expect(instance).toBeInstanceOf(RunLog)
+			insertRunRow(state, {
+				id: 'stale-scheduled-job',
+				status: 'running',
+				startedAt: staleJobStartedAt,
+				surface: 'job',
+				idempotencyKey: 'scheduled-job:job-1:2026-08-21T00:00:00.000Z',
+			})
+			insertRunRow(state, {
+				id: 'stale-subscription-delivery',
+				status: 'running',
+				startedAt: staleSubscriptionStartedAt,
+				surface: 'subscription',
+				idempotencyKey: 'delivery-123',
+			})
+		})
+
+		const summary = await summarizeRunRecords({
+			env,
+			userId,
+			since: new Date(0).toISOString(),
+		})
+		expect(summary).toMatchObject({
+			errors: 0,
+			ignored: 2,
+			running: 0,
+		})
+		const page = await listRunRecords({
+			env,
+			userId,
+			filter: { errorTriage: 'ignored' },
+		})
+		expect(page.runs).toHaveLength(2)
+		for (const run of page.runs) {
+			expect(run).toMatchObject({
+				status: 'error',
+				errorName: runRecordPlatformInterruptedErrorName,
+				errorTriage: 'ignored',
+				triagedBy: 'system:platform-interrupt',
+			})
+		}
+	}
+
+	// --- a real late finish replaces reconciled platform interrupt ---
 	{
 		const userId = uniqueUserId('late-finish-after-interrupted')
 		const staleStartedAt = new Date(
@@ -984,7 +1044,9 @@ test('cap and stale retention journey', async () => {
 			userId,
 			runId: handle.id,
 		})
-		expect(interrupted?.run.errorName).toBe('Interrupted')
+		expect(interrupted?.run.errorName).toBe(
+			runRecordPlatformInterruptedErrorName,
+		)
 
 		await finishRunRecord({
 			env,

--- a/packages/worker/src/run-records/stale-running-interrupt.node.test.ts
+++ b/packages/worker/src/run-records/stale-running-interrupt.node.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest'
+import {
+	runErrorTriageForPlatformInterrupt,
+	runRecordPlatformInterruptedErrorMessage,
+	runRecordPlatformInterruptedErrorName,
+	type RunRecordContext,
+} from './types.ts'
+
+function platformInterruptTriage(overrides: Partial<RunRecordContext>) {
+	return runErrorTriageForPlatformInterrupt({
+		surface: 'job',
+		idempotencyKey: null,
+		...overrides,
+	})
+}
+
+test('platform interrupt has a stable error contract and only auto-ignores retryable deliveries', () => {
+	expect(runRecordPlatformInterruptedErrorName).toBe('platform_interrupted')
+	expect(runRecordPlatformInterruptedErrorMessage).toBe(
+		'The platform interrupted this run before completion; outcome unknown.',
+	)
+
+	expect(
+		platformInterruptTriage({
+			surface: 'job',
+			idempotencyKey: 'scheduled-job:job-1:2026-08-21T00:00:00.000Z',
+		}),
+	).toBe('ignored')
+	expect(
+		platformInterruptTriage({
+			surface: 'subscription',
+			idempotencyKey: 'delivery-123',
+		}),
+	).toBe('ignored')
+
+	expect(
+		platformInterruptTriage({
+			surface: 'job',
+			idempotencyKey: 'manual-retry-key',
+		}),
+	).toBeNull()
+	expect(
+		platformInterruptTriage({
+			surface: 'subscription',
+			idempotencyKey: ' ',
+		}),
+	).toBeNull()
+	expect(
+		platformInterruptTriage({
+			surface: 'execute',
+			idempotencyKey: 'caller-recovery-key',
+		}),
+	).toBeNull()
+})

--- a/packages/worker/src/run-records/types.ts
+++ b/packages/worker/src/run-records/types.ts
@@ -60,6 +60,45 @@ export type RunErrorTriageFilter = (typeof runErrorTriageFilterValues)[number]
 /** Max length for optional triage notes set via `run_update`. */
 export const runErrorTriageMaxNoteLength = 2000
 
+/**
+ * Stable machine-readable name for stale `running` rows reconciled after their
+ * surface TTL. Consumers should treat this as platform weather, not a
+ * user-authored package failure.
+ */
+export const runRecordPlatformInterruptedErrorName = 'platform_interrupted'
+
+export const runRecordPlatformInterruptedErrorMessage =
+	'The platform interrupted this run before completion; outcome unknown.'
+
+/**
+ * Idempotent unattended deliveries are retried by their owning scheduler or
+ * queue, so retain their interrupted attempt as ignored history instead of an
+ * open user-facing failure. Interactive and non-idempotent attempts stay open.
+ */
+export function runErrorTriageForPlatformInterrupt(
+	context: Pick<RunRecordContext, 'surface' | 'idempotencyKey'>,
+): RunErrorTriage | null {
+	const idempotencyKey = context.idempotencyKey?.trim()
+	switch (context.surface) {
+		case 'job':
+			return idempotencyKey?.startsWith('scheduled-job:') ? 'ignored' : null
+		case 'subscription':
+			return idempotencyKey ? 'ignored' : null
+		case 'execute':
+		case 'export':
+		case 'app_fetch':
+		case 'app_realtime':
+		case 'workflow':
+		case 'retriever':
+		case 'webhook':
+			return null
+		default: {
+			const exhaustive: never = context.surface
+			throw new Error(`Unhandled run surface: ${String(exhaustive)}`)
+		}
+	}
+}
+
 export const runLogLevelValues = [
 	'debug',
 	'info',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Treat stale `running` RunLog rows caused by isolate loss as platform weather instead of user-authored package failures.

## Summary

- Reconcile stale rows with the stable `platform_interrupted` error name and an explicit platform-outcome-unknown message.
- Keep manual and caller-recoverable attempts open, while auto-ignoring retained history for keyed scheduled-job occurrences and subscription deliveries that have retry owners.
- Clear only system-applied platform-interrupt triage when a real late error supplies the terminal outcome, through both ordinary and atomic package-invocation finish paths; user-applied triage remains preserved.
- Document the public error contract and cover policy plus Durable Object reconciliation.

## Testing

- `npm run test:node -- packages/worker/src/run-records/stale-running-interrupt.node.test.ts` — passed (1 test).
- `npm run test:workers -- packages/worker/src/run-records/run-records.workers.test.ts` — passed after implementation and first review fix (17 tests).
- `npm run test:workers -- packages/worker/src/run-records/invocation-ledger.workers.test.ts packages/worker/src/run-records/run-records.workers.test.ts` — passed after Bugbot fix (23 tests).
- GitHub `✅ Validate` — passed: Static, Node, Workers, MCP, and E2E all green.
- Cursor Bugbot — passed after its valid atomic invocation-path finding was fixed.
- CodeRabbit — passing/rate-limited after its valid ordinary finish-path finding was fixed.
- Preview manual test skipped as requested: no logged-in UI surface changed.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `313ba6d1` · **Head:** `4992f34f`

**Classification:** extends — changes RunLog stale-row reconciliation and its public error/triage contract; no primitive is added.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `run-records` | storage | extends — classifies stale attempts as platform interrupts, auto-ignores retry-owned deliveries, and reopens known late errors across both finish paths |

### Change flow

RunLog turns an expired `running` row into structured platform-weather history, hides retry-owned attempts from open-failure views, and reopens the row if either terminal finish path reports a late error.

```mermaid
stateDiagram-v2
	[*] --> running: begin eager run record
	running --> success: terminal finish succeeds
	running --> error_open: TTL expires / platform_interrupted
	running --> error_ignored: TTL expires + scheduled-job occurrence or keyed subscription / platform_interrupted + ignored
	error_open --> success: late success supplies known outcome
	error_ignored --> success: late success supplies known outcome
	error_ignored --> error_open: ordinary or package-invocation late error clears system triage
```

### Invariants

- Per-user RunLog Durable Object remains the sole store; no shared D1 write or new primitive is introduced.
- History is retained, and live scheduler state is not inferred from run records.
- User-applied ignored/resolved triage is preserved by ordinary terminal error updates.

</details>

<!-- system-recap:end -->

## Conductor report

Shipped scope is complete and green at `4992f34f`: stale rows use `platform_interrupted`; retry-owned scheduled/subscription history is auto-ignored; late known errors reopen across both terminal paths. CodeRabbit and Bugbot valid findings were addressed. Focused Node/Workers evidence is green, full GitHub Validate is green, and no UI preview test was run per track instruction. Squash merge and production deploy watch are the remaining gates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83e349b9-eed3-4b32-84cb-974a537e8b3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83e349b9-eed3-4b32-84cb-974a537e8b3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stale runs now show a clear `platform_interrupted` error when the platform stops them before completion.
  * Scheduled jobs and keyed subscription deliveries are automatically marked as ignored when their outcome is unknown.
  * Other interrupted runs remain available for review, and later successful or failed completions are preserved.
* **Documentation**
  * Updated run-record documentation to describe interruption handling and triage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->