### PR TITLE
Stop wrangler from exiting on unread OAuth request bodies

### DIFF
--- a/docs/contributing/end-to-end-testing.md
+++ b/docs/contributing/end-to-end-testing.md
@@ -77,7 +77,11 @@ Avoid `page.locator('css')` unless no accessible alternative exists.
   before each test and fails fast with `E2eWebServerDeadError` if Wrangler has
   exited mid-suite (avoids burning retries on `ECONNREFUSED`). On CI, the
   `🎭 E2E` job uploads `logs.local/` as the `e2e-wrangler-logs` artifact when
-  the suite fails.
+  the suite fails. A common local-dev killer is an unread `request.clone()`
+  body: workerd can drop the isolate (`Network connection lost`) and wrangler
+  4.114+ treats that ProxyWorker error as a fatal `wrangler dev` exit
+  ([workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926)).
+  Consume the request (or drain the unused tee) before responding.
 - Ensure the `env.test` section in `packages/worker/wrangler.jsonc` includes
   assets, KV, and durable objects since these are not inherited from top-level
   Wrangler config.

--- a/packages/worker/src/app/handlers/auth-provider.node.test.ts
+++ b/packages/worker/src/app/handlers/auth-provider.node.test.ts
@@ -861,6 +861,28 @@ test('JSON start mode returns the authorize URL for client-side navigation', asy
 	})
 })
 
+test('signed-out JSON start consumes the request body instead of abandoning a clone', async () => {
+	const { db } = createMigratedDb()
+	const env = createAppEnv(db)
+	const request = new Request('http://example.com/auth/github', {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ website: '', turnstileToken: '' }),
+	})
+
+	expect(request.bodyUsed).toBe(false)
+	const response = await runHandler(
+		createAuthProviderStartHandler(env),
+		request,
+		{ provider: 'github' },
+	)
+	expect(response.status).toBe(200)
+	expect(request.bodyUsed).toBe(true)
+})
+
 test('signed-in users link and disconnect providers from their account', async () => {
 	const { sqlite, db } = createMigratedDb()
 	const env = createAppEnv(db, {

--- a/packages/worker/src/app/handlers/auth-provider.ts
+++ b/packages/worker/src/app/handlers/auth-provider.ts
@@ -209,10 +209,15 @@ export function createAuthProviderStartHandler(env: Env) {
 			const { session } = await readAuthSessionResult(request)
 
 			if (!session) {
-				const body = (await request
-					.clone()
-					.json()
-					.catch(() => ({}))) as Record<string, unknown>
+				// Read this request once. `request.clone().json()` tees the
+				// body and leaves the original unread; workerd can then
+				// terminate the isolate ("Network connection lost"), and
+				// wrangler's ProxyController treats that as a fatal
+				// `wrangler dev` exit (workers-sdk#14926).
+				const body = (await request.json().catch(() => ({}))) as Record<
+					string,
+					unknown
+				>
 				const protection = await verifyPublicFormProtection({
 					env,
 					request,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -223,7 +223,13 @@ const appHandler = withCors({
 				request,
 				body: typeof body === 'object' && body !== null ? body : {},
 			})
-			if (!protection.ok) return protection.response
+			if (!protection.ok) {
+				// The clone was the only branch we read. Drain the original
+				// before returning so workerd does not keep a teed body
+				// alive (isolate kill → wrangler ProxyWorker fatal exit).
+				await discardUnreadRequestBody(request)
+				return protection.response
+			}
 		}
 
 		if (url.pathname === '/__maintenance/reindex-capabilities') {
@@ -291,7 +297,10 @@ const appHandler = withCors({
 							request,
 							body: Object.fromEntries(formData),
 						})
-						if (!protection.ok) return protection.response
+						if (!protection.ok) {
+							await discardUnreadRequestBody(request)
+							return protection.response
+						}
 					}
 				}
 				return await handleAuthorizeRequest(request, env)
@@ -442,6 +451,17 @@ function addOAuthDiscoveryCorsHeaders(
 		statusText: response.statusText,
 		headers,
 	})
+}
+
+/**
+ * Finish the unused side of a `request.clone()` tee. workerd treats an
+ * unread cloned original as a leaked stream branch and can terminate the
+ * isolate; wrangler 4.114+ then exits `wrangler dev` instead of recovering
+ * (workers-sdk#14926, "Network connection lost").
+ */
+async function discardUnreadRequestBody(request: Request) {
+	if (request.body === null || request.bodyUsed) return
+	await request.arrayBuffer()
 }
 
 function isOAuthProviderOwnedPath(pathname: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the daily e2e flake where Playwright’s webServer (`wrangler dev`) dies mid-suite with `Error in ProxyController: Error inside ProxyWorker` / `Network connection lost`. That is not a test-timeout problem and not something we should “fix” by restarting Wrangler.

## Summary

Deep dive of the last 24h e2e-wrangler-logs (e.g. [Validate #32537436579 job 96940869941](https://github.com/kentcdodds/kody/actions/runs/32537436579/job/96940869941)):

1. **Product trigger:** signed-out `POST /auth/{provider}` (Continue with GitHub) did `request.clone().json()` for the honeypot/Turnstile peek and never read the original body. workerd treats an unread teed body as a leaked stream branch and can terminate the isolate. The same pattern existed on early-return public-form protection paths in `index.ts`.
2. **Why the whole server dies:** after the isolate drops the connection, wrangler 4.114+ (we ship 4.120.0) does **not** implement miniflare’s `unsafeHandleRuntimeRestart` hook. `ProxyController.emitErrorEvent` treats `Error inside ProxyWorker` as fatal, dumps the entire bundle as “Error contextual data” (~8.7MB in the log), logs `wrangler command errored`, and **exits**. Playwright then sees `ECONNREFUSED` / `E2eWebServerDeadError`. This is [workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926) (still open through 4.124.0 as of 2026-08-20).
3. **Why it shows up on social-login:** that spec is three same-origin full-page OAuth navigations. GitHub start is the signed-out JSON POST (the clone leak). Audit logs show `oauth_signup` succeeding, then ~2s later the ProxyWorker fatal exit — right as the browser loads `/onboarding` or starts the next request.

This PR:

- Reads the social-login start JSON body once (`request.json()`), so `request.bodyUsed` is true.
- Drains the unused original after a `clone()` peek when public-form protection returns early.
- Adds a node-unit regression that a JSON start with a body consumes the request.
- Documents the workerd tee → wrangler fatal-exit path in the e2e notes.

Not done (and not a substitute): restarting Wrangler, raising Playwright timeouts, or pinning wrangler to 4.113.0.

## Testing

- `npx vitest run packages/worker/src/app/handlers/auth-provider.node.test.ts --project node-unit` (14 passed, including the new `bodyUsed` case)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `1e4a6783` · **Head:** `ec730f66`

**Classification:** composes — request-body consumption only; OAuth start/callback contracts, cookies, and redirects are unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-sessions` | auth | composes — consume the social-login start JSON body instead of abandoning a `clone()` tee |
| `app-ui` | surfaces | composes — test-only coverage for that start path |

`scheduled-cron` matched because it shares `packages/worker/src/index.ts`. This PR only drains unused cloned bodies on public-form early returns in the fetch handler.

### Change flow

Signed-out social-login start no longer leaves a teed request body for workerd to kill the isolate over.

```mermaid
sequenceDiagram
	actor Browser
	participant socialStart as app-sessions
	participant workerd as workerd-isolate
	participant wranglerDev as wrangler-dev
	Browser->>socialStart: POST /auth/github JSON body
	Note over socialStart: was clone().json() then respond with original unread
	socialStart->>workerd: request.json() so bodyUsed is true
	workerd-->>Browser: 200 authorizeUrl
	Note over wranglerDev: isolate stay-alive; ProxyController no longer sees Network connection lost
```

### Before / after

**Before:** `POST /auth/github` teed the body, workerd dropped the isolate, wrangler treated `Error inside ProxyWorker` as fatal and exited. Later e2e specs failed with `E2eWebServerDeadError`.

**After:** the start handler consumes the body it reads. Early-return protection peeks drain the unused original. The request path no longer creates the isolate-kill condition.

### Invariants

Session cookies, OAuth state, and redirect targets are unchanged. This does not implement wrangler’s missing `unsafeHandleRuntimeRestart` hook (upstream).

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1635646c-401c-41a9-bce7-e64f819838a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1635646c-401c-41a9-bce7-e64f819838a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authorization requests to reliably process submitted data and return successful responses when users are signed out.
  * Prevented request-processing failures that could cause lost network connections or application shutdowns during form-protection and authorization flows.

* **Documentation**
  * Added troubleshooting guidance for diagnosing end-to-end test server failures related to unread request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->