### PR TITLE
test(account): exhaust updated lease retry budget

### DIFF
--- a/packages/worker/src/account/deletion-state.node.test.ts
+++ b/packages/worker/src/account/deletion-state.node.test.ts
@@ -434,7 +434,7 @@ test('UserMeter instance-inactive acquire and release retry then fail closed', a
 		expect(recovered.releaseAttempts).toBe(2)
 
 		const acquireUnavailable = createTrackedLeaseDoEnv({
-			acquireResetCount: 3,
+			acquireResetCount: 4,
 		})
 		let blockedWrites = 0
 		const blockedOperation = withAccountWriteLease({
@@ -455,11 +455,11 @@ test('UserMeter instance-inactive acquire and release retry then fail closed', a
 				message: durableObjectInstanceInactiveCloseMessage,
 			}),
 		)
-		expect(acquireUnavailable.acquireAttempts).toBe(3)
+		expect(acquireUnavailable.acquireAttempts).toBe(4)
 		expect(blockedWrites).toBe(0)
 
 		const releaseUnavailable = createTrackedLeaseDoEnv({
-			releaseResetCount: 3,
+			releaseResetCount: 4,
 		})
 		let completedWrites = 0
 		const releaseFailedOperation = withAccountWriteLease({
@@ -481,7 +481,7 @@ test('UserMeter instance-inactive acquire and release retry then fail closed', a
 			}),
 		)
 		expect(completedWrites).toBe(1)
-		expect(releaseUnavailable.releaseAttempts).toBe(3)
+		expect(releaseUnavailable.releaseAttempts).toBe(4)
 		expect(
 			await releaseUnavailable.meterFor('user-a').countActiveWriteLeases(),
 		).toEqual({ count: 1 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Restore the lease fail-closed regression test after #1638 extended the shared Durable Object reset retry budget from three to four total attempts.

## Summary

- makes simulated acquire unavailability last through all four attempts
- makes simulated release unavailability last through all four attempts
- updates attempt-count assertions without changing retry delays or production code

## Testing

- `npx vitest run --config vitest.node.config.ts packages/worker/src/account/deletion-state.node.test.ts` — 18 passed
- `npm run format:check && npm run lint` — passed (three pre-existing warnings)
- `npm run validate` — the changed Node test passed; the Cloud VM could not start unrelated mock/dev workers under the all-at-once load, causing unrelated infrastructure timeouts
- GitHub CI — all checks passed, including Node, Workers, MCP, E2E, and Static
- Production deploy — succeeded, including production healthchecks and execute smoke check

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low code risk)</summary>

**Mode:** recap · **Base:** `main` @ `6677d52e` · **Head:** `606d6f14`

**Classification:** composes — no production primitive changes; this PR aligns fail-closed coverage with the existing four-attempt reset helper contract.

### Change flow

The regression test now exhausts every reset-retry attempt before asserting that acquire and release remain fail-closed.

```mermaid
sequenceDiagram
	participant test as account lease regression test
	participant userMeter as user-meter
	loop four configured attempts
		test->>userMeter: simulate instance-inactive acquire or release reset
	end
	userMeter-->>test: surface exhausted reset error and preserve fail-closed state
```

### Invariants

- Acquire exhaustion prevents the write callback.
- Release exhaustion leaves the active token for deletion fencing and repair.
- The shared retry delay list remains owned by #1638 and is unchanged here.

</details>

<!-- system-recap:end -->

## Conductor report

Status: shipped. [PR #1643](https://github.com/kentcdodds/kody/pull/1643) was squash-merged as `d2c29eef`. All PR and post-merge CI checks passed; Bugbot passed with no feedback and CodeRabbit was rate-limited. [Production deploy 32539156096](https://github.com/kentcdodds/kody/actions/runs/32539156096) succeeded, including production healthchecks and the execute smoke check. The targeted 18-test lease suite proved four-attempt acquire/release exhaustion remains fail-closed. No retry delays or production code changed. No gates remain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e37ea620-6eb3-437d-8896-c4b081cfb879?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e37ea620-6eb3-437d-8896-c4b081cfb879&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

