### PR TITLE
Collapse auto-surfaced memories that share a dedupe_key

### DIFF
--- a/docs/contributing/decisions/0033-memory-auto-surface-lab.md
+++ b/docs/contributing/decisions/0033-memory-auto-surface-lab.md
@@ -54,7 +54,25 @@ pick.
 
 Compact **subject — summary** one-liners (id in structured content), top two
 active memories, retrieve on search query and on execute `memoryContext`, **no
-auto-surface hide**. Repeat is the compaction tax.
+auto-surface hide**. Repeat is the compaction tax. Auto-surface collapses later
+ranked hits that share a non-empty `dedupe_key` so two copies of the same fact
+cannot spend both slots.
+
+## Live probe (2026-08-22)
+
+Production `search` / `execute` as Kent: 48 ranked task queries and 54 live
+probes across email, Discord, social, Cursor/GitHub, packages, home, journal,
+content, OAuth, and account/meta/secrets, plus empty browse, entity detail,
+whitespace / `memoryContext`-only, tight `maxResponseSize`, and execute with and
+without `memoryContext`.
+
+n=2 still holds. n=1 loses dual-constraint tasks (draft+support, BWK
+kit+defaults, repo bounds+ManagePullRequest). n=3 buys a few rank-3 edges and
+does not fix misses that never enter the top ranks. Contract checks held: empty
+browse and entity detail do not dump memories; execute surfaces only with
+`memoryContext`; reserved memory budget survives a tight size cap. Misses were
+ranking and a duplicate `dedupe_key` pair, not width. Do not widen auto-surface
+from this probe.
 
 ## Revisit
 

--- a/packages/worker/src/mcp/tools/memory-tool-context.node.test.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.node.test.ts
@@ -215,4 +215,110 @@ test('memory tool context surfaces retrievers, filters weak matches, fails on re
 	expect(compactContent?.text).not.toContain('Tags')
 	expect(compactContent?.text).not.toContain('Updated')
 	expect(compactContent?.text).not.toContain('active-rank-one')
+
+	setupMemoryContextMocks()
+	mockModule.searchMemoryRecords.mockResolvedValue({
+		matches: [
+			{
+				...baseMemory,
+				id: 'dup-first',
+				status: 'active',
+				dedupeKey: 'openai-apps-domain-challenge',
+				subject: 'OpenAI Apps domain verification',
+				summary: 'Challenge token is a static public asset.',
+				score: automaticMemorySingleListRankOneScore,
+			},
+			{
+				...baseMemory,
+				id: 'dup-second',
+				status: 'active',
+				dedupeKey: '  openai-apps-domain-challenge  ',
+				subject: 'OpenAI Apps domain verification',
+				summary: 'Challenge token is a static public asset.',
+				score: 1 / 62,
+			},
+			{
+				...baseMemory,
+				id: 'next-distinct',
+				status: 'active',
+				dedupeKey: 'prefilled-setup-urls',
+				subject: 'Always prefill hosted setup URLs',
+				summary: 'Give a prefilled secrets URL.',
+				score: 1 / 63,
+			},
+			{
+				...baseMemory,
+				id: 'null-key-one',
+				status: 'active',
+				dedupeKey: null,
+				subject: 'Null key one',
+				summary: 'No shared key.',
+				score: 1 / 64,
+			},
+		],
+		suppressedCount: 0,
+		query: 'openai apps challenge',
+	})
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
+	const collapsed = await loadRelevantMemoriesForTool({
+		env: { APP_DB: {} } as Env,
+		callerContext,
+		conversationId: 'conversation-dedupe',
+		memoryContext: { query: 'openai apps challenge' },
+	})
+	expect(collapsed?.memories).toEqual([
+		{
+			id: 'dup-first',
+			subject: 'OpenAI Apps domain verification',
+			summary: 'Challenge token is a static public asset.',
+		},
+		{
+			id: 'next-distinct',
+			subject: 'Always prefill hosted setup URLs',
+			summary: 'Give a prefilled secrets URL.',
+		},
+	])
+
+	setupMemoryContextMocks()
+	mockModule.searchMemoryRecords.mockResolvedValue({
+		matches: [
+			{
+				...baseMemory,
+				id: 'null-a',
+				status: 'active',
+				dedupeKey: null,
+				subject: 'Untitled habit A',
+				summary: 'First untitled fact.',
+				score: automaticMemorySingleListRankOneScore,
+			},
+			{
+				...baseMemory,
+				id: 'null-b',
+				status: 'active',
+				dedupeKey: '   ',
+				subject: 'Untitled habit B',
+				summary: 'Second untitled fact.',
+				score: 1 / 62,
+			},
+		],
+		suppressedCount: 0,
+		query: 'untitled habits',
+	})
+	mockModule.runPackageRetrievers.mockResolvedValue({
+		results: [],
+		warnings: [],
+	})
+	const untitled = await loadRelevantMemoriesForTool({
+		env: { APP_DB: {} } as Env,
+		callerContext,
+		conversationId: 'conversation-null-keys',
+		memoryContext: { query: 'untitled habits' },
+	})
+	expect(untitled?.memories.map((memory) => memory.id)).toEqual([
+		'null-a',
+		'null-b',
+	])
 })

--- a/packages/worker/src/mcp/tools/memory-tool-context.ts
+++ b/packages/worker/src/mcp/tools/memory-tool-context.ts
@@ -28,14 +28,30 @@ export const automaticMemorySingleListRankOneScore = 1 / 61
 /** Auto-surface keeps the top ranked active hits, not an absolute score cut. */
 const automaticMemorySurfaceLimit = 2
 
+function memoryDedupeKey(match: { dedupeKey?: string | null }) {
+	const key = match.dedupeKey?.trim() ?? ''
+	return key.length > 0 ? key : null
+}
+
 function selectAutomaticMemories<
 	T extends {
 		status: string
+		dedupeKey?: string | null
 	},
 >(matches: Array<T>) {
-	return matches
-		.filter((match) => match.status === 'active')
-		.slice(0, automaticMemorySurfaceLimit)
+	const selected: Array<T> = []
+	const seenKeys = new Set<string>()
+	for (const match of matches) {
+		if (match.status !== 'active') continue
+		const key = memoryDedupeKey(match)
+		if (key !== null) {
+			if (seenKeys.has(key)) continue
+			seenKeys.add(key)
+		}
+		selected.push(match)
+		if (selected.length >= automaticMemorySurfaceLimit) break
+	}
+	return selected
 }
 
 async function loadAutomaticMemories(input: {
@@ -56,7 +72,9 @@ async function loadAutomaticMemories(input: {
 		},
 		query: input.query,
 		conversationId: input.conversationId,
-		limit: input.limit,
+		// Default search already returns 5; keep at least n=2 plus overscan so a
+		// collapsed `dedupe_key` pair can still fill the second slot.
+		limit: Math.max(input.limit ?? 5, automaticMemorySurfaceLimit * 2 + 1),
 		includeSuppressedInConversation: true,
 	})
 	const memories = selectAutomaticMemories(result.matches)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep auto-surface at n=2, but stop a duplicate `dedupe_key` pair from spending both slots. Record the 2026-08-22 live probe so the next 0033 revisit does not re-ask “is 1–2 enough?”

## Summary

- Auto-surface walks ranked active memories and skips later hits that share a non-empty `dedupe_key` (whitespace-trimmed). Null or blank keys still surface independently.
- Search overscan stays at least 5 so collapsing one pair can still fill the second slot.
- 0033 lab appendix: live `search`/`execute` probe (48 ranked tasks + 54 probes) still picks n=2. n=3 does not fix ranking misses.

[#1648](https://github.com/kentcdodds/kody/issues/1648) stays open. The live probe is criterion 3 and it **reconfirms** hide/`n=1` still fail dual-constraint work. This PR only attaches that evidence and the small collapse.

## Testing

- `CI=1 npx vitest run --project node-unit packages/worker/src/mcp/tools/memory-tool-context.node.test.ts`
- `npm run validate` (running after this snapshot)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6855af84` · **Head:** `62a4f286`

**Classification:** extends — auto-surface selection on `search`/`execute` now collapses shared `dedupe_key` hits before the n=2 cut.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `mcp-server` | surfaces | extends — `selectAutomaticMemories` skips later ranked active hits that share a non-empty `dedupe_key` |

### Change flow

Search and execute still retrieve ranked memories; this PR collapses duplicate keys before the two-slot cut so a later distinct memory can fill slot two.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant memories as memories
	Agent->>mcpServer: search or execute
	mcpServer->>memories: searchMemoryRecords ranked active hits
	memories-->>mcpServer: matches including shared dedupe_key pair
	Note over mcpServer: skip later hits with the same non-empty key, keep n=2
	mcpServer-->>Agent: compact subject — summary one-liners
```

### Before / after

```text
before: rank1(key=A), rank2(key=A) → surface A twice
after:  rank1(key=A), rank2(key=A), rank3(key=B) → surface A, then B
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b75fa7a-1a84-4b54-bc71-116ca31fce28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b75fa7a-1a84-4b54-bc71-116ca31fce28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic memory suggestions now remove duplicate facts when they share a valid deduplication key.
  * Distinct memories remain available, while entries without a meaningful key are preserved.
  * Memory selection retrieves enough results to fill the configured surface limit after duplicates are removed.

* **Documentation**
  * Added live verification details covering result limits, ranking behavior, and duplicate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->