### PR TITLE
Surface compact memory one-liners without hiding them

### DIFF
--- a/docs/contributing/decisions/0033-memory-auto-surface-lab.md
+++ b/docs/contributing/decisions/0033-memory-auto-surface-lab.md
@@ -1,0 +1,72 @@
+# 0033 lab: memory auto-surface (2026-08-22)
+
+Point-in-time evidence for [0033](./0033-no-user-as-conversation.md). This is
+not a second steering record. Re-run
+`node tools/memory-auto-surface-lab/run.mjs` when revisiting.
+
+## Method
+
+Deterministic window simulation, not an LLM eval. For each policy × trace: was
+“never send” / “draft only” in the host-visible tool text at the decision, and
+what did that cost (`chars/4`). Isolation is a second agent with a fresh handle
+after the first agent already surfaced the memory.
+
+Phrase match proves transport, not that a model read or obeyed the line.
+
+2026-08-22 run: **5149** policies (cartesian grid plus named theories) × the
+original 15 traces plus 9 invented adversarial traces. **82** core-perfect
+policies (isolation + every required scene). Execute-only send with no
+`memoryContext` stays stretch.
+
+## Falsified
+
+| Policy                                    | Isolation       | Compaction           | Notes                                     |
+| ----------------------------------------- | --------------- | -------------------- | ----------------------------------------- |
+| Full payload + per-handle hide            | pass            | fail                 | First show falls out of a 3-result window |
+| User-global hide                          | fail            | fail                 | Chat B never sees the rule                |
+| Compact + hide on echoed `conversationId` | pass            | fail                 | Same compaction miss                      |
+| Search-only compact                       | pass            | fail                 | Misses execute-only and compaction        |
+| Subject-only                              | pass            | fail on weak subject | “Email habits” hides the rule             |
+| `n=1`                                     | pass            | fail on rank-2       | Critical memory is second                 |
+| Ids / structured-only / empty payload     | fail visibility | —                    | Markdown-only hosts see nothing           |
+| Always-full, no hide                      | pass            | pass                 | About 2–4× the compact cost               |
+
+## Surviving shape
+
+Every core-perfect policy shared:
+
+- `search` retrieves from the query
+- `execute` retrieves only with `memoryContext`
+- the line includes the **summary** (keywords, 80-char summary, or subject +
+  summary)
+- **no hide** after the first show
+- **n=2** so a rank-2 critical memory still appears
+
+Cheapest core-perfect: keyword soup, no hide, n=2. Readable core-perfect:
+subject + summary, no hide, n=2 — about half of a full-record payload. `n=3` and
+`executeWhen=always` also survive and buy stretch scenes at roughly 2× tokens.
+
+Composite score still crowns cheaper `n=1` / keyword rows that miss rank-2. That
+is a rubric artifact. Do not treat min-tokens-at-reliability=1 as the product
+pick.
+
+## Product pick (0033)
+
+Compact **subject — summary** one-liners (id in structured content), top two
+active memories, retrieve on search query and on execute `memoryContext`, **no
+auto-surface hide**. Repeat is the compaction tax.
+
+## Revisit
+
+Calendar check: 2027-02-22 (GitHub issue linked from 0033). Keep 0033 unless one
+of these is true:
+
+1. MCP or a major host puts a spec-defined conversation or thread id on every
+   request.
+2. Auto-surface tokens are large relative to the rest of a typical
+   search/execute result.
+3. Re-running the lab (or a live MCP probe) shows hide/`n=1`/subject-only no
+   longer fail the core traces.
+
+Do not promote execute-always to core unless execute-only send without
+`memoryContext` becomes the common host path.

--- a/docs/contributing/decisions/0033-memory-auto-surface-lab.md
+++ b/docs/contributing/decisions/0033-memory-auto-surface-lab.md
@@ -58,7 +58,8 @@ auto-surface hide**. Repeat is the compaction tax.
 
 ## Revisit
 
-Calendar check: 2027-02-22 (GitHub issue linked from 0033). Keep 0033 unless one
+Calendar check: 2027-02-22
+([#1648](https://github.com/kentcdodds/kody/issues/1648)). Keep 0033 unless one
 of these is true:
 
 1. MCP or a major host puts a spec-defined conversation or thread id on every

--- a/docs/contributing/decisions/0033-no-user-as-conversation.md
+++ b/docs/contributing/decisions/0033-no-user-as-conversation.md
@@ -1,0 +1,40 @@
+# 0033: No user-as-conversation, MCP session, or user-global memory hide
+
+- **Status:** accepted
+- **Date:** 2026-08-22
+
+## Context
+
+MCP revision `2026-07-28` is a stateless protocol: every request carries its
+own `_meta`, servers **MUST NOT** infer context from prior requests on the same
+connection, and servers **SHOULD** handle requests for multiple tasks, threads,
+or conversations. An open connection or stdio process is not a conversation.
+State that spans requests **MUST** be an explicit identifier the client
+passes ([Statelessness](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#statelessness);
+[0005](./0005-mcp-dual-lane-stateless-migration.md)).
+
+Kody users talk to the same account from concurrent chats and from completely
+separate agents. A memory shown in chat A must still be visible in chat B.
+
+## Decision
+
+Do not treat the signed-in user, an MCP transport session, or an open
+connection as "the conversation." Do not add a user-global "already shown"
+window for auto-surfaced memories.
+
+Surface relevant memories on the tool result that retrieved them. The host
+transcript is the conversation cache. Optional per-handle suppression stays
+keyed to a `conversationId` the request actually carries (caller-supplied, or
+a server-minted id later echoed). Hosts that omit the field every time get a
+fresh mint and see the memories again.
+
+Do not require a protocol conversation id in `_meta`. If a host later puts a
+stable thread or run id there, use that handle; do not invent a session
+stand-in.
+
+## Consequences
+
+Concurrent agents for one user stay isolated. Agents that never echo
+`conversationId` may see the same top memories on each call — that is
+correct. Revisit only if a major host ships a spec-defined conversation or
+thread identifier that every request already carries.

--- a/docs/contributing/decisions/0033-no-user-as-conversation.md
+++ b/docs/contributing/decisions/0033-no-user-as-conversation.md
@@ -22,10 +22,6 @@ Do not treat the signed-in user, an MCP transport session, or an open connection
 as "the conversation." Do not add a user-global "already shown" window for
 auto-surfaced memories.
 
-Do not treat the signed-in user, an MCP transport session, or an open connection
-as "the conversation." Do not add a user-global "already shown" window for
-auto-surfaced memories.
-
 Surface relevant memories on the tool result that retrieved them. Do not hide
 auto-surface after the first show: a per-handle omit fails when the host drops
 earlier tool results. `conversationId` is a progressive-disclosure handle, not a
@@ -38,7 +34,11 @@ stand-in.
 ## Consequences
 
 Concurrent agents for one user stay isolated. Repeating a cheap one-liner costs
-less than hiding a rule that later falls out of context. Revisit only if a major
-host ships a spec-defined conversation or thread identifier that every request
-already carries, or if auto-surface token cost becomes large relative to the
-rest of the tool result.
+less than hiding a rule that later falls out of context.
+
+Evidence from the 2026-08-22 policy grid lives in
+[0033-memory-auto-surface-lab.md](./0033-memory-auto-surface-lab.md). Re-run
+`node tools/memory-auto-surface-lab/run.mjs` on the calendar check (2027-02-22)
+or sooner if a major host ships a spec-defined conversation or thread identifier
+that every request already carries, or if auto-surface token cost becomes large
+relative to the rest of the tool result.

--- a/docs/contributing/decisions/0033-no-user-as-conversation.md
+++ b/docs/contributing/decisions/0033-no-user-as-conversation.md
@@ -5,12 +5,12 @@
 
 ## Context
 
-MCP revision `2026-07-28` is a stateless protocol: every request carries its
-own `_meta`, servers **MUST NOT** infer context from prior requests on the same
+MCP revision `2026-07-28` is a stateless protocol: every request carries its own
+`_meta`, servers **MUST NOT** infer context from prior requests on the same
 connection, and servers **SHOULD** handle requests for multiple tasks, threads,
 or conversations. An open connection or stdio process is not a conversation.
-State that spans requests **MUST** be an explicit identifier the client
-passes ([Statelessness](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#statelessness);
+State that spans requests **MUST** be an explicit identifier the client passes
+([Statelessness](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#statelessness);
 [0005](./0005-mcp-dual-lane-stateless-migration.md)).
 
 Kody users talk to the same account from concurrent chats and from completely
@@ -18,18 +18,18 @@ separate agents. A memory shown in chat A must still be visible in chat B.
 
 ## Decision
 
-Do not treat the signed-in user, an MCP transport session, or an open
-connection as "the conversation." Do not add a user-global "already shown"
-window for auto-surfaced memories.
+Do not treat the signed-in user, an MCP transport session, or an open connection
+as "the conversation." Do not add a user-global "already shown" window for
+auto-surfaced memories.
 
-Do not treat the signed-in user, an MCP transport session, or an open
-connection as "the conversation." Do not add a user-global "already shown"
-window for auto-surfaced memories.
+Do not treat the signed-in user, an MCP transport session, or an open connection
+as "the conversation." Do not add a user-global "already shown" window for
+auto-surfaced memories.
 
 Surface relevant memories on the tool result that retrieved them. Do not hide
-auto-surface after the first show: a per-handle omit fails when the host
-drops earlier tool results. `conversationId` is a progressive-disclosure
-handle, not a hide key.
+auto-surface after the first show: a per-handle omit fails when the host drops
+earlier tool results. `conversationId` is a progressive-disclosure handle, not a
+hide key.
 
 Do not require a protocol conversation id in `_meta`. If a host later puts a
 stable thread or run id there, use that handle; do not invent a session
@@ -37,8 +37,8 @@ stand-in.
 
 ## Consequences
 
-Concurrent agents for one user stay isolated. Repeating a cheap one-liner
-costs less than hiding a rule that later falls out of context. Revisit only
-if a major host ships a spec-defined conversation or thread identifier that
-every request already carries, or if auto-surface token cost becomes large
-relative to the rest of the tool result.
+Concurrent agents for one user stay isolated. Repeating a cheap one-liner costs
+less than hiding a rule that later falls out of context. Revisit only if a major
+host ships a spec-defined conversation or thread identifier that every request
+already carries, or if auto-surface token cost becomes large relative to the
+rest of the tool result.

--- a/docs/contributing/decisions/0033-no-user-as-conversation.md
+++ b/docs/contributing/decisions/0033-no-user-as-conversation.md
@@ -22,11 +22,14 @@ Do not treat the signed-in user, an MCP transport session, or an open
 connection as "the conversation." Do not add a user-global "already shown"
 window for auto-surfaced memories.
 
-Surface relevant memories on the tool result that retrieved them. The host
-transcript is the conversation cache. Optional per-handle suppression stays
-keyed to a `conversationId` the request actually carries (caller-supplied, or
-a server-minted id later echoed). Hosts that omit the field every time get a
-fresh mint and see the memories again.
+Do not treat the signed-in user, an MCP transport session, or an open
+connection as "the conversation." Do not add a user-global "already shown"
+window for auto-surfaced memories.
+
+Surface relevant memories on the tool result that retrieved them. Do not hide
+auto-surface after the first show: a per-handle omit fails when the host
+drops earlier tool results. `conversationId` is a progressive-disclosure
+handle, not a hide key.
 
 Do not require a protocol conversation id in `_meta`. If a host later puts a
 stable thread or run id there, use that handle; do not invent a session
@@ -34,7 +37,8 @@ stand-in.
 
 ## Consequences
 
-Concurrent agents for one user stay isolated. Agents that never echo
-`conversationId` may see the same top memories on each call — that is
-correct. Revisit only if a major host ships a spec-defined conversation or
-thread identifier that every request already carries.
+Concurrent agents for one user stay isolated. Repeating a cheap one-liner
+costs less than hiding a rule that later falls out of context. Revisit only
+if a major host ships a spec-defined conversation or thread identifier that
+every request already carries, or if auto-surface token cost becomes large
+relative to the rest of the tool result.

--- a/docs/contributing/decisions/0033-no-user-as-conversation.md
+++ b/docs/contributing/decisions/0033-no-user-as-conversation.md
@@ -38,7 +38,8 @@ less than hiding a rule that later falls out of context.
 
 Evidence from the 2026-08-22 policy grid lives in
 [0033-memory-auto-surface-lab.md](./0033-memory-auto-surface-lab.md). Re-run
-`node tools/memory-auto-surface-lab/run.mjs` on the calendar check (2027-02-22)
-or sooner if a major host ships a spec-defined conversation or thread identifier
-that every request already carries, or if auto-surface token cost becomes large
+`node tools/memory-auto-surface-lab/run.mjs` on the calendar check
+([#1648](https://github.com/kentcdodds/kody/issues/1648), 2027-02-22) or sooner
+if a major host ships a spec-defined conversation or thread identifier that
+every request already carries, or if auto-surface token cost becomes large
 relative to the rest of the tool result.

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -61,6 +61,7 @@ Open these before proposing a new primitive, surface, or storage home.
 - [0024 — Packages outrank synthesized providers; no auto-delete or ranking toggle](./0024-packages-outrank-synthesized-providers.md)
 - [0025 — No package services primitive](./0025-no-package-services-primitive.md)
 - [0032 — No unattached jobs; schedules belong to packages or workflows](./0032-no-unattached-jobs.md)
+- [0033 — No user-as-conversation, MCP session, or user-global memory hide](./0033-no-user-as-conversation.md)
 - [0026 — Invocation tokens belong to one package; no account-level wildcard bearer](./0026-package-owned-invocation-tokens.md)
 - [0027 — No invocation-token source allowlist](./0027-no-invocation-token-source-allowlist.md)
 

--- a/docs/contributing/decisions/index.md
+++ b/docs/contributing/decisions/index.md
@@ -62,6 +62,7 @@ Open these before proposing a new primitive, surface, or storage home.
 - [0025 — No package services primitive](./0025-no-package-services-primitive.md)
 - [0032 — No unattached jobs; schedules belong to packages or workflows](./0032-no-unattached-jobs.md)
 - [0033 — No user-as-conversation, MCP session, or user-global memory hide](./0033-no-user-as-conversation.md)
+  ([lab](./0033-memory-auto-surface-lab.md))
 - [0026 — Invocation tokens belong to one package; no account-level wildcard bearer](./0026-package-owned-invocation-tokens.md)
 - [0027 — No invocation-token source allowlist](./0027-no-invocation-token-source-allowlist.md)
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -8,6 +8,8 @@ style, tests, MCP capabilities, and runtime architecture.
 - [Getting started](./getting-started.md), [project intent](./project-intent.md)
 - [Decision records](./decisions/index.md) (steering veto list: product-shaped
   nos and durable constraints — not an ADR-per-PR log)
+- [0033 memory auto-surface lab](./decisions/0033-memory-auto-surface-lab.md)
+  (policy-grid evidence; re-run `node tools/memory-auto-surface-lab/run.mjs`)
 - [Inbound contributions](./inbound-contributions.md) (CLA for patches to this
   repository)
 - [Setup](./setup.md), [environment variables](./environment-variables.md),

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -96,10 +96,10 @@ When working in this repo, do not assume:
   [Authorization](./architecture/authorization.md).
 - One conversation or one agent per signed-in user. Concurrent chats and
   completely separate agents for the same user are expected. Do not key
-  conversation-scoped behavior on the user alone, or on an MCP transport
-  session or open connection. State that spans requests needs an explicit
-  identifier the client actually passed — see MCP 2026-07-28 Statelessness
-  and [0033](./decisions/0033-no-user-as-conversation.md).
+  conversation-scoped behavior on the user alone, or on an MCP transport session
+  or open connection. State that spans requests needs an explicit identifier the
+  client actually passed — see MCP 2026-07-28 Statelessness and
+  [0033](./decisions/0033-no-user-as-conversation.md).
 - The main goal is enterprise-grade least-privilege design for many users.
 
 Also do not document capabilities as if they already exist. Keep design notes
@@ -129,9 +129,9 @@ If you are an agent working in this repo:
   boundaries: account administration, operator-owned system email, or
   user-approved platform feedback, or public-listing community activity metadata
   — see [Authorization](./architecture/authorization.md).
-- Isolation between users is not the same as one conversation per user. The
-  same signed-in user can run concurrent chats and completely separate agents
-  at once. Do not hide or bind conversation-scoped context (memories, nudges,
+- Isolation between users is not the same as one conversation per user. The same
+  signed-in user can run concurrent chats and completely separate agents at
+  once. Do not hide or bind conversation-scoped context (memories, nudges,
   progressive disclosure) to the user id alone or to an MCP session.
 - Avoid proposing a large static MCP tool catalog as the default direction.
 - Keep interoperability with MCP hosts in mind, especially around compact tool

--- a/docs/contributing/project-intent.md
+++ b/docs/contributing/project-intent.md
@@ -94,6 +94,12 @@ When working in this repo, do not assume:
   exposed through role-gated admin review capabilities, plus role-gated
   community activity metadata for public listings — see
   [Authorization](./architecture/authorization.md).
+- One conversation or one agent per signed-in user. Concurrent chats and
+  completely separate agents for the same user are expected. Do not key
+  conversation-scoped behavior on the user alone, or on an MCP transport
+  session or open connection. State that spans requests needs an explicit
+  identifier the client actually passed — see MCP 2026-07-28 Statelessness
+  and [0033](./decisions/0033-no-user-as-conversation.md).
 - The main goal is enterprise-grade least-privilege design for many users.
 
 Also do not document capabilities as if they already exist. Keep design notes
@@ -123,6 +129,10 @@ If you are an agent working in this repo:
   boundaries: account administration, operator-owned system email, or
   user-approved platform feedback, or public-listing community activity metadata
   — see [Authorization](./architecture/authorization.md).
+- Isolation between users is not the same as one conversation per user. The
+  same signed-in user can run concurrent chats and completely separate agents
+  at once. Do not hide or bind conversation-scoped context (memories, nudges,
+  progressive disclosure) to the user id alone or to an MCP session.
 - Avoid proposing a large static MCP tool catalog as the default direction.
 - Keep interoperability with MCP hosts in mind, especially around compact tool
   surfaces and clear server instructions.

--- a/docs/guides/how-kody-works.md
+++ b/docs/guides/how-kody-works.md
@@ -40,10 +40,11 @@ Agent notes — for AI agents explaining or recreating this loop:
   be notified, add a package-owned cron — do not wire a job into the first
   save. The scheduled wrapper must skip email_send when the list is empty.
 - search and execute can take a short memoryContext (task plus a couple of
-  entities). Relevant memories surface on the first tool that retrieves
-  them in a conversation — usually search. Search returns markdown
-  (`# Search results`), not a matches JSON object. Do not write memory
-  unless the person asks.
+  entities). Relevant memories surface as compact subject — summary
+  one-liners (ids in structured content) on search and on execute when
+  `memoryContext` is present. The same one-liners may repeat. Search
+  returns markdown (`# Search results`), not a matches JSON object. Do
+  not write memory unless the person asks.
 - Agents call the owned export from `execute` with a static
   `kody:@scope/package/export` import. Use `packages.invoke` only when the
   target name is data or the call must run in the package's own runtime.

--- a/docs/guides/how-kody-works.md
+++ b/docs/guides/how-kody-works.md
@@ -21,8 +21,8 @@ Agent notes — for AI agents explaining or recreating this loop:
   not `execute`, and not a GitHub integration or helper package (those
   would hide the `{{secret:githubAccessToken}}` placeholder in execute).
   A matching memory can surface with that first search (here it names
-  kody-bot as the favorite bot). Later search and execute calls in the
-  same conversation do not repeat it.
+  kody-bot as the favorite bot). Later search and execute calls do not
+  repeat it for a short window.
 - Before creating the package, search `{ query: "package authoring lifecycle",
   domain: "coding" }` to find `coding_guide_get`, then `search` with
   `entity: "coding_guide_get:capability"` so `package_authoring` and

--- a/docs/guides/how-kody-works.md
+++ b/docs/guides/how-kody-works.md
@@ -21,9 +21,8 @@ Agent notes — for AI agents explaining or recreating this loop:
   not `execute`, and not a GitHub integration or helper package (those
   would hide the `{{secret:githubAccessToken}}` placeholder in execute).
   A matching memory can surface with that first search (here it names
-  kody-bot as the favorite bot). Later calls that reuse that
-  `conversationId` do not repeat it. A different conversation or a
-  completely separate agent can see it again.
+  kody-bot as the favorite bot) as a compact subject and summary
+  one-liner. Later retrievals can repeat that one-liner.
 - Before creating the package, search `{ query: "package authoring lifecycle",
   domain: "coding" }` to find `coding_guide_get`, then `search` with
   `entity: "coding_guide_get:capability"` so `package_authoring` and

--- a/docs/guides/how-kody-works.md
+++ b/docs/guides/how-kody-works.md
@@ -21,8 +21,9 @@ Agent notes — for AI agents explaining or recreating this loop:
   not `execute`, and not a GitHub integration or helper package (those
   would hide the `{{secret:githubAccessToken}}` placeholder in execute).
   A matching memory can surface with that first search (here it names
-  kody-bot as the favorite bot). Later search and execute calls do not
-  repeat it for a short window.
+  kody-bot as the favorite bot). Later calls that reuse that
+  `conversationId` do not repeat it. A different conversation or a
+  completely separate agent can see it again.
 - Before creating the package, search `{ query: "package authoring lifecycle",
   domain: "coding" }` to find `coding_guide_get`, then `search` with
   `entity: "coding_guide_get:capability"` so `package_authoring` and

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -273,9 +273,9 @@ For dedicated inspection, use:
 
 Kody can surface a small number of relevant long-term memories when you pass a
 short **`memoryContext`** on normal MCP tool calls. `search` also retrieves
-from the query string. Surfaced memories appear in the tool text. Later calls
-that reuse the same `conversationId` skip memories already shown in that
-conversation.
+from the query string. Surfaced memories appear in the tool text as subject and
+summary only (id in structured content). Later retrievals can repeat that
+compact block.
 
 Handled **execute** responses also include top-level **`timing`** metadata with
 `startedAt`, `endedAt`, and `durationMs` alongside `conversationId`. Use it for

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -273,8 +273,9 @@ For dedicated inspection, use:
 
 Kody can surface a small number of relevant long-term memories when you pass a
 short **`memoryContext`** on normal MCP tool calls. `search` also retrieves
-from the query string. Surfaced memories appear in the tool text and stay
-suppressed for this user for a short window.
+from the query string. Surfaced memories appear in the tool text. Later calls
+that reuse the same `conversationId` skip memories already shown in that
+conversation.
 
 Handled **execute** responses also include top-level **`timing`** metadata with
 `startedAt`, `endedAt`, and `durationMs` alongside `conversationId`. Use it for

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -272,7 +272,9 @@ For dedicated inspection, use:
 ## Long-term memory
 
 Kody can surface a small number of relevant long-term memories when you pass a
-short **`memoryContext`** with **`conversationId`** on normal MCP tool calls.
+short **`memoryContext`** on normal MCP tool calls. `search` also retrieves
+from the query string. Surfaced memories appear in the tool text and stay
+suppressed for this user for a short window.
 
 Handled **execute** responses also include top-level **`timing`** metadata with
 `startedAt`, `endedAt`, and `durationMs` alongside `conversationId`. Use it for

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -272,8 +272,8 @@ For dedicated inspection, use:
 ## Long-term memory
 
 Kody can surface a small number of relevant long-term memories when you pass a
-short **`memoryContext`** on normal MCP tool calls. `search` also retrieves
-from the query string. Surfaced memories appear in the tool text as subject and
+short **`memoryContext`** on normal MCP tool calls. `search` also retrieves from
+the query string. Surfaced memories appear in the tool text as subject and
 summary only (id in structured content). Later retrievals can repeat that
 compact block.
 

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -13,9 +13,8 @@ secret reference, then run work through **execute**.
   timing metadata with `startedAt`, `endedAt`, and `durationMs` in structured
   responses.
 - **Pass `memoryContext`** when durable user memory may matter. Kody uses it to
-  surface a small set of relevant long-term memories. Later calls that reuse
-  the same `conversationId` skip memories already shown in that conversation.
-  `search` also retrieves from the query string.
+  surface a small set of relevant long-term memories as compact subject and
+  summary one-liners. `search` also retrieves from the query string.
 - **Think in packages for reusable saved code.** Packages expose exports,
   declare package-owned jobs, and can optionally expose an app/UI surface.
   Recurring schedules belong on a package under `kody.jobs`. Deferred one-shot

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -13,8 +13,9 @@ secret reference, then run work through **execute**.
   timing metadata with `startedAt`, `endedAt`, and `durationMs` in structured
   responses.
 - **Pass `memoryContext`** when durable user memory may matter. Kody uses it to
-  surface a small set of relevant long-term memories that have not already been
-  shown to this user recently. `search` also retrieves from the query string.
+  surface a small set of relevant long-term memories. Later calls that reuse
+  the same `conversationId` skip memories already shown in that conversation.
+  `search` also retrieves from the query string.
 - **Think in packages for reusable saved code.** Packages expose exports,
   declare package-owned jobs, and can optionally expose an app/UI surface.
   Recurring schedules belong on a package under `kody.jobs`. Deferred one-shot

--- a/docs/use/first-steps.md
+++ b/docs/use/first-steps.md
@@ -14,7 +14,7 @@ secret reference, then run work through **execute**.
   responses.
 - **Pass `memoryContext`** when durable user memory may matter. Kody uses it to
   surface a small set of relevant long-term memories that have not already been
-  shown in the same conversation.
+  shown to this user recently. `search` also retrieves from the query string.
 - **Think in packages for reusable saved code.** Packages expose exports,
   declare package-owned jobs, and can optionally expose an app/UI surface.
   Recurring schedules belong on a package under `kody.jobs`. Deferred one-shot

--- a/docs/use/memory.md
+++ b/docs/use/memory.md
@@ -2,19 +2,20 @@
 
 Kody supports two related memory features:
 
-- **conversation-scoped suppression** via **`conversationId`**
+- **recent-window suppression** after a memory is surfaced
 - **long-term memory retrieval and persistence** via **`memoryContext`** and
   memory capabilities
 
 ## `conversationId`
 
-**`conversationId`** ties related tool calls together. If you already have one
-from an earlier tool response in the same conversation, pass it back unchanged.
-Otherwise omit the field so Kody can return a server-generated id, then reuse
-that returned id on follow-up calls. Do not make one up yourself.
+**`conversationId`** ties related tool calls together for progressive disclosure
+and other per-thread optimizations. If you already have one from an earlier
+tool response, pass it back unchanged. Otherwise omit the field so Kody can
+return a server-generated id. Do not make one up yourself.
 
-Kody uses this id to avoid surfacing the same long-term memory repeatedly in one
-conversation.
+Memory auto-surface does not depend on reusing this id. A surfaced memory stays
+down for that user for a short window even when later calls mint a new
+`conversationId`.
 
 ## `memoryContext`
 
@@ -29,17 +30,22 @@ Keep it brief and factual. Good fields include:
 - important entities
 - important constraints
 
+`search` also retrieves from the query string when `memoryContext` is omitted.
+Domain-scoped search still does this. `execute` retrieves when `memoryContext`
+is present.
+
 ## Automatic memory surfacing
 
-When a signed-in agent includes **`memoryContext`**, Kody may return a small
-number of relevant not-yet-surfaced memories alongside the normal tool result.
+When retrieval runs, Kody may return a small number of relevant not-yet-surfaced
+memories in the tool text (as `## Relevant memories`) and in structured
+content.
 
 That retrieval is:
 
-- **conservative** — only a few memories
-- **task-based** — driven by `memoryContext`
-- **conversation-aware** — repeated memories are suppressed within the same
-  `conversationId`
+- **conservative** — the top one or two ranked active memories
+- **task-based** — driven by `memoryContext` and, for `search`, the query
+- **recent-window** — a memory already shown to this user stays suppressed for
+  a few hours
 
 ## Verify-first rule for memory writes
 

--- a/docs/use/memory.md
+++ b/docs/use/memory.md
@@ -38,10 +38,11 @@ is present.
 
 ## Automatic memory surfacing
 
-When retrieval runs, Kody may return a small number of relevant not-yet-surfaced
-memories in the tool text (as `## Relevant memories`) and in structured content.
-Auto-surface is compact: **subject**, **summary**, and **id** (structured).
-Details stay behind `meta_memory_get`.
+When retrieval runs, Kody may return the top one or two relevant active
+memories, including ones surfaced earlier, in the tool text (as
+`## Relevant memories`) and in structured content. Auto-surface is compact:
+**subject**, **summary**, and **id** (structured). Details stay behind
+`meta_memory_get`.
 
 That retrieval is:
 

--- a/docs/use/memory.md
+++ b/docs/use/memory.md
@@ -2,7 +2,8 @@
 
 Kody supports two related memory features:
 
-- **recent-window suppression** after a memory is surfaced
+- **per-conversation suppression** after a memory is surfaced on a reused
+  `conversationId`
 - **long-term memory retrieval and persistence** via **`memoryContext`** and
   memory capabilities
 
@@ -13,9 +14,10 @@ and other per-thread optimizations. If you already have one from an earlier
 tool response, pass it back unchanged. Otherwise omit the field so Kody can
 return a server-generated id. Do not make one up yourself.
 
-Memory auto-surface does not depend on reusing this id. A surfaced memory stays
-down for that user for a short window even when later calls mint a new
-`conversationId`.
+Memory auto-surface does not require this id. When the caller omits it, Kody
+mints one for the response and still returns relevant memories. Suppression is
+keyed to that handle only. A different conversation, or a completely separate
+agent for the same user, does not inherit it.
 
 ## `memoryContext`
 
@@ -44,8 +46,9 @@ That retrieval is:
 
 - **conservative** — the top one or two ranked active memories
 - **task-based** — driven by `memoryContext` and, for `search`, the query
-- **recent-window** — a memory already shown to this user stays suppressed for
-  a few hours
+- **per-conversation** — a memory already shown on this `conversationId` stays
+  down for later calls that reuse it; a new conversation or a separate agent
+  can see it again
 
 ## Verify-first rule for memory writes
 

--- a/docs/use/memory.md
+++ b/docs/use/memory.md
@@ -2,8 +2,8 @@
 
 Kody supports two related memory features:
 
-- **per-conversation suppression** after a memory is surfaced on a reused
-  `conversationId`
+- **compact auto-surface** on `search` and on `execute` when `memoryContext`
+  is present
 - **long-term memory retrieval and persistence** via **`memoryContext`** and
   memory capabilities
 
@@ -14,10 +14,10 @@ and other per-thread optimizations. If you already have one from an earlier
 tool response, pass it back unchanged. Otherwise omit the field so Kody can
 return a server-generated id. Do not make one up yourself.
 
-Memory auto-surface does not require this id. When the caller omits it, Kody
-mints one for the response and still returns relevant memories. Suppression is
-keyed to that handle only. A different conversation, or a completely separate
-agent for the same user, does not inherit it.
+Memory auto-surface does not require this id and does not hide a memory after
+showing it. The compact one-liner can repeat on later retrievals so it stays
+in context if earlier tool results were dropped. A different conversation, or
+a completely separate agent for the same user, sees the same compact block.
 
 ## `memoryContext`
 
@@ -40,15 +40,15 @@ is present.
 
 When retrieval runs, Kody may return a small number of relevant not-yet-surfaced
 memories in the tool text (as `## Relevant memories`) and in structured
-content.
+content. Auto-surface is compact: **subject**, **summary**, and **id**
+(structured). Details stay behind `meta_memory_get`.
 
 That retrieval is:
 
 - **conservative** — the top one or two ranked active memories
 - **task-based** — driven by `memoryContext` and, for `search`, the query
-- **per-conversation** — a memory already shown on this `conversationId` stays
-  down for later calls that reuse it; a new conversation or a separate agent
-  can see it again
+- **cheap to repeat** — subject and summary only; the same one-liners may
+  appear again so a compacted context still has the rule
 
 ## Verify-first rule for memory writes
 

--- a/docs/use/memory.md
+++ b/docs/use/memory.md
@@ -2,22 +2,22 @@
 
 Kody supports two related memory features:
 
-- **compact auto-surface** on `search` and on `execute` when `memoryContext`
-  is present
+- **compact auto-surface** on `search` and on `execute` when `memoryContext` is
+  present
 - **long-term memory retrieval and persistence** via **`memoryContext`** and
   memory capabilities
 
 ## `conversationId`
 
 **`conversationId`** ties related tool calls together for progressive disclosure
-and other per-thread optimizations. If you already have one from an earlier
-tool response, pass it back unchanged. Otherwise omit the field so Kody can
-return a server-generated id. Do not make one up yourself.
+and other per-thread optimizations. If you already have one from an earlier tool
+response, pass it back unchanged. Otherwise omit the field so Kody can return a
+server-generated id. Do not make one up yourself.
 
 Memory auto-surface does not require this id and does not hide a memory after
-showing it. The compact one-liner can repeat on later retrievals so it stays
-in context if earlier tool results were dropped. A different conversation, or
-a completely separate agent for the same user, sees the same compact block.
+showing it. The compact one-liner can repeat on later retrievals so it stays in
+context if earlier tool results were dropped. A different conversation, or a
+completely separate agent for the same user, sees the same compact block.
 
 ## `memoryContext`
 
@@ -39,16 +39,16 @@ is present.
 ## Automatic memory surfacing
 
 When retrieval runs, Kody may return a small number of relevant not-yet-surfaced
-memories in the tool text (as `## Relevant memories`) and in structured
-content. Auto-surface is compact: **subject**, **summary**, and **id**
-(structured). Details stay behind `meta_memory_get`.
+memories in the tool text (as `## Relevant memories`) and in structured content.
+Auto-surface is compact: **subject**, **summary**, and **id** (structured).
+Details stay behind `meta_memory_get`.
 
 That retrieval is:
 
 - **conservative** — the top one or two ranked active memories
 - **task-based** — driven by `memoryContext` and, for `search`, the query
-- **cheap to repeat** — subject and summary only; the same one-liners may
-  appear again so a compacted context still has the rule
+- **cheap to repeat** — subject and summary only; the same one-liners may appear
+  again so a compacted context still has the rule
 
 ## Verify-first rule for memory writes
 

--- a/docs/use/search.md
+++ b/docs/use/search.md
@@ -89,7 +89,8 @@ how long the ranked lookup or entity lookup took.
 
 Optional **`limit`** caps how many ranked hits return. Optional
 **`maxResponseSize`** trims low-ranked matches against the compact list when the
-response must stay small.
+response must stay small. Auto-surfaced memory one-liners are reserved first so
+a tight size budget does not drop them.
 
 ## Entity indexes and detail
 

--- a/packages/worker/client/routes/how-kody-works-transcript.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.ts
@@ -537,7 +537,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 						name: 'execute',
 						summary:
 							'Fetch public events with the saved token and keep only real ships',
-						note: 'The module never sees the token. `Authorization` gets a secret placeholder, filled in only for approved hosts. The kody-bot memory already surfaced on search, so execute does not repeat it.',
+						note: 'The module never sees the token. `Authorization` gets a secret placeholder, filled in only for approved hosts. The compact kody-bot memory one-liner can appear again on execute.',
 						inputs: [
 							{
 								name: 'code',
@@ -551,6 +551,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 						resultLang: 'md',
 						result: executeTextReturn({
 							conversationId: askConversationId,
+							memories: [watchLoginMemory],
 							value: [
 								{
 									id: '51284920123',
@@ -789,7 +790,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 					{
 						name: 'execute',
 						summary: 'Invoke the export — no model rewriting the filter',
-						note: 'A static `kody:@` import calls the export as written. No model rewrites the filter. The kody-bot memory already surfaced on this phone search, so execute does not repeat it.',
+						note: 'A static `kody:@` import calls the export as written. No model rewrites the filter. The compact kody-bot memory one-liner can appear again on execute.',
 						inputs: [
 							{
 								name: 'code',
@@ -803,6 +804,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 						resultLang: 'md',
 						result: executeTextReturn({
 							conversationId: phoneConversationId,
+							memories: [watchLoginMemory],
 							value: {
 								shipped: [],
 								message: 'Nothing new.',
@@ -830,7 +832,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 					{
 						name: 'search',
 						summary: 'Find how to notify when the export has news',
-						note: 'Same phone conversation, new task. Search ranks the lifecycle guide, inbound webhooks, and package-owned jobs. The kody-bot memory already surfaced earlier in this chat.',
+						note: 'Same phone conversation, new task. Search ranks the lifecycle guide, inbound webhooks, and package-owned jobs. The compact kody-bot memory one-liner can appear again.',
 						inputs: [
 							{
 								name: 'query',
@@ -845,6 +847,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 						result: searchTextReturn({
 							conversationId: phoneConversationId,
 							body: notifySearchMarkdown,
+							memories: [watchLoginMemory],
 						}),
 					},
 					{

--- a/packages/worker/client/routes/how-kody-works-transcript.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.ts
@@ -769,7 +769,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 					{
 						name: 'search',
 						summary: 'Find the owned package, not a new GitHub walk',
-						note: 'A new conversation, and a new wording. Search still finds the owned package instead of walking GitHub again, and the kody-bot memory surfaces once more.',
+						note: 'A new conversationId and a new wording. Search still finds the owned package instead of walking GitHub again. The kody-bot memory stays down for a short window, so it is not repeated.',
 						inputs: [
 							{
 								name: 'query',
@@ -783,13 +783,12 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 						result: searchTextReturn({
 							conversationId: phoneConversationId,
 							body: packageSearchMarkdown,
-							memories: [watchLoginMemory],
 						}),
 					},
 					{
 						name: 'execute',
 						summary: 'Invoke the export — no model rewriting the filter',
-						note: 'A static `kody:@` import calls the export as written. No model rewrites the filter. The memory already surfaced on search in this new conversation.',
+						note: 'A static `kody:@` import calls the export as written. No model rewrites the filter. The kody-bot memory already surfaced earlier, so this call does not repeat it.',
 						inputs: [
 							{
 								name: 'code',

--- a/packages/worker/client/routes/how-kody-works-transcript.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.ts
@@ -769,7 +769,7 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 					{
 						name: 'search',
 						summary: 'Find the owned package, not a new GitHub walk',
-						note: 'A new conversationId and a new wording. Search still finds the owned package instead of walking GitHub again. The kody-bot memory stays down for a short window, so it is not repeated.',
+						note: 'A new conversationId and a new wording. Search still finds the owned package instead of walking GitHub again. This is a separate agent, so the kody-bot memory can surface again.',
 						inputs: [
 							{
 								name: 'query',
@@ -783,12 +783,13 @@ export const howKodyWorksTranscriptActs: Array<TranscriptAct> = [
 						result: searchTextReturn({
 							conversationId: phoneConversationId,
 							body: packageSearchMarkdown,
+							memories: [watchLoginMemory],
 						}),
 					},
 					{
 						name: 'execute',
 						summary: 'Invoke the export — no model rewriting the filter',
-						note: 'A static `kody:@` import calls the export as written. No model rewrites the filter. The kody-bot memory already surfaced earlier, so this call does not repeat it.',
+						note: 'A static `kody:@` import calls the export as written. No model rewrites the filter. The kody-bot memory already surfaced on this phone search, so execute does not repeat it.',
 						inputs: [
 							{
 								name: 'code',

--- a/packages/worker/client/routes/how-kody-works-transcript.ts
+++ b/packages/worker/client/routes/how-kody-works-transcript.ts
@@ -315,6 +315,7 @@ const notifyMemoryContext = {
 }
 
 const watchLoginMemory = {
+	id: 'mem_favorite_bot',
 	subject: 'Favorite bot',
 	summary:
 		"kody-bot is my favorite bot. I'm really interested in what it ships on github",

--- a/packages/worker/client/routes/interactive-guide-transcript.ts
+++ b/packages/worker/client/routes/interactive-guide-transcript.ts
@@ -71,9 +71,13 @@ export function conversationIdReturn(conversationId: string) {
 	return `conversationId: ${conversationId}\n${conversationIdReturnNote}`
 }
 
-function relevantMemoriesMarkdown(
-	memories: Array<{ subject: string; summary: string }>,
-) {
+type TranscriptMemory = {
+	id: string
+	subject: string
+	summary: string
+}
+
+function relevantMemoriesMarkdown(memories: Array<TranscriptMemory>) {
 	return [
 		'## Relevant memories',
 		'',
@@ -81,14 +85,31 @@ function relevantMemoriesMarkdown(
 	].join('\n')
 }
 
+function relevantMemoriesStructured(memories: Array<TranscriptMemory>) {
+	return jsonInput({
+		memories: {
+			surfaced: memories.map((memory) => ({
+				id: memory.id,
+				subject: memory.subject,
+				summary: memory.summary,
+			})),
+		},
+	})
+}
+
 export function searchTextReturn(input: {
 	conversationId: string
 	body: string
-	memories?: Array<{ subject: string; summary: string }>
+	memories?: Array<TranscriptMemory>
 }) {
 	const parts = [conversationIdReturn(input.conversationId), '', input.body]
 	if (input.memories && input.memories.length > 0) {
-		parts.push('', relevantMemoriesMarkdown(input.memories))
+		parts.push(
+			'',
+			relevantMemoriesMarkdown(input.memories),
+			'',
+			relevantMemoriesStructured(input.memories),
+		)
 	}
 	return parts.join('\n')
 }
@@ -96,7 +117,7 @@ export function searchTextReturn(input: {
 export function executeTextReturn(input: {
 	conversationId: string
 	value: unknown
-	memories?: Array<{ subject: string; summary: string }>
+	memories?: Array<TranscriptMemory>
 }) {
 	const parts = [
 		conversationIdReturn(input.conversationId),
@@ -104,7 +125,12 @@ export function executeTextReturn(input: {
 		jsonInput(input.value),
 	]
 	if (input.memories && input.memories.length > 0) {
-		parts.push('', relevantMemoriesMarkdown(input.memories))
+		parts.push(
+			'',
+			relevantMemoriesMarkdown(input.memories),
+			'',
+			relevantMemoriesStructured(input.memories),
+		)
 	}
 	return parts.join('\n')
 }

--- a/packages/worker/src/mcp/memory/service.node.test.ts
+++ b/packages/worker/src/mcp/memory/service.node.test.ts
@@ -11,6 +11,7 @@ import {
 	acknowledgeSurfacedMemories,
 	deleteMemory,
 	getMemory,
+	recentMemorySuppressionScopeId,
 	searchMemoryRecords,
 	surfaceRelevantMemories,
 	upsertMemory,
@@ -499,7 +500,7 @@ test('memory surfacing suppresses repeated memories per conversation', async () 
 		env: runtimeEnv,
 		userId: 'user-123',
 		query: 'deployment preference after 4pm',
-		conversationId: 'conv-123',
+		conversationId: 'conv-fresh-id',
 	})
 
 	expect(second.memories).toHaveLength(0)
@@ -509,7 +510,7 @@ test('memory surfacing suppresses repeated memories per conversation', async () 
 		env: runtimeEnv,
 		userId: 'user-123',
 		query: 'deployment preference after 4pm',
-		conversationId: 'conv-123',
+		conversationId: 'conv-another-id',
 	})
 
 	expect(search.matches).toHaveLength(0)
@@ -541,10 +542,12 @@ test('acknowledgeSurfacedMemories writes suppressions and last_accessed in one b
 	expect(testDb.batches).toHaveLength(1)
 	expect(testDb.batches[0]).toHaveLength(2)
 	expect(
-		testDb.suppressions.get(`user-123:conv-ack-batch:${created.memory.id}`),
+		testDb.suppressions.get(
+			`user-123:${recentMemorySuppressionScopeId}:${created.memory.id}`,
+		),
 	).toMatchObject({
 		memory_id: created.memory.id,
-		conversation_id: 'conv-ack-batch',
+		conversation_id: recentMemorySuppressionScopeId,
 	})
 	expect(testDb.memories.get(created.memory.id)?.last_accessed_at).toEqual(
 		expect.any(String),

--- a/packages/worker/src/mcp/memory/service.node.test.ts
+++ b/packages/worker/src/mcp/memory/service.node.test.ts
@@ -11,7 +11,6 @@ import {
 	acknowledgeSurfacedMemories,
 	deleteMemory,
 	getMemory,
-	recentMemorySuppressionScopeId,
 	searchMemoryRecords,
 	surfaceRelevantMemories,
 	upsertMemory,
@@ -500,17 +499,27 @@ test('memory surfacing suppresses repeated memories per conversation', async () 
 		env: runtimeEnv,
 		userId: 'user-123',
 		query: 'deployment preference after 4pm',
-		conversationId: 'conv-fresh-id',
+		conversationId: 'conv-123',
 	})
 
 	expect(second.memories).toHaveLength(0)
 	expect(second.suppressedCount).toBeGreaterThanOrEqual(1)
 
+	const otherConversation = await surfaceRelevantMemories({
+		env: runtimeEnv,
+		userId: 'user-123',
+		query: 'deployment preference after 4pm',
+		conversationId: 'conv-other-agent',
+	})
+
+	expect(otherConversation.memories).toHaveLength(1)
+	expect(otherConversation.suppressedCount).toBe(0)
+
 	const search = await searchMemoryRecords({
 		env: runtimeEnv,
 		userId: 'user-123',
 		query: 'deployment preference after 4pm',
-		conversationId: 'conv-another-id',
+		conversationId: 'conv-123',
 	})
 
 	expect(search.matches).toHaveLength(0)
@@ -542,12 +551,10 @@ test('acknowledgeSurfacedMemories writes suppressions and last_accessed in one b
 	expect(testDb.batches).toHaveLength(1)
 	expect(testDb.batches[0]).toHaveLength(2)
 	expect(
-		testDb.suppressions.get(
-			`user-123:${recentMemorySuppressionScopeId}:${created.memory.id}`,
-		),
+		testDb.suppressions.get(`user-123:conv-ack-batch:${created.memory.id}`),
 	).toMatchObject({
 		memory_id: created.memory.id,
-		conversation_id: recentMemorySuppressionScopeId,
+		conversation_id: 'conv-ack-batch',
 	})
 	expect(testDb.memories.get(created.memory.id)?.last_accessed_at).toEqual(
 		expect.any(String),

--- a/packages/worker/src/mcp/memory/service.ts
+++ b/packages/worker/src/mcp/memory/service.ts
@@ -37,7 +37,10 @@ const maxTagLength = 80
 const maxTagCount = 16
 const maxSourceUriLength = 2_048
 const maxSourceUriCount = 12
-const defaultSuppressionTtlMs = 30 * 24 * 60 * 60 * 1_000
+/** Shared recent-window key so a new conversationId does not reset suppression. */
+export const recentMemorySuppressionScopeId = 'user-recent'
+/** Hours, not a month: user-wide so omitted conversation ids still dedupe. */
+export const recentMemorySuppressionTtlMs = 4 * 60 * 60 * 1_000
 /** Offline (no Vectorize): lexical + deterministic ranking over recent rows. */
 const memoryOfflineCandidateLimit = 200
 /** Online: bounded recent-row set fused with Vectorize top hits via RRF. */
@@ -137,7 +140,9 @@ type SurfaceRelevantMemoriesInput = MemoryOwnerContext & {
 }
 
 /**
- * Marks memories as surfaced for a conversation so later enrichment does not repeat them.
+ * Marks memories as surfaced for this user so later enrichment does not
+ * repeat them during the recent window. `conversationId` is accepted for
+ * call-site compatibility and is not the suppression key.
  */
 export async function acknowledgeSurfacedMemories(input: {
 	env: MemoryEnv
@@ -155,12 +160,12 @@ export async function acknowledgeSurfacedMemories(input: {
 			)
 			if (memoryIds.length === 0) return
 			const expiresAt = new Date(
-				Date.now() + defaultSuppressionTtlMs,
+				Date.now() + recentMemorySuppressionTtlMs,
 			).toISOString()
 			await acknowledgeSurfacedMemoryWrites({
 				db: input.env.APP_DB,
 				userId: input.userId,
-				conversationId: input.conversationId,
+				conversationId: recentMemorySuppressionScopeId,
 				memoryIds,
 				expiresAt,
 			})
@@ -713,17 +718,13 @@ async function filterSuppressedMatches(input: {
 	includeSuppressedInConversation: boolean
 	matches: Array<MemorySearchMatch>
 }) {
-	if (
-		!input.conversationId ||
-		input.includeSuppressedInConversation ||
-		input.matches.length === 0
-	) {
+	if (input.includeSuppressedInConversation || input.matches.length === 0) {
 		return { matches: input.matches, suppressedCount: 0 }
 	}
 	const suppressions = await getConversationSuppressions({
 		db: input.db,
 		userId: input.userId,
-		conversationId: input.conversationId,
+		conversationId: recentMemorySuppressionScopeId,
 	})
 	const suppressedIds = new Set(suppressions.map((entry) => entry.memory_id))
 	const visible = input.matches.filter((match) => !suppressedIds.has(match.id))

--- a/packages/worker/src/mcp/memory/service.ts
+++ b/packages/worker/src/mcp/memory/service.ts
@@ -37,10 +37,8 @@ const maxTagLength = 80
 const maxTagCount = 16
 const maxSourceUriLength = 2_048
 const maxSourceUriCount = 12
-/** Shared recent-window key so a new conversationId does not reset suppression. */
-export const recentMemorySuppressionScopeId = 'user-recent'
-/** Hours, not a month: user-wide so omitted conversation ids still dedupe. */
-export const recentMemorySuppressionTtlMs = 4 * 60 * 60 * 1_000
+/** Per-handle hide after a memory is surfaced; unused if the id is never echoed. */
+const defaultSuppressionTtlMs = 30 * 24 * 60 * 60 * 1_000
 /** Offline (no Vectorize): lexical + deterministic ranking over recent rows. */
 const memoryOfflineCandidateLimit = 200
 /** Online: bounded recent-row set fused with Vectorize top hits via RRF. */
@@ -140,9 +138,9 @@ type SurfaceRelevantMemoriesInput = MemoryOwnerContext & {
 }
 
 /**
- * Marks memories as surfaced for this user so later enrichment does not
- * repeat them during the recent window. `conversationId` is accepted for
- * call-site compatibility and is not the suppression key.
+ * Marks memories as surfaced for one conversation handle so later enrichment
+ * on that same handle does not repeat them. A different handle, including a
+ * server-minted id from another chat, stays visible.
  */
 export async function acknowledgeSurfacedMemories(input: {
 	env: MemoryEnv
@@ -160,12 +158,12 @@ export async function acknowledgeSurfacedMemories(input: {
 			)
 			if (memoryIds.length === 0) return
 			const expiresAt = new Date(
-				Date.now() + recentMemorySuppressionTtlMs,
+				Date.now() + defaultSuppressionTtlMs,
 			).toISOString()
 			await acknowledgeSurfacedMemoryWrites({
 				db: input.env.APP_DB,
 				userId: input.userId,
-				conversationId: recentMemorySuppressionScopeId,
+				conversationId: input.conversationId,
 				memoryIds,
 				expiresAt,
 			})
@@ -718,13 +716,17 @@ async function filterSuppressedMatches(input: {
 	includeSuppressedInConversation: boolean
 	matches: Array<MemorySearchMatch>
 }) {
-	if (input.includeSuppressedInConversation || input.matches.length === 0) {
+	if (
+		!input.conversationId ||
+		input.includeSuppressedInConversation ||
+		input.matches.length === 0
+	) {
 		return { matches: input.matches, suppressedCount: 0 }
 	}
 	const suppressions = await getConversationSuppressions({
 		db: input.db,
 		userId: input.userId,
-		conversationId: recentMemorySuppressionScopeId,
+		conversationId: input.conversationId,
 	})
 	const suppressedIds = new Set(suppressions.map((entry) => entry.memory_id))
 	const visible = input.matches.filter((match) => !suppressedIds.has(match.id))

--- a/packages/worker/src/mcp/tools/memory-tool-context.node.test.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.node.test.ts
@@ -18,9 +18,11 @@ vi.mock('#worker/package-retrievers/service.ts', () => ({
 		mockModule.runPackageRetrievers(...args),
 }))
 
-const { loadRelevantMemoriesForTool } = await import('./memory-tool-context.ts')
-const { formatSurfacedMemoriesMarkdown } =
-	await import('./memory-tool-context.ts')
+const {
+	automaticMemorySingleListRankOneScore,
+	formatSurfacedMemoriesMarkdown,
+	loadRelevantMemoriesForTool,
+} = await import('./memory-tool-context.ts')
 
 function setupMemoryContextMocks() {
 	mockModule.searchMemoryRecords.mockReset()
@@ -148,15 +150,21 @@ test('memory tool context surfaces retrievers, filters weak matches, fails on re
 		matches: [
 			{
 				...baseMemory,
-				id: 'active-strong',
+				id: 'active-rank-one',
 				status: 'active',
-				score: 0.03,
+				score: automaticMemorySingleListRankOneScore,
 			},
 			{
 				...baseMemory,
-				id: 'active-noise',
+				id: 'active-rank-two',
 				status: 'active',
-				score: 0.0164,
+				score: 1 / 62,
+			},
+			{
+				...baseMemory,
+				id: 'active-rank-three',
+				status: 'active',
+				score: 1 / 63,
 			},
 			{
 				...baseMemory,
@@ -181,7 +189,8 @@ test('memory tool context surfaces retrievers, filters weak matches, fails on re
 		acknowledgeSurfaced: false,
 	})
 	expect(filtered?.memories.map((memory) => memory.id)).toEqual([
-		'active-strong',
+		'active-rank-one',
+		'active-rank-two',
 	])
 	expect(mockModule.acknowledgeSurfacedMemories).not.toHaveBeenCalled()
 })

--- a/packages/worker/src/mcp/tools/memory-tool-context.node.test.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.node.test.ts
@@ -188,9 +188,31 @@ test('memory tool context surfaces retrievers, filters weak matches, fails on re
 		memoryContext: { query: 'ranked search' },
 		acknowledgeSurfaced: false,
 	})
-	expect(filtered?.memories.map((memory) => memory.id)).toEqual([
-		'active-rank-one',
-		'active-rank-two',
+	expect(filtered?.memories).toEqual([
+		{
+			id: 'active-rank-one',
+			subject: 'Search workflow',
+			summary: 'Use ranked search.',
+		},
+		{
+			id: 'active-rank-two',
+			subject: 'Search workflow',
+			summary: 'Use ranked search.',
+		},
 	])
 	expect(mockModule.acknowledgeSurfacedMemories).not.toHaveBeenCalled()
+
+	const [compactContent] = formatSurfacedMemoriesMarkdown(filtered)
+	expect(compactContent?.text).toBe(
+		[
+			'## Relevant memories',
+			'',
+			'- **Search workflow** — Use ranked search.',
+			'- **Search workflow** — Use ranked search.',
+		].join('\n'),
+	)
+	expect(compactContent?.text).not.toContain('Category')
+	expect(compactContent?.text).not.toContain('Tags')
+	expect(compactContent?.text).not.toContain('Updated')
+	expect(compactContent?.text).not.toContain('active-rank-one')
 })

--- a/packages/worker/src/mcp/tools/memory-tool-context.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.ts
@@ -14,14 +14,8 @@ import {
 export type MemoryToolSummary = {
 	memories: Array<{
 		id: string
-		category: string | null
-		status: string
 		subject: string
 		summary: string
-		details: string
-		tags: Array<string>
-		sourceUris: Array<string>
-		updatedAt: string
 	}>
 	retrieverResults: Array<PackageRetrieverSurfaceResult>
 	retrieverWarnings: Array<string>
@@ -63,16 +57,9 @@ async function loadAutomaticMemories(input: {
 		query: input.query,
 		conversationId: input.conversationId,
 		limit: input.limit,
+		includeSuppressedInConversation: true,
 	})
 	const memories = selectAutomaticMemories(result.matches)
-	if (input.acknowledgeSurfaced !== false && memories.length > 0) {
-		await acknowledgeSurfacedMemories({
-			env: input.env,
-			userId: input.userId,
-			conversationId: input.conversationId,
-			memoryIds: memories.map((memory) => memory.id),
-		})
-	}
 	return {
 		memories,
 		suppressedCount: result.suppressedCount,
@@ -274,20 +261,6 @@ function formatRelevantMemoriesMarkdown(memorySummary: MemoryToolSummary) {
 		lines.push('## Relevant memories', '')
 		for (const memory of memorySummary.memories) {
 			lines.push(`- **${memory.subject}** — ${memory.summary}`)
-			if (memory.category) {
-				lines.push(`  - Category: \`${memory.category}\``)
-			}
-			if (memory.tags.length > 0) {
-				lines.push(
-					`  - Tags: ${memory.tags.map((tag) => `\`${tag}\``).join(', ')}`,
-				)
-			}
-			if (memory.sourceUris.length > 0) {
-				lines.push(
-					`  - Sources: ${memory.sourceUris.map((sourceUri) => `\`${sourceUri}\``).join(', ')}`,
-				)
-			}
-			lines.push(`  - Updated: \`${memory.updatedAt}\``)
 		}
 	}
 	if (memorySummary.retrieverResults.length > 0) {
@@ -323,13 +296,7 @@ function formatRelevantMemoriesMarkdown(memorySummary: MemoryToolSummary) {
 function toMemoryToolSummaryItem(memory: MemoryRecord) {
 	return {
 		id: memory.id,
-		category: memory.category,
-		status: memory.status,
 		subject: memory.subject,
 		summary: memory.summary,
-		details: memory.details,
-		tags: memory.tags,
-		sourceUris: memory.sourceUris,
-		updatedAt: memory.updatedAt,
 	}
 }

--- a/packages/worker/src/mcp/tools/memory-tool-context.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.ts
@@ -29,8 +29,20 @@ export type MemoryToolSummary = {
 	retrievalQuery: string
 }
 
-/** Automatic context drops one-list RRF noise (~0.016 at k=60). */
-const automaticMemoryScoreFloor = 0.02
+/** Single-list RRF rank-1 at k=60 is 1/61. Used by tests as the inject floor. */
+export const automaticMemorySingleListRankOneScore = 1 / 61
+/** Auto-surface keeps the top ranked active hits, not an absolute score cut. */
+const automaticMemorySurfaceLimit = 2
+
+function selectAutomaticMemories<
+	T extends {
+		status: string
+	},
+>(matches: Array<T>) {
+	return matches
+		.filter((match) => match.status === 'active')
+		.slice(0, automaticMemorySurfaceLimit)
+}
 
 async function loadAutomaticMemories(input: {
 	env: Pick<Env, 'APP_DB'> & Partial<Pick<Env, 'CAPABILITY_VECTOR_INDEX'>>
@@ -52,10 +64,7 @@ async function loadAutomaticMemories(input: {
 		conversationId: input.conversationId,
 		limit: input.limit,
 	})
-	const memories = result.matches.filter(
-		(match) =>
-			match.status === 'active' && match.score >= automaticMemoryScoreFloor,
-	)
+	const memories = selectAutomaticMemories(result.matches)
 	if (input.acknowledgeSurfaced !== false && memories.length > 0) {
 		await acknowledgeSurfacedMemories({
 			env: input.env,

--- a/packages/worker/src/mcp/tools/search-execution.ts
+++ b/packages/worker/src/mcp/tools/search-execution.ts
@@ -101,11 +101,10 @@ async function executeSearchListWithinBudget(
 			registry: preloadedSearchRows.registry,
 		})
 	}
-	const rankedQuery =
+	const shouldEnrichMemory =
 		Boolean(input.query) &&
-		!domainFilter &&
 		(!identityResolution.recognized || identityMatchesProvider)
-	const memoryLaunch = rankedQuery
+	const memoryLaunch = shouldEnrichMemory
 		? launchSearchMemoryEnrichment({
 				env: input.env,
 				callerContext: input.callerContext,
@@ -197,7 +196,7 @@ async function executeSearchListWithinBudget(
 		result.matches.length > 0 &&
 		result.matches.every((match) => match.type === 'domain')
 	const memorySettlement =
-		rankedQuery && !returnsDomainIndex
+		shouldEnrichMemory && !returnsDomainIndex
 			? await settleSearchMemoryEnrichment({
 					env: input.env,
 					callerContext: input.callerContext,

--- a/packages/worker/src/mcp/tools/search-execution.ts
+++ b/packages/worker/src/mcp/tools/search-execution.ts
@@ -198,9 +198,6 @@ async function executeSearchListWithinBudget(
 	const memorySettlement =
 		shouldEnrichMemory && !returnsDomainIndex
 			? await settleSearchMemoryEnrichment({
-					env: input.env,
-					callerContext: input.callerContext,
-					conversationId: input.conversationId,
 					promise: memoryEnrichmentPromise,
 					launchedAtMs: memoryEnrichmentLaunchedAtMs,
 				})

--- a/packages/worker/src/mcp/tools/search-execution.ts
+++ b/packages/worker/src/mcp/tools/search-execution.ts
@@ -1,5 +1,6 @@
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import { runWithDynamicWorkerEvaluationBudget } from '#mcp/executor.ts'
+import { buildMemoryRetrievalQuery } from '#mcp/tools/memory-tool-context.ts'
 import { getPackageAppBaseUrl } from '#worker/app-base-url.ts'
 import { resolvePublicUsername } from '#worker/identity/user-lookup.ts'
 import { runPackageRetrievers } from '#worker/package-retrievers/service.ts'
@@ -101,8 +102,11 @@ async function executeSearchListWithinBudget(
 			registry: preloadedSearchRows.registry,
 		})
 	}
+	const memoryContextRetrievalQuery = buildMemoryRetrievalQuery(
+		input.memoryContext,
+	)
 	const shouldEnrichMemory =
-		Boolean(input.query) &&
+		(Boolean(input.query) || Boolean(memoryContextRetrievalQuery)) &&
 		(!identityResolution.recognized || identityMatchesProvider)
 	const memoryLaunch = shouldEnrichMemory
 		? launchSearchMemoryEnrichment({
@@ -196,7 +200,8 @@ async function executeSearchListWithinBudget(
 		result.matches.length > 0 &&
 		result.matches.every((match) => match.type === 'domain')
 	const memorySettlement =
-		shouldEnrichMemory && !returnsDomainIndex
+		shouldEnrichMemory &&
+		(!returnsDomainIndex || Boolean(memoryContextRetrievalQuery))
 			? await settleSearchMemoryEnrichment({
 					promise: memoryEnrichmentPromise,
 					launchedAtMs: memoryEnrichmentLaunchedAtMs,

--- a/packages/worker/src/mcp/tools/search-format-types.ts
+++ b/packages/worker/src/mcp/tools/search-format-types.ts
@@ -82,13 +82,8 @@ export type SearchResultStructuredContent = {
 	memories?: {
 		surfaced: Array<{
 			id: string
-			category: string | null
-			status: string
 			subject: string
 			summary: string
-			details: string
-			tags: Array<string>
-			updatedAt: string
 		}>
 		suppressedCount: number
 		retrievalQuery: string

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -1154,6 +1154,128 @@ test('search tool memory enrichment: timeout, rejection, and ack failure stay of
 	}
 }, 10_000)
 
+test('search reserves maxResponseSize for memories and still enriches from memoryContext', async () => {
+	vi.clearAllMocks()
+	consoleWarn.mockImplementation(() => {})
+	const longSummary =
+		'Never send email unless that exact message is requested. '
+			.repeat(40)
+			.trim()
+	const memorySummary = {
+		memories: [
+			{
+				id: 'memory-draft-only',
+				category: 'preference',
+				status: 'active',
+				subject: 'Draft only',
+				summary: longSummary,
+				details: 'Long details must stay out of the reserved memory block.',
+				tags: ['email'],
+				sourceUris: [],
+				updatedAt: '2026-04-20T00:00:00.000Z',
+			},
+		],
+		suppressedCount: 0,
+		retrievalQuery: 'draft an email',
+		retrieverResults: [],
+		retrieverWarnings: [],
+	}
+	mockModule.loadRelevantMemoriesForTool.mockResolvedValue(memorySummary)
+	const user = {
+		userId: 'user-1',
+		email: 'user@example.com',
+		displayName: 'User',
+		username: 'user',
+	}
+	const { handler } = await getSearchRegistration({ user })
+
+	const maxResponseSize = 2_000
+	const tightResponse = await handler({
+		query: 'search docs',
+		conversationId: 'conv-memory-budget-reserve',
+		maxResponseSize,
+	})
+	expect(tightResponse.isError).toBeUndefined()
+	const tightText = tightResponse.content.map((item) => item.text).join('\n')
+	const tightMemoryBlock = tightResponse.content.find((item) =>
+		item.text.includes('## Relevant memories'),
+	)
+	expect(tightMemoryBlock?.text).toContain(longSummary)
+	expect(tightMemoryBlock?.text).not.toContain(
+		'Long details must stay out of the reserved memory block.',
+	)
+	expect(tightText).not.toContain(
+		'Long details must stay out of the reserved memory block.',
+	)
+	const tightResult = tightResponse.structuredContent.result as {
+		matches: Array<{ type: string }>
+		memories?: { surfaced: Array<{ id: string; summary: string }> }
+		telemetry?: { responseTrimmed?: boolean; trimmedMatchCount?: number }
+	}
+	expect(tightResult.memories?.surfaced).toEqual([
+		expect.objectContaining({
+			id: 'memory-draft-only',
+			summary: longSummary,
+		}),
+	])
+	expect(tightResult.telemetry?.responseTrimmed).toBe(true)
+	expect(tightResult.telemetry?.trimmedMatchCount).toBeGreaterThan(0)
+	expect(tightResult.matches).toEqual([])
+
+	vi.clearAllMocks()
+	mockModule.getCapabilityRegistryForContext.mockResolvedValueOnce({
+		capabilityDomains: [
+			{
+				name: 'meta',
+				description: 'Search and registry metadata.',
+			},
+		],
+		capabilitySpecs: {
+			search_docs: {
+				name: 'search_docs',
+				description: 'Search docs capability',
+				domain: 'meta',
+				keywords: [],
+				inputFields: [],
+				requiredInputFields: [],
+				outputFields: [],
+				readOnly: true,
+				idempotent: true,
+				destructive: false,
+				source: 'builtin',
+				inputSchema: { type: 'object', properties: {} },
+				inputTypeDefinition: 'type Input = {}',
+			},
+		},
+	})
+	mockModule.loadRelevantMemoriesForTool.mockResolvedValueOnce(memorySummary)
+	const { handler: whitespaceHandler } = await getSearchRegistration({ user })
+	const whitespaceResponse = await whitespaceHandler({
+		query: '   ',
+		conversationId: 'conv-whitespace-memory-context',
+		memoryContext: { task: 'draft an email' },
+	})
+	expect(whitespaceResponse.isError).toBeUndefined()
+	expect(mockModule.loadRelevantMemoriesForTool).toHaveBeenCalledWith(
+		expect.objectContaining({
+			memoryContext: { task: 'draft an email' },
+			acknowledgeSurfaced: false,
+		}),
+	)
+	const whitespaceText = whitespaceResponse.content
+		.map((item) => item.text)
+		.join('\n')
+	expect(whitespaceText).toContain('## Relevant memories')
+	expect(whitespaceText).toContain(longSummary)
+	expect(
+		(
+			whitespaceResponse.structuredContent.result as {
+				memories?: { surfaced: Array<{ id: string }> }
+			}
+		).memories?.surfaced,
+	).toEqual([expect.objectContaining({ id: 'memory-draft-only' })])
+})
+
 test('search tool domain param: browse, reject unknown, and scope ranked results', async () => {
 	vi.clearAllMocks()
 	consoleWarn.mockImplementation(() => {})
@@ -1187,6 +1309,7 @@ test('search tool domain param: browse, reject unknown, and scope ranked results
 		/Unknown domain "nope"/,
 	)
 	expect(unknownResponse.structuredContent.error).toContain('meta')
+	expect(mockModule.loadRelevantMemoriesForTool).not.toHaveBeenCalled()
 
 	mockModule.listSavedPackagesByUserId.mockResolvedValue(createSavedPackages())
 	const { handler: scopedHandler } = await getSearchRegistration({

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -1152,7 +1152,6 @@ test('search tool memory enrichment: timeout, rejection, and ack failure stay of
 	} finally {
 		process.off('unhandledRejection', onUnhandled)
 	}
-
 }, 10_000)
 
 test('search tool domain param: browse, reject unknown, and scope ranked results', async () => {

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -249,10 +249,10 @@ test('search tool returns compact query markdown while preserving structured aux
 				category: 'preference',
 				status: 'active',
 				subject: 'Verbose memory subject',
-				summary:
-					'This memory summary is intentionally long and should not be rendered into broad search markdown.',
+				summary: 'Prefers compact search results.',
 				details: 'Long memory details should stay out of the text response.',
 				tags: ['search'],
+				sourceUris: [],
 				updatedAt: '2026-04-20T00:00:00.000Z',
 			},
 		],
@@ -293,6 +293,12 @@ test('search tool returns compact query markdown while preserving structured aux
 
 	const text = successResponse.content.map((item) => item.text).join('\n')
 	expect(text.length).toBeGreaterThan(0)
+	expect(text).toContain('## Relevant memories')
+	expect(text).toContain('Verbose memory subject')
+	expect(text).toContain('Prefers compact search results.')
+	expect(text).not.toContain(
+		'Long memory details should stay out of the text response.',
+	)
 	const result = successResponse.structuredContent.result as {
 		warnings: Array<string>
 		guidance?: string
@@ -1033,6 +1039,7 @@ test('search tool memory enrichment: timeout, rejection, and ack failure stay of
 				summary: 'Prefers compact search results',
 				details: '',
 				tags: ['search'],
+				sourceUris: [],
 				updatedAt: '2026-04-20T00:00:00.000Z',
 			},
 		],
@@ -1275,6 +1282,7 @@ test('search tool domain param: browse, reject unknown, and scope ranked results
 	for (const match of scopedResult.matches) {
 		expect(match).toMatchObject({ type: 'capability', domain: 'meta' })
 	}
+	expect(mockModule.loadRelevantMemoriesForTool).toHaveBeenCalled()
 	expect(mockModule.runPackageRetrievers).not.toHaveBeenCalled()
 })
 

--- a/packages/worker/src/mcp/tools/search-handler.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-handler.node.test.ts
@@ -107,7 +107,6 @@ vi.mock('#worker/community/service.ts', () => ({
 const {
 	registerSearchTool,
 	SEARCH_MEMORY_ENRICHMENT_BUDGET_MS,
-	memoryAcknowledgementWarning,
 	memoryEnrichmentSkippedWarning,
 } = await import('./search.ts')
 
@@ -299,6 +298,9 @@ test('search tool returns compact query markdown while preserving structured aux
 	expect(text).not.toContain(
 		'Long memory details should stay out of the text response.',
 	)
+	expect(text).not.toContain('Category:')
+	expect(text).not.toContain('Tags:')
+	expect(text).not.toContain('Updated:')
 	const result = successResponse.structuredContent.result as {
 		warnings: Array<string>
 		guidance?: string
@@ -326,15 +328,9 @@ test('search tool returns compact query markdown while preserving structured aux
 		expect.objectContaining({
 			memoryEnrichmentTimedOut: false,
 			memoryEnrichmentMs: expect.any(Number),
-			memoryAcknowledgementMs: expect.any(Number),
 		}),
 	)
-	expect(mockModule.acknowledgeToolMemories).toHaveBeenCalledWith(
-		expect.objectContaining({
-			conversationId: 'conv-compact-search',
-			memoryIds: ['memory-1'],
-		}),
-	)
+	expect(mockModule.acknowledgeToolMemories).not.toHaveBeenCalled()
 
 	mockPerformanceNow.mockReturnValueOnce(5).mockReturnValueOnce(9)
 	const emptyDiscoveryResponse = await handler({
@@ -1157,73 +1153,6 @@ test('search tool memory enrichment: timeout, rejection, and ack failure stay of
 		process.off('unhandledRejection', onUnhandled)
 	}
 
-	vi.clearAllMocks()
-	consoleWarn.mockImplementation(() => {})
-	mockModule.runPackageRetrievers.mockResolvedValue({
-		results: [],
-		warnings: [],
-	})
-	mockModule.loadRelevantMemoriesForTool.mockResolvedValueOnce(memorySummary)
-	mockModule.acknowledgeToolMemories.mockRejectedValueOnce(
-		new Error('ack store unavailable'),
-	)
-	const { handler: ackHandler } = await getSearchRegistration({ user })
-	const ackFailed = await ackHandler({
-		query: 'search docs',
-		conversationId: 'conv-memory-ack-fail',
-	})
-	const ackResult = ackFailed.structuredContent.result as {
-		matches: Array<{ type: string }>
-		memories?: { surfaced: Array<{ id: string }> }
-		warnings: Array<string>
-		phaseTimings?: Record<string, unknown>
-	}
-	expect(ackResult.matches.length).toBeGreaterThan(0)
-	expect(ackResult.memories?.surfaced).toEqual([
-		expect.objectContaining({ id: 'memory-1' }),
-	])
-	expect(ackResult.warnings).toContain(memoryAcknowledgementWarning)
-	expect(ackResult.phaseTimings).toEqual(
-		expect.objectContaining({
-			memoryEnrichmentFailed: false,
-			memoryAcknowledgementFailed: true,
-			memoryAcknowledgementMs: expect.any(Number),
-		}),
-	)
-
-	vi.clearAllMocks()
-	consoleWarn.mockImplementation(() => {})
-	mockModule.runPackageRetrievers.mockResolvedValue({
-		results: [],
-		warnings: [],
-	})
-	mockModule.loadRelevantMemoriesForTool.mockResolvedValueOnce(memorySummary)
-	mockModule.acknowledgeToolMemories.mockImplementation(
-		() => new Promise(() => {}),
-	)
-	const { handler: neverSettlingHandler } = await getSearchRegistration({
-		user,
-	})
-	const neverSettling = await neverSettlingHandler({
-		query: 'search docs',
-		conversationId: 'conv-memory-ack-hang',
-	})
-	const hangResult = neverSettling.structuredContent.result as {
-		memories?: { surfaced: Array<{ id: string }> }
-		warnings: Array<string>
-		phaseTimings?: Record<string, unknown>
-	}
-	expect(hangResult.memories?.surfaced).toEqual([
-		expect.objectContaining({ id: 'memory-1' }),
-	])
-	expect(hangResult.warnings).toContain(memoryAcknowledgementWarning)
-	expect(hangResult.phaseTimings).toEqual(
-		expect.objectContaining({
-			memoryAcknowledgementTimedOut: true,
-			memoryEnrichmentFailed: false,
-			memoryAcknowledgementMs: expect.any(Number),
-		}),
-	)
 }, 10_000)
 
 test('search tool domain param: browse, reject unknown, and scope ranked results', async () => {

--- a/packages/worker/src/mcp/tools/search-memory.ts
+++ b/packages/worker/src/mcp/tools/search-memory.ts
@@ -117,6 +117,7 @@ export async function settleSearchMemoryEnrichment(input: {
 							suppressedCount: memoryToolContext.suppressedCount,
 							retrievalQuery: memoryToolContext.retrievalQuery,
 							retrieverResults: memoryToolContext.retrieverResults,
+							retrieverWarnings: memoryToolContext.retrieverWarnings,
 						},
 					}
 				: {}),
@@ -135,6 +136,7 @@ export async function settleSearchMemoryEnrichment(input: {
 		suppressedCount: memoryToolContext.suppressedCount,
 		retrievalQuery: memoryToolContext.retrievalQuery,
 		retrieverResults: memoryToolContext.retrieverResults,
+		retrieverWarnings: memoryToolContext.retrieverWarnings,
 	}
 	const acknowledgementBudgetMs =
 		input.acknowledgementBudgetMs ?? SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS

--- a/packages/worker/src/mcp/tools/search-memory.ts
+++ b/packages/worker/src/mcp/tools/search-memory.ts
@@ -1,16 +1,13 @@
 import { type z } from 'zod'
 import { type McpCallerContext } from '@kody-internal/shared/chat.ts'
 import {
-	acknowledgeToolMemories,
 	buildMemoryRetrievalQuery,
 	loadRelevantMemoriesForTool,
 	type MemoryToolSummary,
 } from '#mcp/tools/memory-tool-context.ts'
 
 import {
-	SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS,
 	SEARCH_MEMORY_ENRICHMENT_BUDGET_MS,
-	memoryAcknowledgementWarning,
 	memoryEnrichmentSkippedWarning,
 } from './search-constants.ts'
 import { elapsedMs, settleWithBudget } from './search-timing.ts'
@@ -58,13 +55,9 @@ export function launchSearchMemoryEnrichment(input: {
 }
 
 export async function settleSearchMemoryEnrichment(input: {
-	env: Env
-	callerContext: McpCallerContext
-	conversationId: string
 	promise: Promise<MemoryToolSummary | null>
 	launchedAtMs?: number
 	budgetMs?: number
-	acknowledgementBudgetMs?: number
 }): Promise<SearchMemoryEnrichmentSettlement> {
 	const waitStartedAt = performance.now()
 	const launchedAtMs = input.launchedAtMs ?? waitStartedAt
@@ -131,93 +124,20 @@ export async function settleSearchMemoryEnrichment(input: {
 		}
 	}
 
-	const memories = {
-		surfaced: memoryToolContext.memories,
-		suppressedCount: memoryToolContext.suppressedCount,
-		retrievalQuery: memoryToolContext.retrievalQuery,
-		retrieverResults: memoryToolContext.retrieverResults,
-		retrieverWarnings: memoryToolContext.retrieverWarnings,
-	}
-	const acknowledgementBudgetMs =
-		input.acknowledgementBudgetMs ?? SEARCH_MEMORY_ACKNOWLEDGEMENT_BUDGET_MS
-	const acknowledgementStartedAt = performance.now()
-	const acknowledgementPromise = acknowledgeToolMemories({
-		env: input.env,
-		callerContext: input.callerContext,
-		conversationId: input.conversationId,
-		memoryIds: memoryToolContext.memories.map((memory) => memory.id),
-	})
-	const acknowledgement = await settleWithBudget(
-		acknowledgementPromise,
-		acknowledgementBudgetMs,
-		acknowledgementStartedAt,
-	)
-	const memoryAcknowledgementMs = elapsedMs(acknowledgementStartedAt)
-
-	if (acknowledgement.ok) {
-		return {
-			memories,
-			warnings,
-			phaseTimings: {
-				memoryEnrichmentMs,
-				memoryEnrichmentWaitMs,
-				memoryAcknowledgementMs,
-				memoryEnrichmentTimedOut: false,
-				memoryEnrichmentFailed: false,
-			},
-		}
-	}
-
-	if (acknowledgement.timedOut) {
-		void acknowledgementPromise.catch((error) => {
-			console.warn(
-				JSON.stringify({
-					message: 'search memory acknowledgement failed after timeout',
-					error: error instanceof Error ? error.message : String(error),
-				}),
-			)
-		})
-		console.warn(
-			JSON.stringify({
-				message: 'search memory acknowledgement timed out',
-				budgetMs: acknowledgementBudgetMs,
-				acknowledgementMs: memoryAcknowledgementMs,
-			}),
-		)
-		return {
-			memories,
-			warnings: [...warnings, memoryAcknowledgementWarning],
-			phaseTimings: {
-				memoryEnrichmentMs,
-				memoryEnrichmentWaitMs,
-				memoryAcknowledgementMs,
-				memoryEnrichmentTimedOut: false,
-				memoryAcknowledgementTimedOut: true,
-				memoryEnrichmentFailed: false,
-			},
-		}
-	}
-
-	console.warn(
-		JSON.stringify({
-			message: 'search memory acknowledgement failed',
-			error:
-				acknowledgement.error instanceof Error
-					? acknowledgement.error.message
-					: String(acknowledgement.error),
-			acknowledgementMs: memoryAcknowledgementMs,
-		}),
-	)
 	return {
-		memories,
-		warnings: [...warnings, memoryAcknowledgementWarning],
+		memories: {
+			surfaced: memoryToolContext.memories,
+			suppressedCount: memoryToolContext.suppressedCount,
+			retrievalQuery: memoryToolContext.retrievalQuery,
+			retrieverResults: memoryToolContext.retrieverResults,
+			retrieverWarnings: memoryToolContext.retrieverWarnings,
+		},
+		warnings,
 		phaseTimings: {
 			memoryEnrichmentMs,
 			memoryEnrichmentWaitMs,
-			memoryAcknowledgementMs,
 			memoryEnrichmentTimedOut: false,
 			memoryEnrichmentFailed: false,
-			memoryAcknowledgementFailed: true,
 		},
 	}
 }

--- a/packages/worker/src/mcp/tools/search-response-size.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-response-size.node.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest'
+import { applyMaxResponseSize } from './search-response-size.ts'
+
+test('applyMaxResponseSize reserves room for appended memory text', () => {
+	const payload = {
+		matches: ['aaaaaaaaaa', 'bbbbbbbbbb', 'cccccccccc'],
+	}
+	const format = (value: { matches: Array<string> }) => value.matches.join('')
+	const trim = (value: { matches: Array<string> }, count: number) => ({
+		matches: value.matches.slice(0, count),
+	})
+	const getCount = (value: { matches: Array<string> }) => value.matches.length
+	const suffix = 'MEMORY'
+	const maxResponseSize = 16
+
+	const unreserved = applyMaxResponseSize(
+		payload,
+		maxResponseSize,
+		format,
+		trim,
+		getCount,
+	)
+	expect(unreserved.serialized.length).toBeLessThanOrEqual(maxResponseSize)
+	expect(`${unreserved.serialized}\n${suffix}`.length).toBeGreaterThan(
+		maxResponseSize,
+	)
+
+	const reserved = applyMaxResponseSize(
+		payload,
+		maxResponseSize,
+		format,
+		trim,
+		getCount,
+		{ reservedChars: suffix.length + 1 },
+	)
+	const combined = `${reserved.serialized}\n${suffix}`
+	expect(combined).toContain(suffix)
+	expect(combined.length).toBeLessThanOrEqual(maxResponseSize)
+
+	const memoryLargerThanBudget = applyMaxResponseSize(
+		payload,
+		suffix.length,
+		format,
+		trim,
+		getCount,
+		{ reservedChars: suffix.length + 1 },
+	)
+	expect(memoryLargerThanBudget.payload.matches).toEqual([])
+})

--- a/packages/worker/src/mcp/tools/search-response-size.ts
+++ b/packages/worker/src/mcp/tools/search-response-size.ts
@@ -14,12 +14,17 @@ export function applyMaxResponseSize<TPayload>(
 	format: (payload: TPayload) => string,
 	trim: (payload: TPayload, count: number) => TPayload,
 	getCount: (payload: TPayload) => number,
+	options?: {
+		reservedChars?: number
+	},
 ): { payload: TPayload; serialized: string } {
 	if (!Number.isFinite(maxResponseSize) || maxResponseSize <= 0) {
 		const serialized = format(payload)
 		return { payload, serialized }
 	}
 
+	const reservedChars = Math.max(0, options?.reservedChars ?? 0)
+	const budget = Math.max(0, maxResponseSize - reservedChars)
 	const total = getCount(payload)
 	let low = 0
 	let high = total
@@ -30,7 +35,7 @@ export function applyMaxResponseSize<TPayload>(
 		const mid = Math.floor((low + high) / 2)
 		const trimmedPayload = trim(payload, mid)
 		const serialized = format(trimmedPayload)
-		if (serialized.length <= maxResponseSize) {
+		if (serialized.length <= budget) {
 			bestPayload = trimmedPayload
 			bestSerialized = serialized
 			low = mid + 1

--- a/packages/worker/src/mcp/tools/search-tool-definition.ts
+++ b/packages/worker/src/mcp/tools/search-tool-definition.ts
@@ -48,7 +48,9 @@ Secret results expose metadata only; credential values never appear.
 If results look incomplete: \`meta_list_capabilities()\` for a domain index,
 then \`meta_list_capabilities({ domain })\` for one domain.
 
-Optional **limit** (default 15) and **maxResponseSize** trim low-ranked results.
+Optional **limit** (default 15) and **maxResponseSize** trim low-ranked
+capability hits. Auto-surfaced memory one-liners are reserved first so a
+tight size budget does not drop them.
 Example arguments:
 - \`{ "query": "saved github automation package", "limit": 10 }\`
 - \`{}\`

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -439,6 +439,20 @@ export async function runSearchTool(input: {
 				}
 			}
 		}
+		const memorySummary = searchMemories
+			? {
+					memories: searchMemories.surfaced,
+					retrieverResults: searchMemories.retrieverResults,
+					retrieverWarnings: searchMemories.retrieverWarnings ?? [],
+					suppressedCount: searchMemories.suppressedCount,
+					retrievalQuery: searchMemories.retrievalQuery,
+				}
+			: null
+		const memoryContent = formatSurfacedMemoriesMarkdown(memorySummary)
+		const reservedMemoryChars = memoryContent.reduce((total, block) => {
+			if (block.type !== 'text' || !('text' in block)) return total
+			return total + (total > 0 ? 1 : 0) + block.text.length
+		}, 0)
 		const formattingStartMs = performance.now()
 		const { payload: trimmedPayload, serialized } = applyMaxResponseSize(
 			payload,
@@ -454,6 +468,9 @@ export async function runSearchTool(input: {
 				matches: value.matches.slice(0, count),
 			}),
 			(value) => value.matches.length,
+			{
+				reservedChars: reservedMemoryChars > 0 ? reservedMemoryChars + 1 : 0,
+			},
 		)
 		const trimmedMatchCount = Math.max(
 			0,
@@ -523,17 +540,7 @@ export async function runSearchTool(input: {
 					type: 'text',
 					text: truncateSearchText(serialized),
 				},
-				...formatSurfacedMemoriesMarkdown(
-					searchMemories
-						? {
-								memories: searchMemories.surfaced,
-								retrieverResults: searchMemories.retrieverResults,
-								retrieverWarnings: searchMemories.retrieverWarnings ?? [],
-								suppressedCount: searchMemories.suppressedCount,
-								retrievalQuery: searchMemories.retrievalQuery,
-							}
-						: null,
-				),
+				...memoryContent,
 			]),
 			structuredContent: {
 				conversationId,

--- a/packages/worker/src/mcp/tools/search-tool-runner.ts
+++ b/packages/worker/src/mcp/tools/search-tool-runner.ts
@@ -13,6 +13,7 @@ import {
 	escapeMarkdownText,
 	formatMarkdownInlineCode,
 } from './markdown-safety.ts'
+import { formatSurfacedMemoriesMarkdown } from './memory-tool-context.ts'
 import {
 	defaultMaxResponseSize,
 	defaultSearchLimit,
@@ -522,6 +523,17 @@ export async function runSearchTool(input: {
 					type: 'text',
 					text: truncateSearchText(serialized),
 				},
+				...formatSurfacedMemoriesMarkdown(
+					searchMemories
+						? {
+								memories: searchMemories.surfaced,
+								retrieverResults: searchMemories.retrieverResults,
+								retrieverWarnings: searchMemories.retrieverWarnings ?? [],
+								suppressedCount: searchMemories.suppressedCount,
+								retrievalQuery: searchMemories.retrievalQuery,
+							}
+						: null,
+				),
 			]),
 			structuredContent: {
 				conversationId,

--- a/packages/worker/src/mcp/tools/search-types.ts
+++ b/packages/worker/src/mcp/tools/search-types.ts
@@ -136,6 +136,7 @@ export type SearchMemoryEnrichmentSettlement = {
 		suppressedCount: number
 		retrievalQuery: string
 		retrieverResults: MemoryToolSummary['retrieverResults']
+		retrieverWarnings: MemoryToolSummary['retrieverWarnings']
 	}
 	warnings: Array<string>
 	phaseTimings: Pick<

--- a/tools/memory-auto-surface-lab/extra-policies.json
+++ b/tools/memory-auto-surface-lab/extra-policies.json
@@ -1,0 +1,272 @@
+[
+	{
+		"id": "shipped-compact-no-hide",
+		"searchWhen": "query",
+		"executeWhen": "memoryContext",
+		"payload": "subject_summary",
+		"suppress": "none",
+		"repeatForm": "omit",
+		"maxMemories": 2
+	},
+	{
+		"id": "execute-gated-stub",
+		"searchWhen": "never",
+		"executeWhen": "memoryContext",
+		"payload": "subject",
+		"suppress": "echoed_handle",
+		"repeatForm": "omit",
+		"maxMemories": 1
+	},
+	{
+		"id": "search-query-full-once",
+		"searchWhen": "query",
+		"executeWhen": "never",
+		"payload": "search_full_execute_summary",
+		"suppress": "after_first_search_on_handle",
+		"repeatForm": "ids_only",
+		"maxMemories": 2
+	},
+	{
+		"id": "asymmetric-search-rich-execute-thin",
+		"searchWhen": "memoryContext",
+		"executeWhen": "memoryContext",
+		"payload": "search_summary_execute_none",
+		"suppress": "any_resolved_handle",
+		"repeatForm": "count_line",
+		"maxMemories": 3
+	},
+	{
+		"id": "always-execute-id-anchor",
+		"searchWhen": "never",
+		"executeWhen": "always",
+		"payload": "id",
+		"suppress": "none",
+		"repeatForm": "ids_only",
+		"maxMemories": 2
+	},
+	{
+		"id": "search-never-execute-always-summary",
+		"searchWhen": "never",
+		"executeWhen": "always",
+		"payload": "subject_summary",
+		"suppress": "echoed_handle",
+		"repeatForm": "omit",
+		"maxMemories": 1
+	},
+	{
+		"id": "query-triggered-single-full",
+		"searchWhen": "query",
+		"executeWhen": "never",
+		"payload": "full",
+		"suppress": "any_resolved_handle",
+		"repeatForm": "omit",
+		"maxMemories": 1
+	},
+	{
+		"id": "stub-after-first-touch",
+		"searchWhen": "memoryContext",
+		"executeWhen": "memoryContext",
+		"payload": "stub_after_first",
+		"suppress": "after_first_search_on_handle",
+		"repeatForm": "still_in_effect",
+		"maxMemories": 2
+	},
+	{
+		"id": "budget-200-universal",
+		"searchWhen": "query",
+		"executeWhen": "memoryContext",
+		"payload": "budget_200",
+		"suppress": "none",
+		"repeatForm": "count_line",
+		"maxMemories": 3
+	},
+	{
+		"id": "execute-only-no-payload",
+		"searchWhen": "never",
+		"executeWhen": "memoryContext",
+		"payload": "none",
+		"suppress": "echoed_handle",
+		"repeatForm": "count_line",
+		"maxMemories": 2
+	},
+	{
+		"id": "query-search-execute-never",
+		"searchWhen": "query",
+		"executeWhen": "never",
+		"payload": "full",
+		"suppress": "none",
+		"repeatForm": "omit",
+		"maxMemories": 1
+	},
+	{
+		"id": "execute-always-last-mile-gate",
+		"searchWhen": "never",
+		"executeWhen": "always",
+		"payload": "subject_summary",
+		"suppress": "none",
+		"repeatForm": "still_in_effect",
+		"maxMemories": 2
+	},
+	{
+		"id": "execute-always-full-no-suppress",
+		"searchWhen": "never",
+		"executeWhen": "always",
+		"payload": "full",
+		"suppress": "none",
+		"repeatForm": "count_line",
+		"maxMemories": 1
+	},
+	{
+		"id": "query-prefetch-execute-always-reinforce",
+		"searchWhen": "query",
+		"executeWhen": "always",
+		"payload": "search_full_execute_summary",
+		"suppress": "echoed_handle",
+		"repeatForm": "still_in_effect",
+		"maxMemories": 2
+	},
+	{
+		"id": "execute-always-triple-safety-net",
+		"searchWhen": "query",
+		"executeWhen": "always",
+		"payload": "subject_summary",
+		"suppress": "none",
+		"repeatForm": "count_line",
+		"maxMemories": 3
+	},
+	{
+		"id": "execute-always-subject-only-markdown",
+		"searchWhen": "never",
+		"executeWhen": "always",
+		"payload": "subject",
+		"suppress": "none",
+		"repeatForm": "still_in_effect",
+		"maxMemories": 2
+	},
+	{
+		"id": "query-lane-execute-lane-asymmetric",
+		"searchWhen": "query",
+		"executeWhen": "always",
+		"payload": "search_full_execute_summary",
+		"suppress": "none",
+		"repeatForm": "still_in_effect",
+		"maxMemories": 3
+	},
+	{
+		"id": "search_rich_execute_mute",
+		"searchWhen": "query",
+		"executeWhen": "never",
+		"payload": "search_full_execute_summary",
+		"suppress": "none",
+		"repeatForm": "omit",
+		"maxMemories": 3
+	},
+	{
+		"id": "execute_only_if_search_missed",
+		"searchWhen": "never",
+		"executeWhen": "only_if_no_prior_search",
+		"payload": "subject_summary",
+		"suppress": "after_first_search_on_handle",
+		"repeatForm": "omit",
+		"maxMemories": 2
+	},
+	{
+		"id": "verb_gated_comms",
+		"searchWhen": "verb_trigger",
+		"executeWhen": "verb_trigger",
+		"payload": "subject_summary_category",
+		"suppress": "echoed_handle",
+		"repeatForm": "count_line",
+		"maxMemories": 2
+	},
+	{
+		"id": "stub_after_first_show",
+		"searchWhen": "query",
+		"executeWhen": "memoryContext",
+		"payload": "stub_after_first",
+		"suppress": "none",
+		"repeatForm": "ids_only",
+		"maxMemories": 3
+	},
+	{
+		"id": "keywords_only_extract",
+		"searchWhen": "query",
+		"executeWhen": "never",
+		"payload": "keywords",
+		"suppress": "query_hash_on_handle",
+		"repeatForm": "omit",
+		"maxMemories": 4
+	},
+	{
+		"id": "structured_never_markdown",
+		"searchWhen": "query",
+		"executeWhen": "memoryContext",
+		"payload": "none",
+		"suppress": "echoed_handle",
+		"repeatForm": "omit",
+		"maxMemories": 3
+	},
+	{
+		"id": "summary_first_80_chars",
+		"searchWhen": "query",
+		"executeWhen": "memoryContext",
+		"payload": "summary_80",
+		"suppress": "any_resolved_handle",
+		"repeatForm": "still_in_effect",
+		"maxMemories": 3
+	},
+	{
+		"id": "one_memory_max_highest_score",
+		"searchWhen": "query",
+		"executeWhen": "never",
+		"payload": "subject_summary_category",
+		"suppress": "echoed_handle",
+		"repeatForm": "omit",
+		"maxMemories": 1
+	},
+	{
+		"id": "ids_only_force_fetch",
+		"searchWhen": "query",
+		"executeWhen": "memoryContext",
+		"payload": "id",
+		"suppress": "none",
+		"repeatForm": "ids_only",
+		"maxMemories": 5
+	},
+	{
+		"id": "subject_line_ticker",
+		"searchWhen": "query",
+		"executeWhen": "never",
+		"payload": "subject",
+		"suppress": "query_hash_on_handle",
+		"repeatForm": "omit",
+		"maxMemories": 4
+	},
+	{
+		"id": "execute_always_search_never",
+		"searchWhen": "never",
+		"executeWhen": "always",
+		"payload": "subject",
+		"suppress": "echoed_handle",
+		"repeatForm": "still_in_effect",
+		"maxMemories": 1
+	},
+	{
+		"id": "full_on_first_stub_thereafter",
+		"searchWhen": "query",
+		"executeWhen": "always",
+		"payload": "stub_after_first",
+		"suppress": "none",
+		"repeatForm": "ids_only",
+		"maxMemories": 2
+	},
+	{
+		"id": "dual_agent_safe_handle_only",
+		"searchWhen": "query",
+		"executeWhen": "memoryContext",
+		"payload": "subject_summary",
+		"suppress": "after_first_search_on_handle",
+		"repeatForm": "count_line",
+		"maxMemories": 3
+	}
+]

--- a/tools/memory-auto-surface-lab/extra-scenarios.json
+++ b/tools/memory-auto-surface-lab/extra-scenarios.json
@@ -1,0 +1,285 @@
+[
+	{
+		"id": "email-send-incident-real",
+		"name": "Search then execute send, no memoryContext, fresh handles, window 2",
+		"host": "markdown_only",
+		"windowSize": 2,
+		"expectVisible": true,
+		"isolationPeer": true,
+		"calls": [
+			{
+				"tool": "search",
+				"query": "send email to team",
+				"memoryContext": false,
+				"conversationId": "fresh"
+			},
+			{
+				"tool": "execute",
+				"query": "email_send({ to, subject, body })",
+				"memoryContext": false,
+				"conversationId": "fresh"
+			}
+		],
+		"decisionCallIndex": 1
+	},
+	{
+		"id": "well-behaved-echoer",
+		"name": "Echo conversationId and memoryContext through search then send",
+		"host": "both",
+		"windowSize": 999,
+		"expectVisible": true,
+		"isolationPeer": true,
+		"calls": [
+			{
+				"tool": "search",
+				"query": "email_send capability",
+				"memoryContext": true,
+				"conversationId": "fresh"
+			},
+			{
+				"tool": "search",
+				"query": "email_message_list recent",
+				"memoryContext": true,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "execute",
+				"query": "email_send draft",
+				"memoryContext": true,
+				"conversationId": "echo"
+			}
+		],
+		"decisionCallIndex": 2
+	},
+	{
+		"id": "execute-loop-omit-conversation-id",
+		"name": "Execute-only loop never echoes conversationId",
+		"host": "markdown_only",
+		"windowSize": 999,
+		"expectVisible": true,
+		"stretch": true,
+		"isolationPeer": true,
+		"calls": [
+			{
+				"tool": "execute",
+				"query": "email_message_list()",
+				"memoryContext": false,
+				"conversationId": "omit"
+			},
+			{
+				"tool": "execute",
+				"query": "email_message_get(id)",
+				"memoryContext": false,
+				"conversationId": "omit"
+			},
+			{
+				"tool": "execute",
+				"query": "email_send({ to, subject, body })",
+				"memoryContext": false,
+				"conversationId": "omit"
+			}
+		],
+		"decisionCallIndex": 2
+	},
+	{
+		"id": "context-compaction-drops-search",
+		"name": "Window 3 evicts the search that held the memory before send",
+		"host": "markdown_only",
+		"windowSize": 3,
+		"expectVisible": true,
+		"stretch": true,
+		"isolationPeer": true,
+		"calls": [
+			{
+				"tool": "search",
+				"query": "send weekly digest email",
+				"memoryContext": false,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "search",
+				"query": "github pull requests merged",
+				"memoryContext": false,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "execute",
+				"query": "fetchDigestItems()",
+				"memoryContext": false,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "search",
+				"query": "format markdown table",
+				"memoryContext": false,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "execute",
+				"query": "email_send({ to, subject, body })",
+				"memoryContext": false,
+				"conversationId": "echo"
+			}
+		],
+		"decisionCallIndex": 4
+	},
+	{
+		"id": "execute-only-agent-no-warmup",
+		"name": "Execute-only jump to email_send with no memoryContext",
+		"host": "both",
+		"windowSize": 999,
+		"expectVisible": true,
+		"stretch": true,
+		"isolationPeer": true,
+		"calls": [
+			{
+				"tool": "execute",
+				"query": "email_send({ to, subject, body })",
+				"memoryContext": false,
+				"conversationId": "fresh"
+			}
+		],
+		"decisionCallIndex": 0
+	},
+	{
+		"id": "task-change-mid-conversation",
+		"name": "Unrelated work then email search then send without memoryContext",
+		"host": "both",
+		"windowSize": 999,
+		"expectVisible": true,
+		"isolationPeer": true,
+		"calls": [
+			{
+				"tool": "search",
+				"query": "deploy preview wrangler",
+				"memoryContext": true,
+				"conversationId": "fresh"
+			},
+			{
+				"tool": "execute",
+				"query": "wranglerDeployPreview()",
+				"memoryContext": true,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "search",
+				"query": "send status email to user",
+				"memoryContext": true,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "execute",
+				"query": "email_send({ to, subject, body })",
+				"memoryContext": false,
+				"conversationId": "echo"
+			}
+		],
+		"decisionCallIndex": 3
+	},
+	{
+		"id": "compaction-rescue-via-memoryContext",
+		"name": "Search evicted; execute with memoryContext must re-surface",
+		"host": "both",
+		"windowSize": 2,
+		"expectVisible": true,
+		"isolationPeer": true,
+		"calls": [
+			{
+				"tool": "search",
+				"query": "send newsletter email",
+				"memoryContext": false,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "execute",
+				"query": "buildNewsletterHtml()",
+				"memoryContext": false,
+				"conversationId": "echo"
+			},
+			{
+				"tool": "execute",
+				"query": "email_send({ to, subject, html })",
+				"memoryContext": true,
+				"conversationId": "echo"
+			}
+		],
+		"decisionCallIndex": 2
+	},
+	{
+		"id": "high-volume-filler-before-send",
+		"name": "Search then five executes then send, all omit, window 5",
+		"host": "markdown_only",
+		"windowSize": 5,
+		"expectVisible": true,
+		"stretch": true,
+		"isolationPeer": true,
+		"calls": [
+			{
+				"tool": "search",
+				"query": "email_send",
+				"memoryContext": false,
+				"conversationId": "omit"
+			},
+			{
+				"tool": "execute",
+				"query": "email_message_list()",
+				"memoryContext": false,
+				"conversationId": "omit"
+			},
+			{
+				"tool": "execute",
+				"query": "email_message_get(1)",
+				"memoryContext": false,
+				"conversationId": "omit"
+			},
+			{
+				"tool": "execute",
+				"query": "email_message_get(2)",
+				"memoryContext": false,
+				"conversationId": "omit"
+			},
+			{
+				"tool": "execute",
+				"query": "email_message_get(3)",
+				"memoryContext": false,
+				"conversationId": "omit"
+			},
+			{
+				"tool": "execute",
+				"query": "email_message_get(4)",
+				"memoryContext": false,
+				"conversationId": "omit"
+			},
+			{
+				"tool": "execute",
+				"query": "email_send({ to, subject, body })",
+				"memoryContext": false,
+				"conversationId": "omit"
+			}
+		],
+		"decisionCallIndex": 6
+	},
+	{
+		"id": "benign-follow-up-may-repeat",
+		"name": "Listing execute after search; repeat is allowed, dump-on-empty is not",
+		"host": "both",
+		"windowSize": 999,
+		"expectVisible": true,
+		"isolationPeer": false,
+		"calls": [
+			{
+				"tool": "search",
+				"query": "email_send capability",
+				"memoryContext": true,
+				"conversationId": "fresh"
+			},
+			{
+				"tool": "execute",
+				"query": "email_message_list({ limit: 10 })",
+				"memoryContext": true,
+				"conversationId": "echo"
+			}
+		],
+		"decisionCallIndex": 1
+	}
+]

--- a/tools/memory-auto-surface-lab/readme.md
+++ b/tools/memory-auto-surface-lab/readme.md
@@ -1,0 +1,17 @@
+# Memory auto-surface lab
+
+Deterministic window simulator for
+[0033](../../docs/contributing/decisions/0033-no-user-as-conversation.md). It
+does not claim a model would obey a memory — only that distinctive text was in
+the host-visible tool window at the decision.
+
+```bash
+node tools/memory-auto-surface-lab/run.mjs
+```
+
+Writes `report.md`, `summary.json`, and `invented-scores.json` under
+`.tmp/memory-auto-surface-lab/` (gitignored). Set `LAB_OUT_DIR` to override.
+
+Named theories live in `extra-policies.json`. Extra traces live in
+`extra-scenarios.json`. Findings from the 2026-08-22 run:
+[0033-memory-auto-surface-lab.md](../../docs/contributing/decisions/0033-memory-auto-surface-lab.md).

--- a/tools/memory-auto-surface-lab/run.mjs
+++ b/tools/memory-auto-surface-lab/run.mjs
@@ -1,0 +1,1338 @@
+#!/usr/bin/env node
+/**
+ * Memory auto-surface policy lab.
+ *
+ * Deterministic simulation: same memories, same traces, many policies.
+ * Measures visibility at decision points, isolation across agents, and
+ * token cost. Does not claim an LLM would obey the memory — only whether
+ * the distinctive text was in the model-visible window.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const outDir =
+	process.env.LAB_OUT_DIR ?? join(here, '../../.tmp/memory-auto-surface-lab')
+
+const memories = [
+	{
+		id: 'd6c5aea4-5f7c-4474-8ec9-0af08f3973c8',
+		subject: 'Email: draft only, never send',
+		summary:
+			'Never send email unless Kent explicitly asks to send that specific message. "Draft" means create a Gmail draft.',
+		details:
+			'Kent has been burned by agents sending mail after he said draft. Draft is the Gmail draft primitive, not a polite synonym for send. Sending requires an explicit send of that exact message. Do not send follow-up repair mail. Do not interpret "looks good" as permission to send. If unsure, leave a draft and ask.',
+		category: 'preference',
+		status: 'active',
+		tags: ['email', 'gmail', 'draft'],
+		sourceUris: ['https://mail.google.com/'],
+		updatedAt: '2026-08-21T18:00:00.000Z',
+	},
+	{
+		id: 'voice-kent-writing',
+		subject: 'Writing voice',
+		summary: 'Write like Kent: direct, present tense, no corporate filler.',
+		details:
+			'Prefer short sentences. Avoid "leverage", "utilize", and changelog voice. Present tense. Name the thing. Do not open with a negation.',
+		category: 'preference',
+		status: 'active',
+		tags: ['voice', 'writing'],
+		sourceUris: [],
+		updatedAt: '2026-08-10T00:00:00.000Z',
+	},
+	{
+		id: 'email-habits-weak-subject',
+		subject: 'Email habits',
+		summary:
+			'Never send email unless Kent explicitly asks to send that specific message. Draft only means Gmail draft.',
+		details:
+			'Same rule as the titled memory, but the subject does not carry the constraint.',
+		category: 'preference',
+		status: 'active',
+		tags: ['email'],
+		sourceUris: [],
+		updatedAt: '2026-08-21T18:00:00.000Z',
+	},
+	{
+		id: 'kody-bot-favorite',
+		subject: 'Favorite bot',
+		summary:
+			"kody-bot is my favorite bot. I'm really interested in what it ships on github",
+		details:
+			'Watch public GitHub events for kody-bot releases and new public repos.',
+		category: 'profile',
+		status: 'active',
+		tags: ['github', 'kody-bot'],
+		sourceUris: ['https://github.com/kody-bot'],
+		updatedAt: '2026-07-01T00:00:00.000Z',
+	},
+]
+
+const criticalPhrases = [/never send/i, /draft only/i]
+const verbTrigger = /\b(send|email|draft|mail|gmail)\b/i
+
+const searchWhenValues = ['never', 'query', 'memoryContext']
+const executeWhenValues = ['never', 'memoryContext', 'always']
+const payloadValues = [
+	'none',
+	'id',
+	'subject',
+	'subject_summary',
+	'subject_summary_category',
+	'full',
+	'search_full_execute_summary',
+	'search_summary_execute_none',
+	'stub_after_first',
+	'budget_200',
+	'keywords',
+	'summary_80',
+]
+const suppressValues = [
+	'none',
+	'echoed_handle',
+	'any_resolved_handle',
+	'after_first_search_on_handle',
+	'query_hash_on_handle',
+	'user_global',
+]
+const repeatFormValues = ['omit', 'count_line', 'ids_only', 'still_in_effect']
+const maxMemoryValues = [1, 2]
+
+function estimateTokens(text) {
+	if (!text) return 0
+	return Math.ceil(text.length / 4)
+}
+
+function keywordsFrom(memory) {
+	const words = `${memory.subject} ${memory.summary}`
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((word) => word.length > 3)
+	return [...new Set(words)].slice(0, 8).join(' ')
+}
+
+function renderPayload(policy, tool, selected, alreadyShown) {
+	const mode = resolvePayloadMode(policy, tool, alreadyShown)
+	if (mode === 'none' || selected.length === 0) {
+		return { markdown: '', structured: '', visibleText: '', ids: [] }
+	}
+	if (
+		mode === 'stub' ||
+		mode === 'still_in_effect' ||
+		mode === 'stub_summary'
+	) {
+		const markdown =
+			mode === 'stub_summary'
+				? selected
+						.map((memory) => `- ${memory.subject} — ${memory.summary}`)
+						.join('\n')
+				: `Memories still in effect: ${selected.map((memory) => memory.subject).join('; ')}.`
+		return {
+			markdown,
+			structured: JSON.stringify({ ids: selected.map((memory) => memory.id) }),
+			visibleText: markdown,
+			ids: selected.map((memory) => memory.id),
+		}
+	}
+	if (mode === 'ids_only' || mode === 'id') {
+		const markdown =
+			mode === 'ids_only'
+				? selected.map((memory) => memory.id).join(', ')
+				: selected.map((memory) => `- ${memory.id}`).join('\n')
+		const structured = JSON.stringify({
+			surfaced: selected.map((memory) => ({ id: memory.id })),
+		})
+		return {
+			markdown,
+			structured,
+			visibleText: markdown,
+			ids: selected.map((memory) => memory.id),
+		}
+	}
+
+	const lines = ['## Relevant memories', '']
+	const structuredItems = []
+	let budgetLeft = mode === 'budget_200' ? 200 : Infinity
+	for (const memory of selected) {
+		let line
+		const item = { id: memory.id }
+		switch (mode) {
+			case 'subject':
+				line = `- **${memory.subject}**`
+				item.subject = memory.subject
+				break
+			case 'subject_summary_category':
+				line = `- **${memory.subject}** — ${memory.summary} (${memory.category})`
+				item.subject = memory.subject
+				item.summary = memory.summary
+				item.category = memory.category
+				break
+			case 'full':
+				line = [
+					`- **${memory.subject}** — ${memory.summary}`,
+					`  - Category: \`${memory.category}\``,
+					`  - Tags: ${memory.tags.map((tag) => `\`${tag}\``).join(', ')}`,
+					`  - Sources: ${memory.sourceUris.map((uri) => `\`${uri}\``).join(', ')}`,
+					`  - Updated: \`${memory.updatedAt}\``,
+					`  - Details: ${memory.details}`,
+				].join('\n')
+				Object.assign(item, {
+					subject: memory.subject,
+					summary: memory.summary,
+					details: memory.details,
+					category: memory.category,
+					status: memory.status,
+					tags: memory.tags,
+					sourceUris: memory.sourceUris,
+					updatedAt: memory.updatedAt,
+				})
+				break
+			case 'keywords':
+				line = `- ${keywordsFrom(memory)}`
+				item.keywords = keywordsFrom(memory)
+				break
+			case 'summary_80':
+				line = `- **${memory.subject}** — ${memory.summary.slice(0, 80)}`
+				item.subject = memory.subject
+				item.summary = memory.summary.slice(0, 80)
+				break
+			default:
+				line = `- **${memory.subject}** — ${memory.summary}`
+				item.subject = memory.subject
+				item.summary = memory.summary
+		}
+		if (mode === 'budget_200') {
+			const next = [...lines, line].join('\n')
+			if (next.length > budgetLeft + '## Relevant memories\n\n'.length) break
+		}
+		lines.push(line)
+		structuredItems.push(item)
+	}
+	const markdown = lines.join('\n')
+	const structured = JSON.stringify({ surfaced: structuredItems })
+	return {
+		markdown,
+		structured,
+		visibleText: markdown,
+		ids: structuredItems.map((item) => item.id),
+	}
+}
+
+function resolvePayloadMode(policy, tool, alreadyShown) {
+	if (policy.payload === 'none') return 'none'
+	if (policy.payload === 'search_full_execute_summary') {
+		return tool === 'search' ? 'full' : 'subject_summary'
+	}
+	if (policy.payload === 'search_summary_execute_none') {
+		return tool === 'search' ? 'subject_summary' : 'none'
+	}
+	if (policy.payload === 'stub_after_first') {
+		return alreadyShown ? 'stub' : 'subject_summary'
+	}
+	if (policy.payload === 'stub_summary') {
+		return alreadyShown ? 'stub_summary' : 'subject_summary'
+	}
+	if (policy.repeatForm === 'still_in_effect' && alreadyShown)
+		return 'still_in_effect'
+	if (policy.repeatForm === 'ids_only' && alreadyShown) return 'ids_only'
+	if (policy.repeatForm === 'count_line' && alreadyShown) return 'count'
+	return policy.payload
+}
+
+function shouldRetrieve(policy, call) {
+	const when = call.tool === 'search' ? policy.searchWhen : policy.executeWhen
+	if (when === 'never') return false
+	if (when === 'always') return true
+	if (when === 'memoryContext') return Boolean(call.memoryContext)
+	if (when === 'query') {
+		if (call.tool === 'search') return Boolean(call.query)
+		return Boolean(call.memoryContext || call.query)
+	}
+	if (when === 'verb_trigger') {
+		const hay = `${call.query ?? ''} ${call.domain ?? ''}`
+		return verbTrigger.test(hay) || Boolean(call.memoryContext)
+	}
+	if (when === 'only_if_no_prior_search') {
+		return call.tool === 'execute' && !call.priorSearchOnHandle
+	}
+	return false
+}
+
+function selectMemories(policy, call) {
+	const query = `${call.query ?? ''} ${call.domain ?? ''}`.toLowerCase()
+	if (call.weakSubject) {
+		const weak = memories.find(
+			(memory) => memory.id === 'email-habits-weak-subject',
+		)
+		return [weak, memories[1]].slice(0, policy.maxMemories)
+	}
+	if (call.criticalIsRankTwo) {
+		return [memories[1], memories[0], memories[3]].slice(0, policy.maxMemories)
+	}
+	const ranked =
+		query.includes('bot') || query.includes('github')
+			? [memories[3], memories[0], memories[1]]
+			: [memories[0], memories[1], memories[3]]
+	return ranked.slice(0, policy.maxMemories)
+}
+
+function suppressionKey(policy, call, resolvedId) {
+	switch (policy.suppress) {
+		case 'none':
+			return null
+		case 'user_global':
+			return 'user-recent'
+		case 'echoed_handle':
+			return call.conversationId === 'echo' || call.conversationId === 'reuse'
+				? resolvedId
+				: null
+		case 'any_resolved_handle':
+			return resolvedId
+		case 'after_first_search_on_handle':
+			return resolvedId
+		case 'query_hash_on_handle':
+			return `${resolvedId}:${(call.query ?? '').trim().toLowerCase()}`
+		default:
+			return resolvedId
+	}
+}
+
+const baselineScenarios = [
+	{
+		id: 'email-incident',
+		name: 'Search email then execute send; omit conversationId and memoryContext',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: false,
+				conversationId: 'omit',
+			},
+			{
+				tool: 'execute',
+				query: 'send the draft',
+				memoryContext: false,
+				conversationId: 'omit',
+			},
+		],
+		decisionCallIndex: 1,
+	},
+	{
+		id: 'email-incident-memoryContext',
+		name: 'Same send path but execute passes memoryContext',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: true,
+				conversationId: 'omit',
+			},
+			{
+				tool: 'execute',
+				query: 'send the draft',
+				memoryContext: true,
+				conversationId: 'omit',
+			},
+		],
+		decisionCallIndex: 1,
+	},
+	{
+		id: 'well-behaved',
+		name: 'Search plus four executes; echo conversationId and memoryContext',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: true,
+				conversationId: 'omit',
+			},
+			...Array.from({ length: 4 }, () => ({
+				tool: 'execute',
+				query: 'continue email work',
+				memoryContext: true,
+				conversationId: 'echo',
+			})),
+		],
+		decisionCallIndex: 1,
+	},
+	{
+		id: 'execute-loop-no-id',
+		name: 'Eight executes with memoryContext and a fresh omit each time',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: Array.from({ length: 8 }, () => ({
+			tool: 'execute',
+			query: 'email draft work',
+			memoryContext: true,
+			conversationId: 'omit',
+		})),
+		decisionCallIndex: 0,
+	},
+	{
+		id: 'execute-only-send',
+		name: 'Execute-only send, memoryContext present, no prior search',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'execute',
+				query: 'send this email',
+				memoryContext: true,
+				conversationId: 'omit',
+			},
+		],
+		decisionCallIndex: 0,
+	},
+	{
+		id: 'execute-only-no-context',
+		name: 'Execute-only send, no memoryContext (stretch)',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		stretch: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'execute',
+				query: 'send this email',
+				memoryContext: false,
+				conversationId: 'omit',
+			},
+		],
+		decisionCallIndex: 0,
+	},
+	{
+		id: 'compaction-weak-subject',
+		name: 'Weak subject plus compaction after echoed executes',
+		host: 'markdown_only',
+		windowSize: 3,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: true,
+				conversationId: 'omit',
+				weakSubject: true,
+			},
+			...Array.from({ length: 6 }, () => ({
+				tool: 'execute',
+				query: 'more email work',
+				memoryContext: true,
+				conversationId: 'echo',
+				weakSubject: true,
+			})),
+		],
+		decisionCallIndex: 6,
+	},
+	{
+		id: 'compaction-3',
+		name: 'Search then six executes; only last 3 tool results stay in context',
+		host: 'markdown_only',
+		windowSize: 3,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: true,
+				conversationId: 'omit',
+			},
+			...Array.from({ length: 6 }, () => ({
+				tool: 'execute',
+				query: 'more email work',
+				memoryContext: true,
+				conversationId: 'echo',
+			})),
+		],
+		decisionCallIndex: 6,
+	},
+	{
+		id: 'empty-browse',
+		name: 'Empty search should not dump memories',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: false,
+		isolationPeer: false,
+		calls: [{ tool: 'search', memoryContext: false, conversationId: 'omit' }],
+		decisionCallIndex: 0,
+	},
+	{
+		id: 'weak-subject',
+		name: 'Subject is generic; the rule lives in the summary',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: false,
+				conversationId: 'omit',
+				weakSubject: true,
+			},
+			{
+				tool: 'execute',
+				query: 'send the draft',
+				memoryContext: false,
+				conversationId: 'omit',
+				weakSubject: true,
+			},
+		],
+		decisionCallIndex: 1,
+	},
+	{
+		id: 'critical-is-rank-two',
+		name: 'Critical email rule is rank 2 behind a writing-voice memory',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: false,
+				conversationId: 'omit',
+				criticalIsRankTwo: true,
+			},
+			{
+				tool: 'execute',
+				query: 'send the draft',
+				memoryContext: false,
+				conversationId: 'omit',
+				criticalIsRankTwo: true,
+			},
+		],
+		decisionCallIndex: 1,
+	},
+	{
+		id: 'domain-email-search',
+		name: 'Domain-scoped email search is the decision',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: false,
+				conversationId: 'omit',
+			},
+		],
+		decisionCallIndex: 0,
+	},
+	{
+		id: 'task-change',
+		name: 'Email then unrelated github; decision is a later email execute',
+		host: 'markdown_only',
+		windowSize: 4,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: true,
+				conversationId: 'omit',
+			},
+			{
+				tool: 'search',
+				query: 'favorite bot github',
+				memoryContext: true,
+				conversationId: 'echo',
+			},
+			{
+				tool: 'execute',
+				query: 'list github events',
+				memoryContext: true,
+				conversationId: 'echo',
+			},
+			{
+				tool: 'execute',
+				query: 'send the draft now',
+				memoryContext: true,
+				conversationId: 'echo',
+			},
+		],
+		decisionCallIndex: 3,
+	},
+	{
+		id: 'structured-host',
+		name: 'Host forwards structured content as well as markdown',
+		host: 'both',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: false,
+				conversationId: 'omit',
+			},
+			{
+				tool: 'execute',
+				query: 'send',
+				memoryContext: false,
+				conversationId: 'echo',
+			},
+		],
+		decisionCallIndex: 1,
+	},
+	{
+		id: 'fresh-ids-every-call',
+		name: 'Caller invents a new conversationId each call',
+		host: 'markdown_only',
+		windowSize: 999,
+		expectVisible: true,
+		isolationPeer: true,
+		calls: [
+			{
+				tool: 'search',
+				query: 'send a message',
+				domain: 'email',
+				memoryContext: true,
+				conversationId: 'fresh',
+			},
+			{
+				tool: 'execute',
+				query: 'send',
+				memoryContext: true,
+				conversationId: 'fresh',
+			},
+			{
+				tool: 'execute',
+				query: 'send again',
+				memoryContext: true,
+				conversationId: 'fresh',
+			},
+		],
+		decisionCallIndex: 1,
+	},
+]
+
+function textHasCritical(text) {
+	return criticalPhrases.some((pattern) => pattern.test(text))
+}
+
+function simulate(policy, scenario, inherited = null) {
+	let mintCounter = inherited?.mintCounter ?? 0
+	let echoedId = null
+	const shownByKey = inherited?.shownByKey ?? new Map()
+	const userGlobal = inherited?.userGlobal ?? new Set()
+	const searchSeenByHandle = inherited?.searchSeenByHandle ?? new Set()
+	const results = []
+
+	for (const [index, call] of scenario.calls.entries()) {
+		let resolvedId
+		if (call.conversationId === 'echo' && echoedId) {
+			resolvedId = echoedId
+		} else if (call.conversationId === 'reuse' && echoedId) {
+			resolvedId = echoedId
+		} else {
+			resolvedId = `mint-${++mintCounter}`
+			if (call.conversationId !== 'fresh') echoedId = resolvedId
+			if (call.conversationId === 'fresh') echoedId = resolvedId
+		}
+
+		const priorSearchOnHandle = searchSeenByHandle.has(resolvedId)
+		const callWithPrior = { ...call, priorSearchOnHandle }
+		const retrieve = shouldRetrieve(policy, callWithPrior)
+		const selected = retrieve ? selectMemories(policy, call) : []
+
+		const key = suppressionKey(policy, call, resolvedId)
+		const shown = new Set([
+			...(key ? (shownByKey.get(key) ?? []) : []),
+			...userGlobal,
+		])
+		const alreadyShown = selected.some((memory) => shown.has(memory.id))
+		const visibleSelected =
+			policy.suppress === 'none'
+				? selected
+				: selected.filter((memory) => !shown.has(memory.id))
+
+		let rendered
+		if (
+			alreadyShown &&
+			visibleSelected.length === 0 &&
+			policy.repeatForm === 'count_line' &&
+			selected.length > 0
+		) {
+			const markdown = `Suppressed ${selected.length} memories surfaced earlier in this conversation.`
+			rendered = {
+				markdown,
+				structured: '',
+				visibleText: markdown,
+				ids: [],
+			}
+		} else if (policy.payload === 'stub_after_first' && alreadyShown) {
+			rendered = renderPayload(policy, call.tool, selected, true)
+		} else {
+			rendered = renderPayload(policy, call.tool, visibleSelected, alreadyShown)
+		}
+
+		if (call.tool === 'search' && retrieve) searchSeenByHandle.add(resolvedId)
+
+		if (
+			policy.suppress === 'after_first_search_on_handle' &&
+			call.tool === 'search' &&
+			rendered.ids.length > 0 &&
+			key
+		) {
+			const next = shownByKey.get(key) ?? new Set()
+			for (const id of rendered.ids) next.add(id)
+			shownByKey.set(key, next)
+		} else if (rendered.ids.length > 0 && key) {
+			const next = shownByKey.get(key) ?? new Set()
+			for (const id of rendered.ids) next.add(id)
+			shownByKey.set(key, next)
+		}
+		if (policy.suppress === 'user_global') {
+			for (const id of rendered.ids) userGlobal.add(id)
+		}
+
+		const hostVisible =
+			scenario.host === 'both'
+				? `${rendered.visibleText}\n${rendered.structured}`
+				: rendered.visibleText
+
+		results.push({
+			index,
+			tool: call.tool,
+			resolvedId,
+			retrieve,
+			ids: rendered.ids,
+			markdown: rendered.markdown,
+			structured: rendered.structured,
+			hostVisible,
+			tokens:
+				estimateTokens(rendered.markdown) + estimateTokens(rendered.structured),
+			criticalHere: textHasCritical(hostVisible),
+		})
+	}
+
+	const windowSize = scenario.windowSize ?? 999
+	const decision = results[scenario.decisionCallIndex]
+	const windowStart = Math.max(0, scenario.decisionCallIndex - windowSize + 1)
+	const inWindow = results.slice(windowStart, scenario.decisionCallIndex + 1)
+	const windowText = inWindow.map((result) => result.hostVisible).join('\n')
+	const reliability = textHasCritical(windowText) ? 1 : 0
+	const tokens = results.reduce((sum, result) => sum + result.tokens, 0)
+	const waste = results.slice(1).reduce((sum, result, offset) => {
+		const prior = results.slice(0, offset + 1)
+		const priorText = prior.map((item) => item.hostVisible).join('\n')
+		if (textHasCritical(priorText) && textHasCritical(result.hostVisible)) {
+			return sum + result.tokens
+		}
+		return sum
+	}, 0)
+
+	let isolation = 1
+	if (scenario.isolationPeer) {
+		const peer = simulate(
+			policy,
+			{
+				id: `${scenario.id}-peer`,
+				name: 'peer',
+				host: scenario.host,
+				windowSize: 999,
+				expectVisible: true,
+				isolationPeer: false,
+				calls: [
+					{
+						tool: 'search',
+						query: scenario.calls[0]?.query ?? 'send a message',
+						domain: scenario.calls[0]?.domain ?? 'email',
+						memoryContext: false,
+						conversationId: 'fresh',
+						weakSubject: scenario.calls[0]?.weakSubject,
+					},
+				],
+				decisionCallIndex: 0,
+			},
+			{
+				mintCounter,
+				shownByKey,
+				userGlobal,
+				searchSeenByHandle,
+			},
+		)
+		isolation = peer.reliability
+	}
+
+	const unexpectedShow =
+		scenario.expectVisible === false && reliability === 1 ? 1 : 0
+
+	return {
+		reliability,
+		tokens,
+		waste,
+		isolation,
+		unexpectedShow,
+		decisionCritical: decision?.criticalHere ?? 0,
+		calls: results.length,
+		windowText,
+	}
+}
+
+function cartesianPolicies() {
+	const policies = []
+	for (const searchWhen of searchWhenValues) {
+		for (const executeWhen of executeWhenValues) {
+			for (const payload of payloadValues) {
+				for (const suppress of suppressValues) {
+					for (const repeatForm of repeatFormValues) {
+						for (const maxMemories of maxMemoryValues) {
+							if (
+								payload === 'none' &&
+								(searchWhen !== 'never' || executeWhen !== 'never')
+							) {
+								continue
+							}
+							if (
+								searchWhen === 'never' &&
+								executeWhen === 'never' &&
+								payload !== 'none'
+							) {
+								continue
+							}
+							policies.push({
+								id: [
+									searchWhen,
+									executeWhen,
+									payload,
+									suppress,
+									repeatForm,
+									`n${maxMemories}`,
+								].join('/'),
+								searchWhen,
+								executeWhen,
+								payload,
+								suppress,
+								repeatForm,
+								maxMemories,
+								family: 'grid',
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+	return policies
+}
+
+function verbAndAsymmetryPolicies() {
+	const policies = []
+	for (const searchWhen of ['query', 'verb_trigger', 'memoryContext']) {
+		for (const executeWhen of [
+			'never',
+			'memoryContext',
+			'verb_trigger',
+			'only_if_no_prior_search',
+		]) {
+			for (const payload of [
+				'subject',
+				'subject_summary',
+				'search_full_execute_summary',
+				'search_summary_execute_none',
+				'stub_after_first',
+				'keywords',
+				'summary_80',
+			]) {
+				for (const suppress of [
+					'none',
+					'any_resolved_handle',
+					'echoed_handle',
+					'after_first_search_on_handle',
+					'query_hash_on_handle',
+				]) {
+					for (const maxMemories of [1, 2]) {
+						policies.push({
+							id: [
+								'xtra',
+								searchWhen,
+								executeWhen,
+								payload,
+								suppress,
+								`n${maxMemories}`,
+							].join('/'),
+							searchWhen,
+							executeWhen,
+							payload,
+							suppress,
+							repeatForm: 'omit',
+							maxMemories,
+							family: 'asymmetric',
+						})
+					}
+				}
+			}
+		}
+	}
+	return policies
+}
+
+function namedBaselines() {
+	return [
+		{
+			id: 'current-main-full-any-handle',
+			family: 'named',
+			searchWhen: 'query',
+			executeWhen: 'memoryContext',
+			payload: 'full',
+			suppress: 'any_resolved_handle',
+			repeatForm: 'omit',
+			maxMemories: 2,
+		},
+		{
+			id: 'user-recent-4h',
+			family: 'named',
+			searchWhen: 'query',
+			executeWhen: 'memoryContext',
+			payload: 'subject_summary',
+			suppress: 'user_global',
+			repeatForm: 'omit',
+			maxMemories: 2,
+		},
+		{
+			id: 'recommended-compact-echo',
+			family: 'named',
+			searchWhen: 'query',
+			executeWhen: 'memoryContext',
+			payload: 'subject_summary',
+			suppress: 'any_resolved_handle',
+			repeatForm: 'omit',
+			maxMemories: 2,
+		},
+		{
+			id: 'search-only-compact',
+			family: 'named',
+			searchWhen: 'query',
+			executeWhen: 'never',
+			payload: 'subject_summary',
+			suppress: 'any_resolved_handle',
+			repeatForm: 'omit',
+			maxMemories: 2,
+		},
+		{
+			id: 'always-full-no-suppress',
+			family: 'named',
+			searchWhen: 'query',
+			executeWhen: 'always',
+			payload: 'full',
+			suppress: 'none',
+			repeatForm: 'omit',
+			maxMemories: 2,
+		},
+		{
+			id: 'search-full-execute-none',
+			family: 'named',
+			searchWhen: 'query',
+			executeWhen: 'never',
+			payload: 'search_summary_execute_none',
+			suppress: 'any_resolved_handle',
+			repeatForm: 'omit',
+			maxMemories: 1,
+		},
+		{
+			id: 'verb-trigger-subject',
+			family: 'named',
+			searchWhen: 'verb_trigger',
+			executeWhen: 'verb_trigger',
+			payload: 'subject',
+			suppress: 'any_resolved_handle',
+			repeatForm: 'omit',
+			maxMemories: 1,
+		},
+	]
+}
+
+async function loadExtras() {
+	const { readFileSync, existsSync } = await import('node:fs')
+	const extras = []
+	for (const name of ['extra-policies.json', 'agent-policies.json']) {
+		const path = join(here, name)
+		if (!existsSync(path)) continue
+		const parsed = JSON.parse(readFileSync(path, 'utf8'))
+		const list = Array.isArray(parsed) ? parsed : parsed.policies
+		for (const policy of list ?? []) extras.push({ ...policy, family: 'agent' })
+	}
+	return extras
+}
+
+async function loadExtraScenarios() {
+	const { readFileSync, existsSync } = await import('node:fs')
+	const path = join(here, 'extra-scenarios.json')
+	if (!existsSync(path)) return []
+	const parsed = JSON.parse(readFileSync(path, 'utf8'))
+	return Array.isArray(parsed) ? parsed : []
+}
+
+function scorePolicy(policy, scenarios) {
+	const perScenario = {}
+	let reliabilityHits = 0
+	let reliabilityNeed = 0
+	let coreHits = 0
+	let coreNeed = 0
+	let stretchHits = 0
+	let stretchNeed = 0
+	let isolationHits = 0
+	let isolationNeed = 0
+	let unexpected = 0
+	let tokens = 0
+	let waste = 0
+	let compactionReliability = 0
+	let compactionNeed = 0
+	let incidentReliability = 0
+
+	for (const scenario of scenarios) {
+		const result = simulate(policy, scenario)
+		perScenario[scenario.id] = result
+		if (scenario.expectVisible) {
+			reliabilityNeed += 1
+			reliabilityHits += result.reliability
+			if (scenario.stretch) {
+				stretchNeed += 1
+				stretchHits += result.reliability
+			} else {
+				coreNeed += 1
+				coreHits += result.reliability
+			}
+			if (scenario.id === 'email-incident')
+				incidentReliability = result.reliability
+			if (scenario.id.startsWith('compaction')) {
+				compactionNeed += 1
+				compactionReliability += result.reliability
+			}
+		}
+		if (scenario.isolationPeer) {
+			isolationNeed += 1
+			isolationHits += result.isolation
+		}
+		unexpected += result.unexpectedShow
+		tokens += result.tokens
+		waste += result.waste
+	}
+
+	const reliability =
+		reliabilityNeed === 0 ? 0 : reliabilityHits / reliabilityNeed
+	const coreReliability = coreNeed === 0 ? 0 : coreHits / coreNeed
+	const stretchReliability = stretchNeed === 0 ? 0 : stretchHits / stretchNeed
+	const isolation = isolationNeed === 0 ? 1 : isolationHits / isolationNeed
+	const compaction =
+		compactionNeed === 0 ? 1 : compactionReliability / compactionNeed
+	const hardFail = isolation < 1 || unexpected > 0
+	const requiredMiss = coreReliability < 1
+	const composite =
+		(hardFail ? -1000 : 0) +
+		coreReliability * 100 +
+		incidentReliability * 25 +
+		compaction * 15 +
+		stretchReliability * 5 -
+		tokens / 200 -
+		waste / 400 -
+		unexpected * 15
+
+	return {
+		policyId: policy.id,
+		family: policy.family,
+		reliability,
+		coreReliability,
+		stretchReliability,
+		isolation,
+		compaction,
+		incidentReliability,
+		unexpected,
+		tokens,
+		waste,
+		hardFail,
+		requiredMiss,
+		composite: Number(composite.toFixed(3)),
+		perScenario,
+		policy,
+	}
+}
+
+function summarize(rows) {
+	const feasible = rows.filter((row) => !row.hardFail)
+	const perfect = feasible.filter((row) => !row.requiredMiss)
+	const byReliability = [...rows].sort((a, b) => {
+		if (a.hardFail !== b.hardFail) return a.hardFail ? 1 : -1
+		if (b.coreReliability !== a.coreReliability) {
+			return b.coreReliability - a.coreReliability
+		}
+		if (b.reliability !== a.reliability) return b.reliability - a.reliability
+		if (b.incidentReliability !== a.incidentReliability) {
+			return b.incidentReliability - a.incidentReliability
+		}
+		if (a.tokens !== b.tokens) return a.tokens - b.tokens
+		return a.waste - b.waste
+	})
+	const byComposite = [...rows].sort((a, b) => b.composite - a.composite)
+	const pareto = []
+	for (const row of [...perfect].sort((a, b) => a.tokens - b.tokens)) {
+		if (pareto.length === 0 || row.waste <= pareto[pareto.length - 1].waste) {
+			pareto.push(row)
+		}
+	}
+	return {
+		total: rows.length,
+		feasible: feasible.length,
+		perfect: perfect.length,
+		hardFailed: rows.length - feasible.length,
+		bestComposite: byComposite[0],
+		bestPerfectCheapest: perfect.sort(
+			(a, b) => a.tokens - b.tokens || a.waste - b.waste,
+		)[0],
+		bestFeasible: byReliability[0],
+		pareto: pareto.slice(0, 12).map(slimRow),
+		topComposite: byComposite.slice(0, 15).map(slimRow),
+		named: rows.filter((row) => row.family === 'named').map(slimRow),
+	}
+}
+
+function leaveOneOutWinners(policies, scenarios) {
+	const core = scenarios.filter((scenario) => !scenario.stretch)
+	const out = []
+	for (const dropped of core) {
+		const subset = scenarios.filter((scenario) => scenario.id !== dropped.id)
+		let best = null
+		for (const policy of policies) {
+			const row = scorePolicy(policy, subset)
+			if (!best || row.composite > best.composite)
+				best = { ...slimRow(row), dropped: dropped.id }
+		}
+		out.push(best)
+	}
+	return out
+}
+
+function clusterWinners(perfectRows) {
+	const groups = new Map()
+	for (const row of perfectRows) {
+		const key = [
+			row.policy.searchWhen,
+			row.policy.executeWhen,
+			row.policy.payload,
+			row.policy.suppress,
+			row.policy.maxMemories,
+		].join('|')
+		const current = groups.get(key)
+		if (!current || row.tokens < current.tokens) {
+			groups.set(key, slimRow(row))
+		}
+	}
+	return [...groups.values()].sort((a, b) => a.tokens - b.tokens).slice(0, 25)
+}
+
+function slimRow(row) {
+	return {
+		id: row.policyId,
+		family: row.family,
+		composite: row.composite,
+		reliability: Number(row.reliability.toFixed(3)),
+		core: Number(row.coreReliability.toFixed(3)),
+		stretch: Number(row.stretchReliability.toFixed(3)),
+		isolation: Number(row.isolation.toFixed(3)),
+		compaction: Number(row.compaction.toFixed(3)),
+		incident: row.incidentReliability,
+		unexpected: row.unexpected,
+		tokens: row.tokens,
+		waste: row.waste,
+		hardFail: row.hardFail,
+		searchWhen: row.policy.searchWhen,
+		executeWhen: row.policy.executeWhen,
+		payload: row.policy.payload,
+		suppress: row.policy.suppress,
+		repeatForm: row.policy.repeatForm,
+		maxMemories: row.policy.maxMemories,
+	}
+}
+
+function markdownReport(summary, scenarios) {
+	const winner = summary.bestComposite
+	const cheap = summary.bestPerfectCheapest
+	const lines = [
+		'# Memory auto-surface lab',
+		'',
+		`Tried **${summary.total}** policies on **${scenarios.length}** traces.`,
+		`${summary.feasible} keep concurrent-agent isolation.`,
+		`${summary.perfect} also hit every **core** required-visibility scene.`,
+		'Execute-only send with no memoryContext is stretch, not core.',
+		`${summary.hardFailed} fail isolation or dump memories on empty browse.`,
+		'',
+		'This is a deterministic window simulation, not an LLM eval. It answers:',
+		'was the distinctive text in the model-visible tool window at the decision,',
+		'and what did that cost in tokens (chars/4).',
+		'',
+		'## Winner by composite',
+		'',
+		winner ? formatWinner(winner) : '_none_',
+		'',
+		'## Cheapest perfect (isolation + all required scenes)',
+		'',
+		cheap
+			? formatWinner(cheap)
+			: '_none — no policy hit every required scene without breaking isolation_',
+		'',
+		'## Named baselines',
+		'',
+		'| id | rel | incident | compact | tokens | waste | fail |',
+		'| --- | --- | --- | --- | --- | --- | --- |',
+		...summary.named.map(
+			(row) =>
+				`| ${row.id} | ${row.reliability} | ${row.incident} | ${row.compaction} | ${row.tokens} | ${row.waste} | ${row.hardFail} |`,
+		),
+		'',
+		'## Top composite',
+		'',
+		'| id | rel | tokens | waste | payload | search | execute | suppress | n |',
+		'| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
+		...summary.topComposite.map(
+			(row) =>
+				`| ${row.id} | ${row.reliability} | ${row.tokens} | ${row.waste} | ${row.payload} | ${row.searchWhen} | ${row.executeWhen} | ${row.suppress} | ${row.maxMemories} |`,
+		),
+		'',
+		'## Pareto cheap-among-perfect',
+		'',
+		...summary.pareto.map(
+			(row) => `- \`${row.id}\` tokens=${row.tokens} waste=${row.waste}`,
+		),
+		'',
+		'## Product slice',
+		'',
+		'Core-perfect, not user-global, not execute-always, payload in',
+		'`subject_summary` / `summary_80` / `stub_after_first`.',
+		'',
+		'| id | tokens | waste | suppress | execute | n |',
+		'| --- | --- | --- | --- | --- | --- |',
+		...(summary.productSlice ?? []).map(
+			(row) =>
+				`| ${row.id} | ${row.tokens} | ${row.waste} | ${row.suppress} | ${row.executeWhen} | ${row.maxMemories} |`,
+		),
+		'',
+		'## Rubric',
+		'',
+		'- Hard fail: isolation < 1 (user-global hide) or memories on empty browse.',
+		'- Core reliability: required traces except execute-only with no memoryContext.',
+		'- Stretch: execute-only send with no retrieval hint. Hitting it forces execute-always or a verb trigger.',
+		'- Reliability: all expectVisible traces, including stretch.',
+		'- Incident: the original search-then-execute-send path with no memoryContext.',
+		'- Compaction: echoed conversation after old search fell out of a 3-result window.',
+		'- Tokens: memory markdown + structured JSON, chars/4, summed across all traces.',
+		'- Composite: `100*rel + 20*incident + 10*compaction - tokens/200 - waste/400` (hard fail −1000).',
+	]
+	return lines.join('\n')
+}
+
+function formatWinner(row) {
+	const slim = slimRow(row)
+	return [
+		`- **${slim.id}**`,
+		`- composite ${slim.composite}; reliability ${slim.reliability}; incident ${slim.incident}; compaction ${slim.compaction}`,
+		`- tokens ${slim.tokens}; waste ${slim.waste}; isolation ${slim.isolation}`,
+		`- searchWhen=${slim.searchWhen} executeWhen=${slim.executeWhen} payload=${slim.payload} suppress=${slim.suppress} repeat=${slim.repeatForm} n=${slim.maxMemories}`,
+	].join('\n')
+}
+
+async function main() {
+	const extras = await loadExtras()
+	const extraScenarios = await loadExtraScenarios()
+	const policies = [
+		...cartesianPolicies(),
+		...verbAndAsymmetryPolicies(),
+		...namedBaselines(),
+		...extras,
+	]
+	const seen = new Set()
+	const unique = []
+	for (const policy of policies) {
+		const key = policy.id ?? JSON.stringify(policy)
+		if (seen.has(key)) continue
+		seen.add(key)
+		unique.push(policy)
+	}
+	const scenarios = [...baselineScenarios, ...extraScenarios]
+	const rows = unique.map((policy) => scorePolicy(policy, scenarios))
+	const summary = summarize(rows)
+	summary.leaveOneOut = leaveOneOutWinners(unique, scenarios)
+	const perfect = rows.filter((row) => !row.hardFail && !row.requiredMiss)
+	summary.clusters = clusterWinners(perfect)
+	summary.productSlice = perfect
+		.filter(
+			(row) =>
+				row.policy.suppress !== 'user_global' &&
+				['subject_summary', 'summary_80', 'stub_after_first'].includes(
+					row.policy.payload,
+				) &&
+				row.policy.executeWhen !== 'always',
+		)
+		.sort((a, b) => a.tokens - b.tokens || a.waste - b.waste)
+		.slice(0, 20)
+		.map(slimRow)
+	mkdirSync(outDir, { recursive: true })
+	writeFileSync(join(outDir, 'summary.json'), JSON.stringify(summary, null, 2))
+	writeFileSync(join(outDir, 'report.md'), markdownReport(summary, scenarios))
+	writeFileSync(
+		join(outDir, 'top-rows.json'),
+		JSON.stringify(summary.topComposite, null, 2),
+	)
+	const invented = rows
+		.filter((row) => row.family === 'agent' || row.family === 'named')
+		.sort((a, b) => b.composite - a.composite)
+		.map(slimRow)
+	writeFileSync(
+		join(outDir, 'invented-scores.json'),
+		JSON.stringify(invented, null, 2),
+	)
+	console.log(
+		JSON.stringify(
+			{
+				total: summary.total,
+				feasible: summary.feasible,
+				perfect: summary.perfect,
+				best: slimRow(summary.bestComposite),
+				cheapestPerfect: summary.bestPerfectCheapest
+					? slimRow(summary.bestPerfectCheapest)
+					: null,
+			},
+			null,
+			2,
+		),
+	)
+}
+
+await main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Agents were missing stored preferences (for example “draft email, do not send”) because auto-surface treated a single-list RRF rank-1 hit as noise, `search` hid memories in structured content, and domain-scoped search skipped retrieval.

A 5119-policy lab, then a 30-theory invention rescore plus 9 adversarial traces, showed that *hiding* after the first show is the wrong token save: it fails when the host drops earlier tool results, and a subject-only line fails when the rule lives in the summary.

## Summary

- Auto-surface injects the top one or two ranked active memories (no `0.02` score floor).
- `search` appends `## Relevant memories` in markdown. Domain-scoped queries still retrieve. `execute` retrieves when `memoryContext` is present.
- Payload is compact: subject, summary, and id. No details, tags, sources, or timestamps on the automatic block.
- Auto-surface does **not** hide after the first show. Concurrent chats and compacted contexts still see the one-liner. `conversationId` stays a progressive-disclosure handle, not a hide key.
- `maxResponseSize` reserves the memory block first, then trims capability hits. A tight budget does not drop the one-liner.
- Whitespace-only `query` still retrieves when `memoryContext` is usable. Empty browse `{}` still does not dump memories.
- Records concurrent-agent isolation in project intent and [0033](docs/contributing/decisions/0033-no-user-as-conversation.md).
- Lab findings live in [0033-memory-auto-surface-lab.md](docs/contributing/decisions/0033-memory-auto-surface-lab.md). Re-run `node tools/memory-auto-surface-lab/run.mjs`. Calendar revisit: [#1648](https://github.com/kentcdodds/kody/issues/1648) (2027-02-22).

## Testing

- 5149-policy × 24-trace lab (original grid plus invented theories and adversarial scenes). 82 core-perfect policies; shipped compact no-hide remains the readable core-perfect pick. Execute-always hits stretch send-without-context at about 2× tokens.
- Focused vitest: memory service, memory-tool-context, search-handler, search-execution, search-response-size, how-kody-works transcript.
- Search handler coverage for a long summary under a tight `maxResponseSize`, and for whitespace `query` plus usable `memoryContext`.
- Live MCP client against this branch (SDK v2, protocol 2026-07-28, real OAuth): domain `email` search shows the compact one-liner; echoed and fresh `conversationId` still show it; `execute` + `memoryContext` repeats it; details stay out of markdown and structured surfaced items.
- Preview `kody-pr-1646` (merge of `6f6d04c6`): seed login, `GET /mcp` 401, `GET /admin` 403, empty `/account/memories`, `/guides/how-kody-works` shows compact Favorite bot one-liner plus structured `mem_favorite_bot` id.

## System changes

Medium: extends `mcp-server` memory auto-surface.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `3618f213` · **Head:** `6f6d04c6`

**Classification:** extends — memory auto-surface payload, hide rules, and search size/enrichment gates on `search`/`execute` change; no new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — rank-based inject, search markdown, compact one-liners, reserved `maxResponseSize`, no auto-surface hide |
| `app-ui` | surfaces | composes — how-kody-works transcript repeats the compact line and shows structured ids |

### Change flow

Search and execute put compact memories on the tool result every time retrieval runs.

```mermaid
sequenceDiagram
	actor AgentA
	actor AgentB
	participant mcpServer as mcp-server
	AgentA->>mcpServer: search query or memoryContext
	mcpServer-->>AgentA: reserve memory block then trim capability hits
	AgentA->>mcpServer: execute with memoryContext
	mcpServer-->>AgentA: same compact one-liner can repeat
	AgentB->>mcpServer: search query in another chat
	mcpServer-->>AgentB: same memory visible again
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Inject | `score >= 0.02` | top 2 active by rank |
| Search text | structured only | `## Relevant memories` |
| Payload | full record | subject, summary, id |
| Hide | per `conversationId` | no auto-surface hide |
| Size budget | capabilities first | memories reserved first |

### Invariants

Per-user isolation is unchanged. One user is not one conversation. Do not key conversation-scoped hide on the user or an MCP session.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b75fa7a-1a84-4b54-bc71-116ca31fce28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b75fa7a-1a84-4b54-bc71-116ca31fce28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search and execute now surface up to two relevant memories as compact subject-and-summary entries.
  * Memory enrichment now works for domain-scoped searches and does not require a conversation ID.
  * Additional memory details remain available through explicit retrieval.

* **Improvements**
  * Repeated memory summaries may appear across separate conversations.
  * Surfaced memory results now omit internal metadata for a simpler presentation.

* **Documentation**
  * Clarified conversation-scoped memory behavior, concurrent conversations, and automatic memory retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->