### PR TITLE
fix(mcp-client): send static bearer tokens on MCP requests

### DIFF
--- a/packages/worker/src/mcp-client/hub.ts
+++ b/packages/worker/src/mcp-client/hub.ts
@@ -11,6 +11,7 @@ import {
 	isStuckMcpAuthenticatingWithoutAuthUrl,
 	resolveMcpOAuthCallbackOutcome,
 } from './oauth-callback-outcome.ts'
+import { withStaticTransportHeaders } from './transport-headers.ts'
 import {
 	createInitialMcpConnectionEpisode,
 	mcpConnectionEpisodeStorageKey,
@@ -199,11 +200,11 @@ class McpClientHubBase extends DurableObject<Env> {
 			url: input.url,
 			name: input.name,
 			callbackUrl: input.callbackUrl,
-			transport: {
-				type: 'auto',
+			transport: withStaticTransportHeaders({
+				type: 'auto' as const,
 				authProvider,
 				...(input.headers ? { headers: input.headers } : {}),
-			},
+			}),
 		})
 		const connected = await this.manager.connectToServer(input.serverId)
 		if (connected.state === 'connected') {
@@ -465,11 +466,11 @@ class McpClientHubBase extends DurableObject<Env> {
 				callbackUrl: input.callbackUrl,
 				...(clientId ? { clientId } : {}),
 				...(existingOptions?.client ? { client: existingOptions.client } : {}),
-				transport: {
+				transport: withStaticTransportHeaders({
 					...existingOptions?.transport,
 					type: existingOptions?.transport.type ?? 'auto',
 					authProvider,
-				},
+				}),
 			})
 		} catch (error) {
 			await this.manager.removeServer(input.serverId).catch(() => {})
@@ -495,11 +496,11 @@ class McpClientHubBase extends DurableObject<Env> {
 					...(existingOptions?.client
 						? { client: existingOptions.client }
 						: {}),
-					transport: {
+					transport: withStaticTransportHeaders({
 						...existingOptions?.transport,
 						type: existingOptions?.transport.type ?? 'auto',
 						authProvider: originalAuthProvider,
-					},
+					}),
 				})
 				.catch(() => {})
 			throw error

--- a/packages/worker/src/mcp-client/transport-headers.node.test.ts
+++ b/packages/worker/src/mcp-client/transport-headers.node.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest'
+import { withStaticTransportHeaders } from './transport-headers.ts'
+
+test('static Authorization headers reach requestInit so transports send them', () => {
+	const transport = withStaticTransportHeaders({
+		type: 'auto' as const,
+		headers: { Authorization: 'Bearer secret-token' },
+	})
+
+	// `headers` alone is dropped by StreamableHTTPClientTransport /
+	// SSEClientTransport; only `requestInit` is merged into outbound fetches.
+	// Keys come back lowercased because they round-trip through `Headers`.
+	expect(transport.requestInit?.headers).toEqual({
+		authorization: 'Bearer secret-token',
+	})
+	expect(transport.headers).toEqual({ Authorization: 'Bearer secret-token' })
+	expect(transport.type).toBe('auto')
+
+	const withoutHeaders = withStaticTransportHeaders({ type: 'auto' as const })
+	expect(withoutHeaders).toEqual({ type: 'auto' })
+	expect(withoutHeaders.requestInit).toBeUndefined()
+
+	const withExistingRequestInit = withStaticTransportHeaders({
+		headers: { Authorization: 'Bearer stored', 'X-From-Headers': 'yes' },
+		requestInit: {
+			redirect: 'follow' as const,
+			headers: { Authorization: 'Bearer explicit' },
+		},
+	})
+	expect(withExistingRequestInit.requestInit?.redirect).toBe('follow')
+	expect(withExistingRequestInit.requestInit?.headers).toEqual({
+		authorization: 'Bearer explicit',
+		'x-from-headers': 'yes',
+	})
+})

--- a/packages/worker/src/mcp-client/transport-headers.ts
+++ b/packages/worker/src/mcp-client/transport-headers.ts
@@ -1,0 +1,41 @@
+/**
+ * Mirror static `transport.headers` into `transport.requestInit.headers`.
+ *
+ * `PersistedMcpTransportOptions` accepts a `headers` field and the Agents SDK
+ * persists it, but the underlying transports never read it — they only merge
+ * `requestInit` into outbound fetches.
+ *
+ * Without this, a server configured with a static `Authorization` header never
+ * receives one, so any MCP server that answers 401 instead of using OAuth can
+ * never connect — it fails with no diagnostic, because the client falls back to
+ * OAuth discovery and reports the discovery failure rather than the 401.
+ *
+ * Explicit `requestInit.headers` win so callers can still override a stored
+ * value.
+ */
+export function withStaticTransportHeaders<
+	T extends {
+		headers?: HeadersInit
+		requestInit?: RequestInit
+		[key: string]: unknown
+	},
+>(transport: T): T {
+	if (!transport.headers) return transport
+	return {
+		...transport,
+		requestInit: {
+			...transport.requestInit,
+			headers: {
+				...headersToRecord(transport.headers),
+				...headersToRecord(transport.requestInit?.headers),
+			},
+		},
+	}
+}
+
+function headersToRecord(
+	init: HeadersInit | undefined,
+): Record<string, string> {
+	if (!init) return {}
+	return Object.fromEntries(new Headers(init).entries())
+}


### PR DESCRIPTION
## Intent

Make static `bearerToken` authentication reach outbound MCP HTTP requests so Kody can connect to token-protected servers such as Executor.

Executor currently cannot connect through `mcp_server_add({ bearerToken })`: Kody stores and forwards the token as `transport.headers`, but the underlying MCP transports only apply `requestInit` to their fetches. The `Authorization` header is therefore silently dropped before the request reaches Executor.

## Summary

- Mirror persisted `transport.headers` into `transport.requestInit.headers`, which `StreamableHTTPClientTransport` and `SSEClientTransport` actually send.
- Apply the normalization during initial registration and both OAuth callback re-registration paths so reconnects keep the credential.
- Preserve the existing `headers` field for stored-option compatibility, while allowing explicit `requestInit.headers` values to win.
- Add a focused node test pinning that static `Authorization` headers reach `requestInit`, transports without headers pass through untouched, and explicit `requestInit.headers` win.

## Testing

- `npx vitest run packages/worker/src/mcp-client/transport-headers.node.test.ts --project node-unit`
- `npm run validate`
- Reproduced with a header-logging MCP endpoint: before this change, discovery, initialization, and tool-list requests contained no `Authorization` header; with the fix, the bearer header reaches the endpoint and the connection succeeds.

## System changes

Only the `McpClientHub` transport-option boundary changes. Static headers remain persisted in their existing field and are copied into the fetch options at registration time; no token format, storage key, or OAuth behavior changes.

Review notes: `docs/contributing/architecture/mcp-client-servers.md` already describes static `Authorization` headers as registered on the transport, so this makes the runtime match the doc — which is also why the gap was easy to miss. The `as const` on `type: 'auto'` at the first `registerServer` call site keeps the conditional `headers` spread from widening `type` to `string`; the two re-registration call sites spread existing options and don't need it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Static authorization headers are now consistently applied to supported MCP connections.
  * Existing connection headers and request options are preserved, with explicit request headers taking precedence.
  * Common header formats, including header tuples and `Headers` objects, are supported.

* **Bug Fixes**
  * Improved header handling during connection registration and authorization-restart flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
