### PR TITLE
Reindex only builtin capabilities on production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -683,10 +683,13 @@ jobs:
             echo "Skipping capability reindex (no deploy URL)."
             exit 0
           fi
+          # Builtins only. User-owned memory/job/package vectors upsert on write.
+          # A full sweep (omit phases) is a DR / embedding-model rebuild, not a
+          # ship gate.
           base="${DEPLOY_URL%/}"
           max_sweeps=8
           sweep=1
-          payload='{}'
+          payload='{"phases":["capabilities"]}'
           while true; do
             echo "POST ${base}/__maintenance/reindex-capabilities (sweep ${sweep})"
             status="$(curl --silent --show-error --location --max-time 120 \
@@ -718,7 +721,7 @@ jobs:
               echo "Capability reindex is incomplete but returned no cursor." >&2
               exit 1
             fi
-            payload="$(jq -nc --argjson cursor "$cursor" '{cursor: $cursor}')"
+            payload="$(jq -nc --argjson cursor "$cursor" '{phases:["capabilities"],cursor:$cursor}')"
             sweep=$((sweep + 1))
           done
 

--- a/docs/contributing/adding-capabilities.md
+++ b/docs/contributing/adding-capabilities.md
@@ -397,12 +397,14 @@ the domain modules.
    depends on the real MCP transport, OAuth handshake, or hosted package app
    session wiring.
 7. After deployed changes materially alter capability names, descriptions,
-   keywords, or schemas, run the guarded
-   `POST /__maintenance/reindex-capabilities` maintenance endpoint so Vectorize
-   has fresh Workers AI embeddings. The endpoint also rebuilds memory, job, and
-   saved-package vectors with user-scoped metadata. Each POST is time-budgeted;
-   if the JSON response has `complete: false`, POST again with
-   `{ "cursor": <response.cursor> }` until `complete` is true.
+   keywords, or schemas, production deploy refreshes builtin capability vectors
+   via the guarded `POST /__maintenance/reindex-capabilities` endpoint with
+   `{ "phases": ["capabilities"] }`. User-owned memory, job, and saved-package
+   vectors upsert on write. For a full rebuild (embedding model, pooling,
+   Vectorize index dimensions, or disaster recovery), POST without `phases` (or
+   with every kind). Each POST is time-budgeted; if the JSON response has
+   `complete: false`, POST again with `{ "cursor": <response.cursor> }` (and the
+   same `phases` when you set them) until `complete` is true.
 
 Example (assuming `example` exists in `capabilityDomainNames`):
 

--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -1346,12 +1346,18 @@ deterministic so upserts and deletes target the same vector.
   `__kody_builtin__`, with metadata `{ kind: 'builtin', domain }`.
 
 Search paths query only per-account namespaces plus the reserved builtin
-namespace. Vector rows are derived from D1 and can be rebuilt with the bounded
-`POST /__maintenance/reindex-capabilities` sweep, which keyset-pages memory,
-job, and saved-package rows, rebuilds builtins in their reserved namespace, and
-returns before a request-time budget. An incomplete sweep includes
-`complete: false` and a `cursor` so the caller can POST again until `complete`
-is true. Production deploy CI loops that endpoint after each production ship.
+namespace. Vector rows are derived from D1. User-owned memory, job, and
+saved-package vectors upsert on write; saved packages also mark
+`saved_package_search_index_debt` and reconcile after the response. The bounded
+`POST /__maintenance/reindex-capabilities` sweep rebuilds requested kinds
+(`phases`; omit the field to rebuild every kind), keyset-pages memory, job, and
+saved-package rows, rebuilds builtins in their reserved namespace, and returns
+before a request-time budget. An incomplete sweep includes `complete: false` and
+a `cursor` so the caller can POST again until `complete` is true. Production
+deploy CI loops that endpoint with `{ "phases": ["capabilities"] }` after each
+production ship so only builtin capability vectors refresh. A full sweep
+(embedding-model change, metadata-contract change, or disaster recovery) omits
+`phases` or lists every kind.
 
 ### `entity_sources` and package import contracts
 

--- a/docs/contributing/environment-variables.md
+++ b/docs/contributing/environment-variables.md
@@ -279,20 +279,22 @@ Worker secrets:
   skips the post-deploy capability reindex and execute smoke check when it is
   unset); bearer token for `POST /__maintenance/reindex-capabilities`,
   `POST /__maintenance/reencrypt-secrets`, and other secret-gated maintenance
-  endpoints. Use the reindex endpoint after changing the embedding model,
-  pooling, or Vectorize index dimensions; it rebuilds built-in capability,
-  memory, job, and saved-package vectors with per-user `userId` metadata on
-  user-owned rows. Each call is time-budgeted and may return `complete: false`
-  plus a `cursor` to resume. Use the re-encrypt endpoint to rewrite remaining
-  pre-AAD (2-part) secret ciphertexts to v2 without rotating `SECRET_STORE_KEY`
-  (see [Secret rotation](./secret-rotation.md)). Local dev uses offline search
-  while `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
+  endpoints. Production deploy POSTs `{ "phases": ["capabilities"] }` so only
+  builtin capability vectors refresh after a ship. User-owned memory, job, and
+  saved-package vectors upsert on write. Omit `phases` (or list every kind)
+  after changing the embedding model, pooling, or Vectorize index dimensions to
+  rebuild those rows too, with per-user `userId` metadata on user-owned rows.
+  Each call is time-budgeted and may return `complete: false` plus a `cursor` to
+  resume. Use the re-encrypt endpoint to rewrite remaining pre-AAD (2-part)
+  secret ciphertexts to v2 without rotating `SECRET_STORE_KEY` (see
+  [Secret rotation](./secret-rotation.md)). Local dev uses offline search while
+  `WRANGLER_IS_LOCAL_DEV` is set or the binding is missing.
 - **`JOB_REINDEX_SECRET`** — optional Worker secret; bearer token for
   `POST /__maintenance/reindex-jobs` when you want a jobs-only Vectorize rebuild
-  (without the full capability/memory/package reindex that
-  `CAPABILITY_REINDEX_SECRET` drives). When unset, the jobs-only endpoint
-  returns not-configured; production deploys rely on the capability reindex path
-  for job vectors and do not require this secret.
+  (without a full capability/memory/package reindex). When unset, the jobs-only
+  endpoint returns not-configured. Production deploys do not refresh job
+  vectors; those upsert on write. Use this secret or a full capability reindex
+  when you need a jobs rebuild.
 - **`STATUS_INCIDENT_EVENT_SECRET`** — optional Worker secret shared with the
   status worker. Bearer token for `POST /__maintenance/status-incidents`, which
   fans `status.incident.opened` / `status.incident.resolved` to admin package

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -428,17 +428,17 @@ automatically:
   through the configured Cloudflare AI Gateway when set)
 - `CAPABILITY_REINDEX_SECRET` (strongly recommended for production — CI skips
   the post-deploy reindex and execute smoke check when unset; optional locally
-  and for previews; bearer auth for `POST /__maintenance/reindex-capabilities`
-  to refresh all capability-search vectors in Vectorize: built-in capabilities,
-  memories, jobs, and saved packages. Saved package projections also refresh
-  when packages are saved or published. Same bearer authenticates
+  and for previews; bearer auth for `POST /__maintenance/reindex-capabilities`.
+  Production deploy refreshes builtin capability vectors only
+  (`{ "phases": ["capabilities"] }`). Omit `phases` to rebuild memories, jobs,
+  and saved packages too. Saved package projections also refresh when packages
+  are saved or published. Same bearer authenticates
   `POST /__maintenance/reencrypt-secrets` — see
   [Secret rotation](./secret-rotation.md).)
 - `JOB_REINDEX_SECRET` (optional Worker secret; bearer auth for
   `POST /__maintenance/reindex-jobs` for a jobs-only Vectorize rebuild. Not
-  required for production deploys — the capability reindex path already
-  refreshes job vectors. Omit locally and for previews unless you need the
-  jobs-only endpoint.)
+  required for production deploys — job vectors upsert on write. Omit locally
+  and for previews unless you need the jobs-only endpoint.)
 - `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`, `GOOGLE_CLIENT_ID` /
   `GOOGLE_CLIENT_SECRET`, `X_CLIENT_ID` / `X_CLIENT_SECRET`, `DISCORD_CLIENT_ID`
   / `DISCORD_CLIENT_SECRET` (optional Worker secrets; enable the "Sign in with
@@ -508,8 +508,7 @@ Configure these GitHub Actions secrets and variables for workflows:
   capability reindex — CI skips those calls when it is unset)
 - `JOB_REINDEX_SECRET` (optional; authenticates
   `POST /__maintenance/reindex-jobs` for a jobs-only Vectorize rebuild.
-  Production deploys do not require it — capability reindex already refreshes
-  job vectors.)
+  Production deploys do not require it — job vectors upsert on write.)
 - `DR_BACKUP_ACCOUNT_ID` / `DR_BACKUP_BUCKET_NAME` / `DR_BACKUP_ACCESS_KEY_ID` /
   `DR_BACKUP_SECRET_ACCESS_KEY` (production DR staging into the DR bucket; also
   used by `.github/workflows/dr-escrow.yml`. `DR_BACKUP_ACCOUNT_ID` is also the
@@ -680,22 +679,23 @@ How to get/set each value:
   locally and for previews)
   - Generate a long random secret (for example `openssl rand -hex 32`), store it
     as the repository secret `CAPABILITY_REINDEX_SECRET`, and let the deploy
-    workflow sync it to the Worker. After each production deploy, CI POSTs to
-    `/__maintenance/reindex-capabilities` with `Authorization: Bearer …` and
-    loops on the returned `cursor` until `complete` is true (each POST is
-    bounded to about 70 seconds; CI follows the cursor for up to 8 sweeps),
-    refreshing built-in capability, memory, job, and saved-package embeddings.
-    Run the same POST loop manually after changing the embedding model, pooling,
-    or Vectorize index dimensions so existing rows are rebuilt with compatible
-    vectors. The same bearer authenticates
-    `POST /__maintenance/reencrypt-secrets` (see
+    workflow sync it to the Worker. After each production deploy, CI POSTs
+    `{ "phases": ["capabilities"] }` to `/__maintenance/reindex-capabilities`
+    with `Authorization: Bearer …` and loops on the returned `cursor` until
+    `complete` is true (each POST is bounded to about 70 seconds; CI follows the
+    cursor for up to 8 sweeps), refreshing builtin capability embeddings.
+    User-owned memory, job, and saved-package vectors upsert on write. For a
+    full rebuild after changing the embedding model, pooling, or Vectorize index
+    dimensions, POST without `phases` and follow the same cursor loop so
+    existing rows are rebuilt with compatible vectors. The same bearer
+    authenticates `POST /__maintenance/reencrypt-secrets` (see
     [Secret rotation](./secret-rotation.md)). Local and preview environments can
     omit it; CI skips reindex and execute-smoke when the secret is unset.
 - `JOB_REINDEX_SECRET` (optional; jobs-only reindex)
   - Bearer token for `POST /__maintenance/reindex-jobs`. Generate and sync the
     same way as `CAPABILITY_REINDEX_SECRET` only if you want the jobs-only
-    maintenance endpoint. Production deploys do not require it; the capability
-    reindex path already refreshes job vectors. Local and preview can omit it.
+    maintenance endpoint. Production deploys do not require it; job vectors
+    upsert on write. Local and preview can omit it.
 
 Preview deploys for pull requests create an app Worker per PR named
 `<app-name>-pr-<number>` (for kody: `kody-pr-123`), sibling runtime and jobs

--- a/packages/worker/src/capability-maintenance.node.test.ts
+++ b/packages/worker/src/capability-maintenance.node.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { expect, test, vi } from 'vitest'
 
 const mockModule = vi.hoisted(() => ({
@@ -87,6 +88,7 @@ test('capability reindex maintenance route rebuilds every vector kind and resume
 	await expect(response.json()).resolves.toEqual({
 		ok: true,
 		complete: true,
+		phases: ['capabilities', 'memories', 'jobs', 'packages'],
 		capabilities: completeStep(3),
 		memories: completeStep(2),
 		jobs: completeStep(1),
@@ -133,6 +135,7 @@ test('capability reindex maintenance route rebuilds every vector kind and resume
 	await expect(incompleteResponse.json()).resolves.toEqual({
 		ok: true,
 		complete: false,
+		phases: ['capabilities', 'memories', 'jobs', 'packages'],
 		cursor: { phase: 'memories', afterId: 'memory-8' },
 		capabilities: completeStep(3),
 		memories: { upserted: 8, complete: false, afterId: 'memory-8' },
@@ -156,6 +159,7 @@ test('capability reindex maintenance route rebuilds every vector kind and resume
 	await expect(resumeResponse.json()).resolves.toEqual({
 		ok: true,
 		complete: true,
+		phases: ['capabilities', 'memories', 'jobs', 'packages'],
 		capabilities: completeStep(0),
 		memories: completeStep(2),
 		jobs: completeStep(1),
@@ -203,6 +207,7 @@ test('capability reindex maintenance route attempts every vector kind before rep
 	await expect(response.json()).resolves.toEqual({
 		ok: false,
 		complete: true,
+		phases: ['capabilities', 'memories', 'jobs', 'packages'],
 		capabilities: completeStep(3),
 		memories: {
 			upserted: 0,
@@ -239,4 +244,83 @@ test('capability reindex maintenance route attempts every vector kind before rep
 	expect(mockModule.reindexMemoryVectors).toHaveBeenCalledTimes(1)
 	expect(mockModule.reindexJobVectors).toHaveBeenCalledTimes(1)
 	expect(mockModule.reindexSavedPackageVectors).toHaveBeenCalledTimes(1)
+})
+
+test('capability reindex can limit work to builtin capabilities for production deploy', async () => {
+	resetMocks()
+	mockModule.reindexCapabilityVectors.mockResolvedValue(completeStep(3))
+	const env = {
+		CAPABILITY_REINDEX_SECRET: 'secret',
+	} as Env
+
+	const response = await handleCapabilityReindexRequest(
+		createReindexRequest({ phases: ['capabilities'] }),
+		env,
+	)
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({
+		ok: true,
+		complete: true,
+		phases: ['capabilities'],
+		capabilities: completeStep(3),
+		memories: completeStep(0),
+		jobs: completeStep(0),
+		packages: completeStep(0),
+	})
+	expect(mockModule.reindexCapabilityVectors).toHaveBeenCalledTimes(1)
+	expect(mockModule.reindexMemoryVectors).not.toHaveBeenCalled()
+	expect(mockModule.reindexJobVectors).not.toHaveBeenCalled()
+	expect(mockModule.reindexSavedPackageVectors).not.toHaveBeenCalled()
+
+	const emptyPhases = await handleCapabilityReindexRequest(
+		createReindexRequest({ phases: [] }),
+		env,
+	)
+	expect(emptyPhases.status).toBe(400)
+	await expect(emptyPhases.json()).resolves.toEqual({
+		ok: false,
+		error: 'phases must be a non-empty array.',
+	})
+
+	const duplicatePhases = await handleCapabilityReindexRequest(
+		createReindexRequest({ phases: ['capabilities', 'capabilities'] }),
+		env,
+	)
+	expect(duplicatePhases.status).toBe(400)
+	await expect(duplicatePhases.json()).resolves.toEqual({
+		ok: false,
+		error: 'phases must not contain duplicates.',
+	})
+
+	const invalidPhase = await handleCapabilityReindexRequest(
+		createReindexRequest({ phases: ['capabilities', 'nope'] }),
+		env,
+	)
+	expect(invalidPhase.status).toBe(400)
+	await expect(invalidPhase.json()).resolves.toEqual({
+		ok: false,
+		error:
+			'phases must contain only capabilities, memories, jobs, or packages.',
+	})
+
+	const cursorOutsidePhases = await handleCapabilityReindexRequest(
+		createReindexRequest({
+			phases: ['capabilities'],
+			cursor: { phase: 'packages', afterId: null },
+		}),
+		env,
+	)
+	expect(cursorOutsidePhases.status).toBe(400)
+	await expect(cursorOutsidePhases.json()).resolves.toEqual({
+		ok: false,
+		error: 'cursor.phase must be one of the requested phases.',
+	})
+
+	const workflow = readFileSync(
+		new URL('../../../.github/workflows/deploy.yml', import.meta.url),
+		'utf8',
+	)
+	expect(workflow).toContain('payload=\'{"phases":["capabilities"]}\'')
+	expect(workflow).toContain('{phases:["capabilities"],cursor:$cursor}')
 })

--- a/packages/worker/src/capability-maintenance.ts
+++ b/packages/worker/src/capability-maintenance.ts
@@ -10,9 +10,11 @@ import { reindexMemoryVectors } from './mcp/memory/memory-reindex.ts'
 import { reindexSavedPackageVectors } from './package-registry/package-reindex.ts'
 import { getErrorMessage } from '@kody-internal/shared/error-message.ts'
 import {
+	capabilityReindexPhases,
 	capabilityReindexTimeBudgetMs,
 	hasReachedReindexDeadline,
 	isCapabilityReindexPhase,
+	resolveCapabilityReindexPhases,
 	type CapabilityReindexCursor,
 	type CapabilityReindexPhase,
 	type VectorReindexSweepResult,
@@ -61,6 +63,7 @@ function parseCapabilityReindexBody(body: unknown):
 	| {
 			ok: true
 			cursor: CapabilityReindexCursor | null
+			phases: ReadonlyArray<CapabilityReindexPhase>
 			timeBudgetMs: number
 	  }
 	| { ok: false; error: string } {
@@ -68,6 +71,7 @@ function parseCapabilityReindexBody(body: unknown):
 		return {
 			ok: true,
 			cursor: null,
+			phases: capabilityReindexPhases,
 			timeBudgetMs: capabilityReindexTimeBudgetMs,
 		}
 	}
@@ -75,6 +79,10 @@ function parseCapabilityReindexBody(body: unknown):
 		return { ok: false, error: 'Reindex body must be a JSON object.' }
 	}
 	const record = body as Record<string, unknown>
+	const phases = resolveCapabilityReindexPhases(record.phases)
+	if (!phases.ok) {
+		return phases
+	}
 	let timeBudgetMs = capabilityReindexTimeBudgetMs
 	if (record.timeBudgetMs !== undefined) {
 		if (
@@ -82,12 +90,15 @@ function parseCapabilityReindexBody(body: unknown):
 			!Number.isFinite(record.timeBudgetMs) ||
 			record.timeBudgetMs < 0
 		) {
-			return { ok: false, error: 'timeBudgetMs must be a non-negative number.' }
+			return {
+				ok: false,
+				error: 'timeBudgetMs must be a non-negative number.',
+			}
 		}
 		timeBudgetMs = record.timeBudgetMs
 	}
 	if (record.cursor === undefined || record.cursor === null) {
-		return { ok: true, cursor: null, timeBudgetMs }
+		return { ok: true, cursor: null, phases: phases.phases, timeBudgetMs }
 	}
 	if (typeof record.cursor !== 'object' || Array.isArray(record.cursor)) {
 		return { ok: false, error: 'cursor must be an object.' }
@@ -99,12 +110,19 @@ function parseCapabilityReindexBody(body: unknown):
 			error: 'cursor.phase must be capabilities, memories, jobs, or packages.',
 		}
 	}
+	if (!phases.phases.includes(cursor.phase)) {
+		return {
+			ok: false,
+			error: 'cursor.phase must be one of the requested phases.',
+		}
+	}
 	if (cursor.afterId !== null && typeof cursor.afterId !== 'string') {
 		return { ok: false, error: 'cursor.afterId must be a string or null.' }
 	}
 	return {
 		ok: true,
 		cursor: { phase: cursor.phase, afterId: cursor.afterId },
+		phases: phases.phases,
 		timeBudgetMs,
 	}
 }
@@ -160,6 +178,7 @@ async function reindexAllCapabilitySearchVectors(
 	input: {
 		baseUrl: string
 		cursor: CapabilityReindexCursor | null
+		phases: ReadonlyArray<CapabilityReindexPhase>
 		deadlineMs: number
 	},
 ) {
@@ -169,22 +188,18 @@ async function reindexAllCapabilitySearchVectors(
 		jobs: skippedReindexStep,
 		packages: skippedReindexStep,
 	}
-	const startPhase = input.cursor?.phase ?? 'capabilities'
+	const startPhase = input.cursor?.phase ?? input.phases[0]
 	let afterId = input.cursor?.afterId ?? null
 	let started = false
 
-	for (const phase of [
-		'capabilities',
-		'memories',
-		'jobs',
-		'packages',
-	] as const) {
+	for (const phase of input.phases) {
 		if (!started) {
 			if (phase !== startPhase) continue
 			started = true
 		} else if (hasReachedReindexDeadline(input.deadlineMs)) {
 			return {
 				...result,
+				phases: input.phases,
 				complete: false as const,
 				cursor: { phase, afterId: null },
 			}
@@ -203,6 +218,7 @@ async function reindexAllCapabilitySearchVectors(
 		if (!step.complete) {
 			return {
 				...result,
+				phases: input.phases,
 				complete: false as const,
 				cursor: { phase, afterId: step.afterId },
 			}
@@ -211,6 +227,7 @@ async function reindexAllCapabilitySearchVectors(
 
 	return {
 		...result,
+		phases: input.phases,
 		complete: true as const,
 	}
 }
@@ -232,6 +249,7 @@ export async function handleCapabilityReindexRequest(
 			const result = await reindexAllCapabilitySearchVectors(env, {
 				baseUrl: new URL(request.url).origin,
 				cursor: parsed.cursor,
+				phases: parsed.phases,
 				deadlineMs: Date.now() + parsed.timeBudgetMs,
 			})
 			const kindResults = (

--- a/packages/worker/src/package-registry/search-index-debt.ts
+++ b/packages/worker/src/package-registry/search-index-debt.ts
@@ -7,7 +7,8 @@ import { upsertSavedPackageVector } from './vectorize.ts'
  * scheduling work on `waitUntil`, mark debt; clear it on success; keep it
  * (with the error) on failure and report to Sentry. Capability reindex also
  * clears debt after a successful upsert so search converges even if the
- * original waitUntil never ran.
+ * original waitUntil never ran. A full capability reindex that includes the
+ * packages phase also clears matching debt after a successful upsert.
  *
  * Each schedule bumps a per-package `generation` and stores the latest
  * `embed_text`. An in-flight reconcile (coalesced per isolate) re-reads the

--- a/packages/worker/src/vectorize/reindex-sweep.node.test.ts
+++ b/packages/worker/src/vectorize/reindex-sweep.node.test.ts
@@ -3,6 +3,7 @@ import { vectorReindexUpsertBatchSize } from './reindex-batches.ts'
 import {
 	reindexPagedVectorRows,
 	reindexVectorCandidateList,
+	resolveCapabilityReindexPhases,
 } from './reindex-sweep.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -104,5 +105,20 @@ test('reindex sweep helpers stop at the deadline and resume from afterId', async
 		upserted: 1,
 		complete: true,
 		afterId: null,
+	})
+})
+
+test('resolveCapabilityReindexPhases omits every kind or canonicalizes a subset', () => {
+	expect(resolveCapabilityReindexPhases(undefined)).toEqual({
+		ok: true,
+		phases: ['capabilities', 'memories', 'jobs', 'packages'],
+	})
+	expect(resolveCapabilityReindexPhases(['packages', 'capabilities'])).toEqual({
+		ok: true,
+		phases: ['capabilities', 'packages'],
+	})
+	expect(resolveCapabilityReindexPhases([])).toEqual({
+		ok: false,
+		error: 'phases must be a non-empty array.',
 	})
 })

--- a/packages/worker/src/vectorize/reindex-sweep.ts
+++ b/packages/worker/src/vectorize/reindex-sweep.ts
@@ -50,6 +50,42 @@ export function isCapabilityReindexPhase(
 	)
 }
 
+/**
+ * Resolve the optional `phases` body field. Omitted `phases` means every
+ * kind (disaster recovery / embedding-model rebuild). Requested phases are
+ * returned in canonical order.
+ */
+export function resolveCapabilityReindexPhases(
+	value: unknown,
+):
+	| { ok: true; phases: ReadonlyArray<CapabilityReindexPhase> }
+	| { ok: false; error: string } {
+	if (value === undefined) {
+		return { ok: true, phases: capabilityReindexPhases }
+	}
+	if (!Array.isArray(value) || value.length === 0) {
+		return { ok: false, error: 'phases must be a non-empty array.' }
+	}
+	const seen = new Set<CapabilityReindexPhase>()
+	for (const item of value) {
+		if (!isCapabilityReindexPhase(item)) {
+			return {
+				ok: false,
+				error:
+					'phases must contain only capabilities, memories, jobs, or packages.',
+			}
+		}
+		if (seen.has(item)) {
+			return { ok: false, error: 'phases must not contain duplicates.' }
+		}
+		seen.add(item)
+	}
+	return {
+		ok: true,
+		phases: capabilityReindexPhases.filter((phase) => seen.has(phase)),
+	}
+}
+
 export function toVectorReindexSweepResult(
 	result: VectorReindexResult,
 	input: { complete: boolean; afterId: string | null },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop treating a full Vectorize rebuild as a ship gate. Production deploy should refresh builtin capability embeddings; user-owned memory, job, and package vectors already upsert on write.

## Summary

- `POST /__maintenance/reindex-capabilities` accepts optional `phases` (canonical order; omit for every kind).
- Production deploy POSTs `{ "phases": ["capabilities"] }` and keeps the cursor loop for builtins only.
- A full sweep (omit `phases`) stays the disaster-recovery / embedding-model rebuild path.
- Docs describe write-time upserts and the deploy-vs-DR split.

## Testing

- `npx vitest run packages/worker/src/capability-maintenance.node.test.ts packages/worker/src/vectorize/reindex-sweep.node.test.ts`
- `npx nx run worker:typecheck`
- `npm run docs:check-temporal`

## System changes

Medium: extends `vectorize-search` (maintenance request contract). Deploy no longer full-rebuilds user-owned vectors.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `5e2f7c1` · **Head:** `b0047ae`

**Classification:** extends — `vectorize-search` gains an optional `phases` filter; production deploy uses it so a ship no longer full-rebuilds user-owned vectors.

### Primitives touched

| Primitive          | Group     | Impact                                                                |
| ------------------ | --------- | --------------------------------------------------------------------- |
| `vectorize-search` | storage   | extends — `POST /__maintenance/reindex-capabilities` accepts `phases` |
| `saved-packages`   | assistant | composes — comment only; write-time upsert + debt stay the live path  |

### Change flow

Production deploy refreshes builtin capability vectors only; user-owned kinds stay on write-time upsert.

```mermaid
sequenceDiagram
	actor DeployCI
	participant vectorizeSearch as vectorize-search
	participant savedPackages as saved-packages
	DeployCI->>vectorizeSearch: POST /__maintenance/reindex-capabilities {phases:[capabilities]}
	vectorizeSearch-->>DeployCI: complete or cursor for builtins only
	Note over savedPackages: write-time upsert + search-index-debt (unchanged)
	Note over vectorizeSearch: omit phases for DR / embedding-model rebuild
```

### Before / after

| Caller | Before | After |
| ------ | ------ | ----- |
| Production deploy | `POST {}` rebuilds capabilities, memories, jobs, packages | `POST { "phases": ["capabilities"] }` |
| DR / model change | same full POST | omit `phases` (or list every kind) |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1374096b-5a6f-4674-86f1-b0bdb9100b6a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1374096b-5a6f-4674-86f1-b0bdb9100b6a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

