### PR TITLE
Match lease fail-closed tests to the reset retry budget

### DIFF
--- a/packages/worker/src/account/deletion-state.node.test.ts
+++ b/packages/worker/src/account/deletion-state.node.test.ts
@@ -6,6 +6,7 @@ import {
 	type UserMeterEnv,
 } from '#worker/entitlements/user-meter-client.ts'
 import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+import { durableObjectResetRetryDelaysMs } from '#worker/durable-object-reset-retry.ts'
 import { durableObjectInstanceInactiveCloseMessage } from '#worker/sentry-options.ts'
 import {
 	AccountDeletionInProgressError,
@@ -433,8 +434,9 @@ test('UserMeter instance-inactive acquire and release retry then fail closed', a
 		expect(recovered.acquireAttempts).toBe(2)
 		expect(recovered.releaseAttempts).toBe(2)
 
+		const failClosedResetCount = durableObjectResetRetryDelaysMs.length + 1
 		const acquireUnavailable = createTrackedLeaseDoEnv({
-			acquireResetCount: 3,
+			acquireResetCount: failClosedResetCount,
 		})
 		let blockedWrites = 0
 		const blockedOperation = withAccountWriteLease({
@@ -455,11 +457,11 @@ test('UserMeter instance-inactive acquire and release retry then fail closed', a
 				message: durableObjectInstanceInactiveCloseMessage,
 			}),
 		)
-		expect(acquireUnavailable.acquireAttempts).toBe(3)
+		expect(acquireUnavailable.acquireAttempts).toBe(failClosedResetCount)
 		expect(blockedWrites).toBe(0)
 
 		const releaseUnavailable = createTrackedLeaseDoEnv({
-			releaseResetCount: 3,
+			releaseResetCount: failClosedResetCount,
 		})
 		let completedWrites = 0
 		const releaseFailedOperation = withAccountWriteLease({
@@ -481,7 +483,7 @@ test('UserMeter instance-inactive acquire and release retry then fail closed', a
 			}),
 		)
 		expect(completedWrites).toBe(1)
-		expect(releaseUnavailable.releaseAttempts).toBe(3)
+		expect(releaseUnavailable.releaseAttempts).toBe(failClosedResetCount)
 		expect(
 			await releaseUnavailable.meterFor('user-a').countActiveWriteLeases(),
 		).toEqual({ count: 1 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock main Validate / production deploy so #1637 (follow checkmark next to username) can go live. Main is red because a UserMeter lease test still assumes the pre-#1638 three-attempt reset budget.

## Summary

- #1638 added a third Durable Object reset delay (`1500ms`), so fail-closed now takes four attempts
- The instance-inactive lease test still used three resets and resolved instead of throwing
- Derive the fail-closed reset count from `durableObjectResetRetryDelaysMs.length + 1`

## Testing

- `deletion-state.node.test.ts`: 18 passed
- Pre-push `test:push`: Node 1909, Workers 300, Playwright 7

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `6677d52e` · **Head:** `80c374f9`

**Classification:** composes — test-only; no production code change.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` / account tests | surfaces | composes — align fail-closed attempt count with retry budget |

### Change flow

Main Validate failed on a lease test that still used three resets after the retry budget grew to four attempts.

```mermaid
sequenceDiagram
	participant validate as Validate
	participant test as deletion-state.node.test
	participant retry as durable-object-reset-retry
	validate->>test: UserMeter instance-inactive fail-closed
	test->>retry: exhaust delays.length plus one attempts
	Note over test: count comes from durableObjectResetRetryDelaysMs
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e9331f-8e81-48a9-8bb2-55b7442a5065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved retry exhaustion test coverage by deriving failure attempts from the configured retry schedule.
  * Updated related attempt-count assertions to remain consistent with retry configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->