### PR TITLE
fix(account): shorten UserMeter write lease RPCs

### DIFF
--- a/packages/worker/src/account/deletion-state.node.test.ts
+++ b/packages/worker/src/account/deletion-state.node.test.ts
@@ -6,6 +6,7 @@ import {
 	type UserMeterEnv,
 } from '#worker/entitlements/user-meter-client.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { durableObjectInstanceInactiveCloseMessage } from '#worker/sentry-options.ts'
 import {
 	AccountDeletionInProgressError,
 	AccountWriteLeaseLostError,
@@ -111,6 +112,89 @@ function createGatedDoEnv(input: {
 		},
 		meterFor(userId: string) {
 			return userMeterRpc({ env, userId })
+		},
+	}
+}
+
+function createTrackedLeaseDoEnv(input?: {
+	acquireResetCount?: number
+	releaseResetCount?: number
+	rpcTimeoutMs?: number
+}) {
+	const base = createInMemoryUserMeterEnv()
+	const namespace = base.env.USER_METER!
+	const calls: Array<{ stubId: number; method: string }> = []
+	let stubCount = 0
+	let acquireAttempts = 0
+	let releaseAttempts = 0
+	const env = {
+		USER_METER: {
+			idFromName: namespace.idFromName.bind(namespace),
+			get(id: DurableObjectId) {
+				const target = namespace.get(id)
+				const stubId = ++stubCount
+				const createdAt = Date.now()
+				const assertFresh = () => {
+					if (
+						input?.rpcTimeoutMs != null &&
+						Date.now() - createdAt > input.rpcTimeoutMs
+					) {
+						throw new Error('Durable Object RPC stub exceeded its timeout.')
+					}
+				}
+				return new Proxy(target, {
+					get(target, prop, receiver) {
+						const value = Reflect.get(target, prop, receiver)
+						if (prop === 'acquireWriteLease') {
+							return async (args: {
+								token: string
+								holder: string
+								acquiredAt: string
+							}) => {
+								calls.push({ stubId, method: 'acquireWriteLease' })
+								assertFresh()
+								acquireAttempts += 1
+								if (acquireAttempts <= (input?.acquireResetCount ?? 0)) {
+									throw new Error(durableObjectInstanceInactiveCloseMessage)
+								}
+								return target.acquireWriteLease(args)
+							}
+						}
+						if (prop === 'assertWriteLeaseHeld') {
+							return async (args: { token: string }) => {
+								calls.push({ stubId, method: 'assertWriteLeaseHeld' })
+								assertFresh()
+								return target.assertWriteLeaseHeld(args)
+							}
+						}
+						if (prop === 'releaseWriteLease') {
+							return async (args: { token: string }) => {
+								calls.push({ stubId, method: 'releaseWriteLease' })
+								assertFresh()
+								releaseAttempts += 1
+								if (releaseAttempts <= (input?.releaseResetCount ?? 0)) {
+									throw new Error(durableObjectInstanceInactiveCloseMessage)
+								}
+								return target.releaseWriteLease(args)
+							}
+						}
+						return typeof value === 'function' ? value.bind(target) : value
+					},
+				})
+			},
+		},
+	} as unknown as UserMeterEnv
+	return {
+		env,
+		calls,
+		get acquireAttempts() {
+			return acquireAttempts
+		},
+		get releaseAttempts() {
+			return releaseAttempts
+		},
+		meterFor(userId: string) {
+			return userMeterRpc({ env: base.env, userId })
 		},
 	}
 }
@@ -292,6 +376,118 @@ test('nested same-user lease reuses the outer lease instead of re-acquiring', as
 	expect(await listActiveAccountWriteLeases(meter.env, 'user-a')).toHaveLength(
 		0,
 	)
+})
+
+test('long write callback does not retain a UserMeter RPC stub', async () => {
+	vi.useFakeTimers()
+	try {
+		vi.setSystemTime(new Date('2099-01-01T00:00:00.000Z'))
+		const { db } = createLeaseTestDb()
+		const rpcTimeoutMs = 90_000
+		const meter = createTrackedLeaseDoEnv({ rpcTimeoutMs })
+
+		const operation = withAccountWriteLease({
+			db,
+			stableUserId: 'user-a',
+			holder: 'test:long-write',
+			env: meter.env,
+			async write() {
+				await new Promise((resolve) => setTimeout(resolve, rpcTimeoutMs + 1))
+				return 'finished'
+			},
+		})
+		await vi.runAllTimersAsync()
+
+		await expect(operation).resolves.toBe('finished')
+		expect(meter.calls).toEqual([
+			{ stubId: 1, method: 'acquireWriteLease' },
+			{ stubId: 2, method: 'assertWriteLeaseHeld' },
+			{ stubId: 3, method: 'releaseWriteLease' },
+		])
+	} finally {
+		vi.useRealTimers()
+	}
+})
+
+test('UserMeter instance-inactive acquire and release retry then fail closed', async () => {
+	vi.useFakeTimers()
+	try {
+		const { db } = createLeaseTestDb()
+		const recovered = createTrackedLeaseDoEnv({
+			acquireResetCount: 1,
+			releaseResetCount: 1,
+		})
+		let recoveredWrites = 0
+		const recoveredOperation = withAccountWriteLease({
+			db,
+			stableUserId: 'user-a',
+			env: recovered.env,
+			async write() {
+				recoveredWrites += 1
+				return 'recovered'
+			},
+		})
+		await vi.runAllTimersAsync()
+		await expect(recoveredOperation).resolves.toBe('recovered')
+		expect(recoveredWrites).toBe(1)
+		expect(recovered.acquireAttempts).toBe(2)
+		expect(recovered.releaseAttempts).toBe(2)
+
+		const acquireUnavailable = createTrackedLeaseDoEnv({
+			acquireResetCount: 3,
+		})
+		let blockedWrites = 0
+		const blockedOperation = withAccountWriteLease({
+			db,
+			stableUserId: 'user-a',
+			env: acquireUnavailable.env,
+			async write() {
+				blockedWrites += 1
+			},
+		})
+		const blockedResult = blockedOperation.then(
+			() => 'resolved' as const,
+			(error: unknown) => error,
+		)
+		await vi.runAllTimersAsync()
+		expect(await blockedResult).toEqual(
+			expect.objectContaining({
+				message: durableObjectInstanceInactiveCloseMessage,
+			}),
+		)
+		expect(acquireUnavailable.acquireAttempts).toBe(3)
+		expect(blockedWrites).toBe(0)
+
+		const releaseUnavailable = createTrackedLeaseDoEnv({
+			releaseResetCount: 3,
+		})
+		let completedWrites = 0
+		const releaseFailedOperation = withAccountWriteLease({
+			db,
+			stableUserId: 'user-a',
+			env: releaseUnavailable.env,
+			async write() {
+				completedWrites += 1
+			},
+		})
+		const releaseFailedResult = releaseFailedOperation.then(
+			() => 'resolved' as const,
+			(error: unknown) => error,
+		)
+		await vi.runAllTimersAsync()
+		expect(await releaseFailedResult).toEqual(
+			expect.objectContaining({
+				message: durableObjectInstanceInactiveCloseMessage,
+			}),
+		)
+		expect(completedWrites).toBe(1)
+		expect(releaseUnavailable.releaseAttempts).toBe(3)
+		expect(
+			await releaseUnavailable.meterFor('user-a').countActiveWriteLeases(),
+		).toEqual({ count: 1 })
+	} finally {
+		vi.useRealTimers()
+	}
 })
 
 test('nested lease for a different user still acquires its own lease', async () => {

--- a/packages/worker/src/account/deletion-state.ts
+++ b/packages/worker/src/account/deletion-state.ts
@@ -4,7 +4,9 @@ import {
 	userMeterNamespace,
 	userMeterRpc,
 	type UserMeterEnv,
+	type UserMeterRpc,
 } from '#worker/entitlements/user-meter-client.ts'
+import { runWithTransientDurableObjectResetRetry } from '#worker/durable-object-reset-retry.ts'
 
 export class AccountDeletionInProgressError extends Error {
 	constructor() {
@@ -50,6 +52,22 @@ function requireUserMeterEnv(env: UserMeterEnv) {
 		throw new Error('USER_METER Durable Object binding is not configured.')
 	}
 	return env
+}
+
+async function runUserMeterRpc<T>(input: {
+	env: UserMeterEnv
+	stableUserId: string
+	operation: (meter: UserMeterRpc) => Promise<T>
+}) {
+	return await runWithTransientDurableObjectResetRetry({
+		operation: async () =>
+			await input.operation(
+				userMeterRpc({
+					env: input.env,
+					userId: input.stableUserId,
+				}),
+			),
+	})
 }
 
 async function insertOrVerifyDoRepairAudit(input: {
@@ -177,10 +195,11 @@ export async function markAccountDeleting(input: {
 		throw new Error('Account could not be marked for deletion.')
 	}
 	const env = requireUserMeterEnv(input.env)
-	const marked = await userMeterRpc({
+	const marked = await runUserMeterRpc({
 		env,
-		userId: stableUserId,
-	}).markDeleting({ deletingAt })
+		stableUserId,
+		operation: async (meter) => await meter.markDeleting({ deletingAt }),
+	})
 	return marked.leaseCount
 }
 
@@ -265,26 +284,37 @@ async function acquireDoAccountWriteLeaseAndWrite<T>(input: {
 		holder: input.holder ?? 'unspecified',
 		acquiredAt: utcSqliteTimestamp(),
 	}
-	const meter = userMeterRpc({
+	const acquired = await runUserMeterRpc({
 		env: input.env,
-		userId: lease.stableUserId,
-	})
-	const acquired = await meter.acquireWriteLease({
-		token: lease.token,
-		holder: lease.holder,
-		acquiredAt: lease.acquiredAt,
+		stableUserId: lease.stableUserId,
+		operation: async (meter) =>
+			await meter.acquireWriteLease({
+				token: lease.token,
+				holder: lease.holder,
+				acquiredAt: lease.acquiredAt,
+			}),
 	})
 	if (!acquired.acquired) {
 		throw new AccountDeletionInProgressError()
 	}
 	try {
 		const result = await input.write()
-		const held = await meter.assertWriteLeaseHeld({ token: lease.token })
+		const held = await runUserMeterRpc({
+			env: input.env,
+			stableUserId: lease.stableUserId,
+			operation: async (meter) =>
+				await meter.assertWriteLeaseHeld({ token: lease.token }),
+		})
 		if (!held.held) throw new AccountWriteLeaseLostError()
 		return result
 	} finally {
 		input.frame.active = false
-		await meter.releaseWriteLease({ token: lease.token })
+		await runUserMeterRpc({
+			env: input.env,
+			stableUserId: lease.stableUserId,
+			operation: async (meter) =>
+				await meter.releaseWriteLease({ token: lease.token }),
+		})
 	}
 }
 
@@ -293,13 +323,17 @@ export async function listActiveAccountWriteLeases(
 	stableUserId: string,
 ): Promise<Array<ListedAccountWriteLease>> {
 	const requiredEnv = requireUserMeterEnv(env)
-	const meter = userMeterRpc({ env: requiredEnv, userId: stableUserId })
 	const leases: Array<ListedAccountWriteLease> = []
 	let startAfter: string | null = null
 	for (;;) {
-		const page = await meter.listWriteLeases({
-			pageSize: 500,
-			startAfter,
+		const page = await runUserMeterRpc({
+			env: requiredEnv,
+			stableUserId,
+			operation: async (meter) =>
+				await meter.listWriteLeases({
+					pageSize: 500,
+					startAfter,
+				}),
 		})
 		for (const lease of page.leases) {
 			leases.push({
@@ -328,10 +362,14 @@ export async function repairAccountWriteLease(input: {
 	}
 	const reason = input.reason.trim()
 	const env = requireUserMeterEnv(input.env)
-	const meter = userMeterRpc({ env, userId: input.stableUserId })
-	const prepared = await meter.prepareWriteLeaseRepair({
-		token: input.token,
-		expectedAcquiredAt: input.expectedAcquiredAt,
+	const prepared = await runUserMeterRpc({
+		env,
+		stableUserId: input.stableUserId,
+		operation: async (meter) =>
+			await meter.prepareWriteLeaseRepair({
+				token: input.token,
+				expectedAcquiredAt: input.expectedAcquiredAt,
+			}),
 	})
 	if (prepared.prepared) {
 		const now = utcSqliteTimestamp()
@@ -347,10 +385,15 @@ export async function repairAccountWriteLease(input: {
 			now,
 		})
 		// Finalize DO lease; fail closed on transport errors (audit row persists for retry).
-		await meter.finalizeWriteLeaseRepair({
-			token: prepared.token,
-			repairId: prepared.repairId,
-			expectedAcquiredAt: prepared.acquiredAt,
+		await runUserMeterRpc({
+			env,
+			stableUserId: input.stableUserId,
+			operation: async (meter) =>
+				await meter.finalizeWriteLeaseRepair({
+					token: prepared.token,
+					repairId: prepared.repairId,
+					expectedAcquiredAt: prepared.acquiredAt,
+				}),
 		})
 		return { repaired: true as const, repairId: prepared.repairId }
 	}
@@ -364,8 +407,13 @@ export async function repairAccountWriteLease(input: {
 		reason,
 	})
 	if (existingAudit) {
-		const stillHeld = await meter.assertWriteLeaseHeld({
-			token: input.token,
+		const stillHeld = await runUserMeterRpc({
+			env,
+			stableUserId: input.stableUserId,
+			operation: async (meter) =>
+				await meter.assertWriteLeaseHeld({
+					token: input.token,
+				}),
 		})
 		if (!stillHeld.held) {
 			return { repaired: true as const, repairId: existingAudit.id }

--- a/packages/worker/src/entitlements/user-meter.workers.test.ts
+++ b/packages/worker/src/entitlements/user-meter.workers.test.ts
@@ -858,6 +858,23 @@ test('UserMeter deletion leases: mark, acquire, release, repair, export, and pur
 	).resolves.toEqual({ acquired: true })
 	expect(await meterB.countActiveWriteLeases()).toEqual({ count: 2 })
 
+	const markedWithActiveWrites = await meterB.markDeleting({
+		deletingAt: '2026-08-01 09:00:00',
+	})
+	expect(markedWithActiveWrites).toEqual({
+		deletingAt: '2026-08-01 09:00:00',
+		created: true,
+		leaseCount: 2,
+	})
+	await expect(
+		meterB.acquireWriteLease({
+			token: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+			holder: 'test:blocked-during-deletion',
+			acquiredAt: '2026-08-01 10:06:30',
+		}),
+	).resolves.toEqual({ acquired: false })
+	expect(await meterB.countActiveWriteLeases()).toEqual({ count: 2 })
+
 	// listWriteLeases is paged and returns entries without authority field.
 	const listed = await meterB.listWriteLeases({ pageSize: 1 })
 	expect(listed.leases).toHaveLength(1)
@@ -993,14 +1010,16 @@ test('UserMeter deletion leases: mark, acquire, release, repair, export, and pur
 		}),
 	).resolves.toEqual({ acquired: false })
 
-	expect(await meterB.readDeletionState()).toEqual({ deletingAt: null })
+	expect(await meterB.readDeletionState()).toEqual({
+		deletingAt: '2026-08-01 09:00:00',
+	})
 	await expect(
 		meterB.markDeleting({
 			deletingAt: '2026-08-01 15:00:00',
 		}),
 	).resolves.toEqual({
-		deletingAt: '2026-08-01 15:00:00',
-		created: true,
+		deletingAt: '2026-08-01 09:00:00',
+		created: false,
 		leaseCount: 0,
 	})
 	expect(await meterB.countActiveWriteLeases()).toEqual({ count: 0 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Prevent long `/mcp`, sandbox, and other account-write operations from retaining a UserMeter Durable Object stub across caller I/O, while preserving fail-closed account-deletion fencing.

## Summary

- resolves a fresh UserMeter stub for each short acquire, assert, and release RPC
- retries transient Durable Object resets on account-deletion UserMeter RPCs
- preserves nested same-user lease reuse and active-token deletion fencing
- adds regression coverage for callbacks longer than the RPC timeout, reset recovery/exhaustion, and deletion with active tokens

## Testing

- `npx vitest run --config vitest.node.config.ts packages/worker/src/account/deletion-state.node.test.ts` — 18 passed
- `npx vitest run --config vitest.workers.config.ts packages/worker/src/entitlements/user-meter.workers.test.ts` — 10 passed
- `npm run typecheck && npm run format:check && npm run lint && npm run primitives:check` — passed
- `npm run validate` — attempted locally; the VM could not start unrelated mock/dev workers under the all-at-once load, causing cross-suite infrastructure timeouts
- GitHub CI — all 20 checks passed, including Node, Workers, MCP, E2E, and Static

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `313ba6d1` · **Head:** `14883ca0`

**Classification:** extends — changes the UserMeter write-lease client lifecycle and transient-reset handling without adding a primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `user-meter` | storage | extends — each lease operation uses a short-lived, reset-retried stub |
| `entitlements` | auth | composes — Workers coverage exercises the existing UserMeter deletion contract |

### Change flow

Account-write callers keep one durable token across long work, but no UserMeter stub remains open while that work runs.

```mermaid
sequenceDiagram
	participant caller as account-write caller
	participant userMeter as user-meter
	caller->>userMeter: acquire active-write token (fresh stub + reset retry)
	userMeter-->>caller: token accepted or deletion rejected
	Note over caller: run long MCP, sandbox, or network callback without an open UserMeter RPC
	caller->>userMeter: assert token still held (fresh stub + reset retry)
	caller->>userMeter: release token in finally (fresh stub + reset retry)
```

### Invariants

- D1 `deleting_at` remains the permanent point gate; UserMeter remains authoritative for active tokens.
- Once deletion is marked, new tokens are rejected and existing tokens continue to block deletion.
- Exhausted acquire retries prevent the write; exhausted release retries retain the token for fail-closed repair.
- Nested same-user calls reuse the outer token.

</details>

<!-- system-recap:end -->

## Conductor report

Status: ready to merge. All 20 CI checks passed. Bugbot passed with no feedback; CodeRabbit was rate-limited. Targeted lease and real-DO tests are green. Preview manual testing was skipped because this change adds no logged-in UI surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e37ea620-6eb3-437d-8896-c4b081cfb879?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e37ea620-6eb3-437d-8896-c4b081cfb879&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

